### PR TITLE
Pass the size of blob files to SstFileManager during DB open

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1935,12 +1935,12 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
 
     std::unordered_map<std::string, uint64_t> known_file_sizes;
     for (const auto& md : metadata) {
-      for (auto lmd : md.levels) {
-        for (auto fmd : lmd.files) {
+      for (const auto& lmd : md.levels) {
+        for (const auto& fmd : lmd.files) {
           known_file_sizes[fmd.relative_filename] = fmd.size;
         }
       }
-      for (auto bmd : md.blob_files) {
+      for (const auto& bmd : md.blob_files) {
         std::string name = bmd.blob_file_name;
         // The BlobMetaData.blob_file_name may start with "/".
         if (!name.empty() && name[0] == '/') {

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1930,21 +1930,24 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     // vast majority of all files), we'll pass the size to SstFileManager.
     // For all other files SstFileManager will query the size from filesystem.
 
-    std::vector<LiveFileMetaData> metadata;
-
-    // TODO: Once GetLiveFilesMetaData supports blob files, update the logic
-    // below to get known_file_sizes for blob files.
-    impl->mutex_.Lock();
-    impl->versions_->GetLiveFilesMetaData(&metadata);
-    impl->mutex_.Unlock();
+    std::vector<ColumnFamilyMetaData> metadata;
+    impl->GetAllColumnFamilyMetaData(&metadata);
 
     std::unordered_map<std::string, uint64_t> known_file_sizes;
     for (const auto& md : metadata) {
-      std::string name = md.name;
-      if (!name.empty() && name[0] == '/') {
-        name = name.substr(1);
+      for (auto lmd : md.levels) {
+        for (auto fmd : lmd.files) {
+          known_file_sizes[fmd.relative_filename] = fmd.size;
+        }
       }
-      known_file_sizes[name] = md.size;
+      for (auto bmd : md.blob_files) {
+        std::string name = bmd.blob_file_name;
+        // The BlobMetaData.blob_file_name may start with "/".
+        if (!name.empty() && name[0] == '/') {
+          name = name.substr(1);
+        }
+        known_file_sizes[name] = bmd.blob_file_size;
+      }
     }
 
     std::vector<std::string> paths;

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -1631,7 +1631,7 @@ TEST_F(DBSSTTest, GetTotalSstFilesSize) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
 
-TEST_F(DBSSTTest, GetTotalSstAndBlobFilesSize) {
+TEST_F(DBSSTTest, OpenDBWithoutGetFileSizeInvocations) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.compression = kNoCompression;

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -1660,7 +1660,7 @@ TEST_F(DBSSTTest, OpenDBWithoutGetFileSizeInvocations) {
         }
       });
 
-  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  SyncPoint::GetInstance()->EnableProcessing();
   Reopen(options);
 
   ASSERT_EQ(is_get_file_size_called, false);

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -1633,12 +1633,13 @@ TEST_F(DBSSTTest, GetTotalSstFilesSize) {
 
 TEST_F(DBSSTTest, OpenDBWithoutGetFileSizeInvocations) {
   Options options = CurrentOptions();
+  std::unique_ptr<MockEnv> env{MockEnv::Create(Env::Default())};
+  options.env = env.get();
   options.disable_auto_compactions = true;
   options.compression = kNoCompression;
   options.enable_blob_files = true;
   options.blob_file_size = 32;  // create one blob per file
   options.skip_checking_sst_file_sizes_on_db_open = true;
-  options.env = MockEnv::Create(Env::Default());
 
   DestroyAndReopen(options);
   // Generate 5 files in L0
@@ -1662,11 +1663,11 @@ TEST_F(DBSSTTest, OpenDBWithoutGetFileSizeInvocations) {
 
   SyncPoint::GetInstance()->EnableProcessing();
   Reopen(options);
-
-  ASSERT_EQ(is_get_file_size_called, false);
+  ASSERT_FALSE(is_get_file_size_called);
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 
   Destroy(options);
-  delete options.env;
 }
 
 TEST_F(DBSSTTest, GetTotalSstFilesSizeVersionsFilesShared) {

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -878,6 +878,7 @@ IOStatus MockFileSystem::GetFileSize(const std::string& fname,
                                      uint64_t* file_size,
                                      IODebugContext* /*dbg*/) {
   auto fn = NormalizeMockPath(fname);
+  TEST_SYNC_POINT_CALLBACK("MockFileSystem::GetFileSize:CheckFileType", &fn);
   MutexLock lock(&mutex_);
   auto iter = file_map_.find(fn);
   if (iter == file_map_.end()) {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1516,8 +1516,8 @@ class DB {
     GetColumnFamilyMetaData(DefaultColumnFamily(), metadata);
   }
 
-  // Obtains the LSM-tree meta data of all column families of the DB,
-  // including metadata for each live table (SST) file in the DB.
+  // Obtains the LSM-tree meta data of all column families of the DB, including
+  // metadata for each live table (SST) file and each blob file in the DB.
   virtual void GetAllColumnFamilyMetaData(
       std::vector<ColumnFamilyMetaData>* /*metadata*/) {}
 

--- a/include/rocksdb/metadata.h
+++ b/include/rocksdb/metadata.h
@@ -232,7 +232,7 @@ struct ColumnFamilyMetaData {
   uint64_t blob_file_size = 0;
   // The number of blob files in this column family.
   size_t blob_file_count = 0;
-  // The metadata of the blobs in this column family
+  // The metadata of the blobs in this column family.
   std::vector<BlobMetaData> blob_files;
 };
 


### PR DESCRIPTION
Summary:

RocksDB uses the (no longer aptly named) SST file manager (see https://github.com/facebook/rocksdb/wiki/Managing-Disk-Space-Utilization) to track and potentially limit the space used by SST and blob files (as well as to rate-limit the deletion of these data files). The SST file manager tracks the SST and blob file sizes in an in-memory hash map, which has to be rebuilt during DB open. File sizes can be generally obtained by querying the file system; however, there is a performance optimization possibility here since the sizes of SST and blob files are also tracked in the RocksDB MANIFEST, so we can simply pass the file sizes stored there instead of consulting the file system for each file. Currently, this optimization is only implemented for SST files; we would like to extend it to blob files as well.

Test Plan:

Add unit tests for the change to the test suite

Reviewers:

@ltamasi @riversand963  @akankshamahajan15 