### PR TITLE
point_lock_manager: improve performance, serveral changes ---

### DIFF
--- a/utilities/transactions/lock/point/point_lock_manager.h
+++ b/utilities/transactions/lock/point/point_lock_manager.h
@@ -195,7 +195,7 @@ class PointLockManager : public LockManager {
   bool IsLockExpired(TransactionID txn_id, const LockInfo& lock_info, Env* env,
                      uint64_t* wait_time);
 
-  std::shared_ptr<LockMap> GetLockMap(uint32_t column_family_id);
+  LockMap* GetLockMap(uint32_t column_family_id);
 
   Status AcquireWithTimeout(PessimisticTransaction* txn, LockMap* lock_map,
                             LockMapStripe* stripe, uint32_t column_family_id,


### PR DESCRIPTION
1. PointLockManager::AddColumnFamily: use operator[] instead of find+emplace
2. PointLockManager::RemoveColumnFamily: use erase(key) instead of find+erase(iter)
3. PointLockManager::GetLockMap:
   a. return raw pointer instead of shared_ptr which needs atomic inc/dec refcnt
   b. use one lock_maps_cache_->Get() instead of two