### PR TITLE
db_stress support tracking historical values

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -16,6 +16,8 @@ class BatchedOpsStressTest : public StressTest {
   BatchedOpsStressTest() {}
   virtual ~BatchedOpsStressTest() {}
 
+  bool IsStateTracked() const override { return false; }
+
   // Given a key K and value V, this puts ("0"+K, "0"+V), ("1"+K, "1"+V), ...
   // ("9"+K, "9"+V) in DB atomically i.e in a single batch.
   // Also refer BatchedOpsStressTest::TestGet

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -18,6 +18,8 @@ class CfConsistencyStressTest : public StressTest {
 
   ~CfConsistencyStressTest() override {}
 
+  bool IsStateTracked() const override { return false; }
+
   Status TestPut(ThreadState* thread, WriteOptions& write_opts,
                  const ReadOptions& /* read_opts */,
                  const std::vector<int>& rand_column_families,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -807,9 +807,9 @@ DEFINE_int32(get_property_one_in, 1000,
 DEFINE_bool(sync_fault_injection, false,
             "If true, FaultInjectionTestFS will be used for write operations, "
             "and unsynced data in DB will lost after crash. In such a case we "
-            "track DB changes in a trace file in --expected_values_dir for "
-            "verifying there are no holes in the recovered data (future "
-            "work).");
+            "track DB changes in a trace file (\"*.trace\") in "
+            "--expected_values_dir for verifying there are no holes in the "
+            "recovered data (future work).");
 
 DEFINE_bool(best_efforts_recovery, false,
             "If true, use best efforts recovery.");

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -463,12 +463,13 @@ DEFINE_bool(test_secondary, false, "Test secondary instance.");
 
 DEFINE_string(
     expected_values_dir, "",
-    "Dir where file with array of expected uint32_t values will be stored. If "
-    "provided and non-empty, the DB state will be verified against these "
-    "values after recovery. --max_key and --column_family must be kept the "
-    "same across invocations of this program that use the same "
-    "--expected_values_dir. See --seed and --nooverwritepercent for further "
-    "requirements.");
+    "Dir where files containing info about the latest/historical values will "
+    "be stored. If provided and non-empty, the DB state will be verified "
+    "against values from these files after recovery. --max_key and "
+    "--column_family must be kept the same across invocations of this program "
+    "that use the same --expected_values_dir. Currently historical values are "
+    "only tracked when --sync_fault_injection is set. See --seed and "
+    "--nooverwritepercent for further requirements.");
 
 DEFINE_bool(verify_checksum, false,
             "Verify checksum for every block read from storage");
@@ -805,7 +806,10 @@ DEFINE_int32(get_property_one_in, 1000,
 
 DEFINE_bool(sync_fault_injection, false,
             "If true, FaultInjectionTestFS will be used for write operations, "
-            " and unsynced data in DB will lost after crash.");
+            "and unsynced data in DB will lost after crash. In such a case we "
+            "track DB changes in a trace file in --expected_values_dir for "
+            "verifying there are no holes in the recovered data (future "
+            "work).");
 
 DEFINE_bool(best_efforts_recovery, false,
             "If true, use best efforts recovery.");

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -250,6 +250,10 @@ class SharedState {
     }
   }
 
+  Status SaveAtAndAfter(DB* db) {
+    return expected_state_manager_->SaveAtAndAfter(db);
+  }
+
   // Requires external locking covering all keys in `cf`.
   void ClearColumnFamily(int cf) {
     return expected_state_manager_->ClearColumnFamily(cf);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -309,7 +309,6 @@ void StressTest::FinishInitDb(SharedState* shared) {
   }
   // TODO(ajkr): First restore if there's already a trace.
   if (FLAGS_sync_fault_injection) {
-    // TODO(ajkr): Also provide an option to explicitly enable tracing history.
     Status s = shared->SaveAtAndAfter(db_);
     if (!s.ok()) {
       fprintf(stderr, "Error enabling history tracing: %s\n",
@@ -2802,7 +2801,6 @@ void StressTest::Reopen(ThreadState* thread) {
   Open();
 
   if (FLAGS_sync_fault_injection) {
-    // TODO(ajkr): Also provide an option to explicitly enable tracing history.
     Status s = thread->shared->SaveAtAndAfter(db_);
     if (!s.ok()) {
       fprintf(stderr, "Error enabling history tracing: %s\n",

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -307,6 +307,16 @@ void StressTest::FinishInitDb(SharedState* shared) {
     fprintf(stdout, "Compaction filter factory: %s\n",
             compaction_filter_factory->Name());
   }
+  // TODO(ajkr): First restore if there's already a trace.
+  if (FLAGS_sync_fault_injection) {
+    // TODO(ajkr): Also provide an option to explicitly enable tracing history.
+    Status s = shared->SaveAtAndAfter(db_);
+    if (!s.ok()) {
+      fprintf(stderr, "Error enabling history tracing: %s\n",
+              s.ToString().c_str());
+      exit(1);
+    }
+  }
 }
 
 bool StressTest::VerifySecondaries() {
@@ -2790,6 +2800,16 @@ void StressTest::Reopen(ThreadState* thread) {
   fprintf(stdout, "%s Reopening database for the %dth time\n",
           clock_->TimeToString(now / 1000000).c_str(), num_times_reopened_);
   Open();
+
+  if (FLAGS_sync_fault_injection) {
+    // TODO(ajkr): Also provide an option to explicitly enable tracing history.
+    Status s = thread->shared->SaveAtAndAfter(db_);
+    if (!s.ok()) {
+      fprintf(stderr, "Error enabling history tracing: %s\n",
+              s.ToString().c_str());
+      exit(1);
+    }
+  }
 }
 
 void StressTest::CheckAndSetOptionsForUserTimestamp() {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -308,7 +308,7 @@ void StressTest::FinishInitDb(SharedState* shared) {
             compaction_filter_factory->Name());
   }
   // TODO(ajkr): First restore if there's already a trace.
-  if (FLAGS_sync_fault_injection) {
+  if (FLAGS_sync_fault_injection && IsStateTracked()) {
     Status s = shared->SaveAtAndAfter(db_);
     if (!s.ok()) {
       fprintf(stderr, "Error enabling history tracing: %s\n",
@@ -2800,7 +2800,7 @@ void StressTest::Reopen(ThreadState* thread) {
           clock_->TimeToString(now / 1000000).c_str(), num_times_reopened_);
   Open();
 
-  if (FLAGS_sync_fault_injection) {
+  if (FLAGS_sync_fault_injection && IsStateTracked()) {
     Status s = thread->shared->SaveAtAndAfter(db_);
     if (!s.ok()) {
       fprintf(stderr, "Error enabling history tracing: %s\n",

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -65,6 +65,9 @@ class StressTest {
 
   virtual bool ShouldAcquireMutexOnKey() const { return false; }
 
+  // Returns true if DB state is tracked by the stress test.
+  virtual bool IsStateTracked() const = 0;
+
   virtual std::vector<int> GenerateColumnFamilies(
       const int /* num_column_families */, int rand_column_family) const {
     return {rand_column_family};

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -386,10 +386,6 @@ Status AnonExpectedStateManager::Open() {
   return latest_->Open(true /* create */);
 }
 
-Status AnonExpectedStateManager::SaveAtAndAfter(DB* /* db */) {
-  return Status::NotSupported();
-}
-
 }  // namespace ROCKSDB_NAMESPACE
 
 #endif  // GFLAGS

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -311,8 +311,6 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
   return s;
 }
 
-Status FileExpectedStateManager::Restore(DB* /* db */) { return Status::OK(); }
-
 Status FileExpectedStateManager::Clean() {
   std::vector<std::string> expected_state_dir_children;
   Status s = Env::Default()->GetChildren(expected_state_dir_path_,
@@ -381,10 +379,6 @@ Status AnonExpectedStateManager::Open() {
 }
 
 Status AnonExpectedStateManager::SaveAtAndAfter(DB* /* db */) {
-  return Status::NotSupported();
-}
-
-Status AnonExpectedStateManager::Restore(DB* /* db */) {
   return Status::NotSupported();
 }
 

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -298,13 +298,15 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
   // delete after successfully saving new files, so old files will never be used
   // again, even if we crash.
   if (s.ok()) {
-    if (old_saved_seqno != saved_seqno_) {
+    if (old_saved_seqno != kMaxSequenceNumber &&
+        old_saved_seqno != saved_seqno_) {
       s = Env::Default()->DeleteFile(
           GetPathForFilename(ToString(old_saved_seqno) + kStateFilenameSuffix));
     }
   }
   if (s.ok()) {
-    if (old_saved_seqno != saved_seqno_) {
+    if (old_saved_seqno != kMaxSequenceNumber &&
+        old_saved_seqno != saved_seqno_) {
       s = Env::Default()->DeleteFile(
           GetPathForFilename(ToString(old_saved_seqno) + kTraceFilenameSuffix));
     }

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -300,19 +300,15 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
   // Delete old state/trace files. Deletion order does not matter since we only
   // delete after successfully saving new files, so old files will never be used
   // again, even if we crash.
-  if (s.ok()) {
-    if (old_saved_seqno != kMaxSequenceNumber &&
-        old_saved_seqno != saved_seqno_) {
-      s = Env::Default()->DeleteFile(
-          GetPathForFilename(ToString(old_saved_seqno) + kStateFilenameSuffix));
-    }
+  if (s.ok() && old_saved_seqno != kMaxSequenceNumber &&
+      old_saved_seqno != saved_seqno_) {
+    s = Env::Default()->DeleteFile(
+        GetPathForFilename(ToString(old_saved_seqno) + kStateFilenameSuffix));
   }
-  if (s.ok()) {
-    if (old_saved_seqno != kMaxSequenceNumber &&
-        old_saved_seqno != saved_seqno_) {
-      s = Env::Default()->DeleteFile(
-          GetPathForFilename(ToString(old_saved_seqno) + kTraceFilenameSuffix));
-    }
+  if (s.ok() && old_saved_seqno != kMaxSequenceNumber &&
+      old_saved_seqno != saved_seqno_) {
+    s = Env::Default()->DeleteFile(
+        GetPathForFilename(ToString(old_saved_seqno) + kTraceFilenameSuffix));
   }
   return s;
 }

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -311,7 +311,7 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
   }
   return s;
 }
-#else  // ROCKSDB_LITE
+#else   // ROCKSDB_LITE
 Status FileExpectedStateManager::SaveAtAndAfter(DB* /* db */) {
   return Status::NotSupported();
 }

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -297,13 +297,13 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
   // delete after successfully saving new files, so old files will never be used
   // again, even if we crash.
   if (s.ok()) {
-    if (old_saved_seqno != kMaxSequenceNumber) {
+    if (old_saved_seqno != saved_seqno_) {
       s = Env::Default()->DeleteFile(
           GetPathForFilename(ToString(old_saved_seqno) + kStateFilenameSuffix));
     }
   }
   if (s.ok()) {
-    if (old_saved_seqno != kMaxSequenceNumber) {
+    if (old_saved_seqno != saved_seqno_) {
       s = Env::Default()->DeleteFile(
           GetPathForFilename(ToString(old_saved_seqno) + kTraceFilenameSuffix));
     }

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -196,6 +196,12 @@ Status FileExpectedStateManager::Open() {
   return s;
 }
 
+Status FileExpectedStateManager::SaveAtAndAfter(DB* /* db */) {
+  return Status::OK();
+}
+
+Status FileExpectedStateManager::Restore(DB* /* db */) { return Status::OK(); }
+
 Status FileExpectedStateManager::Clean() {
   // An incomplete `Open()` could have left behind an invalid temporary file.
   std::string temp_path = GetTempPathForFilename(kLatestFilename);
@@ -237,6 +243,14 @@ AnonExpectedStateManager::AnonExpectedStateManager(size_t max_key,
 Status AnonExpectedStateManager::Open() {
   latest_.reset(new AnonExpectedState(max_key_, num_column_families_));
   return latest_->Open(true /* create */);
+}
+
+Status AnonExpectedStateManager::SaveAtAndAfter(DB* /* db */) {
+  return Status::NotSupported();
+}
+
+Status AnonExpectedStateManager::Restore(DB* /* db */) {
+  return Status::NotSupported();
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -287,7 +287,10 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
   // tempfile.
   std::unique_ptr<TraceWriter> trace_writer;
   if (s.ok()) {
-    s = NewFileTraceWriter(Env::Default(), EnvOptions(), trace_file_path,
+    EnvOptions soptions;
+    // Disable buffering so traces will not get stuck in application buffer.
+    soptions.writable_file_max_buffer_size = 0;
+    s = NewFileTraceWriter(Env::Default(), soptions, trace_file_path,
                            &trace_writer);
   }
   if (s.ok()) {

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -250,6 +250,7 @@ Status FileExpectedStateManager::Open() {
   return s;
 }
 
+#ifndef ROCKSDB_LITE
 Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
   SequenceNumber seqno = db->GetLatestSequenceNumber();
 
@@ -310,6 +311,11 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
   }
   return s;
 }
+#else  // ROCKSDB_LITE
+Status FileExpectedStateManager::SaveAtAndAfter(DB* /* db */) {
+  return Status::NotSupported();
+}
+#endif  // ROCKSDB_LITE
 
 Status FileExpectedStateManager::Clean() {
   std::vector<std::string> expected_state_dir_children;

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -12,8 +12,10 @@
 #include <atomic>
 #include <memory>
 
+#include "rocksdb/db.h"
 #include "rocksdb/env.h"
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/types.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -126,6 +128,24 @@ class ExpectedStateManager {
   // member function.
   virtual Status Open() = 0;
 
+  // Saves expected values for the current state of `db` and begins tracking
+  // changes. Following a successful `SaveAtAndAfter()`, `Restore()` can be
+  // called on the same DB, as long as its state does not roll back to before
+  // its current state.
+  //
+  // Requires external locking preventing concurrent execution with any other
+  // member function. Furthermore, `db` must not be mutated while this function
+  // is executing.
+  virtual Status SaveAtAndAfter(DB* db) = 0;
+
+  // Restores expected values according to the current state of `db`. See
+  // `SaveAtAndAfter()` for conditions where this can be called.
+  //
+  // Requires external locking preventing concurrent execution with any other
+  // member function. Furthermore, `db` must not be mutated while this function
+  // is executing.
+  virtual Status Restore(DB* db) = 0;
+
   // Requires external locking covering all keys in `cf`.
   void ClearColumnFamily(int cf) { return latest_->ClearColumnFamily(cf); }
 
@@ -186,6 +206,22 @@ class FileExpectedStateManager : public ExpectedStateManager {
   // member function.
   Status Open() override;
 
+  // See `ExpectedStateManager::SaveAtAndAfter()` API doc.
+  //
+  // This implementation makes a copy of "LATEST.state" into
+  // "<current seqno>.state", and starts a trace in "<current seqno>.trace".
+  // Due to using external files, a following `Restore()` can happen even
+  // from a different process.
+  Status SaveAtAndAfter(DB* db) override;
+
+  // See `ExpectedStateManager::Restore()` API doc.
+  //
+  // Say `db->GetLatestSequenceNumber()` was `a` last time `SaveAtAndAfter()`
+  // was called and now it is `b`. Then this function replays `b - a` write
+  // operations from "`a`.trace" onto "`a`.state", and then copies the resulting
+  // file into "LATEST.state".
+  Status Restore(DB* db) override;
+
  private:
   // Requires external locking preventing concurrent execution with any other
   // member function.
@@ -204,6 +240,18 @@ class FileExpectedStateManager : public ExpectedStateManager {
 class AnonExpectedStateManager : public ExpectedStateManager {
  public:
   explicit AnonExpectedStateManager(size_t max_key, size_t num_column_families);
+
+  // See `ExpectedStateManager::SaveAtAndAfter()` API doc.
+  //
+  // This implementation returns `Status::NotSupported` since we do not
+  // currently have a need to keep history of expected state within a process.
+  Status SaveAtAndAfter(DB* db) override;
+
+  // See `ExpectedStateManager::Restore()` API doc.
+  //
+  // This implementation returns `Status::NotSupported` since we do not
+  // currently have a need to keep history of expected state within a process.
+  Status Restore(DB* db) override;
 
   // Requires external locking preventing concurrent execution with any other
   // member function.

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <memory>
 
+#include "db/dbformat.h"
 #include "file/file_util.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
@@ -240,6 +241,7 @@ class FileExpectedStateManager : public ExpectedStateManager {
   static const std::string kTempFilenameSuffix;
 
   const std::string expected_state_dir_path_;
+  SequenceNumber saved_seqno_ = kMaxSequenceNumber;
 };
 
 // An `AnonExpectedStateManager` implements an `ExpectedStateManager` backed by

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -234,7 +234,9 @@ class AnonExpectedStateManager : public ExpectedStateManager {
   //
   // This implementation returns `Status::NotSupported` since we do not
   // currently have a need to keep history of expected state within a process.
-  Status SaveAtAndAfter(DB* db) override;
+  Status SaveAtAndAfter(DB* /* db */) override {
+    return Status::NotSupported();
+  }
 
   // Requires external locking preventing concurrent execution with any other
   // member function.

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -12,10 +12,13 @@
 #include <atomic>
 #include <memory>
 
+#include "file/file_util.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
+#include "rocksdb/file_system.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/types.h"
+#include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -230,7 +233,9 @@ class FileExpectedStateManager : public ExpectedStateManager {
   std::string GetTempPathForFilename(const std::string& filename);
   std::string GetPathForFilename(const std::string& filename);
 
-  static const std::string kLatestFilename;
+  static const std::string kLatestBasename;
+  static const std::string kStateFilenameSuffix;
+  static const std::string kTraceFilenameSuffix;
   static const std::string kTempFilenamePrefix;
   static const std::string kTempFilenameSuffix;
 

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -133,22 +133,12 @@ class ExpectedStateManager {
   virtual Status Open() = 0;
 
   // Saves expected values for the current state of `db` and begins tracking
-  // changes. Following a successful `SaveAtAndAfter()`, `Restore()` can be
-  // called on the same DB, as long as its state does not roll back to before
-  // its current state.
+  // changes.
   //
   // Requires external locking preventing concurrent execution with any other
   // member function. Furthermore, `db` must not be mutated while this function
   // is executing.
   virtual Status SaveAtAndAfter(DB* db) = 0;
-
-  // Restores expected values according to the current state of `db`. See
-  // `SaveAtAndAfter()` for conditions where this can be called.
-  //
-  // Requires external locking preventing concurrent execution with any other
-  // member function. Furthermore, `db` must not be mutated while this function
-  // is executing.
-  virtual Status Restore(DB* db) = 0;
 
   // Requires external locking covering all keys in `cf`.
   void ClearColumnFamily(int cf) { return latest_->ClearColumnFamily(cf); }
@@ -214,17 +204,7 @@ class FileExpectedStateManager : public ExpectedStateManager {
   //
   // This implementation makes a copy of "LATEST.state" into
   // "<current seqno>.state", and starts a trace in "<current seqno>.trace".
-  // Due to using external files, a following `Restore()` can happen even
-  // from a different process.
   Status SaveAtAndAfter(DB* db) override;
-
-  // See `ExpectedStateManager::Restore()` API doc.
-  //
-  // Say `db->GetLatestSequenceNumber()` was `a` last time `SaveAtAndAfter()`
-  // was called and now it is `b`. Then this function replays `b - a` write
-  // operations from "`a`.trace" onto "`a`.state", and then copies the resulting
-  // file into "LATEST.state".
-  Status Restore(DB* db) override;
 
  private:
   // Requires external locking preventing concurrent execution with any other
@@ -255,12 +235,6 @@ class AnonExpectedStateManager : public ExpectedStateManager {
   // This implementation returns `Status::NotSupported` since we do not
   // currently have a need to keep history of expected state within a process.
   Status SaveAtAndAfter(DB* db) override;
-
-  // See `ExpectedStateManager::Restore()` API doc.
-  //
-  // This implementation returns `Status::NotSupported` since we do not
-  // currently have a need to keep history of expected state within a process.
-  Status Restore(DB* db) override;
 
   // Requires external locking preventing concurrent execution with any other
   // member function.

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -231,6 +231,8 @@ class FileExpectedStateManager : public ExpectedStateManager {
   std::string GetPathForFilename(const std::string& filename);
 
   static const std::string kLatestFilename;
+  static const std::string kTempFilenamePrefix;
+  static const std::string kTempFilenameSuffix;
 
   const std::string expected_state_dir_path_;
 };

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -179,6 +179,8 @@ class NonBatchedOpsStressTest : public StressTest {
 
   bool ShouldAcquireMutexOnKey() const override { return true; }
 
+  bool IsStateTracked() const override { return true; }
+
   Status TestGet(ThreadState* thread, const ReadOptions& read_opts,
                  const std::vector<int>& rand_column_families,
                  const std::vector<int64_t>& rand_keys) override {


### PR DESCRIPTION
When `--sync_fault_injection` is set, this PR takes a snapshot of the expected values and starts an operation trace when the DB is opened. These files are stored in `--expected_values_dir`. They will be used for recovering the expected state of the DB following a crash where a suffix of unsynced operations are allowed to be lost.

Test Plan: injected crashed at various points in `FileExpectedStateManager` and verified the next run recovers the state/trace file with highest seqno and removes all older/temporary files. Note we don't use sync_fault_injection in CI crash tests yet.