### PR TITLE
Fix Windows build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ commands:
 executors:
   windows-2xlarge:
     machine:
-      image: 'windows-server-2019-vs2019:stable'
+      image: 'windows-server-2019-vs2019:previous'
       resource_class: windows.2xlarge
       shell: bash.exe
 


### PR DESCRIPTION
Summary: Fix window build failure by reverting to previous tag as suggested by CircleCI. 

Test Plan: Watch CircleCI builds for a day or two for failure

Reviewers:

Subscribers:

Tasks:

Tags: