### PR TITLE
Add `IteratorTraceExecutionResult` for iterator related trace records.

### DIFF
--- a/include/rocksdb/trace_record.h
+++ b/include/rocksdb/trace_record.h
@@ -157,10 +157,9 @@ class IteratorQueryTraceRecord : public QueryTraceRecord {
 
   virtual ~IteratorQueryTraceRecord() override;
 
-  // Iterate lower bound.
+  // Get the iterator's lower/upper bound. They may be used in ReadOptions to
+  // create an Iterator instance.
   virtual Slice GetLowerBound() const;
-
-  // Iterate upper bound.
   virtual Slice GetUpperBound() const;
 
  private:

--- a/include/rocksdb/trace_record.h
+++ b/include/rocksdb/trace_record.h
@@ -65,19 +65,15 @@ class TraceRecord {
    public:
     virtual ~Handler() = default;
 
-    // Handle WriteQueryTraceRecord
     virtual Status Handle(const WriteQueryTraceRecord& record,
                           std::unique_ptr<TraceRecordResult>* result) = 0;
 
-    // Handle GetQueryTraceRecord
     virtual Status Handle(const GetQueryTraceRecord& record,
                           std::unique_ptr<TraceRecordResult>* result) = 0;
 
-    // Handle IteratorSeekQueryTraceRecord
     virtual Status Handle(const IteratorSeekQueryTraceRecord& record,
                           std::unique_ptr<TraceRecordResult>* result) = 0;
 
-    // Handle MultiGetQueryTraceRecord
     virtual Status Handle(const MultiGetQueryTraceRecord& record,
                           std::unique_ptr<TraceRecordResult>* result) = 0;
   };
@@ -152,6 +148,24 @@ class GetQueryTraceRecord : public QueryTraceRecord {
 class IteratorQueryTraceRecord : public QueryTraceRecord {
  public:
   explicit IteratorQueryTraceRecord(uint64_t timestamp);
+
+  IteratorQueryTraceRecord(PinnableSlice&& lower_bound,
+                           PinnableSlice&& upper_bound, uint64_t timestamp);
+
+  IteratorQueryTraceRecord(const std::string& lower_bound,
+                           const std::string& upper_bound, uint64_t timestamp);
+
+  virtual ~IteratorQueryTraceRecord() override;
+
+  // Iterate lower bound.
+  virtual Slice GetLowerBound() const;
+
+  // Iterate upper bound.
+  virtual Slice GetUpperBound() const;
+
+ private:
+  PinnableSlice lower_;
+  PinnableSlice upper_;
 };
 
 // Trace record for Iterator::Seek() and Iterator::SeekForPrev() operation.
@@ -193,12 +207,6 @@ class IteratorSeekQueryTraceRecord : public IteratorQueryTraceRecord {
   // Key to seek to.
   virtual Slice GetKey() const;
 
-  // Iterate lower bound.
-  virtual Slice GetLowerBound() const;
-
-  // Iterate upper bound.
-  virtual Slice GetUpperBound() const;
-
   Status Accept(Handler* handler,
                 std::unique_ptr<TraceRecordResult>* result) override;
 
@@ -206,8 +214,6 @@ class IteratorSeekQueryTraceRecord : public IteratorQueryTraceRecord {
   SeekType type_;
   uint32_t cf_id_;
   PinnableSlice key_;
-  PinnableSlice lower_;
-  PinnableSlice upper_;
 };
 
 // Trace record for DB::MultiGet() operation.

--- a/include/rocksdb/trace_record_result.h
+++ b/include/rocksdb/trace_record_result.h
@@ -45,47 +45,6 @@ class TraceRecordResult {
     virtual Status Handle(const IteratorTraceExecutionResult& result) = 0;
   };
 
-  /*
-   * Example handler to just print the trace record execution results.
-   *
-   * class ResultPrintHandler : public TraceRecordResult::Handler {
-   *  public:
-   *   ResultPrintHandler();
-   *   ~ResultPrintHandler() override {}
-   *
-   *   Status Handle(const StatusOnlyTraceExecutionResult& result) override {
-   *     std::cout << "Status: " << result.GetStatus().ToString() << std::endl;
-   *   }
-   *
-   *   Status Handle(const SingleValueTraceExecutionResult& result) override {
-   *     std::cout << "Status: " << result.GetStatus().ToString()
-   *               << ", value: " << result.GetValue() << std::endl;
-   *   }
-   *
-   *   Status Handle(const MultiValuesTraceExecutionResult& result) override {
-   *     size_t size = result.GetMultiStatus().size();
-   *     for (size_t i = 0; i < size; i++) {
-   *       std::cout << "Status: " << result.GetMultiStatus()[i].ToString()
-   *                 << ", value: " << result.GetValues()[i] << std::endl;
-   *     }
-   *   }
-   *
-   *   Status Handle(const IteratorTraceExecutionResult& result) override {
-   *     if (result.GetValid()) {
-   *       std::cout << "Valid: true"
-   *                 << ", status: " << result.GetStatus().ToString()
-   *                 << ", key: " << result.GetKey().ToString()
-   *                 << ", value: " << result.GetValue().ToString()
-   *                 << std::endl;
-   *     } else {
-   *       std::cout << "Valid: false"
-   *                 << ", status: " << result.GetStatus().ToString()
-   *                 << std::endl;
-   *     }
-   *   }
-   * };
-   * */
-
   // Accept the handler.
   virtual Status Accept(Handler* handler) = 0;
 

--- a/include/rocksdb/trace_record_result.h
+++ b/include/rocksdb/trace_record_result.h
@@ -9,11 +9,13 @@
 #include <vector>
 
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "rocksdb/trace_record.h"
 
 namespace ROCKSDB_NAMESPACE {
 
+class IteratorTraceExecutionResult;
 class MultiValuesTraceExecutionResult;
 class SingleValueTraceExecutionResult;
 class StatusOnlyTraceExecutionResult;
@@ -34,14 +36,13 @@ class TraceRecordResult {
    public:
     virtual ~Handler() = default;
 
-    // Handle StatusOnlyTraceExecutionResult
     virtual Status Handle(const StatusOnlyTraceExecutionResult& result) = 0;
 
-    // Handle SingleValueTraceExecutionResult
     virtual Status Handle(const SingleValueTraceExecutionResult& result) = 0;
 
-    // Handle MultiValuesTraceExecutionResult
     virtual Status Handle(const MultiValuesTraceExecutionResult& result) = 0;
+
+    virtual Status Handle(const IteratorTraceExecutionResult& result) = 0;
   };
 
   /*
@@ -66,6 +67,20 @@ class TraceRecordResult {
    *     for (size_t i = 0; i < size; i++) {
    *       std::cout << "Status: " << result.GetMultiStatus()[i].ToString()
    *                 << ", value: " << result.GetValues()[i] << std::endl;
+   *     }
+   *   }
+   *
+   *   Status Handle(const IteratorTraceExecutionResult& result) override {
+   *     if (result.GetValid()) {
+   *       std::cout << "Valid: true"
+   *                 << ", status: " << result.GetStatus().ToString()
+   *                 << ", key: " << result.GetKey().ToString()
+   *                 << ", value: " << result.GetValue().ToString()
+   *                 << std::endl;
+   *     } else {
+   *       std::cout << "Valid: false"
+   *                 << ", status: " << result.GetStatus().ToString()
+   *                 << std::endl;
    *     }
    *   }
    * };
@@ -106,8 +121,7 @@ class TraceExecutionResult : public TraceRecordResult {
 };
 
 // Result for operations that only return a single Status.
-// Example operations: DB::Write(), Iterator::Seek() and
-// Iterator::SeekForPrev().
+// Example operation: DB::Write()
 class StatusOnlyTraceExecutionResult : public TraceExecutionResult {
  public:
   StatusOnlyTraceExecutionResult(Status status, uint64_t start_timestamp,
@@ -138,7 +152,7 @@ class SingleValueTraceExecutionResult : public TraceExecutionResult {
 
   virtual ~SingleValueTraceExecutionResult() override;
 
-  // Return status of DB::Get(), etc.
+  // Return status of DB::Get().
   virtual const Status& GetStatus() const;
 
   // Value for the searched key.
@@ -151,7 +165,7 @@ class SingleValueTraceExecutionResult : public TraceExecutionResult {
   std::string value_;
 };
 
-// Result for operations that return multiple Status(es) and values.
+// Result for operations that return multiple Status(es) and values as vectors.
 // Example operation: DB::MultiGet()
 class MultiValuesTraceExecutionResult : public TraceExecutionResult {
  public:
@@ -162,7 +176,7 @@ class MultiValuesTraceExecutionResult : public TraceExecutionResult {
 
   virtual ~MultiValuesTraceExecutionResult() override;
 
-  // Returned Status(es) of DB::MultiGet(), etc.
+  // Returned Status(es) of DB::MultiGet().
   virtual const std::vector<Status>& GetMultiStatus() const;
 
   // Returned values for the searched keys.
@@ -173,6 +187,42 @@ class MultiValuesTraceExecutionResult : public TraceExecutionResult {
  private:
   std::vector<Status> multi_status_;
   std::vector<std::string> values_;
+};
+
+// Result for Iterator operations.
+// Example operations: Iterator::Seek(), Iterator::SeekForPrev()
+class IteratorTraceExecutionResult : public TraceExecutionResult {
+ public:
+  IteratorTraceExecutionResult(bool valid, Status status, PinnableSlice&& key,
+                               PinnableSlice&& value, uint64_t start_timestamp,
+                               uint64_t end_timestamp, TraceType trace_type);
+
+  IteratorTraceExecutionResult(bool valid, Status status,
+                               const std::string& key, const std::string& value,
+                               uint64_t start_timestamp, uint64_t end_timestamp,
+                               TraceType trace_type);
+
+  virtual ~IteratorTraceExecutionResult() override;
+
+  // Return if the Iterator is valid.
+  virtual bool GetValid() const;
+
+  // Return the status of the Iterator.
+  virtual const Status& GetStatus() const;
+
+  // Key of the current iterating entry, empty if GetValid() is false.
+  virtual Slice GetKey() const;
+
+  // Value of the current iterating entry, empty if GetValid() is false.
+  virtual Slice GetValue() const;
+
+  virtual Status Accept(Handler* handler) override;
+
+ private:
+  bool valid_;
+  Status status_;
+  PinnableSlice key_;
+  PinnableSlice value_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/trace_replay/trace_record_result.cc
+++ b/trace_replay/trace_record_result.cc
@@ -103,4 +103,44 @@ Status MultiValuesTraceExecutionResult::Accept(Handler* handler) {
   return handler->Handle(*this);
 }
 
+// IteratorTraceExecutionResult
+IteratorTraceExecutionResult::IteratorTraceExecutionResult(
+    bool valid, Status status, PinnableSlice&& key, PinnableSlice&& value,
+    uint64_t start_timestamp, uint64_t end_timestamp, TraceType trace_type)
+    : TraceExecutionResult(start_timestamp, end_timestamp, trace_type),
+      valid_(valid),
+      status_(std::move(status)),
+      key_(std::move(key)),
+      value_(std::move(value)) {}
+
+IteratorTraceExecutionResult::IteratorTraceExecutionResult(
+    bool valid, Status status, const std::string& key, const std::string& value,
+    uint64_t start_timestamp, uint64_t end_timestamp, TraceType trace_type)
+    : TraceExecutionResult(start_timestamp, end_timestamp, trace_type),
+      valid_(valid),
+      status_(std::move(status)) {
+  key_.PinSelf(key);
+  value_.PinSelf(value);
+}
+
+IteratorTraceExecutionResult::~IteratorTraceExecutionResult() {
+  key_.clear();
+  value_.clear();
+}
+
+bool IteratorTraceExecutionResult::GetValid() const { return valid_; }
+
+const Status& IteratorTraceExecutionResult::GetStatus() const {
+  return status_;
+}
+
+Slice IteratorTraceExecutionResult::GetKey() const { return Slice(key_); }
+
+Slice IteratorTraceExecutionResult::GetValue() const { return Slice(value_); }
+
+Status IteratorTraceExecutionResult::Accept(Handler* handler) {
+  assert(handler != nullptr);
+  return handler->Handle(*this);
+}
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
- Allow to get `Valid()`, `status()`, `key()` and `value()` of an iterator from `IteratorTraceExecutionResult`.
- Move lower bound and upper bound from `IteratorSeekQueryTraceRecord` to `IteratorQueryTraceRecord`.

Added test in `DBTest2.TraceAndReplay`.