### PR TITLE
Make queries return the value of the default column for wide-column entities

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -176,6 +176,7 @@ bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
                                   const Slice& blob_index) {
   assert(!is_blob_);
   assert(!is_wide_);
+  assert(value_of_default_column_.empty());
 
   if (expose_blob_index_) {  // Stacked BlobDB implementation
     is_blob_ = true;
@@ -213,6 +214,7 @@ bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
 bool DBIter::SetWideColumnValueIfNeeded(const Slice& wide_columns_slice) {
   assert(!is_blob_);
   assert(!is_wide_);
+  assert(value_of_default_column_.empty());
 
   Slice wide_columns_copy = wide_columns_slice;
 
@@ -277,6 +279,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
 
   is_blob_ = false;
   is_wide_ = false;
+  value_of_default_column_.clear();
 
   do {
     // Will update is_key_seqnum_zero_ as soon as we parsed the current key
@@ -607,6 +610,7 @@ bool DBIter::MergeValuesNewToOld() {
 
       is_blob_ = false;
       assert(!is_wide_);
+      assert(value_of_default_column_.empty());
 
       // iter_ is positioned after put
       iter_.Next();
@@ -984,6 +988,7 @@ bool DBIter::FindValueForCurrentKey() {
   s.PermitUncheckedError();
   is_blob_ = false;
   is_wide_ = false;
+  value_of_default_column_.clear();
 
   switch (last_key_entry_type) {
     case kTypeDeletion:
@@ -1026,6 +1031,7 @@ bool DBIter::FindValueForCurrentKey() {
 
         is_blob_ = false;
         assert(!is_wide_);
+        assert(value_of_default_column_.empty());
 
         return true;
       } else if (last_not_merge_type == kTypeWideColumnEntity) {
@@ -1103,6 +1109,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
   ParsedInternalKey ikey;
   is_blob_ = false;
   is_wide_ = false;
+  value_of_default_column_.clear();
 
   while (true) {
     if (!iter_.Valid()) {
@@ -1241,6 +1248,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
 
       is_blob_ = false;
       assert(!is_wide_);
+      assert(value_of_default_column_.empty());
 
       return true;
     } else if (ikey.type == kTypeWideColumnEntity) {

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -17,6 +17,7 @@
 #include "db/merge_context.h"
 #include "db/merge_helper.h"
 #include "db/pinned_iterators_manager.h"
+#include "db/wide/wide_column_serialization.h"
 #include "file/filename.h"
 #include "logging/logging.h"
 #include "memory/arena.h"
@@ -74,6 +75,7 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       verify_checksums_(read_options.verify_checksums),
       expose_blob_index_(expose_blob_index),
       is_blob_(false),
+      is_wide_(false),
       arena_mode_(arena_mode),
       range_del_agg_(&ioptions.internal_comparator, s),
       db_impl_(db_impl),
@@ -173,6 +175,7 @@ void DBIter::Next() {
 bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
                                   const Slice& blob_index) {
   assert(!is_blob_);
+  assert(!is_wide_);
 
   if (expose_blob_index_) {  // Stacked BlobDB implementation
     is_blob_ = true;
@@ -207,13 +210,23 @@ bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
   return true;
 }
 
-bool DBIter::SetWideColumnValueIfNeeded(const Slice& /* wide_columns_slice */) {
+bool DBIter::SetWideColumnValueIfNeeded(const Slice& wide_columns_slice) {
   assert(!is_blob_);
+  assert(!is_wide_);
 
-  // TODO: support wide-column entities
-  status_ = Status::NotSupported("Encountered unexpected wide-column entity");
-  valid_ = false;
-  return false;
+  Slice wide_columns_copy = wide_columns_slice;
+
+  const Status s = WideColumnSerialization::GetValueOfDefaultColumn(
+      wide_columns_copy, value_of_default_column_);
+
+  if (!s.ok()) {
+    status_ = s;
+    valid_ = false;
+    return false;
+  }
+
+  is_wide_ = true;
+  return true;
 }
 
 // PRE: saved_key_ has the current user key if skipping_saved_key
@@ -263,6 +276,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
   bool reseek_done = false;
 
   is_blob_ = false;
+  is_wide_ = false;
 
   do {
     // Will update is_key_seqnum_zero_ as soon as we parsed the current key
@@ -590,7 +604,10 @@ bool DBIter::MergeValuesNewToOld() {
       if (!s.ok()) {
         return false;
       }
+
       is_blob_ = false;
+      assert(!is_wide_);
+
       // iter_ is positioned after put
       iter_.Next();
       if (!iter_.status().ok()) {
@@ -966,6 +983,8 @@ bool DBIter::FindValueForCurrentKey() {
   Status s;
   s.PermitUncheckedError();
   is_blob_ = false;
+  is_wide_ = false;
+
   switch (last_key_entry_type) {
     case kTypeDeletion:
     case kTypeDeletionWithTimestamp:
@@ -1004,7 +1023,10 @@ bool DBIter::FindValueForCurrentKey() {
         if (!s.ok()) {
           return false;
         }
+
         is_blob_ = false;
+        assert(!is_wide_);
+
         return true;
       } else if (last_not_merge_type == kTypeWideColumnEntity) {
         // TODO: support wide-column entities
@@ -1080,6 +1102,8 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
   // Find the next value that's visible.
   ParsedInternalKey ikey;
   is_blob_ = false;
+  is_wide_ = false;
+
   while (true) {
     if (!iter_.Valid()) {
       valid_ = false;
@@ -1214,7 +1238,10 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
       if (!s.ok()) {
         return false;
       }
+
       is_blob_ = false;
+      assert(!is_wide_);
+
       return true;
     } else if (ikey.type == kTypeWideColumnEntity) {
       // TODO: support wide-column entities

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -160,9 +160,12 @@ class DBIter final : public Iterator {
   }
   Slice value() const override {
     assert(valid_);
+    assert(!is_blob_ || !is_wide_);
 
     if (!expose_blob_index_ && is_blob_) {
       return blob_value_;
+    } else if (is_wide_) {
+      return value_of_default_column_;
     } else if (current_entry_is_merged_) {
       // If pinned_value_ is set then the result of merge operator is one of
       // the merge operands and we should return it.
@@ -326,6 +329,7 @@ class DBIter final : public Iterator {
   Slice pinned_value_;
   // for prefix seek mode to support prev()
   PinnableSlice blob_value_;
+  Slice value_of_default_column_;
   Statistics* statistics_;
   uint64_t max_skip_;
   uint64_t max_skippable_internal_keys_;
@@ -361,6 +365,7 @@ class DBIter final : public Iterator {
   // the stacked BlobDB implementation is used, false otherwise.
   bool expose_blob_index_;
   bool is_blob_;
+  bool is_wide_;
   bool arena_mode_;
   // List of operands for merge operator.
   MergeContext merge_context_;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -305,6 +305,11 @@ class DBIter final : public Iterator {
 
   bool SetWideColumnValueIfNeeded(const Slice& wide_columns_slice);
 
+  void ResetWideColumnValue() {
+    is_wide_ = false;
+    value_of_default_column_.clear();
+  }
+
   Status Merge(const Slice* val, const Slice& user_key);
 
   const SliceTransform* prefix_extractor_;

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -21,6 +21,7 @@
 #include "db/pinned_iterators_manager.h"
 #include "db/range_tombstone_fragmenter.h"
 #include "db/read_callback.h"
+#include "db/wide/wide_column_serialization.h"
 #include "logging/logging.h"
 #include "memory/arena.h"
 #include "memory/memory_usage.h"
@@ -759,12 +760,6 @@ static bool SaveValue(void* arg, const char* entry) {
                 "Encounter unsupported blob value. Please open DB with "
                 "ROCKSDB_NAMESPACE::blob_db::BlobDB instead.");
           }
-        } else {
-          assert(type == kTypeWideColumnEntity);
-
-          // TODO: support wide-column entities
-          *(s->status) =
-              Status::NotSupported("Encountered unexpected wide-column entity");
         }
 
         if (!s->status->ok()) {
@@ -798,7 +793,17 @@ static bool SaveValue(void* arg, const char* entry) {
           merge_context->PushOperand(
               v, s->inplace_update_support == false /* operand_pinned */);
         } else if (s->value != nullptr) {
-          s->value->assign(v.data(), v.size());
+          if (type != kTypeWideColumnEntity) {
+            assert(type == kTypeValue || type == kTypeBlobIndex);
+            s->value->assign(v.data(), v.size());
+          } else {
+            Slice value;
+            *(s->status) =
+                WideColumnSerialization::GetValueOfDefaultColumn(v, value);
+            if (s->status->ok()) {
+              s->value->assign(value.data(), value.size());
+            }
+          }
         }
         if (s->inplace_update_support) {
           s->mem->GetLock(s->key->user_key())->ReadUnlock();

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -68,11 +68,31 @@ TEST_F(DBWideBasicTest, PutEntity) {
       ASSERT_EQ(iter->key(), first_key);
       ASSERT_EQ(iter->value(), first_value_of_default_column);
 
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_OK(iter->status());
+      ASSERT_EQ(iter->key(), second_key);
+      ASSERT_TRUE(iter->value().empty());
+
+      iter->Next();
+      ASSERT_FALSE(iter->Valid());
+      ASSERT_OK(iter->status());
+
       iter->SeekToLast();
       ASSERT_TRUE(iter->Valid());
       ASSERT_OK(iter->status());
       ASSERT_EQ(iter->key(), second_key);
       ASSERT_TRUE(iter->value().empty());
+
+      iter->Prev();
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_OK(iter->status());
+      ASSERT_EQ(iter->key(), first_key);
+      ASSERT_EQ(iter->value(), first_value_of_default_column);
+
+      iter->Prev();
+      ASSERT_FALSE(iter->Valid());
+      ASSERT_OK(iter->status());
     }
   };
 

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -37,9 +37,8 @@ TEST_F(DBWideBasicTest, PutEntity) {
 
     {
       PinnableSlice result;
-      ASSERT_TRUE(db_->Get(ReadOptions(), db_->DefaultColumnFamily(),
-                           second_key, &result)
-                      .IsNotFound());
+      ASSERT_OK(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), second_key,
+                         &result));
       ASSERT_TRUE(result.empty());
     }
 
@@ -56,7 +55,7 @@ TEST_F(DBWideBasicTest, PutEntity) {
       ASSERT_OK(statuses[0]);
       ASSERT_EQ(values[0], first_value_of_default_column);
 
-      ASSERT_TRUE(statuses[1].IsNotFound());
+      ASSERT_OK(statuses[1]);
       ASSERT_TRUE(values[1].empty());
     }
 
@@ -64,12 +63,16 @@ TEST_F(DBWideBasicTest, PutEntity) {
       std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
 
       iter->SeekToFirst();
-      ASSERT_FALSE(iter->Valid());
-      ASSERT_TRUE(iter->status().IsNotSupported());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_OK(iter->status());
+      ASSERT_EQ(iter->key(), first_key);
+      ASSERT_EQ(iter->value(), first_value_of_default_column);
 
       iter->SeekToLast();
-      ASSERT_FALSE(iter->Valid());
-      ASSERT_TRUE(iter->status().IsNotSupported());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_OK(iter->status());
+      ASSERT_EQ(iter->key(), second_key);
+      ASSERT_TRUE(iter->value().empty());
     }
   };
 

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -15,6 +15,8 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+const Slice kDefaultWideColumnName;
+
 Status WideColumnSerialization::Serialize(const WideColumns& columns,
                                           std::string& output) {
   if (columns.size() >

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -149,7 +149,8 @@ Status WideColumnSerialization::GetValueOfDefaultColumn(Slice& input,
   }
 
   if (columns.empty() || columns[0].name() != kDefaultWideColumnName) {
-    return Status::NotFound("Default column not found");
+    value.clear();
+    return Status::OK();
   }
 
   value = columns[0].value();

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -139,4 +139,22 @@ WideColumns::const_iterator WideColumnSerialization::Find(
   return it;
 }
 
+Status WideColumnSerialization::GetValueOfDefaultColumn(Slice& input,
+                                                        Slice& value) {
+  WideColumns columns;
+
+  const Status s = Deserialize(input, columns);
+  if (!s.ok()) {
+    return s;
+  }
+
+  if (columns.empty() || columns[0].name() != kDefaultWideColumnName) {
+    return Status::NotFound("Default column not found");
+  }
+
+  value = columns[0].value();
+
+  return Status::OK();
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -48,6 +48,7 @@ class WideColumnSerialization {
 
   static WideColumns::const_iterator Find(const WideColumns& columns,
                                           const Slice& column_name);
+  static Status GetValueOfDefaultColumn(Slice& input, Slice& value);
 
   static constexpr uint32_t kCurrentVersion = 1;
 };

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -71,4 +71,6 @@ inline bool operator!=(const WideColumn& lhs, const WideColumn& rhs) {
 
 using WideColumns = std::vector<WideColumn>;
 
+extern const Slice kDefaultWideColumnName;
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -9,6 +9,7 @@
 #include "db/merge_helper.h"
 #include "db/pinned_iterators_manager.h"
 #include "db/read_callback.h"
+#include "db/wide/wide_column_serialization.h"
 #include "monitoring/file_read_sample.h"
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics.h"
@@ -258,10 +259,6 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
             state_ = kUnexpectedBlobIndex;
             return false;
           }
-        } else if (type == kTypeWideColumnEntity) {
-          // TODO: support wide-column entities
-          state_ = kUnexpectedWideColumnEntity;
-          return false;
         }
 
         if (is_blob_index_ != nullptr) {
@@ -272,14 +269,33 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
           state_ = kFound;
           if (do_merge_) {
             if (LIKELY(pinnable_val_ != nullptr)) {
+              Slice value_to_use = value;
+
+              if (type == kTypeWideColumnEntity) {
+                Slice value_copy = value;
+
+                const Status st =
+                    WideColumnSerialization::GetValueOfDefaultColumn(
+                        value_copy, value_to_use);
+
+                if (st.IsNotFound()) {
+                  state_ = kDeleted;  // will result in Status::NotFound()
+                                      // getting returned
+                  return false;
+                } else if (!st.ok()) {
+                  state_ = kCorrupt;
+                  return false;
+                }
+              }
+
               if (LIKELY(value_pinner != nullptr)) {
                 // If the backing resources for the value are provided, pin them
-                pinnable_val_->PinSlice(value, value_pinner);
+                pinnable_val_->PinSlice(value_to_use, value_pinner);
               } else {
                 TEST_SYNC_POINT_CALLBACK("GetContext::SaveValue::PinSelf",
                                          this);
                 // Otherwise copy the value
-                pinnable_val_->PinSelf(value);
+                pinnable_val_->PinSelf(value_to_use);
               }
             }
           } else {

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -274,11 +274,9 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
               if (type == kTypeWideColumnEntity) {
                 Slice value_copy = value;
 
-                const Status st =
-                    WideColumnSerialization::GetValueOfDefaultColumn(
-                        value_copy, value_to_use);
-
-                if (!st.ok()) {
+                if (!WideColumnSerialization::GetValueOfDefaultColumn(
+                         value_copy, value_to_use)
+                         .ok()) {
                   state_ = kCorrupt;
                   return false;
                 }

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -278,11 +278,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
                     WideColumnSerialization::GetValueOfDefaultColumn(
                         value_copy, value_to_use);
 
-                if (st.IsNotFound()) {
-                  state_ = kDeleted;  // will result in Status::NotFound()
-                                      // getting returned
-                  return false;
-                } else if (!st.ok()) {
+                if (!st.ok()) {
                   state_ = kCorrupt;
                   return false;
                 }


### PR DESCRIPTION
Summary:
The patch adds support for wide-column entities to the existing query
APIs (`Get`, `MultiGet`, and iterator). Namely, when during a query a
wide-column entity is encountered, we will return the value of the default
(anonymous) column as the result. Later, we plan to add wide-column
specific query APIs which will enable retrieving entire wide-column entities
or a subset of their columns.

Test Plan:
`make check`