### PR TITLE
Refactor `DoWrite` code in `db_bench`, create new `RandomReadRollingWriteDelete` benchmark.

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -337,61 +337,69 @@ DEFINE_int32(num_multi_db, 0,
 DEFINE_double(compression_ratio, 0.5, "Arrange to generate values that shrink"
               " to this fraction of their original size after compression");
 
-DEFINE_double(
-    overwrite_probability, 0.0,
-    "Used in 'filluniquerandom' benchmark: for each write operation, "
-    "we give a probability to perform an overwrite instead. The key used for "
-    "the overwrite is randomly chosen from the last 'overwrite_window_size' "
-    "keys "
-    "previously inserted into the DB. "
-    "Valid overwrite_probability values: [0.0, 1.0].");
+// DEFINE_double(
+//     overwrite_probability, 0.0,
+//     "Used in 'filluniquerandom' benchmark: for each write operation, "
+//     "we give a probability to perform an overwrite instead. The key used for
+//     " "the overwrite is randomly chosen from the last 'overwrite_window_size'
+//     " "keys " "previously inserted into the DB. " "Valid
+//     overwrite_probability values: [0.0, 1.0].");
 
-DEFINE_uint32(overwrite_window_size, 1,
-              "Used in 'filluniquerandom' benchmark. For each write "
-              "operation, when "
-              "the overwrite_probability flag is set by the user, the key used "
-              "to perform "
-              "an overwrite is randomly chosen from the last "
-              "'overwrite_window_size' keys "
-              "previously inserted into the DB. "
-              "Warning: large values can affect throughput. "
-              "Valid overwrite_window_size values: [1, kMaxUint32].");
+// DEFINE_uint32(overwrite_window_size, 1,
+//               "Used in 'filluniquerandom' benchmark. For each write "
+//               "operation, when "
+//               "the overwrite_probability flag is set by the user, the key
+//               used " "to perform " "an overwrite is randomly chosen from the
+//               last "
+//               "'overwrite_window_size' keys "
+//               "previously inserted into the DB. "
+//               "Warning: large values can affect throughput. "
+//               "Valid overwrite_window_size values: [1, kMaxUint32].");
 
 DEFINE_uint64(
-    disposable_entries_delete_delay, 0,
+    dentry_delete_delay, 0,
     "Minimum delay in microseconds for the series of Deletes "
     "to be issued. When 0 the insertion of the last disposable entry is "
     "immediately followed by the issuance of the Deletes. "
-    "(only compatible with fillanddeleteuniquerandom benchmark).");
+    "(only compatible with randomreadrollingwritedelete benchmark).");
 
-DEFINE_uint64(disposable_entries_batch_size, 0,
-              "Number of consecutively inserted disposable KV entries "
+DEFINE_uint64(dentry_batch_size, 0,
+              "Number of disposable KV entries inserted"
               "that will be deleted after 'delete_delay' microseconds. "
               "A series of Deletes is always issued once all the "
               "disposable KV entries it targets have been inserted "
-              "into the DB. When 0 no deletes are issued and a "
-              "regular 'filluniquerandom' benchmark occurs. "
-              "(only compatible with fillanddeleteuniquerandom benchmark)");
+              "into the DB. "
+              "(only compatible with randomreadrollingwritedelete benchmark)");
 
-DEFINE_int32(disposable_entries_value_size, 64,
+DEFINE_int32(dentry_vsize, 64,
              "Size of the values (in bytes) of the entries targeted by "
              "selective deletes. "
              "(only compatible with fillanddeleteuniquerandom benchmark)");
 
-DEFINE_uint64(
-    persistent_entries_batch_size, 0,
-    "Number of KV entries being inserted right before the deletes "
-    "targeting the disposable KV entries are issued. These "
-    "persistent keys are not targeted by the deletes, and will always "
-    "remain valid in the DB. (only compatible with "
-    "--benchmarks='fillanddeleteuniquerandom' "
-    "and used when--disposable_entries_batch_size is > 0).");
+DEFINE_double(dentry_probability, 0.0,
+              "Probability for each entry to be made 'disposable' (deleted "
+              "shortly after being inserted). Only compatible with "
+              "--benchmarks='randomreadrollingwritedelete' "
+              "and used when--dentry_batch_size is > 0).");
 
-DEFINE_int32(persistent_entries_value_size, 64,
+DEFINE_int32(pentry_vsize, 64,
              "Size of the values (in bytes) of the entries not targeted by "
              "deletes. (only compatible with "
-             "--benchmarks='fillanddeleteuniquerandom' "
-             "and used when--disposable_entries_batch_size is > 0).");
+             "--benchmarks='randomreadrollingwritedelete' "
+             "and used when --dentry_probability is in [0.0,1.0).");
+
+DEFINE_double(read_probability, 0.0,
+              "Probability for each operation in RandomReadRollingWriteDelete "
+              "to be a read.");
+
+DEFINE_uint64(
+    dseed, 1234,
+    "Random seed for disposable entry key generation. "
+    "Only compatible with --benchmarks='randomreadrollingwritedelete'.");
+DEFINE_uint64(
+    pseed, 5678,
+    "Random seed for persistent entry key generation. "
+    "Only compatible with --benchmarks='randomreadrollingwritedelete'.");
 
 DEFINE_double(read_random_exp_range, 0.0,
               "Read random's key will be generated using distribution of "
@@ -4768,6 +4776,7 @@ class Benchmark {
           bytes_(0),
           stage_(0),
           num_written_(0),
+          num_deletes_(0),
           batch_bytes_(0),
           id_(0) {}
 
@@ -4852,6 +4861,27 @@ class Benchmark {
           val_.size() + bench_.key_size_ + bench_.user_timestamp_size_;
       bytes_ += val_.size() + bench_.key_size_ + bench_.user_timestamp_size_;
       ++num_written_;
+    }
+
+    void DeleteKInBatch(const int64_t rand_num) {
+      if (bench_.use_blob_db_) {
+#ifndef ROCKSDB_LITE
+        // Stacked BlobDB
+        blob_db::BlobDB* blobdb =
+            static_cast<blob_db::BlobDB*>(db_with_cfh_->db);
+        s_ = blobdb->Delete(bench_.write_options_, key_);
+#endif  //  ROCKSDB_LITE
+      } else if (FLAGS_num_column_families <= 1) {
+        batch_.Delete(key_);
+      } else {
+        // We use same rand_num as seed for key and column family so that we
+        // can deterministically find the cfh corresponding to a particular
+        // key while reading the key.
+        batch_.Delete(db_with_cfh_->GetCfh(rand_num), key_);
+      }
+      batch_bytes_ += bench_.key_size_ + bench_.user_timestamp_size_;
+      bytes_ += bench_.key_size_ + bench_.user_timestamp_size_;
+      ++num_deletes_;
     }
 
     void GenerateDeleteRange(const int64_t rand_num) {
@@ -4983,7 +5013,7 @@ class Benchmark {
     Duration duration_;
     WriteBatch batch_;
     DBWithColumnFamilies* db_with_cfh_;
-    int64_t bytes_, stage_, num_written_, batch_bytes_;
+    int64_t bytes_, stage_, num_written_, num_deletes_, batch_bytes_;
     size_t id_;
 
     std::unique_ptr<const char[]> key_guard_, begin_key_guard_, end_key_guard_;
@@ -4998,512 +5028,214 @@ class Benchmark {
     RandomGenerator gen_;
   };
 
+  class ReadAgent {
+   public:
+    ReadAgent(Benchmark& bench, ThreadState* thread)
+        : bench_(bench),
+          thread_(thread),
+          options_(ReadOptions(FLAGS_verify_checksum, true)),
+          num_key_gens_((bench_.db_.db == nullptr) ? bench_.multi_dbs_.size()
+                                                   : 1),
+          found_(0),
+          bytes_(0),
+          key_rand_(0),
+          num_keys_(0) {}
+    void Init() {
+      key_ = bench_.AllocateKey(&key_guard_);
+      if (bench_.user_timestamp_size_ > 0) {
+        ts_guard_.reset(new char[bench_.user_timestamp_size_]);
+      }
+      num_reads_ = 0;
+    }
+    void ReadKey(int64_t key_rand) {
+      ts_ptr_ = nullptr;
+      if (bench_.user_timestamp_size_ > 0) {
+        ts_ = bench_.mock_app_clock_->GetTimestampForRead(thread_->rand,
+                                                          ts_guard_.get());
+        options_.timestamp = &ts_;
+        ts_ptr_ = &ts_ret_;
+      }
+      pinnable_val_.Reset();
+      if (FLAGS_num_column_families > 1) {
+        s_ = db_with_cfh_->db->Get(options_, db_with_cfh_->GetCfh(key_rand),
+                                   key_, &pinnable_val_, ts_ptr_);
+      } else {
+        s_ = db_with_cfh_->db->Get(options_,
+                                   db_with_cfh_->db->DefaultColumnFamily(),
+                                   key_, &pinnable_val_, ts_ptr_);
+      }
+      num_reads_++;
+    }
+
+    void SelectNewDBWithCfh() {
+      id_ = thread_->rand.Next() % num_key_gens_;
+      db_with_cfh_ = bench_.SelectDBWithCfh(id_);
+    }
+
+   private:
+    Benchmark& bench_;
+    ThreadState* thread_;
+    ReadOptions options_;
+    size_t num_key_gens_;
+    int64_t found_, bytes_, key_rand_;
+    int num_keys_;
+    std::unique_ptr<const char[]> key_guard_;
+    std::unique_ptr<char[]> ts_guard_;
+    Slice ts_;
+    PinnableSlice pinnable_val_;
+    std::string ts_ret_;
+    std::string* ts_ptr_;
+    Status s_;
+    DBWithColumnFamilies* db_with_cfh_;
+    size_t id_;
+
+   public:
+    Slice key_;
+    uint64_t num_reads_;
+  };
+
   void DoWrite(ThreadState* thread, WriteMode write_mode) {
     WriteAgent writer(*this, thread, write_mode);
     writer.Init();
-    // const int test_duration = write_mode == RANDOM ? FLAGS_duration : 0;
-    // const int64_t num_ops = writes_ == 0 ? num_ : writes_;
 
-    // size_t num_key_gens = 1;
-    // if (db_.db == nullptr) {
-    //   num_key_gens = multi_dbs_.size();
-    // }
-    // std::vector<std::unique_ptr<KeyGenerator>> key_gens(num_key_gens);
-    // int64_t max_ops = num_ops * num_key_gens;
-    // int64_t ops_per_stage = max_ops;
-    // if (FLAGS_num_column_families > 1 && FLAGS_num_hot_column_families > 0) {
-    //   ops_per_stage = (max_ops - 1) / (FLAGS_num_column_families /
-    //                                    FLAGS_num_hot_column_families) +
-    //                   1;
-    // }
-
-    // Duration duration(test_duration, max_ops, ops_per_stage);
-    // for (size_t i = 0; i < num_key_gens; i++) {
-    //   key_gens[i].reset(new KeyGenerator(&(thread->rand), write_mode,
-    //                                      num_ + max_num_range_tombstones_,
-    //                                      ops_per_stage));
-    // }
-
-    // if (num_ != FLAGS_num) {
-    //   char msg[100];
-    //   snprintf(msg, sizeof(msg), "(%" PRIu64 " ops)", num_);
-    //   thread->stats.AddMessage(msg);
-    // }
-
-    // RandomGenerator gen;
-    // WriteBatch batch(/*reserved_bytes=*/0, /*max_bytes=*/0,
-    //                  user_timestamp_size_);
-    // Status s;
-    // int64_t bytes = 0;
-
-    // std::unique_ptr<const char[]> key_guard;
-    // Slice key = AllocateKey(&key_guard);
-    // std::unique_ptr<const char[]> begin_key_guard;
-    // Slice begin_key = AllocateKey(&begin_key_guard);
-    // std::unique_ptr<const char[]> end_key_guard;
-    // Slice end_key = AllocateKey(&end_key_guard);
-
-    // //-------********* benchmark *********-----------
-    //     double p = 0.0;
-    //     uint64_t num_overwrites = 0, num_unique_keys = 0,
-    //     num_selective_deletes = 0;
-    //     // If user set overwrite_probability flag,
-    //     // check if value is in [0.0,1.0].
-    //     if (FLAGS_overwrite_probability > 0.0) {
-    //       p = FLAGS_overwrite_probability > 1.0 ? 1.0 :
-    //       FLAGS_overwrite_probability;
-    //       // If overwrite set by user, and UNIQUE_RANDOM mode on,
-    //       // the overwrite_window_size must be > 0.
-    //       if (write_mode == UNIQUE_RANDOM && FLAGS_overwrite_window_size ==
-    //       0) {
-    //         fprintf(stderr,
-    //                 "Overwrite_window_size must be  strictly greater than
-    //                 0.\n");
-    //         ErrorExit();
-    //       }
-    //     }
-
-    //     // Default_random_engine provides slightly
-    //     // improved throughput over mt19937.
-    //     std::default_random_engine overwrite_gen{
-    //         static_cast<unsigned int>(FLAGS_seed)};
-    //     std::bernoulli_distribution overwrite_decider(p);
-
-    //     // Inserted key window is filled with the last N
-    //     // keys previously inserted into the DB (with
-    //     // N=FLAGS_overwrite_window_size).
-    //     // We use a deque struct because:
-    //     // - random access is O(1)
-    //     // - insertion/removal at beginning/end is also O(1).
-    //     std::deque<int64_t> inserted_key_window;
-    //     Random64 reservoir_id_gen(FLAGS_seed);
-
-    //     // --- Variables used in disposable/persistent keys simulation:
-    //     // The following variables are used when
-    //     // disposable_entries_batch_size is >0. We simualte a workload
-    //     // where the following sequence is repeated multiple times:
-    //     // "A set of keys S1 is inserted ('disposable entries'), then after
-    //     // some delay another set of keys S2 is inserted ('persistent
-    //     entries')
-    //     // and the first set of keys S1 is deleted. S2 artificially
-    //     represents
-    //     // the insertion of hypothetical results from some undefined
-    //     computation
-    //     // done on the first set of keys S1. The next sequence can start as
-    //     soon
-    //     // as the last disposable entry in the set S1 of this sequence is
-    //     // inserted, if the delay is non negligible"
-    //     bool skip_for_loop = false, is_disposable_entry = true;
-    //     std::vector<uint64_t> disposable_entries_index(num_key_gens, 0);
-    //     std::vector<uint64_t> persistent_ent_and_del_index(num_key_gens, 0);
-    //     const uint64_t kNumDispAndPersEntries =
-    //         FLAGS_disposable_entries_batch_size +
-    //         FLAGS_persistent_entries_batch_size;
-    //     if (kNumDispAndPersEntries > 0) {
-    //       if ((write_mode != UNIQUE_RANDOM) || (writes_per_range_tombstone_ >
-    //       0) ||
-    //           (p > 0.0)) {
-    //         fprintf(
-    //             stderr,
-    //             "Disposable/persistent deletes are not compatible with
-    //             overwrites " "and DeleteRanges; and are only supported in
-    //             filluniquerandom.\n");
-    //         ErrorExit();
-    //       }
-    //       if (FLAGS_disposable_entries_value_size < 0 ||
-    //           FLAGS_persistent_entries_value_size < 0) {
-    //         fprintf(
-    //             stderr,
-    //             "disposable_entries_value_size and
-    //             persistent_entries_value_size" "have to be positive.\n");
-    //         ErrorExit();
-    //       }
-    //     }
-    //     Random rnd_disposable_entry(static_cast<uint32_t>(FLAGS_seed));
-    //     std::string random_value;
-    //     // Queue that stores scheduled timestamp of disposable entries
-    //     deletes,
-    //     // along with starting index of disposable entry keys to delete.
-    //     std::vector<std::queue<std::pair<uint64_t, uint64_t>>>
-    //     disposable_entries_q(
-    //         num_key_gens);
-    //     // --- End of variables used in disposable/persistent keys
-    //     simulation.
-    // //-------********* benchmark *********-----------
-
-    // std::vector<std::unique_ptr<const char[]>> expanded_key_guards;
-    // std::vector<Slice> expanded_keys;
-    // if (FLAGS_expand_range_tombstones) {
-    //   expanded_key_guards.resize(range_tombstone_width_);
-    //   for (auto& expanded_key_guard : expanded_key_guards) {
-    //     expanded_keys.emplace_back(AllocateKey(&expanded_key_guard));
-    //   }
-    // }
-
-    // std::unique_ptr<char[]> ts_guard;
-    // if (user_timestamp_size_ > 0) {
-    //   ts_guard.reset(new char[user_timestamp_size_]);
-    // }
-
-    // int64_t stage = 0;
-    // int64_t num_written = 0;
-
-    // while (!duration.Done(entries_per_batch_)) {
-    //   if (duration.GetStage() != stage) {
-    //     stage = duration.GetStage();
-    //     if (db_.db != nullptr) {
-    //       db_.CreateNewCf(open_options_, stage);
-    //     } else {
-    //       for (auto& db : multi_dbs_) {
-    //         db.CreateNewCf(open_options_, stage);
-    //       }
-    //     }
-    //   }
     while (!writer.IsDurationDone(entries_per_batch_)) {
       writer.CreateNewCfIfStage();
       writer.SelectNewDBWithCfh();
       writer.ClearBatch();
-      // size_t id = thread->rand.Next() % num_key_gens;
-      // DBWithColumnFamilies* db_with_cfh = SelectDBWithCfh(id);
-      // batch.Clear();
-      // int64_t batch_bytes = 0;
 
       for (int64_t j = 0; j < entries_per_batch_; j++) {
         int64_t rand_num = 0;
-
-        // ------ ***** new benchmark **** -------
-        // if ((write_mode == UNIQUE_RANDOM) && (p > 0.0)) {
-        //   if ((inserted_key_window.size() > 0) &&
-        //       overwrite_decider(overwrite_gen)) {
-        //     num_overwrites++;
-        //     rand_num = inserted_key_window[reservoir_id_gen.Next() %
-        //                                    inserted_key_window.size()];
-        //   } else {
-        //     num_unique_keys++;
-        //     rand_num = key_gens[id]->Next();
-        //     if (inserted_key_window.size() < FLAGS_overwrite_window_size) {
-        //       inserted_key_window.push_back(rand_num);
-        //     } else {
-        //       inserted_key_window.pop_front();
-        //       inserted_key_window.push_back(rand_num);
-        //     }
-        //   }
-        // } else if (kNumDispAndPersEntries > 0) {
-        //   // Check if queue is non-empty and if we need to insert
-        //   // 'persistent' KV entries (KV entries that are never deleted)
-        //   // and delete disposable entries previously inserted.
-        //   if (!disposable_entries_q[id].empty() &&
-        //       (disposable_entries_q[id].front().first <
-        //        FLAGS_env->NowMicros())) {
-        //     // If we need to perform a "merge op" pattern,
-        //     // we first write all the persistent KV entries not targeted
-        //     // by deletes, and then we write the disposable entries deletes.
-        //     if (persistent_ent_and_del_index[id] <
-        //         FLAGS_persistent_entries_batch_size) {
-        //       // Generate key to insert.
-        //       rand_num =
-        //           key_gens[id]->Fetch(disposable_entries_q[id].front().second
-        //           +
-        //                               FLAGS_disposable_entries_batch_size +
-        //                               persistent_ent_and_del_index[id]);
-        //       persistent_ent_and_del_index[id]++;
-        //       is_disposable_entry = false;
-        //       skip_for_loop = false;
-        //     } else if (persistent_ent_and_del_index[id] <
-        //                kNumDispAndPersEntries) {
-        //       // Find key of the entry to delete.
-        //       rand_num =
-        //           key_gens[id]->Fetch(disposable_entries_q[id].front().second
-        //           +
-        //                               (persistent_ent_and_del_index[id] -
-        //                                FLAGS_persistent_entries_batch_size));
-        //       persistent_ent_and_del_index[id]++;
-        //       GenerateKeyFromInt(rand_num, FLAGS_num, &key);
-        //       // For the delete operation, everything happens here and we
-        //       // skip the rest of the for-loop, which is designed for
-        //       // inserts.
-        //       if (FLAGS_num_column_families <= 1) {
-        //         batch.Delete(key);
-        //       } else {
-        //         // We use same rand_num as seed for key and column family so
-        //         // that we can deterministically find the cfh corresponding
-        //         to a
-        //         // particular key while reading the key.
-        //         batch.Delete(db_with_cfh->GetCfh(rand_num), key);
-        //       }
-        //       // A delete only includes Key+Timestamp (no value).
-        //       batch_bytes += key_size_ + user_timestamp_size_;
-        //       bytes += key_size_ + user_timestamp_size_;
-        //       num_selective_deletes++;
-        //       // Skip rest of the for-loop (j=0, j<entries_per_batch_,j++).
-        //       skip_for_loop = true;
-        //     } else {
-        //       assert(false);  // should never reach this point.
-        //     }
-        //     // If disposable_entries_q needs to be updated (ie: when a
-        //     selective
-        //     // insert+delete was successfully completed, pop the job out of
-        //     the
-        //     // queue).
-        //     if (!disposable_entries_q[id].empty() &&
-        //         (disposable_entries_q[id].front().first <
-        //          FLAGS_env->NowMicros()) &&
-        //         persistent_ent_and_del_index[id] == kNumDispAndPersEntries) {
-        //       disposable_entries_q[id].pop();
-        //       persistent_ent_and_del_index[id] = 0;
-        //     }
-
-        //     // If we are deleting disposable entries, skip the rest of the
-        //     // for-loop since there is no key-value inserts at this moment in
-        //     // time.
-        //     if (skip_for_loop) {
-        //       continue;
-        //     }
-
-        //   }
-        //   // If no job is in the queue, then we keep inserting disposable KV
-        //   // entries that will be deleted later by a series of deletes.
-        //   else {
-        //     rand_num = key_gens[id]->Fetch(disposable_entries_index[id]);
-        //     disposable_entries_index[id]++;
-        //     is_disposable_entry = true;
-        //     if ((disposable_entries_index[id] %
-        //          FLAGS_disposable_entries_batch_size) == 0) {
-        //       // Skip the persistent KV entries inserts for now
-        //       disposable_entries_index[id] +=
-        //           FLAGS_persistent_entries_batch_size;
-        //     }
-        //   }
-        // } else {
-        //   rand_num = key_gens[id]->Next();
-        // }
-        // ------ ***** end new benchmark **** -------
-
-        // rand_num = key_gens[id]->Next();
-        // GenerateKeyFromInt(rand_num, FLAGS_num, &key);
-        // Slice val;
-        // val = gen.Generate();
-
-        // ------ ***** begin new benchmark **** -------
-        // if (kNumDispAndPersEntries > 0) {
-        //   random_value = rnd_disposable_entry.RandomString(
-        //       is_disposable_entry ? FLAGS_disposable_entries_value_size
-        //                           : FLAGS_persistent_entries_value_size);
-        //   val = Slice(random_value);
-        //   num_unique_keys++;
-        // } else {
-        //   val = gen.Generate();
-        // }
-        // ------ ***** end new benchmark **** -------
-
         rand_num = writer.GenerateKeyGenRand();
         GenerateKeyFromInt(rand_num, FLAGS_num, &writer.key_);
         writer.val_ = writer.gen_.Generate();
 
-        //         if (use_blob_db_) {
-        // #ifndef ROCKSDB_LITE
-        //           // Stacked BlobDB
-        //           blob_db::BlobDB* blobdb =
-        //               static_cast<blob_db::BlobDB*>(db_with_cfh->db);
-        //           if (FLAGS_blob_db_max_ttl_range > 0) {
-        //             int ttl = rand() % FLAGS_blob_db_max_ttl_range;
-        //             s = blobdb->PutWithTTL(write_options_, key, val, ttl);
-        //           } else {
-        //             s = blobdb->Put(write_options_, key, val);
-        //           }
-        // #endif  //  ROCKSDB_LITE
-        //         } else if (FLAGS_num_column_families <= 1) {
-        //           batch.Put(key, val);
-        //         } else {
-        //           // We use same rand_num as seed for key and column family
-        //           so that we
-        //           // can deterministically find the cfh corresponding to a
-        //           particular
-        //           // key while reading the key.
-        //           batch.Put(db_with_cfh->GetCfh(rand_num), key,
-        //                     val);
-        //         }
-        // batch_bytes += val.size() + key_size_ + user_timestamp_size_;
-        // bytes += val.size() + key_size_ + user_timestamp_size_;
-        // ++num_written;
-
         writer.PutKVInBatch(rand_num);
-
-        // // ------ ***** begin new benchmark **** -------
-        // // If all disposable entries have been inserted, then we need to
-        // // add in the job queue a call for 'persistent entry insertions +
-        // // disposable entry deletions'.
-        // if (kNumDispAndPersEntries > 0 && is_disposable_entry &&
-        //     ((disposable_entries_index[id] % kNumDispAndPersEntries) == 0)) {
-        //   // Queue contains [timestamp, starting_idx],
-        //   // timestamp = current_time + delay (minimum aboslute time when to
-        //   // start inserting the selective deletes) starting_idx = index in
-        //   the
-        //   // keygen of the rand_num to generate the key of the first KV entry
-        //   to
-        //   // delete (= key of the first selective delete).
-        //   disposable_entries_q[id].push(std::make_pair(
-        //       FLAGS_env->NowMicros() +
-        //           FLAGS_disposable_entries_delete_delay /* timestamp */,
-        //       disposable_entries_index[id] - kNumDispAndPersEntries
-        //       /*starting idx*/));
-        // }
-        // // ------ ***** end new benchmark **** -------
-
-        //         if (writes_per_range_tombstone_ > 0 &&
-        //             num_written > writes_before_delete_range_ &&
-        //             (num_written - writes_before_delete_range_) /
-        //                     writes_per_range_tombstone_ <=
-        //                 max_num_range_tombstones_ &&
-        //             (num_written - writes_before_delete_range_) %
-        //                     writes_per_range_tombstone_ ==
-        //                 0) {
-        //           int64_t begin_num = key_gens[id]->Next();
-        //           if (FLAGS_expand_range_tombstones) {
-        //             for (int64_t offset = 0; offset < range_tombstone_width_;
-        //                  ++offset) {
-        //               GenerateKeyFromInt(begin_num + offset, FLAGS_num,
-        //                                  &expanded_keys[offset]);
-        //               if (use_blob_db_) {
-        // #ifndef ROCKSDB_LITE
-        //                 // Stacked BlobDB
-        //                 s = db_with_cfh->db->Delete(write_options_,
-        //                                             expanded_keys[offset]);
-        // #endif  //  ROCKSDB_LITE
-        //               } else if (FLAGS_num_column_families <= 1) {
-        //                 batch.Delete(expanded_keys[offset]);
-        //               } else {
-        //                 batch.Delete(db_with_cfh->GetCfh(rand_num),
-        //                              expanded_keys[offset]);
-        //               }
-        //             }
-        //           } else {
-        //             GenerateKeyFromInt(begin_num, FLAGS_num, &begin_key);
-        //             GenerateKeyFromInt(begin_num + range_tombstone_width_,
-        //             FLAGS_num,
-        //                                &end_key);
-        //             if (use_blob_db_) {
-        // #ifndef ROCKSDB_LITE
-        //               // Stacked BlobDB
-        //               s = db_with_cfh->db->DeleteRange(
-        //                   write_options_,
-        //                   db_with_cfh->db->DefaultColumnFamily(), begin_key,
-        //                   end_key);
-        // #endif  //  ROCKSDB_LITE
-        //             } else if (FLAGS_num_column_families <= 1) {
-        //               batch.DeleteRange(begin_key, end_key);
-        //             } else {
-        //               batch.DeleteRange(db_with_cfh->GetCfh(rand_num),
-        //               begin_key,
-        //                                 end_key);
-        //             }
-        //           }
-        //         }
         writer.GenerateDeleteRange(rand_num);
       }
-      // if (thread->shared->write_rate_limiter.get() != nullptr) {
-      //   thread->shared->write_rate_limiter->Request(
-      //       batch_bytes, Env::IO_HIGH,
-      //       nullptr /* stats */, RateLimiter::OpType::kWrite);
-      //   // Set time at which last op finished to Now() to hide latency and
-      //   // sleep from rate limiter. Also, do the check once per batch, not
-      //   // once per write.
-      //   thread->stats.ResetLastOpTime();
-      // }
       if (writer.HasWriteRateLimiter()) {
         writer.SendWRLRequest();
       }
-
-      // if (user_timestamp_size_ > 0) {
-      //   Slice user_ts = mock_app_clock_->Allocate(ts_guard.get());
-      //   s = batch.AssignTimestamp(user_ts);
-      //   if (!s.ok()) {
-      //     fprintf(stderr, "assign timestamp to write batch: %s\n",
-      //             s.ToString().c_str());
-      //     ErrorExit();
-      //   }
-      // }
       if (writer.HasUserTimestamp()) {
         writer.TimestampBatch();
       }
 
-      // if (!use_blob_db_) {
-      //   // Not stacked BlobDB
-      //   s = db_with_cfh->db->Write(write_options_, &batch);
-      // }
-
-      // thread->stats.FinishedOps(db_with_cfh, db_with_cfh->db,
-      //                           entries_per_batch_, kWrite);
-
-      // if (FLAGS_sine_write_rate) {
-      //   uint64_t now = FLAGS_env->NowMicros();
-
-      //   uint64_t usecs_since_last;
-      //   if (now > thread->stats.GetSineInterval()) {
-      //     usecs_since_last = now - thread->stats.GetSineInterval();
-      //   } else {
-      //     usecs_since_last = 0;
-      //   }
-
-      //   if (usecs_since_last >
-      //       (FLAGS_sine_write_rate_interval_milliseconds * uint64_t{1000})) {
-      //     double usecs_since_start =
-      //             static_cast<double>(now - thread->stats.GetStart());
-      //     thread->stats.ResetSineInterval();
-      //     uint64_t write_rate =
-      //             static_cast<uint64_t>(SineRate(usecs_since_start /
-      //             1000000.0));
-      //     thread->shared->write_rate_limiter.reset(
-      //             NewGenericRateLimiter(write_rate));
-      //   }
-      // }
-
-      // if (!s.ok()) {
-      //   s = listener_->WaitForRecovery(600000000) ? Status::OK() : s;
-      // }
-
-      // if (!s.ok()) {
-      //   fprintf(stderr, "put error: %s\n", s.ToString().c_str());
-      //   ErrorExit();
-      // }
-
       writer.FinishBatchOps();
     }
-
-    // // ------ ***** begin new benchmark **** -------
-    // if ((write_mode == UNIQUE_RANDOM) && (p > 0.0)) {
-    //   fprintf(stdout,
-    //           "Number of unique keys inserted: %" PRIu64
-    //           ".\nNumber of overwrites: %" PRIu64 "\n",
-    //           num_unique_keys, num_overwrites);
-    // } else if (kNumDispAndPersEntries > 0) {
-    //   fprintf(stdout,
-    //           "Number of unique keys inserted (disposable+persistent): %"
-    //           PRIu64
-    //           ".\nNumber of 'disposable entry delete': %" PRIu64 "\n",
-    //           num_written, num_selective_deletes);
-    // }
-    // // ------ ***** end new benchmark **** -------
-    // thread->stats.AddBytes(bytes);
     writer.AddBytesToThread();
   }
 
-  Status RandomReadRollingWriteDelete(ThreadState* thread,
+  void DoRandomReadRollingWriteDelete(ThreadState* thread,
                                       WriteMode write_mode) {
+    double read_prob = 0.0, dentry_prob = 0.0;
+    if (FLAGS_read_probability > 0.0) {
+      read_prob = FLAGS_read_probability < 1.0 ? FLAGS_read_probability : 1.0;
+    }
+    if (FLAGS_dentry_probability > 0.0) {
+      dentry_prob =
+          FLAGS_dentry_probability < 1.0 ? FLAGS_dentry_probability : 1.0;
+    }
+
+    // Default_random_engine provides slightly
+    // improved throughput over mt19937.
+    std::default_random_engine read_gen{static_cast<unsigned int>(FLAGS_seed)},
+        dentry_gen{static_cast<unsigned int>(FLAGS_seed)},
+        delete_shuffle_gen{static_cast<unsigned int>(FLAGS_seed)};
+    std::bernoulli_distribution read_decider(read_prob);
+    std::bernoulli_distribution dentry_decider(dentry_prob);
+
+    // Once a batch of disposable entries has been inserted,
+    // the start timestamp for the corresponding salve of deletes
+    // is added to the delete_timestamps queue.
+    std::queue<uint64_t> delete_timestamps;
+    // Shuffle the deletes so that they are not written in the
+    // same order as the disposable entries.
+    std::vector<int64_t> delete_reservoir;
+    // Stats
+    uint64_t dentry_count = 0, pentry_count = 0, delete_count = 0;
+
+    // Verify value sizes are positive.
+    if (FLAGS_dentry_vsize < 0 || FLAGS_pentry_vsize < 0) {
+      fprintf(stderr, "dentry_vsize and pentry_vsize must be positive.\n");
+      ErrorExit();
+    }
+
+    if (FLAGS_pseed == FLAGS_dseed) {
+      fprintf(stderr,
+              "pseed and dseed are identical: the persistent "
+              "entries cannot persist in the DB. "
+              "Please use different seeds.\n");
+      ErrorExit();
+    }
+    // rnd_dentry and rnd_dentry_delete use the same seed: they work like
+    // iterators. rnd_pentry has a different seed, so even though there is a
+    // slight chance that a pentry is deleted further down the road, it is still
+    // worth using this 'iterator-like' approach.
+    Random64 rnd_dentry(static_cast<uint64_t>(FLAGS_dseed)),
+        rnd_dentry_delete(static_cast<uint64_t>(FLAGS_dseed)),
+        rnd_pentry(static_cast<uint64_t>(FLAGS_pseed));
+    Random rnd_value(static_cast<uint32_t>(FLAGS_seed));
+    std::string random_value("");
+    bool is_dentry = false;
+    int64_t key_rand = 0;
+
+    ReadAgent reader(*this, thread);
     WriteAgent writer(*this, thread, write_mode);
     writer.Init();
+
     while (!writer.IsDurationDone(entries_per_batch_)) {
       writer.CreateNewCfIfStage();
       writer.SelectNewDBWithCfh();
       writer.ClearBatch();
       for (int64_t j = 0; j < entries_per_batch_; j++) {
-        int64_t rand_num = 0;
-        rand_num = writer.GenerateKeyGenRand();
-        GenerateKeyFromInt(rand_num, FLAGS_num, &writer.key_);
-        writer.val_ = writer.gen_.Generate();
-        writer.PutKVInBatch(rand_num);
-        writer.GenerateDeleteRange(rand_num);
-      }
+        if (read_decider(read_gen)) {
+          reader.SelectNewDBWithCfh();
+          key_rand = GetRandomKey(&thread->rand);
+          GenerateKeyFromInt(key_rand, FLAGS_num, &reader.key_);
+          reader.ReadKey(key_rand);
+          if (writer.IsDurationDone(1)) {
+            break;
+          }
+          // Read operation is not considered a batch entry.
+          j--;
+        } else {
+          if (delete_reservoir.empty()) {
+            if (delete_timestamps.front() < (FLAGS_env->NowMicros())) {
+              for (uint64_t i = 0; i < FLAGS_dentry_batch_size; i++) {
+                delete_reservoir.push_back(rnd_dentry_delete.Next());
+              }
+              std::shuffle(delete_reservoir.begin(), delete_reservoir.end(),
+                           delete_shuffle_gen /* random engine */);
+              delete_timestamps.pop();
+            }
+          }
+          int64_t rand_num = 0;
+          if (!delete_reservoir.empty()) {
+            rand_num = delete_reservoir.back();
+            delete_reservoir.pop_back();
+            GenerateKeyFromInt(rand_num, FLAGS_num, &writer.key_);
+            writer.DeleteKInBatch(rand_num);
+            delete_count++;
+          } else {
+            is_dentry = dentry_decider(dentry_gen);
+            rand_num = is_dentry ? rnd_dentry.Next() : rnd_pentry.Next();
+            GenerateKeyFromInt(rand_num, FLAGS_num, &writer.key_);
+            random_value = rnd_value.RandomString(
+                is_dentry ? FLAGS_dentry_vsize : FLAGS_pentry_vsize);
+            writer.val_ = Slice(random_value);
+            writer.PutKVInBatch(rand_num);
+            if (is_dentry) {
+              dentry_count++;
+              if ((dentry_count % FLAGS_dentry_batch_size) == 0) {
+                delete_timestamps.push(
+                    FLAGS_env->NowMicros() +
+                    FLAGS_dentry_delete_delay /* timestamp */);
+              }
+            } else {
+              pentry_count++;
+            }
+          }
+        }
+      }  // end of write batch.
       if (writer.HasWriteRateLimiter()) {
         writer.SendWRLRequest();
       }
@@ -5512,6 +5244,10 @@ class Benchmark {
       }
       writer.FinishBatchOps();
     }
+    fprintf(stdout,
+            "Number of disp keys: %" PRIu64 ".\nNumber of pers keys: %" PRIu64
+            ".\nNumber of deletes: %" PRIu64 ".\nNumber fo reads: %" PRId64,
+            dentry_count, pentry_count, delete_count, reader.num_reads_);
     writer.AddBytesToThread();
   }
 


### PR DESCRIPTION
Refactored the `DoWrite` function in `db_bench` by creating two inner `Benchmark` classes: a `WriteAgent` and a `ReadAgent`. The goal is to make the `DoWrite`  function, and additional `Benchmark` functions, more modulable and easier to decipher.
As a result, the former `fillanddeleteuniquerandom` (#8593) is extracted from the DoWrite function and placed inside a new `Benchmark::DoRandomReadRollingWriteDelete`. The modularity introduced with the `ReadAgent` and `WriteAgent` classes strongly helps with the readability and the logic of the code while avoiding code redundancy.
The new `ReandomReadRollingWriteDelete` benchmark is similar to `fillanddeleteuniquerandom`:
Disposable and persistent KV entries are inserted into the DB, and after a certain delay, a batch of disposable KV entries are deleted, whereas persistent KV entries are (almost) never deleted. In addition, reads are randomly issued throughout the benchmark. Unlike `fillanddeleteuniquerandom`, this current benchmark supports multiple threads, and the memory footprint behind the persistent/disposable logic is greatly reduced by using pseudo random number generator as iterators.