### PR TITLE
Exclude some tests from valgrind_test

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -1536,9 +1536,11 @@ class DBIteratorTestForPinnedData : public DBIteratorTest {
 }
 };
 
+#ifndef ROCKSDB_VALGRIND_RUN
 TEST_P(DBIteratorTestForPinnedData, PinnedDataIteratorRandomizedNormal) {
   PinnedDataIteratorRandomized(TestConfig::NORMAL);
 }
+#endif  // ROCKSDB_VALGRIND_RUN
 
 TEST_P(DBIteratorTestForPinnedData, PinnedDataIteratorRandomizedCLoseAndOpen) {
   PinnedDataIteratorRandomized(TestConfig::CLOSE_AND_OPEN);

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -1494,6 +1494,7 @@ TEST_F(DBBasicTestWithTimestamp, CompactDeletionWithTimestampMarkerToBottom) {
   Close();
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 class DBBasicTestWithTimestampFilterPrefixSettings
     : public DBBasicTestWithTimestampBase,
       public testing::WithParamInterface<
@@ -1625,6 +1626,7 @@ INSTANTIATE_TEST_CASE_P(
             BlockBasedTableOptions::IndexType::kHashSearch,
             BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch,
             BlockBasedTableOptions::IndexType::kBinarySearchWithFirstKey)));
+#endif  // ROCKSDB_VALGRIND_RUN
 
 class DataVisibilityTest : public DBBasicTestWithTimestampBase {
  public:
@@ -2215,6 +2217,7 @@ TEST_F(DataVisibilityTest, MultiGetCrossCF) {
   Close();
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 class DBBasicTestWithTimestampCompressionSettings
     : public DBBasicTestWithTimestampBase,
       public testing::WithParamInterface<
@@ -2954,6 +2957,7 @@ INSTANTIATE_TEST_CASE_P(
             BlockBasedTableOptions::IndexType::kHashSearch,
             BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch,
             BlockBasedTableOptions::IndexType::kBinarySearchWithFirstKey)));
+#endif  // ROCKSDB_VALGRIND_RUN
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1398,6 +1398,7 @@ TEST_F(ExternalSSTFileTest, IngestNonExistingFile) {
   ASSERT_EQ(1, num_sst_files);
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 TEST_F(ExternalSSTFileTest, CompactDuringAddFileRandom) {
   env_->skip_fsync_ = true;
   Options options = CurrentOptions();
@@ -1455,6 +1456,7 @@ TEST_F(ExternalSSTFileTest, CompactDuringAddFileRandom) {
     }
   }
 }
+#endif  // ROCKSDB_VALGRIND_RUN
 
 TEST_F(ExternalSSTFileTest, PickedLevelDynamic) {
   env_->skip_fsync_ = true;
@@ -1716,6 +1718,7 @@ TEST_F(ExternalSSTFileTest, WithUnorderedWrite) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoRandomized) {
   env_->skip_fsync_ = true;
   Options options = CurrentOptions();
@@ -1757,6 +1760,7 @@ TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoRandomized) {
     VerifyDBFromMap(true_data, &kcnt, false);
   }
 }
+#endif  // ROCKSDB_VALGRIND_RUN
 
 TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoAssignedLevel) {
   Options options = CurrentOptions();

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -84,6 +84,7 @@ class MockWriteCallback : public WriteCallback {
   bool AllowWriteBatching() override { return allow_batching_; }
 };
 
+#ifndef ROCKSDB_VALGRIND_RUN
 class WriteCallbackPTest
     : public WriteCallbackTest,
       public ::testing::WithParamInterface<
@@ -376,6 +377,7 @@ INSTANTIATE_TEST_CASE_P(WriteCallbackPTest, WriteCallbackPTest,
                                            ::testing::Bool(), ::testing::Bool(),
                                            ::testing::Bool(), ::testing::Bool(),
                                            ::testing::Bool()));
+#endif  // ROCKSDB_VALGRIND_RUN
 
 TEST_F(WriteCallbackTest, WriteCallBackTest) {
   Options options;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -1048,6 +1048,7 @@ TEST_P(BackupEngineTestWithParam, VerifyBackup) {
   CloseDBAndBackupEngine();
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 // open DB, write, close DB, backup, restore, repeat
 TEST_P(BackupEngineTestWithParam, OfflineIntegrationTest) {
   // has to be a big number, so that it triggers the memtable flush
@@ -1158,6 +1159,7 @@ TEST_P(BackupEngineTestWithParam, OnlineIntegrationTest) {
 
   CloseBackupEngine();
 }
+#endif  // ROCKSDB_VALGRIND_RUN
 
 INSTANTIATE_TEST_CASE_P(BackupEngineTestWithParam, BackupEngineTestWithParam,
                         ::testing::Bool());
@@ -1548,6 +1550,7 @@ TEST_F(BackupEngineTest, BlobFileCorruptedBeforeBackup) {
   CloseDBAndBackupEngine();
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 // Test if BackupEngine will fail to create new backup if some table has been
 // corrupted and the table file checksum is stored in the DB manifest for the
 // case when backup table files will be stored in a shared directory
@@ -1606,6 +1609,7 @@ TEST_P(BackupEngineTestWithParam, BlobFileCorruptedBeforeBackup) {
   ASSERT_NOK(backup_engine_->CreateNewBackup(db_.get()));
   CloseDBAndBackupEngine();
 }
+#endif  // ROCKSDB_VALGRIND_RUN
 
 TEST_F(BackupEngineTest, TableFileWithoutDbChecksumCorruptedDuringBackup) {
   const int keys_iteration = 50000;
@@ -2526,6 +2530,7 @@ TEST_F(BackupEngineTest, KeepLogFiles) {
   AssertBackupConsistency(0, 0, 500, 600, true);
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 class BackupEngineRateLimitingTestWithParam
     : public BackupEngineTest,
       public testing::WithParamInterface<
@@ -2600,6 +2605,7 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimiting) {
 
   AssertBackupConsistency(0, 0, 100000, 100010);
 }
+#endif  // ROCKSDB_VALGRIND_RUN
 
 TEST_F(BackupEngineTest, ReadOnlyBackupEngine) {
   DestroyDB(dbname_, options_);

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -1504,6 +1504,7 @@ TEST_P(TransactionTest, DISABLED_TwoPhaseMultiThreadTest) {
   }
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 TEST_P(TransactionStressTest, TwoPhaseLongPrepareTest) {
   WriteOptions write_options;
   write_options.sync = true;
@@ -1614,6 +1615,7 @@ TEST_P(TransactionTest, TwoPhaseSequenceTest) {
   ASSERT_EQ(s, Status::OK());
   ASSERT_EQ(value, "bar4");
 }
+#endif  // ROCKSDB_VALGRIND_RUN
 
 TEST_P(TransactionTest, TwoPhaseDoubleRecoveryTest) {
   WriteOptions write_options;
@@ -5520,6 +5522,7 @@ TEST_P(TransactionTest, MemoryLimitTest) {
   delete txn;
 }
 
+#ifndef ROCKSDB_VALGRIND_RUN
 // This test clarifies the existing expectation from the sequence number
 // algorithm. It could detect mistakes in updating the code but it is not
 // necessarily the one acceptable way. If the algorithm is legitimately changed,
@@ -5643,6 +5646,7 @@ TEST_P(TransactionStressTest, SeqAdvanceTest) {
     ASSERT_OK(ReOpen());
   }
 }
+#endif  // ROCKSDB_VALGRIND_RUN
 
 // Verify that the optimization would not compromize the correctness
 TEST_P(TransactionTest, Optimizations) {


### PR DESCRIPTION
Summary:
valgrind_test has grown too long again. Remove some top time consumers. Picked tests from the top lists:

----------] 21 tests from DBAsBaseDB/TransactionStressTest (196116 ms total)
[----------] 19 tests from DBBloomFilterTest (205843 ms total)
[----------] 114 tests from NumLevels/DBTestUniversalCompaction (220381 ms total)
[----------] 80 tests from MergeOperatorPinningTest/PerConfigMergeOperatorPinningTest (222282 ms total)
[----------] 48 tests from Timestamp/DBBasicTestWithTsIterTombstones (231845 ms total)
[----------] 6 tests from MergeOperatorPinningTest/MergeOperatorPinningTest (277963 ms total)
[----------] 6 tests from DBBasicTestDeadline/DBBasicTestDeadline (297691 ms total)
[----------] 4 tests from FaultTest/FaultInjectionTestSplitted (389107 ms total)
[----------] 14 tests from BackupEngineTestWithParam/BackupEngineTestWithParam (395719 ms total)
[----------] 96 tests from Timestamp/DBBasicTestWithTimestampPrefixSeek (439977 ms total)
[----------] 22 tests from ExternalSSTFileTest (501245 ms total)
[----------] 62 tests from DBCompactionTest (546485 ms total)
[----------] 99 tests from DBTest (620521 ms total)
[----------] 8 tests from RateLimiting/BackupEngineRateLimitingTestWithParam (694925 ms total)
[----------] 44 tests from BackupEngineTest (800690 ms total)
[----------] 80 tests from MultiThreaded/MultiThreadedDBTest (896628 ms total)
[----------] 8 tests from DBIteratorTestForPinnedDataInstance/DBIteratorTestForPinnedData (1052371 ms total)
[----------] 60 tests from ExternalSSTFileTest/ExternalSSTFileTest (1075585 ms total)
[----------] 128 tests from WriteCallbackPTest/WriteCallbackPTest (1471369 ms total)
[----------] 768 tests from Timestamp/DBBasicTestWithTimestampFilterPrefixSettings (1842140 ms total)
r

Test Plan: "make valgrind_test" and see it builds.