### PR TITLE
Charge blob cache usage against the global memory limit

### DIFF
--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -21,7 +21,8 @@ BlobSource::BlobSource(const ImmutableOptions* immutable_options,
       db_session_id_(db_session_id),
       statistics_(immutable_options->statistics.get()),
       blob_file_cache_(blob_file_cache),
-      blob_cache_(immutable_options->blob_cache) {}
+      blob_cache_(immutable_options->blob_cache),
+      write_buffer_manager_(immutable_options->write_buffer_manager) {}
 
 BlobSource::~BlobSource() = default;
 

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -152,6 +152,10 @@ class WriteBufferManager final {
 
   void RemoveDBFromQueue(StallInterface* wbm_stall);
 
+  // Charge the memory usage of the blob cache when the backing cache of the
+  // blob cache and the block cache are different.
+  void ReserveMemWithBlobCache(std::shared_ptr<Cache> blob_cache);
+
  private:
   std::atomic<size_t> buffer_size_;
   std::atomic<size_t> mutable_limit_;

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -199,4 +199,14 @@ void WriteBufferManager::RemoveDBFromQueue(StallInterface* wbm_stall) {
   wbm_stall->Signal();
 }
 
+void WriteBufferManager::ReserveMemWithBlobCache(
+    std::shared_ptr<Cache> blob_cache) {
+#ifndef ROCKSDB_LITE
+  assert(cache_res_mgr_ != nullptr);
+  std::lock_guard<std::mutex> lock(cache_res_mgr_mu_);
+  Status s = cache_res_mgr_->UpdateBlobCacheReservation(blob_cache);
+  s.PermitUncheckedError();
+#endif  // ROCKSDB_LITE
+}
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary:

To help service owners to manage their memory budget effectively, we have been working towards counting all major memory users inside RocksDB towards a single global memory limit (see e.g. https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager#cost-memory-used-in-memtable-to-block-cache). The global limit is specified by the capacity of the block-based table's block cache, and is technically implemented by inserting dummy entries ("reservations") into the block cache. The goal of this task is to support charging the memory usage of the new blob cache against this global memory limit when the backing cache of the blob cache and the block cache are different.

Test Plan:

Reviewers:

Subscribers:

Tasks:

This PR is a part of #10156

Tags: