### PR TITLE
Fix flaky CassandraFunctionalTest...ExpiredColumnsToTombstone

### DIFF
--- a/utilities/cassandra/cassandra_functional_test.cc
+++ b/utilities/cassandra/cassandra_functional_test.cc
@@ -182,16 +182,22 @@ TEST_F(CassandraFunctionalTest, SimpleMergeTest) {
                         ToMicroSeconds(now + 11));
 }
 
+constexpr int64_t kTestTimeoutSecs = 600;
+
 TEST_F(CassandraFunctionalTest,
        CompactionShouldConvertExpiredColumnsToTombstone) {
   CassandraStore store(OpenDb());
   int64_t now= time(nullptr);
 
-  store.Append("k1", CreateTestRowValue({
-    CreateTestColumnSpec(kExpiringColumn, 0, ToMicroSeconds(now - kTtl - 20)), //expired
-    CreateTestColumnSpec(kExpiringColumn, 1, ToMicroSeconds(now - kTtl + 10)), // not expired
-    CreateTestColumnSpec(kTombstone, 3, ToMicroSeconds(now))
-  }));
+  store.Append(
+      "k1",
+      CreateTestRowValue(
+          {CreateTestColumnSpec(kExpiringColumn, 0,
+                                ToMicroSeconds(now - kTtl - 20)),  // expired
+           CreateTestColumnSpec(
+               kExpiringColumn, 1,
+               ToMicroSeconds(now - kTtl + kTestTimeoutSecs)),  // not expired
+           CreateTestColumnSpec(kTombstone, 3, ToMicroSeconds(now))}));
 
   ASSERT_OK(store.Flush());
 
@@ -210,7 +216,7 @@ TEST_F(CassandraFunctionalTest,
   VerifyRowValueColumns(merged.get_columns(), 0, kTombstone, 0,
                         ToMicroSeconds(now - 10));
   VerifyRowValueColumns(merged.get_columns(), 1, kExpiringColumn, 1,
-                        ToMicroSeconds(now - kTtl + 10));
+                        ToMicroSeconds(now - kTtl + kTestTimeoutSecs));
   VerifyRowValueColumns(merged.get_columns(), 2, kColumn, 2,
                         ToMicroSeconds(now));
   VerifyRowValueColumns(merged.get_columns(), 3, kTombstone, 3,


### PR DESCRIPTION
Summary: You could easily reproduce the failure by injecting sleep(11)
before `store.Flush()`. Fixed by setting TTL time to approximately test
timeout time.

Test Plan: manual