### PR TITLE
Fix TSAN caused by calling `rend()` and `pop_front()`.

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1183,10 +1183,6 @@ IOStatus DBImpl::WriteToWAL(const WriteBatch& merged_batch,
     assert(with_log_mutex);
   }
 
-#ifdef NDEBUG
-  (void)with_log_mutex;
-#endif
-
   Slice log_entry = WriteBatchInternal::Contents(&merged_batch);
   *log_size = log_entry.size();
   // When two_write_queues_ WriteToWAL has to be protected from concurretn calls
@@ -1214,13 +1210,15 @@ IOStatus DBImpl::WriteToWAL(const WriteBatch& merged_batch,
   if (with_db_mutex || with_log_mutex) {
 #endif  // __has_feature(thread_sanitizer)
 #endif  // defined(__has_feature)
-    assert(alive_log_files_tail_ != alive_log_files_.rend());
     assert(alive_log_files_tail_ == alive_log_files_.rbegin());
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
   }
 #endif  // __has_feature(thread_sanitizer)
 #endif  // defined(__has_feature)
+  if (with_db_mutex || with_log_mutex) {
+    assert(alive_log_files_tail_ != alive_log_files_.rend());
+  }
   LogFileNumberSize& last_alive_log = *alive_log_files_tail_;
   last_alive_log.AddSize(*log_size);
   log_empty_ = false;


### PR DESCRIPTION
Summary:
PR9686 makes `WriteToWAL()` call `assert(...!=rend())` while not holding
db mutex or log mutex. Another thread may concurrently call
`pop_front()`, causing race condition.
To fix, assert only if mutex is held.

Test Plan:
COMPILE_WITH_TSAN=1 make check