### PR TITLE
Add overwrite ratio to db_bench --benchmark=updaterandom.

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -392,9 +392,11 @@ DEFINE_int64(seed, 0, "Seed base for random number generators. "
 
 DEFINE_int32(threads, 1, "Number of concurrent threads to run.");
 
-DEFINE_int32(num_overwrites, -1, "Percent of overwrites in benchmark.");
+DEFINE_int32(num_overwrites, -1,
+             "Number of overwrites in UpdateRandom benchmark.");
 
-DEFINE_uint64(overwrite_sample_size, 100, "Size of overwrite sample.");
+DEFINE_uint64(overwrite_sample_size, 100,
+              "Size of overwrite sample used in UpdateRandom benchmark.");
 
 DEFINE_int32(duration, 0, "Time in seconds for the random-ops tests to run."
              " When 0 then num & reads determine the test duration");

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -392,12 +392,6 @@ DEFINE_int64(seed, 0, "Seed base for random number generators. "
 
 DEFINE_int32(threads, 1, "Number of concurrent threads to run.");
 
-DEFINE_int32(num_overwrites, -1,
-             "Number of overwrites in UpdateRandom benchmark.");
-
-DEFINE_uint64(overwrite_sample_size, 100,
-              "Size of overwrite sample used in UpdateRandom benchmark.");
-
 DEFINE_int32(duration, 0, "Time in seconds for the random-ops tests to run."
              " When 0 then num & reads determine the test duration");
 
@@ -901,6 +895,20 @@ DEFINE_int64(max_num_range_tombstones, 0,
 
 DEFINE_bool(expand_range_tombstones, false,
             "Expand range tombstone into sequential regular tombstones.");
+
+DEFINE_int32(num_overwrites, -1,
+             "Number of overwrites in UpdateRandom benchmark. This "
+             "number is used in combination with num to create a ratio r. "
+             "Then, each new write operation has a probability r of "
+             "being an overwrite.");
+
+DEFINE_uint64(overwrite_sample_size, 100,
+              "Size of overwrite sample used in UpdateRandom benchmark. "
+              "Used only when num_overwrites flag is set by user. "
+              "Whenever an overwrite is performed, a key is picked from "
+              "the overwrite sample (~reservoir of inserted keys). Conversely, "
+              "for each pure write, the newly inserted key is randomly added "
+              "to this reservoir of fixed size.");
 
 #ifndef ROCKSDB_LITE
 // Transactions Options


### PR DESCRIPTION
Add a `num_overwrites` and a `overwrite_sample_size` flag to `db_bench`.
Add the possibility of performing an `updaterandom` benchmark with a fixed overwrite ratio _p_ (p=`num_overwrites`/`num`).
For each write operation, there is a probability _p_ that the write is an overwrite. 
When an overwrite is decided, a previously inserted key is chosen from a key sample (akin to a reservoir of existing keys). The size of the sample is set to be `overwrite_sample_size`.
When a pure write is decided, the key is inserted into the DB and randomly inserted into the key sample as well (the sample has a fixed size `overwrite_sample_size`).
The key sample/reservoir is used so that the user can decide if the overwrite are mostly targeting recently inserted keys (when `overwrite_sample_size` is small compared to num), or can target keys inserted "a long time ago" (when `overwrite_sample_size` is comparable to num).
No unit test specifically added.