### PR TITLE
fix gflags assertion fail

### DIFF
--- a/util/gflags_compat.h
+++ b/util/gflags_compat.h
@@ -15,6 +15,5 @@
 #ifndef DEFINE_uint32
 // DEFINE_uint32 does not appear in older versions of gflags. This should be
 // a sane definition for those versions.
-#define DEFINE_uint32(name, val, txt) \
-  DEFINE_VARIABLE(GFLAGS_NAMESPACE::uint32, U, name, val, txt)
+#define DEFINE_uint32 DEFINE_uint64
 #endif


### PR DESCRIPTION
when using gflags-2.1.2, assertion fails:

db_bench: /builddir/build/BUILD/gflags-2.1.2/src/gflags.cc:250: google::{anonymous}::FlagValue::FlagValue(void*, const char*, bool): Assertion `type_ <= FV_MAX_INDEX' failed.

this commit fix this issue, using uint64 as a fake for uint32 makes no harm for this case