### PR TITLE
Add CompressedSecondaryCache into stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -179,7 +179,8 @@ default_params = {
     "async_io": lambda: random.choice([0, 1]),
     "wal_compression": lambda: random.choice(["none", "zstd"]),
     "verify_sst_unique_id_in_manifest": 1,  # always do unique_id verification
-    "secondary_cache_uri": "",
+    "secondary_cache_uri": lambda: random.choice(
+        ["", "compressed_secondary_cache://capacity=8388608"]),
     "allow_data_in_errors": True,
 }
 


### PR DESCRIPTION
Summary:
The secondary cache is randomly disabled or enabled with CompressedSecondaryCache.

Test Plan:
 - To test that the CompressedSecondaryCache is used and the stress test runs successfully, run  `make -j24 CRASH_TEST_EXT_ARGS=—duration=960 blackbox_crash_test `