### PR TITLE
[RFC] Disable automatic error recovery for user write failures

### DIFF
--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -79,6 +79,7 @@ class ErrorHandler {
 
     Status RecoverFromBGError(bool is_manual = false);
     void CancelErrorRecovery();
+    void StopDB();
 
     void EndAutoRecovery();
 
@@ -112,7 +113,9 @@ class ErrorHandler {
     // The pointer of DB statistics.
     std::shared_ptr<Statistics> bg_error_stats_;
 
-    Status OverrideNoSpaceError(const Status& bg_error, bool* auto_recovery);
+    Status OverrideNoSpaceError(const Status& bg_error,
+                                const BackgroundErrorReason reason,
+                                bool* auto_recovery);
     void RecoverFromNoSpace();
     const Status& StartRecoverFromRetryableBGIOError(const IOStatus& io_error);
     void RecoverFromRetryableBGIOError();

--- a/utilities/transactions/optimistic_transaction_db_impl.cc
+++ b/utilities/transactions/optimistic_transaction_db_impl.cc
@@ -44,6 +44,9 @@ Status OptimisticTransactionDB::Open(const Options& options,
   column_families.push_back(
       ColumnFamilyDescriptor(kDefaultColumnFamilyName, cf_options));
   std::vector<ColumnFamilyHandle*> handles;
+
+  // Disable automatic error recovery
+  db_options.max_bgerror_resume_count = 0;
   Status s = Open(db_options, dbname, column_families, &handles, dbptr);
   if (s.ok()) {
     assert(handles.size() == 1);

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -228,6 +228,8 @@ Status TransactionDB::Open(
   std::vector<ColumnFamilyDescriptor> column_families_copy = column_families;
   std::vector<size_t> compaction_enabled_cf_indices;
   DBOptions db_options_2pc = db_options;
+  // Disable automatic error recovery
+  db_options_2pc.max_bgerror_resume_count = 0;
   PrepareWrap(&db_options_2pc, &column_families_copy,
               &compaction_enabled_cf_indices);
   const bool use_seq_per_batch =


### PR DESCRIPTION
In the current error recovery logic, background write errors during flush/compaction are automatically retried under some circumstances (NoSpace, retryable errors in distributed file systems). Normally, these errors are not visible to the user and we can try to recover from them in the background. However, if recovery takes a long time, the memtables eventually would become full with buffered writes and writes will be stopped by the write controller. When that happens, we currently return Status::Incomplete rather than indefinitely hang the write thread. There are 2 problems with this approach -
1. The Incomplete error may not be handled correctly by the user. It used to be returned only when the write_options.no_slowdown was set.
2. Other writes may be queued behind the incomplete write. If the background error recovery succeeds, the queued writes may be successful, which might cause inconsistency, especially with TransactionDB.

The solution is to stop all further writes once we return an error for a user write. This is accomplished in this PR as follows -
1. When the write controller stops writes and there is a background error, stop all further writes by setting the severity in ```bg_error_``` to ```kHardError```.
2. Disable automatic error recovery in TransactionDB::Open() by setting ```db_options.max_bgerror_resume_count``` to 0. (Is this still required if we have #1?) 