### PR TITLE
Fix internal build error

### DIFF
--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -467,7 +467,6 @@ struct IOErrorInfo {
   std::string file_path;
   size_t length;
   uint64_t offset;
-  ;
 };
 
 // EventListener class contains a set of callback functions that will


### PR DESCRIPTION
Internal build reported:
```
rocksdb/listener.h:470:3: error: extra ';' inside a struct [-Werror,-Wextra-semi]
```

Test plan:
import to fbcode and compile.