### PR TITLE
BackupEngineOptions: use shared ptr for info_log

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1386,7 +1386,7 @@ Status StressTest::TestBackupRestore(
       FLAGS_db + "/.restore" + std::to_string(thread->tid);
   BackupEngineOptions backup_opts(backup_dir);
   // For debugging, get info_log from live options
-  backup_opts.info_log = db_->GetDBOptions().info_log.get();
+  backup_opts.info_log.reset(db_->GetDBOptions().info_log.get());
   if (thread->rand.OneIn(10)) {
     backup_opts.share_table_files = false;
   } else {

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "rocksdb/env.h"
 #include "rocksdb/io_status.h"
@@ -55,7 +56,7 @@ struct BackupEngineOptions {
   // Backup info and error messages will be written to info_log
   // if non-nullptr.
   // Default: nullptr
-  Logger* info_log;
+  std::shared_ptr<Logger> info_log;
 
   // If sync == true, we can guarantee you'll get consistent backup and
   // restore even on a machine crash/reboot. Backup and restore processes are

--- a/java/rocksjni/backup_engine_options.cc
+++ b/java/rocksjni/backup_engine_options.cc
@@ -107,7 +107,7 @@ void Java_org_rocksdb_BackupEngineOptions_setInfoLog(JNIEnv* /*env*/,
   auto* sptr_logger =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::LoggerJniCallback>*>(
           jhandle);
-  bopt->info_log = sptr_logger->get();
+  bopt->info_log.reset(sptr_logger->get());
 }
 
 /*

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -3510,7 +3510,7 @@ void BackupCommand::DoCommand() {
 
   BackupEngineOptions backup_options =
       BackupEngineOptions(backup_dir_, custom_env);
-  backup_options.info_log = logger_.get();
+  backup_options.info_log.reset(logger_.get());
   backup_options.max_background_operations = num_threads_;
   status = BackupEngine::Open(options_.env, backup_options, &backup_engine);
   if (status.ok()) {
@@ -3557,7 +3557,7 @@ void RestoreCommand::DoCommand() {
   Status status;
   {
     BackupEngineOptions opts(backup_dir_, custom_env);
-    opts.info_log = logger_.get();
+    opts.info_log.reset(logger_.get());
     opts.max_background_operations = num_threads_;
     BackupEngineReadOnly* raw_restore_engine_ptr;
     status =

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -112,7 +112,7 @@ void BackupEngineOptions::Dump(Logger* logger) const {
   ROCKS_LOG_INFO(logger, "               Options.backup_env: %p", backup_env);
   ROCKS_LOG_INFO(logger, "        Options.share_table_files: %d",
                  static_cast<int>(share_table_files));
-  ROCKS_LOG_INFO(logger, "                 Options.info_log: %p", info_log);
+  ROCKS_LOG_INFO(logger, "                 Options.info_log: %p", info_log.get());
   ROCKS_LOG_INFO(logger, "                     Options.sync: %d",
                  static_cast<int>(sync));
   ROCKS_LOG_INFO(logger, "         Options.destroy_old_data: %d",
@@ -1069,7 +1069,7 @@ IOStatus BackupEngineImpl::Initialize() {
   if (read_only_) {
     ROCKS_LOG_INFO(options_.info_log, "Starting read_only backup engine");
   }
-  options_.Dump(options_.info_log);
+  options_.Dump(options_.info_log.get());
 
   auto meta_path = GetAbsolutePath(kMetaDirName);
 
@@ -1204,7 +1204,7 @@ IOStatus BackupEngineImpl::Initialize() {
       if (io_s.ok()) {
         io_s = backup_iter->second->LoadFromFile(
             options_.backup_dir, abs_path_to_size,
-            options_.backup_rate_limiter.get(), options_.info_log,
+            options_.backup_rate_limiter.get(), options_.info_log.get(),
             &reported_ignored_fields_);
       }
       if (io_s.IsCorruption() || io_s.IsNotSupported()) {

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -741,7 +741,7 @@ class BackupEngineTest : public testing::Test {
 
   void OpenBackupEngine(bool destroy_old_data = false) {
     engine_options_->destroy_old_data = destroy_old_data;
-    engine_options_->info_log = logger_.get();
+    engine_options_->info_log.reset(logger_.get());
     BackupEngine* backup_engine;
     ASSERT_OK(BackupEngine::Open(test_db_env_.get(), *engine_options_,
                                  &backup_engine));


### PR DESCRIPTION
We usually use new keyword to alloc space when create Logger,
so we use shared ptr is more intelligent.

Signed-off-by: Yite Gu <ess_gyt@qq.com>