### PR TITLE
Add experimental mempurge policy flag to db_stress.

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -349,7 +349,7 @@ inline enum ROCKSDB_NAMESPACE::MemPurgePolicy StringToMemPurgePolicy(
   } else if (!strcasecmp(mpolicy, "kAlternate")) {
     return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
   }
-  fprintf(stdout, "Cannot parse mempurge policy: '%s'\n", mpolicy);
+  fprintf(stderr, "Cannot parse mempurge policy: '%s'\n", mpolicy);
   return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
 }
 

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -142,6 +142,7 @@ DECLARE_uint64(periodic_compaction_seconds);
 DECLARE_uint64(compaction_ttl);
 DECLARE_bool(allow_concurrent_memtable_write);
 DECLARE_bool(experimental_allow_mempurge);
+DECLARE_string(experimental_mempurge_policy);
 DECLARE_bool(enable_write_thread_adaptive_yield);
 DECLARE_int32(reopen);
 DECLARE_double(bloom_bits);
@@ -338,6 +339,19 @@ inline enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
     ret_compression_type = ROCKSDB_NAMESPACE::kSnappyCompression;
   }
   return ret_compression_type;
+}
+
+inline enum ROCKSDB_NAMESPACE::MemPurgePolicy StringToMemPurgePolicy(
+    const char* mpolicy) {
+  assert(mpolicy);
+  if (!strcasecmp(mpolicy, "kAlways")) {
+    return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlways;
+  } else if (!strcasecmp(mpolicy, "kAlternate")) {
+    return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
+  }
+
+  fprintf(stdout, "Cannot parse mempurge policy '%s'\n", mpolicy);
+  return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
 }
 
 inline enum ROCKSDB_NAMESPACE::ChecksumType StringToChecksumType(

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -349,8 +349,7 @@ inline enum ROCKSDB_NAMESPACE::MemPurgePolicy StringToMemPurgePolicy(
   } else if (!strcasecmp(mpolicy, "kAlternate")) {
     return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
   }
-
-  fprintf(stdout, "Cannot parse mempurge policy '%s'\n", mpolicy);
+  fprintf(stdout, "Cannot parse mempurge policy: '%s'\n", mpolicy);
   return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
 }
 

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -330,7 +330,7 @@ DEFINE_bool(experimental_allow_mempurge, false,
             "Allow mempurge process to collect memtable garbage bytes.");
 
 DEFINE_string(experimental_mempurge_policy, "kAlternate",
-              "Set garbage collection policy.");
+              "Set mempurge (memtable garbage collection) policy.");
 
 DEFINE_bool(enable_write_thread_adaptive_yield, true,
             "Use a yielding spin loop for brief writer thread waits.");

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -330,7 +330,7 @@ DEFINE_bool(experimental_allow_mempurge, false,
             "Allow mempurge process to collect memtable garbage bytes.");
 
 DEFINE_string(experimental_mempurge_policy, "kAlternate",
-              "Set mempurge (memtable garbage collection) policy.");
+              "Set mempurge (MemTable Garbage Collection) policy.");
 
 DEFINE_bool(enable_write_thread_adaptive_yield, true,
             "Use a yielding spin loop for brief writer thread waits.");

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -329,6 +329,9 @@ DEFINE_bool(allow_concurrent_memtable_write, false,
 DEFINE_bool(experimental_allow_mempurge, false,
             "Allow mempurge process to collect memtable garbage bytes.");
 
+DEFINE_string(experimental_mempurge_policy, "kAlternate",
+              "Set garbage collection policy.");
+
 DEFINE_bool(enable_write_thread_adaptive_yield, true,
             "Use a yielding spin loop for brief writer thread waits.");
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2268,6 +2268,8 @@ void StressTest::Open() {
     options_.allow_concurrent_memtable_write =
         FLAGS_allow_concurrent_memtable_write;
     options_.experimental_allow_mempurge = FLAGS_experimental_allow_mempurge;
+    options_.experimental_mempurge_policy =
+        StringToMemPurgePolicy(FLAGS_experimental_mempurge_policy.c_str());
     options_.periodic_compaction_seconds = FLAGS_periodic_compaction_seconds;
     options_.ttl = FLAGS_compaction_ttl;
     options_.enable_pipelined_write = FLAGS_enable_pipelined_write;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -221,6 +221,7 @@ simple_default_params = {
     "allow_concurrent_memtable_write": lambda: random.randint(0, 1),
     "column_families": 1,
     "experimental_allow_mempurge": 0,
+    "experimental_mempurge_policy": "kAlternate",
     "max_background_compactions": 1,
     "max_bytes_for_level_base": 67108864,
     "memtablerep": "skip_list",

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -220,8 +220,8 @@ whitebox_default_params = {
 simple_default_params = {
     "allow_concurrent_memtable_write": lambda: random.randint(0, 1),
     "column_families": 1,
-    "experimental_allow_mempurge": 0,
-    "experimental_mempurge_policy": "kAlternate",
+    "experimental_allow_mempurge": lambda: random.randint(0, 1),
+    "experimental_mempurge_policy": lambda: random.choice(["kAlways", "kAlternate"]),
     "max_background_compactions": 1,
     "max_bytes_for_level_base": 67108864,
     "memtablerep": "skip_list",


### PR DESCRIPTION
Add `experimental_mempurge_policy` flag to `db_stress` and `db_crashtest.py`.
This flag is only read if the `experimental_allow_mempurge` flag is set to `true`. This flag can take the following values: `kAlways`, and `kAlternate` (default). 
- `kAlways`: a flush is always redirected to a mempurge. If the mempurge aborts, the a regular flush proceeds.
- `kAlternate`: if one or more of the flush input memtables is an mempurge output memtable, then a flush is performed, else a mempurge is carried out. Similar to kAlways, if a mempurge aborts, the FlushJob proceeds to a regular flush to storage.