### PR TITLE
DB::GetSortedWalFiles() to ensure file deletion is disabled

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -137,9 +137,12 @@ Status DBImpl::GetSortedWalFiles(VectorLogPtr& files) {
   if (s.ok()) {
     s = wal_manager_.GetSortedWalFiles(files);
   }
-  if (s.ok()) {
-    EnableFileDeletions(false);
+
+  Status s2 = EnableFileDeletions(false);
+  if (!s2.ok() && s.ok()) {
+    s = s2;
   }
+
   return s;
 }
 

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -130,7 +130,7 @@ Status DBImpl::GetSortedWalFiles(VectorLogPtr& files) {
 
     // Disable deletion in order to avoid the case where a file is deleted in
     // the middle of the process so IO error is returned.
-    s1 = DisableFileDeletionsWithLock();
+    s = DisableFileDeletionsWithLock();
   }
   ROCKS_LOG_INFO(immutable_db_options_.info_log,
                  "GetSortedWalFiles(): disabled file deletions.");

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -130,17 +130,16 @@ Status DBImpl::GetSortedWalFiles(VectorLogPtr& files) {
 
     // Disable deletion in order to avoid the case where a file is deleted in
     // the middle of the process so IO error is returned.
-    s = DisableFileDeletionsWithLock();
+    s1 = DisableFileDeletionsWithLock();
   }
   ROCKS_LOG_INFO(immutable_db_options_.info_log,
                  "GetSortedWalFiles(): disabled file deletions.");
   if (s.ok()) {
     s = wal_manager_.GetSortedWalFiles(files);
-  }
-
-  Status s2 = EnableFileDeletions(false);
-  if (!s2.ok() && s.ok()) {
-    s = s2;
+    Status s2 = EnableFileDeletions(false);
+    if (!s2.ok() && s.ok()) {
+      s = s2;
+    }
   }
 
   return s;

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -131,9 +131,6 @@ Status DBImpl::GetSortedWalFiles(VectorLogPtr& files) {
   // Disable deletion in order to avoid the case where a file is deleted in
   // the middle of the process so IO error is returned.
   Status s = DisableFileDeletions();
-
-  ROCKS_LOG_INFO(immutable_db_options_.info_log,
-                 "GetSortedWalFiles(): disabled file deletions.");
   bool file_deletion_supported = !s.IsNotSupported();
   if (s.ok() || !file_deletion_supported) {
     s = wal_manager_.GetSortedWalFiles(files);

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -38,20 +38,26 @@ uint64_t DBImpl::MinObsoleteSstNumberToKeep() {
 }
 
 Status DBImpl::DisableFileDeletions() {
-  InstrumentedMutexLock l(&mutex_);
-  return DisableFileDeletionsWithLock();
-}
-
-Status DBImpl::DisableFileDeletionsWithLock() {
-  mutex_.AssertHeld();
-  ++disable_delete_obsolete_files_;
-  if (disable_delete_obsolete_files_ == 1) {
+  Status s;
+  int my_disable_delete_obsolete_files;
+  {
+    InstrumentedMutexLock l(&mutex_);
+    s = DisableFileDeletionsWithLock();
+    my_disable_delete_obsolete_files = disable_delete_obsolete_files_;
+  }
+  if (my_disable_delete_obsolete_files == 1) {
     ROCKS_LOG_INFO(immutable_db_options_.info_log, "File Deletions Disabled");
   } else {
     ROCKS_LOG_WARN(immutable_db_options_.info_log,
                    "File Deletions Disabled, but already disabled. Counter: %d",
                    disable_delete_obsolete_files_);
   }
+  return s;
+}
+
+Status DBImpl::DisableFileDeletionsWithLock() {
+  mutex_.AssertHeld();
+  ++disable_delete_obsolete_files_;
   return Status::OK();
 }
 

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -50,7 +50,7 @@ Status DBImpl::DisableFileDeletions() {
   } else {
     ROCKS_LOG_WARN(immutable_db_options_.info_log,
                    "File Deletions Disabled, but already disabled. Counter: %d",
-                   disable_delete_obsolete_files_);
+                   my_disable_delete_obsolete_files);
   }
   return s;
 }

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -394,6 +394,7 @@ const Status& ErrorHandler::SetBGError(const IOStatus& bg_io_err,
   if (BackgroundErrorReason::kManifestWrite == reason ||
       BackgroundErrorReason::kManifestWriteNoWAL == reason) {
     // Always returns ok
+    ROCKS_LOG_INFO(db_options_.info_log, "Disabling File Deletions");
     db_->DisableFileDeletionsWithLock().PermitUncheckedError();
   }
 


### PR DESCRIPTION
Summary:
If DB::GetSortedWalFiles() runs without file deletion disbled, file might get deleted in the middle and error is returned to users. It makes the function hard to use. Fix it by disabling file deletion if it is not done.

Fix another minor issue of logging within DB mutex, which should not be done unless a major failure happens.

Test Plan: Run all existing tests