### PR TITLE
Refactor the detailed consistency checks and the SST saving logic in VersionBuilder

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -302,6 +302,10 @@ class VersionBuilder::Rep {
       const VersionStorageInfo* vstorage, int level, Checker checker,
       const std::string& sync_point,
       ExpectedLinkedSsts* expected_linked_ssts) const {
+#ifdef NDEBUG
+    (void)sync_point;
+#endif
+
     assert(vstorage);
     assert(level >= 0 && level < num_levels_);
     assert(expected_linked_ssts);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -35,7 +35,8 @@
 namespace ROCKSDB_NAMESPACE {
 
 class VersionBuilder::Rep {
-  struct NewestFirstBySeqNo {
+  class NewestFirstBySeqNo {
+   public:
     bool operator()(const FileMetaData* lhs, const FileMetaData* rhs) const {
       assert(lhs);
       assert(rhs);
@@ -53,7 +54,8 @@ class VersionBuilder::Rep {
     }
   };
 
-  struct BySmallestKey {
+  class BySmallestKey {
+   public:
     explicit BySmallestKey(const InternalKeyComparator* cmp) : cmp_(cmp) {}
 
     bool operator()(const FileMetaData* lhs, const FileMetaData* rhs) const {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -306,7 +306,7 @@ class VersionBuilder::Rep {
     assert(level >= 0 && level < num_levels_);
     assert(expected_linked_ssts);
 
-    auto& level_files = vstorage->LevelFiles(level);
+    const auto& level_files = vstorage->LevelFiles(level);
 
     if (level_files.empty()) {
       return Status::OK();

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -299,7 +299,7 @@ class VersionBuilder::Rep {
   }
 
   template <class Checker>
-  Status CheckConsistencyLevelDetails(
+  Status CheckConsistencyDetailsForLevel(
       const VersionStorageInfo* vstorage, int level, Checker checker,
       const std::string& sync_point,
       ExpectedLinkedSsts* expected_linked_ssts) const {
@@ -395,7 +395,7 @@ class VersionBuilder::Rep {
           return Status::OK();
         };
 
-        const Status s = CheckConsistencyLevelDetails(
+        const Status s = CheckConsistencyDetailsForLevel(
             vstorage, /* level */ 0, l0_checker,
             "VersionBuilder::CheckConsistency0", &expected_linked_ssts);
         if (!s.ok()) {
@@ -436,7 +436,7 @@ class VersionBuilder::Rep {
           return Status::OK();
         };
 
-        const Status s = CheckConsistencyLevelDetails(
+        const Status s = CheckConsistencyDetailsForLevel(
             vstorage, level, checker, "VersionBuilder::CheckConsistency1",
             &expected_linked_ssts);
         if (!s.ok()) {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -34,7 +34,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-namespace {
 struct NewestFirstBySeqNo {
   bool operator()(const FileMetaData* lhs, const FileMetaData* rhs) const {
     assert(lhs);
@@ -73,7 +72,6 @@ struct BySmallestKey {
  private:
   const InternalKeyComparator* cmp_;
 };
-}  // namespace
 
 class VersionBuilder::Rep {
  private:

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -34,47 +34,46 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-struct NewestFirstBySeqNo {
-  bool operator()(const FileMetaData* lhs, const FileMetaData* rhs) const {
-    assert(lhs);
-    assert(rhs);
-
-    if (lhs->fd.largest_seqno != rhs->fd.largest_seqno) {
-      return lhs->fd.largest_seqno > rhs->fd.largest_seqno;
-    }
-
-    if (lhs->fd.smallest_seqno != rhs->fd.smallest_seqno) {
-      return lhs->fd.smallest_seqno > rhs->fd.smallest_seqno;
-    }
-
-    // Break ties by file number
-    return lhs->fd.GetNumber() > rhs->fd.GetNumber();
-  }
-};
-
-struct BySmallestKey {
-  explicit BySmallestKey(const InternalKeyComparator* cmp) : cmp_(cmp) {}
-
-  bool operator()(const FileMetaData* lhs, const FileMetaData* rhs) const {
-    assert(lhs);
-    assert(rhs);
-    assert(cmp_);
-
-    const int r = cmp_->Compare(lhs->smallest, rhs->smallest);
-    if (r != 0) {
-      return (r < 0);
-    }
-
-    // Break ties by file number
-    return (lhs->fd.GetNumber() < rhs->fd.GetNumber());
-  }
-
- private:
-  const InternalKeyComparator* cmp_;
-};
-
 class VersionBuilder::Rep {
- private:
+  struct NewestFirstBySeqNo {
+    bool operator()(const FileMetaData* lhs, const FileMetaData* rhs) const {
+      assert(lhs);
+      assert(rhs);
+
+      if (lhs->fd.largest_seqno != rhs->fd.largest_seqno) {
+        return lhs->fd.largest_seqno > rhs->fd.largest_seqno;
+      }
+
+      if (lhs->fd.smallest_seqno != rhs->fd.smallest_seqno) {
+        return lhs->fd.smallest_seqno > rhs->fd.smallest_seqno;
+      }
+
+      // Break ties by file number
+      return lhs->fd.GetNumber() > rhs->fd.GetNumber();
+    }
+  };
+
+  struct BySmallestKey {
+    explicit BySmallestKey(const InternalKeyComparator* cmp) : cmp_(cmp) {}
+
+    bool operator()(const FileMetaData* lhs, const FileMetaData* rhs) const {
+      assert(lhs);
+      assert(rhs);
+      assert(cmp_);
+
+      const int r = cmp_->Compare(lhs->smallest, rhs->smallest);
+      if (r != 0) {
+        return (r < 0);
+      }
+
+      // Break ties by file number
+      return (lhs->fd.GetNumber() < rhs->fd.GetNumber());
+    }
+
+   private:
+    const InternalKeyComparator* cmp_;
+  };
+
   struct LevelState {
     std::unordered_set<uint64_t> deleted_files;
     // Map from file number to file meta data.

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -317,7 +317,7 @@ class VersionBuilder::Rep {
                              level_files[0]->oldest_blob_file_number,
                              expected_linked_ssts);
 
-    for (size_t i = 1; i < level_files.size(); i++) {
+    for (size_t i = 1; i < level_files.size(); ++i) {
       assert(level_files[i]);
       UpdateExpectedLinkedSsts(level_files[i]->fd.GetNumber(),
                                level_files[i]->oldest_blob_file_number,

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -282,6 +282,10 @@ class VersionBuilder::Rep {
     }
   }
 
+  // Mapping used for checking the consistency of links between SST files and
+  // blob files. It is built using the forward links (table file -> blob file),
+  // and is subsequently compared with the inverse mapping stored in the
+  // BlobFileMetaData objects.
   using ExpectedLinkedSsts =
       std::unordered_map<uint64_t, BlobFileMetaData::LinkedSsts>;
 
@@ -344,14 +348,11 @@ class VersionBuilder::Rep {
     return Status::OK();
   }
 
+  // Make sure table files are sorted correctly and that the links between
+  // table files and blob files are consistent.
   Status CheckConsistencyDetails(const VersionStorageInfo* vstorage) const {
     assert(vstorage);
 
-    // Make sure the files are sorted correctly and that the links between
-    // table files and blob files are consistent. The latter is checked using
-    // the following mapping, which is built using the forward links
-    // (table file -> blob file), and is subsequently compared with the inverse
-    // mapping stored in the BlobFileMetaData objects.
     ExpectedLinkedSsts expected_linked_ssts;
 
     if (num_levels_ > 0) {
@@ -447,7 +448,8 @@ class VersionBuilder::Rep {
       }
     }
 
-    // Make sure that all blob files in the version have non-garbage data.
+    // Make sure that all blob files in the version have non-garbage data and
+    // the links between them and the table files are consistent.
     const auto& blob_files = vstorage->GetBlobFiles();
     for (const auto& pair : blob_files) {
       const uint64_t blob_file_number = pair.first;

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -37,8 +37,8 @@ class VersionBuilder {
   ~VersionBuilder();
 
   bool CheckConsistencyForNumLevels();
-  Status Apply(VersionEdit* edit);
-  Status SaveTo(VersionStorageInfo* vstorage);
+  Status Apply(const VersionEdit* edit);
+  Status SaveTo(VersionStorageInfo* vstorage) const;
   Status LoadTableHandlers(InternalStats* internal_stats, int max_threads,
                            bool prefetch_index_and_filter_in_cache,
                            bool is_initial_load,
@@ -66,5 +66,4 @@ class BaseReferencedVersionBuilder {
   Version* version_;
 };
 
-extern bool NewestFirstBySeqNo(FileMetaData* a, FileMetaData* b);
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -119,10 +119,9 @@ Status OverlapWithIterator(const Comparator* ucmp,
 // are MergeInProgress).
 class FilePicker {
  public:
-  FilePicker(std::vector<FileMetaData*>* files, const Slice& user_key,
-             const Slice& ikey, autovector<LevelFilesBrief>* file_levels,
-             unsigned int num_levels, FileIndexer* file_indexer,
-             const Comparator* user_comparator,
+  FilePicker(const Slice& user_key, const Slice& ikey,
+             autovector<LevelFilesBrief>* file_levels, unsigned int num_levels,
+             FileIndexer* file_indexer, const Comparator* user_comparator,
              const InternalKeyComparator* internal_comparator)
       : num_levels_(num_levels),
         curr_level_(static_cast<unsigned int>(-1)),
@@ -130,9 +129,6 @@ class FilePicker {
         hit_file_level_(static_cast<unsigned int>(-1)),
         search_left_bound_(0),
         search_right_bound_(FileIndexer::kLevelMaxIndex),
-#ifndef NDEBUG
-        files_(files),
-#endif
         level_files_brief_(file_levels),
         is_hit_file_last_in_level_(false),
         curr_file_level_(nullptr),
@@ -213,21 +209,7 @@ class FilePicker {
             }
           }
         }
-#ifndef NDEBUG
-        // Sanity check to make sure that the files are correctly sorted
-        if (prev_file_) {
-          if (curr_level_ != 0) {
-            int comp_sign = internal_comparator_->Compare(
-                prev_file_->largest_key, f->smallest_key);
-            assert(comp_sign < 0);
-          } else {
-            // level == 0, the current file cannot be newer than the previous
-            // one. Use compressed data structure, has no attribute seqNo
-            assert(curr_index_in_curr_level_ > 0);
-          }
-        }
-        prev_file_ = f;
-#endif
+
         returned_file_level_ = curr_level_;
         if (curr_level_ > 0 && cmp_largest < 0) {
           // No more files to search in this level.
@@ -259,9 +241,6 @@ class FilePicker {
   unsigned int hit_file_level_;
   int32_t search_left_bound_;
   int32_t search_right_bound_;
-#ifndef NDEBUG
-  std::vector<FileMetaData*>* files_;
-#endif
   autovector<LevelFilesBrief>* level_files_brief_;
   bool search_ended_;
   bool is_hit_file_last_in_level_;
@@ -273,9 +252,6 @@ class FilePicker {
   FileIndexer* file_indexer_;
   const Comparator* user_comparator_;
   const InternalKeyComparator* internal_comparator_;
-#ifndef NDEBUG
-  FdWithKeyRange* prev_file_;
-#endif
 
   // Setup local variables to search next level.
   // Returns false if there are no more levels to search.
@@ -345,9 +321,7 @@ class FilePicker {
       }
       start_index_in_curr_level_ = start_index;
       curr_index_in_curr_level_ = start_index;
-#ifndef NDEBUG
-      prev_file_ = nullptr;
-#endif
+
       return true;
     }
     // curr_level_ = num_levels_. So, no more levels to search.
@@ -2019,10 +1993,10 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     pinned_iters_mgr.StartPinning();
   }
 
-  FilePicker fp(
-      storage_info_.files_, user_key, ikey, &storage_info_.level_files_brief_,
-      storage_info_.num_non_empty_levels_, &storage_info_.file_indexer_,
-      user_comparator(), internal_comparator());
+  FilePicker fp(user_key, ikey, &storage_info_.level_files_brief_,
+                storage_info_.num_non_empty_levels_,
+                &storage_info_.file_indexer_, user_comparator(),
+                internal_comparator());
   FdWithKeyRange* f = fp.GetNextFile();
 
   while (f != nullptr) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -224,8 +224,6 @@ class FilePicker {
             // level == 0, the current file cannot be newer than the previous
             // one. Use compressed data structure, has no attribute seqNo
             assert(curr_index_in_curr_level_ > 0);
-            assert(!NewestFirstBySeqNo(files_[0][curr_index_in_curr_level_],
-                  files_[0][curr_index_in_curr_level_-1]));
           }
         }
         prev_file_ = f;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -137,9 +137,6 @@ class FilePicker {
         file_indexer_(file_indexer),
         user_comparator_(user_comparator),
         internal_comparator_(internal_comparator) {
-#ifdef NDEBUG
-    (void)files;
-#endif
     // Setup member variables to search first level.
     search_ended_ = !PrepareNextLevel();
     if (!search_ended_) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -490,7 +490,7 @@ class VersionStorageInfo {
     next_file_to_compact_by_size_[level] = 0;
   }
 
-  const InternalKeyComparator* InternalComparator() {
+  const InternalKeyComparator* InternalComparator() const {
     return internal_comparator_;
   }
 


### PR DESCRIPTION
Summary:
The patch refactors the parts of `VersionBuilder` that deal with SST file
comparisons. Specifically, it makes the following changes:
* Turns `NewestFirstBySeqNo` and `BySmallestKey` from free-standing
functions into function objects. Note: `BySmallestKey` has a pointer to the
`InternalKeyComparator`, while `NewestFirstBySeqNo` is completely
stateless.
* Eliminates the wrapper `FileComparator`, which was essentially an
unnecessary DIY virtual function call mechanism.
* Refactors `CheckConsistencyDetails` and `SaveSSTFilesTo` using helper
function templates that take comparator/checker function objects. Using
static polymorphism eliminates the need to make runtime decisions about
which comparator to use.
* Extends some error messages returned by the consistency checks and
makes them more uniform.
* Removes some incomplete/redundant consistency checks from `VersionBuilder`
and `FilePicker`.
* Improves const correctness in several places.

Test Plan:
`make check`