### PR TITLE
Fix db_stress failure

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1366,7 +1366,6 @@ Status StressTest::TestBackupRestore(
   BackupableDBOptions backup_opts(backup_dir);
   // For debugging, get info_log from live options
   backup_opts.info_log = db_->GetDBOptions().info_log.get();
-  assert(backup_opts.info_log);
   if (thread->rand.OneIn(10)) {
     backup_opts.share_table_files = false;
   } else {


### PR DESCRIPTION
Summary: FaultInjectionTestFS injects error in Rename operation. Because
of injected error, info.log fails to be created if rename  returns error and info_log is set to nullptr which leads to this assertion

Test Plan: run the db_stress job locally

Reviewers:

Subscribers:

Tasks:

Tags: