### PR TITLE
remove redundant assignment code for member state

### DIFF
--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -737,7 +737,6 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       checksum_handoff_file_types(options.checksum_handoff_file_types),
       lowest_used_cache_tier(options.lowest_used_cache_tier),
       compaction_service(options.compaction_service) {
-  stats = statistics.get();
   fs = env->GetFileSystem();
   if (env != nullptr) {
     clock = env->GetSystemClock().get();


### PR DESCRIPTION
Remove redundant assignment code for member `state` in the constructor of `ImmutableDBOptions`.  
There are two identical and redundant statements `stats = statistics.get();` in lines 740 and 748 of the code.  
This commit removed the line 740.