### PR TITLE
Update statistics for async scan readaheads

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,9 +3,11 @@
 ### Bug Fixes
 * Fixed bug where `FlushWAL(true /* sync */)` (used by `GetLiveFilesStorageInfo()`, which is used by checkpoint and backup) could cause parallel writes at the tail of a WAL file to never be synced.
 * Fix periodic_task unable to re-register the same task type, which may cause `SetOptions()` fail to update periodical_task time like: `stats_dump_period_sec`, `stats_persist_period_sec`.
+* Fixed a bug in the rocksdb.prefetched.bytes.discarded stat. It was counting the prefetch buffer size, rather than the actual number of bytes discarded from the buffer.
 
 ### Public API changes
 * Add `rocksdb_column_family_handle_get_id`, `rocksdb_column_family_handle_get_name` to get name, id of column family in C API
+* Add a new stat rocksdb.async.prefetch.abort.micros to measure time spent waiting for async prefetch reads to abort
 
 ### Java API Changes
 * Add CompactionPriority.RoundRobin.

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -565,6 +565,9 @@ enum Histograms : uint32_t {
   // Number of levels requiring IO for MultiGet
   NUM_LEVEL_READ_PER_MULTIGET,
 
+  // Wait time for aborting async read in FilePrefetchBuffer destructor
+  ASYNC_PREFETCH_ABORT_MICROS,
+
   HISTOGRAM_ENUM_MAX,
 };
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5623,6 +5623,10 @@ class HistogramTypeJni {
         return 0x35;
       case ROCKSDB_NAMESPACE::Histograms::MULTIGET_IO_BATCH_SIZE:
         return 0x36;
+      case NUM_LEVEL_READ_PER_MULTIGET:
+        return 0x37;
+      case ASYNC_PREFETCH_ABORT_MICROS:
+        return 0x38;
       case ROCKSDB_NAMESPACE::Histograms::HISTOGRAM_ENUM_MAX:
         // 0x1F for backwards compatibility on current minor version.
         return 0x1F;
@@ -5748,6 +5752,10 @@ class HistogramTypeJni {
         return ROCKSDB_NAMESPACE::Histograms::PREFETCHED_BYTES_DISCARDED;
       case 0x36:
         return ROCKSDB_NAMESPACE::Histograms::MULTIGET_IO_BATCH_SIZE;
+      case 0x37:
+        return ROCKSDB_NAMESPACE::Histograms::NUM_LEVEL_READ_PER_MULTIGET;
+      case 0x38:
+        return ROCKSDB_NAMESPACE::Histograms::ASYNC_PREFETCH_ABORT_MICROS;
       case 0x1F:
         // 0x1F for backwards compatibility on current minor version.
         return ROCKSDB_NAMESPACE::Histograms::HISTOGRAM_ENUM_MAX;

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -295,6 +295,7 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {PREFETCHED_BYTES_DISCARDED, "rocksdb.prefetched.bytes.discarded"},
     {MULTIGET_IO_BATCH_SIZE, "rocksdb.multiget.io.batch.size"},
     {NUM_LEVEL_READ_PER_MULTIGET, "rocksdb.num.level.read.per.multiget"},
+    {ASYNC_PREFETCH_ABORT_MICROS, "rocksdb.async.prefetch.abort.micros"},
 };
 
 std::shared_ptr<Statistics> CreateDBStatistics() {


### PR DESCRIPTION
Imported a fix to "rocksdb.prefetched.bytes.discarded" stat from #10561, and added a new stat "rocksdb.async.prefetch.abort.micros" to measure time spent waiting for async reads to abort.