### PR TITLE
Skip swaths of range tombstone covered keys in merging iterator (2022 edition)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,9 @@
 ### New Features
 *  RocksDB does internal auto prefetching if it notices 2 sequential reads if readahead_size is not specified. New option `num_file_reads_for_auto_readahead` is added in BlockBasedTableOptions which indicates after how many sequential reads internal auto prefetching should be start (default is 2).
 
+### Performance Improvements
+* Iterator performance is improved for `DeleteRange()` users. Internally, iterator will skip to the end of a range tombstone when possible, instead of looping through each key and check individually if a key is range deleted.
+
 ## 7.6.0 (08/19/2022)
 ### New Features
 * Added `prepopulate_blob_cache` to ColumnFamilyOptions. If enabled, prepopulate warm/hot blobs which are already in memory into blob cache at the time of flush. On a flush, the blob that is in memory (in memtables) get flushed to the device. If using Direct IO, additional IO is incurred to read this blob back into memory again, which is avoided by enabling this option. This further helps if the workload exhibits high temporal locality, where most of the reads go to recently written data. This also helps in case of the remote file system since it involves network traffic and higher latencies.

--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -44,15 +44,17 @@ class ArenaWrappedDBIter : public Iterator {
   // Get the arena to be used to allocate memory for DBIter to be wrapped,
   // as well as child iterators in it.
   virtual Arena* GetArena() { return &arena_; }
-  virtual ReadRangeDelAggregator* GetRangeDelAggregator() {
-    return db_iter_->GetRangeDelAggregator();
-  }
+
   const ReadOptions& GetReadOptions() { return read_options_; }
 
   // Set the internal iterator wrapped inside the DB Iterator. Usually it is
   // a merging iterator.
   virtual void SetIterUnderDBIter(InternalIterator* iter) {
     db_iter_->SetIter(iter);
+  }
+
+  void SetMemtableRangetombstoneIter(TruncatedRangeDelIterator** iter) {
+    memtable_range_tombstone_iter_ = iter;
   }
 
   bool Valid() const override { return db_iter_->Valid(); }
@@ -104,6 +106,7 @@ class ArenaWrappedDBIter : public Iterator {
   ReadCallback* read_callback_;
   bool expose_blob_index_ = false;
   bool allow_refresh_ = true;
+  TruncatedRangeDelIterator** memtable_range_tombstone_iter_ = nullptr;
 };
 
 // Generate the arena wrapped iterator class.

--- a/db/c.cc
+++ b/db/c.cc
@@ -4116,6 +4116,8 @@ uint64_t rocksdb_perfcontext_metric(rocksdb_perfcontext_t* context,
       return rep->blob_checksum_time;
     case rocksdb_blob_decompress_time:
       return rep->blob_decompress_time;
+    case rocksdb_internal_range_del_reseek_count:
+      return rep->internal_range_del_reseek_count;
     default:
       break;
   }

--- a/db/db_compaction_filter_test.cc
+++ b/db/db_compaction_filter_test.cc
@@ -328,11 +328,10 @@ TEST_F(DBTestCompactionFilter, CompactionFilter) {
   Arena arena;
   {
     InternalKeyComparator icmp(options.comparator);
-    ReadRangeDelAggregator range_del_agg(&icmp,
-                                         kMaxSequenceNumber /* upper_bound */);
     ReadOptions read_options;
+    read_options.ignore_range_deletions = true;
     ScopedArenaIterator iter(dbfull()->NewInternalIterator(
-        read_options, &arena, &range_del_agg, kMaxSequenceNumber, handles_[1]));
+        read_options, &arena, kMaxSequenceNumber, handles_[1]));
     iter->SeekToFirst();
     ASSERT_OK(iter->status());
     while (iter->Valid()) {
@@ -422,11 +421,10 @@ TEST_F(DBTestCompactionFilter, CompactionFilter) {
   count = 0;
   {
     InternalKeyComparator icmp(options.comparator);
-    ReadRangeDelAggregator range_del_agg(&icmp,
-                                         kMaxSequenceNumber /* upper_bound */);
     ReadOptions read_options;
+    read_options.ignore_range_deletions = true;
     ScopedArenaIterator iter(dbfull()->NewInternalIterator(
-        read_options, &arena, &range_del_agg, kMaxSequenceNumber, handles_[1]));
+        read_options, &arena, kMaxSequenceNumber, handles_[1]));
     iter->SeekToFirst();
     ASSERT_OK(iter->status());
     while (iter->Valid()) {
@@ -701,11 +699,10 @@ TEST_F(DBTestCompactionFilter, CompactionFilterContextManual) {
     int total = 0;
     Arena arena;
     InternalKeyComparator icmp(options.comparator);
-    ReadRangeDelAggregator range_del_agg(&icmp,
-                                         kMaxSequenceNumber /* snapshots */);
     ReadOptions read_options;
-    ScopedArenaIterator iter(dbfull()->NewInternalIterator(
-        read_options, &arena, &range_del_agg, kMaxSequenceNumber));
+    read_options.ignore_range_deletions = true;
+    ScopedArenaIterator iter(dbfull()->NewInternalIterator(read_options, &arena,
+                                                           kMaxSequenceNumber));
     iter->SeekToFirst();
     ASSERT_OK(iter->status());
     while (iter->Valid()) {

--- a/db/db_compaction_filter_test.cc
+++ b/db/db_compaction_filter_test.cc
@@ -329,7 +329,6 @@ TEST_F(DBTestCompactionFilter, CompactionFilter) {
   {
     InternalKeyComparator icmp(options.comparator);
     ReadOptions read_options;
-    read_options.ignore_range_deletions = true;
     ScopedArenaIterator iter(dbfull()->NewInternalIterator(
         read_options, &arena, kMaxSequenceNumber, handles_[1]));
     iter->SeekToFirst();
@@ -422,7 +421,6 @@ TEST_F(DBTestCompactionFilter, CompactionFilter) {
   {
     InternalKeyComparator icmp(options.comparator);
     ReadOptions read_options;
-    read_options.ignore_range_deletions = true;
     ScopedArenaIterator iter(dbfull()->NewInternalIterator(
         read_options, &arena, kMaxSequenceNumber, handles_[1]));
     iter->SeekToFirst();
@@ -700,7 +698,6 @@ TEST_F(DBTestCompactionFilter, CompactionFilterContextManual) {
     Arena arena;
     InternalKeyComparator icmp(options.comparator);
     ReadOptions read_options;
-    read_options.ignore_range_deletions = true;
     ScopedArenaIterator iter(dbfull()->NewInternalIterator(read_options, &arena,
                                                            kMaxSequenceNumber));
     iter->SeekToFirst();

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1641,7 +1641,6 @@ Status DBImpl::GetFullHistoryTsLow(ColumnFamilyHandle* column_family,
 
 InternalIterator* DBImpl::NewInternalIterator(const ReadOptions& read_options,
                                               Arena* arena,
-                                              RangeDelAggregator* range_del_agg,
                                               SequenceNumber sequence,
                                               ColumnFamilyHandle* column_family,
                                               bool allow_unprepared_value) {
@@ -1656,8 +1655,8 @@ InternalIterator* DBImpl::NewInternalIterator(const ReadOptions& read_options,
   mutex_.Lock();
   SuperVersion* super_version = cfd->GetSuperVersion()->Ref();
   mutex_.Unlock();
-  return NewInternalIterator(read_options, cfd, super_version, arena,
-                             range_del_agg, sequence, allow_unprepared_value);
+  return NewInternalIterator(read_options, cfd, super_version, arena, sequence,
+                             allow_unprepared_value);
 }
 
 void DBImpl::SchedulePurge() {
@@ -1788,16 +1787,12 @@ static void CleanupGetMergeOperandsState(void* arg1, void* /*arg2*/) {
 
 }  // namespace
 
-InternalIterator* DBImpl::NewInternalIterator(const ReadOptions& read_options,
-                                              ColumnFamilyData* cfd,
-                                              SuperVersion* super_version,
-                                              Arena* arena,
-                                              RangeDelAggregator* range_del_agg,
-                                              SequenceNumber sequence,
-                                              bool allow_unprepared_value) {
+InternalIterator* DBImpl::NewInternalIterator(
+    const ReadOptions& read_options, ColumnFamilyData* cfd,
+    SuperVersion* super_version, Arena* arena, SequenceNumber sequence,
+    bool allow_unprepared_value, ArenaWrappedDBIter* db_iter) {
   InternalIterator* internal_iter;
   assert(arena != nullptr);
-  assert(range_del_agg != nullptr);
   // Need to create internal iterator from the arena.
   MergeIteratorBuilder merge_iter_builder(
       &cfd->internal_comparator(), arena,
@@ -1806,19 +1801,26 @@ InternalIterator* DBImpl::NewInternalIterator(const ReadOptions& read_options,
   // Collect iterator for mutable mem
   merge_iter_builder.AddIterator(
       super_version->mem->NewIterator(read_options, arena));
-  std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter;
   Status s;
   if (!read_options.ignore_range_deletions) {
-    range_del_iter.reset(super_version->mem->NewRangeTombstoneIterator(
-        read_options, sequence, false /* immutable_memtable */));
-    range_del_agg->AddTombstones(std::move(range_del_iter));
+    auto range_del_iter = super_version->mem->NewRangeTombstoneIterator(
+        read_options, sequence, false /* immutable_memtable */);
+    if (range_del_iter == nullptr || range_del_iter->empty()) {
+      delete range_del_iter;
+      merge_iter_builder.AddRangeTombstoneIterator(nullptr);
+    } else {
+      merge_iter_builder.AddRangeTombstoneIterator(
+          new TruncatedRangeDelIterator(
+              std::unique_ptr<FragmentedRangeTombstoneIterator>(range_del_iter),
+              &cfd->ioptions()->internal_comparator, nullptr, nullptr));
+    }
   }
   // Collect all needed child iterators for immutable memtables
   if (s.ok()) {
     super_version->imm->AddIterators(read_options, &merge_iter_builder);
     if (!read_options.ignore_range_deletions) {
       s = super_version->imm->AddRangeTombstoneIterators(read_options, arena,
-                                                         range_del_agg);
+                                                         merge_iter_builder);
     }
   }
   TEST_SYNC_POINT_CALLBACK("DBImpl::NewInternalIterator:StatusCallback", &s);
@@ -1826,10 +1828,11 @@ InternalIterator* DBImpl::NewInternalIterator(const ReadOptions& read_options,
     // Collect iterators for files in L0 - Ln
     if (read_options.read_tier != kMemtableTier) {
       super_version->current->AddIterators(read_options, file_options_,
-                                           &merge_iter_builder, range_del_agg,
+                                           &merge_iter_builder,
                                            allow_unprepared_value);
     }
-    internal_iter = merge_iter_builder.Finish();
+    internal_iter = merge_iter_builder.Finish(
+        read_options.ignore_range_deletions ? nullptr : db_iter);
     SuperVersionHandle* cleanup = new SuperVersionHandle(
         this, &mutex_, super_version,
         read_options.background_purge_on_iterator_cleanup ||
@@ -3354,9 +3357,8 @@ ArenaWrappedDBIter* DBImpl::NewIteratorImpl(const ReadOptions& read_options,
       read_options.snapshot != nullptr ? false : allow_refresh);
 
   InternalIterator* internal_iter = NewInternalIterator(
-      db_iter->GetReadOptions(), cfd, sv, db_iter->GetArena(),
-      db_iter->GetRangeDelAggregator(), snapshot,
-      /* allow_unprepared_value */ true);
+      db_iter->GetReadOptions(), cfd, sv, db_iter->GetArena(), snapshot,
+      /* allow_unprepared_value */ true, db_iter);
   db_iter->SetIterUnderDBIter(internal_iter);
 
   return db_iter;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1812,7 +1812,8 @@ InternalIterator* DBImpl::NewInternalIterator(
       merge_iter_builder.AddRangeTombstoneIterator(
           new TruncatedRangeDelIterator(
               std::unique_ptr<FragmentedRangeTombstoneIterator>(range_del_iter),
-              &cfd->ioptions()->internal_comparator, nullptr, nullptr));
+              &cfd->ioptions()->internal_comparator, nullptr /* smallest */,
+              nullptr /* largest */));
     }
   }
   // Collect all needed child iterators for immutable memtables

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -739,14 +739,10 @@ class DBImpl : public DB {
   // the value and so will require PrepareValue() to be called before value();
   // allow_unprepared_value = false is convenient when this optimization is not
   // useful, e.g. when reading the whole column family.
-  // If read_options.ignore_range_deletions is false, then:
-  //   If range_del_agg is not nullptr, range tombstones from each sorted runs
-  //   are added to range_del_agg. Keys covered by range tombstones are
-  //   outputted by this iterator. Otherwise, range_del_agg is nullptr, range
-  //   tombstones are processed internally and output keys of this iterator are
-  //   not covered by any range tombstone.
-  // If read_options.ignore_range_deletions is true, no range tombstone will be
-  // added to range_del_agg nor will range tombstones be handled internally.
+  //
+  // read_options.ignore_range_deletions determines whether range tombstones are
+  // processed in the returned interator internally, i.e., whether range
+  // tombstone covered keys are in this iterator's output.
   // @param read_options Must outlive the returned iterator.
   InternalIterator* NewInternalIterator(
       const ReadOptions& read_options, Arena* arena, SequenceNumber sequence,

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -143,8 +143,7 @@ Iterator* DBImplReadOnly::NewIterator(const ReadOptions& read_options,
       super_version->version_number, read_callback);
   auto internal_iter = NewInternalIterator(
       db_iter->GetReadOptions(), cfd, super_version, db_iter->GetArena(),
-      db_iter->GetRangeDelAggregator(), read_seq,
-      /* allow_unprepared_value */ true);
+      read_seq, /* allow_unprepared_value */ true, db_iter);
   db_iter->SetIterUnderDBIter(internal_iter);
   return db_iter;
 }
@@ -194,9 +193,8 @@ Status DBImplReadOnly::NewIterators(
         sv->mutable_cf_options.max_sequential_skip_in_iterations,
         sv->version_number, read_callback);
     auto* internal_iter = NewInternalIterator(
-        db_iter->GetReadOptions(), cfd, sv, db_iter->GetArena(),
-        db_iter->GetRangeDelAggregator(), read_seq,
-        /* allow_unprepared_value */ true);
+        db_iter->GetReadOptions(), cfd, sv, db_iter->GetArena(), read_seq,
+        /* allow_unprepared_value */ true, db_iter);
     db_iter->SetIterUnderDBIter(internal_iter);
     iterators->push_back(db_iter);
   }

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -493,8 +493,7 @@ ArenaWrappedDBIter* DBImplSecondary::NewIteratorImpl(
       expose_blob_index, read_options.snapshot ? false : allow_refresh);
   auto internal_iter = NewInternalIterator(
       db_iter->GetReadOptions(), cfd, super_version, db_iter->GetArena(),
-      db_iter->GetRangeDelAggregator(), snapshot,
-      /* allow_unprepared_value */ true);
+      snapshot, /* allow_unprepared_value */ true, db_iter);
   db_iter->SetIterUnderDBIter(internal_iter);
   return db_iter;
 }

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -1575,7 +1575,7 @@ void DBIter::SeekToFirst() {
     max_skip_ = std::numeric_limits<uint64_t>::max();
   }
   status_ = Status::OK();
-  // if iterator is empty, this status_ would be unchecked.
+  // if iterator is empty, this status_ could be unchecked.
   status_.PermitUncheckedError();
   direction_ = kForward;
   ReleaseTempPinnedData();
@@ -1646,7 +1646,7 @@ void DBIter::SeekToLast() {
     max_skip_ = std::numeric_limits<uint64_t>::max();
   }
   status_ = Status::OK();
-  // if iterator is empty, this status_ would be unchecked.
+  // if iterator is empty, this status_ could be unchecked.
   status_.PermitUncheckedError();
   direction_ = kReverse;
   ReleaseTempPinnedData();

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -1575,6 +1575,8 @@ void DBIter::SeekToFirst() {
     max_skip_ = std::numeric_limits<uint64_t>::max();
   }
   status_ = Status::OK();
+  // if iterator is empty, this status_ would be unchecked.
+  status_.PermitUncheckedError();
   direction_ = kForward;
   ReleaseTempPinnedData();
   ResetBlobValue();
@@ -1644,6 +1646,8 @@ void DBIter::SeekToLast() {
     max_skip_ = std::numeric_limits<uint64_t>::max();
   }
   status_ = Status::OK();
+  // if iterator is empty, this status_ would be unchecked.
+  status_.PermitUncheckedError();
   direction_ = kReverse;
   ReleaseTempPinnedData();
   ResetBlobValue();

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -78,7 +78,6 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       is_blob_(false),
       is_wide_(false),
       arena_mode_(arena_mode),
-      range_del_agg_(&ioptions.internal_comparator, s),
       db_impl_(db_impl),
       cfd_(cfd),
       timestamp_ub_(read_options.timestamp),
@@ -394,49 +393,27 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
               saved_key_.SetUserKey(
                   ikey_.user_key, !pin_thru_lifetime_ ||
                                       !iter_.iter()->IsKeyPinned() /* copy */);
-              if (range_del_agg_.ShouldDelete(
-                      ikey_, RangeDelPositioningMode::kForwardTraversal)) {
-                // Arrange to skip all upcoming entries for this key since
-                // they are hidden by this deletion.
-                skipping_saved_key = true;
-                num_skipped = 0;
-                reseek_done = false;
-                PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
-              } else {
-                if (ikey_.type == kTypeBlobIndex) {
-                  if (!SetBlobValueIfNeeded(ikey_.user_key, iter_.value())) {
-                    return false;
-                  }
-                } else if (ikey_.type == kTypeWideColumnEntity) {
-                  if (!SetWideColumnValueIfNeeded(iter_.value())) {
-                    return false;
-                  }
+              if (ikey_.type == kTypeBlobIndex) {
+                if (!SetBlobValueIfNeeded(ikey_.user_key, iter_.value())) {
+                  return false;
                 }
-
-                valid_ = true;
-                return true;
+              } else if (ikey_.type == kTypeWideColumnEntity) {
+                if (!SetWideColumnValueIfNeeded(iter_.value())) {
+                  return false;
+                }
               }
+              valid_ = true;
+              return true;
             }
             break;
           case kTypeMerge:
             saved_key_.SetUserKey(
                 ikey_.user_key,
                 !pin_thru_lifetime_ || !iter_.iter()->IsKeyPinned() /* copy */);
-            if (range_del_agg_.ShouldDelete(
-                    ikey_, RangeDelPositioningMode::kForwardTraversal)) {
-              // Arrange to skip all upcoming entries for this key since
-              // they are hidden by this deletion.
-              skipping_saved_key = true;
-              num_skipped = 0;
-              reseek_done = false;
-              PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
-            } else {
-              // By now, we are sure the current ikey is going to yield a
-              // value
-              current_entry_is_merged_ = true;
-              valid_ = true;
-              return MergeValuesNewToOld();  // Go to a different state machine
-            }
+            // By now, we are sure the current ikey is going to yield a value
+            current_entry_is_merged_ = true;
+            valid_ = true;
+            return MergeValuesNewToOld();  // Go to a different state machine
             break;
           default:
             valid_ = false;
@@ -562,9 +539,7 @@ bool DBIter::MergeValuesNewToOld() {
       // hit the next user key, stop right here
       break;
     }
-    if (kTypeDeletion == ikey.type || kTypeSingleDeletion == ikey.type ||
-               range_del_agg_.ShouldDelete(
-                   ikey, RangeDelPositioningMode::kForwardTraversal)) {
+    if (kTypeDeletion == ikey.type || kTypeSingleDeletion == ikey.type) {
       // hit a delete with the same user key, stop right here
       // iter_ is positioned after delete
       iter_.Next();
@@ -913,11 +888,7 @@ bool DBIter::FindValueForCurrentKey() {
       case kTypeValue:
       case kTypeBlobIndex:
       case kTypeWideColumnEntity:
-        if (range_del_agg_.ShouldDelete(
-                ikey, RangeDelPositioningMode::kBackwardTraversal)) {
-          last_key_entry_type = kTypeRangeDeletion;
-          PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
-        } else if (iter_.iter()->IsValuePinned()) {
+        if (iter_.iter()->IsValuePinned()) {
           pinned_value_ = iter_.value();
         } else {
           valid_ = false;
@@ -938,21 +909,12 @@ bool DBIter::FindValueForCurrentKey() {
         last_not_merge_type = last_key_entry_type;
         PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
         break;
-      case kTypeMerge:
-        if (range_del_agg_.ShouldDelete(
-                ikey, RangeDelPositioningMode::kBackwardTraversal)) {
-          merge_context_.Clear();
-          last_key_entry_type = kTypeRangeDeletion;
-          last_not_merge_type = last_key_entry_type;
-          PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
-        } else {
-          assert(merge_operator_ != nullptr);
-          merge_context_.PushOperandBack(
-              iter_.value(),
-              iter_.iter()->IsValuePinned() /* operand_pinned */);
-          PERF_COUNTER_ADD(internal_merge_count, 1);
-        }
-        break;
+      case kTypeMerge: {
+        assert(merge_operator_ != nullptr);
+        merge_context_.PushOperandBack(
+            iter_.value(), iter_.iter()->IsValuePinned() /* operand_pinned */);
+        PERF_COUNTER_ADD(internal_merge_count, 1);
+      } break;
       default:
         valid_ = false;
         status_ = Status::Corruption(
@@ -989,8 +951,7 @@ bool DBIter::FindValueForCurrentKey() {
   }
 
   if (timestamp_lb_ != nullptr) {
-    assert(last_key_entry_type == ikey_.type ||
-           last_key_entry_type == kTypeRangeDeletion);
+    assert(last_key_entry_type == ikey_.type);
   }
 
   Status s;
@@ -1005,7 +966,6 @@ bool DBIter::FindValueForCurrentKey() {
     case kTypeDeletion:
     case kTypeDeletionWithTimestamp:
     case kTypeSingleDeletion:
-    case kTypeRangeDeletion:
       if (timestamp_lb_ == nullptr) {
         valid_ = false;
       } else {
@@ -1016,8 +976,7 @@ bool DBIter::FindValueForCurrentKey() {
     case kTypeMerge:
       current_entry_is_merged_ = true;
       if (last_not_merge_type == kTypeDeletion ||
-          last_not_merge_type == kTypeSingleDeletion ||
-          last_not_merge_type == kTypeRangeDeletion) {
+          last_not_merge_type == kTypeSingleDeletion) {
         s = Merge(nullptr, saved_key_.GetUserKey());
         if (!s.ok()) {
           return false;
@@ -1157,8 +1116,6 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
   }
 
   if (ikey.type == kTypeDeletion || ikey.type == kTypeSingleDeletion ||
-      range_del_agg_.ShouldDelete(
-          ikey, RangeDelPositioningMode::kBackwardTraversal) ||
       kTypeDeletionWithTimestamp == ikey.type) {
     if (timestamp_lb_ == nullptr) {
       valid_ = false;
@@ -1221,9 +1178,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
     if (!user_comparator_.Equal(ikey.user_key, saved_key_.GetUserKey())) {
       break;
     }
-    if (ikey.type == kTypeDeletion || ikey.type == kTypeSingleDeletion ||
-        range_del_agg_.ShouldDelete(
-            ikey, RangeDelPositioningMode::kForwardTraversal)) {
+    if (ikey.type == kTypeDeletion || ikey.type == kTypeSingleDeletion) {
       break;
     }
     if (!iter_.PrepareValue()) {
@@ -1498,7 +1453,6 @@ void DBIter::Seek(const Slice& target) {
     SetSavedKeyToSeekTarget(target);
     iter_.Seek(saved_key_.GetInternalKey());
 
-    range_del_agg_.InvalidateRangeDelMapPositions();
     RecordTick(statistics_, NUMBER_DB_SEEK);
   }
   if (!iter_.Valid()) {
@@ -1574,7 +1528,6 @@ void DBIter::SeekForPrev(const Slice& target) {
     PERF_TIMER_GUARD(seek_internal_seek_time);
     SetSavedKeyToSeekForPrevTarget(target);
     iter_.SeekForPrev(saved_key_.GetInternalKey());
-    range_del_agg_.InvalidateRangeDelMapPositions();
     RecordTick(statistics_, NUMBER_DB_SEEK);
   }
   if (!iter_.Valid()) {
@@ -1633,7 +1586,6 @@ void DBIter::SeekToFirst() {
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
     iter_.SeekToFirst();
-    range_del_agg_.InvalidateRangeDelMapPositions();
   }
 
   RecordTick(statistics_, NUMBER_DB_SEEK);
@@ -1703,7 +1655,6 @@ void DBIter::SeekToLast() {
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
     iter_.SeekToLast();
-    range_del_agg_.InvalidateRangeDelMapPositions();
   }
   PrevInternal(nullptr);
   if (statistics_ != nullptr) {

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -139,7 +139,6 @@ class DBIter final : public Iterator {
     iter_.Set(iter);
     iter_.iter()->SetPinnedItersMgr(&pinned_iters_mgr_);
   }
-  ReadRangeDelAggregator* GetRangeDelAggregator() { return &range_del_agg_; }
 
   bool Valid() const override {
 #ifdef ROCKSDB_ASSERT_STATUS_CHECKED
@@ -380,7 +379,6 @@ class DBIter final : public Iterator {
   bool arena_mode_;
   // List of operands for merge operator.
   MergeContext merge_context_;
-  ReadRangeDelAggregator range_del_agg_;
   LocalStatistics local_stats_;
   PinnedIteratorsManager pinned_iters_mgr_;
 #ifdef ROCKSDB_LITE

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -4,6 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include "db/db_test_util.h"
+#include "db/version_set.h"
 #include "port/stack_trace.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
 #include "test_util/testutil.h"
@@ -1754,6 +1755,822 @@ TEST_F(DBRangeDelTest, IteratorRefresh) {
 
     delete iter;
   }
+}
+
+void VerifyIteratorReachesEnd(InternalIterator* iter) {
+  ASSERT_TRUE(!iter->Valid() && iter->status().ok());
+}
+
+void VerifyIteratorReachesEnd(Iterator* iter) {
+  ASSERT_TRUE(!iter->Valid() && iter->status().ok());
+}
+
+TEST_F(DBRangeDelTest, IteratorReseek) {
+  // Range tombstone triggers reseek in merging iterator.
+  // Test set up:
+  //    one memtable: range tombstone [0, 1)
+  //    one immutable memtable: range tombstone [1, 2)
+  //    one L0 file with range tombstone [2, 3)
+  //    one L1 file with range tombstone [3, 4)
+  // Seek(a) should trigger cascading reseeks at all levels
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+
+  DestroyAndReopen(options);
+  // L1
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(3),
+                             Key(4)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+  // L0
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(2),
+                             Key(3)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  // Immutable memtable
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(1),
+                             Key(2)));
+  ASSERT_OK(static_cast_with_check<DBImpl>(db_)->TEST_SwitchMemtable());
+  std::string value;
+  ASSERT_TRUE(dbfull()->GetProperty(db_->DefaultColumnFamily(),
+                                    "rocksdb.num-immutable-mem-table", &value));
+  ASSERT_EQ(1, std::stoi(value));
+  // live memtable
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(0),
+                             Key(1)));
+  // this memtable is still active
+  ASSERT_TRUE(dbfull()->GetProperty(db_->DefaultColumnFamily(),
+                                    "rocksdb.num-immutable-mem-table", &value));
+  ASSERT_EQ(1, std::stoi(value));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  get_perf_context()->Reset();
+  iter->Seek(Key(0));
+  // Reseeked immutable memtable, L0 and L1
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 3);
+  VerifyIteratorReachesEnd(iter);
+  get_perf_context()->Reset();
+  iter->SeekForPrev(Key(1));
+  // Reseeked L0 and L1
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+  VerifyIteratorReachesEnd(iter);
+  get_perf_context()->Reset();
+  iter->SeekToFirst();
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 0);
+  VerifyIteratorReachesEnd(iter);
+  iter->SeekToLast();
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 0);
+  VerifyIteratorReachesEnd(iter);
+  delete iter;
+}
+
+TEST_F(DBRangeDelTest, ReseekDuringNextAndPrev) {
+  // Range tombstone triggers reseek during Next() in merging iterator.
+  // Test set up:
+  //    memtable has: [0, 1) [2, 3)
+  //    L0 has: 2
+  //    L1 has: 1, 2, 3
+  // Seek(0) will reseek 1 for all L0 and L1.
+  // Then Next() will try to reseek 3 for L0 and L1.
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+
+  DestroyAndReopen(options);
+  // L1
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), "foo"));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), "foo"));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(3), "foo"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+
+  // L0
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), "foo"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+
+  // Memtable
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(0),
+                             Key(1)));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(2),
+                             Key(3)));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  auto iter_test_forward = [&] {
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), Key(1));
+
+    get_perf_context()->Reset();
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), Key(3));
+    // Reseeked L0 and L1
+    ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+
+    // Next to Prev
+    get_perf_context()->Reset();
+    iter->Prev();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), Key(1));
+    // Reseeked L0 and L1
+    ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+
+    // Prev to Next
+    get_perf_context()->Reset();
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), Key(3));
+    // Reseeked L0 and L1
+    ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+
+    iter->Next();
+    VerifyIteratorReachesEnd(iter);
+  };
+
+  get_perf_context()->Reset();
+  iter->Seek(Key(0));
+  // Reseeked L0 and L1
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+  iter_test_forward();
+  iter->Seek(Key(1));
+  // Reseeked L0 and L1
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+  iter_test_forward();
+
+  get_perf_context()->Reset();
+  iter->SeekForPrev(Key(2));
+  // Reseeked L0 and L1
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+  iter_test_forward();
+  iter->SeekForPrev(Key(1));
+  // Reseeked L0 and L1
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+  iter_test_forward();
+
+  get_perf_context()->Reset();
+  iter->SeekToFirst();
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 0);
+  iter_test_forward();
+
+  iter->SeekToLast();
+  iter->Prev();
+  iter_test_forward();
+  delete iter;
+}
+
+TEST_F(DBRangeDelTest, TombstoneFromCurrentLevel) {
+  // Range tombstone triggers reseek when covering key from the same level.
+  // in merging iterator. Test set up:
+  //    memtable has: [0, 1)
+  //    L0 has: [2, 3), 2
+  //    L1 has: 1, 2, 3
+  // Seek(0) will reseek at 1 for L0 and L1.
+  // Then Next() reseek at 3
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+
+  DestroyAndReopen(options);
+  // L1
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), "foo"));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), "foo"));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(3), "foo"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+
+  // L0
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), "foo"));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(2),
+                             Key(3)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+
+  // Memtable
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(0),
+                             Key(1)));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  get_perf_context()->Reset();
+  iter->Seek(Key(0));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(1));
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 2);
+
+  get_perf_context()->Reset();
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(3));
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 1);
+
+  delete iter;
+}
+
+TEST_F(DBRangeDelTest, TombstoneAcrossFileBoundary) {
+  // Verify that a range tombstone across file boundary covers keys from older
+  // levels. Test set up:
+  //    L1_0: 1, 3, [2, 6)   L1_1: 5, 7, [2, 6) (this is from compaction with
+  //    L1_0) L2 has: 4
+  // Seek(1) and Next() should move the L1 level iterator to
+  // L1_1. Check if 4 is returned after Next().
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 2 * 1024;
+  options.max_compaction_bytes = 2 * 1024;
+
+  DestroyAndReopen(options);
+
+  Random rnd(301);
+  // L2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(4), rnd.RandomString(1 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // L1_1
+  ASSERT_OK(db_->Put(WriteOptions(), Key(5), rnd.RandomString(1 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(7), rnd.RandomString(1 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+
+  // L1_0
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), rnd.RandomString(1 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(3), rnd.RandomString(1 << 10)));
+  // Prevent keys being compacted away
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(2),
+                             Key(6)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_EQ(2, NumTableFilesAtLevel(0));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(2, NumTableFilesAtLevel(1));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  get_perf_context()->Reset();
+  iter->Seek(Key(1));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(1));
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(7));
+  // 1 reseek into L2 when key 4 in L2 is covered by [2, 6) from L1
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 1);
+
+  delete iter;
+  db_->ReleaseSnapshot(snapshot);
+  ;
+}
+
+TEST_F(DBRangeDelTest, NonOverlappingTombstonAtBoundary) {
+  // Verify that a range tombstone across file boundary covers keys from older
+  // levels. Test set up:
+  //    L1_0: 1, 3, [4, 7)         L1_1: 6, 8, [4, 7)
+  //    L2: 5
+  // [4, 7) from L1_0 should cover 5 is sentinel works
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 2 * 1024;
+  DestroyAndReopen(options);
+
+  Random rnd(301);
+  // L2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(5), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // L1_1
+  ASSERT_OK(db_->Put(WriteOptions(), Key(6), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(8), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+
+  // L1_0
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(3), rnd.RandomString(4 << 10)));
+  // Prevent keys being compacted away
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(4),
+                             Key(7)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_EQ(2, NumTableFilesAtLevel(0));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(2, NumTableFilesAtLevel(1));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  iter->Seek(Key(3));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key(), Key(3));
+  get_perf_context()->Reset();
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(8));
+  // 1 reseek into L1
+  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 1);
+  for (auto& k : {4, 5, 6}) {
+    get_perf_context()->Reset();
+    iter->Seek(Key(k));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key().ToString(), Key(8));
+    // 1 reseek into L1
+    ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 1);
+  }
+  delete iter;
+}
+
+TEST_F(DBRangeDelTest, OlderLevelHasNewerData) {
+  // L1_0: 1, 3, [2, 7)   L1_1: 5, 6 at a newer sequence number than [2, 7)
+  // Compact L1_1 to L2. Seek(3) should not skip 6.
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 3 * 1024;
+  DestroyAndReopen(options);
+
+  Random rnd(301);
+  // L1_0
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(3), rnd.RandomString(4 << 10)));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(2),
+                             Key(7)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+
+  // L1_1
+  ASSERT_OK(db_->Put(WriteOptions(), Key(5), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(6), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(2, NumTableFilesAtLevel(1));
+
+  Slice begin(Key(6));
+  EXPECT_OK(dbfull()->TEST_CompactRange(1, &begin, nullptr));
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  iter->Seek(Key(3));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(5));
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key().ToString(), Key(6));
+  delete iter;
+  db_->ReleaseSnapshot(snapshot);
+}
+
+TEST_F(DBRangeDelTest, LevelBoundaryDefinedByTombstone) {
+  // L1 has: 1, 2, [4, 5)
+  // L2 has: 4
+  // Seek(3), which is over all points keys in L1, check whether
+  // sentinel key from L1 works in this case.
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 3 * 1024;
+  DestroyAndReopen(options);
+  Random rnd(301);
+  // L2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(4), "foo"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  const Snapshot* snapshot = db_->GetSnapshot();
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // L1_0
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(4),
+                             Key(5)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  iter->Seek(Key(3));
+  ASSERT_TRUE(!iter->Valid());
+  ASSERT_OK(iter->status());
+
+  get_perf_context()->Reset();
+  iter->SeekForPrev(Key(5));
+  // This is not reseeked in SeekForPrevImpl, but could be optimized to.
+  //  ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count, 1);
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key(), Key(2));
+  db_->ReleaseSnapshot(snapshot);
+  delete iter;
+}
+
+TEST_F(DBRangeDelTest, TombstoneOnlyFile) {
+  // L1_0: 1, 2, L1_1: [3, 5)
+  // L2: 3
+  // Seek(2) then Next() which advance L1 iterator into L1_1.
+  // If sentinel works with tombstone only file, it should cover the key in L2.
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 3 * 1024;
+
+  DestroyAndReopen(options);
+  Random rnd(301);
+  // L2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(3), "foo"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // L1_0
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // L1_1
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(3),
+                             Key(5)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(2, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  iter->Seek(Key(2));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key(), Key(2));
+  iter->Next();
+  VerifyIteratorReachesEnd(iter);
+  iter->SeekForPrev(Key(4));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key(), Key(2));
+  iter->Next();
+  VerifyIteratorReachesEnd(iter);
+  delete iter;
+}
+
+void VerifyIteratorKey(InternalIterator* iter,
+                       std::vector<std::string> expected_keys,
+                       bool forward = true) {
+  for (auto& key : expected_keys) {
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->user_key(), key);
+    if (forward) {
+      iter->Next();
+    } else {
+      iter->Prev();
+    }
+  }
+}
+
+TEST_F(DBRangeDelTest, TombstoneOnlyLevel) {
+  // L1 [3, 5)
+  // L2 has: 3, 4
+  // Any kind of iterator seek should skip 4.
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 3 * 1024;
+
+  DestroyAndReopen(options);
+  // L2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(3), "foo"));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(4), "bar"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // L1
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(3),
+                             Key(5)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  get_perf_context()->Reset();
+  uint64_t expected_reseek = 0;
+  for (auto i = 0; i < 7; ++i) {
+    iter->Seek(Key(i));
+    VerifyIteratorReachesEnd(iter);
+    if (i < 5) {
+      ++expected_reseek;
+    }
+    ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count,
+              expected_reseek);
+    iter->SeekForPrev(Key(i));
+    VerifyIteratorReachesEnd(iter);
+    if (i > 2) {
+      ++expected_reseek;
+    }
+    ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count,
+              expected_reseek);
+    iter->SeekToFirst();
+    VerifyIteratorReachesEnd(iter);
+    ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count,
+              ++expected_reseek);
+    iter->SeekToLast();
+    VerifyIteratorReachesEnd(iter);
+    ASSERT_EQ(get_perf_context()->internal_range_del_reseek_count,
+              ++expected_reseek);
+  }
+
+  ColumnFamilyData* cfd =
+      static_cast_with_check<ColumnFamilyHandleImpl>(db_->DefaultColumnFamily())
+          ->cfd();
+  SuperVersion* sv = cfd->GetSuperVersion();
+  Arena arena;
+  ReadOptions read_options;
+  MergeIteratorBuilder merge_iter_builder(&cfd->internal_comparator(), &arena,
+                                          false /* prefix seek */);
+  InternalIterator* level_iter = sv->current->TEST_GetLevelIterator(
+      read_options, &merge_iter_builder, 1 /* level */,
+      nullptr /* range_del_aggregator */, true);
+  auto k = Key(3);
+  IterKey target;
+  target.SetInternalKey(k, kMaxSequenceNumber, kValueTypeForSeek);
+  level_iter->Seek(target.GetInternalKey());
+  VerifyIteratorKey(level_iter, {Key(5)});
+  VerifyIteratorReachesEnd(level_iter);
+
+  k = Key(5);
+  target.SetInternalKey(k, 0, kValueTypeForSeekForPrev);
+  level_iter->SeekForPrev(target.GetInternalKey());
+  VerifyIteratorKey(level_iter, {Key(3)}, false);
+  VerifyIteratorReachesEnd(iter);
+
+  level_iter->SeekToFirst();
+  VerifyIteratorKey(level_iter, {Key(5)});
+  VerifyIteratorReachesEnd(iter);
+
+  level_iter->SeekToLast();
+  VerifyIteratorKey(level_iter, {Key(3)}, false);
+  VerifyIteratorReachesEnd(iter);
+
+  delete iter;
+  delete level_iter;
+}
+
+TEST_F(DBRangeDelTest, TombstoneOnlyWithVisibleKey) {
+  // L1: [3, 5)
+  // L2: 2, 4, 5
+  // 2 and 5 should be visible
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 3 * 1024;
+
+  DestroyAndReopen(options);
+  // L2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), "foo"));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(4), "bar"));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(5), "foobar"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // l1
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(3),
+                             Key(5)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  auto iter_test_backward = [&] {
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key(), Key(5));
+    iter->Prev();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key(), Key(2));
+    iter->Prev();
+    VerifyIteratorReachesEnd(iter);
+  };
+  auto iter_test_forward = [&] {
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key(), Key(2));
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(iter->key(), Key(5));
+    iter->Next();
+    VerifyIteratorReachesEnd(iter);
+  };
+  iter->Seek(Key(4));
+  iter_test_backward();
+  iter->SeekForPrev(Key(4));
+  iter->Next();
+  iter_test_backward();
+
+  iter->Seek(Key(4));
+  iter->Prev();
+  iter_test_forward();
+  iter->SeekForPrev(Key(4));
+  iter_test_forward();
+
+  iter->SeekToFirst();
+  iter_test_forward();
+  iter->SeekToLast();
+  iter_test_backward();
+
+  delete iter;
+}
+
+// Right sentinel tested in many test cases above
+TEST_F(DBRangeDelTest, LeftSentinelKeyTest) {
+  // L1_0: 0, 1    L1_1: [2, 3), 5
+  // L2: 2
+  // SeekForPrev(4) then Next() should give 1 due to sentinel key keeping
+  // [2, 3) alive.
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 3 * 1024;
+  options.max_compaction_bytes = 1024;
+
+  DestroyAndReopen(options);
+  // L2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), "foo"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // L1_0
+  Random rnd(301);
+  ASSERT_OK(db_->Put(WriteOptions(), Key(0), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+
+  // L1_1
+  ASSERT_OK(db_->Put(WriteOptions(), Key(5), "bar"));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(2),
+                             Key(3)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(2, NumTableFilesAtLevel(1));
+
+  auto iter = db_->NewIterator(ReadOptions());
+  iter->SeekForPrev(Key(4));
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key(), Key(1));
+  iter->Prev();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->key(), Key(0));
+  iter->Prev();
+  ASSERT_TRUE(!iter->Valid());
+  ASSERT_OK(iter->status());
+  delete iter;
+}
+
+TEST_F(DBRangeDelTest, LeftSentinelKeyTestWithNewerKey) {
+  // L1_0: 1, 2 and newer than L1_1,    L1_1: [2, 4), 5
+  // L2: 3
+  // SeekForPrev(4) then Next() should give 2 and then 1.
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 3 * 1024;
+  options.max_compaction_bytes = 1024;
+
+  DestroyAndReopen(options);
+  // L2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(3), "foo"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // L1_1
+  ASSERT_OK(db_->Put(WriteOptions(), Key(5), "bar"));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(2),
+                             Key(4)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+
+  // L1_0
+  Random rnd(301);
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), rnd.RandomString(4 << 10)));
+  auto seq = dbfull()->TEST_GetLastVisibleSequence();
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(2, NumTableFilesAtLevel(1));
+
+  Arena arena;
+  InternalKeyComparator icmp(options.comparator);
+  ReadOptions read_options;
+  ScopedArenaIterator iter;
+  iter.set(
+      dbfull()->NewInternalIterator(read_options, &arena, kMaxSequenceNumber));
+
+  auto k = Key(4);
+  IterKey target;
+  target.SetInternalKey(k, 0 /* sequence_number */, kValueTypeForSeekForPrev);
+  iter->SeekForPrev(target.GetInternalKey());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->user_key(), Key(2));
+  SequenceNumber actual_seq;
+  ValueType type;
+  UnPackSequenceAndType(ExtractInternalKeyFooter(iter->key()), &actual_seq,
+                        &type);
+  ASSERT_EQ(seq, actual_seq);
+  // might as well check type
+  ASSERT_EQ(type, kTypeValue);
+
+  iter->Prev();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(iter->user_key(), Key(1));
+  iter->Prev();
+  ASSERT_TRUE(!iter->Valid());
+  ASSERT_OK(iter->status());
+}
+
+TEST_F(DBRangeDelTest, SentinelKeyCommonCaseTest) {
+  // L1 has 3 files
+  // L1_0: 1, 2     L1_1: [3, 4) 5, 6, [7, 8)     L1_2: 9
+  // Check iterator operations on LevelIterator and DB Iter
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = 3 * 1024;
+
+  DestroyAndReopen(options);
+  Random rnd(301);
+  // L1_0
+  ASSERT_OK(db_->Put(WriteOptions(), Key(1), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(2), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+
+  // L1_1
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(3),
+                             Key(4)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(5), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Put(WriteOptions(), Key(6), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(7),
+                             Key(8)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(2, NumTableFilesAtLevel(1));
+
+  // L1_2
+  ASSERT_OK(db_->Put(WriteOptions(), Key(9), rnd.RandomString(4 << 10)));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(3, NumTableFilesAtLevel(1));
+
+  ColumnFamilyData* cfd =
+      static_cast_with_check<ColumnFamilyHandleImpl>(db_->DefaultColumnFamily())
+          ->cfd();
+  SuperVersion* sv = cfd->GetSuperVersion();
+  Arena arena;
+  ReadOptions read_options;
+  MergeIteratorBuilder merge_iter_builder(&cfd->internal_comparator(), &arena,
+                                          false /* prefix seek */);
+  InternalIterator* level_iter = sv->current->TEST_GetLevelIterator(
+      read_options, &merge_iter_builder, 1 /* level */,
+      nullptr /* range_del_aggregator */, true);
+  auto k = Key(7);
+  IterKey target;
+  target.SetInternalKey(k, kMaxSequenceNumber, kValueTypeForSeek);
+  level_iter->Seek(target.GetInternalKey());
+  VerifyIteratorKey(level_iter, {Key(8), Key(9)});
+  ASSERT_TRUE(!level_iter->Valid() && level_iter->status().ok());
+
+  k = Key(6);
+  target.SetInternalKey(k, kMaxSequenceNumber, kValueTypeForSeek);
+  level_iter->Seek(target.GetInternalKey());
+  VerifyIteratorKey(level_iter, {Key(6), Key(8), Key(9)});
+
+  k = Key(4);
+  target.SetInternalKey(k, 0, kValueTypeForSeekForPrev);
+  level_iter->SeekForPrev(target.GetInternalKey());
+  VerifyIteratorKey(level_iter, {Key(3), Key(2), Key(1)}, false);
+
+  k = Key(5);
+  target.SetInternalKey(k, 0, kValueTypeForSeekForPrev);
+  level_iter->SeekForPrev(target.GetInternalKey());
+  VerifyIteratorKey(level_iter, {Key(5), Key(3), Key(2), Key(1)}, false);
+
+  level_iter->SeekToFirst();
+  VerifyIteratorKey(level_iter,
+                    {Key(1), Key(2), Key(5), Key(6), Key(8), Key(9)});
+
+  level_iter->SeekToLast();
+  VerifyIteratorKey(level_iter,
+                    {Key(9), Key(6), Key(5), Key(3), Key(2), Key(1)}, false);
+
+  delete level_iter;
 }
 
 #endif  // ROCKSDB_LITE

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -2295,6 +2295,8 @@ TEST_F(DBRangeDelTest, TombstoneOnlyLevel) {
   InternalIterator* level_iter = sv->current->TEST_GetLevelIterator(
       read_options, &merge_iter_builder, 1 /* level */,
       nullptr /* range_del_aggregator */, true);
+  // This is needed to make LevelIterator range tombstone aware
+  merge_iter_builder.Finish();
   auto k = Key(3);
   IterKey target;
   target.SetInternalKey(k, kMaxSequenceNumber, kValueTypeForSeek);
@@ -2541,6 +2543,8 @@ TEST_F(DBRangeDelTest, SentinelKeyCommonCaseTest) {
   InternalIterator* level_iter = sv->current->TEST_GetLevelIterator(
       read_options, &merge_iter_builder, 1 /* level */,
       nullptr /* range_del_aggregator */, true);
+  // This is needed to make LevelIterator range tombstone aware
+  merge_iter_builder.Finish();
   auto k = Key(7);
   IterKey target;
   target.SetInternalKey(k, kMaxSequenceNumber, kValueTypeForSeek);

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -2601,31 +2601,37 @@ TEST_F(DBRangeDelTest, SentinelKeyCommonCaseTest) {
   IterKey target;
   target.SetInternalKey(k, kMaxSequenceNumber, kValueTypeForSeek);
   level_iter->Seek(target.GetInternalKey());
-  VerifyIteratorKey(level_iter, {Key(8), Key(9)});
+  VerifyIteratorKey(level_iter, {Key(8), Key(9), Key(9)});
   ASSERT_TRUE(!level_iter->Valid() && level_iter->status().ok());
 
   k = Key(6);
   target.SetInternalKey(k, kMaxSequenceNumber, kValueTypeForSeek);
   level_iter->Seek(target.GetInternalKey());
-  VerifyIteratorKey(level_iter, {Key(6), Key(8), Key(9)});
+  VerifyIteratorKey(level_iter, {Key(6), Key(8), Key(9), Key(9)});
+  ASSERT_TRUE(!level_iter->Valid() && level_iter->status().ok());
 
   k = Key(4);
   target.SetInternalKey(k, 0, kValueTypeForSeekForPrev);
   level_iter->SeekForPrev(target.GetInternalKey());
-  VerifyIteratorKey(level_iter, {Key(3), Key(2), Key(1)}, false);
+  VerifyIteratorKey(level_iter, {Key(3), Key(2), Key(1), Key(1)}, false);
+  ASSERT_TRUE(!level_iter->Valid() && level_iter->status().ok());
 
   k = Key(5);
   target.SetInternalKey(k, 0, kValueTypeForSeekForPrev);
   level_iter->SeekForPrev(target.GetInternalKey());
-  VerifyIteratorKey(level_iter, {Key(5), Key(3), Key(2), Key(1)}, false);
+  VerifyIteratorKey(level_iter, {Key(5), Key(3), Key(2), Key(1), Key(1)},
+                    false);
 
   level_iter->SeekToFirst();
-  VerifyIteratorKey(level_iter,
-                    {Key(1), Key(2), Key(5), Key(6), Key(8), Key(9)});
+  VerifyIteratorKey(level_iter, {Key(1), Key(2), Key(2), Key(5), Key(6), Key(8),
+                                 Key(9), Key(9)});
+  ASSERT_TRUE(!level_iter->Valid() && level_iter->status().ok());
 
   level_iter->SeekToLast();
-  VerifyIteratorKey(level_iter,
-                    {Key(9), Key(6), Key(5), Key(3), Key(2), Key(1)}, false);
+  VerifyIteratorKey(
+      level_iter,
+      {Key(9), Key(9), Key(6), Key(5), Key(3), Key(2), Key(1), Key(1)}, false);
+  ASSERT_TRUE(!level_iter->Valid() && level_iter->status().ok());
 
   miter->~InternalIterator();
 }

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -2110,7 +2110,8 @@ TEST_F(DBRangeDelTest, OlderLevelHasNewerData) {
   MoveFilesToLevel(1);
   ASSERT_EQ(2, NumTableFilesAtLevel(1));
 
-  Slice begin(Key(6));
+  auto key = Key(6);
+  Slice begin(key);
   EXPECT_OK(dbfull()->TEST_CompactRange(1, &begin, nullptr));
   ASSERT_EQ(1, NumTableFilesAtLevel(1));
   ASSERT_EQ(1, NumTableFilesAtLevel(2));

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -2027,7 +2027,6 @@ TEST_F(DBRangeDelTest, TombstoneAcrossFileBoundary) {
 
   delete iter;
   db_->ReleaseSnapshot(snapshot);
-  ;
 }
 
 TEST_F(DBRangeDelTest, NonOverlappingTombstonAtBoundary) {

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -967,15 +967,14 @@ std::string DBTestBase::AllEntriesFor(const Slice& user_key, int cf) {
   Arena arena;
   auto options = CurrentOptions();
   InternalKeyComparator icmp(options.comparator);
-  ReadRangeDelAggregator range_del_agg(&icmp,
-                                       kMaxSequenceNumber /* upper_bound */);
   ReadOptions read_options;
+  read_options.ignore_range_deletions = true;
   ScopedArenaIterator iter;
   if (cf == 0) {
-    iter.set(dbfull()->NewInternalIterator(read_options, &arena, &range_del_agg,
+    iter.set(dbfull()->NewInternalIterator(read_options, &arena,
                                            kMaxSequenceNumber));
   } else {
-    iter.set(dbfull()->NewInternalIterator(read_options, &arena, &range_del_agg,
+    iter.set(dbfull()->NewInternalIterator(read_options, &arena,
                                            kMaxSequenceNumber, handles_[cf]));
   }
   InternalKey target(user_key, kMaxSequenceNumber, kTypeValue);
@@ -1431,17 +1430,14 @@ void DBTestBase::validateNumberOfEntries(int numValues, int cf) {
   Arena arena;
   auto options = CurrentOptions();
   InternalKeyComparator icmp(options.comparator);
-  ReadRangeDelAggregator range_del_agg(&icmp,
-                                       kMaxSequenceNumber /* upper_bound */);
-  // This should be defined after range_del_agg so that it destructs the
-  // assigned iterator before it range_del_agg is already destructed.
   ReadOptions read_options;
+  read_options.ignore_range_deletions = true;
   ScopedArenaIterator iter;
   if (cf != 0) {
-    iter.set(dbfull()->NewInternalIterator(read_options, &arena, &range_del_agg,
+    iter.set(dbfull()->NewInternalIterator(read_options, &arena,
                                            kMaxSequenceNumber, handles_[cf]));
   } else {
-    iter.set(dbfull()->NewInternalIterator(read_options, &arena, &range_del_agg,
+    iter.set(dbfull()->NewInternalIterator(read_options, &arena,
                                            kMaxSequenceNumber));
   }
   iter->SeekToFirst();
@@ -1646,11 +1642,10 @@ void DBTestBase::VerifyDBInternal(
     std::vector<std::pair<std::string, std::string>> true_data) {
   Arena arena;
   InternalKeyComparator icmp(last_options_.comparator);
-  ReadRangeDelAggregator range_del_agg(&icmp,
-                                       kMaxSequenceNumber /* upper_bound */);
   ReadOptions read_options;
-  auto iter = dbfull()->NewInternalIterator(read_options, &arena,
-                                            &range_del_agg, kMaxSequenceNumber);
+  read_options.ignore_range_deletions = true;
+  auto iter =
+      dbfull()->NewInternalIterator(read_options, &arena, kMaxSequenceNumber);
   iter->SeekToFirst();
   for (auto p : true_data) {
     ASSERT_TRUE(iter->Valid());

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -968,7 +968,6 @@ std::string DBTestBase::AllEntriesFor(const Slice& user_key, int cf) {
   auto options = CurrentOptions();
   InternalKeyComparator icmp(options.comparator);
   ReadOptions read_options;
-  read_options.ignore_range_deletions = true;
   ScopedArenaIterator iter;
   if (cf == 0) {
     iter.set(dbfull()->NewInternalIterator(read_options, &arena,
@@ -1431,7 +1430,6 @@ void DBTestBase::validateNumberOfEntries(int numValues, int cf) {
   auto options = CurrentOptions();
   InternalKeyComparator icmp(options.comparator);
   ReadOptions read_options;
-  read_options.ignore_range_deletions = true;
   ScopedArenaIterator iter;
   if (cf != 0) {
     iter.set(dbfull()->NewInternalIterator(read_options, &arena,
@@ -1643,7 +1641,6 @@ void DBTestBase::VerifyDBInternal(
   Arena arena;
   InternalKeyComparator icmp(last_options_.comparator);
   ReadOptions read_options;
-  read_options.ignore_range_deletions = true;
   auto iter =
       dbfull()->NewInternalIterator(read_options, &arena, kMaxSequenceNumber);
   iter->SeekToFirst();

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -139,7 +139,8 @@ inline size_t InternalKeyEncodingLength(const ParsedInternalKey& key) {
 // Pack a sequence number and a ValueType into a uint64_t
 inline uint64_t PackSequenceAndType(uint64_t seq, ValueType t) {
   assert(seq <= kMaxSequenceNumber);
-  assert(IsExtendedValueType(t));
+  // kTypeMaxValid is used in TruncatedRangeDelIterator, see its constructor.
+  assert(IsExtendedValueType(t) || t == kTypeMaxValid);
   return (seq << 8) | t;
 }
 

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -392,6 +392,13 @@ inline uint64_t GetInternalKeySeqno(const Slice& internal_key) {
   return num >> 8;
 }
 
+inline ValueType GetInternalKeyOpType(const Slice& internal_key) {
+  const size_t n = internal_key.size();
+  assert(n >= kNumInternalBytes);
+  uint64_t num = DecodeFixed64(internal_key.data() + n - kNumInternalBytes);
+  return static_cast<ValueType>(num & 0xff);
+}
+
 // The class to store keys in an efficient way. It allows:
 // 1. Users can either copy the key into it, or have it point to an unowned
 //    address.

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -393,13 +393,6 @@ inline uint64_t GetInternalKeySeqno(const Slice& internal_key) {
   return num >> 8;
 }
 
-inline ValueType GetInternalKeyOpType(const Slice& internal_key) {
-  const size_t n = internal_key.size();
-  assert(n >= kNumInternalBytes);
-  uint64_t num = DecodeFixed64(internal_key.data() + n - kNumInternalBytes);
-  return static_cast<ValueType>(num & 0xff);
-}
-
 // The class to store keys in an efficient way. It allows:
 // 1. Users can either copy the key into it, or have it point to an unowned
 //    address.

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -210,6 +210,29 @@ Status MemTableListVersion::AddRangeTombstoneIterators(
   return Status::OK();
 }
 
+Status MemTableListVersion::AddRangeTombstoneIterators(
+    const ReadOptions& read_opts, Arena* /*arena*/,
+    MergeIteratorBuilder& builder) {
+  // Except for snapshot read, using kMaxSequenceNumber is OK because these
+  // are immutable memtables.
+  SequenceNumber read_seq = read_opts.snapshot != nullptr
+                                ? read_opts.snapshot->GetSequenceNumber()
+                                : kMaxSequenceNumber;
+  for (auto& m : memlist_) {
+    auto range_del_iter = m->NewRangeTombstoneIterator(read_opts, read_seq, true /* immutale_memtable */);
+    if (range_del_iter == nullptr || range_del_iter->empty()) {
+      delete range_del_iter;
+      builder.AddRangeTombstoneIterator(nullptr);
+    } else {
+      builder.AddRangeTombstoneIterator(new TruncatedRangeDelIterator(
+          std::unique_ptr<FragmentedRangeTombstoneIterator>(range_del_iter),
+          &m->GetInternalKeyComparator(), nullptr /* smallest */,
+          nullptr /* largest */));
+    }
+  }
+  return Status::OK();
+}
+
 void MemTableListVersion::AddIterators(
     const ReadOptions& options, std::vector<InternalIterator*>* iterator_list,
     Arena* arena) {

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -219,7 +219,8 @@ Status MemTableListVersion::AddRangeTombstoneIterators(
                                 ? read_opts.snapshot->GetSequenceNumber()
                                 : kMaxSequenceNumber;
   for (auto& m : memlist_) {
-    auto range_del_iter = m->NewRangeTombstoneIterator(read_opts, read_seq, true /* immutale_memtable */);
+    auto range_del_iter = m->NewRangeTombstoneIterator(
+        read_opts, read_seq, true /* immutale_memtable */);
     if (range_del_iter == nullptr || range_del_iter->empty()) {
       delete range_del_iter;
       builder.AddRangeTombstoneIterator(nullptr);

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -111,6 +111,9 @@ class MemTableListVersion {
   Status AddRangeTombstoneIterators(const ReadOptions& read_opts, Arena* arena,
                                     RangeDelAggregator* range_del_agg);
 
+  Status AddRangeTombstoneIterators(const ReadOptions& read_opts, Arena* arena,
+                                    MergeIteratorBuilder& builder);
+
   void AddIterators(const ReadOptions& options,
                     std::vector<InternalIterator*>* iterator_list,
                     Arena* arena);

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -75,6 +75,7 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
 }
 
 bool TruncatedRangeDelIterator::Valid() const {
+  assert(iter_ != nullptr);
   return iter_->Valid() &&
          (smallest_ == nullptr ||
           icmp_->Compare(*smallest_, iter_->parsed_end_key()) < 0) &&

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -37,7 +37,6 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
                                          false /* log_err_key */);  // TODO
     pik_status.PermitUncheckedError();
     assert(pik_status.ok());
-
     smallest_ = &parsed_smallest;
   }
   if (largest != nullptr) {
@@ -69,6 +68,9 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
       // the truncated end key can cover the largest key in this sstable, reduce
       // its sequence number by 1.
       parsed_largest.sequence -= 1;
+      // This line is not needed for correctness, but it ensures that the
+      // truncated end key is not covering keys from the next SST file.
+      parsed_largest.type = kValueTypeForSeek;
     }
     largest_ = &parsed_largest;
   }

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -46,6 +46,7 @@ class TruncatedRangeDelIterator {
   // Seeks to the tombstone with the highest visible sequence number that covers
   // target (a user key). If no such tombstone exists, the position will be at
   // the earliest tombstone that ends after target.
+  // REQUIRES: target is a user key.
   void Seek(const Slice& target);
 
   // Seeks to the tombstone with the highest visible sequence number that covers

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -76,8 +76,9 @@ ParsedInternalKey UncutEndpoint(const Slice& s) {
   return ParsedInternalKey(s, kMaxSequenceNumber, kTypeRangeDeletion);
 }
 
-ParsedInternalKey InternalValue(const Slice& key, SequenceNumber seq) {
-  return ParsedInternalKey(key, seq, kTypeValue);
+ParsedInternalKey InternalValue(const Slice& key, SequenceNumber seq,
+                                ValueType type = kTypeValue) {
+  return ParsedInternalKey(key, seq, type);
 }
 
 void VerifyIterator(
@@ -292,16 +293,17 @@ TEST_F(RangeDelAggregatorTest, TruncatedIterPartiallyCutTombstones) {
   TruncatedRangeDelIterator iter(std::move(input_iter), &bytewise_icmp,
                                  &smallest, &largest);
 
-  VerifyIterator(&iter, bytewise_icmp,
-                 {{InternalValue("d", 7), UncutEndpoint("e"), 10},
-                  {UncutEndpoint("e"), UncutEndpoint("g"), 8},
-                  {UncutEndpoint("j"), InternalValue("m", 8), 4}});
+  VerifyIterator(
+      &iter, bytewise_icmp,
+      {{InternalValue("d", 7), UncutEndpoint("e"), 10},
+       {UncutEndpoint("e"), UncutEndpoint("g"), 8},
+       {UncutEndpoint("j"), InternalValue("m", 8, kValueTypeForSeek), 4}});
 
   VerifySeek(
       &iter, bytewise_icmp,
       {{"d", InternalValue("d", 7), UncutEndpoint("e"), 10},
        {"e", UncutEndpoint("e"), UncutEndpoint("g"), 8},
-       {"ia", UncutEndpoint("j"), InternalValue("m", 8), 4},
+       {"ia", UncutEndpoint("j"), InternalValue("m", 8, kValueTypeForSeek), 4},
        {"n", UncutEndpoint(""), UncutEndpoint(""), 0, true /* invalid */},
        {"", InternalValue("d", 7), UncutEndpoint("e"), 10}});
 
@@ -310,7 +312,7 @@ TEST_F(RangeDelAggregatorTest, TruncatedIterPartiallyCutTombstones) {
       {{"d", InternalValue("d", 7), UncutEndpoint("e"), 10},
        {"e", UncutEndpoint("e"), UncutEndpoint("g"), 8},
        {"ia", UncutEndpoint("e"), UncutEndpoint("g"), 8},
-       {"n", UncutEndpoint("j"), InternalValue("m", 8), 4},
+       {"n", UncutEndpoint("j"), InternalValue("m", 8, kValueTypeForSeek), 4},
        {"", UncutEndpoint(""), UncutEndpoint(""), 0, true /* invalid */}});
 }
 

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -303,7 +303,8 @@ TEST_F(RangeDelAggregatorTest, TruncatedIterPartiallyCutTombstones) {
       &iter, bytewise_icmp,
       {{"d", InternalValue("d", 7), UncutEndpoint("e"), 10},
        {"e", UncutEndpoint("e"), UncutEndpoint("g"), 8},
-       {"ia", UncutEndpoint("j"), InternalValue("m", 8, kValueTypeForSeek), 4},
+       {"ia", UncutEndpoint("j"), InternalValue("m", 8, kValueTypeForSeek), 4,
+        false /* invalid */},
        {"n", UncutEndpoint(""), UncutEndpoint(""), 0, true /* invalid */},
        {"", InternalValue("d", 7), UncutEndpoint("e"), 10}});
 
@@ -312,7 +313,8 @@ TEST_F(RangeDelAggregatorTest, TruncatedIterPartiallyCutTombstones) {
       {{"d", InternalValue("d", 7), UncutEndpoint("e"), 10},
        {"e", UncutEndpoint("e"), UncutEndpoint("g"), 8},
        {"ia", UncutEndpoint("e"), UncutEndpoint("g"), 8},
-       {"n", UncutEndpoint("j"), InternalValue("m", 8, kValueTypeForSeek), 4},
+       {"n", UncutEndpoint("j"), InternalValue("m", 8, kValueTypeForSeek), 4,
+        false /* invalid */},
        {"", UncutEndpoint(""), UncutEndpoint(""), 0, true /* invalid */}});
 }
 

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -236,7 +236,8 @@ InternalIterator* TableCache::NewIterator(
     TableReaderCaller caller, Arena* arena, bool skip_filters, int level,
     size_t max_file_size_for_l0_meta_pin,
     const InternalKey* smallest_compaction_key,
-    const InternalKey* largest_compaction_key, bool allow_unprepared_value) {
+    const InternalKey* largest_compaction_key, bool allow_unprepared_value,
+    TruncatedRangeDelIterator** range_del_iter) {
   PERF_TIMER_GUARD(new_table_iterator_nanos);
 
   Status s;
@@ -281,25 +282,39 @@ InternalIterator* TableCache::NewIterator(
       *table_reader_ptr = table_reader;
     }
   }
-  if (s.ok() && range_del_agg != nullptr && !options.ignore_range_deletions) {
-    if (range_del_agg->AddFile(fd.GetNumber())) {
-      std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-          static_cast<FragmentedRangeTombstoneIterator*>(
-              table_reader->NewRangeTombstoneIterator(options)));
-      if (range_del_iter != nullptr) {
-        s = range_del_iter->status();
+  if (s.ok() && !options.ignore_range_deletions) {
+    if (range_del_iter != nullptr) {
+      auto new_range_del_iter =
+          table_reader->NewRangeTombstoneIterator(options);
+      if (new_range_del_iter == nullptr || new_range_del_iter->empty()) {
+        *range_del_iter = nullptr;
+      } else {
+        *range_del_iter = new TruncatedRangeDelIterator(
+            std::unique_ptr<FragmentedRangeTombstoneIterator>(
+                new_range_del_iter),
+            &icomparator, &file_meta.smallest, &file_meta.largest);
       }
-      if (s.ok()) {
-        const InternalKey* smallest = &file_meta.smallest;
-        const InternalKey* largest = &file_meta.largest;
-        if (smallest_compaction_key != nullptr) {
-          smallest = smallest_compaction_key;
+    }
+    if (range_del_agg != nullptr) {
+      if (range_del_agg->AddFile(fd.GetNumber())) {
+        std::unique_ptr<FragmentedRangeTombstoneIterator> new_range_del_iter(
+            static_cast<FragmentedRangeTombstoneIterator*>(
+                table_reader->NewRangeTombstoneIterator(options)));
+        if (new_range_del_iter != nullptr) {
+          s = new_range_del_iter->status();
         }
-        if (largest_compaction_key != nullptr) {
-          largest = largest_compaction_key;
+        if (s.ok()) {
+          const InternalKey* smallest = &file_meta.smallest;
+          const InternalKey* largest = &file_meta.largest;
+          if (smallest_compaction_key != nullptr) {
+            smallest = smallest_compaction_key;
+          }
+          if (largest_compaction_key != nullptr) {
+            largest = largest_compaction_key;
+          }
+          range_del_agg->AddTombstones(std::move(new_range_del_iter), smallest,
+                                       largest);
         }
-        range_del_agg->AddTombstones(std::move(range_del_iter), smallest,
-                                     largest);
       }
     }
   }

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -287,6 +287,7 @@ InternalIterator* TableCache::NewIterator(
       auto new_range_del_iter =
           table_reader->NewRangeTombstoneIterator(options);
       if (new_range_del_iter == nullptr || new_range_del_iter->empty()) {
+        delete new_range_del_iter;
         *range_del_iter = nullptr;
       } else {
         *range_del_iter = new TruncatedRangeDelIterator(

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -63,6 +63,10 @@ class TableCache {
   // the returned iterator.  The returned "*table_reader_ptr" object is owned
   // by the cache and should not be deleted, and is valid for as long as the
   // returned iterator is live.
+  // If !options.ignore_range_deletions, and range_del_iter is non-nullptr,
+  // then range_del_iter is set to a range tombstone iterator
+  // for the specified file number. The upper/lower bounds for the
+  // TruncatedRangeDelIterator are set to the file's boundary.
   // @param options Must outlive the returned iterator.
   // @param range_del_agg If non-nullptr, adds range deletions to the
   //    aggregator. If an error occurs, returns it in a NewErrorInternalIterator
@@ -79,7 +83,8 @@ class TableCache {
       TableReaderCaller caller, Arena* arena, bool skip_filters, int level,
       size_t max_file_size_for_l0_meta_pin,
       const InternalKey* smallest_compaction_key,
-      const InternalKey* largest_compaction_key, bool allow_unprepared_value);
+      const InternalKey* largest_compaction_key, bool allow_unprepared_value,
+      TruncatedRangeDelIterator** range_del_iter = nullptr);
 
   // If a seek to internal key "k" in specified file finds an entry,
   // call get_context->SaveValue() repeatedly until

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -64,9 +64,10 @@ class TableCache {
   // by the cache and should not be deleted, and is valid for as long as the
   // returned iterator is live.
   // If !options.ignore_range_deletions, and range_del_iter is non-nullptr,
-  // then range_del_iter is set to a range tombstone iterator
-  // for the specified file number. The upper/lower bounds for the
-  // TruncatedRangeDelIterator are set to the file's boundary.
+  // then range_del_iter is set to a TruncatedRangeDelIterator for range
+  // tombstones in the SST file corresponding to the specified file number. The
+  // upper/lower bounds for the TruncatedRangeDelIterator are set to the SST
+  // file's boundary.
   // @param options Must outlive the returned iterator.
   // @param range_del_agg If non-nullptr, adds range deletions to the
   //    aggregator. If an error occurs, returns it in a NewErrorInternalIterator

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1828,7 +1828,7 @@ InternalIterator* Version::TEST_GetLevelIterator(
     const ReadOptions& read_options, MergeIteratorBuilder* merge_iter_builder,
     int level, RangeDelAggregator* range_del_agg, bool allow_unprepared_value) {
   return new LevelIterator(
-      cfd_->table_cache(), read_options, FileOptions(),
+      cfd_->table_cache(), read_options, file_options_,
       cfd_->internal_comparator(), &storage_info_.LevelFilesBrief(level),
       mutable_cf_options_.prefix_extractor, should_sample_file_read(),
       cfd_->internal_stats()->GetFileReadHist(level),

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1964,7 +1964,7 @@ void Version::AddIteratorsForLevel(const ReadOptions& read_options,
       const auto& file = storage_info_.LevelFilesBrief(0).files[i];
       merge_iter_builder->AddIterator(cfd_->table_cache()->NewIterator(
           read_options, soptions, cfd_->internal_comparator(),
-          *file.file_metadata, /*range_del_aggregator=*/nullptr,
+          *file.file_metadata, /*range_del_agg=*/nullptr,
           mutable_cf_options_.prefix_extractor, nullptr,
           cfd_->internal_stats()->GetFileReadHist(0),
           TableReaderCaller::kUserIterator, arena,
@@ -1995,7 +1995,7 @@ void Version::AddIteratorsForLevel(const ReadOptions& read_options,
         mutable_cf_options_.prefix_extractor, should_sample_file_read(),
         cfd_->internal_stats()->GetFileReadHist(level),
         TableReaderCaller::kUserIterator, IsFilterSkipped(level), level,
-        /*range_del_aggregator=*/nullptr, /*compaction_boundaries=*/nullptr,
+        /*range_del_agg=*/nullptr, /*compaction_boundaries=*/nullptr,
         allow_unprepared_value, merge_iter_builder));
   }
 }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -963,8 +963,7 @@ class Version {
 
   InternalIterator* TEST_GetLevelIterator(
       const ReadOptions& read_options, MergeIteratorBuilder* merge_iter_builder,
-      int level, RangeDelAggregator* range_del_agg,
-      bool allow_unprepared_value);
+      int level, bool allow_unprepared_value);
 
  private:
   Env* env_;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1453,11 +1453,6 @@ class VersionSet {
     AppendVersion(cfd, version);
   }
 
-  InternalIterator* TEST_GetLevelIterator(
-      const ReadOptions& read_options, MergeIteratorBuilder* merge_iter_builder,
-      int level, RangeDelAggregator* range_del_agg,
-      bool allow_unprepared_value);
-
  protected:
   using VersionBuilderMap =
       UnorderedMap<uint32_t, std::unique_ptr<BaseReferencedVersionBuilder>>;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -803,7 +803,6 @@ class Version {
   void AddIterators(const ReadOptions& read_options,
                     const FileOptions& soptions,
                     MergeIteratorBuilder* merger_iter_builder,
-                    RangeDelAggregator* range_del_agg,
                     bool allow_unprepared_value);
 
   // @param read_options Must outlive any iterator built by
@@ -811,8 +810,7 @@ class Version {
   void AddIteratorsForLevel(const ReadOptions& read_options,
                             const FileOptions& soptions,
                             MergeIteratorBuilder* merger_iter_builder,
-                            int level, RangeDelAggregator* range_del_agg,
-                            bool allow_unprepared_value);
+                            int level, bool allow_unprepared_value);
 
   Status OverlapWithLevelIterator(const ReadOptions&, const FileOptions&,
                                   const Slice& smallest_user_key,
@@ -962,6 +960,11 @@ class Version {
   const MutableCFOptions& GetMutableCFOptions() { return mutable_cf_options_; }
 
   Status VerifySstUniqueIds() const;
+
+  InternalIterator* TEST_GetLevelIterator(
+      const ReadOptions& read_options, MergeIteratorBuilder* merge_iter_builder,
+      int level, RangeDelAggregator* range_del_agg,
+      bool allow_unprepared_value);
 
  private:
   Env* env_;
@@ -1449,6 +1452,11 @@ class VersionSet {
     version->PrepareAppend(mutable_cf_options, update_stats);
     AppendVersion(cfd, version);
   }
+
+  InternalIterator* TEST_GetLevelIterator(
+      const ReadOptions& read_options, MergeIteratorBuilder* merge_iter_builder,
+      int level, RangeDelAggregator* range_del_agg,
+      bool allow_unprepared_value);
 
  protected:
   using VersionBuilderMap =

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1715,7 +1715,8 @@ enum {
   rocksdb_blob_read_time,
   rocksdb_blob_checksum_time,
   rocksdb_blob_decompress_time,
-  rocksdb_total_metric_count = 77
+  rocksdb_internal_range_del_reseek_count,
+  rocksdb_total_metric_count = 78
 };
 
 extern ROCKSDB_LIBRARY_API void rocksdb_set_perf_level(int);

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -124,7 +124,7 @@ struct PerfContext {
   // How many values were fed into merge operator by iterators.
   //
   uint64_t internal_merge_count;
-  // Number of times we reseeked inside a table iterator, specifically to skip
+  // Number of times we reseeked inside a merging iterator, specifically to skip
   // after or before a range of keys covered by a range deletion in a newer LSM
   // component.
   uint64_t internal_range_del_reseek_count;

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -124,6 +124,10 @@ struct PerfContext {
   // How many values were fed into merge operator by iterators.
   //
   uint64_t internal_merge_count;
+  // Number of times we reseeked inside a table iterator, specifically to skip
+  // after or before a range of keys covered by a range deletion in a newer LSM
+  // component.
+  uint64_t internal_range_del_reseek_count;
 
   uint64_t get_snapshot_time;        // total nanos spent on getting snapshot
   uint64_t get_from_memtable_time;   // total nanos spent on querying memtables

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -59,6 +59,7 @@ PerfContext::PerfContext(const PerfContext& other) {
   internal_delete_skipped_count = other.internal_delete_skipped_count;
   internal_recent_skipped_count = other.internal_recent_skipped_count;
   internal_merge_count = other.internal_merge_count;
+  internal_range_del_reseek_count = other.internal_range_del_reseek_count;
   write_wal_time = other.write_wal_time;
   get_snapshot_time = other.get_snapshot_time;
   get_from_memtable_time = other.get_from_memtable_time;
@@ -166,6 +167,7 @@ PerfContext::PerfContext(PerfContext&& other) noexcept {
   internal_delete_skipped_count = other.internal_delete_skipped_count;
   internal_recent_skipped_count = other.internal_recent_skipped_count;
   internal_merge_count = other.internal_merge_count;
+  internal_range_del_reseek_count = other.internal_range_del_reseek_count;
   write_wal_time = other.write_wal_time;
   get_snapshot_time = other.get_snapshot_time;
   get_from_memtable_time = other.get_from_memtable_time;
@@ -275,6 +277,7 @@ PerfContext& PerfContext::operator=(const PerfContext& other) {
   internal_delete_skipped_count = other.internal_delete_skipped_count;
   internal_recent_skipped_count = other.internal_recent_skipped_count;
   internal_merge_count = other.internal_merge_count;
+  internal_range_del_reseek_count = other.internal_range_del_reseek_count;
   write_wal_time = other.write_wal_time;
   get_snapshot_time = other.get_snapshot_time;
   get_from_memtable_time = other.get_from_memtable_time;
@@ -381,6 +384,7 @@ void PerfContext::Reset() {
   internal_delete_skipped_count = 0;
   internal_recent_skipped_count = 0;
   internal_merge_count = 0;
+  internal_range_del_reseek_count = 0;
   write_wal_time = 0;
 
   get_snapshot_time = 0;
@@ -509,6 +513,7 @@ std::string PerfContext::ToString(bool exclude_zero_counters) const {
   PERF_CONTEXT_OUTPUT(internal_delete_skipped_count);
   PERF_CONTEXT_OUTPUT(internal_recent_skipped_count);
   PERF_CONTEXT_OUTPUT(internal_merge_count);
+  PERF_CONTEXT_OUTPUT(internal_range_del_reseek_count);
   PERF_CONTEXT_OUTPUT(write_wal_time);
   PERF_CONTEXT_OUTPUT(get_snapshot_time);
   PERF_CONTEXT_OUTPUT(get_from_memtable_time);

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -186,11 +186,11 @@ class InternalIteratorBase : public Cleanable {
   // Default implementation is no-op and its implemented by iterators.
   virtual void SetReadaheadState(ReadaheadFileInfo* /*readahead_file_info*/) {}
 
-  // When used under merging iterator, LevelIterator treats some file boundary
-  // as key to prevent it from moving to next SST file before range tombstones
-  // in the current SST file are no longer needed. This method makes it cheap to
-  // check sentinel key. This should only be used by MergingIterator and
-  // LevelIterator for now.
+  // When used under merging iterator, LevelIterator treats file boundaries
+  // as sentinel keys to prevent it from moving to next SST file before range
+  // tombstones in the current SST file are no longer needed. This method makes
+  // it cheap to check if the current key is a sentinel key. This should only be
+  // used by MergingIterator and LevelIterator for now.
   virtual bool IsDeleteRangeSentinelKey() const { return false; }
 
  protected:

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -186,6 +186,13 @@ class InternalIteratorBase : public Cleanable {
   // Default implementation is no-op and its implemented by iterators.
   virtual void SetReadaheadState(ReadaheadFileInfo* /*readahead_file_info*/) {}
 
+  // When used under merging iterator, LevelIterator treats some file boundary
+  // as key to prevent it from moving to next SST file before range tombstones
+  // in the current SST file are no longer needed. This method makes it cheap to
+  // check sentinel key. This should only be used by MergingIterator and
+  // LevelIterator for now.
+  virtual bool IsDeleteRangeSentinelKey() const { return false; }
+
  protected:
   void SeekForPrevImpl(const Slice& target, const CompareInterface* cmp) {
     Seek(target);

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -162,7 +162,7 @@ class IteratorWrapperBase {
     }
   }
 
-  bool IsRangeDeleteSentinelKey() const {
+  bool IsDeleteRangeSentinelKey() const {
     return iter_->IsDeleteRangeSentinelKey();
   }
 

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -162,6 +162,10 @@ class IteratorWrapperBase {
     }
   }
 
+  bool IsRangeDeleteSentinelKey() const {
+    return iter_->IsDeleteRangeSentinelKey();
+  }
+
  private:
   void Update() {
     valid_ = iter_->Valid();

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -8,8 +8,8 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "table/merging_iterator.h"
-#include <string>
-#include <vector>
+
+#include "db/arena_wrapped_db_iter.h"
 #include "db/dbformat.h"
 #include "db/pinned_iterators_manager.h"
 #include "memory/arena.h"
@@ -31,8 +31,6 @@ namespace {
 using MergerMaxIterHeap = BinaryHeap<IteratorWrapper*, MaxIteratorComparator>;
 using MergerMinIterHeap = BinaryHeap<IteratorWrapper*, MinIteratorComparator>;
 }  // namespace
-
-const size_t kNumIterReserve = 4;
 
 class MergingIterator : public InternalIterator {
  public:
@@ -68,7 +66,24 @@ class MergingIterator : public InternalIterator {
     current_ = nullptr;
   }
 
+  // Merging iterator can optionally process range deletions: if a key is
+  // covered by a range deletion, the merging iterator will not output it but
+  // skip it.
+  //
+  // Add next range tombstone iterator to this merging iterator.
+  // There must be either no range tombstone iterator, or same number of
+  // range tombstone iterators as point iterators after all range tombstone
+  // iters are added. The i-th added range tombstone iterator and the i-th point
+  // iterator must point to the same sorted run.
+  void AddRangeTombstoneIterator(TruncatedRangeDelIterator* iter) {
+    child_range_tombstones_.emplace_back(iter);
+  }
+
   ~MergingIterator() override {
+    for (auto child : child_range_tombstones_) {
+      delete child;
+    }
+
     for (auto& child : children_) {
       child.DeleteIter(is_arena_mode_);
     }
@@ -86,6 +101,17 @@ class MergingIterator : public InternalIterator {
       child.SeekToFirst();
       AddToMinHeapOrCheckStatus(&child);
     }
+    for (auto& range_tombstone_iter : child_range_tombstones_) {
+      if (range_tombstone_iter != nullptr) {
+        // nullptr means no tombstones for this level
+        range_tombstone_iter->SeekToFirst();
+      }
+    }
+
+    if (!child_range_tombstones_.empty()) {
+      // Skip range tombstone covered keys
+      FindNextVisibleEntry();
+    }
     direction_ = kForward;
     current_ = CurrentForward();
   }
@@ -98,48 +124,50 @@ class MergingIterator : public InternalIterator {
       child.SeekToLast();
       AddToMaxHeapOrCheckStatus(&child);
     }
+    for (auto& range_tombstone_iter : child_range_tombstones_) {
+      if (range_tombstone_iter != nullptr) {
+        range_tombstone_iter->SeekToLast();
+      }
+    }
+
+    if (!child_range_tombstones_.empty()) {
+      // Skip range tombstone covered keys
+      FindPrevUserEntry();
+    }
     direction_ = kReverse;
     current_ = CurrentReverse();
   }
 
+  // Position this merging iterator at the first key >= target (internal key).
+  // If range tombstones are present, keys covered by range tombstones are
+  // skipped, and this merging iter points to the first non-range-deleted key >=
+  // target after Seek(). If !Valid() and status().ok() then end of the iterator
+  // is reached.
+  //
+  // Internally, this involves positioning all child iterators at the first key
+  // >= target. If range tombstones are present, we apply a similar technique of
+  // cascading seek as in Pebble (https://github.com/cockroachdb/pebble).
+  // Specifically, if there is a range tombstone that covers the target key at
+  // level L, then we know this range tombstone covers the range [target, range
+  // tombstone end) for all levels > L. So for all levels > L, we can do seek on
+  // the range tombstone end key instead of target. This optimization is applied
+  // at each level and hence the name "cascading seek". After a round of
+  // (cascading) seeks, the top of the heap is checked to see if it is covered
+  // by a range tombstone (see FindNextVisibleEntry() for more detail), and
+  // advanced if so. The process is repeated until a visible key is at the top
+  // of the heap.
+  // TODO: consider user defined timestamp?
   void Seek(const Slice& target) override {
-    ClearHeaps();
-    status_ = Status::OK();
-    for (auto& child : children_) {
-      {
-        PERF_TIMER_GUARD(seek_child_seek_time);
-        child.Seek(target);
-      }
-
-      PERF_COUNTER_ADD(seek_child_seek_count, 1);
-
-      // child.status() is set to Status::TryAgain indicating asynchronous
-      // request for retrieval of data blocks has been submitted. So it should
-      // return at this point and Seek should be called again to retrieve the
-      // requested block and add the child to min heap.
-      if (child.status() == Status::TryAgain()) {
-        continue;
-      }
-      {
-        // Strictly, we timed slightly more than min heap operation,
-        // but these operations are very cheap.
-        PERF_TIMER_GUARD(seek_min_heap_time);
-        AddToMinHeapOrCheckStatus(&child);
-      }
-    }
-
-    for (auto& child : children_) {
-      if (child.status() == Status::TryAgain()) {
-        child.Seek(target);
-        {
-          PERF_TIMER_GUARD(seek_min_heap_time);
-          AddToMinHeapOrCheckStatus(&child);
-        }
-        PERF_COUNTER_ADD(number_async_seek, 1);
-      }
+    assert(child_range_tombstones_.empty() ||
+           child_range_tombstones_.size() == children_.size());
+    SeekImpl(target);
+    if (!child_range_tombstones_.empty()) {
+      // Skip range tombstone covered keys
+      FindNextVisibleEntry();
     }
 
     direction_ = kForward;
+
     {
       PERF_TIMER_GUARD(seek_min_heap_time);
       current_ = CurrentForward();
@@ -147,22 +175,14 @@ class MergingIterator : public InternalIterator {
   }
 
   void SeekForPrev(const Slice& target) override {
-    ClearHeaps();
-    InitMaxHeap();
-    status_ = Status::OK();
-
-    for (auto& child : children_) {
-      {
-        PERF_TIMER_GUARD(seek_child_seek_time);
-        child.SeekForPrev(target);
-      }
-      PERF_COUNTER_ADD(seek_child_seek_count, 1);
-
-      {
-        PERF_TIMER_GUARD(seek_max_heap_time);
-        AddToMaxHeapOrCheckStatus(&child);
-      }
+    assert(child_range_tombstones_.empty() ||
+           child_range_tombstones_.size() == children_.size());
+    SeekForPrevImpl(target);
+    if (!child_range_tombstones_.empty()) {
+      // Skip range tombstone covered keys
+      FindPrevUserEntry();
     }
+
     direction_ = kReverse;
     {
       PERF_TIMER_GUARD(seek_max_heap_time);
@@ -178,9 +198,9 @@ class MergingIterator : public InternalIterator {
     // true for all of the non-current children since current_ is
     // the smallest child and key() == current_->key().
     if (direction_ != kForward) {
-      SwitchToForward();
       // The loop advanced all non-current children to be > key() so current_
       // should still be strictly the smallest key.
+      SwitchToForward();
     }
 
     // For the heap modifications below to be correct, current_ must be the
@@ -199,6 +219,10 @@ class MergingIterator : public InternalIterator {
       // current stopped being valid, remove it from the heap.
       considerStatus(current_->status());
       minHeap_.pop();
+    }
+
+    if (!child_range_tombstones_.empty()) {
+      FindNextVisibleEntry();
     }
     current_ = CurrentForward();
   }
@@ -241,6 +265,11 @@ class MergingIterator : public InternalIterator {
       // current stopped being valid, remove it from the heap.
       considerStatus(current_->status());
       maxHeap_->pop();
+    }
+
+    if (!child_range_tombstones_.empty()) {
+      // Skip range tombstone covered keys
+      FindPrevUserEntry();
     }
     current_ = CurrentReverse();
   }
@@ -300,11 +329,27 @@ class MergingIterator : public InternalIterator {
   }
 
  private:
+  friend class MergeIteratorBuilder;
   // Clears heaps for both directions, used when changing direction or seeking
   void ClearHeaps();
   // Ensures that maxHeap_ is initialized when starting to go in the reverse
   // direction
   void InitMaxHeap();
+
+  // Advance this merging iterator until the current key (top of min heap) is
+  // not covered by any range tombstone or that there is no more keys (heap is
+  // empty). After this call, if Valid(), current_ points to the next key that
+  // is not covered by any range tombstone.
+  void FindNextVisibleEntry();
+  void FindPrevUserEntry();
+
+  void SeekImpl(const Slice& target, size_t starting_level = 0,
+                bool range_tombstone_reseek = false);
+
+  // Seek to fist key <= target key (internal key) for
+  // children_[starting_level:].
+  void SeekForPrevImpl(const Slice& target, size_t starting_level = 0,
+                       bool range_tombstone_reseek = false);
 
   bool is_arena_mode_;
   bool prefix_seek_mode_;
@@ -312,7 +357,24 @@ class MergingIterator : public InternalIterator {
   enum Direction : uint8_t { kForward, kReverse };
   Direction direction_;
   const InternalKeyComparator* comparator_;
-  autovector<IteratorWrapper, kNumIterReserve> children_;
+  // Uses vector instead of autovector to make GetChildIndex() work.
+  // We could also use an autovector with larger reserved size.
+  std::vector<IteratorWrapper> children_;
+  // child_range_tombstones_[i] contains range tombstones in sorted run
+  // that corresponds to children_[i].
+  // child_range_tombstones_.empty() means not handling range tombstones.
+  // child_range_tombstones[i] == nullptr means a sorted run does not have range
+  // tombstones.
+  std::vector<TruncatedRangeDelIterator*> child_range_tombstones_;
+  // Checks if top of the heap (current key) is covered by a range tombstone by
+  // It current key is covered by some range tombstone, its iter is advanced and
+  // heap property is maintained. Returns whether top of heap is deleted.
+  bool IsNextDeleted();
+  bool IsPrevDeleted();
+
+  // Return the index of child in children_.
+  // REQUIRES: child in children_.
+  size_t GetChildIndex(IteratorWrapper* child);
 
   // Cached pointer to child iterator with the current key, or nullptr if no
   // child iterators are valid.  This is the top of minHeap_ or maxHeap_
@@ -353,6 +415,401 @@ class MergingIterator : public InternalIterator {
   }
 };
 
+// Seek to fist key >= target key (internal key) for children_[starting_level:].
+// Cascading seek optimizations are applied if range tombstones are present (see
+// comment above Seek() for more).
+//
+// range_tombstone_reseek: whether this Seek is to some range tombstone end and
+// is part of a "cascading seek". This is used for recoding relevant
+// perf_context.
+void MergingIterator::SeekImpl(const Slice& target, size_t starting_level,
+                               bool range_tombstone_reseek) {
+  ClearHeaps();
+  status_ = Status::OK();
+  IterKey current_search_key;
+  current_search_key.SetInternalKey(target, false /* copy */);
+  // (level, target) pairs
+  autovector<std::pair<size_t, std::string>> pinned_prefetched_target;
+
+  for (auto level = starting_level; level < children_.size(); ++level) {
+    {
+      PERF_TIMER_GUARD(seek_child_seek_time);
+      children_[level].Seek(current_search_key.GetInternalKey());
+    }
+
+    if (range_tombstone_reseek) {
+      // we are seeking to end of some range tombstone from a newer sorted run
+      PERF_COUNTER_ADD(internal_range_del_reseek_count, 1);
+    }
+
+    PERF_COUNTER_ADD(seek_child_seek_count, 1);
+
+    if (!child_range_tombstones_.empty()) {
+      // avoids copying target key for async requests in range tombstone free
+      // path
+      if (children_[level].status().IsTryAgain()) {
+        // search target might change to some range tombstone end key, so
+        // we need to remember them for async requests.
+        pinned_prefetched_target.emplace_back(
+            level, current_search_key.GetInternalKey().ToString());
+      }
+      if (child_range_tombstones_[level] != nullptr) {
+        child_range_tombstones_[level]->Seek(current_search_key.GetUserKey());
+        // current_search_key < end_key guaranteed by the Seek() call above if
+        // Valid().
+        // Only interested in user key coverage since older sorted runs must
+        // have smaller sequence numbers than this tombstone.
+        //
+        // TODO: child_range_tombstones_[level]->seq() is the max covering
+        //  sequence number, can make it cheaper by not looking for max.
+        if (child_range_tombstones_[level]->Valid() &&
+            comparator_->user_comparator()->Compare(
+                child_range_tombstones_[level]->start_key().user_key,
+                current_search_key.GetUserKey()) <= 0 &&
+            child_range_tombstones_[level]->seq()) {
+          range_tombstone_reseek = true;
+          // covered by this range tombstone
+          current_search_key.SetInternalKey(
+              child_range_tombstones_[level]->end_key().user_key,
+              kMaxSequenceNumber);
+        }
+      }
+    }
+    // child.status() is set to Status::TryAgain indicating asynchronous
+    // request for retrieval of data blocks has been submitted. So it should
+    // return at this point and Seek should be called again to retrieve the
+    // requested block and add the child to min heap.
+    if (children_[level].status().IsTryAgain()) {
+      continue;
+    }
+    {
+      // Strictly, we timed slightly more than min heap operation,
+      // but these operations are very cheap.
+      PERF_TIMER_GUARD(seek_min_heap_time);
+      AddToMinHeapOrCheckStatus(&children_[level]);
+    }
+  }
+  for (size_t level = 0; level < starting_level; ++level) {
+    PERF_TIMER_GUARD(seek_min_heap_time);
+    AddToMinHeapOrCheckStatus(&children_[level]);
+  }
+
+  if (child_range_tombstones_.empty()) {
+    for (auto& child : children_) {
+      if (child.status().IsTryAgain()) {
+        child.Seek(target);
+        {
+          PERF_TIMER_GUARD(seek_min_heap_time);
+          AddToMinHeapOrCheckStatus(&child);
+        }
+        PERF_COUNTER_ADD(number_async_seek, 1);
+      }
+    }
+  } else {
+    for (auto& prefetch : pinned_prefetched_target) {
+      children_[prefetch.first].Seek(prefetch.second);
+      {
+        PERF_TIMER_GUARD(seek_min_heap_time);
+        AddToMinHeapOrCheckStatus(&children_[prefetch.first]);
+      }
+      PERF_COUNTER_ADD(number_async_seek, 1);
+    }
+  }
+}
+
+// Returns iff the current key (min heap top) is deleted (by some range
+// deletion), advance the iterator at heap top if so. Heap order is restored.
+// See FindNextVisibleEntry() for more detail on internal implementation
+// of advancing child iters.
+//
+// REQUIRES: min heap is currently not empty, and iter is in kForward direction.
+bool MergingIterator::IsNextDeleted() {
+  auto current = minHeap_.top();
+  auto level = GetChildIndex(current);
+  ParsedInternalKey pik;
+  // TODO: error handling
+  ParseInternalKey(current->key(), &pik, false /* log_error_key */)
+      .PermitUncheckedError();
+  if (pik.type == kTypeRangeDeletion) {
+    // Sentinel key: file boundary used as a fake key, always delete and move to
+    // next. We need this sentinel key to keep level iterator from advancing to
+    // next SST file when current range tombstone is still in effect.
+    current->Next();
+    if (current->Valid()) {
+      minHeap_.replace_top(current);
+    } else {
+      considerStatus(current->status());
+      minHeap_.pop();
+    }
+    return true /* entry deleted */;
+  }
+
+  // Check for sorted runs [0, level] for potential covering range tombstone.
+  // For all sorted runs newer than the sorted run containing current key:
+  //  we can advance their range tombstone iter to after current user key,
+  //  since current key is at top of the heap, which means all previous
+  //  iters must pointer to a user key after the current user key.
+  for (size_t i = 0; i <= level; ++i) {
+    // current level has no range tombstone left
+    if (child_range_tombstones_[i] == nullptr ||
+        !child_range_tombstones_[i]->Valid()) {
+      continue;
+    }
+
+    // truncated range tombstone iter covers keys in internal key range
+    if (comparator_->Compare(child_range_tombstones_[i]->end_key(), pik) <= 0) {
+      // range tombstone iter is behind
+      child_range_tombstones_[i]->Seek(pik.user_key);
+      // Exhausted all range tombstones at i-th level
+      if (!child_range_tombstones_[i]->Valid()) {
+        continue;
+      }
+    }
+
+    // The above successful seek guarantees current key < tombstone end key
+    // (internal key), now make sure start key <= current key
+    if (comparator_->Compare(pik, child_range_tombstones_[i]->start_key()) <
+        0) {
+      // current internal key < start internal key, no covering range tombstone
+      // from this level
+      continue;
+    }
+
+    // Now we know start key <= current key < end key (internal key). Check
+    // sequence number if the range tombstone is from the same level as current
+    // key. Note that there should be no need to seek sequence number since
+    // tombstone_iter->Seek() does it and Valid() guarantees that seqno is
+    // valid.
+    if (i == level) {
+      if (pik.sequence >= child_range_tombstones_[i]->seq()) {
+        // equal case for range tombstones in ingested files: point key takes
+        // precedence tombstone is older than current internal key
+        continue;
+      }
+      // move to next key without seeking
+      // Note that we could reseek all iters from older levels until the end key
+      //  of the current tombstone. iters from older level will be reseeked
+      //  lazily when they reach top of the queue. Since the current key will
+      //  likely produce series of keys covered by the current tombstone, we
+      //  need to dedup the reseek if we plan to do the reseek.
+      // TODO: potentially iterate until end of tombstone before fixing the heap
+      // TODO: potentially optimize this iteration by switching to seek after
+      //   a certain number of iterations of the same user key.
+      current->Next();
+      if (current->Valid()) {
+        minHeap_.replace_top(current);
+      } else {
+        considerStatus(current->status());
+        minHeap_.pop();
+      }
+      return true /* entry deleted */;
+    }
+    assert(pik.sequence < child_range_tombstones_[i]->seq());
+    // i < level
+    // tombstone->Valid() means there is a valid sequence number
+    std::string target;
+    AppendInternalKey(&target, child_range_tombstones_[i]->end_key());
+    SeekImpl(target, level, true /* tombstone_reseek */);
+    return true /* entry deleted */;
+  }
+  return false /* not deleted */;
+}
+
+void MergingIterator::SeekForPrevImpl(const Slice& target,
+                                      size_t starting_level,
+                                      bool range_tombstone_reseek) {
+  ClearHeaps();
+  InitMaxHeap();
+  status_ = Status::OK();
+  IterKey current_search_key;
+  current_search_key.SetInternalKey(target, false /* copy */);
+  // (level, target) pairs
+  autovector<std::pair<size_t, std::string>> pinned_prefetched_target;
+
+  for (auto level = starting_level; level < children_.size(); ++level) {
+    {
+      PERF_TIMER_GUARD(seek_child_seek_time);
+      children_[level].SeekForPrev(current_search_key.GetInternalKey());
+    }
+
+    if (range_tombstone_reseek) {
+      // This seek is to some range tombstone end key
+      PERF_COUNTER_ADD(internal_range_del_reseek_count, 1);
+    }
+
+    PERF_COUNTER_ADD(seek_child_seek_count, 1);
+
+    if (!child_range_tombstones_.empty()) {
+      // avoids copying target key for async requests in range tombstone free
+      // path
+      if (children_[level].status().IsTryAgain()) {
+        // search target might change to some range tombstone end key, so
+        // we need to remember them for async requests.
+        pinned_prefetched_target.emplace_back(
+            level, current_search_key.GetInternalKey().ToString());
+      }
+      if (child_range_tombstones_[level] != nullptr) {
+        child_range_tombstones_[level]->SeekForPrev(
+            current_search_key.GetUserKey());
+        // start key <= current_search_key guaranteed by the Seek() call above
+        // Only interested in user key coverage since older sorted runs must
+        // have smaller sequence numbers than this tombstone.
+        if (child_range_tombstones_[level]->Valid() &&
+            comparator_->user_comparator()->Compare(
+                current_search_key.GetUserKey(),
+                child_range_tombstones_[level]->end_key().user_key) < 0 &&
+            child_range_tombstones_[level]->seq()) {
+          range_tombstone_reseek = true;
+          // covered by this range tombstone
+          current_search_key.SetInternalKey(
+              child_range_tombstones_[level]->start_key().user_key,
+              kMaxSequenceNumber, kValueTypeForSeekForPrev);
+        }
+      }
+    }
+    // child.status() is set to Status::TryAgain indicating asynchronous
+    // request for retrieval of data blocks has been submitted. So it should
+    // return at this point and Seek should be called again to retrieve the
+    // requested block and add the child to min heap.
+    if (children_[level].status().IsTryAgain()) {
+      continue;
+    }
+    {
+      // Strictly, we timed slightly more than min heap operation,
+      // but these operations are very cheap.
+      PERF_TIMER_GUARD(seek_max_heap_time);
+      AddToMaxHeapOrCheckStatus(&children_[level]);
+    }
+  }
+  for (size_t level = 0; level < starting_level; ++level) {
+    PERF_TIMER_GUARD(seek_max_heap_time);
+    AddToMaxHeapOrCheckStatus(&children_[level]);
+  }
+
+  if (child_range_tombstones_.empty()) {
+    for (auto& child : children_) {
+      if (child.status().IsTryAgain()) {
+        child.Seek(target);
+        {
+          PERF_TIMER_GUARD(seek_min_heap_time);
+          AddToMinHeapOrCheckStatus(&child);
+        }
+        PERF_COUNTER_ADD(number_async_seek, 1);
+      }
+    }
+  } else {
+    for (auto& prefetch : pinned_prefetched_target) {
+      children_[prefetch.first].SeekForPrev(prefetch.second);
+      {
+        PERF_TIMER_GUARD(seek_max_heap_time);
+        AddToMaxHeapOrCheckStatus(&children_[prefetch.first]);
+      }
+      PERF_COUNTER_ADD(number_async_seek, 1);
+    }
+  }
+}
+
+// Returns iff the current key (max heap top) is deleted (by some range
+// deletion), move the iterator at heap top backward if so. Heap order is
+// restored. See FindNextVisibleEntry() for more detail on internal
+// implementation of advancing child iters.
+//
+// REQUIRES: max heap is currently not empty, and iter is in kReverse direction.
+bool MergingIterator::IsPrevDeleted() {
+  auto current = maxHeap_->top();
+  auto level = GetChildIndex(current);
+  ParsedInternalKey pik;
+  // TODO: error handling
+  ParseInternalKey(current->key(), &pik, false /* log_error_key */)
+      .PermitUncheckedError();
+  if (pik.type == kTypeRangeDeletion) {
+    // Sentinel key: file boundary used as a fake key, always delete and move to
+    // prev. We need this sentinel key to keep level iterator from advancing to
+    // next SST file when current range tombstone is still in effect.
+    current->Prev();
+    if (current->Valid()) {
+      maxHeap_->replace_top(current);
+    } else {
+      considerStatus(current->status());
+      maxHeap_->pop();
+    }
+    return true /* entry deleted */;
+  }
+
+  // Check for sorted runs [0, level] for potential covering range tombstone.
+  // For all sorted runs newer than the sorted run containing current key:
+  //  we advance their range tombstone iter to cover current user key (or before
+  //  if there is no such tombstone). We can do so since current key is at top
+  //  of the heap, which means all previous iters must pointer to a user key
+  //  less than or equal to the current user key.
+  for (size_t i = 0; i <= level; ++i) {
+    // current level has no range tombstone left
+    if (child_range_tombstones_[i] == nullptr ||
+        !child_range_tombstones_[i]->Valid()) {
+      continue;
+    }
+
+    // truncated range tombstone iter covers keys in internal key range
+    if (comparator_->Compare(pik, child_range_tombstones_[i]->start_key()) <
+        0) {
+      child_range_tombstones_[i]->SeekForPrev(pik.user_key);
+      // Exhausted all range tombstones at i-th level
+      if (!child_range_tombstones_[i]->Valid()) {
+        continue;
+      }
+    }
+
+    // The above successful seek guarantees tombstone start key <= current
+    // internal key (internal key), now make sure current key < tombstone end
+    // key
+    if (comparator_->Compare(child_range_tombstones_[i]->end_key(), pik) <= 0) {
+      // tombstone end key <= current key
+      continue;
+    }
+
+    // Now we know start key <= current key < end key (internal key).
+    // Check sequence number if the range tombstone is from the same level
+    // as current key. Note that there
+    // should be no need to seek sequence number since tombstone_iter->Seek()
+    // does it and Valid() guarantees that seqno is valid.
+    if (i == level) {
+      if (pik.sequence >= child_range_tombstones_[i]->seq()) {
+        // equal case for range tombstones in ingested files
+        // tombstone is older than current internal key
+        continue;
+      }
+      // move to next key without seeking
+      current->Prev();
+      if (current->Valid()) {
+        maxHeap_->replace_top(current);
+      } else {
+        considerStatus(current->status());
+        maxHeap_->pop();
+      }
+      return true /* entry deleted */;
+    }
+    assert(pik.sequence < child_range_tombstones_[i]->seq());
+    // i < level
+    // tombstone->Valid() means there is a valid sequence number
+    std::string target;
+    AppendInternalKey(&target, child_range_tombstones_[i]->start_key());
+    // This is different from IsDeleted() which does reseek at sorted runs >=
+    // level. With min heap, if level L is at top of the heap, then levels <L
+    // all have internal keys > level L's current internal key,
+    // which means levels <L are already at a different user key.
+    // With max heap, if level L is at top of the heap, then levels <L
+    // all have internal keys smaller than level L's current internal key,
+    // which might still be the same user key.
+    SeekForPrevImpl(target, i + 1, true /* tombstone_reseek */);
+    return true /* entry deleted */;
+  }
+  return false /* not deleted */;
+}
+
+size_t MergingIterator::GetChildIndex(IteratorWrapper* child) {
+  return child - &children_[0];
+}
+
 void MergingIterator::AddToMinHeapOrCheckStatus(IteratorWrapper* child) {
   if (child->Valid()) {
     assert(child->status().ok());
@@ -371,9 +828,14 @@ void MergingIterator::AddToMaxHeapOrCheckStatus(IteratorWrapper* child) {
   }
 }
 
+// Advance all non current_ child to > current_.key().
+// We advance current_ after the this function call as it does require a Seek().
+//
+// Advance all range tombstones iters, including the one corresponding to
+// current_, to the first tombstone with end_key > current_.key() (internal
+// key).
+// TODO: potentially do cascading seek here too
 void MergingIterator::SwitchToForward() {
-  // Otherwise, advance the non-current children.  We advance current_
-  // just after the if-block.
   ClearHeaps();
   Slice target = key();
   for (auto& child : children_) {
@@ -392,6 +854,20 @@ void MergingIterator::SwitchToForward() {
       }
     }
     AddToMinHeapOrCheckStatus(&child);
+  }
+
+  // current range tombstone iter also need to seek for the following case:
+  //
+  // Previous direction is backward, so range tombstone iter may point to a
+  // tombstone before current_. If there is no such tombstone, then the range
+  // tombstone is !Valid(). Need to reseek here to make it valid again.
+  if (!child_range_tombstones_.empty()) {
+    Slice target_user_key = ExtractUserKey(target);
+    for (auto& t : child_range_tombstones_) {
+      if (t != nullptr) {
+        t->Seek(target_user_key);
+      }
+    }
   }
 
   for (auto& child : children_) {
@@ -423,6 +899,16 @@ void MergingIterator::SwitchToBackward() {
     }
     AddToMaxHeapOrCheckStatus(&child);
   }
+
+  if (!child_range_tombstones_.empty()) {
+    Slice target_user_key = ExtractUserKey(target);
+    for (auto& t : child_range_tombstones_) {
+      if (t != nullptr) {
+        t->SeekForPrev(target_user_key);
+      }
+    }
+  }
+
   direction_ = kReverse;
   if (!prefix_seek_mode_) {
     // Note that we don't do assert(current_ == CurrentReverse()) here
@@ -443,7 +929,25 @@ void MergingIterator::ClearHeaps() {
 
 void MergingIterator::InitMaxHeap() {
   if (!maxHeap_) {
-    maxHeap_.reset(new MergerMaxIterHeap(comparator_));
+    maxHeap_ = std::make_unique<MergerMaxIterHeap>(comparator_);
+  }
+}
+
+// For the current key (heap top), range tombstones at levels [0, current key
+// level] are examined in order. If a covering tombstone is found from a
+// level before current key's level, SeekImpl() is called to apply cascading
+// seek from current key's level. If the covering tombstone is from current
+// key's level, then the current child iterator is simply advanced to its next
+// key without reseeking.
+void MergingIterator::FindNextVisibleEntry() {
+  while (!minHeap_.empty() && IsNextDeleted()) {
+    // move to next entry
+  }
+}
+
+void MergingIterator::FindPrevUserEntry() {
+  while (!maxHeap_->empty() && IsPrevDeleted()) {
+    // move to previous entry
   }
 }
 
@@ -495,12 +999,39 @@ void MergeIteratorBuilder::AddIterator(InternalIterator* iter) {
   }
 }
 
-InternalIterator* MergeIteratorBuilder::Finish() {
+void MergeIteratorBuilder::AddRangeTombstoneIterator(
+    TruncatedRangeDelIterator* iter,
+    TruncatedRangeDelIterator*** range_del_iter_ptr) {
+  if (!use_merging_iter) {
+    use_merging_iter = true;
+    merge_iter->AddIterator(first_iter);
+    first_iter = nullptr;
+  }
+  merge_iter->AddRangeTombstoneIterator(iter);
+  if (range_del_iter_ptr != nullptr) {
+    range_del_iter_ptrs_.emplace_back(
+        merge_iter->child_range_tombstones_.size() - 1, range_del_iter_ptr);
+  }
+}
+
+InternalIterator* MergeIteratorBuilder::Finish(ArenaWrappedDBIter* db_iter) {
   InternalIterator* ret = nullptr;
   if (!use_merging_iter) {
     ret = first_iter;
     first_iter = nullptr;
   } else {
+    for (auto& p : range_del_iter_ptrs_) {
+      // Need to do this in Finish() stage instead of during
+      // AddRangeTombstoneIterator() since memory address of
+      // child_range_tombstones_[i] might change during vector resizing.
+      *(p.second) = &(merge_iter->child_range_tombstones_[p.first]);
+    }
+    if (db_iter != nullptr) {
+      assert(!merge_iter->child_range_tombstones_.empty());
+      // memtable is always the first level
+      db_iter->SetMemtableRangetombstoneIter(
+          &merge_iter->child_range_tombstones_.front());
+    }
     ret = merge_iter;
     merge_iter = nullptr;
   }

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -566,7 +566,7 @@ void MergingIterator::SeekImpl(const Slice& target, size_t starting_level,
 bool MergingIterator::IsNextDeleted() {
   auto current = minHeap_.top();
   auto level = GetChildIndex(current);
-  if (current->IsRangeDeleteSentinelKey()) {
+  if (current->IsDeleteRangeSentinelKey()) {
     current->Next();
     // enters new file
     if (current->Valid()) {
@@ -796,7 +796,7 @@ void MergingIterator::SeekForPrevImpl(const Slice& target,
 bool MergingIterator::IsPrevDeleted() {
   auto current = maxHeap_->top();
   auto level = GetChildIndex(current);
-  if (current->IsRangeDeleteSentinelKey()) {
+  if (current->IsDeleteRangeSentinelKey()) {
     // Sentinel key: file boundary used as a fake key, always delete and move to
     // prev. We need this sentinel key to keep level iterator from advancing to
     // next SST file when current range tombstone is still in effect.
@@ -1041,7 +1041,7 @@ void MergingIterator::InitMaxHeap() {
 // seek from current key's level. If the covering tombstone is from current
 // key's level, then the current child iterator is simply advanced to its next
 // key without reseeking.
-void MergingIterator::FindNextVisibleEntry() {
+inline void MergingIterator::FindNextVisibleEntry() {
   // We cannot just check range_tombstones_.active.empty() for the following
   // case. When a child iter is about to return a sentinel key due to prefix
   // seek, its range tombstone iter could already be !Valid() and hence not
@@ -1049,16 +1049,16 @@ void MergingIterator::FindNextVisibleEntry() {
   // the top of the heap before returning.
   while (!minHeap_.empty() &&
          (!range_tombstones_.active.empty() ||
-          minHeap_.top()->IsRangeDeleteSentinelKey()) &&
+          minHeap_.top()->IsDeleteRangeSentinelKey()) &&
          IsNextDeleted()) {
     // move to next entry
   }
 }
 
-void MergingIterator::FindPrevVisibleEntry() {
+inline void MergingIterator::FindPrevVisibleEntry() {
   while (!maxHeap_->empty() &&
          (!range_tombstones_.active.empty() ||
-          maxHeap_->top()->IsRangeDeleteSentinelKey()) &&
+          maxHeap_->top()->IsDeleteRangeSentinelKey()) &&
          IsPrevDeleted()) {
     // move to previous entry
   }

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -234,8 +234,14 @@ class MergingIterator : public InternalIterator {
       minHeap_.pop();
     }
 
-    if (!child_range_tombstones_.empty()) {
-      FindNextVisibleEntry();
+    for (auto& t : child_range_tombstones_) {
+      if (t != nullptr) {
+        // Only need to skip range tombstone covered keys when there is a
+        // non-empty range tombstone iter. This helps reduce performance impact
+        // for no range tombstone use cases.
+        FindNextVisibleEntry();
+        break;
+      }
     }
     current_ = CurrentForward();
   }
@@ -280,9 +286,14 @@ class MergingIterator : public InternalIterator {
       maxHeap_->pop();
     }
 
-    if (!child_range_tombstones_.empty()) {
-      // Skip range tombstone covered keys
-      FindPrevVisibleEntry();
+    for (auto& t : child_range_tombstones_) {
+      if (t != nullptr) {
+        // Only need to skip range tombstone covered keys when there is a
+        // non-empty range tombstone iter. This helps reduce performance impact
+        // for no range tombstone use cases.
+        FindPrevVisibleEntry();
+        break;
+      }
     }
     current_ = CurrentReverse();
   }

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -26,8 +26,6 @@
 #include "util/stop_watch.h"
 
 namespace ROCKSDB_NAMESPACE {
-// Without anonymous namespace here, we fail the warning -Wmissing-prototypes
-namespace {
 // For merging iterator to process range deletions, we treat the start and end
 // key of a range deletion as point keys and put them into the minHeap/maxHeap
 // used in merging iterator. Take minHeap for example, we are able to keep track
@@ -105,7 +103,8 @@ class MaxHeapItemComparator {
  private:
   const InternalKeyComparator* comparator_;
 };
-
+// Without anonymous namespace here, we fail the warning -Wmissing-prototypes
+namespace {
 using MergerMinIterHeap = BinaryHeap<HeapItem*, MinHeapItemComparator>;
 using MergerMaxIterHeap = BinaryHeap<HeapItem*, MaxHeapItemComparator>;
 }  // namespace

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -28,39 +28,90 @@
 namespace ROCKSDB_NAMESPACE {
 // Without anonymous namespace here, we fail the warning -Wmissing-prototypes
 namespace {
-using MergerMaxIterHeap = BinaryHeap<IteratorWrapper*, MaxIteratorComparator>;
-using MergerMinIterHeap = BinaryHeap<IteratorWrapper*, MinIteratorComparator>;
+// For merging iterator to process range deletions, we treat the start and end
+// key of a range deletion as point keys and put them into the minHeap/maxHeap
+// used in merging iterator. Take minHeap for example, we are able to keep track
+// of currently active range tombstones (the ones where start keys are popped
+// but end keys are still in the heap). This `active_` set of range tombstones
+// is then used to quickly determine whether the point key at heap top is
+// deleted (by heap property, the point key at heap top must be within internal
+// key range of active range tombstones).
+//
+// The HeapItem structure represents the aforementioned 3 types of elements in
+// the minHeap/maxHeap.
+struct HeapItem {
+  HeapItem() = default;
+
+  enum Type { ITERATOR, DELETE_RANGE_START, DELETE_RANGE_END };
+  IteratorWrapper iter;
+  size_t level = 0;
+  std::string pinned_key;
+  // Will be overwritten, initialize here so compiler does not complain.
+  Type type = ITERATOR;
+
+  explicit HeapItem(size_t _level, InternalIteratorBase<Slice>* _iter)
+      : level(_level), type(Type::ITERATOR) {
+    iter.Set(_iter);
+  }
+
+  void SetTombstoneEndKey(ParsedInternalKey&& pik) {
+    pinned_key.clear();
+    // Range tombstone end key is exclusive. If a point internal key has same
+    // user key and sequence number as the start or end key, the order will be
+    // start < end key < < internal key.
+    //
+    // Note: The op_type change of end key may not be necessary, but kept so
+    // that keys are non-decreasing in the case of a range tombstone and a user
+    // key straddles two SST files.
+    ParsedInternalKey p(pik.user_key, pik.sequence, kValueTypeForSeek);
+    AppendInternalKey(&pinned_key, p);
+  }
+
+  Slice key() const {
+    if (type == Type::ITERATOR) {
+      return iter.key();
+    }
+    return pinned_key;
+  }
+
+  bool IsDeleteRangeSentinelKey() const {
+    if (type == Type::ITERATOR) {
+      return iter.IsDeleteRangeSentinelKey();
+    }
+    return false;
+  }
+};
+
+class MinHeapItemComparator {
+ public:
+  MinHeapItemComparator(const InternalKeyComparator* comparator)
+      : comparator_(comparator) {}
+  bool operator()(HeapItem* a, HeapItem* b) const {
+    return comparator_->Compare(a->key(), b->key()) > 0;
+  }
+
+ private:
+  const InternalKeyComparator* comparator_;
+};
+
+class MaxHeapItemComparator {
+ public:
+  MaxHeapItemComparator(const InternalKeyComparator* comparator)
+      : comparator_(comparator) {}
+  bool operator()(HeapItem* a, HeapItem* b) const {
+    return comparator_->Compare(a->key(), b->key()) < 0;
+  }
+
+ private:
+  const InternalKeyComparator* comparator_;
+};
+
+using MergerMinIterHeap = BinaryHeap<HeapItem*, MinHeapItemComparator>;
+using MergerMaxIterHeap = BinaryHeap<HeapItem*, MaxHeapItemComparator>;
 }  // namespace
 
 class MergingIterator : public InternalIterator {
  public:
-  class MergingIteratorRangeTombstones {
-   public:
-    // iters[i] contains range tombstones in sorted run that corresponds to
-    // children_[i]. iters.empty() means not handling range tombstones. iters[i]
-    // == nullptr means a sorted run does not have range tombstones.
-    std::vector<TruncatedRangeDelIterator*> iters;
-    // levels whose range tombstone iter is currently valid
-    std::set<size_t> active;
-
-    // Verify that active has all and only valid iterator from iters.
-    // Only called in assert()'s.
-    bool ActiveIsCorrect() {
-      for (size_t i = 0; i < iters.size(); ++i) {
-        if (iters[i] && iters[i]->Valid()) {
-          if (!active.count(i)) {
-            return false;
-          }
-        } else {
-          if (active.count(i)) {
-            return false;
-          }
-        }
-      }
-      return true;
-    }
-  };
-
   MergingIterator(const InternalKeyComparator* comparator,
                   InternalIterator** children, int n, bool is_arena_mode,
                   bool prefix_seek_mode)
@@ -73,7 +124,8 @@ class MergingIterator : public InternalIterator {
         pinned_iters_mgr_(nullptr) {
     children_.resize(n);
     for (int i = 0; i < n; i++) {
-      children_[i].Set(children[i]);
+      children_[i].level = i;
+      children_[i].iter.Set(children[i]);
     }
   }
 
@@ -84,7 +136,7 @@ class MergingIterator : public InternalIterator {
   }
 
   virtual void AddIterator(InternalIterator* iter) {
-    children_.emplace_back(iter);
+    children_.emplace_back(children_.size(), iter);
     if (pinned_iters_mgr_) {
       iter->SetPinnedItersMgr(pinned_iters_mgr_);
     }
@@ -107,18 +159,33 @@ class MergingIterator : public InternalIterator {
   // and when a level iterator moves to a different SST file, the range
   // tombstone iterator could be updated. In that case, the merging iterator
   // is only responsible to freeing the new range tombstone iterator
-  // that it has pointers to in child_range_tombstones_.
+  // that it has pointers to in range_tombstone_iters_.
   void AddRangeTombstoneIterator(TruncatedRangeDelIterator* iter) {
-    range_tombstones_.iters.emplace_back(iter);
+    range_tombstone_iters_.emplace_back(iter);
+  }
+
+  // Called by MergingIteratorBuilder when all point iterators and range
+  // tombstone iterators are added. Initializes HeapItems for range tombstone
+  // iterators.
+  void Finish() {
+    if (!range_tombstone_iters_.empty()) {
+      pinned_heap_item_.resize(range_tombstone_iters_.size() * 2);
+      for (size_t i = 0; i < range_tombstone_iters_.size(); ++i) {
+        pinned_heap_item_[2 * i].type = HeapItem::DELETE_RANGE_START;
+        pinned_heap_item_[2 * i].level = i;
+        pinned_heap_item_[2 * i + 1].type = HeapItem::DELETE_RANGE_END;
+        pinned_heap_item_[2 * i + 1].level = i;
+      }
+    }
   }
 
   ~MergingIterator() override {
-    for (auto child : range_tombstones_.iters) {
+    for (auto child : range_tombstone_iters_) {
       delete child;
     }
 
     for (auto& child : children_) {
-      child.DeleteIter(is_arena_mode_);
+      child.iter.DeleteIter(is_arena_mode_);
     }
     status_.PermitUncheckedError();
   }
@@ -127,25 +194,73 @@ class MergingIterator : public InternalIterator {
 
   Status status() const override { return status_; }
 
+  // Add current range tombstone from range_tombstone_iters_[level] into min
+  // heap.
+  void InsertRangeTombstoneToMinHeap(size_t level) {
+    assert(!range_tombstone_iters_.empty() &&
+           range_tombstone_iters_[level]->Valid());
+    pinned_heap_item_[level * 2].SetTombstoneEndKey(
+        range_tombstone_iters_[level]->start_key());
+    pinned_heap_item_[level * 2 + 1].SetTombstoneEndKey(
+        range_tombstone_iters_[level]->end_key());
+    minHeap_.push(&pinned_heap_item_[level * 2]);
+    minHeap_.push(&pinned_heap_item_[level * 2 + 1]);
+  }
+
+  // Add current range tombstone from range_tombstone_iters_[level] into max
+  // heap.
+  void InsertRangeTombstoneToMaxHeap(size_t level) {
+    assert(!range_tombstone_iters_.empty() &&
+           range_tombstone_iters_[level]->Valid());
+    pinned_heap_item_[level * 2].SetTombstoneEndKey(
+        range_tombstone_iters_[level]->start_key());
+    pinned_heap_item_[level * 2 + 1].SetTombstoneEndKey(
+        range_tombstone_iters_[level]->end_key());
+    maxHeap_->push(&pinned_heap_item_[level * 2]);
+    maxHeap_->push(&pinned_heap_item_[level * 2 + 1]);
+  }
+
+  // Remove HeapItems from top of minHeap_ that are of type DELETE_RANGE_START
+  // until minHeap_ is empty or the top of the minHeap_ is not of type
+  // DELETE_RANGE_START. Each such item means a range tombstone becomes active,
+  // so `active_` is updated accordingly.
+  void PopDeleteRangeStart() {
+    while (!minHeap_.empty() &&
+           minHeap_.top()->type == HeapItem::DELETE_RANGE_START) {
+      active_.insert(minHeap_.top()->level);
+      minHeap_.pop();
+    }
+  }
+
+  // Remove HeapItems from top of maxHeap_ that are of type DELETE_RANGE_START
+  // until minHeap_ is empty or the top of the maxHeap_ is not of type
+  // DELETE_RANGE_START. Each such item means a range tombstone becomes active,
+  // so `active_` is updated accordingly.
+  void PopDeleteRangeEnd() {
+    while (!maxHeap_->empty() &&
+           maxHeap_->top()->type == HeapItem::DELETE_RANGE_END) {
+      active_.insert(maxHeap_->top()->level);
+      maxHeap_->pop();
+    }
+  }
+
   void SeekToFirst() override {
     ClearHeaps();
     status_ = Status::OK();
     for (auto& child : children_) {
-      child.SeekToFirst();
+      child.iter.SeekToFirst();
       AddToMinHeapOrCheckStatus(&child);
     }
 
-    range_tombstones_.active.clear();
-    for (size_t i = 0; i < range_tombstones_.iters.size(); ++i) {
-      if (range_tombstones_.iters[i]) {
-        range_tombstones_.iters[i]->SeekToFirst();
-        if (range_tombstones_.iters[i]->Valid()) {
+    for (size_t i = 0; i < range_tombstone_iters_.size(); ++i) {
+      if (range_tombstone_iters_[i]) {
+        range_tombstone_iters_[i]->SeekToFirst();
+        if (range_tombstone_iters_[i]->Valid()) {
           // It is possible to be invalid due to snapshots.
-          range_tombstones_.active.insert(i);
+          InsertRangeTombstoneToMinHeap(i);
         }
       }
     }
-    assert(range_tombstones_.ActiveIsCorrect());
     FindNextVisibleEntry();
     direction_ = kForward;
     current_ = CurrentForward();
@@ -156,21 +271,19 @@ class MergingIterator : public InternalIterator {
     InitMaxHeap();
     status_ = Status::OK();
     for (auto& child : children_) {
-      child.SeekToLast();
+      child.iter.SeekToLast();
       AddToMaxHeapOrCheckStatus(&child);
     }
 
-    range_tombstones_.active.clear();
-    for (size_t i = 0; i < range_tombstones_.iters.size(); ++i) {
-      if (range_tombstones_.iters[i]) {
-        range_tombstones_.iters[i]->SeekToLast();
-        if (range_tombstones_.iters[i]->Valid()) {
+    for (size_t i = 0; i < range_tombstone_iters_.size(); ++i) {
+      if (range_tombstone_iters_[i]) {
+        range_tombstone_iters_[i]->SeekToLast();
+        if (range_tombstone_iters_[i]->Valid()) {
           // It is possible to be invalid due to snapshots.
-          range_tombstones_.active.insert(i);
+          InsertRangeTombstoneToMaxHeap(i);
         }
       }
     }
-    assert(range_tombstones_.ActiveIsCorrect());
     FindPrevVisibleEntry();
     direction_ = kReverse;
     current_ = CurrentReverse();
@@ -186,25 +299,32 @@ class MergingIterator : public InternalIterator {
   // >= target. If range tombstones are present, we apply a similar
   // optimization, cascading seek, as in Pebble
   // (https://github.com/cockroachdb/pebble). Specifically, if there is a range
-  // tombstone [start, end) that covers the target key at level L, then this
-  // range tombstone must cover the range [target, end) for all levels > L. So
-  // for all levels > L, we can pretend the target key is `end`. This
+  // tombstone [start, end) that covers the target user key at level L, then
+  // this range tombstone must cover the range [target key, end) in all levels >
+  // L. So for all levels > L, we can pretend the target key is `end`. This
   // optimization is applied at each level and hence the name "cascading seek".
   // After a round of (cascading) seeks, the top of the heap is checked to see
   // if it is covered by a range tombstone (see FindNextVisibleEntry() for more
   // detail), and advanced if so. The process is repeated until a visible key is
   // at the top of the heap.
-  // For correctness reasoning, one invariant that merging iter guarantees is
-  // that, suppose current_ is from level L, then for each range tombstone
-  // iterators at level <= L, it is at or before the first range tombstone with
-  // end key > current_.key(). This ensures that in FindNextVisibleEntry(), we
-  // never need to move any range tombstone iter backward to check if the
-  // current_.key() is covered.
+  //
+  // As mentioned in comments above HeapItem, to make the checking of whether
+  // top of the heap is covered by some range tombstone efficient, we treat each
+  // range deletion [start, end) as two point keys and insert them into the same
+  // min/maxHeap_ where point iterators are. The set `active_` tracks levels
+  // that have active range tombstones. If level L is in `active_`, then the
+  // point key at top of the heap is within internal key range of the range
+  // tombstone that range_tombstone_iters_[L] currently points to. For
+  // correctness reasoning, one invariant that Seek() guarantees is that,
+  // suppose current_ is from level L. Then for each range tombstone iterators
+  // at level <= L, it is at or before the first range tombstone with end key >
+  // current_.key(). This ensures that when a point iterator reaches top of the
+  // heap, `active_` is calculated correctly, since no range tombstone iterators
+  // are skipped beyond that point iterator doing Seek().
   void Seek(const Slice& target) override {
-    assert(range_tombstones_.iters.empty() ||
-           range_tombstones_.iters.size() == children_.size());
+    assert(range_tombstone_iters_.empty() ||
+           range_tombstone_iters_.size() == children_.size());
     SeekImpl(target);
-    assert(range_tombstones_.ActiveIsCorrect());
     FindNextVisibleEntry();
 
     direction_ = kForward;
@@ -216,10 +336,9 @@ class MergingIterator : public InternalIterator {
   }
 
   void SeekForPrev(const Slice& target) override {
-    assert(range_tombstones_.iters.empty() ||
-           range_tombstones_.iters.size() == children_.size());
+    assert(range_tombstone_iters_.empty() ||
+           range_tombstone_iters_.size() == children_.size());
     SeekForPrevImpl(target);
-    assert(range_tombstones_.ActiveIsCorrect());
     FindPrevVisibleEntry();
 
     direction_ = kReverse;
@@ -253,13 +372,14 @@ class MergingIterator : public InternalIterator {
       // replace_top() to restore the heap property.  When the same child
       // iterator yields a sequence of keys, this is cheap.
       assert(current_->status().ok());
-      minHeap_.replace_top(current_);
+      minHeap_.replace_top(minHeap_.top());
     } else {
       // current stopped being valid, remove it from the heap.
       considerStatus(current_->status());
       minHeap_.pop();
     }
-    assert(range_tombstones_.ActiveIsCorrect());
+    // Heap changed: so we should pop range tombstone starts to bring active_
+    // current
     FindNextVisibleEntry();
     current_ = CurrentForward();
   }
@@ -290,20 +410,18 @@ class MergingIterator : public InternalIterator {
     // For the heap modifications below to be correct, current_ must be the
     // current top of the heap.
     assert(current_ == CurrentReverse());
-
     current_->Prev();
     if (current_->Valid()) {
       // current is still valid after the Prev() call above.  Call
       // replace_top() to restore the heap property.  When the same child
       // iterator yields a sequence of keys, this is cheap.
       assert(current_->status().ok());
-      maxHeap_->replace_top(current_);
+      maxHeap_->replace_top(maxHeap_->top());
     } else {
       // current stopped being valid, remove it from the heap.
       considerStatus(current_->status());
       maxHeap_->pop();
     }
-    assert(range_tombstones_.ActiveIsCorrect());
     FindPrevVisibleEntry();
     current_ = CurrentReverse();
   }
@@ -346,7 +464,7 @@ class MergingIterator : public InternalIterator {
   void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override {
     pinned_iters_mgr_ = pinned_iters_mgr;
     for (auto& child : children_) {
-      child.SetPinnedItersMgr(pinned_iters_mgr);
+      child.iter.SetPinnedItersMgr(pinned_iters_mgr);
     }
   }
 
@@ -391,19 +509,29 @@ class MergingIterator : public InternalIterator {
   enum Direction : uint8_t { kForward, kReverse };
   Direction direction_;
   const InternalKeyComparator* comparator_;
-  // Uses vector instead of autovector to make GetChildIndex() work.
-  // We could also use an autovector with larger reserved size.
-  std::vector<IteratorWrapper> children_;
-  MergingIteratorRangeTombstones range_tombstones_;
+  // We could also use an autovector with a larger reserved size.
+  std::vector<HeapItem> children_;
+  // HeapItem for range tombstone start and end keys. Each range tombstone
+  // iterator will have at most 1 start key and 1 end key HeapItem in the heap
+  // at the same time, so this vector will be of size 2 * children_.size();
+  // pinned_heap_item_[2*i] and pinned_heap_item_[2*i+1] corresponds to the
+  // start key and end key HeapItem from range_tombstone_iters_[i].
+  std::vector<HeapItem> pinned_heap_item_;
+  // range_tombstone_iters_[i] contains range tombstones in sorted run that
+  // corresponds to children_[i]. range_tombstone_iters_.empty() means not
+  // handling range tombstones in merging iterator. range_tombstone_iters_[i] ==
+  // nullptr means the sorted run of children_[i] does not have range
+  // tombstones.
+  std::vector<TruncatedRangeDelIterator*> range_tombstone_iters_;
+
+  // Levels (indices into range_tombstone_iters_/children_ ) that currently have
+  // active range tombstones. See comments above Seek() for meaning of `active`.
+  std::set<size_t> active_;
   // Checks if top of the heap (current key) is covered by a range tombstone by
   // It current key is covered by some range tombstone, its iter is advanced and
   // heap property is maintained. Returns whether top of heap is deleted.
   bool IsNextDeleted();
   bool IsPrevDeleted();
-
-  // Return the index of child in children_.
-  // REQUIRES: child in children_.
-  size_t GetChildIndex(IteratorWrapper* child);
 
   // Cached pointer to child iterator with the current key, or nullptr if no
   // child iterators are valid.  This is the top of minHeap_ or maxHeap_
@@ -420,11 +548,11 @@ class MergingIterator : public InternalIterator {
 
   // In forward direction, process a child that is not in the min heap.
   // If valid, add to the min heap. Otherwise, check status.
-  void AddToMinHeapOrCheckStatus(IteratorWrapper*);
+  void AddToMinHeapOrCheckStatus(HeapItem*);
 
   // In backward direction, process a child that is not in the max heap.
   // If valid, add to the min heap. Otherwise, check status.
-  void AddToMaxHeapOrCheckStatus(IteratorWrapper*);
+  void AddToMaxHeapOrCheckStatus(HeapItem*);
 
   void SwitchToForward();
 
@@ -434,13 +562,15 @@ class MergingIterator : public InternalIterator {
 
   IteratorWrapper* CurrentForward() const {
     assert(direction_ == kForward);
-    return !minHeap_.empty() ? minHeap_.top() : nullptr;
+    assert(minHeap_.empty() || minHeap_.top()->type == HeapItem::ITERATOR);
+    return !minHeap_.empty() ? &minHeap_.top()->iter : nullptr;
   }
 
   IteratorWrapper* CurrentReverse() const {
     assert(direction_ == kReverse);
     assert(maxHeap_);
-    return !maxHeap_->empty() ? maxHeap_->top() : nullptr;
+    assert(maxHeap_->empty() || maxHeap_->top()->type == HeapItem::ITERATOR);
+    return !maxHeap_->empty() ? &maxHeap_->top()->iter : nullptr;
   }
 };
 
@@ -457,48 +587,47 @@ void MergingIterator::SeekImpl(const Slice& target, size_t starting_level,
   status_ = Status::OK();
   IterKey current_search_key;
   current_search_key.SetInternalKey(target, false /* copy */);
+  // Seek target might change to some range tombstone end key, so
+  // we need to remember them for async requests.
   // (level, target) pairs
-  autovector<std::pair<size_t, std::string>> pinned_prefetched_target;
+  autovector<std::pair<size_t, std::string>> prefetched_target;
 
   for (auto level = starting_level; level < children_.size(); ++level) {
     {
       PERF_TIMER_GUARD(seek_child_seek_time);
-      children_[level].Seek(current_search_key.GetInternalKey());
+      children_[level].iter.Seek(current_search_key.GetInternalKey());
     }
 
     PERF_COUNTER_ADD(seek_child_seek_count, 1);
 
-    if (!range_tombstones_.iters.empty()) {
+    if (!range_tombstone_iters_.empty()) {
       if (range_tombstone_reseek) {
         // This seek is to some range tombstone end key.
         // Should only happen when there are range tombstones.
         PERF_COUNTER_ADD(internal_range_del_reseek_count, 1);
       }
-      if (children_[level].status().IsTryAgain()) {
-        // search target might change to some range tombstone end key, so
-        // we need to remember them for async requests.
-        pinned_prefetched_target.emplace_back(
+      if (children_[level].iter.status().IsTryAgain()) {
+        prefetched_target.emplace_back(
             level, current_search_key.GetInternalKey().ToString());
       }
-      auto range_tombstone_iter = range_tombstones_.iters[level];
+      auto range_tombstone_iter = range_tombstone_iters_[level];
       if (range_tombstone_iter) {
         range_tombstone_iter->Seek(current_search_key.GetUserKey());
-        if (!range_tombstone_iter->Valid()) {
-          range_tombstones_.active.erase(level);
-        } else {
-          range_tombstones_.active.insert(level);
+        if (range_tombstone_iter->Valid()) {
+          InsertRangeTombstoneToMinHeap(level);
           // current_search_key < end_key guaranteed by the Seek() and Valid()
           // calls above. Only interested in user key coverage since older
           // sorted runs must have smaller sequence numbers than this tombstone.
           //
-          // TODO: range_tombstone_iter->seq() is the max covering
+          // TODO: range_tombstone_iter->Seek() finds the max covering
           //  sequence number, can make it cheaper by not looking for max.
           if (comparator_->user_comparator()->Compare(
                   range_tombstone_iter->start_key().user_key,
-                  current_search_key.GetUserKey()) <= 0 &&
-              range_tombstone_iter->seq()) {
+                  current_search_key.GetUserKey()) <= 0) {
+            // Since range_tombstone_iter->Valid(), seqno should be valid, so
+            // there is no need to check it.
             range_tombstone_reseek = true;
-            // Current target is covered by this range tombstone.
+            // Current target user key is covered by this range tombstone.
             // All older sorted runs will seek to range tombstone end key.
             // Note that for prefix seek case, it is possible that the prefix
             // is not the same as the original target, it should not affect
@@ -508,15 +637,13 @@ void MergingIterator::SeekImpl(const Slice& target, size_t starting_level,
                 range_tombstone_iter->end_key().user_key, kMaxSequenceNumber);
           }
         }
-      } else {
-        range_tombstones_.active.erase(level);
       }
     }
-    // child.status() is set to Status::TryAgain indicating asynchronous
+    // child.iter.status() is set to Status::TryAgain indicating asynchronous
     // request for retrieval of data blocks has been submitted. So it should
     // return at this point and Seek should be called again to retrieve the
     // requested block and add the child to min heap.
-    if (children_[level].status().IsTryAgain()) {
+    if (children_[level].iter.status().IsTryAgain()) {
       continue;
     }
     {
@@ -527,16 +654,16 @@ void MergingIterator::SeekImpl(const Slice& target, size_t starting_level,
     }
   }
   // TODO: perhaps we could save some upheap cost by add all child iters first
-  //  and then do a single heapify
+  //  and then do a single heapify.
   for (size_t level = 0; level < starting_level; ++level) {
     PERF_TIMER_GUARD(seek_min_heap_time);
     AddToMinHeapOrCheckStatus(&children_[level]);
   }
 
-  if (range_tombstones_.iters.empty()) {
+  if (range_tombstone_iters_.empty()) {
     for (auto& child : children_) {
-      if (child.status().IsTryAgain()) {
-        child.Seek(target);
+      if (child.iter.status().IsTryAgain()) {
+        child.iter.Seek(target);
         {
           PERF_TIMER_GUARD(seek_min_heap_time);
           AddToMinHeapOrCheckStatus(&child);
@@ -545,147 +672,132 @@ void MergingIterator::SeekImpl(const Slice& target, size_t starting_level,
       }
     }
   } else {
-    for (auto& prefetch : pinned_prefetched_target) {
+    for (auto& prefetch : prefetched_target) {
       // (level, target) pairs
-      children_[prefetch.first].Seek(prefetch.second);
+      children_[prefetch.first].iter.Seek(prefetch.second);
       {
         PERF_TIMER_GUARD(seek_min_heap_time);
         AddToMinHeapOrCheckStatus(&children_[prefetch.first]);
       }
       PERF_COUNTER_ADD(number_async_seek, 1);
     }
+    for (size_t level = 0; level < starting_level; ++level) {
+      if (range_tombstone_iters_[level] &&
+          range_tombstone_iters_[level]->Valid()) {
+        InsertRangeTombstoneToMinHeap(level);
+      }
+    }
   }
 }
 
-// Returns true iff the current key (min heap top) is deleted by some range
-// deletion, advance the iterator at heap top if so. Heap order is restored.
+// Returns true iff the current key (min heap top) should not be returned
+// to user (of the merging iterator). This can be because the current key
+// is deleted by some range tombstone, the current key is some fake file
+// boundary sentinel key, or the current key is an end point of a range
+// tombstone. Advance the iterator at heap top if so. Heap order is restored
+// and `active_` is updated if needed.
 // See FindNextVisibleEntry() for more detail on internal implementation
 // of advancing child iters.
 //
-// REQUIRES: min heap is currently not empty, and iter is in kForward direction.
+// REQUIRES:
+// - min heap is currently not empty, and iter is in kForward direction.
+// - minHeap_ top is not DELETE_RANGE_START (so that active_ is `active_` is
+// current).
 bool MergingIterator::IsNextDeleted() {
+  // 3 types of keys:
+  // - point key
+  // - file boundary sentinel keys
+  // - range deletion end key
   auto current = minHeap_.top();
-  auto level = GetChildIndex(current);
-  if (current->IsDeleteRangeSentinelKey()) {
-    current->Next();
-    // enters new file
-    if (current->Valid()) {
+  if (current->type == HeapItem::DELETE_RANGE_END) {
+    minHeap_.pop();
+    active_.erase(current->level);
+    assert(range_tombstone_iters_[current->level] &&
+           range_tombstone_iters_[current->level]->Valid());
+    range_tombstone_iters_[current->level]->Next();
+    if (range_tombstone_iters_[current->level]->Valid()) {
+      InsertRangeTombstoneToMinHeap(current->level);
+    }
+    return true /* current key deleted */;
+  }
+  if (current->iter.IsDeleteRangeSentinelKey()) {
+    // If the file boundary is defined by a range deletion, the range
+    // tombstone's end key must come before this sentinel key (see op_type in
+    // SetTombstoneEndKey()).
+    assert(ExtractValueType(current->iter.key()) != kTypeRangeDeletion ||
+           active_.count(current->level) == 0);
+    // LevelIterator enters a new SST file
+    current->iter.Next();
+    if (current->iter.Valid()) {
+      assert(current->iter.status().ok());
       minHeap_.replace_top(current);
-      // Check LevelIterator does the bookkeeping for active iter
-      assert((!range_tombstones_.iters[level] &&
-              range_tombstones_.active.count(level) == 0) ||
-             (range_tombstones_.iters[level] &&
-              range_tombstones_.active.count(level) &&
-              range_tombstones_.iters[level]->Valid()));
     } else {
-      considerStatus(current->status());
       minHeap_.pop();
     }
-    return true /* entry deleted */;
+    // Remove last SST file's range tombstone end key if there is one.
+    // This means file boundary is before range tombstone end key,
+    // which could happen when a range tombstone and a user key
+    // straddle two SST files. Note that in TruncatedRangeDelIterator,
+    // parsed_largest.sequence is decremented 1 in this case.
+    if (!minHeap_.empty() && minHeap_.top()->level == current->level &&
+        minHeap_.top()->type == HeapItem::DELETE_RANGE_END) {
+      minHeap_.pop();
+      active_.erase(current->level);
+    }
+    if (range_tombstone_iters_[current->level] &&
+        range_tombstone_iters_[current->level]->Valid()) {
+      InsertRangeTombstoneToMinHeap(current->level);
+    }
+    return true /* current key deleted */;
   }
+  assert(current->type == HeapItem::ITERATOR);
+  // Point key case: check active_ for range tombstone coverage.
   ParsedInternalKey pik;
-  // TODO: error handling
-  ParseInternalKey(current->key(), &pik, false /* log_error_key */)
-      .PermitUncheckedError();
-  // Check for sorted runs [0, level] for potential covering range tombstone.
-  // For all sorted runs newer than the sorted run containing current key:
-  //  we can advance their range tombstone iter to after current user key,
-  //  since current key is at top of the heap, which means all previous
-  //  iters must be pointing to a user key after the current user key.
-  assert(range_tombstones_.ActiveIsCorrect());
-  for (auto i = range_tombstones_.active.begin();
-       i != range_tombstones_.active.end() && *i <= level;) {
-    auto range_tombstone_iter = range_tombstones_.iters[*i];
-    assert(range_tombstone_iter && range_tombstone_iter->Valid());
-
-    // This is more likely to be true than other checks in this loop
-    if (comparator_->Compare(pik, range_tombstone_iter->start_key()) < 0) {
-      // current internal key < start internal key, no covering range tombstone
-      // from this level
-      ++i;
-      continue;
-    }
-
-    // truncated range tombstone iter covers keys in internal key range
-    if (comparator_->Compare(range_tombstone_iter->end_key(), pik) <= 0) {
-      // range_tombstone_iter is behind
-      // TODO: what we are doing here is really forward seeking, i.e., only need
-      //   to look at range tombstones after the current range tombstone in
-      //   child_range_tombstones_[i]. We can add a SeekForward/SeekBackward API
-      //   in `TruncatedRangeDelIterator` to reduce binary search space.
-      range_tombstone_iter->Seek(pik.user_key);
-      // Exhausted all range tombstones at i-th level
-      if (!range_tombstone_iter->Valid()) {
-        i = range_tombstones_.active.erase(i);
-        continue;
-      }
-
-      // The above Seek() guarantees current key < tombstone end key (internal
-      // key), now make sure start key <= current key
-      if (comparator_->Compare(pik, range_tombstone_iter->start_key()) < 0) {
-        // current internal key < start internal key, no covering range
-        // tombstone from this level
-        ++i;
-        continue;
-      }
-    }
-
-    // Now we know start key <= current key < end key (internal key). Check
-    // sequence number if the range tombstone is from the same level as current
-    // key. Note that there should be no need to seek sequence number since
-    // tombstone_iter->Seek() does it and Valid() guarantees that seqno is
-    // valid.
-    if (*i == level) {
-      if (pik.sequence >= range_tombstone_iter->seq()) {
-        // tombstone is older than current internal key
-        // equal case for range tombstones in ingested files: point key takes
-        // precedence
-        ++i;
-        continue;
-      }
-      // move to next key without seeking
-      // Note that we could reseek all iters from levels older than the current
-      // tombstone until the end key. Currently iters from older level will be
-      //  reseeked lazily when they reach top of the queue. Since the current
-      //  key will likely produce series of keys covered by the current
-      //  tombstone, we need to dedup the reseek if we plan to reseek all iters
-      //  from older levels until the end key.
-      // TODO: potentially iterate until end of tombstone before fixing the
-      //  heap. If we plan to this this, optimize the loop by switching to seek
-      //  after
-      //   a certain number of iterations of the same user key.
-      current->Next();
-      // current key is covered by tombstone from the same level
-      // it's impossible that the current tombstone iter becomes invalid
-      assert(range_tombstones_.active.count(level) &&
-             range_tombstones_.iters[level] &&
-             range_tombstones_.iters[level]->Valid());
-      if (current->Valid()) {
-        minHeap_.replace_top(current);
+  ParseInternalKey(current->iter.key(), &pik, false).PermitUncheckedError();
+  for (auto& i : active_) {
+    if (i < current->level) {
+      // range tombstone is from a newer level, definitely covers
+      assert(comparator_->Compare(range_tombstone_iters_[i]->start_key(),
+                                  pik) <= 0);
+      assert(comparator_->Compare(pik, range_tombstone_iters_[i]->end_key()) <
+             0);
+      std::string target;
+      AppendInternalKey(&target, range_tombstone_iters_[i]->end_key());
+      SeekImpl(target, current->level, true);
+      // SeekImpl takes care of PopDeleteRangeStart()
+      return true /* current key deleted */;
+    } else if (i == current->level) {
+      // range tombstone is from the same level as current, check sequence
+      // number. By `active_` we know current key is between start key and end
+      // key.
+      assert(comparator_->Compare(range_tombstone_iters_[i]->start_key(),
+                                  pik) <= 0);
+      assert(comparator_->Compare(pik, range_tombstone_iters_[i]->end_key()) <
+             0);
+      if (pik.sequence < range_tombstone_iters_[current->level]->seq()) {
+        // covered by range tombstone
+        current->iter.Next();
+        if (current->iter.Valid()) {
+          minHeap_.replace_top(current);
+        } else {
+          minHeap_.pop();
+        }
+        return true /* current key deleted */;
       } else {
-        considerStatus(current->status());
-        minHeap_.pop();
+        return false /* current key not deleted */;
       }
-      return true /* entry deleted */;
+    } else {
+      return false /* current key not deleted */;
+      // range tombstone from an older sorted run with current key < end key.
+      // current key is not deleted and the older sorted run will have its range
+      // tombstone updated when the range tombstone's end key are popped from
+      // minHeap_.
     }
-    assert(pik.sequence < range_tombstone_iter->seq());
-    // i < level
-    // tombstone->Valid() means there is a valid sequence number
-    std::string target;
-    AppendInternalKey(&target, range_tombstone_iter->end_key());
-    // The second parameter could also be i + 1. For levels [i + 1, `level`),
-    // their iters are pointing at a user key that is larger than current_
-    // from `level`. So it might not be worth seeking, and we use `level` here.
-    // One drawback of using `level` is potential redundant seeks as in the
-    // following todo.
-    // TODO: we probably do some redundant seeks when the same range tombstone
-    // triggers multiple SeekImpl(). We can use range_tombstone_reseek in
-    // SeekImpl() to do some optimization: check if a child iter's current key
-    // is after target before calling Seek.
-    SeekImpl(target, level, true /* tombstone_reseek */);
-    return true /* entry deleted */;
   }
-  return false /* not deleted */;
+  // we can reach here only if active is empty
+  assert(active_.empty());
+  assert(minHeap_.top()->type == HeapItem::ITERATOR);
+  return false /* current key not deleted */;
 }
 
 void MergingIterator::SeekForPrevImpl(const Slice& target,
@@ -696,44 +808,40 @@ void MergingIterator::SeekForPrevImpl(const Slice& target,
   status_ = Status::OK();
   IterKey current_search_key;
   current_search_key.SetInternalKey(target, false /* copy */);
+  // Seek target might change to some range tombstone end key, so
+  // we need to remember them for async requests.
   // (level, target) pairs
-  autovector<std::pair<size_t, std::string>> pinned_prefetched_target;
+  autovector<std::pair<size_t, std::string>> prefetched_target;
 
   for (auto level = starting_level; level < children_.size(); ++level) {
     {
       PERF_TIMER_GUARD(seek_child_seek_time);
-      children_[level].SeekForPrev(current_search_key.GetInternalKey());
+      children_[level].iter.SeekForPrev(current_search_key.GetInternalKey());
     }
 
     PERF_COUNTER_ADD(seek_child_seek_count, 1);
 
-    if (!range_tombstones_.iters.empty()) {
+    if (!range_tombstone_iters_.empty()) {
       if (range_tombstone_reseek) {
         // This seek is to some range tombstone end key.
         // Should only happen when there are range tombstones.
         PERF_COUNTER_ADD(internal_range_del_reseek_count, 1);
       }
-      if (children_[level].status().IsTryAgain()) {
-        // search target might change to some range tombstone end key, so
-        // we need to remember them for async requests.
-        pinned_prefetched_target.emplace_back(
+      if (children_[level].iter.status().IsTryAgain()) {
+        prefetched_target.emplace_back(
             level, current_search_key.GetInternalKey().ToString());
       }
-      auto range_tombstone_iter = range_tombstones_.iters[level];
+      auto range_tombstone_iter = range_tombstone_iters_[level];
       if (range_tombstone_iter) {
         range_tombstone_iter->SeekForPrev(current_search_key.GetUserKey());
-        if (!range_tombstone_iter->Valid()) {
-          range_tombstones_.active.erase(level);
-        } else {
-          range_tombstones_.active.insert(level);
-
+        if (range_tombstone_iter->Valid()) {
+          InsertRangeTombstoneToMaxHeap(level);
           // start key <= current_search_key guaranteed by the Seek() call above
           // Only interested in user key coverage since older sorted runs must
           // have smaller sequence numbers than this tombstone.
           if (comparator_->user_comparator()->Compare(
                   current_search_key.GetUserKey(),
-                  range_tombstone_iter->end_key().user_key) < 0 &&
-              range_tombstone_iter->seq()) {
+                  range_tombstone_iter->end_key().user_key) < 0) {
             range_tombstone_reseek = true;
             // covered by this range tombstone
             current_search_key.SetInternalKey(
@@ -741,15 +849,13 @@ void MergingIterator::SeekForPrevImpl(const Slice& target,
                 kValueTypeForSeekForPrev);
           }
         }
-      } else {
-        range_tombstones_.active.erase(level);
       }
     }
-    // child.status() is set to Status::TryAgain indicating asynchronous
+    // child.iter.status() is set to Status::TryAgain indicating asynchronous
     // request for retrieval of data blocks has been submitted. So it should
     // return at this point and Seek should be called again to retrieve the
     // requested block and add the child to min heap.
-    if (children_[level].status().IsTryAgain()) {
+    if (children_[level].iter.status().IsTryAgain()) {
       continue;
     }
     {
@@ -764,162 +870,147 @@ void MergingIterator::SeekForPrevImpl(const Slice& target,
     AddToMaxHeapOrCheckStatus(&children_[level]);
   }
 
-  if (range_tombstones_.iters.empty()) {
+  if (range_tombstone_iters_.empty()) {
     for (auto& child : children_) {
-      if (child.status().IsTryAgain()) {
-        child.Seek(target);
+      if (child.iter.status().IsTryAgain()) {
+        child.iter.SeekForPrev(target);
         {
           PERF_TIMER_GUARD(seek_min_heap_time);
-          AddToMinHeapOrCheckStatus(&child);
+          AddToMaxHeapOrCheckStatus(&child);
         }
         PERF_COUNTER_ADD(number_async_seek, 1);
       }
     }
   } else {
-    for (auto& prefetch : pinned_prefetched_target) {
-      children_[prefetch.first].SeekForPrev(prefetch.second);
+    for (auto& prefetch : prefetched_target) {
+      // (level, target) pairs
+      children_[prefetch.first].iter.SeekForPrev(prefetch.second);
       {
         PERF_TIMER_GUARD(seek_max_heap_time);
         AddToMaxHeapOrCheckStatus(&children_[prefetch.first]);
       }
       PERF_COUNTER_ADD(number_async_seek, 1);
     }
+    for (size_t level = 0; level < starting_level; ++level) {
+      PERF_TIMER_GUARD(seek_max_heap_time);
+      if (range_tombstone_iters_[level] &&
+          range_tombstone_iters_[level]->Valid()) {
+        InsertRangeTombstoneToMaxHeap(level);
+      }
+    }
   }
 }
 
-// Returns true iff the current key (max heap top) is deleted by some range
-// deletion, move the iterator at heap top backward if so. Heap order is
-// restored. See FindNextVisibleEntry() for more detail on internal
-// implementation of advancing child iters.
-//
-// REQUIRES: max heap is currently not empty, and iter is in kReverse direction.
+// See IsNextDeleted().
+// REQUIRES:
+// - max heap is currently not empty, and iter is in kReverse direction.
+// - maxHeap_ top is not DELETE_RANGE_END (so that active_ is `active_` is
+// current).
 bool MergingIterator::IsPrevDeleted() {
+  // 3 types of keys:
+  // - point key
+  // - file boundary sentinel keys
+  // - range deletion end key
   auto current = maxHeap_->top();
-  auto level = GetChildIndex(current);
-  if (current->IsDeleteRangeSentinelKey()) {
-    // Sentinel key: file boundary used as a fake key, always delete and move to
-    // prev. We need this sentinel key to keep level iterator from advancing to
-    // next SST file when current range tombstone is still in effect.
-    current->Prev();
-    if (current->Valid()) {
+  if (current->type == HeapItem::DELETE_RANGE_START) {
+    maxHeap_->pop();
+    active_.erase(current->level);
+    assert(range_tombstone_iters_[current->level] &&
+           range_tombstone_iters_[current->level]->Valid());
+    range_tombstone_iters_[current->level]->Prev();
+    if (range_tombstone_iters_[current->level]->Valid()) {
+      InsertRangeTombstoneToMaxHeap(current->level);
+    }
+    return true /* current key deleted */;
+  }
+  if (current->iter.IsDeleteRangeSentinelKey()) {
+    // Different from IsNextDeleted(), range tombstone start key is before file
+    // boundary due to op_type set in SetTombstoneEndKey().
+    assert(ExtractValueType(current->iter.key()) != kTypeRangeDeletion ||
+           active_.count(current->level));
+    // LevelIterator enters a new SST file
+    current->iter.Prev();
+    if (current->iter.Valid()) {
+      assert(current->iter.status().ok());
       maxHeap_->replace_top(current);
-      assert((!range_tombstones_.iters[level] &&
-              range_tombstones_.active.count(level) == 0) ||
-             (range_tombstones_.iters[level] &&
-              range_tombstones_.active.count(level) &&
-              range_tombstones_.iters[level]->Valid()));
     } else {
-      considerStatus(current->status());
       maxHeap_->pop();
-      assert(!range_tombstones_.iters[level] &&
-             range_tombstones_.active.count(level) == 0);
     }
-    return true /* entry deleted */;
+    if (!maxHeap_->empty() && maxHeap_->top()->level == current->level &&
+        maxHeap_->top()->type == HeapItem::DELETE_RANGE_START) {
+      maxHeap_->pop();
+      active_.erase(current->level);
+    }
+    if (range_tombstone_iters_[current->level] &&
+        range_tombstone_iters_[current->level]->Valid()) {
+      InsertRangeTombstoneToMaxHeap(current->level);
+    }
+    return true /* current key deleted */;
   }
+  assert(current->type == HeapItem::ITERATOR);
+  // Point key case: check active_ for range tombstone coverage.
   ParsedInternalKey pik;
-  // TODO: error handling
-  ParseInternalKey(current->key(), &pik, false /* log_error_key */)
-      .PermitUncheckedError();
-  // Check for sorted runs [0, level] for potential covering range tombstone.
-  // For all sorted runs newer than the sorted run containing current key:
-  //  we advance their range tombstone iter to cover current user key (or before
-  //  if there is no such tombstone). We can do so since current key is at top
-  //  of the heap, which means all previous iters must pointer to a user key
-  //  less than or equal to the current user key.
-  assert(range_tombstones_.ActiveIsCorrect());
-  for (auto i = range_tombstones_.active.begin();
-       i != range_tombstones_.active.end() && *i <= level;) {
-    auto range_tombstone_iter = range_tombstones_.iters[*i];
-    assert(range_tombstone_iter && range_tombstone_iter->Valid());
-
-    if (comparator_->Compare(range_tombstone_iter->end_key(), pik) <= 0) {
-      // tombstone end key <= current key
-      ++i;
-      continue;
-    }
-
-    if (comparator_->Compare(pik, range_tombstone_iter->start_key()) < 0) {
-      range_tombstone_iter->SeekForPrev(pik.user_key);
-      // Exhausted all range tombstones at i-th level
-      if (!range_tombstone_iter->Valid()) {
-        i = range_tombstones_.active.erase(i);
-        continue;
-      }
-      // The above Seek() guarantees tombstone start key <= current internal key
-      // (internal key), now make sure current key < tombstone end key
-      if (comparator_->Compare(range_tombstone_iter->end_key(), pik) <= 0) {
-        // tombstone end key <= current key
-        ++i;
-        continue;
-      }
-    }
-
-    // Now we know start key <= current key < end key (internal key).
-    // Check sequence number if the range tombstone is from the same level
-    // as current key. Note that there
-    // should be no need to seek sequence number since tombstone_iter->Seek()
-    // does it and Valid() guarantees that seqno is valid.
-    if (*i == level) {
-      if (pik.sequence >= range_tombstone_iter->seq()) {
-        // tombstone is older than current internal key
-        // equal case for range tombstones in ingested files: point key takes
-        // precedence
-        ++i;
-        continue;
-      }
-      // move to next key without seeking
-      // current key is covered by tombstone from the same level
-      // it's impossible we go invalid because of tombstone sentinel
-      // it's also impossible that the current tombstone iter becomes invalid
-      current->Prev();
-      assert(range_tombstones_.active.count(level) &&
-             range_tombstones_.iters[level] &&
-             range_tombstones_.iters[level]->Valid());
-      if (current->Valid()) {
-        maxHeap_->replace_top(current);
+  ParseInternalKey(current->iter.key(), &pik, false).PermitUncheckedError();
+  for (auto& i : active_) {
+    if (i < current->level) {
+      // range tombstone is from a newer level, definitely covers
+      assert(comparator_->Compare(range_tombstone_iters_[i]->start_key(),
+                                  pik) <= 0);
+      assert(comparator_->Compare(pik, range_tombstone_iters_[i]->end_key()) <
+             0);
+      std::string target;
+      AppendInternalKey(&target, range_tombstone_iters_[i]->start_key());
+      // This is different from IsDeleted() which does reseek at sorted runs >=
+      // level (instead of i+1 here). With min heap, if level L is at top of the
+      // heap, then levels <L all have internal keys > level L's current
+      // internal key, which means levels <L are already at a different user
+      // key. With max heap, if level L is at top of the heap, then levels <L
+      // all have internal keys smaller than level L's current internal key,
+      // which might still be the same user key.
+      SeekForPrevImpl(target, i + 1, true);
+      // SeekImpl takes care of PopDeleteRangeStart()
+      return true /* current key deleted */;
+    } else if (i == current->level) {
+      // By `active_` we know current key is between start key and end key.
+      assert(comparator_->Compare(range_tombstone_iters_[i]->start_key(),
+                                  pik) <= 0);
+      assert(comparator_->Compare(pik, range_tombstone_iters_[i]->end_key()) <
+             0);
+      if (pik.sequence < range_tombstone_iters_[current->level]->seq()) {
+        current->iter.Prev();
+        if (current->iter.Valid()) {
+          maxHeap_->replace_top(current);
+        } else {
+          maxHeap_->pop();
+        }
+        return true /* current key deleted */;
       } else {
-        considerStatus(current->status());
-        maxHeap_->pop();
+        return false /* current key not deleted */;
       }
-      return true /* entry deleted */;
+    } else {
+      return false /* current key not deleted */;
     }
-    assert(pik.sequence < range_tombstone_iter->seq());
-    // i < level
-    // tombstone->Valid() means there is a valid sequence number
-    std::string target;
-    AppendInternalKey(&target, range_tombstone_iter->start_key());
-    // This is different from IsDeleted() which does reseek at sorted runs >=
-    // level. With min heap, if level L is at top of the heap, then levels <L
-    // all have internal keys > level L's current internal key,
-    // which means levels <L are already at a different user key.
-    // With max heap, if level L is at top of the heap, then levels <L
-    // all have internal keys smaller than level L's current internal key,
-    // which might still be the same user key.
-    SeekForPrevImpl(target, *i + 1, true /* tombstone_reseek */);
-    return true /* entry deleted */;
   }
-  return false /* not deleted */;
+  assert(active_.empty());
+  assert(maxHeap_->top()->type == HeapItem::ITERATOR);
+  return false /* current key not deleted */;
 }
 
-size_t MergingIterator::GetChildIndex(IteratorWrapper* child) {
-  return child - &children_[0];
-}
-
-void MergingIterator::AddToMinHeapOrCheckStatus(IteratorWrapper* child) {
-  if (child->Valid()) {
-    assert(child->status().ok());
+void MergingIterator::AddToMinHeapOrCheckStatus(HeapItem* child) {
+  if (child->iter.Valid()) {
+    assert(child->iter.status().ok());
     minHeap_.push(child);
   } else {
-    considerStatus(child->status());
+    considerStatus(child->iter.status());
   }
 }
 
-void MergingIterator::AddToMaxHeapOrCheckStatus(IteratorWrapper* child) {
-  if (child->Valid()) {
-    assert(child->status().ok());
+void MergingIterator::AddToMaxHeapOrCheckStatus(HeapItem* child) {
+  if (child->iter.Valid()) {
+    assert(child->iter.status().ok());
     maxHeap_->push(child);
   } else {
-    considerStatus(child->status());
+    considerStatus(child->iter.status());
   }
 }
 
@@ -928,59 +1019,58 @@ void MergingIterator::AddToMaxHeapOrCheckStatus(IteratorWrapper* child) {
 // Seek().
 //
 // Advance all range tombstones iters, including the one corresponding to
-// current_, to the first tombstone with end_key > current_.key() (internal
-// key).
+// current_, to the first tombstone with end_key > current_.key() (user key).
 // TODO: potentially do cascading seek here too
 void MergingIterator::SwitchToForward() {
   ClearHeaps();
   Slice target = key();
   for (auto& child : children_) {
-    if (&child != current_) {
-      child.Seek(target);
-      // child.status() is set to Status::TryAgain indicating asynchronous
+    if (&child.iter != current_) {
+      child.iter.Seek(target);
+      // child.iter.status() is set to Status::TryAgain indicating asynchronous
       // request for retrieval of data blocks has been submitted. So it should
       // return at this point and Seek should be called again to retrieve the
       // requested block and add the child to min heap.
-      if (child.status() == Status::TryAgain()) {
+      if (child.iter.status() == Status::TryAgain()) {
         continue;
       }
-      if (child.Valid() && comparator_->Equal(target, child.key())) {
-        assert(child.status().ok());
-        child.Next();
+      if (child.iter.Valid() && comparator_->Equal(target, child.key())) {
+        assert(child.iter.status().ok());
+        child.iter.Next();
       }
     }
     AddToMinHeapOrCheckStatus(&child);
   }
 
-  // current range tombstone iter also need to seek for the following case:
-  //
-  // Previous direction is backward, so range tombstone iter may point to a
-  // tombstone before current_. If there is no such tombstone, then the range
-  // tombstone is !Valid(). Need to reseek here to make it valid again.
-  Slice target_user_key = ExtractUserKey(target);
-  range_tombstones_.active.clear();
-  for (size_t i = 0; i < range_tombstones_.iters.size(); ++i) {
-    if (range_tombstones_.iters[i]) {
-      range_tombstones_.iters[i]->Seek(target_user_key);
-      if (range_tombstones_.iters[i]->Valid()) {
-        range_tombstones_.active.insert(i);
-      }
-    }
-  }
-  assert(range_tombstones_.ActiveIsCorrect());
-
   for (auto& child : children_) {
-    if (child.status() == Status::TryAgain()) {
-      child.Seek(target);
-      if (child.Valid() && comparator_->Equal(target, child.key())) {
-        assert(child.status().ok());
-        child.Next();
+    if (child.iter.status() == Status::TryAgain()) {
+      child.iter.Seek(target);
+      if (child.iter.Valid() && comparator_->Equal(target, child.key())) {
+        assert(child.iter.status().ok());
+        child.iter.Next();
       }
       AddToMinHeapOrCheckStatus(&child);
     }
   }
 
+  // Current range tombstone iter also needs to seek for the following case:
+  //
+  // Previous direction is backward, so range tombstone iter may point to a
+  // tombstone before current_. If there is no such tombstone, then the range
+  // tombstone is !Valid(). Need to reseek here to make it valid again.
+  Slice target_user_key = ExtractUserKey(target);
+  for (size_t i = 0; i < range_tombstone_iters_.size(); ++i) {
+    if (range_tombstone_iters_[i]) {
+      range_tombstone_iters_[i]->Seek(target_user_key);
+      if (range_tombstone_iters_[i]->Valid()) {
+        InsertRangeTombstoneToMinHeap(i);
+      }
+    }
+  }
+
+  PopDeleteRangeStart();
   direction_ = kForward;
+  assert(current_ == CurrentForward());
 }
 
 void MergingIterator::SwitchToBackward() {
@@ -988,29 +1078,43 @@ void MergingIterator::SwitchToBackward() {
   InitMaxHeap();
   Slice target = key();
   for (auto& child : children_) {
-    if (&child != current_) {
-      child.SeekForPrev(target);
+    if (&child.iter != current_) {
+      child.iter.SeekForPrev(target);
       TEST_SYNC_POINT_CALLBACK("MergeIterator::Prev:BeforePrev", &child);
-      if (child.Valid() && comparator_->Equal(target, child.key())) {
-        assert(child.status().ok());
-        child.Prev();
+      if (child.iter.Valid() && comparator_->Equal(target, child.key())) {
+        assert(child.iter.status().ok());
+        child.iter.Prev();
       }
     }
     AddToMaxHeapOrCheckStatus(&child);
   }
 
-  Slice target_user_key = ExtractUserKey(target);
-  range_tombstones_.active.clear();
-  for (size_t i = 0; i < range_tombstones_.iters.size(); ++i) {
-    if (range_tombstones_.iters[i]) {
-      range_tombstones_.iters[i]->SeekForPrev(target_user_key);
-      if (range_tombstones_.iters[i]->Valid()) {
-        range_tombstones_.active.insert(i);
+  ParsedInternalKey pik;
+  ParseInternalKey(target, &pik, false /* log_err_key */)
+      .PermitUncheckedError();
+  for (size_t i = 0; i < range_tombstone_iters_.size(); ++i) {
+    if (range_tombstone_iters_[i]) {
+      range_tombstone_iters_[i]->SeekForPrev(pik.user_key);
+      if (range_tombstone_iters_[i]->Valid()) {
+        // Since the SeekForPrev above is only for user key,
+        // we may end up with some range deletions with start key having the
+        // same user key at current_, but with a smaller sequence number. This
+        // makes current_ not at maxHeap_ top for the CurrentReverse() call
+        // below.  n If there is a range tombstone start key with the same user
+        // key and the same sequence number as current_, it will be fine as in
+        // InsertRangeTombstoneToMaxHeap() we change op_type to be the smallest.
+        if (comparator_->Compare(pik, range_tombstone_iters_[i]->start_key()) <
+            0) {
+          range_tombstone_iters_[i]->Prev();
+          if (!range_tombstone_iters_[i]->Valid()) {
+            continue;
+          }
+        }
+        InsertRangeTombstoneToMaxHeap(i);
       }
     }
   }
-  assert(range_tombstones_.ActiveIsCorrect());
-
+  PopDeleteRangeEnd();
   direction_ = kReverse;
   if (!prefix_seek_mode_) {
     // Note that we don't do assert(current_ == CurrentReverse()) here
@@ -1020,6 +1124,7 @@ void MergingIterator::SwitchToBackward() {
     current_ = CurrentReverse();
   }
   assert(current_ == CurrentReverse());
+  assert(!current_ || maxHeap_->top()->type == HeapItem::ITERATOR);
 }
 
 void MergingIterator::ClearHeaps() {
@@ -1027,6 +1132,7 @@ void MergingIterator::ClearHeaps() {
   if (maxHeap_) {
     maxHeap_->clear();
   }
+  active_.clear();
 }
 
 void MergingIterator::InitMaxHeap() {
@@ -1035,32 +1141,29 @@ void MergingIterator::InitMaxHeap() {
   }
 }
 
-// For the current key (heap top), range tombstones at levels [0, current key
-// level] are examined in order. If a covering tombstone is found from a
-// level before current key's level, SeekImpl() is called to apply cascading
-// seek from current key's level. If the covering tombstone is from current
-// key's level, then the current child iterator is simply advanced to its next
-// key without reseeking.
+// Repeatedly check and remove heap top key if it is not a point key
+// that is not covered by range tombstones. SeekImpl() is called to apply
+// cascading if the heap top is a point key covered by some range tombstone from
+// a newer sorted run. If the covering tombstone is from current key's level,
+// then the current child iterator is simply advanced to its next key without
+// reseeking.
 inline void MergingIterator::FindNextVisibleEntry() {
-  // We cannot just check range_tombstones_.active.empty() for the following
-  // case. When a child iter is about to return a sentinel key due to prefix
-  // seek, its range tombstone iter could already be !Valid() and hence not
-  // in the active set. We need to skip that file's sentinel key if it's at
-  // the top of the heap before returning.
+  // When active_ is empty, we know heap top cannot be range deletion end key.
+  // It cannot be start key per method requirement.
+  PopDeleteRangeStart();
   while (!minHeap_.empty() &&
-         (!range_tombstones_.active.empty() ||
-          minHeap_.top()->IsDeleteRangeSentinelKey()) &&
+         (!active_.empty() || minHeap_.top()->IsDeleteRangeSentinelKey()) &&
          IsNextDeleted()) {
-    // move to next entry
+    PopDeleteRangeStart();
   }
 }
 
 inline void MergingIterator::FindPrevVisibleEntry() {
+  PopDeleteRangeEnd();
   while (!maxHeap_->empty() &&
-         (!range_tombstones_.active.empty() ||
-          maxHeap_->top()->IsDeleteRangeSentinelKey()) &&
+         (!active_.empty() || maxHeap_->top()->IsDeleteRangeSentinelKey()) &&
          IsPrevDeleted()) {
-    // move to previous entry
+    PopDeleteRangeEnd();
   }
 }
 
@@ -1112,9 +1215,8 @@ void MergeIteratorBuilder::AddIterator(InternalIterator* iter) {
   }
 }
 
-size_t MergeIteratorBuilder::AddRangeTombstoneIterator(
-    TruncatedRangeDelIterator* iter, std::set<size_t>** active_iter,
-    TruncatedRangeDelIterator*** iter_ptr) {
+void MergeIteratorBuilder::AddRangeTombstoneIterator(
+    TruncatedRangeDelIterator* iter, TruncatedRangeDelIterator*** iter_ptr) {
   if (!use_merging_iter) {
     use_merging_iter = true;
     if (first_iter) {
@@ -1123,17 +1225,13 @@ size_t MergeIteratorBuilder::AddRangeTombstoneIterator(
     }
   }
   merge_iter->AddRangeTombstoneIterator(iter);
-  if (active_iter) {
-    *active_iter = &merge_iter->range_tombstones_.active;
-  }
   if (iter_ptr) {
-    // This is needed instead of set to &range_tombstones_.iters[i] directly
-    // here since memory address of range_tombstones_.iters[i] might change
+    // This is needed instead of set to &range_tombstone_iters_[i] directly
+    // here since memory address of range_tombstone_iters_[i] might change
     // during vector resizing.
     range_del_iter_ptrs_.emplace_back(
-        merge_iter->range_tombstones_.iters.size() - 1, iter_ptr);
+        merge_iter->range_tombstone_iters_.size() - 1, iter_ptr);
   }
-  return merge_iter->range_tombstones_.iters.size() - 1;
 }
 
 InternalIterator* MergeIteratorBuilder::Finish(ArenaWrappedDBIter* db_iter) {
@@ -1143,14 +1241,15 @@ InternalIterator* MergeIteratorBuilder::Finish(ArenaWrappedDBIter* db_iter) {
     first_iter = nullptr;
   } else {
     for (auto& p : range_del_iter_ptrs_) {
-      *(p.second) = &(merge_iter->range_tombstones_.iters[p.first]);
+      *(p.second) = &(merge_iter->range_tombstone_iters_[p.first]);
     }
     if (db_iter) {
-      assert(!merge_iter->range_tombstones_.iters.empty());
+      assert(!merge_iter->range_tombstone_iters_.empty());
       // memtable is always the first level
       db_iter->SetMemtableRangetombstoneIter(
-          &merge_iter->range_tombstones_.iters.front());
+          &merge_iter->range_tombstone_iters_.front());
     }
+    merge_iter->Finish();
     ret = merge_iter;
     merge_iter = nullptr;
   }

--- a/table/merging_iterator.h
+++ b/table/merging_iterator.h
@@ -56,8 +56,8 @@ class MergeIteratorBuilder {
   // to where the merging iterator stores iter when Finish() is called.
   // This is used by level iterator to update range tombstones when switching
   // to a different SST file.
-  size_t AddRangeTombstoneIterator(
-      TruncatedRangeDelIterator* iter, std::set<size_t>** active_iter = nullptr,
+  void AddRangeTombstoneIterator(
+      TruncatedRangeDelIterator* iter,
       TruncatedRangeDelIterator*** iter_ptr = nullptr);
 
   // Get arena used to build the merging iterator. It is called one a child

--- a/table/merging_iterator.h
+++ b/table/merging_iterator.h
@@ -56,9 +56,9 @@ class MergeIteratorBuilder {
   // to where the merging iterator stores iter when Finish() is called.
   // This is used by level iterator to update range tombstones when switching
   // to a different SST file.
-  void AddRangeTombstoneIterator(
-      TruncatedRangeDelIterator* iter,
-      TruncatedRangeDelIterator*** range_del_iter_ptr = nullptr);
+  size_t AddRangeTombstoneIterator(
+      TruncatedRangeDelIterator* iter, std::set<size_t>** active_iter = nullptr,
+      TruncatedRangeDelIterator*** iter_ptr = nullptr);
 
   // Get arena used to build the merging iterator. It is called one a child
   // iterator needs to be allocated.
@@ -77,7 +77,7 @@ class MergeIteratorBuilder {
   bool use_merging_iter;
   Arena* arena;
   // Used to set LevelIterator.range_tombstone_iter_.
-  // See AddRangeTombstoneIterator() and Finish() for more detail.
+  // See AddRangeTombstoneIterator() for more detail.
   std::vector<std::pair<size_t, TruncatedRangeDelIterator***>>
       range_del_iter_ptrs_;
 };

--- a/table/merging_iterator.h
+++ b/table/merging_iterator.h
@@ -30,7 +30,7 @@ using InternalIterator = InternalIteratorBase<Slice>;
 // The result does no duplicate suppression.  I.e., if a particular
 // key is present in K child iterators, it will be yielded K times.
 //
-//  REQUIRES: n >= 0
+// REQUIRES: n >= 0
 extern InternalIterator* NewMergingIterator(
     const InternalKeyComparator* comparator, InternalIterator** children, int n,
     Arena* arena = nullptr, bool prefix_seek_mode = false);
@@ -52,10 +52,10 @@ class MergeIteratorBuilder {
   // Add a range tombstone iterator to underlying merge iterator.
   // See MergingIterator::AddRangeTombstoneIterator() for more detail.
   //
-  // If range_del_iter_ptr_ is not nullptr, *range_del_iter_ptr_ will point
-  // to where the merging iterator stores iter when Finish() is called.
-  // This is used by level iterator to update range tombstones when switching
-  // to a different SST file.
+  // If `iter_ptr` is not nullptr, *iter_ptr will be set to where the merging
+  // iterator stores `iter` when MergeIteratorBuilder::Finish() is called. This
+  // is used by level iterator to update range tombstone iters when switching to
+  // a different SST file.
   void AddRangeTombstoneIterator(
       TruncatedRangeDelIterator* iter,
       TruncatedRangeDelIterator*** iter_ptr = nullptr);
@@ -77,7 +77,7 @@ class MergeIteratorBuilder {
   bool use_merging_iter;
   Arena* arena;
   // Used to set LevelIterator.range_tombstone_iter_.
-  // See AddRangeTombstoneIterator() for more detail.
+  // See AddRangeTombstoneIterator() implementation for more detail.
   std::vector<std::pair<size_t, TruncatedRangeDelIterator***>>
       range_del_iter_ptrs_;
 };

--- a/utilities/debug.cc
+++ b/utilities/debug.cc
@@ -78,7 +78,6 @@ Status GetAllKeyVersions(DB* db, ColumnFamilyHandle* cfh, Slice begin_key,
   DBImpl* idb = static_cast<DBImpl*>(db->GetRootDB());
   auto icmp = InternalKeyComparator(idb->GetOptions(cfh).comparator);
   ReadOptions read_options;
-  read_options.ignore_range_deletions = true;
   Arena arena;
   ScopedArenaIterator iter(
       idb->NewInternalIterator(read_options, &arena, kMaxSequenceNumber, cfh));

--- a/utilities/debug.cc
+++ b/utilities/debug.cc
@@ -78,11 +78,10 @@ Status GetAllKeyVersions(DB* db, ColumnFamilyHandle* cfh, Slice begin_key,
   DBImpl* idb = static_cast<DBImpl*>(db->GetRootDB());
   auto icmp = InternalKeyComparator(idb->GetOptions(cfh).comparator);
   ReadOptions read_options;
-  ReadRangeDelAggregator range_del_agg(&icmp,
-                                       kMaxSequenceNumber /* upper_bound */);
+  read_options.ignore_range_deletions = true;
   Arena arena;
-  ScopedArenaIterator iter(idb->NewInternalIterator(
-      read_options, &arena, &range_del_agg, kMaxSequenceNumber, cfh));
+  ScopedArenaIterator iter(
+      idb->NewInternalIterator(read_options, &arena, kMaxSequenceNumber, cfh));
 
   if (!begin_key.empty()) {
     InternalKey ikey;


### PR DESCRIPTION
Summary: Delete range logic is moved from `DBIter` to `MergingIterator`, and `MergingIterator` will seek to the end of a range deletion if possible instead of scanning through each key and check with `RangeDelAggregator`.

With the invariant that a key in level L (consider memtable as the first level, each immutable and L0 as a separate level) has a larger sequence number than all keys in any level >L, a range tombstone `[start, end)` from level L covers all keys in its range in any level >L. This property motivates optimizations in iterator: 
- in `Seek(target)`, if level L has a range tombstone `[start, end)` that covers `target.UserKey`, then for all levels > L, we can do Seek() on `end` instead of `target` to skip some range tombstone covered keys.
- in `Next()/Prev()`, if the current key is covered by a range tombstone `[start, end)` from level L, we can do `Seek` to `end` for all levels > L.

This PR implements the above optimizations in `MergingIterator`. As all range tombstone covered keys are now skipped in `MergingIterator`, the range tombstone logic is removed from `DBIter`. The idea in this PR is similar to #7317, but this PR leaves `InternalIterator` interface mostly unchanged. **Credit**: the cascading seek optimization and the sentinel key (discussed below) are inspired by [Pebble](https://github.com/cockroachdb/pebble/blob/master/merging_iter.go) and suggested by @ajkr in #7317. The two optimizations are mostly implemented in `SeekImpl()/SeekForPrevImpl()` and `IsNextDeleted()/IsPrevDeleted()` in `merging_iterator.cc`. See comments for each method for more detail. 

One notable change is that the minHeap/maxHeap used by `MergingIterator` now contains range tombstone end keys besides point key iterators. This helps to reduce the number of key comparisons. For example, for a range tombstone `[start, end)`, a `start` and an `end` `HeapItem` are inserted into the heap. When a `HeapItem` for range tombstone start key is popped from the minHeap, we know this range tombstone becomes "active" in the sense that, before the range tombstone's end key is popped from the minHeap, all the keys popped from this heap is covered by the range tombstone's internal key range `[start, end)`.

Another major change, *delete range sentinel key*, is made to `LevelIterator`. Before this PR, when all point keys in an SST file are iterated through in `MergingIterator`, a level iterator would advance to the next SST file in its level. In the case when an SST file has a range tombstone that covers keys beyond the SST file's last point key, advancing to the next SST file would lose this range tombstone. Consequently, `MergingIterator` could return keys that should have been deleted by some range tombstone. We prevent this by pretending that file boundaries in each SST file are sentinel keys. A `LevelIterator` now only advance the file iterator once the sentinel key is processed.


Test plan:
- Added many unit tests in db_range_del_test
- Stress test: `./db_stress --readpercent=5 --prefixpercent=19 --writepercent=20 -delpercent=10 --iterpercent=44 --delrangepercent=2`
- Additional iterator stress test is added to verify against iterators against expected state: #10538. This is based on @ajkr's previous attempt https://github.com/facebook/rocksdb/pull/5506#issuecomment-506021913. 

```
python3 ./tools/db_crashtest.py blackbox --simple --write_buffer_size=524288 --target_file_size_base=524288 --max_bytes_for_level_base=2097152 --compression_type=none --max_background_compactions=8 --value_size_mult=33 --max_key=5000000 --interval=10 --duration=7200 --delrangepercent=3 --delpercent=9 --iterpercent=25 --writepercent=60 --readpercent=3 --prefixpercent=0 --num_iterations=1000 --range_deletion_width=100 --verify_iterator_with_expected_state_one_in=1
```

- Performance benchmark: I used a similar setup as in the blog [post](http://rocksdb.org/blog/2018/11/21/delete-range.html) that introduced DeleteRange, "a database with 5 million data keys, and 10000 range tombstones (ignoring those dropped during compaction) that were written in regular intervals after 4.5 million data keys were written".  As expected, the performance with this PR depends on the range tombstone width.
```
# Setup: 
TEST_TMPDIR=/dev/shm ./db_bench_main --benchmarks=fillrandom --writes=4500000 --num=5000000
TEST_TMPDIR=/dev/shm ./db_bench_main --benchmarks=overwrite --writes=500000 --num=5000000 --use_existing_db=true --writes_per_range_tombstone=50

# Scan entire DB
TEST_TMPDIR=/dev/shm ./db_bench_main --benchmarks=readseq[-X5] --use_existing_db=true --num=5000000 --disable_auto_compactions=true

# Short range scan (10 Next())
TEST_TMPDIR=/dev/shm/width-100/ ./db_bench_main --benchmarks=seekrandom[-X5] --use_existing_db=true --num=500000 --reads=100000 --seek_nexts=10 --disable_auto_compactions=true

# Long range scan(1000 Next())
TEST_TMPDIR=/dev/shm/width-100/ ./db_bench_main --benchmarks=seekrandom[-X5] --use_existing_db=true --num=500000 --reads=2500 --seek_nexts=1000 --disable_auto_compactions=true
```
Avg over of 10 runs (some slower tests had fews runs):

For the first column (tombstone), 0 means no range tombstone, 100-10000 means width of the 10k range tombstones, and 1 means there is a single range tombstone in the entire DB (width is 1000). The 1 tombstone case is to test regression when there's very few range tombstones in the DB, as no range tombstone is likely to take a different code path than with range tombstones.

- Scan entire DB

| tombstone width | Pre-PR ops/sec | Post-PR ops/sec | ±% |
| ------------- | ------------- | ------------- |  ------------- | 
| 0 range tombstone    |2525600 (± 43564)    |2486917 (± 33698)    |-1.53%               |
| 100   |1853835 (± 24736)    |2073884 (± 32176)    |+11.87%              |
| 1000  |422415 (± 7466)      |1115801 (± 22781)    |+164.15%             |
| 10000 |22384 (± 227)        |227919 (± 6647)      |+918.22%             |
| 1 range tombstone      |2176540 (± 39050)    |2434954 (± 24563)    |+11.87%              |
- Short range scan

| tombstone width | Pre-PR ops/sec | Post-PR ops/sec | ±% |
| ------------- | ------------- | ------------- |  ------------- | 
| 0  range tombstone   |35398 (± 533)        |35338 (± 569)        |-0.17%               |
| 100   |28276 (± 664)        |31684 (± 331)        |+12.05%              |
| 1000  |7637 (± 77)          |25422 (± 277)        |+232.88%             |
| 10000 |1367                 |28667                |+1997.07%            |
| 1 range tombstone      |32618 (± 581)        |32748 (± 506)        |+0.4%                |


- Long range scan 

| tombstone width | Pre-PR ops/sec | Post-PR ops/sec | ±% |
| ------------- | ------------- | ------------- |  ------------- | 
| 0 range tombstone     |2262 (± 33)          |2353 (± 20)          |+4.02%               |
| 100   |1696 (± 26)          |1926 (± 18)          |+13.56%              |
| 1000  |410 (± 6)            |1255 (± 29)          |+206.1%              |
| 10000 |25                   |414                  |+1556.0%             |
| 1 range tombstone   |1957 (± 30)          |2185 (± 44)          |+11.65%              |


- Microbench does not show significant regression: https://gist.github.com/cbi42/59f280f85a59b678e7e5d8561e693b61