### PR TITLE
Log error message when LinkFile() is not supported when ingesting files

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -142,6 +142,9 @@ Status ExternalSstFileIngestionJob::Prepare(
                  ingestion_options_.failed_move_fall_back_to_copy) {
         // Original file is on a different FS, use copy instead of hard linking.
         f.copy_file = true;
+        ROCKS_LOG_INFO(db_options_.info_log,
+                       "Triy to link file %s but it's not supported : %s",
+                       path_outside_db.c_str(), status.ToString().c_str());
       }
     } else {
       f.copy_file = true;

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -97,6 +97,10 @@ Status ImportColumnFamilyJob::Prepare(uint64_t next_file_number,
       if (status.IsNotSupported()) {
         // Original file is on a different FS, use copy instead of hard linking
         hardlink_files = false;
+        ROCKS_LOG_INFO(
+            db_options_.info_log,
+            "AddFile() tries to link file %s but it's not supported : %s",
+            f.internal_file_path.c_str(), status.ToString().c_str());
       }
     }
     if (!hardlink_files) {

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -97,10 +97,9 @@ Status ImportColumnFamilyJob::Prepare(uint64_t next_file_number,
       if (status.IsNotSupported()) {
         // Original file is on a different FS, use copy instead of hard linking
         hardlink_files = false;
-        ROCKS_LOG_INFO(
-            db_options_.info_log,
-            "AddFile() tries to link file %s but it's not supported : %s",
-            f.internal_file_path.c_str(), status.ToString().c_str());
+        ROCKS_LOG_INFO(db_options_.info_log,
+                       "Try to link file %s but it's not supported : %s",
+                       f.internal_file_path.c_str(), status.ToString().c_str());
       }
     }
     if (!hardlink_files) {


### PR DESCRIPTION
Summary:
Right now, whether moving file is skipped due to LinkFile() is not supported is opaque to users. Add a log message to help users debug.

Test Plan: Run existing test. Manual test verify the log message printed out.