### PR TITLE
Enable blob caching for MultiGetBlob in RocksDB

### DIFF
--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -415,8 +415,6 @@ void BlobFileReader::MultiGetBlob(const ReadOptions& read_options,
   uint64_t total_len = 0;
   for (size_t i = 0; i < num_blobs; ++i) {
     const size_t key_size = blob_reqs[i]->user_key->size();
-    assert(IsValidBlobOffset(blob_reqs[i]->offset, key_size, blob_reqs[i]->len,
-                             file_size_));
     const uint64_t adjustment =
         read_options.verify_checksums
             ? BlobLogRecord::CalculateAdjustmentForRecordHeader(key_size)

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -11,6 +11,7 @@
 #include "file/random_access_file_reader.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/rocksdb_namespace.h"
+#include "table/multiget_context.h"
 #include "util/autovector.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -47,12 +48,9 @@ class BlobFileReader {
                  uint64_t* bytes_read) const;
 
   // offsets must be sorted in ascending order by caller.
-  void MultiGetBlob(
-      const ReadOptions& read_options,
-      const autovector<std::reference_wrapper<const Slice>>& user_keys,
-      const autovector<uint64_t>& offsets,
-      const autovector<uint64_t>& value_sizes, autovector<Status*>& statuses,
-      autovector<PinnableSlice*>& values, uint64_t* bytes_read) const;
+  void MultiGetBlob(const ReadOptions& read_options,
+                    autovector<BlobReadRequest*>& blob_reqs,
+                    uint64_t* bytes_read) const;
 
   CompressionType GetCompressionType() const { return compression_type_; }
 

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -8,6 +8,7 @@
 #include <cinttypes>
 #include <memory>
 
+#include "db/blob/blob_read_request.h"
 #include "file/random_access_file_reader.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/rocksdb_namespace.h"

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -12,7 +12,6 @@
 #include "file/random_access_file_reader.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/rocksdb_namespace.h"
-#include "table/multiget_context.h"
 #include "util/autovector.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -201,8 +201,9 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     autovector<BlobReadRequest*> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; ++i) {
-      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                                        &value_buf[i], &statuses_buf[i]);
+      requests_buf[i] =
+          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                          kNoCompression, &value_buf[i], &statuses_buf[i]);
       blob_reqs.push_back(&requests_buf[i]);
     }
 
@@ -303,16 +304,14 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     std::array<Status, num_blobs> statuses_buf;
     std::array<PinnableSlice, num_blobs> value_buf;
     std::array<BlobReadRequest, num_blobs> requests_buf;
+    autovector<BlobReadRequest*> blob_reqs;
 
-    requests_buf[0] = BlobReadRequest(key_refs[0], offsets[0], blob_sizes[0],
-                                      &value_buf[0], &statuses_buf[0]);
-    requests_buf[1] = BlobReadRequest(key_refs[1], offsets[1], blob_sizes[1],
-                                      &value_buf[1], &statuses_buf[1]);
-    requests_buf[2] = BlobReadRequest(key_refs[2], offsets[2], blob_sizes[2],
-                                      &value_buf[2], &statuses_buf[2]);
-
-    autovector<BlobReadRequest*> blob_reqs = {
-        &requests_buf[0], &requests_buf[1], &requests_buf[2]};
+    for (size_t i = 0; i < num_blobs; ++i) {
+      requests_buf[i] =
+          BlobReadRequest(key_refs[i], offsets[i], blob_sizes[i],
+                          kNoCompression, &value_buf[i], &statuses_buf[i]);
+      blob_reqs.push_back(&requests_buf[i]);
+    }
 
     reader->MultiGetBlob(read_options, blob_reqs, &bytes_read);
 
@@ -350,15 +349,11 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     std::array<PinnableSlice, num_blobs> value_buf;
     std::array<BlobReadRequest, num_blobs> requests_buf;
 
-    requests_buf[0] =
-        BlobReadRequest(key_refs[0], blob_offsets[0], blob_sizes[0],
-                        &value_buf[0], &statuses_buf[0]);
-    requests_buf[1] =
-        BlobReadRequest(key_refs[1], blob_offsets[1], blob_sizes[1],
-                        &value_buf[1], &statuses_buf[1]);
-    requests_buf[2] =
-        BlobReadRequest(key_refs[2], blob_offsets[2], blob_sizes[2],
-                        &value_buf[2], &statuses_buf[2]);
+    for (size_t i = 0; i < num_blobs; ++i) {
+      requests_buf[i] =
+          BlobReadRequest(key_refs[i], blob_offsets[i], blob_sizes[i],
+                          kNoCompression, &value_buf[i], &statuses_buf[i]);
+    }
 
     autovector<BlobReadRequest*> blob_reqs = {
         &requests_buf[0], &requests_buf[1], &requests_buf[2]};
@@ -366,7 +361,6 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     reader->MultiGetBlob(read_options, blob_reqs, &bytes_read);
 
     for (size_t i = 0; i < num_blobs; ++i) {
-      printf("%zu: %s\n", i, statuses_buf[i].ToString().c_str());
       if (i == num_blobs - 1) {
         ASSERT_TRUE(statuses_buf[i].IsCorruption());
       } else {
@@ -399,13 +393,13 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
 
     requests_buf[0] =
         BlobReadRequest(key_refs[0], blob_offsets[0], blob_sizes[0],
-                        &value_buf[0], &statuses_buf[0]);
+                        kNoCompression, &value_buf[0], &statuses_buf[0]);
     requests_buf[1] =
         BlobReadRequest(key_refs[1], blob_offsets[1], blob_sizes[1] + 1,
-                        &value_buf[1], &statuses_buf[1]);
+                        kNoCompression, &value_buf[1], &statuses_buf[1]);
     requests_buf[2] =
         BlobReadRequest(key_refs[2], blob_offsets[2], blob_sizes[2],
-                        &value_buf[2], &statuses_buf[2]);
+                        kNoCompression, &value_buf[2], &statuses_buf[2]);
 
     autovector<BlobReadRequest*> blob_reqs = {
         &requests_buf[0], &requests_buf[1], &requests_buf[2]};

--- a/db/blob/blob_read_request.h
+++ b/db/blob/blob_read_request.h
@@ -24,17 +24,17 @@ struct BlobReadRequest {
   uint64_t offset = 0;
 
   // Length to read in bytes
-  size_t len;
+  size_t len = 0;
 
   // Blob compression type
-  CompressionType compression;
+  CompressionType compression = kNoCompression;
 
   // Output parameter set by MultiGetBlob() to point to the data buffer, and
   // the number of valid bytes
-  PinnableSlice* result;
+  PinnableSlice* result = nullptr;
 
   // Status of read
-  Status* status;
+  Status* status = nullptr;
 
   BlobReadRequest(const Slice& _user_key, uint64_t _offset, size_t _len,
                   CompressionType _compression, PinnableSlice* _result,

--- a/db/blob/blob_read_request.h
+++ b/db/blob/blob_read_request.h
@@ -14,9 +14,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-class Status;
-class Slice;
-
 // A read Blob request structure for use in BlobSource::MultiGetBlob and
 // BlobFileReader::MultiGetBlob.
 struct BlobReadRequest {

--- a/db/blob/blob_read_request.h
+++ b/db/blob/blob_read_request.h
@@ -1,0 +1,61 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cinttypes>
+
+#include "rocksdb/compression_type.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "util/autovector.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class Status;
+class Slice;
+
+// A read Blob request structure for use in BlobSource::MultiGetBlob and
+// BlobFileReader::MultiGetBlob.
+struct BlobReadRequest {
+  // User key to lookup the paired blob
+  const Slice* user_key = nullptr;
+
+  // File offset in bytes
+  uint64_t offset = 0;
+
+  // Length to read in bytes
+  size_t len;
+
+  // Blob compression type
+  CompressionType compression;
+
+  // Output parameter set by MultiGetBlob() to point to the data buffer, and
+  // the number of valid bytes
+  PinnableSlice* result;
+
+  // Status of read
+  Status* status;
+
+  BlobReadRequest(const Slice& _user_key, uint64_t _offset, size_t _len,
+                  CompressionType _compression, PinnableSlice* _result,
+                  Status* _status)
+      : user_key(&_user_key),
+        offset(_offset),
+        len(_len),
+        compression(_compression),
+        result(_result),
+        status(_status) {}
+
+  BlobReadRequest() = default;
+  BlobReadRequest(const BlobReadRequest& other) = default;
+  BlobReadRequest& operator=(const BlobReadRequest& other) = default;
+};
+
+using BlobFileReadRequests =
+    std::tuple<uint64_t /* file_number */, uint64_t /* file_size */,
+               autovector<BlobReadRequest>>;
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -204,7 +204,7 @@ Status BlobSource::GetBlob(const ReadOptions& read_options,
 
 void BlobSource::MultiGetBlob(
     const ReadOptions& read_options,
-    std::unordered_map<uint64_t, autovector<BlobReadRequest>>& blob_reqs,
+    std::map<uint64_t, autovector<BlobReadRequest>>& blob_reqs,
     uint64_t* bytes_read) {
   assert(blob_reqs.size() > 0);
 
@@ -357,7 +357,7 @@ void BlobSource::MultiGetBlobFromOneFile(
     blob_file_reader.GetValue()->MultiGetBlob(read_options, _blob_reqs,
                                               &_bytes_read);
 
-    if (read_options.fill_cache) {
+    if (blob_cache_ && read_options.fill_cache) {
       // If filling cache is allowed and a cache is configured, try to put
       // the blob(s) to the cache.
       for (size_t i = 0; i < _blob_reqs.size(); ++i) {

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -218,8 +218,8 @@ void BlobSource::MultiGetBlob(
 
     auto& blob_reqs_in_file = batch_rqs.second;
     if (!s.ok()) {
-      for (const auto& blob : blob_reqs_in_file) {
-        *(blob.status) = s;
+      for (const auto& blob_req : blob_reqs_in_file) {
+        *blob_req.status = s;
       }
       continue;
     }
@@ -242,11 +242,11 @@ void BlobSource::MultiGetBlob(
       const uint64_t offset = blob_req.offset;
       const uint64_t value_size = blob_req.len;
       if (!IsValidBlobOffset(offset, key_size, value_size, file_size)) {
-        *(blob_req.status) = Status::Corruption("Invalid blob offset");
+        *blob_req.status = Status::Corruption("Invalid blob offset");
         continue;
       }
       if (blob_req.compression != compression) {
-        *(blob_req.status) =
+        *blob_req.status =
             Status::Corruption("Compression type mismatch when reading a blob");
         continue;
       }

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -204,22 +204,70 @@ Status BlobSource::GetBlob(const ReadOptions& read_options,
 
 void BlobSource::MultiGetBlob(
     const ReadOptions& read_options,
-    const autovector<std::reference_wrapper<const Slice>>& user_keys,
-    uint64_t file_number, uint64_t file_size,
-    const autovector<uint64_t>& offsets,
-    const autovector<uint64_t>& value_sizes, autovector<Status*>& statuses,
-    autovector<PinnableSlice*>& blobs, uint64_t* bytes_read) {
-  size_t num_blobs = user_keys.size();
+    std::unordered_map<uint64_t, autovector<BlobReadRequest>>& blob_reqs,
+    uint64_t* bytes_read) {
+  assert(blob_reqs.size() > 0);
+
+  Status s;
+
+  for (auto& batch_rqs : blob_reqs) {
+    const uint64_t file_number = batch_rqs.first;
+    CacheHandleGuard<BlobFileReader> blob_file_reader;
+    s = GetBlobFileReader(file_number, &blob_file_reader);
+    assert(!s.ok() || blob_file_reader.GetValue());
+
+    auto& blob_reqs_in_file = batch_rqs.second;
+    if (!s.ok()) {
+      for (const auto& blob : blob_reqs_in_file) {
+        *(blob.status) = s;
+      }
+      continue;
+    }
+
+    assert(blob_file_reader.GetValue());
+    const uint64_t file_size = blob_file_reader.GetValue()->GetFileSize();
+    const CompressionType compression =
+        blob_file_reader.GetValue()->GetCompressionType();
+
+    // sort blob_reqs_in_file by file offset.
+    std::sort(
+        blob_reqs_in_file.begin(), blob_reqs_in_file.end(),
+        [](const BlobReadRequest& lhs, const BlobReadRequest& rhs) -> bool {
+          return lhs.offset < rhs.offset;
+        });
+
+    autovector<BlobReadRequest*> _batch_rqs;
+    for (auto& blob_req : blob_reqs_in_file) {
+      const uint64_t key_size = blob_req.user_key->size();
+      const uint64_t offset = blob_req.offset;
+      const uint64_t value_size = blob_req.len;
+      if (!IsValidBlobOffset(offset, key_size, value_size, file_size)) {
+        *(blob_req.status) = Status::Corruption("Invalid blob offset");
+        continue;
+      }
+      if (blob_req.compression != compression) {
+        *(blob_req.status) =
+            Status::Corruption("Compression type mismatch when reading a blob");
+        continue;
+      }
+      _batch_rqs.push_back(&blob_req);
+    }
+
+    MultiGetBlobFromOneFile(read_options, file_number, file_size, _batch_rqs,
+                            bytes_read);
+  }
+}
+
+void BlobSource::MultiGetBlobFromOneFile(
+    const ReadOptions& read_options, uint64_t file_number, uint64_t file_size,
+    autovector<BlobReadRequest*>& blob_reqs, uint64_t* bytes_read) {
+  const size_t num_blobs = blob_reqs.size();
   assert(num_blobs > 0);
   assert(num_blobs <= MultiGetContext::MAX_BATCH_SIZE);
-  assert(num_blobs == offsets.size());
-  assert(num_blobs == value_sizes.size());
-  assert(num_blobs == statuses.size());
-  assert(num_blobs == blobs.size());
 
 #ifndef NDEBUG
-  for (size_t i = 0; i < offsets.size() - 1; ++i) {
-    assert(offsets[i] <= offsets[i + 1]);
+  for (size_t i = 0; i < num_blobs - 1; ++i) {
+    assert(blob_reqs[i]->offset <= blob_reqs[i + 1]->offset);
   }
 #endif  // !NDEBUG
 
@@ -234,15 +282,18 @@ void BlobSource::MultiGetBlob(
   if (blob_cache_) {
     size_t cached_blob_count = 0;
     for (size_t i = 0; i < num_blobs; ++i) {
+      auto& req = blob_reqs[i];
+
       CachableEntry<std::string> blob_entry;
-      const CacheKey cache_key = base_cache_key.WithOffset(offsets[i]);
+      const CacheKey cache_key = base_cache_key.WithOffset(req->offset);
       const Slice key = cache_key.AsSlice();
 
       s = GetBlobFromCache(key, &blob_entry);
+
       if (s.ok() && blob_entry.GetValue()) {
-        assert(statuses[i]);
-        *statuses[i] = s;
-        blobs[i]->PinSelf(*blob_entry.GetValue());
+        assert(req->status);
+        *req->status = s;
+        req->result->PinSelf(*blob_entry.GetValue());
 
         // Update the counter for the number of valid blobs read from the cache.
         ++cached_blob_count;
@@ -251,10 +302,10 @@ void BlobSource::MultiGetBlob(
         uint64_t adjustment =
             read_options.verify_checksums
                 ? BlobLogRecord::CalculateAdjustmentForRecordHeader(
-                      user_keys[i].get().size())
+                      req->user_key->size())
                 : 0;
-        assert(offsets[i] >= adjustment);
-        total_bytes += value_sizes[i] + adjustment;
+        assert(req->offset >= adjustment);
+        total_bytes += req->len + adjustment;
         cache_hit_mask |= (Mask{1} << i);  // cache hit
       }
     }
@@ -272,8 +323,8 @@ void BlobSource::MultiGetBlob(
   if (no_io) {
     for (size_t i = 0; i < num_blobs; ++i) {
       if (!(cache_hit_mask & (Mask{1} << i))) {
-        assert(statuses[i]);
-        *statuses[i] =
+        assert(blob_reqs[i]->status);
+        *blob_reqs[i]->status =
             Status::Incomplete("Cannot read blob(s): no disk I/O allowed");
       }
     }
@@ -282,50 +333,42 @@ void BlobSource::MultiGetBlob(
 
   {
     // Find the rest of blobs from the file since I/O is allowed.
-    autovector<std::reference_wrapper<const Slice>> _user_keys;
-    autovector<uint64_t> _offsets;
-    autovector<uint64_t> _value_sizes;
-    autovector<Status*> _statuses;
-    autovector<PinnableSlice*> _blobs;
+    autovector<BlobReadRequest*> _blob_reqs;
     uint64_t _bytes_read = 0;
 
     for (size_t i = 0; i < num_blobs; ++i) {
       if (!(cache_hit_mask & (Mask{1} << i))) {
-        _user_keys.emplace_back(user_keys[i]);
-        _offsets.push_back(offsets[i]);
-        _value_sizes.push_back(value_sizes[i]);
-        _statuses.push_back(statuses[i]);
-        _blobs.push_back(blobs[i]);
+        _blob_reqs.push_back(blob_reqs[i]);
       }
     }
 
     CacheHandleGuard<BlobFileReader> blob_file_reader;
     s = blob_file_cache_->GetBlobFileReader(file_number, &blob_file_reader);
     if (!s.ok()) {
-      for (size_t i = 0; i < _blobs.size(); ++i) {
-        assert(_statuses[i]);
-        *_statuses[i] = s;
+      for (size_t i = 0; i < _blob_reqs.size(); ++i) {
+        assert(_blob_reqs[i]->status);
+        *_blob_reqs[i]->status = s;
       }
       return;
     }
 
     assert(blob_file_reader.GetValue());
 
-    blob_file_reader.GetValue()->MultiGetBlob(read_options, _user_keys,
-                                              _offsets, _value_sizes, _statuses,
-                                              _blobs, &_bytes_read);
+    blob_file_reader.GetValue()->MultiGetBlob(read_options, _blob_reqs,
+                                              &_bytes_read);
 
     if (read_options.fill_cache) {
       // If filling cache is allowed and a cache is configured, try to put
       // the blob(s) to the cache.
-      for (size_t i = 0; i < _blobs.size(); ++i) {
-        if (_statuses[i]->ok()) {
+      for (size_t i = 0; i < _blob_reqs.size(); ++i) {
+        if (_blob_reqs[i]->status->ok()) {
           CachableEntry<std::string> blob_entry;
-          const CacheKey cache_key = base_cache_key.WithOffset(_offsets[i]);
+          const CacheKey cache_key =
+              base_cache_key.WithOffset(_blob_reqs[i]->offset);
           const Slice key = cache_key.AsSlice();
-          s = PutBlobIntoCache(key, &blob_entry, _blobs[i]);
+          s = PutBlobIntoCache(key, &blob_entry, _blob_reqs[i]->result);
           if (!s.ok()) {
-            *_statuses[i] = s;
+            *_blob_reqs[i]->status = s;
           }
         }
       }

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -206,52 +206,13 @@ void BlobSource::MultiGetBlob(const ReadOptions& read_options,
                               autovector<BlobFileReadRequests>& blob_reqs,
                               uint64_t* bytes_read) {
   assert(blob_reqs.size() > 0);
-
-  Status s;
-
-  for (auto& batch_req : blob_reqs) {
-    auto& [file_number, file_size, blob_reqs_in_file] = batch_req;
-    // CacheHandleGuard<BlobFileReader> blob_file_reader;
-    // s = GetBlobFileReader(file_number, &blob_file_reader);
-    // assert(!s.ok() || blob_file_reader.GetValue());
-
-    // if (!s.ok()) {
-    //   for (const auto& blob_req : blob_reqs_in_file) {
-    //     *blob_req.status = s;
-    //   }
-    //   continue;
-    // }
-
-    // assert(blob_file_reader.GetValue());
-    // const uint64_t file_size = blob_file_reader.GetValue()->GetFileSize();
-    // const CompressionType compression =
-    //     blob_file_reader.GetValue()->GetCompressionType();
-
+  for (auto& [file_number, file_size, blob_reqs_in_file] : blob_reqs) {
     // sort blob_reqs_in_file by file offset.
     std::sort(
         blob_reqs_in_file.begin(), blob_reqs_in_file.end(),
         [](const BlobReadRequest& lhs, const BlobReadRequest& rhs) -> bool {
           return lhs.offset < rhs.offset;
         });
-
-    // autovector<BlobReadRequest*> _batch_reqs;
-    // for (auto& blob_req : blob_reqs_in_file) {
-    //   const uint64_t key_size = blob_req.user_key->size();
-    //   const uint64_t offset = blob_req.offset;
-    //   const uint64_t value_size = blob_req.len;
-    //   if (!IsValidBlobOffset(offset, key_size, value_size, file_size)) {
-    //     *blob_req.status = Status::Corruption("Invalid blob offset");
-    //     continue;
-    //   }
-    //   if (blob_req.compression != compression) {
-    //     *blob_req.status =
-    //         Status::Corruption("Compression type mismatch when reading a
-    //         blob");
-    //     continue;
-    //   }
-    //   _batch_reqs.push_back(&blob_req);
-    // }
-
     MultiGetBlobFromOneFile(read_options, file_number, file_size,
                             blob_reqs_in_file, bytes_read);
   }

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -247,9 +247,6 @@ void BlobSource::MultiGetBlobFromOneFile(const ReadOptions& read_options,
   using Mask = uint64_t;
   Mask cache_hit_mask = 0;
 
-  Status s;
-  s.PermitUncheckedError();
-
   uint64_t total_bytes = 0;
   const OffsetableCacheKey base_cache_key(db_id_, db_session_id_, file_number,
                                           file_size);
@@ -263,7 +260,7 @@ void BlobSource::MultiGetBlobFromOneFile(const ReadOptions& read_options,
       const CacheKey cache_key = base_cache_key.WithOffset(req.offset);
       const Slice key = cache_key.AsSlice();
 
-      s = GetBlobFromCache(key, &blob_entry);
+      const Status s = GetBlobFromCache(key, &blob_entry);
 
       if (s.ok() && blob_entry.GetValue()) {
         assert(req.status);
@@ -318,7 +315,8 @@ void BlobSource::MultiGetBlobFromOneFile(const ReadOptions& read_options,
     }
 
     CacheHandleGuard<BlobFileReader> blob_file_reader;
-    s = blob_file_cache_->GetBlobFileReader(file_number, &blob_file_reader);
+    Status s =
+        blob_file_cache_->GetBlobFileReader(file_number, &blob_file_reader);
     if (!s.ok()) {
       for (size_t i = 0; i < _blob_reqs.size(); ++i) {
         assert(_blob_reqs[i]->status);

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -206,6 +206,10 @@ void BlobSource::MultiGetBlob(const ReadOptions& read_options,
                               autovector<BlobFileReadRequests>& blob_reqs,
                               uint64_t* bytes_read) {
   assert(blob_reqs.size() > 0);
+
+  uint64_t total_bytes_read = 0;
+  uint64_t bytes_read_in_file = 0;
+
   for (auto& [file_number, file_size, blob_reqs_in_file] : blob_reqs) {
     // sort blob_reqs_in_file by file offset.
     std::sort(
@@ -213,8 +217,15 @@ void BlobSource::MultiGetBlob(const ReadOptions& read_options,
         [](const BlobReadRequest& lhs, const BlobReadRequest& rhs) -> bool {
           return lhs.offset < rhs.offset;
         });
+
     MultiGetBlobFromOneFile(read_options, file_number, file_size,
-                            blob_reqs_in_file, bytes_read);
+                            blob_reqs_in_file, &bytes_read_in_file);
+
+    total_bytes_read += bytes_read_in_file;
+  }
+
+  if (bytes_read) {
+    *bytes_read = total_bytes_read;
   }
 }
 

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -248,6 +248,8 @@ void BlobSource::MultiGetBlobFromOneFile(const ReadOptions& read_options,
   Mask cache_hit_mask = 0;
 
   Status s;
+  s.PermitUncheckedError();
+
   uint64_t total_bytes = 0;
   const OffsetableCacheKey base_cache_key(db_id_, db_session_id_, file_number,
                                           file_size);

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -13,6 +13,7 @@
 #include "rocksdb/cache.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "table/block_based/cachable_entry.h"
+#include "table/multiget_context.h"
 #include "util/autovector.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -37,7 +38,7 @@ class BlobSource {
 
   ~BlobSource();
 
-  // Read a blob from the underlying cache or storage.
+  // Read a blob from the underlying cache or one on-disk blob file.
   //
   // If successful, returns ok and sets "*value" to the newly retrieved
   // uncompressed blob. If there was an error while fetching the blob, sets
@@ -52,25 +53,45 @@ class BlobSource {
                  FilePrefetchBuffer* prefetch_buffer, PinnableSlice* value,
                  uint64_t* bytes_read);
 
-  // Read multiple blobs from the underlying cache or storage.
+  // Read multiple blobs from the underlying cache or on-disk blob file(s).
   //
-  // If successful, returns ok and sets the elements of blobs to the newly
+  // If successful, returns ok and sets the elements of "blob_reqs" to the newly
   // retrieved uncompressed blobs. If there was an error while fetching one of
-  // blobs, sets its corresponding "blobs[i]" to empty and sets "statuses[i]" to
-  // a non-ok status.
+  // blobs, sets its corresponding "blob_reqs[i].result" to empty and sets
+  // "blob_reqs[i].status" to a non-ok status.
   //
   // Note:
-  //  - Offsets must be sorted in ascending order by caller.
+  //  - The main difference between this function and MultiGetBlobFromOneFile is
+  //    that this function can read multiple blobs from multiple blob files.
+  //
   //  - For consistency, whether the blob is found in the cache or on disk, sets
   //  "*bytes_read" to the total size of on-disk (possibly compressed) blob
   //  records.
-  void MultiGetBlob(
-      const ReadOptions& read_options,
-      const autovector<std::reference_wrapper<const Slice>>& user_keys,
-      uint64_t file_number, uint64_t file_size,
-      const autovector<uint64_t>& offsets,
-      const autovector<uint64_t>& value_sizes, autovector<Status*>& statuses,
-      autovector<PinnableSlice*>& blobs, uint64_t* bytes_read);
+  void MultiGetBlob(const ReadOptions& read_options,
+                    std::unordered_map</*blob file number*/ uint64_t,
+                                       autovector<BlobReadRequest>>& blob_reqs,
+                    uint64_t* bytes_read);
+
+  // Read multiple blobs from the underlying cache or one on-disk blob file.
+  //
+  // If successful, returns ok and sets the elements of "blob_reqs" to the newly
+  // retrieved uncompressed blobs. If there was an error while fetching one of
+  // blobs, sets its corresponding "blob_reqs[i].result" to empty and sets
+  // "blob_reqs[i].status" to a non-ok status.
+  //
+  // Note:
+  //  - The main difference between this function and MultiGetBlob is that this
+  //  function is only used for the case where the demanded blobs are stored in
+  //  one blob file. MultiGetBlob will call this function multiple times if the
+  //  demanded blobs are stored in multiple blob files.
+  //
+  //  - For consistency, whether the blob is found in the cache or on disk, sets
+  //  "*bytes_read" to the total size of on-disk (possibly compressed) blob
+  //  records.
+  void MultiGetBlobFromOneFile(const ReadOptions& read_options,
+                               uint64_t file_number, uint64_t file_size,
+                               autovector<BlobReadRequest*>& blob_reqs,
+                               uint64_t* bytes_read);
 
   inline Status GetBlobFileReader(
       uint64_t blob_file_number,

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -68,8 +68,8 @@ class BlobSource {
   //  "*bytes_read" to the total size of on-disk (possibly compressed) blob
   //  records.
   void MultiGetBlob(const ReadOptions& read_options,
-                    std::unordered_map</*blob file number*/ uint64_t,
-                                       autovector<BlobReadRequest>>& blob_reqs,
+                    std::map</*blob file number*/ uint64_t,
+                             autovector<BlobReadRequest>>& blob_reqs,
                     uint64_t* bytes_read);
 
   // Read multiple blobs from the underlying cache or one on-disk blob file.

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -14,7 +14,6 @@
 #include "rocksdb/cache.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "table/block_based/cachable_entry.h"
-#include "table/multiget_context.h"
 #include "util/autovector.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -10,6 +10,7 @@
 #include "cache/cache_helpers.h"
 #include "cache/cache_key.h"
 #include "db/blob/blob_file_cache.h"
+#include "db/blob/blob_read_request.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "table/block_based/cachable_entry.h"
@@ -38,7 +39,7 @@ class BlobSource {
 
   ~BlobSource();
 
-  // Read a blob from the underlying cache or one on-disk blob file.
+  // Read a blob from the underlying cache or one blob file.
   //
   // If successful, returns ok and sets "*value" to the newly retrieved
   // uncompressed blob. If there was an error while fetching the blob, sets
@@ -53,12 +54,12 @@ class BlobSource {
                  FilePrefetchBuffer* prefetch_buffer, PinnableSlice* value,
                  uint64_t* bytes_read);
 
-  // Read multiple blobs from the underlying cache or on-disk blob file(s).
+  // Read multiple blobs from the underlying cache or blob file(s).
   //
-  // If successful, returns ok and sets the elements of "blob_reqs" to the newly
-  // retrieved uncompressed blobs. If there was an error while fetching one of
-  // blobs, sets its corresponding "blob_reqs[i].result" to empty and sets
-  // "blob_reqs[i].status" to a non-ok status.
+  // If successful, returns ok and sets "result" in the elements of "blob_reqs"
+  // to the newly retrieved uncompressed blobs. If there was an error while
+  // fetching one of blobs, sets its "result" to empty and sets its
+  // corresponding "status" to a non-ok status.
   //
   // Note:
   //  - The main difference between this function and MultiGetBlobFromOneFile is
@@ -68,16 +69,15 @@ class BlobSource {
   //  "*bytes_read" to the total size of on-disk (possibly compressed) blob
   //  records.
   void MultiGetBlob(const ReadOptions& read_options,
-                    std::map</*blob file number*/ uint64_t,
-                             autovector<BlobReadRequest>>& blob_reqs,
+                    autovector<BlobFileReadRequests>& blob_reqs,
                     uint64_t* bytes_read);
 
-  // Read multiple blobs from the underlying cache or one on-disk blob file.
+  // Read multiple blobs from the underlying cache or one blob file.
   //
-  // If successful, returns ok and sets the elements of "blob_reqs" to the newly
-  // retrieved uncompressed blobs. If there was an error while fetching one of
-  // blobs, sets its corresponding "blob_reqs[i].result" to empty and sets
-  // "blob_reqs[i].status" to a non-ok status.
+  // If successful, returns ok and sets "result" in the elements of "blob_reqs"
+  // to the newly retrieved uncompressed blobs. If there was an error while
+  // fetching one of blobs, sets its "result" to empty and sets its
+  // corresponding "status" to a non-ok status.
   //
   // Note:
   //  - The main difference between this function and MultiGetBlob is that this
@@ -90,7 +90,7 @@ class BlobSource {
   //  records.
   void MultiGetBlobFromOneFile(const ReadOptions& read_options,
                                uint64_t file_number, uint64_t file_size,
-                               autovector<BlobReadRequest*>& blob_reqs,
+                               autovector<BlobReadRequest>& blob_reqs,
                                uint64_t* bytes_read);
 
   inline Status GetBlobFileReader(

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -633,12 +633,8 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
     autovector<BlobReadRequest*> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i += 2) {  // even index
-      requests_buf[i].user_key = &keys[i];
-      requests_buf[i].offset = blob_offsets[i];
-      requests_buf[i].len = blob_sizes[i];
-      requests_buf[i].compression = kNoCompression;
-      requests_buf[i].result = &value_buf[i];
-      requests_buf[i].status = &statuses_buf[i];
+      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                                        &value_buf[i], &statuses_buf[i]);
       blob_reqs.push_back(&requests_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                 blob_offsets[i]));
@@ -713,12 +709,8 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
 
     blob_reqs.clear();
     for (size_t i = 0; i < num_blobs; ++i) {
-      requests_buf[i].user_key = &keys[i];
-      requests_buf[i].offset = blob_offsets[i];
-      requests_buf[i].len = blob_sizes[i];
-      requests_buf[i].compression = kNoCompression;
-      requests_buf[i].result = &value_buf[i];
-      requests_buf[i].status = &statuses_buf[i];
+      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                                        &value_buf[i], &statuses_buf[i]);
       blob_reqs.push_back(&requests_buf[i]);
     }
 
@@ -763,12 +755,8 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
     autovector<BlobReadRequest*> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i++) {
-      requests_buf[i].user_key = &keys[i];
-      requests_buf[i].offset = blob_offsets[i];
-      requests_buf[i].len = blob_sizes[i];
-      requests_buf[i].compression = kNoCompression;
-      requests_buf[i].result = &value_buf[i];
-      requests_buf[i].status = &statuses_buf[i];
+      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                                        &value_buf[i], &statuses_buf[i]);
       blob_reqs.push_back(&requests_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                 blob_offsets[i]));
@@ -812,12 +800,8 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
     autovector<BlobReadRequest*> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i++) {
-      requests_buf[i].user_key = &keys[i];
-      requests_buf[i].offset = blob_offsets[i];
-      requests_buf[i].len = blob_sizes[i];
-      requests_buf[i].compression = kNoCompression;
-      requests_buf[i].result = &value_buf[i];
-      requests_buf[i].status = &statuses_buf[i];
+      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                                        &value_buf[i], &statuses_buf[i]);
       blob_reqs.push_back(&requests_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(non_existing_file_number,
                                                 file_size, blob_offsets[i]));

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -630,12 +630,13 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
     std::array<Status, num_blobs> statuses_buf;
     std::array<PinnableSlice, num_blobs> value_buf;
     std::array<BlobReadRequest, num_blobs> requests_buf;
-    autovector<BlobReadRequest*> blob_reqs;
+    autovector<BlobReadRequest> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i += 2) {  // even index
-      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                                        &value_buf[i], &statuses_buf[i]);
-      blob_reqs.push_back(&requests_buf[i]);
+      requests_buf[i] =
+          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                          kNoCompression, &value_buf[i], &statuses_buf[i]);
+      blob_reqs.push_back(requests_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                 blob_offsets[i]));
     }
@@ -709,9 +710,10 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
 
     blob_reqs.clear();
     for (size_t i = 0; i < num_blobs; ++i) {
-      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                                        &value_buf[i], &statuses_buf[i]);
-      blob_reqs.push_back(&requests_buf[i]);
+      requests_buf[i] =
+          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                          kNoCompression, &value_buf[i], &statuses_buf[i]);
+      blob_reqs.push_back(requests_buf[i]);
     }
 
     blob_source.MultiGetBlobFromOneFile(read_options, blob_file_number,
@@ -752,12 +754,13 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
     std::array<Status, num_blobs> statuses_buf;
     std::array<PinnableSlice, num_blobs> value_buf;
     std::array<BlobReadRequest, num_blobs> requests_buf;
-    autovector<BlobReadRequest*> blob_reqs;
+    autovector<BlobReadRequest> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i++) {
-      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                                        &value_buf[i], &statuses_buf[i]);
-      blob_reqs.push_back(&requests_buf[i]);
+      requests_buf[i] =
+          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                          kNoCompression, &value_buf[i], &statuses_buf[i]);
+      blob_reqs.push_back(requests_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                 blob_offsets[i]));
     }
@@ -797,12 +800,13 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
     std::array<Status, num_blobs> statuses_buf;
     std::array<PinnableSlice, num_blobs> value_buf;
     std::array<BlobReadRequest, num_blobs> requests_buf;
-    autovector<BlobReadRequest*> blob_reqs;
+    autovector<BlobReadRequest> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i++) {
-      requests_buf[i] = BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                                        &value_buf[i], &statuses_buf[i]);
-      blob_reqs.push_back(&requests_buf[i]);
+      requests_buf[i] =
+          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
+                          kNoCompression, &value_buf[i], &statuses_buf[i]);
+      blob_reqs.push_back(requests_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(non_existing_file_number,
                                                 file_size, blob_offsets[i]));
     }

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -741,16 +741,16 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromMultiFiles) {
     ASSERT_GE((int)get_perf_context()->blob_checksum_time, 0);
     ASSERT_EQ((int)get_perf_context()->blob_decompress_time, 0);
 
-    ASSERT_EQ(statistics->getTickerCount(BLOB_DB_CACHE_MISS),
-              num_blobs * 2);  // MultiGetBlob
+    // Fake blob requests: MultiGetBlob and TEST_BlobInCache
+    ASSERT_EQ(statistics->getTickerCount(BLOB_DB_CACHE_MISS), num_blobs * 2);
+    // Real blob requests: MultiGetBlob and TEST_BlobInCache
     ASSERT_EQ(statistics->getTickerCount(BLOB_DB_CACHE_HIT),
-              num_blobs * blob_files * 2);  // TEST_BlobInCache
-    ASSERT_EQ(statistics->getTickerCount(BLOB_DB_CACHE_ADD),
-              0);  // MultiGetBlob
+              num_blobs * blob_files * 2);
+    ASSERT_EQ(statistics->getTickerCount(BLOB_DB_CACHE_ADD), 0);
+    // Real blob requests: MultiGetBlob and TEST_BlobInCache
     ASSERT_EQ(statistics->getTickerCount(BLOB_DB_CACHE_BYTES_READ),
-              blob_value_bytes * blob_files * 2);  // TEST_BlobInCache
-    ASSERT_EQ(statistics->getTickerCount(BLOB_DB_CACHE_BYTES_WRITE),
-              0);  // MultiGetBlob
+              blob_value_bytes * blob_files * 2);
+    ASSERT_EQ(statistics->getTickerCount(BLOB_DB_CACHE_BYTES_WRITE), 0);
   }
 }
 

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -822,14 +822,11 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
     uint64_t bytes_read = 0;
     std::array<Status, num_blobs> statuses_buf;
     std::array<PinnableSlice, num_blobs> value_buf;
-    std::array<BlobReadRequest, num_blobs> requests_buf;
     autovector<BlobReadRequest> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i += 2) {  // even index
-      requests_buf[i] =
-          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                          kNoCompression, &value_buf[i], &statuses_buf[i]);
-      blob_reqs.push_back(requests_buf[i]);
+      blob_reqs.emplace_back(keys[i], blob_offsets[i], blob_sizes[i],
+                             kNoCompression, &value_buf[i], &statuses_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                 blob_offsets[i]));
     }
@@ -903,10 +900,8 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
 
     blob_reqs.clear();
     for (size_t i = 0; i < num_blobs; ++i) {
-      requests_buf[i] =
-          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                          kNoCompression, &value_buf[i], &statuses_buf[i]);
-      blob_reqs.push_back(requests_buf[i]);
+      blob_reqs.emplace_back(keys[i], blob_offsets[i], blob_sizes[i],
+                             kNoCompression, &value_buf[i], &statuses_buf[i]);
     }
 
     blob_source.MultiGetBlobFromOneFile(read_options, blob_file_number,
@@ -946,14 +941,11 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
 
     std::array<Status, num_blobs> statuses_buf;
     std::array<PinnableSlice, num_blobs> value_buf;
-    std::array<BlobReadRequest, num_blobs> requests_buf;
     autovector<BlobReadRequest> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i++) {
-      requests_buf[i] =
-          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                          kNoCompression, &value_buf[i], &statuses_buf[i]);
-      blob_reqs.push_back(requests_buf[i]);
+      blob_reqs.emplace_back(keys[i], blob_offsets[i], blob_sizes[i],
+                             kNoCompression, &value_buf[i], &statuses_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(blob_file_number, file_size,
                                                 blob_offsets[i]));
     }
@@ -992,14 +984,11 @@ TEST_F(BlobSourceTest, MultiGetBlobsFromCache) {
 
     std::array<Status, num_blobs> statuses_buf;
     std::array<PinnableSlice, num_blobs> value_buf;
-    std::array<BlobReadRequest, num_blobs> requests_buf;
     autovector<BlobReadRequest> blob_reqs;
 
     for (size_t i = 0; i < num_blobs; i++) {
-      requests_buf[i] =
-          BlobReadRequest(keys[i], blob_offsets[i], blob_sizes[i],
-                          kNoCompression, &value_buf[i], &statuses_buf[i]);
-      blob_reqs.push_back(requests_buf[i]);
+      blob_reqs.emplace_back(keys[i], blob_offsets[i], blob_sizes[i],
+                             kNoCompression, &value_buf[i], &statuses_buf[i]);
       ASSERT_FALSE(blob_source.TEST_BlobInCache(non_existing_file_number,
                                                 file_size, blob_offsets[i]));
     }

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -629,7 +629,7 @@ TEST_F(DBBlobBasicTest, MultiGetBlobsFromMultipleFiles) {
   Options options = GetDefaultOptions();
 
   LRUCacheOptions co;
-  co.capacity = 2048;
+  co.capacity = 2 << 20; // 2MB
   co.num_shard_bits = 2;
   co.metadata_charge_policy = kDontChargeCacheMetadata;
   auto backing_cache = NewLRUCache(co);

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -299,6 +299,141 @@ TEST_F(DBBlobBasicTest, MultiGetBlobs) {
   }
 }
 
+TEST_F(DBBlobBasicTest, MultiGetBlobsFromCache) {
+  Options options = GetDefaultOptions();
+
+  LRUCacheOptions co;
+  co.capacity = 2048;
+  co.num_shard_bits = 2;
+  co.metadata_charge_policy = kDontChargeCacheMetadata;
+  auto backing_cache = NewLRUCache(co);
+
+  constexpr size_t min_blob_size = 6;
+  options.min_blob_size = min_blob_size;
+  options.create_if_missing = true;
+  options.enable_blob_files = true;
+  options.blob_cache = backing_cache;
+
+  BlockBasedTableOptions block_based_options;
+  block_based_options.no_block_cache = false;
+  block_based_options.block_cache = backing_cache;
+  block_based_options.cache_index_and_filter_blocks = true;
+  options.table_factory.reset(NewBlockBasedTableFactory(block_based_options));
+
+  DestroyAndReopen(options);
+
+  // Put then retrieve three key-values. The first value is below the size limit
+  // and is thus stored inline; the other two are stored separately as blobs.
+  constexpr size_t num_keys = 3;
+
+  constexpr char first_key[] = "first_key";
+  constexpr char first_value[] = "short";
+  static_assert(sizeof(first_value) - 1 < min_blob_size,
+                "first_value too long to be inlined");
+
+  ASSERT_OK(Put(first_key, first_value));
+
+  constexpr char second_key[] = "second_key";
+  constexpr char second_value[] = "long_value";
+  static_assert(sizeof(second_value) - 1 >= min_blob_size,
+                "second_value too short to be stored as blob");
+
+  ASSERT_OK(Put(second_key, second_value));
+
+  constexpr char third_key[] = "third_key";
+  constexpr char third_value[] = "other_long_value";
+  static_assert(sizeof(third_value) - 1 >= min_blob_size,
+                "third_value too short to be stored as blob");
+
+  ASSERT_OK(Put(third_key, third_value));
+
+  ASSERT_OK(Flush());
+
+  ReadOptions read_options;
+  read_options.fill_cache = false;
+
+  std::array<Slice, num_keys> keys{{first_key, second_key, third_key}};
+
+  {
+    std::array<PinnableSlice, num_keys> values;
+    std::array<Status, num_keys> statuses;
+
+    db_->MultiGet(read_options, db_->DefaultColumnFamily(), num_keys, &keys[0],
+                  &values[0], &statuses[0]);
+
+    ASSERT_OK(statuses[0]);
+    ASSERT_EQ(values[0], first_value);
+
+    ASSERT_OK(statuses[1]);
+    ASSERT_EQ(values[1], second_value);
+
+    ASSERT_OK(statuses[2]);
+    ASSERT_EQ(values[2], third_value);
+  }
+
+  // Try again with no I/O allowed. The first (inlined) value should be
+  // successfully read; however, the two blob values could only be read from the
+  // blob file, so for those the read should return Incomplete.
+  read_options.read_tier = kBlockCacheTier;
+
+  {
+    std::array<PinnableSlice, num_keys> values;
+    std::array<Status, num_keys> statuses;
+
+    db_->MultiGet(read_options, db_->DefaultColumnFamily(), num_keys, &keys[0],
+                  &values[0], &statuses[0]);
+
+    ASSERT_OK(statuses[0]);
+    ASSERT_EQ(values[0], first_value);
+
+    ASSERT_TRUE(statuses[1].IsIncomplete());
+
+    ASSERT_TRUE(statuses[2].IsIncomplete());
+  }
+
+  // Fill the cache when reading blobs from the blob file.
+  read_options.read_tier = kReadAllTier;
+  read_options.fill_cache = true;
+
+  {
+    std::array<PinnableSlice, num_keys> values;
+    std::array<Status, num_keys> statuses;
+
+    db_->MultiGet(read_options, db_->DefaultColumnFamily(), num_keys, &keys[0],
+                  &values[0], &statuses[0]);
+
+    ASSERT_OK(statuses[0]);
+    ASSERT_EQ(values[0], first_value);
+
+    ASSERT_OK(statuses[1]);
+    ASSERT_EQ(values[1], second_value);
+
+    ASSERT_OK(statuses[2]);
+    ASSERT_EQ(values[2], third_value);
+  }
+
+  // Try again with no I/O allowed. All blobs should be successfully read from
+  // the cache.
+  read_options.read_tier = kBlockCacheTier;
+
+  {
+    std::array<PinnableSlice, num_keys> values;
+    std::array<Status, num_keys> statuses;
+
+    db_->MultiGet(read_options, db_->DefaultColumnFamily(), num_keys, &keys[0],
+                  &values[0], &statuses[0]);
+
+    ASSERT_OK(statuses[0]);
+    ASSERT_EQ(values[0], first_value);
+
+    ASSERT_OK(statuses[1]);
+    ASSERT_EQ(values[1], second_value);
+
+    ASSERT_OK(statuses[2]);
+    ASSERT_EQ(values[2], third_value);
+  }
+}
+
 #ifndef ROCKSDB_LITE
 TEST_F(DBBlobBasicTest, MultiGetWithDirectIO) {
   Options options = GetDefaultOptions();

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1934,7 +1934,6 @@ void Version::MultiGetBlob(
         continue;
       }
 
-      printf("blob_file_number: %llu\n", blob_file_number);
       blob_reqs[blob_file_number].push_back(BlobReadRequest(
           key_context.ukey_with_ts, blob_index.offset(), blob_index.size(),
           key_context.value, key_context.s, blob_index.compression()));
@@ -1945,7 +1944,6 @@ void Version::MultiGetBlob(
                              /*bytes_read=*/nullptr);
 
   for (const auto& req : blob_reqs) {
-    printf("end blob_file_number: %llu\n", req.first);
     const auto& blob_reqs_in_file = req.second;
     for (const auto& blob_req : blob_reqs_in_file) {
       if (blob_req.status->ok()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1911,7 +1911,7 @@ void Version::MultiGetBlob(
   assert(!blob_ctxs.empty());
 
   Status status;
-  std::unordered_map<uint64_t, autovector<BlobReadRequest>> blob_reqs;
+  std::map<uint64_t, autovector<BlobReadRequest>> blob_reqs;
 
   for (auto& ctx : blob_ctxs) {
     const uint64_t blob_file_number = ctx.first;
@@ -1934,6 +1934,7 @@ void Version::MultiGetBlob(
         continue;
       }
 
+      printf("blob_file_number: %llu\n", blob_file_number);
       blob_reqs[blob_file_number].push_back(BlobReadRequest(
           key_context.ukey_with_ts, blob_index.offset(), blob_index.size(),
           key_context.value, key_context.s, blob_index.compression()));
@@ -1944,6 +1945,7 @@ void Version::MultiGetBlob(
                              /*bytes_read=*/nullptr);
 
   for (const auto& req : blob_reqs) {
+    printf("end blob_file_number: %llu\n", req.first);
     const auto& blob_reqs_in_file = req.second;
     for (const auto& blob_req : blob_reqs_in_file) {
       if (blob_req.status->ok()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1910,7 +1910,6 @@ void Version::MultiGetBlob(
     std::unordered_map<uint64_t, BlobReadContexts>& blob_ctxs) {
   assert(!blob_ctxs.empty());
 
-  Status status;
   std::map<uint64_t, autovector<BlobReadRequest>> blob_reqs;
 
   for (auto& ctx : blob_ctxs) {
@@ -1924,12 +1923,12 @@ void Version::MultiGetBlob(
       const KeyContext& key_context = blob.second;
 
       if (!blob_file_meta) {
-        *(key_context.s) = Status::Corruption("Invalid blob file number");
+        *key_context.s = Status::Corruption("Invalid blob file number");
         continue;
       }
 
       if (blob_index.HasTTL() || blob_index.IsInlined()) {
-        *(key_context.s) =
+        *key_context.s =
             Status::Corruption("Unexpected TTL/inlined blob index");
         continue;
       }
@@ -1949,7 +1948,7 @@ void Version::MultiGetBlob(
       if (blob_req.status->ok()) {
         range.AddValueSize(blob_req.result->size());
         if (range.GetValueSize() > read_options.value_size_soft_limit) {
-          *(blob_req.status) = Status::Aborted();
+          *blob_req.status = Status::Aborted();
         }
       }
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1907,113 +1907,49 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
 
 void Version::MultiGetBlob(
     const ReadOptions& read_options, MultiGetRange& range,
-    std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs) {
-  if (read_options.read_tier == kBlockCacheTier) {
-    Status s = Status::Incomplete("Cannot read blob(s): no disk I/O allowed");
-    for (const auto& elem : blob_rqs) {
-      for (const auto& blob_rq : elem.second) {
-        const KeyContext& key_context = blob_rq.second;
-        assert(key_context.s);
-        assert(key_context.s->ok());
-        *(key_context.s) = s;
-        assert(key_context.get_context);
-        auto& get_context = *(key_context.get_context);
-        get_context.MarkKeyMayExist();
-      }
-    }
-    return;
-  }
+    std::unordered_map<uint64_t, BlobReadContexts>& blob_ctxs) {
+  assert(!blob_ctxs.empty());
 
-  assert(!blob_rqs.empty());
   Status status;
+  std::unordered_map<uint64_t, autovector<BlobReadRequest>> blob_reqs;
 
-  for (auto& elem : blob_rqs) {
-    const uint64_t blob_file_number = elem.first;
+  for (auto& ctx : blob_ctxs) {
+    const uint64_t blob_file_number = ctx.first;
+    const auto blob_file_meta =
+        storage_info_.GetBlobFileMetaData(blob_file_number);
 
-    if (!storage_info_.GetBlobFileMetaData(blob_file_number)) {
-      auto& blobs_in_file = elem.second;
-      for (const auto& blob : blobs_in_file) {
-        const KeyContext& key_context = blob.second;
-        *(key_context.s) = Status::Corruption("Invalid blob file number");
-      }
-      continue;
-    }
-
-    CacheHandleGuard<BlobFileReader> blob_file_reader;
-    assert(blob_source_);
-    status =
-        blob_source_->GetBlobFileReader(blob_file_number, &blob_file_reader);
-    assert(!status.ok() || blob_file_reader.GetValue());
-
-    auto& blobs_in_file = elem.second;
-    if (!status.ok()) {
-      for (const auto& blob : blobs_in_file) {
-        const KeyContext& key_context = blob.second;
-        *(key_context.s) = status;
-      }
-      continue;
-    }
-
-    assert(blob_file_reader.GetValue());
-    const uint64_t file_size = blob_file_reader.GetValue()->GetFileSize();
-    const CompressionType compression =
-        blob_file_reader.GetValue()->GetCompressionType();
-
-    // sort blobs_in_file by file offset.
-    std::sort(
-        blobs_in_file.begin(), blobs_in_file.end(),
-        [](const BlobReadRequest& lhs, const BlobReadRequest& rhs) -> bool {
-          assert(lhs.first.file_number() == rhs.first.file_number());
-          return lhs.first.offset() < rhs.first.offset();
-        });
-
-    autovector<std::reference_wrapper<const KeyContext>> blob_read_key_contexts;
-    autovector<std::reference_wrapper<const Slice>> user_keys;
-    autovector<uint64_t> offsets;
-    autovector<uint64_t> value_sizes;
-    autovector<Status*> statuses;
-    autovector<PinnableSlice*> values;
+    auto& blobs_in_file = ctx.second;
     for (const auto& blob : blobs_in_file) {
-      const auto& blob_index = blob.first;
+      const BlobIndex& blob_index = blob.first;
       const KeyContext& key_context = blob.second;
+
+      if (!blob_file_meta) {
+        *(key_context.s) = Status::Corruption("Invalid blob file number");
+        continue;
+      }
+
       if (blob_index.HasTTL() || blob_index.IsInlined()) {
         *(key_context.s) =
             Status::Corruption("Unexpected TTL/inlined blob index");
         continue;
       }
-      const uint64_t key_size = key_context.ukey_with_ts.size();
-      const uint64_t offset = blob_index.offset();
-      const uint64_t value_size = blob_index.size();
-      if (!IsValidBlobOffset(offset, key_size, value_size, file_size)) {
-        *(key_context.s) = Status::Corruption("Invalid blob offset");
-        continue;
-      }
-      if (blob_index.compression() != compression) {
-        *(key_context.s) =
-            Status::Corruption("Compression type mismatch when reading a blob");
-        continue;
-      }
-      blob_read_key_contexts.emplace_back(std::cref(key_context));
-      user_keys.emplace_back(std::cref(key_context.ukey_with_ts));
-      offsets.push_back(blob_index.offset());
-      value_sizes.push_back(blob_index.size());
-      statuses.push_back(key_context.s);
-      values.push_back(key_context.value);
+
+      blob_reqs[blob_file_number].push_back(BlobReadRequest(
+          key_context.ukey_with_ts, blob_index.offset(), blob_index.size(),
+          blob_index.compression(), key_context.value, key_context.s));
     }
-    blob_file_reader.GetValue()->MultiGetBlob(read_options, user_keys, offsets,
-                                              value_sizes, statuses, values,
-                                              /*bytes_read=*/nullptr);
-    size_t num = blob_read_key_contexts.size();
-    assert(num == user_keys.size());
-    assert(num == offsets.size());
-    assert(num == value_sizes.size());
-    assert(num == statuses.size());
-    assert(num == values.size());
-    for (size_t i = 0; i < num; ++i) {
-      if (statuses[i]->ok()) {
-        range.AddValueSize(blob_read_key_contexts[i].get().value->size());
+  }
+
+  blob_source_->MultiGetBlob(read_options, blob_reqs,
+                             /*bytes_read=*/nullptr);
+
+  for (const auto& req : blob_reqs) {
+    const auto& blob_reqs_in_file = req.second;
+    for (const auto& blob_req : blob_reqs_in_file) {
+      if (blob_req.status->ok()) {
+        range.AddValueSize(blob_req.result->size());
         if (range.GetValueSize() > read_options.value_size_soft_limit) {
-          *(blob_read_key_contexts[i].get().s) = Status::Aborted();
+          *(blob_req.status) = Status::Aborted();
         }
       }
     }
@@ -2253,7 +2189,7 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
 
   MultiGetRange keys_with_blobs_range(*range, range->begin(), range->end());
   // blob_file => [[blob_idx, it], ...]
-  std::unordered_map<uint64_t, BlobReadRequests> blob_rqs;
+  std::unordered_map<uint64_t, BlobReadContexts> blob_ctxs;
   int prev_level = -1;
 
   while (!fp.IsSearchEnded()) {
@@ -2270,7 +2206,7 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
         // Call MultiGetFromSST for looking up a single file
         s = MultiGetFromSST(read_options, fp.CurrentFileRange(),
                             fp.GetHitFileLevel(), fp.IsHitFileLastInLevel(), f,
-                            blob_rqs, num_filter_read, num_index_read,
+                            blob_ctxs, num_filter_read, num_index_read,
                             num_sst_read);
         if (fp.GetHitFileLevel() == 0) {
           dump_stats_for_l0_file = true;
@@ -2285,7 +2221,7 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
       while (f != nullptr) {
         mget_tasks.emplace_back(MultiGetFromSSTCoroutine(
             read_options, fp.CurrentFileRange(), fp.GetHitFileLevel(),
-            fp.IsHitFileLastInLevel(), f, blob_rqs, num_filter_read,
+            fp.IsHitFileLastInLevel(), f, blob_ctxs, num_filter_read,
             num_index_read, num_sst_read));
         if (fp.KeyMaySpanNextFile()) {
           break;
@@ -2358,8 +2294,8 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                       num_level_read);
   }
 
-  if (s.ok() && !blob_rqs.empty()) {
-    MultiGetBlob(read_options, keys_with_blobs_range, blob_rqs);
+  if (s.ok() && !blob_ctxs.empty()) {
+    MultiGetBlob(read_options, keys_with_blobs_range, blob_ctxs);
   }
 
   // Process any left over keys

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1936,7 +1936,7 @@ void Version::MultiGetBlob(
 
       blob_reqs[blob_file_number].push_back(BlobReadRequest(
           key_context.ukey_with_ts, blob_index.offset(), blob_index.size(),
-          blob_index.compression(), key_context.value, key_context.s));
+          key_context.value, key_context.s, blob_index.compression()));
     }
   }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1933,6 +1933,7 @@ void Version::MultiGetBlob(
         continue;
       }
 
+      key_context.value->Reset();
       blob_reqs_in_file.emplace_back(
           key_context.ukey_with_ts, blob_index.offset(), blob_index.size(),
           blob_index.compression(), key_context.value, key_context.s);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1944,8 +1944,9 @@ void Version::MultiGetBlob(
     }
   }
 
-  blob_source_->MultiGetBlob(read_options, blob_reqs,
-                             /*bytes_read=*/nullptr);
+  if (blob_reqs.size() > 0) {
+    blob_source_->MultiGetBlob(read_options, blob_reqs, /*bytes_read=*/nullptr);
+  }
 
   for (auto& ctx : blob_ctxs) {
     BlobReadContexts& blobs_in_file = ctx.second;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -860,11 +860,11 @@ class Version {
                  FilePrefetchBuffer* prefetch_buffer, PinnableSlice* value,
                  uint64_t* bytes_read) const;
 
-  using BlobReadRequest =
+  using BlobReadContext =
       std::pair<BlobIndex, std::reference_wrapper<const KeyContext>>;
-  using BlobReadRequests = std::vector<BlobReadRequest>;
+  using BlobReadContexts = std::vector<BlobReadContext>;
   void MultiGetBlob(const ReadOptions& read_options, MultiGetRange& range,
-                    std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs);
+                    std::unordered_map<uint64_t, BlobReadContexts>& blob_ctxs);
 
   // Loads some stats information from files (if update_stats is set) and
   // populates derived data structures. Call without mutex held. It needs to be
@@ -989,7 +989,7 @@ class Version {
       /* ret_type */ Status, /* func_name */ MultiGetFromSST,
       const ReadOptions& read_options, MultiGetRange file_range,
       int hit_file_level, bool is_hit_file_last_in_level, FdWithKeyRange* f,
-      std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs,
+      std::unordered_map<uint64_t, BlobReadContexts>& blob_ctxs,
       uint64_t& num_filter_read, uint64_t& num_index_read,
       uint64_t& num_sst_read);
 

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -14,7 +14,7 @@ namespace ROCKSDB_NAMESPACE {
 DEFINE_SYNC_AND_ASYNC(Status, Version::MultiGetFromSST)
 (const ReadOptions& read_options, MultiGetRange file_range, int hit_file_level,
  bool is_hit_file_last_in_level, FdWithKeyRange* f,
- std::unordered_map<uint64_t, BlobReadRequests>& blob_rqs,
+ std::unordered_map<uint64_t, BlobReadContexts>& blob_ctxs,
  uint64_t& num_filter_read, uint64_t& num_index_read, uint64_t& num_sst_read) {
   bool timer_enabled = GetPerfLevel() >= PerfLevel::kEnableTimeExceptForMutex &&
                        get_perf_context()->per_level_perf_context_enabled;
@@ -110,7 +110,7 @@ DEFINE_SYNC_AND_ASYNC(Status, Version::MultiGetFromSST)
             Status tmp_s = blob_index.DecodeFrom(blob_index_slice);
             if (tmp_s.ok()) {
               const uint64_t blob_file_num = blob_index.file_number();
-              blob_rqs[blob_file_num].emplace_back(
+              blob_ctxs[blob_file_num].emplace_back(
                   std::make_pair(blob_index, std::cref(*iter)));
             } else {
               *(iter->s) = tmp_s;

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -78,15 +78,15 @@ struct BlobReadRequest {
   // Status of read
   Status* status;
 
-  BlobReadRequest(const Slice& user_key, uint64_t offset, size_t len,
-                  CompressionType compression, PinnableSlice* result,
-                  Status* status)
-      : user_key(&user_key),
-        offset(offset),
-        len(len),
-        compression(compression),
-        result(result),
-        status(status) {}
+  BlobReadRequest(const Slice& _user_key, uint64_t _offset, size_t _len,
+                  CompressionType _compression, PinnableSlice* _result,
+                  Status* _status)
+      : user_key(&_user_key),
+        offset(_offset),
+        len(_len),
+        compression(_compression),
+        result(_result),
+        status(_status) {}
 
   BlobReadRequest() = default;
 };

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -68,9 +68,6 @@ struct BlobReadRequest {
   // Length to read in bytes
   size_t len;
 
-  // Blob compression type
-  CompressionType compression;
-
   // Output parameter set by MultiGetBlob() to point to the data buffer, and
   // the number of valid bytes
   PinnableSlice* result;
@@ -78,17 +75,38 @@ struct BlobReadRequest {
   // Status of read
   Status* status;
 
+  // Blob compression type
+  CompressionType compression;
+
   BlobReadRequest(const Slice& _user_key, uint64_t _offset, size_t _len,
-                  CompressionType _compression, PinnableSlice* _result,
-                  Status* _status)
+                  PinnableSlice* _result, Status* _status,
+                  CompressionType _compression = kNoCompression)
       : user_key(&_user_key),
         offset(_offset),
         len(_len),
-        compression(_compression),
         result(_result),
-        status(_status) {}
+        status(_status),
+        compression(_compression) {}
 
   BlobReadRequest() = default;
+
+  BlobReadRequest(const BlobReadRequest& other)
+      : user_key(other.user_key),
+        offset(other.offset),
+        len(other.len),
+        result(other.result),
+        status(other.status),
+        compression(other.compression) {}
+
+  BlobReadRequest& operator=(const BlobReadRequest& other) {
+    user_key = other.user_key;
+    offset = other.offset;
+    len = other.len;
+    result = other.result;
+    status = other.status;
+    compression = other.compression;
+    return *this;
+  }
 };
 
 // The MultiGetContext class is a container for the sorted list of keys that

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -56,6 +56,41 @@ struct KeyContext {
   KeyContext() = default;
 };
 
+// A read Blob request structure for use in BlobSource::MultiGetBlob and
+// BlobFileReader::MultiGetBlob.
+struct BlobReadRequest {
+  // User key to lookup the paired blob
+  const Slice* user_key;
+
+  // File offset in bytes
+  uint64_t offset;
+
+  // Length to read in bytes
+  size_t len;
+
+  // Blob compression type
+  CompressionType compression;
+
+  // Output parameter set by MultiGetBlob() to point to the data buffer, and
+  // the number of valid bytes
+  PinnableSlice* result;
+
+  // Status of read
+  Status* status;
+
+  BlobReadRequest(const Slice& user_key, uint64_t offset, size_t len,
+                  CompressionType compression, PinnableSlice* result,
+                  Status* status)
+      : user_key(&user_key),
+        offset(offset),
+        len(len),
+        compression(compression),
+        result(result),
+        status(status) {}
+
+  BlobReadRequest() = default;
+};
+
 // The MultiGetContext class is a container for the sorted list of keys that
 // we need to lookup in a batch. Its main purpose is to make batch execution
 // easier by allowing various stages of the MultiGet lookups to operate on

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -56,59 +56,6 @@ struct KeyContext {
   KeyContext() = default;
 };
 
-// A read Blob request structure for use in BlobSource::MultiGetBlob and
-// BlobFileReader::MultiGetBlob.
-struct BlobReadRequest {
-  // User key to lookup the paired blob
-  const Slice* user_key;
-
-  // File offset in bytes
-  uint64_t offset;
-
-  // Length to read in bytes
-  size_t len;
-
-  // Output parameter set by MultiGetBlob() to point to the data buffer, and
-  // the number of valid bytes
-  PinnableSlice* result;
-
-  // Status of read
-  Status* status;
-
-  // Blob compression type
-  CompressionType compression;
-
-  BlobReadRequest(const Slice& _user_key, uint64_t _offset, size_t _len,
-                  PinnableSlice* _result, Status* _status,
-                  CompressionType _compression = kNoCompression)
-      : user_key(&_user_key),
-        offset(_offset),
-        len(_len),
-        result(_result),
-        status(_status),
-        compression(_compression) {}
-
-  BlobReadRequest() = default;
-
-  BlobReadRequest(const BlobReadRequest& other)
-      : user_key(other.user_key),
-        offset(other.offset),
-        len(other.len),
-        result(other.result),
-        status(other.status),
-        compression(other.compression) {}
-
-  BlobReadRequest& operator=(const BlobReadRequest& other) {
-    user_key = other.user_key;
-    offset = other.offset;
-    len = other.len;
-    result = other.result;
-    status = other.status;
-    compression = other.compression;
-    return *this;
-  }
-};
-
 // The MultiGetContext class is a container for the sorted list of keys that
 // we need to lookup in a batch. Its main purpose is to make batch execution
 // easier by allowing various stages of the MultiGet lookups to operate on


### PR DESCRIPTION
Summary:

- [x] Enabled blob caching for MultiGetBlob in RocksDB
- [x] Refactored MultiGetBlob logic and interface in RocksDB
- [x] Cleaned up Version::MultiGetBlob() and moved 'blob'-related code snippets into BlobSource
- [x] Add End-to-end test cases in db_blob_basic_test and also add unit tests in blob_source_test

This task is a part of #10156