### PR TITLE
Reduce a duplicate consistency check when applying a new version

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1144,10 +1144,15 @@ class VersionBuilder::Rep {
 
   // Save the current state in *vstorage.
   Status SaveTo(VersionStorageInfo* vstorage) const {
-    Status s = CheckConsistency(base_vstorage_);
+    Status s;
+
+#ifndef NDEBUG
+    // The same check is done within Apply() so we skip it in debug mode.
+    s = CheckConsistency(base_vstorage_);
     if (!s.ok()) {
       return s;
     }
+#endif  // NDEBUG
 
     s = CheckConsistency(vstorage);
     if (!s.ok()) {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1147,7 +1147,7 @@ class VersionBuilder::Rep {
     Status s;
 
 #ifndef NDEBUG
-    // The same check is done within Apply() so we skip it in debug mode.
+    // The same check is done within Apply() so we skip it in release mode.
     s = CheckConsistency(base_vstorage_);
     if (!s.ok()) {
       return s;


### PR DESCRIPTION
Summary:
One consistency check in SaveTo() is dupilcated with the one within Apply(). Remove one of then in release mode to reduce time spent in DB mutex.

Test Plan:
Run existing tests and see nothing breaks.