### PR TITLE
Dedicate cacheline for DB mutex

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1190,10 +1190,7 @@ class DBImpl : public DB {
   //
   // `mutex_` can be a hot lock in some workloads, so it deserves dedicated
   // cachelines.
-  ALIGN_AS(CACHE_LINE_SIZE) mutable InstrumentedMutex mutex_;
-  char padding[(CACHE_LINE_SIZE -
-                (sizeof(InstrumentedMutex) % CACHE_LINE_SIZE)) %
-               CACHE_LINE_SIZE] ROCKSDB_FIELD_UNUSED;
+  mutable CacheAlignedInstrumentedMutex mutex_;
 
   ColumnFamilyHandleImpl* default_cf_handle_;
   InternalStats* default_cf_internal_stats_;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1191,8 +1191,9 @@ class DBImpl : public DB {
   // `mutex_` can be a hot lock in some workloads, so it deserves dedicated
   // cachelines.
   ALIGN_AS(CACHE_LINE_SIZE) mutable InstrumentedMutex mutex_;
-  char padding[CACHE_LINE_SIZE - (sizeof(InstrumentedMutex) %
-                                  CACHE_LINE_SIZE)] ROCKSDB_FIELD_UNUSED;
+  char padding[(CACHE_LINE_SIZE -
+                (sizeof(InstrumentedMutex) % CACHE_LINE_SIZE)) %
+               CACHE_LINE_SIZE] ROCKSDB_FIELD_UNUSED;
 
   ColumnFamilyHandleImpl* default_cf_handle_;
   InternalStats* default_cf_internal_stats_;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1191,6 +1191,8 @@ class DBImpl : public DB {
   // `mutex_` can be a hot lock in some workloads, so it deserves dedicated
   // cachelines.
   ALIGN_AS(CACHE_LINE_SIZE) mutable InstrumentedMutex mutex_;
+  char padding[CACHE_LINE_SIZE - (sizeof(InstrumentedMutex) %
+                                  CACHE_LINE_SIZE)] ROCKSDB_FIELD_UNUSED;
 
   ColumnFamilyHandleImpl* default_cf_handle_;
   InternalStats* default_cf_internal_stats_;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1187,7 +1187,10 @@ class DBImpl : public DB {
   // WriteToWAL need different synchronization: log_empty_, alive_log_files_,
   // logs_, logfile_number_. Refer to the definition of each variable below for
   // more description.
-  mutable InstrumentedMutex mutex_;
+  //
+  // `mutex_` can be a hot lock in some workloads, so it deserves dedicated
+  // cachelines.
+  ALIGN_AS(CACHE_LINE_SIZE) mutable InstrumentedMutex mutex_;
 
   ColumnFamilyHandleImpl* default_cf_handle_;
   InternalStats* default_cf_internal_stats_;

--- a/monitoring/instrumented_mutex.h
+++ b/monitoring/instrumented_mutex.h
@@ -51,6 +51,14 @@ class InstrumentedMutex {
   int stats_code_;
 };
 
+class ALIGN_AS(CACHE_LINE_SIZE) CacheAlignedInstrumentedMutex
+    : public InstrumentedMutex {
+  using InstrumentedMutex::InstrumentedMutex;
+  char padding[(CACHE_LINE_SIZE - sizeof(InstrumentedMutex) % CACHE_LINE_SIZE) %
+               CACHE_LINE_SIZE] ROCKSDB_FIELD_UNUSED;
+};
+static_assert(sizeof(CacheAlignedInstrumentedMutex) % CACHE_LINE_SIZE == 0);
+
 // RAII wrapper for InstrumentedMutex
 class InstrumentedMutexLock {
  public:


### PR DESCRIPTION
We found a case of cacheline bouncing due to writers locking/unlocking `mutex_` and readers accessing `block_cache_tracer_`. We discovered it only after the issue was fixed by #9462 shifting the `DBImpl` members such that `mutex_` and `block_cache_tracer_` were naturally placed in separate cachelines in our regression testing setup. This PR forces the cacheline alignment of `mutex_` so we don't accidentally reintroduce the problem.