### PR TITLE
Reduce Windows build parallelism number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,7 +519,7 @@ jobs:
             ${CMAKE_BIN} -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Debug -DOPTDBG=1 -DPORTABLE=1 -DSNAPPY=1 -DJNI=1 << parameters.extra_cmake_opt >> ..
             cd ..
             echo "Building with VS version: ${CMAKE_GENERATOR}"
-            msbuild.exe build/rocksdb.sln -maxCpuCount:64 -property:Configuration=Debug -property:Platform=x64
+            msbuild.exe build/rocksdb.sln -maxCpuCount -property:Configuration=Debug -property:Platform=x64
       - run:
           name: "Test RocksDB"
           shell: powershell.exe
@@ -783,111 +783,135 @@ jobs:
 
 workflows:
   version: 2
-  build-linux:
-    jobs:
-      - build-linux
-  build-linux-cmake:
-    jobs:
-      - build-linux-cmake
-      - build-linux-cmake-ubuntu-20
-  build-linux-encrypted-env:
-    jobs:
-      - build-linux-encrypted-env
-  build-linux-shared_lib-alt_namespace-status_checked:
-    jobs:
-      - build-linux-shared_lib-alt_namespace-status_checked
-  build-linux-lite:
-    jobs:
-      - build-linux-lite
-  build-linux-release:
-    jobs:
-      - build-linux-release
-  build-linux-release-rtti:
-    jobs:
-      - build-linux-release-rtti
-  build-linux-lite-release:
-    jobs:
-      - build-linux-lite-release
-  build-linux-clang10-asan:
-    jobs:
-      - build-linux-clang10-asan
-  build-linux-clang10-mini-tsan:
-    jobs:
-      - build-linux-clang10-mini-tsan:
-          start_test: ""
-          end_test: "env_test"
-      - build-linux-clang10-mini-tsan:
-          start_test: "env_test"
-          end_test: ""
-  build-linux-clang10-ubsan:
-    jobs:
-      - build-linux-clang10-ubsan
-  build-linux-clang10-clang-analyze:
-    jobs:
-      - build-linux-clang10-clang-analyze
-  build-linux-unity-and-headers:
-    jobs:
-      - build-linux-unity-and-headers
-  build-windows-vs2019:
-    jobs:
-      - build-windows:
-          name: "build-windows-vs2019"
-  build-windows-vs2019-cxx20:
-    jobs:
-      - build-windows:
-          name: "build-windows-vs2019-cxx20"
-          extra_cmake_opt: -DCMAKE_CXX_STANDARD=20
+#  build-linux:
+#    jobs:
+#      - build-linux
+#  build-linux-cmake:
+#    jobs:
+#      - build-linux-cmake
+#      - build-linux-cmake-ubuntu-20
+#  build-linux-encrypted-env:
+#    jobs:
+#      - build-linux-encrypted-env
+#  build-linux-shared_lib-alt_namespace-status_checked:
+#    jobs:
+#      - build-linux-shared_lib-alt_namespace-status_checked
+#  build-linux-lite:
+#    jobs:
+#      - build-linux-lite
+#  build-linux-release:
+#    jobs:
+#      - build-linux-release
+#  build-linux-release-rtti:
+#    jobs:
+#      - build-linux-release-rtti
+#  build-linux-lite-release:
+#    jobs:
+#      - build-linux-lite-release
+#  build-linux-clang10-asan:
+#    jobs:
+#      - build-linux-clang10-asan
+#  build-linux-clang10-mini-tsan:
+#    jobs:
+#      - build-linux-clang10-mini-tsan:
+#          start_test: ""
+#          end_test: "env_test"
+#      - build-linux-clang10-mini-tsan:
+#          start_test: "env_test"
+#          end_test: ""
+#  build-linux-clang10-ubsan:
+#    jobs:
+#      - build-linux-clang10-ubsan
+#  build-linux-clang10-clang-analyze:
+#    jobs:
+#      - build-linux-clang10-clang-analyze
+#  build-linux-unity-and-headers:
+#    jobs:
+#      - build-linux-unity-and-headers
+#  build-windows-vs2019:
+#    jobs:
+#      - build-windows:
+#          name: "build-windows-vs2019"
+#  build-windows-vs2019-cxx20:
+#    jobs:
+#      - build-windows:
+#          name: "build-windows-vs2019-cxx20"
+#          extra_cmake_opt: -DCMAKE_CXX_STANDARD=20
   build-windows-vs2017:
     jobs:
       - build-windows:
           name: "build-windows-vs2017"
           vs_year: "2017"
           cmake_generator: "Visual Studio 15 Win64"
-  build-java:
+  build-windows-vs2017_2:
     jobs:
-      - build-linux-java
-      - build-linux-java-static
-      - build-macos-java
-      - build-macos-java-static
-      - build-macos-java-static-universal
-  build-examples:
+      - build-windows:
+          name: "build-windows-vs2017"
+          vs_year: "2017"
+          cmake_generator: "Visual Studio 15 Win64"
+  build-windows-vs2017_3:
     jobs:
-      - build-examples
-  build-linux-compilers-no_test_run:
+      - build-windows:
+          name: "build-windows-vs2017"
+          vs_year: "2017"
+          cmake_generator: "Visual Studio 15 Win64"
+  build-windows-vs2017_4:
     jobs:
-      - build-linux-clang-no_test_run
-      - build-linux-clang-13-no_test_run
-      - build-linux-gcc-7
-      - build-linux-gcc-8-no_test_run
-      - build-linux-gcc-10-cxx20-no_test_run
-      - build-linux-gcc-11-no_test_run
-      - build-linux-arm-cmake-no_test_run
-  build-macos:
+      - build-windows:
+          name: "build-windows-vs2017"
+          vs_year: "2017"
+          cmake_generator: "Visual Studio 15 Win64"
+  build-windows-vs2017_5:
     jobs:
-      - build-macos
-      - build-macos-cmake:
-          run_even_tests: true
-      - build-macos-cmake:
-          run_even_tests: false
-  build-cmake-mingw:
-    jobs:
-      - build-cmake-mingw
-  build-linux-arm:
-    jobs:
-      - build-linux-arm
-  build-fuzzers:
-    jobs:
-      - build-fuzzers
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - build-format-compatible
-      - build-linux-arm-test-full
-      - build-linux-run-microbench
-      - build-linux-non-shm
+      - build-windows:
+          name: "build-windows-vs2017"
+          vs_year: "2017"
+          cmake_generator: "Visual Studio 15 Win64"
+#  build-java:
+#    jobs:
+#      - build-linux-java
+#      - build-linux-java-static
+#      - build-macos-java
+#      - build-macos-java-static
+#      - build-macos-java-static-universal
+#  build-examples:
+#    jobs:
+#      - build-examples
+#  build-linux-compilers-no_test_run:
+#    jobs:
+#      - build-linux-clang-no_test_run
+#      - build-linux-clang-13-no_test_run
+#      - build-linux-gcc-7
+#      - build-linux-gcc-8-no_test_run
+#      - build-linux-gcc-10-cxx20-no_test_run
+#      - build-linux-gcc-11-no_test_run
+#      - build-linux-arm-cmake-no_test_run
+#  build-macos:
+#    jobs:
+#      - build-macos
+#      - build-macos-cmake:
+#          run_even_tests: true
+#      - build-macos-cmake:
+#          run_even_tests: false
+#  build-cmake-mingw:
+#    jobs:
+#      - build-cmake-mingw
+#  build-linux-arm:
+#    jobs:
+#      - build-linux-arm
+#  build-fuzzers:
+#    jobs:
+#      - build-fuzzers
+#  nightly:
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - main
+#    jobs:
+#      - build-format-compatible
+#      - build-linux-arm-test-full
+#      - build-linux-run-microbench
+#      - build-linux-non-shm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -783,135 +783,111 @@ jobs:
 
 workflows:
   version: 2
-#  build-linux:
-#    jobs:
-#      - build-linux
-#  build-linux-cmake:
-#    jobs:
-#      - build-linux-cmake
-#      - build-linux-cmake-ubuntu-20
-#  build-linux-encrypted-env:
-#    jobs:
-#      - build-linux-encrypted-env
-#  build-linux-shared_lib-alt_namespace-status_checked:
-#    jobs:
-#      - build-linux-shared_lib-alt_namespace-status_checked
-#  build-linux-lite:
-#    jobs:
-#      - build-linux-lite
-#  build-linux-release:
-#    jobs:
-#      - build-linux-release
-#  build-linux-release-rtti:
-#    jobs:
-#      - build-linux-release-rtti
-#  build-linux-lite-release:
-#    jobs:
-#      - build-linux-lite-release
-#  build-linux-clang10-asan:
-#    jobs:
-#      - build-linux-clang10-asan
-#  build-linux-clang10-mini-tsan:
-#    jobs:
-#      - build-linux-clang10-mini-tsan:
-#          start_test: ""
-#          end_test: "env_test"
-#      - build-linux-clang10-mini-tsan:
-#          start_test: "env_test"
-#          end_test: ""
-#  build-linux-clang10-ubsan:
-#    jobs:
-#      - build-linux-clang10-ubsan
-#  build-linux-clang10-clang-analyze:
-#    jobs:
-#      - build-linux-clang10-clang-analyze
-#  build-linux-unity-and-headers:
-#    jobs:
-#      - build-linux-unity-and-headers
-#  build-windows-vs2019:
-#    jobs:
-#      - build-windows:
-#          name: "build-windows-vs2019"
-#  build-windows-vs2019-cxx20:
-#    jobs:
-#      - build-windows:
-#          name: "build-windows-vs2019-cxx20"
-#          extra_cmake_opt: -DCMAKE_CXX_STANDARD=20
+  build-linux:
+    jobs:
+      - build-linux
+  build-linux-cmake:
+    jobs:
+      - build-linux-cmake
+      - build-linux-cmake-ubuntu-20
+  build-linux-encrypted-env:
+    jobs:
+      - build-linux-encrypted-env
+  build-linux-shared_lib-alt_namespace-status_checked:
+    jobs:
+      - build-linux-shared_lib-alt_namespace-status_checked
+  build-linux-lite:
+    jobs:
+      - build-linux-lite
+  build-linux-release:
+    jobs:
+      - build-linux-release
+  build-linux-release-rtti:
+    jobs:
+      - build-linux-release-rtti
+  build-linux-lite-release:
+    jobs:
+      - build-linux-lite-release
+  build-linux-clang10-asan:
+    jobs:
+      - build-linux-clang10-asan
+  build-linux-clang10-mini-tsan:
+    jobs:
+      - build-linux-clang10-mini-tsan:
+          start_test: ""
+          end_test: "env_test"
+      - build-linux-clang10-mini-tsan:
+          start_test: "env_test"
+          end_test: ""
+  build-linux-clang10-ubsan:
+    jobs:
+      - build-linux-clang10-ubsan
+  build-linux-clang10-clang-analyze:
+    jobs:
+      - build-linux-clang10-clang-analyze
+  build-linux-unity-and-headers:
+    jobs:
+      - build-linux-unity-and-headers
+  build-windows-vs2019:
+    jobs:
+      - build-windows:
+          name: "build-windows-vs2019"
+  build-windows-vs2019-cxx20:
+    jobs:
+      - build-windows:
+          name: "build-windows-vs2019-cxx20"
+          extra_cmake_opt: -DCMAKE_CXX_STANDARD=20
   build-windows-vs2017:
     jobs:
       - build-windows:
           name: "build-windows-vs2017"
           vs_year: "2017"
           cmake_generator: "Visual Studio 15 Win64"
-  build-windows-vs2017_2:
+  build-java:
     jobs:
-      - build-windows:
-          name: "build-windows-vs2017"
-          vs_year: "2017"
-          cmake_generator: "Visual Studio 15 Win64"
-  build-windows-vs2017_3:
+      - build-linux-java
+      - build-linux-java-static
+      - build-macos-java
+      - build-macos-java-static
+      - build-macos-java-static-universal
+  build-examples:
     jobs:
-      - build-windows:
-          name: "build-windows-vs2017"
-          vs_year: "2017"
-          cmake_generator: "Visual Studio 15 Win64"
-  build-windows-vs2017_4:
+      - build-examples
+  build-linux-compilers-no_test_run:
     jobs:
-      - build-windows:
-          name: "build-windows-vs2017"
-          vs_year: "2017"
-          cmake_generator: "Visual Studio 15 Win64"
-  build-windows-vs2017_5:
+      - build-linux-clang-no_test_run
+      - build-linux-clang-13-no_test_run
+      - build-linux-gcc-7
+      - build-linux-gcc-8-no_test_run
+      - build-linux-gcc-10-cxx20-no_test_run
+      - build-linux-gcc-11-no_test_run
+      - build-linux-arm-cmake-no_test_run
+  build-macos:
     jobs:
-      - build-windows:
-          name: "build-windows-vs2017"
-          vs_year: "2017"
-          cmake_generator: "Visual Studio 15 Win64"
-#  build-java:
-#    jobs:
-#      - build-linux-java
-#      - build-linux-java-static
-#      - build-macos-java
-#      - build-macos-java-static
-#      - build-macos-java-static-universal
-#  build-examples:
-#    jobs:
-#      - build-examples
-#  build-linux-compilers-no_test_run:
-#    jobs:
-#      - build-linux-clang-no_test_run
-#      - build-linux-clang-13-no_test_run
-#      - build-linux-gcc-7
-#      - build-linux-gcc-8-no_test_run
-#      - build-linux-gcc-10-cxx20-no_test_run
-#      - build-linux-gcc-11-no_test_run
-#      - build-linux-arm-cmake-no_test_run
-#  build-macos:
-#    jobs:
-#      - build-macos
-#      - build-macos-cmake:
-#          run_even_tests: true
-#      - build-macos-cmake:
-#          run_even_tests: false
-#  build-cmake-mingw:
-#    jobs:
-#      - build-cmake-mingw
-#  build-linux-arm:
-#    jobs:
-#      - build-linux-arm
-#  build-fuzzers:
-#    jobs:
-#      - build-fuzzers
-#  nightly:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - main
-#    jobs:
-#      - build-format-compatible
-#      - build-linux-arm-test-full
-#      - build-linux-run-microbench
-#      - build-linux-non-shm
+      - build-macos
+      - build-macos-cmake:
+          run_even_tests: true
+      - build-macos-cmake:
+          run_even_tests: false
+  build-cmake-mingw:
+    jobs:
+      - build-cmake-mingw
+  build-linux-arm:
+    jobs:
+      - build-linux-arm
+  build-fuzzers:
+    jobs:
+      - build-fuzzers
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - build-format-compatible
+      - build-linux-arm-test-full
+      - build-linux-run-microbench
+      - build-linux-non-shm


### PR DESCRIPTION
To avoid OOM issue for VS2017 build.

Test Plan: Run VS2017 build 5 times, seems fine.