### PR TITLE
Fix clang-analyze by adding assertion

### DIFF
--- a/utilities/transactions/write_committed_transaction_ts_test.cc
+++ b/utilities/transactions/write_committed_transaction_ts_test.cc
@@ -263,6 +263,7 @@ TEST_P(WriteCommittedTxnWithTsTest, TransactionDbLevelApi) {
   PutFixed64(&ts_str, 100);
   Slice value = value_str;
 
+  assert(db);
   ASSERT_TRUE(
       db->Put(WriteOptions(), handles_[1], "foo", "bar").IsNotSupported());
   ASSERT_TRUE(db->Delete(WriteOptions(), handles_[1], "foo").IsNotSupported());


### PR DESCRIPTION
Summary:
Clang-analyze complains about potential nullptr dereference.
Fix by adding an assertion to make clang happy.

Test Plan:
USE_CLANG=1 make -j20 analyze_incremental