### PR TITLE
Fix bug in rocksdb internal automatic prefetching

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -123,6 +123,8 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
   //    If readahead is enabled: prefetch the remaining bytes + readahead bytes
   //        and satisfy the request.
   //    If readahead is not enabled: return false.
+  TEST_SYNC_POINT_CALLBACK("FilePrefetchBuffer::TryReadFromCache",
+                           &readahead_size_);
   if (offset + n > buffer_offset_ + buffer_.CurrentSize()) {
     if (readahead_size_ > 0) {
       assert(reader != nullptr);
@@ -161,8 +163,6 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
 #endif
         return false;
       }
-      TEST_SYNC_POINT_CALLBACK("FilePrefetchBuffer::TryReadFromCache",
-                               &readahead_size_);
       readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
     } else {
       return false;

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -139,8 +139,9 @@ class FilePrefetchBuffer {
       if ((offset + size > buffer_offset_ + buffer_.CurrentSize()) &&
           IsBlockSequential(offset) &&
           (num_file_reads_ + 1 > kMinNumFileReadsToStartAutoReadahead)) {
+        size_t initial_auto_readahead_size = kInitAutoReadaheadSize;
         readahead_size_ =
-            std::max(kInitAutoReadaheadSize,
+            std::max(initial_auto_readahead_size,
                      (readahead_size_ >= value ? readahead_size_ - value : 0));
       }
     }

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -30,6 +30,8 @@ class RandomAccessFileReader;
 class FilePrefetchBuffer {
  public:
   static const int kMinNumFileReadsToStartAutoReadahead = 2;
+  static const size_t kInitAutoReadaheadSize = 8 * 1024;
+
   // Constructor.
   //
   // All arguments are optional.
@@ -57,7 +59,6 @@ class FilePrefetchBuffer {
       : buffer_offset_(0),
         readahead_size_(readahead_size),
         max_readahead_size_(max_readahead_size),
-        initial_readahead_size_(readahead_size),
         min_offset_read_(port::kMaxSizet),
         enable_(enable),
         track_min_offset_(track_min_offset),
@@ -95,6 +96,7 @@ class FilePrefetchBuffer {
   // tracked if track_min_offset = true.
   size_t min_offset_read() const { return min_offset_read_; }
 
+  // Called in case of implicit auto prefetching.
   void UpdateReadPattern(const uint64_t& offset, const size_t& len,
                          bool is_adaptive_readahead = false) {
     if (is_adaptive_readahead) {
@@ -111,9 +113,10 @@ class FilePrefetchBuffer {
     return (prev_len_ == 0 || (prev_offset_ + prev_len_ == offset));
   }
 
+  // Called in case of implicit auto prefetching.
   void ResetValues() {
     num_file_reads_ = 1;
-    readahead_size_ = initial_readahead_size_;
+    readahead_size_ = kInitAutoReadaheadSize;
   }
 
   void GetReadaheadState(ReadaheadFileInfo::ReadaheadInfo* readahead_info) {
@@ -137,7 +140,7 @@ class FilePrefetchBuffer {
           IsBlockSequential(offset) &&
           (num_file_reads_ + 1 > kMinNumFileReadsToStartAutoReadahead)) {
         readahead_size_ =
-            std::max(initial_readahead_size_,
+            std::max(kInitAutoReadaheadSize,
                      (readahead_size_ >= value ? readahead_size_ - value : 0));
       }
     }
@@ -150,7 +153,6 @@ class FilePrefetchBuffer {
   // FilePrefetchBuffer object won't be created from Iterator flow if
   // max_readahead_size_ = 0.
   size_t max_readahead_size_;
-  size_t initial_readahead_size_;
   // The minimum `offset` ever passed to TryReadFromCache().
   size_t min_offset_read_;
   // if false, TryReadFromCache() always return false, and we only take stats

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -161,10 +161,12 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   }
 
   void SetReadaheadState(ReadaheadFileInfo* readahead_file_info) override {
-    block_prefetcher_.SetReadaheadState(
-        &(readahead_file_info->data_block_readahead_info));
-    if (index_iter_) {
-      index_iter_->SetReadaheadState(readahead_file_info);
+    if (read_options_.adaptive_readahead) {
+      block_prefetcher_.SetReadaheadState(
+          &(readahead_file_info->data_block_readahead_info));
+      if (index_iter_) {
+        index_iter_->SetReadaheadState(readahead_file_info);
+      }
     }
   }
 

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -30,8 +30,11 @@ class BlockPrefetcher {
 
   void ResetValues() {
     num_file_reads_ = 1;
-    readahead_size_ = BlockBasedTable::kInitAutoReadaheadSize;
-    initial_auto_readahead_size_ = readahead_size_;
+    // Since initial_auto_readahead_size_ can be different from
+    // kInitAutoReadaheadSize in case of adaptive_readahead, so fallback the
+    // readahead_size_ to kInitAutoReadaheadSize in case of reset.
+    initial_auto_readahead_size_ = BlockBasedTable::kInitAutoReadaheadSize;
+    readahead_size_ = initial_auto_readahead_size_;
     readahead_limit_ = 0;
     return;
   }

--- a/table/block_based/partitioned_index_iterator.h
+++ b/table/block_based/partitioned_index_iterator.h
@@ -123,8 +123,10 @@ class PartitionedIndexIterator : public InternalIteratorBase<IndexValue> {
   }
 
   void SetReadaheadState(ReadaheadFileInfo* readahead_file_info) override {
-    block_prefetcher_.SetReadaheadState(
-        &(readahead_file_info->index_block_readahead_info));
+    if (read_options_.adaptive_readahead) {
+      block_prefetcher_.SetReadaheadState(
+          &(readahead_file_info->index_block_readahead_info));
+    }
   }
 
   std::unique_ptr<InternalIteratorBase<IndexValue>> index_iter_;


### PR DESCRIPTION
Summary: After introducing adaptive_readahead, the original flow got
broken. Readahead size was set to 0 because of which rocksdb wasn't be
able to do automatic prefetching which it enables after seeing
sequential reads. This PR fixes it.

----------------------------------------------------------------------------------------------------

Before this patch:
b_bench -use_existing_db=true -db=/tmp/prefix_scan -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=5000000 -use_direct_reads=true -seek_nexts=327680 -duration=120 -ops_between_duration_checks=1
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
RocksDB:    version 6.27
Date:       Tue Nov 30 11:56:50 2021
CPU:        24 * Intel Core Processor (Broadwell)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    5000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    2594.0 MB (estimated)
FileSize:   1373.3 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
WARNING: Assertions are enabled; benchmarks unnecessarily slow
------------------------------------------------
DB path: [/tmp/prefix_scan]

seekrandom   : 5356367.174 micros/op 0 ops/sec;   29.4 MB/s (23 of 23 found)

----------------------------------------------------------------------------------------------------

After the patch:
./db_bench -use_existing_db=true -db=/tmp/prefix_scan -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=5000000 -use_direct_reads=true -seek_nexts=327680 -duration=120 -ops_between_duration_checks=1
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
RocksDB:    version 6.27
Date:       Tue Nov 30 14:38:33 2021
CPU:        24 * Intel Core Processor (Broadwell)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    5000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    2594.0 MB (estimated)
FileSize:   1373.3 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
WARNING: Assertions are enabled; benchmarks unnecessarily slow
------------------------------------------------
DB path: [/tmp/prefix_scan]
seekrandom   :  456504.277 micros/op 2 ops/sec;  359.8 MB/s (264 of 264 found)

----------------------------------------------------------------------------------------------------

Test Plan: Ran ./db_bench -db=/data/mysql/rocksdb/prefix_scan
-benchmarks="fillseq" -key_size=32 -value_size=512 -num=5000000 -use_d
irect_io_for_flush_and_compaction=true -target_file_size_base=16777216
and then ./db_bench -use_existing_db=true
-db=/data/mysql/rocksdb/prefix_scan -benchmarks="seekrandom"
-key_size=32 -value_siz
e=512 -num=5000000 -use_direct_reads=true -seek_nexts=327680
-duration=120 -ops_between_duration_checks=1
 and compared the results.

Reviewers:

Subscribers:

Tasks:

Tags: