### PR TITLE
Update main version.h to NEXT release

### DIFF
--- a/include/rocksdb/version.h
+++ b/include/rocksdb/version.h
@@ -9,8 +9,10 @@
 
 #include "rocksdb/rocksdb_namespace.h"
 
+// NOTE: in 'main' development branch, this should be the *next*
+// minor or major version number planned for release.
 #define ROCKSDB_MAJOR 7
-#define ROCKSDB_MINOR 1
+#define ROCKSDB_MINOR 2
 #define ROCKSDB_PATCH 0
 
 // Do not use these. We made the mistake of declaring macros starting with


### PR DESCRIPTION
Summary: Henceforth, the version number in version.h shall reflect the
*next* version number to be tagged (to the best of our knowledge) rather
than the *previous* (unpatched) version.

The primary advantage is being able to distinguish (in source code `#if`s
or human running tools) the development version from the last released
version.

Test Plan: CI