### PR TITLE
Range Locking: add support for escalation barriers

### DIFF
--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -97,6 +97,21 @@ class RangeLockManagerHandle : public LockManagerHandle {
   using RangeLockStatus =
       std::unordered_multimap<ColumnFamilyId, RangeLockInfo>;
 
+  // Lock Escalation barrier check function.
+  // It is called for a couple of endpoints A and B, such that A < B.
+  // If escalation_barrier_check_func(A, B)==true, then there's a lock
+  // escalation barrier between A and B, and lock escalation is not allowed
+  // to bridge the gap between A and B.
+  //
+  // The function may be called from any thread that acquires or releases
+  // locks. It should not throw exceptions. There is currently no way to return
+  // an error.
+  using EscalationBarrierFunc =
+      std::function<bool(const Endpoint& a, const Endpoint& b)>;
+
+  // Set the user-provided barrier check function
+  virtual void SetEscalationBarrierFunc(EscalationBarrierFunc func) = 0;
+
   virtual RangeLockStatus GetRangeLockStatusData() = 0;
 
   class Counters {

--- a/utilities/transactions/lock/range/range_locking_test.cc
+++ b/utilities/transactions/lock/range/range_locking_test.cc
@@ -276,9 +276,10 @@ TEST_F(RangeLockingTest, BasicLockEscalation) {
 
   // Get the locks until we hit an escalation
   for (int i = 0; i < 2020; i++) {
-    char buf[32];
-    snprintf(buf, sizeof(buf) - 1, "%08d", i);
-    ASSERT_OK(txn->GetRangeLock(cf, Endpoint(buf), Endpoint(buf)));
+    std::ostringstream buf;
+    buf << std::setw(8) << std::setfill('0') << i;
+    std::string buf_str = buf.str();
+    ASSERT_OK(txn->GetRangeLock(cf, Endpoint(buf_str), Endpoint(buf_str)));
   }
   counters = range_lock_mgr->GetStatus();
   ASSERT_GT(counters.escalation_count, 0);
@@ -286,6 +287,60 @@ TEST_F(RangeLockingTest, BasicLockEscalation) {
 
   delete txn;
 }
+
+// An escalation barrier function. Allow escalation iff the first two bytes are
+// identical.
+static bool escalation_barrier(const Endpoint& a, const Endpoint& b) {
+  assert(a.slice.size() > 2);
+  assert(b.slice.size() > 2);
+  if (memcmp(a.slice.data(), b.slice.data(), 2)) {
+    return true;  // This is a barrier
+  } else {
+    return false;  // No barrier
+  }
+}
+
+TEST_F(RangeLockingTest, LockEscalationBarrier) {
+  auto cf = db->DefaultColumnFamily();
+
+  auto counters = range_lock_mgr->GetStatus();
+
+  // Initially not using any lock memory
+  ASSERT_EQ(counters.escalation_count, 0);
+
+  range_lock_mgr->SetMaxLockMemory(8000);
+  range_lock_mgr->SetEscalationBarrierFunc(escalation_barrier);
+
+  // Insert enough locks to cause lock escalations to happen
+  auto txn = NewTxn();
+  const int N = 2000;
+  for (int i = 0; i < N; i++) {
+    std::ostringstream buf;
+    buf << std::setw(4) << std::setfill('0') << i;
+    std::string buf_str = buf.str();
+    ASSERT_OK(txn->GetRangeLock(cf, Endpoint(buf_str), Endpoint(buf_str)));
+  }
+  counters = range_lock_mgr->GetStatus();
+  ASSERT_GT(counters.escalation_count, 0);
+
+  // Check that lock escalation was not performed across escalation barriers:
+  // Use another txn to acquire locks near the barriers.
+  auto txn2 = NewTxn();
+  range_lock_mgr->SetMaxLockMemory(500000);
+  for (int i = 100; i < N; i += 100) {
+    std::ostringstream buf;
+    buf << std::setw(4) << std::setfill('0') << i - 1 << "-a";
+    std::string buf_str = buf.str();
+    // Check that we CAN get a lock near the escalation barrier
+    ASSERT_OK(txn2->GetRangeLock(cf, Endpoint(buf_str), Endpoint(buf_str)));
+  }
+
+  txn->Rollback();
+  txn2->Rollback();
+  delete txn;
+  delete txn2;
+}
+
 #endif
 
 TEST_F(RangeLockingTest, LockWaitCount) {

--- a/utilities/transactions/lock/range/range_tree/lib/locktree/locktree.cc
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/locktree.cc
@@ -96,7 +96,17 @@ void locktree::create(locktree_manager *mgr, DICTIONARY_ID dict_id,
   m_sto_end_early_count = 0;
   m_sto_end_early_time = 0;
 
+  m_escalation_barrier = [](const DBT *, const DBT *, void *) -> bool {
+    return false;
+  };
+
   m_lock_request_info.init(mutex_factory);
+}
+
+void locktree::set_escalation_barrier_func(
+    lt_escalation_barrier_check_func func, void *extra) {
+  m_escalation_barrier = func;
+  m_escalation_barrier_arg = extra;
 }
 
 void lt_lock_request_info::init(toku_external_mutex_factory_t mutex_factory) {
@@ -863,14 +873,19 @@ void locktree::escalate(lt_escalate_cb after_escalate_callback,
       //  - belongs to a different txnid, or
       //  - belongs to several txnids, or
       //  - is a shared lock (we could potentially merge those but
-      //    currently we don't)
+      //    currently we don't), or
+      //  - is across a lock escalation barrier.
       int next_txnid_index = current_index + 1;
 
       while (next_txnid_index < num_extracted &&
              (extracted_buf[current_index].txnid ==
               extracted_buf[next_txnid_index].txnid) &&
              !extracted_buf[next_txnid_index].is_shared &&
-             !extracted_buf[next_txnid_index].owners) {
+             !extracted_buf[next_txnid_index].owners &&
+             !m_escalation_barrier(
+                 extracted_buf[current_index].range.get_right_key(),
+                 extracted_buf[next_txnid_index].range.get_left_key(),
+                 m_escalation_barrier_arg)) {
         next_txnid_index++;
       }
 


### PR DESCRIPTION
Range Locking supports Lock Escalation. Lock Escalation is invoked when
lock memory is nearly exhausted and it reduced the amount of memory used
by joining adjacent locks.

Bridging the gap between certain locks has adverse effects. For example,
in MyRocks it is not a good idea to bridge the gap between locks in
different indexes, as that get the lock to cover large portions of
indexes, or even entire indexes.

Resolve this by introducing Escalation Barrier. The escalation process
will call the user-provided barrier callback function:
   bool(const Endpoint& a, const Endpoint& b)

If the function returns true, there's a barrier between a and b and Lock
Escalation will not try to bridge the gap between a and b.