### PR TITLE
RemoteCompaction support Fallback to local compaction

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,7 @@
 * Add compaction priority information in RemoteCompaction, which can be used to schedule high priority job first.
 * Added new callback APIs `OnBlobFileCreationStarted`,`OnBlobFileCreated`and `OnBlobFileDeleted` in `EventListener` class of listener.h. It notifies listeners during creation/deletion of individual blob files in Integrated BlobDB. It also log blob file creation finished event and deletion event in LOG file.
 * Batch blob read requests for `DB::MultiGet` using `MultiRead`.
+* Add support for fallback to local compaction, the user can return `CompactionServiceJobStatus::kUseLocal` to instruct RocksDB to run the compaction locally instead of waiting for the remote compaction result.
 
 ### Public API change
 * Remove obsolete implementation details FullKey and ParseFullKey from public API

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -146,7 +146,7 @@ class CompactionJob {
   // consecutive groups such that each group has a similar size.
   void GenSubcompactionBoundaries();
 
-  void ProcessKeyValueCompactionWithCompactionService(
+  CompactionServiceJobStatus ProcessKeyValueCompactionWithCompactionService(
       SubcompactionState* sub_compact);
 
   // update the thread status for starting a compaction.

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -19,6 +19,11 @@ class TestCompactionServiceBase {
     override_start_status = s;
   }
 
+  void OverrideWaitStatus(CompactionServiceJobStatus s) {
+    is_override_wait_status = true;
+    override_wait_status = s;
+  }
+
   void OverrideWaitResult(std::string str) {
     is_override_wait_result = true;
     override_wait_result = std::move(str);
@@ -27,6 +32,7 @@ class TestCompactionServiceBase {
   void ResetOverride() {
     is_override_wait_result = false;
     is_override_start_status = false;
+    is_override_wait_status = false;
   }
 
   virtual ~TestCompactionServiceBase() = default;
@@ -34,6 +40,9 @@ class TestCompactionServiceBase {
  protected:
   bool is_override_start_status = false;
   CompactionServiceJobStatus override_start_status =
+      CompactionServiceJobStatus::kFailure;
+  bool is_override_wait_status = false;
+  CompactionServiceJobStatus override_wait_status =
       CompactionServiceJobStatus::kFailure;
   bool is_override_wait_result = false;
   std::string override_wait_result;
@@ -74,6 +83,10 @@ class MyTestCompactionServiceLegacy : public CompactionService,
       }
       compaction_input = std::move(i->second);
       jobs_.erase(i);
+    }
+
+    if (is_override_wait_status) {
+      return override_wait_status;
     }
 
     CompactionServiceOptionsOverride options_override;
@@ -158,6 +171,10 @@ class MyTestCompactionService : public CompactionService,
       }
       compaction_input = std::move(i->second);
       jobs_.erase(i);
+    }
+
+    if (is_override_wait_status) {
+      return override_wait_status;
     }
 
     CompactionServiceOptionsOverride options_override;
@@ -323,7 +340,7 @@ TEST_P(CompactionServiceTest, BasicCompactions) {
   Statistics* compactor_statistics = GetCompactorStatistics();
   ASSERT_GE(my_cs->GetCompactionNum(), 1);
 
-  // make sure the compaction statistics is only recorded on remote side
+  // make sure the compaction statistics is only recorded on the remote side
   ASSERT_GE(
       compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY), 1);
   Statistics* primary_statistics = GetPrimaryStatistics();
@@ -656,6 +673,91 @@ TEST_P(CompactionServiceTest, CompactionInfo) {
   ASSERT_EQ(Env::BOTTOM, info.priority);
   info = my_cs->GetCompactionInfoForWait();
   ASSERT_EQ(Env::BOTTOM, info.priority);
+}
+
+TEST_P(CompactionServiceTest, FallbackLocal) {
+  Options options = CurrentOptions();
+  ReopenWithCompactionService(&options);
+
+  auto my_cs = GetCompactionService();
+  my_cs->OverrideStartStatus(CompactionServiceJobStatus::kUseLocal);
+
+  for (int i = 0; i < 20; i++) {
+    for (int j = 0; j < 10; j++) {
+      int key_id = i * 10 + j;
+      ASSERT_OK(Put(Key(key_id), "value" + ToString(key_id)));
+    }
+    ASSERT_OK(Flush());
+  }
+
+  for (int i = 0; i < 10; i++) {
+    for (int j = 0; j < 10; j++) {
+      int key_id = i * 20 + j * 2;
+      ASSERT_OK(Put(Key(key_id), "value_new" + ToString(key_id)));
+    }
+    ASSERT_OK(Flush());
+  }
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+
+  // verify result
+  for (int i = 0; i < 200; i++) {
+    auto result = Get(Key(i));
+    if (i % 2) {
+      ASSERT_EQ(result, "value" + ToString(i));
+    } else {
+      ASSERT_EQ(result, "value_new" + ToString(i));
+    }
+  }
+
+  ASSERT_EQ(my_cs->GetCompactionNum(), 0);
+  Statistics* compactor_statistics = GetCompactorStatistics();
+  // make sure the compaction statistics is only recorded on the local side
+  ASSERT_EQ(
+      compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY), 0);
+  Statistics* primary_statistics = GetPrimaryStatistics();
+  ASSERT_GE(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
+            1);
+
+  // re-enable remote compaction
+  my_cs->ResetOverride();
+  std::string start_str = Key(15);
+  std::string end_str = Key(45);
+  Slice start(start_str);
+  Slice end(end_str);
+  uint64_t comp_num = my_cs->GetCompactionNum();
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &start, &end));
+  ASSERT_GE(my_cs->GetCompactionNum(), comp_num + 1);
+
+  // return run local again with API WaitForComplete
+  my_cs->OverrideWaitStatus(CompactionServiceJobStatus::kUseLocal);
+  start_str = Key(120);
+  start = start_str;
+  comp_num = my_cs->GetCompactionNum();
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &start, nullptr));
+  ASSERT_EQ(my_cs->GetCompactionNum(),
+            comp_num);  // no remote compaction is run
+
+  // verify result after 2 manual compactions
+  for (int i = 0; i < 200; i++) {
+    auto result = Get(Key(i));
+    if (i % 2) {
+      ASSERT_EQ(result, "value" + ToString(i));
+    } else {
+      ASSERT_EQ(result, "value_new" + ToString(i));
+    }
+  }
+
+  // re-enable remote compaction again and trigger auto compaction
+  my_cs->ResetOverride();
+  for (int i = 0; i < 10; i++) {
+    for (int j = 0; j < 10; j++) {
+      int key_id = i * 20 + j * 2;
+      ASSERT_OK(Put(Key(key_id), "value_new" + ToString(key_id)));
+    }
+    ASSERT_OK(Flush());
+  }
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_GE(my_cs->GetCompactionNum(), comp_num + 1);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -722,7 +722,7 @@ TEST_P(CompactionServiceTest, FallbackLocal) {
   ASSERT_EQ(
       compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
       compactor_new_key);
-  ASSERT_GE(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
+  ASSERT_GT(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
             primary_new_key);
 
   // re-enable remote compaction
@@ -740,7 +740,7 @@ TEST_P(CompactionServiceTest, FallbackLocal) {
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &start, &end));
   ASSERT_GE(my_cs->GetCompactionNum(), comp_num + 1);
   // make sure the compaction statistics is only recorded on the remote side
-  ASSERT_GE(
+  ASSERT_GT(
       compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
       compactor_new_key);
   ASSERT_EQ(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
@@ -763,7 +763,7 @@ TEST_P(CompactionServiceTest, FallbackLocal) {
   ASSERT_EQ(
       compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
       compactor_new_key);
-  ASSERT_GE(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
+  ASSERT_GT(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
             primary_new_key);
 
   // verify result after 2 manual compactions
@@ -792,7 +792,7 @@ TEST_P(CompactionServiceTest, FallbackLocal) {
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
   ASSERT_GE(my_cs->GetCompactionNum(), comp_num + 1);
   // make sure the compaction statistics is only recorded on the remote side
-  ASSERT_GE(
+  ASSERT_GT(
       compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),
       compactor_new_key);
   ASSERT_EQ(primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY),

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -749,10 +749,6 @@ TEST_P(CompactionServiceTest, FallbackLocalManual) {
   Slice start(start_str);
   Slice end(end_str);
   uint64_t comp_num = my_cs->GetCompactionNum();
-  compactor_new_key =
-      compactor_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY);
-  primary_new_key =
-      primary_statistics->getTickerCount(COMPACTION_KEY_DROP_NEWER_ENTRY);
 
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &start, &end));
   ASSERT_GE(my_cs->GetCompactionNum(), comp_num + 1);

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -372,7 +372,7 @@ extern const char* kHostnameForDbHostId;
 enum class CompactionServiceJobStatus : char {
   kSuccess,
   kFailure,
-  kUseLocal,  // TODO: Add support for use local compaction
+  kUseLocal,
 };
 
 struct CompactionServiceJobInfo {


### PR DESCRIPTION
Summary: Add support for fallback to local compaction, the user can
return `CompactionServiceJobStatus::kUseLocal` to instruct RocksDB to
run the compaction locally instead of waiting for the remote compaction
result.

Test Plan: unittest