### PR TITLE
Minor RocksJava Java code cosmetics

### DIFF
--- a/java/src/main/java/org/rocksdb/AbstractMutableOptions.java
+++ b/java/src/main/java/org/rocksdb/AbstractMutableOptions.java
@@ -344,7 +344,6 @@ public abstract class AbstractMutableOptions {
           final CompressionType compressionType = CompressionType.getFromInternal(valueStr);
           return setEnum(key, compressionType);
 
-
         default:
           throw new IllegalStateException(key + " has unknown value type: " + key.getValueType());
       }

--- a/java/src/main/java/org/rocksdb/AbstractMutableOptions.java
+++ b/java/src/main/java/org/rocksdb/AbstractMutableOptions.java
@@ -343,9 +343,11 @@ public abstract class AbstractMutableOptions {
         case ENUM:
           final CompressionType compressionType = CompressionType.getFromInternal(valueStr);
           return setEnum(key, compressionType);
-      }
 
-      throw new IllegalStateException(key + " has unknown value type: " + key.getValueType());
+
+        default:
+          throw new IllegalStateException(key + " has unknown value type: " + key.getValueType());
+      }
     }
 
     /**

--- a/java/src/main/java/org/rocksdb/AbstractNativeReference.java
+++ b/java/src/main/java/org/rocksdb/AbstractNativeReference.java
@@ -67,7 +67,7 @@ public abstract class AbstractNativeReference implements AutoCloseable {
   @Override
   @Deprecated
   protected void finalize() throws Throwable {
-    if(isOwningHandle()) {
+    if (isOwningHandle()) {
       //TODO(AR) log a warning message... developer should have called close()
     }
     dispose();

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -15,8 +15,9 @@ public class CompactRangeOptions extends RocksObject {
   private final static byte VALUE_kIfHaveCompactionFilter = 1;
   private final static byte VALUE_kForce = 2;
 
-  // For level based compaction, we can configure if we want to skip/force bottommost level compaction.
-  // The order of this enum MUST follow the C++ layer. See BottommostLevelCompaction in db/options.h
+  // For level based compaction, we can configure if we want to skip/force bottommost level
+  // compaction. The order of this enum MUST follow the C++ layer. See BottommostLevelCompaction in
+  // db/options.h
   public enum BottommostLevelCompaction {
     /**
      * Skip bottommost level compaction

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -16,12 +16,12 @@ public class CompactRangeOptions extends RocksObject {
   private final static byte VALUE_kForce = 2;
 
   // For level based compaction, we can configure if we want to skip/force bottommost level compaction.
-  // The order of this neum MUST follow the C++ layer. See BottommostLevelCompaction in db/options.h
+  // The order of this enum MUST follow the C++ layer. See BottommostLevelCompaction in db/options.h
   public enum BottommostLevelCompaction {
     /**
      * Skip bottommost level compaction
      */
-    kSkip((byte)VALUE_kSkip),
+    kSkip(VALUE_kSkip),
     /**
      * Only compact bottommost level if there is a compaction filter. This is the default option
      */

--- a/java/src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
@@ -26,7 +26,7 @@ public interface MutableColumnFamilyOptionsInterface<
    * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
    *   while overflowing the underlying platform specific value.
    */
-  MutableColumnFamilyOptionsInterface setWriteBufferSize(long writeBufferSize);
+  MutableColumnFamilyOptionsInterface<T> setWriteBufferSize(long writeBufferSize);
 
   /**
    * Return size of write buffer size.
@@ -43,7 +43,7 @@ public interface MutableColumnFamilyOptionsInterface<
    * @param disableAutoCompactions true if auto-compactions are disabled.
    * @return the reference to the current option.
    */
-  MutableColumnFamilyOptionsInterface setDisableAutoCompactions(
+  MutableColumnFamilyOptionsInterface<T> setDisableAutoCompactions(
       boolean disableAutoCompactions);
 
   /**
@@ -64,7 +64,7 @@ public interface MutableColumnFamilyOptionsInterface<
    *   level-0 compaction
    * @return the reference to the current option.
    */
-  MutableColumnFamilyOptionsInterface setLevel0FileNumCompactionTrigger(
+  MutableColumnFamilyOptionsInterface<T> setLevel0FileNumCompactionTrigger(
       int level0FileNumCompactionTrigger);
 
   /**
@@ -86,7 +86,7 @@ public interface MutableColumnFamilyOptionsInterface<
    * @return the reference to the current option.
    * @see #maxCompactionBytes()
    */
-  MutableColumnFamilyOptionsInterface setMaxCompactionBytes(final long maxCompactionBytes);
+  MutableColumnFamilyOptionsInterface<T> setMaxCompactionBytes(final long maxCompactionBytes);
 
   /**
    * We try to limit number of bytes in one compaction to be lower than this

--- a/java/src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
@@ -26,7 +26,7 @@ public interface MutableColumnFamilyOptionsInterface<
    * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
    *   while overflowing the underlying platform specific value.
    */
-  MutableColumnFamilyOptionsInterface<T> setWriteBufferSize(long writeBufferSize);
+  T setWriteBufferSize(long writeBufferSize);
 
   /**
    * Return size of write buffer size.
@@ -43,8 +43,7 @@ public interface MutableColumnFamilyOptionsInterface<
    * @param disableAutoCompactions true if auto-compactions are disabled.
    * @return the reference to the current option.
    */
-  MutableColumnFamilyOptionsInterface<T> setDisableAutoCompactions(
-      boolean disableAutoCompactions);
+  T setDisableAutoCompactions(boolean disableAutoCompactions);
 
   /**
    * Disable automatic compactions. Manual compactions can still
@@ -64,8 +63,7 @@ public interface MutableColumnFamilyOptionsInterface<
    *   level-0 compaction
    * @return the reference to the current option.
    */
-  MutableColumnFamilyOptionsInterface<T> setLevel0FileNumCompactionTrigger(
-      int level0FileNumCompactionTrigger);
+  T setLevel0FileNumCompactionTrigger(int level0FileNumCompactionTrigger);
 
   /**
    * Number of files to trigger level-0 compaction. A value &lt; 0 means that
@@ -86,7 +84,7 @@ public interface MutableColumnFamilyOptionsInterface<
    * @return the reference to the current option.
    * @see #maxCompactionBytes()
    */
-  MutableColumnFamilyOptionsInterface<T> setMaxCompactionBytes(final long maxCompactionBytes);
+  T setMaxCompactionBytes(final long maxCompactionBytes);
 
   /**
    * We try to limit number of bytes in one compaction to be lower than this

--- a/java/src/main/java/org/rocksdb/OptionsUtil.java
+++ b/java/src/main/java/org/rocksdb/OptionsUtil.java
@@ -5,7 +5,6 @@
 
 package org.rocksdb;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class OptionsUtil {

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -4651,7 +4651,7 @@ public class RocksDB extends RocksObject {
     return rangeSliceHandles;
   }
 
-  protected void storeOptionsInstance(DBOptionsInterface options) {
+  protected void storeOptionsInstance(DBOptionsInterface<?> options) {
     options_ = options;
   }
 
@@ -4974,7 +4974,7 @@ public class RocksDB extends RocksObject {
 
   private native static int version();
 
-  protected DBOptionsInterface options_;
+  protected DBOptionsInterface<?> options_;
   private static Version version;
 
   public static class Version {

--- a/java/src/main/java/org/rocksdb/SanityLevel.java
+++ b/java/src/main/java/org/rocksdb/SanityLevel.java
@@ -16,8 +16,7 @@ public enum SanityLevel {
    *
    * @return the internal representation value.
    */
-  // TODO(AR) should be made package-private
-  public byte getValue() {
+  byte getValue() {
     return value;
   }
 

--- a/java/src/main/java/org/rocksdb/TraceOptions.java
+++ b/java/src/main/java/org/rocksdb/TraceOptions.java
@@ -13,7 +13,7 @@ public class TraceOptions {
   private final long maxTraceFileSize;
 
   public TraceOptions() {
-    this.maxTraceFileSize = 64L * 1024L * 1024L * 1024L;  // 64 GB
+    this.maxTraceFileSize = 64L * 1024L * 1024L * 1024L; // 64 GB
   }
 
   public TraceOptions(final long maxTraceFileSize) {

--- a/java/src/main/java/org/rocksdb/TraceOptions.java
+++ b/java/src/main/java/org/rocksdb/TraceOptions.java
@@ -13,7 +13,7 @@ public class TraceOptions {
   private final long maxTraceFileSize;
 
   public TraceOptions() {
-    this.maxTraceFileSize = 64L * 1024 * 1024 * 1024; // 64 GB
+    this.maxTraceFileSize = 64L * 1024L * 1024L * 1024L;  // 64 GB
   }
 
   public TraceOptions(final long maxTraceFileSize) {

--- a/java/src/main/java/org/rocksdb/TransactionDB.java
+++ b/java/src/main/java/org/rocksdb/TransactionDB.java
@@ -6,7 +6,6 @@
 package org.rocksdb;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/java/src/main/java/org/rocksdb/TransactionalDB.java
+++ b/java/src/main/java/org/rocksdb/TransactionalDB.java
@@ -5,10 +5,7 @@
 
 package org.rocksdb;
 
-
-interface TransactionalDB<T extends TransactionalOptions<T>>
-    extends AutoCloseable {
-
+interface TransactionalDB<T extends TransactionalOptions<T>> extends AutoCloseable {
   /**
    * Starts a new Transaction.
    *

--- a/java/src/main/java/org/rocksdb/TransactionalDB.java
+++ b/java/src/main/java/org/rocksdb/TransactionalDB.java
@@ -6,7 +6,7 @@
 package org.rocksdb;
 
 
-interface TransactionalDB<T extends TransactionalOptions>
+interface TransactionalDB<T extends TransactionalOptions<T>>
     extends AutoCloseable {
 
   /**

--- a/java/src/main/java/org/rocksdb/util/Environment.java
+++ b/java/src/main/java/org/rocksdb/util/Environment.java
@@ -1,7 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 package org.rocksdb.util;
 
-import java.io.File;
 import java.io.IOException;
 
 public class Environment {


### PR DESCRIPTION
Specifically:
- unused imports
- code formatting
- typos in comments
- unnecessary casts
- missing default label in switch statement
- explicit use of long literals in multiplication
- use generics where possible without backward compatibility risk