### PR TITLE
Fix periodic_task unable to re-register the same task type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,7 +667,7 @@ set(SOURCES
         db/merge_helper.cc
         db/merge_operator.cc
         db/output_validator.cc
-        db/periodic_work_scheduler.cc
+        db/periodic_task_scheduler.cc
         db/range_del_aggregator.cc
         db/range_tombstone_fragmenter.cc
         db/repair.cc
@@ -1296,7 +1296,7 @@ if(WITH_TESTS)
         db/merge_test.cc
         db/options_file_test.cc
         db/perf_context_test.cc
-        db/periodic_work_scheduler_test.cc
+        db/periodic_task_scheduler_test.cc
         db/plain_table_db_test.cc
         db/seqno_time_test.cc
         db/prefix_test.cc

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Bug Fixes
 * Fixed bug where `FlushWAL(true /* sync */)` (used by `GetLiveFilesStorageInfo()`, which is used by checkpoint and backup) could cause parallel writes at the tail of a WAL file to never be synced.
+* Fix periodic_task unable to re-register the same task type, which was causing periodic task update failure.
 
 ### Public API changes
 * Add `rocksdb_column_family_handle_get_id`, `rocksdb_column_family_handle_get_name` to get name, id of column family in C API

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 ## Unreleased
 ### Bug Fixes
 * Fixed bug where `FlushWAL(true /* sync */)` (used by `GetLiveFilesStorageInfo()`, which is used by checkpoint and backup) could cause parallel writes at the tail of a WAL file to never be synced.
-* Fix periodic_task unable to re-register the same task type, which was causing periodic task update failure.
+* Fix periodic_task unable to re-register the same task type, which may cause `SetOptions()` fail to update periodical_task time like: `stats_dump_period_sec`, `stats_persist_period_sec`.
 
 ### Public API changes
 * Add `rocksdb_column_family_handle_get_id`, `rocksdb_column_family_handle_get_name` to get name, id of column family in C API

--- a/Makefile
+++ b/Makefile
@@ -1882,7 +1882,7 @@ blob_garbage_meter_test: $(OBJ_DIR)/db/blob/blob_garbage_meter_test.o $(TEST_LIB
 timer_test: $(OBJ_DIR)/util/timer_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
-periodic_work_scheduler_test: $(OBJ_DIR)/db/periodic_work_scheduler_test.o $(TEST_LIBRARY) $(LIBRARY)
+periodic_task_scheduler_test: $(OBJ_DIR)/db/periodic_task_scheduler_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
 testutil_test: $(OBJ_DIR)/test_util/testutil_test.o $(TEST_LIBRARY) $(LIBRARY)

--- a/TARGETS
+++ b/TARGETS
@@ -82,7 +82,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "db/merge_helper.cc",
         "db/merge_operator.cc",
         "db/output_validator.cc",
-        "db/periodic_work_scheduler.cc",
+        "db/periodic_task_scheduler.cc",
         "db/range_del_aggregator.cc",
         "db/range_tombstone_fragmenter.cc",
         "db/repair.cc",
@@ -419,7 +419,7 @@ cpp_library_wrapper(name="rocksdb_whole_archive_lib", srcs=[
         "db/merge_helper.cc",
         "db/merge_operator.cc",
         "db/output_validator.cc",
-        "db/periodic_work_scheduler.cc",
+        "db/periodic_task_scheduler.cc",
         "db/range_del_aggregator.cc",
         "db/range_tombstone_fragmenter.cc",
         "db/repair.cc",
@@ -5598,8 +5598,8 @@ cpp_unittest_wrapper(name="perf_context_test",
             extra_compiler_flags=[])
 
 
-cpp_unittest_wrapper(name="periodic_work_scheduler_test",
-            srcs=["db/periodic_work_scheduler_test.cc"],
+cpp_unittest_wrapper(name="periodic_task_scheduler_test",
+            srcs=["db/periodic_task_scheduler_test.cc"],
             deps=[":rocksdb_test_lib"],
             extra_compiler_flags=[])
 

--- a/db/db_impl/compacted_db_impl.cc
+++ b/db/db_impl/compacted_db_impl.cc
@@ -242,7 +242,7 @@ Status CompactedDBImpl::Open(const Options& options,
   std::unique_ptr<CompactedDBImpl> db(new CompactedDBImpl(db_options, dbname));
   Status s = db->Init(options);
   if (s.ok()) {
-    s = db->StartPeriodicWorkScheduler();
+    s = db->StartPeriodicTaskScheduler();
   }
   if (s.ok()) {
     ROCKS_LOG_INFO(db->immutable_db_options_.info_log,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -494,8 +494,13 @@ void DBImpl::CancelAllBackgroundWork(bool wait) {
 #ifndef ROCKSDB_LITE
   for (uint8_t task_type = 0;
        task_type < static_cast<uint8_t>(PeriodicTaskType::kMax); task_type++) {
-    periodic_task_scheduler_.Unregister(
+    Status s = periodic_task_scheduler_.Unregister(
         static_cast<PeriodicTaskType>(task_type));
+    if (!s.ok()) {
+      ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                     "Failed to unregister periodic task %d, status: %s",
+                     task_type, s.ToString().c_str());
+    }
   }
 #endif  // !ROCKSDB_LITE
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1109,6 +1109,10 @@ void DBImpl::DumpStats() {
   PrintStatistics();
 }
 
+// Periodically flush info log out of application buffer at a low frequency.
+// This improves debuggability in case of RocksDB hanging since it ensures the
+// log messages leading up to the hang will eventually become visible in the
+// log.
 void DBImpl::FlushInfoLog() {
   if (shutdown_initiated_) {
     return;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -45,7 +45,7 @@
 #include "db/memtable_list.h"
 #include "db/merge_context.h"
 #include "db/merge_helper.h"
-#include "db/periodic_work_scheduler.h"
+#include "db/periodic_task_scheduler.h"
 #include "db/range_tombstone_fragmenter.h"
 #include "db/table_cache.h"
 #include "db/table_properties_collector.h"

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -260,6 +260,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
   SetDbSessionId();
   assert(!db_session_id_.empty());
 
+#ifndef ROCKSDB_LITE
   periodic_task_functions_.emplace(PeriodicTaskType::kDumpStats,
                                    [this]() { this->DumpStats(); });
   periodic_task_functions_.emplace(PeriodicTaskType::kPersistStats,
@@ -269,6 +270,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
   periodic_task_functions_.emplace(
       PeriodicTaskType::kRecordSeqnoTime,
       [this]() { this->RecordSeqnoToTimeMapping(); });
+#endif  // ROCKSDB_LITE
 
   versions_.reset(new VersionSet(dbname_, &immutable_db_options_, file_options_,
                                  table_cache_.get(), write_buffer_manager_,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -217,7 +217,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
       refitting_level_(false),
       opened_successfully_(false),
 #ifndef ROCKSDB_LITE
-      periodic_task_scheduler_(*env_),
+      periodic_task_scheduler_(),
 #endif  // ROCKSDB_LITE
       two_write_queues_(options.two_write_queues),
       manual_wal_flush_(options.manual_wal_flush),

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -217,7 +217,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
       refitting_level_(false),
       opened_successfully_(false),
 #ifndef ROCKSDB_LITE
-      periodic_work_scheduler_(nullptr),
+      periodic_task_scheduler_(*env_),
 #endif  // ROCKSDB_LITE
       two_write_queues_(options.two_write_queues),
       manual_wal_flush_(options.manual_wal_flush),
@@ -259,6 +259,16 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
   table_cache_ = NewLRUCache(co);
   SetDbSessionId();
   assert(!db_session_id_.empty());
+
+  periodic_task_functions_.emplace(PeriodicTaskType::kDumpStats,
+                                   [this]() { this->DumpStats(); });
+  periodic_task_functions_.emplace(PeriodicTaskType::kPersistStats,
+                                   [this]() { this->PersistStats(); });
+  periodic_task_functions_.emplace(PeriodicTaskType::kFlushInfoLog,
+                                   [this]() { this->FlushInfoLog(); });
+  periodic_task_functions_.emplace(
+      PeriodicTaskType::kRecordSeqnoTime,
+      [this]() { this->RecordSeqnoToTimeMapping(); });
 
   versions_.reset(new VersionSet(dbname_, &immutable_db_options_, file_options_,
                                  table_cache_.get(), write_buffer_manager_,
@@ -480,9 +490,10 @@ void DBImpl::CancelAllBackgroundWork(bool wait) {
                  "Shutdown: canceling all background work");
 
 #ifndef ROCKSDB_LITE
-  if (periodic_work_scheduler_ != nullptr) {
-    periodic_work_scheduler_->Unregister(this);
-    periodic_work_scheduler_->UnregisterRecordSeqnoTimeWorker(this);
+  for (uint8_t task_type = 0;
+       task_type < static_cast<uint8_t>(PeriodicTaskType::kMax); task_type++) {
+    periodic_task_scheduler_.Unregister(
+        static_cast<PeriodicTaskType>(task_type));
   }
 #endif  // !ROCKSDB_LITE
 
@@ -767,30 +778,50 @@ void DBImpl::PrintStatistics() {
   }
 }
 
-Status DBImpl::StartPeriodicWorkScheduler() {
+Status DBImpl::StartPeriodicTaskScheduler() {
 #ifndef ROCKSDB_LITE
 
 #ifndef NDEBUG
   // It only used by test to disable scheduler
   bool disable_scheduler = false;
   TEST_SYNC_POINT_CALLBACK(
-      "DBImpl::StartPeriodicWorkScheduler:DisableScheduler",
+      "DBImpl::StartPeriodicTaskScheduler:DisableScheduler",
       &disable_scheduler);
   if (disable_scheduler) {
     return Status::OK();
   }
-#endif  // !NDEBUG
 
   {
     InstrumentedMutexLock l(&mutex_);
-    periodic_work_scheduler_ = PeriodicWorkScheduler::Default();
-    TEST_SYNC_POINT_CALLBACK("DBImpl::StartPeriodicWorkScheduler:Init",
-                             &periodic_work_scheduler_);
+    TEST_SYNC_POINT_CALLBACK("DBImpl::StartPeriodicTaskScheduler:Init",
+                             &periodic_task_scheduler_);
   }
 
-  return periodic_work_scheduler_->Register(
-      this, mutable_db_options_.stats_dump_period_sec,
-      mutable_db_options_.stats_persist_period_sec);
+#endif  // !NDEBUG
+  if (mutable_db_options_.stats_dump_period_sec > 0) {
+    Status s = periodic_task_scheduler_.Register(
+        PeriodicTaskType::kDumpStats,
+        periodic_task_functions_.at(PeriodicTaskType::kDumpStats),
+        mutable_db_options_.stats_dump_period_sec);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  if (mutable_db_options_.stats_persist_period_sec > 0) {
+    Status s = periodic_task_scheduler_.Register(
+        PeriodicTaskType::kPersistStats,
+        periodic_task_functions_.at(PeriodicTaskType::kPersistStats),
+        mutable_db_options_.stats_persist_period_sec);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  Status s = periodic_task_scheduler_.Register(
+      PeriodicTaskType::kFlushInfoLog,
+      periodic_task_functions_.at(PeriodicTaskType::kFlushInfoLog));
+
+  return s;
 #else
   return Status::OK();
 #endif  // !ROCKSDB_LITE
@@ -798,9 +829,6 @@ Status DBImpl::StartPeriodicWorkScheduler() {
 
 Status DBImpl::RegisterRecordSeqnoTimeWorker() {
 #ifndef ROCKSDB_LITE
-  if (!periodic_work_scheduler_) {
-    return Status::OK();
-  }
   uint64_t min_time_duration = std::numeric_limits<uint64_t>::max();
   uint64_t max_time_duration = std::numeric_limits<uint64_t>::min();
   {
@@ -828,26 +856,13 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
   }
 
   Status s;
-  if (seqno_time_cadence != record_seqno_time_cadence_) {
-    if (seqno_time_cadence == 0) {
-      periodic_work_scheduler_->UnregisterRecordSeqnoTimeWorker(this);
-    } else {
-      s = periodic_work_scheduler_->RegisterRecordSeqnoTimeWorker(
-          this, seqno_time_cadence);
-    }
-
-    if (s.ok()) {
-      record_seqno_time_cadence_ = seqno_time_cadence;
-    }
-
-    if (s.IsNotSupported()) {
-      // TODO: Fix the timer cannot cancel and re-add the same task
-      ROCKS_LOG_WARN(
-          immutable_db_options_.info_log,
-          "Updating seqno to time worker cadence is not supported yet, to make "
-          "the change effective, please reopen the DB instance.");
-      s = Status::OK();
-    }
+  if (seqno_time_cadence == 0) {
+    s = periodic_task_scheduler_.Unregister(PeriodicTaskType::kRecordSeqnoTime);
+  } else {
+    s = periodic_task_scheduler_.Register(
+        PeriodicTaskType::kRecordSeqnoTime,
+        periodic_task_functions_.at(PeriodicTaskType::kRecordSeqnoTime),
+        seqno_time_cadence);
   }
 
   return s;
@@ -1279,22 +1294,36 @@ Status DBImpl::SetDBOptions(
         MaybeScheduleFlushOrCompaction();
       }
 
-      if (new_options.stats_dump_period_sec !=
-              mutable_db_options_.stats_dump_period_sec ||
-          new_options.stats_persist_period_sec !=
-              mutable_db_options_.stats_persist_period_sec) {
-        mutex_.Unlock();
-        periodic_work_scheduler_->Unregister(this);
-        s = periodic_work_scheduler_->Register(
-            this, new_options.stats_dump_period_sec,
-            new_options.stats_persist_period_sec);
-        mutex_.Lock();
+      mutex_.Unlock();
+      if (new_options.stats_dump_period_sec == 0) {
+        s = periodic_task_scheduler_.Unregister(PeriodicTaskType::kDumpStats);
+      } else {
+        s = periodic_task_scheduler_.Register(
+            PeriodicTaskType::kDumpStats,
+            periodic_task_functions_.at(PeriodicTaskType::kDumpStats),
+            new_options.stats_dump_period_sec);
       }
       if (new_options.max_total_wal_size !=
           mutable_db_options_.max_total_wal_size) {
         max_total_wal_size_.store(new_options.max_total_wal_size,
                                   std::memory_order_release);
       }
+      if (s.ok()) {
+        if (new_options.stats_persist_period_sec == 0) {
+          s = periodic_task_scheduler_.Unregister(
+              PeriodicTaskType::kPersistStats);
+        } else {
+          s = periodic_task_scheduler_.Register(
+              PeriodicTaskType::kPersistStats,
+              periodic_task_functions_.at(PeriodicTaskType::kPersistStats),
+              new_options.stats_persist_period_sec);
+        }
+      }
+      mutex_.Lock();
+      if (!s.ok()) {
+        return s;
+      }
+
       write_controller_.set_max_delayed_write_rate(
           new_options.delayed_write_rate);
       table_cache_.get()->SetCapacity(new_options.max_open_files == -1
@@ -3043,12 +3072,7 @@ Status DBImpl::CreateColumnFamilyImpl(const ColumnFamilyOptions& cf_options,
   }  // InstrumentedMutexLock l(&mutex_)
 
   if (cf_options.preclude_last_level_data_seconds > 0) {
-    // TODO(zjay): Fix the timer issue and re-enable this.
-    ROCKS_LOG_ERROR(
-        immutable_db_options_.info_log,
-        "Creating column family with `preclude_last_level_data_seconds` needs "
-        "to restart DB to take effect");
-    //    s = RegisterRecordSeqnoTimeWorker();
+    s = RegisterRecordSeqnoTimeWorker();
   }
   sv_context.Clean();
   // this is outside the mutex

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -32,7 +32,7 @@
 #include "db/log_writer.h"
 #include "db/logs_with_prep_tracker.h"
 #include "db/memtable_list.h"
-#include "db/periodic_work_scheduler.h"
+#include "db/periodic_task_scheduler.h"
 #include "db/post_memtable_callback.h"
 #include "db/pre_release_callback.h"
 #include "db/range_del_aggregator.h"
@@ -1144,7 +1144,7 @@ class DBImpl : public DB {
   int TEST_BGCompactionsAllowed() const;
   int TEST_BGFlushesAllowed() const;
   size_t TEST_GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
-  void TEST_WaitForPeridicWorkerRun(std::function<void()> callback) const;
+  void TEST_WaitForPeridicTaskRun(std::function<void()> callback) const;
   SeqnoToTimeMapping TEST_GetSeqnoToTimeMapping() const;
   size_t TEST_EstimateInMemoryStatsHistorySize() const;
 
@@ -1159,7 +1159,7 @@ class DBImpl : public DB {
   }
 
 #ifndef ROCKSDB_LITE
-  const PeriodicTaskScheduler& TEST_GetPeriodicWorkScheduler() const;
+  const PeriodicTaskScheduler& TEST_GetPeriodicTaskScheduler() const;
 #endif  // !ROCKSDB_LITE
 
 #endif  // NDEBUG
@@ -2608,11 +2608,10 @@ class DBImpl : public DB {
 
 #ifndef ROCKSDB_LITE
   // Scheduler to run DumpStats(), PersistStats(), and FlushInfoLog().
-  // Currently, it always use a global instance from
-  // PeriodicTaskScheduler::Default(). Only in unittest, it can be overrided by
-  // PeriodicWorkTestScheduler.
+  // Currently, internally it has a global timer instance for running the tasks.
   PeriodicTaskScheduler periodic_task_scheduler_;
 
+  // It contains the implementations for each periodic task.
   std::map<PeriodicTaskType, const PeriodicTaskFunc> periodic_task_functions_;
 #endif
 

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -304,14 +304,11 @@ size_t DBImpl::TEST_GetWalPreallocateBlockSize(
 #ifndef ROCKSDB_LITE
 void DBImpl::TEST_WaitForPeridicWorkerRun(
     std::function<void()> callback) const {
-  if (periodic_work_scheduler_ != nullptr) {
-    static_cast<PeriodicWorkTestScheduler*>(periodic_work_scheduler_)
-        ->TEST_WaitForRun(callback);
-  }
+  periodic_task_scheduler_.TEST_WaitForRun(callback);
 }
 
-PeriodicWorkTestScheduler* DBImpl::TEST_GetPeriodicWorkScheduler() const {
-  return static_cast<PeriodicWorkTestScheduler*>(periodic_work_scheduler_);
+const PeriodicTaskScheduler& DBImpl::TEST_GetPeriodicWorkScheduler() const {
+  return periodic_task_scheduler_;
 }
 
 SeqnoToTimeMapping DBImpl::TEST_GetSeqnoToTimeMapping() const {

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -12,7 +12,7 @@
 #include "db/column_family.h"
 #include "db/db_impl/db_impl.h"
 #include "db/error_handler.h"
-#include "db/periodic_work_scheduler.h"
+#include "db/periodic_task_scheduler.h"
 #include "monitoring/thread_status_updater.h"
 #include "util/cast_util.h"
 
@@ -302,12 +302,11 @@ size_t DBImpl::TEST_GetWalPreallocateBlockSize(
 }
 
 #ifndef ROCKSDB_LITE
-void DBImpl::TEST_WaitForPeridicWorkerRun(
-    std::function<void()> callback) const {
+void DBImpl::TEST_WaitForPeridicTaskRun(std::function<void()> callback) const {
   periodic_task_scheduler_.TEST_WaitForRun(callback);
 }
 
-const PeriodicTaskScheduler& DBImpl::TEST_GetPeriodicWorkScheduler() const {
+const PeriodicTaskScheduler& DBImpl::TEST_GetPeriodicTaskScheduler() const {
   return periodic_task_scheduler_;
 }
 

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -11,7 +11,7 @@
 #include "db/builder.h"
 #include "db/db_impl/db_impl.h"
 #include "db/error_handler.h"
-#include "db/periodic_work_scheduler.h"
+#include "db/periodic_task_scheduler.h"
 #include "env/composite_env_wrapper.h"
 #include "file/filename.h"
 #include "file/read_write_util.h"

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -2105,7 +2105,7 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
                    "DB::Open() failed: %s", s.ToString().c_str());
   }
   if (s.ok()) {
-    s = impl->StartPeriodicWorkScheduler();
+    s = impl->StartPeriodicTaskScheduler();
   }
 
   if (s.ok()) {

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -695,10 +695,10 @@ TEST_P(DBSSTTestRateLimit, RateLimitedDelete) {
         *abs_time_us = Env::Default()->NowMicros();
       });
 
-  // Disable PeriodicWorkScheduler as it also has TimedWait, which could update
+  // Disable PeriodicTaskScheduler as it also has TimedWait, which could update
   // the simulated sleep time
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::StartPeriodicWorkScheduler:DisableScheduler", [&](void* arg) {
+      "DBImpl::StartPeriodicTaskScheduler:DisableScheduler", [&](void* arg) {
         bool* disable_scheduler = static_cast<bool*>(arg);
         *disable_scheduler = true;
       });

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -1592,7 +1592,8 @@ void InternalStats::DumpCFMapStats(
     int files = vstorage->NumLevelFiles(level);
     total_files += files;
     total_files_being_compacted += files_being_compacted[level];
-    if (comp_stats_[level].micros > 0 || files > 0) {
+    if (comp_stats_[level].micros > 0 || comp_stats_[level].cpu_micros > 0 ||
+        files > 0) {
       compaction_stats_sum->Add(comp_stats_[level]);
       total_file_size += vstorage->NumLevelBytes(level);
       uint64_t input_bytes;

--- a/db/periodic_task_scheduler.cc
+++ b/db/periodic_task_scheduler.cc
@@ -1,4 +1,5 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).

--- a/db/periodic_task_scheduler.cc
+++ b/db/periodic_task_scheduler.cc
@@ -94,6 +94,11 @@ Status PeriodicTaskScheduler::Unregister(PeriodicTaskType task_type) {
   return Status::OK();
 }
 
+Timer* PeriodicTaskScheduler::Default() {
+  static Timer timer(SystemClock::Default().get());
+  return &timer;
+}
+
 #ifndef NDEBUG
 void PeriodicTaskScheduler::TEST_OverrideTimer(SystemClock* clock) {
   static Timer test_timer(clock);

--- a/db/periodic_task_scheduler.cc
+++ b/db/periodic_task_scheduler.cc
@@ -29,6 +29,13 @@ static const std::map<PeriodicTaskType, uint64_t> kDefaultPeriodSeconds = {
     {PeriodicTaskType::kRecordSeqnoTime, kInvalidPeriodSec},
 };
 
+static const std::map<PeriodicTaskType, std::string> kPeriodicTaskTypeNames = {
+    {PeriodicTaskType::kDumpStats, "dump_st"},
+    {PeriodicTaskType::kPersistStats, "pst_st"},
+    {PeriodicTaskType::kFlushInfoLog, "flush_info_log"},
+    {PeriodicTaskType::kRecordSeqnoTime, "record_seq_time"},
+};
+
 Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
                                        const PeriodicTaskFunc& fn) {
   return Register(task_type, fn, kDefaultPeriodSeconds.at(task_type));
@@ -55,7 +62,9 @@ Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
   }
 
   timer_->Start();
-  std::string unique_id = env_.GenerateUniqueId();
+  // put task type name as prefix, for easy debug
+  std::string unique_id =
+      kPeriodicTaskTypeNames.at(task_type) + std::to_string(id_++);
 
   bool succeeded = timer_->Add(
       fn, unique_id,

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -59,7 +59,7 @@ class PeriodicTaskScheduler {
   void TEST_OverrideTimer(SystemClock* clock);
 
   // Call Timer TEST_WaitForRun() which wait until Timer starting waiting.
-  void TEST_WaitForRun(const std::function<void()> callback) const {
+  void TEST_WaitForRun(const std::function<void()>& callback) const {
     if (timer_ != nullptr) {
       timer_->TEST_WaitForRun(callback);
     }

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -36,9 +36,8 @@ enum class PeriodicTaskType : uint8_t {
 // flushing cannot be disabled.
 class PeriodicTaskScheduler {
  public:
-  explicit PeriodicTaskScheduler(Env& env) : env_(env) {}
+  explicit PeriodicTaskScheduler() = default;
 
-  PeriodicTaskScheduler() = delete;
   PeriodicTaskScheduler(const PeriodicTaskScheduler&) = delete;
   PeriodicTaskScheduler(PeriodicTaskScheduler&&) = delete;
   PeriodicTaskScheduler& operator=(const PeriodicTaskScheduler&) = delete;
@@ -99,11 +98,12 @@ class PeriodicTaskScheduler {
   // Internal tasks map
   std::map<PeriodicTaskType, TaskInfo> tasks_map_;
 
-  // Global timer pointer
+  // Global timer pointer, which doesn't support synchronous add/cancel tasks
+  // so having a global `timer_mutex` for add/cancel task.
   Timer* timer_ = Default();
 
-  // Env, used for generate unique id
-  Env& env_;
+  // Global task id, protected by the global `timer_mutex`
+  inline static uint64_t id_;
 
   static constexpr uint64_t kMicrosInSecond = 1000U * 1000U;
 };

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -1,4 +1,5 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
@@ -16,6 +17,7 @@ using PeriodicTaskFunc = std::function<void()>;
 
 constexpr uint64_t kInvalidPeriodSec = 0;
 
+// List of task types
 enum class PeriodicTaskType : uint8_t {
   kDumpStats = 0,
   kPersistStats,
@@ -24,33 +26,47 @@ enum class PeriodicTaskType : uint8_t {
   kMax,
 };
 
-// PeriodicTaskScheduler is a singleton object, which is scheduling/running
-// DumpStats(), PersistStats(), and FlushInfoLog() for all DB instances. All DB
-// instances use the same object from `Default()`.
+// PeriodicTaskScheduler contains the periodic task scheduled from the DB
+// instance. It's used to schedule/unschedule DumpStats(), PersistStats(),
+// FlushInfoLog(), etc. Each type of the task can only have one instance,
+// re-register the same task type would only update the repeat period.
 //
-// Internally, it uses a single threaded timer object to run the periodic work
-// functions. Timer thread will always be started since the info log flushing
-// cannot be disabled.
+// Internally, it uses a global single threaded timer object to run the periodic
+// task functions. Timer thread will always be started since the info log
+// flushing cannot be disabled.
 class PeriodicTaskScheduler {
  public:
   explicit PeriodicTaskScheduler(Env& env) : env_(env) {}
 
+  PeriodicTaskScheduler() = delete;
+  PeriodicTaskScheduler(const PeriodicTaskScheduler&) = delete;
+  PeriodicTaskScheduler(PeriodicTaskScheduler&&) = delete;
+  PeriodicTaskScheduler& operator=(const PeriodicTaskScheduler&) = delete;
+  PeriodicTaskScheduler& operator=(PeriodicTaskScheduler&&) = delete;
+
+  // Register a task with its default repeat period
   Status Register(PeriodicTaskType task_type, const PeriodicTaskFunc& fn);
 
+  // Register a task with specified repeat period. 0 is an invalid argument
+  // (kInvalidPeriodSec). To stop the task, please use Unregister() specifically
   Status Register(PeriodicTaskType task_type, const PeriodicTaskFunc& fn,
                   uint64_t repeat_period_seconds);
 
+  // Unregister the task
   Status Unregister(PeriodicTaskType task_type);
 
 #ifndef NDEBUG
+  // Override the timer for the unittest
   void TEST_OverrideTimer(SystemClock* clock);
 
+  // Call Timer TEST_WaitForRun() which wait until Timer starting waiting.
   void TEST_WaitForRun(std::function<void()> callback) const {
     if (timer_ != nullptr) {
       timer_->TEST_WaitForRun(callback);
     }
   }
 
+  // Get global valid task number in the Timer
   size_t TEST_GetValidTaskNum() const {
     if (timer_ != nullptr) {
       return timer_->TEST_GetPendingTaskNum();
@@ -58,23 +74,21 @@ class PeriodicTaskScheduler {
     return 0;
   }
 
+  // If it has the specified task type registered
   bool TEST_HasTask(PeriodicTaskType task_type) const {
     auto it = tasks_map_.find(task_type);
     return it != tasks_map_.end();
   }
 #endif  // NDEBUG
 
-  // Periodically flush info log out of application buffer at a low frequency.
-  // This improves debuggability in case of RocksDB hanging since it ensures the
-  // log messages leading up to the hang will eventually become visible in the
-  // log.
-
  private:
+  // default global Timer instance
   Timer* Default() {
     static Timer timer(SystemClock::Default().get());
     return &timer;
   }
 
+  // Internal structure to store task information
   struct TaskInfo {
     TaskInfo(std::string _name, uint64_t _repeat_every_sec)
         : name(std::move(_name)), repeat_every_sec(_repeat_every_sec) {}
@@ -82,10 +96,13 @@ class PeriodicTaskScheduler {
     uint64_t repeat_every_sec;
   };
 
+  // Internal tasks map
   std::map<PeriodicTaskType, TaskInfo> tasks_map_;
 
+  // Global timer pointer
   Timer* timer_ = Default();
 
+  // Env, used for generate unique id
   Env& env_;
 
   static constexpr uint64_t kMicrosInSecond = 1000U * 1000U;

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -59,7 +59,7 @@ class PeriodicTaskScheduler {
   void TEST_OverrideTimer(SystemClock* clock);
 
   // Call Timer TEST_WaitForRun() which wait until Timer starting waiting.
-  void TEST_WaitForRun(std::function<void()> callback) const {
+  void TEST_WaitForRun(const std::function<void()> callback) const {
     if (timer_ != nullptr) {
       timer_->TEST_WaitForRun(callback);
     }
@@ -82,10 +82,7 @@ class PeriodicTaskScheduler {
 
  private:
   // default global Timer instance
-  Timer* Default() {
-    static Timer timer(SystemClock::Default().get());
-    return &timer;
-  }
+  static Timer* Default();
 
   // Internal structure to store task information
   struct TaskInfo {

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -87,6 +87,8 @@ class PeriodicTaskScheduler {
   Timer* timer_ = Default();
 
   Env& env_;
+
+  static constexpr uint64_t kMicrosInSecond = 1000U * 1000U;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/periodic_task_scheduler_test.cc
+++ b/db/periodic_task_scheduler_test.cc
@@ -1,4 +1,5 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
@@ -217,29 +218,6 @@ TEST_F(PeriodicTaskSchedulerTest, MultiEnv) {
   ASSERT_OK(db->Close());
   delete db;
   Close();
-}
-
-class MyClass {
- public:
-  void Register() {
-    timer_->Add([&] { fprintf(stdout, "JJJ1\n"); }, "fn_sch_test", 0, 0);
-  }
-
- private:
-  Timer* Default() {
-    static Timer timer(SystemClock::Default().get());
-    return &timer;
-  }
-
-  Timer* timer_ = Default();
-};
-
-TEST_F(PeriodicTaskSchedulerTest, TT1) {
-  MyClass my1;
-  my1.Register();
-
-  MyClass my2;
-  my2.Register();
 }
 
 #endif  // !ROCKSDB_LITE

--- a/db/periodic_task_scheduler_test.cc
+++ b/db/periodic_task_scheduler_test.cc
@@ -3,7 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-#include "db/periodic_work_scheduler.h"
+#include "db/periodic_task_scheduler.h"
 
 #include "db/db_test_util.h"
 #include "env/composite_env_wrapper.h"
@@ -12,10 +12,10 @@
 namespace ROCKSDB_NAMESPACE {
 
 #ifndef ROCKSDB_LITE
-class PeriodicWorkSchedulerTest : public DBTestBase {
+class PeriodicTaskSchedulerTest : public DBTestBase {
  public:
-  PeriodicWorkSchedulerTest()
-      : DBTestBase("periodic_work_scheduler_test", /*env_do_fsync=*/true) {
+  PeriodicTaskSchedulerTest()
+      : DBTestBase("periodic_task_scheduler_test", /*env_do_fsync=*/true) {
     mock_clock_ = std::make_shared<MockSystemClock>(env_->GetSystemClock());
     mock_env_.reset(new CompositeEnvWrapper(env_, mock_clock_));
   }
@@ -28,14 +28,14 @@ class PeriodicWorkSchedulerTest : public DBTestBase {
     mock_clock_->InstallTimedWaitFixCallback();
     SyncPoint::GetInstance()->SetCallBack(
         "DBImpl::StartPeriodicTaskScheduler:Init", [&](void* arg) {
-          auto periodic_work_scheduler_ptr =
+          auto periodic_task_scheduler_ptr =
               reinterpret_cast<PeriodicTaskScheduler*>(arg);
-          periodic_work_scheduler_ptr->TEST_OverrideTimer(mock_clock_.get());
+          periodic_task_scheduler_ptr->TEST_OverrideTimer(mock_clock_.get());
         });
   }
 };
 
-TEST_F(PeriodicWorkSchedulerTest, Basic) {
+TEST_F(PeriodicTaskSchedulerTest, Basic) {
   constexpr unsigned int kPeriodSec = 10;
   Close();
   Options options;
@@ -64,26 +64,26 @@ TEST_F(PeriodicWorkSchedulerTest, Basic) {
   ASSERT_EQ(kPeriodSec, dbfull()->GetDBOptions().stats_persist_period_sec);
 
   ASSERT_GT(kPeriodSec, 1u);
-  dbfull()->TEST_WaitForPeridicWorkerRun([&] {
+  dbfull()->TEST_WaitForPeridicTaskRun([&] {
     mock_clock_->MockSleepForSeconds(static_cast<int>(kPeriodSec) - 1);
   });
 
   const PeriodicTaskScheduler& scheduler =
-      dbfull()->TEST_GetPeriodicWorkScheduler();
+      dbfull()->TEST_GetPeriodicTaskScheduler();
   ASSERT_EQ(3, scheduler.TEST_GetValidTaskNum());
 
   ASSERT_EQ(1, dump_st_counter);
   ASSERT_EQ(1, pst_st_counter);
   ASSERT_EQ(1, flush_info_log_counter);
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kPeriodSec)); });
 
   ASSERT_EQ(2, dump_st_counter);
   ASSERT_EQ(2, pst_st_counter);
   ASSERT_EQ(2, flush_info_log_counter);
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kPeriodSec)); });
 
   ASSERT_EQ(3, dump_st_counter);
@@ -97,7 +97,7 @@ TEST_F(PeriodicWorkSchedulerTest, Basic) {
   ASSERT_EQ(0u, dbfull()->GetDBOptions().stats_persist_period_sec);
 
   // Info log flush should still run.
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kPeriodSec)); });
   ASSERT_EQ(3, dump_st_counter);
   ASSERT_EQ(3, pst_st_counter);
@@ -112,7 +112,7 @@ TEST_F(PeriodicWorkSchedulerTest, Basic) {
 
   ASSERT_EQ(2, scheduler.TEST_GetValidTaskNum());
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kPeriodSec)); });
   ASSERT_EQ(4, dump_st_counter);
   ASSERT_EQ(3, pst_st_counter);
@@ -121,7 +121,7 @@ TEST_F(PeriodicWorkSchedulerTest, Basic) {
   Close();
 }
 
-TEST_F(PeriodicWorkSchedulerTest, MultiInstances) {
+TEST_F(PeriodicTaskSchedulerTest, MultiInstances) {
   constexpr int kPeriodSec = 5;
   const int kInstanceNum = 10;
 
@@ -149,23 +149,23 @@ TEST_F(PeriodicWorkSchedulerTest, MultiInstances) {
 
   auto dbi = static_cast_with_check<DBImpl>(dbs[kInstanceNum - 1]);
 
-  const PeriodicTaskScheduler& scheduler = dbi->TEST_GetPeriodicWorkScheduler();
+  const PeriodicTaskScheduler& scheduler = dbi->TEST_GetPeriodicTaskScheduler();
   ASSERT_EQ(kInstanceNum * 3, scheduler.TEST_GetValidTaskNum());
 
   int expected_run = kInstanceNum;
-  dbi->TEST_WaitForPeridicWorkerRun(
+  dbi->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
   ASSERT_EQ(expected_run, dump_st_counter);
   ASSERT_EQ(expected_run, pst_st_counter);
 
   expected_run += kInstanceNum;
-  dbi->TEST_WaitForPeridicWorkerRun(
+  dbi->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   ASSERT_EQ(expected_run, dump_st_counter);
   ASSERT_EQ(expected_run, pst_st_counter);
 
   expected_run += kInstanceNum;
-  dbi->TEST_WaitForPeridicWorkerRun(
+  dbi->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   ASSERT_EQ(expected_run, dump_st_counter);
   ASSERT_EQ(expected_run, pst_st_counter);
@@ -177,9 +177,9 @@ TEST_F(PeriodicWorkSchedulerTest, MultiInstances) {
 
   expected_run += (kInstanceNum - half) * 2;
 
-  dbi->TEST_WaitForPeridicWorkerRun(
+  dbi->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
-  dbi->TEST_WaitForPeridicWorkerRun(
+  dbi->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   ASSERT_EQ(expected_run, dump_st_counter);
   ASSERT_EQ(expected_run, pst_st_counter);
@@ -190,7 +190,7 @@ TEST_F(PeriodicWorkSchedulerTest, MultiInstances) {
   }
 }
 
-TEST_F(PeriodicWorkSchedulerTest, MultiEnv) {
+TEST_F(PeriodicTaskSchedulerTest, MultiEnv) {
   constexpr int kDumpPeriodSec = 5;
   constexpr int kPersistPeriodSec = 10;
   Close();
@@ -234,7 +234,7 @@ class MyClass {
   Timer* timer_ = Default();
 };
 
-TEST_F(PeriodicWorkSchedulerTest, TT1) {
+TEST_F(PeriodicTaskSchedulerTest, TT1) {
   MyClass my1;
   my1.Register();
 

--- a/db/periodic_work_scheduler.cc
+++ b/db/periodic_work_scheduler.cc
@@ -81,12 +81,14 @@ Status PeriodicTaskScheduler::Unregister(PeriodicTaskType task_type) {
   return Status::OK();
 }
 
+#ifndef NDEBUG
 void PeriodicTaskScheduler::TEST_OverrideTimer(SystemClock* clock) {
   static Timer test_timer(clock);
   test_timer.TEST_OverrideTimer(clock);
   MutexLock l(&timer_mu_);
   timer_ = &test_timer;
 }
+#endif  // NDEBUG
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/db/periodic_work_scheduler.cc
+++ b/db/periodic_work_scheduler.cc
@@ -64,7 +64,9 @@ Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
   }
   auto result = tasks_map_.try_emplace(
       task_type, TaskInfo{unique_id, repeat_period_seconds});
-  assert(result.second);
+  if (!result.second) {
+    return Status::Aborted("Failed to add periodic task");
+  };
   return Status::OK();
 }
 

--- a/db/periodic_work_scheduler.h
+++ b/db/periodic_work_scheduler.h
@@ -42,6 +42,7 @@ class PeriodicTaskScheduler {
 
   Status Unregister(PeriodicTaskType task_type);
 
+#ifndef NDEBUG
   void TEST_OverrideTimer(SystemClock* clock);
 
   void TEST_WaitForRun(std::function<void()> callback) const {
@@ -61,6 +62,7 @@ class PeriodicTaskScheduler {
     auto it = tasks_map_.find(task_type);
     return it != tasks_map_.end();
   }
+#endif  // NDEBUG
 
   // Periodically flush info log out of application buffer at a low frequency.
   // This improves debuggability in case of RocksDB hanging since it ensures the

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -457,8 +457,6 @@ TEST_F(SeqnoTimeTest, BasicSeqnoToTimeMapping) {
   ASSERT_OK(db_->Close());
 }
 
-// TODO(zjay): Disabled, until New CF bug with preclude_last_level_data_seconds
-//  is fixed
 TEST_F(SeqnoTimeTest, MultiCFs) {
   Options options = CurrentOptions();
   options.preclude_last_level_data_seconds = 0;

--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -44,11 +44,10 @@ class StatsHistoryTest : public DBTestBase {
   void SetUp() override {
     mock_clock_->InstallTimedWaitFixCallback();
     SyncPoint::GetInstance()->SetCallBack(
-        "DBImpl::StartPeriodicWorkScheduler:Init", [&](void* arg) {
-          auto* periodic_work_scheduler_ptr =
-              reinterpret_cast<PeriodicWorkScheduler**>(arg);
-          *periodic_work_scheduler_ptr =
-              PeriodicWorkTestScheduler::Default(mock_clock_);
+        "DBImpl::StartPeriodicTaskScheduler:Init", [&](void* arg) {
+          auto periodic_work_scheduler_ptr =
+              reinterpret_cast<PeriodicTaskScheduler*>(arg);
+          periodic_work_scheduler_ptr->TEST_OverrideTimer(mock_clock_.get());
         });
   }
 };

--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -15,7 +15,7 @@
 #include "db/column_family.h"
 #include "db/db_impl/db_impl.h"
 #include "db/db_test_util.h"
-#include "db/periodic_work_scheduler.h"
+#include "db/periodic_task_scheduler.h"
 #include "monitoring/persistent_stats_history.h"
 #include "options/options_helper.h"
 #include "port/stack_trace.h"
@@ -45,9 +45,9 @@ class StatsHistoryTest : public DBTestBase {
     mock_clock_->InstallTimedWaitFixCallback();
     SyncPoint::GetInstance()->SetCallBack(
         "DBImpl::StartPeriodicTaskScheduler:Init", [&](void* arg) {
-          auto periodic_work_scheduler_ptr =
+          auto periodic_task_scheduler_ptr =
               reinterpret_cast<PeriodicTaskScheduler*>(arg);
-          periodic_work_scheduler_ptr->TEST_OverrideTimer(mock_clock_.get());
+          periodic_task_scheduler_ptr->TEST_OverrideTimer(mock_clock_.get());
         });
   }
 };
@@ -66,10 +66,10 @@ TEST_F(StatsHistoryTest, RunStatsDumpPeriodSec) {
 
   // Wait for the first stats persist to finish, as the initial delay could be
   // different.
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   ASSERT_GE(counter, 1);
 
@@ -98,17 +98,17 @@ TEST_F(StatsHistoryTest, StatsPersistScheduling) {
 
   // Wait for the first stats persist to finish, as the initial delay could be
   // different.
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   ASSERT_GE(counter, 1);
 
   // Test cancel job through SetOptions
   ASSERT_OK(dbfull()->SetDBOptions({{"stats_persist_period_sec", "0"}}));
   int old_val = counter;
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec * 2); });
   ASSERT_EQ(counter, old_val);
 
@@ -130,7 +130,7 @@ TEST_F(StatsHistoryTest, PersistentStatsFreshInstall) {
       {{"stats_persist_period_sec", std::to_string(kPeriodSec)}}));
   ASSERT_EQ(kPeriodSec, dbfull()->GetDBOptions().stats_persist_period_sec);
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   ASSERT_GE(counter, 1);
   Close();
@@ -149,11 +149,11 @@ TEST_F(StatsHistoryTest, GetStatsHistoryInMemory) {
   ReopenWithColumnFamilies({"default", "pikachu"}, options);
 
   // make sure the first stats persist to finish
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
 
   // Wait for stats persist to finish
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
 
   std::unique_ptr<StatsHistoryIterator> stats_iter;
@@ -171,7 +171,7 @@ TEST_F(StatsHistoryTest, GetStatsHistoryInMemory) {
   ASSERT_GT(stats_count, 0);
   // Wait a bit and verify no more stats are found
   for (int i = 0; i < 10; ++i) {
-    dbfull()->TEST_WaitForPeridicWorkerRun(
+    dbfull()->TEST_WaitForPeridicTaskRun(
         [&] { mock_clock_->MockSleepForSeconds(1); });
   }
   ASSERT_OK(db_->GetStatsHistory(0, mock_clock_->NowSeconds(), &stats_iter));
@@ -226,7 +226,7 @@ TEST_F(StatsHistoryTest, InMemoryStatsHistoryPurging) {
 
   const int kIterations = 10;
   for (int i = 0; i < kIterations; ++i) {
-    dbfull()->TEST_WaitForPeridicWorkerRun(
+    dbfull()->TEST_WaitForPeridicTaskRun(
         [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   }
 
@@ -250,7 +250,7 @@ TEST_F(StatsHistoryTest, InMemoryStatsHistoryPurging) {
 
   // Wait for stats persist to finish
   for (int i = 0; i < kIterations; ++i) {
-    dbfull()->TEST_WaitForPeridicWorkerRun(
+    dbfull()->TEST_WaitForPeridicTaskRun(
         [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   }
 
@@ -299,11 +299,11 @@ TEST_F(StatsHistoryTest, GetStatsHistoryFromDisk) {
 
   // Wait for the first stats persist to finish, as the initial delay could be
   // different.
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
 
   // Wait for stats persist to finish
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
 
   auto iter =
@@ -311,14 +311,14 @@ TEST_F(StatsHistoryTest, GetStatsHistoryFromDisk) {
   int key_count1 = countkeys(iter);
   delete iter;
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   iter =
       db_->NewIterator(ReadOptions(), dbfull()->PersistentStatsColumnFamily());
   int key_count2 = countkeys(iter);
   delete iter;
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   iter =
       db_->NewIterator(ReadOptions(), dbfull()->PersistentStatsColumnFamily());
@@ -392,32 +392,32 @@ TEST_F(StatsHistoryTest, PersitentStatsVerifyValue) {
 
   // Wait for the first stats persist to finish, as the initial delay could be
   // different.
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
 
   // Wait for stats persist to finish
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   auto iter =
       db_->NewIterator(ReadOptions(), dbfull()->PersistentStatsColumnFamily());
   countkeys(iter);
   delete iter;
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   iter =
       db_->NewIterator(ReadOptions(), dbfull()->PersistentStatsColumnFamily());
   countkeys(iter);
   delete iter;
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   iter =
       db_->NewIterator(ReadOptions(), dbfull()->PersistentStatsColumnFamily());
   countkeys(iter);
   delete iter;
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
 
   std::map<std::string, uint64_t> stats_map_after;
@@ -481,10 +481,10 @@ TEST_F(StatsHistoryTest, PersistentStatsCreateColumnFamilies) {
   ASSERT_EQ(Get(2, "foo"), "bar");
 
   // make sure the first stats persist to finish
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   auto iter =
       db_->NewIterator(ReadOptions(), dbfull()->PersistentStatsColumnFamily());
@@ -581,7 +581,7 @@ TEST_F(StatsHistoryTest, ForceManualFlushStatsCF) {
 
   // Wait for the first stats persist to finish, as the initial delay could be
   // different.
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec - 1); });
 
   ColumnFamilyData* cfd_default =
@@ -600,7 +600,7 @@ TEST_F(StatsHistoryTest, ForceManualFlushStatsCF) {
   ASSERT_OK(Put(1, "Eevee", "v0"));
   ASSERT_EQ("v0", Get(1, "Eevee"));
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   // writing to all three cf, flush default cf
   // LogNumbers: default: 16, stats: 10, pikachu: 5
@@ -629,7 +629,7 @@ TEST_F(StatsHistoryTest, ForceManualFlushStatsCF) {
   ASSERT_EQ("v2", Get("bar2"));
   ASSERT_EQ("v2", Get("foo2"));
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   // writing to default and stats cf, flushing default cf
   // LogNumbers: default: 19, stats: 19, pikachu: 19
@@ -644,7 +644,7 @@ TEST_F(StatsHistoryTest, ForceManualFlushStatsCF) {
   ASSERT_OK(Put(1, "Jolteon", "v3"));
   ASSERT_EQ("v3", Get(1, "Jolteon"));
 
-  dbfull()->TEST_WaitForPeridicWorkerRun(
+  dbfull()->TEST_WaitForPeridicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(kPeriodSec); });
   // writing to all three cf, flushing test cf
   // LogNumbers: default: 19, stats: 19, pikachu: 22

--- a/src.mk
+++ b/src.mk
@@ -73,7 +73,7 @@ LIB_SOURCES =                                                   \
   db/merge_helper.cc                                            \
   db/merge_operator.cc                                          \
   db/output_validator.cc                                        \
-  db/periodic_work_scheduler.cc                                 \
+  db/periodic_task_scheduler.cc                                 \
   db/range_del_aggregator.cc                                    \
   db/range_tombstone_fragmenter.cc                              \
   db/repair.cc                                                  \
@@ -500,7 +500,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/obsolete_files_test.cc                                             \
   db/options_file_test.cc                                               \
   db/perf_context_test.cc                                               \
-  db/periodic_work_scheduler_test.cc                                    \
+  db/periodic_task_scheduler_test.cc                                    \
   db/plain_table_db_test.cc                                             \
   db/prefix_test.cc                                                     \
   db/repair_test.cc                                                     \

--- a/util/timer.h
+++ b/util/timer.h
@@ -137,6 +137,7 @@ class Timer {
     if (thread_) {
       thread_->join();
     }
+    thread_.release();
     return true;
   }
 
@@ -187,11 +188,7 @@ class Timer {
     return ret;
   }
 
-  bool TEST_HasVaildTask(const std::string& func_name) const {
-    InstrumentedMutexLock l(&mutex_);
-    auto it = map_.find(func_name);
-    return it != map_.end() && it->second->IsValid();
-  }
+  void TEST_OverrideTimer(SystemClock* clock) { clock_ = clock; }
 #endif  // NDEBUG
 
  private:

--- a/util/timer.h
+++ b/util/timer.h
@@ -137,7 +137,6 @@ class Timer {
     if (thread_) {
       thread_->join();
     }
-    thread_.release();
     return true;
   }
 
@@ -188,7 +187,10 @@ class Timer {
     return ret;
   }
 
-  void TEST_OverrideTimer(SystemClock* clock) { clock_ = clock; }
+  void TEST_OverrideTimer(SystemClock* clock) {
+    InstrumentedMutexLock l(&mutex_);
+    clock_ = clock;
+  }
 #endif  // NDEBUG
 
  private:


### PR DESCRIPTION
Timer has a limitation that it cannot re-register a task with the same name,
because the cancel only mark the task as invalid and wait for the Timer thread
to clean it up later, before the task is cleaned up, the same task name cannot
be added. Which makes the task option update likely to fail, which basically
cancel and re-register the same task name. Change the periodic task name to a
random unique id and store it in periodic_task_scheduler.

Also refactor the `periodic_work` to `periodic_task` to make each job function
as a `task`.

Test Plan: unittests