### PR TITLE
Try to schedule TTL compaction slightly ahead of time

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,9 @@
 ### New Features
 * RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.
 
+### Behavior Change
+* RocksDB will try to schedule compactions based on options.ttl slightly ahead of the deadline, so that when the time the threshold hits, compaction usually already finished.
+
 ## 6.24.0 (2021-08-20)
 ### Bug Fixes
 * If the primary's CURRENT file is missing or inaccessible, the secondary instance should not hang repeatedly trying to switch to a new MANIFEST. It should instead return the error code encountered while accessing the file.

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -715,11 +715,13 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through SetOptions() API
   bool report_bg_io_stats = false;
 
-  // Files containing updates older than TTL will go through the compaction
+  // Files containing updates older than TTL go through the compaction
   // process. This usually happens in a cascading way so that those entries
   // will be compacted to bottommost level/file.
   // The feature is used to remove stale entries that have been deleted or
   // updated from the file system.
+  // RocksDB will try to schedule the compactions ahead of the TTL deadline,
+  // so that by the time TTL hits, stale entries are already removed.
   // Pre-req: This needs max_open_files to be set to -1.
   // In Level: Non-bottom-level files older than TTL will go through the
   //           compaction process.


### PR DESCRIPTION
Summary: options.ttl right now describes a time where related compaction should start to be scheduled. This interface is harder to use than the inteface where TTL is the deadline the compaction has to finish. Furthermore, it limits the capability we move the compactions even further ahead of time to smooth compaction traffic. We change the compactions to be scheduled not after TTL, but slightly before TTL.

Test Plan: Run all existing tests.