### PR TITLE
Disable subcompactions for user_defined_timestamp

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -365,6 +365,9 @@ ts_params = {
     "enable_blob_files": 0,
     "use_blob_db": 0,
     "ingest_external_file_one_in": 0,
+    # TODO akanksha: Currently subcompactions is failing with user_defined_timestamp.
+    # Remove this check once its fixed.
+    "subcompactions": 1,
 }
 
 multiops_txn_default_params = {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -365,9 +365,12 @@ ts_params = {
     "enable_blob_files": 0,
     "use_blob_db": 0,
     "ingest_external_file_one_in": 0,
-    # TODO akanksha: Currently subcompactions is failing with user_defined_timestamp.
+    # TODO akanksha: Currently subcompactions is failing with user_defined_timestamp if
+    # subcompactions > 1, or
+    # compact_pri == 4 even if subcompactions is 1, there can still be multiple subcompactions.
     # Remove this check once its fixed.
     "subcompactions": 1,
+    "compaction_pri": random.randint(0, 3),
 }
 
 multiops_txn_default_params = {


### PR DESCRIPTION
Summary: Currently user_defined_timestamp is failing in stress test with
subcompactions. So disabling it for now and will re enable it once its
fixed.

Test Plan: make crash_test_with_ts -j32