### PR TITLE
Add an internal iterator that can measure the inflow of blobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1124,6 +1124,7 @@ if(WITH_TESTS)
     list(APPEND TESTS
         cache/cache_test.cc
         cache/lru_cache_test.cc
+        db/blob/blob_counting_iterator_test.cc
         db/blob/blob_file_addition_test.cc
         db/blob/blob_file_builder_test.cc
         db/blob/blob_file_cache_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1827,6 +1827,9 @@ block_cache_trace_analyzer_test: $(OBJ_DIR)/tools/block_cache_analyzer/block_cac
 defer_test: $(OBJ_DIR)/util/defer_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+blob_counting_iterator_test: $(OBJ_DIR)/db/blob/blob_counting_iterator_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 blob_file_addition_test: $(OBJ_DIR)/db/blob/blob_file_addition_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/TARGETS
+++ b/TARGETS
@@ -909,6 +909,13 @@ ROCKS_TESTS = [
         [],
     ],
     [
+        "blob_counting_iterator_test",
+        "db/blob/blob_counting_iterator_test.cc",
+        "parallel",
+        [],
+        [],
+    ],
+    [
         "blob_db_test",
         "utilities/blob_db/blob_db_test.cc",
         "parallel",

--- a/db/blob/blob_counting_iterator.h
+++ b/db/blob/blob_counting_iterator.h
@@ -1,0 +1,129 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cassert>
+
+#include "table/internal_iterator.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class BlobCountingIterator : public InternalIterator {
+ public:
+  explicit BlobCountingIterator(InternalIterator* iter) : iter_(iter) {
+    assert(iter_);
+  }
+
+  bool Valid() const override {
+    assert(iter_);
+    return iter_->Valid();
+  }
+
+  void SeekToFirst() override {
+    assert(iter_);
+    iter_->SeekToFirst();
+    CountBlobIfNeeded();
+  }
+
+  void SeekToLast() override {
+    assert(iter_);
+    iter_->SeekToLast();
+    CountBlobIfNeeded();
+  }
+
+  void Seek(const Slice& target) override {
+    assert(iter_);
+    iter_->Seek(target);
+    CountBlobIfNeeded();
+  }
+
+  void SeekForPrev(const Slice& target) override {
+    assert(iter_);
+    iter_->SeekForPrev(target);
+    CountBlobIfNeeded();
+  }
+
+  void Next() override {
+    assert(iter_);
+    iter_->Next();
+    CountBlobIfNeeded();
+  }
+
+  bool NextAndGetResult(IterateResult* result) override {
+    assert(iter_);
+    const bool res = iter_->NextAndGetResult(result);
+    CountBlobIfNeeded();
+    return res;
+  }
+
+  void Prev() override {
+    assert(iter_);
+    iter_->Prev();
+    CountBlobIfNeeded();
+  }
+
+  Slice key() const override {
+    assert(iter_);
+    return iter_->key();
+  }
+
+  Slice user_key() const override {
+    assert(iter_);
+    return iter_->user_key();
+  }
+
+  Slice value() const override {
+    assert(iter_);
+    return iter_->value();
+  }
+
+  Status status() const override {
+    assert(iter_);
+    return iter_->status();
+  }
+
+  bool PrepareValue() override {
+    assert(iter_);
+    return iter_->PrepareValue();
+  }
+
+  bool MayBeOutOfLowerBound() override {
+    assert(iter_);
+    return iter_->MayBeOutOfLowerBound();
+  }
+
+  IterBoundCheck UpperBoundCheckResult() override {
+    assert(iter_);
+    return iter_->UpperBoundCheckResult();
+  }
+
+  void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override {
+    assert(iter_);
+    iter_->SetPinnedItersMgr(pinned_iters_mgr);
+  }
+
+  bool IsKeyPinned() const override {
+    assert(iter_);
+    return iter_->IsKeyPinned();
+  }
+
+  bool IsValuePinned() const override {
+    assert(iter_);
+    return iter_->IsValuePinned();
+  }
+
+  Status GetProperty(std::string prop_name, std::string* prop) override {
+    assert(iter_);
+    return iter_->GetProperty(prop_name, prop);
+  }
+
+ private:
+  void CountBlobIfNeeded() {}
+
+  InternalIterator* iter_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_counting_iterator.h
+++ b/db/blob/blob_counting_iterator.h
@@ -23,13 +23,7 @@ class BlobCountingIterator : public InternalIterator {
     UpdateAndCountBlobIfNeeded();
   }
 
-  bool Valid() const override {
-    if (!status_.ok()) {
-      return false;
-    }
-
-    return iter_->Valid();
-  }
+  bool Valid() const override { return iter_->Valid() && status_.ok(); }
 
   void SeekToFirst() override {
     iter_->SeekToFirst();

--- a/db/blob/blob_counting_iterator.h
+++ b/db/blob/blob_counting_iterator.h
@@ -14,6 +14,9 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+// An internal iterator that passes each key-value encountered to
+// BlobGarbageMeter as inflow in order to measure the total number and size of
+// blobs in the compaction input on a per-blob file basis.
 class BlobCountingIterator : public InternalIterator {
  public:
   BlobCountingIterator(InternalIterator* iter,

--- a/db/blob/blob_counting_iterator.h
+++ b/db/blob/blob_counting_iterator.h
@@ -125,9 +125,9 @@ class BlobCountingIterator : public InternalIterator {
 
  private:
   void UpdateAndCountBlobIfNeeded() {
-    assert(!Valid() || iter_->status().ok());
+    assert(!iter_->Valid() || iter_->status().ok());
 
-    if (!Valid()) {
+    if (!iter_->Valid()) {
       status_ = iter_->status();
       return;
     }

--- a/db/blob/blob_counting_iterator.h
+++ b/db/blob/blob_counting_iterator.h
@@ -8,6 +8,8 @@
 #include <cassert>
 
 #include "db/blob/blob_garbage_meter.h"
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/status.h"
 #include "table/internal_iterator.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/blob/blob_counting_iterator_test.cc
+++ b/db/blob/blob_counting_iterator_test.cc
@@ -35,6 +35,8 @@ void CheckInFlow(const BlobGarbageMeter& blob_garbage_meter,
 }
 
 TEST(BlobCountingIteratorTest, CountBlobs) {
+  // Note: the input consists of three key-values: two are blob references to
+  // different blob files, while the third one is a plain value.
   constexpr char user_key0[] = "key0";
   constexpr char user_key1[] = "key1";
   constexpr char user_key2[] = "key2";

--- a/db/blob/blob_counting_iterator_test.cc
+++ b/db/blob/blob_counting_iterator_test.cc
@@ -22,7 +22,11 @@ void CheckInFlow(const BlobGarbageMeter& blob_garbage_meter,
   const auto& flows = blob_garbage_meter.flows();
 
   const auto it = flows.find(blob_file_number);
-  ASSERT_NE(it, flows.end());
+  if (it == flows.end()) {
+    ASSERT_EQ(count, 0);
+    ASSERT_EQ(bytes, 0);
+    return;
+  }
 
   const auto& in = it->second.GetInFlow();
 
@@ -82,6 +86,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   ASSERT_EQ(blob_counter.value(), values[0]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
               first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 0, 0);
 
   blob_counter.Next();
   ASSERT_TRUE(blob_counter.Valid());

--- a/db/blob/blob_counting_iterator_test.cc
+++ b/db/blob/blob_counting_iterator_test.cc
@@ -77,6 +77,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.SeekToFirst();
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
               first_expected_bytes);
@@ -84,6 +85,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.Next();
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[1]);
+  ASSERT_EQ(blob_counter.user_key(), user_key1);
   ASSERT_EQ(blob_counter.value(), values[1]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
               first_expected_bytes);
@@ -93,6 +95,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.Next();
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[2]);
+  ASSERT_EQ(blob_counter.user_key(), user_key2);
   ASSERT_EQ(blob_counter.value(), values[2]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
               first_expected_bytes);
@@ -110,6 +113,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.SeekToFirst();
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
               2 * first_expected_bytes);
@@ -120,6 +124,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
     IterateResult result;
     ASSERT_TRUE(blob_counter.NextAndGetResult(&result));
     ASSERT_EQ(result.key, keys[1]);
+    ASSERT_EQ(blob_counter.user_key(), user_key1);
     ASSERT_TRUE(blob_counter.Valid());
     ASSERT_EQ(blob_counter.key(), keys[1]);
     ASSERT_EQ(blob_counter.value(), values[1]);
@@ -133,6 +138,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
     IterateResult result;
     ASSERT_TRUE(blob_counter.NextAndGetResult(&result));
     ASSERT_EQ(result.key, keys[2]);
+    ASSERT_EQ(blob_counter.user_key(), user_key2);
     ASSERT_TRUE(blob_counter.Valid());
     ASSERT_EQ(blob_counter.key(), keys[2]);
     ASSERT_EQ(blob_counter.value(), values[2]);
@@ -156,6 +162,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.SeekToLast();
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[2]);
+  ASSERT_EQ(blob_counter.user_key(), user_key2);
   ASSERT_EQ(blob_counter.value(), values[2]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
               2 * first_expected_bytes);
@@ -165,6 +172,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.Prev();
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[1]);
+  ASSERT_EQ(blob_counter.user_key(), user_key1);
   ASSERT_EQ(blob_counter.value(), values[1]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
               2 * first_expected_bytes);
@@ -174,6 +182,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.Prev();
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 3,
               3 * first_expected_bytes);
@@ -191,6 +200,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.Seek(keys[0]);
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
               4 * first_expected_bytes);
@@ -200,6 +210,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.Seek(keys[1]);
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[1]);
+  ASSERT_EQ(blob_counter.user_key(), user_key1);
   ASSERT_EQ(blob_counter.value(), values[1]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
               4 * first_expected_bytes);
@@ -209,6 +220,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.Seek(keys[2]);
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[2]);
+  ASSERT_EQ(blob_counter.user_key(), user_key2);
   ASSERT_EQ(blob_counter.value(), values[2]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
               4 * first_expected_bytes);
@@ -233,6 +245,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.SeekForPrev(keys[0]);
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 5,
               5 * first_expected_bytes);
@@ -242,6 +255,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.SeekForPrev(keys[1]);
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[1]);
+  ASSERT_EQ(blob_counter.user_key(), user_key1);
   ASSERT_EQ(blob_counter.value(), values[1]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 5,
               5 * first_expected_bytes);
@@ -251,6 +265,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   blob_counter.SeekForPrev(keys[2]);
   ASSERT_TRUE(blob_counter.Valid());
   ASSERT_EQ(blob_counter.key(), keys[2]);
+  ASSERT_EQ(blob_counter.user_key(), user_key2);
   ASSERT_EQ(blob_counter.value(), values[2]);
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 5,
               5 * first_expected_bytes);

--- a/db/blob/blob_counting_iterator_test.cc
+++ b/db/blob/blob_counting_iterator_test.cc
@@ -293,6 +293,23 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
               5 * second_expected_bytes);
 }
 
+TEST(BlobCountingIteratorTest, CorruptBlobIndex) {
+  const std::vector<std::string> keys{
+      test::KeyStr("user_key", 1, kTypeBlobIndex)};
+  const std::vector<std::string> values{"i_am_not_a_blob_index"};
+
+  assert(keys.size() == values.size());
+
+  test::VectorIterator input(keys, values);
+  BlobGarbageMeter blob_garbage_meter;
+
+  BlobCountingIterator blob_counter(&input, &blob_garbage_meter);
+
+  blob_counter.SeekToFirst();
+  ASSERT_FALSE(blob_counter.Valid());
+  ASSERT_NOK(blob_counter.status());
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/blob/blob_counting_iterator_test.cc
+++ b/db/blob/blob_counting_iterator_test.cc
@@ -1,0 +1,186 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob/blob_counting_iterator.h"
+
+#include <string>
+#include <vector>
+
+#include "db/blob/blob_garbage_meter.h"
+#include "db/blob/blob_index.h"
+#include "db/blob/blob_log_format.h"
+#include "db/dbformat.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+void CheckInFlow(const BlobGarbageMeter& blob_garbage_meter,
+                 uint64_t blob_file_number, uint64_t count, uint64_t bytes) {
+  const auto& flows = blob_garbage_meter.flows();
+
+  const auto it = flows.find(blob_file_number);
+  ASSERT_NE(it, flows.end());
+
+  const auto& in = it->second.GetInFlow();
+
+  ASSERT_EQ(in.GetCount(), count);
+  ASSERT_EQ(in.GetBytes(), bytes);
+}
+
+TEST(BlobCountingIteratorTest, CountBlobs) {
+  constexpr char user_key0[] = "key0";
+  constexpr char user_key1[] = "key1";
+  constexpr char user_key2[] = "key2";
+
+  const std::vector<std::string> keys{
+      test::KeyStr(user_key0, 1, kTypeBlobIndex),
+      test::KeyStr(user_key1, 2, kTypeBlobIndex),
+      test::KeyStr(user_key2, 3, kTypeValue)};
+
+  constexpr uint64_t first_blob_file_number = 4;
+  constexpr uint64_t first_offset = 1000;
+  constexpr uint64_t first_size = 2000;
+
+  std::string first_blob_index;
+  BlobIndex::EncodeBlob(&first_blob_index, first_blob_file_number, first_offset,
+                        first_size, kNoCompression);
+
+  constexpr uint64_t second_blob_file_number = 6;
+  constexpr uint64_t second_offset = 2000;
+  constexpr uint64_t second_size = 4000;
+
+  std::string second_blob_index;
+  BlobIndex::EncodeBlob(&second_blob_index, second_blob_file_number,
+                        second_offset, second_size, kNoCompression);
+
+  const std::vector<std::string> values{first_blob_index, second_blob_index,
+                                        "raw_value"};
+
+  assert(keys.size() == values.size());
+
+  test::VectorIterator input(keys, values);
+  BlobGarbageMeter blob_garbage_meter;
+
+  BlobCountingIterator blob_counter(&input, &blob_garbage_meter);
+
+  constexpr uint64_t first_expected_bytes =
+      first_size +
+      BlobLogRecord::CalculateAdjustmentForRecordHeader(sizeof(user_key0) - 1);
+  constexpr uint64_t second_expected_bytes =
+      second_size +
+      BlobLogRecord::CalculateAdjustmentForRecordHeader(sizeof(user_key1) - 1);
+
+  // Call SeekToFirst and iterate forward
+  blob_counter.SeekToFirst();
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.value(), values[0]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
+              first_expected_bytes);
+
+  blob_counter.Next();
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[1]);
+  ASSERT_EQ(blob_counter.value(), values[1]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
+              first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 1,
+              second_expected_bytes);
+
+  blob_counter.Next();
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[2]);
+  ASSERT_EQ(blob_counter.value(), values[2]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
+              first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 1,
+              second_expected_bytes);
+
+  blob_counter.Next();
+  ASSERT_FALSE(blob_counter.Valid());
+
+  // Do it again using NextAndGetResult
+  blob_counter.SeekToFirst();
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.value(), values[0]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
+              2 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 1,
+              second_expected_bytes);
+
+  {
+    IterateResult result;
+    ASSERT_TRUE(blob_counter.NextAndGetResult(&result));
+    ASSERT_EQ(result.key, keys[1]);
+    ASSERT_TRUE(blob_counter.Valid());
+    ASSERT_EQ(blob_counter.key(), keys[1]);
+    ASSERT_EQ(blob_counter.value(), values[1]);
+    CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
+                2 * first_expected_bytes);
+    CheckInFlow(blob_garbage_meter, second_blob_file_number, 2,
+                2 * second_expected_bytes);
+  }
+
+  {
+    IterateResult result;
+    ASSERT_TRUE(blob_counter.NextAndGetResult(&result));
+    ASSERT_EQ(result.key, keys[2]);
+    ASSERT_TRUE(blob_counter.Valid());
+    ASSERT_EQ(blob_counter.key(), keys[2]);
+    ASSERT_EQ(blob_counter.value(), values[2]);
+    CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
+                2 * first_expected_bytes);
+    CheckInFlow(blob_garbage_meter, second_blob_file_number, 2,
+                2 * second_expected_bytes);
+  }
+
+  {
+    IterateResult result;
+    ASSERT_FALSE(blob_counter.NextAndGetResult(&result));
+    ASSERT_FALSE(blob_counter.Valid());
+  }
+
+  // Call SeekToLast and iterate backward
+  blob_counter.SeekToLast();
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[2]);
+  ASSERT_EQ(blob_counter.value(), values[2]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
+              2 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 2,
+              2 * second_expected_bytes);
+
+  blob_counter.Prev();
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[1]);
+  ASSERT_EQ(blob_counter.value(), values[1]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
+              2 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 3,
+              3 * second_expected_bytes);
+
+  blob_counter.Prev();
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.value(), values[0]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 3,
+              3 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 3,
+              3 * second_expected_bytes);
+
+  blob_counter.Prev();
+  ASSERT_FALSE(blob_counter.Valid());
+
+  // Call Seek/SeekForPrev for all keys
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/blob/blob_counting_iterator_test.cc
+++ b/db/blob/blob_counting_iterator_test.cc
@@ -101,6 +101,10 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Next();
   ASSERT_FALSE(blob_counter.Valid());
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
+              first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 1,
+              second_expected_bytes);
 
   // Do it again using NextAndGetResult
   blob_counter.SeekToFirst();
@@ -142,6 +146,10 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
     IterateResult result;
     ASSERT_FALSE(blob_counter.NextAndGetResult(&result));
     ASSERT_FALSE(blob_counter.Valid());
+    CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
+                2 * first_expected_bytes);
+    CheckInFlow(blob_garbage_meter, second_blob_file_number, 2,
+                2 * second_expected_bytes);
   }
 
   // Call SeekToLast and iterate backward
@@ -174,8 +182,80 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Prev();
   ASSERT_FALSE(blob_counter.Valid());
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 3,
+              3 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 3,
+              3 * second_expected_bytes);
 
-  // Call Seek/SeekForPrev for all keys
+  // Call Seek for all keys (plus one that's greater than all of them)
+  blob_counter.Seek(keys[0]);
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.value(), values[0]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
+              4 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 3,
+              3 * second_expected_bytes);
+
+  blob_counter.Seek(keys[1]);
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[1]);
+  ASSERT_EQ(blob_counter.value(), values[1]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
+              4 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 4,
+              4 * second_expected_bytes);
+
+  blob_counter.Seek(keys[2]);
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[2]);
+  ASSERT_EQ(blob_counter.value(), values[2]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
+              4 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 4,
+              4 * second_expected_bytes);
+
+  blob_counter.Seek("zzz");
+  ASSERT_FALSE(blob_counter.Valid());
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
+              4 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 4,
+              4 * second_expected_bytes);
+
+  // Call SeekForPrev for all keys (plus one that's less than all of them)
+  blob_counter.SeekForPrev("aaa");
+  ASSERT_FALSE(blob_counter.Valid());
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
+              4 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 4,
+              4 * second_expected_bytes);
+
+  blob_counter.SeekForPrev(keys[0]);
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[0]);
+  ASSERT_EQ(blob_counter.value(), values[0]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 5,
+              5 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 4,
+              4 * second_expected_bytes);
+
+  blob_counter.SeekForPrev(keys[1]);
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[1]);
+  ASSERT_EQ(blob_counter.value(), values[1]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 5,
+              5 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 5,
+              5 * second_expected_bytes);
+
+  blob_counter.SeekForPrev(keys[2]);
+  ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_EQ(blob_counter.key(), keys[2]);
+  ASSERT_EQ(blob_counter.value(), values[2]);
+  CheckInFlow(blob_garbage_meter, first_blob_file_number, 5,
+              5 * first_expected_bytes);
+  CheckInFlow(blob_garbage_meter, second_blob_file_number, 5,
+              5 * second_expected_bytes);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_counting_iterator_test.cc
+++ b/db/blob/blob_counting_iterator_test.cc
@@ -76,6 +76,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   // Call SeekToFirst and iterate forward
   blob_counter.SeekToFirst();
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[0]);
   ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
@@ -84,6 +85,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Next();
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[1]);
   ASSERT_EQ(blob_counter.user_key(), user_key1);
   ASSERT_EQ(blob_counter.value(), values[1]);
@@ -94,6 +96,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Next();
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[2]);
   ASSERT_EQ(blob_counter.user_key(), user_key2);
   ASSERT_EQ(blob_counter.value(), values[2]);
@@ -104,6 +107,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Next();
   ASSERT_FALSE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 1,
               first_expected_bytes);
   CheckInFlow(blob_garbage_meter, second_blob_file_number, 1,
@@ -112,6 +116,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   // Do it again using NextAndGetResult
   blob_counter.SeekToFirst();
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[0]);
   ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
@@ -126,6 +131,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
     ASSERT_EQ(result.key, keys[1]);
     ASSERT_EQ(blob_counter.user_key(), user_key1);
     ASSERT_TRUE(blob_counter.Valid());
+    ASSERT_OK(blob_counter.status());
     ASSERT_EQ(blob_counter.key(), keys[1]);
     ASSERT_EQ(blob_counter.value(), values[1]);
     CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
@@ -140,6 +146,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
     ASSERT_EQ(result.key, keys[2]);
     ASSERT_EQ(blob_counter.user_key(), user_key2);
     ASSERT_TRUE(blob_counter.Valid());
+    ASSERT_OK(blob_counter.status());
     ASSERT_EQ(blob_counter.key(), keys[2]);
     ASSERT_EQ(blob_counter.value(), values[2]);
     CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
@@ -152,6 +159,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
     IterateResult result;
     ASSERT_FALSE(blob_counter.NextAndGetResult(&result));
     ASSERT_FALSE(blob_counter.Valid());
+    ASSERT_OK(blob_counter.status());
     CheckInFlow(blob_garbage_meter, first_blob_file_number, 2,
                 2 * first_expected_bytes);
     CheckInFlow(blob_garbage_meter, second_blob_file_number, 2,
@@ -161,6 +169,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   // Call SeekToLast and iterate backward
   blob_counter.SeekToLast();
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[2]);
   ASSERT_EQ(blob_counter.user_key(), user_key2);
   ASSERT_EQ(blob_counter.value(), values[2]);
@@ -171,6 +180,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Prev();
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[1]);
   ASSERT_EQ(blob_counter.user_key(), user_key1);
   ASSERT_EQ(blob_counter.value(), values[1]);
@@ -181,6 +191,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Prev();
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[0]);
   ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
@@ -191,6 +202,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Prev();
   ASSERT_FALSE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 3,
               3 * first_expected_bytes);
   CheckInFlow(blob_garbage_meter, second_blob_file_number, 3,
@@ -199,6 +211,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   // Call Seek for all keys (plus one that's greater than all of them)
   blob_counter.Seek(keys[0]);
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[0]);
   ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
@@ -209,6 +222,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Seek(keys[1]);
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[1]);
   ASSERT_EQ(blob_counter.user_key(), user_key1);
   ASSERT_EQ(blob_counter.value(), values[1]);
@@ -219,6 +233,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Seek(keys[2]);
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[2]);
   ASSERT_EQ(blob_counter.user_key(), user_key2);
   ASSERT_EQ(blob_counter.value(), values[2]);
@@ -229,6 +244,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.Seek("zzz");
   ASSERT_FALSE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
               4 * first_expected_bytes);
   CheckInFlow(blob_garbage_meter, second_blob_file_number, 4,
@@ -237,6 +253,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
   // Call SeekForPrev for all keys (plus one that's less than all of them)
   blob_counter.SeekForPrev("aaa");
   ASSERT_FALSE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   CheckInFlow(blob_garbage_meter, first_blob_file_number, 4,
               4 * first_expected_bytes);
   CheckInFlow(blob_garbage_meter, second_blob_file_number, 4,
@@ -244,6 +261,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.SeekForPrev(keys[0]);
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[0]);
   ASSERT_EQ(blob_counter.user_key(), user_key0);
   ASSERT_EQ(blob_counter.value(), values[0]);
@@ -254,6 +272,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.SeekForPrev(keys[1]);
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[1]);
   ASSERT_EQ(blob_counter.user_key(), user_key1);
   ASSERT_EQ(blob_counter.value(), values[1]);
@@ -264,6 +283,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
   blob_counter.SeekForPrev(keys[2]);
   ASSERT_TRUE(blob_counter.Valid());
+  ASSERT_OK(blob_counter.status());
   ASSERT_EQ(blob_counter.key(), keys[2]);
   ASSERT_EQ(blob_counter.user_key(), user_key2);
   ASSERT_EQ(blob_counter.value(), values[2]);

--- a/src.mk
+++ b/src.mk
@@ -379,6 +379,7 @@ BENCH_MAIN_SOURCES =                                                    \
 TEST_MAIN_SOURCES =                                                     \
   cache/cache_test.cc                                                   \
   cache/lru_cache_test.cc                                               \
+  db/blob/blob_counting_iterator_test.cc                                \
   db/blob/blob_file_addition_test.cc                                    \
   db/blob/blob_file_builder_test.cc                                     \
   db/blob/blob_file_cache_test.cc                                       \


### PR DESCRIPTION
Summary:
Follow-up to #8426 .

The patch adds a new kind of `InternalIterator` that wraps another one and
passes each key-value encountered to `BlobGarbageMeter` as inflow.
This iterator will be used as an input iterator for compactions when the input
SSTs reference blob files.

Test Plan:
`make check`