### PR TITLE
Add extra information to RemoteCompaction APIs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 # Rocksdb Change Log
+## Unreleased
+### New Features
+* RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.
+
 ## 6.24.0 (2021-08-20)
 ### Bug Fixes
 * If the primary's CURRENT file is missing or inaccessible, the secondary instance should not hang repeatedly trying to switch to a new MANIFEST. It should instead return the error code encountered while accessing the file.

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -984,8 +984,9 @@ void CompactionJob::ProcessKeyValueCompactionWithCompactionService(
       "[%s] [JOB %d] Starting remote compaction (output level: %d): %s",
       compaction_input.column_family.name.c_str(), job_id_,
       compaction_input.output_level, input_files_oss.str().c_str());
+  CompactionServiceJobInfo info(dbname_, db_id_, db_session_id_);
   CompactionServiceJobStatus compaction_status =
-      db_options_.compaction_service->Start(compaction_input_binary,
+      db_options_.compaction_service->Start(info, compaction_input_binary,
                                             GetCompactionId(sub_compact));
   if (compaction_status != CompactionServiceJobStatus::kSuccess) {
     sub_compact->status =

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -984,10 +984,10 @@ void CompactionJob::ProcessKeyValueCompactionWithCompactionService(
       "[%s] [JOB %d] Starting remote compaction (output level: %d): %s",
       compaction_input.column_family.name.c_str(), job_id_,
       compaction_input.output_level, input_files_oss.str().c_str());
-  CompactionServiceJobInfo info(dbname_, db_id_, db_session_id_);
+  CompactionServiceJobInfo info(dbname_, db_id_, db_session_id_,
+                                GetCompactionId(sub_compact));
   CompactionServiceJobStatus compaction_status =
-      db_options_.compaction_service->Start(info, compaction_input_binary,
-                                            GetCompactionId(sub_compact));
+      db_options_.compaction_service->Start(info, compaction_input_binary);
   if (compaction_status != CompactionServiceJobStatus::kSuccess) {
     sub_compact->status =
         Status::Incomplete("CompactionService failed to start compaction job.");
@@ -996,7 +996,7 @@ void CompactionJob::ProcessKeyValueCompactionWithCompactionService(
 
   std::string compaction_result_binary;
   compaction_status = db_options_.compaction_service->WaitForComplete(
-      info, GetCompactionId(sub_compact), &compaction_result_binary);
+      info, &compaction_result_binary);
 
   CompactionServiceResult compaction_result;
   s = CompactionServiceResult::Read(compaction_result_binary,

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -987,7 +987,7 @@ void CompactionJob::ProcessKeyValueCompactionWithCompactionService(
   CompactionServiceJobInfo info(dbname_, db_id_, db_session_id_,
                                 GetCompactionId(sub_compact));
   CompactionServiceJobStatus compaction_status =
-      db_options_.compaction_service->Start(info, compaction_input_binary);
+      db_options_.compaction_service->StartV2(info, compaction_input_binary);
   if (compaction_status != CompactionServiceJobStatus::kSuccess) {
     sub_compact->status =
         Status::Incomplete("CompactionService failed to start compaction job.");
@@ -995,7 +995,7 @@ void CompactionJob::ProcessKeyValueCompactionWithCompactionService(
   }
 
   std::string compaction_result_binary;
-  compaction_status = db_options_.compaction_service->WaitForComplete(
+  compaction_status = db_options_.compaction_service->WaitForCompleteV2(
       info, &compaction_result_binary);
 
   CompactionServiceResult compaction_result;

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -996,7 +996,7 @@ void CompactionJob::ProcessKeyValueCompactionWithCompactionService(
 
   std::string compaction_result_binary;
   compaction_status = db_options_.compaction_service->WaitForComplete(
-      GetCompactionId(sub_compact), &compaction_result_binary);
+      info, GetCompactionId(sub_compact), &compaction_result_binary);
 
   CompactionServiceResult compaction_result;
   s = CompactionServiceResult::Read(compaction_result_binary,

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -128,7 +128,7 @@ class MyTestCompactionService : public CompactionService,
 
   const char* Name() const override { return kClassName(); }
 
-  CompactionServiceJobStatus Start(
+  CompactionServiceJobStatus StartV2(
       const CompactionServiceJobInfo& info,
       const std::string& compaction_service_input) override {
     InstrumentedMutexLock l(&mutex_);
@@ -141,7 +141,7 @@ class MyTestCompactionService : public CompactionService,
     return s;
   }
 
-  CompactionServiceJobStatus WaitForComplete(
+  CompactionServiceJobStatus WaitForCompleteV2(
       const CompactionServiceJobInfo& info,
       std::string* compaction_service_result) override {
     std::string compaction_input;

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -14,14 +14,14 @@ class MyTestCompactionService : public CompactionService {
  public:
   MyTestCompactionService(const std::string& db_path, Options& options,
                           std::shared_ptr<Statistics> statistics = nullptr)
-      : db_path_(db_path), options_(options), statistics_(statistics) {}
+                          : db_path_(db_path), options_(options), statistics_(statistics) {}
 
-  static const char* kClassName() { return "MyTestCompactionService"; }
+                          static const char* kClassName() { return "MyTestCompactionService"; }
 
-  const char* Name() const override { return kClassName(); }
+                          const char* Name() const override { return kClassName(); }
 
-  CompactionServiceJobStatus Start(const std::string& compaction_service_input,
-                                   uint64_t job_id) override {
+                          CompactionServiceJobStatus Start(const std::string& compaction_service_input,
+                                                           uint64_t job_id) override {
     InstrumentedMutexLock l(&mutex_);
     jobs_.emplace(job_id, compaction_service_input);
     CompactionServiceJobStatus s = CompactionServiceJobStatus::kSuccess;
@@ -79,6 +79,33 @@ class MyTestCompactionService : public CompactionService {
   Options options_;
   std::shared_ptr<Statistics> statistics_;
 };
+
+//class MyTestCompactionServiceLegacy : public CompactionService {
+//};
+//
+//template <class T>
+//class CCTest : public DBTestBase {
+// public:
+//  explicit CCTest()
+//  : DBTestBase("compaction_service_test", true) {}
+//
+//};
+//
+//TYPED_TEST_CASE_P(CCTest);
+//
+//TYPED_TEST_P(CCTest, Test1) {
+//  std::cout << "HI" << std::endl;
+//}
+//
+//REGISTER_TYPED_TEST_CASE_P(
+//    CCTest,  // The first argument is the test case name.
+//    // The rest of the arguments are the test names.
+//    Test1);
+//
+//typedef testing::Types<MyTestCompactionService> MyTest;
+//INSTANTIATE_TYPED_TEST_CASE_P(CCTestName,    // Instance name
+//                               CCTest,             // Test case name
+//                               MyTest);  // Type list
 
 class CompactionServiceTest : public DBTestBase {
  public:

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -16,7 +16,7 @@ class TestCompactionServiceBase {
 
   void OverrideStartStatus(CompactionServiceJobStatus s) {
     is_override_start_status = true;
-    override_start_status = std::move(s);
+    override_start_status = s;
   }
 
   void OverrideWaitResult(std::string str) {
@@ -29,11 +29,11 @@ class TestCompactionServiceBase {
     is_override_start_status = false;
   }
 
-  virtual ~TestCompactionServiceBase(){};
+  virtual ~TestCompactionServiceBase() = default;
 
  protected:
   bool is_override_start_status = false;
-  CompactionServiceJobStatus override_start_status;
+  CompactionServiceJobStatus override_start_status = CompactionServiceJobStatus::kFailure;
   bool is_override_wait_result = false;
   std::string override_wait_result;
 };
@@ -42,9 +42,9 @@ class MyTestCompactionServiceLegacy : public CompactionService,
                                       public TestCompactionServiceBase {
  public:
   MyTestCompactionServiceLegacy(
-      const std::string& db_path, Options& options,
-      std::shared_ptr<Statistics> statistics = nullptr)
-      : db_path_(db_path), options_(options), statistics_(statistics) {}
+      std::string db_path, Options& options,
+      std::shared_ptr<Statistics>& statistics)
+      : db_path_(std::move(db_path)), options_(options), statistics_(statistics) {}
 
   static const char* kClassName() { return "MyTestCompactionServiceLegacy"; }
 
@@ -116,9 +116,9 @@ class MyTestCompactionServiceLegacy : public CompactionService,
 class MyTestCompactionService : public CompactionService,
                                 public TestCompactionServiceBase {
  public:
-  MyTestCompactionService(const std::string& db_path, Options& options,
-                          std::shared_ptr<Statistics> statistics = nullptr)
-      : db_path_(db_path), options_(options), statistics_(statistics) {}
+  MyTestCompactionService(std::string db_path, Options& options,
+                          std::shared_ptr<Statistics>& statistics)
+      : db_path_(std::move(db_path)), options_(options), statistics_(statistics) {}
 
   static const char* kClassName() { return "MyTestCompactionService"; }
 
@@ -128,7 +128,7 @@ class MyTestCompactionService : public CompactionService,
                                    const std::string& compaction_service_input,
                                    uint64_t job_id) override {
     InstrumentedMutexLock l(&mutex_);
-    assert(info.db_name.compare(db_path_) == 0);
+    assert(info.db_name == db_path_);
     jobs_.emplace(job_id, compaction_service_input);
     CompactionServiceJobStatus s = CompactionServiceJobStatus::kSuccess;
     if (is_override_start_status) {
@@ -141,7 +141,7 @@ class MyTestCompactionService : public CompactionService,
       const CompactionServiceJobInfo& info, uint64_t job_id,
       std::string* compaction_service_result) override {
     std::string compaction_input;
-    assert(info.db_name.compare(db_path_) == 0);
+    assert(info.db_name == db_path_);
     {
       InstrumentedMutexLock l(&mutex_);
       auto i = jobs_.find(job_id);
@@ -192,45 +192,26 @@ class MyTestCompactionService : public CompactionService,
 };
 
 template <class T>
-class CCTest : public DBTestBase {
- public:
-  explicit CCTest() : DBTestBase("compaction_service_test", true) {}
-
-  T GetCS() {}
-};
-
-typedef testing::Types<MyTestCompactionService, MyTestCompactionServiceLegacy>
-    MyTest;
-TYPED_TEST_CASE(CCTest,  // Instance name
-                MyTest);
-
-TYPED_TEST(CCTest, Test1) { std::cout << "HI" << std::endl; }
-
-template <class T>
 class CompactionServiceTest : public DBTestBase {
  public:
   explicit CompactionServiceTest()
       : DBTestBase("compaction_service_test", true) {}
 
  protected:
-  void ReopenWithCompactionService() {
-    Options options = CurrentOptions();
-    options.env = env_;
+  void ReopenWithCompactionService(Options* options) {
+    options->env = env_;
     primary_statistics_ = CreateDBStatistics();
-    options.statistics = primary_statistics_;
+    options->statistics = primary_statistics_;
     compactor_statistics_ = CreateDBStatistics();
-    compaction_service_ = std::make_shared<T>(dbname_, options, compactor_statistics_);
-    options.compaction_service = compaction_service_;
-    DestroyAndReopen(options);
+    compaction_service_ =
+        std::make_shared<T>(dbname_, *options, compactor_statistics_);
+    options->compaction_service = compaction_service_;
+    DestroyAndReopen(*options);
   }
 
-  Statistics* GetCompactorStatistics() {
-    return primary_statistics_.get();
-  }
+  Statistics* GetCompactorStatistics() { return compactor_statistics_.get(); }
 
-  Statistics* GetPrimaryStatistics() {
-    return compactor_statistics_.get();
-  }
+  Statistics* GetPrimaryStatistics() { return primary_statistics_.get(); }
 
   T* GetCompactionService() {
     return compaction_service_.get();
@@ -280,7 +261,8 @@ typedef testing::Types<MyTestCompactionService, MyTestCompactionServiceLegacy> M
 TYPED_TEST_CASE(CompactionServiceTest, MyTestCompactionServiceTypes);
 
 TYPED_TEST(CompactionServiceTest, BasicCompactions) {
-  CompactionServiceTest<TypeParam>::ReopenWithCompactionService();
+  Options options = CompactionServiceTest<TypeParam>::CurrentOptions();
+  CompactionServiceTest<TypeParam>::ReopenWithCompactionService(&options);
 
   for (int i = 0; i < 20; i++) {
     for (int j = 0; j < 10; j++) {
@@ -313,17 +295,17 @@ TYPED_TEST(CompactionServiceTest, BasicCompactions) {
   ASSERT_GE(my_cs->GetCompactionNum(), 1);
 
   // make sure the compaction statistics is only recorded on remote side
-//  ASSERT_GE(
-//      compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY), 1);
+  ASSERT_GE(
+      compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY), 1);
   Statistics* primary_statistics = CompactionServiceTest<TypeParam>::GetPrimaryStatistics();
-//  ASSERT_EQ(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
-//            0);
+  ASSERT_EQ(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
+            0);
 
   // Test failed compaction
   SyncPoint::GetInstance()->SetCallBack(
       "DBImplSecondary::CompactWithoutInstallation::End", [&](void* status) {
         // override job status
-        Status* s = static_cast<Status*>(status);
+        auto s = static_cast<Status*>(status);
         *s = Status::Aborted("MyTestCompactionService failed to compact!");
       });
   SyncPoint::GetInstance()->EnableProcessing();
@@ -354,15 +336,11 @@ TYPED_TEST(CompactionServiceTest, BasicCompactions) {
 
 TYPED_TEST(CompactionServiceTest, ManualCompaction) {
   Options options = CompactionServiceTest<TypeParam>::CurrentOptions();
-  options.env = CompactionServiceTest<TypeParam>::env_;
   options.disable_auto_compactions = true;
-  options.compaction_service =
-      std::make_shared<MyTestCompactionService>(CompactionServiceTest<TypeParam>::dbname_, options);
-  CompactionServiceTest<TypeParam>::DestroyAndReopen(options);
+  CompactionServiceTest<TypeParam>::ReopenWithCompactionService(&options);
   CompactionServiceTest<TypeParam>::GenerateTestData();
 
-  auto my_cs =
-      dynamic_cast<MyTestCompactionService*>(options.compaction_service.get());
+  auto my_cs = CompactionServiceTest<TypeParam>::GetCompactionService();
 
   std::string start_str = CompactionServiceTest<TypeParam>::Key(15);
   std::string end_str = CompactionServiceTest<TypeParam>::Key(45);
@@ -392,205 +370,198 @@ TYPED_TEST(CompactionServiceTest, ManualCompaction) {
   ASSERT_GE(my_cs->GetCompactionNum(), comp_num + 1);
   CompactionServiceTest<TypeParam>::VerifyTestData();
 }
-//
-//TYPED_TEST(CompactionServiceTest, FailedToStart) {
-//  Options options = CurrentOptions();
-//  options.env = env_;
-//  options.disable_auto_compactions = true;
-//  options.compaction_service =
-//      std::make_shared<MyTestCompactionService>(dbname_, options);
-//  DestroyAndReopen(options);
-//  GenerateTestData();
-//
-//  auto my_cs = dynamic_cast<TestCompactionServiceBase*>(
-//      options.compaction_service.get());
-//  my_cs->OverrideStartStatus(CompactionServiceJobStatus::kFailure);
-//
-//  std::string start_str = Key(15);
-//  std::string end_str = Key(45);
-//  Slice start(start_str);
-//  Slice end(end_str);
-//  Status s = db_->CompactRange(CompactRangeOptions(), &start, &end);
-//  ASSERT_TRUE(s.IsIncomplete());
-//}
-//
-//TYPED_TEST(CompactionServiceTest, InvalidResult) {
-//  Options options = CurrentOptions();
-//  options.env = env_;
-//  options.disable_auto_compactions = true;
-//  options.compaction_service =
-//      std::make_shared<MyTestCompactionService>(dbname_, options);
-//  DestroyAndReopen(options);
-//  GenerateTestData();
-//
-//  auto my_cs = dynamic_cast<TestCompactionServiceBase*>(
-//      options.compaction_service.get());
-//  my_cs->OverrideWaitResult("Invalid Str");
-//
-//  std::string start_str = Key(15);
-//  std::string end_str = Key(45);
-//  Slice start(start_str);
-//  Slice end(end_str);
-//  Status s = db_->CompactRange(CompactRangeOptions(), &start, &end);
-//  ASSERT_FALSE(s.ok());
-//}
-//
-//TYPED_TEST(CompactionServiceTest, SubCompaction) {
-//  Options options = CurrentOptions();
-//  options.env = env_;
-//  options.max_subcompactions = 10;
-//  options.target_file_size_base = 1 << 10;  // 1KB
-//  options.disable_auto_compactions = true;
-//  options.compaction_service =
-//      std::make_shared<MyTestCompactionService>(dbname_, options);
-//
-//  DestroyAndReopen(options);
-//  GenerateTestData();
-//  VerifyTestData();
-//
-//  auto my_cs =
-//      dynamic_cast<MyTestCompactionService*>(options.compaction_service.get());
-//  int compaction_num_before = my_cs->GetCompactionNum();
-//
-//  auto cro = CompactRangeOptions();
-//  cro.max_subcompactions = 10;
-//  Status s = db_->CompactRange(cro, nullptr, nullptr);
-//  ASSERT_OK(s);
-//  VerifyTestData();
-//  int compaction_num = my_cs->GetCompactionNum() - compaction_num_before;
-//  // make sure there's sub-compaction by checking the compaction number
-//  ASSERT_GE(compaction_num, 2);
-//}
-//
-//class PartialDeleteCompactionFilter : public CompactionFilter {
-// public:
-//  CompactionFilter::Decision FilterV2(
-//      int /*level*/, const Slice& key, ValueType /*value_type*/,
-//      const Slice& /*existing_value*/, std::string* /*new_value*/,
-//      std::string* /*skip_until*/) const override {
-//    int i = std::stoi(key.ToString().substr(3));
-//    if (i > 5 && i <= 105) {
-//      return CompactionFilter::Decision::kRemove;
-//    }
-//    return CompactionFilter::Decision::kKeep;
-//  }
-//
-//  const char* Name() const override { return "PartialDeleteCompactionFilter"; }
-//};
-//
-//TYPED_TEST(CompactionServiceTest, CompactionFilter) {
-//  Options options = CurrentOptions();
-//  options.env = env_;
-//  std::unique_ptr<CompactionFilter> delete_comp_filter(
-//      new PartialDeleteCompactionFilter());
-//  options.compaction_filter = delete_comp_filter.get();
-//  options.compaction_service =
-//      std::make_shared<MyTestCompactionService>(dbname_, options);
-//
-//  DestroyAndReopen(options);
-//
-//  for (int i = 0; i < 20; i++) {
-//    for (int j = 0; j < 10; j++) {
-//      int key_id = i * 10 + j;
-//      ASSERT_OK(Put(Key(key_id), "value" + ToString(key_id)));
-//    }
-//    ASSERT_OK(Flush());
-//  }
-//
-//  for (int i = 0; i < 10; i++) {
-//    for (int j = 0; j < 10; j++) {
-//      int key_id = i * 20 + j * 2;
-//      ASSERT_OK(Put(Key(key_id), "value_new" + ToString(key_id)));
-//    }
-//    ASSERT_OK(Flush());
-//  }
-//  ASSERT_OK(dbfull()->TEST_WaitForCompact());
-//
-//  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
-//
-//  // verify result
-//  for (int i = 0; i < 200; i++) {
-//    auto result = Get(Key(i));
-//    if (i > 5 && i <= 105) {
-//      ASSERT_EQ(result, "NOT_FOUND");
-//    } else if (i % 2) {
-//      ASSERT_EQ(result, "value" + ToString(i));
-//    } else {
-//      ASSERT_EQ(result, "value_new" + ToString(i));
-//    }
-//  }
-//  auto my_cs =
-//      dynamic_cast<MyTestCompactionService*>(options.compaction_service.get());
-//  ASSERT_GE(my_cs->GetCompactionNum(), 1);
-//}
-//
-//TYPED_TEST(CompactionServiceTest, Snapshot) {
-//  Options options = CurrentOptions();
-//  options.env = env_;
-//  options.compaction_service =
-//      std::make_shared<MyTestCompactionService>(dbname_, options);
-//
-//  DestroyAndReopen(options);
-//
-//  ASSERT_OK(Put(Key(1), "value1"));
-//  ASSERT_OK(Put(Key(2), "value1"));
-//  const Snapshot* s1 = db_->GetSnapshot();
-//  ASSERT_OK(Flush());
-//
-//  ASSERT_OK(Put(Key(1), "value2"));
-//  ASSERT_OK(Put(Key(3), "value2"));
-//  ASSERT_OK(Flush());
-//
-//  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
-//  auto my_cs =
-//      dynamic_cast<MyTestCompactionService*>(options.compaction_service.get());
-//  ASSERT_GE(my_cs->GetCompactionNum(), 1);
-//  ASSERT_EQ("value1", Get(Key(1), s1));
-//  ASSERT_EQ("value2", Get(Key(1)));
-//  db_->ReleaseSnapshot(s1);
-//}
-//
-//TYPED_TEST(CompactionServiceTest, ConcurrentCompaction) {
-//  Options options = CurrentOptions();
-//  options.level0_file_num_compaction_trigger = 100;
-//  options.env = env_;
-//  options.compaction_service =
-//      std::make_shared<MyTestCompactionService>(dbname_, options);
-//  options.max_background_jobs = 20;
-//
-//  DestroyAndReopen(options);
-//  GenerateTestData();
-//
-//  ColumnFamilyMetaData meta;
-//  db_->GetColumnFamilyMetaData(&meta);
-//
-//  std::vector<std::thread> threads;
-//  for (const auto& file : meta.levels[1].files) {
-//    threads.push_back(std::thread([&]() {
-//      std::string fname = file.db_path + "/" + file.name;
-//      ASSERT_OK(db_->CompactFiles(CompactionOptions(), {fname}, 2));
-//    }));
-//  }
-//
-//  for (auto& thread : threads) {
-//    thread.join();
-//  }
-//  ASSERT_OK(dbfull()->TEST_WaitForCompact());
-//
-//  // verify result
-//  for (int i = 0; i < 200; i++) {
-//    auto result = Get(Key(i));
-//    if (i % 2) {
-//      ASSERT_EQ(result, "value" + ToString(i));
-//    } else {
-//      ASSERT_EQ(result, "value_new" + ToString(i));
-//    }
-//  }
-//  auto my_cs =
-//      dynamic_cast<MyTestCompactionService*>(options.compaction_service.get());
-//  ASSERT_EQ(my_cs->GetCompactionNum(), 10);
-//  ASSERT_EQ(FilesPerLevel(), "0,0,10");
-//}
+
+TYPED_TEST(CompactionServiceTest, FailedToStart) {
+  Options options = CompactionServiceTest<TypeParam>::CurrentOptions();
+  options.disable_auto_compactions = true;
+  CompactionServiceTest<TypeParam>::ReopenWithCompactionService(&options);
+
+  CompactionServiceTest<TypeParam>::GenerateTestData();
+
+  auto my_cs = CompactionServiceTest<TypeParam>::GetCompactionService();
+  my_cs->OverrideStartStatus(CompactionServiceJobStatus::kFailure);
+
+  std::string start_str = CompactionServiceTest<TypeParam>::Key(15);
+  std::string end_str = CompactionServiceTest<TypeParam>::Key(45);
+  Slice start(start_str);
+  Slice end(end_str);
+  Status s = CompactionServiceTest<TypeParam>::db_->CompactRange(
+      CompactRangeOptions(), &start, &end);
+  ASSERT_TRUE(s.IsIncomplete());
+}
+
+TYPED_TEST(CompactionServiceTest, InvalidResult) {
+  Options options = CompactionServiceTest<TypeParam>::CurrentOptions();
+  options.disable_auto_compactions = true;
+  CompactionServiceTest<TypeParam>::ReopenWithCompactionService(&options);
+
+  CompactionServiceTest<TypeParam>::GenerateTestData();
+
+  auto my_cs = CompactionServiceTest<TypeParam>::GetCompactionService();
+  my_cs->OverrideWaitResult("Invalid Str");
+
+  std::string start_str = CompactionServiceTest<TypeParam>::Key(15);
+  std::string end_str = CompactionServiceTest<TypeParam>::Key(45);
+  Slice start(start_str);
+  Slice end(end_str);
+  Status s = CompactionServiceTest<TypeParam>::db_->CompactRange(
+      CompactRangeOptions(), &start, &end);
+  ASSERT_FALSE(s.ok());
+}
+
+TYPED_TEST(CompactionServiceTest, SubCompaction) {
+  Options options = CompactionServiceTest<TypeParam>::CurrentOptions();
+  options.max_subcompactions = 10;
+  options.target_file_size_base = 1 << 10;  // 1KB
+  options.disable_auto_compactions = true;
+  CompactionServiceTest<TypeParam>::ReopenWithCompactionService(&options);
+
+  CompactionServiceTest<TypeParam>::GenerateTestData();
+  CompactionServiceTest<TypeParam>::VerifyTestData();
+
+  auto my_cs = CompactionServiceTest<TypeParam>::GetCompactionService();
+  int compaction_num_before = my_cs->GetCompactionNum();
+
+  auto cro = CompactRangeOptions();
+  cro.max_subcompactions = 10;
+  Status s = CompactionServiceTest<TypeParam>::db_->CompactRange(cro, nullptr,
+                                                                 nullptr);
+  ASSERT_OK(s);
+  CompactionServiceTest<TypeParam>::VerifyTestData();
+  int compaction_num = my_cs->GetCompactionNum() - compaction_num_before;
+  // make sure there's sub-compaction by checking the compaction number
+  ASSERT_GE(compaction_num, 2);
+}
+
+class PartialDeleteCompactionFilter : public CompactionFilter {
+ public:
+  CompactionFilter::Decision FilterV2(
+      int /*level*/, const Slice& key, ValueType /*value_type*/,
+      const Slice& /*existing_value*/, std::string* /*new_value*/,
+      std::string* /*skip_until*/) const override {
+    int i = std::stoi(key.ToString().substr(3));
+    if (i > 5 && i <= 105) {
+      return CompactionFilter::Decision::kRemove;
+    }
+    return CompactionFilter::Decision::kKeep;
+  }
+
+  const char* Name() const override { return "PartialDeleteCompactionFilter"; }
+};
+
+TYPED_TEST(CompactionServiceTest, CompactionFilter) {
+  Options options = CompactionServiceTest<TypeParam>::CurrentOptions();
+  std::unique_ptr<CompactionFilter> delete_comp_filter(
+      new PartialDeleteCompactionFilter());
+  options.compaction_filter = delete_comp_filter.get();
+  CompactionServiceTest<TypeParam>::ReopenWithCompactionService(&options);
+
+  for (int i = 0; i < 20; i++) {
+    for (int j = 0; j < 10; j++) {
+      int key_id = i * 10 + j;
+      ASSERT_OK(CompactionServiceTest<TypeParam>::Put(
+          CompactionServiceTest<TypeParam>::Key(key_id),
+          "value" + ToString(key_id)));
+    }
+    ASSERT_OK(CompactionServiceTest<TypeParam>::Flush());
+  }
+
+  for (int i = 0; i < 10; i++) {
+    for (int j = 0; j < 10; j++) {
+      int key_id = i * 20 + j * 2;
+      ASSERT_OK(CompactionServiceTest<TypeParam>::Put(
+          CompactionServiceTest<TypeParam>::Key(key_id),
+          "value_new" + ToString(key_id)));
+    }
+    ASSERT_OK(CompactionServiceTest<TypeParam>::Flush());
+  }
+  ASSERT_OK(CompactionServiceTest<TypeParam>::dbfull()->TEST_WaitForCompact());
+
+  ASSERT_OK(CompactionServiceTest<TypeParam>::db_->CompactRange(
+      CompactRangeOptions(), nullptr, nullptr));
+
+  // verify result
+  for (int i = 0; i < 200; i++) {
+    auto result = CompactionServiceTest<TypeParam>::Get(
+        CompactionServiceTest<TypeParam>::Key(i));
+    if (i > 5 && i <= 105) {
+      ASSERT_EQ(result, "NOT_FOUND");
+    } else if (i % 2) {
+      ASSERT_EQ(result, "value" + ToString(i));
+    } else {
+      ASSERT_EQ(result, "value_new" + ToString(i));
+    }
+  }
+  auto my_cs = CompactionServiceTest<TypeParam>::GetCompactionService();
+  ASSERT_GE(my_cs->GetCompactionNum(), 1);
+}
+
+TYPED_TEST(CompactionServiceTest, Snapshot) {
+  Options options = CompactionServiceTest<TypeParam>::CurrentOptions();
+  CompactionServiceTest<TypeParam>::ReopenWithCompactionService(&options);
+
+  ASSERT_OK(CompactionServiceTest<TypeParam>::Put(
+      CompactionServiceTest<TypeParam>::Key(1), "value1"));
+  ASSERT_OK(CompactionServiceTest<TypeParam>::Put(
+      CompactionServiceTest<TypeParam>::Key(2), "value1"));
+  const Snapshot* s1 = CompactionServiceTest<TypeParam>::db_->GetSnapshot();
+  ASSERT_OK(CompactionServiceTest<TypeParam>::Flush());
+
+  ASSERT_OK(CompactionServiceTest<TypeParam>::Put(
+      CompactionServiceTest<TypeParam>::Key(1), "value2"));
+  ASSERT_OK(CompactionServiceTest<TypeParam>::Put(
+      CompactionServiceTest<TypeParam>::Key(3), "value2"));
+  ASSERT_OK(CompactionServiceTest<TypeParam>::Flush());
+
+  ASSERT_OK(CompactionServiceTest<TypeParam>::db_->CompactRange(
+      CompactRangeOptions(), nullptr, nullptr));
+  auto my_cs = CompactionServiceTest<TypeParam>::GetCompactionService();
+  ASSERT_GE(my_cs->GetCompactionNum(), 1);
+  ASSERT_EQ("value1", CompactionServiceTest<TypeParam>::Get(
+                          CompactionServiceTest<TypeParam>::Key(1), s1));
+  ASSERT_EQ("value2", CompactionServiceTest<TypeParam>::Get(
+                          CompactionServiceTest<TypeParam>::Key(1)));
+  CompactionServiceTest<TypeParam>::db_->ReleaseSnapshot(s1);
+}
+
+TYPED_TEST(CompactionServiceTest, ConcurrentCompaction) {
+  Options options = CompactionServiceTest<TypeParam>::CurrentOptions();
+  options.level0_file_num_compaction_trigger = 100;
+  options.max_background_jobs = 20;
+  CompactionServiceTest<TypeParam>::ReopenWithCompactionService(&options);
+  CompactionServiceTest<TypeParam>::GenerateTestData();
+
+  ColumnFamilyMetaData meta;
+  CompactionServiceTest<TypeParam>::db_->GetColumnFamilyMetaData(&meta);
+
+  std::vector<std::thread> threads;
+  for (const auto& file : meta.levels[1].files) {
+    threads.push_back(std::thread([&]() {
+      std::string fname = file.db_path + "/" + file.name;
+      ASSERT_OK(CompactionServiceTest<TypeParam>::db_->CompactFiles(
+          CompactionOptions(), {fname}, 2));
+    }));
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  ASSERT_OK(CompactionServiceTest<TypeParam>::dbfull()->TEST_WaitForCompact());
+
+  // verify result
+  for (int i = 0; i < 200; i++) {
+    auto result = CompactionServiceTest<TypeParam>::Get(
+        CompactionServiceTest<TypeParam>::Key(i));
+    if (i % 2) {
+      ASSERT_EQ(result, "value" + ToString(i));
+    } else {
+      ASSERT_EQ(result, "value_new" + ToString(i));
+    }
+  }
+  auto my_cs = CompactionServiceTest<TypeParam>::GetCompactionService();
+  ASSERT_EQ(my_cs->GetCompactionNum(), 10);
+  ASSERT_EQ(CompactionServiceTest<TypeParam>::FilesPerLevel(), "0,0,10");
+}
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -405,7 +405,7 @@ class CompactionService : public Customizable {
   // `DB::OpenAndCompact()`.
   // job_id is pre-assigned, it will be reset after DB re-open.
   // Warning: deprecated, please use the new interface
-  // `Start(CompactionServiceJobInfo, ...)` instead.
+  // `StartV2(CompactionServiceJobInfo, ...)` instead.
   virtual CompactionServiceJobStatus Start(
       const std::string& /*compaction_service_input*/, uint64_t /*job_id*/) {
     return CompactionServiceJobStatus::kUseLocal;
@@ -414,7 +414,7 @@ class CompactionService : public Customizable {
   // Start the remote compaction with `compaction_service_input`, which can be
   // passed to `DB::OpenAndCompact()` on the remote side. `info` provides the
   // information the user might want to know, which includes `job_id`.
-  virtual CompactionServiceJobStatus Start(
+  virtual CompactionServiceJobStatus StartV2(
       const CompactionServiceJobInfo& info,
       const std::string& compaction_service_input) {
     // Default implementation to call legacy interface, please override and
@@ -424,14 +424,14 @@ class CompactionService : public Customizable {
 
   // Wait compaction to be finish.
   // Warning: deprecated, please use the new interface
-  // `WaitForComplete(CompactionServiceJobInfo, ...)` instead.
+  // `WaitForCompleteV2(CompactionServiceJobInfo, ...)` instead.
   virtual CompactionServiceJobStatus WaitForComplete(
       uint64_t /*job_id*/, std::string* /*compaction_service_result*/) {
     return CompactionServiceJobStatus::kUseLocal;
   }
 
   // Wait for remote compaction to finish.
-  virtual CompactionServiceJobStatus WaitForComplete(
+  virtual CompactionServiceJobStatus WaitForCompleteV2(
       const CompactionServiceJobInfo& info,
       std::string* compaction_service_result) {
     // Default implementation to call legacy interface, please override and

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -389,7 +389,7 @@ class CompactionService : public Customizable {
   static const char* Type() { return "CompactionService"; }
 
   // Returns the name of this compaction service.
-  virtual const char* Name() const = 0;
+  const char* Name() const override = 0;
 
   // Start the compaction with input information, which can be passed to
   // `DB::OpenAndCompact()`.
@@ -421,7 +421,7 @@ class CompactionService : public Customizable {
     return WaitForComplete(job_id, compaction_service_result);
   }
 
-  virtual ~CompactionService() {}
+  ~CompactionService() override = default;
 };
 
 struct DBOptions {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -410,7 +410,9 @@ class CompactionService : public Customizable {
   // Wait compaction to be finish.
   // Warning: deprecated, please use the new interface `WaitForComplete(CompactionServiceJobInfo, ...)` instead.
   virtual CompactionServiceJobStatus WaitForComplete(
-      uint64_t job_id, std::string* compaction_service_result);
+      uint64_t job_id, std::string* compaction_service_result) {
+    return CompactionServiceJobStatus::kUseLocal;
+  }
 
   // doc
   virtual CompactionServiceJobStatus WaitForComplete(const CompactionServiceJobInfo& info,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -407,7 +407,7 @@ class CompactionService : public Customizable {
   // Warning: deprecated, please use the new interface
   // `Start(CompactionServiceJobInfo, ...)` instead.
   virtual CompactionServiceJobStatus Start(
-      const std::string& compaction_service_input, uint64_t job_id) {
+      const std::string& /*compaction_service_input*/, uint64_t /*job_id*/) {
     return CompactionServiceJobStatus::kUseLocal;
   }
 
@@ -426,7 +426,7 @@ class CompactionService : public Customizable {
   // Warning: deprecated, please use the new interface
   // `WaitForComplete(CompactionServiceJobInfo, ...)` instead.
   virtual CompactionServiceJobStatus WaitForComplete(
-      uint64_t job_id, std::string* compaction_service_result) {
+      uint64_t /*job_id*/, std::string* /*compaction_service_result*/) {
     return CompactionServiceJobStatus::kUseLocal;
   }
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -385,7 +385,6 @@ struct CompactionServiceJobInfo {
                     // different DBs and sessions.
 
   // TODO: Add priority information
-
   CompactionServiceJobInfo(std::string db_name_, std::string db_id_,
                            std::string db_session_id_, uint64_t job_id_)
       : db_name(std::move(db_name_)),

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -400,7 +400,9 @@ class CompactionService : public Customizable {
     return CompactionServiceJobStatus::kUseLocal;
   }
 
-  // doc
+  // Start the remote compaction with `compaction_service_input`, which can be passed to `DB::OpenAndCompact()` on the remote side.
+  // `info` provides the information the user might want to know.
+  // `job_id` is pre-assigned, it will be reset after DB re-open.
   virtual CompactionServiceJobStatus Start(
       const CompactionServiceJobInfo& info, const std::string& compaction_service_input, uint64_t job_id) {
     // Default implementation to call legacy interface, please override and replace the legacy implementation
@@ -414,7 +416,7 @@ class CompactionService : public Customizable {
     return CompactionServiceJobStatus::kUseLocal;
   }
 
-  // doc
+  // Wait for remote compaction to finish.
   virtual CompactionServiceJobStatus WaitForComplete(const CompactionServiceJobInfo& info,
       uint64_t job_id, std::string* compaction_service_result) {
     // Default implementation to call legacy interface, please override and replace the legacy implementation


### PR DESCRIPTION
Summary: Currently, we only provide job_id in RemoteCompaction APIs, the
main problem of `job_id` is it cannot uniquely identify a compaction job
between DB instances or between sessions.
Providing DB and session id to the user, which will make building cross
DB compaction service easier.

Test Plan: unittest