### PR TITLE
Aggregate blob file related changes in VersionBuilder as VersionEdits are applied

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -492,9 +492,10 @@ class VersionBuilder::Rep {
     if (base_it != base_blob_files.end()) {
       assert(base_it->second);
 
-      mutable_it =
-          mutable_blob_file_metas_.emplace(blob_file_number, base_it->second)
-              .first;
+      mutable_it = mutable_blob_file_metas_
+                       .emplace(blob_file_number,
+                                MutableBlobFileMetaData(base_it->second))
+                       .first;
       return &mutable_it->second;
     }
 
@@ -535,7 +536,8 @@ class VersionBuilder::Rep {
         blob_file_addition.GetChecksumMethod(),
         blob_file_addition.GetChecksumValue(), deleter);
 
-    mutable_blob_file_metas_.emplace(blob_file_number, std::move(shared_meta));
+    mutable_blob_file_metas_.emplace(
+        blob_file_number, MutableBlobFileMetaData(std::move(shared_meta)));
 
     return Status::OK();
   }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -168,7 +168,7 @@ class VersionBuilder::Rep {
           garbage_blob_count_(meta->GetGarbageBlobCount()),
           garbage_blob_bytes_(meta->GetGarbageBlobBytes()) {}
 
-    std::shared_ptr<SharedBlobFileMetaData> GetSharedMeta() const {
+    const std::shared_ptr<SharedBlobFileMetaData>& GetSharedMeta() const {
       return shared_meta_;
     }
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -213,9 +213,9 @@ class VersionBuilder::Rep {
 
    private:
     std::shared_ptr<SharedBlobFileMetaData> shared_meta_;
-    // Delta
+    // Accumulated changes
     BlobFileMetaDataDelta delta_;
-    // Accumulated values
+    // Resulting state after applying the changes
     BlobFileMetaData::LinkedSsts linked_ssts_;
     uint64_t garbage_blob_count_ = 0;
     uint64_t garbage_blob_bytes_ = 0;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -157,7 +157,7 @@ class VersionBuilder::Rep {
    public:
     // To be used for brand new blob files
     explicit MutableBlobFileMetaData(
-        std::shared_ptr<SharedBlobFileMetaData> shared_meta)
+        std::shared_ptr<SharedBlobFileMetaData>&& shared_meta)
         : shared_meta_(std::move(shared_meta)) {}
 
     // To be used for pre-existing blob files

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -86,6 +86,9 @@ class VersionBuilder::Rep {
     std::unordered_map<uint64_t, FileMetaData*> added_files;
   };
 
+  // A class that represents the accumulated changes (like additional garbage or
+  // newly linked/unliked SST files) for a given blob file after applying a
+  // series of VersionEdits.
   class BlobFileMetaDataDelta {
    public:
     bool IsEmpty() const {
@@ -153,6 +156,11 @@ class VersionBuilder::Rep {
     std::unordered_set<uint64_t> newly_unlinked_ssts_;
   };
 
+  // A class that represents the state of a blob file after applying a series of
+  // VersionEdits. In addition to the resulting state, it also contains the
+  // delta (see BlobFileMetaDataDelta above). The resulting state can be used to
+  // identify obsolete blob files, while the delta makes it possible to
+  // efficiently detect trivial moves.
   class MutableBlobFileMetaData {
    public:
     // To be used for brand new blob files

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -456,7 +456,7 @@ class VersionBuilder::Rep {
   Status ApplyBlobFileGarbage(const BlobFileGarbage& blob_file_garbage) {
     const uint64_t blob_file_number = blob_file_garbage.GetBlobFileNumber();
 
-    MutableBlobFileMetaData* mutable_meta =
+    MutableBlobFileMetaData* const mutable_meta =
         GetOrCreateMutableBlobFileMetaData(blob_file_number);
 
     if (!mutable_meta) {
@@ -563,7 +563,7 @@ class VersionBuilder::Rep {
         GetOldestBlobFileNumberForTableFile(level, file_number);
 
     if (blob_file_number != kInvalidBlobFileNumber) {
-      MutableBlobFileMetaData* mutable_meta =
+      MutableBlobFileMetaData* const mutable_meta =
           GetOrCreateMutableBlobFileMetaData(blob_file_number);
       if (mutable_meta) {
         mutable_meta->UnlinkSst(file_number);
@@ -633,7 +633,7 @@ class VersionBuilder::Rep {
     const uint64_t blob_file_number = f->oldest_blob_file_number;
 
     if (blob_file_number != kInvalidBlobFileNumber) {
-      MutableBlobFileMetaData* mutable_meta =
+      MutableBlobFileMetaData* const mutable_meta =
           GetOrCreateMutableBlobFileMetaData(blob_file_number);
       if (mutable_meta) {
         mutable_meta->LinkSst(file_number);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -87,7 +87,7 @@ class VersionBuilder::Rep {
   };
 
   // A class that represents the accumulated changes (like additional garbage or
-  // newly linked/unliked SST files) for a given blob file after applying a
+  // newly linked/unlinked SST files) for a given blob file after applying a
   // series of VersionEdits.
   class BlobFileMetaDataDelta {
    public:


### PR DESCRIPTION
Summary:
The current VersionBuilder code on mainline keeps track of blob file related
changes ("delta") induced by a series of `VersionEdit`s in the form of
`BlobFileMetaDataDelta` objects. Specifically, `BlobFileMetaDataDelta`
contains the amount of additional garbage generated by compactions, as well
as the set of newly linked/unlinked SSTs. This is very handy for detecting trivial moves,
since in that case the newly linked and unlinked SSTs cancel each other out.
However, this representation does not allow us to easily tell whether a certain
blob file is obsolete after applying a set of `VersionEdit`s or not. In order to
solve this issue, the patch introduces `MutableBlobFileMetaData`, which, in addition
to the delta, also contains the materialized state after applying a set of version edits
(i.e. the total amount of garbage and the resulting set of linked SSTs). This will
enable us to add further consistency checks and to improve certain pieces of
functionality where knowing up front which blob files get obsoleted is beneficial.
(Note: this patch is just the refactoring part; I plan to create separate PRs for
the enhancements.)

Test Plan:
Ran `make check` and the stress tests in BlobDB mode.