### PR TITLE
Handle "NotSupported" status by default implementation of Close() in …

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -683,8 +683,6 @@ ColumnFamilyData::~ColumnFamilyData() {
         s = data_dir_ptr->Close(IOOptions(), nullptr);
         if (!s.ok()) {
           // TODO(zichen): add `Status Close()` and `CloseDirectories()
-          ROCKS_LOG_WARN(ioptions_.logger, "Ignoring error %s",
-                         s.ToString().c_str());
           s.PermitUncheckedError();
         }
       }

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -443,8 +443,19 @@ Status SetIdentityFile(Env* env, const std::string& dbname,
     s = dir_obj->FsyncWithDirOptions(IOOptions(), nullptr,
                                      DirFsyncOptions(identify_file_name));
   }
+
+  // The default Close() could return "NotSupported" and we bypass it
+  // if it is not impelmented. Detailed explanations can be found in
+  // db/db_impl/db_impl.h
   if (s.ok()) {
-    s = dir_obj->Close(IOOptions(), nullptr);
+    Status temp_s = dir_obj->Close(IOOptions(), nullptr);
+    if (!temp_s.ok()) {
+      if (temp_s.IsNotSupported()) {
+        temp_s.PermitUncheckedError();
+      } else {
+        s = temp_s;
+      }
+    }
   }
   if (!s.ok()) {
     env->DeleteFile(tmp).PermitUncheckedError();


### PR DESCRIPTION
Summary:

The default implementation of Close() function in Directory/FSDirectory classes returns `NotSupported` status. However, we don't want operations that worked in older versions to begin failing after upgrading when run on FileSystems that have not implemented Directory::Close() yet. So we require the upper level that calls Close() function should properly handle "NotSupported" status instead of treating it as an error status. 