### PR TITLE
Reset blob value as soon as it's not needed in DBIter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,6 +34,7 @@
 ### Performance Improvements
 * Instead of constructing `FragmentedRangeTombstoneList` during every read operation, it is now constructed once and stored in immutable memtables. This improves speed of querying range tombstones from immutable memtables.  
 * Improve read performance by avoiding dynamic memory allocation.
+* When using iterators with the integrated BlobDB implementation, blob cache handles are now released immediately when the iterator's position changes.
 
 ## 7.5.0 (07/15/2022)
 ### New Features

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -243,8 +243,10 @@ TEST_F(DBBlobBasicTest, IterateBlobsFromCachePinning) {
 
   Reopen(options);
 
-  // Put then iterate over three key-values. The second value is below the size limit
-  // and is thus stored inline; the other two are stored separately as blobs.
+  // Put then iterate over three key-values. The second value is below the size
+  // limit and is thus stored inline; the other two are stored separately as
+  // blobs. We expect to have something pinned in the cache iff we are
+  // positioned on a blob.
 
   constexpr char first_key[] = "first_key";
   constexpr char first_value[] = "long_value";
@@ -273,7 +275,6 @@ TEST_F(DBBlobBasicTest, IterateBlobsFromCachePinning) {
   read_options.fill_cache = true;
 
   std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
-
   for (iter->SeekToFirst(); iter->Valid(); iter->Next());
 
   iter->SeekToFirst();

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -299,6 +299,8 @@ TEST_F(DBBlobBasicTest, IterateBlobsFromCachePinning) {
 
   iter->Next();
   ASSERT_FALSE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(options.blob_cache->GetPinnedUsage(), 0);
 }
 
 TEST_F(DBBlobBasicTest, MultiGetBlobs) {

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -227,6 +227,80 @@ TEST_F(DBBlobBasicTest, IterateBlobsFromCache) {
   }
 }
 
+TEST_F(DBBlobBasicTest, IterateBlobsFromCachePinning) {
+  constexpr size_t min_blob_size = 6;
+
+  Options options = GetDefaultOptions();
+
+  LRUCacheOptions cache_options;
+  cache_options.capacity = 2048;
+  cache_options.num_shard_bits = 0;
+  cache_options.metadata_charge_policy = kDontChargeCacheMetadata;
+
+  options.blob_cache = NewLRUCache(cache_options);
+  options.enable_blob_files = true;
+  options.min_blob_size = min_blob_size;
+
+  Reopen(options);
+
+  // Put then iterate over three key-values. The second value is below the size limit
+  // and is thus stored inline; the other two are stored separately as blobs.
+
+  constexpr char first_key[] = "first_key";
+  constexpr char first_value[] = "long_value";
+  static_assert(sizeof(first_value) - 1 >= min_blob_size,
+                "first_value too short to be stored as blob");
+
+  ASSERT_OK(Put(first_key, first_value));
+
+  constexpr char second_key[] = "second_key";
+  constexpr char second_value[] = "short";
+  static_assert(sizeof(second_value) - 1 < min_blob_size,
+                "second_value too long to be inlined");
+
+  ASSERT_OK(Put(second_key, second_value));
+
+  constexpr char third_key[] = "third_key";
+  constexpr char third_value[] = "other_long_value";
+  static_assert(sizeof(third_value) - 1 >= min_blob_size,
+                "third_value too short to be stored as blob");
+
+  ASSERT_OK(Put(third_key, third_value));
+
+  ASSERT_OK(Flush());
+
+  ReadOptions read_options;
+  read_options.fill_cache = true;
+
+  std::unique_ptr<Iterator> iter(db_->NewIterator(read_options));
+
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next());
+
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(iter->key(), first_key);
+  ASSERT_EQ(iter->value(), first_value);
+  ASSERT_GT(options.blob_cache->GetPinnedUsage(), 0);
+
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(iter->key(), second_key);
+  ASSERT_EQ(iter->value(), second_value);
+  ASSERT_EQ(options.blob_cache->GetPinnedUsage(), 0);
+
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+  ASSERT_EQ(iter->key(), third_key);
+  ASSERT_EQ(iter->value(), third_value);
+  ASSERT_GT(options.blob_cache->GetPinnedUsage(), 0);
+
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+}
+
 TEST_F(DBBlobBasicTest, MultiGetBlobs) {
   constexpr size_t min_blob_size = 6;
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -177,6 +177,7 @@ void DBIter::Next() {
 bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
                                   const Slice& blob_index) {
   assert(!is_blob_);
+  assert(blob_value_.empty());
   assert(!is_wide_);
   assert(value_of_default_column_.empty());
 
@@ -216,6 +217,7 @@ bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
 
 bool DBIter::SetWideColumnValueIfNeeded(const Slice& wide_columns_slice) {
   assert(!is_blob_);
+  assert(blob_value_.empty());
   assert(!is_wide_);
   assert(value_of_default_column_.empty());
 
@@ -280,7 +282,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
   // to one.
   bool reseek_done = false;
 
-  is_blob_ = false;
+  ResetBlobValue();
   assert(!is_wide_);
   assert(value_of_default_column_.empty());
 
@@ -611,7 +613,7 @@ bool DBIter::MergeValuesNewToOld() {
         return false;
       }
 
-      is_blob_ = false;
+      ResetBlobValue();
       assert(!is_wide_);
       assert(value_of_default_column_.empty());
 
@@ -990,7 +992,8 @@ bool DBIter::FindValueForCurrentKey() {
 
   Status s;
   s.PermitUncheckedError();
-  is_blob_ = false;
+
+  ResetBlobValue();
   assert(!is_wide_);
   assert(value_of_default_column_.empty());
 
@@ -1033,7 +1036,7 @@ bool DBIter::FindValueForCurrentKey() {
           return false;
         }
 
-        is_blob_ = false;
+        ResetBlobValue();
         assert(!is_wide_);
         assert(value_of_default_column_.empty());
 
@@ -1111,7 +1114,8 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
   // In case read_callback presents, the value we seek to may not be visible.
   // Find the next value that's visible.
   ParsedInternalKey ikey;
-  is_blob_ = false;
+
+  ResetBlobValue();
   assert(!is_wide_);
   assert(value_of_default_column_.empty());
 
@@ -1250,7 +1254,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
         return false;
       }
 
-      is_blob_ = false;
+      ResetBlobValue();
       assert(!is_wide_);
       assert(value_of_default_column_.empty());
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -134,6 +134,7 @@ void DBIter::Next() {
   PERF_CPU_TIMER_GUARD(iter_next_cpu_nanos, clock_);
   // Release temporarily pinned blocks from last operation
   ReleaseTempPinnedData();
+  ResetBlobValue();
   ResetWideColumnValue();
   local_stats_.skip_count_ += num_internal_keys_skipped_;
   local_stats_.skip_count_--;
@@ -282,7 +283,8 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
   // to one.
   bool reseek_done = false;
 
-  ResetBlobValue();
+  assert(!is_blob_);
+  assert(blob_value_.empty());
   assert(!is_wide_);
   assert(value_of_default_column_.empty());
 
@@ -662,6 +664,7 @@ void DBIter::Prev() {
 
   PERF_CPU_TIMER_GUARD(iter_prev_cpu_nanos, clock_);
   ReleaseTempPinnedData();
+  ResetBlobValue();
   ResetWideColumnValue();
   ResetInternalKeysSkippedCounter();
   bool ok = true;
@@ -993,7 +996,8 @@ bool DBIter::FindValueForCurrentKey() {
   Status s;
   s.PermitUncheckedError();
 
-  ResetBlobValue();
+  assert(!is_blob_);
+  assert(blob_value_.empty());
   assert(!is_wide_);
   assert(value_of_default_column_.empty());
 
@@ -1115,7 +1119,8 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
   // Find the next value that's visible.
   ParsedInternalKey ikey;
 
-  ResetBlobValue();
+  assert(!is_blob_);
+  assert(blob_value_.empty());
   assert(!is_wide_);
   assert(value_of_default_column_.empty());
 
@@ -1482,6 +1487,7 @@ void DBIter::Seek(const Slice& target) {
 
   status_ = Status::OK();
   ReleaseTempPinnedData();
+  ResetBlobValue();
   ResetWideColumnValue();
   ResetInternalKeysSkippedCounter();
 
@@ -1559,6 +1565,7 @@ void DBIter::SeekForPrev(const Slice& target) {
 
   status_ = Status::OK();
   ReleaseTempPinnedData();
+  ResetBlobValue();
   ResetWideColumnValue();
   ResetInternalKeysSkippedCounter();
 
@@ -1617,6 +1624,7 @@ void DBIter::SeekToFirst() {
   status_ = Status::OK();
   direction_ = kForward;
   ReleaseTempPinnedData();
+  ResetBlobValue();
   ResetWideColumnValue();
   ResetInternalKeysSkippedCounter();
   ClearSavedValue();
@@ -1665,6 +1673,7 @@ void DBIter::SeekToLast() {
                                *iterate_upper_bound_, /*a_has_ts=*/false, k,
                                /*b_has_ts=*/false)) {
       ReleaseTempPinnedData();
+      ResetBlobValue();
       ResetWideColumnValue();
       PrevInternal(nullptr);
 
@@ -1685,6 +1694,7 @@ void DBIter::SeekToLast() {
   status_ = Status::OK();
   direction_ = kReverse;
   ReleaseTempPinnedData();
+  ResetBlobValue();
   ResetWideColumnValue();
   ResetInternalKeysSkippedCounter();
   ClearSavedValue();

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -303,6 +303,11 @@ class DBIter final : public Iterator {
   // index when using the integrated BlobDB implementation.
   bool SetBlobValueIfNeeded(const Slice& user_key, const Slice& blob_index);
 
+  void ResetBlobValue() {
+    is_blob_ = false;
+    blob_value_.Reset();
+  }
+
   bool SetWideColumnValueIfNeeded(const Slice& wide_columns_slice);
 
   void ResetWideColumnValue() {


### PR DESCRIPTION
Summary:
We have recently added caching support to BlobDB, and separately,
implemented an optimization where reading blobs from the cache
results in the cache handle being transferred to the target `PinnableSlice`
(as opposed to the contents getting copied). With these changes,
it makes sense to reset the `PinnableSlice` storing the blob value in
`DBIter` as soon as we move to a different iterator position to prevent
us from holding on to the cache handle any longer than necessary.

Test Plan:
`make check`