### PR TITLE
Fix bug with kHashSearch and changing prefix_extractor with SetOptions

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3467,7 +3467,36 @@ TEST_F(DBTest, BlockBasedTablePrefixIndexTest) {
   ASSERT_OK(Flush());
   ASSERT_OK(Put("k2", "v2"));
 
-  // Reopen it without prefix extractor, make sure everything still works.
+  // Reopen with different prefix extractor, make sure everything still works.
+  // RocksDB should just fall back to the binary index.
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+
+  Reopen(options);
+  ASSERT_EQ("v1", Get("k1"));
+  ASSERT_EQ("v2", Get("k2"));
+
+  // Back to original
+  ASSERT_OK(dbfull()->SetOptions({{"prefix_extractor", "fixed:1"}}));
+  ASSERT_EQ("v1", Get("k1"));
+  ASSERT_EQ("v2", Get("k2"));
+
+  // Same if there's a problem initally loading prefix transform
+  options.prefix_extractor.reset(NewFixedPrefixTransform(1));
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlockBasedTable::Open::ForceNullTablePrefixExtractor",
+      [&](void* arg) { *static_cast<bool*>(arg) = true; });
+  SyncPoint::GetInstance()->EnableProcessing();
+  Reopen(options);
+  ASSERT_EQ("v1", Get("k1"));
+  ASSERT_EQ("v2", Get("k2"));
+
+  // Change again
+  ASSERT_OK(dbfull()->SetOptions({{"prefix_extractor", "fixed:2"}}));
+  ASSERT_EQ("v1", Get("k1"));
+  ASSERT_EQ("v2", Get("k2"));
+  SyncPoint::GetInstance()->DisableProcessing();
+
+  // Reopen with no prefix extractor, make sure everything still works.
   // RocksDB should just fall back to the binary index.
   table_options.index_type = BlockBasedTableOptions::kBinarySearch;
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
@@ -3477,6 +3506,7 @@ TEST_F(DBTest, BlockBasedTablePrefixIndexTest) {
   ASSERT_EQ("v1", Get("k1"));
   ASSERT_EQ("v2", Get("k2"));
 }
+
 TEST_F(DBTest, BlockBasedTablePrefixHashIndexTest) {
   // create a DB with block prefix index
   BlockBasedTableOptions table_options;

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -625,7 +625,7 @@ class IterKey {
 };
 
 // Convert from a SliceTransform of user keys, to a SliceTransform of
-// user keys.
+// internal keys.
 class InternalKeySliceTransform : public SliceTransform {
  public:
   explicit InternalKeySliceTransform(const SliceTransform* transform)

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -596,12 +596,6 @@ struct BlockBasedTable::Rep {
   BlockBasedTableOptions::IndexType index_type;
   bool whole_key_filtering;
   bool prefix_filtering;
-  // TODO(kailiu) It is very ugly to use internal key in table, since table
-  // module should not be relying on db module. However to make things easier
-  // and compatible with existing code, we introduce a wrapper that allows
-  // block to extract prefix without knowing if a key is internal or not.
-  // null if no prefix_extractor is passed in when opening the table reader.
-  std::unique_ptr<SliceTransform> internal_prefix_transform;
   std::shared_ptr<const SliceTransform> table_prefix_extractor;
 
   std::shared_ptr<const FragmentedRangeTombstoneList> fragmented_range_dels;

--- a/table/block_based/block_prefix_index.cc
+++ b/table/block_based/block_prefix_index.cc
@@ -69,9 +69,6 @@ struct PrefixRecord {
 
 class BlockPrefixIndex::Builder {
  public:
-  explicit Builder(const SliceTransform* internal_prefix_extractor)
-      : internal_prefix_extractor_(internal_prefix_extractor) {}
-
   void Add(const Slice& key_prefix, uint32_t start_block, uint32_t num_blocks) {
     PrefixRecord* record = reinterpret_cast<PrefixRecord*>(
         arena_.AllocateAligned(sizeof(PrefixRecord)));
@@ -82,7 +79,7 @@ class BlockPrefixIndex::Builder {
     prefixes_.push_back(record);
   }
 
-  BlockPrefixIndex* Finish() {
+  BlockPrefixIndex* Finish(const SliceTransform* prefix_extractor) {
     // For now, use roughly 1:1 prefix to bucket ratio.
     uint32_t num_buckets = static_cast<uint32_t>(prefixes_.size()) + 1;
 
@@ -154,25 +151,22 @@ class BlockPrefixIndex::Builder {
 
     assert(offset == total_block_array_entries);
 
-    return new BlockPrefixIndex(internal_prefix_extractor_, num_buckets,
-                                buckets, total_block_array_entries,
-                                block_array_buffer);
+    return new BlockPrefixIndex(prefix_extractor, num_buckets, buckets,
+                                total_block_array_entries, block_array_buffer);
   }
 
  private:
-  const SliceTransform* internal_prefix_extractor_;
-
   std::vector<PrefixRecord*> prefixes_;
   Arena arena_;
 };
 
-Status BlockPrefixIndex::Create(const SliceTransform* internal_prefix_extractor,
+Status BlockPrefixIndex::Create(const SliceTransform* prefix_extractor,
                                 const Slice& prefixes, const Slice& prefix_meta,
                                 BlockPrefixIndex** prefix_index) {
   uint64_t pos = 0;
   auto meta_pos = prefix_meta;
   Status s;
-  Builder builder(internal_prefix_extractor);
+  Builder builder;
 
   while (!meta_pos.empty()) {
     uint32_t prefix_size = 0;
@@ -201,14 +195,14 @@ Status BlockPrefixIndex::Create(const SliceTransform* internal_prefix_extractor,
   }
 
   if (s.ok()) {
-    *prefix_index = builder.Finish();
+    *prefix_index = builder.Finish(prefix_extractor);
   }
 
   return s;
 }
 
 uint32_t BlockPrefixIndex::GetBlocks(const Slice& key, uint32_t** blocks) {
-  Slice prefix = internal_prefix_extractor_->Transform(key);
+  Slice prefix = internal_prefix_extractor_.Transform(key);
 
   uint32_t bucket = PrefixToBucket(prefix, num_buckets_);
   uint32_t block_id = buckets_[bucket];

--- a/table/block_based/block_prefix_index.h
+++ b/table/block_based/block_prefix_index.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <stdint.h>
+
+#include "db/dbformat.h"
 #include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -46,17 +48,19 @@ class BlockPrefixIndex {
   class Builder;
   friend Builder;
 
-  BlockPrefixIndex(const SliceTransform* internal_prefix_extractor,
-                   uint32_t num_buckets, uint32_t* buckets,
-                   uint32_t num_block_array_buffer_entries,
+  BlockPrefixIndex(const SliceTransform* prefix_extractor, uint32_t num_buckets,
+                   uint32_t* buckets, uint32_t num_block_array_buffer_entries,
                    uint32_t* block_array_buffer)
-      : internal_prefix_extractor_(internal_prefix_extractor),
+      : internal_prefix_extractor_(prefix_extractor),
         num_buckets_(num_buckets),
         num_block_array_buffer_entries_(num_block_array_buffer_entries),
         buckets_(buckets),
         block_array_buffer_(block_array_buffer) {}
 
-  const SliceTransform* internal_prefix_extractor_;
+  // TODO(kailiu) It is very ugly to use internal key in table, since table
+  // module should not be relying on db module.
+  InternalKeySliceTransform internal_prefix_extractor_;
+
   uint32_t num_buckets_;
   uint32_t num_block_array_buffer_entries_;
   uint32_t* buckets_;

--- a/table/block_based/hash_index_reader.cc
+++ b/table/block_based/hash_index_reader.cc
@@ -95,8 +95,8 @@ Status HashIndexReader::Create(const BlockBasedTable* table,
   }
 
   BlockPrefixIndex* prefix_index = nullptr;
-  assert(rep->internal_prefix_transform.get() != nullptr);
-  s = BlockPrefixIndex::Create(rep->internal_prefix_transform.get(),
+  assert(rep->table_prefix_extractor);
+  s = BlockPrefixIndex::Create(rep->table_prefix_extractor.get(),
                                prefixes_contents.data,
                                prefixes_meta_contents.data, &prefix_index);
   // TODO: log error


### PR DESCRIPTION
Summary: When opening an SST file created using index_type=kHashSearch,
the *current* prefix_extractor would be saved, and used with hash index
if the *new current* prefix_extractor at query time is compatible with
the SST file. This is a problem if the prefix_extractor at SST open time
is not compatible but SetOptions later changes (back) to one that is
compatible.

This change fixes that by using the known compatible (or missing) prefix
extractor we save for use with prefix filtering. Detail: I have moved the
InternalKeySliceTransform wrapper to avoid some indirection and remove
unnecessary fields.

Test Plan: expanded unit test (using some logic from #10122) that fails
before fix and probably covers some other previously uncovered cases.