### PR TITLE
Add TransactionLogIterator::RecycleWriteBatch() API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
 ### Public API changes
+* Add TransactionLogIterator::RecycleWriteBatch() method to optionally recycle a WriteBatch handed out by TransactionLogIterator::GetBatch(). This is an optional API that can be used to avoid repeated memory allocations for new WriteBatch objects when calling GetBatch() on the same TransactionLogIterator instance. Using the API is performance optimization which should not affect correctness.
 * Add new API GetUnixTime in Snapshot class which returns the unix time at which Snapshot is taken.
 * Add transaction `get_pinned` and `multi_get` to C API.
 * Add two-phase commit support to C API.
@@ -16,6 +17,9 @@
 
 ### Behavior changes
 * DB::Open(), DB::OpenAsSecondary() will fail if a Logger cannot be created (#9984)
+
+### Performance Improvements
+* Embedders can use the new TransactionLogIterator::RecycleWriteBatch() method to optionally return a WriteBatch handed out by TransactionLogIterator::GetBatch() back to the TransactionLogIterator. This is an optional API that can be used to avoid repeated memory allocations for new WriteBatch objects when calling GetBatch() on the same TransactionLogIterator instance.
 
 ## 7.3.0 (05/20/2022)
 ### Bug Fixes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,7 +19,7 @@
 * DB::Open(), DB::OpenAsSecondary() will fail if a Logger cannot be created (#9984)
 
 ### Performance Improvements
-* Embedders can use the new TransactionLogIterator::RecycleWriteBatch() method to optionally return a WriteBatch handed out by TransactionLogIterator::GetBatch() back to the TransactionLogIterator. This is an optional API that can be used to avoid repeated memory allocations for new WriteBatch objects when calling GetBatch() on the same TransactionLogIterator instance.
+* Embedders can use the new TransactionLogIterator::RecycleWriteBatch() method to optionally return a WriteBatch handed out by TransactionLogIterator::GetBatch() back to the TransactionLogIterator. This is an optional API that can be used to avoid repeated memory allocations for new WriteBatch objects.
 
 ## 7.3.0 (05/20/2022)
 ### Bug Fixes

--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -45,6 +45,7 @@ SequenceNumber ReadRecords(std::unique_ptr<TransactionLogIterator>& iter,
     ++count;
     lastSequence = res.sequence;
     EXPECT_OK(iter->status());
+    iter->RecycleWriteBatch(std::move(res.writeBatchPtr));
     iter->Next();
   }
   if (expect_ok) {

--- a/db/transaction_log_impl.cc
+++ b/db/transaction_log_impl.cc
@@ -87,6 +87,10 @@ void TransactionLogIteratorImpl::RecycleWriteBatch(
     std::unique_ptr<WriteBatch> write_batch) {
   assert(write_batch);
   current_batch_ = std::move(write_batch);
+  if (current_batch_) {
+    // Reset the previous instance so it is ready for reuse.
+    current_batch_->Clear();
+  }
 }
 
 Status TransactionLogIteratorImpl::status() { return current_status_; }
@@ -257,7 +261,8 @@ void TransactionLogIteratorImpl::UpdateCurrentWriteBatch(const Slice& record) {
     // No WriteBatch present, so create a new instance.
     current_batch_ = std::make_unique<WriteBatch>();
   } else {
-    // Reset the previous instance to save repeated memory allocations.
+    // Reset the previous instance. It may be empty already, but
+    // it is better to err on the side of caution here.
     current_batch_->Clear();
   }
 

--- a/db/transaction_log_impl.h
+++ b/db/transaction_log_impl.h
@@ -74,6 +74,9 @@ class TransactionLogIteratorImpl : public TransactionLogIterator {
 
   virtual BatchResult GetBatch() override;
 
+  virtual void RecycleWriteBatch(
+      std::unique_ptr<WriteBatch> write_batch) override;
+
  private:
   const std::string& dir_;
   const ImmutableDBOptions* options_;

--- a/db/wal_manager_test.cc
+++ b/db/wal_manager_test.cc
@@ -209,6 +209,7 @@ int CountRecords(TransactionLogIterator* iter) {
     ++count;
     lastSequence = res.sequence;
     EXPECT_OK(iter->status());
+    iter->RecycleWriteBatch(std::move(res.writeBatchPtr));
     iter->Next();
   }
   EXPECT_OK(iter->status());

--- a/include/rocksdb/transaction_log.h
+++ b/include/rocksdb/transaction_log.h
@@ -105,6 +105,16 @@ class TransactionLogIterator {
   // ONLY use if Valid() is true and status() is OK.
   virtual BatchResult GetBatch() = 0;
 
+  // Return a WriteBatch returned by GetBatch() to the TransactionLogIterator.
+  // Embedders can optionally use this API to recycle already handed-out
+  // WriteBatches and avoid repeated allocations for retrieving WriteBatches
+  // via repeated calls to GetBatch().
+  // Using this API can have a positive impact on performance if GetBatch()
+  // is called subsequently on the same TransactionLogIterator instance.
+  // Usage of this API should not affect the correctness of the Iterator's
+  // behavior.
+  virtual void RecycleWriteBatch(std::unique_ptr<WriteBatch> write_batch) = 0;
+
   // The read options for TransactionLogIterator.
   struct ReadOptions {
     // If true, all data read from underlying storage will be


### PR DESCRIPTION
Add TransactionLogIterator::RecycleWriteBatch() method to optionally recycle a
WriteBatch handed out by TransactionLogIterator::GetBatch().
This is an optional API that can be used to avoid repeated memory allocations
for new WriteBatch objects when calling GetBatch() on the same
TransactionLogIterator instance.
Using the API is performance optimization which should not affect correctness.

Example usage:

    std::unique_ptr<TransactionLogIterator> iter;
    Status status = wal_manager_->GetUpdatesSince(
        seq, &iter, TransactionLogIterator::ReadOptions());

    BatchResult res;
    while (iter->Valid()) {
      res = iter->GetBatch();

      // performance optimization: return the WriteBatch instance
      // back to the TransactionLogIterator instance, so it can
      // recycle the WriteBatch's internals and avoid repeated
      // memory allocations for each batch.
      iter->RecycleWriteBatch(std::move(res.writeBatchPtr));

      iter->Next();
    }