### PR TITLE
Use only ASCII in source files

### DIFF
--- a/build_tools/check-sources.sh
+++ b/build_tools/check-sources.sh
@@ -5,29 +5,35 @@
 
 BAD=""
 
-git grep 'namespace rocksdb' -- '*.[ch]*'
+git grep -n 'namespace rocksdb' -- '*.[ch]*'
 if [ "$?" != "1" ]; then
   echo "^^^^^ Do not hardcode namespace rocksdb. Use ROCKSDB_NAMESPACE"
   BAD=1
 fi
 
-git grep -i 'nocommit' -- ':!build_tools/check-sources.sh'
+git grep -n -i 'nocommit' -- ':!build_tools/check-sources.sh'
 if [ "$?" != "1" ]; then
   echo "^^^^^ Code was not intended to be committed"
   BAD=1
 fi
 
-git grep '<rocksdb/' -- ':!build_tools/check-sources.sh'
+git grep -n '<rocksdb/' -- ':!build_tools/check-sources.sh'
 if [ "$?" != "1" ]; then
   echo '^^^^^ Use double-quotes as in #include "rocksdb/something.h"'
   BAD=1
 fi
 
-git grep 'using namespace' -- ':!build_tools' ':!docs' \
+git grep -n 'using namespace' -- ':!build_tools' ':!docs' \
     ':!third-party/folly/folly/lang/Align.h' \
     ':!third-party/gtest-1.8.1/fused-src/gtest/gtest.h'
 if [ "$?" != "1" ]; then
   echo '^^^^ Do not use "using namespace"'
+  BAD=1
+fi
+
+git grep -n -P "[\x80-\xFF]" -- ':!docs' ':!*.md'
+if [ "$?" != "1" ]; then
+  echo '^^^^ Use only ASCII characters in source files'
   BAD=1
 fi
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2375,12 +2375,12 @@ class CombinedStats {
 
     if (throughput_mbs_.size() == throughput_ops_.size()) {
       fprintf(stdout,
-              "%s [AVG %d runs] : %d (± %d) ops/sec; %6.1f (± %.1f) MB/sec\n",
+              "%s [AVG %d runs] : %d (\xC2\xB1 %d) ops/sec; %6.1f (\xC2\xB1 %.1f) MB/sec\n",
               name, num_runs, static_cast<int>(CalcAvg(throughput_ops_)),
               static_cast<int>(CalcConfidence95(throughput_ops_)),
               CalcAvg(throughput_mbs_), CalcConfidence95(throughput_mbs_));
     } else {
-      fprintf(stdout, "%s [AVG %d runs] : %d (± %d) ops/sec\n", name, num_runs,
+      fprintf(stdout, "%s [AVG %d runs] : %d (\xC2\xB1 %d) ops/sec\n", name, num_runs,
               static_cast<int>(CalcAvg(throughput_ops_)),
               static_cast<int>(CalcConfidence95(throughput_ops_)));
     }
@@ -2422,8 +2422,9 @@ class CombinedStats {
     int num_runs = static_cast<int>(throughput_ops_.size());
 
     if (throughput_mbs_.size() == throughput_ops_.size()) {
+      // \xC2\xB1 is +/- character in UTF-8
       fprintf(stdout,
-              "%s [AVG    %d runs] : %d (± %d) ops/sec; %6.1f (± %.1f) MB/sec\n"
+              "%s [AVG    %d runs] : %d (\xC2\xB1 %d) ops/sec; %6.1f (\xC2\xB1 %.1f) MB/sec\n"
               "%s [MEDIAN %d runs] : %d ops/sec; %6.1f MB/sec\n",
               name, num_runs, static_cast<int>(CalcAvg(throughput_ops_)),
               static_cast<int>(CalcConfidence95(throughput_ops_)),
@@ -2432,7 +2433,7 @@ class CombinedStats {
               CalcMedian(throughput_mbs_));
     } else {
       fprintf(stdout,
-              "%s [AVG    %d runs] : %d (± %d) ops/sec\n"
+              "%s [AVG    %d runs] : %d (\xC2\xB1 %d) ops/sec\n"
               "%s [MEDIAN %d runs] : %d ops/sec\n",
               name, num_runs, static_cast<int>(CalcAvg(throughput_ops_)),
               static_cast<int>(CalcConfidence95(throughput_ops_)), name,

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2375,13 +2375,14 @@ class CombinedStats {
 
     if (throughput_mbs_.size() == throughput_ops_.size()) {
       fprintf(stdout,
-              "%s [AVG %d runs] : %d (\xC2\xB1 %d) ops/sec; %6.1f (\xC2\xB1 %.1f) MB/sec\n",
+              "%s [AVG %d runs] : %d (\xC2\xB1 %d) ops/sec; %6.1f (\xC2\xB1 "
+              "%.1f) MB/sec\n",
               name, num_runs, static_cast<int>(CalcAvg(throughput_ops_)),
               static_cast<int>(CalcConfidence95(throughput_ops_)),
               CalcAvg(throughput_mbs_), CalcConfidence95(throughput_mbs_));
     } else {
-      fprintf(stdout, "%s [AVG %d runs] : %d (\xC2\xB1 %d) ops/sec\n", name, num_runs,
-              static_cast<int>(CalcAvg(throughput_ops_)),
+      fprintf(stdout, "%s [AVG %d runs] : %d (\xC2\xB1 %d) ops/sec\n", name,
+              num_runs, static_cast<int>(CalcAvg(throughput_ops_)),
               static_cast<int>(CalcConfidence95(throughput_ops_)));
     }
   }
@@ -2424,7 +2425,8 @@ class CombinedStats {
     if (throughput_mbs_.size() == throughput_ops_.size()) {
       // \xC2\xB1 is +/- character in UTF-8
       fprintf(stdout,
-              "%s [AVG    %d runs] : %d (\xC2\xB1 %d) ops/sec; %6.1f (\xC2\xB1 %.1f) MB/sec\n"
+              "%s [AVG    %d runs] : %d (\xC2\xB1 %d) ops/sec; %6.1f (\xC2\xB1 "
+              "%.1f) MB/sec\n"
               "%s [MEDIAN %d runs] : %d ops/sec; %6.1f MB/sec\n",
               name, num_runs, static_cast<int>(CalcAvg(throughput_ops_)),
               static_cast<int>(CalcConfidence95(throughput_ops_)),

--- a/util/ribbon_alg.h
+++ b/util/ribbon_alg.h
@@ -150,7 +150,7 @@ namespace ribbon {
 // (m/n) than is required with Gaussian elimination.
 //
 // Recommended reading:
-// "Peeling Close to the Orientability Threshold – Spatial Coupling in
+// "Peeling Close to the Orientability Threshold - Spatial Coupling in
 // Hashing-Based Data Structures" by Stefan Walzer
 //
 // ######################################################################

--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -13,6 +13,7 @@
 #include "port/lang.h" // for FALLTHROUGH_INTENDED, inserted as appropriate
 /* END RocksDB customizations */
 
+// clang-format off
 /*
  * xxHash - Extremely Fast Hash algorithm
  * Header File

--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -3673,7 +3673,7 @@ XXH3_initCustomSecret_avx512(void* XXH_RESTRICT customSecret, xxh_u64 seed64)
         int i;
         for (i=0; i < nbRounds; ++i) {
             /* GCC has a bug, _mm512_stream_load_si512 accepts 'void*', not 'void const*',
-             * this will warn "discards ‘const’ qualifier". */
+             * this will warn "discards 'const' qualifier". */
             union {
                 XXH_ALIGN(64) const __m512i* cp;
                 XXH_ALIGN(64) void* p;


### PR DESCRIPTION
Summary: Fix existing usage of non-ASCII and add a check to prevent
future use. Added `-n` option to greps to provide line numbers.

Alternative to #10147

Test Plan: used new checker to find & fix cases, manually check
db_bench output is preserved