### PR TITLE
Fix a bug in hash linked list

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 * Fix a bug where `GenericRateLimiter` could revert the bandwidth set dynamically using `SetBytesPerSecond()` when a user configures a structure enclosing it, e.g., using `GetOptionsFromString()` to configure an `Options` that references an existing `RateLimiter` object.
 * Fix race conditions in `GenericRateLimiter`.
 * Fix a bug in `FIFOCompactionPicker::PickTTLCompaction` where total_size calculating might cause underflow
+* Fix data race bug in hash linked list memtable. With this bug, read request might temporarily miss an old record in the memtable in a race condition to the hash bucket.
 
 ## 7.5.0 (07/15/2022)
 ### New Features

--- a/memtable/hash_linklist_rep.cc
+++ b/memtable/hash_linklist_rep.cc
@@ -780,14 +780,13 @@ MemTableRep::Iterator* HashLinkListRep::GetIterator(Arena* alloc_arena) {
         }
       } else {
         auto* skip_list_header = GetSkipListBucketHeader(bucket);
-        if (skip_list_header != nullptr) {
-          // Is a skip list
-          MemtableSkipList::Iterator itr(&skip_list_header->skip_list);
-          for (itr.SeekToFirst(); itr.Valid(); itr.Next()) {
-            list->Insert(itr.key());
-            count++;
+        assert(skip_list_header != nullptr);
+        // Is a skip list
+        MemtableSkipList::Iterator itr(&skip_list_header->skip_list);
+        for (itr.SeekToFirst(); itr.Valid(); itr.Next()) {
+          list->Insert(itr.key());
+          count++;
           }
-        }
       }
     }
     if (if_log_bucket_dist_when_flash_) {


### PR DESCRIPTION
Summary:
In hash linked list, with a bucket of only one record, following sequence can cause users to temporarily miss a record:

Thread 1: Fetch the structure bucket x points too, which would be a Node n1 for a key, with next pointer to be null
Thread 2: Insert a key to bucket x that is larger than the existing key. This will make n1->next points to a new node n2, and update bucket x to point to n1.
Thread 1: see n1->next is not null, so it thinks it is a header of linked list and ignore the key of n1.

Fix it by refetch structure that bucket x points to when it sees n1->next is not null. This should work because if n1->next is not null, bucket x should already point to a linked list or skip list header.

A related change is to revert th order of testing for linked list and skip list. This is because after refetching the bucket, it might end up with a skip list, rather than linked list.

Test Plan: Run existing tests and make sure at least it doesn't regress.