### PR TITLE
Fix build for io_uring

### DIFF
--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -97,6 +97,9 @@ inline void UpdateResult(struct io_uring_cqe* cqe, const std::string& file_name,
                             cqe->res);
     }
   }
+#ifdef NDEBUG
+  (void)len;
+#endif
 }
 #endif
 

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -65,7 +65,7 @@ struct Posix_IOHandle {
 };
 
 inline void UpdateResult(struct io_uring_cqe* cqe, const std::string& file_name,
-                         ROCKSDB_MAYBE_UNUSED size_t len, size_t iov_len, bool async_read,
+                         size_t len, size_t iov_len, bool async_read,
                          size_t& finished_len, FSReadRequest* req) {
   if (cqe->res < 0) {
     req->result = Slice(req->scratch, 0);

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -65,8 +65,9 @@ struct Posix_IOHandle {
 };
 
 inline void UpdateResult(struct io_uring_cqe* cqe, const std::string& file_name,
-                         ROCKSDB_MAYBE_UNUSED size_t len, size_t iov_len, bool async_read,
-                         size_t& finished_len, FSReadRequest* req) {
+                         ROCKSDB_MAYBE_UNUSED size_t len, size_t iov_len,
+                         bool async_read, size_t& finished_len,
+                         FSReadRequest* req) {
   if (cqe->res < 0) {
     req->result = Slice(req->scratch, 0);
     req->status = IOError("Req failed", file_name, cqe->res);

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -65,7 +65,7 @@ struct Posix_IOHandle {
 };
 
 inline void UpdateResult(struct io_uring_cqe* cqe, const std::string& file_name,
-                         size_t len, size_t iov_len, bool async_read,
+                         ROCKSDB_MAYBE_UNUSED size_t len, size_t iov_len, bool async_read,
                          size_t& finished_len, FSReadRequest* req) {
   if (cqe->res < 0) {
     req->result = Slice(req->scratch, 0);

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -65,9 +65,8 @@ struct Posix_IOHandle {
 };
 
 inline void UpdateResult(struct io_uring_cqe* cqe, const std::string& file_name,
-                         ROCKSDB_MAYBE_UNUSED size_t len, size_t iov_len,
-                         bool async_read, size_t& finished_len,
-                         FSReadRequest* req) {
+                         ROCKSDB_MAYBE_UNUSED size_t len, size_t iov_len, bool async_read,
+                         size_t& finished_len, FSReadRequest* req) {
   if (cqe->res < 0) {
     req->result = Slice(req->scratch, 0);
     req->status = IOError("Req failed", file_name, cqe->res);


### PR DESCRIPTION
Minor fix for build failure:
```
./env/io_posix.h:68:33: error: unused parameter 'len' [-Werror=unused-parameter]
   68 |                          size_t len, size_t iov_len, bool async_read,
      |                          ~~~~~~~^~~
```
Only happens for release build with io_uring.

Test Plan: build pass with io_uring