### PR TITLE
Allow db_stress to use a secondary cache

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -262,6 +262,7 @@ DECLARE_bool(fail_if_options_file_error);
 DECLARE_uint64(batch_protection_bytes_per_key);
 
 DECLARE_uint64(user_timestamp_size);
+DECLARE_string(secondary_cache_uri);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -131,6 +131,7 @@ DECLARE_int32(get_current_wal_file_one_in);
 DECLARE_int32(set_options_one_in);
 DECLARE_int32(set_in_place_one_in);
 DECLARE_int64(cache_size);
+DECLARE_int32(cache_numshardbits);
 DECLARE_bool(cache_index_and_filter_blocks);
 DECLARE_int32(top_level_index_pinning);
 DECLARE_int32(partition_pinning);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -284,6 +284,11 @@ DEFINE_int32(set_in_place_one_in, 0,
 DEFINE_int64(cache_size, 2LL * KB * KB * KB,
              "Number of bytes to use as a cache of uncompressed data.");
 
+DEFINE_int32(cache_numshardbits, 6,
+             "Number of shards for the block cache"
+             " is 2 ** cache_numshardbits. Negative means use default settings."
+             " This is applied only if FLAGS_cache_size is non-negative.");
+
 DEFINE_bool(cache_index_and_filter_blocks, false,
             "True if indexes/filters should be cached in block cache.");
 
@@ -817,7 +822,7 @@ DEFINE_int32(open_metadata_write_fault_one_in, 0,
 
 #ifndef ROCKSDB_LITE
 DEFINE_string(secondary_cache_uri, "",
-              "Full URI for creating a custom secondary cache object");
+              "Full URI for creating a customized secondary cache object");
 #endif  // ROCKSDB_LITE
 
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -815,4 +815,9 @@ DEFINE_int32(open_metadata_write_fault_one_in, 0,
              "On non-zero, enables fault injection on file metadata write "
              "during DB reopen.");
 
+#ifndef ROCKSDB_LITE
+DEFINE_string(secondary_cache_uri, "",
+              "Full URI for creating a custom secondary cache object");
+#endif  // ROCKSDB_LITE
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -129,8 +129,9 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity) {
     return cache;
   } else {
     LRUCacheOptions opts;
-    std::shared_ptr<SecondaryCache> secondary_cache;
     opts.capacity = capacity;
+#ifndef ROCKSDB_LITE
+    std::shared_ptr<SecondaryCache> secondary_cache;
     if (!FLAGS_secondary_cache_uri.empty()) {
       Status s = ObjectRegistry::NewInstance()->NewSharedObject<SecondaryCache>(
           FLAGS_secondary_cache_uri, &secondary_cache);
@@ -142,6 +143,7 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity) {
       }
       opts.secondary_cache = secondary_cache;
     }
+#endif
     return NewLRUCache(opts);
   }
 }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -51,7 +51,7 @@ std::shared_ptr<const FilterPolicy> CreateFilterPolicy() {
 }  // namespace
 
 StressTest::StressTest()
-    : cache_(NewCache(FLAGS_cache_size)),
+    : cache_(NewCache(FLAGS_cache_size, FLAGS_cache_numshardbits)),
       compressed_cache_(NewLRUCache(FLAGS_compressed_cache_size)),
       filter_policy_(CreateFilterPolicy()),
       db_(nullptr),
@@ -116,7 +116,8 @@ StressTest::~StressTest() {
   delete cmp_db_;
 }
 
-std::shared_ptr<Cache> StressTest::NewCache(size_t capacity) {
+std::shared_ptr<Cache> StressTest::NewCache(
+    size_t capacity, int32_t num_shard_bits) {
   if (capacity <= 0) {
     return nullptr;
   }
@@ -130,6 +131,7 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity) {
   } else {
     LRUCacheOptions opts;
     opts.capacity = capacity;
+    opts.num_shard_bits = num_shard_bits;
 #ifndef ROCKSDB_LITE
     std::shared_ptr<SecondaryCache> secondary_cache;
     if (!FLAGS_secondary_cache_uri.empty()) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -116,8 +116,8 @@ StressTest::~StressTest() {
   delete cmp_db_;
 }
 
-std::shared_ptr<Cache> StressTest::NewCache(
-    size_t capacity, int32_t num_shard_bits) {
+std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
+                                            int32_t num_shard_bits) {
   if (capacity <= 0) {
     return nullptr;
   }

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -23,7 +23,7 @@ class StressTest {
 
   virtual ~StressTest();
 
-  std::shared_ptr<Cache> NewCache(size_t capacity);
+  std::shared_ptr<Cache> NewCache(size_t capacity, int32_t num_shard_bits);
 
   static std::vector<std::string> GetBlobCompressionTags();
 


### PR DESCRIPTION
Add a ```-secondary_cache_uri``` to db_stress to allow the user to specify a custom ```SecondaryCache``` object from the object registry. Also allow db_crashtest.py to be run with an alternate db_stress location. Together, these changes will allow us to run db_stress using FB internal components.