### PR TITLE
Add rocksdb_livefiles_column_family_name C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -4737,9 +4737,8 @@ int rocksdb_livefiles_count(
   return static_cast<int>(lf->rep.size());
 }
 
-const char* rocksdb_livefiles_column_family_name(
-  const rocksdb_livefiles_t* lf,
-  int index) {
+const char* rocksdb_livefiles_column_family_name(const rocksdb_livefiles_t* lf,
+                                                 int index) {
   return lf->rep[index].column_family_name.c_str();
 }
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -4737,6 +4737,12 @@ int rocksdb_livefiles_count(
   return static_cast<int>(lf->rep.size());
 }
 
+const char* rocksdb_livefiles_column_family_name(
+  const rocksdb_livefiles_t* lf,
+  int index) {
+  return lf->rep[index].column_family_name.c_str();
+}
+
 const char* rocksdb_livefiles_name(
   const rocksdb_livefiles_t* lf,
   int index) {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1995,6 +1995,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_fifo_compaction_options_destroy(
 
 extern ROCKSDB_LIBRARY_API int rocksdb_livefiles_count(
     const rocksdb_livefiles_t*);
+extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_column_family_name(
+    const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_name(
     const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API int rocksdb_livefiles_level(


### PR DESCRIPTION
Extend C API to add new function `rocksdb_livefiles_column_family_name`.