### PR TITLE
Fix DB::Open() error logging

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1971,10 +1971,10 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
           "DB::Open() failed --- Unable to persist Options file",
           persist_options_status.ToString());
     }
-  } else {
+  }
+  if (!s.ok()) {
     ROCKS_LOG_WARN(impl->immutable_db_options_.info_log,
-                   "Persisting Option File error: %s",
-                   persist_options_status.ToString().c_str());
+                   "DB::Open() failed: %s", s.ToString().c_str());
   }
   if (s.ok()) {
     s = impl->StartPeriodicWorkScheduler();


### PR DESCRIPTION
Summary:
Right now we log a wrong error when DB::Open() fails. Fix it.

Test Plan: CI runs should pass