### PR TITLE
Read blob from blob cache if exists when GetBlob()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,6 +614,7 @@ set(SOURCES
         db/blob/blob_log_format.cc
         db/blob/blob_log_sequential_reader.cc
         db/blob/blob_log_writer.cc
+        db/blob/blob_source.cc
         db/blob/prefetch_buffer_collection.cc
         db/builder.cc
         db/c.cc
@@ -1212,6 +1213,7 @@ if(WITH_TESTS)
         db/blob/blob_file_garbage_test.cc
         db/blob/blob_file_reader_test.cc
         db/blob/blob_garbage_meter_test.cc
+        db/blob/blob_source_test.cc
         db/blob/db_blob_basic_test.cc
         db/blob/db_blob_compaction_test.cc
         db/blob/db_blob_corruption_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1861,6 +1861,9 @@ blob_file_garbage_test: $(OBJ_DIR)/db/blob/blob_file_garbage_test.o $(TEST_LIBRA
 blob_file_reader_test: $(OBJ_DIR)/db/blob/blob_file_reader_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+blob_source_test: $(OBJ_DIR)/db/blob/blob_source_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 blob_garbage_meter_test: $(OBJ_DIR)/db/blob/blob_garbage_meter_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/TARGETS
+++ b/TARGETS
@@ -30,6 +30,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "db/blob/blob_log_format.cc",
         "db/blob/blob_log_sequential_reader.cc",
         "db/blob/blob_log_writer.cc",
+        "db/blob/blob_source.cc",
         "db/blob/prefetch_buffer_collection.cc",
         "db/builder.cc",
         "db/c.cc",
@@ -358,6 +359,7 @@ cpp_library_wrapper(name="rocksdb_whole_archive_lib", srcs=[
         "db/blob/blob_log_format.cc",
         "db/blob/blob_log_sequential_reader.cc",
         "db/blob/blob_log_writer.cc",
+        "db/blob/blob_source.cc",
         "db/blob/prefetch_buffer_collection.cc",
         "db/builder.cc",
         "db/c.cc",
@@ -4798,6 +4800,18 @@ cpp_unittest_wrapper(name="blob_garbage_meter_test",
             extra_compiler_flags=[])
 
 
+cpp_unittest_wrapper(name="blob_source_test",
+            srcs=["db/blob/blob_source_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
+cpp_unittest_wrapper(name="block_based_filter_block_test",
+            srcs=["table/block_based/block_based_filter_block_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
 cpp_unittest_wrapper(name="block_based_table_reader_test",
             srcs=["table/block_based/block_based_table_reader_test.cc"],
             deps=[":rocksdb_test_lib"],
@@ -5872,4 +5886,3 @@ cpp_unittest_wrapper(name="write_unprepared_transaction_test",
             srcs=["utilities/transactions/write_unprepared_transaction_test.cc"],
             deps=[":rocksdb_test_lib"],
             extra_compiler_flags=[])
-

--- a/TARGETS
+++ b/TARGETS
@@ -4806,12 +4806,6 @@ cpp_unittest_wrapper(name="blob_source_test",
             extra_compiler_flags=[])
 
 
-cpp_unittest_wrapper(name="block_based_filter_block_test",
-            srcs=["table/block_based/block_based_filter_block_test.cc"],
-            deps=[":rocksdb_test_lib"],
-            extra_compiler_flags=[])
-
-
 cpp_unittest_wrapper(name="block_based_table_reader_test",
             srcs=["table/block_based/block_based_table_reader_test.cc"],
             deps=[":rocksdb_test_lib"],
@@ -5886,3 +5880,4 @@ cpp_unittest_wrapper(name="write_unprepared_transaction_test",
             srcs=["utilities/transactions/write_unprepared_transaction_test.cc"],
             deps=[":rocksdb_test_lib"],
             extra_compiler_flags=[])
+

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -37,7 +37,7 @@ BlobSource::BlobSource(Cache* cache, const ImmutableOptions* immutable_options,
       blob_cache_(immutable_options->blob_cache),
       lowest_used_cache_tier_(immutable_options->lowest_used_cache_tier) {}
 
-BlobSource::~BlobSource() = default;
+BlobSource::~BlobSource() { delete blob_file_cache_; }
 
 Status BlobSource::MaybeReadBlobFromCache(
     FilePrefetchBuffer* prefetch_buffer, const ReadOptions& read_options,
@@ -124,9 +124,8 @@ Status BlobSource::GetBlobFromCache(const Slice& cache_key, Cache* blob_cache,
         lowest_used_cache_tier_, blob_cache, cache_key, wait,
         nullptr /* cache_helper */, nullptr /* create_db */, priority);
     if (cache_handle != nullptr) {
-      Slice* value =
-          new Slice(static_cast<char*>(blob_cache->Value(cache_handle)));
-      blob->SetCachedValue(value, blob_cache, cache_handle);
+      Slice value(static_cast<char*>(blob_cache->Value(cache_handle)));
+      blob->SetCachedValue(&value, blob_cache, cache_handle);
       return Status::OK();
     }
   }

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -120,9 +120,7 @@ Status BlobSource::GetBlob(const ReadOptions& read_options,
       if (bytes_read) {
         *bytes_read = value_size;
       }
-      std::string* buf = value->GetSelf();
-      buf = blob_entry.GetValue();
-      (void)buf;
+      value->GetSelf()->swap(*blob_entry.GetValue());
       value->PinSelf();
       return s;
     }

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -14,19 +14,14 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-BlobSource::BlobSource(Cache* cache, const ImmutableOptions* immutable_options,
-                       const FileOptions* file_options,
+BlobSource::BlobSource(const ImmutableOptions* immutable_options,
                        const std::string& db_id,
                        const std::string& db_session_id,
-                       uint32_t column_family_id,
-                       HistogramImpl* blob_file_read_hist,
-                       const std::shared_ptr<IOTracer>& io_tracer)
+                       BlobFileCache* blob_file_cache)
     : db_id_(db_id),
       db_session_id_(db_session_id),
       statistics_(immutable_options->statistics.get()),
-      blob_file_cache_(new BlobFileCache(cache, immutable_options, file_options,
-                                         column_family_id, blob_file_read_hist,
-                                         io_tracer)),
+      blob_file_cache_(blob_file_cache),
       blob_cache_(immutable_options->blob_cache) {}
 
 BlobSource::~BlobSource() = default;

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -44,7 +44,7 @@ Status BlobSource::GetBlobFromCache(const Slice& cache_key,
 
   assert(blob->IsEmpty());
 
-  return Status::NotFound("Blob record not found in cache");
+  return Status::NotFound("Blob not found in cache");
 }
 
 Status BlobSource::PutBlobIntoCache(const Slice& cache_key,

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "db/blob/blob_file_reader.h"
-#include "file/file_prefetch_buffer.h"
 #include "options/cf_options.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -85,12 +84,6 @@ Status BlobSource::GetBlob(const ReadOptions& read_options,
                            FilePrefetchBuffer* prefetch_buffer,
                            PinnableSlice* value, uint64_t* bytes_read) {
   assert(value);
-
-  const uint64_t key_size = user_key.size();
-
-  if (!IsValidBlobOffset(offset, key_size, value_size, file_size)) {
-    return Status::Corruption("Invalid blob offset");
-  }
 
   Status s;
 

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -1,0 +1,296 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob/blob_source.h"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#include "db/blob/blob_file_reader.h"
+#include "db/blob/blob_log_format.h"
+#include "file/file_prefetch_buffer.h"
+#include "monitoring/statistics.h"
+#include "options/cf_options.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "util/compression.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+BlobSource::BlobSource(Cache* cache, const ImmutableOptions* immutable_options,
+                       const FileOptions* file_options,
+                       const std::string& db_id,
+                       const std::string& db_session_id,
+                       uint32_t column_family_id,
+                       HistogramImpl* blob_file_read_hist,
+                       const std::shared_ptr<IOTracer>& io_tracer)
+    : db_id_(db_id),
+      db_session_id_(db_session_id),
+      statistics_(immutable_options->statistics.get()),
+      blob_file_cache_(new BlobFileCache(cache, immutable_options, file_options,
+                                         column_family_id, blob_file_read_hist,
+                                         io_tracer)),
+      blob_cache_(immutable_options->blob_cache),
+      lowest_used_cache_tier_(immutable_options->lowest_used_cache_tier) {}
+
+BlobSource::~BlobSource() = default;
+
+Status BlobSource::MaybeReadBlobFromCache(
+    FilePrefetchBuffer* prefetch_buffer, const ReadOptions& read_options,
+    const CacheKey& cache_key, uint64_t offset, const bool wait,
+    CachableEntry<Slice>* blob_entry) const {
+  assert(blob_entry != nullptr);
+  assert(blob_entry->IsEmpty());
+
+  // First, try to get the blob from the cache
+  //
+  // If either blob cache is enabled, we'll try to read from it.
+  Status s;
+  Slice key;
+  if (blob_cache_ != nullptr) {
+    key = cache_key.AsSlice();
+    s = GetBlobFromCache(key, blob_cache_.get(), blob_entry, wait);
+    if (blob_entry->GetValue()) {
+      if (prefetch_buffer) {
+        // Update the blob details so that PrefetchBuffer can use the read
+        // pattern to determine if reads are sequential or not for prefetching.
+        // It should also take in account blob read from cache.
+        prefetch_buffer->UpdateReadPattern(
+            offset, blob_entry->GetValue()->size(),
+            read_options.adaptive_readahead /* decrease_readahead_size */);
+      }
+    }
+  }
+
+  assert(s.ok() || blob_entry->GetValue() == nullptr);
+
+  return s;
+}
+
+Cache::Handle* BlobSource::GetEntryFromCache(
+    const CacheTier& cache_tier, Cache* blob_cache, const Slice& key,
+    const bool wait, const Cache::CacheItemHelper* cache_helper,
+    const Cache::CreateCallback& create_cb, Cache::Priority priority) const {
+  assert(blob_cache);
+
+  Cache::Handle* cache_handle = nullptr;
+
+  if (cache_tier == CacheTier::kNonVolatileBlockTier) {
+    cache_handle = blob_cache->Lookup(key, cache_helper, create_cb, priority,
+                                      wait, statistics_);
+  } else {
+    cache_handle = blob_cache->Lookup(key, statistics_);
+  }
+
+  return cache_handle;
+}
+
+Status BlobSource::InsertEntryToCache(
+    const CacheTier& cache_tier, Cache* blob_cache, const Slice& key,
+    const Cache::CacheItemHelper* cache_helper, const Slice* blob,
+    size_t charge, Cache::Handle** cache_handle,
+    Cache::Priority priority) const {
+  Status s;
+
+  if (cache_tier == CacheTier::kNonVolatileBlockTier) {
+    s = blob_cache->Insert(
+        key, const_cast<void*>(static_cast<const void*>(blob->data())),
+        cache_helper, charge, cache_handle, priority);
+  } else {
+    s = blob_cache->Insert(
+        key, const_cast<void*>(static_cast<const void*>(blob->data())), charge,
+        cache_helper->del_cb, cache_handle, priority);
+  }
+
+  return s;
+}
+
+Status BlobSource::GetBlobFromCache(const Slice& cache_key, Cache* blob_cache,
+                                    CachableEntry<Slice>* blob,
+                                    bool wait) const {
+  assert(blob);
+  assert(blob->IsEmpty());
+  const Cache::Priority priority = Cache::Priority::LOW;
+
+  // Lookup uncompressed cache first
+  if (blob_cache != nullptr) {
+    assert(!cache_key.empty());
+    Cache::Handle* cache_handle = nullptr;
+    cache_handle = GetEntryFromCache(
+        lowest_used_cache_tier_, blob_cache, cache_key, wait,
+        nullptr /* cache_helper */, nullptr /* create_db */, priority);
+    if (cache_handle != nullptr) {
+      Slice* value =
+          new Slice(static_cast<char*>(blob_cache->Value(cache_handle)));
+      blob->SetCachedValue(value, blob_cache, cache_handle);
+      return Status::OK();
+    }
+  }
+
+  assert(blob->IsEmpty());
+
+  // TODO: If not found, search from the compressed blob cache.
+
+  return Status::NotFound("Blob record not found in cache");
+}
+
+Status BlobSource::PutBlobToCache(const Slice& cache_key, Cache* blob_cache,
+                                  CachableEntry<Slice>* cached_blob,
+                                  PinnableSlice* blob) const {
+  assert(blob);
+  assert(!cache_key.empty());
+
+  const Cache::Priority priority = Cache::Priority::LOW;
+
+  Status s;
+
+  // TODO: Insert compressed blob into compressed blob cache.
+  // Release the hold on the compressed cache entry immediately.
+
+  // Insert into uncompressed blob cache
+  if (blob_cache != nullptr) {
+    Cache::Handle* cache_handle = nullptr;
+    s = InsertEntryToCache(lowest_used_cache_tier_, blob_cache, cache_key,
+                           GetCacheItemHelper(), blob, blob->size(),
+                           &cache_handle, priority);
+    if (s.ok()) {
+      assert(cache_handle != nullptr);
+      cached_blob->SetCachedValue(blob, blob_cache, cache_handle);
+    }
+  }
+
+  return s;
+}
+
+CacheKey BlobSource::GetCacheKey(uint64_t file_number, uint64_t file_size,
+                                 uint64_t offset) const {
+  OffsetableCacheKey base_cache_key =
+      OffsetableCacheKey(db_id_, db_session_id_, file_number, file_size);
+  return base_cache_key.WithOffset(offset);
+}
+
+Status BlobSource::GetBlob(const ReadOptions& read_options,
+                           const Slice& user_key, uint64_t file_number,
+                           uint64_t offset, uint64_t file_size,
+                           uint64_t value_size,
+                           CompressionType compression_type,
+                           FilePrefetchBuffer* prefetch_buffer,
+                           PinnableSlice* value, uint64_t* bytes_read) {
+  assert(value);
+
+  const uint64_t key_size = user_key.size();
+
+  if (!IsValidBlobOffset(offset, key_size, value_size, file_size)) {
+    return Status::Corruption("Invalid blob offset");
+  }
+
+  const CacheKey cache_key = GetCacheKey(file_number, file_size, offset);
+
+  CachableEntry<Slice> blob_entry;
+
+  // TODO: We haven't support cache tiering for blob files yet, but will do it
+  // later.
+  if (blob_cache_ &&
+      lowest_used_cache_tier_ != CacheTier::kNonVolatileBlockTier) {
+    const Status s =
+        MaybeReadBlobFromCache(prefetch_buffer, read_options, cache_key, offset,
+                               true /* wait_for_cache */, &blob_entry);
+
+    if (s.ok() && blob_entry.GetValue() != nullptr) {
+      assert(blob_entry.GetValue()->size() == value_size);
+      if (bytes_read) {
+        *bytes_read = value_size;
+      }
+      value->PinSelf(*blob_entry.GetValue());
+      blob_entry.TransferTo(value);
+      return s;
+    }
+  }
+
+  assert(blob_entry.IsEmpty());
+
+  const bool no_io = read_options.read_tier == kBlockCacheTier;
+  if (no_io) {
+    return Status::Incomplete(
+        "A cache miss occurs if blob cache is enabled, and no blocking io "
+        "is allowed further.");
+  }
+
+  // Can't find the blob from the cache. Since I/O is allowed, read from the
+  // file.
+  CacheHandleGuard<BlobFileReader> blob_file_reader;
+  blob_file_cache_->GetBlobFileReader(file_number, &blob_file_reader);
+
+  assert(blob_file_reader.GetValue());
+
+  if (compression_type != blob_file_reader.GetValue()->GetCompressionType()) {
+    return Status::Corruption("Compression type mismatch when reading blob");
+  }
+
+  // Note: if verify_checksum is set, we read the entire blob record to be able
+  // to perform the verification; otherwise, we just read the blob itself. Since
+  // the offset in BlobIndex actually points to the blob value, we need to make
+  // an adjustment in the former case.
+  const uint64_t adjustment =
+      read_options.verify_checksums
+          ? BlobLogRecord::CalculateAdjustmentForRecordHeader(key_size)
+          : 0;
+  assert(offset >= adjustment);
+
+  const uint64_t record_size = value_size + adjustment;
+
+  {
+    const Status s = blob_file_reader.GetValue()->GetBlob(
+        read_options, user_key, offset, value_size, compression_type,
+        prefetch_buffer, value, bytes_read);
+    if (!s.ok()) {
+      return s;
+    }
+
+    if (bytes_read) {
+      *bytes_read = record_size;
+    }
+  }
+
+  if (blob_cache_ && read_options.fill_cache) {
+    // If filling cache is allowed and a cache is configured, try to put the
+    // blob to the cache.
+    Slice key = cache_key.AsSlice();
+    const Status s = PutBlobToCache(key, blob_cache_.get(), &blob_entry, value);
+    if (!s.ok()) {
+      return s;
+    }
+    value->PinSelf(*blob_entry.GetValue());
+    blob_entry.TransferTo(value);
+  }
+
+  return Status::OK();
+}
+
+bool BlobSource::TEST_BlobInCache(uint64_t file_number, uint64_t file_size,
+                                  uint64_t offset) const {
+  assert(blob_cache_ != nullptr);
+
+  Cache* const cache = blob_cache_.get();
+  if (cache == nullptr) {
+    return false;
+  }
+
+  const CacheKey cache_key = GetCacheKey(file_number, file_size, offset);
+  const Slice key = cache_key.AsSlice();
+
+  Cache::Handle* const cache_handle = cache->Lookup(key);
+  if (cache_handle == nullptr) {
+    return false;
+  }
+
+  cache->Release(cache_handle);
+
+  return true;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -75,10 +75,9 @@ inline Status BlobSource::InsertEntryIntoCache(Cache* blob_cache,
                                                const Slice* blob, size_t charge,
                                                Cache::Handle** cache_handle,
                                                Cache::Priority priority) const {
-  const Status s =
-      blob_cache->Insert(key, const_cast<void*>(static_cast<const void*>(blob)),
-                         charge, nullptr /* deleter */, cache_handle, priority);
-  return s;
+  return blob_cache->Insert(
+      key, const_cast<void*>(static_cast<const void*>(blob)), charge,
+      nullptr /* deleter */, cache_handle, priority);
 }
 
 Status BlobSource::GetBlobFromCache(const Slice& cache_key, Cache* blob_cache,

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -6,18 +6,11 @@
 #include "db/blob/blob_source.h"
 
 #include <cassert>
-#include <cstdint>
-#include <cstdio>
 #include <string>
 
 #include "db/blob/blob_file_reader.h"
-#include "db/blob/blob_log_format.h"
 #include "file/file_prefetch_buffer.h"
-#include "monitoring/statistics.h"
 #include "options/cf_options.h"
-#include "rocksdb/slice.h"
-#include "rocksdb/status.h"
-#include "util/compression.h"
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -10,7 +10,6 @@
 #include "cache/cache_helpers.h"
 #include "cache/cache_key.h"
 #include "db/blob/blob_file_cache.h"
-#include "db/blob/blob_file_meta.h"
 #include "db/blob/blob_log_format.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "table/block_based/cachable_entry.h"

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -32,15 +32,9 @@ class IOTracer;
 // storage with minimal cost.
 class BlobSource {
  public:
-  // The Cache* parameter is used to store blob file readers. When it's passed
-  // in, BlobSource will exclusively own cache afterwards. If it's a raw pointer
-  // managed by another shared/unique pointer, the developer must release the
-  // ownership.
-  BlobSource(Cache* cache, const ImmutableOptions* immutable_options,
-             const FileOptions* file_options, const std::string& db_id,
-             const std::string& db_session_id, uint32_t column_family_id,
-             HistogramImpl* blob_file_read_hist,
-             const std::shared_ptr<IOTracer>& io_tracer);
+  BlobSource(const ImmutableOptions* immutable_options,
+             const std::string& db_id, const std::string& db_session_id,
+             BlobFileCache* blob_file_cache);
 
   BlobSource(const BlobSource&) = delete;
   BlobSource& operator=(const BlobSource&) = delete;

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -1,0 +1,139 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cinttypes>
+
+#include "cache/cache_helpers.h"
+#include "cache/cache_key.h"
+#include "db/blob/blob_file_cache.h"
+#include "db/blob/blob_file_meta.h"
+#include "db/blob/blob_log_format.h"
+#include "rocksdb/rocksdb_namespace.h"
+#include "table/block_based/cachable_entry.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class Cache;
+struct ImmutableOptions;
+struct FileOptions;
+class HistogramImpl;
+class Status;
+class BlobFileReader;
+class FilePrefetchBuffer;
+class Slice;
+class IOTracer;
+
+class BlobSource {
+ public:
+  BlobSource(Cache* cache, const ImmutableOptions* immutable_options,
+             const FileOptions* file_options, const std::string& db_id,
+             const std::string& db_session_id, uint32_t column_family_id,
+             HistogramImpl* blob_file_read_hist,
+             const std::shared_ptr<IOTracer>& io_tracer);
+
+  BlobSource(const BlobSource&) = delete;
+  BlobSource& operator=(const BlobSource&) = delete;
+
+  ~BlobSource();
+
+  Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
+                 uint64_t file_number, uint64_t offset, uint64_t file_size,
+                 uint64_t value_size, CompressionType compression_type,
+                 FilePrefetchBuffer* prefetch_buffer, PinnableSlice* value,
+                 uint64_t* bytes_read);
+
+  bool TEST_BlobInCache(uint64_t file_number, uint64_t file_size,
+                        uint64_t offset) const;
+
+ private:
+  CacheKey GetCacheKey(uint64_t file_number, uint64_t file_size,
+                       uint64_t offset) const;
+
+  void SaveValue(const Slice& src, PinnableSlice* dst);
+
+  Status MaybeReadBlobFromCache(FilePrefetchBuffer* prefetch_buffer,
+                                const ReadOptions& read_options,
+                                const CacheKey& cache_key, uint64_t offset,
+                                const bool wait,
+                                CachableEntry<Slice>* blob_entry) const;
+
+  Cache::Handle* GetEntryFromCache(const CacheTier& cache_tier,
+                                   Cache* blob_cache, const Slice& key,
+                                   const bool wait,
+                                   const Cache::CacheItemHelper* cache_helper,
+                                   const Cache::CreateCallback& create_cb,
+                                   Cache::Priority priority) const;
+
+  Status InsertEntryToCache(const CacheTier& cache_tier, Cache* blob_cache,
+                            const Slice& key,
+                            const Cache::CacheItemHelper* cache_helper,
+                            const Slice* blob, size_t charge,
+                            Cache::Handle** cache_handle,
+                            Cache::Priority priority) const;
+
+  Status GetBlobFromCache(const Slice& cache_key, Cache* blob_cache,
+                          CachableEntry<Slice>* blob, bool wait) const;
+
+  Status PutBlobToCache(const Slice& cache_key, Cache* blob_cache,
+                        CachableEntry<Slice>* cached_blob,
+                        PinnableSlice* blob) const;
+
+  static size_t SizeCallback(void* obj) {
+    assert(obj != nullptr);
+
+    const Slice header_slice(static_cast<const char*>(obj),
+                             BlobLogRecord::kHeaderSize);
+
+    BlobLogRecord record;
+    const Status s = record.DecodeHeaderFrom(header_slice);
+    assert(s == Status::OK());
+
+    return record.record_size();
+  }
+
+  static Status SaveToCallback(void* from_obj, size_t from_offset,
+                               size_t length, void* out) {
+    assert(from_obj != nullptr);
+
+    const char* buf = static_cast<const char*>(from_obj);
+    const Slice header_slice(buf, BlobLogRecord::kHeaderSize);
+
+    BlobLogRecord record;
+    const Status s = record.DecodeHeaderFrom(header_slice);
+    assert(s == Status::OK());
+
+    assert(length == record.record_size());
+    (void)from_offset;
+    memcpy(out, buf, length);
+
+    return Status::OK();
+  }
+
+  static Cache::CacheItemHelper* GetCacheItemHelper() {
+    static Cache::CacheItemHelper cache_helper(
+        SizeCallback, SaveToCallback,
+        [](const Slice& /*key*/, void* /*val*/) -> void {});
+    return &cache_helper;
+  }
+
+  const std::string& db_id_;
+  const std::string& db_session_id_;
+
+  Statistics* statistics_;
+
+  // A cache to store blob file reader.
+  BlobFileCache* blob_file_cache_;
+
+  // A cache to store uncompressed blobs.
+  std::shared_ptr<Cache> blob_cache_;
+
+  // The control option of how the cache tiers will be used. Currently rocksdb
+  // support block cache (volatile tier), secondary cache (non-volatile tier).
+  const CacheTier lowest_used_cache_tier_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -10,21 +10,16 @@
 #include "cache/cache_helpers.h"
 #include "cache/cache_key.h"
 #include "db/blob/blob_file_cache.h"
-#include "db/blob/blob_log_format.h"
+#include "include/rocksdb/cache.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "table/block_based/cachable_entry.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-class Cache;
 struct ImmutableOptions;
-struct FileOptions;
-class HistogramImpl;
 class Status;
-class BlobFileReader;
 class FilePrefetchBuffer;
 class Slice;
-class IOTracer;
 
 // BlobSource is a class that provides universal access to blobs, regardless of
 // whether they are in the blob cache, secondary cache, or (remote) storage.

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -11,10 +11,9 @@
 #include <memory>
 #include <string>
 
-#include "blob_file_cache.h"
+#include "db/blob/blob_file_cache.h"
 #include "db/blob/blob_log_format.h"
 #include "db/blob/blob_log_writer.h"
-#include "db/blob/blob_source.h"
 #include "db/db_test_util.h"
 #include "file/filename.h"
 #include "file/read_write_util.h"

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <string>
 
+#include "blob_file_cache.h"
 #include "db/blob/blob_log_format.h"
 #include "db/blob/blob_log_writer.h"
 #include "db/blob/blob_source.h"
@@ -173,9 +174,12 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
   FileOptions file_options;
   constexpr HistogramImpl* blob_file_read_hist = nullptr;
 
-  BlobSource blob_source(backing_cache.get(), &immutable_options, &file_options,
-                         db_id, db_session_id, column_family_id,
-                         blob_file_read_hist, nullptr /*IOTracer*/);
+  std::unique_ptr<BlobFileCache> blob_file_cache(new BlobFileCache(
+      backing_cache.get(), &immutable_options, &file_options, column_family_id,
+      blob_file_read_hist, nullptr /*IOTracer*/));
+
+  BlobSource blob_source(&immutable_options, db_id, db_session_id,
+                         blob_file_cache.get());
 
   ReadOptions read_options;
   read_options.verify_checksums = true;

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -1,4 +1,4 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -174,12 +174,12 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
   FileOptions file_options;
   constexpr HistogramImpl* blob_file_read_hist = nullptr;
 
-  std::unique_ptr<BlobFileCache> blob_file_cache(new BlobFileCache(
+  BlobFileCache* blob_file_cache = new BlobFileCache(
       backing_cache.get(), &immutable_options, &file_options, column_family_id,
-      blob_file_read_hist, nullptr /*IOTracer*/));
+      blob_file_read_hist, nullptr /*IOTracer*/);
 
   BlobSource blob_source(&immutable_options, db_id, db_session_id,
-                         blob_file_cache.get());
+                         blob_file_cache);
 
   ReadOptions read_options;
   read_options.verify_checksums = true;

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -1,0 +1,276 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob/blob_source.h"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#include "db/blob/blob_log_format.h"
+#include "db/blob/blob_log_writer.h"
+#include "db/blob/blob_source.h"
+#include "db/db_test_util.h"
+#include "file/filename.h"
+#include "file/read_write_util.h"
+#include "options/cf_options.h"
+#include "rocksdb/options.h"
+#include "util/compression.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+namespace {
+
+// Creates a test blob file with `num` blobs in it.
+void WriteBlobFile(const ImmutableOptions& immutable_options,
+                   uint32_t column_family_id, bool has_ttl,
+                   const ExpirationRange& expiration_range_header,
+                   const ExpirationRange& expiration_range_footer,
+                   uint64_t blob_file_number, const std::vector<Slice>& keys,
+                   const std::vector<Slice>& blobs, CompressionType compression,
+                   std::vector<uint64_t>& blob_offsets,
+                   std::vector<uint64_t>& blob_sizes) {
+  assert(!immutable_options.cf_paths.empty());
+  size_t num = keys.size();
+  assert(num == blobs.size());
+  assert(num == blob_offsets.size());
+  assert(num == blob_sizes.size());
+
+  const std::string blob_file_path =
+      BlobFileName(immutable_options.cf_paths.front().path, blob_file_number);
+  std::unique_ptr<FSWritableFile> file;
+  ASSERT_OK(NewWritableFile(immutable_options.fs.get(), blob_file_path, &file,
+                            FileOptions()));
+
+  std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
+      std::move(file), blob_file_path, FileOptions(), immutable_options.clock));
+
+  constexpr Statistics* statistics = nullptr;
+  constexpr bool use_fsync = false;
+  constexpr bool do_flush = false;
+
+  BlobLogWriter blob_log_writer(std::move(file_writer), immutable_options.clock,
+                                statistics, blob_file_number, use_fsync,
+                                do_flush);
+
+  BlobLogHeader header(column_family_id, compression, has_ttl,
+                       expiration_range_header);
+
+  ASSERT_OK(blob_log_writer.WriteHeader(header));
+
+  std::vector<std::string> compressed_blobs(num);
+  std::vector<Slice> blobs_to_write(num);
+  if (kNoCompression == compression) {
+    for (size_t i = 0; i < num; ++i) {
+      blobs_to_write[i] = blobs[i];
+      blob_sizes[i] = blobs[i].size();
+    }
+  } else {
+    CompressionOptions opts;
+    CompressionContext context(compression);
+    constexpr uint64_t sample_for_compression = 0;
+    CompressionInfo info(opts, context, CompressionDict::GetEmptyDict(),
+                         compression, sample_for_compression);
+
+    constexpr uint32_t compression_format_version = 2;
+
+    for (size_t i = 0; i < num; ++i) {
+      ASSERT_TRUE(CompressData(blobs[i], info, compression_format_version,
+                               &compressed_blobs[i]));
+      blobs_to_write[i] = compressed_blobs[i];
+      blob_sizes[i] = compressed_blobs[i].size();
+    }
+  }
+
+  for (size_t i = 0; i < num; ++i) {
+    uint64_t key_offset = 0;
+    ASSERT_OK(blob_log_writer.AddRecord(keys[i], blobs_to_write[i], &key_offset,
+                                        &blob_offsets[i]));
+  }
+
+  BlobLogFooter footer;
+  footer.blob_count = num;
+  footer.expiration_range = expiration_range_footer;
+
+  std::string checksum_method;
+  std::string checksum_value;
+  ASSERT_OK(
+      blob_log_writer.AppendFooter(footer, &checksum_method, &checksum_value));
+}
+
+}  // anonymous namespace
+
+class BlobSourceTest : public DBTestBase {
+ protected:
+ public:
+  explicit BlobSourceTest()
+      : DBTestBase("blob_source_test", /*env_do_fsync=*/true) {}
+};
+
+TEST_F(BlobSourceTest, GetBlobsFromCache) {
+  Options options;
+  options.env = env_;
+  options.cf_paths.emplace_back(
+      test::PerThreadDBPath(env_, "BlobSourceTest_GetBlobsFromCache"), 0);
+  options.enable_blob_files = true;
+
+  LRUCacheOptions co;
+  co.capacity = 2048;
+  co.num_shard_bits = 2;
+  co.metadata_charge_policy = kDontChargeCacheMetadata;
+  options.blob_cache = NewLRUCache(co);
+  options.lowest_used_cache_tier = CacheTier::kVolatileTier;
+
+  Reopen(options);
+
+  std::string db_id;
+  ASSERT_OK(db_->GetDbIdentity(db_id));
+
+  std::string db_session_id;
+  ASSERT_OK(db_->GetDbSessionId(db_session_id));
+
+  ImmutableOptions immutable_options(options);
+
+  constexpr uint32_t column_family_id = 1;
+  constexpr bool has_ttl = false;
+  constexpr ExpirationRange expiration_range;
+  constexpr uint64_t blob_file_number = 1;
+  constexpr size_t num_blobs = 16;
+
+  std::vector<std::string> key_strs;
+  std::vector<std::string> blob_strs;
+
+  for (size_t i = 0; i < num_blobs; ++i) {
+    key_strs.push_back("key" + std::to_string(i));
+    blob_strs.push_back("blob" + std::to_string(i));
+  }
+
+  std::vector<Slice> keys;
+  std::vector<Slice> blobs;
+
+  uint64_t file_size = BlobLogHeader::kSize;
+  for (size_t i = 0; i < num_blobs; ++i) {
+    keys.push_back({key_strs[i]});
+    blobs.push_back({blob_strs[i]});
+    file_size += BlobLogRecord::kHeaderSize + keys[i].size() + blobs[i].size();
+  }
+  file_size += BlobLogFooter::kSize;
+
+  std::vector<uint64_t> blob_offsets(keys.size());
+  std::vector<uint64_t> blob_sizes(keys.size());
+
+  WriteBlobFile(immutable_options, column_family_id, has_ttl, expiration_range,
+                expiration_range, blob_file_number, keys, blobs, kNoCompression,
+                blob_offsets, blob_sizes);
+
+  constexpr size_t capacity = 10;
+  std::shared_ptr<Cache> backing_cache =
+      NewLRUCache(capacity);  // Blob file cache
+
+  FileOptions file_options;
+  constexpr HistogramImpl* blob_file_read_hist = nullptr;
+
+  BlobSource blob_source(backing_cache.get(), &immutable_options, &file_options,
+                         db_id, db_session_id, column_family_id,
+                         blob_file_read_hist, nullptr /*IOTracer*/);
+
+  ReadOptions read_options;
+  read_options.verify_checksums = true;
+
+  constexpr FilePrefetchBuffer* prefetch_buffer = nullptr;
+
+  // GetBlob
+  {
+    std::vector<PinnableSlice> values(keys.size());
+    uint64_t bytes_read = 0;
+
+    read_options.fill_cache = false;
+
+    for (size_t i = 0; i < num_blobs; ++i) {
+      ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
+                                                blob_offsets[i]));
+
+      ASSERT_OK(blob_source.GetBlob(read_options, keys[i], blob_file_number,
+                                    blob_offsets[i], file_size, blob_sizes[i],
+                                    kNoCompression, prefetch_buffer, &values[i],
+                                    &bytes_read));
+      ASSERT_EQ(values[i], blobs[i]);
+      ASSERT_EQ(bytes_read,
+                blob_sizes[i] + keys[i].size() + BlobLogRecord::kHeaderSize);
+
+      ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
+                                                blob_offsets[i]));
+    }
+
+    read_options.fill_cache = true;
+
+    for (size_t i = 0; i < num_blobs; ++i) {
+      ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
+                                                blob_offsets[i]));
+
+      ASSERT_OK(blob_source.GetBlob(read_options, keys[i], blob_file_number,
+                                    blob_offsets[i], file_size, blob_sizes[i],
+                                    kNoCompression, prefetch_buffer, &values[i],
+                                    &bytes_read));
+      ASSERT_EQ(values[i], blobs[i]);
+      ASSERT_EQ(bytes_read,
+                blob_sizes[i] + keys[i].size() + BlobLogRecord::kHeaderSize);
+
+      ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
+                                               blob_offsets[i]));
+    }
+
+    read_options.fill_cache = true;
+
+    for (size_t i = 0; i < num_blobs; ++i) {
+      ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
+                                               blob_offsets[i]));
+
+      ASSERT_OK(blob_source.GetBlob(read_options, keys[i], blob_file_number,
+                                    blob_offsets[i], file_size, blob_sizes[i],
+                                    kNoCompression, prefetch_buffer, &values[i],
+                                    &bytes_read));
+      ASSERT_EQ(values[i], blobs[i]);
+      ASSERT_EQ(bytes_read, blob_sizes[i]);
+
+      ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
+                                               blob_offsets[i]));
+    }
+  }
+
+  options.blob_cache->EraseUnRefEntries();
+
+  // Cache-only GetBlob
+  {
+    std::vector<PinnableSlice> values(keys.size());
+    uint64_t bytes_read = 0;
+
+    read_options.read_tier = ReadTier::kBlockCacheTier;
+    read_options.fill_cache = true;
+
+    for (size_t i = 0; i < num_blobs; ++i) {
+      ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
+                                                blob_offsets[i]));
+
+      ASSERT_NOK(blob_source.GetBlob(read_options, keys[i], blob_file_number,
+                                     blob_offsets[i], file_size, blob_sizes[i],
+                                     kNoCompression, prefetch_buffer,
+                                     &values[i], &bytes_read));
+      ASSERT_TRUE(values[i].empty());
+      ASSERT_EQ(bytes_read, 0);
+
+      ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
+                                                blob_offsets[i]));
+    }
+  }
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <memory>
 #include <string>
 
 #include "blob_file_cache.h"
@@ -174,12 +175,12 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
   FileOptions file_options;
   constexpr HistogramImpl* blob_file_read_hist = nullptr;
 
-  BlobFileCache* blob_file_cache = new BlobFileCache(
+  std::unique_ptr<BlobFileCache> blob_file_cache(new BlobFileCache(
       backing_cache.get(), &immutable_options, &file_options, column_family_id,
-      blob_file_read_hist, nullptr /*IOTracer*/);
+      blob_file_read_hist, nullptr /*IOTracer*/));
 
   BlobSource blob_source(&immutable_options, db_id, db_session_id,
-                         blob_file_cache);
+                         blob_file_cache.get());
 
   ReadOptions read_options;
   read_options.verify_checksums = true;

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -290,7 +290,7 @@ class Cache {
   virtual const char* Name() const = 0;
 
   // Insert a mapping from key->value into the volatile cache only
-  // and assign it // the specified charge against the total cache capacity.
+  // and assign it with the specified charge against the total cache capacity.
   // If strict_capacity_limit is true and cache reaches its full capacity,
   // return Status::Incomplete.
   //
@@ -394,8 +394,8 @@ class Cache {
   // memory - call this only if you're shutting down the process.
   // Any attempts of using cache after this call will fail terribly.
   // Always delete the DB object before calling this method!
-  virtual void DisownData(){
-      // default implementation is noop
+  virtual void DisownData() {
+    // default implementation is noop
   }
 
   struct ApplyToAllEntriesOptions {

--- a/src.mk
+++ b/src.mk
@@ -21,6 +21,7 @@ LIB_SOURCES =                                                   \
   db/blob/blob_log_format.cc                                    \
   db/blob/blob_log_sequential_reader.cc                         \
   db/blob/blob_log_writer.cc                                    \
+  db/blob/blob_source.cc                                        \
   db/blob/prefetch_buffer_collection.cc                         \
   db/builder.cc                                                 \
   db/c.cc                                                       \
@@ -415,6 +416,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/blob/blob_file_garbage_test.cc                                     \
   db/blob/blob_file_reader_test.cc                                      \
   db/blob/blob_garbage_meter_test.cc                                    \
+  db/blob/blob_source_test.cc                                           \
   db/blob/db_blob_basic_test.cc                                         \
   db/blob/db_blob_compaction_test.cc                                    \
   db/blob/db_blob_corruption_test.cc                                    \


### PR DESCRIPTION
Summary:

There is currently no caching mechanism for blobs, which is not ideal especially when the database resides on remote storage (where we cannot rely on the OS page cache). As part of this task, we would like to make it possible for the application to configure a blob cache.

Tasks:

In this task, we added a new abstraction layer `BlobSource` to retrieve blobs from either blob cache or raw blob file. Note: For simplicity, the current PR only includes `GetBlob()`.  `MultiGetBlob()` will be included in the next PR.
 
This PR is a part of #10156 