### PR TITLE
Fix race in WriteBufferManager

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1098,8 +1098,10 @@ class DBImpl : public DB {
     // Called from WriteBufferManager. This function changes the state_
     // to State::RUNNING indicating the stall is cleared and DB can proceed.
     void Signal() override {
-      MutexLock lock(&state_mutex_);
-      state_ = State::RUNNING;
+      {
+        MutexLock lock(&state_mutex_);
+        state_ = State::RUNNING;
+      }
       state_cv_.Signal();
     }
 

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -85,9 +85,7 @@ class WriteBufferManager {
     buffer_size_.store(new_size, std::memory_order_relaxed);
     mutable_limit_.store(new_size * 7 / 8, std::memory_order_relaxed);
     // Check if stall is active and can be ended.
-    if (allow_stall_) {
-      EndWriteStall();
-    }
+    MaybeEndWriteStall();
   }
 
   // Below functions should be called by RocksDB internally.
@@ -118,17 +116,12 @@ class WriteBufferManager {
   // pass allow_stall = true during WriteBufferManager instance creation.
   //
   // Should only be called by RocksDB internally .
-  bool ShouldStall() {
-    if (allow_stall_ && enabled()) {
-      if (IsStallActive()) {
-        return true;
-      }
-      if (IsStallThresholdExceeded()) {
-        stall_active_.store(true, std::memory_order_relaxed);
-        return true;
-      }
+  bool ShouldStall() const {
+    if (!allow_stall_ || !enabled()) {
+      return false;
     }
-    return false;
+
+    return IsStallActive() || IsStallThresholdExceeded();
   }
 
   // Returns true if stall is active.
@@ -137,7 +130,9 @@ class WriteBufferManager {
   }
 
   // Returns true if stalling condition is met.
-  bool IsStallThresholdExceeded() { return memory_usage() >= buffer_size_; }
+  bool IsStallThresholdExceeded() const {
+    return memory_usage() >= buffer_size_;
+  }
 
   void ReserveMem(size_t mem);
 
@@ -151,8 +146,9 @@ class WriteBufferManager {
   // Should only be called by RocksDB internally.
   void BeginWriteStall(StallInterface* wbm_stall);
 
-  // Remove DB instances from queue and signal them to continue.
-  void EndWriteStall();
+  // If stall conditions have resolved, remove DB instances from queue and
+  // signal them to continue.
+  void MaybeEndWriteStall();
 
   void RemoveDBFromQueue(StallInterface* wbm_stall);
 
@@ -167,9 +163,11 @@ class WriteBufferManager {
   std::mutex cache_rev_mng_mu_;
 
   std::list<StallInterface*> queue_;
-  // Protects the queue_
+  // Protects the queue_ and stall_active_.
   std::mutex mu_;
   bool allow_stall_;
+  // Value should only be changed by BeginWriteStall() and MaybeEndWriteStall()
+  // while holding mu_, but it can be read without a lock.
   std::atomic<bool> stall_active_;
 
   void ReserveMemWithCache(size_t mem);


### PR DESCRIPTION
EndWriteStall has a data race: `queue_.empty()` is checked outside of the
mutex, so once we enter the critical section another thread may already have
cleared the list, and accessing the `front()` is undefined behavior (and causes
interesting crashes under high concurrency).

This PR fixes the bug, and also rewrites the logic to make it easier to reason
about it. It also fixes another subtle bug: if some writers are stalled and
`SetBufferSize(0)` is called, which disables the WBM, the writer are not
unblocked because of an early `enabled()` check in `EndWriteStall()`.

It doesn't significantly change the locking behavior, as before writers won't
lock unless entering a stall condition, and `FreeMem` almost always locks if
stalling is allowed, but that is inevitable with the current design. Liveness is
guaranteed by the fact that if some writes are blocked, eventually all writes
will be blocked due to `stall_active_`, and eventually all memory is freed.

While at it, do a couple of optimizations:

- In `WBMStallInterface::Signal()` signal the CV only after releasing the
  lock. Signaling under the lock is a common pitfall, as it causes the woken-up
  thread to immediately go back to sleep because the mutex is still locked by
  the awaker.

- Move all allocations and deallocations outside of the lock.

Test Plan:
```
USE_CLANG=1 make -j64 all check
```
