### PR TITLE
Calculate table size of FastLRUCache more accurately

### DIFF
--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -315,9 +315,8 @@ uint8_t LRUCacheShard::CalcHashBits(
     ++num_hash_bits;
   }
   // Compute the ceiling of log2(num_entries). If num_entries == 0, return 1.
-  return static_cast<size_t>(1 << num_hash_bits) < num_entries
-             ? num_hash_bits + 1
-             : num_hash_bits;
+  return size_t{1} << num_hash_bits < num_entries ? num_hash_bits + 1
+                                                  : num_hash_bits;
 }
 
 void LRUCacheShard::SetCapacity(size_t capacity) {

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -299,7 +299,8 @@ uint8_t LRUCacheShard::CalcHashBits(
     CacheMetadataChargePolicy metadata_charge_policy) {
   LRUHandle h;
   h.CalcTotalCharge(estimated_value_size, metadata_charge_policy);
-  size_t num_entries = static_cast<size_t>(capacity / (kLoadFactor * h.total_charge));
+  size_t num_entries =
+      static_cast<size_t>(capacity / (kLoadFactor * h.total_charge));
   uint8_t num_hash_bits = 0;
   while (num_entries >>= 1) {
     ++num_hash_bits;

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -310,7 +310,7 @@ uint8_t LRUCacheShard::CalcHashBits(
   size_t num_entries =
       static_cast<size_t>(capacity / (kLoadFactor * handle_charge));
 
-  // Compute the ceiling of log2(num_entries). If num_entries == 0, return 1.
+  // Compute the ceiling of log2(num_entries).
   uint8_t num_hash_bits = 0;
   size_t num_entries_copy = num_entries;
   while (num_entries_copy >>= 1) {

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -192,8 +192,7 @@ LRUCacheShard::LRUCacheShard(size_t capacity, size_t estimated_value_size,
     : capacity_(capacity),
       strict_capacity_limit_(strict_capacity_limit),
       table_(
-          CalcHashBits(capacity, estimated_value_size, metadata_charge_policy) +
-          static_cast<uint8_t>(ceil(log2(1.0 / kLoadFactor)))),
+          CalcHashBits(capacity, estimated_value_size, metadata_charge_policy)),
       usage_(0),
       lru_usage_(0) {
   set_metadata_charge_policy(metadata_charge_policy);
@@ -300,7 +299,7 @@ uint8_t LRUCacheShard::CalcHashBits(
     CacheMetadataChargePolicy metadata_charge_policy) {
   LRUHandle h;
   h.CalcTotalCharge(estimated_value_size, metadata_charge_policy);
-  size_t num_entries = capacity / h.total_charge;
+  size_t num_entries = static_cast<size_t>(capacity / (kLoadFactor * h.total_charge));
   uint8_t num_hash_bits = 0;
   while (num_entries >>= 1) {
     ++num_hash_bits;

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -310,7 +310,7 @@ uint8_t LRUCacheShard::CalcHashBits(
   size_t num_entries =
       static_cast<size_t>(capacity / (kLoadFactor * handle_charge));
 
-  // Compute the ceiling of log2(num_entries).
+  // Compute the ceiling of log2(num_entries). If num_entries == 0, return 0.
   uint8_t num_hash_bits = 0;
   size_t num_entries_copy = num_entries;
   while (num_entries_copy >>= 1) {

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -309,14 +309,15 @@ uint8_t LRUCacheShard::CalcHashBits(
       CalcEstimatedHandleCharge(estimated_value_size, metadata_charge_policy);
   size_t num_entries =
       static_cast<size_t>(capacity / (kLoadFactor * handle_charge));
+
+  // Compute the ceiling of log2(num_entries). If num_entries == 0, return 1.
   uint8_t num_hash_bits = 0;
   size_t num_entries_copy = num_entries;
   while (num_entries_copy >>= 1) {
     ++num_hash_bits;
   }
-  // Compute the ceiling of log2(num_entries). If num_entries == 0, return 1.
-  return size_t{1} << num_hash_bits < num_entries ? num_hash_bits + 1
-                                                  : num_hash_bits;
+  num_hash_bits += size_t{1} << num_hash_bits < num_entries ? 1 : 0;
+  return num_hash_bits;
 }
 
 void LRUCacheShard::SetCapacity(size_t capacity) {

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -368,7 +368,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
 
  private:
   friend class LRUCache;
-  friend class ROCKSDB_NAMESPACE::fast_lru_cache::FastLRUCacheTest;
+  friend class FastLRUCacheTest;
 
   void LRU_Remove(LRUHandle* e);
   void LRU_Insert(LRUHandle* e);

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -25,6 +25,9 @@ namespace ROCKSDB_NAMESPACE {
 
 namespace fast_lru_cache {
 
+// Forward declaration of friend class.
+class FastLRUCacheTest;
+
 // LRU cache implementation using an open-address hash table.
 //
 // Every slot in the hash table is an LRUHandle. Because handles can be
@@ -365,7 +368,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
 
  private:
   friend class LRUCache;
-  friend class FastLRUCacheTest;
+  friend class ROCKSDB_NAMESPACE::fast_lru_cache::FastLRUCacheTest;
 
   void LRU_Remove(LRUHandle* e);
   void LRU_Insert(LRUHandle* e);
@@ -375,6 +378,11 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
   // This function is not thread safe - it needs to be executed while
   // holding the mutex_.
   void EvictFromLRU(size_t charge, autovector<LRUHandle>* deleted);
+
+  // Returns the charge of a single handle.
+  static size_t CalcEstimatedHandleCharge(
+      size_t estimated_value_size,
+      CacheMetadataChargePolicy metadata_charge_policy);
 
   // Returns the number of bits used to hash an element in the hash
   // table.

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -365,6 +365,8 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
 
  private:
   friend class LRUCache;
+  friend class FastLRUCacheTest;
+
   void LRU_Remove(LRUHandle* e);
   void LRU_Insert(LRUHandle* e);
 

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -244,7 +244,7 @@ class FastLRUCacheTest : public testing::Test {
 
   size_t CalcHandleCharge(size_t estimated_value_size, CacheMetadataChargePolicy metadata_charge_policy) {
     LRUHandle h;
-    h.CalcTotalCharge(estimated_value_size, kDontChargeCacheMetadata);
+    h.CalcTotalCharge(estimated_value_size, metadata_charge_policy);
     return h.total_charge;
   }
 
@@ -308,7 +308,7 @@ TEST_F(FastLRUCacheTest, CalcHashBitsTest) {
 
   // Large capacity.
   capacity = 31924172;
-  estimated_value_size = 1;
+  estimated_value_size = 321;
   metadata_charge_policy = kDefaultCacheMetadataChargePolicy;
   max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
   hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -206,6 +206,7 @@ TEST_F(LRUCacheTest, EntriesWithPriority) {
   ValidateLRUList({"e", "f", "g", "Z", "d"}, 2);
 }
 
+namespace fast_lru_cache {
 // TODO(guido) Consolidate the following FastLRUCache tests with
 // that of LRUCache.
 class FastLRUCacheTest : public testing::Test {
@@ -238,27 +239,34 @@ class FastLRUCacheTest : public testing::Test {
 
   Status Insert(char key, size_t len) { return Insert(std::string(len, key)); }
 
-  uint8_t CalcHashBitsWrapper(size_t capacity, size_t estimated_value_size, CacheMetadataChargePolicy metadata_charge_policy) {
-    return fast_lru_cache::LRUCacheShard::CalcHashBits(capacity, estimated_value_size, metadata_charge_policy);
+  size_t CalcEstimatedHandleChargeWrapper(
+      size_t estimated_value_size,
+      CacheMetadataChargePolicy metadata_charge_policy) {
+    return fast_lru_cache::LRUCacheShard::CalcEstimatedHandleCharge(
+        estimated_value_size, metadata_charge_policy);
   }
 
-  size_t CalcHandleCharge(size_t estimated_value_size, CacheMetadataChargePolicy metadata_charge_policy) {
-    LRUHandle h;
-    h.CalcTotalCharge(estimated_value_size, metadata_charge_policy);
-    return h.total_charge;
+  uint8_t CalcHashBitsWrapper(
+      size_t capacity, size_t estimated_value_size,
+      CacheMetadataChargePolicy metadata_charge_policy) {
+    return fast_lru_cache::LRUCacheShard::CalcHashBits(
+        capacity, estimated_value_size, metadata_charge_policy);
   }
 
+  // Maximum number of items that a shard can hold.
   double CalcMaxOccupancy(size_t capacity, size_t estimated_value_size, CacheMetadataChargePolicy metadata_charge_policy) {
-    size_t handle_charge = CalcHandleCharge(estimated_value_size, metadata_charge_policy);
+    size_t handle_charge =
+        fast_lru_cache::LRUCacheShard::CalcEstimatedHandleCharge(
+            estimated_value_size, metadata_charge_policy);
     return capacity / (fast_lru_cache::kLoadFactor * handle_charge);
   }
 
-  void ExpectTableSizeRoughlyMaxOccupancy(uint8_t hash_bits, double max_occupancy) {
+  bool TableSizeIsAppropriate(uint8_t hash_bits, double max_occupancy) {
     if (hash_bits == 0) {
-      EXPECT_EQ(max_occupancy, 0);
+      return max_occupancy <= 1;
     } else {
-      EXPECT_GE(1 << hash_bits, max_occupancy);
-      EXPECT_LE(1 << (hash_bits - 1), max_occupancy);
+      return (1 << hash_bits >= max_occupancy) &&
+             (1 << (hash_bits - 1) <= max_occupancy);
     }
   }
 
@@ -283,31 +291,35 @@ TEST_F(FastLRUCacheTest, CalcHashBitsTest) {
   CacheMetadataChargePolicy metadata_charge_policy = kDontChargeCacheMetadata;
   double max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
   uint8_t hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
-  ExpectTableSizeRoughlyMaxOccupancy(hash_bits, max_occupancy);
+  EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, max_occupancy));
 
   capacity = 1024;
   estimated_value_size = 1;
   metadata_charge_policy = kFullChargeCacheMetadata;
   max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
   hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
-  ExpectTableSizeRoughlyMaxOccupancy(hash_bits, max_occupancy);
+  EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, max_occupancy));
 
   // No elements fit in cache.
   capacity = 0;
   estimated_value_size = 1;
   metadata_charge_policy = kDontChargeCacheMetadata;
   hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
-  ExpectTableSizeRoughlyMaxOccupancy(hash_bits, 0);
+  EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, 0 /* max_occupancy */));
 
-  // Capacity below the size of a handle, but because the load factor is < 100%
-  // at least one handle will fit.
+  // Set the capacity just below a single handle. Because the load factor is <
+  // 100% at least one handle will fit in the table.
   estimated_value_size = 1;
-  capacity = CalcHandleCharge(1, kDontChargeCacheMetadata) - 1;
-  assert(capacity / fast_lru_cache::kLoadFactor > capacity);
+  size_t handle_charge = CalcEstimatedHandleChargeWrapper(
+      8192 /* estimated_value_size */, kDontChargeCacheMetadata);
+  capacity = handle_charge - 1;
+  // The load factor should be bounded away from 100%.
+  assert(static_cast<size_t>(capacity / fast_lru_cache::kLoadFactor) >
+         handle_charge);
   metadata_charge_policy = kDontChargeCacheMetadata;
   max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
   hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
-  ExpectTableSizeRoughlyMaxOccupancy(hash_bits, max_occupancy);
+  EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, max_occupancy));
 
   // Large capacity.
   capacity = 31924172;
@@ -315,8 +327,10 @@ TEST_F(FastLRUCacheTest, CalcHashBitsTest) {
   metadata_charge_policy = kFullChargeCacheMetadata;
   max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
   hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
-  ExpectTableSizeRoughlyMaxOccupancy(hash_bits, max_occupancy);
+  EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, max_occupancy));
 }
+
+}  // namespace fast_lru_cache
 
 class TestSecondaryCache : public SecondaryCache {
  public:

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -254,7 +254,8 @@ class FastLRUCacheTest : public testing::Test {
   }
 
   // Maximum number of items that a shard can hold.
-  double CalcMaxOccupancy(size_t capacity, size_t estimated_value_size, CacheMetadataChargePolicy metadata_charge_policy) {
+  double CalcMaxOccupancy(size_t capacity, size_t estimated_value_size,
+                          CacheMetadataChargePolicy metadata_charge_policy) {
     size_t handle_charge =
         fast_lru_cache::LRUCacheShard::CalcEstimatedHandleCharge(
             estimated_value_size, metadata_charge_policy);
@@ -289,22 +290,27 @@ TEST_F(FastLRUCacheTest, CalcHashBitsTest) {
   size_t capacity = 1024;
   size_t estimated_value_size = 1;
   CacheMetadataChargePolicy metadata_charge_policy = kDontChargeCacheMetadata;
-  double max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
-  uint8_t hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
+  double max_occupancy =
+      CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
+  uint8_t hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size,
+                                          metadata_charge_policy);
   EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, max_occupancy));
 
   capacity = 1024;
   estimated_value_size = 1;
   metadata_charge_policy = kFullChargeCacheMetadata;
-  max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
-  hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
+  max_occupancy =
+      CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
+  hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size,
+                                  metadata_charge_policy);
   EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, max_occupancy));
 
   // No elements fit in cache.
   capacity = 0;
   estimated_value_size = 1;
   metadata_charge_policy = kDontChargeCacheMetadata;
-  hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
+  hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size,
+                                  metadata_charge_policy);
   EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, 0 /* max_occupancy */));
 
   // Set the capacity just below a single handle. Because the load factor is <
@@ -317,16 +323,20 @@ TEST_F(FastLRUCacheTest, CalcHashBitsTest) {
   assert(static_cast<size_t>(capacity / fast_lru_cache::kLoadFactor) >
          handle_charge);
   metadata_charge_policy = kDontChargeCacheMetadata;
-  max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
-  hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
+  max_occupancy =
+      CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
+  hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size,
+                                  metadata_charge_policy);
   EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, max_occupancy));
 
   // Large capacity.
   capacity = 31924172;
   estimated_value_size = 321;
   metadata_charge_policy = kFullChargeCacheMetadata;
-  max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
-  hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
+  max_occupancy =
+      CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
+  hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size,
+                                  metadata_charge_policy);
   EXPECT_TRUE(TableSizeIsAppropriate(hash_bits, max_occupancy));
 }
 

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -254,8 +254,12 @@ class FastLRUCacheTest : public testing::Test {
   }
 
   void ExpectTableSizeRoughlyMaxOccupancy(uint8_t hash_bits, double max_occupancy) {
-    EXPECT_GT(1 << hash_bits, max_occupancy);
-    EXPECT_LT(1 << (hash_bits - 1), max_occupancy);
+    if (hash_bits == 0) {
+      EXPECT_EQ(max_occupancy, 0);
+    } else {
+      EXPECT_GE(1 << hash_bits, max_occupancy);
+      EXPECT_LE(1 << (hash_bits - 1), max_occupancy);
+    }
   }
 
  private:
@@ -283,18 +287,17 @@ TEST_F(FastLRUCacheTest, CalcHashBitsTest) {
 
   capacity = 1024;
   estimated_value_size = 1;
-  metadata_charge_policy = kDefaultCacheMetadataChargePolicy;
+  metadata_charge_policy = kFullChargeCacheMetadata;
   max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
   hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
   ExpectTableSizeRoughlyMaxOccupancy(hash_bits, max_occupancy);
 
-  // Capacity below the size of a handle. No elements fit in the cache.
-  capacity = 1;
+  // No elements fit in cache.
+  capacity = 0;
   estimated_value_size = 1;
   metadata_charge_policy = kDontChargeCacheMetadata;
-  max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
   hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
-  ExpectTableSizeRoughlyMaxOccupancy(hash_bits, max_occupancy);
+  ExpectTableSizeRoughlyMaxOccupancy(hash_bits, 0);
 
   // Capacity below the size of a handle, but because the load factor is < 100%
   // at least one handle will fit.
@@ -309,7 +312,7 @@ TEST_F(FastLRUCacheTest, CalcHashBitsTest) {
   // Large capacity.
   capacity = 31924172;
   estimated_value_size = 321;
-  metadata_charge_policy = kDefaultCacheMetadataChargePolicy;
+  metadata_charge_policy = kFullChargeCacheMetadata;
   max_occupancy = CalcMaxOccupancy(capacity, estimated_value_size, metadata_charge_policy);
   hash_bits = CalcHashBitsWrapper(capacity, estimated_value_size, metadata_charge_policy);
   ExpectTableSizeRoughlyMaxOccupancy(hash_bits, max_occupancy);


### PR DESCRIPTION
Summary: Calculate the required size of the hash table in FastLRUCache more accurately.

Test plan: ``make -j24 check``