### PR TITLE
fix option_util_test when cfoption num_level got 0Option util test fix

### DIFF
--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -363,7 +363,8 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, DBOptions& db_options,
   cf_opt->max_write_buffer_number_to_maintain = rnd->Uniform(100);
   cf_opt->max_write_buffer_size_to_maintain = rnd->Uniform(10000);
   cf_opt->min_write_buffer_number_to_merge = rnd->Uniform(100);
-  cf_opt->num_levels = rnd->Uniform(100);
+  uint32_t isZero=rnd->Uniform(100);
+  cf_opt->num_levels = isZero ? 1 : isZero;
   cf_opt->target_file_size_multiplier = rnd->Uniform(100);
 
   // vector int options

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -363,8 +363,8 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, DBOptions& db_options,
   cf_opt->max_write_buffer_number_to_maintain = rnd->Uniform(100);
   cf_opt->max_write_buffer_size_to_maintain = rnd->Uniform(10000);
   cf_opt->min_write_buffer_number_to_merge = rnd->Uniform(100);
-  uint32_t isZero=rnd->Uniform(100);
-  cf_opt->num_levels = isZero ? 1 : isZero;
+  uint32_t isNotZero=rnd->Uniform(100);
+  cf_opt->num_levels = isNotZero ? isNotZero : 1;
   cf_opt->target_file_size_multiplier = rnd->Uniform(100);
 
   // vector int options


### PR DESCRIPTION
#9364 
Above issue, when RandomInitOption initialize num_level zero by accident

utilities/options/options_util_test.cc:62: Failure
PersistRocksDBOptions(db_opt, cf_names, cf_opts, kFileName, env_->GetFileSystem().get())
Invalid argument: [RocksDBOptionsParser]: failed the verification on ColumnFamilyOptions::max_bytes_for_level_multiplier_additional--- The specified one is while the persisted one is 1:1:1:1:1:1:1

occurs.

So I make If random function returns 0 just make level 1. @hx235 