### PR TITLE
Add to HISTORY and minor loose ends from #9294, #9254

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,12 +5,17 @@
 * Added `TraceOptions::preserve_write_order`. When enabled it  guarantees write records are traced in the same order they are logged to WAL and applied to the DB. By default it is disabled (false) to match the legacy behavior and prevent regression.
 * Made the Env class extend the Customizable class.  Implementations need to be registered with the ObjectRegistry and to implement a Name() method in order to be created via this method.
 * Add ObjectLibrary::AddFactory and ObjectLibrary::PatternEntry classes.  This method and associated class are the preferred mechanism for registering factories with the ObjectLibrary going forward.  The ObjectLibrary::Register method, which uses regular expressions and may be problematic, is deprecated and will be in a future release.
+* Changed `BlockBasedTableOptions::block_size` from `size_t` to `uint64_t`.
 
 ### Behavior Changes
 * `DB::DestroyColumnFamilyHandle()` will return Status::InvalidArgument() if called with `DB::DefaultColumnFamily()`.
+* On 32-bit platforms, mmap reads are no longer quietly disabled, just discouraged.
 
 ### Bug Fixes
 * Fix a bug that FlushMemTable may return ok even flush not succeed.
+
+### New Features
+* Added RocksJava support for MacOS universal binary (ARM+x86)
 
 ## 6.28.0 (2021-12-17)
 ### New Features

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -558,7 +558,7 @@ PosixRandomAccessFile::PosixRandomAccessFile(
 #endif
 {
   assert(!options.use_direct_reads || !options.use_mmap_reads);
-  assert(!options.use_mmap_reads || sizeof(void*) < 8);
+  assert(!options.use_mmap_reads);
 }
 
 PosixRandomAccessFile::~PosixRandomAccessFile() { close(fd_); }

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -84,7 +84,8 @@ struct EnvOptions {
   // Construct from Options
   explicit EnvOptions(const DBOptions& options);
 
-  // If true, then use mmap to read data
+  // If true, then use mmap to read data.
+  // Not recommended for 32-bit OS.
   bool use_mmap_reads = false;
 
   // If true, then use mmap to write data

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -772,7 +772,9 @@ struct DBOptions {
   // large amounts of data (such as xfs's allocsize option).
   size_t manifest_preallocation_size = 4 * 1024 * 1024;
 
-  // Allow the OS to mmap file for reading sst tables. Default: false
+  // Allow the OS to mmap file for reading sst tables.
+  // Not recommended for 32-bit OS.
+  // Default: false
   bool allow_mmap_reads = false;
 
   // Allow the OS to mmap file for writing.

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -297,9 +297,9 @@ IOStatus WinFileSystem::NewRandomAccessFile(
 
   UniqueCloseHandlePtr fileGuard(hFile, CloseHandleFunc);
 
-  // CAUTION! This will map the entire file into the process address space
-  if (options.use_mmap_reads && sizeof(void*) >= 8) {
-    // Use mmap when virtual address-space is plentiful.
+  // CAUTION! This will map the entire file into the process address space.
+  // Not recommended for 32-bit platforms.
+  if (options.use_mmap_reads) {
     uint64_t fileSize;
 
     s = GetFileSize(fname, IOOptions(), &fileSize, dbg);


### PR DESCRIPTION
Summary: Loose ends relate to mmap on 32-bit systems. (Testing is more
complicated when the feature was completely disabled on 32-bit.)

Test Plan: CI