### PR TITLE
Some checksum code refactoring

### DIFF
--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -30,6 +30,10 @@ std::vector<CompressionType> GetSupportedDictCompressions();
 
 std::vector<ChecksumType> GetSupportedChecksums();
 
+inline bool IsSupportedChecksumType(ChecksumType type) {
+  return type >= kNoChecksum && type <= kXXH3;
+}
+
 // Checks that the combination of DBOptions and ColumnFamilyOptions are valid
 Status ValidateOptions(const DBOptions& db_opts,
                        const ColumnFamilyOptions& cf_opts);

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -100,12 +100,6 @@ class BlockBasedTableBuilder : public TableBuilder {
   // Get file checksum function name
   const char* GetFileChecksumFuncName() const override;
 
-  // Computes and populates block trailer for a block
-  static void ComputeBlockTrailer(const Slice& block_contents,
-                                  CompressionType compression_type,
-                                  ChecksumType checksum_type,
-                                  std::array<char, kBlockTrailerSize>* trailer);
-
  private:
   bool ok() const { return status().ok(); }
 

--- a/table/format.cc
+++ b/table/format.cc
@@ -17,6 +17,7 @@
 #include "memory/memory_allocator.h"
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics.h"
+#include "options/options_helper.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "table/block_based/block.h"
@@ -25,8 +26,10 @@
 #include "util/coding.h"
 #include "util/compression.h"
 #include "util/crc32c.h"
+#include "util/hash.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"
+#include "util/xxhash.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -50,8 +53,8 @@ bool ShouldReportDetailedTime(Env* env, Statistics* stats) {
 
 void BlockHandle::EncodeTo(std::string* dst) const {
   // Sanity check that all fields have been set
-  assert(offset_ != ~static_cast<uint64_t>(0));
-  assert(size_ != ~static_cast<uint64_t>(0));
+  assert(offset_ != ~uint64_t{0});
+  assert(size_ != ~uint64_t{0});
   PutVarint64Varint64(dst, offset_, size_);
 }
 
@@ -245,6 +248,11 @@ Status Footer::DecodeFrom(Slice* input) {
       return Status::Corruption("bad checksum type");
     }
     checksum_ = static_cast<ChecksumType>(chksum);
+    if (chksum != static_cast<uint32_t>(checksum_) ||
+        !IsSupportedChecksumType(checksum_)) {
+      return Status::Corruption("unknown checksum type " +
+                                ROCKSDB_NAMESPACE::ToString(chksum));
+    }
   }
 
   Status result = metaindex_handle_.DecodeFrom(input);
@@ -342,6 +350,84 @@ Status ReadFooterFromFile(const IOOptions& opts, RandomAccessFileReader* file,
         ToString(footer->table_magic_number()) + " in " + file->file_name());
   }
   return Status::OK();
+}
+
+namespace {
+// Custom handling for the last byte of a block, to avoid invoking streaming
+// API to get an effective block checksum. This function is its own inverse
+// because it uses xor.
+inline uint32_t ModifyChecksumForLastByte(uint32_t checksum, char last_byte) {
+  // This strategy bears some resemblance to extending a CRC checksum by one
+  // more byte, except we don't need to re-mix the input checksum as long as
+  // we do this step only once (per checksum).
+  const uint32_t kRandomPrime = 0x6b9083d9;
+  return checksum ^ static_cast<uint8_t>(last_byte) * kRandomPrime;
+}
+}  // namespace
+
+uint32_t ComputeBuiltinChecksum(ChecksumType type, const char* data,
+                                size_t data_size) {
+  if (data_size == 0) {
+    return 0;
+  }
+  switch (type) {
+    case kCRC32c:
+      return crc32c::Mask(crc32c::Value(data, data_size));
+    case kxxHash:
+      return XXH32(data, data_size, /*seed*/ 0);
+    case kxxHash64:
+      return Lower32of64(XXH64(data, data_size, /*seed*/ 0));
+    case kXXH3: {
+      // See corresponding code in ComputeBuiltinChecksumWithLastByte
+      uint32_t v = Lower32of64(XXH3_64bits(data, data_size - 1));
+      return ModifyChecksumForLastByte(v, data[data_size - 1]);
+    }
+    default:  // including kNoChecksum
+      return 0;
+  }
+}
+
+uint32_t ComputeBuiltinChecksumWithLastByte(ChecksumType type, const char* data,
+                                            size_t data_size, char last_byte) {
+  switch (type) {
+    case kCRC32c: {
+      uint32_t crc = crc32c::Value(data, data_size);
+      // Extend to cover last byte (compression type)
+      crc = crc32c::Extend(crc, &last_byte, 1);
+      return crc32c::Mask(crc);
+    }
+    case kxxHash: {
+      XXH32_state_t* const state = XXH32_createState();
+      XXH32_reset(state, 0);
+      XXH32_update(state, data, data_size);
+      // Extend to cover last byte (compression type)
+      XXH32_update(state, &last_byte, 1);
+      uint32_t v = XXH32_digest(state);
+      XXH32_freeState(state);
+      return v;
+    }
+    case kxxHash64: {
+      XXH64_state_t* const state = XXH64_createState();
+      XXH64_reset(state, 0);
+      XXH64_update(state, data, data_size);
+      // Extend to cover last byte (compression type)
+      XXH64_update(state, &last_byte, 1);
+      uint32_t v = Lower32of64(XXH64_digest(state));
+      XXH64_freeState(state);
+      return v;
+    }
+    case kXXH3: {
+      // XXH3 is a complicated hash function that is extremely fast on
+      // contiguous input, but that makes its streaming support rather
+      // complex. It is worth custom handling of the last byte (`type`)
+      // in order to avoid allocating a large state object and bringing
+      // that code complexity into CPU working set.
+      uint32_t v = Lower32of64(XXH3_64bits(data, data_size));
+      return ModifyChecksumForLastByte(v, last_byte);
+    }
+    default:  // including kNoChecksum
+      return 0;
+  }
 }
 
 Status UncompressBlockContentsForCompressionType(

--- a/table/format.h
+++ b/table/format.h
@@ -226,17 +226,16 @@ inline CompressionType get_block_compression_type(const char* block_data,
   return static_cast<CompressionType>(block_data[block_size]);
 }
 
-// Custom handling for the last byte of a block, to avoid invoking streaming
-// API to get an effective block checksum. This function is its own inverse
-// because it uses xor.
-inline uint32_t ModifyChecksumForCompressionType(uint32_t checksum,
-                                                 char compression_type) {
-  // This strategy bears some resemblance to extending a CRC checksum by one
-  // more byte, except we don't need to re-mix the input checksum as long as
-  // we do this step only once (per checksum).
-  const uint32_t kRandomPrime = 0x6b9083d9;
-  return checksum ^ static_cast<uint8_t>(compression_type) * kRandomPrime;
-}
+// Computes a checksum using the given ChecksumType. Sometimes we need to
+// include one more input byte logically at the end but not part of the main
+// data buffer. If data_size >= 1, then
+// ComputeBuiltinChecksum(type, data, size)
+// ==
+// ComputeBuiltinChecksumWithLastByte(type, data, size - 1, data[size - 1])
+uint32_t ComputeBuiltinChecksum(ChecksumType type, const char* data,
+                                size_t size);
+uint32_t ComputeBuiltinChecksumWithLastByte(ChecksumType type, const char* data,
+                                            size_t size, char last_byte);
 
 // Represents the contents of a block read from an SST file. Depending on how
 // it's created, it may or may not own the actual block bytes. As an example,
@@ -313,15 +312,6 @@ struct BlockContents {
   }
 };
 
-// Read the block identified by "handle" from "file".  On failure
-// return non-OK.  On success fill *result and return OK.
-extern Status ReadBlockContents(
-    RandomAccessFileReader* file, FilePrefetchBuffer* prefetch_buffer,
-    const Footer& footer, const ReadOptions& options, const BlockHandle& handle,
-    BlockContents* contents, const ImmutableOptions& ioptions,
-    bool do_uncompress = true, const Slice& compression_dict = Slice(),
-    const PersistentCacheOptions& cache_options = PersistentCacheOptions());
-
 // The 'data' points to the raw block contents read in from file.
 // This method allocates a new heap buffer and the raw block
 // contents are uncompresed into this buffer. This buffer is
@@ -352,8 +342,7 @@ extern Status ReifyDbHostIdProperty(Env* env, std::string* db_host_id);
 // TODO(andrewkr): we should prefer one way of representing a null/uninitialized
 // BlockHandle. Currently we use zeros for null and use negation-of-zeros for
 // uninitialized.
-inline BlockHandle::BlockHandle()
-    : BlockHandle(~static_cast<uint64_t>(0), ~static_cast<uint64_t>(0)) {}
+inline BlockHandle::BlockHandle() : BlockHandle(~uint64_t{0}, ~uint64_t{0}) {}
 
 inline BlockHandle::BlockHandle(uint64_t _offset, uint64_t _size)
     : offset_(_offset), size_(_size) {}


### PR DESCRIPTION
Summary: To prepare for adding checksum to footer and "context aware"
checksums. This also brings closely related code much closer together.

Recently added `BlockBasedTableBuilder::ComputeBlockTrailer` for testing
is made obsolete in the refactoring, as testing the checksums can happen
at a lower level of abstraction.

Also now checking for unrecognized checksum type on reading footer,
rather than later on use.

Also removed an obsolete function delcaration.

Test Plan: existing tests worked before refactoring to remove
`ComputeBlockTrailer`. And then refactored+improved tests using it.