### PR TITLE
Temporarily disable block-based filter when stress testing timestamp

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -305,6 +305,7 @@ ts_params = {
     "use_blob_db": 0,
     "enable_compaction_filter": 0,
     "ingest_external_file_one_in": 0,
+    "use_block_based_filter": 0,
 }
 
 def finalize_and_sanitize(src_params):


### PR DESCRIPTION
Current implementation does not support user-defined timestamp when
block-based filter is used. Will implement the support in the future, or
wait to see if block-based filter can be deprecated and removed.

Test plan:
make whitebox_crash_test_with_ts