### PR TITLE
Accelerate advancing the compact cursor under round-robin compaction …

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -97,6 +97,8 @@ const char* GetCompactionReasonString(CompactionReason compaction_reason) {
       return "ChangeTemperature";
     case CompactionReason::kForcedBlobGC:
       return "ForcedBlobGC";
+    case CompactionReason::kLevelRoundRobinTtlPreExpire:
+      return "RoundRobinFilePreExpireWithBoostTtl";
     case CompactionReason::kNumOfReasons:
       // fall through
     default:
@@ -1627,8 +1629,11 @@ Status CompactionJob::InstallCompactionResults(
                              stats.GetBytes());
   }
 
-  if (compaction->compaction_reason() == CompactionReason::kLevelMaxLevelSize &&
-      compaction->immutable_options()->compaction_pri == kRoundRobin) {
+  if (compaction->immutable_options()->compaction_pri == kRoundRobin &&
+      (compaction->compaction_reason() ==
+           CompactionReason::kLevelMaxLevelSize ||
+       compaction->compaction_reason() ==
+           CompactionReason::kLevelRoundRobinTtlPreExpire)) {
     int start_level = compaction->start_level();
     if (start_level > 0) {
       auto vstorage = compaction->input_version()->storage_info();

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -148,6 +148,9 @@ enum class CompactionReason : int {
   kChangeTemperature,
   // Compaction scheduled to force garbage collection of blob files
   kForcedBlobGC,
+  // [Level: kRoundRobin] files pointed by the compact cursor pre-expire with
+  // respect to boosted ttls (more can be found in db/compaction/file_pri.h
+  kLevelRoundRobinTtlPreExpire,
   // total number of compaction reasons, new reasons must be added above this.
   kNumOfReasons,
 };


### PR DESCRIPTION
Summary:

In the existing logic of round-robin, a round-robin compaction is triggered only if the level is **full**. When TTL expires for many files at once, there is might be sudden burst. To alleviate this case, we trigger a compaction if the file under the round-robin cursor is close to expiration (**regardless** of whether other files are close to TTL since we can only do a compaction following the cursor under the round-robin logic). To determine if it is close to expiration (called pre-expired in codes and comments), we reuse `FileTtlBooster`'s logic (more details can be found in `compaction/file_pri.h`). With this change, we essentially add another compaction reason (`CompactionReason::LevelRoundRobinTtlPreExpire`) for round-robin compaction. 

Test Case:
Add `RoundRobinTtlBoosterPreExpire` in `db_compaction_test.cc`