### PR TITLE
[ResourceManagement] Account for dictionary-building buffer in global memory limit

### DIFF
--- a/cache/cache_entry_roles.cc
+++ b/cache/cache_entry_roles.cc
@@ -19,6 +19,7 @@ std::array<const char*, kNumCacheEntryRoles> kCacheEntryRoleToCamelString{{
     "IndexBlock",
     "OtherBlock",
     "WriteBuffer",
+    "CompressionDictionaryBuildingBuffer",
     "Misc",
 }};
 
@@ -30,6 +31,7 @@ std::array<const char*, kNumCacheEntryRoles> kCacheEntryRoleToHyphenString{{
     "index-block",
     "other-block",
     "write-buffer",
+    "compression-dictionary-building-buffer",
     "misc",
 }};
 

--- a/cache/cache_entry_roles.h
+++ b/cache/cache_entry_roles.h
@@ -31,8 +31,8 @@ enum class CacheEntryRole {
   kOtherBlock,
   // WriteBufferManager reservations to account for memtable usage
   kWriteBuffer,
-  // Compression dictionary building buffer reservations to account for memtable
-  // usage
+  // BlockBasedTableBuilder reservations to account for
+  // compression dictionary building buffer's memory usage
   kCompressionDictionaryBuildingBuffer,
   // Default bucket, for miscellaneous cache entries. Do not use for
   // entries that could potentially add up to large usage.

--- a/cache/cache_entry_roles.h
+++ b/cache/cache_entry_roles.h
@@ -14,6 +14,8 @@
 namespace ROCKSDB_NAMESPACE {
 
 // Classifications of block cache entries, for reporting statistics
+// Adding new enum to this class requires corresponding updates to
+// kCacheEntryRoleToCamelString and kCacheEntryRoleToHyphenString
 enum class CacheEntryRole {
   // Block-based table data block
   kDataBlock,

--- a/cache/cache_entry_roles.h
+++ b/cache/cache_entry_roles.h
@@ -29,6 +29,9 @@ enum class CacheEntryRole {
   kOtherBlock,
   // WriteBufferManager reservations to account for memtable usage
   kWriteBuffer,
+  // Compression dictionary building buffer reservations to account for memtable
+  // usage
+  kCompressionDictionaryBuildingBuffer,
   // Default bucket, for miscellaneous cache entries. Do not use for
   // entries that could potentially add up to large usage.
   kMisc,

--- a/cache/cache_reservation_manager.cc
+++ b/cache/cache_reservation_manager.cc
@@ -69,6 +69,8 @@ Status CacheReservationManager::UpdateCacheReservation(
 // This makes it possible to keep the template definitions in the .cc file.
 template Status CacheReservationManager::UpdateCacheReservation<
     CacheEntryRole::kWriteBuffer>(std::size_t new_mem_used);
+template Status CacheReservationManager::UpdateCacheReservation<
+    CacheEntryRole::kCompressionDictionaryBuildingBuffer>(std::size_t new_mem_used);    
 // For cache reservation manager unit tests
 template Status CacheReservationManager::UpdateCacheReservation<
     CacheEntryRole::kMisc>(std::size_t new_mem_used);

--- a/cache/cache_reservation_manager.cc
+++ b/cache/cache_reservation_manager.cc
@@ -70,7 +70,8 @@ Status CacheReservationManager::UpdateCacheReservation(
 template Status CacheReservationManager::UpdateCacheReservation<
     CacheEntryRole::kWriteBuffer>(std::size_t new_mem_used);
 template Status CacheReservationManager::UpdateCacheReservation<
-    CacheEntryRole::kCompressionDictionaryBuildingBuffer>(std::size_t new_mem_used);    
+    CacheEntryRole::kCompressionDictionaryBuildingBuffer>(
+    std::size_t new_mem_used);
 // For cache reservation manager unit tests
 template Status CacheReservationManager::UpdateCacheReservation<
     CacheEntryRole::kMisc>(std::size_t new_mem_used);

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -905,11 +905,12 @@ void BlockBasedTableBuilder::Add(const Slice& key, const Slice& value) {
       r->first_key_in_next_block = &key;
       Flush();
       if (r->state == Rep::State::kBuffered) {
-        bool exceeds_buffer_limit = (r->buffer_limit != 0 && r->data_begin_offset > r->buffer_limit);
+        bool exceeds_buffer_limit =
+            (r->buffer_limit != 0 && r->data_begin_offset > r->buffer_limit);
         bool is_cache_full = false;
 
         // Increase cache reservation for the last buffered data block
-        // only if the block is not going to be unbuffered immediately 
+        // only if the block is not going to be unbuffered immediately
         // and there exists a cache reservation manager
         if (!exceeds_buffer_limit && r->cache_rev_mng != nullptr) {
           Status s = r->cache_rev_mng->UpdateCacheReservation<
@@ -1937,7 +1938,8 @@ void BlockBasedTableBuilder::EnterUnbuffered() {
   r->data_begin_offset = 0;
   if (r->cache_rev_mng != nullptr) {
     Status s = r->cache_rev_mng->UpdateCacheReservation<
-        CacheEntryRole::kCompressionDictionaryBuildingBuffer>(r->data_begin_offset);
+        CacheEntryRole::kCompressionDictionaryBuildingBuffer>(
+        r->data_begin_offset);
     s.PermitUncheckedError();
   }
 }

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -450,9 +450,9 @@ struct BlockBasedTableBuilder::Rep {
     }
     // TODO figure out c++ member initialization syntax
     buffer_exceeds_global_memory_limit = false;
-    cache_rep = (table_options.block_cache != nullptr
-                     ? new CacheRep(table_options.block_cache.get())
-                     : nullptr);
+    cache_rep = (table_options_.no_block_cache
+                     ? nullptr)
+                     : new CacheRep(table_options.block_cache.get());
 
     for (uint32_t i = 0; i < compression_opts.parallel_threads; i++) {
       compression_ctxs[i].reset(new CompressionContext(compression_type));

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -450,8 +450,9 @@ struct BlockBasedTableBuilder::Rep {
     buffer_exceeds_global_memory_limit = false;
     if (table_options.no_block_cache) {
       cache_rev_mng.reset(nullptr);
-    } else{
-      cache_rev_mng.reset(new CacheReservationManager(table_options.block_cache));
+    } else {
+      cache_rev_mng.reset(
+          new CacheReservationManager(table_options.block_cache));
     }
     for (uint32_t i = 0; i < compression_opts.parallel_threads; i++) {
       compression_ctxs[i].reset(new CompressionContext(compression_type));
@@ -1013,11 +1014,13 @@ void BlockBasedTableBuilder::WriteBlock(BlockBuilder* block,
     rep_->data_block_buffers.emplace_back(std::move(raw_block_contents));
     rep_->data_begin_offset += rep_->data_block_buffers.back().size();
     if (rep_->cache_rev_mng != nullptr) {
-      //TODO: figure out if we need external sync for this
-      Status s = rep_->cache_rev_mng->UpdateCacheReservation<CacheEntryRole::kCompressionDictionaryBuildingBuffer>(rep_->data_block_buffers.size());
-      if (s.IsIncomplete()) { 
+      // TODO: figure out if we need external sync for this
+      Status s = rep_->cache_rev_mng->UpdateCacheReservation<
+          CacheEntryRole::kCompressionDictionaryBuildingBuffer>(
+          rep_->data_block_buffers.size());
+      if (s.IsIncomplete()) {
         rep_->buffer_exceeds_global_memory_limit = true;
-      } 
+      }
     }
     return;
   }
@@ -1934,8 +1937,9 @@ void BlockBasedTableBuilder::EnterUnbuffered() {
     // flushing all the buffered data blocks
     if (ok()) {
       if (rep_->cache_rev_mng != nullptr) {
-        //TODO: figure out if we need external sync for this
-        Status s = rep_->cache_rev_mng->UpdateCacheReservation<CacheEntryRole::kCompressionDictionaryBuildingBuffer>(0);
+        // TODO: figure out if we need external sync for this
+        Status s = rep_->cache_rev_mng->UpdateCacheReservation<
+            CacheEntryRole::kCompressionDictionaryBuildingBuffer>(0);
         s.PermitUncheckedError();
       }
     }

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -101,6 +101,10 @@ class BlockBasedTableBuilder : public TableBuilder {
  private:
   bool ok() const { return status().ok(); }
 
+  void ReserveLastBufferedDataBlockMemInCache();
+
+  void FreeAllBufferedDataBlocksMemFromCache();
+
   // Transition state from buffered to unbuffered. See `Rep::State` API comment
   // for details of the states.
   // REQUIRES: `rep_->state == kBuffered`

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -101,10 +101,6 @@ class BlockBasedTableBuilder : public TableBuilder {
  private:
   bool ok() const { return status().ok(); }
 
-  void ReserveLastBufferedDataBlockMemInCache();
-
-  void FreeAllBufferedDataBlocksMemFromCache();
-
   // Transition state from buffered to unbuffered. See `Rep::State` API comment
   // for details of the states.
   // REQUIRES: `rep_->state == kBuffered`

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -7,6 +7,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include <stddef.h>
 #include <stdio.h>
 
 #include <algorithm>
@@ -4744,6 +4745,221 @@ TEST_P(BlockBasedTableTest, OutOfBoundOnNext) {
   iter->Next();
   ASSERT_FALSE(iter->Valid());
   ASSERT_FALSE(iter->UpperBoundCheckResult() == IterBoundCheck::kOutOfBound);
+}
+
+TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnBuilderFinish){
+  constexpr std::size_t kSizeDummyEntry = 256 * 1024;
+  constexpr std::size_t kMetaDataChargeOverhead = 10000;
+  constexpr std::size_t kCacheCapacity = 8 * 1024 * 1024;
+  constexpr std::size_t kMaxDictBytes = 1024;
+  constexpr std::size_t kMaxDictBufferBytes = 1024;
+  
+  BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
+  LRUCacheOptions lo;
+  lo.capacity = kCacheCapacity;
+  lo.num_shard_bits = 0;  // 2^0 shard
+  lo.strict_capacity_limit = true;
+  std::shared_ptr<Cache> cache(NewLRUCache(lo));
+  table_options.block_cache = cache;
+  table_options.flush_block_policy_factory = std::make_shared<FlushBlockEveryKeyPolicyFactory>();
+  
+  Options options;
+  options.compression = kSnappyCompression;
+  options.compression_opts.max_dict_bytes = kMaxDictBytes;
+  options.compression_opts.max_dict_buffer_bytes = kMaxDictBufferBytes;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  test::StringSink* sink = new test::StringSink();
+  std::unique_ptr<FSWritableFile> holder(sink);
+  std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
+      std::move(holder), "test_file_name", FileOptions()));
+
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  InternalKeyComparator ikc(options.comparator);
+  IntTblPropCollectorFactories int_tbl_prop_collector_factories;
+
+  std::unique_ptr<TableBuilder> builder(options.table_factory->NewTableBuilder(
+      TableBuilderOptions(ioptions, moptions, ikc,
+                          &int_tbl_prop_collector_factories, kSnappyCompression,
+                          options.compression_opts, kUnknownColumnFamily,
+                          "test_cf", -1 /* level */),
+      file_writer.get()));
+
+  
+  std::string key1 = "key1";
+  std::string value1 = "val1";
+  InternalKey ik1(key1, 0 /* sequnce number */, kTypeValue);
+  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy 
+  // therefore won't trigger any data block's buffering
+  builder->Add(ik1.Encode(), value1);
+  ASSERT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
+
+  std::string key2 = "key2";
+  std::string value2 = "val2";
+  InternalKey ik2(key2, 1 /* sequnce number */, kTypeValue);
+  // Adding the second key will trigger a flush of the last data block (the one containing key1 and value1) by FlushBlockEveryKeyPolicy 
+  // and hence trigger buffering of that data block.
+  builder->Add(ik2.Encode(), value2);
+  // Cache reservation will increase for last buffered data block (the one containing key1 and value1)
+  // since the buffer limit is not exceeded after that buffering and the cache will not be full after this reservation
+  EXPECT_GE(cache->GetPinnedUsage(), 1 * kSizeDummyEntry);
+  EXPECT_LT(cache->GetPinnedUsage(), 1 * kSizeDummyEntry + kMetaDataChargeOverhead);
+  
+  ASSERT_OK(builder->Finish());
+  EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
+}
+
+TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnBufferLimitExceed){
+  constexpr std::size_t kSizeDummyEntry = 256 * 1024;
+  constexpr std::size_t kMetaDataChargeOverhead = 10000;
+  constexpr std::size_t kCacheCapacity = 8 * 1024 * 1024;
+  constexpr std::size_t kMaxDictBytes = 1024;
+  // A small positive kMaxDictBufferBytes leads to a small buffer limit for our testing purpose 
+  // 27 is chosen so that buffering two data blocks, each containing key1, value1 and key2, value2
+  // will exceed buffer limit 
+  constexpr std::size_t kMaxDictBufferBytes = 27;
+  
+  BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
+  LRUCacheOptions lo;
+  lo.capacity = kCacheCapacity;
+  lo.num_shard_bits = 0;  // 2^0 shard
+  lo.strict_capacity_limit = true;
+  std::shared_ptr<Cache> cache(NewLRUCache(lo));
+  table_options.block_cache = cache;
+  table_options.flush_block_policy_factory = std::make_shared<FlushBlockEveryKeyPolicyFactory>();
+  
+  Options options;
+  options.compression = kSnappyCompression;
+  options.compression_opts.max_dict_bytes = kMaxDictBytes;
+  options.compression_opts.max_dict_buffer_bytes = kMaxDictBufferBytes;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  test::StringSink* sink = new test::StringSink();
+  std::unique_ptr<FSWritableFile> holder(sink);
+  std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
+      std::move(holder), "test_file_name", FileOptions()));
+
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  InternalKeyComparator ikc(options.comparator);
+  IntTblPropCollectorFactories int_tbl_prop_collector_factories;
+
+  std::unique_ptr<TableBuilder> builder(options.table_factory->NewTableBuilder(
+      TableBuilderOptions(ioptions, moptions, ikc,
+                          &int_tbl_prop_collector_factories, kSnappyCompression,
+                          options.compression_opts, kUnknownColumnFamily,
+                          "test_cf", -1 /* level */),
+      file_writer.get()));
+
+  
+  std::string key1 = "key1";
+  std::string value1 = "val1";
+  InternalKey ik1(key1, 0 /* sequnce number */, kTypeValue);
+  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy 
+  // therefore won't trigger any data block's buffering
+  builder->Add(ik1.Encode(), value1);
+  ASSERT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
+
+  std::string key2 = "key2";
+  std::string value2 = "val2";
+  InternalKey ik2(key2, 1 /* sequnce number */, kTypeValue);
+  // Adding the second key will trigger a flush of the last data block (the one containing key1 and value1) by FlushBlockEveryKeyPolicy 
+  // and hence trigger buffering of the last data block.
+  builder->Add(ik2.Encode(), value2);
+  // Cache reservation will increase for last buffered data block (the one containing key1 and value1)
+  // since the buffer limit is not exceeded after the buffering and the cache will not be full after this reservation
+  EXPECT_GE(cache->GetPinnedUsage(), 1 * kSizeDummyEntry);
+  EXPECT_LT(cache->GetPinnedUsage(), 1 * kSizeDummyEntry + kMetaDataChargeOverhead);
+
+  std::string key3 = "key3";
+  std::string value3 = "val3";
+  InternalKey ik3(key3, 2 /* sequnce number */, kTypeValue);
+  // Adding the third key will trigger a flush of the last data block (the one containing key2 and value2) by FlushBlockEveryKeyPolicy 
+  // and hence trigger buffering of the last data block.
+  builder->Add(ik3.Encode(), value3);
+  // Cache reservation will decrease since the buffer limit is now exceeded after the last buffering 
+  // and EnterUnbuffered() is triggered
+  EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
+
+  ASSERT_OK(builder->Finish());
+  EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
+}
+
+TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnCacheFull){
+  constexpr std::size_t kSizeDummyEntry = 256 * 1024;
+  constexpr std::size_t kMetaDataChargeOverhead = 10000;
+  // A small kCacheCapacity is chosen so that increase cache reservation for buffering two data blocks, each containing key1, value1 and key2, a big value2
+  // will cause cache full
+  constexpr std::size_t kCacheCapacity = 1 * kSizeDummyEntry + kSizeDummyEntry / 2;
+  constexpr std::size_t kMaxDictBytes = 1024;
+  // A big kMaxDictBufferBytes is chosen so that adding a big key value pair (key2, value2) won't exceed the buffer limit
+  constexpr std::size_t kMaxDictBufferBytes = 1024 * 1024 * 1024;
+  
+  BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
+  LRUCacheOptions lo;
+  lo.capacity = kCacheCapacity;
+  lo.num_shard_bits = 0;  // 2^0 shard
+  lo.strict_capacity_limit = true;
+  std::shared_ptr<Cache> cache(NewLRUCache(lo));
+  table_options.block_cache = cache;
+  table_options.flush_block_policy_factory = std::make_shared<FlushBlockEveryKeyPolicyFactory>();
+  
+  Options options;
+  options.compression = kSnappyCompression;
+  options.compression_opts.max_dict_bytes = kMaxDictBytes;
+  options.compression_opts.max_dict_buffer_bytes = kMaxDictBufferBytes;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  test::StringSink* sink = new test::StringSink();
+  std::unique_ptr<FSWritableFile> holder(sink);
+  std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
+      std::move(holder), "test_file_name", FileOptions()));
+
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  InternalKeyComparator ikc(options.comparator);
+  IntTblPropCollectorFactories int_tbl_prop_collector_factories;
+
+  std::unique_ptr<TableBuilder> builder(options.table_factory->NewTableBuilder(
+      TableBuilderOptions(ioptions, moptions, ikc,
+                          &int_tbl_prop_collector_factories, kSnappyCompression,
+                          options.compression_opts, kUnknownColumnFamily,
+                          "test_cf", -1 /* level */),
+      file_writer.get()));
+
+  
+  std::string key1 = "key1";
+  std::string value1 = "val1";
+  InternalKey ik1(key1, 0 /* sequnce number */, kTypeValue);
+  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy 
+  // therefore won't trigger any data block's buffering
+  builder->Add(ik1.Encode(), value1);
+  ASSERT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
+
+  std::string key2 = "key2";
+  std::string value2(kSizeDummyEntry, '0');
+  InternalKey ik2(key2, 1 /* sequnce number */, kTypeValue);
+  // Adding the second key will trigger a flush of the last data block (the one containing key1 and value1) by FlushBlockEveryKeyPolicy 
+  // and hence trigger buffering of the last data block.
+  builder->Add(ik2.Encode(), value2);
+  // Cache reservation will increase for the last buffered data block (the one containing key1 and value1)
+  // since the buffer limit is not exceeded after the buffering and the cache will not be full after this reservation
+  EXPECT_GE(cache->GetPinnedUsage(), 1 * kSizeDummyEntry);
+  EXPECT_LT(cache->GetPinnedUsage(), 1 * kSizeDummyEntry + kMetaDataChargeOverhead);
+
+  std::string key3 = "key3";
+  std::string value3 = "value3";
+  InternalKey ik3(key3, 2 /* sequnce number */, kTypeValue);
+  // Adding the third key will trigger a flush of the last data block (the one containing key2 and value2) by FlushBlockEveryKeyPolicy 
+  // and hence trigger buffering of the last data block.
+  builder->Add(ik3.Encode(), value3);
+  // Cache reservation will decrease since the cache is now full after increasing reservation for the last buffered block
+  // and EnterUnbuffered() is triggered
+  EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
+
+  ASSERT_OK(builder->Finish());
+  EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4747,13 +4747,15 @@ TEST_P(BlockBasedTableTest, OutOfBoundOnNext) {
   ASSERT_FALSE(iter->UpperBoundCheckResult() == IterBoundCheck::kOutOfBound);
 }
 
-TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnBuilderFinish){
+TEST_P(
+    BlockBasedTableTest,
+    IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnBuilderFinish) {
   constexpr std::size_t kSizeDummyEntry = 256 * 1024;
   constexpr std::size_t kMetaDataChargeOverhead = 10000;
   constexpr std::size_t kCacheCapacity = 8 * 1024 * 1024;
   constexpr std::size_t kMaxDictBytes = 1024;
   constexpr std::size_t kMaxDictBufferBytes = 1024;
-  
+
   BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
   LRUCacheOptions lo;
   lo.capacity = kCacheCapacity;
@@ -4761,8 +4763,9 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
   lo.strict_capacity_limit = true;
   std::shared_ptr<Cache> cache(NewLRUCache(lo));
   table_options.block_cache = cache;
-  table_options.flush_block_policy_factory = std::make_shared<FlushBlockEveryKeyPolicyFactory>();
-  
+  table_options.flush_block_policy_factory =
+      std::make_shared<FlushBlockEveryKeyPolicyFactory>();
+
   Options options;
   options.compression = kSnappyCompression;
   options.compression_opts.max_dict_bytes = kMaxDictBytes;
@@ -4786,11 +4789,10 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
                           "test_cf", -1 /* level */),
       file_writer.get()));
 
-  
   std::string key1 = "key1";
   std::string value1 = "val1";
   InternalKey ik1(key1, 0 /* sequnce number */, kTypeValue);
-  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy 
+  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy
   // therefore won't trigger any data block's buffering
   builder->Add(ik1.Encode(), value1);
   ASSERT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
@@ -4798,28 +4800,33 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
   std::string key2 = "key2";
   std::string value2 = "val2";
   InternalKey ik2(key2, 1 /* sequnce number */, kTypeValue);
-  // Adding the second key will trigger a flush of the last data block (the one containing key1 and value1) by FlushBlockEveryKeyPolicy 
-  // and hence trigger buffering of that data block.
+  // Adding the second key will trigger a flush of the last data block (the one
+  // containing key1 and value1) by FlushBlockEveryKeyPolicy and hence trigger
+  // buffering of that data block.
   builder->Add(ik2.Encode(), value2);
-  // Cache reservation will increase for last buffered data block (the one containing key1 and value1)
-  // since the buffer limit is not exceeded after that buffering and the cache will not be full after this reservation
+  // Cache reservation will increase for last buffered data block (the one
+  // containing key1 and value1) since the buffer limit is not exceeded after
+  // that buffering and the cache will not be full after this reservation
   EXPECT_GE(cache->GetPinnedUsage(), 1 * kSizeDummyEntry);
-  EXPECT_LT(cache->GetPinnedUsage(), 1 * kSizeDummyEntry + kMetaDataChargeOverhead);
-  
+  EXPECT_LT(cache->GetPinnedUsage(),
+            1 * kSizeDummyEntry + kMetaDataChargeOverhead);
+
   ASSERT_OK(builder->Finish());
   EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
 }
 
-TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnBufferLimitExceed){
+TEST_P(
+    BlockBasedTableTest,
+    IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnBufferLimitExceed) {
   constexpr std::size_t kSizeDummyEntry = 256 * 1024;
   constexpr std::size_t kMetaDataChargeOverhead = 10000;
   constexpr std::size_t kCacheCapacity = 8 * 1024 * 1024;
   constexpr std::size_t kMaxDictBytes = 1024;
-  // A small positive kMaxDictBufferBytes leads to a small buffer limit for our testing purpose 
-  // 27 is chosen so that buffering two data blocks, each containing key1, value1 and key2, value2
-  // will exceed buffer limit 
+  // A small positive kMaxDictBufferBytes leads to a small buffer limit for our
+  // testing purpose 27 is chosen so that buffering two data blocks, each
+  // containing key1, value1 and key2, value2 will exceed buffer limit
   constexpr std::size_t kMaxDictBufferBytes = 27;
-  
+
   BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
   LRUCacheOptions lo;
   lo.capacity = kCacheCapacity;
@@ -4827,8 +4834,9 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
   lo.strict_capacity_limit = true;
   std::shared_ptr<Cache> cache(NewLRUCache(lo));
   table_options.block_cache = cache;
-  table_options.flush_block_policy_factory = std::make_shared<FlushBlockEveryKeyPolicyFactory>();
-  
+  table_options.flush_block_policy_factory =
+      std::make_shared<FlushBlockEveryKeyPolicyFactory>();
+
   Options options;
   options.compression = kSnappyCompression;
   options.compression_opts.max_dict_bytes = kMaxDictBytes;
@@ -4852,11 +4860,10 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
                           "test_cf", -1 /* level */),
       file_writer.get()));
 
-  
   std::string key1 = "key1";
   std::string value1 = "val1";
   InternalKey ik1(key1, 0 /* sequnce number */, kTypeValue);
-  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy 
+  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy
   // therefore won't trigger any data block's buffering
   builder->Add(ik1.Encode(), value1);
   ASSERT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
@@ -4864,38 +4871,47 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
   std::string key2 = "key2";
   std::string value2 = "val2";
   InternalKey ik2(key2, 1 /* sequnce number */, kTypeValue);
-  // Adding the second key will trigger a flush of the last data block (the one containing key1 and value1) by FlushBlockEveryKeyPolicy 
-  // and hence trigger buffering of the last data block.
+  // Adding the second key will trigger a flush of the last data block (the one
+  // containing key1 and value1) by FlushBlockEveryKeyPolicy and hence trigger
+  // buffering of the last data block.
   builder->Add(ik2.Encode(), value2);
-  // Cache reservation will increase for last buffered data block (the one containing key1 and value1)
-  // since the buffer limit is not exceeded after the buffering and the cache will not be full after this reservation
+  // Cache reservation will increase for last buffered data block (the one
+  // containing key1 and value1) since the buffer limit is not exceeded after
+  // the buffering and the cache will not be full after this reservation
   EXPECT_GE(cache->GetPinnedUsage(), 1 * kSizeDummyEntry);
-  EXPECT_LT(cache->GetPinnedUsage(), 1 * kSizeDummyEntry + kMetaDataChargeOverhead);
+  EXPECT_LT(cache->GetPinnedUsage(),
+            1 * kSizeDummyEntry + kMetaDataChargeOverhead);
 
   std::string key3 = "key3";
   std::string value3 = "val3";
   InternalKey ik3(key3, 2 /* sequnce number */, kTypeValue);
-  // Adding the third key will trigger a flush of the last data block (the one containing key2 and value2) by FlushBlockEveryKeyPolicy 
-  // and hence trigger buffering of the last data block.
+  // Adding the third key will trigger a flush of the last data block (the one
+  // containing key2 and value2) by FlushBlockEveryKeyPolicy and hence trigger
+  // buffering of the last data block.
   builder->Add(ik3.Encode(), value3);
-  // Cache reservation will decrease since the buffer limit is now exceeded after the last buffering 
-  // and EnterUnbuffered() is triggered
+  // Cache reservation will decrease since the buffer limit is now exceeded
+  // after the last buffering and EnterUnbuffered() is triggered
   EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
 
   ASSERT_OK(builder->Finish());
   EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
 }
 
-TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnCacheFull){
+TEST_P(
+    BlockBasedTableTest,
+    IncreaseCacheReservationForCompressDictBuildingBufferOnBuilderAddAndDecreaseOnCacheFull) {
   constexpr std::size_t kSizeDummyEntry = 256 * 1024;
   constexpr std::size_t kMetaDataChargeOverhead = 10000;
-  // A small kCacheCapacity is chosen so that increase cache reservation for buffering two data blocks, each containing key1, value1 and key2, a big value2
-  // will cause cache full
-  constexpr std::size_t kCacheCapacity = 1 * kSizeDummyEntry + kSizeDummyEntry / 2;
+  // A small kCacheCapacity is chosen so that increase cache reservation for
+  // buffering two data blocks, each containing key1, value1 and key2, a big
+  // value2 will cause cache full
+  constexpr std::size_t kCacheCapacity =
+      1 * kSizeDummyEntry + kSizeDummyEntry / 2;
   constexpr std::size_t kMaxDictBytes = 1024;
-  // A big kMaxDictBufferBytes is chosen so that adding a big key value pair (key2, value2) won't exceed the buffer limit
+  // A big kMaxDictBufferBytes is chosen so that adding a big key value pair
+  // (key2, value2) won't exceed the buffer limit
   constexpr std::size_t kMaxDictBufferBytes = 1024 * 1024 * 1024;
-  
+
   BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
   LRUCacheOptions lo;
   lo.capacity = kCacheCapacity;
@@ -4903,8 +4919,9 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
   lo.strict_capacity_limit = true;
   std::shared_ptr<Cache> cache(NewLRUCache(lo));
   table_options.block_cache = cache;
-  table_options.flush_block_policy_factory = std::make_shared<FlushBlockEveryKeyPolicyFactory>();
-  
+  table_options.flush_block_policy_factory =
+      std::make_shared<FlushBlockEveryKeyPolicyFactory>();
+
   Options options;
   options.compression = kSnappyCompression;
   options.compression_opts.max_dict_bytes = kMaxDictBytes;
@@ -4928,11 +4945,10 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
                           "test_cf", -1 /* level */),
       file_writer.get()));
 
-  
   std::string key1 = "key1";
   std::string value1 = "val1";
   InternalKey ik1(key1, 0 /* sequnce number */, kTypeValue);
-  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy 
+  // Adding the first key won't trigger a flush by FlushBlockEveryKeyPolicy
   // therefore won't trigger any data block's buffering
   builder->Add(ik1.Encode(), value1);
   ASSERT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
@@ -4940,22 +4956,27 @@ TEST_P(BlockBasedTableTest, IncreaseCacheReservationForCompressDictBuildingBuffe
   std::string key2 = "key2";
   std::string value2(kSizeDummyEntry, '0');
   InternalKey ik2(key2, 1 /* sequnce number */, kTypeValue);
-  // Adding the second key will trigger a flush of the last data block (the one containing key1 and value1) by FlushBlockEveryKeyPolicy 
-  // and hence trigger buffering of the last data block.
+  // Adding the second key will trigger a flush of the last data block (the one
+  // containing key1 and value1) by FlushBlockEveryKeyPolicy and hence trigger
+  // buffering of the last data block.
   builder->Add(ik2.Encode(), value2);
-  // Cache reservation will increase for the last buffered data block (the one containing key1 and value1)
-  // since the buffer limit is not exceeded after the buffering and the cache will not be full after this reservation
+  // Cache reservation will increase for the last buffered data block (the one
+  // containing key1 and value1) since the buffer limit is not exceeded after
+  // the buffering and the cache will not be full after this reservation
   EXPECT_GE(cache->GetPinnedUsage(), 1 * kSizeDummyEntry);
-  EXPECT_LT(cache->GetPinnedUsage(), 1 * kSizeDummyEntry + kMetaDataChargeOverhead);
+  EXPECT_LT(cache->GetPinnedUsage(),
+            1 * kSizeDummyEntry + kMetaDataChargeOverhead);
 
   std::string key3 = "key3";
   std::string value3 = "value3";
   InternalKey ik3(key3, 2 /* sequnce number */, kTypeValue);
-  // Adding the third key will trigger a flush of the last data block (the one containing key2 and value2) by FlushBlockEveryKeyPolicy 
-  // and hence trigger buffering of the last data block.
+  // Adding the third key will trigger a flush of the last data block (the one
+  // containing key2 and value2) by FlushBlockEveryKeyPolicy and hence trigger
+  // buffering of the last data block.
   builder->Add(ik3.Encode(), value3);
-  // Cache reservation will decrease since the cache is now full after increasing reservation for the last buffered block
-  // and EnterUnbuffered() is triggered
+  // Cache reservation will decrease since the cache is now full after
+  // increasing reservation for the last buffered block and EnterUnbuffered() is
+  // triggered
   EXPECT_EQ(cache->GetPinnedUsage(), 0 * kSizeDummyEntry);
 
   ASSERT_OK(builder->Finish());

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4823,7 +4823,7 @@ TEST_P(
   constexpr std::size_t kCacheCapacity = 8 * 1024 * 1024;
   constexpr std::size_t kMaxDictBytes = 1024;
   // A small positive kMaxDictBufferBytes leads to a small buffer limit for our
-  // testing purpose 27 is chosen so that buffering two data blocks, each
+  // testing purpose. 27 is chosen so that buffering two data blocks, each
   // containing key1, value1 and key2, value2 will exceed buffer limit
   constexpr std::size_t kMaxDictBufferBytes = 27;
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4824,7 +4824,7 @@ TEST_P(
   constexpr std::size_t kMaxDictBytes = 1024;
   // A small positive kMaxDictBufferBytes leads to a small buffer limit for our
   // testing purpose. 27 is chosen so that buffering two data blocks, each
-  // containing key1, value1 and key2, value2 will exceed buffer limit
+  // containing key1/value1, key2/value2, will exceed buffer limit
   constexpr std::size_t kMaxDictBufferBytes = 27;
 
   BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
@@ -4903,8 +4903,8 @@ TEST_P(
   constexpr std::size_t kSizeDummyEntry = 256 * 1024;
   constexpr std::size_t kMetaDataChargeOverhead = 10000;
   // A small kCacheCapacity is chosen so that increase cache reservation for
-  // buffering two data blocks, each containing key1, value1 and key2, a big
-  // value2 will cause cache full
+  // buffering two data blocks, each containing key1/value1, key2/a big
+  // value2, will cause cache full
   constexpr std::size_t kCacheCapacity =
       1 * kSizeDummyEntry + kSizeDummyEntry / 2;
   constexpr std::size_t kMaxDictBytes = 1024;


### PR DESCRIPTION
Context:
Some data blocks are temporarily buffered in memory in BlockBasedTableBuilder for building compression dictionary used in data block compression. Currently this memory usage is not counted toward our global memory usage utilizing block cache capacity. To improve that, this PR charges that memory usage into the block cache to achieve better memory tracking and limiting.

Summary: 
- Reserve memory in block cache for buffered data blocks that are used to build a compression dictionary
- Release all the memory associated with buffering the data blocks mentioned above in EnterUnbuffered(), which is called when (a) buffer limit is exceeded after buffering OR (b) the block cache becomes full after reservation OR (c) BlockBasedTableBuilder calls Finish()

Test Plan:
- Passing existing unit tests
- Passing new unit tests

