### PR TITLE
Update supported VS versions in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -180,8 +180,7 @@ to build a portable binary, add `PORTABLE=1` before your make commands, like thi
 * **iOS**:
   * Run: `TARGET_OS=IOS make static_lib`. When building the project which uses rocksdb iOS library, make sure to define two important pre-processing macros: `ROCKSDB_LITE` and `IOS_CROSS_COMPILE`.
 
-* **Windows**:
-  * For building with MS Visual Studio 13 you will need Update 4 installed.
+* **Windows** (Visual Studio 2017 to up):
   * Read and follow the instructions at CMakeLists.txt
   * Or install via [vcpkg](https://github.com/microsoft/vcpkg)
        * run `vcpkg install rocksdb:x64-windows`


### PR DESCRIPTION
We only run CI for VS2017 and VS2019 now, so the claim that users can build with "VS13" is stale.