### PR TITLE
Enable wal_compression in crash_tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -174,9 +174,7 @@ default_params = {
     "detect_filter_construct_corruption": lambda: random.choice([0, 1]),
     "adaptive_readahead": lambda: random.choice([0, 1]),
     "async_io": lambda: random.choice([0, 1]),
-    # Temporarily disable wal compression because it causes backup/checkpoint to miss
-    # compressed WAL files.
-    "wal_compression": "none",
+    "wal_compression": lambda: random.choice(["none", "zstd"]),
     "verify_sst_unique_id_in_manifest": 1,  # always do unique_id verification
     "secondary_cache_uri": "",
 }


### PR DESCRIPTION
Summary: Same as title

Test Plan: 
 ```
export CRASH_TEST_EXT_ARGS=" --wal_compression=zstd"
 make crash_test -j
```

Reviewers:

Subscribers:

Tasks:

Tags: