### PR TITLE
Fix flaky test EnvPosixTestWithParam.RunMany

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -459,6 +459,14 @@ TEST_P(EnvPosixTestWithParam, RunMany) {
   env_->Schedule(&CB::Run, &cb2);
   env_->Schedule(&CB::Run, &cb3);
   env_->Schedule(&CB::Run, &cb4);
+  // thread-pool pops a thread function and then run the function, which may
+  // cause threadpool is empty but the last function is still running. Add a
+  // dummy function at the end, to make sure the last callback is finished
+  // before threadpool is empty.
+  struct DummyCB {
+    static void Run(void*) {}
+  };
+  env_->Schedule(&DummyCB::Run, nullptr);
 
   WaitThreadPoolsEmpty();
   ASSERT_EQ(4, last_id.load(std::memory_order_acquire));


### PR DESCRIPTION
Summary: Thread-pool pops a thread function and then run the function,
which may cause thread-pool is empty but the last function is still
running.

Test Plan: `gtest-parallel ./env_test
--gtest_filter=DefaultEnvWithoutDirectIO/EnvPosixTestWithParam.RunMany/0
-r 10000 -w 1000`