### PR TITLE
Fix MultiGet with PinnableSlices and Merge for WBWI

### DIFF
--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -621,8 +621,7 @@ WriteBatchWithIndexInternal::WriteBatchWithIndexInternal(
 Status WriteBatchWithIndexInternal::MergeKey(const Slice& key,
                                              const Slice* value,
                                              const MergeContext& context,
-                                             std::string* result,
-                                             Slice* result_operand) const {
+                                             std::string* result) const {
   if (column_family_ != nullptr) {
     auto cfh = static_cast_with_check<ColumnFamilyHandleImpl>(column_family_);
     const auto merge_operator = cfh->cfd()->ioptions()->merge_operator.get();
@@ -638,7 +637,7 @@ Status WriteBatchWithIndexInternal::MergeKey(const Slice& key,
       SystemClock* clock = immutable_db_options.clock;
       return MergeHelper::TimedFullMerge(merge_operator, key, value,
                                          context.GetOperands(), result, logger,
-                                         statistics, clock, result_operand);
+                                         statistics, clock);
     } else if (db_options_ != nullptr) {
       Statistics* statistics = db_options_->statistics.get();
       Env* env = db_options_->env;
@@ -646,12 +645,12 @@ Status WriteBatchWithIndexInternal::MergeKey(const Slice& key,
       SystemClock* clock = env->GetSystemClock().get();
       return MergeHelper::TimedFullMerge(merge_operator, key, value,
                                          context.GetOperands(), result, logger,
-                                         statistics, clock, result_operand);
+                                         statistics, clock);
     } else {
       const auto cf_opts = cfh->cfd()->ioptions();
       return MergeHelper::TimedFullMerge(
           merge_operator, key, value, context.GetOperands(), result,
-          cf_opts->logger, cf_opts->stats, cf_opts->clock, result_operand);
+          cf_opts->logger, cf_opts->stats, cf_opts->clock);
     }
   } else {
     return Status::InvalidArgument("Must provide a column_family");

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -306,13 +306,12 @@ class WriteBatchWithIndexInternal {
                                         const Slice& key,
                                         MergeContext* merge_context,
                                         std::string* value, Status* s);
-  Status MergeKey(const Slice& key, const Slice* value, std::string* result,
-                  Slice* result_operand = nullptr) const {
-    return MergeKey(key, value, merge_context_, result, result_operand);
+  Status MergeKey(const Slice& key, const Slice* value,
+                  std::string* result) const {
+    return MergeKey(key, value, merge_context_, result);
   }
   Status MergeKey(const Slice& key, const Slice* value,
-                  const MergeContext& context, std::string* result,
-                  Slice* result_operand = nullptr) const;
+                  const MergeContext& context, std::string* result) const;
   size_t GetNumOperands() const { return merge_context_.GetNumOperands(); }
   MergeContext* GetMergeContext() { return &merge_context_; }
   Slice GetOperand(int index) const { return merge_context_.GetOperand(index); }


### PR DESCRIPTION
The MultiGetFromBatchAndDB would fail if the PinnableSlice value being returned was pinned.  This could happen if the value was retrieved from the DB (not memtable) or potentially if the values were reused (and a previous iteration returned a slice that was pinned).

This change resets the pinnable value to clear it prior to attempting to use it, thereby eliminating the problem with the value already being pinned.