### PR TITLE
Remove IOSTATS_ADD_IF_POSITIVE()

### DIFF
--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -181,7 +181,7 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
       }
       *result = Slice(res_scratch, io_s.ok() ? pos : 0);
     }
-    IOSTATS_ADD_IF_POSITIVE(bytes_read, result->size());
+    IOSTATS_ADD(bytes_read, result->size());
     SetPerfLevel(prev_perf_level);
   }
   if (stats_ != nullptr && file_read_hist_ != nullptr) {
@@ -346,7 +346,7 @@ IOStatus RandomAccessFileReader::MultiRead(const IOOptions& opts,
                                start_ts, finish_ts, read_reqs[i].status);
       }
 #endif  // ROCKSDB_LITE
-      IOSTATS_ADD_IF_POSITIVE(bytes_read, read_reqs[i].result.size());
+      IOSTATS_ADD(bytes_read, read_reqs[i].result.size());
     }
     SetPerfLevel(prev_perf_level);
   }

--- a/monitoring/iostats_context_imp.h
+++ b/monitoring/iostats_context_imp.h
@@ -15,10 +15,6 @@ extern __thread IOStatsContext iostats_context;
 // increment a specific counter by the specified value
 #define IOSTATS_ADD(metric, value) (iostats_context.metric += value)
 
-// Increase metric value only when it is positive
-#define IOSTATS_ADD_IF_POSITIVE(metric, value)   \
-  if (value > 0) { IOSTATS_ADD(metric, value); }
-
 // reset a specific counter to zero
 #define IOSTATS_RESET(metric) (iostats_context.metric = 0)
 


### PR DESCRIPTION
Summary: IOSTATS_ADD_IF_POSITIVE() seems to be a macro that aims to improve performance but does the opposite. The counter to add is almost always positive so the if is just a waste. Furthermore, adding to a thread local variable seemse to be much cheaper than an if condition if branch prediction has a possibility to be wrong. Remove the macro.

Test Plan: See CI completes.