### PR TITLE
[NO REVIEW] Add a unit test for another case in which SD marker's seq may be zeroed

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -312,8 +312,9 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
         num_skipped++;  // skip this entry
         PERF_COUNTER_ADD(internal_key_skipped_count, 1);
       } else {
-        assert(!skipping_saved_key ||
-               CompareKeyForSkip(ikey_.user_key, saved_key_.GetUserKey()) > 0);
+        // assert(!skipping_saved_key ||
+        //       CompareKeyForSkip(ikey_.user_key, saved_key_.GetUserKey()) >
+        //       0);
         if (!iter_.PrepareValue()) {
           assert(!iter_.status().ok());
           valid_ = false;


### PR DESCRIPTION
Add a unit test for another case in which SD marker's seq may be zeroed. Incorrect
result may be returned by iterator afterwards.

Also remove some assertion to emulate what happens if RocksDB is built
in opt mode.

Test plan:
```
 ./write_prepared_transaction_test --gtest_filter=*/WritePreparedTransactionTest.ReleaseEarliestSnapshotDuringCompaction_WithSD2/*
```