### PR TITLE
Fix stress test with best-efforts-recovery

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1424,8 +1424,8 @@ void StressTest::TestCompactFiles(ThreadState* /* thread */,
 Status StressTest::TestBackupRestore(
     ThreadState* thread, const std::vector<int>& rand_column_families,
     const std::vector<int64_t>& rand_keys) {
-  std::string backup_dir = FLAGS_db + "/.backup" + std::to_string(thread->tid);
-  std::string restore_dir =
+  const std::string backup_dir = FLAGS_db + "/.backup" + std::to_string(thread->tid);
+  const std::string restore_dir =
       FLAGS_db + "/.restore" + std::to_string(thread->tid);
   BackupEngineOptions backup_opts(backup_dir);
   // For debugging, get info_log from live options
@@ -1558,6 +1558,7 @@ Status StressTest::TestBackupRestore(
   // Not yet implemented: opening restored BlobDB or TransactionDB
   if (s.ok() && !FLAGS_use_txn && !FLAGS_use_blob_db) {
     Options restore_options(options_);
+    restore_options.best_efforts_recovery = false;
     restore_options.listeners.clear();
     // Avoid dangling/shared file descriptors, for reliable destroy
     restore_options.sst_file_manager = nullptr;
@@ -1614,11 +1615,19 @@ Status StressTest::TestBackupRestore(
     bool exists = thread->shared->Exists(rand_column_families[i], rand_keys[0]);
     if (get_status.ok()) {
       if (!exists && from_latest && ShouldAcquireMutexOnKey()) {
-        s = Status::Corruption("key exists in restore but not in original db");
+        std::ostringstream oss;
+        oss << "0x" << key.ToString(true)
+            << " exists in restore but not in original db";
+        s = Status::Corruption(oss.str());
+        assert(false);
       }
     } else if (get_status.IsNotFound()) {
       if (exists && from_latest && ShouldAcquireMutexOnKey()) {
-        s = Status::Corruption("key exists in original db but not in restore");
+        std::ostringstream oss;
+        oss << "0x" << key.ToString(true)
+            << " exists in original db but not in restore";
+        s = Status::Corruption(oss.str());
+        assert(false);
       }
     } else {
       s = get_status;
@@ -1760,6 +1769,7 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   DB* checkpoint_db = nullptr;
   if (s.ok()) {
     Options options(options_);
+    options.best_efforts_recovery = false;
     options.listeners.clear();
     // Avoid race condition in trash handling after delete checkpoint_db
     options.sst_file_manager.reset();
@@ -1791,13 +1801,20 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
           thread->shared->Exists(rand_column_families[i], rand_keys[0]);
       if (get_status.ok()) {
         if (!exists && ShouldAcquireMutexOnKey()) {
-          s = Status::Corruption(
-              "key exists in checkpoint but not in original db");
+          std::ostringstream oss;
+          oss << "0x" << key.ToString(true) << " exists in checkpoint "
+              << checkpoint_dir << " but not in original db";
+          s = Status::Corruption(oss.str());
+          assert(false);
         }
       } else if (get_status.IsNotFound()) {
         if (exists && ShouldAcquireMutexOnKey()) {
-          s = Status::Corruption(
-              "key exists in original db but not in checkpoint");
+          std::ostringstream oss;
+          oss << "0x" << key.ToString(true)
+              << " exists in original db but not in checkpoint "
+              << checkpoint_dir;
+          s = Status::Corruption(oss.str());
+          assert(false);
         }
       } else {
         s = get_status;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -455,7 +455,6 @@ void StressTest::VerificationAbort(SharedState* shared, std::string msg,
   fprintf(stderr, "Verification failed: %s. Status is %s\n", msg.c_str(),
           s.ToString().c_str());
   shared->SetVerificationFailure();
-  assert(false);
 }
 
 void StressTest::VerificationAbort(SharedState* shared, std::string msg, int cf,
@@ -466,7 +465,6 @@ void StressTest::VerificationAbort(SharedState* shared, std::string msg, int cf,
           "Verification failed for column family %d key %s (%" PRIi64 "): %s\n",
           cf, key_slice.ToString(true).c_str(), key, msg.c_str());
   shared->SetVerificationFailure();
-  assert(false);
 }
 
 void StressTest::PrintStatistics() {
@@ -1621,7 +1619,6 @@ Status StressTest::TestBackupRestore(
         oss << "0x" << key.ToString(true)
             << " exists in restore but not in original db";
         s = Status::Corruption(oss.str());
-        assert(false);
       }
     } else if (get_status.IsNotFound()) {
       if (exists && from_latest && ShouldAcquireMutexOnKey()) {
@@ -1629,7 +1626,6 @@ Status StressTest::TestBackupRestore(
         oss << "0x" << key.ToString(true)
             << " exists in original db but not in restore";
         s = Status::Corruption(oss.str());
-        assert(false);
       }
     } else {
       s = get_status;
@@ -1807,7 +1803,6 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
           oss << "0x" << key.ToString(true) << " exists in checkpoint "
               << checkpoint_dir << " but not in original db";
           s = Status::Corruption(oss.str());
-          assert(false);
         }
       } else if (get_status.IsNotFound()) {
         if (exists && ShouldAcquireMutexOnKey()) {
@@ -1816,7 +1811,6 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
               << " exists in original db but not in checkpoint "
               << checkpoint_dir;
           s = Status::Corruption(oss.str());
-          assert(false);
         }
       } else {
         s = get_status;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -455,6 +455,7 @@ void StressTest::VerificationAbort(SharedState* shared, std::string msg,
   fprintf(stderr, "Verification failed: %s. Status is %s\n", msg.c_str(),
           s.ToString().c_str());
   shared->SetVerificationFailure();
+  assert(false);
 }
 
 void StressTest::VerificationAbort(SharedState* shared, std::string msg, int cf,
@@ -465,6 +466,7 @@ void StressTest::VerificationAbort(SharedState* shared, std::string msg, int cf,
           "Verification failed for column family %d key %s (%" PRIi64 "): %s\n",
           cf, key_slice.ToString(true).c_str(), key, msg.c_str());
   shared->SetVerificationFailure();
+  assert(false);
 }
 
 void StressTest::PrintStatistics() {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1424,7 +1424,8 @@ void StressTest::TestCompactFiles(ThreadState* /* thread */,
 Status StressTest::TestBackupRestore(
     ThreadState* thread, const std::vector<int>& rand_column_families,
     const std::vector<int64_t>& rand_keys) {
-  const std::string backup_dir = FLAGS_db + "/.backup" + std::to_string(thread->tid);
+  const std::string backup_dir =
+      FLAGS_db + "/.backup" + std::to_string(thread->tid);
   const std::string restore_dir =
       FLAGS_db + "/.restore" + std::to_string(thread->tid);
   BackupEngineOptions backup_opts(backup_dir);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -313,9 +313,10 @@ txn_params = {
 }
 
 best_efforts_recovery_params = {
-    #"best_efforts_recovery": 1,
+    "best_efforts_recovery": 1,
     "atomic_flush": 0,
     "disable_wal": 1,
+    "column_families": 1,
     "sync_fault_injection": 0,
 }
 
@@ -502,12 +503,12 @@ def finalize_and_sanitize(src_params):
         dest_params["memtable_prefix_bloom_size_ratio"] = 0
     if dest_params.get("two_write_queues") == 1:
         dest_params["enable_pipelined_write"] = 0
-    #if dest_params.get("best_efforts_recovery") == 1:
-    dest_params["disable_wal"] = 1
-    dest_params["atomic_flush"] = 0
-    dest_params["enable_compaction_filter"] = 0
-    dest_params["sync"] = 0
-    dest_params["write_fault_one_in"] = 0
+    if dest_params.get("best_efforts_recovery") == 1:
+      dest_params["disable_wal"] = 1
+      dest_params["atomic_flush"] = 0
+      dest_params["enable_compaction_filter"] = 0
+      dest_params["sync"] = 0
+      dest_params["write_fault_one_in"] = 0
 
     return dest_params
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -313,10 +313,7 @@ txn_params = {
 }
 
 best_efforts_recovery_params = {
-    "best_efforts_recovery": True,
-    "skip_verifydb": True,
-    "verify_db_one_in": 0,
-    "continuous_verification_interval": 0,
+    #"best_efforts_recovery": 1,
     "atomic_flush": 0,
     "disable_wal": 1,
     "sync_fault_injection": 0,
@@ -505,12 +502,12 @@ def finalize_and_sanitize(src_params):
         dest_params["memtable_prefix_bloom_size_ratio"] = 0
     if dest_params.get("two_write_queues") == 1:
         dest_params["enable_pipelined_write"] = 0
-    if dest_params.get("best_efforts_recovery") == 1:
-        dest_params["disable_wal"] = 1
-        dest_params["atomic_flush"] = 0
-        dest_params["enable_compaction_filter"] = 0
-        dest_params["sync"] = 0
-        dest_params["write_fault_one_in"] = 0
+    #if dest_params.get("best_efforts_recovery") == 1:
+    dest_params["disable_wal"] = 1
+    dest_params["atomic_flush"] = 0
+    dest_params["enable_compaction_filter"] = 0
+    dest_params["sync"] = 0
+    dest_params["write_fault_one_in"] = 0
 
     return dest_params
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -34,7 +34,7 @@ default_params = {
     "acquire_snapshot_one_in": 10000,
     "backup_max_size": 100 * 1024 * 1024,
     # Consider larger number when backups considered more stable
-    "backup_one_in": 100,
+    "backup_one_in": 100000,
     "batch_protection_bytes_per_key": lambda: random.choice([0, 8]),
     "block_size": 16384,
     "bloom_bits": lambda: random.choice([random.randint(0,19),
@@ -42,7 +42,7 @@ default_params = {
     "cache_index_and_filter_blocks": lambda: random.randint(0, 1),
     "cache_size": 8388608,
     "reserve_table_reader_memory": lambda: random.choice([0, 1]),
-    "checkpoint_one_in": 100,
+    "checkpoint_one_in": 1000000,
     "compression_type": lambda: random.choice(
         ["none", "snappy", "zlib", "lz4", "lz4hc", "xpress", "zstd"]),
     "bottommost_compression_type": lambda:


### PR DESCRIPTION
This PR

- since we are testing with disable_wal = true and best_efforts_recovery, we should set column family count to 1, due to the requirement of `ExpectedState` tracking and replaying logic.
- during backup and checkpoint restore, disable best-efforts-recovery. This does not matter now because db_crashtest.py always disables wal when testing best-efforts-recovery. In the future, if we enable wal, then not setting `restore_opitions.best_efforts_recovery` will cause backup db not to recover the WALs, and differ from db (that enables WAL).
- during verification of backup and checkpoint restore, print the key where inconsistency exists between expected state and db.

Test plan:
TEST_TMPDIR=/dev/shm/rocksdb make crash_test_with_best_efforts_recovery