### PR TITLE
Enable SingleDelete with user defined ts in db_bench and crash tests

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2782,12 +2782,6 @@ void StressTest::CheckAndSetOptionsForUserTimestamp() {
             static_cast<int>(cmp->timestamp_size()));
     exit(1);
   }
-  if (FLAGS_nooverwritepercent > 0) {
-    fprintf(stderr,
-            "-nooverwritepercent must be 0 because SingleDelete must be "
-            "disabled.\n");
-    exit(1);
-  }
   if (FLAGS_use_merge || FLAGS_use_full_merge_v1) {
     fprintf(stderr, "Merge does not support timestamp yet.\n");
     exit(1);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -297,8 +297,6 @@ ts_params = {
     "user_timestamp_size": 8,
     "use_merge": 0,
     "use_full_merge_v1": 0,
-    # In order to disable SingleDelete
-    "nooverwritepercent": 0,
     "use_txn": 0,
     "read_only": 0,
     "secondary_catch_up_one_in": 0,


### PR DESCRIPTION
Summary: Enable SingleDelete with user defined timestamp in db_bench,
db_stress and crash test

Test Plan: 1. For db_stress, ran the command for full duration: i) python3 -u tools/db_crashtest.py
--enable_ts whitebox --nooverwritepercent=100
ii) make crash_test_with_ts

2. For db_bench, ran:  ./db_bench -benchmarks=randomreplacekeys
-user_timestamp_size=8 -use_single_deletes=true

Reviewers:

Subscribers:

Tasks:

Tags: