### PR TITLE
Remove VS2017 from Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,9 +21,6 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CMAKE_GENERATOR: Visual Studio 14 Win64
       DEV_ENV: C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\devenv.com
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      CMAKE_GENERATOR: Visual Studio 15 Win64
-      DEV_ENV: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\devenv.com
 
 install:
   - md %THIRDPARTY_HOME%


### PR DESCRIPTION
Summary:
It appears that VS2017 is covered in CircleCI so we don't need it in Appveyor. Also, currently Appveyor has some problem with installing VS2017.

Test Plan: Watch Appveyor run.