### PR TITLE
Update Java API for FilterPolicy changes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,7 +29,7 @@
 * Removed timestamp from WriteOptions. Accordingly, added to DB APIs Put, Delete, SingleDelete, etc. accepting an additional argument 'timestamp'. Added Put, Delete, SingleDelete, etc to WriteBatch accepting an additional argument 'timestamp'. Removed WriteBatch::AssignTimestamps(vector<Slice>) API. Renamed WriteBatch::AssignTimestamp() to WriteBatch::UpdateTimestamps() with clarified comments.
 * Significant updates to FilterPolicy-related APIs and configuration:
   * Remove public API support for deprecated, inefficient block-based filter (use_block_based_builder=true).
-    * Old code and configuration strings that would enable it now quietly enable full filters instead, though any built-in FilterPolicy can still read block-based filters.
+    * Old code and configuration strings that would enable it now quietly enable full filters instead, though any built-in FilterPolicy can still read block-based filters. This includes changing the longstanding default behavior of the Java API.
     * Remove deprecated FilterPolicy::CreateFilter() and FilterPolicy::KeyMayMatch()
     * Remove `rocksdb_filterpolicy_create()` from C API, as the only C API support for custom filter policies is now obsolete.
     * If temporary memory usage in full filter creation is a problem, consider using partitioned filters, smaller SST files, or setting reserve_table_builder_memory=true.

--- a/java/rocksjni/filter.cc
+++ b/java/rocksjni/filter.cc
@@ -21,13 +21,12 @@
  * Method:    createBloomFilter
  * Signature: (DZ)J
  */
-jlong Java_org_rocksdb_BloomFilter_createNewBloomFilter(
-    JNIEnv* /*env*/, jclass /*jcls*/, jdouble bits_per_key,
-    jboolean use_block_base_builder) {
+jlong Java_org_rocksdb_BloomFilter_createNewBloomFilter(JNIEnv* /*env*/,
+                                                        jclass /*jcls*/,
+                                                        jdouble bits_per_key) {
   auto* sptr_filter =
       new std::shared_ptr<const ROCKSDB_NAMESPACE::FilterPolicy>(
-          ROCKSDB_NAMESPACE::NewBloomFilterPolicy(bits_per_key,
-                                                  use_block_base_builder));
+          ROCKSDB_NAMESPACE::NewBloomFilterPolicy(bits_per_key));
   return reinterpret_cast<jlong>(sptr_filter);
 }
 

--- a/java/src/main/java/org/rocksdb/BloomFilter.java
+++ b/java/src/main/java/org/rocksdb/BloomFilter.java
@@ -21,7 +21,6 @@ package org.rocksdb;
 public class BloomFilter extends Filter {
 
   private static final double DEFAULT_BITS_PER_KEY = 10.0;
-  private static final boolean DEFAULT_MODE = true;
 
   /**
    * BloomFilter constructor
@@ -31,7 +30,7 @@ public class BloomFilter extends Filter {
    * result has been closed.</p>
    */
   public BloomFilter() {
-    this(DEFAULT_BITS_PER_KEY, DEFAULT_MODE);
+    this(DEFAULT_BITS_PER_KEY);
   }
 
   /**
@@ -48,7 +47,7 @@ public class BloomFilter extends Filter {
    * @param bitsPerKey number of bits to use
    */
   public BloomFilter(final double bitsPerKey) {
-    this(bitsPerKey, DEFAULT_MODE);
+    super(createNewBloomFilter(bitsPerKey));
   }
 
   /**
@@ -59,21 +58,16 @@ public class BloomFilter extends Filter {
    * is 10, which yields a filter with ~ 1% false positive rate.
    * <p><strong>default bits_per_key</strong>: 10</p>
    *
-   * <p>use_block_based_builder: use block based filter rather than full filter.
-   * If you want to builder full filter, it needs to be set to false.
-   * </p>
-   * <p><strong>default mode: block based filter</strong></p>
    * <p>
    * Callers must delete the result after any database that is using the
    * result has been closed.</p>
    *
    * @param bitsPerKey number of bits to use
-   * @param useBlockBasedMode use block based mode or full filter mode
+   * @param IGNORED_useBlockBasedMode obsolete, ignored parameter
    */
-  public BloomFilter(final double bitsPerKey, final boolean useBlockBasedMode) {
-    super(createNewBloomFilter(bitsPerKey, useBlockBasedMode));
+  public BloomFilter(final double bitsPerKey, final boolean IGNORED_useBlockBasedMode) {
+    this(bitsPerKey);
   }
 
-  private native static long createNewBloomFilter(final double bitsKeyKey,
-      final boolean useBlockBasedMode);
+  private native static long createNewBloomFilter(final double bitsKeyKey);
 }


### PR DESCRIPTION
Summary: Obsolete block-based filter no longer in public API, from #9535

Test Plan: existing tests