### PR TITLE
Return Status::NotSupported() in RateLimiter::GetTotalPendingRequests default impl

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,7 +33,7 @@
 * Added new callback APIs `OnBlobFileCreationStarted`,`OnBlobFileCreated`and `OnBlobFileDeleted` in `EventListener` class of listener.h. It notifies listeners during creation/deletion of individual blob files in Integrated BlobDB. It also log blob file creation finished event and deletion event in LOG file.
 * Batch blob read requests for `DB::MultiGet` using `MultiRead`.
 * Add support for fallback to local compaction, the user can return `CompactionServiceJobStatus::kUseLocal` to instruct RocksDB to run the compaction locally instead of waiting for the remote compaction result.
-* Add built-in rate limiter's implementation for `RateLimiter::GetTotalPendingRequests()` for the total number of requests that are pending for bytes in the rate limiter.
+* Add built-in rate limiter's implementation of `RateLimiter::GetTotalPendingRequest(int64_t* total_pending_requests, const Env::IOPriority pri)` for the total number of requests that are pending for bytes in the rate limiter.
 
 ### Public API change
 * Remove obsolete implementation details FullKey and ParseFullKey from public API

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -91,7 +91,7 @@ class RateLimiter {
       const Env::IOPriority pri = Env::IO_TOTAL) const = 0;
 
   // Total # of requests that are pending for bytes in rate limiter
-  // For convenience, this function is implemented by the RateLimiter returned
+  // For convenience, this function is supported by the RateLimiter returned
   // by NewGenericRateLimiter but is not required by RocksDB.
   //
   // REQUIRED: total_pending_request != nullptr

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -11,6 +11,7 @@
 
 #include "rocksdb/env.h"
 #include "rocksdb/statistics.h"
+#include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -91,13 +92,16 @@ class RateLimiter {
 
   // Total # of requests that are pending for bytes in rate limiter
   // For convenience, this function is implemented by the RateLimiter returned
-  // by NewGenericRateLimiter but is not required by RocksDB. The default
-  // implementation indicates "not supported".
-  virtual int64_t GetTotalPendingRequests(
+  // by NewGenericRateLimiter but is not required by RocksDB.
+  //
+  // REQUIRED: total_pending_request != nullptr
+  virtual Status GetTotalPendingRequests(
+      int64_t* total_pending_requests,
       const Env::IOPriority pri = Env::IO_TOTAL) const {
-    assert(false);
+    assert(total_pending_requests != nullptr);
+    (void)total_pending_requests;
     (void)pri;
-    return -1;
+    return Status::NotSupported();
   }
 
   virtual int64_t GetBytesPerSecond() const = 0;

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -102,7 +102,8 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
       10 /* fairness */));
   int64_t total_pending_requests = 0;
   for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
-    ASSERT_OK(limiter->GetTotalPendingRequests(&total_pending_requests, static_cast<Env::IOPriority>(i)));
+    ASSERT_OK(limiter->GetTotalPendingRequests(
+        &total_pending_requests, static_cast<Env::IOPriority>(i)));
     ASSERT_EQ(total_pending_requests, 0);
   }
   // This is a variable for making sure the following callback is called
@@ -116,10 +117,11 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
         request_mutex->Unlock();
 
         for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
-          EXPECT_OK(limiter->GetTotalPendingRequests(&total_pending_requests, static_cast<Env::IOPriority>(i)));
+          EXPECT_OK(limiter->GetTotalPendingRequests(
+              &total_pending_requests, static_cast<Env::IOPriority>(i)));
           if (i == Env::IO_USER || i == Env::IO_TOTAL) {
-              EXPECT_EQ(total_pending_requests, 1);
-          }else{
+            EXPECT_EQ(total_pending_requests, 1);
+          } else {
             EXPECT_EQ(total_pending_requests, 0);
           }
         }
@@ -134,7 +136,8 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
                    RateLimiter::OpType::kWrite);
   ASSERT_EQ(nonzero_pending_requests_verified, true);
   for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
-    EXPECT_OK(limiter->GetTotalPendingRequests(&total_pending_requests, static_cast<Env::IOPriority>(i)));
+    EXPECT_OK(limiter->GetTotalPendingRequests(
+        &total_pending_requests, static_cast<Env::IOPriority>(i)));
     EXPECT_EQ(total_pending_requests, 0);
   }
   SyncPoint::GetInstance()->DisableProcessing();

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -100,9 +100,10 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
   std::unique_ptr<RateLimiter> limiter(NewGenericRateLimiter(
       200 /* rate_bytes_per_sec */, 1000 * 1000 /* refill_period_us */,
       10 /* fairness */));
+  int64_t total_pending_requests = 0;
   for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
-    ASSERT_EQ(limiter->GetTotalPendingRequests(static_cast<Env::IOPriority>(i)),
-              0);
+    ASSERT_OK(limiter->GetTotalPendingRequests(&total_pending_requests, static_cast<Env::IOPriority>(i)));
+    ASSERT_EQ(total_pending_requests, 0);
   }
   // This is a variable for making sure the following callback is called
   // and the assertions in it are indeed excuted
@@ -113,11 +114,15 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
         // We temporarily unlock the mutex so that the following
         // GetTotalPendingRequests() can acquire it
         request_mutex->Unlock();
-        EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_USER), 1);
-        EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_HIGH), 0);
-        EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_MID), 0);
-        EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_LOW), 0);
-        EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_TOTAL), 1);
+
+        for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
+          EXPECT_OK(limiter->GetTotalPendingRequests(&total_pending_requests, static_cast<Env::IOPriority>(i)));
+          if (i == Env::IO_USER || i == Env::IO_TOTAL) {
+              EXPECT_EQ(total_pending_requests, 1);
+          }else{
+            EXPECT_EQ(total_pending_requests, 0);
+          }
+        }
         // We lock the mutex again so that the request thread can resume running
         // with the mutex locked
         request_mutex->Lock();
@@ -128,11 +133,10 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
   limiter->Request(200, Env::IO_USER, nullptr /* stats */,
                    RateLimiter::OpType::kWrite);
   ASSERT_EQ(nonzero_pending_requests_verified, true);
-  EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_USER), 0);
-  EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_HIGH), 0);
-  EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_MID), 0);
-  EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_LOW), 0);
-  EXPECT_EQ(limiter->GetTotalPendingRequests(Env::IO_TOTAL), 0);
+  for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
+    EXPECT_OK(limiter->GetTotalPendingRequests(&total_pending_requests, static_cast<Env::IOPriority>(i)));
+    EXPECT_EQ(total_pending_requests, 0);
+  }
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearCallBack(
       "GenericRateLimiter::Request:PostEnqueueRequest");

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -115,14 +115,13 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
         // We temporarily unlock the mutex so that the following
         // GetTotalPendingRequests() can acquire it
         request_mutex->Unlock();
-
         for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
           EXPECT_OK(limiter->GetTotalPendingRequests(
-              &total_pending_requests, static_cast<Env::IOPriority>(i)));
+              &total_pending_requests, static_cast<Env::IOPriority>(i))) << "Failed to return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
           if (i == Env::IO_USER || i == Env::IO_TOTAL) {
-            EXPECT_EQ(total_pending_requests, 1);
+            EXPECT_EQ(total_pending_requests, 1) << "Failed to correctly return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
           } else {
-            EXPECT_EQ(total_pending_requests, 0);
+            EXPECT_EQ(total_pending_requests, 0) << "Failed to correctly return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
           }
         }
         // We lock the mutex again so that the request thread can resume running
@@ -137,8 +136,8 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
   ASSERT_EQ(nonzero_pending_requests_verified, true);
   for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
     EXPECT_OK(limiter->GetTotalPendingRequests(
-        &total_pending_requests, static_cast<Env::IOPriority>(i)));
-    EXPECT_EQ(total_pending_requests, 0);
+        &total_pending_requests, static_cast<Env::IOPriority>(i))) << "Failed to return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
+    EXPECT_EQ(total_pending_requests, 0) << "Failed to correctly return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
   }
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearCallBack(

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -117,11 +117,19 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
         request_mutex->Unlock();
         for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
           EXPECT_OK(limiter->GetTotalPendingRequests(
-              &total_pending_requests, static_cast<Env::IOPriority>(i))) << "Failed to return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
+              &total_pending_requests, static_cast<Env::IOPriority>(i)))
+              << "Failed to return total pending requests for priority level = "
+              << static_cast<Env::IOPriority>(i);
           if (i == Env::IO_USER || i == Env::IO_TOTAL) {
-            EXPECT_EQ(total_pending_requests, 1) << "Failed to correctly return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
+            EXPECT_EQ(total_pending_requests, 1)
+                << "Failed to correctly return total pending requests for "
+                   "priority level = "
+                << static_cast<Env::IOPriority>(i);
           } else {
-            EXPECT_EQ(total_pending_requests, 0) << "Failed to correctly return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
+            EXPECT_EQ(total_pending_requests, 0)
+                << "Failed to correctly return total pending requests for "
+                   "priority level = "
+                << static_cast<Env::IOPriority>(i);
           }
         }
         // We lock the mutex again so that the request thread can resume running
@@ -135,9 +143,14 @@ TEST_F(RateLimiterTest, GetTotalPendingRequests) {
                    RateLimiter::OpType::kWrite);
   ASSERT_EQ(nonzero_pending_requests_verified, true);
   for (int i = Env::IO_LOW; i <= Env::IO_TOTAL; ++i) {
-    EXPECT_OK(limiter->GetTotalPendingRequests(
-        &total_pending_requests, static_cast<Env::IOPriority>(i))) << "Failed to return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
-    EXPECT_EQ(total_pending_requests, 0) << "Failed to correctly return total pending requests for priority level = " << static_cast<Env::IOPriority>(i);
+    EXPECT_OK(limiter->GetTotalPendingRequests(&total_pending_requests,
+                                               static_cast<Env::IOPriority>(i)))
+        << "Failed to return total pending requests for priority level = "
+        << static_cast<Env::IOPriority>(i);
+    EXPECT_EQ(total_pending_requests, 0)
+        << "Failed to correctly return total pending requests for priority "
+           "level = "
+        << static_cast<Env::IOPriority>(i);
   }
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearCallBack(


### PR DESCRIPTION
Context:
After more discussion, a fix in #8938 might turn out to be too restrictive for the case where `GetTotalPendingRequests` might be invoked on RateLimiter classes that does not support the recently added API `RateLimiter::GetTotalPendingRequests` (#8890) due to the `assert(false)` in #8938. Furthermore, sentinel value like `-1` proposed in #8938 is easy to be ignored and unchecked. Therefore we decided to adopt `Status::NotSupported()`, which is also a convention of adding new API to public header in RocksDB.

Summary:
- Changed return value type of  `RateLimiter::GetTotalPendingRequests` in related declaration/definition
- Passed in pointer argument to hold the output instead of returning it as before
- Adapted to the changes above in calling `RateLimiter::GetTotalPendingRequests` in test
- Minor improvement to `TEST_F(RateLimiterTest, GetTotalPendingRequests)`:  added failure message for assertion and replaced repetitive statements with a loop