### PR TITLE
Track each SST's timestamp information as user properties

### DIFF
--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -552,6 +552,42 @@ TEST_F(DBBasicTestWithTimestamp, SimpleIterate) {
   Close();
 }
 
+#ifndef ROCKSDB_LITE
+TEST_F(DBBasicTestWithTimestamp, GetTimestampTableProperties) {
+  Options options = CurrentOptions();
+  const size_t kTimestampSize = Timestamp(0, 0).size();
+  TestComparator test_cmp(kTimestampSize);
+  options.comparator = &test_cmp;
+  DestroyAndReopen(options);
+  
+  // Create 2 tables
+  for (int table = 0; table < 2; ++table) {
+    for (int i = 0; i < 10; i++) {
+      WriteOptions write_opts;
+      std::string ts_str = Timestamp(i, 0);
+      Slice ts = ts_str;
+      write_opts.timestamp = &ts;
+      ASSERT_OK(db_->Put(write_opts, "key", Key(i)));
+    }
+    ASSERT_OK(Flush());
+  }
+
+  TablePropertiesCollection props;
+  ASSERT_OK(db_->GetPropertiesOfAllTables(&props));
+  ASSERT_EQ(2U, props.size());
+  for (const auto& item : props) {
+    auto& user_collected = item.second->user_collected_properties;
+    ASSERT_TRUE(user_collected.find("min_timestamp") !=
+                user_collected.end());
+    ASSERT_TRUE(user_collected.find("max_timestamp") !=
+                user_collected.end());
+    ASSERT_EQ(user_collected.at("min_timestamp"), Timestamp(0, 0));
+    ASSERT_EQ(user_collected.at("max_timestamp"), Timestamp(9, 0));
+  }
+  Close();
+}
+#endif  // !ROCKSDB_LITE
+
 class DBBasicTestWithTimestampTableOptions
     : public DBBasicTestWithTimestampBase,
       public testing::WithParamInterface<BlockBasedTableOptions::IndexType> {

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -602,7 +602,6 @@ TEST_F(DBBasicTestWithTimestamp, GetTimestampTableProperties) {
   TestComparator test_cmp(kTimestampSize);
   options.comparator = &test_cmp;
   DestroyAndReopen(options);
-  
   // Create 2 tables
   for (int table = 0; table < 2; ++table) {
     for (int i = 0; i < 10; i++) {

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -619,12 +619,12 @@ TEST_F(DBBasicTestWithTimestamp, GetTimestampTableProperties) {
   ASSERT_EQ(2U, props.size());
   for (const auto& item : props) {
     auto& user_collected = item.second->user_collected_properties;
-    ASSERT_TRUE(user_collected.find("rocksdb.min_timestamp") !=
+    ASSERT_TRUE(user_collected.find("rocksdb.timestamp_min") !=
                 user_collected.end());
-    ASSERT_TRUE(user_collected.find("rocksdb.max_timestamp") !=
+    ASSERT_TRUE(user_collected.find("rocksdb.timestamp_max") !=
                 user_collected.end());
-    ASSERT_EQ(user_collected.at("rocksdb.min_timestamp"), Timestamp(0, 0));
-    ASSERT_EQ(user_collected.at("rocksdb.max_timestamp"), Timestamp(9, 0));
+    ASSERT_EQ(user_collected.at("rocksdb.timestamp_min"), Timestamp(0, 0));
+    ASSERT_EQ(user_collected.at("rocksdb.timestamp_max"), Timestamp(9, 0));
   }
   Close();
 }

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -577,12 +577,12 @@ TEST_F(DBBasicTestWithTimestamp, GetTimestampTableProperties) {
   ASSERT_EQ(2U, props.size());
   for (const auto& item : props) {
     auto& user_collected = item.second->user_collected_properties;
-    ASSERT_TRUE(user_collected.find("min_timestamp") !=
+    ASSERT_TRUE(user_collected.find("rocksdb.min_timestamp") !=
                 user_collected.end());
-    ASSERT_TRUE(user_collected.find("max_timestamp") !=
+    ASSERT_TRUE(user_collected.find("rocksdb.max_timestamp") !=
                 user_collected.end());
-    ASSERT_EQ(user_collected.at("min_timestamp"), Timestamp(0, 0));
-    ASSERT_EQ(user_collected.at("max_timestamp"), Timestamp(9, 0));
+    ASSERT_EQ(user_collected.at("rocksdb.min_timestamp"), Timestamp(0, 0));
+    ASSERT_EQ(user_collected.at("rocksdb.max_timestamp"), Timestamp(9, 0));
   }
   Close();
 }

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -91,8 +91,6 @@ static const SequenceNumber kMaxSequenceNumber = ((0x1ull << 56) - 1);
 
 static const SequenceNumber kDisableGlobalSequenceNumber = port::kMaxUint64;
 
-static const std::string kDisableUserTimestamp = "";
-
 constexpr uint64_t kNumInternalBytes = 8;
 
 // Defined in dbformat.cc

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -91,6 +91,8 @@ static const SequenceNumber kMaxSequenceNumber = ((0x1ull << 56) - 1);
 
 static const SequenceNumber kDisableGlobalSequenceNumber = port::kMaxUint64;
 
+static const std::string kDisableUserTimestamp = "";
+
 constexpr uint64_t kNumInternalBytes = 8;
 
 // The data structure that represents an internal key in the way that user_key,

--- a/db/table_properties_collector.h
+++ b/db/table_properties_collector.h
@@ -151,8 +151,8 @@ class TimestampTablePropertiesCollector : public IntTblPropCollector {
   Status Finish(UserCollectedProperties* properties) override {
     assert(min_timestamp_.size() == max_timestamp_.size()
         && max_timestamp_.size() == cmp_->timestamp_size());
-    properties->insert({"min_timestamp", min_timestamp_});
-    properties->insert({"max_timestamp", max_timestamp_});
+    properties->insert({"rocksdb.min_timestamp", min_timestamp_});
+    properties->insert({"rocksdb.max_timestamp", max_timestamp_});
     return Status::OK();
   }
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -515,6 +515,12 @@ struct BlockBasedTableBuilder::Rep {
         new BlockBasedTablePropertiesCollector(
             table_options.index_type, table_options.whole_key_filtering,
             moptions.prefix_extractor != nullptr));
+    const Comparator* ucmp = tbo.internal_comparator.user_comparator();
+    assert(ucmp);
+    if (ucmp->timestamp_size() > 0) {
+      table_properties_collectors.emplace_back(
+          new TimestampTablePropertiesCollector(ucmp));
+    }
     if (table_options.verify_compression) {
       for (uint32_t i = 0; i < compression_opts.parallel_threads; i++) {
         verify_ctxs[i].reset(new UncompressionContext(compression_type));


### PR DESCRIPTION
Track each SST's timestamp information as user properties #8959

Rockdb has supported user-defined timestamp feature. Application can specify a timestamp
when writing each k-v pair. When data flush from memory to disk file called SST files. 
Each SST files consist of multiple data blocks and several metadata blocks. Among the metadata 
blocks, there is one called Properties block that tracks some pre-defined properties of this SST file.

This PR is for collecting the properties of min and max timestamps of all keys in the file. With those
properties the SST file is more convenient to tell whether the keys in the SST have timestamps or not.

The changes involved are as follows:

1) Add a class TimestampTablePropertiesCollector to collect min/max timestamp when add keys to table,
   The way TimestampTablePropertiesCollector use to compare timestamp of key should defined by
   user by implementing the Comparator::CompareTimestamp function in the user defined comparator.
2) Add corresponding unit tests.