### PR TITLE
Batch blob read IO for MultiGet

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,7 @@
 * Allow a single write batch to include keys from multiple column families whose timestamps' formats can differ. For example, some column families may disable timestamp, while others enable timestamp.
 * Add compaction priority information in RemoteCompaction, which can be used to schedule high priority job first.
 * Added new callback APIs `OnBlobFileCreationStarted`,`OnBlobFileCreated`and `OnBlobFileDeleted` in `EventListener` class of listener.h. It notifies listeners during creation/deletion of individual blob files in Integrated BlobDB. It also log blob file creation finished event and deletion event in LOG file.
+* Batch blob read requests for `DB::MultiGet` using `MultiRead`.
 
 ### Public API change
 * Remove obsolete implementation details FullKey and ParseFullKey from public API

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -426,6 +426,9 @@ void BlobFileReader::MultiGetBlob(
   }
 
   for (size_t i = 0; i < num_blobs; ++i) {
+    if (!read_reqs[i].status.ok() || !statuses[i]->ok()) {
+      continue;
+    }
     const Slice& record_slice = read_reqs[i].result;
     const Slice value_slice(record_slice.data() + adjustments[i],
                             value_sizes[i]);

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -353,7 +353,7 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
 
 void BlobFileReader::MultiGetBlob(
     const ReadOptions& read_options,
-    const autovector<std::reference_wrapper<Slice>>& user_keys,
+    const autovector<std::reference_wrapper<const Slice>>& user_keys,
     const autovector<uint64_t>& offsets,
     const autovector<uint64_t>& value_sizes, autovector<Status*>& statuses,
     autovector<PinnableSlice*>& values, uint64_t* bytes_read) const {
@@ -391,9 +391,9 @@ void BlobFileReader::MultiGetBlob(
     }
   } else {
     buf.reset(new char[total_len]);
-    uint64_t pos = 0;
+    std::ptrdiff_t pos = 0;
     for (size_t i = 0; i < read_reqs.size(); ++i) {
-      read_reqs[i].scratch = pos + buf.get();
+      read_reqs[i].scratch = buf.get() + pos;
       pos += read_reqs[i].len;
     }
   }

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -264,6 +264,17 @@ Status BlobFileReader::ReadFromFile(const RandomAccessFileReader* file_reader,
   return Status::OK();
 }
 
+Status BlobFileReader::MultiReadFromFile(
+    const RandomAccessFileReader* file_reader,
+    const autovector<uint64_t>& read_offsets,
+    const autovector<size_t>& read_sizes, Statistics* statistics) {
+  assert(file_reader);
+  (void)read_offsets;
+  (void)read_sizes;
+  (void)statistics;
+  return Status::OK();
+}
+
 BlobFileReader::BlobFileReader(
     std::unique_ptr<RandomAccessFileReader>&& file_reader, uint64_t file_size,
     CompressionType compression_type, SystemClock* clock,
@@ -348,6 +359,23 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
     *bytes_read = record_size;
   }
 
+  return Status::OK();
+}
+
+Status BlobFileReader::MultiGetBlob(
+    const ReadOptions& read_options,
+    const autovector<std::reference_wrapper<Slice>>& user_keys,
+    const autovector<uint64_t>& offsets,
+    const autovector<uint64_t>& value_sizes,
+    const autovector<CompressionType>& compression_types,
+    autovector<PinnableSlice*>& values, uint64_t* bytes_read) const {
+  (void)read_options;
+  (void)user_keys;
+  (void)offsets;
+  (void)value_sizes;
+  (void)compression_types;
+  (void)values;
+  (void)bytes_read;
   return Status::OK();
 }
 

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -11,6 +11,7 @@
 #include "file/random_access_file_reader.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/rocksdb_namespace.h"
+#include "util/autovector.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -43,6 +44,14 @@ class BlobFileReader {
                  CompressionType compression_type, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
+  Status MultiGetBlob(
+      const ReadOptions& read_options,
+      const autovector<std::reference_wrapper<Slice>>& user_keys,
+      const autovector<uint64_t>& offsets,
+      const autovector<uint64_t>& value_sizes,
+      const autovector<CompressionType>& compression_types,
+      autovector<PinnableSlice*>& values, uint64_t* bytes_read) const;
+
  private:
   BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,
                  uint64_t file_size, CompressionType compression_type,
@@ -69,6 +78,11 @@ class BlobFileReader {
                              uint64_t read_offset, size_t read_size,
                              Statistics* statistics, Slice* slice, Buffer* buf,
                              AlignedBuf* aligned_buf);
+
+  static Status MultiReadFromFile(const RandomAccessFileReader* file_reader,
+                                  const autovector<uint64_t>& read_offsets,
+                                  const autovector<size_t>& read_sizes,
+                                  Statistics* statistics);
 
   static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
                            uint64_t value_size);

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -49,8 +49,11 @@ class BlobFileReader {
       const autovector<std::reference_wrapper<Slice>>& user_keys,
       const autovector<uint64_t>& offsets,
       const autovector<uint64_t>& value_sizes,
-      const autovector<CompressionType>& compression_types,
       autovector<PinnableSlice*>& values, uint64_t* bytes_read) const;
+
+  CompressionType GetCompressionType() const { return compression_type_; }
+
+  uint64_t GetFileSize() const { return file_size_; }
 
  private:
   BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,
@@ -78,11 +81,6 @@ class BlobFileReader {
                              uint64_t read_offset, size_t read_size,
                              Statistics* statistics, Slice* slice, Buffer* buf,
                              AlignedBuf* aligned_buf);
-
-  static Status MultiReadFromFile(const RandomAccessFileReader* file_reader,
-                                  const autovector<uint64_t>& read_offsets,
-                                  const autovector<size_t>& read_sizes,
-                                  Statistics* statistics);
 
   static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
                            uint64_t value_size);

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -44,13 +44,12 @@ class BlobFileReader {
                  CompressionType compression_type, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
-  void MultiGetBlob(const ReadOptions& read_options,
-                    const autovector<std::reference_wrapper<Slice>>& user_keys,
-                    const autovector<uint64_t>& offsets,
-                    const autovector<uint64_t>& value_sizes,
-                    autovector<Status*>& statuses,
-                    autovector<PinnableSlice*>& values,
-                    uint64_t* bytes_read) const;
+  void MultiGetBlob(
+      const ReadOptions& read_options,
+      const autovector<std::reference_wrapper<const Slice>>& user_keys,
+      const autovector<uint64_t>& offsets,
+      const autovector<uint64_t>& value_sizes, autovector<Status*>& statuses,
+      autovector<PinnableSlice*>& values, uint64_t* bytes_read) const;
 
   CompressionType GetCompressionType() const { return compression_type_; }
 

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -44,12 +44,13 @@ class BlobFileReader {
                  CompressionType compression_type, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
-  Status MultiGetBlob(
-      const ReadOptions& read_options,
-      const autovector<std::reference_wrapper<Slice>>& user_keys,
-      const autovector<uint64_t>& offsets,
-      const autovector<uint64_t>& value_sizes,
-      autovector<PinnableSlice*>& values, uint64_t* bytes_read) const;
+  void MultiGetBlob(const ReadOptions& read_options,
+                    const autovector<std::reference_wrapper<Slice>>& user_keys,
+                    const autovector<uint64_t>& offsets,
+                    const autovector<uint64_t>& value_sizes,
+                    autovector<Status*>& statuses,
+                    autovector<PinnableSlice*>& values,
+                    uint64_t* bytes_read) const;
 
   CompressionType GetCompressionType() const { return compression_type_; }
 

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -277,12 +277,13 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     PinnableSlice value;
     uint64_t bytes_read = 0;
 
-    ASSERT_TRUE(
-        reader
-            ->GetBlob(read_options, shorter_key,
-                      blob_offsets[0] - (keys[0].size() - sizeof(shorter_key)),
-                      blob_sizes[0], kNoCompression, &value, &bytes_read)
-            .IsCorruption());
+    ASSERT_TRUE(reader
+                    ->GetBlob(read_options, shorter_key,
+                              blob_offsets[0] -
+                                  (keys[0].size() - sizeof(shorter_key) - 1),
+                              blob_sizes[0], kNoCompression, &value,
+                              &bytes_read)
+                    .IsCorruption());
     ASSERT_EQ(bytes_read, 0);
 
     // MultiGetBlob
@@ -317,7 +318,7 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
 
   // Incorrect key
   {
-    constexpr char incorrect_key[] = "foo";
+    constexpr char incorrect_key[] = "foo1";
     PinnableSlice value;
     uint64_t bytes_read = 0;
 

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -239,8 +239,8 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     uint64_t bytes_read = 0;
 
     ASSERT_TRUE(reader
-                    ->GetBlob(read_options, keys[2], blob_offsets[2] - 1,
-                              blob_sizes[2], kNoCompression, &value,
+                    ->GetBlob(read_options, keys[0], blob_offsets[0] - 1,
+                              blob_sizes[0], kNoCompression, &value,
                               &bytes_read)
                     .IsCorruption());
     ASSERT_EQ(bytes_read, 0);
@@ -252,8 +252,8 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     uint64_t bytes_read = 0;
 
     ASSERT_TRUE(reader
-                    ->GetBlob(read_options, keys[0], blob_offsets[0] + 1,
-                              blob_sizes[0], kNoCompression, &value,
+                    ->GetBlob(read_options, keys[2], blob_offsets[2] + 1,
+                              blob_sizes[2], kNoCompression, &value,
                               &bytes_read)
                     .IsCorruption());
     ASSERT_EQ(bytes_read, 0);

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -280,7 +280,7 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     ASSERT_TRUE(reader
                     ->GetBlob(read_options, shorter_key,
                               blob_offsets[0] -
-                                  (keys[0].size() - sizeof(shorter_key) - 1),
+                                  (keys[0].size() - sizeof(shorter_key) + 1),
                               blob_sizes[0], kNoCompression, &value,
                               &bytes_read)
                     .IsCorruption());

--- a/db/blob/blob_index.h
+++ b/db/blob/blob_index.h
@@ -52,6 +52,9 @@ class BlobIndex {
 
   BlobIndex() : type_(Type::kUnknown) {}
 
+  BlobIndex(const BlobIndex&) = default;
+  BlobIndex& operator=(const BlobIndex&) = default;
+
   bool IsInlined() const { return type_ == Type::kInlinedTTL; }
 
   bool HasTTL() const {

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -522,10 +522,20 @@ class DBBlobBasicIOErrorTest : public DBBlobBasicTest,
   std::string sync_point_;
 };
 
+class DBBlobBasicIOErrorMultiGetTest : public DBBlobBasicIOErrorTest {
+ public:
+  DBBlobBasicIOErrorMultiGetTest() : DBBlobBasicIOErrorTest() {}
+};
+
 INSTANTIATE_TEST_CASE_P(DBBlobBasicTest, DBBlobBasicIOErrorTest,
                         ::testing::ValuesIn(std::vector<std::string>{
                             "BlobFileReader::OpenFile:NewRandomAccessFile",
                             "BlobFileReader::GetBlob:ReadFromFile"}));
+
+INSTANTIATE_TEST_CASE_P(DBBlobBasicTest, DBBlobBasicIOErrorMultiGetTest,
+                        ::testing::ValuesIn(std::vector<std::string>{
+                            "BlobFileReader::OpenFile:NewRandomAccessFile",
+                            "BlobFileReader::MultiGetBlob:ReadFromFile"}));
 
 TEST_P(DBBlobBasicIOErrorTest, GetBlob_IOError) {
   Options options;
@@ -556,7 +566,7 @@ TEST_P(DBBlobBasicIOErrorTest, GetBlob_IOError) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
-TEST_P(DBBlobBasicIOErrorTest, MultiGetBlobs_IOError) {
+TEST_P(DBBlobBasicIOErrorMultiGetTest, MultiGetBlobs_IOError) {
   Options options = GetDefaultOptions();
   options.env = fault_injection_env_.get();
   options.enable_blob_files = true;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2162,7 +2162,7 @@ bool DBImpl::MultiCFSnapshot(
     // consecutive retries, it means the write rate is very high. In that case
     // its probably ok to take the mutex on the 3rd try so we can succeed for
     // sure
-    static const int num_retries = 3;
+    constexpr int num_retries = 3;
     for (int i = 0; i < num_retries; ++i) {
       last_try = (i == num_retries - 1);
       bool retry = false;
@@ -2192,8 +2192,9 @@ bool DBImpl::MultiCFSnapshot(
           *snapshot = versions_->LastPublishedSequence();
         }
       } else {
-        *snapshot = reinterpret_cast<const SnapshotImpl*>(read_options.snapshot)
-                        ->number_;
+        *snapshot =
+            static_cast_with_check<const SnapshotImpl>(read_options.snapshot)
+                ->number_;
       }
       for (auto cf_iter = cf_list->begin(); cf_iter != cf_list->end();
            ++cf_iter) {
@@ -2394,17 +2395,9 @@ void DBImpl::PrepareMultiGetKeys(
     autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE>* sorted_keys) {
   if (sorted_input) {
 #ifndef NDEBUG
-    CompareKeyContext key_context_less;
-
-    for (size_t index = 1; index < sorted_keys->size(); ++index) {
-      const KeyContext* const lhs = (*sorted_keys)[index - 1];
-      const KeyContext* const rhs = (*sorted_keys)[index];
-
-      // lhs should be <= rhs, or in other words, rhs should NOT be < lhs
-      assert(!key_context_less(rhs, lhs));
-    }
+    assert(std::is_sorted(sorted_keys->begin(), sorted_keys->end(),
+                          CompareKeyContext()));
 #endif
-
     return;
   }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1919,8 +1919,8 @@ Status Version::MultiGetBlob(const ReadOptions& read_options,
         blob_file_reader.GetValue()->GetCompressionType();
 
     std::sort(blobs_in_file.begin(), blobs_in_file.end(),
-              [](std::pair<BlobIndex, BlobIterator>& lhs,
-                 std::pair<BlobIndex, BlobIterator>& rhs) -> bool {
+              [](const std::pair<BlobIndex, BlobIterator>& lhs,
+                 const std::pair<BlobIndex, BlobIterator>& rhs) -> bool {
                 return lhs.first.offset() < rhs.first.offset();
               });
     autovector<std::reference_wrapper<Slice>> user_keys;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1866,9 +1866,10 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
 
 Status Version::MultiGetBlob(const ReadOptions& read_options,
                              MultiGetRange& range) {
-  if (!range.NeedsAnyBlobRead()) {
-    return Status::OK();
-  } else if (read_options.read_tier == kBlockCacheTier) {
+  // Guaranteed by caller.
+  assert(range.NeedsAnyBlobRead());
+
+  if (read_options.read_tier == kBlockCacheTier) {
     Status s = Status::Incomplete("Cannot read blob(s): no disk I/O allowed");
     for (auto it = range.blob_begin(); it != range.blob_end(); ++it) {
       *(it->s) = s;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1959,9 +1959,10 @@ Status Version::MultiGetBlob(const ReadOptions& read_options,
         range.AddValueSize(blob_it->value->size());
         if (range.GetValueSize() > read_options.value_size_soft_limit) {
           status = Status::Aborted();
-          break;
+          *(blob_it->s) = status;
+        } else {
+          *(blob_it->s) = Status::OK();
         }
-        *(blob_it->s) = Status::OK();
       }
     } else {
       for (const auto& blob : blobs_in_file) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1922,7 +1922,7 @@ void Version::MultiGetBlob(const ReadOptions& read_options,
 
     // TODO: sort blobs_in_file by file offset.
     autovector<BlobIterator> blob_read_its;
-    autovector<std::reference_wrapper<Slice>> user_keys;
+    autovector<std::reference_wrapper<const Slice>> user_keys;
     autovector<uint64_t> offsets;
     autovector<uint64_t> value_sizes;
     autovector<Status*> statuses;
@@ -1943,7 +1943,7 @@ void Version::MultiGetBlob(const ReadOptions& read_options,
         continue;
       }
       blob_read_its.emplace_back(blob_it);
-      user_keys.emplace_back(std::ref(blob_it->ukey_with_ts));
+      user_keys.emplace_back(std::cref(blob_it->ukey_with_ts));
       offsets.push_back(blob_index.offset());
       value_sizes.push_back(blob_index.size());
       statuses.push_back(blob_it->s);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1974,9 +1974,6 @@ Status Version::MultiGetBlob(const ReadOptions& read_options,
         *(blob_it->s) = status;
       }
     }
-    if (!status.ok()) {
-      break;
-    }
   }
   return status;
 }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -713,6 +713,8 @@ class Version {
                  const BlobIndex& blob_index, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
+  Status MultiGetBlob(const ReadOptions& read_options, MultiGetRange& range);
+
   // Loads some stats information from files. Call without mutex held. It needs
   // to be called before applying the version to the version set.
   void PrepareApply(const MutableCFOptions& mutable_cf_options,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -713,7 +713,7 @@ class Version {
                  const BlobIndex& blob_index, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
-  Status MultiGetBlob(const ReadOptions& read_options, MultiGetRange& range);
+  void MultiGetBlob(const ReadOptions& read_options, MultiGetRange& range);
 
   // Loads some stats information from files. Call without mutex held. It needs
   // to be called before applying the version to the version set.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -713,7 +713,11 @@ class Version {
                  const BlobIndex& blob_index, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
-  void MultiGetBlob(const ReadOptions& read_options, MultiGetRange& range);
+  using BlobReadRequests =
+      std::vector<std::pair<BlobIndex, MultiGetRange::Iterator>>;
+  void MultiGetBlob(
+      const ReadOptions& read_options, MultiGetRange& range,
+      const std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs);
 
   // Loads some stats information from files. Call without mutex held. It needs
   // to be called before applying the version to the version set.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -713,8 +713,8 @@ class Version {
                  const BlobIndex& blob_index, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
-  using BlobReadRequests =
-      std::vector<std::pair<BlobIndex, MultiGetRange::Iterator>>;
+  using BlobReadRequests = std::vector<
+      std::pair<BlobIndex, std::reference_wrapper<const KeyContext>>>;
   void MultiGetBlob(
       const ReadOptions& read_options, MultiGetRange& range,
       const std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs);

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -97,13 +97,17 @@ class MultiGetContext {
   // that need to be performed
   static const int MAX_BATCH_SIZE = 32;
 
+  static_assert(MAX_BATCH_SIZE < 64, "MAX_BATCH_SIZE cannot exceed 63");
+
   MultiGetContext(autovector<KeyContext*, MAX_BATCH_SIZE>* sorted_keys,
                   size_t begin, size_t num_keys, SequenceNumber snapshot,
                   const ReadOptions& read_opts)
       : num_keys_(num_keys),
         value_mask_(0),
         value_size_(0),
-        lookup_key_ptr_(reinterpret_cast<LookupKey*>(lookup_key_stack_buf)) {
+        lookup_key_ptr_(reinterpret_cast<LookupKey*>(lookup_key_stack_buf)),
+        blob_mask_(0) {
+    assert(num_keys <= MAX_BATCH_SIZE);
     if (num_keys > MAX_LOOKUP_KEYS_ON_STACK) {
       lookup_key_heap_buf.reset(new char[sizeof(LookupKey) * num_keys]);
       lookup_key_ptr_ = reinterpret_cast<LookupKey*>(
@@ -139,6 +143,7 @@ class MultiGetContext {
   uint64_t value_size_;
   std::unique_ptr<char[]> lookup_key_heap_buf;
   LookupKey* lookup_key_ptr_;
+  uint64_t blob_mask_;
 
  public:
   // MultiGetContext::Range - Specifies a range of keys, by start and end index,
@@ -213,6 +218,62 @@ class MultiGetContext {
       size_t index_;
     };
 
+    class BlobIterator {
+     public:
+      typedef BlobIterator self_type;
+      typedef KeyContext value_type;
+      typedef KeyContext& reference;
+      typedef KeyContext* pointer;
+      typedef int difference_type;
+
+      BlobIterator(const Range* range, size_t idx)
+          : range_(range), ctx_(range->ctx_), index_(idx) {
+        while (index_ < range_->end_ &&
+               0 == ((uint64_t{1} << index_) & range_->ctx_->blob_mask_)) {
+          ++index_;
+        }
+#ifndef NDEBUG
+        if (index_ < range_->end_) {
+          assert(ctx_->sorted_keys_[index_]->is_blob_index);
+          assert(ctx_->sorted_keys_[index_]->value);
+        }
+#endif
+      }
+
+      BlobIterator(const BlobIterator&) = default;
+      BlobIterator& operator=(const BlobIterator&) = default;
+
+      BlobIterator& operator++() {
+        while (++index_ < range_->end_ &&
+               0 == ((uint64_t{1} << index_) & range_->ctx_->blob_mask_)) {
+        }
+        return *this;
+      }
+
+      bool operator==(BlobIterator other) const {
+        assert(range_->ctx_ == other.range_->ctx_);
+        return index_ == other.index_;
+      }
+
+      bool operator!=(BlobIterator other) const { return !(*this == other); }
+
+      KeyContext& operator*() {
+        assert(index_ < range_->end_ && index_ >= range_->start_);
+        return *(ctx_->sorted_keys_[index_]);
+      }
+
+      KeyContext* operator->() {
+        assert(index_ < range_->end_ && index_ >= range_->start_);
+        return ctx_->sorted_keys_[index_];
+      }
+
+     private:
+      friend Range;
+      const Range* range_;
+      const MultiGetContext* ctx_;
+      size_t index_;
+    };
+
     Range(const Range& mget_range,
           const Iterator& first,
           const Iterator& last) {
@@ -236,6 +297,10 @@ class MultiGetContext {
       skip_mask_ |= uint64_t{1} << iter.index_;
     }
 
+    bool IsKeySkipped(const Iterator& iter) const {
+      return skip_mask_ & (uint64_t{1} << iter.index_);
+    }
+
     // Update the value_mask_ in MultiGetContext so its
     // immediately reflected in all the Range Iterators
     void MarkKeyDone(Iterator& iter) {
@@ -256,6 +321,21 @@ class MultiGetContext {
     uint64_t GetValueSize() { return ctx_->value_size_; }
 
     void AddValueSize(uint64_t value_size) { ctx_->value_size_ += value_size; }
+
+    BlobIterator blob_begin() const { return BlobIterator(this, start_); }
+
+    BlobIterator blob_end() const { return BlobIterator(this, end_); }
+
+    void MarkBlobReadNeeded(Iterator& iter) {
+      assert(CheckKeyDone(iter));
+      assert(!IsKeySkipped(iter));
+      ctx_->blob_mask_ |= (uint64_t{1} << iter.index_);
+    }
+
+    bool NeedsAnyBlobRead() const {
+      uint64_t blob_mask = ctx_->blob_mask_;
+      return 0 != (blob_mask & ~(blob_mask - 1));
+    }
 
    private:
     friend MultiGetContext;


### PR DESCRIPTION
In batched `MultiGet()`, RocksDB batches blob read IO and uses `RandomAccessFileReader::MultiRead()`
to read the blobs instead of issuing multiple `Read()`.

Test plan:
```
make check
```