### PR TITLE
Add comments/permit unchecked error to close_db_dir pull requests

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -682,8 +682,10 @@ ColumnFamilyData::~ColumnFamilyData() {
       if (data_dir_ptr) {
         s = data_dir_ptr->Close(IOOptions(), nullptr);
         if (!s.ok()) {
+          // TODO(zichen): add `Status Close()` and `CloseDirectories()
           ROCKS_LOG_WARN(ioptions_.logger, "Ignoring error %s",
                          s.ToString().c_str());
+          s.PermitUncheckedError();
         }
       }
     }

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1661,6 +1661,8 @@ IOStatus PosixDirectory::Fsync(const IOOptions& opts, IODebugContext* dbg) {
   return FsyncWithDirOptions(opts, dbg, DirFsyncOptions());
 }
 
+// Users who want the file entries synced in Directory project must call a
+// Fsync or FsyncWithDirOptions function before Close
 IOStatus PosixDirectory::Close(const IOOptions& /*opts*/,
                                IODebugContext* /*dbg*/) {
   IOStatus s = IOStatus::OK();


### PR DESCRIPTION
Summary:

In [close_db_dir](https://github.com/facebook/rocksdb/pull/10049) pull request, some merging conflicts occurred (some comments and one line `s.PermitUncheckedError()` are missing). This pull request aims to put them back.