### PR TITLE
fix clang-analyze in corruption_test

### DIFF
--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -354,6 +354,7 @@ TEST_F(CorruptionTest, PostPITRCorruptionWALsRetained) {
     options_.create_missing_column_families = true;
     std::vector<ColumnFamilyHandle*> cfhs;
     ASSERT_OK(DB::Open(options_, dbname_, cf_descs, &cfhs, &db_));
+    assert(db_ != nullptr);  // suppress false clang-analyze report
 
     ASSERT_OK(db_->Put(WriteOptions(), cfhs[0], "k", "v"));
     ASSERT_OK(db_->Put(WriteOptions(), cfhs[1], "k", "v"));
@@ -375,6 +376,8 @@ TEST_F(CorruptionTest, PostPITRCorruptionWALsRetained) {
     options_.avoid_flush_during_recovery = true;
     std::vector<ColumnFamilyHandle*> cfhs;
     ASSERT_OK(DB::Open(options_, dbname_, cf_descs, &cfhs, &db_));
+    assert(db_ != nullptr);  // suppress false clang-analyze report
+
     // Flush one but not both CFs and write some data so there's a seqno gap
     // between the PITR corruption and the next DB session's first WAL.
     ASSERT_OK(db_->Put(WriteOptions(), cfhs[1], "k2", "v2"));
@@ -391,6 +394,7 @@ TEST_F(CorruptionTest, PostPITRCorruptionWALsRetained) {
   for (int i = 0; i < 2; ++i) {
     std::vector<ColumnFamilyHandle*> cfhs;
     ASSERT_OK(DB::Open(options_, dbname_, cf_descs, &cfhs, &db_));
+    assert(db_ != nullptr);  // suppress false clang-analyze report
 
     for (auto* cfh : cfhs) {
       delete cfh;


### PR DESCRIPTION
This PR fixes a clang-analyze error that I introduced in #9906:

```
db/corruption_test.cc:358:15: warning: Called C++ object pointer is null
    ASSERT_OK(db_->Put(WriteOptions(), cfhs[0], "k", "v"));
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./test_util/testharness.h:76:62: note: expanded from macro 'ASSERT_OK'
  ASSERT_PRED_FORMAT1(ROCKSDB_NAMESPACE::test::AssertStatus, s)
                                                             ^
third-party/gtest-1.8.1/fused-src/gtest/gtest.h:19909:36: note: expanded
from macro 'ASSERT_PRED_FORMAT1'
  GTEST_PRED_FORMAT1_(pred_format, v1, GTEST_FATAL_FAILURE_)
                                   ^~
third-party/gtest-1.8.1/fused-src/gtest/gtest.h:19892:34: note: expanded
from macro 'GTEST_PRED_FORMAT1_'
  GTEST_ASSERT_(pred_format(#v1, v1), \
                                 ^~
third-party/gtest-1.8.1/fused-src/gtest/gtest.h:19868:52: note: expanded
from macro 'GTEST_ASSERT_'
  if (const ::testing::AssertionResult gtest_ar = (expression)) \
                                                   ^~~~~~~~~~
1 warning generated.
```