### PR TITLE
GetUpdatesSince missing updates

### DIFF
--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -120,6 +120,10 @@ Status WalManager::GetUpdatesSince(
     return s;
   }
 
+  std::sort(std::begin(*wal_files), std::end(*wal_files), [](auto& lhs, auto& rhs) {
+    return lhs->StartSequence() > rhs->StartSequence();
+  });
+
   s = RetainProbableWalFiles(*wal_files, seq);
   if (!s.ok()) {
     return s;


### PR DESCRIPTION
RetainProbableWalFiles assumes wal files are sorted by sequence which
is not guaranteed by GetSortedWalFiles.

Fixes: https://github.com/facebook/rocksdb/issues/10476