### PR TITLE
Add WAL fragment checksum handshake with WAL logical record

### DIFF
--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -151,8 +151,10 @@ class Reader {
   std::unique_ptr<char[]> uncompressed_buffer_;
   // Reusable uncompressed record
   std::string uncompressed_record_;
-  // Used for stream hashing log record
+  // Used for stream hashing log record content (logical record)
   XXH3_state_t* hash_state_;
+  // Used for stream hashing fragment content (physical record)
+  XXH3_state_t* fragment_hash_state_;
 
   // Extend record types with the following special values
   enum {
@@ -173,7 +175,10 @@ class Reader {
   };
 
   // Return type, or one of the preceding special values
-  unsigned int ReadPhysicalRecord(Slice* result, size_t* drop_size);
+  // If fragment_checksum is provided, it is set to the XXH3 hash computed on
+  // the original buffer that contains the result fragment content.
+  unsigned int ReadPhysicalRecord(Slice* result, size_t* drop_size,
+                                  uint64_t* fragment_checksum = nullptr);
 
   // Read some more
   bool ReadMore(size_t* drop_size, int *error);

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -194,8 +194,19 @@ class LogTest
     std::string scratch;
     Slice record;
     bool ret = false;
-    ret = reader_->ReadRecord(&record, &scratch, wal_recovery_mode);
+    uint64_t record_checksum;
+    ret = reader_->ReadRecord(&record, &scratch, wal_recovery_mode,
+                              &record_checksum);
     if (ret) {
+      if (!allow_retry_read_) {
+        // allow_retry_read_ means using FragmentBufferedReader which does not
+        // support record checksum yet.
+        uint64_t actual_record_checksum =
+            XXH3_64bits(record.data(), record.size());
+        if (actual_record_checksum != record_checksum) {
+          assert(actual_record_checksum == record_checksum);
+        }
+      }
       return record.ToString();
     } else {
       return "EOF";


### PR DESCRIPTION
In log::Reader, `ReadPhysicalRecord()` reads in WAL fragments which are then concatenated together in `ReadRecord()` to form a full WAL record. To protect memory corruption during the copying of fragment content, this PR adds checksum handshake between WAL fragment and WAL logical records.

Test plan: added checksum verification in log_test.cc,`make check -j32`.