### PR TITLE
Fix flaky tests related to Blob file deletions

### DIFF
--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -310,6 +310,7 @@ TEST_F(DBSSTTest, DBWithSstFileManager) {
     ASSERT_EQ(sfm->GetTrackedFiles(), files_in_db);
   }
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
   std::unordered_map<std::string, uint64_t> files_in_db;
   ASSERT_OK(GetAllDataFiles(kTableFile, &files_in_db));
@@ -416,6 +417,7 @@ TEST_F(DBSSTTest, DBWithSstFileManagerForBlobFiles) {
   ASSERT_EQ(files_moved, 0);
 
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
   std::unordered_map<std::string, uint64_t> files_in_db;
   ASSERT_OK(GetAllDataFiles(kTableFile, &files_in_db));
@@ -561,6 +563,7 @@ TEST_F(DBSSTTest, DBWithSstFileManagerForBlobFilesWithGC) {
   constexpr Slice* end = nullptr;
 
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), begin, end));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
   sfm->WaitForEmptyTrash();
 
   ASSERT_EQ(Get(first_key), first_value);
@@ -1664,6 +1667,7 @@ TEST_F(DBSSTTest, DBWithSFMForBlobFilesAtomicFlush) {
   constexpr Slice* end = nullptr;
   // Compaction job will create a new file and delete the older files.
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), begin, end));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
   ASSERT_EQ(files_added, 1);
   ASSERT_EQ(files_scheduled_to_delete, 1);

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1548,6 +1548,7 @@ TEST_F(EventListenerTest, BlobDBFileTest) {
   // On compaction, because of blob_garbage_collection_age_cutoff, it will
   // delete the oldest blob file and create new blob file during compaction.
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), begin, end));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
   blob_event_listener->CheckCounters();
 }


### PR DESCRIPTION
Summary: CompactRange() only waits for manual.done to be set
which happens as soon as new version is installed. Added TEST_WaitForCompact() which
waits for compaction thread to actually finish which is after
PurgeObsoleteFiles().

Test Plan: Reproducible by adding  `bg_cv_.SignalAll();`  inside if condition https://github.com/facebook/rocksdb/blob/297d9132752d9658989c1e99cfc836978b886ca1/db/db_impl/db_impl_compaction_flush.cc#L2876

Reviewers:

Subscribers:

Tasks:

Tags: