### PR TITLE
Remove unused variable - run_had_errors

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -512,7 +512,6 @@ def blackbox_crash_main(args, unknown_args):
 
         for line in errs.split('\n'):
             if line != '' and  not line.startswith('WARNING'):
-                run_had_errors = True
                 print('stderr has error message:')
                 print('***' + line + '***')
 


### PR DESCRIPTION
Unused since https://github.com/facebook/rocksdb/commit/ab718b415fc9b2a66a2ed642c18803f764839d7b .
Noticed on https://lgtm.com/projects/g/facebook/rocksdb/snapshot/b215f1a83226f111ff52305987af93564272b7d3/files/tools/db_crashtest.py?sort=name&dir=ASC&mode=heatmap#xf254f528ad18f108:1