### PR TITLE
Add default impl to dir close

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -936,7 +936,7 @@ class WritableFile {
   // size due to whole pages writes. The behavior is undefined if called
   // with other writes to follow.
   virtual Status Truncate(uint64_t /*size*/) { return Status::OK(); }
-  virtual Status Close() = 0;
+  virtual Status Close() { return Status::NotSupported("Close"); }
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;  // sync data
 

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1021,7 +1021,10 @@ class FSWritableFile {
                             IODebugContext* /*dbg*/) {
     return IOStatus::OK();
   }
-  virtual IOStatus Close(const IOOptions& options, IODebugContext* dbg) = 0;
+  virtual IOStatus Close(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) {
+    return IOStatus::NotSupported("Close");
+  }
   virtual IOStatus Flush(const IOOptions& options, IODebugContext* dbg) = 0;
   virtual IOStatus Sync(const IOOptions& options,
                         IODebugContext* dbg) = 0;  // sync data


### PR DESCRIPTION
Summary:

As pointed by @anand1976 in his [comment](https://github.com/facebook/rocksdb/pull/10049#pullrequestreview-994255819), previous implementation is not backward-compatible. In this implementation, the default implementation `return Status::NotSupported("Close")` or `return IOStatus::NotSupported("Close")` is added for `Close()` function for `*Directory` classes.

Test: DBBasicTest.DBCloseAllDirectoryFDs