### PR TITLE
Fix hang in MultiRead with O_DIRECT and io_uring

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1523,11 +1523,6 @@ TEST_F(EnvPosixTest, MultiReadNonAlignedLargeNum) {
 }
 
 TEST_F(EnvPosixTest, MultiReadDirectIONonAlignedLargeNum) {
-#if !defined(OS_MACOSX) && !defined(OS_SOLARIS) && !defined(OS_AIX)
-  ROCKSDB_GTEST_SKIP("direct reads/writes are not supported");
-  return;
-#endif
-
   EnvOptions soptions;
   soptions.use_direct_reads = soptions.use_direct_writes = true;
   std::string fname = test::PerThreadDBPath(env_, "testfile");

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1523,6 +1523,11 @@ TEST_F(EnvPosixTest, MultiReadNonAlignedLargeNum) {
 }
 
 TEST_F(EnvPosixTest, MultiReadDirectIONonAlignedLargeNum) {
+#if !defined(OS_MACOSX) && !defined(OS_SOLARIS) && !defined(OS_AIX)
+  ROCKSDB_GTEST_SKIP("direct reads/writes are not supported");
+  return;
+#endif
+
   EnvOptions soptions;
   soptions.use_direct_reads = soptions.use_direct_writes = true;
   std::string fname = test::PerThreadDBPath(env_, "testfile");

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -750,14 +750,17 @@ IOStatus PosixRandomAccessFile::MultiRead(FSReadRequest* reqs,
                    bytes_read, read_again);
       int32_t res = cqe->res;
       if (res >= 0) {
-        if (bytes_read == 0 && read_again) {
-          Slice tmp_slice;
-          req->status =
-              Read(req->offset + req_wrap->finished_len,
-                   req->len - req_wrap->finished_len, options, &tmp_slice,
-                   req->scratch + req_wrap->finished_len, dbg);
-          req->result =
-              Slice(req->scratch, req_wrap->finished_len + tmp_slice.size());
+        if (bytes_read == 0) {
+          if (read_again) {
+            Slice tmp_slice;
+            req->status =
+                Read(req->offset + req_wrap->finished_len,
+                     req->len - req_wrap->finished_len, options, &tmp_slice,
+                     req->scratch + req_wrap->finished_len, dbg);
+            req->result =
+                Slice(req->scratch, req_wrap->finished_len + tmp_slice.size());
+          }
+          // else It means EOF so no need to do anything.
         } else if (bytes_read < req_wrap->iov.iov_len) {
           incomplete_rq_list.push_back(req_wrap);
         }

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -117,11 +117,7 @@ inline void UpdateResult(struct io_uring_cqe* cqe, const std::string& file_name,
       // comment
       // https://github.com/facebook/rocksdb/pull/6441#issuecomment-589843435
       // Fall back to pread in this case.
-      bool is_sector_aligned = IsSectorAligned(finished_len, alignment);
-      TEST_SYNC_POINT_CALLBACK(
-          "UpdateResults::io_uring_result::SectorAlignment",
-          &is_sector_aligned);
-      if (use_direct_io && !is_sector_aligned) {
+      if (use_direct_io && !IsSectorAligned(finished_len, alignment)) {
         // Bytes reads don't fill sectors. Should only happen at the end
         // of the file.
         req->result = Slice(req->scratch, finished_len);

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -117,7 +117,11 @@ inline void UpdateResult(struct io_uring_cqe* cqe, const std::string& file_name,
       // comment
       // https://github.com/facebook/rocksdb/pull/6441#issuecomment-589843435
       // Fall back to pread in this case.
-      if (use_direct_io && !IsSectorAligned(finished_len, alignment)) {
+      bool is_sector_aligned = IsSectorAligned(finished_len, alignment);
+      TEST_SYNC_POINT_CALLBACK(
+          "UpdateResults::io_uring_result::SectorAlignment",
+          &is_sector_aligned);
+      if (use_direct_io && !is_sector_aligned) {
         // Bytes reads don't fill sectors. Should only happen at the end
         // of the file.
         req->result = Slice(req->scratch, finished_len);


### PR DESCRIPTION
Summary: Fix bug in O_DIRECT and io_uring when its EOF and bytes_read =
0 because of wrong check, it got added into incomplete list and gets stuck in an infinite loop as it will always return bytes_read = 0. The bug was introduced by PR https://github.com/facebook/rocksdb/pull/10197 and that PR is not released yet in any release branch.

Test Plan: Added new unit test

Reviewers:

Subscribers:

Tasks:

Tags: