### PR TITLE
Max Index size and max top level index size compaction

### DIFF
--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -141,6 +141,9 @@ Status CompactionOutputs::AddToOutput(
   if (compaction_->output_level() != 0 &&
       current_output_file_size_ >= compaction_->max_output_file_size()) {
     pending_close_ = true;
+  } else if (!pending_close_ && builder_->NeedSplit()) {
+    // Table builder is hinting we should create new SST file
+    pending_close_ = true;
   }
 
   if (partitioner_) {

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -278,6 +278,16 @@ struct BlockBasedTableOptions {
   // compression is enabled.  This parameter can be changed dynamically.
   uint64_t block_size = 4 * 1024;
 
+  // Hint compaction job to limit index size per SST.
+  // It is supported only for kBinarySearch and kTwoLevelIndexSearch
+  uint64_t max_index_size = ULLONG_MAX;
+
+  // Hint compaction job to limit top level index size per SST
+  // It is not exactly size of top level index, but raw size
+  // of all keys in the top level index
+  // It is supported only for kTwoLevelIndexSearch
+  uint64_t max_top_level_index_raw_key_size = ULLONG_MAX;
+
   // This is used to close a block before it reaches the configured
   // 'block_size'. If the percentage of free space in the current block is less
   // than this specified number and adding a new record to the block will

--- a/java/rocksjni/table.cc
+++ b/java/rocksjni/table.cc
@@ -45,7 +45,7 @@ jlong Java_org_rocksdb_PlainTableConfig_newTableFactoryHandle(
 /*
  * Class:     org_rocksdb_BlockBasedTableConfig
  * Method:    newTableFactoryHandle
- * Signature: (ZZZZBBDBZJJJJIIIJZZZJZZIIZZBJIJI)J
+ * Signature: (ZZZZBBDBZJJJJIIIJZZZJZZIIZZBJIJIJJ)J
  */
 jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
     JNIEnv *, jobject, jboolean jcache_index_and_filter_blocks,
@@ -65,7 +65,8 @@ jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
     jboolean jenable_index_compression, jboolean jblock_align,
     jbyte jindex_shortening, jlong jblock_cache_size,
     jint jblock_cache_num_shard_bits, jlong jblock_cache_compressed_size,
-    jint jblock_cache_compressed_num_shard_bits) {
+    jint jblock_cache_compressed_num_shard_bits, jlong max_index_size,
+    jlong max_top_level_index_raw_key_size) {
   ROCKSDB_NAMESPACE::BlockBasedTableOptions options;
   options.cache_index_and_filter_blocks =
       static_cast<bool>(jcache_index_and_filter_blocks);
@@ -152,6 +153,9 @@ jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
   options.index_shortening =
       ROCKSDB_NAMESPACE::IndexShorteningModeJni::toCppIndexShorteningMode(
           jindex_shortening);
+  options.max_index_size = static_cast<uint64_t>(max_index_size);
+  options.max_top_level_index_raw_key_size =
+      static_cast<uint64_t>(max_top_level_index_raw_key_size);
 
   return GET_CPLUSPLUS_POINTER(
       ROCKSDB_NAMESPACE::NewBlockBasedTableFactory(options));

--- a/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
+++ b/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
@@ -42,6 +42,8 @@ public class BlockBasedTableConfig extends TableFormatConfig {
     enableIndexCompression = true;
     blockAlign = false;
     indexShortening = IndexShorteningMode.kShortenSeparators;
+    maxIndexSize = Long.MAX_VALUE;
+    maxTopLevelIndexRawKeySize = Long.MAX_VALUE;
 
     // NOTE: ONLY used if blockCache == null
     blockCacheSize = 8 * 1024 * 1024;
@@ -955,6 +957,54 @@ public class BlockBasedTableConfig extends TableFormatConfig {
     return this;
   }
 
+  /**
+   * Hint compaction job to limit index size per SST
+   *
+   * @return max index size in bytes
+   */
+  public long maxIndexSize() {
+    return maxIndexSize;
+  }
+
+  /**
+   * Hint compaction job to limit index size per SST
+   * Default: Long.MAX_VALUE
+   *
+   * @param maxIndexSize max index size in bytes
+   * @return the reference to the current config.
+   */
+  public BlockBasedTableConfig setMaxIndexSize(long maxIndexSize) {
+    this.maxIndexSize = maxIndexSize;
+    return this;
+  }
+
+  /**
+   * Hint compaction job to limit top level index size per SST
+   * It is not exactly size of top level index, but raw size
+   * of all keys in the top level index
+   * It is supported only for kBinarySearch and kTwoLevelIndexSearch
+   *
+   * @return max top level index size in bytes
+   */
+  public long maxTopLevelIndexRawKeySize() {
+    return maxTopLevelIndexRawKeySize;
+  }
+
+  /**
+   * Hint compaction job to limit top level index size per SST
+   * It is not exactly size of top level index, but raw size
+   * of all keys in the top level index
+   * It is supported only for kTwoLevelIndexSearch
+   * Default: Long.MAX_VALUE
+   *
+   * @param maxTopLevelIndexRawKeySize max top level index size in bytes
+   * @return the reference to the current config.
+   */
+  public BlockBasedTableConfig setMaxTopLevelIndexRawKeySize(long maxTopLevelIndexRawKeySize) {
+    this.maxTopLevelIndexRawKeySize = maxTopLevelIndexRawKeySize;
+    return this;
+  }
+
   @Override protected long newTableFactoryHandle() {
     final long filterPolicyHandle;
     if (filterPolicy != null) {
@@ -993,7 +1043,8 @@ public class BlockBasedTableConfig extends TableFormatConfig {
         optimizeFiltersForMemory, useDeltaEncoding, filterPolicyHandle, wholeKeyFiltering,
         verifyCompression, readAmpBytesPerBit, formatVersion, enableIndexCompression, blockAlign,
         indexShortening.getValue(), blockCacheSize, blockCacheNumShardBits,
-        blockCacheCompressedSize, blockCacheCompressedNumShardBits);
+        blockCacheCompressedSize, blockCacheCompressedNumShardBits, maxIndexSize,
+        maxTopLevelIndexRawKeySize);
   }
 
   private native long newTableFactoryHandle(final boolean cacheIndexAndFilterBlocks,
@@ -1009,11 +1060,10 @@ public class BlockBasedTableConfig extends TableFormatConfig {
       final long filterPolicyHandle, final boolean wholeKeyFiltering,
       final boolean verifyCompression, final int readAmpBytesPerBit, final int formatVersion,
       final boolean enableIndexCompression, final boolean blockAlign, final byte indexShortening,
-
       @Deprecated final long blockCacheSize, @Deprecated final int blockCacheNumShardBits,
-
       @Deprecated final long blockCacheCompressedSize,
-      @Deprecated final int blockCacheCompressedNumShardBits);
+      @Deprecated final int blockCacheCompressedNumShardBits, final long maxIndexSize,
+      final long maxTopLevelIndexRawKeySize);
 
   //TODO(AR) flushBlockPolicyFactory
   private boolean cacheIndexAndFilterBlocks;
@@ -1044,6 +1094,8 @@ public class BlockBasedTableConfig extends TableFormatConfig {
   private boolean enableIndexCompression;
   private boolean blockAlign;
   private IndexShorteningMode indexShortening;
+  private long maxIndexSize;
+  private long maxTopLevelIndexRawKeySize;
 
   // NOTE: ONLY used if blockCache == null
   @Deprecated private long blockCacheSize;

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -909,6 +909,13 @@ BlockBasedTableBuilder::~BlockBasedTableBuilder() {
   delete rep_;
 }
 
+bool BlockBasedTableBuilder::NeedSplit() const {
+  Rep* r = rep_;
+  assert(rep_->state != Rep::State::kClosed);
+  if (!ok() || r->reason != TableFileCreationReason::kCompaction) return false;
+  return r->index_builder->NeedSplit();
+}
+
 void BlockBasedTableBuilder::Add(const Slice& key, const Slice& value) {
   Rep* r = rep_;
   assert(rep_->state != Rep::State::kClosed);

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -91,6 +91,8 @@ class BlockBasedTableBuilder : public TableBuilder {
 
   bool NeedCompact() const override;
 
+  bool NeedSplit() const override;
+
   // Get table properties
   TableProperties GetTableProperties() const override;
 

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -306,6 +306,15 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct BlockBasedTableOptions, metadata_block_size),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"max_index_size",
+         {offsetof(struct BlockBasedTableOptions, max_index_size),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"max_top_level_index_raw_key_size",
+         {offsetof(struct BlockBasedTableOptions,
+                   max_top_level_index_raw_key_size),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         {"partition_filters",
          {offsetof(struct BlockBasedTableOptions, partition_filters),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -853,6 +862,13 @@ std::string BlockBasedTableFactory::GetPrintableOptions() const {
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  metadata_block_size: %" PRIu64 "\n",
            table_options_.metadata_block_size);
+  ret.append(buffer);
+  snprintf(buffer, kBufferSize, "  max_index_size: %" PRIu64 "\n",
+           table_options_.max_index_size);
+  ret.append(buffer);
+  snprintf(buffer, kBufferSize,
+           "  max_top_level_index_raw_key_size: %" PRIu64 "\n",
+           table_options_.max_top_level_index_raw_key_size);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  partition_filters: %d\n",
            table_options_.partition_filters);

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -213,6 +213,9 @@ class TableBuilder {
   // be further compacted.
   virtual bool NeedCompact() const { return false; }
 
+  // Returns true if based on options builder is requesting a split
+  virtual bool NeedSplit() const { return false; }
+
   // Returns table properties
   virtual TableProperties GetTableProperties() const = 0;
 


### PR DESCRIPTION
This PR adds a possibility to configure block based sst compaction to split it when index or top level index becomes too big. In our case where we have very long keys that are very hard to shorten as big portion is same (shortener does not benefit that) index grows. For us it happened that even with two level index we got top level index 300MB or more for one SST.

We are also using cache for indexes so basically single GET operation hitting such file loaded 300MB of data into cache (top level block). When one had more files like that, cache stopped working as blocks were pushing out each other very quickly. Simple GET operations performance dropped to almost zero.

Here we split file when index or top level index becomes to big to lower impact of such scenario.
