### PR TITLE
Printing IO Error in DumpDBFileSummary

### DIFF
--- a/db/db_info_dumper.cc
+++ b/db/db_info_dumper.cc
@@ -35,10 +35,12 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
   Header(options.info_log, "DB SUMMARY\n");
   Header(options.info_log, "DB Session ID:  %s\n", session_id.c_str());
 
+  Status s;
   // Get files in dbname dir
-  if (!env->GetChildren(dbname, &files).ok()) {
-    Error(options.info_log,
-          "Error when reading %s dir\n", dbname.c_str());
+  s = env->GetChildren(dbname, &files);
+  if (!s.ok()) {
+    Error(options.info_log, "Error when reading %s dir %s\n", dbname.c_str(),
+          s.ToString().c_str());
   }
   std::sort(files.begin(), files.end());
   for (const std::string& file : files) {
@@ -53,24 +55,27 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
         Header(options.info_log, "IDENTITY file:  %s\n", file.c_str());
         break;
       case kDescriptorFile:
-        if (env->GetFileSize(dbname + "/" + file, &file_size).ok()) {
+        s = env->GetFileSize(dbname + "/" + file, &file_size);
+        if (s.ok()) {
           Header(options.info_log,
                  "MANIFEST file:  %s size: %" PRIu64 " Bytes\n", file.c_str(),
                  file_size);
         } else {
-          Error(options.info_log, "Error when reading MANIFEST file: %s/%s\n",
-                dbname.c_str(), file.c_str());
+          Error(options.info_log,
+                "Error when reading MANIFEST file: %s/%s %s\n", dbname.c_str(),
+                file.c_str(), s.ToString().c_str());
         }
         break;
       case kWalFile:
-        if (env->GetFileSize(dbname + "/" + file, &file_size).ok()) {
+        s = env->GetFileSize(dbname + "/" + file, &file_size);
+        if (s.ok()) {
           wal_info.append(file)
               .append(" size: ")
               .append(std::to_string(file_size))
               .append(" ; ");
         } else {
-          Error(options.info_log, "Error when reading LOG file: %s/%s\n",
-                dbname.c_str(), file.c_str());
+          Error(options.info_log, "Error when reading LOG file: %s/%s %s\n",
+                dbname.c_str(), file.c_str(), s.ToString.c_str());
         }
         break;
       case kTableFile:
@@ -86,10 +91,10 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
   // Get sst files in db_path dir
   for (auto& db_path : options.db_paths) {
     if (dbname.compare(db_path.path) != 0) {
-      if (!env->GetChildren(db_path.path, &files).ok()) {
-        Error(options.info_log,
-            "Error when reading %s dir\n",
-            db_path.path.c_str());
+      s = env->GetChildren(db_path.path, &files);
+      if (!s.ok()) {
+        Error(options.info_log, "Error when reading %s dir %s\n",
+              db_path.path.c_str(), s.ToString().c_str());
         continue;
       }
       std::sort(files.begin(), files.end());
@@ -111,22 +116,25 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
   // Get wal file in wal_dir
   const auto& wal_dir = options.GetWalDir(dbname);
   if (!options.IsWalDirSameAsDBPath(dbname)) {
-    if (!env->GetChildren(wal_dir, &files).ok()) {
-      Error(options.info_log, "Error when reading %s dir\n", wal_dir.c_str());
+    s = env->GetChildren(wal_dir, &files);
+    if (!s.ok()) {
+      Error(options.info_log, "Error when reading %s dir %s\n", wal_dir.c_str(),
+            s.ToString().c_str());
       return;
     }
     wal_info.clear();
     for (const std::string& file : files) {
       if (ParseFileName(file, &number, &type)) {
         if (type == kWalFile) {
-          if (env->GetFileSize(wal_dir + "/" + file, &file_size).ok()) {
+          s = env->GetFileSize(wal_dir + "/" + file, &file_size);
+          if (s.ok()) {
             wal_info.append(file)
                 .append(" size: ")
                 .append(std::to_string(file_size))
                 .append(" ; ");
           } else {
-            Error(options.info_log, "Error when reading LOG file %s/%s\n",
-                  wal_dir.c_str(), file.c_str());
+            Error(options.info_log, "Error when reading LOG file %s/%s %s\n",
+                  wal_dir.c_str(), file.c_str(), s.ToString().c_str());
           }
         }
       }

--- a/db/db_info_dumper.cc
+++ b/db/db_info_dumper.cc
@@ -75,7 +75,7 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
               .append(" ; ");
         } else {
           Error(options.info_log, "Error when reading LOG file: %s/%s %s\n",
-                dbname.c_str(), file.c_str(), s.ToString.c_str());
+                dbname.c_str(), file.c_str(), s.ToString().c_str());
         }
         break;
       case kTableFile:


### PR DESCRIPTION
Summary:
Right now in DumpDBFileSummary, IO error isn't printed out, but they are sometimes helpful. Print it out instead.

Test Plan: Watch existing tests to pass.