### PR TITLE
Ignore non-overlapping levels when determinig grandparent files

### DIFF
--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -554,9 +554,10 @@ void CompactionPicker::GetGrandparents(
   InternalKey start, limit;
   GetRange(inputs, output_level_inputs, &start, &limit);
   // Compute the set of grandparent files that overlap this compaction
-  // (parent == level+1; grandparent == level+2)
-  for (int level = output_level_inputs.level + 1;
-       level < vstorage->NumberLevels(); level++) {
+  // (parent == level+1; grandparent == level+2 or the first
+  // level after that has overlapping files)
+  for (int level = output_level_inputs.level + 1; level < NumberLevels();
+       level++) {
     vstorage->GetOverlappingInputs(level, &start, &limit, grandparents);
     if (!grandparents->empty()) {
       break;


### PR DESCRIPTION
Summary:
Right now, when picking a compaction, grand parent files are from output_level + 1. This usually works, but if the level doesn't have any overlapping file, it will be more efficient to go further down. This is because the files are likely to be trivial moved further and might create a violation of max_compaction_bytes. This situation can naturally happen and might happen even more with TTL compactions. There is no harm to fix it.

Test Plan: Run existing tests and see it passes. Also briefly run crash test.