### PR TITLE
Revert "Refactor FilterPolicies toward Customizable (#9567)"

### DIFF
--- a/microbench/ribbon_bench.cc
+++ b/microbench/ribbon_bench.cc
@@ -47,28 +47,30 @@ struct KeyMaker {
 };
 
 // benchmark arguments:
-// 0. filter impl (like filter_bench -impl)
+// 0. filter mode
 // 1. filter config bits_per_key
 // 2. average data key length
 // 3. data entry number
 static void CustomArguments(benchmark::internal::Benchmark *b) {
-  for (int filter_impl : {0, 2, 3}) {
+  for (int filter_mode :
+       {BloomFilterPolicy::kLegacyBloom, BloomFilterPolicy::kFastLocalBloom,
+        BloomFilterPolicy::kStandard128Ribbon}) {
     for (int bits_per_key : {10, 20}) {
       for (int key_len_avg : {10, 100}) {
         for (int64_t entry_num : {1 << 10, 1 << 20}) {
-          b->Args({filter_impl, bits_per_key, key_len_avg, entry_num});
+          b->Args({filter_mode, bits_per_key, key_len_avg, entry_num});
         }
       }
     }
   }
-  b->ArgNames({"filter_impl", "bits_per_key", "key_len_avg", "entry_num"});
+  b->ArgNames({"filter_mode", "bits_per_key", "key_len_avg", "entry_num"});
 }
 
 static void FilterBuild(benchmark::State &state) {
   // setup data
-  auto filter = BloomLikeFilterPolicy::Create(
-      BloomLikeFilterPolicy::GetAllFixedImpls().at(state.range(0)),
-      static_cast<double>(state.range(1)));
+  auto filter = new BloomFilterPolicy(
+      static_cast<double>(state.range(1)),
+      static_cast<BloomFilterPolicy::Mode>(state.range(0)));
   auto tester = new mock::MockBlockBasedTableTester(filter);
   KeyMaker km(state.range(2));
   std::unique_ptr<const char[]> owner;
@@ -89,9 +91,9 @@ BENCHMARK(FilterBuild)->Apply(CustomArguments);
 
 static void FilterQueryPositive(benchmark::State &state) {
   // setup data
-  auto filter = BloomLikeFilterPolicy::Create(
-      BloomLikeFilterPolicy::GetAllFixedImpls().at(state.range(0)),
-      static_cast<double>(state.range(1)));
+  auto filter = new BloomFilterPolicy(
+      static_cast<double>(state.range(1)),
+      static_cast<BloomFilterPolicy::Mode>(state.range(0)));
   auto tester = new mock::MockBlockBasedTableTester(filter);
   KeyMaker km(state.range(2));
   std::unique_ptr<const char[]> owner;
@@ -117,9 +119,9 @@ BENCHMARK(FilterQueryPositive)->Apply(CustomArguments);
 
 static void FilterQueryNegative(benchmark::State &state) {
   // setup data
-  auto filter = BloomLikeFilterPolicy::Create(
-      BloomLikeFilterPolicy::GetAllFixedImpls().at(state.range(0)),
-      static_cast<double>(state.range(1)));
+  auto filter = new BloomFilterPolicy(
+      static_cast<double>(state.range(1)),
+      static_cast<BloomFilterPolicy::Mode>(state.range(0)));
   auto tester = new mock::MockBlockBasedTableTester(filter);
   KeyMaker km(state.range(2));
   std::unique_ptr<const char[]> owner;

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -882,6 +882,7 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
       dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
   EXPECT_EQ(bfp->GetMillibitsPerKey(), 4567);
   EXPECT_EQ(bfp->GetWholeBitsPerKey(), 5);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kAutoBloom);
   // Verify that only the lower 32bits are stored in
   // new_opt.read_amp_bytes_per_bit.
   EXPECT_EQ(1U, new_opt.read_amp_bytes_per_bit);
@@ -935,6 +936,7 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
   bfp = dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
   EXPECT_EQ(bfp->GetMillibitsPerKey(), 4000);
   EXPECT_EQ(bfp->GetWholeBitsPerKey(), 4);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kAutoBloom);
 
   // use_block_based_builder=true now ignored in public API (same as false)
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
@@ -942,67 +944,82 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
   bfp = dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
   EXPECT_EQ(bfp->GetMillibitsPerKey(), 4000);
   EXPECT_EQ(bfp->GetWholeBitsPerKey(), 4);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kAutoBloom);
 
   // Back door way of enabling deprecated block-based Bloom
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
       config_options, table_opt,
       "filter_policy=rocksdb.internal.DeprecatedBlockBasedBloomFilter:4",
       &new_opt));
-  auto builtin =
-      dynamic_cast<const BuiltinFilterPolicy*>(new_opt.filter_policy.get());
-  EXPECT_EQ(builtin->GetId(),
-            "rocksdb.internal.DeprecatedBlockBasedBloomFilter:4");
+  bfp = dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
+  EXPECT_EQ(bfp->GetWholeBitsPerKey(), 4);  // Only whole bits used
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kDeprecatedBlock);
 
   // Test configuring using other internal names
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
       config_options, table_opt,
       "filter_policy=rocksdb.internal.LegacyBloomFilter:3", &new_opt));
-  builtin =
-      dynamic_cast<const BuiltinFilterPolicy*>(new_opt.filter_policy.get());
-  EXPECT_EQ(builtin->GetId(), "rocksdb.internal.LegacyBloomFilter:3");
+  bfp = dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
+  EXPECT_EQ(bfp->GetWholeBitsPerKey(), 3);  // Only whole bits used
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kLegacyBloom);
 
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
       config_options, table_opt,
       "filter_policy=rocksdb.internal.FastLocalBloomFilter:1.234", &new_opt));
-  builtin =
-      dynamic_cast<const BuiltinFilterPolicy*>(new_opt.filter_policy.get());
-  EXPECT_EQ(builtin->GetId(), "rocksdb.internal.FastLocalBloomFilter:1.234");
+  bfp = dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
+  EXPECT_EQ(bfp->GetMillibitsPerKey(), 1234);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kFastLocalBloom);
 
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
       config_options, table_opt,
       "filter_policy=rocksdb.internal.Standard128RibbonFilter:1.234",
       &new_opt));
-  builtin =
-      dynamic_cast<const BuiltinFilterPolicy*>(new_opt.filter_policy.get());
-  EXPECT_EQ(builtin->GetId(), "rocksdb.internal.Standard128RibbonFilter:1.234");
+  bfp = dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
+  EXPECT_EQ(bfp->GetMillibitsPerKey(), 1234);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kStandard128Ribbon);
 
   // Ribbon filter policy (no Bloom hybrid)
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
       config_options, table_opt, "filter_policy=ribbonfilter:5.678:-1;",
       &new_opt));
   ASSERT_TRUE(new_opt.filter_policy != nullptr);
-  auto rfp =
-      dynamic_cast<const RibbonFilterPolicy*>(new_opt.filter_policy.get());
-  EXPECT_EQ(rfp->GetMillibitsPerKey(), 5678);
-  EXPECT_EQ(rfp->GetBloomBeforeLevel(), -1);
+  bfp = dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
+  EXPECT_EQ(bfp->GetMillibitsPerKey(), 5678);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kStandard128Ribbon);
 
   // Ribbon filter policy (default Bloom hybrid)
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
       config_options, table_opt, "filter_policy=ribbonfilter:6.789;",
       &new_opt));
   ASSERT_TRUE(new_opt.filter_policy != nullptr);
-  rfp = dynamic_cast<const RibbonFilterPolicy*>(new_opt.filter_policy.get());
-  EXPECT_EQ(rfp->GetMillibitsPerKey(), 6789);
-  EXPECT_EQ(rfp->GetBloomBeforeLevel(), 0);
+  auto ltfp = dynamic_cast<const LevelThresholdFilterPolicy*>(
+      new_opt.filter_policy.get());
+  EXPECT_EQ(ltfp->TEST_GetStartingLevelForB(), 0);
+
+  bfp = dynamic_cast<const BloomFilterPolicy*>(ltfp->TEST_GetPolicyA());
+  EXPECT_EQ(bfp->GetMillibitsPerKey(), 6789);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kFastLocalBloom);
+
+  bfp = dynamic_cast<const BloomFilterPolicy*>(ltfp->TEST_GetPolicyB());
+  EXPECT_EQ(bfp->GetMillibitsPerKey(), 6789);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kStandard128Ribbon);
 
   // Ribbon filter policy (custom Bloom hybrid)
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
       config_options, table_opt, "filter_policy=ribbonfilter:6.789:5;",
       &new_opt));
   ASSERT_TRUE(new_opt.filter_policy != nullptr);
-  rfp = dynamic_cast<const RibbonFilterPolicy*>(new_opt.filter_policy.get());
-  EXPECT_EQ(rfp->GetMillibitsPerKey(), 6789);
-  EXPECT_EQ(rfp->GetBloomBeforeLevel(), 5);
+  ltfp = dynamic_cast<const LevelThresholdFilterPolicy*>(
+      new_opt.filter_policy.get());
+  EXPECT_EQ(ltfp->TEST_GetStartingLevelForB(), 5);
+
+  bfp = dynamic_cast<const BloomFilterPolicy*>(ltfp->TEST_GetPolicyA());
+  EXPECT_EQ(bfp->GetMillibitsPerKey(), 6789);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kFastLocalBloom);
+
+  bfp = dynamic_cast<const BloomFilterPolicy*>(ltfp->TEST_GetPolicyB());
+  EXPECT_EQ(bfp->GetMillibitsPerKey(), 6789);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kStandard128Ribbon);
 
   // Check block cache options are overwritten when specified
   // in new format as a struct.
@@ -2860,6 +2877,7 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
   bfp = dynamic_cast<const BloomFilterPolicy*>(new_opt.filter_policy.get());
   EXPECT_EQ(bfp->GetMillibitsPerKey(), 4000);
   EXPECT_EQ(bfp->GetWholeBitsPerKey(), 4);
+  EXPECT_EQ(bfp->GetMode(), BloomFilterPolicy::kAutoBloom);
 
   // Check block cache options are overwritten when specified
   // in new format as a struct.

--- a/table/block_based/block_based_filter_block.cc
+++ b/table/block_based/block_based_filter_block.cc
@@ -15,7 +15,6 @@
 #include "monitoring/perf_context_imp.h"
 #include "rocksdb/filter_policy.h"
 #include "table/block_based/block_based_table_reader.h"
-#include "util/cast_util.h"
 #include "util/coding.h"
 #include "util/string_util.h"
 
@@ -158,9 +157,9 @@ void BlockBasedFilterBlockBuilder::GenerateFilter() {
 
   // Generate filter for current set of keys and append to result_.
   filter_offsets_.push_back(static_cast<uint32_t>(result_.size()));
-  DeprecatedBlockBasedBloomFilterPolicy::CreateFilter(
-      tmp_entries_.data(), static_cast<int>(num_entries), bits_per_key_,
-      &result_);
+  BloomFilterPolicy::CreateFilter(tmp_entries_.data(),
+                                  static_cast<int>(num_entries), bits_per_key_,
+                                  &result_);
 
   tmp_entries_.clear();
   entries_.clear();
@@ -284,8 +283,7 @@ bool BlockBasedFilterBlockReader::MayMatch(
       assert(table());
       assert(table()->get_rep());
 
-      const bool may_match =
-          DeprecatedBlockBasedBloomFilterPolicy::KeyMayMatch(entry, filter);
+      const bool may_match = BloomFilterPolicy::KeyMayMatch(entry, filter);
       if (may_match) {
         PERF_COUNTER_ADD(bloom_sst_hit_count, 1);
         return true;

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -82,8 +82,7 @@ FilterBlockBuilder* CreateFilterBlockBuilder(
   } else {
     // Check for backdoor deprecated block-based bloom config
     size_t starting_est = filter_bits_builder->EstimateEntriesAdded();
-    constexpr auto kSecretStart =
-        DeprecatedBlockBasedBloomFilterPolicy::kSecretBitsPerKeyStart;
+    constexpr auto kSecretStart = BloomFilterPolicy::kSecretBitsPerKeyStart;
     if (starting_est >= kSecretStart && starting_est < kSecretStart + 100) {
       int bits_per_key = static_cast<int>(starting_est - kSecretStart);
       delete filter_bits_builder;

--- a/table/block_based/filter_policy.cc
+++ b/table/block_based/filter_policy.cc
@@ -10,7 +10,6 @@
 #include "rocksdb/filter_policy.h"
 
 #include <array>
-#include <climits>
 #include <cstring>
 #include <deque>
 #include <limits>
@@ -19,8 +18,6 @@
 #include "cache/cache_entry_roles.h"
 #include "cache/cache_reservation_manager.h"
 #include "logging/logging.h"
-#include "port/lang.h"
-#include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/slice.h"
 #include "table/block_based/block_based_filter_block.h"
 #include "table/block_based/block_based_table_reader.h"
@@ -32,7 +29,6 @@
 #include "util/hash.h"
 #include "util/ribbon_config.h"
 #include "util/ribbon_impl.h"
-#include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -1311,8 +1307,21 @@ Status XXPH3FilterBitsBuilder::MaybePostVerify(const Slice& filter_content) {
 }
 }  // namespace
 
-BloomLikeFilterPolicy::BloomLikeFilterPolicy(double bits_per_key)
-    : warned_(false), aggregate_rounding_balance_(0) {
+const std::vector<BloomFilterPolicy::Mode> BloomFilterPolicy::kAllFixedImpls = {
+    kLegacyBloom,
+    kDeprecatedBlock,
+    kFastLocalBloom,
+    kStandard128Ribbon,
+};
+
+const std::vector<BloomFilterPolicy::Mode> BloomFilterPolicy::kAllUserModes = {
+    kDeprecatedBlock,
+    kAutoBloom,
+    kStandard128Ribbon,
+};
+
+BloomFilterPolicy::BloomFilterPolicy(double bits_per_key, Mode mode)
+    : mode_(mode), warned_(false), aggregate_rounding_balance_(0) {
   // Sanitize bits_per_key
   if (bits_per_key < 0.5) {
     // Round down to no filter
@@ -1344,48 +1353,14 @@ BloomLikeFilterPolicy::BloomLikeFilterPolicy(double bits_per_key)
   whole_bits_per_key_ = (millibits_per_key_ + 500) / 1000;
 }
 
-BloomLikeFilterPolicy::~BloomLikeFilterPolicy() {}
+BloomFilterPolicy::~BloomFilterPolicy() {}
 
 const char* BuiltinFilterPolicy::Name() const {
   return "rocksdb.BuiltinBloomFilter";
 }
 
-const char* DeprecatedBlockBasedBloomFilterPolicy::kName() {
-  return "rocksdb.internal.DeprecatedBlockBasedBloomFilter";
-}
-
-std::string DeprecatedBlockBasedBloomFilterPolicy::GetId() const {
-  return kName() + GetBitsPerKeySuffix();
-}
-
-DeprecatedBlockBasedBloomFilterPolicy::DeprecatedBlockBasedBloomFilterPolicy(
-    double bits_per_key)
-    : BloomLikeFilterPolicy(bits_per_key) {}
-
-FilterBitsBuilder* DeprecatedBlockBasedBloomFilterPolicy::GetBuilderWithContext(
-    const FilterBuildingContext&) const {
-  if (GetWholeBitsPerKey() == 0) {
-    // "No filter" special case
-    return nullptr;
-  }
-  // Internal contract: returns a new fake builder that encodes bits per key
-  // into a special value from EstimateEntriesAdded()
-  struct B : public FilterBitsBuilder {
-    explicit B(int bits_per_key) : est(kSecretBitsPerKeyStart + bits_per_key) {}
-    size_t est;
-    size_t EstimateEntriesAdded() override { return est; }
-    void AddKey(const Slice&) override {}
-    using FilterBitsBuilder::Finish;  // FIXME
-    Slice Finish(std::unique_ptr<const char[]>*) override { return Slice(); }
-    size_t ApproximateNumEntries(size_t) override { return 0; }
-  };
-  return new B(GetWholeBitsPerKey());
-}
-
-void DeprecatedBlockBasedBloomFilterPolicy::CreateFilter(const Slice* keys,
-                                                         int n,
-                                                         int bits_per_key,
-                                                         std::string* dst) {
+void BloomFilterPolicy::CreateFilter(const Slice* keys, int n, int bits_per_key,
+                                     std::string* dst) {
   // Compute bloom filter size (in both bits and bytes)
   uint32_t bits = static_cast<uint32_t>(n * bits_per_key);
 
@@ -1408,8 +1383,8 @@ void DeprecatedBlockBasedBloomFilterPolicy::CreateFilter(const Slice* keys,
   }
 }
 
-bool DeprecatedBlockBasedBloomFilterPolicy::KeyMayMatch(
-    const Slice& key, const Slice& bloom_filter) {
+bool BloomFilterPolicy::KeyMayMatch(const Slice& key,
+                                    const Slice& bloom_filter) {
   const size_t len = bloom_filter.size();
   if (len < 2 || len > 0xffffffffU) {
     return false;
@@ -1431,31 +1406,13 @@ bool DeprecatedBlockBasedBloomFilterPolicy::KeyMayMatch(
                                                  array);
 }
 
-BloomFilterPolicy::BloomFilterPolicy(double bits_per_key)
-    : BloomLikeFilterPolicy(bits_per_key) {}
-
 FilterBitsBuilder* BloomFilterPolicy::GetBuilderWithContext(
     const FilterBuildingContext& context) const {
-  if (GetMillibitsPerKey() == 0) {
+  if (millibits_per_key_ == 0) {
     // "No filter" special case
     return nullptr;
-  } else if (context.table_options.format_version < 5) {
-    return GetLegacyBloomBuilderWithContext(context);
-  } else {
-    return GetFastLocalBloomBuilderWithContext(context);
   }
-}
-
-const char* BloomFilterPolicy::kName() { return "bloomfilter"; }
-
-std::string BloomFilterPolicy::GetId() const {
-  // Including ":false" for better forward-compatibility with 6.29 and earlier
-  // which required a boolean `use_block_based_builder` parameter
-  return kName() + GetBitsPerKeySuffix() + ":false";
-}
-
-FilterBitsBuilder* BloomLikeFilterPolicy::GetFastLocalBloomBuilderWithContext(
-    const FilterBuildingContext& context) const {
+  Mode cur = mode_;
   bool offm = context.table_options.optimize_filters_for_memory;
   bool reserve_filter_construction_mem =
       (context.table_options.reserve_table_builder_memory &&
@@ -1465,73 +1422,80 @@ FilterBitsBuilder* BloomLikeFilterPolicy::GetFastLocalBloomBuilderWithContext(
     cache_res_mgr = std::make_shared<CacheReservationManager>(
         context.table_options.block_cache);
   }
+  // Unusual code construction so that we can have just
+  // one exhaustive switch without (risky) recursion
+  for (int i = 0; i < 2; ++i) {
+    switch (cur) {
+      case kAutoBloom:
+        if (context.table_options.format_version < 5) {
+          cur = kLegacyBloom;
+        } else {
+          cur = kFastLocalBloom;
+        }
+        break;
+      case kDeprecatedBlock: {
+        if (context.info_log && !warned_.load(std::memory_order_relaxed)) {
+          warned_ = true;
+          ROCKS_LOG_WARN(context.info_log,
+                         "Using deprecated block-based Bloom filter is "
+                         "inefficient (%d bits per key).",
+                         whole_bits_per_key_);
+        }
+        // Internal contract: returns a new fake builder that encodes bits per
+        // key into a special value from EstimateEntriesAdded()
+        struct B : public FilterBitsBuilder {
+          explicit B(int bits_per_key)
+              : est(kSecretBitsPerKeyStart + bits_per_key) {}
+          size_t est;
+          size_t EstimateEntriesAdded() override { return est; }
+          void AddKey(const Slice&) override {}
+          using FilterBitsBuilder::Finish;  // FIXME
+          Slice Finish(std::unique_ptr<const char[]>*) override {
+            return Slice();
+          }
+          size_t ApproximateNumEntries(size_t) override { return 0; }
+        };
+        return new B(GetWholeBitsPerKey());
+      }
+      case kFastLocalBloom:
         return new FastLocalBloomBitsBuilder(
             millibits_per_key_, offm ? &aggregate_rounding_balance_ : nullptr,
             cache_res_mgr,
             context.table_options.detect_filter_construct_corruption);
-}
-
-FilterBitsBuilder* BloomLikeFilterPolicy::GetLegacyBloomBuilderWithContext(
-    const FilterBuildingContext& context) const {
-  if (whole_bits_per_key_ >= 14 && context.info_log &&
-      !warned_.load(std::memory_order_relaxed)) {
-    warned_ = true;
-    const char* adjective;
-    if (whole_bits_per_key_ >= 20) {
-      adjective = "Dramatic";
-    } else {
-      adjective = "Significant";
-    }
-    // For more details, see
-    // https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter
-    ROCKS_LOG_WARN(context.info_log,
-                   "Using legacy Bloom filter with high (%d) bits/key. "
-                   "%s filter space and/or accuracy improvement is available "
-                   "with format_version>=5.",
-                   whole_bits_per_key_, adjective);
-  }
-  return new LegacyBloomBitsBuilder(whole_bits_per_key_, context.info_log);
-}
-
-FilterBitsBuilder*
-BloomLikeFilterPolicy::GetStandard128RibbonBuilderWithContext(
-    const FilterBuildingContext& context) const {
-  // FIXME: code duplication with GetFastLocalBloomBuilderWithContext
-  bool offm = context.table_options.optimize_filters_for_memory;
-  bool reserve_filter_construction_mem =
-      (context.table_options.reserve_table_builder_memory &&
-       context.table_options.block_cache);
-  std::shared_ptr<CacheReservationManager> cache_res_mgr;
-  if (reserve_filter_construction_mem) {
-    cache_res_mgr = std::make_shared<CacheReservationManager>(
-        context.table_options.block_cache);
-  }
-  return new Standard128RibbonBitsBuilder(
-      desired_one_in_fp_rate_, millibits_per_key_,
-      offm ? &aggregate_rounding_balance_ : nullptr, cache_res_mgr,
-      context.table_options.detect_filter_construct_corruption,
-      context.info_log);
-}
-
-std::string BloomLikeFilterPolicy::GetBitsPerKeySuffix() const {
-  std::string rv = ":" + ROCKSDB_NAMESPACE::ToString(millibits_per_key_ / 1000);
-  int frac = millibits_per_key_ % 1000;
-  if (frac > 0) {
-    rv.push_back('.');
-    rv.push_back(static_cast<char>('0' + (frac / 100)));
-    frac %= 100;
-    if (frac > 0) {
-      rv.push_back(static_cast<char>('0' + (frac / 10)));
-      frac %= 10;
-      if (frac > 0) {
-        rv.push_back(static_cast<char>('0' + frac));
-      }
+      case kLegacyBloom:
+        if (whole_bits_per_key_ >= 14 && context.info_log &&
+            !warned_.load(std::memory_order_relaxed)) {
+          warned_ = true;
+          const char* adjective;
+          if (whole_bits_per_key_ >= 20) {
+            adjective = "Dramatic";
+          } else {
+            adjective = "Significant";
+          }
+          // For more details, see
+          // https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter
+          ROCKS_LOG_WARN(
+              context.info_log,
+              "Using legacy Bloom filter with high (%d) bits/key. "
+              "%s filter space and/or accuracy improvement is available "
+              "with format_version>=5.",
+              whole_bits_per_key_, adjective);
+        }
+        return new LegacyBloomBitsBuilder(whole_bits_per_key_,
+                                          context.info_log);
+      case kStandard128Ribbon:
+        return new Standard128RibbonBitsBuilder(
+            desired_one_in_fp_rate_, millibits_per_key_,
+            offm ? &aggregate_rounding_balance_ : nullptr, cache_res_mgr,
+            context.table_options.detect_filter_construct_corruption,
+            context.info_log);
     }
   }
-  return rv;
+  assert(false);
+  return nullptr;  // something legal
 }
 
-FilterBitsBuilder* BuiltinFilterPolicy::GetBuilderFromContext(
+FilterBitsBuilder* BloomFilterPolicy::GetBuilderFromContext(
     const FilterBuildingContext& context) {
   if (context.table_options.filter_policy) {
     return context.table_options.filter_policy->GetBuilderWithContext(context);
@@ -1539,62 +1503,6 @@ FilterBitsBuilder* BuiltinFilterPolicy::GetBuilderFromContext(
     return nullptr;
   }
 }
-
-// For testing only, but always constructable with internal names
-namespace test {
-
-const char* LegacyBloomFilterPolicy::kName() {
-  return "rocksdb.internal.LegacyBloomFilter";
-}
-
-std::string LegacyBloomFilterPolicy::GetId() const {
-  return kName() + GetBitsPerKeySuffix();
-}
-
-FilterBitsBuilder* LegacyBloomFilterPolicy::GetBuilderWithContext(
-    const FilterBuildingContext& context) const {
-  if (GetMillibitsPerKey() == 0) {
-    // "No filter" special case
-    return nullptr;
-  }
-  return GetLegacyBloomBuilderWithContext(context);
-}
-
-const char* FastLocalBloomFilterPolicy::kName() {
-  return "rocksdb.internal.FastLocalBloomFilter";
-}
-
-std::string FastLocalBloomFilterPolicy::GetId() const {
-  return kName() + GetBitsPerKeySuffix();
-}
-
-FilterBitsBuilder* FastLocalBloomFilterPolicy::GetBuilderWithContext(
-    const FilterBuildingContext& context) const {
-  if (GetMillibitsPerKey() == 0) {
-    // "No filter" special case
-    return nullptr;
-  }
-  return GetFastLocalBloomBuilderWithContext(context);
-}
-
-const char* Standard128RibbonFilterPolicy::kName() {
-  return "rocksdb.internal.Standard128RibbonFilter";
-}
-
-std::string Standard128RibbonFilterPolicy::GetId() const {
-  return kName() + GetBitsPerKeySuffix();
-}
-
-FilterBitsBuilder* Standard128RibbonFilterPolicy::GetBuilderWithContext(
-    const FilterBuildingContext& context) const {
-  if (GetMillibitsPerKey() == 0) {
-    // "No filter" special case
-    return nullptr;
-  }
-  return GetStandard128RibbonBuilderWithContext(context);
-}
-
-}  // namespace test
 
 BuiltinFilterBitsReader* BuiltinFilterPolicy::GetBuiltinFilterBitsReader(
     const Slice& contents) {
@@ -1771,58 +1679,70 @@ const FilterPolicy* NewBloomFilterPolicy(double bits_per_key,
                                          bool /*use_block_based_builder*/) {
   // NOTE: use_block_based_builder now ignored so block-based filter is no
   // longer accessible in public API.
-  return new BloomFilterPolicy(bits_per_key);
+  BloomFilterPolicy::Mode m = BloomFilterPolicy::kAutoBloom;
+  assert(std::find(BloomFilterPolicy::kAllUserModes.begin(),
+                   BloomFilterPolicy::kAllUserModes.end(),
+                   m) != BloomFilterPolicy::kAllUserModes.end());
+  return new BloomFilterPolicy(bits_per_key, m);
 }
 
-RibbonFilterPolicy::RibbonFilterPolicy(double bloom_equivalent_bits_per_key,
-                                       int bloom_before_level)
-    : BloomLikeFilterPolicy(bloom_equivalent_bits_per_key),
-      bloom_before_level_(bloom_before_level) {}
+// Chooses between two filter policies based on LSM level, but
+// only for Level and Universal compaction styles. Flush is treated
+// as level -1. Policy b is considered fallback / primary policy.
+LevelThresholdFilterPolicy::LevelThresholdFilterPolicy(
+    std::unique_ptr<const FilterPolicy>&& a,
+    std::unique_ptr<const FilterPolicy>&& b, int starting_level_for_b)
+    : policy_a_(std::move(a)),
+      policy_b_(std::move(b)),
+      starting_level_for_b_(starting_level_for_b) {
+  // Don't use this wrapper class if you were going to set to -1
+  assert(starting_level_for_b_ >= 0);
+}
 
-FilterBitsBuilder* RibbonFilterPolicy::GetBuilderWithContext(
+FilterBitsBuilder* LevelThresholdFilterPolicy::GetBuilderWithContext(
     const FilterBuildingContext& context) const {
-  // Treat unknown same as bottommost
-  int levelish = INT_MAX;
-
   switch (context.compaction_style) {
     case kCompactionStyleLevel:
     case kCompactionStyleUniversal: {
+      int levelish;
       if (context.reason == TableFileCreationReason::kFlush) {
         // Treat flush as level -1
         assert(context.level_at_creation == 0);
         levelish = -1;
       } else if (context.level_at_creation == -1) {
         // Unknown level
-        assert(levelish == INT_MAX);
+        // Policy b considered fallback / primary
+        return policy_b_->GetBuilderWithContext(context);
       } else {
         levelish = context.level_at_creation;
       }
-      break;
+      if (levelish >= starting_level_for_b_) {
+        return policy_b_->GetBuilderWithContext(context);
+      } else {
+        return policy_a_->GetBuilderWithContext(context);
+      }
     }
     case kCompactionStyleFIFO:
     case kCompactionStyleNone:
-      // Treat as bottommost
-      assert(levelish == INT_MAX);
       break;
   }
-  if (levelish < bloom_before_level_) {
-    return GetFastLocalBloomBuilderWithContext(context);
-  } else {
-    return GetStandard128RibbonBuilderWithContext(context);
-  }
-}
-
-const char* RibbonFilterPolicy::kName() { return "ribbonfilter"; }
-
-std::string RibbonFilterPolicy::GetId() const {
-  return kName() + GetBitsPerKeySuffix() + ":" +
-         ROCKSDB_NAMESPACE::ToString(bloom_before_level_);
+  // Policy b considered fallback / primary
+  return policy_b_->GetBuilderWithContext(context);
 }
 
 const FilterPolicy* NewRibbonFilterPolicy(double bloom_equivalent_bits_per_key,
                                           int bloom_before_level) {
-  return new RibbonFilterPolicy(bloom_equivalent_bits_per_key,
-                                bloom_before_level);
+  std::unique_ptr<const FilterPolicy> ribbon_only{new BloomFilterPolicy(
+      bloom_equivalent_bits_per_key, BloomFilterPolicy::kStandard128Ribbon)};
+  if (bloom_before_level > -1) {
+    // Could also use Bloom policy
+    std::unique_ptr<const FilterPolicy> bloom_only{new BloomFilterPolicy(
+        bloom_equivalent_bits_per_key, BloomFilterPolicy::kFastLocalBloom)};
+    return new LevelThresholdFilterPolicy(
+        std::move(bloom_only), std::move(ribbon_only), bloom_before_level);
+  } else {
+    return ribbon_only.release();
+  }
 }
 
 FilterBuildingContext::FilterBuildingContext(
@@ -1831,84 +1751,55 @@ FilterBuildingContext::FilterBuildingContext(
 
 FilterPolicy::~FilterPolicy() { }
 
-std::shared_ptr<const FilterPolicy> BloomLikeFilterPolicy::Create(
-    const std::string& name, double bits_per_key) {
-  if (name == test::LegacyBloomFilterPolicy::kName()) {
-    return std::make_shared<test::LegacyBloomFilterPolicy>(bits_per_key);
-  } else if (name == test::FastLocalBloomFilterPolicy::kName()) {
-    return std::make_shared<test::FastLocalBloomFilterPolicy>(bits_per_key);
-  } else if (name == test::Standard128RibbonFilterPolicy::kName()) {
-    return std::make_shared<test::Standard128RibbonFilterPolicy>(bits_per_key);
-  } else if (name == DeprecatedBlockBasedBloomFilterPolicy::kName()) {
-    return std::make_shared<DeprecatedBlockBasedBloomFilterPolicy>(
-        bits_per_key);
-  } else if (name == BloomFilterPolicy::kName()) {
-    // For testing
-    return std::make_shared<BloomFilterPolicy>(bits_per_key);
-  } else if (name == RibbonFilterPolicy::kName()) {
-    // For testing
-    return std::make_shared<RibbonFilterPolicy>(bits_per_key,
-                                                /*bloom_before_level*/ 0);
-  } else {
-    return nullptr;
-  }
-}
-
 Status FilterPolicy::CreateFromString(
     const ConfigOptions& /*options*/, const std::string& value,
     std::shared_ptr<const FilterPolicy>* policy) {
+  const std::string kBloomName = "bloomfilter:";
+  const std::string kRibbonName = "ribbonfilter:";
   if (value == kNullptrString) {
     policy->reset();
-    return Status::OK();
   } else if (value == "rocksdb.BuiltinBloomFilter") {
-    *policy = std::make_shared<ReadOnlyBuiltinFilterPolicy>();
-    return Status::OK();
-  }
+    *policy = std::make_shared<BuiltinFilterPolicy>();
+  } else {
 #ifndef ROCKSDB_LITE
-  const std::vector<std::string> vals = StringSplit(value, ':');
-  if (vals.size() < 2) {
-    return Status::NotFound("Invalid filter policy name ", value);
-  }
-  const std::string& name = vals[0];
-  double bits_per_key = ParseDouble(trim(vals[1]));
-  if (name == BloomFilterPolicy::kName()) {
-    bool use_block_based_builder = false;
-    if (vals.size() > 2) {
-      use_block_based_builder =
-          ParseBoolean("use_block_based_builder", trim(vals[2]));
+    const std::vector<std::string> vals = StringSplit(value, ':');
+    if (vals.size() < 2) {
+      return Status::NotFound("Invalid filter policy name ", value);
     }
-    policy->reset(NewBloomFilterPolicy(bits_per_key, use_block_based_builder));
-  } else if (name == RibbonFilterPolicy::kName()) {
-    int bloom_before_level;
-    if (vals.size() < 3) {
-      bloom_before_level = 0;
+    const std::string& name = vals[0];
+    double bits_per_key = ParseDouble(trim(vals[1]));
+    if (name == "bloomfilter") {  // TODO: constants for names
+      // NOTE: ignoring obsolete bool for "use_block_based_builder"
+      policy->reset(NewBloomFilterPolicy(bits_per_key));
+    } else if (name == "ribbonfilter") {
+      int bloom_before_level;
+      if (vals.size() < 3) {
+        bloom_before_level = 0;
+      } else {
+        bloom_before_level = ParseInt(trim(vals[2]));
+      }
+      policy->reset(NewRibbonFilterPolicy(/*bloom_equivalent*/ bits_per_key,
+                                          bloom_before_level));
+    } else if (name == "rocksdb.internal.DeprecatedBlockBasedBloomFilter") {
+      *policy = std::make_shared<BloomFilterPolicy>(
+          bits_per_key, BloomFilterPolicy::kDeprecatedBlock);
+    } else if (name == "rocksdb.internal.LegacyBloomFilter") {
+      *policy = std::make_shared<BloomFilterPolicy>(
+          bits_per_key, BloomFilterPolicy::kLegacyBloom);
+    } else if (name == "rocksdb.internal.FastLocalBloomFilter") {
+      *policy = std::make_shared<BloomFilterPolicy>(
+          bits_per_key, BloomFilterPolicy::kFastLocalBloom);
+    } else if (name == "rocksdb.internal.Standard128RibbonFilter") {
+      *policy = std::make_shared<BloomFilterPolicy>(
+          bits_per_key, BloomFilterPolicy::kStandard128Ribbon);
     } else {
-      bloom_before_level = ParseInt(trim(vals[2]));
+      return Status::NotFound("Invalid filter policy name ", value);
     }
-    policy->reset(NewRibbonFilterPolicy(/*bloom_equivalent*/ bits_per_key,
-                                        bloom_before_level));
-  } else {
-    *policy = BloomLikeFilterPolicy::Create(name, bits_per_key);
-  }
-  if (*policy) {
-    return Status::OK();
-  } else {
-    return Status::NotFound("Invalid filter policy name ", value);
-  }
 #else
-  return Status::NotSupported("Cannot load filter policy in LITE mode ", value);
+    return Status::NotSupported("Cannot load filter policy in LITE mode ",
+                                value);
 #endif  // ROCKSDB_LITE
+  }
+  return Status::OK();
 }
-
-const std::vector<std::string>& BloomLikeFilterPolicy::GetAllFixedImpls() {
-  STATIC_AVOID_DESTRUCTION(std::vector<std::string>, impls){
-      // Match filter_bench -impl=x ordering
-      test::LegacyBloomFilterPolicy::kName(),
-      DeprecatedBlockBasedBloomFilterPolicy::kName(),
-      test::FastLocalBloomFilterPolicy::kName(),
-      test::Standard128RibbonFilterPolicy::kName(),
-  };
-  return impls;
-}
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/filter_policy_internal.h
+++ b/table/block_based/filter_policy_internal.h
@@ -46,19 +46,19 @@ class BuiltinFilterBitsReader : public FilterBitsReader {
   virtual bool HashMayMatch(const uint64_t /* h */) { return true; }
 };
 
-// Base class for RocksDB built-in filter policies. This provides the
-// ability to read all kinds of built-in filters (so that old filters can
-// be used even when you change between built-in policies).
+// Base class for RocksDB built-in filter policies. This can read all
+// kinds of built-in filters (for backward compatibility with old
+// OPTIONS files) but does not build filters, so new SST files generated
+// under the policy will get no filters (like nullptr FilterPolicy).
+// This class is considered internal API and subject to change.
 class BuiltinFilterPolicy : public FilterPolicy {
- public:  // overrides
+ public:
+  static BuiltinFilterBitsReader* GetBuiltinFilterBitsReader(
+      const Slice& contents);
+
   // Shared name because any built-in policy can read filters from
   // any other
-  // FIXME when making filter policies Configurable. For now, this
-  // is still rocksdb.BuiltinBloomFilter
   const char* Name() const override;
-
-  // Convert to a string understood by FilterPolicy::CreateFromString
-  virtual std::string GetId() const = 0;
 
   // Read metadata to determine what kind of FilterBitsReader is needed
   // and return a new one. This must successfully process any filter data
@@ -66,21 +66,11 @@ class BuiltinFilterPolicy : public FilterPolicy {
   // chosen for this BloomFilterPolicy. Not compatible with CreateFilter.
   FilterBitsReader* GetFilterBitsReader(const Slice& contents) const override;
 
- public:  // new
-  // An internal function for the implementation of
-  // BuiltinFilterBitsReader::GetFilterBitsReader without requiring an instance
-  // or working around potential virtual overrides.
-  static BuiltinFilterBitsReader* GetBuiltinFilterBitsReader(
-      const Slice& contents);
-
-  // Returns a new FilterBitsBuilder from the filter_policy in
-  // table_options of a context, or nullptr if not applicable.
-  // (An internal convenience function to save boilerplate.)
-  static FilterBitsBuilder* GetBuilderFromContext(const FilterBuildingContext&);
-
- protected:
-  // Deprecated block-based filter only (no longer in public API)
-  bool KeyMayMatch(const Slice& key, const Slice& bloom_filter) const;
+  // Does not write filters.
+  FilterBitsBuilder* GetBuilderWithContext(
+      const FilterBuildingContext&) const override {
+    return nullptr;
+  }
 
  private:
   // For Bloom filter implementation(s) (except deprecated block-based filter)
@@ -90,58 +80,85 @@ class BuiltinFilterPolicy : public FilterPolicy {
   static BuiltinFilterBitsReader* GetRibbonBitsReader(const Slice& contents);
 };
 
-// A "read only" filter policy used for backward compatibility with old
-// OPTIONS files, which did not specifying a Bloom configuration, just
-// "rocksdb.BuiltinBloomFilter". Although this can read existing filters,
-// this policy does not build new filters, so new SST files generated
-// under the policy will get no filters (like nullptr FilterPolicy).
-// This class is considered internal API and subject to change.
-class ReadOnlyBuiltinFilterPolicy : public BuiltinFilterPolicy {
- public:
-  // Convert to a string understood by FilterPolicy::CreateFromString
-  virtual std::string GetId() const override { return Name(); }
-
-  // Does not write filters.
-  FilterBitsBuilder* GetBuilderWithContext(
-      const FilterBuildingContext&) const override {
-    return nullptr;
-  }
-};
-
 // RocksDB built-in filter policy for Bloom or Bloom-like filters including
 // Ribbon filters.
 // This class is considered internal API and subject to change.
 // See NewBloomFilterPolicy and NewRibbonFilterPolicy.
-class BloomLikeFilterPolicy : public BuiltinFilterPolicy {
+class BloomFilterPolicy : public BuiltinFilterPolicy {
  public:
-  explicit BloomLikeFilterPolicy(double bits_per_key);
+  // An internal marker for operating modes of BloomFilterPolicy, in terms
+  // of selecting an implementation. This makes it easier for tests to track
+  // or to walk over the built-in set of Bloom filter implementations. The
+  // only variance in BloomFilterPolicy by mode/implementation is in
+  // GetFilterBitsBuilder(), so an enum is practical here vs. subclasses.
+  //
+  // This enum is essentially the union of all the different kinds of return
+  // value from GetFilterBitsBuilder, or "underlying implementation", and
+  // higher-level modes that choose an underlying implementation based on
+  // context information.
+  enum Mode {
+    // Legacy implementation of Bloom filter for full and partitioned filters.
+    // Set to 0 in case of value confusion with bool use_block_based_builder
+    // NOTE: TESTING ONLY as this mode does not use best compatible
+    // implementation
+    kLegacyBloom = 0,
+    // Deprecated block-based Bloom filter implementation.
+    // Set to 1 in case of value confusion with bool use_block_based_builder
+    // NOTE: DEPRECATED but user exposed
+    kDeprecatedBlock = 1,
+    // A fast, cache-local Bloom filter implementation. See description in
+    // FastLocalBloomImpl.
+    // NOTE: TESTING ONLY as this mode does not check format_version
+    kFastLocalBloom = 2,
+    // A Bloom alternative saving about 30% space for ~3-4x construction
+    // CPU time. See ribbon_alg.h and ribbon_impl.h.
+    kStandard128Ribbon = 3,
+    // Automatically choose between kLegacyBloom and kFastLocalBloom based on
+    // context at build time, including compatibility with format_version.
+    kAutoBloom = 100,
+  };
+  // All the different underlying implementations that a BloomFilterPolicy
+  // might use, as a mode that says "always use this implementation."
+  // Only appropriate for unit tests.
+  static const std::vector<Mode> kAllFixedImpls;
 
-  ~BloomLikeFilterPolicy() override;
+  // All the different modes of BloomFilterPolicy that are exposed from
+  // user APIs. Only appropriate for higher-level unit tests. Integration
+  // tests should prefer using NewBloomFilterPolicy (user-exposed).
+  static const std::vector<Mode> kAllUserModes;
+
+  explicit BloomFilterPolicy(double bits_per_key, Mode mode);
+
+  ~BloomFilterPolicy() override;
+
+  // For Deprecated block-based filter (no longer customizable in public API)
+  static void CreateFilter(const Slice* keys, int n, int bits_per_key,
+                           std::string* dst);
+  static bool KeyMayMatch(const Slice& key, const Slice& bloom_filter);
+
+  // To use this function, call GetBuilderFromContext().
+  //
+  // Neither the context nor any objects therein should be saved beyond
+  // the call to this function, unless it's shared_ptr.
+  FilterBitsBuilder* GetBuilderWithContext(
+      const FilterBuildingContext&) const override;
+
+  // Internal contract: for kDeprecatedBlock, GetBuilderWithContext returns
+  // a new fake builder that encodes bits per key into a special value from
+  // EstimateEntriesAdded(), using kSecretBitsPerKeyStart + bits_per_key
+  static constexpr size_t kSecretBitsPerKeyStart = 1234567890U;
+
+  // Returns a new FilterBitsBuilder from the filter_policy in
+  // table_options of a context, or nullptr if not applicable.
+  // (An internal convenience function to save boilerplate.)
+  static FilterBitsBuilder* GetBuilderFromContext(const FilterBuildingContext&);
 
   // Essentially for testing only: configured millibits/key
   int GetMillibitsPerKey() const { return millibits_per_key_; }
   // Essentially for testing only: legacy whole bits/key
   int GetWholeBitsPerKey() const { return whole_bits_per_key_; }
-
-  // All the different underlying implementations that a BloomLikeFilterPolicy
-  // might use, as a configuration string name for a testing mode for
-  // "always use this implementation." Only appropriate for unit tests.
-  static const std::vector<std::string>& GetAllFixedImpls();
-
-  // Convenience function for creating by name for fixed impls
-  static std::shared_ptr<const FilterPolicy> Create(const std::string& name,
-                                                    double bits_per_key);
-
- protected:
-  // Some implementations used by aggregating policies
-  FilterBitsBuilder* GetLegacyBloomBuilderWithContext(
-      const FilterBuildingContext& context) const;
-  FilterBitsBuilder* GetFastLocalBloomBuilderWithContext(
-      const FilterBuildingContext& context) const;
-  FilterBitsBuilder* GetStandard128RibbonBuilderWithContext(
-      const FilterBuildingContext& context) const;
-
-  std::string GetBitsPerKeySuffix() const;
+  // Testing only
+  Mode GetMode() const { return mode_; }
 
  private:
   // Bits per key settings are for configuring Bloom filters.
@@ -160,6 +177,10 @@ class BloomLikeFilterPolicy : public BuiltinFilterPolicy {
   // example, 100 -> 1% fp rate.
   double desired_one_in_fp_rate_;
 
+  // Selected mode (a specific implementation or way of selecting an
+  // implementation) for building new SST filters.
+  Mode mode_;
+
   // Whether relevant warnings have been logged already. (Remember so we
   // only report once per BloomFilterPolicy instance, to keep the noise down.)
   mutable std::atomic<bool> warned_;
@@ -175,111 +196,28 @@ class BloomLikeFilterPolicy : public BuiltinFilterPolicy {
   mutable std::atomic<int64_t> aggregate_rounding_balance_;
 };
 
-// For NewBloomFilterPolicy
-//
-// This is a user-facing policy that automatically choose between
-// LegacyBloom and FastLocalBloom based on context at build time,
-// including compatibility with format_version.
-class BloomFilterPolicy : public BloomLikeFilterPolicy {
+// Chooses between two filter policies based on LSM level, but
+// only for Level and Universal compaction styles. Flush is treated
+// as level -1. Policy b is considered fallback / primary policy.
+class LevelThresholdFilterPolicy : public BuiltinFilterPolicy {
  public:
-  explicit BloomFilterPolicy(double bits_per_key);
-
-  // To use this function, call BuiltinFilterPolicy::GetBuilderFromContext().
-  //
-  // Neither the context nor any objects therein should be saved beyond
-  // the call to this function, unless it's shared_ptr.
-  FilterBitsBuilder* GetBuilderWithContext(
-      const FilterBuildingContext&) const override;
-
-  static const char* kName();
-  std::string GetId() const override;
-};
-
-// For NewRibbonFilterPolicy
-//
-// This is a user-facing policy that chooses between Standard128Ribbon
-// and FastLocalBloom based on context at build time (LSM level and other
-// factors in extreme cases).
-class RibbonFilterPolicy : public BloomLikeFilterPolicy {
- public:
-  explicit RibbonFilterPolicy(double bloom_equivalent_bits_per_key,
-                              int bloom_before_level);
+  LevelThresholdFilterPolicy(std::unique_ptr<const FilterPolicy>&& a,
+                             std::unique_ptr<const FilterPolicy>&& b,
+                             int starting_level_for_b);
 
   FilterBitsBuilder* GetBuilderWithContext(
-      const FilterBuildingContext&) const override;
+      const FilterBuildingContext& context) const override;
 
-  int GetBloomBeforeLevel() const { return bloom_before_level_; }
+  inline int TEST_GetStartingLevelForB() const { return starting_level_for_b_; }
 
-  static const char* kName();
-  std::string GetId() const override;
+  inline const FilterPolicy* TEST_GetPolicyA() const { return policy_a_.get(); }
+
+  inline const FilterPolicy* TEST_GetPolicyB() const { return policy_b_.get(); }
 
  private:
-  const int bloom_before_level_;
+  const std::unique_ptr<const FilterPolicy> policy_a_;
+  const std::unique_ptr<const FilterPolicy> policy_b_;
+  int starting_level_for_b_;
 };
-
-// Deprecated block-based filter only. We still support reading old
-// block-based filters from any BuiltinFilterPolicy, but there is no public
-// option to build them. However, this class is used to build them for testing
-// and for a public backdoor to building them by constructing this policy from
-// a string.
-class DeprecatedBlockBasedBloomFilterPolicy : public BloomLikeFilterPolicy {
- public:
-  explicit DeprecatedBlockBasedBloomFilterPolicy(double bits_per_key);
-
-  // Internal contract: returns a new fake builder that encodes bits per key
-  // into a special value from EstimateEntriesAdded(), using
-  // kSecretBitsPerKeyStart
-  FilterBitsBuilder* GetBuilderWithContext(
-      const FilterBuildingContext&) const override;
-  static constexpr size_t kSecretBitsPerKeyStart = 1234567890U;
-
-  static const char* kName();
-  std::string GetId() const override;
-
-  static void CreateFilter(const Slice* keys, int n, int bits_per_key,
-                           std::string* dst);
-  static bool KeyMayMatch(const Slice& key, const Slice& bloom_filter);
-};
-
-// For testing only, but always constructable with internal names
-namespace test {
-
-class LegacyBloomFilterPolicy : public BloomLikeFilterPolicy {
- public:
-  explicit LegacyBloomFilterPolicy(double bits_per_key)
-      : BloomLikeFilterPolicy(bits_per_key) {}
-
-  FilterBitsBuilder* GetBuilderWithContext(
-      const FilterBuildingContext& context) const override;
-
-  static const char* kName();
-  std::string GetId() const override;
-};
-
-class FastLocalBloomFilterPolicy : public BloomLikeFilterPolicy {
- public:
-  explicit FastLocalBloomFilterPolicy(double bits_per_key)
-      : BloomLikeFilterPolicy(bits_per_key) {}
-
-  FilterBitsBuilder* GetBuilderWithContext(
-      const FilterBuildingContext& context) const override;
-
-  static const char* kName();
-  std::string GetId() const override;
-};
-
-class Standard128RibbonFilterPolicy : public BloomLikeFilterPolicy {
- public:
-  explicit Standard128RibbonFilterPolicy(double bloom_equiv_bits_per_key)
-      : BloomLikeFilterPolicy(bloom_equiv_bits_per_key) {}
-
-  FilterBitsBuilder* GetBuilderWithContext(
-      const FilterBuildingContext& context) const override;
-
-  static const char* kName();
-  std::string GetId() const override;
-};
-
-}  // namespace test
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/mock_block_based_table.h
+++ b/table/block_based/mock_block_based_table.h
@@ -4,8 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-#include <memory>
-
 #include "rocksdb/filter_policy.h"
 #include "table/block_based/block_based_filter_block.h"
 #include "table/block_based/block_based_table_reader.h"
@@ -32,15 +30,10 @@ class MockBlockBasedTableTester {
   std::unique_ptr<BlockBasedTable> table_;
 
   explicit MockBlockBasedTableTester(const FilterPolicy* filter_policy)
-      : MockBlockBasedTableTester(
-            std::shared_ptr<const FilterPolicy>(filter_policy)){};
-
-  explicit MockBlockBasedTableTester(
-      std::shared_ptr<const FilterPolicy> filter_policy)
       : ioptions_(options_),
         env_options_(options_),
         icomp_(options_.comparator) {
-    table_options_.filter_policy = std::move(filter_policy);
+    table_options_.filter_policy.reset(filter_policy);
 
     constexpr bool skip_filters = false;
     constexpr bool immortal_table = false;

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -39,13 +39,6 @@ DEFINE_int32(bits_per_key, 10, "");
 
 namespace ROCKSDB_NAMESPACE {
 
-namespace {
-const std::string kLegacyBloom = test::LegacyBloomFilterPolicy::kName();
-const std::string kFastLocalBloom = test::FastLocalBloomFilterPolicy::kName();
-const std::string kStandard128Ribbon =
-    test::Standard128RibbonFilterPolicy::kName();
-}  // namespace
-
 static const int kVerbose = 1;
 
 static Slice Key(int i, char* buffer) {
@@ -70,7 +63,7 @@ static int NextLength(int length) {
 
 class BlockBasedBloomTest : public testing::Test {
  private:
-  std::unique_ptr<const DeprecatedBlockBasedBloomFilterPolicy> policy_;
+  int bits_per_key_;
   std::string filter_;
   std::vector<std::string> keys_;
 
@@ -83,7 +76,9 @@ class BlockBasedBloomTest : public testing::Test {
   }
 
   void ResetPolicy(double bits_per_key) {
-    policy_.reset(new DeprecatedBlockBasedBloomFilterPolicy(bits_per_key));
+    bits_per_key_ =
+        BloomFilterPolicy(bits_per_key, BloomFilterPolicy::kDeprecatedBlock)
+            .GetWholeBitsPerKey();
     Reset();
   }
 
@@ -99,9 +94,9 @@ class BlockBasedBloomTest : public testing::Test {
       key_slices.push_back(Slice(keys_[i]));
     }
     filter_.clear();
-    DeprecatedBlockBasedBloomFilterPolicy::CreateFilter(
-        &key_slices[0], static_cast<int>(key_slices.size()),
-        policy_->GetWholeBitsPerKey(), &filter_);
+    BloomFilterPolicy::CreateFilter(key_slices.data(),
+                                    static_cast<int>(key_slices.size()),
+                                    bits_per_key_, &filter_);
     keys_.clear();
     if (kVerbose >= 2) DumpFilter();
   }
@@ -127,7 +122,7 @@ class BlockBasedBloomTest : public testing::Test {
     if (!keys_.empty()) {
       Build();
     }
-    return DeprecatedBlockBasedBloomFilterPolicy::KeyMayMatch(s, filter_);
+    return BloomFilterPolicy::KeyMayMatch(s, filter_);
   }
 
   double FalsePositiveRate() {
@@ -269,7 +264,7 @@ TEST_F(BlockBasedBloomTest, Schema) {
 
 // Different bits-per-byte
 
-class FullBloomTest : public testing::TestWithParam<std::string> {
+class FullBloomTest : public testing::TestWithParam<BloomFilterPolicy::Mode> {
  protected:
   BlockBasedTableOptions table_options_;
 
@@ -290,9 +285,9 @@ class FullBloomTest : public testing::TestWithParam<std::string> {
     return dynamic_cast<BuiltinFilterBitsBuilder*>(bits_builder_.get());
   }
 
-  const BloomLikeFilterPolicy* GetBloomLikeFilterPolicy() {
+  const BloomFilterPolicy* GetBloomFilterPolicy() {
     // Throws on bad cast
-    return &dynamic_cast<const BloomLikeFilterPolicy&>(*policy_);
+    return &dynamic_cast<const BloomFilterPolicy&>(*policy_);
   }
 
   void Reset() {
@@ -304,7 +299,7 @@ class FullBloomTest : public testing::TestWithParam<std::string> {
   }
 
   void ResetPolicy(double bits_per_key) {
-    policy_ = BloomLikeFilterPolicy::Create(GetParam(), bits_per_key);
+    policy_.reset(new BloomFilterPolicy(bits_per_key, GetParam()));
     Reset();
   }
 
@@ -425,7 +420,7 @@ TEST_P(FullBloomTest, FilterSize) {
                                                        {INFINITY, 100000},
                                                        {NAN, 100000}}) {
     ResetPolicy(bpk.first);
-    auto bfp = GetBloomLikeFilterPolicy();
+    auto bfp = GetBloomFilterPolicy();
     EXPECT_EQ(bpk.second, bfp->GetMillibitsPerKey());
     EXPECT_EQ((bpk.second + 500) / 1000, bfp->GetWholeBitsPerKey());
 
@@ -438,7 +433,7 @@ TEST_P(FullBloomTest, FilterSize) {
     computed -= 0.5;
     some_computed_less_than_denoted |= (computed < bpk.first);
     ResetPolicy(computed);
-    bfp = GetBloomLikeFilterPolicy();
+    bfp = GetBloomFilterPolicy();
     EXPECT_EQ(bpk.second, bfp->GetMillibitsPerKey());
     EXPECT_EQ((bpk.second + 500) / 1000, bfp->GetWholeBitsPerKey());
 
@@ -456,7 +451,7 @@ TEST_P(FullBloomTest, FilterSize) {
       size_t n2 = bits_builder->ApproximateNumEntries(space);
       EXPECT_GE(n2, n);
       size_t space2 = bits_builder->CalculateSpace(n2);
-      if (n > 12000 && GetParam() == kStandard128Ribbon) {
+      if (n > 12000 && GetParam() == BloomFilterPolicy::kStandard128Ribbon) {
         // TODO(peterd): better approximation?
         EXPECT_GE(space2, space);
         EXPECT_LE(space2 * 0.998, space * 1.0);
@@ -573,14 +568,14 @@ TEST_P(FullBloomTest, OptimizeForMemory) {
     }
 
     int64_t ex_min_total_size = int64_t{FLAGS_bits_per_key} * total_keys / 8;
-    if (GetParam() == kStandard128Ribbon) {
+    if (GetParam() == BloomFilterPolicy::kStandard128Ribbon) {
       // ~ 30% savings vs. Bloom filter
       ex_min_total_size = 7 * ex_min_total_size / 10;
     }
     EXPECT_GE(static_cast<int64_t>(total_size), ex_min_total_size);
 
     int64_t blocked_bloom_overhead = nfilters * (CACHE_LINE_SIZE + 5);
-    if (GetParam() == kLegacyBloom) {
+    if (GetParam() == BloomFilterPolicy::kLegacyBloom) {
       // this config can add extra cache line to make odd number
       blocked_bloom_overhead += nfilters * CACHE_LINE_SIZE;
     }
@@ -588,7 +583,7 @@ TEST_P(FullBloomTest, OptimizeForMemory) {
     EXPECT_GE(total_mem, total_size);
 
     // optimize_filters_for_memory not implemented with legacy Bloom
-    if (offm && GetParam() != kLegacyBloom) {
+    if (offm && GetParam() != BloomFilterPolicy::kLegacyBloom) {
       // This value can include a small extra penalty for kExtraPadding
       fprintf(stderr, "Internal fragmentation (optimized): %g%%\n",
               (total_mem - total_size) * 100.0 / total_size);
@@ -634,8 +629,8 @@ TEST(FullBloomFilterConstructionReserveMemTest,
     lo.strict_capacity_limit = true;
     std::shared_ptr<Cache> cache(NewLRUCache(lo));
     table_options.block_cache = cache;
-    table_options.filter_policy =
-        BloomLikeFilterPolicy::Create(kStandard128Ribbon, FLAGS_bits_per_key);
+    table_options.filter_policy.reset(new BloomFilterPolicy(
+        FLAGS_bits_per_key, BloomFilterPolicy::Mode::kStandard128Ribbon));
     FilterBuildingContext ctx(table_options);
     std::unique_ptr<FilterBitsBuilder> filter_bits_builder(
         table_options.filter_policy->GetBuilderWithContext(ctx));
@@ -697,35 +692,35 @@ inline uint32_t SelectByCacheLineSize(uint32_t for64, uint32_t for128,
 // ability to read filters generated using other cache line sizes.
 // See RawSchema.
 TEST_P(FullBloomTest, Schema) {
-#define EXPECT_EQ_Bloom(a, b)               \
-  {                                         \
-    if (GetParam() != kStandard128Ribbon) { \
-      EXPECT_EQ(a, b);                      \
-    }                                       \
+#define EXPECT_EQ_Bloom(a, b)                                  \
+  {                                                            \
+    if (GetParam() != BloomFilterPolicy::kStandard128Ribbon) { \
+      EXPECT_EQ(a, b);                                         \
+    }                                                          \
   }
-#define EXPECT_EQ_Ribbon(a, b)              \
-  {                                         \
-    if (GetParam() == kStandard128Ribbon) { \
-      EXPECT_EQ(a, b);                      \
-    }                                       \
+#define EXPECT_EQ_Ribbon(a, b)                                 \
+  {                                                            \
+    if (GetParam() == BloomFilterPolicy::kStandard128Ribbon) { \
+      EXPECT_EQ(a, b);                                         \
+    }                                                          \
   }
-#define EXPECT_EQ_FastBloom(a, b)        \
-  {                                      \
-    if (GetParam() == kFastLocalBloom) { \
-      EXPECT_EQ(a, b);                   \
-    }                                    \
+#define EXPECT_EQ_FastBloom(a, b)                           \
+  {                                                         \
+    if (GetParam() == BloomFilterPolicy::kFastLocalBloom) { \
+      EXPECT_EQ(a, b);                                      \
+    }                                                       \
   }
-#define EXPECT_EQ_LegacyBloom(a, b)   \
-  {                                   \
-    if (GetParam() == kLegacyBloom) { \
-      EXPECT_EQ(a, b);                \
-    }                                 \
+#define EXPECT_EQ_LegacyBloom(a, b)                      \
+  {                                                      \
+    if (GetParam() == BloomFilterPolicy::kLegacyBloom) { \
+      EXPECT_EQ(a, b);                                   \
+    }                                                    \
   }
-#define EXPECT_EQ_NotLegacy(a, b)     \
-  {                                   \
-    if (GetParam() != kLegacyBloom) { \
-      EXPECT_EQ(a, b);                \
-    }                                 \
+#define EXPECT_EQ_NotLegacy(a, b)                        \
+  {                                                      \
+    if (GetParam() != BloomFilterPolicy::kLegacyBloom) { \
+      EXPECT_EQ(a, b);                                   \
+    }                                                    \
   }
 
   char buffer[sizeof(int)];
@@ -1264,8 +1259,9 @@ TEST_P(FullBloomTest, CorruptFilters) {
 }
 
 INSTANTIATE_TEST_CASE_P(Full, FullBloomTest,
-                        testing::Values(kLegacyBloom, kFastLocalBloom,
-                                        kStandard128Ribbon));
+                        testing::Values(BloomFilterPolicy::kLegacyBloom,
+                                        BloomFilterPolicy::kFastLocalBloom,
+                                        BloomFilterPolicy::kStandard128Ribbon));
 
 static double GetEffectiveBitsPerKey(FilterBitsBuilder* builder) {
   union {

--- a/util/filter_bench.cc
+++ b/util/filter_bench.cc
@@ -31,7 +31,6 @@ int main() {
 #include "util/random.h"
 #include "util/stderr_logger.h"
 #include "util/stop_watch.h"
-#include "util/string_util.h"
 
 using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 using GFLAGS_NAMESPACE::RegisterFlagValidator;
@@ -141,7 +140,6 @@ using ROCKSDB_NAMESPACE::Arena;
 using ROCKSDB_NAMESPACE::BlockContents;
 using ROCKSDB_NAMESPACE::BloomFilterPolicy;
 using ROCKSDB_NAMESPACE::BloomHash;
-using ROCKSDB_NAMESPACE::BloomLikeFilterPolicy;
 using ROCKSDB_NAMESPACE::BuiltinFilterBitsBuilder;
 using ROCKSDB_NAMESPACE::CachableEntry;
 using ROCKSDB_NAMESPACE::Cache;
@@ -149,7 +147,6 @@ using ROCKSDB_NAMESPACE::EncodeFixed32;
 using ROCKSDB_NAMESPACE::FastRange32;
 using ROCKSDB_NAMESPACE::FilterBitsReader;
 using ROCKSDB_NAMESPACE::FilterBuildingContext;
-using ROCKSDB_NAMESPACE::FilterPolicy;
 using ROCKSDB_NAMESPACE::FullFilterBlockReader;
 using ROCKSDB_NAMESPACE::GetSliceHash;
 using ROCKSDB_NAMESPACE::GetSliceHash64;
@@ -290,16 +287,6 @@ static uint32_t DryRunHash64(Slice &s) {
   return Lower32of64(GetSliceHash64(s));
 }
 
-const std::shared_ptr<const FilterPolicy> &GetPolicy() {
-  static std::shared_ptr<const FilterPolicy> policy;
-  if (!policy) {
-    policy = BloomLikeFilterPolicy::Create(
-        BloomLikeFilterPolicy::GetAllFixedImpls().at(FLAGS_impl),
-        FLAGS_bits_per_key);
-  }
-  return policy;
-}
-
 struct FilterBench : public MockBlockBasedTableTester {
   std::vector<KeyMaker> kms_;
   std::vector<FilterInfo> infos_;
@@ -310,7 +297,9 @@ struct FilterBench : public MockBlockBasedTableTester {
   StderrLogger stderr_logger_;
 
   FilterBench()
-      : MockBlockBasedTableTester(GetPolicy()),
+      : MockBlockBasedTableTester(new BloomFilterPolicy(
+            FLAGS_bits_per_key,
+            static_cast<BloomFilterPolicy::Mode>(FLAGS_impl))),
         random_(FLAGS_seed),
         m_queries_(0) {
     for (uint32_t i = 0; i < FLAGS_batch_size; ++i) {


### PR DESCRIPTION
This reverts commit 8c681087c79744f02692fc736ad501d173540527.

The reason is the crash test began failing on the below assertion
following this commit.

```
db_stress: table/block_based/filter_policy.cc:316: rocksdb::{anonymous}::FastLocalBloomBitsBuilder::FastLocalBloomBitsBuilder(int, std::atomic<long int>*, std::shared_ptr<rocksdb::CacheReservationManager>, bool): Assertion `millibits_per_key >= 1000' failed.
```