### PR TITLE
Integrate WAL compression into log reader/writer.

### DIFF
--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -463,7 +463,7 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
 
     if (uncompress_ && type != kSetCompressionType) {
       // Uncompress compressed records
-      std::string uncompressed_buffer = "";
+      uncompressed_record_.clear();
       size_t uncompressed_size = 0;
       int remaining = 0;
       do {
@@ -471,12 +471,10 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
             uncompress_->Uncompress(header + header_size, length,
                                     uncompressed_buffer_, &uncompressed_size);
         if (uncompressed_size > 0) {
-          std::string uncompressed_fragment;
-          uncompressed_fragment.assign(uncompressed_buffer_, uncompressed_size);
-          uncompressed_buffer += uncompressed_fragment;
+          uncompressed_record_.append(uncompressed_buffer_, uncompressed_size);
         }
       } while (remaining > 0 || uncompressed_size == kBlockSize);
-      *result = Slice(std::move(uncompressed_buffer));
+      *result = Slice(uncompressed_record_);
       return type;
     } else {
       *result = Slice(header + header_size, length);
@@ -747,7 +745,7 @@ bool FragmentBufferedReader::TryReadFragment(
 
   if (uncompress_ && type != kSetCompressionType) {
     // Uncompress compressed records
-    std::string uncompressed_buffer = "";
+    uncompressed_record_.clear();
     size_t uncompressed_size = 0;
     int remaining = 0;
     do {
@@ -755,12 +753,10 @@ bool FragmentBufferedReader::TryReadFragment(
           uncompress_->Uncompress(header + header_size, length,
                                   uncompressed_buffer_, &uncompressed_size);
       if (uncompressed_size > 0) {
-        std::string uncompressed_fragment;
-        uncompressed_fragment.assign(uncompressed_buffer_, uncompressed_size);
-        uncompressed_buffer += uncompressed_fragment;
+        uncompressed_record_.append(uncompressed_buffer_, uncompressed_size);
       }
     } while (remaining > 0 || uncompressed_size == kBlockSize);
-    *fragment = Slice(std::move(uncompressed_buffer));
+    *fragment = Slice(std::move(uncompressed_record_));
     *fragment_type_or_err = type;
     return true;
   } else {

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -476,7 +476,7 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
           uncompressed_buffer += uncompressed_fragment;
         }
       } while (remaining > 0 || uncompressed_size == kBlockSize);
-      *result = Slice(uncompressed_buffer);
+      *result = Slice(std::move(uncompressed_buffer));
       return type;
     } else {
       *result = Slice(header + header_size, length);
@@ -760,7 +760,7 @@ bool FragmentBufferedReader::TryReadFragment(
         uncompressed_buffer += uncompressed_fragment;
       }
     } while (remaining > 0 || uncompressed_size == kBlockSize);
-    *fragment = Slice(uncompressed_buffer);
+    *fragment = Slice(std::move(uncompressed_buffer));
     *fragment_type_or_err = type;
     return true;
   } else {

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -474,7 +474,7 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
           uncompressed_record_.append(uncompressed_buffer_.get(),
                                       uncompressed_size);
         }
-      } while (remaining > 0);
+      } while (remaining > 0 || uncompressed_size == kBlockSize);
       *result = Slice(uncompressed_record_);
       return type;
     } else {

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -136,6 +136,9 @@ class Reader {
   CompressionType compression_type_;
   // Track whether the compression type record has been read or not.
   bool compression_type_record_read_;
+  StreamingUncompress* uncompress_;
+  // Reusable uncompressed output buffer
+  char* uncompressed_buffer_;
 
   // Extend record types with the following special values
   enum {
@@ -167,6 +170,8 @@ class Reader {
   // buffer_ must be updated to remove the dropped bytes prior to invocation.
   void ReportCorruption(size_t bytes, const char* reason);
   void ReportDrop(size_t bytes, const Status& reason);
+
+  void InitCompression(const CompressionTypeRecord& compression_record);
 };
 
 class FragmentBufferedReader : public Reader {

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -138,7 +138,7 @@ class Reader {
   bool compression_type_record_read_;
   StreamingUncompress* uncompress_;
   // Reusable uncompressed output buffer
-  char* uncompressed_buffer_;
+  std::unique_ptr<char[]> uncompressed_buffer_;
   // Reusable uncompressed record
   std::string uncompressed_record_;
 

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -139,6 +139,8 @@ class Reader {
   StreamingUncompress* uncompress_;
   // Reusable uncompressed output buffer
   char* uncompressed_buffer_;
+  // Reusable uncompressed record
+  std::string uncompressed_record_;
 
   // Extend record types with the following special values
   enum {

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -1025,7 +1025,7 @@ TEST_P(StreamingCompressionTest, Basic) {
         uncompressed_fragment.assign(uncompressed_output_buffer, output_pos);
         uncompressed_buffer += uncompressed_fragment;
       }
-    } while (ret_val > 0 || output_pos == kBlockSize);
+    } while (ret_val > 0);
   }
   allocator->Deallocate((void*)uncompressed_output_buffer);
   delete allocator;

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -914,6 +914,11 @@ TEST_P(CompressionLogTest, Empty) {
 }
 
 TEST_P(CompressionLogTest, ReadWrite) {
+  CompressionType compression_type = std::get<2>(GetParam());
+  if (!StreamingCompressionTypeSupported(compression_type)) {
+    ROCKSDB_GTEST_SKIP("Test requires support for compression type");
+    return;
+  }
   ASSERT_OK(SetupTestEnv());
   Write("foo");
   Write("bar");
@@ -928,6 +933,11 @@ TEST_P(CompressionLogTest, ReadWrite) {
 }
 
 TEST_P(CompressionLogTest, ManyBlocks) {
+  CompressionType compression_type = std::get<2>(GetParam());
+  if (!StreamingCompressionTypeSupported(compression_type)) {
+    ROCKSDB_GTEST_SKIP("Test requires support for compression type");
+    return;
+  }
   ASSERT_OK(SetupTestEnv());
   for (int i = 0; i < 100000; i++) {
     Write(NumberString(i));
@@ -939,6 +949,11 @@ TEST_P(CompressionLogTest, ManyBlocks) {
 }
 
 TEST_P(CompressionLogTest, Fragmentation) {
+  CompressionType compression_type = std::get<2>(GetParam());
+  if (!StreamingCompressionTypeSupported(compression_type)) {
+    ROCKSDB_GTEST_SKIP("Test requires support for compression type");
+    return;
+  }
   ASSERT_OK(SetupTestEnv());
   Write("small");
   Write(BigString("medium", 50000));

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -904,6 +904,11 @@ class CompressionLogTest : public LogTest {
 };
 
 TEST_P(CompressionLogTest, Empty) {
+  CompressionType compression_type = std::get<2>(GetParam());
+  if (!StreamingCompressionTypeSupported(compression_type)) {
+    ROCKSDB_GTEST_SKIP("Test requires support for compression type");
+    return;
+  }
   ASSERT_OK(SetupTestEnv());
   const bool compression_enabled =
       std::get<2>(GetParam()) == kNoCompression ? false : true;

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -1025,7 +1025,7 @@ TEST_P(StreamingCompressionTest, Basic) {
         uncompressed_fragment.assign(uncompressed_output_buffer, output_pos);
         uncompressed_buffer += uncompressed_fragment;
       }
-    } while (ret_val > 0);
+    } while (ret_val > 0 || output_pos == kBlockSize);
   }
   allocator->Deallocate((void*)uncompressed_output_buffer);
   delete allocator;

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -10,6 +10,7 @@
 #include "db/log_writer.h"
 
 #include <stdint.h>
+
 #include "file/writable_file_writer.h"
 #include "rocksdb/env.h"
 #include "util/coding.h"
@@ -26,7 +27,9 @@ Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
       log_number_(log_number),
       recycle_log_files_(recycle_log_files),
       manual_flush_(manual_flush),
-      compression_type_(compression_type) {
+      compression_type_(compression_type),
+      compress_(nullptr),
+      compressed_buffer_(nullptr) {
   for (int i = 0; i <= kMaxRecordType; i++) {
     char t = static_cast<char>(i);
     type_crc_[i] = crc32c::Value(&t, 1);
@@ -36,6 +39,12 @@ Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
 Writer::~Writer() {
   if (dest_) {
     WriteBuffer().PermitUncheckedError();
+  }
+  if (compress_) {
+    delete compress_;
+  }
+  if (compressed_buffer_) {
+    delete[] compressed_buffer_;
   }
 }
 
@@ -63,6 +72,12 @@ IOStatus Writer::AddRecord(const Slice& slice) {
   // zero-length record
   IOStatus s;
   bool begin = true;
+  int compress_remaining = 0;
+  bool compress_start = false;
+  if (compress_) {
+    compress_->Reset();
+    compress_start = true;
+  }
   do {
     const int64_t leftover = kBlockSize - block_offset_;
     assert(leftover >= 0);
@@ -85,10 +100,31 @@ IOStatus Writer::AddRecord(const Slice& slice) {
     assert(static_cast<int64_t>(kBlockSize - block_offset_) >= header_size);
 
     const size_t avail = kBlockSize - block_offset_ - header_size;
+
+    // Compress the record
+    if (compress_ && (compress_start || left == 0)) {
+      compress_remaining = compress_->Compress(slice.data(), slice.size(),
+                                               compressed_buffer_, &left);
+
+      if (compress_remaining < 0) {
+        // Set failure status
+        s = IOStatus::IOError("Unexpected WAL compression error");
+        s.SetDataLoss(true);
+        break;
+      } else if (left == 0) {
+        // Nothing left to compress
+        if (!compress_start) {
+          break;
+        }
+      }
+      compress_start = false;
+      ptr = compressed_buffer_;
+    }
+
     const size_t fragment_length = (left < avail) ? left : avail;
 
     RecordType type;
-    const bool end = (left == fragment_length);
+    const bool end = (left == fragment_length && compress_remaining == 0);
     if (begin && end) {
       type = recycle_log_files_ ? kRecyclableFullType : kFullType;
     } else if (begin) {
@@ -103,7 +139,7 @@ IOStatus Writer::AddRecord(const Slice& slice) {
     ptr += fragment_length;
     left -= fragment_length;
     begin = false;
-  } while (s.ok() && left > 0);
+  } while (s.ok() && (left > 0 || compress_remaining > 0));
 
   if (s.ok()) {
     if (!manual_flush_) {
@@ -132,6 +168,17 @@ IOStatus Writer::AddCompressionTypeRecord() {
     if (!manual_flush_) {
       s = dest_->Flush();
     }
+    // Initialize fields required for compression
+    const size_t max_output_buffer_len =
+        kBlockSize - (recycle_log_files_ ? kRecyclableHeaderSize : kHeaderSize);
+    CompressionOptions opts;
+    constexpr uint32_t compression_format_version = 2;
+    compress_ = StreamingCompress::Create(compression_type_, opts,
+                                          compression_format_version,
+                                          max_output_buffer_len);
+    assert(compress_ != nullptr);
+    compressed_buffer_ = new char[max_output_buffer_len];
+    assert(compressed_buffer_ != nullptr);
   } else {
     // Disable compression if the record could not be added.
     compression_type_ = kNoCompression;

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -117,7 +117,7 @@ class Writer {
   CompressionType compression_type_;
   StreamingCompress* compress_;
   // Reusable compressed output buffer
-  char* compressed_buffer_;
+  std::unique_ptr<char[]> compressed_buffer_;
 };
 
 }  // namespace log

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -16,6 +16,7 @@
 #include "rocksdb/io_status.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
+#include "util/compression.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -114,6 +115,9 @@ class Writer {
 
   // Compression Type
   CompressionType compression_type_;
+  StreamingCompress* compress_;
+  // Reusable compressed output buffer
+  char* compressed_buffer_;
 };
 
 }  // namespace log

--- a/util/compression.h
+++ b/util/compression.h
@@ -1621,7 +1621,7 @@ class StreamingCompress {
   // Returns -1 for errors, the remaining size of the input buffer that needs to
   // be compressed
   virtual int Compress(const char* input, size_t input_size, char* output,
-                       size_t* output_size) = 0;
+                       size_t* output_pos) = 0;
   // static method to create object of a class inherited from StreamingCompress
   // based on the actual compression type.
   static StreamingCompress* Create(CompressionType compression_type,
@@ -1661,7 +1661,7 @@ class StreamingUncompress {
   // output_size - size of the output buffer
   // Returns -1 for errors, remaining input to be processed otherwise.
   virtual int Uncompress(const char* input, size_t input_size, char* output,
-                         size_t* output_size) = 0;
+                         size_t* output_pos) = 0;
   static StreamingUncompress* Create(CompressionType compression_type,
                                      uint32_t compress_format_version,
                                      size_t max_output_len);
@@ -1692,7 +1692,7 @@ class ZSTDStreamingCompress final : public StreamingCompress {
 #endif
   }
   int Compress(const char* input, size_t input_size, char* output,
-               size_t* output_size) override;
+               size_t* output_pos) override;
   void Reset() override;
 #ifdef ZSTD_STREAMING
   ZSTD_CCtx* cctx_;


### PR DESCRIPTION
Integrate the streaming compress/uncompress API into WAL compression.
The streaming compression object is stored in the log_writer along with a reusable output buffer to store the compressed buffer(s).
The streaming uncompress object is stored in the log_reader along with a reusable output buffer to store the uncompressed buffer(s).

Test Plan:
Added unit tests to verify different scenarios - large buffers, split compressed buffers, etc.

Future optimizations:
The overhead for small records is quite high, so it makes sense to compress only buffers above a certain threshold and use a separate record type to indicate that those records are compressed.