### PR TITLE
Fix a bug handling multiget index I/O error.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 * Fixed a bug where RocksDB could corrupt DBs with `avoid_flush_during_recovery == true` by removing valid WALs, leading to `Status::Corruption` with message like "SST file is ahead of WALs" when attempting to reopen.
 * Fixed a bug in async_io path where incorrect length of data is read by FilePrefetchBuffer if data is consumed from two populated buffers and request for more data is sent.
 * Fixed a CompactionFilter bug. Compaction filter used to use `Delete` to remove keys, even if the keys should be removed with `SingleDelete`. Mixing `Delete` and `SingleDelete` may cause undefined behavior.
+* Fixed a bug which might cause process crash when I/O error happens when reading an index block in MultiGet().
 
 ### New Features
 * DB::GetLiveFilesStorageInfo is ready for production use.

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -582,6 +582,7 @@ template <class TValue>
 template <typename DecodeEntryFunc>
 bool BlockIter<TValue>::ParseNextKey(bool* is_shared) {
   current_ = NextEntryOffset();
+  assert(data_ != nullptr);
   const char* p = data_ + current_;
   const char* limit = data_ + restarts_;  // Restarts come right after data
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2928,6 +2928,9 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
         }
         if (first_block) {
           iiter->Seek(key);
+          if (!iiter->Valid()) {
+            break;
+          }
         }
         first_block = false;
         iiter->Next();


### PR DESCRIPTION
Summary:
In one path of BlockBasedTable::MultiGet(), Next() is directly called after calling Seek() against the index iterator. This might cause crash if an I/O error happens in Seek().
The bug is discovered in crash test.

Test Plan: See existing CI tests pass.