### PR TITLE
Fix format_compatible blowing away its TEST_TMPDIR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,7 @@ jobs:
     steps:
       - checkout # check out the code in the project directory
       - run: apt-get update -y && apt-get install -y libgflags-dev
-      - run: TEST_TMPDIR=/dev/shm && make V=1 -j8 unity_test
+      - run: make V=1 -j8 unity_test
       - run: make V=1 -j8 -k check-headers # could be moved to a different build
       - post-steps
 

--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -63,6 +63,9 @@ scriptpath=`dirname ${BASH_SOURCE[0]}`
 test_dir=${TEST_TMPDIR:-"/tmp"}"/rocksdb_format_compatible_$USER"
 rm -rf ${test_dir:?}
 
+# Prevent 'make clean' etc. from wiping out test_dir
+export TEST_TMPDIR=$test_dir"/misc"
+
 # For saving current version of scripts as we checkout different versions to test
 script_copy_dir=$test_dir"/script_copy"
 mkdir -p $script_copy_dir


### PR DESCRIPTION
Summary: #9961 broke format_compatible check because of `make clean`
referencing TEST_TMPDIR. The Makefile behavior seems reasonable to me,
so here's a fix in check_format_compatible.sh

Apparently I also included removing a redundant part of our CircleCI config.

Test Plan: manual run: SHORT_TEST=1 ./tools/check_format_compatible.sh