### PR TITLE
Fix off-by-one bug in VersionStorageInfo::ComputeFilesMarkedForForcedBlobGC

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2982,7 +2982,7 @@ void VersionStorageInfo::ComputeFilesMarkedForForcedBlobGC(
   uint64_t sum_total_blob_bytes = oldest_meta->GetTotalBlobBytes();
   uint64_t sum_garbage_blob_bytes = oldest_meta->GetGarbageBlobBytes();
 
-  while (true) {
+  while (count < blob_files_.size()) {
     const auto& meta = blob_files_[count];
     assert(meta);
 


### PR DESCRIPTION
Summary:
Fixes a bug introduced in #9526 where we index one position past the
end of a `vector`.

Test Plan:
`make asan_check`

Will add a unit test in a separate PR.