### PR TITLE
Change some size_t in Env/FileSystem APIs to uint64_t

### DIFF
--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -294,7 +294,7 @@ class SpecialEnv : public EnvWrapper {
         return Append(data);
       }
       Status Truncate(uint64_t size) override { return base_->Truncate(size); }
-      void PrepareWrite(size_t offset, size_t len) override {
+      void PrepareWrite(uint64_t offset, size_t len) override {
         base_->PrepareWrite(offset, len);
       }
       void SetPreallocationBlockSize(size_t size) override {

--- a/env/composite_env.cc
+++ b/env/composite_env.cc
@@ -34,7 +34,7 @@ class CompositeSequentialFileWrapper : public SequentialFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  Status InvalidateCache(size_t offset, size_t length) override {
+  Status InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
   Status PositionedRead(uint64_t offset, size_t n, Slice* result,
@@ -95,7 +95,7 @@ class CompositeRandomAccessFileWrapper : public RandomAccessFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  Status InvalidateCache(size_t offset, size_t length) override {
+  Status InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
 
@@ -192,7 +192,7 @@ class CompositeWritableFileWrapper : public WritableFile {
     return target_->GetUniqueId(id, max_size);
   }
 
-  Status InvalidateCache(size_t offset, size_t length) override {
+  Status InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
 
@@ -202,7 +202,7 @@ class CompositeWritableFileWrapper : public WritableFile {
     return target_->RangeSync(offset, nbytes, io_opts, &dbg);
   }
 
-  void PrepareWrite(size_t offset, size_t len) override {
+  void PrepareWrite(uint64_t offset, size_t len) override {
     IOOptions io_opts;
     IODebugContext dbg;
     target_->PrepareWrite(offset, len, io_opts, &dbg);

--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -89,7 +89,7 @@ class CompositeEnv : public Env {
     IODebugContext dbg;
     return file_system_->DeleteFile(f, io_opts, &dbg);
   }
-  Status Truncate(const std::string& fname, size_t size) override {
+  Status Truncate(const std::string& fname, uint64_t size) override {
     IOOptions io_opts;
     IODebugContext dbg;
     return file_system_->Truncate(fname, size, io_opts, &dbg);

--- a/env/env.cc
+++ b/env/env.cc
@@ -126,7 +126,7 @@ class LegacySequentialFileWrapper : public FSSequentialFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  IOStatus InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override {
     return status_to_io_status(target_->InvalidateCache(offset, length));
   }
   IOStatus PositionedRead(uint64_t offset, size_t n,
@@ -191,7 +191,7 @@ class LegacyRandomAccessFileWrapper : public FSRandomAccessFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  IOStatus InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override {
     return status_to_io_status(target_->InvalidateCache(offset, length));
   }
 
@@ -318,7 +318,7 @@ class LegacyWritableFileWrapper : public FSWritableFile {
     return target_->GetUniqueId(id, max_size);
   }
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override {
     return status_to_io_status(target_->InvalidateCache(offset, length));
   }
 
@@ -328,7 +328,7 @@ class LegacyWritableFileWrapper : public FSWritableFile {
     return status_to_io_status(target_->RangeSync(offset, nbytes));
   }
 
-  void PrepareWrite(size_t offset, size_t len, const IOOptions& /*options*/,
+  void PrepareWrite(uint64_t offset, size_t len, const IOOptions& /*options*/,
                     IODebugContext* /*dbg*/) override {
     target_->PrepareWrite(offset, len);
   }
@@ -472,7 +472,7 @@ class LegacyFileSystemWrapper : public FileSystem {
                       IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->DeleteFile(f));
   }
-  IOStatus Truncate(const std::string& fname, size_t size,
+  IOStatus Truncate(const std::string& fname, uint64_t size,
                     const IOOptions& /*options*/,
                     IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->Truncate(fname, size));

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -92,8 +92,8 @@ size_t EncryptedSequentialFile::GetRequiredBufferAlignment() const {
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
-IOStatus EncryptedSequentialFile::InvalidateCache(size_t offset,
-                                                  size_t length) {
+IOStatus EncryptedSequentialFile::InvalidateCache(uint64_t offset,
+                                                  uint64_t length) {
   return file_->InvalidateCache(offset + prefixLength_, length);
 }
 
@@ -192,8 +192,8 @@ size_t EncryptedRandomAccessFile::GetRequiredBufferAlignment() const {
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
-IOStatus EncryptedRandomAccessFile::InvalidateCache(size_t offset,
-                                                    size_t length) {
+IOStatus EncryptedRandomAccessFile::InvalidateCache(uint64_t offset,
+                                                    uint64_t length) {
   return file_->InvalidateCache(offset + prefixLength_, length);
 }
 
@@ -295,7 +295,8 @@ IOStatus EncryptedWritableFile::Truncate(uint64_t size,
 // of this file. If the length is 0, then it refers to the end of file.
 // If the system is not caching the file contents, then this is a noop.
 // This call has no effect on dirty pages in the cache.
-IOStatus EncryptedWritableFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus EncryptedWritableFile::InvalidateCache(uint64_t offset,
+                                                uint64_t length) {
   return file_->InvalidateCache(offset + prefixLength_, length);
 }
 
@@ -316,7 +317,7 @@ IOStatus EncryptedWritableFile::RangeSync(uint64_t offset, uint64_t nbytes,
 // of space on devices where it can result in less file
 // fragmentation and/or less waste from over-zealous filesystem
 // pre-allocation.
-void EncryptedWritableFile::PrepareWrite(size_t offset, size_t len,
+void EncryptedWritableFile::PrepareWrite(uint64_t offset, size_t len,
                                          const IOOptions& options,
                                          IODebugContext* dbg) {
   file_->PrepareWrite(offset + prefixLength_, len, options, dbg);

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1900,7 +1900,7 @@ TEST_P(EnvPosixTestWithParam, WritableFileWrapper) {
       return 0;
     }
 
-    Status InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+    Status InvalidateCache(uint64_t /*offset*/, uint64_t /*length*/) override {
       inc(19);
       return Status::OK();
     }
@@ -1910,7 +1910,7 @@ TEST_P(EnvPosixTestWithParam, WritableFileWrapper) {
       return Status::OK();
     }
 
-    void PrepareWrite(size_t /*offset*/, size_t /*len*/) override { inc(21); }
+    void PrepareWrite(uint64_t /*offset*/, size_t /*len*/) override { inc(21); }
 
     Status Allocate(uint64_t /*offset*/, uint64_t /*len*/) override {
       inc(22);

--- a/env/file_system_tracer.cc
+++ b/env/file_system_tracer.cc
@@ -199,7 +199,7 @@ IOStatus FileSystemTracingWrapper::GetFileSize(const std::string& fname,
 }
 
 IOStatus FileSystemTracingWrapper::Truncate(const std::string& fname,
-                                            size_t size,
+                                            uint64_t size,
                                             const IOOptions& options,
                                             IODebugContext* dbg) {
   StopWatchNano timer(clock_);
@@ -232,8 +232,8 @@ IOStatus FSSequentialFileTracingWrapper::Read(size_t n,
   return s;
 }
 
-IOStatus FSSequentialFileTracingWrapper::InvalidateCache(size_t offset,
-                                                         size_t length) {
+IOStatus FSSequentialFileTracingWrapper::InvalidateCache(uint64_t offset,
+                                                         uint64_t length) {
   StopWatchNano timer(clock_);
   timer.Start();
   IOStatus s = target()->InvalidateCache(offset, length);
@@ -322,8 +322,8 @@ IOStatus FSRandomAccessFileTracingWrapper::Prefetch(uint64_t offset, size_t n,
   return s;
 }
 
-IOStatus FSRandomAccessFileTracingWrapper::InvalidateCache(size_t offset,
-                                                           size_t length) {
+IOStatus FSRandomAccessFileTracingWrapper::InvalidateCache(uint64_t offset,
+                                                           uint64_t length) {
   StopWatchNano timer(clock_);
   timer.Start();
   IOStatus s = target()->InvalidateCache(offset, length);
@@ -414,8 +414,8 @@ uint64_t FSWritableFileTracingWrapper::GetFileSize(const IOOptions& options,
   return file_size;
 }
 
-IOStatus FSWritableFileTracingWrapper::InvalidateCache(size_t offset,
-                                                       size_t length) {
+IOStatus FSWritableFileTracingWrapper::InvalidateCache(uint64_t offset,
+                                                       uint64_t length) {
   StopWatchNano timer(clock_);
   timer.Start();
   IOStatus s = target()->InvalidateCache(offset, length);

--- a/env/file_system_tracer.h
+++ b/env/file_system_tracer.h
@@ -84,7 +84,7 @@ class FileSystemTracingWrapper : public FileSystemWrapper {
   IOStatus GetFileSize(const std::string& fname, const IOOptions& options,
                        uint64_t* file_size, IODebugContext* dbg) override;
 
-  IOStatus Truncate(const std::string& fname, size_t size,
+  IOStatus Truncate(const std::string& fname, uint64_t size,
                     const IOOptions& options, IODebugContext* dbg) override;
 
  private:
@@ -149,7 +149,7 @@ class FSSequentialFileTracingWrapper : public FSSequentialFileOwnerWrapper {
   IOStatus Read(size_t n, const IOOptions& options, Slice* result,
                 char* scratch, IODebugContext* dbg) override;
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
   IOStatus PositionedRead(uint64_t offset, size_t n, const IOOptions& options,
                           Slice* result, char* scratch,
@@ -226,7 +226,7 @@ class FSRandomAccessFileTracingWrapper : public FSRandomAccessFileOwnerWrapper {
   IOStatus Prefetch(uint64_t offset, size_t n, const IOOptions& options,
                     IODebugContext* dbg) override;
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
  private:
   std::shared_ptr<IOTracer> io_tracer_;
@@ -314,7 +314,7 @@ class FSWritableFileTracingWrapper : public FSWritableFileOwnerWrapper {
 
   uint64_t GetFileSize(const IOOptions& options, IODebugContext* dbg) override;
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
  private:
   std::shared_ptr<IOTracer> io_tracer_;

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -300,7 +300,8 @@ IOStatus PosixSequentialFile::Skip(uint64_t n) {
   return IOStatus::OK();
 }
 
-IOStatus PosixSequentialFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus PosixSequentialFile::InvalidateCache(uint64_t offset,
+                                              uint64_t length) {
 #ifndef OS_LINUX
   (void)offset;
   (void)length;
@@ -852,7 +853,8 @@ void PosixRandomAccessFile::Hint(AccessPattern pattern) {
   }
 }
 
-IOStatus PosixRandomAccessFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus PosixRandomAccessFile::InvalidateCache(uint64_t offset,
+                                                uint64_t length) {
   if (use_direct_io()) {
     return IOStatus::OK();
   }
@@ -917,7 +919,8 @@ IOStatus PosixMmapReadableFile::Read(uint64_t offset, size_t n,
   return s;
 }
 
-IOStatus PosixMmapReadableFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus PosixMmapReadableFile::InvalidateCache(uint64_t offset,
+                                                uint64_t length) {
 #ifndef OS_LINUX
   (void)offset;
   (void)length;
@@ -1150,7 +1153,7 @@ uint64_t PosixMmapFile::GetFileSize(const IOOptions& /*opts*/,
   return file_offset_ + used;
 }
 
-IOStatus PosixMmapFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus PosixMmapFile::InvalidateCache(uint64_t offset, uint64_t length) {
 #ifndef OS_LINUX
   (void)offset;
   (void)length;
@@ -1383,7 +1386,7 @@ void PosixWritableFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint hint) {
 #endif  // OS_LINUX
 }
 
-IOStatus PosixWritableFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus PosixWritableFile::InvalidateCache(uint64_t offset, uint64_t length) {
   if (use_direct_io()) {
     return IOStatus::OK();
   }

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -142,7 +142,7 @@ class PosixSequentialFile : public FSSequentialFile {
                                   const IOOptions& opts, Slice* result,
                                   char* scratch, IODebugContext* dbg) override;
   virtual IOStatus Skip(uint64_t n) override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
+  virtual IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
   virtual bool use_direct_io() const override { return use_direct_io_; }
   virtual size_t GetRequiredBufferAlignment() const override {
     return logical_sector_size_;
@@ -205,7 +205,7 @@ class PosixRandomAccessFile : public FSRandomAccessFile {
   virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 #endif
   virtual void Hint(AccessPattern pattern) override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
+  virtual IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
   virtual bool use_direct_io() const override { return use_direct_io_; }
   virtual size_t GetRequiredBufferAlignment() const override {
     return logical_sector_size_;
@@ -264,7 +264,7 @@ class PosixWritableFile : public FSWritableFile {
   virtual void SetWriteLifeTimeHint(Env::WriteLifeTimeHint hint) override;
   virtual uint64_t GetFileSize(const IOOptions& opts,
                                IODebugContext* dbg) override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
+  virtual IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
   virtual size_t GetRequiredBufferAlignment() const override {
     return logical_sector_size_;
   }
@@ -296,7 +296,7 @@ class PosixMmapReadableFile : public FSRandomAccessFile {
   virtual IOStatus Read(uint64_t offset, size_t n, const IOOptions& opts,
                         Slice* result, char* scratch,
                         IODebugContext* dbg) const override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
+  virtual IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 };
 
 class PosixMmapFile : public FSWritableFile {
@@ -352,7 +352,7 @@ class PosixMmapFile : public FSWritableFile {
   virtual IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
   virtual uint64_t GetFileSize(const IOOptions& opts,
                                IODebugContext* dbg) override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
+  virtual IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 #ifdef ROCKSDB_FALLOCATE_PRESENT
   virtual IOStatus Allocate(uint64_t offset, uint64_t len,
                             const IOOptions& opts,

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -563,7 +563,7 @@ class TestMemLogger : public Logger {
       break;
     }
   }
-  size_t GetLogFileSize() const override { return log_size_; }
+  uint64_t GetLogFileSize() const override { return log_size_; }
 };
 
 static std::unordered_map<std::string, OptionTypeInfo> mock_fs_type_info = {
@@ -815,7 +815,7 @@ IOStatus MockFileSystem::DeleteFile(const std::string& fname,
   return IOStatus::OK();
 }
 
-IOStatus MockFileSystem::Truncate(const std::string& fname, size_t size,
+IOStatus MockFileSystem::Truncate(const std::string& fname, uint64_t size,
                                   const IOOptions& options,
                                   IODebugContext* dbg) {
   auto fn = NormalizeMockPath(fname);

--- a/env/mock_env.h
+++ b/env/mock_env.h
@@ -64,7 +64,7 @@ class MockFileSystem : public FileSystem {
                        IODebugContext* dbg) override;
   IOStatus DeleteFile(const std::string& fname, const IOOptions& options,
                       IODebugContext* dbg) override;
-  IOStatus Truncate(const std::string& fname, size_t size,
+  IOStatus Truncate(const std::string& fname, uint64_t size,
                     const IOOptions& options, IODebugContext* dbg) override;
   IOStatus CreateDir(const std::string& dirname, const IOOptions& options,
                      IODebugContext* dbg) override;

--- a/file/readahead_raf.cc
+++ b/file/readahead_raf.cc
@@ -100,7 +100,7 @@ class ReadaheadRandomAccessFile : public FSRandomAccessFile {
 
   void Hint(AccessPattern pattern) override { file_->Hint(pattern); }
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override {
     std::unique_lock<std::mutex> lk(lock_);
     buffer_.Clear();
     return file_->InvalidateCache(offset, length);

--- a/file/sequence_file_reader.cc
+++ b/file/sequence_file_reader.cc
@@ -205,7 +205,7 @@ class ReadaheadSequentialFile : public FSSequentialFile {
     return file_->PositionedRead(offset, n, opts, result, scratch, dbg);
   }
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override {
     std::unique_lock<std::mutex> lk(lock_);
     buffer_.Clear();
     return file_->InvalidateCache(offset, length);

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -51,8 +51,7 @@ IOStatus WritableFileWriter::Append(const Slice& data,
   {
     IOSTATS_TIMER_GUARD(prepare_write_nanos);
     TEST_SYNC_POINT("WritableFileWriter::Append:BeforePrepareWrite");
-    writable_file_->PrepareWrite(static_cast<size_t>(GetFileSize()), left,
-                                 IOOptions(), nullptr);
+    writable_file_->PrepareWrite(GetFileSize(), left, IOOptions(), nullptr);
   }
 
   // See whether we need to enlarge the buffer to avoid the flush

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -247,7 +247,7 @@ class WritableFileWriter {
 
   uint64_t GetFileSize() const { return filesize_; }
 
-  IOStatus InvalidateCache(size_t offset, size_t length) {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) {
     return writable_file_->InvalidateCache(offset, length);
   }
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -363,7 +363,7 @@ class Env : public Customizable {
   virtual Status DeleteFile(const std::string& fname) = 0;
 
   // Truncate the named file to the specified size.
-  virtual Status Truncate(const std::string& /*fname*/, size_t /*size*/) {
+  virtual Status Truncate(const std::string& /*fname*/, uint64_t /*size*/) {
     return Status::NotSupported("Truncate is not supported for this Env");
   }
 
@@ -725,7 +725,7 @@ class SequentialFile {
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
-  virtual Status InvalidateCache(size_t /*offset*/, size_t /*length*/) {
+  virtual Status InvalidateCache(uint64_t /*offset*/, uint64_t /*length*/) {
     return Status::NotSupported(
         "SequentialFile::InvalidateCache not supported.");
   }
@@ -842,7 +842,7 @@ class RandomAccessFile {
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
-  virtual Status InvalidateCache(size_t /*offset*/, size_t /*length*/) {
+  virtual Status InvalidateCache(uint64_t /*offset*/, uint64_t /*length*/) {
     return Status::NotSupported(
         "RandomAccessFile::InvalidateCache not supported.");
   }
@@ -1002,7 +1002,7 @@ class WritableFile {
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
   // This call has no effect on dirty pages in the cache.
-  virtual Status InvalidateCache(size_t /*offset*/, size_t /*length*/) {
+  virtual Status InvalidateCache(uint64_t /*offset*/, uint64_t /*length*/) {
     return Status::NotSupported("WritableFile::InvalidateCache not supported.");
   }
 
@@ -1024,7 +1024,7 @@ class WritableFile {
   // of space on devices where it can result in less file
   // fragmentation and/or less waste from over-zealous filesystem
   // pre-allocation.
-  virtual void PrepareWrite(size_t offset, size_t len) {
+  virtual void PrepareWrite(uint64_t offset, size_t len) {
     if (preallocation_block_size_ == 0) {
       return;
     }
@@ -1166,7 +1166,7 @@ enum InfoLogLevel : unsigned char {
 // including data loss, unreported corruption, deadlocks, and more.
 class Logger {
  public:
-  size_t kDoNotSupportGetLogFileSize = (std::numeric_limits<size_t>::max)();
+  uint64_t kDoNotSupportGetLogFileSize = (std::numeric_limits<uint64_t>::max)();
 
   explicit Logger(const InfoLogLevel log_level = InfoLogLevel::INFO_LEVEL)
       : closed_(false), log_level_(log_level) {}
@@ -1206,7 +1206,9 @@ class Logger {
   virtual void Logv(const InfoLogLevel log_level, const char* format,
                     va_list ap);
 
-  virtual size_t GetLogFileSize() const { return kDoNotSupportGetLogFileSize; }
+  virtual uint64_t GetLogFileSize() const {
+    return kDoNotSupportGetLogFileSize;
+  }
   // Flush to the OS buffers
   virtual void Flush() {}
   virtual InfoLogLevel GetInfoLogLevel() const { return log_level_; }
@@ -1453,7 +1455,7 @@ class EnvWrapper : public Env {
   Status DeleteFile(const std::string& f) override {
     return target_.env->DeleteFile(f);
   }
-  Status Truncate(const std::string& fname, size_t size) override {
+  Status Truncate(const std::string& fname, uint64_t size) override {
     return target_.env->Truncate(fname, size);
   }
   Status CreateDir(const std::string& d) override {
@@ -1651,7 +1653,7 @@ class SequentialFileWrapper : public SequentialFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  Status InvalidateCache(size_t offset, size_t length) override {
+  Status InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
   Status PositionedRead(uint64_t offset, size_t n, Slice* result,
@@ -1686,7 +1688,7 @@ class RandomAccessFileWrapper : public RandomAccessFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  Status InvalidateCache(size_t offset, size_t length) override {
+  Status InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
 
@@ -1753,7 +1755,7 @@ class WritableFileWrapper : public WritableFile {
     return target_->GetUniqueId(id, max_size);
   }
 
-  Status InvalidateCache(size_t offset, size_t length) override {
+  Status InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
 
@@ -1761,7 +1763,7 @@ class WritableFileWrapper : public WritableFile {
     return target_->RangeSync(offset, nbytes);
   }
 
-  void PrepareWrite(size_t offset, size_t len) override {
+  void PrepareWrite(uint64_t offset, size_t len) override {
     target_->PrepareWrite(offset, len);
   }
 
@@ -1825,7 +1827,7 @@ class LoggerWrapper : public Logger {
             va_list ap) override {
     return target_->Logv(log_level, format, ap);
   }
-  size_t GetLogFileSize() const override { return target_->GetLogFileSize(); }
+  uint64_t GetLogFileSize() const override { return target_->GetLogFileSize(); }
   void Flush() override { return target_->Flush(); }
   InfoLogLevel GetInfoLogLevel() const override {
     return target_->GetInfoLogLevel();

--- a/include/rocksdb/env_encryption.h
+++ b/include/rocksdb/env_encryption.h
@@ -227,7 +227,7 @@ class EncryptedSequentialFile : public FSSequentialFile {
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
   // Positioned Read for direct I/O
   // If Direct I/O enabled, offset, n, and scratch should be properly aligned
@@ -299,7 +299,7 @@ class EncryptedRandomAccessFile : public FSRandomAccessFile {
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 };
 
 // A file abstraction for sequential writing.  The implementation
@@ -357,7 +357,7 @@ class EncryptedWritableFile : public FSWritableFile {
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
   // This call has no effect on dirty pages in the cache.
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
   // Sync a file range with disk.
   // offset is the starting byte of the file range to be synchronized.
@@ -373,7 +373,7 @@ class EncryptedWritableFile : public FSWritableFile {
   // of space on devices where it can result in less file
   // fragmentation and/or less waste from over-zealous filesystem
   // pre-allocation.
-  void PrepareWrite(size_t offset, size_t len, const IOOptions& options,
+  void PrepareWrite(uint64_t offset, size_t len, const IOOptions& options,
                     IODebugContext* dbg) override;
 
   void SetPreallocationBlockSize(size_t size) override;

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -475,7 +475,7 @@ class FileSystem : public Customizable {
                               IODebugContext* dbg) = 0;
 
   // Truncate the named file to the specified size.
-  virtual IOStatus Truncate(const std::string& /*fname*/, size_t /*size*/,
+  virtual IOStatus Truncate(const std::string& /*fname*/, uint64_t /*size*/,
                             const IOOptions& /*options*/,
                             IODebugContext* /*dbg*/) {
     return IOStatus::NotSupported("Truncate is not supported for this FileSystem");
@@ -688,7 +688,7 @@ class FSSequentialFile {
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
-  virtual IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) {
+  virtual IOStatus InvalidateCache(uint64_t /*offset*/, uint64_t /*length*/) {
     return IOStatus::NotSupported("InvalidateCache not supported.");
   }
 
@@ -814,7 +814,7 @@ class FSRandomAccessFile {
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
-  virtual IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) {
+  virtual IOStatus InvalidateCache(uint64_t /*offset*/, uint64_t /*length*/) {
     return IOStatus::NotSupported("InvalidateCache not supported.");
   }
 
@@ -990,7 +990,7 @@ class FSWritableFile {
   // of this file. If the length is 0, then it refers to the end of file.
   // If the system is not caching the file contents, then this is a noop.
   // This call has no effect on dirty pages in the cache.
-  virtual IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) {
+  virtual IOStatus InvalidateCache(uint64_t /*offset*/, uint64_t /*length*/) {
     return IOStatus::NotSupported("InvalidateCache not supported.");
   }
 
@@ -1013,8 +1013,8 @@ class FSWritableFile {
   // of space on devices where it can result in less file
   // fragmentation and/or less waste from over-zealous filesystem
   // pre-allocation.
-  virtual void PrepareWrite(size_t offset, size_t len, const IOOptions& options,
-                            IODebugContext* dbg) {
+  virtual void PrepareWrite(uint64_t offset, size_t len,
+                            const IOOptions& options, IODebugContext* dbg) {
     if (preallocation_block_size_ == 0) {
       return;
     }
@@ -1267,7 +1267,7 @@ class FileSystemWrapper : public FileSystem {
                       IODebugContext* dbg) override {
     return target_->DeleteFile(f, options, dbg);
   }
-  IOStatus Truncate(const std::string& fname, size_t size,
+  IOStatus Truncate(const std::string& fname, uint64_t size,
                     const IOOptions& options, IODebugContext* dbg) override {
     return target_->Truncate(fname, size, options, dbg);
   }
@@ -1414,7 +1414,7 @@ class FSSequentialFileWrapper : public FSSequentialFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  IOStatus InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
   IOStatus PositionedRead(uint64_t offset, size_t n, const IOOptions& options,
@@ -1467,7 +1467,7 @@ class FSRandomAccessFileWrapper : public FSRandomAccessFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  IOStatus InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
 
@@ -1566,7 +1566,7 @@ class FSWritableFileWrapper : public FSWritableFile {
     return target_->GetUniqueId(id, max_size);
   }
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override {
     return target_->InvalidateCache(offset, length);
   }
 
@@ -1575,7 +1575,7 @@ class FSWritableFileWrapper : public FSWritableFile {
     return target_->RangeSync(offset, nbytes, options, dbg);
   }
 
-  void PrepareWrite(size_t offset, size_t len, const IOOptions& options,
+  void PrepareWrite(uint64_t offset, size_t len, const IOOptions& options,
                     IODebugContext* dbg) override {
     target_->PrepareWrite(offset, len, options, dbg);
   }

--- a/logging/auto_roll_logger.h
+++ b/logging/auto_roll_logger.h
@@ -44,7 +44,7 @@ class AutoRollLogger : public Logger {
     return status_;
   }
 
-  size_t GetLogFileSize() const override {
+  uint64_t GetLogFileSize() const override {
     if (!logger_) {
       return 0;
     }

--- a/logging/auto_roll_logger_test.cc
+++ b/logging/auto_roll_logger_test.cc
@@ -130,8 +130,8 @@ void AutoRollLoggerTest::RollLogFileBySizeTest(AutoRollLogger* logger,
   // measure the size of each message, which is supposed
   // to be equal or greater than log_message.size()
   LogMessage(logger, log_message.c_str());
-  size_t message_size = logger->GetLogFileSize();
-  size_t current_log_size = message_size;
+  uint64_t message_size = logger->GetLogFileSize();
+  uint64_t current_log_size = message_size;
 
   // Test the cases when the log file will not be rolled.
   while (current_log_size + message_size < log_max_size) {

--- a/logging/env_logger.h
+++ b/logging/env_logger.h
@@ -149,7 +149,7 @@ class EnvLogger : public Logger {
     }
   }
 
-  size_t GetLogFileSize() const override {
+  uint64_t GetLogFileSize() const override {
     MutexLock l(&mutex_);
     return file_.GetFileSize();
   }

--- a/logging/posix_logger.h
+++ b/logging/posix_logger.h
@@ -173,7 +173,7 @@ class PosixLogger : public Logger {
       break;
     }
   }
-  size_t GetLogFileSize() const override { return log_size_; }
+  uint64_t GetLogFileSize() const override { return log_size_; }
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -214,7 +214,7 @@ IOStatus WinFileSystem::DeleteFile(const std::string& fname,
   return result;
 }
 
-IOStatus WinFileSystem::Truncate(const std::string& fname, size_t size,
+IOStatus WinFileSystem::Truncate(const std::string& fname, uint64_t size,
                                  const IOOptions& /*options*/,
                                  IODebugContext* /*dbg*/) {
   IOStatus s;

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -122,7 +122,7 @@ class WinFileSystem : public FileSystem {
                       IODebugContext* dbg) override;
 
   // Truncate the named file to the specified size.
-  IOStatus Truncate(const std::string& /*fname*/, size_t /*size*/,
+  IOStatus Truncate(const std::string& /*fname*/, uint64_t /*size*/,
                     const IOOptions& /*options*/,
                     IODebugContext* /*dbg*/) override;
   IOStatus NewSequentialFile(const std::string& fname,

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -231,7 +231,8 @@ IOStatus WinMmapReadableFile::Read(uint64_t offset, size_t n,
   return s;
 }
 
-IOStatus WinMmapReadableFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus WinMmapReadableFile::InvalidateCache(uint64_t offset,
+                                              uint64_t length) {
   return IOStatus::OK();
 }
 
@@ -539,7 +540,7 @@ uint64_t WinMmapFile::GetFileSize(const IOOptions& /*options*/,
   return file_offset_ + used;
 }
 
-IOStatus WinMmapFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus WinMmapFile::InvalidateCache(uint64_t offset, uint64_t length) {
   return IOStatus::OK();
 }
 
@@ -662,7 +663,7 @@ IOStatus WinSequentialFile::Skip(uint64_t n) {
   return IOStatus::OK();
 }
 
-IOStatus WinSequentialFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus WinSequentialFile::InvalidateCache(uint64_t offset, uint64_t length) {
   return IOStatus::OK();
 }
 
@@ -720,7 +721,8 @@ IOStatus WinRandomAccessFile::Read(uint64_t offset, size_t n,
   return ReadImpl(offset, n, result, scratch);
 }
 
-IOStatus WinRandomAccessFile::InvalidateCache(size_t offset, size_t length) {
+IOStatus WinRandomAccessFile::InvalidateCache(uint64_t offset,
+                                              uint64_t length) {
   return IOStatus::OK();
 }
 

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -124,7 +124,7 @@ class WinSequentialFile : protected WinFileData, public FSSequentialFile {
 
   IOStatus Skip(uint64_t n) override;
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
   virtual bool use_direct_io() const override {
     return WinFileData::use_direct_io();
@@ -152,7 +152,7 @@ class WinMmapReadableFile : private WinFileData, public FSRandomAccessFile {
                 Slice* result, char* scratch,
                 IODebugContext* dbg) const override;
 
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
+  virtual IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
   virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
@@ -239,7 +239,7 @@ class WinMmapFile : private WinFileData, public FSWritableFile {
    */
   uint64_t GetFileSize(const IOOptions& options, IODebugContext* dbg) override;
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
   IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& options,
                     IODebugContext* dbg) override;
@@ -294,7 +294,7 @@ class WinRandomAccessFile
     return WinFileData::use_direct_io();
   }
 
-  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(uint64_t offset, uint64_t length) override;
 
   virtual size_t GetRequiredBufferAlignment() const override;
 };

--- a/port/win/win_logger.cc
+++ b/port/win/win_logger.cc
@@ -185,8 +185,7 @@ void WinLogger::Logv(const char* format, va_list ap) {
   }
 }
 
-size_t WinLogger::GetLogFileSize() const { return log_size_; }
-
+uint64_t WinLogger::GetLogFileSize() const { return log_size_; }
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/port/win/win_logger.h
+++ b/port/win/win_logger.h
@@ -40,7 +40,7 @@ class WinLogger : public ROCKSDB_NAMESPACE::Logger {
   using ROCKSDB_NAMESPACE::Logger::Logv;
   void Logv(const char* format, va_list ap) override;
 
-  size_t GetLogFileSize() const override;
+  uint64_t GetLogFileSize() const override;
 
   void DebugWriter(const char* str, int len);
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1449,8 +1449,7 @@ Status BlockBasedTableBuilder::InsertBlockInCompressedCache(
       RecordTick(rep_->ioptions.stats, BLOCK_CACHE_COMPRESSED_ADD_FAILURES);
     }
     // Invalidate OS cache.
-    r->file->InvalidateCache(static_cast<size_t>(r->get_offset()), size)
-        .PermitUncheckedError();
+    r->file->InvalidateCache(r->get_offset(), size).PermitUncheckedError();
   }
   return s;
 }

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -339,7 +339,7 @@ class NullLogger : public Logger {
  public:
   using Logger::Logv;
   virtual void Logv(const char* /*format*/, va_list /*ap*/) override {}
-  virtual size_t GetLogFileSize() const override { return 0; }
+  virtual uint64_t GetLogFileSize() const override { return 0; }
 };
 
 // Corrupts key by changing the type

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6455,9 +6455,7 @@ class Benchmark {
 
       // Pick a Iterator to use
       size_t db_idx_to_use =
-          (db_.db == nullptr)
-              ? (size_t{thread->rand.Next()} % multi_dbs_.size())
-              : 0;
+          (db_.db == nullptr) ? thread->rand.Next() % multi_dbs_.size() : 0;
       std::unique_ptr<Iterator> single_iter;
       Iterator* iter_to_use;
       if (FLAGS_use_tailing_iterator) {

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -73,7 +73,8 @@ TEST_F(WritableFileWriterTest, RangeSync) {
     size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const override {
       return 0;
     }
-    IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+    IOStatus InvalidateCache(uint64_t /*offset*/,
+                             uint64_t /*length*/) override {
       return IOStatus::OK();
     }
 
@@ -186,7 +187,8 @@ TEST_F(WritableFileWriterTest, IncrementalBuffer) {
     size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const override {
       return 0;
     }
-    IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+    IOStatus InvalidateCache(uint64_t /*offset*/,
+                             uint64_t /*length*/) override {
       return IOStatus::OK();
     }
     bool use_direct_io() const override { return use_direct_io_; }

--- a/utilities/env_mirror.cc
+++ b/utilities/env_mirror.cc
@@ -55,7 +55,7 @@ class SequentialFileMirror : public SequentialFile {
     assert(as == bs);
     return as;
   }
-  Status InvalidateCache(size_t offset, size_t length) override {
+  Status InvalidateCache(uint64_t offset, uint64_t length) override {
     Status as = a_->InvalidateCache(offset, length);
     Status bs = b_->InvalidateCache(offset, length);
     assert(as == bs);
@@ -183,7 +183,7 @@ class WritableFileMirror : public WritableFile {
     // NOTE: we don't verify this one
     return a_->GetUniqueId(id, max_size);
   }
-  Status InvalidateCache(size_t offset, size_t length) override {
+  Status InvalidateCache(uint64_t offset, uint64_t length) override {
     Status as = a_->InvalidateCache(offset, length);
     Status bs = b_->InvalidateCache(offset, length);
     assert(as == bs);


### PR DESCRIPTION
Summary: Update some public APIs to use uint64_t for file sizes and
offsets where size_t was used before. (This doesn't work for >4GB files
on 32-bit systems.)

Test Plan: Run 32-bit build & test locally (pre-existing test failures,
so mostly relying on build) because 64-bit linux build considers size_t
and uint64_t compatible for overrides.