### PR TITLE
Change the semantics of bytes_read in GetBlob/MultiGetBlob for consistency

### DIFF
--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -443,50 +443,37 @@ void BlobFileReader::MultiGetBlob(
   }
 
   assert(s.ok());
+
+  uint64_t total_bytes = 0;
   for (size_t i = 0; i < num_blobs; ++i) {
     auto& req = read_reqs[i];
+    const auto& record_slice = req.result;
+
     assert(statuses[i]);
-    if (req.status.ok() && req.result.size() != req.len) {
+    if (req.status.ok() && record_slice.size() != req.len) {
       req.status = IOStatus::Corruption("Failed to read data from blob file");
     }
     *statuses[i] = req.status;
-  }
 
-  if (read_options.verify_checksums) {
-    for (size_t i = 0; i < num_blobs; ++i) {
-      assert(statuses[i]);
-      if (!statuses[i]->ok()) {
-        continue;
-      }
-      const Slice& record_slice = read_reqs[i].result;
-      s = VerifyBlob(record_slice, user_keys[i], value_sizes[i]);
-      if (!s.ok()) {
-        assert(statuses[i]);
-        *statuses[i] = s;
-      }
+    // Verify checksums if enabled
+    if (statuses[i]->ok() && read_options.verify_checksums) {
+      *statuses[i] = VerifyBlob(record_slice, user_keys[i], value_sizes[i]);
     }
-  }
 
-  for (size_t i = 0; i < num_blobs; ++i) {
-    assert(statuses[i]);
-    if (!statuses[i]->ok()) {
-      continue;
+    // Uncompress blob if needed
+    if (statuses[i]->ok()) {
+      const Slice value_slice(record_slice.data() + adjustments[i],
+                              value_sizes[i]);
+      *statuses[i] = UncompressBlobIfNeeded(value_slice, compression_type_,
+                                            clock_, statistics_, values[i]);
     }
-    const Slice& record_slice = read_reqs[i].result;
-    const Slice value_slice(record_slice.data() + adjustments[i],
-                            value_sizes[i]);
-    s = UncompressBlobIfNeeded(value_slice, compression_type_, clock_,
-                               statistics_, values[i]);
-    if (!s.ok()) {
-      *statuses[i] = s;
+
+    if (statuses[i]->ok()) {
+      total_bytes += record_slice.size();
     }
   }
 
   if (bytes_read) {
-    uint64_t total_bytes = 0;
-    for (const auto& req : read_reqs) {
-      total_bytes += req.result.size();
-    }
     *bytes_read = total_bytes;
   }
 }

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -44,7 +44,7 @@ class BlobFileReader {
                  uint64_t offset, uint64_t value_size,
                  CompressionType compression_type,
                  FilePrefetchBuffer* prefetch_buffer, PinnableSlice* value,
-                 uint64_t* bytes_read = nullptr) const;
+                 uint64_t* bytes_read) const;
 
   // offsets must be sorted in ascending order by caller.
   void MultiGetBlob(
@@ -52,7 +52,7 @@ class BlobFileReader {
       const autovector<std::reference_wrapper<const Slice>>& user_keys,
       const autovector<uint64_t>& offsets,
       const autovector<uint64_t>& value_sizes, autovector<Status*>& statuses,
-      autovector<PinnableSlice*>& values, uint64_t* bytes_read = nullptr) const;
+      autovector<PinnableSlice*>& values, uint64_t* bytes_read) const;
 
   CompressionType GetCompressionType() const { return compression_type_; }
 

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -44,7 +44,7 @@ class BlobFileReader {
                  uint64_t offset, uint64_t value_size,
                  CompressionType compression_type,
                  FilePrefetchBuffer* prefetch_buffer, PinnableSlice* value,
-                 uint64_t* bytes_read) const;
+                 uint64_t* bytes_read = nullptr) const;
 
   // offsets must be sorted in ascending order by caller.
   void MultiGetBlob(
@@ -52,7 +52,7 @@ class BlobFileReader {
       const autovector<std::reference_wrapper<const Slice>>& user_keys,
       const autovector<uint64_t>& offsets,
       const autovector<uint64_t>& value_sizes, autovector<Status*>& statuses,
-      autovector<PinnableSlice*>& values, uint64_t* bytes_read) const;
+      autovector<PinnableSlice*>& values, uint64_t* bytes_read = nullptr) const;
 
   CompressionType GetCompressionType() const { return compression_type_; }
 

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -288,8 +288,6 @@ void BlobSource::MultiGetBlob(
     if (bytes_read) {
       *bytes_read = total_bytes;
     }
-
-    RecordTick(statistics_, BLOB_DB_BLOB_FILE_BYTES_READ, _bytes_read);
   }
 }
 

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -133,10 +133,9 @@ Status BlobSource::GetBlob(const ReadOptions& read_options,
       return Status::Corruption("Compression type mismatch when reading blob");
     }
 
-    uint64_t _bytes_read = 0;
-    s = blob_file_reader.GetValue()->GetBlob(
-        read_options, user_key, offset, value_size, compression_type,
-        prefetch_buffer, value, &_bytes_read);
+    s = blob_file_reader.GetValue()->GetBlob(read_options, user_key, offset,
+                                             value_size, compression_type,
+                                             prefetch_buffer, value);
     if (!s.ok()) {
       return s;
     }

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -144,8 +144,6 @@ Status BlobSource::GetBlob(const ReadOptions& read_options,
     if (bytes_read) {
       *bytes_read = value->size();  // uncompressed blob size
     }
-
-    RecordTick(statistics_, BLOB_DB_BLOB_FILE_BYTES_READ, _bytes_read);
   }
 
   if (blob_cache_ && read_options.fill_cache) {

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -40,9 +40,12 @@ class BlobSource {
   // Read a blob from the underlying cache or storage.
   //
   // If successful, returns ok and sets "*value" to the newly retrieved
-  // uncompressed blob, and "*bytes_read" is set as its size. If there was an
-  // error while fetching the blob, sets "*value" to empty and returns a
-  // non-ok status.
+  // uncompressed blob. If there was an error while fetching the blob, sets
+  // "*value" to empty and returns a non-ok status.
+  //
+  // Note: For consistency, whether the blob is found in the cache or on disk,
+  // sets "*bytes_read" to the size of on-disk (possibly compressed) blob
+  // record.
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
                  uint64_t file_number, uint64_t offset, uint64_t file_size,
                  uint64_t value_size, CompressionType compression_type,
@@ -52,12 +55,14 @@ class BlobSource {
   // Read multiple blobs from the underlying cache or storage.
   //
   // If successful, returns ok and sets "*blobs" to the newly retrieved
-  // uncompressed blobs, and "*bytes_read" is set as the total size of
   // uncompressed blobs. If there was an error while fetching one of blobs,
   // sets its corresponding "blobs[i]" to empty and sets "statuses[i]" to
   // a non-ok status.
   //
-  // Note: Offsets must be sorted in ascending order by caller.
+  // Note:
+  //  - Offsets must be sorted in ascending order by caller.
+  //  - For consistency, whether the blob is found in the cache or on disk, sets
+  //  "*bytes_read" to the size of on-disk (possibly compressed) blob records.
   void MultiGetBlob(
       const ReadOptions& read_options,
       const autovector<std::reference_wrapper<const Slice>>& user_keys,

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -54,7 +54,8 @@ class BlobSource {
   // If successful, returns ok and sets "*blobs" to the newly retrieved
   // uncompressed blobs, and "*bytes_read" is set as the total size of
   // uncompressed blobs. If there was an error while fetching one of blobs,
-  // sets its corresponding "blobs[i]" to empty and returns a non-ok status.
+  // sets its corresponding "blobs[i]" to empty and sets "statuses[i]" to
+  // a non-ok status.
   //
   // Note: Offsets must be sorted in ascending order by caller.
   void MultiGetBlob(

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -37,13 +37,26 @@ class BlobSource {
 
   ~BlobSource();
 
+  // Read a blob from the underlying cache or storage.
+  //
+  // If successful, returns ok and sets "*value" to the newly retrieved
+  // uncompressed blob, and "*bytes_read" is set as its size. If there was an
+  // error while fetching the blob, sets "*value" to empty and returns a
+  // non-ok status.
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
                  uint64_t file_number, uint64_t offset, uint64_t file_size,
                  uint64_t value_size, CompressionType compression_type,
                  FilePrefetchBuffer* prefetch_buffer, PinnableSlice* value,
                  uint64_t* bytes_read);
 
-  // Offsets must be sorted in ascending order by caller.
+  // Read multiple blobs from the underlying cache or storage.
+  //
+  // If successful, returns ok and sets "*blobs" to the newly retrieved
+  // uncompressed blobs, and "*bytes_read" is set as the total size of
+  // uncompressed blobs. If there was an error while fetching one of blobs,
+  // sets its corresponding "blobs[i]" to empty and returns a non-ok status.
+  //
+  // Note: Offsets must be sorted in ascending order by caller.
   void MultiGetBlob(
       const ReadOptions& read_options,
       const autovector<std::reference_wrapper<const Slice>>& user_keys,

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -54,15 +54,16 @@ class BlobSource {
 
   // Read multiple blobs from the underlying cache or storage.
   //
-  // If successful, returns ok and sets "*blobs" to the newly retrieved
-  // uncompressed blobs. If there was an error while fetching one of blobs,
-  // sets its corresponding "blobs[i]" to empty and sets "statuses[i]" to
+  // If successful, returns ok and sets the elements of blobs to the newly
+  // retrieved uncompressed blobs. If there was an error while fetching one of
+  // blobs, sets its corresponding "blobs[i]" to empty and sets "statuses[i]" to
   // a non-ok status.
   //
   // Note:
   //  - Offsets must be sorted in ascending order by caller.
   //  - For consistency, whether the blob is found in the cache or on disk, sets
-  //  "*bytes_read" to the size of on-disk (possibly compressed) blob records.
+  //  "*bytes_read" to the total size of on-disk (possibly compressed) blob
+  //  records.
   void MultiGetBlob(
       const ReadOptions& read_options,
       const autovector<std::reference_wrapper<const Slice>>& user_keys,

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -205,7 +205,8 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer, &values[i],
                                     &bytes_read));
       ASSERT_EQ(values[i], blobs[i]);
-      ASSERT_EQ(bytes_read, blob_sizes[i]);
+      ASSERT_EQ(bytes_read,
+                BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 
       ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                 blob_offsets[i]));
@@ -222,7 +223,8 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer, &values[i],
                                     &bytes_read));
       ASSERT_EQ(values[i], blobs[i]);
-      ASSERT_EQ(bytes_read, blob_sizes[i]);
+      ASSERT_EQ(bytes_read,
+                BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                blob_offsets[i]));
@@ -239,7 +241,8 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer, &values[i],
                                     &bytes_read));
       ASSERT_EQ(values[i], blobs[i]);
-      ASSERT_EQ(bytes_read, blob_sizes[i]);
+      ASSERT_EQ(bytes_read,
+                BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                blob_offsets[i]));
@@ -257,7 +260,8 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer, &values[i],
                                     &bytes_read));
       ASSERT_EQ(values[i], blobs[i]);
-      ASSERT_EQ(bytes_read, blob_sizes[i]);
+      ASSERT_EQ(bytes_read,
+                BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                blob_offsets[i]));
@@ -409,7 +413,8 @@ TEST_F(BlobSourceTest, GetCompressedBlobs) {
                                     &values[i], &bytes_read));
       ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
       ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
-      ASSERT_EQ(bytes_read, blobs[i].size());
+      ASSERT_EQ(bytes_read,
+                BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[i]));
@@ -428,16 +433,8 @@ TEST_F(BlobSourceTest, GetCompressedBlobs) {
                                     &values[i], &bytes_read));
       ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
       ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
-      ASSERT_EQ(bytes_read, blobs[i].size() /*uncompressed size*/);
-
-      // Uncompressed blob size is passed in GetBlob
-      ASSERT_OK(blob_source.GetBlob(read_options, keys[i], file_number,
-                                    blob_offsets[i], file_size, blobs[i].size(),
-                                    compression, nullptr /*prefetch_buffer*/,
-                                    &values[i], &bytes_read));
-      ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
-      ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
-      ASSERT_EQ(bytes_read, blobs[i].size() /*uncompressed size*/);
+      ASSERT_EQ(bytes_read,
+                BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[i]));
@@ -558,7 +555,8 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer,
                                     &value_buf[i], &bytes_read));
       ASSERT_EQ(value_buf[i], blobs[i]);
-      ASSERT_EQ(bytes_read, blob_sizes[i]);
+      ASSERT_EQ(bytes_read,
+                BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                blob_offsets[i]));

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "db/blob/blob_file_cache.h"
+#include "db/blob/blob_file_reader.h"
 #include "db/blob/blob_log_format.h"
 #include "db/blob/blob_log_writer.h"
 #include "db/db_test_util.h"
@@ -108,33 +109,34 @@ class BlobSourceTest : public DBTestBase {
  protected:
  public:
   explicit BlobSourceTest()
-      : DBTestBase("blob_source_test", /*env_do_fsync=*/true) {}
+      : DBTestBase("blob_source_test", /*env_do_fsync=*/true) {
+    options_.env = env_;
+    options_.enable_blob_files = true;
+    options_.create_if_missing = true;
+
+    LRUCacheOptions co;
+    co.capacity = 2048;
+    co.num_shard_bits = 2;
+    co.metadata_charge_policy = kDontChargeCacheMetadata;
+    options_.blob_cache = NewLRUCache(co);
+    options_.lowest_used_cache_tier = CacheTier::kVolatileTier;
+
+    assert(db_->GetDbIdentity(db_id_).ok());
+    assert(db_->GetDbSessionId(db_session_id_).ok());
+  }
+
+  Options options_;
+  std::string db_id_;
+  std::string db_session_id_;
 };
 
 TEST_F(BlobSourceTest, GetBlobsFromCache) {
-  Options options;
-  options.env = env_;
-  options.cf_paths.emplace_back(
+  options_.cf_paths.emplace_back(
       test::PerThreadDBPath(env_, "BlobSourceTest_GetBlobsFromCache"), 0);
-  options.enable_blob_files = true;
-  options.create_if_missing = true;
 
-  LRUCacheOptions co;
-  co.capacity = 2048;
-  co.num_shard_bits = 2;
-  co.metadata_charge_policy = kDontChargeCacheMetadata;
-  options.blob_cache = NewLRUCache(co);
-  options.lowest_used_cache_tier = CacheTier::kVolatileTier;
+  DestroyAndReopen(options_);
 
-  DestroyAndReopen(options);
-
-  std::string db_id;
-  ASSERT_OK(db_->GetDbIdentity(db_id));
-
-  std::string db_session_id;
-  ASSERT_OK(db_->GetDbSessionId(db_session_id));
-
-  ImmutableOptions immutable_options(options);
+  ImmutableOptions immutable_options(options_);
 
   constexpr uint32_t column_family_id = 1;
   constexpr bool has_ttl = false;
@@ -179,7 +181,7 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
       backing_cache.get(), &immutable_options, &file_options, column_family_id,
       blob_file_read_hist, nullptr /*IOTracer*/));
 
-  BlobSource blob_source(&immutable_options, db_id, db_session_id,
+  BlobSource blob_source(&immutable_options, db_id_, db_session_id_,
                          blob_file_cache.get());
 
   ReadOptions read_options;
@@ -264,7 +266,7 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
     }
   }
 
-  options.blob_cache->EraseUnRefEntries();
+  options_.blob_cache->EraseUnRefEntries();
 
   {
     // Cache-only GetBlob
@@ -320,30 +322,134 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
   }
 }
 
+TEST_F(BlobSourceTest, GetCompressedBlobs) {
+  options_.cf_paths.emplace_back(
+      test::PerThreadDBPath(env_, "BlobSourceTest_GetCompressedBlobs"), 0);
+
+  DestroyAndReopen(options_);
+
+  ImmutableOptions immutable_options(options_);
+
+  constexpr uint32_t column_family_id = 1;
+  constexpr bool has_ttl = false;
+  constexpr ExpirationRange expiration_range;
+  constexpr size_t num_blobs = 256;
+
+  std::vector<std::string> key_strs;
+  std::vector<std::string> blob_strs;
+
+  for (size_t i = 0; i < num_blobs; ++i) {
+    key_strs.push_back("key" + std::to_string(i));
+    blob_strs.push_back("blob" + std::to_string(i));
+  }
+
+  std::vector<Slice> keys;
+  std::vector<Slice> blobs;
+
+  for (size_t i = 0; i < num_blobs; ++i) {
+    keys.push_back({key_strs[i]});
+    blobs.push_back({blob_strs[i]});
+  }
+
+  std::vector<uint64_t> blob_offsets(keys.size());
+  std::vector<uint64_t> blob_sizes(keys.size());
+
+  constexpr size_t capacity = 1024;
+  auto backing_cache = NewLRUCache(capacity);  // Blob file cache
+
+  FileOptions file_options;
+  std::unique_ptr<BlobFileCache> blob_file_cache(new BlobFileCache(
+      backing_cache.get(), &immutable_options, &file_options, column_family_id,
+      nullptr /*HistogramImpl*/, nullptr /*IOTracer*/));
+
+  BlobSource blob_source(&immutable_options, db_id_, db_session_id_,
+                         blob_file_cache.get());
+
+  ReadOptions read_options;
+  read_options.verify_checksums = true;
+
+  uint64_t bytes_read = 0;
+  std::vector<PinnableSlice> values(keys.size());
+
+  {
+    // ZSTD Compression
+    const uint64_t file_number = 1;
+    const CompressionType compression = kZSTD;
+
+    read_options.read_tier = ReadTier::kReadAllTier;
+
+    WriteBlobFile(immutable_options, column_family_id, has_ttl,
+                  expiration_range, expiration_range, file_number, keys, blobs,
+                  compression, blob_offsets, blob_sizes);
+
+    CacheHandleGuard<BlobFileReader> blob_file_reader;
+    ASSERT_OK(blob_source.GetBlobFileReader(file_number, &blob_file_reader));
+    ASSERT_NE(blob_file_reader.GetValue(), nullptr);
+
+    const uint64_t file_size = blob_file_reader.GetValue()->GetFileSize();
+    ASSERT_EQ(blob_file_reader.GetValue()->GetCompressionType(), compression);
+
+    for (size_t i = 0; i < num_blobs; ++i) {
+      ASSERT_NE(blobs[i].size() /*uncompressed size*/,
+                blob_sizes[i] /*compressed size*/);
+    }
+
+    read_options.fill_cache = true;
+    read_options.read_tier = ReadTier::kReadAllTier;
+
+    for (size_t i = 0; i < num_blobs; ++i) {
+      ASSERT_FALSE(blob_source.TEST_BlobInCache(file_number, file_size,
+                                                blob_offsets[i]));
+      ASSERT_OK(blob_source.GetBlob(read_options, keys[i], file_number,
+                                    blob_offsets[i], file_size, blob_sizes[i],
+                                    compression, nullptr /*prefetch_buffer*/,
+                                    &values[i], &bytes_read));
+      ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
+      ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
+      ASSERT_EQ(bytes_read,
+                blob_sizes[i] + keys[i].size() + BlobLogRecord::kHeaderSize);
+
+      ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
+                                               blob_offsets[i]));
+    }
+
+    read_options.read_tier = ReadTier::kBlockCacheTier;
+
+    for (size_t i = 0; i < num_blobs; ++i) {
+      ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
+                                               blob_offsets[i]));
+
+      // Compressed blob size is passed in GetBlob
+      ASSERT_OK(blob_source.GetBlob(read_options, keys[i], file_number,
+                                    blob_offsets[i], file_size, blob_sizes[i],
+                                    compression, nullptr /*prefetch_buffer*/,
+                                    &values[i], &bytes_read));
+      ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
+      ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
+      ASSERT_EQ(bytes_read, blobs[i].size() /*uncompressed size*/);
+
+      // Uncompressed blob size is passed in GetBlob
+      ASSERT_OK(blob_source.GetBlob(read_options, keys[i], file_number,
+                                    blob_offsets[i], file_size, blobs[i].size(),
+                                    compression, nullptr /*prefetch_buffer*/,
+                                    &values[i], &bytes_read));
+      ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
+      ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
+      ASSERT_EQ(bytes_read, blobs[i].size() /*uncompressed size*/);
+
+      ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
+                                               blob_offsets[i]));
+    }
+  }
+}
+
 TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
-  Options options;
-  options.env = env_;
-  options.cf_paths.emplace_back(
+  options_.cf_paths.emplace_back(
       test::PerThreadDBPath(env_, "BlobSourceTest_MultiGetBlobsFromCache"), 0);
-  options.enable_blob_files = true;
-  options.create_if_missing = true;
 
-  LRUCacheOptions co;
-  co.capacity = 2048;
-  co.num_shard_bits = 2;
-  co.metadata_charge_policy = kDontChargeCacheMetadata;
-  options.blob_cache = NewLRUCache(co);
-  options.lowest_used_cache_tier = CacheTier::kVolatileTier;
+  DestroyAndReopen(options_);
 
-  DestroyAndReopen(options);
-
-  std::string db_id;
-  ASSERT_OK(db_->GetDbIdentity(db_id));
-
-  std::string db_session_id;
-  ASSERT_OK(db_->GetDbSessionId(db_session_id));
-
-  ImmutableOptions immutable_options(options);
+  ImmutableOptions immutable_options(options_);
 
   constexpr uint32_t column_family_id = 1;
   constexpr bool has_ttl = false;
@@ -388,7 +494,7 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
       backing_cache.get(), &immutable_options, &file_options, column_family_id,
       blob_file_read_hist, nullptr /*IOTracer*/));
 
-  BlobSource blob_source(&immutable_options, db_id, db_session_id,
+  BlobSource blob_source(&immutable_options, db_id_, db_session_id_,
                          blob_file_cache.get());
 
   ReadOptions read_options;
@@ -485,7 +591,7 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
     }
   }
 
-  options.blob_cache->EraseUnRefEntries();
+  options_.blob_cache->EraseUnRefEntries();
 
   {
     // Cache-only MultiGetBlob

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -372,9 +372,9 @@ TEST_F(BlobSourceTest, GetCompressedBlobs) {
   std::vector<PinnableSlice> values(keys.size());
 
   {
-    // ZSTD Compression
+    // Snappy Compression
     const uint64_t file_number = 1;
-    const CompressionType compression = kZSTD;
+    const CompressionType compression = kSnappyCompression;
 
     read_options.read_tier = ReadTier::kReadAllTier;
 

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -205,8 +205,7 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer, &values[i],
                                     &bytes_read));
       ASSERT_EQ(values[i], blobs[i]);
-      ASSERT_EQ(bytes_read,
-                blob_sizes[i] + keys[i].size() + BlobLogRecord::kHeaderSize);
+      ASSERT_EQ(bytes_read, blob_sizes[i]);
 
       ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                 blob_offsets[i]));
@@ -223,8 +222,7 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer, &values[i],
                                     &bytes_read));
       ASSERT_EQ(values[i], blobs[i]);
-      ASSERT_EQ(bytes_read,
-                blob_sizes[i] + keys[i].size() + BlobLogRecord::kHeaderSize);
+      ASSERT_EQ(bytes_read, blob_sizes[i]);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                blob_offsets[i]));
@@ -411,8 +409,7 @@ TEST_F(BlobSourceTest, GetCompressedBlobs) {
                                     &values[i], &bytes_read));
       ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
       ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
-      ASSERT_EQ(bytes_read,
-                blob_sizes[i] + keys[i].size() + BlobLogRecord::kHeaderSize);
+      ASSERT_EQ(bytes_read, blobs[i].size());
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[i]));
@@ -561,8 +558,7 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer,
                                     &value_buf[i], &bytes_read));
       ASSERT_EQ(value_buf[i], blobs[i]);
-      ASSERT_EQ(bytes_read,
-                blob_sizes[i] + keys[i].size() + BlobLogRecord::kHeaderSize);
+      ASSERT_EQ(bytes_read, blob_sizes[i]);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                blob_offsets[i]));

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -323,6 +323,12 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
 }
 
 TEST_F(BlobSourceTest, GetCompressedBlobs) {
+  if (!Snappy_Supported()) {
+    return;
+  }
+
+  const CompressionType compression = kSnappyCompression;
+
   options_.cf_paths.emplace_back(
       test::PerThreadDBPath(env_, "BlobSourceTest_GetCompressedBlobs"), 0);
 
@@ -374,7 +380,6 @@ TEST_F(BlobSourceTest, GetCompressedBlobs) {
   {
     // Snappy Compression
     const uint64_t file_number = 1;
-    const CompressionType compression = kSnappyCompression;
 
     read_options.read_tier = ReadTier::kReadAllTier;
 

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -411,7 +411,7 @@ TEST_F(BlobSourceTest, GetCompressedBlobs) {
                                     blob_offsets[i], file_size, blob_sizes[i],
                                     compression, nullptr /*prefetch_buffer*/,
                                     &values[i], &bytes_read));
-      ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
+      ASSERT_EQ(values[i], blobs[i] /*uncompressed blob*/);
       ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
       ASSERT_EQ(bytes_read,
                 BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
@@ -431,8 +431,8 @@ TEST_F(BlobSourceTest, GetCompressedBlobs) {
                                     blob_offsets[i], file_size, blob_sizes[i],
                                     compression, nullptr /*prefetch_buffer*/,
                                     &values[i], &bytes_read));
+      ASSERT_EQ(values[i], blobs[i] /*uncompressed blob*/);
       ASSERT_NE(values[i].size(), blob_sizes[i] /*compressed size*/);
-      ASSERT_EQ(values[i].size(), blobs[i].size() /*uncompressed size*/);
       ASSERT_EQ(bytes_read,
                 BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 


### PR DESCRIPTION
Summary:

The `bytes_read` returned by the current BlobSource interface is ambiguous. The uncompressed blob size is returned if the cache hits. The size of the blob read from disk, presumably the compressed version, is returned if the cache misses. Two differing semantics might cause ambiguity and consistency issues. For example, this inconsistency causes the assertion failure (T124246362 and its hot fix is #10249). 

This goal is to require that the value of `byte read` always be an on-disk blob record size.
