### PR TITLE
Try to start TTL earlier with kMinOverlappingRatio is used

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@
 * Prevent a `CompactRange()` with `CompactRangeOptions::change_level == true` from possibly causing corruption to the LSM state (overlapping files within a level) when run in parallel with another manual compaction. Note that setting `force_consistency_checks == true` (the default) would cause the DB to enter read-only mode in this scenario and return `Status::Corruption`, rather than committing any corruption.
 * Fixed a bug in CompactionIterator when write-prepared transaction is used. A released earliest write conflict snapshot may cause assertion failure in dbg mode and unexpected key in opt mode.
 
+### Public Interface Change
+* When options.ttl is used with leveled compaction with compactinon priority kMinOverlappingRatio, files exceeding half of TTL value will be prioritized more, so that by the time TTL is reached, fewer extra compactions will be scheduled to clear them up. At the same time, when compacting files with data older than half of TTL, output files may be cut off based on those files' boundaries, in order for the early TTL compaction to work properly.
+
 ## 6.26.0 (2021-10-20)
 ### Bug Fixes
 * Fixes a bug in directed IO mode when calling MultiGet() for blobs in the same blob file. The bug is caused by not sorting the blob read requests by file offsets.

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -613,16 +613,16 @@ bool Compaction::DoesInputReferenceBlobFiles() const {
 }
 
 uint64_t Compaction::MinInputFileOldestAncesterTime(
-    const InternalKey& start, const InternalKey& end) const {
+    const InternalKey* start, const InternalKey* end) const {
   uint64_t min_oldest_ancester_time = port::kMaxUint64;
   const InternalKeyComparator& icmp =
       column_family_data()->internal_comparator();
   for (const auto& level_files : inputs_) {
     for (const auto& file : level_files.files) {
-      if (icmp.Compare(file->largest, start) < 0) {
+      if (start != nullptr && icmp.Compare(file->largest, *start) < 0) {
         continue;
       }
-      if (icmp.Compare(file->smallest, end) > 0) {
+      if (end != nullptr && icmp.Compare(file->smallest, *end) > 0) {
         continue;
       }
       uint64_t oldest_ancester_time = file->TryGetOldestAncesterTime();

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -612,18 +612,17 @@ bool Compaction::DoesInputReferenceBlobFiles() const {
   return false;
 }
 
-uint64_t Compaction::MinInputFileOldestAncesterTime(const Slice* start,
-                                                    const Slice* end) const {
+uint64_t Compaction::MinInputFileOldestAncesterTime(
+    const InternalKey& start, const InternalKey& end) const {
   uint64_t min_oldest_ancester_time = port::kMaxUint64;
-  const Comparator* ucmp = column_family_data()->user_comparator();
+  const InternalKeyComparator& icmp =
+      column_family_data()->internal_comparator();
   for (const auto& level_files : inputs_) {
     for (const auto& file : level_files.files) {
-      if (start != nullptr &&
-          ucmp->Compare(file->largest.user_key(), *start) < 0) {
+      if (icmp.Compare(file->largest, start) < 0) {
         continue;
       }
-      if (end != nullptr &&
-          ucmp->Compare(file->smallest.user_key(), *end) > 0) {
+      if (icmp.Compare(file->smallest, end) > 0) {
         continue;
       }
       uint64_t oldest_ancester_time = file->TryGetOldestAncesterTime();

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -612,10 +612,20 @@ bool Compaction::DoesInputReferenceBlobFiles() const {
   return false;
 }
 
-uint64_t Compaction::MinInputFileOldestAncesterTime() const {
+uint64_t Compaction::MinInputFileOldestAncesterTime(const Slice* start,
+                                                    const Slice* end) const {
   uint64_t min_oldest_ancester_time = port::kMaxUint64;
+  const Comparator* ucmp = column_family_data()->user_comparator();
   for (const auto& level_files : inputs_) {
     for (const auto& file : level_files.files) {
+      if (start != nullptr &&
+          ucmp->Compare(file->largest.user_key(), *start) < 0) {
+        continue;
+      }
+      if (end != nullptr &&
+          ucmp->Compare(file->smallest.user_key(), *end) > 0) {
+        continue;
+      }
       uint64_t oldest_ancester_time = file->TryGetOldestAncesterTime();
       if (oldest_ancester_time != 0) {
         min_oldest_ancester_time =

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -306,8 +306,8 @@ class Compaction {
 
   // start and end are sub compact range. Null if no boundary.
   // This is used to filter out some input files' ancester's time range.
-  uint64_t MinInputFileOldestAncesterTime(const Slice* start,
-                                          const Slice* end) const;
+  uint64_t MinInputFileOldestAncesterTime(const InternalKey& start,
+                                          const InternalKey& end) const;
 
   // Called by DBImpl::NotifyOnCompactionCompleted to make sure number of
   // compaction begin and compaction completion callbacks match.

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -306,8 +306,8 @@ class Compaction {
 
   // start and end are sub compact range. Null if no boundary.
   // This is used to filter out some input files' ancester's time range.
-  uint64_t MinInputFileOldestAncesterTime(const InternalKey& start,
-                                          const InternalKey& end) const;
+  uint64_t MinInputFileOldestAncesterTime(const InternalKey* start,
+                                          const InternalKey* end) const;
 
   // Called by DBImpl::NotifyOnCompactionCompleted to make sure number of
   // compaction begin and compaction completion callbacks match.

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -304,7 +304,10 @@ class Compaction {
 
   uint32_t max_subcompactions() const { return max_subcompactions_; }
 
-  uint64_t MinInputFileOldestAncesterTime() const;
+  // start and end are sub compact range. Null if no boundary.
+  // This is used to filter out some input files' ancester's time range.
+  uint64_t MinInputFileOldestAncesterTime(const Slice* start,
+                                          const Slice* end) const;
 
   // Called by DBImpl::NotifyOnCompactionCompleted to make sure number of
   // compaction begin and compaction completion callbacks match.

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1850,15 +1850,17 @@ Status CompactionJob::FinishCompactionOutputFile(
     // accurate oldest ancester time.
     // This makes oldest ancester time in manifest more accurate than in
     // table properties. Not sure how to resolve it.
-    uint64_t refined_oldest_ancester_time;
-    Slice new_smallest = meta->smallest.user_key();
-    Slice new_largest = meta->largest.user_key();
-    if (!new_largest.empty() && !new_smallest.empty()) {
-      refined_oldest_ancester_time =
-          sub_compact->compaction->MinInputFileOldestAncesterTime(
-              &(meta->smallest), &(meta->largest));
-      if (refined_oldest_ancester_time != port::kMaxUint64) {
-        meta->oldest_ancester_time = refined_oldest_ancester_time;
+    if (meta->smallest.size() > 0 && meta->largest.size() > 0) {
+      uint64_t refined_oldest_ancester_time;
+      Slice new_smallest = meta->smallest.user_key();
+      Slice new_largest = meta->largest.user_key();
+      if (!new_largest.empty() && !new_smallest.empty()) {
+        refined_oldest_ancester_time =
+            sub_compact->compaction->MinInputFileOldestAncesterTime(
+                &(meta->smallest), &(meta->largest));
+        if (refined_oldest_ancester_time != port::kMaxUint64) {
+          meta->oldest_ancester_time = refined_oldest_ancester_time;
+        }
       }
     }
   }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1855,8 +1855,8 @@ Status CompactionJob::FinishCompactionOutputFile(
     Slice new_largest = meta->largest.user_key();
     if (!new_largest.empty() && !new_smallest.empty()) {
       refined_oldest_ancester_time =
-          sub_compact->compaction->MinInputFileOldestAncesterTime(&new_smallest,
-                                                                  &new_largest);
+          sub_compact->compaction->MinInputFileOldestAncesterTime(
+              meta->smallest, meta->largest);
       if (refined_oldest_ancester_time != port::kMaxUint64) {
         meta->oldest_ancester_time = refined_oldest_ancester_time;
       }
@@ -2131,9 +2131,12 @@ Status CompactionJob::OpenCompactionOutputFile(
                    get_time_status.ToString().c_str());
   }
   uint64_t current_time = static_cast<uint64_t>(temp_current_time);
+  InternalKey tmp_start, tmp_end;
+  tmp_start.SetMinPossibleForUserKey(*(sub_compact->start));
+  tmp_end.SetMinPossibleForUserKey(*(sub_compact->end));
   uint64_t oldest_ancester_time =
-      sub_compact->compaction->MinInputFileOldestAncesterTime(
-          sub_compact->start, sub_compact->end);
+      sub_compact->compaction->MinInputFileOldestAncesterTime(tmp_start,
+                                                              tmp_end);
   if (oldest_ancester_time == port::kMaxUint64) {
     oldest_ancester_time = current_time;
   }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -170,6 +170,13 @@ struct CompactionJob::SubcompactionState {
     }
   }
 
+  // Some identified files with old oldest ancester time and the range should be
+  // isolated out so that the output file(s) in that range can be merged down
+  // for TTL and clear the timestamps for the range.
+  std::vector<FileMetaData*> files_to_cut_for_ttl;
+  int cur_files_to_cut_for_ttl = -1;
+  int next_files_to_cut_for_ttl = 0;
+
   uint64_t current_output_file_size = 0;
 
   // State during the subcompaction
@@ -212,6 +219,8 @@ struct CompactionJob::SubcompactionState {
     return Status::OK();
   }
 
+  void FillFilesToCutForTtl();
+
   // Returns true iff we should stop building the current output
   // before processing "internal_key".
   bool ShouldStopBefore(const Slice& internal_key, uint64_t curr_file_size) {
@@ -244,6 +253,40 @@ struct CompactionJob::SubcompactionState {
       return true;
     }
 
+    if (!files_to_cut_for_ttl.empty()) {
+      if (cur_files_to_cut_for_ttl != -1) {
+        // Previous key is inside the range of a file
+        if (icmp->Compare(internal_key,
+                          files_to_cut_for_ttl[cur_files_to_cut_for_ttl]
+                              ->largest.Encode()) > 0) {
+          next_files_to_cut_for_ttl = cur_files_to_cut_for_ttl + 1;
+          cur_files_to_cut_for_ttl = -1;
+          return true;
+        }
+      } else {
+        // Look for the key position
+        while (next_files_to_cut_for_ttl <
+               static_cast<int>(files_to_cut_for_ttl.size())) {
+          if (icmp->Compare(internal_key,
+                            files_to_cut_for_ttl[next_files_to_cut_for_ttl]
+                                ->smallest.Encode()) >= 0) {
+            if (icmp->Compare(internal_key,
+                              files_to_cut_for_ttl[next_files_to_cut_for_ttl]
+                                  ->largest.Encode()) <= 0) {
+              // With in the current file
+              cur_files_to_cut_for_ttl = next_files_to_cut_for_ttl;
+              return true;
+            }
+            // Beyond the current file
+            next_files_to_cut_for_ttl++;
+          } else {
+            // Still fall into the gap
+            break;
+          }
+        }
+      }
+    }
+
     return false;
   }
 
@@ -255,6 +298,46 @@ struct CompactionJob::SubcompactionState {
     return blob_garbage_meter->ProcessOutFlow(key, value);
   }
 };
+
+void CompactionJob::SubcompactionState::FillFilesToCutForTtl() {
+  if (compaction->immutable_options()->compaction_style !=
+          CompactionStyle::kCompactionStyleLevel ||
+      compaction->immutable_options()->compaction_pri !=
+          CompactionPri::kMinOverlappingRatio ||
+      compaction->mutable_cf_options()->ttl == 0 ||
+      compaction->num_input_levels() < 2 || compaction->bottommost_level()) {
+    return;
+  }
+
+  // We define new file with oldest ancestor time to be younger than 1/4 TTL,
+  // and an old one to be older than 1/2 TTL time.
+  int64_t temp_current_time;
+  auto get_time_status = compaction->immutable_options()->clock->GetCurrentTime(
+      &temp_current_time);
+  if (!get_time_status.ok()) {
+    return;
+  }
+  uint64_t current_time = static_cast<uint64_t>(temp_current_time);
+  if (current_time < compaction->mutable_cf_options()->ttl) {
+    return;
+  }
+  uint64_t old_age_thres =
+      current_time - compaction->mutable_cf_options()->ttl / 2;
+
+  const std::vector<FileMetaData*>& olevel =
+      *(compaction->inputs(compaction->num_input_levels() - 1));
+  for (FileMetaData* file : olevel) {
+    // Worth filtering out by start and end?
+    uint64_t oldest_ancester_time = file->TryGetOldestAncesterTime();
+    // We put old files if they are not too small to prevent a flood
+    // of small files.
+    if (oldest_ancester_time < old_age_thres &&
+        file->fd.GetFileSize() >
+            compaction->mutable_cf_options()->target_file_size_base / 2) {
+      files_to_cut_for_ttl.push_back(file);
+    }
+  }
+}
 
 // Maintains state for the entire compaction
 struct CompactionJob::CompactionState {
@@ -1291,6 +1374,7 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
   auto c_iter = sub_compact->c_iter.get();
   c_iter->SeekToFirst();
   if (c_iter->Valid() && sub_compact->compaction->output_level() != 0) {
+    sub_compact->FillFilesToCutForTtl();
     // ShouldStopBefore() maintains state based on keys processed so far. The
     // compaction loop always calls it on the "next" key, thus won't tell it the
     // first key. So we do that here.
@@ -1739,7 +1823,6 @@ Status CompactionJob::FinishCompactionOutputFile(
       meta->UpdateBoundariesForRange(smallest_candidate, largest_candidate,
                                      tombstone.seq_,
                                      cfd->internal_comparator());
-
       // The smallest key in a file is used for range tombstone truncation, so
       // it cannot have a seqnum of 0 (unless the smallest data key in a file
       // has a seqnum of 0). Otherwise, the truncated tombstone may expose
@@ -1763,6 +1846,21 @@ Status CompactionJob::FinishCompactionOutputFile(
   if (s.ok()) {
     meta->fd.file_size = current_bytes;
     meta->marked_for_compaction = sub_compact->builder->NeedCompact();
+    // With accurate smallest and largest key, we can get a slightly more
+    // accurate oldest ancester time.
+    // This makes oldest ancester time in manifest more accurate than in
+    // table properties. Not sure how to resolve it.
+    uint64_t refined_oldest_ancester_time;
+    Slice new_smallest = meta->smallest.user_key();
+    Slice new_largest = meta->largest.user_key();
+    if (!new_largest.empty() && !new_smallest.empty()) {
+      refined_oldest_ancester_time =
+          sub_compact->compaction->MinInputFileOldestAncesterTime(&new_smallest,
+                                                                  &new_largest);
+      if (refined_oldest_ancester_time != port::kMaxUint64) {
+        meta->oldest_ancester_time = refined_oldest_ancester_time;
+      }
+    }
   }
   sub_compact->current_output()->finished = true;
   sub_compact->total_bytes += current_bytes;
@@ -2034,7 +2132,8 @@ Status CompactionJob::OpenCompactionOutputFile(
   }
   uint64_t current_time = static_cast<uint64_t>(temp_current_time);
   uint64_t oldest_ancester_time =
-      sub_compact->compaction->MinInputFileOldestAncesterTime();
+      sub_compact->compaction->MinInputFileOldestAncesterTime(
+          sub_compact->start, sub_compact->end);
   if (oldest_ancester_time == port::kMaxUint64) {
     oldest_ancester_time = current_time;
   }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1856,7 +1856,7 @@ Status CompactionJob::FinishCompactionOutputFile(
     if (!new_largest.empty() && !new_smallest.empty()) {
       refined_oldest_ancester_time =
           sub_compact->compaction->MinInputFileOldestAncesterTime(
-              meta->smallest, meta->largest);
+              &(meta->smallest), &(meta->largest));
       if (refined_oldest_ancester_time != port::kMaxUint64) {
         meta->oldest_ancester_time = refined_oldest_ancester_time;
       }
@@ -2132,11 +2132,16 @@ Status CompactionJob::OpenCompactionOutputFile(
   }
   uint64_t current_time = static_cast<uint64_t>(temp_current_time);
   InternalKey tmp_start, tmp_end;
-  tmp_start.SetMinPossibleForUserKey(*(sub_compact->start));
-  tmp_end.SetMinPossibleForUserKey(*(sub_compact->end));
+  if (sub_compact->start != nullptr) {
+    tmp_start.SetMinPossibleForUserKey(*(sub_compact->start));
+  }
+  if (sub_compact->end != nullptr) {
+    tmp_end.SetMinPossibleForUserKey(*(sub_compact->end));
+  }
   uint64_t oldest_ancester_time =
-      sub_compact->compaction->MinInputFileOldestAncesterTime(tmp_start,
-                                                              tmp_end);
+      sub_compact->compaction->MinInputFileOldestAncesterTime(
+          (sub_compact->start != nullptr) ? &tmp_start : nullptr,
+          (sub_compact->end != nullptr) ? &tmp_end : nullptr);
   if (oldest_ancester_time == port::kMaxUint64) {
     oldest_ancester_time = current_time;
   }

--- a/db/compaction/file_pri.h
+++ b/db/compaction/file_pri.h
@@ -1,0 +1,92 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+
+#pragma once
+#include <algorithm>
+
+#include "db/version_edit.h"
+
+namespace ROCKSDB_NAMESPACE {
+// We boost files that are closer to TTL limit. This boosting could be
+// through FileMetaData.compensated_file_size but this compensated size
+// is widely used as something similar to file size so dramatically boost
+// the value might cause unintended consequences.
+//
+// This boosting algorithm can go very fancy, but here we use a simple
+// formula which can satisify:
+// (1) Different levels are triggered slightly differently to avoid
+//     too many cascading cases
+// (2) Files in the same level get boosting more when TTL gets closer.
+//
+// Don't do any boosting before TTL has past by half. This is to make
+// sure lower write amp for most of the case. And all levels should be
+// fully boosted when total TTL compaction threshold triggers.
+// Differientiate boosting ranges of each level by 1/2. This will make
+// range for each level exponentially increasing. We could do it by
+// having them to be equal, or go even fancier. We can adjust it after
+// we observe the behavior in production.
+// The threshold starting boosting:
+// +------------------------------------------------------------------ +
+// ^                            ^   ^     ^       ^                 ^
+// Age 0                        ... |     |    second last level    thresold
+//                                  |     |
+//                                  |  third last level
+//                                  |
+//                            forth last level
+//
+// We arbitrarily set with 0 when a file is aged boost_age_start and
+// grow linearly. The ratio is arbitrarily set so that when the next level
+// starts to boost, the previous level's boosting amount is 16.
+class FileTtlBooster {
+ public:
+  FileTtlBooster(uint64_t current_time, uint64_t ttl, int num_non_empty_levels,
+                 int level)
+      : current_time_(current_time) {
+    if (ttl == 0 || level == 0 || level >= num_non_empty_levels - 1) {
+      enabled_ = false;
+      boost_age_start_ = 0;
+      boost_step_ = 1;
+    } else {
+      enabled_ = true;
+      uint64_t all_boost_start_age = ttl / 2;
+      uint64_t all_boost_age_range = (ttl / 32) * 31 - all_boost_start_age;
+      uint64_t boost_age_range =
+          all_boost_age_range >> (num_non_empty_levels - level - 1);
+      boost_age_start_ = all_boost_start_age + boost_age_range;
+      const uint64_t kBoostRatio = 16;
+      // prevent 0 value to avoid divide 0 error.
+      boost_step_ = std::max(boost_age_range / kBoostRatio, uint64_t{1});
+    }
+  }
+
+  uint64_t GetBoostScore(FileMetaData* f) {
+    if (!enabled_) {
+      return 1;
+    }
+    uint64_t oldest_ancester_time = f->TryGetOldestAncesterTime();
+    if (oldest_ancester_time >= current_time_) {
+      return 1;
+    }
+    uint64_t age = current_time_ - oldest_ancester_time;
+    if (age > boost_age_start_) {
+      // Use integer just for convenience.
+      // We could make all file_to_order double if we want.
+      // Technically this can overflow if users override timing and
+      // give a very high current time. Ignore the case for simplicity.
+      // Boosting is addition to current value, so +1. This will effectively
+      // make boosting to kick in after the first boost_step_ is reached.
+      return (age - boost_age_start_) / boost_step_ + 1;
+    }
+    return 1;
+  }
+
+ private:
+  bool enabled_;
+  uint64_t current_time_;
+  uint64_t boost_age_start_;
+  uint64_t boost_step_;
+};
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -149,7 +149,7 @@ class VersionBuilderTest : public testing::Test {
   }
 
   void UpdateVersionStorageInfo() {
-    vstorage_.UpdateFilesByCompactionPri(ioptions_.compaction_pri);
+    vstorage_.UpdateFilesByCompactionPri(ioptions_, mutable_cf_options_);
     vstorage_.UpdateNumNonEmptyLevels();
     vstorage_.GenerateFileIndexer();
     vstorage_.GenerateLevelFilesBrief();

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -197,7 +197,8 @@ class VersionStorageInfo {
   // Sort all files for this version based on their file size and
   // record results in files_by_compaction_pri_. The largest files are listed
   // first.
-  void UpdateFilesByCompactionPri(CompactionPri compaction_pri);
+  void UpdateFilesByCompactionPri(const ImmutableOptions& immutable_options,
+                                  const MutableCFOptions& mutable_cf_options);
 
   void GenerateLevel0NonOverlapping();
   bool level0_non_overlapping() const {

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -177,7 +177,7 @@ class VersionStorageInfoTestBase : public testing::Test {
   void Finalize() {
     vstorage_.UpdateNumNonEmptyLevels();
     vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
-    vstorage_.UpdateFilesByCompactionPri(ioptions_.compaction_pri);
+    vstorage_.UpdateFilesByCompactionPri(ioptions_, mutable_cf_options_);
     vstorage_.GenerateFileIndexer();
     vstorage_.GenerateLevelFilesBrief();
     vstorage_.GenerateLevel0NonOverlapping();

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -808,6 +808,8 @@ DEFINE_uint64(periodic_compaction_seconds,
               "Files older than this will be picked up for compaction and"
               " rewritten to the same level");
 
+DEFINE_uint64(ttl_seconds, ROCKSDB_NAMESPACE::Options().ttl, "Set options.ttl");
+
 static bool ValidateInt32Percent(const char* flagname, int32_t value) {
   if (value <= 0 || value>=100) {
     fprintf(stderr, "Invalid value for --%s: %d, 0< pct <100 \n",
@@ -4285,7 +4287,7 @@ class Benchmark {
     options.disable_auto_compactions = FLAGS_disable_auto_compactions;
     options.optimize_filters_for_hits = FLAGS_optimize_filters_for_hits;
     options.periodic_compaction_seconds = FLAGS_periodic_compaction_seconds;
-
+    options.ttl = FLAGS_ttl_seconds;
     // fill storage options
     options.advise_random_on_open = FLAGS_advise_random_on_open;
     options.access_hint_on_compaction_start = FLAGS_compaction_fadvice_e;


### PR DESCRIPTION
Summary:
Right now, when options.ttl is set, compactions are triggered around the time when TTL is reached. This might cause extra compactions which are often bursty. This commit tries to mitigate it by picking those files earlier in normal compaction picking process. This is only implemented using kMinOverlappingRatio with Leveled compaction as it is the default value and it is more complicated to change other styles.

When a file is aged more than ttl/2, RocksDB starts to boost the compaction priority of files in normal compaction picking process, and hope by the time TTL is reached, very few extra compaction is needed.

In order for this to work, another change is made: during a compaction, if an output level file is older than ttl/2, cut output files based on original boundary (if it is not in the last level). This is to make sure that after an old file is moved to the next level, and new data is merged from the upper level, the new data falling into this range isn't reset with old timestamp. Without this change, in many cases, most files from one level will keep having old timestamp, even if they have newer data and we stuck in it.

Test Plan: Add a unit test to test the boosting logic. Will add a unit test to test it end-to-end.