### PR TITLE
Skip ZSTD dict tests if the version doesn't support it

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1326,7 +1326,7 @@ TEST_F(DBTest2, PresetCompressionDict) {
           options.compression_opts.zstd_max_train_bytes = 0;
           break;
         case kWithZSTDfinalizeDict:
-          if (compression_type != kZSTD) {
+          if (compression_type != kZSTD || !ZSTD_FinalizeDictionarySupported()) {
             continue;
           }
           options.compression_opts.max_dict_bytes = kBlockSizeBytes;
@@ -1334,7 +1334,7 @@ TEST_F(DBTest2, PresetCompressionDict) {
           options.compression_opts.use_zstd_dict_trainer = false;
           break;
         case kWithZSTDTrainedDict:
-          if (compression_type != kZSTD) {
+          if (compression_type != kZSTD || !ZSTD_TrainDictionarySupported()) {
             continue;
           }
           options.compression_opts.max_dict_bytes = kBlockSizeBytes;

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1326,7 +1326,8 @@ TEST_F(DBTest2, PresetCompressionDict) {
           options.compression_opts.zstd_max_train_bytes = 0;
           break;
         case kWithZSTDfinalizeDict:
-          if (compression_type != kZSTD || !ZSTD_FinalizeDictionarySupported()) {
+          if (compression_type != kZSTD ||
+              !ZSTD_FinalizeDictionarySupported()) {
             continue;
           }
           options.compression_opts.max_dict_bytes = kBlockSizeBytes;


### PR DESCRIPTION
For example, the default ZSTD version for ubuntu20 is 1.4.4, which will
fail the test `PresetCompressionDict`:

```
db/db_test_util.cc:607: Failure
Invalid argument: zstd finalizeDictionary cannot be used because ZSTD 1.4.5+ is not linked with the binary.
terminate called after throwing an instance of 'testing::internal::GoogleTestFailureException'
```

Test Plan: test pass with old zstd