### PR TITLE
[WIP] Record stack traces for hanging/slow tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,13 @@ commands:
           command: |
             sudo apt-get update -y && sudo apt-get install -y libgflags-dev
 
+  install-pstack:
+    steps:
+      - run:
+          name: Install pstack
+          command: |
+            sudo apt-get update -y && sudo apt-get install -y pstack
+
   install-benchmark:
     steps:
       - run:
@@ -227,6 +234,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
+      - install-pstack
       - run: make DRIVER=./tools/run_with_pstack.sh V=1 J=32 -j32 check
       - post-steps
 
@@ -237,6 +245,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
+      - install-pstack
       - run: ENCRYPTED_ENV=1 ROCKSDB_DISABLE_SNAPPY=1 ROCKSDB_DISABLE_ZLIB=1 ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 make DRIVER=./tools/run_with_pstack.sh V=1 J=32 -j32 check
       - run: |
           ./sst_dump --help | egrep -q 'Supported compression types: kNoCompression$' # Verify no compiled in compression
@@ -249,6 +258,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
+      - install-pstack
       - run: ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=shared OPT="-DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make DRIVER=./tools/run_with_pstack.sh V=1 -j32 check
       - post-steps
 
@@ -286,6 +296,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
+      - install-pstack
       - run: LITE=1 make DRIVER=./tools/run_with_pstack.sh V=1 J=8 -j8 check
       - post-steps
 
@@ -320,6 +331,7 @@ jobs:
       - pre-steps
       - install-gflags
       - install-clang-10
+      - install-pstack
       - run: COMPILE_WITH_ASAN=1 CC=clang-10 CXX=clang++-10 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make DRIVER=./tools/run_with_pstack.sh V=1 -j32 check # aligned new doesn't work for reason we haven't figured out
       - post-steps
 
@@ -361,6 +373,7 @@ jobs:
       - pre-steps
       - install-gflags
       - install-clang-10
+      - install-pstack
       - run: COMPILE_WITH_UBSAN=1 OPT="-fsanitize-blacklist=.circleci/ubsan_suppression_list.txt" CC=clang-10 CXX=clang++-10 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make DRIVER=./tools/run_with_pstack.sh V=1 -j32 ubsan_check # aligned new doesn't work for reason we haven't figured out
       - post-steps
 
@@ -372,6 +385,7 @@ jobs:
       - pre-steps
       - install-gflags
       - install-valgrind
+      - install-pstack
       - run: PORTABLE=1 make DRIVER=./tools/run_with_pstack.sh V=1 -j32 valgrind_test
       - post-steps
 
@@ -429,6 +443,7 @@ jobs:
       - pre-steps
       - run: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update -y && sudo apt-get install gcc-7 g++-7 libgflags-dev
       - run: make checkout_folly
+      - install-pstack
       - run: USE_FOLLY=1 CC=gcc-7 CXX=g++-7 V=1 make DRIVER=./tools/run_with_pstack.sh -j32 check
       - post-steps
 
@@ -484,6 +499,7 @@ jobs:
       - install-clang-13
       - install-gflags
       - run: make checkout_folly
+      - install-pstack
       - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 USE_FOLLY=1 COMPILE_WITH_UBSAN=1 COMPILE_WITH_ASAN=1 make DRIVER=./tools/run_with_pstack.sh -j32 check
       - post-steps
 
@@ -736,6 +752,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
+      - install-pstack
       - run: make DRIVER=./tools/run_with_pstack.sh V=1 -j32 check
       - post-steps
 
@@ -746,6 +763,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
+      - install-pstack
       - run: make DRIVER=./tools/run_with_pstack.sh V=1 J=4 -j4 check
       - post-steps
 
@@ -756,6 +774,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
+      - install-pstack
       - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make DRIVER=./tools/run_with_pstack.sh V=1 J=4 -j4 all_but_some_tests check_some
       - post-steps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
-      - run: make V=1 J=32 -j32 check
+      - run: make DRIVER=./tools/run_with_pstack.sh V=1 J=32 -j32 check
       - post-steps
 
   build-linux-encrypted_env-no_compression:
@@ -237,7 +237,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
-      - run: ENCRYPTED_ENV=1 ROCKSDB_DISABLE_SNAPPY=1 ROCKSDB_DISABLE_ZLIB=1 ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 make V=1 J=32 -j32 check
+      - run: ENCRYPTED_ENV=1 ROCKSDB_DISABLE_SNAPPY=1 ROCKSDB_DISABLE_ZLIB=1 ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 make DRIVER=./tools/run_with_pstack.sh V=1 J=32 -j32 check
       - run: |
           ./sst_dump --help | egrep -q 'Supported compression types: kNoCompression$' # Verify no compiled in compression
       - post-steps
@@ -249,7 +249,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
-      - run: ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=shared OPT="-DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make V=1 -j32 check
+      - run: ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=shared OPT="-DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make DRIVER=./tools/run_with_pstack.sh V=1 -j32 check
       - post-steps
 
   build-linux-release:
@@ -286,7 +286,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
-      - run: LITE=1 make V=1 J=8 -j8 check
+      - run: LITE=1 make DRIVER=./tools/run_with_pstack.sh V=1 J=8 -j8 check
       - post-steps
 
   build-linux-lite-release:
@@ -320,7 +320,7 @@ jobs:
       - pre-steps
       - install-gflags
       - install-clang-10
-      - run: COMPILE_WITH_ASAN=1 CC=clang-10 CXX=clang++-10 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j32 check # aligned new doesn't work for reason we haven't figured out
+      - run: COMPILE_WITH_ASAN=1 CC=clang-10 CXX=clang++-10 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make DRIVER=./tools/run_with_pstack.sh V=1 -j32 check # aligned new doesn't work for reason we haven't figured out
       - post-steps
 
   build-linux-clang10-mini-tsan:
@@ -361,7 +361,7 @@ jobs:
       - pre-steps
       - install-gflags
       - install-clang-10
-      - run: COMPILE_WITH_UBSAN=1 OPT="-fsanitize-blacklist=.circleci/ubsan_suppression_list.txt" CC=clang-10 CXX=clang++-10 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j32 ubsan_check # aligned new doesn't work for reason we haven't figured out
+      - run: COMPILE_WITH_UBSAN=1 OPT="-fsanitize-blacklist=.circleci/ubsan_suppression_list.txt" CC=clang-10 CXX=clang++-10 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make DRIVER=./tools/run_with_pstack.sh V=1 -j32 ubsan_check # aligned new doesn't work for reason we haven't figured out
       - post-steps
 
   build-linux-valgrind:
@@ -372,7 +372,7 @@ jobs:
       - pre-steps
       - install-gflags
       - install-valgrind
-      - run: PORTABLE=1 make V=1 -j32 valgrind_test
+      - run: PORTABLE=1 make DRIVER=./tools/run_with_pstack.sh V=1 -j32 valgrind_test
       - post-steps
 
   build-linux-clang10-clang-analyze:
@@ -429,7 +429,7 @@ jobs:
       - pre-steps
       - run: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update -y && sudo apt-get install gcc-7 g++-7 libgflags-dev
       - run: make checkout_folly
-      - run: USE_FOLLY=1 CC=gcc-7 CXX=g++-7 V=1 make -j32 check
+      - run: USE_FOLLY=1 CC=gcc-7 CXX=g++-7 V=1 make DRIVER=./tools/run_with_pstack.sh -j32 check
       - post-steps
 
   build-linux-gcc-8-no_test_run:
@@ -484,7 +484,7 @@ jobs:
       - install-clang-13
       - install-gflags
       - run: make checkout_folly
-      - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 USE_FOLLY=1 COMPILE_WITH_UBSAN=1 COMPILE_WITH_ASAN=1 make -j32 check
+      - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 USE_FOLLY=1 COMPILE_WITH_UBSAN=1 COMPILE_WITH_ASAN=1 make DRIVER=./tools/run_with_pstack.sh -j32 check
       - post-steps
 
   # This job is only to make sure the microbench tests are able to run, the benchmark result is not meaningful as the CI host is changing.
@@ -736,7 +736,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
-      - run: make V=1 -j32 check
+      - run: make DRIVER=./tools/run_with_pstack.sh V=1 -j32 check
       - post-steps
 
   build-linux-arm-test-full:
@@ -746,7 +746,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
-      - run: make V=1 J=4 -j4 check
+      - run: make DRIVER=./tools/run_with_pstack.sh V=1 J=4 -j4 check
       - post-steps
 
   build-linux-arm:
@@ -756,7 +756,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
-      - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make V=1 J=4 -j4 all_but_some_tests check_some
+      - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make DRIVER=./tools/run_with_pstack.sh V=1 J=4 -j4 all_but_some_tests check_some
       - post-steps
 
   build-linux-arm-cmake-no_test_run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,7 @@ jobs:
     resource_class: 2xlarge
     steps:
       - pre-steps
+      - run: set -m; sleep 10 & ; sleep 10 & ; pkill -g $(jobs -p)
       - install-gflags
       - install-pstack
       - run: make DRIVER=./tools/run_with_pstack.sh V=1 J=32 -j32 check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,8 +774,7 @@ jobs:
     steps:
       - pre-steps
       - install-gflags
-      - install-pstack
-      - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make DRIVER=./tools/run_with_pstack.sh V=1 J=4 -j4 all_but_some_tests check_some
+      - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make V=1 J=4 -j4 all_but_some_tests check_some
       - post-steps
 
   build-linux-arm-cmake-no_test_run:

--- a/Makefile
+++ b/Makefile
@@ -1016,7 +1016,7 @@ check: all
 	    $(MAKE) T="$$t" TMPD=$(TMPD) check_0;                       \
 	else                                                            \
 	    for t in $(TESTS); do                                       \
-	      echo "===== Running $$t (`date`)"; ./$$t || exit 1; done;          \
+	      echo "===== Running $$t (`date`)"; $(DRIVER) ./$$t || exit 1; done;          \
 	fi
 	rm -rf $(TMPD)
 ifneq ($(PLATFORM), OS_AIX)
@@ -1036,7 +1036,7 @@ endif
 
 # TODO add ldb_tests
 check_some: $(ROCKSDBTESTS_SUBSET)
-	for t in $(ROCKSDBTESTS_SUBSET); do echo "===== Running $$t (`date`)"; ./$$t || exit 1; done
+	for t in $(ROCKSDBTESTS_SUBSET); do echo "===== Running $$t (`date`)"; $(DRIVER) ./$$t || exit 1; done
 
 .PHONY: ldb_tests
 ldb_tests: ldb
@@ -1113,16 +1113,16 @@ valgrind_test_some:
 	ROCKSDB_VALGRIND_RUN=1 DISABLE_JEMALLOC=1 $(MAKE) valgrind_check_some
 
 valgrind_check: $(TESTS)
-	$(MAKE) DRIVER="$(VALGRIND_VER) $(VALGRIND_OPTS)" gen_parallel_tests
+	$(MAKE) DRIVER="$(DRIVER) $(VALGRIND_VER) $(VALGRIND_OPTS)" gen_parallel_tests
 	$(AM_V_GEN)if test "$(J)" != 1                                  \
 	    && (build_tools/gnu_parallel --gnu --help 2>/dev/null) |                    \
 	        grep -q 'GNU Parallel';                                 \
 	then                                                            \
       $(MAKE) TMPD=$(TMPD)                                        \
-      DRIVER="$(VALGRIND_VER) $(VALGRIND_OPTS)" valgrind_check_0; \
+      DRIVER="$(DRIVER) $(VALGRIND_VER) $(VALGRIND_OPTS)" valgrind_check_0; \
 	else                                                            \
 		for t in $(filter-out %skiplist_test options_settable_test,$(TESTS)); do \
-			$(VALGRIND_VER) $(VALGRIND_OPTS) ./$$t; \
+			$(DRIVER) $(VALGRIND_VER) $(VALGRIND_OPTS) ./$$t; \
 			ret_code=$$?; \
 			if [ $$ret_code -ne 0 ]; then \
 				exit $$ret_code; \
@@ -1132,7 +1132,7 @@ valgrind_check: $(TESTS)
 
 valgrind_check_some: $(ROCKSDBTESTS_SUBSET)
 	for t in $(ROCKSDBTESTS_SUBSET); do \
-		$(VALGRIND_VER) $(VALGRIND_OPTS) ./$$t; \
+		$(DRIVER) $(VALGRIND_VER) $(VALGRIND_OPTS) ./$$t; \
 		ret_code=$$?; \
 		if [ $$ret_code -ne 0 ]; then \
 			exit $$ret_code; \

--- a/tools/run_with_pstack.sh
+++ b/tools/run_with_pstack.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# While wrapped command runs, a background subshell prints its stack traces
+# after every minute of waiting.
+
+# Enable job control so background subshell gets its own process group ID.
+set -m
+# For cleaning up background loop on exit (adapted from
+# https://stackoverflow.com/a/2173421).
+trap 'trap - SIGTERM && pkill -g $(jobs -p)' SIGINT SIGTERM EXIT
+
+"$@" &
+test_pid=$!
+while true; do sleep 60; pstack $test_pid; done &
+loop_pid=$!
+wait $test_pid
+test_ret=$?
+exit $test_ret

--- a/tools/run_with_pstack.sh
+++ b/tools/run_with_pstack.sh
@@ -7,7 +7,7 @@
 set -m
 # For cleaning up background jobs on exit (adapted from
 # https://stackoverflow.com/a/2173421).
-trap 'trap - SIGTERM && jobs -p | xargs printf -- "-%s " | xargs kill --' SIGINT SIGTERM EXIT
+trap 'trap - SIGTERM && jobs -p | xargs printf -- "-%s " | xargs kill --' INT TERM EXIT
 
 "$@" &
 test_pid=$!

--- a/tools/run_with_pstack.sh
+++ b/tools/run_with_pstack.sh
@@ -7,6 +7,7 @@
 set -m
 # For cleaning up background jobs on exit (adapted from
 # https://stackoverflow.com/a/2173421).
+# Negating the PIDs passed to kill causes the whole process group to be killed.
 trap 'trap - SIGTERM && jobs -p | xargs printf -- "-%s " | xargs kill --' INT TERM EXIT
 
 "$@" &

--- a/tools/run_with_pstack.sh
+++ b/tools/run_with_pstack.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
 # While wrapped command runs, a background subshell prints its stack traces
-# after every minute of waiting.
+# after two minutes of waiting.
 
 # Enable job control so background subshell gets its own process group ID.
 set -m
-# For cleaning up background loop on exit (adapted from
+# For cleaning up background jobs on exit (adapted from
 # https://stackoverflow.com/a/2173421).
 trap 'trap - SIGTERM && jobs -p | xargs printf -- "-%s " | xargs kill --' SIGINT SIGTERM EXIT
 
 "$@" &
 test_pid=$!
-while true; do sleep 60; pstack $test_pid; done &
+(sleep 120; pstack $test_pid) &
 wait $test_pid

--- a/tools/run_with_pstack.sh
+++ b/tools/run_with_pstack.sh
@@ -7,7 +7,7 @@
 set -m
 # For cleaning up background loop on exit (adapted from
 # https://stackoverflow.com/a/2173421).
-trap 'trap - SIGTERM && pkill -g $(jobs -p)' SIGINT SIGTERM EXIT
+trap 'trap - SIGTERM && jobs -p | xargs printf -- "-%s " | xargs kill --' SIGINT SIGTERM EXIT
 
 "$@" &
 test_pid=$!

--- a/tools/run_with_pstack.sh
+++ b/tools/run_with_pstack.sh
@@ -8,7 +8,7 @@ set -m
 # For cleaning up background jobs on exit (adapted from
 # https://stackoverflow.com/a/2173421).
 # Negating the PIDs passed to kill causes the whole process group to be killed.
-trap 'trap - SIGTERM && jobs -p | xargs printf -- "-%s " | xargs kill --' INT TERM EXIT
+trap 'trap - TERM && jobs -p | xargs printf -- "-%s " | xargs kill --' INT TERM EXIT
 
 "$@" &
 test_pid=$!

--- a/tools/run_with_pstack.sh
+++ b/tools/run_with_pstack.sh
@@ -8,7 +8,7 @@ set -m
 # For cleaning up background jobs on exit (adapted from
 # https://stackoverflow.com/a/2173421).
 # Negating the PIDs passed to kill causes the whole process group to be killed.
-trap 'trap - TERM && jobs -p | xargs printf -- "-%s " | xargs kill --' INT TERM EXIT
+trap 'trap - TERM && pkill -g $(jobs -p)' INT TERM EXIT
 
 "$@" &
 test_pid=$!

--- a/tools/run_with_pstack.sh
+++ b/tools/run_with_pstack.sh
@@ -12,7 +12,4 @@ trap 'trap - SIGTERM && jobs -p | xargs printf -- "-%s " | xargs kill --' SIGINT
 "$@" &
 test_pid=$!
 while true; do sleep 60; pstack $test_pid; done &
-loop_pid=$!
 wait $test_pid
-test_ret=$?
-exit $test_ret


### PR DESCRIPTION
This PR adds a wrapper script, "tools/run_with_pstack.sh", that prints a test's stack traces using `pstack` after a test runs for two minutes. It changes the Makefile to support running test binaries with a driver program, and changes CircleCI config to use "tools/run_with_pstack.sh" as the driver in many of its test runs.

A parallel test's stack traces go to the log file ("t/log-run-*") and can be found in the CircleCI test artifacts upload upon failure. A non-parallel test's stack traces go directly to the console.