### PR TITLE
Conditionally declare and define variable that is unused in LITE mode

### DIFF
--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -160,7 +160,9 @@ class WritableFileWriter {
   bool perform_data_verification_;
   uint32_t buffered_data_crc32c_checksum_;
   bool buffered_data_with_checksum_;
+#ifndef ROCKSDB_LITE
   Temperature temperature_;
+#endif  // ROCKSDB_LITE
 
  public:
   WritableFileWriter(
@@ -191,8 +193,12 @@ class WritableFileWriter {
         checksum_finalized_(false),
         perform_data_verification_(perform_data_verification),
         buffered_data_crc32c_checksum_(0),
-        buffered_data_with_checksum_(buffered_data_with_checksum),
-        temperature_(options.temperature) {
+        buffered_data_with_checksum_(buffered_data_with_checksum)
+#ifndef ROCKSDB_LITE
+        ,
+        temperature_(options.temperature)
+#endif  // ROCKSDB_LITE
+  {
     assert(!use_direct_io() || max_buffer_size_ > 0);
     TEST_SYNC_POINT_CALLBACK("WritableFileWriter::WritableFileWriter:0",
                              reinterpret_cast<void*>(max_buffer_size_));

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -193,12 +193,10 @@ class WritableFileWriter {
         checksum_finalized_(false),
         perform_data_verification_(perform_data_verification),
         buffered_data_crc32c_checksum_(0),
-        buffered_data_with_checksum_(buffered_data_with_checksum)
+        buffered_data_with_checksum_(buffered_data_with_checksum) {
 #ifndef ROCKSDB_LITE
-        ,
-        temperature_(options.temperature)
+    temperature_ = options.temperature;
 #endif  // ROCKSDB_LITE
-  {
     assert(!use_direct_io() || max_buffer_size_ > 0);
     TEST_SYNC_POINT_CALLBACK("WritableFileWriter::WritableFileWriter:0",
                              reinterpret_cast<void*>(max_buffer_size_));


### PR DESCRIPTION
Context: 
As mentioned in https://github.com/facebook/rocksdb/issues/9701, we have the following in LITE=1 make static_lib for v7.0.2
```
  CC       file/sequence_file_reader.o
  CC       file/sst_file_manager_impl.o
  CC       file/writable_file_writer.o
In file included from file/writable_file_writer.cc:10:
./file/writable_file_writer.h:163:15: error: private field 'temperature_' is not used [-Werror,-Wunused-private-field]
  Temperature temperature_;
              ^
1 error generated.
make: *** [file/writable_file_writer.o] Error 1
```

Summary: as titled

Test plan:
- Local `LITE=1 make static_lib` reveals the same error and error is gone after this fix
- CI