### PR TITLE
Temporarily disable file deletion after open failure in db_stress

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2558,10 +2558,16 @@ void StressTest::Open() {
             ingest_read_error = false;
 
             Random rand(static_cast<uint32_t>(FLAGS_seed));
+// TODO: This is disabled for now as deleting the CURRENT file after open
+// failure causes the DB to not be reopened again due to the presence of
+// WAL files, which DB::Open considers to be a corruption. Re-enable once
+// we figure out a proper fix
+#if 0
             if (rand.OneIn(2)) {
               fault_fs_guard->DeleteFilesCreatedAfterLastDirSync(IOOptions(),
                                                                  nullptr);
             }
+#endif
             if (rand.OneIn(3)) {
               fault_fs_guard->DropUnsyncedFileData();
             } else if (rand.OneIn(2)) {


### PR DESCRIPTION
Write and metadata error injection during DB open was enabled in #8474. This causes crash tests to fail very frequently due to another fault injection feature that deletes files created after the last dir sync during DB open, with the following error -
```open error: Corruption: While creating a new Db, wal_dir contains existing log file: : 000049.log```

 In real life, a similar failure would happen if the FS returns error on the CURRENT file rename, but the rename actually succeeded and got partially persisted (dir entry for the old CURRENT file got removed, but the entry for the new one is not persisted). When the DB is reopened, it would proceed to create a new DB, but fail later due to the presence of old WAL files. Temporarily disable the fault injection feature until we figure out the likelihood of this bug happening and the proper way to fix it.

Test:
Stress test can open the DB successfully  