### PR TITLE
Add undefok for BlobDB options not supported prior to 7.5

### DIFF
--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -290,7 +290,8 @@ level_const_params="
   $hard_pending_arg \
 "
 
-# TODO: these inherit level_const_params because the non-blob LSM tree uses leveled compaction
+# These inherit level_const_params because the non-blob LSM tree uses leveled compaction.
+# The use of undefok is for options that are not supported until 7.5.
 blob_const_params="
   $level_const_params \
   --enable_blob_files=true \
@@ -305,6 +306,7 @@ blob_const_params="
   --use_shared_block_and_blob_cache=$use_shared_block_and_blob_cache \
   --blob_cache_size=$blob_cache_size \
   --blob_cache_numshardbits=$blob_cache_numshardbits \
+  --undefok=use_blob_cache,use_shared_block_and_blob_cache,blob_cache_size,blob_cache_numshardbits \
 "
 
 # TODO:


### PR DESCRIPTION
Summary:
This adds --undefok to support use of this script with BlobDB for db_bench versions prior
to 7.5 when the options land in a release.

While there is a limit to how far back this script can go WRT backwards compatiblity,
this is an easy change to support early 7.x releases.

Test Plan:
Run it with versions of db_bench that do not and then do support these options

Reviewers:

Subscribers:

Tasks:

Tags: