### PR TITLE
Remove code that only compiles for Visual Studio versions older than 2015

### DIFF
--- a/db/c_test.c
+++ b/db/c_test.c
@@ -33,11 +33,6 @@ int geteuid() {
   return result;
 }
 
-// VS < 2015
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-#define snprintf _snprintf
-#endif
-
 #endif
 
 const char* phase = "";

--- a/include/rocksdb/io_status.h
+++ b/include/rocksdb/io_status.h
@@ -42,16 +42,8 @@ class IOStatus : public Status {
   // Copy the specified status.
   IOStatus(const IOStatus& s);
   IOStatus& operator=(const IOStatus& s);
-  IOStatus(IOStatus&& s)
-#if !(defined _MSC_VER) || ((defined _MSC_VER) && (_MSC_VER >= 1900))
-      noexcept
-#endif
-      ;
-  IOStatus& operator=(IOStatus&& s)
-#if !(defined _MSC_VER) || ((defined _MSC_VER) && (_MSC_VER >= 1900))
-      noexcept
-#endif
-      ;
+  IOStatus(IOStatus&& s) noexcept;
+  IOStatus& operator=(IOStatus&& s) noexcept;
   bool operator==(const IOStatus& rhs) const;
   bool operator!=(const IOStatus& rhs) const;
 
@@ -194,19 +186,11 @@ inline IOStatus& IOStatus::operator=(const IOStatus& s) {
   return *this;
 }
 
-inline IOStatus::IOStatus(IOStatus&& s)
-#if !(defined _MSC_VER) || ((defined _MSC_VER) && (_MSC_VER >= 1900))
-    noexcept
-#endif
-    : IOStatus() {
+inline IOStatus::IOStatus(IOStatus&& s) noexcept : IOStatus() {
   *this = std::move(s);
 }
 
-inline IOStatus& IOStatus::operator=(IOStatus&& s)
-#if !(defined _MSC_VER) || ((defined _MSC_VER) && (_MSC_VER >= 1900))
-    noexcept
-#endif
-{
+inline IOStatus& IOStatus::operator=(IOStatus&& s) noexcept {
   if (this != &s) {
 #ifdef ROCKSDB_ASSERT_STATUS_CHECKED
     s.checked_ = true;

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -56,16 +56,8 @@ class Status {
   // Copy the specified status.
   Status(const Status& s);
   Status& operator=(const Status& s);
-  Status(Status&& s)
-#if !(defined _MSC_VER) || ((defined _MSC_VER) && (_MSC_VER >= 1900))
-      noexcept
-#endif
-      ;
-  Status& operator=(Status&& s)
-#if !(defined _MSC_VER) || ((defined _MSC_VER) && (_MSC_VER >= 1900))
-      noexcept
-#endif
-      ;
+  Status(Status&& s) noexcept;
+  Status& operator=(Status&& s) noexcept;
   bool operator==(const Status& rhs) const;
   bool operator!=(const Status& rhs) const;
 
@@ -537,20 +529,12 @@ inline Status& Status::operator=(const Status& s) {
   return *this;
 }
 
-inline Status::Status(Status&& s)
-#if !(defined _MSC_VER) || ((defined _MSC_VER) && (_MSC_VER >= 1900))
-    noexcept
-#endif
-    : Status() {
+inline Status::Status(Status&& s) noexcept : Status() {
   s.MarkChecked();
   *this = std::move(s);
 }
 
-inline Status& Status::operator=(Status&& s)
-#if !(defined _MSC_VER) || ((defined _MSC_VER) && (_MSC_VER >= 1900))
-    noexcept
-#endif
-{
+inline Status& Status::operator=(Status&& s) noexcept {
   if (this != &s) {
     s.MarkChecked();
     MustCheck();

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -23,8 +23,6 @@
 
 #define __declspec(S)
 
-#define ROCKSDB_NOEXCEPT noexcept
-
 #undef PLATFORM_IS_LITTLE_ENDIAN
 #if defined(OS_MACOSX)
   #include <machine/endian.h>

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -70,19 +70,7 @@ extern const bool kDefaultToAdaptiveMutex;
 
 namespace port {
 
-// VS < 2015
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-
-// VS 15 has snprintf
-#define snprintf _snprintf
-
-#define ROCKSDB_NOEXCEPT
-
-#else // VS >= 2015 or MinGW
-
 #define ROCKSDB_NOEXCEPT noexcept
-
-#endif //_MSC_VER
 
 // "Windows is designed to run on little-endian computer architectures."
 // https://docs.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -70,8 +70,6 @@ extern const bool kDefaultToAdaptiveMutex;
 
 namespace port {
 
-#define ROCKSDB_NOEXCEPT noexcept
-
 // "Windows is designed to run on little-endian computer architectures."
 // https://docs.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
 constexpr bool kLittleEndian = true;
@@ -218,8 +216,8 @@ extern void InitOnce(OnceType* once, void (*initializer)());
 
 #ifdef ROCKSDB_JEMALLOC
 // Separate inlines so they can be replaced if needed
-void* jemalloc_aligned_alloc(size_t size, size_t alignment) ROCKSDB_NOEXCEPT;
-void jemalloc_aligned_free(void* p) ROCKSDB_NOEXCEPT;
+void* jemalloc_aligned_alloc(size_t size, size_t alignment) noexcept;
+void jemalloc_aligned_free(void* p) noexcept;
 #endif
 
 inline void *cacheline_aligned_alloc(size_t size) {

--- a/port/win/win_jemalloc.cc
+++ b/port/win/win_jemalloc.cc
@@ -41,10 +41,10 @@ ZSTD_customMem GetJeZstdAllocationOverrides() {
 
 namespace ROCKSDB_NAMESPACE {
 namespace port {
-void* jemalloc_aligned_alloc(size_t size, size_t alignment) ROCKSDB_NOEXCEPT {
+void* jemalloc_aligned_alloc(size_t size, size_t alignment) noexcept {
   return je_aligned_alloc(alignment, size);
 }
-void jemalloc_aligned_free(void* p) ROCKSDB_NOEXCEPT { je_free(p); }
+void jemalloc_aligned_free(void* p) noexcept { je_free(p); }
 }  // namespace port
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/table/format.h
+++ b/table/format.h
@@ -307,9 +307,7 @@ struct BlockContents {
     return usable_size() + sizeof(*this);
   }
 
-  BlockContents(BlockContents&& other) noexcept {
-    *this = std::move(other);
-  }
+  BlockContents(BlockContents&& other) noexcept { *this = std::move(other); }
 
   BlockContents& operator=(BlockContents&& other) {
     data = std::move(other.data);

--- a/table/format.h
+++ b/table/format.h
@@ -307,7 +307,7 @@ struct BlockContents {
     return usable_size() + sizeof(*this);
   }
 
-  BlockContents(BlockContents&& other) ROCKSDB_NOEXCEPT {
+  BlockContents(BlockContents&& other) noexcept {
     *this = std::move(other);
   }
 

--- a/table/scoped_arena_iterator.h
+++ b/table/scoped_arena_iterator.h
@@ -13,7 +13,7 @@
 namespace ROCKSDB_NAMESPACE {
 class ScopedArenaIterator {
 
-  void reset(InternalIterator* iter) ROCKSDB_NOEXCEPT {
+  void reset(InternalIterator* iter) noexcept {
     if (iter_ != nullptr) {
       iter_->~InternalIterator();
     }
@@ -28,12 +28,12 @@ class ScopedArenaIterator {
   ScopedArenaIterator(const ScopedArenaIterator&) = delete;
   ScopedArenaIterator& operator=(const ScopedArenaIterator&) = delete;
 
-  ScopedArenaIterator(ScopedArenaIterator&& o) ROCKSDB_NOEXCEPT {
+  ScopedArenaIterator(ScopedArenaIterator&& o) noexcept {
     iter_ = o.iter_;
     o.iter_ = nullptr;
   }
 
-  ScopedArenaIterator& operator=(ScopedArenaIterator&& o) ROCKSDB_NOEXCEPT {
+  ScopedArenaIterator& operator=(ScopedArenaIterator&& o) noexcept {
     reset(o.iter_);
     o.iter_ = nullptr;
     return *this;

--- a/table/scoped_arena_iterator.h
+++ b/table/scoped_arena_iterator.h
@@ -12,7 +12,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 class ScopedArenaIterator {
-
   void reset(InternalIterator* iter) noexcept {
     if (iter_ != nullptr) {
       iter_->~InternalIterator();

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -69,9 +69,7 @@ public:
       bufstart_(nullptr) {
   }
 
-  AlignedBuffer(AlignedBuffer&& o) noexcept {
-    *this = std::move(o);
-  }
+  AlignedBuffer(AlignedBuffer&& o) noexcept { *this = std::move(o); }
 
   AlignedBuffer& operator=(AlignedBuffer&& o) noexcept {
     alignment_ = std::move(o.alignment_);

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -69,11 +69,11 @@ public:
       bufstart_(nullptr) {
   }
 
-  AlignedBuffer(AlignedBuffer&& o) ROCKSDB_NOEXCEPT {
+  AlignedBuffer(AlignedBuffer&& o) noexcept {
     *this = std::move(o);
   }
 
-  AlignedBuffer& operator=(AlignedBuffer&& o) ROCKSDB_NOEXCEPT {
+  AlignedBuffer& operator=(AlignedBuffer&& o) noexcept {
     alignment_ = std::move(o.alignment_);
     buf_ = std::move(o.buf_);
     capacity_ = std::move(o.capacity_);

--- a/util/compression.h
+++ b/util/compression.h
@@ -86,12 +86,12 @@ class ZSTDUncompressCachedData {
   // Init from cache
   ZSTDUncompressCachedData(const ZSTDUncompressCachedData& o) = delete;
   ZSTDUncompressCachedData& operator=(const ZSTDUncompressCachedData&) = delete;
-  ZSTDUncompressCachedData(ZSTDUncompressCachedData&& o) ROCKSDB_NOEXCEPT
+  ZSTDUncompressCachedData(ZSTDUncompressCachedData&& o) noexcept
       : ZSTDUncompressCachedData() {
     *this = std::move(o);
   }
   ZSTDUncompressCachedData& operator=(ZSTDUncompressCachedData&& o)
-      ROCKSDB_NOEXCEPT {
+      noexcept {
     assert(zstd_ctx_ == nullptr);
     std::swap(zstd_ctx_, o.zstd_ctx_);
     std::swap(cache_idx_, o.cache_idx_);
@@ -138,9 +138,9 @@ class ZSTDUncompressCachedData {
   ZSTDUncompressCachedData(const ZSTDUncompressCachedData&) {}
   ZSTDUncompressCachedData& operator=(const ZSTDUncompressCachedData&) = delete;
   ZSTDUncompressCachedData(ZSTDUncompressCachedData&&)
-      ROCKSDB_NOEXCEPT = default;
+      noexcept = default;
   ZSTDUncompressCachedData& operator=(ZSTDUncompressCachedData&&)
-      ROCKSDB_NOEXCEPT = default;
+      noexcept = default;
   ZSTDNativeContext Get() const { return nullptr; }
   int64_t GetCacheIndex() const { return -1; }
   void CreateIfNeeded() {}

--- a/util/compression.h
+++ b/util/compression.h
@@ -90,8 +90,7 @@ class ZSTDUncompressCachedData {
       : ZSTDUncompressCachedData() {
     *this = std::move(o);
   }
-  ZSTDUncompressCachedData& operator=(ZSTDUncompressCachedData&& o)
-      noexcept {
+  ZSTDUncompressCachedData& operator=(ZSTDUncompressCachedData&& o) noexcept {
     assert(zstd_ctx_ == nullptr);
     std::swap(zstd_ctx_, o.zstd_ctx_);
     std::swap(cache_idx_, o.cache_idx_);
@@ -137,10 +136,9 @@ class ZSTDUncompressCachedData {
   ZSTDUncompressCachedData() {}
   ZSTDUncompressCachedData(const ZSTDUncompressCachedData&) {}
   ZSTDUncompressCachedData& operator=(const ZSTDUncompressCachedData&) = delete;
-  ZSTDUncompressCachedData(ZSTDUncompressCachedData&&)
-      noexcept = default;
-  ZSTDUncompressCachedData& operator=(ZSTDUncompressCachedData&&)
-      noexcept = default;
+  ZSTDUncompressCachedData(ZSTDUncompressCachedData&&) noexcept = default;
+  ZSTDUncompressCachedData& operator=(ZSTDUncompressCachedData&&) noexcept =
+      default;
   ZSTDNativeContext Get() const { return nullptr; }
   int64_t GetCacheIndex() const { return -1; }
   void CreateIfNeeded() {}

--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -3865,13 +3865,7 @@ XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTR
     (void)(&XXH_writeLE64);
     {   int const nbRounds = XXH_SECRET_DEFAULT_SIZE / sizeof(__m128i);
 
-#       if defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER < 1900
-        // MSVC 32bit mode does not support _mm_set_epi64x before 2015
-        XXH_ALIGN(16) const xxh_i64 seed64x2[2] = { (xxh_i64)seed64, (xxh_i64)(0U - seed64) };
-        __m128i const seed = _mm_load_si128((__m128i const*)seed64x2);
-#       else
         __m128i const seed = _mm_set_epi64x((xxh_i64)(0U - seed64), (xxh_i64)seed64);
-#       endif
         int i;
 
         XXH_ALIGN(64)        const float* const src  = (float const*) XXH3_kSecret;

--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -3865,7 +3865,13 @@ XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTR
     (void)(&XXH_writeLE64);
     {   int const nbRounds = XXH_SECRET_DEFAULT_SIZE / sizeof(__m128i);
 
+#       if defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER < 1900
+        // MSVC 32bit mode does not support _mm_set_epi64x before 2015
+        XXH_ALIGN(16) const xxh_i64 seed64x2[2] = { (xxh_i64)seed64, (xxh_i64)(0U - seed64) };
+        __m128i const seed = _mm_load_si128((__m128i const*)seed64x2);
+#       else
         __m128i const seed = _mm_set_epi64x((xxh_i64)(0U - seed64), (xxh_i64)seed64);
+#       endif
         int i;
 
         XXH_ALIGN(64)        const float* const src  = (float const*) XXH3_kSecret;

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -699,11 +699,11 @@ class BackupEngineImpl {
     CopyOrCreateWorkItem(const CopyOrCreateWorkItem&) = delete;
     CopyOrCreateWorkItem& operator=(const CopyOrCreateWorkItem&) = delete;
 
-    CopyOrCreateWorkItem(CopyOrCreateWorkItem&& o) ROCKSDB_NOEXCEPT {
+    CopyOrCreateWorkItem(CopyOrCreateWorkItem&& o) noexcept {
       *this = std::move(o);
     }
 
-    CopyOrCreateWorkItem& operator=(CopyOrCreateWorkItem&& o) ROCKSDB_NOEXCEPT {
+    CopyOrCreateWorkItem& operator=(CopyOrCreateWorkItem&& o) noexcept {
       src_path = std::move(o.src_path);
       dst_path = std::move(o.dst_path);
       src_temperature = std::move(o.src_temperature);
@@ -773,12 +773,12 @@ class BackupEngineImpl {
         dst_relative("") {}
 
     BackupAfterCopyOrCreateWorkItem(BackupAfterCopyOrCreateWorkItem&& o)
-        ROCKSDB_NOEXCEPT {
+        noexcept {
       *this = std::move(o);
     }
 
     BackupAfterCopyOrCreateWorkItem& operator=(
-        BackupAfterCopyOrCreateWorkItem&& o) ROCKSDB_NOEXCEPT {
+        BackupAfterCopyOrCreateWorkItem&& o) noexcept {
       result = std::move(o.result);
       shared = o.shared;
       needed_to_copy = o.needed_to_copy;
@@ -818,12 +818,12 @@ class BackupEngineImpl {
           to_file(_to_file),
           checksum_hex(_checksum_hex) {}
     RestoreAfterCopyOrCreateWorkItem(RestoreAfterCopyOrCreateWorkItem&& o)
-        ROCKSDB_NOEXCEPT {
+        noexcept {
       *this = std::move(o);
     }
 
     RestoreAfterCopyOrCreateWorkItem& operator=(
-        RestoreAfterCopyOrCreateWorkItem&& o) ROCKSDB_NOEXCEPT {
+        RestoreAfterCopyOrCreateWorkItem&& o) noexcept {
       result = std::move(o.result);
       checksum_hex = std::move(o.checksum_hex);
       return *this;

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -772,8 +772,8 @@ class BackupEngineImpl {
         dst_path(""),
         dst_relative("") {}
 
-    BackupAfterCopyOrCreateWorkItem(BackupAfterCopyOrCreateWorkItem&& o)
-        noexcept {
+    BackupAfterCopyOrCreateWorkItem(
+        BackupAfterCopyOrCreateWorkItem&& o) noexcept {
       *this = std::move(o);
     }
 
@@ -817,8 +817,8 @@ class BackupEngineImpl {
           from_file(_from_file),
           to_file(_to_file),
           checksum_hex(_checksum_hex) {}
-    RestoreAfterCopyOrCreateWorkItem(RestoreAfterCopyOrCreateWorkItem&& o)
-        noexcept {
+    RestoreAfterCopyOrCreateWorkItem(
+        RestoreAfterCopyOrCreateWorkItem&& o) noexcept {
       *this = std::move(o);
     }
 

--- a/utilities/persistent_cache/volatile_tier_impl.h
+++ b/utilities/persistent_cache/volatile_tier_impl.h
@@ -74,9 +74,8 @@ class VolatileCacheTier : public PersistentCacheTier {
   // Cache data abstraction
   //
   struct CacheData : LRUElement<CacheData> {
-    explicit CacheData(CacheData&& rhs) noexcept 
-        : key(std::move(rhs.key)),
-          value(std::move(rhs.value)) {}
+    explicit CacheData(CacheData&& rhs) noexcept
+        : key(std::move(rhs.key)), value(std::move(rhs.value)) {}
 
     explicit CacheData(const std::string& _key, const std::string& _value = "")
         : key(_key), value(_value) {}

--- a/utilities/persistent_cache/volatile_tier_impl.h
+++ b/utilities/persistent_cache/volatile_tier_impl.h
@@ -74,7 +74,7 @@ class VolatileCacheTier : public PersistentCacheTier {
   // Cache data abstraction
   //
   struct CacheData : LRUElement<CacheData> {
-    explicit CacheData(CacheData&& rhs) ROCKSDB_NOEXCEPT
+    explicit CacheData(CacheData&& rhs) noexcept 
         : key(std::move(rhs.key)),
           value(std::move(rhs.value)) {}
 


### PR DESCRIPTION
There are currently some preprocessor checks that assume support for Visual Studio versions older than 2015 (i.e., 0 < _MSC_VER < 1900), although we don't support them any more.

We removed all code that only compiles on those older versions, except third-party/ files.

The ROCKSDB_NOEXCEPT symbol is now obsolete, since it now always gets replaced by noexcept. We removed it.