### PR TITLE
Add API for writing wide-column entities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1301,6 +1301,7 @@ if(WITH_TESTS)
         db/version_set_test.cc
         db/wal_manager_test.cc
         db/wal_edit_test.cc
+        db/wide/db_wide_basic_test.cc
         db/wide/wide_column_serialization_test.cc
         db/write_batch_test.cc
         db/write_callback_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1383,6 +1383,9 @@ db_blob_compaction_test: $(OBJ_DIR)/db/blob/db_blob_compaction_test.o $(TEST_LIB
 db_readonly_with_timestamp_test: $(OBJ_DIR)/db/db_readonly_with_timestamp_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+db_wide_basic_test: $(OBJ_DIR)/db/wide/db_wide_basic_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 db_with_timestamp_basic_test: $(OBJ_DIR)/db/db_with_timestamp_basic_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/TARGETS
+++ b/TARGETS
@@ -5240,6 +5240,12 @@ cpp_unittest_wrapper(name="db_wal_test",
             extra_compiler_flags=[])
 
 
+cpp_unittest_wrapper(name="db_wide_basic_test",
+            srcs=["db/wide/db_wide_basic_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
 cpp_unittest_wrapper(name="db_with_timestamp_basic_test",
             srcs=["db/db_with_timestamp_basic_test.cc"],
             deps=[":rocksdb_test_lib"],

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -981,6 +981,21 @@ TEST_F(CompactionIteratorWithSnapshotCheckerTest,
           2 /*earliest_write_conflict_snapshot*/);
 }
 
+// Same as above but with a wide-column entity. In addition to the value getting
+// trimmed, the type of the KV is changed to kTypeValue.
+TEST_F(CompactionIteratorWithSnapshotCheckerTest,
+       KeepSingleDeletionForWriteConflictChecking_WideColumnEntity) {
+  AddSnapshot(2, 0);
+  RunTest({test::KeyStr("a", 2, kTypeSingleDeletion),
+           test::KeyStr("a", 1, kTypeWideColumnEntity)},
+          {"", "fake_entity"},
+          {test::KeyStr("a", 2, kTypeSingleDeletion),
+           test::KeyStr("a", 1, kTypeValue)},
+          {"", ""}, 2 /* last_committed_seq */, nullptr /* merge_operator */,
+          nullptr /* compaction_filter */, false /* bottommost_level */,
+          2 /* earliest_write_conflict_snapshot */);
+}
+
 // Compaction filter should keep uncommitted key as-is, and
 //   * Convert the latest value to deletion, and/or
 //   * if latest value is a merge, apply filter to all subsequent merges.

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -59,7 +59,7 @@ class CompactedDBImpl : public DBImpl {
   Status PutEntity(const WriteOptions& /* options */,
                    ColumnFamilyHandle* /* column_family */,
                    const Slice& /* key */,
-                   const WideColumnDescs& /* column_descs */) override {
+                   const WideColumns& /* columns */) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
 

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -54,12 +54,22 @@ class CompactedDBImpl : public DBImpl {
                      const Slice& /*key*/, const Slice& /*value*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
+
+  using DBImpl::PutEntity;
+  Status PutEntity(const WriteOptions& /* options */,
+                   ColumnFamilyHandle* /* column_family */,
+                   const Slice& /* key */,
+                   const WideColumnDescs& /* column_descs */) override {
+    return Status::NotSupported("Not supported in compacted db mode.");
+  }
+
   using DBImpl::Merge;
   virtual Status Merge(const WriteOptions& /*options*/,
                        ColumnFamilyHandle* /*column_family*/,
                        const Slice& /*key*/, const Slice& /*value*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
+
   using DBImpl::Delete;
   virtual Status Delete(const WriteOptions& /*options*/,
                         ColumnFamilyHandle* /*column_family*/,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -217,6 +217,11 @@ class DBImpl : public DB {
   Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
              const Slice& key, const Slice& ts, const Slice& value) override;
 
+  using DB::PutEntity;
+  Status PutEntity(const WriteOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   const WideColumnDescs& column_descs) override;
+
   using DB::Merge;
   Status Merge(const WriteOptions& options, ColumnFamilyHandle* column_family,
                const Slice& key, const Slice& value) override;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -220,7 +220,7 @@ class DBImpl : public DB {
   using DB::PutEntity;
   Status PutEntity(const WriteOptions& options,
                    ColumnFamilyHandle* column_family, const Slice& key,
-                   const WideColumnDescs& column_descs) override;
+                   const WideColumns& columns) override;
 
   using DB::Merge;
   Status Merge(const WriteOptions& options, ColumnFamilyHandle* column_family,

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -48,6 +48,15 @@ class DBImplReadOnly : public DBImpl {
                      const Slice& /*key*/, const Slice& /*value*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
+
+  using DBImpl::PutEntity;
+  Status PutEntity(const WriteOptions& /* options */,
+                   ColumnFamilyHandle* /* column_family */,
+                   const Slice& /* key */,
+                   const WideColumnDescs& /* column_descs */) override {
+    return Status::NotSupported("Not supported operation in read only mode.");
+  }
+
   using DBImpl::Merge;
   virtual Status Merge(const WriteOptions& /*options*/,
                        ColumnFamilyHandle* /*column_family*/,

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -53,7 +53,7 @@ class DBImplReadOnly : public DBImpl {
   Status PutEntity(const WriteOptions& /* options */,
                    ColumnFamilyHandle* /* column_family */,
                    const Slice& /* key */,
-                   const WideColumnDescs& /* column_descs */) override {
+                   const WideColumns& /* columns */) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -119,6 +119,14 @@ class DBImplSecondary : public DBImpl {
     return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
+  using DBImpl::PutEntity;
+  Status PutEntity(const WriteOptions& /* options */,
+                   ColumnFamilyHandle* /* column_family */,
+                   const Slice& /* key */,
+                   const WideColumnDescs& /* column_descs */) override {
+    return Status::NotSupported("Not supported operation in secondary mode.");
+  }
+
   using DBImpl::Merge;
   Status Merge(const WriteOptions& /*options*/,
                ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -123,7 +123,7 @@ class DBImplSecondary : public DBImpl {
   Status PutEntity(const WriteOptions& /* options */,
                    ColumnFamilyHandle* /* column_family */,
                    const Slice& /* key */,
-                   const WideColumnDescs& /* column_descs */) override {
+                   const WideColumns& /* columns */) override {
     return Status::NotSupported("Not supported operation in secondary mode.");
   }
 

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2257,7 +2257,7 @@ Status DB::PutEntity(const WriteOptions& options,
   assert(default_cf_ucmp);
 
   WriteBatch batch(/* reserved_bytes */ 0, /* max_bytes */ 0,
-                   /* protection_bytes_per_key */ 0,
+                   options.protection_bytes_per_key,
                    default_cf_ucmp->timestamp_size());
 
   const Status s = batch.PutEntity(column_family, key, columns);

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -37,6 +37,17 @@ Status DBImpl::Put(const WriteOptions& o, ColumnFamilyHandle* column_family,
   return DB::Put(o, column_family, key, ts, val);
 }
 
+Status DBImpl::PutEntity(const WriteOptions& options,
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         const WideColumnDescs& column_descs) {
+  const Status s = FailIfCfHasTs(column_family);
+  if (!s.ok()) {
+    return s;
+  }
+
+  return DB::PutEntity(options, column_family, key, column_descs);
+}
+
 Status DBImpl::Merge(const WriteOptions& o, ColumnFamilyHandle* column_family,
                      const Slice& key, const Slice& val) {
   const Status s = FailIfCfHasTs(column_family);
@@ -2234,6 +2245,13 @@ Status DB::Put(const WriteOptions& opt, ColumnFamilyHandle* column_family,
     return s;
   }
   return Write(opt, &batch);
+}
+
+Status DB::PutEntity(const WriteOptions& /* options */,
+                     ColumnFamilyHandle* /* column_family */,
+                     const Slice& /* key */,
+                     const WideColumnDescs& /* column_descs */) {
+  return Status::OK();
 }
 
 Status DB::Delete(const WriteOptions& opt, ColumnFamilyHandle* column_family,

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -39,13 +39,13 @@ Status DBImpl::Put(const WriteOptions& o, ColumnFamilyHandle* column_family,
 
 Status DBImpl::PutEntity(const WriteOptions& options,
                          ColumnFamilyHandle* column_family, const Slice& key,
-                         const WideColumnDescs& column_descs) {
+                         const WideColumns& columns) {
   const Status s = FailIfCfHasTs(column_family);
   if (!s.ok()) {
     return s;
   }
 
-  return DB::PutEntity(options, column_family, key, column_descs);
+  return DB::PutEntity(options, column_family, key, columns);
 }
 
 Status DBImpl::Merge(const WriteOptions& o, ColumnFamilyHandle* column_family,
@@ -2249,7 +2249,7 @@ Status DB::Put(const WriteOptions& opt, ColumnFamilyHandle* column_family,
 
 Status DB::PutEntity(const WriteOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
-                     const WideColumnDescs& column_descs) {
+                     const WideColumns& columns) {
   const ColumnFamilyHandle* const default_cf = DefaultColumnFamily();
   assert(default_cf);
 
@@ -2260,7 +2260,7 @@ Status DB::PutEntity(const WriteOptions& options,
                    /* protection_bytes_per_key */ 0,
                    default_cf_ucmp->timestamp_size());
 
-  const Status s = batch.PutEntity(column_family, key, column_descs);
+  const Status s = batch.PutEntity(column_family, key, columns);
   if (!s.ok()) {
     return s;
   }

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -211,7 +211,7 @@ bool DBIter::SetWideColumnValueIfNeeded(const Slice& /* wide_columns_slice */) {
   assert(!is_blob_);
 
   // TODO: support wide-column entities
-  status_ = Status::Corruption("Encountered unexpected wide-column entity");
+  status_ = Status::NotSupported("Encountered unexpected wide-column entity");
   valid_ = false;
   return false;
 }

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -599,6 +599,7 @@ bool DBIter::MergeValuesNewToOld() {
       }
       return true;
     } else if (kTypeWideColumnEntity == ikey.type) {
+      // TODO: support wide-column entities
       status_ = Status::NotSupported(
           "Merge currently not supported for wide-column entities");
       valid_ = false;
@@ -953,6 +954,7 @@ bool DBIter::FindValueForCurrentKey() {
         is_blob_ = false;
         return true;
       } else if (last_not_merge_type == kTypeWideColumnEntity) {
+        // TODO: support wide-column entities
         status_ = Status::NotSupported(
             "Merge currently not supported for wide-column entities");
         valid_ = false;
@@ -1150,6 +1152,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
       is_blob_ = false;
       return true;
     } else if (ikey.type == kTypeWideColumnEntity) {
+      // TODO: support wide-column entities
       status_ = Status::NotSupported(
           "Merge currently not supported for wide-column entities");
       valid_ = false;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -552,7 +552,7 @@ bool DBIter::MergeValuesNewToOld() {
       return false;
     }
 
-    if (kTypeValue == ikey.type || kTypeWideColumnEntity == ikey.type) {
+    if (kTypeValue == ikey.type) {
       // hit a put, merge the put value with operands and store the
       // final result in saved_value_. We are done!
       const Slice val = iter_.value();
@@ -599,6 +599,11 @@ bool DBIter::MergeValuesNewToOld() {
         return false;
       }
       return true;
+    } else if (kTypeWideColumnEntity == ikey.type) {
+      status_ = Status::NotSupported(
+          "Merge currently not supported for wide-column entities");
+      valid_ = false;
+      return false;
     } else {
       valid_ = false;
       status_ = Status::Corruption(

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -207,8 +207,7 @@ bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
   return true;
 }
 
-bool DBIter::SetWideColumnEntityValueIfNeeded(
-    const Slice& /* wide_column_entity */) {
+bool DBIter::SetWideColumnValueIfNeeded(const Slice& /* wide_columns_slice */) {
   assert(!is_blob_);
 
   // TODO: support wide-column entities
@@ -360,7 +359,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
                   return false;
                 }
               } else if (ikey_.type == kTypeWideColumnEntity) {
-                if (!SetWideColumnEntityValueIfNeeded(iter_.value())) {
+                if (!SetWideColumnValueIfNeeded(iter_.value())) {
                   return false;
                 }
               }
@@ -385,7 +384,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
                     return false;
                   }
                 } else if (ikey_.type == kTypeWideColumnEntity) {
-                  if (!SetWideColumnEntityValueIfNeeded(iter_.value())) {
+                  if (!SetWideColumnValueIfNeeded(iter_.value())) {
                     return false;
                   }
                 }
@@ -972,7 +971,7 @@ bool DBIter::FindValueForCurrentKey() {
       }
       break;
     case kTypeWideColumnEntity:
-      if (!SetWideColumnEntityValueIfNeeded(pinned_value_)) {
+      if (!SetWideColumnValueIfNeeded(pinned_value_)) {
         return false;
       }
       break;
@@ -1075,7 +1074,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
         return false;
       }
     } else if (ikey_.type == kTypeWideColumnEntity) {
-      if (!SetWideColumnEntityValueIfNeeded(pinned_value_)) {
+      if (!SetWideColumnValueIfNeeded(pinned_value_)) {
         return false;
       }
     }

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -298,7 +298,7 @@ class DBIter final : public Iterator {
   // index when using the integrated BlobDB implementation.
   bool SetBlobValueIfNeeded(const Slice& user_key, const Slice& blob_index);
 
-  bool SetWideColumnEntityValueIfNeeded(const Slice& wide_column_entity);
+  bool SetWideColumnValueIfNeeded(const Slice& wide_columns_slice);
 
   Status Merge(const Slice* val, const Slice& user_key);
 

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -298,6 +298,8 @@ class DBIter final : public Iterator {
   // index when using the integrated BlobDB implementation.
   bool SetBlobValueIfNeeded(const Slice& user_key, const Slice& blob_index);
 
+  bool SetWideColumnEntityValueIfNeeded(const Slice& wide_column_entity);
+
   Status Merge(const Slice* val, const Slice& user_key);
 
   const SliceTransform* prefix_extractor_;

--- a/db/db_kv_checksum_test.cc
+++ b/db/db_kv_checksum_test.cc
@@ -64,7 +64,8 @@ std::pair<WriteBatch, Status> GetWriteBatch(ColumnFamilyHandle* cf_handle,
       s = wb.Merge(cf_handle, "key", "val");
       break;
     case WriteBatchOpType::kPutEntity:
-      s = wb.PutEntity(cf_handle, "key", {{"foo", "bar"}, {"hello", "world"}});
+      s = wb.PutEntity(cf_handle, "key",
+                       {{"attr_name1", "foo"}, {"attr_name2", "bar"}});
       break;
     case WriteBatchOpType::kNum:
       assert(false);

--- a/db/db_kv_checksum_test.cc
+++ b/db/db_kv_checksum_test.cc
@@ -15,6 +15,7 @@ enum class WriteBatchOpType {
   kSingleDelete,
   kDeleteRange,
   kMerge,
+  kPutEntity,
   kNum,
 };
 
@@ -61,6 +62,9 @@ std::pair<WriteBatch, Status> GetWriteBatch(ColumnFamilyHandle* cf_handle,
       break;
     case WriteBatchOpType::kMerge:
       s = wb.Merge(cf_handle, "key", "val");
+      break;
+    case WriteBatchOpType::kPutEntity:
+      s = wb.PutEntity(cf_handle, "key", {{"foo", "bar"}, {"hello", "world"}});
       break;
     case WriteBatchOpType::kNum:
       assert(false);
@@ -135,10 +139,10 @@ std::string GetOpTypeString(const WriteBatchOpType& op_type) {
       return "SingleDelete";
     case WriteBatchOpType::kDeleteRange:
       return "DeleteRange";
-      break;
     case WriteBatchOpType::kMerge:
       return "Merge";
-      break;
+    case WriteBatchOpType::kPutEntity:
+      return "PutEntity";
     case WriteBatchOpType::kNum:
       assert(false);
   }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2902,7 +2902,7 @@ class ModelDB : public DB {
   Status PutEntity(const WriteOptions& /* options */,
                    ColumnFamilyHandle* /* column_family */,
                    const Slice& /* key */,
-                   const WideColumnDescs& /* column_descs */) override {
+                   const WideColumns& /* columns */) override {
     return Status::NotSupported();
   }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2897,6 +2897,15 @@ class ModelDB : public DB {
              const Slice& /*v*/) override {
     return Status::NotSupported();
   }
+
+  using DB::PutEntity;
+  Status PutEntity(const WriteOptions& /* options */,
+                   ColumnFamilyHandle* /* column_family */,
+                   const Slice& /* key */,
+                   const WideColumnDescs& /* column_descs */) override {
+    return Status::NotSupported();
+  }
+
   using DB::Close;
   Status Close() override { return Status::OK(); }
   using DB::Delete;

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -18,7 +18,6 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/types.h"
-#include "rocksdb/wide_columns.h"
 #include "util/coding.h"
 #include "util/user_comparator_wrapper.h"
 
@@ -672,8 +671,7 @@ extern bool ReadKeyFromWriteBatchEntry(Slice* input, Slice* key,
 // input will be advanced to after the record.
 extern Status ReadRecordFromWriteBatch(Slice* input, char* tag,
                                        uint32_t* column_family, Slice* key,
-                                       Slice* value, Slice* blob, Slice* xid,
-                                       WideColumnDescs* column_descs);
+                                       Slice* value, Slice* blob, Slice* xid);
 
 // When user call DeleteRange() to delete a range of keys,
 // we will store a serialized RangeTombstone in MemTable and SST.

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -18,6 +18,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/types.h"
+#include "rocksdb/wide_columns.h"
 #include "util/coding.h"
 #include "util/user_comparator_wrapper.h"
 
@@ -671,7 +672,8 @@ extern bool ReadKeyFromWriteBatchEntry(Slice* input, Slice* key,
 // input will be advanced to after the record.
 extern Status ReadRecordFromWriteBatch(Slice* input, char* tag,
                                        uint32_t* column_family, Slice* key,
-                                       Slice* value, Slice* blob, Slice* xid);
+                                       Slice* value, Slice* blob, Slice* xid,
+                                       WideColumnDescs* column_descs);
 
 // When user call DeleteRange() to delete a range of keys,
 // we will store a serialized RangeTombstone in MemTable and SST.

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -751,6 +751,9 @@ static bool SaveValue(void* arg, const char* entry) {
           *(s->status) = Status::NotSupported(
               "Encounter unsupported blob value. Please open DB with "
               "ROCKSDB_NAMESPACE::blob_db::BlobDB instead.");
+        } else if (type == kTypeWideColumnEntity) {
+          *(s->status) =
+              Status::NotSupported("Encountered unexpected wide-column entity");
         } else if (*(s->merge_in_progress)) {
           *(s->status) = Status::NotSupported("Merge operator not supported");
         } else if (!s->do_merge) {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -746,19 +746,23 @@ static bool SaveValue(void* arg, const char* entry) {
     switch (type) {
       case kTypeBlobIndex:
       case kTypeWideColumnEntity:
-        if (type == kTypeBlobIndex && s->is_blob_index == nullptr) {
-          ROCKS_LOG_ERROR(s->logger, "Encounter unexpected blob index.");
-          *(s->status) = Status::NotSupported(
-              "Encounter unsupported blob value. Please open DB with "
-              "ROCKSDB_NAMESPACE::blob_db::BlobDB instead.");
-        } else if (type == kTypeWideColumnEntity) {
-          // TODO: support wide-column entities
-          *(s->status) =
-              Status::NotSupported("Encountered unexpected wide-column entity");
-        } else if (*(s->merge_in_progress)) {
+        if (*(s->merge_in_progress)) {
           *(s->status) = Status::NotSupported("Merge operator not supported");
         } else if (!s->do_merge) {
           *(s->status) = Status::NotSupported("GetMergeOperands not supported");
+        } else if (type == kTypeBlobIndex) {
+          if (s->is_blob_index == nullptr) {
+            ROCKS_LOG_ERROR(s->logger, "Encounter unexpected blob index.");
+            *(s->status) = Status::NotSupported(
+                "Encounter unsupported blob value. Please open DB with "
+                "ROCKSDB_NAMESPACE::blob_db::BlobDB instead.");
+          }
+        } else {
+          assert(type == kTypeWideColumnEntity);
+
+          // TODO: support wide-column entities
+          *(s->status) =
+              Status::NotSupported("Encountered unexpected wide-column entity");
         }
 
         if (!s->status->ok()) {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -752,6 +752,7 @@ static bool SaveValue(void* arg, const char* entry) {
               "Encounter unsupported blob value. Please open DB with "
               "ROCKSDB_NAMESPACE::blob_db::BlobDB instead.");
         } else if (type == kTypeWideColumnEntity) {
+          // TODO: support wide-column entities
           *(s->status) =
               Status::NotSupported("Encountered unexpected wide-column entity");
         } else if (*(s->merge_in_progress)) {

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -212,11 +212,15 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
       const Slice val = iter->value();
       PinnableSlice blob_value;
       const Slice* val_ptr;
-      if ((kTypeValue == ikey.type || kTypeBlobIndex == ikey.type) &&
+      if ((kTypeValue == ikey.type || kTypeBlobIndex == ikey.type ||
+           kTypeWideColumnEntity == ikey.type) &&
           (range_del_agg == nullptr ||
            !range_del_agg->ShouldDelete(
                ikey, RangeDelPositioningMode::kForwardTraversal))) {
-        if (ikey.type == kTypeBlobIndex) {
+        if (ikey.type == kTypeWideColumnEntity) {
+          return Status::NotSupported(
+              "Merge currently not supported for wide-column entities");
+        } else if (ikey.type == kTypeBlobIndex) {
           BlobIndex blob_index;
 
           s = blob_index.DecodeFrom(val);

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -218,6 +218,7 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
            !range_del_agg->ShouldDelete(
                ikey, RangeDelPositioningMode::kForwardTraversal))) {
         if (ikey.type == kTypeWideColumnEntity) {
+          // TODO: support wide-column entities
           return Status::NotSupported(
               "Merge currently not supported for wide-column entities");
         } else if (ikey.type == kTypeBlobIndex) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2161,6 +2161,10 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
             "Encounter unexpected blob index. Please open DB with "
             "ROCKSDB_NAMESPACE::blob_db::BlobDB instead.");
         return;
+      case GetContext::kUnexpectedWideColumnEntity:
+        *status =
+            Status::NotSupported("Encountered unexpected wide-column entity");
+        return;
     }
     f = fp.GetNextFile();
   }

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -141,6 +141,11 @@ DEFINE_SYNC_AND_ASYNC(Status, Version::MultiGetFromSST)
             "ROCKSDB_NAMESPACE::blob_db::BlobDB instead.");
         file_range.MarkKeyDone(iter);
         continue;
+      case GetContext::kUnexpectedWideColumnEntity:
+        *status =
+            Status::NotSupported("Encountered unexpected wide-column entity");
+        file_range.MarkKeyDone(iter);
+        continue;
     }
   }
 

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -96,6 +96,26 @@ TEST_F(DBWideBasicTest, PutAndReadEntity) {
   verify();
 }
 
+TEST_F(DBWideBasicTest, PutEntityColumnFamily) {
+  Options options = GetDefaultOptions();
+  CreateAndReopenWithCF({"corinthian"}, options);
+
+  // Use the DB::PutEntity API
+  constexpr char first_key[] = "first";
+  WideColumns first_columns{{"foo", "bar"}, {"hello", "world"}};
+
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), handles_[1], first_key, first_columns));
+
+  // Use WriteBatch
+  constexpr char second_key[] = "second";
+  WideColumns second_columns{{"one", "two"}, {"three", "four"}};
+
+  WriteBatch batch;
+  ASSERT_OK(batch.PutEntity(handles_[1], second_key, second_columns));
+  ASSERT_OK(db_->Write(WriteOptions(), &batch));
+}
+
 TEST_F(DBWideBasicTest, PutEntityError) {
   Options options = GetDefaultOptions();
 

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -119,6 +119,8 @@ TEST_F(DBWideBasicTest, PutEntityColumnFamily) {
 }
 
 TEST_F(DBWideBasicTest, PutEntityTimestampError) {
+  // Note: timestamps are currently not supported
+
   Options options = GetDefaultOptions();
   options.comparator = test::BytewiseComparatorWithU64TsWrapper();
 
@@ -144,6 +146,8 @@ TEST_F(DBWideBasicTest, PutEntityTimestampError) {
 }
 
 TEST_F(DBWideBasicTest, PutEntitySerializationError) {
+  // Make sure duplicate columns are caught
+
   Options options = GetDefaultOptions();
 
   // Use the DB::PutEntity API

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -22,8 +22,6 @@ class DBWideBasicTest : public DBTestBase {
 TEST_F(DBWideBasicTest, PutEntity) {
   Options options = GetDefaultOptions();
 
-  constexpr size_t num_keys = 2;
-
   // Use the DB::PutEntity API
   constexpr char first_key[] = "first";
   WideColumns first_columns{{"foo", "bar"}, {"hello", "world"}};
@@ -57,6 +55,8 @@ TEST_F(DBWideBasicTest, PutEntity) {
     }
 
     {
+      constexpr size_t num_keys = 2;
+
       std::array<Slice, num_keys> keys{{first_key, second_key}};
       std::array<PinnableSlice, num_keys> values;
       std::array<Status, num_keys> statuses;

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -24,14 +24,14 @@ TEST_F(DBWideBasicTest, PutEntity) {
 
   // Use the DB::PutEntity API
   constexpr char first_key[] = "first";
-  WideColumns first_columns{{"foo", "bar"}, {"hello", "world"}};
+  WideColumns first_columns{{"attr_name1", "foo"}, {"attr_name2", "bar"}};
 
   ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
                            first_key, first_columns));
 
   // Use WriteBatch
   constexpr char second_key[] = "second";
-  WideColumns second_columns{{"one", "two"}, {"three", "four"}};
+  WideColumns second_columns{{"attr_one", "two"}, {"attr_three", "four"}};
 
   WriteBatch batch;
   ASSERT_OK(
@@ -138,14 +138,14 @@ TEST_F(DBWideBasicTest, PutEntityColumnFamily) {
 
   // Use the DB::PutEntity API
   constexpr char first_key[] = "first";
-  WideColumns first_columns{{"foo", "bar"}, {"hello", "world"}};
+  WideColumns first_columns{{"attr_name1", "foo"}, {"attr_name2", "bar"}};
 
   ASSERT_OK(
       db_->PutEntity(WriteOptions(), handles_[1], first_key, first_columns));
 
   // Use WriteBatch
   constexpr char second_key[] = "second";
-  WideColumns second_columns{{"one", "two"}, {"three", "four"}};
+  WideColumns second_columns{{"attr_one", "two"}, {"attr_three", "four"}};
 
   WriteBatch batch;
   ASSERT_OK(batch.PutEntity(handles_[1], second_key, second_columns));
@@ -164,7 +164,7 @@ TEST_F(DBWideBasicTest, PutEntityTimestampError) {
 
   // Use the DB::PutEntity API
   constexpr char first_key[] = "first";
-  WideColumns first_columns{{"foo", "bar"}, {"hello", "world"}};
+  WideColumns first_columns{{"attr_name1", "foo"}, {"attr_name2", "bar"}};
 
   ASSERT_TRUE(db_->PutEntity(WriteOptions(), handle, first_key, first_columns)
                   .IsInvalidArgument());

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -4,13 +4,9 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include <array>
-#include <sstream>
-#include <string>
 
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
-#include "test_util/sync_point.h"
-#include "utilities/fault_injection_env.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -23,64 +19,81 @@ class DBWideBasicTest : public DBTestBase {
 TEST_F(DBWideBasicTest, Entity) {
   Options options = GetDefaultOptions();
 
-  constexpr char key[] = "key";
-  WideColumns columns{{"foo", "bar"}, {"hello", "world"}};
+  constexpr size_t num_keys = 2;
 
+  // Use the DB::PutEntity API
+  constexpr char first_key[] = "first";
+  WideColumns first_columns{{"foo", "bar"}, {"hello", "world"}};
+
+  ASSERT_OK(db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(),
+                           first_key, first_columns));
+
+  // Use WriteBatch
+  constexpr char second_key[] = "second";
+  WideColumns second_columns{{"one", "two"}, {"three", "four"}};
+
+  WriteBatch batch;
   ASSERT_OK(
-      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key, columns));
+      batch.PutEntity(db_->DefaultColumnFamily(), second_key, second_columns));
+  ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+  // Note: currently, read APIs are supposed to return NotSupported
+  auto verify = [&]() {
+    {
+      PinnableSlice result;
+      ASSERT_TRUE(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), first_key,
+                           &result)
+                      .IsNotSupported());
+    }
+
+    {
+      PinnableSlice result;
+      ASSERT_TRUE(db_->Get(ReadOptions(), db_->DefaultColumnFamily(),
+                           second_key, &result)
+                      .IsNotSupported());
+    }
+
+    {
+      std::array<Slice, num_keys> keys{{first_key, second_key}};
+      std::array<PinnableSlice, num_keys> values;
+      std::array<Status, num_keys> statuses;
+
+      db_->MultiGet(ReadOptions(), db_->DefaultColumnFamily(), num_keys,
+                    &keys[0], &values[0], &statuses[0]);
+
+      ASSERT_TRUE(values[0].empty());
+      ASSERT_TRUE(statuses[0].IsNotSupported());
+
+      ASSERT_TRUE(values[1].empty());
+      ASSERT_TRUE(statuses[1].IsNotSupported());
+    }
+
+    {
+      std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+
+      iter->SeekToFirst();
+      ASSERT_FALSE(iter->Valid());
+      ASSERT_TRUE(iter->status().IsNotSupported());
+
+      iter->SeekToLast();
+      ASSERT_FALSE(iter->Valid());
+      ASSERT_TRUE(iter->status().IsNotSupported());
+    }
+  };
 
   // Try reading from memtable
-  {
-    PinnableSlice result;
-    ASSERT_TRUE(
-        db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
-            .IsNotSupported());
-  }
+  verify();
 
-  {
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
-
-    iter->SeekToFirst();
-    ASSERT_FALSE(iter->Valid());
-    ASSERT_TRUE(iter->status().IsNotSupported());
-  }
-
+  // Try reading after recovery
   options.avoid_flush_during_recovery = true;
   Reopen(options);
 
-  // Try reading after recovery
-  {
-    PinnableSlice result;
-    ASSERT_TRUE(
-        db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
-            .IsNotSupported());
-  }
-
-  {
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
-
-    iter->SeekToFirst();
-    ASSERT_FALSE(iter->Valid());
-    ASSERT_TRUE(iter->status().IsNotSupported());
-  }
-
-  ASSERT_OK(Flush());
+  verify();
 
   // Try reading from storage
-  {
-    PinnableSlice result;
-    ASSERT_TRUE(
-        db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
-            .IsNotSupported());
-  }
+  ASSERT_OK(Flush());
 
-  {
-    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
-
-    iter->SeekToFirst();
-    ASSERT_FALSE(iter->Valid());
-    ASSERT_TRUE(iter->status().IsNotSupported());
-  }
+  verify();
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -15,7 +15,7 @@ namespace ROCKSDB_NAMESPACE {
 
 class DBWideBasicTest : public DBTestBase {
  protected:
-  DBWideBasicTest()
+  explicit DBWideBasicTest()
       : DBTestBase("db_wide_basic_test", /* env_do_fsync */ false) {}
 };
 

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -1,0 +1,92 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <array>
+#include <sstream>
+#include <string>
+
+#include "db/db_test_util.h"
+#include "port/stack_trace.h"
+#include "test_util/sync_point.h"
+#include "utilities/fault_injection_env.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class DBWideBasicTest : public DBTestBase {
+ protected:
+  DBWideBasicTest()
+      : DBTestBase("db_wide_basic_test", /* env_do_fsync */ false) {}
+};
+
+TEST_F(DBWideBasicTest, Entity) {
+  Options options = GetDefaultOptions();
+
+  constexpr char key[] = "key";
+  WideColumns columns{{"foo", "bar"}, {"hello", "world"}};
+
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), db_->DefaultColumnFamily(), key, columns));
+
+  // Try reading from memtable
+  {
+    PinnableSlice result;
+    ASSERT_TRUE(
+        db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
+            .IsNotSupported());
+  }
+
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_TRUE(iter->status().IsNotSupported());
+  }
+
+  Reopen(options);
+
+  // Try reading after recovery
+  {
+    PinnableSlice result;
+    ASSERT_TRUE(
+        db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
+            .IsNotSupported());
+  }
+
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_TRUE(iter->status().IsNotSupported());
+  }
+
+  ASSERT_OK(Flush());
+
+  // Try reading from storage
+  {
+    PinnableSlice result;
+    ASSERT_TRUE(
+        db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
+            .IsNotSupported());
+  }
+
+  {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_TRUE(iter->status().IsNotSupported());
+  }
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  RegisterCustomObjects(argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -45,6 +45,7 @@ TEST_F(DBWideBasicTest, Entity) {
     ASSERT_TRUE(iter->status().IsNotSupported());
   }
 
+  options.avoid_flush_during_recovery = true;
   Reopen(options);
 
   // Try reading after recovery

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -124,6 +124,14 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
   }
 }
 
+TEST(WideColumnSerializationTest, SerializeOutOfOrderError) {
+  WideColumns columns{{"hello", "world"}, {"foo", "bar"}};
+  std::string output;
+
+  ASSERT_TRUE(
+      WideColumnSerialization::Serialize(columns, output).IsCorruption());
+}
+
 TEST(WideColumnSerializationTest, DeserializeVersionError) {
   // Can't decode version
 

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -124,6 +124,14 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
   }
 }
 
+TEST(WideColumnSerializationTest, SerializeDuplicateError) {
+  WideColumns columns{{"foo", "bar"}, {"foo", "baz"}};
+  std::string output;
+
+  ASSERT_TRUE(
+      WideColumnSerialization::Serialize(columns, output).IsCorruption());
+}
+
 TEST(WideColumnSerializationTest, SerializeOutOfOrderError) {
   WideColumns columns{{"hello", "world"}, {"foo", "bar"}};
   std::string output;

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -930,7 +930,7 @@ Status WriteBatch::Put(ColumnFamilyHandle* column_family, const SliceParts& key,
 
 Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
                                      const Slice& key,
-                                     const WideColumnDescs& column_descs) {
+                                     const WideColumns& columns) {
   assert(b);
 
   if (key.size() > size_t{std::numeric_limits<uint32_t>::max()}) {
@@ -938,7 +938,7 @@ Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
   }
 
   std::string entity;
-  const Status s = WideColumnSerialization::Serialize(column_descs, entity);
+  const Status s = WideColumnSerialization::Serialize(columns, entity);
   if (!s.ok()) {
     return s;
   }
@@ -976,8 +976,7 @@ Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
 }
 
 Status WriteBatch::PutEntity(ColumnFamilyHandle* column_family,
-                             const Slice& key,
-                             const WideColumnDescs& column_descs) {
+                             const Slice& key, const WideColumns& columns) {
   Status s;
   uint32_t cf_id = 0;
   size_t ts_sz = 0;
@@ -995,7 +994,7 @@ Status WriteBatch::PutEntity(ColumnFamilyHandle* column_family,
         "Cannot call this method on column family enabling timestamp");
   }
 
-  return WriteBatchInternal::PutEntity(this, cf_id, key, column_descs);
+  return WriteBatchInternal::PutEntity(this, cf_id, key, columns);
 }
 
 Status WriteBatchInternal::InsertNoop(WriteBatch* b) {

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -2904,6 +2904,11 @@ class ProtectionInfoUpdater : public WriteBatch::Handler {
     return UpdateProtInfo(cf, key, val, kTypeValue);
   }
 
+  Status PutEntityCF(uint32_t cf, const Slice& key,
+                     const Slice& entity) override {
+    return UpdateProtInfo(cf, key, entity, kTypeWideColumnEntity);
+  }
+
   Status DeleteCF(uint32_t cf, const Slice& key) override {
     return UpdateProtInfo(cf, key, "", kTypeDeletion);
   }

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -941,7 +941,7 @@ Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
   WideColumns sorted_columns(columns);
   std::sort(sorted_columns.begin(), sorted_columns.end(),
             [](const WideColumn& lhs, const WideColumn& rhs) {
-              return lhs.name().compare(rhs.name()) > 0;
+              return lhs.name().compare(rhs.name()) < 0;
             });
 
   std::string entity;

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -38,6 +38,7 @@
 
 #include "rocksdb/write_batch.h"
 
+#include <algorithm>
 #include <limits>
 #include <map>
 #include <stack>
@@ -937,8 +938,14 @@ Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
     return Status::InvalidArgument("key is too large");
   }
 
+  WideColumns sorted_columns(columns);
+  std::sort(sorted_columns.begin(), sorted_columns.end(),
+            [](const WideColumn& lhs, const WideColumn& rhs) {
+              return lhs.name().compare(rhs.name()) > 0;
+            });
+
   std::string entity;
-  const Status s = WideColumnSerialization::Serialize(columns, entity);
+  const Status s = WideColumnSerialization::Serialize(sorted_columns, entity);
   if (!s.ok()) {
     return s;
   }

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -38,6 +38,7 @@
 
 #include "rocksdb/write_batch.h"
 
+#include <limits>
 #include <map>
 #include <stack>
 #include <stdexcept>
@@ -932,17 +933,17 @@ Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
                                      const WideColumnDescs& column_descs) {
   assert(b);
 
-  if (key.size() > size_t{port::kMaxUint32}) {
+  if (key.size() > size_t{std::numeric_limits<uint32_t>::max()}) {
     return Status::InvalidArgument("key is too large");
   }
 
   std::string entity;
-  const Status s = WideColumnSerialization::Serialize(column_descs, &entity);
+  const Status s = WideColumnSerialization::Serialize(column_descs, entity);
   if (!s.ok()) {
     return s;
   }
 
-  if (entity.size() > size_t{port::kMaxUint32}) {
+  if (entity.size() > size_t{std::numeric_limits<uint32_t>::max()}) {
     return Status::InvalidArgument("wide column entity is too large");
   }
 

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -984,6 +984,11 @@ Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
 
 Status WriteBatch::PutEntity(ColumnFamilyHandle* column_family,
                              const Slice& key, const WideColumns& columns) {
+  if (!column_family) {
+    return Status::InvalidArgument(
+        "Cannot call this method without a column family handle");
+  }
+
   Status s;
   uint32_t cf_id = 0;
   size_t ts_sz = 0;

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -88,6 +88,10 @@ class WriteBatchInternal {
   static Status Put(WriteBatch* batch, uint32_t column_family_id,
                     const SliceParts& key, const SliceParts& value);
 
+  static Status PutEntity(WriteBatch* batch, uint32_t column_family_id,
+                          const Slice& key,
+                          const WideColumnDescs& column_descs);
+
   static Status Delete(WriteBatch* batch, uint32_t column_family_id,
                        const SliceParts& key);
 

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -89,8 +89,7 @@ class WriteBatchInternal {
                     const SliceParts& key, const SliceParts& value);
 
   static Status PutEntity(WriteBatch* batch, uint32_t column_family_id,
-                          const Slice& key,
-                          const WideColumnDescs& column_descs);
+                          const Slice& key, const WideColumns& columns);
 
   static Status Delete(WriteBatch* batch, uint32_t column_family_id,
                        const SliceParts& key);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -407,6 +407,7 @@ class DB {
     return Put(options, DefaultColumnFamily(), key, ts, value);
   }
 
+  // UNDER CONSTRUCTION -- DO NOT USE
   virtual Status PutEntity(const WriteOptions& options,
                            ColumnFamilyHandle* column_family, const Slice& key,
                            const WideColumns& columns) = 0;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -409,7 +409,7 @@ class DB {
 
   virtual Status PutEntity(const WriteOptions& options,
                            ColumnFamilyHandle* column_family, const Slice& key,
-                           const WideColumnDescs& column_descs) = 0;
+                           const WideColumns& columns) = 0;
 
   // Remove the database entry (if any) for "key".  Returns OK on
   // success, and a non-OK status on error.  It is not an error if "key"

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -27,6 +27,7 @@
 #include "rocksdb/transaction_log.h"
 #include "rocksdb/types.h"
 #include "rocksdb/version.h"
+#include "rocksdb/wide_columns.h"
 
 #ifdef _WIN32
 // Windows API macro interference
@@ -405,6 +406,10 @@ class DB {
                      const Slice& ts, const Slice& value) {
     return Put(options, DefaultColumnFamily(), key, ts, value);
   }
+
+  virtual Status PutEntity(const WriteOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           const WideColumnDescs& column_descs) = 0;
 
   // Remove the database entry (if any) for "key".  Returns OK on
   // success, and a non-OK status on error.  It is not an error if "key"

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -88,8 +88,8 @@ class StackableDB : public DB {
   using DB::PutEntity;
   Status PutEntity(const WriteOptions& options,
                    ColumnFamilyHandle* column_family, const Slice& key,
-                   const WideColumnDescs& column_descs) override {
-    return db_->PutEntity(options, column_family, key, column_descs);
+                   const WideColumns& columns) override {
+    return db_->PutEntity(options, column_family, key, columns);
   }
 
   using DB::Get;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -85,6 +85,13 @@ class StackableDB : public DB {
     return db_->Put(options, column_family, key, ts, val);
   }
 
+  using DB::PutEntity;
+  Status PutEntity(const WriteOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   const WideColumnDescs& column_descs) override {
+    return db_->PutEntity(options, column_family, key, column_descs);
+  }
+
   using DB::Get;
   virtual Status Get(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -115,7 +115,7 @@ class WriteBatchWithIndex : public WriteBatchBase {
 
   Status PutEntity(ColumnFamilyHandle* /* column_family */,
                    const Slice& /* key */,
-                   const WideColumnDescs& /* column_descs */) override {
+                   const WideColumns& /* columns */) override {
     return Status::NotSupported(
         "PutEntity not supported by WriteBatchWithIndex");
   }

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -113,9 +113,13 @@ class WriteBatchWithIndex : public WriteBatchBase {
   Status Put(ColumnFamilyHandle* column_family, const Slice& key,
              const Slice& ts, const Slice& value) override;
 
-  Status PutEntity(ColumnFamilyHandle* /* column_family */,
-                   const Slice& /* key */,
+  Status PutEntity(ColumnFamilyHandle* column_family, const Slice& /* key */,
                    const WideColumns& /* columns */) override {
+    if (!column_family) {
+      return Status::InvalidArgument(
+          "Cannot call this method without a column family handle");
+    }
+
     return Status::NotSupported(
         "PutEntity not supported by WriteBatchWithIndex");
   }

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -113,6 +113,13 @@ class WriteBatchWithIndex : public WriteBatchBase {
   Status Put(ColumnFamilyHandle* column_family, const Slice& key,
              const Slice& ts, const Slice& value) override;
 
+  Status PutEntity(ColumnFamilyHandle* /* column_family */,
+                   const Slice& /* key */,
+                   const WideColumnDescs& /* column_descs */) override {
+    return Status::NotSupported(
+        "PutEntity not supported by WriteBatchWithIndex");
+  }
+
   using WriteBatchBase::Merge;
   Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
                const Slice& value) override;

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -247,7 +247,7 @@ class WriteBatch : public WriteBatchBase {
     virtual Status PutEntityCF(uint32_t /* column_family_id */,
                                const Slice& /* key */,
                                const Slice& /* entity */) {
-      return Status::InvalidArgument("PutEntityCF not implemented");
+      return Status::NotSupported("PutEntityCF not implemented");
     }
 
     virtual Status DeleteCF(uint32_t column_family_id, const Slice& key) {

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -102,7 +102,7 @@ class WriteBatch : public WriteBatchBase {
 
   using WriteBatchBase::PutEntity;
   Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
-                   const WideColumnDescs& column_descs) override;
+                   const WideColumns& columns) override;
 
   using WriteBatchBase::Delete;
   // If the database contains a mapping for "key", erase it.  Else do nothing.

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -246,7 +246,7 @@ class WriteBatch : public WriteBatchBase {
 
     virtual Status PutEntityCF(uint32_t /* column_family_id */,
                                const Slice& /* key */,
-                               const WideColumnDescs& /* column_descs */) {
+                               const Slice& /* entity */) {
       return Status::InvalidArgument("PutEntityCF not implemented");
     }
 

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -100,6 +100,7 @@ class WriteBatch : public WriteBatchBase {
     return Put(nullptr, key, value);
   }
 
+  // UNDER CONSTRUCTION -- DO NOT USE
   using WriteBatchBase::PutEntity;
   Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
                    const WideColumns& columns) override;

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -100,6 +100,10 @@ class WriteBatch : public WriteBatchBase {
     return Put(nullptr, key, value);
   }
 
+  using WriteBatchBase::PutEntity;
+  Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
+                   const WideColumnDescs& column_descs) override;
+
   using WriteBatchBase::Delete;
   // If the database contains a mapping for "key", erase it.  Else do nothing.
   // The following Delete(..., const Slice& key) can be used when user-defined
@@ -240,6 +244,12 @@ class WriteBatch : public WriteBatchBase {
     }
     virtual void Put(const Slice& /*key*/, const Slice& /*value*/) {}
 
+    virtual Status PutEntityCF(uint32_t /* column_family_id */,
+                               const Slice& /* key */,
+                               const WideColumnDescs& /* column_descs */) {
+      return Status::InvalidArgument("PutEntityCF not implemented");
+    }
+
     virtual Status DeleteCF(uint32_t column_family_id, const Slice& key) {
       if (column_family_id == 0) {
         Delete(key);
@@ -345,6 +355,9 @@ class WriteBatch : public WriteBatchBase {
 
   // Returns true if PutCF will be called during Iterate
   bool HasPut() const;
+
+  // Returns true if PutEntityCF will be called during Iterate
+  bool HasPutEntity() const;
 
   // Returns true if DeleteCF will be called during Iterate
   bool HasDelete() const;

--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -43,7 +43,7 @@ class WriteBatchBase {
   virtual Status Put(const SliceParts& key, const SliceParts& value);
 
   virtual Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
-                           const WideColumnDescs& column_descs) = 0;
+                           const WideColumns& columns) = 0;
 
   // Merge "value" with the existing value of "key" in the database.
   // "key->merge(existing, value)"

--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -42,6 +42,7 @@ class WriteBatchBase {
                      const SliceParts& value);
   virtual Status Put(const SliceParts& key, const SliceParts& value);
 
+  // UNDER CONSTRUCTION -- DO NOT USE
   virtual Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
                            const WideColumns& columns) = 0;
 

--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -11,6 +11,7 @@
 #include <cstddef>
 
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/wide_columns.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -40,6 +41,9 @@ class WriteBatchBase {
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
                      const SliceParts& value);
   virtual Status Put(const SliceParts& key, const SliceParts& value);
+
+  virtual Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
+                           const WideColumnDescs& column_descs) = 0;
 
   // Merge "value" with the existing value of "key" in the database.
   // "key->merge(existing, value)"

--- a/src.mk
+++ b/src.mk
@@ -503,6 +503,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/version_edit_test.cc                                               \
   db/version_set_test.cc                                                \
   db/wal_manager_test.cc                                                \
+  db/wide/db_wide_basic_test.cc                                         \
   db/wide/wide_column_serialization_test.cc                             \
   db/write_batch_test.cc                                                \
   db/write_callback_test.cc                                             \

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -307,10 +307,11 @@ void MetaBlockIter::SeekImpl(const Slice& target) {
 // target = "seek_user_key @ type | seqno".
 //
 // For any type other than kTypeValue, kTypeDeletion, kTypeSingleDeletion,
-// or kTypeBlobIndex, this function behaves identically as Seek().
+// kTypeBlobIndex, or kTypeWideColumnEntity, this function behaves identically
+// to Seek().
 //
 // For any type in kTypeValue, kTypeDeletion, kTypeSingleDeletion,
-// or kTypeBlobIndex:
+// kTypeBlobIndex, or kTypeWideColumnEntity:
 //
 // If the return value is FALSE, iter location is undefined, and it means:
 // 1) there is no key in this block falling into the range:
@@ -412,7 +413,8 @@ bool DataBlockIter::SeekForGetImpl(const Slice& target) {
   if (value_type != ValueType::kTypeValue &&
       value_type != ValueType::kTypeDeletion &&
       value_type != ValueType::kTypeSingleDeletion &&
-      value_type != ValueType::kTypeBlobIndex) {
+      value_type != ValueType::kTypeBlobIndex &&
+      value_type != ValueType::kTypeWideColumnEntity) {
     SeekImpl(target);
     return true;
   }

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -259,6 +259,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
             return false;
           }
         } else if (type == kTypeWideColumnEntity) {
+          // TODO: support wide-column entities
           state_ = kUnexpectedWideColumnEntity;
           return false;
         }
@@ -293,6 +294,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
               Slice blob_value(pin_val);
               push_operand(blob_value, nullptr);
             } else if (type == kTypeWideColumnEntity) {
+              // TODO: support wide-column entities
               state_ = kUnexpectedWideColumnEntity;
               return false;
             } else {
@@ -318,6 +320,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
               push_operand(blob_value, nullptr);
             }
           } else if (type == kTypeWideColumnEntity) {
+            // TODO: support wide-column entities
             state_ = kUnexpectedWideColumnEntity;
             return false;
           } else {

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -252,14 +252,21 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
       case kTypeBlobIndex:
       case kTypeWideColumnEntity:
         assert(state_ == kNotFound || state_ == kMerge);
-        if (type == kTypeBlobIndex && is_blob_index_ == nullptr) {
-          // Blob value not supported. Stop.
-          state_ = kUnexpectedBlobIndex;
+        if (type == kTypeBlobIndex) {
+          if (is_blob_index_ == nullptr) {
+            // Blob value not supported. Stop.
+            state_ = kUnexpectedBlobIndex;
+            return false;
+          }
+        } else if (type == kTypeWideColumnEntity) {
+          state_ = kUnexpectedWideColumnEntity;
           return false;
         }
+
         if (is_blob_index_ != nullptr) {
           *is_blob_index_ = (type == kTypeBlobIndex);
         }
+
         if (kNotFound == state_) {
           state_ = kFound;
           if (do_merge_) {

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -293,8 +293,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
               Slice blob_value(pin_val);
               push_operand(blob_value, nullptr);
             } else if (type == kTypeWideColumnEntity) {
-              // TODO: support wide-column entities
-              state_ = kCorrupt;
+              state_ = kUnexpectedWideColumnEntity;
               return false;
             } else {
               assert(type == kTypeValue);
@@ -319,8 +318,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
               push_operand(blob_value, nullptr);
             }
           } else if (type == kTypeWideColumnEntity) {
-            // TODO: support wide-column entities
-            state_ = kCorrupt;
+            state_ = kUnexpectedWideColumnEntity;
             return false;
           } else {
             assert(type == kTypeValue);

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -74,6 +74,7 @@ class GetContext {
     kCorrupt,
     kMerge,  // saver contains the current merge result (the operands)
     kUnexpectedBlobIndex,
+    // TODO: remove once wide-column entities are supported by Get/MultiGet
     kUnexpectedWideColumnEntity,
   };
   GetContextStats get_context_stats_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -74,6 +74,7 @@ class GetContext {
     kCorrupt,
     kMerge,  // saver contains the current merge result (the operands)
     kUnexpectedBlobIndex,
+    kUnexpectedWideColumnEntity,
   };
   GetContextStats get_context_stats_;
 

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -201,7 +201,7 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
     last_entry_offset = input.data() - write_batch.Data().data();
 
     s = ReadRecordFromWriteBatch(&input, &tag, &column_family_id, &key, &value,
-                                 &blob, &xid, /* FIXME column_descs */ nullptr);
+                                 &blob, &xid);
     if (!s.ok()) {
       break;
     }

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -200,8 +200,8 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
     // set offset of current entry for call to AddNewEntry()
     last_entry_offset = input.data() - write_batch.Data().data();
 
-    s = ReadRecordFromWriteBatch(&input, &tag, &column_family_id, &key,
-                                  &value, &blob, &xid);
+    s = ReadRecordFromWriteBatch(&input, &tag, &column_family_id, &key, &value,
+                                 &blob, &xid, /* FIXME column_descs */ nullptr);
     if (!s.ok()) {
       break;
     }

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -200,8 +200,8 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
     // set offset of current entry for call to AddNewEntry()
     last_entry_offset = input.data() - write_batch.Data().data();
 
-    s = ReadRecordFromWriteBatch(&input, &tag, &column_family_id, &key, &value,
-                                 &blob, &xid);
+    s = ReadRecordFromWriteBatch(&input, &tag, &column_family_id, &key,
+                                  &value, &blob, &xid);
     if (!s.ok()) {
       break;
     }

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -473,8 +473,9 @@ Status ReadableWriteBatch::GetEntryFromDataOffset(size_t data_offset,
   Slice input = Slice(rep_.data() + data_offset, rep_.size() - data_offset);
   char tag;
   uint32_t column_family;
-  Status s = ReadRecordFromWriteBatch(&input, &tag, &column_family, Key, value,
-                                      blob, xid);
+  Status s =
+      ReadRecordFromWriteBatch(&input, &tag, &column_family, Key, value, blob,
+                               xid, /* FIXME column_descs */ nullptr);
   if (!s.ok()) {
     return s;
   }

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -473,9 +473,8 @@ Status ReadableWriteBatch::GetEntryFromDataOffset(size_t data_offset,
   Slice input = Slice(rep_.data() + data_offset, rep_.size() - data_offset);
   char tag;
   uint32_t column_family;
-  Status s =
-      ReadRecordFromWriteBatch(&input, &tag, &column_family, Key, value, blob,
-                               xid, /* FIXME column_descs */ nullptr);
+  Status s = ReadRecordFromWriteBatch(&input, &tag, &column_family, Key, value,
+                                      blob, xid);
   if (!s.ok()) {
     return s;
   }


### PR DESCRIPTION
Summary:
The patch builds on https://github.com/facebook/rocksdb/pull/9915 and adds
a new API called `PutEntity` that can be used to write a wide-column entity
to the database. The new API is added to both `DB` and `WriteBatch`. Note
that currently there is no way to retrieve these entities; more precisely, all
read APIs (`Get`, `MultiGet`, and iterator) return `NotSupported` when they
encounter a wide-column entity that is required to answer a query. Read-side
support (as well as other missing functionality like `Merge`, compaction filter,
and timestamp support) will be added in later PRs.

Test Plan:
`make check`