### PR TITLE
Improve SimulatedHybridFileSystem

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### New Features
 * Introduced 'CommitWithTimestamp' as a new tag. Currently, there is no API for user to trigger a write with this tag to the WAL. This is part of the efforts to support write-commited transactions with user-defined timestamps.
+* Introduce SimulatedHybridFileSystem which can help simulating HDD latency in db_bench. Tiered Storage latency simulation can be enabled using -simulate_hybrid_fs_file (note that it doesn't work if db_bench is interrupted in the middle). -simulate_hdd can also be used to simulate all files on HDD.
 
 ### Bug Fixes
 * Fixed a bug in rocksdb automatic implicit prefetching which got broken because of new feature adaptive_readahead and internal prefetching got disabled when iterator moves from one file to next.

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1154,6 +1154,10 @@ DEFINE_string(simulate_hybrid_fs_file, "",
               "File for Store Metadata for Simulate hybrid FS. Empty means "
               "disable the feature. Now, if it is set, "
               "bottommost_temperature is set to kWarm.");
+DEFINE_int32(simulate_hybrid_hdd_multipliers, 1,
+             "In simulate_hybrid_fs_file or simulate_hdd mode, how many HDDs "
+             "are simulated.");
+DEFINE_bool(simulate_hdd, false, "Simulate read/write latency on HDD.");
 
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_guard;
 
@@ -8135,12 +8139,15 @@ int db_bench_tool(int argc, char** argv) {
       fprintf(stderr, "Failed creating env: %s\n", s.ToString().c_str());
       exit(1);
     }
-  } else if (FLAGS_simulate_hybrid_fs_file != "") {
+  } else if (FLAGS_simulate_hdd || FLAGS_simulate_hybrid_fs_file != "") {
     //**TODO: Make the simulate fs something that can be loaded
     // from the ObjectRegistry...
     static std::shared_ptr<ROCKSDB_NAMESPACE::Env> composite_env =
         NewCompositeEnv(std::make_shared<SimulatedHybridFileSystem>(
-            FileSystem::Default(), FLAGS_simulate_hybrid_fs_file));
+            FileSystem::Default(), FLAGS_simulate_hybrid_fs_file,
+            /*throughput_multiplier=*/
+            int{FLAGS_simulate_hybrid_hdd_multipliers},
+            /*is_full_fs_warm=*/FLAGS_simulate_hdd));
     FLAGS_env = composite_env.get();
   }
 #endif  // ROCKSDB_LITE

--- a/tools/simulated_hybrid_file_system.h
+++ b/tools/simulated_hybrid_file_system.h
@@ -28,8 +28,13 @@ class SimulatedHybridFileSystem : public FileSystemWrapper {
   // metadata_file_name stores metadata of the files, so that it can be
   // loaded after process restarts. If the file doesn't exist, create
   // one. The file is written when the class is destroyed.
-  explicit SimulatedHybridFileSystem(const std::shared_ptr<FileSystem>& base,
-                                     const std::string& metadata_file_name);
+  // throughput_multiplier: multiplier of throughput. For example, 1 is to
+  //      simulate single disk spindle. 4 is to simualte 4 disk spindles.
+  // is_full_fs_warm: if true, all files are all included in slow I/O
+  // simulation.
+  SimulatedHybridFileSystem(const std::shared_ptr<FileSystem>& base,
+                            const std::string& metadata_file_name,
+                            int throughput_multiplier, bool is_full_fs_warm);
 
   ~SimulatedHybridFileSystem() override;
 
@@ -55,6 +60,7 @@ class SimulatedHybridFileSystem : public FileSystemWrapper {
   std::unordered_set<std::string> warm_file_set_;
   std::string metadata_file_name_;
   std::string name_;
+  bool is_full_fs_warm_;
 };
 
 // Simulated random access file that can control IOPs and latency to simulate
@@ -84,7 +90,7 @@ class SimulatedHybridRaf : public FSRandomAccessFileOwnerWrapper {
   std::shared_ptr<RateLimiter> rate_limiter_;
   Temperature temperature_;
 
-  void RequestRateLimit(int64_t num_requests) const;
+  void SimulateIOWait(int64_t num_requests) const;
 };
 
 class SimulatedWritableFile : public FSWritableFileWrapper {
@@ -113,7 +119,7 @@ class SimulatedWritableFile : public FSWritableFileWrapper {
   std::shared_ptr<RateLimiter> rate_limiter_;
   size_t unsynced_bytes = 0;
 
-  void RequestRateLimit(int64_t num_requests) const;
+  void SimulateIOWait(int64_t num_requests) const;
 };
 }  // namespace ROCKSDB_NAMESPACE
 


### PR DESCRIPTION
Summary:
Several improvements to SimulatedHybridFileSystem:
(1) Allow a mode where all I/Os to all files simulate HDD. This can be enabled in db_bench using -simulate_hdd
(2) Latency calculation is slightly more accurate
(3) Allow to simulate more than one HDD spindles.

Test Plan: Run db_bench and observe the results are reasonable.