### PR TITLE
Fail DB::Open if hashing features enabled with incompatible Comparator

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,10 @@
   * `rocksdb_level_metadata_t` and its and its get functions & destroy function.
   * `rocksdb_file_metadata_t` and its and get functions & destroy functions.
 * Add suggest_compact_range() and suggest_compact_range_cf() to C API.
+* Minor changes to C API for custom comparators.
+
+### Behavior changes
+* DB::Open will now fail if a `Comparator` satisfying `CanKeysWithDifferentByteContentsBeEqual()` is used with a feature that hashes keys or prefixes, such as Bloom filters or hash indices. RocksDB can return wrong results if these hashing-based features are used with a comparator that can treat different byte strings as equal. Because of this change, some existing custom comparators might need to add an override for `CanKeysWithDifferentByteContentsBeEqual()` to return false if appropriate.
 
 ### Bug Fixes
 * Fix a bug in which backup/checkpoint can include a WAL deleted by RocksDB.

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -225,11 +225,6 @@ static int CmpCompare(void* arg, const char* a, size_t alen,
   return r;
 }
 
-static const char* CmpName(void* arg) {
-  (void)arg;
-  return "foo";
-}
-
 // Custom compaction filter
 static void CFilterDestroy(void* arg) { (void)arg; }
 static const char* CFilterName(void* arg) {
@@ -610,7 +605,8 @@ int main(int argc, char** argv) {
            ((int) geteuid()));
 
   StartPhase("create_objects");
-  cmp = rocksdb_comparator_create(NULL, CmpDestroy, CmpCompare, CmpName);
+  cmp = rocksdb_comparator_create(NULL, CmpDestroy, CmpCompare, "foo",
+                                  /*can_keys_...=*/0);
   dbpath = rocksdb_dbpath_create(dbpathname, 1024 * 1024);
   env = rocksdb_create_default_env();
 

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1428,6 +1428,16 @@ Status ColumnFamilyData::ValidateOptions(
         "FIFO compaction only supported with max_open_files = -1.");
   }
 
+  if (cf_options.comparator->CanKeysWithDifferentByteContentsBeEqual()) {
+    // Checks for incompatible hashing (see also
+    // BlockBasedTableFactory::ValidateOptions)
+    if (cf_options.memtable_prefix_bloom_size_ratio > 0.0) {
+      return Status::InvalidArgument(
+          "Memtable Bloom filter not compatible with comparator where "
+          "different byte contents can be equal");
+    }
+  }
+
   return s;
 }
 

--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -195,6 +195,7 @@ class DoubleComparator : public Comparator {
   void FindShortSuccessor(std::string* /*key*/) const override {}
 };
 
+// Hash order first, then lexicographic order when hashes match
 class HashComparator : public Comparator {
  public:
   HashComparator() {}
@@ -216,6 +217,10 @@ class HashComparator : public Comparator {
                              const Slice& /*limit*/) const override {}
 
   void FindShortSuccessor(std::string* /*key*/) const override {}
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 
 class TwoStrComparator : public Comparator {
@@ -248,6 +253,10 @@ class TwoStrComparator : public Comparator {
                              const Slice& /*limit*/) const override {}
 
   void FindShortSuccessor(std::string* /*key*/) const override {}
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 }  // namespace
 

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -3139,6 +3139,10 @@ class BackwardBytewiseComparator : public Comparator {
                              const Slice& /*limit*/) const override {}
 
   void FindShortSuccessor(std::string* /*key*/) const override {}
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 
 const BackwardBytewiseComparator kBackwardBytewiseComparator{};
@@ -3363,6 +3367,10 @@ class WeirdComparator : public Comparator {
                              const Slice& /*limit*/) const override {}
 
   void FindShortSuccessor(std::string* /*key*/) const override {}
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 const WeirdComparator kWeirdComparator{};
 

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3240,6 +3240,9 @@ TEST_P(DBCompactionTestWithParam, ForceBottommostLevelCompaction) {
     void FindShortSuccessor(std::string* key) const override {
       return BytewiseComparator()->FindShortSuccessor(key);
     }
+    bool CanKeysWithDifferentByteContentsBeEqual() const override {
+      return false;
+    }
   } short_key_cmp;
   Options options = CurrentOptions();
   options.target_file_size_base = 100000000;

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -131,7 +131,8 @@ bool DBTestBase::ShouldSkipOptions(int option_config, int skip_mask) {
         option_config == kPlainTableCappedPrefix ||
         option_config == kPlainTableCappedPrefixNonMmap ||
         option_config == kPlainTableAllBytesPrefix ||
-        option_config == kVectorRep || option_config == kHashLinkList ||
+        option_config == kVectorRepAndMemtableBloom ||
+        option_config == kHashLinkList ||
         option_config == kUniversalCompaction ||
         option_config == kUniversalCompactionMultiLevel ||
         option_config == kUniversalSubcompactions ||
@@ -412,10 +413,12 @@ Options DBTestBase::GetOptions(
       options.max_sequential_skip_in_iterations = 999999;
       set_block_based_table_factory = false;
       break;
-    case kVectorRep:
+    case kVectorRepAndMemtableBloom:
       options.memtable_factory.reset(new VectorRepFactory(100));
       options.allow_concurrent_memtable_write = false;
       options.unordered_write = false;
+      options.memtable_prefix_bloom_size_ratio = 0.1;
+      options.memtable_whole_key_filtering = true;
       break;
     case kHashLinkList:
       options.prefix_extractor.reset(NewFixedPrefixTransform(1));

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -1009,7 +1009,7 @@ class DBTestBase : public testing::Test {
     kPlainTableCappedPrefix = 4,
     kPlainTableCappedPrefixNonMmap = 5,
     kPlainTableAllBytesPrefix = 6,
-    kVectorRep = 7,
+    kVectorRepAndMemtableBloom = 7,
     kHashLinkList = 8,
     kMergePut = 9,
     kFilter = 10,

--- a/db/db_with_timestamp_test_util.h
+++ b/db/db_with_timestamp_test_util.h
@@ -105,6 +105,10 @@ class DBBasicTestWithTimestampBase : public DBTestBase {
       }
       return 0;
     }
+
+    bool CanKeysWithDifferentByteContentsBeEqual() const override {
+      return false;
+    }
   };
 
   std::string Timestamp(uint64_t low, uint64_t high);

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -282,6 +282,9 @@ class InternalKeyComparator
   virtual const Comparator* GetRootComparator() const override {
     return user_comparator_.GetRootComparator();
   }
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return user_comparator_.CanKeysWithDifferentByteContentsBeEqual();
+  }
 };
 
 // The class represent the internal key in encoded form.

--- a/db/file_indexer_test.cc
+++ b/db/file_indexer_test.cc
@@ -40,6 +40,10 @@ class IntComparator : public Comparator {
                              const Slice& /*limit*/) const override {}
 
   void FindShortSuccessor(std::string* /*key*/) const override {}
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 
 class FileIndexerTest : public testing::Test {

--- a/db/prefix_test.cc
+++ b/db/prefix_test.cc
@@ -131,6 +131,10 @@ class TestKeyComparator : public Comparator {
                              const Slice& /*limit*/) const override {}
 
   void FindShortSuccessor(std::string* /*key*/) const override {}
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 
 namespace {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1732,7 +1732,8 @@ extern ROCKSDB_LIBRARY_API rocksdb_comparator_t* rocksdb_comparator_create(
     void* state, void (*destructor)(void*),
     int (*compare)(void*, const char* a, size_t alen, const char* b,
                    size_t blen),
-    const char* (*name)(void*));
+    const char* name,
+    unsigned char can_keys_with_different_byte_contents_be_equal);
 extern ROCKSDB_LIBRARY_API void rocksdb_comparator_destroy(
     rocksdb_comparator_t*);
 
@@ -1746,7 +1747,9 @@ rocksdb_comparator_with_ts_create(
     int (*compare_without_ts)(void*, const char* a, size_t alen,
                               unsigned char a_has_ts, const char* b,
                               size_t blen, unsigned char b_has_ts),
-    const char* (*name)(void*), size_t timestamp_size);
+    const char* name,
+    unsigned char can_keys_with_different_byte_contents_be_equal,
+    size_t timestamp_size);
 
 /* Filter policy */
 

--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -150,8 +150,8 @@ class Comparator : public Customizable {
 // must not be deleted.
 extern const Comparator* BytewiseComparator();
 
-// Return a builtin comparator that uses reverse lexicographic byte-wise
-// ordering.
+// Return a builtin comparator that uses the reverse order of
+// BytewiseComparator (still left-to-right lexicographic)
 extern const Comparator* ReverseBytewiseComparator();
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/filter_policy.h
+++ b/include/rocksdb/filter_policy.h
@@ -34,6 +34,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+class Comparator;
 class Slice;
 struct BlockBasedTableOptions;
 struct ConfigOptions;

--- a/java/rocksjni/native_comparator_wrapper_test.cc
+++ b/java/rocksjni/native_comparator_wrapper_test.cc
@@ -29,6 +29,10 @@ class NativeComparatorWrapperTestStringComparator : public Comparator {
   }
 
   void FindShortSuccessor(std::string* /*key*/) const { return; }
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -412,10 +412,7 @@ struct BlockBasedTableBuilder::Rep {
         data_block(table_options.block_restart_interval,
                    table_options.use_delta_encoding,
                    false /* use_value_delta_encoding */,
-                   tbo.internal_comparator.user_comparator()
-                           ->CanKeysWithDifferentByteContentsBeEqual()
-                       ? BlockBasedTableOptions::kDataBlockBinarySearch
-                       : table_options.data_block_index_type,
+                   table_options.data_block_index_type,
                    table_options.data_block_hash_table_util_ratio),
         range_del_block(1 /* block_restart_interval */),
         internal_prefix_transform(tbo.moptions.prefix_extractor.get()),

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -685,6 +685,28 @@ Status BlockBasedTableFactory::ValidateOptions(
         "max_successive_merges larger than 0 is currently inconsistent with "
         "unordered_write");
   }
+  if (cf_opts.comparator->CanKeysWithDifferentByteContentsBeEqual()) {
+    // More checks for incompatible hashing (see also
+    // ColumnFamilyData::ValidateOptions)
+    if (table_options_.index_type == BlockBasedTableOptions::kHashSearch) {
+      return Status::InvalidArgument(
+          "Hash index not compatible with comparator where different byte "
+          "contents can be equal");
+    }
+    if (table_options_.data_block_index_type ==
+        BlockBasedTableOptions::kDataBlockBinaryAndHash) {
+      return Status::InvalidArgument(
+          "Data block hash index not compatible with comparator where "
+          "different byte contents can be equal");
+    }
+    if (table_options_.filter_policy) {
+      // TODO: re-add support for custom filtering that doesn't require this
+      // assumption
+      return Status::InvalidArgument(
+          "Filter policy is not compatible with comparator where different "
+          "byte contents can be equal");
+    }
+  }
   const auto& options_overrides =
       table_options_.cache_usage_options.options_overrides;
   for (auto options_overrides_iter = options_overrides.cbegin();

--- a/table/plain/plain_table_factory.h
+++ b/table/plain/plain_table_factory.h
@@ -170,6 +170,9 @@ class PlainTableFactory : public TableFactory {
       const TableBuilderOptions& table_builder_options,
       WritableFileWriter* file) const override;
 
+  Status ValidateOptions(const DBOptions& db_opts,
+                         const ColumnFamilyOptions& cf_opts) const override;
+
   std::string GetPrintableOptions() const override;
   static const char kValueTypeSeqId0 = char(~0);
 

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -117,6 +117,10 @@ class Uint64ComparatorImpl : public Comparator {
   }
 
   void FindShortSuccessor(std::string* /*key*/) const override { return; }
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 }  // namespace
 

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -104,6 +104,10 @@ class SimpleSuffixReverseComparator : public Comparator {
                                      const Slice& /*limit*/) const override {}
 
   virtual void FindShortSuccessor(std::string* /*key*/) const override {}
+
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
 };
 
 // Returns a user key comparator that can be used for comparing two uint64_t

--- a/tools/db_sanity_test.cc
+++ b/tools/db_sanity_test.cc
@@ -119,6 +119,9 @@ class SanityTestSpecialComparator : public SanityTest {
     virtual void FindShortSuccessor(std::string* key) const override {
       BytewiseComparator()->FindShortSuccessor(key);
     }
+    bool CanKeysWithDifferentByteContentsBeEqual() const override {
+      return false;
+    }
   };
   Options options_;
 };

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -288,6 +288,10 @@ class ComparatorWithU64TsImpl : public Comparator {
     }
   }
 
+  bool CanKeysWithDifferentByteContentsBeEqual() const override {
+    return false;
+  }
+
  private:
   static std::string kClassNameInternal() {
     std::stringstream ss;


### PR DESCRIPTION
Summary: RocksDB allows Comparators to treat keys with different byte
contents as equal, if that's appropriate for the application, but that
makes the comparator incompatible with a number of hashing-based
features that assume equal keys generate the same hash. Before now, the
only protection against getting wrong results with such incompatible
combinations is quietly disabling data block hash index if the
Comparator returns true for `CanKeysWithDifferentByteContentsBeEqual()`.

This change attempts to detect all the cases in which RocksDB can
produce wrong results with such a Comparator and fail DB::Open with an
appropriate status.  (More nuiance in HISTORY entry.) Many of the cases
were found by expanding the unit test and seeing what fails in data
correctness.

Also included:
* Override `CanKeysWithDifferentByteContentsBeEqual()` for most of the
testing comparators, as appropriate. (Didn't find any "bad configuration"
cases in unit tests.)
* Allow setting can_keys_with_different_byte_contents_be_equal in C API,
and move `name` to be a `char*` rather than a function pointer to a
function returning `char*`. (What would be the reason for that complexity?)
* Include memtable Bloom in standard testing configurations, by adding to
an existing configuration. (Now `kVectorRepAndMemtableBloom`)
* Clarify API comment for `ReverseBytewiseComparator`
* Rename a testing comparator that was named like
`ReverseBytewiseComparator` but actually quite different.

Related to #10256

Test Plan: substantially updated unit tests