### PR TITLE
Update `TestGet()` to verify against expected state

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### Behavior Change
+* Updated `TestGet()` in `no_batched_op_stress` (default stress test) to check the result of Get() operations against expected state.
 
 ## 7.6.0 (08/19/2022)
 ### New Features

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -360,8 +360,10 @@ class NonBatchedOpsStressTest : public StressTest {
       }
       // found case
       thread->stats.AddGets(1, 1);
-      if (thread->shared->Get(rand_column_families[0], rand_keys[0]) ==
-          SharedState::DELETION_SENTINEL) {
+      // we only have the latest expected state
+      if (!read_opts_copy.timestamp &&
+          thread->shared->Get(rand_column_families[0], rand_keys[0]) ==
+              SharedState::DELETION_SENTINEL) {
         thread->shared->SetVerificationFailure();
         fprintf(stderr,
                 "error : inconsistent values for key %s: Get returns %s, "
@@ -371,15 +373,17 @@ class NonBatchedOpsStressTest : public StressTest {
     } else if (s.IsNotFound()) {
       // not found case
       thread->stats.AddGets(1, 0);
-      auto expected =
-          thread->shared->Get(rand_column_families[0], rand_keys[0]);
-      if (expected != SharedState::DELETION_SENTINEL &&
-          expected != SharedState::UNKNOWN_SENTINEL) {
-        thread->shared->SetVerificationFailure();
-        fprintf(stderr,
-                "error : inconsistent values for key %s: expected state has "
-                "the key, Get() returns NotFound.\n",
-                key.ToString(true).c_str());
+      if (!read_opts_copy.timestamp) {
+        auto expected =
+            thread->shared->Get(rand_column_families[0], rand_keys[0]);
+        if (expected != SharedState::DELETION_SENTINEL &&
+            expected != SharedState::UNKNOWN_SENTINEL) {
+          thread->shared->SetVerificationFailure();
+          fprintf(stderr,
+                  "error : inconsistent values for key %s: expected state has "
+                  "the key, Get() returns NotFound.\n",
+                  key.ToString(true).c_str());
+        }
       }
     } else {
       if (error_count == 0) {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -360,9 +360,27 @@ class NonBatchedOpsStressTest : public StressTest {
       }
       // found case
       thread->stats.AddGets(1, 1);
+      if (thread->shared->Get(rand_column_families[0], rand_keys[0]) ==
+          SharedState::DELETION_SENTINEL) {
+        thread->shared->SetVerificationFailure();
+        fprintf(stderr,
+                "error : inconsistent values for key %s: Get returns %s, "
+                "expected state does not have the key.\n",
+                key.ToString(true).c_str(), StringToHex(from_db).c_str());
+      }
     } else if (s.IsNotFound()) {
       // not found case
       thread->stats.AddGets(1, 0);
+      auto expected =
+          thread->shared->Get(rand_column_families[0], rand_keys[0]);
+      if (expected != SharedState::DELETION_SENTINEL &&
+          expected != SharedState::UNKNOWN_SENTINEL) {
+        thread->shared->SetVerificationFailure();
+        fprintf(stderr,
+                "error : inconsistent values for key %s: expected state has "
+                "the key, Get() returns NotFound.\n",
+                key.ToString(true).c_str());
+      }
     } else {
       if (error_count == 0) {
         // errors case


### PR DESCRIPTION
Summary: updated `TestGet()` in `no_batched_op_stress` to check the result of `Get()` operations against expected state (`expected_state_manager_`). More specifically, if `Get()` finds a key, expected state should not have `DELETION_SENTINEL` for the same key, and if `Get()` returns NotFound for a key, expected state should not have the key. One intention for this change it to verify correctness of code path change regarding range tombstones.

Test plan: run db_stress with nonzero readpercent: `./db_stress_branch --readpercent=57 --prefixpercent=4 --writepercent=25 -delpercent=5 --iterpercent=5 --delrangepercent=4`. When I initially used wrong column family in `thread->shared->Get`, the test reported inconsistencies.
- internally run various flavor of crash test