### PR TITLE
build a single binary to run all microbenches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1980,6 +1980,9 @@ ribbon_bench: $(OBJ_DIR)/microbench/ribbon_bench.o $(LIBRARY)
 db_basic_bench: $(OBJ_DIR)/microbench/db_basic_bench.o $(LIBRARY)
 	$(AM_LINK)
 
+microbench_all: $(OBJ_DIR)/microbench/microbench_all.o $(LIBRARY)
+	$(AM_LINK)
+
 cache_reservation_manager_test: $(OBJ_DIR)/cache/cache_reservation_manager_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 #-------------------------------------------------
@@ -2247,7 +2250,7 @@ rocksdbjavastaticosx_ub: rocksdbjavastaticosx_archs
 	lipo -create -output ./java/target/$(ROCKSDBJNILIB) java/target/librocksdbjni-osx-x86_64.jnilib java/target/librocksdbjni-osx-arm64.jnilib
 	$(MAKE) rocksdbjavastatic_jar
 
-rocksdbjavastaticosx_archs: 
+rocksdbjavastaticosx_archs:
 	$(MAKE) rocksdbjavastaticosx_arch_x86_64
 	$(MAKE) rocksdbjavastaticosx_arch_arm64
 

--- a/TARGETS
+++ b/TARGETS
@@ -6,6 +6,7 @@
 #
 load("@fbcode_macros//build_defs:auto_headers.bzl", "AutoHeaders")
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load(":defs.bzl", "test_binary")
 
 REPO_PATH = package_name() + "/"
@@ -818,10 +819,13 @@ cpp_library(
     os_deps = ROCKSDB_OS_DEPS,
     os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
     preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
-    exported_deps = [":rocksdb_lib"],
-    exported_external_deps = ROCKSDB_EXTERNAL_DEPS + [
-        ("googletest", None, "gtest"),
+    exported_deps = [
+        ":rocksdb_lib",
+        "fbsource//third-party/benchmark:benchmark",
+        "fbsource//third-party/gmock-global:gmock-global",
+        "fbsource//third-party/googletest:gtest",
     ],
+    exported_external_deps = ROCKSDB_EXTERNAL_DEPS,
 )
 
 cpp_library(
@@ -889,6 +893,25 @@ cpp_library(
     preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
     exported_deps = ROCKSDB_LIB_DEPS,
     exported_external_deps = ROCKSDB_EXTERNAL_DEPS,
+)
+
+cpp_binary(
+    name = "rocksdb_microbench_bin",
+    srcs = [
+        "microbench/db_basic_bench.cc",
+        "microbench/ribbon_bench.cc",
+    ],
+    arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
+    compiler_flags = ROCKSDB_COMPILER_FLAGS,
+    os_deps = ROCKSDB_OS_DEPS,
+    os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
+    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS+["-DIS_BENCH_BUILD"],
+    include_paths = ROCKSDB_INCLUDE_PATHS,
+    deps = [
+        ":rocksdb_lib",
+        ":rocksdb_test_lib",
+    ],
+    external_deps = ROCKSDB_EXTERNAL_DEPS,
 )
 
 cpp_binary(
@@ -2245,9 +2268,7 @@ ROCKS_TESTS = [
         os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
         preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
         deps = [":rocksdb_test_lib"] + extra_deps,
-        external_deps = ROCKSDB_EXTERNAL_DEPS + [
-            ("googletest", None, "gtest"),
-        ],
+        external_deps = ROCKSDB_EXTERNAL_DEPS
     )
     for test_name, test_cc, parallelism, extra_deps, extra_compiler_flags in ROCKS_TESTS
     if not is_opt_mode

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -162,10 +162,11 @@ def generate_targets(repo_path, deps_map):
         src_mk.get("TEST_LIB_SOURCES", []) +
         src_mk.get("EXP_LIB_SOURCES", []) +
         src_mk.get("ANALYZER_LIB_SOURCES", []),
-        [":rocksdb_lib"],
-        extra_external_deps=""" + [
-        ("googletest", None, "gtest"),
-    ]""")
+        [":rocksdb_lib",
+        "fbsource//third-party/benchmark:benchmark",
+        "fbsource//third-party/googletest:gtest",
+        "fbsource//third-party/gmock-global:gmock-global"]
+        )
     # rocksdb_tools_lib
     TARGETS.add_library(
         "rocksdb_tools_lib",
@@ -184,12 +185,17 @@ def generate_targets(repo_path, deps_map):
         src_mk.get("ANALYZER_LIB_SOURCES", [])
         + src_mk.get('STRESS_LIB_SOURCES', [])
         + ["test_util/testutil.cc"])
-
+    # rocksdb_microbench_bin
+    TARGETS.add_binary(
+        "rocksdb_microbench_bin",
+        src_mk.get("MICROBENCH_SOURCES", []),
+        [":rocksdb_lib", ":rocksdb_test_lib"],
+        ["-DIS_BENCH_BUILD"]
+        )
     print("Extra dependencies:\n{0}".format(json.dumps(deps_map)))
 
     # Dictionary test executable name -> relative source file path
     test_source_map = {}
-    print(src_mk)
 
     # c_test.c is added through TARGETS.add_c_test(). If there
     # are more than one .c test file, we need to extend

--- a/buckifier/targets_builder.py
+++ b/buckifier/targets_builder.py
@@ -40,7 +40,8 @@ class TARGETSBuilder(object):
         self.targets_file.close()
 
     def add_library(self, name, srcs, deps=None, headers=None,
-                    extra_external_deps="", link_whole=False):
+                    extra_external_deps="", link_whole=False,
+                     external_dependencies=None):
         headers_attr_prefix = ""
         if headers is None:
             headers_attr_prefix = "auto_"
@@ -54,10 +55,13 @@ class TARGETSBuilder(object):
             headers=headers,
             deps=pretty_list(deps),
             extra_external_deps=extra_external_deps,
-            link_whole=link_whole).encode("utf-8"))
+            link_whole=link_whole,
+            external_dependencies=pretty_list(external_dependencies)
+            ).encode("utf-8"))
         self.total_lib = self.total_lib + 1
 
-    def add_rocksdb_library(self, name, srcs, headers=None):
+    def add_rocksdb_library(self, name, srcs, headers=None,
+                            external_dependencies=None):
         headers_attr_prefix = ""
         if headers is None:
             headers_attr_prefix = "auto_"
@@ -68,14 +72,19 @@ class TARGETSBuilder(object):
             name=name,
             srcs=pretty_list(srcs),
             headers_attr_prefix=headers_attr_prefix,
-            headers=headers).encode("utf-8"))
+            headers=headers,
+            external_dependencies=pretty_list(external_dependencies)
+            ).encode("utf-8")
+            )
         self.total_lib = self.total_lib + 1
 
-    def add_binary(self, name, srcs, deps=None):
+    def add_binary(self, name, srcs, deps=None, extra_preprocessor_flags=None):
         self.targets_file.write(targets_cfg.binary_template.format(
             name=name,
             srcs=pretty_list(srcs),
-            deps=pretty_list(deps)).encode("utf-8"))
+            deps=pretty_list(deps),
+            extra_preprocessor_flags=pretty_list(extra_preprocessor_flags)
+            ).encode("utf-8"))
         self.total_bin = self.total_bin + 1
 
     def add_c_test(self):

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -13,6 +13,7 @@ rocksdb_target_header_template = \
 #
 load("@fbcode_macros//build_defs:auto_headers.bzl", "AutoHeaders")
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load(":defs.bzl", "test_binary")
 
 REPO_PATH = package_name() + "/"
@@ -186,7 +187,9 @@ cpp_binary(
     srcs = [{srcs}],
     arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
     compiler_flags = ROCKSDB_COMPILER_FLAGS,
-    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
+    os_deps = ROCKSDB_OS_DEPS,
+    os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
+    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS+[{extra_preprocessor_flags}],
     include_paths = ROCKSDB_INCLUDE_PATHS,
     deps = [{deps}],
     external_deps = ROCKSDB_EXTERNAL_DEPS,
@@ -220,9 +223,7 @@ ROCKS_TESTS = [
         os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
         preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
         deps = [":rocksdb_test_lib"] + extra_deps,
-        external_deps = ROCKSDB_EXTERNAL_DEPS + [
-            ("googletest", None, "gtest"),
-        ],
+        external_deps = ROCKSDB_EXTERNAL_DEPS
     )
     for test_name, test_cc, parallelism, extra_deps, extra_compiler_flags in ROCKS_TESTS
     if not is_opt_mode

--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -131,4 +131,9 @@ BENCHMARK(DBClose)->Iterations(200);  // specify iteration number as the db size
 
 }  // namespace ROCKSDB_NAMESPACE
 
+#ifndef BENCHMARK_MAIN_ONCE
+#ifndef IS_BENCH_BUILD
 BENCHMARK_MAIN();
+#define BENCHMARK_MAIN_ONCE
+#endif
+#endif

--- a/microbench/microbench_all.cc
+++ b/microbench/microbench_all.cc
@@ -1,0 +1,16 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+// this is a simple micro-benchmark for compare ribbon filter vs. other filter
+// for more comprehensive, please check the dedicate util/filter_bench.
+
+#include <benchmark/benchmark.h>
+#include "microbench/ribbon_bench.cc"
+#include "microbench/db_basic_bench.cc"
+
+#ifndef BENCHMARK_MAIN_ONCE
+BENCHMARK_MAIN();
+#define BENCHMARK_MAIN_ONCE
+#endif

--- a/microbench/ribbon_bench.cc
+++ b/microbench/ribbon_bench.cc
@@ -153,4 +153,9 @@ BENCHMARK(FilterQueryNegative)->Apply(CustomArguments);
 
 }  // namespace ROCKSDB_NAMESPACE
 
+#ifndef BENCHMARK_MAIN_ONCE
+#ifndef IS_BENCH_BUILD
 BENCHMARK_MAIN();
+#define BENCHMARK_MAIN_ONCE
+#endif
+#endif

--- a/src.mk
+++ b/src.mk
@@ -590,6 +590,7 @@ TEST_MAIN_SOURCES_C = \
 
 MICROBENCH_SOURCES =                                          \
   microbench/ribbon_bench.cc                                  \
+  microbench/db_basic_bench.cc                                  \
 
 JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/backupenginejni.cc                            \


### PR DESCRIPTION
Summary:
This diff adds a cpp_binary target to internal_repo_rocksdb (via buckifier) and the equivalent to make.

The following command will run the microbenchmarks:
```
buck2 run //internal_repo_rocksdb/repo:rocksdb_microbench_bin
```
ASAN detects an issue with the microbenchmarks, but I suspect the root cause is https://github.com/google/benchmark/issues/1322.

Differential Revision: D33709046

