### PR TITLE
Fix a race condition in transaction stress test

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -66,6 +66,7 @@ StressTest::StressTest()
 #ifndef ROCKSDB_LITE
       txn_db_(nullptr),
 #endif
+      db_aptr_(nullptr),
       clock_(db_stress_env->GetSystemClock().get()),
       new_column_family_name_(1),
       num_times_reopened_(0),
@@ -2541,7 +2542,13 @@ void StressTest::Open(SharedState* shared) {
         fflush(stderr);
       }
       assert(s.ok());
-      db_ = txn_db_;
+
+      // Do not swap the order of the following.
+      {
+        db_ = txn_db_;
+        db_aptr_.store(txn_db_, std::memory_order_release);
+      }
+
       // after a crash, rollback to commit recovered transactions
       std::vector<Transaction*> trans;
       txn_db_->GetAllPreparedTransactions(&trans);

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -236,6 +236,10 @@ class StressTest {
 #ifndef ROCKSDB_LITE
   TransactionDB* txn_db_;
 #endif
+
+  // Currently only used in MultiOpsTxnsStressTest
+  std::atomic<DB*> db_aptr_;
+
   Options options_;
   SystemClock* clock_;
   std::vector<ColumnFamilyHandle*> column_families_;

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -1248,13 +1248,17 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
   }
 }
 
+// VerifyPkSkFast() can be called by MultiOpsTxnsStressListener's callbacks
+// which can be called before TransactionDB::Open() returns to caller.
+// Therefore, at that time, db_ is still nullptr thus we have to use txn_db_
+// here.
 void MultiOpsTxnsStressTest::VerifyPkSkFast(int job_id) {
-  const Snapshot* const snapshot = db_->GetSnapshot();
+  const Snapshot* const snapshot = txn_db_->GetSnapshot();
   assert(snapshot);
-  ManagedSnapshot snapshot_guard(db_, snapshot);
+  ManagedSnapshot snapshot_guard(txn_db_, snapshot);
 
   std::ostringstream oss;
-  auto* dbimpl = static_cast_with_check<DBImpl>(db_->GetRootDB());
+  auto* dbimpl = static_cast_with_check<DBImpl>(txn_db_->GetRootDB());
   assert(dbimpl);
 
   oss << "Job " << job_id << ": [" << snapshot->GetSequenceNumber() << ","
@@ -1270,7 +1274,7 @@ void MultiOpsTxnsStressTest::VerifyPkSkFast(int job_id) {
   ropts.snapshot = snapshot;
   ropts.total_order_seek = true;
 
-  std::unique_ptr<Iterator> it(db_->NewIterator(ropts));
+  std::unique_ptr<Iterator> it(txn_db_->NewIterator(ropts));
   for (it->Seek(start_key); it->Valid(); it->Next()) {
     Record record;
     Status s = record.DecodeSecondaryIndexEntry(it->key(), it->value());
@@ -1287,7 +1291,7 @@ void MultiOpsTxnsStressTest::VerifyPkSkFast(int job_id) {
     // Form a primary key and search in the primary index.
     std::string pk = Record::EncodePrimaryKey(record.a_value());
     std::string value;
-    s = db_->Get(ropts, pk, &value);
+    s = txn_db_->Get(ropts, pk, &value);
     if (!s.ok()) {
       oss << "Error searching pk " << Slice(pk).ToString(true) << ". "
           << s.ToString() << ". sk " << it->key().ToString(true);

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -1250,9 +1250,13 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
 
 // VerifyPkSkFast() can be called by MultiOpsTxnsStressListener's callbacks
 // which can be called before TransactionDB::Open() returns to caller.
-// Therefore, at that time, db_ is still nullptr thus we have to use txn_db_
-// here.
+// Therefore, at that time, db_ and txn_db_  may still be nullptr.
 void MultiOpsTxnsStressTest::VerifyPkSkFast(int job_id) {
+  if (txn_db_ == nullptr) {
+    // This can happen during an auto compaction during db open.
+    return;
+  }
+
   const Snapshot* const snapshot = txn_db_->GetSnapshot();
   assert(snapshot);
   ManagedSnapshot snapshot_guard(txn_db_, snapshot);

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -1253,6 +1253,12 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
 // Therefore, at that time, db_ and txn_db_  may still be nullptr.
 // Caller has to make sure that the race condition does not happen.
 void MultiOpsTxnsStressTest::VerifyPkSkFast(int job_id) {
+  DB* const db = db_aptr_.load(std::memory_order_acquire);
+  if (db == nullptr) {
+    return;
+  }
+
+  assert(db_ == db);
   assert(db_ != nullptr);
 
   const Snapshot* const snapshot = db_->GetSnapshot();


### PR DESCRIPTION
Summary:
Before this PR, there can be a race condition between the thread calling
`StressTest::Open()` and a background compaction thread calling
`MultiOpsTxnsStressTest::VerifyPkSkFast()`.

```
Time   thread1                             bg_compact_thr
 |     TransactionDB::Open(..., &txn_db_)
 |     db_ is still nullptr
 |                                         db_->GetSnapshot()  // segfault
 |     db_ = txn_db_
 V
```

Test Plan:
CI