### PR TITLE
Add a UT to trigger flush race

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -9,11 +9,13 @@
 
 #include <atomic>
 #include <limits>
+#include <chrono>
 
 #include "db/db_impl/db_impl.h"
 #include "db/db_test_util.h"
 #include "env/mock_env.h"
 #include "file/filename.h"
+#include "include/rocksdb/utilities/checkpoint.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "rocksdb/utilities/transaction_db.h"
@@ -75,6 +77,62 @@ TEST_F(DBFlushTest, FlushWhileWritingManifest) {
   ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
 #ifndef ROCKSDB_LITE
   ASSERT_EQ(2, TotalTableFiles());
+#endif  // ROCKSDB_LITE
+}
+
+// We had issue when a flush with wait triggered due to ExportColumnFamily can
+// finish before the result is committed to manifest. This is happening because
+// of a simultaneous flush on the column family. Run in loop to reproduce the
+// failure.
+TEST_F(DBFlushTest, FlushBeforeWritingManifestWithCheckpoint) {
+  Options options;
+  options.disable_auto_compactions = true;
+  options.max_background_flushes = 3;
+  options.max_write_buffer_number = 3;
+  env_->SetBackgroundThreads(3, Env::HIGH);
+  options.env = env_;
+  Reopen(options);
+
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"DBImpl::FlushMemTable:AfterScheduleNonExportFlush",
+        "FlushJob::WriteLevel0Table:flush_started2"}});
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "FlushJob::WriteLevel0Table:flush_started1", [&](void* /*arg*/) {
+        // Add second write and flush without wait.
+        FlushOptions no_wait;
+        no_wait.wait = false;
+        no_wait.allow_write_stall = true;
+        ASSERT_OK(Put("foo", "v"));
+        ASSERT_OK(dbfull()->Flush(no_wait));
+      });
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::FlushMemTable:AfterScheduleNonExportFlush",
+      [&](void* /*arg*/) { SyncPoint::GetInstance()->DisableProcessing(); });
+
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  rocksdb::ExportImportFilesMetaData* cf_sst_files_metadata = nullptr;
+  rocksdb::Checkpoint* checkpoint;
+  auto status = rocksdb::Checkpoint::Create(dbfull(), &checkpoint);
+  ASSERT_EQ(status.ok(), true);
+
+  // Add first write and trigger an ExportColumnFamily which will trigger a
+  // flush.
+  ASSERT_OK(Put("bar", "v"));
+  uint64_t timeSinceEpochMilliseconds =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
+  std::string dir_path =
+      "/tmp/checkpoint1_" + std::to_string(timeSinceEpochMilliseconds);
+  status = checkpoint->ExportColumnFamily(dbfull()->DefaultColumnFamily(),
+                                          dir_path, &cf_sst_files_metadata);
+  ASSERT_EQ(status.ok(), true);
+
+#ifndef ROCKSDB_LITE
+  ASSERT_GT(cf_sst_files_metadata->files.size(), 0);
 #endif  // ROCKSDB_LITE
 }
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2038,6 +2038,12 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
       MaybeScheduleFlushOrCompaction();
     }
 
+    if (flush_options.wait) {
+      TEST_SYNC_POINT("DBImpl::FlushMemTable:AfterScheduleExportFlush");
+    } else {
+      TEST_SYNC_POINT("DBImpl::FlushMemTable:AfterScheduleNonExportFlush");
+    }
+
     if (!writes_stopped) {
       write_thread_.ExitUnbatched(&w);
       if (two_write_queues_) {

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -14,6 +14,11 @@
 #include <algorithm>
 #include <vector>
 
+#ifndef NDEBUG
+#include <chrono>
+#include <thread>
+#endif
+
 #include "db/builder.h"
 #include "db/db_iter.h"
 #include "db/dbformat.h"
@@ -846,6 +851,8 @@ Status FlushJob::WriteLevel0Table() {
                      "[%s] [JOB %d] Level-0 flush table #%" PRIu64 ": started",
                      cfd_->GetName().c_str(), job_context_->job_id,
                      meta_.fd.GetNumber());
+      TEST_SYNC_POINT("FlushJob::WriteLevel0Table:flush_started1");
+      TEST_SYNC_POINT("FlushJob::WriteLevel0Table:flush_started2");
 
       TEST_SYNC_POINT_CALLBACK("FlushJob::WriteLevel0Table:output_compression",
                                &output_compression_);
@@ -945,6 +952,10 @@ Status FlushJob::WriteLevel0Table() {
     db_mutex_->Lock();
   }
   base_->Unref();
+
+#ifndef NDEBUG
+  std::this_thread::sleep_for(std::chrono::milliseconds(rand() % 100));
+#endif
 
   // Note that if file_size is zero, the file has been deleted and
   // should not be added to the manifest.


### PR DESCRIPTION
Suspected Race:

1. A write was done to column family and a flush with wait is triggered(let's call it Flush_A).
2. A second write is issued to the column family which also triggers a flush(let's call it Flush_B) such that both flushes are running in parallel.
3. Flush_B flushes its memtable before Flush_A and goes ahead with commit. This leads to Flush_A exiting the WaitForFlushMemTables before the commit to manifest happens.
