### PR TITLE
Log the amount of blob garbage generated by compactions in the MANIFEST

### DIFF
--- a/db/blob/blob_counting_iterator.h
+++ b/db/blob/blob_counting_iterator.h
@@ -11,6 +11,7 @@
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/status.h"
 #include "table/internal_iterator.h"
+#include "test_util/sync_point.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -130,6 +131,9 @@ class BlobCountingIterator : public InternalIterator {
       status_ = iter_->status();
       return;
     }
+
+    TEST_SYNC_POINT(
+        "BlobCountingIterator::UpdateAndCountBlobIfNeeded:ProcessInFlow");
 
     status_ = blob_garbage_meter_->ProcessInFlow(key(), value());
   }

--- a/db/blob/db_blob_compaction_test.cc
+++ b/db/blob/db_blob_compaction_test.cc
@@ -4,6 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include "db/blob/blob_index.h"
+#include "db/blob/blob_log_format.h"
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "test_util/sync_point.h"
@@ -457,6 +458,112 @@ TEST_F(DBBlobCompactionTest, CompactionFilterReadBlobAndKeep) {
 #endif  // ROCKSDB_LITE
 
   Close();
+}
+
+TEST_F(DBBlobCompactionTest, TrackGarbage) {
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+
+  Reopen(options);
+
+  // First table+blob file pair: 4 blobs with different keys
+  constexpr char first_key[] = "first_key";
+  constexpr char first_value[] = "first_value";
+  constexpr char second_key[] = "second_key";
+  constexpr char second_value[] = "second_value";
+  constexpr char third_key[] = "third_key";
+  constexpr char third_value[] = "third_value";
+  constexpr char fourth_key[] = "fourth_key";
+  constexpr char fourth_value[] = "fourth_value";
+
+  ASSERT_OK(Put(first_key, first_value));
+  ASSERT_OK(Put(second_key, second_value));
+  ASSERT_OK(Put(third_key, third_value));
+  ASSERT_OK(Put(fourth_key, fourth_value));
+  ASSERT_OK(Flush());
+
+  // Second table+blob file pair: overwrite 2 existing keys
+  constexpr char new_first_value[] = "new_first_value";
+  constexpr char new_second_value[] = "new_second_value";
+
+  ASSERT_OK(Put(first_key, new_first_value));
+  ASSERT_OK(Put(second_key, new_second_value));
+  ASSERT_OK(Flush());
+
+  // Compact them together. The first blob file should have 2 garbage blobs
+  // corresponding to the 2 overwritten keys.
+  constexpr Slice* begin = nullptr;
+  constexpr Slice* end = nullptr;
+
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), begin, end));
+
+  VersionSet* const versions = dbfull()->TEST_GetVersionSet();
+  assert(versions);
+  assert(versions->GetColumnFamilySet());
+
+  ColumnFamilyData* const cfd = versions->GetColumnFamilySet()->GetDefault();
+  assert(cfd);
+
+  Version* const current = cfd->current();
+  assert(current);
+
+  const VersionStorageInfo* const storage_info = current->storage_info();
+  assert(storage_info);
+
+  const auto& blob_files = storage_info->GetBlobFiles();
+  ASSERT_EQ(blob_files.size(), 2);
+
+  {
+    auto it = blob_files.begin();
+    const auto& meta = it->second;
+    assert(meta);
+
+    constexpr uint64_t first_expected_bytes =
+        sizeof(first_value) - 1 +
+        BlobLogRecord::CalculateAdjustmentForRecordHeader(sizeof(first_key) -
+                                                          1);
+    constexpr uint64_t second_expected_bytes =
+        sizeof(second_value) - 1 +
+        BlobLogRecord::CalculateAdjustmentForRecordHeader(sizeof(second_key) -
+                                                          1);
+    constexpr uint64_t third_expected_bytes =
+        sizeof(third_value) - 1 +
+        BlobLogRecord::CalculateAdjustmentForRecordHeader(sizeof(third_key) -
+                                                          1);
+    constexpr uint64_t fourth_expected_bytes =
+        sizeof(fourth_value) - 1 +
+        BlobLogRecord::CalculateAdjustmentForRecordHeader(sizeof(fourth_key) -
+                                                          1);
+
+    ASSERT_EQ(meta->GetTotalBlobCount(), 4);
+    ASSERT_EQ(meta->GetTotalBlobBytes(),
+              first_expected_bytes + second_expected_bytes +
+                  third_expected_bytes + fourth_expected_bytes);
+    ASSERT_EQ(meta->GetGarbageBlobCount(), 2);
+    ASSERT_EQ(meta->GetGarbageBlobBytes(),
+              first_expected_bytes + second_expected_bytes);
+  }
+
+  {
+    auto it = blob_files.rbegin();
+    const auto& meta = it->second;
+    assert(meta);
+
+    constexpr uint64_t new_first_expected_bytes =
+        sizeof(new_first_value) - 1 +
+        BlobLogRecord::CalculateAdjustmentForRecordHeader(sizeof(first_key) -
+                                                          1);
+    constexpr uint64_t new_second_expected_bytes =
+        sizeof(new_second_value) - 1 +
+        BlobLogRecord::CalculateAdjustmentForRecordHeader(sizeof(second_key) -
+                                                          1);
+
+    ASSERT_EQ(meta->GetTotalBlobCount(), 2);
+    ASSERT_EQ(meta->GetTotalBlobBytes(),
+              new_first_expected_bytes + new_second_expected_bytes);
+    ASSERT_EQ(meta->GetGarbageBlobCount(), 0);
+    ASSERT_EQ(meta->GetGarbageBlobBytes(), 0);
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/db_blob_compaction_test.cc
+++ b/db/blob/db_blob_compaction_test.cc
@@ -283,13 +283,12 @@ TEST_F(DBBlobCompactionTest, BlindWriteFilter) {
 TEST_F(DBBlobCompactionTest, SkipUntilFilter) {
   Options options = GetDefaultOptions();
   options.enable_blob_files = true;
-  options.create_if_missing = true;
 
   std::unique_ptr<CompactionFilter> compaction_filter_guard(
       new SkipUntilFilter("z"));
   options.compaction_filter = compaction_filter_guard.get();
 
-  DestroyAndReopen(options);
+  Reopen(options);
 
   const std::vector<std::string> keys{"a", "b", "c"};
   const std::vector<std::string> values{"a_value", "b_value", "c_value"};

--- a/db/blob/db_blob_compaction_test.cc
+++ b/db/blob/db_blob_compaction_test.cc
@@ -317,6 +317,7 @@ TEST_F(DBBlobCompactionTest, SkipUntilFilter) {
     ASSERT_EQ(Get(key), "NOT_FOUND");
   }
 
+  // Make sure SkipUntil was performed using iteration rather than Seek
   ASSERT_EQ(process_in_flow_called, keys.size());
 
   Close();

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -581,12 +581,8 @@ bool Compaction::ShouldFormSubcompactions() const {
   }
 }
 
-bool Compaction::ShouldCollectBlobProperties() const {
+bool Compaction::DoesInputReferenceBlobFiles() const {
   assert(input_version_);
-
-  if (mutable_cf_options_.enable_blob_files) {
-    return true;
-  }
 
   const VersionStorageInfo* storage_info = input_version_->storage_info();
   assert(storage_info);

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -581,6 +581,33 @@ bool Compaction::ShouldFormSubcompactions() const {
   }
 }
 
+bool Compaction::ShouldCollectBlobProperties() const {
+  assert(input_version_);
+
+  if (mutable_cf_options_.enable_blob_files) {
+    return true;
+  }
+
+  const VersionStorageInfo* storage_info = input_version_->storage_info();
+  assert(storage_info);
+
+  if (storage_info->GetBlobFiles().empty()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < inputs_.size(); ++i) {
+    for (const FileMetaData* meta : inputs_[i].files) {
+      assert(meta);
+
+      if (meta->oldest_blob_file_number != kInvalidBlobFileNumber) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 uint64_t Compaction::MinInputFileOldestAncesterTime() const {
   uint64_t min_oldest_ancester_time = port::kMaxUint64;
   for (const auto& level_files : inputs_) {

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -266,6 +266,12 @@ class Compaction {
   // Should this compaction be broken up into smaller ones run in parallel?
   bool ShouldFormSubcompactions() const;
 
+  // Returns true iff we should collect blob related table properties during
+  // this compaction.
+  //
+  // PRE: input version has been set.
+  bool ShouldCollectBlobProperties() const;
+
   // test function to validate the functionality of IsBottommostLevel()
   // function -- determines if compaction with inputs and storage is bottommost
   static bool TEST_IsBottommostLevel(

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -266,11 +266,10 @@ class Compaction {
   // Should this compaction be broken up into smaller ones run in parallel?
   bool ShouldFormSubcompactions() const;
 
-  // Returns true iff we should collect blob related table properties during
-  // this compaction.
+  // Returns true iff at least one input file references a blob file.
   //
   // PRE: input version has been set.
-  bool ShouldCollectBlobProperties() const;
+  bool DoesInputReferenceBlobFiles() const;
 
   // test function to validate the functionality of IsBottommostLevel()
   // function -- determines if compaction with inputs and storage is bottommost

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -75,10 +75,8 @@ CompactionIterator::CompactionIterator(
     const std::atomic<bool>* manual_compaction_canceled,
     const std::shared_ptr<Logger> info_log,
     const std::string* full_history_ts_low)
-    : input_(
-          input, cmp,
-          compaction ==
-              nullptr),  // Now only need to count number of entries in flush.
+    : input_(input, cmp,
+             !compaction || compaction->DoesInputReferenceBlobFiles()),
       cmp_(cmp),
       merge_helper_(merge_helper),
       snapshots_(snapshots),

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -97,6 +97,8 @@ class CompactionIterator {
     virtual double blob_garbage_collection_age_cutoff() const = 0;
 
     virtual Version* input_version() const = 0;
+
+    virtual bool DoesInputReferenceBlobFiles() const = 0;
   };
 
   class RealCompaction : public CompactionProxy {
@@ -144,6 +146,10 @@ class CompactionIterator {
 
     Version* input_version() const override {
       return compaction_->input_version();
+    }
+
+    bool DoesInputReferenceBlobFiles() const override {
+      return compaction_->DoesInputReferenceBlobFiles();
     }
 
    private:

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -182,6 +182,8 @@ class FakeCompaction : public CompactionIterator::CompactionProxy {
 
   Version* input_version() const override { return nullptr; }
 
+  bool DoesInputReferenceBlobFiles() const override { return false; }
+
   bool key_not_exists_beyond_output_level = false;
 
   bool is_bottommost_level = false;

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1269,6 +1269,10 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
       break;
     }
 
+    if (blob_garbage_meter.get()) {
+      blob_garbage_meter->ProcessOutFlow(key, value);
+    }
+
     sub_compact->current_output_file_size =
         sub_compact->builder->EstimatedFileSize();
     const ParsedInternalKey& ikey = c_iter->ikey();

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -357,7 +357,6 @@ CompactionJob::CompactionJob(
       event_logger_(event_logger),
       paranoid_file_checks_(paranoid_file_checks),
       measure_io_stats_(measure_io_stats),
-      collect_blob_properties_(compaction->ShouldCollectBlobProperties()),
       thread_pri_(thread_pri),
       full_history_ts_low_(std::move(full_history_ts_low)),
       blob_callback_(blob_callback) {

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -233,7 +233,7 @@ struct CompactionJob::SubcompactionState {
     return false;
   }
 
-  Status ProcessBlobIfNeeded(const Slice& key, const Slice& value) {
+  Status ProcessOutFlowIfNeeded(const Slice& key, const Slice& value) {
     if (!blob_garbage_meter) {
       return Status::OK();
     }
@@ -1268,7 +1268,7 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
       break;
     }
 
-    status = sub_compact->ProcessBlobIfNeeded(key, value);
+    status = sub_compact->ProcessOutFlowIfNeeded(key, value);
     if (!status.ok()) {
       break;
     }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -357,6 +357,7 @@ CompactionJob::CompactionJob(
       event_logger_(event_logger),
       paranoid_file_checks_(paranoid_file_checks),
       measure_io_stats_(measure_io_stats),
+      collect_blob_properties_(compaction->ShouldCollectBlobProperties()),
       thread_pri_(thread_pri),
       full_history_ts_low_(std::move(full_history_ts_low)),
       blob_callback_(blob_callback) {

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -211,6 +211,7 @@ class CompactionJob {
 
   bool paranoid_file_checks_;
   bool measure_io_stats_;
+  bool collect_blob_properties_;
   // Stores the Slices that designate the boundaries for each subcompaction
   std::vector<Slice> boundaries_;
   // Stores the approx size of keys covered in the range of each subcompaction

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -211,7 +211,6 @@ class CompactionJob {
 
   bool paranoid_file_checks_;
   bool measure_io_stats_;
-  bool collect_blob_properties_;
   // Stores the Slices that designate the boundaries for each subcompaction
   std::vector<Slice> boundaries_;
   // Stores the approx size of keys covered in the range of each subcompaction


### PR DESCRIPTION
Summary:
The patch builds on `BlobGarbageMeter` and `BlobCountingIterator`
(introduced in #8426 and
#8443 respectively)
and ties it all together. It measures the amount of garbage
generated by a compaction and logs the corresponding `BlobFileGarbage`
records as part of the compaction job's `VersionEdit`. Note: in order
to have accurate results, `kRemoveAndSkipUntil` for compaction filters
is implemented using iteration.

Test Plan:
Ran `make check` and the crash test script.