### PR TITLE
Add check for using namespace

### DIFF
--- a/build_tools/check-sources.sh
+++ b/build_tools/check-sources.sh
@@ -23,6 +23,14 @@ if [ "$?" != "1" ]; then
   BAD=1
 fi
 
+git grep 'using namespace' -- ':!build_tools' ':!docs' \
+    ':!third-party/folly/folly/lang/Align.h' \
+    ':!third-party/gtest-1.8.1/fused-src/gtest/gtest.h'
+if [ "$?" != "1" ]; then
+  echo '^^^^ Do not use "using namespace"'
+  BAD=1
+fi
+
 if [ "$BAD" ]; then
   exit 1
 fi


### PR DESCRIPTION
As title.

Test plan:
manually add `using namespace` to a file, and run `make check-sources`.
Then, remove `using namespace`, and run `make check-sources`