### PR TITLE
[internal] Parallelize sandcastle tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -879,9 +879,9 @@ tests-regexp = .
 EXCLUDE_TESTS_REGEX ?= "^$"
 
 ifeq ($(PRINT_PARALLEL_OUTPUTS), 1)
-	parallel_com = '{}'
+	parallel_redir =
 else
-	parallel_com = '{} >& t/log-{/}'
+	parallel_redir = >& t/$(test_log_prefix)log-{/}
 endif
 
 .PHONY: check_0
@@ -898,7 +898,7 @@ check_0:
 	  | $(prioritize_long_running_tests)				\
 	  | grep -E '$(tests-regexp)'					\
 	  | grep -E -v '$(EXCLUDE_TESTS_REGEX)'					\
-	  | build_tools/gnu_parallel -j$(J) --plain --joblog=LOG $$eta --gnu  $(parallel_com) ; \
+	  | build_tools/gnu_parallel -j$(J) --plain --joblog=LOG $$eta --gnu '{} $(parallel_redir)' ; \
 	parallel_retcode=$$? ; \
 	awk '{ if ($$7 != 0 || $$8 != 0) { if ($$7 == "Exitval") { h = $$0; } else { if (!f) print h; print; f = 1 } } } END { if(f) exit 1; }' < LOG ; \
 	awk_retcode=$$?; \
@@ -907,6 +907,7 @@ check_0:
 valgrind-exclude-regexp = InlineSkipTest.ConcurrentInsert|TransactionStressTest.DeadlockStress|DBCompactionTest.SuggestCompactRangeNoTwoLevel0Compactions|BackupableDBTest.RateLimiting|DBTest.CloseSpeedup|DBTest.ThreadStatusFlush|DBTest.RateLimitingTest|DBTest.EncodeDecompressedBlockSizeTest|FaultInjectionTest.UninstalledCompaction|HarnessTest.Randomized|ExternalSSTFileTest.CompactDuringAddFileRandom|ExternalSSTFileTest.IngestFileWithGlobalSeqnoRandomized|MySQLStyleTransactionTest.TransactionStressTest
 
 .PHONY: valgrind_check_0
+valgrind_check_0: test_log_prefix := valgrind_
 valgrind_check_0:
 	$(AM_V_GEN)export TEST_TMPDIR=$(TMPD);				\
 	printf '%s\n' ''						\
@@ -921,8 +922,8 @@ valgrind_check_0:
 	  | grep -E '$(tests-regexp)'					\
 	  | grep -E -v '$(valgrind-exclude-regexp)'					\
 	  | build_tools/gnu_parallel -j$(J) --plain --joblog=LOG $$eta --gnu \
-	  '(if [[ "{}" == "./"* ]] ; then $(DRIVER) {}; else {}; fi) ' \
-	  '>& t/valgrind_log-{/}'
+	  '(if [[ "{}" == "./"* ]] ; then $(DRIVER) {}; else {}; fi) \
+	  $(parallel_redir)' \
 
 CLEAN_FILES += t LOG $(TMPD)
 

--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -84,21 +84,20 @@ UPLOAD_DB_DIR="
     ]
 }"
 
-# We will eventually set the RATIO to 1, but we want do this
-# in steps. RATIO=$(nproc) will make it work as J=1
+# set default RATIO to 1, which sets J=$(nproc) and j=$(nproc)
 if [ -z $RATIO ]; then
-  RATIO=$(nproc)
+  RATIO=1
 fi
 
-if [ -z $PARALLEL_J ]; then
-  PARALLEL_J="J=$(expr $(nproc) / ${RATIO})"
+if [ -z $PARALLEL_VARS ]; then
+  # These cannot go after 'make' because of recursive make calls. Set them
+  # in shell for easy export to child make.
+  PARALLEL_VARS="PRINT_PARALLEL_OUTPUTS=1 J=$(expr $(nproc) / ${RATIO})"
 fi
 
-if [ -z $PARALLEL_j ]; then
-  PARALLEL_j="-j$(expr $(nproc) / ${RATIO})"
+if [ -z $PARALLEL_OPTS ]; then
+  PARALLEL_OPTS="-j$(expr $(nproc) / ${RATIO})"
 fi
-
-PARALLELISM="$PARALLEL_J $PARALLEL_j"
 
 DEBUG="OPT=-g"
 SHM="TEST_TMPDIR=/dev/shm/rocksdb"
@@ -158,7 +157,7 @@ UNIT_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and test RocksDB debug version\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -181,7 +180,7 @@ UNIT_TEST_NON_SHM_COMMANDS="[
             {
                 \"name\":\"Build and test RocksDB debug version\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $NON_SHM $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=non_shm_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $NON_SHM $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=non_shm_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -202,7 +201,7 @@ RELEASE_BUILD_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB release\",
-                \"shell\":\"cd $WORKING_DIR; make $PARALLEL_j release || $CONTRUN_NAME=release $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; make $PARALLEL_OPTS release || $CONTRUN_NAME=release $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -223,7 +222,7 @@ UNIT_TEST_COMMANDS_481="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and test RocksDB debug version\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $GCC_481 $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=unit_gcc_481_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $GCC_481 $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=unit_gcc_481_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -244,7 +243,7 @@ RELEASE_BUILD_COMMANDS_481="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB release on GCC 4.8.1\",
-                \"shell\":\"cd $WORKING_DIR; $GCC_481 make $PARALLEL_j release || $CONTRUN_NAME=release_gcc481 $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $GCC_481 make $PARALLEL_OPTS release || $CONTRUN_NAME=release_gcc481 $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -265,7 +264,7 @@ CLANG_UNIT_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and test RocksDB debug\",
-                \"shell\":\"cd $WORKING_DIR; $CLANG $SHM $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=clang_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $CLANG $SHM $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=clang_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -286,7 +285,7 @@ CLANG_RELEASE_BUILD_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB release\",
-                \"shell\":\"cd $WORKING_DIR; $CLANG make $PARALLEL_j release|| $CONTRUN_NAME=clang_release $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $CLANG make $PARALLEL_OPTS release|| $CONTRUN_NAME=clang_release $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -307,7 +306,7 @@ CLANG_ANALYZE_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"RocksDB build and analyze\",
-                \"shell\":\"cd $WORKING_DIR; $CLANG $SHM $DEBUG make $PARALLEL_j analyze || $CONTRUN_NAME=clang_analyze $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $CLANG $SHM $DEBUG make $PARALLEL_OPTS analyze || $CONTRUN_NAME=clang_analyze $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -328,7 +327,7 @@ CODE_COV_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build, test and collect code coverage info\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM coverage || $CONTRUN_NAME=coverage $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS coverage || $CONTRUN_NAME=coverage $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -349,7 +348,7 @@ UNITY_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build, test unity test\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG V=1 make J=1 unity_test || $CONTRUN_NAME=unity_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG V=1 $PARALLEL_VARS make $PARALLEL_OPTS unity_test || $CONTRUN_NAME=unity_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -370,7 +369,7 @@ LITE_BUILD_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB debug version\",
-                \"shell\":\"cd $WORKING_DIR; $SKIP_FORMAT_CHECKS make J=1 LITE=1 all check || $CONTRUN_NAME=lite $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS LITE=1 all check || $CONTRUN_NAME=lite $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -392,14 +391,14 @@ STRESS_CRASH_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug crash tests\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 crash_test || $CONTRUN_NAME=crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS crash_test || $CONTRUN_NAME=crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -422,14 +421,14 @@ BLACKBOX_STRESS_CRASH_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug blackbox crash tests\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 blackbox_crash_test || $CONTRUN_NAME=blackbox_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS blackbox_crash_test || $CONTRUN_NAME=blackbox_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -452,14 +451,14 @@ WHITEBOX_STRESS_CRASH_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug whitebox crash tests\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 whitebox_crash_test || $CONTRUN_NAME=whitebox_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS whitebox_crash_test || $CONTRUN_NAME=whitebox_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -482,14 +481,14 @@ STRESS_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug crash tests with atomic flush\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 crash_test_with_atomic_flush || $CONTRUN_NAME=crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_atomic_flush || $CONTRUN_NAME=crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -512,14 +511,14 @@ STRESS_CRASH_TEST_WITH_TXN_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug crash tests with txn\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 crash_test_with_txn || $CONTRUN_NAME=crash_test_with_txn $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_txn || $CONTRUN_NAME=crash_test_with_txn $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -542,14 +541,14 @@ STRESS_CRASH_TEST_WITH_TS_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug crash tests with ts\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make J=1 crash_test_with_ts || $CONTRUN_NAME=crash_test_with_ts $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_ts || $CONTRUN_NAME=crash_test_with_ts $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -594,7 +593,7 @@ ASAN_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Test RocksDB debug under ASAN\",
-\"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $ASAN $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM asan_check || $CONTRUN_NAME=asan_check $TASK_CREATION_TOOL\",
+\"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $ASAN $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS asan_check || $CONTRUN_NAME=asan_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -617,7 +616,7 @@ ASAN_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug asan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make J=1 asan_crash_test || $CONTRUN_NAME=asan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS asan_crash_test || $CONTRUN_NAME=asan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -641,7 +640,7 @@ ASAN_BLACKBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug blackbox asan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make J=1 blackbox_asan_crash_test || $CONTRUN_NAME=blackbox_asan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS blackbox_asan_crash_test || $CONTRUN_NAME=blackbox_asan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -665,7 +664,7 @@ ASAN_WHITEBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug whitebox asan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make J=1 whitebox_asan_crash_test || $CONTRUN_NAME=whitebox_asan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS whitebox_asan_crash_test || $CONTRUN_NAME=whitebox_asan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -689,7 +688,7 @@ ASAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug asan_crash_test_with_atomic_flush\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make J=1 asan_crash_test_with_atomic_flush || $CONTRUN_NAME=asan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS asan_crash_test_with_atomic_flush || $CONTRUN_NAME=asan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -713,7 +712,7 @@ ASAN_CRASH_TEST_WITH_TXN_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug asan_crash_test_with_txn\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make J=1 asan_crash_test_with_txn || $CONTRUN_NAME=asan_crash_test_with_txn $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS asan_crash_test_with_txn || $CONTRUN_NAME=asan_crash_test_with_txn $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -735,7 +734,7 @@ UBSAN_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Test RocksDB debug under UBSAN\",
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $UBSAN $CLANG $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM ubsan_check || $CONTRUN_NAME=ubsan_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $UBSAN $CLANG $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS ubsan_check || $CONTRUN_NAME=ubsan_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -758,7 +757,7 @@ UBSAN_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug ubsan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make J=1 ubsan_crash_test || $CONTRUN_NAME=ubsan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS ubsan_crash_test || $CONTRUN_NAME=ubsan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -782,7 +781,7 @@ UBSAN_BLACKBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug blackbox ubsan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make J=1 blackbox_ubsan_crash_test || $CONTRUN_NAME=blackbox_ubsan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS blackbox_ubsan_crash_test || $CONTRUN_NAME=blackbox_ubsan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -806,7 +805,7 @@ UBSAN_WHITEBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug whitebox ubsan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make J=1 whitebox_ubsan_crash_test || $CONTRUN_NAME=whitebox_ubsan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS whitebox_ubsan_crash_test || $CONTRUN_NAME=whitebox_ubsan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -830,7 +829,7 @@ UBSAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug ubsan_crash_test_with_atomic_flush\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make J=1 ubsan_crash_test_with_atomic_flush || $CONTRUN_NAME=ubsan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS ubsan_crash_test_with_atomic_flush || $CONTRUN_NAME=ubsan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -854,7 +853,7 @@ UBSAN_CRASH_TEST_WITH_TXN_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug ubsan_crash_test_with_txn\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make J=1 ubsan_crash_test_with_txn || $CONTRUN_NAME=ubsan_crash_test_with_txn $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS ubsan_crash_test_with_txn || $CONTRUN_NAME=ubsan_crash_test_with_txn $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -878,7 +877,7 @@ VALGRIND_TEST_COMMANDS="[
             {
                 \"name\":\"Run RocksDB debug unit tests\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG make $PARALLELISM valgrind_test || $CONTRUN_NAME=valgrind_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $PARALLEL_VARS make $PARALLEL_OPTS valgrind_test || $CONTRUN_NAME=valgrind_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -901,7 +900,7 @@ TSAN_UNIT_TEST_COMMANDS="[
             {
                 \"name\":\"Run RocksDB debug unit test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=tsan_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=tsan_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -924,7 +923,7 @@ TSAN_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make J=1 crash_test || $CONTRUN_NAME=tsan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS crash_test || $CONTRUN_NAME=tsan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -948,7 +947,7 @@ TSAN_BLACKBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make J=1 blackbox_crash_test || $CONTRUN_NAME=tsan_blackbox_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS blackbox_crash_test || $CONTRUN_NAME=tsan_blackbox_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -972,7 +971,7 @@ TSAN_WHITEBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make J=1 whitebox_crash_test || $CONTRUN_NAME=tsan_whitebox_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS whitebox_crash_test || $CONTRUN_NAME=tsan_whitebox_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -996,7 +995,7 @@ TSAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make J=1 crash_test_with_atomic_flush || $CONTRUN_NAME=tsan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_atomic_flush || $CONTRUN_NAME=tsan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -1020,7 +1019,7 @@ TSAN_CRASH_TEST_WITH_TXN_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make J=1 crash_test_with_txn || $CONTRUN_NAME=tsan_crash_test_with_txn $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_txn || $CONTRUN_NAME=tsan_crash_test_with_txn $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -1077,7 +1076,7 @@ run_no_compression()
   cat Makefile | grep -v tools/ldb_test.py > .tmp.Makefile
   mv .tmp.Makefile Makefile
   export $SKIP_FORMAT_CHECKS
-  make $DEBUG J=1 check
+  make $DEBUG $PARALLELISM check
 }
 
 NO_COMPRESSION_COMMANDS="[
@@ -1170,7 +1169,7 @@ JAVA_BUILD_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB for Java\",
-                \"shell\":\"cd $WORKING_DIR; $SETUP_JAVA_ENV; $SHM make rocksdbjava || $CONTRUN_NAME=rocksdbjava $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SETUP_JAVA_ENV; $SHM $PARALLEL_VARS make $PARALLEL_OPTS rocksdbjava || $CONTRUN_NAME=rocksdbjava $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }

--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -89,15 +89,17 @@ if [ -z $RATIO ]; then
   RATIO=1
 fi
 
-if [ -z $PARALLEL_VARS ]; then
-  # These cannot go after 'make' because of recursive make calls. Set them
-  # in shell for easy export to child make.
-  PARALLEL_VARS="PRINT_PARALLEL_OUTPUTS=1 J=$(expr $(nproc) / ${RATIO})"
+# Should probably be called PARALLEL_TEST
+if [ -z $PARALLEL_J ]; then
+  PARALLEL_J="PRINT_PARALLEL_OUTPUTS=1 J=$(expr $(nproc) / ${RATIO})"
 fi
 
-if [ -z $PARALLEL_OPTS ]; then
-  PARALLEL_OPTS="-j$(expr $(nproc) / ${RATIO})"
+# Should probably be called PARALLEL_MAKE
+if [ -z $PARALLEL_j ]; then
+  PARALLEL_j="-j$(expr $(nproc) / ${RATIO})"
 fi
+
+PARALLELISM="$PARALLEL_J $PARALLEL_j"
 
 DEBUG="OPT=-g"
 SHM="TEST_TMPDIR=/dev/shm/rocksdb"
@@ -157,7 +159,7 @@ UNIT_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and test RocksDB debug version\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -180,7 +182,7 @@ UNIT_TEST_NON_SHM_COMMANDS="[
             {
                 \"name\":\"Build and test RocksDB debug version\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $NON_SHM $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=non_shm_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $NON_SHM $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=non_shm_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -201,7 +203,7 @@ RELEASE_BUILD_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB release\",
-                \"shell\":\"cd $WORKING_DIR; make $PARALLEL_OPTS release || $CONTRUN_NAME=release $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; make $PARALLEL_j release || $CONTRUN_NAME=release $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -222,7 +224,7 @@ UNIT_TEST_COMMANDS_481="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and test RocksDB debug version\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $GCC_481 $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=unit_gcc_481_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $GCC_481 $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=unit_gcc_481_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -243,7 +245,7 @@ RELEASE_BUILD_COMMANDS_481="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB release on GCC 4.8.1\",
-                \"shell\":\"cd $WORKING_DIR; $GCC_481 make $PARALLEL_OPTS release || $CONTRUN_NAME=release_gcc481 $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $GCC_481 make $PARALLEL_j release || $CONTRUN_NAME=release_gcc481 $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -264,7 +266,7 @@ CLANG_UNIT_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and test RocksDB debug\",
-                \"shell\":\"cd $WORKING_DIR; $CLANG $SHM $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=clang_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $CLANG $SHM $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=clang_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -285,7 +287,7 @@ CLANG_RELEASE_BUILD_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB release\",
-                \"shell\":\"cd $WORKING_DIR; $CLANG make $PARALLEL_OPTS release|| $CONTRUN_NAME=clang_release $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $CLANG make $PARALLEL_j release|| $CONTRUN_NAME=clang_release $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -306,7 +308,7 @@ CLANG_ANALYZE_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"RocksDB build and analyze\",
-                \"shell\":\"cd $WORKING_DIR; $CLANG $SHM $DEBUG make $PARALLEL_OPTS analyze || $CONTRUN_NAME=clang_analyze $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $CLANG $SHM $DEBUG make $PARALLEL_j analyze || $CONTRUN_NAME=clang_analyze $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -327,7 +329,7 @@ CODE_COV_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build, test and collect code coverage info\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS coverage || $CONTRUN_NAME=coverage $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM coverage || $CONTRUN_NAME=coverage $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -348,7 +350,7 @@ UNITY_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build, test unity test\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG V=1 $PARALLEL_VARS make $PARALLEL_OPTS unity_test || $CONTRUN_NAME=unity_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG V=1 make $PARALLELISM unity_test || $CONTRUN_NAME=unity_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -369,7 +371,7 @@ LITE_BUILD_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB debug version\",
-                \"shell\":\"cd $WORKING_DIR; $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS LITE=1 all check || $CONTRUN_NAME=lite $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SKIP_FORMAT_CHECKS make $PARALLELISM LITE=1 all check || $CONTRUN_NAME=lite $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -391,14 +393,14 @@ STRESS_CRASH_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug crash tests\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS crash_test || $CONTRUN_NAME=crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM crash_test || $CONTRUN_NAME=crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -421,14 +423,14 @@ BLACKBOX_STRESS_CRASH_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug blackbox crash tests\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS blackbox_crash_test || $CONTRUN_NAME=blackbox_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM blackbox_crash_test || $CONTRUN_NAME=blackbox_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -451,14 +453,14 @@ WHITEBOX_STRESS_CRASH_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug whitebox crash tests\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS whitebox_crash_test || $CONTRUN_NAME=whitebox_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM whitebox_crash_test || $CONTRUN_NAME=whitebox_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -481,14 +483,14 @@ STRESS_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug crash tests with atomic flush\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_atomic_flush || $CONTRUN_NAME=crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM crash_test_with_atomic_flush || $CONTRUN_NAME=crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -511,14 +513,14 @@ STRESS_CRASH_TEST_WITH_TXN_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug crash tests with txn\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_txn || $CONTRUN_NAME=crash_test_with_txn $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM crash_test_with_txn || $CONTRUN_NAME=crash_test_with_txn $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -541,14 +543,14 @@ STRESS_CRASH_TEST_WITH_TS_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build and run RocksDB debug stress tests\",
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
             {
                 \"name\":\"Build and run RocksDB debug crash tests with ts\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_ts || $CONTRUN_NAME=crash_test_with_ts $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM crash_test_with_ts || $CONTRUN_NAME=crash_test_with_ts $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -593,7 +595,7 @@ ASAN_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Test RocksDB debug under ASAN\",
-\"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $ASAN $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS asan_check || $CONTRUN_NAME=asan_check $TASK_CREATION_TOOL\",
+\"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $ASAN $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM asan_check || $CONTRUN_NAME=asan_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -616,7 +618,7 @@ ASAN_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug asan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS asan_crash_test || $CONTRUN_NAME=asan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make $PARALLELISM asan_crash_test || $CONTRUN_NAME=asan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -640,7 +642,7 @@ ASAN_BLACKBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug blackbox asan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS blackbox_asan_crash_test || $CONTRUN_NAME=blackbox_asan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make $PARALLELISM blackbox_asan_crash_test || $CONTRUN_NAME=blackbox_asan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -664,7 +666,7 @@ ASAN_WHITEBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug whitebox asan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS whitebox_asan_crash_test || $CONTRUN_NAME=whitebox_asan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make $PARALLELISM whitebox_asan_crash_test || $CONTRUN_NAME=whitebox_asan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -688,7 +690,7 @@ ASAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug asan_crash_test_with_atomic_flush\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS asan_crash_test_with_atomic_flush || $CONTRUN_NAME=asan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make $PARALLELISM asan_crash_test_with_atomic_flush || $CONTRUN_NAME=asan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -712,7 +714,7 @@ ASAN_CRASH_TEST_WITH_TXN_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug asan_crash_test_with_txn\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS asan_crash_test_with_txn || $CONTRUN_NAME=asan_crash_test_with_txn $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $SKIP_FORMAT_CHECKS make $PARALLELISM asan_crash_test_with_txn || $CONTRUN_NAME=asan_crash_test_with_txn $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -734,7 +736,7 @@ UBSAN_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Test RocksDB debug under UBSAN\",
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $UBSAN $CLANG $DEBUG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS ubsan_check || $CONTRUN_NAME=ubsan_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $UBSAN $CLANG $DEBUG $SKIP_FORMAT_CHECKS make $PARALLELISM ubsan_check || $CONTRUN_NAME=ubsan_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -757,7 +759,7 @@ UBSAN_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug ubsan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS ubsan_crash_test || $CONTRUN_NAME=ubsan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make $PARALLELISM ubsan_crash_test || $CONTRUN_NAME=ubsan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -781,7 +783,7 @@ UBSAN_BLACKBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug blackbox ubsan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS blackbox_ubsan_crash_test || $CONTRUN_NAME=blackbox_ubsan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make $PARALLELISM blackbox_ubsan_crash_test || $CONTRUN_NAME=blackbox_ubsan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -805,7 +807,7 @@ UBSAN_WHITEBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug whitebox ubsan_crash_test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS whitebox_ubsan_crash_test || $CONTRUN_NAME=whitebox_ubsan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make $PARALLELISM whitebox_ubsan_crash_test || $CONTRUN_NAME=whitebox_ubsan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -829,7 +831,7 @@ UBSAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug ubsan_crash_test_with_atomic_flush\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS ubsan_crash_test_with_atomic_flush || $CONTRUN_NAME=ubsan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make $PARALLELISM ubsan_crash_test_with_atomic_flush || $CONTRUN_NAME=ubsan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -853,7 +855,7 @@ UBSAN_CRASH_TEST_WITH_TXN_COMMANDS="[
             {
                 \"name\":\"Build and run RocksDB debug ubsan_crash_test_with_txn\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS ubsan_crash_test_with_txn || $CONTRUN_NAME=ubsan_crash_test_with_txn $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH $CLANG $SKIP_FORMAT_CHECKS make $PARALLELISM ubsan_crash_test_with_txn || $CONTRUN_NAME=ubsan_crash_test_with_txn $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -877,7 +879,7 @@ VALGRIND_TEST_COMMANDS="[
             {
                 \"name\":\"Run RocksDB debug unit tests\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $PARALLEL_VARS make $PARALLEL_OPTS valgrind_test || $CONTRUN_NAME=valgrind_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG make $PARALLELISM valgrind_test || $CONTRUN_NAME=valgrind_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -900,7 +902,7 @@ TSAN_UNIT_TEST_COMMANDS="[
             {
                 \"name\":\"Run RocksDB debug unit test\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $SKIP_FORMAT_CHECKS $PARALLEL_VARS make $PARALLEL_OPTS check || $CONTRUN_NAME=tsan_check $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $SKIP_FORMAT_CHECKS make $PARALLELISM check || $CONTRUN_NAME=tsan_check $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }
@@ -923,7 +925,7 @@ TSAN_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS crash_test || $CONTRUN_NAME=tsan_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make $PARALLELISM crash_test || $CONTRUN_NAME=tsan_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -947,7 +949,7 @@ TSAN_BLACKBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS blackbox_crash_test || $CONTRUN_NAME=tsan_blackbox_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make $PARALLELISM blackbox_crash_test || $CONTRUN_NAME=tsan_blackbox_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -971,7 +973,7 @@ TSAN_WHITEBOX_CRASH_TEST_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS whitebox_crash_test || $CONTRUN_NAME=tsan_whitebox_crash_test $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make $PARALLELISM whitebox_crash_test || $CONTRUN_NAME=tsan_whitebox_crash_test $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -995,7 +997,7 @@ TSAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_atomic_flush || $CONTRUN_NAME=tsan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make $PARALLELISM crash_test_with_atomic_flush || $CONTRUN_NAME=tsan_crash_test_with_atomic_flush $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -1019,7 +1021,7 @@ TSAN_CRASH_TEST_WITH_TXN_COMMANDS="[
             {
                 \"name\":\"Compile and run\",
                 \"timeout\": 86400,
-                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 $PARALLEL_VARS make $PARALLEL_OPTS crash_test_with_txn || $CONTRUN_NAME=tsan_crash_test_with_txn $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; set -o pipefail && $SHM $DEBUG $TSAN $TSAN_CRASH CRASH_TEST_KILL_ODD=1887 make $PARALLELISM crash_test_with_txn || $CONTRUN_NAME=tsan_crash_test_with_txn $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             },
@@ -1169,7 +1171,7 @@ JAVA_BUILD_TEST_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Build RocksDB for Java\",
-                \"shell\":\"cd $WORKING_DIR; $SETUP_JAVA_ENV; $SHM $PARALLEL_VARS make $PARALLEL_OPTS rocksdbjava || $CONTRUN_NAME=rocksdbjava $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; $SETUP_JAVA_ENV; $SHM make $PARALLELISM rocksdbjava || $CONTRUN_NAME=rocksdbjava $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }


### PR DESCRIPTION
Summary: Some tests are timing out, so increase parallelism but also
keep test output on console

Large credit to jay-zhuang who is currently unavailable to revise & land #9135

Test Plan:
make check and valgrind_test, with and without PRINT_PARALLEL_OUTPUTS=1
https://www.internalfb.com/intern/sandcastle/group/nonce/6211105410048528/