### PR TITLE
Use == operator for shared_ptr nullptr comparison

### DIFF
--- a/include/rocksdb/utilities/object_registry.h
+++ b/include/rocksdb/utilities/object_registry.h
@@ -531,10 +531,10 @@ class ObjectRegistry {
         }
       }
     }
-    if (parent_ != nullptr) {
-      return parent_->FindFactory<T>(name);
-    } else {
+    if (parent_ == nullptr) {
       return nullptr;
+    } else {
+      return parent_->FindFactory<T>(name);
     }
   }
 


### PR DESCRIPTION
From C++ 20 onwards, the != operator is not supported for a shared_ptr.
So switch to using ==.

Test Plan:
make check