### PR TITLE
db_stress: db_stress segmentation fault

### DIFF
--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -12,6 +12,7 @@
 #include "file/filename.h"
 #include "rocksdb/db.h"
 #include "rocksdb/file_system.h"
+#include "rocksdb/env.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/table_properties.h"
 #include "rocksdb/unique_id.h"
@@ -26,7 +27,7 @@ namespace ROCKSDB_NAMESPACE {
 // Verify across process executions that all seen IDs are unique
 class UniqueIdVerifier {
  public:
-  explicit UniqueIdVerifier(const std::string& db_name);
+  explicit UniqueIdVerifier(const std::string& db_name, Env* env);
   ~UniqueIdVerifier();
 
   void Verify(const std::string& id);
@@ -49,12 +50,13 @@ class DbStressListener : public EventListener {
  public:
   DbStressListener(const std::string& db_name,
                    const std::vector<DbPath>& db_paths,
-                   const std::vector<ColumnFamilyDescriptor>& column_families)
+                   const std::vector<ColumnFamilyDescriptor>& column_families,
+		   Env* env)
       : db_name_(db_name),
         db_paths_(db_paths),
         column_families_(column_families),
         num_pending_file_creations_(0),
-        unique_ids_(db_name) {}
+        unique_ids_(db_name, env) {}
 
   const char* Name() const override { return kClassName(); }
   static const char* kClassName() { return "DBStressListener"; }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2497,7 +2497,8 @@ void StressTest::Open() {
     options_.listeners.clear();
 #ifndef ROCKSDB_LITE
     options_.listeners.emplace_back(
-        new DbStressListener(FLAGS_db, options_.db_paths, cf_descriptors));
+        new DbStressListener(FLAGS_db, options_.db_paths,
+		cf_descriptors, db_stress_env));
 #endif  // !ROCKSDB_LITE
     options_.create_missing_column_families = true;
     if (!FLAGS_use_txn) {


### PR DESCRIPTION
db_stress seg faults with below commands.

"rm -rf /tmp/rocksdbtest*; sudo ./db_stress --ops_per_thread=1000 --reopen=5 --fs_uri=zenfs://dev:nvmeXnY"
"rm -rf /tmp/rocksdbtest*; db_stress --ops_per_thread=1000 --reopen=5"
=======================================
Error opening unique id file for append: IO error: No such file or directory:
 While open a file for appending: /tmp/rocksdbtest-0/dbstress/.unique_ids:
 No such file or directory
Choosing random keys with no overwrite
Creating 2621440 locks
Starting continuous_verification_thread
2021/11/15-08:46:49  Initializing worker threads
2021/11/15-08:46:49  Starting database operations
2021/11/15-08:46:49  Reopening database for the 1th time
WARNING: prefix_size is non-zero but memtablerep != prefix_hash
DB path: [/tmp/rocksdbtest-0/dbstress]
Segmentation fault
=======================================

db_stress is also broken for custom filesystems such as ZenFS(RocksDb plugin).

This happens on a new database, UniqueIdVerifier's constructor tries to read the
".unique_ids" file, if the file is not present, the data_file_writer_ is set as
an invalid(null) pointer and in subsequent calls (~UniqueIdVerifier()
and UniqueIdVerifier::Verify()) it accesses this null pointer and crashes.

This patch uses the filesystem interface from relevant environment and creates
the .unique_ids file if it does not exist, so that data_file_writer_
points to a valid file and is not null. This patch also fixes the
issue for custom filesystems.

Signed-off-by: Aravind Ramesh <Aravind.Ramesh@wdc.com>