### PR TITLE
Temporary disable Travis s390x Makefile build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,10 @@ matrix:
     compiler: clang
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
+    arch: s390x # Temporary while working through gcc-7 + assembler issue
+    env: TEST_GROUP=platform_dependent
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
+    os: linux
     arch: arm64
     env: TEST_GROUP=platform_dependent
   - if: type = pull_request AND commit_message !~ /FULL_CI/


### PR DESCRIPTION
Summary: Due to some unexplained errors with gcc-7

```
Assembler messages:
Error: invalid switch -march=z14
Error: unrecognized option -march=z14
```

Test Plan: CI