### PR TITLE
Fix flaky ldb_cmd_test tests caused by file deletions during validation

### DIFF
--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -257,14 +257,15 @@ class FileChecksumTestHelper {
     EXPECT_OK(db_->DisableFileDeletions());
     std::vector<LiveFileMetaData> live_files;
     db_->GetLiveFilesMetaData(&live_files);
+    Status cs;
     for (auto a_file : live_files) {
-      Status cs = VerifyChecksum(a_file);
+      cs = VerifyChecksum(a_file);
       if (!cs.ok()) {
-        return cs;
+        break;
       }
     }
     EXPECT_OK(db_->EnableFileDeletions());
-    return Status::OK();
+    return cs;
   }
 };
 

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -254,6 +254,7 @@ class FileChecksumTestHelper {
   // comparing it with the one being generated when a SST file is created.
   Status VerifyEachFileChecksum() {
     assert(db_ != nullptr);
+    EXPECT_OK(db_->DisableFileDeletions());
     std::vector<LiveFileMetaData> live_files;
     db_->GetLiveFilesMetaData(&live_files);
     for (auto a_file : live_files) {
@@ -262,6 +263,7 @@ class FileChecksumTestHelper {
         return cs;
       }
     }
+    EXPECT_OK(db_->EnableFileDeletions());
     return Status::OK();
   }
 };


### PR DESCRIPTION
Summary:
In FileChecksumTestHelper::VerifyEachFileChecksum(), we query the file list, and then for each file in the list verify the checksum. However, compaction can delete those files in the mean time and cause failures. To prevent it from happening, disable file deletion during the validation.

Test Plan: Run exsiting test and see it doesn't fail.