### PR TITLE
jemalloc_helper: Limit the mm_malloc.h hack to glibc on linux

### DIFF
--- a/port/jemalloc_helper.h
+++ b/port/jemalloc_helper.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(__GLIBC__)
 // glibc's `posix_memalign()` declaration specifies `throw()` while clang's
 // declaration does not. There is a hack in clang to make its re-declaration
 // compatible with glibc's if they are declared consecutively. That hack breaks


### PR DESCRIPTION
Original author: @kraj (#8413)

We have a hack to ensure clang's `posix_memalign()` hack works to be
compatible with glibc's `posix_memalign()` declaration. Our side of the
hack is irrelevant and should be omitted when not using glibc.