### PR TITLE
Recover to exact latest seqno of data committed to MANIFEST

### DIFF
--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -418,11 +418,17 @@ class VersionEdit {
                      temperature, oldest_blob_file_number, oldest_ancester_time,
                      file_creation_time, file_checksum, file_checksum_func_name,
                      min_timestamp, max_timestamp));
+    if (!HasLastSequence() || largest_seqno > GetLastSequence()) {
+      SetLastSequence(largest_seqno);
+    }
   }
 
   void AddFile(int level, const FileMetaData& f) {
     assert(f.fd.smallest_seqno <= f.fd.largest_seqno);
     new_files_.emplace_back(level, f);
+    if (!HasLastSequence() || f.fd.largest_seqno > GetLastSequence()) {
+      SetLastSequence(f.fd.largest_seqno);
+    }
   }
 
   // Retrieve the table files added as well as their associated levels.

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -444,6 +444,10 @@ void VersionEditHandler::CheckIterationResult(const log::Reader& reader,
     }
     if (last_seq != kMaxSequenceNumber &&
         last_seq > version_set_->descriptor_last_sequence_) {
+      // This is the maximum last sequence of all `VersionEdit`s iterated. It
+      // may be greater than the maximum `largest_seqno` of all files in case
+      // the newest data referred to by the MANIFEST has been dropped or had its
+      // sequence number zeroed through compaction.
       version_set_->descriptor_last_sequence_ = last_seq;
     }
     version_set_->prev_log_number_ = version_edit_params_.prev_log_number_;

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -605,13 +605,12 @@ Status VersionEditHandler::ExtractInfoFromVersionEdit(ColumnFamilyData* cfd,
                    edit.min_log_number_to_keep_);
     }
     if (edit.has_last_sequence_) {
-      // Within a batch commit of `VersionEdit`s, the last `VersionEdit` is
-      // not guaranteed to have the largest `last_sequence_`. So, we need to
-      // look for the largest `last_sequence_` over all `VersionEdit`s.
-      if (!version_edit_params_.has_last_sequence_ ||
-          edit.last_sequence_ > version_edit_params_.last_sequence_) {
-        version_edit_params_.SetLastSequence(edit.last_sequence_);
-      }
+      // `VersionEdit::last_sequence_`s are assumed to be non-decreasing. This
+      // is legacy behavior that cannot change without breaking downgrade
+      // compatibility.
+      assert(!version_edit_params_.has_last_sequence_ ||
+             version_edit_params_.last_sequence_ <= edit.last_sequence_);
+      version_edit_params_.SetLastSequence(edit.last_sequence_);
     }
     if (!version_edit_params_.has_prev_log_number_) {
       version_edit_params_.SetPrevLogNumber(0);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4159,8 +4159,8 @@ Status VersionSet::ProcessManifestWrites(
   std::vector<std::unique_ptr<BaseReferencedVersionBuilder>> builder_guards;
 
   // Tracking `max_last_sequence` is needed to ensure we write
-  // `VersionEdit::last_sequence_`s in non-decreasing order for downgrade
-  // compatibility. It also allows us to defer updating
+  // `VersionEdit::last_sequence_`s in non-decreasing order according to the
+  // recovery code's requirement. It also allows us to defer updating
   // `descriptor_last_sequence_` until the apply phase, after the log phase
   // succeeds.
   SequenceNumber max_last_sequence = descriptor_last_sequence_;
@@ -4642,7 +4642,7 @@ Status VersionSet::ProcessManifestWrites(
 
 #ifndef NDEBUG
   // This is here kind of awkwardly because there's no other consistency
-  // checks on `VersionSet`'s updates for the new `Version`. We might want
+  // checks on `VersionSet`'s updates for the new `Version`s. We might want
   // to move it to a dedicated function, or remove it if we gain enough
   // confidence in `descriptor_last_sequence_`.
   if (s.ok()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4533,7 +4533,7 @@ Status VersionSet::ProcessManifestWrites(
       // This tracks the maximum `last_sequence` in any of the `VersionEdit`s
       // being applied. We use it to update the `VersionSet` if we find the
       // MANIFEST now refers to data with a new highest sequence number.
-      uint64_t last_sequence = 0;
+      SequenceNumber last_sequence = 0;
       for (const auto& e : batch_edits) {
         ColumnFamilyData* cfd = nullptr;
         if (!e->IsColumnFamilyManipulation()) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1139,16 +1139,6 @@ class VersionSet {
     last_sequence_.store(s, std::memory_order_release);
   }
 
-  // Marks sequence numbers through `s` as referred to by the descriptor
-  // (manifest file).
-  //
-  // Requires DB mutex held.
-  void MarkDescriptorLastSequence(SequenceNumber s) {
-    if (s > descriptor_last_sequence_) {
-      descriptor_last_sequence_ = s;
-    }
-  }
-
   // Note: memory_order_release must be sufficient
   void SetLastPublishedSequence(uint64_t s) {
     assert(s >= last_published_sequence_);
@@ -1447,9 +1437,11 @@ class VersionSet {
                                bool new_descriptor_log,
                                const ColumnFamilyOptions* new_cf_options);
 
-  void LogAndApplyCFHelper(VersionEdit* edit);
+  void LogAndApplyCFHelper(VersionEdit* edit,
+                           SequenceNumber* max_last_sequence);
   Status LogAndApplyHelper(ColumnFamilyData* cfd, VersionBuilder* b,
-                           VersionEdit* edit, InstrumentedMutex* mu);
+                           VersionEdit* edit, SequenceNumber* max_last_sequence,
+                           InstrumentedMutex* mu);
 };
 
 // ReactiveVersionSet represents a collection of versions of the column

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1125,9 +1125,7 @@ class VersionSet {
   // (manifest file).
   //
   // Requires DB mutex held.
-  uint64_t DescriptorLastSequence() const {
-    return descriptor_last_sequence_;
-  }
+  uint64_t DescriptorLastSequence() const { return descriptor_last_sequence_; }
 
   // Note: memory_order_acquire must be sufficient.
   uint64_t LastAllocatedSequence() const {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1121,12 +1121,6 @@ class VersionSet {
     return last_sequence_.load(std::memory_order_acquire);
   }
 
-  // Returns the last sequence number of any data referred to by the descriptor
-  // (manifest file).
-  //
-  // Requires DB mutex held.
-  uint64_t DescriptorLastSequence() const { return descriptor_last_sequence_; }
-
   // Note: memory_order_acquire must be sufficient.
   uint64_t LastAllocatedSequence() const {
     return last_allocated_sequence_.load(std::memory_order_seq_cst);
@@ -1149,7 +1143,7 @@ class VersionSet {
   // (manifest file).
   //
   // Requires DB mutex held.
-  void MarkDescriptorLastSequence(uint64_t s) {
+  void MarkDescriptorLastSequence(SequenceNumber s) {
     if (s > descriptor_last_sequence_) {
       descriptor_last_sequence_ = s;
     }
@@ -1404,7 +1398,7 @@ class VersionSet {
   std::atomic<uint64_t> last_sequence_;
   // The last sequence number of data committed to the descriptor (manifest
   // file).
-  uint64_t descriptor_last_sequence_ = 0;
+  SequenceNumber descriptor_last_sequence_ = 0;
   // The last seq that is already allocated. It is applicable only when we have
   // two write queues. In that case seq might or might not have appreated in
   // memtable but it is expected to appear in the WAL.

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -1476,7 +1476,7 @@ public class RocksDBTest {
       try (final RocksDB db = RocksDB.open(options, dbPath)) {
         final RocksDB.LiveFiles livefiles = db.getLiveFiles(true);
         assertThat(livefiles).isNotNull();
-        assertThat(livefiles.manifestFileSize).isEqualTo(57);
+        assertThat(livefiles.manifestFileSize).isEqualTo(59);
         assertThat(livefiles.files.size()).isEqualTo(3);
         assertThat(livefiles.files.get(0)).isEqualTo("/CURRENT");
         assertThat(livefiles.files.get(1)).isEqualTo("/MANIFEST-000004");


### PR DESCRIPTION
The LastSequence field in the MANIFEST file is the baseline seqno for a recovered DB. Recovering WAL entries might cause the recovered DB's seqno to advance above this baseline, but the recovered DB will never use a smaller seqno.

Before this PR, we were writing the DB's seqno at the time of LogAndApply() as the LastSequence value. This works in the sense that it is a large enough baseline for the recovered DB that it'll never overwrite any records in existing SST files. At the same time, it's arbitrarily larger than what's needed. This behavior comes from LevelDB, where there was no tracking of largest seqno in an SST file. 

Now we know the largest seqno of newly written SST files, so we can write an exact value in LastSequence that actually reflects the largest seqno in any file referred to by the MANIFEST. This is primarily useful for correctness testing with unsynced data loss, where the recovered DB's seqno needs to indicate what records were recovered.

Test Plan:

- #9338 adds crash-recovery correctness testing coverage for WAL disabled use cases
- #9357 will extend that testing to cover file ingestion
- Added assertion at end of LogAndApply() for `VersionSet::descriptor_last_sequence_` consistency with files
- Manually tested upgrade/downgrade compatibility with a custom crash test that randomly picks between a `db_stress` built with and without this PR (for old code it must run with `-disable_wal=0`)
  - Branch: https://github.com/ajkr/rocksdb/tree/638171597be8132c99cbba37de19b3ea8926194e
  - Command: `TEST_TMPDIR=/dev/shm/ DEBUG_LEVEL=0 python3 tools/db_crashtest.py blackbox --max_key=10000 --interval=10 --duration=86400 --value_size_mult=33 --write_buffer_size=262144 --compression_type=none`