### PR TITLE
Expose unix time in rocksdb::Snapshot

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### Public API changes
+* Add new API GetUnixTime in Snapshot class which returns the unix time at which Snapshot is taken.
 
 ## 7.3.0 (05/20/2022)
 ### Bug Fixes

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1844,7 +1844,8 @@ TEST_F(DBTest, Snapshot) {
     uint64_t time_snap1 = GetTimeOldestSnapshots();
     ASSERT_GT(time_snap1, 0U);
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
-    ASSERT_EQ(GetTimeOldestSnapshots(), s1->GetSnapshotTime());
+    ASSERT_EQ(GetTimeOldestSnapshots(),
+              static_cast<uint64_t>(s1->GetSnapshotTime()));
     ASSERT_OK(Put(0, "foo", "0v2"));
     ASSERT_OK(Put(1, "foo", "1v2"));
 
@@ -1854,7 +1855,8 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_EQ(2U, GetNumSnapshots());
     ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
-    ASSERT_EQ(GetTimeOldestSnapshots(), s1->GetSnapshotTime());
+    ASSERT_EQ(GetTimeOldestSnapshots(),
+              static_cast<uint64_t>(s1->GetSnapshotTime()));
     ASSERT_OK(Put(0, "foo", "0v3"));
     ASSERT_OK(Put(1, "foo", "1v3"));
 
@@ -1863,7 +1865,8 @@ TEST_F(DBTest, Snapshot) {
       ASSERT_EQ(3U, GetNumSnapshots());
       ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
       ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
-      ASSERT_EQ(GetTimeOldestSnapshots(), s1->GetSnapshotTime());
+      ASSERT_EQ(GetTimeOldestSnapshots(),
+                static_cast<uint64_t>(s1->GetSnapshotTime()));
 
       ASSERT_OK(Put(0, "foo", "0v4"));
       ASSERT_OK(Put(1, "foo", "1v4"));
@@ -1880,7 +1883,8 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_EQ(2U, GetNumSnapshots());
     ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
-    ASSERT_EQ(GetTimeOldestSnapshots(), s1->GetSnapshotTime());
+    ASSERT_EQ(GetTimeOldestSnapshots(),
+              static_cast<uint64_t>(s1->GetSnapshotTime()));
     ASSERT_EQ("0v1", Get(0, "foo", s1));
     ASSERT_EQ("1v1", Get(1, "foo", s1));
     ASSERT_EQ("0v2", Get(0, "foo", s2));
@@ -1896,7 +1900,8 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_EQ(1U, GetNumSnapshots());
     ASSERT_LT(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s2->GetSequenceNumber());
-    ASSERT_EQ(GetTimeOldestSnapshots(), s2->GetSnapshotTime());
+    ASSERT_EQ(GetTimeOldestSnapshots(),
+              static_cast<uint64_t>(s2->GetSnapshotTime()));
 
     db_->ReleaseSnapshot(s2);
     ASSERT_EQ(0U, GetNumSnapshots());

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1844,6 +1844,7 @@ TEST_F(DBTest, Snapshot) {
     uint64_t time_snap1 = GetTimeOldestSnapshots();
     ASSERT_GT(time_snap1, 0U);
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
+    ASSERT_EQ(GetTimeOldestSnapshots(), s1->GetSnapshotTime());
     ASSERT_OK(Put(0, "foo", "0v2"));
     ASSERT_OK(Put(1, "foo", "1v2"));
 
@@ -1853,6 +1854,7 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_EQ(2U, GetNumSnapshots());
     ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
+    ASSERT_EQ(GetTimeOldestSnapshots(), s1->GetSnapshotTime());
     ASSERT_OK(Put(0, "foo", "0v3"));
     ASSERT_OK(Put(1, "foo", "1v3"));
 
@@ -1861,6 +1863,7 @@ TEST_F(DBTest, Snapshot) {
       ASSERT_EQ(3U, GetNumSnapshots());
       ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
       ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
+      ASSERT_EQ(GetTimeOldestSnapshots(), s1->GetSnapshotTime());
 
       ASSERT_OK(Put(0, "foo", "0v4"));
       ASSERT_OK(Put(1, "foo", "1v4"));
@@ -1877,6 +1880,7 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_EQ(2U, GetNumSnapshots());
     ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
+    ASSERT_EQ(GetTimeOldestSnapshots(), s1->GetSnapshotTime());
     ASSERT_EQ("0v1", Get(0, "foo", s1));
     ASSERT_EQ("1v1", Get(1, "foo", s1));
     ASSERT_EQ("0v2", Get(0, "foo", s2));
@@ -1892,6 +1896,7 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_EQ(1U, GetNumSnapshots());
     ASSERT_LT(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s2->GetSequenceNumber());
+    ASSERT_EQ(GetTimeOldestSnapshots(), s2->GetSnapshotTime());
 
     db_->ReleaseSnapshot(s2);
     ASSERT_EQ(0U, GetNumSnapshots());
@@ -2855,6 +2860,12 @@ class ModelDB : public DB {
     KVMap map_;
 
     SequenceNumber GetSequenceNumber() const override {
+      // no need to call this
+      assert(false);
+      return 0;
+    }
+
+    int64_t GetSnapshotTime() const override {
       // no need to call this
       assert(false);
       return 0;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1845,7 +1845,7 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_GT(time_snap1, 0U);
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
     ASSERT_EQ(GetTimeOldestSnapshots(),
-              static_cast<uint64_t>(s1->GetSnapshotTime()));
+              static_cast<uint64_t>(s1->GetUnixTime()));
     ASSERT_OK(Put(0, "foo", "0v2"));
     ASSERT_OK(Put(1, "foo", "1v2"));
 
@@ -1856,7 +1856,7 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
     ASSERT_EQ(GetTimeOldestSnapshots(),
-              static_cast<uint64_t>(s1->GetSnapshotTime()));
+              static_cast<uint64_t>(s1->GetUnixTime()));
     ASSERT_OK(Put(0, "foo", "0v3"));
     ASSERT_OK(Put(1, "foo", "1v3"));
 
@@ -1866,7 +1866,7 @@ TEST_F(DBTest, Snapshot) {
       ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
       ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
       ASSERT_EQ(GetTimeOldestSnapshots(),
-                static_cast<uint64_t>(s1->GetSnapshotTime()));
+                static_cast<uint64_t>(s1->GetUnixTime()));
 
       ASSERT_OK(Put(0, "foo", "0v4"));
       ASSERT_OK(Put(1, "foo", "1v4"));
@@ -1884,7 +1884,7 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s1->GetSequenceNumber());
     ASSERT_EQ(GetTimeOldestSnapshots(),
-              static_cast<uint64_t>(s1->GetSnapshotTime()));
+              static_cast<uint64_t>(s1->GetUnixTime()));
     ASSERT_EQ("0v1", Get(0, "foo", s1));
     ASSERT_EQ("1v1", Get(1, "foo", s1));
     ASSERT_EQ("0v2", Get(0, "foo", s2));
@@ -1901,7 +1901,7 @@ TEST_F(DBTest, Snapshot) {
     ASSERT_LT(time_snap1, GetTimeOldestSnapshots());
     ASSERT_EQ(GetSequenceOldestSnapshots(), s2->GetSequenceNumber());
     ASSERT_EQ(GetTimeOldestSnapshots(),
-              static_cast<uint64_t>(s2->GetSnapshotTime()));
+              static_cast<uint64_t>(s2->GetUnixTime()));
 
     db_->ReleaseSnapshot(s2);
     ASSERT_EQ(0U, GetNumSnapshots());
@@ -2870,7 +2870,7 @@ class ModelDB : public DB {
       return 0;
     }
 
-    int64_t GetSnapshotTime() const override {
+    int64_t GetUnixTime() const override {
       // no need to call this
       assert(false);
       return 0;

--- a/db/snapshot_impl.h
+++ b/db/snapshot_impl.h
@@ -27,9 +27,9 @@ class SnapshotImpl : public Snapshot {
   // scope of queries to IsInSnapshot.
   SequenceNumber min_uncommitted_ = kMinUnCommittedSeq;
 
-  virtual SequenceNumber GetSequenceNumber() const override { return number_; }
+  SequenceNumber GetSequenceNumber() const override { return number_; }
 
-  virtual int64_t GetSnapshotTime() const override { return unix_time_; }
+  int64_t GetUnixTime() const override { return unix_time_; }
 
  private:
   friend class SnapshotList;

--- a/db/snapshot_impl.h
+++ b/db/snapshot_impl.h
@@ -29,6 +29,8 @@ class SnapshotImpl : public Snapshot {
 
   virtual SequenceNumber GetSequenceNumber() const override { return number_; }
 
+  virtual int64_t GetSnapshotTime() const override { return unix_time_; }
+
  private:
   friend class SnapshotList;
 

--- a/include/rocksdb/snapshot.h
+++ b/include/rocksdb/snapshot.h
@@ -19,8 +19,12 @@ class DB;
 // To Destroy a Snapshot, call DB::ReleaseSnapshot(snapshot).
 class Snapshot {
  public:
-  // returns Snapshot's sequence number
+  // Returns Snapshot's sequence number.
   virtual SequenceNumber GetSequenceNumber() const = 0;
+
+  // Returns unix time i.e. the number of seconds since the Epoch, 1970-01-01
+  // 00:00:00 (UTC).
+  virtual int64_t GetSnapshotTime() const = 0;
 
  protected:
   virtual ~Snapshot();

--- a/include/rocksdb/snapshot.h
+++ b/include/rocksdb/snapshot.h
@@ -19,12 +19,11 @@ class DB;
 // To Destroy a Snapshot, call DB::ReleaseSnapshot(snapshot).
 class Snapshot {
  public:
-  // Returns Snapshot's sequence number.
   virtual SequenceNumber GetSequenceNumber() const = 0;
 
   // Returns unix time i.e. the number of seconds since the Epoch, 1970-01-01
   // 00:00:00 (UTC).
-  virtual int64_t GetSnapshotTime() const = 0;
+  virtual int64_t GetUnixTime() const = 0;
 
  protected:
   virtual ~Snapshot();


### PR DESCRIPTION
Summary: RocksDB snapshot already has a member unix_time_ set after
snapshot is taken. It is now exposed through GetSnapshotTime() API.

Test Plan: Update unit tests