### PR TITLE
Fix the potential Segment Fault in RecoverFromBGError when db_ is nullptr

### DIFF
--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -605,7 +605,12 @@ Status ErrorHandler::RecoverFromBGError(bool is_manual) {
   // can generate background errors should be the flush operations
   recovery_error_ = Status::OK();
   recovery_error_.PermitUncheckedError();
-  Status s = db_->ResumeImpl(recover_context_);
+  Status s;
+  if (db_) {
+    s = db_->ResumeImpl(recover_context_);
+  } else {
+    return bg_error_;
+  }
   if (s.ok()) {
     soft_error_no_bg_work_ = false;
   } else {


### PR DESCRIPTION
RecoverFromBGError can be called by a separate thread (e.g., the rocksdb::SstFileManagerImpl::ClearError()). It is possible that application has already taken the action to close the db or restart the db. Therefore, when the recover thread calls RecoverFromBGError, db_ pointer can be nullptr in some cases and causes segment fault. Fix it by checking the db_ pointer. If it is nullptr, directly returns the bg_error_

test plan: make check