### PR TITLE
Fix GetSortedWalFiles() IO error during file deletion

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,9 +2,15 @@
 ## Unreleased
 ### Bug Fixes
 * If the primary's CURRENT file is missing or inaccessible, the secondary instance should not hang repeatedly trying to switch to a new MANIFEST. It should instead return the error code encountered while accessing the file.
+* Fix `GetSortedWalFiles()` may return IO error during WAL file deletion.
+
 ### New Features
 * Made the EventListener extend the Customizable class.
 * EventListeners that have a non-empty Name() and that are registered with the ObjectRegistry can now be serialized to/from the OPTIONS file.
+
+### Performance Improvements
+* Try to avoid updating DBOptions if `SetDBOptions()` does not change any option value.
+
 ## 6.23.0 (2021-07-16)
 ### Behavior Changes
 * Obsolete keys in the bottommost level that were preserved for a snapshot will now be cleaned upon snapshot release in all cases. This form of compaction (snapshot release triggered compaction) previously had an artificial limitation that multiple tombstones needed to be present.
@@ -27,9 +33,6 @@
 ### Public API change
 * Added APIs to the Customizable class to allow developers to create their own Customizable classes.  Created the utilities/customizable_util.h file to contain helper methods for developing new Customizable classes.
 * Change signature of SecondaryCache::Name().  Make SecondaryCache customizable and add SecondaryCache::CreateFromString method.
-
-### Performance Improvements
-* Try to avoid updating DBOptions if `SetDBOptions()` does not change any option value.
 
 ## 6.22.0 (2021-06-18)
 ### Behavior Changes

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1653,11 +1653,10 @@ TEST_F(DBWALTest, WalCleanupConflictGetWal) {
 
   FlushOptions flush_opts;
   flush_opts.wait = false;
-  db_->Flush(flush_opts);
+  ASSERT_OK(db_->Flush(flush_opts));
 
   VectorLogPtr log_files;
-  auto s = db_->GetSortedWalFiles(log_files);
-  ASSERT_OK(s);
+  ASSERT_OK(db_->GetSortedWalFiles(log_files));
   ASSERT_EQ(0, log_files.size());
 }
 

--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -314,18 +314,12 @@ Status WalManager::GetSortedWalsOfType(const std::string& path,
 
       uint64_t size_bytes;
       s = env_->GetFileSize(LogFileName(path, number), &size_bytes);
-      // re-try in case the alive log file has been moved to archive.
+      // re-try in case the alive WAL file has been moved to archive.
       if (!s.ok() && log_type == kAliveLogFile) {
         std::string archived_file = ArchivedLogFileName(path, number);
-        s = env_->FileExists(archived_file);
-        if (s.ok()) {
-          s = env_->GetFileSize(archived_file, &size_bytes);
-          if (!s.ok() && env_->FileExists(archived_file).IsNotFound()) {
-            // oops, the file just got deleted from archived dir! move on
-            continue;
-          }
-        } else if (s.IsNotFound()) {
-          // Cannot find the WAL file in both WAL_dir and archived dir, skip it
+        s = env_->GetFileSize(archived_file, &size_bytes);
+        if (!s.ok()) {
+          // Cannot get the WAL file size in both WAL_dir and archived dir, skip
           continue;
         }
       }

--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -324,6 +324,10 @@ Status WalManager::GetSortedWalsOfType(const std::string& path,
             s = Status::OK();
             continue;
           }
+        } else {
+          // the file just got deleted from WAL folder, skip it
+          s = Status::OK();
+          continue;
         }
       }
       if (!s.ok()) {

--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -321,12 +321,10 @@ Status WalManager::GetSortedWalsOfType(const std::string& path,
           s = env_->GetFileSize(archived_file, &size_bytes);
           if (!s.ok() && env_->FileExists(archived_file).IsNotFound()) {
             // oops, the file just got deleted from archived dir! move on
-            s = Status::OK();
             continue;
           }
         } else {
           // the file just got deleted from WAL folder, skip it
-          s = Status::OK();
           continue;
         }
       }


### PR DESCRIPTION
Summary: `GetSortedWalFiles()` may return IO error if WAL files are
deleting. Error message:
`IO error: No such file or directory: while stat a file for size: ...`
It is caused by race condition between files purging and WalManager
getting wals.

Also correct HISTORY for #8518.

Test Plan: Added an unittest to reproduce