### PR TITLE
Fix a minor regression script issue

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -1103,7 +1103,7 @@ NO_COMPRESSION_COMMANDS="[
 #
 run_regression()
 {
-  time -v bash -vx ./build_tools/regression_build_test.sh $(mktemp -d  $WORKING_DIR/rocksdb.XXXX) $(mktemp rocksdb_test_stats.XXXX)
+  time bash -vx ./build_tools/regression_build_test.sh $(mktemp -d  $WORKING_DIR/rocksdb.XXXX) $(mktemp rocksdb_test_stats.XXXX)
 
   # ======= report size to ODS ========
 

--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -1344,7 +1344,7 @@ case $1 in
   run_regression)
     set -e
     run_regression
-    unset -e
+    set +e
     ;;
   java_build)
     echo $JAVA_BUILD_TEST_COMMANDS


### PR DESCRIPTION
Summary: The system default `time` doesn't support option -v

Test Plan: CI: https://www.internalfb.com/intern/sandcastle/job/13510799359724405