### PR TITLE
Deflake BlobDBTest.SnapshotAndGarbageCollection

### DIFF
--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -871,10 +871,13 @@ TEST_F(BlobDBTest, SnapshotAndGarbageCollection) {
   bdb_options.garbage_collection_cutoff = 1.0;
   bdb_options.disable_background_tasks = true;
 
+  Options options;
+  options.disable_auto_compactions = true;
+
   // i = when to take snapshot
   for (int i = 0; i < 4; i++) {
     Destroy();
-    Open(bdb_options);
+    Open(bdb_options, options);
 
     const Snapshot *snapshot = nullptr;
 


### PR DESCRIPTION
Summary:
This test case has been failing occasionally due to automatic
compactions kicking in, resulting in GC generating additional
blob files that the test did not expect. Disabling automatic
compactions to get rid of this flakiness.

Test Plan:
`gtest-parallel --repeat=1000 ./blob_db_test --gtest_filter="BlobDBTest.SnapshotAndGarbageCollection"`