### PR TITLE
Support using secondary cache with the blob cache

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
   * User can configure the new ColumnFamilyOptions `blob_cache` to enable/disable blob caching.
   * Either sharing the backend cache with the block cache or using a completely separate cache is supported.
   * A new abstraction interface called `BlobSource` for blob read logic gives all users access to blobs, whether they are in the blob cache, secondary cache, or (remote) storage. Blobs can be potentially read both while handling user reads (`Get`, `MultiGet`, or iterator) and during compaction (while dealing with compaction filters, Merges, or garbage collection) but eventually all blob reads go through `Version::GetBlob` or, for MultiGet, `Version::MultiGetBlob` (and then get dispatched to the interface -- `BlobSource`).
+  * Support using secondary cache with the blob cache. When creating a blob cache, the user can set a secondary blob cache by configuring `secondary_cache` in LRUCacheOptions.
 * Add experimental tiered compaction feature `AdvancedColumnFamilyOptions::preclude_last_level_data_seconds`, which makes sure the new data inserted within preclude_last_level_data_seconds won't be placed on cold tier (the feature is not complete).
 
 ### Public API changes

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -529,7 +529,7 @@ bool LRUCacheShard::Release(Cache::Handle* handle, bool erase_if_last_ref) {
     // If it was the last reference, and the entry is either not secondary
     // cache compatible (i.e a dummy entry for accounting), or is secondary
     // cache compatible and has a non-null value, then decrement the cache
-    // usage. If value is null in the latter case, taht means the lookup
+    // usage. If value is null in the latter case, that means the lookup
     // failed and we didn't charge the cache.
     if (last_reference && (!e->IsSecondaryCacheCompatible() || e->value)) {
       assert(usage_ >= e->total_charge);

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -428,4 +428,25 @@ bool BlobSource::TEST_BlobInCache(uint64_t file_number, uint64_t file_size,
   return false;
 }
 
+// Callbacks for secondary blob cache
+size_t BlobSource::SizeCallback(void* obj) {
+  assert(obj != nullptr);
+  return static_cast<const std::string*>(obj)->size();
+}
+
+Status BlobSource::SaveToCallback(void* from_obj, size_t from_offset,
+                                  size_t length, void* out) {
+  assert(from_obj != nullptr);
+  const std::string* buf = static_cast<const std::string*>(from_obj);
+  assert(buf->size() >= from_offset + length);
+  memcpy(out, buf->data() + from_offset, length);
+  return Status::OK();
+}
+
+Cache::CacheItemHelper* BlobSource::GetCacheItemHelper() {
+  static Cache::CacheItemHelper cache_helper(SizeCallback, SaveToCallback,
+                                             &DeleteCacheEntry<std::string>);
+  return &cache_helper;
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -87,7 +87,7 @@ Cache::Handle* BlobSource::GetEntryFromCache(const Slice& key) const {
     Cache::CreateCallback create_cb = [&](const void* buf, size_t size,
                                           void** out_obj,
                                           size_t* charge) -> Status {
-      *out_obj = reinterpret_cast<void*>(new char[size]);
+      *out_obj = new char[size];
       memcpy(*out_obj, buf, size);
       *charge = size;
       return Status::OK();

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -87,8 +87,9 @@ Cache::Handle* BlobSource::GetEntryFromCache(const Slice& key) const {
     Cache::CreateCallback create_cb = [&](const void* buf, size_t size,
                                           void** out_obj,
                                           size_t* charge) -> Status {
-      *out_obj = new char[size];
-      memcpy(*out_obj, buf, size);
+      std::string* blob = new std::string();
+      blob->assign(static_cast<const char*>(buf), size);
+      *out_obj = blob;
       *charge = size;
       return Status::OK();
     };

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -123,6 +123,28 @@ class BlobSource {
     return base_cache_key.WithOffset(offset);
   }
 
+  // Callbacks for secondary blob cache
+  static size_t SizeCallback(void* obj) {
+    assert(obj != nullptr);
+    return static_cast<std::string*>(obj)->size();
+  }
+
+  static Status SaveToCallback(void* from_obj, size_t from_offset,
+                               size_t length, void* out) {
+    assert(from_obj != nullptr);
+    const std::string* buf = static_cast<const std::string*>(from_obj);
+    assert(length == buf->size());
+    assert(from_offset == 0);
+    memcpy(out, buf, length);
+    return Status::OK();
+  }
+
+  static Cache::CacheItemHelper* GetCacheItemHelper() {
+    static Cache::CacheItemHelper cache_helper(SizeCallback, SaveToCallback,
+                                               &DeleteCacheEntry<std::string>);
+    return &cache_helper;
+  }
+
   const std::string& db_id_;
   const std::string& db_session_id_;
 
@@ -133,6 +155,11 @@ class BlobSource {
 
   // A cache to store uncompressed blobs.
   std::shared_ptr<Cache> blob_cache_;
+
+  // The control option of how the cache tiers will be used. Currently rocksdb
+  // support block/blob cache (volatile tier), secondary cache (non-volatile
+  // tier).
+  const CacheTier lowest_used_cache_tier_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -133,10 +133,8 @@ class BlobSource {
                                size_t length, void* out) {
     assert(from_obj != nullptr);
     const std::string* buf = static_cast<const std::string*>(from_obj);
-    assert(length == buf->size());
-    assert(from_offset == 0);
-    (void)from_offset;
-    memcpy(out, buf, length);
+    assert(buf->size() >= from_offset + length);
+    memcpy(out, buf->data() + from_offset, length);
     return Status::OK();
   }
 

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -126,7 +126,7 @@ class BlobSource {
   // Callbacks for secondary blob cache
   static size_t SizeCallback(void* obj) {
     assert(obj != nullptr);
-    return static_cast<std::string*>(obj)->size();
+    return static_cast<const std::string*>(obj)->size();
   }
 
   static Status SaveToCallback(void* from_obj, size_t from_offset,
@@ -156,8 +156,9 @@ class BlobSource {
   std::shared_ptr<Cache> blob_cache_;
 
   // The control option of how the cache tiers will be used. Currently rocksdb
-  // support block/blob cache (volatile tier), secondary cache (non-volatile
-  // tier).
+  // support block/blob cache (volatile tier) and secondary cache (this tier
+  // isn't strictly speaking a non-volatile tier since the compressed cache in
+  // this tier is in volatile memory).
   const CacheTier lowest_used_cache_tier_;
 };
 

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -124,25 +124,12 @@ class BlobSource {
   }
 
   // Callbacks for secondary blob cache
-  static size_t SizeCallback(void* obj) {
-    assert(obj != nullptr);
-    return static_cast<const std::string*>(obj)->size();
-  }
+  static size_t SizeCallback(void* obj);
 
   static Status SaveToCallback(void* from_obj, size_t from_offset,
-                               size_t length, void* out) {
-    assert(from_obj != nullptr);
-    const std::string* buf = static_cast<const std::string*>(from_obj);
-    assert(buf->size() >= from_offset + length);
-    memcpy(out, buf->data() + from_offset, length);
-    return Status::OK();
-  }
+                               size_t length, void* out);
 
-  static Cache::CacheItemHelper* GetCacheItemHelper() {
-    static Cache::CacheItemHelper cache_helper(SizeCallback, SaveToCallback,
-                                               &DeleteCacheEntry<std::string>);
-    return &cache_helper;
-  }
+  static Cache::CacheItemHelper* GetCacheItemHelper();
 
   const std::string& db_id_;
   const std::string& db_session_id_;

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -135,6 +135,7 @@ class BlobSource {
     const std::string* buf = static_cast<const std::string*>(from_obj);
     assert(length == buf->size());
     assert(from_offset == 0);
+    (void)from_offset;
     memcpy(out, buf, length);
     return Status::OK();
   }

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -1210,8 +1210,7 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
       auto sec_handle1 = secondary_cache->Lookup(key1, create_cb, true, found);
       ASSERT_FALSE(found);
       ASSERT_NE(sec_handle1, nullptr);
-      ASSERT_TRUE(sec_handle1->IsReady());
-      ASSERT_NE(sec_handle1->Value(), nullptr);
+      ASSERT_EQ(sec_handle1->Value(), nullptr);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[1]));
@@ -1252,8 +1251,7 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
       auto sec_handle1 = secondary_cache->Lookup(key1, create_cb, true, found);
       ASSERT_FALSE(found);
       ASSERT_NE(sec_handle1, nullptr);
-      ASSERT_TRUE(sec_handle1->IsReady());
-      ASSERT_NE(sec_handle1->Value(), nullptr);
+      ASSERT_EQ(sec_handle1->Value(), nullptr);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[1]));
@@ -1309,8 +1307,7 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
       sec_handle0 = secondary_cache->Lookup(key0, create_cb, true, found);
       ASSERT_FALSE(found);
       ASSERT_NE(sec_handle0, nullptr);
-      ASSERT_TRUE(sec_handle0->IsReady());
-      ASSERT_NE(sec_handle0->Value(), nullptr);
+      ASSERT_EQ(sec_handle0->Value(), nullptr);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[0]));

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -1088,19 +1088,12 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
 
   Random rnd(301);
 
-  std::vector<std::string> key_strs;
-  std::vector<std::string> blob_strs;
-  key_strs.push_back("key0");
-  blob_strs.push_back(rnd.RandomString(1010));
-  key_strs.push_back("key1");
-  blob_strs.push_back(rnd.RandomString(1020));
+  std::vector<std::string> key_strs{"key0", "key1"};
+  std::vector<std::string> blob_strs{rnd.RandomString(1010),
+                                     rnd.RandomString(1020)};
 
-  std::vector<Slice> keys;
-  std::vector<Slice> blobs;
-  keys.push_back({key_strs[0]});
-  blobs.push_back({blob_strs[0]});
-  keys.push_back({key_strs[1]});
-  blobs.push_back({blob_strs[1]});
+  std::vector<Slice> keys{key_strs[0], key_strs[1]};
+  std::vector<Slice> blobs{blob_strs[0], blob_strs[1]};
 
   std::vector<uint64_t> blob_offsets(keys.size());
   std::vector<uint64_t> blob_sizes(keys.size());

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -1131,7 +1131,6 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
   read_options.verify_checksums = true;
 
   auto blob_cache = options_.blob_cache;
-  auto secondary_cache = lru_cache_ops_.secondary_cache;
   {
     // GetBlob
     std::vector<PinnableSlice> values(keys.size());

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -1136,8 +1136,9 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
   Cache::CreateCallback create_cb = [&](const void* buf, size_t size,
                                         void** out_obj,
                                         size_t* charge) -> Status {
-    *out_obj = new char[size];
-    memcpy(*out_obj, buf, size);
+    std::string* blob = new std::string();
+    blob->assign(static_cast<const char*>(buf), size);
+    *out_obj = blob;
     *charge = size;
     return Status::OK();
   };
@@ -1183,8 +1184,13 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
       blob_cache->Release(handle0);
 
       bool found = false;
-      secondary_cache->Lookup(key0, create_cb, true, found);
+      auto sec_handle0 = secondary_cache->Lookup(key0, create_cb, true, found);
       ASSERT_TRUE(found);
+      ASSERT_NE(sec_handle0, nullptr);
+      ASSERT_TRUE(sec_handle0->IsReady());
+      auto value = static_cast<std::string*>(sec_handle0->Value());
+      ASSERT_EQ(*value, blobs[0]);
+      delete value;
 
       // For blob source interface, after a cache miss occurs in the primary
       // cache, key0 can be retrieved in the secondary cache.
@@ -1201,8 +1207,11 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
       blob_cache->Release(handle1);
 
       bool found = false;
-      secondary_cache->Lookup(key1, create_cb, true, found);
+      auto sec_handle1 = secondary_cache->Lookup(key1, create_cb, true, found);
       ASSERT_FALSE(found);
+      ASSERT_NE(sec_handle1, nullptr);
+      ASSERT_TRUE(sec_handle1->IsReady());
+      ASSERT_NE(sec_handle1->Value(), nullptr);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[1]));
@@ -1218,8 +1227,13 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
       blob_cache->Release(handle0);
 
       bool found = false;
-      secondary_cache->Lookup(key0, create_cb, true, found);
+      auto sec_handle0 = secondary_cache->Lookup(key0, create_cb, true, found);
       ASSERT_TRUE(found);
+      ASSERT_NE(sec_handle0, nullptr);
+      ASSERT_TRUE(sec_handle0->IsReady());
+      auto value = static_cast<std::string*>(sec_handle0->Value());
+      ASSERT_EQ(*value, blobs[0]);
+      delete value;
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[0]));
@@ -1235,8 +1249,11 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
       blob_cache->Release(handle1);
 
       bool found = false;
-      secondary_cache->Lookup(key1, create_cb, true, found);
+      auto sec_handle1 = secondary_cache->Lookup(key1, create_cb, true, found);
       ASSERT_FALSE(found);
+      ASSERT_NE(sec_handle1, nullptr);
+      ASSERT_TRUE(sec_handle1->IsReady());
+      ASSERT_NE(sec_handle1->Value(), nullptr);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[1]));
@@ -1275,8 +1292,13 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
 
       // before we promote key0 to the primary cache
       bool found = false;
-      secondary_cache->Lookup(key0, create_cb, true, found);
+      auto sec_handle0 = secondary_cache->Lookup(key0, create_cb, true, found);
       ASSERT_TRUE(found);
+      ASSERT_NE(sec_handle0, nullptr);
+      ASSERT_TRUE(sec_handle0->IsReady());
+      auto value = static_cast<std::string*>(sec_handle0->Value());
+      ASSERT_EQ(*value, blobs[0]);
+      delete value;
 
       auto handle0 = blob_cache->Lookup(key0, statistics);
       ASSERT_NE(handle0, nullptr);
@@ -1284,8 +1306,11 @@ TEST_F(BlobSecondaryCacheTest, GetBlobsFromSecondaryCache) {
 
       // after we promote key0 to the primary cache
       found = false;
-      secondary_cache->Lookup(key0, create_cb, true, found);
+      sec_handle0 = secondary_cache->Lookup(key0, create_cb, true, found);
       ASSERT_FALSE(found);
+      ASSERT_NE(sec_handle0, nullptr);
+      ASSERT_TRUE(sec_handle0->IsReady());
+      ASSERT_NE(sec_handle0->Value(), nullptr);
 
       ASSERT_TRUE(blob_source.TEST_BlobInCache(file_number, file_size,
                                                blob_offsets[0]));


### PR DESCRIPTION
Summary:

RocksDB supports a two-level cache hierarchy (see https://rocksdb.org/blog/2021/05/27/rocksdb-secondary-cache.html), where items evicted from the primary cache can be spilled over to the secondary cache, or items from the secondary cache can be promoted to the primary one. We have a CacheLib-based non-volatile secondary cache implementation that can be used to improve read latencies and reduce the amount of network bandwidth when using distributed file systems. In addition, we have recently implemented a compressed secondary cache that can be used as a replacement for the OS page cache when e.g. direct I/O is used. The goals of this task are to add support for using a secondary cache with the blob cache and to measure the potential performance gains using `db_bench`.

This task is a part of https://github.com/facebook/rocksdb/issues/10156