### PR TITLE
Fix backward compatibility breakage in FileSystemWrapper

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1195,7 +1195,7 @@ class FileSystemWrapper : public FileSystem {
 
   // Deprecated. Will be removed in a major release. Derived classes
   // should implement this method.
-  virtual const char* Name() const override { return target_->Name(); }
+  const char* Name() const override { return target_->Name(); }
 
   // Return the target to which this Env forwards all calls
   FileSystem* target() const { return target_.get(); }

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1193,6 +1193,10 @@ class FileSystemWrapper : public FileSystem {
   explicit FileSystemWrapper(const std::shared_ptr<FileSystem>& t);
   ~FileSystemWrapper() override {}
 
+  // Deprecated. Will be removed in a major release. Derived classes
+  // should implement this method.
+  virtual const char* Name() const override { return target_->Name(); }
+
   // Return the target to which this Env forwards all calls
   FileSystem* target() const { return target_.get(); }
 


### PR DESCRIPTION
Implement the Name() method in FileSystemWrapper, since #8649 removed it and it can cause compilation failures. We can deprecate it in RocksDB 7.0.