### PR TITLE
Change Windows image back to stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ commands:
 executors:
   windows-2xlarge:
     machine:
-      image: 'windows-server-2019-vs2019:previous'
+      image: 'windows-server-2019-vs2019:stable'
       resource_class: windows.2xlarge
       shell: bash.exe
 


### PR DESCRIPTION
Summary: Since windows timeout issue has been fixed. Change the image back to
stable.

Test Plan: Check CircleCI jobs

Reviewers:

Subscribers:

Tasks:

Tags: