### PR TITLE
Enable ClockCache in DB block cache test

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -369,7 +369,7 @@ ClockCacheShard::ClockCacheShard(
 void ClockCacheShard::EraseUnRefEntries() {
   autovector<ClockHandle> deleted;
 
-  table_.ApplyToEntriesRange(
+  table_.ApplyToEntriesRange<void>(
       [this, &deleted](ClockHandle* h) {
         // Externally unreferenced element.
         table_.Remove(h, &deleted);
@@ -404,9 +404,9 @@ void ClockCacheShard::ApplyToSomeEntries(
     *state = index_end << (32 - length_bits);
   }
 
-  table_.ApplyToEntriesRange(
+  table_.ConstApplyToEntriesRange<void>(
       [callback,
-       metadata_charge_policy = metadata_charge_policy_](ClockHandle* h) {
+       metadata_charge_policy = metadata_charge_policy_](const ClockHandle* h) {
         callback(h->key(), h->value, h->GetCharge(metadata_charge_policy),
                  h->deleter);
       },
@@ -615,8 +615,8 @@ size_t ClockCacheShard::GetPinnedUsage() const {
   // which creates additional synchronization costs.
   size_t clock_usage = 0;
 
-  table_.ConstApplyToEntriesRange(
-      [&clock_usage](ClockHandle* h) {
+  table_.ConstApplyToEntriesRange<void>(
+      [&clock_usage](const ClockHandle* h) {
         if (h->ExternalRefs() > 1) {
           // We check > 1 because we are holding an external ref.
           clock_usage += h->total_charge;

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -369,7 +369,7 @@ ClockCacheShard::ClockCacheShard(
 void ClockCacheShard::EraseUnRefEntries() {
   autovector<ClockHandle> deleted;
 
-  table_.ApplyToEntriesRange<void>(
+  table_.ApplyToEntriesRange(
       [this, &deleted](ClockHandle* h) {
         // Externally unreferenced element.
         table_.Remove(h, &deleted);
@@ -404,7 +404,7 @@ void ClockCacheShard::ApplyToSomeEntries(
     *state = index_end << (32 - length_bits);
   }
 
-  table_.ConstApplyToEntriesRange<void>(
+  table_.ConstApplyToEntriesRange(
       [callback,
        metadata_charge_policy = metadata_charge_policy_](const ClockHandle* h) {
         callback(h->key(), h->value, h->GetCharge(metadata_charge_policy),
@@ -615,7 +615,7 @@ size_t ClockCacheShard::GetPinnedUsage() const {
   // which creates additional synchronization costs.
   size_t clock_usage = 0;
 
-  table_.ConstApplyToEntriesRange<void>(
+  table_.ConstApplyToEntriesRange(
       [&clock_usage](const ClockHandle* h) {
         if (h->ExternalRefs() > 1) {
           // We check > 1 because we are holding an external ref.

--- a/cache/clock_cache.h
+++ b/cache/clock_cache.h
@@ -576,8 +576,7 @@ class ClockHandleTable {
   // metadata.
   void Free(autovector<ClockHandle>* deleted);
 
-  template <typename T>
-  void ApplyToEntriesRange(std::function<T(ClockHandle*)> func,
+  void ApplyToEntriesRange(std::function<void(ClockHandle*)> func,
                            uint32_t index_begin, uint32_t index_end,
                            bool apply_if_will_be_deleted) {
     for (uint32_t i = index_begin; i < index_end; i++) {
@@ -592,8 +591,7 @@ class ClockHandleTable {
     }
   }
 
-  template <typename T>
-  void ConstApplyToEntriesRange(std::function<T(const ClockHandle*)> func,
+  void ConstApplyToEntriesRange(std::function<void(const ClockHandle*)> func,
                                 uint32_t index_begin, uint32_t index_end,
                                 bool apply_if_will_be_deleted) const {
     for (uint32_t i = index_begin; i < index_end; i++) {

--- a/cache/clock_cache.h
+++ b/cache/clock_cache.h
@@ -577,7 +577,8 @@ class ClockHandleTable {
   void Free(autovector<ClockHandle>* deleted);
 
   template <typename T>
-  void ApplyToEntriesRange(T func, uint32_t index_begin, uint32_t index_end,
+  void ApplyToEntriesRange(std::function<T(ClockHandle*)> func,
+                           uint32_t index_begin, uint32_t index_end,
                            bool apply_if_will_be_deleted) {
     for (uint32_t i = index_begin; i < index_end; i++) {
       ClockHandle* h = &array_[i];
@@ -592,8 +593,8 @@ class ClockHandleTable {
   }
 
   template <typename T>
-  void ConstApplyToEntriesRange(T func, uint32_t index_begin,
-                                uint32_t index_end,
+  void ConstApplyToEntriesRange(std::function<T(const ClockHandle*)> func,
+                                uint32_t index_begin, uint32_t index_end,
                                 bool apply_if_will_be_deleted) const {
     for (uint32_t i = index_begin; i < index_end; i++) {
       ClockHandle* h = &array_[i];


### PR DESCRIPTION
Summary: A test in db_block_cache_test.cc was skipping ClockCache due to the 16-byte key length requirement. We fixed this. Along the way, we fixed a bug in ApplyToSomeEntries, which assumed the function being applied could modify handle metadata, and thus took an exclusive reference. This is incompatible with calls that need to inspect every element (including externally referenced ones) to gather stats.

Test plan: ``make -j24 check``