### PR TITLE
Reduce build/test parallelism in build_tools/rocksdb-lego-determinator

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -84,9 +84,9 @@ UPLOAD_DB_DIR="
     ]
 }"
 
-# set default RATIO to 1, which sets J=$(nproc) and j=$(nproc)
+# set default RATIO to 2, which sets J=$(nproc)/2 and j=$(nproc)/2
 if [ -z $RATIO ]; then
-  RATIO=1
+  RATIO=2
 fi
 
 # Should probably be called PARALLEL_TEST


### PR DESCRIPTION
Summary:
build_tools/rocksdb-lego-determinator is to generate commands for continuous tests. Recently it changed to by default run tests in parallel with parallelism to be number of CPU processors. This sometimes causes out of space when running so many tests in parallel. Reduce the parallelism by half to temporarily work it around.

Test Plan: Run build_tools/rocksdb-lego-determinator and watch generated commands.