### PR TITLE
Disallow a combination of options

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,9 @@
 * Remove deprecated API AdvancedColumnFamilyOptions::soft_rate_limit.
 * Remove deprecated API AdvancedColumnFamilyOptions::hard_rate_limit.
 
+### Behavior Changes
+* Disallow the combination of DBOptions.use_direct_io_for_flush_and_compaction == true and DBOptions.writable_file_max_buffer_size == 0. This combination can cause WritableFileWriter::Append() to loop forever, and it does not make much sense in direct IO.
+
 ## 6.29.0 (01/21/2022)
 Note: The next release will be major release 7.0. See https://github.com/facebook/rocksdb/issues/9390 for more info.
 ### Public API change
@@ -44,9 +47,6 @@ Note: The next release will be major release 7.0. See https://github.com/faceboo
 
 ### New Features
 * Added RocksJava support for MacOS universal binary (ARM+x86)
-
-### Behavior Changes
-* Disallow the combination of DBOptions.use_direct_io_for_flush_and_compaction == true and DBOptions.writable_file_max_buffer_size == 0. This combination can cause WritableFileWriter::Append() to loop forever, and it does not make much sense in direct IO.
 
 ## 6.28.0 (2021-12-17)
 ### New Features

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,6 +45,9 @@ Note: The next release will be major release 7.0. See https://github.com/faceboo
 ### New Features
 * Added RocksJava support for MacOS universal binary (ARM+x86)
 
+### Behavior Changes
+* Disallow the combination of DBOptions.use_direct_io_for_flush_and_compaction == true and DBOptions.writable_file_max_buffer_size == 0. This combination can cause WritableFileWriter::Append() to loop forever, and it does not make much sense in direct IO.
+
 ## 6.28.0 (2021-12-17)
 ### New Features
 * Introduced 'CommitWithTimestamp' as a new tag. Currently, there is no API for user to trigger a write with this tag to the WAL. This is part of the efforts to support write-commited transactions with user-defined timestamps.

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -52,6 +52,10 @@ TEST_F(DBBasicTest, OpenWhenOpen) {
 }
 
 TEST_F(DBBasicTest, EnableDirectIOWithZeroBuf) {
+  if (!IsDirectIOSupported()) {
+    ROCKSDB_GTEST_BYPASS("Direct IO not supported");
+    return;
+  }
   Options options = GetDefaultOptions();
   options.create_if_missing = true;
   options.use_direct_io_for_flush_and_compaction = true;
@@ -62,7 +66,7 @@ TEST_F(DBBasicTest, EnableDirectIOWithZeroBuf) {
   Reopen(options);
   const std::unordered_map<std::string, std::string> new_db_opts = {
       {"writable_file_max_buffer_size", "0"}};
-  ASSERT_TRUE(dbfull()->SetDBOptions(new_db_opts).IsInvalidArgument());
+  ASSERT_TRUE(db_->SetDBOptions(new_db_opts).IsInvalidArgument());
 }
 
 TEST_F(DBBasicTest, UniqueSession) {

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -51,6 +51,20 @@ TEST_F(DBBasicTest, OpenWhenOpen) {
   delete db2;
 }
 
+TEST_F(DBBasicTest, EnableDirectIOWithZeroBuf) {
+  Options options = GetDefaultOptions();
+  options.create_if_missing = true;
+  options.use_direct_io_for_flush_and_compaction = true;
+  options.writable_file_max_buffer_size = 0;
+  ASSERT_TRUE(TryReopen(options).IsInvalidArgument());
+
+  options.writable_file_max_buffer_size = 1024;
+  Reopen(options);
+  const std::unordered_map<std::string, std::string> new_db_opts = {
+      {"writable_file_max_buffer_size", "0"}};
+  ASSERT_TRUE(dbfull()->SetDBOptions(new_db_opts).IsInvalidArgument());
+}
+
 TEST_F(DBBasicTest, UniqueSession) {
   Options options = CurrentOptions();
   std::string sid1, sid2, sid3, sid4;

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -294,6 +294,12 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
         "atomic_flush is currently incompatible with best-efforts recovery");
   }
 
+  if (db_options.use_direct_io_for_flush_and_compaction &&
+      0 == db_options.writable_file_max_buffer_size) {
+    return Status::InvalidArgument(
+        "writes in direct IO require writable_file_max_buffer_size > 0");
+  }
+
   return Status::OK();
 }
 

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -31,7 +31,7 @@ IOStatus WritableFileWriter::Create(const std::shared_ptr<FileSystem>& fs,
   if (file_opts.use_direct_writes &&
       0 == file_opts.writable_file_max_buffer_size) {
     return IOStatus::InvalidArgument(
-        "Direct write must set writable_file_max_buffer_size > 0");
+        "Direct write requires writable_file_max_buffer_size > 0");
   }
   std::unique_ptr<FSWritableFile> file;
   IOStatus io_s = fs->NewWritableFile(fname, file_opts, &file, dbg);

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -28,6 +28,11 @@ IOStatus WritableFileWriter::Create(const std::shared_ptr<FileSystem>& fs,
                                     const FileOptions& file_opts,
                                     std::unique_ptr<WritableFileWriter>* writer,
                                     IODebugContext* dbg) {
+  if (file_opts.use_direct_writes &&
+      0 == file_opts.writable_file_max_buffer_size) {
+    return IOStatus::InvalidArgument(
+        "Direct write must set writable_file_max_buffer_size > 0");
+  }
   std::unique_ptr<FSWritableFile> file;
   IOStatus io_s = fs->NewWritableFile(fname, file_opts, &file, dbg);
   if (io_s.ok()) {

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -190,6 +190,7 @@ class WritableFileWriter {
         perform_data_verification_(perform_data_verification),
         buffered_data_crc32c_checksum_(0),
         buffered_data_with_checksum_(buffered_data_with_checksum) {
+    assert(!use_direct_io() || max_buffer_size_ > 0);
     TEST_SYNC_POINT_CALLBACK("WritableFileWriter::WritableFileWriter:0",
                              reinterpret_cast<void*>(max_buffer_size_));
     buf_.Alignment(writable_file_->GetRequiredBufferAlignment());

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -157,7 +157,7 @@ public:
     }
 
     size_t new_capacity = Roundup(requested_capacity, alignment_);
-    char* new_buf = new char[new_capacity];
+    char* new_buf = new char[new_capacity + alignment_];
     char* new_bufstart = reinterpret_cast<char*>(
         (reinterpret_cast<uintptr_t>(new_buf) + (alignment_ - 1)) &
         ~static_cast<uintptr_t>(alignment_ - 1));

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -157,7 +157,7 @@ public:
     }
 
     size_t new_capacity = Roundup(requested_capacity, alignment_);
-    char* new_buf = new char[new_capacity + alignment_];
+    char* new_buf = new char[new_capacity];
     char* new_bufstart = reinterpret_cast<char*>(
         (reinterpret_cast<uintptr_t>(new_buf) + (alignment_ - 1)) &
         ~static_cast<uintptr_t>(alignment_ - 1));

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -25,7 +25,7 @@ namespace ROCKSDB_NAMESPACE {
 
 class WritableFileWriterTest : public testing::Test {};
 
-const uint32_t kMb = 1 << 20;
+constexpr uint32_t kMb = static_cast<uint32_t>(1) << 20;
 
 TEST_F(WritableFileWriterTest, RangeSync) {
   class FakeWF : public FSWritableFile {
@@ -251,7 +251,7 @@ TEST_F(DBWritableFileWriterTest, AppendWithChecksum) {
   Options options = GetDefaultOptions();
   options.create_if_missing = true;
   DestroyAndReopen(options);
-  std::string fname = this->dbname_ + "/test_file";
+  std::string fname = dbname_ + "/test_file";
   std::unique_ptr<FSWritableFile> writable_file_ptr;
   ASSERT_OK(fault_fs_->NewWritableFile(fname, file_options, &writable_file_ptr,
                                        /*dbg*/ nullptr));
@@ -291,7 +291,7 @@ TEST_F(DBWritableFileWriterTest, AppendVerifyNoChecksum) {
   Options options = GetDefaultOptions();
   options.create_if_missing = true;
   DestroyAndReopen(options);
-  std::string fname = this->dbname_ + "/test_file";
+  std::string fname = dbname_ + "/test_file";
   std::unique_ptr<FSWritableFile> writable_file_ptr;
   ASSERT_OK(fault_fs_->NewWritableFile(fname, file_options, &writable_file_ptr,
                                        /*dbg*/ nullptr));
@@ -334,7 +334,7 @@ TEST_F(DBWritableFileWriterTest, AppendWithChecksumRateLimiter) {
   Options options = GetDefaultOptions();
   options.create_if_missing = true;
   DestroyAndReopen(options);
-  std::string fname = this->dbname_ + "/test_file";
+  std::string fname = dbname_ + "/test_file";
   std::unique_ptr<FSWritableFile> writable_file_ptr;
   ASSERT_OK(fault_fs_->NewWritableFile(fname, file_options, &writable_file_ptr,
                                        /*dbg*/ nullptr));
@@ -376,7 +376,7 @@ TEST_F(DBWritableFileWriterTest, AppendWithChecksumRateLimiter) {
   FileOptions file_options1 = FileOptions();
   file_options1.rate_limiter =
       NewGenericRateLimiter(static_cast<int64_t>(0.5 * raw_rate));
-  fname = this->dbname_ + "/test_file_1";
+  fname = dbname_ + "/test_file_1";
   std::unique_ptr<FSWritableFile> writable_file_ptr1;
   ASSERT_OK(fault_fs_->NewWritableFile(fname, file_options1,
                                        &writable_file_ptr1,
@@ -857,7 +857,7 @@ TEST_F(DBWritableFileWriterTest, IOErrorNotification) {
   DestroyAndReopen(options);
   ImmutableOptions ioptions(options);
 
-  std::string fname = this->dbname_ + "/test_file";
+  std::string fname = dbname_ + "/test_file";
   std::unique_ptr<FakeWF> writable_file_ptr(new FakeWF);
 
   std::unique_ptr<WritableFileWriter> file_writer;

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -235,60 +235,6 @@ TEST_F(WritableFileWriterTest, IncrementalBuffer) {
 }
 
 TEST_F(WritableFileWriterTest, BufferWithZeroCapacityDirectIO) {
-  class FakeWF : public FSWritableFile {
-   public:
-    explicit FakeWF() = default;
-    ~FakeWF() override {}
-
-    using FSWritableFile::Append;
-    IOStatus Append(const Slice& /*data*/, const IOOptions& /*options*/,
-                    IODebugContext* /*dbg*/) override {
-      return IOStatus::OK();
-    }
-    using FSWritableFile::PositionedAppend;
-    IOStatus PositionedAppend(const Slice& /*data*/, uint64_t /*pos*/,
-                              const IOOptions& /*options*/,
-                              IODebugContext* /*dbg*/) override {
-      return IOStatus::OK();
-    }
-
-    IOStatus Truncate(uint64_t /*size*/, const IOOptions& /*options*/,
-                      IODebugContext* /*dbg*/) override {
-      return IOStatus::OK();
-    }
-    IOStatus Close(const IOOptions& /*options*/,
-                   IODebugContext* /*dbg*/) override {
-      return IOStatus::OK();
-    }
-    IOStatus Flush(const IOOptions& /*options*/,
-                   IODebugContext* /*dbg*/) override {
-      return IOStatus::OK();
-    }
-    IOStatus Sync(const IOOptions& /*options*/,
-                  IODebugContext* /*dbg*/) override {
-      return IOStatus::OK();
-    }
-    IOStatus Fsync(const IOOptions& /*options*/,
-                   IODebugContext* /*dbg*/) override {
-      return IOStatus::OK();
-    }
-    void SetIOPriority(Env::IOPriority /*pri*/) override {}
-    uint64_t GetFileSize(const IOOptions& /*options*/,
-                         IODebugContext* /*dbg*/) override {
-      return 0;
-    }
-    void GetPreallocationStatus(size_t* /*block_size*/,
-                                size_t* /*last_allocated_block*/) override {}
-    size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const override {
-      return 0;
-    }
-    IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
-      return IOStatus::OK();
-    }
-
-    bool use_direct_io() const override { return true; }
-  };
-
   EnvOptions env_opts;
   env_opts.use_direct_writes = true;
   env_opts.writable_file_max_buffer_size = 0;

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -234,6 +234,69 @@ TEST_F(WritableFileWriterTest, IncrementalBuffer) {
   }
 }
 
+TEST_F(WritableFileWriterTest, BufferWithZeroCapacityDirectIO) {
+  class FakeWF : public FSWritableFile {
+   public:
+    explicit FakeWF() = default;
+    ~FakeWF() override {}
+
+    using FSWritableFile::Append;
+    IOStatus Append(const Slice& /*data*/, const IOOptions& /*options*/,
+                    IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    using FSWritableFile::PositionedAppend;
+    IOStatus PositionedAppend(const Slice& /*data*/, uint64_t /*pos*/,
+                              const IOOptions& /*options*/,
+                              IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+
+    IOStatus Truncate(uint64_t /*size*/, const IOOptions& /*options*/,
+                      IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Close(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Flush(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Sync(const IOOptions& /*options*/,
+                  IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Fsync(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    void SetIOPriority(Env::IOPriority /*pri*/) override {}
+    uint64_t GetFileSize(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) override {
+      return 0;
+    }
+    void GetPreallocationStatus(size_t* /*block_size*/,
+                                size_t* /*last_allocated_block*/) override {}
+    size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const override {
+      return 0;
+    }
+    IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+      return IOStatus::OK();
+    }
+
+    bool use_direct_io() const override { return true; }
+  };
+
+  EnvOptions env_opts;
+  env_opts.writable_file_max_buffer_size = 0;
+  std::unique_ptr<FakeWF> wf(new FakeWF());
+  std::unique_ptr<WritableFileWriter> writer(
+      new WritableFileWriter(std::move(wf), "" /* dont care */, env_opts));
+  ASSERT_OK(writer->Append("test data"));
+}
+
 class DBWritableFileWriterTest : public DBTestBase {
  public:
   DBWritableFileWriterTest()

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -300,10 +300,6 @@ TEST_F(WritableFileWriterTest, BufferWithZeroCapacityDirectIO) {
                                    /*dbg=*/nullptr);
     ASSERT_TRUE(s.IsInvalidArgument());
   }
-  std::unique_ptr<FakeWF> wf(new FakeWF());
-  std::unique_ptr<WritableFileWriter> writer(
-      new WritableFileWriter(std::move(wf), "" /* dont care */, env_opts));
-  ASSERT_OK(writer->Append("test data"));
 }
 
 class DBWritableFileWriterTest : public DBTestBase {

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -290,7 +290,16 @@ TEST_F(WritableFileWriterTest, BufferWithZeroCapacityDirectIO) {
   };
 
   EnvOptions env_opts;
+  env_opts.use_direct_writes = true;
   env_opts.writable_file_max_buffer_size = 0;
+  {
+    std::unique_ptr<WritableFileWriter> writer;
+    const Status s =
+        WritableFileWriter::Create(FileSystem::Default(), /*fname=*/"dont_care",
+                                   FileOptions(env_opts), &writer,
+                                   /*dbg=*/nullptr);
+    ASSERT_TRUE(s.IsInvalidArgument());
+  }
   std::unique_ptr<FakeWF> wf(new FakeWF());
   std::unique_ptr<WritableFileWriter> writer(
       new WritableFileWriter(std::move(wf), "" /* dont care */, env_opts));


### PR DESCRIPTION
Disallow `immutable_db_opts.use_direct_io_for_flush_and_compaction == true` and
`mutable_db_opts.writable_file_max_buffer_size == 0`, since it causes `WritableFileWriter::Append()`
to loop forever and does not make much sense in direct IO.

This combination of options itself does not make much sense: asking RocksDB to do direct IO but not allowing
RocksDB to allocate a buffer. We should detect this false combination and warn user early, no matter whether
the application is running on a platform that supports direct IO or not. In the case of platform **not** supporting
direct IO, it's ok if the user learns about this and then finds that direct IO is not supported.

One tricky thing: the constructor of `WritableFileWriter` is being used in our unit tests, and it's impossible
to return status code from constructor. Since we do not throw, I put an assertion for now. Fortunately,
the constructor is not exposed to external applications.

Closing #7109 

Test plan:
make check