### PR TITLE
Add MultiGet to replay

### DIFF
--- a/trace_replay/trace_replay.h
+++ b/trace_replay/trace_replay.h
@@ -268,6 +268,10 @@ class Replayer {
   // (SeekForPrev) based on the trace records.
   static void BGWorkIterSeekForPrev(void* arg);
 
+  // The background function for MultiThreadReplay to execute MultiGet based on
+  // the trace records
+  static void BGWorkMultiGet(void* arg);
+
   DBImpl* db_;
   Env* env_;
   std::unique_ptr<TraceReader> trace_reader_;


### PR DESCRIPTION
When the trace contains the MultiGet record, with this PR, it can replay the MultiGet.

test plan: make check and replay the real trace.