### PR TITLE
Fix bug that BlockBasedTableBuilder don't flush to file when max_dict_bytes>0,max_dict_buffer_bytes=0

### DIFF
--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -918,8 +918,7 @@ void BlockBasedTableBuilder::Add(const Slice& key, const Slice& value) {
       r->first_key_in_next_block = &key;
       Flush();
       if (r->state == Rep::State::kBuffered) {
-        bool exceeds_buffer_limit =
-            (r->buffer_limit != 0 && r->data_begin_offset > r->buffer_limit);
+        bool exceeds_buffer_limit = r->data_begin_offset > r->buffer_limit;
         bool exceeds_global_block_cache_limit = false;
 
         // Increase cache reservation for the last buffered data block


### PR DESCRIPTION
Fix #9296
when max_dict_bytes > 0, max_dict_buffer_bytes = 0, target_file_size = 0
v6.8.1 exceeds_buffer_limit=false
v6.26.0 exceeds_buffer_limit=true