### PR TITLE
FilterBitsBuilder::FinishV2 public API

### DIFF
--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -581,7 +581,6 @@ class AlwaysTrueBitsBuilder : public FilterBitsBuilder {
     // payload, 5 bytes metadata)
     return Slice("\0\0\0\0\0\0", 6);
   }
-  using FilterBitsBuilder::Finish;
   size_t ApproximateNumEntries(size_t) override { return SIZE_MAX; }
 };
 
@@ -1506,13 +1505,12 @@ TEST_P(DBFilterConstructionCorruptionTestWithParam, DetectCorruption) {
 
   SyncPoint::GetInstance()->SetCallBack(
       "XXPH3FilterBitsBuilder::Finish::TamperFilter", [&](void* arg) {
-        std::pair<std::unique_ptr<char[]>*, std::size_t>* TEST_arg_pair =
-            (std::pair<std::unique_ptr<char[]>*, std::size_t>*)arg;
+        std::pair<CacheAllocationPtr*, std::size_t>* TEST_arg_pair =
+            (std::pair<CacheAllocationPtr*, std::size_t>*)arg;
         std::size_t filter_size = TEST_arg_pair->second;
         // 5 is the kMetadataLen and
         assert(filter_size >= 8 + 5);
-        std::unique_ptr<char[]>* filter_content_to_corrupt =
-            TEST_arg_pair->first;
+        CacheAllocationPtr* filter_content_to_corrupt = TEST_arg_pair->first;
         std::memset(filter_content_to_corrupt->get(), '\0', 8);
       });
   SyncPoint::GetInstance()->EnableProcessing();

--- a/memory/memory_allocator.h
+++ b/memory/memory_allocator.h
@@ -29,7 +29,7 @@ using CacheAllocationPtr = std::unique_ptr<char[], CustomDeleter>;
 inline CacheAllocationPtr AllocateBlock(size_t size,
                                         MemoryAllocator* allocator) {
   if (allocator) {
-    auto block = reinterpret_cast<char*>(allocator->Allocate(size));
+    auto block = static_cast<char*>(allocator->Allocate(size));
     return CacheAllocationPtr(block, allocator);
   }
   return CacheAllocationPtr(new char[size]);

--- a/table/block_based/block_based_filter_block.cc
+++ b/table/block_based/block_based_filter_block.cc
@@ -117,12 +117,10 @@ inline void BlockBasedFilterBlockBuilder::AddPrefix(const Slice& key) {
   }
 }
 
-Slice BlockBasedFilterBlockBuilder::Finish(
-    const BlockHandle& /*tmp*/, Status* status,
-    std::unique_ptr<const char[]>* /* filter_data */) {
-  // In this impl we ignore BlockHandle and filter_data
-  *status = Status::OK();
-
+Status BlockBasedFilterBlockBuilder::Finish(const BlockHandle& /*prev*/,
+                                            MemoryAllocator* /*allocator*/,
+                                            CacheAllocationPtr* /*output_buf*/,
+                                            Slice* output_filter) {
   if (!start_.empty()) {
     GenerateFilter();
   }
@@ -135,7 +133,8 @@ Slice BlockBasedFilterBlockBuilder::Finish(
 
   PutFixed32(&result_, array_offset);
   result_.push_back(kFilterBaseLg);  // Save encoding parameter in result
-  return Slice(result_);
+  *output_filter = result_;
+  return Status::OK();
 }
 
 void BlockBasedFilterBlockBuilder::GenerateFilter() {

--- a/table/block_based/block_based_filter_block.h
+++ b/table/block_based/block_based_filter_block.h
@@ -52,10 +52,10 @@ class BlockBasedFilterBlockBuilder : public FilterBlockBuilder {
     return start_.empty() && filter_offsets_.empty();
   }
   virtual size_t EstimateEntriesAdded() override;
-  virtual Slice Finish(
-      const BlockHandle& tmp, Status* status,
-      std::unique_ptr<const char[]>* filter_data = nullptr) override;
-  using FilterBlockBuilder::Finish;
+
+  virtual Status Finish(const BlockHandle& prev, MemoryAllocator* allocator,
+                        CacheAllocationPtr* output_buf,
+                        Slice* output_filter) override;
 
  private:
   void AddKey(const Slice& key);

--- a/table/block_based/block_based_filter_block_test.cc
+++ b/table/block_based/block_based_filter_block_test.cc
@@ -31,7 +31,7 @@ class BlockBasedFilterBlockTest : public mock::MockBlockBasedTableTester,
 TEST_F(BlockBasedFilterBlockTest, BlockBasedEmptyBuilder) {
   FilterBlockBuilder* builder =
       new BlockBasedFilterBlockBuilder(nullptr, table_options_, 10);
-  Slice slice(builder->Finish());
+  Slice slice(builder->TEST_Finish());
   ASSERT_EQ("\\x00\\x00\\x00\\x00\\x0b", EscapeString(slice));
 
   CachableEntry<BlockContents> block(
@@ -64,7 +64,7 @@ TEST_F(BlockBasedFilterBlockTest, BlockBasedSingleChunk) {
   builder->Add("box");
   builder->StartBlock(300);
   builder->Add("hello");
-  Slice slice(builder->Finish());
+  Slice slice(builder->TEST_Finish());
 
   CachableEntry<BlockContents> block(
       new BlockContents(slice), nullptr /* cache */, nullptr /* cache_handle */,
@@ -126,7 +126,7 @@ TEST_F(BlockBasedFilterBlockTest, BlockBasedMultiChunk) {
   builder->Add("box");
   builder->Add("hello");
 
-  Slice slice(builder->Finish());
+  Slice slice(builder->TEST_Finish());
 
   CachableEntry<BlockContents> block(
       new BlockContents(slice), nullptr /* cache */, nullptr /* cache_handle */,

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1568,9 +1568,11 @@ void BlockBasedTableBuilder::WriteFilterBlock(
       // See FilterBlockBuilder::Finish() for more on the difference in
       // transferred filter data payload among different FilterBlockBuilder
       // subtypes.
-      std::unique_ptr<const char[]> filter_data;
-      Slice filter_content =
-          rep_->filter_builder->Finish(filter_block_handle, &s, &filter_data);
+      CacheAllocationPtr filter_data;
+      Slice filter_content;
+      s = rep_->filter_builder->Finish(filter_block_handle,
+                                       /*TODO: allocator*/ nullptr,
+                                       &filter_data, &filter_content);
 
       assert(s.ok() || s.IsIncomplete() || s.IsCorruption());
       if (s.IsCorruption()) {

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -37,9 +37,9 @@ class PartitionedFilterBlockBuilder : public FullFilterBlockBuilder {
   void Add(const Slice& key) override;
   size_t EstimateEntriesAdded() override;
 
-  virtual Slice Finish(
-      const BlockHandle& last_partition_block_handle, Status* status,
-      std::unique_ptr<const char[]>* filter_data = nullptr) override;
+  virtual Status Finish(const BlockHandle& prev, MemoryAllocator* allocator,
+                        CacheAllocationPtr* output_buf,
+                        Slice* output_filter) override;
 
   virtual void ResetFilterBitsBuilder() override {
     // Previously constructed partitioned filters by
@@ -65,7 +65,7 @@ class PartitionedFilterBlockBuilder : public FullFilterBlockBuilder {
       index_on_filter_block_builder_without_seq_;  // same for user keys
   struct FilterEntry {
     std::string key;
-    std::unique_ptr<const char[]> filter_data;
+    CacheAllocationPtr filter_data;
     Slice filter;
   };
   std::deque<FilterEntry> filters;  // list of partitioned filters and keys used
@@ -77,7 +77,7 @@ class PartitionedFilterBlockBuilder : public FullFilterBlockBuilder {
   // then the whole partitioned filters should not be used.
   Status partitioned_filters_construction_status_;
   std::string last_filter_entry_key;
-  std::unique_ptr<const char[]> last_filter_data;
+  CacheAllocationPtr last_filter_data;
   std::unique_ptr<IndexBuilder> value;
   bool finishing_filters =
       false;  // true if Finish is called once but not complete yet.

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -136,9 +136,9 @@ class PartitionedFilterBlockTest
     BlockHandle bh;
     Status status;
     Slice slice;
-    std::unique_ptr<const char[]> filter_data;
     do {
-      slice = builder->Finish(bh, &status, &filter_data);
+      status = builder->Finish(bh, /*allocator*/ nullptr,
+                               /*output_buf*/ nullptr, &slice);
       bh = Write(slice);
     } while (status.IsIncomplete());
 

--- a/util/filter_bench.cc
+++ b/util/filter_bench.cc
@@ -440,8 +440,11 @@ void FilterBench::Go() {
       for (uint32_t i = 0; i < keys_to_add; ++i) {
         builder->AddKey(kms_[0].Get(filter_id, i));
       }
-      info.filter_ =
-          builder->Finish(&info.owner_, &info.filter_construction_status);
+      info.filter_construction_status =
+          builder->FinishV2(/*allocator*/ nullptr, &info.filter_);
+      if (info.filter_.size() > 0) {
+        info.owner_.reset(info.filter_.data());
+      }
       if (info.filter_construction_status.ok()) {
         info.filter_construction_status =
             builder->MaybePostVerify(info.filter_);

--- a/utilities/memory_allocators.h
+++ b/utilities/memory_allocators.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <malloc.h>
+
 #include <atomic>
 
 #include "rocksdb/memory_allocator.h"
@@ -20,6 +22,16 @@ class DefaultMemoryAllocator : public MemoryAllocator {
   }
 
   void Deallocate(void* p) override { delete[] static_cast<char*>(p); }
+
+  size_t UsableSize(void* p, size_t allocation_size) const override {
+#ifdef ROCKSDB_MALLOC_USABLE_SIZE
+    (void)allocation_size;
+    return malloc_usable_size(p);
+#else
+    (void)p;
+    return allocation_size;
+#endif  // ROCKSDB_MALLOC_USABLE_SIZE
+  }
 };
 
 // Base class for a MemoryAllocator.  This implementation does nothing


### PR DESCRIPTION
Summary:
We recently added a new variant of FilterBitsBuilder::Finish to allow
for construction failure when some memory or CPU corruption is detected.
This came with some known awkwardness:

* Overloading causes people to have to add `using
FilterBitsBuilder::Finish` to their code even if they didn't make any
changes.
* Status is an optional output parameter rather than return value
(convention). Being optional causes the implementor to have to deal with
the case in which there was corruption, but they're unable to report
that directly to the caller. (Use safe "always true" filter for this
case.)

This commit solves some of that awkwardness, and predicted future needs,
with ::FinishV2 (Note: we have other V2 functions in public APIs)

* No need for `using FilterBitsBuilder::Finish`
* Status is return value
* The caller can specify a MemoryAllocator to use for allocating the
filter block. With a bit more work, this will enable "no copy" block
cache warming. This would be especially useful in a future in which
allocations from the block cache allocator are directly drawn from the
block cache memory budget without the need for managing cache
reservations.

The new function would be easier to understand if CacheAllocationPtr
were a public type (along with CustomDeleter), but I don't think we
should make that public, at least until we get rid of the idiom of using
nullptr for default allocator.

Test Plan: existing tests. The allocator functionality is mostly a
placeholder in the public API for future use, so I don't think it needs
to be fully vetted until RocksDB calls FinishV2 will an allocator other
than nullptr.