### PR TITLE
reduce scanning of filemeta during purge and sizing

### DIFF
--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -119,7 +119,7 @@ class CompactionPickerTest : public testing::Test {
     f->compensated_file_size =
         (compensated_file_size != 0) ? compensated_file_size : file_size;
     f->oldest_ancester_time = oldest_ancestor_time;
-    vstorage->AddFile(level, f);
+    vstorage->AddFile(level, f, true /*newly_added*/);
     files_.emplace_back(f);
     file_map_.insert({file_number, {f, level}});
   }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1061,12 +1061,16 @@ class VersionBuilder::Rep {
       const auto& add_files = level_state.added_files;
       const auto add_it = add_files.find(file_number);
 
-      // Note: if the file appears both in the base version and in the added
-      // list, the added FileMetaData supersedes the one in the base version.
-      if (add_it != add_files.end() && add_it->second != f) {
-        vstorage->RemoveCurrentStats(f);
+      if (add_it != add_files.end()) {
+        // Note: if the file appears both in the base version and in the added
+        // list, the added FileMetaData supersedes the one in the base version.
+        if (add_it->second != f) {
+          vstorage->RemoveCurrentStats(f);
+        } else {
+          vstorage->AddFile(level, f, true /*newly_added*/);
+        }
       } else {
-        vstorage->AddFile(level, f);
+        vstorage->AddFile(level, f, false /*newly_added*/);
       }
     }
   }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1061,16 +1061,12 @@ class VersionBuilder::Rep {
       const auto& add_files = level_state.added_files;
       const auto add_it = add_files.find(file_number);
 
-      if (add_it != add_files.end()) {
-        // Note: if the file appears both in the base version and in the added
-        // list, the added FileMetaData supersedes the one in the base version.
-        if (add_it->second != f) {
-          vstorage->RemoveCurrentStats(f);
-        } else {
-          vstorage->AddFile(level, f, true /*newly_added*/);
-        }
+      // Note: if the file appears both in the base version and in the added
+      // list, the added FileMetaData supersedes the one in the base version.
+      if (add_it != add_files.end() && add_it->second != f) {
+        vstorage->RemoveCurrentStats(f);
       } else {
-        vstorage->AddFile(level, f, false /*newly_added*/);
+        vstorage->AddFile(level, f, add_it != add_files.end() /*newly_added*/);
       }
     }
   }

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -76,7 +76,7 @@ class VersionBuilderTest : public testing::Test {
     f->compensated_file_size = file_size;
     f->num_entries = num_entries;
     f->num_deletions = num_deletions;
-    vstorage_.AddFile(level, f);
+    vstorage_.AddFile(level, f, true /*newly_added*/);
     if (sampled) {
       f->init_stats_from_file = true;
       vstorage_.UpdateAccumulatedStats(f);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1724,7 +1724,7 @@ VersionStorageInfo::VersionStorageInfo(
       file_indexer_(user_comparator),
       compaction_style_(compaction_style),
       files_(new std::vector<FileMetaData*>[num_levels_]),
-      new_files_(1),
+      new_files_(0),
       base_level_(num_levels_ == 1 ? -1 : 1),
       level_multiplier_(0.0),
       files_by_compaction_pri_(num_levels_),
@@ -1742,8 +1742,6 @@ VersionStorageInfo::VersionStorageInfo(
       current_num_deletions_(0),
       current_num_samples_(0),
       estimated_compaction_needed_bytes_(0),
-      total_file_size_(0),
-      new_file_size_(0),
       finalized_(false),
       force_consistency_checks_(_force_consistency_checks) {
   if (ref_vstorage != nullptr) {
@@ -3080,11 +3078,8 @@ void VersionStorageInfo::AddFile(int level, FileMetaData* f, bool newly_added) {
 
   f->refs++;
 
-  auto file_size = f->fd.GetFileSize();
-  total_file_size_ += file_size;
   if (newly_added) {
     new_files_.push_back(f);
-    new_file_size_ += file_size;
   }
 }
 
@@ -5770,8 +5765,7 @@ uint64_t VersionSet::ApproximateSize(Version* v, const FdWithKeyRange& f,
 }
 
 void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
-                              std::vector<uint64_t>* live_blob_files,
-                              bool only_new_table_files) const {
+                              std::vector<uint64_t>* live_blob_files) const {
   assert(live_table_files);
   assert(live_blob_files);
 
@@ -5791,12 +5785,12 @@ void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
     assert(dummy_versions);
     Version* v = dummy_versions->next_;
     // Scan the full list of files from the first version.
-    const auto* vstorage0 = v->storage_info();
-    assert(vstorage0);
-    for (int level = 0; level < vstorage0->num_levels(); ++level) {
-      total_table_files += vstorage0->LevelFiles(level).size();
+    const auto* vstorage_first = v->storage_info();
+    assert(vstorage_first);
+    for (int level = 0; level < vstorage_first->num_levels(); ++level) {
+      total_table_files += vstorage_first->LevelFiles(level).size();
     }
-    total_blob_files += vstorage0->GetBlobFiles().size();
+    total_blob_files += vstorage_first->GetBlobFiles().size();
     v = v->next_;
 
     // Scan the delta list of files from other versions.
@@ -5831,6 +5825,9 @@ void VersionSet::AddLiveFiles(std::vector<uint64_t>* live_table_files,
     // Get the full list of files from the first version.
     v->AddLiveFiles(live_table_files, live_blob_files,
                     false /*only_new_table_files*/);
+    if (v == current) {
+      found_current = true;
+    }
     v = v->next_;
 
     for (; v != dummy_versions; v = v->next_) {
@@ -6063,31 +6060,45 @@ uint64_t VersionSet::GetNumLiveVersions(Version* dummy_versions) {
 }
 
 uint64_t VersionSet::GetTotalSstFilesSize(Version* dummy_versions) {
+  std::unordered_set<uint64_t> unique_files;
   uint64_t total_size = 0;
-  for (Version* v = dummy_versions->next_; v != dummy_versions; v = v->next_) {
+  // Get the size of all files from the first version.
+  Version* v = dummy_versions->next_;
+  VersionStorageInfo* storage_info_first = v->storage_info();
+  for (int level = 0; level < storage_info_first->num_levels_; level++) {
+    for (const auto& file_meta : storage_info_first->LevelFiles(level)) {
+      unique_files.insert(file_meta->fd.packed_number_and_path_id);
+      total_size += file_meta->fd.GetFileSize();
+    }
+  }
+  // Add the size of new files from other versions.
+  for (; v != dummy_versions; v = v->next_) {
     VersionStorageInfo* storage_info = v->storage_info();
-    if (total_size == 0) {
-      total_size = storage_info->total_file_size_;
-    } else {
-      total_size += storage_info->new_file_size_;
+    for (const auto& file_meta : storage_info->NewlyAddedFiles()) {
+      if (unique_files.find(file_meta->fd.packed_number_and_path_id) ==
+          unique_files.end()) {
+        unique_files.insert(file_meta->fd.packed_number_and_path_id);
+        total_size += file_meta->fd.GetFileSize();
+      }
     }
   }
 #ifndef NDEBUG
-  std::unordered_set<uint64_t> unique_files;
-  uint64_t total_size2 = 0;
-  for (Version* v = dummy_versions->next_; v != dummy_versions; v = v->next_) {
-    VersionStorageInfo* storage_info = v->storage_info();
+  std::unordered_set<uint64_t> full_scan_files;
+  uint64_t full_scan_size = 0;
+  for (Version* vv = dummy_versions->next_; vv != dummy_versions;
+       vv = vv->next_) {
+    VersionStorageInfo* storage_info = vv->storage_info();
     for (int level = 0; level < storage_info->num_levels_; level++) {
       for (const auto& file_meta : storage_info->LevelFiles(level)) {
-        if (unique_files.find(file_meta->fd.packed_number_and_path_id) ==
-            unique_files.end()) {
-          unique_files.insert(file_meta->fd.packed_number_and_path_id);
-          total_size2 += file_meta->fd.GetFileSize();
+        if (full_scan_files.find(file_meta->fd.packed_number_and_path_id) ==
+            full_scan_files.end()) {
+          full_scan_files.insert(file_meta->fd.packed_number_and_path_id);
+          full_scan_size += file_meta->fd.GetFileSize();
         }
       }
     }
   }
-  assert(total_size == total_size2);
+  assert(total_size == full_scan_size);
 #endif  // !NDEBUG
   return total_size;
 }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -685,11 +685,6 @@ class VersionStorageInfo {
   // target sizes.
   uint64_t estimated_compaction_needed_bytes_;
 
-  // total size of all table files
-  uint64_t total_file_size_;
-  // total size of newly added table files
-  uint64_t new_file_size_;
-
   bool finalized_;
 
   // If set to true, we will run consistency checks even if RocksDB
@@ -1288,8 +1283,7 @@ class VersionSet {
   // Add all files listed in any live version to *live_table_files and
   // *live_blob_files. Note that these lists may contain duplicates.
   void AddLiveFiles(std::vector<uint64_t>* live_table_files,
-                    std::vector<uint64_t>* live_blob_files,
-                    bool only_new_table_files = false) const;
+                    std::vector<uint64_t>* live_blob_files) const;
 
   // Return the approximate size of data to be scanned for range [start, end)
   // in levels [start_level, end_level). If end_level == -1 it will search

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -160,7 +160,7 @@ class VersionStorageInfoTestBase : public testing::Test {
         kUnknownFileChecksum, kUnknownFileChecksumFuncName,
         kDisableUserTimestamp, kDisableUserTimestamp);
     f->compensated_file_size = file_size;
-    vstorage_.AddFile(level, f);
+    vstorage_.AddFile(level, f, true /*newly_added*/);
   }
 
   void AddBlob(uint64_t blob_file_number, uint64_t total_blob_count,


### PR DESCRIPTION
For read-heavy workload over large dataset, excessive filemeta scanning has been causing foreground performance jitters for us. See https://github.com/facebook/rocksdb/pull/8494 for more details.

This patch reduces scanning filemeta by identifying and storing newly added files into a separate field of `VersionStorageInfo`. This implementation is much simpler than previous attempt.

Signed-off-by: tabokie <xy.tao@outlook.com>