### PR TITLE
Async optimization in scan path

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,6 +34,7 @@
 ### Performance Improvements
 * Iterator performance is improved for `DeleteRange()` users. Internally, iterator will skip to the end of a range tombstone when possible, instead of looping through each key and check individually if a key is range deleted.
 * Eliminated some allocations and copies in the blob read path. Also, `PinnableSlice` now only points to the blob value and pins the backing resource (cache entry or buffer) in all cases, instead of containing a copy of the blob value. See #10625 and #10647.
+* In case of scans with async_io enabled, few optimizations have been added to issue more asynchronous requests in parallel in order to avoid synchronous prefetching.
 
 ## 7.6.0 (08/19/2022)
 ### New Features

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -764,7 +764,7 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   // - If curr_ is filled.
   //   - prefetch_size on second.
   // Calculate length and offsets for reading.
-  if (bufs_[curr_].buffer_.CurrentSize() == 0) {
+  if (!DoesBufferContainData(curr_)) {
     // Prefetch full data + prefetch_size in curr_.
     rounddown_start1 = Rounddown(offset_to_read, alignment);
     roundup_end1 = Roundup(offset_to_read + n + prefetch_size, alignment);

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -31,7 +31,23 @@ class RandomAccessFileReader;
 
 struct BufferInfo {
   AlignedBuffer buffer_;
+
   uint64_t offset_ = 0;
+
+  // Below parameters are used in case of async read flow.
+  // Length requested for in ReadAsync.
+  size_t async_req_len = 0;
+
+  // async_read_in_progress can be used as mutex. Callback can update the buffer
+  // and its size but async_read_in_progress is only set by main thread.
+  bool async_read_in_progress = false;
+
+  // io_handle is allocated and used by underlying file system in case of
+  // asynchronous reads.
+  void* io_handle = nullptr;
+
+  // pos represents the index of this buffer in vector of BufferInfo.
+  uint32_t pos = 0;
 };
 
 // FilePrefetchBuffer is a smart buffer to store and read data from a file.
@@ -53,9 +69,6 @@ class FilePrefetchBuffer {
   //   it. Used for adaptable readahead of the file footer/metadata.
   // implicit_auto_readahead : Readahead is enabled implicitly by rocksdb after
   //   doing sequential scans for two times.
-  // async_io : When async_io is enabled, if it's implicit_auto_readahead, it
-  //   prefetches data asynchronously in second buffer while curr_ is being
-  //   consumed.
   //
   // Automatic readhead is enabled for a file if readahead_size
   // and max_readahead_size are passed in.
@@ -69,6 +82,7 @@ class FilePrefetchBuffer {
                      FileSystem* fs = nullptr, SystemClock* clock = nullptr,
                      Statistics* stats = nullptr)
       : curr_(0),
+        poll_index_(curr_ ^ 1),
         readahead_size_(readahead_size),
         initial_auto_readahead_size_(readahead_size),
         max_readahead_size_(max_readahead_size),
@@ -80,9 +94,7 @@ class FilePrefetchBuffer {
         prev_len_(0),
         num_file_reads_for_auto_readahead_(num_file_reads_for_auto_readahead),
         num_file_reads_(num_file_reads),
-        io_handle_(nullptr),
         del_fn_(nullptr),
-        async_read_in_progress_(false),
         async_request_submitted_(false),
         fs_(fs),
         clock_(clock),
@@ -93,13 +105,20 @@ class FilePrefetchBuffer {
     // while curr_ is being consumed. If data is overlapping in two buffers,
     // data is copied to third buffer to return continuous buffer.
     bufs_.resize(3);
+    for (uint32_t i = 0; i < 2; i++) {
+      bufs_[i].pos = i;
+    }
   }
 
   ~FilePrefetchBuffer() {
     // Abort any pending async read request before destroying the class object.
-    if (async_read_in_progress_ && fs_ != nullptr) {
+    if (fs_ != nullptr) {
       std::vector<void*> handles;
-      handles.emplace_back(io_handle_);
+      for (uint32_t i = 0; i < 2; i++) {
+        if (bufs_[i].async_read_in_progress && bufs_[i].io_handle != nullptr) {
+          handles.emplace_back(bufs_[i].io_handle);
+        }
+      }
       StopWatch sw(clock_, stats_, ASYNC_PREFETCH_ABORT_MICROS);
       Status s = fs_->AbortIO(handles);
       assert(s.ok());
@@ -142,12 +161,17 @@ class FilePrefetchBuffer {
         }
       }
     }
+
+    for (uint32_t i = 0; i < 2; i++) {
+      // Release io_handle.
+      if (bufs_[i].io_handle != nullptr && del_fn_ != nullptr) {
+        del_fn_(bufs_[i].io_handle);
+        bufs_[i].io_handle = nullptr;
+      }
+    }
     RecordInHistogram(stats_, PREFETCHED_BYTES_DISCARDED, bytes_discarded);
 
-    // Release io_handle_.
-    if (io_handle_ != nullptr && del_fn_ != nullptr) {
-      del_fn_(io_handle_);
-      io_handle_ = nullptr;
+    if (del_fn_ != nullptr) {
       del_fn_ = nullptr;
     }
   }
@@ -236,7 +260,8 @@ class FilePrefetchBuffer {
     //   - block is sequential with the previous read and,
     //   - num_file_reads_ + 1 (including this read) >
     //   num_file_reads_for_auto_readahead_
-    if (implicit_auto_readahead_ && readahead_size_ > 0) {
+    if (implicit_auto_readahead_ && readahead_size_ > 0 &&
+        !bufs_[curr_].async_read_in_progress) {
       if ((offset + size >
            bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) &&
           IsBlockSequential(offset) &&
@@ -258,6 +283,8 @@ class FilePrefetchBuffer {
   void CalculateOffsetAndLen(size_t alignment, uint64_t offset,
                              size_t roundup_len, size_t index, bool refit_tail,
                              uint64_t& chunk_len);
+
+  void UpdateBuffersIfNeeded(uint64_t offset);
 
   // It calls Poll API if any there is any pending asynchronous request. It then
   // checks if data is in any buffer. It clears the outdated data and swaps the
@@ -319,11 +346,15 @@ class FilePrefetchBuffer {
   // curr_ represents the index for bufs_ indicating which buffer is being
   // consumed currently.
   uint32_t curr_;
+  // poll_index_ represents which buffer index to poll to get async results.
+  uint32_t poll_index_;
+
   size_t readahead_size_;
   size_t initial_auto_readahead_size_;
   // FilePrefetchBuffer object won't be created from Iterator flow if
   // max_readahead_size_ = 0.
   size_t max_readahead_size_;
+
   // The minimum `offset` ever passed to TryReadFromCache().
   size_t min_offset_read_;
   // if false, TryReadFromCache() always return false, and we only take stats
@@ -343,15 +374,10 @@ class FilePrefetchBuffer {
   uint64_t num_file_reads_for_auto_readahead_;
   uint64_t num_file_reads_;
 
-  // io_handle_ is allocated and used by underlying file system in case of
-  // asynchronous reads.
-  void* io_handle_;
   IOHandleDeleter del_fn_;
-  bool async_read_in_progress_;
-
   // If async_request_submitted_ is set then it indicates RocksDB called
-  // PrefetchAsync to submit request. It needs to TryReadFromCacheAsync to poll
-  // the submitted request without checking if data is sequential and
+  // PrefetchAsync to submit request. It needs to call TryReadFromCacheAsync to
+  // poll the submitted request without checking if data is sequential and
   // num_file_reads_.
   bool async_request_submitted_;
 

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -260,10 +260,11 @@ class FilePrefetchBuffer {
     //   - block is sequential with the previous read and,
     //   - num_file_reads_ + 1 (including this read) >
     //   num_file_reads_for_auto_readahead_
-    if (implicit_auto_readahead_ && readahead_size_ > 0 &&
-        !bufs_[curr_].async_read_in_progress) {
-      if ((offset + size >
-           bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) &&
+    size_t curr_size = bufs_[curr_].async_read_in_progress
+                           ? bufs_[curr_].async_req_len
+                           : bufs_[curr_].buffer_.CurrentSize();
+    if (implicit_auto_readahead_ && readahead_size_ > 0) {
+      if ((offset + size > bufs_[curr_].offset_ + curr_size) &&
           IsBlockSequential(offset) &&
           (num_file_reads_ + 1 > num_file_reads_for_auto_readahead_)) {
         readahead_size_ =
@@ -283,6 +284,8 @@ class FilePrefetchBuffer {
   void CalculateOffsetAndLen(size_t alignment, uint64_t offset,
                              size_t roundup_len, size_t index, bool refit_tail,
                              uint64_t& chunk_len);
+
+  void AbortIOIfNeeded(uint64_t offset);
 
   void UpdateBuffersIfNeeded(uint64_t offset);
 

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1066,6 +1066,7 @@ TEST_P(PrefetchTest, DBIterLevelReadAhead) {
     }
 
     ASSERT_OK(options.statistics->Reset());
+
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
     int num_keys = 0;
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1645,6 +1645,311 @@ namespace {
     Close();
   }
 
+  TEST_P(PrefetchTest, MultipleSeekWithPosixFS) {
+    if (mem_env_ || encrypted_env_) {
+      ROCKSDB_GTEST_SKIP("Test requires non-mem or non-encrypted environment");
+      return;
+    }
+
+    const int kNumKeys = 1000;
+    std::shared_ptr<MockFS> fs = std::make_shared<MockFS>(
+        FileSystem::Default(), /*support_prefetch=*/false);
+    std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, fs));
+
+    bool use_direct_io = std::get<0>(GetParam());
+    Options options = CurrentOptions();
+    options.write_buffer_size = 1024;
+    options.create_if_missing = true;
+    options.compression = kNoCompression;
+    options.env = env.get();
+    options.statistics = CreateDBStatistics();
+    if (use_direct_io) {
+      options.use_direct_reads = true;
+      options.use_direct_io_for_flush_and_compaction = true;
+    }
+    BlockBasedTableOptions table_options;
+    table_options.no_block_cache = true;
+    table_options.cache_index_and_filter_blocks = false;
+    table_options.metadata_block_size = 1024;
+    table_options.index_type =
+        BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+    options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+    Status s = TryReopen(options);
+    if (use_direct_io && (s.IsNotSupported() || s.IsInvalidArgument())) {
+      // If direct IO is not supported, skip the test
+      return;
+    } else {
+      ASSERT_OK(s);
+    }
+
+    int total_keys = 0;
+    // Write the keys.
+    {
+      WriteBatch batch;
+      Random rnd(309);
+      for (int j = 0; j < 5; j++) {
+        for (int i = j * kNumKeys; i < (j + 1) * kNumKeys; i++) {
+          ASSERT_OK(batch.Put(BuildKey(i), rnd.RandomString(1000)));
+          total_keys++;
+        }
+        ASSERT_OK(db_->Write(WriteOptions(), &batch));
+        ASSERT_OK(Flush());
+      }
+      MoveFilesToLevel(2);
+    }
+
+    int num_keys_first_batch = 0;
+    int num_keys_second_batch = 0;
+    // Calculate number of keys without async_io for correctness validation.
+    {
+      auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
+      // First Seek.
+      iter->Seek(BuildKey(450));
+      while (iter->Valid() && num_keys_first_batch < 100) {
+        ASSERT_OK(iter->status());
+        num_keys_first_batch++;
+        iter->Next();
+      }
+      ASSERT_OK(iter->status());
+
+      iter->Seek(BuildKey(942));
+      while (iter->Valid()) {
+        ASSERT_OK(iter->status());
+        num_keys_second_batch++;
+        iter->Next();
+      }
+      ASSERT_OK(iter->status());
+    }
+
+    int buff_prefetch_count = 0;
+    bool read_async_called = false;
+    ReadOptions ro;
+    ro.adaptive_readahead = true;
+    ro.async_io = true;
+
+    if (std::get<1>(GetParam())) {
+      ro.readahead_size = 16 * 1024;
+    }
+
+    SyncPoint::GetInstance()->SetCallBack(
+        "FilePrefetchBuffer::PrefetchAsyncInternal:Start",
+        [&](void*) { buff_prefetch_count++; });
+
+    SyncPoint::GetInstance()->SetCallBack(
+        "UpdateResults::io_uring_result",
+        [&](void* /*arg*/) { read_async_called = true; });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    // Read the keys using seek.
+    {
+      ASSERT_OK(options.statistics->Reset());
+      get_perf_context()->Reset();
+
+      auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
+      int num_keys = 0;
+      // First Seek.
+      {
+        iter->Seek(BuildKey(450));
+        while (iter->Valid() && num_keys < 100) {
+          ASSERT_OK(iter->status());
+          num_keys++;
+          iter->Next();
+        }
+        ASSERT_OK(iter->status());
+        ASSERT_EQ(num_keys, num_keys_first_batch);
+        // Check stats to make sure async prefetch is done.
+        {
+          HistogramData async_read_bytes;
+          options.statistics->histogramData(ASYNC_READ_BYTES,
+                                            &async_read_bytes);
+
+          // Not all platforms support iouring. In that case, ReadAsync in posix
+          // won't submit async requests.
+          if (read_async_called) {
+            ASSERT_GT(async_read_bytes.count, 0);
+            ASSERT_GT(get_perf_context()->number_async_seek, 0);
+          } else {
+            ASSERT_EQ(async_read_bytes.count, 0);
+            ASSERT_EQ(get_perf_context()->number_async_seek, 0);
+          }
+        }
+      }
+
+      // Second Seek.
+      {
+        num_keys = 0;
+        ASSERT_OK(options.statistics->Reset());
+        get_perf_context()->Reset();
+
+        iter->Seek(BuildKey(942));
+        while (iter->Valid()) {
+          ASSERT_OK(iter->status());
+          num_keys++;
+          iter->Next();
+        }
+        ASSERT_OK(iter->status());
+        ASSERT_EQ(num_keys, num_keys_second_batch);
+
+        ASSERT_GT(buff_prefetch_count, 0);
+
+        // Check stats to make sure async prefetch is done.
+        {
+          HistogramData async_read_bytes;
+          options.statistics->histogramData(ASYNC_READ_BYTES,
+                                            &async_read_bytes);
+          HistogramData prefetched_bytes_discarded;
+          options.statistics->histogramData(PREFETCHED_BYTES_DISCARDED,
+                                            &prefetched_bytes_discarded);
+
+          // Not all platforms support iouring. In that case, ReadAsync in posix
+          // won't submit async requests.
+          if (read_async_called) {
+            ASSERT_GT(async_read_bytes.count, 0);
+            ASSERT_GT(get_perf_context()->number_async_seek, 0);
+          } else {
+            ASSERT_EQ(async_read_bytes.count, 0);
+            ASSERT_EQ(get_perf_context()->number_async_seek, 0);
+          }
+          ASSERT_GT(prefetched_bytes_discarded.count, 0);
+        }
+      }
+    }
+
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+    Close();
+  }
+
+  TEST_P(PrefetchTest, SeekParallelizationTest1) {
+    if (mem_env_ || encrypted_env_) {
+      ROCKSDB_GTEST_SKIP("Test requires non-mem or non-encrypted environment");
+      return;
+    }
+    const int kNumKeys = 2000;
+    // Set options
+    std::shared_ptr<MockFS> fs = std::make_shared<MockFS>(
+        FileSystem::Default(), /*support_prefetch=*/false);
+    std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, fs));
+
+    bool use_direct_io = std::get<0>(GetParam());
+    Options options = CurrentOptions();
+    options.write_buffer_size = 1024;
+    options.create_if_missing = true;
+    options.compression = kNoCompression;
+    options.env = env.get();
+    if (use_direct_io) {
+      options.use_direct_reads = true;
+      options.use_direct_io_for_flush_and_compaction = true;
+    }
+
+    options.statistics = CreateDBStatistics();
+    BlockBasedTableOptions table_options;
+    table_options.no_block_cache = true;
+    table_options.cache_index_and_filter_blocks = false;
+    table_options.metadata_block_size = 1024;
+    table_options.index_type =
+        BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+    options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+    Status s = TryReopen(options);
+    if (use_direct_io && (s.IsNotSupported() || s.IsInvalidArgument())) {
+      // If direct IO is not supported, skip the test
+      return;
+    } else {
+      ASSERT_OK(s);
+    }
+
+    WriteBatch batch;
+    Random rnd(309);
+    for (int i = 0; i < kNumKeys; i++) {
+      ASSERT_OK(batch.Put(BuildKey(i), rnd.RandomString(1000)));
+    }
+    ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+    std::string start_key = BuildKey(0);
+    std::string end_key = BuildKey(kNumKeys - 1);
+    Slice least(start_key.data(), start_key.size());
+    Slice greatest(end_key.data(), end_key.size());
+
+    ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &least, &greatest));
+
+    int buff_prefetch_count = 0;
+
+    SyncPoint::GetInstance()->SetCallBack(
+        "FilePrefetchBuffer::PrefetchAsyncInternal:Start",
+        [&](void*) { buff_prefetch_count++; });
+
+    bool read_async_called = false;
+    SyncPoint::GetInstance()->SetCallBack(
+        "UpdateResults::io_uring_result",
+        [&](void* /*arg*/) { read_async_called = true; });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    ReadOptions ro;
+    ro.adaptive_readahead = true;
+    ro.async_io = true;
+
+    if (std::get<1>(GetParam())) {
+      ro.readahead_size = 16 * 1024;
+    }
+
+    {
+      ASSERT_OK(options.statistics->Reset());
+      // Each block contains around 4 keys.
+      auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ro));
+      iter->Seek(
+          BuildKey(0));  // Prefetch data because of seek parallelization.
+      ASSERT_TRUE(iter->Valid());
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+
+      // New data block. Since num_file_reads in FilePrefetch after this read is
+      // 2, it won't go for prefetching.
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+
+      // Prefetch data.
+      iter->Next();
+      ASSERT_TRUE(iter->Valid());
+
+      // Check stats to make sure async prefetch is done.
+      {
+        HistogramData async_read_bytes;
+        options.statistics->histogramData(ASYNC_READ_BYTES, &async_read_bytes);
+        // Not all platforms support iouring. In that case, ReadAsync in posix
+        // won't submit async requests.
+        if (read_async_called) {
+          ASSERT_GT(async_read_bytes.count, 0);
+          ASSERT_GT(get_perf_context()->number_async_seek, 0);
+          if (std::get<1>(GetParam())) {
+            ASSERT_EQ(buff_prefetch_count, 1);
+          } else {
+            ASSERT_EQ(buff_prefetch_count, 2);
+          }
+        } else {
+          ASSERT_EQ(async_read_bytes.count, 0);
+          ASSERT_EQ(get_perf_context()->number_async_seek, 0);
+          ASSERT_EQ(buff_prefetch_count, 1);
+        }
+      }
+
+      buff_prefetch_count = 0;
+    }
+    Close();
+  }
+
 #ifndef ROCKSDB_LITE
 #ifdef GFLAGS
   TEST_P(PrefetchTest, TraceReadAsyncWithCallbackWrapper) {

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -473,6 +473,7 @@ IOStatus RandomAccessFileReader::ReadAsync(
 
   if (use_direct_io() && is_aligned == false) {
     FSReadRequest aligned_req = Align(req, alignment);
+    aligned_req.status.PermitUncheckedError();
 
     // Allocate aligned buffer.
     read_async_info->buf_.Alignment(alignment);


### PR DESCRIPTION
Summary: Optimizations
1. In FilePrefetchBuffer, when data is overlapping between two buffers, it copies the data from first to third buffer, then from 
second to third buffer to return continuous buffer. This optimization will call ReadAsync on first buffer as soon as buffer is empty instead of getting blocked by second buffer to copy the data.
2. For fixed size readahead_size, FilePrefetchBuffer will issues two async read calls. One with length + readahead_size_/2 on first buffer(if buffer is empty) and readahead_size_/2 on second buffer during seek.

- Add readahead_size to db_stress for stress testing these changes in https://github.com/facebook/rocksdb/pull/10632

Test Plan:
- CircleCI tests
- stress_test completed successfully
export CRASH_TEST_EXT_ARGS="--async_io=1"
make crash_test -j32
- db_bench showed no regression
   With this PR:
```
 ./db_bench -use_existing_db=true -db=/tmp/prefix_scan_prefetch_main1 -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=50000000 -use_direct_reads=false -seek_nexts=327680 -duration=30 -ops_between_duration_checks=1 -async_io=1
Set seed to 1661876074584472 because --seed was 0
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
Integrated BlobDB: blob cache disabled
RocksDB:    version 7.7.0
Date:       Tue Aug 30 09:14:34 2022
CPU:        32 * Intel Xeon Processor (Skylake)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    50000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    25939.9 MB (estimated)
FileSize:   13732.9 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
------------------------------------------------
DB path: [/tmp/prefix_scan_prefetch_main1]
seekrandom   :  270878.018 micros/op 3 ops/sec 30.068 seconds 111 operations;  618.7 MB/s (111 of 111 found)

 ./db_bench -use_existing_db=true -db=/tmp/prefix_scan_prefetch_main1 -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=50000000 -use_direct_reads=true -seek_nexts=327680 -duration=30 -ops_between_duration_checks=1 -async_io=1
Set seed to 1661875332862922 because --seed was 0
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
Integrated BlobDB: blob cache disabled
RocksDB:    version 7.7.0
Date:       Tue Aug 30 09:02:12 2022
CPU:        32 * Intel Xeon Processor (Skylake)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    50000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    25939.9 MB (estimated)
FileSize:   13732.9 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
WARNING: Assertions are enabled; benchmarks unnecessarily slow
------------------------------------------------
DB path: [/tmp/prefix_scan_prefetch_main1]
seekrandom   :  358352.488 micros/op 2 ops/sec 30.102 seconds 84 operations;  474.4 MB/s (84 of 84 found)
```

Without PR in main:
```
./db_bench -use_existing_db=true -db=/tmp/prefix_scan_prefetch_main1 -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=50000000 -use_direct_reads=false -seek_nexts=327680 -duration=30 -ops_between_duration_checks=1 -async_io=1
Set seed to 1661876425983045 because --seed was 0
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
Integrated BlobDB: blob cache disabled
RocksDB:    version 7.7.0
Date:       Tue Aug 30 09:20:26 2022
CPU:        32 * Intel Xeon Processor (Skylake)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    50000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    25939.9 MB (estimated)
FileSize:   13732.9 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
------------------------------------------------
DB path: [/tmp/prefix_scan_prefetch_main1]
seekrandom   :  280881.953 micros/op 3 ops/sec 30.054 seconds 107 operations;  605.2 MB/s (107 of 107 found)

 ./db_bench -use_existing_db=true -db=/tmp/prefix_scan_prefetch_main1 -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=50000000 -use_direct_reads=false -seek_nexts=327680 -duration=30 -ops_between_duration_checks=1 -async_io=0
Set seed to 1661876475267771 because --seed was 0
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
Integrated BlobDB: blob cache disabled
RocksDB:    version 7.7.0
Date:       Tue Aug 30 09:21:15 2022
CPU:        32 * Intel Xeon Processor (Skylake)
CPUCache:   16384 KB
Keys:       32 bytes each (+ 0 bytes user-defined timestamp)
Values:     512 bytes each (256 bytes after compression)
Entries:    50000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    25939.9 MB (estimated)
FileSize:   13732.9 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: Snappy
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
------------------------------------------------
DB path: [/tmp/prefix_scan_prefetch_main1]
seekrandom   :  363155.084 micros/op 2 ops/sec 30.142 seconds 83 operations;  468.1 MB/s (83 of 83 found)
```
