### PR TITLE
Skip directory fsync for filesystem btrfs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,9 @@
 * Clarified in API comments that RocksDB is not exception safe for callbacks and custom extensions. An exception propagating into RocksDB can lead to undefined behavior, including data loss, unreported corruption, deadlocks, and more.
 * Marked `WriteBufferManager` as `final` because it is not intended for extension.
 
+### Public API change
+* Add API `FSDirectory::FsyncWithDirOptions()`, which provides extra information like directory fsync reason in `DirFsyncOptions`. File system like btrfs is using that to skip directory fsync for creating a new file, or when renaming a file, fsync the target file instead of the directory.
+
 ## 6.26.0 (2021-10-20)
 ### Bug Fixes
 * Fixes a bug in directed IO mode when calling MultiGet() for blobs in the same blob file. The bug is caused by not sorting the blob read requests by file offsets.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,9 +20,8 @@
 * Made FileSystem extend the Customizable class and added a CreateFromString method.  Implementations need to be registered with the ObjectRegistry and to implement a Name() method in order to be created via this method.
 * Clarified in API comments that RocksDB is not exception safe for callbacks and custom extensions. An exception propagating into RocksDB can lead to undefined behavior, including data loss, unreported corruption, deadlocks, and more.
 * Marked `WriteBufferManager` as `final` because it is not intended for extension.
-
-### Public API change
-* Add API `FSDirectory::FsyncWithDirOptions()`, which provides extra information like directory fsync reason in `DirFsyncOptions`. File system like btrfs is using that to skip directory fsync for creating a new file, or when renaming a file, fsync the target file instead of the directory.
+* Add API `FSDirectory::FsyncWithDirOptions()`, which provides extra information like directory fsync reason in `DirFsyncOptions`. File system like btrfs is using that to skip directory fsync for creating a new file, or when renaming a file, fsync the target file instead of the directory, which improves the `DB::Open()` speed by ~20%.
+* `DB::Open()` is not going be blocked by obsolete file purge if `DBOptions::avoid_unnecessary_blocking_io` is set to true.
 
 ## 6.26.0 (2021-10-20)
 ### Bug Fixes

--- a/Makefile
+++ b/Makefile
@@ -1926,6 +1926,9 @@ clipping_iterator_test: $(OBJ_DIR)/db/compaction/clipping_iterator_test.o $(TEST
 ribbon_bench: $(OBJ_DIR)/microbench/ribbon_bench.o $(LIBRARY)
 	$(AM_LINK)
 
+db_basic_bench: $(OBJ_DIR)/microbench/db_basic_bench.o $(LIBRARY)
+	$(AM_LINK)
+
 cache_reservation_manager_test: $(OBJ_DIR)/cache/cache_reservation_manager_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 #-------------------------------------------------

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -763,12 +763,16 @@ Status CompactionJob::Run() {
     constexpr IODebugContext* dbg = nullptr;
 
     if (output_directory_) {
-      io_s = output_directory_->Fsync(IOOptions(), dbg);
+      io_s = output_directory_->FsyncWithDirOptions(
+          IOOptions(), dbg,
+          DirFsyncOptions(DirFsyncOptions::FsyncReason::kNewFileSynced));
     }
 
     if (io_s.ok() && wrote_new_blob_files && blob_output_directory_ &&
         blob_output_directory_ != output_directory_) {
-      io_s = blob_output_directory_->Fsync(IOOptions(), dbg);
+      io_s = blob_output_directory_->FsyncWithDirOptions(
+          IOOptions(), dbg,
+          DirFsyncOptions(DirFsyncOptions::FsyncReason::kNewFileSynced));
     }
   }
   if (io_status_.ok()) {
@@ -2442,7 +2446,8 @@ Status CompactionServiceCompactionJob::Run() {
     constexpr IODebugContext* dbg = nullptr;
 
     if (output_directory_) {
-      io_s = output_directory_->Fsync(IOOptions(), dbg);
+      io_s = output_directory_->FsyncWithDirOptions(IOOptions(), dbg,
+                                                    DirFsyncOptions());
     }
   }
   if (io_status_.ok()) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -974,6 +974,9 @@ class DBImpl : public DB {
   // is only for the special test of CancelledCompactions
   Status TEST_WaitForCompact(bool waitUnscheduled = false);
 
+  // Wait for any background purge
+  Status TEST_WaitForPurge();
+
   // Get the background error status
   Status TEST_GetBGError();
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -120,7 +120,9 @@ IOStatus DBImpl::SyncClosedLogs(JobContext* job_context) {
       }
     }
     if (io_s.ok()) {
-      io_s = directories_.GetWalDir()->Fsync(IOOptions(), nullptr);
+      io_s = directories_.GetWalDir()->FsyncWithDirOptions(
+          IOOptions(), nullptr,
+          DirFsyncOptions(DirFsyncOptions::FsyncReason::kNewFileSynced));
     }
 
     mutex_.Lock();
@@ -532,7 +534,9 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
     // Sync on all distinct output directories.
     for (auto dir : distinct_output_dirs) {
       if (dir != nullptr) {
-        Status error_status = dir->Fsync(IOOptions(), nullptr);
+        Status error_status = dir->FsyncWithDirOptions(
+            IOOptions(), nullptr,
+            DirFsyncOptions(DirFsyncOptions::FsyncReason::kNewFileSynced));
         if (!error_status.ok()) {
           s = error_status;
           break;

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -184,6 +184,14 @@ Status DBImpl::TEST_WaitForCompact(bool wait_unscheduled) {
   return error_handler_.GetBGError();
 }
 
+Status DBImpl::TEST_WaitForPurge() {
+  InstrumentedMutexLock l(&mutex_);
+  while (bg_purge_scheduled_ && error_handler_.GetBGError().ok()) {
+    bg_cv_.Wait();
+  }
+  return error_handler_.GetBGError();
+}
+
 Status DBImpl::TEST_GetBGError() {
   InstrumentedMutexLock l(&mutex_);
   return error_handler_.GetBGError();

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1694,10 +1694,6 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
       if (impl->two_write_queues_) {
         impl->log_write_mutex_.Unlock();
       }
-
-      impl->DeleteObsoleteFiles();
-
-      TEST_SYNC_POINT("DBImpl::Open:AfterDeleteFiles");
     }
     if (s.ok()) {
       // In WritePrepared there could be gap in sequence numbers. This breaks
@@ -1770,6 +1766,8 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
 
     *dbptr = impl;
     impl->opened_successfully_ = true;
+    impl->DeleteObsoleteFiles();
+    TEST_SYNC_POINT("DBImpl::Open:AfterDeleteFiles");
     impl->MaybeScheduleFlushOrCompaction();
   } else {
     persist_options_status.PermitUncheckedError();

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1696,10 +1696,8 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
       }
 
       impl->DeleteObsoleteFiles();
-      s = impl->directories_.GetDbDir()->FsyncWithDirOptions(
-          IOOptions(), nullptr,
-          DirFsyncOptions(DirFsyncOptions::FsyncReason::kFileDeleted));
-      TEST_SYNC_POINT("DBImpl::Open:AfterDeleteFilesAndSyncDir");
+
+      TEST_SYNC_POINT("DBImpl::Open:AfterDeleteFiles");
     }
     if (s.ok()) {
       // In WritePrepared there could be gap in sequence numbers. This breaks

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1696,7 +1696,9 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
       }
 
       impl->DeleteObsoleteFiles();
-      s = impl->directories_.GetDbDir()->Fsync(IOOptions(), nullptr);
+      s = impl->directories_.GetDbDir()->FsyncWithDirOptions(
+          IOOptions(), nullptr,
+          DirFsyncOptions(DirFsyncOptions::FsyncReason::kFileDeleted));
       TEST_SYNC_POINT("DBImpl::Open:AfterDeleteFilesAndSyncDir");
     }
     if (s.ok()) {

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1142,7 +1142,9 @@ IOStatus DBImpl::WriteToWAL(const WriteThread::WriteGroup& write_group,
       // We only sync WAL directory the first time WAL syncing is
       // requested, so that in case users never turn on WAL sync,
       // we can avoid the disk I/O in the write code path.
-      io_s = directories_.GetWalDir()->Fsync(IOOptions(), nullptr);
+      io_s = directories_.GetWalDir()->FsyncWithDirOptions(
+          IOOptions(), nullptr,
+          DirFsyncOptions(DirFsyncOptions::FsyncReason::kNewFileSynced));
     }
   }
 

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -690,7 +690,7 @@ TEST_F(DBSecondaryTest, SwitchToNewManifestDuringOpen) {
   SyncPoint::GetInstance()->LoadDependency(
       {{"ReactiveVersionSet::MaybeSwitchManifest:AfterGetCurrentManifestPath:0",
         "VersionSet::ProcessManifestWrites:BeforeNewManifest"},
-       {"DBImpl::Open:AfterDeleteFilesAndSyncDir",
+       {"DBImpl::Open:AfterDeleteFiles",
         "ReactiveVersionSet::MaybeSwitchManifest:AfterGetCurrentManifestPath:"
         "1"}});
   SyncPoint::GetInstance()->EnableProcessing();

--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -313,7 +313,7 @@ TEST_F(DeleteFileTest, BackgroundPurgeCFDropTest) {
   options.avoid_unnecessary_blocking_io = true;
   options.create_if_missing = false;
   Reopen(options);
-  dbfull()->TEST_WaitForPurge();
+  ASSERT_OK(dbfull()->TEST_WaitForPurge());
 
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();

--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -310,6 +310,11 @@ TEST_F(DeleteFileTest, BackgroundPurgeCFDropTest) {
     do_test(false);
   }
 
+  options.avoid_unnecessary_blocking_io = true;
+  options.create_if_missing = false;
+  Reopen(options);
+  dbfull()->TEST_WaitForPurge();
+
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->LoadDependency(
@@ -317,9 +322,6 @@ TEST_F(DeleteFileTest, BackgroundPurgeCFDropTest) {
         "DBImpl::BGWorkPurge:start"}});
   SyncPoint::GetInstance()->EnableProcessing();
 
-  options.avoid_unnecessary_blocking_io = true;
-  options.create_if_missing = false;
-  Reopen(options);
   {
     SCOPED_TRACE("avoid_unnecessary_blocking_io = true");
     do_test(true);

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -168,7 +168,9 @@ Status ExternalSstFileIngestionJob::Prepare(
   TEST_SYNC_POINT("ExternalSstFileIngestionJob::BeforeSyncDir");
   if (status.ok()) {
     for (auto path_id : ingestion_path_ids) {
-      status = directories_->GetDataDir(path_id)->Fsync(IOOptions(), nullptr);
+      status = directories_->GetDataDir(path_id)->FsyncWithDirOptions(
+          IOOptions(), nullptr,
+          DirFsyncOptions(DirFsyncOptions::FsyncReason::kNewFileSynced));
       if (!status.ok()) {
         ROCKS_LOG_WARN(db_options_.info_log,
                        "Failed to sync directory %" ROCKSDB_PRIszt

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -937,7 +937,9 @@ Status FlushJob::WriteLevel0Table() {
                    meta_.marked_for_compaction ? " (needs compaction)" : "");
 
     if (s.ok() && output_file_directory_ != nullptr && sync_output_directory_) {
-      s = output_file_directory_->Fsync(IOOptions(), nullptr);
+      s = output_file_directory_->FsyncWithDirOptions(
+          IOOptions(), nullptr,
+          DirFsyncOptions(DirFsyncOptions::FsyncReason::kNewFileSynced));
     }
     TEST_SYNC_POINT_CALLBACK("FlushJob::WriteLevel0Table", &mems_);
     db_mutex_->Lock();

--- a/env/composite_env.cc
+++ b/env/composite_env.cc
@@ -272,7 +272,7 @@ class CompositeDirectoryWrapper : public Directory {
   Status Fsync() override {
     IOOptions io_opts;
     IODebugContext dbg;
-    return target_->Fsync(io_opts, &dbg);
+    return target_->FsyncWithDirOptions(io_opts, &dbg, DirFsyncOptions());
   }
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return target_->GetUniqueId(id, max_size);

--- a/env/file_system.cc
+++ b/env/file_system.cc
@@ -241,4 +241,16 @@ std::string FileSystemWrapper::SerializeOptions(
   }
 }
 #endif  // ROCKSDB_LITE
+
+DirFsyncOptions::DirFsyncOptions() { reason = kDefault; }
+
+DirFsyncOptions::DirFsyncOptions(std::string file_renamed_new_name) {
+  reason = kFileRenamed;
+  renamed_new_name = file_renamed_new_name;
+}
+
+DirFsyncOptions::DirFsyncOptions(FsyncReason fsync_reason) {
+  assert(fsync_reason != kFileRenamed);
+  reason = fsync_reason;
+}
 }  // namespace ROCKSDB_NAMESPACE

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -391,12 +391,17 @@ struct PosixMemoryMappedFileBuffer : public MemoryMappedFileBuffer {
 
 class PosixDirectory : public FSDirectory {
  public:
-  explicit PosixDirectory(int fd) : fd_(fd) {}
+  explicit PosixDirectory(int fd);
   ~PosixDirectory();
   virtual IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
 
+  virtual IOStatus FsyncWithDirOptions(
+      const IOOptions&, IODebugContext*,
+      const DirFsyncOptions& dir_fsync_options) override;
+
  private:
   int fd_;
+  bool is_btrfs_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/delete_scheduler.cc
+++ b/file/delete_scheduler.cc
@@ -357,7 +357,9 @@ Status DeleteScheduler::DeleteTrashFile(const std::string& path_in_trash,
           s = fs_->NewDirectory(dir_to_sync, IOOptions(), &dir_obj, nullptr);
         }
         if (s.ok()) {
-          s = dir_obj->Fsync(IOOptions(), nullptr);
+          s = dir_obj->FsyncWithDirOptions(
+              IOOptions(), nullptr,
+              DirFsyncOptions(DirFsyncOptions::FsyncReason::kFileDeleted));
           TEST_SYNC_POINT_CALLBACK(
               "DeleteScheduler::DeleteTrashFile::AfterSyncDir",
               reinterpret_cast<void*>(const_cast<std::string*>(&dir_to_sync)));

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -106,7 +106,7 @@ struct IOOptions {
 
   IOOptions() : IOOptions(false) {}
 
-  IOOptions(bool force_dir_fsync_)
+  explicit IOOptions(bool force_dir_fsync_)
       : timeout(std::chrono::microseconds::zero()),
         prio(IOPriority::kIOLow),
         type(IOType::kUnknown),

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -100,7 +100,36 @@ struct IOOptions {
   // such as NewRandomAccessFile and NewWritableFile.
   std::unordered_map<std::string, std::string> property_bag;
 
-  IOOptions() : timeout(0), prio(IOPriority::kIOLow), type(IOType::kUnknown) {}
+  // Force directory fsync, some file systems like btrfs may skip directory
+  // fsync, set this to force the fsync
+  bool force_dir_fsync;
+
+  IOOptions() : IOOptions(false) {}
+
+  IOOptions(bool force_dir_fsync_)
+      : timeout(std::chrono::microseconds::zero()),
+        prio(IOPriority::kIOLow),
+        type(IOType::kUnknown),
+        force_dir_fsync(force_dir_fsync_) {}
+};
+
+struct DirFsyncOptions {
+  enum FsyncReason : uint8_t {
+    kNewFileSynced,
+    kFileRenamed,
+    kDirRenamed,
+    kFileDeleted,
+    kDefault,
+  } reason;
+
+  std::string renamed_new_name;  // for kFileRenamed
+  // add other options for other FsyncReason
+
+  DirFsyncOptions();
+
+  explicit DirFsyncOptions(std::string file_renamed_new_name);
+
+  explicit DirFsyncOptions(FsyncReason fsync_reason);
 };
 
 // File scope options that control how a file is opened/created and accessed
@@ -1111,6 +1140,15 @@ class FSDirectory {
   // Fsync directory. Can be called concurrently from multiple threads.
   virtual IOStatus Fsync(const IOOptions& options, IODebugContext* dbg) = 0;
 
+  // FsyncWithDirOptions after renaming a file. Depends on the filesystem, it
+  // may fsync directory or just the renaming file (e.g. btrfs). By default, it
+  // just calls directory fsync.
+  virtual IOStatus FsyncWithDirOptions(
+      const IOOptions& options, IODebugContext* dbg,
+      const DirFsyncOptions& /*dir_fsync_options*/) {
+    return Fsync(options, dbg);
+  }
+
   virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
     return 0;
   }
@@ -1623,6 +1661,13 @@ class FSDirectoryWrapper : public FSDirectory {
   IOStatus Fsync(const IOOptions& options, IODebugContext* dbg) override {
     return target_->Fsync(options, dbg);
   }
+
+  IOStatus FsyncWithDirOptions(
+      const IOOptions& options, IODebugContext* dbg,
+      const DirFsyncOptions& dir_fsync_options) override {
+    return target_->FsyncWithDirOptions(options, dbg, dir_fsync_options);
+  }
+
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return target_->GetUniqueId(id, max_size);
   }

--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -1,0 +1,132 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+// this is a simple micro-benchmark for compare ribbon filter vs. other filter
+// for more comprehensive, please check the dedicate util/filter_bench.
+#include <benchmark/benchmark.h>
+
+#include "rocksdb/options.h"
+#include "rocksdb/db.h"
+#include "util/random.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+static void DBOpen(benchmark::State &state) {
+  // create DB
+  DB* db;
+  Options options;
+  auto env = Env::Default();
+  std::string db_path;
+  auto s = env->GetTestDirectory(&db_path);
+  if (!s.ok()) {
+    state.SkipWithError(s.ToString().c_str());
+    return;
+  }
+  std::string db_name = db_path + "/bench_dbopen";
+
+  DestroyDB(db_name, options);
+
+  options.create_if_missing = true;
+  s = DB::Open(options, db_name, &db);
+  if (!s.ok()) {
+    state.SkipWithError(s.ToString().c_str());
+    return;
+  }
+  db->Close();
+
+  options.create_if_missing = false;
+
+  auto rnd = Random(12345);
+
+  for (auto _ : state) {
+    s = DB::Open(options, db_name, &db);
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+    state.PauseTiming();
+    auto wo = WriteOptions();
+    for (int i = 0; i < 2; i++) {
+      for (int j = 0; j < 100; j++) {
+        s = db->Put(wo, rnd.RandomString(10), rnd.RandomString(100));
+        if (!s.ok()) {
+          state.SkipWithError(s.ToString().c_str());
+        }
+      }
+      s = db->Flush(FlushOptions());
+    }
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+    s = db->Close();
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+    state.ResumeTiming();
+  }
+  DestroyDB(db_name, options);
+}
+
+BENCHMARK(DBOpen)->Iterations(200); // specify iteration number as the db size is impacted by iteration number
+
+static void DBClose(benchmark::State &state) {
+  // create DB
+  DB* db;
+  Options options;
+  auto env = Env::Default();
+  std::string db_path;
+  auto s = env->GetTestDirectory(&db_path);
+  if (!s.ok()) {
+    state.SkipWithError(s.ToString().c_str());
+    return;
+  }
+  std::string db_name = db_path + "/bench_dbclose";
+
+  DestroyDB(db_name, options);
+
+  options.create_if_missing = true;
+  s = DB::Open(options, db_name, &db);
+  if (!s.ok()) {
+    state.SkipWithError(s.ToString().c_str());
+    return;
+  }
+  db->Close();
+
+  options.create_if_missing = false;
+
+  auto rnd = Random(12345);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    s = DB::Open(options, db_name, &db);
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+    auto wo = WriteOptions();
+    for (int i = 0; i < 2; i++) {
+      for (int j = 0; j < 100; j++) {
+        s = db->Put(wo, rnd.RandomString(10), rnd.RandomString(100));
+        if (!s.ok()) {
+          state.SkipWithError(s.ToString().c_str());
+        }
+      }
+      s = db->Flush(FlushOptions());
+    }
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+    state.ResumeTiming();
+    s = db->Close();
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+  }
+  DestroyDB(db_name, options);
+}
+
+BENCHMARK(DBClose)->Iterations(200); // specify iteration number as the db size is impacted by iteration number
+
+}  // namespace ROCKSDB_NAMESPACE
+
+BENCHMARK_MAIN();

--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -7,13 +7,13 @@
 // for more comprehensive, please check the dedicate util/filter_bench.
 #include <benchmark/benchmark.h>
 
-#include "rocksdb/options.h"
 #include "rocksdb/db.h"
+#include "rocksdb/options.h"
 #include "util/random.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-static void DBOpen(benchmark::State &state) {
+static void DBOpen(benchmark::State& state) {
   // create DB
   DB* db;
   Options options;
@@ -68,9 +68,10 @@ static void DBOpen(benchmark::State &state) {
   DestroyDB(db_name, options);
 }
 
-BENCHMARK(DBOpen)->Iterations(200); // specify iteration number as the db size is impacted by iteration number
+BENCHMARK(DBOpen)->Iterations(200);  // specify iteration number as the db size
+                                     // is impacted by iteration number
 
-static void DBClose(benchmark::State &state) {
+static void DBClose(benchmark::State& state) {
   // create DB
   DB* db;
   Options options;
@@ -125,7 +126,8 @@ static void DBClose(benchmark::State &state) {
   DestroyDB(db_name, options);
 }
 
-BENCHMARK(DBClose)->Iterations(200); // specify iteration number as the db size is impacted by iteration number
+BENCHMARK(DBClose)->Iterations(200);  // specify iteration number as the db size
+                                      // is impacted by iteration number
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/microbench/ribbon_bench.cc
+++ b/microbench/ribbon_bench.cc
@@ -7,6 +7,8 @@
 // for more comprehensive, please check the dedicate util/filter_bench.
 #include <benchmark/benchmark.h>
 
+#include "rocksdb/options.h"
+#include "rocksdb/db.h"
 #include "table/block_based/filter_policy_internal.h"
 #include "table/block_based/mock_block_based_table.h"
 
@@ -150,6 +152,57 @@ static void FilterQueryNegative(benchmark::State &state) {
       benchmark::Counter(fp_cnt * 100, benchmark::Counter::kAvgIterations);
 }
 BENCHMARK(FilterQueryNegative)->Apply(CustomArguments);
+
+
+static void DBOpen(benchmark::State &state) {
+  // create DB
+  DB* db;
+  Options options;
+  std::string db_name = "/Users/zjay/ws/tmp/bench";
+  DestroyDB(db_name, options);
+
+  options.create_if_missing = true;
+  Status s = DB::Open(options, db_name, &db);
+  if (!s.ok()) {
+    state.SkipWithError(s.ToString().c_str());
+    return;
+  }
+  db->Close();
+
+  options.create_if_missing = false;
+
+  auto rnd = Random(12345);
+
+  for (auto _ : state) {
+    s = DB::Open(options, db_name, &db);
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+    state.PauseTiming();
+    auto wo = WriteOptions();
+    wo.disableWAL = false;
+    for (int i = 0; i < 2; i++) {
+      for (int j = 0; j < 100; j++) {
+        s = db->Put(wo, rnd.RandomString(10), rnd.RandomString(100));
+        if (!s.ok()) {
+          state.SkipWithError(s.ToString().c_str());
+        }
+      }
+      s = db->Flush(FlushOptions());
+    }
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+    s = db->Close();
+    if (!s.ok()) {
+      state.SkipWithError(s.ToString().c_str());
+    }
+    state.ResumeTiming();
+  }
+  DestroyDB(db_name, options);
+}
+
+BENCHMARK(DBOpen)->Iterations(200);
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/util/timer_test.cc
+++ b/util/timer_test.cc
@@ -6,6 +6,7 @@
 #include "util/timer.h"
 
 #include "db/db_test_util.h"
+#include "rocksdb/file_system.h"
 #include "test_util/mock_time_env.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -419,7 +419,7 @@ class BlobDBImpl : public BlobDB {
   std::string blob_dir_;
 
   // pointer to directory
-  std::unique_ptr<Directory> dir_ent_;
+  std::unique_ptr<FSDirectory> dir_ent_;
 
   // Read Write Mutex, which protects all the data structures
   // HEAVILY TRAFFICKED

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -108,6 +108,29 @@ IOStatus TestFSDirectory::Fsync(const IOOptions& options, IODebugContext* dbg) {
   return s;
 }
 
+IOStatus TestFSDirectory::FsyncWithDirOptions(
+    const IOOptions& options, IODebugContext* dbg,
+    const DirFsyncOptions& dir_fsync_options) {
+  if (!fs_->IsFilesystemActive()) {
+    return fs_->GetError();
+  }
+  {
+    IOStatus in_s = fs_->InjectMetadataWriteError();
+    if (!in_s.ok()) {
+      return in_s;
+    }
+  }
+  fs_->SyncDir(dirname_);
+  IOStatus s = dir_->FsyncWithDirOptions(options, dbg, dir_fsync_options);
+  {
+    IOStatus in_s = fs_->InjectMetadataWriteError();
+    if (!in_s.ok()) {
+      return in_s;
+    }
+  }
+  return s;
+}
+
 TestFSWritableFile::TestFSWritableFile(const std::string& fname,
                                        const FileOptions& file_opts,
                                        std::unique_ptr<FSWritableFile>&& f,

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -177,6 +177,10 @@ class TestFSDirectory : public FSDirectory {
   virtual IOStatus Fsync(const IOOptions& options,
                          IODebugContext* dbg) override;
 
+  virtual IOStatus FsyncWithDirOptions(
+      const IOOptions& options, IODebugContext* dbg,
+      const DirFsyncOptions& dir_fsync_options) override;
+
  private:
   FaultInjectionTestFS* fs_;
   std::string dirname_;


### PR DESCRIPTION
Summary:
Directory fsync might be expensive on btrfs and it may not be needed.
Here are 4 directory fsync cases:
1. creating a new file: dir-fsync is not needed on btrfs, as long as the
   new file itself is synced.
2. renaming a file: dir-fsync is not needed if the renamed file is
   synced. So an API `FsyncAfterFileRename(filename, ...)` is provided
   to sync the file on btrfs. By default, it just calls dir-fsync.
3. deleting files: dir-fsync is forced by set
   `IOOptions.force_dir_fsync = true`
4. renaming multiple files (like backup and checkpoint): dir-fsync is
   forced, the same as above.

Test Plan: run tests on btrfs and non btrfs