### PR TITLE
reimplement print single sst meta when dump manifest

### DIFF
--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -770,6 +770,8 @@ std::string VersionEdit::DebugString(bool hex_key) const {
     r.append("\n  AddFile: ");
     AppendNumberTo(&r, new_files_[i].first);
     r.append(" ");
+    r.append(f.DebugString(hex_key));
+    
     AppendNumberTo(&r, f.fd.GetNumber());
     r.append(" ");
     AppendNumberTo(&r, f.fd.GetFileSize());

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -273,6 +273,42 @@ struct FileMetaData {
     }
     return kUnknownFileCreationTime;
   }
+
+  std::string DebugString(bool hex_key) const {
+    std::string r;
+    AppendNumberTo(&r, this->fd.GetNumber());
+    r.push_back(':');
+    AppendNumberTo(&r, this->fd.GetFileSize());
+    r.append("[");
+    AppendNumberTo(&r, this->fd.smallest_seqno);
+    r.append(" .. ");
+    AppendNumberTo(&r, this->fd.largest_seqno);
+    r.append("]");
+    r.append("[");
+    r.append(this->smallest.DebugString(hex_key));
+    r.append(" .. ");
+    r.append(this->largest.DebugString(hex_key));
+    r.append("]");
+    if (this->oldest_blob_file_number != kInvalidBlobFileNumber) {
+      r.append(" blob_file:");
+      AppendNumberTo(&r, this->oldest_blob_file_number);
+    }
+    r.append(" oldest_ancester_time:");
+    AppendNumberTo(&r, this->oldest_ancester_time);
+    r.append(" file_creation_time:");
+    AppendNumberTo(&r, this->file_creation_time);
+    r.append(" file_checksum:");
+    r.append(this->file_checksum);
+    r.append(" file_checksum_func_name: ");
+    r.append(this->file_checksum_func_name);
+    if (this->temperature != Temperature::kUnknown) {
+      r.append(" temperature: ");
+      // Maybe change to human readable format whenthe feature becomes
+      // permanent
+      r.append(ToString(static_cast<int>(this->temperature)));
+    }
+    return r;
+  }
 };
 
 // A compressed copy of file meta data that just contain minimum data needed

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3671,23 +3671,7 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
     const std::vector<FileMetaData*>& files = storage_info_.files_[level];
     for (size_t i = 0; i < files.size(); i++) {
       r.push_back(' ');
-      AppendNumberTo(&r, files[i]->fd.GetNumber());
-      r.push_back(':');
-      AppendNumberTo(&r, files[i]->fd.GetFileSize());
-      r.append("[");
-      AppendNumberTo(&r, files[i]->fd.smallest_seqno);
-      r.append(" .. ");
-      AppendNumberTo(&r, files[i]->fd.largest_seqno);
-      r.append("]");
-      r.append("[");
-      r.append(files[i]->smallest.DebugString(hex));
-      r.append(" .. ");
-      r.append(files[i]->largest.DebugString(hex));
-      r.append("]");
-      if (files[i]->oldest_blob_file_number != kInvalidBlobFileNumber) {
-        r.append(" blob_file:");
-        AppendNumberTo(&r, files[i]->oldest_blob_file_number);
-      }
+      r.append(files[i]->DebugString(hex));
       if (print_stats) {
         r.append("(");
         r.append(ToString(
@@ -5011,7 +4995,8 @@ Status VersionSet::GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) {
 }
 
 Status VersionSet::DumpManifest(Options& options, std::string& dscname,
-                                bool verbose, bool hex, bool json) {
+                                bool verbose, bool hex, bool json,
+                                uint64_t sst_file_number) {
   // Open the specified manifest file.
   std::unique_ptr<SequentialFileReader> file_reader;
   Status s;
@@ -5038,7 +5023,7 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
     reporter.status = &s;
     log::Reader reader(nullptr, std::move(file_reader), &reporter,
                        true /* checksum */, 0 /* log_number */);
-    handler.Iterate(reader, &s);
+    handler.Iterate(reader, &s, sst_file_number);
   }
 
   return handler.status();

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1058,8 +1058,11 @@ class VersionSet {
   Status GetLiveFilesChecksumInfo(FileChecksumList* checksum_list);
 
   // printf contents (for debugging)
+  // If sst_file_number is > 0, only prints manifest info for specified SST file
+  // number
   Status DumpManifest(Options& options, std::string& manifestFileName,
-                      bool verbose, bool hex = false, bool json = false);
+                      bool verbose, bool hex = false, bool json = false,
+                      uint64_t sst_file_number = 0);
 
 #endif  // ROCKSDB_LITE
 

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -436,6 +436,7 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
   } else {
     iter->SeekToFirst();
   }
+  std::string prev_key = "";
   for (; iter->Valid(); iter->Next()) {
     Slice key = iter->key();
     Slice value = iter->value();
@@ -479,6 +480,16 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
                 blob_index.DebugString(output_hex_).c_str());
       }
     }
+    if (prev_key.size() != 0 &&
+        internal_comparator_.Compare(key, Slice(prev_key)) <= 0) {
+      InternalKey current, last;
+      current.DecodeFrom(key);
+      last.DecodeFrom(Slice(prev_key));
+      return Status::Corruption("current key " + current.DebugString(true) +
+                                " is not greater than last key " +
+                                last.DebugString(true));
+    }
+    prev_key = key.ToString(false);
   }
 
   read_num_ += i;

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1064,7 +1064,7 @@ void DBLoaderCommand::DoCommand() {
 namespace {
 
 void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
-                      bool json) {
+                      bool json, uint64_t sst_file_number = 0) {
   EnvOptions sopt;
   std::string dbname("dummy");
   std::shared_ptr<Cache> tc(NewLRUCache(options.max_open_files - 10,
@@ -1080,7 +1080,7 @@ void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
   VersionSet versions(dbname, &immutable_db_options, sopt, tc.get(), &wb, &wc,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                       /*db_session_id*/ "");
-  Status s = versions.DumpManifest(options, file, verbose, hex, json);
+  Status s = versions.DumpManifest(options, file, verbose, hex, json, sst_file_number);
   if (!s.ok()) {
     fprintf(stderr, "Error in processing file %s %s\n", file.c_str(),
             s.ToString().c_str());
@@ -1092,6 +1092,7 @@ void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
 const std::string ManifestDumpCommand::ARG_VERBOSE = "verbose";
 const std::string ManifestDumpCommand::ARG_JSON = "json";
 const std::string ManifestDumpCommand::ARG_PATH = "path";
+const std::string ManifestDumpCommand::ARG_NUMBER = "sst_file_number";
 
 void ManifestDumpCommand::Help(std::string& ret) {
   ret.append("  ");
@@ -1099,6 +1100,7 @@ void ManifestDumpCommand::Help(std::string& ret) {
   ret.append(" [--" + ARG_VERBOSE + "]");
   ret.append(" [--" + ARG_JSON + "]");
   ret.append(" [--" + ARG_PATH + "=<path_to_manifest_file>]");
+  ret.append(" [--" + ARG_NUMBER + "=<sst_file_number>]");
   ret.append("\n");
 }
 
@@ -1106,12 +1108,13 @@ ManifestDumpCommand::ManifestDumpCommand(
     const std::vector<std::string>& /*params*/,
     const std::map<std::string, std::string>& options,
     const std::vector<std::string>& flags)
-    : LDBCommand(
-          options, flags, false,
-          BuildCmdLineOptions({ARG_VERBOSE, ARG_PATH, ARG_HEX, ARG_JSON})),
+    : LDBCommand(options, flags, false,
+                 BuildCmdLineOptions(
+                     {ARG_VERBOSE, ARG_PATH, ARG_HEX, ARG_JSON, ARG_NUMBER})),
       verbose_(false),
       json_(false),
-      path_("") {
+      path_(""),
+      sst_file_number_(0) {
   verbose_ = IsFlagPresent(flags, ARG_VERBOSE);
   json_ = IsFlagPresent(flags, ARG_JSON);
 
@@ -1122,6 +1125,11 @@ ManifestDumpCommand::ManifestDumpCommand(
     if (path_.empty()) {
       exec_state_ = LDBCommandExecuteResult::Failed("--path: missing pathname");
     }
+  }
+
+  itr = options.find(ARG_NUMBER);
+  if (itr != options.end()) {
+    sst_file_number_ = ParseUint64(itr->second);
   }
 }
 
@@ -1194,7 +1202,7 @@ void ManifestDumpCommand::DoCommand() {
     fprintf(stdout, "Processing Manifest file %s\n", manifestfile.c_str());
   }
 
-  DumpManifestFile(options_, manifestfile, verbose_, is_key_hex_, json_);
+  DumpManifestFile(options_, manifestfile, verbose_, is_key_hex_, json_, sst_file_number_);
 
   if (verbose_) {
     fprintf(stdout, "Processing Manifest file %s done\n", manifestfile.c_str());

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -184,10 +184,12 @@ class ManifestDumpCommand : public LDBCommand {
   bool verbose_;
   bool json_;
   std::string path_;
+  uint64_t sst_file_number_;
 
   static const std::string ARG_VERBOSE;
   static const std::string ARG_JSON;
   static const std::string ARG_PATH;
+  static const std::string ARG_NUMBER;
 };
 
 class FileChecksumDumpCommand : public LDBCommand {


### PR DESCRIPTION
original PR https://github.com/facebook/rocksdb/pull/6716

Add --sst_file_number field for manifest_dump command to print the specified sst file meta. By the way, add key order check for sst_dump.

Usage:
$ ./ldb --db=/data3/zbk/kv4/deploy/data/db --hex manifest_dump --sst_file_number=63
```
--------------- Column family "write"  (ID 2) --------------
63:132906243[3555338 .. 3555338]['7A311B40EFCC2CB4C5911ECF3937D728DED26AE53FA5E61BE04F23F2BE54EACC73' seq:3555
338, type:1 .. '7A313030302E25CD5F57252E' seq:3555338, type:1] oldest_ancester_time:0 at level 0
```

Signed-off-by: Xintao <hunterlxt@live.com>