### PR TITLE
Work around falsely reported data race on LRUHandle::flags

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -557,6 +557,9 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
     e->SetSecondaryCacheCompatible(true);
     e->info_.helper = helper;
   } else {
+#ifdef __SANITIZE_THREAD__
+    e->is_secondary_cache_compatible_for_tsan = false;
+#endif  // __SANITIZE_THREAD__
     e->info_.deleter = deleter;
   }
   e->charge = charge;


### PR DESCRIPTION
Summary: Some bits are mutated and read while holding a lock, other
immutable bits (esp. secondary cache compatibility) can be read by
arbitrary threads without holding a lock. AFAIK, this doesn't cause an
issue on any architecture we care about, because you will get some
legitimate version of the value that includes the initialization, as
long as synchronization guarantees the initialization happens before the
read.

I've only seen this in #8538 so far, but it should be fixed regardless.
Otherwise, we'll surely get these false reports again some time.

Test Plan: some local TSAN test runs and in CircleCI