### PR TITLE
Fix compile warnings

### DIFF
--- a/env/env.cc
+++ b/env/env.cc
@@ -9,7 +9,6 @@
 
 #include "rocksdb/env.h"
 
-#include <algorithm>
 #include <thread>
 
 #include "env/composite_env_wrapper.h"
@@ -735,9 +734,7 @@ Status Env::GetChildrenFileAttributes(const std::string& dir,
 }
 
 Status Env::GetHostNameString(std::string* result) {
-  std::array<char, kMaxHostNameLen> hostname_buf;
-  // make sure array contents are properly zeroed
-  std::fill(hostname_buf.begin(), hostname_buf.end(), '\0');
+  std::array<char, kMaxHostNameLen> hostname_buf{};
   Status s = GetHostName(hostname_buf.data(), hostname_buf.size());
   if (s.ok()) {
     hostname_buf[hostname_buf.size() - 1] = '\0';

--- a/env/env.cc
+++ b/env/env.cc
@@ -9,6 +9,7 @@
 
 #include "rocksdb/env.h"
 
+#include <algorithm>
 #include <thread>
 
 #include "env/composite_env_wrapper.h"
@@ -735,6 +736,8 @@ Status Env::GetChildrenFileAttributes(const std::string& dir,
 
 Status Env::GetHostNameString(std::string* result) {
   std::array<char, kMaxHostNameLen> hostname_buf;
+  // make sure array contents are properly zeroed
+  std::fill(hostname_buf.begin(), hostname_buf.end(), 0);
   Status s = GetHostName(hostname_buf.data(), hostname_buf.size());
   if (s.ok()) {
     hostname_buf[hostname_buf.size() - 1] = '\0';

--- a/env/env.cc
+++ b/env/env.cc
@@ -737,7 +737,7 @@ Status Env::GetChildrenFileAttributes(const std::string& dir,
 Status Env::GetHostNameString(std::string* result) {
   std::array<char, kMaxHostNameLen> hostname_buf;
   // make sure array contents are properly zeroed
-  std::fill(hostname_buf.begin(), hostname_buf.end(), 0);
+  std::fill(hostname_buf.begin(), hostname_buf.end(), '\0');
   Status s = GetHostName(hostname_buf.data(), hostname_buf.size());
   if (s.ok()) {
     hostname_buf[hostname_buf.size() - 1] = '\0';

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -248,7 +248,7 @@ class CompactionFilterFactory : public Customizable {
       const CompactionFilter::Context& context) = 0;
 
   // Returns a name that identifies this `CompactionFilter` factory.
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -75,7 +75,7 @@ class Comparator : public Customizable {
   //
   // Names starting with "rocksdb." are reserved and should not be used
   // by any clients of this package.
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 
   // Advanced functions: these are used to reduce the space requirements
   // for internal data structures like index blocks.

--- a/include/rocksdb/file_checksum.h
+++ b/include/rocksdb/file_checksum.h
@@ -85,7 +85,7 @@ class FileChecksumGenFactory : public Customizable {
       const FileChecksumGenContext& context) = 0;
 
   // Return the name of this FileChecksumGenFactory.
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 };
 
 // FileChecksumList stores the checksum information of a list of files (e.g.,

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -311,7 +311,7 @@ class MemTableRepFactory : public Customizable {
     return CreateMemTableRep(key_cmp, allocator, slice_transform, logger);
   }
 
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 
   // Return true if the current MemTableRep supports concurrent inserts
   // Default: false

--- a/include/rocksdb/merge_operator.h
+++ b/include/rocksdb/merge_operator.h
@@ -205,7 +205,7 @@ class MergeOperator : public Customizable {
   // TODO: the name is currently not stored persistently and thus
   //       no checking is enforced. Client is responsible for providing
   //       consistent MergeOperator between DB opens.
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 
   // Determines whether the PartialMerge can be called with just a single
   // merge operand.

--- a/include/rocksdb/secondary_cache.h
+++ b/include/rocksdb/secondary_cache.h
@@ -79,7 +79,7 @@ class SecondaryCache : public Customizable {
   // Wait for a collection of handles to become ready
   virtual void WaitAll(std::vector<SecondaryCacheResultHandle*> handles) = 0;
 
-  virtual std::string GetPrintableOptions() const = 0;
+  virtual std::string GetPrintableOptions() const override = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -38,7 +38,7 @@ class SliceTransform : public Customizable {
   virtual ~SliceTransform(){};
 
   // Return the name of this transformation.
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
   static const char* Type() { return "SliceTransform"; }
 
   // Creates and configures a new SliceTransform from the input options and id.

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -93,7 +93,7 @@ class SstPartitionerFactory : public Customizable {
       const SstPartitioner::Context& context) const = 0;
 
   // Returns a name that identifies this partitioner factory.
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 };
 
 /*

--- a/include/rocksdb/system_clock.h
+++ b/include/rocksdb/system_clock.h
@@ -34,7 +34,7 @@ class SystemClock : public Customizable {
                                  const std::string& value,
                                  std::shared_ptr<SystemClock>* result);
   // The name of this system clock
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 
   // The name/nickname for the Default SystemClock.  This name can be used
   // to determine if the clock is the default one.

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -162,7 +162,7 @@ class TablePropertiesCollectorFactory : public Customizable {
       TablePropertiesCollectorFactory::Context context) = 0;
 
   // The name of the properties collector can be used for debugging purpose.
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 
   // Can be overridden by sub-classes to return the Name, followed by
   // configuration info that will // be logged to the info log when the

--- a/include/rocksdb/wal_filter.h
+++ b/include/rocksdb/wal_filter.h
@@ -105,7 +105,7 @@ class WalFilter : public Customizable {
 
   // Returns a name that identifies this WAL filter.
   // The name will be printed to LOG file on start up for diagnosis.
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
* added missing override specifiers for overriden methods
  this fixes compiler warnings emitted by g++ and clang++ when compile option `-Wsuggest-override` is turned on.
* fix compile warning with -Wmaybe-uninitialized
  g++-11 warns about a _potentially_ uninitialized variable when using `-Wmaybe_uninitialized`:
  ```  
      env/env.cc: In member function ‘virtual rocksdb::Status rocksdb::Env::GetHostNameString(std::string*)’:
      env/env.cc:738:66: error: ‘hostname_buf’ may be used uninitialized [-Werror=maybe-uninitialized]
        738 |   Status s = GetHostName(hostname_buf.data(), hostname_buf.size());
            |                                                                  ^
      In file included from /usr/include/c++/11/tuple:39,
                       from /usr/include/c++/11/functional:54,
                       from ./include/rocksdb/env.h:22,
                       from env/env.cc:10:
      /usr/include/c++/11/array:176:7: note: by argument 1 of type ‘const std::array<char, 256>*’ to ‘constexpr std::array<_Tp, _Nm>::size_type std::array<_Tp, _Nm>::size() const [with _Tp = char; long unsigned int _Nm = 256]’ declared here
        176 |       size() const noexcept { return _Nm; }
            |       ^~~~
      env/env.cc:737:37: note: ‘hostname_buf’ declared here
        737 |   std::array<char, kMaxHostNameLen> hostname_buf;
  ```