### PR TITLE
EnvWrapper should provide constructor with file system and sys…

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -1322,6 +1322,16 @@ class EnvWrapper : public Env {
  public:
   // Initialize an EnvWrapper that delegates all calls to *t
   explicit EnvWrapper(Env* t) : target_(t) {}
+
+  explicit EnvWrapper(Env* t,
+                      const std::shared_ptr<FileSystem>& fs)
+      :Env(fs), target_(t) {}
+
+  explicit EnvWrapper(Env* t,
+                      const std::shared_ptr<FileSystem>& fs,
+                      const std::shared_ptr<SystemClock>& clock)
+      :Env(fs, clock), target_(t) {}
+
   ~EnvWrapper() override;
 
   // Return the target to which this Env forwards all calls

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -1323,14 +1323,12 @@ class EnvWrapper : public Env {
   // Initialize an EnvWrapper that delegates all calls to *t
   explicit EnvWrapper(Env* t) : target_(t) {}
 
-  explicit EnvWrapper(Env* t,
-                      const std::shared_ptr<FileSystem>& fs)
-      :Env(fs), target_(t) {}
+  explicit EnvWrapper(Env* t, const std::shared_ptr<FileSystem>& fs)
+      : Env(fs), target_(t) {}
 
-  explicit EnvWrapper(Env* t,
-                      const std::shared_ptr<FileSystem>& fs,
+  explicit EnvWrapper(Env* t, const std::shared_ptr<FileSystem>& fs,
                       const std::shared_ptr<SystemClock>& clock)
-      :Env(fs, clock), target_(t) {}
+      : Env(fs, clock), target_(t) {}
 
   ~EnvWrapper() override;
 


### PR DESCRIPTION
EnvWrapper needs to have the function of being initialized with parameter（env）‘s file system. Otherwise it will call LegacyFileSystemWrapper‘s function（or its father class file system‘s function）instead of the function in your own file system， unless you implement the function which you just need in your own file system in LegacyFileSystemWrapper。