### PR TITLE
Improve one BlockBasedTable::RetrieveMultipleBlocks() error handling

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1864,7 +1864,8 @@ void BlockBasedTable::RetrieveMultipleBlocks(
           continue;
         }
       }
-
+    }
+    if (s.ok()) {
       CompressionType compression_type =
           raw_block_contents.get_compression_type();
       BlockContents contents;


### PR DESCRIPTION
Summary:
Right now BlockBasedTable::RetrieveMultipleBlocks() override error from MaybeReadBlockAndLoadToCache() with checksum checking error. MaybeReadBlockAndLoadToCache() only inserts blocks to cache in this path, so error can happen when decompression or block cache full. It's not clear whether it is a problem as we would decompress it again. I think it is a better practice stop operation we see an error anyway.

Test Plan: Run all existing tests.