### PR TITLE
Stress Test to inject write failures in reopen

### DIFF
--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -824,5 +824,8 @@ DEFINE_int32(open_metadata_write_fault_one_in, 0,
 DEFINE_string(secondary_cache_uri, "",
               "Full URI for creating a customized secondary cache object");
 #endif  // ROCKSDB_LITE
+DEFINE_int32(open_write_fault_one_in, 0,
+             "On non-zero, enables fault injection on file write "
+             "during DB reopen.");
 
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -31,6 +31,7 @@ DECLARE_int32(continuous_verification_interval);
 DECLARE_int32(read_fault_one_in);
 DECLARE_int32(write_fault_one_in);
 DECLARE_int32(open_metadata_write_fault_one_in);
+DECLARE_int32(open_write_fault_one_in);
 
 namespace ROCKSDB_NAMESPACE {
 class StressTest;

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -86,7 +86,8 @@ int db_stress_tool(int argc, char** argv) {
 
 #ifndef NDEBUG
   if (FLAGS_read_fault_one_in || FLAGS_sync_fault_injection ||
-      FLAGS_write_fault_one_in || FLAGS_open_metadata_write_fault_one_in) {
+      FLAGS_write_fault_one_in || FLAGS_open_metadata_write_fault_one_in ||
+      FLAGS_open_write_fault_one_in) {
     FaultInjectionTestFS* fs =
         new FaultInjectionTestFS(raw_env->GetFileSystem());
     fault_fs_guard.reset(fs);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -140,6 +140,7 @@ default_params = {
     "key_len_percent_dist": "1,30,69",
     "read_fault_one_in": lambda: random.choice([0, 1000]),
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 8]),
+    "open_write_fault_one_in": lambda: random.choice([0, 16]),
     "sync_fault_injection": False,
     "get_property_one_in": 1000000,
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -365,6 +365,7 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   // want to inject. Types decides the file types we want to inject the
   // error (e.g., Wal files, SST files), which is empty by default.
   void SetRandomWriteError(uint32_t seed, int one_in, IOStatus error,
+                           bool inject_for_all_file_types,
                            const std::vector<FileType>& types) {
     MutexLock l(&mutex_);
     Random tmp_rand(seed);
@@ -372,6 +373,7 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     error_ = error;
     write_error_rand_ = tmp_rand;
     write_error_one_in_ = one_in;
+    inject_for_all_file_types_ = inject_for_all_file_types;
     write_error_allowed_types_ = types;
   }
 
@@ -492,6 +494,7 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   Random write_error_rand_;
   int write_error_one_in_;
   int metadata_write_error_one_in_;
+  bool inject_for_all_file_types_;
   std::vector<FileType> write_error_allowed_types_;
   bool ingest_data_corruption_before_write_;
   ChecksumType checksum_handoff_func_tpye_;


### PR DESCRIPTION
Summary:
Previously Stress can inject metadata write failures when reopening a DB. We extend it to file append too, in the same way.

Test Plan: manually run crash test with various setting and make sure the failures are triggered as expected.