### PR TITLE
Fix a comment in RateLimiter::RequestToken

### DIFF
--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -31,8 +31,8 @@ size_t RateLimiter::RequestToken(size_t bytes, size_t alignment,
 
     if (alignment > 0) {
       // Here we may actually require more than burst and block
-      // but we can not write less than one page at a time on direct I/O
-      // thus we may want not to use ratelimiter
+      // as we can not write/read less than one page at a time on direct I/O
+      // thus we do not want to be strictly constrained by burst
       bytes = std::max(alignment, TruncateToPageBoundary(alignment, bytes));
     }
     Request(bytes, io_priority, stats, op_type);


### PR DESCRIPTION
**Context/Summary:**
- The truncation mentioned in the comment also applies to read in the code but the comment does not reflect that.


**Test plan:**
- No code change