### PR TITLE
Adjust the blob cache printout in db_bench/db_stress

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2415,14 +2415,16 @@ void StressTest::Open(SharedState* shared) {
 
   if (FLAGS_use_blob_cache) {
     fprintf(stdout,
-            "Integrated BlobDB: blob cache enabled, block and blob caches "
-            "shared: %d, blob cache size %" PRIu64
-            ", blob cache num shard bits: %d, blob cache prepopulated: %s\n",
-            FLAGS_use_shared_block_and_blob_cache, FLAGS_blob_cache_size,
-            FLAGS_blob_cache_numshardbits,
-            options_.prepopulate_blob_cache == PrepopulateBlobCache::kFlushOnly
-                ? "flush only"
-                : "disable");
+            "Integrated BlobDB: blob cache enabled"
+            ", block and blob caches shared: %d",
+            FLAGS_use_shared_block_and_blob_cache);
+    if (!FLAGS_use_shared_block_and_blob_cache) {
+      fprintf(stdout,
+              ", blob cache size %" PRIu64 ", blob cache num shard bits: %d",
+              FLAGS_blob_cache_size, FLAGS_blob_cache_numshardbits);
+    }
+    fprintf(stdout, ", blob cache prepopulated: %d\n",
+            FLAGS_prepopulate_blob_cache);
   } else {
     fprintf(stdout, "Integrated BlobDB: blob cache disabled\n");
   }

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4464,13 +4464,19 @@ class Benchmark {
             fprintf(stderr, "Unknown prepopulate blob cache mode\n");
             exit(1);
         }
+
         fprintf(stdout,
-                "Integrated BlobDB: blob cache enabled, block and blob caches "
-                "shared: %d, blob cache size %" PRIu64
-                ", blob cache num shard bits: %d, hot/warm blobs prepopulated: "
-                "%d\n",
-                FLAGS_use_shared_block_and_blob_cache, FLAGS_blob_cache_size,
-                FLAGS_blob_cache_numshardbits, FLAGS_prepopulate_blob_cache);
+                "Integrated BlobDB: blob cache enabled"
+                ", block and blob caches shared: %d",
+                FLAGS_use_shared_block_and_blob_cache);
+        if (!FLAGS_use_shared_block_and_blob_cache) {
+          fprintf(stdout,
+                  ", blob cache size %" PRIu64
+                  ", blob cache num shard bits: %d",
+                  FLAGS_blob_cache_size, FLAGS_blob_cache_numshardbits);
+        }
+        fprintf(stdout, ", blob cache prepopulated: %d\n",
+                FLAGS_prepopulate_blob_cache);
       } else {
         fprintf(stdout, "Integrated BlobDB: blob cache disabled\n");
       }


### PR DESCRIPTION
Summary:
Currently, `db_bench` and `db_stress` print the blob cache options even if
a shared block/blob cache is configured, i.e. when they are not actually
in effect. The patch changes this so they are only printed when a separate blob
cache is used.

Test Plan:
Tested manually using `db_bench` and `db_stress`.