### PR TITLE
Add property_bag to FileOptions

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rocksdb/env.h"


### PR DESCRIPTION
Add a property_bag option in FileOptions for direct FileSystem users to pass custom properties to the provider in APIs such as NewRandomAccessFile, NewWritableFile etc. This field will be ignored/not populated by RocksDB.