### PR TITLE
Fix some bugs in verify_random_db.sh

### DIFF
--- a/tools/verify_random_db.sh
+++ b/tools/verify_random_db.sh
@@ -19,21 +19,23 @@ try_load_options=${4:-"1"}
 ignore_unknown_options=${5:-"0"}
 db_dump=$db_dir"/"$dump_file_name
 base_db_dump=$base_db_dir"/"$dump_file_name
-extra_param=
+extra_params=
 
-if [ "$try_load_options" = "1" ]; then
- extra_param=" --try_load_options "
+if [ "$try_load_options" = "0" ]; then
+ extra_params=" --try_load_options=false"
+elif [ "$try_load_options" = "1" ]; then
+ extra_params=" --try_load_options=true"
 fi
 
 if [ "$ignore_unknown_options" = "1" ]; then
- extra_param=" --ignore_unknown_options "
+ extra_params="$extra_params --ignore_unknown_options"
 fi
 
 set -e
 echo == Dumping data from $db_dir to $db_dump
-./ldb dump --db=$db_dir $extra_param > $db_dump
+./ldb dump --db=$db_dir $extra_params > $db_dump
 
 echo == Dumping data from $base_db_dir to $base_db_dump
-./ldb dump --db=$base_db_dir $extra_param > $base_db_dump
+./ldb dump --db=$base_db_dir $extra_params > $base_db_dump
 
-diff $db_dump $base_db_dir
+diff $db_dump $base_db_dump


### PR DESCRIPTION
Summary:
The patch attempts to fix three bugs in `verify_random_db.sh`:
1) https://github.com/facebook/rocksdb/pull/9937 changed the default for
`--try_load_options` to true in the script's use case, so we have to
explicitly set it to false if the corresponding argument of the script
is 0. This should fix the issue we've been seeing with our forward
compatibility tests where 7.3 is unable to open a database created by
the version on main after adding a new configuration option.
2) The script seems to support two "extra parameters"; however,
in practice, if the second one was set, only that one was passed on to
`ldb`. Now both get forwarded.
3) When running the `diff` command, the base DB directory was passed as
the second argument instead of the file containing the `ldb` output
(this actually seems to work, probably accidentally though).