### PR TITLE
Add blob dump support to the dump command

### DIFF
--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -25,7 +25,6 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/utilities/db_ttl.h"
 #include "rocksdb/utilities/ldb_cmd_execute_result.h"
-#include "utilities/blob_db/blob_dump_tool.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -71,10 +70,7 @@ class LDBCommand {
   static const std::string ARG_BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD;
   static const std::string ARG_BLOB_COMPACTION_READAHEAD_SIZE;
   static const std::string ARG_DECODE_BLOB_INDEX;
-  static const std::string ARG_BLOB_DUMP_SHOW_KEY_TYPE;
-  static const std::string ARG_BLOB_DUMP_SHOW_BLOB_TYPE;
-  static const std::string ARG_BLOB_DUMP_SHOW_UNCOMPRESSED_BLOB_TYPE;
-  static const std::string ARG_BLOB_DUMP_SHOW_SUMMARY;
+  static const std::string ARG_DUMP_UNCOMPRESSED_BLOBS;
 
   struct ParsedParams {
     std::string cmd;
@@ -261,11 +257,6 @@ class LDBCommand {
   bool ParseCompressionTypeOption(
       const std::map<std::string, std::string>& options,
       const std::string& option, CompressionType& value,
-      LDBCommandExecuteResult& exec_state);
-
-  bool ParseBlobDumpDisplayTypeOption(
-      const std::map<std::string, std::string>& options,
-      const std::string& option, blob_db::BlobDumpTool::DisplayType& value,
       LDBCommandExecuteResult& exec_state);
 
   /**

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -25,6 +25,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/utilities/db_ttl.h"
 #include "rocksdb/utilities/ldb_cmd_execute_result.h"
+#include "utilities/blob_db/blob_dump_tool.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -70,6 +71,10 @@ class LDBCommand {
   static const std::string ARG_BLOB_GARBAGE_COLLECTION_FORCE_THRESHOLD;
   static const std::string ARG_BLOB_COMPACTION_READAHEAD_SIZE;
   static const std::string ARG_DECODE_BLOB_INDEX;
+  static const std::string ARG_BLOB_DUMP_SHOW_KEY_TYPE;
+  static const std::string ARG_BLOB_DUMP_SHOW_BLOB_TYPE;
+  static const std::string ARG_BLOB_DUMP_SHOW_UNCOMPRESSED_BLOB_TYPE;
+  static const std::string ARG_BLOB_DUMP_SHOW_SUMMARY;
 
   struct ParsedParams {
     std::string cmd;
@@ -256,6 +261,11 @@ class LDBCommand {
   bool ParseCompressionTypeOption(
       const std::map<std::string, std::string>& options,
       const std::string& option, CompressionType& value,
+      LDBCommandExecuteResult& exec_state);
+
+  bool ParseBlobDumpDisplayTypeOption(
+      const std::map<std::string, std::string>& options,
+      const std::string& option, blob_db::BlobDumpTool::DisplayType& value,
       LDBCommandExecuteResult& exec_state);
 
   /**

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -108,8 +108,6 @@ const char* LDBCommand::DELIM = " ==> ";
 
 namespace {
 
-using ROCKSDB_NAMESPACE::blob_db::BlobDumpTool;
-
 void DumpWalFile(Options options, std::string wal_file, bool print_header,
                  bool print_values, bool is_write_committed,
                  LDBCommandExecuteResult* exec_state);
@@ -117,8 +115,8 @@ void DumpWalFile(Options options, std::string wal_file, bool print_header,
 void DumpSstFile(Options options, std::string filename, bool output_hex,
                  bool show_properties, bool decode_blob_index);
 
-void DumpBlobFile(std::string filename, bool is_key_hex, bool is_value_hex,
-                  bool dump_uncompressed_blobs);
+void DumpBlobFile(const std::string& filename, bool is_key_hex,
+                  bool is_value_hex, bool dump_uncompressed_blobs);
 };
 
 LDBCommand* LDBCommand::InitFromCmdLineArgs(
@@ -3548,8 +3546,9 @@ void DumpSstFile(Options options, std::string filename, bool output_hex,
   }
 }
 
-void DumpBlobFile(std::string filename, bool is_key_hex, bool is_value_hex,
-                  bool dump_uncompressed_blobs) {
+void DumpBlobFile(const std::string& filename, bool is_key_hex,
+                  bool is_value_hex, bool dump_uncompressed_blobs) {
+  using ROCKSDB_NAMESPACE::blob_db::BlobDumpTool;
   BlobDumpTool tool;
   BlobDumpTool::DisplayType blob_type = is_value_hex
                                             ? BlobDumpTool::DisplayType::kHex

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -108,6 +108,11 @@ class DBDumperCommand : public LDBCommand {
   bool print_stats_;
   std::string path_;
   bool decode_blob_index_;
+  blob_db::BlobDumpTool::DisplayType show_key_type_ =
+      blob_db::BlobDumpTool::DisplayType::kRaw;
+  blob_db::BlobDumpTool::DisplayType show_blob_type_;
+  blob_db::BlobDumpTool::DisplayType show_uncompressed_blob_type_;
+  bool show_summary_;
 
   static const std::string ARG_COUNT_ONLY;
   static const std::string ARG_COUNT_DELIM;

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -108,11 +108,7 @@ class DBDumperCommand : public LDBCommand {
   bool print_stats_;
   std::string path_;
   bool decode_blob_index_;
-  blob_db::BlobDumpTool::DisplayType show_key_type_ =
-      blob_db::BlobDumpTool::DisplayType::kRaw;
-  blob_db::BlobDumpTool::DisplayType show_blob_type_;
-  blob_db::BlobDumpTool::DisplayType show_uncompressed_blob_type_;
-  bool show_summary_;
+  bool dump_uncompressed_blobs_;
 
   static const std::string ARG_COUNT_ONLY;
   static const std::string ARG_COUNT_DELIM;

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -727,7 +727,7 @@ class LDBTestCase(unittest.TestCase):
         expected_pattern = re.compile(regex)
         blob_files = self.getBlobFiles(dbPath)
         self.assertTrue(len(blob_files) >= 1)
-        cmd = "dump --path=%s --blob_dump_show_blob_type=raw --blob_dump_show_summary"
+        cmd = "dump --path=%s --dump_uncompressed_blobs"
         self.assertRunOKFull((cmd)
                              % (blob_files[0]),
                              expected_pattern, unexpected=False,

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -716,6 +716,23 @@ class LDBTestCase(unittest.TestCase):
                              expected_pattern, unexpected=False,
                              isPattern=True)
 
+    def testBlobDump(self):
+        print("Running testBlobDump")
+        dbPath = os.path.join(self.TMP_DIR, self.DB_NAME)
+        self.assertRunOK("batchput x1 y1 --create_if_missing --enable_blob_files", "OK")
+        self.assertRunOK("batchput --enable_blob_files x2 y2 x3 y3 \"x4 abc\" \"y4 xyz\"", "OK")
+
+        # Pattern to expect from blob file dump.
+        regex = ".*Blob log header[\s\S]*Blob log footer[\s\S]*Read record[\s\S]*Summary"
+        expected_pattern = re.compile(regex)
+        blob_files = self.getBlobFiles(dbPath)
+        self.assertTrue(len(blob_files) >= 1)
+        cmd = "dump --path=%s --blob_dump_show_blob_type=raw --blob_dump_show_summary"
+        self.assertRunOKFull((cmd)
+                             % (blob_files[0]),
+                             expected_pattern, unexpected=False,
+                             isPattern=True)
+
     def testWALDump(self):
         print("Running testWALDump...")
 


### PR DESCRIPTION
This patch is the first part of adding blob dump support. It only adds blob dump support to the dump command. A follow up patch will add blob dump support to the dump_live_files command.