### PR TITLE
Fix incorrect order of comments in win_thread.cc

### DIFF
--- a/port/win/win_thread.cc
+++ b/port/win/win_thread.cc
@@ -185,5 +185,5 @@ unsigned int __stdcall  WindowsThread::Data::ThreadProc(void* arg) {
 } // namespace port
 }  // namespace ROCKSDB_NAMESPACE
 
-#endif  // OS_WIN
 #endif  // !_POSIX_THREADS
+#endif  // OS_WIN


### PR DESCRIPTION
The comments in the `#endif` section at the end of the file were in the
wrong order.
