### PR TITLE
[CI] Use large macos instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ jobs:
   build-macos:
     macos:
       xcode: 11.3.0
+    resource_class: large
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos
@@ -132,6 +133,7 @@ jobs:
   build-macos-cmake:
     macos:
       xcode: 11.3.0
+    resource_class: large
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos


### PR DESCRIPTION
Macos build is taking more than 1 hour, bump the instance type from the
default medium to large (large macos instance was not available before).

Test Plan: watch CI pass