### PR TITLE
Revert "Avoid dynamic memory allocation on read path (#10453)"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -41,7 +41,6 @@
 
 ### Performance Improvements
 * Instead of constructing `FragmentedRangeTombstoneList` during every read operation, it is now constructed once and stored in immutable memtables. This improves speed of querying range tombstones from immutable memtables.
-* Improve read performance by avoiding dynamic memory allocation.
 * When using iterators with the integrated BlobDB implementation, blob cache handles are now released immediately when the iterator's position changes.
 
 ## Behavior Change


### PR DESCRIPTION
This reverts commit 0d885e80d41f2ace03e87bd00dcc981868209509. The original commit causes a ASAN stack-use-after-return failure due to the `CreateCallback` being allocated on stack and then used in another thread when a secondary cache object is promoted to the primary cache.