### PR TITLE
Work around some new clang-analyze failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1221,7 +1221,7 @@ analyze_incremental:
 	$(CLANG_SCAN_BUILD) --use-analyzer=$(CLANG_ANALYZER) \
 		--use-c++=$(CXX) --use-cc=$(CC) --status-bugs \
 		-o $(CURDIR)/scan_build_report \
-		$(MAKE) dbg
+		$(MAKE) SKIP_LINK=1 dbg
 
 CLEAN_FILES += unity.cc
 unity.cc: Makefile util/build_version.cc.in

--- a/include/rocksdb/io_status.h
+++ b/include/rocksdb/io_status.h
@@ -171,7 +171,7 @@ inline IOStatus::IOStatus(Code _code, SubCode _subcode, const Slice& msg,
     memcpy(result + len1 + 2, msg2.data(), len2);
   }
   result[size] = '\0';  // null terminator for C style string
-  state_ = result;
+  state_.reset(result);
 }
 
 inline IOStatus::IOStatus(const IOStatus& s) : Status(s.code_, s.subcode_) {
@@ -181,7 +181,7 @@ inline IOStatus::IOStatus(const IOStatus& s) : Status(s.code_, s.subcode_) {
   retryable_ = s.retryable_;
   data_loss_ = s.data_loss_;
   scope_ = s.scope_;
-  state_ = (s.state_ == nullptr) ? nullptr : CopyState(s.state_);
+  state_ = (s.state_ == nullptr) ? nullptr : CopyState(s.state_.get());
 }
 inline IOStatus& IOStatus::operator=(const IOStatus& s) {
   // The following condition catches both aliasing (when this == &s),
@@ -196,8 +196,7 @@ inline IOStatus& IOStatus::operator=(const IOStatus& s) {
     retryable_ = s.retryable_;
     data_loss_ = s.data_loss_;
     scope_ = s.scope_;
-    delete[] state_;
-    state_ = (s.state_ == nullptr) ? nullptr : CopyState(s.state_);
+    state_ = (s.state_ == nullptr) ? nullptr : CopyState(s.state_.get());
   }
   return *this;
 }
@@ -228,9 +227,7 @@ inline IOStatus& IOStatus::operator=(IOStatus&& s)
     data_loss_ = s.data_loss_;
     scope_ = s.scope_;
     s.scope_ = kIOErrorScopeFileSystem;
-    delete[] state_;
-    state_ = nullptr;
-    std::swap(state_, s.state_);
+    state_ = std::move(s.state_);
   }
   return *this;
 }

--- a/third-party/gtest-1.8.1/fused-src/gtest/gtest.h
+++ b/third-party/gtest-1.8.1/fused-src/gtest/gtest.h
@@ -53,6 +53,7 @@
 #define GTEST_INCLUDE_GTEST_GTEST_H_
 
 #include <limits>
+#include <memory>
 #include <ostream>
 #include <vector>
 
@@ -2442,6 +2443,10 @@ GTEST_API_ bool IsTrue(bool condition);
 
 // Defines scoped_ptr.
 
+// RocksDB: use unique_ptr to work around some clang-analyze false reports
+template <typename T>
+using scoped_ptr = std::unique_ptr<T>;
+/*
 // This implementation of scoped_ptr is PARTIAL - it only contains
 // enough stuff to satisfy Google Test's need.
 template <typename T>
@@ -2481,6 +2486,7 @@ class scoped_ptr {
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(scoped_ptr);
 };
+*/
 
 // Defines RE.
 

--- a/util/status.cc
+++ b/util/status.cc
@@ -17,24 +17,11 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-const char* Status::CopyState(const char* state) {
-#ifdef OS_WIN
-  const size_t cch = std::strlen(state) + 1;  // +1 for the null terminator
-  char* result = new char[cch];
-  errno_t ret
-#if defined(_MSC_VER)
-    ;
-#else
-    __attribute__((__unused__));
-#endif
-  ret = strncpy_s(result, cch, state, cch - 1);
-  result[cch - 1] = '\0';
-  assert(ret == 0);
-  return result;
-#else
-  const size_t cch = std::strlen(state) + 1;  // +1 for the null terminator
-  return std::strncpy(new char[cch], state, cch);
-#endif
+std::unique_ptr<const char[]> Status::CopyState(const char* s) {
+  const size_t cch = std::strlen(s) + 1;  // +1 for the null terminator
+  char* rv = new char[cch];
+  std::strncpy(rv, s, cch);
+  return std::unique_ptr<const char[]>(rv);
 }
 
 static const char* msgs[static_cast<int>(Status::kMaxSubCode)] = {
@@ -72,7 +59,7 @@ Status::Status(Code _code, SubCode _subcode, const Slice& msg,
     memcpy(result + len1 + 2, msg2.data(), len2);
   }
   result[size] = '\0';  // null terminator for C style string
-  state_ = result;
+  state_.reset(result);
 }
 
 std::string Status::ToString() const {
@@ -152,7 +139,7 @@ std::string Status::ToString() const {
     if (subcode_ != kNone) {
       result.append(": ");
     }
-    result.append(state_);
+    result.append(state_.get());
   }
   return result;
 }

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -185,6 +185,7 @@ class TtlTest : public testing::Test {
 
   // Runs a manual compaction
   Status ManualCompact(ColumnFamilyHandle* cf = nullptr) {
+    assert(db_ttl_);
     if (cf == nullptr) {
       return db_ttl_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
     } else {


### PR DESCRIPTION
Summary: ... seen only in internal clang-analyze runs after #9481

* Mostly, this works around falsely reported leaks by using
std::unique_ptr in some places where clang-analyze was getting
confused. (I didn't see any changes in C++17 that could make our Status
implementation leak memory.) 
* Also fixed SetBGError returning address of a stack variable.
* Also fixed another false null deref report by adding an assert.

Also, use SKIP_LINK=1 to speed up `make analyze`

Test Plan: Was able to reproduce the reported errors locally and verify
they're fixed (except SetBGError). Otherwise, existing tests