### PR TITLE
Abort RocksDB performance regression test on failure in test setup

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -297,6 +297,7 @@ function build_checkpoint {
             echo "Building checkpoints: $ORIGIN_PATH/$db_index -> $DB_PATH/$db_index ..."
             $cmd_prefix $DB_BENCH_DIR/ldb checkpoint --checkpoint_dir=$DB_PATH/$db_index \
                         --db=$ORIGIN_PATH/$db_index --try_load_options 2>&1
+            exit_on_error $?
         done
     else
         # checkpoint cannot build in directory already exists
@@ -304,6 +305,7 @@ function build_checkpoint {
         echo "Building checkpoint: $ORIGIN_PATH -> $DB_PATH ..."
         $cmd_prefix $DB_BENCH_DIR/ldb checkpoint --checkpoint_dir=$DB_PATH \
                     --db=$ORIGIN_PATH --try_load_options 2>&1
+        exit_on_error $?
     fi
 }
 


### PR DESCRIPTION
Summary:
Need to exit if ldb command fails, to avoid running db_bench on
empty/bad DB and considering the results valid.

Differential Revision: D36673200

