### PR TITLE
Fix FreeBSD building

### DIFF
--- a/port/jemalloc_helper.h
+++ b/port/jemalloc_helper.h
@@ -21,6 +21,7 @@
 #ifdef ROCKSDB_JEMALLOC
 #ifdef __FreeBSD__
 #include <malloc_np.h>
+#define JEMALLOC_USABLE_SIZE_CONST const
 #else
 #define JEMALLOC_MANGLE
 #include <jemalloc/jemalloc.h>


### PR DESCRIPTION
FreeBSD doesn't have `JEMALLOC_USABLE_SIZE_CONST` so we need to define
it.

This fixes MariaDB MDEV-20248.