### PR TITLE
Midpoint insertions in ClockCache

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -250,11 +250,11 @@ void ClockCacheShard::ClockRemove(ClockHandle* h) {
 
 void ClockCacheShard::ClockInsert(ClockHandle* h) {
   assert(!h->IsInClockList());
-  bool condition =
+  bool is_high_priority =
       h->HasHit() || h->GetCachePriority() == Cache::Priority::HIGH;
   h->SetClockPriority(static_cast<ClockHandle::ClockPriority>(
-      condition * ClockHandle::ClockPriority::HIGH +
-      (1 - condition) * ClockHandle::ClockPriority::MEDIUM));
+      is_high_priority * ClockHandle::ClockPriority::HIGH +
+      (1 - is_high_priority) * ClockHandle::ClockPriority::MEDIUM));
   clock_usage_ += h->total_charge;
 }
 

--- a/cache/clock_cache.h
+++ b/cache/clock_cache.h
@@ -372,7 +372,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) ClockCacheShard final : public CacheShard {
  private:
   friend class ClockCache;
   void ClockRemove(ClockHandle* e);
-  void ClockInsert(ClockHandle* e);
+  void ClockInsert(ClockHandle* e, ClockHandle::ClockPriority priority);
 
   // Free some space following strict clock policy until enough space
   // to hold (usage_ + charge) is freed or the clock list is empty

--- a/cache/clock_cache.h
+++ b/cache/clock_cache.h
@@ -65,6 +65,8 @@ struct ClockHandle {
   static constexpr int kIsVisibleOffset = 0;
   static constexpr int kIsElementOffset = 1;
   static constexpr int kClockPriorityOffset = 2;
+  static constexpr int kIsHitOffset = 4;
+  static constexpr int kCachePriorityOffset = 5;
 
   enum Flags : uint8_t {
     // Whether the handle is visible to Lookups.
@@ -74,6 +76,9 @@ struct ClockHandle {
     // Clock priorities. Represents how close a handle is from
     // being evictable.
     CLOCK_PRIORITY = (3 << kClockPriorityOffset),
+    // Whether the handle has been looked up after its insertion.
+    HAS_HIT = (1 << kIsHitOffset),
+    CACHE_PRIORITY = (1 << kCachePriorityOffset),
   };
   uint8_t flags;
 
@@ -82,7 +87,7 @@ struct ClockHandle {
     LOW = (1 << kClockPriorityOffset),   // Immediately evictable.
     MEDIUM = (2 << kClockPriorityOffset),
     HIGH = (3 << kClockPriorityOffset)
-    // Priority is CLOCK_NONE if and only if
+    // Priority is NONE if and only if
     // (i) the handle is not an element, or
     // (ii) the handle is an element but it is being referenced.
   };
@@ -102,7 +107,8 @@ struct ClockHandle {
     flags = 0;
     SetIsVisible(false);
     SetIsElement(false);
-    SetPriority(ClockPriority::NONE);
+    SetClockPriority(ClockPriority::NONE);
+    SetCachePriority(Cache::Priority::LOW);
     displacements = 0;
     key_data.fill(0);
   }
@@ -142,20 +148,36 @@ struct ClockHandle {
     }
   }
 
-  ClockPriority GetPriority() const {
+  bool HasHit() const { return flags & HAS_HIT; }
+
+  void SetHit() { flags |= HAS_HIT; }
+
+  bool IsInClockList() const {
+    return GetClockPriority() != ClockHandle::ClockPriority::NONE;
+  }
+
+  Cache::Priority GetCachePriority() const {
+    return static_cast<Cache::Priority>(flags & CACHE_PRIORITY);
+  }
+
+  void SetCachePriority(Cache::Priority priority) {
+    if (priority == Cache::Priority::HIGH) {
+      flags |= Flags::CACHE_PRIORITY;
+    } else {
+      flags &= ~Flags::CACHE_PRIORITY;
+    }
+  }
+
+  ClockPriority GetClockPriority() const {
     return static_cast<ClockPriority>(flags & Flags::CLOCK_PRIORITY);
   }
 
-  bool IsInClockList() const {
-    return GetPriority() != ClockHandle::ClockPriority::NONE;
-  }
-
-  void SetPriority(ClockPriority priority) {
+  void SetClockPriority(ClockPriority priority) {
     flags &= ~Flags::CLOCK_PRIORITY;
     flags |= priority;
   }
 
-  void DecreasePriority() {
+  void DecreaseClockPriority() {
     uint8_t p = static_cast<uint8_t>(flags & Flags::CLOCK_PRIORITY) >>
                 kClockPriorityOffset;
     assert(p > 0);
@@ -372,7 +394,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) ClockCacheShard final : public CacheShard {
  private:
   friend class ClockCache;
   void ClockRemove(ClockHandle* e);
-  void ClockInsert(ClockHandle* e, ClockHandle::ClockPriority priority);
+  void ClockInsert(ClockHandle* e);
 
   // Free some space following strict clock policy until enough space
   // to hold (usage_ + charge) is freed or the clock list is empty

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -448,28 +448,29 @@ TEST_F(ClockCacheTest, Validate) {
 
 TEST_F(ClockCacheTest, ClockPriorityTest) {
   clock_cache::ClockHandle handle;
-  EXPECT_EQ(handle.GetPriority(),
+  EXPECT_EQ(handle.GetClockPriority(),
             clock_cache::ClockHandle::ClockPriority::NONE);
-  handle.SetPriority(clock_cache::ClockHandle::ClockPriority::HIGH);
-  EXPECT_EQ(handle.GetPriority(),
+  handle.SetClockPriority(clock_cache::ClockHandle::ClockPriority::HIGH);
+  EXPECT_EQ(handle.GetClockPriority(),
             clock_cache::ClockHandle::ClockPriority::HIGH);
-  handle.DecreasePriority();
-  EXPECT_EQ(handle.GetPriority(),
+  handle.DecreaseClockPriority();
+  EXPECT_EQ(handle.GetClockPriority(),
             clock_cache::ClockHandle::ClockPriority::MEDIUM);
-  handle.DecreasePriority();
-  EXPECT_EQ(handle.GetPriority(), clock_cache::ClockHandle::ClockPriority::LOW);
-  handle.SetPriority(clock_cache::ClockHandle::ClockPriority::MEDIUM);
-  EXPECT_EQ(handle.GetPriority(),
+  handle.DecreaseClockPriority();
+  EXPECT_EQ(handle.GetClockPriority(),
+            clock_cache::ClockHandle::ClockPriority::LOW);
+  handle.SetClockPriority(clock_cache::ClockHandle::ClockPriority::MEDIUM);
+  EXPECT_EQ(handle.GetClockPriority(),
             clock_cache::ClockHandle::ClockPriority::MEDIUM);
-  handle.SetPriority(clock_cache::ClockHandle::ClockPriority::NONE);
-  EXPECT_EQ(handle.GetPriority(),
+  handle.SetClockPriority(clock_cache::ClockHandle::ClockPriority::NONE);
+  EXPECT_EQ(handle.GetClockPriority(),
             clock_cache::ClockHandle::ClockPriority::NONE);
-  handle.SetPriority(clock_cache::ClockHandle::ClockPriority::MEDIUM);
-  EXPECT_EQ(handle.GetPriority(),
+  handle.SetClockPriority(clock_cache::ClockHandle::ClockPriority::MEDIUM);
+  EXPECT_EQ(handle.GetClockPriority(),
             clock_cache::ClockHandle::ClockPriority::MEDIUM);
-  handle.DecreasePriority();
-  handle.DecreasePriority();
-  EXPECT_EQ(handle.GetPriority(),
+  handle.DecreaseClockPriority();
+  handle.DecreaseClockPriority();
+  EXPECT_EQ(handle.GetClockPriority(),
             clock_cache::ClockHandle::ClockPriority::NONE);
 }
 


### PR DESCRIPTION
Summary: When an element is first inserted into the ClockCache, it is now assigned either medium or high clock priority, depending on whether its cache priority is low or high, respectively. This is a variant of LRUCache's midpoint insertions. The main difference is that LRUCache can specify the allocated capacity for high-priority elements via the ``high_pri_pool_ratio`` parameter. Contrarily, in ClockCache, low- and high-priority elements compete for all cache slots, and one group can take over the other (of course, it takes more low-priority insertions to push out high-priority elements). However, just as LRUCache, ClockCache provides the following guarantee: a high-priority element will not be evicted before a low-priority element that was inserted earlier in time.

Test plan: ``make -j24 check``