### PR TITLE
Fix default implementaton of close() function for Directory/FSDirecto…

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -936,7 +936,7 @@ class WritableFile {
   // size due to whole pages writes. The behavior is undefined if called
   // with other writes to follow.
   virtual Status Truncate(uint64_t /*size*/) { return Status::OK(); }
-  virtual Status Close() { return Status::NotSupported("Close"); }
+  virtual Status Close() = 0;
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;  // sync data
 
@@ -1149,7 +1149,7 @@ class Directory {
   // Fsync directory. Can be called concurrently from multiple threads.
   virtual Status Fsync() = 0;
   // Close directory.
-  virtual Status Close() = 0;
+  virtual Status Close() { return Status::NotSupported("Close"); }
 
   virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
     return 0;

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1022,9 +1022,8 @@ class FSWritableFile {
     return IOStatus::OK();
   }
   virtual IOStatus Close(const IOOptions& /*options*/,
-                         IODebugContext* /*dbg*/) {
-    return IOStatus::NotSupported("Close");
-  }
+                         IODebugContext* /*dbg*/) = 0;
+
   virtual IOStatus Flush(const IOOptions& options, IODebugContext* dbg) = 0;
   virtual IOStatus Sync(const IOOptions& options,
                         IODebugContext* dbg) = 0;  // sync data
@@ -1271,7 +1270,10 @@ class FSDirectory {
   }
 
   // Close directory
-  virtual IOStatus Close(const IOOptions& options, IODebugContext* dbg) = 0;
+  virtual IOStatus Close(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) {
+    return IOStatus::NotSupported("Close");
+  }
 
   virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
     return 0;


### PR DESCRIPTION
Summary:

As pointed by @anand1976 in his [comment](https://github.com/facebook/rocksdb/pull/10049#pullrequestreview-994255819), previous implementation (adding Close() function in Directory/FSDirectory class) is not backward-compatible. And we mistakenly added the default implementation `return Status::NotSupported("Close")` or `return IOStatus::NotSupported("Close")` in WritableFile class in this [pull request](https://github.com/facebook/rocksdb/pull/10101). This pull request fixes the above issue.