### PR TITLE
Dynamically configure BlockBasedTableOptions.prepopulate_block_cache

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 * Made the EventListener extend the Customizable class.
 * EventListeners that have a non-empty Name() and that are registered with the ObjectRegistry can now be serialized to/from the OPTIONS file.
 * Insert warm blocks (data blocks, uncompressed dict blocks, index and filter blocks) in Block cache during flush under option BlockBasedTableOptions.prepopulate_block_cache. Previously it was enabled for only data blocks.
+* BlockBasedTableOptions.prepopulate_block_cache can be dynamically configured using DB::SetOptions.
 
 ### Performance Improvements
 * Try to avoid updating DBOptions if `SetDBOptions()` does not change any option value.

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -472,6 +472,10 @@ struct BlockBasedTableOptions {
   // further helps if the workload exhibits high temporal locality, where most
   // of the reads go to recently written data. This also helps in case of
   // Distributed FileSystem.
+  //
+  // This parameter can be changed dynamically by
+  // DB::SetOptions({{"block_based_table_factory",
+  //                  "{prepopulate_block_cache=kFlushOnly;}"}}));
   enum class PrepopulateBlockCache : char {
     // Disable prepopulate block cache.
     kDisable,

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -262,54 +262,8 @@ class OptionTypeInfo {
   // @param map The string to enum mapping for this enum
   template <typename T>
   static OptionTypeInfo Enum(
-      int offset, const std::unordered_map<std::string, T>* const map) {
-    return OptionTypeInfo(
-        offset, OptionType::kEnum, OptionVerificationType::kNormal,
-        OptionTypeFlags::kNone,
-        // Uses the map argument to convert the input string into
-        // its corresponding enum value.  If value is found in the map,
-        // addr is updated to the corresponding map entry.
-        // @return OK if the value is found in the map
-        // @return InvalidArgument if the value is not found in the map
-        [map](const ConfigOptions&, const std::string& name,
-              const std::string& value, void* addr) {
-          if (map == nullptr) {
-            return Status::NotSupported("No enum mapping ", name);
-          } else if (ParseEnum<T>(*map, value, static_cast<T*>(addr))) {
-            return Status::OK();
-          } else {
-            return Status::InvalidArgument("No mapping for enum ", name);
-          }
-        },
-        // Uses the map argument to convert the input enum into
-        // its corresponding string value.  If enum value is found in the map,
-        // value is updated to the corresponding string value in the map.
-        // @return OK if the enum is found in the map
-        // @return InvalidArgument if the enum is not found in the map
-        [map](const ConfigOptions&, const std::string& name, const void* addr,
-              std::string* value) {
-          if (map == nullptr) {
-            return Status::NotSupported("No enum mapping ", name);
-          } else if (SerializeEnum<T>(*map, (*static_cast<const T*>(addr)),
-                                      value)) {
-            return Status::OK();
-          } else {
-            return Status::InvalidArgument("No mapping for enum ", name);
-          }
-        },
-        // Casts addr1 and addr2 to the enum type and returns true if
-        // they are equal, false otherwise.
-        [](const ConfigOptions&, const std::string&, const void* addr1,
-           const void* addr2, std::string*) {
-          return (*static_cast<const T*>(addr1) ==
-                  *static_cast<const T*>(addr2));
-        });
-  }  // End OptionTypeInfo::Enum
-
-  template <typename T>
-  static OptionTypeInfo Enum(
       int offset, const std::unordered_map<std::string, T>* const map,
-      OptionTypeFlags flags) {
+      OptionTypeFlags flags = OptionTypeFlags::kNone) {
     return OptionTypeInfo(
         offset, OptionType::kEnum, OptionVerificationType::kNormal, flags,
         // Uses the map argument to convert the input string into

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -306,6 +306,52 @@ class OptionTypeInfo {
         });
   }  // End OptionTypeInfo::Enum
 
+  template <typename T>
+  static OptionTypeInfo Enum(
+      int offset, const std::unordered_map<std::string, T>* const map,
+      OptionTypeFlags flags) {
+    return OptionTypeInfo(
+        offset, OptionType::kEnum, OptionVerificationType::kNormal, flags,
+        // Uses the map argument to convert the input string into
+        // its corresponding enum value.  If value is found in the map,
+        // addr is updated to the corresponding map entry.
+        // @return OK if the value is found in the map
+        // @return InvalidArgument if the value is not found in the map
+        [map](const ConfigOptions&, const std::string& name,
+              const std::string& value, void* addr) {
+          if (map == nullptr) {
+            return Status::NotSupported("No enum mapping ", name);
+          } else if (ParseEnum<T>(*map, value, static_cast<T*>(addr))) {
+            return Status::OK();
+          } else {
+            return Status::InvalidArgument("No mapping for enum ", name);
+          }
+        },
+        // Uses the map argument to convert the input enum into
+        // its corresponding string value.  If enum value is found in the map,
+        // value is updated to the corresponding string value in the map.
+        // @return OK if the enum is found in the map
+        // @return InvalidArgument if the enum is not found in the map
+        [map](const ConfigOptions&, const std::string& name, const void* addr,
+              std::string* value) {
+          if (map == nullptr) {
+            return Status::NotSupported("No enum mapping ", name);
+          } else if (SerializeEnum<T>(*map, (*static_cast<const T*>(addr)),
+                                      value)) {
+            return Status::OK();
+          } else {
+            return Status::InvalidArgument("No mapping for enum ", name);
+          }
+        },
+        // Casts addr1 and addr2 to the enum type and returns true if
+        // they are equal, false otherwise.
+        [](const ConfigOptions&, const std::string&, const void* addr1,
+           const void* addr2, std::string*) {
+          return (*static_cast<const T*>(addr1) ==
+                  *static_cast<const T*>(addr2));
+        });
+  }  // End OptionTypeInfo::Enum
+
   // Creates an OptionTypeInfo for a Struct type.  Structs have a
   // map of string-OptionTypeInfo associated with them that describes how
   // to process the object for parsing, serializing, and matching.

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -427,7 +427,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
         {"prepopulate_block_cache",
          OptionTypeInfo::Enum<BlockBasedTableOptions::PrepopulateBlockCache>(
              offsetof(struct BlockBasedTableOptions, prepopulate_block_cache),
-             &block_base_table_prepopulate_block_cache_string_map)},
+             &block_base_table_prepopulate_block_cache_string_map,
+             OptionTypeFlags::kMutable)},
 
 #endif  // ROCKSDB_LITE
 };


### PR DESCRIPTION
Summary: Dynamically configure BlockBasedTableOptions.prepopulate_block_cache using DB::SetOptions.

Test Plan: Added new unit test

Reviewers:

Subscribers:

Tasks:

Tags: