### PR TITLE
Fix regression_test.sh deleterandom duration

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -139,10 +139,10 @@ function main {
       build_checkpoint
       run_db_bench "readrandom"
       run_db_bench "readwhilewriting"
-      run_db_bench "deleterandom" $((NUM_KEYS / 10 / $NUM_THREADS))
+      run_db_bench "deleterandom"
       run_db_bench "seekrandom"
       run_db_bench "seekrandomwhilewriting"
-      run_db_bench "multireadrandom" 
+      run_db_bench "multireadrandom"
   fi
 
   cleanup_test_directory $TEST_ROOT_DIR


### PR DESCRIPTION
Summary: deleterandom tests are too fast to get good signal, e.g.
--deletes=31250 in 0.170 seconds vs. --reads=1500000 in 288.491
seconds for readrandom. Removing the special handling (unknown
motivation in faa7eb3b99) should suffice.

Test Plan: watch continuous results