### PR TITLE
Clarify the returning value of Customizable utilities

### DIFF
--- a/include/rocksdb/utilities/customizable_util.h
+++ b/include/rocksdb/utilities/customizable_util.h
@@ -222,7 +222,7 @@ static Status LoadManagedObject(const ConfigOptions& config_options,
   if (!status.ok()) {  // GetOptionsMap failed
     return status;
   } else if (value.empty()) {  // No Id and no options.  Clear the object
-    return Status::InvalidArgument("No ID or options available");
+    return Status::NotSupported("No ID or options available");
   } else {
     return NewManagedObject(config_options, id, opt_map, result);
   }
@@ -261,7 +261,7 @@ static Status NewUniqueObject(
     return status;
   } else if (opt_map.empty()) {
     // There was no ID and no map (everything empty).
-    return Status::InvalidArgument("No ID or options available");
+    return Status::NotSupported("No ID or options available");
   } else {
     return Status::NotSupported("Cannot reset object ");
   }
@@ -331,7 +331,7 @@ static Status NewStaticObject(
     return status;
   } else if (opt_map.empty()) {
     // There was no ID and no map (everything empty).
-    return Status::InvalidArgument("No ID or options available");
+    return Status::NotSupported("No ID or options available");
   } else {
     return Status::NotSupported("Cannot reset object ");
   }


### PR DESCRIPTION
Problem:

Function `NewSharedObject` returns OK without setting the result instance:
https://github.com/facebook/rocksdb/blob/4cf2f6723ac552bcc68ac7bafe201ac08931ecaf/include/rocksdb/utilities/customizable_util.h#L77-L78
Afterwards, in `RocksDBOptionsParser::EndSection`, table factory is treated as loaded when in fact it is still the default table factory of CFOptions.
https://github.com/facebook/rocksdb/blob/4cf2f6723ac552bcc68ac7bafe201ac08931ecaf/options/options_parser.cc#L456-L460

Summary:

Clarify the return semantics of Customizable utilities: always set returning instance when the function returns OK.

Signed-off-by: tabokie <xy.tao@outlook.com>