### PR TITLE
Fixes a few issues with ManagedObjects

### DIFF
--- a/env/emulated_clock.h
+++ b/env/emulated_clock.h
@@ -33,6 +33,7 @@ class EmulatedSystemClock : public SystemClockWrapper {
 
   static const char* kClassName() { return "TimeEmulatedSystemClock"; }
   const char* Name() const override { return kClassName(); }
+  std::string GetId() const override { return GenerateIndividualId(); }
 
   virtual void SleepForMicroseconds(int micros) override {
     sleep_counter_++;

--- a/env/env.cc
+++ b/env/env.cc
@@ -1180,7 +1180,7 @@ std::string SystemClockWrapper::SerializeOptions(
 static int RegisterBuiltinSystemClocks(ObjectLibrary& library,
                                        const std::string& /*arg*/) {
   library.Register<SystemClock>(
-      EmulatedSystemClock::kClassName(),
+      Customizable::RegexIndividualId(EmulatedSystemClock::kClassName()),
       [](const std::string& /*uri*/, std::unique_ptr<SystemClock>* guard,
          std::string* /* errmsg */) {
         guard->reset(new EmulatedSystemClock(SystemClock::Default()));
@@ -1205,8 +1205,7 @@ Status SystemClock::CreateFromString(const ConfigOptions& config_options,
       RegisterBuiltinSystemClocks(*(ObjectLibrary::Default().get()), "");
     });
 #endif  // ROCKSDB_LITE
-    return LoadSharedObject<SystemClock>(config_options, value, nullptr,
-                                         result);
+    return LoadManagedObject<SystemClock>(config_options, value, result);
   }
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/env/file_system.cc
+++ b/env/file_system.cc
@@ -84,7 +84,7 @@ Status FileSystem::CreateFromString(const ConfigOptions& config_options,
       RegisterBuiltinFileSystems(*(ObjectLibrary::Default().get()), "");
     });
 #endif  // ROCKSDB_LITE
-    return LoadSharedObject<FileSystem>(config_options, value, nullptr, result);
+    return LoadManagedObject<FileSystem>(config_options, value, result);
   }
 }
 

--- a/include/rocksdb/customizable.h
+++ b/include/rocksdb/customizable.h
@@ -189,9 +189,13 @@ class Customizable : public Configurable {
   // method in order to get CheckedCast to function properly.
   virtual const Customizable* Inner() const { return nullptr; }
 
+  // Generates a regular expression that will match either the name
+  // or the name in the individual id syntax
+  static std::string RegexIndividualId(const std::string& name);
+
  protected:
   // Generates a ID specific for this instance of the customizable.
-  // The unique ID is of the form <name>:<addr>#pid, where:
+  // The unique ID is of the form <name>@<addr>#pid, where:
   // - name is the Name() of this object;
   // - addr is the memory address of this object;
   // - pid is the process ID of this process ID for this process.

--- a/options/customizable.cc
+++ b/options/customizable.cc
@@ -35,6 +35,12 @@ std::string Customizable::GenerateIndividualId() const {
   return ostr.str();
 }
 
+std::string Customizable::RegexIndividualId(const std::string& name) {
+  std::string regex = name;
+  regex.append("(@.+#[0-9]+)?");
+  return regex;
+}
+
 #ifndef ROCKSDB_LITE
 Status Customizable::GetOption(const ConfigOptions& config_options,
                                const std::string& opt_name,


### PR DESCRIPTION
- There was a deadlock if attempting to create two managed objects concurrently.   For example, if nested managed objects were defined, the system would deadlock attempting to create the inner one since the outer one held the lock
- Added a RegexIndividualId method to convert a name into a regular expression for matching ids for GenerateIndividualId.  This method takes some of the guesswork and variation out of the system
- Made the SystemClock and FileSystem use LoadManagedObject during CreateFromString.  This allows the derived methods to be Managed.  Currently, this only affects the EmulatedSystemClock, making it more of a singleton.

Finally, tests were added for all of these changes.