### PR TITLE
Fix missing Handle release in TableCache::GetRangeTombstoneIterator

### DIFF
--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -667,7 +667,8 @@ TEST_F(DBRangeDelTest, TableEvictedDuringScan) {
   opts.max_open_files = 1;
   Reopen(opts);
 
-  ColumnFamilyData* const cfd = dbfull()->TEST_GetVersionSet()->GetColumnFamilySet()->GetDefault();
+  ColumnFamilyData* const cfd =
+      dbfull()->TEST_GetVersionSet()->GetColumnFamilySet()->GetDefault();
   assert(cfd);
 
   Version* const version = cfd->current();

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -667,15 +667,8 @@ TEST_F(DBRangeDelTest, TableEvictedDuringScan) {
   opts.max_open_files = 1;
   Reopen(opts);
 
-  ColumnFamilyData* const cfd =
-      dbfull()->TEST_GetVersionSet()->GetColumnFamilySet()->GetDefault();
-  assert(cfd);
-
-  Version* const version = cfd->current();
-  assert(version);
-
   std::string str;
-  ASSERT_OK(version->TablesRangeTombstoneSummary(100, &str));
+  dbfull()->TablesRangeTombstoneSummary(db_->DefaultColumnFamily(), 100, &str);
 }
 
 TEST_F(DBRangeDelTest, GetCoveredKeyFromMutableMemtable) {

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -668,7 +668,8 @@ TEST_F(DBRangeDelTest, TableEvictedDuringScan) {
   Reopen(opts);
 
   std::string str;
-  dbfull()->TablesRangeTombstoneSummary(db_->DefaultColumnFamily(), 100, &str);
+  ASSERT_OK(dbfull()->TablesRangeTombstoneSummary(db_->DefaultColumnFamily(),
+                                                  100, &str));
 }
 
 TEST_F(DBRangeDelTest, GetCoveredKeyFromMutableMemtable) {

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -675,7 +675,7 @@ TEST_F(DBRangeDelTest, TableEvictedDuringScan) {
   assert(version);
 
   std::string str;
-  version->TablesRangeTombstoneSummary(100, &str);
+  ASSERT_OK(version->TablesRangeTombstoneSummary(100, &str));
 }
 
 TEST_F(DBRangeDelTest, GetCoveredKeyFromMutableMemtable) {

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -660,6 +660,21 @@ TEST_F(DBRangeDelTest, TableEvictedDuringScan) {
   ASSERT_EQ(kNum, expected);
   delete iter;
   db_->ReleaseSnapshot(snapshot);
+
+  // Also test proper cache handling in GetRangeTombstoneIterator,
+  // via TablesRangeTombstoneSummary. (This once triggered memory leak
+  // report with ASAN.)
+  opts.max_open_files = 1;
+  Reopen(opts);
+
+  ColumnFamilyData* const cfd = dbfull()->TEST_GetVersionSet()->GetColumnFamilySet()->GetDefault();
+  assert(cfd);
+
+  Version* const version = cfd->current();
+  assert(version);
+
+  std::string str;
+  version->TablesRangeTombstoneSummary(100, &str);
 }
 
 TEST_F(DBRangeDelTest, GetCoveredKeyFromMutableMemtable) {


### PR DESCRIPTION
Summary: This appears to be little used code so not a major bug, but is
blocking #8544

Test Plan: Added regression test to the end of
DBRangeDelTest::TableEvictedDuringScan. Without this fix, ASAN reports
memory leak.