### PR TITLE
Add new determinators for multiops transactions stress test

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -563,6 +563,66 @@ STRESS_CRASH_TEST_WITH_TS_COMMANDS="[
     }
 ]"
 
+#
+# RocksDB stress/crash test for write-committed multi-ops transactions
+#
+STRESS_CRASH_TEST_WITH_MULTIOPS_WC_TXN_COMMANDS="[
+    {
+        \"name\":\"Rocksdb Stress Crash Test with multi-ops transactions (wc)\",
+        \"oncall\":\"$ONCALL\",
+        \"executeLocal\": \"true\",
+        \"timeout\": 86400,
+        \"steps\": [
+            $CLEANUP_ENV,
+            {
+                \"name\":\"Build and run RocksDB debug stress tests\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"user\":\"root\",
+                $PARSER
+            },
+            {
+                \"name\":\"Build and run RocksDB debug crash tests with multi-ops transactions (wc)\",
+                \"timeout\": 86400,
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM crash_test_with_multiops_wc_txn || $CONTRUN_NAME=crash_test_with_multiops_wc_txn $TASK_CREATION_TOOL\",
+                \"user\":\"root\",
+                $PARSER
+            },
+            $UPLOAD_DB_DIR
+        ]
+        $REPORT
+    }
+]"
+
+#
+# RocksDB stress/crash test for write-prepared multi-ops transactions
+#
+STRESS_CRASH_TEST_WITH_MULTIOPS_WP_TXN_COMMANDS="[
+    {
+        \"name\":\"Rocksdb Stress Crash Test with multi-ops transactions (wp)\",
+        \"oncall\":\"$ONCALL\",
+        \"executeLocal\": \"true\",
+        \"timeout\": 86400,
+        \"steps\": [
+            $CLEANUP_ENV,
+            {
+                \"name\":\"Build and run RocksDB debug stress tests\",
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM db_stress || $CONTRUN_NAME=db_stress $TASK_CREATION_TOOL\",
+                \"user\":\"root\",
+                $PARSER
+            },
+            {
+                \"name\":\"Build and run RocksDB debug crash tests with multi-ops transactions (wp)\",
+                \"timeout\": 86400,
+                \"shell\":\"cd $WORKING_DIR; $SHM $DEBUG $NON_TSAN_CRASH make $PARALLELISM crash_test_with_multiops_wp_txn || $CONTRUN_NAME=crash_test_with_multiops_wp_txn $TASK_CREATION_TOOL\",
+                \"user\":\"root\",
+                $PARSER
+            },
+            $UPLOAD_DB_DIR
+        ]
+        $REPORT
+    }
+]"
+
 # RocksDB write stress test.
 # We run on disk device on purpose (i.e. no $SHM)
 # because we want to add some randomness to fsync commands

--- a/crash_test.mk
+++ b/crash_test.mk
@@ -42,6 +42,12 @@ crash_test_with_ts: $(DB_STRESS_CMD)
 	$(CRASHTEST_MAKE) whitebox_crash_test_with_ts
 	$(CRASHTEST_MAKE) blackbox_crash_test_with_ts
 
+crash_test_with_multiops_wc_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_MAKE) blackbox_crash_test_with_multiops_wc_txn
+
+crash_test_with_multiops_wp_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_MAKE) blackbox_crash_test_with_multiops_wp_txn
+
 blackbox_crash_test: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --simple blackbox $(CRASH_TEST_EXT_ARGS)
 	$(CRASHTEST_PY) blackbox $(CRASH_TEST_EXT_ARGS)

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -214,6 +214,8 @@ def setup_multiops_txn_key_spaces_file():
         multiops_txn_key_spaces_file = tempfile.mkstemp(
                 prefix=key_spaces_file_prefix)[1]
     else:
+        if not os.path.exists(test_tmpdir):
+            os.mkdir(test_tmpdir)
         multiops_txn_key_spaces_file = tempfile.mkstemp(
                 prefix=key_spaces_file_prefix, dir=test_tmpdir)[1]
     return multiops_txn_key_spaces_file


### PR DESCRIPTION
Summary:
Add determinators for multiops transactions stress test with
write-committed and write-prepared policies.

Test plan:
Internal CI