### PR TITLE
Deflake FlushStaleColumnFamilies test

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -2209,6 +2209,16 @@ TEST_P(ColumnFamilyTest, FlushStaleColumnFamilies) {
   WaitForFlush(2);
   // 3 files for default column families, 1 file for column family [two], zero
   // files for column family [one], because it's empty
+
+  std::vector<LiveFileMetaData> metadata;
+  db_->GetLiveFilesMetaData(&metadata);
+  if (metadata.size() != 4) {
+    int i = 0;
+    for (const auto& meta : metadata) {
+      std::cout << i++ << ": " << meta.column_family_name << ", " << meta.level
+                << ", " << meta.file_type << std::endl;
+    }
+  }
   AssertCountLiveFiles(4);
 
   ASSERT_OK(Flush(0));

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -2218,6 +2218,7 @@ TEST_P(ColumnFamilyTest, FlushStaleColumnFamilies) {
       std::cout << i++ << ": " << meta.column_family_name << ", " << meta.level
                 << ", " << meta.file_type << std::endl;
     }
+    env_->SleepForMicroseconds(1000000000);
   }
   AssertCountLiveFiles(4);
 


### PR DESCRIPTION
Make the Stale Flush test more robust by explicitly checking the target CF is
flushed.  Currently it's flaky because the default CF may have more than 3
SSTs.

Test Plan: the test more likely to fail on a resource limited host:
```
gtest-parallel ./column_family_test --gtest_filter=FormatDef/ColumnFamilyTest.FlushStaleColumnFamilies/0 -r 1000 -w 100
```