### PR TITLE
Fix double slashes in user-provided db path.

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -3351,7 +3351,18 @@ void DBFileDumperCommand::DoCommand() {
   }
   // remove the trailing '\n'
   manifest_filename.resize(manifest_filename.size() - 1);
-  std::string manifest_filepath = db_->GetName() + "/" + manifest_filename;
+  std::string manifest_filepath = db_->GetName();
+  // Correct concatenation of filepath and filename:
+  // Add slash '/' in between if necessary, or check that
+  // there is no double slashes when concatenation happens.
+  if (manifest_filepath.size() > 0 && manifest_filepath.back() != '/' &&
+      manifest_filename.front() != '/') {
+    manifest_filepath += "/";
+  } else if (manifest_filepath.size() > 0 && manifest_filepath.back() == '/' &&
+             manifest_filename.front() == '/') {
+    manifest_filepath.pop_back();
+  }
+  manifest_filepath += manifest_filename;
   std::cout << manifest_filepath << std::endl;
   DumpManifestFile(options_, manifest_filepath, false, false, false);
   std::cout << std::endl;
@@ -3361,7 +3372,15 @@ void DBFileDumperCommand::DoCommand() {
   std::vector<LiveFileMetaData> metadata;
   db_->GetLiveFilesMetaData(&metadata);
   for (auto& fileMetadata : metadata) {
-    std::string filename = fileMetadata.db_path + fileMetadata.name;
+    std::string filename = fileMetadata.db_path;
+    if (filename.size() > 0 && filename.back() != '/' &&
+        fileMetadata.name.front() != '/') {
+      filename += "/";
+    } else if (filename.size() > 0 && filename.back() == '/' &&
+               fileMetadata.name.front() == '/') {
+      filename.pop_back();
+    }
+    filename += fileMetadata.name;
     std::cout << filename << " level:" << fileMetadata.level << std::endl;
     std::cout << "------------------------------" << std::endl;
     DumpSstFile(options_, filename, false, true);

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -3351,18 +3351,12 @@ void DBFileDumperCommand::DoCommand() {
   }
   // remove the trailing '\n'
   manifest_filename.resize(manifest_filename.size() - 1);
-  std::string manifest_filepath = db_->GetName();
+  std::string manifest_filepath = db_->GetName() + "/" + manifest_filename;
   // Correct concatenation of filepath and filename:
-  // Add slash '/' in between if necessary, or check that
-  // there is no double slashes when concatenation happens.
-  if (manifest_filepath.size() > 0 && manifest_filepath.back() != '/' &&
-      manifest_filename.front() != '/') {
-    manifest_filepath += "/";
-  } else if (manifest_filepath.size() > 0 && manifest_filepath.back() == '/' &&
-             manifest_filename.front() == '/') {
-    manifest_filepath.pop_back();
-  }
-  manifest_filepath += manifest_filename;
+  // Check that there is no double slashes (or more!) when concatenation
+  // happens.
+  manifest_filepath = NormalizePath(manifest_filepath);
+
   std::cout << manifest_filepath << std::endl;
   DumpManifestFile(options_, manifest_filepath, false, false, false);
   std::cout << std::endl;
@@ -3372,15 +3366,11 @@ void DBFileDumperCommand::DoCommand() {
   std::vector<LiveFileMetaData> metadata;
   db_->GetLiveFilesMetaData(&metadata);
   for (auto& fileMetadata : metadata) {
-    std::string filename = fileMetadata.db_path;
-    if (filename.size() > 0 && filename.back() != '/' &&
-        fileMetadata.name.front() != '/') {
-      filename += "/";
-    } else if (filename.size() > 0 && filename.back() == '/' &&
-               fileMetadata.name.front() == '/') {
-      filename.pop_back();
-    }
-    filename += fileMetadata.name;
+    std::string filename = fileMetadata.db_path + "/" + fileMetadata.name;
+    // Correct concatenation of filepath and filename:
+    // Check that there is no double slashes (or more!) when concatenation
+    // happens.
+    filename = NormalizePath(filename);
     std::cout << filename << " level:" << fileMetadata.level << std::endl;
     std::cout << "------------------------------" << std::endl;
     DumpSstFile(options_, filename, false, true);


### PR DESCRIPTION
At the moment, the following command : "`./ --db=mypath/ dump_file_files`" returns a series of erronous names with double slashes, ie: "`mypath//000xxx.sst`", including manifest file names with double slashes "`mypath//MANIFEST-00XXX`", whereas "`./ --db=mypath dump_file_files`" correctly returns "`mypath/000xxx.sst`" and "`mypath/MANIFEST-00XXX`".

This (very short) PR simply checks if there is a need to add or remove any '`/`' character when the `db_path` and `manifest_filename`/sst `filenames` are concatenated.