### PR TITLE
Continue to deflake BackupEngineTest.Concurrency

### DIFF
--- a/env/fs_remap.cc
+++ b/env/fs_remap.cc
@@ -268,9 +268,10 @@ IOStatus RemapFileSystem::RenameFile(const std::string& src,
                                      IODebugContext* dbg) {
   auto status_and_src_enc_path = EncodePath(src);
   if (!status_and_src_enc_path.first.ok()) {
-    fprintf(stderr, "y7jin %s %s\n", status_and_src_enc_path.first.ToString().c_str(), status_and_src_enc_path.second.c_str());
-    fflush(stderr);
-    assert(false);
+    if (status_and_src_enc_path.first.IsNotFound()) {
+      const IOStatus& s = status_and_src_enc_path.first;
+      status_and_src_enc_path.first = IOStatus::PathNotFound(s.ToString());
+    }
     return status_and_src_enc_path.first;
   }
   auto status_and_dest_enc_path = EncodePathWithNewBasename(dest);

--- a/env/fs_remap.cc
+++ b/env/fs_remap.cc
@@ -268,6 +268,9 @@ IOStatus RemapFileSystem::RenameFile(const std::string& src,
                                      IODebugContext* dbg) {
   auto status_and_src_enc_path = EncodePath(src);
   if (!status_and_src_enc_path.first.ok()) {
+    fprintf(stderr, "y7jin %s %s\n", status_and_src_enc_path.first.ToString().c_str(), status_and_src_enc_path.second.c_str());
+    fflush(stderr);
+    assert(false);
     return status_and_src_enc_path.first;
   }
   auto status_and_dest_enc_path = EncodePathWithNewBasename(dest);

--- a/logging/auto_roll_logger.cc
+++ b/logging/auto_roll_logger.cc
@@ -333,10 +333,6 @@ Status CreateLoggerFromOptions(const std::string& dbname,
       if (s.IsNotFound()) {
         s = Status::OK();
       }
-    } else if (!s.ok()) {
-      fprintf(stderr, "code=%d subcode=%d %s\n", (int)s.code(), (int)s.subcode(), s.ToString().c_str());
-      fflush(stderr);
-      assert(false);
     }
   } else if (s.IsNotFound()) {
     // "LOG" is not required to exist since this could be a new DB.

--- a/logging/auto_roll_logger.cc
+++ b/logging/auto_roll_logger.cc
@@ -333,6 +333,10 @@ Status CreateLoggerFromOptions(const std::string& dbname,
       if (s.IsNotFound()) {
         s = Status::OK();
       }
+    } else if (!s.ok()) {
+      fprintf(stderr, "code=%d subcode=%d %s\n", (int)s.code(), (int)s.subcode(), s.ToString().c_str());
+      fflush(stderr);
+      assert(false);
     }
   } else if (s.IsNotFound()) {
     // "LOG" is not required to exist since this could be a new DB.


### PR DESCRIPTION
Even after #10069, `BackupEngineTest.Concurrency` is still flaky with decreased probability of failure.

Repro steps as follows
```bash
make backup_engine_test
gtest-parallel -r 1000 -w 64 ./backup_engine_test --gtest_filter=BackupEngineTest.Concurrency
```

The first two commits of this PR demonstrate how the test is flaky. #10069 handles the case in which
`Rename()` file returns `IOError` with subcode `PathNotFound`, and `CreateLoggerFromOptions()`
allows the operation to succeed, as expected by the test. However, `BackupEngineTest` uses
`RemapFileSystem` on top of `ChrootFileSystem` which can return `NotFound` instead of `IOError`.

This behavior is different from `Env::Default()` which returns PathNotFound if the src of `rename()`
does not exist. We should make the behaviors of the test Env/FS match a real Env/FS.

Test plan
```bash
make check
gtest-parallel -r 1000 -w 64 ./backup_engine_test --gtest_filter=BackupEngineTest.Concurrency
```