### PR TITLE
Refactor and unify blob file saving and the logic that finds the oldest live blob file

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -847,7 +847,7 @@ class VersionBuilder::Rep {
     return Status::OK();
   }
 
-  template <class ProcessBase, class ProcessMutable, class ProcessBoth>
+  template <typename ProcessBase, typename ProcessMutable, typename ProcessBoth>
   void MergeBlobFileMetas(uint64_t first_blob_file, ProcessBase process_base,
                           ProcessMutable process_mutable,
                           ProcessBoth process_both) const {
@@ -916,7 +916,7 @@ class VersionBuilder::Rep {
     }
   }
 
-  template <class Meta>
+  template <typename Meta>
   static bool CheckLinkedSsts(const Meta& meta,
                               uint64_t* min_oldest_blob_file_num) {
     assert(min_oldest_blob_file_num);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -847,6 +847,15 @@ class VersionBuilder::Rep {
     return Status::OK();
   }
 
+  // Helper function template for merging the blob file metadata from the base
+  // version with the mutable metadata representing the state after applying the
+  // edits. The function objects process_base and process_mutable are
+  // respectively called to handle a base version object when there is no
+  // matching mutable object, and a mutable object when there is no matching
+  // base version object. process_both is called to perform the merge when a
+  // given blob file appears both in the base version and the mutable list. The
+  // helper stops processing objects if a function object returns false. Blob
+  // files with a file number below first_blob_file are not processed.
   template <typename ProcessBase, typename ProcessMutable, typename ProcessBoth>
   void MergeBlobFileMetas(uint64_t first_blob_file, ProcessBase process_base,
                           ProcessMutable process_mutable,
@@ -916,6 +925,8 @@ class VersionBuilder::Rep {
     }
   }
 
+  // Helper function template for finding the first blob file that has linked
+  // SSTs.
   template <typename Meta>
   static bool CheckLinkedSsts(const Meta& meta,
                               uint64_t* min_oldest_blob_file_num) {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -933,7 +933,7 @@ class VersionBuilder::Rep {
     assert(min_oldest_blob_file_num);
 
     if (!meta.GetLinkedSsts().empty()) {
-      assert(*min_oldest_blob_file_num == std::numeric_limits<uint64_t>::max());
+      assert(*min_oldest_blob_file_num == kInvalidBlobFileNumber);
 
       *min_oldest_blob_file_num = meta.GetBlobFileNumber();
 
@@ -945,7 +945,7 @@ class VersionBuilder::Rep {
 
   // Find the oldest blob file that has linked SSTs.
   uint64_t GetMinOldestBlobFileNumber() const {
-    uint64_t min_oldest_blob_file_num = std::numeric_limits<uint64_t>::max();
+    uint64_t min_oldest_blob_file_num = kInvalidBlobFileNumber;
 
     auto process_base =
         [&min_oldest_blob_file_num](

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -973,8 +973,8 @@ class VersionBuilder::Rep {
 
   // Add the blob file specified by meta to *vstorage if it is determined to
   // contain valid data (blobs).
-  static void AddBlobFileIfNeeded(VersionStorageInfo* vstorage,
-                                  std::shared_ptr<BlobFileMetaData> meta) {
+  template <typename T>
+  static void AddBlobFileIfNeeded(VersionStorageInfo* vstorage, T&& meta) {
     assert(vstorage);
     assert(meta);
 
@@ -983,7 +983,7 @@ class VersionBuilder::Rep {
       return;
     }
 
-    vstorage->AddBlobFile(std::move(meta));
+    vstorage->AddBlobFile(std::forward<T>(meta));
   }
 
   // Merge the blob file metadata from the base version with the changes (edits)

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -975,9 +975,9 @@ class VersionBuilder::Rep {
   // of garbage in the file, and whether the file or any lower-numbered blob
   // files have any linked SSTs. The latter condition is tracked using the
   // flag *found_first_non_empty.
-  void AddBlobFileIfNeeded(VersionStorageInfo* vstorage,
-                           const std::shared_ptr<BlobFileMetaData>& meta,
-                           bool* found_first_non_empty) const {
+  static void AddBlobFileIfNeeded(VersionStorageInfo* vstorage,
+                                  const std::shared_ptr<BlobFileMetaData>& meta,
+                                  bool* found_first_non_empty) {
     assert(vstorage);
     assert(meta);
     assert(found_first_non_empty);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1005,8 +1005,7 @@ class VersionBuilder::Rep {
 
     auto process_mutable =
         [vstorage](const MutableBlobFileMetaData& mutable_meta) {
-          auto meta = CreateBlobFileMetaData(mutable_meta);
-          AddBlobFileIfNeeded(vstorage, meta);
+          AddBlobFileIfNeeded(vstorage, CreateBlobFileMetaData(mutable_meta));
 
           return true;
         };
@@ -1029,9 +1028,7 @@ class VersionBuilder::Rep {
         return true;
       }
 
-      auto meta = CreateBlobFileMetaData(mutable_meta);
-
-      AddBlobFileIfNeeded(vstorage, meta);
+      AddBlobFileIfNeeded(vstorage, CreateBlobFileMetaData(mutable_meta));
 
       return true;
     };

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -941,7 +941,7 @@ class VersionBuilder::Rep {
     }
 
     return true;
-  };
+  }
 
   // Find the oldest blob file that has linked SSTs.
   uint64_t GetMinOldestBlobFileNumber() const {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -967,7 +967,7 @@ class VersionBuilder::Rep {
       assert(base_meta);
       assert(base_meta->GetSharedMeta() == mutable_meta.GetSharedMeta());
 #else
-      void(base_meta);
+      (void)base_meta;
 #endif
 
       // Look at mutable_meta since it supersedes *base_meta

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -674,122 +674,6 @@ class VersionBuilder::Rep {
     return meta->oldest_blob_file_number;
   }
 
-  template <class ProcessBase, class ProcessMutable, class ProcessBoth>
-  void MergeBlobFileMetas(ProcessBase process_base,
-                          ProcessMutable process_mutable,
-                          ProcessBoth process_both) const {
-    assert(base_vstorage_);
-
-    const auto& base_blob_files = base_vstorage_->GetBlobFiles();
-    auto base_it = base_blob_files.begin();
-    const auto base_it_end = base_blob_files.end();
-
-    auto mutable_it = mutable_blob_file_metas_.begin();
-    const auto mutable_it_end = mutable_blob_file_metas_.end();
-
-    while (base_it != base_it_end && mutable_it != mutable_it_end) {
-      const uint64_t base_blob_file_number = base_it->first;
-      const uint64_t mutable_blob_file_number = mutable_it->first;
-
-      if (base_blob_file_number < mutable_blob_file_number) {
-        const auto& base_meta = base_it->second;
-
-        if (!process_base(base_meta)) {
-          return;
-        }
-
-        ++base_it;
-      } else if (mutable_blob_file_number < base_blob_file_number) {
-        const auto& mutable_meta = mutable_it->second;
-
-        if (!process_mutable(mutable_meta)) {
-          return;
-        }
-
-        ++mutable_it;
-      } else {
-        assert(base_blob_file_number == mutable_blob_file_number);
-
-        const auto& base_meta = base_it->second;
-        const auto& mutable_meta = mutable_it->second;
-
-        if (!process_both(base_meta, mutable_meta)) {
-          return;
-        }
-
-        ++base_it;
-        ++mutable_it;
-      }
-    }
-
-    while (base_it != base_it_end) {
-      const auto& base_meta = base_it->second;
-
-      if (!process_base(base_meta)) {
-        return;
-      }
-
-      ++base_it;
-    }
-
-    while (mutable_it != mutable_it_end) {
-      const auto& mutable_meta = mutable_it->second;
-
-      if (!process_mutable(mutable_meta)) {
-        return;
-      }
-
-      ++mutable_it;
-    }
-  }
-
-  template <class Meta>
-  static bool ProcessMeta(const Meta& meta,
-                          uint64_t* min_oldest_blob_file_num) {
-    assert(min_oldest_blob_file_num);
-
-    if (!meta.GetLinkedSsts().empty()) {
-      assert(*min_oldest_blob_file_num == std::numeric_limits<uint64_t>::max());
-
-      *min_oldest_blob_file_num = meta.GetBlobFileNumber();
-
-      return false;
-    }
-
-    return true;
-  };
-
-  uint64_t GetMinOldestBlobFileNumber() const {
-    uint64_t min_oldest_blob_file_num = std::numeric_limits<uint64_t>::max();
-
-    auto process_base =
-        [&min_oldest_blob_file_num](
-            const std::shared_ptr<BlobFileMetaData>& base_meta) {
-          assert(base_meta);
-
-          return ProcessMeta(*base_meta, &min_oldest_blob_file_num);
-        };
-
-    auto process_mutable = [&min_oldest_blob_file_num](
-                               const MutableBlobFileMetaData& mutable_meta) {
-      return ProcessMeta(mutable_meta, &min_oldest_blob_file_num);
-    };
-
-    auto process_both = [&min_oldest_blob_file_num](
-                            const std::shared_ptr<BlobFileMetaData>& base_meta,
-                            const MutableBlobFileMetaData& mutable_meta) {
-      assert(base_meta);
-      assert(base_meta->GetSharedMeta() == mutable_meta.GetSharedMeta());
-
-      // Look at mutable_meta since that's the up-to-date state
-      return ProcessMeta(mutable_meta, &min_oldest_blob_file_num);
-    };
-
-    MergeBlobFileMetas(process_base, process_mutable, process_both);
-
-    return min_oldest_blob_file_num;
-  }
-
   Status ApplyFileDeletion(int level, uint64_t file_number) {
     assert(level != VersionStorageInfo::FileLocation::Invalid().GetLevel());
 
@@ -961,6 +845,122 @@ class VersionBuilder::Rep {
     }
 
     return Status::OK();
+  }
+
+  template <class ProcessBase, class ProcessMutable, class ProcessBoth>
+  void MergeBlobFileMetas(ProcessBase process_base,
+                          ProcessMutable process_mutable,
+                          ProcessBoth process_both) const {
+    assert(base_vstorage_);
+
+    const auto& base_blob_files = base_vstorage_->GetBlobFiles();
+    auto base_it = base_blob_files.begin();
+    const auto base_it_end = base_blob_files.end();
+
+    auto mutable_it = mutable_blob_file_metas_.begin();
+    const auto mutable_it_end = mutable_blob_file_metas_.end();
+
+    while (base_it != base_it_end && mutable_it != mutable_it_end) {
+      const uint64_t base_blob_file_number = base_it->first;
+      const uint64_t mutable_blob_file_number = mutable_it->first;
+
+      if (base_blob_file_number < mutable_blob_file_number) {
+        const auto& base_meta = base_it->second;
+
+        if (!process_base(base_meta)) {
+          return;
+        }
+
+        ++base_it;
+      } else if (mutable_blob_file_number < base_blob_file_number) {
+        const auto& mutable_meta = mutable_it->second;
+
+        if (!process_mutable(mutable_meta)) {
+          return;
+        }
+
+        ++mutable_it;
+      } else {
+        assert(base_blob_file_number == mutable_blob_file_number);
+
+        const auto& base_meta = base_it->second;
+        const auto& mutable_meta = mutable_it->second;
+
+        if (!process_both(base_meta, mutable_meta)) {
+          return;
+        }
+
+        ++base_it;
+        ++mutable_it;
+      }
+    }
+
+    while (base_it != base_it_end) {
+      const auto& base_meta = base_it->second;
+
+      if (!process_base(base_meta)) {
+        return;
+      }
+
+      ++base_it;
+    }
+
+    while (mutable_it != mutable_it_end) {
+      const auto& mutable_meta = mutable_it->second;
+
+      if (!process_mutable(mutable_meta)) {
+        return;
+      }
+
+      ++mutable_it;
+    }
+  }
+
+  template <class Meta>
+  static bool ProcessMeta(const Meta& meta,
+                          uint64_t* min_oldest_blob_file_num) {
+    assert(min_oldest_blob_file_num);
+
+    if (!meta.GetLinkedSsts().empty()) {
+      assert(*min_oldest_blob_file_num == std::numeric_limits<uint64_t>::max());
+
+      *min_oldest_blob_file_num = meta.GetBlobFileNumber();
+
+      return false;
+    }
+
+    return true;
+  };
+
+  uint64_t GetMinOldestBlobFileNumber() const {
+    uint64_t min_oldest_blob_file_num = std::numeric_limits<uint64_t>::max();
+
+    auto process_base =
+        [&min_oldest_blob_file_num](
+            const std::shared_ptr<BlobFileMetaData>& base_meta) {
+          assert(base_meta);
+
+          return ProcessMeta(*base_meta, &min_oldest_blob_file_num);
+        };
+
+    auto process_mutable = [&min_oldest_blob_file_num](
+                               const MutableBlobFileMetaData& mutable_meta) {
+      return ProcessMeta(mutable_meta, &min_oldest_blob_file_num);
+    };
+
+    auto process_both = [&min_oldest_blob_file_num](
+                            const std::shared_ptr<BlobFileMetaData>& base_meta,
+                            const MutableBlobFileMetaData& mutable_meta) {
+      assert(base_meta);
+      assert(base_meta->GetSharedMeta() == mutable_meta.GetSharedMeta());
+
+      // Look at mutable_meta since that's the up-to-date state
+      return ProcessMeta(mutable_meta, &min_oldest_blob_file_num);
+    };
+
+    MergeBlobFileMetas(process_base, process_mutable, process_both);
+
+    return min_oldest_blob_file_num;
   }
 
   static std::shared_ptr<BlobFileMetaData> CreateBlobFileMetaData(

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -963,8 +963,12 @@ class VersionBuilder::Rep {
     auto process_both = [&min_oldest_blob_file_num](
                             const std::shared_ptr<BlobFileMetaData>& base_meta,
                             const MutableBlobFileMetaData& mutable_meta) {
+#ifndef NDEBUG
       assert(base_meta);
       assert(base_meta->GetSharedMeta() == mutable_meta.GetSharedMeta());
+#else
+      void(base_meta);
+#endif
 
       // Look at mutable_meta since it supersedes *base_meta
       return CheckLinkedSsts(mutable_meta, &min_oldest_blob_file_num);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -917,8 +917,8 @@ class VersionBuilder::Rep {
   }
 
   template <class Meta>
-  static bool ProcessMeta(const Meta& meta,
-                          uint64_t* min_oldest_blob_file_num) {
+  static bool CheckLinkedSsts(const Meta& meta,
+                              uint64_t* min_oldest_blob_file_num) {
     assert(min_oldest_blob_file_num);
 
     if (!meta.GetLinkedSsts().empty()) {
@@ -940,12 +940,12 @@ class VersionBuilder::Rep {
             const std::shared_ptr<BlobFileMetaData>& base_meta) {
           assert(base_meta);
 
-          return ProcessMeta(*base_meta, &min_oldest_blob_file_num);
+          return CheckLinkedSsts(*base_meta, &min_oldest_blob_file_num);
         };
 
     auto process_mutable = [&min_oldest_blob_file_num](
                                const MutableBlobFileMetaData& mutable_meta) {
-      return ProcessMeta(mutable_meta, &min_oldest_blob_file_num);
+      return CheckLinkedSsts(mutable_meta, &min_oldest_blob_file_num);
     };
 
     auto process_both = [&min_oldest_blob_file_num](
@@ -955,7 +955,7 @@ class VersionBuilder::Rep {
       assert(base_meta->GetSharedMeta() == mutable_meta.GetSharedMeta());
 
       // Look at mutable_meta since that's the up-to-date state
-      return ProcessMeta(mutable_meta, &min_oldest_blob_file_num);
+      return CheckLinkedSsts(mutable_meta, &min_oldest_blob_file_num);
     };
 
     MergeBlobFileMetas(kInvalidBlobFileNumber, process_base, process_mutable,

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -943,6 +943,7 @@ class VersionBuilder::Rep {
     return true;
   };
 
+  // Find the oldest blob file that has linked SSTs.
   uint64_t GetMinOldestBlobFileNumber() const {
     uint64_t min_oldest_blob_file_num = std::numeric_limits<uint64_t>::max();
 
@@ -965,7 +966,7 @@ class VersionBuilder::Rep {
       assert(base_meta);
       assert(base_meta->GetSharedMeta() == mutable_meta.GetSharedMeta());
 
-      // Look at mutable_meta since that's the up-to-date state
+      // Look at mutable_meta since it supersedes *base_meta
       return CheckLinkedSsts(mutable_meta, &min_oldest_blob_file_num);
     };
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -973,9 +973,8 @@ class VersionBuilder::Rep {
 
   // Add the blob file specified by meta to *vstorage if it is determined to
   // contain valid data (blobs).
-  static void AddBlobFileIfNeeded(
-      VersionStorageInfo* vstorage,
-      const std::shared_ptr<BlobFileMetaData>& meta) {
+  static void AddBlobFileIfNeeded(VersionStorageInfo* vstorage,
+                                  std::shared_ptr<BlobFileMetaData> meta) {
     assert(vstorage);
     assert(meta);
 
@@ -984,7 +983,7 @@ class VersionBuilder::Rep {
       return;
     }
 
-    vstorage->AddBlobFile(meta);
+    vstorage->AddBlobFile(std::move(meta));
   }
 
   // Merge the blob file metadata from the base version with the changes (edits)

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -314,7 +314,7 @@ class VersionBuilder::Rep {
     (*expected_linked_ssts)[blob_file_number].emplace(table_file_number);
   }
 
-  template <class Checker>
+  template <typename Checker>
   Status CheckConsistencyDetailsForLevel(
       const VersionStorageInfo* vstorage, int level, Checker checker,
       const std::string& sync_point,
@@ -989,8 +989,8 @@ class VersionBuilder::Rep {
 
   // Add the blob file specified by meta to *vstorage if it is determined to
   // contain valid data (blobs).
-  template <typename T>
-  static void AddBlobFileIfNeeded(VersionStorageInfo* vstorage, T&& meta) {
+  template <typename Meta>
+  static void AddBlobFileIfNeeded(VersionStorageInfo* vstorage, Meta&& meta) {
     assert(vstorage);
     assert(meta);
 
@@ -999,7 +999,7 @@ class VersionBuilder::Rep {
       return;
     }
 
-    vstorage->AddBlobFile(std::forward<T>(meta));
+    vstorage->AddBlobFile(std::forward<Meta>(meta));
   }
 
   // Merge the blob file metadata from the base version with the changes (edits)
@@ -1079,7 +1079,7 @@ class VersionBuilder::Rep {
     }
   }
 
-  template <class Cmp>
+  template <typename Cmp>
   void SaveSSTFilesTo(VersionStorageInfo* vstorage, int level, Cmp cmp) const {
     // Merge the set of added files with the set of pre-existing files.
     // Drop any deleted files.  Store the result in *vstorage.

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3044,8 +3044,7 @@ void VersionStorageInfo::AddBlobFile(
   auto it = blob_files_.lower_bound(blob_file_number);
   assert(it == blob_files_.end() || it->first != blob_file_number);
 
-  blob_files_.insert(
-      it, BlobFiles::value_type(blob_file_number, std::move(blob_file_meta)));
+  blob_files_.emplace_hint(it, blob_file_number, std::move(blob_file_meta));
 }
 
 // Version::PrepareApply() need to be called before calling the function, or


### PR DESCRIPTION
Summary:
The patch refactors and unifies the logic in `VersionBuilder::SaveBlobFilesTo`
and `VersionBuilder::GetMinOldestBlobFileNumber` by introducing a generic
helper that can "merge" the list of `BlobFileMetaData` in the base version with
the list of `MutableBlobFileMetaData` representing the updated state after
applying a sequence of `VersionEdit`s. This serves as groundwork for subsequent
changes that will enable us to determine whether a blob file is live after applying
a sequence of edits without calling `VersionBuilder::SaveTo`.

Test Plan:
`make check`