### PR TITLE
Fix stress/crash test handling of SST unique IDs

### DIFF
--- a/db_stress_tool/db_stress_listener.cc
+++ b/db_stress_tool/db_stress_listener.cc
@@ -123,10 +123,15 @@ void UniqueIdVerifier::Verify(const std::string& id) {
 }
 
 void DbStressListener::VerifyTableFileUniqueId(
-    const TableProperties& new_file_properties) {
+    const TableProperties& new_file_properties, const std::string& file_path) {
   // Verify unique ID
   std::string id;
-  GetUniqueIdFromTableProperties(new_file_properties, &id);
+  Status s = GetUniqueIdFromTableProperties(new_file_properties, &id);
+  if (!s.ok()) {
+    fprintf(stderr, "Error getting SST unique id for %s: %s\n",
+            file_path.c_str(), s.ToString().c_str());
+    assert(false);
+  }
   unique_ids_.Verify(id);
 }
 


### PR DESCRIPTION
Summary: Was not handling the case of OnTableFileCreated invoked for
table file NOT created.

Also improved error reporting and caught a missing status check.

Also strengthened the db_stress listener to require file_size > 0 when
status.ok(). We would be violating the API contract if status is OK and
we didn't create a valid SST file.

Test Plan: make blackbox_crash_test for a while