### PR TITLE
Replace per-shard chained hash tables with open-addressing scheme

### DIFF
--- a/cache/cache_test.cc
+++ b/cache/cache_test.cc
@@ -650,6 +650,10 @@ TEST_P(CacheTest, ReleaseWithoutErase) {
 }
 
 TEST_P(CacheTest, SetCapacity) {
+  if (GetParam() == kFast) {
+    ROCKSDB_GTEST_BYPASS("FastLRUCache doesn't support capacity adjustments.");
+    return;
+  }
   // test1: increase capacity
   // lets create a cache with capacity 5,
   // then, insert 5 elements, then increase capacity
@@ -698,6 +702,12 @@ TEST_P(CacheTest, SetCapacity) {
 }
 
 TEST_P(LRUCacheTest, SetStrictCapacityLimit) {
+  if (GetParam() == kFast) {
+    ROCKSDB_GTEST_BYPASS(
+        "FastLRUCache doesn't support an unbounded number of inserts beyond "
+        "capacity.");
+    return;
+  }
   // test1: set the flag to false. Insert more keys than capacity. See if they
   // all go through.
   std::shared_ptr<Cache> cache = NewCache(5, 0, false);
@@ -749,6 +759,10 @@ TEST_P(LRUCacheTest, SetStrictCapacityLimit) {
 }
 
 TEST_P(CacheTest, OverCapacity) {
+  if (GetParam() == kFast) {
+    ROCKSDB_GTEST_BYPASS("FastLRUCache doesn't support capacity adjustments.");
+    return;
+  }
   size_t n = 10;
 
   // a LRUCache with n entries and one shard only

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -19,8 +19,8 @@
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics.h"
 #include "port/lang.h"
-#include "util/hash.h"
 #include "util/distributed_mutex.h"
+#include "util/hash.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -102,11 +102,14 @@ LRUHandle* LRUHandleTable::Insert(LRUHandle* h, LRUHandle** old) {
   }
 }
 
-void LRUHandleTable::Remove(LRUHandle *h) {
-  assert(h->next == nullptr && h->prev == nullptr); // Already off the LRU list.
+void LRUHandleTable::Remove(LRUHandle* h) {
+  assert(h->next == nullptr &&
+         h->prev == nullptr);  // Already off the LRU list.
   int probe = 0;
-  int slot = FindSlot(h->key(), [&h](LRUHandle* e) { return e == h; }, probe, -1 /*displacement*/);
-  assert(slot != -1); // The handle must be in the hash table.
+  int slot = FindSlot(
+      h->key(), [&h](LRUHandle* e) { return e == h; }, probe,
+      -1 /*displacement*/);
+  assert(slot != -1);  // The handle must be in the hash table.
   h->SetIsVisible(false);
   h->SetIsElement(false);
   occupancy_--;
@@ -348,11 +351,11 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
          (strict_capacity_limit_ || handle == nullptr)) ||
         table_.GetOccupancy() == size_t{1} << table_.GetLengthBits()) {
       // Originally, when strict_capacity_limit_ == false and handle != nullptr
-      // (i.e., the user wants to immediately get a reference to the new handle),
-      // the insertion would proceed even if the total charge already exceeds
-      // capacity. We can't do this, because we can't physically insert a new
-      // handle when the table is at maximum occupancy. Thus, we need the extra
-      // occupancy clause.
+      // (i.e., the user wants to immediately get a reference to the new
+      // handle), the insertion would proceed even if the total charge already
+      // exceeds capacity. We can't do this, because we can't physically insert
+      // a new handle when the table is at maximum occupancy. Thus, we need the
+      // extra occupancy clause.
       // TODO(Guido): The tests currently assume the former behavior. Do
       // something about it.
       if (handle == nullptr) {
@@ -582,8 +585,8 @@ std::shared_ptr<Cache> NewFastLRUCache(
     num_shard_bits = GetDefaultCacheShardBits(capacity);
   }
   return std::make_shared<fast_lru_cache::LRUCache>(
-      capacity, estimated_value_size, num_shard_bits,
-      strict_capacity_limit, metadata_charge_policy);
+      capacity, estimated_value_size, num_shard_bits, strict_capacity_limit,
+      metadata_charge_policy);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -294,7 +294,7 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
 uint8_t LRUCacheShard::CalcHashBits(
     size_t capacity, size_t estimated_value_size,
     CacheMetadataChargePolicy metadata_charge_policy) {
-  LRUHandle* h = reinterpret_cast<LRUHandle*>(new LRUHandle);
+  LRUHandle* h = reinterpret_cast<LRUHandle*>(new LRUHandle());
   h->CalcTotalCharge(estimated_value_size, metadata_charge_policy);
   size_t num_entries = capacity / h->total_charge;
   h->Free();

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -340,7 +340,9 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
   tmp.refs = 0;
   tmp.next = tmp.prev = nullptr;
   tmp.CalcTotalCharge(charge, metadata_charge_policy_);
-  memcpy(tmp.key_data, key.data(), kCacheKeySize);
+  for (int i = 0; i < kCacheKeySize; i++) {
+    tmp.key_data[i] = key.data()[i];
+  }
 
   Status s = Status::OK();
   autovector<LRUHandle> last_reference_list;

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -106,10 +106,9 @@ void LRUHandleTable::Remove(LRUHandle* h) {
   assert(h->next == nullptr &&
          h->prev == nullptr);  // Already off the LRU list.
   int probe = 0;
-  int slot = FindSlot(
+  FindSlot(
       h->key(), [&h](LRUHandle* e) { return e == h; }, probe,
       -1 /*displacement*/);
-  assert(slot != -1);  // The handle must be in the hash table.
   h->SetIsVisible(false);
   h->SetIsElement(false);
   occupancy_--;

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -294,7 +294,7 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
 uint8_t LRUCacheShard::CalcHashBits(
     size_t capacity, size_t estimated_value_size,
     CacheMetadataChargePolicy metadata_charge_policy) {
-  LRUHandle* h = reinterpret_cast<LRUHandle*>(new LRUHandle());
+  LRUHandle* h = new LRUHandle();
   h->CalcTotalCharge(estimated_value_size, metadata_charge_policy);
   size_t num_entries = capacity / h->total_charge;
   h->Free();

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -183,7 +183,7 @@ LRUCacheShard::LRUCacheShard(size_t capacity, size_t estimated_value_size,
       strict_capacity_limit_(strict_capacity_limit),
       table_(
           GetHashBits(capacity, estimated_value_size, metadata_charge_policy) +
-          ceil(log2(1.0 / kLoadFactor))),
+          static_cast<uint8_t>(ceil(log2(1.0 / kLoadFactor)))),
       usage_(0),
       lru_usage_(0) {
   set_metadata_charge_policy(metadata_charge_policy);

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -215,7 +215,6 @@ void LRUCacheShard::EraseUnRefEntries() {
   }
 }
 
-// TODO(guido) Check this makes sense in the new data structure.
 void LRUCacheShard::ApplyToSomeEntries(
     const std::function<void(const Slice& key, void* value, size_t charge,
                              DeleterFn deleter)>& callback,
@@ -516,7 +515,7 @@ size_t LRUCacheShard::GetPinnedUsage() const {
 std::string LRUCacheShard::GetPrintableOptions() const { return std::string{}; }
 
 LRUCache::LRUCache(size_t capacity, size_t estimated_value_size,
-                   uint8_t num_shard_bits, bool strict_capacity_limit,
+                   int num_shard_bits, bool strict_capacity_limit,
                    CacheMetadataChargePolicy metadata_charge_policy)
     : ShardedCache(capacity, num_shard_bits, strict_capacity_limit) {
   // // We must enforce strict capacity requirement, or else insertions
@@ -594,7 +593,7 @@ std::shared_ptr<Cache> NewFastLRUCache(
     num_shard_bits = GetDefaultCacheShardBits(capacity);
   }
   return std::make_shared<fast_lru_cache::LRUCache>(
-      capacity, estimated_value_size, static_cast<uint8_t>(num_shard_bits),
+      capacity, estimated_value_size, num_shard_bits,
       strict_capacity_limit, metadata_charge_policy);
 }
 

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -356,10 +356,10 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
       // Originally, when strict_capacity_limit_ == false and handle != nullptr
       // (i.e., the user wants to immediately get a reference to the new
       // handle), the insertion would proceed even if the total charge already
-      // exceeds capacity. We can't do this now, because we can't physically insert
-      // a new handle when the table is at maximum occupancy.
-      // TODO(Guido) Some tests (at least two from cache_test, as well as the stress
-      // tests) currently assume the old behavior.
+      // exceeds capacity. We can't do this now, because we can't physically
+      // insert a new handle when the table is at maximum occupancy.
+      // TODO(Guido) Some tests (at least two from cache_test, as well as the
+      // stress tests) currently assume the old behavior.
       if (handle == nullptr) {
         // Don't insert the entry but still return ok, as if the entry inserted
         // into cache and get evicted immediately.

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -9,26 +9,38 @@
 
 #include "cache/fast_lru_cache.h"
 
+#include <math.h>
+
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics.h"
 #include "port/lang.h"
+#include "util/hash.h"
 #include "util/mutexlock.h"
 
-#define KEY_LENGTH \
-  16  // TODO(guido) Make use of this symbol in other parts of the source code
-      // (e.g., cache_key.h, cache_test.cc, etc.)
+#define LOAD_FACTOR 0.7
 
 namespace ROCKSDB_NAMESPACE {
 
 namespace fast_lru_cache {
 
+namespace {
+// Returns x % 2^{bits}.
+inline uint32_t BinaryMod(uint32_t x, uint32_t bits) {
+  return (x << (32 - bits)) >> (32 - bits);
+}
+}  // namespace
+
 LRUHandleTable::LRUHandleTable(int hash_bits)
     : length_bits_(hash_bits),
-      list_(new LRUHandle* [size_t{1} << length_bits_] {}) {}
+      occupancy_(0),
+      array_(new LRUHandle[size_t{1} << length_bits_]) {
+  std::memset(array_, 0, (size_t{1} << length_bits_) * sizeof(LRUHandle));
+}
 
 LRUHandleTable::~LRUHandleTable() {
   ApplyToEntriesRange(
@@ -41,36 +53,131 @@ LRUHandleTable::~LRUHandleTable() {
 }
 
 LRUHandle* LRUHandleTable::Lookup(const Slice& key, uint32_t hash) {
-  return *FindPointer(key, hash);
+  int probe = 0;
+  int slot = FindPresentElement(key, hash, probe, 0);
+  return (slot == -1) ? nullptr : &array_[slot];
 }
 
-inline LRUHandle** LRUHandleTable::Head(uint32_t hash) {
-  return &list_[hash >> (32 - length_bits_)];
-}
+LRUHandle* LRUHandleTable::Insert(LRUHandle* h, LRUHandle** old) {
+  int probe = 0;
+  int slot = FindPresentElementOrAvailableSlot(h->key(), h->hash, probe,
+                                               1 /*displacement*/);
+  *old = nullptr;
+  if (slot == -1) {
+    return nullptr;
+  }
 
-LRUHandle* LRUHandleTable::Insert(LRUHandle* h) {
-  LRUHandle** ptr = FindPointer(h->key(), h->hash);
-  LRUHandle* old = *ptr;
-  h->next_hash = (old == nullptr ? nullptr : old->next_hash);
-  *ptr = h;
-  return old;
+  if (array_[slot].IsEmpty() || array_[slot].IsTombstone()) {
+    bool empty = array_[slot].IsEmpty();
+    Assign(slot, h);
+    LRUHandle* new_entry = &array_[slot];
+    if (empty) {
+      // This used to be an empty slot.
+      return new_entry;
+    }
+    // It used to be a tombstone, so there may already be a copy of the
+    // key in the table.
+    slot = FindElement(h->key(), h->hash, probe, 0 /*displacement*/);
+    if (slot == -1) {
+      // No existing copy of the key.
+      return new_entry;
+    }
+    *old = &array_[slot];
+    return new_entry;
+  } else {
+    // There is an existing copy of the key.
+    *old = &array_[slot];
+    // Find an available slot for the new element.
+    array_[slot].displacements++;
+    slot = FindAvailableSlot(h->key(), probe, 1 /*displacement*/);
+    if (slot == -1) {
+      return nullptr;
+    }
+    Assign(slot, h);
+    return &array_[slot];
+  }
 }
 
 LRUHandle* LRUHandleTable::Remove(const Slice& key, uint32_t hash) {
-  LRUHandle** ptr = FindPointer(key, hash);
-  LRUHandle* result = *ptr;
-  if (result != nullptr) {
-    *ptr = result->next_hash;
+  int probe = 0;
+  int slot = FindElement(key, hash, probe, -1 /*displacement*/);
+  if (slot == -1) {
+    assert(false);
+    // Remove assumes the element is in the table.
   }
-  return result;
+  LRUHandle* e = &array_[slot];
+  e->SetIsElement(false);
+  e->SetIsPresent(false);
+  occupancy_--;
+  return e;
 }
 
-LRUHandle** LRUHandleTable::FindPointer(const Slice& key, uint32_t hash) {
-  LRUHandle** ptr = &list_[hash >> (32 - length_bits_)];
-  while (*ptr != nullptr && ((*ptr)->hash != hash || key != (*ptr)->key())) {
-    ptr = &(*ptr)->next_hash;
+void LRUHandleTable::Assign(int slot, LRUHandle* src) {
+  LRUHandle* dst = &array_[slot];
+  uint32_t disp = dst->displacements;
+  memcpy(dst, src, sizeof(LRUHandle));
+  dst->displacements = disp;
+  dst->SetIsPresent(true);
+  dst->SetIsElement(true);
+  occupancy_++;
+}
+
+void LRUHandleTable::Exclude(LRUHandle* e) { e->SetIsPresent(false); }
+
+int LRUHandleTable::FindElement(const Slice& key, uint32_t hash, int& probe,
+                                int displacement) {
+  std::function<bool(LRUHandle*)> cond = [&, key, hash](LRUHandle* e) {
+    return e->Matches(key, hash) && e->IsElement();
+  };
+  return FindSlot(key, cond, probe, displacement);
+}
+
+int LRUHandleTable::FindPresentElement(const Slice& key, uint32_t hash,
+                                       int& probe, int displacement) {
+  std::function<bool(LRUHandle*)> cond = [&, key, hash](LRUHandle* e) {
+    return e->Matches(key, hash) && e->IsPresent();
+  };
+  return FindSlot(key, cond, probe, displacement);
+}
+
+int LRUHandleTable::FindAvailableSlot(const Slice& key, int& probe,
+                                      int displacement) {
+  std::function<bool(LRUHandle*)> cond = [](LRUHandle* e) {
+    return e->IsEmpty() || e->IsTombstone();
+  };
+  return FindSlot(key, cond, probe, displacement);
+}
+
+int LRUHandleTable::FindPresentElementOrAvailableSlot(const Slice& key,
+                                                      uint32_t hash, int& probe,
+                                                      int displacement) {
+  std::function<bool(LRUHandle*)> cond = [&, key, hash](LRUHandle* e) {
+    return e->IsEmpty() || e->IsTombstone() ||
+           (e->Matches(key, hash) && e->IsPresent());
+  };
+  return FindSlot(key, cond, probe, displacement);
+}
+
+int LRUHandleTable::FindSlot(const Slice& key,
+                             std::function<bool(LRUHandle*)> cond, int& probe,
+                             int displacement) {
+  uint32_t base =
+      BinaryMod(Hash(key.data(), key.size(), 0xbc9f1d34), length_bits_);
+  uint32_t increment = BinaryMod(
+      (Hash(key.data(), key.size(), 0x7a2bb9d5) << 1) | 1, length_bits_);
+  uint32_t current = BinaryMod(base + probe * increment, length_bits_);
+  while (1) {
+    LRUHandle* e = &array_[current];
+    probe++;
+    if (cond(e)) {
+      return current;
+    }
+    current = BinaryMod(current + increment, length_bits_);
+    if (e->IsEmpty() || current == base) {
+      return -1;
+    }
+    e->displacements += displacement;
   }
-  return ptr;
 }
 
 LRUCacheShard::LRUCacheShard(size_t capacity, size_t estimated_value_size,
@@ -79,7 +186,8 @@ LRUCacheShard::LRUCacheShard(size_t capacity, size_t estimated_value_size,
     : capacity_(0),
       strict_capacity_limit_(strict_capacity_limit),
       table_(
-          GetHashBits(capacity, estimated_value_size, metadata_charge_policy)),
+          GetHashBits(capacity, estimated_value_size, metadata_charge_policy) +
+          ceil(log2(1.0 / LOAD_FACTOR))),
       usage_(0),
       lru_usage_(0) {
   set_metadata_charge_policy(metadata_charge_policy);
@@ -97,10 +205,9 @@ void LRUCacheShard::EraseUnRefEntries() {
     while (lru_.next != &lru_) {
       LRUHandle* old = lru_.next;
       // LRU list contains only elements which can be evicted.
-      assert(old->InCache() && !old->HasRefs());
+      assert(old->IsPresent() && !old->HasRefs());
       LRU_Remove(old);
       table_.Remove(old->key(), old->hash);
-      old->SetInCache(false);
       assert(usage_ >= old->total_charge);
       usage_ -= old->total_charge;
       last_reference_list.push_back(old);
@@ -113,6 +220,7 @@ void LRUCacheShard::EraseUnRefEntries() {
   }
 }
 
+// TODO(guido) Check this makes sense in the new data structure.
 void LRUCacheShard::ApplyToSomeEntries(
     const std::function<void(const Slice& key, void* value, size_t charge,
                              DeleterFn deleter)>& callback,
@@ -174,10 +282,9 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
   while ((usage_ + charge) > capacity_ && lru_.next != &lru_) {
     LRUHandle* old = lru_.next;
     // LRU list contains only elements which can be evicted.
-    assert(old->InCache() && !old->HasRefs());
+    assert(old->IsPresent() && !old->HasRefs());
     LRU_Remove(old);
     table_.Remove(old->key(), old->hash);
-    old->SetInCache(false);
     assert(usage_ >= old->total_charge);
     usage_ -= old->total_charge;
     deleted->push_back(old);
@@ -187,17 +294,14 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
 int LRUCacheShard::GetHashBits(
     size_t capacity, size_t estimated_value_size,
     CacheMetadataChargePolicy metadata_charge_policy) {
-  LRUHandle* e = reinterpret_cast<LRUHandle*>(
-      new char[sizeof(LRUHandle) - 1 + KEY_LENGTH]);
-  e->key_length = KEY_LENGTH;
-  e->deleter = nullptr;
-  e->refs = 0;
-  e->flags = 0;
-  e->refs = 0;
+  LRUHandle e;
+  e.deleter = nullptr;
+  e.refs = 0;
+  e.flags = 0;
+  e.refs = 0;
 
-  e->CalcTotalCharge(estimated_value_size, metadata_charge_policy);
-  size_t num_entries = capacity / e->total_charge;
-  e->Free();
+  e.CalcTotalCharge(estimated_value_size, metadata_charge_policy);
+  size_t num_entries = capacity / e.total_charge;
   int num_hash_bits = 0;
   while (num_entries >>= 1) {
     ++num_hash_bits;
@@ -224,43 +328,70 @@ void LRUCacheShard::SetStrictCapacityLimit(bool strict_capacity_limit) {
   strict_capacity_limit_ = strict_capacity_limit;
 }
 
-Status LRUCacheShard::InsertItem(LRUHandle* e, Cache::Handle** handle,
-                                 bool free_handle_on_fail) {
+Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
+                             size_t charge, Cache::DeleterFn deleter,
+                             Cache::Handle** handle,
+                             Cache::Priority /*priority*/) {
+  if (key.size() != KEY_LENGTH) {
+    return Status::NotSupported("FastLRUCache only supports key size " +
+                                std::to_string(KEY_LENGTH) + "B");
+  }
+
+  LRUHandle tmp;
+  tmp.displacements = 0;
+  tmp.flags = 0;
+  tmp.value = value;
+  tmp.deleter = deleter;
+  tmp.hash = hash;
+  tmp.refs = 0;
+  tmp.next = tmp.prev = nullptr;
+  tmp.CalcTotalCharge(charge, metadata_charge_policy_);
+  memcpy(tmp.key_data, key.data(), KEY_LENGTH);
+
   Status s = Status::OK();
   autovector<LRUHandle*> last_reference_list;
   {
     MutexLock l(&mutex_);
-
     // Free the space following strict LRU policy until enough space
     // is freed or the lru list is empty.
-    EvictFromLRU(e->total_charge, &last_reference_list);
-
-    if ((usage_ + e->total_charge) > capacity_ &&
-        (strict_capacity_limit_ || handle == nullptr)) {
-      e->SetInCache(false);
+    EvictFromLRU(tmp.total_charge, &last_reference_list);
+    if ((usage_ + tmp.total_charge > capacity_ &&
+         (strict_capacity_limit_ || handle == nullptr)) ||
+        table_.GetOccupancy() == size_t{1} << table_.GetLengthBits()) {
+      // The new occupancy check is there to avoid some bad situations, due to
+      // the support of
+      //  non-strict capacity limit and capacity adjustments:
+      //  - If the strict_capacity_limit == false and the user provides a
+      //  handle, the old code
+      //    forced the insert. But in our closed-address hash table we can't
+      //    insert if the table occupancy is maximum.
+      //  - When the capacity is adjusted, we currently don't rebuild the table.
+      //  So an insert
+      //    may pass the shard usage check, regardless of the table occupancy.
+      // Unfortunately, the tests currently set strict_capacity_limit = false,
+      // so we can't just disable it here.
       if (handle == nullptr) {
         // Don't insert the entry but still return ok, as if the entry inserted
         // into cache and get evicted immediately.
-        last_reference_list.push_back(e);
+        last_reference_list.push_back(&tmp);
       } else {
-        if (free_handle_on_fail) {
-          delete[] reinterpret_cast<char*>(e);
-          *handle = nullptr;
-        }
         s = Status::Incomplete("Insert failed due to LRU cache being full.");
       }
     } else {
       // Insert into the cache. Note that the cache might get larger than its
       // capacity if not enough space was freed up.
-      LRUHandle* old = table_.Insert(e);
+      LRUHandle* old;
+      LRUHandle* e = table_.Insert(&tmp, &old);
+      assert(e != nullptr);  // Insertions should never fail.
       usage_ += e->total_charge;
       if (old != nullptr) {
         s = Status::OkOverwritten();
-        assert(old->InCache());
-        old->SetInCache(false);
+        assert(old->IsPresent());
+        table_.Exclude(old);
         if (!old->HasRefs()) {
           // old is on LRU because it's in cache and its reference count is 0.
           LRU_Remove(old);
+          table_.Remove(old->key(), old->hash);
           assert(usage_ >= old->total_charge);
           usage_ -= old->total_charge;
           last_reference_list.push_back(old);
@@ -292,7 +423,7 @@ Cache::Handle* LRUCacheShard::Lookup(const Slice& key, uint32_t hash) {
     MutexLock l(&mutex_);
     e = table_.Lookup(key, hash);
     if (e != nullptr) {
-      assert(e->InCache());
+      assert(e->IsPresent());
       if (!e->HasRefs()) {
         // The entry is in LRU since it's in hash and has no external references
         LRU_Remove(e);
@@ -321,14 +452,13 @@ bool LRUCacheShard::Release(Cache::Handle* handle, bool erase_if_last_ref) {
   {
     MutexLock l(&mutex_);
     last_reference = e->Unref();
-    if (last_reference && e->InCache()) {
+    if (last_reference && e->IsPresent()) {
       // The item is still in cache, and nobody else holds a reference to it.
       if (usage_ > capacity_ || erase_if_last_ref) {
         // The LRU list must be empty since the cache is full.
         assert(lru_.next == &lru_ || erase_if_last_ref);
         // Take this opportunity and remove the item.
         table_.Remove(e->key(), e->hash);
-        e->SetInCache(false);
       } else {
         // Put the item back on the LRU list, and don't free it.
         LRU_Insert(e);
@@ -349,54 +479,25 @@ bool LRUCacheShard::Release(Cache::Handle* handle, bool erase_if_last_ref) {
   return last_reference;
 }
 
-Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
-                             size_t charge, Cache::DeleterFn deleter,
-                             Cache::Handle** handle,
-                             Cache::Priority /*priority*/) {
-  if (key.size() != KEY_LENGTH) {
-    return Status::NotSupported("FastLRUCache only supports key size " +
-                                std::to_string(KEY_LENGTH) + "B");
-  }
-
-  // Allocate the memory here outside of the mutex.
-  // If the cache is full, we'll have to release it.
-  // It shouldn't happen very often though.
-  LRUHandle* e = reinterpret_cast<LRUHandle*>(
-      new char[sizeof(LRUHandle) - 1 + key.size()]);
-
-  e->value = value;
-  e->flags = 0;
-  e->deleter = deleter;
-  e->key_length = key.size();
-  e->hash = hash;
-  e->refs = 0;
-  e->next = e->prev = nullptr;
-  e->SetInCache(true);
-  e->CalcTotalCharge(charge, metadata_charge_policy_);
-  memcpy(e->key_data, key.data(), key.size());
-
-  return InsertItem(e, handle, /* free_handle_on_fail */ true);
-}
-
 void LRUCacheShard::Erase(const Slice& key, uint32_t hash) {
   LRUHandle* e;
   bool last_reference = false;
   {
     MutexLock l(&mutex_);
-    e = table_.Remove(key, hash);
+    e = table_.Lookup(key, hash);
     if (e != nullptr) {
-      assert(e->InCache());
-      e->SetInCache(false);
+      table_.Exclude(e);
       if (!e->HasRefs()) {
-        // The entry is in LRU since it's in hash and has no external references
+        // The entry is in LRU since it's in cache and has no external
+        // references
         LRU_Remove(e);
+        table_.Remove(key, hash);
         assert(usage_ >= e->total_charge);
         usage_ -= e->total_charge;
         last_reference = true;
       }
     }
   }
-
   // Free the entry here outside of mutex for performance reasons.
   // last_reference will only be true if e != nullptr.
   if (last_reference) {
@@ -421,6 +522,9 @@ LRUCache::LRUCache(size_t capacity, size_t estimated_value_size,
                    int num_shard_bits, bool strict_capacity_limit,
                    CacheMetadataChargePolicy metadata_charge_policy)
     : ShardedCache(capacity, num_shard_bits, strict_capacity_limit) {
+  // // We must enforce strict capacity requirement, or else insertions
+  // // will fail when all slots are occupied and also pinned.
+  // assert(strict_capacity_limit);
   num_shards_ = 1 << num_shard_bits;
   shards_ = reinterpret_cast<LRUCacheShard*>(
       port::cacheline_aligned_alloc(sizeof(LRUCacheShard) * num_shards_));

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -158,7 +158,7 @@ int LRUHandleTable::FindSlot(const Slice& key,
                              int displacement) {
   uint32_t base =
       BinaryMod(Hash(key.data(), key.size(), kProbingSeed1), length_bits_);
-uint32_t increment = BinaryMod(
+  uint32_t increment = BinaryMod(
       (Hash(key.data(), key.size(), kProbingSeed2) << 1) | 1, length_bits_);
   uint32_t current = BinaryMod(base + probe * increment, length_bits_);
   while (true) {

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -334,7 +334,7 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
                                 std::to_string(kCacheKeySize) + "B");
   }
 
-  LRUHandle *tmp = new LRUHandle();
+  LRUHandle* tmp = new LRUHandle();
   tmp->value = value;
   tmp->deleter = deleter;
   tmp->hash = hash;

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -294,9 +294,10 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
 uint8_t LRUCacheShard::CalcHashBits(
     size_t capacity, size_t estimated_value_size,
     CacheMetadataChargePolicy metadata_charge_policy) {
-  LRUHandle h;
-  h.CalcTotalCharge(estimated_value_size, metadata_charge_policy);
-  size_t num_entries = capacity / h.total_charge;
+  LRUHandle* h = reinterpret_cast<LRUHandle*>(new LRUHandle);
+  h->CalcTotalCharge(estimated_value_size, metadata_charge_policy);
+  size_t num_entries = capacity / h->total_charge;
+  h->Free();
   uint8_t num_hash_bits = 0;
   while (num_entries >>= 1) {
     ++num_hash_bits;

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -268,7 +268,7 @@ void LRUCacheShard::LRU_Remove(LRUHandle* h) {
 void LRUCacheShard::LRU_Insert(LRUHandle* h) {
   assert(h->next == nullptr);
   assert(h->prev == nullptr);
-  // Insert "e" to head of LRU list.
+  // Insert h to head of LRU list.
   h->next = &lru_;
   h->prev = lru_.prev;
   h->prev->next = h;

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -101,10 +101,7 @@ LRUHandle* LRUHandleTable::Insert(LRUHandle* h, LRUHandle** old) {
 LRUHandle* LRUHandleTable::Remove(const Slice& key, uint32_t hash) {
   int probe = 0;
   int slot = FindElement(key, hash, probe, -1 /*displacement*/);
-  if (slot == -1) {
-    assert(false);
-    // Remove assumes the element is in the table.
-  }
+  assert(slot != -1); // Remove assumes the key/hash is in the hash table.
   LRUHandle* e = &array_[slot];
   e->SetIsElement(false);
   e->SetIsPresent(false);

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -44,10 +44,11 @@ LRUHandleTable::LRUHandleTable(uint8_t hash_bits)
 
 LRUHandleTable::~LRUHandleTable() {
   // TODO(Guido) If users still hold references to handles,
-  // they will become invalidated. And if we choose not to
+  // those will become invalidated. And if we choose not to
   // delete the data, it will become leaked.
   ApplyToEntriesRange(
       [](LRUHandle* h) {
+        // TODO(Guido) Remove the HasRefs() check?
         if (!h->HasRefs()) {
           h->FreeData();
         }
@@ -157,9 +158,9 @@ int LRUHandleTable::FindVisibleElementOrAvailableSlot(const Slice& key,
       probe, displacement);
 }
 
-int LRUHandleTable::FindSlot(const Slice& key,
-                             std::function<bool(LRUHandle*)> cond, int& probe,
-                             int displacement) {
+inline int LRUHandleTable::FindSlot(const Slice& key,
+                                    std::function<bool(LRUHandle*)> cond,
+                                    int& probe, int displacement) {
   uint32_t base =
       BinaryMod(Hash(key.data(), key.size(), kProbingSeed1), length_bits_);
   uint32_t increment = BinaryMod(

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -38,8 +38,10 @@ namespace fast_lru_cache {
 // (V) Visible: An element can visible for lookups (IS_VISIBLE set), or not.
 //    Initially, every element is visible. An element that is not visible is
 //    called a ghost.
-// These properties induce 4 different states, with transitions defined as follows:
-// - V --> not V: When a visible element is deleted or replaced by a new version.
+// These properties induce 4 different states, with transitions defined as
+// follows:
+// - V --> not V: When a visible element is deleted or replaced by a new
+// version.
 // - Not V --> V: This cannot happen. A ghost remains in that state until it is
 //    not referenced any more, at which point it is ready to be removed from the
 //    hash table. (A ghost simply waits to transition to the afterlife---it will
@@ -225,7 +227,7 @@ class LRUHandleTable {
 
   // Removes h from the hash table. The handle must already be off
   // the LRU list.
-  void Remove(LRUHandle *h);
+  void Remove(LRUHandle* h);
 
   // Turns a visible element h into a ghost (i.e., not visible).
   void Exclude(LRUHandle* h);

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -22,7 +22,7 @@
 constexpr uint8_t kCacheKeySize =
     static_cast<uint8_t>(sizeof(ROCKSDB_NAMESPACE::CacheKey));
 
-constexpr float kLoadFactor = 0.7;
+constexpr double kLoadFactor = 0.7;
 
 constexpr uint32_t kProbingSeed1 = 0xbc9f1d34;
 constexpr uint32_t kProbingSeed2 = 0x7a2bb9d5;

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -347,7 +347,7 @@ class LRUCache
 #endif
     : public ShardedCache {
  public:
-  LRUCache(size_t capacity, size_t estimated_value_size, uint8_t num_shard_bits,
+  LRUCache(size_t capacity, size_t estimated_value_size, int num_shard_bits,
            bool strict_capacity_limit,
            CacheMetadataChargePolicy metadata_charge_policy =
                kDontChargeCacheMetadata);

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -41,7 +41,7 @@ namespace fast_lru_cache {
 // These properties induce 4 different states, with transitions defined as
 // follows:
 // - V --> not V: When a visible element is deleted or replaced by a new
-// version.
+//    version.
 // - Not V --> V: This cannot happen. A ghost remains in that state until it's
 //    not referenced any more, at which point it's ready to be removed from the
 //    hash table. (A ghost simply waits to transition to the afterlife---it will

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <array>
 
 #include "cache/cache_key.h"
 #include "cache/sharded_cache.h"

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -179,8 +179,13 @@ struct LRUHandle {
     if (metadata_charge_policy != kFullChargeCacheMetadata) {
       return 0;
     } else {
+#ifdef ROCKSDB_MALLOC_USABLE_SIZE
+      return malloc_usable_size(
+          const_cast<void*>(static_cast<const void*>(this)));
+#else
       return sizeof(LRUHandle);  // TODO Is this the right metadata accounting
                                  // we want with pre-allocated handles?
+#endif
     }
   }
 

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -80,9 +80,8 @@ constexpr uint8_t kCacheKeySize =
 // For p = 70%, between 1 and 2 probes are needed on average.
 constexpr double kLoadFactor = 0.7;
 
-// Arbitrary seeds.
-constexpr uint32_t kProbingSeed1 = 0xbc9f1d34;
-constexpr uint32_t kProbingSeed2 = 0x7a2bb9d5;
+constexpr uint32_t kProbingSeed = 0x7a2bb9d5; // Arbitrary seeds.
+constexpr uint32_t kLargePrime = 433494437; // Arbitrary large prime number.
 
 // An experimental (under development!) alternative to LRUCache
 
@@ -211,7 +210,7 @@ struct LRUHandle {
 // 4.4.3's builtin hashtable.
 class LRUHandleTable {
  public:
-  explicit LRUHandleTable(uint8_t hash_bits);
+  explicit LRUHandleTable(uint32_t size);
   ~LRUHandleTable();
 
   // Returns a pointer to a visible element matching the key/hash, or
@@ -245,7 +244,7 @@ class LRUHandleTable {
     }
   }
 
-  uint8_t GetLengthBits() const { return length_bits_; }
+  uint32_t GetSize() const { return size_; }
 
   uint32_t GetOccupancy() const { return occupancy_; }
 
@@ -269,12 +268,14 @@ class LRUHandleTable {
   int FindSlot(const Slice& key, std::function<bool(LRUHandle*)> cond,
                int& probe, int displacement);
 
-  // Number of hash bits used for table index.
-  // The size of the table is 1 << length_bits_.
-  uint8_t length_bits_;
+  // Number of slots in the hash table.
+  uint32_t size_;
 
   // Number of elements in the table.
   uint32_t occupancy_;
+
+  // Probing increment.
+  uint32_t increment_;
 
   std::unique_ptr<LRUHandle[]> array_;
 };
@@ -355,7 +356,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
 
   // Returns the number of bits used to hash an element in the hash
   // table.
-  static uint8_t GetHashBits(size_t capacity, size_t estimated_value_size,
+  static size_t CalcSize(size_t capacity, size_t estimated_value_size,
                              CacheMetadataChargePolicy metadata_charge_policy);
 
   // Initialized before use.

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -18,6 +18,8 @@
 #include "rocksdb/secondary_cache.h"
 #include "util/autovector.h"
 
+#define KEY_LENGTH 16
+
 namespace ROCKSDB_NAMESPACE {
 namespace fast_lru_cache {
 
@@ -26,26 +28,31 @@ namespace fast_lru_cache {
 struct LRUHandle {
   void* value;
   Cache::DeleterFn deleter;
-  LRUHandle* next_hash;
   LRUHandle* next;
   LRUHandle* prev;
   size_t total_charge;  // TODO(opt): Only allow uint32_t?
-  size_t key_length;
   // The hash of key(). Used for fast sharding and comparisons.
   uint32_t hash;
   // The number of external refs to this entry. The cache itself is not counted.
   uint32_t refs;
 
   enum Flags : uint8_t {
-    // Whether this entry is referenced by the hash table.
-    IN_CACHE = (1 << 0),
+    // Whether the handle can be found via a Lookup.
+    IS_PRESENT = (1 << 0),
+    // Whether the slot is in use by an element.
+    // IS_PRESENT implies IS_ELEMENT.
+    IS_ELEMENT = (1 << 1),
   };
   uint8_t flags;
 
-  // Beginning of the key (MUST BE THE LAST FIELD IN THIS STRUCT!)
-  char key_data[1];
+  // Number of elements that hash to this slot or a lower one,
+  // but ended up in a higher slot. This field is managed
+  // by the hash table, but not the shard.
+  uint32_t displacements;
 
-  Slice key() const { return Slice(key_data, key_length); }
+  char key_data[KEY_LENGTH];
+
+  Slice key() const { return Slice(key_data, KEY_LENGTH); }
 
   // Increase the reference count by 1.
   void Ref() { refs++; }
@@ -60,13 +67,23 @@ struct LRUHandle {
   // Return true if there are external refs, false otherwise.
   bool HasRefs() const { return refs > 0; }
 
-  bool InCache() const { return flags & IN_CACHE; }
+  bool IsPresent() const { return flags & IS_PRESENT; }
 
-  void SetInCache(bool in_cache) {
-    if (in_cache) {
-      flags |= IN_CACHE;
+  void SetIsPresent(bool is_present) {
+    if (is_present) {
+      flags |= IS_PRESENT;
     } else {
-      flags &= ~IN_CACHE;
+      flags &= ~IS_PRESENT;
+    }
+  }
+
+  bool IsElement() const { return flags & IS_ELEMENT; }
+
+  void SetIsElement(bool is_element) {
+    if (is_element) {
+      flags |= IS_ELEMENT;
+    } else {
+      flags &= ~IS_ELEMENT;
     }
   }
 
@@ -75,7 +92,6 @@ struct LRUHandle {
     if (deleter) {
       (*deleter)(key(), value);
     }
-    delete[] reinterpret_cast<char*>(this);
   }
 
   // Calculate the memory usage by metadata.
@@ -84,13 +100,7 @@ struct LRUHandle {
     if (metadata_charge_policy != kFullChargeCacheMetadata) {
       return 0;
     } else {
-#ifdef ROCKSDB_MALLOC_USABLE_SIZE
-      return malloc_usable_size(
-          const_cast<void*>(static_cast<const void*>(this)));
-#else
-      // This is the size that is used when a new handle is created.
-      return sizeof(LRUHandle) - 1 + key_length;
-#endif
+      return sizeof(LRUHandle);
     }
   }
 
@@ -105,6 +115,21 @@ struct LRUHandle {
     assert(total_charge >= meta_charge);
     return total_charge - meta_charge;
   }
+
+  // A handle can represent 3 different things: an empty slot, a tombstone, or
+  // an actual element.
+  inline bool IsEmpty() {
+    return !this->IsElement() && this->displacements == 0;
+  }
+
+  inline bool IsTombstone() {
+    return !this->IsElement() && this->displacements > 0;
+  }
+
+  inline bool Matches(const Slice& some_key, uint32_t some_hash) {
+    return this->IsElement() && this->hash == some_hash &&
+           this->key() == some_key;
+  }
 };
 
 // We provide our own simple hash table since it removes a whole bunch
@@ -117,42 +142,68 @@ class LRUHandleTable {
   explicit LRUHandleTable(int hash_bits);
   ~LRUHandleTable();
 
+  // Returns a pointer to the handle matching the key/hash, or nullptr
+  // if not present.
   LRUHandle* Lookup(const Slice& key, uint32_t hash);
-  LRUHandle* Insert(LRUHandle* h);
+  // Returns a pointer to the inserted handle. The argument old is
+  // an output argument, which is a reference to a pointer to an
+  // existing handle that matches the key/hash, or nullptr if no such
+  // handle exists.
+  LRUHandle* Insert(LRUHandle* h, LRUHandle** old);
+  // Returns a pointer to the handle matching the key/hash, or nullptr
+  // if not present. Assumes the element is in the table.
   LRUHandle* Remove(const Slice& key, uint32_t hash);
+
+  void Exclude(LRUHandle* e);
+
+  void Assign(int slot, LRUHandle* src);
 
   template <typename T>
   void ApplyToEntriesRange(T func, uint32_t index_begin, uint32_t index_end) {
     for (uint32_t i = index_begin; i < index_end; i++) {
-      LRUHandle* h = list_[i];
-      while (h != nullptr) {
-        auto n = h->next_hash;
-        assert(h->InCache());
+      LRUHandle* h = &array_[i];
+      if (h->IsPresent()) {
         func(h);
-        h = n;
       }
     }
   }
 
   int GetLengthBits() const { return length_bits_; }
 
-  // Return the address of the head of the chain in the bucket given
-  // by the hash.
-  inline LRUHandle** Head(uint32_t hash);
+  uint32_t GetOccupancy() const { return occupancy_; }
 
  private:
-  // Return a pointer to slot that points to a cache entry that
-  // matches key/hash.  If there is no such cache entry, return a
-  // pointer to the trailing slot in the corresponding linked list.
-  LRUHandle** FindPointer(const Slice& key, uint32_t hash);
+  int FindElement(const Slice& key, uint32_t hash, int& probe,
+                  int displacement);
+
+  int FindPresentElement(const Slice& key, uint32_t hash, int& probe,
+                         int displacement);
+
+  int FindAvailableSlot(const Slice& key, int& probe, int displacement);
+
+  int FindPresentElementOrAvailableSlot(const Slice& key, uint32_t hash,
+                                        int& probe, int displacement);
+
+  // Returns the index of the first probe that contains a handle e
+  // such that cond(e) is true.  If the probe sequence ends without
+  // a match, returns a pointer to the first slot available in the
+  // sequence.  Otherwise, if no match is found and no slot is
+  // available, returns -1. For every handle e probed, except any
+  // matching slot, we update e->displacements += displacement.
+  // The variable probe is updated such that consecutive calls to
+  // FindSlot use every probe number, without repetition.
+  int FindSlot(const Slice& key, std::function<bool(LRUHandle*)> cond,
+               int& probe, int displacement);
 
   // Number of hash bits (upper because lower bits used for sharding)
   // used for table index. Length == 1 << length_bits_
   int length_bits_;
 
-  // The table consists of an array of buckets where each bucket is
-  // a linked list of cache entries that hash into the bucket.
-  std::unique_ptr<LRUHandle*[]> list_;
+  uint32_t occupancy_;
+
+  // TODO(guido) Cache alignment.
+  // TODO(guido) unique_ptr?
+  LRUHandle* array_;
 };
 
 // A single shard of sharded cache.
@@ -172,6 +223,10 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
   void SetStrictCapacityLimit(bool strict_capacity_limit) override;
 
   // Like Cache methods, but with an extra "hash" parameter.
+  // Insert an item into the hash table and, if handle is null, insert into
+  // the LRU list. Older items are evicted as necessary. If the cache is full
+  // and free_handle_on_fail is true, the item is deleted and handle is set to
+  // nullptr.
   Status Insert(const Slice& key, uint32_t hash, void* value, size_t charge,
                 Cache::DeleterFn deleter, Cache::Handle** handle,
                 Cache::Priority priority) override;
@@ -216,13 +271,6 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
 
  private:
   friend class LRUCache;
-  // Insert an item into the hash table and, if handle is null, insert into
-  // the LRU list. Older items are evicted as necessary. If the cache is full
-  // and free_handle_on_fail is true, the item is deleted and handle is set to
-  // nullptr.
-  Status InsertItem(LRUHandle* item, Cache::Handle** handle,
-                    bool free_handle_on_fail);
-
   void LRU_Remove(LRUHandle* e);
   void LRU_Insert(LRUHandle* e);
 

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -82,9 +82,9 @@ constexpr uint8_t kCacheKeySize =
 // power of 2, p is really an upper bound on the actual load factor---the
 // actual load factor is anywhere between p/2 and p. This is a bit wasteful,
 // but bear in mind that slots only hold metadata, not actual values.
-// Since space cost is dominated by the values (the LSM blocks), overprovisioning
-// the table with metadata only increases the total cache space usage by
-// a tiny fraction.
+// Since space cost is dominated by the values (the LSM blocks),
+// overprovisioning the table with metadata only increases the total cache space
+// usage by a tiny fraction.
 constexpr double kLoadFactor = 0.7;
 
 // Arbitrary seeds.

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -8,9 +8,9 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #pragma once
 
+#include <array>
 #include <memory>
 #include <string>
-#include <array>
 
 #include "cache/cache_key.h"
 #include "cache/sharded_cache.h"
@@ -167,7 +167,7 @@ struct LRUHandle {
     }
   }
 
-  void Free() {
+  void FreeData() {
     assert(refs == 0);
     if (deleter) {
       (*deleter)(key(), value);

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -199,14 +199,14 @@ class LRUHandleTable {
   int FindPresentElementOrAvailableSlot(const Slice& key, uint32_t hash,
                                         int& probe, int displacement);
 
-  // Returns the index of the first probe that contains a handle e
+  // Returns the index of the first slot probed that has a handle e
   // such that cond(e) is true.  If the probe sequence ends without
   // a match, returns a pointer to the first slot available in the
   // sequence.  Otherwise, if no match is found and no slot is
-  // available, returns -1. For every handle e probed, except any
+  // available, returns -1.  For every handle e probed, except the
   // matching slot, we update e->displacements += displacement.
-  // The variable probe is updated such that consecutive calls to
-  // FindSlot use every probe number, without repetition.
+  // The variable probe is modified such that consecutive calls to
+  // FindSlot continue probing where the previous left.
   int FindSlot(const Slice& key, std::function<bool(LRUHandle*)> cond,
                int& probe, int displacement);
 

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -360,7 +360,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
   // Returns the number of bits used to hash an element in the hash
   // table.
   static uint8_t CalcHashBits(size_t capacity, size_t estimated_value_size,
-                             CacheMetadataChargePolicy metadata_charge_policy);
+                              CacheMetadataChargePolicy metadata_charge_policy);
 
   // Initialized before use.
   size_t capacity_;

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -46,8 +46,7 @@ struct LRUHandle {
   uint8_t flags;
 
   // Number of elements that hash to this slot or a lower one,
-  // but ended up in a higher slot. This field is managed
-  // by the hash table, but not the shard.
+  // but wind up in a higher slot.
   uint32_t displacements;
 
   char key_data[KEY_LENGTH];

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -180,13 +180,22 @@ struct LRUHandle {
     if (metadata_charge_policy != kFullChargeCacheMetadata) {
       return 0;
     } else {
-#ifdef ROCKSDB_MALLOC_USABLE_SIZE
-      return malloc_usable_size(
-          const_cast<void*>(static_cast<const void*>(this)));
-#else
-      return sizeof(LRUHandle);  // TODO Is this the right metadata accounting
-                                 // we want with pre-allocated handles?
-#endif
+      // #ifdef ROCKSDB_MALLOC_USABLE_SIZE
+      //       return malloc_usable_size(
+      //           const_cast<void*>(static_cast<const void*>(this)));
+      // #else
+      // TODO(Guido) malloc_usable_size only works when we call it on
+      // a pointer allocated with malloc. Because our handles are all
+      // allocated in a single shot as an array, the user can't call
+      // CalcMetaCharge (or CalcTotalCharge or GetCharge) on a handle
+      // pointer returned by the cache. Moreover, malloc_usable_size
+      // expects a heap-allocated handle, but sometimes in our code we
+      // wish to pass a stack-allocated handle (this is only a performance
+      // concern).
+      // What is the right way to compute metadata charges with pre-allocated
+      // handles?
+      return sizeof(LRUHandle);
+      // #endif
     }
   }
 

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -277,9 +277,6 @@ class LRUHandleTable {
   // Number of elements in the table.
   uint32_t occupancy_;
 
-  // Probing increment.
-  uint32_t increment_;
-
   std::unique_ptr<LRUHandle[]> array_;
 };
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -114,7 +114,8 @@ default_params = {
     "use_direct_reads": lambda: random.randint(0, 1),
     "use_direct_io_for_flush_and_compaction": lambda: random.randint(0, 1),
     "mock_direct_io": False,
-    "cache_type": "lru_cache", #lambda: random.choice(["fast_lru_cache", "lru_cache"]),   # clock_cache is broken
+    "cache_type": "lru_cache",  # clock_cache is broken
+                                # fast_lru_cache is currently incompatible with stress tests, because they use strict_capacity_limit = false
     "use_full_merge_v1": lambda: random.randint(0, 1),
     "use_merge": lambda: random.randint(0, 1),
     # 999 -> use Bloom API

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -114,7 +114,7 @@ default_params = {
     "use_direct_reads": lambda: random.randint(0, 1),
     "use_direct_io_for_flush_and_compaction": lambda: random.randint(0, 1),
     "mock_direct_io": False,
-    "cache_type": lambda: random.choice(["fast_lru_cache", "lru_cache"]),   # clock_cache is broken
+    "cache_type": "lru_cache" #lambda: random.choice(["fast_lru_cache", "lru_cache"]),   # clock_cache is broken
     "use_full_merge_v1": lambda: random.randint(0, 1),
     "use_merge": lambda: random.randint(0, 1),
     # 999 -> use Bloom API

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -114,7 +114,7 @@ default_params = {
     "use_direct_reads": lambda: random.randint(0, 1),
     "use_direct_io_for_flush_and_compaction": lambda: random.randint(0, 1),
     "mock_direct_io": False,
-    "cache_type": "lru_cache" #lambda: random.choice(["fast_lru_cache", "lru_cache"]),   # clock_cache is broken
+    "cache_type": "lru_cache", #lambda: random.choice(["fast_lru_cache", "lru_cache"]),   # clock_cache is broken
     "use_full_merge_v1": lambda: random.randint(0, 1),
     "use_merge": lambda: random.randint(0, 1),
     # 999 -> use Bloom API


### PR DESCRIPTION
Summary: In FastLRUCache, we replace the current chained per-shard hash table by an open-addressing hash table. In particular, this allows us to preallocate all handles.

Because all handles are preallocated, this implementation doesn't support strict_capacity_limit = false (i.e., allowing insertions beyond the predefined capacity). This clashes with current assumptions of some tests, namely two tests in cache_test and the crash tests. We have disabled these for now.

Test plan: ``make -j24 check``