### PR TITLE
Integrate caching into the blob read logic

### DIFF
--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -10,12 +10,14 @@
 
 #include <memory>
 
+#include "rocksdb/cache.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/universal_compaction.h"
 
 namespace ROCKSDB_NAMESPACE {
 
+class Cache;
 class Slice;
 class SliceTransform;
 class TablePropertiesCollectorFactory;
@@ -227,7 +229,7 @@ enum class Temperature : uint8_t {
 };
 
 // The control option of how the cache tiers will be used. Currently rocksdb
-// support block cahe (volatile tier), secondary cache (non-volatile tier).
+// support block cache (volatile tier), secondary cache (non-volatile tier).
 // In the future, we may add more caching layers.
 enum class CacheTier : uint8_t {
   kVolatileTier = 0,
@@ -952,6 +954,15 @@ struct AdvancedColumnFamilyOptions {
   //
   // Dynamically changeable through the SetOptions() API
   int blob_file_starting_level = 0;
+
+  // Disable blob cache. If this is set to true,
+  // then no blob cache should be used, and the blob_cache should
+  // point to a nullptr object.
+  bool no_blob_cache = false;
+
+  // If non-NULL use the specified cache for blobs.
+  // If NULL, rocksdb will automatically create and use an 8MB internal cache.
+  std::shared_ptr<Cache> blob_cache = nullptr;
 
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1412,7 +1412,6 @@ struct Options : public DBOptions, public ColumnFamilyOptions {
   Options* DisableExtraChecks();
 };
 
-//
 // An application can issue a read request (via Get/Iterators) and specify
 // if that read should process data that ALREADY resides on a specified cache
 // level. For example, if an application specifies kBlockCacheTier then the

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -732,6 +732,14 @@ static std::unordered_map<std::string, OptionTypeInfo>
          OptionTypeInfo::AsCustomSharedPtr<SstPartitionerFactory>(
              offsetof(struct ImmutableCFOptions, sst_partitioner_factory),
              OptionVerificationType::kByName, OptionTypeFlags::kAllowNull)},
+        {"no_blob_cache",
+         {offsetof(struct ImmutableCFOptions, no_blob_cache),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"blob_cache",
+         OptionTypeInfo::AsCustomSharedPtr<Cache>(
+             offsetof(struct ImmutableCFOptions, blob_cache),
+             OptionVerificationType::kByName, OptionTypeFlags::kAllowNull)},
 };
 
 const std::string OptionsHelper::kCFOptionsName = "ColumnFamilyOptions";
@@ -870,7 +878,9 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
           cf_options.memtable_insert_with_hint_prefix_extractor),
       cf_paths(cf_options.cf_paths),
       compaction_thread_limiter(cf_options.compaction_thread_limiter),
-      sst_partitioner_factory(cf_options.sst_partitioner_factory) {}
+      sst_partitioner_factory(cf_options.sst_partitioner_factory),
+      no_blob_cache(cf_options.no_blob_cache),
+      blob_cache(cf_options.blob_cache) {}
 
 ImmutableOptions::ImmutableOptions() : ImmutableOptions(Options()) {}
 
@@ -907,9 +917,9 @@ uint64_t MultiplyCheckOverflow(uint64_t op1, double op2) {
 // when level_compaction_dynamic_level_bytes is true and leveled compaction
 // is used, the base level is not always L1, so precomupted max_file_size can
 // no longer be used. Recompute file_size_for_level from base level.
-uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options,
-    int level, CompactionStyle compaction_style, int base_level,
-    bool level_compaction_dynamic_level_bytes) {
+uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options, int level,
+                             CompactionStyle compaction_style, int base_level,
+                             bool level_compaction_dynamic_level_bytes) {
   if (!level_compaction_dynamic_level_bytes || level < base_level ||
       compaction_style != kCompactionStyleLevel) {
     assert(level >= 0);

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -78,6 +78,10 @@ struct ImmutableCFOptions {
   std::shared_ptr<ConcurrentTaskLimiter> compaction_thread_limiter;
 
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory;
+
+  bool no_blob_cache;
+
+  std::shared_ptr<Cache> blob_cache;
 };
 
 struct ImmutableOptions : public ImmutableDBOptions, public ImmutableCFOptions {


### PR DESCRIPTION
Summary:

In contrast with block-based tables, which can utilize RocksDB's block cache (see https://github.com/facebook/rocksdb/wiki/Block-Cache), there is currently no caching mechanism for blobs, which is not ideal especially when the database resides on Warm Storage (where we cannot rely on the OS page cache). As part of this task, we would like to make it possible for the application to configure a blob cache.

- We would like this cache to store uncompressed blobs.
- RocksDB supports pluggable cache implementations (see the `Cache` interface); we would like to support the same interface here.
- Blobs can be potentially read both while handling user reads (`Get`, `MultiGet`, or iterator) and during compaction (while dealing with compaction filters, `Merge`s, or garbage collection) but eventually all blob file reads go through `Version::GetBlob` or, for `MultiGet`, `Version::MultiGetBlob` (and then get dispatched to `BlobFileReader`).
- There are two read options that need attention: `read_tier`, which can be used by the application to specify that a read should be served exclusively from the cache, and `fill_cache`, which can be used to enable/disable caching the data that was read (for example, the application might not want to cache the data retrieved during long range scans; we also use this option to prevent data read during compactions from polluting the cache).
- Add unit tests and update the BlobDB wiki as part of this task.