### PR TITLE
build_tools/rocksdb-lego-determinator to pass parallelism information for no_compression

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -1153,7 +1153,7 @@ NO_COMPRESSION_COMMANDS="[
             $CLEANUP_ENV,
             {
                 \"name\":\"Run RocksDB debug unit test\",
-                \"shell\":\"cd $WORKING_DIR; build_tools/rocksdb-lego-determinator run_no_compression || $CONTRUN_NAME=run_no_compression $TASK_CREATION_TOOL\",
+                \"shell\":\"cd $WORKING_DIR; PARALLEL_J=$PARALLEL_J PARALLEL_j=$PARALLEL_j build_tools/rocksdb-lego-determinator run_no_compression || $CONTRUN_NAME=run_no_compression $TASK_CREATION_TOOL\",
                 \"user\":\"root\",
                 $PARSER
             }


### PR DESCRIPTION
Summary:
Right now, parallelism information passed to "build_tools/rocksdb-lego-determinator no_compression" isn't effective when the test actually runs, as the information is dropped in the middle. Fix it.

Test Plan: Run "build_tools/rocksdb-lego-determinator no_compression" and execute the command line generated and observe the parallelism.