### PR TITLE
arena.h: fix Arena::IsInInlineBlock()

### DIFF
--- a/memory/arena.h
+++ b/memory/arena.h
@@ -78,7 +78,7 @@ class Arena : public Allocator {
   size_t BlockSize() const override { return kBlockSize; }
 
   bool IsInInlineBlock() const {
-    return blocks_.empty();
+    return blocks_.empty() && huge_blocks_.empty();
   }
 
  private:


### PR DESCRIPTION
When I enable hugepage on my box, unit test fails, this PR fixes this issue:

[  FAILED  ] ArenaTest.ApproximateMemoryUsage (1 ms)

memory/arena_test.cc:127: Failure
Value of: arena.IsInInlineBlock()
  Actual: true
Expected: false
arena.IsInInlineBlock() = 1
memory/arena_test.cc:127: Failure
Value of: arena.IsInInlineBlock()
  Actual: true
Expected: false