### PR TITLE
Multi-File Trivial Move in L0->L1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -75,6 +75,7 @@
 
 ### Performance Improvements
 * Rather than doing total sort against all files in a level, SortFileByOverlappingRatio() to only find the top 50 files based on score. This can improve write throughput for the use cases where data is loaded in increasing key order and there are a lot of files in one LSM-tree, where applying compaction results is the bottleneck.
+* In leveled compaction, L0->L1 trivial move will allow more than one file to be moved in one compaction. This would allow L0 files to be moved down faster when data is loaded in sequential order, making slowdown or stop condition harder to hit. Also seek L0->L1 trivial move when only some files qualify.
 
 ## 7.3.0 (05/20/2022)
 ### Bug Fixes

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -214,7 +214,8 @@ Compaction::Compaction(
     CompressionOptions _compression_opts, Temperature _output_temperature,
     uint32_t _max_subcompactions, std::vector<FileMetaData*> _grandparents,
     bool _manual_compaction, const std::string& _trim_ts, double _score,
-    bool _deletion_compaction, CompactionReason _compaction_reason,
+    bool _deletion_compaction, bool all_level_non_overlapping,
+    CompactionReason _compaction_reason,
     BlobGarbageCollectionPolicy _blob_garbage_collection_policy,
     double _blob_garbage_collection_age_cutoff)
     : input_vstorage_(vstorage),
@@ -233,6 +234,7 @@ Compaction::Compaction(
       output_compression_opts_(_compression_opts),
       output_temperature_(_output_temperature),
       deletion_compaction_(_deletion_compaction),
+      all_level_non_overlapping_(all_level_non_overlapping),
       inputs_(PopulateWithAtomicBoundaries(vstorage, std::move(_inputs))),
       grandparents_(std::move(_grandparents)),
       score_(_score),
@@ -241,6 +243,7 @@ Compaction::Compaction(
       is_manual_compaction_(_manual_compaction),
       trim_ts_(_trim_ts),
       is_trivial_move_(false),
+
       compaction_reason_(_compaction_reason),
       notify_on_compaction_completion_(false),
       enable_blob_garbage_collection_(
@@ -333,7 +336,8 @@ bool Compaction::IsTrivialMove() const {
   // filter to be applied to that level, and thus cannot be a trivial move.
 
   // Check if start level have files with overlapping ranges
-  if (start_level_ == 0 && input_vstorage_->level0_non_overlapping() == false) {
+  if (start_level_ == 0 && input_vstorage_->level0_non_overlapping() == false &&
+      !all_level_non_overlapping_) {
     // We cannot move files from L0 to L1 if the files are overlapping
     return false;
   }

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -214,7 +214,7 @@ Compaction::Compaction(
     CompressionOptions _compression_opts, Temperature _output_temperature,
     uint32_t _max_subcompactions, std::vector<FileMetaData*> _grandparents,
     bool _manual_compaction, const std::string& _trim_ts, double _score,
-    bool _deletion_compaction, bool all_level_non_overlapping,
+    bool _deletion_compaction, bool l0_files_might_overlap,
     CompactionReason _compaction_reason,
     BlobGarbageCollectionPolicy _blob_garbage_collection_policy,
     double _blob_garbage_collection_age_cutoff)
@@ -234,7 +234,7 @@ Compaction::Compaction(
       output_compression_opts_(_compression_opts),
       output_temperature_(_output_temperature),
       deletion_compaction_(_deletion_compaction),
-      all_level_non_overlapping_(all_level_non_overlapping),
+      l0_files_might_overlap_(l0_files_might_overlap),
       inputs_(PopulateWithAtomicBoundaries(vstorage, std::move(_inputs))),
       grandparents_(std::move(_grandparents)),
       score_(_score),
@@ -337,7 +337,7 @@ bool Compaction::IsTrivialMove() const {
 
   // Check if start level have files with overlapping ranges
   if (start_level_ == 0 && input_vstorage_->level0_non_overlapping() == false &&
-      !all_level_non_overlapping_) {
+      l0_files_might_overlap_) {
     // We cannot move files from L0 to L1 if the files are overlapping
     return false;
   }

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -337,9 +337,9 @@ bool Compaction::IsTrivialMove() const {
 
   // Check if start level have files with overlapping ranges
   if (start_level_ == 0 && input_vstorage_->level0_non_overlapping() == false &&
-      (l0_files_might_overlap_ ||
-       cfd_->ioptions()->compaction_style == kCompactionStyleUniversal)) {
-    // We cannot move files from L0 to L1 if the files are overlapping
+      l0_files_might_overlap_) {
+    // We cannot move files from L0 to L1 if the L0 files in the LSM-tree are
+    // overlapping, unless we are sure that files picked in L0 don't overlap.
     return false;
   }
 

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -337,7 +337,8 @@ bool Compaction::IsTrivialMove() const {
 
   // Check if start level have files with overlapping ranges
   if (start_level_ == 0 && input_vstorage_->level0_non_overlapping() == false &&
-      l0_files_might_overlap_) {
+      (l0_files_might_overlap_ ||
+       cfd_->ioptions()->compaction_style == kCompactionStyleUniversal)) {
     // We cannot move files from L0 to L1 if the files are overlapping
     return false;
   }

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -389,8 +389,9 @@ class Compaction {
   // should it split the output file using the compact cursor?
   InternalKey output_split_key_;
 
-  // If true, all levels in the compaction have non-overlapping files and are
-  // sorted by keys.
+  // L0 files in LSM-tree might be overlapping. But the compaction picking
+  // logic might pick a subset of the files that aren't overlapping. if
+  // that is the case, set the value to false. Otherwise, set it true.
   bool l0_files_might_overlap_;
 
   // Compaction input files organized by level. Constant after construction

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -81,7 +81,7 @@ class Compaction {
              std::vector<FileMetaData*> grandparents,
              bool manual_compaction = false, const std::string& trim_ts = "",
              double score = -1, bool deletion_compaction = false,
-             bool all_level_non_overlapping = false,
+             bool l0_files_might_overlap = true,
              CompactionReason compaction_reason = CompactionReason::kUnknown,
              BlobGarbageCollectionPolicy blob_garbage_collection_policy =
                  BlobGarbageCollectionPolicy::kUseDefault,
@@ -391,7 +391,7 @@ class Compaction {
 
   // If true, all levels in the compaction have non-overlapping files and are
   // sorted by keys.
-  bool all_level_non_overlapping_;
+  bool l0_files_might_overlap_;
 
   // Compaction input files organized by level. Constant after construction
   const std::vector<CompactionInputFiles> inputs_;

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -81,6 +81,7 @@ class Compaction {
              std::vector<FileMetaData*> grandparents,
              bool manual_compaction = false, const std::string& trim_ts = "",
              double score = -1, bool deletion_compaction = false,
+             bool all_level_non_overlapping = false,
              CompactionReason compaction_reason = CompactionReason::kUnknown,
              BlobGarbageCollectionPolicy blob_garbage_collection_policy =
                  BlobGarbageCollectionPolicy::kUseDefault,
@@ -387,6 +388,10 @@ class Compaction {
   const bool deletion_compaction_;
   // should it split the output file using the compact cursor?
   InternalKey output_split_key_;
+
+  // If true, all levels in the compaction have non-overlapping files and are
+  // sorted by keys.
+  bool all_level_non_overlapping_;
 
   // Compaction input files organized by level. Constant after construction
   const std::vector<CompactionInputFiles> inputs_;

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -641,7 +641,8 @@ Compaction* CompactionPicker::CompactRange(
         GetCompressionOptions(mutable_cf_options, vstorage, output_level),
         Temperature::kUnknown, compact_range_options.max_subcompactions,
         /* grandparents */ {}, /* is manual */ true, trim_ts, /* score */ -1,
-        /* deletion_compaction */ false, CompactionReason::kUnknown,
+        /* deletion_compaction */ false, /* all_level_non_overlapping */ false,
+        CompactionReason::kUnknown,
         compact_range_options.blob_garbage_collection_policy,
         compact_range_options.blob_garbage_collection_age_cutoff);
 
@@ -823,7 +824,8 @@ Compaction* CompactionPicker::CompactRange(
       GetCompressionOptions(mutable_cf_options, vstorage, output_level),
       Temperature::kUnknown, compact_range_options.max_subcompactions,
       std::move(grandparents), /* is manual */ true, trim_ts, /* score */ -1,
-      /* deletion_compaction */ false, CompactionReason::kUnknown,
+      /* deletion_compaction */ false, /* all_level_non_overlapping */ false,
+      CompactionReason::kUnknown,
       compact_range_options.blob_garbage_collection_policy,
       compact_range_options.blob_garbage_collection_age_cutoff);
 

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -543,6 +543,10 @@ bool CompactionPicker::SetupOtherInputs(
                      output_level_inputs_size);
       inputs->files = expanded_inputs.files;
     }
+  } else {
+    // Likely to be trivial move. Expand files if they are still trivial moves,
+    // but limit to mutable_cf_options.max_compaction_bytes or 8 files so that
+    // we don't create too much compaction pressure for the next level.
   }
   return true;
 }
@@ -641,7 +645,7 @@ Compaction* CompactionPicker::CompactRange(
         GetCompressionOptions(mutable_cf_options, vstorage, output_level),
         Temperature::kUnknown, compact_range_options.max_subcompactions,
         /* grandparents */ {}, /* is manual */ true, trim_ts, /* score */ -1,
-        /* deletion_compaction */ false, /* all_level_non_overlapping */ false,
+        /* deletion_compaction */ false, /* l0_files_might_overlap */ true,
         CompactionReason::kUnknown,
         compact_range_options.blob_garbage_collection_policy,
         compact_range_options.blob_garbage_collection_age_cutoff);
@@ -824,7 +828,7 @@ Compaction* CompactionPicker::CompactRange(
       GetCompressionOptions(mutable_cf_options, vstorage, output_level),
       Temperature::kUnknown, compact_range_options.max_subcompactions,
       std::move(grandparents), /* is manual */ true, trim_ts, /* score */ -1,
-      /* deletion_compaction */ false, /* all_level_non_overlapping */ false,
+      /* deletion_compaction */ false, /* l0_files_might_overlap */ true,
       CompactionReason::kUnknown,
       compact_range_options.blob_garbage_collection_policy,
       compact_range_options.blob_garbage_collection_age_cutoff);

--- a/db/compaction/compaction_picker.h
+++ b/db/compaction/compaction_picker.h
@@ -217,6 +217,8 @@ class CompactionPicker {
     return &compactions_in_progress_;
   }
 
+  const InternalKeyComparator* icmp() const { return icmp_; }
+
  protected:
   const ImmutableOptions& ioptions_;
 

--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -116,7 +116,7 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
       mutable_cf_options.compression_opts, Temperature::kUnknown,
       /* max_subcompactions */ 0, {}, /* is manual */ false,
       /* trim_ts */ "", vstorage->CompactionScore(0),
-      /* is deletion compaction */ true, /* all_level_non_overlapping */ false,
+      /* is deletion compaction */ true, /* l0_files_might_overlap */ true,
       CompactionReason::kFIFOTtl);
   return c;
 }
@@ -161,7 +161,7 @@ Compaction* FIFOCompactionPicker::PickSizeCompaction(
             0 /* max_subcompactions */, {}, /* is manual */ false,
             /* trim_ts */ "", vstorage->CompactionScore(0),
             /* is deletion compaction */ false,
-            /* all_level_non_overlapping */ false,
+            /* l0_files_might_overlap */ true,
             CompactionReason::kFIFOReduceNumFiles);
         return c;
       }
@@ -212,7 +212,7 @@ Compaction* FIFOCompactionPicker::PickSizeCompaction(
       /* max_subcompactions */ 0, {}, /* is manual */ false,
       /* trim_ts */ "", vstorage->CompactionScore(0),
       /* is deletion compaction */ true,
-      /* all_level_non_overlapping */ false, CompactionReason::kFIFOMaxSize);
+      /* l0_files_might_overlap */ true, CompactionReason::kFIFOMaxSize);
   return c;
 }
 
@@ -318,7 +318,7 @@ Compaction* FIFOCompactionPicker::PickCompactionToWarm(
       Temperature::kWarm,
       /* max_subcompactions */ 0, {}, /* is manual */ false, /* trim_ts */ "",
       vstorage->CompactionScore(0),
-      /* is deletion compaction */ false, /* all_level_non_overlapping */ false,
+      /* is deletion compaction */ false, /* l0_files_might_overlap */ true,
       CompactionReason::kChangeTemperature);
   return c;
 }

--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -116,7 +116,8 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
       mutable_cf_options.compression_opts, Temperature::kUnknown,
       /* max_subcompactions */ 0, {}, /* is manual */ false,
       /* trim_ts */ "", vstorage->CompactionScore(0),
-      /* is deletion compaction */ true, CompactionReason::kFIFOTtl);
+      /* is deletion compaction */ true, /* all_level_non_overlapping */ false,
+      CompactionReason::kFIFOTtl);
   return c;
 }
 
@@ -160,6 +161,7 @@ Compaction* FIFOCompactionPicker::PickSizeCompaction(
             0 /* max_subcompactions */, {}, /* is manual */ false,
             /* trim_ts */ "", vstorage->CompactionScore(0),
             /* is deletion compaction */ false,
+            /* all_level_non_overlapping */ false,
             CompactionReason::kFIFOReduceNumFiles);
         return c;
       }
@@ -209,7 +211,8 @@ Compaction* FIFOCompactionPicker::PickSizeCompaction(
       mutable_cf_options.compression_opts, Temperature::kUnknown,
       /* max_subcompactions */ 0, {}, /* is manual */ false,
       /* trim_ts */ "", vstorage->CompactionScore(0),
-      /* is deletion compaction */ true, CompactionReason::kFIFOMaxSize);
+      /* is deletion compaction */ true,
+      /* all_level_non_overlapping */ false, CompactionReason::kFIFOMaxSize);
   return c;
 }
 
@@ -315,7 +318,8 @@ Compaction* FIFOCompactionPicker::PickCompactionToWarm(
       Temperature::kWarm,
       /* max_subcompactions */ 0, {}, /* is manual */ false, /* trim_ts */ "",
       vstorage->CompactionScore(0),
-      /* is deletion compaction */ false, CompactionReason::kChangeTemperature);
+      /* is deletion compaction */ false, /* all_level_non_overlapping */ false,
+      CompactionReason::kChangeTemperature);
   return c;
 }
 

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -428,6 +428,9 @@ uint32_t LevelCompactionBuilder::GetPathId(
 }
 
 bool LevelCompactionBuilder::TryPickL0TrivialMove() {
+  if (vstorage_->base_level() <= 0) {
+    return false;
+  }
   if (start_level_ == 0 && mutable_cf_options_.compression_per_level.empty() &&
       !vstorage_->LevelFiles(output_level_).empty() &&
       ioptions_.db_paths.size() <= 1) {

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -89,6 +89,7 @@ class LevelCompactionBuilder {
   // function will return false.
   bool PickFileToCompact();
 
+  // Return true if a L0 trivial move is picked up.
   bool TryPickL0TrivialMove();
 
   // For L0->L0, picks the longest span of files that aren't currently

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -358,7 +358,7 @@ Compaction* LevelCompactionBuilder::GetCompaction() {
       Temperature::kUnknown,
       /* max_subcompactions */ 0, std::move(grandparents_), is_manual_,
       /* trim_ts */ "", start_level_score_, false /* deletion_compaction */,
-      /* all_level_non_overlapping */ start_level_ != 0 || is_l0_trivial_move_,
+      /* l0_files_might_overlap */ start_level_ == 0 && !is_l0_trivial_move_,
       compaction_reason_);
 
   // If it's level 0 compaction, make sure we don't execute any other level 0

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -7,11 +7,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include "db/compaction/compaction_picker_level.h"
+
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "db/compaction/compaction_picker_level.h"
+#include "db/version_edit.h"
 #include "logging/log_buffer.h"
 #include "test_util/sync_point.h"
 
@@ -117,6 +119,7 @@ class LevelCompactionBuilder {
   int base_index_ = -1;
   double start_level_score_ = 0;
   bool is_manual_ = false;
+  bool is_l0_trivial_move_ = false;
   CompactionInputFiles start_level_inputs_;
   std::vector<CompactionInputFiles> compaction_inputs_;
   CompactionInputFiles output_level_inputs_;
@@ -261,7 +264,7 @@ void LevelCompactionBuilder::SetupInitialFiles() {
 }
 
 bool LevelCompactionBuilder::SetupOtherL0FilesIfNeeded() {
-  if (start_level_ == 0 && output_level_ != 0) {
+  if (start_level_ == 0 && output_level_ != 0 && !is_l0_trivial_move_) {
     return compaction_picker_->GetOverlappingL0Files(
         vstorage_, &start_level_inputs_, output_level_, &parent_index_);
   }
@@ -274,7 +277,8 @@ bool LevelCompactionBuilder::SetupOtherInputsIfNeeded() {
   // need to consider other levels.
   if (output_level_ != 0) {
     output_level_inputs_.level = output_level_;
-    if (!compaction_picker_->SetupOtherInputs(
+    if (!is_l0_trivial_move_ &&
+        !compaction_picker_->SetupOtherInputs(
             cf_name_, mutable_cf_options_, vstorage_, &start_level_inputs_,
             &output_level_inputs_, &parent_index_, base_index_)) {
       return false;
@@ -285,20 +289,22 @@ bool LevelCompactionBuilder::SetupOtherInputsIfNeeded() {
       compaction_inputs_.push_back(output_level_inputs_);
     }
 
-    // In some edge cases we could pick a compaction that will be compacting
-    // a key range that overlap with another running compaction, and both
-    // of them have the same output level. This could happen if
-    // (1) we are running a non-exclusive manual compaction
-    // (2) AddFile ingest a new file into the LSM tree
-    // We need to disallow this from happening.
-    if (compaction_picker_->FilesRangeOverlapWithCompaction(compaction_inputs_,
-                                                            output_level_)) {
-      // This compaction output could potentially conflict with the output
-      // of a currently running compaction, we cannot run it.
-      return false;
+    if (!is_l0_trivial_move_) {
+      // In some edge cases we could pick a compaction that will be compacting
+      // a key range that overlap with another running compaction, and both
+      // of them have the same output level. This could happen if
+      // (1) we are running a non-exclusive manual compaction
+      // (2) AddFile ingest a new file into the LSM tree
+      // We need to disallow this from happening.
+      if (compaction_picker_->FilesRangeOverlapWithCompaction(
+              compaction_inputs_, output_level_)) {
+        // This compaction output could potentially conflict with the output
+        // of a currently running compaction, we cannot run it.
+        return false;
+      }
+      compaction_picker_->GetGrandparents(vstorage_, start_level_inputs_,
+                                          output_level_inputs_, &grandparents_);
     }
-    compaction_picker_->GetGrandparents(vstorage_, start_level_inputs_,
-                                        output_level_inputs_, &grandparents_);
   } else {
     compaction_inputs_.push_back(start_level_inputs_);
   }
@@ -349,6 +355,7 @@ Compaction* LevelCompactionBuilder::GetCompaction() {
       Temperature::kUnknown,
       /* max_subcompactions */ 0, std::move(grandparents_), is_manual_,
       /* trim_ts */ "", start_level_score_, false /* deletion_compaction */,
+      /* all_level_non_overlapping */ start_level_ != 0 || is_l0_trivial_move_,
       compaction_reason_);
 
   // If it's level 0 compaction, make sure we don't execute any other level 0
@@ -429,20 +436,80 @@ bool LevelCompactionBuilder::PickFileToCompact() {
   }
 
   start_level_inputs_.clear();
+  start_level_inputs_.level = start_level_;
 
   assert(start_level_ >= 0);
 
-  // Pick the largest file in this level that is not already
-  // being compacted
-  const std::vector<int>& file_size =
-      vstorage_->FilesByCompactionPri(start_level_);
   const std::vector<FileMetaData*>& level_files =
       vstorage_->LevelFiles(start_level_);
 
+  if (start_level_ == 0 && mutable_cf_options_.compression_per_level.empty() &&
+      !vstorage_->LevelFiles(output_level_).empty()) {
+    // Try to pick trivial move from L0 to L1. We start from the oldest
+    // file. We keep expanding to newer files if it would form a
+    // trivial move.
+    // For now we don't support it with
+    // mutable_cf_options_.compression_per_level to prevent the logic
+    // of determining whether L0 can be trivial moved to the next level.
+    // We skip the case where output level is empty, since in this case, at
+    // least the oldest file would qualify for trivial move, and this would
+    // be a surprising behavior with few benefits.
+
+    // We search from the oldest file from the newest. In theory, there are
+    // files in the middle can form trivial move too, but it is probably
+    // uncommon and we ignore these cases for simplicity.
+    InternalKey my_smallest, my_largest;
+    for (auto it = level_files.rbegin(); it != level_files.rend(); ++it) {
+      CompactionInputFiles output_level_inputs;
+      output_level_inputs.level = output_level_;
+      FileMetaData* file = *it;
+      if (it == level_files.rbegin()) {
+        my_smallest = file->smallest;
+        my_largest = file->largest;
+      } else {
+        if (compaction_picker_->icmp()->Compare(file->largest, my_smallest) <
+            0) {
+          my_smallest = file->smallest;
+        } else if (compaction_picker_->icmp()->Compare(file->smallest,
+                                                       my_largest) > 0) {
+          my_largest = file->largest;
+        } else {
+          break;
+        }
+      }
+      vstorage_->GetOverlappingInputs(output_level_, &my_smallest, &my_largest,
+                                      &output_level_inputs.files);
+      if (output_level_inputs.empty()) {
+        start_level_inputs_.files.push_back(file);
+      } else {
+        break;
+      }
+    }
+  }
+
+  if (!start_level_inputs_.empty()) {
+    // Sort files by key range. Not sure it's 100% necessary but it's cleaner
+    // to always keep files sorted by key the key ranges don't overlap.
+    std::sort(start_level_inputs_.files.begin(),
+              start_level_inputs_.files.end(),
+              [icmp = compaction_picker_->icmp()](FileMetaData* f1,
+                                                  FileMetaData* f2) -> bool {
+                return (icmp->Compare(f1->smallest, f2->smallest) < 0);
+              });
+
+    is_l0_trivial_move_ = true;
+    return true;
+  }
+
+  // Pick the file with the highest score in this level that is not already
+  // being compacted.
+  const std::vector<int>& file_scores =
+      vstorage_->FilesByCompactionPri(start_level_);
+
   unsigned int cmp_idx;
   for (cmp_idx = vstorage_->NextCompactionIndex(start_level_);
-       cmp_idx < file_size.size(); cmp_idx++) {
-    int index = file_size[cmp_idx];
+       cmp_idx < file_scores.size(); cmp_idx++) {
+    int index = file_scores[cmp_idx];
     auto* f = level_files[index];
 
     // do not pick a file to compact if it is being compacted
@@ -460,7 +527,6 @@ bool LevelCompactionBuilder::PickFileToCompact() {
     }
 
     start_level_inputs_.files.push_back(f);
-    start_level_inputs_.level = start_level_;
     if (!compaction_picker_->ExpandInputsToCleanCut(cf_name_, vstorage_,
                                                     &start_level_inputs_) ||
         compaction_picker_->FilesRangeOverlapWithCompaction(
@@ -478,8 +544,8 @@ bool LevelCompactionBuilder::PickFileToCompact() {
       continue;
     }
 
-    // Now that input level is fully expanded, we check whether any output files
-    // are locked due to pending compaction.
+    // Now that input level is fully expanded, we check whether any output
+    // files are locked due to pending compaction.
     //
     // Note we rely on ExpandInputsToCleanCut() to tell us whether any output-
     // level files are locked, not just the extra ones pulled in for user-key

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -444,7 +444,8 @@ bool LevelCompactionBuilder::PickFileToCompact() {
       vstorage_->LevelFiles(start_level_);
 
   if (start_level_ == 0 && mutable_cf_options_.compression_per_level.empty() &&
-      !vstorage_->LevelFiles(output_level_).empty()) {
+      !vstorage_->LevelFiles(output_level_).empty() &&
+      ioptions_.db_paths.size() <= 1) {
     // Try to pick trivial move from L0 to L1. We start from the oldest
     // file. We keep expanding to newer files if it would form a
     // trivial move.

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -472,6 +472,7 @@ bool LevelCompactionBuilder::TryPickL0TrivialMove() {
       vstorage_->GetOverlappingInputs(output_level_, &my_smallest, &my_largest,
                                       &output_level_inputs.files);
       if (output_level_inputs.empty()) {
+        assert(!file->being_compacted);
         start_level_inputs_.files.push_back(file);
       } else {
         break;

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -758,7 +758,9 @@ Compaction* UniversalCompactionBuilder::PickCompactionToReduceSortedRuns(
                         Temperature::kUnknown,
                         /* max_subcompactions */ 0, grandparents,
                         /* is manual */ false, /* trim_ts */ "", score_,
-                        false /* deletion_compaction */, compaction_reason);
+                        false /* deletion_compaction */,
+                        /* all_level_non_overlapping */ false,
+                        compaction_reason);
 }
 
 // Look at overall size amplification. If size amplification
@@ -1083,6 +1085,7 @@ Compaction* UniversalCompactionBuilder::PickIncrementalForReduceSizeAmp(
       Temperature::kUnknown,
       /* max_subcompactions */ 0, /* grandparents */ {}, /* is manual */ false,
       /* trim_ts */ "", score_, false /* deletion_compaction */,
+      /* all_level_non_overlapping */ false,
       CompactionReason::kUniversalSizeAmplification);
 }
 
@@ -1225,6 +1228,7 @@ Compaction* UniversalCompactionBuilder::PickDeleteTriggeredCompaction() {
       Temperature::kUnknown,
       /* max_subcompactions */ 0, grandparents, /* is manual */ false,
       /* trim_ts */ "", score_, false /* deletion_compaction */,
+      /* all_level_non_overlapping */ false,
       CompactionReason::kFilesMarkedForCompaction);
 }
 
@@ -1300,7 +1304,7 @@ Compaction* UniversalCompactionBuilder::PickCompactionToOldest(
       Temperature::kUnknown,
       /* max_subcompactions */ 0, /* grandparents */ {}, /* is manual */ false,
       /* trim_ts */ "", score_, false /* deletion_compaction */,
-      compaction_reason);
+      /* all_level_non_overlapping */ false, compaction_reason);
 }
 
 Compaction* UniversalCompactionBuilder::PickPeriodicCompaction() {

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -759,8 +759,7 @@ Compaction* UniversalCompactionBuilder::PickCompactionToReduceSortedRuns(
                         /* max_subcompactions */ 0, grandparents,
                         /* is manual */ false, /* trim_ts */ "", score_,
                         false /* deletion_compaction */,
-                        /* all_level_non_overlapping */ false,
-                        compaction_reason);
+                        /* l0_files_might_overlap */ true, compaction_reason);
 }
 
 // Look at overall size amplification. If size amplification
@@ -1085,7 +1084,7 @@ Compaction* UniversalCompactionBuilder::PickIncrementalForReduceSizeAmp(
       Temperature::kUnknown,
       /* max_subcompactions */ 0, /* grandparents */ {}, /* is manual */ false,
       /* trim_ts */ "", score_, false /* deletion_compaction */,
-      /* all_level_non_overlapping */ false,
+      /* l0_files_might_overlap */ true,
       CompactionReason::kUniversalSizeAmplification);
 }
 
@@ -1228,7 +1227,7 @@ Compaction* UniversalCompactionBuilder::PickDeleteTriggeredCompaction() {
       Temperature::kUnknown,
       /* max_subcompactions */ 0, grandparents, /* is manual */ false,
       /* trim_ts */ "", score_, false /* deletion_compaction */,
-      /* all_level_non_overlapping */ false,
+      /* l0_files_might_overlap */ true,
       CompactionReason::kFilesMarkedForCompaction);
 }
 
@@ -1304,7 +1303,7 @@ Compaction* UniversalCompactionBuilder::PickCompactionToOldest(
       Temperature::kUnknown,
       /* max_subcompactions */ 0, /* grandparents */ {}, /* is manual */ false,
       /* trim_ts */ "", score_, false /* deletion_compaction */,
-      /* all_level_non_overlapping */ false, compaction_reason);
+      /* l0_files_might_overlap */ true, compaction_reason);
 }
 
 Compaction* UniversalCompactionBuilder::PickPeriodicCompaction() {

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -948,8 +948,8 @@ TEST_F(CorruptionTest, CompactionKeyOrderCheck) {
   ASSERT_OK(db_->SetOptions({{"check_flush_compaction_key_order", "true"}}));
   CompactRangeOptions cro;
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
-  dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr)
-      .PermitUncheckedError();
+  ASSERT_NOK(
+      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr));
 }
 
 TEST_F(CorruptionTest, FlushKeyOrderCheck) {
@@ -998,9 +998,8 @@ TEST_F(CorruptionTest, DisableKeyOrderCheck) {
   ASSERT_OK(dbi->TEST_FlushMemTable());
   CompactRangeOptions cro;
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
-  Status s =
-      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
-  s.PermitUncheckedError();
+  ASSERT_OK(
+      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
 }

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -554,7 +554,10 @@ TEST_F(CorruptionTest, CorruptedDescriptor) {
   ASSERT_OK(db_->Put(WriteOptions(), "foo", "hello"));
   DBImpl* dbi = static_cast_with_check<DBImpl>(db_);
   ASSERT_OK(dbi->TEST_FlushMemTable());
-  ASSERT_OK(dbi->TEST_CompactRange(0, nullptr, nullptr));
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  Status s =
+      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
 
   Corrupt(kDescriptorFile, 0, 1000);
   Status s = TryReopen();
@@ -809,7 +812,10 @@ TEST_F(CorruptionTest, ParanoidFileChecksWithDeleteRangeFirst) {
     } else {
       DBImpl* dbi = static_cast_with_check<DBImpl>(db_);
       ASSERT_OK(dbi->TEST_FlushMemTable());
-      ASSERT_OK(dbi->TEST_CompactRange(0, nullptr, nullptr, nullptr, true));
+      CompactRangeOptions cro;
+      cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+      Status s =
+          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
     }
     db_->ReleaseSnapshot(snap);
   }
@@ -845,7 +851,10 @@ TEST_F(CorruptionTest, ParanoidFileChecksWithDeleteRange) {
     } else {
       DBImpl* dbi = static_cast_with_check<DBImpl>(db_);
       ASSERT_OK(dbi->TEST_FlushMemTable());
-      ASSERT_OK(dbi->TEST_CompactRange(0, nullptr, nullptr, nullptr, true));
+      CompactRangeOptions cro;
+      cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+      Status s =
+          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
     }
     db_->ReleaseSnapshot(snap);
   }
@@ -878,7 +887,10 @@ TEST_F(CorruptionTest, ParanoidFileChecksWithDeleteRangeLast) {
     } else {
       DBImpl* dbi = static_cast_with_check<DBImpl>(db_);
       ASSERT_OK(dbi->TEST_FlushMemTable());
-      ASSERT_OK(dbi->TEST_CompactRange(0, nullptr, nullptr, nullptr, true));
+      CompactRangeOptions cro;
+      cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+      Status s =
+          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
     }
     db_->ReleaseSnapshot(snap);
   }
@@ -934,7 +946,10 @@ TEST_F(CorruptionTest, CompactionKeyOrderCheck) {
 
   mock->SetCorruptionMode(mock::MockTableFactory::kCorruptNone);
   ASSERT_OK(db_->SetOptions({{"check_flush_compaction_key_order", "true"}}));
-  ASSERT_NOK(dbi->TEST_CompactRange(0, nullptr, nullptr, nullptr, true));
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  Status s =
+      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
 }
 
 TEST_F(CorruptionTest, FlushKeyOrderCheck) {
@@ -981,7 +996,10 @@ TEST_F(CorruptionTest, DisableKeyOrderCheck) {
   ASSERT_OK(db_->Put(WriteOptions(), "foo2", "v1"));
   ASSERT_OK(db_->Put(WriteOptions(), "foo4", "v1"));
   ASSERT_OK(dbi->TEST_FlushMemTable());
-  ASSERT_OK(dbi->TEST_CompactRange(0, nullptr, nullptr, nullptr, true));
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  Status s =
+      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
 }

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -556,8 +556,8 @@ TEST_F(CorruptionTest, CorruptedDescriptor) {
   ASSERT_OK(dbi->TEST_FlushMemTable());
   CompactRangeOptions cro;
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
-  Status s =
-      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
+  ASSERT_OK(
+      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr));
 
   Corrupt(kDescriptorFile, 0, 1000);
   Status s = TryReopen();
@@ -814,8 +814,8 @@ TEST_F(CorruptionTest, ParanoidFileChecksWithDeleteRangeFirst) {
       ASSERT_OK(dbi->TEST_FlushMemTable());
       CompactRangeOptions cro;
       cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
-      Status s =
-          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
+      ASSERT_OK(
+          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr));
     }
     db_->ReleaseSnapshot(snap);
   }
@@ -853,8 +853,8 @@ TEST_F(CorruptionTest, ParanoidFileChecksWithDeleteRange) {
       ASSERT_OK(dbi->TEST_FlushMemTable());
       CompactRangeOptions cro;
       cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
-      Status s =
-          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
+      ASSERT_OK(
+          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr));
     }
     db_->ReleaseSnapshot(snap);
   }
@@ -889,8 +889,8 @@ TEST_F(CorruptionTest, ParanoidFileChecksWithDeleteRangeLast) {
       ASSERT_OK(dbi->TEST_FlushMemTable());
       CompactRangeOptions cro;
       cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
-      Status s =
-          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
+      ASSERT_OK(
+          dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr));
     }
     db_->ReleaseSnapshot(snap);
   }
@@ -948,8 +948,8 @@ TEST_F(CorruptionTest, CompactionKeyOrderCheck) {
   ASSERT_OK(db_->SetOptions({{"check_flush_compaction_key_order", "true"}}));
   CompactRangeOptions cro;
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
-  Status s =
-      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
+  dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr)
+      .PermitUncheckedError();
 }
 
 TEST_F(CorruptionTest, FlushKeyOrderCheck) {
@@ -1000,6 +1000,7 @@ TEST_F(CorruptionTest, DisableKeyOrderCheck) {
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
   Status s =
       dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
+  s.PermitUncheckedError();
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
 }

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -7,6 +7,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include "rocksdb/options.h"
 #ifndef ROCKSDB_LITE
 
 #include <fcntl.h>
@@ -770,7 +771,9 @@ TEST_F(CorruptionTest, ParanoidFileChecksOnCompact) {
     DBImpl* dbi = static_cast_with_check<DBImpl>(db_);
     ASSERT_OK(dbi->TEST_FlushMemTable());
     mock->SetCorruptionMode(mode);
-    s = dbi->TEST_CompactRange(0, nullptr, nullptr, nullptr, true);
+    CompactRangeOptions cro;
+    cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+    s = dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
     if (mode == mock::MockTableFactory::kCorruptNone) {
       ASSERT_OK(s);
     } else {
@@ -902,7 +905,10 @@ TEST_F(CorruptionTest, LogCorruptionErrorsInCompactionIterator) {
 
   DBImpl* dbi = static_cast_with_check<DBImpl>(db_);
   ASSERT_OK(dbi->TEST_FlushMemTable());
-  Status s = dbi->TEST_CompactRange(0, nullptr, nullptr, nullptr, true);
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  Status s =
+      dbi->CompactRange(cro, dbi->DefaultColumnFamily(), nullptr, nullptr);
   ASSERT_NOK(s);
   ASSERT_TRUE(s.IsCorruption());
 }


### PR DESCRIPTION
Summary: In leveled compaction, L0->L1 trivial move will allow more than one file to be moved in one compaction. This would allow L0 files to be moved down faster when data is loaded in sequential order, making slowdown or stop condition harder to hit. Also seek L0->L1 trivial move when only some files qualify.
1. We always try to find L0->L1 trivial move from the oldest files. Keep including newer files, until adding a new file won't trigger a trivial move
2. Modify the trivial move condition so that this compaction would be tagged as trivial move.

Test Plan:
See throughput improvements with db_bench with fast fillseq benchmark and small L0 files:

./db_bench_l0_move --benchmarks=fillseq --compression_type=lz4 --write_buffer_size=5000000 --num=100000000 --value_size=1000 -level_compaction_dynamic_level_bytes

The throughput improved by about 50%. Stalling still happens though.