### PR TITLE
Enhanced heuristic for experimental mempurge

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3039,11 +3039,11 @@ void rocksdb_options_set_experimental_mempurge_policy(rocksdb_options_t* opt,
   switch (v) {
     case 0:
       opt->rep.experimental_mempurge_policy =
-          ROCKSDB_NAMESPACE::Options::ALTERNATE;
+          ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALTERNATE;
       break;
     case 1:
       opt->rep.experimental_mempurge_policy =
-          ROCKSDB_NAMESPACE::Options::ALWAYS;
+          ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALWAYS;
       break;
     default:
       assert(0);

--- a/db/c.cc
+++ b/db/c.cc
@@ -3034,6 +3034,26 @@ void rocksdb_options_set_experimental_allow_mempurge(rocksdb_options_t* opt,
   opt->rep.experimental_allow_mempurge = v;
 }
 
+void rocksdb_options_set_experimental_mempurge_policy(rocksdb_options_t* opt,
+                                                      int v) {
+  switch (v) {
+    case 0:
+      opt->rep.experimental_mempurge_policy =
+          ROCKSDB_NAMESPACE::Options::ALTERNATE;
+      break;
+    case 1:
+      opt->rep.experimental_mempurge_policy =
+          ROCKSDB_NAMESPACE::Options::ALWAYS;
+      break;
+    case 2:
+      opt->rep.experimental_mempurge_policy =
+          ROCKSDB_NAMESPACE::Options::RANDOM;
+      break;
+    default:
+      assert(0);
+  }
+}
+
 void rocksdb_options_set_access_hint_on_compaction_start(
     rocksdb_options_t* opt, int v) {
   switch(v) {

--- a/db/c.cc
+++ b/db/c.cc
@@ -3039,11 +3039,11 @@ void rocksdb_options_set_experimental_mempurge_policy(rocksdb_options_t* opt,
   switch (v) {
     case 0:
       opt->rep.experimental_mempurge_policy =
-          ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALTERNATE;
+          ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
       break;
     case 1:
       opt->rep.experimental_mempurge_policy =
-          ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALWAYS;
+          ROCKSDB_NAMESPACE::MemPurgePolicy::kAlways;
       break;
     default:
       assert(0);

--- a/db/c.cc
+++ b/db/c.cc
@@ -3045,10 +3045,6 @@ void rocksdb_options_set_experimental_mempurge_policy(rocksdb_options_t* opt,
       opt->rep.experimental_mempurge_policy =
           ROCKSDB_NAMESPACE::Options::ALWAYS;
       break;
-    case 2:
-      opt->rep.experimental_mempurge_policy =
-          ROCKSDB_NAMESPACE::Options::RANDOM;
-      break;
     default:
       assert(0);
   }

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -695,6 +695,7 @@ TEST_F(DBFlushTest, MemPurgeBasic) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
+  options.experimental_mempurge_policy = DBOptions::MemPurgePolicy::ALWAYS;
   ASSERT_OK(TryReopen(options));
   uint32_t mempurge_count = 0;
   uint32_t sst_count = 0;
@@ -808,7 +809,7 @@ TEST_F(DBFlushTest, MemPurgeBasic) {
   // Assert that at least one flush to storage has been performed
   ASSERT_GT(sst_count, EXPECTED_SST_COUNT);
   // (which will consequently increase the number of mempurges recorded too).
-  ASSERT_EQ(mempurge_count, mempurge_count_record);
+  ASSERT_GE(mempurge_count, mempurge_count_record);
 
   // Assert that there is no data corruption, even with
   // a flush to storage.
@@ -842,6 +843,7 @@ TEST_F(DBFlushTest, MemPurgeDeleteAndDeleteRange) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
+  options.experimental_mempurge_policy = DBOptions::MemPurgePolicy::ALWAYS;
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1045,6 +1047,7 @@ TEST_F(DBFlushTest, MemPurgeAndCompactionFilter) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
+  options.experimental_mempurge_policy = DBOptions::MemPurgePolicy::ALWAYS;
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1116,10 +1119,11 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
   options.inplace_update_support = false;
   options.allow_concurrent_memtable_write = true;
 
-  // Enforce size of a single MemTable to 1MB.
+  // Enforce size of a single MemTable to 128KB.
   options.write_buffer_size = 128 << 10;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
+  options.experimental_mempurge_policy = DBOptions::MemPurgePolicy::ALWAYS;
   ASSERT_OK(TryReopen(options));
 
   const size_t KVSIZE = 10;
@@ -1158,7 +1162,7 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
     // more than would fit in maximum allowed memtables.
     Random rnd(719);
     const size_t NUM_REPEAT = 100;
-    const size_t RAND_KEY_LENGTH = 8192;
+    const size_t RAND_KEY_LENGTH = 4096;
     const size_t RAND_VALUES_LENGTH = 1024;
     std::vector<std::string> values_default(KVSIZE), values_pikachu(KVSIZE);
 
@@ -1235,7 +1239,10 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
     const uint32_t EXPECTED_SST_COUNT = 0;
 
     EXPECT_GE(mempurge_count, EXPECTED_MIN_MEMPURGE_COUNT);
-    EXPECT_EQ(sst_count, EXPECTED_SST_COUNT);
+    if (options.experimental_mempurge_policy ==
+        DBOptions::MemPurgePolicy::ALWAYS) {
+      EXPECT_EQ(sst_count, EXPECTED_SST_COUNT);
+    }
 
     ReopenWithColumnFamilies({"default", "pikachu"}, options);
     // Check that there was no data corruption anywhere,

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -695,7 +695,7 @@ TEST_F(DBFlushTest, MemPurgeBasic) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = DBOptions::MemPurgePolicy::ALWAYS;
+  options.experimental_mempurge_policy = MemPurgePolicy::kAlways;
   ASSERT_OK(TryReopen(options));
   uint32_t mempurge_count = 0;
   uint32_t sst_count = 0;
@@ -843,7 +843,7 @@ TEST_F(DBFlushTest, MemPurgeDeleteAndDeleteRange) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = DBOptions::MemPurgePolicy::ALWAYS;
+  options.experimental_mempurge_policy = MemPurgePolicy::kAlways;
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1047,7 +1047,7 @@ TEST_F(DBFlushTest, MemPurgeAndCompactionFilter) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = DBOptions::MemPurgePolicy::ALWAYS;
+  options.experimental_mempurge_policy = MemPurgePolicy::kAlways;
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1123,7 +1123,7 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
   options.write_buffer_size = 128 << 10;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = DBOptions::MemPurgePolicy::ALWAYS;
+  options.experimental_mempurge_policy = MemPurgePolicy::kAlways;
   ASSERT_OK(TryReopen(options));
 
   const size_t KVSIZE = 10;
@@ -1239,8 +1239,7 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
     const uint32_t EXPECTED_SST_COUNT = 0;
 
     EXPECT_GE(mempurge_count, EXPECTED_MIN_MEMPURGE_COUNT);
-    if (options.experimental_mempurge_policy ==
-        DBOptions::MemPurgePolicy::ALWAYS) {
+    if (options.experimental_mempurge_policy == MemPurgePolicy::kAlways) {
       EXPECT_EQ(sst_count, EXPECTED_SST_COUNT);
     }
 

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -603,7 +603,9 @@ Status FlushJob::MemPurge() {
   const uint64_t micros = clock_->NowMicros() - start_micros;
   const uint64_t cpu_micros = clock_->CPUNanos() / 1000 - start_cpu_micros;
   ROCKS_LOG_INFO(db_options_.info_log,
-                 "[%s] [JOB %d] Mempurge lasted %zu microseconds %zu cpu "
+                 "[%s] [JOB %d] Mempurge lasted %" PRIu64
+                 " microseconds %" PRIu64
+                 " cpu "
                  "microseconds. Status is %s ok. Perc capacity: %f\n",
                  cfd_->GetName().c_str(), job_context_->job_id, micros,
                  cpu_micros, s.ok() ? "" : "not",
@@ -614,10 +616,10 @@ Status FlushJob::MemPurge() {
 }
 
 bool FlushJob::MemPurgeDecider() {
-  DBOptions::MemPurgePolicy policy = db_options_.experimental_mempurge_policy;
-  if (policy == DBOptions::MemPurgePolicy::ALWAYS) {
+  MemPurgePolicy policy = db_options_.experimental_mempurge_policy;
+  if (policy == MemPurgePolicy::kAlways) {
     return true;
-  } else if (policy == DBOptions::MemPurgePolicy::ALTERNATE) {
+  } else if (policy == MemPurgePolicy::kAlternate) {
     // Note: if at least one of the flushed memtables is
     // an output of a previous mempurge process, then flush
     // to storage.
@@ -816,10 +818,11 @@ Status FlushJob::WriteLevel0Table() {
   stats.cpu_micros = clock_->CPUNanos() / 1000 - start_cpu_micros;
   const uint64_t micros = clock_->NowMicros() - start_micros;
   const uint64_t cpu_micros = clock_->CPUNanos() / 1000 - start_cpu_micros;
-  ROCKS_LOG_INFO(
-      db_options_.info_log,
-      "[%s] [JOB %d] Flush lasted %zu microseconds %zu cpu microseconds.\n",
-      cfd_->GetName().c_str(), job_context_->job_id, micros, cpu_micros);
+  ROCKS_LOG_INFO(db_options_.info_log,
+                 "[%s] [JOB %d] Flush lasted %" PRIu64 " microseconds %" PRIu64
+                 " cpu microseconds.\n",
+                 cfd_->GetName().c_str(), job_context_->job_id, micros,
+                 cpu_micros);
   if (has_output) {
     stats.bytes_written = meta_.fd.GetFileSize();
     stats.num_output_files = 1;

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -603,7 +603,7 @@ Status FlushJob::MemPurge() {
   const uint64_t micros = clock_->NowMicros() - start_micros;
   const uint64_t cpu_micros = clock_->CPUNanos() / 1000 - start_cpu_micros;
   ROCKS_LOG_INFO(db_options_.info_log,
-                 "[%s] [JOB %d] Mempurge lasted %lu microseconds %lu cpu "
+                 "[%s] [JOB %d] Mempurge lasted %zu microseconds %zu cpu "
                  "microseconds. Status is %s ok. Perc capacity: %f\n",
                  cfd_->GetName().c_str(), job_context_->job_id, micros,
                  cpu_micros, s.ok() ? "" : "not",
@@ -818,7 +818,7 @@ Status FlushJob::WriteLevel0Table() {
   const uint64_t cpu_micros = clock_->CPUNanos() / 1000 - start_cpu_micros;
   ROCKS_LOG_INFO(
       db_options_.info_log,
-      "[%s] [JOB %d] Flush lasted %lu microseconds %lu cpu microseconds.\n",
+      "[%s] [JOB %d] Flush lasted %zu microseconds %zu cpu microseconds.\n",
       cfd_->GetName().c_str(), job_context_->job_id, micros, cpu_micros);
   if (has_output) {
     stats.bytes_written = meta_.fd.GetFileSize();

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -357,6 +357,9 @@ Status FlushJob::MemPurge() {
   assert(!mems_.empty());
 
   MemTable* new_mem = nullptr;
+  // For performance/log investigation purposes:
+  // look at how much useful payload we harvest in the new_mem.
+  // This value is then printed to the DB log.
   double new_mem_capacity = 0.0;
 
   // Create two iterators, one for the memtable data (contains

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -357,7 +357,7 @@ Status FlushJob::MemPurge() {
   assert(!mems_.empty());
 
   MemTable* new_mem = nullptr;
-  double new_mem_capacity=0.0;
+  double new_mem_capacity = 0.0;
 
   // Create two iterators, one for the memtable data (contains
   // info from puts + deletes), and one for the memtable
@@ -580,7 +580,7 @@ Status FlushJob::MemPurge() {
                                 */);
         new_mem->Ref();
         new_mem_capacity = (new_mem->ApproximateMemoryUsage()) * 1.0 /
-                              mutable_cf_options_.write_buffer_size;
+                           mutable_cf_options_.write_buffer_size;
         db_mutex_->Unlock();
       } else {
         s = Status::Aborted(Slice("Mempurge filled more than one memtable."));

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -624,9 +624,6 @@ bool FlushJob::MemPurgeDecider() {
     // an output of a previous mempurge process, then flush
     // to storage.
     return !(contains_mempurge_outcome_);
-  } else if (policy == DBOptions::MemPurgePolicy::RANDOM) {
-    Random32 rnd(123);
-    return rnd.OneIn(2);
   }
   return false;
 }

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -123,6 +123,7 @@ class FlushJob {
   // recommend all users not to set this flag as true given that the MemPurge
   // process has not matured yet.
   Status MemPurge();
+  bool MemPurgeDecider();
 #ifndef ROCKSDB_LITE
   std::unique_ptr<FlushJobInfo> GetFlushJobInfo() const;
 #endif  // !ROCKSDB_LITE

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -191,6 +191,8 @@ class FlushJob {
 
   const std::string full_history_ts_low_;
   BlobFileCompletionCallback* blob_callback_;
+
+  bool contains_mempurge_outcome_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -557,10 +557,11 @@ class MemTable {
   // Flush job info of the current memtable.
   std::unique_ptr<FlushJobInfo> flush_job_info_;
 #endif  // !ROCKSDB_LITE
-
+ public:
   // Returns a heuristic flush decision
   bool ShouldFlushNow();
 
+ private:
   // Updates flush_state_ using ShouldFlushNow()
   void UpdateFlushState();
 

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -389,6 +389,24 @@ class MemTableList {
   // not freed, but put into a vector for future deref and reclamation.
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
+  void AddMempurgeOutcomeID(uint64_t mid) {
+    if (mempurged_ids_.find(mid) == mempurged_ids_.end()) {
+      mempurged_ids_.insert(mid);
+    }
+  }
+
+  void RemoveMemPurgeMemtableID(uint64_t mid) {
+    if (mempurged_ids_.find(mid) != mempurged_ids_.end()) {
+      mempurged_ids_.erase(mid);
+    }
+  }
+
+  bool IsMempurgeOutcome(uint64_t mid) {
+    if (mempurged_ids_.find(mid) == mempurged_ids_.end()) {
+      return false;
+    }
+    return true;
+  }
 
  private:
   friend Status InstallMemtableAtomicFlushResults(
@@ -433,6 +451,10 @@ class MemTableList {
 
   // Cached value of current_->HasHistory().
   std::atomic<bool> current_has_history_;
+
+  // Store the IDs of the memtables installed in this
+  // list that result from a mempurge operation.
+  std::unordered_set<uint64_t> mempurged_ids_;
 };
 
 // Installs memtable atomic flush results.

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -389,19 +389,19 @@ class MemTableList {
   // not freed, but put into a vector for future deref and reclamation.
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
-  void AddMempurgeOutcomeID(uint64_t mid) {
+  void AddMemPurgeOutputID(uint64_t mid) {
     if (mempurged_ids_.find(mid) == mempurged_ids_.end()) {
       mempurged_ids_.insert(mid);
     }
   }
 
-  void RemoveMemPurgeMemtableID(uint64_t mid) {
+  void RemoveMemPurgeOutputID(uint64_t mid) {
     if (mempurged_ids_.find(mid) != mempurged_ids_.end()) {
       mempurged_ids_.erase(mid);
     }
   }
 
-  bool IsMempurgeOutcome(uint64_t mid) {
+  bool IsMemPurgeOutput(uint64_t mid) {
     if (mempurged_ids_.find(mid) == mempurged_ids_.end()) {
       return false;
     }

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -369,6 +369,11 @@ struct DbPath {
 
 extern const char* kHostnameForDbHostId;
 
+enum class MemPurgePolicy : char {
+  kAlternate = 0x00,
+  kAlways = 0x01,
+};
+
 enum class CompactionServiceJobStatus : char {
   kSuccess,
   kFailure,
@@ -790,8 +795,9 @@ struct DBOptions {
   // policy.
   // Default: ALTERNATE
   // (experimental).
-  enum class MemPurgePolicy : char { ALTERNATE = 0x00, ALWAYS = 0x01 };
-  MemPurgePolicy experimental_mempurge_policy = MemPurgePolicy::ALTERNATE;
+  // enum class MemPurgePolicy : char { ALTERNATE = 0x00, ALWAYS = 0x01 };
+  // MemPurgePolicy experimental_mempurge_policy = MemPurgePolicy::ALTERNATE;
+  MemPurgePolicy experimental_mempurge_policy = MemPurgePolicy::kAlternate;
 
   // Amount of data to build up in memtables across all column
   // families before writing to disk.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -790,8 +790,8 @@ struct DBOptions {
   // policy.
   // Default: ALTERNATE
   // (experimental).
-  enum MemPurgePolicy { ALTERNATE, ALWAYS };
-  MemPurgePolicy experimental_mempurge_policy = ALTERNATE;
+  enum class MemPurgePolicy { ALTERNATE, ALWAYS };
+  MemPurgePolicy experimental_mempurge_policy = MemPurgePolicy::ALTERNATE;
 
   // Amount of data to build up in memtables across all column
   // families before writing to disk.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -790,7 +790,7 @@ struct DBOptions {
   // policy.
   // Default: ALTERNATE
   // (experimental).
-  enum MemPurgePolicy { ALTERNATE, ALWAYS, RANDOM };
+  enum MemPurgePolicy { ALTERNATE, ALWAYS };
   MemPurgePolicy experimental_mempurge_policy = ALTERNATE;
 
   // Amount of data to build up in memtables across all column

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -786,6 +786,13 @@ struct DBOptions {
   // (experimental).
   bool experimental_allow_mempurge = false;
 
+  // If experimental_allow_mempurge is true, will dictate MemPurge
+  // policy.
+  // Default: ALTERNATE
+  // (experimental).
+  enum MemPurgePolicy { ALTERNATE, ALWAYS, RANDOM };
+  MemPurgePolicy experimental_mempurge_policy = ALTERNATE;
+
   // Amount of data to build up in memtables across all column
   // families before writing to disk.
   //

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -790,7 +790,7 @@ struct DBOptions {
   // policy.
   // Default: ALTERNATE
   // (experimental).
-  enum class MemPurgePolicy { ALTERNATE, ALWAYS };
+  enum class MemPurgePolicy : char { ALTERNATE = 0x00, ALWAYS = 0x01 };
   MemPurgePolicy experimental_mempurge_policy = MemPurgePolicy::ALTERNATE;
 
   // Amount of data to build up in memtables across all column

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -50,8 +50,7 @@ static std::unordered_map<std::string, InfoLogLevel> info_log_level_string_map =
 static std::unordered_map<std::string, DBOptions::MemPurgePolicy>
     experimental_mempurge_policy_string_map = {
         {"ALTERNATE", DBOptions::MemPurgePolicy::ALTERNATE},
-        {"ALWAYS", DBOptions::MemPurgePolicy::ALWAYS},
-        {"RANDOM", DBOptions::MemPurgePolicy::RANDOM}};
+        {"ALWAYS", DBOptions::MemPurgePolicy::ALWAYS}};
 
 static std::unordered_map<std::string, OptionTypeInfo>
     db_mutable_options_type_info = {

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -47,10 +47,10 @@ static std::unordered_map<std::string, InfoLogLevel> info_log_level_string_map =
      {"FATAL_LEVEL", InfoLogLevel::FATAL_LEVEL},
      {"HEADER_LEVEL", InfoLogLevel::HEADER_LEVEL}};
 
-static std::unordered_map<std::string, DBOptions::MemPurgePolicy>
+static std::unordered_map<std::string, MemPurgePolicy>
     experimental_mempurge_policy_string_map = {
-        {"ALTERNATE", DBOptions::MemPurgePolicy::ALTERNATE},
-        {"ALWAYS", DBOptions::MemPurgePolicy::ALWAYS}};
+        {"kAlternate", MemPurgePolicy::kAlternate},
+        {"kAlways", MemPurgePolicy::kAlways}};
 
 static std::unordered_map<std::string, OptionTypeInfo>
     db_mutable_options_type_info = {
@@ -202,7 +202,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"experimental_mempurge_policy",
-         OptionTypeInfo::Enum<DBOptions::MemPurgePolicy>(
+         OptionTypeInfo::Enum<MemPurgePolicy>(
              offsetof(struct ImmutableDBOptions, experimental_mempurge_policy),
              &experimental_mempurge_policy_string_map)},
         {"is_fd_close_on_exec",

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -47,6 +47,12 @@ static std::unordered_map<std::string, InfoLogLevel> info_log_level_string_map =
      {"FATAL_LEVEL", InfoLogLevel::FATAL_LEVEL},
      {"HEADER_LEVEL", InfoLogLevel::HEADER_LEVEL}};
 
+static std::unordered_map<std::string, DBOptions::MemPurgePolicy>
+    experimental_mempurge_policy_string_map = {
+        {"ALTERNATE", DBOptions::MemPurgePolicy::ALTERNATE},
+        {"ALWAYS", DBOptions::MemPurgePolicy::ALWAYS},
+        {"RANDOM", DBOptions::MemPurgePolicy::RANDOM}};
+
 static std::unordered_map<std::string, OptionTypeInfo>
     db_mutable_options_type_info = {
         {"allow_os_buffer",
@@ -196,6 +202,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableDBOptions, experimental_allow_mempurge),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"experimental_mempurge_policy",
+         OptionTypeInfo::Enum<DBOptions::MemPurgePolicy>(
+             offsetof(struct ImmutableDBOptions, experimental_mempurge_policy),
+             &experimental_mempurge_policy_string_map)},
         {"is_fd_close_on_exec",
          {offsetof(struct ImmutableDBOptions, is_fd_close_on_exec),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -546,6 +556,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       is_fd_close_on_exec(options.is_fd_close_on_exec),
       advise_random_on_open(options.advise_random_on_open),
       experimental_allow_mempurge(options.experimental_allow_mempurge),
+      experimental_mempurge_policy(options.experimental_mempurge_policy),
       db_write_buffer_size(options.db_write_buffer_size),
       write_buffer_manager(options.write_buffer_manager),
       access_hint_on_compaction_start(options.access_hint_on_compaction_start),
@@ -682,6 +693,9 @@ void ImmutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "                  Options.experimental_allow_mempurge: %d",
                    experimental_allow_mempurge);
+  ROCKS_LOG_HEADER(log,
+                   "                  Options.experimental_mempurge_policy: %d",
+                   static_cast<int>(experimental_mempurge_policy));
   ROCKS_LOG_HEADER(
       log, "                   Options.db_write_buffer_size: %" ROCKSDB_PRIszt,
       db_write_buffer_size);

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -55,6 +55,7 @@ struct ImmutableDBOptions {
   bool is_fd_close_on_exec;
   bool advise_random_on_open;
   bool experimental_allow_mempurge;
+  DBOptions::MemPurgePolicy experimental_mempurge_policy;
   size_t db_write_buffer_size;
   std::shared_ptr<WriteBufferManager> write_buffer_manager;
   DBOptions::AccessHint access_hint_on_compaction_start;

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -55,7 +55,7 @@ struct ImmutableDBOptions {
   bool is_fd_close_on_exec;
   bool advise_random_on_open;
   bool experimental_allow_mempurge;
-  DBOptions::MemPurgePolicy experimental_mempurge_policy;
+  MemPurgePolicy experimental_mempurge_policy;
   size_t db_write_buffer_size;
   std::shared_ptr<WriteBufferManager> write_buffer_manager;
   DBOptions::AccessHint access_hint_on_compaction_start;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -8023,12 +8023,13 @@ int db_bench_tool(int argc, char** argv) {
             FLAGS_compaction_fadvice.c_str());
   }
 
-  if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "ALWAYS"))
+  if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "kAlways"))
     FLAGS_experimental_mempurge_policy_e =
-        ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALWAYS;
-  else if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "ALTERNATE"))
+        ROCKSDB_NAMESPACE::MemPurgePolicy::kAlways;
+  else if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(),
+                       "kAlternate"))
     FLAGS_experimental_mempurge_policy_e =
-        ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALTERNATE;
+        ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
   else {
     fprintf(stdout, "Unknown mempurge policy:%s\n",
             FLAGS_experimental_mempurge_policy.c_str());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -8024,7 +8024,8 @@ int db_bench_tool(int argc, char** argv) {
   }
 
   if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "ALWAYS"))
-    FLAGS_experimental_mempurge_policy_e = ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALWAYS;
+    FLAGS_experimental_mempurge_policy_e =
+        ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALWAYS;
   else if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "ALTERNATE"))
     FLAGS_experimental_mempurge_policy_e =
         ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALTERNATE;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -8024,10 +8024,10 @@ int db_bench_tool(int argc, char** argv) {
   }
 
   if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "ALWAYS"))
-    FLAGS_experimental_mempurge_policy_e = ROCKSDB_NAMESPACE::Options::ALWAYS;
+    FLAGS_experimental_mempurge_policy_e = ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALWAYS;
   else if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "ALTERNATE"))
     FLAGS_experimental_mempurge_policy_e =
-        ROCKSDB_NAMESPACE::Options::ALTERNATE;
+        ROCKSDB_NAMESPACE::Options::MemPurgePolicy::ALTERNATE;
   else {
     fprintf(stdout, "Unknown mempurge policy:%s\n",
             FLAGS_experimental_mempurge_policy.c_str());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1115,6 +1115,19 @@ static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
   return ROCKSDB_NAMESPACE::kSnappyCompression;  // default value
 }
 
+static enum ROCKSDB_NAMESPACE::MemPurgePolicy StringToMemPurgePolicy(
+    const char* mpolicy) {
+  assert(mpolicy);
+  if (!strcasecmp(mpolicy, "kAlways")) {
+    return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlways;
+  } else if (!strcasecmp(mpolicy, "kAlternate")) {
+    return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
+  }
+
+  fprintf(stdout, "Cannot parse mempurge policy '%s'\n", mpolicy);
+  return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
+}
+
 static std::string ColumnFamilyName(size_t i) {
   if (i == 0) {
     return ROCKSDB_NAMESPACE::kDefaultColumnFamilyName;
@@ -1252,10 +1265,8 @@ DEFINE_bool(allow_concurrent_memtable_write, true,
 DEFINE_bool(experimental_allow_mempurge, false,
             "Allow memtable garbage collection.");
 
-DEFINE_string(experimental_mempurge_policy, "ALTERNATE",
+DEFINE_string(experimental_mempurge_policy, "kAlternate",
               "Specify memtable garbage collection policy.");
-static auto FLAGS_experimental_mempurge_policy_e =
-    ROCKSDB_NAMESPACE::Options().experimental_mempurge_policy;
 
 DEFINE_bool(inplace_update_support,
             ROCKSDB_NAMESPACE::Options().inplace_update_support,
@@ -4331,7 +4342,8 @@ class Benchmark {
     options.allow_concurrent_memtable_write =
         FLAGS_allow_concurrent_memtable_write;
     options.experimental_allow_mempurge = FLAGS_experimental_allow_mempurge;
-    options.experimental_mempurge_policy = FLAGS_experimental_mempurge_policy_e;
+    options.experimental_mempurge_policy =
+        StringToMemPurgePolicy(FLAGS_experimental_mempurge_policy.c_str());
     options.inplace_update_support = FLAGS_inplace_update_support;
     options.inplace_update_num_locks = FLAGS_inplace_update_num_locks;
     options.enable_write_thread_adaptive_yield =
@@ -8021,18 +8033,6 @@ int db_bench_tool(int argc, char** argv) {
   else {
     fprintf(stdout, "Unknown compaction fadvice:%s\n",
             FLAGS_compaction_fadvice.c_str());
-  }
-
-  if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "kAlways"))
-    FLAGS_experimental_mempurge_policy_e =
-        ROCKSDB_NAMESPACE::MemPurgePolicy::kAlways;
-  else if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(),
-                       "kAlternate"))
-    FLAGS_experimental_mempurge_policy_e =
-        ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
-  else {
-    fprintf(stdout, "Unknown mempurge policy:%s\n",
-            FLAGS_experimental_mempurge_policy.c_str());
   }
 
   FLAGS_value_size_distribution_type_e =

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1252,6 +1252,11 @@ DEFINE_bool(allow_concurrent_memtable_write, true,
 DEFINE_bool(experimental_allow_mempurge, false,
             "Allow memtable garbage collection.");
 
+DEFINE_string(experimental_mempurge_policy, "ALTERNATE",
+              "Specify memtable garbage collection policy.");
+static auto FLAGS_experimental_mempurge_policy_e =
+    ROCKSDB_NAMESPACE::Options().experimental_mempurge_policy;
+
 DEFINE_bool(inplace_update_support,
             ROCKSDB_NAMESPACE::Options().inplace_update_support,
             "Support in-place memtable update for smaller or same-size values");
@@ -4326,6 +4331,7 @@ class Benchmark {
     options.allow_concurrent_memtable_write =
         FLAGS_allow_concurrent_memtable_write;
     options.experimental_allow_mempurge = FLAGS_experimental_allow_mempurge;
+    options.experimental_mempurge_policy = FLAGS_experimental_mempurge_policy_e;
     options.inplace_update_support = FLAGS_inplace_update_support;
     options.inplace_update_num_locks = FLAGS_inplace_update_num_locks;
     options.enable_write_thread_adaptive_yield =
@@ -8015,6 +8021,16 @@ int db_bench_tool(int argc, char** argv) {
   else {
     fprintf(stdout, "Unknown compaction fadvice:%s\n",
             FLAGS_compaction_fadvice.c_str());
+  }
+
+  if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "ALWAYS"))
+    FLAGS_experimental_mempurge_policy_e = ROCKSDB_NAMESPACE::Options::ALWAYS;
+  else if (!strcasecmp(FLAGS_experimental_mempurge_policy.c_str(), "ALTERNATE"))
+    FLAGS_experimental_mempurge_policy_e =
+        ROCKSDB_NAMESPACE::Options::ALTERNATE;
+  else {
+    fprintf(stdout, "Unknown mempurge policy:%s\n",
+            FLAGS_experimental_mempurge_policy.c_str());
   }
 
   FLAGS_value_size_distribution_type_e =


### PR DESCRIPTION
Add `experimental_mempurge_policy` option flag and introduce two new `MemPurge` (Memtable Garbage Collection) policies: 'ALWAYS' and 'ALTERNATE'. Default value: ALTERNATE.
`ALWAYS`: every flush will first go through a `MemPurge` process. If the output is too big to fit into a single memtable, then the mempurge is aborted and a regular flush process carries on. `ALWAYS` is designed for user that need to reduce the number of L0 SST file created to a strict minimum, and can afford a small dent in performance. 
`ALTERNATE`: a flush is transformed into a `MemPurge` except if one of the memtables being flushed is the product of a previous `MemPurge`. `ALTERNATE` is a good tradeoff between reduction in number of L0 SST files created and performance. `ALTERNATE` perform particularly well for completely random garbage ratios, or garbage ratios anywhere in (0%,50%], and even higher when there is a wild variability in garbage ratios.
This PR also includes support for `experimental_mempurge_policy` in `db_bench`. 
Testing was done locally by replacing all the `MemPurge` policies of the unit tests with `ALTERNATE`, as well as local testing with `db_crashtest.py` `whitebox` and `blackbox`. Overall, if an `ALWAYS` mempurge policy passes the tests, there is no reasons why an `ALTERNATE` policy would fail, and therefore the mempurge policy was set to `ALWAYS` for all mempurge unit tests.