### PR TITLE
fix a false positive case of parsing table factory from options file

### DIFF
--- a/options/options_parser.cc
+++ b/options/options_parser.cc
@@ -453,12 +453,13 @@ Status RocksDBOptionsParser::EndSection(
           section_arg);
     }
     // Ignore error as table factory deserialization is optional
+    cf_opt->table_factory.reset();
     s = TableFactory::CreateFromString(
         config_options,
         section_title.substr(
             opt_section_titles[kOptionSectionTableOptions].size()),
         &(cf_opt->table_factory));
-    if (s.ok()) {
+    if (s.ok() && cf_opt->table_factory != nullptr) {
       s = cf_opt->table_factory->ConfigureFromMap(config_options, opt_map);
       // Translate any errors (NotFound, NotSupported, to InvalidArgument
       if (s.ok() || s.IsInvalidArgument()) {


### PR DESCRIPTION
Summary:
During options file parsing, reset table factory before attempting to parse it
from string. This avoids mistakenly treating the default table factory as a
newly created one.

Signed-off-by: tabokie <xy.tao@outlook.com>