### PR TITLE
Add mutex to RegisteredOptions

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -249,6 +249,7 @@ bool StressTest::BuildOptionsTable() {
            "2",
        }},
       {"max_sequential_skip_in_iterations", {"4", "8", "12"}},
+      {"block_based_table_factory", {"{block_size=2048}", "{block_size=4096}"}},
   };
 
   if (FLAGS_allow_setting_blob_options_dynamically) {

--- a/options/configurable_helper.h
+++ b/options/configurable_helper.h
@@ -174,7 +174,7 @@ class ConfigurableHelper {
   // @return         A pointer to the OptionTypeInfo from the options if found,
   //                 nullptr if the name was not found in the input options
   static const OptionTypeInfo* FindOption(
-      const std::vector<Configurable::RegisteredOptions>& options,
+      const std::deque<Configurable::RegisteredOptions>& options,
       const std::string& name, std::string* opt_name, void** opt_ptr);
 
   static Status ConfigureCustomizableOption(

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -258,7 +258,7 @@ blackbox_default_params = {
     # since we will be killing anyway, use large value for ops_per_thread
     "ops_per_thread": 100000000,
     "reopen": 0,
-    "set_options_one_in": 10000,
+    "set_options_one_in": 100,
 }
 
 whitebox_default_params = {


### PR DESCRIPTION
Adds a mutex to the RegisteredOptions structure.  Each set of registered options (one per "struct") has its own mutex and is used while that option is being processed (serialized, configured, etc).

This change, along with #10479 and #10387, closes #10079.