### PR TITLE
Avoid updating DBOptions if there's no value updated

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,10 @@
 ### Public API change
 * Added APIs to the Customizable class to allow developers to create their own Customizable classes.  Created the utilities/customizable_util.h file to contain helper methods for developing new Customizable classes.
 * Change signature of SecondaryCache::Name().  Make SecondaryCache customizable and add SecondaryCache::CreateFromString method.
+
+### Performance Improvements
+* Try avoid updating options operation if `SetDBOptions()` does not change any option value.
+
 ## 6.22.0 (2021-06-18)
 ### Behavior Changes
 * Added two additional tickers, MEMTABLE_PAYLOAD_BYTES_AT_FLUSH and MEMTABLE_GARBAGE_BYTES_AT_FLUSH. These stats can be used to estimate the ratio of "garbage" (outdated) bytes in the memtable that are discarded at flush time.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,7 +23,7 @@
 * Change signature of SecondaryCache::Name().  Make SecondaryCache customizable and add SecondaryCache::CreateFromString method.
 
 ### Performance Improvements
-* Try avoid updating options operation if `SetDBOptions()` does not change any option value.
+* Try to avoid updating DBOptions if `SetDBOptions()` does not change any option value.
 
 ## 6.22.0 (2021-06-18)
 ### Behavior Changes

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1134,19 +1134,21 @@ Status DBImpl::SetDBOptions(
   WriteContext write_context;
   {
     InstrumentedMutexLock l(&mutex_);
-    bool is_changed;
     s = GetMutableDBOptionsFromStrings(mutable_db_options_, options_map,
-                                       &new_options, &is_changed);
-    if (!is_changed) {
+                                       &new_options);
+
+    if (new_options.bytes_per_sync == 0) {
+      new_options.bytes_per_sync = 1024 * 1024;
+    }
+
+    if (MutableDBOptionsAreEqual(mutable_db_options_, new_options)) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "SetDBOptions(), input option value is not changed, "
                      "skipping updating.");
       persist_options_status.PermitUncheckedError();
       return s;
     }
-    if (new_options.bytes_per_sync == 0) {
-      new_options.bytes_per_sync = 1024 * 1024;
-    }
+
     DBOptions new_db_options =
         BuildDBOptions(immutable_db_options_, new_options);
     if (s.ok()) {

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -95,6 +95,62 @@ TEST_F(DBOptionsTest, ImmutableTrackAndVerifyWalsInManifest) {
   ASSERT_FALSE(s.ok());
 }
 
+TEST_F(DBOptionsTest, AvoidUpdatingOptions) {
+  Options options;
+  options.env = env_;
+  options.max_background_jobs = 4;
+  options.delayed_write_rate = 1024;
+
+  Reopen(options);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  bool is_changed_stats = false;
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteOptionsFile:PersistOptions", [&](void* /*arg*/) {
+        ASSERT_FALSE(is_changed_stats);  // should only save options file once
+        is_changed_stats = true;
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // helper function to check the status and reset after each check
+  auto is_changed = [&] {
+    bool ret = is_changed_stats;
+    is_changed_stats = false;
+    return ret;
+  };
+
+  // without changing the value
+  ASSERT_OK(dbfull()->SetDBOptions({{"max_background_jobs", "4"}}));
+  ASSERT_FALSE(is_changed());
+
+  // changing the value
+  ASSERT_OK(dbfull()->SetDBOptions({{"bytes_per_sync", "123"}}));
+  ASSERT_TRUE(is_changed());
+
+  // update again
+  ASSERT_OK(dbfull()->SetDBOptions({{"bytes_per_sync", "123"}}));
+  ASSERT_FALSE(is_changed());
+
+  // without changing a default value
+  ASSERT_OK(dbfull()->SetDBOptions({{"strict_bytes_per_sync", "false"}}));
+  ASSERT_FALSE(is_changed());
+
+  // now change
+  ASSERT_OK(dbfull()->SetDBOptions({{"strict_bytes_per_sync", "true"}}));
+  ASSERT_TRUE(is_changed());
+
+  // multiple values without change
+  ASSERT_OK(dbfull()->SetDBOptions(
+      {{"max_total_wal_size", "0"}, {"stats_dump_period_sec", "600"}}));
+  ASSERT_FALSE(is_changed());
+
+  // multiple values with change
+  ASSERT_OK(dbfull()->SetDBOptions(
+      {{"max_open_files", "100"}, {"stats_dump_period_sec", "600"}}));
+  ASSERT_TRUE(is_changed());
+}
+
 // RocksDB lite don't support dynamic options.
 #ifndef ROCKSDB_LITE
 

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -95,6 +95,9 @@ TEST_F(DBOptionsTest, ImmutableTrackAndVerifyWalsInManifest) {
   ASSERT_FALSE(s.ok());
 }
 
+// RocksDB lite don't support dynamic options.
+#ifndef ROCKSDB_LITE
+
 TEST_F(DBOptionsTest, AvoidUpdatingOptions) {
   Options options;
   options.env = env_;
@@ -150,9 +153,6 @@ TEST_F(DBOptionsTest, AvoidUpdatingOptions) {
       {{"max_open_files", "100"}, {"stats_dump_period_sec", "600"}}));
   ASSERT_TRUE(is_changed());
 }
-
-// RocksDB lite don't support dynamic options.
-#ifndef ROCKSDB_LITE
 
 TEST_F(DBOptionsTest, GetLatestDBOptions) {
   // GetOptions should be able to get latest option changed by SetOptions.

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -123,6 +123,10 @@ TEST_F(DBOptionsTest, AvoidUpdatingOptions) {
     return ret;
   };
 
+  // without changing the value, but it's sanitized to a different value
+  ASSERT_OK(dbfull()->SetDBOptions({{"bytes_per_sync", "0"}}));
+  ASSERT_TRUE(is_changed());
+
   // without changing the value
   ASSERT_OK(dbfull()->SetDBOptions({{"max_background_jobs", "4"}}));
   ASSERT_FALSE(is_changed());

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -860,7 +860,7 @@ void MutableDBOptions::Dump(Logger* log) const {
 Status GetMutableDBOptionsFromStrings(
     const MutableDBOptions& base_options,
     const std::unordered_map<std::string, std::string>& options_map,
-    MutableDBOptions* new_options) {
+    MutableDBOptions* new_options, bool* is_changed) {
   assert(new_options);
   *new_options = base_options;
   ConfigOptions config_options;
@@ -868,6 +868,13 @@ Status GetMutableDBOptionsFromStrings(
       config_options, options_map, db_mutable_options_type_info, new_options);
   if (!s.ok()) {
     *new_options = base_options;
+  }
+  // check if new_options is changed by comparing to base_options
+  if (is_changed) {
+    std::string mismatch;
+    *is_changed = !OptionTypeInfo::StructsAreEqual(
+        config_options, "MutableDBOptions", &db_mutable_options_type_info,
+        "MutableDBOptions", &base_options, new_options, &mismatch);
   }
   return s;
 }

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -860,7 +860,7 @@ void MutableDBOptions::Dump(Logger* log) const {
 Status GetMutableDBOptionsFromStrings(
     const MutableDBOptions& base_options,
     const std::unordered_map<std::string, std::string>& options_map,
-    MutableDBOptions* new_options, bool* is_changed) {
+    MutableDBOptions* new_options) {
   assert(new_options);
   *new_options = base_options;
   ConfigOptions config_options;
@@ -869,14 +869,16 @@ Status GetMutableDBOptionsFromStrings(
   if (!s.ok()) {
     *new_options = base_options;
   }
-  // check if new_options is changed by comparing to base_options
-  if (is_changed) {
-    std::string mismatch;
-    *is_changed = !OptionTypeInfo::StructsAreEqual(
-        config_options, "MutableDBOptions", &db_mutable_options_type_info,
-        "MutableDBOptions", &base_options, new_options, &mismatch);
-  }
   return s;
+}
+
+bool MutableDBOptionsAreEqual(const MutableDBOptions& this_options,
+                              const MutableDBOptions& that_options) {
+  ConfigOptions config_options;
+  std::string mismatch;
+  return OptionTypeInfo::StructsAreEqual(
+      config_options, "MutableDBOptions", &db_mutable_options_type_info,
+      "MutableDBOptions", &this_options, &that_options, &mismatch);
 }
 
 Status GetStringFromMutableDBOptions(const ConfigOptions& config_options,

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -140,7 +140,7 @@ Status GetStringFromMutableDBOptions(const ConfigOptions& config_options,
 Status GetMutableDBOptionsFromStrings(
     const MutableDBOptions& base_options,
     const std::unordered_map<std::string, std::string>& options_map,
-    MutableDBOptions* new_options);
+    MutableDBOptions* new_options, bool* is_changed = nullptr);
 #endif  // ROCKSDB_LITE
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -140,7 +140,10 @@ Status GetStringFromMutableDBOptions(const ConfigOptions& config_options,
 Status GetMutableDBOptionsFromStrings(
     const MutableDBOptions& base_options,
     const std::unordered_map<std::string, std::string>& options_map,
-    MutableDBOptions* new_options, bool* is_changed = nullptr);
+    MutableDBOptions* new_options);
+
+bool MutableDBOptionsAreEqual(const MutableDBOptions& this_options,
+                              const MutableDBOptions& that_options);
 #endif  // ROCKSDB_LITE
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: Try to avoid expensive updating DBOptions if
`SetDBOptions()` does not change any option value.

Test Plan: added unittest