### PR TITLE
Fix flaky EventListenerTest.DisableBGCompaction

### DIFF
--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -159,7 +159,7 @@ Status DBImpl::TEST_AtomicFlushMemTables(
 Status DBImpl::TEST_WaitForBackgroundWork() {
   InstrumentedMutexLock l(&mutex_);
   WaitForBackgroundWork();
-  return Status::OK();
+  return error_handler_.GetBGError();
 }
 
 Status DBImpl::TEST_WaitForFlushMemTable(ColumnFamilyHandle* column_family) {

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -515,6 +515,9 @@ TEST_F(EventListenerTest, DisableBGCompaction) {
     db_->GetColumnFamilyMetaData(handles_[1], &cf_meta);
   }
   ASSERT_GE(listener->slowdown_count, kSlowdownTrigger * 9);
+  // We don't want the listener executing during DBTestBase::Close() due to
+  // race on handles_.
+  dbfull()->TEST_WaitForBackgroundWork();
 }
 
 class TestCompactionReasonListener : public EventListener {

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -517,7 +517,7 @@ TEST_F(EventListenerTest, DisableBGCompaction) {
   ASSERT_GE(listener->slowdown_count, kSlowdownTrigger * 9);
   // We don't want the listener executing during DBTestBase::Close() due to
   // race on handles_.
-  dbfull()->TEST_WaitForBackgroundWork();
+  ASSERT_OK(dbfull()->TEST_WaitForBackgroundWork());
 }
 
 class TestCompactionReasonListener : public EventListener {


### PR DESCRIPTION
Summary: Wasn't able to easily reproduce error, but easy to see a race
condition between TestFlushListener::OnFlushCompleted and
DBTestBase::Close(), which frees CF handles before closing DB.

Test Plan: CI etc.