### PR TITLE
Add support for BlobDB to ldb

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### New Features
 * Allow WriteBatchWithIndex to index a WriteBatch that includes keys with user-defined timestamps. The index itself does not have timestamp.
+* Added BlobDB options to `ldb`
 
 ### Bug Fixes
 * * Fixed a data race on `versions_` between `DBImpl::ResumeImpl()` and threads waiting for recovery to complete (#9496)

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -242,6 +242,11 @@ class LDBCommand {
   bool ParseStringOption(const std::map<std::string, std::string>& options,
                          const std::string& option, std::string* value);
 
+  bool ParseCompressionTypeOption(
+      const std::map<std::string, std::string>& options,
+      const std::string& option, CompressionType& value,
+      LDBCommandExecuteResult& exec_state);
+
   /**
    * Returns the value of the specified option as a boolean.
    * default_val is used if the option is not found in options.

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -61,6 +61,10 @@ class LDBCommand {
   static const std::string ARG_CREATE_IF_MISSING;
   static const std::string ARG_NO_VALUE;
   static const std::string ARG_DISABLE_CONSISTENCY_CHECKS;
+  static const std::string ARG_ENABLE_BLOB_FILES;
+  static const std::string ARG_MIN_BLOB_SIZE;
+  static const std::string ARG_BLOB_FILE_SIZE;
+  static const std::string ARG_BLOB_COMPRESSION_TYPE;
 
   struct ParsedParams {
     std::string cmd;
@@ -172,6 +176,8 @@ class LDBCommand {
 
   // The value passed to options.force_consistency_checks.
   bool force_consistency_checks_;
+
+  bool enable_blob_files_;
 
   bool create_if_missing_;
 

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -65,6 +65,10 @@ class LDBCommand {
   static const std::string ARG_MIN_BLOB_SIZE;
   static const std::string ARG_BLOB_FILE_SIZE;
   static const std::string ARG_BLOB_COMPRESSION_TYPE;
+  static const std::string ARG_ENABLE_BLOB_GARBAGE_COLLECTION;
+  static const std::string ARG_BLOB_GARBAGE_COLLECTION_AGE_CUTOFF;
+  static const std::string ARG_BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD;
+  static const std::string ARG_BLOB_COMPACTION_READAHEAD_SIZE;
 
   struct ParsedParams {
     std::string cmd;
@@ -179,6 +183,8 @@ class LDBCommand {
 
   bool enable_blob_files_;
 
+  bool enable_blob_garbage_collection_;
+
   bool create_if_missing_;
 
   /**
@@ -238,6 +244,10 @@ class LDBCommand {
   bool ParseIntOption(const std::map<std::string, std::string>& options,
                       const std::string& option, int& value,
                       LDBCommandExecuteResult& exec_state);
+
+  bool ParseDoubleOption(const std::map<std::string, std::string>& options,
+                         const std::string& option, double& value,
+                         LDBCommandExecuteResult& exec_state);
 
   bool ParseStringOption(const std::map<std::string, std::string>& options,
                          const std::string& option, std::string* value);

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -583,7 +583,7 @@ bool LDBCommand::ParseCompressionTypeOption(
     LDBCommandExecuteResult& exec_state) {
   auto itr = option_map_.find(option);
   if (itr != option_map_.end()) {
-    std::string comp = itr->second;
+    const std::string& comp = itr->second;
     if (comp == "no") {
       value = kNoCompression;
       return true;

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -361,7 +361,7 @@ LDBCommand::LDBCommand(const std::map<std::string, std::string>& options,
       option_map_(options),
       flags_(flags),
       valid_cmd_line_options_(valid_cmd_line_options) {
-  std::map<std::string, std::string>::const_iterator itr = options.find(ARG_DB);
+  auto itr = options.find(ARG_DB);
   if (itr != options.end()) {
     db_path_ = itr->second;
   }
@@ -549,8 +549,7 @@ bool LDBCommand::ParseDoubleOption(
     const std::map<std::string, std::string>& /*options*/,
     const std::string& option, double& value,
     LDBCommandExecuteResult& exec_state) {
-  std::map<std::string, std::string>::const_iterator itr =
-      option_map_.find(option);
+  auto itr = option_map_.find(option);
   if (itr != option_map_.end()) {
     try {
 #if defined(CYGWIN)
@@ -581,8 +580,7 @@ bool LDBCommand::ParseIntOption(
     const std::map<std::string, std::string>& /*options*/,
     const std::string& option, int& value,
     LDBCommandExecuteResult& exec_state) {
-  std::map<std::string, std::string>::const_iterator itr =
-      option_map_.find(option);
+  auto itr = option_map_.find(option);
   if (itr != option_map_.end()) {
     try {
 #if defined(CYGWIN)
@@ -720,11 +718,11 @@ void LDBCommand::OverrideBaseCFOptions(ColumnFamilyOptions* cf_opts) {
   int min_blob_size;
   if (ParseIntOption(option_map_, ARG_MIN_BLOB_SIZE, min_blob_size,
                      exec_state_)) {
-    if (min_blob_size > 0) {
+    if (min_blob_size >= 0) {
       cf_opts->min_blob_size = min_blob_size;
     } else {
       exec_state_ =
-          LDBCommandExecuteResult::Failed(ARG_MIN_BLOB_SIZE + " must be > 0.");
+          LDBCommandExecuteResult::Failed(ARG_MIN_BLOB_SIZE + " must be >= 0.");
     }
   }
 
@@ -785,16 +783,16 @@ void LDBCommand::OverrideBaseCFOptions(ColumnFamilyOptions* cf_opts) {
     cf_opts->disable_auto_compactions = !StringToBool(itr->second);
   }
 
-  CompressionType compression_type_;
+  CompressionType compression_type;
   if (ParseCompressionTypeOption(option_map_, ARG_COMPRESSION_TYPE,
-                                 compression_type_, exec_state_)) {
-    cf_opts->compression = compression_type_;
+                                 compression_type, exec_state_)) {
+    cf_opts->compression = compression_type;
   }
 
-  CompressionType blob_compression_type_;
+  CompressionType blob_compression_type;
   if (ParseCompressionTypeOption(option_map_, ARG_BLOB_COMPRESSION_TYPE,
-                                 blob_compression_type_, exec_state_)) {
-    cf_opts->blob_compression_type = blob_compression_type_;
+                                 blob_compression_type, exec_state_)) {
+    cf_opts->blob_compression_type = blob_compression_type;
   }
 
   int compression_max_dict_bytes;
@@ -945,9 +943,7 @@ bool LDBCommand::ParseKeyValue(const std::string& line, std::string* key,
  * appropriate error msg to stderr.
  */
 bool LDBCommand::ValidateCmdLineOptions() {
-  for (std::map<std::string, std::string>::const_iterator itr =
-           option_map_.begin();
-       itr != option_map_.end(); ++itr) {
+  for (auto itr = option_map_.begin(); itr != option_map_.end(); ++itr) {
     if (std::find(valid_cmd_line_options_.begin(),
                   valid_cmd_line_options_.end(),
                   itr->first) == valid_cmd_line_options_.end()) {
@@ -1036,7 +1032,7 @@ bool LDBCommand::IsValueHex(const std::map<std::string, std::string>& options,
 bool LDBCommand::ParseBooleanOption(
     const std::map<std::string, std::string>& options,
     const std::string& option, bool default_val) {
-  std::map<std::string, std::string>::const_iterator itr = options.find(option);
+  auto itr = options.find(option);
   if (itr != options.end()) {
     std::string option_val = itr->second;
     return StringToBool(itr->second);
@@ -1066,8 +1062,7 @@ CompactorCommand::CompactorCommand(
                                       ARG_VALUE_HEX, ARG_TTL})),
       null_from_(true),
       null_to_(true) {
-  std::map<std::string, std::string>::const_iterator itr =
-      options.find(ARG_FROM);
+  auto itr = options.find(ARG_FROM);
   if (itr != options.end()) {
     null_from_ = false;
     from_ = itr->second;
@@ -1274,8 +1269,7 @@ ManifestDumpCommand::ManifestDumpCommand(
   verbose_ = IsFlagPresent(flags, ARG_VERBOSE);
   json_ = IsFlagPresent(flags, ARG_JSON);
 
-  std::map<std::string, std::string>::const_iterator itr =
-      options.find(ARG_PATH);
+  auto itr = options.find(ARG_PATH);
   if (itr != options.end()) {
     path_ = itr->second;
     if (path_.empty()) {
@@ -1416,8 +1410,7 @@ FileChecksumDumpCommand::FileChecksumDumpCommand(
     : LDBCommand(options, flags, false,
                  BuildCmdLineOptions({ARG_PATH, ARG_HEX})),
       path_("") {
-  std::map<std::string, std::string>::const_iterator itr =
-      options.find(ARG_PATH);
+  auto itr = options.find(ARG_PATH);
   if (itr != options.end()) {
     path_ = itr->second;
     if (path_.empty()) {
@@ -1692,8 +1685,7 @@ InternalDumpCommand::InternalDumpCommand(
   has_to_ = ParseStringOption(options, ARG_TO, &to_);
 
   ParseIntOption(options, ARG_MAX_KEYS, max_keys_, exec_state_);
-  std::map<std::string, std::string>::const_iterator itr =
-      options.find(ARG_COUNT_DELIM);
+  auto itr = options.find(ARG_COUNT_DELIM);
   if (itr != options.end()) {
     delim_ = itr->second;
     count_delim_ = true;
@@ -1828,8 +1820,7 @@ DBDumperCommand::DBDumperCommand(
       count_only_(false),
       count_delim_(false),
       print_stats_(false) {
-  std::map<std::string, std::string>::const_iterator itr =
-      options.find(ARG_FROM);
+  auto itr = options.find(ARG_FROM);
   if (itr != options.end()) {
     null_from_ = false;
     from_ = itr->second;
@@ -2594,8 +2585,7 @@ WALDumperCommand::WALDumperCommand(
       is_write_committed_(false) {
   wal_file_.clear();
 
-  std::map<std::string, std::string>::const_iterator itr =
-      options.find(ARG_WAL_FILE);
+  auto itr = options.find(ARG_WAL_FILE);
   if (itr != options.end()) {
     wal_file_ = itr->second;
   }
@@ -2814,8 +2804,7 @@ ScanCommand::ScanCommand(const std::vector<std::string>& /*params*/,
       end_key_specified_(false),
       max_keys_scanned_(-1),
       no_value_(false) {
-  std::map<std::string, std::string>::const_iterator itr =
-      options.find(ARG_FROM);
+  auto itr = options.find(ARG_FROM);
   if (itr != options.end()) {
     start_key_ = itr->second;
     if (is_key_hex_) {
@@ -3902,8 +3891,7 @@ ListFileRangeDeletesCommand::ListFileRangeDeletesCommand(
     const std::map<std::string, std::string>& options,
     const std::vector<std::string>& flags)
     : LDBCommand(options, flags, true, BuildCmdLineOptions({ARG_MAX_KEYS})) {
-  std::map<std::string, std::string>::const_iterator itr =
-      options.find(ARG_MAX_KEYS);
+  auto itr = options.find(ARG_MAX_KEYS);
   if (itr != options.end()) {
     try {
 #if defined(CYGWIN)

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -551,12 +551,21 @@ bool LDBCommand::ParseDoubleOption(
     LDBCommandExecuteResult& exec_state) {
   auto itr = option_map_.find(option);
   if (itr != option_map_.end()) {
-    try {
 #if defined(CYGWIN)
-      value = std::strtod(itr->second.c_str(), 0);
+    char* str_end = nullptr;
+    value = std::strtod(itr->second.c_str(), &str_end);
+    if (str_end == itr->second.c_str()) {
+      exec_state =
+          LDBCommandExecuteResult::Failed(option + " has an invalid value.");
+    } else if (errno == ERANGE) {
+      exec_state = LDBCommandExecuteResult::Failed(
+          option + " has a value out-of-range.");
+    } else {
+      return true;
+    }
 #else
+    try {
       value = std::stod(itr->second);
-#endif
       return true;
     } catch (const std::invalid_argument&) {
       exec_state =
@@ -565,6 +574,7 @@ bool LDBCommand::ParseDoubleOption(
       exec_state = LDBCommandExecuteResult::Failed(
           option + " has a value out-of-range.");
     }
+#endif
   }
   return false;
 }
@@ -582,12 +592,21 @@ bool LDBCommand::ParseIntOption(
     LDBCommandExecuteResult& exec_state) {
   auto itr = option_map_.find(option);
   if (itr != option_map_.end()) {
-    try {
 #if defined(CYGWIN)
-      value = strtol(itr->second.c_str(), 0, 10);
+    char* str_end = nullptr;
+    value = strtol(itr->second.c_str(), &str_end, 10);
+    if (str_end == itr->second.c_str()) {
+      exec_state =
+          LDBCommandExecuteResult::Failed(option + " has an invalid value.");
+    } else if (errno == ERANGE) {
+      exec_state = LDBCommandExecuteResult::Failed(
+          option + " has a value out-of-range.");
+    } else {
+      return true;
+    }
 #else
+    try {
       value = std::stoi(itr->second);
-#endif
       return true;
     } catch (const std::invalid_argument&) {
       exec_state =
@@ -596,6 +615,7 @@ bool LDBCommand::ParseIntOption(
       exec_state = LDBCommandExecuteResult::Failed(
           option + " has a value out-of-range.");
     }
+#endif
   }
   return false;
 }

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -340,6 +340,19 @@ class LDBTestCase(unittest.TestCase):
         self.assertFalse(self.dumpDb(
             "--db=%s --create_if_missing" % origDbPath, dumpFilePath))
 
+        # Dump and load with BlobDB enabled
+        blobParams = " ".join(["--enable_blob_files", "--min_blob_size=1024",
+                                "--blob_file_size=2097152"])
+        dumpFilePath = os.path.join(self.TMP_DIR, "dump9")
+        loadedDbPath = os.path.join(self.TMP_DIR, "loaded_from_dump9")
+        self.assertTrue(self.dumpDb(
+            "--db=%s %s" % (origDbPath, blobParams), dumpFilePath))
+        self.assertTrue(self.loadDb(
+            "--db=%s %s --create_if_missing" % (loadedDbPath, blobParams),
+            dumpFilePath))
+        self.assertRunOKFull("scan --db=%s" % loadedDbPath,
+                "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+
     def testIDumpBasics(self):
         print("Running testIDumpBasics...")
         self.assertRunOK("put a val --create_if_missing", "OK")

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -372,7 +372,7 @@ class LDBTestCase(unittest.TestCase):
         dumpFilePath = os.path.join(self.TMP_DIR, "dump9")
         loadedDbPath = os.path.join(self.TMP_DIR, "loaded_from_dump9")
         self.assertTrue(self.dumpDb(
-            "--db=%s %s" % (origDbPath, blobParams), dumpFilePath))
+            "--db=%s" % (origDbPath), dumpFilePath))
         self.assertTrue(self.loadDb(
             "--db=%s %s --create_if_missing" % (loadedDbPath, blobParams),
             dumpFilePath))

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -341,7 +341,7 @@ class LDBTestCase(unittest.TestCase):
             "--db=%s --create_if_missing" % origDbPath, dumpFilePath))
 
         # Dump and load with BlobDB enabled
-        blobParams = " ".join(["--enable_blob_files", "--min_blob_size=1024",
+        blobParams = " ".join(["--enable_blob_files", "--min_blob_size=1",
                                 "--blob_file_size=2097152"])
         dumpFilePath = os.path.join(self.TMP_DIR, "dump9")
         loadedDbPath = os.path.join(self.TMP_DIR, "loaded_from_dump9")
@@ -350,8 +350,13 @@ class LDBTestCase(unittest.TestCase):
         self.assertTrue(self.loadDb(
             "--db=%s %s --create_if_missing" % (loadedDbPath, blobParams),
             dumpFilePath))
+        self.assertTrue(self.loadDb(
+            "--db=%s %s" % (loadedDbPath, blobParams),
+            dumpFilePath))
         self.assertRunOKFull("scan --db=%s" % loadedDbPath,
                 "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        blob_files = self.getBlobFiles(loadedDbPath)
+        self.assertTrue(len(blob_files) >= 1)
 
     def testIDumpBasics(self):
         print("Running testIDumpBasics...")
@@ -561,6 +566,9 @@ class LDBTestCase(unittest.TestCase):
 
     def getWALFiles(self, directory):
         return glob.glob(directory + "/*.log")
+
+    def getBlobFiles(self, directory):
+        return glob.glob(directory + "/*.blob")
 
     def copyManifests(self, src, dest):
         return 0 == run_err_null("cp " + src + " " + dest)

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -374,10 +374,7 @@ class LDBTestCase(unittest.TestCase):
         self.assertTrue(self.dumpDb(
             "--db=%s" % (origDbPath), dumpFilePath))
         self.assertTrue(self.loadDb(
-            "--db=%s %s --create_if_missing" % (loadedDbPath, blobParams),
-            dumpFilePath))
-        self.assertTrue(self.loadDb(
-            "--db=%s %s" % (loadedDbPath, blobParams),
+            "--db=%s %s --create_if_missing --disable_wal" % (loadedDbPath, blobParams),
             dumpFilePath))
         self.assertRunOKFull("scan --db=%s" % loadedDbPath,
                 "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -165,6 +165,32 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunFAIL("batchput k1")
         self.assertRunFAIL("batchput k1 v1 k2")
 
+    def testBlobBatchPut(self):
+        print("Running testBlobBatchPut...")
+
+        dbPath = os.path.join(self.TMP_DIR, self.DB_NAME)
+        self.assertRunOK("batchput x1 y1 --create_if_missing --enable_blob_files", "OK")
+        self.assertRunOK("scan", "x1 : y1")
+        self.assertRunOK("batchput --enable_blob_files x2 y2 x3 y3 \"x4 abc\" \"y4 xyz\"", "OK")
+        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 abc : y4 xyz")
+
+        blob_files = self.getBlobFiles(dbPath)
+        self.assertTrue(len(blob_files) >= 1)
+
+    def testBlobPut(self):
+        print("Running testBlobPut...")
+
+        dbPath = os.path.join(self.TMP_DIR, self.DB_NAME)
+        self.assertRunOK("put --create_if_missing --enable_blob_files x1 y1", "OK")
+        self.assertRunOK("get x1", "y1")
+        self.assertRunOK("put --enable_blob_files x2 y2", "OK")
+        self.assertRunOK("get x1", "y1")
+        self.assertRunOK("get x2", "y2")
+        self.assertRunFAIL("get x3")
+
+        blob_files = self.getBlobFiles(dbPath)
+        self.assertTrue(len(blob_files) >= 1)
+
     def testCountDelimDump(self):
         print("Running testCountDelimDump...")
         self.assertRunOK("batchput x.1 x1 --create_if_missing", "OK")

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -74,6 +74,14 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
   ret.append("  --" + LDBCommand::ARG_BLOB_FILE_SIZE + "=<int,e.g.:2097152>\n");
   ret.append("  --" + LDBCommand::ARG_BLOB_COMPRESSION_TYPE +
              "=<no|snappy|zlib|bzip2|lz4|lz4hc|xpress|zstd>\n");
+  ret.append("  --" + LDBCommand::ARG_ENABLE_BLOB_GARBAGE_COLLECTION +
+             " : Enable blob garbage collection\n");
+  ret.append("  --" + LDBCommand::ARG_BLOB_GARBAGE_COLLECTION_AGE_CUTOFF +
+             "=<double,e.g.:0.25>\n");
+  ret.append("  --" + LDBCommand::ARG_BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD +
+             "=<double,e.g.:0.25>\n");
+  ret.append("  --" + LDBCommand::ARG_BLOB_COMPACTION_READAHEAD_SIZE +
+             "=<int,e.g.:2097152>\n");
 
   ret.append("\n\n");
   ret.append("Data Access Commands:\n");

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -68,6 +68,12 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
   ret.append("  --" + LDBCommand::ARG_WRITE_BUFFER_SIZE +
              "=<int,e.g.:4194304>\n");
   ret.append("  --" + LDBCommand::ARG_FILE_SIZE + "=<int,e.g.:2097152>\n");
+  ret.append("  --" + LDBCommand::ARG_ENABLE_BLOB_FILES +
+             " : Set it to true to enable key-value separation\n");
+  ret.append("  --" + LDBCommand::ARG_MIN_BLOB_SIZE + "=<int,e.g.:2097152>\n");
+  ret.append("  --" + LDBCommand::ARG_BLOB_FILE_SIZE + "=<int,e.g.:2097152>\n");
+  ret.append("  --" + LDBCommand::ARG_BLOB_COMPRESSION_TYPE +
+             "=<no|snappy|zlib|bzip2|lz4|lz4hc|xpress|zstd>\n");
 
   ret.append("\n\n");
   ret.append("Data Access Commands:\n");

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -69,7 +69,7 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
              "=<int,e.g.:4194304>\n");
   ret.append("  --" + LDBCommand::ARG_FILE_SIZE + "=<int,e.g.:2097152>\n");
   ret.append("  --" + LDBCommand::ARG_ENABLE_BLOB_FILES +
-             " : Set it to true to enable key-value separation\n");
+             " : Enable key-value separation using BlobDB\n");
   ret.append("  --" + LDBCommand::ARG_MIN_BLOB_SIZE + "=<int,e.g.:2097152>\n");
   ret.append("  --" + LDBCommand::ARG_BLOB_FILE_SIZE + "=<int,e.g.:2097152>\n");
   ret.append("  --" + LDBCommand::ARG_BLOB_COMPRESSION_TYPE +


### PR DESCRIPTION
Summary:
Add the configuration options and help messages of BlobDB to `ldb`

Test Plan:
`python ./tools/ldb_test.py`