### PR TITLE
Add Env::IOPriority `rate_limiter_priority` to IOOptions

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -89,6 +89,12 @@ struct IOOptions {
   // Priority - high or low
   IOPriority prio;
 
+  // Priority used to charge rate limiter configured in file system level (if
+  // any)
+  // Limitation: right now RocksDB internal does not consider this
+  // rate_limiter_priority
+  Env::IOPriority rate_limiter_priority;
+
   // Type of data being read/written
   IOType type;
 
@@ -109,6 +115,7 @@ struct IOOptions {
   explicit IOOptions(bool force_dir_fsync_)
       : timeout(std::chrono::microseconds::zero()),
         prio(IOPriority::kIOLow),
+        rate_limiter_priority(Env::IO_TOTAL),
         type(IOType::kUnknown),
         force_dir_fsync(force_dir_fsync_) {}
 };


### PR DESCRIPTION
**Context/Todo:**
As requested, allow IOOptions to take in an Env::IOPriority for convenience to pass down rate limiter related hint to file system level and for future interaction between RocksDB internal's rate limiting and custom file system level's rate-limiting.

**Test:**
No actual code changes in RocksDB internals