### PR TITLE
Add compiler option /utf-8 avoid charset problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
 include(ReadVersion)
 include(GoogleTest)


### PR DESCRIPTION
This project can't be compiled due to a warning [C4819](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4819?view=msvc-170) in my environment. Some file use UTF-8 but without BOM will cause MSVC unhappy.

> C4819: The file contains a character that cannot be represented in the current code page (number). Save the file in Unicode format to prevent data loss.

My environment:
```
-- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.19044.
-- The CXX compiler identification is MSVC 19.29.30145.0
-- The C compiler identification is MSVC 19.29.30145.0
-- The ASM compiler identification is MSVC
```
I'm not familiar with cmake. I am unsure whether it breaks other platforms without `if(MSVC)` surrounding.