### PR TITLE
Add a gflag for IO uring enable/disable

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 * Fix the implementation of `prepopulate_block_cache = kFlushOnly` to only apply to flushes rather than to all generated files.
 * Fix WAL log data corruption when using DBOptions.manual_wal_flush(true) and WriteOptions.sync(true) together. The sync WAL should work with locked log_write_mutex_.
 * Add checks for validity of the IO uring completion queue entries, and fail the BlockBasedTableReader MultiGet sub-batch if there's an invalid completion
+* Add a Gflag rocksdb_io_uring_enable to enable/disable IO uring usage on startup, with the default being true
 
 ### New Features
 * RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,7 @@
 * Fix the implementation of `prepopulate_block_cache = kFlushOnly` to only apply to flushes rather than to all generated files.
 * Fix WAL log data corruption when using DBOptions.manual_wal_flush(true) and WriteOptions.sync(true) together. The sync WAL should work with locked log_write_mutex_.
 * Add checks for validity of the IO uring completion queue entries, and fail the BlockBasedTableReader MultiGet sub-batch if there's an invalid completion
-* Add a Gflag rocksdb_io_uring_enable to enable/disable IO uring usage on startup, with the default being true
+* Add a Gflag (temporarily for troubleshooting) rocksdb_io_uring_enable to enable/disable IO uring usage on startup, with the default being true
 
 ### New Features
 * RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,7 @@
 * Fix the implementation of `prepopulate_block_cache = kFlushOnly` to only apply to flushes rather than to all generated files.
 * Fix WAL log data corruption when using DBOptions.manual_wal_flush(true) and WriteOptions.sync(true) together. The sync WAL should work with locked log_write_mutex_.
 * Add checks for validity of the IO uring completion queue entries, and fail the BlockBasedTableReader MultiGet sub-batch if there's an invalid completion
-* Add a Gflag (temporarily for troubleshooting) rocksdb_io_uring_enable to enable/disable IO uring usage on startup, with the default being true
+* Add an interface RocksDbIOUringEnable() that, if defined by the user, will allow them to enable/disable the use of IO uring by RocksDB
 
 ### New Features
 * RemoteCompaction's interface now includes `db_name`, `db_id`, `session_id`, which could help the user uniquely identify compaction job between db instances and sessions.

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -323,8 +323,6 @@ EOF
         then
           COMMON_FLAGS="$COMMON_FLAGS -DGFLAGS=1"
           PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lgflags"
-          JAVA_LDFLAGS="$JAVA_LDFLAGS -lgflags"
-          JAVA_STATIC_LDFLAGS="$JAVA_STATIC_LDFLAGS -lgflags"
         # check if namespace is gflags
         elif $CXX $PLATFORM_CXXFLAGS -x c++ - -o /dev/null 2>/dev/null << EOF
             #include <gflags/gflags.h>

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -324,6 +324,7 @@ EOF
           COMMON_FLAGS="$COMMON_FLAGS -DGFLAGS=1"
           PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lgflags"
           JAVA_LDFLAGS="$JAVA_LDFLAGS -lgflags"
+          JAVA_STATIC_LDFLAGS="$JAVA_STATIC_LDFLAGS -lgflags"
         # check if namespace is gflags
         elif $CXX $PLATFORM_CXXFLAGS -x c++ - -o /dev/null 2>/dev/null << EOF
             #include <gflags/gflags.h>

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -323,6 +323,7 @@ EOF
         then
           COMMON_FLAGS="$COMMON_FLAGS -DGFLAGS=1"
           PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lgflags"
+          JAVA_LDFLAGS="$JAVA_LDFLAGS -lgflags"
         # check if namespace is gflags
         elif $CXX $PLATFORM_CXXFLAGS -x c++ - -o /dev/null 2>/dev/null << EOF
             #include <gflags/gflags.h>

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -16,7 +16,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #ifdef GFLAGS
-#include <gflags/gflags.h>
+#include <util/gflags_compat.h>
 #endif  // GFLAGS
 #include <pthread.h>
 #include <signal.h>

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -15,6 +15,9 @@
 #endif
 #include <errno.h>
 #include <fcntl.h>
+#ifdef GFLAGS
+#include <gflags/gflags.h>
+#endif // GFLAGS
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
@@ -72,6 +75,11 @@
 #if !defined(EXT4_SUPER_MAGIC)
 #define EXT4_SUPER_MAGIC 0xEF53
 #endif
+
+#ifdef GFLAGS
+DEFINE_bool(rocksdb_io_uring_enable, true,
+            "If true, use IO uring if the platform supports it");
+#endif // GFLAGS
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -267,7 +275,10 @@ class PosixFileSystem : public FileSystem {
           options
 #if defined(ROCKSDB_IOURING_PRESENT)
           ,
-          thread_local_io_urings_.get()
+#ifdef GFLAGS
+          !FLAGS_rocksdb_io_uring_enable ? nullptr :
+#endif
+                  thread_local_io_urings_.get()
 #endif
               ));
     }

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1035,7 +1035,7 @@ class PosixFileSystem : public FileSystem {
       return false;
     }
   }
-#endif // ROCKSDB_IOURING_PRESENT
+#endif  // ROCKSDB_IOURING_PRESENT
 
 #if defined(ROCKSDB_IOURING_PRESENT)
   // io_uring instance

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -17,7 +17,7 @@
 #include <fcntl.h>
 #ifdef GFLAGS
 #include <gflags/gflags.h>
-#endif // GFLAGS
+#endif  // GFLAGS
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
@@ -79,7 +79,7 @@
 #ifdef GFLAGS
 DEFINE_bool(rocksdb_io_uring_enable, true,
             "If true, use IO uring if the platform supports it");
-#endif // GFLAGS
+#endif  // GFLAGS
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -278,7 +278,7 @@ class PosixFileSystem : public FileSystem {
 #ifdef GFLAGS
           !FLAGS_rocksdb_io_uring_enable ? nullptr :
 #endif
-                  thread_local_io_urings_.get()
+                                         thread_local_io_urings_.get()
 #endif
               ));
     }

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -15,9 +15,6 @@
 #endif
 #include <errno.h>
 #include <fcntl.h>
-#ifdef GFLAGS
-#include <util/gflags_compat.h>
-#endif  // GFLAGS
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
@@ -61,6 +58,9 @@
 #include "test_util/sync_point.h"
 #include "util/coding.h"
 #include "util/compression_context_cache.h"
+#ifdef GFLAGS
+#include "util/gflags_compat.h"
+#endif  // GFLAGS
 #include "util/random.h"
 #include "util/string_util.h"
 #include "util/thread_local.h"

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1021,6 +1021,11 @@ DEFINE_string(block_cache_trace_file, "", "Block cache trace file path.");
 DEFINE_int32(trace_replay_threads, 1,
              "The number of threads to replay, must >=1.");
 
+DEFINE_bool(io_uring_enabled, true,
+    "If true, enable the use of IO uring if the platform supports it");
+extern "C" bool RocksDbIOUringEnable() {
+  return FLAGS_io_uring_enabled;
+}
 #endif  // ROCKSDB_LITE
 
 static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1022,10 +1022,8 @@ DEFINE_int32(trace_replay_threads, 1,
              "The number of threads to replay, must >=1.");
 
 DEFINE_bool(io_uring_enabled, true,
-    "If true, enable the use of IO uring if the platform supports it");
-extern "C" bool RocksDbIOUringEnable() {
-  return FLAGS_io_uring_enabled;
-}
+            "If true, enable the use of IO uring if the platform supports it");
+extern "C" bool RocksDbIOUringEnable() { return FLAGS_io_uring_enabled; }
 #endif  // ROCKSDB_LITE
 
 static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(


### PR DESCRIPTION
In case of IO uring bugs, we need to provide a way for users to turn it off.

Test plan:
Manually run db_bench with/without the option and verify the behavior