### PR TITLE
Fix an assertion failure when ManifestTailer switches to new Manifest in multi-cf mode

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,7 @@
 * Explicitly check for and disallow the `BlockBasedTableOptions` if insertion into one of {`block_cache`, `block_cache_compressed`, `persistent_cache`} can show up in another of these. (RocksDB expects to be able to use the same key for different physical data among tiers.)
 * Users who configured a dedicated thread pool for bottommost compactions by explicitly adding threads to the `Env::Priority::BOTTOM` pool will no longer see RocksDB schedule automatic compactions exceeding the DB's compaction concurrency limit. For details on per-DB compaction concurrency limit, see API docs of `max_background_compactions` and `max_background_jobs`.
 * Fixed a bug of background flush thread picking more memtables to flush and prematurely advancing column family's log_number.
+* Fixed an assertion failure in ManifestTailer.
 
 ### Behavior Changes
 * `NUM_FILES_IN_SINGLE_COMPACTION` was only counting the first input level files, now it's including all input files.

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -874,7 +874,7 @@ Status ManifestTailer::OnColumnFamilyAdd(VersionEdit& edit,
 
 #ifndef NDEBUG
   auto version_iter = versions_.find(edit.GetColumnFamily());
-  assert(version_iter != versions_.end());
+  assert(version_iter == versions_.end());
 #endif  // !NDEBUG
   return Status::OK();
 }

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -639,6 +639,9 @@ void VersionEditHandlerPointInTime::CheckIterationResult(
       }
     }
   } else {
+    for (const auto& elem : versions_) {
+      delete elem.second;
+    }
     versions_.clear();
   }
 }

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -638,6 +638,8 @@ void VersionEditHandlerPointInTime::CheckIterationResult(
         versions_.erase(v_iter);
       }
     }
+  } else {
+    versions_.clear();
   }
 }
 


### PR DESCRIPTION
Original unit test fail to test the case of multi-cf mode switching to new manifest. The assertion
failure will trigger when the primary instance reopens and secondary continues to tail the
newly-created MANIFEST. Fix the assertion failure and update existing unit tests.

Test plan:
make check