### PR TITLE
Update circleci xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,8 @@ jobs:
     macos:
       xcode: 12.5.1
     resource_class: large
+    environment:
+      DISABLE_JEMALLOC: 1 # jemalloc cause env_test hang, disable it for now
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos
@@ -554,7 +556,7 @@ jobs:
     resource_class: medium
     environment:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
-      DISABLE_JEMALLOC: 1
+      DISABLE_JEMALLOC: 1 # jemalloc causes java 8 crash, maybe a known issue
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ executors:
 jobs:
   build-macos:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     resource_class: large
     steps:
       - increase-max-open-files-on-macos
@@ -174,7 +174,7 @@ jobs:
 
   build-macos-cmake:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     resource_class: large
     steps:
       - increase-max-open-files-on-macos
@@ -550,7 +550,7 @@ jobs:
 
   build-macos-java:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     resource_class: medium
     environment:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -554,6 +554,7 @@ jobs:
     resource_class: medium
     environment:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
+      DISABLE_JEMALLOC: 1
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,7 @@ jobs:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos
       - install-gflags-on-macos
+      - install-jdk8-on-macos
       - pre-steps-macos
       - run:
           name: "Set Java Environment"


### PR DESCRIPTION
Summary: xcode 11.3.1 is deprecated https://circleci.com/docs/2.0/testing-ios/ , jobs are failing:
```
failed to create host: Image xcode:11.3.0 is not supported
```

Test Plan: CI