### PR TITLE
Implement TestFSRandomAccessFile::MultiRead()

### DIFF
--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -138,6 +138,8 @@ class TestFSRandomAccessFile : public FSRandomAccessFile {
   IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,
                 Slice* result, char* scratch,
                 IODebugContext* dbg) const override;
+  IOStatus MultiRead(FSReadRequest* reqs, size_t num_reqs,
+                     const IOOptions& options, IODebugContext* dbg) override;
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }


### PR DESCRIPTION
Summary: Right now, the failure injection test for MultiGet() is not sufficient. Improve it with TestFSRandomAccessFile::MultiRead() injecting failures.

Test Plan: Run crash test locally for a while.