### PR TITLE
Revert "Make platform009 default for FB developers (#8389)"

### DIFF
--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -69,6 +69,10 @@ if [ -z "$ROCKSDB_NO_FBCODE" -a -d /mnt/gvfs/third-party ]; then
       source "$PWD/build_tools/fbcode_config_platform007.sh"
     elif [ -n "$ROCKSDB_FBCODE_BUILD_WITH_PLATFORM009" ]; then
       source "$PWD/build_tools/fbcode_config_platform009.sh"
+    elif [ -z "$USE_CLANG" ]; then
+        # Still use platform007 for gcc by default for build break on
+        # some hosts.
+      source "$PWD/build_tools/fbcode_config_platform007.sh"
     else
       source "$PWD/build_tools/fbcode_config_platform009.sh"
     fi


### PR DESCRIPTION
Summary: This reverts commit a42a342a7a034d60bc916b253ae952265965c957.
 Some of the hosts are failing.