### PR TITLE
L0 Subcompaction to trim input files

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -1392,7 +1392,7 @@ TEST_P(DBCompactionTestWithParam, PartialOverlappingL0) {
   ASSERT_EQ(NumTableFilesAtLevel(1, 0), 1);  // One file in L1
 
   ASSERT_OK(db_->EnableAutoCompaction({db_->DefaultColumnFamily()}));
-  dbfull()->TEST_WaitForCompact();
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
   // We expect that all the files were trivially moved from L0 to L1
   ASSERT_EQ(NumTableFilesAtLevel(0, 0), 0);

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -1355,10 +1355,20 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveTargetLevel) {
 }
 
 TEST_P(DBCompactionTestWithParam, PartialOverlappingL0) {
+  class SubCompactionEventListener : public EventListener {
+   public:
+    void OnSubcompactionCompleted(const SubcompactionJobInfo&) override {
+      sub_compaction_finished_++;
+    }
+    std::atomic<int> sub_compaction_finished_{0};
+  };
+
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.write_buffer_size = 10 * 1024 * 1024;
   options.max_subcompactions = max_subcompactions_;
+  SubCompactionEventListener* listener = new SubCompactionEventListener();
+  options.listeners.emplace_back(listener);
 
   DestroyAndReopen(options);
 
@@ -1371,7 +1381,8 @@ TEST_P(DBCompactionTestWithParam, PartialOverlappingL0) {
   ASSERT_OK(Flush());
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
 
-  // non overlapping ranges
+  // Ranges that are only briefly overlapping so that they won't be trivially
+  // moved but subcompaction ranges would only contain a subset of files.
   std::vector<std::pair<int32_t, int32_t>> ranges = {
       {100, 199}, {198, 399}, {397, 600}, {598, 800}, {799, 900}, {895, 999},
   };
@@ -1391,10 +1402,16 @@ TEST_P(DBCompactionTestWithParam, PartialOverlappingL0) {
   ASSERT_EQ(level0_files, ranges.size());    // Multiple files in L0
   ASSERT_EQ(NumTableFilesAtLevel(1, 0), 1);  // One file in L1
 
+  listener->sub_compaction_finished_ = 0;
   ASSERT_OK(db_->EnableAutoCompaction({db_->DefaultColumnFamily()}));
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  if (max_subcompactions_ > 3) {
+    // RocksDB might not generate the exact number of sub compactions.
+    // Here we validate that at least subcompaction happened.
+    ASSERT_GT(listener->sub_compaction_finished_.load(), 2);
+  }
 
-  // We expect that all the files were trivially moved from L0 to L1
+  // We expect that all the files were compacted to L1
   ASSERT_EQ(NumTableFilesAtLevel(0, 0), 0);
   ASSERT_GT(NumTableFilesAtLevel(1, 0), 1);
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5840,6 +5840,9 @@ InternalIterator* VersionSet::MakeInputIterator(
                                               fmd.largest.user_key()) > 0) {
             continue;
           }
+          // We should be able to filter out the case where the end key
+          // equals to the end boundary, since the end key is exclusive.
+          // We try to be extra safe here.
           if (end.has_value() &&
               cfd->user_comparator()->Compare(end.value(),
                                               fmd.smallest.user_key()) < 0) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5818,8 +5818,8 @@ InternalIterator* VersionSet::MakeInputIterator(
     const ReadOptions& read_options, const Compaction* c,
     RangeDelAggregator* range_del_agg,
     const FileOptions& file_options_compactions,
-    const std::optional<const Slice> start,
-    const std::optional<const Slice> end) {
+    const std::optional<const Slice>& start,
+    const std::optional<const Slice>& end) {
   auto cfd = c->column_family_data();
   // Level-0 files have to be merged together.  For other levels,
   // we will make a concatenating iterator per level.

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5818,7 +5818,8 @@ InternalIterator* VersionSet::MakeInputIterator(
     const ReadOptions& read_options, const Compaction* c,
     RangeDelAggregator* range_del_agg,
     const FileOptions& file_options_compactions,
-    std::optional<const Slice> start, std::optional<const Slice> end) {
+    const std::optional<const Slice> start,
+    const std::optional<const Slice> end) {
   auto cfd = c->column_family_data();
   // Level-0 files have to be merged together.  For other levels,
   // we will make a concatenating iterator per level.

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -27,6 +27,7 @@
 #include "db/blob/blob_log_format.h"
 #include "db/compaction/compaction.h"
 #include "db/compaction/file_pri.h"
+#include "db/dbformat.h"
 #include "db/internal_stats.h"
 #include "db/log_reader.h"
 #include "db/log_writer.h"
@@ -5816,7 +5817,8 @@ void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
 InternalIterator* VersionSet::MakeInputIterator(
     const ReadOptions& read_options, const Compaction* c,
     RangeDelAggregator* range_del_agg,
-    const FileOptions& file_options_compactions) {
+    const FileOptions& file_options_compactions,
+    std::optional<const Slice> start, std::optional<const Slice> end) {
   auto cfd = c->column_family_data();
   // Level-0 files have to be merged together.  For other levels,
   // we will make a concatenating iterator per level.
@@ -5831,10 +5833,22 @@ InternalIterator* VersionSet::MakeInputIterator(
       if (c->level(which) == 0) {
         const LevelFilesBrief* flevel = c->input_levels(which);
         for (size_t i = 0; i < flevel->num_files; i++) {
+          const FileMetaData& fmd = *flevel->files[i].file_metadata;
+          if (start.has_value() &&
+              cfd->user_comparator()->Compare(start.value(),
+                                              fmd.largest.user_key()) > 0) {
+            continue;
+          }
+          if (end.has_value() &&
+              cfd->user_comparator()->Compare(end.value(),
+                                              fmd.smallest.user_key()) < 0) {
+            continue;
+          }
+
           list[num++] = cfd->table_cache()->NewIterator(
               read_options, file_options_compactions,
-              cfd->internal_comparator(), *flevel->files[i].file_metadata,
-              range_del_agg, c->mutable_cf_options()->prefix_extractor,
+              cfd->internal_comparator(), fmd, range_del_agg,
+              c->mutable_cf_options()->prefix_extractor,
               /*table_reader_ptr=*/nullptr,
               /*file_read_hist=*/nullptr, TableReaderCaller::kCompaction,
               /*arena=*/nullptr,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1266,7 +1266,8 @@ class VersionSet {
       const ReadOptions& read_options, const Compaction* c,
       RangeDelAggregator* range_del_agg,
       const FileOptions& file_options_compactions,
-      std::optional<const Slice> start, std::optional<const Slice> end);
+      const std::optional<const Slice> start,
+      const std::optional<const Slice> end);
 
   // Add all files listed in any live version to *live_table_files and
   // *live_blob_files. Note that these lists may contain duplicates.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1267,8 +1267,8 @@ class VersionSet {
       const ReadOptions& read_options, const Compaction* c,
       RangeDelAggregator* range_del_agg,
       const FileOptions& file_options_compactions,
-      const std::optional<const Slice> start,
-      const std::optional<const Slice> end);
+      const std::optional<const Slice>& start,
+      const std::optional<const Slice>& end);
 
   // Add all files listed in any live version to *live_table_files and
   // *live_blob_files. Note that these lists may contain duplicates.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1261,10 +1261,12 @@ class VersionSet {
   // Create an iterator that reads over the compaction inputs for "*c".
   // The caller should delete the iterator when no longer needed.
   // @param read_options Must outlive the returned iterator.
+  // @param start, end indicates compaction range
   InternalIterator* MakeInputIterator(
       const ReadOptions& read_options, const Compaction* c,
       RangeDelAggregator* range_del_agg,
-      const FileOptions& file_options_compactions);
+      const FileOptions& file_options_compactions,
+      std::optional<const Slice> start, std::optional<const Slice> end);
 
   // Add all files listed in any live version to *live_table_files and
   // *live_blob_files. Note that these lists may contain duplicates.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -24,6 +24,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_set>


### PR DESCRIPTION
Summary:
When sub compaction is decided for L0->L1 compaction, most of the cases, all L0 files will be involved in all sub compactions. However, it is not always the case. When files are generally (but not strictly) inserted in sequential order, there can be a subset of L0 files invovled. Yet RocksDB always open all those L0 files, and build an iterator, read many of the files' first of last block with expensive readahead. We trim some input files to reduce overhead a little bit.

Test Plan: Add a unit test to cover this case and manually validate the behavior while running the test.