### PR TITLE
Add statistics support on CompactionService remote side

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,8 @@
 * ldb has a new feature, `list_live_files_metadata`, that shows the live SST files, as well as their LSM storage level and the column family they belong to.
 * The new BlobDB implementation now tracks the amount of garbage in each blob file in the MANIFEST.
 * Integrated BlobDB now supports Merge with base values (Put/Delete etc.).
+* RemoteCompaction supports sub-compaction, the job_id in the user interface is changed from `int` to `uint64_t` to support sub-compaction id.
+* Expose statistics option in RemoteCompaction worker.
 
 ### Public API change
 * Added APIs to the Customizable class to allow developers to create their own Customizable classes.  Created the utilities/customizable_util.h file to contain helper methods for developing new Customizable classes.

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -767,6 +767,7 @@ Status DB::OpenAndCompact(
   compaction_input.db_options.env = override_options.env;
   compaction_input.db_options.file_checksum_gen_factory =
       override_options.file_checksum_gen_factory;
+  compaction_input.db_options.statistics = override_options.statistics;
   compaction_input.column_family.options.comparator =
       override_options.comparator;
   compaction_input.column_family.options.merge_operator =

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1797,6 +1797,11 @@ struct CompactionServiceOptionsOverride {
   std::shared_ptr<const SliceTransform> prefix_extractor = nullptr;
   std::shared_ptr<TableFactory> table_factory;
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory = nullptr;
+
+  // statistics is used to collect DB operation metrics, the metrics won't be
+  // returned to CompactionService primary host, to collect that, the user needs
+  // to set it here.
+  std::shared_ptr<Statistics> statistics = nullptr;
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: Add statistics option on CompactionService remote side.

Test Plan: `make check`