### PR TITLE
Fix clang error implicit conversion loses integer precision

### DIFF
--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -99,7 +99,7 @@ struct Posix_IOHandle {
 
 inline void UpdateResult(struct io_uring_cqe* cqe, const std::string& file_name,
                          size_t len, size_t iov_len, bool async_read,
-                         bool use_direct_io, uint32_t alignment,
+                         bool use_direct_io, size_t alignment,
                          size_t& finished_len, FSReadRequest* req,
                          size_t& bytes_read, bool& read_again) {
   read_again = false;


### PR DESCRIPTION
Summary: Fix  error: implicit conversion loses integer precision:
'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int')
[-Werror,-Wshorten-64-to-32]

Test Plan: USE_CLANG=1 make -j32

Reviewers:

Subscribers:

Tasks:

Tags: