### PR TITLE
Improve benchmark.sh

### DIFF
--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -254,7 +254,7 @@ function summarize_result {
   else
       wamp=$( echo "scale=1; $sum_wgb / $l0_wgb" | bc )
   fi
-  if [[ "$sum_wgp" == "" ]]; then
+  if [[ "$sum_wgb" == "" ]]; then
       wmb_ps=""
   else
       wmb_ps=$( echo "scale=1; ( $sum_wgb * 1024.0 ) / $uptime" | bc )

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -292,7 +292,12 @@ function run_bulkload {
        --disable_wal=1 \
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
   summarize_result $log_file_name bulkload fillrandom
 
@@ -305,7 +310,12 @@ function run_bulkload {
        $params_w \
        --threads=1 \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
 }
 
@@ -348,7 +358,12 @@ function run_manual_compaction_worker {
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
 
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
 
   summarize_result $log_file_namefillrandom_output_file man_compact_fillrandom_$3 fillrandom
@@ -374,7 +389,12 @@ function run_manual_compaction_worker {
        ;}
        2>&1 | tee -a $log_file_name"
 
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
 
   # Can't use summarize_result here. One way to analyze the results is to run
@@ -414,10 +434,10 @@ function run_fillseq {
   # Make sure that we'll have unique names for all the files so that data won't
   # be overwritten.
   if [ $1 == 1 ]; then
-    log_file_name=$output_dir/benchmark_fillseq.wal_disabled.v${value_size}.log
+    log_file_name="${output_dir}/benchmark_fillseq.wal_disabled.v${value_size}.log"
     test_name=fillseq.wal_disabled.v${value_size}
   else
-    log_file_name=$output_dir/benchmark_fillseq.wal_enabled.v${value_size}.log
+    log_file_name="${output_dir}/benchmark_fillseq.wal_enabled.v${value_size}.log"
     test_name=fillseq.wal_enabled.v${value_size}
   fi
 
@@ -433,7 +453,13 @@ function run_fillseq {
        --disable_wal=$1 \
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
 
   # The constant "fillseq" which we pass to db_bench is the benchmark name.
@@ -452,7 +478,12 @@ function run_change {
        --merge_operator=\"put\" \
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
   summarize_result $log_file_name ${operation}.t${num_threads}.s${syncval} $operation
 }
@@ -467,7 +498,12 @@ function run_filluniquerandom {
        --threads=1 \
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
   summarize_result $log_file_name filluniquerandom filluniquerandom
 }
@@ -481,7 +517,12 @@ function run_readrandom {
        --threads=$num_threads \
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
   summarize_result $log_file_name readrandom.t${num_threads} readrandom
 }
@@ -496,7 +537,12 @@ function run_multireadrandom {
        $params_w \
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
   summarize_result $log_file_name multireadrandom.t${num_threads} multireadrandom
 }
@@ -513,7 +559,12 @@ function run_readwhile {
        --merge_operator=\"put\" \
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
   summarize_result $log_file_name readwhile${operation}.t${num_threads} readwhile${operation}
 }
@@ -552,7 +603,12 @@ function run_range {
        --reverse_iterator=$reverse_arg \
        --seed=$( date +%s ) \
        2>&1 | tee -a $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
   summarize_result $log_file_name ${full_name}.t${num_threads} seekrandom
 }
@@ -566,7 +622,12 @@ function run_randomtransaction {
        --threads=5 \
        --transaction_sets=5 \
        2>&1 | tee $log_file_name"
-  echo $cmd | tee $log_file_name
+  if [[ "$job_id" != "" ]]; then
+    echo "Job ID: ${job_id}" > $log_file_name
+    echo $cmd | tee -a $log_file_name
+  else
+    echo $cmd | tee $log_file_name
+  fi
   eval $cmd
 }
 

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -92,7 +92,7 @@ if [ ! -d $output_dir ]; then
   mkdir -p $output_dir
 fi
 
-report="$output_dir/report.txt"
+report="$output_dir/report.tsv"
 schedule="$output_dir/schedule.txt"
 
 # all multithreaded tests run with sync=1 unless
@@ -235,6 +235,13 @@ function summarize_result {
   p99=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.0f", $7 }' )
   p999=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.0f", $9 }' )
   p9999=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.0f", $11 }' )
+
+  # if the report TSV (Tab Separate Values) file does not yet exist, create it and write the header row to it
+  if [ ! -f "$report" ]; then
+    echo -e "ops_sec\tmb_sec\ttotal_size_gb\tlevel0_size_gb\tsum_gb\twrite_amplification\twrite_mbps\tusec_op\tpercentile_50\tpercentile_75\tpercentile_99\tpercentile_99.9\tpercentile_99.99\tuptime\tstall_time\tstall_percent\ttest_name" \
+      >> $report
+  fi
+
   echo -e "$ops_sec\t$mb_sec\t$sum_size\t$l0_wgb\t$sum_wgb\t$wamp\t$wmb_ps\t$usecs_op\t$p50\t$p75\t$p99\t$p999\t$p9999\t$uptime\t$stall_time\t$stall_pct\t$test_name" \
     >> $report
 }

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -212,6 +212,7 @@ function summarize_result {
   # that "Compaction Stats" is written to stdout at least once. If it won't
   # happen then empty output from grep when searching for "Sum" will cause
   # syntax errors.
+  version=$( grep ^RocksDB: $test_out | awk '{ print $3 }' )
   uptime=$( grep ^Uptime\(secs $test_out | tail -1 | awk '{ printf "%.0f", $2 }' )
   stall_time=$( grep "^Cumulative stall" $test_out | tail -1  | awk '{  print $3 }' )
   stall_pct=$( grep "^Cumulative stall" $test_out| tail -1  | awk '{  print $5 }' )
@@ -242,11 +243,11 @@ function summarize_result {
 
   # if the report TSV (Tab Separate Values) file does not yet exist, create it and write the header row to it
   if [ ! -f "$report" ]; then
-    echo -e "ops_sec\tmb_sec\ttotal_size_gb\tlevel0_size_gb\tsum_gb\twrite_amplification\twrite_mbps\tusec_op\tpercentile_50\tpercentile_75\tpercentile_99\tpercentile_99.9\tpercentile_99.99\tuptime\tstall_time\tstall_percent\ttest_name" \
+    echo -e "ops_sec\tmb_sec\ttotal_size_gb\tlevel0_size_gb\tsum_gb\twrite_amplification\twrite_mbps\tusec_op\tpercentile_50\tpercentile_75\tpercentile_99\tpercentile_99.9\tpercentile_99.99\tuptime\tstall_time\tstall_percent\ttest_name\trocksdb_version" \
       >> $report
   fi
 
-  echo -e "$ops_sec\t$mb_sec\t$sum_size\t$l0_wgb\t$sum_wgb\t$wamp\t$wmb_ps\t$usecs_op\t$p50\t$p75\t$p99\t$p999\t$p9999\t$uptime\t$stall_time\t$stall_pct\t$test_name" \
+  echo -e "$ops_sec\t$mb_sec\t$sum_size\t$l0_wgb\t$sum_wgb\t$wamp\t$wmb_ps\t$usecs_op\t$p50\t$p75\t$p99\t$p999\t$p9999\t$uptime\t$stall_time\t$stall_pct\t$test_name\t$version" \
     >> $report
 }
 
@@ -612,7 +613,7 @@ for job in ${jobs[@]}; do
     echo "Complete $job in $((end-start)) seconds" | tee -a $schedule
   fi
 
-  echo -e "ops/sec\tmb/sec\tSize-GB\tL0_GB\tSum_GB\tW-Amp\tW-MB/s\tusec/op\tp50\tp75\tp99\tp99.9\tp99.99\tUptime\tStall-time\tStall%\tTest"
+  echo -e "ops/sec\tmb/sec\tSize-GB\tL0_GB\tSum_GB\tW-Amp\tW-MB/s\tusec/op\tp50\tp75\tp99\tp99.9\tp99.99\tUptime\tStall-time\tStall%\tTest\tVersion"
   tail -1 $report
 
 done

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -87,7 +87,7 @@ if [ -z $WAL_DIR ]; then
   exit $EXIT_INVALID_ARGS
 fi
 
-output_dir=${OUTPUT_DIR:-/tmp/}
+output_dir=${OUTPUT_DIR:-/tmp}
 if [ ! -d $output_dir ]; then
   mkdir -p $output_dir
 fi

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -217,16 +217,16 @@ function summarize_result {
   stall_pct=$( grep "^Cumulative stall" $test_out| tail -1  | awk '{  print $5 }' )
   ops_sec=$( grep ^${bench_name} $test_out | awk '{ print $5 }' )
   mb_sec=$( grep ^${bench_name} $test_out | awk '{ print $7 }' )
-  lo_wgb=$( grep "^  L0" $test_out | tail -1 | awk '{ print $9 }' )
+  l0_wgb=$( grep "^  L0" $test_out | tail -1 | awk '{ print $9 }' )
   sum_wgb=$( grep "^ Sum" $test_out | tail -1 | awk '{ print $9 }' )
   sum_size=$( grep "^ Sum" $test_out | tail -1 | awk '{ printf "%.1f", $3 / 1024.0 }' )
-  if [ "$lo_wgb" = "" ]; then
-      lo_wgb="0.0"
+  if [ "$l0_wgb" = "" ]; then
+      l0_wgb="0.0"
   fi
-  if [ "$lo_wgb" = "0.0" ]; then
+  if [ "$l0_wgb" = "0.0" ]; then
       wamp="0.0"
   else
-      wamp=$( echo "scale=1; $sum_wgb / $lo_wgb" | bc )
+      wamp=$( echo "scale=1; $sum_wgb / $l0_wgb" | bc )
   fi
   wmb_ps=$( echo "scale=1; ( $sum_wgb * 1024.0 ) / $uptime" | bc )
   usecs_op=$( grep ^${bench_name} $test_out | awk '{ printf "%.1f", $3 }' )
@@ -235,7 +235,7 @@ function summarize_result {
   p99=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.0f", $7 }' )
   p999=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.0f", $9 }' )
   p9999=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.0f", $11 }' )
-  echo -e "$ops_sec\t$mb_sec\t$sum_size\t$lo_wgb\t$sum_wgb\t$wamp\t$wmb_ps\t$usecs_op\t$p50\t$p75\t$p99\t$p999\t$p9999\t$uptime\t$stall_time\t$stall_pct\t$test_name" \
+  echo -e "$ops_sec\t$mb_sec\t$sum_size\t$l0_wgb\t$sum_wgb\t$wamp\t$wmb_ps\t$usecs_op\t$p50\t$p75\t$p99\t$p999\t$p9999\t$uptime\t$stall_time\t$stall_pct\t$test_name" \
     >> $report
 }
 

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -92,6 +92,9 @@ if [ ! -d $output_dir ]; then
   mkdir -p $output_dir
 fi
 
+report="$output_dir/report.txt"
+schedule="$output_dir/schedule.txt"
+
 # all multithreaded tests run with sync=1 unless
 # $DB_BENCH_NO_SYNC is defined
 syncval="1"
@@ -233,7 +236,7 @@ function summarize_result {
   p999=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.0f", $9 }' )
   p9999=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.0f", $11 }' )
   echo -e "$ops_sec\t$mb_sec\t$sum_size\t$lo_wgb\t$sum_wgb\t$wamp\t$wmb_ps\t$usecs_op\t$p50\t$p75\t$p99\t$p999\t$p9999\t$uptime\t$stall_time\t$stall_pct\t$test_name" \
-    >> $output_dir/report.txt
+    >> $report
 }
 
 function run_bulkload {
@@ -528,8 +531,6 @@ function now() {
   echo `date +"%s"`
 }
 
-report="$output_dir/report.txt"
-schedule="$output_dir/schedule.txt"
 
 echo "===== Benchmark ====="
 
@@ -601,6 +602,6 @@ for job in ${jobs[@]}; do
   fi
 
   echo -e "ops/sec\tmb/sec\tSize-GB\tL0_GB\tSum_GB\tW-Amp\tW-MB/s\tusec/op\tp50\tp75\tp99\tp99.9\tp99.99\tUptime\tStall-time\tStall%\tTest"
-  tail -1 $output_dir/report.txt
+  tail -1 $report
 
 done

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -220,15 +220,19 @@ function summarize_result {
   l0_wgb=$( grep "^  L0" $test_out | tail -1 | awk '{ print $9 }' )
   sum_wgb=$( grep "^ Sum" $test_out | tail -1 | awk '{ print $9 }' )
   sum_size=$( grep "^ Sum" $test_out | tail -1 | awk '{ printf "%.1f", $3 / 1024.0 }' )
-  if [ "$l0_wgb" = "" ]; then
+  if [[ "$l0_wgb" == "" ]]; then
       l0_wgb="0.0"
   fi
-  if [ "$l0_wgb" = "0.0" ]; then
+  if [[ "$l0_wgb" == "0.0" ]]; then
       wamp="0.0"
   else
       wamp=$( echo "scale=1; $sum_wgb / $l0_wgb" | bc )
   fi
-  wmb_ps=$( echo "scale=1; ( $sum_wgb * 1024.0 ) / $uptime" | bc )
+  if [[ "$sum_wgp" == "" ]]; then
+      wmb_ps=""
+  else
+      wmb_ps=$( echo "scale=1; ( $sum_wgb * 1024.0 ) / $uptime" | bc )
+  fi
   usecs_op=$( grep ^${bench_name} $test_out | awk '{ printf "%.1f", $3 }' )
   p50=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.1f", $3 }' )
   p75=$( grep "^Percentiles:" $test_out | tail -1 | awk '{ printf "%.1f", $5 }' )


### PR DESCRIPTION
* Started on some proper usage text to document the options
* Added a `JOB_ID` parameter, so that we can trace jobs and relate them to other assets
* Now generates a correct TSV file of the summary
* Summary has new additional fields:
    * RocksDB Version
    * Date
    * Job ID
* db_bench log files now also include the Job ID