### PR TITLE
Attempt to deflake ObsoleteFilesTest.DeleteObsoleteOptionsFile

### DIFF
--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -524,12 +524,6 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
         break;
       case kOptionsFile:
         keep = (number >= optsfile_num2);
-        TEST_SYNC_POINT_CALLBACK(
-            "DBImpl::PurgeObsoleteFiles:CheckOptionsFiles:1",
-            reinterpret_cast<void*>(&number));
-        TEST_SYNC_POINT_CALLBACK(
-            "DBImpl::PurgeObsoleteFiles:CheckOptionsFiles:2",
-            reinterpret_cast<void*>(&keep));
         break;
       case kCurrentFile:
       case kDBLockFile:

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -149,18 +149,6 @@ TEST_F(ObsoleteFilesTest, RaceForObsoleteFileDeletion) {
 
 TEST_F(ObsoleteFilesTest, DeleteObsoleteOptionsFile) {
   ReopenDB();
-  SyncPoint::GetInstance()->DisableProcessing();
-  std::vector<uint64_t> optsfiles_nums;
-  std::vector<bool> optsfiles_keep;
-  SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::PurgeObsoleteFiles:CheckOptionsFiles:1", [&](void* arg) {
-        optsfiles_nums.push_back(*reinterpret_cast<uint64_t*>(arg));
-      });
-  SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::PurgeObsoleteFiles:CheckOptionsFiles:2", [&](void* arg) {
-        optsfiles_keep.push_back(*reinterpret_cast<bool*>(arg));
-      });
-  SyncPoint::GetInstance()->EnableProcessing();
 
   createLevel0Files(2, 50000);
   CheckFileTypeCounts(wal_dir_, 1, 0, 0);
@@ -176,7 +164,6 @@ TEST_F(ObsoleteFilesTest, DeleteObsoleteOptionsFile) {
     }
   }
   ASSERT_OK(dbfull()->EnableFileDeletions(true /* force */));
-  ASSERT_EQ(optsfiles_nums.size(), optsfiles_keep.size());
 
   Close();
 


### PR DESCRIPTION
Summary:
We've been seeing occasional crashes on CI while inserting into the
vectors in `ObsoleteFilesTest.DeleteObsoleteOptionsFile`. The crashes
don't reproduce locally (could be either a race or an object lifecycle
issue) but the good news is that the vectors in question are not really
used for anything meaningful by the test. (The assertion about the sizes
of the two vectors being equal is guaranteed to hold, since the two sync
points where they are populated are right after each other.) The patch
simply removes the vectors from the test, alongside the associated
callbacks and sync points.

Test Plan:
`make check`