### PR TITLE
Replace the output split key with its pointer in subcompaction

### DIFF
--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -285,13 +285,13 @@ Compaction::Compaction(
 
   // Every compaction regardless of any compaction reason may respect the
   // existing compact cursor in the output level to split output files
-  InternalKey temp_split_key = InternalKey();
+  output_split_key_ = nullptr;
   if (immutable_options_.compaction_style == kCompactionStyleLevel &&
       immutable_options_.compaction_pri == kRoundRobin) {
-    const InternalKey cursor =
-        input_vstorage_->GetCompactCursors()[output_level_];
-    if (cursor.Valid()) {
-      const Slice& cursor_user_key = ExtractUserKey(cursor.Encode());
+    const InternalKey* cursor =
+        &input_vstorage_->GetCompactCursors()[output_level_];
+    if (cursor->size() != 0) {
+      const Slice& cursor_user_key = ExtractUserKey(cursor->Encode());
       auto ucmp = vstorage->InternalComparator()->user_comparator();
       // May split output files according to the cursor if it in the user-key
       // range
@@ -299,11 +299,10 @@ Compaction::Compaction(
               0 &&
           ucmp->CompareWithoutTimestamp(cursor_user_key, largest_user_key_) <=
               0) {
-        temp_split_key = cursor;
+        output_split_key_ = cursor;
       }
     }
   }
-  output_split_key_ = temp_split_key;
 }
 
 Compaction::~Compaction() {

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -182,7 +182,7 @@ class Compaction {
   // split the output files according to the existing cursor in the output
   // level under round-robin compaction policy. Empty indicates no required
   // splitting key
-  const InternalKey GetOutputSplitKey() const { return output_split_key_; }
+  const InternalKey* GetOutputSplitKey() const { return output_split_key_; }
 
   // If true, then the compaction can be done by simply deleting input files.
   bool deletion_compaction() const { return deletion_compaction_; }
@@ -387,7 +387,7 @@ class Compaction {
   // If true, then the compaction can be done by simply deleting input files.
   const bool deletion_compaction_;
   // should it split the output file using the compact cursor?
-  InternalKey output_split_key_;
+  const InternalKey* output_split_key_;
 
   // L0 files in LSM-tree might be overlapping. But the compaction picking
   // logic might pick a subset of the files that aren't overlapping. if


### PR DESCRIPTION
Summary:

Earlier implementation of cutting the output files with a compact cursor under Round-Robin priority uses `Valid()` to determine if the `output_split_key` is valid in `ShouldStopBefore`. This contributes to excessive CPU computation, as pointed out by [this issue](https://github.com/facebook/rocksdb/issues/10315). In this PR, we change the type of `output_split_key` to be `InternalKey*` and set it as `nullptr` if it is not going to be used in `ShouldStopBefore`, `Valid()` condition checking can be avoided using that pointer.