### PR TITLE
Use released clang-format instead of the one from dev branch

### DIFF
--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Download clang-format-diff.py
       uses: wei/wget@v1
       with:
-        args: https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format-diff.py
+        args: https://raw.githubusercontent.com/llvm/llvm-project/release/12.x/clang/tools/clang-format/clang-format-diff.py
 
     - name: Check format
       run: VERBOSE_CHECK=1 make check-format

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -29,8 +29,10 @@ jobs:
     - name: Install argparse
       run: pip install argparse
 
-    - name: Install clang-format
-      run: sudo apt-get install clang-format
+    - name: Download clang-format-diff.py
+      uses: wei/wget@v1
+      with:
+        args: https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format-diff.py
 
     - name: Check format
       run: VERBOSE_CHECK=1 make check-format

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -29,10 +29,8 @@ jobs:
     - name: Install argparse
       run: pip install argparse
 
-    - name: Download clang-format-diff.py
-      uses: wei/wget@v1
-      with:
-        args: https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format-diff.py
+    - name: Install clang-format
+      run: sudo apt-get install clang-format
 
     - name: Check format
       run: VERBOSE_CHECK=1 make check-format


### PR DESCRIPTION
We should use the released clang-format version instead of the one from
dev branch. Otherwise the format report could be inconsistent with local
development env and CI. e.g.: #9644

Test Plan: CI