### PR TITLE
[RFC] Fix (?) an ingestion related LSM tree consistency check

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -383,7 +383,7 @@ class VersionBuilder::Rep {
             // This is an external file that we ingested
             const SequenceNumber external_file_seqno = rhs->fd.smallest_seqno;
 
-            if (!(external_file_seqno < lhs->fd.largest_seqno ||
+            if (!(external_file_seqno < lhs->fd.smallest_seqno ||
                   external_file_seqno == 0)) {
               std::ostringstream oss;
               oss << "L0 file #" << lhs->fd.GetNumber() << " with seqno "


### PR DESCRIPTION
Summary:
IIUC the goal here is to detect overlaps between sequence number ranges
in L0; if so, we should really be comparing against `smallest_seqno`, not
`largest_seqno`. (See also the L0 check for the non-ingestion case.)

Seems to me this has been broken (?) since 2016 and has somehow
survived through multiple rounds of changes. It was introduced
when `IngestExternalFile` was first added in
https://github.com/facebook/rocksdb/commit/869ae5d7868d7d48dd55b7be02a23581101ed69a :
that patch flipped the order of comparisons in `NewestFirstBySeqNo` from
(`smallest_seqno`, `largest_seqno`) to (`largest_seqno`, `smallest_seqno`)
but didn't consider this change in the consistency check. This effectively
turned this check into a no-op, since the previous check already ensures the
`largest_seqno`s are in decreasing order (assuming they are different), and
`smallest_seqno` is supposed to be less than or equal to `largest_seqno`
for any given file.

Test Plan:
Will add some unit tests if we agree this is broken.