### PR TITLE
Fix build error due to uninitialized read_req

### DIFF
--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -414,7 +414,7 @@ void BlobFileReader::MultiGetBlob(const ReadOptions& read_options,
     assert(blob_reqs[i]->offset >= adjustment);
     adjustments.push_back(adjustment);
 
-    FSReadRequest read_req;
+    FSReadRequest read_req = {};
     read_req.offset = blob_reqs[i]->offset - adjustment;
     read_req.len = blob_reqs[i]->len + adjustment;
     read_reqs.emplace_back(read_req);


### PR DESCRIPTION
GCC-12 has strick check on variables, and thus
build fails when it finds read_req is not properly
initialized (-Werror=maybe-uninitialized). Add
default value to fix this.

Change-Id: Ib8a9085e2d613ee7b943b58a6a58e1bc351725d7
Signed-off-by: Jun He <jun.he@arm.com>