### PR TITLE
Provide implementation to prefetch data asynchronously in FilePrefetchBuffer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 * `BlockBasedTableOptions::detect_filter_construct_corruption` can now be dynamically configured using `DB::SetOptions`.
 * Automatically recover from retryable read IO errors during backgorund flush/compaction.
 * Experimental support for preserving file Temperatures through backup and restore, and for updating DB metadata for outside changes to file Temperature (`UpdateManifestForFilesState` or `ldb update_manifest --update_temperatures`).
+* Experimental support for async_io in ReadOptions which is used by FilePrefetchBuffer to prefetch some of the data asynchronously,  if reads are sequential and auto readahead is enabled by rocksdb internally.
 
 ### Bug Fixes
 * Fixed a data race on `versions_` between `DBImpl::ResumeImpl()` and threads waiting for recovery to complete (#9496)

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -448,7 +448,7 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
             return false;
           }
         }
-        if (implicit_auto_readahead_ && async_prefetch_) {
+        if (implicit_auto_readahead_ && async_io_) {
           // Prefetch n + readahead_size_/2 synchronously as remaining
           // readahead_size_/2 will be prefetched asynchronously.
           s = PrefetchAsync(opts, reader, fs, offset, n, readahead_size_ / 2,

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -446,7 +446,7 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
             return false;
           }
         }
-        if (implicit_auto_readahead_ && is_adaptive_readahead_) {
+        if (implicit_auto_readahead_ && async_prefetch_) {
           // Prefetch n + readahead_size_/2 synchronously as remaining
           // readahead_size_/2 will be prefetched asynchronously.
           s = PrefetchAsync(opts, reader, fs, offset, n, readahead_size_ / 2,

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -21,55 +21,32 @@
 #include "util/rate_limiter.h"
 
 namespace ROCKSDB_NAMESPACE {
-Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
-                                    RandomAccessFileReader* reader,
-                                    uint64_t offset, size_t n,
-                                    Env::IOPriority rate_limiter_priority) {
-  if (!enable_ || reader == nullptr) {
-    return Status::OK();
-  }
-  TEST_SYNC_POINT("FilePrefetchBuffer::Prefetch:Start");
-  size_t alignment = reader->file()->GetRequiredBufferAlignment();
-  size_t offset_ = static_cast<size_t>(offset);
-  uint64_t rounddown_offset = Rounddown(offset_, alignment);
-  uint64_t roundup_end = Roundup(offset_ + n, alignment);
-  uint64_t roundup_len = roundup_end - rounddown_offset;
-  assert(roundup_len >= alignment);
-  assert(roundup_len % alignment == 0);
 
+void FilePrefetchBuffer::Calculate(size_t alignment, uint64_t offset,
+                                   size_t roundup_len, size_t& chunk_len) {
+  uint64_t chunk_offset_in_buffer = 0;
+  bool copy_data_to_new_buffer = false;
   // Check if requested bytes are in the existing buffer_.
-  // If all bytes exist -- return.
   // If only a few bytes exist -- reuse them & read only what is really needed.
   //     This is typically the case of incremental reading of data.
   // If no bytes exist in buffer -- full pread.
-
-  Status s;
-  uint64_t chunk_offset_in_buffer = 0;
-  uint64_t chunk_len = 0;
-  bool copy_data_to_new_buffer = false;
   if (buffer_.CurrentSize() > 0 && offset >= buffer_offset_ &&
       offset <= buffer_offset_ + buffer_.CurrentSize()) {
-    if (offset + n <= buffer_offset_ + buffer_.CurrentSize()) {
-      // All requested bytes are already in the buffer. So no need to Read
-      // again.
-      return s;
+    // Only a few requested bytes are in the buffer. memmove those chunk of
+    // bytes to the beginning, and memcpy them back into the new buffer if a
+    // new buffer is created.
+    chunk_offset_in_buffer =
+        Rounddown(static_cast<size_t>(offset - buffer_offset_), alignment);
+    chunk_len = buffer_.CurrentSize() - chunk_offset_in_buffer;
+    assert(chunk_offset_in_buffer % alignment == 0);
+    assert(chunk_len % alignment == 0);
+    assert(chunk_offset_in_buffer + chunk_len <=
+           buffer_offset_ + buffer_.CurrentSize());
+    if (chunk_len > 0) {
+      copy_data_to_new_buffer = true;
     } else {
-      // Only a few requested bytes are in the buffer. memmove those chunk of
-      // bytes to the beginning, and memcpy them back into the new buffer if a
-      // new buffer is created.
-      chunk_offset_in_buffer =
-          Rounddown(static_cast<size_t>(offset - buffer_offset_), alignment);
-      chunk_len = buffer_.CurrentSize() - chunk_offset_in_buffer;
-      assert(chunk_offset_in_buffer % alignment == 0);
-      assert(chunk_len % alignment == 0);
-      assert(chunk_offset_in_buffer + chunk_len <=
-             buffer_offset_ + buffer_.CurrentSize());
-      if (chunk_len > 0) {
-        copy_data_to_new_buffer = true;
-      } else {
-        // this reset is not necessary, but just to be safe.
-        chunk_offset_in_buffer = 0;
-      }
+      // this reset is not necessary, but just to be safe.
+      chunk_offset_in_buffer = 0;
     }
   }
 
@@ -86,6 +63,35 @@ Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
     buffer_.RefitTail(static_cast<size_t>(chunk_offset_in_buffer),
                       static_cast<size_t>(chunk_len));
   }
+}
+
+Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
+                                    RandomAccessFileReader* reader,
+                                    uint64_t offset, size_t n,
+                                    Env::IOPriority rate_limiter_priority) {
+  if (!enable_ || reader == nullptr) {
+    return Status::OK();
+  }
+
+  Status s;
+  TEST_SYNC_POINT("FilePrefetchBuffer::Prefetch:Start");
+
+  if (offset + n <= buffer_offset_ + buffer_.CurrentSize()) {
+    // All requested bytes are already in the buffer. So no need to Read
+    // again.
+    return s;
+  }
+
+  size_t alignment = reader->file()->GetRequiredBufferAlignment();
+  size_t _offset = static_cast<size_t>(offset);
+  uint64_t rounddown_offset = Rounddown(_offset, alignment);
+  uint64_t roundup_end = Roundup(_offset + n, alignment);
+  uint64_t roundup_len = roundup_end - rounddown_offset;
+  assert(roundup_len >= alignment);
+  assert(roundup_len % alignment == 0);
+  uint64_t chunk_len = 0;
+
+  Calculate(alignment, offset, roundup_len, chunk_len);
 
   Slice result;
   size_t read_len = static_cast<size_t>(roundup_len - chunk_len);
@@ -121,6 +127,8 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
     return false;
   }
 
+  bool prefetched = false;
+
   // If the buffer contains only a few of the requested bytes:
   //    If readahead is enabled: prefetch the remaining bytes + readahead bytes
   //        and satisfy the request.
@@ -137,18 +145,7 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
                      rate_limiter_priority);
       } else {
         if (implicit_auto_readahead_) {
-          // Prefetch only if this read is sequential otherwise reset
-          // readahead_size_ to initial value.
-          if (!IsBlockSequential(offset)) {
-            UpdateReadPattern(offset, n);
-            ResetValues();
-            // Ignore status as Prefetch is not called.
-            s.PermitUncheckedError();
-            return false;
-          }
-          num_file_reads_++;
-          if (num_file_reads_ <= kMinNumFileReadsToStartAutoReadahead) {
-            UpdateReadPattern(offset, n);
+          if (!IsEligibleForPrefetch(offset, n)) {
             // Ignore status as Prefetch is not called.
             s.PermitUncheckedError();
             return false;
@@ -166,7 +163,7 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
 #endif
         return false;
       }
-      readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
+      prefetched = true;
     } else {
       return false;
     }
@@ -174,6 +171,10 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
   UpdateReadPattern(offset, n);
   uint64_t offset_in_buffer = offset - buffer_offset_;
   *result = Slice(buffer_.BufferStart() + offset_in_buffer, n);
+
+  if (prefetched) {
+    readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
+  }
   return true;
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -62,7 +62,7 @@ class FilePrefetchBuffer {
   FilePrefetchBuffer(size_t readahead_size = 0, size_t max_readahead_size = 0,
                      bool enable = true, bool track_min_offset = false,
                      bool implicit_auto_readahead = false,
-                     bool async_prefetch = false)
+                     bool async_io = false)
       : curr_(0),
         readahead_size_(readahead_size),
         max_readahead_size_(max_readahead_size),
@@ -76,7 +76,7 @@ class FilePrefetchBuffer {
         io_handle_(nullptr),
         del_fn_(nullptr),
         async_read_in_progress_(false),
-        async_prefetch_(async_prefetch) {
+        async_io_(async_io) {
     bufs_.resize(3);
   }
 
@@ -248,6 +248,6 @@ class FilePrefetchBuffer {
   void* io_handle_;
   IOHandleDeleter del_fn_;
   bool async_read_in_progress_;
-  bool async_prefetch_;
+  bool async_io_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -117,7 +117,13 @@ class FilePrefetchBuffer {
   bool TryReadFromCache(const IOOptions& opts, RandomAccessFileReader* reader,
                         uint64_t offset, size_t n, Slice* result, Status* s,
                         Env::IOPriority rate_limiter_priority,
-                        bool for_compaction = false, FileSystem* fs = nullptr);
+                        bool for_compaction = false);
+
+  bool TryReadFromCacheAsync(const IOOptions& opts,
+                             RandomAccessFileReader* reader, uint64_t offset,
+                             size_t n, Slice* result, Status* status,
+                             Env::IOPriority rate_limiter_priority,
+                             bool for_compaction /* = false */, FileSystem* fs);
 
   // The minimum `offset` ever passed to TryReadFromCache(). This will nly be
   // tracked if track_min_offset = true.
@@ -188,8 +194,8 @@ class FilePrefetchBuffer {
   // Calculates roundoff offset and length to be prefetched based on alignment
   // and data present in buffer_.
   void CalculateOffsetAndLen(size_t alignment, uint64_t offset,
-                             size_t roundup_len, uint64_t& chunk_len,
-                             size_t index);
+                             size_t roundup_len, size_t index, bool refit_tail,
+                             uint64_t& chunk_len);
 
   Status Read(const IOOptions& opts, RandomAccessFileReader* reader,
               Env::IOPriority rate_limiter_priority, uint64_t read_len,

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -62,7 +62,7 @@ class FilePrefetchBuffer {
   FilePrefetchBuffer(size_t readahead_size = 0, size_t max_readahead_size = 0,
                      bool enable = true, bool track_min_offset = false,
                      bool implicit_auto_readahead = false,
-                     bool is_adaptive_readahead = false)
+                     bool async_prefetch = false)
       : curr_(0),
         readahead_size_(readahead_size),
         max_readahead_size_(max_readahead_size),
@@ -76,7 +76,7 @@ class FilePrefetchBuffer {
         io_handle_(nullptr),
         del_fn_(nullptr),
         async_read_in_progress_(false),
-        is_adaptive_readahead_(is_adaptive_readahead) {
+        async_prefetch_(async_prefetch) {
     bufs_.resize(3);
   }
 
@@ -132,7 +132,7 @@ class FilePrefetchBuffer {
   // Called in case of implicit auto prefetching.
   void UpdateReadPattern(const uint64_t& offset, const size_t& len,
                          bool decrease_readaheadsize) {
-    if (is_adaptive_readahead_ && decrease_readaheadsize) {
+    if (decrease_readaheadsize) {
       // Since this block was eligible for prefetch but it was found in
       // cache, so check and decrease the readahead_size by 8KB (default)
       // if eligible.
@@ -247,6 +247,6 @@ class FilePrefetchBuffer {
   void* io_handle_;
   IOHandleDeleter del_fn_;
   bool async_read_in_progress_;
-  bool is_adaptive_readahead_;
+  bool async_prefetch_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -202,8 +202,9 @@ class FilePrefetchBuffer {
               uint64_t chunk_len, uint64_t rounddown_start, uint32_t index);
 
   Status ReadAsync(const IOOptions& opts, RandomAccessFileReader* reader,
-                   uint64_t read_len, uint64_t chunk_len,
-                   uint64_t rounddown_start, uint32_t index);
+                   Env::IOPriority rate_limiter_priority, uint64_t read_len,
+                   uint64_t chunk_len, uint64_t rounddown_start,
+                   uint32_t index);
 
   void CopyDataToBuffer(uint64_t alignment, uint64_t& offset, size_t& length,
                         uint32_t src);

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -763,6 +763,8 @@ TEST_P(PrefetchTest1, DBIterLevelReadAhead) {
     ReadOptions ro;
     if (is_adaptive_readahead) {
       ro.adaptive_readahead = true;
+      // TODO akanksha: Remove after adding new units.
+      ro.async_prefetch = true;
     }
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
     int num_keys = 0;
@@ -858,6 +860,8 @@ TEST_P(PrefetchTest2, NonSequentialReads) {
     // Iterate until prefetch is done.
     ReadOptions ro;
     ro.adaptive_readahead = true;
+    // TODO akanksha: Remove after adding new units.
+    ro.async_prefetch = true;
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
     iter->SeekToFirst();
     while (iter->Valid() && buff_prefetch_count == 0) {
@@ -944,6 +948,8 @@ TEST_P(PrefetchTest2, DecreaseReadAheadIfInCache) {
   SyncPoint::GetInstance()->EnableProcessing();
   ReadOptions ro;
   ro.adaptive_readahead = true;
+  // TODO akanksha: Remove after adding new units.
+  ro.async_prefetch = true;
   {
     /*
      * Reseek keys from sequential Data Blocks within same partitioned

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -718,9 +718,11 @@ TEST_P(PrefetchTest1, DBIterLevelReadAhead) {
 
   WriteBatch batch;
   Random rnd(309);
+  int total_keys = 0;
   for (int j = 0; j < 5; j++) {
     for (int i = j * kNumKeys; i < (j + 1) * kNumKeys; i++) {
       ASSERT_OK(batch.Put(BuildKey(i), rnd.RandomString(1000)));
+      total_keys++;
     }
     ASSERT_OK(db_->Write(WriteOptions(), &batch));
     ASSERT_OK(Flush());
@@ -765,8 +767,10 @@ TEST_P(PrefetchTest1, DBIterLevelReadAhead) {
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
     int num_keys = 0;
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+      ASSERT_OK(iter->status());
       num_keys++;
     }
+    ASSERT_EQ(num_keys, total_keys);
 
     ASSERT_GT(buff_prefetch_count, 0);
     buff_prefetch_count = 0;
@@ -958,28 +962,35 @@ TEST_P(PrefetchTest2, DecreaseReadAheadIfInCache) {
     // After caching, blocks will be read from cache (Sequential blocks)
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
     iter->Seek(BuildKey(0));
+    ASSERT_TRUE(iter->Valid());
     iter->Seek(BuildKey(1000));
+    ASSERT_TRUE(iter->Valid());
     iter->Seek(BuildKey(1004));  // Prefetch data (not in cache).
+    ASSERT_TRUE(iter->Valid());
     ASSERT_EQ(current_readahead_size, expected_current_readahead_size);
 
     // Missed one sequential block but 1011 is already in buffer so
     // readahead will not be reset.
     iter->Seek(BuildKey(1011));
+    ASSERT_TRUE(iter->Valid());
     ASSERT_EQ(current_readahead_size, expected_current_readahead_size);
 
     // Eligible to Prefetch data (not in buffer) but block is in cache so no
     // prefetch will happen and will result in decrease in readahead_size.
     // readahead_size will be 8 * 1024
     iter->Seek(BuildKey(1015));
+    ASSERT_TRUE(iter->Valid());
     expected_current_readahead_size -= decrease_readahead_size;
 
     // 1016 is the same block as 1015. So no change in readahead_size.
     iter->Seek(BuildKey(1016));
+    ASSERT_TRUE(iter->Valid());
 
     // Prefetch data (not in buffer) but found in cache. So decrease
     // readahead_size. Since it will 0 after decrementing so readahead_size will
     // be set to initial value.
     iter->Seek(BuildKey(1019));
+    ASSERT_TRUE(iter->Valid());
     expected_current_readahead_size = std::max(
         decrease_readahead_size,
         (expected_current_readahead_size >= decrease_readahead_size
@@ -988,6 +999,7 @@ TEST_P(PrefetchTest2, DecreaseReadAheadIfInCache) {
 
     // Prefetch next sequential data.
     iter->Seek(BuildKey(1022));
+    ASSERT_TRUE(iter->Valid());
     ASSERT_EQ(current_readahead_size, expected_current_readahead_size);
     ASSERT_EQ(buff_prefetch_count, 2);
     buff_prefetch_count = 0;

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -764,7 +764,7 @@ TEST_P(PrefetchTest1, DBIterLevelReadAhead) {
     if (is_adaptive_readahead) {
       ro.adaptive_readahead = true;
       // TODO akanksha: Remove after adding new units.
-      ro.async_prefetch = true;
+      ro.async_io = true;
     }
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
     int num_keys = 0;
@@ -861,7 +861,7 @@ TEST_P(PrefetchTest2, NonSequentialReads) {
     ReadOptions ro;
     ro.adaptive_readahead = true;
     // TODO akanksha: Remove after adding new units.
-    ro.async_prefetch = true;
+    ro.async_io = true;
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
     iter->SeekToFirst();
     while (iter->Valid() && buff_prefetch_count == 0) {
@@ -949,7 +949,7 @@ TEST_P(PrefetchTest2, DecreaseReadAheadIfInCache) {
   ReadOptions ro;
   ro.adaptive_readahead = true;
   // TODO akanksha: Remove after adding new units.
-  ro.async_prefetch = true;
+  ro.async_io = true;
   {
     /*
      * Reseek keys from sequential Data Blocks within same partitioned

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -424,4 +424,12 @@ IOStatus RandomAccessFileReader::PrepareIOOptions(const ReadOptions& ro,
     return PrepareIOFromReadOptions(ro, SystemClock::Default().get(), opts);
   }
 }
+
+IOStatus RandomAccessFileReader::ReadAsync(
+    FSReadRequest& req, const IOOptions& opts,
+    std::function<void(const FSReadRequest&, void*)> cb, void* cb_arg,
+    void** io_handle, IOHandleDeleter* del_fn) {
+  return file_->ReadAsync(req, opts, cb, cb_arg, io_handle, del_fn,
+                          nullptr /*dbg*/);
+}
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -425,10 +425,18 @@ IOStatus RandomAccessFileReader::PrepareIOOptions(const ReadOptions& ro,
   }
 }
 
+// TODO akanksha: Add perf_times etc.
 IOStatus RandomAccessFileReader::ReadAsync(
     FSReadRequest& req, const IOOptions& opts,
     std::function<void(const FSReadRequest&, void*)> cb, void* cb_arg,
-    void** io_handle, IOHandleDeleter* del_fn) {
+    void** io_handle, IOHandleDeleter* del_fn,
+    Env::IOPriority rate_limiter_priority) {
+  if (use_direct_io()) {
+    req.status = Read(opts, req.offset, req.len, &(req.result), req.scratch,
+                      nullptr /*dbg*/, rate_limiter_priority);
+    cb(req, cb_arg);
+    return IOStatus::OK();
+  }
   return file_->ReadAsync(req, opts, cb, cb_arg, io_handle, del_fn,
                           nullptr /*dbg*/);
 }

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -177,6 +177,7 @@ class RandomAccessFileReader {
 
   IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
                      std::function<void(const FSReadRequest&, void*)> cb,
-                     void* cb_arg, void** io_handle, IOHandleDeleter* del_fn);
+                     void* cb_arg, void** io_handle, IOHandleDeleter* del_fn,
+                     Env::IOPriority rate_limiter_priority);
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -174,5 +174,9 @@ class RandomAccessFileReader {
   bool use_direct_io() const { return file_->use_direct_io(); }
 
   IOStatus PrepareIOOptions(const ReadOptions& ro, IOOptions& opts);
+
+  IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
+                     std::function<void(const FSReadRequest&, void*)> cb,
+                     void* cb_arg, void** io_handle, IOHandleDeleter* del_fn);
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1598,6 +1598,9 @@ struct ReadOptions {
   // Default: `Env::IO_TOTAL`.
   Env::IOPriority rate_limiter_priority = Env::IO_TOTAL;
 
+  // TODO akanksha: Add details.
+  bool async_prefetch;
+
   ReadOptions();
   ReadOptions(bool cksum, bool cache);
 };

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1599,7 +1599,7 @@ struct ReadOptions {
   Env::IOPriority rate_limiter_priority = Env::IO_TOTAL;
 
   // TODO akanksha: Add details.
-  bool async_prefetch;
+  bool async_io;
 
   ReadOptions();
   ReadOptions(bool cksum, bool cache);

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1598,7 +1598,13 @@ struct ReadOptions {
   // Default: `Env::IO_TOTAL`.
   Env::IOPriority rate_limiter_priority = Env::IO_TOTAL;
 
-  // TODO akanksha: Add details.
+  // Experimental
+  //
+  // If async_io is enabled, RocksDB will prefetch some of data asynchronously.
+  // RocksDB apply it if reads are sequential and its internal automatic
+  // prefetching.
+  //
+  // Default: false
   bool async_io;
 
   ReadOptions();

--- a/options/options.cc
+++ b/options/options.cc
@@ -666,7 +666,7 @@ ReadOptions::ReadOptions()
       io_timeout(std::chrono::microseconds::zero()),
       value_size_soft_limit(std::numeric_limits<uint64_t>::max()),
       adaptive_readahead(false),
-      async_prefetch(false) {}
+      async_io(false) {}
 
 ReadOptions::ReadOptions(bool cksum, bool cache)
     : snapshot(nullptr),
@@ -691,6 +691,6 @@ ReadOptions::ReadOptions(bool cksum, bool cache)
       io_timeout(std::chrono::microseconds::zero()),
       value_size_soft_limit(std::numeric_limits<uint64_t>::max()),
       adaptive_readahead(false),
-      async_prefetch(false) {}
+      async_io(false) {}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/options.cc
+++ b/options/options.cc
@@ -665,7 +665,8 @@ ReadOptions::ReadOptions()
       deadline(std::chrono::microseconds::zero()),
       io_timeout(std::chrono::microseconds::zero()),
       value_size_soft_limit(std::numeric_limits<uint64_t>::max()),
-      adaptive_readahead(false) {}
+      adaptive_readahead(false),
+      async_prefetch(false) {}
 
 ReadOptions::ReadOptions(bool cksum, bool cache)
     : snapshot(nullptr),
@@ -689,6 +690,7 @@ ReadOptions::ReadOptions(bool cksum, bool cache)
       deadline(std::chrono::microseconds::zero()),
       io_timeout(std::chrono::microseconds::zero()),
       value_size_soft_limit(std::numeric_limits<uint64_t>::max()),
-      adaptive_readahead(false) {}
+      adaptive_readahead(false),
+      async_prefetch(false) {}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -234,7 +234,7 @@ void BlockBasedTableIterator::InitDataBlock() {
     //   Enabled from the very first IO when ReadOptions.readahead_size is set.
     block_prefetcher_.PrefetchIfNeeded(
         rep, data_block_handle, read_options_.readahead_size, is_for_compaction,
-        read_options_.adaptive_readahead);
+        read_options_.async_prefetch);
     Status s;
     table_->NewDataBlockIterator<DataBlockIter>(
         read_options_, data_block_handle, &block_iter_, BlockType::kData,

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -232,9 +232,9 @@ void BlockBasedTableIterator::InitDataBlock() {
     //   Enabled after 2 sequential IOs when ReadOptions.readahead_size == 0.
     // Explicit user requested readahead:
     //   Enabled from the very first IO when ReadOptions.readahead_size is set.
-    block_prefetcher_.PrefetchIfNeeded(rep, data_block_handle,
-                                       read_options_.readahead_size,
-                                       is_for_compaction);
+    block_prefetcher_.PrefetchIfNeeded(
+        rep, data_block_handle, read_options_.readahead_size, is_for_compaction,
+        read_options_.adaptive_readahead);
     Status s;
     table_->NewDataBlockIterator<DataBlockIter>(
         read_options_, data_block_handle, &block_iter_, BlockType::kData,

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -234,7 +234,7 @@ void BlockBasedTableIterator::InitDataBlock() {
     //   Enabled from the very first IO when ReadOptions.readahead_size is set.
     block_prefetcher_.PrefetchIfNeeded(
         rep, data_block_handle, read_options_.readahead_size, is_for_compaction,
-        read_options_.async_prefetch);
+        read_options_.async_io);
     Status s;
     table_->NewDataBlockIterator<DataBlockIter>(
         read_options_, data_block_handle, &block_iter_, BlockType::kData,

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1474,7 +1474,7 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
           // prefetching. It should also take in account blocks read from cache.
           prefetch_buffer->UpdateReadPattern(handle.offset(),
                                              BlockSizeWithTrailer(handle),
-                                             ro.adaptive_readahead);
+                                             true /*decrease_readahead_size*/);
         }
       }
     }

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1472,9 +1472,9 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
           // Update the block details so that PrefetchBuffer can use the read
           // pattern to determine if reads are sequential or not for
           // prefetching. It should also take in account blocks read from cache.
-          prefetch_buffer->UpdateReadPattern(handle.offset(),
-                                             BlockSizeWithTrailer(handle),
-                                             true /*decrease_readahead_size*/);
+          prefetch_buffer->UpdateReadPattern(
+              handle.offset(), BlockSizeWithTrailer(handle),
+              ro.adaptive_readahead /*decrease_readahead_size*/);
         }
       }
     }

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -653,20 +653,20 @@ struct BlockBasedTable::Rep {
                                 size_t max_readahead_size,
                                 std::unique_ptr<FilePrefetchBuffer>* fpb,
                                 bool implicit_auto_readahead,
-                                bool is_adaptive_readahead) const {
-    fpb->reset(new FilePrefetchBuffer(
-        readahead_size, max_readahead_size,
-        !ioptions.allow_mmap_reads /* enable */, false /* track_min_offset */,
-        implicit_auto_readahead, is_adaptive_readahead));
+                                bool async_prefetch) const {
+    fpb->reset(new FilePrefetchBuffer(readahead_size, max_readahead_size,
+                                      !ioptions.allow_mmap_reads /* enable */,
+                                      false /* track_min_offset */,
+                                      implicit_auto_readahead, async_prefetch));
   }
 
   void CreateFilePrefetchBufferIfNotExists(
       size_t readahead_size, size_t max_readahead_size,
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
-      bool is_adaptive_readahead) const {
+      bool async_prefetch) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
-                               implicit_auto_readahead, is_adaptive_readahead);
+                               implicit_auto_readahead, async_prefetch);
     }
   }
 };

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -652,20 +652,21 @@ struct BlockBasedTable::Rep {
   void CreateFilePrefetchBuffer(size_t readahead_size,
                                 size_t max_readahead_size,
                                 std::unique_ptr<FilePrefetchBuffer>* fpb,
-                                bool implicit_auto_readahead) const {
-    fpb->reset(new FilePrefetchBuffer(readahead_size, max_readahead_size,
-                                      !ioptions.allow_mmap_reads /* enable */,
-                                      false /* track_min_offset */,
-                                      implicit_auto_readahead));
+                                bool implicit_auto_readahead,
+                                bool is_adaptive_readahead) const {
+    fpb->reset(new FilePrefetchBuffer(
+        readahead_size, max_readahead_size,
+        !ioptions.allow_mmap_reads /* enable */, false /* track_min_offset */,
+        implicit_auto_readahead, is_adaptive_readahead));
   }
 
   void CreateFilePrefetchBufferIfNotExists(
       size_t readahead_size, size_t max_readahead_size,
-      std::unique_ptr<FilePrefetchBuffer>* fpb,
-      bool implicit_auto_readahead) const {
+      std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
+      bool is_adaptive_readahead) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
-                               implicit_auto_readahead);
+                               implicit_auto_readahead, is_adaptive_readahead);
     }
   }
 };

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -653,20 +653,20 @@ struct BlockBasedTable::Rep {
                                 size_t max_readahead_size,
                                 std::unique_ptr<FilePrefetchBuffer>* fpb,
                                 bool implicit_auto_readahead,
-                                bool async_prefetch) const {
+                                bool async_io) const {
     fpb->reset(new FilePrefetchBuffer(readahead_size, max_readahead_size,
                                       !ioptions.allow_mmap_reads /* enable */,
                                       false /* track_min_offset */,
-                                      implicit_auto_readahead, async_prefetch));
+                                      implicit_auto_readahead, async_io));
   }
 
   void CreateFilePrefetchBufferIfNotExists(
       size_t readahead_size, size_t max_readahead_size,
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
-      bool async_prefetch) const {
+      bool async_io) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
-                               implicit_auto_readahead, async_prefetch);
+                               implicit_auto_readahead, async_io);
     }
   }
 };

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -14,20 +14,18 @@ namespace ROCKSDB_NAMESPACE {
 void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
                                        const BlockHandle& handle,
                                        size_t readahead_size,
-                                       bool is_for_compaction,
-                                       bool async_prefetch) {
+                                       bool is_for_compaction, bool async_io) {
   if (is_for_compaction) {
     rep->CreateFilePrefetchBufferIfNotExists(
         compaction_readahead_size_, compaction_readahead_size_,
-        &prefetch_buffer_, false, async_prefetch);
+        &prefetch_buffer_, false, async_io);
     return;
   }
 
   // Explicit user requested readahead.
   if (readahead_size > 0) {
-    rep->CreateFilePrefetchBufferIfNotExists(readahead_size, readahead_size,
-                                             &prefetch_buffer_, false,
-                                             async_prefetch);
+    rep->CreateFilePrefetchBufferIfNotExists(
+        readahead_size, readahead_size, &prefetch_buffer_, false, async_io);
     return;
   }
 
@@ -71,9 +69,9 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
   }
 
   if (rep->file->use_direct_io()) {
-    rep->CreateFilePrefetchBufferIfNotExists(
-        initial_auto_readahead_size_, max_auto_readahead_size,
-        &prefetch_buffer_, true, async_prefetch);
+    rep->CreateFilePrefetchBufferIfNotExists(initial_auto_readahead_size_,
+                                             max_auto_readahead_size,
+                                             &prefetch_buffer_, true, async_io);
     return;
   }
 
@@ -88,9 +86,9 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
       handle.offset(),
       BlockBasedTable::BlockSizeWithTrailer(handle) + readahead_size_);
   if (s.IsNotSupported()) {
-    rep->CreateFilePrefetchBufferIfNotExists(
-        initial_auto_readahead_size_, max_auto_readahead_size,
-        &prefetch_buffer_, true, async_prefetch);
+    rep->CreateFilePrefetchBufferIfNotExists(initial_auto_readahead_size_,
+                                             max_auto_readahead_size,
+                                             &prefetch_buffer_, true, async_io);
     return;
   }
 

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -14,18 +14,20 @@ namespace ROCKSDB_NAMESPACE {
 void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
                                        const BlockHandle& handle,
                                        size_t readahead_size,
-                                       bool is_for_compaction) {
+                                       bool is_for_compaction,
+                                       bool is_adaptive_readahead) {
   if (is_for_compaction) {
-    rep->CreateFilePrefetchBufferIfNotExists(compaction_readahead_size_,
-                                             compaction_readahead_size_,
-                                             &prefetch_buffer_, false);
+    rep->CreateFilePrefetchBufferIfNotExists(
+        compaction_readahead_size_, compaction_readahead_size_,
+        &prefetch_buffer_, false, is_adaptive_readahead);
     return;
   }
 
   // Explicit user requested readahead.
   if (readahead_size > 0) {
     rep->CreateFilePrefetchBufferIfNotExists(readahead_size, readahead_size,
-                                             &prefetch_buffer_, false);
+                                             &prefetch_buffer_, false,
+                                             is_adaptive_readahead);
     return;
   }
 
@@ -69,9 +71,9 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
   }
 
   if (rep->file->use_direct_io()) {
-    rep->CreateFilePrefetchBufferIfNotExists(initial_auto_readahead_size_,
-                                             max_auto_readahead_size,
-                                             &prefetch_buffer_, true);
+    rep->CreateFilePrefetchBufferIfNotExists(
+        initial_auto_readahead_size_, max_auto_readahead_size,
+        &prefetch_buffer_, true, is_adaptive_readahead);
     return;
   }
 
@@ -86,9 +88,9 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
       handle.offset(),
       BlockBasedTable::BlockSizeWithTrailer(handle) + readahead_size_);
   if (s.IsNotSupported()) {
-    rep->CreateFilePrefetchBufferIfNotExists(initial_auto_readahead_size_,
-                                             max_auto_readahead_size,
-                                             &prefetch_buffer_, true);
+    rep->CreateFilePrefetchBufferIfNotExists(
+        initial_auto_readahead_size_, max_auto_readahead_size,
+        &prefetch_buffer_, true, is_adaptive_readahead);
     return;
   }
 

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -15,11 +15,11 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
                                        const BlockHandle& handle,
                                        size_t readahead_size,
                                        bool is_for_compaction,
-                                       bool is_adaptive_readahead) {
+                                       bool async_prefetch) {
   if (is_for_compaction) {
     rep->CreateFilePrefetchBufferIfNotExists(
         compaction_readahead_size_, compaction_readahead_size_,
-        &prefetch_buffer_, false, is_adaptive_readahead);
+        &prefetch_buffer_, false, async_prefetch);
     return;
   }
 
@@ -27,7 +27,7 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
   if (readahead_size > 0) {
     rep->CreateFilePrefetchBufferIfNotExists(readahead_size, readahead_size,
                                              &prefetch_buffer_, false,
-                                             is_adaptive_readahead);
+                                             async_prefetch);
     return;
   }
 
@@ -73,7 +73,7 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
   if (rep->file->use_direct_io()) {
     rep->CreateFilePrefetchBufferIfNotExists(
         initial_auto_readahead_size_, max_auto_readahead_size,
-        &prefetch_buffer_, true, is_adaptive_readahead);
+        &prefetch_buffer_, true, async_prefetch);
     return;
   }
 
@@ -90,7 +90,7 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
   if (s.IsNotSupported()) {
     rep->CreateFilePrefetchBufferIfNotExists(
         initial_auto_readahead_size_, max_auto_readahead_size,
-        &prefetch_buffer_, true, is_adaptive_readahead);
+        &prefetch_buffer_, true, async_prefetch);
     return;
   }
 

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -16,7 +16,7 @@ class BlockPrefetcher {
       : compaction_readahead_size_(compaction_readahead_size) {}
   void PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
                         const BlockHandle& handle, size_t readahead_size,
-                        bool is_for_compaction, bool is_adaptive_readahead);
+                        bool is_for_compaction, bool async_prefetch);
   FilePrefetchBuffer* prefetch_buffer() { return prefetch_buffer_.get(); }
 
   void UpdateReadPattern(const uint64_t& offset, const size_t& len) {

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -16,7 +16,7 @@ class BlockPrefetcher {
       : compaction_readahead_size_(compaction_readahead_size) {}
   void PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
                         const BlockHandle& handle, size_t readahead_size,
-                        bool is_for_compaction);
+                        bool is_for_compaction, bool is_adaptive_readahead);
   FilePrefetchBuffer* prefetch_buffer() { return prefetch_buffer_.get(); }
 
   void UpdateReadPattern(const uint64_t& offset, const size_t& len) {

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -16,7 +16,7 @@ class BlockPrefetcher {
       : compaction_readahead_size_(compaction_readahead_size) {}
   void PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
                         const BlockHandle& handle, size_t readahead_size,
-                        bool is_for_compaction, bool async_prefetch);
+                        bool is_for_compaction, bool async_io);
   FilePrefetchBuffer* prefetch_buffer() { return prefetch_buffer_.get(); }
 
   void UpdateReadPattern(const uint64_t& offset, const size_t& len) {

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -498,7 +498,7 @@ Status PartitionedFilterBlockReader::CacheDependencies(const ReadOptions& ro,
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
   rep->CreateFilePrefetchBuffer(0, 0, &prefetch_buffer,
                                 false /* Implicit autoreadahead */,
-                                false /*adaptive_readahead*/);
+                                false /*async_prefetch*/);
 
   IOOptions opts;
   s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -498,7 +498,7 @@ Status PartitionedFilterBlockReader::CacheDependencies(const ReadOptions& ro,
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
   rep->CreateFilePrefetchBuffer(0, 0, &prefetch_buffer,
                                 false /* Implicit autoreadahead */,
-                                false /*async_prefetch*/);
+                                false /*async_io*/);
 
   IOOptions opts;
   s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -497,7 +497,8 @@ Status PartitionedFilterBlockReader::CacheDependencies(const ReadOptions& ro,
   uint64_t prefetch_len = last_off - prefetch_off;
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
   rep->CreateFilePrefetchBuffer(0, 0, &prefetch_buffer,
-                                false /* Implicit autoreadahead */);
+                                false /* Implicit autoreadahead */,
+                                false /*adaptive_readahead*/);
 
   IOOptions opts;
   s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_index_iterator.cc
+++ b/table/block_based/partitioned_index_iterator.cc
@@ -91,7 +91,7 @@ void PartitionedIndexIterator::InitPartitionedIndexBlock() {
     //   Enabled from the very first IO when ReadOptions.readahead_size is set.
     block_prefetcher_.PrefetchIfNeeded(
         rep, partitioned_index_handle, read_options_.readahead_size,
-        is_for_compaction, read_options_.async_prefetch);
+        is_for_compaction, read_options_.async_io);
     Status s;
     table_->NewDataBlockIterator<IndexBlockIter>(
         read_options_, partitioned_index_handle, &block_iter_,

--- a/table/block_based/partitioned_index_iterator.cc
+++ b/table/block_based/partitioned_index_iterator.cc
@@ -91,7 +91,7 @@ void PartitionedIndexIterator::InitPartitionedIndexBlock() {
     //   Enabled from the very first IO when ReadOptions.readahead_size is set.
     block_prefetcher_.PrefetchIfNeeded(
         rep, partitioned_index_handle, read_options_.readahead_size,
-        is_for_compaction, read_options_.adaptive_readahead);
+        is_for_compaction, read_options_.async_prefetch);
     Status s;
     table_->NewDataBlockIterator<IndexBlockIter>(
         read_options_, partitioned_index_handle, &block_iter_,

--- a/table/block_based/partitioned_index_iterator.cc
+++ b/table/block_based/partitioned_index_iterator.cc
@@ -89,9 +89,9 @@ void PartitionedIndexIterator::InitPartitionedIndexBlock() {
     //   Enabled after 2 sequential IOs when ReadOptions.readahead_size == 0.
     // Explicit user requested readahead:
     //   Enabled from the very first IO when ReadOptions.readahead_size is set.
-    block_prefetcher_.PrefetchIfNeeded(rep, partitioned_index_handle,
-                                       read_options_.readahead_size,
-                                       is_for_compaction);
+    block_prefetcher_.PrefetchIfNeeded(
+        rep, partitioned_index_handle, read_options_.readahead_size,
+        is_for_compaction, read_options_.adaptive_readahead);
     Status s;
     table_->NewDataBlockIterator<IndexBlockIter>(
         read_options_, partitioned_index_handle, &block_iter_,

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -81,7 +81,7 @@ InternalIteratorBase<IndexValue>* PartitionIndexReader::NewIterator(
     ro.deadline = read_options.deadline;
     ro.io_timeout = read_options.io_timeout;
     ro.adaptive_readahead = read_options.adaptive_readahead;
-    ro.async_prefetch = read_options.async_prefetch;
+    ro.async_io = read_options.async_io;
     // We don't return pinned data from index blocks, so no need
     // to set `block_contents_pinned`.
     std::unique_ptr<InternalIteratorBase<IndexValue>> index_iter(
@@ -154,7 +154,7 @@ Status PartitionIndexReader::CacheDependencies(const ReadOptions& ro,
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
   rep->CreateFilePrefetchBuffer(0, 0, &prefetch_buffer,
                                 false /*Implicit auto readahead*/,
-                                false /*async_prefetch*/);
+                                false /*async_io*/);
   IOOptions opts;
   {
     Status s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -81,6 +81,7 @@ InternalIteratorBase<IndexValue>* PartitionIndexReader::NewIterator(
     ro.deadline = read_options.deadline;
     ro.io_timeout = read_options.io_timeout;
     ro.adaptive_readahead = read_options.adaptive_readahead;
+    ro.async_prefetch = read_options.async_prefetch;
     // We don't return pinned data from index blocks, so no need
     // to set `block_contents_pinned`.
     std::unique_ptr<InternalIteratorBase<IndexValue>> index_iter(
@@ -153,7 +154,7 @@ Status PartitionIndexReader::CacheDependencies(const ReadOptions& ro,
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
   rep->CreateFilePrefetchBuffer(0, 0, &prefetch_buffer,
                                 false /*Implicit auto readahead*/,
-                                false /*is_adaptive_readahead*/);
+                                false /*async_prefetch*/);
   IOOptions opts;
   {
     Status s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -152,7 +152,8 @@ Status PartitionIndexReader::CacheDependencies(const ReadOptions& ro,
   uint64_t prefetch_len = last_off - prefetch_off;
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
   rep->CreateFilePrefetchBuffer(0, 0, &prefetch_buffer,
-                                false /*Implicit auto readahead*/);
+                                false /*Implicit auto readahead*/,
+                                false /*is_adaptive_readahead*/);
   IOOptions opts;
   {
     Status s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -72,7 +72,8 @@ inline bool BlockFetcher::TryGetFromPrefetchBuffer() {
     if (io_s.ok() &&
         prefetch_buffer_->TryReadFromCache(
             opts, file_, handle_.offset(), block_size_with_trailer_, &slice_,
-            &io_s, read_options_.rate_limiter_priority, for_compaction_)) {
+            &io_s, read_options_.rate_limiter_priority, for_compaction_,
+            ioptions_.fs.get())) {
       ProcessTrailerIfPresent();
       if (!io_status_.ok()) {
         return true;

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -69,18 +69,28 @@ inline bool BlockFetcher::TryGetFromPrefetchBuffer() {
   if (prefetch_buffer_ != nullptr) {
     IOOptions opts;
     IOStatus io_s = file_->PrepareIOOptions(read_options_, opts);
-    if (io_s.ok() &&
-        prefetch_buffer_->TryReadFromCache(
+    if (io_s.ok()) {
+      bool read_from_prefetch_buffer = false;
+      if (read_options_.adaptive_readahead) {
+        read_from_prefetch_buffer = prefetch_buffer_->TryReadFromCacheAsync(
             opts, file_, handle_.offset(), block_size_with_trailer_, &slice_,
             &io_s, read_options_.rate_limiter_priority, for_compaction_,
-            ioptions_.fs.get())) {
-      ProcessTrailerIfPresent();
-      if (!io_status_.ok()) {
-        return true;
+            ioptions_.fs.get());
+      } else {
+        read_from_prefetch_buffer = prefetch_buffer_->TryReadFromCache(
+            opts, file_, handle_.offset(), block_size_with_trailer_, &slice_,
+            &io_s, read_options_.rate_limiter_priority, for_compaction_);
       }
-      got_from_prefetch_buffer_ = true;
-      used_buf_ = const_cast<char*>(slice_.data());
-    } else if (!io_s.ok()) {
+      if (read_from_prefetch_buffer) {
+        ProcessTrailerIfPresent();
+        if (!io_status_.ok()) {
+          return true;
+        }
+        got_from_prefetch_buffer_ = true;
+        used_buf_ = const_cast<char*>(slice_.data());
+      }
+    }
+    if (!io_s.ok()) {
       io_status_ = io_s;
       return true;
     }

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -71,7 +71,7 @@ inline bool BlockFetcher::TryGetFromPrefetchBuffer() {
     IOStatus io_s = file_->PrepareIOOptions(read_options_, opts);
     if (io_s.ok()) {
       bool read_from_prefetch_buffer = false;
-      if (read_options_.adaptive_readahead) {
+      if (read_options_.async_prefetch) {
         read_from_prefetch_buffer = prefetch_buffer_->TryReadFromCacheAsync(
             opts, file_, handle_.offset(), block_size_with_trailer_, &slice_,
             &io_s, read_options_.rate_limiter_priority, for_compaction_,

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -71,7 +71,7 @@ inline bool BlockFetcher::TryGetFromPrefetchBuffer() {
     IOStatus io_s = file_->PrepareIOOptions(read_options_, opts);
     if (io_s.ok()) {
       bool read_from_prefetch_buffer = false;
-      if (read_options_.async_prefetch) {
+      if (read_options_.async_io) {
         read_from_prefetch_buffer = prefetch_buffer_->TryReadFromCacheAsync(
             opts, file_, handle_.offset(), block_size_with_trailer_, &slice_,
             &io_s, read_options_.rate_limiter_priority, for_compaction_,


### PR DESCRIPTION
Summary: In FilePrefetchBuffer if reads are sequential, after prefetching call ReadAsync API to prefetch data asynchronously so that in next prefetching data will be available. Data prefetched asynchronously will be readahead_size/2. It uses two buffers, one for synchronous prefetching and one for asynchronous. In case, the data is overlapping, the data is copied from both buffers to third buffer to make it continuous.
This feature is under ReadOptions::async_io and is under experimental.

Test Plan: 
1. Add new unit tests
2. Run **db_stress** to make sure nothing crashes.

    -   Normal prefetch without `async_io` ran successfully:
```
export CRASH_TEST_EXT_ARGS=" --async_io=0"
 make crash_test -j
 ```

3. **Run Regressions**.
   i) Main branch without any change for normal prefetching with async_io disabled:
       
 ```
 ./db_bench -db=/tmp/prefix_scan_prefetch_main -benchmarks="fillseq" -key_size=32 -value_size=512 -num=5000000 - 
           use_direct_io_for_flush_and_compaction=true -target_file_size_base=16777216
 ```
 
```
./db_bench -use_existing_db=true -db=/tmp/prefix_scan_prefetch_main -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=5000000 -use_direct_reads=true -seek_nexts=327680 -duration=120 -ops_between_duration_checks=1
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
RocksDB:    version 7.0
Date:       Thu Mar 17 13:11:34 2022
CPU:        24 * Intel Core Processor (Broadwell)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    5000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    2594.0 MB (estimated)
FileSize:   1373.3 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
------------------------------------------------
DB path: [/tmp/prefix_scan_prefetch_main]
seekrandom   :  483618.390 micros/op 2 ops/sec;  338.9 MB/s (249 of 249 found)
```

  ii) normal prefetching after changes with async_io disable:

```
./db_bench -use_existing_db=true -db=/tmp/prefix_scan_prefetch_withchange -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=5000000 -use_direct_reads=true -seek_nexts=327680 -duration=120 -ops_between_duration_checks=1
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
RocksDB:    version 7.0
Date:       Thu Mar 17 14:11:31 2022
CPU:        24 * Intel Core Processor (Broadwell)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    5000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    2594.0 MB (estimated)
FileSize:   1373.3 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
------------------------------------------------
DB path: [/tmp/prefix_scan_prefetch_withchange]
seekrandom   :  471347.227 micros/op 2 ops/sec;  348.1 MB/s (255 of 255 found)
```

