### PR TITLE
Stable cache keys on ingested SST files

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1114,6 +1114,8 @@ class DBImpl : public DB {
     State state_;
   };
 
+  static std::string GenerateDbSessionId(Env* env);
+
  protected:
   const std::string dbname_;
   std::string db_id_;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -649,8 +649,6 @@ Status BlockBasedTable::Open(
       // under these portable/stable keys.
       // Note: For now, each external SST file gets its own unique session id,
       // so we can use a fixed file number under than session id.
-      // ... except FIXME (peterd): sst_file_writer currently uses wrong
-      // format for db_session_ids so this approach doesn't work yet.
       db_session_id = rep->table_properties->db_session_id;
       file_num = 1;
     }

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "db/db_impl/db_impl.h"
 #include "db/dbformat.h"
 #include "file/writable_file_writer.h"
 #include "rocksdb/file_system.h"
@@ -245,7 +246,7 @@ Status SstFileWriter::Open(const std::string& file_path) {
   // Here we mimic the way db_session_id behaves by resetting the db_session_id
   // every time SstFileWriter is used, and in this case db_id is set to be "SST
   // Writer".
-  std::string db_session_id = r->ioptions.env->GenerateUniqueId();
+  std::string db_session_id = DBImpl::GenerateDbSessionId(r->ioptions.env);
   if (!db_session_id.empty() && db_session_id.back() == '\n') {
     db_session_id.pop_back();
   }

--- a/util/defer.h
+++ b/util/defer.h
@@ -57,6 +57,14 @@ class SaveAndRestore {
  public:
   // obj is non-null pointer to value to be saved and later restored.
   explicit SaveAndRestore(T* obj) : obj_(obj), saved_(*obj) {}
+  // new_value is stored in *obj
+  SaveAndRestore(T* obj, const T& new_value)
+      : obj_(obj), saved_(std::move(*obj)) {
+    *obj = new_value;
+  }
+  SaveAndRestore(T* obj, T&& new_value) : obj_(obj), saved_(std::move(*obj)) {
+    *obj = std::move(new_value);
+  }
   ~SaveAndRestore() { *obj_ = std::move(saved_); }
 
   // No copies


### PR DESCRIPTION
Summary: Extends #8659 to work for ingested external SST files, even
the same file ingested into different DBs sharing a block cache.

Note: These new cache keys are currently only enabled when FileSystem
does not provide GetUniqueId. For now, they are typically larger,
so slightly less efficient.

Test Plan: Extended unit test