### PR TITLE
Fix make clean fail after java build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -554,9 +554,6 @@ jobs:
             which java && java -version
             which javac && javac -version
       - run:
-          name: "Build RocksDBJava Shared Library"
-          command: make V=1 J=8 -j8 rocksdbjava
-      - run:
           name: "Test RocksDBJava"
           command: make V=1 J=8 -j8 jtest
       - post-steps
@@ -601,9 +598,6 @@ jobs:
             echo 'export PATH=$JAVA_HOME/bin:$PATH' >> $BASH_ENV
             which java && java -version
             which javac && javac -version
-      - run:
-          name: "Build RocksDBJava Shared Library"
-          command: make V=1 J=16 -j16 rocksdbjava
       - run:
           name: "Test RocksDBJava"
           command: make V=1 J=16 -j16 jtest

--- a/Makefile
+++ b/Makefile
@@ -1216,7 +1216,7 @@ clean-rocks:
 	$(FIND) . -name "*.[oda]" -exec rm -f {} \;
 	$(FIND) . -type f -regex ".*\.\(\(gcda\)\|\(gcno\)\)" -exec rm -f {} \;
 
-clean-rocksjava:
+clean-rocksjava: clean-rocks
 	rm -rf jl jls
 	cd java && $(MAKE) clean
 


### PR DESCRIPTION
Seems clean-rocksjava and clean-rocks conflict.
Also remove unnecessary step in java CI build, otherwise it will rebuild
the code again as java make sample do clean up first.

Test Plan: `make rocksdbjava && make clean` should return success