### PR TITLE
Avoid dynamic memory allocation on read path

### DIFF
--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -777,7 +777,6 @@ class TestSecondaryCache : public SecondaryCache {
         cache_->Release(handle);
       }
     }
-    last_create_cb_ = create_cb;
     return secondary_handle;
   }
 
@@ -806,10 +805,6 @@ class TestSecondaryCache : public SecondaryCache {
     } else {
       EXPECT_EQ(ckey_prefix_, current_prefix.ToString());
     }
-  }
-
-  Status CreateCallback(const void* buf, size_t size, void** out_obj, size_t* charge) {
-    return last_create_cb_(buf, size, out_obj, charge);
   }
 
  private:
@@ -856,9 +851,6 @@ class TestSecondaryCache : public SecondaryCache {
   bool inject_failure_;
   std::string ckey_prefix_;
   ResultMap result_map_;
-
-  // only used for test
-  Cache::CreateCallback last_create_cb_;
 };
 
 class DBSecondaryCacheTest : public DBTestBase {
@@ -994,11 +986,6 @@ TEST_F(LRUCacheSecondaryCacheTest, BasicTest) {
   PerfContext perf_ctx = *get_perf_context();
   ASSERT_EQ(perf_ctx.secondary_cache_hit_count, secondary_cache->num_lookups());
 
-  char buff[256];
-  size_t size = 256;
-  void *output;
-  size_t output_size;
-  ASSERT_OK(secondary_cache->CreateCallback(buff, size, &output, &output_size));
   cache.reset();
   secondary_cache.reset();
 }

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -777,6 +777,7 @@ class TestSecondaryCache : public SecondaryCache {
         cache_->Release(handle);
       }
     }
+    last_create_cb_ = create_cb;
     return secondary_handle;
   }
 
@@ -805,6 +806,10 @@ class TestSecondaryCache : public SecondaryCache {
     } else {
       EXPECT_EQ(ckey_prefix_, current_prefix.ToString());
     }
+  }
+
+  Status CreateCallback(const void* buf, size_t size, void** out_obj, size_t* charge) {
+    return last_create_cb_(buf, size, out_obj, charge);
   }
 
  private:
@@ -851,6 +856,9 @@ class TestSecondaryCache : public SecondaryCache {
   bool inject_failure_;
   std::string ckey_prefix_;
   ResultMap result_map_;
+
+  // only used for test
+  Cache::CreateCallback last_create_cb_;
 };
 
 class DBSecondaryCacheTest : public DBTestBase {
@@ -986,6 +994,11 @@ TEST_F(LRUCacheSecondaryCacheTest, BasicTest) {
   PerfContext perf_ctx = *get_perf_context();
   ASSERT_EQ(perf_ctx.secondary_cache_hit_count, secondary_cache->num_lookups());
 
+  char buff[256];
+  size_t size = 256;
+  void *output;
+  size_t output_size;
+  ASSERT_OK(secondary_cache->CreateCallback(buff, size, &output, &output_size));
   cache.reset();
   secondary_cache.reset();
 }

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -317,12 +317,12 @@ class BlockBasedTable : public TableReader {
   void UpdateCacheMissMetrics(BlockType block_type,
                               GetContext* get_context) const;
 
+  template <typename TBlocklike>
   Cache::Handle* GetEntryFromCache(const CacheTier& cache_tier,
                                    Cache* block_cache, const Slice& key,
                                    BlockType block_type, const bool wait,
                                    GetContext* get_context,
                                    const Cache::CacheItemHelper* cache_helper,
-                                   const Cache::CreateCallback& create_cb,
                                    Cache::Priority priority) const;
 
   template <typename TBlocklike>


### PR DESCRIPTION
Summary: lambda function dynamicly allocates memory from heap if it needs to
capture multiple values, which could be expensive.
Switch to explictly use local functor from stack.

Test Plan: CI
db_bench shows ~2-3% read improvement:
```
# before the change
TEST_TMPDIR=/tmp/dbbench4 ./db_bench_main --benchmarks=filluniquerandom,readrandom -compression_type=none -max_background_jobs=12 -num=10000000
readrandom   :       8.528 micros/op 117265 ops/sec 85.277 seconds 10000000 operations;   13.0 MB/s (10000000 of 10000000 found)
# after the change
TEST_TMPDIR=/tmp/dbbench5 ./db_bench_new --benchmarks=filluniquerandom,readrandom -compression_type=none -max_background_jobs=12 -num=10000000
readrandom   :       8.263 micros/op 121015 ops/sec 82.634 seconds 10000000 operations;   13.4 MB/s (10000000 of 10000000 found)
```
details: https://gist.github.com/jay-zhuang/5ac0628db8fc9cbcb499e056d4cb5918

Micro-benchmark shows a similar improvement ~1-2%:
before the change:
https://gist.github.com/jay-zhuang/9dc0ebf51bbfbf4af82f6193d43cf75b
after the change:
https://gist.github.com/jay-zhuang/fc061f1813cd8f441109ad0b0fe7c185