### PR TITLE
Support specifying blob garbage collection parameters when CompactRange()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@
 
 ### New Features
 * Add FileSystem::ReadAsync API in io_tracing
+* Add blob garbage collection parameters `blob_garbage_collection_policy` and `blob_garbage_collection_age_cutoff` to both force-enable and force-disable GC, as well as selectively override age cutoff when using CompactRange. 
 
 ### Behavior changes
 * DB::Open(), DB::OpenAsSecondary() will fail if a Logger cannot be created (#9984)

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -215,7 +215,7 @@ Compaction::Compaction(
     uint32_t _max_subcompactions, std::vector<FileMetaData*> _grandparents,
     bool _manual_compaction, const std::string& _trim_ts, double _score,
     bool _deletion_compaction, CompactionReason _compaction_reason,
-    bool _enable_blob_garbage_collection,
+    BlobGarbageCollectionPolicy _blob_garbage_collection_policy,
     double _blob_garbage_collection_age_cutoff)
     : input_vstorage_(vstorage),
       start_level_(_inputs[0].level),
@@ -243,7 +243,7 @@ Compaction::Compaction(
       is_trivial_move_(false),
       compaction_reason_(_compaction_reason),
       notify_on_compaction_completion_(false),
-      enable_blob_garbage_collection_(_enable_blob_garbage_collection),
+      blob_garbage_collection_policy_(_blob_garbage_collection_policy),
       blob_garbage_collection_age_cutoff_(_blob_garbage_collection_age_cutoff) {
   MarkFilesBeingCompacted(true);
   if (is_manual_compaction_) {

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -214,7 +214,9 @@ Compaction::Compaction(
     CompressionOptions _compression_opts, Temperature _output_temperature,
     uint32_t _max_subcompactions, std::vector<FileMetaData*> _grandparents,
     bool _manual_compaction, const std::string& _trim_ts, double _score,
-    bool _deletion_compaction, CompactionReason _compaction_reason)
+    bool _deletion_compaction, CompactionReason _compaction_reason,
+    bool _enable_blob_garbage_collection,
+    double _blob_garbage_collection_age_cutoff)
     : input_vstorage_(vstorage),
       start_level_(_inputs[0].level),
       output_level_(_output_level),
@@ -240,7 +242,9 @@ Compaction::Compaction(
       trim_ts_(_trim_ts),
       is_trivial_move_(false),
       compaction_reason_(_compaction_reason),
-      notify_on_compaction_completion_(false) {
+      notify_on_compaction_completion_(false),
+      enable_blob_garbage_collection_(_enable_blob_garbage_collection),
+      blob_garbage_collection_age_cutoff_(_blob_garbage_collection_age_cutoff) {
   MarkFilesBeingCompacted(true);
   if (is_manual_compaction_) {
     compaction_reason_ = CompactionReason::kManualCompaction;
@@ -325,8 +329,8 @@ bool Compaction::IsTrivialMove() const {
   }
 
   if (!(start_level_ != output_level_ && num_input_levels() == 1 &&
-          input(0, 0)->fd.GetPathId() == output_path_id() &&
-          InputCompressionMatchesOutput())) {
+        input(0, 0)->fd.GetPathId() == output_path_id() &&
+        InputCompressionMatchesOutput())) {
     return false;
   }
 

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -81,7 +81,9 @@ class Compaction {
              std::vector<FileMetaData*> grandparents,
              bool manual_compaction = false, const std::string& trim_ts = "",
              double score = -1, bool deletion_compaction = false,
-             CompactionReason compaction_reason = CompactionReason::kUnknown);
+             CompactionReason compaction_reason = CompactionReason::kUnknown,
+             bool enable_blob_garbage_collection = false,
+             double blob_garbage_collection_age_cutoff = 0.25);
 
   // No copying allowed
   Compaction(const Compaction&) = delete;
@@ -306,6 +308,14 @@ class Compaction {
 
   uint32_t max_subcompactions() const { return max_subcompactions_; }
 
+  bool enable_blob_garbage_collection() const {
+    return enable_blob_garbage_collection_;
+  }
+
+  double blob_garbage_collection_age_cutoff() const {
+    return blob_garbage_collection_age_cutoff_;
+  }
+
   // start and end are sub compact range. Null if no boundary.
   // This is used to filter out some input files' ancester's time range.
   uint64_t MinInputFileOldestAncesterTime(const InternalKey* start,
@@ -332,8 +342,9 @@ class Compaction {
 
   // Get the atomic file boundaries for all files in the compaction. Necessary
   // in order to avoid the scenario described in
-  // https://github.com/facebook/rocksdb/pull/4432#discussion_r221072219 and plumb
-  // down appropriate key boundaries to RangeDelAggregator during compaction.
+  // https://github.com/facebook/rocksdb/pull/4432#discussion_r221072219 and
+  // plumb down appropriate key boundaries to RangeDelAggregator during
+  // compaction.
   static std::vector<CompactionInputFiles> PopulateWithAtomicBoundaries(
       VersionStorageInfo* vstorage, std::vector<CompactionInputFiles> inputs);
 
@@ -348,7 +359,7 @@ class Compaction {
 
   VersionStorageInfo* input_vstorage_;
 
-  const int start_level_;    // the lowest level to be compacted
+  const int start_level_;   // the lowest level to be compacted
   const int output_level_;  // levels to which output files are stored
   uint64_t max_output_file_size_;
   uint64_t max_compaction_bytes_;
@@ -359,7 +370,7 @@ class Compaction {
   VersionEdit edit_;
   const int number_levels_;
   ColumnFamilyData* cfd_;
-  Arena arena_;          // Arena used to allocate space for file_levels_
+  Arena arena_;  // Arena used to allocate space for file_levels_
 
   const uint32_t output_path_id_;
   CompressionType output_compression_;
@@ -377,7 +388,7 @@ class Compaction {
   // State used to check for number of overlapping grandparent files
   // (grandparent == "output_level_ + 1")
   std::vector<FileMetaData*> grandparents_;
-  const double score_;         // score that was used to pick this compaction.
+  const double score_;  // score that was used to pick this compaction.
 
   // Is this compaction creating a file in the bottom most level?
   const bool bottommost_level_;
@@ -412,6 +423,12 @@ class Compaction {
   // Notify on compaction completion only if listener was notified on compaction
   // begin.
   bool notify_on_compaction_completion_;
+
+  // Enable/disable garbage collection for blobs during compaction.
+  bool enable_blob_garbage_collection_;
+
+  // Blob garbage collection age threshold.
+  double blob_garbage_collection_age_cutoff_;
 };
 
 // Return sum of sizes of all files in `files`.

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -83,7 +83,7 @@ class Compaction {
              double score = -1, bool deletion_compaction = false,
              CompactionReason compaction_reason = CompactionReason::kUnknown,
              BlobGarbageCollectionPolicy blob_garbage_collection_policy =
-                 BlobGarbageCollectionPolicy::kUserDefault,
+                 BlobGarbageCollectionPolicy::kUseDefault,
              double blob_garbage_collection_age_cutoff = -1);
 
   // No copying allowed
@@ -310,19 +310,10 @@ class Compaction {
   uint32_t max_subcompactions() const { return max_subcompactions_; }
 
   bool enable_blob_garbage_collection() const {
-    if (blob_garbage_collection_policy_ ==
-        BlobGarbageCollectionPolicy::kDisable) {
-      return false;
-    }
-    return blob_garbage_collection_policy_ ==
-               BlobGarbageCollectionPolicy::kForce ||
-           mutable_cf_options()->enable_blob_garbage_collection;
+    return enable_blob_garbage_collection_;
   }
 
   double blob_garbage_collection_age_cutoff() const {
-    if (blob_garbage_collection_age_cutoff_ < 0) {
-      return mutable_cf_options()->blob_garbage_collection_age_cutoff;
-    }
     return blob_garbage_collection_age_cutoff_;
   }
 
@@ -434,12 +425,10 @@ class Compaction {
   // begin.
   bool notify_on_compaction_completion_;
 
-  // Force-enable/force-disable GC collection for blobs during compaction.
-  BlobGarbageCollectionPolicy blob_garbage_collection_policy_;
+  // Enable/disable GC collection for blobs during compaction.
+  bool enable_blob_garbage_collection_;
 
   // Blob garbage collection age cutoff.
-  // Note that it will not override the age cutoff in the DB options if it is
-  // a negative value.
   double blob_garbage_collection_age_cutoff_;
 };
 

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -142,12 +142,17 @@ class CompactionIterator {
     }
 
     bool enable_blob_garbage_collection() const override {
-      return compaction_->mutable_cf_options()->enable_blob_garbage_collection;
+      return compaction_->enable_blob_garbage_collection() ||
+             compaction_->mutable_cf_options()->enable_blob_garbage_collection;
     }
 
     double blob_garbage_collection_age_cutoff() const override {
-      return compaction_->mutable_cf_options()
-          ->blob_garbage_collection_age_cutoff;
+      if (compaction_->enable_blob_garbage_collection()) {
+        return compaction_->blob_garbage_collection_age_cutoff();
+      } else {
+        return compaction_->mutable_cf_options()
+            ->blob_garbage_collection_age_cutoff;
+      }
     }
 
     uint64_t blob_compaction_readahead_size() const override {

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -142,17 +142,11 @@ class CompactionIterator {
     }
 
     bool enable_blob_garbage_collection() const override {
-      return compaction_->enable_blob_garbage_collection() ||
-             compaction_->mutable_cf_options()->enable_blob_garbage_collection;
+      return compaction_->enable_blob_garbage_collection();
     }
 
     double blob_garbage_collection_age_cutoff() const override {
-      if (compaction_->enable_blob_garbage_collection()) {
-        return compaction_->blob_garbage_collection_age_cutoff();
-      } else {
-        return compaction_->mutable_cf_options()
-            ->blob_garbage_collection_age_cutoff;
-      }
+      return compaction_->blob_garbage_collection_age_cutoff();
     }
 
     uint64_t blob_compaction_readahead_size() const override {

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -640,7 +640,11 @@ Compaction* CompactionPicker::CompactRange(
         GetCompressionType(vstorage, mutable_cf_options, output_level, 1),
         GetCompressionOptions(mutable_cf_options, vstorage, output_level),
         Temperature::kUnknown, compact_range_options.max_subcompactions,
-        /* grandparents */ {}, /* is manual */ true, trim_ts);
+        /* grandparents */ {}, /* is manual */ true, trim_ts, /* score */ -1,
+        /* deletion_compaction */ false, CompactionReason::kUnknown,
+        compact_range_options.enable_blob_garbage_collection,
+        compact_range_options.blob_garbage_collection_age_cutoff);
+
     RegisterCompaction(c);
     vstorage->ComputeCompactionScore(ioptions_, mutable_cf_options);
     return c;
@@ -818,8 +822,10 @@ Compaction* CompactionPicker::CompactRange(
                          vstorage->base_level()),
       GetCompressionOptions(mutable_cf_options, vstorage, output_level),
       Temperature::kUnknown, compact_range_options.max_subcompactions,
-      std::move(grandparents),
-      /* is manual compaction */ true, trim_ts);
+      std::move(grandparents), /* is manual */ true, trim_ts, /* score */ -1,
+      /* deletion_compaction */ false, CompactionReason::kUnknown,
+      compact_range_options.enable_blob_garbage_collection,
+      compact_range_options.blob_garbage_collection_age_cutoff);
 
   TEST_SYNC_POINT_CALLBACK("CompactionPicker::CompactRange:Return", compaction);
   RegisterCompaction(compaction);

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -642,7 +642,7 @@ Compaction* CompactionPicker::CompactRange(
         Temperature::kUnknown, compact_range_options.max_subcompactions,
         /* grandparents */ {}, /* is manual */ true, trim_ts, /* score */ -1,
         /* deletion_compaction */ false, CompactionReason::kUnknown,
-        compact_range_options.enable_blob_garbage_collection,
+        compact_range_options.blob_garbage_collection_policy,
         compact_range_options.blob_garbage_collection_age_cutoff);
 
     RegisterCompaction(c);
@@ -824,7 +824,7 @@ Compaction* CompactionPicker::CompactRange(
       Temperature::kUnknown, compact_range_options.max_subcompactions,
       std::move(grandparents), /* is manual */ true, trim_ts, /* score */ -1,
       /* deletion_compaction */ false, CompactionReason::kUnknown,
-      compact_range_options.enable_blob_garbage_collection,
+      compact_range_options.blob_garbage_collection_policy,
       compact_range_options.blob_garbage_collection_age_cutoff);
 
   TEST_SYNC_POINT_CALLBACK("CompactionPicker::CompactRange:Return", compaction);

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -6383,13 +6383,17 @@ class DBCompactionTestBlobGC
   bool updated_enable_blob_files_;
 };
 
-TEST_F(DBCompactionTest, CompactionWithBlobGCOverrides) {
+INSTANTIATE_TEST_CASE_P(DBCompactionTestBlobGC, DBCompactionTestBlobGC,
+                        ::testing::Combine(::testing::Values(0.0, 0.5, 1.0),
+                                           ::testing::Bool()));
+
+TEST_P(DBCompactionTestBlobGC, CompactionWithBlobGCOverrides) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.enable_blob_files = true;
   options.blob_file_size = 32;  // one blob per file
   options.enable_blob_garbage_collection = true;
-  options.blob_garbage_collection_age_cutoff = 0.2;
+  options.blob_garbage_collection_age_cutoff = 0;
 
   DestroyAndReopen(options);
 
@@ -6407,66 +6411,49 @@ TEST_F(DBCompactionTest, CompactionWithBlobGCOverrides) {
   // garbage collected values getting inlined.
   ASSERT_OK(db_->SetOptions({{"enable_blob_files", "false"}}));
 
-  for (int k = 0; k < 5; k++) {
-    CompactRangeOptions cro;
-    cro.enable_blob_garbage_collection = true;
-    cro.blob_garbage_collection_age_cutoff = 0.2 * (k + 1);
+  CompactRangeOptions cro;
+  cro.blob_garbage_collection_policy = BlobGarbageCollectionPolicy::kForce;
+  cro.blob_garbage_collection_age_cutoff = blob_gc_age_cutoff_;
 
-    ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
+  ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
 
-    // Check that the GC stats are correct
-    {
-      VersionSet* const versions = dbfull()->GetVersionSet();
-      assert(versions);
-      assert(versions->GetColumnFamilySet());
+  // Check that the GC stats are correct
+  {
+    VersionSet* const versions = dbfull()->GetVersionSet();
+    assert(versions);
+    assert(versions->GetColumnFamilySet());
 
-      ColumnFamilyData* const cfd =
-          versions->GetColumnFamilySet()->GetDefault();
-      assert(cfd);
+    ColumnFamilyData* const cfd = versions->GetColumnFamilySet()->GetDefault();
+    assert(cfd);
 
-      const InternalStats* const internal_stats = cfd->internal_stats();
-      assert(internal_stats);
+    const InternalStats* const internal_stats = cfd->internal_stats();
+    assert(internal_stats);
 
-      const auto& compaction_stats = internal_stats->TEST_GetCompactionStats();
-      ASSERT_GE(compaction_stats.size(), 2);
+    const auto& compaction_stats = internal_stats->TEST_GetCompactionStats();
+    ASSERT_GE(compaction_stats.size(), 2);
 
-      ASSERT_GT(compaction_stats[1].bytes_read_blob, 0);
-      ASSERT_EQ(compaction_stats[1].bytes_written_blob, 0);
-    }
+    ASSERT_GE(compaction_stats[1].bytes_read_blob, 0);
+    ASSERT_EQ(compaction_stats[1].bytes_written_blob, 0);
+  }
 
-    // Expected number of blob files after each compaction:
-    //
-    // 1st iteration: 128 * (1 - 0.2) = 103
-    // 2nd iteration: 103 * (1 - 0.4) =  62
-    // 3rd iteration:  62 * (1 - 0.6) =  25
-    // 4th iteration:  25 * (1 - 0.8) =   5
-    // 5th iteration:   5 * (1 - 1.0) =   0
-    const size_t cutoff_index = static_cast<size_t>(
-        cro.blob_garbage_collection_age_cutoff * original_blob_files.size());
-    const size_t expected_num_files = original_blob_files.size() - cutoff_index;
+  const size_t cutoff_index = static_cast<size_t>(
+      cro.blob_garbage_collection_age_cutoff * original_blob_files.size());
+  const size_t expected_num_files = original_blob_files.size() - cutoff_index;
 
-    const std::vector<uint64_t> new_blob_files = GetBlobFileNumbers();
+  const std::vector<uint64_t> new_blob_files = GetBlobFileNumbers();
 
-    ASSERT_EQ(new_blob_files.size(), expected_num_files);
+  ASSERT_EQ(new_blob_files.size(), expected_num_files);
 
-    // Original blob files below the cutoff should be gone, original blob files
-    // at or above the cutoff should be still there
-    for (size_t i = cutoff_index; i < original_blob_files.size(); ++i) {
-      ASSERT_EQ(new_blob_files[i - cutoff_index], original_blob_files[i]);
-    }
+  // Original blob files below the cutoff should be gone, original blob files
+  // at or above the cutoff should be still there
+  for (size_t i = cutoff_index; i < original_blob_files.size(); ++i) {
+    ASSERT_EQ(new_blob_files[i - cutoff_index], original_blob_files[i]);
+  }
 
-    // Delete inlined values
-    for (size_t i = 0; i < cutoff_index; ++i) {
-      ASSERT_OK(Delete("key" + std::to_string(i)));
-    }
-
-    original_blob_files = std::move(new_blob_files);
+  for (size_t i = 0; i < 128; ++i) {
+    ASSERT_EQ(Get("key" + std::to_string(i)), "value" + std::to_string(i));
   }
 }
-
-INSTANTIATE_TEST_CASE_P(DBCompactionTestBlobGC, DBCompactionTestBlobGC,
-                        ::testing::Combine(::testing::Values(0.0, 0.5, 1.0),
-                                           ::testing::Bool()));
 
 TEST_P(DBCompactionTestBlobGC, CompactionWithBlobGC) {
   Options options;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2115,7 +2115,7 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
   std::vector<BlobGarbageCollectionPolicy> blob_gc_policies = {
       BlobGarbageCollectionPolicy::kForce,
       BlobGarbageCollectionPolicy::kDisable,
-      BlobGarbageCollectionPolicy::kUserDefault};
+      BlobGarbageCollectionPolicy::kUseDefault};
   cro.blob_garbage_collection_policy =
       blob_gc_policies[thread->rand.Next() %
                        static_cast<uint32_t>(blob_gc_policies.size())];

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -674,7 +674,7 @@ void StressTest::OperateDb(ThreadState* thread) {
 #ifndef NDEBUG
   if (FLAGS_read_fault_one_in) {
     fault_fs_guard->SetThreadLocalReadErrorContext(thread->shared->GetSeed(),
-                                            FLAGS_read_fault_one_in);
+                                                   FLAGS_read_fault_one_in);
   }
 #endif  // NDEBUG
   if (FLAGS_write_fault_one_in) {
@@ -2112,6 +2112,14 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
                           static_cast<uint32_t>(bottom_level_styles.size())];
   cro.allow_write_stall = static_cast<bool>(thread->rand.Next() % 2);
   cro.max_subcompactions = static_cast<uint32_t>(thread->rand.Next() % 4);
+  cro.enable_blob_garbage_collection =
+      static_cast<bool>(thread->rand.Next() % 2);
+
+  if (FLAGS_enable_blob_files && FLAGS_enable_blob_garbage_collection) {
+    cro.enable_blob_garbage_collection = true;
+    cro.blob_garbage_collection_age_cutoff =
+        static_cast<double>(thread->rand.Next() % 100) / 100.0;
+  }
 
   const Snapshot* pre_snapshot = nullptr;
   uint32_t pre_hash = 0;
@@ -2315,7 +2323,8 @@ void StressTest::PrintEnv() const {
   fprintf(stdout, "Open metadata write fault one in:\n");
   fprintf(stdout, "                            %d\n",
           FLAGS_open_metadata_write_fault_one_in);
-  fprintf(stdout, "Sync fault injection      : %d\n", FLAGS_sync_fault_injection);
+  fprintf(stdout, "Sync fault injection      : %d\n",
+          FLAGS_sync_fault_injection);
   fprintf(stdout, "Best efforts recovery     : %d\n",
           static_cast<int>(FLAGS_best_efforts_recovery));
   fprintf(stdout, "Fail if OPTIONS file error: %d\n",
@@ -2690,7 +2699,7 @@ void StressTest::Reopen(ThreadState* thread) {
   }
   assert(!write_prepared || bg_canceled);
 #else
-  (void) thread;
+  (void)thread;
 #endif
 
   for (auto cf : column_families_) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2112,14 +2112,15 @@ void StressTest::TestCompactRange(ThreadState* thread, int64_t rand_key,
                           static_cast<uint32_t>(bottom_level_styles.size())];
   cro.allow_write_stall = static_cast<bool>(thread->rand.Next() % 2);
   cro.max_subcompactions = static_cast<uint32_t>(thread->rand.Next() % 4);
-  cro.enable_blob_garbage_collection =
-      static_cast<bool>(thread->rand.Next() % 2);
-
-  if (FLAGS_enable_blob_files && FLAGS_enable_blob_garbage_collection) {
-    cro.enable_blob_garbage_collection = true;
-    cro.blob_garbage_collection_age_cutoff =
-        static_cast<double>(thread->rand.Next() % 100) / 100.0;
-  }
+  std::vector<BlobGarbageCollectionPolicy> blob_gc_policies = {
+      BlobGarbageCollectionPolicy::kForce,
+      BlobGarbageCollectionPolicy::kDisable,
+      BlobGarbageCollectionPolicy::kUserDefault};
+  cro.blob_garbage_collection_policy =
+      blob_gc_policies[thread->rand.Next() %
+                       static_cast<uint32_t>(blob_gc_policies.size())];
+  cro.blob_garbage_collection_age_cutoff =
+      static_cast<double>(thread->rand.Next() % 100) / 100.0;
 
   const Snapshot* pre_snapshot = nullptr;
   uint32_t pre_hash = 0;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1823,6 +1823,18 @@ struct CompactRangeOptions {
   // Cancellation can be delayed waiting on automatic compactions when used
   // together with `exclusive_manual_compaction == true`.
   std::atomic<bool>* canceled = nullptr;
+
+  // If set to true, it will replace the option in the ColumnFamilyOptions for
+  // this compaction. The compaction will perform garbage collection (GC) of
+  // blobs that are no longer referenced by any live SST files. Also, valid
+  // blobs residing in blob files older than a cutoff get relocated to new files
+  // as they are encountered during compaction.
+  bool enable_blob_garbage_collection = false;
+
+  // The cutoff in terms of blob file age for garbage collection.
+  // Note that enable_blob_garbage_collection has to be set in order for this
+  // option to have any effect.
+  double blob_garbage_collection_age_cutoff = 0.25;
 };
 
 // IngestExternalFileOptions is used by IngestExternalFile()

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1798,8 +1798,8 @@ enum class BlobGarbageCollectionPolicy {
   kForce,
   // Skip blob file garbage collection.
   kDisable,
-  // Inherit blob file garbage collection policy from DBOptions.
-  kUserDefault,
+  // Inherit blob file garbage collection policy from ColumnFamilyOptions.
+  kUseDefault,
 };
 
 // CompactRangeOptions is used by CompactRange() call.
@@ -1835,19 +1835,17 @@ struct CompactRangeOptions {
   // together with `exclusive_manual_compaction == true`.
   std::atomic<bool>* canceled = nullptr;
 
-  // If set to kForce, it will perform garbage collection (GC) of blobs that are
-  // no longer referenced by any live SST files. If set to kDisable, it will not
-  // perform GC. Both kForce and kDisable will override user-provided setting in
-  // DBOptions.enable_blob_garbage_collection. This enables customers to both
-  // force-enable and force-disable GC when calling CompactRange as well as
-  // selectively override the age cutoff.
+  // If set to kForce, RocksDB will override enable_blob_file_garbage_collection
+  // to true; if set to kDisable, RocksDB will override it to false, and
+  // kUseDefault leaves the setting in effect. This enables customers to both
+  // force-enable and force-disable GC when calling CompactRange.
   BlobGarbageCollectionPolicy blob_garbage_collection_policy =
-      BlobGarbageCollectionPolicy::kUserDefault;
+      BlobGarbageCollectionPolicy::kUseDefault;
 
-  // If set to a negative value, it will use the user-provided value from
-  // DBOptions.blob_garbage_collection_age_cutoff. Otherwise, it will override
-  // the user-provided setting. This enables customers to selectively override
-  // the age cutoff.
+  // If set to < 0 or > 1, RocksDB leaves blob_garbage_collection_age_cutoff
+  // from ColumnFamilyOptions in effect. Otherwise, it will override the
+  // user-provided setting. This enables customers to selectively override the
+  // age cutoff.
   double blob_garbage_collection_age_cutoff = -1;
 };
 


### PR DESCRIPTION
Summary:

Garbage collection is generally controlled by the BlobDB configuration options `enable_blob_garbage_collection` and `blob_garbage_collection_age_cutoff`. However, there might be use cases where we would want to temporarily override these options while performing a manual compaction. (One use case would be doing a full key-space manual compaction with full=100% garbage collection age cutoff in order to minimize the space occupied by the database.) Our goal here is to make it possible to override the configured GC parameters when using the `CompactRange` API to perform manual compactions. This PR would involve:

- Extending the `CompactRangeOptions` structure so clients can both force-enable and force-disable GC, as well as use a different cutoff than what's currently configured
- Storing whether blob GC should actually be enabled during a certain manual compaction and the cutoff to use in the `Compaction` object (considering the above overrides) and passing it to `CompactionIterator` via `CompactionProxy`
- Updating the BlobDB wiki to document the new options.

Test Plan:

Adding unit tests and adding the new options to the stress test tool.

Reviewers: