### PR TITLE
Add remote compaction read/write bytes statistics

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 
 ### New Features
 * Provided support for SingleDelete with user defined timestamp.
+* Add remote compaction read/write bytes statistics: `REMOTE_COMPACT_READ_BYTES`, `REMOTE_COMPACT_WRITE_BYTES`.
 
 ### Public API change
 * Made SystemClock extend the Customizable class and added a CreateFromString method.  Implementations need to be registered with the ObjectRegistry and to implement a Name() method in order to be created via this method.

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -117,7 +117,7 @@ class CompactionJob {
   void AggregateStatistics();
   void UpdateCompactionStats();
   void LogCompaction();
-  void RecordCompactionIOStats();
+  virtual void RecordCompactionIOStats();
   void CleanupCompaction();
 
   // Call compaction filter. Then iterate through input and compact the
@@ -304,10 +304,10 @@ struct CompactionServiceResult {
   std::string output_path;
 
   // some statistics about the compaction
-  uint64_t num_output_records;
-  uint64_t total_bytes;
-  uint64_t bytes_read;
-  uint64_t bytes_written;
+  uint64_t num_output_records = 0;
+  uint64_t total_bytes = 0;
+  uint64_t bytes_read = 0;
+  uint64_t bytes_written = 0;
   CompactionJobStats stats;
 
   // serialization interface to read and write the object
@@ -346,6 +346,9 @@ class CompactionServiceCompactionJob : private CompactionJob {
   void CleanupCompaction();
 
   IOStatus io_status() const { return CompactionJob::io_status(); }
+
+ protected:
+  void RecordCompactionIOStats() override;
 
  private:
   // Get table file name in output_path

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -215,6 +215,10 @@ enum Tickers : uint32_t {
   COMPACT_WRITE_BYTES_PERIODIC,
   COMPACT_WRITE_BYTES_TTL,
 
+  // Remote compaction read/write statistics
+  REMOTE_COMPACT_READ_BYTES,
+  REMOTE_COMPACT_WRITE_BYTES,
+
   // Number of table's properties loaded directly from file, without creating
   // table reader object.
   NUMBER_DIRECT_LOAD_TABLE_PROPERTIES,

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -215,10 +215,6 @@ enum Tickers : uint32_t {
   COMPACT_WRITE_BYTES_PERIODIC,
   COMPACT_WRITE_BYTES_TTL,
 
-  // Remote compaction read/write statistics
-  REMOTE_COMPACT_READ_BYTES,
-  REMOTE_COMPACT_WRITE_BYTES,
-
   // Number of table's properties loaded directly from file, without creating
   // table reader object.
   NUMBER_DIRECT_LOAD_TABLE_PROPERTIES,
@@ -416,6 +412,10 @@ enum Tickers : uint32_t {
   // Bytes read/written while creating backups
   BACKUP_READ_BYTES,
   BACKUP_WRITE_BYTES,
+
+  // Remote compaction read/write statistics
+  REMOTE_COMPACT_READ_BYTES,
+  REMOTE_COMPACT_WRITE_BYTES,
 
   TICKER_ENUM_MAX
 };

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5008,6 +5008,10 @@ class TickerTypeJni {
         return -0x20;
       case ROCKSDB_NAMESPACE::Tickers::BACKUP_WRITE_BYTES:
         return -0x21;
+      case ROCKSDB_NAMESPACE::Tickers::REMOTE_COMPACT_READ_BYTES:
+        return -0x22;
+      case ROCKSDB_NAMESPACE::Tickers::REMOTE_COMPACT_WRITE_BYTES:
+        return -0x23;
       case ROCKSDB_NAMESPACE::Tickers::TICKER_ENUM_MAX:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep
@@ -5353,6 +5357,10 @@ class TickerTypeJni {
         return ROCKSDB_NAMESPACE::Tickers::BACKUP_READ_BYTES;
       case -0x21:
         return ROCKSDB_NAMESPACE::Tickers::BACKUP_WRITE_BYTES;
+      case -0x22:
+        return ROCKSDB_NAMESPACE::Tickers::REMOTE_COMPACT_READ_BYTES;
+      case -0x23:
+        return ROCKSDB_NAMESPACE::Tickers::REMOTE_COMPACT_WRITE_BYTES;
       case 0x5F:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -769,6 +769,23 @@ public enum TickerType {
      */
     SECONDARY_CACHE_HITS((byte) -0x1E),
 
+    /**
+     * Bytes read by `VerifyChecksum()` and `VerifyFileChecksums()` APIs.
+     */
+    VERIFY_CHECKSUM_READ_BYTES((byte) -0x1F),
+
+    /**
+     * Bytes read/written while creating backups
+     */
+    BACKUP_READ_BYTES((byte) -0x20),
+    BACKUP_WRITE_BYTES((byte) -0x21),
+
+    /**
+     * Remote compaction read/write statistics
+     */
+    REMOTE_COMPACT_READ_BYTES((byte) -0x22),
+    REMOTE_COMPACT_WRITE_BYTES((byte) -0x23),
+
     TICKER_ENUM_MAX((byte) 0x5F);
 
     private final byte value;

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -115,6 +115,8 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {COMPACT_WRITE_BYTES_MARKED, "rocksdb.compact.write.marked.bytes"},
     {COMPACT_WRITE_BYTES_PERIODIC, "rocksdb.compact.write.periodic.bytes"},
     {COMPACT_WRITE_BYTES_TTL, "rocksdb.compact.write.ttl.bytes"},
+    {REMOTE_COMPACT_READ_BYTES, "rocksdb.remote.compact.read.bytes"},
+    {REMOTE_COMPACT_WRITE_BYTES, "rocksdb.remote.compact.write.bytes"},
     {NUMBER_DIRECT_LOAD_TABLE_PROPERTIES,
      "rocksdb.number.direct.load.table.properties"},
     {NUMBER_SUPERVERSION_ACQUIRES, "rocksdb.number.superversion_acquires"},

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -115,8 +115,6 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {COMPACT_WRITE_BYTES_MARKED, "rocksdb.compact.write.marked.bytes"},
     {COMPACT_WRITE_BYTES_PERIODIC, "rocksdb.compact.write.periodic.bytes"},
     {COMPACT_WRITE_BYTES_TTL, "rocksdb.compact.write.ttl.bytes"},
-    {REMOTE_COMPACT_READ_BYTES, "rocksdb.remote.compact.read.bytes"},
-    {REMOTE_COMPACT_WRITE_BYTES, "rocksdb.remote.compact.write.bytes"},
     {NUMBER_DIRECT_LOAD_TABLE_PROPERTIES,
      "rocksdb.number.direct.load.table.properties"},
     {NUMBER_SUPERVERSION_ACQUIRES, "rocksdb.number.superversion_acquires"},
@@ -216,6 +214,8 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {VERIFY_CHECKSUM_READ_BYTES, "rocksdb.verify_checksum.read.bytes"},
     {BACKUP_READ_BYTES, "rocksdb.backup.read.bytes"},
     {BACKUP_WRITE_BYTES, "rocksdb.backup.write.bytes"},
+    {REMOTE_COMPACT_READ_BYTES, "rocksdb.remote.compact.read.bytes"},
+    {REMOTE_COMPACT_WRITE_BYTES, "rocksdb.remote.compact.write.bytes"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {


### PR DESCRIPTION
Summary:
Add basic read/write bytes statistics on the primary side:
`REMOTE_COMPACT_READ_BYTES`
`REMOTE_COMPACT_WRITE_BYTES`

Fixed existing statistics missing some IO for remote compaction.

Test Plan: CI