### PR TITLE
db_stress verify with lost unsynced operations

### DIFF
--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -225,7 +225,7 @@ size_t GenerateValue(uint32_t rand, char* v, size_t max_sz) {
       ((rand % kRandomValueMaxFactor) + 1) * FLAGS_value_size_mult;
   assert(value_sz <= max_sz && value_sz >= sizeof(uint32_t));
   (void)max_sz;
-  *((uint32_t*)v) = rand;
+  PutUnaligned(reinterpret_cast<uint32_t*>(v), rand);
   for (size_t i = sizeof(uint32_t); i < value_sz; i++) {
     v[i] = (char)(rand ^ i);
   }
@@ -235,7 +235,9 @@ size_t GenerateValue(uint32_t rand, char* v, size_t max_sz) {
 
 uint32_t GetValueBase(Slice s) {
   assert(s.size() >= sizeof(uint32_t));
-  return *((uint32_t*)s.data());
+  uint32_t res;
+  GetUnaligned(reinterpret_cast<const uint32_t*>(s.data()), &res);
+  return res;
 }
 
 std::string NowNanosStr() {

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -233,6 +233,11 @@ size_t GenerateValue(uint32_t rand, char* v, size_t max_sz) {
   return value_sz;  // the size of the value set.
 }
 
+uint32_t GetValueBase(Slice s) {
+  assert(s.size() >= sizeof(uint32_t));
+  return *((uint32_t*)s.data());
+}
+
 std::string NowNanosStr() {
   uint64_t t = db_stress_env->NowNanos();
   std::string ret;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -567,6 +567,7 @@ extern std::vector<int64_t> GenerateNKeys(ThreadState* thread, int num_keys,
                                           uint64_t iteration);
 
 extern size_t GenerateValue(uint32_t rand, char* v, size_t max_sz);
+extern uint32_t GetValueBase(Slice s);
 
 extern StressTest* CreateCfConsistencyStressTest();
 extern StressTest* CreateBatchedOpsStressTest();

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -818,7 +818,7 @@ DEFINE_bool(sync_fault_injection, false,
             "and unsynced data in DB will lost after crash. In such a case we "
             "track DB changes in a trace file (\"*.trace\") in "
             "--expected_values_dir for verifying there are no holes in the "
-            "recovered data (future work).");
+            "recovered data.");
 
 DEFINE_bool(best_efforts_recovery, false,
             "If true, use best efforts recovery.");

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -254,6 +254,14 @@ class SharedState {
     return expected_state_manager_->SaveAtAndAfter(db);
   }
 
+  bool HasHistory() {
+    return expected_state_manager_->HasHistory();
+  }
+
+  Status Restore(DB* db) {
+    return expected_state_manager_->Restore(db);
+  }
+
   // Requires external locking covering all keys in `cf`.
   void ClearColumnFamily(int cf) {
     return expected_state_manager_->ClearColumnFamily(cf);

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -254,13 +254,9 @@ class SharedState {
     return expected_state_manager_->SaveAtAndAfter(db);
   }
 
-  bool HasHistory() {
-    return expected_state_manager_->HasHistory();
-  }
+  bool HasHistory() { return expected_state_manager_->HasHistory(); }
 
-  Status Restore(DB* db) {
-    return expected_state_manager_->Restore(db);
-  }
+  Status Restore(DB* db) { return expected_state_manager_->Restore(db); }
 
   // Requires external locking covering all keys in `cf`.
   void ClearColumnFamily(int cf) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -307,7 +307,20 @@ void StressTest::FinishInitDb(SharedState* shared) {
     fprintf(stdout, "Compaction filter factory: %s\n",
             compaction_filter_factory->Name());
   }
-  // TODO(ajkr): First restore if there's already a trace.
+
+  if (shared->HasHistory()) {
+    // The way it works right now is, if there's any history, that means the
+    // previous run mutating the DB had all its operations traced, in which case
+    // we should always be able to `Restore()` the expected values to match the
+    // `db_`'s current seqno.
+    Status s = shared->Restore(db_);
+    if (!s.ok()) {
+      fprintf(stderr, "Error restoring historical expected values: %s\n",
+              s.ToString().c_str());
+      exit(1);
+    }
+  }
+
   if (FLAGS_sync_fault_injection && IsStateTracked()) {
     Status s = shared->SaveAtAndAfter(db_);
     if (!s.ok()) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -308,7 +308,7 @@ void StressTest::FinishInitDb(SharedState* shared) {
             compaction_filter_factory->Name());
   }
 
-  if (shared->HasHistory()) {
+  if (shared->HasHistory() && IsStateTracked()) {
     // The way it works right now is, if there's any history, that means the
     // previous run mutating the DB had all its operations traced, in which case
     // we should always be able to `Restore()` the expected values to match the

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -593,12 +593,6 @@ Status AnonExpectedStateManager::Open() {
   return latest_->Open(true /* create */);
 }
 
-bool AnonExpectedStateManager::HasHistory() { return false; }
-
-Status AnonExpectedStateManager::Restore(DB* /* db */) {
-  return Status::NotSupported();
-}
-
 }  // namespace ROCKSDB_NAMESPACE
 
 #endif  // GFLAGS

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -7,6 +7,7 @@
 
 #include "db_stress_tool/expected_state.h"
 
+#include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_shared_state.h"
 #include "rocksdb/trace_reader_writer.h"
 #include "rocksdb/trace_record_result.h"
@@ -326,20 +327,20 @@ bool FileExpectedStateManager::HasHistory() {
 Status FileExpectedStateManager::Restore(DB* db) {
   // An `ExpectedStateTraceRecordHandler` applies a configurable number of
   // write operation trace records to the configured expected state.
-  class ExpectedStateTraceRecordHandler : public TraceRecord::Handler {
+  class ExpectedStateTraceRecordHandler : public TraceRecord::Handler,
+                                          public WriteBatch::Handler {
    public:
     ExpectedStateTraceRecordHandler(uint64_t max_write_ops,
                                     ExpectedState* state)
         : max_write_ops_(max_write_ops), state_(state) {}
 
-    Status Handle(const WriteQueryTraceRecord& /* record */,
+    Status Handle(const WriteQueryTraceRecord& record,
                   std::unique_ptr<TraceRecordResult>* /* result */) override {
       if (num_write_ops_ == max_write_ops_) {
         return Status::OK();
       }
-
-      num_write_ops_++;
-      return Status::OK();
+      WriteBatch batch(record.GetWriteBatchRep().ToString());
+      return batch.Iterate(this);
     }
 
     // Ignore reads.
@@ -358,6 +359,65 @@ Status FileExpectedStateManager::Restore(DB* db) {
     Status Handle(const MultiGetQueryTraceRecord& /* record */,
                   std::unique_ptr<TraceRecordResult>* /* result */) override {
       return Status::OK();
+    }
+
+    // Below are the WriteBatch::Handler overrides. We could use a separate
+    // object, but it's convenient and works to share state with the
+    // `TraceRecord::Handler`.
+
+    Status PutCF(uint32_t column_family_id, const Slice& key,
+                 const Slice& value) override {
+      uint64_t key_id;
+      if (!GetIntVal(key.ToString(), &key_id)) {
+        return Status::Corruption("unable to parse key", key.ToString());
+      }
+      uint32_t value_id = GetValueBase(value);
+
+      state_->Put(column_family_id, static_cast<int64_t>(key_id), value_id,
+                  false /* pending */);
+      ++num_write_ops_;
+      return Status::OK();
+    }
+
+    Status DeleteCF(uint32_t column_family_id, const Slice& key) override {
+      uint64_t key_id;
+      if (!GetIntVal(key.ToString(), &key_id)) {
+        return Status::Corruption("unable to parse key", key.ToString());
+      }
+
+      state_->Delete(column_family_id, static_cast<int64_t>(key_id),
+                     false /* pending */);
+      ++num_write_ops_;
+      return Status::OK();
+    }
+
+    Status SingleDeleteCF(uint32_t column_family_id,
+                          const Slice& key) override {
+      return DeleteCF(column_family_id, key);
+    }
+
+    Status DeleteRangeCF(uint32_t column_family_id, const Slice& begin_key,
+                         const Slice& end_key) override {
+      uint64_t begin_key_id, end_key_id;
+      if (!GetIntVal(begin_key.ToString(), &begin_key_id)) {
+        return Status::Corruption("unable to parse begin key",
+                                  begin_key.ToString());
+      }
+      if (!GetIntVal(end_key.ToString(), &end_key_id)) {
+        return Status::Corruption("unable to parse end key",
+                                  end_key.ToString());
+      }
+
+      state_->DeleteRange(column_family_id, static_cast<int64_t>(begin_key_id),
+                          static_cast<int64_t>(end_key_id),
+                          false /* pending */);
+      ++num_write_ops_;
+      return Status::OK();
+    }
+
+    Status MergeCF(uint32_t column_family_id, const Slice& key,
+                   const Slice& value) override {
+      return PutCF(column_family_id, key, value);
     }
 
    private:

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -502,8 +502,8 @@ Status FileExpectedStateManager::Restore(DB* db) {
                                           nullptr /* dbg */);
   }
   if (s.ok()) {
-    latest_.reset(new FileExpectedState(latest_file_path,
-                                        max_key_, num_column_families_));
+    latest_.reset(new FileExpectedState(latest_file_path, max_key_,
+                                        num_column_families_));
     s = latest_->Open(false /* create */);
   }
 
@@ -587,9 +587,7 @@ Status AnonExpectedStateManager::Open() {
   return latest_->Open(true /* create */);
 }
 
-bool AnonExpectedStateManager::HasHistory() {
-  return false;
-}
+bool AnonExpectedStateManager::HasHistory() { return false; }
 
 Status AnonExpectedStateManager::Restore(DB* /* db */) {
   return Status::NotSupported();

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -324,6 +324,7 @@ bool FileExpectedStateManager::HasHistory() {
   return saved_seqno_ != kMaxSequenceNumber;
 }
 
+#ifndef ROCKSDB_LITE
 Status FileExpectedStateManager::Restore(DB* db) {
   // An `ExpectedStateTraceRecordHandler` applies a configurable number of
   // write operation trace records to the configured expected state.
@@ -519,6 +520,11 @@ Status FileExpectedStateManager::Restore(DB* db) {
   }
   return s;
 }
+#else   // ROCKSDB_LITE
+Status FileExpectedStateManager::Restore(DB* /* db */) {
+  return Status::NotSupported();
+}
+#endif  // ROCKSDB_LITE
 
 Status FileExpectedStateManager::Clean() {
   std::vector<std::string> expected_state_dir_children;

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -333,8 +333,7 @@ bool FileExpectedStateManager::HasHistory() {
 class ExpectedStateTraceRecordHandler : public TraceRecord::Handler,
                                         public WriteBatch::Handler {
  public:
-  ExpectedStateTraceRecordHandler(uint64_t max_write_ops,
-                                  ExpectedState* state)
+  ExpectedStateTraceRecordHandler(uint64_t max_write_ops, ExpectedState* state)
       : max_write_ops_(max_write_ops), state_(state) {}
 
   ~ExpectedStateTraceRecordHandler() {
@@ -398,8 +397,7 @@ class ExpectedStateTraceRecordHandler : public TraceRecord::Handler,
     return Status::OK();
   }
 
-  Status SingleDeleteCF(uint32_t column_family_id,
-                        const Slice& key) override {
+  Status SingleDeleteCF(uint32_t column_family_id, const Slice& key) override {
     return DeleteCF(column_family_id, key);
   }
 
@@ -411,13 +409,11 @@ class ExpectedStateTraceRecordHandler : public TraceRecord::Handler,
                                 begin_key.ToString());
     }
     if (!GetIntVal(end_key.ToString(), &end_key_id)) {
-      return Status::Corruption("unable to parse end key",
-                                end_key.ToString());
+      return Status::Corruption("unable to parse end key", end_key.ToString());
     }
 
     state_->DeleteRange(column_family_id, static_cast<int64_t>(begin_key_id),
-                        static_cast<int64_t>(end_key_id),
-                        false /* pending */);
+                        static_cast<int64_t>(end_key_id), false /* pending */);
     ++num_write_ops_;
     return Status::OK();
   }

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -318,6 +318,10 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* /* db */) {
 }
 #endif  // ROCKSDB_LITE
 
+bool FileExpectedStateManager::HasHistory() {
+  return saved_seqno_ != kMaxSequenceNumber;
+}
+
 Status FileExpectedStateManager::Restore(DB* /* db */) { return Status::OK(); }
 
 Status FileExpectedStateManager::Clean() {
@@ -385,6 +389,10 @@ AnonExpectedStateManager::AnonExpectedStateManager(size_t max_key,
 Status AnonExpectedStateManager::Open() {
   latest_.reset(new AnonExpectedState(max_key_, num_column_families_));
   return latest_->Open(true /* create */);
+}
+
+bool AnonExpectedStateManager::HasHistory() {
+  return false;
 }
 
 Status AnonExpectedStateManager::Restore(DB* /* db */) {

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -318,6 +318,8 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* /* db */) {
 }
 #endif  // ROCKSDB_LITE
 
+Status FileExpectedStateManager::Restore(DB* /* db */) { return Status::OK(); }
+
 Status FileExpectedStateManager::Clean() {
   std::vector<std::string> expected_state_dir_children;
   Status s = Env::Default()->GetChildren(expected_state_dir_path_,
@@ -383,6 +385,10 @@ AnonExpectedStateManager::AnonExpectedStateManager(size_t max_key,
 Status AnonExpectedStateManager::Open() {
   latest_.reset(new AnonExpectedState(max_key_, num_column_families_));
   return latest_->Open(true /* create */);
+}
+
+Status AnonExpectedStateManager::Restore(DB* /* db */) {
+  return Status::NotSupported();
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -133,12 +133,22 @@ class ExpectedStateManager {
   virtual Status Open() = 0;
 
   // Saves expected values for the current state of `db` and begins tracking
-  // changes.
+  // changes. Following a successful `SaveAtAndAfter()`, `Restore()` can be
+  // called on the same DB, as long as its state does not roll back to before
+  // its current state.
   //
   // Requires external locking preventing concurrent execution with any other
   // member function. Furthermore, `db` must not be mutated while this function
   // is executing.
   virtual Status SaveAtAndAfter(DB* db) = 0;
+
+  // Restores expected values according to the current state of `db`. See
+  // `SaveAtAndAfter()` for conditions where this can be called.
+  //
+  // Requires external locking preventing concurrent execution with any other
+  // member function. Furthermore, `db` must not be mutated while this function
+  // is executing.
+  virtual Status Restore(DB* db) = 0;
 
   // Requires external locking covering all keys in `cf`.
   void ClearColumnFamily(int cf) { return latest_->ClearColumnFamily(cf); }
@@ -204,7 +214,17 @@ class FileExpectedStateManager : public ExpectedStateManager {
   //
   // This implementation makes a copy of "LATEST.state" into
   // "<current seqno>.state", and starts a trace in "<current seqno>.trace".
+  // Due to using external files, a following `Restore()` can happen even
+  // from a different process.
   Status SaveAtAndAfter(DB* db) override;
+
+  // See `ExpectedStateManager::Restore()` API doc.
+  //
+  // Say `db->GetLatestSequenceNumber()` was `a` last time `SaveAtAndAfter()`
+  // was called and now it is `b`. Then this function replays `b - a` write
+  // operations from "`a`.trace" onto "`a`.state", and then copies the resulting
+  // file into "LATEST.state".
+  Status Restore(DB* db) override;
 
  private:
   // Requires external locking preventing concurrent execution with any other
@@ -237,6 +257,12 @@ class AnonExpectedStateManager : public ExpectedStateManager {
   Status SaveAtAndAfter(DB* /* db */) override {
     return Status::NotSupported();
   }
+
+  // See `ExpectedStateManager::Restore()` API doc.
+  //
+  // This implementation returns `Status::NotSupported` since we do not
+  // currently have a need to keep history of expected state within a process.
+  Status Restore(DB* db) override;
 
   // Requires external locking preventing concurrent execution with any other
   // member function.

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -269,13 +269,13 @@ class AnonExpectedStateManager : public ExpectedStateManager {
   }
 
   // See `ExpectedStateManager::HasHistory()` API doc.
-  bool HasHistory() override;
+  bool HasHistory() override { return false; }
 
   // See `ExpectedStateManager::Restore()` API doc.
   //
   // This implementation returns `Status::NotSupported` since we do not
   // currently have a need to keep history of expected state within a process.
-  Status Restore(DB* db) override;
+  Status Restore(DB* /* db */) override { return Status::NotSupported(); }
 
   // Requires external locking preventing concurrent execution with any other
   // member function.

--- a/db_stress_tool/expected_state.h
+++ b/db_stress_tool/expected_state.h
@@ -142,6 +142,13 @@ class ExpectedStateManager {
   // is executing.
   virtual Status SaveAtAndAfter(DB* db) = 0;
 
+  // Returns true if at least one state of historical expected values can be
+  // restored.
+  //
+  // Requires external locking preventing concurrent execution with any other
+  // member function.
+  virtual bool HasHistory() = 0;
+
   // Restores expected values according to the current state of `db`. See
   // `SaveAtAndAfter()` for conditions where this can be called.
   //
@@ -218,6 +225,9 @@ class FileExpectedStateManager : public ExpectedStateManager {
   // from a different process.
   Status SaveAtAndAfter(DB* db) override;
 
+  // See `ExpectedStateManager::HasHistory()` API doc.
+  bool HasHistory() override;
+
   // See `ExpectedStateManager::Restore()` API doc.
   //
   // Say `db->GetLatestSequenceNumber()` was `a` last time `SaveAtAndAfter()`
@@ -257,6 +267,9 @@ class AnonExpectedStateManager : public ExpectedStateManager {
   Status SaveAtAndAfter(DB* /* db */) override {
     return Status::NotSupported();
   }
+
+  // See `ExpectedStateManager::HasHistory()` API doc.
+  bool HasHistory() override;
 
   // See `ExpectedStateManager::Restore()` API doc.
   //


### PR DESCRIPTION
When a previous run left behind historical state/trace files (implying it was run with --sync_fault_injection set), this PR uses them to restore the expected state according to the DB's recovered sequence number. That way, a tail of latest unsynced operations are permitted to be dropped, as is the case when data in page cache or certain `Env`s is lost. The point of the verification in this scenario is just to ensure there is no hole in the recovered data.

Test Plan:
- ran it a while, made sure it is restoring expected values using the historical state/trace files:
```
$ rm -rf ./tmp-db/ ./exp/ && mkdir -p ./tmp-db/ ./exp/ && while ./db_stress -compression_type=none -clear_column_family_one_in=0 -expected_values_dir=./exp -sync_fault_injection=1 -destroy_db_initially=0 -db=./tmp-db -max_key=1000000 -ops_per_thread=10000 -reopen=0 -threads=32 ; do : ; done
```