### PR TITLE
Fix key size in cache_bench

### DIFF
--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -215,6 +215,7 @@ struct KeyGen {
     EncodeFixed64(key_data + 10, key);
     key_data[18] = char{4};
     EncodeFixed64(key_data + 19, key);
+    assert(27 >= kCacheKeySize);
     return Slice(&key_data[off], kCacheKeySize);
   }
 };

--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -321,10 +321,12 @@ class CacheBench {
     Random64 rnd(1);
     KeyGen keygen;
     char *value = createValue(rnd);
-    Status s = cache_->Insert(keygen.GetRand(rnd, max_key_, max_log_), value,
-                      &helper1, FLAGS_value_bytes);
-    if (s != Status::OK()) {
-      delete value;
+    for (uint64_t i = 0; i < 2 * FLAGS_cache_size; i += FLAGS_value_bytes) {
+      Status s = cache_->Insert(keygen.GetRand(rnd, max_key_, max_log_), value,
+                        &helper1, FLAGS_value_bytes);
+      if (s != Status::OK()) {
+        delete value;
+      }
     }
   }
 

--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -325,7 +325,7 @@ class CacheBench {
     for (uint64_t i = 0; i < 2 * FLAGS_cache_size; i += FLAGS_value_bytes) {
       Status s = cache_->Insert(keygen.GetRand(rnd, max_key_, max_log_),
                                 createValue(rnd), &helper1, FLAGS_value_bytes);
-      assert(s == Status::OK());
+      assert(s.ok());
     }
   }
 
@@ -547,7 +547,7 @@ class CacheBench {
           // do insert
           Status s = cache_->Insert(key, createValue(thread->rnd), &helper2,
                                     FLAGS_value_bytes, &handle);
-          assert(s == Status::OK());
+          assert(s.ok());
         }
       } else if (random_op < insert_threshold_) {
         if (handle) {
@@ -557,7 +557,7 @@ class CacheBench {
         // do insert
         Status s = cache_->Insert(key, createValue(thread->rnd), &helper3,
                                   FLAGS_value_bytes, &handle);
-        assert(s == Status::OK());
+        assert(s.ok());
       } else if (random_op < lookup_threshold_) {
         if (handle) {
           cache_->Release(handle);

--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -322,8 +322,8 @@ class CacheBench {
     Random64 rnd(1);
     KeyGen keygen;
     for (uint64_t i = 0; i < 2 * FLAGS_cache_size; i += FLAGS_value_bytes) {
-      Status s = cache_->Insert(keygen.GetRand(rnd, max_key_, max_log_), createValue(rnd),
-                                &helper1, FLAGS_value_bytes);
+      Status s = cache_->Insert(keygen.GetRand(rnd, max_key_, max_log_),
+                                createValue(rnd), &helper1, FLAGS_value_bytes);
       assert(s == Status::OK());
     }
   }
@@ -544,8 +544,8 @@ class CacheBench {
                              FLAGS_value_bytes);
         } else {
           // do insert
-          Status s =
-              cache_->Insert(key, createValue(thread->rnd), &helper2, FLAGS_value_bytes, &handle);
+          Status s = cache_->Insert(key, createValue(thread->rnd), &helper2,
+                                    FLAGS_value_bytes, &handle);
           assert(s == Status::OK());
         }
       } else if (random_op < insert_threshold_) {
@@ -554,8 +554,8 @@ class CacheBench {
           handle = nullptr;
         }
         // do insert
-        Status s =
-            cache_->Insert(key, createValue(thread->rnd), &helper3, FLAGS_value_bytes, &handle);
+        Status s = cache_->Insert(key, createValue(thread->rnd), &helper3,
+                                  FLAGS_value_bytes, &handle);
         assert(s == Status::OK());
       } else if (random_op < lookup_threshold_) {
         if (handle) {

--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -322,9 +322,9 @@ class CacheBench {
     Random64 rnd(1);
     KeyGen keygen;
     for (uint64_t i = 0; i < 2 * FLAGS_cache_size; i += FLAGS_value_bytes) {
-      char *value = createValue(rnd);
+      char* value = createValue(rnd);
       Status s = cache_->Insert(keygen.GetRand(rnd, max_key_, max_log_), value,
-                        &helper1, FLAGS_value_bytes);
+                                &helper1, FLAGS_value_bytes);
       assert(s == Status::OK());
     }
   }
@@ -545,9 +545,9 @@ class CacheBench {
                              FLAGS_value_bytes);
         } else {
           // do insert
-          char *value = createValue(thread->rnd);
-          Status s = cache_->Insert(key, value, &helper2,
-                          FLAGS_value_bytes, &handle);
+          char* value = createValue(thread->rnd);
+          Status s =
+              cache_->Insert(key, value, &helper2, FLAGS_value_bytes, &handle);
           assert(s == Status::OK());
         }
       } else if (random_op < insert_threshold_) {
@@ -556,9 +556,9 @@ class CacheBench {
           handle = nullptr;
         }
         // do insert
-        char *value = createValue(thread->rnd);
-        Status s = cache_->Insert(key, value, &helper3,
-                        FLAGS_value_bytes, &handle);
+        char* value = createValue(thread->rnd);
+        Status s =
+            cache_->Insert(key, value, &helper3, FLAGS_value_bytes, &handle);
         assert(s == Status::OK());
       } else if (random_op < lookup_threshold_) {
         if (handle) {

--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -322,8 +322,7 @@ class CacheBench {
     Random64 rnd(1);
     KeyGen keygen;
     for (uint64_t i = 0; i < 2 * FLAGS_cache_size; i += FLAGS_value_bytes) {
-      char* value = createValue(rnd);
-      Status s = cache_->Insert(keygen.GetRand(rnd, max_key_, max_log_), value,
+      Status s = cache_->Insert(keygen.GetRand(rnd, max_key_, max_log_), createValue(rnd),
                                 &helper1, FLAGS_value_bytes);
       assert(s == Status::OK());
     }
@@ -545,9 +544,8 @@ class CacheBench {
                              FLAGS_value_bytes);
         } else {
           // do insert
-          char* value = createValue(thread->rnd);
           Status s =
-              cache_->Insert(key, value, &helper2, FLAGS_value_bytes, &handle);
+              cache_->Insert(key, createValue(thread->rnd), &helper2, FLAGS_value_bytes, &handle);
           assert(s == Status::OK());
         }
       } else if (random_op < insert_threshold_) {
@@ -556,9 +554,8 @@ class CacheBench {
           handle = nullptr;
         }
         // do insert
-        char* value = createValue(thread->rnd);
         Status s =
-            cache_->Insert(key, value, &helper3, FLAGS_value_bytes, &handle);
+            cache_->Insert(key, createValue(thread->rnd), &helper3, FLAGS_value_bytes, &handle);
         assert(s == Status::OK());
       } else if (random_op < lookup_threshold_) {
         if (handle) {

--- a/cache/cache_key.h
+++ b/cache/cache_key.h
@@ -65,6 +65,9 @@ class CacheKey {
   uint64_t offset_etc64_;
 };
 
+constexpr uint8_t kCacheKeySize =
+    static_cast<uint8_t>(sizeof(CacheKey));
+
 // A file-specific generator of cache keys, sometimes referred to as the
 // "base" cache key for a file because all the cache keys for various offsets
 // within the file are computed using simple arithmetic. The basis for the

--- a/cache/cache_key.h
+++ b/cache/cache_key.h
@@ -65,8 +65,7 @@ class CacheKey {
   uint64_t offset_etc64_;
 };
 
-constexpr uint8_t kCacheKeySize =
-    static_cast<uint8_t>(sizeof(CacheKey));
+constexpr uint8_t kCacheKeySize = static_cast<uint8_t>(sizeof(CacheKey));
 
 // A file-specific generator of cache keys, sometimes referred to as the
 // "base" cache key for a file because all the cache keys for various offsets

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -22,10 +22,11 @@
 #include "util/distributed_mutex.h"
 
 namespace ROCKSDB_NAMESPACE {
+
 namespace fast_lru_cache {
 
 // LRU cache implementation using an open-address hash table.
-
+//
 // Every slot in the hash table is an LRUHandle. Because handles can be
 // referenced externally, we can't discard them immediately once they are
 // deleted (via a delete or an LRU eviction) or replaced by a new version
@@ -51,7 +52,7 @@ namespace fast_lru_cache {
 // - Not R --> R: When an unreferenced element becomes referenced. This can only
 //    happen if the element is V, since references to an element can only be
 //    created when it's visible.
-
+//
 // Internally, the cache uses an open-addressed hash table to index the handles.
 // We use tombstone counters to keep track of displacements.
 // Because of the tombstones and the two possible visibility states of an
@@ -69,9 +70,6 @@ namespace fast_lru_cache {
 // tombstone or an empty slot, depending on the number of displacements of the
 // slot. In any case, the slot becomes available. When a handle is inserted
 // into that slot, it becomes a visible element again.
-
-constexpr uint8_t kCacheKeySize =
-    static_cast<uint8_t>(sizeof(ROCKSDB_NAMESPACE::CacheKey));
 
 // The load factor p is a real number in (0, 1) such that at all
 // times at most a fraction p of all slots, without counting tombstones,


### PR DESCRIPTION
Summary: cache_bench wasn't generating 16B keys, which are necessary for FastLRUCache. Also:
- Added asserts in cache_bench, which is assuming that inserts never fail. When they fail (for example, if we used keys of the wrong size), memory allocated to the values will becomes leaked, and eventually the program crashes.
- Move kCacheKeySize to the right spot. 

Test: ``make -j24 check``. Also, run cache_bench with FastLRUCache and check that memory usage doesn't blow up:
``./cache_bench -cache_type=fast_lru_cache -num_shard_bits=6 -skewed=true \
                        -lookup_insert_percent=100 -lookup_percent=0 -insert_percent=0 -erase_percent=0 \
                        -populate_cache=true -cache_size=1073741824 -ops_per_thread=10000000 \
                        -value_bytes=8192 -resident_ratio=1 -threads=16``