### PR TITLE
Fix failed VerifySstUniqueIds unittests

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -7,6 +7,7 @@
 
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
+#include "table/unique_id_impl.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -294,8 +295,8 @@ TEST_F(CompactionServiceTest, BasicCompactions) {
   SyncPoint::GetInstance()->SetCallBack(
       "Version::VerifySstUniqueIds::Passed", [&](void* arg) {
         // override job status
-        auto id = static_cast<std::string*>(arg);
-        assert(!id->empty());
+        auto id = static_cast<UniqueId64x2*>(arg);
+        assert(*id != kNullUniqueId64x2);
         verify_passed++;
       });
   SyncPoint::GetInstance()->EnableProcessing();

--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -16,6 +16,7 @@
 #include "rocksdb/comparator.h"
 #include "rocksdb/db.h"
 #include "rocksdb/transaction_log.h"
+#include "table/unique_id_impl.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -49,8 +50,8 @@ class RepairTest : public DBTestBase {
     SyncPoint::GetInstance()->SetCallBack(
         "Version::VerifySstUniqueIds::Passed", [&](void* arg) {
           // override job status
-          auto id = static_cast<std::string*>(arg);
-          assert(!id->empty());
+          auto id = static_cast<UniqueId64x2*>(arg);
+          assert(*id != kNullUniqueId64x2);
           verify_passed++;
         });
     SyncPoint::GetInstance()->EnableProcessing();


### PR DESCRIPTION
Summary: which should use UniqueId64x2 instead of string.

Test Plan: unittest