### PR TITLE
Use a sorted vector instead of a map to store blob file metadata

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 ### Performance Improvements
 * Mitigated the overhead of building the file location hash table used by the online LSM tree consistency checks, which can improve performance for certain workloads (see #9351).
+* Switched to using a sorted `std::vector` instead of `std::map` for storing the metadata objects for blob files, which can improve performance for certain workloads, especially when the number of blob files is high.
 
 ### Public API changes
 * Require C++17 compatible compiler (GCC >= 7, Clang >= 5, Visual Studio >= 2017). See #9388.

--- a/db/blob/db_blob_compaction_test.cc
+++ b/db/blob/db_blob_compaction_test.cc
@@ -512,8 +512,7 @@ TEST_F(DBBlobCompactionTest, TrackGarbage) {
   ASSERT_EQ(blob_files.size(), 2);
 
   {
-    auto it = blob_files.begin();
-    const auto& meta = it->second;
+    const auto& meta = blob_files.front();
     assert(meta);
 
     constexpr uint64_t first_expected_bytes =
@@ -543,8 +542,7 @@ TEST_F(DBBlobCompactionTest, TrackGarbage) {
   }
 
   {
-    auto it = blob_files.rbegin();
-    const auto& meta = it->second;
+    const auto& meta = blob_files.back();
     assert(meta);
 
     constexpr uint64_t new_first_expected_bytes =

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -1168,7 +1168,9 @@ uint64_t CompactionIterator::ComputeBlobGarbageCollectionCutoffFileNumber(
   std::advance(
       it, compaction->blob_garbage_collection_age_cutoff() * blob_files.size());
 
-  return it != blob_files.end() ? it->first
+  assert(it == blob_files.end() || *it);
+
+  return it != blob_files.end() ? (*it)->GetBlobFileNumber()
                                 : std::numeric_limits<uint64_t>::max();
 }
 

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -1164,14 +1164,17 @@ uint64_t CompactionIterator::ComputeBlobGarbageCollectionCutoffFileNumber(
 
   const auto& blob_files = storage_info->GetBlobFiles();
 
-  auto it = blob_files.begin();
-  std::advance(
-      it, compaction->blob_garbage_collection_age_cutoff() * blob_files.size());
+  const size_t cutoff_index = static_cast<size_t>(
+      compaction->blob_garbage_collection_age_cutoff() * blob_files.size());
 
-  assert(it == blob_files.end() || *it);
+  if (cutoff_index >= blob_files.size()) {
+    return std::numeric_limits<uint64_t>::max();
+  }
 
-  return it != blob_files.end() ? (*it)->GetBlobFileNumber()
-                                : std::numeric_limits<uint64_t>::max();
+  const auto& meta = blob_files[cutoff_index];
+  assert(meta);
+
+  return meta->GetBlobFileNumber();
 }
 
 std::unique_ptr<BlobFetcher> CompactionIterator::CreateBlobFetcherIfNeeded(

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -963,11 +963,14 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
 
   const auto& blob_files = vstorage->GetBlobFiles();
   if (!blob_files.empty()) {
-    ROCKS_LOG_BUFFER(log_buffer_,
-                     "[%s] Blob file summary: head=%" PRIu64 ", tail=%" PRIu64
-                     "\n",
-                     column_family_name.c_str(), blob_files.begin()->first,
-                     blob_files.rbegin()->first);
+    assert(blob_files.front());
+    assert(blob_files.back());
+
+    ROCKS_LOG_BUFFER(
+        log_buffer_,
+        "[%s] Blob file summary: head=%" PRIu64 ", tail=%" PRIu64 "\n",
+        column_family_name.c_str(), blob_files.front()->GetBlobFileNumber(),
+        blob_files.back()->GetBlobFileNumber());
   }
 
   UpdateCompactionJobStats(stats);
@@ -1014,8 +1017,11 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
   stream.EndArray();
 
   if (!blob_files.empty()) {
-    stream << "blob_file_head" << blob_files.begin()->first;
-    stream << "blob_file_tail" << blob_files.rbegin()->first;
+    assert(blob_files.front());
+    stream << "blob_file_head" << blob_files.front()->GetBlobFileNumber();
+
+    assert(blob_files.back());
+    stream << "blob_file_tail" << blob_files.back()->GetBlobFileNumber();
   }
 
   CleanupCompaction();

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -6065,7 +6065,7 @@ TEST_F(DBCompactionTest, CompactionWithBlob) {
   const auto& blob_files = storage_info->GetBlobFiles();
   ASSERT_EQ(blob_files.size(), 1);
 
-  const auto& blob_file = blob_files.begin()->second;
+  const auto& blob_file = blob_files.front();
   ASSERT_NE(blob_file, nullptr);
 
   ASSERT_EQ(table_file->smallest.user_key(), first_key);

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -267,7 +267,7 @@ Status DBImpl::GetLiveFilesStorageInfo(
       LiveFileStorageInfo& info = results.back();
 
       info.relative_filename = BlobFileName(meta->GetBlobFileNumber());
-      info.directory = GetName();  // TODO?: support db_paths/cf_paths
+      info.directory = GetDir(/* path_id */ 0);
       info.file_number = meta->GetBlobFileNumber();
       info.file_type = kBlobFile;
       info.size = meta->GetBlobFileSize();

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -260,8 +260,7 @@ Status DBImpl::GetLiveFilesStorageInfo(
       }
     }
     const auto& blob_files = vsi.GetBlobFiles();
-    for (const auto& pair : blob_files) {
-      const auto& meta = pair.second;
+    for (const auto& meta : blob_files) {
       assert(meta);
 
       results.emplace_back();

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -1629,7 +1629,7 @@ TEST_F(DBFlushTest, FlushWithBlob) {
   const auto& blob_files = storage_info->GetBlobFiles();
   ASSERT_EQ(blob_files.size(), 1);
 
-  const auto& blob_file = blob_files.begin()->second;
+  const auto& blob_file = blob_files.front();
   assert(blob_file);
 
   ASSERT_EQ(table_file->smallest.user_key(), "key1");

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5110,6 +5110,7 @@ Status DBImpl::VerifyChecksumInternal(const ReadOptions& read_options,
       const auto& blob_files = vstorage->GetBlobFiles();
       for (const auto& meta : blob_files) {
         assert(meta);
+
         const uint64_t blob_file_number = meta->GetBlobFileNumber();
 
         const std::string blob_file_name = BlobFileName(

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5108,10 +5108,10 @@ Status DBImpl::VerifyChecksumInternal(const ReadOptions& read_options,
 
     if (s.ok() && use_file_checksum) {
       const auto& blob_files = vstorage->GetBlobFiles();
-      for (const auto& pair : blob_files) {
-        const uint64_t blob_file_number = pair.first;
-        const auto& meta = pair.second;
+      for (const auto& meta : blob_files) {
         assert(meta);
+        const uint64_t blob_file_number = meta->GetBlobFileNumber();
+
         const std::string blob_file_name = BlobFileName(
             cfd->ioptions()->cf_paths.front().path, blob_file_number);
         s = VerifyFullFileChecksum(meta->GetChecksumValue(),

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -265,11 +265,14 @@ Status DBImpl::FlushMemTableToOutputFile(
 
     const auto& blob_files = storage_info->GetBlobFiles();
     if (!blob_files.empty()) {
-      ROCKS_LOG_BUFFER(log_buffer,
-                       "[%s] Blob file summary: head=%" PRIu64 ", tail=%" PRIu64
-                       "\n",
-                       column_family_name.c_str(), blob_files.begin()->first,
-                       blob_files.rbegin()->first);
+      assert(blob_files.front());
+      assert(blob_files.back());
+
+      ROCKS_LOG_BUFFER(
+          log_buffer,
+          "[%s] Blob file summary: head=%" PRIu64 ", tail=%" PRIu64 "\n",
+          column_family_name.c_str(), blob_files.front()->GetBlobFileNumber(),
+          blob_files.back()->GetBlobFileNumber());
     }
   }
 
@@ -706,11 +709,14 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
 
       const auto& blob_files = storage_info->GetBlobFiles();
       if (!blob_files.empty()) {
-        ROCKS_LOG_BUFFER(log_buffer,
-                         "[%s] Blob file summary: head=%" PRIu64
-                         ", tail=%" PRIu64 "\n",
-                         column_family_name.c_str(), blob_files.begin()->first,
-                         blob_files.rbegin()->first);
+        assert(blob_files.front());
+        assert(blob_files.back());
+
+        ROCKS_LOG_BUFFER(
+            log_buffer,
+            "[%s] Blob file summary: head=%" PRIu64 ", tail=%" PRIu64 "\n",
+            column_family_name.c_str(), blob_files.front()->GetBlobFileNumber(),
+            blob_files.back()->GetBlobFileNumber());
       }
     }
     if (made_progress) {

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -76,7 +76,7 @@ void DBImpl::TEST_GetFilesMetaData(
   if (blob_metadata != nullptr) {
     blob_metadata->clear();
     for (const auto& blob : cfd->current()->storage_info()->GetBlobFiles()) {
-      blob_metadata->push_back(blob.second);
+      blob_metadata->push_back(blob);
     }
   }
 }

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -60,24 +60,37 @@ void DBImpl::TEST_GetFilesMetaData(
     ColumnFamilyHandle* column_family,
     std::vector<std::vector<FileMetaData>>* metadata,
     std::vector<std::shared_ptr<BlobFileMetaData>>* blob_metadata) {
+  assert(metadata);
+
   auto cfh = static_cast_with_check<ColumnFamilyHandleImpl>(column_family);
+  assert(cfh);
+
   auto cfd = cfh->cfd();
+  assert(cfd);
+
   InstrumentedMutexLock l(&mutex_);
+
+  const auto* current = cfd->current();
+  assert(current);
+
+  const auto* vstorage = current->storage_info();
+  assert(vstorage);
+
   metadata->resize(NumberLevels());
-  for (int level = 0; level < NumberLevels(); level++) {
-    const std::vector<FileMetaData*>& files =
-        cfd->current()->storage_info()->LevelFiles(level);
+
+  for (int level = 0; level < NumberLevels(); ++level) {
+    const std::vector<FileMetaData*>& files = vstorage->LevelFiles(level);
 
     (*metadata)[level].clear();
+    (*metadata)[level].reserve(files.size());
+
     for (const auto& f : files) {
       (*metadata)[level].push_back(*f);
     }
   }
-  if (blob_metadata != nullptr) {
-    blob_metadata->clear();
-    for (const auto& blob : cfd->current()->storage_info()->GetBlobFiles()) {
-      blob_metadata->push_back(blob);
-    }
+
+  if (blob_metadata) {
+    *blob_metadata = vstorage->GetBlobFiles();
   }
 }
 

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -1145,7 +1145,8 @@ std::vector<uint64_t> DBTestBase::GetBlobFileNumbers() {
   result.reserve(blob_files.size());
 
   for (const auto& blob_file : blob_files) {
-    result.emplace_back(blob_file.first);
+    assert(blob_file);
+    result.emplace_back(blob_file->GetBlobFileNumber());
   }
 
   return result;

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -433,7 +433,7 @@ TEST_F(DBWALTest, RecoverWithBlob) {
   const auto& blob_files = storage_info->GetBlobFiles();
   ASSERT_EQ(blob_files.size(), 1);
 
-  const auto& blob_file = blob_files.begin()->second;
+  const auto& blob_file = blob_files.front();
   ASSERT_NE(blob_file, nullptr);
 
   ASSERT_EQ(table_file->smallest.user_key(), "key1");

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -312,8 +312,11 @@ Status FlushJob::Run(LogsWithPrepTracker* prep_tracker, FileMetaData* file_meta,
 
   const auto& blob_files = vstorage->GetBlobFiles();
   if (!blob_files.empty()) {
-    stream << "blob_file_head" << blob_files.begin()->first;
-    stream << "blob_file_tail" << blob_files.rbegin()->first;
+    assert(blob_files.front());
+    stream << "blob_file_head" << blob_files.front()->GetBlobFileNumber();
+
+    assert(blob_files.back());
+    stream << "blob_file_tail" << blob_files.back()->GetBlobFileNumber();
   }
 
   stream << "immutable_memtables" << cfd_->imm()->NumNotFlushed();

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -757,9 +757,15 @@ bool InternalStats::HandleLiveSstFilesSizeAtTemperature(std::string* value,
 
 bool InternalStats::HandleNumBlobFiles(uint64_t* value, DBImpl* /*db*/,
                                        Version* /*version*/) {
+  assert(cfd_);
+  assert(cfd_->current());
+
   const auto* vstorage = cfd_->current()->storage_info();
+  assert(vstorage);
+
   const auto& blob_files = vstorage->GetBlobFiles();
   *value = blob_files.size();
+
   return true;
 }
 
@@ -770,8 +776,9 @@ bool InternalStats::HandleBlobStats(std::string* value, Slice /*suffix*/) {
   uint64_t current_num_blob_files = blob_files.size();
   uint64_t current_file_size = 0;
   uint64_t current_garbage_size = 0;
-  for (const auto& pair : blob_files) {
-    const auto& meta = pair.second;
+  for (const auto& meta : blob_files) {
+    assert(meta);
+
     current_file_size += meta->GetBlobFileSize();
     current_garbage_size += meta->GetGarbageBlobBytes();
   }

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -758,48 +758,74 @@ bool InternalStats::HandleLiveSstFilesSizeAtTemperature(std::string* value,
 bool InternalStats::HandleNumBlobFiles(uint64_t* value, DBImpl* /*db*/,
                                        Version* /*version*/) {
   assert(cfd_);
-  assert(cfd_->current());
 
-  const auto* vstorage = cfd_->current()->storage_info();
+  const auto* current = cfd_->current();
+  assert(current);
+
+  const auto* vstorage = current->storage_info();
   assert(vstorage);
 
   const auto& blob_files = vstorage->GetBlobFiles();
+
   *value = blob_files.size();
 
   return true;
 }
 
 bool InternalStats::HandleBlobStats(std::string* value, Slice /*suffix*/) {
-  std::ostringstream oss;
-  auto* current_version = cfd_->current();
-  const auto& blob_files = current_version->storage_info()->GetBlobFiles();
-  uint64_t current_num_blob_files = blob_files.size();
-  uint64_t current_file_size = 0;
-  uint64_t current_garbage_size = 0;
+  assert(cfd_);
+
+  const auto* current = cfd_->current();
+  assert(current);
+
+  const auto* vstorage = current->storage_info();
+  assert(vstorage);
+
+  const auto& blob_files = vstorage->GetBlobFiles();
+
+  uint64_t total_file_size = 0;
+  uint64_t total_garbage_size = 0;
+
   for (const auto& meta : blob_files) {
     assert(meta);
 
-    current_file_size += meta->GetBlobFileSize();
-    current_garbage_size += meta->GetGarbageBlobBytes();
+    total_file_size += meta->GetBlobFileSize();
+    total_garbage_size += meta->GetGarbageBlobBytes();
   }
-  oss << "Number of blob files: " << current_num_blob_files
-      << "\nTotal size of blob files: " << current_file_size
-      << "\nTotal size of garbage in blob files: " << current_garbage_size
+
+  std::ostringstream oss;
+
+  oss << "Number of blob files: " << blob_files.size()
+      << "\nTotal size of blob files: " << total_file_size
+      << "\nTotal size of garbage in blob files: " << total_garbage_size
       << '\n';
+
   value->append(oss.str());
+
   return true;
 }
 
 bool InternalStats::HandleTotalBlobFileSize(uint64_t* value, DBImpl* /*db*/,
                                             Version* /*version*/) {
+  assert(cfd_);
+
   *value = cfd_->GetTotalBlobFileSize();
+
   return true;
 }
 
 bool InternalStats::HandleLiveBlobFileSize(uint64_t* value, DBImpl* /*db*/,
                                            Version* /*version*/) {
-  const auto* vstorage = cfd_->current()->storage_info();
+  assert(cfd_);
+
+  const auto* current = cfd_->current();
+  assert(current);
+
+  const auto* vstorage = current->storage_info();
+  assert(vstorage);
+
   *value = vstorage->GetTotalBlobFileSize();
+
   return true;
 }
 

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -1256,26 +1256,7 @@ class BlobDBJobLevelEventListenerTest : public EventListener {
   explicit BlobDBJobLevelEventListenerTest(EventListenerTest* test)
       : test_(test), call_count_(0) {}
 
-  static std::shared_ptr<BlobFileMetaData> GetBlobFileMetaData(
-      const VersionStorageInfo::BlobFiles& blob_files,
-      uint64_t blob_file_number) {
-    const auto it = std::lower_bound(
-        blob_files.begin(), blob_files.end(), blob_file_number,
-        [](const std::shared_ptr<BlobFileMetaData>& lhs, uint64_t rhs) {
-          assert(lhs);
-          return lhs->GetBlobFileNumber() < rhs;
-        });
-    assert(it == blob_files.end() || *it);
-
-    if (it == blob_files.end() ||
-        (*it)->GetBlobFileNumber() != blob_file_number) {
-      return std::shared_ptr<BlobFileMetaData>();
-    }
-
-    return *it;
-  }
-
-  const VersionStorageInfo::BlobFiles& GetBlobFiles() {
+  const VersionStorageInfo* GetVersionStorageInfo() const {
     VersionSet* const versions = test_->dbfull()->GetVersionSet();
     assert(versions);
 
@@ -1288,8 +1269,28 @@ class BlobDBJobLevelEventListenerTest : public EventListener {
     const VersionStorageInfo* const storage_info = current->storage_info();
     EXPECT_NE(storage_info, nullptr);
 
-    const auto& blob_files = storage_info->GetBlobFiles();
-    return blob_files;
+    return storage_info;
+  }
+
+  void CheckBlobFileAdditions(
+      const std::vector<BlobFileAdditionInfo>& blob_file_addition_infos) const {
+    const auto* vstorage = GetVersionStorageInfo();
+
+    EXPECT_FALSE(blob_file_addition_infos.empty());
+
+    for (const auto& blob_file_addition_info : blob_file_addition_infos) {
+      const auto meta = vstorage->GetBlobFileMetaData(
+          blob_file_addition_info.blob_file_number);
+
+      EXPECT_NE(meta, nullptr);
+      EXPECT_EQ(meta->GetBlobFileNumber(),
+                blob_file_addition_info.blob_file_number);
+      EXPECT_EQ(meta->GetTotalBlobBytes(),
+                blob_file_addition_info.total_blob_bytes);
+      EXPECT_EQ(meta->GetTotalBlobCount(),
+                blob_file_addition_info.total_blob_count);
+      EXPECT_FALSE(blob_file_addition_info.blob_file_path.empty());
+    }
   }
 
   std::vector<std::string> GetFlushedFiles() {
@@ -1303,46 +1304,28 @@ class BlobDBJobLevelEventListenerTest : public EventListener {
 
   void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
     call_count_++;
-    EXPECT_FALSE(info.blob_file_addition_infos.empty());
-    const auto& blob_files = GetBlobFiles();
+
     {
       std::lock_guard<std::mutex> lock(mutex_);
       flushed_files_.push_back(info.file_path);
     }
+
     EXPECT_EQ(info.blob_compression_type, kNoCompression);
 
-    for (const auto& blob_file_addition_info : info.blob_file_addition_infos) {
-      const auto meta = GetBlobFileMetaData(
-          blob_files, blob_file_addition_info.blob_file_number);
-      EXPECT_EQ(meta->GetBlobFileNumber(),
-                blob_file_addition_info.blob_file_number);
-      EXPECT_EQ(meta->GetTotalBlobBytes(),
-                blob_file_addition_info.total_blob_bytes);
-      EXPECT_EQ(meta->GetTotalBlobCount(),
-                blob_file_addition_info.total_blob_count);
-      EXPECT_FALSE(blob_file_addition_info.blob_file_path.empty());
-    }
+    CheckBlobFileAdditions(info.blob_file_addition_infos);
   }
 
-  void OnCompactionCompleted(DB* /*db*/, const CompactionJobInfo& ci) override {
+  void OnCompactionCompleted(DB* /*db*/,
+                             const CompactionJobInfo& info) override {
     call_count_++;
-    EXPECT_FALSE(ci.blob_file_garbage_infos.empty());
-    const auto& blob_files = GetBlobFiles();
-    EXPECT_EQ(ci.blob_compression_type, kNoCompression);
 
-    for (const auto& blob_file_addition_info : ci.blob_file_addition_infos) {
-      const auto meta = GetBlobFileMetaData(
-          blob_files, blob_file_addition_info.blob_file_number);
-      EXPECT_EQ(meta->GetBlobFileNumber(),
-                blob_file_addition_info.blob_file_number);
-      EXPECT_EQ(meta->GetTotalBlobBytes(),
-                blob_file_addition_info.total_blob_bytes);
-      EXPECT_EQ(meta->GetTotalBlobCount(),
-                blob_file_addition_info.total_blob_count);
-      EXPECT_FALSE(blob_file_addition_info.blob_file_path.empty());
-    }
+    EXPECT_EQ(info.blob_compression_type, kNoCompression);
 
-    for (const auto& blob_file_garbage_info : ci.blob_file_garbage_infos) {
+    CheckBlobFileAdditions(info.blob_file_addition_infos);
+
+    EXPECT_FALSE(info.blob_file_garbage_infos.empty());
+
+    for (const auto& blob_file_garbage_info : info.blob_file_garbage_infos) {
       EXPECT_GT(blob_file_garbage_info.blob_file_number, 0U);
       EXPECT_GT(blob_file_garbage_info.garbage_blob_count, 0U);
       EXPECT_GT(blob_file_garbage_info.garbage_blob_bytes, 0U);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -995,8 +995,6 @@ class VersionBuilder::Rep {
   void SaveBlobFilesTo(VersionStorageInfo* vstorage) const {
     assert(vstorage);
 
-    // TODO: make this tighter by considering the number of newly obsoleted blob
-    // files
     assert(base_vstorage_);
     vstorage->ReserveBlob(base_vstorage_->GetBlobFiles().size() +
                           mutable_blob_file_metas_.size());

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -995,6 +995,12 @@ class VersionBuilder::Rep {
   void SaveBlobFilesTo(VersionStorageInfo* vstorage) const {
     assert(vstorage);
 
+    // TODO: make this tighter by considering the number of newly obsoleted blob
+    // files
+    assert(base_vstorage_);
+    vstorage->ReserveBlob(base_vstorage_->GetBlobFiles().size() +
+                          mutable_blob_file_metas_.size());
+
     const uint64_t oldest_blob_file_with_linked_ssts =
         GetMinOldestBlobFileNumber();
 

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-#include <algorithm>
 #include <cstring>
 #include <iomanip>
 #include <memory>

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3050,11 +3050,9 @@ void VersionStorageInfo::AddBlobFile(
     std::shared_ptr<BlobFileMetaData> blob_file_meta) {
   assert(blob_file_meta);
 
-  const uint64_t blob_file_number = blob_file_meta->GetBlobFileNumber();
-
   assert(blob_files_.empty() ||
-         (blob_files_.back() &&
-          blob_files_.back()->GetBlobFileNumber() < blob_file_number));
+         (blob_files_.back() && blob_files_.back()->GetBlobFileNumber() <
+                                    blob_file_meta->GetBlobFileNumber()));
 
   blob_files_.emplace_back(std::move(blob_file_meta));
 }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3077,6 +3077,25 @@ void VersionStorageInfo::AddBlobFile(
   blob_files_.emplace_back(std::move(blob_file_meta));
 }
 
+VersionStorageInfo::BlobFiles::const_iterator
+VersionStorageInfo::GetBlobFileMetaDataImpl(uint64_t blob_file_number) const {
+  const auto it = std::lower_bound(
+      blob_files_.begin(), blob_files_.end(), blob_file_number,
+      [](const std::shared_ptr<BlobFileMetaData>& lhs, uint64_t rhs) {
+        assert(lhs);
+        return lhs->GetBlobFileNumber() < rhs;
+      });
+
+  assert(it == blob_files_.end() || *it);
+
+  if (it != blob_files_.end() &&
+      (*it)->GetBlobFileNumber() == blob_file_number) {
+    return it;
+  }
+
+  return blob_files_.end();
+}
+
 void VersionStorageInfo::SetFinalized() {
   finalized_ = true;
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3000,7 +3000,8 @@ void VersionStorageInfo::ComputeFilesMarkedForForcedBlobGC(
   uint64_t sum_total_blob_bytes = oldest_meta->GetTotalBlobBytes();
   uint64_t sum_garbage_blob_bytes = oldest_meta->GetGarbageBlobBytes();
 
-  for (const auto& meta : blob_files_) {
+  while (true) {
+    const auto& meta = blob_files_[count];
     assert(meta);
 
     if (!meta->GetLinkedSsts().empty()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5271,7 +5271,11 @@ Status VersionSet::GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) {
 
     /* SST files */
     for (int level = 0; level < cfd->NumberLevels(); level++) {
-      for (const auto& file : vstorage->LevelFiles(level)) {
+      const auto& level_files = vstorage->LevelFiles(level);
+
+      for (const auto& file : level_files) {
+        assert(file);
+
         s = checksum_list->InsertOneFileChecksum(file->fd.GetNumber(),
                                                  file->file_checksum,
                                                  file->file_checksum_func_name);
@@ -5438,7 +5442,11 @@ Status VersionSet::WriteCurrentStateToManifest(
       assert(vstorage);
 
       for (int level = 0; level < cfd->NumberLevels(); level++) {
-        for (const auto& f : vstorage->LevelFiles(level)) {
+        const auto& level_files = vstorage->LevelFiles(level);
+
+        for (const auto& f : level_files) {
+          assert(f);
+
           edit.AddFile(
               level, f->fd.GetNumber(), f->fd.GetPathId(), f->fd.GetFileSize(),
               f->smallest, f->largest, f->fd.smallest_seqno,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1491,8 +1491,9 @@ void Version::GetColumnFamilyMetaData(ColumnFamilyMetaData* cf_meta) {
         level, level_size, std::move(files));
     cf_meta->size += level_size;
   }
-  for (const auto& iter : vstorage->GetBlobFiles()) {
-    const auto meta = iter.second.get();
+  for (const auto& meta : vstorage->GetBlobFiles()) {
+    assert(meta);
+
     cf_meta->blob_files.emplace_back(
         meta->GetBlobFileNumber(), BlobFileName("", meta->GetBlobFileNumber()),
         ioptions->cf_paths.front().path, meta->GetBlobFileSize(),
@@ -1825,8 +1826,15 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
 
   const uint64_t blob_file_number = blob_index.file_number();
 
-  const auto it = blob_files.find(blob_file_number);
-  if (it == blob_files.end()) {
+  const auto it = std::lower_bound(
+      blob_files.begin(), blob_files.end(), blob_file_number,
+      [](const std::shared_ptr<BlobFileMetaData>& lhs, uint64_t rhs) {
+        assert(lhs);
+        return lhs->GetBlobFileNumber() < rhs;
+      });
+  assert(it == blob_files.end() || *it);
+  if (it == blob_files.end() ||
+      (*it)->GetBlobFileNumber() != blob_file_number) {
     return Status::Corruption("Invalid blob file number");
   }
 
@@ -1873,7 +1881,17 @@ void Version::MultiGetBlob(
   const auto& blob_files = storage_info_.GetBlobFiles();
   for (auto& elem : blob_rqs) {
     uint64_t blob_file_number = elem.first;
-    if (blob_files.find(blob_file_number) == blob_files.end()) {
+
+    const auto it = std::lower_bound(
+        blob_files.begin(), blob_files.end(), blob_file_number,
+        [](const std::shared_ptr<BlobFileMetaData>& lhs, uint64_t rhs) {
+          assert(lhs);
+          return lhs->GetBlobFileNumber() < rhs;
+        });
+    assert(it == blob_files.end() || *it);
+
+    if (it == blob_files.end() ||
+        (*it)->GetBlobFileNumber() != blob_file_number) {
       auto& blobs_in_file = elem.second;
       for (const auto& blob : blobs_in_file) {
         const KeyContext& key_context = blob.second;
@@ -2972,9 +2990,7 @@ void VersionStorageInfo::ComputeFilesMarkedForForcedBlobGC(
   // blob_garbage_collection_force_threshold and the entire batch has to be
   // eligible for GC according to blob_garbage_collection_age_cutoff in order
   // for us to schedule any compactions.
-  const auto oldest_it = blob_files_.begin();
-
-  const auto& oldest_meta = oldest_it->second;
+  const auto& oldest_meta = blob_files_.front();
   assert(oldest_meta);
 
   const auto& linked_ssts = oldest_meta->GetLinkedSsts();
@@ -2984,9 +3000,7 @@ void VersionStorageInfo::ComputeFilesMarkedForForcedBlobGC(
   uint64_t sum_total_blob_bytes = oldest_meta->GetTotalBlobBytes();
   uint64_t sum_garbage_blob_bytes = oldest_meta->GetGarbageBlobBytes();
 
-  auto it = oldest_it;
-  for (++it; it != blob_files_.end(); ++it) {
-    const auto& meta = it->second;
+  for (const auto& meta : blob_files_) {
     assert(meta);
 
     if (!meta->GetLinkedSsts().empty()) {
@@ -3055,10 +3069,11 @@ void VersionStorageInfo::AddBlobFile(
 
   const uint64_t blob_file_number = blob_file_meta->GetBlobFileNumber();
 
-  auto it = blob_files_.lower_bound(blob_file_number);
-  assert(it == blob_files_.end() || it->first != blob_file_number);
+  assert(blob_files_.empty() ||
+         (blob_files_.back() &&
+          blob_files_.back()->GetBlobFileNumber() < blob_file_number));
 
-  blob_files_.emplace_hint(it, blob_file_number, std::move(blob_file_meta));
+  blob_files_.emplace_back(std::move(blob_file_meta));
 }
 
 void VersionStorageInfo::SetFinalized() {
@@ -3847,9 +3862,10 @@ uint64_t VersionStorageInfo::EstimateLiveDataSize() const {
   }
   // For BlobDB, the result also includes the exact value of live bytes in the
   // blob files of the version.
-  const auto& blobFiles = GetBlobFiles();
-  for (const auto& pair : blobFiles) {
-    const auto& meta = pair.second;
+  const auto& blob_files = GetBlobFiles();
+  for (const auto& meta : blob_files) {
+    assert(meta);
+
     size += meta->GetTotalBlobBytes();
     size -= meta->GetGarbageBlobBytes();
   }
@@ -3902,8 +3918,7 @@ void Version::AddLiveFiles(std::vector<uint64_t>* live_table_files,
   }
 
   const auto& blob_files = storage_info_.GetBlobFiles();
-  for (const auto& pair : blob_files) {
-    const auto& meta = pair.second;
+  for (const auto& meta : blob_files) {
     assert(meta);
 
     live_blob_files->emplace_back(meta->GetBlobFileNumber());
@@ -3960,8 +3975,7 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
     r.append("--- blob files --- version# ");
     AppendNumberTo(&r, version_number_);
     r.append(" ---\n");
-    for (const auto& pair : blob_files) {
-      const auto& blob_file_meta = pair.second;
+    for (const auto& blob_file_meta : blob_files) {
       assert(blob_file_meta);
 
       r.append(blob_file_meta->DebugString());
@@ -5269,12 +5283,8 @@ Status VersionSet::GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) {
 
     /* Blob files */
     const auto& blob_files = cfd->current()->storage_info()->GetBlobFiles();
-    for (const auto& pair : blob_files) {
-      const uint64_t blob_file_number = pair.first;
-      const auto& meta = pair.second;
-
+    for (const auto& meta : blob_files) {
       assert(meta);
-      assert(blob_file_number == meta->GetBlobFileNumber());
 
       std::string checksum_value = meta->GetChecksumValue();
       std::string checksum_method = meta->GetChecksumMethod();
@@ -5284,8 +5294,8 @@ Status VersionSet::GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) {
         checksum_method = kUnknownFileChecksumFuncName;
       }
 
-      s = checksum_list->InsertOneFileChecksum(blob_file_number, checksum_value,
-                                               checksum_method);
+      s = checksum_list->InsertOneFileChecksum(meta->GetBlobFileNumber(),
+                                               checksum_value, checksum_method);
       if (!s.ok()) {
         return s;
       }
@@ -5438,12 +5448,10 @@ Status VersionSet::WriteCurrentStateToManifest(
       }
 
       const auto& blob_files = cfd->current()->storage_info()->GetBlobFiles();
-      for (const auto& pair : blob_files) {
-        const uint64_t blob_file_number = pair.first;
-        const auto& meta = pair.second;
-
+      for (const auto& meta : blob_files) {
         assert(meta);
-        assert(blob_file_number == meta->GetBlobFileNumber());
+
+        const uint64_t blob_file_number = meta->GetBlobFileNumber();
 
         edit.AddBlobFile(blob_file_number, meta->GetTotalBlobCount(),
                          meta->GetTotalBlobBytes(), meta->GetChecksumMethod(),
@@ -5970,21 +5978,24 @@ uint64_t VersionSet::GetTotalSstFilesSize(Version* dummy_versions) {
 
 uint64_t VersionSet::GetTotalBlobFileSize(Version* dummy_versions) {
   std::unordered_set<uint64_t> unique_blob_files;
-  uint64_t all_v_blob_file_size = 0;
+  uint64_t all_versions_blob_file_size = 0;
   for (auto* v = dummy_versions->next_; v != dummy_versions; v = v->next_) {
     // iterate all the versions
     auto* vstorage = v->storage_info();
     const auto& blob_files = vstorage->GetBlobFiles();
-    for (const auto& pair : blob_files) {
-      if (unique_blob_files.find(pair.first) == unique_blob_files.end()) {
+    for (const auto& meta : blob_files) {
+      assert(meta);
+
+      const uint64_t blob_file_number = meta->GetBlobFileNumber();
+
+      if (unique_blob_files.find(blob_file_number) == unique_blob_files.end()) {
         // find Blob file that has not been counted
-        unique_blob_files.insert(pair.first);
-        const auto& meta = pair.second;
-        all_v_blob_file_size += meta->GetBlobFileSize();
+        unique_blob_files.insert(blob_file_number);
+        all_versions_blob_file_size += meta->GetBlobFileSize();
       }
     }
   }
-  return all_v_blob_file_size;
+  return all_versions_blob_file_size;
 }
 
 Status VersionSet::VerifyFileMetadata(const std::string& fpath,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -334,6 +334,26 @@ class VersionStorageInfo {
   using BlobFiles = std::vector<std::shared_ptr<BlobFileMetaData>>;
   const BlobFiles& GetBlobFiles() const { return blob_files_; }
 
+  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  BlobFiles::const_iterator GetBlobFileMetaDataImpl(
+      uint64_t blob_file_number) const;
+
+  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  std::shared_ptr<BlobFileMetaData> GetBlobFileMetaData(
+      uint64_t blob_file_number) const {
+    const auto it = GetBlobFileMetaDataImpl(blob_file_number);
+
+    if (it == blob_files_.end()) {
+      return std::shared_ptr<BlobFileMetaData>();
+    }
+
+    assert(*it);
+    assert((*it)->GetBlobFileNumber() == blob_file_number);
+
+    return *it;
+  }
+
+  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   uint64_t GetTotalBlobFileSize() const {
     uint64_t total_blob_bytes = 0;
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -335,22 +335,22 @@ class VersionStorageInfo {
   const BlobFiles& GetBlobFiles() const { return blob_files_; }
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
-  BlobFiles::const_iterator GetBlobFileMetaDataImpl(
+  BlobFiles::const_iterator GetBlobFileMetaDataLB(
       uint64_t blob_file_number) const;
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   std::shared_ptr<BlobFileMetaData> GetBlobFileMetaData(
       uint64_t blob_file_number) const {
-    const auto it = GetBlobFileMetaDataImpl(blob_file_number);
+    const auto it = GetBlobFileMetaDataLB(blob_file_number);
 
-    if (it == blob_files_.end()) {
-      return std::shared_ptr<BlobFileMetaData>();
+    assert(it == blob_files_.end() || *it);
+
+    if (it != blob_files_.end() &&
+        (*it)->GetBlobFileNumber() == blob_file_number) {
+      return *it;
     }
 
-    assert(*it);
-    assert((*it)->GetBlobFileNumber() == blob_file_number);
-
-    return *it;
+    return std::shared_ptr<BlobFileMetaData>();
   }
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -331,14 +331,13 @@ class VersionStorageInfo {
   }
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
-  using BlobFiles = std::map<uint64_t, std::shared_ptr<BlobFileMetaData>>;
+  using BlobFiles = std::vector<std::shared_ptr<BlobFileMetaData>>;
   const BlobFiles& GetBlobFiles() const { return blob_files_; }
 
   uint64_t GetTotalBlobFileSize() const {
     uint64_t total_blob_bytes = 0;
 
-    for (const auto& pair : blob_files_) {
-      const auto& meta = pair.second;
+    for (const auto& meta : blob_files_) {
       assert(meta);
 
       total_blob_bytes += meta->GetBlobFileSize();
@@ -546,7 +545,7 @@ class VersionStorageInfo {
   using FileLocations = std::unordered_map<uint64_t, FileLocation>;
   FileLocations file_locations_;
 
-  // Map of blob files in version by number.
+  // Vector of blob files in version sorted by blob file number.
   BlobFiles blob_files_;
 
   // Level that L0 data should be compacted to. All levels < base_level_ should

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -266,7 +266,7 @@ class VersionStorageInfo {
 
   void set_l0_delay_trigger_count(int v) { l0_delay_trigger_count_ = v; }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: This version has been saved (see VersionBuilder::SaveTo)
   int NumLevelFiles(int level) const {
     assert(finalized_);
     return static_cast<int>(files_[level].size());
@@ -275,7 +275,7 @@ class VersionStorageInfo {
   // Return the combined file size of all files at the specified level.
   uint64_t NumLevelBytes(int level) const;
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: This version has been saved (see VersionBuilder::SaveTo)
   const std::vector<FileMetaData*>& LevelFiles(int level) const {
     return files_[level];
   }
@@ -332,15 +332,15 @@ class VersionStorageInfo {
     return files_[location.GetLevel()][location.GetPosition()];
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: This version has been saved (see VersionBuilder::SaveTo)
   using BlobFiles = std::vector<std::shared_ptr<BlobFileMetaData>>;
   const BlobFiles& GetBlobFiles() const { return blob_files_; }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: This version has been saved (see VersionBuilder::SaveTo)
   BlobFiles::const_iterator GetBlobFileMetaDataLB(
       uint64_t blob_file_number) const;
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: This version has been saved (see VersionBuilder::SaveTo)
   std::shared_ptr<BlobFileMetaData> GetBlobFileMetaData(
       uint64_t blob_file_number) const {
     const auto it = GetBlobFileMetaDataLB(blob_file_number);
@@ -355,7 +355,7 @@ class VersionStorageInfo {
     return std::shared_ptr<BlobFileMetaData>();
   }
 
-  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: This version has been saved (see VersionBuilder::SaveTo)
   uint64_t GetTotalBlobFileSize() const {
     uint64_t total_blob_bytes = 0;
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -127,6 +127,8 @@ class VersionStorageInfo {
 
   void AddFile(int level, FileMetaData* f);
 
+  void ReserveBlob(size_t size) { blob_files_.reserve(size); }
+
   void AddBlobFile(std::shared_ptr<BlobFileMetaData> blob_file_meta);
 
   void PrepareForVersionAppend(const ImmutableOptions& immutable_options,


### PR DESCRIPTION
Summary:
The patch replaces `std::map` with a sorted `std::vector` for
`VersionStorageInfo::blob_files_` and preallocates the space
for the `vector` before saving the `BlobFileMetaData` into the
new `VersionStorageInfo` in `VersionBuilder::Rep::SaveBlobFilesTo`.
These changes reduce the time the DB mutex is held while
saving new `Version`s, and using a sorted `vector` also makes
lookups faster thanks to better memory locality.

In addition, the patch introduces helper methods
`VersionStorageInfo::GetBlobFileMetaData` and
`VersionStorageInfo::GetBlobFileMetaDataLB` that can be used by
clients to perform lookups in the `vector`, and does some general
cleanup in the parts of code where blob file metadata are used.

Test Plan:
Ran `make check` and the crash test script for a while.

Performance was tested using a load-optimized benchmark (`fillseq` with vector memtable, no WAL) and small file sizes so that a significant number of files are produced:

```
numactl --interleave=all ./db_bench --benchmarks=fillseq --allow_concurrent_memtable_write=false --level0_file_num_compaction_trigger=4 --level0_slowdown_writes_trigger=20 --level0_stop_writes_trigger=30 --max_background_jobs=8 --max_write_buffer_number=8 --db=/data/ltamasi-dbbench --wal_dir=/data/ltamasi-dbbench --num=800000000 --num_levels=8 --key_size=20 --value_size=400 --block_size=8192 --cache_size=51539607552 --cache_numshardbits=6 --compression_max_dict_bytes=0 --compression_ratio=0.5 --compression_type=lz4 --bytes_per_sync=8388608 --cache_index_and_filter_blocks=1 --cache_high_pri_pool_ratio=0.5 --benchmark_write_rate_limit=0 --write_buffer_size=16777216 --target_file_size_base=16777216 --max_bytes_for_level_base=67108864 --verify_checksum=1 --delete_obsolete_files_period_micros=62914560 --max_bytes_for_level_multiplier=8 --statistics=0 --stats_per_interval=1 --stats_interval_seconds=20 --histogram=1 --memtablerep=skip_list --bloom_bits=10 --open_files=-1 --subcompactions=1 --compaction_style=0 --min_level_to_compress=3 --level_compaction_dynamic_level_bytes=true --pin_l0_filter_and_index_blocks_in_cache=1 --soft_pending_compaction_bytes_limit=167503724544 --hard_pending_compaction_bytes_limit=335007449088 --min_level_to_compress=0 --use_existing_db=0 --sync=0 --threads=1 --memtablerep=vector --allow_concurrent_memtable_write=false --disable_wal=1 --enable_blob_files=1 --blob_file_size=16777216 --min_blob_size=0 --blob_compression_type=lz4 --enable_blob_garbage_collection=1 --seed=<some value>
```

Final statistics before the patch:

```
Cumulative writes: 0 writes, 700M keys, 0 commit groups, 0.0 writes per commit group, ingest: 284.62 GB, 121.27 MB/s
Interval writes: 0 writes, 334K keys, 0 commit groups, 0.0 writes per commit group, ingest: 139.28 MB, 72.46 MB/s
```

With the patch:

```
Cumulative writes: 0 writes, 760M keys, 0 commit groups, 0.0 writes per commit group, ingest: 308.66 GB, 131.52 MB/s
Interval writes: 0 writes, 445K keys, 0 commit groups, 0.0 writes per commit group, ingest: 185.35 MB, 93.15 MB/s
```

Total time to complete the benchmark is 2611 seconds with the patch, down from 2986 secs.