### PR TITLE
Clarify Options::rate_limiter api

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -513,7 +513,7 @@ struct DBOptions {
   // Default: Env::Default()
   Env* env = Env::Default();
 
-  // Use to control write rate of flush and compaction. Flush has higher
+  // Use to control write/read rate of flush and compaction. Flush has higher
   // priority than compaction. Rate limiting is disabled if nullptr.
   // If rate limiter is enabled, bytes_per_sync is set to 1MB by default.
   // Default: nullptr


### PR DESCRIPTION
Context/Summary:
I believe we also rate-limit read using the rate limiter passed into db options, e.g, https://github.com/facebook/rocksdb/blob/6.27.fb/file/random_access_file_reader.cc#L159

Test:
Existing tests