### PR TITLE
Make Get/SetOption available in LITE mode

### DIFF
--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -207,6 +207,7 @@ class WritableFileWriter {
                   });
 #else  // !ROCKSDB_LITE
     (void)listeners;
+    (void)temperature_;
 #endif
     if (file_checksum_gen_factory != nullptr) {
       FileChecksumGenContext checksum_gen_context;

--- a/include/rocksdb/configurable.h
+++ b/include/rocksdb/configurable.h
@@ -121,7 +121,6 @@ class Configurable {
       const std::unordered_map<std::string, std::string>& opt_map,
       std::unordered_map<std::string, std::string>* unused);
 
-#ifndef ROCKSDB_LITE
   // Updates the named option to the input value, returning OK if successful.
   // Note that ConfigureOption does not cause PrepareOptions to be invoked.
   // @param config_options Controls how the name/value is processed.
@@ -133,9 +132,9 @@ class Configurable {
   //       not know how to convert the value.  This can happen if, for example,
   //       there is some nested Configurable that cannot be created.
   // @return InvalidArgument If the value cannot be successfully  parsed.
-  Status ConfigureOption(const ConfigOptions& config_options,
-                         const std::string& name, const std::string& value);
-#endif  // ROCKSDB_LITE
+  virtual Status ConfigureOption(const ConfigOptions& config_options,
+                                 const std::string& name,
+                                 const std::string& value);
 
   // Configures the options for this class based on the input parameters.
   // On successful completion, the object is updated with the settings from
@@ -190,6 +189,7 @@ class Configurable {
   // @return OK on success.
   Status GetOptionNames(const ConfigOptions& config_options,
                         std::unordered_set<std::string>* result) const;
+#endif  // ROCKSDB_LITE
 
   // Returns the value of the option associated with the input name
   // This method is the functional inverse of ConfigureOption
@@ -202,7 +202,6 @@ class Configurable {
   //      its value cannot be serialized.
   virtual Status GetOption(const ConfigOptions& config_options,
                            const std::string& name, std::string* value) const;
-#endif  // ROCKSDB_LITE
 
   // Checks to see if this Configurable is equivalent to other.
   // This method assumes that the two objects are of the same class.

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -144,6 +144,7 @@ bool SerializeEnum(const std::unordered_map<std::string, T>& type_map,
   return false;
 }
 
+#ifndef ROCKSDB_LITE
 template <typename T>
 Status ParseVector(const ConfigOptions& config_options,
                    const OptionTypeInfo& elem_info, char separator,
@@ -195,11 +196,13 @@ using SerializeFunc = std::function<Status(
 using EqualsFunc = std::function<bool(
     const ConfigOptions& /*opts*/, const std::string& /*name*/,
     const void* /*addr1*/, const void* /*addr2*/, std::string* mismatch)>;
+#endif  // ROCKSDB_LITE
 
 // A struct for storing constant option information such as option name,
 // option type, and offset.
 class OptionTypeInfo {
  public:
+#ifndef ROCKSDB_LITE
   // A simple "normal", non-mutable Type "type" at offset
   OptionTypeInfo(int offset, OptionType type)
       : offset_(offset),
@@ -784,6 +787,7 @@ class OptionTypeInfo {
   //          (e.g. "{a={b=c;}" ) -- missing closing brace
   // @return InvalidArgument if an expected delimiter is not found
   //        e.g. "{a=b}c=d;" -- missing delimiter before "c"
+#endif  // ROCSDB_LITE
   static Status NextToken(const std::string& opts, char delimiter, size_t start,
                           size_t* end, std::string* token);
 
@@ -791,6 +795,7 @@ class OptionTypeInfo {
   constexpr static const char* kIdPropSuffix() { return ".id"; }
 
  private:
+#ifndef ROCKSDB_LITE
   int offset_;
 
   // The optional function to convert a string to its representation
@@ -805,8 +810,10 @@ class OptionTypeInfo {
   OptionType type_;
   OptionVerificationType verification_;
   OptionTypeFlags flags_;
+#endif  // ROCKSDB_LITE
 };
 
+#ifndef ROCKSDB_LITE
 // Parses the input value into elements of the result vector.  This method
 // will break the input value into the individual tokens (based on the
 // separator), where each of those tokens will be parsed based on the rules of
@@ -943,4 +950,5 @@ bool VectorsAreEqual(const ConfigOptions& config_options,
     return true;
   }
 }
+#endif  // ROCKSDB_LITE
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -64,11 +64,11 @@ std::unique_ptr<Configurable> CFOptionsAsConfigurable(
 std::unique_ptr<Configurable> CFOptionsAsConfigurable(
     const ColumnFamilyOptions& opts,
     const std::unordered_map<std::string, std::string>* opt_map = nullptr);
+#endif  // !ROCKSDB_LITE
 
 extern Status StringToMap(
     const std::string& opts_str,
     std::unordered_map<std::string, std::string>* opts_map);
-#endif  // !ROCKSDB_LITE
 
 struct OptionsHelper {
   static const std::string kCFOptionsName /*= "ColumnFamilyOptions"*/;


### PR DESCRIPTION
Some classes (like CompressionOptions) would benefit from allowing them to be configured in LITE mode.  This allows a class to override the Get/Set method and provide an implementation.  