### PR TITLE
Run Merge with Integrated BlobDB in stress, crash and db_bench

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 ### New Features
 * ldb has a new feature, `list_live_files_metadata`, that shows the live SST files, as well as their LSM storage level and the column family they belong to.
 * The new BlobDB implementation now tracks the amount of garbage in each blob file in the MANIFEST.
+* Integrated BlobDB now supports Merge with base values (Put/Delete etc.).
 
 ## 6.22.0 (2021-06-18)
 ### Behavior Changes

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2357,10 +2357,10 @@ void StressTest::Open() {
 
   if ((options_.enable_blob_files || options_.enable_blob_garbage_collection ||
        FLAGS_allow_setting_blob_options_dynamically) &&
-      (FLAGS_use_merge || FLAGS_best_efforts_recovery)) {
+      FLAGS_best_efforts_recovery) {
     fprintf(stderr,
-            "Integrated BlobDB is currently incompatible with Merge, "
-            "and best-effort recovery\n");
+            "Integrated BlobDB is currently incompatible with best-effort "
+            "recovery\n");
     exit(1);
   }
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -7840,13 +7840,6 @@ int db_bench_tool(int argc, char** argv) {
     exit(1);
   }
 
-  if ((FLAGS_enable_blob_files || FLAGS_enable_blob_garbage_collection) &&
-      !FLAGS_merge_operator.empty()) {
-    fprintf(stderr,
-            "Integrated BlobDB is currently incompatible with Merge.\n");
-    exit(1);
-  }
-
   ROCKSDB_NAMESPACE::Benchmark benchmark;
   benchmark.Run();
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -280,8 +280,6 @@ blob_params = {
     "blob_compression_type": lambda: random.choice(["none", "snappy", "lz4", "zstd"]),
     "enable_blob_garbage_collection": lambda: random.choice([0] + [1] * 3),
     "blob_garbage_collection_age_cutoff": lambda: random.choice([0.0, 0.25, 0.5, 0.75, 1.0]),
-    # The following are currently incompatible with the integrated BlobDB
-    "use_merge": 0,
 }
 
 ts_params = {


### PR DESCRIPTION
Summary: Run Merge with Intergrated BlobDB in stress tests, crash tests and db_bench.

Test Plan: 1. python3 -u tools/db_crashtest.py --simple whitebox
---use_merge=1 --enable_blob_files=1
           2.  ./db_bench --benchmarks="readwhilemerging"
--merge_operator=uint64add --enable_blob_files=true

Reviewers:

Subscribers:

Tasks:

Tags: