### PR TITLE
Make Configurable/Customizable options copyable

### DIFF
--- a/include/rocksdb/configurable.h
+++ b/include/rocksdb/configurable.h
@@ -288,7 +288,7 @@ class Configurable {
  protected:
   // True once the object is prepared.  Once the object is prepared, only
   // mutable options can be configured.
-  std::atomic<bool> is_prepared_;
+  bool is_prepared_;
 
   // Returns the raw pointer for the associated named option.
   // The name is typically the name of an option registered via the


### PR DESCRIPTION
The atomic variable "is_prepared_" was keeping Configurable objects from being copy-constructed.  Removed the atomic to allow copies.

Since the variable is only changed from false to true (and never back), there is no reason it had to be atomic.

Added tests that simple Configurable and Customizable objects can be put on the stack and copied.