### PR TITLE
Mempurge support for wal

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1059,17 +1059,20 @@ uint64_t ColumnFamilyData::GetLiveSstFilesSize() const {
 }
 
 MemTable* ColumnFamilyData::ConstructNewMemtable(
-    const MutableCFOptions& mutable_cf_options, SequenceNumber earliest_seq) {
+    const MutableCFOptions& mutable_cf_options, SequenceNumber earliest_seq,
+    uint64_t log_number) {
   return new MemTable(internal_comparator_, ioptions_, mutable_cf_options,
-                      write_buffer_manager_, earliest_seq, id_);
+                      write_buffer_manager_, earliest_seq, id_, log_number);
 }
 
 void ColumnFamilyData::CreateNewMemtable(
-    const MutableCFOptions& mutable_cf_options, SequenceNumber earliest_seq) {
+    const MutableCFOptions& mutable_cf_options, SequenceNumber earliest_seq,
+    uint64_t log_number) {
   if (mem_ != nullptr) {
     delete mem_->Unref();
   }
-  SetMemtable(ConstructNewMemtable(mutable_cf_options, earliest_seq));
+  SetMemtable(
+      ConstructNewMemtable(mutable_cf_options, earliest_seq, log_number));
   mem_->Ref();
 }
 

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -371,9 +371,10 @@ class ColumnFamilyData {
 
   // See Memtable constructor for explanation of earliest_seq param.
   MemTable* ConstructNewMemtable(const MutableCFOptions& mutable_cf_options,
-                                 SequenceNumber earliest_seq);
+                                 SequenceNumber earliest_seq,
+                                 uint64_t log_number = 0);
   void CreateNewMemtable(const MutableCFOptions& mutable_cf_options,
-                         SequenceNumber earliest_seq);
+                         SequenceNumber earliest_seq, uint64_t log_number = 0);
 
   TableCache* table_cache() const { return table_cache_.get(); }
   BlobFileCache* blob_file_cache() const { return blob_file_cache_.get(); }

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -1132,6 +1132,7 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
 
     ASSERT_EQ("v1", Get(1, "foo"));
     ASSERT_EQ("v5", Get(1, "baz"));
+    ASSERT_OK(Put(0, "bar", "v2"));
     ASSERT_OK(Put(1, "bar", "v2"));
     ASSERT_OK(Put(1, "foo", "v3"));
     uint32_t mempurge_count = 0;
@@ -1160,8 +1161,8 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
     Random rnd(719);
     const size_t NUM_REPEAT = 100;
     const size_t RAND_VALUES_LENGTH = 10240;
-    std::string p_v1, p_v2, p_v3, p_v4, p_v5, p_v6, p_v7, p_v8, p_v9, p_rv1,
-        p_rv2, p_rv3;
+    std::string p_v1, p_v2, p_v3, p_v4, p_v5, p_v6, p_v7, p_v8, p_v9, p_v5_1,
+        p_v6_1, p_v7_1, p_v8_1, p_v9_1;
 
     // Insert a very first set of keys that will be
     // mempurged at least once.
@@ -1169,16 +1170,30 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
     p_v2 = rnd.RandomString(RAND_VALUES_LENGTH);
     p_v3 = rnd.RandomString(RAND_VALUES_LENGTH);
     p_v4 = rnd.RandomString(RAND_VALUES_LENGTH);
-    ASSERT_OK(Put(KEY1, p_v1));
-    ASSERT_OK(Put(KEY2, p_v2));
-    ASSERT_OK(Put(KEY3, p_v3));
-    ASSERT_OK(Put(KEY4, p_v4));
-    ASSERT_EQ(Get(KEY1), p_v1);
-    ASSERT_EQ(Get(KEY2), p_v2);
-    ASSERT_EQ(Get(KEY3), p_v3);
-    ASSERT_EQ(Get(KEY4), p_v4);
 
-    // Insertion of of K-V pairs, multiple times (overwrites).
+    // Insert KEY1, KEY2, KEY3, KEY4 to
+    // both 'default' and 'pikachu' CFs.
+    ASSERT_OK(Put(0, KEY1, p_v1));
+    ASSERT_OK(Put(0, KEY2, p_v2));
+    ASSERT_OK(Put(0, KEY3, p_v3));
+    ASSERT_OK(Put(0, KEY4, p_v4));
+    ASSERT_OK(Put(1, KEY1, p_v1));
+    ASSERT_OK(Put(1, KEY2, p_v2));
+    ASSERT_OK(Put(1, KEY3, p_v3));
+    ASSERT_OK(Put(1, KEY4, p_v4));
+
+    // Check that the insertion was seamless.
+    ASSERT_EQ(Get(0, KEY1), p_v1);
+    ASSERT_EQ(Get(0, KEY2), p_v2);
+    ASSERT_EQ(Get(0, KEY3), p_v3);
+    ASSERT_EQ(Get(0, KEY4), p_v4);
+    ASSERT_EQ(Get(1, KEY1), p_v1);
+    ASSERT_EQ(Get(1, KEY2), p_v2);
+    ASSERT_EQ(Get(1, KEY3), p_v3);
+    ASSERT_EQ(Get(1, KEY4), p_v4);
+
+    // Insertion of of K-V pairs, multiple times (overwrites)
+    // into 'default' CF. Will trigger mempurge.
     for (size_t i = 0; i < NUM_REPEAT; i++) {
       // Create value strings of arbitrary length RAND_VALUES_LENGTH bytes.
       p_v5 = rnd.RandomString(RAND_VALUES_LENGTH);
@@ -1193,6 +1208,7 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
       ASSERT_OK(Put(KEY8, p_v8));
       ASSERT_OK(Put(KEY9, p_v9));
 
+      // Check key validity.
       ASSERT_EQ(Get(KEY1), p_v1);
       ASSERT_EQ(Get(KEY2), p_v2);
       ASSERT_EQ(Get(KEY3), p_v3);
@@ -1204,6 +1220,36 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
       ASSERT_EQ(Get(KEY9), p_v9);
     }
 
+    // Insertion of of K-V pairs, multiple times (overwrites)
+    // into 'pikachu' CF. Will trigger mempurge.
+    // Check that we keep the older logs for 'default' imm().
+    for (size_t i = 0; i < NUM_REPEAT; i++) {
+      // Create value strings of arbitrary length RAND_VALUES_LENGTH bytes.
+      p_v5_1 = rnd.RandomString(RAND_VALUES_LENGTH);
+      p_v6_1 = rnd.RandomString(RAND_VALUES_LENGTH);
+      p_v7_1 = rnd.RandomString(RAND_VALUES_LENGTH);
+      p_v8_1 = rnd.RandomString(RAND_VALUES_LENGTH);
+      p_v9_1 = rnd.RandomString(RAND_VALUES_LENGTH);
+
+      // Insertion into 'Pikachu' CF.
+      ASSERT_OK(Put(1, KEY5, p_v5_1));
+      ASSERT_OK(Put(1, KEY6, p_v6_1));
+      ASSERT_OK(Put(1, KEY7, p_v7_1));
+      ASSERT_OK(Put(1, KEY8, p_v8_1));
+      ASSERT_OK(Put(1, KEY9, p_v9_1));
+
+      // Check key validity.
+      ASSERT_EQ(Get(1, KEY1), p_v1);
+      ASSERT_EQ(Get(1, KEY2), p_v2);
+      ASSERT_EQ(Get(1, KEY3), p_v3);
+      ASSERT_EQ(Get(1, KEY4), p_v4);
+      ASSERT_EQ(Get(1, KEY5), p_v5_1);
+      ASSERT_EQ(Get(1, KEY6), p_v6_1);
+      ASSERT_EQ(Get(1, KEY7), p_v7_1);
+      ASSERT_EQ(Get(1, KEY8), p_v8_1);
+      ASSERT_EQ(Get(1, KEY9), p_v9_1);
+    }
+
     // Check that there was at least one mempurge
     const uint32_t EXPECTED_MIN_MEMPURGE_COUNT = 1;
     // Check that there was no SST files created during flush.
@@ -1213,11 +1259,16 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
     EXPECT_EQ(sst_count, EXPECTED_SST_COUNT);
 
     ReopenWithColumnFamilies({"default", "pikachu"}, options);
+    // Check that there was no data corruption anywhere,
+    // not in 'default' nor in 'Pikachu' CFs.
     ASSERT_EQ("v3", Get(1, "foo"));
     ASSERT_OK(Put(1, "foo", "v4"));
     ASSERT_EQ("v4", Get(1, "foo"));
     ASSERT_EQ("v2", Get(1, "bar"));
     ASSERT_EQ("v5", Get(1, "baz"));
+    // Check keys in 'Default'.
+    // KEY1-KEY4 were for sure contained
+    // in the imm() at Reopen/recovery time.
     ASSERT_EQ(Get(KEY1), p_v1);
     ASSERT_EQ(Get(KEY2), p_v2);
     ASSERT_EQ(Get(KEY3), p_v3);
@@ -1227,6 +1278,18 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
     ASSERT_EQ(Get(KEY7), p_v7);
     ASSERT_EQ(Get(KEY8), p_v8);
     ASSERT_EQ(Get(KEY9), p_v9);
+    // Check keys in 'Pikachu'.
+    // KEY1-KEY4 were for sure contained
+    // in the imm() at Reopen/recovery time.
+    ASSERT_EQ(Get(1, KEY1), p_v1);
+    ASSERT_EQ(Get(1, KEY2), p_v2);
+    ASSERT_EQ(Get(1, KEY3), p_v3);
+    ASSERT_EQ(Get(1, KEY4), p_v4);
+    ASSERT_EQ(Get(1, KEY5), p_v5_1);
+    ASSERT_EQ(Get(1, KEY6), p_v6_1);
+    ASSERT_EQ(Get(1, KEY7), p_v7_1);
+    ASSERT_EQ(Get(1, KEY8), p_v8_1);
+    ASSERT_EQ(Get(1, KEY9), p_v9_1);
   } while (ChangeWalOptions());
 }
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2400,10 +2400,10 @@ void DBImpl::SchedulePendingFlush(const FlushRequest& flush_req,
     // if kWriteBufferFull, then IsFlushPending shiuld work
     // else (eg: WALFull), #_not_started_flushes >= min_wf_to_merge
     // so we need to schedule
-    if (immutable_db_options_.experimental_allow_mempurge &&
-        flush_reason != FlushReason::kWriteBufferFull) {
-      cfd->imm()->FlushRequested();
-    }
+    // if (immutable_db_options_.experimental_allow_mempurge &&
+    //     flush_reason != FlushReason::kWriteBufferFull) {
+    //   cfd->imm()->FlushRequested();
+    // }
     if (!cfd->queued_for_flush() && cfd->imm()->IsFlushPending()) {
       cfd->Ref();
       cfd->set_queued_for_flush(true);

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -630,7 +630,7 @@ Status DBImpl::Recover(
         // Clear memtables if recovery failed
         for (auto cfd : *versions_->GetColumnFamilySet()) {
           cfd->CreateNewMemtable(*cfd->GetLatestMutableCFOptions(),
-                                 kMaxSequenceNumber);
+                                 kMaxSequenceNumber, cfd->GetLogNumber());
         }
       }
     }
@@ -1066,7 +1066,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& wal_numbers,
           flushed = true;
 
           cfd->CreateNewMemtable(*cfd->GetLatestMutableCFOptions(),
-                                 *next_sequence);
+                                 *next_sequence, cfd->GetLogNumber());
         }
       }
     }
@@ -1204,7 +1204,8 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& wal_numbers,
           flushed = true;
 
           cfd->CreateNewMemtable(*cfd->GetLatestMutableCFOptions(),
-                                 versions_->LastSequence());
+                                 versions_->LastSequence(),
+                                 cfd->GetLogNumber());
         }
         data_seen = true;
       }

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -253,8 +253,8 @@ Status DBImplSecondary::RecoverLogFiles(
                                          curr_log_num != log_number)) {
             const MutableCFOptions mutable_cf_options =
                 *cfd->GetLatestMutableCFOptions();
-            MemTable* new_mem =
-                cfd->ConstructNewMemtable(mutable_cf_options, seq_of_batch);
+            MemTable* new_mem = cfd->ConstructNewMemtable(
+                mutable_cf_options, seq_of_batch, log_number);
             cfd->mem()->SetNextLogNumber(log_number);
             cfd->imm()->Add(cfd->mem(), &job_context->memtables_to_free);
             new_mem->Ref();

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1805,7 +1805,8 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   }
   if (s.ok()) {
     SequenceNumber seq = versions_->LastSequence();
-    new_mem = cfd->ConstructNewMemtable(mutable_cf_options, seq);
+    new_mem =
+        cfd->ConstructNewMemtable(mutable_cf_options, seq, new_log_number);
     context->superversion_context.NewSuperVersion();
   }
   ROCKS_LOG_INFO(immutable_db_options_.info_log,

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -123,6 +123,7 @@ class FlushJob {
   // recommend all users not to set this flag as true given that the MemPurge
   // process has not matured yet.
   Status MemPurge();
+  uint64_t ExtractEarliestLogFileNumber();
 #ifndef ROCKSDB_LITE
   std::unique_ptr<FlushJobInfo> GetFlushJobInfo() const;
 #endif  // !ROCKSDB_LITE

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -67,7 +67,8 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
                    const ImmutableOptions& ioptions,
                    const MutableCFOptions& mutable_cf_options,
                    WriteBufferManager* write_buffer_manager,
-                   SequenceNumber latest_seq, uint32_t column_family_id)
+                   SequenceNumber latest_seq, uint32_t column_family_id,
+                   uint64_t current_logfile_number)
     : comparator_(cmp),
       moptions_(ioptions, mutable_cf_options),
       refs_(0),
@@ -98,6 +99,7 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
       earliest_seqno_(latest_seq),
       creation_seq_(latest_seq),
       mem_next_logfile_number_(0),
+      mem_min_logfile_number_(current_logfile_number),
       min_prep_log_referenced_(0),
       locks_(moptions_.inplace_update_support
                  ? moptions_.inplace_update_num_locks

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -106,7 +106,8 @@ class MemTable {
                     const ImmutableOptions& ioptions,
                     const MutableCFOptions& mutable_cf_options,
                     WriteBufferManager* write_buffer_manager,
-                    SequenceNumber earliest_seq, uint32_t column_family_id);
+                    SequenceNumber earliest_seq, uint32_t column_family_id,
+                    uint64_t current_logfile_number = 0);
   // No copying allowed
   MemTable(const MemTable&) = delete;
   MemTable& operator=(const MemTable&) = delete;
@@ -387,9 +388,15 @@ class MemTable {
   // operations on the same MemTable.
   void SetNextLogNumber(uint64_t num) { mem_next_logfile_number_ = num; }
 
-  // Returns the earliest log file number that (possibly)
+  // Set the earliest log file number that (possibly)
   // contains entries from this memtable.
-  uint64_t MinLogFileNumber() { return mem_min_logfile_number_; }
+  void SetEarliestLogFileNumber(uint64_t logno) {
+    mem_min_logfile_number_ = logno;
+  }
+
+  // Return the earliest log file number that (possibly)
+  // contains entries from this memtable.
+  uint64_t GetEarliestLogFileNumber() { return mem_min_logfile_number_; }
 
   // if this memtable contains data from a committed
   // two phase transaction we must take note of the

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -387,6 +387,10 @@ class MemTable {
   // operations on the same MemTable.
   void SetNextLogNumber(uint64_t num) { mem_next_logfile_number_ = num; }
 
+  // Returns the earliest log file number that (possibly)
+  // contains entries from this memtable.
+  uint64_t MinLogFileNumber() { return mem_min_logfile_number_; }
+
   // if this memtable contains data from a committed
   // two phase transaction we must take note of the
   // log which contains that data so we can know
@@ -516,6 +520,10 @@ class MemTable {
 
   // The log files earlier than this number can be deleted.
   uint64_t mem_next_logfile_number_;
+
+  // The earliest log containing entries inserted into
+  // this memtable.
+  uint64_t mem_min_logfile_number_;
 
   // the earliest log containing a prepared section
   // which has been inserted into this memtable.

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -324,18 +324,9 @@ bool MemTableListVersion::TrimHistory(autovector<MemTable*>* to_delete,
 
 // Returns true if there is at least one memtable on which flush has
 // not yet started.
-bool MemTableList::IsFlushPending() {
-  if (flush_requested_ && num_flush_not_started_ > 0) {
-    // if ((flush_requested_ && num_flush_not_started_ > 0) ||
-    //     (num_flush_not_started_ >= min_write_buffer_number_to_merge_)) {
-    // if (has_silent_memtables_ &&
-    // !imm_flush_needed.load(std::memory_order_relaxed)){
-    //   imm_flush_needed.store(true, std::memory_order_release);
-    // }
-    assert(imm_flush_needed.load(std::memory_order_relaxed));
-    return true;
-  }
-  if (num_flush_not_started_ >= min_write_buffer_number_to_merge_) {
+bool MemTableList::IsFlushPending() const {
+  if ((flush_requested_ && num_flush_not_started_ > 0) ||
+      (num_flush_not_started_ >= min_write_buffer_number_to_merge_)) {
     assert(imm_flush_needed.load(std::memory_order_relaxed));
     return true;
   }

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -529,6 +529,8 @@ Status MemTableList::TryInstallMemtableFlushResults(
         // Notify new head of manifest write queue.
         // wake up all the waiting writers
         const int num_cfds = 1;
+        RemoveMemTablesOrRestoreFlags(s, cfd, batch_count, log_buffer,
+                                      to_delete, mu);
         vset->WakeUpWaitingManifestWriters(num_cfds);
         (void)num_cfds;
         *io_s = IOStatus::OK();

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -248,7 +248,7 @@ class MemTableList {
 
   // Returns true if there is at least one memtable on which flush has
   // not yet started.
-  bool IsFlushPending();
+  bool IsFlushPending() const;
 
   // Returns the earliest memtables that needs to be flushed. The returned
   // memtables are guaranteed to be in the ascending order of created time.

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -268,7 +268,7 @@ class MemTableList {
       autovector<MemTable*>* to_delete, FSDirectory* db_directory,
       LogBuffer* log_buffer,
       std::list<std::unique_ptr<FlushJobInfo>>* committed_flush_jobs_info,
-      IOStatus* io_s);
+      IOStatus* io_s, bool write_edits);
 
   // New memtables are inserted at the front of the list.
   // Takes ownership of the referenced held on *m by the caller of Add().

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -336,6 +336,10 @@ class MemTableList {
 
   size_t* current_memory_usage() { return &current_memory_usage_; }
 
+  // Returns the earliest log that possibly contain entries
+  // from one of the memtables of this memtable_list.
+  uint64_t EarliestLogContainingData();
+
   // Returns the min log containing the prep section after memtables listsed in
   // `memtables_to_flush` are flushed and their status is persisted in manifest.
   uint64_t PrecomputeMinLogContainingPrepSection(

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -269,7 +269,7 @@ class MemTableList {
       autovector<MemTable*>* to_delete, FSDirectory* db_directory,
       LogBuffer* log_buffer,
       std::list<std::unique_ptr<FlushJobInfo>>* committed_flush_jobs_info,
-      IOStatus* io_s, bool write_edits);
+      IOStatus* io_s, bool write_edits = true);
 
   // New memtables are inserted at the front of the list.
   // Takes ownership of the referenced held on *m by the caller of Add().

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -387,7 +387,7 @@ class Repairer {
     // Initialize per-column family memtables
     for (auto* cfd : *vset_.GetColumnFamilySet()) {
       cfd->CreateNewMemtable(*cfd->GetLatestMutableCFOptions(),
-                             kMaxSequenceNumber);
+                             kMaxSequenceNumber, cfd->GetLogNumber());
     }
     auto cf_mems = new ColumnFamilyMemTablesImpl(vset_.GetColumnFamilySet());
 

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -548,6 +548,11 @@ Status VersionEditHandler::ExtractInfoFromVersionEdit(ColumnFamilyData* cfd,
             "records NOT monotonically increasing");
       } else {
         cfd->SetLogNumber(edit.log_number_);
+        if (version_set_->db_options()->experimental_allow_mempurge &&
+            edit.log_number_ > 0 &&
+            (cfd->mem()->GetEarliestLogFileNumber() == 0)) {
+          cfd->mem()->SetEarliestLogFileNumber(edit.log_number_);
+        }
         version_edit_params_.SetLogNumber(edit.log_number_);
       }
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5639,7 +5639,7 @@ ColumnFamilyData* VersionSet::CreateColumnFamily(
   // GetLatestMutableCFOptions() is safe here without mutex since the
   // cfd is not available to client
   new_cfd->CreateNewMemtable(*new_cfd->GetLatestMutableCFOptions(),
-                             LastSequence(), new_cfd->GetLogNumber());
+                             LastSequence(), edit->log_number_);
   new_cfd->SetLogNumber(edit->log_number_);
   return new_cfd;
 }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4416,42 +4416,6 @@ Status VersionSet::ProcessManifestWrites(
 
 void VersionSet::WakeUpWaitingManifestWriters(const int num_cfds) {
   // wake up all the waiting writers
-  // while (true) {
-  //   ManifestWriter* ready = manifest_writers_.front();
-  //   manifest_writers_.pop_front();
-  //   bool need_signal = true;
-  //   for (const auto& w : writers) {
-  //     if (&w == ready) {
-  //       need_signal = false;
-  //       break;
-  //     }
-  //   }
-  //   ready->status = s;
-  //   ready->done = true;
-  //   if (ready->manifest_write_callback) {
-  //     (ready->manifest_write_callback)(s);
-  //   }
-  //   if (need_signal) {
-  //     ready->cv.Signal();
-  //   }
-  //   if (ready == last_writer) {
-  //     break;
-  //   }
-  // }
-  // if (!manifest_writers_.empty()) {
-  //   manifest_writers_.front()->cv.Signal();
-  // }
-  // int num_cfds = static_cast<int>(column_family_datas.size());
-
-  // while (!first_writer.done && &first_writer != manifest_writers_.front()) {
-  //   first_writer.cv.Wait();
-  // }
-  // if (first_writer.done) {
-  //   return;
-  // }
-  // for (int i = 0; i != num_cfds; ++i) {
-  //   manifest_writers_.pop_front();
-  // }
   // Notify new head of manifest write queue.
   (void)num_cfds;
   if (!manifest_writers_.empty()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4414,10 +4414,9 @@ Status VersionSet::ProcessManifestWrites(
   return s;
 }
 
-void VersionSet::WakeUpWaitingManifestWriters(const int num_cfds) {
+void VersionSet::WakeUpWaitingManifestWriters() {
   // wake up all the waiting writers
   // Notify new head of manifest write queue.
-  (void)num_cfds;
   if (!manifest_writers_.empty()) {
     manifest_writers_.front()->cv.Signal();
   }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5639,7 +5639,7 @@ ColumnFamilyData* VersionSet::CreateColumnFamily(
   // GetLatestMutableCFOptions() is safe here without mutex since the
   // cfd is not available to client
   new_cfd->CreateNewMemtable(*new_cfd->GetLatestMutableCFOptions(),
-                             LastSequence());
+                             LastSequence(), new_cfd->GetLogNumber());
   new_cfd->SetLogNumber(edit->log_number_);
   return new_cfd;
 }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4414,6 +4414,51 @@ Status VersionSet::ProcessManifestWrites(
   return s;
 }
 
+void VersionSet::WakeUpWaitingManifestWriters(const int num_cfds) {
+  // wake up all the waiting writers
+  // while (true) {
+  //   ManifestWriter* ready = manifest_writers_.front();
+  //   manifest_writers_.pop_front();
+  //   bool need_signal = true;
+  //   for (const auto& w : writers) {
+  //     if (&w == ready) {
+  //       need_signal = false;
+  //       break;
+  //     }
+  //   }
+  //   ready->status = s;
+  //   ready->done = true;
+  //   if (ready->manifest_write_callback) {
+  //     (ready->manifest_write_callback)(s);
+  //   }
+  //   if (need_signal) {
+  //     ready->cv.Signal();
+  //   }
+  //   if (ready == last_writer) {
+  //     break;
+  //   }
+  // }
+  // if (!manifest_writers_.empty()) {
+  //   manifest_writers_.front()->cv.Signal();
+  // }
+  // int num_cfds = static_cast<int>(column_family_datas.size());
+
+  // while (!first_writer.done && &first_writer != manifest_writers_.front()) {
+  //   first_writer.cv.Wait();
+  // }
+  // if (first_writer.done) {
+  //   return;
+  // }
+  // for (int i = 0; i != num_cfds; ++i) {
+  //   manifest_writers_.pop_front();
+  // }
+  // Notify new head of manifest write queue.
+  (void)num_cfds;
+  if (!manifest_writers_.empty()) {
+    manifest_writers_.front()->cv.Signal();
+  }
+}
+
 // 'datas' is grammatically incorrect. We still use this notation to indicate
 // that this variable represents a collection of column_family_data.
 Status VersionSet::LogAndApply(

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1014,7 +1014,7 @@ class VersionSet {
                                        FileSystem* fs,
                                        std::string* manifest_filename,
                                        uint64_t* manifest_file_number);
-  void WakeUpWaitingManifestWriters(const int num_cfds);
+  void WakeUpWaitingManifestWriters();
 
   // Recover the last saved descriptor from persistent storage.
   // If read_only == true, Recover() will not complain if some column families

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1014,6 +1014,7 @@ class VersionSet {
                                        FileSystem* fs,
                                        std::string* manifest_filename,
                                        uint64_t* manifest_file_number);
+  void WakeUpWaitingManifestWriters(const int num_cfds);
 
   // Recover the last saved descriptor from persistent storage.
   // If read_only == true, Recover() will not complain if some column families

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1160,6 +1160,15 @@ class VersionSet {
       if (min_log_num > num && !cfd->IsDropped()) {
         min_log_num = num;
       }
+      // If mempurge is activated, there may be an immutable memtable
+      // that has data not flushed to any SST file.
+      if (db_options_->experimental_allow_mempurge && !(cfd->IsEmpty()) &&
+          !(cfd->IsDropped())) {
+        num = cfd->imm()->EarliestLogContainingData();
+        if ((num > 0) && (min_log_num > num)) {
+          min_log_num = num;
+        }
+      }
     }
     return min_log_num;
   }
@@ -1176,6 +1185,15 @@ class VersionSet {
       // cfd->IsDropped() becomes true after the drop is persisted in MANIFEST.
       if (min_log_num > cfd->GetLogNumber() && !cfd->IsDropped()) {
         min_log_num = cfd->GetLogNumber();
+      }
+      // If mempurge is activated, there may be an immutable memtable
+      // that has data not flushed to any SST file.
+      if (db_options_->experimental_allow_mempurge && !(cfd->IsEmpty()) &&
+          !(cfd->IsDropped())) {
+        uint64_t num = cfd->imm()->EarliestLogContainingData();
+        if ((num > 0) && (min_log_num > num)) {
+          min_log_num = num;
+        }
       }
     }
     return min_log_num;


### PR DESCRIPTION
In this PR, `mempurge` is made compatible with the Write Ahead Log: in case of recovery, the DB is now capable of recovering the data that was "mempurged" and kept in the `imm()` list of immutable memtables. 
The twist was to add a uint64_t to the `memtable` struct to store the number of the earliest log file containing entries from the `memtable`. When a `Flush` operation is replaced with a `MemPurge`, the `VersionEdit` (which usually contains the new min log file number to pick up for recovery and the level 0 file path of the newly created SST file) is no longer appended to the manifest log, and every time the `deleteWal` method is called, a check is made on the list of immutable memtables. 
This PR also includes a unit test that verifies that no data is lost upon Reopening of the database when the mempurge feature is activated. This extensive unit test includes two column families, with valid data contained in the imm() at time of "crash"/reopening (recovery). 