### PR TITLE
~DBTest needs to destroy SST File Manager before Env.

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -117,6 +117,10 @@ DBTestBase::~DBTestBase() {
   } else {
     EXPECT_OK(DestroyDB(dbname_, options));
   }
+
+  // SST File manager might refernece Env, so it needs to be destoryed before
+  // Env.
+  last_options_.sst_file_manager.reset();
   delete env_;
 }
 


### PR DESCRIPTION
Summary:
Right now, Env can be destroyed before SST File manager in DBTest's destructor, causing failure during test cleaning up. Remove SST File manager first instead.
One failure I observed is a CI failure:
```
[   RUN   ]   DBSSTTest.DBWithMaxSpaceAllowedWithBlobFiles
WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=1196842)
  Write of size 8 at 0x7b5800000000 by main thread:
    #0 rocksdb::EnvWrapper::~EnvWrapper() env/env.cc:1120 (db_sst_test+0x8a9df9)
    #1 rocksdb::SpecialEnv::~SpecialEnv() db/db_test_util.h:114 (db_sst_test+0x52cdfd)
    #2 rocksdb::SpecialEnv::~SpecialEnv() db/db_test_util.h:114 (db_sst_test+0x52cdfd)
    #3 rocksdb::DBTestBase::~DBTestBase() db/db_test_util.cc:120 (db_sst_test+0x51906c)
    #4 rocksdb::DBSSTTest::~DBSSTTest() db/db_sst_test.cc:19 (db_sst_test+0x4e54b5)
    #5 rocksdb::DBSSTTest_DBWithMaxSpaceAllowedWithBlobFiles_Test::~DBSSTTest_DBWithMaxSpaceAllowedWithBlobFiles_Test() db/db_sst_test.cc:1074 (db_sst_test+0x4e54b5)
    #6 rocksdb::DBSSTTest_DBWithMaxSpaceAllowedWithBlobFiles_Test::~DBSSTTest_DBWithMaxSpaceAllowedWithBlobFiles_Test() db/db_sst_test.cc:1074 (db_sst_test+0x4e54b5)
......

  Previous read of size 8 at 0x7b5800000000 by thread T4 (mutexes: write M1359):
    #0 GetFreeSpace env/env.cc:598 (db_sst_test+0x8a29ee)
    #1 rocksdb::SstFileManagerImpl::ClearError() file/sst_file_manager_impl.cc:264 (db_sst_test+0x92cd57)
......
```
Test Plan: Run all tests.