### PR TITLE
Fix LITE mode builds on MacOs

### DIFF
--- a/db/blob/blob_file_completion_callback.h
+++ b/db/blob/blob_file_completion_callback.h
@@ -22,12 +22,17 @@ class BlobFileCompletionCallback {
       ErrorHandler* error_handler, EventLogger* event_logger,
       const std::vector<std::shared_ptr<EventListener>>& listeners,
       const std::string& dbname)
-      : sst_file_manager_(sst_file_manager),
-        mutex_(mutex),
-        error_handler_(error_handler),
-        event_logger_(event_logger),
-        listeners_(listeners),
-        dbname_(dbname) {}
+      : event_logger_(event_logger), listeners_(listeners), dbname_(dbname) {
+#ifndef ROCKSDB_LITE
+    sst_file_manager_ = sst_file_manager;
+    mutex_ = mutex;
+    error_handler_ = error_handler;
+#else
+    (void)sst_file_manager;
+    (void)mutex;
+    (void)error_handler;
+#endif  // ROCKSDB_LITE
+  }
 
   void OnBlobFileCreationStarted(const std::string& file_name,
                                  const std::string& column_family_name,
@@ -84,9 +89,11 @@ class BlobFileCompletionCallback {
   }
 
  private:
+#ifndef ROCKSDB_LITE
   SstFileManager* sst_file_manager_;
   InstrumentedMutex* mutex_;
   ErrorHandler* error_handler_;
+#endif  // ROCKSDB_LITE
   EventLogger* event_logger_;
   std::vector<std::shared_ptr<EventListener>> listeners_;
   std::string dbname_;


### PR DESCRIPTION
On MacOS, there were errors building in LITE mode related to unused private member variables:

In file included from ./db/compaction/compaction_job.h:20:
./db/blob/blob_file_completion_callback.h:87:19: error: private field ‘sst_file_manager_’ is not used [-Werror,-Wunused-private-field]
  SstFileManager* sst_file_manager_;
                  ^
./db/blob/blob_file_completion_callback.h:88:22: error: private field ‘mutex_’ is not used [-Werror,-Wunused-private-field]
  InstrumentedMutex* mutex_;
                     ^
./db/blob/blob_file_completion_callback.h:89:17: error: private field ‘error_handler_’ is not used [-Werror,-Wunused-private-field]
  ErrorHandler* error_handler_;

This PR resolves those build issues by removing the values as members in LITE mode and fixing the constructor to ignore the input values in LITE mode (otherwise we get unused parameter warnings).

Tested by validating compiles without warnings.