### PR TITLE
Add experimental API `WaitForFlushAndCompact()`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 * Removed Customizable support for RateLimiter and removed its CreateFromString() and Type() functions.
 * `CompactRangeOptions::exclusive_manual_compaction` is now false by default. This ensures RocksDB does not introduce artificial parallelism limitations by default.
 * Tiered Storage: change `bottommost_temperture` to `last_level_temperture`. The old option name is kept only for migration, please use the new option. The behavior is changed to apply temperature for the `last_level` SST files only.
+* Add experimental API `WaitForFlushAndCompact()` for waiting for background flush and compaction jobs.
 
 ### Bug Fixes
 * Fix a bug starting in 7.4.0 in which some fsync operations might be skipped in a DB after any DropColumnFamily on that DB, until it is re-opened. This can lead to data loss on power loss. (For custom FileSystem implementations, this could lead to `FSDirectory::Fsync` or `FSDirectory::Close` after the first `FSDirectory::Close`; Also, valgrind could report call to `close()` with `fd=-1`.)

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -207,7 +207,7 @@ TEST_P(TieredCompactionTest, SequenceBasedTieredStorageUniversal) {
     seq_history.emplace_back(dbfull()->GetLatestSequenceNumber());
     expect_stats[0].Add(kBasicFlushStats);
   }
-  ASSERT_OK(dbfull()->WaitForCompact(true));
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
 
   // the penultimate level file temperature is not cold, all data are output to
   // the penultimate level.
@@ -372,7 +372,7 @@ TEST_P(TieredCompactionTest, RangeBasedTieredStorageUniversal) {
     ASSERT_OK(Flush());
     expect_stats[0].Add(kBasicFlushStats);
   }
-  ASSERT_OK(dbfull()->WaitForCompact(true));
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
   ASSERT_EQ("0,0,0,0,0,1,1", FilesPerLevel());
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
@@ -461,7 +461,7 @@ TEST_P(TieredCompactionTest, RangeBasedTieredStorageUniversal) {
     }
     ASSERT_OK(Flush());
   }
-  ASSERT_OK(dbfull()->WaitForCompact(
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact(
       true));  // make sure the compaction is able to finish
   ASSERT_EQ("0,0,0,0,0,1,1", FilesPerLevel());
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
@@ -916,7 +916,7 @@ TEST_P(TieredCompactionTest, SequenceBasedTieredStorageLevel) {
     ASSERT_OK(Flush());
     expect_stats[0].Add(kBasicFlushStats);
   }
-  ASSERT_OK(dbfull()->WaitForCompact(true));
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
 
   // non last level is hot
   ASSERT_EQ("0,1", FilesPerLevel());
@@ -959,7 +959,7 @@ TEST_P(TieredCompactionTest, SequenceBasedTieredStorageLevel) {
     ASSERT_OK(Flush());
     seq_history.emplace_back(dbfull()->GetLatestSequenceNumber());
   }
-  ASSERT_OK(dbfull()->WaitForCompact(true));
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
   ASSERT_EQ("0,1,0,0,0,0,1", FilesPerLevel());
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
@@ -1010,7 +1010,7 @@ TEST_P(TieredCompactionTest, SequenceBasedTieredStorageLevel) {
     ASSERT_OK(Flush());
     seq_history.emplace_back(dbfull()->GetLatestSequenceNumber());
   }
-  ASSERT_OK(dbfull()->WaitForCompact(true));
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
 
   latest_cold_seq = seq_history[0];
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
@@ -1139,7 +1139,7 @@ TEST_P(TieredCompactionTest, RangeBasedTieredStorageLevel) {
     }
     ASSERT_OK(Flush());
   }
-  ASSERT_OK(dbfull()->WaitForCompact(true));
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
   ASSERT_EQ("0,0,0,0,0,1,1", FilesPerLevel());
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -5407,7 +5407,7 @@ TEST_P(RoundRobinSubcompactionsAgainstPressureToken, PressureTokenTest) {
   }
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstPressureToken:2");
 
-  ASSERT_OK(dbfull()->WaitForCompact());
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact());
   ASSERT_TRUE(num_planned_subcompactions_verified);
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
@@ -5482,7 +5482,7 @@ TEST_P(RoundRobinSubcompactionsAgainstResources, SubcompactionsUsingResources) {
         "CompactionJob::ReleaseSubcompactionResources:1"}});
   SyncPoint::GetInstance()->EnableProcessing();
 
-  ASSERT_OK(dbfull()->WaitForCompact());
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact());
   ASSERT_OK(dbfull()->EnableAutoCompaction({dbfull()->DefaultColumnFamily()}));
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstResources:0");
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstResources:1");
@@ -5498,7 +5498,7 @@ TEST_P(RoundRobinSubcompactionsAgainstResources, SubcompactionsUsingResources) {
       total_low_pri_threads_ - 1,
       env_->ReleaseThreads(total_low_pri_threads_ - 1, Env::Priority::LOW));
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstResources:4");
-  ASSERT_OK(dbfull()->WaitForCompact());
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact());
   ASSERT_TRUE(num_planned_subcompactions_verified);
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
@@ -5570,11 +5570,11 @@ TEST_P(DBCompactionTestWithParam, RoundRobinWithoutAdditionalResources) {
         "BackgroundCallCompaction:0"}});
   SyncPoint::GetInstance()->EnableProcessing();
 
-  ASSERT_OK(dbfull()->WaitForCompact());
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact());
   ASSERT_OK(dbfull()->EnableAutoCompaction({dbfull()->DefaultColumnFamily()}));
   TEST_SYNC_POINT("DBCompactionTest::RoundRobinWithoutAdditionalResources:0");
 
-  ASSERT_OK(dbfull()->WaitForCompact());
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact());
   ASSERT_TRUE(num_planned_subcompactions_verified);
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1030,9 +1030,7 @@ class DBImpl : public DB {
   VersionSet* GetVersionSet() const { return versions_.get(); }
 
   // Wait for any compaction
-  // We add a bool parameter to wait for unscheduledCompactions_ == 0, but this
-  // is only for the special test of CancelledCompactions
-  Status WaitForCompact(bool waitUnscheduled = false) override;
+  Status WaitForFlushAndCompact(bool waitUnscheduled = false) override;
 
 #ifndef NDEBUG
   // Compact any files in the named level that overlap [*begin, *end]

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1032,7 +1032,7 @@ class DBImpl : public DB {
   // Wait for any compaction
   // We add a bool parameter to wait for unscheduledCompactions_ == 0, but this
   // is only for the special test of CancelledCompactions
-  Status WaitForCompact(bool waitUnscheduled = false);
+  Status WaitForCompact(bool waitUnscheduled = false) override;
 
 #ifndef NDEBUG
   // Compact any files in the named level that overlap [*begin, *end]

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3830,7 +3830,8 @@ Status DBImpl::WaitForCompact(bool wait_unscheduled) {
   InstrumentedMutexLock l(&mutex_);
   while ((bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||
           bg_flush_scheduled_ ||
-          (wait_unscheduled && unscheduled_compactions_)) &&
+          (wait_unscheduled &&
+           (unscheduled_compactions_ || unscheduled_flushes_))) &&
          (error_handler_.GetBGError().ok())) {
     bg_cv_.Wait();
   }

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3825,7 +3825,7 @@ void DBImpl::GetSnapshotContext(
   *snapshot_seqs = snapshots_.GetAll(earliest_write_conflict_snapshot);
 }
 
-Status DBImpl::WaitForCompact(bool wait_unscheduled) {
+Status DBImpl::WaitForFlushAndCompact(bool wait_unscheduled) {
   // Wait until the compaction completes
   InstrumentedMutexLock l(&mutex_);
   while ((bg_bottom_compaction_scheduled_ || bg_compaction_scheduled_ ||

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -190,7 +190,7 @@ Status DBImpl::TEST_WaitForFlushMemTable(ColumnFamilyHandle* column_family) {
 
 Status DBImpl::TEST_WaitForCompact(bool wait_unscheduled) {
   // Wait until the compaction completes
-  return WaitForCompact(wait_unscheduled);
+  return WaitForFlushAndCompact(wait_unscheduled);
 }
 
 Status DBImpl::TEST_WaitForPurge() {

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -94,7 +94,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
     }
     ASSERT_OK(Flush());
   }
-  ASSERT_OK(dbfull()->WaitForCompact(true));
+  ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
 
   // All data is hot, only output to penultimate level
   ASSERT_EQ("0,0,0,0,0,1", FilesPerLevel());
@@ -115,7 +115,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
       });
     }
     ASSERT_OK(Flush());
-    ASSERT_OK(dbfull()->WaitForCompact(true));
+    ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
     ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
     ASSERT_EQ(GetSstSizeHelper(Temperature::kCold), 0);
   }
@@ -129,7 +129,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
       });
     }
     ASSERT_OK(Flush());
-    ASSERT_OK(dbfull()->WaitForCompact(true));
+    ASSERT_OK(dbfull()->WaitForFlushAndCompact(true));
   }
 
   CompactRangeOptions cro;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2549,7 +2549,7 @@ void StressTest::Open(SharedState* shared) {
             // wait for all compactions to finish to make sure DB is in
             // clean state before executing queries.
             s = static_cast_with_check<DBImpl>(db_->GetRootDB())
-                    ->WaitForCompact(true /* wait_unscheduled */);
+                    ->WaitForFlushAndCompact(true /* wait_unscheduled */);
             if (!s.ok()) {
               for (auto cf : column_families_) {
                 delete cf;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1742,6 +1742,9 @@ class DB {
     return Status::NotSupported("NewDefaultReplayer() is not implemented.");
   }
 
+  virtual Status WaitForCompact(bool wait_unscheduled) {
+    return Status::NotSupported("WaitForCompact() is not implemented.");
+  }
 #endif  // ROCKSDB_LITE
 
   // Needed for StackableDB

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1741,11 +1741,11 @@ class DB {
       std::unique_ptr<Replayer>* /*replayer*/) {
     return Status::NotSupported("NewDefaultReplayer() is not implemented.");
   }
+#endif  // !ROCKSDB_LITE
 
   virtual Status WaitForCompact(bool /*wait_unscheduled*/) {
     return Status::NotSupported("WaitForCompact() is not implemented.");
   }
-#endif  // ROCKSDB_LITE
 
   // Needed for StackableDB
   virtual DB* GetRootDB() { return this; }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1743,8 +1743,13 @@ class DB {
   }
 #endif  // !ROCKSDB_LITE
 
-  virtual Status WaitForCompact(bool /*wait_unscheduled*/) {
-    return Status::NotSupported("WaitForCompact() is not implemented.");
+  // Experimental and subject to change
+  // Wait for the background flush and Compaction to finish.
+  // `wait_unscheduled` will wait for unscheduled job to be finished. It might
+  // be useful for the user to wait the DB instance to be stable status.
+  // If there's any background error, return the error.
+  virtual Status WaitForFlushAndCompact(bool /*wait_unscheduled*/) {
+    return Status::NotSupported("WaitForFlushAndCompact() is not implemented.");
   }
 
   // Needed for StackableDB

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1742,7 +1742,7 @@ class DB {
     return Status::NotSupported("NewDefaultReplayer() is not implemented.");
   }
 
-  virtual Status WaitForCompact(bool wait_unscheduled) {
+  virtual Status WaitForCompact(bool /*wait_unscheduled*/) {
     return Status::NotSupported("WaitForCompact() is not implemented.");
   }
 #endif  // ROCKSDB_LITE

--- a/microbench/README.md
+++ b/microbench/README.md
@@ -57,4 +57,4 @@ $ ./db_basic_bench --benchmark_filter=<TEST_NAME> --benchmark_repetitions=10
 ...
 <TEST_NAME>_cv    3.2%
 ```
-RocksDB has background compaction jobs which may cause the test result to vary a lot. If the micro-benchmark is not purposely testing the operation while compaction is in progress, it should wait for the compaction to finish (`db_impl->WaitForCompact()`) or disable auto-compaction.
+RocksDB has background compaction jobs which may cause the test result to vary a lot. If the micro-benchmark is not purposely testing the operation while compaction is in progress, it should wait for the compaction to finish (`db_impl->WaitForFlushAndCompact()`) or disable auto-compaction.

--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -303,7 +303,7 @@ static void DBPut(benchmark::State& state) {
 
   if (state.thread_index() == 0) {
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    Status s = db_full->WaitForCompact(true);
+    Status s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -410,7 +410,7 @@ static void ManualCompaction(benchmark::State& state) {
 
   if (state.thread_index() == 0) {
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(true);
+    s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -508,7 +508,7 @@ static void ManualFlush(benchmark::State& state) {
 
   if (state.thread_index() == 0) {
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    Status s = db_full->WaitForCompact(true);
+    Status s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -592,7 +592,7 @@ static void DBGet(benchmark::State& state) {
     }
 
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(true);
+    s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -705,7 +705,7 @@ static void SimpleGetWithPerfContext(benchmark::State& state) {
       }
     }
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(true);
+    s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -1108,7 +1108,7 @@ static void IteratorSeek(benchmark::State& state) {
     }
 
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(true);
+    s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -1199,7 +1199,7 @@ static void IteratorNext(benchmark::State& state) {
     }
 
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(true);
+    s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -1263,7 +1263,7 @@ static void IteratorNextWithPerfContext(benchmark::State& state) {
       }
     }
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    Status s = db_full->WaitForCompact(true);
+    Status s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -1361,7 +1361,7 @@ static void IteratorPrev(benchmark::State& state) {
     }
 
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(true);
+    s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;
@@ -1453,7 +1453,7 @@ static void PrefixSeek(benchmark::State& state) {
     }
 
     auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(true);
+    s = db_full->WaitForFlushAndCompact(true);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
       return;


### PR DESCRIPTION
Add experimental API `WaitForFlushAndCompact()` for waiting for background
flush and compaction jobs. The API could be useful for the user to wait the db
to be in a stable status.

Fix #10428

Test Plan: CI. the API is already wildly used in unittests