### PR TITLE
Fix a bug that occur when plugin pkg-config requirements are empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ ROCKSDB_PLUGIN_PKGCONFIG_REQUIRES = $(foreach plugin, $(ROCKSDB_PLUGINS), $($(pl
 PLATFORM_LDFLAGS += $(foreach plugin, $(ROCKSDB_PLUGINS), $($(plugin)_LDFLAGS))
 CXXFLAGS += $(foreach plugin, $(ROCKSDB_PLUGINS), $($(plugin)_CXXFLAGS))
 
-ifneq ($(ROCKSDB_PLUGIN_PKGCONFIG_REQUIRES),)
+ifneq ($(strip $(ROCKSDB_PLUGIN_PKGCONFIG_REQUIRES)),)
 LDFLAGS := $(LDFLAGS) $(shell pkg-config --libs $(ROCKSDB_PLUGIN_PKGCONFIG_REQUIRES))
 ifneq ($(.SHELLSTATUS),0)
 $(error pkg-config failed)


### PR DESCRIPTION
Fix a bug introduced by #9198. The bug is triggered when a plugin does not provide any pkg-config requirements.