### PR TITLE
Fix ldb --try_load_options doesn't use customized Env

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -722,6 +722,10 @@ void LDBCommand::PrepareOptions() {
     }
   }
 
+  if (options_.env == Env::Default()) {
+    options_.env = config_options_.env;
+  }
+
   OverrideBaseOptions();
   if (exec_state_.IsFailed()) {
     return;


### PR DESCRIPTION
Summary:
As title. The reason is that after loading customized options, the env is not set back to the correct one. Fix it.

Test Plan: Manually validate in an environment where the command failed.