### PR TITLE
Verify write batch checksum before WAL

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1918,10 +1918,9 @@ class DBImpl : public DB {
   // Merge write batches in the write group into merged_batch.
   // Returns OK if merge is successful.
   // Returns Corruption if corruption in write batch is detected.
-  Status MergeBatch(WriteBatch** merged_batch,
-                    const WriteThread::WriteGroup& write_group,
-                    WriteBatch* tmp_batch, size_t* write_with_wal,
-                    WriteBatch** to_be_cached_state);
+  Status MergeBatch(const WriteThread::WriteGroup& write_group,
+                    WriteBatch* tmp_batch, WriteBatch** merged_batch,
+                    size_t* write_with_wal, WriteBatch** to_be_cached_state);
 
   // rate_limiter_priority is used to charge `DBOptions::rate_limiter`
   // for automatic WAL flush (`Options::manual_wal_flush` == false)

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1915,9 +1915,13 @@ class DBImpl : public DB {
   Status PreprocessWrite(const WriteOptions& write_options, bool* need_log_sync,
                          WriteContext* write_context);
 
-  WriteBatch* MergeBatch(const WriteThread::WriteGroup& write_group,
-                         WriteBatch* tmp_batch, size_t* write_with_wal,
-                         WriteBatch** to_be_cached_state);
+  // Merge write batches in the write group into merged_batch.
+  // Returns OK if merge is successful.
+  // Returns Corruption if corruption in write batch is detected.
+  Status MergeBatch(WriteBatch** merged_batch,
+                    const WriteThread::WriteGroup& write_group,
+                    WriteBatch* tmp_batch, size_t* write_with_wal,
+                    WriteBatch** to_be_cached_state);
 
   // rate_limiter_priority is used to charge `DBOptions::rate_limiter`
   // for automatic WAL flush (`Options::manual_wal_flush` == false)

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1176,9 +1176,9 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
   return status;
 }
 
-Status DBImpl::MergeBatch(WriteBatch** merged_batch,
-                          const WriteThread::WriteGroup& write_group,
-                          WriteBatch* tmp_batch, size_t* write_with_wal,
+Status DBImpl::MergeBatch(const WriteThread::WriteGroup& write_group,
+                          WriteBatch* tmp_batch, WriteBatch** merged_batch,
+                          size_t* write_with_wal,
                           WriteBatch** to_be_cached_state) {
   assert(write_with_wal != nullptr);
   assert(tmp_batch != nullptr);
@@ -1274,7 +1274,7 @@ IOStatus DBImpl::WriteToWAL(const WriteThread::WriteGroup& write_group,
   size_t write_with_wal = 0;
   WriteBatch* to_be_cached_state = nullptr;
   WriteBatch* merged_batch;
-  io_s = status_to_io_status(MergeBatch(&merged_batch, write_group, &tmp_batch_,
+  io_s = status_to_io_status(MergeBatch(write_group, &tmp_batch_, &merged_batch,
                                         &write_with_wal, &to_be_cached_state));
   if (UNLIKELY(!io_s.ok())) {
     return io_s;
@@ -1370,7 +1370,7 @@ IOStatus DBImpl::ConcurrentWriteToWAL(
   size_t write_with_wal = 0;
   WriteBatch* to_be_cached_state = nullptr;
   WriteBatch* merged_batch;
-  io_s = status_to_io_status(MergeBatch(&merged_batch, write_group, &tmp_batch,
+  io_s = status_to_io_status(MergeBatch(write_group, &tmp_batch, &merged_batch,
                                         &write_with_wal, &to_be_cached_state));
   if (UNLIKELY(!io_s.ok())) {
     return io_s;

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1366,7 +1366,7 @@ IOStatus DBImpl::ConcurrentWriteToWAL(
   size_t write_with_wal = 0;
   WriteBatch* to_be_cached_state = nullptr;
   WriteBatch* merged_batch;
-  io_s = status_to_io_status(MergeBatch(&merged_batch, write_group, &tmp_batch_,
+  io_s = status_to_io_status(MergeBatch(&merged_batch, write_group, &tmp_batch,
                                         &write_with_wal, &to_be_cached_state));
   if (UNLIKELY(!io_s.ok())) {
     return io_s;

--- a/db/db_kv_checksum_test.cc
+++ b/db/db_kv_checksum_test.cc
@@ -559,6 +559,8 @@ INSTANTIATE_TEST_CASE_P(
       return oss.str();
     });
 
+// TODO: add test for transactions
+// TODO: add test for corrupted write batch with WAL disabled
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/db_kv_checksum_test.cc
+++ b/db/db_kv_checksum_test.cc
@@ -404,7 +404,7 @@ TEST_P(DbKvChecksumTestMergedBatch, WriteToWALCorrupted) {
                             corrupt_byte_addend_);
         }
         leader_count++;
-        while (not follower_joined) {
+        while (!follower_joined) {
           // busy waiting
         }
       });
@@ -508,7 +508,7 @@ TEST_P(DbKvChecksumTestMergedBatch, WriteToWALWithColumnFamilyCorrupted) {
                             corrupt_byte_addend_);
         }
         leader_count++;
-        while (not follower_joined) {
+        while (!follower_joined) {
           // busy waiting
         }
       });

--- a/db/db_kv_checksum_test.cc
+++ b/db/db_kv_checksum_test.cc
@@ -25,6 +25,49 @@ WriteBatchOpType operator+(WriteBatchOpType lhs, const int rhs) {
   return static_cast<WriteBatchOpType>(static_cast<T>(lhs) + rhs);
 }
 
+std::pair<WriteBatch, Status> GetWriteBatch(ColumnFamilyHandle* cf_handle,
+                                            WriteBatchOpType op_type) {
+  Status s;
+  WriteBatch wb(0 /* reserved_bytes */, 0 /* max_bytes */,
+                8 /* protection_bytes_per_entry */, 0 /* default_cf_ts_sz */);
+  switch (op_type) {
+    case WriteBatchOpType::kPut:
+      s = wb.Put(cf_handle, "key", "val");
+      break;
+    case WriteBatchOpType::kDelete:
+      s = wb.Delete(cf_handle, "key");
+      break;
+    case WriteBatchOpType::kSingleDelete:
+      s = wb.SingleDelete(cf_handle, "key");
+      break;
+    case WriteBatchOpType::kDeleteRange:
+      s = wb.DeleteRange(cf_handle, "begin", "end");
+      break;
+    case WriteBatchOpType::kMerge:
+      s = wb.Merge(cf_handle, "key", "val");
+      break;
+    case WriteBatchOpType::kBlobIndex: {
+      // TODO(ajkr): use public API once available.
+      uint32_t cf_id;
+      if (cf_handle == nullptr) {
+        cf_id = 0;
+      } else {
+        cf_id = cf_handle->GetID();
+      }
+
+      std::string blob_index;
+      BlobIndex::EncodeInlinedTTL(&blob_index, /* expiration */ 9876543210,
+                                  "val");
+
+      s = WriteBatchInternal::PutBlobIndex(&wb, cf_id, "key", blob_index);
+      break;
+    }
+    case WriteBatchOpType::kNum:
+      assert(false);
+  }
+  return {std::move(wb), std::move(s)};
+}
+
 class DbKvChecksumTest
     : public DBTestBase,
       public ::testing::WithParamInterface<std::tuple<WriteBatchOpType, char>> {
@@ -33,48 +76,6 @@ class DbKvChecksumTest
       : DBTestBase("db_kv_checksum_test", /*env_do_fsync=*/false) {
     op_type_ = std::get<0>(GetParam());
     corrupt_byte_addend_ = std::get<1>(GetParam());
-  }
-
-  std::pair<WriteBatch, Status> GetWriteBatch(ColumnFamilyHandle* cf_handle) {
-    Status s;
-    WriteBatch wb(0 /* reserved_bytes */, 0 /* max_bytes */,
-                  8 /* protection_bytes_per_entry */, 0 /* default_cf_ts_sz */);
-    switch (op_type_) {
-      case WriteBatchOpType::kPut:
-        s = wb.Put(cf_handle, "key", "val");
-        break;
-      case WriteBatchOpType::kDelete:
-        s = wb.Delete(cf_handle, "key");
-        break;
-      case WriteBatchOpType::kSingleDelete:
-        s = wb.SingleDelete(cf_handle, "key");
-        break;
-      case WriteBatchOpType::kDeleteRange:
-        s = wb.DeleteRange(cf_handle, "begin", "end");
-        break;
-      case WriteBatchOpType::kMerge:
-        s = wb.Merge(cf_handle, "key", "val");
-        break;
-      case WriteBatchOpType::kBlobIndex: {
-        // TODO(ajkr): use public API once available.
-        uint32_t cf_id;
-        if (cf_handle == nullptr) {
-          cf_id = 0;
-        } else {
-          cf_id = cf_handle->GetID();
-        }
-
-        std::string blob_index;
-        BlobIndex::EncodeInlinedTTL(&blob_index, /* expiration */ 9876543210,
-                                    "val");
-
-        s = WriteBatchInternal::PutBlobIndex(&wb, cf_id, "key", blob_index);
-        break;
-      }
-      case WriteBatchOpType::kNum:
-        assert(false);
-    }
-    return {std::move(wb), std::move(s)};
   }
 
   void CorruptNextByteCallBack(void* arg) {
@@ -99,34 +100,28 @@ class DbKvChecksumTest
   size_t entry_len_ = std::numeric_limits<size_t>::max();
 };
 
-std::string GetTestNameSuffix(
-    ::testing::TestParamInfo<std::tuple<WriteBatchOpType, char>> info) {
-  std::ostringstream oss;
-  switch (std::get<0>(info.param)) {
+std::string GetOpTypeString(const WriteBatchOpType& op_type) {
+  switch (op_type) {
     case WriteBatchOpType::kPut:
-      oss << "Put";
-      break;
+      return "Put";
     case WriteBatchOpType::kDelete:
-      oss << "Delete";
-      break;
+      return "Delete";
     case WriteBatchOpType::kSingleDelete:
-      oss << "SingleDelete";
-      break;
+      return "SingleDelete";
     case WriteBatchOpType::kDeleteRange:
-      oss << "DeleteRange";
+      return "DeleteRange";
       break;
     case WriteBatchOpType::kMerge:
-      oss << "Merge";
+      return "Merge";
       break;
     case WriteBatchOpType::kBlobIndex:
-      oss << "BlobIndex";
+      return "BlobIndex";
       break;
     case WriteBatchOpType::kNum:
       assert(false);
   }
-  oss << "Add"
-      << static_cast<int>(static_cast<unsigned char>(std::get<1>(info.param)));
-  return oss.str();
+  assert(false);
+  return "";
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -134,7 +129,13 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(::testing::Range(static_cast<WriteBatchOpType>(0),
                                         WriteBatchOpType::kNum),
                        ::testing::Values(2, 103, 251)),
-    GetTestNameSuffix);
+    [](const testing::TestParamInfo<std::tuple<WriteBatchOpType, char>>& args) {
+      std::ostringstream oss;
+      oss << GetOpTypeString(std::get<0>(args.param)) << "Add"
+          << static_cast<int>(
+                 static_cast<unsigned char>(std::get<1>(args.param)));
+      return oss.str();
+    });
 
 TEST_P(DbKvChecksumTest, MemTableAddCorrupted) {
   // This test repeatedly attempts to write `WriteBatch`es containing a single
@@ -157,7 +158,7 @@ TEST_P(DbKvChecksumTest, MemTableAddCorrupted) {
     Reopen(options);
 
     SyncPoint::GetInstance()->EnableProcessing();
-    auto batch_and_status = GetWriteBatch(nullptr /* cf_handle */);
+    auto batch_and_status = GetWriteBatch(nullptr /* cf_handle */, op_type_);
     ASSERT_OK(batch_and_status.second);
     ASSERT_TRUE(
         db_->Write(WriteOptions(), &batch_and_status.first).IsCorruption());
@@ -193,7 +194,7 @@ TEST_P(DbKvChecksumTest, MemTableAddWithColumnFamilyCorrupted) {
     ReopenWithColumnFamilies({kDefaultColumnFamilyName, "pikachu"}, options);
 
     SyncPoint::GetInstance()->EnableProcessing();
-    auto batch_and_status = GetWriteBatch(handles_[1]);
+    auto batch_and_status = GetWriteBatch(handles_[1], op_type_);
     ASSERT_OK(batch_and_status.second);
     ASSERT_TRUE(
         db_->Write(WriteOptions(), &batch_and_status.first).IsCorruption());
@@ -208,7 +209,7 @@ TEST_P(DbKvChecksumTest, MemTableAddWithColumnFamilyCorrupted) {
 
 TEST_P(DbKvChecksumTest, NoCorruptionCase) {
   // If this test fails, we may have found a piece of malfunctioned hardware
-  auto batch_and_status = GetWriteBatch(nullptr);
+  auto batch_and_status = GetWriteBatch(nullptr, op_type_);
   ASSERT_OK(batch_and_status.second);
   ASSERT_OK(batch_and_status.first.VerifyChecksum());
 }
@@ -237,7 +238,7 @@ TEST_P(DbKvChecksumTest, WriteToWALCorrupted) {
     auto log_size_pre_write = dbfull()->TEST_total_log_size();
 
     SyncPoint::GetInstance()->EnableProcessing();
-    auto batch_and_status = GetWriteBatch(nullptr /* cf_handle */);
+    auto batch_and_status = GetWriteBatch(nullptr /* cf_handle */, op_type_);
     ASSERT_OK(batch_and_status.second);
     ASSERT_TRUE(
         db_->Write(WriteOptions(), &batch_and_status.first).IsCorruption());
@@ -278,7 +279,7 @@ TEST_P(DbKvChecksumTest, WriteToWALWithColumnFamilyCorrupted) {
     auto log_size_pre_write = dbfull()->TEST_total_log_size();
 
     SyncPoint::GetInstance()->EnableProcessing();
-    auto batch_and_status = GetWriteBatch(handles_[1]);
+    auto batch_and_status = GetWriteBatch(handles_[1], op_type_);
     ASSERT_OK(batch_and_status.second);
     ASSERT_TRUE(
         db_->Write(WriteOptions(), &batch_and_status.first).IsCorruption());
@@ -293,6 +294,258 @@ TEST_P(DbKvChecksumTest, WriteToWALWithColumnFamilyCorrupted) {
     ASSERT_TRUE(entry_len_ < std::numeric_limits<size_t>::max());
   }
 }
+
+class DbKvChecksumTestMergedBatch
+    : public DBTestBase,
+      public ::testing::WithParamInterface<
+          std::tuple<WriteBatchOpType, WriteBatchOpType, char>> {
+ public:
+  DbKvChecksumTestMergedBatch()
+      : DBTestBase("db_kv_checksum_test", /*env_do_fsync=*/false) {
+    op_type1_ = std::get<0>(GetParam());
+    op_type2_ = std::get<1>(GetParam());
+    corrupt_byte_addend_ = std::get<2>(GetParam());
+  }
+
+ protected:
+  WriteBatchOpType op_type1_;
+  WriteBatchOpType op_type2_;
+  char corrupt_byte_addend_;
+};
+
+void CorruptWriteBatch(Slice* content, size_t offset,
+                       char corrupt_byte_addend) {
+  ASSERT_TRUE(offset < content->size());
+  char* buf = const_cast<char*>(content->data());
+  buf[offset] += corrupt_byte_addend;
+}
+
+TEST_P(DbKvChecksumTestMergedBatch, NoCorruptionCase) {
+  // Veirfy write batch checksum after write batch append
+  auto batch1 = GetWriteBatch(nullptr /* cf_handle */, op_type1_);
+  ASSERT_OK(batch1.second);
+  auto batch2 = GetWriteBatch(nullptr /* cf_handle */, op_type2_);
+  ASSERT_OK(batch2.second);
+  ASSERT_OK(WriteBatchInternal::Append(&batch1.first, &batch2.first));
+  ASSERT_OK(batch1.first.VerifyChecksum());
+}
+
+TEST_P(DbKvChecksumTestMergedBatch, WriteToWALCorrupted) {
+  // This test has two writers repeatedly attempt to write `WriteBatch`es
+  // containing a single entry of type op_type1_ and op_type2_ respectively. The
+  // leader of the write group writes the batch containinng the entry of type
+  // op_type1_. One byte of the pre-merged write batches is corrupted by adding
+  // `corrupt_byte_addend_` to the batch's original value during each attempt.
+  // The test repeats until an attempt has been made on each byte in both
+  // pre-merged write batches. All attempts are expected to fail with
+  // `Status::Corruption`.
+  Options options = CurrentOptions();
+  if (op_type1_ == WriteBatchOpType::kMerge ||
+      op_type2_ == WriteBatchOpType::kMerge) {
+    options.merge_operator = MergeOperators::CreateStringAppendOperator();
+  }
+
+  auto leader_batch_and_status =
+      GetWriteBatch(nullptr /* cf_handle */, op_type1_);
+  ASSERT_OK(leader_batch_and_status.second);
+  auto follower_batch_and_status =
+      GetWriteBatch(nullptr /* cf_handle */, op_type2_);
+  auto leader_batch_size = leader_batch_and_status.first.GetDataSize();
+  size_t total_bytes =
+      leader_batch_size + follower_batch_and_status.first.GetDataSize();
+  // First 8 bytes are for sequence number which is not protected in write batch
+  size_t corrupt_byte_offset = 8;
+
+  std::atomic<bool> follower_joined{false};
+  std::atomic<int> leader_count{0};
+  port::Thread follower_thread;
+  SyncPoint::GetInstance()->EnableProcessing();
+  while (corrupt_byte_offset < total_bytes) {
+    // Reopen DB since it failed WAL write which lead to read-only mode
+    Reopen(options);
+    // This callback should only be called by the leader thread
+    SyncPoint::GetInstance()->SetCallBack(
+        "WriteThread::JoinBatchGroup:Wait", [&](void* arg_leader) {
+          auto* leader = reinterpret_cast<WriteThread::Writer*>(arg_leader);
+          ASSERT_EQ(leader->state, WriteThread::STATE_GROUP_LEADER);
+
+          // This callback should only be called by the follower thread
+          SyncPoint::GetInstance()->SetCallBack(
+              "WriteThread::JoinBatchGroup:Wait", [&](void* arg_follower) {
+                auto* follower =
+                    reinterpret_cast<WriteThread::Writer*>(arg_follower);
+                // The leader thread will wait on this bool and hence wait until
+                // this writer joins the write group
+                ASSERT_NE(follower->state, WriteThread::STATE_GROUP_LEADER);
+                if (corrupt_byte_offset >= leader_batch_size) {
+                  Slice batch_content = follower->batch->Data();
+                  CorruptWriteBatch(&batch_content,
+                                    corrupt_byte_offset - leader_batch_size,
+                                    corrupt_byte_addend_);
+                }
+                // Leader busy waits on this flag
+                follower_joined = true;
+              });
+
+          // Start the other writer thread which will join the write group as
+          // follower
+          follower_thread = port::Thread([&]() {
+            follower_batch_and_status =
+                GetWriteBatch(nullptr /* cf_handle */, op_type2_);
+            ASSERT_OK(follower_batch_and_status.second);
+            ASSERT_TRUE(
+                db_->Write(WriteOptions(), &follower_batch_and_status.first)
+                    .IsCorruption());
+          });
+
+          ASSERT_EQ(leader->batch->GetDataSize(), leader_batch_size);
+          if (corrupt_byte_offset < leader_batch_size) {
+            Slice batch_content = leader->batch->Data();
+            CorruptWriteBatch(&batch_content, corrupt_byte_offset,
+                              corrupt_byte_addend_);
+          }
+          leader_count++;
+          while (not follower_joined) {
+            // busy waiting
+          }
+        });
+    auto log_size_pre_write = dbfull()->TEST_total_log_size();
+    leader_batch_and_status = GetWriteBatch(nullptr /* cf_handle */, op_type1_);
+    ASSERT_OK(leader_batch_and_status.second);
+    ASSERT_TRUE(db_->Write(WriteOptions(), &leader_batch_and_status.first)
+                    .IsCorruption());
+    follower_thread.join();
+    ASSERT_EQ(1, leader_count);
+    // Nothing should have been written to WAL
+    ASSERT_EQ(log_size_pre_write, dbfull()->TEST_total_log_size());
+    ASSERT_TRUE(dbfull()->TEST_GetBGError().IsCorruption());
+
+    corrupt_byte_offset++;
+    if (corrupt_byte_offset == leader_batch_size) {
+      // skip over the sequence number part of follower's write batch
+      corrupt_byte_offset += 8;
+    }
+    follower_joined = false;
+    leader_count = 0;
+  }
+  SyncPoint::GetInstance()->DisableProcessing();
+}
+
+TEST_P(DbKvChecksumTestMergedBatch, WriteToWALWithColumnFamilyCorrupted) {
+  // This test has two writers repeatedly attempt to write `WriteBatch`es
+  // containing a single entry of type op_type1_ and op_type2_ respectively. The
+  // leader of the write group writes the batch containinng the entry of type
+  // op_type1_. One byte of the pre-merged write batches is corrupted by adding
+  // `corrupt_byte_addend_` to the batch's original value during each attempt.
+  // The test repeats until an attempt has been made on each byte in both
+  // pre-merged write batches. All attempts are expected to fail with
+  // `Status::Corruption`.
+  Options options = CurrentOptions();
+  if (op_type1_ == WriteBatchOpType::kMerge ||
+      op_type2_ == WriteBatchOpType::kMerge) {
+    options.merge_operator = MergeOperators::CreateStringAppendOperator();
+  }
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  auto leader_batch_and_status = GetWriteBatch(handles_[1], op_type1_);
+  ASSERT_OK(leader_batch_and_status.second);
+  auto follower_batch_and_status = GetWriteBatch(handles_[1], op_type2_);
+  auto leader_batch_size = leader_batch_and_status.first.GetDataSize();
+  size_t total_bytes =
+      leader_batch_size + follower_batch_and_status.first.GetDataSize();
+  // First 8 bytes are for sequence number which is not protected in write batch
+  size_t corrupt_byte_offset = 8;
+
+  std::atomic<bool> follower_joined{false};
+  std::atomic<int> leader_count{0};
+  port::Thread follower_thread;
+  SyncPoint::GetInstance()->EnableProcessing();
+  while (corrupt_byte_offset < total_bytes) {
+    // Reopen DB since it failed WAL write which lead to read-only mode
+    ReopenWithColumnFamilies({kDefaultColumnFamilyName, "pikachu"}, options);
+    // This callback should only be called by the leader thread
+    SyncPoint::GetInstance()->SetCallBack(
+        "WriteThread::JoinBatchGroup:Wait", [&](void* arg_leader) {
+          auto* leader = reinterpret_cast<WriteThread::Writer*>(arg_leader);
+          ASSERT_EQ(leader->state, WriteThread::STATE_GROUP_LEADER);
+
+          // This callback should only be called by the follower thread
+          SyncPoint::GetInstance()->SetCallBack(
+              "WriteThread::JoinBatchGroup:Wait", [&](void* arg_follower) {
+                auto* follower =
+                    reinterpret_cast<WriteThread::Writer*>(arg_follower);
+                // The leader thread will wait on this bool and hence wait until
+                // this writer joins the write group
+                ASSERT_NE(follower->state, WriteThread::STATE_GROUP_LEADER);
+                if (corrupt_byte_offset >= leader_batch_size) {
+                  Slice batch_content =
+                      WriteBatchInternal::Contents(follower->batch);
+                  CorruptWriteBatch(&batch_content,
+                                    corrupt_byte_offset - leader_batch_size,
+                                    corrupt_byte_addend_);
+                }
+                follower_joined = true;
+              });
+
+          // Start the other writer thread which will join the write group as
+          // follower
+          follower_thread = port::Thread([&]() {
+            follower_batch_and_status = GetWriteBatch(handles_[1], op_type2_);
+            ASSERT_OK(follower_batch_and_status.second);
+            ASSERT_TRUE(
+                db_->Write(WriteOptions(), &follower_batch_and_status.first)
+                    .IsCorruption());
+          });
+
+          ASSERT_EQ(leader->batch->GetDataSize(), leader_batch_size);
+          if (corrupt_byte_offset < leader_batch_size) {
+            Slice batch_content = WriteBatchInternal::Contents(leader->batch);
+            CorruptWriteBatch(&batch_content, corrupt_byte_offset,
+                              corrupt_byte_addend_);
+          }
+          leader_count++;
+          while (not follower_joined) {
+            // busy waiting
+          }
+        });
+    auto log_size_pre_write = dbfull()->TEST_total_log_size();
+    leader_batch_and_status = GetWriteBatch(handles_[1], op_type1_);
+    ASSERT_OK(leader_batch_and_status.second);
+    ASSERT_TRUE(db_->Write(WriteOptions(), &leader_batch_and_status.first)
+                    .IsCorruption());
+    follower_thread.join();
+    ASSERT_EQ(1, leader_count);
+    // Nothing should have been written to WAL
+    ASSERT_EQ(log_size_pre_write, dbfull()->TEST_total_log_size());
+    ASSERT_TRUE(dbfull()->TEST_GetBGError().IsCorruption());
+
+    corrupt_byte_offset++;
+    if (corrupt_byte_offset == leader_batch_size) {
+      // skip over the sequence number part of follower's write batch
+      corrupt_byte_offset += 8;
+    }
+    follower_joined = false;
+    leader_count = 0;
+  }
+  SyncPoint::GetInstance()->DisableProcessing();
+}
+
+INSTANTIATE_TEST_CASE_P(
+    DbKvChecksumTestMergedBatch, DbKvChecksumTestMergedBatch,
+    ::testing::Combine(::testing::Range(static_cast<WriteBatchOpType>(0),
+                                        WriteBatchOpType::kNum),
+                       ::testing::Range(static_cast<WriteBatchOpType>(0),
+                                        WriteBatchOpType::kNum),
+                       ::testing::Values(2, 103, 251)),
+    [](const testing::TestParamInfo<
+        std::tuple<WriteBatchOpType, WriteBatchOpType, char>>& args) {
+      std::ostringstream oss;
+      oss << GetOpTypeString(std::get<0>(args.param))
+          << GetOpTypeString(std::get<1>(args.param)) << "Add"
+          << static_cast<int>(
+                 static_cast<unsigned char>(std::get<2>(args.param)));
+      return oss.str();
+    });
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1495,7 +1495,8 @@ Status WriteBatch::VerifyChecksum() const {
   if (prot_info_ == nullptr) {
     return Status::OK();
   }
-  Slice input(rep_.data() + WriteBatchInternal::kHeader, rep_.size());
+  Slice input(rep_.data() + WriteBatchInternal::kHeader,
+              rep_.size() - WriteBatchInternal::kHeader);
   Slice key, value, blob, xid;
   char tag = 0;
   uint32_t column_family = 0;  // default

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1502,7 +1502,7 @@ Status WriteBatch::VerifyChecksum() const {
   uint32_t column_family = 0;  // default
   Status s;
   size_t prot_info_idx = 0;
-  bool checksum_protected;
+  bool checksum_protected = true;
   while (!input.empty() && prot_info_idx < prot_info_->entries_.size()) {
     // In case key/value/column_family are not updated by
     // ReadRecordFromWriteBatch

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -2835,9 +2835,9 @@ Status WriteBatchInternal::Append(WriteBatch* dst, const WriteBatch* src,
                                   const bool wal_only) {
   assert(dst->Count() == 0 ||
          (dst->prot_info_ == nullptr) == (src->prot_info_ == nullptr));
-  if ((src->prot_info_ != nullptr and
+  if ((src->prot_info_ != nullptr &&
        src->prot_info_->entries_.size() != src->Count()) ||
-      (dst->prot_info_ != nullptr and
+      (dst->prot_info_ != nullptr &&
        dst->prot_info_->entries_.size() != dst->Count())) {
     return Status::Corruption(
         "Write batch has inconsistent count and number of checksums");

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -206,6 +206,10 @@ class WriteBatchInternal {
                            bool batch_per_txn = true,
                            bool hint_per_batch = false);
 
+  // Appends src write batch to dst write batch and updates count in dst
+  // write batch. Returns OK if the append is successful. Checks number of
+  // checksum against count in dst and src write batches, and returns Corruption
+  // if the count is inconsistent.
   static Status Append(WriteBatch* dst, const WriteBatch* src,
                        const bool WAL_only = false);
 

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -389,6 +389,7 @@ void WriteThread::JoinBatchGroup(Writer* w) {
   }
 
   TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Wait", w);
+  TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Wait2", w);
 
   if (!linked_as_leader) {
     /**

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -391,6 +391,12 @@ class WriteBatch : public WriteBatchBase {
   Status UpdateTimestamps(const Slice& ts,
                           std::function<size_t(uint32_t /*cf*/)> ts_sz_func);
 
+  // Verify the per-key-value checksums of this write batch.
+  // Corruption status will be returned if the verification fails.
+  // If this write batch does not have per-key-value checksum,
+  // OK status will be returned.
+  Status VerifyChecksum() const;
+
   using WriteBatchBase::GetWriteBatch;
   WriteBatch* GetWriteBatch() override { return this; }
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1652,6 +1652,10 @@ static const bool FLAGS_table_cache_numshardbits_dummy __attribute__((__unused__
     RegisterFlagValidator(&FLAGS_table_cache_numshardbits,
                           &ValidateTableCacheNumshardbits);
 
+DEFINE_uint32(write_batch_protection_bytes_per_key, 0,
+              "Size of per-key-value checksum in each write batch. Currently "
+              "only value 0 and 8 are supported.");
+
 namespace ROCKSDB_NAMESPACE {
 namespace {
 static Status CreateMemTableRepFactory(
@@ -4905,7 +4909,8 @@ class Benchmark {
 
     RandomGenerator gen;
     WriteBatch batch(/*reserved_bytes=*/0, /*max_bytes=*/0,
-                     /*protection_bytes_per_key=*/0, user_timestamp_size_);
+                     FLAGS_write_batch_protection_bytes_per_key,
+                     user_timestamp_size_);
     Status s;
     int64_t bytes = 0;
 
@@ -6694,7 +6699,8 @@ class Benchmark {
 
   void DoDelete(ThreadState* thread, bool seq) {
     WriteBatch batch(/*reserved_bytes=*/0, /*max_bytes=*/0,
-                     /*protection_bytes_per_key=*/0, user_timestamp_size_);
+                     FLAGS_write_batch_protection_bytes_per_key,
+                     user_timestamp_size_);
     Duration duration(seq ? 0 : FLAGS_duration, deletes_);
     int64_t i = 0;
     std::unique_ptr<const char[]> key_guard;
@@ -6894,7 +6900,8 @@ class Benchmark {
     std::string keys[3];
 
     WriteBatch batch(/*reserved_bytes=*/0, /*max_bytes=*/0,
-                     /*protection_bytes_per_key=*/0, user_timestamp_size_);
+                     FLAGS_write_batch_protection_bytes_per_key,
+                     user_timestamp_size_);
     Status s;
     for (int i = 0; i < 3; i++) {
       keys[i] = key.ToString() + suffixes[i];
@@ -6926,7 +6933,7 @@ class Benchmark {
     std::string suffixes[3] = {"1", "2", "0"};
     std::string keys[3];
 
-    WriteBatch batch(0, 0, /*protection_bytes_per_key=*/0,
+    WriteBatch batch(0, 0, FLAGS_write_batch_protection_bytes_per_key,
                      user_timestamp_size_);
     Status s;
     for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
Summary:
Context: WriteBatch can have key-value checksums when it was created `with protection_bytes_per_key > 0`.
This PR added checksum verification for write batches before they are written to WAL.

Test plan:
- Added new unit tests to db_kv_checksum_test.cc: `make check -j32`
- benchmark on performance regression: `./db_bench --benchmarks=fillrandom[-X20] -db=/dev/shm/test_rocksdb -write_batch_protection_bytes_per_key=8`
  - Pre-PR:
`
fillrandom [AVG    20 runs] : 198875 (± 3006) ops/sec;   22.0 (± 0.3) MB/sec
`
  - Post-PR:
`
fillrandom [AVG    20 runs] : 196487 (± 2279) ops/sec;   21.7 (± 0.3) MB/sec
`
  Mean regressed about 1% (198875 -> 196487 ops/sec).

