### PR TITLE
Fix CalcHashBits

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -287,16 +287,13 @@ size_t ClockCacheShard::CalcEstimatedHandleCharge(
 int ClockCacheShard::CalcHashBits(
     size_t capacity, size_t estimated_value_size,
     CacheMetadataChargePolicy metadata_charge_policy) {
-  if (capacity == 0) {
-    return 0;
-  }
   size_t handle_charge =
       CalcEstimatedHandleCharge(estimated_value_size, metadata_charge_policy);
   assert(handle_charge > 0);
   uint32_t num_entries =
       static_cast<uint32_t>(capacity / (kLoadFactor * handle_charge)) + 1;
-  int hash_bits = FloorLog2(num_entries);
-  return hash_bits + (size_t{1} << hash_bits < num_entries ? 1 : 0);
+  assert(num_entries <= uint32_t{1} << 31);
+  return FloorLog2((num_entries << 1) - 1);
 }
 
 void ClockCacheShard::SetCapacity(size_t capacity) {

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -287,14 +287,14 @@ size_t ClockCacheShard::CalcEstimatedHandleCharge(
 int ClockCacheShard::CalcHashBits(
     size_t capacity, size_t estimated_value_size,
     CacheMetadataChargePolicy metadata_charge_policy) {
-  size_t handle_charge =
-      CalcEstimatedHandleCharge(estimated_value_size, metadata_charge_policy);
-  uint32_t num_entries =
-      static_cast<uint32_t>(capacity / (kLoadFactor * handle_charge));
-
-  if (num_entries == 0) {
+  if (capacity == 0) {
     return 0;
   }
+  size_t handle_charge =
+      CalcEstimatedHandleCharge(estimated_value_size, metadata_charge_policy);
+  assert(handle_charge > 0);
+  uint32_t num_entries =
+      static_cast<uint32_t>(capacity / (kLoadFactor * handle_charge)) + 1;
   int hash_bits = FloorLog2(num_entries);
   return hash_bits + (size_t{1} << hash_bits < num_entries ? 1 : 0);
 }
@@ -516,6 +516,8 @@ ClockCache::ClockCache(size_t capacity, size_t estimated_value_size,
                        int num_shard_bits, bool strict_capacity_limit,
                        CacheMetadataChargePolicy metadata_charge_policy)
     : ShardedCache(capacity, num_shard_bits, strict_capacity_limit) {
+  assert(estimated_value_size > 0 ||
+         metadata_charge_policy != kDontChargeCacheMetadata);
   num_shards_ = 1 << num_shard_bits;
   shards_ = reinterpret_cast<ClockCacheShard*>(
       port::cacheline_aligned_alloc(sizeof(ClockCacheShard) * num_shards_));

--- a/cache/fast_lru_cache.cc
+++ b/cache/fast_lru_cache.cc
@@ -288,16 +288,13 @@ size_t LRUCacheShard::CalcEstimatedHandleCharge(
 int LRUCacheShard::CalcHashBits(
     size_t capacity, size_t estimated_value_size,
     CacheMetadataChargePolicy metadata_charge_policy) {
-  if (capacity == 0) {
-    return 0;
-  }
   size_t handle_charge =
       CalcEstimatedHandleCharge(estimated_value_size, metadata_charge_policy);
   assert(handle_charge > 0);
   uint32_t num_entries =
       static_cast<uint32_t>(capacity / (kLoadFactor * handle_charge)) + 1;
-  int hash_bits = FloorLog2(num_entries);
-  return hash_bits + (size_t{1} << hash_bits < num_entries ? 1 : 0);
+  assert(num_entries <= uint32_t{1} << 31);
+  return FloorLog2((num_entries << 1) - 1);
 }
 
 void LRUCacheShard::SetCapacity(size_t capacity) {


### PR DESCRIPTION
Summary: We fix two bugs in CalcHashBits. The first one is an off-by-one error: the desired number of table slots is the real number ``capacity / (kLoadFactor * handle_charge)``, which should not be rounded down. The second one is that we should disallow inputs that set the element charge to 0, namely ``estimated_value_size == 0 && metadata_charge_policy == kDontChargeCacheMetadata``.

Test plan: CalcHashBits is tested by CalcHashBitsTest (in lru_cache_test.cc). The test now iterates over many more inputs; it covers, in particular, the rounding error edge case. Overall, the test is now more robust. Run ``make -j24 check``.