### PR TITLE
Provide API to dump wals without opening the rocksdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,6 +713,7 @@ set(SOURCES
         db/version_set.cc
         db/wal_edit.cc
         db/wal_manager.cc
+        db/wal_dump.cc
         db/write_batch.cc
         db/write_batch_base.cc
         db/write_controller.cc

--- a/db/wal_dump.cc
+++ b/db/wal_dump.cc
@@ -1,0 +1,39 @@
+#include "rocksdb/wal_dump.h"
+#include <memory>
+#include <thread>
+
+#include "rocksdb/env.h"
+#include "db/wal_manager.h"
+#include "db/version_set.h"
+#include "options/db_options.h"
+
+namespace rocksdb {
+
+#ifndef ROCKSDB_LITE
+
+Status WalDump::CreateWalIter(std::string dbname,
+                                   SequenceNumber start_seq,
+                                   SequenceNumber end_seq,
+                                   std::unique_ptr<TransactionLogIterator>* iter,
+                                   const TransactionLogIterator::ReadOptions& read_options) {
+  thread_local ImmutableDBOptions db_options;
+  thread_local EnvOptions env_options;
+
+  db_options.db_paths.emplace_back(dbname, std::numeric_limits<uint64_t>::max());
+  db_options.wal_dir = dbname;
+  db_options.env = Env::Default();
+
+  std::unique_ptr<WalManager> wal_manager(new WalManager(db_options, env_options, nullptr));
+  thread_local std::unique_ptr<VersionSet> versions;
+  versions.reset(new VersionSet(dbname, &db_options, env_options, nullptr, nullptr, nullptr, nullptr, nullptr, ""));
+  versions->SetLastSequence(end_seq);
+
+  auto s = wal_manager->GetUpdatesSince(start_seq, iter, read_options, versions.get());
+  if (!s.ok()) {
+    return Status::Corruption("failed to get updates of wal manager, Err: " + s.ToString());
+  }
+  return Status::OK();
+}
+
+#endif  // ROCKSDB_LITE
+}  // namespace rocksdb

--- a/include/rocksdb/wal_dump.h
+++ b/include/rocksdb/wal_dump.h
@@ -1,0 +1,31 @@
+#include <string>
+#include <vector>
+
+#include "rocksdb/transaction_log.h"
+#include "rocksdb/status.h"
+#include "rocksdb/types.h"
+#include "rocksdb/write_batch.h"
+#include "rocksdb/options.h"
+#include "rocksdb/env.h"
+
+namespace rocksdb {
+
+#ifndef ROCKSDB_LITE
+
+class WalDump {
+ public:
+  WalDumper() {}
+  ~WalDumper() {}
+
+  static Status CreateWalIter(std::string dbname,
+                              SequenceNumber start_seq,
+                              SequenceNumber end_seq,
+                              std::unique_ptr<TransactionLogIterator>* iter,
+                              const TransactionLogIterator::ReadOptions& read_options =
+                              TransactionLogIterator::ReadOptions());
+
+};
+
+
+#endif  // ROCKSDB_LITE
+}  // namespace rocksdb


### PR DESCRIPTION
Case:
Server A open rocksdb and keep writing to rocksdb. If server B needs to dump wals of server A, WalManager::GetUpdatesSince() can be used to create an iterator to achieve the aim. However, If WalManager::GetUpdatesSince() is used directly, server B has to open the same rocksdb first. It may cause unkown problems, if rocksdb is opened by two servers at the same time.

Solution:
An API is provided to create iterator for wals without opening rocksdb. The difference with the iterator created with WalManager::GetUpdatesSince() is that an end sequence has to be given directly rather than get it with versionset of rocksdb. The end sequence has to less than or equal to the latest sequence of the rocksdb. Once the iterator is created, it can be used like which created by WalManager::GetUpdatesSince().
