### PR TITLE
Improve universal compaction picker for tiered compaction

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@
 * To minimize the internal fragmentation caused by the variable size of the compressed blocks in `CompressedSecondaryCache`, the original block is split according to the jemalloc bin size in `Insert()` and then merged back in `Lookup()`.
 * PosixLogger is removed and by default EnvLogger will be used for info logging. The behavior of the two loggers should be very similar when using the default Posix Env.
 * Remove [min|max]_timestamp from VersionEdit for now since they are not tracked in MANIFEST anyway but consume two empty std::string (up to 64 bytes) for each file. Should they be added back in the future, we should store them more compactly.
+* Improve universal tiered storage compaction picker to avoid extra major compaction triggered by size amplification. If `preclude_last_level_data_seconds` is enabled, the size amplification is calculated within non last_level data only which skip the last level and use the penultimate level as the size base.
 
 ### Performance Improvements
 * Instead of constructing `FragmentedRangeTombstoneList` during every read operation, it is now constructed once and stored in immutable memtables. This improves speed of querying range tombstones from immutable memtables.  

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -3175,28 +3175,107 @@ TEST_F(CompactionPickerTest, UniversalMarkedManualCompaction) {
   ASSERT_EQ(0U, vstorage_->FilesMarkedForCompaction().size());
 }
 
-TEST_F(CompactionPickerTest, UniversalSizeAmpTierCompaction) {
+TEST_F(CompactionPickerTest, UniversalSizeAmpTierCompactionNonLastLevel) {
+  // This test make sure size amplification compaction could still be triggered
+  // if the last sorted run is not the last level.
   const uint64_t kFileSize = 100000;
   const int kNumLevels = 7;
+  const int kLastLevel = kNumLevels - 1;
 
   ioptions_.compaction_style = kCompactionStyleUniversal;
   ioptions_.preclude_last_level_data_seconds = 1000;
+  mutable_cf_options_.compaction_options_universal.max_size_amplification_percent = 200;
   UniversalCompactionPicker universal_compaction_picker(ioptions_, &icmp_);
 
   NewVersionStorage(kNumLevels, kCompactionStyleUniversal);
   Add(0, 100U, "100", "300", 1 * kFileSize);
   Add(0, 101U, "200", "400", 1 * kFileSize);
-  Add(5, 90U, "100", "600", 10 * kFileSize);
-  Add(6, 80U, "200", "300", 1 * kFileSize);
+  Add(4, 90U, "100", "600", 4 * kFileSize);
+  Add(5, 80U, "200", "300", 2 * kFileSize);
   UpdateVersionStorageInfo();
 
   std::unique_ptr<Compaction> compaction(
       universal_compaction_picker.PickCompaction(
           cf_name_, mutable_cf_options_, mutable_db_options_, vstorage_.get(),
           &log_buffer_));
-  std::cout << static_cast<int>(compaction->compaction_reason()) << std::endl;
-  std::cout << compaction->output_level() << std::endl;
+
+  // Make sure it's a size amp compaction and includes all files
+  ASSERT_EQ(compaction->compaction_reason(), CompactionReason::kUniversalSizeAmplification);
+  ASSERT_EQ(compaction->output_level(), kLastLevel);
+  ASSERT_EQ(compaction->input_levels(0)->num_files, 2);
+  ASSERT_EQ(compaction->input_levels(4)->num_files, 1);
+  ASSERT_EQ(compaction->input_levels(5)->num_files, 1);
 }
+
+TEST_F(CompactionPickerTest, UniversalSizeRatioTierCompactionLastLevel) {
+  // This test makes sure the size amp calculation skips the last level (L6), so
+  // size amp compaction is not triggered, instead a size ratio compaction is
+  // triggered.
+  const uint64_t kFileSize = 100000;
+  const int kNumLevels = 7;
+  const int kLastLevel = kNumLevels - 1;
+  const int kPenultimateLevel = kLastLevel - 1;
+
+  ioptions_.compaction_style = kCompactionStyleUniversal;
+  ioptions_.preclude_last_level_data_seconds = 1000;
+  mutable_cf_options_.compaction_options_universal.max_size_amplification_percent = 200;
+  UniversalCompactionPicker universal_compaction_picker(ioptions_, &icmp_);
+
+  NewVersionStorage(kNumLevels, kCompactionStyleUniversal);
+  Add(0, 100U, "100", "300", 1 * kFileSize);
+  Add(0, 101U, "200", "400", 1 * kFileSize);
+  Add(5, 90U, "100", "600", 4 * kFileSize);
+  Add(6, 80U, "200", "300", 2 * kFileSize);
+  UpdateVersionStorageInfo();
+
+  std::unique_ptr<Compaction> compaction(
+      universal_compaction_picker.PickCompaction(
+          cf_name_, mutable_cf_options_, mutable_db_options_, vstorage_.get(),
+          &log_buffer_));
+
+  // Internally, size amp compaction is evaluated before size ratio compaction.
+  // Here to make sure it's size ratio compaction instead of size amp
+  ASSERT_EQ(compaction->compaction_reason(), CompactionReason::kUniversalSizeRatio);
+  ASSERT_EQ(compaction->output_level(), kPenultimateLevel - 1);
+  ASSERT_EQ(compaction->input_levels(0)->num_files, 2);
+  ASSERT_EQ(compaction->input_levels(5)->num_files, 0);
+  ASSERT_EQ(compaction->input_levels(6)->num_files, 0);
+}
+
+TEST_F(CompactionPickerTest, UniversalSizeAmpTierCompactionLastLevel) {
+  // This test makes sure the size amp compaction for tiered storage could still
+  // be triggered, but only for non-last-level files
+  const uint64_t kFileSize = 100000;
+  const int kNumLevels = 7;
+  const int kLastLevel = kNumLevels - 1;
+  const int kPenultimateLevel = kLastLevel - 1;
+
+  ioptions_.compaction_style = kCompactionStyleUniversal;
+  ioptions_.preclude_last_level_data_seconds = 1000;
+  mutable_cf_options_.compaction_options_universal.max_size_amplification_percent = 200;
+  UniversalCompactionPicker universal_compaction_picker(ioptions_, &icmp_);
+
+  NewVersionStorage(kNumLevels, kCompactionStyleUniversal);
+  Add(0, 100U, "100", "300", 3 * kFileSize);
+  Add(0, 101U, "200", "400", 2 * kFileSize);
+  Add(5, 90U, "100", "600", 2 * kFileSize);
+  Add(6, 80U, "200", "300", 2 * kFileSize);
+  UpdateVersionStorageInfo();
+
+  std::unique_ptr<Compaction> compaction(
+      universal_compaction_picker.PickCompaction(
+          cf_name_, mutable_cf_options_, mutable_db_options_, vstorage_.get(),
+          &log_buffer_));
+
+  // It's a Size Amp compaction, but doesn't include the last level file and
+  // output to the penultimate level.
+  ASSERT_EQ(compaction->compaction_reason(), CompactionReason::kUniversalSizeAmplification);
+  ASSERT_EQ(compaction->output_level(), kPenultimateLevel);
+  ASSERT_EQ(compaction->input_levels(0)->num_files, 2);
+  ASSERT_EQ(compaction->input_levels(5)->num_files, 1);
+  ASSERT_EQ(compaction->input_levels(6)->num_files, 0);
+}
+
 
 class PerKeyPlacementCompactionPickerTest
     : public CompactionPickerTest,

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -3184,7 +3184,8 @@ TEST_F(CompactionPickerTest, UniversalSizeAmpTierCompactionNonLastLevel) {
 
   ioptions_.compaction_style = kCompactionStyleUniversal;
   ioptions_.preclude_last_level_data_seconds = 1000;
-  mutable_cf_options_.compaction_options_universal.max_size_amplification_percent = 200;
+  mutable_cf_options_.compaction_options_universal
+      .max_size_amplification_percent = 200;
   UniversalCompactionPicker universal_compaction_picker(ioptions_, &icmp_);
 
   NewVersionStorage(kNumLevels, kCompactionStyleUniversal);
@@ -3200,7 +3201,8 @@ TEST_F(CompactionPickerTest, UniversalSizeAmpTierCompactionNonLastLevel) {
           &log_buffer_));
 
   // Make sure it's a size amp compaction and includes all files
-  ASSERT_EQ(compaction->compaction_reason(), CompactionReason::kUniversalSizeAmplification);
+  ASSERT_EQ(compaction->compaction_reason(),
+            CompactionReason::kUniversalSizeAmplification);
   ASSERT_EQ(compaction->output_level(), kLastLevel);
   ASSERT_EQ(compaction->input_levels(0)->num_files, 2);
   ASSERT_EQ(compaction->input_levels(4)->num_files, 1);
@@ -3218,7 +3220,8 @@ TEST_F(CompactionPickerTest, UniversalSizeRatioTierCompactionLastLevel) {
 
   ioptions_.compaction_style = kCompactionStyleUniversal;
   ioptions_.preclude_last_level_data_seconds = 1000;
-  mutable_cf_options_.compaction_options_universal.max_size_amplification_percent = 200;
+  mutable_cf_options_.compaction_options_universal
+      .max_size_amplification_percent = 200;
   UniversalCompactionPicker universal_compaction_picker(ioptions_, &icmp_);
 
   NewVersionStorage(kNumLevels, kCompactionStyleUniversal);
@@ -3235,7 +3238,8 @@ TEST_F(CompactionPickerTest, UniversalSizeRatioTierCompactionLastLevel) {
 
   // Internally, size amp compaction is evaluated before size ratio compaction.
   // Here to make sure it's size ratio compaction instead of size amp
-  ASSERT_EQ(compaction->compaction_reason(), CompactionReason::kUniversalSizeRatio);
+  ASSERT_EQ(compaction->compaction_reason(),
+            CompactionReason::kUniversalSizeRatio);
   ASSERT_EQ(compaction->output_level(), kPenultimateLevel - 1);
   ASSERT_EQ(compaction->input_levels(0)->num_files, 2);
   ASSERT_EQ(compaction->input_levels(5)->num_files, 0);
@@ -3252,7 +3256,8 @@ TEST_F(CompactionPickerTest, UniversalSizeAmpTierCompactionLastLevel) {
 
   ioptions_.compaction_style = kCompactionStyleUniversal;
   ioptions_.preclude_last_level_data_seconds = 1000;
-  mutable_cf_options_.compaction_options_universal.max_size_amplification_percent = 200;
+  mutable_cf_options_.compaction_options_universal
+      .max_size_amplification_percent = 200;
   UniversalCompactionPicker universal_compaction_picker(ioptions_, &icmp_);
 
   NewVersionStorage(kNumLevels, kCompactionStyleUniversal);
@@ -3269,13 +3274,13 @@ TEST_F(CompactionPickerTest, UniversalSizeAmpTierCompactionLastLevel) {
 
   // It's a Size Amp compaction, but doesn't include the last level file and
   // output to the penultimate level.
-  ASSERT_EQ(compaction->compaction_reason(), CompactionReason::kUniversalSizeAmplification);
+  ASSERT_EQ(compaction->compaction_reason(),
+            CompactionReason::kUniversalSizeAmplification);
   ASSERT_EQ(compaction->output_level(), kPenultimateLevel);
   ASSERT_EQ(compaction->input_levels(0)->num_files, 2);
   ASSERT_EQ(compaction->input_levels(5)->num_files, 1);
   ASSERT_EQ(compaction->input_levels(6)->num_files, 0);
 }
-
 
 class PerKeyPlacementCompactionPickerTest
     : public CompactionPickerTest,

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -3254,7 +3254,6 @@ TEST_F(CompactionPickerTest, UniversalSizeAmpTierCompactionNotSuport) {
   const uint64_t kFileSize = 100000;
   const int kNumLevels = 2;
   const int kLastLevel = kNumLevels - 1;
-  const int kPenultimateLevel = kLastLevel - 1;
 
   ioptions_.compaction_style = kCompactionStyleUniversal;
   ioptions_.preclude_last_level_data_seconds = 1000;

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -817,11 +817,13 @@ Compaction* UniversalCompactionBuilder::PickCompactionToReduceSizeAmp() {
   // size of the base sorted run for size amp calculation
   uint64_t base_sr_size = sorted_runs_.back().size;
   size_t sr_end_idx = sorted_runs_.size() - 1;
-  if (ioptions_.preclude_last_level_data_seconds > 0) {
-    if (sorted_runs_.back().level == ioptions_.num_levels - 1) {
-      sr_end_idx = sorted_runs_.size() - 2;
-      base_sr_size = sorted_runs_[sr_end_idx].size;
-    }
+  // If tiered compaction is enabled and the last sorted run is the last level
+  if (ioptions_.preclude_last_level_data_seconds > 0 &&
+      ioptions_.num_levels > 2 &&
+      sorted_runs_.back().level == ioptions_.num_levels - 1 &&
+      sorted_runs_.size() > 1) {
+    sr_end_idx = sorted_runs_.size() - 2;
+    base_sr_size = sorted_runs_[sr_end_idx].size;
   }
 
   // keep adding up all the remaining files

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -1242,7 +1242,7 @@ Compaction* UniversalCompactionBuilder::PickDeleteTriggeredCompaction() {
 }
 
 Compaction* UniversalCompactionBuilder::PickCompactionToOldest(
-    size_t start_index, rocksdb::CompactionReason compaction_reason) {
+    size_t start_index, CompactionReason compaction_reason) {
   return PickCompactionWithSortedRunRange(start_index, sorted_runs_.size() - 1,
                                           compaction_reason);
 }

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -106,7 +106,7 @@ class UniversalCompactionBuilder {
   Compaction* PickCompactionToOldest(size_t start_index,
                                      CompactionReason compaction_reason);
 
-  Compaction* PickCompactionSortedRuns(size_t start_index, size_t end_index,
+  Compaction* PickCompactionWithSortedRunRange(size_t start_index, size_t end_index,
                                        CompactionReason compaction_reason);
 
   // Try to pick periodic compaction. The caller should only call it
@@ -824,7 +824,6 @@ Compaction* UniversalCompactionBuilder::PickCompactionToReduceSizeAmp() {
     }
   }
 
-
   // keep adding up all the remaining files
   for (size_t loop = start_index; loop < sr_end_idx; loop++) {
     sr = &sorted_runs_[loop];
@@ -880,8 +879,8 @@ Compaction* UniversalCompactionBuilder::PickCompactionToReduceSizeAmp() {
       return picked;
     }
   }
-  return PickCompactionSortedRuns(start_index, sr_end_idx,
-                                  CompactionReason::kUniversalSizeAmplification);
+  return PickCompactionWithSortedRunRange(
+      start_index, sr_end_idx, CompactionReason::kUniversalSizeAmplification);
 }
 
 Compaction* UniversalCompactionBuilder::PickIncrementalForReduceSizeAmp(
@@ -1242,11 +1241,13 @@ Compaction* UniversalCompactionBuilder::PickDeleteTriggeredCompaction() {
       CompactionReason::kFilesMarkedForCompaction);
 }
 
-Compaction* UniversalCompactionBuilder::PickCompactionToOldest(size_t start_index, rocksdb::CompactionReason compaction_reason) {
-  return PickCompactionSortedRuns(start_index, sorted_runs_.size() - 1, compaction_reason);
+Compaction* UniversalCompactionBuilder::PickCompactionToOldest(
+    size_t start_index, rocksdb::CompactionReason compaction_reason) {
+  return PickCompactionWithSortedRunRange(start_index, sorted_runs_.size() - 1,
+                                          compaction_reason);
 }
 
-Compaction* UniversalCompactionBuilder::PickCompactionSortedRuns(
+Compaction* UniversalCompactionBuilder::PickCompactionWithSortedRunRange(
     size_t start_index, size_t end_index, CompactionReason compaction_reason) {
   assert(start_index < sorted_runs_.size());
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -885,6 +885,12 @@ struct AdvancedColumnFamilyOptions {
   // will be precluded from the last level.
   // 0 means no key will be precluded from the last level.
   //
+  // Note: when enabled, universal size amplification (controlled by option
+  //  `compaction_options_universal.max_size_amplification_percent`) calculation
+  //  will exclude the last level. As the feature is designed for tiered storage
+  //  and a typical setting is the last level is cold tier which is likely not
+  //  size constrained, the size amp is going to be only for non-last levels.
+  //
   // Default: 0 (disable the feature)
   uint64_t preclude_last_level_data_seconds = 0;
 


### PR DESCRIPTION
Current universal compaction picker may cause extra size amplification
compaction if there're more hot data on penultimate level. Improve the picker
to skip the last level for size amp calculation if tiered compaction is
enabled, which can
1. avoid extra unnecessary size amp compaction;
2. typically cold tier (the last level) is not size constrained, so skip size
   amp for cold tier is intended;

Test Plan: CI and added unittest