### PR TITLE
Mark destructors as override

### DIFF
--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -40,7 +40,7 @@ class Comparator : public Customizable {
     return *this;
   }
 
-  virtual ~Comparator() {}
+  ~Comparator() override {}
 
   static Status CreateFromString(const ConfigOptions& opts,
                                  const std::string& id,

--- a/include/rocksdb/customizable.h
+++ b/include/rocksdb/customizable.h
@@ -55,7 +55,7 @@ namespace ROCKSDB_NAMESPACE {
  */
 class Customizable : public Configurable {
  public:
-  virtual ~Customizable() {}
+  ~Customizable() override {}
 
   // Returns the name of this class of Customizable
   virtual const char* Name() const = 0;

--- a/include/rocksdb/file_checksum.h
+++ b/include/rocksdb/file_checksum.h
@@ -74,7 +74,7 @@ class FileChecksumGenerator {
 // including data loss, unreported corruption, deadlocks, and more.
 class FileChecksumGenFactory : public Customizable {
  public:
-  virtual ~FileChecksumGenFactory() {}
+  ~FileChecksumGenFactory() override {}
   static const char* Type() { return "FileChecksumGenFactory"; }
   static Status CreateFromString(
       const ConfigOptions& options, const std::string& value,

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -750,7 +750,7 @@ class EventListener : public Customizable {
   // happens. ShouldBeNotifiedOnFileIO should be set to true to get a callback.
   virtual void OnIOError(const IOErrorInfo& /*info*/) {}
 
-  virtual ~EventListener() {}
+  ~EventListener() override {}
 };
 
 #else

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -294,7 +294,7 @@ class MemTableRep {
 // new MemTableRep objects
 class MemTableRepFactory : public Customizable {
  public:
-  virtual ~MemTableRepFactory() {}
+  ~MemTableRepFactory() override {}
 
   static const char* Type() { return "MemTableRepFactory"; }
   static Status CreateFromString(const ConfigOptions& config_options,

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -83,7 +83,7 @@ class SstPartitioner {
 // including data loss, unreported corruption, deadlocks, and more.
 class SstPartitionerFactory : public Customizable {
  public:
-  virtual ~SstPartitionerFactory() {}
+  ~SstPartitionerFactory() override {}
   static const char* Type() { return "SstPartitionerFactory"; }
   static Status CreateFromString(
       const ConfigOptions& options, const std::string& value,
@@ -124,7 +124,7 @@ class SstPartitionerFixedPrefixFactory : public SstPartitionerFactory {
  public:
   explicit SstPartitionerFixedPrefixFactory(size_t len);
 
-  virtual ~SstPartitionerFixedPrefixFactory() {}
+  ~SstPartitionerFixedPrefixFactory() override {}
 
   static const char* kClassName() { return "SstPartitionerFixedPrefixFactory"; }
   const char* Name() const override { return kClassName(); }

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -587,7 +587,7 @@ enum StatsLevel : uint8_t {
 // including data loss, unreported corruption, deadlocks, and more.
 class Statistics : public Customizable {
  public:
-  virtual ~Statistics() {}
+  ~Statistics() override {}
   static const char* Type() { return "Statistics"; }
   static Status CreateFromString(const ConfigOptions& opts,
                                  const std::string& value,

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -151,7 +151,7 @@ class TablePropertiesCollectorFactory : public Customizable {
     static const int kUnknownLevelAtCreation = -1;
   };
 
-  virtual ~TablePropertiesCollectorFactory() {}
+  ~TablePropertiesCollectorFactory() override {}
   static const char* Type() { return "TablePropertiesCollectorFactory"; }
   static Status CreateFromString(
       const ConfigOptions& options, const std::string& value,


### PR DESCRIPTION
Summary:
It is better practice to mark destructors as override. Without this
change there can be issues building with
-Wsuggest-destructor-override.

Differential Revision: D33671992

