### PR TITLE
Disable file ingestion in crash test for CF consistency

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -301,6 +301,8 @@ cf_consistency_params = {
     # Snapshots are used heavily in this test mode, while they are incompatible
     # with compaction filter.
     "enable_compaction_filter": 0,
+    # `CfConsistencyStressTest::TestIngestExternalFile()` is not implemented.
+    "ingest_external_file_one_in": 0,
 }
 
 txn_params = {


### PR DESCRIPTION
Test Plan:

```
$ python3 tools/db_crashtest.py --cf_consistency blackbox
```