### PR TITLE
Fixed manifest_dump issues when printing keys and values containing null characters

### DIFF
--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -911,7 +911,7 @@ void DumpManifestHandler::CheckIterationResult(const log::Reader& reader,
     assert(cfd->current());
 
     // Print out DebugStrings. Can include non-terminating null characters.
-    fwrite(cfd->current()->DebugString(hex_).c_str(), sizeof(char),
+    fwrite(cfd->current()->DebugString(hex_).data(), sizeof(char),
            cfd->current()->DebugString(hex_).size(), stdout);
   }
   fprintf(stdout,

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -910,14 +910,9 @@ void DumpManifestHandler::CheckIterationResult(const log::Reader& reader,
     }
     assert(cfd->current());
 
-    // Print out DebugStrings. Null characters are replaced with whitespaces.
-    for (const char& x : cfd->current()->DebugString(hex_)) {
-      if (x == '\0') {
-        fputc(' ', stdout);
-      } else {
-        fputc(x, stdout);
-      }
-    }
+    // Print out DebugStrings. Can include non-terminating null characters.
+    fwrite(cfd->current()->DebugString(hex_).c_str(), sizeof(char),
+           cfd->current()->DebugString(hex_).size(), stdout);
   }
   fprintf(stdout,
           "next_file_number %" PRIu64 " last_sequence %" PRIu64

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -909,7 +909,15 @@ void DumpManifestHandler::CheckIterationResult(const log::Reader& reader,
       fprintf(stdout, "comparator: %s\n", cfd->user_comparator()->Name());
     }
     assert(cfd->current());
-    fprintf(stdout, "%s \n", cfd->current()->DebugString(hex_).c_str());
+
+    // Print out DebugStrings. Null characters are replaced with whitespaces.
+    for (const char& x : cfd->current()->DebugString(hex_)) {
+      if (x == '\0') {
+        fputc(' ', stdout);
+      } else {
+        fputc(x, stdout);
+      }
+    }
   }
   fprintf(stdout,
           "next_file_number %" PRIu64 " last_sequence %" PRIu64

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -12,7 +12,6 @@
 #include "db/version_builder.h"
 #include "db/version_edit.h"
 #include "db/version_set.h"
-
 namespace ROCKSDB_NAMESPACE {
 
 struct FileMetaData;
@@ -285,9 +284,23 @@ class DumpManifestHandler : public VersionEditHandler {
   Status ApplyVersionEdit(VersionEdit& edit, ColumnFamilyData** cfd) override {
     // Write out each individual edit
     if (verbose_ && !json_) {
-      fprintf(stdout, "%s\n", edit.DebugString(hex_).c_str());
+      // Print out DebugStrings. Null characters are replaced with whitespaces.
+      for (const char& x : edit.DebugString(hex_)) {
+        if (x == '\0') {
+          fputc(' ', stdout);
+        } else {
+          fputc(x, stdout);
+        }
+      }
     } else if (json_) {
-      fprintf(stdout, "%s\n", edit.DebugJSON(count_, hex_).c_str());
+      // Print out DebugStrings. Null characters are replaced with whitespaces.
+      for (const char& x : edit.DebugJSON(count_, hex_)) {
+        if (x == '\0') {
+          fputc(' ', stdout);
+        } else {
+          fputc(x, stdout);
+        }
+      }
     }
     ++count_;
     return VersionEditHandler::ApplyVersionEdit(edit, cfd);

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -285,23 +285,13 @@ class DumpManifestHandler : public VersionEditHandler {
   Status ApplyVersionEdit(VersionEdit& edit, ColumnFamilyData** cfd) override {
     // Write out each individual edit
     if (verbose_ && !json_) {
-      // Print out DebugStrings. Null characters are replaced with whitespaces.
-      for (const char& x : edit.DebugString(hex_)) {
-        if (x == '\0') {
-          fputc(' ', stdout);
-        } else {
-          fputc(x, stdout);
-        }
-      }
+      // Print out DebugStrings. Can include non-terminating null characters.
+      fwrite(edit.DebugString(hex_).c_str(), sizeof(char),
+             edit.DebugString(hex_).size(), stdout);
     } else if (json_) {
-      // Print out DebugStrings. Null characters are replaced with whitespaces.
-      for (const char& x : edit.DebugJSON(count_, hex_)) {
-        if (x == '\0') {
-          fputc(' ', stdout);
-        } else {
-          fputc(x, stdout);
-        }
-      }
+      // Print out DebugStrings. Can include non-terminating null characters.
+      fwrite(edit.DebugString(hex_).c_str(), sizeof(char),
+             edit.DebugString(hex_).size(), stdout);
     }
     ++count_;
     return VersionEditHandler::ApplyVersionEdit(edit, cfd);

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -12,6 +12,7 @@
 #include "db/version_builder.h"
 #include "db/version_edit.h"
 #include "db/version_set.h"
+
 namespace ROCKSDB_NAMESPACE {
 
 struct FileMetaData;

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -286,11 +286,11 @@ class DumpManifestHandler : public VersionEditHandler {
     // Write out each individual edit
     if (verbose_ && !json_) {
       // Print out DebugStrings. Can include non-terminating null characters.
-      fwrite(edit.DebugString(hex_).c_str(), sizeof(char),
+      fwrite(edit.DebugString(hex_).data(), sizeof(char),
              edit.DebugString(hex_).size(), stdout);
     } else if (json_) {
       // Print out DebugStrings. Can include non-terminating null characters.
-      fwrite(edit.DebugString(hex_).c_str(), sizeof(char),
+      fwrite(edit.DebugString(hex_).data(), sizeof(char),
              edit.DebugString(hex_).size(), stdout);
     }
     ++count_;

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -482,19 +482,14 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunOK("put a3 b3", "OK")
         self.assertRunOK("put a4 b4", "OK")
 
-        # Regex pattern of manifest_dump verbose.
-        # Note that the key/values can include non-alphanumerical symbols.
-        subpat = num + ":" + num + "\[[^\0]+ seq:[0-9]+, type:[0-9]+ .. [^\0]+ seq:[0-9]+, type:[0-9]+\]"
-        manifest_verbose_regex = "Processing .*MANIFEST.*\n"
-        manifest_verbose_regex += "(VersionEdit {([^}]+)}\n)+"
-        manifest_verbose_regex += "(.*\n){3}"
-        manifest_verbose_regex += "(--- level \d+ --- version\# \d+ ---\n( "+subpat+"\n)*){64}"
-        manifest_verbose_regex += "next_file_number.*\n"
-        manifest_verbose_regex += "Processing .*MANIFEST.*done"
-        expected_verbose_pattern = re.compile(manifest_verbose_regex)
-        # Test manifest_dump verbose when keys and values contain null characters
-        cmd_verbose = "manifest_dump --verbose --db=%s" %dbPath
-        self.assertRunOKFull(cmd_verbose , expected_verbose_pattern,
+        # Verifies that all "levels" are printed out.
+        # There should be 66 mentions of levels.
+        expected_verbose_output = re.compile("66")
+        # Test manifest_dump verbose and count within the
+        # Terminal how many levels are printed out.
+        cmd_verbose = "manifest_dump --verbose --db=%s | grep -c -E 'level'" %dbPath
+
+        self.assertRunOKFull(cmd_verbose , expected_verbose_output,
                              unexpected=False, isPattern=True)
 
 

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -477,17 +477,17 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunOK("put a1 b1", "OK")
         self.assertRunOK("put a2 b2", "OK")
         self.assertRunOK("put --hex 0x12000DA0 0x80C0000B", "OK")
-        self.assertRunOK("put --hex 0xb000000b 0xc000000c", "OK")
+        self.assertRunOK("put --hex 0x7200004f 0x80000004", "OK")
         self.assertRunOK("put --hex 0xa000000a 0xf000000f", "OK")
         self.assertRunOK("put a3 b3", "OK")
         self.assertRunOK("put a4 b4", "OK")
 
         # Verifies that all "levels" are printed out.
         # There should be 66 mentions of levels.
-        expected_verbose_output = re.compile("66")
-        # Test manifest_dump verbose and count within the
-        # Terminal how many levels are printed out.
-        cmd_verbose = "manifest_dump --verbose --db=%s | grep -c -E 'level'" %dbPath
+        expected_verbose_output = re.compile("matched")
+        # Test manifest_dump verbose and verify that key 0x7200004f
+        # is present. Note that 0x72=r and 0x4f=O, hence the regex \'r.{2}O\'
+        cmd_verbose = "manifest_dump --verbose --db=%s | grep -aq $'\'r.{2}O\'' && echo 'matched' || echo 'not matched'" %dbPath
 
         self.assertRunOKFull(cmd_verbose , expected_verbose_output,
                              unexpected=False, isPattern=True)

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -486,7 +486,12 @@ class LDBTestCase(unittest.TestCase):
         # There should be 66 mentions of levels.
         expected_verbose_output = re.compile("matched")
         # Test manifest_dump verbose and verify that key 0x7200004f
-        # is present. Note that 0x72=r and 0x4f=O, hence the regex \'r.{2}O\'
+        # is present. Note that we are forced to use grep here because
+        # an output with a non-terminating null character in it isn't piped
+        # correctly through the Python subprocess object.
+        # Also note that 0x72=r and 0x4f=O, hence the regex \'r.{2}O\'
+        # (we cannot use null character in the subprocess input either,
+        # so we have to use '.{2}')
         cmd_verbose = "manifest_dump --verbose --db=%s | grep -aq $'\'r.{2}O\'' && echo 'matched' || echo 'not matched'" %dbPath
 
         self.assertRunOKFull(cmd_verbose , expected_verbose_output,


### PR DESCRIPTION
Changed fprintf function to fputc in ApplyVersionEdit, and replaced null characters with whitespaces. 
Added unit test in ldb_test.py - verifies that manifest_dump --verbose output is correct when keys and values containing null characters are inserted.