### PR TITLE
Prevent joining detached thread in ThreadPoolImpl

### DIFF
--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -200,9 +200,7 @@ void ThreadPoolImpl::Impl::BGThread(size_t thread_id) {
           queue_.empty()) {
         break;
        }
-    }
-
-    if (!exit_all_threads_ && IsLastExcessiveThread(thread_id)) {
+    } else if (IsLastExcessiveThread(thread_id)) {
       // Current thread is the last generated one and is excessive.
       // We always terminate excessive thread in the reverse order of
       // generation time. But not when `exit_all_threads_ == true`,

--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -202,10 +202,12 @@ void ThreadPoolImpl::Impl::BGThread(size_t thread_id) {
        }
     }
 
-    if (IsLastExcessiveThread(thread_id)) {
+    if (!exit_all_threads_ && IsLastExcessiveThread(thread_id)) {
       // Current thread is the last generated one and is excessive.
       // We always terminate excessive thread in the reverse order of
-      // generation time.
+      // generation time. But not when `exit_all_threads_ == true`,
+      // otherwise `JoinThreads()` could try to `join()` a `detach()`ed
+      // thread.
       auto& terminating_thread = bgthreads_.back();
       terminating_thread.detach();
       bgthreads_.pop_back();


### PR DESCRIPTION
This draining mechanism should not be run during `JoinThreads()` because it can detach threads that will be joined. Joining detached threads would throw an exception.

With this PR, we skip draining when `JoinThreads()` has already decided what threads to `join()`, so the threads will exit naturally once the work queue empties.

Test Plan: verified it unblocked using `WaitForJobsAndJoinAllThreads()` in #8611.