### PR TITLE
Add listener API that notifies on IOError

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Added new option "adaptive_readahead" in ReadOptions. For iterators, RocksDB does auto-readahead on noticing sequential reads and by enabling this option, readahead_size of current file (if reads are sequential) will be carried forward to next file instead of starting from the scratch at each level (except L0 level files). If reads are not sequential it will fall back to 8KB. This option is applicable only for RocksDB internal prefetch buffer and isn't supported with underlying file system prefetching.
 * Added the read count and read bytes related stats to Statistics for tiered storage hot, warm, and cold file reads.
 * Added an option to dynamically charge an updating estimated memory usage of block-based table building to block cache if block cache available. It currently only includes charging memory usage of constructing (new) Bloom Filter and Ribbon Filter to block cache. To enable this feature, set `BlockBasedTableOptions::reserve_table_builder_memory = true`.
+* Add a new API OnIOError in listener.h that notifies listeners when an IO error occurs during FileSystem operation along with filename, status etc.
 
 ### Bug Fixes
 * Prevent a `CompactRange()` with `CompactRangeOptions::change_level == true` from possibly causing corruption to the LSM state (overlapping files within a level) when run in parallel with another manual compaction. Note that setting `force_consistency_checks == true` (the default) would cause the DB to enter read-only mode in this scenario and return `Status::Corruption`, rather than committing any corruption.

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -185,7 +185,8 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
           NotifyOnFileReadFinish(orig_offset, tmp.size(), start_ts, finish_ts,
                                  io_s);
           if (!io_s.ok()) {
-            NotifyOnIOError(io_s, "Read", file_name(), tmp.size(), orig_offset);
+            NotifyOnIOError(io_s, FileOperationType::kRead, file_name(),
+                            tmp.size(), orig_offset);
           }
         }
 
@@ -248,13 +249,13 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
           auto finish_ts = FileOperationInfo::FinishNow();
           NotifyOnFileReadFinish(offset + pos, tmp_result.size(), start_ts,
                                  finish_ts, io_s);
+
           if (!io_s.ok()) {
-            NotifyOnIOError(io_s, "Read", file_name(), tmp_result.size(),
-                            offset + pos);
+            NotifyOnIOError(io_s, FileOperationType::kRead, file_name(),
+                            tmp_result.size(), offset + pos);
           }
         }
 #endif
-
         if (res_scratch == nullptr) {
           // we can't simply use `scratch` because reads of mmap'd files return
           // data in a different buffer.
@@ -437,11 +438,13 @@ IOStatus RandomAccessFileReader::MultiRead(const IOOptions& opts,
         auto finish_ts = FileOperationInfo::FinishNow();
         NotifyOnFileReadFinish(read_reqs[i].offset, read_reqs[i].result.size(),
                                start_ts, finish_ts, read_reqs[i].status);
-        if (!read_reqs[i].status.ok()) {
-          NotifyOnIOError(read_reqs[i].status, "Read", file_name(),
-                          read_reqs[i].result.size(), read_reqs[i].offset);
-        }
       }
+      if (!read_reqs[i].status.ok()) {
+        NotifyOnIOError(read_reqs[i].status, FileOperationType::kRead,
+                        file_name(), read_reqs[i].result.size(),
+                        read_reqs[i].offset);
+      }
+
 #endif  // ROCKSDB_LITE
       IOSTATS_ADD(bytes_read, read_reqs[i].result.size());
       IOStatsAddBytesByTemperature(file_temperature_,

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -184,6 +184,9 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
           auto finish_ts = FileOperationInfo::FinishNow();
           NotifyOnFileReadFinish(orig_offset, tmp.size(), start_ts, finish_ts,
                                  io_s);
+          if (!io_s.ok()) {
+            NotifyOnIOError(io_s, "Read", file_name(), tmp.size(), orig_offset);
+          }
         }
 
         buf.Size(buf.CurrentSize() + tmp.size());
@@ -245,6 +248,10 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
           auto finish_ts = FileOperationInfo::FinishNow();
           NotifyOnFileReadFinish(offset + pos, tmp_result.size(), start_ts,
                                  finish_ts, io_s);
+          if (!io_s.ok()) {
+            NotifyOnIOError(io_s, "Read", file_name(), tmp_result.size(),
+                            offset + pos);
+          }
         }
 #endif
 
@@ -430,6 +437,10 @@ IOStatus RandomAccessFileReader::MultiRead(const IOOptions& opts,
         auto finish_ts = FileOperationInfo::FinishNow();
         NotifyOnFileReadFinish(read_reqs[i].offset, read_reqs[i].result.size(),
                                start_ts, finish_ts, read_reqs[i].status);
+        if (!read_reqs[i].status.ok()) {
+          NotifyOnIOError(read_reqs[i].status, "Read", file_name(),
+                          read_reqs[i].result.size(), read_reqs[i].offset);
+        }
       }
 #endif  // ROCKSDB_LITE
       IOSTATS_ADD(bytes_read, read_reqs[i].result.size());

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -61,6 +61,18 @@ class RandomAccessFileReader {
       listener->OnFileReadFinish(info);
     }
   }
+
+  void NotifyOnIOError(const IOStatus& io_status, const std::string& operation,
+                       const std::string& file_path, size_t length,
+                       uint64_t offset) const {
+    IOErrorInfo io_error_info(io_status, operation, file_path, length, offset);
+
+    for (auto& listener : listeners_) {
+      listener->OnIOError(io_error_info);
+      // io_status->PermitUncheckedError();
+    }
+  }
+
 #endif  // ROCKSDB_LITE
 
   bool ShouldNotifyListeners() const { return !listeners_.empty(); }

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -60,17 +60,21 @@ class RandomAccessFileReader {
     for (auto& listener : listeners_) {
       listener->OnFileReadFinish(info);
     }
+    info.status.PermitUncheckedError();
   }
 
-  void NotifyOnIOError(const IOStatus& io_status, const std::string& operation,
+  void NotifyOnIOError(const IOStatus& io_status, FileOperationType operation,
                        const std::string& file_path, size_t length,
                        uint64_t offset) const {
+    if (listeners_.empty()) {
+      return;
+    }
     IOErrorInfo io_error_info(io_status, operation, file_path, length, offset);
 
     for (auto& listener : listeners_) {
       listener->OnIOError(io_error_info);
-      // io_status->PermitUncheckedError();
     }
+    io_status.PermitUncheckedError();
   }
 
 #endif  // ROCKSDB_LITE

--- a/file/sequence_file_reader.h
+++ b/file/sequence_file_reader.h
@@ -37,6 +37,7 @@ class SequentialFileReader {
     for (auto& listener : listeners_) {
       listener->OnFileReadFinish(info);
     }
+    info.status.PermitUncheckedError();
   }
 
   void AddFileIOListeners(

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -221,7 +221,8 @@ IOStatus WritableFileWriter::Close() {
         auto finish_ts = FileOperationInfo::FinishNow();
         NotifyOnFileTruncateFinish(start_ts, finish_ts, s);
         if (!interim.ok()) {
-          NotifyOnIOError(interim, "Truncate", file_name(), filesize_);
+          NotifyOnIOError(interim, FileOperationType::kTruncate, file_name(),
+                          filesize_);
         }
       }
 #endif
@@ -241,7 +242,7 @@ IOStatus WritableFileWriter::Close() {
           NotifyOnFileSyncFinish(start_ts, finish_ts, s,
                                  FileOperationType::kFsync);
           if (!interim.ok()) {
-            NotifyOnIOError(interim, "Fsync", file_name());
+            NotifyOnIOError(interim, FileOperationType::kFsync, file_name());
           }
         }
 #endif
@@ -266,7 +267,7 @@ IOStatus WritableFileWriter::Close() {
       auto finish_ts = FileOperationInfo::FinishNow();
       NotifyOnFileCloseFinish(start_ts, finish_ts, s);
       if (!interim.ok()) {
-        NotifyOnIOError(interim, "Close", file_name());
+        NotifyOnIOError(interim, FileOperationType::kClose, file_name());
       }
     }
 #endif
@@ -328,7 +329,7 @@ IOStatus WritableFileWriter::Flush() {
       auto finish_ts = std::chrono::steady_clock::now();
       NotifyOnFileFlushFinish(start_ts, finish_ts, s);
       if (!s.ok()) {
-        NotifyOnIOError(s, "Flush", file_name());
+        NotifyOnIOError(s, FileOperationType::kFlush, file_name());
       }
     }
 #endif
@@ -438,7 +439,9 @@ IOStatus WritableFileWriter::SyncInternal(bool use_fsync) {
         start_ts, finish_ts, s,
         use_fsync ? FileOperationType::kFsync : FileOperationType::kSync);
     if (!s.ok()) {
-      NotifyOnIOError(s, (use_fsync ? "Fsync" : "Sync"), file_name());
+      NotifyOnIOError(
+          s, (use_fsync ? FileOperationType::kFsync : FileOperationType::kSync),
+          file_name());
     }
   }
 #endif
@@ -461,7 +464,8 @@ IOStatus WritableFileWriter::RangeSync(uint64_t offset, uint64_t nbytes) {
     auto finish_ts = std::chrono::steady_clock::now();
     NotifyOnFileRangeSyncFinish(offset, nbytes, start_ts, finish_ts, s);
     if (!s.ok()) {
-      NotifyOnIOError(s, "RangeSync", file_name(), nbytes, offset);
+      NotifyOnIOError(s, FileOperationType::kRangeSync, file_name(), nbytes,
+                      offset);
     }
   }
 #endif
@@ -519,7 +523,8 @@ IOStatus WritableFileWriter::WriteBuffered(const char* data, size_t size) {
         auto finish_ts = std::chrono::steady_clock::now();
         NotifyOnFileWriteFinish(old_size, allowed, start_ts, finish_ts, s);
         if (!s.ok()) {
-          NotifyOnIOError(s, "Append", file_name(), allowed, old_size);
+          NotifyOnIOError(s, FileOperationType::kAppend, file_name(), allowed,
+                          old_size);
         }
       }
 #endif
@@ -592,7 +597,8 @@ IOStatus WritableFileWriter::WriteBufferedWithChecksum(const char* data,
       auto finish_ts = std::chrono::steady_clock::now();
       NotifyOnFileWriteFinish(old_size, left, start_ts, finish_ts, s);
       if (!s.ok()) {
-        NotifyOnIOError(s, "Append", file_name(), left, old_size);
+        NotifyOnIOError(s, FileOperationType::kAppend, file_name(), left,
+                        old_size);
       }
     }
 #endif
@@ -696,8 +702,8 @@ IOStatus WritableFileWriter::WriteDirect() {
         auto finish_ts = std::chrono::steady_clock::now();
         NotifyOnFileWriteFinish(write_offset, size, start_ts, finish_ts, s);
         if (!s.ok()) {
-          NotifyOnIOError(s, "PositionedAppend", file_name(), size,
-                          write_offset);
+          NotifyOnIOError(s, FileOperationType::kPositionedAppend, file_name(),
+                          size, write_offset);
         }
       }
       if (!s.ok()) {
@@ -790,7 +796,8 @@ IOStatus WritableFileWriter::WriteDirectWithChecksum() {
       auto finish_ts = std::chrono::steady_clock::now();
       NotifyOnFileWriteFinish(write_offset, left, start_ts, finish_ts, s);
       if (!s.ok()) {
-        NotifyOnIOError(s, "PositionedAppend", file_name(), left, write_offset);
+        NotifyOnIOError(s, FileOperationType::kPositionedAppend, file_name(),
+                        left, write_offset);
       }
     }
     if (!s.ok()) {

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -220,6 +220,9 @@ IOStatus WritableFileWriter::Close() {
       if (ShouldNotifyListeners()) {
         auto finish_ts = FileOperationInfo::FinishNow();
         NotifyOnFileTruncateFinish(start_ts, finish_ts, s);
+        if (!interim.ok()) {
+          NotifyOnIOError(interim, "Truncate", file_name(), filesize_);
+        }
       }
 #endif
     }
@@ -237,6 +240,9 @@ IOStatus WritableFileWriter::Close() {
           auto finish_ts = FileOperationInfo::FinishNow();
           NotifyOnFileSyncFinish(start_ts, finish_ts, s,
                                  FileOperationType::kFsync);
+          if (!interim.ok()) {
+            NotifyOnIOError(interim, "Fsync", file_name());
+          }
         }
 #endif
       }
@@ -259,6 +265,9 @@ IOStatus WritableFileWriter::Close() {
     if (ShouldNotifyListeners()) {
       auto finish_ts = FileOperationInfo::FinishNow();
       NotifyOnFileCloseFinish(start_ts, finish_ts, s);
+      if (!interim.ok()) {
+        NotifyOnIOError(interim, "Close", file_name());
+      }
     }
 #endif
   }
@@ -318,6 +327,9 @@ IOStatus WritableFileWriter::Flush() {
     if (ShouldNotifyListeners()) {
       auto finish_ts = std::chrono::steady_clock::now();
       NotifyOnFileFlushFinish(start_ts, finish_ts, s);
+      if (!s.ok()) {
+        NotifyOnIOError(s, "Flush", file_name());
+      }
     }
 #endif
   }
@@ -425,6 +437,9 @@ IOStatus WritableFileWriter::SyncInternal(bool use_fsync) {
     NotifyOnFileSyncFinish(
         start_ts, finish_ts, s,
         use_fsync ? FileOperationType::kFsync : FileOperationType::kSync);
+    if (!s.ok()) {
+      NotifyOnIOError(s, (use_fsync ? "Fsync" : "Sync"), file_name());
+    }
   }
 #endif
   SetPerfLevel(prev_perf_level);
@@ -445,6 +460,9 @@ IOStatus WritableFileWriter::RangeSync(uint64_t offset, uint64_t nbytes) {
   if (ShouldNotifyListeners()) {
     auto finish_ts = std::chrono::steady_clock::now();
     NotifyOnFileRangeSyncFinish(offset, nbytes, start_ts, finish_ts, s);
+    if (!s.ok()) {
+      NotifyOnIOError(s, "RangeSync", file_name(), nbytes, offset);
+    }
   }
 #endif
   return s;
@@ -500,6 +518,9 @@ IOStatus WritableFileWriter::WriteBuffered(const char* data, size_t size) {
       if (ShouldNotifyListeners()) {
         auto finish_ts = std::chrono::steady_clock::now();
         NotifyOnFileWriteFinish(old_size, allowed, start_ts, finish_ts, s);
+        if (!s.ok()) {
+          NotifyOnIOError(s, "Append", file_name(), allowed, old_size);
+        }
       }
 #endif
       if (!s.ok()) {
@@ -570,6 +591,9 @@ IOStatus WritableFileWriter::WriteBufferedWithChecksum(const char* data,
     if (ShouldNotifyListeners()) {
       auto finish_ts = std::chrono::steady_clock::now();
       NotifyOnFileWriteFinish(old_size, left, start_ts, finish_ts, s);
+      if (!s.ok()) {
+        NotifyOnIOError(s, "Append", file_name(), left, old_size);
+      }
     }
 #endif
     if (!s.ok()) {
@@ -671,6 +695,10 @@ IOStatus WritableFileWriter::WriteDirect() {
       if (ShouldNotifyListeners()) {
         auto finish_ts = std::chrono::steady_clock::now();
         NotifyOnFileWriteFinish(write_offset, size, start_ts, finish_ts, s);
+        if (!s.ok()) {
+          NotifyOnIOError(s, "PositionedAppend", file_name(), size,
+                          write_offset);
+        }
       }
       if (!s.ok()) {
         buf_.Size(file_advance + leftover_tail);
@@ -761,6 +789,9 @@ IOStatus WritableFileWriter::WriteDirectWithChecksum() {
     if (ShouldNotifyListeners()) {
       auto finish_ts = std::chrono::steady_clock::now();
       NotifyOnFileWriteFinish(write_offset, left, start_ts, finish_ts, s);
+      if (!s.ok()) {
+        NotifyOnIOError(s, "PositionedAppend", file_name(), left, write_offset);
+      }
     }
     if (!s.ok()) {
       // In this case, we do not change buffered_data_crc32c_checksum_ because

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -114,6 +114,17 @@ class WritableFileWriter {
     }
     info.status.PermitUncheckedError();
   }
+
+  void NotifyOnIOError(const IOStatus& io_status, const std::string& operation,
+                       const std::string& file_path, size_t length = 0,
+                       uint64_t offset = 0) {
+    IOErrorInfo io_error_info(io_status, operation, file_path, length, offset);
+
+    for (auto& listener : listeners_) {
+      listener->OnIOError(io_error_info);
+      // io_status->PermitUncheckedError();
+    }
+  }
 #endif  // ROCKSDB_LITE
 
   bool ShouldNotifyListeners() const { return !listeners_.empty(); }

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -115,15 +115,17 @@ class WritableFileWriter {
     info.status.PermitUncheckedError();
   }
 
-  void NotifyOnIOError(const IOStatus& io_status, const std::string& operation,
+  void NotifyOnIOError(const IOStatus& io_status, FileOperationType operation,
                        const std::string& file_path, size_t length = 0,
                        uint64_t offset = 0) {
+    if (listeners_.empty()) {
+      return;
+    }
     IOErrorInfo io_error_info(io_status, operation, file_path, length, offset);
-
     for (auto& listener : listeners_) {
       listener->OnIOError(io_error_info);
-      // io_status->PermitUncheckedError();
     }
+    io_error_info.io_status.PermitUncheckedError();
   }
 #endif  // ROCKSDB_LITE
 

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -727,7 +727,7 @@ class EventListener : public Customizable {
   virtual void OnBlobFileDeleted(const BlobFileDeletionInfo& /*info*/) {}
 
   // A callback function for RocksDB which will be called whenever an IO error
-  // happens.
+  // happens. ShouldBeNotifiedOnFileIO should be set to true to get a callback.
   virtual void OnIOError(const IOErrorInfo& /*info*/) {}
 
   virtual ~EventListener() {}

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -13,10 +13,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include "io_status.h"
 #include "rocksdb/compaction_job_stats.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/customizable.h"
+#include "rocksdb/io_status.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table_properties.h"
 #include "rocksdb/types.h"

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <chrono>
-#include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -239,7 +238,10 @@ enum class FileOperationType {
   kFlush,
   kSync,
   kFsync,
-  kRangeSync
+  kRangeSync,
+  kAppend,
+  kPositionedAppend,
+  kOpen
 };
 
 struct FileOperationInfo {
@@ -452,7 +454,7 @@ struct ExternalFileIngestionInfo {
 };
 
 struct IOErrorInfo {
-  IOErrorInfo(const IOStatus& _io_status, const std::string& _operation,
+  IOErrorInfo(const IOStatus& _io_status, FileOperationType _operation,
               const std::string& _file_path, size_t _length, uint64_t _offset)
       : io_status(_io_status),
         operation(_operation),
@@ -461,7 +463,7 @@ struct IOErrorInfo {
         offset(_offset) {}
 
   IOStatus io_status;
-  std::string operation;
+  FileOperationType operation;
   std::string file_path;
   size_t length;
   uint64_t offset;

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -7,11 +7,13 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "io_status.h"
 #include "rocksdb/compaction_job_stats.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/customizable.h"
@@ -449,6 +451,23 @@ struct ExternalFileIngestionInfo {
   TableProperties table_properties;
 };
 
+struct IOErrorInfo {
+  IOErrorInfo(const IOStatus& _io_status, const std::string& _operation,
+              const std::string& _file_path, size_t _length, uint64_t _offset)
+      : io_status(_io_status),
+        operation(_operation),
+        file_path(_file_path),
+        length(_length),
+        offset(_offset) {}
+
+  IOStatus io_status;
+  std::string operation;
+  std::string file_path;
+  size_t length;
+  uint64_t offset;
+  ;
+};
+
 // EventListener class contains a set of callback functions that will
 // be called when specific RocksDB event happens such as flush.  It can
 // be used as a building block for developing custom features such as
@@ -704,6 +723,10 @@ class EventListener : public Customizable {
   // outside this function call, they should make copies from these
   // returned value.
   virtual void OnBlobFileDeleted(const BlobFileDeletionInfo& /*info*/) {}
+
+  // A callback function for RocksDB which will be called whenever an IO error
+  // happens.
+  virtual void OnIOError(const IOErrorInfo& /*info*/) {}
 
   virtual ~EventListener() {}
 };


### PR DESCRIPTION
Summary: Add a new API in listener.h that notifies about IOErrors on
Read/Write/Append/Flush etc. The API reports about IOStatus, filename, Operation
name, offset and length.

Test Plan: In progress

Reviewers:

Subscribers:

Tasks:

Tags: