### PR TITLE
Clean up some of the files left after test runs

### DIFF
--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -315,6 +315,7 @@ TEST_F(DBBlobBasicTest, MultiGetWithDirectIO) {
     ASSERT_OK(statuses[2]);
     ASSERT_EQ(values[2], second_blob);
   }
+  ASSERT_OK(options.env->DeleteFile(file_path));
 }
 #endif  // !ROCKSDB_LITE
 
@@ -574,6 +575,7 @@ TEST_F(DBBlobBasicTest, GenerateIOTracing) {
     // Assuming blob files will have Append, Close and then Read operations.
     ASSERT_GT(blob_files_op_count, 2);
   }
+  ASSERT_OK(env_->DeleteFile(trace_file));
 }
 #endif  // !ROCKSDB_LITE
 

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -590,6 +590,9 @@ int main(int argc, char** argv) {
     CheckGet(db, roptions, "foo", "hello");
 
     rocksdb_backup_engine_close(be);
+
+    rocksdb_destroy_db(options, dbbackupname, &err);
+    CheckNoError(err);
   }
 
   StartPhase("checkpoint");
@@ -717,6 +720,7 @@ int main(int argc, char** argv) {
     CheckNoError(err);
     rocksdb_delete(db, woptions, "sstk3", 5, &err);
     CheckNoError(err);
+    remove(sstfilename);
   }
 
   StartPhase("writebatch");
@@ -2964,6 +2968,8 @@ int main(int argc, char** argv) {
 
   StartPhase("cleanup");
   rocksdb_close(db);
+  rocksdb_destroy_db(options, dbname, &err);
+  CheckNoError(err);
   rocksdb_options_destroy(options);
   rocksdb_block_based_options_destroy(table_options);
   rocksdb_readoptions_destroy(roptions);

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -82,6 +82,7 @@ class ColumnFamilyTestBase : public testing::Test {
     }
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
     Destroy(column_families);
+    EXPECT_OK(DestroyDB(dbname_, Options(db_options_, column_family_options_)));
     delete env_;
   }
 
@@ -948,6 +949,7 @@ TEST_P(ColumnFamilyTest, IgnoreRecoveredLog) {
       }
     }
   }
+  ASSERT_OK(DestroyDir(env_, backup_logs));
 }
 
 #ifndef ROCKSDB_LITE  // TEST functions used are not supported

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -20,6 +20,7 @@
 #include "db/error_handler.h"
 #include "db/version_set.h"
 #include "file/writable_file_writer.h"
+#include "options/options_helper.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
@@ -96,6 +97,12 @@ class CompactionJobTestBase : public testing::Test {
         test::CreateEnvFromSystem(ConfigOptions(), &base_env, &env_guard_));
     env_ = base_env;
     fs_ = env_->GetFileSystem();
+  }
+
+  ~CompactionJobTestBase() {
+    Options options(BuildDBOptions(db_options_, mutable_db_options_),
+                    ColumnFamilyOptions());
+    EXPECT_OK(DestroyDB(dbname_, options));
   }
 
   void SetUp() override {

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1147,6 +1147,7 @@ TEST_F(DBBasicTest, DBClose) {
   ASSERT_EQ(env->GetCloseCount(), 2);
   options.info_log.reset();
   ASSERT_EQ(env->GetCloseCount(), 3);
+  ASSERT_OK(DestroyDB(dbname, options));
 }
 
 TEST_F(DBBasicTest, DBCloseFlushError) {

--- a/db/db_encryption_test.cc
+++ b/db/db_encryption_test.cc
@@ -117,6 +117,7 @@ TEST_F(DBEncryptionTest, ReadEmptyFile) {
   ASSERT_OK(status);
 
   ASSERT_TRUE(data.empty());
+  ASSERT_OK(defaultEnv->DeleteFile(filePath));
 }
 
 #endif // ROCKSDB_LITE

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -715,6 +715,9 @@ TEST_P(DBSSTTestRateLimit, RateLimitedDelete) {
       0, options.statistics->getAndResetTickerCount(FILES_DELETED_IMMEDIATELY));
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  if (different_wal_dir) {
+    ASSERT_OK(DestroyDir(options.env, alternative_wal_dir_));
+  }
 }
 
 INSTANTIATE_TEST_CASE_P(RateLimitedDelete, DBSSTTestRateLimit,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2232,6 +2232,7 @@ TEST_F(DBTest, DBOpen_Options) {
 
   delete db;
   db = nullptr;
+  ASSERT_OK(DestroyDB(dbname, options));
 }
 
 TEST_F(DBTest, DBOpen_Change_NumLevels) {
@@ -2288,6 +2289,8 @@ TEST_F(DBTest, DestroyDBMetaDatabase) {
   ASSERT_TRUE(!(DB::Open(options, dbname, &db)).ok());
   ASSERT_TRUE(!(DB::Open(options, metadbname, &db)).ok());
   ASSERT_TRUE(!(DB::Open(options, metametadbname, &db)).ok());
+  ASSERT_OK(
+      DestroyDir(env_, dbname));  // The meta dbs leave stuff around.  Clean up
 }
 
 #ifndef ROCKSDB_LITE
@@ -2439,6 +2442,7 @@ TEST_F(DBTest, SnapshotFiles) {
         ASSERT_EQ(info.file_number, manifest_number);
       }
     }
+    ASSERT_OK(DestroyDir(env_, snapdir));
   } while (ChangeCompactOptions());
 }
 

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -743,6 +743,7 @@ TEST_F(DBWALTest, IgnoreRecoveredLog) {
     ASSERT_NOK(s);
     Destroy(options);
   } while (ChangeWalOptions());
+  ASSERT_OK(DestroyDir(env_, backup_logs));
 }
 
 TEST_F(DBWALTest, RecoveryWithEmptyLog) {

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -614,6 +614,7 @@ TEST_P(FaultInjectionTest, NoDuplicateTrailingEntries) {
     // Verify that only one version edit exists in the file.
     ASSERT_EQ(1, count);
   }
+  ASSERT_OK(fault_fs->DeleteFile(file_name, IOOptions(), nullptr));
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -476,6 +476,9 @@ TEST_F(EventListenerTest, MultiDBMultiListeners) {
   for (auto db : dbs) {
     delete db;
   }
+  for (int d = 0; d < kNumDBs; ++d) {
+    ASSERT_OK(DestroyDB(dbname_ + ToString(d), options));
+  }
 }
 
 TEST_F(EventListenerTest, DisableBGCompaction) {

--- a/db/options_file_test.cc
+++ b/db/options_file_test.cc
@@ -78,6 +78,7 @@ TEST_F(OptionsFileTest, NumberOfOptionsFiles) {
     VerifyOptionsFileName(db, filename_history);
     delete db;
   }
+  ASSERT_OK(DestroyDB(dbname_, opt));
 }
 
 TEST_F(OptionsFileTest, OptionsFileName) {

--- a/db/perf_context_test.cc
+++ b/db/perf_context_test.cc
@@ -66,10 +66,14 @@ std::shared_ptr<DB> OpenDb(bool read_only = false) {
     return std::shared_ptr<DB>(db);
 }
 
-class PerfContextTest : public testing::Test {};
+class PerfContextTest : public testing::Test {
+ public:
+  PerfContextTest() { EXPECT_OK(DestroyDB(kDbName, Options())); }
+
+  ~PerfContextTest() { EXPECT_OK(DestroyDB(kDbName, Options())); }
+};
 
 TEST_F(PerfContextTest, SeekIntoDeletion) {
-  DestroyDB(kDbName, Options());
   auto db = OpenDb();
   WriteOptions write_options;
   ReadOptions read_options;
@@ -518,7 +522,6 @@ TEST_F(PerfContextTest, KeyComparisonCount) {
 // starts to become linear to the input size.
 
 TEST_F(PerfContextTest, SeekKeyComparison) {
-  DestroyDB(kDbName, Options());
   auto db = OpenDb();
   WriteOptions write_options;
   ReadOptions read_options;
@@ -652,7 +655,6 @@ TEST_F(PerfContextTest, ToString) {
 }
 
 TEST_F(PerfContextTest, MergeOperatorTime) {
-  DestroyDB(kDbName, Options());
   DB* db;
   Options options;
   options.create_if_missing = true;
@@ -833,7 +835,6 @@ TEST_F(PerfContextTest, CPUTimer) {
     return;
   }
 
-  DestroyDB(kDbName, Options());
   auto db = OpenDb();
   WriteOptions write_options;
   ReadOptions read_options;

--- a/db/periodic_work_scheduler_test.cc
+++ b/db/periodic_work_scheduler_test.cc
@@ -192,6 +192,9 @@ TEST_F(PeriodicWorkSchedulerTest, MultiInstances) {
     ASSERT_OK(dbs[i]->Close());
     delete dbs[i];
   }
+  for (int i = 0; i < kInstanceNum; i++) {
+    ASSERT_OK(DestroyDB(test::PerThreadDBPath(std::to_string(i)), options));
+  }
 }
 
 TEST_F(PeriodicWorkSchedulerTest, MultiEnv) {
@@ -225,6 +228,7 @@ TEST_F(PeriodicWorkSchedulerTest, MultiEnv) {
   ASSERT_OK(db->Close());
   delete db;
   Close();
+  ASSERT_OK(DestroyDB(dbname, options2));
 }
 #endif  // !ROCKSDB_LITE
 }  // namespace ROCKSDB_NAMESPACE

--- a/logging/auto_roll_logger_test.cc
+++ b/logging/auto_roll_logger_test.cc
@@ -49,19 +49,18 @@ void LogMessage(const InfoLogLevel log_level, Logger* logger,
 
 class AutoRollLoggerTest : public testing::Test {
  public:
-  static void InitTestDb() {
-#ifdef OS_WIN
-    // Replace all slashes in the path so windows CompSpec does not
-    // become confused
-    std::string testDir(kTestDir);
-    std::replace_if(testDir.begin(), testDir.end(),
-                    [](char ch) { return ch == '/'; }, '\\');
-    std::string deleteCmd = "if exist " + testDir + " rd /s /q " + testDir;
-#else
-    std::string deleteCmd = "rm -rf " + kTestDir;
-#endif
-    ASSERT_TRUE(system(deleteCmd.c_str()) == 0);
-    ASSERT_OK(Env::Default()->CreateDir(kTestDir));
+  AutoRollLoggerTest() {
+    env_ = Env::Default();
+    test_dir_ = test::PerThreadDBPath(env_, "db_log_test");
+    log_file_ = test_dir_ + "/LOG";
+    RecreateLogDir();
+  }
+
+  ~AutoRollLoggerTest() { EXPECT_OK(DestroyDir(env_, test_dir_)); }
+
+  void RecreateLogDir() {
+    EXPECT_OK(DestroyDir(env_, test_dir_));
+    EXPECT_OK(env_->CreateDir(test_dir_));
   }
 
   void RollLogFileBySizeTest(AutoRollLogger* logger, size_t log_max_size,
@@ -70,11 +69,11 @@ class AutoRollLoggerTest : public testing::Test {
                              const std::shared_ptr<SystemClock>& sc,
                              AutoRollLogger* logger, size_t time,
                              const std::string& log_message);
-  // return list of files under kTestDir that contains "LOG"
+  // return list of files under test_dir_ that contains "LOG"
   std::vector<std::string> GetLogFiles() {
     std::vector<std::string> ret;
     std::vector<std::string> files;
-    Status s = default_env->GetChildren(kTestDir, &files);
+    Status s = env_->GetChildren(test_dir_, &files);
     // Should call ASSERT_OK() here but it doesn't compile. It's not
     // worth the time figuring out why.
     EXPECT_TRUE(s.ok());
@@ -86,10 +85,10 @@ class AutoRollLoggerTest : public testing::Test {
     return ret;
   }
 
-  // Delete all log files under kTestDir
+  // Delete all log files under test_dir_
   void CleanupLogFiles() {
     for (const std::string& f : GetLogFiles()) {
-      ASSERT_OK(default_env->DeleteFile(kTestDir + "/" + f));
+      ASSERT_OK(env_->DeleteFile(test_dir_ + "/" + f));
     }
   }
 
@@ -107,18 +106,13 @@ class AutoRollLoggerTest : public testing::Test {
   }
 
   static const std::string kSampleMessage;
-  static const std::string kTestDir;
-  static const std::string kLogFile;
-  static Env* default_env;
+  std::string test_dir_;
+  std::string log_file_;
+  Env* env_;
 };
 
 const std::string AutoRollLoggerTest::kSampleMessage(
     "this is the message to be written to the log file!!");
-const std::string AutoRollLoggerTest::kTestDir(
-    test::PerThreadDBPath("db_log_test"));
-const std::string AutoRollLoggerTest::kLogFile(
-    test::PerThreadDBPath("db_log_test") + "/LOG");
-Env* AutoRollLoggerTest::default_env = Env::Default();
 
 void AutoRollLoggerTest::RollLogFileBySizeTest(AutoRollLogger* logger,
                                                size_t log_max_size,
@@ -157,7 +151,7 @@ void AutoRollLoggerTest::RollLogFileByTimeTest(
   uint64_t actual_ctime;
 
   uint64_t total_log_size;
-  EXPECT_OK(fs->GetFileSize(kLogFile, IOOptions(), &total_log_size, nullptr));
+  EXPECT_OK(fs->GetFileSize(log_file_, IOOptions(), &total_log_size, nullptr));
   expected_ctime = logger->TEST_ctime();
   logger->SetCallNowMicrosEveryNRecords(0);
 
@@ -189,12 +183,11 @@ void AutoRollLoggerTest::RollLogFileByTimeTest(
 }
 
 TEST_F(AutoRollLoggerTest, RollLogFileBySize) {
-    InitTestDb();
     size_t log_max_size = 1024 * 5;
     size_t keep_log_file_num = 10;
 
     AutoRollLogger logger(FileSystem::Default(), SystemClock::Default(),
-                          kTestDir, "", log_max_size, 0, keep_log_file_num);
+                          test_dir_, "", log_max_size, 0, keep_log_file_num);
 
     RollLogFileBySizeTest(&logger, log_max_size,
                           kSampleMessage + ":RollLogFileBySize");
@@ -208,24 +201,22 @@ TEST_F(AutoRollLoggerTest, RollLogFileByTime) {
   size_t log_size = 1024 * 5;
   size_t keep_log_file_num = 10;
 
-  InitTestDb();
   // -- Test the existence of file during the server restart.
-  ASSERT_EQ(Status::NotFound(), default_env->FileExists(kLogFile));
-  AutoRollLogger logger(default_env->GetFileSystem(), nsc, kTestDir, "",
-                        log_size, time, keep_log_file_num);
-  ASSERT_OK(default_env->FileExists(kLogFile));
+  ASSERT_EQ(Status::NotFound(), env_->FileExists(log_file_));
+  AutoRollLogger logger(env_->GetFileSystem(), nsc, test_dir_, "", log_size,
+                        time, keep_log_file_num);
+  ASSERT_OK(env_->FileExists(log_file_));
 
-  RollLogFileByTimeTest(default_env->GetFileSystem(), nsc, &logger, time,
+  RollLogFileByTimeTest(env_->GetFileSystem(), nsc, &logger, time,
                         kSampleMessage + ":RollLogFileByTime");
 }
 
 TEST_F(AutoRollLoggerTest, SetInfoLogLevel) {
-  InitTestDb();
   Options options;
   options.info_log_level = InfoLogLevel::FATAL_LEVEL;
   options.max_log_file_size = 1024;
   std::shared_ptr<Logger> logger;
-  ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+  ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
   auto* auto_roll_logger = dynamic_cast<AutoRollLogger*>(logger.get());
   ASSERT_NE(nullptr, auto_roll_logger);
   ASSERT_EQ(InfoLogLevel::FATAL_LEVEL, auto_roll_logger->GetInfoLogLevel());
@@ -241,7 +232,6 @@ TEST_F(AutoRollLoggerTest, SetInfoLogLevel) {
 TEST_F(AutoRollLoggerTest, OpenLogFilesMultipleTimesWithOptionLog_max_size) {
   // If only 'log_max_size' options is specified, then every time
   // when rocksdb is restarted, a new empty log file will be created.
-  InitTestDb();
   // WORKAROUND:
   // avoid complier's complaint of "comparison between signed
   // and unsigned integer expressions" because literal 0 is
@@ -252,7 +242,7 @@ TEST_F(AutoRollLoggerTest, OpenLogFilesMultipleTimesWithOptionLog_max_size) {
 
   AutoRollLogger* logger =
       new AutoRollLogger(FileSystem::Default(), SystemClock::Default(),
-                         kTestDir, "", log_size, 0, keep_log_file_num);
+                         test_dir_, "", log_size, 0, keep_log_file_num);
 
   LogMessage(logger, kSampleMessage.c_str());
   ASSERT_GT(logger->GetLogFileSize(), kZero);
@@ -260,7 +250,7 @@ TEST_F(AutoRollLoggerTest, OpenLogFilesMultipleTimesWithOptionLog_max_size) {
 
   // reopens the log file and an empty log file will be created.
   logger = new AutoRollLogger(FileSystem::Default(), SystemClock::Default(),
-                              kTestDir, "", log_size, 0, 10);
+                              test_dir_, "", log_size, 0, 10);
   ASSERT_EQ(logger->GetLogFileSize(), kZero);
   delete logger;
 }
@@ -269,11 +259,9 @@ TEST_F(AutoRollLoggerTest, CompositeRollByTimeAndSizeLogger) {
   size_t time = 2, log_max_size = 1024 * 5;
   size_t keep_log_file_num = 10;
 
-  InitTestDb();
-
   auto nsc =
       std::make_shared<EmulatedSystemClock>(SystemClock::Default(), true);
-  AutoRollLogger logger(FileSystem::Default(), nsc, kTestDir, "", log_max_size,
+  AutoRollLogger logger(FileSystem::Default(), nsc, test_dir_, "", log_max_size,
                         time, keep_log_file_num);
 
   // Test the ability to roll by size
@@ -292,18 +280,17 @@ TEST_F(AutoRollLoggerTest, CreateLoggerFromOptions) {
   DBOptions options;
   auto nsc =
       std::make_shared<EmulatedSystemClock>(SystemClock::Default(), true);
-  std::unique_ptr<Env> nse(new CompositeEnvWrapper(Env::Default(), nsc));
+  std::unique_ptr<Env> nse(new CompositeEnvWrapper(env_, nsc));
 
   std::shared_ptr<Logger> logger;
 
   // Normal logger
-  ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+  ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
   ASSERT_TRUE(dynamic_cast<PosixLogger*>(logger.get()));
 
   // Only roll by size
-  InitTestDb();
   options.max_log_file_size = 1024;
-  ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+  ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
   AutoRollLogger* auto_roll_logger =
     dynamic_cast<AutoRollLogger*>(logger.get());
   ASSERT_TRUE(auto_roll_logger);
@@ -313,10 +300,10 @@ TEST_F(AutoRollLoggerTest, CreateLoggerFromOptions) {
 
   // Only roll by Time
   options.env = nse.get();
-  InitTestDb();
+
   options.max_log_file_size = 0;
   options.log_file_time_to_roll = 2;
-  ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+  ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
   auto_roll_logger =
     dynamic_cast<AutoRollLogger*>(logger.get());
   RollLogFileByTimeTest(options.env->GetFileSystem(), nsc, auto_roll_logger,
@@ -324,10 +311,10 @@ TEST_F(AutoRollLoggerTest, CreateLoggerFromOptions) {
                         kSampleMessage + ":CreateLoggerFromOptions - time");
 
   // roll by both Time and size
-  InitTestDb();
+  RecreateLogDir();
   options.max_log_file_size = 1024 * 5;
   options.log_file_time_to_roll = 2;
-  ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+  ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
   auto_roll_logger =
     dynamic_cast<AutoRollLogger*>(logger.get());
   RollLogFileBySizeTest(auto_roll_logger, options.max_log_file_size,
@@ -339,11 +326,11 @@ TEST_F(AutoRollLoggerTest, CreateLoggerFromOptions) {
   // Set keep_log_file_num
   {
     const size_t kFileNum = 3;
-    InitTestDb();
+    RecreateLogDir();
     options.max_log_file_size = 512;
     options.log_file_time_to_roll = 2;
     options.keep_log_file_num = kFileNum;
-    ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+    ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
     auto_roll_logger = dynamic_cast<AutoRollLogger*>(logger.get());
 
     // Roll the log 4 times, and it will trim to 3 files.
@@ -366,11 +353,11 @@ TEST_F(AutoRollLoggerTest, CreateLoggerFromOptions) {
   // db_log_dir.
   {
     const size_t kFileNum = 3;
-    InitTestDb();
+    RecreateLogDir();
     options.max_log_file_size = 512;
     options.log_file_time_to_roll = 2;
     options.keep_log_file_num = kFileNum;
-    options.db_log_dir = kTestDir;
+    options.db_log_dir = test_dir_;
     ASSERT_OK(CreateLoggerFromOptions("/dummy/db/name", options, &logger));
     auto_roll_logger = dynamic_cast<AutoRollLogger*>(logger.get());
 
@@ -399,10 +386,10 @@ TEST_F(AutoRollLoggerTest, AutoDeleting) {
   for (int attempt = 0; attempt < 2; attempt++) {
     // In the first attemp, db_log_dir is not set, while in the
     // second it is set.
-    std::string dbname = (attempt == 0) ? kTestDir : "/test/dummy/dir";
-    std::string db_log_dir = (attempt == 0) ? "" : kTestDir;
+    std::string dbname = (attempt == 0) ? test_dir_ : "/test/dummy/dir";
+    std::string db_log_dir = (attempt == 0) ? "" : test_dir_;
 
-    InitTestDb();
+    RecreateLogDir();
     const size_t kMaxFileSize = 512;
     {
       size_t log_num = 8;
@@ -442,9 +429,8 @@ TEST_F(AutoRollLoggerTest, LogFlushWhileRolling) {
   DBOptions options;
   std::shared_ptr<Logger> logger;
 
-  InitTestDb();
   options.max_log_file_size = 1024 * 5;
-  ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+  ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
   AutoRollLogger* auto_roll_logger =
       dynamic_cast<AutoRollLogger*>(logger.get());
   ASSERT_TRUE(auto_roll_logger);
@@ -482,15 +468,13 @@ TEST_F(AutoRollLoggerTest, LogFlushWhileRolling) {
 #endif  // OS_WIN
 
 TEST_F(AutoRollLoggerTest, InfoLogLevel) {
-  InitTestDb();
-
   size_t log_size = 8192;
   size_t log_lines = 0;
   // an extra-scope to force the AutoRollLogger to flush the log file when it
   // becomes out of scope.
   {
     AutoRollLogger logger(FileSystem::Default(), SystemClock::Default(),
-                          kTestDir, "", log_size, 0, 10);
+                          test_dir_, "", log_size, 0, 10);
     for (int log_level = InfoLogLevel::HEADER_LEVEL;
          log_level >= InfoLogLevel::DEBUG_LEVEL; log_level--) {
       logger.SetInfoLogLevel((InfoLogLevel)log_level);
@@ -516,7 +500,7 @@ TEST_F(AutoRollLoggerTest, InfoLogLevel) {
       log_lines += InfoLogLevel::HEADER_LEVEL - log_level + 1;
     }
   }
-  std::ifstream inFile(AutoRollLoggerTest::kLogFile.c_str());
+  std::ifstream inFile(log_file_.c_str());
   size_t lines = std::count(std::istreambuf_iterator<char>(inFile),
                          std::istreambuf_iterator<char>(), '\n');
   ASSERT_EQ(log_lines, lines);
@@ -524,12 +508,10 @@ TEST_F(AutoRollLoggerTest, InfoLogLevel) {
 }
 
 TEST_F(AutoRollLoggerTest, Close) {
-  InitTestDb();
-
   size_t log_size = 8192;
   size_t log_lines = 0;
-  AutoRollLogger logger(FileSystem::Default(), SystemClock::Default(), kTestDir,
-                        "", log_size, 0, 10);
+  AutoRollLogger logger(FileSystem::Default(), SystemClock::Default(),
+                        test_dir_, "", log_size, 0, 10);
   for (int log_level = InfoLogLevel::HEADER_LEVEL;
        log_level >= InfoLogLevel::DEBUG_LEVEL; log_level--) {
     logger.SetInfoLogLevel((InfoLogLevel)log_level);
@@ -556,7 +538,7 @@ TEST_F(AutoRollLoggerTest, Close) {
   }
   ASSERT_EQ(logger.Close(), Status::OK());
 
-  std::ifstream inFile(AutoRollLoggerTest::kLogFile.c_str());
+  std::ifstream inFile(log_file_.c_str());
   size_t lines = std::count(std::istreambuf_iterator<char>(inFile),
                          std::istreambuf_iterator<char>(), '\n');
   ASSERT_EQ(log_lines, lines);
@@ -565,14 +547,15 @@ TEST_F(AutoRollLoggerTest, Close) {
 
 // Test the logger Header function for roll over logs
 // We expect the new logs creates as roll over to carry the headers specified
-static std::vector<std::string> GetOldFileNames(const std::string& path) {
+static std::vector<std::string> GetOldFileNames(Env* env,
+                                                const std::string& path) {
   std::vector<std::string> ret;
 
   const std::string dirname = path.substr(/*start=*/0, path.find_last_of("/"));
   const std::string fname = path.substr(path.find_last_of("/") + 1);
 
   std::vector<std::string> children;
-  EXPECT_OK(Env::Default()->GetChildren(dirname, &children));
+  EXPECT_OK(env->GetChildren(dirname, &children));
 
   // We know that the old log files are named [path]<something>
   // Return all entities that match the pattern
@@ -593,11 +576,10 @@ TEST_F(AutoRollLoggerTest, LogHeaderTest) {
   // test_num == 0 -> standard call to Header()
   // test_num == 1 -> call to Log() with InfoLogLevel::HEADER_LEVEL
   for (int test_num = 0; test_num < 2; test_num++) {
-
-    InitTestDb();
+    RecreateLogDir();
 
     AutoRollLogger logger(FileSystem::Default(), SystemClock::Default(),
-                          kTestDir, /*db_log_dir=*/"", LOG_MAX_SIZE,
+                          test_dir_, /*db_log_dir=*/"", LOG_MAX_SIZE,
                           /*log_file_time_to_roll=*/0,
                           /*keep_log_file_num=*/10);
 
@@ -629,7 +611,7 @@ TEST_F(AutoRollLoggerTest, LogHeaderTest) {
     // Flush the log for the latest file
     LogFlush(&logger);
 
-    const auto oldfiles = GetOldFileNames(newfname);
+    const auto oldfiles = GetOldFileNames(env_, newfname);
 
     ASSERT_EQ(oldfiles.size(), (size_t) 2);
 
@@ -645,22 +627,14 @@ TEST_F(AutoRollLoggerTest, LogHeaderTest) {
 TEST_F(AutoRollLoggerTest, LogFileExistence) {
   ROCKSDB_NAMESPACE::DB* db;
   ROCKSDB_NAMESPACE::Options options;
-#ifdef OS_WIN
-  // Replace all slashes in the path so windows CompSpec does not
-  // become confused
-  std::string testDir(kTestDir);
-  std::replace_if(testDir.begin(), testDir.end(),
-    [](char ch) { return ch == '/'; }, '\\');
-  std::string deleteCmd = "if exist " + testDir + " rd /s /q " + testDir;
-#else
-  std::string deleteCmd = "rm -rf " + kTestDir;
-#endif
-  ASSERT_EQ(system(deleteCmd.c_str()), 0);
+
+  ASSERT_OK(DestroyDir(env_, test_dir_));
   options.max_log_file_size = 100 * 1024 * 1024;
   options.create_if_missing = true;
-  ASSERT_OK(ROCKSDB_NAMESPACE::DB::Open(options, kTestDir, &db));
-  ASSERT_OK(default_env->FileExists(kLogFile));
+  ASSERT_OK(ROCKSDB_NAMESPACE::DB::Open(options, test_dir_, &db));
+  ASSERT_OK(env_->FileExists(log_file_));
   delete db;
+  ASSERT_OK(DestroyDB(test_dir_, options));
 }
 
 TEST_F(AutoRollLoggerTest, FileCreateFailure) {
@@ -674,29 +648,27 @@ TEST_F(AutoRollLoggerTest, FileCreateFailure) {
 }
 
 TEST_F(AutoRollLoggerTest, RenameOnlyWhenExists) {
-  InitTestDb();
-  SpecialEnv env(Env::Default());
+  SpecialEnv env(env_);
   Options options;
   options.env = &env;
 
   // Originally no LOG exists. Should not see a rename.
   {
     std::shared_ptr<Logger> logger;
-    ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+    ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
     ASSERT_EQ(0, env.rename_count_);
   }
 
   // Now a LOG exists. Create a new one should see a rename.
   {
     std::shared_ptr<Logger> logger;
-    ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+    ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
     ASSERT_EQ(1, env.rename_count_);
   }
 }
 
 TEST_F(AutoRollLoggerTest, RenameError) {
-  InitTestDb();
-  SpecialEnv env(Env::Default());
+  SpecialEnv env(env_);
   env.rename_error_ = true;
   Options options;
   options.env = &env;
@@ -704,14 +676,14 @@ TEST_F(AutoRollLoggerTest, RenameError) {
   // Originally no LOG exists. Should not be impacted by rename error.
   {
     std::shared_ptr<Logger> logger;
-    ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+    ASSERT_OK(CreateLoggerFromOptions(test_dir_, options, &logger));
     ASSERT_TRUE(logger != nullptr);
   }
 
   // Now a LOG exists. Rename error should cause failure.
   {
     std::shared_ptr<Logger> logger;
-    ASSERT_NOK(CreateLoggerFromOptions(kTestDir, options, &logger));
+    ASSERT_NOK(CreateLoggerFromOptions(test_dir_, options, &logger));
     ASSERT_TRUE(logger == nullptr);
   }
 }

--- a/table/cuckoo/cuckoo_table_builder_test.cc
+++ b/table/cuckoo/cuckoo_table_builder_test.cc
@@ -41,6 +41,12 @@ class CuckooBuilderTest : public testing::Test {
     file_options_ = FileOptions(options);
   }
 
+  ~CuckooBuilderTest() override {
+    if (!fname.empty()) {
+      EXPECT_OK(env_->DeleteFile(fname));
+    }
+  }
+
   void CheckFileContents(const std::vector<std::string>& keys,
       const std::vector<std::string>& values,
       const std::vector<uint64_t>& expected_locations,

--- a/table/cuckoo/cuckoo_table_reader_test.cc
+++ b/table/cuckoo/cuckoo_table_reader_test.cc
@@ -72,6 +72,12 @@ class CuckooReaderTest : public testing::Test {
     file_options = FileOptions(options);
   }
 
+  ~CuckooReaderTest() {
+    if (!fname.empty()) {
+      env->DeleteFile(fname).PermitUncheckedError();
+    }
+  }
+
   void SetUp(int num) {
     num_items = num;
     hash_map.clear();

--- a/tools/reduce_levels_test.cc
+++ b/tools/reduce_levels_test.cc
@@ -22,9 +22,11 @@ class ReduceLevelTest : public testing::Test {
 public:
   ReduceLevelTest() {
     dbname_ = test::PerThreadDBPath("db_reduce_levels_test");
-    DestroyDB(dbname_, Options());
+    EXPECT_OK(DestroyDB(dbname_, Options()));
     db_ = nullptr;
   }
+
+  ~ReduceLevelTest() { EXPECT_OK(DestroyDB(dbname_, Options())); }
 
   Status OpenDB(bool create_if_missing, int levels);
 

--- a/tools/trace_analyzer_test.cc
+++ b/tools/trace_analyzer_test.cc
@@ -55,7 +55,7 @@ class TraceAnalyzerTest : public testing::Test {
     dbname_ = test_path_ + "/db";
   }
 
-  ~TraceAnalyzerTest() override {}
+  ~TraceAnalyzerTest() override { EXPECT_OK(DestroyDir(env_, test_path_)); }
 
   void GenerateTrace(std::string trace_path) {
     Options options;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -686,6 +686,12 @@ class BackupEngineTest : public testing::Test {
     backup_chroot_env_->DeleteFile(latest_backup_).PermitUncheckedError();
   }
 
+  ~BackupEngineTest() {
+    EXPECT_OK(
+        DestroyDir(Env::Default(), test::PerThreadDBPath("db_for_backup")));
+    EXPECT_OK(DestroyDir(Env::Default(), test::PerThreadDBPath("db_backups")));
+  }
+
   DB* OpenDB() {
     DB* db;
     EXPECT_OK(DB::Open(options_, dbname_, &db));

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -745,6 +745,7 @@ TEST_F(CheckpointTest, CurrentFileModifiedWhileCheckpointing2PC) {
   delete snapshotDB;
   snapshotDB = nullptr;
   delete txdb;
+  ASSERT_OK(DestroyDB(dbname, CurrentOptions()));
 }
 
 TEST_F(CheckpointTest, CheckpointInvalidDirectoryName) {

--- a/utilities/memory/memory_test.cc
+++ b/utilities/memory/memory_test.cc
@@ -21,8 +21,22 @@ namespace ROCKSDB_NAMESPACE {
 class MemoryTest : public testing::Test {
  public:
   MemoryTest() : kDbDir(test::PerThreadDBPath("memory_test")), rnd_(301) {
-    assert(Env::Default()->CreateDirIfMissing(kDbDir).ok());
+    EXPECT_OK(Env::Default()->CreateDirIfMissing(kDbDir));
+    Options opt;
+    for (int i = 0; i < kNumDBs; ++i) {
+      EXPECT_OK(DestroyDB(GetDBName(i), opt));
+    }
   }
+
+  ~MemoryTest() {
+    Options opt;
+    for (int i = 0; i < kNumDBs; ++i) {
+      EXPECT_OK(DestroyDB(GetDBName(i), opt));
+    }
+    EXPECT_OK(Env::Default()->DeleteDir(kDbDir));
+  }
+
+  const int kNumDBs = 10;
 
   std::string GetDBName(int id) { return kDbDir + "db_" + ToString(id); }
 
@@ -92,7 +106,6 @@ class MemoryTest : public testing::Test {
 TEST_F(MemoryTest, SharedBlockCacheTotal) {
   std::vector<DB*> dbs;
   std::vector<uint64_t> usage_by_type;
-  const int kNumDBs = 10;
   const int kKeySize = 100;
   const int kValueSize = 500;
   Options opt;
@@ -145,7 +158,6 @@ TEST_F(MemoryTest, MemTableAndTableReadersTotal) {
   std::vector<DB*> dbs;
   std::vector<uint64_t> usage_by_type;
   std::vector<std::vector<ColumnFamilyHandle*>> vec_handles;
-  const int kNumDBs = 10;
   // These key/value sizes ensure each KV has its own memtable. Note that the
   // minimum write_buffer_size allowed is 64 KB.
   const int kKeySize = 100;

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -757,6 +757,7 @@ TEST_F(OptionsUtilTest, WalDirInOptins) {
   delete db;
   ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, "");
+  ASSERT_OK(DestroyDB(dbname_, options));
 }
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -61,6 +61,7 @@ class TransactionTestBase : public ::testing::Test {
     options.write_buffer_size = 4 * 1024;
     options.unordered_write = write_ordering == kUnorderedWrite;
     options.level0_file_num_compaction_trigger = 2;
+    options.info_log_level = INFO_LEVEL;
     options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
     special_env.skip_fsync_ = true;
     env = new FaultInjectionTestEnv(&special_env);

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -288,6 +288,7 @@ TEST(WriteBatchWithIndex, SubBatchCnt) {
 
   delete cf_handle;
   delete db;
+  ASSERT_OK(DestroyDB(dbname, options));
 }
 
 TEST(CommitEntry64b, BasicTest) {


### PR DESCRIPTION
This change attempts to clean up some of the test/temporary files left around after running the tests.  This was discovered when attempting to run in a smaller (ram disk) TEST_TMPDIR.

Many test would destroy the DB on start but not on exit (DBTestBase does this).  With this change, the DB directory is also deleted/destroyed on test completion.

This PR does not remove ALL of the files left after a test run but gets most of them.  There are about 20-ish files/directories left around after this change (prior there were 65+ directories, some of them quite large).

Note that running tests via make check (and comparable commands) do not leave stuff around by explicitly deleting the TMPD directory after the command is complete.  This is an issue when running tests by hand/individually (and possibly when running tests via ctest?)