### PR TITLE
Fixes in async_io scan path

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -401,6 +401,7 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(
     // Length > 0: More data needs to be consumed so it will continue async and
     // sync prefetching and copy the remaining data to third buffer in the end.
     if (length == 0) {
+      curr_ = curr_ ^ 1;
       return s;
     }
   }
@@ -543,9 +544,8 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
   // of reads not sequential and PrefetchAsync can be called for any block and
   // RocksDB will call TryReadFromCacheAsync after PrefetchAsync to Poll for
   // requested bytes.
-  if (!bufs_[curr_].async_read_in_progress &&
-      bufs_[curr_].buffer_.CurrentSize() > 0 && offset < bufs_[curr_].offset_ &&
-      prev_len_ != 0) {
+  if (!async_request_submitted_ && prev_len_ != 0 &&
+      offset < bufs_[curr_].offset_) {
     return false;
   }
 

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -119,12 +119,14 @@ Status FilePrefetchBuffer::ReadAsync(const IOOptions& opts,
   req.offset = rounddown_start + chunk_len;
   req.result = result;
   req.scratch = bufs_[index].buffer_.BufferStart() + chunk_len;
-  Status s = reader->ReadAsync(req, opts, fp,
-                               /*cb_arg=*/nullptr, &io_handle_, &del_fn_,
+  bufs_[index].async_req_len = req.len;
+
+  Status s = reader->ReadAsync(req, opts, fp, &(bufs_[index].pos),
+                               &(bufs_[index].io_handle), &del_fn_,
                                /*aligned_buf=*/nullptr);
   req.status.PermitUncheckedError();
   if (s.ok()) {
-    async_read_in_progress_ = true;
+    bufs_[index].async_read_in_progress = true;
   }
   return s;
 }
@@ -194,65 +196,69 @@ void FilePrefetchBuffer::CopyDataToBuffer(uint32_t src, uint64_t& offset,
   }
 }
 
-void FilePrefetchBuffer::PollAndUpdateBuffersIfNeeded(uint64_t offset) {
-  if (async_read_in_progress_ && fs_ != nullptr) {
-    // Wait for prefetch data to complete.
-    // No mutex is needed as PrefetchAsyncCallback updates the result in second
-    // buffer and FilePrefetchBuffer should wait for Poll before accessing the
-    // second buffer.
-    std::vector<void*> handles;
-    handles.emplace_back(io_handle_);
-    StopWatch sw(clock_, stats_, POLL_WAIT_MICROS);
-    fs_->Poll(handles, 1).PermitUncheckedError();
-  }
-
-  // Reset and Release io_handle_ after the Poll API as request has been
-  // completed.
-  async_read_in_progress_ = false;
-  if (io_handle_ != nullptr && del_fn_ != nullptr) {
-    del_fn_(io_handle_);
-    io_handle_ = nullptr;
-    del_fn_ = nullptr;
-  }
-
-  // Index of second buffer.
-  uint32_t second = curr_ ^ 1;
-
-  // First clear the buffers if it contains outdated data. Outdated data can be
+void FilePrefetchBuffer::UpdateBuffersIfNeeded(uint64_t offset) {
+  // Clear the buffers if it contains outdated data. Outdated data can be
   // because previous sequential reads were read from the cache instead of these
   // buffer.
-  {
-    if (bufs_[curr_].buffer_.CurrentSize() > 0 &&
-        offset >= bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) {
-      bufs_[curr_].buffer_.Clear();
-    }
-    if (bufs_[second].buffer_.CurrentSize() > 0 &&
-        offset >= bufs_[second].offset_ + bufs_[second].buffer_.CurrentSize()) {
-      bufs_[second].buffer_.Clear();
-    }
+  uint32_t second = curr_ ^ 1;
+  if (!bufs_[curr_].async_read_in_progress &&
+      bufs_[curr_].buffer_.CurrentSize() > 0 &&
+      offset >= bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) {
+    bufs_[curr_].buffer_.Clear();
+  }
+  if (!bufs_[second].async_read_in_progress &&
+      bufs_[second].buffer_.CurrentSize() > 0 &&
+      offset >= bufs_[second].offset_ + bufs_[second].buffer_.CurrentSize()) {
+    bufs_[second].buffer_.Clear();
   }
 
-  // If data is in second buffer, make it curr_. Second buffer can be either
-  // partial filled or full.
-  if (bufs_[second].buffer_.CurrentSize() > 0 &&
+  // If data starts from second buffer, make it curr_. Second buffer can be
+  // either partial filled or full.
+  if (!bufs_[second].async_read_in_progress &&
+      bufs_[second].buffer_.CurrentSize() > 0 &&
       offset >= bufs_[second].offset_ &&
       offset < bufs_[second].offset_ + bufs_[second].buffer_.CurrentSize()) {
     // Clear the curr_ as buffers have been swapped and curr_ contains the
     // outdated data and switch the buffers.
-    bufs_[curr_].buffer_.Clear();
+    if (!bufs_[curr_].async_read_in_progress) {
+      bufs_[curr_].buffer_.Clear();
+    }
     curr_ = curr_ ^ 1;
   }
 }
 
-// If async_read = true:
-// async_read is enabled in case of sequential reads. So when
-// buffers are switched, we clear the curr_ buffer as we assume the data has
-// been consumed because of sequential reads.
+void FilePrefetchBuffer::PollAndUpdateBuffersIfNeeded(uint64_t offset) {
+  if (bufs_[poll_index_].async_read_in_progress && fs_ != nullptr) {
+    // Wait for prefetch data to complete.
+    // No mutex is needed as async_read_in_progress behaves as mutex and is
+    // updated by main thread only.
+    std::vector<void*> handles;
+    handles.emplace_back(bufs_[poll_index_].io_handle);
+    StopWatch sw(clock_, stats_, POLL_WAIT_MICROS);
+    fs_->Poll(handles, 1).PermitUncheckedError();
+
+    // Reset and Release io_handle after the Poll API as request has been
+    // completed.
+    bufs_[poll_index_].async_read_in_progress = false;
+    if (bufs_[poll_index_].io_handle != nullptr && del_fn_ != nullptr) {
+      del_fn_(bufs_[poll_index_].io_handle);
+      bufs_[poll_index_].io_handle = nullptr;
+    }
+  }
+
+  UpdateBuffersIfNeeded(offset);
+}
+
+// If async_io is enabled in case of sequential reads, PrefetchAsyncInternal is
+// called. When buffers are switched, we clear the curr_ buffer as we assume the
+// data has been consumed because of sequential reads.
+// Data in buffers will always be sequential with curr_ following second and
+// not vice versa.
 //
 // Scenarios for prefetching asynchronously:
-// Case1: If both buffers are empty, prefetch n bytes
-//        synchronously in curr_
-//        and prefetch readahead_size_/2 async in second buffer.
+// Case1: If both buffers are empty, prefetch n + readahead_size_/2 bytes
+//        synchronously in curr_ and prefetch readahead_size_/2 async in second
+//        buffer.
 // Case2: If second buffer has partial or full data, make it current and
 //        prefetch readahead_size_/2 async in second buffer. In case of
 //        partial data, prefetch remaining bytes from size n synchronously to
@@ -260,9 +266,10 @@ void FilePrefetchBuffer::PollAndUpdateBuffersIfNeeded(uint64_t offset) {
 // Case3: If curr_ has partial data, prefetch remaining bytes from size n
 //        synchronously in curr_ to fulfill the requested bytes request and
 //        prefetch readahead_size_/2 bytes async in second buffer.
-// Case4: If data is in both buffers, copy requested data from curr_ and second
-//        buffer to third buffer. If all requested bytes have been copied, do
-//        the asynchronous prefetching in second buffer.
+// Case4: (Special case) If data is in both buffers, copy requested data from
+//        curr_, send async request on curr_, wait for poll to fill second
+//        buffer (if any), and copy remaining data from second buffer to third
+//        buffer.
 Status FilePrefetchBuffer::PrefetchAsyncInternal(
     const IOOptions& opts, RandomAccessFileReader* reader, uint64_t offset,
     size_t length, size_t readahead_size, Env::IOPriority rate_limiter_priority,
@@ -273,11 +280,92 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(
 
   TEST_SYNC_POINT("FilePrefetchBuffer::PrefetchAsyncInternal:Start");
 
-  PollAndUpdateBuffersIfNeeded(offset);
+  size_t alignment = reader->file()->GetRequiredBufferAlignment();
+  Status s;
 
-  // If all the requested bytes are in curr_, it will go for async prefetching
-  // only.
-  if (bufs_[curr_].buffer_.CurrentSize() > 0 &&
+  // Following variables are used in case data is overlapping between 2
+  // buffers (copy_to_third_buffer will be set to true in that case).
+  uint64_t tmp_offset = offset;
+  size_t tmp_length = length;
+
+  // 1. Swap buffers if needed to point curr_ to first buffer with data.
+  UpdateBuffersIfNeeded(offset);
+  uint32_t second = curr_ ^ 1;
+
+  // 2. If data is overlapping over two buffers, copy the data from curr_ and
+  // call ReadAsync on curr_.
+  if (!bufs_[curr_].async_read_in_progress &&
+      bufs_[curr_].buffer_.CurrentSize() > 0 &&
+      offset >= bufs_[curr_].offset_ &&
+      offset < bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize() &&
+      (/*Data extends over curr_ buffer and second buffer either has data or in
+         process of population=*/
+       (offset + length > bufs_[second].offset_) &&
+       (bufs_[second].async_read_in_progress ||
+        bufs_[second].buffer_.CurrentSize() > 0))) {
+    // Allocate new buffer to third buffer;
+    bufs_[2].buffer_.Clear();
+    bufs_[2].buffer_.Alignment(alignment);
+    bufs_[2].buffer_.AllocateNewBuffer(length);
+    bufs_[2].offset_ = offset;
+    copy_to_third_buffer = true;
+
+    CopyDataToBuffer(curr_, tmp_offset, tmp_length);
+
+    // Call async prefetching on curr_ since data has been consumed in curr_.
+    if (tmp_offset + tmp_length <=
+        bufs_[second].offset_ + bufs_[second].async_req_len) {
+      uint64_t rounddown_start =
+          bufs_[second].offset_ + bufs_[second].async_req_len;
+      uint64_t roundup_end =
+          Roundup(rounddown_start + readahead_size, alignment);
+      uint64_t roundup_len = roundup_end - rounddown_start;
+      uint64_t chunk_len = 0;
+      CalculateOffsetAndLen(alignment, rounddown_start, roundup_len, curr_,
+                            false, chunk_len);
+
+      bufs_[curr_].offset_ = rounddown_start;
+      assert(roundup_len >= chunk_len);
+      uint64_t read_len = static_cast<size_t>(roundup_len - chunk_len);
+      s = ReadAsync(opts, reader, read_len, chunk_len, rounddown_start, curr_);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+  }
+
+  // 3. Call Poll only if data is needed for the second buffer.
+  //    - Return if whole data is in curr_ and second buffer in progress.
+  //    - If second buffer is empty, it will go for ReadAsync for second buffer.
+  if (!bufs_[curr_].async_read_in_progress &&
+      bufs_[curr_].buffer_.CurrentSize() > 0 &&
+      offset >= bufs_[curr_].offset_ &&
+      offset + length <=
+          bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) {
+    // Whole data is in curr_.
+    UpdateBuffersIfNeeded(offset);
+    second = curr_ ^ 1;
+    if (bufs_[second].async_read_in_progress) {
+      return s;
+    }
+  } else {
+    PollAndUpdateBuffersIfNeeded(offset);
+  }
+  second = curr_ ^ 1;
+
+  if (copy_to_third_buffer) {
+    offset = tmp_offset;
+    length = tmp_length;
+  }
+
+  if (bufs_[curr_].async_read_in_progress) {
+    poll_index_ = curr_;
+  }
+
+  // 4. After polling and swapping buffers, if all the requested bytes are in
+  // curr_, it will only go for async prefetching. copy_to_third_buffer is a
+  // special case so it will be handled separately.
+  if (!copy_to_third_buffer && bufs_[curr_].buffer_.CurrentSize() > 0 &&
       offset + length <=
           bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) {
     offset += length;
@@ -287,51 +375,39 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(
     // last call, we don't need to prefetch further as this call is to poll the
     // data submitted in previous call.
     if (async_request_submitted_) {
-      return Status::OK();
-    }
-  }
-
-  async_request_submitted_ = false;
-
-  Status s;
-  size_t prefetch_size = length + readahead_size;
-  size_t alignment = reader->file()->GetRequiredBufferAlignment();
-  // Index of second buffer.
-  uint32_t second = curr_ ^ 1;
-
-  // Data is overlapping i.e. some of the data is in curr_ buffer and remaining
-  // in second buffer.
-  if (bufs_[curr_].buffer_.CurrentSize() > 0 &&
-      bufs_[second].buffer_.CurrentSize() > 0 &&
-      offset >= bufs_[curr_].offset_ &&
-      offset < bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize() &&
-      offset + length > bufs_[second].offset_) {
-    // Allocate new buffer to third buffer;
-    bufs_[2].buffer_.Clear();
-    bufs_[2].buffer_.Alignment(alignment);
-    bufs_[2].buffer_.AllocateNewBuffer(length);
-    bufs_[2].offset_ = offset;
-    copy_to_third_buffer = true;
-
-    // Move data from curr_ buffer to third.
-    CopyDataToBuffer(curr_, offset, length);
-    if (length == 0) {
-      // Requested data has been copied and curr_ still has unconsumed data.
       return s;
     }
+
+    // If valid data already exists in second buffer, return.
+    if (!bufs_[second].async_read_in_progress &&
+        bufs_[second].buffer_.CurrentSize() > 0 &&
+        bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize() ==
+            bufs_[second].offset_) {
+      return s;
+    }
+  }
+  async_request_submitted_ = false;
+
+  // 5. Data is overlapping i.e. some of the data has been copied to third
+  // buffer
+  // and remaining will be updated below.
+  if (copy_to_third_buffer && !bufs_[second].async_read_in_progress &&
+      bufs_[second].buffer_.CurrentSize() > 0) {
     CopyDataToBuffer(second, offset, length);
-    // Length == 0: All the requested data has been copied to third buffer. It
-    // should go for only async prefetching.
+
+    // Length == 0: All the requested data has been copied to third buffer and
+    // it has already gone for async prefetching. It can return without doing
+    // anything further.
     // Length > 0: More data needs to be consumed so it will continue async and
     // sync prefetching and copy the remaining data to third buffer in the end.
-    // swap the buffers.
-    curr_ = curr_ ^ 1;
-    // Update prefetch_size as length has been updated in CopyDataToBuffer.
-    prefetch_size = length + readahead_size;
+    if (length == 0) {
+      return s;
+    }
   }
 
+  // 6. Go for ReadAsync and Read (if needed).
+  size_t prefetch_size = length + readahead_size;
   size_t _offset = static_cast<size_t>(offset);
-  second = curr_ ^ 1;
 
   // offset and size alignment for curr_ buffer with synchronous prefetching
   uint64_t rounddown_start1 = Rounddown(_offset, alignment);
@@ -375,6 +451,7 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(
     uint64_t read_len2 = static_cast<size_t>(roundup_len2 - chunk_len2);
     ReadAsync(opts, reader, read_len2, chunk_len2, rounddown_start2, second)
         .PermitUncheckedError();
+    poll_index_ = second;
   }
 
   if (read_len1 > 0) {
@@ -466,7 +543,8 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
   // of reads not sequential and PrefetchAsync can be called for any block and
   // RocksDB will call TryReadFromCacheAsync after PrefetchAsync to Poll for
   // requested bytes.
-  if (bufs_[curr_].buffer_.CurrentSize() > 0 && offset < bufs_[curr_].offset_ &&
+  if (!bufs_[curr_].async_read_in_progress &&
+      bufs_[curr_].buffer_.CurrentSize() > 0 && offset < bufs_[curr_].offset_ &&
       prev_len_ != 0) {
     return false;
   }
@@ -512,6 +590,7 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
       return false;
     }
   }
+
   UpdateReadPattern(offset, n, false /*decrease_readaheadsize*/);
 
   uint32_t index = curr_;
@@ -528,8 +607,8 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
 }
 
 void FilePrefetchBuffer::PrefetchAsyncCallback(const FSReadRequest& req,
-                                               void* /*cb_arg*/) {
-  uint32_t index = curr_ ^ 1;
+                                               void* cb_arg) {
+  uint32_t index = *(static_cast<uint32_t*>(cb_arg));
 
 #ifndef NDEBUG
   if (req.result.size() < req.len) {
@@ -569,9 +648,6 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
 
   PollAndUpdateBuffersIfNeeded(offset);
 
-  // Index of second buffer.
-  uint32_t second = curr_ ^ 1;
-
   // Since PrefetchAsync can be called on non sequential reads. So offset can
   // be less than buffers' offset. In that case it clears the buffer and
   // prefetch that block.
@@ -590,9 +666,10 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
 
   Status s;
   size_t alignment = reader->file()->GetRequiredBufferAlignment();
+  uint32_t second = curr_ ^ 1;
 
   // TODO akanksha: Handle the scenario if data is overlapping in 2 buffers.
-  // Currently, tt covers 2 scenarios. Either one buffer (curr_) has no data or
+  // Currently, it covers 2 scenarios. Either one buffer (curr_) has no data or
   // it has partial data. It ignores the contents in second buffer (overlapping
   // data in 2 buffers) and send the request to re-read that data again.
 
@@ -628,8 +705,8 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   assert(roundup_len >= chunk_len);
 
   size_t read_len = static_cast<size_t>(roundup_len - chunk_len);
-
   s = ReadAsync(opts, reader, read_len, chunk_len, rounddown_start, second);
+  poll_index_ = second;
 
   if (!s.ok()) {
     return s;

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -30,7 +30,23 @@ class RandomAccessFileReader;
 
 struct BufferInfo {
   AlignedBuffer buffer_;
+
   uint64_t offset_ = 0;
+
+  // Below parameters are used in case of async read flow.
+  // Length requested for in ReadAsync.
+  size_t async_req_len = 0;
+
+  // async_read_in_progress can be used as mutex. Callback can update the buffer
+  // and its size but async_read_in_progress is only set by main thread.
+  bool async_read_in_progress = false;
+
+  // io_handle is allocated and used by underlying file system in case of
+  // asynchronous reads.
+  void* io_handle = nullptr;
+
+  // pos represents the index of this buffer in vector of BufferInfo.
+  uint32_t pos = 0;
 };
 
 // FilePrefetchBuffer is a smart buffer to store and read data from a file.
@@ -54,9 +70,6 @@ class FilePrefetchBuffer {
   //   it. Used for adaptable readahead of the file footer/metadata.
   // implicit_auto_readahead : Readahead is enabled implicitly by rocksdb after
   //   doing sequential scans for two times.
-  // async_io : When async_io is enabled, if it's implicit_auto_readahead, it
-  //   prefetches data asynchronously in second buffer while curr_ is being
-  //   consumed.
   //
   // Automatic readhead is enabled for a file if readahead_size
   // and max_readahead_size are passed in.
@@ -68,6 +81,7 @@ class FilePrefetchBuffer {
                      uint64_t num_file_reads = 0, FileSystem* fs = nullptr,
                      SystemClock* clock = nullptr, Statistics* stats = nullptr)
       : curr_(0),
+        poll_index_(curr_ ^ 1),
         readahead_size_(readahead_size),
         initial_auto_readahead_size_(readahead_size),
         max_readahead_size_(max_readahead_size),
@@ -78,9 +92,7 @@ class FilePrefetchBuffer {
         prev_offset_(0),
         prev_len_(0),
         num_file_reads_(num_file_reads),
-        io_handle_(nullptr),
         del_fn_(nullptr),
-        async_read_in_progress_(false),
         async_request_submitted_(false),
         fs_(fs),
         clock_(clock),
@@ -91,13 +103,20 @@ class FilePrefetchBuffer {
     // while curr_ is being consumed. If data is overlapping in two buffers,
     // data is copied to third buffer to return continuous buffer.
     bufs_.resize(3);
+    for (uint32_t i = 0; i < 2; i++) {
+      bufs_[i].pos = i;
+    }
   }
 
   ~FilePrefetchBuffer() {
     // Abort any pending async read request before destroying the class object.
-    if (async_read_in_progress_ && fs_ != nullptr) {
+    if (fs_ != nullptr) {
       std::vector<void*> handles;
-      handles.emplace_back(io_handle_);
+      for (uint32_t i = 0; i < 2; i++) {
+        if (bufs_[i].async_read_in_progress && bufs_[i].io_handle != nullptr) {
+          handles.emplace_back(bufs_[i].io_handle);
+        }
+      }
       Status s = fs_->AbortIO(handles);
       assert(s.ok());
     }
@@ -110,12 +129,17 @@ class FilePrefetchBuffer {
     if (bufs_[curr_ ^ 1].buffer_.CurrentSize() != 0) {
       bytes_discarded += bufs_[curr_ ^ 1].buffer_.CurrentSize();
     }
+
+    for (uint32_t i = 0; i < 2; i++) {
+      // Release io_handle.
+      if (bufs_[i].io_handle != nullptr && del_fn_ != nullptr) {
+        del_fn_(bufs_[i].io_handle);
+        bufs_[i].io_handle = nullptr;
+      }
+    }
     RecordInHistogram(stats_, PREFETCHED_BYTES_DISCARDED, bytes_discarded);
 
-    // Release io_handle_.
-    if (io_handle_ != nullptr && del_fn_ != nullptr) {
-      del_fn_(io_handle_);
-      io_handle_ = nullptr;
+    if (del_fn_ != nullptr) {
       del_fn_ = nullptr;
     }
   }
@@ -204,7 +228,8 @@ class FilePrefetchBuffer {
     //   - block is sequential with the previous read and,
     //   - num_file_reads_ + 1 (including this read) >
     //   kMinNumFileReadsToStartAutoReadahead
-    if (implicit_auto_readahead_ && readahead_size_ > 0) {
+    if (implicit_auto_readahead_ && readahead_size_ > 0 &&
+        !bufs_[curr_].async_read_in_progress) {
       if ((offset + size >
            bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) &&
           IsBlockSequential(offset) &&
@@ -226,6 +251,8 @@ class FilePrefetchBuffer {
   void CalculateOffsetAndLen(size_t alignment, uint64_t offset,
                              size_t roundup_len, size_t index, bool refit_tail,
                              uint64_t& chunk_len);
+
+  void UpdateBuffersIfNeeded(uint64_t offset);
 
   // It calls Poll API if any there is any pending asynchronous request. It then
   // checks if data is in any buffer. It clears the outdated data and swaps the
@@ -287,11 +314,15 @@ class FilePrefetchBuffer {
   // curr_ represents the index for bufs_ indicating which buffer is being
   // consumed currently.
   uint32_t curr_;
+  // poll_index_ represents which buffer index to poll to get async results.
+  uint32_t poll_index_;
+
   size_t readahead_size_;
   size_t initial_auto_readahead_size_;
   // FilePrefetchBuffer object won't be created from Iterator flow if
   // max_readahead_size_ = 0.
   size_t max_readahead_size_;
+
   // The minimum `offset` ever passed to TryReadFromCache().
   size_t min_offset_read_;
   // if false, TryReadFromCache() always return false, and we only take stats
@@ -309,15 +340,10 @@ class FilePrefetchBuffer {
   // num_file_reads_ is only used when implicit_auto_readahead_ is set.
   uint64_t num_file_reads_;
 
-  // io_handle_ is allocated and used by underlying file system in case of
-  // asynchronous reads.
-  void* io_handle_;
   IOHandleDeleter del_fn_;
-  bool async_read_in_progress_;
-
   // If async_request_submitted_ is set then it indicates RocksDB called
-  // PrefetchAsync to submit request. It needs to TryReadFromCacheAsync to poll
-  // the submitted request without checking if data is sequential and
+  // PrefetchAsync to submit request. It needs to call TryReadFromCacheAsync to
+  // poll the submitted request without checking if data is sequential and
   // num_file_reads_.
   bool async_request_submitted_;
 

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -957,6 +957,7 @@ TEST_P(PrefetchTest, DBIterLevelReadAhead) {
     }
 
     ASSERT_OK(options.statistics->Reset());
+
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
     int num_keys = 0;
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -472,6 +472,7 @@ IOStatus RandomAccessFileReader::ReadAsync(
 
   if (use_direct_io() && is_aligned == false) {
     FSReadRequest aligned_req = Align(req, alignment);
+    aligned_req.status.PermitUncheckedError();
 
     // Allocate aligned buffer.
     read_async_info->buf_.Alignment(alignment);


### PR DESCRIPTION
Summary: Optimization and fixes
1.  Call ReadAsync before copying data to third buffer
 [**TODO**] - For fixed size readahead_size,  prefetch readahead_size/2 during seek as well (**In separate PR**)

Test Plan: 
- CircleCI tests
- stress_test completed successfully
```
export CRASH_TEST_EXT_ARGS="--async_io=1"
make crash_test -j32
```
-  db_bench showed no regression.

 For direct_reads = true
 With changes:
```
./db_bench -use_existing_db=true -db=/tmp/prefix_scan_prefetch_main1 -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=50000000 -use_direct_reads=true -seek_nexts=327680 -duration=30 -ops_between_duration_checks=1 -async_io=1
Set seed to 1661555616688467 because --seed was 0
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
Integrated BlobDB: blob cache disabled
RocksDB:    version 7.7.0
Date:       Fri Aug 26 16:13:36 2022
CPU:        32 * Intel Xeon Processor (Skylake)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    50000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    25939.9 MB (estimated)
FileSize:   13732.9 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
------------------------------------------------
DB path: [/tmp/prefix_scan_prefetch_main1]
seekrandom   :  327253.120 micros/op 3 ops/sec 30.107 seconds 92 operations;  519.5 MB/s (92 of 92 found)
```
For direct_reads = false
 With changes:
 ```
./db_bench -use_existing_db=true -db=/tmp/prefix_scan_prefetch_main1 -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=50000000 -use_direct_reads=false -seek_nexts=327680 -duration=30 -ops_between_duration_checks=1 -async_io=1
Set seed to 1661555722526186 because --seed was 0
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
Integrated BlobDB: blob cache disabled
RocksDB:    version 7.7.0
Date:       Fri Aug 26 16:15:22 2022
CPU:        32 * Intel Xeon Processor (Skylake)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    50000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    25939.9 MB (estimated)
FileSize:   13732.9 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
------------------------------------------------
DB path: [/tmp/prefix_scan_prefetch_main1]
seekrandom   :  256693.915 micros/op 3 ops/sec 30.033 seconds 117 operations;  653.2 MB/s (117 of 117 found)
```

