### PR TITLE
Fix in-place updates for value types other than kTypeValue

### DIFF
--- a/db/db_inplace_update_test.cc
+++ b/db/db_inplace_update_test.cc
@@ -80,7 +80,8 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntity) {
     constexpr int num_values = 10;
     for (int i = num_values; i > 0; --i) {
       constexpr char key[] = "key";
-      WideColumns wide_columns{{"attr", DummyString(i, 'a')}};
+      const std::string value = DummyString(i, 'a');
+      WideColumns wide_columns{{"attr", value}};
 
       ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[1], key, wide_columns));
       // TODO: use Get to check entity once it's supported
@@ -106,7 +107,8 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntityLargeNewValue) {
     constexpr int num_values = 10;
     for (int i = 0; i < num_values; ++i) {
       constexpr char key[] = "key";
-      WideColumns wide_columns{{"attr", DummyString(i, 'a')}};
+      const std::string value = DummyString(i, 'a');
+      WideColumns wide_columns{{"attr", value}};
 
       ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[1], key, wide_columns));
       // TODO: use Get to check entity once it's supported

--- a/db/db_inplace_update_test.cc
+++ b/db/db_inplace_update_test.cc
@@ -65,6 +65,58 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateLargeNewValue) {
   } while (ChangeCompactOptions());
 }
 
+TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntity) {
+  do {
+    Options options = CurrentOptions();
+    options.create_if_missing = true;
+    options.inplace_update_support = true;
+    options.env = env_;
+    options.allow_concurrent_memtable_write = false;
+
+    Reopen(options);
+    CreateAndReopenWithCF({"pikachu"}, options);
+
+    // Update key with values of smaller size
+    constexpr int num_values = 10;
+    for (int i = num_values; i > 0; --i) {
+      constexpr char key[] = "key";
+      WideColumns wide_columns{{"attr", DummyString(i, 'a')}};
+
+      ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[1], key, wide_columns));
+      // TODO: use Get to check entity once it's supported
+    }
+
+    // Only 1 instance for that key.
+    validateNumberOfEntries(1, 1);
+  } while (ChangeCompactOptions());
+}
+
+TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntityLargeNewValue) {
+  do {
+    Options options = CurrentOptions();
+    options.create_if_missing = true;
+    options.inplace_update_support = true;
+    options.env = env_;
+    options.allow_concurrent_memtable_write = false;
+
+    Reopen(options);
+    CreateAndReopenWithCF({"pikachu"}, options);
+
+    // Update key with values of smaller size
+    constexpr int num_values = 10;
+    for (int i = 0; i < num_values; ++i) {
+      constexpr char key[] = "key";
+      WideColumns wide_columns{{"attr", DummyString(i, 'a')}};
+
+      ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[1], key, wide_columns));
+      // TODO: use Get to check entity once it's supported
+    }
+
+    // All 10 updates exist in the internal iterator
+    validateNumberOfEntries(num_values, 1);
+  } while (ChangeCompactOptions());
+}
+
 TEST_F(DBTestInPlaceUpdate, InPlaceUpdateCallbackSmallerSize) {
   do {
     Options options = CurrentOptions();

--- a/db/db_inplace_update_test.cc
+++ b/db/db_inplace_update_test.cc
@@ -65,7 +65,7 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateLargeNewValue) {
   } while (ChangeCompactOptions());
 }
 
-TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntity) {
+TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntitySmallerNewValue) {
   do {
     Options options = CurrentOptions();
     options.create_if_missing = true;
@@ -92,7 +92,7 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntity) {
   } while (ChangeCompactOptions());
 }
 
-TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntityLargeNewValue) {
+TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntityLargerNewValue) {
   do {
     Options options = CurrentOptions();
     options.create_if_missing = true;
@@ -103,7 +103,7 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateEntityLargeNewValue) {
     Reopen(options);
     CreateAndReopenWithCF({"pikachu"}, options);
 
-    // Update key with values of smaller size
+    // Update key with values of larger size
     constexpr int num_values = 10;
     for (int i = 0; i < num_values; ++i) {
       constexpr char key[] = "key";

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -1058,8 +1058,8 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
   PERF_COUNTER_ADD(get_from_memtable_count, 1);
 }
 
-Status MemTable::Update(SequenceNumber seq, const Slice& key,
-                        const Slice& value, ValueType value_type,
+Status MemTable::Update(SequenceNumber seq, ValueType value_type,
+                        const Slice& key, const Slice& value,
                         const ProtectionInfoKVOS64* kv_prot_info) {
   LookupKey lkey(key, seq);
   Slice mem_key = lkey.memtable_key();

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -1122,7 +1122,7 @@ Status MemTable::Update(SequenceNumber seq, const Slice& key,
 }
 
 Status MemTable::UpdateCallback(SequenceNumber seq, const Slice& key,
-                                const Slice& delta, ValueType value_type,
+                                const Slice& delta,
                                 const ProtectionInfoKVOS64* kv_prot_info) {
   LookupKey lkey(key, seq);
   Slice memkey = lkey.memtable_key();
@@ -1151,7 +1151,7 @@ Status MemTable::UpdateCallback(SequenceNumber seq, const Slice& key,
       ValueType type;
       uint64_t existing_seq;
       UnPackSequenceAndType(tag, &existing_seq, &type);
-      if (type == value_type) {
+      if (type == kTypeValue) {
         Slice prev_value = GetLengthPrefixedSlice(key_ptr + key_length);
         uint32_t prev_size = static_cast<uint32_t>(prev_value.size());
 
@@ -1192,10 +1192,10 @@ Status MemTable::UpdateCallback(SequenceNumber seq, const Slice& key,
           if (kv_prot_info != nullptr) {
             ProtectionInfoKVOS64 updated_kv_prot_info(*kv_prot_info);
             updated_kv_prot_info.UpdateV(delta, str_value);
-            s = Add(seq, value_type, key, Slice(str_value),
+            s = Add(seq, kTypeValue, key, Slice(str_value),
                     &updated_kv_prot_info);
           } else {
-            s = Add(seq, value_type, key, Slice(str_value),
+            s = Add(seq, kTypeValue, key, Slice(str_value),
                     nullptr /* kv_prot_info */);
           }
           RecordTick(moptions_.statistics, NUMBER_KEYS_WRITTEN);
@@ -1210,7 +1210,7 @@ Status MemTable::UpdateCallback(SequenceNumber seq, const Slice& key,
       }
     }
   }
-  // The latest value is not value_type or key doesn't exist
+  // The latest value is not `kTypeValue` or key doesn't exist
   return Status::NotFound();
 }
 

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -1059,7 +1059,7 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
 }
 
 Status MemTable::Update(SequenceNumber seq, const Slice& key,
-                        const Slice& value,
+                        const Slice& value, ValueType value_type,
                         const ProtectionInfoKVOS64* kv_prot_info) {
   LookupKey lkey(key, seq);
   Slice mem_key = lkey.memtable_key();
@@ -1089,7 +1089,7 @@ Status MemTable::Update(SequenceNumber seq, const Slice& key,
       SequenceNumber existing_seq;
       UnPackSequenceAndType(tag, &existing_seq, &type);
       assert(existing_seq != seq);
-      if (type == kTypeValue) {
+      if (type == value_type) {
         Slice prev_value = GetLengthPrefixedSlice(key_ptr + key_length);
         uint32_t prev_size = static_cast<uint32_t>(prev_value.size());
         uint32_t new_size = static_cast<uint32_t>(value.size());
@@ -1117,12 +1117,12 @@ Status MemTable::Update(SequenceNumber seq, const Slice& key,
     }
   }
 
-  // The latest value is not `kTypeValue` or key doesn't exist
-  return Add(seq, kTypeValue, key, value, kv_prot_info);
+  // The latest value is not value_type or key doesn't exist
+  return Add(seq, value_type, key, value, kv_prot_info);
 }
 
 Status MemTable::UpdateCallback(SequenceNumber seq, const Slice& key,
-                                const Slice& delta,
+                                const Slice& delta, ValueType value_type,
                                 const ProtectionInfoKVOS64* kv_prot_info) {
   LookupKey lkey(key, seq);
   Slice memkey = lkey.memtable_key();
@@ -1151,70 +1151,66 @@ Status MemTable::UpdateCallback(SequenceNumber seq, const Slice& key,
       ValueType type;
       uint64_t existing_seq;
       UnPackSequenceAndType(tag, &existing_seq, &type);
-      switch (type) {
-        case kTypeValue: {
-          Slice prev_value = GetLengthPrefixedSlice(key_ptr + key_length);
-          uint32_t prev_size = static_cast<uint32_t>(prev_value.size());
+      if (type == value_type) {
+        Slice prev_value = GetLengthPrefixedSlice(key_ptr + key_length);
+        uint32_t prev_size = static_cast<uint32_t>(prev_value.size());
 
-          char* prev_buffer = const_cast<char*>(prev_value.data());
-          uint32_t new_prev_size = prev_size;
+        char* prev_buffer = const_cast<char*>(prev_value.data());
+        uint32_t new_prev_size = prev_size;
 
-          std::string str_value;
-          WriteLock wl(GetLock(lkey.user_key()));
-          auto status = moptions_.inplace_callback(prev_buffer, &new_prev_size,
-                                                   delta, &str_value);
-          if (status == UpdateStatus::UPDATED_INPLACE) {
-            // Value already updated by callback.
-            assert(new_prev_size <= prev_size);
-            if (new_prev_size < prev_size) {
-              // overwrite the new prev_size
-              char* p = EncodeVarint32(const_cast<char*>(key_ptr) + key_length,
-                                       new_prev_size);
-              if (VarintLength(new_prev_size) < VarintLength(prev_size)) {
-                // shift the value buffer as well.
-                memcpy(p, prev_buffer, new_prev_size);
-                prev_buffer = p;
-              }
+        std::string str_value;
+        WriteLock wl(GetLock(lkey.user_key()));
+        auto status = moptions_.inplace_callback(prev_buffer, &new_prev_size,
+                                                 delta, &str_value);
+        if (status == UpdateStatus::UPDATED_INPLACE) {
+          // Value already updated by callback.
+          assert(new_prev_size <= prev_size);
+          if (new_prev_size < prev_size) {
+            // overwrite the new prev_size
+            char* p = EncodeVarint32(const_cast<char*>(key_ptr) + key_length,
+                                     new_prev_size);
+            if (VarintLength(new_prev_size) < VarintLength(prev_size)) {
+              // shift the value buffer as well.
+              memcpy(p, prev_buffer, new_prev_size);
+              prev_buffer = p;
             }
-            RecordTick(moptions_.statistics, NUMBER_KEYS_UPDATED);
-            UpdateFlushState();
-            if (kv_prot_info != nullptr) {
-              ProtectionInfoKVOS64 updated_kv_prot_info(*kv_prot_info);
-              // `seq` is swallowed and `existing_seq` prevails.
-              updated_kv_prot_info.UpdateS(seq, existing_seq);
-              updated_kv_prot_info.UpdateV(delta,
-                                           Slice(prev_buffer, new_prev_size));
-              Slice encoded(entry, prev_buffer + new_prev_size - entry);
-              return VerifyEncodedEntry(encoded, updated_kv_prot_info);
-            }
-            return Status::OK();
-          } else if (status == UpdateStatus::UPDATED) {
-            Status s;
-            if (kv_prot_info != nullptr) {
-              ProtectionInfoKVOS64 updated_kv_prot_info(*kv_prot_info);
-              updated_kv_prot_info.UpdateV(delta, str_value);
-              s = Add(seq, kTypeValue, key, Slice(str_value),
-                      &updated_kv_prot_info);
-            } else {
-              s = Add(seq, kTypeValue, key, Slice(str_value),
-                      nullptr /* kv_prot_info */);
-            }
-            RecordTick(moptions_.statistics, NUMBER_KEYS_WRITTEN);
-            UpdateFlushState();
-            return s;
-          } else if (status == UpdateStatus::UPDATE_FAILED) {
-            // `UPDATE_FAILED` is named incorrectly. It indicates no update
-            // happened. It does not indicate a failure happened.
-            UpdateFlushState();
-            return Status::OK();
           }
+          RecordTick(moptions_.statistics, NUMBER_KEYS_UPDATED);
+          UpdateFlushState();
+          if (kv_prot_info != nullptr) {
+            ProtectionInfoKVOS64 updated_kv_prot_info(*kv_prot_info);
+            // `seq` is swallowed and `existing_seq` prevails.
+            updated_kv_prot_info.UpdateS(seq, existing_seq);
+            updated_kv_prot_info.UpdateV(delta,
+                                         Slice(prev_buffer, new_prev_size));
+            Slice encoded(entry, prev_buffer + new_prev_size - entry);
+            return VerifyEncodedEntry(encoded, updated_kv_prot_info);
+          }
+          return Status::OK();
+        } else if (status == UpdateStatus::UPDATED) {
+          Status s;
+          if (kv_prot_info != nullptr) {
+            ProtectionInfoKVOS64 updated_kv_prot_info(*kv_prot_info);
+            updated_kv_prot_info.UpdateV(delta, str_value);
+            s = Add(seq, value_type, key, Slice(str_value),
+                    &updated_kv_prot_info);
+          } else {
+            s = Add(seq, value_type, key, Slice(str_value),
+                    nullptr /* kv_prot_info */);
+          }
+          RecordTick(moptions_.statistics, NUMBER_KEYS_WRITTEN);
+          UpdateFlushState();
+          return s;
+        } else if (status == UpdateStatus::UPDATE_FAILED) {
+          // `UPDATE_FAILED` is named incorrectly. It indicates no update
+          // happened. It does not indicate a failure happened.
+          UpdateFlushState();
+          return Status::OK();
         }
-        default:
-          break;
       }
     }
   }
-  // The latest value is not `kTypeValue` or key doesn't exist
+  // The latest value is not value_type or key doesn't exist
   return Status::NotFound();
 }
 

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -287,13 +287,13 @@ class MemTable {
   Status Update(SequenceNumber seq, const Slice& key, const Slice& value,
                 ValueType value_type, const ProtectionInfoKVOS64* kv_prot_info);
 
-  // If `key` exists in current memtable with type value_type and the existing
+  // If `key` exists in current memtable with type `kTypeValue` and the existing
   // value is at least as large as the new value, updates it in-place. Otherwise
-  // if `key` exists in current memtable with type value_type, adds the new
+  // if `key` exists in current memtable with type `kTypeValue`, adds the new
   // value to the memtable out-of-place.
   //
   // Returns `Status::NotFound` if `key` does not exist in current memtable or
-  // the latest version of `key` does not have type value_type.
+  // the latest version of `key` does not have `kTypeValue`.
   //
   // Returns `Status::TryAgain` if the `seq`, `key` combination already exists
   // in the memtable and `MemTableRepFactory::CanHandleDuplicatedKey()` is true.
@@ -302,7 +302,7 @@ class MemTable {
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable.
   Status UpdateCallback(SequenceNumber seq, const Slice& key,
-                        const Slice& delta, ValueType value_type,
+                        const Slice& delta,
                         const ProtectionInfoKVOS64* kv_prot_info);
 
   // Returns the number of successive merge entries starting from the newest

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -284,8 +284,8 @@ class MemTable {
   //
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable.
-  Status Update(SequenceNumber seq, const Slice& key, const Slice& value,
-                ValueType value_type, const ProtectionInfoKVOS64* kv_prot_info);
+  Status Update(SequenceNumber seq, ValueType value_type, const Slice& key,
+                const Slice& value, const ProtectionInfoKVOS64* kv_prot_info);
 
   // If `key` exists in current memtable with type `kTypeValue` and the existing
   // value is at least as large as the new value, updates it in-place. Otherwise

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -274,7 +274,7 @@ class MemTable {
   void MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                 ReadCallback* callback);
 
-  // If `key` exists in current memtable with type `kTypeValue` and the existing
+  // If `key` exists in current memtable with type value_type and the existing
   // value is at least as large as the new value, updates it in-place. Otherwise
   // adds the new value to the memtable out-of-place.
   //
@@ -285,15 +285,15 @@ class MemTable {
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable.
   Status Update(SequenceNumber seq, const Slice& key, const Slice& value,
-                const ProtectionInfoKVOS64* kv_prot_info);
+                ValueType value_type, const ProtectionInfoKVOS64* kv_prot_info);
 
-  // If `key` exists in current memtable with type `kTypeValue` and the existing
+  // If `key` exists in current memtable with type value_type and the existing
   // value is at least as large as the new value, updates it in-place. Otherwise
-  // if `key` exists in current memtable with type `kTypeValue`, adds the new
+  // if `key` exists in current memtable with type value_type, adds the new
   // value to the memtable out-of-place.
   //
   // Returns `Status::NotFound` if `key` does not exist in current memtable or
-  // the latest version of `key` does not have `kTypeValue`.
+  // the latest version of `key` does not have type value_type.
   //
   // Returns `Status::TryAgain` if the `seq`, `key` combination already exists
   // in the memtable and `MemTableRepFactory::CanHandleDuplicatedKey()` is true.
@@ -302,7 +302,7 @@ class MemTable {
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable.
   Status UpdateCallback(SequenceNumber seq, const Slice& key,
-                        const Slice& delta,
+                        const Slice& delta, ValueType value_type,
                         const ProtectionInfoKVOS64* kv_prot_info);
 
   // Returns the number of successive merge entries starting from the newest

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1989,10 +1989,11 @@ class MemTableInserter : public WriteBatch::Handler {
                    hint_per_batch_ ? &GetHintMap()[mem] : nullptr);
     } else if (moptions->inplace_callback == nullptr) {
       assert(!concurrent_memtable_writes_);
-      ret_status = mem->Update(sequence_, key, value, kv_prot_info);
+      ret_status = mem->Update(sequence_, key, value, value_type, kv_prot_info);
     } else {
       assert(!concurrent_memtable_writes_);
-      ret_status = mem->UpdateCallback(sequence_, key, value, kv_prot_info);
+      ret_status =
+          mem->UpdateCallback(sequence_, key, value, value_type, kv_prot_info);
       if (ret_status.IsNotFound()) {
         // key not found in memtable. Do sst get, update, add
         SnapshotImpl read_from_snapshot;

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1987,13 +1987,14 @@ class MemTableInserter : public WriteBatch::Handler {
           mem->Add(sequence_, value_type, key, value, kv_prot_info,
                    concurrent_memtable_writes_, get_post_process_info(mem),
                    hint_per_batch_ ? &GetHintMap()[mem] : nullptr);
-    } else if (moptions->inplace_callback == nullptr) {
+    } else if (moptions->inplace_callback == nullptr ||
+               value_type != kTypeValue) {
       assert(!concurrent_memtable_writes_);
       ret_status = mem->Update(sequence_, key, value, value_type, kv_prot_info);
     } else {
       assert(!concurrent_memtable_writes_);
-      ret_status =
-          mem->UpdateCallback(sequence_, key, value, value_type, kv_prot_info);
+      assert(value_type == kTypeValue);
+      ret_status = mem->UpdateCallback(sequence_, key, value, kv_prot_info);
       if (ret_status.IsNotFound()) {
         // key not found in memtable. Do sst get, update, add
         SnapshotImpl read_from_snapshot;

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1990,7 +1990,7 @@ class MemTableInserter : public WriteBatch::Handler {
     } else if (moptions->inplace_callback == nullptr ||
                value_type != kTypeValue) {
       assert(!concurrent_memtable_writes_);
-      ret_status = mem->Update(sequence_, key, value, value_type, kv_prot_info);
+      ret_status = mem->Update(sequence_, value_type, key, value, kv_prot_info);
     } else {
       assert(!concurrent_memtable_writes_);
       assert(value_type == kTypeValue);


### PR DESCRIPTION
Summary:
The patch fixes a couple of issues related to in-place updates: 1) the value type was not passed from
`MemTableInserter::PutCFImpl` to `MemTable::Update` and 2) `MemTable::UpdateCallback` was called
for any value type (with the callee's logic assuming `kTypeValue`) even though the callback mechanism
is only safe for plain values.

Test plan:
`make check`