### PR TITLE
Fix compilation error when building static_lib

### DIFF
--- a/memory/memkind_kmem_allocator.h
+++ b/memory/memkind_kmem_allocator.h
@@ -22,6 +22,7 @@ class MemkindKmemAllocator : public BaseMemoryAllocator {
 
   static bool IsSupported(std::string* msg) {
 #ifdef MEMKIND
+    (void)msg;
     return true;
 #else
     *msg = "Not compiled with MemKind";


### PR DESCRIPTION
With memkind installed, either on a non-fb machine or using `ROCKSDB_NO_FBCODE=1`.

```
ROCKSDB_NO_FBCODE=1 make static_lib
```

Compilation failed due to unused variable warning treated as error. To bypass this, we need to
disable warning-as-error, which is not ideal.

Test plan:
Repeat the above command, and rely on CI. 