### PR TITLE
Fix race conditions in GenericRateLimiter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 * Fix a bug where `GenericRateLimiter` could revert the bandwidth set dynamically using `SetBytesPerSecond()` when a user configures a structure enclosing it, e.g., using `GetOptionsFromString()` to configure an `Options` that references an existing `RateLimiter` object.
+* Fix race conditions in `GenericRateLimiter`.
 
 ## 7.5.0 (07/15/2022)
 ### New Features

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,7 +37,6 @@
 * Fix a bug where concurrent compactions might cause unnecessary further write stalling. In some cases, this might cause write rate to drop to minimum.
 * Fix a bug in Logger where if dbname and db_log_dir are on different filesystems, dbname creation would fail wrt to db_log_dir path returning an error and fails to open the DB.
 * Fix a CPU and memory efficiency issue introduce by https://github.com/facebook/rocksdb/pull/8336 which made InternalKeyComparator configurable as an unintended side effect.
-* Fix a bug where `GenericRateLimiter` could revert the bandwidth set dynamically using `SetBytesPerSecond()` when a user configures a structure enclosing it, e.g., configuring an `Options` that references an in-use `RateLimiter` object via `GetOptionsFromString()`.
 
 ## Behavior Change
 * In leveled compaction with dynamic levelling, level multiplier is not anymore adjusted due to oversized L0. Instead, compaction score is adjusted by increasing size level target by adding incoming bytes from upper levels. This would deprioritize compactions from upper levels if more data from L0 is coming. This is to fix some unnecessary full stalling due to drastic change of level targets, while not wasting write bandwidth for compaction while writes are overloaded.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,7 @@
 * Fix a bug where concurrent compactions might cause unnecessary further write stalling. In some cases, this might cause write rate to drop to minimum.
 * Fix a bug in Logger where if dbname and db_log_dir are on different filesystems, dbname creation would fail wrt to db_log_dir path returning an error and fails to open the DB.
 * Fix a CPU and memory efficiency issue introduce by https://github.com/facebook/rocksdb/pull/8336 which made InternalKeyComparator configurable as an unintended side effect.
+* Fix a bug where `GenericRateLimiter` could revert the bandwidth set dynamically using `SetBytesPerSecond()` when a user configures a structure enclosing it, e.g., configuring an `Options` that references an in-use `RateLimiter` object via `GetOptionsFromString()`.
 
 ## Behavior Change
 * In leveled compaction with dynamic levelling, level multiplier is not anymore adjusted due to oversized L0. Instead, compaction score is adjusted by increasing size level target by adding incoming bytes from upper levels. This would deprioritize compactions from upper levels if more data from L0 is coming. This is to fix some unnecessary full stalling due to drastic change of level targets, while not wasting write bandwidth for compaction while writes are overloaded.

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -150,10 +150,6 @@ class RateLimiter {
 // @auto_tuned: Enables dynamic adjustment of rate limit within the range
 //              `[rate_bytes_per_sec / 20, rate_bytes_per_sec]`, according to
 //              the recent demand for background I/O.
-//
-// Thread-safety notes:
-// - The object returned by this function is not thread-safe to use with
-//   Configurable APIs, e.g., `GetOptionsFromString()`.
 extern RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us = 100 * 1000,
     int32_t fairness = 10,

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -150,6 +150,11 @@ class RateLimiter {
 // @auto_tuned: Enables dynamic adjustment of rate limit within the range
 //              `[rate_bytes_per_sec / 20, rate_bytes_per_sec]`, according to
 //              the recent demand for background I/O.
+//
+// Thread-safety notes:
+// - `SetBytesPerSecond()` on the returned `RateLimiter` object must not run
+//   concurrently with configuration APIs affecting the same object, e.g.,
+//   `GetOptionsFromString()`.
 extern RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us = 100 * 1000,
     int32_t fairness = 10,

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -152,9 +152,10 @@ class RateLimiter {
 //              the recent demand for background I/O.
 //
 // Thread-safety notes:
-// - `SetBytesPerSecond()` on the returned `RateLimiter` object must not run
-//   concurrently with configuration APIs affecting the same object, e.g.,
-//   `GetOptionsFromString()`.
+// - The object returned by this function is not thread-safe to use with
+//   Configurable APIs, e.g., `GetOptionsFromString()`. Furthermore, its
+//   `SetBytesPerSecond()` uses Configurable internally and is thus susceptible
+//   to race conditions when called while the rate limiter is in-use.
 extern RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us = 100 * 1000,
     int32_t fairness = 10,

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -153,9 +153,7 @@ class RateLimiter {
 //
 // Thread-safety notes:
 // - The object returned by this function is not thread-safe to use with
-//   Configurable APIs, e.g., `GetOptionsFromString()`. Furthermore, its
-//   `SetBytesPerSecond()` uses Configurable internally and is thus susceptible
-//   to race conditions when called while the rate limiter is in-use.
+//   Configurable APIs, e.g., `GetOptionsFromString()`.
 extern RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us = 100 * 1000,
     int32_t fairness = 10,

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -54,20 +54,20 @@ GenericRateLimiter::GenericRateLimiter(
       rate_bytes_per_sec_(auto_tuned ? rate_bytes_per_sec / 2
                                      : rate_bytes_per_sec),
       refill_bytes_per_period_(
-          CalculateRefillBytesPerPeriod(rate_bytes_per_sec_)),
+          CalculateRefillBytesPerPeriodLocked(rate_bytes_per_sec_)),
       clock_(clock),
       stop_(false),
       exit_cv_(&request_mutex_),
       requests_to_wait_(0),
       available_bytes_(0),
-      next_refill_us_(NowMicrosMonotonic()),
+      next_refill_us_(NowMicrosMonotonicLocked()),
       fairness_(fairness > 100 ? 100 : fairness),
       rnd_((uint32_t)time(nullptr)),
       wait_until_refill_pending_(false),
       auto_tuned_(auto_tuned),
       num_drains_(0),
       max_bytes_per_sec_(rate_bytes_per_sec),
-      tuned_time_(NowMicrosMonotonic()) {
+      tuned_time_(NowMicrosMonotonicLocked()) {
   for (int i = Env::IO_LOW; i < Env::IO_TOTAL; ++i) {
     total_requests_[i] = 0;
     total_bytes_through_[i] = 0;
@@ -98,10 +98,9 @@ GenericRateLimiter::~GenericRateLimiter() {
 // This API allows user to dynamically change rate limiter's bytes per second.
 void GenericRateLimiter::SetBytesPerSecond(int64_t bytes_per_second) {
   assert(bytes_per_second > 0);
-  rate_bytes_per_sec_ = bytes_per_second;
-  refill_bytes_per_period_.store(
-      CalculateRefillBytesPerPeriod(bytes_per_second),
-      std::memory_order_relaxed);
+  ConfigureFromMap(ConfigOptions(),
+                   {{"rate_bytes_per_sec", std::to_string(bytes_per_second)}})
+      .PermitUncheckedError();
 }
 
 void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
@@ -115,10 +114,10 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
 
   if (auto_tuned_) {
     static const int kRefillsPerTune = 100;
-    std::chrono::microseconds now(NowMicrosMonotonic());
+    std::chrono::microseconds now(NowMicrosMonotonicLocked());
     if (now - tuned_time_ >=
         kRefillsPerTune * std::chrono::microseconds(refill_period_us_)) {
-      Status s = Tune();
+      Status s = TuneLocked();
       s.PermitUncheckedError();  //**TODO: What to do on error?
     }
   }
@@ -152,7 +151,7 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
   // (1) Waiting for the next refill time.
   // (2) Refilling the bytes and granting requests.
   do {
-    int64_t time_until_refill_us = next_refill_us_ - NowMicrosMonotonic();
+    int64_t time_until_refill_us = next_refill_us_ - NowMicrosMonotonicLocked();
     if (time_until_refill_us > 0) {
       if (wait_until_refill_pending_) {
         // Somebody is performing (1). Trust we'll be woken up when our request
@@ -173,7 +172,7 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
     } else {
       // Whichever thread reaches here first performs duty (2) as described
       // above.
-      RefillBytesAndGrantRequests();
+      RefillBytesAndGrantRequestsLocked();
       if (r.granted) {
         // If there is any remaining requests, make sure there exists at least
         // one candidate is awake for future duties by signaling a front request
@@ -215,7 +214,7 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
 }
 
 std::vector<Env::IOPriority>
-GenericRateLimiter::GeneratePriorityIterationOrder() {
+GenericRateLimiter::GeneratePriorityIterationOrderLocked() {
   std::vector<Env::IOPriority> pri_iteration_order(Env::IO_TOTAL /* 4 */);
   // We make Env::IO_USER a superior priority by always iterating its queue
   // first
@@ -223,12 +222,12 @@ GenericRateLimiter::GeneratePriorityIterationOrder() {
 
   bool high_pri_iterated_after_mid_low_pri = rnd_.OneIn(fairness_);
   TEST_SYNC_POINT_CALLBACK(
-      "GenericRateLimiter::GeneratePriorityIterationOrder::"
+      "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
       "PostRandomOneInFairnessForHighPri",
       &high_pri_iterated_after_mid_low_pri);
   bool mid_pri_itereated_after_low_pri = rnd_.OneIn(fairness_);
   TEST_SYNC_POINT_CALLBACK(
-      "GenericRateLimiter::GeneratePriorityIterationOrder::"
+      "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
       "PostRandomOneInFairnessForMidPri",
       &mid_pri_itereated_after_low_pri);
 
@@ -247,15 +246,15 @@ GenericRateLimiter::GeneratePriorityIterationOrder() {
   }
 
   TEST_SYNC_POINT_CALLBACK(
-      "GenericRateLimiter::GeneratePriorityIterationOrder::"
+      "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
       "PreReturnPriIterationOrder",
       &pri_iteration_order);
   return pri_iteration_order;
 }
 
-void GenericRateLimiter::RefillBytesAndGrantRequests() {
+void GenericRateLimiter::RefillBytesAndGrantRequestsLocked() {
   TEST_SYNC_POINT("GenericRateLimiter::RefillBytesAndGrantRequests");
-  next_refill_us_ = NowMicrosMonotonic() + refill_period_us_;
+  next_refill_us_ = NowMicrosMonotonicLocked() + refill_period_us_;
   // Carry over the left over quota from the last period
   auto refill_bytes_per_period =
       refill_bytes_per_period_.load(std::memory_order_relaxed);
@@ -264,7 +263,7 @@ void GenericRateLimiter::RefillBytesAndGrantRequests() {
   }
 
   std::vector<Env::IOPriority> pri_iteration_order =
-      GeneratePriorityIterationOrder();
+      GeneratePriorityIterationOrderLocked();
 
   for (int i = Env::IO_LOW; i < Env::IO_TOTAL; ++i) {
     assert(!pri_iteration_order.empty());
@@ -293,7 +292,7 @@ void GenericRateLimiter::RefillBytesAndGrantRequests() {
   }
 }
 
-int64_t GenericRateLimiter::CalculateRefillBytesPerPeriod(
+int64_t GenericRateLimiter::CalculateRefillBytesPerPeriodLocked(
     int64_t rate_bytes_per_sec) {
   if (std::numeric_limits<int64_t>::max() / rate_bytes_per_sec <
       refill_period_us_) {
@@ -305,7 +304,7 @@ int64_t GenericRateLimiter::CalculateRefillBytesPerPeriod(
   }
 }
 
-Status GenericRateLimiter::Tune() {
+Status GenericRateLimiter::TuneLocked() {
   const int kLowWatermarkPct = 50;
   const int kHighWatermarkPct = 90;
   const int kAdjustFactorPct = 5;
@@ -314,7 +313,7 @@ Status GenericRateLimiter::Tune() {
   const int kAllowedRangeFactor = 20;
 
   std::chrono::microseconds prev_tuned_time = tuned_time_;
-  tuned_time_ = std::chrono::microseconds(NowMicrosMonotonic());
+  tuned_time_ = std::chrono::microseconds(NowMicrosMonotonicLocked());
 
   int64_t elapsed_intervals = (tuned_time_ - prev_tuned_time +
                                std::chrono::microseconds(refill_period_us_) -

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -98,9 +98,20 @@ GenericRateLimiter::~GenericRateLimiter() {
 // This API allows user to dynamically change rate limiter's bytes per second.
 void GenericRateLimiter::SetBytesPerSecond(int64_t bytes_per_second) {
   assert(bytes_per_second > 0);
+#ifndef ROCKSDB_LITE
+  // TODO: this mutates `options_` (a `GenericRateLimiterOptions`) without
+  // locking internally. That means clients are responsible to avoid calling
+  // `SetBytesPerSecond()` concurrently with any Configurable APIs.
   ConfigureFromMap(ConfigOptions(),
                    {{"rate_bytes_per_sec", std::to_string(bytes_per_second)}})
       .PermitUncheckedError();
+#else  // ROCKSDB_LITE
+  // TODO: if Configurable does one day support mutating options in LITE mode,
+  // this mutation will be susceptible to the same race condition as above.
+  MutexLock g(&request_mutex_);
+  options_.max_bytes_per_sec = bytes_per_second;
+  InitializeLocked();
+#endif
 }
 
 void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -253,7 +253,8 @@ GenericRateLimiter::GeneratePriorityIterationOrderLocked() {
 }
 
 void GenericRateLimiter::RefillBytesAndGrantRequestsLocked() {
-  TEST_SYNC_POINT("GenericRateLimiter::RefillBytesAndGrantRequests");
+  TEST_SYNC_POINT_CALLBACK("GenericRateLimiter::RefillBytesAndGrantRequestsLocked",
+                           &request_mutex_);
   next_refill_us_ = NowMicrosMonotonicLocked() + refill_period_us_;
   // Carry over the left over quota from the last period
   auto refill_bytes_per_period =

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -349,7 +349,9 @@ Status GenericRateLimiter::TuneLocked() {
     new_bytes_per_sec = prev_bytes_per_sec;
   }
   if (new_bytes_per_sec != prev_bytes_per_sec) {
-    SetBytesPerSecond(new_bytes_per_sec);
+    rate_bytes_per_sec_ = new_bytes_per_sec;
+    refill_bytes_per_period_ =
+        CalculateRefillBytesPerPeriodLocked(rate_bytes_per_sec_);
   }
   num_drains_ = 0;
   return Status::OK();

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -100,8 +100,7 @@ void GenericRateLimiter::SetBytesPerSecond(int64_t bytes_per_second) {
   assert(bytes_per_second > 0);
 #ifndef ROCKSDB_LITE
   // TODO: this mutates `options_` (a `GenericRateLimiterOptions`) without
-  // locking internally. That means clients are responsible to avoid calling
-  // `SetBytesPerSecond()` concurrently with any Configurable APIs.
+  // locking internally.
   ConfigureFromMap(ConfigOptions(),
                    {{"rate_bytes_per_sec", std::to_string(bytes_per_second)}})
       .PermitUncheckedError();

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -253,8 +253,8 @@ GenericRateLimiter::GeneratePriorityIterationOrderLocked() {
 }
 
 void GenericRateLimiter::RefillBytesAndGrantRequestsLocked() {
-  TEST_SYNC_POINT_CALLBACK("GenericRateLimiter::RefillBytesAndGrantRequestsLocked",
-                           &request_mutex_);
+  TEST_SYNC_POINT_CALLBACK(
+      "GenericRateLimiter::RefillBytesAndGrantRequestsLocked", &request_mutex_);
   next_refill_us_ = NowMicrosMonotonicLocked() + refill_period_us_;
   // Carry over the left over quota from the last period
   auto refill_bytes_per_period =

--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -92,7 +92,7 @@ class GenericRateLimiter : public RateLimiter {
   }
 
   virtual int64_t GetBytesPerSecond() const override {
-    return rate_bytes_per_sec_;
+    return rate_bytes_per_sec_.load(std::memory_order_relaxed);
   }
 
   virtual void TEST_SetClock(std::shared_ptr<SystemClock> clock) {
@@ -102,20 +102,21 @@ class GenericRateLimiter : public RateLimiter {
   }
 
  private:
-  void RefillBytesAndGrantRequests();
-  std::vector<Env::IOPriority> GeneratePriorityIterationOrder();
-  int64_t CalculateRefillBytesPerPeriod(int64_t rate_bytes_per_sec);
-  Status Tune();
+  void RefillBytesAndGrantRequestsLocked();
+  std::vector<Env::IOPriority> GeneratePriorityIterationOrderLocked();
+  int64_t CalculateRefillBytesPerPeriodLocked(int64_t rate_bytes_per_sec);
+  Status TuneLocked();
 
-  uint64_t NowMicrosMonotonic() { return clock_->NowNanos() / std::milli::den; }
+  uint64_t NowMicrosMonotonicLocked() {
+    return clock_->NowNanos() / std::milli::den;
+  }
 
   // This mutex guard all internal states
   mutable port::Mutex request_mutex_;
 
   const int64_t refill_period_us_;
 
-  int64_t rate_bytes_per_sec_;
-  // This variable can be changed dynamically.
+  std::atomic<int64_t> rate_bytes_per_sec_;
   std::atomic<int64_t> refill_bytes_per_period_;
   std::shared_ptr<SystemClock> clock_;
 

--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -98,7 +98,7 @@ class GenericRateLimiter : public RateLimiter {
   virtual void TEST_SetClock(std::shared_ptr<SystemClock> clock) {
     MutexLock g(&request_mutex_);
     clock_ = std::move(clock);
-    next_refill_us_ = NowMicrosMonotonic();
+    next_refill_us_ = NowMicrosMonotonicLocked();
   }
 
  private:
@@ -106,6 +106,7 @@ class GenericRateLimiter : public RateLimiter {
   std::vector<Env::IOPriority> GeneratePriorityIterationOrderLocked();
   int64_t CalculateRefillBytesPerPeriodLocked(int64_t rate_bytes_per_sec);
   Status TuneLocked();
+  void SetBytesPerSecondLocked(int64_t bytes_per_second);
 
   uint64_t NowMicrosMonotonicLocked() {
     return clock_->NowNanos() / std::milli::den;

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -202,7 +202,7 @@ TEST_F(RateLimiterTest, GeneratePriorityIterationOrder) {
     bool mid_pri_itereated_after_low_pri_set = false;
     bool pri_iteration_order_verified = false;
     SyncPoint::GetInstance()->SetCallBack(
-        "GenericRateLimiter::GeneratePriorityIterationOrder::"
+        "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
         "PostRandomOneInFairnessForHighPri",
         [&](void* arg) {
           bool* high_pri_iterated_after_mid_low_pri = (bool*)arg;
@@ -212,7 +212,7 @@ TEST_F(RateLimiterTest, GeneratePriorityIterationOrder) {
         });
 
     SyncPoint::GetInstance()->SetCallBack(
-        "GenericRateLimiter::GeneratePriorityIterationOrder::"
+        "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
         "PostRandomOneInFairnessForMidPri",
         [&](void* arg) {
           bool* mid_pri_itereated_after_low_pri = (bool*)arg;
@@ -222,7 +222,7 @@ TEST_F(RateLimiterTest, GeneratePriorityIterationOrder) {
         });
 
     SyncPoint::GetInstance()->SetCallBack(
-        "GenericRateLimiter::GeneratePriorityIterationOrder::"
+        "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
         "PreReturnPriIterationOrder",
         [&](void* arg) {
           std::vector<Env::IOPriority>* pri_iteration_order =
@@ -249,13 +249,13 @@ TEST_F(RateLimiterTest, GeneratePriorityIterationOrder) {
     ASSERT_EQ(pri_iteration_order_verified, true);
     SyncPoint::GetInstance()->DisableProcessing();
     SyncPoint::GetInstance()->ClearCallBack(
-        "GenericRateLimiter::GeneratePriorityIterationOrder::"
+        "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
         "PreReturnPriIterationOrder");
     SyncPoint::GetInstance()->ClearCallBack(
-        "GenericRateLimiter::GeneratePriorityIterationOrder::"
+        "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
         "PostRandomOneInFairnessForMidPri");
     SyncPoint::GetInstance()->ClearCallBack(
-        "GenericRateLimiter::GeneratePriorityIterationOrder::"
+        "GenericRateLimiter::GeneratePriorityIterationOrderLocked::"
         "PostRandomOneInFairnessForHighPri");
   }
 }

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -393,7 +393,8 @@ TEST_F(RateLimiterTest, LimitChangeTest) {
       // guaranteed under any situation
       int32_t new_limit = (target << 1) >> (iter << 1);
       ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
-          "GenericRateLimiter::RefillBytesAndGrantRequestsLocked", [&](void* arg) {
+          "GenericRateLimiter::RefillBytesAndGrantRequestsLocked",
+          [&](void* arg) {
             port::Mutex* request_mutex = static_cast<port::Mutex*>(arg);
             // We temporarily unlock the mutex so that the following
             // SetBytesPerSecond() can acquire it
@@ -401,10 +402,10 @@ TEST_F(RateLimiterTest, LimitChangeTest) {
 
             limiter->SetBytesPerSecond(new_limit);
 
-            // We lock the mutex again so that the request thread can resume running
-            // with the mutex locked
+            // We lock the mutex again so that the request thread can resume
+            // running with the mutex locked
             request_mutex->Lock();
-      });
+          });
 
       Arg arg(target, Env::IO_HIGH, limiter);
       // TODO(lightmark): more test cases are welcome.

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -387,11 +387,14 @@ TEST_F(RateLimiterTest, LimitChangeTest) {
           std::make_shared<GenericRateLimiter>(
               target, refill_period, 10, RateLimiter::Mode::kWritesOnly,
               SystemClock::Default(), false /* auto_tuned */);
+      // After "GenericRateLimiter::Request:1" the mutex is held until the bytes
+      // are refilled. This test could be improved to change the limit when lock
+      // is released in `TimedWait()`.
       ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
           {{"GenericRateLimiter::Request",
             "RateLimiterTest::LimitChangeTest:changeLimitStart"},
            {"RateLimiterTest::LimitChangeTest:changeLimitEnd",
-            "GenericRateLimiter::RefillBytesAndGrantRequests"}});
+            "GenericRateLimiter::Request:1"}});
       Arg arg(target, Env::IO_HIGH, limiter);
       // The idea behind is to start a request first, then before it refills,
       // update limit to a different value (2X/0.5X). No starvation should

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -387,21 +387,28 @@ TEST_F(RateLimiterTest, LimitChangeTest) {
           std::make_shared<GenericRateLimiter>(
               target, refill_period, 10, RateLimiter::Mode::kWritesOnly,
               SystemClock::Default(), false /* auto_tuned */);
-      ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
-          {{"GenericRateLimiter::Request",
-            "RateLimiterTest::LimitChangeTest:changeLimitStart"},
-           {"RateLimiterTest::LimitChangeTest:changeLimitEnd",
-            "GenericRateLimiter::RefillBytesAndGrantRequests"}});
-      Arg arg(target, Env::IO_HIGH, limiter);
+
       // The idea behind is to start a request first, then before it refills,
-      // update limit to a different value (2X/0.5X). No starvation should
-      // be guaranteed under any situation
+      // update limit to a different value (2X/0.5X). No starvation should be
+      // guaranteed under any situation
+      int32_t new_limit = (target << 1) >> (iter << 1);
+      ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+          "GenericRateLimiter::RefillBytesAndGrantRequestsLocked", [&](void* arg) {
+            port::Mutex* request_mutex = static_cast<port::Mutex*>(arg);
+            // We temporarily unlock the mutex so that the following
+            // SetBytesPerSecond() can acquire it
+            request_mutex->Unlock();
+
+            limiter->SetBytesPerSecond(new_limit);
+
+            // We lock the mutex again so that the request thread can resume running
+            // with the mutex locked
+            request_mutex->Lock();
+      });
+
+      Arg arg(target, Env::IO_HIGH, limiter);
       // TODO(lightmark): more test cases are welcome.
       env->StartThread(writer, &arg);
-      int32_t new_limit = (target << 1) >> (iter << 1);
-      TEST_SYNC_POINT("RateLimiterTest::LimitChangeTest:changeLimitStart");
-      arg.limiter->SetBytesPerSecond(new_limit);
-      TEST_SYNC_POINT("RateLimiterTest::LimitChangeTest:changeLimitEnd");
       env->WaitForJoin();
       fprintf(stderr,
               "[COMPLETE] request size %" PRIi32 " KB, new limit %" PRIi32


### PR DESCRIPTION
Made locking strict for all accesses of `GenericRateLimiter` internal state.

`SetBytesPerSecond()` was the main problem since it had no locking, while the two updates it makes need to be done as one atomic operation.

The test case, "ConfigOptionsTest.ConfiguringOptionsDoesNotRevertRateLimiterBandwidth", is for the issue fixed in #10378, but I forgot to include the test there.