### PR TITLE
Remove explicit padding from CacheAlignedInstrumentedMutex

### DIFF
--- a/monitoring/instrumented_mutex.h
+++ b/monitoring/instrumented_mutex.h
@@ -53,7 +53,6 @@ class InstrumentedMutex {
 
 class ALIGN_AS(CACHE_LINE_SIZE) CacheAlignedInstrumentedMutex
     : public InstrumentedMutex {
-  using InstrumentedMutex::InstrumentedMutex;
 };
 static_assert(alignof(CacheAlignedInstrumentedMutex) != CACHE_LINE_SIZE ||
               sizeof(CacheAlignedInstrumentedMutex) % CACHE_LINE_SIZE == 0);

--- a/monitoring/instrumented_mutex.h
+++ b/monitoring/instrumented_mutex.h
@@ -55,7 +55,6 @@ class ALIGN_AS(CACHE_LINE_SIZE) CacheAlignedInstrumentedMutex
     : public InstrumentedMutex {
   using InstrumentedMutex::InstrumentedMutex;
 };
-static_assert(sizeof(CacheAlignedInstrumentedMutex) % CACHE_LINE_SIZE == 0);
 
 // RAII wrapper for InstrumentedMutex
 class InstrumentedMutexLock {

--- a/monitoring/instrumented_mutex.h
+++ b/monitoring/instrumented_mutex.h
@@ -55,6 +55,8 @@ class ALIGN_AS(CACHE_LINE_SIZE) CacheAlignedInstrumentedMutex
     : public InstrumentedMutex {
   using InstrumentedMutex::InstrumentedMutex;
 };
+static_assert(alignof(CacheAlignedInstrumentedMutex) != CACHE_LINE_SIZE ||
+              sizeof(CacheAlignedInstrumentedMutex) % CACHE_LINE_SIZE == 0);
 
 // RAII wrapper for InstrumentedMutex
 class InstrumentedMutexLock {

--- a/monitoring/instrumented_mutex.h
+++ b/monitoring/instrumented_mutex.h
@@ -53,6 +53,7 @@ class InstrumentedMutex {
 
 class ALIGN_AS(CACHE_LINE_SIZE) CacheAlignedInstrumentedMutex
     : public InstrumentedMutex {
+  using InstrumentedMutex::InstrumentedMutex;
 };
 static_assert(alignof(CacheAlignedInstrumentedMutex) != CACHE_LINE_SIZE ||
               sizeof(CacheAlignedInstrumentedMutex) % CACHE_LINE_SIZE == 0);

--- a/monitoring/instrumented_mutex.h
+++ b/monitoring/instrumented_mutex.h
@@ -54,8 +54,6 @@ class InstrumentedMutex {
 class ALIGN_AS(CACHE_LINE_SIZE) CacheAlignedInstrumentedMutex
     : public InstrumentedMutex {
   using InstrumentedMutex::InstrumentedMutex;
-  char padding[(CACHE_LINE_SIZE - sizeof(InstrumentedMutex) % CACHE_LINE_SIZE) %
-               CACHE_LINE_SIZE] ROCKSDB_FIELD_UNUSED;
 };
 static_assert(sizeof(CacheAlignedInstrumentedMutex) % CACHE_LINE_SIZE == 0);
 


### PR DESCRIPTION
Fixes #9779.

The padding at the end of a struct is added implicitly according to the
sizeof spec: "When applied to a class, the result is the
number of bytes in an object of that class including any padding
required for placing objects of that type in an array"
(https://eel.is/c++draft/expr.sizeof#2.sentence-2). We should drop the
explicit padding since it assumed support for zero-length arrays, which
is non-standard.

Test Plan: rely on CI