### PR TITLE
Fix an issue with MemTableRepFactory::CreateFromString

### DIFF
--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -597,7 +597,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
                 static_cast<std::shared_ptr<MemTableRepFactory>*>(addr);
             Status s =
                 MemTableRepFactory::CreateFromString(opts, value, &factory);
-            if (s.ok()) {
+            if (factory && s.ok()) {
               shared->reset(factory.release());
             }
             return s;
@@ -613,7 +613,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
                 static_cast<std::shared_ptr<MemTableRepFactory>*>(addr);
             Status s =
                 MemTableRepFactory::CreateFromString(opts, value, &factory);
-            if (s.ok()) {
+            if (factory && s.ok()) {
               shared->reset(factory.release());
             }
             return s;

--- a/options/configurable.cc
+++ b/options/configurable.cc
@@ -53,12 +53,12 @@ Status Configurable::PrepareOptions(const ConfigOptions& opts) {
                 opt_info.AsRawPointer<Configurable>(opt_iter.opt_ptr);
             if (config != nullptr) {
               status = config->PrepareOptions(opts);
-              if (!status.ok()) {
-                return status;
-              }
             } else if (!opt_info.CanBeNull()) {
               status = Status::NotFound("Missing configurable object",
                                         map_iter.first);
+            }
+            if (!status.ok()) {
+              return status;
             }
           }
         }


### PR DESCRIPTION
If ignore_unsupported_options=true, then it is possible for MemTableRepFactory::CreateFromString to succeed without setting a result (result=nullptr).  This would cause the original value to be overwritten with null and an error would be raised later when PrepareOptions is invoked.

Added unit test for this condition.  Will add (in another PR unless required by reviewers) comparable tests for all of the other Customizable classes.