### PR TITLE
Revert NewClockCache signature

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -584,8 +584,7 @@ void ClockCache::DisownData() {
 }  // namespace clock_cache
 
 std::shared_ptr<Cache> NewClockCache(
-    size_t capacity, size_t /*estimated_value_size*/, int num_shard_bits,
-    bool strict_capacity_limit,
+    size_t capacity, int num_shard_bits, bool strict_capacity_limit,
     CacheMetadataChargePolicy metadata_charge_policy) {
   return NewLRUCache(capacity, num_shard_bits, strict_capacity_limit, 0.5,
                      nullptr, kDefaultToAdaptiveMutex, metadata_charge_policy);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -114,9 +114,9 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
   }
 
   if (FLAGS_cache_type == "clock_cache") {
-    auto cache = NewClockCache(static_cast<size_t>(capacity), FLAGS_block_size,
-                               num_shard_bits, false /*strict_capacity_limit*/,
-                               kDefaultCacheMetadataChargePolicy);
+    auto cache = ExperimentalNewClockCache(
+        static_cast<size_t>(capacity), FLAGS_block_size, num_shard_bits,
+        false /*strict_capacity_limit*/, kDefaultCacheMetadataChargePolicy);
     if (!cache) {
       fprintf(stderr, "Clock cache not supported.");
       exit(1);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -10,6 +10,7 @@
 
 #include "util/compression.h"
 #ifdef GFLAGS
+#include "cache/clock_cache.h"
 #include "cache/fast_lru_cache.h"
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_compaction_filter.h"

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -180,9 +180,10 @@ extern std::shared_ptr<SecondaryCache> NewCompressedSecondaryCache(
 //
 // Return nullptr if it is not supported.
 extern std::shared_ptr<Cache> NewClockCache(
-    size_t capacity, size_t estimated_value_size, int num_shard_bits,
-    bool strict_capacity_limit,
-    CacheMetadataChargePolicy metadata_charge_policy);
+    size_t capacity, int num_shard_bits = -1,
+    bool strict_capacity_limit = false,
+    CacheMetadataChargePolicy metadata_charge_policy =
+        kDefaultCacheMetadataChargePolicy);
 
 class Cache {
  public:

--- a/java/rocksjni/clock_cache.cc
+++ b/java/rocksjni/clock_cache.cc
@@ -23,10 +23,8 @@ jlong Java_org_rocksdb_ClockCache_newClockCache(
     jboolean jstrict_capacity_limit) {
   auto* sptr_clock_cache = new std::shared_ptr<ROCKSDB_NAMESPACE::Cache>(
       ROCKSDB_NAMESPACE::NewClockCache(
-          static_cast<size_t>(jcapacity), 1 /* estimated_value_size */,
-          static_cast<int>(jnum_shard_bits),
-          static_cast<bool>(jstrict_capacity_limit),
-          rocksdb::CacheMetadataChargePolicy::kFullChargeCacheMetadata));
+          static_cast<size_t>(jcapacity), static_cast<int>(jnum_shard_bits),
+          static_cast<bool>(jstrict_capacity_limit)));
   return GET_CPLUSPLUS_POINTER(sptr_clock_cache);
 }
 


### PR DESCRIPTION
Summary: This complements #10351. This PR reverts NewClockCache's signature to an older version, expected by the users of the old (buggy) ClockCache.

Test plan: ``make -j24 check`` and re-run the pre-release tests.