### PR TITLE
Fix LITE build (unused constant)

### DIFF
--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -20,7 +20,9 @@ namespace ROCKSDB_NAMESPACE {
 
 // TODO: move these to gflags.
 static constexpr uint32_t kInitNumC = 1000;
+#ifndef ROCKSDB_LITE
 static constexpr uint32_t kInitialCARatio = 3;
+#endif  // ROCKSDB_LITE
 static constexpr bool kDoPreload = true;
 
 std::string MultiOpsTxnsStressTest::Record::EncodePrimaryKey(uint32_t a) {


### PR DESCRIPTION
Under MacOS, the LITE build was failing with:

db_stress_tool/multi_ops_txns_stress.cc:23:27: error: unused variable 'kInitialCARatio' [-Werror,-Wunused-const-variable]
static constexpr uint32_t kInitialCARatio = 3;
                          

