### PR TITLE
Clean up VersionStorageInfo a bit

### DIFF
--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -148,16 +148,11 @@ class CompactionPickerTest : public testing::Test {
       ASSERT_OK(builder.SaveTo(temp_vstorage_.get()));
       vstorage_ = std::move(temp_vstorage_);
     }
-    vstorage_->CalculateBaseBytes(ioptions_, mutable_cf_options_);
-    vstorage_->UpdateFilesByCompactionPri(ioptions_, mutable_cf_options_);
-    vstorage_->UpdateNumNonEmptyLevels();
-    vstorage_->GenerateFileIndexer();
-    vstorage_->GenerateLevelFilesBrief();
+    vstorage_->PrepareAppend(ioptions_, mutable_cf_options_);
     vstorage_->ComputeCompactionScore(ioptions_, mutable_cf_options_);
-    vstorage_->GenerateLevel0NonOverlapping();
-    vstorage_->ComputeFilesMarkedForCompaction();
     vstorage_->SetFinalized();
   }
+
   void AddFileToVersionStorage(int level, uint32_t file_number,
                                const char* smallest, const char* largest,
                                uint64_t file_size = 1, uint32_t path_id = 0,

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -76,7 +76,7 @@ class CompactionPickerTest : public testing::Test {
     options_.num_levels = num_levels;
     vstorage_.reset(new VersionStorageInfo(&icmp_, ucmp_, options_.num_levels,
                                            style, nullptr, false));
-    vstorage_->CalculateBaseBytes(ioptions_, mutable_cf_options_);
+    vstorage_->PrepareAppend(ioptions_, mutable_cf_options_);
   }
 
   // Create a new VersionStorageInfo object so we can add mode files and then

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -76,7 +76,7 @@ class CompactionPickerTest : public testing::Test {
     options_.num_levels = num_levels;
     vstorage_.reset(new VersionStorageInfo(&icmp_, ucmp_, options_.num_levels,
                                            style, nullptr, false));
-    vstorage_->PrepareAppend(ioptions_, mutable_cf_options_);
+    vstorage_->PrepareForVersionAppend(ioptions_, mutable_cf_options_);
   }
 
   // Create a new VersionStorageInfo object so we can add mode files and then
@@ -148,7 +148,7 @@ class CompactionPickerTest : public testing::Test {
       ASSERT_OK(builder.SaveTo(temp_vstorage_.get()));
       vstorage_ = std::move(temp_vstorage_);
     }
-    vstorage_->PrepareAppend(ioptions_, mutable_cf_options_);
+    vstorage_->PrepareForVersionAppend(ioptions_, mutable_cf_options_);
     vstorage_->ComputeCompactionScore(ioptions_, mutable_cf_options_);
     vstorage_->SetFinalized();
   }

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -153,26 +153,6 @@ class CompactionPickerTest : public testing::Test {
     vstorage_->SetFinalized();
   }
 
-  void AddFileToVersionStorage(int level, uint32_t file_number,
-                               const char* smallest, const char* largest,
-                               uint64_t file_size = 1, uint32_t path_id = 0,
-                               SequenceNumber smallest_seq = 100,
-                               SequenceNumber largest_seq = 100,
-                               size_t compensated_file_size = 0,
-                               bool marked_for_compact = false) {
-    VersionStorageInfo* base_vstorage = vstorage_.release();
-    vstorage_.reset(new VersionStorageInfo(&icmp_, ucmp_, options_.num_levels,
-                                           kCompactionStyleUniversal,
-                                           base_vstorage, false));
-    Add(level, file_number, smallest, largest, file_size, path_id, smallest_seq,
-        largest_seq, compensated_file_size, marked_for_compact);
-
-    VersionBuilder builder(FileOptions(), &ioptions_, nullptr, base_vstorage,
-                           nullptr);
-    builder.SaveTo(vstorage_.get());
-    UpdateVersionStorageInfo();
-  }
-
  private:
   std::unique_ptr<VersionStorageInfo> temp_vstorage_;
 };

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -73,7 +73,6 @@ class VersionBuilderTest : public testing::Test {
         kUnknownFileCreationTime, kUnknownFileChecksum,
         kUnknownFileChecksumFuncName, kDisableUserTimestamp,
         kDisableUserTimestamp);
-    f->compensated_file_size = file_size;
     f->num_entries = num_entries;
     f->num_deletions = num_deletions;
     vstorage_.AddFile(level, f);
@@ -152,15 +151,14 @@ class VersionBuilderTest : public testing::Test {
     return meta;
   }
 
-  void UpdateVersionStorageInfo() {
-    vstorage_.UpdateFilesByCompactionPri(ioptions_, mutable_cf_options_);
-    vstorage_.UpdateNumNonEmptyLevels();
-    vstorage_.GenerateFileIndexer();
-    vstorage_.GenerateLevelFilesBrief();
-    vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
-    vstorage_.GenerateLevel0NonOverlapping();
-    vstorage_.SetFinalized();
+  void UpdateVersionStorageInfo(VersionStorageInfo* vstorage) {
+    assert(vstorage);
+
+    vstorage->PrepareAppend(ioptions_, mutable_cf_options_);
+    vstorage->SetFinalized();
   }
+
+  void UpdateVersionStorageInfo() { UpdateVersionStorageInfo(&vstorage_); }
 };
 
 void UnrefFilesInVersion(VersionStorageInfo* new_vstorage) {
@@ -187,6 +185,7 @@ TEST_F(VersionBuilderTest, ApplyAndSaveTo) {
   Add(3, 27U, "171", "179", 100U);
   Add(3, 28U, "191", "220", 100U);
   Add(3, 29U, "221", "300", 100U);
+
   UpdateVersionStorageInfo();
 
   VersionEdit version_edit;
@@ -210,6 +209,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveTo) {
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
 
+  UpdateVersionStorageInfo(&new_vstorage);
+
   ASSERT_EQ(400U, new_vstorage.NumLevelBytes(2));
   ASSERT_EQ(300U, new_vstorage.NumLevelBytes(3));
 
@@ -228,6 +229,7 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic) {
 
   Add(5, 26U, "150", "170", 100U);
   Add(5, 27U, "171", "179", 100U);
+
   UpdateVersionStorageInfo();
 
   VersionEdit version_edit;
@@ -252,6 +254,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic) {
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
 
+  UpdateVersionStorageInfo(&new_vstorage);
+
   ASSERT_EQ(0U, new_vstorage.NumLevelBytes(0));
   ASSERT_EQ(100U, new_vstorage.NumLevelBytes(3));
   ASSERT_EQ(300U, new_vstorage.NumLevelBytes(4));
@@ -272,6 +276,7 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic2) {
 
   Add(5, 26U, "150", "170", 100U);
   Add(5, 27U, "171", "179", 100U);
+
   UpdateVersionStorageInfo();
 
   VersionEdit version_edit;
@@ -298,6 +303,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic2) {
                                   kCompactionStyleLevel, nullptr, false);
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
 
   ASSERT_EQ(0U, new_vstorage.NumLevelBytes(0));
   ASSERT_EQ(100U, new_vstorage.NumLevelBytes(4));
@@ -352,6 +359,8 @@ TEST_F(VersionBuilderTest, ApplyMultipleAndSaveTo) {
                                   kCompactionStyleLevel, nullptr, false);
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
 
   ASSERT_EQ(500U, new_vstorage.NumLevelBytes(2));
 
@@ -423,6 +432,8 @@ TEST_F(VersionBuilderTest, ApplyDeleteAndSaveTo) {
   ASSERT_OK(version_builder.Apply(&version_edit2));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
 
+  UpdateVersionStorageInfo(&new_vstorage);
+
   ASSERT_EQ(300U, new_vstorage.NumLevelBytes(2));
 
   UnrefFilesInVersion(&new_vstorage);
@@ -433,8 +444,11 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionIncorrectLevel) {
   constexpr uint64_t file_number = 2345;
   constexpr char smallest[] = "bar";
   constexpr char largest[] = "foo";
+  constexpr uint64_t file_size = 100;
 
-  Add(level, file_number, smallest, largest);
+  Add(level, file_number, smallest, largest, file_size);
+
+  UpdateVersionStorageInfo();
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -457,6 +471,8 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionIncorrectLevel) {
 }
 
 TEST_F(VersionBuilderTest, ApplyFileDeletionNotInLSMTree) {
+  UpdateVersionStorageInfo();
+
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
@@ -497,6 +513,8 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionAndAddition) {
       largest_seq, num_entries, num_deletions, sampled, smallest_seqno,
       largest_seqno);
 
+  UpdateVersionStorageInfo();
+
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
@@ -531,6 +549,9 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionAndAddition) {
                                   force_consistency_checks);
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
+
   ASSERT_EQ(new_vstorage.GetFileLocation(file_number).GetLevel(), level);
 
   UnrefFilesInVersion(&new_vstorage);
@@ -541,8 +562,11 @@ TEST_F(VersionBuilderTest, ApplyFileAdditionAlreadyInBase) {
   constexpr uint64_t file_number = 2345;
   constexpr char smallest[] = "bar";
   constexpr char largest[] = "foo";
+  constexpr uint64_t file_size = 10000;
 
-  Add(level, file_number, smallest, largest);
+  Add(level, file_number, smallest, largest, file_size);
+
+  UpdateVersionStorageInfo();
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -555,7 +579,6 @@ TEST_F(VersionBuilderTest, ApplyFileAdditionAlreadyInBase) {
 
   constexpr int new_level = 2;
   constexpr uint32_t path_id = 0;
-  constexpr uint64_t file_size = 10000;
   constexpr SequenceNumber smallest_seqno = 100;
   constexpr SequenceNumber largest_seqno = 1000;
   constexpr bool marked_for_compaction = false;
@@ -576,6 +599,8 @@ TEST_F(VersionBuilderTest, ApplyFileAdditionAlreadyInBase) {
 }
 
 TEST_F(VersionBuilderTest, ApplyFileAdditionAlreadyApplied) {
+  UpdateVersionStorageInfo();
+
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
@@ -625,6 +650,8 @@ TEST_F(VersionBuilderTest, ApplyFileAdditionAlreadyApplied) {
 }
 
 TEST_F(VersionBuilderTest, ApplyFileAdditionAndDeletion) {
+  UpdateVersionStorageInfo();
+
   constexpr int level = 1;
   constexpr uint64_t file_number = 2345;
   constexpr uint32_t path_id = 0;
@@ -666,12 +693,17 @@ TEST_F(VersionBuilderTest, ApplyFileAdditionAndDeletion) {
                                   force_consistency_checks);
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
+
   ASSERT_FALSE(new_vstorage.GetFileLocation(file_number).IsValid());
 
   UnrefFilesInVersion(&new_vstorage);
 }
 
 TEST_F(VersionBuilderTest, ApplyBlobFileAddition) {
+  UpdateVersionStorageInfo();
+
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
@@ -704,6 +736,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAddition) {
                                   force_consistency_checks);
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
 
   const auto& new_blob_files = new_vstorage.GetBlobFiles();
   ASSERT_EQ(new_blob_files.size(), 1);
@@ -741,6 +775,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyInBase) {
           checksum_value, BlobFileMetaData::LinkedSsts(), garbage_blob_count,
           garbage_blob_bytes);
 
+  UpdateVersionStorageInfo();
+
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
@@ -760,6 +796,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyInBase) {
 
 TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyApplied) {
   // Attempt to add the same blob file twice using version edits.
+
+  UpdateVersionStorageInfo();
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -813,6 +851,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
   // Add dummy table file to ensure the blob file is referenced.
   AddDummyFile(table_file_number, blob_file_number);
 
+  UpdateVersionStorageInfo();
+
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
@@ -836,6 +876,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
                                   force_consistency_checks);
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
 
   const auto& new_blob_files = new_vstorage.GetBlobFiles();
   ASSERT_EQ(new_blob_files.size(), 1);
@@ -861,6 +903,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
 
 TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
   // Increase the amount of garbage for a blob file added using a version edit.
+
+  UpdateVersionStorageInfo();
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -905,6 +949,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
+  UpdateVersionStorageInfo(&new_vstorage);
+
   const auto& new_blob_files = new_vstorage.GetBlobFiles();
   ASSERT_EQ(new_blob_files.size(), 1);
 
@@ -927,6 +973,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
 TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileNotFound) {
   // Attempt to increase the amount of garbage for a blob file that is
   // neither in the base version, nor was it added using a version edit.
+
+  UpdateVersionStorageInfo();
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -952,6 +1000,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileNotFound) {
 TEST_F(VersionBuilderTest, BlobFileGarbageOverflow) {
   // Test that VersionEdits that would result in the count/total size of garbage
   // exceeding the count/total size of all blobs are rejected.
+
+  UpdateVersionStorageInfo();
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -1032,6 +1082,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
     AddDummyFile(table_file_number, blob_file_number);
   }
 
+  UpdateVersionStorageInfo();
+
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
@@ -1068,6 +1120,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
                                   force_consistency_checks);
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
 
   const auto& new_blob_files = new_vstorage.GetBlobFiles();
   ASSERT_EQ(new_blob_files.size(), 3);
@@ -1115,6 +1169,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
 
   ASSERT_OK(second_builder.SaveTo(&newer_vstorage));
 
+  UpdateVersionStorageInfo(&newer_vstorage);
+
   const auto& newer_blob_files = newer_vstorage.GetBlobFiles();
   ASSERT_EQ(newer_blob_files.size(), 2);
 
@@ -1148,6 +1204,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesToConcurrentJobs) {
           checksum_method, checksum_value,
           BlobFileMetaData::LinkedSsts{base_table_file_number},
           garbage_blob_count, garbage_blob_bytes);
+
+  UpdateVersionStorageInfo();
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -1193,6 +1251,8 @@ TEST_F(VersionBuilderTest, SaveBlobFilesToConcurrentJobs) {
                                   force_consistency_checks);
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
 
   const auto& new_blob_files = new_vstorage.GetBlobFiles();
   ASSERT_EQ(new_blob_files.size(), 2);
@@ -1292,6 +1352,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFiles) {
                                   force_consistency_checks);
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
 
   UnrefFilesInVersion(&new_vstorage);
 }
@@ -1581,6 +1643,8 @@ TEST_F(VersionBuilderTest, MaintainLinkedSstsForBlobFiles) {
 
   ASSERT_OK(builder.SaveTo(&new_vstorage));
 
+  UpdateVersionStorageInfo(&new_vstorage);
+
   {
     const auto& blob_files = new_vstorage.GetBlobFiles();
     ASSERT_EQ(blob_files.size(), 5);
@@ -1605,6 +1669,7 @@ TEST_F(VersionBuilderTest, MaintainLinkedSstsForBlobFiles) {
 
 TEST_F(VersionBuilderTest, CheckConsistencyForFileDeletedTwice) {
   Add(0, 1U, "150", "200", 100U);
+
   UpdateVersionStorageInfo();
 
   VersionEdit version_edit;
@@ -1621,6 +1686,8 @@ TEST_F(VersionBuilderTest, CheckConsistencyForFileDeletedTwice) {
                                   true /* force_consistency_checks */);
   ASSERT_OK(version_builder.Apply(&version_edit));
   ASSERT_OK(version_builder.SaveTo(&new_vstorage));
+
+  UpdateVersionStorageInfo(&new_vstorage);
 
   VersionBuilder version_builder2(env_options, &ioptions_, table_cache,
                                  &new_vstorage, version_set);

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -155,7 +155,7 @@ class VersionBuilderTest : public testing::Test {
   void UpdateVersionStorageInfo(VersionStorageInfo* vstorage) {
     assert(vstorage);
 
-    vstorage->PrepareAppend(ioptions_, mutable_cf_options_);
+    vstorage->PrepareForVersionAppend(ioptions_, mutable_cf_options_);
     vstorage->SetFinalized();
   }
 

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -73,6 +73,7 @@ class VersionBuilderTest : public testing::Test {
         kUnknownFileCreationTime, kUnknownFileChecksum,
         kUnknownFileChecksumFuncName, kDisableUserTimestamp,
         kDisableUserTimestamp);
+    f->compensated_file_size = file_size;
     f->num_entries = num_entries;
     f->num_deletions = num_deletions;
     vstorage_.AddFile(level, f);

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -396,7 +396,6 @@ class VersionEdit {
   const DeletedFiles& GetDeletedFiles() const { return deleted_files_; }
 
   // Add the specified table file at the specified level.
-  // REQUIRES: This version has not been saved (see VersionSet::SaveTo)
   // REQUIRES: "smallest" and "largest" are smallest and largest keys in file
   // REQUIRES: "oldest_blob_file_number" is the number of the oldest blob file
   // referred to by this file if any, kInvalidBlobFileNumber otherwise.

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -532,7 +532,7 @@ Status VersionEditHandler::MaybeCreateVersion(const VersionEdit& /*edit*/,
     s = builder->SaveTo(v->storage_info());
     if (s.ok()) {
       // Install new version
-      v->PrepareApply(
+      v->PrepareAppend(
           *cfd->GetLatestMutableCFOptions(),
           !(version_set_->db_options_->skip_stats_update_on_db_open));
       version_set_->AppendVersion(cfd, v);
@@ -806,7 +806,7 @@ Status VersionEditHandlerPointInTime::MaybeCreateVersion(
                                 version_set_->current_version_number_++);
     s = builder->SaveTo(version->storage_info());
     if (s.ok()) {
-      version->PrepareApply(
+      version->PrepareAppend(
           *cfd->GetLatestMutableCFOptions(),
           !version_set_->db_options_->skip_stats_update_on_db_open);
       auto v_iter = versions_.find(cfd->GetID());

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2407,7 +2407,12 @@ void Version::PrepareAppend(const MutableCFOptions& mutable_cf_options,
   TEST_SYNC_POINT_CALLBACK(
       "Version::PrepareAppend:forced_check",
       reinterpret_cast<void*>(&storage_info_.force_consistency_checks_));
-  UpdateAccumulatedStats(update_stats);
+
+  if (update_stats) {
+    UpdateAccumulatedStats();
+  }
+
+  storage_info_.ComputeCompensatedSizes();
   storage_info_.UpdateNumNonEmptyLevels();
   storage_info_.CalculateBaseBytes(*cfd_->ioptions(), mutable_cf_options);
   storage_info_.UpdateFilesByCompactionPri(*cfd_->ioptions(),
@@ -2469,59 +2474,54 @@ void VersionStorageInfo::RemoveCurrentStats(FileMetaData* file_meta) {
   }
 }
 
-void Version::UpdateAccumulatedStats(bool update_stats) {
-  if (update_stats) {
-    // maximum number of table properties loaded from files.
-    const int kMaxInitCount = 20;
-    int init_count = 0;
-    // here only the first kMaxInitCount files which haven't been
-    // initialized from file will be updated with num_deletions.
-    // The motivation here is to cap the maximum I/O per Version creation.
-    // The reason for choosing files from lower-level instead of higher-level
-    // is that such design is able to propagate the initialization from
-    // lower-level to higher-level:  When the num_deletions of lower-level
-    // files are updated, it will make the lower-level files have accurate
-    // compensated_file_size, making lower-level to higher-level compaction
-    // will be triggered, which creates higher-level files whose num_deletions
-    // will be updated here.
-    for (int level = 0;
-         level < storage_info_.num_levels_ && init_count < kMaxInitCount;
-         ++level) {
-      for (auto* file_meta : storage_info_.files_[level]) {
-        if (MaybeInitializeFileMetaData(file_meta)) {
-          // each FileMeta will be initialized only once.
-          storage_info_.UpdateAccumulatedStats(file_meta);
-          // when option "max_open_files" is -1, all the file metadata has
-          // already been read, so MaybeInitializeFileMetaData() won't incur
-          // any I/O cost. "max_open_files=-1" means that the table cache passed
-          // to the VersionSet and then to the ColumnFamilySet has a size of
-          // TableCache::kInfiniteCapacity
-          if (vset_->GetColumnFamilySet()->get_table_cache()->GetCapacity() ==
-              TableCache::kInfiniteCapacity) {
-            continue;
-          }
-          if (++init_count >= kMaxInitCount) {
-            break;
-          }
+void Version::UpdateAccumulatedStats() {
+  // maximum number of table properties loaded from files.
+  const int kMaxInitCount = 20;
+  int init_count = 0;
+  // here only the first kMaxInitCount files which haven't been
+  // initialized from file will be updated with num_deletions.
+  // The motivation here is to cap the maximum I/O per Version creation.
+  // The reason for choosing files from lower-level instead of higher-level
+  // is that such design is able to propagate the initialization from
+  // lower-level to higher-level:  When the num_deletions of lower-level
+  // files are updated, it will make the lower-level files have accurate
+  // compensated_file_size, making lower-level to higher-level compaction
+  // will be triggered, which creates higher-level files whose num_deletions
+  // will be updated here.
+  for (int level = 0;
+       level < storage_info_.num_levels_ && init_count < kMaxInitCount;
+       ++level) {
+    for (auto* file_meta : storage_info_.files_[level]) {
+      if (MaybeInitializeFileMetaData(file_meta)) {
+        // each FileMeta will be initialized only once.
+        storage_info_.UpdateAccumulatedStats(file_meta);
+        // when option "max_open_files" is -1, all the file metadata has
+        // already been read, so MaybeInitializeFileMetaData() won't incur
+        // any I/O cost. "max_open_files=-1" means that the table cache passed
+        // to the VersionSet and then to the ColumnFamilySet has a size of
+        // TableCache::kInfiniteCapacity
+        if (vset_->GetColumnFamilySet()->get_table_cache()->GetCapacity() ==
+            TableCache::kInfiniteCapacity) {
+          continue;
         }
-      }
-    }
-    // In case all sampled-files contain only deletion entries, then we
-    // load the table-property of a file in higher-level to initialize
-    // that value.
-    for (int level = storage_info_.num_levels_ - 1;
-         storage_info_.accumulated_raw_value_size_ == 0 && level >= 0;
-         --level) {
-      for (int i = static_cast<int>(storage_info_.files_[level].size()) - 1;
-           storage_info_.accumulated_raw_value_size_ == 0 && i >= 0; --i) {
-        if (MaybeInitializeFileMetaData(storage_info_.files_[level][i])) {
-          storage_info_.UpdateAccumulatedStats(storage_info_.files_[level][i]);
+        if (++init_count >= kMaxInitCount) {
+          break;
         }
       }
     }
   }
-
-  storage_info_.ComputeCompensatedSizes();
+  // In case all sampled-files contain only deletion entries, then we
+  // load the table-property of a file in higher-level to initialize
+  // that value.
+  for (int level = storage_info_.num_levels_ - 1;
+       storage_info_.accumulated_raw_value_size_ == 0 && level >= 0; --level) {
+    for (int i = static_cast<int>(storage_info_.files_[level].size()) - 1;
+         storage_info_.accumulated_raw_value_size_ == 0 && i >= 0; --i) {
+      if (MaybeInitializeFileMetaData(storage_info_.files_[level][i])) {
+        storage_info_.UpdateAccumulatedStats(storage_info_.files_[level][i]);
+      }
+    }
+  }
 }
 
 void VersionStorageInfo::ComputeCompensatedSizes() {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2402,11 +2402,10 @@ void VersionStorageInfo::GenerateLevelFilesBrief() {
   }
 }
 
-void Version::PrepareApply(
-    const MutableCFOptions& mutable_cf_options,
-    bool update_stats) {
+void Version::PrepareAppend(const MutableCFOptions& mutable_cf_options,
+                            bool update_stats) {
   TEST_SYNC_POINT_CALLBACK(
-      "Version::PrepareApply:forced_check",
+      "Version::PrepareAppend:forced_check",
       reinterpret_cast<void*>(&storage_info_.force_consistency_checks_));
   UpdateAccumulatedStats(update_stats);
   storage_info_.UpdateNumNonEmptyLevels();
@@ -3062,7 +3061,7 @@ void VersionStorageInfo::AddBlobFile(
   blob_files_.emplace_hint(it, blob_file_number, std::move(blob_file_meta));
 }
 
-// Version::PrepareApply() need to be called before calling the function, or
+// Version::PrepareAppend() need to be called before calling the function, or
 // following functions called:
 // 1. UpdateNumNonEmptyLevels();
 // 2. CalculateBaseBytes();
@@ -4419,7 +4418,7 @@ Status VersionSet::ProcessManifestWrites(
     if (s.ok()) {
       if (!first_writer.edit_list.front()->IsColumnFamilyManipulation()) {
         for (int i = 0; i < static_cast<int>(versions.size()); ++i) {
-          versions[i]->PrepareApply(*mutable_cf_options_ptrs[i], true);
+          versions[i]->PrepareAppend(*mutable_cf_options_ptrs[i], true);
         }
       }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4414,8 +4414,10 @@ Status VersionSet::ProcessManifestWrites(
 
     if (s.ok()) {
       if (!first_writer.edit_list.front()->IsColumnFamilyManipulation()) {
+        constexpr bool update_stats = true;
+
         for (int i = 0; i < static_cast<int>(versions.size()); ++i) {
-          versions[i]->PrepareAppend(*mutable_cf_options_ptrs[i], true);
+          versions[i]->PrepareAppend(*mutable_cf_options_ptrs[i], update_stats);
         }
       }
 
@@ -5910,9 +5912,9 @@ ColumnFamilyData* VersionSet::CreateColumnFamily(
                            *new_cfd->GetLatestMutableCFOptions(), io_tracer_,
                            current_version_number_++);
 
-  assert(v->storage_info());
-  v->storage_info()->PrepareForVersionAppend(
-      *new_cfd->ioptions(), *new_cfd->GetLatestMutableCFOptions());
+  constexpr bool update_stats = false;
+
+  v->PrepareAppend(*new_cfd->GetLatestMutableCFOptions(), update_stats);
 
   AppendVersion(new_cfd, v);
   // GetLatestMutableCFOptions() is safe here without mutex since the

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2402,7 +2402,7 @@ void VersionStorageInfo::GenerateLevelFilesBrief() {
   }
 }
 
-void VersionStorageInfo::PrepareAppend(
+void VersionStorageInfo::PrepareForVersionAppend(
     const ImmutableOptions& immutable_options,
     const MutableCFOptions& mutable_cf_options) {
   ComputeCompensatedSizes();
@@ -2425,7 +2425,7 @@ void Version::PrepareAppend(const MutableCFOptions& mutable_cf_options,
     UpdateAccumulatedStats();
   }
 
-  storage_info_.PrepareAppend(*cfd_->ioptions(), mutable_cf_options);
+  storage_info_.PrepareForVersionAppend(*cfd_->ioptions(), mutable_cf_options);
 }
 
 bool Version::MaybeInitializeFileMetaData(FileMetaData* file_meta) {
@@ -5911,8 +5911,8 @@ ColumnFamilyData* VersionSet::CreateColumnFamily(
                            current_version_number_++);
 
   assert(v->storage_info());
-  v->storage_info()->PrepareAppend(*new_cfd->ioptions(),
-                                   *new_cfd->GetLatestMutableCFOptions());
+  v->storage_info()->PrepareForVersionAppend(
+      *new_cfd->ioptions(), *new_cfd->GetLatestMutableCFOptions());
 
   AppendVersion(new_cfd, v);
   // GetLatestMutableCFOptions() is safe here without mutex since the

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2402,6 +2402,19 @@ void VersionStorageInfo::GenerateLevelFilesBrief() {
   }
 }
 
+void VersionStorageInfo::PrepareAppend(
+    const ImmutableOptions& immutable_options,
+    const MutableCFOptions& mutable_cf_options) {
+  ComputeCompensatedSizes();
+  UpdateNumNonEmptyLevels();
+  CalculateBaseBytes(immutable_options, mutable_cf_options);
+  UpdateFilesByCompactionPri(immutable_options, mutable_cf_options);
+  GenerateFileIndexer();
+  GenerateLevelFilesBrief();
+  GenerateLevel0NonOverlapping();
+  GenerateBottommostFiles();
+}
+
 void Version::PrepareAppend(const MutableCFOptions& mutable_cf_options,
                             bool update_stats) {
   TEST_SYNC_POINT_CALLBACK(
@@ -2412,15 +2425,7 @@ void Version::PrepareAppend(const MutableCFOptions& mutable_cf_options,
     UpdateAccumulatedStats();
   }
 
-  storage_info_.ComputeCompensatedSizes();
-  storage_info_.UpdateNumNonEmptyLevels();
-  storage_info_.CalculateBaseBytes(*cfd_->ioptions(), mutable_cf_options);
-  storage_info_.UpdateFilesByCompactionPri(*cfd_->ioptions(),
-                                           mutable_cf_options);
-  storage_info_.GenerateFileIndexer();
-  storage_info_.GenerateLevelFilesBrief();
-  storage_info_.GenerateLevel0NonOverlapping();
-  storage_info_.GenerateBottommostFiles();
+  storage_info_.PrepareAppend(*cfd_->ioptions(), mutable_cf_options);
 }
 
 bool Version::MaybeInitializeFileMetaData(FileMetaData* file_meta) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -129,10 +129,10 @@ class VersionStorageInfo {
 
   void AddBlobFile(std::shared_ptr<BlobFileMetaData> blob_file_meta);
 
-  void PrepareAppend(const ImmutableOptions& immutable_options,
-                     const MutableCFOptions& mutable_cf_options);
+  void PrepareForVersionAppend(const ImmutableOptions& immutable_options,
+                               const MutableCFOptions& mutable_cf_options);
 
-  // REQUIRES: PrepareAppend has been called
+  // REQUIRES: PrepareForVersionAppend has been called
   void SetFinalized();
 
   // Update the accumulated stats from a file-meta.
@@ -251,13 +251,13 @@ class VersionStorageInfo {
 
   int num_levels() const { return num_levels_; }
 
-  // REQUIRES: PrepareAppend has been called
+  // REQUIRES: PrepareForVersionAppend has been called
   int num_non_empty_levels() const {
     assert(finalized_);
     return num_non_empty_levels_;
   }
 
-  // REQUIRES: PrepareAppend has been called
+  // REQUIRES: PrepareForVersionAppend has been called
   // This may or may not return number of level files. It is to keep backward
   // compatible behavior in universal compaction.
   int l0_delay_trigger_count() const { return l0_delay_trigger_count_; }
@@ -352,7 +352,7 @@ class VersionStorageInfo {
     return level_files_brief_[level];
   }
 
-  // REQUIRES: PrepareAppend has been called
+  // REQUIRES: PrepareForVersionAppend has been called
   const std::vector<int>& FilesByCompactionPri(int level) const {
     assert(finalized_);
     return files_by_compaction_pri_[level];
@@ -416,7 +416,7 @@ class VersionStorageInfo {
     return next_file_to_compact_by_size_[level];
   }
 
-  // REQUIRES: PrepareAppend has been called
+  // REQUIRES: PrepareForVersionAppend has been called
   const FileIndexer& file_indexer() const {
     assert(finalized_);
     return file_indexer_;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -741,9 +741,9 @@ class Version {
                     std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs);
 
   // Loads some stats information from files. Call without mutex held. It needs
-  // to be called before applying the version to the version set.
-  void PrepareApply(const MutableCFOptions& mutable_cf_options,
-                    bool update_stats);
+  // to be called before appending the version to the version set.
+  void PrepareAppend(const MutableCFOptions& mutable_cf_options,
+                     bool update_stats);
 
   // Reference count management (so Versions do not disappear out from
   // under live iterators)
@@ -1296,7 +1296,7 @@ class VersionSet {
         new Version(cfd, this, file_options_, mutable_cf_options, io_tracer_);
 
     constexpr bool update_stats = false;
-    version->PrepareApply(mutable_cf_options, update_stats);
+    version->PrepareAppend(mutable_cf_options, update_stats);
     AppendVersion(cfd, version);
   }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -129,6 +129,9 @@ class VersionStorageInfo {
 
   void AddBlobFile(std::shared_ptr<BlobFileMetaData> blob_file_meta);
 
+  void PrepareAppend(const ImmutableOptions& immutable_options,
+                     const MutableCFOptions& mutable_cf_options);
+
   void SetFinalized();
 
   // Update num_non_empty_levels_.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -251,14 +251,13 @@ class VersionStorageInfo {
 
   int num_levels() const { return num_levels_; }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: PrepareAppend has been called
   int num_non_empty_levels() const {
     assert(finalized_);
     return num_non_empty_levels_;
   }
 
-  // REQUIRES: This version has been finalized.
-  // (CalculateBaseBytes() is called)
+  // REQUIRES: PrepareAppend has been called
   // This may or may not return number of level files. It is to keep backward
   // compatible behavior in universal compaction.
   int l0_delay_trigger_count() const { return l0_delay_trigger_count_; }
@@ -353,13 +352,13 @@ class VersionStorageInfo {
     return level_files_brief_[level];
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: PrepareAppend has been called
   const std::vector<int>& FilesByCompactionPri(int level) const {
     assert(finalized_);
     return files_by_compaction_pri_[level];
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: ComputeCompactionScore has been called
   // REQUIRES: DB mutex held during access
   const autovector<std::pair<int, FileMetaData*>>& FilesMarkedForCompaction()
       const {
@@ -367,14 +366,14 @@ class VersionStorageInfo {
     return files_marked_for_compaction_;
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: ComputeCompactionScore has been called
   // REQUIRES: DB mutex held during access
   const autovector<std::pair<int, FileMetaData*>>& ExpiredTtlFiles() const {
     assert(finalized_);
     return expired_ttl_files_;
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: ComputeCompactionScore has been called
   // REQUIRES: DB mutex held during access
   const autovector<std::pair<int, FileMetaData*>>&
   FilesMarkedForPeriodicCompaction() const {
@@ -386,7 +385,7 @@ class VersionStorageInfo {
     files_marked_for_periodic_compaction_.emplace_back(level, f);
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: ComputeCompactionScore has been called
   // REQUIRES: DB mutex held during access
   const autovector<std::pair<int, FileMetaData*>>&
   BottommostFilesMarkedForCompaction() const {
@@ -394,7 +393,7 @@ class VersionStorageInfo {
     return bottommost_files_marked_for_compaction_;
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: ComputeCompactionScore has been called
   // REQUIRES: DB mutex held during access
   const autovector<std::pair<int, FileMetaData*>>& FilesMarkedForForcedBlobGC()
       const {
@@ -417,7 +416,7 @@ class VersionStorageInfo {
     return next_file_to_compact_by_size_[level];
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: PrepareAppend has been called
   const FileIndexer& file_indexer() const {
     assert(finalized_);
     return file_indexer_;
@@ -611,7 +610,7 @@ class VersionStorageInfo {
 
   // Level that should be compacted next and its compaction score.
   // Score < 1 means compaction is not strictly needed.  These fields
-  // are initialized by Finalize().
+  // are initialized by ComputeCompactionScore.
   // The most critical level to be compacted is listed first
   // These are used to pick the best compaction level
   std::vector<double> compaction_score_;
@@ -659,7 +658,6 @@ class Version {
   // yield the contents of this Version when merged together.
   // @param read_options Must outlive any iterator built by
   // `merger_iter_builder`.
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo).
   void AddIterators(const ReadOptions& read_options,
                     const FileOptions& soptions,
                     MergeIteratorBuilder* merger_iter_builder,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -132,22 +132,14 @@ class VersionStorageInfo {
   void PrepareAppend(const ImmutableOptions& immutable_options,
                      const MutableCFOptions& mutable_cf_options);
 
+  // REQUIRES: PrepareAppend has been called
   void SetFinalized();
-
-  // Update num_non_empty_levels_.
-  void UpdateNumNonEmptyLevels();
-
-  void GenerateFileIndexer() {
-    file_indexer_.UpdateIndex(&arena_, num_non_empty_levels_, files_);
-  }
 
   // Update the accumulated stats from a file-meta.
   void UpdateAccumulatedStats(FileMetaData* file_meta);
 
   // Decrease the current stat from a to-be-deleted file-meta
   void RemoveCurrentStats(FileMetaData* file_meta);
-
-  void ComputeCompensatedSizes();
 
   // Updates internal structures that keep track of compaction scores
   // We use compaction scores to figure out which compaction to do next
@@ -195,23 +187,9 @@ class VersionStorageInfo {
       double blob_garbage_collection_age_cutoff,
       double blob_garbage_collection_force_threshold);
 
-  // Generate level_files_brief_ from files_
-  void GenerateLevelFilesBrief();
-  // Sort all files for this version based on their file size and
-  // record results in files_by_compaction_pri_. The largest files are listed
-  // first.
-  void UpdateFilesByCompactionPri(const ImmutableOptions& immutable_options,
-                                  const MutableCFOptions& mutable_cf_options);
-
-  void GenerateLevel0NonOverlapping();
   bool level0_non_overlapping() const {
     return level0_non_overlapping_;
   }
-
-  // Check whether each file in this version is bottommost (i.e., nothing in its
-  // key-range could possibly exist in an older file/level).
-  // REQUIRES: This version has not been saved
-  void GenerateBottommostFiles();
 
   // Updates the oldest snapshot and related internal state, like the bottommost
   // files marked for compaction.
@@ -501,10 +479,6 @@ class VersionStorageInfo {
   // Returns maximum total bytes of data on a given level.
   uint64_t MaxBytesForLevel(int level) const;
 
-  // Must be called after any change to MutableCFOptions.
-  void CalculateBaseBytes(const ImmutableOptions& ioptions,
-                          const MutableCFOptions& options);
-
   // Returns an estimate of the amount of live data in bytes.
   uint64_t EstimateLiveDataSize() const;
 
@@ -533,6 +507,21 @@ class VersionStorageInfo {
                                      int last_level, int last_l0_idx);
 
  private:
+  void ComputeCompensatedSizes();
+  void UpdateNumNonEmptyLevels();
+  void CalculateBaseBytes(const ImmutableOptions& ioptions,
+                          const MutableCFOptions& options);
+  void UpdateFilesByCompactionPri(const ImmutableOptions& immutable_options,
+                                  const MutableCFOptions& mutable_cf_options);
+
+  void GenerateFileIndexer() {
+    file_indexer_.UpdateIndex(&arena_, num_non_empty_levels_, files_);
+  }
+
+  void GenerateLevelFilesBrief();
+  void GenerateLevel0NonOverlapping();
+  void GenerateBottommostFiles();
+
   const InternalKeyComparator* internal_comparator_;
   const Comparator* user_comparator_;
   int num_levels_;            // Number of levels

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -740,9 +740,9 @@ class Version {
   void MultiGetBlob(const ReadOptions& read_options, MultiGetRange& range,
                     std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs);
 
-  // Loads some stats information from files and populates derived data
-  // structures. Call without mutex held. It needs to be called before appending
-  // the version to the version set.
+  // Loads some stats information from files (if update_stats is set) and
+  // populates derived data structures. Call without mutex held. It needs to be
+  // called before appending the version to the version set.
   void PrepareAppend(const MutableCFOptions& mutable_cf_options,
                      bool update_stats);
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -740,8 +740,9 @@ class Version {
   void MultiGetBlob(const ReadOptions& read_options, MultiGetRange& range,
                     std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs);
 
-  // Loads some stats information from files. Call without mutex held. It needs
-  // to be called before appending the version to the version set.
+  // Loads some stats information from files and populates derived data
+  // structures. Call without mutex held. It needs to be called before appending
+  // the version to the version set.
   void PrepareAppend(const MutableCFOptions& mutable_cf_options,
                      bool update_stats);
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -850,7 +850,7 @@ class Version {
 
   // Update the accumulated stats associated with the current version.
   // This accumulated stats will be used in compaction.
-  void UpdateAccumulatedStats(bool update_stats);
+  void UpdateAccumulatedStats();
 
   ColumnFamilyData* cfd_;  // ColumnFamilyData to which this Version belongs
   Logger* info_log_;

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -210,8 +210,8 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelStatic) {
   ioptions_.level_compaction_dynamic_level_bytes = false;
   mutable_cf_options_.max_bytes_for_level_base = 10;
   mutable_cf_options_.max_bytes_for_level_multiplier = 5;
-  Add(4, 100U, "1", "2");
-  Add(5, 101U, "1", "2");
+  Add(4, 100U, "1", "2", 100U);
+  Add(5, 101U, "1", "2", 100U);
 
   vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(1), 10U);

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -159,6 +159,7 @@ class VersionStorageInfoTestBase : public testing::Test {
         kUnknownOldestAncesterTime, kUnknownFileCreationTime,
         kUnknownFileChecksum, kUnknownFileChecksumFuncName,
         kDisableUserTimestamp, kDisableUserTimestamp);
+    f->compensated_file_size = file_size;
     vstorage_.AddFile(level, f);
   }
 

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -159,7 +159,6 @@ class VersionStorageInfoTestBase : public testing::Test {
         kUnknownOldestAncesterTime, kUnknownFileCreationTime,
         kUnknownFileChecksum, kUnknownFileChecksumFuncName,
         kDisableUserTimestamp, kDisableUserTimestamp);
-    f->compensated_file_size = file_size;
     vstorage_.AddFile(level, f);
   }
 

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -222,28 +222,53 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelStatic) {
   ASSERT_EQ(0, logger_->log_count);
 }
 
-TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic) {
+TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_1) {
   ioptions_.level_compaction_dynamic_level_bytes = true;
   mutable_cf_options_.max_bytes_for_level_base = 1000;
   mutable_cf_options_.max_bytes_for_level_multiplier = 5;
+
   Add(5, 1U, "1", "2", 500U);
 
   vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(vstorage_.base_level(), 5);
+}
 
+TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_2) {
+  ioptions_.level_compaction_dynamic_level_bytes = true;
+  mutable_cf_options_.max_bytes_for_level_base = 1000;
+  mutable_cf_options_.max_bytes_for_level_multiplier = 5;
+
+  Add(5, 1U, "1", "2", 500U);
   Add(5, 2U, "3", "4", 550U);
   vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(4), 1000U);
   ASSERT_EQ(vstorage_.base_level(), 4);
+}
 
+TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_3) {
+  ioptions_.level_compaction_dynamic_level_bytes = true;
+  mutable_cf_options_.max_bytes_for_level_base = 1000;
+  mutable_cf_options_.max_bytes_for_level_multiplier = 5;
+
+  Add(5, 1U, "1", "2", 500U);
+  Add(5, 2U, "3", "4", 550U);
   Add(4, 3U, "3", "4", 550U);
   vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(4), 1000U);
   ASSERT_EQ(vstorage_.base_level(), 4);
+}
 
+TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_4) {
+  ioptions_.level_compaction_dynamic_level_bytes = true;
+  mutable_cf_options_.max_bytes_for_level_base = 1000;
+  mutable_cf_options_.max_bytes_for_level_multiplier = 5;
+
+  Add(5, 1U, "1", "2", 500U);
+  Add(5, 2U, "3", "4", 550U);
+  Add(4, 3U, "3", "4", 550U);
   Add(3, 4U, "3", "4", 250U);
   Add(3, 5U, "5", "7", 300U);
   vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
@@ -251,11 +276,23 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic) {
   ASSERT_EQ(vstorage_.MaxBytesForLevel(4), 1005U);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(3), 1000U);
   ASSERT_EQ(vstorage_.base_level(), 3);
+}
 
+TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_5) {
+  ioptions_.level_compaction_dynamic_level_bytes = true;
+  mutable_cf_options_.max_bytes_for_level_base = 1000;
+  mutable_cf_options_.max_bytes_for_level_multiplier = 5;
+
+  Add(5, 1U, "1", "2", 500U);
+  Add(5, 2U, "3", "4", 550U);
+  Add(4, 3U, "3", "4", 550U);
+  Add(3, 4U, "3", "4", 250U);
+  Add(3, 5U, "5", "7", 300U);
   Add(1, 6U, "3", "4", 5U);
   Add(1, 7U, "8", "9", 5U);
-  logger_->log_count = 0;
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(1, logger_->log_count);
   ASSERT_GT(vstorage_.MaxBytesForLevel(4), 1005U);
   ASSERT_GT(vstorage_.MaxBytesForLevel(3), 1005U);

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -179,7 +179,7 @@ class VersionStorageInfoTestBase : public testing::Test {
   }
 
   void UpdateVersionStorageInfo() {
-    vstorage_.PrepareAppend(ioptions_, mutable_cf_options_);
+    vstorage_.PrepareForVersionAppend(ioptions_, mutable_cf_options_);
     vstorage_.SetFinalized();
   }
 

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -210,10 +210,12 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelStatic) {
   ioptions_.level_compaction_dynamic_level_bytes = false;
   mutable_cf_options_.max_bytes_for_level_base = 10;
   mutable_cf_options_.max_bytes_for_level_multiplier = 5;
+
   Add(4, 100U, "1", "2", 100U);
   Add(5, 101U, "1", "2", 100U);
 
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(vstorage_.MaxBytesForLevel(1), 10U);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(2), 50U);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(3), 250U);
@@ -229,7 +231,8 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_1) {
 
   Add(5, 1U, "1", "2", 500U);
 
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(vstorage_.base_level(), 5);
 }
@@ -241,7 +244,9 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_2) {
 
   Add(5, 1U, "1", "2", 500U);
   Add(5, 2U, "3", "4", 550U);
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(4), 1000U);
   ASSERT_EQ(vstorage_.base_level(), 4);
@@ -255,7 +260,9 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_3) {
   Add(5, 1U, "1", "2", 500U);
   Add(5, 2U, "3", "4", 550U);
   Add(4, 3U, "3", "4", 550U);
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(4), 1000U);
   ASSERT_EQ(vstorage_.base_level(), 4);
@@ -271,7 +278,9 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamic_4) {
   Add(4, 3U, "3", "4", 550U);
   Add(3, 4U, "3", "4", 250U);
   Add(3, 5U, "5", "7", 300U);
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(1, logger_->log_count);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(4), 1005U);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(3), 1000U);
@@ -305,6 +314,7 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamicLotsOfData) {
   ioptions_.level_compaction_dynamic_level_bytes = true;
   mutable_cf_options_.max_bytes_for_level_base = 100;
   mutable_cf_options_.max_bytes_for_level_multiplier = 2;
+
   Add(0, 1U, "1", "2", 50U);
   Add(1, 2U, "1", "2", 50U);
   Add(2, 3U, "1", "2", 500U);
@@ -312,7 +322,8 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamicLotsOfData) {
   Add(4, 5U, "1", "2", 1700U);
   Add(5, 6U, "1", "2", 500U);
 
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(vstorage_.MaxBytesForLevel(4), 800U);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(3), 400U);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(2), 200U);
@@ -326,12 +337,14 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamicLargeLevel) {
   ioptions_.level_compaction_dynamic_level_bytes = true;
   mutable_cf_options_.max_bytes_for_level_base = 10U * kOneGB;
   mutable_cf_options_.max_bytes_for_level_multiplier = 10;
+
   Add(0, 1U, "1", "2", 50U);
   Add(3, 4U, "1", "2", 32U * kOneGB);
   Add(4, 5U, "1", "2", 500U * kOneGB);
   Add(5, 6U, "1", "2", 3000U * kOneGB);
 
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(vstorage_.MaxBytesForLevel(5), 3000U * kOneGB);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(4), 300U * kOneGB);
   ASSERT_EQ(vstorage_.MaxBytesForLevel(3), 30U * kOneGB);
@@ -355,7 +368,8 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamicWithLargeL0_1) {
   Add(3, 6U, "1", "2", 40000U);
   Add(2, 7U, "1", "2", 8000U);
 
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(2, vstorage_.base_level());
   // level multiplier should be 3.5
@@ -381,7 +395,8 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamicWithLargeL0_2) {
   Add(3, 6U, "1", "2", 40000U);
   Add(2, 7U, "1", "2", 8000U);
 
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(2, vstorage_.base_level());
   // level multiplier should be 3.5
@@ -413,7 +428,8 @@ TEST_F(VersionStorageInfoTest, MaxBytesForLevelDynamicWithLargeL0_3) {
   Add(3, 6U, "1", "2", 40000U);
   Add(2, 7U, "1", "2", 8000U);
 
-  vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(0, logger_->log_count);
   ASSERT_EQ(2, vstorage_.base_level());
   // level multiplier should be 3.5
@@ -436,6 +452,9 @@ TEST_F(VersionStorageInfoTest, EstimateLiveDataSize) {
   Add(4, 5U, "4", "5", 1U);  // Inside range of last level
   Add(4, 6U, "6", "7", 1U);  // Inside range of last level
   Add(5, 7U, "4", "7", 10U);
+
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(10U, vstorage_.EstimateLiveDataSize());
 }
 
@@ -447,6 +466,9 @@ TEST_F(VersionStorageInfoTest, EstimateLiveDataSize2) {
   Add(1, 5U, "5", "6", 1U);
   Add(2, 6U, "2", "3", 1U);
   Add(3, 7U, "7", "8", 1U);
+
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(4U, vstorage_.EstimateLiveDataSize());
 }
 
@@ -460,8 +482,8 @@ TEST_F(VersionStorageInfoTest, GetOverlappingInputs) {
   // Two files that do not overlap.
   Add(1, 5U, {"g", 0, kTypeValue}, {"h", 0, kTypeValue}, 1);
   Add(1, 6U, {"i", 0, kTypeValue}, {"j", 0, kTypeValue}, 1);
-  vstorage_.UpdateNumNonEmptyLevels();
-  vstorage_.GenerateLevelFilesBrief();
+
+  UpdateVersionStorageInfo();
 
   ASSERT_EQ("1,2", GetOverlappingFiles(
       1, {"a", 0, kTypeValue}, {"b", 0, kTypeValue}));
@@ -488,6 +510,8 @@ TEST_F(VersionStorageInfoTest, FileLocationAndMetaDataByNumber) {
   Add(0, 12U, "1", "2", 5000U);
 
   Add(2, 7U, "1", "2", 8000U);
+
+  UpdateVersionStorageInfo();
 
   ASSERT_EQ(vstorage_.GetFileLocation(11U),
             VersionStorageInfo::FileLocation(0, 0));
@@ -707,8 +731,9 @@ TEST_F(VersionStorageInfoTimestampTest, GetOverlappingInputs) {
       /*largest=*/
       {PackUserKeyAndTimestamp("d", /*ts=*/1), /*s=*/0, kTypeValue},
       /*file_size=*/100);
-  vstorage_.UpdateNumNonEmptyLevels();
-  vstorage_.GenerateLevelFilesBrief();
+
+  UpdateVersionStorageInfo();
+
   ASSERT_EQ(
       "1,2",
       GetOverlappingFiles(

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -178,15 +178,8 @@ class VersionStorageInfoTestBase : public testing::Test {
     vstorage_.AddBlobFile(std::move(meta));
   }
 
-  void Finalize() {
-    vstorage_.UpdateNumNonEmptyLevels();
-    vstorage_.CalculateBaseBytes(ioptions_, mutable_cf_options_);
-    vstorage_.UpdateFilesByCompactionPri(ioptions_, mutable_cf_options_);
-    vstorage_.GenerateFileIndexer();
-    vstorage_.GenerateLevelFilesBrief();
-    vstorage_.GenerateLevel0NonOverlapping();
-    vstorage_.GenerateBottommostFiles();
-
+  void UpdateVersionStorageInfo() {
+    vstorage_.PrepareAppend(ioptions_, mutable_cf_options_);
     vstorage_.SetFinalized();
   }
 
@@ -477,7 +470,7 @@ TEST_F(VersionStorageInfoTest, FileLocationAndMetaDataByNumber) {
 
 TEST_F(VersionStorageInfoTest, ForcedBlobGCEmpty) {
   // No SST or blob files in VersionStorageInfo
-  Finalize();
+  UpdateVersionStorageInfo();
 
   constexpr double age_cutoff = 0.5;
   constexpr double force_threshold = 0.75;
@@ -573,7 +566,7 @@ TEST_F(VersionStorageInfoTest, ForcedBlobGC) {
             garbage_blob_bytes);
   }
 
-  Finalize();
+  UpdateVersionStorageInfo();
 
   assert(vstorage_.num_levels() > 0);
   const auto& level_files = vstorage_.LevelFiles(level);

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -788,7 +788,7 @@ TEST_F(LdbCmdTest, DisableConsistencyChecks) {
     char* argv[] = {arg1, arg2, arg3};
 
     SyncPoint::GetInstance()->SetCallBack(
-        "Version::PrepareApply:forced_check", [&](void* arg) {
+        "Version::PrepareAppend:forced_check", [&](void* arg) {
           bool* forced = reinterpret_cast<bool*>(arg);
           ASSERT_TRUE(*forced);
         });
@@ -808,7 +808,7 @@ TEST_F(LdbCmdTest, DisableConsistencyChecks) {
     char* argv[] = {arg1, arg2, arg3};
 
     SyncPoint::GetInstance()->SetCallBack(
-        "Version::PrepareApply:forced_check", [&](void* arg) {
+        "Version::PrepareAppend:forced_check", [&](void* arg) {
           bool* forced = reinterpret_cast<bool*>(arg);
           ASSERT_TRUE(*forced);
         });


### PR DESCRIPTION
Summary:
The patch does some cleanup in and around `VersionStorageInfo`:
* Renames the method `PrepareApply` to `PrepareAppend` in `Version`
to make it clear that it is to be called before appending the `Version` to
`VersionSet` (via `AppendVersion`), not before applying any `VersionEdit`s.
* Introduces a helper method `VersionStorageInfo::PrepareForVersionAppend`
(called by `Version::PrepareAppend`) that encapsulates the population of the
various derived data structures in `VersionStorageInfo`, and turns the
methods computing the derived structures (`UpdateNumNonEmptyLevels`,
`CalculateBaseBytes` etc.) into private helpers.
* Changes `Version::PrepareAppend` so it only calls `UpdateAccumulatedStats`
if the `update_stats` flag is set. (Earlier, this was checked by the callee.)
Related to this, it also moves the call to `ComputeCompensatedSizes` to
`VersionStorageInfo::PrepareForVersionAppend`.
* Updates and cleans up `version_builder_test`, `version_set_test`, and
`compaction_picker_test` so `PrepareForVersionAppend` is called anytime
a new `VersionStorageInfo` is set up or saved. This cleanup also involves
splitting `VersionStorageInfoTest.MaxBytesForLevelDynamic`
into multiple smaller test cases.
* Fixes up a bunch of comments that were outdated or just plain incorrect.

Test Plan:
Ran `make check` and the crash test script for a while.