### PR TITLE
DB::PutEntity() shouldn't be defined as =0

### DIFF
--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -410,7 +410,7 @@ class DB {
   // UNDER CONSTRUCTION -- DO NOT USE
   virtual Status PutEntity(const WriteOptions& options,
                            ColumnFamilyHandle* column_family, const Slice& key,
-                           const WideColumns& columns) = 0;
+                           const WideColumns& columns);
 
   // Remove the database entry (if any) for "key".  Returns OK on
   // success, and a non-OK status on error.  It is not an error if "key"


### PR DESCRIPTION
Summary:
DB::PutEntity() is defined as 0, but it is actually implemented in db/db_impl/db_impl_write.cc. It is incorrect, and might cause problems when users implement class DB themselves.

Test Plan: See existing tests pass