### PR TITLE
Fast path for detecting unchanged prefix_extractor

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,9 +14,13 @@
 ### New Features
 * Added `Options::DisableExtraChecks()` that can be used to improve peak write performance by disabling checks that should not be necessary in the absence of software logic errors or CPU+memory hardware errors. (Default options are slowly moving toward some performance overheads for extra correctness checking.)
 
+### Performance Improvements
+* Improved read performance when a prefix extractor is used (Seek, Get, MultiGet), even compared to version 6.25 baseline (see bug fix below), by optimizing the common case of prefix extractor compatible with table file and unchanging.
+
 ### Bug Fixes
 * Fix a bug that FlushMemTable may return ok even flush not succeed.
 * Fixed a bug of Sync() and Fsync() not using `fcntl(F_FULLFSYNC)` on OS X and iOS.
+* Fixed a significant performance regression in version 6.26 when a prefix extractor is used on the read path (Seek, Get, MultiGet). (Excessive time was spent in SliceTransform::AsString().)
 
 ## 6.28.0 (2021-12-17)
 ### New Features

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -328,8 +328,8 @@ Status BuildTable(
       ReadOptions read_options;
       std::unique_ptr<InternalIterator> it(table_cache->NewIterator(
           read_options, file_options, tboptions.internal_comparator, *meta,
-          nullptr /* range_del_agg */,
-          mutable_cf_options.prefix_extractor.get(), nullptr,
+          nullptr /* range_del_agg */, mutable_cf_options.prefix_extractor,
+          nullptr,
           (internal_stats == nullptr) ? nullptr
                                       : internal_stats->GetFileReadHist(0),
           TableReaderCaller::kFlush, /*arena=*/nullptr,

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -790,8 +790,8 @@ Status CompactionJob::Run() {
       }
     }
     ColumnFamilyData* cfd = compact_->compaction->column_family_data();
-    auto prefix_extractor =
-        compact_->compaction->mutable_cf_options()->prefix_extractor.get();
+    auto& prefix_extractor =
+        compact_->compaction->mutable_cf_options()->prefix_extractor;
     std::atomic<size_t> next_file_idx(0);
     auto verify_table = [&](Status& output_status) {
       while (true) {

--- a/db/convenience.cc
+++ b/db/convenience.cc
@@ -59,7 +59,7 @@ Status VerifySstFileChecksum(const Options& options,
       new RandomAccessFileReader(std::move(file), file_path));
   const bool kImmortal = true;
   s = ioptions.table_factory->NewTableReader(
-      TableReaderOptions(ioptions, options.prefix_extractor.get(), env_options,
+      TableReaderOptions(ioptions, options.prefix_extractor, env_options,
                          internal_comparator, false /* skip_filters */,
                          !kImmortal, false /* force_direct_prefetch */,
                          -1 /* level */),

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -573,7 +573,7 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
 
   status = cfd_->ioptions()->table_factory->NewTableReader(
       TableReaderOptions(
-          *cfd_->ioptions(), sv->mutable_cf_options.prefix_extractor.get(),
+          *cfd_->ioptions(), sv->mutable_cf_options.prefix_extractor,
           env_options_, cfd_->internal_comparator(),
           /*skip_filters*/ false, /*immortal*/ false,
           /*force_direct_prefetch*/ false, /*level*/ -1,

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -701,7 +701,7 @@ void ForwardIterator::RebuildIterators(bool refresh_sv) {
         /*smallest_compaction_key=*/nullptr,
         /*largest_compaction_key=*/nullptr, allow_unprepared_value_));
   }
-  BuildLevelIterators(vstorage);
+  BuildLevelIterators(vstorage, sv_);
   current_ = nullptr;
   is_prev_set_ = false;
 
@@ -792,7 +792,7 @@ void ForwardIterator::RenewIterators() {
     DeleteIterator(l);
   }
   level_iters_.clear();
-  BuildLevelIterators(vstorage_new);
+  BuildLevelIterators(vstorage_new, svnew);
   current_ = nullptr;
   is_prev_set_ = false;
   SVCleanup();
@@ -806,7 +806,8 @@ void ForwardIterator::RenewIterators() {
   }
 }
 
-void ForwardIterator::BuildLevelIterators(const VersionStorageInfo* vstorage) {
+void ForwardIterator::BuildLevelIterators(const VersionStorageInfo* vstorage,
+                                          SuperVersion* sv) {
   level_iters_.reserve(vstorage->num_levels() - 1);
   for (int32_t level = 1; level < vstorage->num_levels(); ++level) {
     const auto& level_files = vstorage->LevelFiles(level);
@@ -822,7 +823,7 @@ void ForwardIterator::BuildLevelIterators(const VersionStorageInfo* vstorage) {
     } else {
       level_iters_.push_back(new ForwardLevelIterator(
           cfd_, read_options_, level_files,
-          sv_->mutable_cf_options.prefix_extractor, allow_unprepared_value_));
+          sv->mutable_cf_options.prefix_extractor, allow_unprepared_value_));
     }
   }
 }

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -97,7 +97,8 @@ class ForwardIterator : public InternalIterator {
 
   void RebuildIterators(bool refresh_sv);
   void RenewIterators();
-  void BuildLevelIterators(const VersionStorageInfo* vstorage);
+  void BuildLevelIterators(const VersionStorageInfo* vstorage,
+                           SuperVersion* sv);
   void ResetIncompleteIterators();
   void SeekInternal(const Slice& internal_key, bool seek_to_first);
   void UpdateCurrent();

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -227,7 +227,7 @@ Status ImportColumnFamilyJob::GetIngestedFileInfo(
 
   status = cfd_->ioptions()->table_factory->NewTableReader(
       TableReaderOptions(
-          *cfd_->ioptions(), sv->mutable_cf_options.prefix_extractor.get(),
+          *cfd_->ioptions(), sv->mutable_cf_options.prefix_extractor,
           env_options_, cfd_->internal_comparator(),
           /*skip_filters*/ false, /*immortal*/ false,
           /*force_direct_prefetch*/ false, /*level*/ -1,

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -368,7 +368,7 @@ class TestPlainTableFactory : public PlainTableFactory {
         table_reader_options.internal_comparator, encoding_type, file_size,
         bloom_bits_per_key_, hash_table_ratio_, index_sparseness_,
         std::move(props), std::move(file), table_reader_options.ioptions,
-        table_reader_options.prefix_extractor, expect_bloom_not_match_,
+        table_reader_options.prefix_extractor.get(), expect_bloom_not_match_,
         store_index_in_file_, column_family_id_, column_family_name_));
 
     *table = std::move(new_reader);

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -544,7 +544,7 @@ class Repairer {
       InternalIterator* iter = table_cache_->NewIterator(
           ropts, file_options_, cfd->internal_comparator(), t->meta,
           nullptr /* range_del_agg */,
-          cfd->GetLatestMutableCFOptions()->prefix_extractor.get(),
+          cfd->GetLatestMutableCFOptions()->prefix_extractor,
           /*table_reader_ptr=*/nullptr, /*file_read_hist=*/nullptr,
           TableReaderCaller::kRepair, /*arena=*/nullptr, /*skip_filters=*/false,
           /*level=*/-1, /*max_file_size_for_l0_meta_pin=*/0,

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1143,11 +1143,11 @@ class VersionBuilder::Rep {
     return s;
   }
 
-  Status LoadTableHandlers(InternalStats* internal_stats, int max_threads,
-                           bool prefetch_index_and_filter_in_cache,
-                           bool is_initial_load,
-                           const SliceTransform* prefix_extractor,
-                           size_t max_file_size_for_l0_meta_pin) {
+  Status LoadTableHandlers(
+      InternalStats* internal_stats, int max_threads,
+      bool prefetch_index_and_filter_in_cache, bool is_initial_load,
+      const std::shared_ptr<const SliceTransform>& prefix_extractor,
+      size_t max_file_size_for_l0_meta_pin) {
     assert(table_cache_ != nullptr);
 
     size_t table_cache_capacity = table_cache_->get_cache()->GetCapacity();
@@ -1272,7 +1272,7 @@ Status VersionBuilder::SaveTo(VersionStorageInfo* vstorage) const {
 Status VersionBuilder::LoadTableHandlers(
     InternalStats* internal_stats, int max_threads,
     bool prefetch_index_and_filter_in_cache, bool is_initial_load,
-    const SliceTransform* prefix_extractor,
+    const std::shared_ptr<const SliceTransform>& prefix_extractor,
     size_t max_file_size_for_l0_meta_pin) {
   return rep_->LoadTableHandlers(
       internal_stats, max_threads, prefetch_index_and_filter_in_cache,

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -39,11 +39,11 @@ class VersionBuilder {
   bool CheckConsistencyForNumLevels();
   Status Apply(const VersionEdit* edit);
   Status SaveTo(VersionStorageInfo* vstorage) const;
-  Status LoadTableHandlers(InternalStats* internal_stats, int max_threads,
-                           bool prefetch_index_and_filter_in_cache,
-                           bool is_initial_load,
-                           const SliceTransform* prefix_extractor,
-                           size_t max_file_size_for_l0_meta_pin);
+  Status LoadTableHandlers(
+      InternalStats* internal_stats, int max_threads,
+      bool prefetch_index_and_filter_in_cache, bool is_initial_load,
+      const std::shared_ptr<const SliceTransform>& prefix_extractor,
+      size_t max_file_size_for_l0_meta_pin);
   uint64_t GetMinOldestBlobFileNumber() const;
 
  private:

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -564,7 +564,7 @@ Status VersionEditHandler::LoadTables(ColumnFamilyData* cfd,
       cfd->internal_stats(),
       version_set_->db_options_->max_file_opening_threads,
       prefetch_index_and_filter_in_cache, is_initial_load,
-      cfd->GetLatestMutableCFOptions()->prefix_extractor.get(),
+      cfd->GetLatestMutableCFOptions()->prefix_extractor,
       MaxFileSizeForL0MetaPin(*cfd->GetLatestMutableCFOptions()));
   if ((s.IsPathNotFound() || s.IsCorruption()) && no_error_if_files_missing_) {
     s = Status::OK();

--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -35,10 +35,6 @@ struct ConfigOptions;
 // including data loss, unreported corruption, deadlocks, and more.
 class SliceTransform : public Customizable {
  public:
-  SliceTransform() : instance_id_(NextInstanceId()) {
-    assert(instance_id_ > 0);
-  }
-
   virtual ~SliceTransform(){};
 
   // Return the name of this transformation.
@@ -111,19 +107,6 @@ class SliceTransform : public Customizable {
   virtual bool SameResultWhenAppended(const Slice& /*prefix*/) const {
     return false;
   }
-
-  // Provides a fast way to determine whether this is the same SliceTransform
-  // as one previously seen. Guaranteed not 0 and guaranteed unique between
-  // two SliceTranforms ever created in the same process lifetime. Note that
-  // different SliceTransforms might be equivalent (compatible), which can be
-  // checked by comparing AsString().
-  inline uint64_t GetInstanceId() const { return instance_id_; }
-
- private:
-  const uint64_t instance_id_;
-
-  // Thread-safe instance id generator
-  static uint64_t NextInstanceId();
 };
 
 // The prefix is the first `prefix_len` bytes of the key, and keys shorter

--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -35,6 +35,10 @@ struct ConfigOptions;
 // including data loss, unreported corruption, deadlocks, and more.
 class SliceTransform : public Customizable {
  public:
+  SliceTransform() : instance_id_(NextInstanceId()) {
+    assert(instance_id_ > 0);
+  }
+
   virtual ~SliceTransform(){};
 
   // Return the name of this transformation.
@@ -107,6 +111,19 @@ class SliceTransform : public Customizable {
   virtual bool SameResultWhenAppended(const Slice& /*prefix*/) const {
     return false;
   }
+
+  // Provides a fast way to determine whether this is the same SliceTransform
+  // as one previously seen. Guaranteed not 0 and guaranteed unique between
+  // two SliceTranforms ever created in the same process lifetime. Note that
+  // different SliceTransforms might be equivalent (compatible), which can be
+  // checked by comparing AsString().
+  inline uint64_t GetInstanceId() const { return instance_id_; }
+
+ private:
+  const uint64_t instance_id_;
+
+  // Thread-safe instance id generator
+  static uint64_t NextInstanceId();
 };
 
 // The prefix is the first `prefix_len` bytes of the key, and keys shorter

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -91,24 +91,22 @@ class BlockBasedTable : public TableReader {
   //    are set.
   // @param force_direct_prefetch if true, always prefetching to RocksDB
   //    buffer, rather than calling RandomAccessFile::Prefetch().
-  static Status Open(const ReadOptions& ro, const ImmutableOptions& ioptions,
-                     const EnvOptions& env_options,
-                     const BlockBasedTableOptions& table_options,
-                     const InternalKeyComparator& internal_key_comparator,
-                     std::unique_ptr<RandomAccessFileReader>&& file,
-                     uint64_t file_size,
-                     std::unique_ptr<TableReader>* table_reader,
-                     const SliceTransform* prefix_extractor = nullptr,
-                     bool prefetch_index_and_filter_in_cache = true,
-                     bool skip_filters = false, int level = -1,
-                     const bool immortal_table = false,
-                     const SequenceNumber largest_seqno = 0,
-                     bool force_direct_prefetch = false,
-                     TailPrefetchStats* tail_prefetch_stats = nullptr,
-                     BlockCacheTracer* const block_cache_tracer = nullptr,
-                     size_t max_file_size_for_l0_meta_pin = 0,
-                     const std::string& cur_db_session_id = "",
-                     uint64_t cur_file_num = 0);
+  static Status Open(
+      const ReadOptions& ro, const ImmutableOptions& ioptions,
+      const EnvOptions& env_options,
+      const BlockBasedTableOptions& table_options,
+      const InternalKeyComparator& internal_key_comparator,
+      std::unique_ptr<RandomAccessFileReader>&& file, uint64_t file_size,
+      std::unique_ptr<TableReader>* table_reader,
+      const std::shared_ptr<const SliceTransform>& prefix_extractor = nullptr,
+      bool prefetch_index_and_filter_in_cache = true, bool skip_filters = false,
+      int level = -1, const bool immortal_table = false,
+      const SequenceNumber largest_seqno = 0,
+      bool force_direct_prefetch = false,
+      TailPrefetchStats* tail_prefetch_stats = nullptr,
+      BlockCacheTracer* const block_cache_tracer = nullptr,
+      size_t max_file_size_for_l0_meta_pin = 0,
+      const std::string& cur_db_session_id = "", uint64_t cur_file_num = 0);
 
   bool PrefixMayMatch(const Slice& internal_key,
                       const ReadOptions& read_options,
@@ -597,11 +595,6 @@ struct BlockBasedTable::Rep {
   // null if no prefix_extractor is passed in when opening the table reader.
   std::unique_ptr<SliceTransform> internal_prefix_transform;
   std::shared_ptr<const SliceTransform> table_prefix_extractor;
-
-  // If the prefix extractor configured at the time of table open matches the
-  // prefix extractor used to build the table file, its instance id will be
-  // recorded here for fast path checking that it hasn't changed.
-  uint64_t known_good_prefix_extractor_instance_id = 0;
 
   std::shared_ptr<const FragmentedRangeTombstoneList> fragmented_range_dels;
 

--- a/table/block_based/data_block_hash_index_test.cc
+++ b/table/block_based/data_block_hash_index_test.cc
@@ -580,7 +580,7 @@ void TestBoundary(InternalKey& ik1, std::string& v1, InternalKey& ik2,
   const bool kSkipFilters = true;
   const bool kImmortal = true;
   ASSERT_OK(ioptions.table_factory->NewTableReader(
-      TableReaderOptions(ioptions, moptions.prefix_extractor.get(), soptions,
+      TableReaderOptions(ioptions, moptions.prefix_extractor, soptions,
                          internal_comparator, !kSkipFilters, !kImmortal,
                          level_),
       std::move(file_reader), sink->contents().size(), &table_reader));

--- a/table/plain/plain_table_factory.cc
+++ b/table/plain/plain_table_factory.cc
@@ -67,7 +67,7 @@ Status PlainTableFactory::NewTableReader(
       table, table_options_.bloom_bits_per_key, table_options_.hash_table_ratio,
       table_options_.index_sparseness, table_options_.huge_page_tlb_size,
       table_options_.full_scan_mode, table_reader_options.immortal,
-      table_reader_options.prefix_extractor);
+      table_reader_options.prefix_extractor.get());
 }
 
 TableBuilder* PlainTableFactory::NewTableBuilder(

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -150,7 +150,7 @@ Status SstFileDumper::NewTableReader(
     const InternalKeyComparator& /*internal_comparator*/, uint64_t file_size,
     std::unique_ptr<TableReader>* /*table_reader*/) {
   auto t_opt =
-      TableReaderOptions(ioptions_, moptions_.prefix_extractor.get(), soptions_,
+      TableReaderOptions(ioptions_, moptions_.prefix_extractor, soptions_,
                          internal_comparator_, false /* skip_filters */,
                          false /* imortal */, true /* force_direct_prefetch */);
   // Allow open file with global sequence number for backward compatibility.

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -56,7 +56,7 @@ Status SstFileReader::Open(const std::string& file_path) {
     file_reader.reset(new RandomAccessFileReader(std::move(file), file_path));
   }
   if (s.ok()) {
-    TableReaderOptions t_opt(r->ioptions, r->moptions.prefix_extractor.get(),
+    TableReaderOptions t_opt(r->ioptions, r->moptions.prefix_extractor,
                              r->soptions, r->ioptions.internal_comparator);
     // Allow open file with global sequence number for backward compatibility.
     t_opt.largest_seqno = kMaxSequenceNumber;

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -30,16 +30,16 @@ class Status;
 
 struct TableReaderOptions {
   // @param skip_filters Disables loading/accessing the filter block
-  TableReaderOptions(const ImmutableOptions& _ioptions,
-                     const SliceTransform* _prefix_extractor,
-                     const EnvOptions& _env_options,
-                     const InternalKeyComparator& _internal_comparator,
-                     bool _skip_filters = false, bool _immortal = false,
-                     bool _force_direct_prefetch = false, int _level = -1,
-                     BlockCacheTracer* const _block_cache_tracer = nullptr,
-                     size_t _max_file_size_for_l0_meta_pin = 0,
-                     const std::string& _cur_db_session_id = "",
-                     uint64_t _cur_file_num = 0)
+  TableReaderOptions(
+      const ImmutableOptions& _ioptions,
+      const std::shared_ptr<const SliceTransform>& _prefix_extractor,
+      const EnvOptions& _env_options,
+      const InternalKeyComparator& _internal_comparator,
+      bool _skip_filters = false, bool _immortal = false,
+      bool _force_direct_prefetch = false, int _level = -1,
+      BlockCacheTracer* const _block_cache_tracer = nullptr,
+      size_t _max_file_size_for_l0_meta_pin = 0,
+      const std::string& _cur_db_session_id = "", uint64_t _cur_file_num = 0)
       : TableReaderOptions(
             _ioptions, _prefix_extractor, _env_options, _internal_comparator,
             _skip_filters, _immortal, _force_direct_prefetch, _level,
@@ -48,17 +48,16 @@ struct TableReaderOptions {
   }
 
   // @param skip_filters Disables loading/accessing the filter block
-  TableReaderOptions(const ImmutableOptions& _ioptions,
-                     const SliceTransform* _prefix_extractor,
-                     const EnvOptions& _env_options,
-                     const InternalKeyComparator& _internal_comparator,
-                     bool _skip_filters, bool _immortal,
-                     bool _force_direct_prefetch, int _level,
-                     SequenceNumber _largest_seqno,
-                     BlockCacheTracer* const _block_cache_tracer,
-                     size_t _max_file_size_for_l0_meta_pin,
-                     const std::string& _cur_db_session_id,
-                     uint64_t _cur_file_num)
+  TableReaderOptions(
+      const ImmutableOptions& _ioptions,
+      const std::shared_ptr<const SliceTransform>& _prefix_extractor,
+      const EnvOptions& _env_options,
+      const InternalKeyComparator& _internal_comparator, bool _skip_filters,
+      bool _immortal, bool _force_direct_prefetch, int _level,
+      SequenceNumber _largest_seqno,
+      BlockCacheTracer* const _block_cache_tracer,
+      size_t _max_file_size_for_l0_meta_pin,
+      const std::string& _cur_db_session_id, uint64_t _cur_file_num)
       : ioptions(_ioptions),
         prefix_extractor(_prefix_extractor),
         env_options(_env_options),
@@ -74,7 +73,7 @@ struct TableReaderOptions {
         cur_file_num(_cur_file_num) {}
 
   const ImmutableOptions& ioptions;
-  const SliceTransform* prefix_extractor;
+  const std::shared_ptr<const SliceTransform>& prefix_extractor;
   const EnvOptions& env_options;
   const InternalKeyComparator& internal_comparator;
   // This is only used for BlockBasedTable (reader)

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -143,8 +143,8 @@ void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
     std::unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(std::move(raf), file_name));
     s = opts.table_factory->NewTableReader(
-        TableReaderOptions(ioptions, moptions.prefix_extractor.get(),
-                           env_options, ikc),
+        TableReaderOptions(ioptions, moptions.prefix_extractor, env_options,
+                           ikc),
         std::move(file_reader), file_size, &table_reader);
     if (!s.ok()) {
       fprintf(stderr, "Open Table Error: %s\n", s.ToString().c_str());

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -438,7 +438,7 @@ class TableConstructor : public Constructor {
 
     file_reader_.reset(new RandomAccessFileReader(std::move(source), "test"));
     return ioptions.table_factory->NewTableReader(
-        TableReaderOptions(ioptions, moptions.prefix_extractor.get(), soptions,
+        TableReaderOptions(ioptions, moptions.prefix_extractor, soptions,
                            *last_internal_comparator_, /*skip_filters*/ false,
                            /*immortal*/ false, false, level_, largest_seqno_,
                            &block_cache_tracer_, moptions.write_buffer_size, "",
@@ -4472,8 +4472,8 @@ TEST_P(BlockBasedTableTest, DISABLED_TableWithGlobalSeqno) {
         new RandomAccessFileReader(std::move(source), ""));
 
     options.table_factory->NewTableReader(
-        TableReaderOptions(ioptions, moptions.prefix_extractor.get(),
-                           EnvOptions(), ikc),
+        TableReaderOptions(ioptions, moptions.prefix_extractor, EnvOptions(),
+                           ikc),
         std::move(file_reader), ss_rw.contents().size(), &table_reader);
 
     return table_reader->NewIterator(
@@ -4640,8 +4640,7 @@ TEST_P(BlockBasedTableTest, BlockAlignTest) {
   const MutableCFOptions moptions2(options2);
 
   ASSERT_OK(ioptions.table_factory->NewTableReader(
-      TableReaderOptions(ioptions2, moptions2.prefix_extractor.get(),
-                         EnvOptions(),
+      TableReaderOptions(ioptions2, moptions2.prefix_extractor, EnvOptions(),
                          GetPlainInternalComparator(options2.comparator)),
       std::move(file_reader), sink->contents().size(), &table_reader));
 

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -12,7 +12,6 @@
 #include <stdio.h>
 
 #include <algorithm>
-#include <atomic>
 
 #include "rocksdb/convenience.h"
 #include "rocksdb/slice_transform.h"
@@ -278,11 +277,6 @@ std::string SliceTransform::AsString() const {
 #else
   return GetId();
 #endif  // ROCKSDB_LITE
-}
-
-uint64_t SliceTransform::NextInstanceId() {
-  static std::atomic<uint64_t> next_id{1};
-  return next_id.fetch_add(1, std::memory_order_relaxed);
 }
 
 // 2 small internal utility functions, for efficient hex conversions

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -12,6 +12,7 @@
 #include <stdio.h>
 
 #include <algorithm>
+#include <atomic>
 
 #include "rocksdb/convenience.h"
 #include "rocksdb/slice_transform.h"
@@ -267,7 +268,7 @@ Status SliceTransform::CreateFromString(
     }
   }
   return status;
-}  // namespace ROCKSDB_NAMESPACE
+}
 
 std::string SliceTransform::AsString() const {
 #ifndef ROCKSDB_LITE
@@ -277,6 +278,11 @@ std::string SliceTransform::AsString() const {
 #else
   return GetId();
 #endif  // ROCKSDB_LITE
+}
+
+uint64_t SliceTransform::NextInstanceId() {
+  static std::atomic<uint64_t> last_id{1};
+  return last_id.fetch_add(1, std::memory_order_relaxed);
 }
 
 // 2 small internal utility functions, for efficient hex conversions

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -281,8 +281,8 @@ std::string SliceTransform::AsString() const {
 }
 
 uint64_t SliceTransform::NextInstanceId() {
-  static std::atomic<uint64_t> last_id{1};
-  return last_id.fetch_add(1, std::memory_order_relaxed);
+  static std::atomic<uint64_t> next_id{1};
+  return next_id.fetch_add(1, std::memory_order_relaxed);
 }
 
 // 2 small internal utility functions, for efficient hex conversions


### PR DESCRIPTION
Summary: Fixes a major performance regression in 6.26, where
extra CPU is spent in SliceTransform::AsString when reads involve
a prefix_extractor (Get, MultiGet, Seek). Common case performance
is now better than 6.25.

This change creates a "fast path" for verifying that the current prefix
extractor is unchanged and compatible with what was used to
generate a table file. This fast path detects the common case by
pointer comparison on the current prefix_extractor and a "known
good" prefix extractor (if applicable) that is saved at the time the
table reader is opened. The "known good" prefix extractor is saved
as another shared_ptr copy (in an existing field, however) to ensure
the pointer is not recycled.

When the prefix_extractor has changed to a different instance but
same compatible configuration (rare, odd), performance is still a
regression compared to 6.25, but this is likely acceptable because
of the oddity of such a case. The performance of incompatible
prefix_extractor is essentially unchanged.

Also fixed a minor case (ForwardIterator) where a prefix_extractor
could be used via a raw pointer after being freed as a shared_ptr,
if replaced via SetOptions.

Test Plan:

## Performance
Populate DB with `TEST_TMPDIR=/dev/shm/rocksdb ./db_bench -benchmarks=fillrandom -num=10000000 -disable_wal=1 -write_buffer_size=10000000 -bloom_bits=16 -compaction_style=2 -fifo_compaction_max_table_files_size_mb=10000 -fifo_compaction_allow_compaction=0 -prefix_size=12`

Running head-to-head comparisons simultaneously with `TEST_TMPDIR=/dev/shm/rocksdb ./db_bench -use_existing_db -readonly -benchmarks=seekrandom -num=10000000 -duration=20 -disable_wal=1 -bloom_bits=16 -compaction_style=2 -fifo_compaction_max_table_files_size_mb=10000 -fifo_compaction_allow_compaction=0 -prefix_size=12`

Below each is compared by ops/sec vs. baseline which is version 6.25 (multiple baseline runs because of variable machine load)

v6.26: 4833 vs. 6698 (<- major regression!)
v6.27: 4737 vs. 6397 (still)
New: 6704 vs. 6461 (better than baseline in common case)
Disabled fastpath: 4843 vs. 6389 (e.g. if prefix extractor instance changes but is still compatible)
Changed prefix size (no usable filter) in new: 787 vs. 5927
Changed prefix size (no usable filter) in new & baseline: 773 vs. 784