### PR TITLE
fix commit mistake

### DIFF
--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -789,7 +789,7 @@ bool BlockIter<TValue>::BinarySeek(const Slice& target, uint32_t* index,
       // blocks before "mid" are uninteresting.
       left = mid;
     } else if (cmp > 0) {
-      // Key at "mid" is >= "target". Therefore all blocks at or
+      // Key at "mid" is > "target". Therefore all blocks at or
       // after "mid" are uninteresting.
       right = mid - 1;
     } else {


### PR DESCRIPTION
Compare returns value:
```
< 0       iff "a" < "b",
== 0      iff "a" == "b",
> 0       iff "a" > "b"
```
here `cmp > 0` should be `Key at "mid" is > "target"`