### PR TITLE
Support for integrated blobdb specific paths

### DIFF
--- a/db/blob/blob_file_builder.cc
+++ b/db/blob/blob_file_builder.cc
@@ -157,9 +157,9 @@ Status BlobFileBuilder::OpenBlobFileIfNeeded() {
   const uint64_t blob_file_number = file_number_generator_();
 
   assert(immutable_options_);
-  assert(!immutable_options_->cf_paths.empty());
+  assert(!immutable_options_->blob_path.empty());
   std::string blob_file_path =
-      BlobFileName(immutable_options_->cf_paths.front().path, blob_file_number);
+      BlobFileName(immutable_options_->blob_path, blob_file_number);
 
   std::unique_ptr<FSWritableFile> file;
 

--- a/db/blob/blob_file_builder_test.cc
+++ b/db/blob/blob_file_builder_test.cc
@@ -122,10 +122,8 @@ TEST_F(BlobFileBuilderTest, BuildAndCheckOneFile) {
   constexpr size_t value_offset = 1234;
 
   Options options;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileBuilderTest_BuildAndCheckOneFile"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileBuilderTest_BuildAndCheckOneFile");
   options.enable_blob_files = true;
   options.env = &mock_env_;
 
@@ -177,9 +175,8 @@ TEST_F(BlobFileBuilderTest, BuildAndCheckOneFile) {
 
   const std::string& blob_file_path = blob_file_paths[0];
 
-  ASSERT_EQ(
-      blob_file_path,
-      BlobFileName(immutable_options.cf_paths.front().path, blob_file_number));
+  ASSERT_EQ(blob_file_path,
+            BlobFileName(immutable_options.blob_path, blob_file_number));
 
   ASSERT_EQ(blob_file_additions.size(), 1);
 
@@ -205,10 +202,8 @@ TEST_F(BlobFileBuilderTest, BuildAndCheckMultipleFiles) {
   constexpr size_t value_offset = 1234567890;
 
   Options options;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileBuilderTest_BuildAndCheckMultipleFiles"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileBuilderTest_BuildAndCheckMultipleFiles");
   options.enable_blob_files = true;
   options.blob_file_size = value_size;
   options.env = &mock_env_;
@@ -262,8 +257,7 @@ TEST_F(BlobFileBuilderTest, BuildAndCheckMultipleFiles) {
     const uint64_t blob_file_number = i + 2;
 
     ASSERT_EQ(blob_file_paths[i],
-              BlobFileName(immutable_options.cf_paths.front().path,
-                           blob_file_number));
+              BlobFileName(immutable_options.blob_path, blob_file_number));
 
     const auto& blob_file_addition = blob_file_additions[i];
 
@@ -292,9 +286,8 @@ TEST_F(BlobFileBuilderTest, InlinedValues) {
   constexpr size_t value_offset = 1234567890;
 
   Options options;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderTest_InlinedValues"),
-      0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderTest_InlinedValues");
   options.enable_blob_files = true;
   options.min_blob_size = 1024;
   options.env = &mock_env_;
@@ -346,8 +339,8 @@ TEST_F(BlobFileBuilderTest, Compression) {
   constexpr size_t value_size = 100;
 
   Options options;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderTest_Compression"), 0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderTest_Compression");
   options.enable_blob_files = true;
   options.blob_compression_type = kSnappyCompression;
   options.env = &mock_env_;
@@ -387,9 +380,8 @@ TEST_F(BlobFileBuilderTest, Compression) {
 
   const std::string& blob_file_path = blob_file_paths[0];
 
-  ASSERT_EQ(
-      blob_file_path,
-      BlobFileName(immutable_options.cf_paths.front().path, blob_file_number));
+  ASSERT_EQ(blob_file_path,
+            BlobFileName(immutable_options.blob_path, blob_file_number));
 
   ASSERT_EQ(blob_file_additions.size(), 1);
 
@@ -428,9 +420,8 @@ TEST_F(BlobFileBuilderTest, CompressionError) {
   }
 
   Options options;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderTest_CompressionError"),
-      0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderTest_CompressionError");
   options.enable_blob_files = true;
   options.blob_compression_type = kSnappyCompression;
   options.env = &mock_env_;
@@ -472,9 +463,8 @@ TEST_F(BlobFileBuilderTest, CompressionError) {
   constexpr uint64_t blob_file_number = 2;
 
   ASSERT_EQ(blob_file_paths.size(), 1);
-  ASSERT_EQ(
-      blob_file_paths[0],
-      BlobFileName(immutable_options.cf_paths.front().path, blob_file_number));
+  ASSERT_EQ(blob_file_paths[0],
+            BlobFileName(immutable_options.blob_path, blob_file_number));
 
   ASSERT_TRUE(blob_file_additions.empty());
 }
@@ -505,8 +495,8 @@ TEST_F(BlobFileBuilderTest, Checksum) {
   };
 
   Options options;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderTest_Checksum"), 0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderTest_Checksum");
   options.enable_blob_files = true;
   options.file_checksum_gen_factory =
       std::make_shared<DummyFileChecksumGenFactory>();
@@ -547,9 +537,8 @@ TEST_F(BlobFileBuilderTest, Checksum) {
 
   const std::string& blob_file_path = blob_file_paths[0];
 
-  ASSERT_EQ(
-      blob_file_path,
-      BlobFileName(immutable_options.cf_paths.front().path, blob_file_number));
+  ASSERT_EQ(blob_file_path,
+            BlobFileName(immutable_options.blob_path, blob_file_number));
 
   ASSERT_EQ(blob_file_additions.size(), 1);
 
@@ -601,9 +590,8 @@ TEST_P(BlobFileBuilderIOErrorTest, IOError) {
   constexpr size_t value_size = 8;
 
   Options options;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderIOErrorTest_IOError"),
-      0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileBuilderIOErrorTest_IOError");
   options.enable_blob_files = true;
   options.blob_file_size = value_size;
   options.env = &mock_env_;
@@ -651,8 +639,7 @@ TEST_P(BlobFileBuilderIOErrorTest, IOError) {
 
     ASSERT_EQ(blob_file_paths.size(), 1);
     ASSERT_EQ(blob_file_paths[0],
-              BlobFileName(immutable_options.cf_paths.front().path,
-                           blob_file_number));
+              BlobFileName(immutable_options.blob_path, blob_file_number));
   }
 
   ASSERT_TRUE(blob_file_additions.empty());

--- a/db/blob/blob_file_cache_test.cc
+++ b/db/blob/blob_file_cache_test.cc
@@ -31,10 +31,10 @@ namespace {
 void WriteBlobFile(uint32_t column_family_id,
                    const ImmutableOptions& immutable_options,
                    uint64_t blob_file_number) {
-  assert(!immutable_options.cf_paths.empty());
+  assert(!immutable_options.blob_path.empty());
 
   const std::string blob_file_path =
-      BlobFileName(immutable_options.cf_paths.front().path, blob_file_number);
+      BlobFileName(immutable_options.blob_path, blob_file_number);
 
   std::unique_ptr<FSWritableFile> file;
   ASSERT_OK(NewWritableFile(immutable_options.fs.get(), blob_file_path, &file,
@@ -93,9 +93,8 @@ TEST_F(BlobFileCacheTest, GetBlobFileReader) {
   Options options;
   options.env = &mock_env_;
   options.statistics = CreateDBStatistics();
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileCacheTest_GetBlobFileReader"),
-      0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileCacheTest_GetBlobFileReader");
   options.enable_blob_files = true;
 
   constexpr uint32_t column_family_id = 1;
@@ -137,10 +136,8 @@ TEST_F(BlobFileCacheTest, GetBlobFileReader_Race) {
   Options options;
   options.env = &mock_env_;
   options.statistics = CreateDBStatistics();
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileCacheTest_GetBlobFileReader_Race"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileCacheTest_GetBlobFileReader_Race");
   options.enable_blob_files = true;
 
   constexpr uint32_t column_family_id = 1;
@@ -189,10 +186,8 @@ TEST_F(BlobFileCacheTest, GetBlobFileReader_IOError) {
   Options options;
   options.env = &mock_env_;
   options.statistics = CreateDBStatistics();
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileCacheTest_GetBlobFileReader_IOError"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileCacheTest_GetBlobFileReader_IOError");
   options.enable_blob_files = true;
 
   constexpr size_t capacity = 10;
@@ -223,10 +218,8 @@ TEST_F(BlobFileCacheTest, GetBlobFileReader_CacheFull) {
   Options options;
   options.env = &mock_env_;
   options.statistics = CreateDBStatistics();
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileCacheTest_GetBlobFileReader_CacheFull"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileCacheTest_GetBlobFileReader_CacheFull");
   options.enable_blob_files = true;
 
   constexpr uint32_t column_family_id = 1;

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -73,11 +73,10 @@ Status BlobFileReader::OpenFile(
   assert(file_size);
   assert(file_reader);
 
-  const auto& cf_paths = immutable_options.cf_paths;
-  assert(!cf_paths.empty());
+  const auto& blob_path = immutable_options.blob_path;
+  assert(!blob_path.empty());
 
-  const std::string blob_file_path =
-      BlobFileName(cf_paths.front().path, blob_file_number);
+  const std::string blob_file_path = BlobFileName(blob_path, blob_file_number);
 
   FileSystem* const fs = immutable_options.fs.get();
   assert(fs);

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -37,12 +37,12 @@ void WriteBlobFile(const ImmutableOptions& immutable_options,
                    uint64_t blob_file_number, const Slice& key,
                    const Slice& blob, CompressionType compression_type,
                    uint64_t* blob_offset, uint64_t* blob_size) {
-  assert(!immutable_options.cf_paths.empty());
+  assert(!immutable_options.blob_path.empty());
   assert(blob_offset);
   assert(blob_size);
 
   const std::string blob_file_path =
-      BlobFileName(immutable_options.cf_paths.front().path, blob_file_number);
+      BlobFileName(immutable_options.blob_path, blob_file_number);
 
   std::unique_ptr<FSWritableFile> file;
   ASSERT_OK(NewWritableFile(immutable_options.fs.get(), blob_file_path, &file,
@@ -115,10 +115,8 @@ class BlobFileReaderTest : public testing::Test {
 TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileReaderTest_CreateReaderAndGetBlob"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileReaderTest_CreateReaderAndGetBlob");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -257,8 +255,8 @@ TEST_F(BlobFileReaderTest, Malformed) {
 
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_Malformed"), 0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_Malformed");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -271,7 +269,7 @@ TEST_F(BlobFileReaderTest, Malformed) {
     constexpr ExpirationRange expiration_range;
 
     const std::string blob_file_path =
-        BlobFileName(immutable_options.cf_paths.front().path, blob_file_number);
+        BlobFileName(immutable_options.blob_path, blob_file_number);
 
     std::unique_ptr<FSWritableFile> file;
     ASSERT_OK(NewWritableFile(immutable_options.fs.get(), blob_file_path, &file,
@@ -309,8 +307,8 @@ TEST_F(BlobFileReaderTest, Malformed) {
 TEST_F(BlobFileReaderTest, TTL) {
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_TTL"), 0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_TTL");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -343,10 +341,8 @@ TEST_F(BlobFileReaderTest, TTL) {
 TEST_F(BlobFileReaderTest, ExpirationRangeInHeader) {
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileReaderTest_ExpirationRangeInHeader"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileReaderTest_ExpirationRangeInHeader");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -382,10 +378,8 @@ TEST_F(BlobFileReaderTest, ExpirationRangeInHeader) {
 TEST_F(BlobFileReaderTest, ExpirationRangeInFooter) {
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileReaderTest_ExpirationRangeInFooter"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileReaderTest_ExpirationRangeInFooter");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -421,10 +415,8 @@ TEST_F(BlobFileReaderTest, ExpirationRangeInFooter) {
 TEST_F(BlobFileReaderTest, IncorrectColumnFamily) {
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileReaderTest_IncorrectColumnFamily"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileReaderTest_IncorrectColumnFamily");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -459,8 +451,8 @@ TEST_F(BlobFileReaderTest, IncorrectColumnFamily) {
 TEST_F(BlobFileReaderTest, BlobCRCError) {
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_BlobCRCError"), 0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_BlobCRCError");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -517,8 +509,8 @@ TEST_F(BlobFileReaderTest, Compression) {
 
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_Compression"), 0);
+  options.blob_path =
+      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_Compression");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -583,10 +575,8 @@ TEST_F(BlobFileReaderTest, UncompressionError) {
 
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileReaderTest_UncompressionError"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileReaderTest_UncompressionError");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -664,10 +654,8 @@ TEST_P(BlobFileReaderIOErrorTest, IOError) {
 
   Options options;
   options.env = &fault_injection_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&fault_injection_env_,
-                            "BlobFileReaderIOErrorTest_IOError"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &fault_injection_env_, "BlobFileReaderIOErrorTest_IOError");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);
@@ -742,10 +730,8 @@ INSTANTIATE_TEST_CASE_P(BlobFileReaderTest, BlobFileReaderDecodingErrorTest,
 TEST_P(BlobFileReaderDecodingErrorTest, DecodingError) {
   Options options;
   options.env = &mock_env_;
-  options.cf_paths.emplace_back(
-      test::PerThreadDBPath(&mock_env_,
-                            "BlobFileReaderDecodingErrorTest_DecodingError"),
-      0);
+  options.blob_path = test::PerThreadDBPath(
+      &mock_env_, "BlobFileReaderDecodingErrorTest_DecodingError");
   options.enable_blob_files = true;
 
   ImmutableOptions immutable_options(options);

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -359,6 +359,10 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
     }
   }
 
+  if (result.blob_path.empty() && !result.cf_paths.empty()) {
+    result.blob_path = result.cf_paths.front().path;
+  }
+
   if (result.max_compaction_bytes == 0) {
     result.max_compaction_bytes = result.target_file_size_base * 25;
   }

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -3334,6 +3334,49 @@ TEST_P(ColumnFamilyTest, DefaultCfPathsTest) {
   ASSERT_EQ(1, GetSstFileCount(dbname_));
 }
 
+TEST_P(ColumnFamilyTest, BlobPathTest) {
+  Open();
+  // If blob_path is not specified, the blob file will be stored in
+  // cf_paths[0].path. Otherwise, the blob file will be stored in blob_path.
+  ColumnFamilyOptions cf_opt1, cf_opt2;
+  cf_opt1.enable_blob_files = true;
+  cf_opt1.min_blob_size = 0;
+  cf_opt1.cf_paths.emplace_back(dbname_ + "_one",
+                                std::numeric_limits<uint64_t>::max());
+  cf_opt2.enable_blob_files = true;
+  cf_opt2.min_blob_size = 0;
+  cf_opt2.cf_paths.emplace_back(dbname_ + "_two",
+                                std::numeric_limits<uint64_t>::max());
+  cf_opt2.blob_path = dbname_ + "_two_blob";
+
+  CreateColumnFamilies({"one", "two"}, {cf_opt1, cf_opt2});
+  Reopen({ColumnFamilyOptions(), cf_opt1, cf_opt2});
+  ASSERT_OK(Put(1, "key1", "val1"));
+  ASSERT_OK(Put(2, "key2", "val2"));
+  ASSERT_OK(Flush(1));
+  ASSERT_OK(Flush(2));
+  ASSERT_EQ("val1", Get(1, "key1"));
+  ASSERT_EQ("val2", Get(2, "key2"));
+
+  // There should be a blob file under directories both cf_opt1.cf_paths[0].path
+  // and cf_opt2.blob_path.
+  auto check_blobfilecount = [&](const std::string& dir, int expected) {
+    std::vector<std::string> files;
+    ASSERT_OK(env_->GetChildren(dir, &files));
+    int blob_file_count = 0;
+    for (const auto& file : files) {
+      uint64_t number;
+      FileType type;
+      if (ParseFileName(file, &number, &type) && type == kBlobFile) {
+        blob_file_count++;
+      }
+    }
+    ASSERT_EQ(expected, blob_file_count);
+  };
+  check_blobfilecount(cf_opt1.cf_paths[0].path, 1);
+  check_blobfilecount(cf_opt2.blob_path, 1);
+}
+
 TEST_P(ColumnFamilyTest, MultipleCFPathsTest) {
   Open();
   // Configure Column family specific paths.

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2699,16 +2699,22 @@ Status DBImpl::CreateColumnFamilyImpl(const ColumnFamilyOptions& cf_options,
   DBOptions db_options =
       BuildDBOptions(immutable_db_options_, mutable_db_options_);
   s = ColumnFamilyData::ValidateOptions(db_options, cf_options);
-  if (s.ok()) {
-    for (auto& cf_path : cf_options.cf_paths) {
-      s = env_->CreateDirIfMissing(cf_path.path);
-      if (!s.ok()) {
-        break;
-      }
-    }
-  }
   if (!s.ok()) {
     return s;
+  }
+
+  for (auto& cf_path : cf_options.cf_paths) {
+    s = env_->CreateDirIfMissing(cf_path.path);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  if (!cf_options.blob_path.empty()) {
+    s = env_->CreateDirIfMissing(cf_options.blob_path);
+    if (!s.ok()) {
+      return s;
+    }
   }
 
   SuperVersionContext sv_context(/* create_superversion */ true);
@@ -4094,6 +4100,9 @@ Status DestroyDB(const std::string& dbname, const Options& options,
       for (const DbPath& cf_path : cf.options.cf_paths) {
         paths.insert(cf_path.path);
       }
+      if (!cf.options.blob_path.empty()) {
+        paths.insert(cf.options.blob_path);
+      }
     }
     for (const auto& path : paths) {
       if (env->GetChildren(path, &filenames).ok()) {
@@ -5009,8 +5018,8 @@ Status DBImpl::VerifyChecksumInternal(const ReadOptions& read_options,
         const uint64_t blob_file_number = pair.first;
         const auto& meta = pair.second;
         assert(meta);
-        const std::string blob_file_name = BlobFileName(
-            cfd->ioptions()->cf_paths.front().path, blob_file_number);
+        const std::string blob_file_name =
+            BlobFileName(cfd->ioptions()->blob_path, blob_file_number);
         s = VerifyFullFileChecksum(meta->GetChecksumValue(),
                                    meta->GetChecksumMethod(), blob_file_name,
                                    read_options);

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1584,6 +1584,9 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
       for (auto& cf_path : cf.options.cf_paths) {
         paths.emplace_back(cf_path.path);
       }
+      if (!cf.options.blob_path.empty()) {
+        paths.emplace_back(cf.options.blob_path);
+      }
     }
     for (auto& path : paths) {
       s = impl->env_->CreateDirIfMissing(path);

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -211,7 +211,7 @@ TEST_F(ObsoleteFilesTest, BlobFiles) {
   assert(ioptions);
   assert(!ioptions->cf_paths.empty());
 
-  const std::string& path = ioptions->cf_paths.front().path;
+  const std::string& path = ioptions->blob_path;
 
   // Add an obsolete blob file.
   constexpr uint64_t first_blob_file_number = 234;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -450,7 +450,7 @@ class VersionBuilder::Rep {
         assert(shared_meta);
 
         vs->AddObsoleteBlobFile(shared_meta->GetBlobFileNumber(),
-                                ioptions->cf_paths.front().path);
+                                ioptions->blob_path);
       }
 
       delete shared_meta;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1512,10 +1512,10 @@ void Version::GetColumnFamilyMetaData(ColumnFamilyMetaData* cf_meta) {
     const auto meta = iter.second.get();
     cf_meta->blob_files.emplace_back(
         meta->GetBlobFileNumber(), BlobFileName("", meta->GetBlobFileNumber()),
-        ioptions->cf_paths.front().path, meta->GetBlobFileSize(),
-        meta->GetTotalBlobCount(), meta->GetTotalBlobBytes(),
-        meta->GetGarbageBlobCount(), meta->GetGarbageBlobBytes(),
-        meta->GetChecksumMethod(), meta->GetChecksumValue());
+        ioptions->blob_path, meta->GetBlobFileSize(), meta->GetTotalBlobCount(),
+        meta->GetTotalBlobBytes(), meta->GetGarbageBlobCount(),
+        meta->GetGarbageBlobBytes(), meta->GetChecksumMethod(),
+        meta->GetChecksumValue());
     cf_meta->blob_file_count++;
     cf_meta->blob_file_size += meta->GetBlobFileSize();
   }

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -842,6 +842,15 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through the SetOptions() API
   double blob_garbage_collection_age_cutoff = 0.25;
 
+  // A path where blob files for this column family can be put into. Blob
+  // files are not associated with levels, so the logic for placing SSTs
+  // files does not readily generalize to blob files. Currently, A single path
+  // be used to store blob files. If blob_path is empty, cf_paths.front() will
+  // be used.
+  //
+  // Default: empty
+  std::string blob_path = "";
+
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -829,7 +829,8 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
           cf_options.memtable_insert_with_hint_prefix_extractor),
       cf_paths(cf_options.cf_paths),
       compaction_thread_limiter(cf_options.compaction_thread_limiter),
-      sst_partitioner_factory(cf_options.sst_partitioner_factory) {}
+      sst_partitioner_factory(cf_options.sst_partitioner_factory),
+      blob_path(cf_options.blob_path) {}
 
 ImmutableOptions::ImmutableOptions() : ImmutableOptions(Options()) {}
 

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -82,6 +82,8 @@ struct ImmutableCFOptions {
   std::shared_ptr<ConcurrentTaskLimiter> compaction_thread_limiter;
 
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory;
+
+  std::string blob_path;
 };
 
 struct ImmutableOptions : public ImmutableDBOptions, public ImmutableCFOptions {

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -388,6 +388,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
        sizeof(std::shared_ptr<MemTableRepFactory>)},
       {offset_of(&ColumnFamilyOptions::table_properties_collector_factories),
        sizeof(ColumnFamilyOptions::TablePropertiesCollectorFactories)},
+      {offset_of(&ColumnFamilyOptions::blob_path), sizeof(std::string)},
       {offset_of(&ColumnFamilyOptions::comparator), sizeof(Comparator*)},
       {offset_of(&ColumnFamilyOptions::merge_operator),
        sizeof(std::shared_ptr<MergeOperator>)},


### PR DESCRIPTION
Summary:
This PR is for https://github.com/facebook/rocksdb/issues/8535
A new option called blob_path to set blob file path for integrated blobdb is added. To maintain backward compatibility, if blob_path is empty, cf_paths.front() will be used.