### PR TITLE
Fix spelling in public API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,7 @@
 * Remove deprecated API AdvancedColumnFamilyOptions::rate_limit_delay_max_milliseconds.
 * Removed timestamp from WriteOptions. Accordingly, added to DB APIs Put, Delete, SingleDelete, etc. accepting an additional argument 'timestamp'. Added Put, Delete, SingleDelete, etc to WriteBatch accepting an additional argument 'timestamp'. Removed WriteBatch::AssignTimestamps(vector<Slice>) API. Renamed WriteBatch::AssignTimestamp() to WriteBatch::UpdateTimestamps() with clarified comments.
 * Remove default implementation of Name() from FileSystemWrapper.
+* Rename `SizeApproximationOptions.include_memtabtles` to `SizeApproximationOptions.include_memtables`.
 
 ### Behavior Changes
 * Disallow the combination of DBOptions.use_direct_io_for_flush_and_compaction == true and DBOptions.writable_file_max_buffer_size == 0. This combination can cause WritableFileWriter::Append() to loop forever, and it does not make much sense in direct IO.

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3592,7 +3592,7 @@ void DBImpl::GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
 Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
                                    ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes) {
-  if (!options.include_memtabtles && !options.include_files) {
+  if (!options.include_memtables && !options.include_files) {
     return Status::InvalidArgument("Invalid options");
   }
 
@@ -3630,7 +3630,7 @@ Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
           options, v, k1.Encode(), k2.Encode(), /*start_level=*/0,
           /*end_level=*/-1, TableReaderCaller::kUserApproximateSize);
     }
-    if (options.include_memtabtles) {
+    if (options.include_memtables) {
       sizes[i] += sv->mem->ApproximateStats(k1.Encode(), k2.Encode()).size;
       sizes[i] += sv->imm->ApproximateStats(k1.Encode(), k2.Encode()).size;
     }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1450,7 +1450,7 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   std::string end = Key(60);
   Range r(start, end);
   SizeApproximationOptions size_approx_options;
-  size_approx_options.include_memtabtles = true;
+  size_approx_options.include_memtables = true;
   size_approx_options.include_files = true;
   ASSERT_OK(
       db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
@@ -1551,8 +1551,8 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   ASSERT_GT(size_with_mt, size_without_mt);
   ASSERT_GT(size_without_mt, 6000);
 
-  // Check that include_memtabtles flag works as expected
-  size_approx_options.include_memtabtles = false;
+  // Check that include_memtables flag works as expected
+  size_approx_options.include_memtables = false;
   ASSERT_OK(
       db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
   ASSERT_EQ(size, size_without_mt);
@@ -1614,7 +1614,7 @@ TEST_F(DBTest, ApproximateSizesFilesWithErrorMargin) {
     const Range r(start, end);
 
     SizeApproximationOptions size_approx_options;
-    size_approx_options.include_memtabtles = false;
+    size_approx_options.include_memtables = false;
     size_approx_options.include_files = true;
     size_approx_options.files_size_error_margin = -1.0;  // disabled
 

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -572,7 +572,7 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
   std::string end = Key(60);
   Range r(start, end);
   SizeApproximationOptions size_approx_options;
-  size_approx_options.include_memtabtles = true;
+  size_approx_options.include_memtables = true;
   size_approx_options.include_files = true;
   ASSERT_OK(
       db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1669,8 +1669,8 @@ Status StressTest::TestApproximateSize(
   std::string key2_str = Key(key2);
   Range range{Slice(key1_str), Slice(key2_str)};
   SizeApproximationOptions sao;
-  sao.include_memtabtles = thread->rand.OneIn(2);
-  if (sao.include_memtabtles) {
+  sao.include_memtables = thread->rand.OneIn(2);
+  if (sao.include_memtables) {
     sao.include_files = thread->rand.OneIn(2);
   }
   if (thread->rand.OneIn(2)) {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -340,7 +340,7 @@ extern ROCKSDB_LIBRARY_API rocksdb_t* rocksdb_open_as_secondary_column_families(
     const char* secondary_path, int num_column_families,
     const char* const* column_family_names,
     const rocksdb_options_t* const* column_family_options,
-    rocksdb_column_family_handle_t** colummn_family_handles, char** errptr);
+    rocksdb_column_family_handle_t** column_family_handles, char** errptr);
 
 extern ROCKSDB_LIBRARY_API char** rocksdb_list_column_families(
     const rocksdb_options_t* options, const char* name, size_t* lencf,

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -340,7 +340,7 @@ extern ROCKSDB_LIBRARY_API rocksdb_t* rocksdb_open_as_secondary_column_families(
     const char* secondary_path, int num_column_families,
     const char* const* column_family_names,
     const rocksdb_options_t* const* column_family_options,
-    rocksdb_column_family_handle_t** column_family_handles, char** errptr);
+    rocksdb_column_family_handle_t** colummn_family_handles, char** errptr);
 
 extern ROCKSDB_LIBRARY_API char** rocksdb_list_column_families(
     const rocksdb_options_t* options, const char* name, size_t* lencf,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1139,7 +1139,7 @@ class DB {
                                      uint64_t* sizes,
                                      uint8_t include_flags = INCLUDE_FILES) {
     SizeApproximationOptions options;
-    options.include_memtabtles =
+    options.include_memtables =
         (include_flags & SizeApproximationFlags::INCLUDE_MEMTABLES) != 0;
     options.include_files =
         (include_flags & SizeApproximationFlags::INCLUDE_FILES) != 0;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1870,7 +1870,7 @@ struct ImportColumnFamilyOptions {
 // Options used with DB::GetApproximateSizes()
 struct SizeApproximationOptions {
   // Defines whether the returned size should include the recently written
-  // data in the mem-tables. If set to false, include_files must be true.
+  // data in the memtables. If set to false, include_files must be true.
   bool include_memtables = false;
   // Defines whether the returned size should include data serialized to disk.
   // If set to false, include_memtables must be true.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1871,9 +1871,9 @@ struct ImportColumnFamilyOptions {
 struct SizeApproximationOptions {
   // Defines whether the returned size should include the recently written
   // data in the mem-tables. If set to false, include_files must be true.
-  bool include_memtabtles = false;
+  bool include_memtables = false;
   // Defines whether the returned size should include data serialized to disk.
-  // If set to false, include_memtabtles must be true.
+  // If set to false, include_memtables must be true.
   bool include_files = true;
   // When approximating the files total size that is used to store a keys range
   // using DB::GetApproximateSizes, allow approximation with an error margin of


### PR DESCRIPTION
I feel it would be nice if we can fix this spelling error.

In `SizeApproximationOptions`, the `include_memtabtles` should be `include_memtables`.

Test plan
make check