### PR TITLE
Add comments for MultiGetBlob() and checks for MultiRead()

### DIFF
--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -358,10 +358,17 @@ void BlobFileReader::MultiGetBlob(
     const autovector<uint64_t>& value_sizes, autovector<Status*>& statuses,
     autovector<PinnableSlice*>& values, uint64_t* bytes_read) const {
   const size_t num_blobs = user_keys.size();
+  assert(num_blobs > 0);
   assert(num_blobs == offsets.size());
   assert(num_blobs == value_sizes.size());
   assert(num_blobs == statuses.size());
   assert(num_blobs == values.size());
+
+#ifndef NDEBUG
+  for (size_t i = 0; i < offsets.size() - 1; ++i) {
+    assert(offsets[i] <= offsets[i + 1]);
+  }
+#endif  // !NDEBUG
 
   std::vector<FSReadRequest> read_reqs(num_blobs);
   autovector<uint64_t> adjustments;

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -44,6 +44,7 @@ class BlobFileReader {
                  CompressionType compression_type, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
+  // offsets must be sorted in ascending order by caller.
   void MultiGetBlob(
       const ReadOptions& read_options,
       const autovector<std::reference_wrapper<const Slice>>& user_keys,

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -224,6 +224,12 @@ IOStatus RandomAccessFileReader::MultiRead(const IOOptions& opts,
   (void)aligned_buf;  // suppress warning of unused variable in LITE mode
   assert(num_reqs > 0);
 
+#ifndef NDEBUG
+  for (size_t i = 0; i < num_reqs - 1; ++i) {
+    assert(read_reqs[i].offset <= read_reqs[i + 1].offset);
+  }
+#endif  // !NDEBUG
+
   // To be paranoid modify scratch a little bit, so in case underlying
   // FileSystem doesn't fill the buffer but return succee and `scratch` returns
   // contains a previous block, returned value will not pass checksum.


### PR DESCRIPTION
Summary:
Add comments for MultiGetBlob() that input argument `offsets` must be
sorted. In addition, add assertion for this condition in debug build.
Repeat the same for RandomAccessFileReader::MultiRead().

Test Plan:
make check