### PR TITLE
[db_stress] Cleanup cf handlers before deleting db

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2568,6 +2568,7 @@ void StressTest::Open() {
               }
               column_families_.clear();
               delete db_;
+              db_ = nullptr;
             }
           }
           if (!s.ok()) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2563,6 +2563,10 @@ void StressTest::Open() {
             s = static_cast_with_check<DBImpl>(db_->GetRootDB())
                     ->TEST_WaitForCompact(true);
             if (!s.ok()) {
+              for (auto cf : column_families_) {
+                delete cf;
+              }
+              column_families_.clear();
               delete db_;
             }
           }


### PR DESCRIPTION
Delete column family handlers before deleting db to avoid `last_ref`
assert.

Test Plan: Inject compaction test in db_stress test