### PR TITLE
db_stress begin tracking expected state after verification

### DIFF
--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -61,7 +61,6 @@ bool RunStressTest(StressTest* stress) {
   stress->InitDb();
   SharedState shared(db_stress_env, stress);
   stress->FinishInitDb(&shared);
-  stress->SyncExpectedStateWithDb(&shared);
 
 #ifndef NDEBUG
   if (FLAGS_sync_fault_injection) {

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -61,6 +61,7 @@ bool RunStressTest(StressTest* stress) {
   stress->InitDb();
   SharedState shared(db_stress_env, stress);
   stress->FinishInitDb(&shared);
+  stress->SyncExpectedStateWithDb(&shared);
 
 #ifndef NDEBUG
   if (FLAGS_sync_fault_injection) {
@@ -111,6 +112,10 @@ bool RunStressTest(StressTest* stress) {
         fprintf(stdout, "Crash-recovery verification passed :)\n");
       }
     }
+
+    // This is after the verification step to avoid making all those `Get()`s
+    // and `MultiGet()`s contend on the DB-wide trace mutex.
+    stress->TrackExpectedState(&shared);
 
     now = clock->NowMicros();
     fprintf(stdout, "%s Starting database operations\n",

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -297,21 +297,6 @@ void StressTest::FinishInitDb(SharedState* shared) {
     PreloadDbAndReopenAsReadOnly(FLAGS_max_key, shared);
   }
 
-  if (FLAGS_enable_compaction_filter) {
-    auto* compaction_filter_factory =
-        reinterpret_cast<DbStressCompactionFilterFactory*>(
-            options_.compaction_filter_factory.get());
-    assert(compaction_filter_factory);
-    // This must be called only after any potential `SharedState::Restore()` has
-    // completed in order for the `compaction_filter_factory` to operate on the
-    // correct latest values file.
-    compaction_filter_factory->SetSharedState(shared);
-    fprintf(stdout, "Compaction filter factory: %s\n",
-            compaction_filter_factory->Name());
-  }
-}
-
-void StressTest::SyncExpectedStateWithDb(SharedState* shared) {
   if (shared->HasHistory()) {
     // The way it works right now is, if there's any history, that means the
     // previous run mutating the DB had all its operations traced, in which case
@@ -323,6 +308,19 @@ void StressTest::SyncExpectedStateWithDb(SharedState* shared) {
               s.ToString().c_str());
       exit(1);
     }
+  }
+
+  if (FLAGS_enable_compaction_filter) {
+    auto* compaction_filter_factory =
+        reinterpret_cast<DbStressCompactionFilterFactory*>(
+            options_.compaction_filter_factory.get());
+    assert(compaction_filter_factory);
+    // This must be called only after any potential `SharedState::Restore()` has
+    // completed in order for the `compaction_filter_factory` to operate on the
+    // correct latest values file.
+    compaction_filter_factory->SetSharedState(shared);
+    fprintf(stdout, "Compaction filter factory: %s\n",
+            compaction_filter_factory->Name());
   }
 }
 

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -34,6 +34,10 @@ class StressTest {
   // dependency with `SharedState`.
   virtual void FinishInitDb(SharedState*);
 
+  void SyncExpectedStateWithDb(SharedState* shared);
+
+  void TrackExpectedState(SharedState* shared);
+
   // Return false if verification fails.
   bool VerifySecondaries();
 

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -34,8 +34,6 @@ class StressTest {
   // dependency with `SharedState`.
   virtual void FinishInitDb(SharedState*);
 
-  void SyncExpectedStateWithDb(SharedState* shared);
-
   void TrackExpectedState(SharedState* shared);
 
   // Return false if verification fails.


### PR DESCRIPTION
Previously we enabled tracking expected state changes during
`FinishInitDb()`, as soon as the DB was opened. This meant tracing was
enabled during the `VerifyDb()` in the setup phase (pre-`OperateDb()`). This cost extra CPU by requiring
`DBImpl::trace_mutex_` to be acquired on each read operation. It was
unnecessary since we know there are no expected state changes during the
setup phase. So, this PR delays tracking expected state changes
until the end of the setup phase.

Test Plan:

Measured this PR reduced the `VerifyDb()` time in the setup phase 76% (387 -> 92 seconds) with
`-disable_wal=1` (i.e., expected state tracking enabled).

- benchmark command: `./db_stress -max_key=100000000 -ops_per_thread=1 -destroy_db_initially=1 -expected_values_dir=/dev/shm/dbstress_expected/ -db=/dev/shm/dbstress/ --clear_column_family_one_in=0 --disable_wal=1 --reopen=0`
- without this PR, `VerifyDb()` in the setup phase takes 387 seconds:

```
2022/01/30-21:43:04  Initializing worker threads
Crash-recovery verification passed :)
2022/01/30-21:49:31  Starting database operations
```

- with this PR, `VerifyDb()` in the setup phase takes 92 seconds

```
2022/01/30-21:59:06  Initializing worker threads
Crash-recovery verification passed :)
2022/01/30-22:00:38  Starting database operations
```