### PR TITLE
increase buffer size in PosixFileSystem::GetAbsolutePath to PATH_MAX

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -883,8 +883,8 @@ class PosixFileSystem : public FileSystem {
       return IOStatus::OK();
     }
 
-    char the_path[256];
-    char* ret = getcwd(the_path, 256);
+    char the_path[4096];
+    char* ret = getcwd(the_path, 4096);
     if (ret == nullptr) {
       return IOStatus::IOError(errnoStr(errno).c_str());
     }


### PR DESCRIPTION
RocksDB fails to open database with relative path when length of cwd
is longer than 256 bytes. This happens due to ERANGE in getcwd call.
Here we simply increase buffer size to the most common PATH_MAX value.