### PR TITLE
Enable compaction filter for db_stress with user-defined timestamp

### DIFF
--- a/db_stress_tool/db_stress_compaction_filter.h
+++ b/db_stress_tool/db_stress_compaction_filter.h
@@ -36,9 +36,14 @@ class DbStressCompactionFilter : public CompactionFilter {
       return Decision::kKeep;
     }
     uint64_t key_num = 0;
-    bool ok = GetIntVal(key.ToString(), &key_num);
-    assert(ok);
-    (void)ok;
+    {
+      Slice ukey_without_ts = key;
+      assert(ukey_without_ts.size() >= FLAGS_user_timestamp_size);
+      ukey_without_ts.remove_suffix(FLAGS_user_timestamp_size);
+      [[maybe_unused]] bool ok =
+          GetIntVal(ukey_without_ts.ToString(), &key_num);
+      assert(ok);
+    }
     port::Mutex* key_mutex = state_->GetMutexForKey(cf_id_, key_num);
     if (!key_mutex->TryLock()) {
       return Decision::kKeep;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2697,10 +2697,6 @@ void CheckAndSetOptionsForUserTimestamp(Options& options) {
     exit(1);
   }
 #endif  // !ROCKSDB_LITE
-  if (FLAGS_enable_compaction_filter) {
-    fprintf(stderr, "CompactionFilter not supported with timestamp.\n");
-    exit(1);
-  }
   if (FLAGS_test_cf_consistency || FLAGS_test_batches_snapshots) {
     fprintf(stderr,
             "Due to per-key ts-seq ordering constraint, only the (default) "

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -361,7 +361,6 @@ ts_params = {
     "use_txn": 0,
     "enable_blob_files": 0,
     "use_blob_db": 0,
-    "enable_compaction_filter": 0,
     "ingest_external_file_one_in": 0,
 }
 


### PR DESCRIPTION
Before this PR, when user-defined timestamp is enabled, db_stress disables compaction filter.

This is no longer necessary after this PR, since the `DbStressCompactionFilter` is now aware of
the presence of timestamps.

Test plan
TEST_TMPDIR=/dev/shm make crash_test_with_ts