### PR TITLE
Include minimal contextual information in `CompactionIterator`

### DIFF
--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -669,7 +669,7 @@ void CompactionIterator::NextFromInput() {
             // We cannot drop the SingleDelete as timestamp is enabled, and
             // timestamp of this key is greater than or equal to
             // *full_history_ts_low_. We will output the SingleDelete.
-            validity_info_.SetValid(ValidContext::kKeepHistory);
+            validity_info_.SetValid(ValidContext::kKeepTsHistory);
           } else if (has_outputted_key_ ||
                      DefinitelyInSnapshot(ikey_.sequence,
                                           earliest_write_conflict_snapshot_) ||
@@ -704,7 +704,7 @@ void CompactionIterator::NextFromInput() {
             // outputted on the next iteration.)
 
             // Setting valid_ to true will output the current SingleDelete
-            validity_info_.SetValid(ValidContext::kKeepSDForCC);
+            validity_info_.SetValid(ValidContext::kKeepSDForConflictCheck);
 
             // Set up the Put to be outputted in the next iteration.
             // (Optimization 3).
@@ -1153,14 +1153,14 @@ void CompactionIterator::PrepareOutput() {
             "earliest_snapshot %" PRIu64
             ", earliest_write_conflict_snapshot %" PRIu64
             " job_snapshot %" PRIu64
-            ". timestamp_size: %d full_history_ts_low_ %s. validity %s",
+            ". timestamp_size: %d full_history_ts_low_ %s. validity %x",
             ikey_.DebugString(allow_data_in_errors_, true).c_str(),
             earliest_snapshot_, earliest_write_conflict_snapshot_,
             job_snapshot_, static_cast<int>(timestamp_size_),
             full_history_ts_low_ != nullptr
                 ? Slice(*full_history_ts_low_).ToString(true).c_str()
                 : "null",
-            validity_info_.ToString().c_str());
+            validity_info_.rep);
         assert(false);
       }
       ikey_.sequence = 0;

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -83,9 +83,12 @@ CompactionIterator::CompactionIterator(
       bottommost_level_(!compaction_ ? false
                                      : compaction_->bottommost_level() &&
                                            !compaction_->allow_ingest_behind()),
-      visible_at_tip_(snapshots_->empty()),
-      earliest_snapshot_(snapshots_->empty() ? kMaxSequenceNumber
-                                             : snapshots_->at(0)),
+      // snapshots_ cannot be nullptr, but we will assert later in the body of
+      // the constructor.
+      visible_at_tip_(snapshots_ ? snapshots_->empty() : false),
+      earliest_snapshot_(!snapshots_ || snapshots_->empty()
+                             ? kMaxSequenceNumber
+                             : snapshots_->at(0)),
       info_log_(info_log),
       allow_data_in_errors_(allow_data_in_errors),
       enforce_single_del_contracts_(enforce_single_del_contracts),

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cinttypes>
 #include <deque>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -236,7 +235,7 @@ class CompactionIterator {
   const Slice& value() const { return value_; }
   const Status& status() const { return status_; }
   const ParsedInternalKey& ikey() const { return ikey_; }
-  bool Valid() const { return validity_info_.IsValid(); }
+  inline bool Valid() const { return validity_info_.IsValid(); }
   const Slice& user_key() const { return current_user_key_; }
   const CompactionIterationStats& iter_stats() const { return iter_stats_; }
   uint64_t num_input_entry_scanned() const { return input_.num_itered(); }
@@ -374,13 +373,14 @@ class CompactionIterator {
     kParseKeyError = 2,
     kCurrentKeyUncommitted = 3,
     kKeepSDAndClearPut = 4,
-    kKeepHistory = 5,
-    kKeepSDForCC = 6,
+    kKeepTsHistory = 5,
+    kKeepSDForConflictCheck = 6,
     kKeepSDForSnapshot = 7,
     kKeepSD = 8,
     kKeepDel = 9,
     kNewUserKey = 10,
   };
+
   struct ValidityInfo {
     inline bool IsValid() const { return rep & 1; }
     ValidContext GetContext() const {
@@ -388,13 +388,9 @@ class CompactionIterator {
     }
     inline void SetValid(uint8_t ctx) { rep = (ctx << 1) | 1; }
     inline void Invalidate() { rep = 0; }
-    std::string ToString() const {
-      std::ostringstream oss;
-      oss << "valid=" << IsValid() << ", ctx=" << GetContext();
-      return oss.str();
-    }
-    uint8_t rep;
-  } validity_info_{.rep = 0};
+
+    uint8_t rep{0};
+  } validity_info_;
 
   // Points to a copy of the current compaction iterator output (current_key_)
   // if valid.

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -332,29 +332,26 @@ class CompactionIterator {
   // earliest visible snapshot of an older value.
   // See WritePreparedTransactionTest::ReleaseSnapshotDuringCompaction3.
   std::unordered_set<SequenceNumber> released_snapshots_;
-  std::vector<SequenceNumber>::const_iterator earliest_snapshot_iter_;
   const SequenceNumber earliest_write_conflict_snapshot_;
   const SequenceNumber job_snapshot_;
   const SnapshotChecker* const snapshot_checker_;
   Env* env_;
   SystemClock* clock_;
-  bool report_detailed_time_;
-  bool expect_valid_internal_key_;
+  const bool report_detailed_time_;
+  const bool expect_valid_internal_key_;
   CompactionRangeDelAggregator* range_del_agg_;
   BlobFileBuilder* blob_file_builder_;
   std::unique_ptr<CompactionProxy> compaction_;
   const CompactionFilter* compaction_filter_;
   const std::atomic<bool>* shutting_down_;
   const std::atomic<bool>& manual_compaction_canceled_;
-  bool bottommost_level_;
-  bool valid_ = false;
-  bool visible_at_tip_;
-  SequenceNumber earliest_snapshot_;
-  SequenceNumber latest_snapshot_;
+  const bool bottommost_level_;
+  const bool visible_at_tip_;
+  const SequenceNumber earliest_snapshot_;
 
   std::shared_ptr<Logger> info_log_;
 
-  bool allow_data_in_errors_;
+  const bool allow_data_in_errors_;
 
   const bool enforce_single_del_contracts_;
 
@@ -370,6 +367,7 @@ class CompactionIterator {
 
   // State
   //
+  bool valid_ = false;
   // Points to a copy of the current compaction iterator output (current_key_)
   // if valid_.
   Slice key_;


### PR DESCRIPTION
The main purpose is to make debugging easier without sacrificing performance.

Instead of using a boolean variable for `CompactionIterator::valid_`, we can extend it to an `uint8_t`,
using the LSB to denote if the compaction iterator is valid and 4 additional bits to denote where
the iterator is set valid inside `NextFromInput()`. Therefore, when the control flow reaches
`PrepareOutput()` and hits assertion there, we can have a better idea of what has gone wrong.

Test plan
make check
```
TEST_TMPDIR=/dev/shm/rocksdb time ./db_bench -compression_type=none -write_buffer_size=1073741824 -benchmarks=fillseq,flush
```
The above command has a 'flush' benchmark which uses `CompactionIterator`.  I haven't observed any CPU regression or drop in throughput or latency increase.