### PR TITLE
change FileChecksumGenFactory OptionTypeFlags as never compare

### DIFF
--- a/options/customizable_test.cc
+++ b/options/customizable_test.cc
@@ -1530,8 +1530,8 @@ TEST_F(LoadCustomizableTest, LoadSstPartitionerFactoryTest) {
 
 TEST_F(LoadCustomizableTest, LoadChecksumGenFactoryTest) {
   std::shared_ptr<FileChecksumGenFactory> factory;
-  ASSERT_NOK(FileChecksumGenFactory::CreateFromString(config_options_, "Mock",
-                                                      &factory));
+  ASSERT_OK(FileChecksumGenFactory::CreateFromString(config_options_, "Mock",
+                                                     &factory));
   ASSERT_OK(FileChecksumGenFactory::CreateFromString(
       config_options_, FileChecksumGenCrc32cFactory::kClassName(), &factory));
   ASSERT_NE(factory, nullptr);

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -452,7 +452,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
         {"file_checksum_gen_factory",
          OptionTypeInfo::AsCustomSharedPtr<FileChecksumGenFactory>(
              offsetof(struct ImmutableDBOptions, file_checksum_gen_factory),
-             OptionVerificationType::kByName, OptionTypeFlags::kAllowNull)},
+             OptionVerificationType::kByName,
+             OptionTypeFlags::kAllowNull | OptionTypeFlags::kCompareNever)},
         {"statistics",
          OptionTypeInfo::AsCustomSharedPtr<Statistics>(
              // Statistics should not be compared and can be null

--- a/options/options_parser.cc
+++ b/options/options_parser.cc
@@ -293,7 +293,6 @@ Status RocksDBOptionsParser::Parse(const ConfigOptions& config_options_in,
           config_options.ignore_unknown_options = false;
         }
       }
-
       s = ParseSection(&section, &title, &argument, line, line_num);
       if (!s.ok()) {
         return s;

--- a/util/file_checksum_helper.cc
+++ b/util/file_checksum_helper.cc
@@ -166,6 +166,12 @@ Status FileChecksumGenFactory::CreateFromString(
   } else {
     Status s = LoadSharedObject<FileChecksumGenFactory>(options, value, nullptr,
                                                         result);
+    // This is just a short-term change to handle the unregistered object like
+    // user customized factory. In the long term, other solution is needed.
+    if (!s.ok()) {
+      *result = nullptr;
+      return Status::OK();
+    }
     return s;
   }
 }


### PR DESCRIPTION
Currently, if user provide a shared pointer of an customized FileChecksumGenFactory to DBOptions, we did not register it. Therefore, when CreateFromString is called or when VerifyRocksDBOptionsFromFile which try to load this object form object registry based on the provided name, it will fail. Change the OptionTypeFlags as kCompareNever and also return Status::OK() at its CreateFromString if LoadSharedObject failed (this is only a short-term fix).

Test plan: add new testing case