### PR TITLE
Replace `std::shared_ptr<SystemClock>` by `SystemClock*` in `TraceExecutionHandler`

### DIFF
--- a/trace_replay/trace_record_handler.cc
+++ b/trace_replay/trace_record_handler.cc
@@ -17,8 +17,7 @@ TraceExecutionHandler::TraceExecutionHandler(
     : TraceRecord::Handler(),
       db_(db),
       write_opts_(WriteOptions()),
-      read_opts_(ReadOptions()),
-      clock_(SystemClock::Default()) {
+      read_opts_(ReadOptions()) {
   assert(db != nullptr);
   assert(!handles.empty());
   cf_map_.reserve(handles.size());
@@ -26,6 +25,7 @@ TraceExecutionHandler::TraceExecutionHandler(
     assert(handle != nullptr);
     cf_map_.insert({handle->GetID(), handle});
   }
+  clock_ = db_->GetEnv()->GetSystemClock().get();
 }
 
 TraceExecutionHandler::~TraceExecutionHandler() { cf_map_.clear(); }

--- a/trace_replay/trace_record_handler.h
+++ b/trace_replay/trace_record_handler.h
@@ -38,7 +38,7 @@ class TraceExecutionHandler : public TraceRecord::Handler {
   std::unordered_map<uint32_t, ColumnFamilyHandle*> cf_map_;
   WriteOptions write_opts_;
   ReadOptions read_opts_;
-  std::shared_ptr<SystemClock> clock_;
+  SystemClock* clock_;
 };
 
 // To do: Handler for trace_analyzer.


### PR DESCRIPTION
All/most trace related APIs directly use `SystemClock*` (https://github.com/facebook/rocksdb/pull/8033). Do the same in `TraceExecutionHandler`.

Test:
None