### PR TITLE
Fix regression issue of too large score

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2774,10 +2774,10 @@ void VersionStorageInfo::ComputeCompactionScore(
             for (auto f : files_[base_level_]) {
               base_level_size += f->compensated_file_size;
             }
-            if (base_level_size > 0) {
-              score = std::max(score, static_cast<double>(total_size) /
-                                          static_cast<double>(base_level_size));
-            }
+            score = std::max(score, static_cast<double>(total_size) /
+                                        static_cast<double>(std::max(
+                                            base_level_size,
+                                            level_max_bytes_[base_level_])));
           }
           if (immutable_options.level_compaction_dynamic_level_bytes &&
               score > 1.0) {


### PR DESCRIPTION
Summary:
https://github.com/facebook/rocksdb/pull/10057 caused a regression bug: since the base level size is not adjusted based on L0 size anymore, L0 score might become very large. This makes compaction heavily favor L0->L1 compaction against L1->L2 compaction, and cause in some cases, data stuck in L1 without being moved down. We fix calculating a score of L0 by size(L0)/size(L1) in the case where L0 is large..

Test Plan: run db_bench against data on tmpfs and watch the behavior of data stuck in L1 goes away.