### PR TITLE
Fix crash due to MultiGet async IO and direct IO

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -51,6 +51,7 @@ static void DeleteEntry(const Slice& /*key*/, void* value) {
 #undef WITHOUT_COROUTINES
 #define WITH_COROUTINES
 #include "db/table_cache_sync_and_async.h"
+#undef WITH_COROUTINES
 // clang-format on
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -82,6 +82,7 @@
 #undef WITHOUT_COROUTINES
 #define WITH_COROUTINES
 #include "db/version_set_sync_and_async.h"
+#undef WITH_COROUTINES
 // clang-format on
 
 namespace ROCKSDB_NAMESPACE {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -96,6 +96,7 @@ CacheAllocationPtr CopyBufferToHeap(MemoryAllocator* allocator, Slice& buf) {
 #undef WITHOUT_COROUTINES
 #define WITH_COROUTINES
 #include "table/block_based/block_based_table_reader_sync_and_async.h"
+#undef WITH_COROUTINES
 // clang-format on
 
 namespace ROCKSDB_NAMESPACE {


### PR DESCRIPTION
MultiGet with async IO is not officially supported with Posix yet. Avoid a crash by using synchronous MultiRead when direct IO is enabled.

Test:
Run db_crashtest.py manually
