### PR TITLE
RFC: Compatible evolution of T** params to unique_ptr<T>*

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -8,6 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include <cstring>
+#include <memory>
 
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
@@ -756,7 +757,7 @@ TEST_F(DBBasicTest, DBOpen_Options) {
   Destroy(options);
 
   // Does not exist, and create_if_missing == false: error
-  DB* db = nullptr;
+  std::unique_ptr<DB> db;
   options.create_if_missing = false;
   Status s = DB::Open(options, dbname_, &db);
   ASSERT_TRUE(strstr(s.ToString().c_str(), "does not exist") != nullptr);
@@ -768,8 +769,7 @@ TEST_F(DBBasicTest, DBOpen_Options) {
   ASSERT_OK(s);
   ASSERT_TRUE(db != nullptr);
 
-  delete db;
-  db = nullptr;
+  // Note: explicit db.reset() not strictly required
 
   // Does exist, and error_if_exists == true: error
   options.create_if_missing = false;
@@ -784,9 +784,6 @@ TEST_F(DBBasicTest, DBOpen_Options) {
   s = DB::Open(options, dbname_, &db);
   ASSERT_OK(s);
   ASSERT_TRUE(db != nullptr);
-
-  delete db;
-  db = nullptr;
 }
 
 TEST_F(DBBasicTest, CompactOnFlush) {

--- a/db/db_impl/compacted_db_impl.cc
+++ b/db/db_impl/compacted_db_impl.cc
@@ -145,8 +145,8 @@ Status CompactedDBImpl::Init(const Options& options) {
   return Status::NotSupported("no file exists");
 }
 
-Status CompactedDBImpl::Open(const Options& options,
-                             const std::string& dbname, DB** dbptr) {
+Status CompactedDBImpl::Open(const Options& options, const std::string& dbname,
+                             UniquePtrOut<DB> dbptr) {
   *dbptr = nullptr;
 
   if (options.max_open_files != -1) {
@@ -163,7 +163,7 @@ Status CompactedDBImpl::Open(const Options& options,
     ROCKS_LOG_INFO(db->immutable_db_options_.info_log,
                    "Opened the db as fully compacted mode");
     LogFlush(db->immutable_db_options_.info_log);
-    *dbptr = db.release();
+    *dbptr = std::move(db);
   }
   return s;
 }

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -21,7 +21,7 @@ class CompactedDBImpl : public DBImpl {
   ~CompactedDBImpl() override;
 
   static Status Open(const Options& options, const std::string& dbname,
-                     DB** dbptr);
+                     UniquePtrOut<DB> dbptr);
 
   // Implementations of the DB interface
   using DB::Get;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -913,8 +913,9 @@ class DBImpl : public DB {
   // This is to be used only by internal rocksdb classes.
   static Status Open(const DBOptions& db_options, const std::string& name,
                      const std::vector<ColumnFamilyDescriptor>& column_families,
-                     std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
-                     const bool seq_per_batch, const bool batch_per_txn);
+                     std::vector<ColumnFamilyHandle*>* handles,
+                     UniquePtrOut<DB> dbptr, const bool seq_per_batch,
+                     const bool batch_per_txn);
 
   static IOStatus CreateAndNewDirectory(
       FileSystem* fs, const std::string& dirname,

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1484,7 +1484,8 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
   return s;
 }
 
-Status DB::Open(const Options& options, const std::string& dbname, DB** dbptr) {
+Status DB::Open(const Options& options, const std::string& dbname,
+                UniquePtrOut<DB> dbptr) {
   DBOptions db_options(options);
   ColumnFamilyOptions cf_options(options);
   std::vector<ColumnFamilyDescriptor> column_families;
@@ -1514,7 +1515,8 @@ Status DB::Open(const Options& options, const std::string& dbname, DB** dbptr) {
 
 Status DB::Open(const DBOptions& db_options, const std::string& dbname,
                 const std::vector<ColumnFamilyDescriptor>& column_families,
-                std::vector<ColumnFamilyHandle*>* handles, DB** dbptr) {
+                std::vector<ColumnFamilyHandle*>* handles,
+                UniquePtrOut<DB> dbptr) {
   const bool kSeqPerBatch = true;
   const bool kBatchPerTxn = true;
   return DBImpl::Open(db_options, dbname, column_families, handles, dbptr,
@@ -1567,8 +1569,9 @@ IOStatus DBImpl::CreateWAL(uint64_t log_file_num, uint64_t recycle_log_number,
 
 Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
                     const std::vector<ColumnFamilyDescriptor>& column_families,
-                    std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
-                    const bool seq_per_batch, const bool batch_per_txn) {
+                    std::vector<ColumnFamilyHandle*>* handles,
+                    UniquePtrOut<DB> dbptr, const bool seq_per_batch,
+                    const bool batch_per_txn) {
   Status s = ValidateOptionsByTable(db_options, column_families);
   if (!s.ok()) {
     return s;
@@ -1759,7 +1762,7 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     persist_options_status = impl->WriteOptionsFile(
         false /*need_mutex_lock*/, false /*need_enter_write_thread*/);
 
-    *dbptr = impl;
+    dbptr->reset(impl);
     impl->opened_successfully_ = true;
     impl->MaybeScheduleFlushOrCompaction();
   } else {

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -137,7 +137,7 @@ class DBImplReadOnly : public DBImpl {
   static Status OpenForReadOnlyWithoutCheck(
       const DBOptions& db_options, const std::string& dbname,
       const std::vector<ColumnFamilyDescriptor>& column_families,
-      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
+      std::vector<ColumnFamilyHandle*>* handles, UniquePtrOut<DB> dbptr,
       bool error_if_wal_file_exists = false);
   friend class DB;
 };

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -588,7 +588,8 @@ Status DBImplSecondary::TryCatchUpWithPrimary() {
 }
 
 Status DB::OpenAsSecondary(const Options& options, const std::string& dbname,
-                           const std::string& secondary_path, DB** dbptr) {
+                           const std::string& secondary_path,
+                           UniquePtrOut<DB> dbptr) {
   *dbptr = nullptr;
 
   DBOptions db_options(options);
@@ -610,7 +611,7 @@ Status DB::OpenAsSecondary(
     const DBOptions& db_options, const std::string& dbname,
     const std::string& secondary_path,
     const std::vector<ColumnFamilyDescriptor>& column_families,
-    std::vector<ColumnFamilyHandle*>* handles, DB** dbptr) {
+    std::vector<ColumnFamilyHandle*>* handles, UniquePtrOut<DB> dbptr) {
   *dbptr = nullptr;
   if (db_options.max_open_files != -1) {
     // TODO (yanqin) maybe support max_open_files != -1 by creating hard links
@@ -661,7 +662,7 @@ Status DB::OpenAsSecondary(
   impl->mutex_.Unlock();
   sv_context.Clean();
   if (s.ok()) {
-    *dbptr = impl;
+    dbptr->reset(impl);
     for (auto h : *handles) {
       impl->NewThreadStatusCfInfo(
           static_cast_with_check<ColumnFamilyHandleImpl>(h)->cfd());
@@ -834,7 +835,7 @@ Status DB::OpenAndCompact(
 Status DB::OpenAsSecondary(const Options& /*options*/,
                            const std::string& /*name*/,
                            const std::string& /*secondary_path*/,
-                           DB** /*dbptr*/) {
+                           UniquePtrOut<DB> /*dbptr*/) {
   return Status::NotSupported("Not supported in ROCKSDB_LITE.");
 }
 
@@ -842,7 +843,7 @@ Status DB::OpenAsSecondary(
     const DBOptions& /*db_options*/, const std::string& /*dbname*/,
     const std::string& /*secondary_path*/,
     const std::vector<ColumnFamilyDescriptor>& /*column_families*/,
-    std::vector<ColumnFamilyHandle*>* /*handles*/, DB** /*dbptr*/) {
+    std::vector<ColumnFamilyHandle*>* /*handles*/, UniquePtrOut<DB> /*dbptr*/) {
   return Status::NotSupported("Not supported in ROCKSDB_LITE.");
 }
 #endif  // !ROCKSDB_LITE

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -10,15 +10,18 @@
 
 #include <stdint.h>
 #include <stdio.h>
+
 #include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "rocksdb/iterator.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/metadata.h"
 #include "rocksdb/options.h"
+#include "rocksdb/pointer.h"
 #include "rocksdb/snapshot.h"
 #include "rocksdb/sst_file_writer.h"
 #include "rocksdb/thread_status.h"
@@ -156,7 +159,7 @@ class DB {
   //
   // Caller must delete *dbptr when it is no longer needed.
   static Status Open(const Options& options, const std::string& name,
-                     DB** dbptr);
+                     UniquePtrOut<DB> dbptr);
 
   // Open the database for read only. All DB interfaces
   // that modify data, like put/delete, will return error.
@@ -172,7 +175,7 @@ class DB {
   // Not supported in ROCKSDB_LITE, in which case the function will
   // return Status::NotSupported.
   static Status OpenForReadOnly(const Options& options, const std::string& name,
-                                DB** dbptr,
+                                UniquePtrOut<DB> dbptr,
                                 bool error_if_wal_file_exists = false);
 
   // Open the database for read only with column families. When opening DB with
@@ -192,7 +195,7 @@ class DB {
   static Status OpenForReadOnly(
       const DBOptions& db_options, const std::string& name,
       const std::vector<ColumnFamilyDescriptor>& column_families,
-      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
+      std::vector<ColumnFamilyHandle*>* handles, UniquePtrOut<DB> dbptr,
       bool error_if_wal_file_exists = false);
 
   // The following OpenAsSecondary functions create a secondary instance that
@@ -218,7 +221,8 @@ class DB {
   // Open DB as secondary instance with only the default column family.
   // Return OK on success, non-OK on failures.
   static Status OpenAsSecondary(const Options& options, const std::string& name,
-                                const std::string& secondary_path, DB** dbptr);
+                                const std::string& secondary_path,
+                                UniquePtrOut<DB> dbptr);
 
   // Open DB as secondary instance with column families. You can open a subset
   // of column families in secondary mode.
@@ -241,7 +245,7 @@ class DB {
       const DBOptions& db_options, const std::string& name,
       const std::string& secondary_path,
       const std::vector<ColumnFamilyDescriptor>& column_families,
-      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr);
+      std::vector<ColumnFamilyHandle*>* handles, UniquePtrOut<DB> dbptr);
 
   // Open DB with column families.
   // db_options specify database specific options
@@ -259,7 +263,8 @@ class DB {
   // DestroyColumnFamilyHandle() with all the handles.
   static Status Open(const DBOptions& db_options, const std::string& name,
                      const std::vector<ColumnFamilyDescriptor>& column_families,
-                     std::vector<ColumnFamilyHandle*>* handles, DB** dbptr);
+                     std::vector<ColumnFamilyHandle*>* handles,
+                     UniquePtrOut<DB> dbptr);
 
   // Open DB and run the compaction.
   // It's a read-only operation, the result won't be installed to the DB, it


### PR DESCRIPTION
Summary: Adds a compatibility layer in public APIs such that allocating
out parameters such as `DB** dbptr` can now accept either `DB**` or
`unique_ptr<DB>*`.

Test Plan: small test case added, CI etc.