### PR TITLE
Add Java API change HISTORY section for #9212

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,9 @@
 ### Performance Improvements
 * Replaced map property `TableProperties::properties_offsets`  with uint64_t property `external_sst_file_global_seqno_offset` to save table properties's memory.
 
+### Java API Changes
+* Removed Java API `TableProperties.getPropertiesOffsets()` as it exposed internal details to external users.
+
 ## 6.27.0 (2021-11-19)
 ### New Features
 * Added new ChecksumType kXXH3 which is faster than kCRC32c on almost all x86\_64 hardware.


### PR DESCRIPTION
Context/Summary:
#9212 removed a Java public API without noting it in HISTORY.

Test:
Existing tests.