### PR TITLE
SEGFAULT:  copy listeners from options object because options could be deleted, invalidating pointer

### DIFF
--- a/db/job_context.h
+++ b/db/job_context.h
@@ -24,7 +24,7 @@ struct SuperVersion;
 struct SuperVersionContext {
   struct WriteStallNotification {
     WriteStallInfo write_stall_info;
-    const ImmutableOptions* immutable_options;
+    std::vector<std::shared_ptr<EventListener>> immutable_options_listeners;
   };
 
   autovector<SuperVersion*> superversions_to_free;
@@ -67,7 +67,7 @@ struct SuperVersionContext {
     notif.write_stall_info.cf_name = name;
     notif.write_stall_info.condition.prev = old_cond;
     notif.write_stall_info.condition.cur = new_cond;
-    notif.immutable_options = ioptions;
+    notif.immutable_options_listeners = ioptions->listeners;
     write_stall_notifications.push_back(notif);
 #else
     (void)old_cond;
@@ -81,7 +81,7 @@ struct SuperVersionContext {
 #if !defined(ROCKSDB_LITE) && !defined(ROCKSDB_DISABLE_STALL_NOTIFICATION)
     // notify listeners on changed write stall conditions
     for (auto& notif : write_stall_notifications) {
-      for (auto& listener : notif.immutable_options->listeners) {
+      for (auto& listener : notif.immutable_options_listeners) {
         listener->OnStallConditionsChanged(notif.write_stall_info);
       }
     }


### PR DESCRIPTION
NOTE:  only first commit contains desired code changes.  Others are white-space changes to make "buck targets" check happy.

…efore background compaction completes.