### PR TITLE
Reduce overhead of SortFileByOverlappingRatio()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -57,7 +57,7 @@
 * When compiled with folly (Meta-internal integration; experimental in open source build), improve the locking performance (CPU efficiency) of LRUCache by using folly DistributedMutex in place of standard mutex.
 
 ### Performance Improvements
-* Rather than doing total sort against all files in a level, SortFileByOverlappingRatio() to only find the top 8 files based on score. Also, don't sort files in the last level. This can improve write throughput for the use cases where data is loaded in increasing key order and there are a lot of files in one LSM-tree, where applying compaction results is the bottleneck.
+* Rather than doing total sort against all files in a level, SortFileByOverlappingRatio() to only find the top 50 files based on score. This can improve write throughput for the use cases where data is loaded in increasing key order and there are a lot of files in one LSM-tree, where applying compaction results is the bottleneck.
 
 ## 7.3.0 (05/20/2022)
 ### Bug Fixes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -56,6 +56,9 @@
 ### Performance Improvements
 * When compiled with folly (Meta-internal integration; experimental in open source build), improve the locking performance (CPU efficiency) of LRUCache by using folly DistributedMutex in place of standard mutex.
 
+### Performance Improvements
+* Rather than doing total sort against all files in a level, SortFileByOverlappingRatio() to only find the top 8 files based on score. Also, don't sort files in the last level. This can improve write throughput for the use cases where data is loaded in increasing key order and there are a lot of files in one LSM-tree, where applying compaction results is the bottleneck.
+
 ## 7.3.0 (05/20/2022)
 ### Bug Fixes
 * Fixed a bug where manual flush would block forever even though flush options had wait=false.

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3189,21 +3189,15 @@ void SortFileByOverlappingRatio(
                                           ttl_boost_score;
   }
 
-  // We are going to find the files with highest score. Since we are going
-  // to pick files fro highest score to lower, it's unlikely that we would
-  // need to pick many files, so we limit files for this partial order.
-  // In case we use up all the sorted files, we are essentially pick files
-  // in random order, but it should be rare.
-  const size_t kTotalSortedElements = 8;
-  size_t num_to_sort =
-      temp->size() > kTotalSortedElements ? kTotalSortedElements : temp->size();
-  auto comp_func = [&](const Fsize& f1, const Fsize& f2) -> bool {
-    return file_to_order[f1.file->fd.GetNumber()] <
-           file_to_order[f2.file->fd.GetNumber()];
-  };
-  std::nth_element(temp->begin(), temp->begin() + num_to_sort, temp->end(),
-                   comp_func);
-  std::sort(temp->begin(), temp->begin() + num_to_sort, comp_func);
+  size_t num_to_sort = temp->size() > VersionStorageInfo::kNumberFilesToSort
+                           ? VersionStorageInfo::kNumberFilesToSort
+                           : temp->size();
+
+  std::partial_sort(temp->begin(), temp->begin() + num_to_sort, temp->end(),
+                    [&](const Fsize& f1, const Fsize& f2) -> bool {
+                      return file_to_order[f1.file->fd.GetNumber()] <
+                             file_to_order[f2.file->fd.GetNumber()];
+                    });
 }
 
 void SortFileByRoundRobin(const InternalKeyComparator& icmp,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3189,11 +3189,21 @@ void SortFileByOverlappingRatio(
                                           ttl_boost_score;
   }
 
-  std::sort(temp->begin(), temp->end(),
-            [&](const Fsize& f1, const Fsize& f2) -> bool {
-              return file_to_order[f1.file->fd.GetNumber()] <
-                     file_to_order[f2.file->fd.GetNumber()];
-            });
+  // We are going to find the files with highest score. Since we are going
+  // to pick files fro highest score to lower, it's unlikely that we would
+  // need to pick many files, so we limit files for this partial order.
+  // In case we use up all the sorted files, we are essentially pick files
+  // in random order, but it should be rare.
+  const size_t kTotalSortedElements = 8;
+  size_t num_to_sort =
+      temp->size() > kTotalSortedElements ? kTotalSortedElements : temp->size();
+  auto comp_func = [&](const Fsize& f1, const Fsize& f2) -> bool {
+    return file_to_order[f1.file->fd.GetNumber()] <
+           file_to_order[f2.file->fd.GetNumber()];
+  };
+  std::nth_element(temp->begin(), temp->begin() + num_to_sort, temp->end(),
+                   comp_func);
+  std::sort(temp->begin(), temp->begin() + num_to_sort, comp_func);
 }
 
 void SortFileByRoundRobin(const InternalKeyComparator& icmp,


### PR DESCRIPTION
Summary: Currently SortFileByOverlappingRatio() is O(nlogn). It is usually OK but When there are a lot of files in an LSM-tree, SortFileByOverlappingRatio() can take non-trivial amount of time. The problem is severe when the user is loading keys in sorted order, where compaction is only trivial move and this operation becomes the bottleneck and limit the total throughput. This commit makes SortFileByOverlappingRatio() only find the top 50 files based on score. 50 files are usually enough for the parallel compactions needed for the level, and in case it is not enough, we would fall back to random, which should be acceptable.

Test Plan:
Run a fillseq that generates a lot of files, and observe throughput improved (although stall is not yet eliminated). The command ran:

TEST_TMPDIR=/dev/shm/ ./db_bench_sort --benchmarks=fillseq --compression_type=lz4 --write_buffer_size=5000000 --num=100000000 --value_size=1000

The throughput improved by 11%.