### PR TITLE
InternalStats::DumpCFMapStat: fix sum.w_amp

### DIFF
--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -1519,9 +1519,11 @@ void InternalStats::DumpCFMapStats(
     }
   }
   // Cumulative summary
-  double w_amp = (compaction_stats_sum->bytes_written +
-                  compaction_stats_sum->bytes_written_blob) /
-                 static_cast<double>(curr_ingest + 1);
+  double w_amp = (0 == curr_ingest)
+                     ? 0.0
+                     : (compaction_stats_sum->bytes_written +
+                        compaction_stats_sum->bytes_written_blob) /
+                           static_cast<double>(curr_ingest);
   // Stats summary across levels
   std::map<LevelStatType, double> sum_stats;
   PrepareLevelStats(&sum_stats, total_files, total_files_being_compacted,


### PR DESCRIPTION
sum `w_amp` will be a very large number`(bytes_written + bytes_written_blob)` when there is no any flush and ingest.

This PR set sum `w_amp` to zero if there is no any flush and ingest, this is conform to per-level `w_amp` computation.