### PR TITLE
VerifySstUniqueIds status is overrided for multi CFs

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -711,7 +711,7 @@ Status DBImpl::VerifySstUniqueIdInManifest() {
       "Verifying SST unique id between MANIFEST and SST file table properties");
   Status status;
   for (auto cfd : *versions_->GetColumnFamilySet()) {
-    if (!cfd->IsDropped()) {
+    if (!cfd->IsDropped() && status.ok()) {
       auto version = cfd->current();
       version->Ref();
       mutex_.Unlock();


### PR DESCRIPTION
Summary: There's bug that basically we only report the last CF's
VerifySstUniqueIds() result:
https://github.com/facebook/rocksdb/pull/9990#discussion_r877268810

Test Plan: CI