### PR TITLE
Enable crash test to run using fbcode components

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -1195,6 +1195,40 @@ JAVA_BUILD_TEST_COMMANDS="[
     }
 ]"
 
+#
+# RocksDB fbcode stress/crash test
+#
+FBCODE_STRESS_CRASH_TEST_COMMANDS="[
+    {
+        'name':'Rocksdb Fbcode Stress and Crash Test',
+        'oncall':'$ONCALL',
+        'executeLocal': 'true',
+        'timeout': 86400,
+        'steps': [
+            {
+                'name':'Copy RocksDB code to fbcode repo',
+                'shell':'cd $WORKING_DIR; cp -R internal_repo_rocksdb/repo/* rocksdb/src && cp -R rocksdb/src/include/rocksdb/* rocksdb  || $CONTRUN_NAME=db_stress_fbcode $TASK_CREATION_TOOL',
+                'user':'root',
+                $PARSER
+            },
+            {
+                'name':'Build RocksDB fbcode stress tests',
+                'shell':'cd $WORKING_DIR; buck build @mode/dbg rocks/tools:rocks_db_stress || $CONTRUN_NAME=db_stress_fbcode $TASK_CREATION_TOOL',
+                'user':'root',
+                $PARSER
+            },
+            {
+                'name':'Run RocksDB whitebox crash tests',
+                'timeout': 86400,
+                'shell':'cd $WORKING_DIR; mkdir /dev/shm/rocksdb_whitebox_crash_test && TEST_TMPDIR=\$(mktemp -d --tmpdir=/dev/shm/rocksdb_whitebox_crash_test) python3 rocksdb/src/tools/db_crashtest.py --stress_cmd=buck-out/dbg/gen/rocks/tools/rocks_db_stress -secondary_cache_uri=\"$SECONDARY_CACHE_URI\" --env_uri=$ENV_URI -checkpoint_one_in=0 -backup_one_in=0 -cache_size=134217728 -cache_numshardbits=4 -logtostderr=false whitebox || $CONTRUN_NAME=whitebox_crash_test $TASK_CREATION_TOOL',
+                'user':'root',
+                $PARSER
+            },
+        ],
+        $REPORT
+    }
+]"
+
 
 case $1 in
   unit)
@@ -1331,6 +1365,11 @@ case $1 in
     ;;
   java_build)
     echo $JAVA_BUILD_TEST_COMMANDS
+    ;;
+  fbcode_stress_crash)
+    set -f
+    echo $FBCODE_STRESS_CRASH_TEST_COMMANDS
+    set +f
     ;;
   *)
     echo "Invalid determinator command"

--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -1207,7 +1207,7 @@ FBCODE_STRESS_CRASH_TEST_COMMANDS="[
         'steps': [
             {
                 'name':'Copy RocksDB code to fbcode repo',
-                'shell':'cd $WORKING_DIR; cp -R internal_repo_rocksdb/repo/* rocksdb/src && cp -R rocksdb/src/include/rocksdb/* rocksdb  || $CONTRUN_NAME=db_stress_fbcode $TASK_CREATION_TOOL',
+                'shell':'cd internal_repo_rocksdb/repo && git init && git add * && git commit -a -m \"Make internal_repo_rocksdb/repo a git repo\" && cd ../.. && echo Y | python3 rocks/release_script/release_to_fbcode.py -u internal_repo_rocksdb/repo master || $CONTRUN_NAME=db_stress_fbcode $TASK_CREATION_TOOL',
                 'user':'root',
                 $PARSER
             },

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -59,7 +59,7 @@ class SharedState {
   static bool ignore_read_error;
 #endif // ROCKSDB_SUPPORT_THREAD_LOCAL
 
-  SharedState(Env* env, StressTest* stress_test)
+  SharedState(Env* /*env*/, StressTest* stress_test)
       : cv_(&mu_),
         seed_(static_cast<uint32_t>(FLAGS_seed)),
         max_key_(FLAGS_max_key),
@@ -123,14 +123,16 @@ class SharedState {
             "--clear_column_family_one_in is greater than zero.");
       }
       uint64_t size = 0;
+      Env* default_env = Env::Default();
       if (status.ok()) {
-        status = env->GetFileSize(FLAGS_expected_values_path, &size);
+        status = default_env->GetFileSize(FLAGS_expected_values_path, &size);
       }
       std::unique_ptr<WritableFile> wfile;
       if (status.ok() && size == 0) {
         const EnvOptions soptions;
         status =
-            env->NewWritableFile(FLAGS_expected_values_path, &wfile, soptions);
+            default_env->NewWritableFile(FLAGS_expected_values_path,
+                                    &wfile, soptions);
       }
       if (status.ok() && size == 0) {
         std::string buf(expected_values_size, '\0');
@@ -138,8 +140,8 @@ class SharedState {
         values_init_needed = true;
       }
       if (status.ok()) {
-        status = env->NewMemoryMappedFileBuffer(FLAGS_expected_values_path,
-                                                &expected_mmap_buffer_);
+        status = default_env->NewMemoryMappedFileBuffer(
+                    FLAGS_expected_values_path, &expected_mmap_buffer_);
       }
       if (status.ok()) {
         assert(expected_mmap_buffer_->GetLen() == expected_values_size);

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -130,9 +130,8 @@ class SharedState {
       std::unique_ptr<WritableFile> wfile;
       if (status.ok() && size == 0) {
         const EnvOptions soptions;
-        status =
-            default_env->NewWritableFile(FLAGS_expected_values_path,
-                                    &wfile, soptions);
+        status = default_env->NewWritableFile(FLAGS_expected_values_path,
+                                              &wfile, soptions);
       }
       if (status.ok() && size == 0) {
         std::string buf(expected_values_size, '\0');
@@ -141,7 +140,7 @@ class SharedState {
       }
       if (status.ok()) {
         status = default_env->NewMemoryMappedFileBuffer(
-                    FLAGS_expected_values_path, &expected_mmap_buffer_);
+            FLAGS_expected_values_path, &expected_mmap_buffer_);
       }
       if (status.ok()) {
         assert(expected_mmap_buffer_->GetLen() == expected_values_size);


### PR DESCRIPTION
Add a new test ```fbcode_crash_test``` to rocksdb-lego-determinator. This test allows the crash test to be run on Facebook Sandcastle infra using fbcode components. Also use the default Env in db_stress to access the expected values path as it requires a memory mapped file and may not work with custom Envs.