### PR TITLE
Temporarily disable s390x+cmake* Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,9 @@ matrix:
     os : linux
     arch: arm64
     env: JOB_NAME=cmake
+  - os : linux
+    arch: s390x
+    env: JOB_NAME=cmake
   - if: type = pull_request AND commit_message !~ /FULL_CI/ AND commit_message !~ /java/
     os : linux
     arch: arm64
@@ -168,8 +171,7 @@ matrix:
     os: linux
     arch: ppc64le
     env: JOB_NAME=cmake-gcc8
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: linux
+  - os: linux
     arch: s390x
     env: JOB_NAME=cmake-gcc8
   - if: type = pull_request AND commit_message !~ /FULL_CI/
@@ -180,8 +182,7 @@ matrix:
     os: linux
     arch: ppc64le
     env: JOB_NAME=cmake-gcc9
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: linux
+  - os: linux
     arch: s390x
     env: JOB_NAME=cmake-gcc9
   - if: type = pull_request AND commit_message !~ /FULL_CI/
@@ -192,8 +193,7 @@ matrix:
     os: linux
     arch: ppc64le
     env: JOB_NAME=cmake-gcc9-c++20
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: linux
+  - os: linux
     arch: s390x
     env: JOB_NAME=cmake-gcc9-c++20
   - if: type = pull_request AND commit_message !~ /FULL_CI/


### PR DESCRIPTION
Temporarily disable s390x+cmake* jobs until a cmake-3.14.5-Linux-s390x.deb can be installed to https://rocksdb-deps.s3-us-west-2.amazonaws.com.