### PR TITLE
Make checkpoint support for non-default path of live files

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -73,7 +73,7 @@ Status DBImpl::GetLiveFiles(std::vector<std::string>& ret,
   }
 
   // Make a set of all of the live table and blob files
-  std::vector<uint64_t> live_table_files;
+  std::vector<FileDescriptor> live_table_files;
   std::vector<uint64_t> live_blob_files;
   for (auto cfd : *versions_->GetColumnFamilySet()) {
     if (cfd->IsDropped()) {
@@ -88,8 +88,8 @@ Status DBImpl::GetLiveFiles(std::vector<std::string>& ret,
 
   // create names of the live files. The names are not absolute
   // paths, instead they are relative to dbname_;
-  for (const auto& table_file_number : live_table_files) {
-    ret.emplace_back(MakeTableFileName("", table_file_number));
+  for (const auto& table_file : live_table_files) {
+    ret.emplace_back(MakeTableFileName("", table_file.GetNumber()));
   }
 
   for (const auto& blob_file_number : live_blob_files) {
@@ -115,8 +115,8 @@ Status DBImpl::GetLiveFiles(std::vector<std::string>& ret,
 }
 
 Status DBImpl::GetLiveFilesWithPath(
-    std::unordered_map<std::string, std::vector<std::string>>& path_to_files,
-    uint64_t* manifest_file_size, bool flush_memtable) {
+    std::unordered_map<std::string, std::vector<std::string>>&,
+    uint64_t*, bool) {
   return Status::Corruption("GetLiveFilesWithPath not supported in DBImpl");
 }
 

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -114,6 +114,12 @@ Status DBImpl::GetLiveFiles(std::vector<std::string>& ret,
   return Status::OK();
 }
 
+Status DBImpl::GetLiveFilesWithPath(
+    std::unordered_map<std::string, std::vector<std::string>>& path_to_files,
+    uint64_t* manifest_file_size, bool flush_memtable) {
+  return Status::Corruption("GetLiveFilesWithPath not supported in DBImpl");
+}
+
 Status DBImpl::GetSortedWalFiles(VectorLogPtr& files) {
   {
     // If caller disabled deletions, this function should return files that are

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -182,11 +182,13 @@ Status DBImpl::GetLiveFilesWithPath(
       path_to_files[path].emplace_back(
           MakeTableFileName("", table_file.GetNumber()));
     }
+    live_table_files.clear();
 
     for (const auto& blob_file_number : live_blob_files) {
       path_to_files[cf_paths[0].path].emplace_back(
           BlobFileName("", blob_file_number));
     }
+    live_blob_files.clear();
   }
   path_to_files[dbname_].emplace_back(CurrentFileName(""));
   path_to_files[dbname_].emplace_back(

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -77,6 +77,12 @@ class CompactedDBImpl : public DBImpl {
     return DBImpl::GetLiveFiles(ret, manifest_file_size,
                                 false /* flush_memtable */);
   }
+  virtual Status GetLiveFilesWithPath(
+      std::unordered_map<std::string, std::vector<std::string>>& ret,
+      uint64_t* manifest_file_size, bool /*flush_memtable*/) override {
+    return DBImpl::GetLiveFilesWithPath(ret, manifest_file_size,
+                                        false /*flush_memtable*/);
+  }
   using DBImpl::Flush;
   virtual Status Flush(const FlushOptions& /*options*/,
                        ColumnFamilyHandle* /*column_family*/) override {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -380,6 +380,9 @@ class DBImpl : public DB {
   virtual Status GetLiveFiles(std::vector<std::string>&,
                               uint64_t* manifest_file_size,
                               bool flush_memtable = true) override;
+  virtual Status GetLiveFilesWithPath(
+      std::unordered_map<std::string, std::vector<std::string>>&,
+      uint64_t* manifest_file_size, bool flush_memtable = true) override;
   virtual Status GetSortedWalFiles(VectorLogPtr& files) override;
   virtual Status GetCurrentWalFile(
       std::unique_ptr<LogFile>* current_log_file) override;

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -375,8 +375,10 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
   assert(state.manifest_file_number != 0);
 
   // Now, convert lists to unordered sets, WITHOUT mutex held; set is slow.
-  std::unordered_set<uint64_t> sst_live_set(state.sst_live.begin(),
-                                            state.sst_live.end());
+  std::unordered_set<uint64_t> sst_live_set;
+  for (const auto& fd : state.sst_live) {
+    sst_live_set.emplace(fd.GetNumber());
+  }
   std::unordered_set<uint64_t> blob_live_set(state.blob_live.begin(),
                                              state.blob_live.end());
   std::unordered_set<uint64_t> log_recycle_files_set(

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -99,6 +99,12 @@ class DBImplReadOnly : public DBImpl {
     return DBImpl::GetLiveFiles(ret, manifest_file_size,
                                 false /* flush_memtable */);
   }
+  virtual Status GetLiveFilesWithPath(
+      std::unordered_map<std::string, std::vector<std::string>>& ret,
+      uint64_t* manifest_file_size, bool /*flush_memtable*/) override {
+    return DBImpl::GetLiveFilesWithPath(ret, manifest_file_size,
+                                        false /* flush_memtable */);
+  }
 
   using DBImpl::Flush;
   virtual Status Flush(const FlushOptions& /*options*/,

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -168,6 +168,13 @@ class DBImplSecondary : public DBImpl {
     return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
+  Status GetLiveFilesWithPath(
+      std::unordered_map<std::string, std::vector<std::string>>& ret,
+      uint64_t* /*manifest_file_size*/,
+      bool /*flush_memtable*/ = true) override {
+    return Status::NotSupported("Not supported operation in secondary mode.");
+  }
+
   using DBImpl::Flush;
   Status Flush(const FlushOptions& /*options*/,
                ColumnFamilyHandle* /*column_family*/) override {

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -169,7 +169,7 @@ class DBImplSecondary : public DBImpl {
   }
 
   Status GetLiveFilesWithPath(
-      std::unordered_map<std::string, std::vector<std::string>>& ret,
+      std::unordered_map<std::string, std::vector<std::string>>&,
       uint64_t* /*manifest_file_size*/,
       bool /*flush_memtable*/ = true) override {
     return Status::NotSupported("Not supported operation in secondary mode.");

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3115,6 +3115,12 @@ class ModelDB : public DB {
     return Status::OK();
   }
 
+  Status GetLiveFilesWithPath(
+      std::unordered_map<std::string, std::vector<std::string>>&, uint64_t*,
+      bool /*flush_memtable*/ = true) override {
+    return Status::OK();
+  }
+
   Status GetLiveFilesChecksumInfo(
       FileChecksumList* /*checksum_list*/) override {
     return Status::OK();

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -142,7 +142,7 @@ struct JobContext {
   std::vector<CandidateFileInfo> full_scan_candidate_files;
 
   // the list of all live sst files that cannot be deleted
-  std::vector<uint64_t> sst_live;
+  std::vector<FileDescriptor> sst_live;
 
   // the list of sst files that we need to delete
   std::vector<ObsoleteFileInfo> sst_delete_files;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3634,7 +3634,7 @@ bool VersionStorageInfo::RangeMightExistAfterSortedRun(
   return false;
 }
 
-void Version::AddLiveFiles(std::vector<uint64_t>* live_table_files,
+void Version::AddLiveFiles(std::vector<FileDescriptor>* live_table_files,
                            std::vector<uint64_t>* live_blob_files) const {
   assert(live_table_files);
   assert(live_blob_files);
@@ -3644,7 +3644,7 @@ void Version::AddLiveFiles(std::vector<uint64_t>* live_table_files,
     for (const auto& meta : level_files) {
       assert(meta);
 
-      live_table_files->emplace_back(meta->fd.GetNumber());
+      live_table_files->emplace_back(meta->fd);
     }
   }
 
@@ -5403,7 +5403,7 @@ uint64_t VersionSet::ApproximateSize(Version* v, const FdWithKeyRange& f,
       v->GetMutableCFOptions().prefix_extractor.get());
 }
 
-void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
+void VersionSet::AddLiveFiles(std::vector<FileDescriptor>* live_table_files,
                               std::vector<uint64_t>* live_blob_files) const {
   assert(live_table_files);
   assert(live_blob_files);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -727,7 +727,7 @@ class Version {
 
   // Add all files listed in the current version to *live_table_files and
   // *live_blob_files.
-  void AddLiveFiles(std::vector<uint64_t>* live_table_files,
+  void AddLiveFiles(std::vector<FileDescriptor>* live_table_files,
                     std::vector<uint64_t>* live_blob_files) const;
 
   // Return a human readable string that describes this version's contents.
@@ -1209,7 +1209,7 @@ class VersionSet {
 
   // Add all files listed in any live version to *live_table_files and
   // *live_blob_files. Note that these lists may contain duplicates.
-  void AddLiveFiles(std::vector<uint64_t>* live_table_files,
+  void AddLiveFiles(std::vector<FileDescriptor>* live_table_files,
                     std::vector<uint64_t>* live_blob_files) const;
 
   // Return the approximate size of data to be scanned for range [start, end)

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -1089,7 +1089,7 @@ TEST_F(VersionSetTest, AddLiveBlobFiles) {
   first_version->Ref();
 
   // Get live files directly from version.
-  std::vector<uint64_t> version_table_files;
+  std::vector<FileDescriptor> version_table_files;
   std::vector<uint64_t> version_blob_files;
 
   first_version->AddLiveFiles(&version_table_files, &version_blob_files);
@@ -1127,7 +1127,7 @@ TEST_F(VersionSetTest, AddLiveBlobFiles) {
 
   // Get all live files from version set. Note that the result contains
   // duplicates.
-  std::vector<uint64_t> all_table_files;
+  std::vector<FileDescriptor> all_table_files;
   std::vector<uint64_t> all_blob_files;
 
   versions_->AddLiveFiles(&all_table_files, &all_blob_files);

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -131,15 +131,21 @@ uint64_t TableFileNameToNumber(const std::string& name) {
   return number;
 }
 
-std::string TableFileName(const std::vector<DbPath>& db_paths, uint64_t number,
+std::string TableFilePath(const std::vector<DbPath>& db_paths,
                           uint32_t path_id) {
-  assert(number > 0);
   std::string path;
   if (path_id >= db_paths.size()) {
     path = db_paths.back().path;
   } else {
     path = db_paths[path_id].path;
   }
+  return path;
+}
+
+std::string TableFileName(const std::vector<DbPath>& db_paths, uint64_t number,
+                          uint32_t path_id) {
+  assert(number > 0);
+  std::string path = TableFilePath(db_paths, path_id);
   return MakeTableFileName(path, number);
 }
 

--- a/file/filename.h
+++ b/file/filename.h
@@ -71,6 +71,10 @@ extern std::string Rocks2LevelTableFileName(const std::string& fullname);
 // TODO(yhchiang): could merge this function with ParseFileName()
 extern uint64_t TableFileNameToNumber(const std::string& name);
 
+// Return the the path of sstable by path id.
+extern std::string TableFilePath(const std::vector<DbPath>& db_paths,
+                                 uint32_t path_id);
+
 // Return the name of the sstable with the specified number
 // in the db named by "dbname".  The result will be prefixed with
 // "dbname".

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1350,6 +1350,14 @@ class DB {
                               uint64_t* manifest_file_size,
                               bool flush_memtable = true) = 0;
 
+  // Retrieve the all files in the database, just like GetLiveFiles.
+  // Unlike GetLiveFiles, the files returned by GetLiveFilesWithPath are put
+  // into a map. The key is files path, the value is a list of all files in the
+  // path.
+  virtual Status GetLiveFilesWithPath(
+      std::unordered_map<std::string, std::vector<std::string>>&,
+      uint64_t* manifest_file_size, bool flush_memtable = true) = 0;
+
   // Retrieve the sorted list of all wal files with earliest file first
   virtual Status GetSortedWalFiles(VectorLogPtr& files) = 0;
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -399,7 +399,7 @@ class StackableDB : public DB {
 
   virtual Status GetLiveFilesWithPath(
       std::unordered_map<std::string, std::vector<std::string>>& ret,
-      uint64_t* manifest_file_size, bool flush_memtable) override {
+      uint64_t* manifest_file_size, bool flush_memtable = true) override {
     return db_->GetLiveFilesWithPath(ret, manifest_file_size, flush_memtable);
   }
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -397,6 +397,12 @@ class StackableDB : public DB {
     return db_->GetLiveFiles(vec, mfs, flush_memtable);
   }
 
+  virtual Status GetLiveFilesWithPath(
+      std::unordered_map<std::string, std::vector<std::string>>& ret,
+      uint64_t* manifest_file_size, bool flush_memtable) override {
+    return db_->GetLiveFilesWithPath(ret, manifest_file_size, flush_memtable);
+  }
+
   virtual SequenceNumber GetLatestSequenceNumber() const override {
     return db_->GetLatestSequenceNumber();
   }

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -92,11 +92,15 @@ class DummyDB : public StackableDB {
     return Status::OK();
   }
 
-  Status GetLiveFiles(std::vector<std::string>& vec, uint64_t* mfs,
-                      bool /*flush_memtable*/ = true) override {
+  Status GetLiveFilesWithPath(
+    std::unordered_map<std::string, std::vector<std::string>>& path_to_files,
+    uint64_t* manifest_file_size, bool  /*flush_memtable*/ = true) override {
     EXPECT_TRUE(!deletions_enabled_);
-    vec = live_files_;
-    *mfs = 100;
+    path_to_files.clear();
+    for (const auto& live_file : live_files_) {
+      path_to_files[dbname_].emplace_back(live_file);
+    }
+    *manifest_file_size = 100;
     return Status::OK();
   }
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -161,6 +161,11 @@ class BlobDBImpl : public BlobDB {
   virtual Status GetLiveFiles(std::vector<std::string>&,
                               uint64_t* manifest_file_size,
                               bool flush_memtable = true) override;
+
+  virtual Status GetLiveFilesWithPath(
+      std::unordered_map<std::string, std::vector<std::string>>&,
+      uint64_t* manifest_file_size, bool flush_memtable = true) override;
+
   virtual void GetLiveFilesMetaData(std::vector<LiveFileMetaData>*) override;
 
   ~BlobDBImpl();

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -85,8 +85,8 @@ Status BlobDBImpl::GetLiveFiles(std::vector<std::string>& ret,
 }
 
 Status BlobDBImpl::GetLiveFilesWithPath(
-    std::unordered_map<std::string, std::vector<std::string>>& path_to_files,
-    uint64_t* manifest_file_size, bool flush_memtable) {
+    std::unordered_map<std::string, std::vector<std::string>>&,
+    uint64_t*, bool) {
   return Status::Corruption("GetLiveFilesWithPath not supported in BlobDBImpl");
 }
 

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -84,6 +84,12 @@ Status BlobDBImpl::GetLiveFiles(std::vector<std::string>& ret,
   return Status::OK();
 }
 
+Status BlobDBImpl::GetLiveFilesWithPath(
+    std::unordered_map<std::string, std::vector<std::string>>& path_to_files,
+    uint64_t* manifest_file_size, bool flush_memtable) {
+  return Status::Corruption("GetLiveFilesWithPath not supported in BlobDBImpl");
+}
+
 void BlobDBImpl::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
   // Path should be relative to db_name.
   assert(bdb_options_.path_relative);

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -311,10 +311,9 @@ Status CheckpointImpl::CreateCustomCheckpoint(
       if (type != kTableFile && type != kBlobFile) {
         // copy non-table, non-blob files here
         // * if it's kDescriptorFile, limit the size to manifest_file_size
-        s = copy_file_cb(db_->GetName(), live_file,
-                         (type == kDescriptorFile) ? manifest_file_size : 0,
-                         type, kUnknownFileChecksumFuncName,
-                         kUnknownFileChecksum);
+        s = copy_file_cb(
+            path, live_file, (type == kDescriptorFile) ? manifest_file_size : 0,
+            type, kUnknownFileChecksumFuncName, kUnknownFileChecksum);
       } else {
         // process table and blob files below
         live_table_and_blob_files.emplace_back(path, live_file, number, type);


### PR DESCRIPTION
Make checkpoint support for non-default path of live files

Summary:
This PR is for https://github.com/facebook/rocksdb/issues/8647. A new API based on GetLiveFiles to db.h is added. This API can retrieves the all files with path and name in the database. For a live file with non-default path, the correct path can be located using this API when doing a checkpoint.