### PR TITLE
[BugFix][RateLimiter] Fix BackupEngine's internal callers of GenericRateLimiter::Request() not honoring bytes <= GetSingleBurstBytes()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,6 +45,7 @@
 * Fixed a bug where stalled writes would remain stalled forever after the user calls `WriteBufferManager::SetBufferSize()` with `new_size == 0` to dynamically disable memory limiting.
 * Make `DB::close()` thread-safe.
 * Fix a bug in atomic flush where one bg flush thread will wait forever for a preceding bg flush thread to commit its result to MANIFEST but encounters an error which is mapped to a soft error (DB not stopped).
+* Fix a bug in `BackupEngine` where some internal callers of `GenericRateLimiter::Request()` do not honor `bytes <= GetSingleBurstBytes()`.
 
 ### New Features
 * Print information about blob files when using "ldb list_live_files_metadata"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 ### Behavior Changes
 * `NUM_FILES_IN_SINGLE_COMPACTION` was only counting the first input level files, now it's including all input files.
 * `TransactionUtil::CheckKeyForConflicts` can also perform conflict-checking based on user-defined timestamps in addition to sequence numbers.
+* Removed `GenericRateLimiter`'s minimum refill bytes per period previously enforced.
 
 ### Public Interface Change
 * When options.ttl is used with leveled compaction with compactinon priority kMinOverlappingRatio, files exceeding half of TTL value will be prioritized more, so that by the time TTL is reached, fewer extra compactions will be scheduled to clear them up. At the same time, when compacting files with data older than half of TTL, output files may be cut off based on those files' boundaries, in order for the early TTL compaction to work properly.

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -302,8 +302,7 @@ int64_t GenericRateLimiter::CalculateRefillBytesPerPeriod(
     // inaccurate but is a number that is large enough.
     return port::kMaxInt64 / 1000000;
   } else {
-    return std::max(kMinRefillBytesPerPeriod,
-                    rate_bytes_per_sec * refill_period_us_ / 1000000);
+    return rate_bytes_per_sec * refill_period_us_ / 1000000;
   }
 }
 

--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -106,8 +106,6 @@ class GenericRateLimiter : public RateLimiter {
   // This mutex guard all internal states
   mutable port::Mutex request_mutex_;
 
-  const int64_t kMinRefillBytesPerPeriod = 100;
-
   const int64_t refill_period_us_;
 
   int64_t rate_bytes_per_sec_;

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -232,7 +232,7 @@ class BackupEngineImpl {
     }
   };
 
-  static void LoopRateLimitRequestHelper(const std::size_t total_bytes_to_request, RateLimiter* rate_limiter, const Env::IOPriority pri, Statistics* stats, RateLimiter::OpType op_type);
+  static void LoopRateLimitRequestHelper(const std::size_t total_bytes_to_request, RateLimiter* rate_limiter, const Env::IOPriority pri, Statistics* stats, const RateLimiter::OpType op_type);
 
   static inline std::string WithoutTrailingSlash(const std::string& path) {
     if (path.empty() || path.back() != '/') {
@@ -2388,7 +2388,7 @@ Status BackupEngineImpl::GetFileDbIdentities(Env* src_env,
   }
 }
 
-void BackupEngineImpl::LoopRateLimitRequestHelper(const std::size_t total_bytes_to_request, RateLimiter* rate_limiter, const Env::IOPriority pri, Statistics* stats, RateLimiter::OpType op_type) {
+void BackupEngineImpl::LoopRateLimitRequestHelper(const std::size_t total_bytes_to_request, RateLimiter* rate_limiter, const Env::IOPriority pri, Statistics* stats, const RateLimiter::OpType op_type) {
   assert(rate_limiter != nullptr);
   std::size_t remaining_bytes = total_bytes_to_request;
   std::size_t request_bytes = 0;

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -2397,8 +2397,6 @@ void BackupEngineImpl::LoopRateLimitRequestHelper(const std::size_t total_bytes_
     rate_limiter->Request(request_bytes, pri, stats, op_type);
     remaining_bytes -= request_bytes;
   }
-  // rate_limiter->Request(total_bytes_to_request, pri, stats, op_type);
-
 }
 
 void BackupEngineImpl::DeleteChildren(const std::string& dir,

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -35,7 +35,9 @@
 #include "logging/logging.h"
 #include "monitoring/iostats_context_imp.h"
 #include "port/port.h"
+#include "rocksdb/env.h"
 #include "rocksdb/rate_limiter.h"
+#include "rocksdb/statistics.h"
 #include "rocksdb/transaction_log.h"
 #include "table/sst_file_dumper.h"
 #include "test_util/sync_point.h"
@@ -233,7 +235,7 @@ class BackupEngineImpl {
   };
 
   static void LoopRateLimitRequestHelper(
-      const std::size_t total_bytes_to_request, RateLimiter* rate_limiter,
+      const size_t total_bytes_to_request, RateLimiter* rate_limiter,
       const Env::IOPriority pri, Statistics* stats,
       const RateLimiter::OpType op_type);
 
@@ -2396,12 +2398,12 @@ Status BackupEngineImpl::GetFileDbIdentities(Env* src_env,
 }
 
 void BackupEngineImpl::LoopRateLimitRequestHelper(
-    const std::size_t total_bytes_to_request, RateLimiter* rate_limiter,
+    const size_t total_bytes_to_request, RateLimiter* rate_limiter,
     const Env::IOPriority pri, Statistics* stats,
     const RateLimiter::OpType op_type) {
   assert(rate_limiter != nullptr);
-  std::size_t remaining_bytes = total_bytes_to_request;
-  std::size_t request_bytes = 0;
+  size_t remaining_bytes = total_bytes_to_request;
+  size_t request_bytes = 0;
   while (remaining_bytes > 0) {
     request_bytes =
         std::min(static_cast<size_t>(rate_limiter->GetSingleBurstBytes()),

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -234,10 +234,11 @@ class BackupEngineImpl {
     }
   };
 
-  static void LoopRateLimitRequestHelper(
-      const size_t total_bytes_to_request, RateLimiter* rate_limiter,
-      const Env::IOPriority pri, Statistics* stats,
-      const RateLimiter::OpType op_type);
+  static void LoopRateLimitRequestHelper(const size_t total_bytes_to_request,
+                                         RateLimiter* rate_limiter,
+                                         const Env::IOPriority pri,
+                                         Statistics* stats,
+                                         const RateLimiter::OpType op_type);
 
   static inline std::string WithoutTrailingSlash(const std::string& path) {
     if (path.empty() || path.back() != '/') {

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2565,7 +2565,7 @@ class BackupEngineRateLimitingTestWithParam
     : public BackupEngineTest,
       public testing::WithParamInterface<
           std::tuple<bool /* make throttle */,
-                     int  /* 0 = single threaded, 1 = multi threaded*/,
+                     int /* 0 = single threaded, 1 = multi threaded*/,
                      std::pair<uint64_t, uint64_t> /* limits */>> {
  public:
   BackupEngineRateLimitingTestWithParam() {}
@@ -2582,8 +2582,8 @@ INSTANTIATE_TEST_CASE_P(
                       std::make_tuple(true, 0, std::make_pair(1 * MB, 5 * MB)),
                       std::make_tuple(true, 0, std::make_pair(2 * MB, 3 * MB)),
                       std::make_tuple(true, 1, std::make_pair(1 * MB, 5 * MB)),
-                      std::make_tuple(true, 1, std::make_pair(2 * MB, 3 * MB)),
-                      std::make_tuple(true, 0, std::make_pair(100, 100))));
+                      std::make_tuple(true, 1, 
+                                      std::make_pair(2 * MB, 3 * MB))));
 
 TEST_P(BackupEngineRateLimitingTestWithParam, RateLimiting) {
   size_t const kMicrosPerSec = 1000 * 1000LL;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2865,6 +2865,8 @@ class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
   int64_t GetBytesPerSecond() const override { return 0; }
 
  private:
+  // This is the key to this MockedRateLimiterWithLowRefillBytesPerPeriod where we don't impose minimum refill_bytes_per_period_ like 
+  // GenericRateLimiter does. Therefore, we can achieve creating a rate limiter with really low refill_bytes_per_period_
   int64_t CalculateRefillBytesPerPeriod(int64_t rate_bytes_per_sec) {
     if (port::kMaxInt64 / rate_bytes_per_sec < refill_period_us_) {
       // Avoid unexpected result in the overflow case. The result now is still
@@ -2885,7 +2887,7 @@ INSTANTIATE_TEST_CASE_P(RateLimiterWithLowRefillBytesPerPeriod,
                         BackupEngineRateLimitingTestWithParam2,
                         ::testing::Values(std::make_tuple(std::make_pair(1,
                                                                          1))));
-
+// To verify we don't request over-sized bytes relative to refill_bytes_per_period_ in each GenericRateLimiter::Request() called in BackupEngine and trigger assertion failure on over-sized request in debug builds
 TEST_P(BackupEngineRateLimitingTestWithParam2,
        RateLimitingWithLowRefillBytesPerPeriod) {
   backupable_options_->max_background_operations = 1;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2831,10 +2831,10 @@ class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
         refill_period_us_(refill_period_us),
         refill_bytes_per_period_(
             CalculateRefillBytesPerPeriod(rate_bytes_per_sec)) {
-              for (int i = Env::IO_LOW; i < Env::IO_TOTAL; ++i) {
-                total_bytes_through_[i] = 0;
-              }
-            }
+    for (int i = Env::IO_LOW; i < Env::IO_TOTAL; ++i) {
+      total_bytes_through_[i] = 0;
+    }
+  }
 
   ~MockedRateLimiterWithLowRefillBytesPerPeriod() override {
     MutexLock g(&request_mutex_);

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2815,12 +2815,13 @@ class BackupEngineRateLimitingTestWithParam2
   BackupEngineRateLimitingTestWithParam2() {}
 };
 
-// A mocked rate limiter where extremly low refill_bytes_per_period_ can be achieved
-// and makes it easier to test whether we trigger the assertion failure on 
-// bytes <= refill_bytes_per_period_ or not when Request() is called in BackupEngine. 
-// It is hard to directly test on GenericRateLimiter since it imposes a lower limit = 100
-// on refill_bytes_per_period_ and it's hard to artificially create a case 
-// where Request() is called with bytes > 100 in BackupEngine
+// A mocked rate limiter where extremly low refill_bytes_per_period_ can be
+// achieved and makes it easier to test whether we trigger the assertion failure
+// on bytes <= refill_bytes_per_period_ or not when Request() is called in
+// BackupEngine. It is hard to directly test on GenericRateLimiter since it
+// imposes a lower limit = 100 on refill_bytes_per_period_ and it's hard to
+// artificially create a case where Request() is called with bytes > 100 in
+// BackupEngine
 class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
  public:
   MockedRateLimiterWithLowRefillBytesPerPeriod(RateLimiter::Mode mode,
@@ -2895,8 +2896,9 @@ INSTANTIATE_TEST_CASE_P(RateLimiterWithLowRefillBytesPerPeriod,
                                                                          1))));
 // To verify we don't request over-sized bytes relative to
 // refill_bytes_per_period_ in each RateLimiter::Request() called in
-// BackupEngine and hence indirectly verify we don't trigger assertion 
-// failure on over-sized request like the one in GenericRateLimiter in debug builds
+// BackupEngine and hence indirectly verify we don't trigger assertion
+// failure on over-sized request like the one in GenericRateLimiter in debug
+// builds
 TEST_P(BackupEngineRateLimitingTestWithParam2,
        RateLimitingWithLowRefillBytesPerPeriod) {
   backupable_options_->max_background_operations = 1;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2865,8 +2865,10 @@ class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
   int64_t GetBytesPerSecond() const override { return 0; }
 
  private:
-  // This is the key to this MockedRateLimiterWithLowRefillBytesPerPeriod where we don't impose minimum refill_bytes_per_period_ like 
-  // GenericRateLimiter does. Therefore, we can achieve creating a rate limiter with really low refill_bytes_per_period_
+  // This is the key to this MockedRateLimiterWithLowRefillBytesPerPeriod where
+  // we don't impose minimum refill_bytes_per_period_ like GenericRateLimiter
+  // does. Therefore, we can achieve creating a rate limiter with really low
+  // refill_bytes_per_period_
   int64_t CalculateRefillBytesPerPeriod(int64_t rate_bytes_per_sec) {
     if (port::kMaxInt64 / rate_bytes_per_sec < refill_period_us_) {
       // Avoid unexpected result in the overflow case. The result now is still
@@ -2887,7 +2889,10 @@ INSTANTIATE_TEST_CASE_P(RateLimiterWithLowRefillBytesPerPeriod,
                         BackupEngineRateLimitingTestWithParam2,
                         ::testing::Values(std::make_tuple(std::make_pair(1,
                                                                          1))));
-// To verify we don't request over-sized bytes relative to refill_bytes_per_period_ in each GenericRateLimiter::Request() called in BackupEngine and trigger assertion failure on over-sized request in debug builds
+// To verify we don't request over-sized bytes relative to
+// refill_bytes_per_period_ in each GenericRateLimiter::Request() called in
+// BackupEngine and trigger assertion failure on over-sized request in debug
+// builds
 TEST_P(BackupEngineRateLimitingTestWithParam2,
        RateLimitingWithLowRefillBytesPerPeriod) {
   backupable_options_->max_background_operations = 1;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2895,11 +2895,15 @@ TEST_P(BackupEngineRateLimitingTestWithParam2,
        RateLimitingWithLowRefillBytesPerPeriod) {
   backupable_options_->max_background_operations = 1;
   const uint64_t backup_rate_limiter_limit = std::get<0>(GetParam()).first;
-  std::shared_ptr<RateLimiter> backup_rate_limiter = std::make_shared<MockedRateLimiterWithLowRefillBytesPerPeriod>(RateLimiter::Mode::kAllIo, backup_rate_limiter_limit, 1000 * 1000);
+  std::shared_ptr<RateLimiter> backup_rate_limiter =
+      std::make_shared<MockedRateLimiterWithLowRefillBytesPerPeriod>(
+          RateLimiter::Mode::kAllIo, backup_rate_limiter_limit, 1000 * 1000);
   backupable_options_->backup_rate_limiter = backup_rate_limiter;
 
   const uint64_t restore_rate_limiter_limit = std::get<0>(GetParam()).second;
-  std::shared_ptr<RateLimiter> restore_rate_limiter = std::make_shared<MockedRateLimiterWithLowRefillBytesPerPeriod>(RateLimiter::Mode::kAllIo, restore_rate_limiter_limit, 1000 * 1000);
+  std::shared_ptr<RateLimiter> restore_rate_limiter =
+      std::make_shared<MockedRateLimiterWithLowRefillBytesPerPeriod>(
+          RateLimiter::Mode::kAllIo, restore_rate_limiter_limit, 1000 * 1000);
   backupable_options_->restore_rate_limiter = restore_rate_limiter;
 
   DestroyDB(dbname_, Options());

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2821,7 +2821,6 @@ class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
                                                int64_t rate_bytes_per_sec,
                                                int64_t refill_period_us)
       : RateLimiter(mode),
-        rate_bytes_per_sec_(rate_bytes_per_sec),
         refill_period_us_(refill_period_us),
         refill_bytes_per_period_(
             CalculateRefillBytesPerPeriod(rate_bytes_per_sec)) {}
@@ -2879,7 +2878,6 @@ class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
     }
   }
 
-  const int64_t rate_bytes_per_sec_;
   const int64_t refill_period_us_;
   std::atomic<int64_t> refill_bytes_per_period_;
   int64_t total_bytes_through_[Env::IO_TOTAL];

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2830,7 +2830,11 @@ class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
       : RateLimiter(mode),
         refill_period_us_(refill_period_us),
         refill_bytes_per_period_(
-            CalculateRefillBytesPerPeriod(rate_bytes_per_sec)) {}
+            CalculateRefillBytesPerPeriod(rate_bytes_per_sec)) {
+              for (int i = Env::IO_LOW; i < Env::IO_TOTAL; ++i) {
+                total_bytes_through_[i] = 0;
+              }
+            }
 
   ~MockedRateLimiterWithLowRefillBytesPerPeriod() override {
     MutexLock g(&request_mutex_);

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2815,11 +2815,12 @@ class BackupEngineRateLimitingTestWithParam2
   BackupEngineRateLimitingTestWithParam2() {}
 };
 
-// A mocked rate limiter where extremly low refill_bytes_per_period_ can be
-// achieved and makes it easier to test whether we trigger the assertion failure
+// A mocked rate limiter where extremly low refill_bytes_per_period_ is achievable
+// and makes it easier to test whether we trigger the assertion failure
 // on bytes <= refill_bytes_per_period_ or not when Request() is called in
-// BackupEngine. It is hard to directly test on GenericRateLimiter since it
-// imposes a lower limit = 100 on refill_bytes_per_period_ and it's hard to
+// BackupEngine. 
+// It is hard to directly test on GenericRateLimiter since it
+// imposes a low bound = 100 on refill_bytes_per_period_ and it's hard to
 // artificially create a case where Request() is called with bytes > 100 in
 // BackupEngine
 class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2815,11 +2815,10 @@ class BackupEngineRateLimitingTestWithParam2
   BackupEngineRateLimitingTestWithParam2() {}
 };
 
-// A mocked rate limiter where extremly low refill_bytes_per_period_ is achievable
-// and makes it easier to test whether we trigger the assertion failure
-// on bytes <= refill_bytes_per_period_ or not when Request() is called in
-// BackupEngine. 
-// It is hard to directly test on GenericRateLimiter since it
+// A mocked rate limiter where extremly low refill_bytes_per_period_ is
+// achievable and makes it easier to test whether we trigger the assertion
+// failure on bytes <= refill_bytes_per_period_ or not when Request() is called
+// in BackupEngine. It is hard to directly test on GenericRateLimiter since it
 // imposes a low bound = 100 on refill_bytes_per_period_ and it's hard to
 // artificially create a case where Request() is called with bytes > 100 in
 // BackupEngine

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2582,8 +2582,8 @@ INSTANTIATE_TEST_CASE_P(
                       std::make_tuple(true, 0, std::make_pair(1 * MB, 5 * MB)),
                       std::make_tuple(true, 0, std::make_pair(2 * MB, 3 * MB)),
                       std::make_tuple(true, 1, std::make_pair(1 * MB, 5 * MB)),
-                      std::make_tuple(true, 1,
-                                      std::make_pair(2 * MB, 3 * MB))));
+                      std::make_tuple(true, 1, std::make_pair(2 * MB, 3 * MB)),
+                      std::make_tuple(true, 1, std::make_pair(200, 200))));
 
 TEST_P(BackupEngineRateLimitingTestWithParam, RateLimiting) {
   size_t const kMicrosPerSec = 1000 * 1000LL;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2895,15 +2895,11 @@ TEST_P(BackupEngineRateLimitingTestWithParam2,
        RateLimitingWithLowRefillBytesPerPeriod) {
   backupable_options_->max_background_operations = 1;
   const uint64_t backup_rate_limiter_limit = std::get<0>(GetParam()).first;
-  std::shared_ptr<RateLimiter> backup_rate_limiter(
-      new MockedRateLimiterWithLowRefillBytesPerPeriod(
-          RateLimiter::Mode::kAllIo, backup_rate_limiter_limit, 1000 * 1000));
+  std::shared_ptr<RateLimiter> backup_rate_limiter = std::make_shared<MockedRateLimiterWithLowRefillBytesPerPeriod>(RateLimiter::Mode::kAllIo, backup_rate_limiter_limit, 1000 * 1000);
   backupable_options_->backup_rate_limiter = backup_rate_limiter;
 
   const uint64_t restore_rate_limiter_limit = std::get<0>(GetParam()).second;
-  std::shared_ptr<RateLimiter> restore_rate_limiter(
-      new MockedRateLimiterWithLowRefillBytesPerPeriod(
-          RateLimiter::Mode::kAllIo, restore_rate_limiter_limit, 1000 * 1000));
+  std::shared_ptr<RateLimiter> restore_rate_limiter = std::make_shared<MockedRateLimiterWithLowRefillBytesPerPeriod>(RateLimiter::Mode::kAllIo, restore_rate_limiter_limit, 1000 * 1000);
   backupable_options_->restore_rate_limiter = restore_rate_limiter;
 
   DestroyDB(dbname_, Options());

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2817,8 +2817,9 @@ class BackupEngineRateLimitingTestWithParam2
 
 class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
  public:
-  MockedRateLimiterWithLowRefillBytesPerPeriod(RateLimiter::Mode mode, int64_t rate_bytes_per_sec,
-                             int64_t refill_period_us)
+  MockedRateLimiterWithLowRefillBytesPerPeriod(RateLimiter::Mode mode,
+                                               int64_t rate_bytes_per_sec,
+                                               int64_t refill_period_us)
       : RateLimiter(mode),
         rate_bytes_per_sec_(rate_bytes_per_sec),
         refill_period_us_(refill_period_us),
@@ -2880,28 +2881,29 @@ class MockedRateLimiterWithLowRefillBytesPerPeriod : public RateLimiter {
   int64_t total_bytes_through_[Env::IO_TOTAL];
 };
 
-INSTANTIATE_TEST_CASE_P(
-    RateLimiterWithLowRefillBytesPerPeriod, BackupEngineRateLimitingTestWithParam2,
-    ::testing::Values(std::make_tuple(std::make_pair(1, 1))));
+INSTANTIATE_TEST_CASE_P(RateLimiterWithLowRefillBytesPerPeriod,
+                        BackupEngineRateLimitingTestWithParam2,
+                        ::testing::Values(std::make_tuple(std::make_pair(1,
+                                                                         1))));
 
 TEST_P(BackupEngineRateLimitingTestWithParam2,
        RateLimitingWithLowRefillBytesPerPeriod) {
   backupable_options_->max_background_operations = 1;
   const uint64_t backup_rate_limiter_limit = std::get<0>(GetParam()).first;
   std::shared_ptr<RateLimiter> backup_rate_limiter(
-      new MockedRateLimiterWithLowRefillBytesPerPeriod(RateLimiter::Mode::kAllIo,
-                                     backup_rate_limiter_limit, 1000 * 1000));
+      new MockedRateLimiterWithLowRefillBytesPerPeriod(
+          RateLimiter::Mode::kAllIo, backup_rate_limiter_limit, 1000 * 1000));
   backupable_options_->backup_rate_limiter = backup_rate_limiter;
 
-  const uint64_t restore_rate_limiter_limit =
-      std::get<0>(GetParam()).second;
+  const uint64_t restore_rate_limiter_limit = std::get<0>(GetParam()).second;
   std::shared_ptr<RateLimiter> restore_rate_limiter(
-      new MockedRateLimiterWithLowRefillBytesPerPeriod(RateLimiter::Mode::kAllIo,
-                                     restore_rate_limiter_limit, 1000 * 1000));
+      new MockedRateLimiterWithLowRefillBytesPerPeriod(
+          RateLimiter::Mode::kAllIo, restore_rate_limiter_limit, 1000 * 1000));
   backupable_options_->restore_rate_limiter = restore_rate_limiter;
 
   DestroyDB(dbname_, Options());
-  OpenDBAndBackupEngine(true /* destroy_old_data */, false /* dummy */, kShareWithChecksum /* shared_option */);
+  OpenDBAndBackupEngine(true /* destroy_old_data */, false /* dummy */,
+                        kShareWithChecksum /* shared_option */);
 
   FillDB(db_.get(), 0, 5);
   int64_t total_bytes_through_before_backup =


### PR DESCRIPTION
**Context:**
Some existing internal calls of `GenericRateLimiter::Request()` in backupable_db.cc and newly added internal calls in https://github.com/facebook/rocksdb/pull/8722/ do not make sure `bytes <= GetSingleBurstBytes()` as required by rate_limiter https://github.com/facebook/rocksdb/blob/master/include/rocksdb/rate_limiter.h#L47. 

**Impacts of this bug include:** 
(1) In debug build, when `GenericRateLimiter::Request()` requests bytes greater than `GenericRateLimiter:: kMinRefillBytesPerPeriod = 100` byte, process will crash due to assertion failure. See https://github.com/facebook/rocksdb/pull/9063#discussion_r737034133 and for possible scenario
(2) In production build, although there will not be the above crash due to disabled assertion, the bug can lead to a request of small bytes being blocked for a long time by a request of same priority with insanely large bytes from a different thread. See updated https://github.com/facebook/rocksdb/wiki/Rate-Limiter ("Notice that although....the maximum bytes that can be granted in a single request have to be bounded...") for more info.

There is an on-going effort to move rate-limiting to file wrapper level so rate limiting in `BackupEngine` and this PR might be made obsolete in the future.

**Summary:**
- Implemented loop-calling `GenericRateLimiter::Request()` with `bytes <= GetSingleBurstBytes()` as a static private helper function `BackupEngineImpl::LoopRateLimitRequestHelper`
   -- Considering make this a util function in `RateLimiter` later or do something with `RateLimiter::RequestToken()`
- Replaced buggy internal callers with this helper function wherever requested byte is not pre-limited by `GetSingleBurstBytes()`
- Removed the minimum refill bytes per period enforced by `GenericRateLimiter` since it is useless and prevents testing `GenericRateLimiter` for extreme case with small refill bytes per period.

**Test:**
- Added a new test that failed the assertion before this change and now passes
  - It exposed bugs in [the write during creation in `CopyOrCreateFile()`](https://github.com/facebook/rocksdb/blob/df7cc66e171dfa665e34d293717242784195e1da/utilities/backupable/backupable_db.cc#L2034-L2043), [the read of table properties in `GetFileDbIdentities()`](https://github.com/facebook/rocksdb/blob/df7cc66e171dfa665e34d293717242784195e1da/utilities/backupable/backupable_db.cc#L2372-L2378), [some read of metadata in `BackupMeta::LoadFromFile()`](https://github.com/facebook/rocksdb/blob/df7cc66e171dfa665e34d293717242784195e1da/utilities/backupable/backupable_db.cc#L2726)
- Passing Existing tests