### PR TITLE
Initialize cache dumper `DumpUnit` in constructor

### DIFF
--- a/utilities/cache_dump_load_impl.h
+++ b/utilities/cache_dump_load_impl.h
@@ -79,6 +79,8 @@ struct DumpUnit {
   // address of the begin of the block in this string.
   void* value;
 
+  DumpUnit() { reset(); }
+
   void reset() {
     timestamp = 0;
     type = CacheDumpUnitType::kBlockTypeMax;


### PR DESCRIPTION
Should fix clang-analyze:

```
utilities/cache_dump_load_impl.cc:296:38: warning: The left operand of '!=' is a garbage value
  while (io_s.ok() && dump_unit.type != CacheDumpUnitType::kFooter) {
                      ~~~~~~~~~~~~~~ ^
```