### PR TITLE
Filter `Get()`s from `db_stress` traces

### DIFF
--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -296,7 +296,9 @@ Status FileExpectedStateManager::SaveAtAndAfter(DB* db) {
                            &trace_writer);
   }
   if (s.ok()) {
-    s = db->StartTrace(TraceOptions(), std::move(trace_writer));
+    TraceOptions trace_opts;
+    trace_opts.filter |= kTraceFilterGet;
+    s = db->StartTrace(trace_opts, std::move(trace_writer));
   }
 
   // Delete old state/trace files. Deletion order does not matter since we only


### PR DESCRIPTION
`db_stress` traces are used for tracking unsynced changes. For that purpose, we
only need to track writes and not reads. Currently `TraceOptions` only
supports excluding `Get()`s from the trace, so this PR only excludes
`Get()`s. In the future it would be good to exclude `MultiGet()`s and
iterator operations too.

Test Plan:

- trace-heavy `db_stress` command elapsed time reduced 37%

Benchmark:
```
TEST_TMPDIR=/dev/shm /usr/bin/time ./db_stress -ops_per_thread=100000 -sync_fault_injection=1 -expected_values_dir=/dev/shm/dbstress_expected --clear_column_family_one_in=0
```

- replay-heavy `db_stress` command elapsed time reduced 38%

Setup:
```
TEST_TMPDIR=/dev/shm /usr/bin/time ./db_stress -ops_per_thread=100000000 -sync_fault_injection=1 -expected_values_dir=/dev/shm/dbstress_expected --clear_column_family_one_in=0 & sleep 120; pkill -9 db_stress
```
Benchmark:
```
TEST_TMPDIR=/dev/shm /usr/bin/time ./db_stress -ops_per_thread=1 -reopen=0 -expected_values_dir=/dev/shm/dbstress_expected --clear_column_family_one_in=0 --destroy_db_initially=0
```