### PR TITLE
Fix TSAN failure for db_sst_test

### DIFF
--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -1125,6 +1125,9 @@ TEST_F(DBSSTTest, DBWithMaxSpaceAllowedWithBlobFiles) {
 
   TEST_SYNC_POINT("DBSSTTest::DBWithMaxSpaceAllowedWithBlobFiles:1");
   ASSERT_TRUE(delete_blob_file);
+
+  sfm->Close();
+  sst_file_manager.reset();
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
 


### PR DESCRIPTION
Summary: Fix TSAN failure for DBWithMaxSpaceAllowedWithBlobFiles.
Delete/Close SSTFileManager before deleting env pointer in order to
avoid data race on env pointer which is accessed by one thread and
deleted by other.

Test Plan: Watch CircleCI jobs

Reviewers:

Subscribers:

Tasks:

Tags: