### PR TITLE
Fix Statistics in db_stress

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -871,6 +871,7 @@ cpp_library(
         "db_stress_tool/db_stress_gflags.cc",
         "db_stress_tool/db_stress_listener.cc",
         "db_stress_tool/db_stress_shared_state.cc",
+        "db_stress_tool/db_stress_stat.cc",
         "db_stress_tool/db_stress_test_base.cc",
         "db_stress_tool/db_stress_tool.cc",
         "db_stress_tool/expected_state.cc",

--- a/db_stress_tool/CMakeLists.txt
+++ b/db_stress_tool/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(db_stress${ARTIFACT_SUFFIX}
   db_stress_gflags.cc
   db_stress_listener.cc
   db_stress_shared_state.cc
+  db_stress_stat.cc
   db_stress_test_base.cc
   db_stress_tool.cc
   expected_state.cc

--- a/db_stress_tool/db_stress_stat.cc
+++ b/db_stress_tool/db_stress_stat.cc
@@ -3,6 +3,8 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#ifdef GFLAGS
+
 #include "db_stress_tool/db_stress_stat.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -11,3 +13,5 @@ std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> dbstats;
 std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> dbstats_secondaries;
 
 }  // namespace ROCKSDB_NAMESPACE
+
+#endif  // GFLAGS

--- a/db_stress_tool/db_stress_stat.cc
+++ b/db_stress_tool/db_stress_stat.cc
@@ -1,0 +1,13 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db_stress_tool/db_stress_stat.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> dbstats;
+std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> dbstats_secondaries;
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_stat.h
+++ b/db_stress_tool/db_stress_stat.h
@@ -21,9 +21,10 @@ DECLARE_bool(histogram);
 DECLARE_bool(progress_reports);
 
 namespace ROCKSDB_NAMESPACE {
+
 // Database statistics
-static std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> dbstats;
-static std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> dbstats_secondaries;
+extern std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> dbstats;
+extern std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> dbstats_secondaries;
 
 class Stats {
  private:

--- a/src.mk
+++ b/src.mk
@@ -349,6 +349,7 @@ STRESS_LIB_SOURCES =                                            \
   db_stress_tool/db_stress_gflags.cc                           \
   db_stress_tool/db_stress_listener.cc                         \
   db_stress_tool/db_stress_shared_state.cc                     \
+  db_stress_tool/db_stress_stat.cc                             \
   db_stress_tool/db_stress_test_base.cc                        \
   db_stress_tool/db_stress_tool.cc                             \
   db_stress_tool/expected_state.cc                             \


### PR DESCRIPTION
The `Statistics` objects are meant to be shared across translation
units, but this was prevented by declaring them static. We need to
ensure they are defined once in the program. The effect is now
`StressTest::PrintStatistics()` can actually print statistics since it
now sees non-null values when `--statistics=1`.