### PR TITLE
Remove deprecated API AdvancedColumnFamilyOptions::rate_limit_delay_max_milliseconds

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 * Remove deprecated option DBOptions::skip_log_error_on_recovery.
 * Remove ReadOptions::iter_start_seqnum which has been deprecated.
 * Remove DBOptions::preserved_deletes and DB::SetPreserveDeletesSequenceNumber().
+* Remove deprecated API AdvancedColumnFamilyOptions::rate_limit_delay_max_milliseconds.
 
 ### Behavior Changes
 * Disallow the combination of DBOptions.use_direct_io_for_flush_and_compaction == true and DBOptions.writable_file_max_buffer_size == 0. This combination can cause WritableFileWriter::Append() to loop forever, and it does not make much sense in direct IO.

--- a/db/c.cc
+++ b/db/c.cc
@@ -3274,16 +3274,6 @@ size_t rocksdb_options_get_hard_pending_compaction_bytes_limit(
   return opt->rep.hard_pending_compaction_bytes_limit;
 }
 
-void rocksdb_options_set_rate_limit_delay_max_milliseconds(
-    rocksdb_options_t* opt, unsigned int v) {
-  opt->rep.rate_limit_delay_max_milliseconds = v;
-}
-
-unsigned int rocksdb_options_get_rate_limit_delay_max_milliseconds(
-    rocksdb_options_t* opt) {
-  return opt->rep.rate_limit_delay_max_milliseconds;
-}
-
 void rocksdb_options_set_max_manifest_file_size(
     rocksdb_options_t* opt, size_t v) {
   opt->rep.max_manifest_file_size = v;

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1635,10 +1635,6 @@ int main(int argc, char** argv) {
     CheckCondition(11 ==
                    rocksdb_options_get_hard_pending_compaction_bytes_limit(o));
 
-    rocksdb_options_set_rate_limit_delay_max_milliseconds(o, 1);
-    CheckCondition(1 ==
-                   rocksdb_options_get_rate_limit_delay_max_milliseconds(o));
-
     rocksdb_options_set_max_manifest_file_size(o, 12);
     CheckCondition(12 == rocksdb_options_get_max_manifest_file_size(o));
 
@@ -1847,8 +1843,6 @@ int main(int argc, char** argv) {
         10 == rocksdb_options_get_soft_pending_compaction_bytes_limit(copy));
     CheckCondition(
         11 == rocksdb_options_get_hard_pending_compaction_bytes_limit(copy));
-    CheckCondition(1 ==
-                   rocksdb_options_get_rate_limit_delay_max_milliseconds(copy));
     CheckCondition(12 == rocksdb_options_get_max_manifest_file_size(copy));
     CheckCondition(13 == rocksdb_options_get_table_cache_numshardbits(copy));
     CheckCondition(14 == rocksdb_options_get_arena_block_size(copy));
@@ -2073,12 +2067,6 @@ int main(int argc, char** argv) {
         111 == rocksdb_options_get_hard_pending_compaction_bytes_limit(copy));
     CheckCondition(11 ==
                    rocksdb_options_get_hard_pending_compaction_bytes_limit(o));
-
-    rocksdb_options_set_rate_limit_delay_max_milliseconds(copy, 0);
-    CheckCondition(0 ==
-                   rocksdb_options_get_rate_limit_delay_max_milliseconds(copy));
-    CheckCondition(1 ==
-                   rocksdb_options_get_rate_limit_delay_max_milliseconds(o));
 
     rocksdb_options_set_max_manifest_file_size(copy, 112);
     CheckCondition(112 == rocksdb_options_get_max_manifest_file_size(copy));

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -921,9 +921,6 @@ struct AdvancedColumnFamilyOptions {
   // NOT SUPPORTED ANYMORE
   // This does not do anything anymore.
   int max_mem_compaction_level;
-
-  // NOT SUPPORTED ANYMORE -- this options is no longer used
-  unsigned int rate_limit_delay_max_milliseconds = 100;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1198,11 +1198,6 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_hard_pending_compaction_byte
     rocksdb_options_t* opt, size_t v);
 extern ROCKSDB_LIBRARY_API size_t
 rocksdb_options_get_hard_pending_compaction_bytes_limit(rocksdb_options_t* opt);
-extern ROCKSDB_LIBRARY_API void
-rocksdb_options_set_rate_limit_delay_max_milliseconds(rocksdb_options_t*,
-                                                      unsigned int);
-extern ROCKSDB_LIBRARY_API unsigned int
-rocksdb_options_get_rate_limit_delay_max_milliseconds(rocksdb_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_manifest_file_size(
     rocksdb_options_t*, size_t);
 extern ROCKSDB_LIBRARY_API size_t

--- a/java/benchmark/src/main/java/org/rocksdb/benchmark/DbBenchmark.java
+++ b/java/benchmark/src/main/java/org/rocksdb/benchmark/DbBenchmark.java
@@ -1350,13 +1350,6 @@ public class DbBenchmark {
         return Integer.parseInt(value);
       }
     },
-    rate_limit_delay_max_milliseconds(1000,
-        "When hard_rate_limit is set then this is the max time a put will\n" +
-        "\tbe stalled.") {
-      @Override public Object parseValue(String value) {
-        return Integer.parseInt(value);
-      }
-    },
     max_compaction_bytes(0L, "Limit number of bytes in one compaction to be lower than this\n" +
             "\threshold. But it's not guaranteed.") {
       @Override public Object parseValue(String value) {

--- a/options/options.cc
+++ b/options/options.cc
@@ -277,8 +277,6 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     ROCKS_LOG_HEADER(log,
                      "  Options.hard_pending_compaction_bytes_limit: %" PRIu64,
                      hard_pending_compaction_bytes_limit);
-    ROCKS_LOG_HEADER(log, "      Options.rate_limit_delay_max_milliseconds: %u",
-                     rate_limit_delay_max_milliseconds);
     ROCKS_LOG_HEADER(log, "               Options.disable_auto_compactions: %d",
                      disable_auto_compactions);
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -436,7 +436,6 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
 
   // Following options are not settable through
   // GetColumnFamilyOptionsFromString():
-  options->rate_limit_delay_max_milliseconds = 33;
   options->compaction_options_universal = CompactionOptionsUniversal();
   options->num_levels = 42;  // Initialize options for MutableCF
   options->max_mem_compaction_level = 0;

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -2243,6 +2243,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
       {"max_compaction_bytes", "21"},
       {"soft_rate_limit", "1.1"},
       {"hard_rate_limit", "2.1"},
+      {"rate_limit_delay_max_milliseconds", "100"},
       {"hard_pending_compaction_bytes_limit", "211"},
       {"arena_block_size", "22"},
       {"disable_auto_compactions", "true"},

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -449,9 +449,6 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, DBOptions& db_options,
   cf_opt->blob_file_size = uint_max + rnd->Uniform(10000);
   cf_opt->blob_compaction_readahead_size = uint_max + rnd->Uniform(10000);
 
-  // unsigned int options
-  cf_opt->rate_limit_delay_max_milliseconds = rnd->Uniform(10000);
-
   // pointer typed options
   cf_opt->prefix_extractor.reset(RandomSliceTransform(rnd));
   cf_opt->table_factory.reset(RandomTableFactory(rnd));

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -140,7 +140,6 @@ const_params="
   --pin_l0_filter_and_index_blocks_in_cache=1 \
   --benchmark_write_rate_limit=$(( 1024 * 1024 * $mb_written_per_sec )) \
   \
-  --rate_limit_delay_max_milliseconds=1000000 \
   --write_buffer_size=$((128 * M)) \
   --target_file_size_base=$((128 * M)) \
   --max_bytes_for_level_base=$((1 * G)) \

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1245,10 +1245,6 @@ DEFINE_uint64(write_thread_slow_yield_usec, 3,
               "The threshold at which a slow yield is considered a signal that "
               "other processes or threads want the core.");
 
-DEFINE_int32(rate_limit_delay_max_milliseconds, 1000,
-             "When hard_rate_limit is set then this is the max time a put will"
-             " be stalled.");
-
 DEFINE_uint64(rate_limiter_bytes_per_sec, 0, "Set options.rate_limiter value.");
 
 DEFINE_int64(rate_limiter_refill_period_us, 100 * 1000,
@@ -4286,8 +4282,6 @@ class Benchmark {
     options.unordered_write = FLAGS_unordered_write;
     options.write_thread_max_yield_usec = FLAGS_write_thread_max_yield_usec;
     options.write_thread_slow_yield_usec = FLAGS_write_thread_slow_yield_usec;
-    options.rate_limit_delay_max_milliseconds =
-      FLAGS_rate_limit_delay_max_milliseconds;
     options.table_cache_numshardbits = FLAGS_table_cache_numshardbits;
     options.max_compaction_bytes = FLAGS_max_compaction_bytes;
     options.disable_auto_compactions = FLAGS_disable_auto_compactions;


### PR DESCRIPTION
**Context/Summary:**
AdvancedColumnFamilyOptions::rate_limit_delay_max_milliseconds has been marked as deprecated and it's time to actually remove the code.
- Keep `soft_rate_limit`/`hard_rate_limit` in `cf_mutable_options_type_info` to prevent throwing `InvalidArgument` in `GetColumnFamilyOptionsFromMap` when reading an option file still with these options (e.g, old option file generated from RocksDB before the deprecation)
- Keep `soft_rate_limit`/`hard_rate_limit` in under `OptionsOldApiTest.GetOptionsFromMapTest` to test the case mentioned above.
**Test:**
Rely on my eyeball and CI