### PR TITLE
WriteBatch supports append interface

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1493,6 +1493,11 @@ Status WriteBatch::UpdateTimestamps(
   return s;
 }
 
+Status WriteBatch::Append(const WriteBatch* batch,
+                            const bool WAL_only) {
+  return WriteBatchInternal::Append(this, batch, WAL_only);
+}
+
 class MemTableInserter : public WriteBatch::Handler {
 
   SequenceNumber sequence_;

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -213,6 +213,9 @@ class WriteBatch : public WriteBatchBase {
   // Otherwise returns Status::OK().
   Status PopSavePoint() override;
 
+  // Append a batch to the end.
+  Status Append(const WriteBatch* batch, const bool WAL_only = false);
+
   // Support for iterating over the contents of a batch.
   class Handler {
    public:


### PR DESCRIPTION
In some cases, we need to combine multiple batches into one, WriteBatchInternal provide this function but it is not exposed. So I add `Append` interface for WriteBatch, what did i miss？