### PR TITLE
Remove default implementation of Name() from FileSystemWrapper

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,7 @@
 * Remove DBOptions::preserved_deletes and DB::SetPreserveDeletesSequenceNumber().
 * Remove deprecated API AdvancedColumnFamilyOptions::rate_limit_delay_max_milliseconds.
 * Removed timestamp from WriteOptions. Accordingly, added to DB APIs Put, Delete, SingleDelete, etc. accepting an additional argument 'timestamp'. Added Put, Delete, SingleDelete, etc to WriteBatch accepting an additional argument 'timestamp'. Removed WriteBatch::AssignTimestamps(vector<Slice>) API. Renamed WriteBatch::AssignTimestamp() to WriteBatch::UpdateTimestamps() with clarified comments.
+* Remove default implementation of Name() from FileSystemWrapper.
 
 ### Behavior Changes
 * Disallow the combination of DBOptions.use_direct_io_for_flush_and_compaction == true and DBOptions.writable_file_max_buffer_size == 0. This combination can cause WritableFileWriter::Append() to loop forever, and it does not make much sense in direct IO.

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1193,10 +1193,6 @@ class FileSystemWrapper : public FileSystem {
   explicit FileSystemWrapper(const std::shared_ptr<FileSystem>& t);
   ~FileSystemWrapper() override {}
 
-  // Deprecated. Will be removed in a major release. Derived classes
-  // should implement this method.
-  const char* Name() const override { return target_->Name(); }
-
   // Return the target to which this Env forwards all calls
   FileSystem* target() const { return target_.get(); }
 


### PR DESCRIPTION
Remove default implementation of Name(), which is an abstract method
inherited from Customizable, from FileSystemWrapper.