### PR TITLE
Fix a minor clang release build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout # check out the code in the project directory
-      - run: sudo apt-get update -y && sudo apt-get install -y clang libgflags-dev
+      - run: sudo apt-get update -y && sudo apt-get install -y clang libgflags-dev libtbb-dev
       - run: CC=clang CXX=clang++ USE_CLANG=1 PORTABLE=1 make V=1 -j16 all | .circleci/cat_ignore_eagain
       - post-steps
 

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -431,7 +431,7 @@ void ClockCacheShard::ApplyToSomeEntries(
     // Mark finished with all
     *state = UINT32_MAX;
   } else {
-    *state = end_idx;
+    *state = static_cast<uint32_t>(end_idx);
   }
 
   // Do the iteration

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -431,7 +431,7 @@ void ClockCacheShard::ApplyToSomeEntries(
     // Mark finished with all
     *state = UINT32_MAX;
   } else {
-    *state = static_cast<uint32_t>(end_idx);
+    *state = end_idx;
   }
 
   // Do the iteration


### PR DESCRIPTION
Error message:
```
cache/clock_cache.cc:434:14: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
    *state = end_idx;
           ~ ^~~~~~~
```
Make circleci to cover this case by install tbb.

Test Plan: `USE_CLANG=1 make -j1 release`