### PR TITLE
[TechDebt][ResourceMngmt]Minor improvement to CacheReservationManager/WriteBufferManager/CompressionDictBuilding

### DIFF
--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -61,7 +61,7 @@ class WriteBufferManager final {
   bool enabled() const { return buffer_size() > 0; }
 
   // Returns true if pointer to cache is passed.
-  bool cost_to_cache() const { return cache_rev_mng_ != nullptr; }
+  bool cost_to_cache() const { return cache_res_mgr_ != nullptr; }
 
   // Returns the total memory used by memtables.
   // Only valid if enabled()
@@ -158,9 +158,9 @@ class WriteBufferManager final {
   std::atomic<size_t> memory_used_;
   // Memory that hasn't been scheduled to free.
   std::atomic<size_t> memory_active_;
-  std::unique_ptr<CacheReservationManager> cache_rev_mng_;
-  // Protects cache_rev_mng_
-  std::mutex cache_rev_mng_mu_;
+  std::unique_ptr<CacheReservationManager> cache_res_mgr_;
+  // Protects cache_res_mgr_
+  std::mutex cache_res_mgr_mu_;
 
   std::list<StallInterface*> queue_;
   // Protects the queue_ and stall_active_.

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1931,6 +1931,7 @@ void BlockBasedTableBuilder::EnterUnbuffered() {
   }
   r->data_block_buffers.clear();
   r->data_begin_offset = 0;
+  // Release all reserved cache for data block buffers
   if (r->compression_dict_buffer_cache_res_mgr != nullptr) {
     Status s = r->compression_dict_buffer_cache_res_mgr->UpdateCacheReservation<
         CacheEntryRole::kCompressionDictionaryBuildingBuffer>(


### PR DESCRIPTION
Context:
Similar to https://github.com/facebook/rocksdb/pull/9072, https://github.com/facebook/rocksdb/pull/9032, this PR is to clear up some small tech debts in coding of my previous work.

Summary:
- In `CacheReservationManagerTest`, replaced hard-coded test value related to `CacheReservationManager::kSizeDummyEntry` with `CacheReservationManager::GetDummyEntrySize()`
  - I did not replace other tests heavily relying on  `CacheReservationManager::kSizeDummyEntry` being `256 * 1024`. As we don't anticipate change in this value for the near future, we just live with it now.
 - In `WriteBufferManager`, renamed private variable `cache_rev_mng`/`cache_rev_mng_mu` to `cache_res_mgr`/`cache_res_mgr_mu`  for accurate abbreviation of `cache_reservation_manager`
 - In `BlockBasedTableBuilder`, Added a line of comment on releasing cache when we clear up all the buffered data blocks in compression dictionary building

Testing:
- Relied on existing tests as the focus will be finding compilation error