### PR TITLE
Support timestamps in SstFileWriter

### DIFF
--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -120,7 +120,8 @@ class SstFileWriter {
 
   // Add a Put (key with timestamp, value) to the currently opened file
   // REQUIRES: key is after any previously added key according to the
-  // comparator. REQUIRES: the timestamp's size is equal to what is expected by
+  // comparator.
+  // REQUIRES: the timestamp's size is equal to what is expected by
   // the comparator.
   Status Put(const Slice& user_key, const Slice& timestamp, const Slice& value);
 
@@ -134,7 +135,8 @@ class SstFileWriter {
 
   // Add a deletion key with timestamp to the currently opened file
   // REQUIRES: key is after any previously added key according to the
-  // comparator. REQUIRES: the timestamp's size is equal to what is expected by
+  // comparator.
+  // REQUIRES: the timestamp's size is equal to what is expected by
   // the comparator.
   Status Delete(const Slice& user_key, const Slice& timestamp);
 

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -112,10 +112,12 @@ class SstFileWriter {
 
   // Add a Put key with value to currently opened file (deprecated)
   // REQUIRES: key is after any previously added key according to comparator.
+  // REQUIRES: comparator is *not* timestamp-aware.
   ROCKSDB_DEPRECATED_FUNC Status Add(const Slice& user_key, const Slice& value);
 
   // Add a Put key with value to currently opened file
   // REQUIRES: key is after any previously added key according to comparator.
+  // REQUIRES: comparator is *not* timestamp-aware.
   Status Put(const Slice& user_key, const Slice& value);
 
   // Add a Put (key with timestamp, value) to the currently opened file
@@ -127,10 +129,12 @@ class SstFileWriter {
 
   // Add a Merge key with value to currently opened file
   // REQUIRES: key is after any previously added key according to comparator.
+  // REQUIRES: comparator is *not* timestamp-aware.
   Status Merge(const Slice& user_key, const Slice& value);
 
   // Add a deletion key to currently opened file
   // REQUIRES: key is after any previously added key according to comparator.
+  // REQUIRES: comparator is *not* timestamp-aware.
   Status Delete(const Slice& user_key);
 
   // Add a deletion key with timestamp to the currently opened file
@@ -141,6 +145,7 @@ class SstFileWriter {
   Status Delete(const Slice& user_key, const Slice& timestamp);
 
   // Add a range deletion tombstone to currently opened file
+  // REQUIRES: comparator is *not* timestamp-aware.
   Status DeleteRange(const Slice& begin_key, const Slice& end_key);
 
   // Finalize writing to sst file and close file.

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -118,6 +118,12 @@ class SstFileWriter {
   // REQUIRES: key is after any previously added key according to comparator.
   Status Put(const Slice& user_key, const Slice& value);
 
+  // Add a Put (key with timestamp, value) to the currently opened file
+  // REQUIRES: key is after any previously added key according to the
+  // comparator. REQUIRES: the timestamp's size is equal to what is expected by
+  // the comparator.
+  Status Put(const Slice& user_key, const Slice& timestamp, const Slice& value);
+
   // Add a Merge key with value to currently opened file
   // REQUIRES: key is after any previously added key according to comparator.
   Status Merge(const Slice& user_key, const Slice& value);
@@ -125,6 +131,12 @@ class SstFileWriter {
   // Add a deletion key to currently opened file
   // REQUIRES: key is after any previously added key according to comparator.
   Status Delete(const Slice& user_key);
+
+  // Add a deletion key with timestamp to the currently opened file
+  // REQUIRES: key is after any previously added key according to the
+  // comparator. REQUIRES: the timestamp's size is equal to what is expected by
+  // the comparator.
+  Status Delete(const Slice& user_key, const Slice& timestamp);
 
   // Add a range deletion tombstone to currently opened file
   Status DeleteRange(const Slice& begin_key, const Slice& end_key);

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -522,7 +522,8 @@ bool DataBlockIter::ParseNextDataKey(const char* limit) {
     if (global_seqno_ != kDisableGlobalSequenceNumber) {
       // If we are reading a file with a global sequence number we should
       // expect that all encoded sequence numbers are zeros and any value
-      // type is kTypeValue, kTypeMerge, kTypeDeletion, or kTypeRangeDeletion.
+      // type is kTypeValue, kTypeMerge, kTypeDeletion,
+      // kTypeDeletionWithTimestamp, or kTypeRangeDeletion.
       uint64_t packed = ExtractInternalKeyFooter(raw_key_.GetKey());
       SequenceNumber seqno;
       ValueType value_type;

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -530,6 +530,7 @@ bool DataBlockIter::ParseNextDataKey(const char* limit) {
       assert(value_type == ValueType::kTypeValue ||
              value_type == ValueType::kTypeMerge ||
              value_type == ValueType::kTypeDeletion ||
+             value_type == ValueType::kTypeDeletionWithTimestamp ||
              value_type == ValueType::kTypeRangeDeletion);
       assert(seqno == 0);
     }

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -248,7 +248,13 @@ class SstFileReaderTimestampTest : public testing::Test {
     ASSERT_OK(reader.Open(sst_name_));
     ASSERT_OK(reader.VerifyChecksum());
 
-    std::unique_ptr<Iterator> iter(reader.NewIterator(ReadOptions()));
+    const std::string max_ts(options_.comparator->timestamp_size(), '\xff');
+    Slice max_ts_slice(max_ts);
+
+    ReadOptions read_options;
+    read_options.timestamp = &max_ts_slice;
+
+    std::unique_ptr<Iterator> iter(reader.NewIterator(read_options));
     iter->SeekToFirst();
 
     for (size_t i = 0; i + 2 < keys_and_timestamps.size(); i += 3) {

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -374,6 +374,15 @@ TEST_F(SstFileReaderTimestampTest, Basic) {
   }
 }
 
+TEST_F(SstFileReaderTimestampTest, TimestampSizeMismatch) {
+  SstFileWriter writer(soptions_, options_);
+
+  ASSERT_OK(writer.Open(sst_name_));
+
+  ASSERT_NOK(writer.Put("key", "not_an_actual_timestamp", "value"));
+  ASSERT_NOK(writer.Delete("another_key", "timestamp_of_unexpected_size"));
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 #ifdef ROCKSDB_UNITTESTS_WITH_CUSTOM_OBJECTS_FROM_STATIC_LIBS

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -80,23 +80,14 @@ struct SstFileWriter::Rep {
       }
     }
 
-    // TODO(tec) : For external SST files we could omit the seqno and type.
-    switch (value_type) {
-      case ValueType::kTypeValue:
-        ikey.Set(user_key, 0 /* Sequence Number */,
-                 ValueType::kTypeValue /* Put */);
-        break;
-      case ValueType::kTypeMerge:
-        ikey.Set(user_key, 0 /* Sequence Number */,
-                 ValueType::kTypeMerge /* Merge */);
-        break;
-      case ValueType::kTypeDeletion:
-        ikey.Set(user_key, 0 /* Sequence Number */,
-                 ValueType::kTypeDeletion /* Delete */);
-        break;
-      default:
-        return Status::InvalidArgument("Value type is not supported");
-    }
+    assert(value_type == kTypeValue || value_type == kTypeMerge ||
+           value_type == kTypeDeletion ||
+           value_type == kTypeDeletionWithTimestamp);
+
+    constexpr SequenceNumber sequence_number = 0;
+
+    ikey.Set(user_key, sequence_number, value_type);
+
     builder->Add(ikey.Encode(), value);
 
     // update file info


### PR DESCRIPTION
Summary:
As a first step of supporting user-defined timestamps with ingestion, the
patch adds timestamp support to `SstFileWriter`; namely, it adds new
versions of the `Put` and `Delete` APIs that take timestamps. (`Merge`
and `DeleteRange` are currently not supported with user-defined timestamps
in general but once those features are implemented, we can handle them
in `SstFileWriter` in a similar fashion.) The new APIs validate the size of
the timestamp provided by the client. Similarly, calls to the pre-existing
timestamp-less APIs are now disallowed when user-defined timestamps are
in use according to the comparator.

Test Plan:
`make check`