### PR TITLE
Fix bad include

### DIFF
--- a/build_tools/check-sources.sh
+++ b/build_tools/check-sources.sh
@@ -17,9 +17,15 @@ if [ "$?" != "1" ]; then
   BAD=1
 fi
 
-git grep -n '<rocksdb/' -- ':!build_tools/check-sources.sh'
+git grep -n 'include <rocksdb/' -- ':!build_tools/check-sources.sh'
 if [ "$?" != "1" ]; then
   echo '^^^^^ Use double-quotes as in #include "rocksdb/something.h"'
+  BAD=1
+fi
+
+git grep -n 'include "include/rocksdb/' -- ':!build_tools/check-sources.sh'
+if [ "$?" != "1" ]; then
+  echo '^^^^^ Use #include "rocksdb/something.h" instead of #include "include/rocksdb/something.h"'
   BAD=1
 fi
 

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -10,7 +10,7 @@
 #include "cache/cache_helpers.h"
 #include "cache/cache_key.h"
 #include "db/blob/blob_file_cache.h"
-#include "include/rocksdb/cache.h"
+#include "rocksdb/cache.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "table/block_based/cachable_entry.h"
 


### PR DESCRIPTION
Summary: include "include/rocksdb/blah.h" is messing up some internal
builds vs. include "rocksdb/blah." This fixes the bad case and adds a
check for future instances.

Test Plan: back-port to 7.4 release candidate and watch internal build