### PR TITLE
BugFix: Add ImmutableCFOption disable_preload_pinning option

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -922,7 +922,6 @@ class VersionBuilder::Rep {
                            const SliceTransform* prefix_extractor,
                            size_t max_file_size_for_l0_meta_pin) {
     assert(table_cache_ != nullptr);
-    assert(false == ioptions_->disable_preload_pinning);
 
     size_t table_cache_capacity = table_cache_->get_cache()->GetCapacity();
     bool always_load = (table_cache_capacity == TableCache::kInfiniteCapacity);

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -703,6 +703,15 @@ struct AdvancedColumnFamilyOptions {
   // Default: true
   bool force_consistency_checks = true;
 
+  // RocksDB uses the first 25% of num_open_files for precaching during
+  //  start-up and after compactions.  The files precached in this fashion
+  //  provide faster access.  However, these files are also never released.
+  //  Scenarios that have large bloom filters not cached or scenarios where
+  //  user is manually lowering the num_open_files at runtime might want
+  //  to disable this behavior.
+  // Default: false
+  bool disable_preload_pinning = false;
+
   // Measure IO stats in compactions and flushes, if true.
   //
   // Default: false

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -61,6 +61,7 @@ class LDBCommand {
   static const std::string ARG_CREATE_IF_MISSING;
   static const std::string ARG_NO_VALUE;
   static const std::string ARG_DISABLE_CONSISTENCY_CHECKS;
+  static const std::string ARG_DISABLE_PRELOAD_PINNING;
 
   struct ParsedParams {
     std::string cmd;
@@ -172,6 +173,9 @@ class LDBCommand {
 
   // The value passed to options.force_consistency_checks.
   bool force_consistency_checks_;
+
+  // The value passed to options.disable_preload_pinning.
+  bool disable_preload_pinning_;
 
   bool create_if_missing_;
 

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -3665,6 +3665,17 @@ void Java_org_rocksdb_Options_setForceConsistencyChecks(
 
 /*
  * Class:     org_rocksdb_Options
+ * Method:    setDisablePreloadPinning
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_Options_setDisablePreloadPinning(
+    JNIEnv*, jobject, jlong jhandle, jboolean jdisable_preload_pinning) {
+  auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opts->disable_preload_pinning = static_cast<bool>(jdisable_preload_pinning);
+}
+
+/*
+ * Class:     org_rocksdb_Options
  * Method:    forceConsistencyChecks
  * Signature: (J)Z
  */
@@ -3672,6 +3683,17 @@ jboolean Java_org_rocksdb_Options_forceConsistencyChecks(
     JNIEnv*, jobject, jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<bool>(opts->force_consistency_checks);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    disablePreloadPinning
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_Options_disablePreloadPinning(
+    JNIEnv*, jobject, jlong jhandle) {
+  auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<bool>(opts->disable_preload_pinning);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -5201,6 +5223,31 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_forceConsistencyChecks(
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return static_cast<bool>(cf_opts->force_consistency_checks);
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyOptions
+ * Method:    setDisablePreloadPinning
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_ColumnFamilyOptions_setDisablePreloadPinning(
+    JNIEnv*, jobject, jlong jhandle, jboolean jdisable_preload_pinning) {
+  auto* cf_opts =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
+  cf_opts->disable_preload_pinning =
+      static_cast<bool>(jdisable_preload_pinning);
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyOptions
+ * Method:    disablePreloadPinning
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_ColumnFamilyOptions_disablePreloadPinning(
+    JNIEnv*, jobject, jlong jhandle) {
+  auto* cf_opts =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
+  return static_cast<bool>(cf_opts->disable_preload_pinning);
 }
 
 /////////////////////////////////////////////////////////////////////

--- a/java/src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
@@ -462,4 +462,30 @@ public interface AdvancedColumnFamilyOptionsInterface<
    * @return true if consistency checks are enforced
    */
   boolean forceConsistencyChecks();
+
+  /**
+   * RocksDB uses the first 25% of num_open_files for precaching during
+   *  start-up and after compactions.  The files precached in this fashion
+   *  provide faster access.  However, these files are also never released.
+   *  Scenarios that have large bloom filters not cached or scenarios where
+   *  user is manually lowering the num_open_files at runtime might want
+   *  to disable this behavior.
+   *
+   * Default: false
+   *
+   * @param disablePreloadPinning true to stop pinning preload files in cache
+   *
+   * @return the reference to the current options.
+   */
+  T setDisablePreloadPinning(
+      boolean disablePreloadPinning);
+
+  /**
+   * RocksDB uses the first 25% of num_open_files for precaching during
+   *  start-up and after compactions.  The files precached in this fashion
+   *  might or might not be pinned in the table cache.
+   *
+   * @return true when pinning preloaded files into cache is disable
+   */
+  boolean DisablePreloadPinning();
 }

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -896,6 +896,17 @@ public class ColumnFamilyOptions extends RocksObject
   }
 
   @Override
+  public ColumnFamilyOptions setDisablePreloadPinning(final boolean disablePreloadPinning) {
+    setDisablePreloadPinning(nativeHandle_, disablePreloadPinning);
+    return this;
+  }
+
+  @Override
+  public boolean disablePreloadPinning() {
+    return disablePreloadPinning(nativeHandle_);
+  }
+
+  @Override
   public ColumnFamilyOptions setSstPartitionerFactory(SstPartitionerFactory sstPartitionerFactory) {
     setSstPartitionerFactory(nativeHandle_, sstPartitionerFactory.nativeHandle_);
     this.sstPartitionerFactory_ = sstPartitionerFactory;
@@ -1090,6 +1101,9 @@ public class ColumnFamilyOptions extends RocksObject
   private native void setForceConsistencyChecks(final long handle,
     final boolean forceConsistencyChecks);
   private native boolean forceConsistencyChecks(final long handle);
+  private native void setDisablePreloadPinning(final long handle,
+    final boolean disablePreloadPinning);
+  private native boolean disablePreloadPinning(final long handle);
   private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
   private static native void setCompactionThreadLimiter(
       final long nativeHandle_, final long compactionThreadLimiterHandle);

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -1887,6 +1887,17 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options setDisablePreloadPinning(final boolean disablePreloadPinning) {
+    setDisablePreloadPinning(nativeHandle_, disablePreloadPinning);
+    return this;
+  }
+
+  @Override
+  public boolean disablePreloadPinning() {
+    return disablePreloadPinning(nativeHandle_);
+  }
+
+  @Override
   public Options setAtomicFlush(final boolean atomicFlush) {
     setAtomicFlush(nativeHandle_, atomicFlush);
     return this;
@@ -2390,6 +2401,9 @@ public class Options extends RocksObject
   private native void setForceConsistencyChecks(final long handle,
       final boolean forceConsistencyChecks);
   private native boolean forceConsistencyChecks(final long handle);
+  private native void setDisablePreloadPinning(final long handle,
+      final boolean disablePreloadPinning);
+  private native boolean disablePreloadPinning(final long handle);
   private native void setAtomicFlush(final long handle,
       final boolean atomicFlush);
   private native boolean atomicFlush(final long handle);

--- a/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
@@ -626,6 +626,16 @@ public class ColumnFamilyOptionsTest {
   }
 
   @Test
+  public void disablePreloadPinning() {
+    try (final ColumnFamilyOptions opt = new ColumnFamilyOptions()) {
+      final boolean booleanValue = true;
+      opt.setDisablePreloadPinning(booleanValue);
+      assertThat(opt.disablePreloadPinning()).
+          isEqualTo(booleanValue);
+    }
+  }
+
+  @Test
   public void compactionFilter() {
     try(final ColumnFamilyOptions options = new ColumnFamilyOptions();
         final RemoveEmptyValueCompactionFilter cf = new RemoveEmptyValueCompactionFilter()) {

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -1293,6 +1293,16 @@ public class OptionsTest {
   }
 
   @Test
+  public void disablePreloadPinning() {
+    try (final Options options = new Options()) {
+      final boolean booleanValue = true;
+      options.setDisablePreloadPinning(booleanValue);
+      assertThat(options.disablePreloadPinning()).
+          isEqualTo(booleanValue);
+    }
+  }
+
+  @Test
   public void compactionFilter() {
     try(final Options options = new Options();
         final RemoveEmptyValueCompactionFilter cf = new RemoveEmptyValueCompactionFilter()) {

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -485,6 +485,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
         {"compaction_measure_io_stats",
          {0, OptionType::kBoolean, OptionVerificationType::kDeprecated,
           OptionTypeFlags::kNone}},
+        {"disable_preload_pinning",
+         {offset_of(&ImmutableCFOptions::disable_preload_pinning),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         {"inplace_update_support",
          {offset_of(&ImmutableCFOptions::inplace_update_support),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -823,6 +827,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       num_levels(cf_options.num_levels),
       optimize_filters_for_hits(cf_options.optimize_filters_for_hits),
       force_consistency_checks(cf_options.force_consistency_checks),
+      disable_preload_pinning(cf_options.disable_preload_pinning),
       memtable_insert_with_hint_prefix_extractor(
           cf_options.memtable_insert_with_hint_prefix_extractor),
       cf_paths(cf_options.cf_paths),

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -74,6 +74,8 @@ struct ImmutableCFOptions {
 
   bool force_consistency_checks;
 
+  bool disable_preload_pinning;
+
   std::shared_ptr<const SliceTransform>
       memtable_insert_with_hint_prefix_extractor;
 

--- a/options/options.cc
+++ b/options/options.cc
@@ -85,6 +85,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       optimize_filters_for_hits(options.optimize_filters_for_hits),
       paranoid_file_checks(options.paranoid_file_checks),
       force_consistency_checks(options.force_consistency_checks),
+      disable_preload_pinning(options.disable_preload_pinning),
       report_bg_io_stats(options.report_bg_io_stats),
       ttl(options.ttl),
       periodic_compaction_seconds(options.periodic_compaction_seconds),
@@ -378,6 +379,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      paranoid_file_checks);
     ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
                      force_consistency_checks);
+    ROCKS_LOG_HEADER(log, "               Options.disable_preload_pinning: %d",
+                     disable_preload_pinning);
     ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
                      report_bg_io_stats);
     ROCKS_LOG_HEADER(log, "                              Options.ttl: %" PRIu64,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -294,6 +294,7 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
   cf_opts->num_levels = ioptions.num_levels;
   cf_opts->optimize_filters_for_hits = ioptions.optimize_filters_for_hits;
   cf_opts->force_consistency_checks = ioptions.force_consistency_checks;
+  cf_opts->disable_preload_pinning = ioptions.disable_preload_pinning;
   cf_opts->memtable_insert_with_hint_prefix_extractor =
       ioptions.memtable_insert_with_hint_prefix_extractor;
   cf_opts->cf_paths = ioptions.cf_paths;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -496,6 +496,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "check_flush_compaction_key_order=false;"
       "paranoid_file_checks=true;"
       "force_consistency_checks=true;"
+      "disable_preload_pinning=true;"
       "inplace_update_num_locks=7429;"
       "optimize_filters_for_hits=false;"
       "level_compaction_dynamic_level_bytes=false;"

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -1499,6 +1499,10 @@ TEST_F(OptionsTest, MutableCFOptions) {
   ASSERT_NOK(GetColumnFamilyOptionsFromMap(
       config_options, cf_opts, {{"force_consistency_checks", "true"}},
       &cf_opts));
+  // disable preload pinning is not mutable
+  ASSERT_NOK(GetColumnFamilyOptionsFromMap(
+      config_options, cf_opts, {{"disable_preload_pinning", "true"}},
+      &cf_opts));
 
   // Attempt to change the table.  It is not mutable, so this should fail and
   // leave the original intact

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -382,6 +382,7 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, DBOptions& db_options,
   cf_opt->paranoid_file_checks = rnd->Uniform(2);
   cf_opt->purge_redundant_kvs_while_flush = rnd->Uniform(2);
   cf_opt->force_consistency_checks = rnd->Uniform(2);
+  cf_opt->disable_preload_pinning = rnd->Uniform(2);
   cf_opt->compaction_options_fifo.allow_compaction = rnd->Uniform(2);
   cf_opt->memtable_whole_key_filtering = rnd->Uniform(2);
   cf_opt->enable_blob_files = rnd->Uniform(2);

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -64,6 +64,8 @@ const std::string LDBCommand::ARG_TIMESTAMP = "timestamp";
 const std::string LDBCommand::ARG_TRY_LOAD_OPTIONS = "try_load_options";
 const std::string LDBCommand::ARG_DISABLE_CONSISTENCY_CHECKS =
     "disable_consistency_checks";
+const std::string LDBCommand::ARG_DISABLE_PRELOAD_PINNING =
+    "disable_preload_pinning";
 const std::string LDBCommand::ARG_IGNORE_UNKNOWN_OPTIONS =
     "ignore_unknown_options";
 const std::string LDBCommand::ARG_FROM = "from";
@@ -378,6 +380,8 @@ LDBCommand::LDBCommand(const std::map<std::string, std::string>& options,
   try_load_options_ = IsFlagPresent(flags, ARG_TRY_LOAD_OPTIONS);
   force_consistency_checks_ =
       !IsFlagPresent(flags, ARG_DISABLE_CONSISTENCY_CHECKS);
+  disable_preload_pinning_ =
+      IsFlagPresent(flags, ARG_DISABLE_PRELOAD_PINNING);
   config_options_.ignore_unknown_options =
       IsFlagPresent(flags, ARG_IGNORE_UNKNOWN_OPTIONS);
 }
@@ -503,6 +507,7 @@ std::vector<std::string> LDBCommand::BuildCmdLineOptions(
                                   ARG_FIX_PREFIX_LEN,
                                   ARG_TRY_LOAD_OPTIONS,
                                   ARG_DISABLE_CONSISTENCY_CHECKS,
+                                  ARG_DISABLE_PRELOAD_PINNING,
                                   ARG_IGNORE_UNKNOWN_OPTIONS,
                                   ARG_CF_NAME};
   ret.insert(ret.end(), options.begin(), options.end());
@@ -605,6 +610,7 @@ void LDBCommand::OverrideBaseCFOptions(ColumnFamilyOptions* cf_opts) {
   }
 
   cf_opts->force_consistency_checks = force_consistency_checks_;
+  cf_opts->disable_preload_pinning = disable_preload_pinning_;
   if (use_table_options) {
     cf_opts->table_factory.reset(NewBlockBasedTableFactory(table_options));
   }

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -49,6 +49,8 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
              " : Try to load option file from DB.\n");
   ret.append("  --" + LDBCommand::ARG_DISABLE_CONSISTENCY_CHECKS +
              " : Set options.force_consistency_checks = false.\n");
+  ret.append("  --" + LDBCommand::ARG_DISABLE_PRELOAD_PINNING +
+             " : Set options.disable_preload_pinning = true.\n");
   ret.append("  --" + LDBCommand::ARG_IGNORE_UNKNOWN_OPTIONS +
              " : Ignore unknown options when loading option file.\n");
   ret.append("  --" + LDBCommand::ARG_BLOOM_BITS + "=<int,e.g.:14>\n");


### PR DESCRIPTION
This PR is to address https://github.com/facebook/rocksdb/issues/8397

VersionBuilder::Rep::LoadTableHandlers() currently pins 25% of the max_open_files table_readers within the table_cache.  Over time these table readers become irrelevant and just chew up memory and disk space.  It also creates a very bad environment for users that are manipulating max_open_files dynamically as part of a general memory management scheme.  

(The latter scenario is what brought this problem to our attention.)

The new options, disable_preload_pinning, defaults to the existing behavior.  If set to true, files are preload but NOT pinned.