### PR TITLE
avoid memcpy from mmapped plain table tables

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1798,6 +1798,12 @@ Status DBImpl::GetImpl(const ReadOptions& read_options, const Slice& key,
   }
   if (!done) {
     PERF_TIMER_GUARD(get_from_output_files_time);
+    // XXX somehow we have to make sure our SuperVersion is retained (elide
+    // ReturnAndCleanupSuperVersion call)
+    // ... maybe not, possibly just holding onto the last table reader cache
+    // entry (the tablereader holds the open file)
+    // ... sometimes the Version holds the table readers, so we either need to
+    // hold the SuperVersion or the Version?
     sv->current->Get(
         read_options, lkey, get_impl_options.value, timestamp, &s,
         &merge_context, &max_covering_tombstone_seq,

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -657,7 +657,11 @@ TEST_P(PlainTableDBTest, Immortal) {
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
     ASSERT_EQ("b", Get("0000000000000bar"));
     ASSERT_EQ("v1", Get("1000000000000foo"));
-    ASSERT_EQ(2, copied);
+    if (mmap_mode()) {
+      ASSERT_EQ(0, copied);
+    } else {
+      ASSERT_EQ(2, copied);
+    }
     copied = 0;
 
     Close();

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -65,7 +65,8 @@ GetContext::GetContext(
       callback_(callback),
       do_merge_(do_merge),
       is_blob_index_(is_blob_index),
-      tracing_get_id_(tracing_get_id) {
+      tracing_get_id_(tracing_get_id),
+      table_pinner_(nullptr) {
   if (seq_) {
     *seq_ = kMaxSequenceNumber;
   }

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -169,6 +169,16 @@ class GetContext {
 
   void push_operand(const Slice& value, Cleanable* value_pinner);
 
+  void set_table_pinner(std::function<Cleanable*()>* pinner) {
+    table_pinner_ = pinner;
+  }
+
+  bool can_pin_table() { return table_pinner_ != nullptr; }
+
+  void clear_table_pinner() { table_pinner_ = nullptr; }
+
+  Cleanable* pin_table() { return (*table_pinner_)(); }
+
  private:
   const Comparator* ucmp_;
   const MergeOperator* merge_operator_;
@@ -200,6 +210,8 @@ class GetContext {
   // Used for block cache tracing only. A tracing get id uniquely identifies a
   // Get or a MultiGet.
   const uint64_t tracing_get_id_;
+
+  std::function<Cleanable*()>* table_pinner_;
 };
 
 // Call this to replay a log and bring the get_context up to date. The replay


### PR DESCRIPTION
Intended to fix #8374.

Things might be a bit rough now (in particularly I've left various comments I left along the way that I don't intend to keep, the commit message is garbage, ...), but I wanted to get feedback on the implementation before I clean it all up.

plain_table_db_test passes as patched (it no longer copies when files are mapped in and is updated as such). I've seen stress testing tools that I intend to run; any suggestions and guidance is very much welcome.