### PR TITLE
Point libprotobuf-mutator to the latest verified commit hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,8 +152,8 @@ commands:
       - run:
           name: Install libprotobuf-mutator libs
           command: |
-            git clone --single-branch --branch master --depth 1 git@github.com:google/libprotobuf-mutator.git ~/libprotobuf-mutator
-            cd ~/libprotobuf-mutator && mkdir build && cd build
+            git clone -b v1.0 git@github.com:google/libprotobuf-mutator.git ~/libprotobuf-mutator
+            cd ~/libprotobuf-mutator && git checkout ffd86a32874e5c08a143019aad1aaf0907294c9f && mkdir build && cd build
             cmake .. -GNinja -DCMAKE_C_COMPILER=clang-13 -DCMAKE_CXX_COMPILER=clang++-13 -DCMAKE_BUILD_TYPE=Release -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON
             ninja && sudo ninja install
       - run:


### PR DESCRIPTION
Recent updates to https://github.com/google/libprotobuf-mutator has caused link errors for RocksDB
CircleCI job 'build-fuzzers'. This PR points the CI to a specific, most recent verified commit hash.

Test plan:
watch for CI to finish.