### PR TITLE
Fix race condition with WAL tracking and `FlushWAL(true /* sync */)`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,7 @@
 * Fix a bug that could return wrong results with `index_type=kHashSearch` and using `SetOptions` to change the `prefix_extractor`.
 * Fixed a bug in WAL tracking with wal_compression. WAL compression writes a kSetCompressionType record which is not associated with any sequence number. As result, WalManager::GetSortedWalsOfType() will skip these WALs and not return them to caller, e.g. Checkpoint, Backup, causing the operations to fail.
 * Avoid a crash if the IDENTITY file is accidentally truncated to empty. A new DB ID will be written and generated on Open.
-* Fixed a possible corruption for users of `FlushWAL(true /* sync */)` together with `track_and_verify_wals_in_manifest == true`. For those users, losing unsynced data (e.g., due to power loss) could make future DB opens fail with a `Status::Corruption` complaining about missing WAL data.
+* Fixed a possible corruption for users of `manual_wal_flush` and/or `FlushWAL(true /* sync */)`, together with `track_and_verify_wals_in_manifest == true`. For those users, losing unsynced data (e.g., due to power loss) could make future DB opens fail with a `Status::Corruption` complaining about missing WAL data.
 
 ### Public API changes
 * Add new API GetUnixTime in Snapshot class which returns the unix time at which Snapshot is taken.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 * Fix a bug that could return wrong results with `index_type=kHashSearch` and using `SetOptions` to change the `prefix_extractor`.
 * Fixed a bug in WAL tracking with wal_compression. WAL compression writes a kSetCompressionType record which is not associated with any sequence number. As result, WalManager::GetSortedWalsOfType() will skip these WALs and not return them to caller, e.g. Checkpoint, Backup, causing the operations to fail.
 * Avoid a crash if the IDENTITY file is accidentally truncated to empty. A new DB ID will be written and generated on Open.
+* Fixed a possible corruption for users of `FlushWAL(true /* sync */)` together with `track_and_verify_wals_in_manifest == true`. For those users, losing unsynced data (e.g., due to power loss) could make future DB opens fail with a `Status::Corruption` complaining about missing WAL data.
 
 ### Public API changes
 * Add new API GetUnixTime in Snapshot class which returns the unix time at which Snapshot is taken.

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1367,6 +1367,7 @@ Status DBImpl::FlushWAL(bool sync) {
 }
 
 Status DBImpl::SyncWAL() {
+  TEST_SYNC_POINT("DBImpl::SyncWAL:Begin");
   autovector<log::Writer*, 1> logs_to_sync;
   bool need_log_dir_sync;
   uint64_t current_log_number;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1479,8 +1479,8 @@ Status DBImpl::MarkLogsSynced(uint64_t up_to, bool synced_dir) {
     assert(wal.getting_synced);
     if (immutable_db_options_.track_and_verify_wals_in_manifest &&
         wal.writer->file()->GetFileSize() > 0) {
-      size_t tracked_synced_size = std::min(wal.tracked_synced_size_limit,
-                                            wal.writer->file()->GetFileSize());
+      uint64_t tracked_synced_size = std::min(
+          wal.tracked_synced_size_limit, wal.writer->file()->GetFileSize());
       synced_wals.AddWal(wal.number, WalMetadata(tracked_synced_size));
     }
 
@@ -1491,7 +1491,7 @@ Status DBImpl::MarkLogsSynced(uint64_t up_to, bool synced_dir) {
       it = logs_.erase(it);
     } else {
       wal.getting_synced = false;
-      wal.tracked_synced_size_limit = SIZE_MAX;
+      wal.tracked_synced_size_limit = UINT64_MAX;
       ++it;
     }
   }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1400,8 +1400,8 @@ Status DBImpl::SyncWAL() {
       assert(!log.getting_synced);
       log.getting_synced = true;
       // Size is expected to be monotonically increasing.
-      assert(log.writer->file()->GetFileSize() >= log.pre_sync_size);
-      log.pre_sync_size = log.writer->file()->GetFileSize();
+      assert(log.writer->file()->GetFlushedSize() >= log.pre_sync_size);
+      log.pre_sync_size = log.writer->file()->GetFlushedSize();
       logs_to_sync.push_back(log.writer);
     }
 
@@ -1476,7 +1476,7 @@ Status DBImpl::MarkLogsSynced(uint64_t up_to, bool synced_dir) {
     auto& wal = *it;
     assert(wal.getting_synced);
     if (immutable_db_options_.track_and_verify_wals_in_manifest &&
-        wal.writer->file()->GetFileSize() > 0) {
+        wal.writer->file()->GetFlushedSize() > 0) {
       synced_wals.AddWal(wal.number, WalMetadata(wal.pre_sync_size));
     }
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1479,7 +1479,7 @@ Status DBImpl::MarkLogsSynced(uint64_t up_to, bool synced_dir) {
     assert(wal.getting_synced);
     if (immutable_db_options_.track_and_verify_wals_in_manifest &&
         wal.writer->file()->GetFileSize() > 0) {
-      size_t tracked_synced_size = std::min(tracked_synced_size_limit,
+      size_t tracked_synced_size = std::min(wal.tracked_synced_size_limit,
                                             wal.writer->file()->GetFileSize());
       synced_wals.AddWal(wal.number, WalMetadata(tracked_synced_size));
     }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1380,7 +1380,7 @@ Status DBImpl::SyncWAL() {
     current_log_number = logfile_number_;
 
     while (logs_.front().number <= current_log_number &&
-           logs_.front().getting_synced) {
+           logs_.front().IsSyncing()) {
       log_sync_cv_.Wait();
     }
     // First check that logs are safe to sync in background.
@@ -1397,11 +1397,7 @@ Status DBImpl::SyncWAL() {
     for (auto it = logs_.begin();
          it != logs_.end() && it->number <= current_log_number; ++it) {
       auto& log = *it;
-      assert(!log.getting_synced);
-      log.getting_synced = true;
-      // Size is expected to be monotonically increasing.
-      assert(log.writer->file()->GetFlushedSize() >= log.pre_sync_size);
-      log.pre_sync_size = log.writer->file()->GetFlushedSize();
+      log.PrepareForSync();
       logs_to_sync.push_back(log.writer);
     }
 
@@ -1474,10 +1470,10 @@ Status DBImpl::MarkLogsSynced(uint64_t up_to, bool synced_dir) {
   VersionEdit synced_wals;
   for (auto it = logs_.begin(); it != logs_.end() && it->number <= up_to;) {
     auto& wal = *it;
-    assert(wal.getting_synced);
+    assert(wal.IsSyncing());
     if (immutable_db_options_.track_and_verify_wals_in_manifest &&
-        wal.writer->file()->GetFlushedSize() > 0) {
-      synced_wals.AddWal(wal.number, WalMetadata(wal.pre_sync_size));
+        wal.GetPreSyncSize() > 0) {
+      synced_wals.AddWal(wal.number, WalMetadata(wal.GetPreSyncSize()));
     }
 
     if (logs_.size() > 1) {
@@ -1486,12 +1482,12 @@ Status DBImpl::MarkLogsSynced(uint64_t up_to, bool synced_dir) {
       InstrumentedMutexLock l(&log_write_mutex_);
       it = logs_.erase(it);
     } else {
-      wal.getting_synced = false;
+      wal.FinishSync();
       ++it;
     }
   }
   assert(logs_.empty() || logs_[0].number > up_to ||
-         (logs_.size() == 1 && !logs_[0].getting_synced));
+         (logs_.size() == 1 && !logs_[0].IsSyncing()));
 
   Status s;
   if (synced_wals.IsWalAddition()) {
@@ -1511,8 +1507,7 @@ void DBImpl::MarkLogsNotSynced(uint64_t up_to) {
   for (auto it = logs_.begin(); it != logs_.end() && it->number <= up_to;
        ++it) {
     auto& wal = *it;
-    assert(wal.getting_synced);
-    wal.getting_synced = false;
+    wal.FinishSync();
   }
   log_sync_cv_.SignalAll();
 }

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1599,6 +1599,10 @@ class DBImpl : public DB {
     log::Writer* writer;  // own
     // true for some prefix of logs_
     bool getting_synced = false;
+    // This can be used to limit the synced size tracked in MANIFEST. It is
+    // useful for files that undergo append during sync, in which case the file
+    // size at tracking time is not necessarily all synced.
+    size_t tracked_synced_size_limit = SIZE_MAX;
   };
 
   // PurgeFileInfo is a structure to hold information of files to be deleted in

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1599,10 +1599,10 @@ class DBImpl : public DB {
     log::Writer* writer;  // own
     // true for some prefix of logs_
     bool getting_synced = false;
-    // This can be used to limit the synced size tracked in MANIFEST. It is
-    // useful for files that undergo append during sync, in which case the file
-    // size at tracking time is not necessarily all synced.
-    uint64_t tracked_synced_size_limit = UINT64_MAX;
+    // The size of the file before the sync happens. This amount is guaranteed
+    // to be persisted even if appends happen during sync so it can be used for
+    // tracking the synced size in MANIFEST.
+    uint64_t pre_sync_size = 0;
   };
 
   // PurgeFileInfo is a structure to hold information of files to be deleted in

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1602,7 +1602,7 @@ class DBImpl : public DB {
     // This can be used to limit the synced size tracked in MANIFEST. It is
     // useful for files that undergo append during sync, in which case the file
     // size at tracking time is not necessarily all synced.
-    size_t tracked_synced_size_limit = SIZE_MAX;
+    uint64_t tracked_synced_size_limit = UINT64_MAX;
   };
 
   // PurgeFileInfo is a structure to hold information of files to be deleted in

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1593,10 +1593,32 @@ class DBImpl : public DB {
       return s;
     }
 
+    bool IsSyncing() { return getting_synced; }
+
+    uint64_t GetPreSyncSize() {
+      assert(getting_synced);
+      return pre_sync_size;
+    }
+
+    void PrepareForSync() {
+      assert(!getting_synced);
+      // Size is expected to be monotonically increasing.
+      assert(writer->file()->GetFlushedSize() >= pre_sync_size);
+      getting_synced = true;
+      pre_sync_size = writer->file()->GetFlushedSize();
+    }
+
+    void FinishSync() {
+      assert(getting_synced);
+      getting_synced = false;
+    }
+
     uint64_t number;
     // Visual Studio doesn't support deque's member to be noncopyable because
     // of a std::unique_ptr as a member.
     log::Writer* writer;  // own
+
+   private:
     // true for some prefix of logs_
     bool getting_synced = false;
     // The size of the file before the sync happens. This amount is guaranteed

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -88,17 +88,13 @@ IOStatus DBImpl::SyncClosedLogs(JobContext* job_context) {
   autovector<log::Writer*, 1> logs_to_sync;
   uint64_t current_log_number = logfile_number_;
   while (logs_.front().number < current_log_number &&
-         logs_.front().getting_synced) {
+         logs_.front().IsSyncing()) {
     log_sync_cv_.Wait();
   }
   for (auto it = logs_.begin();
        it != logs_.end() && it->number < current_log_number; ++it) {
     auto& log = *it;
-    assert(!log.getting_synced);
-    log.getting_synced = true;
-    // Size is expected to be monotonically increasing.
-    assert(log.writer->file()->GetFileSize() >= log.pre_sync_size);
-    log.pre_sync_size = log.writer->file()->GetFileSize();
+    log.PrepareForSync();
     logs_to_sync.push_back(log.writer);
   }
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -96,6 +96,9 @@ IOStatus DBImpl::SyncClosedLogs(JobContext* job_context) {
     auto& log = *it;
     assert(!log.getting_synced);
     log.getting_synced = true;
+    // Size is expected to be monotonically increasing.
+    assert(log.writer->file()->GetFileSize() >= log.pre_sync_size);
+    log.pre_sync_size = log.writer->file()->GetFileSize();
     logs_to_sync.push_back(log.writer);
   }
 

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -288,7 +288,7 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
     }
     while (!logs_.empty() && logs_.front().number < min_log_number) {
       auto& log = logs_.front();
-      if (log.getting_synced) {
+      if (log.IsSyncing()) {
         log_sync_cv_.Wait();
         // logs_ could have changed while we were waiting.
         continue;

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1192,6 +1192,9 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
       // Note: there does not seem to be a reason to set this early before we
       // actually write to the WAL
       log.getting_synced = true;
+      // Size is expected to be monotonically increasing.
+      assert(log.writer->file()->GetFileSize() >= log.pre_sync_size);
+      log.pre_sync_size = log.writer->file()->GetFileSize();
     }
   } else {
     *need_log_sync = false;

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1181,20 +1181,16 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
     // Note: there does not seem to be a reason to wait for parallel sync at
     // this early step but it is not important since parallel sync (SyncWAL) and
     // need_log_sync are usually not used together.
-    while (logs_.front().getting_synced) {
+    while (logs_.front().IsSyncing()) {
       log_sync_cv_.Wait();
     }
     for (auto& log : logs_) {
-      assert(!log.getting_synced);
       // This is just to prevent the logs to be synced by a parallel SyncWAL
       // call. We will do the actual syncing later after we will write to the
       // WAL.
       // Note: there does not seem to be a reason to set this early before we
       // actually write to the WAL
-      log.getting_synced = true;
-      // Size is expected to be monotonically increasing.
-      assert(log.writer->file()->GetFileSize() >= log.pre_sync_size);
-      log.pre_sync_size = log.writer->file()->GetFileSize();
+      log.PrepareForSync();
     }
   } else {
     *need_log_sync = false;

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -585,7 +585,8 @@ IOStatus WritableFileWriter::WriteBuffered(
 
     left -= allowed;
     src += allowed;
-    flushed_size_ += allowed;
+    uint64_t cur_size = flushed_size_.load(std::memory_order_acquire);
+    flushed_size_.store(cur_size + allowed, std::memory_order_release);
   }
   buf_.Size(0);
   buffered_data_crc32c_checksum_ = 0;
@@ -676,7 +677,8 @@ IOStatus WritableFileWriter::WriteBufferedWithChecksum(
   // the corresponding checksum value
   buf_.Size(0);
   buffered_data_crc32c_checksum_ = 0;
-  flushed_size_ += left;
+  uint64_t cur_size = flushed_size_.load(std::memory_order_acquire);
+  flushed_size_.store(cur_size + left, std::memory_order_release);
   return s;
 }
 
@@ -784,7 +786,8 @@ IOStatus WritableFileWriter::WriteDirect(
     left -= size;
     src += size;
     write_offset += size;
-    flushed_size_ += size;
+    uint64_t cur_size = flushed_size_.load(std::memory_order_acquire);
+    flushed_size_.store(cur_size + size, std::memory_order_release);
     assert((next_write_offset_ % alignment) == 0);
   }
 
@@ -887,7 +890,8 @@ IOStatus WritableFileWriter::WriteDirectWithChecksum(
 
   IOSTATS_ADD(bytes_written, left);
   assert((next_write_offset_ % alignment) == 0);
-  flushed_size_ += left;
+  uint64_t cur_size = flushed_size_.load(std::memory_order_acquire);
+  flushed_size_.store(cur_size + left, std::memory_order_release);
 
   if (s.ok()) {
     // Move the tail to the beginning of the buffer

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -585,6 +585,7 @@ IOStatus WritableFileWriter::WriteBuffered(
 
     left -= allowed;
     src += allowed;
+    flushed_size_ += allowed;
   }
   buf_.Size(0);
   buffered_data_crc32c_checksum_ = 0;
@@ -675,6 +676,7 @@ IOStatus WritableFileWriter::WriteBufferedWithChecksum(
   // the corresponding checksum value
   buf_.Size(0);
   buffered_data_crc32c_checksum_ = 0;
+  flushed_size_ += left;
   return s;
 }
 
@@ -782,6 +784,7 @@ IOStatus WritableFileWriter::WriteDirect(
     left -= size;
     src += size;
     write_offset += size;
+    flushed_size_ += size;
     assert((next_write_offset_ % alignment) == 0);
   }
 
@@ -884,6 +887,7 @@ IOStatus WritableFileWriter::WriteDirectWithChecksum(
 
   IOSTATS_ADD(bytes_written, left);
   assert((next_write_offset_ % alignment) == 0);
+  flushed_size_ += left;
 
   if (s.ok()) {
     // Move the tail to the beginning of the buffer

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -261,6 +261,10 @@ class WritableFileWriter {
     return filesize_.load(std::memory_order_acquire);
   }
 
+  // Returns the size of data flushed to the underlying `FSWritableFile`.
+  // Expected to match `writable_file()->GetFileSize()`.
+  // The return value can serve as a lower-bound for the amount of data synced
+  // by a future call to `SyncWithoutFlush()`.
   uint64_t GetFlushedSize() const {
     return flushed_size_.load(std::memory_order_acquire);
   }

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -261,9 +261,7 @@ class WritableFileWriter {
     return filesize_.load(std::memory_order_acquire);
   }
 
-  uint64_t GetFlushedSize() const {
-    return flushed_size_;
-  }
+  uint64_t GetFlushedSize() const { return flushed_size_; }
 
   IOStatus InvalidateCache(size_t offset, size_t length) {
     return writable_file_->InvalidateCache(offset, length);

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -143,7 +143,7 @@ class WritableFileWriter {
   // Actually written data size can be used for truncate
   // not counting padding data
   std::atomic<uint64_t> filesize_;
-  uint64_t flushed_size_;
+  std::atomic<uint64_t> flushed_size_;
 #ifndef ROCKSDB_LITE
   // This is necessary when we use unbuffered access
   // and writes must happen on aligned offsets
@@ -261,7 +261,9 @@ class WritableFileWriter {
     return filesize_.load(std::memory_order_acquire);
   }
 
-  uint64_t GetFlushedSize() const { return flushed_size_; }
+  uint64_t GetFlushedSize() const {
+    return flushed_size_.load(std::memory_order_acquire);
+  }
 
   IOStatus InvalidateCache(size_t offset, size_t length) {
     return writable_file_->InvalidateCache(offset, length);

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -143,6 +143,7 @@ class WritableFileWriter {
   // Actually written data size can be used for truncate
   // not counting padding data
   std::atomic<uint64_t> filesize_;
+  uint64_t flushed_size_;
 #ifndef ROCKSDB_LITE
   // This is necessary when we use unbuffered access
   // and writes must happen on aligned offsets
@@ -180,6 +181,7 @@ class WritableFileWriter {
         buf_(),
         max_buffer_size_(options.writable_file_max_buffer_size),
         filesize_(0),
+        flushed_size_(0),
 #ifndef ROCKSDB_LITE
         next_write_offset_(0),
 #endif  // ROCKSDB_LITE
@@ -257,6 +259,10 @@ class WritableFileWriter {
 
   uint64_t GetFileSize() const {
     return filesize_.load(std::memory_order_acquire);
+  }
+
+  uint64_t GetFlushedSize() const {
+    return flushed_size_;
   }
 
   IOStatus InvalidateCache(size_t offset, size_t length) {

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -943,6 +943,9 @@ TEST_F(CheckpointTest, PutRaceWithCheckpointTrackedWalSync) {
 
   ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_));
 
+  // Ensure callback ran.
+  ASSERT_EQ("val2", Get("key2"));
+
   Close();
 
   // Simulate full loss of unsynced data. This drops "key2" -> "val2" from the
@@ -953,6 +956,7 @@ TEST_F(CheckpointTest, PutRaceWithCheckpointTrackedWalSync) {
   // AddWal entry indicated the WAL should be synced through "key2" -> "val2".
   Reopen(options);
 
+  // Need to close before `fault_env` goes out of scope.
   Close();
 }
 

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -952,6 +952,8 @@ TEST_F(CheckpointTest, PutRaceWithCheckpointTrackedWalSync) {
   // Before the bug fix, reopening the DB would fail because the MANIFEST's
   // AddWal entry indicated the WAL should be synced through "key2" -> "val2".
   Reopen(options);
+
+  Close();
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -915,6 +915,45 @@ TEST_F(CheckpointTest, CheckpointWithDbPath) {
   delete checkpoint;
 }
 
+TEST_F(CheckpointTest, PutRaceWithCheckpointTrackedWalSync) {
+  // Repro for a race condition where a user write comes in after the checkpoint
+  // syncs WAL for `track_and_verify_wals_in_manifest` but before the
+  // corresponding MANIFEST update. With the bug, that scenario resulted in an
+  // unopenable DB with error "Corruption: Size mismatch: WAL ...".
+  Options options = CurrentOptions();
+  std::unique_ptr<FaultInjectionTestEnv> fault_env(
+      new FaultInjectionTestEnv(env_));
+  options.env = fault_env.get();
+  options.track_and_verify_wals_in_manifest = true;
+  Reopen(options);
+
+  ASSERT_OK(Put("key1", "val1"));
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SyncWAL:BeforeMarkLogsSynced:1",
+      [this](void* /* arg */) { ASSERT_OK(Put("key2", "val2")); });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  std::unique_ptr<Checkpoint> checkpoint;
+  {
+    Checkpoint* checkpoint_ptr;
+    ASSERT_OK(Checkpoint::Create(db_, &checkpoint_ptr));
+    checkpoint.reset(checkpoint_ptr);
+  }
+
+  ASSERT_OK(checkpoint->CreateCheckpoint(snapshot_name_));
+
+  Close();
+
+  // Simulate full loss of unsynced data. This drops "key2" -> "val2" from the
+  // DB WAL.
+  fault_env->DropUnsyncedFileData();
+
+  // Before the bug fix, reopening the DB would fail because the MANIFEST's
+  // AddWal entry indicated the WAL should be synced through "key2" -> "val2".
+  Reopen(options);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
`FlushWAL(true /* sync */)` is used internally and for manual WAL sync. It had a bug when used together with `track_and_verify_wals_in_manifest` where the synced size tracked in MANIFEST was larger than the number of bytes actually synced.

The bug could be repro'd almost immediately with the following crash test command: `python3 tools/db_crashtest.py blackbox --simple --write_buffer_size=524288 --max_bytes_for_level_base=2097152 --target_file_size_base=524288 --duration=3600 --interval=10 --sync_fault_injection=1 --disable_wal=0 --checkpoint_one_in=1000 --max_key=10000 --value_size_mult=33`.

An example error message produced by the above command is shown below. The error sometimes arose from the checkpoint and other times arose from the main stress test DB.

```
Corruption: Size mismatch: WAL (log number: 119) in MANIFEST is 27938 bytes , but actually is 27859 bytes on disk.
```

Test Plan:
- repro unit test
- the above crash test command no longer finds the error. It does find a different error after a while longer such as "Corruption: WAL file 481 required by manifest but not in directory list"