### PR TITLE
Fix GetWindowsErrSz nullptr bug

### DIFF
--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -37,15 +37,18 @@ inline bool IsAligned(size_t alignment, const void* ptr) {
 }  // namespace
 
 std::string GetWindowsErrSz(DWORD err) {
-  LPSTR lpMsgBuf;
+  std::string Err;
+  LPSTR lpMsgBuf = nullptr;
   FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
                      FORMAT_MESSAGE_IGNORE_INSERTS,
                  NULL, err,
                  0,  // Default language
                  reinterpret_cast<LPSTR>(&lpMsgBuf), 0, NULL);
 
-  std::string Err = lpMsgBuf;
-  LocalFree(lpMsgBuf);
+  if (lpMsgBuf) {
+    Err = lpMsgBuf;
+    LocalFree(lpMsgBuf);
+  }
   return Err;
 }
 


### PR DESCRIPTION
`GetWindowsErrSz` may assign a `nullptr` to `std::string` in the event it cannot format the error code to a string. This will result in a crash when `std::string` attempts to calculate the length from `nullptr`.

The change here checks the output from `FormatMessageA` and only assigns to the otuput `std::string` if it is not null. Additionally, the call to free the buffer is only made if a non-null value is returned from `FormatMessageA`. In the event `FormatMessageA` does not output a string, an empty string is returned instead.

Fixes #10274