### PR TITLE
Allow sufficient subcompactions under round-robin compaction priority

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -508,6 +508,8 @@ void CompactionJob::GenSubcompactionBoundaries() {
       // of planned subcompactions
       num_planned_subcompactions =
           std::min(num_planned_subcompactions, GetSubcompactionsLimit());
+    } else {
+      num_planned_subcompactions = max_subcompactions_limit;
     }
   } else {
     num_planned_subcompactions = GetSubcompactionsLimit();


### PR DESCRIPTION
Summary:

Allow sufficient subcompactions can be used when the number of input files is less than `max_subcompactions` under round-robin compaction priority.

Test Case:
Add `RoundRobinWithoutAdditionalResources` into `db_compaction_test`