### PR TITLE
fix inconsistent behaviors related to flush and compaction

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2389,6 +2389,10 @@ Status DBImpl::EnableAutoCompaction(
       s = status;
     }
   }
+  {
+    InstrumentedMutexLock l(&mutex_);
+    MaybeScheduleFlushOrCompaction();
+  }
 
   return s;
 }

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -250,10 +250,10 @@ struct AdvancedColumnFamilyOptions {
   // The maximum number of write buffers that are built up in memory.
   // The default and the minimum number is 2, so that when 1 write buffer
   // is being flushed to storage, new writes can continue to the other
-  // write buffer.
-  // If max_write_buffer_number > 3, writing will be slowed down to
-  // options.delayed_write_rate if we are writing to the last write buffer
-  // allowed.
+  // write buffer without triggering write delay.
+  // This parameter affects write delay condition. It does not affect the
+  // timing of write buffer flush. When the number of write buffers exceeds
+  // this number, writing will be slowed down to options.delayed_write_rate.
   //
   // Default: 2
   //


### PR DESCRIPTION
Schedule a flush/compaction after enabling auto compaction. This is consistent
with the documentation of `EnableAutoCompaction`.

Update the documentation of `max_write_buffer_number` to indicate it does not
affect flush timing.

Signed-off-by: tabokie <xy.tao@outlook.com>