### PR TITLE
(6.27.fb) Fix fstatfs call for compilation on 32 bit systems

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1543,7 +1543,11 @@ PosixDirectory::PosixDirectory(int fd) : fd_(fd) {
 #ifdef OS_LINUX
   struct statfs buf;
   int ret = fstatfs(fd, &buf);
+#if UINTPTR_MAX == 0xffffffff
+  is_btrfs_ = (ret == 0 && static_cast<uint32_t>(buf.f_type) == BTRFS_SUPER_MAGIC);
+#else
   is_btrfs_ = (ret == 0 && buf.f_type == BTRFS_SUPER_MAGIC);
+#endif
 #endif
 }
 


### PR DESCRIPTION
Fix for compilation of 6.27.fb