### PR TITLE
Avoid overloading in SstFileWriter API for user-defined timestamp

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,7 +25,7 @@
 * Added ticker statistics, "rocksdb.backup.read.bytes" and "rocksdb.backup.write.bytes", reporting how many bytes were read and written during backup.
 * Added properties for BlobDB: `rocksdb.num-blob-files`, `rocksdb.blob-stats`, `rocksdb.total-blob-file-size`, and `rocksdb.live-blob-file-size`. The existing property `rocksdb.estimate_live-data-size` was also extended to include live bytes residing in blob files.
 * Added two new RateLimiter IOPriorities: `Env::IO_USER`,`Env::IO_MID`. `Env::IO_USER` will have superior priority over all other RateLimiter IOPriorities without being subject to fair scheduling constraint.
-* `SstFileWriter` now supports `Put`s and `Delete`s with user-defined timestamps. Note that the ingestion logic itself is not timestamp-aware yet.
+* `SstFileWriter` now supports `PutWithTimestamp` and `DeleteWithTimestamp` for user-defined timestamps. Note that the ingestion logic itself is not timestamp-aware yet.
 * Allow a single write batch to include keys from multiple column families whose timestamps' formats can differ. For example, some column families may disable timestamp, while others enable timestamp.
 * Add compaction priority information in RemoteCompaction, which can be used to schedule high priority job first.
 * Added new callback APIs `OnBlobFileCreationStarted`,`OnBlobFileCreated`and `OnBlobFileDeleted` in `EventListener` class of listener.h. It notifies listeners during creation/deletion of individual blob files in Integrated BlobDB. It also log blob file creation finished event and deletion event in LOG file.

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -125,7 +125,8 @@ class SstFileWriter {
   // comparator.
   // REQUIRES: the timestamp's size is equal to what is expected by
   // the comparator.
-  Status Put(const Slice& user_key, const Slice& timestamp, const Slice& value);
+  Status PutWithTimestamp(const Slice& user_key, const Slice& timestamp,
+                          const Slice& value);
 
   // Add a Merge key with value to currently opened file
   // REQUIRES: key is after any previously added key according to comparator.
@@ -142,7 +143,7 @@ class SstFileWriter {
   // comparator.
   // REQUIRES: the timestamp's size is equal to what is expected by
   // the comparator.
-  Status Delete(const Slice& user_key, const Slice& timestamp);
+  Status DeleteWithTimestamp(const Slice& user_key, const Slice& timestamp);
 
   // Add a range deletion tombstone to currently opened file
   // REQUIRES: comparator is *not* timestamp-aware.

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -320,8 +320,9 @@ Status SstFileWriter::Put(const Slice& user_key, const Slice& value) {
   return rep_->Add(user_key, value, ValueType::kTypeValue);
 }
 
-Status SstFileWriter::Put(const Slice& user_key, const Slice& timestamp,
-                          const Slice& value) {
+Status SstFileWriter::PutWithTimestamp(const Slice& user_key,
+                                       const Slice& timestamp,
+                                       const Slice& value) {
   return rep_->Add(user_key, timestamp, value, ValueType::kTypeValue);
 }
 
@@ -333,7 +334,8 @@ Status SstFileWriter::Delete(const Slice& user_key) {
   return rep_->Add(user_key, Slice(), ValueType::kTypeDeletion);
 }
 
-Status SstFileWriter::Delete(const Slice& user_key, const Slice& timestamp) {
+Status SstFileWriter::DeleteWithTimestamp(const Slice& user_key,
+                                          const Slice& timestamp) {
   return rep_->Add(user_key, timestamp, Slice(),
                    ValueType::kTypeDeletionWithTimestamp);
 }


### PR DESCRIPTION
Summary: This was noticed when some user code used member function
pointer in a way that doesn't work with overloading.

This change intended for version 6.25.

Test Plan: existing tests updated