### PR TITLE
Add port::GetProcessID()

### DIFF
--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -23,6 +23,7 @@
 #include "cache/cache_entry_stats.h"
 #include "db/column_family.h"
 #include "db/db_impl/db_impl.h"
+#include "port/port.h"
 #include "rocksdb/system_clock.h"
 #include "rocksdb/table.h"
 #include "table/block_based/cachable_entry.h"
@@ -602,7 +603,8 @@ void InternalStats::CacheEntryRoleStats::BeginCollection(
   ++collection_count;
   role_map_ = CopyCacheDeleterRoleMap();
   std::ostringstream str;
-  str << cache->Name() << "@" << static_cast<void*>(cache);
+  str << cache->Name() << "@" << static_cast<void*>(cache) << "#"
+      << port::GetProcessId();
   cache_id = str.str();
   cache_capacity = cache->GetCapacity();
 }

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -604,7 +604,7 @@ void InternalStats::CacheEntryRoleStats::BeginCollection(
   role_map_ = CopyCacheDeleterRoleMap();
   std::ostringstream str;
   str << cache->Name() << "@" << static_cast<void*>(cache) << "#"
-      << port::GetProcessId();
+      << port::GetProcessID();
   cache_id = str.str();
   cache_capacity = cache->GetCapacity();
 }

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -263,6 +263,8 @@ void SetCpuPriority(ThreadId id, CpuPriority priority) {
 #endif
 }
 
+int64_t GetProcessID() { return getpid(); }
+
 }  // namespace port
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -219,5 +219,7 @@ using ThreadId = pid_t;
 
 extern void SetCpuPriority(ThreadId id, CpuPriority priority);
 
+int64_t GetProcessID();
+
 } // namespace port
 }  // namespace ROCKSDB_NAMESPACE

--- a/port/win/port_win.cc
+++ b/port/win/port_win.cc
@@ -277,6 +277,8 @@ void SetCpuPriority(ThreadId id, CpuPriority priority) {
   (void)priority;
 }
 
+int64_t GetProcessID() { return GetCurrentProcessId(); }
+
 }  // namespace port
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -347,6 +347,8 @@ using ThreadId = int;
 
 extern void SetCpuPriority(ThreadId id, CpuPriority priority);
 
+int64_t GetProcessID();
+
 }  // namespace port
 
 


### PR DESCRIPTION
Summary: Useful in some places for object uniqueness across processes.
Currently used for generating a host-wide identifier of Cache objects
but expected to be used soon in some unique id generation code.

`int64_t` is chosen for return type because POSIX uses signed integer type,
usually `int`, for `pid_t` and Windows uses `DWORD`, which is `uint32_t`.

Future work: avoid copy-pasted declarations in port_*.h, perhaps with
port_common.h always included from port.h

Test Plan: manual for now