### PR TITLE
Fix the failure related to io_uring_prep_cancel

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1153,7 +1153,7 @@ class PosixFileSystem : public FileSystem {
       // Prepare the cancel request.
       struct io_uring_sqe* sqe;
       sqe = io_uring_get_sqe(iu);
-      io_uring_prep_cancel(sqe, posix_handle, 0);
+      io_uring_prep_cancel(sqe, (void*)(unsigned long)1, 0);
       io_uring_sqe_set_data(sqe, posix_handle);
 
       // submit the request.


### PR DESCRIPTION
Summary: Fix for Internal jobs are failing with 
```
 error: no matching function for call to 'io_uring_prep_cancel'
      io_uring_prep_cancel(sqe, posix_handle, 0);
      ^~~~~~~~~~~~~~~~~~~~
note: candidate function not viable: no known conversion from 'rocksdb::Posix_IOHandle *' to '__u64' (aka 'unsigned long long') for 2nd argument
static inline void io_uring_prep_cancel(struct io_uring_sqe *sqe,
```

User data is set using `io_uring_set_data` API so no need to pass posix_handle here.

Test Plan: CircleCI jobs