### PR TITLE
Refactor expected state in stress/crash test

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -847,6 +847,7 @@ cpp_library(
         "db_stress_tool/db_stress_shared_state.cc",
         "db_stress_tool/db_stress_test_base.cc",
         "db_stress_tool/db_stress_tool.cc",
+        "db_stress_tool/expected_state.cc",
         "db_stress_tool/no_batched_ops_stress.cc",
         "test_util/testutil.cc",
         "tools/block_cache_analyzer/block_cache_trace_analyzer.cc",

--- a/db_stress_tool/CMakeLists.txt
+++ b/db_stress_tool/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(db_stress${ARTIFACT_SUFFIX}
   db_stress_shared_state.cc
   db_stress_gflags.cc
   db_stress_tool.cc
+  expected_state.cc
   no_batched_ops_stress.cc)
 target_link_libraries(db_stress${ARTIFACT_SUFFIX} ${ROCKSDB_LIB} ${THIRDPARTY_LIBS})
 list(APPEND tool_deps db_stress)

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -153,7 +153,7 @@ DECLARE_int32(index_type);
 DECLARE_string(db);
 DECLARE_string(secondaries_base);
 DECLARE_bool(test_secondary);
-DECLARE_string(expected_values_path);
+DECLARE_string(expected_values_dir);
 DECLARE_bool(verify_checksum);
 DECLARE_bool(mmap_read);
 DECLARE_bool(mmap_write);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -448,12 +448,12 @@ DEFINE_string(secondaries_base, "",
 DEFINE_bool(test_secondary, false, "Test secondary instance.");
 
 DEFINE_string(
-    expected_values_path, "",
-    "File where the array of expected uint32_t values will be stored. If "
+    expected_values_dir, "",
+    "Dir where file with array of expected uint32_t values will be stored. If "
     "provided and non-empty, the DB state will be verified against these "
     "values after recovery. --max_key and --column_family must be kept the "
     "same across invocations of this program that use the same "
-    "--expected_values_path.");
+    "--expected_values_dir.");
 
 DEFINE_bool(verify_checksum, false,
             "Verify checksum for every block read from storage");

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -130,8 +130,13 @@ class SharedState {
       }
     }
     if (status.ok()) {
-      expected_state_manager_.reset(new ExpectedStateManager(
-          FLAGS_expected_values_dir, FLAGS_max_key, FLAGS_column_families));
+      if (FLAGS_expected_values_dir.empty()) {
+        expected_state_manager_.reset(new AnonExpectedStateManager(
+            FLAGS_max_key, FLAGS_column_families));
+      } else {
+        expected_state_manager_.reset(new FileExpectedStateManager(
+            FLAGS_max_key, FLAGS_column_families, FLAGS_expected_values_dir));
+      }
       status = expected_state_manager_->Open();
     }
     if (!status.ok()) {

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -297,7 +297,7 @@ class SharedState {
   }
 
   bool ShouldVerifyAtBeginning() const {
-    return expected_mmap_buffer_.get() != nullptr;
+    return !FLAGS_expected_values_dir.empty();
   }
 
   bool PrintingVerificationResults() {
@@ -341,7 +341,6 @@ class SharedState {
   // Has to make it owned by a smart ptr as port::Mutex is not copyable
   // and storing it in the container may require copying depending on the impl.
   std::vector<std::vector<std::unique_ptr<port::Mutex>>> key_locks_;
-  std::unique_ptr<MemoryMappedFileBuffer> expected_mmap_buffer_;
   std::atomic<bool> printing_verification_results_;
 };
 

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -131,8 +131,8 @@ class SharedState {
     }
     if (status.ok()) {
       if (FLAGS_expected_values_dir.empty()) {
-        expected_state_manager_.reset(new AnonExpectedStateManager(
-            FLAGS_max_key, FLAGS_column_families));
+        expected_state_manager_.reset(
+            new AnonExpectedStateManager(FLAGS_max_key, FLAGS_column_families));
       } else {
         expected_state_manager_.reset(new FileExpectedStateManager(
             FLAGS_max_key, FLAGS_column_families, FLAGS_expected_values_dir));

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -5,6 +5,8 @@
 
 #include "db_stress_tool/expected_state.h"
 
+#include "db_stress_tool/db_stress_shared_state.h"
+
 namespace ROCKSDB_NAMESPACE {
 
 const std::string ExpectedStateManager::kLatestFilename = "LATEST.state";
@@ -12,8 +14,71 @@ const std::string ExpectedStateManager::kLatestFilename = "LATEST.state";
 ExpectedState::ExpectedState(size_t max_key, size_t num_column_families)
     : max_key_(max_key),
       num_column_families_(num_column_families),
-      values_(nullptr),
-      REMOVEME_values_need_init_(false) {}
+      values_(nullptr) {}
+
+void ExpectedState::ClearColumnFamily(int cf) {
+  std::fill(&Value(cf, 0 /* key */), &Value(cf + 1, 0 /* key */),
+            SharedState::DELETION_SENTINEL);
+}
+
+void ExpectedState::Put(int cf, int64_t key, uint32_t value_base,
+                        bool pending) {
+  if (!pending) {
+    // prevent expected-value update from reordering before Write
+    std::atomic_thread_fence(std::memory_order_release);
+  }
+  Value(cf, key).store(pending ? SharedState::UNKNOWN_SENTINEL : value_base,
+                       std::memory_order_relaxed);
+  if (pending) {
+    // prevent Write from reordering before expected-value update
+    std::atomic_thread_fence(std::memory_order_release);
+  }
+}
+
+uint32_t ExpectedState::Get(int cf, int64_t key) const {
+  return Value(cf, key);
+}
+
+bool ExpectedState::Delete(int cf, int64_t key, bool pending) {
+  if (Value(cf, key) == SharedState::DELETION_SENTINEL) {
+    return false;
+  }
+  Put(cf, key, SharedState::DELETION_SENTINEL, pending);
+  return true;
+}
+
+bool ExpectedState::SingleDelete(int cf, int64_t key, bool pending) {
+  return Delete(cf, key, pending);
+}
+
+int ExpectedState::DeleteRange(int cf, int64_t begin_key, int64_t end_key,
+                               bool pending) {
+  int covered = 0;
+  for (int64_t key = begin_key; key < end_key; ++key) {
+    if (Delete(cf, key, pending)) {
+      ++covered;
+    }
+  }
+  return covered;
+}
+
+bool ExpectedState::Exists(int cf, int64_t key) {
+  // UNKNOWN_SENTINEL counts as exists. That assures a key for which overwrite
+  // is disallowed can't be accidentally added a second time, in which case
+  // SingleDelete wouldn't be able to properly delete the key. It does allow
+  // the case where a SingleDelete might be added which covers nothing, but
+  // that's not a correctness issue.
+  uint32_t expected_value = Value(cf, key).load();
+  return expected_value != SharedState::DELETION_SENTINEL;
+}
+
+void ExpectedState::Reset() {
+  for (size_t i = 0; i < num_column_families_; ++i) {
+    for (size_t j = 0; j < max_key_; ++j) {
+      Delete(i, j, false /* pending */);
+    }
+  }
+}
 
 FileExpectedState::FileExpectedState(std::string expected_state_file_path,
                                      size_t max_key, size_t num_column_families)
@@ -44,7 +109,6 @@ Status FileExpectedState::Open() {
   if (status.ok() && size == 0) {
     std::string buf(expected_values_size, '\0');
     status = wfile->Append(buf);
-    REMOVEME_values_need_init_ = true;
   }
   if (status.ok()) {
     status = default_env->NewMemoryMappedFileBuffer(
@@ -55,6 +119,9 @@ Status FileExpectedState::Open() {
     values_ = static_cast<std::atomic<uint32_t>*>(
         expected_state_mmap_buffer_->GetBase());
     assert(values_ != nullptr);
+    if (size == 0) {
+      Reset();
+    }
   } else {
     assert(values_ == nullptr);
   }
@@ -69,7 +136,7 @@ Status AnonExpectedState::Open() {
       new std::atomic<uint32_t>[GetValuesLen() /
                                 sizeof(std::atomic<uint32_t>)]);
   values_ = &values_allocation_[0];
-  REMOVEME_values_need_init_ = true;
+  Reset();
   return Status::OK();
 }
 

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -122,7 +122,11 @@ Status FileExpectedState::Open(bool create) {
 AnonExpectedState::AnonExpectedState(size_t max_key, size_t num_column_families)
     : ExpectedState(max_key, num_column_families) {}
 
+#ifndef NDEBUG
 Status AnonExpectedState::Open(bool create) {
+#else
+Status AnonExpectedState::Open(bool /* create */) {
+#endif
   // AnonExpectedState only supports being freshly created.
   assert(create);
   values_allocation_.reset(

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -152,7 +152,7 @@ FileExpectedStateManager::FileExpectedStateManager(
     std::string expected_state_dir_path)
     : ExpectedStateManager(max_key, num_column_families),
       expected_state_dir_path_(std::move(expected_state_dir_path)) {
-  assert(expected_state_dir_path_ != "");
+  assert(!expected_state_dir_path_.empty());
 }
 
 Status FileExpectedStateManager::Open() {

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -1,0 +1,91 @@
+//  Copyright (c) 2021-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db_stress_tool/expected_state.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+const std::string ExpectedStateManager::kLatestFilename = "LATEST.state";
+
+ExpectedState::ExpectedState(std::string expected_state_file_path,
+                             size_t max_key, size_t num_column_families)
+    : expected_state_file_path_(std::move(expected_state_file_path)),
+      max_key_(max_key),
+      num_column_families_(num_column_families),
+      expected_state_mmap_buffer_(nullptr),
+      values_(nullptr),
+      REMOVEME_values_need_init_(false) {}
+
+ExpectedState::~ExpectedState() {}
+
+Status ExpectedState::Open() {
+  size_t expected_values_size =
+      sizeof(std::atomic<uint32_t>) * num_column_families_ * max_key_;
+
+  Env* default_env = Env::Default();
+
+  Status status = default_env->FileExists(expected_state_file_path_);
+  uint64_t size = 0;
+  if (status.ok()) {
+    status = default_env->GetFileSize(expected_state_file_path_, &size);
+  } else if (status.IsNotFound()) {
+    // Leave size at zero. Reset `status` since it is OK for file not to be
+    // there -- we will create it below.
+    status = Status::OK();
+  }
+
+  std::unique_ptr<WritableFile> wfile;
+  if (status.ok() && size == 0) {
+    const EnvOptions soptions;
+    status = default_env->NewWritableFile(expected_state_file_path_, &wfile,
+                                          soptions);
+  }
+  if (status.ok() && size == 0) {
+    std::string buf(expected_values_size, '\0');
+    status = wfile->Append(buf);
+    REMOVEME_values_need_init_ = true;
+  }
+  if (status.ok()) {
+    status = default_env->NewMemoryMappedFileBuffer(
+        expected_state_file_path_, &expected_state_mmap_buffer_);
+  }
+  if (status.ok()) {
+    assert(expected_state_mmap_buffer_->GetLen() == expected_values_size);
+    values_ = static_cast<std::atomic<uint32_t>*>(
+        expected_state_mmap_buffer_->GetBase());
+    assert(values_ != nullptr);
+  } else {
+    assert(values_ == nullptr);
+  }
+  return status;
+}
+
+ExpectedStateManager::ExpectedStateManager(std::string expected_state_dir_path,
+                                           size_t max_key,
+                                           size_t num_column_families)
+    : expected_state_dir_path_(std::move(expected_state_dir_path)),
+      max_key_(max_key),
+      num_column_families_(num_column_families),
+      latest_(nullptr) {}
+
+ExpectedStateManager::~ExpectedStateManager() {}
+
+Status ExpectedStateManager::Open() {
+  if (expected_state_dir_path_ == "") {
+    return Status::InvalidArgument(
+        "ExpectedStateManager does not support empty dir name");
+  }
+  std::string expected_state_dir_path_slash =
+      expected_state_dir_path_.back() == '/' ? expected_state_dir_path_
+                                             : expected_state_dir_path_ + "/";
+  std::string expected_state_file_path =
+      expected_state_dir_path_slash + kLatestFilename;
+
+  latest_.reset(new ExpectedState(std::move(expected_state_file_path), max_key_,
+                                  num_column_families_));
+  return latest_->Open();
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -75,7 +75,7 @@ bool ExpectedState::Exists(int cf, int64_t key) {
 void ExpectedState::Reset() {
   for (size_t i = 0; i < num_column_families_; ++i) {
     for (size_t j = 0; j < max_key_; ++j) {
-      Delete(i, j, false /* pending */);
+      Delete(static_cast<int>(i), j, false /* pending */);
     }
   }
 }

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -3,6 +3,8 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#ifdef GFLAGS
+
 #include "db_stress_tool/expected_state.h"
 
 #include "db_stress_tool/db_stress_shared_state.h"
@@ -167,3 +169,5 @@ Status ExpectedStateManager::Open() {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
+
+#endif  // GFLAGS

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -230,8 +230,8 @@ std::string FileExpectedStateManager::GetPathForFilename(
   return expected_state_dir_path_slash + filename;
 }
 
-AnonExpectedStateManager::AnonExpectedStateManager(
-    size_t max_key, size_t num_column_families)
+AnonExpectedStateManager::AnonExpectedStateManager(size_t max_key,
+                                                   size_t num_column_families)
     : ExpectedStateManager(max_key, num_column_families) {}
 
 Status AnonExpectedStateManager::Open() {

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -27,7 +27,7 @@ class ExpectedState {
 
   // Requires external locking preventing concurrent execution with any other
   // member function.
-  virtual Status Open() = 0;
+  virtual Status Open(bool create) = 0;
 
   // Requires external locking covering all keys in `cf`.
   void ClearColumnFamily(int cf);
@@ -92,7 +92,7 @@ class FileExpectedState : public ExpectedState {
 
   // Requires external locking preventing concurrent execution with any other
   // member function.
-  Status Open() override;
+  Status Open(bool create) override;
 
  private:
   const std::string expected_state_file_path_;
@@ -107,7 +107,7 @@ class AnonExpectedState : public ExpectedState {
 
   // Requires external locking preventing concurrent execution with any other
   // member function.
-  Status Open() override;
+  Status Open(bool create) override;
 
  private:
   std::unique_ptr<std::atomic<uint32_t>[]> values_allocation_;
@@ -187,6 +187,13 @@ class FileExpectedStateManager : public ExpectedStateManager {
   Status Open() override;
 
  private:
+  // Requires external locking preventing concurrent execution with any other
+  // member function.
+  Status Clean();
+
+  std::string GetTempPathForFilename(const std::string& filename);
+  std::string GetPathForFilename(const std::string& filename);
+
   static const std::string kLatestFilename;
 
   const std::string expected_state_dir_path_;

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -1,0 +1,75 @@
+//  Copyright (c) 2021-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <stdint.h>
+
+#include <atomic>
+#include <memory>
+
+#include "rocksdb/env.h"
+#include "rocksdb/rocksdb_namespace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// An `ExpectedState` provides read/write access to expected values for every
+// key.
+class ExpectedState {
+ public:
+  explicit ExpectedState(std::string expected_state_file_path, size_t max_key,
+                         size_t num_column_families);
+
+  ~ExpectedState();
+
+  Status Open();
+
+  std::atomic<uint32_t>* REMOVEME_GetValues() { return values_; }
+  bool REMOVEME_ValuesNeedInit() { return REMOVEME_values_need_init_; }
+
+ private:
+  const std::string expected_state_file_path_;
+  const size_t max_key_;
+  const size_t num_column_families_;
+
+  std::unique_ptr<MemoryMappedFileBuffer> expected_state_mmap_buffer_;
+  std::atomic<uint32_t>* values_;
+  bool REMOVEME_values_need_init_;
+};
+
+// An `ExpectedStateManager` manages a directory containing data about the
+// expected state of the database. It exposes operations for reading and
+// modifying the latest expected state.
+class ExpectedStateManager {
+ public:
+  explicit ExpectedStateManager(std::string expected_state_dir_path,
+                                size_t max_key, size_t num_column_families);
+
+  ~ExpectedStateManager();
+
+  // The following APIs are not thread-safe and require external synchronization
+  // for the entire object.
+  Status Open();
+
+  std::atomic<uint32_t>* REMOVEME_GetValues() {
+    return latest_->REMOVEME_GetValues();
+  }
+  bool REMOVEME_ValuesNeedInit() { return latest_->REMOVEME_ValuesNeedInit(); }
+
+  // The following APIs are not thread-safe and require external synchronization
+  // for the affected keys only. For example, `Put("a", ...)` and
+  // `Put("b", ...)` could be executed in parallel with no external
+  // synchronization.
+
+ private:
+  static const std::string kLatestFilename;
+
+  const std::string expected_state_dir_path_;
+  const size_t max_key_;
+  const size_t num_column_families_;
+  std::unique_ptr<ExpectedState> latest_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -3,6 +3,8 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#ifdef GFLAGS
+
 #pragma once
 
 #include <stdint.h>
@@ -177,3 +179,5 @@ class ExpectedStateManager {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
+
+#endif  // GFLAGS

--- a/src.mk
+++ b/src.mk
@@ -345,6 +345,7 @@ STRESS_LIB_SOURCES =                                            \
   db_stress_tool/db_stress_gflags.cc                           \
   db_stress_tool/db_stress_shared_state.cc                     \
   db_stress_tool/db_stress_tool.cc                             \
+  db_stress_tool/expected_state.cc                             \
   db_stress_tool/no_batched_ops_stress.cc                      \
 
 TEST_LIB_SOURCES =                                              \

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -60,7 +60,7 @@ default_params = {
     "destroy_db_initially": 0,
     "enable_pipelined_write": lambda: random.randint(0, 1),
     "enable_compaction_filter": lambda: random.choice([0, 0, 0, 1]),
-    "expected_values_path": lambda: setup_expected_values_file(),
+    "expected_values_dir": lambda: setup_expected_values_dir(),
     "fail_if_options_file_error": lambda: random.randint(0, 1),
     "flush_one_in": 1000000,
     "file_checksum_impl": lambda: random.choice(["none", "crc32c", "xxh64", "big"]),
@@ -172,23 +172,23 @@ def get_dbname(test_name):
         os.mkdir(dbname)
     return dbname
 
-expected_values_file = None
-def setup_expected_values_file():
-    global expected_values_file
-    if expected_values_file is not None:
-        return expected_values_file
-    expected_file_name = "rocksdb_crashtest_" + "expected"
+expected_values_dir = None
+def setup_expected_values_dir():
+    global expected_values_dir
+    if expected_values_dir is not None:
+        return expected_values_dir
+    expected_dir_prefix = "rocksdb_crashtest_expected_"
     test_tmpdir = os.environ.get(_TEST_DIR_ENV_VAR)
     if test_tmpdir is None or test_tmpdir == "":
-        expected_values_file = tempfile.NamedTemporaryFile(
-            prefix=expected_file_name, delete=False).name
+        expected_values_dir = tempfile.mkdtemp(
+            prefix=expected_dir_prefix)
     else:
-        # if tmpdir is specified, store the expected_values_file in the same dir
-        expected_values_file = test_tmpdir + "/" + expected_file_name
-        if os.path.exists(expected_values_file):
-            os.remove(expected_values_file)
-        open(expected_values_file, 'a').close()
-    return expected_values_file
+        # if tmpdir is specified, store the expected_values_dir under that dir
+        expected_values_dir = test_tmpdir + "/" + expected_dir_name
+        if os.path.exists(expected_values_dir):
+            shutil.rmtree(expected_values_dir)
+        os.mkdir(expected_values_dir)
+    return expected_values_dir
 
 
 def is_direct_io_supported(dbname):
@@ -673,7 +673,7 @@ def whitebox_crash_main(args, unknown_args):
             # success
             shutil.rmtree(dbname, True)
             os.mkdir(dbname)
-            cmd_params.pop('expected_values_path', None)
+            cmd_params.pop('expected_values_dir', None)
             check_mode = (check_mode + 1) % total_check_mode
 
         time.sleep(1)  # time to stabilize after a kill
@@ -718,9 +718,9 @@ def main():
         blackbox_crash_main(args, unknown_args)
     if args.test_type == 'whitebox':
         whitebox_crash_main(args, unknown_args)
-    # Only delete the `expected_values_file` if test passes
-    if os.path.exists(expected_values_file):
-        os.remove(expected_values_file)
+    # Only delete the `expected_values_dir` if test passes
+    if expected_values_dir is not None:
+        shutil.rmtree(expected_values_dir)
 
 
 if __name__ == '__main__':

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -184,7 +184,7 @@ def setup_expected_values_dir():
             prefix=expected_dir_prefix)
     else:
         # if tmpdir is specified, store the expected_values_dir under that dir
-        expected_values_dir = test_tmpdir + "/" + expected_dir_name
+        expected_values_dir = test_tmpdir + "/rocksdb_crashtest_expected"
         if os.path.exists(expected_values_dir):
             shutil.rmtree(expected_values_dir)
         os.mkdir(expected_values_dir)


### PR DESCRIPTION
This is a precursor refactoring to enable an upcoming feature: persistence failure correctness testing.

- Changed `--expected_values_path` to `--expected_values_dir` and migrated "db_crashtest.py" to use the new flag. For persistence failure correctness testing there are multiple possible correct states since unsynced data is allowed to be dropped. Making it possible to restore all these possible correct states will eventually involve files containing snapshots of expected values and DB trace files.
- The expected values directory is managed by an `ExpectedStateManager` instance. Managing expected state files is separated out of `SharedState` to prevent `SharedState` from becoming too complex when the new files and features (snapshotting, tracing, and restoring) are introduced.
- Migrated expected values file access/management out of `SharedState` into a separate class called `ExpectedState`. This is not exposed directly to the test but rather the `ExpectedState` for the latest values file is accessed via a pass-through API on `ExpectedStateManager`. This forces the test to always access the single latest `ExpectedState`.
- Changed the initialization of the latest expected values file to use a tempfile followed by rename, and also add cleanup logic for possible stranded tempfiles.

Test Plan: run in several ways; try to make sure it's not obviously broken.

- crashtest blackbox without TEST_TMPDIR
```
$ python3 tools/db_crashtest.py blackbox --simple --write_buffer_size=1048576 --target_file_size_base=1048576 --max_bytes_for_level_base=4194304 --max_key=100000 --value_size_mult=33 --compression_type=none --duration=120 --interval=10 --compression_type=none --blob_compression_type=none
```
- crashtest blackbox with TEST_TMPDIR
```
$ TEST_TMPDIR=/dev/shm python3 tools/db_crashtest.py blackbox --simple --write_buffer_size=1048576 --target_file_size_base=1048576 --max_bytes_for_level_base=4194304 --max_key=100000 --value_size_mult=33 --compression_type=none --duration=120 --interval=10 --compression_type=none --blob_compression_type=none
```
- crashtest whitebox with TEST_TMPDIR
```
$ TEST_TMPDIR=/dev/shm python3 tools/db_crashtest.py whitebox --simple --write_buffer_size=1048576 --target_file_size_base=1048576 --max_bytes_for_level_base=4194304 --max_key=100000 --value_size_mult=33 --compression_type=none --duration=120 --interval=10 --compression_type=none --blob_compression_type=none --random_kill_odd=88887
```
- db_stress without expected_values_dir
```
$ ./db_stress --write_buffer_size=1048576 --target_file_size_base=1048576 --max_bytes_for_level_base=4194304 --max_key=100000 --value_size_mult=33 --compression_type=none --ops_per_thread=10000 --clear_column_family_one_in=0 --destroy_db_initially=true
```
- db_stress with expected_values_dir and manual corruption
```
$ ./db_stress --write_buffer_size=1048576 --target_file_size_base=1048576 --max_bytes_for_level_base=4194304 --max_key=100000 --value_size_mult=33 --compression_type=none --ops_per_thread=10000 --clear_column_family_one_in=0 --destroy_db_initially=true --expected_values_dir=./
// modify one byte in "./LATEST.state"
$ ./db_stress --write_buffer_size=1048576 --target_file_size_base=1048576 --max_bytes_for_level_base=4194304 --max_key=100000 --value_size_mult=33 --compression_type=none --ops_per_thread=10000 --clear_column_family_one_in=0 --destroy_db_initially=false --expected_values_dir=./
...
Verification failed for column family 0 key 0000000000000000 (0): Value not found: NotFound:
...
```