### PR TITLE
Add bash for running the script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,6 +769,7 @@ workflows:
       - build-linux-cmake-with-benchmark
       - build-linux-encrypted_env-no_compression
       - build-linux-lite
+      - build-format-compatible
   jobs-linux-run-tests-san:
     jobs:
       - build-linux-clang10-asan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,7 +769,6 @@ workflows:
       - build-linux-cmake-with-benchmark
       - build-linux-encrypted_env-no_compression
       - build-linux-lite
-      - build-format-compatible
   jobs-linux-run-tests-san:
     jobs:
       - build-linux-clang10-asan

--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -174,7 +174,7 @@ done
 generate_db()
 {
     set +e
-    $script_copy_dir/generate_random_db.sh $1 $2
+    bash $script_copy_dir/generate_random_db.sh $1 $2
     if [ $? -ne 0 ]; then
         echo ==== Error loading data from $2 to $1 ====
         exit 1
@@ -185,7 +185,7 @@ generate_db()
 compare_db()
 {
     set +e
-    $script_copy_dir/verify_random_db.sh $1 $2 $3 $4 $5
+    bash $script_copy_dir/verify_random_db.sh $1 $2 $3 $4 $5
     if [ $? -ne 0 ]; then
         echo ==== Read different content from $1 and $2 or error happened. ====
         exit 1
@@ -196,7 +196,7 @@ compare_db()
 write_external_sst()
 {
     set +e
-    $script_copy_dir/write_external_sst.sh $1 $2 $3
+    bash $script_copy_dir/write_external_sst.sh $1 $2 $3
     if [ $? -ne 0 ]; then
         echo ==== Error writing external SST file using data from $1 to $3 ====
         exit 1
@@ -207,7 +207,7 @@ write_external_sst()
 ingest_external_sst()
 {
     set +e
-    $script_copy_dir/ingest_external_sst.sh $1 $2
+    bash $script_copy_dir/ingest_external_sst.sh $1 $2
     if [ $? -ne 0 ]; then
         echo ==== Error ingesting external SST in $2 to DB at $1 ====
         exit 1
@@ -218,7 +218,7 @@ ingest_external_sst()
 backup_db()
 {
     set +e
-    $script_copy_dir/backup_db.sh $1 $2
+    bash $script_copy_dir/backup_db.sh $1 $2
     if [ $? -ne 0 ]; then
         echo ==== Error backing up DB $1 to $2 ====
         exit 1
@@ -229,7 +229,7 @@ backup_db()
 restore_db()
 {
     set +e
-    $script_copy_dir/restore_db.sh $1 $2
+    bash $script_copy_dir/restore_db.sh $1 $2
     if [ $? -ne 0 ]; then
         echo ==== Error restoring from $1 to $2 ====
         exit 1

--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -174,7 +174,7 @@ done
 generate_db()
 {
     set +e
-    bash $script_copy_dir/generate_random_db.sh $1 $2
+    bash "$script_copy_dir"/generate_random_db.sh "$1" "$2"
     if [ $? -ne 0 ]; then
         echo ==== Error loading data from $2 to $1 ====
         exit 1
@@ -185,7 +185,7 @@ generate_db()
 compare_db()
 {
     set +e
-    bash $script_copy_dir/verify_random_db.sh $1 $2 $3 $4 $5
+    bash "$script_copy_dir"/verify_random_db.sh "$1" "$2" "$3" "$4" "$5"
     if [ $? -ne 0 ]; then
         echo ==== Read different content from $1 and $2 or error happened. ====
         exit 1
@@ -196,7 +196,7 @@ compare_db()
 write_external_sst()
 {
     set +e
-    bash $script_copy_dir/write_external_sst.sh $1 $2 $3
+    bash "$script_copy_dir"/write_external_sst.sh "$1" "$2" "$3"
     if [ $? -ne 0 ]; then
         echo ==== Error writing external SST file using data from $1 to $3 ====
         exit 1
@@ -207,7 +207,7 @@ write_external_sst()
 ingest_external_sst()
 {
     set +e
-    bash $script_copy_dir/ingest_external_sst.sh $1 $2
+    bash "$script_copy_dir"/ingest_external_sst.sh "$1" "$2"
     if [ $? -ne 0 ]; then
         echo ==== Error ingesting external SST in $2 to DB at $1 ====
         exit 1
@@ -218,7 +218,7 @@ ingest_external_sst()
 backup_db()
 {
     set +e
-    bash $script_copy_dir/backup_db.sh $1 $2
+    bash "$script_copy_dir"/backup_db.sh "$1" "$2"
     if [ $? -ne 0 ]; then
         echo ==== Error backing up DB $1 to $2 ====
         exit 1
@@ -229,7 +229,7 @@ backup_db()
 restore_db()
 {
     set +e
-    bash $script_copy_dir/restore_db.sh $1 $2
+    bash "$script_copy_dir"/restore_db.sh "$1" "$2"
     if [ $? -ne 0 ]; then
         echo ==== Error restoring from $1 to $2 ====
         exit 1


### PR DESCRIPTION
workaround for scripts cannot be executed directly in docker /dev/shm
might be a permission configuration.

Test Plan: run the format_compatible test: https://app.circleci.com/pipelines/github/facebook/rocksdb/17161/workflows/531cc2ce-188c-4e18-a050-5c5f4df76f5c/jobs/459757