### PR TITLE
[RateLimiter] Charge read to rate limiter in BackupEngine

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,7 @@
 * Fix a race in item ref counting in LRUCache when promoting an item from the SecondaryCache.
 * Fix a race in BackupEngine if RateLimiter is reconfigured during concurrent Restore operations.
 * Fix a bug on POSIX in which failure to create a lock file (e.g. out of space) can prevent future LockFile attempts in the same process on the same file from succeeding.
-* Fix a bug that backup_rate_limit and restore_rate_limit in BackupEngine only apply to writes but not including reads.
+* Fix a bug that backup_rate_limiter and restore_rate_limiter in BackupEngine could not limit read rates
 
 ### New Features
 * RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 * Fix a race in item ref counting in LRUCache when promoting an item from the SecondaryCache.
 * Fix a race in BackupEngine if RateLimiter is reconfigured during concurrent Restore operations.
 * Fix a bug on POSIX in which failure to create a lock file (e.g. out of space) can prevent future LockFile attempts in the same process on the same file from succeeding.
+* Fix a bug that backup_rate_limit and restore_rate_limit in BackupEngine only apply to writes but not including reads
 
 ### New Features
 * RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,7 @@
 * Fix a race in item ref counting in LRUCache when promoting an item from the SecondaryCache.
 * Fix a race in BackupEngine if RateLimiter is reconfigured during concurrent Restore operations.
 * Fix a bug on POSIX in which failure to create a lock file (e.g. out of space) can prevent future LockFile attempts in the same process on the same file from succeeding.
-* Fix a bug that backup_rate_limit and restore_rate_limit in BackupEngine only apply to writes but not including reads
+* Fix a bug that backup_rate_limit and restore_rate_limit in BackupEngine only apply to writes but not including reads.
 
 ### New Features
 * RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,7 @@
 * Fix a race in item ref counting in LRUCache when promoting an item from the SecondaryCache.
 * Fix a race in BackupEngine if RateLimiter is reconfigured during concurrent Restore operations.
 * Fix a bug on POSIX in which failure to create a lock file (e.g. out of space) can prevent future LockFile attempts in the same process on the same file from succeeding.
-* Fix a bug that backup_rate_limiter and restore_rate_limiter in BackupEngine could not limit read rates
+* Fix a bug that backup_rate_limiter and restore_rate_limiter in BackupEngine could not limit read rates.
 
 ### New Features
 * RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -76,6 +76,9 @@ struct BackupEngineOptions {
 
   // Max bytes that can be transferred in a second during backup.
   // If 0, go as fast as you can
+  // This limit only applies to writes. To also limit reads,
+  // a rate limiter able to also limit reads (e.g, its mode = kAllIo)
+  // have to be passed in through the option "backup_rate_limiter"
   // Default: 0
   uint64_t backup_rate_limit;
 
@@ -86,6 +89,9 @@ struct BackupEngineOptions {
 
   // Max bytes that can be transferred in a second during restore.
   // If 0, go as fast as you can
+  // This limit only applies to writes. To also limit reads,
+  // a rate limiter able to also limit reads (e.g, its mode = kAllIo)
+  // have to be passed in through the option "restore_rate_limiter"
   // Default: 0
   uint64_t restore_rate_limit;
 

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -931,13 +931,15 @@ BackupEngineImpl::BackupEngineImpl(const BackupEngineOptions& options,
       read_only_(read_only) {
   if (options_.backup_rate_limiter == nullptr &&
       options_.backup_rate_limit > 0) {
-    options_.backup_rate_limiter.reset(
-        NewGenericRateLimiter(options_.backup_rate_limit, 100 * 1000 /* refill_period_us */, 10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
+    options_.backup_rate_limiter.reset(NewGenericRateLimiter(
+        options_.backup_rate_limit, 100 * 1000 /* refill_period_us */,
+        10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
   }
   if (options_.restore_rate_limiter == nullptr &&
       options_.restore_rate_limit > 0) {
-    options_.restore_rate_limiter.reset(
-        NewGenericRateLimiter(options_.restore_rate_limit, 100 * 1000 /* refill_period_us */, 10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
+    options_.restore_rate_limiter.reset(NewGenericRateLimiter(
+        options_.restore_rate_limit, 100 * 1000 /* refill_period_us */,
+        10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
   }
 }
 

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -2312,6 +2312,9 @@ Status BackupEngineImpl::GetFileDbIdentities(Env* src_env,
     } else {
       table_properties = tp.get();
       if (table_properties != nullptr && rate_limiter != nullptr) {
+        // sizeof(*table_properties) is a sufficent but far-from-exact approximation 
+        // of read bytes due to metaindex block, std::string properties and 
+        // varint compression
         rate_limiter->Request(sizeof(*table_properties), Env::IO_LOW,
                               nullptr /* stats */, RateLimiter::OpType::kRead);
       }

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -547,8 +547,7 @@ class BackupEngineImpl {
   Status ReadFileAndComputeChecksum(const std::string& src, Env* src_env,
                                     const EnvOptions& src_env_options,
                                     uint64_t size_limit,
-                                    std::string* checksum_hex,
-                                    RateLimiter* rate_limiter) const;
+                                    std::string* checksum_hex) const;
 
   // Obtain db_id and db_session_id from the table properties of file_path
   Status GetFileDbIdentities(Env* src_env, const EnvOptions& src_env_options,
@@ -1887,8 +1886,7 @@ Status BackupEngineImpl::VerifyBackup(BackupID backup_id,
       ROCKS_LOG_INFO(options_.info_log, "Verifying %s checksum...\n",
                      abs_path.c_str());
       Status s = ReadFileAndComputeChecksum(abs_path, backup_env_, EnvOptions(),
-                                            0 /* size_limit */, &checksum_hex,
-                                            options_.backup_rate_limiter.get());
+                                            0 /* size_limit */, &checksum_hex);
       if (!s.ok()) {
         return s;
       } else if (file_info->checksum_hex != checksum_hex) {
@@ -2065,7 +2063,7 @@ Status BackupEngineImpl::AddBackupFileWorkItem(
     if (checksum_hex.empty() && db_session_id.empty()) {
       Status s =
           ReadFileAndComputeChecksum(src_dir + fname, db_env_, src_env_options,
-                                     size_limit, &checksum_hex, rate_limiter);
+                                     size_limit, &checksum_hex);
       if (!s.ok()) {
         return s;
       }
@@ -2183,7 +2181,7 @@ Status BackupEngineImpl::AddBackupFileWorkItem(
         } else {
           Status s = ReadFileAndComputeChecksum(src_dir + fname, db_env_,
                                                 src_env_options, size_limit,
-                                                &checksum_hex, rate_limiter);
+                                                &checksum_hex);
           if (!s.ok()) {
             return s;
           }
@@ -2237,8 +2235,7 @@ Status BackupEngineImpl::AddBackupFileWorkItem(
 
 Status BackupEngineImpl::ReadFileAndComputeChecksum(
     const std::string& src, Env* src_env, const EnvOptions& src_env_options,
-    uint64_t size_limit, std::string* checksum_hex,
-    RateLimiter* rate_limiter) const {
+    uint64_t size_limit, std::string* checksum_hex) const {
   if (checksum_hex == nullptr) {
     return Status::Aborted("Checksum pointer is null");
   }

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -934,15 +934,13 @@ BackupEngineImpl::BackupEngineImpl(const BackupEngineOptions& options,
       read_only_(read_only) {
   if (options_.backup_rate_limiter == nullptr &&
       options_.backup_rate_limit > 0) {
-    options_.backup_rate_limiter.reset(NewGenericRateLimiter(
-        options_.backup_rate_limit, 100 * 1000 /* refill_period_us */,
-        10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
+    options_.backup_rate_limiter.reset(
+        NewGenericRateLimiter(options_.backup_rate_limit));
   }
   if (options_.restore_rate_limiter == nullptr &&
       options_.restore_rate_limit > 0) {
-    options_.restore_rate_limiter.reset(NewGenericRateLimiter(
-        options_.restore_rate_limit, 100 * 1000 /* refill_period_us */,
-        10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
+    options_.restore_rate_limiter.reset(
+        NewGenericRateLimiter(options_.restore_rate_limit));
   }
 }
 

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -2061,9 +2061,8 @@ Status BackupEngineImpl::AddBackupFileWorkItem(
     // since the session id should suffice to avoid file name collision in
     // the shared_checksum directory.
     if (checksum_hex.empty() && db_session_id.empty()) {
-      Status s =
-          ReadFileAndComputeChecksum(src_dir + fname, db_env_, src_env_options,
-                                     size_limit, &checksum_hex);
+      Status s = ReadFileAndComputeChecksum(
+          src_dir + fname, db_env_, src_env_options, size_limit, &checksum_hex);
       if (!s.ok()) {
         return s;
       }

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1887,7 +1887,8 @@ Status BackupEngineImpl::VerifyBackup(BackupID backup_id,
       ROCKS_LOG_INFO(options_.info_log, "Verifying %s checksum...\n",
                      abs_path.c_str());
       Status s = ReadFileAndComputeChecksum(abs_path, backup_env_, EnvOptions(),
-                                            0 /* size_limit */, &checksum_hex, options_.backup_rate_limiter.get());
+                                            0 /* size_limit */, &checksum_hex,
+                                            options_.backup_rate_limiter.get());
       if (!s.ok()) {
         return s;
       } else if (file_info->checksum_hex != checksum_hex) {
@@ -2062,8 +2063,9 @@ Status BackupEngineImpl::AddBackupFileWorkItem(
     // since the session id should suffice to avoid file name collision in
     // the shared_checksum directory.
     if (checksum_hex.empty() && db_session_id.empty()) {
-      Status s = ReadFileAndComputeChecksum(
-          src_dir + fname, db_env_, src_env_options, size_limit, &checksum_hex, rate_limiter);
+      Status s =
+          ReadFileAndComputeChecksum(src_dir + fname, db_env_, src_env_options,
+                                     size_limit, &checksum_hex, rate_limiter);
       if (!s.ok()) {
         return s;
       }
@@ -2235,7 +2237,8 @@ Status BackupEngineImpl::AddBackupFileWorkItem(
 
 Status BackupEngineImpl::ReadFileAndComputeChecksum(
     const std::string& src, Env* src_env, const EnvOptions& src_env_options,
-    uint64_t size_limit, std::string* checksum_hex, RateLimiter* rate_limiter) const {
+    uint64_t size_limit, std::string* checksum_hex,
+    RateLimiter* rate_limiter) const {
   if (checksum_hex == nullptr) {
     return Status::Aborted("Checksum pointer is null");
   }
@@ -2287,7 +2290,8 @@ Status BackupEngineImpl::GetFileDbIdentities(Env* src_env,
                                              const EnvOptions& src_env_options,
                                              const std::string& file_path,
                                              std::string* db_id,
-                                             std::string* db_session_id, RateLimiter* rate_limiter) {
+                                             std::string* db_session_id,
+                                             RateLimiter* rate_limiter) {
   assert(db_id != nullptr || db_session_id != nullptr);
 
   Options options;
@@ -2310,9 +2314,9 @@ Status BackupEngineImpl::GetFileDbIdentities(Env* src_env,
       table_properties = sst_reader.GetInitTableProperties();
     } else {
       table_properties = tp.get();
-      if(table_properties != nullptr && rate_limiter != nullptr) {
-        rate_limiter->Request(sizeof(*table_properties), Env::IO_LOW, nullptr /* stats */,
-                            RateLimiter::OpType::kRead);
+      if (table_properties != nullptr && rate_limiter != nullptr) {
+        rate_limiter->Request(sizeof(*table_properties), Env::IO_LOW,
+                              nullptr /* stats */, RateLimiter::OpType::kRead);
       }
     }
   } else {
@@ -2637,8 +2641,7 @@ const std::string kNonIgnorableFieldPrefix{"ni::"};
 Status BackupEngineImpl::BackupMeta::LoadFromFile(
     const std::string& backup_dir,
     const std::unordered_map<std::string, uint64_t>& abs_path_to_size,
-    Logger* info_log,
-    std::unordered_set<std::string>* reported_ignored_fields,
+    Logger* info_log, std::unordered_set<std::string>* reported_ignored_fields,
     RateLimiter* rate_limiter) {
   assert(reported_ignored_fields);
   assert(Empty());
@@ -2677,9 +2680,9 @@ Status BackupEngineImpl::BackupMeta::LoadFromFile(
       return Status::Corruption("Unexpected empty line");
     }
   }
-  if (!line.empty()){
+  if (!line.empty()) {
     timestamp_ = std::strtoull(line.c_str(), nullptr, /*base*/ 10);
-  } else if(backup_meta_reader->ReadLine(&line)){
+  } else if (backup_meta_reader->ReadLine(&line)) {
     if (rate_limiter != nullptr) {
       rate_limiter->Request(line.size(), Env::IO_LOW, nullptr /* stats */,
                             RateLimiter::OpType::kRead);
@@ -2831,7 +2834,7 @@ Status BackupEngineImpl::BackupMeta::LoadFromFile(
     while (backup_meta_reader->ReadLine(&line)) {
       if (rate_limiter != nullptr) {
         rate_limiter->Request(line.size(), Env::IO_LOW, nullptr /* stats */,
-                            RateLimiter::OpType::kRead);
+                              RateLimiter::OpType::kRead);
       }
       if (line.empty()) {
         return Status::Corruption("Unexpected empty line");

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2701,7 +2701,7 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingChargeReadInBackup) {
   backupable_options_->max_background_operations = is_single_threaded ? 1 : 10;
 
   DestroyDB(dbname_, Options());
-  OpenDBAndBackupEngine(true);
+  OpenDBAndBackupEngine(true, false, kShareWithChecksum);
   FillDB(db_.get(), 0, 10);
   ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), true));
   std::int64_t total_bytes_through_with_no_read_charge =
@@ -2718,17 +2718,8 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingChargeReadInBackup) {
       backup_rate_limiter->GetTotalBytesThrough();
   CloseDBAndBackupEngine();
   DestroyDB(dbname_, Options());
-
-  // total_bytes_through_with_read_charge falls into the interval of
-  // (total_bytes_through_with_no_read_charge,
-  // total_bytes_through_with_no_read_charge * 2] since some of the
-  // write-to-file done in backup_engine_->CreateNewBackup(db_.get(), true) does
-  // not need corresponding read-from-file (e.g, write manifest_fname to the
-  // file)
   EXPECT_GT(total_bytes_through_with_read_charge,
             total_bytes_through_with_no_read_charge);
-  EXPECT_LE(total_bytes_through_with_read_charge,
-            total_bytes_through_with_no_read_charge * 2);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2671,8 +2671,6 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingVerifyBackup) {
 
   if (makeThrottler) {
     EXPECT_GE(verify_backup_time, 0.8 * rate_limited_verify_backup_time);
-  } else {
-    EXPECT_LT(verify_backup_time, rate_limited_verify_backup_time);
   }
   CloseDBAndBackupEngine();
   AssertBackupConsistency(backup_id, 0, 100000, 100010);

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2624,11 +2624,14 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Values(std::make_tuple(true, 0, std::make_pair(1 * MB, 5 * MB)),
                       std::make_tuple(true, 0, std::make_pair(2 * MB, 3 * MB)),
                       std::make_tuple(true, 1, std::make_pair(1 * MB, 5 * MB)),
-                      std::make_tuple(true, 1, std::make_pair(2 * MB, 3 * MB))));
+                      std::make_tuple(true, 1,
+                                      std::make_pair(2 * MB, 3 * MB))));
 
 TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingChargeReadInBackup) {
   std::uint64_t backup_rate_limiter_limit = std::get<2>(GetParam()).first;
-  std::shared_ptr<RateLimiter> backup_rate_limiter(NewGenericRateLimiter(backup_rate_limiter_limit, 100 * 1000 /* refill_period_us */, 10 /* fairness */, RateLimiter::Mode::kWritesOnly /* mode */));
+  std::shared_ptr<RateLimiter> backup_rate_limiter(NewGenericRateLimiter(
+      backup_rate_limiter_limit, 100 * 1000 /* refill_period_us */,
+      10 /* fairness */, RateLimiter::Mode::kWritesOnly /* mode */));
   backupable_options_->backup_rate_limiter = backup_rate_limiter;
   bool is_single_threaded = std::get<1>(GetParam()) == 0 ? true : false;
   backupable_options_->max_background_operations = is_single_threaded ? 1 : 10;
@@ -2637,23 +2640,31 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingChargeReadInBackup) {
   OpenDBAndBackupEngine(true);
   FillDB(db_.get(), 0, 10);
   ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), true));
-  std::int64_t total_bytes_through_with_no_read_charge = backup_rate_limiter->GetTotalBytesThrough();
+  std::int64_t total_bytes_through_with_no_read_charge =
+      backup_rate_limiter->GetTotalBytesThrough();
   CloseBackupEngine();
 
-  backup_rate_limiter.reset(NewGenericRateLimiter(backup_rate_limiter_limit, 100 * 1000 /* refill_period_us */, 10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
+  backup_rate_limiter.reset(NewGenericRateLimiter(
+      backup_rate_limiter_limit, 100 * 1000 /* refill_period_us */,
+      10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
   backupable_options_->backup_rate_limiter = backup_rate_limiter;
   OpenBackupEngine(true);
   ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), true));
-  std::int64_t total_bytes_through_with_read_charge = backup_rate_limiter->GetTotalBytesThrough();
+  std::int64_t total_bytes_through_with_read_charge =
+      backup_rate_limiter->GetTotalBytesThrough();
   CloseDBAndBackupEngine();
   DestroyDB(dbname_, Options());
 
   // total_bytes_through_with_read_charge falls into the interval of
-  // (total_bytes_through_with_no_read_charge, total_bytes_through_with_no_read_charge * 2]
-  // since some of the write-to-file done in backup_engine_->CreateNewBackup(db_.get(), true) does not 
-  // need corresponding read-from-file (e.g, write manifest_fname to the file)
-  EXPECT_GT(total_bytes_through_with_read_charge, total_bytes_through_with_no_read_charge);
-  EXPECT_LE(total_bytes_through_with_read_charge, total_bytes_through_with_no_read_charge * 2);
+  // (total_bytes_through_with_no_read_charge,
+  // total_bytes_through_with_no_read_charge * 2] since some of the
+  // write-to-file done in backup_engine_->CreateNewBackup(db_.get(), true) does
+  // not need corresponding read-from-file (e.g, write manifest_fname to the
+  // file)
+  EXPECT_GT(total_bytes_through_with_read_charge,
+            total_bytes_through_with_no_read_charge);
+  EXPECT_LE(total_bytes_through_with_read_charge,
+            total_bytes_through_with_no_read_charge * 2);
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -2661,11 +2672,14 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Values(std::make_tuple(true, 0, std::make_pair(1 * MB, 5 * MB)),
                       std::make_tuple(true, 0, std::make_pair(2 * MB, 3 * MB)),
                       std::make_tuple(true, 1, std::make_pair(1 * MB, 5 * MB)),
-                      std::make_tuple(true, 1, std::make_pair(2 * MB, 3 * MB))));
+                      std::make_tuple(true, 1,
+                                      std::make_pair(2 * MB, 3 * MB))));
 
 TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingChargeReadInRestore) {
   std::uint64_t restore_rate_limiter_limit = std::get<2>(GetParam()).second;
-  std::shared_ptr<RateLimiter> restore_rate_limiter(NewGenericRateLimiter(restore_rate_limiter_limit, 100 * 1000 /* refill_period_us */, 10 /* fairness */, RateLimiter::Mode::kWritesOnly /* mode */));
+  std::shared_ptr<RateLimiter> restore_rate_limiter(NewGenericRateLimiter(
+      restore_rate_limiter_limit, 100 * 1000 /* refill_period_us */,
+      10 /* fairness */, RateLimiter::Mode::kWritesOnly /* mode */));
   backupable_options_->restore_rate_limiter = restore_rate_limiter;
   bool is_single_threaded = std::get<1>(GetParam()) == 0 ? true : false;
   backupable_options_->max_background_operations = is_single_threaded ? 1 : 10;
@@ -2679,21 +2693,26 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingChargeReadInRestore) {
 
   OpenBackupEngine();
   ASSERT_OK(backup_engine_->RestoreDBFromLatestBackup(dbname_, dbname_));
-  std::int64_t total_bytes_through_with_no_read_charge = restore_rate_limiter->GetTotalBytesThrough();
+  std::int64_t total_bytes_through_with_no_read_charge =
+      restore_rate_limiter->GetTotalBytesThrough();
   CloseBackupEngine();
   AssertBackupConsistency(0, 0, 10, 20);
   DestroyDB(dbname_, Options());
 
-  restore_rate_limiter.reset(NewGenericRateLimiter(restore_rate_limiter_limit, 100 * 1000 /* refill_period_us */, 10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
+  restore_rate_limiter.reset(NewGenericRateLimiter(
+      restore_rate_limiter_limit, 100 * 1000 /* refill_period_us */,
+      10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */));
   backupable_options_->restore_rate_limiter = restore_rate_limiter;
   OpenBackupEngine();
   ASSERT_OK(backup_engine_->RestoreDBFromLatestBackup(dbname_, dbname_));
-  std::int64_t total_bytes_through_with_read_charge = restore_rate_limiter->GetTotalBytesThrough();
+  std::int64_t total_bytes_through_with_read_charge =
+      restore_rate_limiter->GetTotalBytesThrough();
   CloseBackupEngine();
   AssertBackupConsistency(0, 0, 10, 20);
   DestroyDB(dbname_, Options());
 
-  EXPECT_EQ(total_bytes_through_with_read_charge, total_bytes_through_with_no_read_charge * 2);
+  EXPECT_EQ(total_bytes_through_with_read_charge,
+            total_bytes_through_with_no_read_charge * 2);
 }
 
 TEST_F(BackupEngineTest, ReadOnlyBackupEngine) {

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2617,7 +2617,6 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimiting) {
 
   AssertBackupConsistency(0, 0, 100000, 100010);
 }
-#endif  // !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)
 
 INSTANTIATE_TEST_CASE_P(
     RateLimitingChargeReadInBackup, BackupEngineRateLimitingTestWithParam,
@@ -2714,6 +2713,7 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingChargeReadInRestore) {
   EXPECT_EQ(total_bytes_through_with_read_charge,
             total_bytes_through_with_no_read_charge * 2);
 }
+#endif  // !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)
 
 TEST_F(BackupEngineTest, ReadOnlyBackupEngine) {
   DestroyDB(dbname_, options_);


### PR DESCRIPTION
Context:
While all the non-trivial write operations in BackupEngine go through the RateLimiter, reads currently do not. In general, this is not a huge issue because (especially since some I/O efficiency fixes) reads in BackupEngine are mostly limited by corresponding writes, for both backup and restore. But in principle we should charge the RateLimiter for reads as well.

Summary
- Charged read operations in `BackupEngineImpl::CopyOrCreateFile`, `BackupEngineImpl::ReadFileAndComputeChecksum`, `BackupEngineImpl::BackupMeta::LoadFromFile` and `BackupEngineImpl::GetFileDbIdentities`

Test:
- Passed existing tests
- Passed added unit tests