### PR TITLE
Memtable sampling for mempurge heuristic.

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3029,9 +3029,9 @@ unsigned char rocksdb_options_get_advise_random_on_open(
   return opt->rep.advise_random_on_open;
 }
 
-void rocksdb_options_set_experimental_allow_mempurge(rocksdb_options_t* opt,
-                                                     unsigned char v) {
-  opt->rep.experimental_allow_mempurge = v;
+void rocksdb_options_set_experimental_mempurge_threshold(rocksdb_options_t* opt,
+                                                         double v) {
+  opt->rep.experimental_mempurge_threshold = v;
 }
 
 void rocksdb_options_set_access_hint_on_compaction_start(

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -8,6 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include <atomic>
+#include <limits>
 
 #include "db/db_impl/db_impl.h"
 #include "db/db_test_util.h"
@@ -694,8 +695,7 @@ TEST_F(DBFlushTest, MemPurgeBasic) {
   // Enforce size of a single MemTable to 64MB (64MB = 67108864 bytes).
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
-  options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = MemPurgePolicy::kSampling;
+  options.experimental_mempurge_threshold = std::numeric_limits<double>::max();
   ASSERT_OK(TryReopen(options));
   uint32_t mempurge_count = 0;
   uint32_t sst_count = 0;
@@ -842,8 +842,7 @@ TEST_F(DBFlushTest, MemPurgeDeleteAndDeleteRange) {
   // Enforce size of a single MemTable to 64MB (64MB = 67108864 bytes).
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
-  options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = MemPurgePolicy::kSampling;
+  options.experimental_mempurge_threshold = std::numeric_limits<double>::max();
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1046,8 +1045,7 @@ TEST_F(DBFlushTest, MemPurgeAndCompactionFilter) {
   // Enforce size of a single MemTable to 64MB (64MB = 67108864 bytes).
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
-  options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = MemPurgePolicy::kSampling;
+  options.experimental_mempurge_threshold = std::numeric_limits<double>::max();
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1122,8 +1120,7 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
   // Enforce size of a single MemTable to 128KB.
   options.write_buffer_size = 128 << 10;
   // Activate the MemPurge prototype.
-  options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = MemPurgePolicy::kSampling;
+  options.experimental_mempurge_threshold = std::numeric_limits<double>::max();
   ASSERT_OK(TryReopen(options));
 
   const size_t KVSIZE = 10;
@@ -1239,7 +1236,8 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
     const uint32_t EXPECTED_SST_COUNT = 0;
 
     EXPECT_GE(mempurge_count, EXPECTED_MIN_MEMPURGE_COUNT);
-    if (options.experimental_mempurge_policy == MemPurgePolicy::kAlways) {
+    if (options.experimental_mempurge_threshold ==
+        std::numeric_limits<double>::max()) {
       EXPECT_EQ(sst_count, EXPECTED_SST_COUNT);
     }
 

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -695,7 +695,7 @@ TEST_F(DBFlushTest, MemPurgeBasic) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = MemPurgePolicy::kAlways;
+  options.experimental_mempurge_policy = MemPurgePolicy::kSampling;
   ASSERT_OK(TryReopen(options));
   uint32_t mempurge_count = 0;
   uint32_t sst_count = 0;
@@ -843,7 +843,7 @@ TEST_F(DBFlushTest, MemPurgeDeleteAndDeleteRange) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = MemPurgePolicy::kAlways;
+  options.experimental_mempurge_policy = MemPurgePolicy::kSampling;
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1047,7 +1047,7 @@ TEST_F(DBFlushTest, MemPurgeAndCompactionFilter) {
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = MemPurgePolicy::kAlways;
+  options.experimental_mempurge_policy = MemPurgePolicy::kSampling;
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1123,7 +1123,7 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
   options.write_buffer_size = 128 << 10;
   // Activate the MemPurge prototype.
   options.experimental_allow_mempurge = true;
-  options.experimental_mempurge_policy = MemPurgePolicy::kAlways;
+  options.experimental_mempurge_policy = MemPurgePolicy::kSampling;
   ASSERT_OK(TryReopen(options));
 
   const size_t KVSIZE = 10;

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -695,7 +695,8 @@ TEST_F(DBFlushTest, MemPurgeBasic) {
   // Enforce size of a single MemTable to 64MB (64MB = 67108864 bytes).
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
-  options.experimental_mempurge_threshold = std::numeric_limits<double>::max();
+  options.experimental_mempurge_threshold =
+      1.0;  // std::numeric_limits<double>::max();
   ASSERT_OK(TryReopen(options));
   uint32_t mempurge_count = 0;
   uint32_t sst_count = 0;
@@ -842,7 +843,8 @@ TEST_F(DBFlushTest, MemPurgeDeleteAndDeleteRange) {
   // Enforce size of a single MemTable to 64MB (64MB = 67108864 bytes).
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
-  options.experimental_mempurge_threshold = std::numeric_limits<double>::max();
+  options.experimental_mempurge_threshold =
+      1.0;  // std::numeric_limits<double>::max();
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1045,7 +1047,8 @@ TEST_F(DBFlushTest, MemPurgeAndCompactionFilter) {
   // Enforce size of a single MemTable to 64MB (64MB = 67108864 bytes).
   options.write_buffer_size = 1 << 20;
   // Activate the MemPurge prototype.
-  options.experimental_mempurge_threshold = std::numeric_limits<double>::max();
+  options.experimental_mempurge_threshold =
+      1.0;  // std::numeric_limits<double>::max();
   ASSERT_OK(TryReopen(options));
 
   uint32_t mempurge_count = 0;
@@ -1120,7 +1123,8 @@ TEST_F(DBFlushTest, MemPurgeWALSupport) {
   // Enforce size of a single MemTable to 128KB.
   options.write_buffer_size = 128 << 10;
   // Activate the MemPurge prototype.
-  options.experimental_mempurge_threshold = std::numeric_limits<double>::max();
+  options.experimental_mempurge_threshold =
+      1.0;  // std::numeric_limits<double>::max();
   ASSERT_OK(TryReopen(options));
 
   const size_t KVSIZE = 10;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -558,7 +558,7 @@ Status DBImpl::CloseHelper() {
   // flushing (but need to implement something
   // else than imm()->IsFlushPending() because the output
   // memtables added to imm() dont trigger flushes).
-  if (immutable_db_options_.experimental_allow_mempurge) {
+  if (immutable_db_options_.experimental_mempurge_threshold > 0.0) {
     Status flush_ret;
     mutex_.Unlock();
     for (ColumnFamilyData* cf : *versions_->GetColumnFamilySet()) {

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2410,7 +2410,7 @@ void DBImpl::SchedulePendingFlush(const FlushRequest& flush_req,
     // future changes. Therefore, we add the following if
     // statement - note that calling it twice (or more)
     // doesn't break anything.
-    if (immutable_db_options_.experimental_allow_mempurge) {
+    if (immutable_db_options_.experimental_mempurge_threshold > 0.0) {
       // If imm() contains silent memtables,
       // requesting a flush will mark the imm_needed as true.
       cfd->imm()->FlushRequested();
@@ -2556,7 +2556,7 @@ Status DBImpl::BackgroundFlush(bool* made_progress, JobContext* job_context,
 
     for (const auto& iter : flush_req) {
       ColumnFamilyData* cfd = iter.first;
-      if (immutable_db_options_.experimental_allow_mempurge) {
+      if (immutable_db_options_.experimental_mempurge_threshold > 0.0) {
         // If imm() contains silent memtables,
         // requesting a flush will mark the imm_needed as true.
         cfd->imm()->FlushRequested();

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -195,7 +195,7 @@ void FlushJob::PickMemTable() {
   // If mempurge feature is activated, keep track of any potential
   // memtables coming from a previous mempurge operation.
   // Used for mempurge policy.
-  if (db_options_.experimental_allow_mempurge) {
+  if (db_options_.experimental_mempurge_threshold > 0.0) {
     contains_mempurge_outcome_ = false;
     for (MemTable* mt : mems_) {
       if (cfd_->imm()->IsMemPurgeOutput(mt->GetID())) {
@@ -241,7 +241,7 @@ Status FlushJob::Run(LogsWithPrepTracker* prep_tracker,
     prev_cpu_read_nanos = IOSTATS(cpu_read_nanos);
   }
   Status mempurge_s = Status::NotFound("No MemPurge.");
-  if (db_options_.experimental_allow_mempurge &&
+  if ((db_options_.experimental_mempurge_threshold > 0.0) &&
       (cfd_->GetFlushReason() == FlushReason::kWriteBufferFull) &&
       (!mems_.empty()) && MemPurgeDecider()) {
     mempurge_s = MemPurge();
@@ -622,125 +622,121 @@ Status FlushJob::MemPurge() {
 }
 
 bool FlushJob::MemPurgeDecider() {
-  MemPurgePolicy policy = db_options_.experimental_mempurge_policy;
-  if (policy == MemPurgePolicy::kAlways) {
+  double threshold = db_options_.experimental_mempurge_threshold;
+  // Never trigger mempurge when threshold<=0.
+  if (threshold <= 0.0) {
+    return false;
+  }
+  if (threshold > (1.0 * mems_.size())) {
     return true;
-  } else if (policy == MemPurgePolicy::kAlternate) {
-    // Note: if at least one of the flushed memtables is
-    // an output of a previous mempurge process, then flush
-    // to storage.
-    return !(contains_mempurge_outcome_);
-  } else if (policy == MemPurgePolicy::kSampling) {
-    // Payload and useful_payload (in bytes).
-    // The useful payload ratio of a given MemTable
-    // is estimated to be useful_payload/payload.
-    uint64_t payload = 0, useful_payload = 0;
-    // If estimated_useful_payload is > 100%,
-    // then flush to storage, else MemPurge.
-    double estimated_useful_payload = 0.0;
-    // Cochran formula for determining sample size.
-    // 95% confidence interval, 7% precision.
-    // double n0 = (1.96*1.96)*0.25/(0.07*0.07)
-    double n0 = 196.0;
-    ReadOptions ro;
-    ro.total_order_seek = true;
+  }
+  // Payload and useful_payload (in bytes).
+  // The useful payload ratio of a given MemTable
+  // is estimated to be useful_payload/payload.
+  uint64_t payload = 0, useful_payload = 0;
+  // If estimated_useful_payload is > threshold,
+  // then flush to storage, else MemPurge.
+  double estimated_useful_payload = 0.0;
+  // Cochran formula for determining sample size.
+  // 95% confidence interval, 7% precision.
+  // double n0 = (1.96*1.96)*0.25/(0.07*0.07)
+  double n0 = 196.0;
+  ReadOptions ro;
+  ro.total_order_seek = true;
 
-    // Iterate over each memtable of the set.
-    for (MemTable* mt : mems_) {
-      // If the memtable is the output of a previous mempurge,
-      // its approximate useful payload ratio is already calculated.
-      if (cfd_->imm()->IsMemPurgeOutput(mt->GetID())) {
-        estimated_useful_payload +=
-            cfd_->imm()->MemPurgeOutputUsefulPayload(mt->GetID());
-      } else {
-        // Else sample from the table.
-        uint64_t nentries = mt->num_entries();
-        // Corrected Cochran formula for small populations
-        // (converges to n0 for large populations).
-        uint64_t target_sample_size =
-            static_cast<uint64_t>(ceil(n0 / (1.0 + (n0 / nentries))));
-        std::unordered_set<const char*> sentries = {};
-        // Populate sample entries set.
-        mt->UniqueRandomSample(target_sample_size, &sentries);
+  // Iterate over each memtable of the set.
+  for (MemTable* mt : mems_) {
+    // If the memtable is the output of a previous mempurge,
+    // its approximate useful payload ratio is already calculated.
+    if (cfd_->imm()->IsMemPurgeOutput(mt->GetID())) {
+      estimated_useful_payload +=
+          cfd_->imm()->MemPurgeOutputUsefulPayload(mt->GetID());
+    } else {
+      // Else sample from the table.
+      uint64_t nentries = mt->num_entries();
+      // Corrected Cochran formula for small populations
+      // (converges to n0 for large populations).
+      uint64_t target_sample_size =
+          static_cast<uint64_t>(ceil(n0 / (1.0 + (n0 / nentries))));
+      std::unordered_set<const char*> sentries = {};
+      // Populate sample entries set.
+      mt->UniqueRandomSample(target_sample_size, &sentries);
 
-        // Estimate the garbage ratio by comparing if
-        // each sample corresponds to a valid entry.
-        for (const char* ss : sentries) {
-          ParsedInternalKey res;
-          Slice entry_slice = GetLengthPrefixedSlice(ss);
-          Status parse_s =
-              ParseInternalKey(entry_slice, &res, true /*log_err_key*/);
-          if (!parse_s.ok()) {
-            ROCKS_LOG_WARN(db_options_.info_log,
-                           "Memtable Decider: ParseInternalKey did not parse "
-                           "entry_slice %s"
-                           "successfully.",
-                           entry_slice.data());
-          }
-          LookupKey lkey(res.user_key, kMaxSequenceNumber);
-          std::string vget;
-          Status s;
-          MergeContext merge_context;
-          SequenceNumber max_covering_tombstone_seq = 0, sqno = 0;
+      // Estimate the garbage ratio by comparing if
+      // each sample corresponds to a valid entry.
+      for (const char* ss : sentries) {
+        ParsedInternalKey res;
+        Slice entry_slice = GetLengthPrefixedSlice(ss);
+        Status parse_s =
+            ParseInternalKey(entry_slice, &res, true /*log_err_key*/);
+        if (!parse_s.ok()) {
+          ROCKS_LOG_WARN(db_options_.info_log,
+                         "Memtable Decider: ParseInternalKey did not parse "
+                         "entry_slice %s"
+                         "successfully.",
+                         entry_slice.data());
+        }
+        LookupKey lkey(res.user_key, kMaxSequenceNumber);
+        std::string vget;
+        Status s;
+        MergeContext merge_context;
+        SequenceNumber max_covering_tombstone_seq = 0, sqno = 0;
 
-          // Pick the oldest existing snapshot that is more recent
-          // than the sequence number of the sampled entry.
-          SequenceNumber min_seqno_snapshot = kMaxSequenceNumber;
-          SnapshotImpl min_snapshot;
-          for (SequenceNumber seq_num : existing_snapshots_) {
-            if (seq_num > res.sequence && seq_num < min_seqno_snapshot) {
-              min_seqno_snapshot = seq_num;
-            }
-          }
-          min_snapshot.number_ = min_seqno_snapshot;
-          ro.snapshot =
-              min_seqno_snapshot < kMaxSequenceNumber ? &min_snapshot : nullptr;
-
-          // Estimate if the sample entry is valid or not.
-          bool gres = mt->Get(lkey, &vget, nullptr, &s, &merge_context,
-                              &max_covering_tombstone_seq, &sqno, ro);
-          if (!gres) {
-            ROCKS_LOG_WARN(
-                db_options_.info_log,
-                "Memtable Get returned false when Get(sampled entry). "
-                "Yet each sample entry should exist somewhere in the memtable, "
-                "unrelated to whether it has been deleted or not.");
-          }
-          payload += entry_slice.size();
-
-          // TODO(bjlemaire): evaluate typeMerge.
-          // This is where the sampled entry is estimated to be
-          // garbage or not. Note that this is a garbage *estimation*
-          // because we do not include certain items such as
-          // CompactionFitlers triggered at flush, or if the same delete
-          // has been inserted twice or more in the memtable.
-          if (res.type == kTypeValue && gres && s.ok() &&
-              sqno == res.sequence) {
-            useful_payload += entry_slice.size();
-          } else if (((res.type == kTypeDeletion) ||
-                      (res.type == kTypeSingleDeletion)) &&
-                     s.IsNotFound() && gres) {
-            useful_payload += entry_slice.size();
+        // Pick the oldest existing snapshot that is more recent
+        // than the sequence number of the sampled entry.
+        SequenceNumber min_seqno_snapshot = kMaxSequenceNumber;
+        SnapshotImpl min_snapshot;
+        for (SequenceNumber seq_num : existing_snapshots_) {
+          if (seq_num > res.sequence && seq_num < min_seqno_snapshot) {
+            min_seqno_snapshot = seq_num;
           }
         }
-        if (payload > 0) {
-          estimated_useful_payload += useful_payload * 1.0 / payload;
-          ROCKS_LOG_INFO(
-              db_options_.info_log,
-              "Mempurge kSampling policy: garbage ratio from sampling: %f.\n",
-              (payload - useful_payload) * 1.0 / payload);
-        } else {
+        min_snapshot.number_ = min_seqno_snapshot;
+        ro.snapshot =
+            min_seqno_snapshot < kMaxSequenceNumber ? &min_snapshot : nullptr;
+
+        // Estimate if the sample entry is valid or not.
+        bool gres = mt->Get(lkey, &vget, nullptr, &s, &merge_context,
+                            &max_covering_tombstone_seq, &sqno, ro);
+        if (!gres) {
           ROCKS_LOG_WARN(
               db_options_.info_log,
-              "Mempurge kSampling policy: null payload measured, and collected "
-              "sample size is %zu\n.",
-              sentries.size());
+              "Memtable Get returned false when Get(sampled entry). "
+              "Yet each sample entry should exist somewhere in the memtable, "
+              "unrelated to whether it has been deleted or not.");
+        }
+        payload += entry_slice.size();
+
+        // TODO(bjlemaire): evaluate typeMerge.
+        // This is where the sampled entry is estimated to be
+        // garbage or not. Note that this is a garbage *estimation*
+        // because we do not include certain items such as
+        // CompactionFitlers triggered at flush, or if the same delete
+        // has been inserted twice or more in the memtable.
+        if (res.type == kTypeValue && gres && s.ok() && sqno == res.sequence) {
+          useful_payload += entry_slice.size();
+        } else if (((res.type == kTypeDeletion) ||
+                    (res.type == kTypeSingleDeletion)) &&
+                   s.IsNotFound() && gres) {
+          useful_payload += entry_slice.size();
         }
       }
+      if (payload > 0) {
+        estimated_useful_payload += useful_payload * 1.0 / payload;
+        ROCKS_LOG_INFO(
+            db_options_.info_log,
+            "Mempurge kSampling policy: garbage ratio from sampling: %f.\n",
+            (payload - useful_payload) * 1.0 / payload);
+      } else {
+        ROCKS_LOG_WARN(
+            db_options_.info_log,
+            "Mempurge kSampling policy: null payload measured, and collected "
+            "sample size is %zu\n.",
+            sentries.size());
+      }
     }
-    return estimated_useful_payload < 1.0;
   }
-  return false;
+  return estimated_useful_payload < threshold;
 }
 
 Status FlushJob::WriteLevel0Table() {
@@ -952,7 +948,7 @@ Status FlushJob::WriteLevel0Table() {
 
   stats.num_output_files_blob = static_cast<int>(blobs.size());
 
-  if (db_options_.experimental_allow_mempurge && s.ok()) {
+  if ((db_options_.experimental_mempurge_threshold > 0.0) && s.ok()) {
     // The db_mutex is held at this point.
     for (MemTable* mt : mems_) {
       // Note: if m is not a previous mempurge output memtable,

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -622,6 +622,7 @@ Status FlushJob::MemPurge() {
 }
 
 bool FlushJob::MemPurgeDecider() {
+  // new incoming decider!
   MemPurgePolicy policy = db_options_.experimental_mempurge_policy;
   if (policy == MemPurgePolicy::kAlways) {
     return true;

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -623,8 +623,8 @@ Status FlushJob::MemPurge() {
 
 bool FlushJob::MemPurgeDecider() {
   double threshold = db_options_.experimental_mempurge_threshold;
-  // Never trigger mempurge when threshold<=0.
-  if (threshold <= 0.0) {
+  // Never trigger mempurge if threshold is not a strictly positive value.
+  if (!(threshold > 0.0)) {
     return false;
   }
   if (threshold > (1.0 * mems_.size())) {
@@ -725,7 +725,7 @@ bool FlushJob::MemPurgeDecider() {
         estimated_useful_payload += useful_payload * 1.0 / payload;
         ROCKS_LOG_INFO(
             db_options_.info_log,
-            "Mempurge kSampling policy: garbage ratio from sampling: %f.\n",
+            "Mempurge sampling - found garbage ratio from sampling: %f.\n",
             (payload - useful_payload) * 1.0 / payload);
       } else {
         ROCKS_LOG_WARN(

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -690,7 +690,15 @@ bool FlushJob::MemPurgeDecider() {
             useful_payload += entry_slice.size();
           }
         }
-        estimated_useful_payload += useful_payload * 1.0 / payload;
+        if (payload > 0) {
+          estimated_useful_payload += useful_payload * 1.0 / payload;
+        } else {
+          ROCKS_LOG_WARN(
+              db_options_.info_log,
+              "Mempurge kSampling policy: null payload measured, and collected "
+              "sample size is %zu\n.",
+              sentries.size());
+        }
         ROCKS_LOG_INFO(
             db_options_.info_log,
             "Mempurge kSampling policy: garbage ratio from sampling: %f.\n",

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -117,9 +117,9 @@ class FlushJob {
   // of development. At the moment it is only compatible with the Get, Put,
   // Delete operations as well as Iterators and CompactionFilters.
   // For this early version, "MemPurge" is called by setting the
-  // options.experimental_allow_mempurge flag as "true". When this is
+  // options.experimental_mempurge_threshold value as >0.0. When this is
   // the case, ALL automatic flush operations (kWRiteBufferManagerFull) will
-  // first go through the MemPurge process. herefore, we strongly
+  // first go through the MemPurge process. Therefore, we strongly
   // recommend all users not to set this flag as true given that the MemPurge
   // process has not matured yet.
   Status MemPurge();
@@ -192,7 +192,7 @@ class FlushJob {
   const std::string full_history_ts_low_;
   BlobFileCompletionCallback* blob_callback_;
 
-  // Used when experimental_allow_mempurge set to true.
+  // Used when experimental_mempurge_threshold > 0.0.
   bool contains_mempurge_outcome_;
 };
 

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "db/dbformat.h"
@@ -143,6 +144,19 @@ class MemTable {
   // require external synchronization. The value may be less accurate though
   size_t ApproximateMemoryUsageFast() const {
     return approximate_memory_usage_.load(std::memory_order_relaxed);
+  }
+
+  // Returns an estimate of the number of bytes of data in use by this
+  // data structure.
+  //
+  // REQUIRES: external synchronization to prevent simultaneous
+  // operations on the same MemTable (unless this Memtable is immutable).
+  void RandomSample(const uint64_t& sample_size,
+                    std::unordered_set<const char*>* entries) {
+    if (sample_size > (num_entries_ / 2)) {
+      assert(false);
+    }
+    table_->RandomSample(sample_size, entries);
   }
 
   // This method heuristically determines if the memtable should continue to

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -146,23 +146,15 @@ class MemTable {
     return approximate_memory_usage_.load(std::memory_order_relaxed);
   }
 
-  // Returns an estimate of the number of bytes of data in use by this
-  // data structure.
+  // Returns a vector of unique random memtable entries of size 'sample_size'.
   //
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable (unless this Memtable is immutable).
   void UniqueRandomSample(const uint64_t& sample_size,
                           std::unordered_set<const char*>* entries) {
-    if (sample_size > (num_entries_ / 2)) {
-      ReadOptions ro;
-      ro.total_order_seek = true;
-      Arena arena;
-      InternalIterator* iter(NewIterator(ro, &arena));
-      for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-        entries->insert(iter->key().data());
-      }
-    }
-    table_->UniqueRandomSample(sample_size, entries);
+    // TODO(bjlemaire): at the moment, only supported by skiplistrep.
+    // Extend it to all other memtable representations.
+    table_->UniqueRandomSample(num_entries(), sample_size, entries);
   }
 
   // This method heuristically determines if the memtable should continue to

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -148,13 +148,22 @@ class MemTable {
 
   // Returns a vector of unique random memtable entries of size 'sample_size'.
   //
+  // Note: the entries are stored in the unordered_set as length-prefixed keys,
+  //       hence their representation in the set as "const char*".
+  // Note2: the size of the output set 'entries' is not enforced to be strictly
+  //        equal to 'target_sample_size'. Its final size might be slightly
+  //        greater or slightly less than 'target_sample_size'
+  //
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable (unless this Memtable is immutable).
-  void UniqueRandomSample(const uint64_t& sample_size,
+  // REQUIRES: SkipList memtable representation. This function is not
+  // implemented for any other type of memtable representation (vectorrep,
+  // hashskiplist,...).
+  void UniqueRandomSample(const uint64_t& target_sample_size,
                           std::unordered_set<const char*>* entries) {
     // TODO(bjlemaire): at the moment, only supported by skiplistrep.
     // Extend it to all other memtable representations.
-    table_->UniqueRandomSample(num_entries(), sample_size, entries);
+    table_->UniqueRandomSample(num_entries(), target_sample_size, entries);
   }
 
   // This method heuristically determines if the memtable should continue to

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -151,12 +151,18 @@ class MemTable {
   //
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable (unless this Memtable is immutable).
-  void RandomSample(const uint64_t& sample_size,
-                    std::unordered_set<const char*>* entries) {
+  void UniqueRandomSample(const uint64_t& sample_size,
+                          std::unordered_set<const char*>* entries) {
     if (sample_size > (num_entries_ / 2)) {
-      assert(false);
+      ReadOptions ro;
+      ro.total_order_seek = true;
+      Arena arena;
+      InternalIterator* iter(NewIterator(ro, &arena));
+      for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        entries->insert(iter->key().data());
+      }
     }
-    table_->RandomSample(sample_size, entries);
+    table_->UniqueRandomSample(sample_size, entries);
   }
 
   // This method heuristically determines if the memtable should continue to

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -462,6 +462,8 @@ class MemTableList {
 
   // Store the IDs of the memtables installed in this
   // list that result from a mempurge operation.
+  // The value stored in the map is the estimated useful payload ratio
+  // at the time the mempurge happens.
   std::unordered_map<uint64_t, double> mempurged_ids_;
 };
 

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -390,9 +390,7 @@ class MemTableList {
   // not freed, but put into a vector for future deref and reclamation.
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
-  void AddMemPurgeOutputID(uint64_t mid, double useful_payload_ratio) {
-    mempurged_ids_[mid] = useful_payload_ratio;
-  }
+  void AddMemPurgeOutputID(uint64_t mid) { mempurged_ids_.insert(mid); }
 
   void RemoveMemPurgeOutputID(uint64_t mid) {
     if (mempurged_ids_.find(mid) != mempurged_ids_.end()) {
@@ -405,13 +403,6 @@ class MemTableList {
       return false;
     }
     return true;
-  }
-
-  double MemPurgeOutputUsefulPayload(uint64_t mid) {
-    if (mempurged_ids_.find(mid) != mempurged_ids_.end()) {
-      return mempurged_ids_[mid];
-    }
-    return -1.0;
   }
 
  private:
@@ -462,9 +453,7 @@ class MemTableList {
 
   // Store the IDs of the memtables installed in this
   // list that result from a mempurge operation.
-  // The value stored in the map is the estimated useful payload ratio
-  // at the time the mempurge happens.
-  std::unordered_map<uint64_t, double> mempurged_ids_;
+  std::unordered_set<uint64_t> mempurged_ids_;
 };
 
 // Installs memtable atomic flush results.

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -390,10 +390,8 @@ class MemTableList {
   // not freed, but put into a vector for future deref and reclamation.
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
-  void AddMemPurgeOutputID(uint64_t mid) {
-    if (mempurged_ids_.find(mid) == mempurged_ids_.end()) {
-      mempurged_ids_.insert(mid);
-    }
+  void AddMemPurgeOutputID(uint64_t mid, double useful_payload_ratio) {
+    mempurged_ids_[mid] = useful_payload_ratio;
   }
 
   void RemoveMemPurgeOutputID(uint64_t mid) {
@@ -407,6 +405,13 @@ class MemTableList {
       return false;
     }
     return true;
+  }
+
+  double MemPurgeOutputUsefulPayload(uint64_t mid) {
+    if (mempurged_ids_.find(mid) != mempurged_ids_.end()) {
+      return mempurged_ids_[mid];
+    }
+    return -1.0;
   }
 
  private:
@@ -457,7 +462,7 @@ class MemTableList {
 
   // Store the IDs of the memtables installed in this
   // list that result from a mempurge operation.
-  std::unordered_set<uint64_t> mempurged_ids_;
+  std::unordered_map<uint64_t, double> mempurged_ids_;
 };
 
 // Installs memtable atomic flush results.

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -141,8 +141,7 @@ DECLARE_uint64(subcompactions);
 DECLARE_uint64(periodic_compaction_seconds);
 DECLARE_uint64(compaction_ttl);
 DECLARE_bool(allow_concurrent_memtable_write);
-DECLARE_bool(experimental_allow_mempurge);
-DECLARE_string(experimental_mempurge_policy);
+DECLARE_double(experimental_mempurge_threshold);
 DECLARE_bool(enable_write_thread_adaptive_yield);
 DECLARE_int32(reopen);
 DECLARE_double(bloom_bits);
@@ -339,18 +338,6 @@ inline enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
     ret_compression_type = ROCKSDB_NAMESPACE::kSnappyCompression;
   }
   return ret_compression_type;
-}
-
-inline enum ROCKSDB_NAMESPACE::MemPurgePolicy StringToMemPurgePolicy(
-    const char* mpolicy) {
-  assert(mpolicy);
-  if (!strcasecmp(mpolicy, "kAlways")) {
-    return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlways;
-  } else if (!strcasecmp(mpolicy, "kAlternate")) {
-    return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
-  }
-  fprintf(stderr, "Cannot parse mempurge policy: '%s'\n", mpolicy);
-  return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
 }
 
 inline enum ROCKSDB_NAMESPACE::ChecksumType StringToChecksumType(

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -326,11 +326,9 @@ DEFINE_uint64(compaction_ttl, 1000,
 DEFINE_bool(allow_concurrent_memtable_write, false,
             "Allow multi-writers to update mem tables in parallel.");
 
-DEFINE_bool(experimental_allow_mempurge, false,
-            "Allow mempurge process to collect memtable garbage bytes.");
-
-DEFINE_string(experimental_mempurge_policy, "kAlternate",
-              "Set mempurge (MemTable Garbage Collection) policy.");
+DEFINE_double(experimental_mempurge_threshold, 0.0,
+              "Maximum estimated useful payload that triggers a "
+              "mempurge process to collect memtable garbage bytes.");
 
 DEFINE_bool(enable_write_thread_adaptive_yield, true,
             "Use a yielding spin loop for brief writer thread waits.");

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2266,9 +2266,8 @@ void StressTest::Open() {
     options_.max_subcompactions = static_cast<uint32_t>(FLAGS_subcompactions);
     options_.allow_concurrent_memtable_write =
         FLAGS_allow_concurrent_memtable_write;
-    options_.experimental_allow_mempurge = FLAGS_experimental_allow_mempurge;
-    options_.experimental_mempurge_policy =
-        StringToMemPurgePolicy(FLAGS_experimental_mempurge_policy.c_str());
+    options_.experimental_mempurge_threshold =
+        FLAGS_experimental_mempurge_threshold;
     options_.periodic_compaction_seconds = FLAGS_periodic_compaction_seconds;
     options_.ttl = FLAGS_compaction_ttl;
     options_.enable_pipelined_write = FLAGS_enable_pipelined_write;

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -196,13 +196,15 @@ class MemTableRep {
     return 0;
   }
 
-  // Returns a vector of unique random memtable entries of size 'sample_size'.
+  // Returns a vector of unique random memtable entries of approximate
+  // size 'target_sample_size' (this size is not strictly enforced).
   virtual void UniqueRandomSample(const uint64_t& num_entries,
-                                  const uint64_t& sample_size,
+                                  const uint64_t& target_sample_size,
                                   std::unordered_set<const char*>* entries) {
     (void)num_entries;
-    (void)sample_size;
+    (void)target_sample_size;
     (void)entries;
+    assert(false);
   }
 
   // Report an approximation of how much memory has been used other than memory

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -196,8 +196,8 @@ class MemTableRep {
     return 0;
   }
 
-  virtual void RandomSample(const uint64_t& sample_size,
-                            std::unordered_set<const char*>* entries) {
+  virtual void UniqueRandomSample(const uint64_t& sample_size,
+                                  std::unordered_set<const char*>* entries) {
     (void)sample_size;
     (void)entries;
   }

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -38,8 +38,10 @@
 #include <rocksdb/slice.h>
 #include <stdint.h>
 #include <stdlib.h>
+
 #include <memory>
 #include <stdexcept>
+#include <unordered_set>
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -194,6 +196,12 @@ class MemTableRep {
     return 0;
   }
 
+  virtual void RandomSample(const uint64_t& sample_size,
+                            std::unordered_set<const char*>* entries) {
+    (void)sample_size;
+    (void)entries;
+  }
+
   // Report an approximation of how much memory has been used other than memory
   // that was allocated through the allocator.  Safe to call from any thread.
   virtual size_t ApproximateMemoryUsage() = 0;
@@ -229,6 +237,8 @@ class MemTableRep {
     // retreat to the first entry with a key <= target
     virtual void SeekForPrev(const Slice& internal_key,
                              const char* memtable_key) = 0;
+
+    virtual void RandomSeek() {}
 
     // Position at the first entry in collection.
     // Final state of iterator is Valid() iff collection is not empty.

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -196,8 +196,11 @@ class MemTableRep {
     return 0;
   }
 
-  virtual void UniqueRandomSample(const uint64_t& sample_size,
+  // Returns a vector of unique random memtable entries of size 'sample_size'.
+  virtual void UniqueRandomSample(const uint64_t& num_entries,
+                                  const uint64_t& sample_size,
                                   std::unordered_set<const char*>* entries) {
+    (void)num_entries;
     (void)sample_size;
     (void)entries;
   }

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -372,6 +372,7 @@ extern const char* kHostnameForDbHostId;
 enum class MemPurgePolicy : char {
   kAlternate = 0x00,
   kAlways = 0x01,
+  kSampling = 0x02,
 };
 
 enum class CompactionServiceJobStatus : char {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -782,22 +782,21 @@ struct DBOptions {
   // Default: true
   bool advise_random_on_open = true;
 
-  // Ratio 'useful payload bytes'/'total payload bytes' below which
-  // a mempurge is triggered.
-  // If >0.0, memtable(s) will be mempurged instead of flushed to storage
-  // every time the total estimated 'useful payload' [in bytes] (the 'useful
-  // payload' is the difference between the input payload bytes on one hand,
-  // and the garbage bytes being filtered out at mempurge/flush time on
-  // the other hand) is smaller than 'threshold * memtable_size [in bytes]'.
-  // We recommend to use a threshold of 1.0 for efficient mempurges.
-  // Default: 0.0 (never trigger mempurge).
-  // The 'useful payload' is estimated by sampling the memtables being
-  // mempurged/flushed. Therefore a high mempurge threshold ( > 1.0 )
-  // can be used when the sampling consistently overevaluates the 'useful
-  // payload' High values (>1.0) will almost always redirect a flush to a
-  // mempurge. A mempurge is aborted and rerouted to a flush operation when the
-  // `useful payload` is too large to be contained on a single immutable
-  // memtable. (experimental).
+  // [experimental]
+  // Used to activate or deactive the Mempurge feature (memtable garbage
+  // collection). (deactivated by default). At every flush, the total useful
+  // payload (total entries minus garbage entries) is estimated as a ratio
+  // [useful payload bytes]/[size of a memtable (in bytes)]. This ratio is then
+  // compared to this `threshold` value:
+  //     - if ratio<threshold: the flush is replaced by a mempurge operation
+  //     - else: a regular flush operation takes place.
+  // Threshold values:
+  //   0.0: mempurge deactivated (default).
+  //   1.0: recommended threshold value.
+  //   >1.0 : aggressive mempurge.
+  //   0 < threshold < 1.0: mempurge triggered only for very low useful payload
+  //   ratios.
+  // [experimental]
   double experimental_mempurge_threshold = 0.0;
 
   // Amount of data to build up in memtables across all column

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -782,12 +782,22 @@ struct DBOptions {
   // Default: true
   bool advise_random_on_open = true;
 
+  // Ratio 'useful payload bytes'/'total payload bytes' below which
+  // a mempurge is triggered.
   // If >0.0, memtable(s) will be mempurged instead of flushed to storage
-  // every time the total expected 'useful payload' (payload - garbage)
-  // is smaller than threshold * memtable_size.
+  // every time the total estimated 'useful payload' [in bytes] (the 'useful
+  // payload' is the difference between the input payload bytes on one hand,
+  // and the garbage bytes being filtered out at mempurge/flush time on
+  // the other hand) is smaller than 'threshold * memtable_size [in bytes]'.
   // We recommend to use a threshold of 1.0 for efficient mempurges.
   // Default: 0.0 (never trigger mempurge).
-  // (experimental).
+  // The 'useful payload' is estimated by sampling the memtables being
+  // mempurged/flushed. Therefore a high mempurge threshold ( > 1.0 )
+  // can be used when the sampling consistently overevaluates the 'useful
+  // payload' High values (>1.0) will almost always redirect a flush to a
+  // mempurge. A mempurge is aborted and rerouted to a flush operation when the
+  // `useful payload` is too large to be contained on a single immutable
+  // memtable. (experimental).
   double experimental_mempurge_threshold = 0.0;
 
   // Amount of data to build up in memtables across all column

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -369,12 +369,6 @@ struct DbPath {
 
 extern const char* kHostnameForDbHostId;
 
-enum class MemPurgePolicy : char {
-  kAlternate = 0x00,
-  kAlways = 0x01,
-  kSampling = 0x02,
-};
-
 enum class CompactionServiceJobStatus : char {
   kSuccess,
   kFailure,
@@ -788,14 +782,13 @@ struct DBOptions {
   // Default: true
   bool advise_random_on_open = true;
 
-  // If true, allows for memtable purge instead of flush to storage.
+  // If >0.0, memtable(s) will be mempurged instead of flushed to storage
+  // every time the total expected 'useful payload' (payload - garbage)
+  // is smaller than threshold * memtable_size.
+  // We recommend to use a threshold of 1.0 for efficient mempurges.
+  // Default: 0.0 (never trigger mempurge).
   // (experimental).
-  bool experimental_allow_mempurge = false;
-  // If experimental_allow_mempurge is true, will dictate MemPurge
-  // policy.
-  // Default: kAlternate
-  // (experimental).
-  MemPurgePolicy experimental_mempurge_policy = MemPurgePolicy::kAlternate;
+  double experimental_mempurge_threshold = 0.0;
 
   // Amount of data to build up in memtables across all column
   // families before writing to disk.

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -129,15 +129,16 @@ public:
           std::begin(indices), std::end(indices),
           std::default_random_engine(Random::GetTLSInstance()->Next() /* seed */
                                      ));
+      assert(m <= indices.size());
       std::sort(std::begin(indices), std::begin(indices) + m);
-
       // Option 1: take the first m indices from the randomly permuted
       // indices array {0,...,num_entries-1}, and store them in
       // the sample subset.
       iter.SeekToFirst();
       for (uint64_t counter = 0, index = 0; iter.Valid() && (index < m);
            iter.Next(), counter++) {
-        if (counter == indices[index]) {
+        // First check 'index<indices.size()' is required for internal test.
+        if ((index < indices.size()) && (counter == indices[index])) {
           entries->insert(iter.key());
           index++;
         }

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -95,6 +95,19 @@ public:
     return (end_count >= start_count) ? (end_count - start_count) : 0;
   }
 
+  void RandomSample(const uint64_t& sample_size,
+                    std::unordered_set<const char*>* entries) override {
+    // double ApproximateGarbageRatio(const uint64_t sample_size) override {
+    entries->clear();
+    SkipListRep::Iterator iter(&skip_list_);
+    for (uint64_t i = 0; i < sample_size; i++) {
+      do {
+        iter.RandomSeek();
+      } while (!iter.Valid() || (entries->find(iter.key()) != entries->end()));
+      entries->insert(iter.key());
+    }
+  }
+
   ~SkipListRep() override {}
 
   // Iteration over the contents of a skip list
@@ -142,6 +155,8 @@ public:
         iter_.SeekForPrev(EncodeKey(&tmp_, user_key));
       }
     }
+
+    void RandomSeek() override { iter_.RandomSeek(); }
 
     // Position at the first entry in list.
     // Final state of iterator is Valid() iff list is not empty.

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -112,7 +112,8 @@ public:
     // 2-Pick m random elements without repetition.
     // We pick Option 2 when m<sqrt(N) and
     // Option 1 when m > sqrt(N).
-    if (target_sample_size > static_cast<uint64_t>(sqrt(num_entries))) {
+    if (target_sample_size >
+        static_cast<uint64_t>(std::sqrt(1.0 * num_entries))) {
       // Option 1: iterate through each element, and store it in sample
       // subset if Bernoulli dist returns true.
       Random* rnd = Random::GetTLSInstance();

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -107,7 +107,9 @@ public:
     // O(sample_size*log(N))).
     if (sample_size >= (num_entries / 4)) {
       Random rnd(1234);
-      int n = (sample_size > num_entries) ? 1 : num_entries / sample_size;
+      int n = (sample_size > num_entries)
+                  ? 1
+                  : static_cast<int>(num_entries / sample_size);
       for (iter.SeekToFirst(); iter.Valid(); iter.Next()) {
         if (rnd.OneIn(n)) {
           entries->insert(iter.key());

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -125,7 +125,7 @@ public:
         }
       }
     } else {
-      // Option 2: pick m random elements
+      // Option 2: pick m random elements with no duplicates.
       // If Option 2 is picked, then target_sample_size<sqrt(N)
       // Using a set spares the need to check for duplicates.
       for (uint64_t i = 0; i < target_sample_size; i++) {

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -138,6 +138,7 @@ public:
         // At worst, for the final pick , when m=sqrt(N) there is
         // a probability of p= 1/sqrt(N) chances to find a duplicate.
         for (uint64_t j = 0; j < 5; j++) {
+          iter.RandomSeek();
           if (entries->find(iter.key()) == entries->end()) {
             entries->insert(iter.key());
             break;

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -95,8 +95,8 @@ public:
     return (end_count >= start_count) ? (end_count - start_count) : 0;
   }
 
-  void RandomSample(const uint64_t& sample_size,
-                    std::unordered_set<const char*>* entries) override {
+  void UniqueRandomSample(const uint64_t& sample_size,
+                          std::unordered_set<const char*>* entries) override {
     // double ApproximateGarbageRatio(const uint64_t sample_size) override {
     entries->clear();
     SkipListRep::Iterator iter(&skip_list_);

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -48,11 +48,6 @@ static std::unordered_map<std::string, InfoLogLevel> info_log_level_string_map =
      {"FATAL_LEVEL", InfoLogLevel::FATAL_LEVEL},
      {"HEADER_LEVEL", InfoLogLevel::HEADER_LEVEL}};
 
-static std::unordered_map<std::string, MemPurgePolicy>
-    experimental_mempurge_policy_string_map = {
-        {"kAlternate", MemPurgePolicy::kAlternate},
-        {"kAlways", MemPurgePolicy::kAlways}};
-
 static std::unordered_map<std::string, OptionTypeInfo>
     db_mutable_options_type_info = {
         {"allow_os_buffer",
@@ -197,14 +192,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableDBOptions, error_if_exists),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
-        {"experimental_allow_mempurge",
-         {offsetof(struct ImmutableDBOptions, experimental_allow_mempurge),
-          OptionType::kBoolean, OptionVerificationType::kNormal,
+        {"experimental_mempurge_threshold",
+         {offsetof(struct ImmutableDBOptions, experimental_mempurge_threshold),
+          OptionType::kDouble, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
-        {"experimental_mempurge_policy",
-         OptionTypeInfo::Enum<MemPurgePolicy>(
-             offsetof(struct ImmutableDBOptions, experimental_mempurge_policy),
-             &experimental_mempurge_policy_string_map)},
         {"is_fd_close_on_exec",
          {offsetof(struct ImmutableDBOptions, is_fd_close_on_exec),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -615,8 +606,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       allow_fallocate(options.allow_fallocate),
       is_fd_close_on_exec(options.is_fd_close_on_exec),
       advise_random_on_open(options.advise_random_on_open),
-      experimental_allow_mempurge(options.experimental_allow_mempurge),
-      experimental_mempurge_policy(options.experimental_mempurge_policy),
+      experimental_mempurge_threshold(options.experimental_mempurge_threshold),
       db_write_buffer_size(options.db_write_buffer_size),
       write_buffer_manager(options.write_buffer_manager),
       access_hint_on_compaction_start(options.access_hint_on_compaction_start),
@@ -750,12 +740,9 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    is_fd_close_on_exec);
   ROCKS_LOG_HEADER(log, "                  Options.advise_random_on_open: %d",
                    advise_random_on_open);
-  ROCKS_LOG_HEADER(log,
-                   "                  Options.experimental_allow_mempurge: %d",
-                   experimental_allow_mempurge);
-  ROCKS_LOG_HEADER(log,
-                   "                  Options.experimental_mempurge_policy: %d",
-                   static_cast<int>(experimental_mempurge_policy));
+  ROCKS_LOG_HEADER(
+      log, "                  Options.experimental_mempurge_threshold: %f",
+      experimental_mempurge_threshold);
   ROCKS_LOG_HEADER(
       log, "                   Options.db_write_buffer_size: %" ROCKSDB_PRIszt,
       db_write_buffer_size);

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -57,8 +57,7 @@ struct ImmutableDBOptions {
   bool allow_fallocate;
   bool is_fd_close_on_exec;
   bool advise_random_on_open;
-  bool experimental_allow_mempurge;
-  MemPurgePolicy experimental_mempurge_policy;
+  double experimental_mempurge_threshold;
   size_t db_write_buffer_size;
   std::shared_ptr<WriteBufferManager> write_buffer_manager;
   DBOptions::AccessHint access_hint_on_compaction_start;

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -143,7 +143,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"persist_stats_to_disk", "false"},
       {"stats_history_buffer_size", "69"},
       {"advise_random_on_open", "true"},
-      {"experimental_allow_mempurge", "false"},
+      {"experimental_mempurge_threshold", "0.0"},
       {"use_adaptive_mutex", "false"},
       {"new_table_reader_for_compaction_inputs", "true"},
       {"compaction_readahead_size", "100"},
@@ -302,7 +302,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.persist_stats_to_disk, false);
   ASSERT_EQ(new_db_opt.stats_history_buffer_size, 69U);
   ASSERT_EQ(new_db_opt.advise_random_on_open, true);
-  ASSERT_EQ(new_db_opt.experimental_allow_mempurge, false);
+  ASSERT_EQ(new_db_opt.experimental_mempurge_threshold, 0.0);
   ASSERT_EQ(new_db_opt.use_adaptive_mutex, false);
   ASSERT_EQ(new_db_opt.new_table_reader_for_compaction_inputs, true);
   ASSERT_EQ(new_db_opt.compaction_readahead_size, 100);
@@ -2047,7 +2047,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
       {"persist_stats_to_disk", "false"},
       {"stats_history_buffer_size", "69"},
       {"advise_random_on_open", "true"},
-      {"experimental_allow_mempurge", "false"},
+      {"experimental_mempurge_threshold", "0.0"},
       {"use_adaptive_mutex", "false"},
       {"new_table_reader_for_compaction_inputs", "true"},
       {"compaction_readahead_size", "100"},
@@ -2200,7 +2200,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.persist_stats_to_disk, false);
   ASSERT_EQ(new_db_opt.stats_history_buffer_size, 69U);
   ASSERT_EQ(new_db_opt.advise_random_on_open, true);
-  ASSERT_EQ(new_db_opt.experimental_allow_mempurge, false);
+  ASSERT_EQ(new_db_opt.experimental_mempurge_threshold, 0.0);
   ASSERT_EQ(new_db_opt.use_adaptive_mutex, false);
   ASSERT_EQ(new_db_opt.new_table_reader_for_compaction_inputs, true);
   ASSERT_EQ(new_db_opt.compaction_readahead_size, 100);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1046,6 +1046,8 @@ static enum ROCKSDB_NAMESPACE::MemPurgePolicy StringToMemPurgePolicy(
     return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlways;
   } else if (!strcasecmp(mpolicy, "kAlternate")) {
     return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
+  } else if (!strcasecmp(mpolicy, "kSampling")) {
+    return ROCKSDB_NAMESPACE::MemPurgePolicy::kSampling;
   }
 
   fprintf(stdout, "Cannot parse mempurge policy '%s'\n", mpolicy);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1039,21 +1039,6 @@ static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
   return ROCKSDB_NAMESPACE::kSnappyCompression;  // default value
 }
 
-static enum ROCKSDB_NAMESPACE::MemPurgePolicy StringToMemPurgePolicy(
-    const char* mpolicy) {
-  assert(mpolicy);
-  if (!strcasecmp(mpolicy, "kAlways")) {
-    return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlways;
-  } else if (!strcasecmp(mpolicy, "kAlternate")) {
-    return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
-  } else if (!strcasecmp(mpolicy, "kSampling")) {
-    return ROCKSDB_NAMESPACE::MemPurgePolicy::kSampling;
-  }
-
-  fprintf(stdout, "Cannot parse mempurge policy '%s'\n", mpolicy);
-  return ROCKSDB_NAMESPACE::MemPurgePolicy::kAlternate;
-}
-
 static std::string ColumnFamilyName(size_t i) {
   if (i == 0) {
     return ROCKSDB_NAMESPACE::kDefaultColumnFamilyName;
@@ -1188,11 +1173,9 @@ DEFINE_bool(
 DEFINE_bool(allow_concurrent_memtable_write, true,
             "Allow multi-writers to update mem tables in parallel.");
 
-DEFINE_bool(experimental_allow_mempurge, false,
-            "Allow memtable garbage collection.");
-
-DEFINE_string(experimental_mempurge_policy, "kAlternate",
-              "Specify memtable garbage collection policy.");
+DEFINE_double(experimental_mempurge_threshold, 0.0,
+              "Maximum useful payload ratio estimate that triggers a mempurge "
+              "(memtable garbage collection).");
 
 DEFINE_bool(inplace_update_support,
             ROCKSDB_NAMESPACE::Options().inplace_update_support,
@@ -4277,9 +4260,8 @@ class Benchmark {
     options.delayed_write_rate = FLAGS_delayed_write_rate;
     options.allow_concurrent_memtable_write =
         FLAGS_allow_concurrent_memtable_write;
-    options.experimental_allow_mempurge = FLAGS_experimental_allow_mempurge;
-    options.experimental_mempurge_policy =
-        StringToMemPurgePolicy(FLAGS_experimental_mempurge_policy.c_str());
+    options.experimental_mempurge_threshold =
+        FLAGS_experimental_mempurge_threshold;
     options.inplace_update_support = FLAGS_inplace_update_support;
     options.inplace_update_num_locks = FLAGS_inplace_update_num_locks;
     options.enable_write_thread_adaptive_yield =

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -220,8 +220,7 @@ whitebox_default_params = {
 simple_default_params = {
     "allow_concurrent_memtable_write": lambda: random.randint(0, 1),
     "column_families": 1,
-    "experimental_allow_mempurge": lambda: random.randint(0, 1),
-    "experimental_mempurge_policy": lambda: random.choice(["kAlways", "kAlternate"]),
+    "experimental_mempurge_threshold": lambda: 10.0*random.random(),
     "max_background_compactions": 1,
     "max_bytes_for_level_base": 67108864,
     "memtablerep": "skip_list",


### PR DESCRIPTION
Changes the API of the MemPurge process: the `bool experimental_allow_mempurge` and `experimental_mempurge_policy` flags have been replaced by a `double experimental_mempurge_threshold` option. 
This change of API reflects another major change introduced in this PR: the MemPurgeDecider() function now works by sampling the memtables being flushed to estimate the overall amount of useful payload (payload minus the garbage), and then compare this useful payload estimate with the `double experimental_mempurge_threshold` value.
Therefore, when the value of this flag is `0.0` (default value), mempurge is simply deactivated. On the other hand, a value of `DBL_MAX` would be equivalent to always going through a mempurge regardless of the garbage ratio estimate. 
At the moment, a `double experimental_mempurge_threshold` value else than 0.0 or `DBL_MAX` is opnly supported`with the `SkipList` memtable representation. 
Regarding the sampling, this PR includes the introduction of a `MemTable::UniqueRandomSample` function that collects (approximately) random entries from the memtable by using the new `SkipList::Iterator::RandomSeek()` under the hood, or by iterating through each memtable entry, depending on the target sample size and the total number of entries. 
The unit tests have been readapted to support this new API.