### PR TITLE
Work around snappy linker issue with newer compilers

### DIFF
--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -45,6 +45,10 @@ else
 fi
 git fetch $tmp_origin
 
+# Used in building some ancient RocksDB versions where by default it tries to
+# use a precompiled libsnappy.a checked in to the repo.
+export SNAPPY_LDFLAGS=-lsnappy
+
 cleanup() {
   echo "== Cleaning up"
   git reset --hard || true


### PR DESCRIPTION
Summary: After #9481, we are using newer default compiler for
build-format-compatible CircleCI nightly job, which fails on building
2.2.fb.branch branch because it tries to use a pre-compiled libsnappy.a
that is checked into the repo (!). This works around that by setting
SNAPPY_LDFLAGS=-lsnappy, which is only understood by such old versions.

Test Plan: Run check_format_compatible.sh on Ubuntu 20 AWS machine,
watch nightly run