### PR TITLE
remove unused instance variable in GenericRateLimiter

### DIFF
--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -156,7 +156,6 @@ class GenericRateLimiter : public RateLimiter {
   bool wait_until_refill_pending_;
 
   int64_t num_drains_;
-  int64_t prev_num_drains_;
   std::chrono::microseconds tuned_time_;
 };
 


### PR DESCRIPTION
As reported in
https://github.com/facebook/rocksdb/pull/2899#issuecomment-1001467021,
`prev_num_drains_` is confusing as we never set it to nonzero. So this
PR removes it.

Test Plan: `make check -j24`