### PR TITLE
Improve support for valgrind error on reachable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,6 +488,7 @@ VALGRIND_ERROR = 2
 VALGRIND_VER := $(join $(VALGRIND_VER),valgrind)
 
 VALGRIND_OPTS = --error-exitcode=$(VALGRIND_ERROR) --leak-check=full
+# Not yet supported: --show-leak-kinds=definite,possible,reachable --errors-for-leak-kinds=definite,possible,reachable
 
 TEST_OBJECTS = $(patsubst %.cc, $(OBJ_DIR)/%.o, $(TEST_LIB_SOURCES) $(MOCK_LIB_SOURCES)) $(GTEST)
 BENCH_OBJECTS = $(patsubst %.cc, $(OBJ_DIR)/%.o, $(BENCH_LIB_SOURCES))

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -7,6 +7,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors
 
+#include "port/lang.h"
 #if !defined(OS_WIN)
 
 #include <dirent.h>
@@ -511,7 +512,7 @@ Env* Env::Default() {
   ThreadLocalPtr::InitSingletons();
   CompressionContextCache::InitSingleton();
   INIT_SYNC_POINT_SINGLETONS();
-  static PosixEnv default_env;
+  STATIC_AVOID_DESTRUCTION(PosixEnv, default_env);
   return &default_env;
 }
 

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -512,7 +512,8 @@ Env* Env::Default() {
   ThreadLocalPtr::InitSingletons();
   CompressionContextCache::InitSingleton();
   INIT_SYNC_POINT_SINGLETONS();
-  STATIC_AVOID_DESTRUCTION(PosixEnv, default_env);
+  // ~PosixEnv must be called on exit
+  static PosixEnv default_env;
   return &default_env;
 }
 

--- a/port/lang.h
+++ b/port/lang.h
@@ -27,6 +27,10 @@
 #endif  // __SANITIZE_ADDRESS__
 #endif  // __clang__
 
+#ifdef ROCKSDB_VALGRIND_RUN
+#define MUST_FREE_HEAP_ALLOCATIONS 1
+#endif  // ROCKSDB_VALGRIND_RUN
+
 // Coding guidelines say to avoid static objects with non-trivial destructors,
 // because it's easy to cause trouble (UB) in static destruction. This
 // macro makes it easier to define static objects that are normally never


### PR DESCRIPTION
Summary: MyRocks apparently uses valgrind to check for unreachable
unfreed data, which is stricter than our valgrind checks. Internal ref:
D29257815

This patch adds valgrind support to STATIC_AVOID_DESTRUCTION so that it's
not reported with those stricter checks.

Test Plan: make valgrind_test
Also, with modified VALGRIND_OPTS (see Makefile), more kinds of
failures seen before than after this commit.