### PR TITLE
Revert "Bugfix/fix manual flush blocking bug (#9893)"

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1705,11 +1705,9 @@ Status DBImpl::Flush(const FlushOptions& flush_options,
   Status s;
   if (immutable_db_options_.atomic_flush) {
     s = AtomicFlushMemTables({cfh->cfd()}, flush_options,
-                             FlushReason::kManualFlush,
-                             write_controller().IsStopped());
+                             FlushReason::kManualFlush);
   } else {
-    s = FlushMemTable(cfh->cfd(), flush_options, FlushReason::kManualFlush,
-                      write_controller().IsStopped());
+    s = FlushMemTable(cfh->cfd(), flush_options, FlushReason::kManualFlush);
   }
 
   ROCKS_LOG_INFO(immutable_db_options_.info_log,


### PR DESCRIPTION
This reverts commit 6d2577e5672a7abe7b41a67f1cccce3a6601b30e.

A proposal for resolving our current internal test failures. A fix is
being planned.

More context can be found: https://github.com/facebook/rocksdb/pull/9893#issuecomment-1126230634
TSAN error: https://github.com/facebook/rocksdb/pull/9893#issuecomment-1126233132