### PR TITLE
Fix Immutable Customizable Serialization

### DIFF
--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -556,7 +556,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
                  if (root_comp == nullptr) {
                    root_comp = (*ptr);
                  }
-                 *value = root_comp->Name();
+                 *value = root_comp->ToString(opts);
                }
                return Status::OK();
              },

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -539,8 +539,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
              offset_of(&ImmutableCFOptions::user_comparator),
              OptionVerificationType::kByName, OptionTypeFlags::kCompareLoose,
              // Serializes a Comparator
-             [](const ConfigOptions& /*opts*/, const std::string&,
-                const void* addr, std::string* value) {
+             [](const ConfigOptions& opts, const std::string&, const void* addr,
+                std::string* value) {
                // it's a const pointer of const Comparator*
                const auto* ptr = static_cast<const Comparator* const*>(addr);
 
@@ -549,6 +549,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
                // one instead of InternalKeyComparator.
                if (*ptr == nullptr) {
                  *value = kNullptrString;
+               } else if (opts.mutable_options_only) {
+                 *value = "";
                } else {
                  const Comparator* root_comp = (*ptr)->GetRootComparator();
                  if (root_comp == nullptr) {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1096,8 +1096,6 @@ Status OptionTypeInfo::Serialize(const ConfigOptions& config_options,
     return Status::NotSupported("Cannot serialize option: ", opt_name);
   } else if (serialize_func_ != nullptr) {
     return serialize_func_(config_options, opt_name, opt_addr, opt_value);
-  } else if (SerializeSingleOptionHelper(opt_addr, type_, opt_value)) {
-    return Status::OK();
   } else if (IsCustomizable()) {
     const Customizable* custom = AsRawPointer<Customizable>(opt_ptr);
     if (custom == nullptr) {
@@ -1108,7 +1106,18 @@ Status OptionTypeInfo::Serialize(const ConfigOptions& config_options,
     } else {
       ConfigOptions embedded = config_options;
       embedded.delimiter = ";";
-      *opt_value = custom->ToString(embedded);
+      // If this option is mutable, everything inside it should be considered
+      // mutable
+      if (IsMutable()) {
+        embedded.mutable_options_only = false;
+      }
+      std::string value = custom->ToString(embedded);
+      if (!embedded.mutable_options_only ||
+          value.find("=") != std::string::npos) {
+        *opt_value = value;
+      } else {
+        *opt_value = "";
+      }
     }
     return Status::OK();
   } else if (IsConfigurable()) {
@@ -1118,6 +1127,10 @@ Status OptionTypeInfo::Serialize(const ConfigOptions& config_options,
       embedded.delimiter = ";";
       *opt_value = config->ToString(embedded);
     }
+    return Status::OK();
+  } else if (config_options.mutable_options_only && !IsMutable()) {
+    return Status::OK();
+  } else if (SerializeSingleOptionHelper(opt_addr, type_, opt_value)) {
     return Status::OK();
   } else {
     return Status::InvalidArgument("Cannot serialize option: ", opt_name);

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -1795,6 +1795,7 @@ TEST_F(OptionsTest, OnlyMutableCFOptions) {
   std::unordered_set<std::string> a_names;
 
   test::RandomInitCFOptions(&cf_opts, db_opts, &rnd);
+  cf_opts.comparator = ReverseBytewiseComparator();
   auto cf_config = CFOptionsAsConfigurable(cf_opts);
 
   // Get all of the CF Option names (mutable or not)
@@ -1827,6 +1828,8 @@ TEST_F(OptionsTest, OnlyMutableCFOptions) {
   ASSERT_FALSE(mcf_config->AreEquivalent(cfg_opts, cf_config.get(), &mismatch));
   ASSERT_FALSE(cf_config->AreEquivalent(cfg_opts, mcf_config.get(), &mismatch));
 
+  ASSERT_OK(GetColumnFamilyOptionsFromString(cfg_opts, ColumnFamilyOptions(),
+                                             opt_str, &cf_opts));
   delete cf_opts.compaction_filter;
 }
 #endif  // !ROCKSDB_LITE

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -1782,6 +1782,9 @@ TEST_F(OptionsTest, OnlyMutableDBOptions) {
   // Comparing all of the options, the two are not equivalent
   ASSERT_FALSE(mdb_config->AreEquivalent(cfg_opts, db_config.get(), &mismatch));
   ASSERT_FALSE(db_config->AreEquivalent(cfg_opts, mdb_config.get(), &mismatch));
+
+  // Make sure there are only mutable options being configured
+  ASSERT_OK(GetDBOptionsFromString(cfg_opts, DBOptions(), opt_str, &db_opts));
 }
 
 TEST_F(OptionsTest, OnlyMutableCFOptions) {
@@ -1827,7 +1830,9 @@ TEST_F(OptionsTest, OnlyMutableCFOptions) {
   // Comparing all of the options, the two are not equivalent
   ASSERT_FALSE(mcf_config->AreEquivalent(cfg_opts, cf_config.get(), &mismatch));
   ASSERT_FALSE(cf_config->AreEquivalent(cfg_opts, mcf_config.get(), &mismatch));
+  delete cf_opts.compaction_filter;
 
+  // Make sure the options string contains only mutable options
   ASSERT_OK(GetColumnFamilyOptionsFromString(cfg_opts, ColumnFamilyOptions(),
                                              opt_str, &cf_opts));
   delete cf_opts.compaction_filter;


### PR DESCRIPTION
If a Customizable option was not mutable, it would still appear in the list of mutable options when serialized. This meant that when the immutable options were used to configure another immutable object, an "option not changeable" status would be returned.