### PR TITLE
Disable db_stress features incompatible with unsynced data dropping when sync_fault_injection=1

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -484,26 +484,26 @@ def finalize_and_sanitize(src_params):
         dest_params["delpercent"] += dest_params["delrangepercent"]
         dest_params["delrangepercent"] = 0
         dest_params["ingest_external_file_one_in"] = 0
-    # File ingestion does not guarantee prefix-recoverability when unsynced data
-    # can be lost. Ingesting a file syncs data immediately that is newer than
-    # unsynced memtable data that can be lost on restart.
-    #
-    # Even if the above issue is fixed or worked around, our trace-and-replay
-    # does not trace file ingestion, so in its current form it would not recover
-    # the expected state to the correct point in time.
     if (dest_params.get("disable_wal") == 1 or
         dest_params.get("sync_fault_injection") == 1):
+        # File ingestion does not guarantee prefix-recoverability when unsynced
+        # data can be lost. Ingesting a file syncs data immediately that is
+        # newer than unsynced memtable data that can be lost on restart.
+        #
+        # Even if the above issue is fixed or worked around, our
+        # trace-and-replay does not trace file ingestion, so in its current form
+        # it would not recover the expected state to the correct point in time.
         dest_params["ingest_external_file_one_in"] = 0
+        # The `DbStressCompactionFilter` can apply memtable updates to SST
+        # files, which would be problematic when unsynced data can be lost in
+        # crash recoveries.
+        dest_params["enable_compaction_filter"] = 0
     # Only under WritePrepared txns, unordered_write would provide the same guarnatees as vanilla rocksdb
     if dest_params.get("unordered_write", 0) == 1:
         dest_params["txn_write_policy"] = 1
         dest_params["allow_concurrent_memtable_write"] = 1
     if dest_params.get("disable_wal", 0) == 1:
         dest_params["atomic_flush"] = 1
-        # The `DbStressCompactionFilter` can apply memtable updates to SST
-        # files, which would be problematic without WAL since such updates are
-        # expected to be lost in crash recoveries.
-        dest_params["enable_compaction_filter"] = 0
         dest_params["sync"] = 0
         dest_params["write_fault_one_in"] = 0
     if dest_params.get("open_files", 1) != -1:

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -484,14 +484,15 @@ def finalize_and_sanitize(src_params):
         dest_params["delpercent"] += dest_params["delrangepercent"]
         dest_params["delrangepercent"] = 0
         dest_params["ingest_external_file_one_in"] = 0
-    # File ingestion does not guarantee prefix-recoverability with WAL disabled.
-    # Ingesting a file persists data immediately that is newer than memtable
-    # data that can be lost on restart.
+    # File ingestion does not guarantee prefix-recoverability when unsynced data
+    # can be lost. Ingesting a file syncs data immediately that is newer than
+    # unsynced memtable data that can be lost on restart.
     #
     # Even if the above issue is fixed or worked around, our trace-and-replay
     # does not trace file ingestion, so in its current form it would not recover
     # the expected state to the correct point in time.
-    if (dest_params.get("disable_wal") == 1):
+    if (dest_params.get("disable_wal") == 1 or
+        dest_params.get("sync_fault_injection") == 1):
         dest_params["ingest_external_file_one_in"] = 0
     # Only under WritePrepared txns, unordered_write would provide the same guarnatees as vanilla rocksdb
     if dest_params.get("unordered_write", 0) == 1:


### PR DESCRIPTION
The features that cannot work with disable_wal=1 due to unsynced data dropping (ingest_external_file_one_in and enable_compaction_filter) similarly cannot work with sync_fault_injection=1. This PR prevents those features from being used together with sync_fault_injection=1.