### PR TITLE
Clarify Google benchmark < 1.6.0 in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,8 @@ to build a portable binary, add `PORTABLE=1` before your make commands, like thi
 
 * If you wish to build the RocksJava static target, then cmake is required for building Snappy.
 
+* If you wish to run microbench (e.g, `make microbench`, `make ribbon_bench` or `cmake -DWITH_BENCHMARK=1`), Google benchmark < 1.6.0 is needed.
+
 ## Supported platforms
 
 * **Linux - Ubuntu**


### PR DESCRIPTION
**Context:** 
Google benchmark [v1.6.0](https://github.com/google/benchmark/releases/tag/v1.6.0) introduced a breaking change "`introduce accessorrs for public data members (https://github.com/google/benchmark/pull/1208)`" that will fail RocksDB build of microbench developed based on previous code. For example, https://github.com/facebook/rocksdb/issues/9489. 

**Summary:** 
Clarify the maximum version of Google benchmark needed.

**Test:**
CI