### PR TITLE
fix trace_analyzer_tool args column position

### DIFF
--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -101,7 +101,7 @@ DEFINE_bool(convert_to_human_readable_trace, false,
             "You can specify 'no_key' to reduce the size, if key is not "
             "needed in the next step.\n"
             "File name: <prefix>_human_readable_trace.txt\n"
-            "Format:[type_id cf_id value_size time_in_micorsec <key>].");
+            "Format:[<key> type_id cf_id value_size time_in_micorsec].");
 DEFINE_bool(output_qps_stats, false,
             "Output the query per second(qps) statistics \n"
             "For the overall qps, it will contain all qps of each query type. "


### PR DESCRIPTION
The column  meaning explanation is not correct according to the parsed human-readable trace file.

Following are the results data from parsed trace human-readable file format.
The key is in the first column.


```
0x00000005 6 1 0 1661317998095439
0x00000007 0 1 0 1661317998095479
0x00000008 6 1 0 1661317998095493
0x0000000300000001 1 1 6 1661317998101508
0x0000000300000000 1 1 6 1661317998101508
0x0000000300000001 0 1 0 1661317998106486
0x0000000300000000 0 1 0 1661317998106498
0x0000000A 6 1 0 1661317998106515
0x00000007 0 1 0 1661317998111887
0x00000001 6 1 0 1661317998111923
```
