### PR TITLE
Add experimental new FS API AbortIO to cancel read request

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,10 +2,10 @@
 ## Unreleased
 ### New Features
 * DB::GetLiveFilesStorageInfo is ready for production use.
-* EXPERIMENTAL: Add new API AbortIO in file_system to abort the read requests submitted asynchronously.
 
 ### Public API changes
 * Add rollback_deletion_type_callback to TransactionDBOptions so that write-prepared transactions know whether to issue a Delete or SingleDelete to cancel a previous key written during prior prepare phase. The PR aims to prevent mixing SingleDeletes and Deletes for the same key that can lead to undefined behaviors for write-prepared transactions.
+* EXPERIMENTAL: Add new API AbortIO in file_system to abort the read requests submitted asynchronously.
 
 ## 7.2.0 (04/15/2022)
 ### Bug Fixes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### New Features
 * DB::GetLiveFilesStorageInfo is ready for production use.
+* EXPERIMENTAL: Add new API AbortIO in file_system to abort the read requests submitted asynchronously.
 
 ### Public API changes
 * Add rollback_deletion_type_callback to TransactionDBOptions so that write-prepared transactions know whether to issue a Delete or SingleDelete to cancel a previous key written during prior prepare phase. The PR aims to prevent mixing SingleDeletes and Deletes for the same key that can lead to undefined behaviors for write-prepared transactions.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@
 * Add rollback_deletion_type_callback to TransactionDBOptions so that write-prepared transactions know whether to issue a Delete or SingleDelete to cancel a previous key written during prior prepare phase. The PR aims to prevent mixing SingleDeletes and Deletes for the same key that can lead to undefined behaviors for write-prepared transactions.
 * EXPERIMENTAL: Add new API AbortIO in file_system to abort the read requests submitted asynchronously.
 
+### Bug Fixes
+* RocksDB calls FileSystem::Poll API during FilePrefetchBuffer destruction which impacts performance as it waits for read requets completion which is not needed anymore. Calling FileSystem::AbortIO to abort those requests instead fixes that performance issue.
+
 ## 7.2.0 (04/15/2022)
 ### Bug Fixes
 * Fixed bug which caused rocksdb failure in the situation when rocksdb was accessible using UNC path

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1118,6 +1118,13 @@ class PosixFileSystem : public FileSystem {
 #endif
   }
 
+  // TODO akanksha: Look into flags and see how to provide support for AbortIO
+  // in posix for IOUring requests. Currently it calls Poll to wait for requests
+  // to complete the request.
+  virtual IOStatus AbortIO(std::vector<void*>& io_handles) override {
+    return Poll(io_handles, io_handles.size());
+  }
+
 #if defined(ROCKSDB_IOURING_PRESENT)
   // io_uring instance
   std::unique_ptr<ThreadLocalPtr> thread_local_io_urings_;

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -92,7 +92,8 @@ class FilePrefetchBuffer {
     if (async_read_in_progress_ && fs_ != nullptr) {
       std::vector<void*> handles;
       handles.emplace_back(io_handle_);
-      fs_->AbortIO(handles).PermitUncheckedError();
+      Status s = fs_->AbortIO(handles);
+      assert(s.ok());
     }
     // Release io_handle_.
     if (io_handle_ != nullptr && del_fn_ != nullptr) {

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -92,7 +92,7 @@ class FilePrefetchBuffer {
     if (async_read_in_progress_ && fs_ != nullptr) {
       std::vector<void*> handles;
       handles.emplace_back(io_handle_);
-      fs_->Poll(handles, 1).PermitUncheckedError();
+      fs_->AbortIO(handles).PermitUncheckedError();
     }
     // Release io_handle_.
     if (io_handle_ != nullptr && del_fn_ != nullptr) {

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -674,9 +674,9 @@ class FileSystem : public Customizable {
   // the all the read requests related to io_handles should be aborted and
   // it shouldn't call the callback for these io_handles.
   //
-  // Default implementation is to return IOStatus::NotSupported.
+  // Default implementation is to return IOStatus::OK.
   virtual IOStatus AbortIO(std::vector<void*>& /*io_handles*/) {
-    return IOStatus::NotSupported("AbortIO");
+    return IOStatus::OK();
   }
 
   // If you're adding methods here, remember to add them to EnvWrapper too.

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -668,6 +668,17 @@ class FileSystem : public Customizable {
     return IOStatus::OK();
   }
 
+  // EXPERIMENTAL
+  // Abort the read IO requests submitted asynchronously. Underlying FS is
+  // required to support AbortIO API. AbortIO implementation should ensure that
+  // the all the read requests related to io_handles should be aborted and
+  // it shouldn't call the callback for these io_handles.
+  //
+  // Default implementation is to return IOStatus::NotSupported.
+  virtual IOStatus AbortIO(std::vector<void*>& /*io_handles*/) {
+    return IOStatus::NotSupported("AbortIO");
+  }
+
   // If you're adding methods here, remember to add them to EnvWrapper too.
 
  private:
@@ -1498,6 +1509,10 @@ class FileSystemWrapper : public FileSystem {
   virtual IOStatus Poll(std::vector<void*>& io_handles,
                         size_t min_completions) override {
     return target_->Poll(io_handles, min_completions);
+  }
+
+  virtual IOStatus AbortIO(std::vector<void*>& io_handles) override {
+    return target_->AbortIO(io_handles);
   }
 
  protected:


### PR DESCRIPTION
Summary: Add experimental new API AbortIO in FileSystem to abort the
read requests submitted asynchronously through ReadAsync API.

Test Plan: Existing tests

Reviewers:

Subscribers:

Tasks:

Tags: