### PR TITLE
[WIP]Defer indexing building for write-committed txns

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 # Rocksdb Change Log
+## Unreleased
+### Performance improvements
+* Avoid building write batch indexes for transactions during recovery when possible. Defer write batch indexing until the transaction is requested by application for read. This currently applies to write-committed transactions only.
+
 ## 6.28.0 (2021-12-17)
 ### New Features
 * Introduced 'CommitWithTimestamp' as a new tag. Currently, there is no API for user to trigger a write with this tag to the WAL. This is part of the efforts to support write-commited transactions with user-defined timestamps.

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -614,6 +614,8 @@ class Transaction {
 
   virtual uint64_t GetLastLogNumber() const { return log_number_; }
 
+  virtual bool IsIndexingEnabled() const = 0;
+
  private:
   friend class PessimisticTransactionDB;
   friend class WriteUnpreparedTxnDB;

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -406,8 +406,13 @@ class TransactionDB : public StackableDB {
       const TransactionOptions& txn_options = TransactionOptions(),
       Transaction* old_txn = nullptr) = 0;
 
-  virtual Transaction* GetTransactionByName(const TransactionName& name) = 0;
-  virtual void GetAllPreparedTransactions(std::vector<Transaction*>* trans) = 0;
+  inline Transaction* GetTransactionByName(const TransactionName& name) {
+    return GetTransactionByName(name, /*for_read=*/true);
+  }
+
+  inline void GetAllPreparedTransactions(std::vector<Transaction*>* trans) {
+    GetAllPreparedTransactions(trans, /*for_read=*/true);
+  }
 
   // Returns set of all locks held.
   //
@@ -425,6 +430,24 @@ class TransactionDB : public StackableDB {
   // No copying allowed
   TransactionDB(const TransactionDB&) = delete;
   void operator=(const TransactionDB&) = delete;
+
+  // Return the transaction with 'name'.
+  // If 'for_read' is true, then the returned transaction will be used for
+  // reading data (either from the transaction's write batch or from db).
+  // Therefore, the returned transaction's write batch will be indexed.
+  // If 'for_read' is false, then the returned transaction will not be used for
+  // reading data. Therefore, its write batch will not be indexed.
+  virtual Transaction* GetTransactionByName(const TransactionName& name,
+                                            bool for_read) = 0;
+
+  // Return all transactions that have successfully prepared.
+  // If 'for_read' is true, then the returned transactions will be used for
+  // reading data (either from the transaction's write batch or from db).
+  // Therefore, the returned transactions' write batches will be indexed.
+  // If 'for_read' is false, then the returned transactions will not be used for
+  // reading data. Therefore, their write batches will not be indexed.
+  virtual void GetAllPreparedTransactions(std::vector<Transaction*>* trans,
+                                          bool for_read) = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -270,6 +270,8 @@ class WriteBatchWithIndex : public WriteBatchBase {
                               const size_t num_keys, const Slice* keys,
                               PinnableSlice* values, Status* statuses,
                               bool sorted_input, ReadCallback* callback);
+  Status RebuildIndex();
+
   struct Rep;
   std::unique_ptr<Rep> rep;
 };

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -733,7 +733,8 @@ Status PessimisticTransaction::SetName(const TransactionName& name) {
   if (txn_state_ == STARTED) {
     if (name_.length()) {
       s = Status::InvalidArgument("Transaction has already been named.");
-    } else if (txn_db_impl_->GetTransactionByName(name) != nullptr) {
+    } else if (txn_db_impl_->GetTransactionByName(name, /*for_read=*/false) !=
+               nullptr) {
       s = Status::InvalidArgument("Transaction name must be unique.");
     } else if (name.length() < 1 || name.length() > 512) {
       s = Status::InvalidArgument(

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -125,13 +125,15 @@ class PessimisticTransactionDB : public TransactionDB {
   // is expirable (GetExpirationTime() > 0) and that it is expired.
   bool TryStealingExpiredTransactionLocks(TransactionID tx_id);
 
-  Transaction* GetTransactionByName(const TransactionName& name) override;
+  Transaction* GetTransactionByName(const TransactionName& name,
+                                    bool for_read) override;
 
   void RegisterTransaction(Transaction* txn);
   void UnregisterTransaction(Transaction* txn);
 
   // not thread safe. current use case is during recovery (single thread)
-  void GetAllPreparedTransactions(std::vector<Transaction*>* trans) override;
+  void GetAllPreparedTransactions(std::vector<Transaction*>* trans,
+                                  bool for_read) override;
 
   LockManager::PointLockStatus GetLockStatusData() override;
 

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -220,6 +220,8 @@ class TransactionBaseImpl : public Transaction {
 
   void EnableIndexing() override { indexing_enabled_ = true; }
 
+  bool IsIndexingEnabled() const override { return indexing_enabled_; }
+
   uint64_t GetElapsedTime() const override;
 
   uint64_t GetNumPuts() const override;

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -628,5 +628,7 @@ size_t WriteBatchWithIndex::GetDataSize() const {
   return rep->write_batch.GetDataSize();
 }
 
+Status WriteBatchWithIndex::RebuildIndex() { return rep->ReBuildIndex(); }
+
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // !ROCKSDB_LITE


### PR DESCRIPTION
Summary:
During recovery, scanning and processing the WALs can populate the
database's prepared transactions list. When a transaction's commit
marker is seen, we know the transaction has persisted all its writes
safely and can remove this transaction from the above list. During this
time, nobody tries to read via this transaction, thus we do not need to
build the index for the write batch. We do not even need to build the
index for prepared transactions until the said transaction is returned
to user via GetAllPreparedTransactions() and GetTransactionByName() API.

Note this currently applies to write-committed transactions that do not
use the `sub_batch_cnt_` of each WBWI.

Test Plan:
make check

simple benchmarking:
https://gist.github.com/riversand963/d6f319c30409265449d8a6a4f97682ab.

Recovering 1000 prepared transactions each with 20 small kvs, we see 13% reduction in
the execution time of `TransactionDB::Open()`.