### PR TITLE
Fix integer overflow in TraceOptions

### DIFF
--- a/java/src/main/java/org/rocksdb/TraceOptions.java
+++ b/java/src/main/java/org/rocksdb/TraceOptions.java
@@ -13,7 +13,7 @@ public class TraceOptions {
   private final long maxTraceFileSize;
 
   public TraceOptions() {
-    this.maxTraceFileSize = 64 * 1024 * 1024 * 1024;  // 64 GB
+    this.maxTraceFileSize = 64L * 1024 * 1024 * 1024; // 64 GB
   }
 
   public TraceOptions(final long maxTraceFileSize) {
@@ -21,8 +21,8 @@ public class TraceOptions {
   }
 
   /**
-   * To avoid the trace file size grows large than the storage space,
-   * user can set the max trace file size in Bytes. Default is 64GB
+   * To avoid the trace file size grows larger than the storage space,
+   * user can set the max trace file size in Bytes. Default is 64 GB.
    *
    * @return the max trace size
    */


### PR DESCRIPTION
Hello from a happy user of rocksdb java :-)

Default constructor of TraceOptions is supposed to initialize size to 64GB but the expression contains an integer overflow. 

Simple test case with JShell:
```
jshell> 64 * 1024 * 1024 * 1024
$1 ==> 0

jshell> 64L * 1024 * 1024 * 1024
$2 ==> 68719476736
```