### PR TITLE
README: De-list slack channel, list Google group

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The public interface is in `include/`.  Callers should not include or
 rely on the details of any other header files in this package.  Those
 internal APIs may be changed without warning.
 
-Design discussions are conducted in https://www.facebook.com/groups/rocksdb.dev/ and https://rocksdb.slack.com/
+Questions and discussions are welcome on the [RocksDB Developers Public](https://www.facebook.com/groups/rocksdb.dev/) Facebook group and [email list](https://groups.google.com/g/rocksdb) on Google Groups.
 
 ## License
 


### PR DESCRIPTION
Summary: We are phasing out the slack channel, but keeping the Google
Group email list.

Test Plan: no code