### PR TITLE
Add file operation callbacks to SequentialFileReader

### DIFF
--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1205,7 +1205,6 @@ TEST_F(EventListenerTest, ReadManifestAndWALOnRecovery) {
   }
   DestroyAndReopen(options);
   ASSERT_OK(Put("foo", "aaa"));
-  ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   Close();
 
   size_t seq_reads = listener->file_seq_reads_.load();

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1188,7 +1188,7 @@ TEST_F(EventListenerTest, OnBlobFileOperationTest) {
   }
 }
 
-TEST_F(EventListenerTest, OnWALOperationTest) {
+TEST_F(EventListenerTest, ReadManifestAndWALOnRecovery) {
   Options options;
   options.env = CurrentOptions().env;
   options.create_if_missing = true;
@@ -1205,7 +1205,6 @@ TEST_F(EventListenerTest, OnWALOperationTest) {
   }
   DestroyAndReopen(options);
   ASSERT_OK(Put("foo", "aaa"));
-  ASSERT_OK(dbfull()->Flush(FlushOptions()));
   ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   Close();
 

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1209,7 +1209,7 @@ TEST_F(EventListenerTest, OnWALOperationTest) {
   ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   Close();
 
-  unsigned long seq_reads = listener->file_seq_reads_.load();
+  size_t seq_reads = listener->file_seq_reads_.load();
   Reopen(options);
   ASSERT_GT(listener->file_seq_reads_.load(), seq_reads);
 }

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1000,6 +1000,7 @@ class TestFileOperationListener : public EventListener {
     file_syncs_success_.store(0);
     file_truncates_.store(0);
     file_truncates_success_.store(0);
+    file_seq_reads_.store(0);
     blob_file_reads_.store(0);
     blob_file_writes_.store(0);
     blob_file_flushes_.store(0);
@@ -1012,6 +1013,9 @@ class TestFileOperationListener : public EventListener {
     ++file_reads_;
     if (info.status.ok()) {
       ++file_reads_success_;
+    }
+    if (info.path.find("MANIFEST") != std::string::npos) {
+      ++file_seq_reads_;
     }
     if (EndsWith(info.path, ".blob")) {
       ++blob_file_reads_;
@@ -1088,6 +1092,7 @@ class TestFileOperationListener : public EventListener {
   std::atomic<size_t> file_syncs_success_;
   std::atomic<size_t> file_truncates_;
   std::atomic<size_t> file_truncates_success_;
+  std::atomic<size_t> file_seq_reads_;
   std::atomic<size_t> blob_file_reads_;
   std::atomic<size_t> blob_file_writes_;
   std::atomic<size_t> blob_file_flushes_;
@@ -1181,6 +1186,32 @@ TEST_F(EventListenerTest, OnBlobFileOperationTest) {
   if (true == options.use_direct_io_for_flush_and_compaction) {
     ASSERT_GT(listener->blob_file_truncates_.load(), 0U);
   }
+}
+
+TEST_F(EventListenerTest, OnWALOperationTest) {
+  Options options;
+  options.env = CurrentOptions().env;
+  options.create_if_missing = true;
+
+  TestFileOperationListener* listener = new TestFileOperationListener();
+  options.listeners.emplace_back(listener);
+
+  options.use_direct_io_for_flush_and_compaction = false;
+  Status s = TryReopen(options);
+  if (s.IsInvalidArgument()) {
+    options.use_direct_io_for_flush_and_compaction = false;
+  } else {
+    ASSERT_OK(s);
+  }
+  DestroyAndReopen(options);
+  ASSERT_OK(Put("foo", "aaa"));
+  ASSERT_OK(dbfull()->Flush(FlushOptions()));
+  ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
+  Close();
+
+  unsigned long seq_reads = listener->file_seq_reads_.load();
+  Reopen(options);
+  ASSERT_GT(listener->file_seq_reads_.load(), seq_reads);
 }
 
 class BlobDBJobLevelEventListenerTest : public EventListener {

--- a/db/transaction_log_impl.cc
+++ b/db/transaction_log_impl.cc
@@ -63,8 +63,8 @@ Status TransactionLogIteratorImpl::OpenLogFile(
     }
   }
   if (s.ok()) {
-    file_reader->reset(
-        new SequentialFileReader(std::move(file), fname, io_tracer_));
+    file_reader->reset(new SequentialFileReader(
+        std::move(file), fname, io_tracer_, options_->listeners));
   }
   return s;
 }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4745,9 +4745,9 @@ Status VersionSet::Recover(
     if (!s.ok()) {
       return s;
     }
-    manifest_file_reader.reset(
-        new SequentialFileReader(std::move(manifest_file), manifest_path,
-                                 db_options_->log_readahead_size, io_tracer_));
+    manifest_file_reader.reset(new SequentialFileReader(
+        std::move(manifest_file), manifest_path,
+        db_options_->log_readahead_size, io_tracer_, db_options_->listeners));
   }
   uint64_t current_manifest_file_size = 0;
   uint64_t log_number = 0;
@@ -4917,9 +4917,9 @@ Status VersionSet::TryRecoverFromOneManifest(
     if (!s.ok()) {
       return s;
     }
-    manifest_file_reader.reset(
-        new SequentialFileReader(std::move(manifest_file), manifest_path,
-                                 db_options_->log_readahead_size, io_tracer_));
+    manifest_file_reader.reset(new SequentialFileReader(
+        std::move(manifest_file), manifest_path,
+        db_options_->log_readahead_size, io_tracer_, db_options_->listeners));
   }
 
   assert(s.ok());
@@ -5949,9 +5949,9 @@ Status ReactiveVersionSet::MaybeSwitchManifest(
                              &manifest_file, nullptr);
   std::unique_ptr<SequentialFileReader> manifest_file_reader;
   if (s.ok()) {
-    manifest_file_reader.reset(
-        new SequentialFileReader(std::move(manifest_file), manifest_path,
-                                 db_options_->log_readahead_size, io_tracer_));
+    manifest_file_reader.reset(new SequentialFileReader(
+        std::move(manifest_file), manifest_path,
+        db_options_->log_readahead_size, io_tracer_, db_options_->listeners));
     manifest_reader->reset(new log::FragmentBufferedReader(
         nullptr, std::move(manifest_file_reader), reporter, true /* checksum */,
         0 /* log_number */));

--- a/file/sequence_file_reader.cc
+++ b/file/sequence_file_reader.cc
@@ -47,7 +47,14 @@ IOStatus SequentialFileReader::Read(size_t n, Slice* result, char* scratch) {
     AlignedBuffer buf;
     buf.Alignment(alignment);
     buf.AllocateNewBuffer(size);
+
     Slice tmp;
+    uint64_t orig_offset = 0;
+    FileOperationInfo::StartTimePoint start_ts;
+    if (ShouldNotifyListeners()) {
+      orig_offset = aligned_offset + buf.CurrentSize();
+      start_ts = FileOperationInfo::StartNow();
+    }
     io_s = file_->PositionedRead(aligned_offset, size, IOOptions(), &tmp,
                                  buf.BufferStart(), nullptr);
     if (io_s.ok() && offset_advance < tmp.size()) {
@@ -56,6 +63,11 @@ IOStatus SequentialFileReader::Read(size_t n, Slice* result, char* scratch) {
                    std::min(tmp.size() - offset_advance, n));
     }
     *result = Slice(scratch, r);
+    if (ShouldNotifyListeners()) {
+      auto finish_ts = FileOperationInfo::FinishNow();
+      NotifyOnFileReadFinish(orig_offset, tmp.size(), start_ts, finish_ts,
+                             io_s);
+    }
 #endif  // !ROCKSDB_LITE
   } else {
     // To be paranoid, modify scratch a little bit, so in case underlying
@@ -66,7 +78,23 @@ IOStatus SequentialFileReader::Read(size_t n, Slice* result, char* scratch) {
     if (n > 0 && scratch != nullptr) {
       scratch[0]++;
     }
+
+#ifndef ROCKSDB_LITE
+    FileOperationInfo::StartTimePoint start_ts;
+    if (ShouldNotifyListeners()) {
+      start_ts = FileOperationInfo::StartNow();
+    }
+#endif
+
     io_s = file_->Read(n, IOOptions(), result, scratch, nullptr);
+
+#ifndef ROCKSDB_LITE
+    if (ShouldNotifyListeners()) {
+      auto finish_ts = FileOperationInfo::FinishNow();
+      size_t offset = offset_.fetch_add(n);
+      NotifyOnFileReadFinish(offset, result->size(), start_ts, finish_ts, io_s);
+    }
+#endif
   }
   IOSTATS_ADD(bytes_read, result->size());
   return io_s;

--- a/file/sequence_file_reader.cc
+++ b/file/sequence_file_reader.cc
@@ -91,7 +91,7 @@ IOStatus SequentialFileReader::Read(size_t n, Slice* result, char* scratch) {
 #ifndef ROCKSDB_LITE
     if (ShouldNotifyListeners()) {
       auto finish_ts = FileOperationInfo::FinishNow();
-      size_t offset = offset_.fetch_add(n);
+      size_t offset = offset_.fetch_add(result->size());
       NotifyOnFileReadFinish(offset, result->size(), start_ts, finish_ts, io_s);
     }
 #endif


### PR DESCRIPTION
Summary:
This change adds File IO Notifications to the SequentialFileReader The SequentialFileReader is extended
with a listener parameter.

Test Plan:
A new test EventListenerTest::OnWALOperationTest has been added. The
test verifies that during restore the sequential file reader is called
and the notifications are fired.

Reviewers:
yanqin, rmanji

Subscribers:

Tasks:
T75121251

Tags: