### PR TITLE
Fix -Werror=maybe-uninitialized in db_stress_tool

### DIFF
--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -273,7 +273,7 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
     s = FileSystem::Default()->RenameFile(state_file_temp_path, state_file_path,
                                           IOOptions(), nullptr /* dbg */);
   }
-  SequenceNumber old_saved_seqno;
+  SequenceNumber old_saved_seqno = 0;
   if (s.ok()) {
     old_saved_seqno = saved_seqno_;
     saved_seqno_ = seqno;


### PR DESCRIPTION
Context/Summary:
Uninitialized variable `SequenceNumber old_saved_seqno` causes asan related compilation error/warning below:

```
db_stress_tool/expected_state.cc:308:55: error: ‘old_saved_seqno’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  308 |   if (s.ok() && old_saved_seqno != kMaxSequenceNumber &&
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```
      
Fix it by initializing to 0.

Test: 
- make clean && COMPILE_WITH_ASAN=1 make -j48 db_stress_tool/expected_state.o
- monitor related test run to see if same error happens again after merging
      