### PR TITLE
Add CheckedCast/InstanceOf/Name methods to DB class

### DIFF
--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -19,6 +19,8 @@ class CompactedDBImpl : public DBImpl {
   void operator=(const CompactedDBImpl&) = delete;
 
   ~CompactedDBImpl() override;
+  static const char* kClassName() { return "CompactedDBImpl"; }
+  const char* Name() const override { return kClassName(); }
 
   static Status Open(const Options& options, const std::string& dbname,
                      DB** dbptr);

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -143,6 +143,16 @@ class DBImpl : public DB {
 
   virtual ~DBImpl();
 
+  static const char* kClassName() { return "DBImpl"; }
+  const char* Name() const override { return kClassName(); }
+  bool IsInstanceOf(const std::string& name) const override {
+    if (name == kClassName()) {
+      return true;
+    } else {
+      return DB::IsInstanceOf(name);
+    }
+  }
+
   // ---- Implementations of the DB interface ----
 
   using DB::Resume;

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -21,6 +21,8 @@ class DBImplReadOnly : public DBImpl {
   void operator=(const DBImplReadOnly&) = delete;
 
   virtual ~DBImplReadOnly();
+  static const char* kClassName() { return "DBImplReadOnly"; }
+  const char* Name() const override { return kClassName(); }
 
   // Implementations of the DB interface
   using DB::Get;

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -77,6 +77,9 @@ class DBImplSecondary : public DBImpl {
                   std::string secondary_path);
   ~DBImplSecondary() override;
 
+  static const char* kClassName() { return "DBImplSecondary"; }
+  const char* Name() const override { return kClassName(); }
+
   // Recover by replaying MANIFEST and WAL. Also initialize manifest_reader_
   // and log_readers_ to facilitate future operations.
   Status Recover(const std::vector<ColumnFamilyDescriptor>& column_families,

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -1246,6 +1246,25 @@ TEST_F(DBSecondaryTest, OpenWithTransactionDB) {
   ASSERT_OK(TryOpenSecondary(options));
 }
 
+TEST_F(DBSecondaryTest, CheckedCast) {
+  Options options = CurrentOptions();
+  options.create_if_missing = true;
+  options.max_open_files = -1;
+
+  ASSERT_OK(TryOpenSecondary(options));
+  ASSERT_TRUE(db_secondary_->IsInstanceOf(DBImplSecondary::kClassName()));
+  ASSERT_TRUE(db_secondary_->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_EQ(db_secondary_, db_secondary_->CheckedCast<DBImpl>());
+  ASSERT_EQ(db_secondary_, db_secondary_->GetRootDB());
+  std::unique_ptr<WrappedDB> wrapped(new WrappedDB(db_secondary_));
+
+  ASSERT_FALSE(wrapped->IsInstanceOf(DBImplSecondary::kClassName()));
+  ASSERT_FALSE(wrapped->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_EQ(db_secondary_, wrapped->CheckedCast<DBImpl>());
+  ASSERT_EQ(db_secondary_, wrapped->CheckedCast<DBImplSecondary>());
+  ASSERT_EQ(db_secondary_, wrapped->GetRootDB());
+  db_secondary_ = nullptr;  // Deleted via wrapped
+}
 #endif  //! ROCKSDB_LITE
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2863,6 +2863,8 @@ class ModelDB : public DB {
   };
 
   explicit ModelDB(const Options& options) : options_(options) {}
+  static const char* kClassName() { return "ModelDB"; }
+  const char* Name() const override { return kClassName(); }
   using DB::Put;
   Status Put(const WriteOptions& o, ColumnFamilyHandle* cf, const Slice& k,
              const Slice& v) override {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -747,6 +747,65 @@ class DB {
   // use "snapshot" after this call.
   virtual void ReleaseSnapshot(const Snapshot* snapshot) = 0;
 
+  // Returns the name of this class of DB.  DB instances should
+  // override this method.
+  virtual const char* Name() const { return ""; }
+
+  // This method is used to determine if the input name matches the
+  // name of this object.
+  // This method is typically used in conjunction with CheckedCast to find the
+  // derived class instance from its base.  For example, given a DB instance,
+  // one can determine if it can be cast to a TransactionDB or DBWithTTL.
+  //
+  // Intermediary classes (like TransactionDB) may wish to override this method
+  // to check for the intermediary name.
+  //
+  // Note that IsInstanceOf only uses the "is-a" relationship and not "has-a".
+  // Wrapped classes (GetBaseDB) with an Inner "has-a" should not be returned.
+  //
+  // @param name The name of the instance to find.
+  // Returns true if the class is an instance of the input name.
+  virtual bool IsInstanceOf(const std::string& name) const {
+    if (name.empty()) {
+      return false;
+    } else if (name == Name()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // Returns the named instance of the DB as a T*, or nullptr if not
+  // found. This method uses IsInstanceOf/GetBaseDB to find the appropriate
+  // DB instance and then casts it to the expected return type.
+  template <typename T>
+  const T* CheckedCast() const {
+    if (IsInstanceOf(T::kClassName())) {
+      return static_cast<const T*>(this);
+    } else {
+      auto base = GetBaseDB();
+      if (base != nullptr) {
+        return base->CheckedCast<T>();
+      } else {
+        return nullptr;
+      }
+    }
+  }
+
+  template <typename T>
+  T* CheckedCast() {
+    if (IsInstanceOf(T::kClassName())) {
+      return static_cast<T*>(this);
+    } else {
+      auto base = GetBaseDB();
+      if (base != nullptr) {
+        return base->CheckedCast<T>();
+      } else {
+        return nullptr;
+      }
+    }
+  }
+
 #ifndef ROCKSDB_LITE
   // Contains all valid property arguments for GetProperty() or
   // GetMapProperty(). Each is a "string" property for retrieval with
@@ -1749,6 +1808,7 @@ class DB {
 
   // Needed for StackableDB
   virtual DB* GetRootDB() { return this; }
+  virtual DB* GetBaseDB() const { return nullptr; }
 
   // Given a window [start_time, end_time), setup a StatsHistoryIterator
   // to access stats history. Note the start_time and end_time are epoch

--- a/include/rocksdb/utilities/db_ttl.h
+++ b/include/rocksdb/utilities/db_ttl.h
@@ -64,6 +64,15 @@ class DBWithTTL : public StackableDB {
 
   virtual void SetTtl(ColumnFamilyHandle* h, int32_t ttl) = 0;
 
+  static const char* kClassName() { return "DBWithTTL"; }
+  bool IsInstanceOf(const std::string& name) const override {
+    if (name == kClassName()) {
+      return true;
+    } else {
+      return StackableDB::IsInstanceOf(name);
+    }
+  }
+
  protected:
   explicit DBWithTTL(DB* db) : StackableDB(db) {}
 };

--- a/include/rocksdb/utilities/optimistic_transaction_db.h
+++ b/include/rocksdb/utilities/optimistic_transaction_db.h
@@ -72,6 +72,14 @@ class OptimisticTransactionDB : public StackableDB {
                      OptimisticTransactionDB** dbptr);
 
   virtual ~OptimisticTransactionDB() {}
+  static const char* kClassName() { return "OptimisticTransactionDB"; }
+  bool IsInstanceOf(const std::string& name) const override {
+    if (name == kClassName()) {
+      return true;
+    } else {
+      return StackableDB::IsInstanceOf(name);
+    }
+  }
 
   // Starts a new Transaction.
   //

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -35,72 +35,73 @@ class StackableDB : public DB {
     db_ = nullptr;
   }
 
-  virtual Status Close() override { return db_->Close(); }
+  Status Close() override { return db_->Close(); }
 
-  virtual DB* GetBaseDB() { return db_; }
+  DB* GetBaseDB() const override { return db_; }
 
-  virtual DB* GetRootDB() override { return db_->GetRootDB(); }
+  DB* GetRootDB() override { return db_->GetRootDB(); }
 
-  virtual Status CreateColumnFamily(const ColumnFamilyOptions& options,
-                                    const std::string& column_family_name,
-                                    ColumnFamilyHandle** handle) override {
+  // Returns the name of this class of DB.  DB instances should
+  // override this method.
+  const char* Name() const override { return db_->Name(); }
+
+  Status CreateColumnFamily(const ColumnFamilyOptions& options,
+                            const std::string& column_family_name,
+                            ColumnFamilyHandle** handle) override {
     return db_->CreateColumnFamily(options, column_family_name, handle);
   }
 
-  virtual Status CreateColumnFamilies(
+  Status CreateColumnFamilies(
       const ColumnFamilyOptions& options,
       const std::vector<std::string>& column_family_names,
       std::vector<ColumnFamilyHandle*>* handles) override {
     return db_->CreateColumnFamilies(options, column_family_names, handles);
   }
 
-  virtual Status CreateColumnFamilies(
+  Status CreateColumnFamilies(
       const std::vector<ColumnFamilyDescriptor>& column_families,
       std::vector<ColumnFamilyHandle*>* handles) override {
     return db_->CreateColumnFamilies(column_families, handles);
   }
 
-  virtual Status DropColumnFamily(ColumnFamilyHandle* column_family) override {
+  Status DropColumnFamily(ColumnFamilyHandle* column_family) override {
     return db_->DropColumnFamily(column_family);
   }
 
-  virtual Status DropColumnFamilies(
+  Status DropColumnFamilies(
       const std::vector<ColumnFamilyHandle*>& column_families) override {
     return db_->DropColumnFamilies(column_families);
   }
 
-  virtual Status DestroyColumnFamilyHandle(
-      ColumnFamilyHandle* column_family) override {
+  Status DestroyColumnFamilyHandle(ColumnFamilyHandle* column_family) override {
     return db_->DestroyColumnFamilyHandle(column_family);
   }
 
   using DB::Put;
-  virtual Status Put(const WriteOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& val) override {
+  Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, const Slice& val) override {
     return db_->Put(options, column_family, key, val);
   }
 
   using DB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override {
+  Status Get(const ReadOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, PinnableSlice* value) override {
     return db_->Get(options, column_family, key, value);
   }
 
   using DB::GetMergeOperands;
-  virtual Status GetMergeOperands(
-      const ReadOptions& options, ColumnFamilyHandle* column_family,
-      const Slice& key, PinnableSlice* slice,
-      GetMergeOperandsOptions* get_merge_operands_options,
-      int* number_of_operands) override {
+  Status GetMergeOperands(const ReadOptions& options,
+                          ColumnFamilyHandle* column_family, const Slice& key,
+                          PinnableSlice* slice,
+                          GetMergeOperandsOptions* get_merge_operands_options,
+                          int* number_of_operands) override {
     return db_->GetMergeOperands(options, column_family, key, slice,
                                  get_merge_operands_options,
                                  number_of_operands);
   }
 
   using DB::MultiGet;
-  virtual std::vector<Status> MultiGet(
+  std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
@@ -108,31 +109,28 @@ class StackableDB : public DB {
     return db_->MultiGet(options, column_family, keys, values);
   }
 
-  virtual void MultiGet(const ReadOptions& options,
-                        ColumnFamilyHandle* column_family,
-                        const size_t num_keys, const Slice* keys,
-                        PinnableSlice* values, Status* statuses,
-                        const bool sorted_input = false) override {
+  void MultiGet(const ReadOptions& options, ColumnFamilyHandle* column_family,
+                const size_t num_keys, const Slice* keys, PinnableSlice* values,
+                Status* statuses, const bool sorted_input = false) override {
     return db_->MultiGet(options, column_family, num_keys, keys,
                          values, statuses, sorted_input);
   }
 
   using DB::IngestExternalFile;
-  virtual Status IngestExternalFile(
-      ColumnFamilyHandle* column_family,
-      const std::vector<std::string>& external_files,
-      const IngestExternalFileOptions& options) override {
+  Status IngestExternalFile(ColumnFamilyHandle* column_family,
+                            const std::vector<std::string>& external_files,
+                            const IngestExternalFileOptions& options) override {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
   using DB::IngestExternalFiles;
-  virtual Status IngestExternalFiles(
+  Status IngestExternalFiles(
       const std::vector<IngestExternalFileArg>& args) override {
     return db_->IngestExternalFiles(args);
   }
 
   using DB::CreateColumnFamilyWithImport;
-  virtual Status CreateColumnFamilyWithImport(
+  Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
       const ExportImportFilesMetaData& metadata,
@@ -146,113 +144,106 @@ class StackableDB : public DB {
     return db_->VerifyFileChecksums(read_opts);
   }
 
-  virtual Status VerifyChecksum() override { return db_->VerifyChecksum(); }
+  Status VerifyChecksum() override { return db_->VerifyChecksum(); }
 
-  virtual Status VerifyChecksum(const ReadOptions& options) override {
+  Status VerifyChecksum(const ReadOptions& options) override {
     return db_->VerifyChecksum(options);
   }
 
   using DB::KeyMayExist;
-  virtual bool KeyMayExist(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           std::string* value,
-                           bool* value_found = nullptr) override {
+  bool KeyMayExist(const ReadOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   std::string* value, bool* value_found = nullptr) override {
     return db_->KeyMayExist(options, column_family, key, value, value_found);
   }
 
   using DB::Delete;
-  virtual Status Delete(const WriteOptions& wopts,
-                        ColumnFamilyHandle* column_family,
-                        const Slice& key) override {
+  Status Delete(const WriteOptions& wopts, ColumnFamilyHandle* column_family,
+                const Slice& key) override {
     return db_->Delete(wopts, column_family, key);
   }
 
   using DB::SingleDelete;
-  virtual Status SingleDelete(const WriteOptions& wopts,
-                              ColumnFamilyHandle* column_family,
-                              const Slice& key) override {
+  Status SingleDelete(const WriteOptions& wopts,
+                      ColumnFamilyHandle* column_family,
+                      const Slice& key) override {
     return db_->SingleDelete(wopts, column_family, key);
   }
 
   using DB::Merge;
-  virtual Status Merge(const WriteOptions& options,
-                       ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value) override {
+  Status Merge(const WriteOptions& options, ColumnFamilyHandle* column_family,
+               const Slice& key, const Slice& value) override {
     return db_->Merge(options, column_family, key, value);
   }
 
-  virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override {
+  Status Write(const WriteOptions& opts, WriteBatch* updates) override {
     return db_->Write(opts, updates);
   }
 
   using DB::NewIterator;
-  virtual Iterator* NewIterator(const ReadOptions& opts,
-                                ColumnFamilyHandle* column_family) override {
+  Iterator* NewIterator(const ReadOptions& opts,
+                        ColumnFamilyHandle* column_family) override {
     return db_->NewIterator(opts, column_family);
   }
 
-  virtual Status NewIterators(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      std::vector<Iterator*>* iterators) override {
+  Status NewIterators(const ReadOptions& options,
+                      const std::vector<ColumnFamilyHandle*>& column_families,
+                      std::vector<Iterator*>* iterators) override {
     return db_->NewIterators(options, column_families, iterators);
   }
 
-  virtual const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
+  const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
 
-  virtual void ReleaseSnapshot(const Snapshot* snapshot) override {
+  void ReleaseSnapshot(const Snapshot* snapshot) override {
     return db_->ReleaseSnapshot(snapshot);
   }
 
   using DB::GetMapProperty;
   using DB::GetProperty;
-  virtual bool GetProperty(ColumnFamilyHandle* column_family,
-                           const Slice& property, std::string* value) override {
+  bool GetProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                   std::string* value) override {
     return db_->GetProperty(column_family, property, value);
   }
-  virtual bool GetMapProperty(
-      ColumnFamilyHandle* column_family, const Slice& property,
-      std::map<std::string, std::string>* value) override {
+  bool GetMapProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                      std::map<std::string, std::string>* value) override {
     return db_->GetMapProperty(column_family, property, value);
   }
 
   using DB::GetIntProperty;
-  virtual bool GetIntProperty(ColumnFamilyHandle* column_family,
-                              const Slice& property, uint64_t* value) override {
+  bool GetIntProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                      uint64_t* value) override {
     return db_->GetIntProperty(column_family, property, value);
   }
 
   using DB::GetAggregatedIntProperty;
-  virtual bool GetAggregatedIntProperty(const Slice& property,
-                                        uint64_t* value) override {
+  bool GetAggregatedIntProperty(const Slice& property,
+                                uint64_t* value) override {
     return db_->GetAggregatedIntProperty(property, value);
   }
 
   using DB::GetApproximateSizes;
-  virtual Status GetApproximateSizes(const SizeApproximationOptions& options,
-                                     ColumnFamilyHandle* column_family,
-                                     const Range* r, int n,
-                                     uint64_t* sizes) override {
+  Status GetApproximateSizes(const SizeApproximationOptions& options,
+                             ColumnFamilyHandle* column_family, const Range* r,
+                             int n, uint64_t* sizes) override {
     return db_->GetApproximateSizes(options, column_family, r, n, sizes);
   }
 
   using DB::GetApproximateMemTableStats;
-  virtual void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
-                                           const Range& range,
-                                           uint64_t* const count,
-                                           uint64_t* const size) override {
+  void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
+                                   const Range& range, uint64_t* const count,
+                                   uint64_t* const size) override {
     return db_->GetApproximateMemTableStats(column_family, range, count, size);
   }
 
   using DB::CompactRange;
-  virtual Status CompactRange(const CompactRangeOptions& options,
-                              ColumnFamilyHandle* column_family,
-                              const Slice* begin, const Slice* end) override {
+  Status CompactRange(const CompactRangeOptions& options,
+                      ColumnFamilyHandle* column_family, const Slice* begin,
+                      const Slice* end) override {
     return db_->CompactRange(options, column_family, begin, end);
   }
 
   using DB::CompactFiles;
-  virtual Status CompactFiles(
+  Status CompactFiles(
       const CompactionOptions& compact_options,
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names, const int output_level,
@@ -264,107 +255,95 @@ class StackableDB : public DB {
                              compaction_job_info);
   }
 
-  virtual Status PauseBackgroundWork() override {
-    return db_->PauseBackgroundWork();
-  }
-  virtual Status ContinueBackgroundWork() override {
+  Status PauseBackgroundWork() override { return db_->PauseBackgroundWork(); }
+  Status ContinueBackgroundWork() override {
     return db_->ContinueBackgroundWork();
   }
 
-  virtual Status EnableAutoCompaction(
+  Status EnableAutoCompaction(
       const std::vector<ColumnFamilyHandle*>& column_family_handles) override {
     return db_->EnableAutoCompaction(column_family_handles);
   }
 
-  virtual void EnableManualCompaction() override {
+  void EnableManualCompaction() override {
     return db_->EnableManualCompaction();
   }
-  virtual void DisableManualCompaction() override {
+  void DisableManualCompaction() override {
     return db_->DisableManualCompaction();
   }
 
   using DB::NumberLevels;
-  virtual int NumberLevels(ColumnFamilyHandle* column_family) override {
+  int NumberLevels(ColumnFamilyHandle* column_family) override {
     return db_->NumberLevels(column_family);
   }
 
   using DB::MaxMemCompactionLevel;
-  virtual int MaxMemCompactionLevel(
-      ColumnFamilyHandle* column_family) override {
+  int MaxMemCompactionLevel(ColumnFamilyHandle* column_family) override {
     return db_->MaxMemCompactionLevel(column_family);
   }
 
   using DB::Level0StopWriteTrigger;
-  virtual int Level0StopWriteTrigger(
-      ColumnFamilyHandle* column_family) override {
+  int Level0StopWriteTrigger(ColumnFamilyHandle* column_family) override {
     return db_->Level0StopWriteTrigger(column_family);
   }
 
-  virtual const std::string& GetName() const override { return db_->GetName(); }
+  const std::string& GetName() const override { return db_->GetName(); }
 
-  virtual Env* GetEnv() const override { return db_->GetEnv(); }
+  Env* GetEnv() const override { return db_->GetEnv(); }
 
-  virtual FileSystem* GetFileSystem() const override {
-    return db_->GetFileSystem();
-  }
+  FileSystem* GetFileSystem() const override { return db_->GetFileSystem(); }
 
   using DB::GetOptions;
-  virtual Options GetOptions(ColumnFamilyHandle* column_family) const override {
+  Options GetOptions(ColumnFamilyHandle* column_family) const override {
     return db_->GetOptions(column_family);
   }
 
   using DB::GetDBOptions;
-  virtual DBOptions GetDBOptions() const override {
-    return db_->GetDBOptions();
-  }
+  DBOptions GetDBOptions() const override { return db_->GetDBOptions(); }
 
   using DB::Flush;
-  virtual Status Flush(const FlushOptions& fopts,
-                       ColumnFamilyHandle* column_family) override {
+  Status Flush(const FlushOptions& fopts,
+               ColumnFamilyHandle* column_family) override {
     return db_->Flush(fopts, column_family);
   }
-  virtual Status Flush(
+  Status Flush(
       const FlushOptions& fopts,
       const std::vector<ColumnFamilyHandle*>& column_families) override {
     return db_->Flush(fopts, column_families);
   }
 
-  virtual Status SyncWAL() override { return db_->SyncWAL(); }
+  Status SyncWAL() override { return db_->SyncWAL(); }
 
-  virtual Status FlushWAL(bool sync) override { return db_->FlushWAL(sync); }
+  Status FlushWAL(bool sync) override { return db_->FlushWAL(sync); }
 
-  virtual Status LockWAL() override { return db_->LockWAL(); }
+  Status LockWAL() override { return db_->LockWAL(); }
 
-  virtual Status UnlockWAL() override { return db_->UnlockWAL(); }
+  Status UnlockWAL() override { return db_->UnlockWAL(); }
 
 #ifndef ROCKSDB_LITE
 
-  virtual Status DisableFileDeletions() override {
-    return db_->DisableFileDeletions();
-  }
+  Status DisableFileDeletions() override { return db_->DisableFileDeletions(); }
 
-  virtual Status EnableFileDeletions(bool force) override {
+  Status EnableFileDeletions(bool force) override {
     return db_->EnableFileDeletions(force);
   }
 
-  virtual void GetLiveFilesMetaData(
-      std::vector<LiveFileMetaData>* metadata) override {
+  void GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) override {
     db_->GetLiveFilesMetaData(metadata);
   }
 
-  virtual Status GetLiveFilesChecksumInfo(
-      FileChecksumList* checksum_list) override {
+  Status GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) override {
     return db_->GetLiveFilesChecksumInfo(checksum_list);
   }
 
-  virtual Status GetLiveFilesStorageInfo(
+  Status GetLiveFilesStorageInfo(
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) override {
     return db_->GetLiveFilesStorageInfo(opts, files);
   }
 
-  virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
-                                       ColumnFamilyMetaData* cf_meta) override {
+  void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
+                               ColumnFamilyMetaData* cf_meta) override {
     db_->GetColumnFamilyMetaData(column_family, cf_meta);
   }
 
@@ -405,17 +384,16 @@ class StackableDB : public DB {
 
 #endif  // ROCKSDB_LITE
 
-  virtual Status GetLiveFiles(std::vector<std::string>& vec, uint64_t* mfs,
-                              bool flush_memtable = true) override {
+  Status GetLiveFiles(std::vector<std::string>& vec, uint64_t* mfs,
+                      bool flush_memtable = true) override {
     return db_->GetLiveFiles(vec, mfs, flush_memtable);
   }
 
-  virtual SequenceNumber GetLatestSequenceNumber() const override {
+  SequenceNumber GetLatestSequenceNumber() const override {
     return db_->GetLatestSequenceNumber();
   }
 
-  virtual bool SetPreserveDeletesSequenceNumber(
-      SequenceNumber seqnum) override {
+  bool SetPreserveDeletesSequenceNumber(SequenceNumber seqnum) override {
     return db_->SetPreserveDeletesSequenceNumber(seqnum);
   }
 
@@ -429,17 +407,16 @@ class StackableDB : public DB {
     return db_->GetFullHistoryTsLow(column_family, ts_low);
   }
 
-  virtual Status GetSortedWalFiles(VectorLogPtr& files) override {
+  Status GetSortedWalFiles(VectorLogPtr& files) override {
     return db_->GetSortedWalFiles(files);
   }
 
-  virtual Status GetCurrentWalFile(
+  Status GetCurrentWalFile(
       std::unique_ptr<LogFile>* current_log_file) override {
     return db_->GetCurrentWalFile(current_log_file);
   }
 
-  virtual Status GetCreationTimeOfOldestFile(
-      uint64_t* creation_time) override {
+  Status GetCreationTimeOfOldestFile(uint64_t* creation_time) override {
     return db_->GetCreationTimeOfOldestFile(creation_time);
   }
 
@@ -450,66 +427,61 @@ class StackableDB : public DB {
   // do not plan to maintain it, the contract will likely remain underspecified
   // until its removal. Any user is encouraged to read the implementation
   // carefully and migrate away from it when possible.
-  virtual Status DeleteFile(std::string name) override {
-    return db_->DeleteFile(name);
-  }
+  Status DeleteFile(std::string name) override { return db_->DeleteFile(name); }
 
-  virtual Status GetDbIdentity(std::string& identity) const override {
+  Status GetDbIdentity(std::string& identity) const override {
     return db_->GetDbIdentity(identity);
   }
 
-  virtual Status GetDbSessionId(std::string& session_id) const override {
+  Status GetDbSessionId(std::string& session_id) const override {
     return db_->GetDbSessionId(session_id);
   }
 
   using DB::SetOptions;
-  virtual Status SetOptions(ColumnFamilyHandle* column_family_handle,
-                            const std::unordered_map<std::string, std::string>&
-                                new_options) override {
+  Status SetOptions(ColumnFamilyHandle* column_family_handle,
+                    const std::unordered_map<std::string, std::string>&
+                        new_options) override {
     return db_->SetOptions(column_family_handle, new_options);
   }
 
-  virtual Status SetDBOptions(
-      const std::unordered_map<std::string, std::string>& new_options)
-      override {
+  Status SetDBOptions(const std::unordered_map<std::string, std::string>&
+                          new_options) override {
     return db_->SetDBOptions(new_options);
   }
 
   using DB::ResetStats;
-  virtual Status ResetStats() override { return db_->ResetStats(); }
+  Status ResetStats() override { return db_->ResetStats(); }
 
   using DB::GetPropertiesOfAllTables;
-  virtual Status GetPropertiesOfAllTables(
-      ColumnFamilyHandle* column_family,
-      TablePropertiesCollection* props) override {
+  Status GetPropertiesOfAllTables(ColumnFamilyHandle* column_family,
+                                  TablePropertiesCollection* props) override {
     return db_->GetPropertiesOfAllTables(column_family, props);
   }
 
   using DB::GetPropertiesOfTablesInRange;
-  virtual Status GetPropertiesOfTablesInRange(
+  Status GetPropertiesOfTablesInRange(
       ColumnFamilyHandle* column_family, const Range* range, std::size_t n,
       TablePropertiesCollection* props) override {
     return db_->GetPropertiesOfTablesInRange(column_family, range, n, props);
   }
 
-  virtual Status GetUpdatesSince(
+  Status GetUpdatesSince(
       SequenceNumber seq_number, std::unique_ptr<TransactionLogIterator>* iter,
       const TransactionLogIterator::ReadOptions& read_options) override {
     return db_->GetUpdatesSince(seq_number, iter, read_options);
   }
 
-  virtual Status SuggestCompactRange(ColumnFamilyHandle* column_family,
-                                     const Slice* begin,
-                                     const Slice* end) override {
+  Status SuggestCompactRange(ColumnFamilyHandle* column_family,
+                             const Slice* begin, const Slice* end) override {
     return db_->SuggestCompactRange(column_family, begin, end);
   }
 
-  virtual Status PromoteL0(ColumnFamilyHandle* column_family,
-                           int target_level) override {
+  Status PromoteL0(ColumnFamilyHandle* column_family,
+                   int target_level) override {
     return db_->PromoteL0(column_family, target_level);
   }
 
-  virtual ColumnFamilyHandle* DefaultColumnFamily() const override {
+  ColumnFamilyHandle* DefaultColumnFamily() const override {
     return db_->DefaultColumnFamily();
   }
 

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -339,6 +339,15 @@ struct DeadlockPath {
 
 class TransactionDB : public StackableDB {
  public:
+  static const char* kClassName() { return "TransactionDB"; }
+  bool IsInstanceOf(const std::string& name) const override {
+    if (name == kClassName()) {
+      return true;
+    } else {
+      return StackableDB::IsInstanceOf(name);
+    }
+  }
+
   // Optimized version of ::Write that receives more optimization request such
   // as skip_concurrency_control.
   using StackableDB::Write;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -67,6 +67,9 @@ class DummyDB : public StackableDB {
     return ++sequence_number_;
   }
 
+  static const char* kClassName() { return "DummyDB"; }
+  const char* Name() const override { return kClassName(); }
+
   const std::string& GetName() const override { return dbname_; }
 
   Env* GetEnv() const override { return options_.env; }

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -88,6 +88,15 @@ struct BlobDBOptions {
 
 class BlobDB : public StackableDB {
  public:
+  static const char* kClassName() { return "BlobDB"; }
+  bool IsInstanceOf(const std::string& name) const override {
+    if (name == kClassName()) {
+      return true;
+    } else {
+      return StackableDB::IsInstanceOf(name);
+    }
+  }
+
   using ROCKSDB_NAMESPACE::StackableDB::Put;
   virtual Status Put(const WriteOptions& options, const Slice& key,
                      const Slice& value) override = 0;

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -77,6 +77,9 @@ class BlobDBImpl : public BlobDB {
   friend class BlobIndexCompactionFilterGC;
 
  public:
+  static const char* kClassName() { return "BlobDBImpl"; }
+  const char* Name() const override { return kClassName(); }
+
   // deletions check period
   static constexpr uint32_t kDeleteCheckPeriodMillisecs = 2 * 1000;
 

--- a/utilities/memory/memory_test.cc
+++ b/utilities/memory/memory_test.cc
@@ -53,8 +53,7 @@ class MemoryTest : public testing::Test {
       assert(db);
 
       // Cache from DBImpl
-      StackableDB* sdb = dynamic_cast<StackableDB*>(db);
-      DBImpl* db_impl = dynamic_cast<DBImpl*>(sdb ? sdb->GetBaseDB() : db);
+      DBImpl* db_impl = db->CheckedCast<DBImpl>();
       if (db_impl != nullptr) {
         cache_set->insert(db_impl->TEST_table_cache());
       }

--- a/utilities/transactions/optimistic_transaction_db_impl.h
+++ b/utilities/transactions/optimistic_transaction_db_impl.h
@@ -41,6 +41,8 @@ class OptimisticTransactionDBImpl : public OptimisticTransactionDB {
       db_ = nullptr;
     }
   }
+  static const char* kClassName() { return "OptimisticTransactionDBImpl"; }
+  const char* Name() const override { return kClassName(); }
 
   Transaction* BeginTransaction(const WriteOptions& write_options,
                                 const OptimisticTransactionOptions& txn_options,

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -36,6 +36,14 @@ class PessimisticTransactionDB : public TransactionDB {
                                     const TransactionDBOptions& txn_db_options);
 
   virtual ~PessimisticTransactionDB();
+  static const char* kClassName() { return "PessimisticTransactionDB"; }
+  bool IsInstanceOf(const std::string& name) const override {
+    if (name == kClassName()) {
+      return true;
+    } else {
+      return TransactionDB::IsInstanceOf(name);
+    }
+  }
 
   virtual const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
 
@@ -210,6 +218,9 @@ class WriteCommittedTxnDB : public PessimisticTransactionDB {
       : PessimisticTransactionDB(db, txn_db_options) {}
 
   virtual ~WriteCommittedTxnDB() {}
+
+  static const char* kClassName() { return "WriteCommittedTxnDB"; }
+  const char* Name() const override { return kClassName(); }
 
   Transaction* BeginTransaction(const WriteOptions& write_options,
                                 const TransactionOptions& txn_options,

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -170,7 +170,7 @@ class TransactionTestBase : public ::testing::Test {
         txn_db_options.write_policy == WRITE_PREPARED;
     Status s = DBImpl::Open(options_copy, dbname, cfs, handles, &root_db,
                             use_seq_per_batch, use_batch_per_txn);
-    StackableDB* stackable_db = new StackableDB(root_db);
+    StackableDB* stackable_db = new WrappedDB(root_db);
     if (s.ok()) {
       assert(root_db != nullptr);
       s = TransactionDB::WrapStackableDB(stackable_db, txn_db_options,
@@ -205,7 +205,7 @@ class TransactionTestBase : public ::testing::Test {
       delete root_db;
       return s;
     }
-    StackableDB* stackable_db = new StackableDB(root_db);
+    StackableDB* stackable_db = new WrappedDB(root_db);
     assert(root_db != nullptr);
     assert(handles.size() == 1);
     s = TransactionDB::WrapStackableDB(stackable_db, txn_db_options,

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -376,7 +376,7 @@ class WritePreparedTransactionTestBase : public TransactionTestBase {
                                            uint64_t snapshot,
                                            uint64_t next_snapshot,
                                            bool expect_update) {
-    WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+    WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
     // reset old_commit_map_empty_ so that its value indicate whether
     // old_commit_map_ was updated
     wp_db->old_commit_map_empty_ = true;
@@ -698,7 +698,7 @@ INSTANTIATE_TEST_CASE_P(
 #endif  // !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)
 
 TEST_P(WritePreparedTransactionTest, CommitMap) {
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
   ASSERT_NE(wp_db, nullptr);
   ASSERT_NE(wp_db->db_impl_, nullptr);
   size_t size = wp_db->COMMIT_CACHE_SIZE;
@@ -838,7 +838,8 @@ TEST_P(WritePreparedTransactionTest, CheckKeySkipOldMemtable) {
       ASSERT_OK(db->Flush(flush_ops));
     } else {
       ASSERT_EQ(attempt, kAttemptImmMemTable);
-      DBImpl* db_impl = static_cast<DBImpl*>(db->GetRootDB());
+      auto db_impl = db->CheckedCast<DBImpl>();
+      ASSERT_NE(db_impl, nullptr);
       ASSERT_OK(db_impl->TEST_SwitchMemtable());
     }
     uint64_t num_imm_mems;
@@ -936,7 +937,8 @@ TEST_P(WritePreparedTransactionTest, DoubleSnapshot) {
   // Insert initial value
   ASSERT_OK(db->Put(WriteOptions(), "key", "value1"));
 
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
   Transaction* txn =
       wp_db->BeginTransaction(WriteOptions(), txn_options, nullptr);
   ASSERT_OK(txn->SetName("txn"));
@@ -1314,7 +1316,8 @@ TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqBasic) {
 TEST_P(WritePreparedTransactionTest, NewSnapshotLargerThanMax) {
   WriteOptions woptions;
   TransactionOptions txn_options;
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
   Transaction* txn0 = db->BeginTransaction(woptions, txn_options);
   ASSERT_OK(txn0->Put(Slice("key"), Slice("value")));
   ASSERT_OK(txn0->Commit());
@@ -1363,7 +1366,8 @@ TEST_P(WritePreparedTransactionTest, MaxCatchupWithNewSnapshot) {
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
   ASSERT_OK(ReOpen());
   WriteOptions woptions;
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
 
   const int writes = 50;
   const int batch_cnt = 4;
@@ -1413,7 +1417,8 @@ TEST_P(WritePreparedTransactionTest, MaxCatchupWithUnbackedSnapshot) {
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
   ASSERT_OK(ReOpen());
   WriteOptions woptions;
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
 
   const int writes = 50;
   ROCKSDB_NAMESPACE::port::Thread t1([&]() {
@@ -1472,7 +1477,9 @@ TEST_P(WritePreparedTransactionTest, CleanupSnapshotEqualToMax) {
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
   ASSERT_OK(ReOpen());
   WriteOptions woptions;
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
+
   // Insert something to increase seq
   ASSERT_OK(db->Put(woptions, "key", "value"));
   auto snap = db->GetSnapshot();
@@ -1501,7 +1508,9 @@ TEST_P(WritePreparedTransactionTest, AdvanceSeqByOne) {
   auto seq1 = snap->GetSequenceNumber();
   db->ReleaseSnapshot(snap);
 
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
+
   wp_db->AdvanceSeqByOne();
 
   snap = db->GetSnapshot();
@@ -1564,7 +1573,9 @@ TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqWithDuplicates) {
   ASSERT_TRUE(s.IsNotFound());
   delete txn0;
 
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
+
   ASSERT_OK(wp_db->db_impl_->FlushWAL(true));
   wp_db->TEST_Crash();
   ASSERT_OK(ReOpenNoDelete());
@@ -1586,7 +1597,9 @@ TEST_P(WritePreparedTransactionTest, SmallestUnCommittedSeq) {
   const size_t commit_cache_bits = 1;    // disable commit cache
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
   ASSERT_OK(ReOpen());
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
+
   ReadOptions ropt;
   PinnableSlice pinnable_val;
   WriteOptions write_options;
@@ -1676,7 +1689,8 @@ TEST_P(SeqAdvanceConcurrentTest, SeqAdvanceConcurrent) {
     if (n % 1000 == 0) {
       printf("Tested %" ROCKSDB_PRIszt " cases so far\n", n);
     }
-    DBImpl* db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+    DBImpl* db_impl = db->CheckedCast<DBImpl>();
+    ASSERT_NE(db_impl, nullptr);
     auto seq = db_impl->TEST_GetLastVisibleSequence();
     with_empty_commits = 0;
     exp_seq = seq;
@@ -1768,7 +1782,8 @@ TEST_P(SeqAdvanceConcurrentTest, SeqAdvanceConcurrent) {
     ASSERT_OK(db_impl->FlushWAL(true));
     ASSERT_OK(ReOpenNoDelete());
     ASSERT_NE(db, nullptr);
-    db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+    db_impl = db->CheckedCast<DBImpl>();
+    ASSERT_NE(db_impl, nullptr);
     seq = db_impl->TEST_GetLastVisibleSequence();
     ASSERT_LE(exp_seq, seq + with_empty_commits);
 
@@ -1781,7 +1796,9 @@ TEST_P(SeqAdvanceConcurrentTest, SeqAdvanceConcurrent) {
     ASSERT_OK(db_impl->FlushWAL(true));
     ASSERT_OK(ReOpenNoDelete());
     ASSERT_NE(db, nullptr);
-    db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+    db_impl = db->CheckedCast<DBImpl>();
+    ASSERT_NE(db_impl, nullptr);
+
     seq = db_impl->GetLatestSequenceNumber();
     ASSERT_LE(exp_seq, seq + with_empty_commits);
   }
@@ -1793,7 +1810,8 @@ TEST_P(SeqAdvanceConcurrentTest, SeqAdvanceConcurrent) {
 TEST_P(WritePreparedTransactionTest, BasicRecovery) {
   options.disable_auto_compactions = true;
   ASSERT_OK(ReOpen());
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
 
   txn_t0(0);
 
@@ -1838,7 +1856,9 @@ TEST_P(WritePreparedTransactionTest, BasicRecovery) {
   wp_db->TEST_Crash();
   ASSERT_OK(ReOpenNoDelete());
   ASSERT_NE(db, nullptr);
-  wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
+
   // After recovery, all the uncommitted txns (0 and 1) should be inserted into
   // delayed_prepared_
   ASSERT_TRUE(wp_db->prepared_txns_.empty());
@@ -1884,7 +1904,8 @@ TEST_P(WritePreparedTransactionTest, BasicRecovery) {
   wp_db->TEST_Crash();
   ASSERT_OK(ReOpenNoDelete());
   ASSERT_NE(db, nullptr);
-  wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
   ASSERT_TRUE(wp_db->prepared_txns_.empty());
   ASSERT_FALSE(wp_db->delayed_prepared_empty_);
 
@@ -1920,6 +1941,9 @@ TEST_P(WritePreparedTransactionTest, BasicRecovery) {
   ASSERT_OK(ReOpenNoDelete());
   ASSERT_NE(db, nullptr);
   wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
+
   ASSERT_TRUE(wp_db->prepared_txns_.empty());
   ASSERT_TRUE(wp_db->delayed_prepared_empty_);
 
@@ -1949,11 +1973,15 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotEmptyMap) {
       prepare_seq = txn->GetId();
       delete txn;
     }
-    dynamic_cast<WritePreparedTxnDB*>(db)->TEST_Crash();
-    auto db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+    WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+    ASSERT_NE(wp_db, nullptr);
+    wp_db->TEST_Crash();
+
+    auto db_impl = wp_db->CheckedCast<DBImpl>();
+    ASSERT_NE(db_impl, nullptr);
     ASSERT_OK(db_impl->FlushWAL(true));
     ASSERT_OK(ReOpenNoDelete());
-    WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+    wp_db = db->CheckedCast<WritePreparedTxnDB>();
     ASSERT_NE(wp_db, nullptr);
     ASSERT_GT(wp_db->max_evicted_seq_, 0);  // max after recovery
     // Take a snapshot right after recovery
@@ -1993,7 +2021,9 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotEmptyMap) {
 
 // Shows the contract of IsInSnapshot when called on invalid/released snapshots
 TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
+
   WriteOptions woptions;
   ASSERT_OK(db->Put(woptions, "key", "value"));
   // snap seq = 1
@@ -2228,7 +2258,8 @@ TEST_P(WritePreparedTransactionTest, Rollback) {
     for (size_t ivalue = 0; ivalue < num_values; ivalue++) {
       for (bool crash : {false, true}) {
         ASSERT_OK(ReOpen());
-        WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+        WritePreparedTxnDB* wp_db = db->CheckedCast<WritePreparedTxnDB>();
+        ASSERT_NE(wp_db, nullptr);
         std::string key_str = "key" + ToString(ikey);
         switch (ivalue) {
           case 0:
@@ -2288,12 +2319,16 @@ TEST_P(WritePreparedTransactionTest, Rollback) {
 
         if (crash) {
           delete txn;
-          auto db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+          auto db_impl = db->CheckedCast<DBImpl>();
+          ASSERT_NE(db_impl, nullptr);
           ASSERT_OK(db_impl->FlushWAL(true));
-          dynamic_cast<WritePreparedTxnDB*>(db)->TEST_Crash();
+          wp_db = db->CheckedCast<WritePreparedTxnDB>();
+          ASSERT_NE(wp_db, nullptr);
+          wp_db->TEST_Crash();
           ASSERT_OK(ReOpenNoDelete());
           ASSERT_NE(db, nullptr);
-          wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+          wp_db = db->CheckedCast<WritePreparedTxnDB>();
+          ASSERT_NE(wp_db, nullptr);
           txn = db->GetTransactionByName("xid0");
           ASSERT_FALSE(wp_db->delayed_prepared_empty_);
           ReadLock rl(&wp_db->prepared_mutex_);
@@ -2347,7 +2382,10 @@ TEST_P(WritePreparedTransactionTest, DisableGCDuringRecovery) {
   }
   std::reverse(std::begin(versions), std::end(versions));
   VerifyInternalKeys(versions);
-  DBImpl* db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+
+  DBImpl* db_impl = db->CheckedCast<DBImpl>();
+  ASSERT_NE(db_impl, nullptr);
+
   ASSERT_OK(db_impl->FlushWAL(true));
   // Use small buffer to ensure memtable flush during recovery
   options.write_buffer_size = 1024;
@@ -2379,7 +2417,9 @@ TEST_P(WritePreparedTransactionTest, SequenceNumberZero) {
 TEST_P(WritePreparedTransactionTest, CompactionShouldKeepUncommittedKeys) {
   options.disable_auto_compactions = true;
   ASSERT_OK(ReOpen());
-  DBImpl* db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+
+  DBImpl* db_impl = db->CheckedCast<DBImpl>();
+  ASSERT_NE(db_impl, nullptr);
   // Snapshots to avoid keys get evicted.
   std::vector<const Snapshot*> snapshots;
   // Keep track of expected sequence number.
@@ -2478,7 +2518,8 @@ TEST_P(WritePreparedTransactionTest, CompactionShouldKeepSnapshotVisibleKeys) {
   ASSERT_OK(txn1->Prepare());
   ASSERT_EQ(++expected_seq, db->GetLatestSequenceNumber());
   ASSERT_OK(txn1->Commit());
-  DBImpl* db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+  DBImpl* db_impl = db->CheckedCast<DBImpl>();
+  ASSERT_NE(db_impl, nullptr);
   ASSERT_EQ(++expected_seq, db_impl->TEST_GetLastVisibleSequence());
   delete txn1;
   // Take a snapshots to avoid keys get evicted before compaction.
@@ -3259,9 +3300,9 @@ TEST_P(WritePreparedTransactionTest, SingleDeleteAfterRollback) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->EnableProcessing();
 
-  DBImpl* dbimpl = static_cast_with_check<DBImpl>(db->GetRootDB());
-  assert(dbimpl);
-  ASSERT_OK(dbimpl->TEST_CompactRange(
+  DBImpl* db_impl = db->CheckedCast<DBImpl>();
+  ASSERT_NE(db_impl, nullptr);
+  ASSERT_OK(db_impl->TEST_CompactRange(
       /*level=*/0, /*begin=*/nullptr, /*end=*/nullptr,
       /*column_family=*/nullptr, /*disallow_trivial_mode=*/true));
 
@@ -3373,7 +3414,8 @@ TEST_P(WritePreparedTransactionTest,
   ASSERT_EQ(++expected_seq, db->GetLatestSequenceNumber());
   SequenceNumber seq1 = expected_seq;
   ASSERT_OK(db->Put(WriteOptions(), "key2", "value2"));
-  DBImpl* db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+  DBImpl* db_impl = db->CheckedCast<DBImpl>();
+  ASSERT_NE(db_impl, nullptr);
   expected_seq++;  // one for data
   if (options.two_write_queues) {
     expected_seq++;  // one for commit
@@ -3511,8 +3553,10 @@ TEST_P(WritePreparedTransactionTest, NonAtomicCommitOfDelayedPrepared) {
     for (auto split_before_mutex : split_options) {
       UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
       ASSERT_OK(ReOpen());
-      WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
-      DBImpl* db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
+      auto wp_db = db->CheckedCast<WritePreparedTxnDB>();
+      ASSERT_NE(wp_db, nullptr);
+      DBImpl* db_impl = db->CheckedCast<DBImpl>();
+      ASSERT_NE(db_impl, nullptr);
       // Fill up the commit cache
       std::string init_value("value1");
       for (int i = 0; i < 10; i++) {
@@ -3609,7 +3653,8 @@ TEST_P(WritePreparedTransactionTest, NonAtomicUpdateOfDelayedPrepared) {
   const size_t commit_cache_bits = 3;    // 8 entries
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
   ASSERT_OK(ReOpen());
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  auto wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
   // Fill up the commit cache
   std::string init_value("value1");
   for (int i = 0; i < 10; i++) {
@@ -3679,7 +3724,9 @@ TEST_P(WritePreparedTransactionTest, NonAtomicUpdateOfMaxEvictedSeq) {
   const size_t commit_cache_bits = 3;    // 8 entries
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
   ASSERT_OK(ReOpen());
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  auto wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
+
   // Fill up the commit cache
   std::string init_value("value1");
   std::string last_value("value_final");
@@ -3760,7 +3807,8 @@ TEST_P(WritePreparedTransactionTest, AddPreparedBeforeMax) {
   const size_t commit_cache_bits = 0;
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
   ASSERT_OK(ReOpen());
-  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  auto wp_db = db->CheckedCast<WritePreparedTxnDB>();
+  ASSERT_NE(wp_db, nullptr);
   std::string some_value("value_some");
   std::string uncommitted_value("value_uncommitted");
   // Prepare two uncommitted transactions
@@ -3998,6 +4046,88 @@ TEST_P(WritePreparedTransactionTest, WC_WP_WALForwardIncompatibility) {
   CrossCompatibilityTest(WRITE_PREPARED, WRITE_COMMITTED, !empty_wal);
 }
 
+TEST_P(WritePreparedTransactionTest, CheckedPreparedCast) {
+  ASSERT_FALSE(db->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_TRUE(db->IsInstanceOf(TransactionDB::kClassName()));
+  ASSERT_TRUE(db->IsInstanceOf(PessimisticTransactionDB::kClassName()));
+  ASSERT_TRUE(db->IsInstanceOf(WritePreparedTxnDB::kClassName()));
+  ASSERT_FALSE(db->IsInstanceOf(WriteCommittedTxnDB::kClassName()));
+  ASSERT_EQ(db, db->CheckedCast<TransactionDB>());
+  ASSERT_EQ(db, db->CheckedCast<PessimisticTransactionDB>());
+  ASSERT_EQ(db, db->CheckedCast<WritePreparedTxnDB>());
+  ASSERT_EQ(nullptr, db->CheckedCast<WriteCommittedTxnDB>());
+
+  DB* root_db = db->GetRootDB();
+  ASSERT_NE(root_db, nullptr);
+  ASSERT_TRUE(root_db->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_FALSE(root_db->IsInstanceOf(TransactionDB::kClassName()));
+  ASSERT_FALSE(root_db->IsInstanceOf(PessimisticTransactionDB::kClassName()));
+  ASSERT_FALSE(root_db->IsInstanceOf(WritePreparedTxnDB::kClassName()));
+  ASSERT_FALSE(root_db->IsInstanceOf(WriteCommittedTxnDB::kClassName()));
+  ASSERT_EQ(root_db, root_db->CheckedCast<DBImpl>());
+  ASSERT_EQ(nullptr, root_db->CheckedCast<TransactionDB>());
+  ASSERT_EQ(nullptr, root_db->CheckedCast<PessimisticTransactionDB>());
+  ASSERT_EQ(nullptr, root_db->CheckedCast<WritePreparedTxnDB>());
+  ASSERT_EQ(nullptr, root_db->CheckedCast<WriteCommittedTxnDB>());
+  ASSERT_EQ(root_db, db->CheckedCast<DBImpl>());
+
+  DB* base_db = db->GetBaseDB();
+  ASSERT_NE(base_db, nullptr);
+  ASSERT_TRUE(base_db->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_FALSE(base_db->IsInstanceOf(TransactionDB::kClassName()));
+  ASSERT_FALSE(base_db->IsInstanceOf(PessimisticTransactionDB::kClassName()));
+  ASSERT_FALSE(base_db->IsInstanceOf(WritePreparedTxnDB::kClassName()));
+  ASSERT_FALSE(base_db->IsInstanceOf(WriteCommittedTxnDB::kClassName()));
+  ASSERT_EQ(base_db, base_db->CheckedCast<DBImpl>());
+  ASSERT_EQ(nullptr, base_db->CheckedCast<TransactionDB>());
+  ASSERT_EQ(nullptr, base_db->CheckedCast<PessimisticTransactionDB>());
+  ASSERT_EQ(nullptr, base_db->CheckedCast<WritePreparedTxnDB>());
+  ASSERT_EQ(nullptr, base_db->CheckedCast<WriteCommittedTxnDB>());
+  ASSERT_EQ(base_db, db->CheckedCast<DBImpl>());
+}
+
+TEST_P(WritePreparedTransactionTest, CheckedCommittedCast) {
+  txn_db_options.write_policy = WRITE_COMMITTED;
+  options.unordered_write = false;
+  ASSERT_OK(ReOpen());
+  ASSERT_FALSE(db->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_TRUE(db->IsInstanceOf(TransactionDB::kClassName()));
+  ASSERT_TRUE(db->IsInstanceOf(PessimisticTransactionDB::kClassName()));
+  ASSERT_FALSE(db->IsInstanceOf(WritePreparedTxnDB::kClassName()));
+  ASSERT_TRUE(db->IsInstanceOf(WriteCommittedTxnDB::kClassName()));
+  ASSERT_EQ(db, db->CheckedCast<TransactionDB>());
+  ASSERT_EQ(db, db->CheckedCast<PessimisticTransactionDB>());
+  ASSERT_EQ(db, db->CheckedCast<WriteCommittedTxnDB>());
+  ASSERT_EQ(nullptr, db->CheckedCast<WritePreparedTxnDB>());
+
+  DB* root_db = db->GetRootDB();
+  ASSERT_NE(root_db, nullptr);
+  ASSERT_TRUE(root_db->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_FALSE(root_db->IsInstanceOf(TransactionDB::kClassName()));
+  ASSERT_FALSE(root_db->IsInstanceOf(PessimisticTransactionDB::kClassName()));
+  ASSERT_FALSE(root_db->IsInstanceOf(WritePreparedTxnDB::kClassName()));
+  ASSERT_FALSE(root_db->IsInstanceOf(WriteCommittedTxnDB::kClassName()));
+  ASSERT_EQ(root_db, root_db->CheckedCast<DBImpl>());
+  ASSERT_EQ(nullptr, root_db->CheckedCast<TransactionDB>());
+  ASSERT_EQ(nullptr, root_db->CheckedCast<PessimisticTransactionDB>());
+  ASSERT_EQ(nullptr, root_db->CheckedCast<WritePreparedTxnDB>());
+  ASSERT_EQ(nullptr, root_db->CheckedCast<WriteCommittedTxnDB>());
+  ASSERT_EQ(root_db, db->CheckedCast<DBImpl>());
+
+  DB* base_db = db->GetBaseDB();
+  ASSERT_NE(base_db, nullptr);
+  ASSERT_TRUE(base_db->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_FALSE(base_db->IsInstanceOf(TransactionDB::kClassName()));
+  ASSERT_FALSE(base_db->IsInstanceOf(PessimisticTransactionDB::kClassName()));
+  ASSERT_FALSE(base_db->IsInstanceOf(WritePreparedTxnDB::kClassName()));
+  ASSERT_FALSE(base_db->IsInstanceOf(WriteCommittedTxnDB::kClassName()));
+  ASSERT_EQ(base_db, base_db->CheckedCast<DBImpl>());
+  ASSERT_EQ(nullptr, base_db->CheckedCast<TransactionDB>());
+  ASSERT_EQ(nullptr, base_db->CheckedCast<PessimisticTransactionDB>());
+  ASSERT_EQ(nullptr, base_db->CheckedCast<WritePreparedTxnDB>());
+  ASSERT_EQ(nullptr, base_db->CheckedCast<WriteCommittedTxnDB>());
+  ASSERT_EQ(base_db, db->CheckedCast<DBImpl>());
+}
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -60,6 +60,8 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   }
 
   virtual ~WritePreparedTxnDB();
+  static const char* kClassName() { return "WritePreparedTxnDB"; }
+  const char* Name() const override { return kClassName(); }
 
   virtual Status Initialize(
       const std::vector<size_t>& compaction_enabled_cf_indices,

--- a/utilities/transactions/write_unprepared_txn_db.h
+++ b/utilities/transactions/write_unprepared_txn_db.h
@@ -17,6 +17,9 @@ class WriteUnpreparedTxnDB : public WritePreparedTxnDB {
  public:
   using WritePreparedTxnDB::WritePreparedTxnDB;
 
+  static const char* kClassName() { return "WriteUnpreparedTxnDB"; }
+  const char* Name() const override { return kClassName(); }
+
   Status Initialize(const std::vector<size_t>& compaction_enabled_cf_indices,
                     const std::vector<ColumnFamilyHandle*>& handles) override;
 

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -37,6 +37,8 @@ class DBWithTTLImpl : public DBWithTTL {
   explicit DBWithTTLImpl(DB* db);
 
   virtual ~DBWithTTLImpl();
+  static const char* kClassName() { return "DBWithTTLImpl"; }
+  const char* Name() const override { return kClassName(); }
 
   virtual Status Close() override;
 
@@ -83,7 +85,7 @@ class DBWithTTLImpl : public DBWithTTL {
   virtual Iterator* NewIterator(const ReadOptions& opts,
                                 ColumnFamilyHandle* column_family) override;
 
-  virtual DB* GetBaseDB() override { return db_; }
+  virtual DB* GetBaseDB() const override { return db_; }
 
   static bool IsStale(const Slice& value, int32_t ttl, SystemClock* clock);
 

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -725,6 +725,26 @@ TEST_F(TtlTest, DeleteRangeTest) {
   CloseTtl();
 }
 
+TEST_F(TtlTest, CheckedCast) {
+  OpenTtl();
+  ASSERT_TRUE(db_ttl_->IsInstanceOf(DBWithTTL::kClassName()));
+  ASSERT_FALSE(db_ttl_->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_EQ(db_ttl_, db_ttl_->CheckedCast<DBWithTTL>());
+
+  DB* root_db = db_ttl_->GetRootDB();
+  ASSERT_NE(root_db, nullptr);
+  ASSERT_FALSE(root_db->IsInstanceOf(DBWithTTL::kClassName()));
+  ASSERT_TRUE(root_db->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_EQ(root_db, db_ttl_->CheckedCast<DBImpl>());
+
+  DB* base_db = db_ttl_->GetBaseDB();
+  ASSERT_NE(base_db, nullptr);
+  ASSERT_FALSE(base_db->IsInstanceOf(DBWithTTL::kClassName()));
+  ASSERT_TRUE(base_db->IsInstanceOf(DBImpl::kClassName()));
+  ASSERT_EQ(root_db, base_db->CheckedCast<DBImpl>());
+  CloseTtl();
+}
+
 class DummyFilter : public CompactionFilter {
  public:
   bool Filter(int /*level*/, const Slice& /*key*/, const Slice& /*value*/,


### PR DESCRIPTION
This change adds Name, InstanceOf, and CheckedCast methods to the DB hierarchy/. These methods are based off those found in the Customizable classes already.

The static and reinterpret casts in the test code can be replaced by CheckedCast<>.  This has been done for some of the tests but not exhaustively.

Currently, these methods are only used by the tests.  If the Open APIs are unified, these methods could be used to get a specific DB type from the stack.