### PR TITLE
Add iterator's lower and upper bounds to `TraceRecord`

### DIFF
--- a/include/rocksdb/trace_record.h
+++ b/include/rocksdb/trace_record.h
@@ -169,6 +169,16 @@ class IteratorSeekQueryTraceRecord : public IteratorQueryTraceRecord {
   IteratorSeekQueryTraceRecord(SeekType seekType, uint32_t column_family_id,
                                const std::string& key, uint64_t timestamp);
 
+  IteratorSeekQueryTraceRecord(SeekType seekType, uint32_t column_family_id,
+                               PinnableSlice&& key, PinnableSlice&& lower_bound,
+                               PinnableSlice&& upper_bound, uint64_t timestamp);
+
+  IteratorSeekQueryTraceRecord(SeekType seekType, uint32_t column_family_id,
+                               const std::string& key,
+                               const std::string& lower_bound,
+                               const std::string& upper_bound,
+                               uint64_t timestamp);
+
   virtual ~IteratorSeekQueryTraceRecord() override;
 
   // Trace type matches the seek type.
@@ -183,6 +193,12 @@ class IteratorSeekQueryTraceRecord : public IteratorQueryTraceRecord {
   // Key to seek to.
   virtual Slice GetKey() const;
 
+  // Iterate lower bound.
+  virtual Slice GetLowerBound() const;
+
+  // Iterate upper bound.
+  virtual Slice GetUpperBound() const;
+
   Status Accept(Handler* handler,
                 std::unique_ptr<TraceRecordResult>* result) override;
 
@@ -190,6 +206,8 @@ class IteratorSeekQueryTraceRecord : public IteratorQueryTraceRecord {
   SeekType type_;
   uint32_t cf_id_;
   PinnableSlice key_;
+  PinnableSlice lower_;
+  PinnableSlice upper_;
 };
 
 // Trace record for DB::MultiGet() operation.

--- a/trace_replay/trace_record.cc
+++ b/trace_replay/trace_record.cc
@@ -100,6 +100,29 @@ IteratorSeekQueryTraceRecord::IteratorSeekQueryTraceRecord(
   key_.PinSelf(key);
 }
 
+IteratorSeekQueryTraceRecord::IteratorSeekQueryTraceRecord(
+    SeekType seek_type, uint32_t column_family_id, PinnableSlice&& key,
+    PinnableSlice&& lower_bound, PinnableSlice&& upper_bound,
+    uint64_t timestamp)
+    : IteratorQueryTraceRecord(timestamp),
+      type_(seek_type),
+      cf_id_(column_family_id),
+      key_(std::move(key)),
+      lower_(std::move(lower_bound)),
+      upper_(std::move(upper_bound)) {}
+
+IteratorSeekQueryTraceRecord::IteratorSeekQueryTraceRecord(
+    SeekType seek_type, uint32_t column_family_id, const std::string& key,
+    const std::string& lower_bound, const std::string& upper_bound,
+    uint64_t timestamp)
+    : IteratorQueryTraceRecord(timestamp),
+      type_(seek_type),
+      cf_id_(column_family_id) {
+  key_.PinSelf(key);
+  lower_.PinSelf(lower_bound);
+  upper_.PinSelf(upper_bound);
+}
+
 IteratorSeekQueryTraceRecord::~IteratorSeekQueryTraceRecord() { key_.clear(); }
 
 TraceType IteratorSeekQueryTraceRecord::GetTraceType() const {
@@ -116,6 +139,14 @@ uint32_t IteratorSeekQueryTraceRecord::GetColumnFamilyID() const {
 }
 
 Slice IteratorSeekQueryTraceRecord::GetKey() const { return Slice(key_); }
+
+Slice IteratorSeekQueryTraceRecord::GetLowerBound() const {
+  return Slice(lower_);
+}
+
+Slice IteratorSeekQueryTraceRecord::GetUpperBound() const {
+  return Slice(upper_);
+}
 
 Status IteratorSeekQueryTraceRecord::Accept(
     Handler* handler, std::unique_ptr<TraceRecordResult>* result) {

--- a/trace_replay/trace_record_handler.cc
+++ b/trace_replay/trace_record_handler.cc
@@ -93,7 +93,16 @@ Status TraceExecutionHandler::Handle(
     return Status::Corruption("Invalid Column Family ID.");
   }
 
-  Iterator* single_iter = db_->NewIterator(read_opts_, it->second);
+  ReadOptions r_opts = read_opts_;
+  Slice lower = record.GetLowerBound();
+  if (!lower.empty()) {
+    r_opts.iterate_lower_bound = &lower;
+  }
+  Slice upper = record.GetUpperBound();
+  if (!upper.empty()) {
+    r_opts.iterate_upper_bound = &upper;
+  }
+  Iterator* single_iter = db_->NewIterator(r_opts, it->second);
 
   uint64_t start = clock_->NowMicros();
 


### PR DESCRIPTION
Trace file V2 added lower/upper bounds to `Iterator::Seek()` and `Iterator::SeekForPrev()`. They were not used anywhere during the execution of a `TraceRecord`. Now they are added to be used by `ReadOptions` during `Iterator::Seek()` and `Iterator::SeekForPrev()` if they are set.

Added test cases in `DBTest2.TraceAndManualReplay`.