### PR TITLE
Fix ApproximateOffsetOfCompressed test

### DIFF
--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4016,7 +4016,7 @@ static void DoCompressionTest(CompressionType comp) {
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k02"), 0, 0));
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k03"), 2000, 3525));
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k04"), 2000, 3525));
-  ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"), 4000, 7050));
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"), 4000, 7075));
   c.ResetTableReader();
 }
 


### PR DESCRIPTION
Summary: #9857 introduced new an option `use_zstd_dict_trainer`, which
is stored in SST as text, e.g.:
```
...  zstd_max_train_bytes=0; enabled=0;...
```
it increased the sst size a little bit and cause
`ApproximateOffsetOfCompressed` test to fail:
```
Value 7053 is not in range [4000, 7050]
table/table_test.cc:4019: Failure
Value of: Between(c.ApproximateOffsetOf("xyz"), 4000, 7050)
```

Test Plan: verified the test pass after the change