### PR TITLE
ForwardIterator: used newly added VersionStorageInfo::FindFileInRange

### DIFF
--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -464,7 +464,7 @@ void ForwardIterator::SeekInternal(const Slice& internal_key,
       }
       uint32_t f_idx = 0;
       if (!seek_to_first) {
-        f_idx = FindFileInRange(level_files, internal_key, 0,
+        f_idx = vstorage->FindFileInRange(level, internal_key, 0,
                                 static_cast<uint32_t>(level_files.size()));
       }
 
@@ -991,18 +991,6 @@ bool ForwardIterator::TEST_CheckDeletedIters(int* pdeleted_iters,
     *pnum_iters = num_iters;
   }
   return retval;
-}
-
-uint32_t ForwardIterator::FindFileInRange(
-    const std::vector<FileMetaData*>& files, const Slice& internal_key,
-    uint32_t left, uint32_t right) {
-  auto cmp = [&](const FileMetaData* f, const Slice& k) -> bool {
-    return cfd_->internal_comparator().InternalKeyComparator::Compare(
-            f->largest.Encode(), k) < 0;
-  };
-  const auto &b = files.begin();
-  return static_cast<uint32_t>(std::lower_bound(b + left,
-                                 b + right, internal_key, cmp) - b);
 }
 
 void ForwardIterator::DeleteIterator(InternalIterator* iter, bool is_arena) {

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -105,10 +105,6 @@ class ForwardIterator : public InternalIterator {
   void UpdateCurrent();
   bool NeedToSeekImmutable(const Slice& internal_key);
   void DeleteCurrentIter();
-  uint32_t FindFileInRange(
-    const std::vector<FileMetaData*>& files, const Slice& internal_key,
-    uint32_t left, uint32_t right);
-
   bool IsOverUpperBound(const Slice& internal_key) const;
 
   // Set PinnedIteratorsManager for all children Iterators, this function should

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3989,6 +3989,12 @@ uint64_t VersionStorageInfo::NumLevelBytes(int level) const {
   return TotalFileSize(files_[level]);
 }
 
+int VersionStorageInfo::FindFileInRange(int level, const Slice& key,
+                                        uint32_t left, uint32_t right) const {
+  return ROCKSDB_NAMESPACE::FindFileInRange(*internal_comparator_,
+            level_files_brief_[level], key, left, right);
+}
+
 const char* VersionStorageInfo::LevelSummary(
     LevelSummaryStorage* scratch) const {
   int len = 0;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -321,6 +321,8 @@ class VersionStorageInfo {
     return files_[level];
   }
 
+  int FindFileInRange(int level, const Slice& key, uint32_t left, uint32_t right) const;
+
   class FileLocation {
    public:
     FileLocation() = default;


### PR DESCRIPTION
1. `FindFileInRange` is defined in `version_set.cc`, `ForwardIterator` should use it to reduce code explosion
2. The only one FindFileInRange can be optimized some way
    * We have optimized FindFileInRange by devirtualization and prefix caching for known Comparator (now just BytewiseComparator and ReverseBytewiseComparator) with 30x+ speed up, if rocksdb likes this optimization, I'll create a PR.