### PR TITLE
Add comment for new_memory_used parameter in CacheReservationManager::UpdateCacheReservation

### DIFF
--- a/cache/cache_reservation_manager.h
+++ b/cache/cache_reservation_manager.h
@@ -68,8 +68,8 @@ class CacheReservationManager {
   // is set true.
   //
   // @param new_memory_used The number of bytes used by new memory
-  // @return On inserting dummy entries, it returns Status::OK() if all dummy entry
-  // insertions succeed. Otherwise, it returns the first non-ok status;
+  // @return On inserting dummy entries, it returns Status::OK() if all dummy
+  // entry insertions succeed. Otherwise, it returns the first non-ok status;
   // On releasing dummy entries, it always returns Status::OK().
   // On keeping dummy entries the same, it always returns Status::OK().
   Status UpdateCacheReservation(std::size_t new_memory_used);

--- a/cache/cache_reservation_manager.h
+++ b/cache/cache_reservation_manager.h
@@ -67,7 +67,8 @@ class CacheReservationManager {
   // [cache_allocated_size_ * 3/4, cache_allocated_size) when delayed_decrease
   // is set true.
   //
-  // On inserting dummy entries, it returns Status::OK() if all dummy entry
+  // @param new_memory_used The number of bytes used by new memory
+  // @return On inserting dummy entries, it returns Status::OK() if all dummy entry
   // insertions succeed. Otherwise, it returns the first non-ok status;
   // On releasing dummy entries, it always returns Status::OK().
   // On keeping dummy entries the same, it always returns Status::OK().


### PR DESCRIPTION
Context/Summary: this PR is to clarify what the parameter new_memory_used is in CacheReservationManager::UpdateCacheReservation

Test plan:
- Passing existing test
- Make format