### PR TITLE
Add wide column serialization primitives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,7 @@ set(SOURCES
         db/version_set.cc
         db/wal_edit.cc
         db/wal_manager.cc
+        db/wide/wide_column_serialization.cc
         db/write_batch.cc
         db/write_batch_base.cc
         db/write_controller.cc
@@ -1290,6 +1291,7 @@ if(WITH_TESTS)
         db/version_set_test.cc
         db/wal_manager_test.cc
         db/wal_edit_test.cc
+        db/wide/wide_column_serialization_test.cc
         db/write_batch_test.cc
         db/write_callback_test.cc
         db/write_controller_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1902,6 +1902,10 @@ db_basic_bench: $(OBJ_DIR)/microbench/db_basic_bench.o $(LIBRARY)
 
 cache_reservation_manager_test: $(OBJ_DIR)/cache/cache_reservation_manager_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
+
+wide_column_serialization_test: $(OBJ_DIR)/db/wide/wide_column_serialization_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 #-------------------------------------------------
 # make install related stuff
 PREFIX ?= /usr/local

--- a/TARGETS
+++ b/TARGETS
@@ -91,6 +91,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "db/version_set.cc",
         "db/wal_edit.cc",
         "db/wal_manager.cc",
+        "db/wide/wide_column_serialization.cc",
         "db/write_batch.cc",
         "db/write_batch_base.cc",
         "db/write_controller.cc",
@@ -419,6 +420,7 @@ cpp_library_wrapper(name="rocksdb_whole_archive_lib", srcs=[
         "db/version_set.cc",
         "db/wal_edit.cc",
         "db/wal_manager.cc",
+        "db/wide/wide_column_serialization.cc",
         "db/write_batch.cc",
         "db/write_batch_base.cc",
         "db/write_controller.cc",
@@ -5810,6 +5812,12 @@ cpp_unittest_wrapper(name="version_set_test",
 
 cpp_unittest_wrapper(name="wal_manager_test",
             srcs=["db/wal_manager_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
+cpp_unittest_wrapper(name="wide_column_serialization_test",
+            srcs=["db/wide/wide_column_serialization_test.cc"],
             deps=[":rocksdb_test_lib"],
             extra_compiler_flags=[])
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cassert>
 
+#include "util/autovector.h"
 #include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -103,7 +104,8 @@ Status WideColumnSerialization::DeserializeIndex(
     return Status::OK();
   }
 
-  std::vector<std::pair<uint32_t, uint32_t>> column_sizes;
+  constexpr size_t preallocated_columns = 64;
+  autovector<std::pair<uint32_t, uint32_t>, preallocated_columns> column_sizes;
   column_sizes.reserve(num_columns);
 
   for (uint32_t i = 0; i < num_columns; ++i) {

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -1,4 +1,4 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -45,12 +45,9 @@ Status WideColumnSerialization::Serialize(const ColumnDescs& column_descs,
 Status WideColumnSerialization::DeserializeOne(Slice* input,
                                                const Slice& column_name,
                                                ColumnDesc* column_desc) {
-  assert(input);
-  assert(column_desc);
-
   ColumnDescs all_column_descs;
 
-  const Status s = DeserializeAll(input, &all_column_descs);
+  const Status s = DeserializeIndex(input, &all_column_descs);
   if (!s.ok()) {
     return s;
   }
@@ -70,7 +67,12 @@ Status WideColumnSerialization::DeserializeOne(Slice* input,
 }
 
 Status WideColumnSerialization::DeserializeAll(Slice* input,
-                                            ColumnDescs* column_descs) {
+                                               ColumnDescs* column_descs) {
+  return DeserializeIndex(input, column_descs);
+}
+
+Status WideColumnSerialization::DeserializeIndex(Slice* input,
+                                                 ColumnDescs* column_descs) {
   assert(input);
   assert(column_descs);
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -14,11 +14,12 @@ namespace ROCKSDB_NAMESPACE {
 
 Status WideColumnSerialization::Serialize(const WideColumnDescs& column_descs,
                                           std::string* output) {
-  assert(
-      std::is_sorted(column_descs.cbegin(), column_descs.cend(),
-                     [](const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
-                       return lhs.name.compare(rhs.name) < 0;
-                     }));
+  // Column names should be strictly ascending
+  assert(std::adjacent_find(
+             column_descs.cbegin(), column_descs.cend(),
+             [](const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
+               return lhs.name.compare(rhs.name) > 0;
+             }) == column_descs.cend());
   assert(output);
 
   PutVarint32(output, kCurrentVersion);

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -85,6 +85,7 @@ Status WideColumnSerialization::DeserializeIndex(
     Slice* input, WideColumnDescs* column_descs) {
   assert(input);
   assert(column_descs);
+  assert(column_descs->empty());
 
   uint32_t version = 0;
   if (!GetVarint32(input, &version)) {
@@ -121,6 +122,8 @@ Status WideColumnSerialization::DeserializeIndex(
 
     column_sizes.emplace_back(name_size, value_size);
   }
+
+  column_descs->reserve(num_columns);
 
   const Slice data(*input);
   size_t pos = 0;

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -23,19 +23,16 @@ Status WideColumnSerialization::Serialize(const ColumnDescs& column_descs,
 
   uint32_t pos = sizeof(uint16_t) + column_descs.size() * 3 * sizeof(uint32_t);
 
-  for (const auto& column_desc : column_descs) {
+  for (const auto& [column_name, column_value] : column_descs) {
     PutFixed32(output, pos);
-    PutFixed32(output, column_desc.first.size());
-    PutFixed32(output, column_desc.second.size());
+    PutFixed32(output, column_name.size());
+    PutFixed32(output, column_value.size());
 
-    pos += column_desc.first.size() + column_desc.second.size();
+    pos += column_name.size() + column_value.size();
   }
 
-  for (const auto& column_desc : column_descs) {
-    const auto& column_name = column_desc.first;
+  for (const auto& [column_name, column_value] : column_descs) {
     output->append(column_name.data(), column_name.size());
-
-    const auto& column_value = column_desc.second;
     output->append(column_value.data(), column_value.size());
   }
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -17,7 +17,7 @@ Status WideColumnSerialization::Serialize(const WideColumnDescs& column_descs,
   assert(
       std::is_sorted(column_descs.cbegin(), column_descs.cend(),
                      [](const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
-                       return lhs.first.compare(rhs.first) < 0;
+                       return lhs.name.compare(rhs.name) < 0;
                      }));
   assert(output);
 
@@ -57,9 +57,9 @@ Status WideColumnSerialization::DeserializeOne(Slice* input,
   auto it = std::lower_bound(all_column_descs.cbegin(), all_column_descs.cend(),
                              column_name,
                              [](const WideColumnDesc& lhs, const Slice& rhs) {
-                               return lhs.first.compare(rhs) < 0;
+                               return lhs.name.compare(rhs) < 0;
                              });
-  if (it == all_column_descs.end() || it->first != column_name) {
+  if (it == all_column_descs.end() || it->name != column_name) {
     return Status::NotFound("Wide column not found");
   }
 
@@ -124,7 +124,7 @@ Status WideColumnSerialization::DeserializeIndex(
     Slice column_name(data.data() + pos, name_size);
 
     if (!column_descs->empty() &&
-        column_descs->back().first.compare(column_name) >= 0) {
+        column_descs->back().name.compare(column_name) >= 0) {
       return Status::Corruption("Wide columns out of order");
     }
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <limits>
 
+#include "rocksdb/slice.h"
 #include "util/autovector.h"
 #include "util/coding.h"
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -82,7 +82,7 @@ Status WideColumnSerialization::Deserialize(Slice& input,
 
   columns.reserve(num_columns);
 
-  autovector<uint32_t, 64> column_value_sizes;
+  autovector<uint32_t, 16> column_value_sizes;
   column_value_sizes.reserve(num_columns);
 
   for (uint32_t i = 0; i < num_columns; ++i) {

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -14,6 +14,11 @@ namespace ROCKSDB_NAMESPACE {
 
 Status WideColumnSerialization::Serialize(const WideColumnDescs& column_descs,
                                           std::string* output) {
+  assert(
+      std::is_sorted(column_descs.cbegin(), column_descs.cend(),
+                     [](const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
+                       return lhs.first.compare(rhs.first) < 0;
+                     }));
   assert(output);
 
   PutVarint32(output, static_cast<uint32_t>(column_descs.size()));

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -1,0 +1,101 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/wide/wide_column_serialization.h"
+
+#include <bits/stdint-uintn.h>
+
+#include <algorithm>
+#include <cassert>
+#include <string>
+
+#include "util/coding.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+Status WideColumnSerialization::Serialize(const ColumnDescs& column_descs,
+                                          std::string* output) {
+  assert(output);
+
+  PutFixed16(output, column_descs.size());
+
+  uint32_t pos = sizeof(uint16_t) + column_descs.size() * 2 * sizeof(uint32_t);
+
+  for (const auto& column_desc : column_descs) {
+    PutFixed32(output, pos);
+    pos += column_desc.first.size();
+
+    PutFixed32(output, pos);
+    pos += column_desc.second.size();
+  }
+
+  for (const auto& column_desc : column_descs) {
+    const auto& column_name = column_desc.first;
+    output->append(column_name.data(), column_name.size());
+
+    const auto& column_value = column_desc.second;
+    output->append(column_value.data(), column_value.size());
+  }
+
+  return Status::OK();
+}
+
+Status WideColumnSerialization::Deserialize(Slice* input,
+                                            ColumnDescs* column_descs) {
+  assert(input);
+  assert(column_descs);
+
+  const Slice orig_input(*input);
+
+  uint16_t num_columns = 0;
+  if (!GetFixed16(input, &num_columns)) {
+    return Status::Corruption("Error decoding number of columns");
+  }
+
+  if (!num_columns) {
+    return Status::OK();
+  }
+
+  uint32_t name_pos = 0;
+  if (!GetFixed32(input, &name_pos)) {
+    return Status::Corruption("Error decoding column name position");
+  }
+
+  for (uint16_t i = 0; i < num_columns; ++i) {
+    uint32_t value_pos = 0;
+    if (!GetFixed32(input, &value_pos)) {
+      return Status::Corruption("Error decoding column value position");
+    }
+
+    if (value_pos < name_pos) {
+      return Status::Corruption("Invalid name/value position");
+    }
+
+    uint32_t next_name_pos = 0;
+    if (i < num_columns - 1) {
+      if (!GetFixed32(input, &next_name_pos)) {
+        return Status::Corruption("Error decoding column name position");
+      }
+    } else {
+      next_name_pos = orig_input.size();
+    }
+
+    if (next_name_pos < value_pos) {
+      return Status::Corruption("Invalid name/value position");
+    }
+
+    Slice column_name(orig_input.data() + name_pos, value_pos - name_pos);
+    Slice column_value(orig_input.data() + value_pos,
+                       next_name_pos - value_pos);
+
+    column_descs->emplace_back(column_name, column_value);
+
+    name_pos = next_name_pos;
+  }
+
+  return Status::OK();
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -7,8 +7,8 @@
 
 #include <algorithm>
 #include <cassert>
+#include <limits>
 
-#include "port/port.h"
 #include "util/autovector.h"
 #include "util/coding.h"
 
@@ -24,7 +24,8 @@ Status WideColumnSerialization::Serialize(const WideColumnDescs& column_descs,
              }) == column_descs.cend());
   assert(output);
 
-  if (column_descs.size() > static_cast<size_t>(port::kMaxUint32)) {
+  if (column_descs.size() >
+      static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
     return Status::InvalidArgument("Too many wide columns");
   }
 
@@ -36,12 +37,14 @@ Status WideColumnSerialization::Serialize(const WideColumnDescs& column_descs,
 
   for (const auto& desc : column_descs) {
     const Slice& name = desc.name();
-    if (name.size() > static_cast<size_t>(port::kMaxUint32)) {
+    if (name.size() >
+        static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
       return Status::InvalidArgument("Wide column name too long");
     }
 
     const Slice& value = desc.value();
-    if (value.size() > static_cast<size_t>(port::kMaxUint32)) {
+    if (value.size() >
+        static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
       return Status::InvalidArgument("Wide column value too long");
     }
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -32,8 +32,6 @@ Status WideColumnSerialization::Serialize(const WideColumns& columns,
 
   PutVarint32(&output, static_cast<uint32_t>(columns.size()));
 
-  size_t total_column_value_size = 0;
-
   for (const auto& column : columns) {
     const Slice& name = column.name();
     if (name.size() >
@@ -49,11 +47,7 @@ Status WideColumnSerialization::Serialize(const WideColumns& columns,
 
     PutLengthPrefixedSlice(&output, name);
     PutVarint32(&output, static_cast<uint32_t>(value.size()));
-
-    total_column_value_size += value.size();
   }
-
-  output.reserve(output.size() + total_column_value_size);
 
   for (const auto& column : columns) {
     const Slice& value = column.value();

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cassert>
 
+#include "port/port.h"
 #include "util/autovector.h"
 #include "util/coding.h"
 
@@ -22,6 +23,10 @@ Status WideColumnSerialization::Serialize(const WideColumnDescs& column_descs,
                return lhs.name().compare(rhs.name()) > 0;
              }) == column_descs.cend());
   assert(output);
+
+  if (column_descs.size() > static_cast<size_t>(port::kMaxUint32)) {
+    return Status::InvalidArgument("Too many wide columns");
+  }
 
   PutVarint32(output, kCurrentVersion);
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -69,7 +69,7 @@ Status WideColumnSerialization::DeserializeOne(Slice& input,
                                                WideColumnDesc& column_desc) {
   WideColumnDescs all_column_descs;
 
-  const Status s = DeserializeIndex(input, all_column_descs);
+  const Status s = Deserialize(input, all_column_descs);
   if (!s.ok()) {
     return s;
   }
@@ -88,13 +88,8 @@ Status WideColumnSerialization::DeserializeOne(Slice& input,
   return Status::OK();
 }
 
-Status WideColumnSerialization::DeserializeAll(Slice& input,
-                                               WideColumnDescs& column_descs) {
-  return DeserializeIndex(input, column_descs);
-}
-
-Status WideColumnSerialization::DeserializeIndex(
-    Slice& input, WideColumnDescs& column_descs) {
+Status WideColumnSerialization::Deserialize(Slice& input,
+                                            WideColumnDescs& column_descs) {
   assert(column_descs.empty());
 
   uint32_t version = 0;

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -85,7 +85,7 @@ Status WideColumnSerialization::DeserializeIndex(
   }
 
   if (version > kCurrentVersion) {
-    return Status::Corruption("Unsupported wide column version");
+    return Status::NotSupported("Unsupported wide column version");
   }
 
   uint32_t num_columns = 0;

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -5,11 +5,8 @@
 
 #include "db/wide/wide_column_serialization.h"
 
-#include <bits/stdint-uintn.h>
-
 #include <algorithm>
 #include <cassert>
-#include <string>
 
 #include "util/coding.h"
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -141,7 +141,7 @@ Status WideColumnSerialization::DeserializeIndex(
     const uint32_t value_size = column_value_sizes[i];
 
     if (pos + value_size > data.size()) {
-      return Status::Corruption("Error decoding wide column value");
+      return Status::Corruption("Error decoding wide column value payload");
     }
 
     (*column_descs)[i].value() = Slice(data.data() + pos, value_size);

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -36,7 +36,14 @@ Status WideColumnSerialization::Serialize(const WideColumnDescs& column_descs,
 
   for (const auto& desc : column_descs) {
     const Slice& name = desc.name();
+    if (name.size() > static_cast<size_t>(port::kMaxUint32)) {
+      return Status::InvalidArgument("Wide column name too long");
+    }
+
     const Slice& value = desc.value();
+    if (value.size() > static_cast<size_t>(port::kMaxUint32)) {
+      return Status::InvalidArgument("Wide column value too long");
+    }
 
     PutLengthPrefixedSlice(output, name);
     PutVarint32(output, static_cast<uint32_t>(value.size()));

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -15,7 +15,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-Status WideColumnSerialization::Serialize(const ColumnDescs& column_descs,
+Status WideColumnSerialization::Serialize(const WideColumnDescs& column_descs,
                                           std::string* output) {
   assert(output);
 
@@ -41,8 +41,8 @@ Status WideColumnSerialization::Serialize(const ColumnDescs& column_descs,
 
 Status WideColumnSerialization::DeserializeOne(Slice* input,
                                                const Slice& column_name,
-                                               ColumnDesc* column_desc) {
-  ColumnDescs all_column_descs;
+                                               WideColumnDesc* column_desc) {
+  WideColumnDescs all_column_descs;
 
   const Status s = DeserializeIndex(input, &all_column_descs);
   if (!s.ok()) {
@@ -51,7 +51,7 @@ Status WideColumnSerialization::DeserializeOne(Slice* input,
 
   auto it = std::lower_bound(all_column_descs.cbegin(), all_column_descs.cend(),
                              column_name,
-                             [](const ColumnDesc& lhs, const Slice& rhs) {
+                             [](const WideColumnDesc& lhs, const Slice& rhs) {
                                return lhs.first.compare(rhs) < 0;
                              });
   if (it == all_column_descs.end() || it->first != column_name) {
@@ -64,12 +64,12 @@ Status WideColumnSerialization::DeserializeOne(Slice* input,
 }
 
 Status WideColumnSerialization::DeserializeAll(Slice* input,
-                                               ColumnDescs* column_descs) {
+                                               WideColumnDescs* column_descs) {
   return DeserializeIndex(input, column_descs);
 }
 
-Status WideColumnSerialization::DeserializeIndex(Slice* input,
-                                                 ColumnDescs* column_descs) {
+Status WideColumnSerialization::DeserializeIndex(
+    Slice* input, WideColumnDescs* column_descs) {
   assert(input);
   assert(column_descs);
 

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -17,35 +17,35 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-class WideColumnDesc {
+class WideColumn {
  public:
-  WideColumnDesc() = default;
+  WideColumn() = default;
 
-  // Initializes a WideColumnDesc object by forwarding the name and value
+  // Initializes a WideColumn object by forwarding the name and value
   // arguments to the corresponding member Slices. This makes it possible to
-  // construct a WideColumnDesc using combinations of const char*, const
+  // construct a WideColumn using combinations of const char*, const
   // std::string&, const Slice& etc., for example:
   //
   // constexpr char foo[] = "foo";
   // const std::string bar("bar");
-  // WideColumnDesc desc(foo, bar);
+  // WideColumn column(foo, bar);
   template <typename N, typename V>
-  WideColumnDesc(N&& name, V&& value)
+  WideColumn(N&& name, V&& value)
       : name_(std::forward<N>(name)), value_(std::forward<V>(value)) {}
 
-  // Initializes a WideColumnDesc object by forwarding the elements of
+  // Initializes a WideColumn object by forwarding the elements of
   // name_tuple and value_tuple to the constructors of the corresponding member
   // Slices. This makes it possible to initialize the Slices using the Slice
   // constructors that take more than one argument, for example:
   //
   // constexpr char foo_name[] = "foo_name";
   // constexpr char bar_value[] = "bar_value";
-  // WideColumnDesc desc(std::piecewise_construct,
-  //                     std::forward_as_tuple(foo_name, 3),
-  //                     std::forward_as_tuple(bar_value, 3));
+  // WideColumn column(std::piecewise_construct,
+  //                   std::forward_as_tuple(foo_name, 3),
+  //                   std::forward_as_tuple(bar_value, 3));
   template <typename NTuple, typename VTuple>
-  WideColumnDesc(std::piecewise_construct_t, NTuple&& name_tuple,
-                 VTuple&& value_tuple)
+  WideColumn(std::piecewise_construct_t, NTuple&& name_tuple,
+             VTuple&& value_tuple)
       : name_(std::make_from_tuple<Slice>(std::forward<NTuple>(name_tuple))),
         value_(std::make_from_tuple<Slice>(std::forward<VTuple>(value_tuple))) {
   }
@@ -62,28 +62,27 @@ class WideColumnDesc {
 };
 
 // Note: column names and values are compared bytewise.
-bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs);
-bool operator!=(const WideColumnDesc& lhs, const WideColumnDesc& rhs);
+bool operator==(const WideColumn& lhs, const WideColumn& rhs);
+bool operator!=(const WideColumn& lhs, const WideColumn& rhs);
 
-using WideColumnDescs = std::vector<WideColumnDesc>;
+using WideColumns = std::vector<WideColumn>;
 
 class WideColumnSerialization {
  public:
-  static Status Serialize(const WideColumnDescs& column_descs,
-                          std::string& output);
-  static Status Deserialize(Slice& input, WideColumnDescs& column_descs);
+  static Status Serialize(const WideColumns& columns, std::string& output);
+  static Status Deserialize(Slice& input, WideColumns& columns);
 
-  static WideColumnDescs::const_iterator Find(
-      const WideColumnDescs& column_descs, const Slice& column_name);
+  static WideColumns::const_iterator Find(const WideColumns& columns,
+                                          const Slice& column_name);
 
   static constexpr uint32_t kCurrentVersion = 1;
 };
 
-inline bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
+inline bool operator==(const WideColumn& lhs, const WideColumn& rhs) {
   return lhs.name() == rhs.name() && lhs.value() == rhs.value();
 }
 
-inline bool operator!=(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
+inline bool operator!=(const WideColumn& lhs, const WideColumn& rhs) {
   return !(lhs == rhs);
 }
 

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -40,10 +40,10 @@ class WideColumnSerialization {
                                WideColumnDesc* column_desc);
   static Status DeserializeAll(Slice* input, WideColumnDescs* column_descs);
 
+  static constexpr uint32_t kCurrentVersion = 1;
+
  private:
   static Status DeserializeIndex(Slice* input, WideColumnDescs* column_descs);
-
-  static constexpr uint32_t kCurrentVersion = 1;
 };
 
 inline bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -22,7 +22,9 @@ class WideColumnSerialization {
   using ColumnDescs = std::vector<ColumnDesc>;
 
   static Status Serialize(const ColumnDescs& column_descs, std::string* output);
-  static Status Deserialize(Slice* input, ColumnDescs* column_descs);
+  static Status DeserializeOne(Slice* input, const Slice& column_name,
+                               ColumnDesc* column_desc);
+  static Status DeserializeAll(Slice* input, ColumnDescs* column_descs);
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -1,4 +1,4 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -10,11 +10,10 @@
 #include <vector>
 
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
-
-class Slice;
 
 class WideColumnDesc {
  public:

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -11,6 +11,7 @@
 
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/status.h"
+#include "rocksdb/types.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -18,16 +19,14 @@ class Slice;
 
 class WideColumnSerialization {
  public:
-  using ColumnDesc = std::pair<Slice, Slice>;
-  using ColumnDescs = std::vector<ColumnDesc>;
-
-  static Status Serialize(const ColumnDescs& column_descs, std::string* output);
+  static Status Serialize(const WideColumnDescs& column_descs,
+                          std::string* output);
   static Status DeserializeOne(Slice* input, const Slice& column_name,
-                               ColumnDesc* column_desc);
-  static Status DeserializeAll(Slice* input, ColumnDescs* column_descs);
+                               WideColumnDesc* column_desc);
+  static Status DeserializeAll(Slice* input, WideColumnDescs* column_descs);
 
  private:
-  static Status DeserializeIndex(Slice* input, ColumnDescs* column_descs);
+  static Status DeserializeIndex(Slice* input, WideColumnDescs* column_descs);
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -7,14 +7,30 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/status.h"
-#include "rocksdb/types.h"
 
 namespace ROCKSDB_NAMESPACE {
 
 class Slice;
+
+struct WideColumnDesc {
+  WideColumnDesc() = default;
+
+  template <typename N, typename V>
+  WideColumnDesc(N&& n, V&& v)
+      : name(std::forward<N>(n)), value(std::forward<V>(v)) {}
+
+  Slice name;
+  Slice value;
+};
+
+bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs);
+bool operator!=(const WideColumnDesc& lhs, const WideColumnDesc& rhs);
+
+using WideColumnDescs = std::vector<WideColumnDesc>;
 
 class WideColumnSerialization {
  public:
@@ -29,5 +45,13 @@ class WideColumnSerialization {
 
   static constexpr uint32_t kCurrentVersion = 1;
 };
+
+inline bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
+  return lhs.name == rhs.name && lhs.value == rhs.value;
+}
+
+inline bool operator!=(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
+  return !(lhs == rhs);
+}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -7,6 +7,8 @@
 
 #include <cstdint>
 #include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "rocksdb/rocksdb_namespace.h"
@@ -22,6 +24,13 @@ class WideColumnDesc {
   template <typename N, typename V>
   WideColumnDesc(N&& name, V&& value)
       : name_(std::forward<N>(name)), value_(std::forward<V>(value)) {}
+
+  template <typename NTuple, typename VTuple>
+  WideColumnDesc(std::piecewise_construct_t, NTuple&& name_tuple,
+                 VTuple&& value_tuple)
+      : name_(std::make_from_tuple<Slice>(std::forward<NTuple>(name_tuple))),
+        value_(std::make_from_tuple<Slice>(std::forward<VTuple>(value_tuple))) {
+  }
 
   const Slice& name() const { return name_; }
   const Slice& value() const { return value_; }

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -42,7 +42,7 @@ using WideColumnDescs = std::vector<WideColumnDesc>;
 class WideColumnSerialization {
  public:
   static Status Serialize(const WideColumnDescs& column_descs,
-                          std::string* output);
+                          std::string& output);
   static Status DeserializeOne(Slice* input, const Slice& column_name,
                                WideColumnDesc* column_desc);
   static Status DeserializeAll(Slice* input, WideColumnDescs* column_descs);

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -25,6 +25,9 @@ class WideColumnSerialization {
   static Status DeserializeOne(Slice* input, const Slice& column_name,
                                ColumnDesc* column_desc);
   static Status DeserializeAll(Slice* input, ColumnDescs* column_descs);
+
+ private:
+  static Status DeserializeIndex(Slice* input, ColumnDescs* column_descs);
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -16,15 +16,20 @@ namespace ROCKSDB_NAMESPACE {
 
 class Slice;
 
-struct WideColumnDesc {
+class WideColumnDesc {
+ public:
   WideColumnDesc() = default;
 
   template <typename N, typename V>
-  WideColumnDesc(N&& n, V&& v)
-      : name(std::forward<N>(n)), value(std::forward<V>(v)) {}
+  WideColumnDesc(N&& name, V&& value)
+      : name_(std::forward<N>(name)), value_(std::forward<V>(value)) {}
 
-  Slice name;
-  Slice value;
+  const Slice& name() const { return name_; }
+  const Slice& value() const { return value_; }
+
+ private:
+  Slice name_;
+  Slice value_;
 };
 
 bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs);
@@ -47,7 +52,7 @@ class WideColumnSerialization {
 };
 
 inline bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {
-  return lhs.name == rhs.name && lhs.value == rhs.value;
+  return lhs.name() == rhs.name() && lhs.value() == rhs.value();
 }
 
 inline bool operator!=(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -44,8 +44,9 @@ class WideColumnSerialization {
   static Status Serialize(const WideColumnDescs& column_descs,
                           std::string& output);
   static Status Deserialize(Slice& input, WideColumnDescs& column_descs);
-  static Status DeserializeOne(Slice& input, const Slice& column_name,
-                               WideColumnDesc& column_desc);
+
+  static WideColumnDescs::const_iterator Find(
+      const WideColumnDescs& column_descs, const Slice& column_name);
 
   static constexpr uint32_t kCurrentVersion = 1;
 };

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -43,14 +43,11 @@ class WideColumnSerialization {
  public:
   static Status Serialize(const WideColumnDescs& column_descs,
                           std::string& output);
+  static Status Deserialize(Slice& input, WideColumnDescs& column_descs);
   static Status DeserializeOne(Slice& input, const Slice& column_name,
                                WideColumnDesc& column_desc);
-  static Status DeserializeAll(Slice& input, WideColumnDescs& column_descs);
 
   static constexpr uint32_t kCurrentVersion = 1;
-
- private:
-  static Status DeserializeIndex(Slice& input, WideColumnDescs& column_descs);
 };
 
 inline bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -21,10 +21,28 @@ class WideColumnDesc {
  public:
   WideColumnDesc() = default;
 
+  // Initializes a WideColumnDesc object by forwarding the name and value
+  // arguments to the corresponding member Slices. This makes it possible to
+  // construct a WideColumnDesc using combinations of const char*, const
+  // std::string&, const Slice& etc., for example:
+  //
+  // constexpr char foo[] = "foo";
+  // const std::string bar("bar");
+  // WideColumnDesc desc(foo, bar);
   template <typename N, typename V>
   WideColumnDesc(N&& name, V&& value)
       : name_(std::forward<N>(name)), value_(std::forward<V>(value)) {}
 
+  // Initializes a WideColumnDesc object by forwarding the elements of
+  // name_tuple and value_tuple to the constructors of the corresponding member
+  // Slices. This makes it possible to initialize the Slices using the Slice
+  // constructors that take more than one argument, for example:
+  //
+  // constexpr char foo_name[] = "foo_name";
+  // constexpr char bar_value[] = "bar_value";
+  // WideColumnDesc desc(std::piecewise_construct,
+  //                     std::forward_as_tuple(foo_name, 3),
+  //                     std::forward_as_tuple(bar_value, 3));
   template <typename NTuple, typename VTuple>
   WideColumnDesc(std::piecewise_construct_t, NTuple&& name_tuple,
                  VTuple&& value_tuple)

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -26,6 +26,9 @@ class WideColumnDesc {
   const Slice& name() const { return name_; }
   const Slice& value() const { return value_; }
 
+  Slice& name() { return name_; }
+  Slice& value() { return value_; }
+
  private:
   Slice name_;
   Slice value_;

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "rocksdb/rocksdb_namespace.h"
@@ -25,6 +26,8 @@ class WideColumnSerialization {
 
  private:
   static Status DeserializeIndex(Slice* input, WideColumnDescs* column_descs);
+
+  static constexpr uint32_t kCurrentVersion = 1;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -7,65 +7,14 @@
 
 #include <cstdint>
 #include <string>
-#include <tuple>
-#include <utility>
-#include <vector>
 
 #include "rocksdb/rocksdb_namespace.h"
-#include "rocksdb/slice.h"
 #include "rocksdb/status.h"
+#include "rocksdb/wide_columns.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-class WideColumn {
- public:
-  WideColumn() = default;
-
-  // Initializes a WideColumn object by forwarding the name and value
-  // arguments to the corresponding member Slices. This makes it possible to
-  // construct a WideColumn using combinations of const char*, const
-  // std::string&, const Slice& etc., for example:
-  //
-  // constexpr char foo[] = "foo";
-  // const std::string bar("bar");
-  // WideColumn column(foo, bar);
-  template <typename N, typename V>
-  WideColumn(N&& name, V&& value)
-      : name_(std::forward<N>(name)), value_(std::forward<V>(value)) {}
-
-  // Initializes a WideColumn object by forwarding the elements of
-  // name_tuple and value_tuple to the constructors of the corresponding member
-  // Slices. This makes it possible to initialize the Slices using the Slice
-  // constructors that take more than one argument, for example:
-  //
-  // constexpr char foo_name[] = "foo_name";
-  // constexpr char bar_value[] = "bar_value";
-  // WideColumn column(std::piecewise_construct,
-  //                   std::forward_as_tuple(foo_name, 3),
-  //                   std::forward_as_tuple(bar_value, 3));
-  template <typename NTuple, typename VTuple>
-  WideColumn(std::piecewise_construct_t, NTuple&& name_tuple,
-             VTuple&& value_tuple)
-      : name_(std::make_from_tuple<Slice>(std::forward<NTuple>(name_tuple))),
-        value_(std::make_from_tuple<Slice>(std::forward<VTuple>(value_tuple))) {
-  }
-
-  const Slice& name() const { return name_; }
-  const Slice& value() const { return value_; }
-
-  Slice& name() { return name_; }
-  Slice& value() { return value_; }
-
- private:
-  Slice name_;
-  Slice value_;
-};
-
-// Note: column names and values are compared bytewise.
-bool operator==(const WideColumn& lhs, const WideColumn& rhs);
-bool operator!=(const WideColumn& lhs, const WideColumn& rhs);
-
-using WideColumns = std::vector<WideColumn>;
+class Slice;
 
 class WideColumnSerialization {
  public:
@@ -77,13 +26,5 @@ class WideColumnSerialization {
 
   static constexpr uint32_t kCurrentVersion = 1;
 };
-
-inline bool operator==(const WideColumn& lhs, const WideColumn& rhs) {
-  return lhs.name() == rhs.name() && lhs.value() == rhs.value();
-}
-
-inline bool operator!=(const WideColumn& lhs, const WideColumn& rhs) {
-  return !(lhs == rhs);
-}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -43,14 +43,14 @@ class WideColumnSerialization {
  public:
   static Status Serialize(const WideColumnDescs& column_descs,
                           std::string& output);
-  static Status DeserializeOne(Slice* input, const Slice& column_name,
-                               WideColumnDesc* column_desc);
-  static Status DeserializeAll(Slice* input, WideColumnDescs* column_descs);
+  static Status DeserializeOne(Slice& input, const Slice& column_name,
+                               WideColumnDesc& column_desc);
+  static Status DeserializeAll(Slice& input, WideColumnDescs& column_descs);
 
   static constexpr uint32_t kCurrentVersion = 1;
 
  private:
-  static Status DeserializeIndex(Slice* input, WideColumnDescs* column_descs);
+  static Status DeserializeIndex(Slice& input, WideColumnDescs& column_descs);
 };
 
 inline bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs) {

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -1,0 +1,28 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class Slice;
+
+class WideColumnSerialization {
+ public:
+  using ColumnDesc = std::pair<Slice, Slice>;
+  using ColumnDescs = std::vector<ColumnDesc>;
+
+  static Status Serialize(const ColumnDescs& column_descs, std::string* output);
+  static Status Deserialize(Slice* input, ColumnDescs* column_descs);
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -16,6 +16,31 @@ namespace ROCKSDB_NAMESPACE {
 
 class Slice;
 
+// Wide-column serialization/deserialization primitives.
+//
+// The two main parts of the layout are 1) a sorted index containing the column
+// names and column value sizes and 2) the column values themselves. Keeping the
+// index and the values separate will enable selectively reading column values
+// down the line. Note that currently the index has to be fully parsed in order
+// to find out the offset of each column value.
+//
+// Legend: cn = column name, cv = column value, cns = column name size, cvs =
+// column value size.
+//
+//      +----------+--------------+----------+-------+----------+---...
+//      | version  | # of columns |  cns 1   | cn 1  |  cvs 1   |
+//      +----------+--------------+------------------+--------- +---...
+//      | varint32 |   varint32   | varint32 | bytes | varint32 |
+//      +----------+--------------+----------+-------+----------+---...
+//
+//      ... continued ...
+//
+//          ...---+----------+-------+----------+-------+---...---+-------+
+//                |  cns N   | cn N  |  cvs N   | cv 1  |         | cv N  |
+//          ...---+----------+-------+----------+-------+---...---+-------+
+//                | varint32 | bytes | varint32 | bytes |         | bytes |
+//          ...---+----------+-------+----------+-------+---...---+-------+
+
 class WideColumnSerialization {
  public:
   static Status Serialize(const WideColumns& columns, std::string& output);

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -6,8 +6,6 @@
 #pragma once
 
 #include <string>
-#include <utility>
-#include <vector>
 
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/status.h"

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -34,6 +34,7 @@ class WideColumnDesc {
   Slice value_;
 };
 
+// Note: column names and values are compared bytewise.
 bool operator==(const WideColumnDesc& lhs, const WideColumnDesc& rhs);
 bool operator!=(const WideColumnDesc& lhs, const WideColumnDesc& rhs);
 

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -20,8 +20,7 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
     Slice input(output);
     WideColumnDescs deserialized_descs;
 
-    ASSERT_OK(
-        WideColumnSerialization::DeserializeAll(input, deserialized_descs));
+    ASSERT_OK(WideColumnSerialization::Deserialize(input, deserialized_descs));
     ASSERT_EQ(column_descs, deserialized_descs);
   }
 
@@ -64,7 +63,7 @@ TEST(WideColumnSerializationTest, DeserializeVersionError) {
   Slice input(buf);
   WideColumnDescs descs;
 
-  const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+  const Status s = WideColumnSerialization::Deserialize(input, descs);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "version"));
 }
@@ -79,7 +78,7 @@ TEST(WideColumnSerializationTest, DeserializeUnsupportedVersion) {
   Slice input(buf);
   WideColumnDescs descs;
 
-  const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+  const Status s = WideColumnSerialization::Deserialize(input, descs);
   ASSERT_TRUE(s.IsNotSupported());
   ASSERT_TRUE(std::strstr(s.getState(), "version"));
 }
@@ -93,7 +92,7 @@ TEST(WideColumnSerializationTest, DeserializeNumberOfColumnsError) {
   Slice input(buf);
   WideColumnDescs descs;
 
-  const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+  const Status s = WideColumnSerialization::Deserialize(input, descs);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "number"));
 }
@@ -111,7 +110,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "name"));
   }
@@ -124,7 +123,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "value size"));
   }
@@ -137,7 +136,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "name"));
   }
@@ -150,7 +149,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "value size"));
   }
@@ -163,7 +162,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "payload"));
   }
@@ -175,7 +174,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "payload"));
   }
@@ -187,7 +186,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    ASSERT_OK(WideColumnSerialization::DeserializeAll(input, descs));
+    ASSERT_OK(WideColumnSerialization::Deserialize(input, descs));
   }
 }
 
@@ -211,7 +210,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsOutOfOrder) {
   Slice input(buf);
   WideColumnDescs descs;
 
-  const Status s = WideColumnSerialization::DeserializeAll(input, descs);
+  const Status s = WideColumnSerialization::Deserialize(input, descs);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "order"));
 }

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -10,15 +10,14 @@
 namespace ROCKSDB_NAMESPACE {
 
 TEST(WideColumnSerializationTest, Serialize) {
-  WideColumnSerialization::ColumnDescs column_descs{{"foo", "bar"},
-                                                    {"hello", "world"}};
+  WideColumnDescs column_descs{{"foo", "bar"}, {"hello", "world"}};
   std::string output;
 
   ASSERT_OK(WideColumnSerialization::Serialize(column_descs, &output));
 
   {
     Slice input(output);
-    WideColumnSerialization::ColumnDescs deserialized_descs;
+    WideColumnDescs deserialized_descs;
 
     ASSERT_OK(
         WideColumnSerialization::DeserializeAll(&input, &deserialized_descs));
@@ -27,27 +26,25 @@ TEST(WideColumnSerializationTest, Serialize) {
 
   {
     Slice input(output);
-    WideColumnSerialization::ColumnDesc deserialized_desc;
+    WideColumnDesc deserialized_desc;
 
     ASSERT_OK(WideColumnSerialization::DeserializeOne(&input, "foo",
                                                       &deserialized_desc));
-    ASSERT_EQ(deserialized_desc,
-              WideColumnSerialization::ColumnDesc("foo", "bar"));
+    ASSERT_EQ(deserialized_desc, WideColumnDesc("foo", "bar"));
   }
 
   {
     Slice input(output);
-    WideColumnSerialization::ColumnDesc deserialized_desc;
+    WideColumnDesc deserialized_desc;
 
     ASSERT_OK(WideColumnSerialization::DeserializeOne(&input, "hello",
                                                       &deserialized_desc));
-    ASSERT_EQ(deserialized_desc,
-              WideColumnSerialization::ColumnDesc("hello", "world"));
+    ASSERT_EQ(deserialized_desc, WideColumnDesc("hello", "world"));
   }
 
   {
     Slice input(output);
-    WideColumnSerialization::ColumnDesc deserialized_desc;
+    WideColumnDesc deserialized_desc;
 
     ASSERT_NOK(WideColumnSerialization::DeserializeOne(&input, "snafu",
                                                        &deserialized_desc));

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -21,7 +21,7 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
     WideColumnDescs deserialized_descs;
 
     ASSERT_OK(
-        WideColumnSerialization::DeserializeAll(&input, &deserialized_descs));
+        WideColumnSerialization::DeserializeAll(input, deserialized_descs));
     ASSERT_EQ(column_descs, deserialized_descs);
   }
 
@@ -29,8 +29,8 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
     Slice input(output);
     WideColumnDesc deserialized_desc;
 
-    ASSERT_OK(WideColumnSerialization::DeserializeOne(&input, "foo",
-                                                      &deserialized_desc));
+    ASSERT_OK(WideColumnSerialization::DeserializeOne(input, "foo",
+                                                      deserialized_desc));
 
     WideColumnDesc expected_desc{"foo", "bar"};
     ASSERT_EQ(deserialized_desc, expected_desc);
@@ -40,8 +40,8 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
     Slice input(output);
     WideColumnDesc deserialized_desc;
 
-    ASSERT_OK(WideColumnSerialization::DeserializeOne(&input, "hello",
-                                                      &deserialized_desc));
+    ASSERT_OK(WideColumnSerialization::DeserializeOne(input, "hello",
+                                                      deserialized_desc));
 
     WideColumnDesc expected_desc{"hello", "world"};
     ASSERT_EQ(deserialized_desc, expected_desc);
@@ -51,8 +51,8 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
     Slice input(output);
     WideColumnDesc deserialized_desc;
 
-    ASSERT_NOK(WideColumnSerialization::DeserializeOne(&input, "snafu",
-                                                       &deserialized_desc));
+    ASSERT_NOK(WideColumnSerialization::DeserializeOne(input, "snafu",
+                                                       deserialized_desc));
   }
 }
 
@@ -64,7 +64,7 @@ TEST(WideColumnSerializationTest, DeserializeVersionError) {
   Slice input(buf);
   WideColumnDescs descs;
 
-  const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+  const Status s = WideColumnSerialization::DeserializeAll(input, descs);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "version"));
 }
@@ -79,7 +79,7 @@ TEST(WideColumnSerializationTest, DeserializeUnsupportedVersion) {
   Slice input(buf);
   WideColumnDescs descs;
 
-  const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+  const Status s = WideColumnSerialization::DeserializeAll(input, descs);
   ASSERT_TRUE(s.IsNotSupported());
   ASSERT_TRUE(std::strstr(s.getState(), "version"));
 }
@@ -93,7 +93,7 @@ TEST(WideColumnSerializationTest, DeserializeNumberOfColumnsError) {
   Slice input(buf);
   WideColumnDescs descs;
 
-  const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+  const Status s = WideColumnSerialization::DeserializeAll(input, descs);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "number"));
 }
@@ -111,7 +111,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "name"));
   }
@@ -124,7 +124,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "value size"));
   }
@@ -137,7 +137,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "name"));
   }
@@ -150,7 +150,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "value size"));
   }
@@ -163,7 +163,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "payload"));
   }
@@ -175,7 +175,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    const Status s = WideColumnSerialization::DeserializeAll(input, descs);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "payload"));
   }
@@ -187,7 +187,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
     Slice input(buf);
     WideColumnDescs descs;
 
-    ASSERT_OK(WideColumnSerialization::DeserializeAll(&input, &descs));
+    ASSERT_OK(WideColumnSerialization::DeserializeAll(input, descs));
   }
 }
 
@@ -211,7 +211,7 @@ TEST(WideColumnSerializationTest, DeserializeColumnsOutOfOrder) {
   Slice input(buf);
   WideColumnDescs descs;
 
-  const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+  const Status s = WideColumnSerialization::DeserializeAll(input, descs);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "order"));
 }

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -1,4 +1,4 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -10,6 +10,78 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+TEST(WideColumnSerializationTest, Construct) {
+  constexpr char foo[] = "foo";
+  constexpr char bar[] = "bar";
+
+  const std::string foo_str(foo);
+  const std::string bar_str(bar);
+
+  const Slice foo_slice(foo_str);
+  const Slice bar_slice(bar_str);
+
+  {
+    WideColumnDesc desc(foo, bar);
+    ASSERT_EQ(desc.name(), foo);
+    ASSERT_EQ(desc.value(), bar);
+  }
+
+  {
+    WideColumnDesc desc(foo_str, bar);
+    ASSERT_EQ(desc.name(), foo_str);
+    ASSERT_EQ(desc.value(), bar);
+  }
+
+  {
+    WideColumnDesc desc(foo_slice, bar);
+    ASSERT_EQ(desc.name(), foo_slice);
+    ASSERT_EQ(desc.value(), bar);
+  }
+
+  {
+    WideColumnDesc desc(foo, bar_str);
+    ASSERT_EQ(desc.name(), foo);
+    ASSERT_EQ(desc.value(), bar_str);
+  }
+
+  {
+    WideColumnDesc desc(foo_str, bar_str);
+    ASSERT_EQ(desc.name(), foo_str);
+    ASSERT_EQ(desc.value(), bar_str);
+  }
+
+  {
+    WideColumnDesc desc(foo_slice, bar_str);
+    ASSERT_EQ(desc.name(), foo_slice);
+    ASSERT_EQ(desc.value(), bar_str);
+  }
+
+  {
+    WideColumnDesc desc(foo, bar_slice);
+    ASSERT_EQ(desc.name(), foo);
+    ASSERT_EQ(desc.value(), bar_slice);
+  }
+
+  {
+    WideColumnDesc desc(foo_str, bar_slice);
+    ASSERT_EQ(desc.name(), foo_str);
+    ASSERT_EQ(desc.value(), bar_slice);
+  }
+
+  {
+    WideColumnDesc desc(foo_slice, bar_slice);
+    ASSERT_EQ(desc.name(), foo_slice);
+    ASSERT_EQ(desc.value(), bar_slice);
+  }
+
+  {
+    WideColumnDesc desc(std::piecewise_construct, std::forward_as_tuple(foo, 1),
+                        std::forward_as_tuple(bar, 2));
+    ASSERT_EQ(desc.name(), "f");
+    ASSERT_EQ(desc.value(), "ba");
+  }
+}
+
 TEST(WideColumnSerializationTest, SerializeDeserialize) {
   WideColumnDescs column_descs{{"foo", "bar"}, {"hello", "world"}};
   std::string output;

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -16,11 +16,42 @@ TEST(WideColumnSerializationTest, Serialize) {
 
   ASSERT_OK(WideColumnSerialization::Serialize(column_descs, &output));
 
-  Slice input(output);
-  WideColumnSerialization::ColumnDescs deserialized_descs;
+  {
+    Slice input(output);
+    WideColumnSerialization::ColumnDescs deserialized_descs;
 
-  ASSERT_OK(WideColumnSerialization::Deserialize(&input, &deserialized_descs));
-  ASSERT_EQ(column_descs, deserialized_descs);
+    ASSERT_OK(
+        WideColumnSerialization::DeserializeAll(&input, &deserialized_descs));
+    ASSERT_EQ(column_descs, deserialized_descs);
+  }
+
+  {
+    Slice input(output);
+    WideColumnSerialization::ColumnDesc deserialized_desc;
+
+    ASSERT_OK(WideColumnSerialization::DeserializeOne(&input, "foo",
+                                                      &deserialized_desc));
+    ASSERT_EQ(deserialized_desc,
+              WideColumnSerialization::ColumnDesc("foo", "bar"));
+  }
+
+  {
+    Slice input(output);
+    WideColumnSerialization::ColumnDesc deserialized_desc;
+
+    ASSERT_OK(WideColumnSerialization::DeserializeOne(&input, "hello",
+                                                      &deserialized_desc));
+    ASSERT_EQ(deserialized_desc,
+              WideColumnSerialization::ColumnDesc("hello", "world"));
+  }
+
+  {
+    Slice input(output);
+    WideColumnSerialization::ColumnDesc deserialized_desc;
+
+    ASSERT_NOK(WideColumnSerialization::DeserializeOne(&input, "snafu",
+                                                       &deserialized_desc));
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -75,10 +75,14 @@ TEST(WideColumnSerializationTest, Construct) {
   }
 
   {
-    WideColumnDesc desc(std::piecewise_construct, std::forward_as_tuple(foo, 1),
-                        std::forward_as_tuple(bar, 2));
-    ASSERT_EQ(desc.name(), "f");
-    ASSERT_EQ(desc.value(), "ba");
+    constexpr char foo_name[] = "foo_name";
+    constexpr char bar_value[] = "bar_value";
+
+    WideColumnDesc desc(std::piecewise_construct,
+                        std::forward_as_tuple(foo_name, sizeof(foo) - 1),
+                        std::forward_as_tuple(bar_value, sizeof(bar) - 1));
+    ASSERT_EQ(desc.name(), foo);
+    ASSERT_EQ(desc.value(), bar);
   }
 }
 

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -20,11 +20,7 @@ TEST(WideColumnSerializationTest, Serialize) {
   WideColumnSerialization::ColumnDescs deserialized_descs;
 
   ASSERT_OK(WideColumnSerialization::Deserialize(&input, &deserialized_descs));
-
-  ASSERT_TRUE(false) << deserialized_descs[0].first.ToString() << ':'
-                     << deserialized_descs[0].second.ToString() << ' '
-                     << deserialized_descs[1].first.ToString() << ':'
-                     << deserialized_descs[1].second.ToString();
+  ASSERT_EQ(column_descs, deserialized_descs);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -16,42 +16,32 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
 
   ASSERT_OK(WideColumnSerialization::Serialize(column_descs, output));
 
-  {
     Slice input(output);
     WideColumnDescs deserialized_descs;
 
     ASSERT_OK(WideColumnSerialization::Deserialize(input, deserialized_descs));
     ASSERT_EQ(column_descs, deserialized_descs);
+
+  {
+    const auto it = WideColumnSerialization::Find(deserialized_descs, "foo");
+    ASSERT_NE(it, deserialized_descs.cend());
+    ASSERT_EQ(*it, deserialized_descs.front());
   }
 
   {
-    Slice input(output);
-    WideColumnDesc deserialized_desc;
-
-    ASSERT_OK(WideColumnSerialization::DeserializeOne(input, "foo",
-                                                      deserialized_desc));
-
-    WideColumnDesc expected_desc{"foo", "bar"};
-    ASSERT_EQ(deserialized_desc, expected_desc);
+    const auto it = WideColumnSerialization::Find(deserialized_descs, "hello");
+    ASSERT_NE(it, deserialized_descs.cend());
+    ASSERT_EQ(*it, deserialized_descs.back());
   }
 
   {
-    Slice input(output);
-    WideColumnDesc deserialized_desc;
-
-    ASSERT_OK(WideColumnSerialization::DeserializeOne(input, "hello",
-                                                      deserialized_desc));
-
-    WideColumnDesc expected_desc{"hello", "world"};
-    ASSERT_EQ(deserialized_desc, expected_desc);
+    const auto it = WideColumnSerialization::Find(deserialized_descs, "fubar");
+    ASSERT_EQ(it, deserialized_descs.cend());
   }
 
   {
-    Slice input(output);
-    WideColumnDesc deserialized_desc;
-
-    ASSERT_NOK(WideColumnSerialization::DeserializeOne(input, "snafu",
-                                                       deserialized_desc));
+    const auto it = WideColumnSerialization::Find(deserialized_descs, "snafu");
+    ASSERT_EQ(it, deserialized_descs.cend());
   }
 }
 

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -16,11 +16,11 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
 
   ASSERT_OK(WideColumnSerialization::Serialize(column_descs, output));
 
-    Slice input(output);
-    WideColumnDescs deserialized_descs;
+  Slice input(output);
+  WideColumnDescs deserialized_descs;
 
-    ASSERT_OK(WideColumnSerialization::Deserialize(input, deserialized_descs));
-    ASSERT_EQ(column_descs, deserialized_descs);
+  ASSERT_OK(WideColumnSerialization::Deserialize(input, deserialized_descs));
+  ASSERT_EQ(column_descs, deserialized_descs);
 
   {
     const auto it = WideColumnSerialization::Find(deserialized_descs, "foo");

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -1,0 +1,35 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/wide/wide_column_serialization.h"
+
+#include "test_util/testharness.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+TEST(WideColumnSerializationTest, Serialize) {
+  WideColumnSerialization::ColumnDescs column_descs{{"foo", "bar"},
+                                                    {"hello", "world"}};
+  std::string output;
+
+  ASSERT_OK(WideColumnSerialization::Serialize(column_descs, &output));
+
+  Slice input(output);
+  WideColumnSerialization::ColumnDescs deserialized_descs;
+
+  ASSERT_OK(WideColumnSerialization::Deserialize(&input, &deserialized_descs));
+
+  ASSERT_TRUE(false) << deserialized_descs[0].first.ToString() << ':'
+                     << deserialized_descs[0].second.ToString() << ' '
+                     << deserialized_descs[1].first.ToString() << ':'
+                     << deserialized_descs[1].second.ToString();
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -14,7 +14,7 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
   WideColumnDescs column_descs{{"foo", "bar"}, {"hello", "world"}};
   std::string output;
 
-  ASSERT_OK(WideColumnSerialization::Serialize(column_descs, &output));
+  ASSERT_OK(WideColumnSerialization::Serialize(column_descs, output));
 
   {
     Slice input(output);

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -30,7 +30,9 @@ TEST(WideColumnSerializationTest, Serialize) {
 
     ASSERT_OK(WideColumnSerialization::DeserializeOne(&input, "foo",
                                                       &deserialized_desc));
-    ASSERT_EQ(deserialized_desc, WideColumnDesc("foo", "bar"));
+
+    WideColumnDesc expected_desc{"foo", "bar"};
+    ASSERT_EQ(deserialized_desc, expected_desc);
   }
 
   {
@@ -39,7 +41,9 @@ TEST(WideColumnSerializationTest, Serialize) {
 
     ASSERT_OK(WideColumnSerialization::DeserializeOne(&input, "hello",
                                                       &deserialized_desc));
-    ASSERT_EQ(deserialized_desc, WideColumnDesc("hello", "world"));
+
+    WideColumnDesc expected_desc{"hello", "world"};
+    ASSERT_EQ(deserialized_desc, expected_desc);
   }
 
   {

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -6,10 +6,11 @@
 #include "db/wide/wide_column_serialization.h"
 
 #include "test_util/testharness.h"
+#include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-TEST(WideColumnSerializationTest, Serialize) {
+TEST(WideColumnSerializationTest, SerializeDeserialize) {
   WideColumnDescs column_descs{{"foo", "bar"}, {"hello", "world"}};
   std::string output;
 
@@ -52,6 +53,167 @@ TEST(WideColumnSerializationTest, Serialize) {
 
     ASSERT_NOK(WideColumnSerialization::DeserializeOne(&input, "snafu",
                                                        &deserialized_desc));
+  }
+}
+
+TEST(WideColumnSerializationTest, DeserializeVersionError) {
+  // Can't decode version
+
+  std::string buf;
+
+  Slice input(buf);
+  WideColumnDescs descs;
+
+  const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+  ASSERT_TRUE(s.IsCorruption());
+  ASSERT_TRUE(std::strstr(s.getState(), "version"));
+}
+
+TEST(WideColumnSerializationTest, DeserializeUnsupportedVersion) {
+  // Unsupported version
+  constexpr uint32_t future_version = 1000;
+
+  std::string buf;
+  PutVarint32(&buf, future_version);
+
+  Slice input(buf);
+  WideColumnDescs descs;
+
+  const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+  ASSERT_TRUE(s.IsNotSupported());
+  ASSERT_TRUE(std::strstr(s.getState(), "version"));
+}
+
+TEST(WideColumnSerializationTest, DeserializeNumberOfColumnsError) {
+  // Can't decode number of columns
+
+  std::string buf;
+  PutVarint32(&buf, WideColumnSerialization::kCurrentVersion);
+
+  Slice input(buf);
+  WideColumnDescs descs;
+
+  const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+  ASSERT_TRUE(s.IsCorruption());
+  ASSERT_TRUE(std::strstr(s.getState(), "number"));
+}
+
+TEST(WideColumnSerializationTest, DeserializeColumnsError) {
+  std::string buf;
+
+  PutVarint32(&buf, WideColumnSerialization::kCurrentVersion);
+
+  constexpr uint32_t num_columns = 2;
+  PutVarint32(&buf, num_columns);
+
+  // Can't decode the size of the first column name
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "name size"));
+  }
+
+  constexpr uint32_t first_name_size = 4;
+  PutVarint32(&buf, first_name_size);
+
+  // Can't decode the size of the first column value
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "value size"));
+  }
+
+  constexpr uint32_t first_value_size = 16;
+  PutVarint32(&buf, first_value_size);
+
+  // Can't decode the size of the second column name
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "name size"));
+  }
+
+  constexpr uint32_t second_name_size = 8;
+  PutVarint32(&buf, second_name_size);
+
+  // Can't decode the size of the second column value
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "value size"));
+  }
+
+  constexpr uint32_t second_value_size = 64;
+  PutVarint32(&buf, second_value_size);
+
+  // Can't decode the payload of the first column
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "payload"));
+  }
+
+  buf.append(first_name_size, 'b');
+
+  // Still can't decode the payload of the first column
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "payload"));
+  }
+
+  buf.append(first_value_size, '0');
+
+  // Can't decode the payload of the second column
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "payload"));
+  }
+
+  buf.append(second_name_size, 'a');
+
+  // Still can't decode the payload of the second column
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "payload"));
+  }
+
+  buf.append(second_value_size, 'x');
+
+  // Columns out of order
+  {
+    Slice input(buf);
+    WideColumnDescs descs;
+
+    const Status s = WideColumnSerialization::DeserializeAll(&input, &descs);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "order"));
   }
 }
 

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -21,103 +21,106 @@ TEST(WideColumnSerializationTest, Construct) {
   const Slice bar_slice(bar_str);
 
   {
-    WideColumnDesc desc(foo, bar);
-    ASSERT_EQ(desc.name(), foo);
-    ASSERT_EQ(desc.value(), bar);
+    WideColumn column(foo, bar);
+    ASSERT_EQ(column.name(), foo);
+    ASSERT_EQ(column.value(), bar);
   }
 
   {
-    WideColumnDesc desc(foo_str, bar);
-    ASSERT_EQ(desc.name(), foo_str);
-    ASSERT_EQ(desc.value(), bar);
+    WideColumn column(foo_str, bar);
+    ASSERT_EQ(column.name(), foo_str);
+    ASSERT_EQ(column.value(), bar);
   }
 
   {
-    WideColumnDesc desc(foo_slice, bar);
-    ASSERT_EQ(desc.name(), foo_slice);
-    ASSERT_EQ(desc.value(), bar);
+    WideColumn column(foo_slice, bar);
+    ASSERT_EQ(column.name(), foo_slice);
+    ASSERT_EQ(column.value(), bar);
   }
 
   {
-    WideColumnDesc desc(foo, bar_str);
-    ASSERT_EQ(desc.name(), foo);
-    ASSERT_EQ(desc.value(), bar_str);
+    WideColumn column(foo, bar_str);
+    ASSERT_EQ(column.name(), foo);
+    ASSERT_EQ(column.value(), bar_str);
   }
 
   {
-    WideColumnDesc desc(foo_str, bar_str);
-    ASSERT_EQ(desc.name(), foo_str);
-    ASSERT_EQ(desc.value(), bar_str);
+    WideColumn column(foo_str, bar_str);
+    ASSERT_EQ(column.name(), foo_str);
+    ASSERT_EQ(column.value(), bar_str);
   }
 
   {
-    WideColumnDesc desc(foo_slice, bar_str);
-    ASSERT_EQ(desc.name(), foo_slice);
-    ASSERT_EQ(desc.value(), bar_str);
+    WideColumn column(foo_slice, bar_str);
+    ASSERT_EQ(column.name(), foo_slice);
+    ASSERT_EQ(column.value(), bar_str);
   }
 
   {
-    WideColumnDesc desc(foo, bar_slice);
-    ASSERT_EQ(desc.name(), foo);
-    ASSERT_EQ(desc.value(), bar_slice);
+    WideColumn column(foo, bar_slice);
+    ASSERT_EQ(column.name(), foo);
+    ASSERT_EQ(column.value(), bar_slice);
   }
 
   {
-    WideColumnDesc desc(foo_str, bar_slice);
-    ASSERT_EQ(desc.name(), foo_str);
-    ASSERT_EQ(desc.value(), bar_slice);
+    WideColumn column(foo_str, bar_slice);
+    ASSERT_EQ(column.name(), foo_str);
+    ASSERT_EQ(column.value(), bar_slice);
   }
 
   {
-    WideColumnDesc desc(foo_slice, bar_slice);
-    ASSERT_EQ(desc.name(), foo_slice);
-    ASSERT_EQ(desc.value(), bar_slice);
+    WideColumn column(foo_slice, bar_slice);
+    ASSERT_EQ(column.name(), foo_slice);
+    ASSERT_EQ(column.value(), bar_slice);
   }
 
   {
     constexpr char foo_name[] = "foo_name";
     constexpr char bar_value[] = "bar_value";
 
-    WideColumnDesc desc(std::piecewise_construct,
-                        std::forward_as_tuple(foo_name, sizeof(foo) - 1),
-                        std::forward_as_tuple(bar_value, sizeof(bar) - 1));
-    ASSERT_EQ(desc.name(), foo);
-    ASSERT_EQ(desc.value(), bar);
+    WideColumn column(std::piecewise_construct,
+                      std::forward_as_tuple(foo_name, sizeof(foo) - 1),
+                      std::forward_as_tuple(bar_value, sizeof(bar) - 1));
+    ASSERT_EQ(column.name(), foo);
+    ASSERT_EQ(column.value(), bar);
   }
 }
 
 TEST(WideColumnSerializationTest, SerializeDeserialize) {
-  WideColumnDescs column_descs{{"foo", "bar"}, {"hello", "world"}};
+  WideColumns columns{{"foo", "bar"}, {"hello", "world"}};
   std::string output;
 
-  ASSERT_OK(WideColumnSerialization::Serialize(column_descs, output));
+  ASSERT_OK(WideColumnSerialization::Serialize(columns, output));
 
   Slice input(output);
-  WideColumnDescs deserialized_descs;
+  WideColumns deserialized_columns;
 
-  ASSERT_OK(WideColumnSerialization::Deserialize(input, deserialized_descs));
-  ASSERT_EQ(column_descs, deserialized_descs);
+  ASSERT_OK(WideColumnSerialization::Deserialize(input, deserialized_columns));
+  ASSERT_EQ(columns, deserialized_columns);
 
   {
-    const auto it = WideColumnSerialization::Find(deserialized_descs, "foo");
-    ASSERT_NE(it, deserialized_descs.cend());
-    ASSERT_EQ(*it, deserialized_descs.front());
+    const auto it = WideColumnSerialization::Find(deserialized_columns, "foo");
+    ASSERT_NE(it, deserialized_columns.cend());
+    ASSERT_EQ(*it, deserialized_columns.front());
   }
 
   {
-    const auto it = WideColumnSerialization::Find(deserialized_descs, "hello");
-    ASSERT_NE(it, deserialized_descs.cend());
-    ASSERT_EQ(*it, deserialized_descs.back());
+    const auto it =
+        WideColumnSerialization::Find(deserialized_columns, "hello");
+    ASSERT_NE(it, deserialized_columns.cend());
+    ASSERT_EQ(*it, deserialized_columns.back());
   }
 
   {
-    const auto it = WideColumnSerialization::Find(deserialized_descs, "fubar");
-    ASSERT_EQ(it, deserialized_descs.cend());
+    const auto it =
+        WideColumnSerialization::Find(deserialized_columns, "fubar");
+    ASSERT_EQ(it, deserialized_columns.cend());
   }
 
   {
-    const auto it = WideColumnSerialization::Find(deserialized_descs, "snafu");
-    ASSERT_EQ(it, deserialized_descs.cend());
+    const auto it =
+        WideColumnSerialization::Find(deserialized_columns, "snafu");
+    ASSERT_EQ(it, deserialized_columns.cend());
   }
 }
 
@@ -127,9 +130,9 @@ TEST(WideColumnSerializationTest, DeserializeVersionError) {
   std::string buf;
 
   Slice input(buf);
-  WideColumnDescs descs;
+  WideColumns columns;
 
-  const Status s = WideColumnSerialization::Deserialize(input, descs);
+  const Status s = WideColumnSerialization::Deserialize(input, columns);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "version"));
 }
@@ -142,9 +145,9 @@ TEST(WideColumnSerializationTest, DeserializeUnsupportedVersion) {
   PutVarint32(&buf, future_version);
 
   Slice input(buf);
-  WideColumnDescs descs;
+  WideColumns columns;
 
-  const Status s = WideColumnSerialization::Deserialize(input, descs);
+  const Status s = WideColumnSerialization::Deserialize(input, columns);
   ASSERT_TRUE(s.IsNotSupported());
   ASSERT_TRUE(std::strstr(s.getState(), "version"));
 }
@@ -156,9 +159,9 @@ TEST(WideColumnSerializationTest, DeserializeNumberOfColumnsError) {
   PutVarint32(&buf, WideColumnSerialization::kCurrentVersion);
 
   Slice input(buf);
-  WideColumnDescs descs;
+  WideColumns columns;
 
-  const Status s = WideColumnSerialization::Deserialize(input, descs);
+  const Status s = WideColumnSerialization::Deserialize(input, columns);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "number"));
 }
@@ -174,9 +177,9 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
   // Can't decode the first column name
   {
     Slice input(buf);
-    WideColumnDescs descs;
+    WideColumns columns;
 
-    const Status s = WideColumnSerialization::Deserialize(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, columns);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "name"));
   }
@@ -187,9 +190,9 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
   // Can't decode the size of the first column value
   {
     Slice input(buf);
-    WideColumnDescs descs;
+    WideColumns columns;
 
-    const Status s = WideColumnSerialization::Deserialize(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, columns);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "value size"));
   }
@@ -200,9 +203,9 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
   // Can't decode the second column name
   {
     Slice input(buf);
-    WideColumnDescs descs;
+    WideColumns columns;
 
-    const Status s = WideColumnSerialization::Deserialize(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, columns);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "name"));
   }
@@ -213,9 +216,9 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
   // Can't decode the size of the second column value
   {
     Slice input(buf);
-    WideColumnDescs descs;
+    WideColumns columns;
 
-    const Status s = WideColumnSerialization::Deserialize(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, columns);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "value size"));
   }
@@ -226,9 +229,9 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
   // Can't decode the payload of the first column
   {
     Slice input(buf);
-    WideColumnDescs descs;
+    WideColumns columns;
 
-    const Status s = WideColumnSerialization::Deserialize(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, columns);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "payload"));
   }
@@ -238,9 +241,9 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
   // Can't decode the payload of the second column
   {
     Slice input(buf);
-    WideColumnDescs descs;
+    WideColumns columns;
 
-    const Status s = WideColumnSerialization::Deserialize(input, descs);
+    const Status s = WideColumnSerialization::Deserialize(input, columns);
     ASSERT_TRUE(s.IsCorruption());
     ASSERT_TRUE(std::strstr(s.getState(), "payload"));
   }
@@ -250,9 +253,9 @@ TEST(WideColumnSerializationTest, DeserializeColumnsError) {
   // Success
   {
     Slice input(buf);
-    WideColumnDescs descs;
+    WideColumns columns;
 
-    ASSERT_OK(WideColumnSerialization::Deserialize(input, descs));
+    ASSERT_OK(WideColumnSerialization::Deserialize(input, columns));
   }
 }
 
@@ -274,9 +277,9 @@ TEST(WideColumnSerializationTest, DeserializeColumnsOutOfOrder) {
   PutLengthPrefixedSlice(&buf, second_column_name);
 
   Slice input(buf);
-  WideColumnDescs descs;
+  WideColumns columns;
 
-  const Status s = WideColumnSerialization::Deserialize(input, descs);
+  const Status s = WideColumnSerialization::Deserialize(input, columns);
   ASSERT_TRUE(s.IsCorruption());
   ASSERT_TRUE(std::strstr(s.getState(), "order"));
 }

--- a/include/rocksdb/types.h
+++ b/include/rocksdb/types.h
@@ -5,7 +5,9 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
+#include <vector>
+
 #include "rocksdb/slice.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -60,5 +62,9 @@ enum EntryType {
   kEntryDeleteWithTimestamp,
   kEntryOther,
 };
+
+// Wide columns
+using WideColumnDesc = std::pair<Slice, Slice>;
+using WideColumnDescs = std::vector<WideColumnDesc>;
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/types.h
+++ b/include/rocksdb/types.h
@@ -5,9 +5,7 @@
 
 #pragma once
 
-#include <cstdint>
-#include <vector>
-
+#include <stdint.h>
 #include "rocksdb/slice.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -62,9 +60,5 @@ enum EntryType {
   kEntryDeleteWithTimestamp,
   kEntryOther,
 };
-
-// Wide columns
-using WideColumnDesc = std::pair<Slice, Slice>;
-using WideColumnDescs = std::vector<WideColumnDesc>;
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -14,6 +14,8 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+// Class representing a wide column, which is defined as a pair of column name
+// and column value.
 class WideColumn {
  public:
   WideColumn() = default;

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -1,0 +1,72 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class WideColumn {
+ public:
+  WideColumn() = default;
+
+  // Initializes a WideColumn object by forwarding the name and value
+  // arguments to the corresponding member Slices. This makes it possible to
+  // construct a WideColumn using combinations of const char*, const
+  // std::string&, const Slice& etc., for example:
+  //
+  // constexpr char foo[] = "foo";
+  // const std::string bar("bar");
+  // WideColumn column(foo, bar);
+  template <typename N, typename V>
+  WideColumn(N&& name, V&& value)
+      : name_(std::forward<N>(name)), value_(std::forward<V>(value)) {}
+
+  // Initializes a WideColumn object by forwarding the elements of
+  // name_tuple and value_tuple to the constructors of the corresponding member
+  // Slices. This makes it possible to initialize the Slices using the Slice
+  // constructors that take more than one argument, for example:
+  //
+  // constexpr char foo_name[] = "foo_name";
+  // constexpr char bar_value[] = "bar_value";
+  // WideColumn column(std::piecewise_construct,
+  //                   std::forward_as_tuple(foo_name, 3),
+  //                   std::forward_as_tuple(bar_value, 3));
+  template <typename NTuple, typename VTuple>
+  WideColumn(std::piecewise_construct_t, NTuple&& name_tuple,
+             VTuple&& value_tuple)
+      : name_(std::make_from_tuple<Slice>(std::forward<NTuple>(name_tuple))),
+        value_(std::make_from_tuple<Slice>(std::forward<VTuple>(value_tuple))) {
+  }
+
+  const Slice& name() const { return name_; }
+  const Slice& value() const { return value_; }
+
+  Slice& name() { return name_; }
+  Slice& value() { return value_; }
+
+ private:
+  Slice name_;
+  Slice value_;
+};
+
+// Note: column names and values are compared bytewise.
+inline bool operator==(const WideColumn& lhs, const WideColumn& rhs) {
+  return lhs.name() == rhs.name() && lhs.value() == rhs.value();
+}
+
+inline bool operator!=(const WideColumn& lhs, const WideColumn& rhs) {
+  return !(lhs == rhs);
+}
+
+using WideColumns = std::vector<WideColumn>;
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/src.mk
+++ b/src.mk
@@ -82,6 +82,7 @@ LIB_SOURCES =                                                   \
   db/version_set.cc                                             \
   db/wal_edit.cc                                                \
   db/wal_manager.cc                                             \
+  db/wide/wide_column_serialization.cc                          \
   db/write_batch.cc                                             \
   db/write_batch_base.cc                                        \
   db/write_controller.cc                                        \
@@ -497,6 +498,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/version_edit_test.cc                                               \
   db/version_set_test.cc                                                \
   db/wal_manager_test.cc                                                \
+  db/wide/wide_column_serialization_test.cc                             \
   db/write_batch_test.cc                                                \
   db/write_callback_test.cc                                             \
   db/write_controller_test.cc                                           \

--- a/util/autovector.h
+++ b/util/autovector.h
@@ -223,6 +223,16 @@ class autovector {
 
   bool empty() const { return size() == 0; }
 
+  size_type capacity() const { return kSize + vect_.capacity(); }
+
+  void reserve(size_t cap) {
+    if (cap > kSize) {
+      vect_.reserve(cap - kSize);
+    }
+
+    assert(cap <= capacity());
+  }
+
   const_reference operator[](size_type n) const {
     assert(n < size());
     if (n < kSize) {

--- a/util/autovector.h
+++ b/util/autovector.h
@@ -36,7 +36,7 @@ class autovector : public std::vector<T> {
 // full-fledged generic container.
 //
 // Currently we don't support:
-//  * reserve()/shrink_to_fit()
+//  * shrink_to_fit()
 //     If used correctly, in most cases, people should not touch the
 //     underlying vector at all.
 //  * random insert()/erase(), please only use push_back()/pop_back().


### PR DESCRIPTION
Summary:
The patch adds some low-level logic that can be used to serialize/deserialize
a sorted vector of wide columns to/from a simple binary searchable string
representation. Currently, there is no user-facing API; this will be implemented in
subsequent stages.

Test Plan:
`make check`