### PR TITLE
Add the secondary cache information into LRUCache:: GetPrintableOptions

### DIFF
--- a/cache/compressed_secondary_cache.cc
+++ b/cache/compressed_secondary_cache.cc
@@ -139,7 +139,7 @@ std::string CompressedSecondaryCache::GetPrintableOptions() const {
   snprintf(buffer, kBufferSize, "    compression_type : %s\n",
            CompressionTypeToString(cache_options_.compression_type).c_str());
   ret.append(buffer);
-  snprintf(buffer, kBufferSize, "    compression_type : %d\n",
+  snprintf(buffer, kBufferSize, "    compress_format_version : %d\n",
            cache_options_.compress_format_version);
   ret.append(buffer);
   return ret;

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -757,6 +757,16 @@ void LRUCache::WaitAll(std::vector<Handle*>& handles) {
   }
 }
 
+std::string LRUCache::GetPrintableOptions() const {
+  std::string ret;
+  ret.reserve(20000);
+  ret.append(ShardedCache::GetPrintableOptions());
+  if (secondary_cache_) {
+    ret.append(secondary_cache_->GetPrintableOptions());
+  }
+  return ret;
+}
+
 }  // namespace lru_cache
 
 std::shared_ptr<Cache> NewLRUCache(

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -762,6 +762,7 @@ std::string LRUCache::GetPrintableOptions() const {
   ret.reserve(20000);
   ret.append(ShardedCache::GetPrintableOptions());
   if (secondary_cache_) {
+    ret.append("  secondary_cache:\n");
     ret.append(secondary_cache_->GetPrintableOptions());
   }
   return ret;

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -482,14 +482,12 @@ class LRUCache
   virtual DeleterFn GetDeleter(Handle* handle) const override;
   virtual void DisownData() override;
   virtual void WaitAll(std::vector<Handle*>& handles) override;
+  virtual std::string GetPrintableOptions() const override;
 
   //  Retrieves number of elements in LRU, for unit test purpose only.
   size_t TEST_GetLRUSize();
   //  Retrieves high pri pool ratio.
   double GetHighPriPoolRatio();
-  std::shared_ptr<SecondaryCache> GetSecondaryCache() {
-    return secondary_cache_;
-  }
 
  private:
   LRUCacheShard* shards_ = nullptr;

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -482,7 +482,7 @@ class LRUCache
   virtual DeleterFn GetDeleter(Handle* handle) const override;
   virtual void DisownData() override;
   virtual void WaitAll(std::vector<Handle*>& handles) override;
-  virtual std::string GetPrintableOptions() const override;
+  std::string GetPrintableOptions() const override;
 
   //  Retrieves number of elements in LRU, for unit test purpose only.
   size_t TEST_GetLRUSize();

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -487,6 +487,9 @@ class LRUCache
   size_t TEST_GetLRUSize();
   //  Retrieves high pri pool ratio.
   double GetHighPriPoolRatio();
+  std::shared_ptr<SecondaryCache> GetSecondaryCache() {
+    return secondary_cache_;
+  }
 
  private:
   LRUCacheShard* shards_ = nullptr;

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -17,7 +17,6 @@
 
 #include "cache/cache_entry_roles.h"
 #include "cache/cache_reservation_manager.h"
-#include "cache/lru_cache.h"
 #include "logging/logging.h"
 #include "options/options_helper.h"
 #include "port/port.h"
@@ -783,15 +782,6 @@ std::string BlockBasedTableFactory::GetPrintableOptions() const {
     }
     ret.append("  block_cache_options:\n");
     ret.append(table_options_.block_cache->GetPrintableOptions());
-    if (block_cache_name != nullptr &&
-        std::strcmp(block_cache_name, "LRUCache") == 0) {
-      LRUCache* lru_cache =
-          dynamic_cast<LRUCache*>(table_options_.block_cache.get());
-      if (lru_cache->GetSecondaryCache()) {
-        ret.append("  secondary cache:\n");
-        ret.append(lru_cache->GetSecondaryCache()->GetPrintableOptions());
-      }
-    }
   }
   snprintf(buffer, kBufferSize, "  block_cache_compressed: %p\n",
            static_cast<void*>(table_options_.block_cache_compressed.get()));

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -17,6 +17,7 @@
 
 #include "cache/cache_entry_roles.h"
 #include "cache/cache_reservation_manager.h"
+#include "cache/lru_cache.h"
 #include "logging/logging.h"
 #include "options/options_helper.h"
 #include "port/port.h"
@@ -782,6 +783,14 @@ std::string BlockBasedTableFactory::GetPrintableOptions() const {
     }
     ret.append("  block_cache_options:\n");
     ret.append(table_options_.block_cache->GetPrintableOptions());
+    if (std::strcmp(table_options_.block_cache->Name(), "LRUCache") == 0) {
+      LRUCache* lru_cache =
+          dynamic_cast<LRUCache*>(table_options_.block_cache.get());
+      if (lru_cache->GetSecondaryCache()) {
+        ret.append("  secondary cache:\n");
+        ret.append(lru_cache->GetSecondaryCache()->GetPrintableOptions());
+      }
+    }
   }
   snprintf(buffer, kBufferSize, "  block_cache_compressed: %p\n",
            static_cast<void*>(table_options_.block_cache_compressed.get()));

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -783,7 +783,8 @@ std::string BlockBasedTableFactory::GetPrintableOptions() const {
     }
     ret.append("  block_cache_options:\n");
     ret.append(table_options_.block_cache->GetPrintableOptions());
-    if (std::strcmp(table_options_.block_cache->Name(), "LRUCache") == 0) {
+    if (block_cache_name != nullptr &&
+        std::strcmp(block_cache_name, "LRUCache") == 0) {
       LRUCache* lru_cache =
           dynamic_cast<LRUCache*>(table_options_.block_cache.get());
       if (lru_cache->GetSecondaryCache()) {


### PR DESCRIPTION
Summary:
If the primary cache is LRU cache and there is a secondary cache, add  Secondary Cache printable options into LRUCache::GetPrintableOptions.

Test Plan:
1. Current Unit Tests should pass.
2. Use db_bench (with compressed_secondary_cache ) and the LOG should includes the new printable options from Seoncdary Cache. 