### PR TITLE
6.26.fb - Remove invalid RocksJava native entry

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -50,7 +50,6 @@ NATIVE_JAVA_CLASSES = \
 	org.rocksdb.OptimisticTransactionDB\
 	org.rocksdb.OptimisticTransactionOptions\
 	org.rocksdb.Options\
-	org.rocksdb.OptionsString\
 	org.rocksdb.OptionsUtil\
 	org.rocksdb.PersistentCache\
 	org.rocksdb.PlainTableConfig\


### PR DESCRIPTION
This is a backport of https://github.com/facebook/rocksdb/pull/9147 to the 6.26.fb branch

----

It seems that an incorrect native source file entry was introduced in https://github.com/facebook/rocksdb/pull/8999. For some reason it appears that CI was not run against that PR, and so the problem was not detected.

This PR fixes the problem by removing the invalid entry, allowing RocksJava to build correctly again.

CC @alanpaxton