### PR TITLE
Add file based data generation options to db_bench

### DIFF
--- a/db/compaction/compaction_job_stats_test.cc
+++ b/db/compaction/compaction_job_stats_test.cc
@@ -63,7 +63,7 @@ namespace ROCKSDB_NAMESPACE {
 
 static std::string RandomString(Random* rnd, int len, double ratio) {
   std::string r;
-  test::CompressibleString(rnd, ratio, len, &r);
+  test::CompressibleString(rnd, ratio, len, &r, "");
   return r;
 }
 

--- a/db/db_statistics_test.cc
+++ b/db/db_statistics_test.cc
@@ -55,8 +55,8 @@ TEST_F(DBStatisticsTest, CompressionStatsTest) {
     // Check that compressions occur and are counted when compression is turned
     // on
     for (int i = 0; i < kNumKeysWritten; ++i) {
-      ASSERT_OK(
-          Put(Key(i), test::CompressibleString(&rnd, compress_to, len, &buf)));
+      ASSERT_OK(Put(
+          Key(i), test::CompressibleString(&rnd, compress_to, len, &buf, "")));
     }
     ASSERT_OK(Flush());
     EXPECT_EQ(34, PopStat(NUMBER_BLOCK_COMPRESSED));

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1123,7 +1123,7 @@ class DelayFilterFactory : public CompactionFilterFactory {
 
 static std::string CompressibleString(Random* rnd, int len) {
   std::string r;
-  test::CompressibleString(rnd, 0.8, len, &r);
+  test::CompressibleString(rnd, 0.8, len, &r, "");
   return r;
 }
 

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -18,7 +18,7 @@ namespace ROCKSDB_NAMESPACE {
 
 static std::string CompressibleString(Random* rnd, int len) {
   std::string r;
-  test::CompressibleString(rnd, 0.8, len, &r);
+  test::CompressibleString(rnd, 0.8, len, &r, "");
   return r;
 }
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4220,9 +4220,9 @@ static void DoCompressionTest(CompressionType comp) {
   TableConstructor c(BytewiseComparator(), true /* convert_to_internal_key_ */);
   std::string tmp;
   c.Add("k01", "hello");
-  c.Add("k02", test::CompressibleString(&rnd, 0.25, 10000, &tmp));
+  c.Add("k02", test::CompressibleString(&rnd, 0.25, 10000, &tmp, ""));
   c.Add("k03", "hello3");
-  c.Add("k04", test::CompressibleString(&rnd, 0.25, 10000, &tmp));
+  c.Add("k04", test::CompressibleString(&rnd, 0.25, 10000, &tmp, ""));
   std::vector<std::string> keys;
   stl_wrappers::KVMap kvmap;
   Options options;
@@ -5115,7 +5115,8 @@ TEST_P(BlockBasedTableTest, CompressionRatioThreshold) {
         TableConstructor c(BytewiseComparator(),
                            true /* convert_to_internal_key_ */);
         std::string buf;
-        c.Add("x", test::CompressibleString(&rnd, compressible_to, len, &buf));
+        c.Add("x",
+              test::CompressibleString(&rnd, compressible_to, len, &buf, ""));
 
         // write an SST file
         c.Finish(options, ioptions, moptions, table_options,

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -72,7 +72,8 @@ extern bool ShouldPersistUDT(const UserDefinedTimestampTestMode& test_mode);
 // "N*compressed_fraction" bytes and return a Slice that references
 // the generated data.
 extern Slice CompressibleString(Random* rnd, double compressed_fraction,
-                                int len, std::string* dst);
+                                int len, std::string* dst,
+                                const std::string& src);
 
 #ifndef NDEBUG
 // An internal comparator that just forward comparing results from the

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -2448,7 +2448,7 @@ TEST_P(TransactionTest, FlushTest2) {
     Random rnd(47);
     for (int i = 0; i < 1000; i++) {
       s = db->Put(write_options, std::to_string(i),
-                  test::CompressibleString(&rnd, 0.8, 100, &value));
+                  test::CompressibleString(&rnd, 0.8, 100, &value, ""));
       ASSERT_OK(s);
     }
 


### PR DESCRIPTION
Currently, db_bench populates a data store's values with randomly generated strings. This change adds two new options for generating data:

1.  **File Random** - Populates data store values with randomly generated strings from a particular file
2. **File Direct** - Populates data store values with strings read sequentially from a file and wrapping around to the initial read position after reaching the end of the file

In the case of **File Random**, the actual compression ratio will have a larger delta from the target compression ratio compared to the delta achieved in the original randomization scheme. This is because any window of characters in a file will likely be more repeatable than a randomly generated string of the same size. In the case of "File Direct", the target compression ratio be ignored entirely because of the need to remain as close the original file contents as possible.

In addition to the two new options mentioned above, a third option called **Pure Random** is provided. This option is nothing but the original randomization scheme. It is set as the default option.