### PR TITLE
Issue 8239: Add early column family check for DeleteRange 

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2050,7 +2050,7 @@ Status DB::DeleteRange(const WriteOptions& opt,
                        ColumnFamilyHandle* column_family,
                        const Slice& begin_key, const Slice& end_key) {
   WriteBatch batch;
-  Status s = batch.DeleteRange(column_family, begin_key, end_key);
+  Status s = batch.DeleteRange(column_family == nullptr ? DefaultColumnFamily() : column_family, begin_key, end_key);
   if (!s.ok()) {
     return s;
   }

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -129,7 +129,7 @@ TEST_F(DBRangeDelTest, DBInvalidRangeCascadingProblem) {
   Status s2 = db->DeleteRange(write_options, nullptr, "Z", "Y");
   ASSERT_TRUE(s2.IsInvalidArgument());
   Status s3 = db->DeleteRange(write_options, nullptr, "A", "B");
-  ASSERT_OK(s3);  // This fails, "end key comes before start key" !!
+  ASSERT_OK(s3);  // This should work as the db is still alive.
 }
 
 TEST_F(DBRangeDelTest, CompactionOutputFilesExactlyFilled) {

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -101,6 +101,10 @@ class WriteBatchInternal {
   static Status DeleteRange(WriteBatch* b, uint32_t column_family_id,
                             const Slice& begin_key, const Slice& end_key);
 
+  static Status DeleteRange(WriteBatch* b, ColumnFamilyHandle* column_family,
+                            uint32_t column_family_id,
+                            const Slice& begin_key, const Slice& end_key);
+
   static Status DeleteRange(WriteBatch* b, uint32_t column_family_id,
                             const SliceParts& begin_key,
                             const SliceParts& end_key);

--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -21,7 +21,7 @@ class WriteBatch;
 struct SliceParts;
 
 // Abstract base class that defines the basic interface for a write batch.
-// See WriteBatch for a basic implementation and WrithBatchWithIndex for an
+// See WriteBatch for a basic implementation and WriteBatchWithIndex for an
 // indexed implementation.
 class WriteBatchBase {
  public:


### PR DESCRIPTION
This PR tries to address the [issue](https://github.com/facebook/rocksdb/issues/8239) of getting the invalid range delete to the later stage which brings down the entire database, by always providing a valid column family and the sanity check by using `GetComparator`. 