### PR TITLE
Clarify some DB::Open,OpenForReadOnly semantics

### DIFF
--- a/cache/cache_entry_roles.h
+++ b/cache/cache_entry_roles.h
@@ -27,7 +27,7 @@ enum class CacheEntryRole {
   kIndexBlock,
   // Other kinds of block-based table block
   kOtherBlock,
-  // WriteBufferManager resevations to account for memtable usage
+  // WriteBufferManager reservations to account for memtable usage
   kWriteBuffer,
   // Default bucket, for miscellaneous cache entries. Do not use for
   // entries that could potentially add up to large usage.


### PR DESCRIPTION
Summary: Longstanding tech debt

Test Plan: Better than not having an API contract