### PR TITLE
WritableFileWriter to allow operation after failure when SyncWithoutFlush() is involved

### DIFF
--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -151,7 +151,14 @@ class WritableFileWriter {
   uint64_t next_write_offset_;
 #endif  // ROCKSDB_LITE
   bool pending_sync_;
-  bool seen_error_;
+  std::atomic<bool> seen_error_;
+#ifndef NDEBUG
+  // SyncWithoutFlush() is the function that is allowed to be called
+  // concurrently with other function. One of the concurrent call
+  // could set seen_error_, and the other one would hit assertion
+  // in debug mode.
+  std::atomic<bool> sync_without_flush_called_;
+#endif  // NDEBUG
   uint64_t last_sync_size_;
   uint64_t bytes_per_sync_;
   RateLimiter* rate_limiter_;
@@ -290,10 +297,21 @@ class WritableFileWriter {
 
   const char* GetFileChecksumFuncName() const;
 
-  bool seen_error() const { return seen_error_; }
+  bool seen_error() const {
+    return seen_error_.load(std::memory_order_relaxed);
+  }
   // For options of relaxed consistency, users might hope to continue
   // operating on the file after an error happens.
-  void reset_seen_error() { seen_error_ = false; }
+  void reset_seen_error() {
+    seen_error_.store(false, std::memory_order_relaxed);
+  }
+  void set_seen_error() { seen_error_.store(true, std::memory_order_relaxed); }
+
+  IOStatus AssertFalseAndGetStatusForPrevError() {
+    // This should only happen if SyncWithoutFlush() was called.
+    assert(sync_without_flush_called_);
+    return IOStatus::IOError("Writer has previous error.");
+  }
 
  private:
   // Decide the Rate Limiter priority.

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -157,7 +157,7 @@ class WritableFileWriter {
   // concurrently with other function. One of the concurrent call
   // could set seen_error_, and the other one would hit assertion
   // in debug mode.
-  std::atomic<bool> sync_without_flush_called_;
+  std::atomic<bool> sync_without_flush_called_ = false;
 #endif  // NDEBUG
   uint64_t last_sync_size_;
   uint64_t bytes_per_sync_;


### PR DESCRIPTION
Summary:
https://github.com/facebook/rocksdb/pull/10489 adds an assertion in most functions in WritableFileWriter to check no previous error. However, it only works without calling SyncWithoutFlush(). The nature of SyncWithoutFlush() makes two concurrent call fails to check status code of each other and causing assertion failure. Fix the problem by skipping the check after SyncWithoutFlush() is called and not check status code in SyncWithoutFlush().

Since the original change was not officially released yet, the fix isn't added to HISTORY.md.

Test Plan: Make sure existing tests still pass