### PR TITLE
Skip c_test and env_test when ASSERT_STATUS_CHECKED=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,8 +516,10 @@ endif
 ifdef ASSERT_STATUS_CHECKED
 	# TODO: finish fixing all tests to pass this check
 	TESTS_FAILING_ASC = \
+		c_test \
 		db_test \
 		db_test2 \
+		env_test \
 		range_locking_test \
 		testutil_test \
 


### PR DESCRIPTION
- `c_test` fails because `rocksdb_compact_range()` swallows a `Status`.
- `env_test` fails because `ReadRequest`s to `MultiRead()` do not have their `Status`es checked.

Test Plan: `ASSERT_STATUS_CHECKED=1 make -j48 check`