### PR TITLE
remove bad extra RecordTick(stats_, WRITE_WITH_WAL)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 ### Bug Fixes
 * Prevent a `CompactRange()` with `CompactRangeOptions::change_level == true` from possibly causing corruption to the LSM state (overlapping files within a level) when run in parallel with another manual compaction. Note that setting `force_consistency_checks == true` (the default) would cause the DB to enter read-only mode in this scenario and return `Status::Corruption`, rather than committing any corruption.
 * Fixed a bug in CompactionIterator when write-prepared transaction is used. A released earliest write conflict snapshot may cause assertion failure in dbg mode and unexpected key in opt mode.
+* Fix ticker WRITE_WITH_WAL("rocksdb.write.wal"), this bug is caused by a bad extra `RecordTick(stats_, WRITE_WITH_WAL)` (at 2 place), this fix remove the extra `RecordTick`s and fix the corresponding test case.
 
 ## 6.26.0 (2021-10-20)
 ### Bug Fixes

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -156,11 +156,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
   PERF_TIMER_GUARD(write_pre_and_post_process_time);
   WriteThread::Writer w(write_options, my_batch, callback, log_ref,
                         disable_memtable, batch_cnt, pre_release_callback);
-
-  if (!write_options.disableWAL) {
-    RecordTick(stats_, WRITE_WITH_WAL);
-  }
-
   StopWatch write_sw(immutable_db_options_.clock, stats_, DB_WRITE);
 
   write_thread_.JoinBatchGroup(&w);
@@ -681,7 +676,6 @@ Status DBImpl::WriteImplWALOnly(
   PERF_TIMER_GUARD(write_pre_and_post_process_time);
   WriteThread::Writer w(write_options, my_batch, callback, log_ref,
                         disable_memtable, sub_batch_cnt, pre_release_callback);
-  RecordTick(stats_, WRITE_WITH_WAL);
   StopWatch write_sw(immutable_db_options_.clock, stats_, DB_WRITE);
 
   write_thread->JoinBatchGroup(&w);

--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -474,6 +474,7 @@ TEST_F(StatsHistoryTest, PersistentStatsCreateColumnFamilies) {
   options.env = mock_env_.get();
   ASSERT_OK(TryReopen(options));
   CreateColumnFamilies({"one", "two", "three"}, options);
+  ASSERT_OK(Put(1, "foo", "old"));
   ASSERT_OK(Put(1, "foo", "bar"));
   ReopenWithColumnFamilies({"default", "one", "two", "three"}, options);
   ASSERT_EQ(Get(2, "foo"), "bar");

--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -474,7 +474,6 @@ TEST_F(StatsHistoryTest, PersistentStatsCreateColumnFamilies) {
   options.env = mock_env_.get();
   ASSERT_OK(TryReopen(options));
   CreateColumnFamilies({"one", "two", "three"}, options);
-  ASSERT_OK(Put(1, "foo", "old"));
   ASSERT_OK(Put(1, "foo", "bar"));
   ReopenWithColumnFamilies({"default", "one", "two", "three"}, options);
   ASSERT_EQ(Get(2, "foo"), "bar");
@@ -507,7 +506,7 @@ TEST_F(StatsHistoryTest, PersistentStatsCreateColumnFamilies) {
     }
   }
   stats_iter.reset();
-  ASSERT_EQ(num_write_wal, 2);
+  ASSERT_EQ(num_write_wal, 1);
 
   options.persist_stats_to_disk = false;
   ReopenWithColumnFamilies({"default", "one", "two", "three", "four"}, options);
@@ -543,7 +542,7 @@ TEST_F(StatsHistoryTest, PersistentStatsCreateColumnFamilies) {
       }
     }
   }
-  ASSERT_EQ(num_write_wal, 2);
+  ASSERT_EQ(num_write_wal, 1);
 
   Close();
   Destroy(options);


### PR DESCRIPTION
This PR fix wrong ticker `WRITE_WITH_WAL`.

`RecordTick(WRITE_WITH_WAL)` will be called later in `WriteToWAL` and `ConcurrentWriteToWAL`.

Fixes:
1. Delete these two extra `RecordTick(WRITE_WITH_WAL)`
2. Fix corresponding test case