### PR TITLE
Add kUseBaseAddress to OptionTypeFlags to allow a base address to be passed to option functions

### DIFF
--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -311,13 +311,7 @@ class OptionTypeInfo {
         // @return InvalidArgument if the value is not found in the map
         [map](const ConfigOptions&, const std::string& name,
               const std::string& value, void* addr) {
-          if (map == nullptr) {
-            return Status::NotSupported("No enum mapping ", name);
-          } else if (ParseEnum<T>(*map, value, static_cast<T*>(addr))) {
-            return Status::OK();
-          } else {
-            return Status::InvalidArgument("No mapping for enum ", name);
-          }
+          return StringToEnum<T>(name, map, value, static_cast<T*>(addr));
         });
     info.SetSerializeFunc(
         // Uses the map argument to convert the input enum into
@@ -327,14 +321,8 @@ class OptionTypeInfo {
         // @return InvalidArgument if the enum is not found in the map
         [map](const ConfigOptions&, const std::string& name, const void* addr,
               std::string* value) {
-          if (map == nullptr) {
-            return Status::NotSupported("No enum mapping ", name);
-          } else if (SerializeEnum<T>(*map, (*static_cast<const T*>(addr)),
-                                      value)) {
-            return Status::OK();
-          } else {
-            return Status::InvalidArgument("No mapping for enum ", name);
-          }
+          return EnumToString<T>(name, map, *static_cast<const T*>(addr),
+                                 value);
         });
     info.SetEqualsFunc(
         // Casts addr1 and addr2 to the enum type and returns true if
@@ -812,6 +800,33 @@ class OptionTypeInfo {
   Status Validate(const DBOptions& db_opts, const ColumnFamilyOptions& cf_opts,
                   const std::string& name, const void* opt_ptr) const;
 
+  template <typename E>
+  static Status StringToEnum(
+      const std::string& name,
+      const std::unordered_map<std::string, E>* const map,
+      const std::string& value, E* e) {
+    if (map == nullptr) {
+      return Status::NotSupported("No enum mapping ", name);
+    } else if (ParseEnum(*map, value, e)) {
+      return Status::OK();
+    } else {
+      return Status::InvalidArgument("No mapping for enum ", name);
+    }
+  }
+  template <typename E>
+  static Status EnumToString(
+      const std::string& name,
+      const std::unordered_map<std::string, E>* const map, E e,
+      std::string* value) {
+    if (map == nullptr) {
+      return Status::NotSupported("No enum mapping ", name);
+    } else if (SerializeEnum(*map, e, value)) {
+      return Status::OK();
+    } else {
+      return Status::InvalidArgument("No mapping for enum ", name);
+    }
+  }
+
   // Parses the input opts_map according to the type_map for the opt_addr
   // For each name-value pair in opts_map, find the corresponding name in
   // type_map If the name is found:
@@ -926,6 +941,22 @@ class OptionTypeInfo {
 
   constexpr static const char* kIdPropName() { return "id"; }
   constexpr static const char* kIdPropSuffix() { return ".id"; }
+
+  // Fix user-supplied options to be reasonable
+  template <class T, class V>
+  static void ClipToMin(T* ptr, V minvalue) {
+    if (static_cast<V>(*ptr) < minvalue) *ptr = minvalue;
+  }
+  template <class T, class V>
+  static void ClipToMax(T* ptr, V maxvalue) {
+    if (static_cast<V>(*ptr) > maxvalue) *ptr = maxvalue;
+  }
+
+  template <class T, class V>
+  static void ClipToRange(T* ptr, V minvalue, V maxvalue) {
+    ClipToMin(ptr, minvalue);
+    ClipToMax(ptr, maxvalue);
+  }
 
  private:
   int offset_;

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -101,14 +101,16 @@ enum class OptionTypeFlags : uint32_t {
   kCompareLoose = ConfigOptions::kSanityLevelLooselyCompatible,
   kCompareExact = ConfigOptions::kSanityLevelExactMatch,
 
-  kMutable = 0x0100,         // Option is mutable
-  kRawPointer = 0x0200,      // The option is stored as a raw pointer
-  kShared = 0x0400,          // The option is stored as a shared_ptr
-  kUnique = 0x0800,          // The option is stored as a unique_ptr
-  kAllowNull = 0x1000,       // The option can be null
-  kDontSerialize = 0x2000,   // Don't serialize the option
-  kDontPrepare = 0x4000,     // Don't prepare or sanitize this option
-  kStringNameOnly = 0x8000,  // The option serializes to a name only
+  kMutable = 0x00100,         // Option is mutable
+  kRawPointer = 0x00200,      // The option is stored as a raw pointer
+  kShared = 0x00400,          // The option is stored as a shared_ptr
+  kUnique = 0x00800,          // The option is stored as a unique_ptr
+  kAllowNull = 0x01000,       // The option can be null
+  kDontSerialize = 0x02000,   // Don't serialize the option
+  kDontPrepare = 0x04000,     // Don't prepare or sanitize this option
+  kStringNameOnly = 0x08000,  // The option serializes to a name only
+  kUseBaseAddress =
+      0x10000,  // Pass the base (instead of offset) to option functions
 };
 
 inline OptionTypeFlags operator|(const OptionTypeFlags &a,

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -1044,6 +1044,7 @@ void MutableCFOptions::Dump(Logger* log) const {
   ROCKS_LOG_INFO(log,
                  "                       experimental_mempurge_threshold: %f",
                  experimental_mempurge_threshold);
+  
   // Universal Compaction Options
   ROCKS_LOG_INFO(log, "compaction_options_universal.size_ratio : %d",
                  compaction_options_universal.size_ratio);

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -1044,7 +1044,6 @@ void MutableCFOptions::Dump(Logger* log) const {
   ROCKS_LOG_INFO(log,
                  "                       experimental_mempurge_threshold: %f",
                  experimental_mempurge_threshold);
-
   // Universal Compaction Options
   ROCKS_LOG_INFO(log, "compaction_options_universal.size_ratio : %d",
                  compaction_options_universal.size_ratio);

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -1044,7 +1044,7 @@ void MutableCFOptions::Dump(Logger* log) const {
   ROCKS_LOG_INFO(log,
                  "                       experimental_mempurge_threshold: %f",
                  experimental_mempurge_threshold);
-  
+
   // Universal Compaction Options
   ROCKS_LOG_INFO(log, "compaction_options_universal.size_ratio : %d",
                  compaction_options_universal.size_ratio);

--- a/options/configurable_test.cc
+++ b/options/configurable_test.cc
@@ -795,8 +795,9 @@ void ConfigurableParamTest::TestConfigureOptions(
   while (found_one && !unused.empty()) {
     found_one = false;
     for (auto iter = unused.begin(); iter != unused.end();) {
-      if (copy->ConfigureOption(config_options, iter->first, iter->second)
-              .ok()) {
+      Status s =
+          copy->ConfigureOption(config_options, iter->first, iter->second);
+      if (s.ok()) {
         found_one = true;
         iter = unused.erase(iter);
       } else {

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -256,9 +256,6 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    pin_l0_filter_and_index_blocks_in_cache),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
-        {"index_type", OptionTypeInfo::Enum<BlockBasedTableOptions::IndexType>(
-                           offsetof(struct BlockBasedTableOptions, index_type),
-                           &block_base_table_index_type_string_map)},
         {"hash_index_allow_collision",
          {0, OptionType::kBoolean, OptionVerificationType::kDeprecated,
           OptionTypeFlags::kNone}},
@@ -280,35 +277,165 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionType::kChecksumType, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"no_block_cache",
-         {offsetof(struct BlockBasedTableOptions, no_block_cache),
-          OptionType::kBoolean, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone}},
+         OptionTypeInfo(offsetof(struct BlockBasedTableOptions, no_block_cache),
+                        OptionType::kBoolean, OptionVerificationType::kNormal,
+                        OptionTypeFlags::kUseBaseAddress)
+             .SetPrepareFunc([](const ConfigOptions& /*opts*/,
+                                const std::string& /*name*/, void* addr) {
+               auto bbto = static_cast<BlockBasedTableOptions*>(addr);
+               if (bbto->no_block_cache) {
+                 bbto->block_cache.reset();
+               } else if (bbto->block_cache == nullptr) {
+                 LRUCacheOptions co;
+                 co.capacity = 8 << 20;
+                 // It makes little sense to pay overhead for mid-point
+                 // insertion while the block size is only 8MB.
+                 co.high_pri_pool_ratio = 0.0;
+                 bbto->block_cache = NewLRUCache(co);
+               }
+               return Status::OK();
+             })},
         {"block_size",
          {offsetof(struct BlockBasedTableOptions, block_size),
           OptionType::kSizeT, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
         {"block_size_deviation",
-         {offsetof(struct BlockBasedTableOptions, block_size_deviation),
-          OptionType::kInt, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone}},
+         OptionTypeInfo(
+             offsetof(struct BlockBasedTableOptions, block_size_deviation),
+             OptionType::kInt, OptionVerificationType::kNormal,
+             OptionTypeFlags::kNone)
+             .SetParseFunc([](const ConfigOptions& /*opts*/,
+                              const std::string& /*name*/,
+                              const std::string& value, void* addr) {
+               auto deviation = static_cast<int*>(addr);
+               *deviation = ParseInt(value);
+               if (*deviation < 0 || *deviation > 100) {
+                 *deviation = 0;
+               }
+               return Status::OK();
+             })
+             .SetPrepareFunc([](const ConfigOptions& /*opts*/,
+                                const std::string& /*name*/, void* addr) {
+               auto deviation = static_cast<int*>(addr);
+               if (*deviation < 0 || *deviation > 100) {
+                 *deviation = 0;
+               }
+               return Status::OK();
+             })},
         {"block_restart_interval",
-         {offsetof(struct BlockBasedTableOptions, block_restart_interval),
-          OptionType::kInt, OptionVerificationType::kNormal,
-          OptionTypeFlags::kMutable}},
+         OptionTypeInfo(
+             offsetof(struct BlockBasedTableOptions, block_restart_interval),
+             OptionType::kInt, OptionVerificationType::kNormal,
+             OptionTypeFlags::kMutable)
+             .SetParseFunc([](const ConfigOptions& /*opts*/,
+                              const std::string& /*name*/,
+                              const std::string& value, void* addr) {
+               auto interval = static_cast<int*>(addr);
+               *interval = ParseInt(value);
+               *interval = std::max(1, *interval);
+               return Status::OK();
+             })
+             .SetPrepareFunc([](const ConfigOptions& /*opts*/,
+                                const std::string& /*name*/, void* addr) {
+               auto interval = static_cast<int*>(addr);
+               *interval = std::max(1, *interval);
+               return Status::OK();
+             })},
         {"index_block_restart_interval",
-         {offsetof(struct BlockBasedTableOptions, index_block_restart_interval),
-          OptionType::kInt, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone}},
+         OptionTypeInfo(offsetof(struct BlockBasedTableOptions,
+                                 index_block_restart_interval),
+                        OptionType::kInt, OptionVerificationType::kNormal,
+                        OptionTypeFlags::kUseBaseAddress)
+             .SetParseFunc([](const ConfigOptions& /*opts*/,
+                              const std::string& /*name*/,
+                              const std::string& value, void* addr) {
+               auto bbto = static_cast<BlockBasedTableOptions*>(addr);
+               bbto->index_block_restart_interval = ParseInt(value);
+               if (bbto->index_block_restart_interval < 1) {
+                 bbto->index_block_restart_interval = 1;
+               }
+               return Status::OK();
+             })
+             .SetPrepareFunc([](const ConfigOptions& /*opts*/,
+                                const std::string& /*name*/, void* addr) {
+               auto bbto = static_cast<BlockBasedTableOptions*>(addr);
+               if (bbto->index_block_restart_interval < 1) {
+                 bbto->index_block_restart_interval = 1;
+               } else if (bbto->index_type ==
+                              BlockBasedTableOptions::kHashSearch &&
+                          bbto->index_block_restart_interval != 1) {
+                 // Currently kHashSearch is incompatible with
+                 // index_block_restart_interval > 1
+                 bbto->index_block_restart_interval = 1;
+               }
+               return Status::OK();
+             })},
+        {"index_type",
+         OptionTypeInfo(offsetof(struct BlockBasedTableOptions, index_type),
+                        OptionType::kEnum, OptionVerificationType::kNormal,
+                        OptionTypeFlags::kUseBaseAddress)
+             .SetParseFunc([](const ConfigOptions&, const std::string& name,
+                              const std::string& value, void* addr) {
+               auto bbto = static_cast<BlockBasedTableOptions*>(addr);
+               return OptionTypeInfo::StringToEnum(
+                   name, &block_base_table_index_type_string_map, value,
+                   &bbto->index_type);
+             })
+             .SetSerializeFunc([](const ConfigOptions&, const std::string& name,
+                                  const void* addr, std::string* value) {
+               auto bbto = static_cast<const BlockBasedTableOptions*>(addr);
+               return OptionTypeInfo::EnumToString(
+                   name, &block_base_table_index_type_string_map,
+                   bbto->index_type, value);
+             })
+             .SetEqualsFunc([](const ConfigOptions&, const std::string&,
+                               const void* addr1, const void* addr2,
+                               std::string*) {
+               auto bbto1 = static_cast<const BlockBasedTableOptions*>(addr1);
+               auto bbto2 = static_cast<const BlockBasedTableOptions*>(addr2);
+               return bbto1->index_type == bbto2->index_type;
+             })
+             .SetPrepareFunc([](const ConfigOptions& /*opts*/,
+                                const std::string& /*name*/, void* addr) {
+               auto bbto = static_cast<BlockBasedTableOptions*>(addr);
+               if (bbto->index_type == BlockBasedTableOptions::kHashSearch &&
+                   bbto->index_block_restart_interval != 1) {
+                 // Currently kHashSearch is incompatible with
+                 // index_block_restart_interval > 1
+                 bbto->index_block_restart_interval = 1;
+               }
+               if (bbto->partition_filters &&
+                   bbto->index_type !=
+                       BlockBasedTableOptions::kTwoLevelIndexSearch) {
+                 // We do not support partitioned filters without partitioning
+                 // indexes
+                 bbto->partition_filters = false;
+               }
+               return Status::OK();
+             })},
+        {"partition_filters",
+         OptionTypeInfo(
+             offsetof(struct BlockBasedTableOptions, partition_filters),
+             OptionType::kBoolean, OptionVerificationType::kNormal,
+             OptionTypeFlags::kUseBaseAddress)
+             .SetPrepareFunc([](const ConfigOptions& /*opts*/,
+                                const std::string& /*name*/, void* addr) {
+               auto bbto = static_cast<BlockBasedTableOptions*>(addr);
+               if (bbto->partition_filters &&
+                   bbto->index_type !=
+                       BlockBasedTableOptions::kTwoLevelIndexSearch) {
+                 // We do not support partitioned filters without partitioning
+                 // indexes
+                 bbto->partition_filters = false;
+               }
+               return Status::OK();
+             })},
         {"index_per_partition",
          {0, OptionType::kUInt64T, OptionVerificationType::kDeprecated,
           OptionTypeFlags::kNone}},
         {"metadata_block_size",
          {offsetof(struct BlockBasedTableOptions, metadata_block_size),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone}},
-        {"partition_filters",
-         {offsetof(struct BlockBasedTableOptions, partition_filters),
-          OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"optimize_filters_for_memory",
          {offsetof(struct BlockBasedTableOptions, optimize_filters_for_memory),
@@ -425,57 +552,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
 BlockBasedTableFactory::BlockBasedTableFactory(
     const BlockBasedTableOptions& _table_options)
     : table_options_(_table_options) {
-  InitializeOptions();
   RegisterOptions(&table_options_, &block_based_table_type_info);
-
-  const auto table_reader_charged =
-      table_options_.cache_usage_options.options_overrides
-          .at(CacheEntryRole::kBlockBasedTableReader)
-          .charged;
-  if (table_options_.block_cache &&
-      table_reader_charged == CacheEntryRoleOptions::Decision::kEnabled) {
-    table_reader_cache_res_mgr_.reset(new ConcurrentCacheReservationManager(
-        std::make_shared<CacheReservationManagerImpl<
-            CacheEntryRole::kBlockBasedTableReader>>(
-            table_options_.block_cache)));
-  }
-}
-
-void BlockBasedTableFactory::InitializeOptions() {
   if (table_options_.flush_block_policy_factory == nullptr) {
     table_options_.flush_block_policy_factory.reset(
         new FlushBlockBySizePolicyFactory());
-  }
-  if (table_options_.no_block_cache) {
-    table_options_.block_cache.reset();
-  } else if (table_options_.block_cache == nullptr) {
-    LRUCacheOptions co;
-    co.capacity = 8 << 20;
-    // It makes little sense to pay overhead for mid-point insertion while the
-    // block size is only 8MB.
-    co.high_pri_pool_ratio = 0.0;
-    table_options_.block_cache = NewLRUCache(co);
-  }
-  if (table_options_.block_size_deviation < 0 ||
-      table_options_.block_size_deviation > 100) {
-    table_options_.block_size_deviation = 0;
-  }
-  if (table_options_.block_restart_interval < 1) {
-    table_options_.block_restart_interval = 1;
-  }
-  if (table_options_.index_block_restart_interval < 1) {
-    table_options_.index_block_restart_interval = 1;
-  }
-  if (table_options_.index_type == BlockBasedTableOptions::kHashSearch &&
-      table_options_.index_block_restart_interval != 1) {
-    // Currently kHashSearch is incompatible with index_block_restart_interval > 1
-    table_options_.index_block_restart_interval = 1;
-  }
-  if (table_options_.partition_filters &&
-      table_options_.index_type !=
-          BlockBasedTableOptions::kTwoLevelIndexSearch) {
-    // We do not support partitioned filters without partitioning indexes
-    table_options_.partition_filters = false;
   }
   auto& options_overrides =
       table_options_.cache_usage_options.options_overrides;
@@ -490,11 +570,41 @@ void BlockBasedTableFactory::InitializeOptions() {
       options_overrides_iter->second.charged = options.charged;
     }
   }
+
+  ConfigOptions initialize;
+  initialize.invoke_prepare_options = false;
+  //**TODO: Call PrepareOptions instead
+  for (const auto& iter : block_based_table_type_info) {
+    const auto& opt_info = iter.second;
+    if (opt_info.ShouldPrepare() && !opt_info.IsCustomizable()) {
+      Status s = opt_info.Prepare(initialize, iter.first, &table_options_);
+      assert(s.ok());
+    }
+  }
+  InitializeOptions();
+}
+
+void BlockBasedTableFactory::InitializeOptions() {
+  //**TODO: Move this code into PrepareOptions
+  const auto table_reader_charged =
+      table_options_.cache_usage_options.options_overrides
+          .at(CacheEntryRole::kBlockBasedTableReader)
+          .charged;
+  if (table_options_.block_cache &&
+      table_reader_charged == CacheEntryRoleOptions::Decision::kEnabled) {
+    table_reader_cache_res_mgr_.reset(new ConcurrentCacheReservationManager(
+        std::make_shared<CacheReservationManagerImpl<
+            CacheEntryRole::kBlockBasedTableReader>>(
+            table_options_.block_cache)));
+  }
 }
 
 Status BlockBasedTableFactory::PrepareOptions(const ConfigOptions& opts) {
-  InitializeOptions();
-  return TableFactory::PrepareOptions(opts);
+  Status s = TableFactory::PrepareOptions(opts);
+  if (s.ok()) {
+    //**TODO: Setup cache_res_mgr (move from InitializeOptions)
+  }
+  return s;
 }
 
 namespace {


### PR DESCRIPTION
This PR adds a kUseBaseAddress to the OptionTypeFlags.  When set, it causes the OptionTypeInfo functions (ParseFunc, SerializeFunc, etc) to be invoked with the base address of the struct rather than the offset address of the field.

The primary use cases envisioned for this feature are as follows:
- When doing a Prepare/Validate, two fields off a struct are related and need to be checked together;
-  When doing a Parse/Configure, two fields may be set by a single option name/parameter.  For example, if a std::shared_ptr<Env> is added to the Options struct, this might be set by the same CreateFromString as the "raw" env

This PR, along with #10387 and a future PR will address #10079.

