### PR TITLE
Create fillanddeleteuniquerandom benchmark (db_bench), with new option flags.

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -34,6 +34,7 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <queue>
 
 #include "db/db_impl/db_impl.h"
 #include "db/malloc_stats.h"

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4909,6 +4909,7 @@ class Benchmark {
                                       persistent_ent_and_del_index[id]);
               persistent_ent_and_del_index[id]++;
               is_disposable_entry = false;
+              skip_for_loop = false;
             } else if (persistent_ent_and_del_index[id] <
                        NUM_DISP_AND_PERS_ENTRIES) {
               // Find key of the entry to delete.
@@ -5007,9 +5008,10 @@ class Benchmark {
         bytes += val.size() + key_size_ + user_timestamp_size_;
         ++num_written;
 
-        // If selective deletes, then check if we need to
-        // add new batch of selective deletes to insert.
-        if (NUM_DISP_AND_PERS_ENTRIES > 0 &&
+        // If all disposable entries have been inserted, then we need to
+        // add in the job queue a call for 'persistent entry insertions +
+        // disposable entry deletions'.
+        if (NUM_DISP_AND_PERS_ENTRIES > 0 && is_disposable_entry &&
             ((disposable_entries_index[id] % NUM_DISP_AND_PERS_ENTRIES) == 0)) {
           // Queue contains [timestamp, starting_idx],
           // timestamp = current_time + delay (minimum aboslute time when to

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4835,10 +4835,10 @@ class Benchmark {
     if (NUM_DISP_AND_PERS_ENTRIES > 0) {
       if ((write_mode != UNIQUE_RANDOM) || (writes_per_range_tombstone_ > 0) ||
           (p > 0.0)) {
-        fprintf(stderr,
-                "Disposable/persistent deletes are not compatible with "
-                "overwrites and "
-                "DeleteRanges; and are only supported in filluniquerandom.\n");
+        fprintf(
+            stderr,
+            "Disposable/persistent deletes are not compatible with overwrites "
+            "and DeleteRanges; and are only supported in filluniquerandom.\n");
         ErrorExit();
       }
       if (FLAGS_disposable_entries_value_size < 0 ||

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -356,7 +356,8 @@ DEFINE_uint64(
     disposable_entries_delete_delay, 0,
     "Minimum delay in microseconds for the series of Deletes "
     "to be issued. When 0 the insertion of the last disposable entry is "
-    "immediately followed by the issuance of the Deletes.");
+    "immediately followed by the issuance of the Deletes. "
+    "(only compatible with fillanddeleteuniquerandom benchmark).");
 
 DEFINE_uint64(disposable_entries_batch_size, 0,
               "Number of consecutively inserted disposable KV entries "
@@ -365,11 +366,12 @@ DEFINE_uint64(disposable_entries_batch_size, 0,
               "disposable KV entries it targets have been inserted "
               "into the DB. When 0 no deletes are issued and a "
               "regular 'filluniquerandom' benchmark occurs. "
-              "(only compatible with filluniquerandom benchmark)");
+              "(only compatible with fillanddeleteuniquerandom benchmark)");
 
 DEFINE_int32(disposable_entries_value_size, 64,
              "Size of the values (in bytes) of the entries targeted by "
-             "selective deletes. ");
+             "selective deletes. "
+             "(only compatible with fillanddeleteuniquerandom benchmark)");
 
 DEFINE_uint64(
     persistent_entries_batch_size, 0,
@@ -377,12 +379,13 @@ DEFINE_uint64(
     "targeting the disposable KV entries are issued. These "
     "persistent keys are not targeted by the deletes, and will always "
     "remain valid in the DB. (only compatible with "
-    "--benchmarks='filluniquerandom' "
+    "--benchmarks='fillanddeleteuniquerandom' "
     "and used when--disposable_entries_batch_size is > 0).");
 
 DEFINE_int32(persistent_entries_value_size, 64,
              "Size of the values (in bytes) of the entries not targeted by "
-             "deletes. (only compatible with --benchmarks='filluniquerandom' "
+             "deletes. (only compatible with "
+             "--benchmarks='fillanddeleteuniquerandom' "
              "and used when--disposable_entries_batch_size is > 0).");
 
 DEFINE_double(read_random_exp_range, 0.0,
@@ -3299,12 +3302,13 @@ class Benchmark {
       } else if (name == "fillrandom") {
         fresh_db = true;
         method = &Benchmark::WriteRandom;
-      } else if (name == "filluniquerandom") {
+      } else if (name == "filluniquerandom" ||
+                 name == "fillanddeleteuniquerandom") {
         fresh_db = true;
         if (num_threads > 1) {
           fprintf(stderr,
-                  "filluniquerandom multithreaded not supported"
-                  ", use 1 thread");
+                  "filluniquerandom and fillanddeleteuniquerandom "
+                  "multithreaded not supported, use 1 thread");
           num_threads = 1;
         }
         method = &Benchmark::WriteUniqueRandom;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -32,9 +32,9 @@
 #include <cstddef>
 #include <memory>
 #include <mutex>
+#include <queue>
 #include <thread>
 #include <unordered_map>
-#include <queue>
 
 #include "db/db_impl/db_impl.h"
 #include "db/malloc_stats.h"

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4827,10 +4827,8 @@ class Benchmark {
     // as the last disposable entry in the set S1 of this sequence is
     // inserted, if the delay is non negligible"
     bool skip_for_loop = false, is_disposable_entry = true;
-    std::vector<uint64_t> disposable_entries_index(FLAGS_num_column_families,
-                                                   0);
-    std::vector<uint64_t> persistent_ent_and_del_index(
-        FLAGS_num_column_families, 0);
+    std::vector<uint64_t> disposable_entries_index(num_key_gens, 0);
+    std::vector<uint64_t> persistent_ent_and_del_index(num_key_gens, 0);
     const uint64_t NUM_DISP_AND_PERS_ENTRIES =
         FLAGS_disposable_entries_batch_size +
         FLAGS_persistent_entries_batch_size;
@@ -4917,7 +4915,6 @@ class Benchmark {
           if (!disposable_entries_q[id].empty() &&
               (disposable_entries_q[id].front().first <
                FLAGS_env->NowMicros())) {
-            skip_for_loop = false;
             // If we need to perform a "merge op" pattern,
             // we first write all the persistent KV entries not targeted
             // by deletes, and then we write the disposable entries deletes.
@@ -4970,9 +4967,14 @@ class Benchmark {
               disposable_entries_q[id].pop();
               persistent_ent_and_del_index[id] = 0;
             }
+
+            // If we are deleting disposable entries, skip the rest of the
+            // for-loop since there is no key-value inserts at this moment in
+            // time.
             if (skip_for_loop) {
               continue;
             }
+
           }
           // If no job is in the queue, then we keep inserting disposable KV
           // entries that will be deleted later by a series of deletes.

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4929,6 +4929,7 @@ class Benchmark {
                 // particular key while reading the key.
                 batch.Delete(db_with_cfh->GetCfh(rand_num), key);
               }
+              // A delete only includes Key+Timestamp (no value).
               batch_bytes += key_size_ + user_timestamp_size_;
               bytes += key_size_ + user_timestamp_size_;
               num_selective_deletes++;
@@ -5129,8 +5130,8 @@ class Benchmark {
               num_unique_keys, num_overwrites);
     } else if (NUM_DISP_AND_PERS_ENTRIES > 0) {
       fprintf(stdout,
-              "Number of unique keys inserted: %" PRIu64
-              ".\nNumber of 'selective' deletes: %" PRIu64 "\n",
+              "Number of unique keys inserted (disposable+persistent): %" PRIu64
+              ".\nNumber of 'disposable entry delete': %" PRIu64 "\n",
               num_written, num_selective_deletes);
     }
     thread->stats.AddBytes(bytes);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -351,6 +351,25 @@ DEFINE_uint32(overwrite_window_size, 1,
               "Warning: large values can affect throughput. "
               "Valid overwrite_window_size values: [1, kMaxUint32].");
 
+DEFINE_int32(delete_delay, 0,
+             "Minimum delay in microseconds for the delete range "
+             "to be issued. When 0 the insertion of the last targeted entry is "
+             "immediately "
+             "followed by the issuance of the DeleteRange.");
+
+DEFINE_int32(delete_range_size, 0,
+             "Size of the key range to delete after 'delete_delay' "
+             "microseconds. When 0 no deleterange is issued. A DeleteRange is "
+             "always issued "
+             "once all the keys it covers are inserted into the DB. ");
+
+DEFINE_bool(
+    key_before_delete_range, true,
+    "If true, a key is inserted immediately "
+    "before the deleterange is issued. This key will not be targeted by any "
+    "delete operation. Simulate some type of summary data computed "
+    "from the range of entries being deleted.");
+
 DEFINE_double(read_random_exp_range, 0.0,
               "Read random's key will be generated using distribution of "
               "num * exp(-r) where r is uniform number from 0 to this value. "


### PR DESCRIPTION
Introduction of a new `fillanddeleteuniquerandom` benchmark (`db_bench`) with 5 new option flags to simulate a benchmark where the following sequence is repeated multiple times:
"A set of keys S1 is inserted ('`disposable entries`'), then after some delay another set of keys S2 is inserted ('`persistent entries`') and the first set of keys S1 is deleted. S2 artificially represents the insertion of hypothetical results from some undefined computation done on the first set of keys S1. The next sequence can start as soon as the last disposable entry in the set S1 of this sequence is inserted, if the `delay` is non negligible." 
New flags:
- `disposable_entries_delete_delay`: minimum delay in microseconds between insertion of the last `disposable` entry, and the start of the insertion of the first `persistent` entry.
- `disposable_entries_batch_size`: number of `disposable` entries inserted at the beginning of each sequence.
- `disposable_entries_value_size`: size of the random `value` string for the `disposable` entries.
- `persistent_entries_batch_size`: number of `persistent` entries inserted at the end of each sequence, right before the deletion of the `disposable` entries starts.
- `persistent_entries_value_size`: size of the random value string for the `persistent` entries.