### PR TITLE
Fix stats_history_test failure on Windows

### DIFF
--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -245,10 +245,10 @@ TEST_F(StatsHistoryTest, InMemoryStatsHistoryPurging) {
   }
   size_t stats_history_size = dbfull()->TEST_EstimateInMemoryStatsHistorySize();
   ASSERT_GE(slice_count, kIterations - 1);
-  ASSERT_GE(stats_history_size, 14000);
-  // capping memory cost at 14000 bytes since one slice is around 10000~14000
-  ASSERT_OK(dbfull()->SetDBOptions({{"stats_history_buffer_size", "14000"}}));
-  ASSERT_EQ(14000, dbfull()->GetDBOptions().stats_history_buffer_size);
+  ASSERT_GE(stats_history_size, 15000);
+  // capping memory cost at 15000 bytes since one slice is around 10000~15000
+  ASSERT_OK(dbfull()->SetDBOptions({{"stats_history_buffer_size", "15000"}}));
+  ASSERT_EQ(15000, dbfull()->GetDBOptions().stats_history_buffer_size);
 
   // Wait for stats persist to finish
   for (int i = 0; i < kIterations; ++i) {
@@ -270,7 +270,7 @@ TEST_F(StatsHistoryTest, InMemoryStatsHistoryPurging) {
       dbfull()->TEST_EstimateInMemoryStatsHistorySize();
   // only one slice can fit under the new stats_history_buffer_size
   ASSERT_LT(slice_count, 2);
-  ASSERT_TRUE(stats_history_size_reopen < 13000 &&
+  ASSERT_TRUE(stats_history_size_reopen < 15000 &&
               stats_history_size_reopen > 0);
   ASSERT_TRUE(stats_count_reopen < stats_count && stats_count_reopen > 0);
   Close();


### PR DESCRIPTION
Fixed a stats_history_test failure on Windows
* In StatsHistoryTest.InMemoryStatsHistoryPurging test, the capping memory cost of stats_history_size on Windows increases to 15000 bytes with latest changes