### PR TITLE
Log blob file space amp and expose it via the rocksdb.blob-stats DB property

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -68,6 +68,7 @@
 ## New Features
 * Introduced an option `BlockBasedTableBuilder::detect_filter_construct_corruption` for detecting corruption during Bloom Filter (format_version >= 5) and Ribbon Filter construction.
 * Improved the SstDumpTool to read the comparator from table properties and use it to read the SST File.
+* Extended the column family statistics in the info log so the total amount of garbage in the blob files and the blob file space amplification factor are also logged. Also exposed the blob file space amp via the `rocksdb.blob-stats` DB property.
 
 ## 6.29.0 (01/21/2022)
 Note: The next release will be major release 7.0. See https://github.com/facebook/rocksdb/issues/9390 for more info.

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -1675,7 +1675,7 @@ void InternalStats::DumpCFStatsNoFileHistogram(std::string* value) {
 
   snprintf(buf, sizeof(buf),
            "\nBlob file count: %" ROCKSDB_PRIszt
-           ", total size: %.1f GB, garbage size: %.1f, space amp: %.1f\n\n",
+           ", total size: %.1f GB, garbage size: %.1f GB, space amp: %.1f\n\n",
            vstorage->GetBlobFiles().size(), blob_st.total_file_size / kGB,
            blob_st.total_garbage_size / kGB, blob_st.space_amp);
   value->append(buf);

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -781,24 +781,14 @@ bool InternalStats::HandleBlobStats(std::string* value, Slice /*suffix*/) {
   const auto* vstorage = current->storage_info();
   assert(vstorage);
 
-  const auto& blob_files = vstorage->GetBlobFiles();
-
-  uint64_t total_file_size = 0;
-  uint64_t total_garbage_size = 0;
-
-  for (const auto& meta : blob_files) {
-    assert(meta);
-
-    total_file_size += meta->GetBlobFileSize();
-    total_garbage_size += meta->GetGarbageBlobBytes();
-  }
+  const auto blob_st = vstorage->GetBlobStats();
 
   std::ostringstream oss;
 
-  oss << "Number of blob files: " << blob_files.size()
-      << "\nTotal size of blob files: " << total_file_size
-      << "\nTotal size of garbage in blob files: " << total_garbage_size
-      << '\n';
+  oss << "Number of blob files: " << vstorage->GetBlobFiles().size()
+      << "\nTotal size of blob files: " << blob_st.total_file_size
+      << "\nTotal size of garbage in blob files: " << blob_st.total_garbage_size
+      << "\nBlob file space amplification: " << blob_st.space_amp << '\n';
 
   value->append(oss.str());
 
@@ -824,7 +814,7 @@ bool InternalStats::HandleLiveBlobFileSize(uint64_t* value, DBImpl* /*db*/,
   const auto* vstorage = current->storage_info();
   assert(vstorage);
 
-  *value = vstorage->GetTotalBlobFileSize();
+  *value = vstorage->GetBlobStats().total_file_size;
 
   return true;
 }
@@ -1681,10 +1671,13 @@ void InternalStats::DumpCFStatsNoFileHistogram(std::string* value) {
     }
   }
 
+  const auto blob_st = vstorage->GetBlobStats();
+
   snprintf(buf, sizeof(buf),
-           "\nBlob file count: %" ROCKSDB_PRIszt ", total size: %.1f GB\n\n",
-           vstorage->GetBlobFiles().size(),
-           vstorage->GetTotalBlobFileSize() / kGB);
+           "\nBlob file count: %" ROCKSDB_PRIszt
+           ", total size: %.1f GB, garbage size: %.1f, space amp: %.1f\n\n",
+           vstorage->GetBlobFiles().size(), blob_st.total_file_size / kGB,
+           blob_st.total_garbage_size / kGB, blob_st.space_amp);
   value->append(buf);
 
   uint64_t now_micros = clock_->NowMicros();


### PR DESCRIPTION
Summary:
Extend the periodic statistics in the info log with the total amount of garbage
in blob files and the space amplification pertaining to blob files, where the
latter is defined as `total_blob_file_size / (total_blob_file_size - total_blob_garbage_size)`.
Also expose the space amp via the `rocksdb.blob-stats` DB property.

Test Plan:
`make check`