### PR TITLE
Fix various spelling errors still found in code

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -575,7 +575,7 @@ Status DBImpl::CloseHelper() {
   // flushing by first checking if there is a need for
   // flushing (but need to implement something
   // else than imm()->IsFlushPending() because the output
-  // memtables added to imm() dont trigger flushes).
+  // memtables added to imm() don't trigger flushes).
   if (immutable_db_options_.experimental_mempurge_threshold > 0.0) {
     Status flush_ret;
     mutex_.Unlock();

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -314,7 +314,7 @@ class MemTableList {
   // PickMemtablesToFlush() is called.
   void FlushRequested() {
     flush_requested_ = true;
-    // If there are some memtables stored in imm() that dont trigger
+    // If there are some memtables stored in imm() that don't trigger
     // flush (eg: mempurge output memtable), then update imm_flush_needed.
     // Note: if race condition and imm_flush_needed is set to true
     // when there is num_flush_not_started_==0, then there is no

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -374,7 +374,7 @@ class WriteBatch : public WriteBatchBase {
   //
   // in: cf, the column family id.
   // ret: timestamp size of the given column family. Return
-  //      std::numeric_limits<size_t>::max() indicating "dont know or column
+  //      std::numeric_limits<size_t>::max() indicating "don't know or column
   //      family info not found", this will cause UpdateTimestamps() to fail.
   // size_t ts_sz_func(uint32_t cf);
   Status UpdateTimestamps(const Slice& ts,


### PR DESCRIPTION
dont -> don't
refered -> referred

This is a re-run of PR#7785 and acc9679 since these typos keep coming back.