### PR TITLE
Improve fault injection to MultiRead

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -345,11 +345,14 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       }
 
-      if (stat_nok < error_count) {
+      int expected_nok = std::min(error_count, static_cast<int>(num_keys));
+      if (stat_nok < expected_nok) {
         // Grab mutex so multiple thread don't try to print the
         // stack trace at the same time
         MutexLock l(thread->shared->GetMutex());
-        fprintf(stderr, "Didn't get expected error from MultiGet\n");
+        fprintf(stderr, "Didn't get expected error from MultiGet. \n");
+        fprintf(stderr, "num_keys %zu Expected %d errors, seen %d\n",
+                num_keys, expected_nok, stat_nok);
         fprintf(stderr, "Callstack that injected the fault\n");
         fault_fs_guard->PrintFaultBacktrace();
         std::terminate();

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -345,14 +345,13 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       }
 
-      int expected_nok = std::min(error_count, static_cast<int>(num_keys));
-      if (stat_nok < expected_nok) {
+      if (stat_nok < error_count) {
         // Grab mutex so multiple thread don't try to print the
         // stack trace at the same time
         MutexLock l(thread->shared->GetMutex());
         fprintf(stderr, "Didn't get expected error from MultiGet. \n");
-        fprintf(stderr, "num_keys %zu Expected %d errors, seen %d\n",
-                num_keys, expected_nok, stat_nok);
+        fprintf(stderr, "num_keys %zu Expected %d errors, seen %d\n", num_keys,
+                error_count, stat_nok);
         fprintf(stderr, "Callstack that injected the fault\n");
         fault_fs_guard->PrintFaultBacktrace();
         std::terminate();

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -19,7 +19,6 @@
 #include "cache/sharded_cache.h"
 #include "db/dbformat.h"
 #include "db/pinned_iterators_manager.h"
-#include "db_stress_tool/db_stress_common.h"
 #include "file/file_prefetch_buffer.h"
 #include "file/file_util.h"
 #include "file/random_access_file_reader.h"
@@ -66,7 +65,6 @@
 #include "util/crc32c.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"
-#include "utilities/fault_injection_fs.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -1775,9 +1773,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
             "truncated block read from " + rep_->file->file_name() +
             " offset " + ToString(handle.offset()) + ", expected " +
             ToString(req.len) + " bytes, got " + ToString(req.result.size()));
-        if (fault_fs_guard) {
-          fault_fs_guard->AddThreadLocalMessage("size mismatch");
-        }
       }
     }
 
@@ -1813,9 +1808,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
         s = ROCKSDB_NAMESPACE::VerifyBlockChecksum(
             footer.checksum(), data + req_offset, handle.size(),
             rep_->file->file_name(), handle.offset());
-        if (!s.ok() && fault_fs_guard) {
-          fault_fs_guard->AddThreadLocalMessage("checksum mismatch");
-        }
         TEST_SYNC_POINT_CALLBACK("RetrieveMultipleBlocks:VerifyChecksum", &s);
       }
     } else if (!use_shared_buffer) {
@@ -1872,8 +1864,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
           continue;
         }
       }
-    }
-    if (s.ok()) {
+
       CompressionType compression_type =
           raw_block_contents.get_compression_type();
       BlockContents contents;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1864,7 +1864,8 @@ void BlockBasedTable::RetrieveMultipleBlocks(
           continue;
         }
       }
-
+    }
+    if (s.ok()) {
       CompressionType compression_type =
           raw_block_contents.get_compression_type();
       BlockContents contents;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -140,7 +140,7 @@ default_params = {
     "continuous_verification_interval" : 0,
     "max_key_len": 3,
     "key_len_percent_dist": "1,30,69",
-    "read_fault_one_in": lambda: random.choice([0, 1000]),
+    "read_fault_one_in": lambda: random.choice([0, 32, 1000]),
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
     "open_read_fault_one_in": lambda: random.choice([0, 0, 32]),

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -45,7 +45,8 @@ default_params = {
         random.choice(
             ["none", "snappy", "zlib", "bzip2", "lz4", "lz4hc", "xpress",
              "zstd"]),
-    "checksum_type" : lambda: random.choice(["kCRC32c", "kxxHash", "kxxHash64"]),
+    "checksum_type" : lambda: random.choice(["kCRC32c"]),
+#    "checksum_type" : lambda: random.choice(["kCRC32c", "kxxHash", "kxxHash64"]),
     "compression_max_dict_bytes": lambda: 16384 * random.randint(0, 1),
     "compression_zstd_max_train_bytes": lambda: 65536 * random.randint(0, 1),
     # Disabled compression_parallel_threads as the feature is not stable
@@ -77,7 +78,7 @@ default_params = {
     "max_bytes_for_level_base": 10485760,
     "max_key": 100000000,
     "max_write_buffer_number": 3,
-    "mmap_read": lambda: random.randint(0, 1),
+    "mmap_read": 0,
     "nooverwritepercent": 1,
     "open_files": lambda : random.choice([-1, -1, 100, 500000]),
     "optimize_filters_for_memory": lambda: random.randint(0, 1),
@@ -112,7 +113,7 @@ default_params = {
     "writepercent": 35,
     "format_version": lambda: random.choice([2, 3, 4, 5, 5]),
     "index_block_restart_interval": lambda: random.choice(range(1, 16)),
-    "use_multiget" : lambda: random.randint(0, 1),
+    "use_multiget" : 1,
     "periodic_compaction_seconds" :
         lambda: random.choice([0, 0, 1, 2, 10, 100, 1000]),
     "compaction_ttl" : lambda: random.choice([0, 0, 1, 2, 10, 100, 1000]),
@@ -140,7 +141,7 @@ default_params = {
     "continuous_verification_interval" : 0,
     "max_key_len": 3,
     "key_len_percent_dist": "1,30,69",
-    "read_fault_one_in": lambda: random.choice([0, 32, 1000]),
+    "read_fault_one_in": lambda: random.choice([10, 32]),
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
     "open_read_fault_one_in": lambda: random.choice([0, 0, 32]),
@@ -512,12 +513,16 @@ def blackbox_crash_main(args, unknown_args):
             print(outs)
             print('stderr:')
             print(errs)
-            sys.exit(2)
+            sys.exit(1)
 
         for line in errs.split('\n'):
             if line != '' and  not line.startswith('WARNING'):
                 print('stderr has error message:')
                 print('***' + line + '***')
+
+        if "Didn't get expected error" in errs:
+           print('See verification failures')
+           sys.exit(1)
 
         time.sleep(1)  # time to stabilize before the next run
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -45,8 +45,7 @@ default_params = {
         random.choice(
             ["none", "snappy", "zlib", "bzip2", "lz4", "lz4hc", "xpress",
              "zstd"]),
-    "checksum_type" : lambda: random.choice(["kCRC32c"]),
-#    "checksum_type" : lambda: random.choice(["kCRC32c", "kxxHash", "kxxHash64"]),
+    "checksum_type" : lambda: random.choice(["kCRC32c", "kxxHash", "kxxHash64"]),
     "compression_max_dict_bytes": lambda: 16384 * random.randint(0, 1),
     "compression_zstd_max_train_bytes": lambda: 65536 * random.randint(0, 1),
     # Disabled compression_parallel_threads as the feature is not stable
@@ -78,7 +77,7 @@ default_params = {
     "max_bytes_for_level_base": 10485760,
     "max_key": 100000000,
     "max_write_buffer_number": 3,
-    "mmap_read": 0,
+    "mmap_read": lambda: random.randint(0, 1),
     "nooverwritepercent": 1,
     "open_files": lambda : random.choice([-1, -1, 100, 500000]),
     "optimize_filters_for_memory": lambda: random.randint(0, 1),
@@ -113,7 +112,7 @@ default_params = {
     "writepercent": 35,
     "format_version": lambda: random.choice([2, 3, 4, 5, 5]),
     "index_block_restart_interval": lambda: random.choice(range(1, 16)),
-    "use_multiget" : 1,
+    "use_multiget" : lambda: random.randint(0, 1),
     "periodic_compaction_seconds" :
         lambda: random.choice([0, 0, 1, 2, 10, 100, 1000]),
     "compaction_ttl" : lambda: random.choice([0, 0, 1, 2, 10, 100, 1000]),
@@ -141,7 +140,7 @@ default_params = {
     "continuous_verification_interval" : 0,
     "max_key_len": 3,
     "key_len_percent_dist": "1,30,69",
-    "read_fault_one_in": lambda: random.choice([10, 32]),
+    "read_fault_one_in": lambda: random.choice([0, 32, 1000]),
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
     "open_read_fault_one_in": lambda: random.choice([0, 0, 32]),
@@ -513,16 +512,12 @@ def blackbox_crash_main(args, unknown_args):
             print(outs)
             print('stderr:')
             print(errs)
-            sys.exit(1)
+            sys.exit(2)
 
         for line in errs.split('\n'):
             if line != '' and  not line.startswith('WARNING'):
                 print('stderr has error message:')
                 print('***' + line + '***')
-
-        if "Didn't get expected error" in errs:
-           print('See verification failures')
-           sys.exit(1)
 
         time.sleep(1)  # time to stabilize before the next run
 

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -800,9 +800,8 @@ IOStatus FaultInjectionTestFS::InjectThreadSpecificReadError(
       assert(result);
       // For a small chance, set the failure to status but turn the
       // result to be empty, which is supposed to be caught for a check.
-      ctx->message += "pre size " + ToString((long)result->size()) + " ";
       *result = Slice();
-      ctx->message += "inject empty result " + ToString((long)result) + "; ";
+      ctx->message += "inject empty result; ";
       ret_fault_injected = true;
     } else if (!direct_io && Random::GetTLSInstance()->OneIn(7)) {
       assert(result);

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -361,10 +361,12 @@ IOStatus TestFSRandomAccessFile::MultiRead(FSReadRequest* reqs, size_t num_reqs,
       // Already seeing an error.
       break;
     }
+    bool this_injected_error;
     reqs[i].status = fs_->InjectThreadSpecificReadError(
         FaultInjectionTestFS::ErrorOperation::kRead, &reqs[i].result,
         use_direct_io(), reqs[i].scratch, /*need_count_increase=*/true,
-        /*fault_injected=*/&injected_error);
+        /*fault_injected=*/&this_injected_error);
+    injected_error |= this_injected_error;
   }
   if (s.ok()) {
     s = fs_->InjectThreadSpecificReadError(

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -796,8 +796,7 @@ IOStatus FaultInjectionTestFS::InjectThreadSpecificReadError(
       ctx->message += "error; ";
       ret_fault_injected = true;
       return IOStatus::IOError();
-    } else if (op == ErrorOperation::kMultiReadSingleReq &&
-               Random::GetTLSInstance()->OneIn(8)) {
+    } else if (Random::GetTLSInstance()->OneIn(8)) {
       assert(result);
       // For a small chance, set the failure to status but turn the
       // result to be empty, which is supposed to be caught for a check.
@@ -805,8 +804,7 @@ IOStatus FaultInjectionTestFS::InjectThreadSpecificReadError(
       *result = Slice();
       ctx->message += "inject empty result " + ToString((long)result) + "; ";
       ret_fault_injected = true;
-    } else if (op == ErrorOperation::kMultiReadSingleReq && !direct_io &&
-               Random::GetTLSInstance()->OneIn(7)) {
+    } else if (!direct_io && Random::GetTLSInstance()->OneIn(7)) {
       assert(result);
       // With direct I/O, many extra bytes might be read so corrupting
       // one byte might not cause checksum mismatch. Skip checksum

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -370,6 +370,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   // Specify what the operation, so we can inject the right type of error
   enum ErrorOperation : char {
     kRead = 0,
+    kMultiReadSingleReq = 1,
+    kMultiRead = 2,
     kOpen,
   };
 

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -525,6 +525,7 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     int count;
     bool enable_error_injection;
     void* callstack;
+    std::string message;
     int frames;
     ErrorType type;
 

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -440,9 +440,12 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   // corruption in the contents of scratch, or truncation of slice
   // are the types of error with equal probability. For OPEN,
   // its always an IOError.
+  // fault_injected returns whether a fault is injected. It is needed
+  // because some fault is inected with IOStatus to be OK.
   IOStatus InjectThreadSpecificReadError(ErrorOperation op, Slice* slice,
                                          bool direct_io, char* scratch,
-                                         bool need_count_increase);
+                                         bool need_count_increase,
+                                         bool* fault_injected);
 
   // Get the count of how many times we injected since the previous call
   int GetAndResetErrorCount() {

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -503,13 +503,6 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   // saved callstack
   void PrintFaultBacktrace();
 
-  void AddThreadLocalMessage(const std::string& m) {
-    ErrorContext* ctx = static_cast<ErrorContext*>(thread_local_error_->Get());
-    if (ctx) {
-      ctx->message += m;
-    }
-  }
-
  private:
   port::Mutex mutex_;
   std::map<std::string, FSFileState> db_file_state_;

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -441,7 +441,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   // are the types of error with equal probability. For OPEN,
   // its always an IOError.
   IOStatus InjectThreadSpecificReadError(ErrorOperation op, Slice* slice,
-                                         bool direct_io, char* scratch);
+                                         bool direct_io, char* scratch,
+                                         bool need_count_increase);
 
   // Get the count of how many times we injected since the previous call
   int GetAndResetErrorCount() {
@@ -496,6 +497,13 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   // purposes. This call prints the backtrace to stderr and frees the
   // saved callstack
   void PrintFaultBacktrace();
+
+  void AddThreadLocalMessage(const std::string& m) {
+    ErrorContext* ctx = static_cast<ErrorContext*>(thread_local_error_->Get());
+    if (ctx) {
+      ctx->message += m;
+    }
+  }
 
  private:
   port::Mutex mutex_;


### PR DESCRIPTION
Summary:
Several improvements to MultiRead:
1. Fix a bug in stress test which causes false positive when both MultiRead() return and individual read request have failure injected.
2. Add two more types of fault that should be handled: empty read results and checksum mismatch
3. Add a message indicating which type of fault is injected
4. Increase the failure rate

Test Plan: