### PR TITLE
Checkpoint dir options fix

### DIFF
--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -45,8 +45,8 @@ class Checkpoint {
   virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
                                   uint64_t log_size_for_flush = 0,
                                   uint64_t* sequence_number_ptr = nullptr,
-                                  const std::string &db_log_dir = "",
-                                  const std::string &wal_dir = "");
+                                  const std::string& db_log_dir = "",
+                                  const std::string& wal_dir = "");
 
   // Exports all live SST files of a specified Column Family onto export_dir,
   // returning SST files information in metadata.

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -40,9 +40,13 @@ class Checkpoint {
   // sequence_number_ptr: if it is not nullptr, the value it points to will be
   // set to the DB's sequence number. The default value of this parameter is
   // nullptr.
+  // db_log_dir / wal_dir: override db_log_dir or wal_dir option in the
+  // snapshot. If empty, checkpoint_dir will be used.
   virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
                                   uint64_t log_size_for_flush = 0,
-                                  uint64_t* sequence_number_ptr = nullptr);
+                                  uint64_t* sequence_number_ptr = nullptr,
+                                  const std::string &db_log_dir = "",
+                                  const std::string &wal_dir = "");
 
   // Exports all live SST files of a specified Column Family onto export_dir,
   // returning SST files information in metadata.

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -81,8 +81,8 @@ Status Checkpoint::ExportColumnFamily(
 Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
                                         uint64_t log_size_for_flush,
                                         uint64_t* sequence_number_ptr,
-                                        const std::string &db_log_dir,
-                                        const std::string &wal_dir) {
+                                        const std::string& db_log_dir,
+                                        const std::string& wal_dir) {
   DBOptions db_options = db_->GetDBOptions();
 
   Status s = db_->GetEnv()->FileExists(checkpoint_dir);

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -663,11 +663,13 @@ Status CheckpointImpl::CopyOptionsFile(const std::string& src_file,
   src_db_options.db_log_dir = db_log_dir;
   src_db_options.wal_dir = wal_dir;
 
-  std::vector<std::string> src_cf_names(src_cf_descs.size());
-  std::vector<ColumnFamilyOptions> src_cf_opts(src_cf_descs.size());
-  for (size_t i = 0; i < src_cf_descs.size(); i++) {
-    src_cf_names[i] = src_cf_descs[i].name;
-    src_cf_opts[i] = src_cf_descs[i].options;
+  std::vector<std::string> src_cf_names;
+  std::vector<ColumnFamilyOptions> src_cf_opts;
+  src_cf_names.reserve(src_cf_descs.size());
+  src_cf_opts.reserve(src_cf_descs.size());
+  for (ColumnFamilyDescriptor desc : src_cf_descs) {
+    src_cf_names.push_back(desc.name);
+    src_cf_opts.push_back(desc.options);
   }
 
   return PersistRocksDBOptions(src_db_options, src_cf_names, src_cf_opts,

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -214,7 +214,8 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
   }
   if (s.ok()) {
     std::unique_ptr<Directory> checkpoint_directory;
-    s = db_->GetEnv()->NewDirectory(parsed_checkpoint_dir, &checkpoint_directory);
+    s = db_->GetEnv()->NewDirectory(parsed_checkpoint_dir,
+                                    &checkpoint_directory);
     if (s.ok() && checkpoint_directory != nullptr) {
       s = checkpoint_directory->Fsync();
     }

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -42,8 +42,8 @@ Status Checkpoint::Create(DB* db, Checkpoint** checkpoint_ptr) {
 Status Checkpoint::CreateCheckpoint(const std::string& /*checkpoint_dir*/,
                                     uint64_t /*log_size_for_flush*/,
                                     uint64_t* /*sequence_number_ptr*/,
-                                    const std::string &/*db_log_dir*/,
-                                    const std::string &/*wal_dir*/) {
+                                    const std::string& /*db_log_dir*/,
+                                    const std::string& /*wal_dir*/) {
   return Status::NotSupported("");
 }
 

--- a/utilities/checkpoint/checkpoint_impl.h
+++ b/utilities/checkpoint/checkpoint_impl.h
@@ -20,7 +20,9 @@ class CheckpointImpl : public Checkpoint {
 
   Status CreateCheckpoint(const std::string& checkpoint_dir,
                           uint64_t log_size_for_flush,
-                          uint64_t* sequence_number_ptr) override;
+                          uint64_t* sequence_number_ptr,
+                          const std::string &db_log_dir,
+                          const std::string &wal_dir) override;
 
   Status ExportColumnFamily(ColumnFamilyHandle* handle,
                             const std::string& export_dir,
@@ -56,6 +58,11 @@ class CheckpointImpl : public Checkpoint {
       std::function<Status(const std::string& src_dirname,
                            const std::string& fname)>
           copy_file_cb);
+
+  Status CopyOptionsFile(const std::string& src_file,
+                         const std::string& target_file,
+                         const std::string& db_log_dir,
+                         const std::string& wal_dir);
 
  private:
   DB* db_;

--- a/utilities/checkpoint/checkpoint_impl.h
+++ b/utilities/checkpoint/checkpoint_impl.h
@@ -21,8 +21,8 @@ class CheckpointImpl : public Checkpoint {
   Status CreateCheckpoint(const std::string& checkpoint_dir,
                           uint64_t log_size_for_flush,
                           uint64_t* sequence_number_ptr,
-                          const std::string &db_log_dir,
-                          const std::string &wal_dir) override;
+                          const std::string& db_log_dir,
+                          const std::string& wal_dir) override;
 
   Status ExportColumnFamily(ColumnFamilyHandle* handle,
                             const std::string& export_dir,

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -14,16 +14,21 @@
 #ifndef OS_WIN
 #include <unistd.h>
 #endif
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include "db/db_impl/db_impl.h"
 #include "file/file_util.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
+#include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
+#include "rocksdb/utilities/options_util.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
@@ -900,6 +905,150 @@ TEST_F(CheckpointTest, CheckpointReadOnlyDBWithMultipleColumnFamilies) {
   }
   snapshot_handles.clear();
   delete snapshot_db;
+}
+
+TEST_F(CheckpointTest, CheckpointWithOptionsDirsTest) {
+  // If the checkpoint and the source db share the same wal_dir, files may be
+  // corrupted if both write to or delete from the same wal_dir. db_log_dir
+  // should also be updated during checkpointing, but it is less important since
+  // log files are not copied or linked to the checkpoint.
+
+  // 8 bytes key, 1 kB record, 4 kB MemTable. Each batch should trigger 25
+  // flushes
+  const int key_len = 8;
+  const int value_len = 1016;
+  const size_t num_keys = 100;
+  const size_t buffer_size = 4096;
+
+  std::string value(value_len, ' ');
+
+  auto intToKey = [](size_t i) {
+    std::stringstream ss;
+    ss << std::setw(key_len) << std::setfill('0') << i;
+    return ss.str();
+  };
+
+  std::vector<std::string> dirs1 = {"", "", "", ""};
+  std::vector<std::string> dirs2 = {"/logs", "/wal", "", ""};
+  std::vector<std::string> dirs3 = {"/logs", "/wal", "/logs", "/wal"};
+
+  for (auto dirs : {dirs1, dirs2, dirs3}) {
+    std::string src_log_dir = dirs[0].empty() ? "" : dbname_ + dirs[0];
+    std::string src_wal_dir = dirs[1].empty() ? "" : dbname_ + dirs[1];
+    std::string snap_log_dir = dirs[2].empty() ? "" : snapshot_name_ + dirs[2];
+    std::string snap_wal_dir = dirs[3].empty() ? "" : snapshot_name_ + dirs[3];
+
+    Options src_opts = CurrentOptions();
+    WriteOptions w_opts;
+    ReadOptions r_opts;
+    DB* snapshotDB;
+    Checkpoint* checkpoint;
+
+    src_opts = CurrentOptions();
+    delete db_;
+    db_ = nullptr;
+    ASSERT_OK(DestroyDB(dbname_, src_opts));
+
+    // Create a database
+    src_opts.create_if_missing = true;
+    src_opts.write_buffer_size = buffer_size;
+    src_opts.OptimizeUniversalStyleCompaction(buffer_size);
+    src_opts.db_log_dir = src_log_dir;
+    src_opts.wal_dir = src_wal_dir;
+
+    ASSERT_OK(DB::Open(src_opts, dbname_, &db_));
+
+    // Write to src db
+    for (size_t i = 1; i <= num_keys; i++) {
+      ASSERT_OK(db_->Put(w_opts, intToKey(i), value));
+    }
+
+    // Take a snapshot
+    ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+    ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_, 0, nullptr,
+                                           snap_log_dir, snap_wal_dir));
+
+    // Write to src db again
+    for (size_t i = num_keys + 1; i <= num_keys * 2; i++) {
+      ASSERT_OK(db_->Put(w_opts, intToKey(i), value));
+    }
+
+    std::string result;
+    ASSERT_OK(db_->Get(r_opts, intToKey(num_keys), &result));
+    ASSERT_OK(db_->Get(r_opts, intToKey(num_keys * 2), &result));
+
+    // Open snapshot with its own options
+    DBOptions snap_opts;
+    std::vector<ColumnFamilyDescriptor> snap_cfs;
+    ASSERT_OK(LoadLatestOptions(ConfigOptions(), snapshot_name_, &snap_opts,
+                                &snap_cfs));
+
+    ASSERT_TRUE(snap_opts.db_log_dir == snap_log_dir);
+    if (snap_wal_dir.empty()) {
+      ASSERT_TRUE(snap_opts.wal_dir == snapshot_name_);
+    } else {
+      ASSERT_TRUE(snap_opts.wal_dir == snap_wal_dir);
+    }
+
+    std::vector<ColumnFamilyHandle*> handles;
+    ASSERT_OK(
+        DB::Open(snap_opts, snapshot_name_, snap_cfs, &handles, &snapshotDB));
+    for (ColumnFamilyHandle* handle : handles) {
+      delete handle;
+    }
+    handles.clear();
+
+    ASSERT_OK(snapshotDB->Get(r_opts, intToKey(num_keys), &result));
+    ASSERT_TRUE(
+        snapshotDB->Get(r_opts, intToKey(num_keys * 2), &result).IsNotFound());
+
+    // Write to snapshot
+    for (size_t i = num_keys * 2 + 1; i <= num_keys * 3; i++) {
+      ASSERT_OK(snapshotDB->Put(w_opts, intToKey(i), value));
+    }
+
+    ASSERT_OK(snapshotDB->Get(r_opts, intToKey(num_keys * 3), &result));
+    ASSERT_TRUE(db_->Get(r_opts, intToKey(num_keys * 3), &result).IsNotFound());
+
+    // Close and reopen the snapshot
+    delete snapshotDB;
+    ASSERT_OK(
+        DB::Open(snap_opts, snapshot_name_, snap_cfs, &handles, &snapshotDB));
+    for (ColumnFamilyHandle* handle : handles) {
+      delete handle;
+    }
+    handles.clear();
+    ASSERT_TRUE(
+        snapshotDB->Get(r_opts, intToKey(num_keys * 2), &result).IsNotFound());
+    ASSERT_OK(snapshotDB->Get(r_opts, intToKey(num_keys * 3), &result));
+
+    delete snapshotDB;
+
+    // Close and reopen the source db
+    delete db_;
+    src_opts.create_if_missing = false;
+    ASSERT_OK(DB::Open(src_opts, dbname_, &db_));
+    ASSERT_OK(db_->Get(r_opts, intToKey(num_keys * 2), &result));
+    ASSERT_TRUE(db_->Get(r_opts, intToKey(num_keys * 3), &result).IsNotFound());
+    delete db_;
+
+    // Delete the snapshot
+    Options del_opts;
+    del_opts.db_log_dir = snap_opts.db_log_dir;
+    del_opts.wal_dir = snap_opts.wal_dir;
+    ASSERT_OK(DestroyDB(snapshot_name_, del_opts));
+
+    // Reopen the source db again
+    ASSERT_OK(DB::Open(src_opts, dbname_, &db_));
+
+    delete db_;
+    db_ = nullptr;
+    ASSERT_OK(DestroyDB(dbname_, src_opts));
+
+    dbname_ = test::PerThreadDBPath(env_, "db_test");
+
+    delete checkpoint;
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Originally the 2 options `db_log_dir` and `wal_dir` will be reused in a snapshot db since the options files are just copied. By default, if `wal_dir` was not set when a db was created, it is set to the db's dir. Therefore, the snapshot db will use the same WAL dir. If both the original db and the snapshot db write to or delete from the WAL dir, one may modify or delete files which belong to the other. The same applies to `db_log_dir` as well, but as info log files are not copied or linked, it is simpler for this option.

2 arguments are added to `Checkpoint::CreateCheckpoint()`, allowing to override these 2 options.

`wal_dir`:  If the function argument `wal_dir` is empty, or set to the original db location, or the checkpoint location, the snapshot's `wal_dir` option will be updated to the checkpoint location. Otherwise, the absolute path specified in the argument will be used. During checkpointing, live WAL files will be copied or linked the new location, instead of the current WAL dir specified in the original db.

`db_log_dir`: Same as `wal_dir`, but no files will be copied or linked.

A new unit test was added: `CheckpointTest.CheckpointWithOptionsDirsTest`.