### PR TITLE
Fix db_stress SecondaryCache creation using URI

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -119,7 +119,6 @@ StressTest::~StressTest() {
 
 std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
                                             int32_t num_shard_bits) {
-  ConfigOptions config_options;
   if (capacity <= 0) {
     return nullptr;
   }
@@ -137,8 +136,8 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
 #ifndef ROCKSDB_LITE
     std::shared_ptr<SecondaryCache> secondary_cache;
     if (!FLAGS_secondary_cache_uri.empty()) {
-      Status s = SecondaryCache::CreateFromString(
-          config_options, FLAGS_secondary_cache_uri, &secondary_cache);
+      Status s = ObjectRegistry::NewInstance()->NewSharedObject<SecondaryCache>(
+          FLAGS_secondary_cache_uri, &secondary_cache);
       if (secondary_cache == nullptr) {
         fprintf(stderr,
                 "No secondary cache registered matching string: %s status=%s\n",


### PR DESCRIPTION
Revert to the original way of creating a SecondaryCache object in db_stress. The FB implementation of SecondaryCache is compatible with the URI format ('cachelibwrapper://.*'), which does not work with ```SecondaryCache::CreateFromString```.  The latter expects an option string of the format 'id=xxx;opt1=yyy;" and requires the implementation to support ```ConfigureFromMap()```.