### PR TITLE
[DRAFT][CodeMod] Rename fields for clarity

### DIFF
--- a/db/blob/blob_counting_iterator_test.cc
+++ b/db/blob/blob_counting_iterator_test.cc
@@ -303,7 +303,7 @@ TEST(BlobCountingIteratorTest, CountBlobs) {
 
 TEST(BlobCountingIteratorTest, CorruptBlobIndex) {
   const std::vector<std::string> keys{
-      test::KeyStr("user_key", 1, kTypeBlobIndex)};
+      test::KeyStr("user_key_with_ts", 1, kTypeBlobIndex)};
   const std::vector<std::string> values{"i_am_not_a_blob_index"};
 
   assert(keys.size() == values.size());

--- a/db/blob/blob_garbage_meter.cc
+++ b/db/blob/blob_garbage_meter.cc
@@ -91,8 +91,8 @@ Status BlobGarbageMeter::Parse(const Slice& key, const Slice& value,
 
   *blob_file_number = blob_index.file_number();
   *bytes =
-      blob_index.size() +
-      BlobLogRecord::CalculateAdjustmentForRecordHeader(ikey.user_key.size());
+      blob_index.size() + BlobLogRecord::CalculateAdjustmentForRecordHeader(
+                              ikey.user_key_with_ts.size());
 
   return Status::OK();
 }

--- a/db/blob/blob_garbage_meter_test.cc
+++ b/db/blob/blob_garbage_meter_test.cc
@@ -122,7 +122,7 @@ TEST(BlobGarbageMeterTest, MeasureGarbage) {
 }
 
 TEST(BlobGarbageMeterTest, PlainValue) {
-  constexpr char user_key[] = "user_key";
+  constexpr char user_key[] = "user_key_with_ts";
   constexpr SequenceNumber seq = 123;
 
   const InternalKey key(user_key, seq, kTypeValue);
@@ -152,7 +152,7 @@ TEST(BlobGarbageMeterTest, CorruptInternalKey) {
 }
 
 TEST(BlobGarbageMeterTest, CorruptBlobIndex) {
-  constexpr char user_key[] = "user_key";
+  constexpr char user_key[] = "user_key_with_ts";
   constexpr SequenceNumber seq = 123;
 
   const InternalKey key(user_key, seq, kTypeBlobIndex);
@@ -168,7 +168,7 @@ TEST(BlobGarbageMeterTest, CorruptBlobIndex) {
 }
 
 TEST(BlobGarbageMeterTest, InlinedTTLBlobIndex) {
-  constexpr char user_key[] = "user_key";
+  constexpr char user_key[] = "user_key_with_ts";
   constexpr SequenceNumber seq = 123;
 
   const InternalKey key(user_key, seq, kTypeBlobIndex);

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1175,7 +1175,7 @@ Status ColumnFamilyData::RangesOverlapWithMemtables(
 
     if (status.ok()) {
       if (memtable_iter->Valid() &&
-          ucmp->Compare(seek_result.user_key, ranges[i].limit) <= 0) {
+          ucmp->Compare(seek_result.user_key_with_ts, ranges[i].limit) <= 0) {
         *overlap = true;
       } else if (range_del_agg.IsRangeOverlapped(ranges[i].start,
                                                  ranges[i].limit)) {

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -191,7 +191,8 @@ class Compaction {
   void AddInputDeletions(VersionEdit* edit);
 
   // Returns true if the available information we have guarantees that
-  // the input "user_key" does not exist in any level beyond "output_level()".
+  // the input "user_key_with_ts" does not exist in any level beyond
+  // "output_level()".
   bool KeyNotExistsBeyondOutputLevel(const Slice& user_key,
                                      std::vector<size_t>* level_ptrs) const;
 

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -307,7 +307,8 @@ class CompactionIterator {
     if (!timestamp_size_) {
       return;
     }
-    Slice ts = ExtractTimestampFromUserKey(ikey_.user_key, timestamp_size_);
+    Slice ts =
+        ExtractTimestampFromUserKey(ikey_.user_key_with_ts, timestamp_size_);
     curr_ts_.assign(ts.data(), ts.size());
     if (full_history_ts_low_) {
       cmp_with_history_ts_low_ =
@@ -405,8 +406,8 @@ class CompactionIterator {
   // iterator output (or current key in the underlying iterator during
   // NextFromInput()).
   ParsedInternalKey ikey_;
-  // Stores whether ikey_.user_key is valid. If set to false, the user key is
-  // not compared against the current key in the underlying iterator.
+  // Stores whether ikey_.user_key_with_ts is valid. If set to false, the user
+  // key is not compared against the current key in the underlying iterator.
   bool has_current_user_key_ = false;
   // If false, the iterator holds a copy of the current compaction iterator
   // output (or current key in the underlying iterator during NextFromInput()).

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -151,7 +151,7 @@ class FakeCompaction : public CompactionIterator::CompactionProxy {
   int level() const override { return 0; }
 
   bool KeyNotExistsBeyondOutputLevel(
-      const Slice& /*user_key*/,
+      const Slice& /*user_key_with_ts*/,
       std::vector<size_t>* /*level_ptrs*/) const override {
     return is_bottommost_level || key_not_exists_beyond_output_level;
   }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -466,7 +466,8 @@ void CompactionJob::GenSubcompactionBoundaries() {
         Status s = cfd->table_cache()->ApproximateKeyAnchors(
             ReadOptions(), icomp, f->fd, my_anchors);
         if (!s.ok() || my_anchors.empty()) {
-          my_anchors.emplace_back(f->largest.user_key(), f->fd.GetFileSize());
+          my_anchors.emplace_back(f->largest.user_key_with_ts(),
+                                  f->fd.GetFileSize());
         }
         for (auto& ac : my_anchors) {
           // Can be optimize to avoid this loop.
@@ -1468,8 +1469,8 @@ Status CompactionJob::FinishCompactionOutputFile(
     // table properties. Not sure how to resolve it.
     if (meta->smallest.size() > 0 && meta->largest.size() > 0) {
       uint64_t refined_oldest_ancester_time;
-      Slice new_smallest = meta->smallest.user_key();
-      Slice new_largest = meta->largest.user_key();
+      Slice new_smallest = meta->smallest.user_key_with_ts();
+      Slice new_largest = meta->largest.user_key_with_ts();
       if (!new_largest.empty() && !new_smallest.empty()) {
         refined_oldest_ancester_time =
             sub_compact->compaction->MinInputFileOldestAncesterTime(

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -324,14 +324,16 @@ class CompactionJobTestBase : public testing::Test {
       smallest_seqno = std::min(smallest_seqno, key.sequence);
       largest_seqno = std::max(largest_seqno, key.sequence);
 
-      if (first_key ||
-          cfd_->user_comparator()->Compare(key.user_key, smallest) < 0) {
-        smallest.assign(key.user_key.data(), key.user_key.size());
+      if (first_key || cfd_->user_comparator()->Compare(key.user_key_with_ts,
+                                                        smallest) < 0) {
+        smallest.assign(key.user_key_with_ts.data(),
+                        key.user_key_with_ts.size());
         smallest_key.DecodeFrom(skey);
       }
       if (first_key ||
-          cfd_->user_comparator()->Compare(key.user_key, largest) > 0) {
-        largest.assign(key.user_key.data(), key.user_key.size());
+          cfd_->user_comparator()->Compare(key.user_key_with_ts, largest) > 0) {
+        largest.assign(key.user_key_with_ts.data(),
+                       key.user_key_with_ts.size());
         largest_key.DecodeFrom(skey);
       }
 

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -129,7 +129,7 @@ class CompactionOutputs {
 
   Slice SmallestUserKey() const {
     if (!outputs_.empty() && outputs_[0].finished) {
-      return outputs_[0].meta.smallest.user_key();
+      return outputs_[0].meta.smallest.user_key_with_ts();
     } else {
       return Slice{nullptr, 0};
     }
@@ -137,7 +137,7 @@ class CompactionOutputs {
 
   Slice LargestUserKey() const {
     if (!outputs_.empty() && outputs_.back().finished) {
-      return outputs_.back().meta.largest.user_key();
+      return outputs_.back().meta.largest.user_key_with_ts();
     } else {
       return Slice{nullptr, 0};
     }

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -327,15 +327,15 @@ bool CompactionPicker::FilesRangeOverlapWithCompaction(
   if (penultimate_level != Compaction::kInvalidLevel) {
     InternalKey penultimate_smallest, penultimate_largest;
     GetRange(inputs, &penultimate_smallest, &penultimate_largest, level);
-    if (RangeOverlapWithCompaction(penultimate_smallest.user_key(),
-                                   penultimate_largest.user_key(),
+    if (RangeOverlapWithCompaction(penultimate_smallest.user_key_with_ts(),
+                                   penultimate_largest.user_key_with_ts(),
                                    penultimate_level)) {
       return true;
     }
   }
 
-  return RangeOverlapWithCompaction(smallest.user_key(), largest.user_key(),
-                                    level);
+  return RangeOverlapWithCompaction(smallest.user_key_with_ts(),
+                                    largest.user_key_with_ts(), level);
 }
 
 // Returns true if any one of specified files are being compacted

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -663,8 +663,8 @@ bool LevelCompactionBuilder::TryExtendNonL0TrivialMove(int start_index) {
       }
       if (i < static_cast<int>(level_files.size()) - 1 &&
           compaction_picker_->icmp()->user_comparator()->Compare(
-              next_file->largest.user_key(),
-              level_files[i + 1]->smallest.user_key()) == 0) {
+              next_file->largest.user_key_with_ts(),
+              level_files[i + 1]->smallest.user_key_with_ts()) == 0) {
         // Not a clean up after adding the next file. Skip.
         break;
       }

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -164,8 +164,8 @@ struct SmallestKeyHeapComparator {
   explicit SmallestKeyHeapComparator(const Comparator* ucmp) { ucmp_ = ucmp; }
 
   bool operator()(InputFileInfo i1, InputFileInfo i2) const {
-    return (ucmp_->Compare(i1.f->smallest.user_key(),
-                           i2.f->smallest.user_key()) > 0);
+    return (ucmp_->Compare(i1.f->smallest.user_key_with_ts(),
+                           i2.f->smallest.user_key_with_ts()) > 0);
   }
 
  private:
@@ -249,13 +249,13 @@ bool UniversalCompactionBuilder::IsInputFilesNonOverlapping(Compaction* c) {
       prev = curr;
       first_iter = 0;
     } else {
-      if (comparator->Compare(prev.f->largest.user_key(),
-                              curr.f->smallest.user_key()) >= 0) {
+      if (comparator->Compare(prev.f->largest.user_key_with_ts(),
+                              curr.f->smallest.user_key_with_ts()) >= 0) {
         // found overlapping files, return false
         return false;
       }
-      assert(comparator->Compare(curr.f->largest.user_key(),
-                                 prev.f->largest.user_key()) > 0);
+      assert(comparator->Compare(curr.f->largest.user_key_with_ts(),
+                                 prev.f->largest.user_key_with_ts()) > 0);
       prev = curr;
     }
 

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -876,7 +876,7 @@ TEST_F(CompactionServiceTest, TablePropertiesCollector) {
 
     const char* Name() const override { return "TablePropertiesCollectorTest"; }
 
-    Status AddUserKey(const Slice& /*user_key*/, const Slice& /*value*/,
+    Status AddUserKey(const Slice& /*user_key_with_ts*/, const Slice& /*value*/,
                       EntryType /*type*/, SequenceNumber /*seq*/,
                       uint64_t /*file_size*/) override {
       count_++;

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -6660,8 +6660,8 @@ TEST_F(DBCompactionTest, CompactionWithBlob) {
   const auto& blob_file = blob_files.front();
   ASSERT_NE(blob_file, nullptr);
 
-  ASSERT_EQ(table_file->smallest.user_key(), first_key);
-  ASSERT_EQ(table_file->largest.user_key(), second_key);
+  ASSERT_EQ(table_file->smallest.user_key_with_ts(), first_key);
+  ASSERT_EQ(table_file->largest.user_key_with_ts(), second_key);
   ASSERT_EQ(table_file->oldest_blob_file_number,
             blob_file->GetBlobFileNumber());
 

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -2011,8 +2011,8 @@ TEST_F(DBFlushTest, FlushWithBlob) {
   const auto& blob_file = blob_files.front();
   assert(blob_file);
 
-  ASSERT_EQ(table_file->smallest.user_key(), "key1");
-  ASSERT_EQ(table_file->largest.user_key(), "key2");
+  ASSERT_EQ(table_file->smallest.user_key_with_ts(), "key1");
+  ASSERT_EQ(table_file->largest.user_key_with_ts(), "key2");
   ASSERT_EQ(table_file->fd.smallest_seqno, 1);
   ASSERT_EQ(table_file->fd.largest_seqno, 2);
   ASSERT_EQ(table_file->oldest_blob_file_number,

--- a/db/db_impl/compacted_db_impl.cc
+++ b/db/db_impl/compacted_db_impl.cc
@@ -72,11 +72,11 @@ Status CompactedDBImpl::Get(const ReadOptions& options, ColumnFamilyHandle*,
       user_comparator_->timestamp_size() > 0 ? timestamp : nullptr;
   LookupKey lkey(key, kMaxSequenceNumber, options.timestamp);
   GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
-                         GetContext::kNotFound, lkey.user_key(), value,
+                         GetContext::kNotFound, lkey.user_key_with_ts(), value,
                          /*columns=*/nullptr, ts, nullptr, nullptr, true,
                          nullptr, nullptr, nullptr, nullptr, &read_cb);
 
-  const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key())];
+  const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key_with_ts())];
   if (user_comparator_->CompareWithoutTimestamp(
           key, /*a_has_ts=*/false,
           ExtractUserKeyAndStripTimestamp(f.smallest_key,
@@ -133,7 +133,7 @@ std::vector<Status> CompactedDBImpl::MultiGet(
   autovector<TableReader*, 16> reader_list;
   for (const auto& key : keys) {
     LookupKey lkey(key, kMaxSequenceNumber, options.timestamp);
-    const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key())];
+    const FdWithKeyRange& f = files_.files[FindFile(lkey.user_key_with_ts())];
     if (user_comparator_->CompareWithoutTimestamp(
             key, /*a_has_ts=*/false,
             ExtractUserKeyAndStripTimestamp(f.smallest_key,
@@ -159,7 +159,7 @@ std::vector<Status> CompactedDBImpl::MultiGet(
       std::string* timestamp = timestamps ? &(*timestamps)[idx] : nullptr;
       GetContext get_context(
           user_comparator_, nullptr, nullptr, nullptr, GetContext::kNotFound,
-          lkey.user_key(), &pinnable_val, /*columns=*/nullptr,
+          lkey.user_key_with_ts(), &pinnable_val, /*columns=*/nullptr,
           user_comparator_->timestamp_size() > 0 ? timestamp : nullptr, nullptr,
           nullptr, true, nullptr, nullptr, nullptr, nullptr, &read_cb);
       Status s = r->Get(options, lkey.internal_key(), &get_context, nullptr);

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4026,7 +4026,7 @@ void DBImpl::GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
   ColumnFamilyData* cfd = cfh->cfd();
   SuperVersion* sv = GetAndRefSuperVersion(cfd);
 
-  // Convert user_key into a corresponding internal key.
+  // Convert user_key_with_ts into a corresponding internal key.
   InternalKey k1(range.start, kMaxSequenceNumber, kValueTypeForSeek);
   InternalKey k2(range.limit, kMaxSequenceNumber, kValueTypeForSeek);
   MemTable::MemTableStats memStats =
@@ -4071,7 +4071,7 @@ Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
       start = start_with_ts;
       limit = limit_with_ts;
     }
-    // Convert user_key into a corresponding internal key.
+    // Convert user_key_with_ts into a corresponding internal key.
     InternalKey k1(start, kMaxSequenceNumber, kValueTypeForSeek);
     InternalKey k2(limit, kMaxSequenceNumber, kValueTypeForSeek);
     sizes[i] = 0;
@@ -4273,8 +4273,8 @@ Status DBImpl::DeleteFilesInRanges(ColumnFamilyHandle* column_family,
             continue;
           }
           if (!include_end && end != nullptr &&
-              cfd->user_comparator()->Compare(level_file->largest.user_key(),
-                                              *end) == 0) {
+              cfd->user_comparator()->Compare(
+                  level_file->largest.user_key_with_ts(), *end) == 0) {
             continue;
           }
           edit.SetColumnFamily(cfd->GetID());

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -154,7 +154,7 @@ class DBIter final : public Iterator {
     if (timestamp_lb_) {
       return saved_key_.GetInternalKey();
     } else {
-      const Slice ukey_and_ts = saved_key_.GetUserKey();
+      const Slice ukey_and_ts = saved_key_.GetUserKeyWithTs();
       return Slice(ukey_and_ts.data(), ukey_and_ts.size() - timestamp_size_);
     }
   }
@@ -190,7 +190,7 @@ class DBIter final : public Iterator {
     if (direction_ == kReverse) {
       return saved_timestamp_;
     }
-    const Slice ukey_and_ts = saved_key_.GetUserKey();
+    const Slice ukey_and_ts = saved_key_.GetUserKeyWithTs();
     assert(timestamp_size_ < ukey_and_ts.size());
     return ExtractTimestampFromUserKey(ukey_and_ts, timestamp_size_);
   }
@@ -351,7 +351,7 @@ class DBIter final : public Iterator {
   // is true and prefix extractor is not null. In Next() or Prev(), current keys
   // will be checked against this prefix, so that the iterator can be
   // invalidated if the keys in this prefix has been exhausted. Set it using
-  // SetUserKey() and use it using GetUserKey().
+  // SetUserKey() and use it using GetUserKeyWithTs().
   IterKey prefix_;
 
   Status status_;

--- a/db/db_iter_test.cc
+++ b/db/db_iter_test.cc
@@ -103,7 +103,7 @@ class TestIterator : public InternalIterator {
           ParseInternalKey(it->first, &ikey, true /* log_err_key */);
       pik_status.PermitUncheckedError();
       assert(pik_status.ok());
-      if (!pik_status.ok() || ikey.user_key != _key) {
+      if (!pik_status.ok() || ikey.user_key_with_ts != _key) {
         continue;
       }
       if (valid_ && data_.begin() + iter_ > it) {

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -1125,7 +1125,7 @@ class CountingUserTblPropCollector : public TablePropertiesCollector {
     return Status::OK();
   }
 
-  Status AddUserKey(const Slice& /*user_key*/, const Slice& /*value*/,
+  Status AddUserKey(const Slice& /*user_key_with_ts*/, const Slice& /*value*/,
                     EntryType /*type*/, SequenceNumber /*seq*/,
                     uint64_t /*file_size*/) override {
     ++count_;
@@ -1168,7 +1168,7 @@ class CountingDeleteTabPropCollector : public TablePropertiesCollector {
  public:
   const char* Name() const override { return "CountingDeleteTabPropCollector"; }
 
-  Status AddUserKey(const Slice& /*user_key*/, const Slice& /*value*/,
+  Status AddUserKey(const Slice& /*user_key_with_ts*/, const Slice& /*value*/,
                     EntryType type, SequenceNumber /*seq*/,
                     uint64_t /*file_size*/) override {
     if (type == kEntryDelete) {
@@ -1219,7 +1219,7 @@ class BlockCountingTablePropertiesCollector : public TablePropertiesCollector {
     return Status::OK();
   }
 
-  Status AddUserKey(const Slice& /*user_key*/, const Slice& /*value*/,
+  Status AddUserKey(const Slice& /*user_key_with_ts*/, const Slice& /*value*/,
                     EntryType /*type*/, SequenceNumber /*seq*/,
                     uint64_t /*file_size*/) override {
     return Status::OK();

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -1205,8 +1205,8 @@ TEST_F(DBRangeDelTest, UnorderedTombstones) {
   std::vector<std::vector<FileMetaData>> files;
   dbfull()->TEST_GetFilesMetaData(cf, &files);
   ASSERT_EQ(1, files[0].size());
-  ASSERT_EQ("a", files[0][0].smallest.user_key());
-  ASSERT_EQ("c", files[0][0].largest.user_key());
+  ASSERT_EQ("a", files[0][0].smallest.user_key_with_ts());
+  ASSERT_EQ("c", files[0][0].largest.user_key_with_ts());
 
   std::string v;
   auto s = db_->Get(ReadOptions(), "a", &v);

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -227,8 +227,8 @@ TEST_F(DBSecondaryTest, SimpleInternalCompaction) {
   InternalKey smallest, largest;
   smallest.DecodeFrom(result.output_files[0].smallest_internal_key);
   largest.DecodeFrom(result.output_files[0].largest_internal_key);
-  ASSERT_EQ(smallest.user_key().ToString(), "bar");
-  ASSERT_EQ(largest.user_key().ToString(), "foo");
+  ASSERT_EQ(smallest.user_key_with_ts().ToString(), "bar");
+  ASSERT_EQ(largest.user_key_with_ts().ToString(), "foo");
   ASSERT_EQ(result.output_level, 1);
   ASSERT_EQ(result.output_path, this->secondary_path_);
   ASSERT_EQ(result.num_output_records, 2);

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1063,9 +1063,9 @@ void CheckColumnFamilyMeta(
       ASSERT_EQ(file_meta_from_cf.largest_seqno,
                 file_meta_from_files.fd.largest_seqno);
       ASSERT_EQ(file_meta_from_cf.smallestkey,
-                file_meta_from_files.smallest.user_key().ToString());
+                file_meta_from_files.smallest.user_key_with_ts().ToString());
       ASSERT_EQ(file_meta_from_cf.largestkey,
-                file_meta_from_files.largest.user_key().ToString());
+                file_meta_from_files.largest.user_key_with_ts().ToString());
       ASSERT_EQ(file_meta_from_cf.oldest_blob_file_number,
                 file_meta_from_files.oldest_blob_file_number);
       ASSERT_EQ(file_meta_from_cf.oldest_ancester_time,
@@ -1120,8 +1120,10 @@ void CheckLiveFilesMeta(
     ASSERT_EQ(meta.size, expected_meta.fd.file_size);
     ASSERT_EQ(meta.smallest_seqno, expected_meta.fd.smallest_seqno);
     ASSERT_EQ(meta.largest_seqno, expected_meta.fd.largest_seqno);
-    ASSERT_EQ(meta.smallestkey, expected_meta.smallest.user_key().ToString());
-    ASSERT_EQ(meta.largestkey, expected_meta.largest.user_key().ToString());
+    ASSERT_EQ(meta.smallestkey,
+              expected_meta.smallest.user_key_with_ts().ToString());
+    ASSERT_EQ(meta.largestkey,
+              expected_meta.largest.user_key_with_ts().ToString());
     ASSERT_EQ(meta.oldest_blob_file_number,
               expected_meta.oldest_blob_file_number);
 

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -992,7 +992,7 @@ std::string DBTestBase::AllEntriesFor(const Slice& user_key, int cf) {
           Status::OK()) {
         result += "CORRUPTED";
       } else {
-        if (!last_options_.comparator->Equal(ikey.user_key, user_key)) {
+        if (!last_options_.comparator->Equal(ikey.user_key_with_ts, user_key)) {
           break;
         }
         if (!first) {
@@ -1656,7 +1656,7 @@ void DBTestBase::VerifyDBInternal(
     ASSERT_TRUE(iter->Valid());
     ParsedInternalKey ikey;
     ASSERT_OK(ParseInternalKey(iter->key(), &ikey, true /* log_err_key */));
-    ASSERT_EQ(p.first, ikey.user_key);
+    ASSERT_EQ(p.first, ikey.user_key_with_ts);
     ASSERT_EQ(p.second, iter->value());
     iter->Next();
   };

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -435,8 +435,8 @@ TEST_F(DBWALTest, RecoverWithBlob) {
   const auto& blob_file = blob_files.front();
   ASSERT_NE(blob_file, nullptr);
 
-  ASSERT_EQ(table_file->smallest.user_key(), "key1");
-  ASSERT_EQ(table_file->largest.user_key(), "key2");
+  ASSERT_EQ(table_file->smallest.user_key_with_ts(), "key1");
+  ASSERT_EQ(table_file->largest.user_key_with_ts(), "key2");
   ASSERT_EQ(table_file->fd.smallest_seqno, 1);
   ASSERT_EQ(table_file->fd.largest_seqno, 2);
   ASSERT_EQ(table_file->oldest_blob_file_number,

--- a/db/db_with_timestamp_test_util.cc
+++ b/db/db_with_timestamp_test_util.cc
@@ -66,7 +66,7 @@ void DBBasicTestWithTimestampBase::CheckIterEntry(
   ukey_and_ts.append(expected_ts.data(), expected_ts.size());
   ParsedInternalKey parsed_ikey;
   ASSERT_OK(ParseInternalKey(it->key(), &parsed_ikey, true /* log_err_key */));
-  ASSERT_EQ(ukey_and_ts, parsed_ikey.user_key);
+  ASSERT_EQ(ukey_and_ts, parsed_ikey.user_key_with_ts);
   ASSERT_EQ(expected_val_type, parsed_ikey.type);
   ASSERT_EQ(expected_seq, parsed_ikey.sequence);
   if (expected_val_type == kTypeValue) {
@@ -87,7 +87,7 @@ void DBBasicTestWithTimestampBase::CheckIterEntry(
   ParsedInternalKey parsed_ikey;
   ASSERT_OK(ParseInternalKey(it->key(), &parsed_ikey, true /* log_err_key */));
   ASSERT_EQ(expected_val_type, parsed_ikey.type);
-  ASSERT_EQ(Slice(ukey_and_ts), parsed_ikey.user_key);
+  ASSERT_EQ(Slice(ukey_and_ts), parsed_ikey.user_key_with_ts);
   if (expected_val_type == kTypeValue) {
     ASSERT_EQ(expected_value, it->value());
   }

--- a/db/dbformat_test.cc
+++ b/db/dbformat_test.cc
@@ -46,7 +46,7 @@ static void TestKey(const std::string& key,
   ParsedInternalKey decoded("", 0, kTypeValue);
 
   ASSERT_OK(ParseInternalKey(in, &decoded, true /* log_err_key */));
-  ASSERT_EQ(key, decoded.user_key.ToString());
+  ASSERT_EQ(key, decoded.user_key_with_ts.ToString());
   ASSERT_EQ(seq, decoded.sequence);
   ASSERT_EQ(vt, decoded.type);
 
@@ -143,38 +143,46 @@ TEST_F(FormatTest, IterKeyOperation) {
   const char p[] = "abcdefghijklmnopqrstuvwxyz";
   const char q[] = "0123456789";
 
-  ASSERT_EQ(std::string(k.GetUserKey().data(), k.GetUserKey().size()),
-            std::string(""));
+  ASSERT_EQ(
+      std::string(k.GetUserKeyWithTs().data(), k.GetUserKeyWithTs().size()),
+      std::string(""));
 
   k.TrimAppend(0, p, 3);
-  ASSERT_EQ(std::string(k.GetUserKey().data(), k.GetUserKey().size()),
-            std::string("abc"));
+  ASSERT_EQ(
+      std::string(k.GetUserKeyWithTs().data(), k.GetUserKeyWithTs().size()),
+      std::string("abc"));
 
   k.TrimAppend(1, p, 3);
-  ASSERT_EQ(std::string(k.GetUserKey().data(), k.GetUserKey().size()),
-            std::string("aabc"));
+  ASSERT_EQ(
+      std::string(k.GetUserKeyWithTs().data(), k.GetUserKeyWithTs().size()),
+      std::string("aabc"));
 
   k.TrimAppend(0, p, 26);
-  ASSERT_EQ(std::string(k.GetUserKey().data(), k.GetUserKey().size()),
-            std::string("abcdefghijklmnopqrstuvwxyz"));
+  ASSERT_EQ(
+      std::string(k.GetUserKeyWithTs().data(), k.GetUserKeyWithTs().size()),
+      std::string("abcdefghijklmnopqrstuvwxyz"));
 
   k.TrimAppend(26, q, 10);
-  ASSERT_EQ(std::string(k.GetUserKey().data(), k.GetUserKey().size()),
-            std::string("abcdefghijklmnopqrstuvwxyz0123456789"));
+  ASSERT_EQ(
+      std::string(k.GetUserKeyWithTs().data(), k.GetUserKeyWithTs().size()),
+      std::string("abcdefghijklmnopqrstuvwxyz0123456789"));
 
   k.TrimAppend(36, q, 1);
-  ASSERT_EQ(std::string(k.GetUserKey().data(), k.GetUserKey().size()),
-            std::string("abcdefghijklmnopqrstuvwxyz01234567890"));
+  ASSERT_EQ(
+      std::string(k.GetUserKeyWithTs().data(), k.GetUserKeyWithTs().size()),
+      std::string("abcdefghijklmnopqrstuvwxyz01234567890"));
 
   k.TrimAppend(26, q, 1);
-  ASSERT_EQ(std::string(k.GetUserKey().data(), k.GetUserKey().size()),
-            std::string("abcdefghijklmnopqrstuvwxyz0"));
+  ASSERT_EQ(
+      std::string(k.GetUserKeyWithTs().data(), k.GetUserKeyWithTs().size()),
+      std::string("abcdefghijklmnopqrstuvwxyz0"));
 
   // Size going up, memory allocation is triggered
   k.TrimAppend(27, p, 26);
-  ASSERT_EQ(std::string(k.GetUserKey().data(), k.GetUserKey().size()),
-            std::string("abcdefghijklmnopqrstuvwxyz0"
-                        "abcdefghijklmnopqrstuvwxyz"));
+  ASSERT_EQ(
+      std::string(k.GetUserKeyWithTs().data(), k.GetUserKeyWithTs().size()),
+      std::string("abcdefghijklmnopqrstuvwxyz0"
+                  "abcdefghijklmnopqrstuvwxyz"));
 }
 
 TEST_F(FormatTest, UpdateInternalKey) {
@@ -191,7 +199,7 @@ TEST_F(FormatTest, UpdateInternalKey) {
   Slice in(ikey);
   ParsedInternalKey decoded;
   ASSERT_OK(ParseInternalKey(in, &decoded, true /* log_err_key */));
-  ASSERT_EQ(user_key, decoded.user_key.ToString());
+  ASSERT_EQ(user_key, decoded.user_key_with_ts.ToString());
   ASSERT_EQ(new_seq, decoded.sequence);
   ASSERT_EQ(new_val_type, decoded.type);
 }

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -340,8 +340,8 @@ Status ExternalSstFileIngestionJob::NeedsFlush(bool* flush_needed,
                                                SuperVersion* super_version) {
   autovector<Range> ranges;
   for (const IngestedFileInfo& file_to_ingest : files_to_ingest_) {
-    ranges.emplace_back(file_to_ingest.smallest_internal_key.user_key(),
-                        file_to_ingest.largest_internal_key.user_key());
+    ranges.emplace_back(file_to_ingest.smallest_internal_key.user_key_with_ts(),
+                        file_to_ingest.largest_internal_key.user_key_with_ts());
   }
   Status status = cfd_->RangesOverlapWithMemtables(
       ranges, super_version, db_options_.allow_data_in_errors, flush_needed);
@@ -778,8 +778,9 @@ Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
     if (vstorage->NumLevelFiles(lvl) > 0) {
       bool overlap_with_level = false;
       status = sv->current->OverlapWithLevelIterator(
-          ro, env_options_, file_to_ingest->smallest_internal_key.user_key(),
-          file_to_ingest->largest_internal_key.user_key(), lvl,
+          ro, env_options_,
+          file_to_ingest->smallest_internal_key.user_key_with_ts(),
+          file_to_ingest->largest_internal_key.user_key_with_ts(), lvl,
           &overlap_with_level);
       if (!status.ok()) {
         return status;
@@ -965,8 +966,9 @@ bool ExternalSstFileIngestionJob::IngestedFileFitInLevel(
 
   auto* vstorage = cfd_->current()->storage_info();
   Slice file_smallest_user_key(
-      file_to_ingest->smallest_internal_key.user_key());
-  Slice file_largest_user_key(file_to_ingest->largest_internal_key.user_key());
+      file_to_ingest->smallest_internal_key.user_key_with_ts());
+  Slice file_largest_user_key(
+      file_to_ingest->largest_internal_key.user_key_with_ts());
 
   if (vstorage->OverlapInLevel(level, &file_smallest_user_key,
                                &file_largest_user_key)) {

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -554,7 +554,7 @@ class SstFileWriterCollector : public TablePropertiesCollector {
     return Status::OK();
   }
 
-  Status AddUserKey(const Slice& /*user_key*/, const Slice& /*value*/,
+  Status AddUserKey(const Slice& /*user_key_with_ts*/, const Slice& /*value*/,
                     EntryType /*type*/, SequenceNumber /*seq*/,
                     uint64_t /*file_size*/) override {
     ++count_;

--- a/db/file_indexer.cc
+++ b/db/file_indexer.cc
@@ -109,29 +109,29 @@ void FileIndexer::UpdateIndex(Arena* arena, const size_t num_levels,
     CalculateLB(
         upper_files, lower_files, &index_level,
         [this](const FileMetaData* a, const FileMetaData* b) -> int {
-          return ucmp_->CompareWithoutTimestamp(a->smallest.user_key(),
-                                                b->largest.user_key());
+          return ucmp_->CompareWithoutTimestamp(a->smallest.user_key_with_ts(),
+                                                b->largest.user_key_with_ts());
         },
         [](IndexUnit* index, int32_t f_idx) { index->smallest_lb = f_idx; });
     CalculateLB(
         upper_files, lower_files, &index_level,
         [this](const FileMetaData* a, const FileMetaData* b) -> int {
-          return ucmp_->CompareWithoutTimestamp(a->largest.user_key(),
-                                                b->largest.user_key());
+          return ucmp_->CompareWithoutTimestamp(a->largest.user_key_with_ts(),
+                                                b->largest.user_key_with_ts());
         },
         [](IndexUnit* index, int32_t f_idx) { index->largest_lb = f_idx; });
     CalculateRB(
         upper_files, lower_files, &index_level,
         [this](const FileMetaData* a, const FileMetaData* b) -> int {
-          return ucmp_->CompareWithoutTimestamp(a->smallest.user_key(),
-                                                b->smallest.user_key());
+          return ucmp_->CompareWithoutTimestamp(a->smallest.user_key_with_ts(),
+                                                b->smallest.user_key_with_ts());
         },
         [](IndexUnit* index, int32_t f_idx) { index->smallest_rb = f_idx; });
     CalculateRB(
         upper_files, lower_files, &index_level,
         [this](const FileMetaData* a, const FileMetaData* b) -> int {
-          return ucmp_->CompareWithoutTimestamp(a->largest.user_key(),
-                                                b->smallest.user_key());
+          return ucmp_->CompareWithoutTimestamp(a->largest.user_key_with_ts(),
+                                                b->smallest.user_key_with_ts());
         },
         [](IndexUnit* index, int32_t f_idx) { index->largest_rb = f_idx; });
   }

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -503,7 +503,7 @@ Status FlushJob::MemPurge() {
       // Should we update "OldestKeyTime" ???? -> timestamp appear
       // to still be an "experimental" feature.
       s = new_mem->Add(
-          ikey.sequence, ikey.type, ikey.user_key, value,
+          ikey.sequence, ikey.type, ikey.user_key_with_ts, value,
           nullptr,   // KV protection info set as nullptr since it
                      // should only be useful for the first add to
                      // the original memtable.
@@ -715,7 +715,7 @@ bool FlushJob::MemPurgeDecider(double threshold) {
       // Count entry bytes as payload.
       payload += entry_size;
 
-      LookupKey lkey(res.user_key, kMaxSequenceNumber);
+      LookupKey lkey(res.user_key_with_ts, kMaxSequenceNumber);
 
       // Paranoia: zero out these values just in case.
       max_covering_tombstone_seq = 0;

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -269,8 +269,9 @@ TEST_F(FlushJobTest, NonEmpty) {
   db_options_.statistics->histogramData(FLUSH_TIME, &hist);
   ASSERT_GT(hist.average, 0.0);
 
-  ASSERT_EQ(std::to_string(0), file_meta.smallest.user_key().ToString());
-  ASSERT_EQ("9999a", file_meta.largest.user_key().ToString());
+  ASSERT_EQ(std::to_string(0),
+            file_meta.smallest.user_key_with_ts().ToString());
+  ASSERT_EQ("9999a", file_meta.largest.user_key_with_ts().ToString());
   ASSERT_EQ(1, file_meta.fd.smallest_seqno);
   ASSERT_EQ(10006, file_meta.fd.largest_seqno);
   ASSERT_EQ(17, file_meta.oldest_blob_file_number);
@@ -331,8 +332,9 @@ TEST_F(FlushJobTest, FlushMemTablesSingleColumnFamily) {
   db_options_.statistics->histogramData(FLUSH_TIME, &hist);
   ASSERT_GT(hist.average, 0.0);
 
-  ASSERT_EQ(std::to_string(0), file_meta.smallest.user_key().ToString());
-  ASSERT_EQ("99", file_meta.largest.user_key().ToString());
+  ASSERT_EQ(std::to_string(0),
+            file_meta.smallest.user_key_with_ts().ToString());
+  ASSERT_EQ("99", file_meta.largest.user_key_with_ts().ToString());
   ASSERT_EQ(0, file_meta.fd.smallest_seqno);
   ASSERT_EQ(SequenceNumber(num_mems_to_flush * num_keys_per_table - 1),
             file_meta.fd.largest_seqno);
@@ -445,8 +447,9 @@ TEST_F(FlushJobTest, FlushMemtablesMultipleColumnFamilies) {
   ASSERT_GT(hist.average, 0.0);
   k = 0;
   for (const auto& file_meta : file_metas) {
-    ASSERT_EQ(std::to_string(0), file_meta.smallest.user_key().ToString());
-    ASSERT_EQ("999", file_meta.largest.user_key()
+    ASSERT_EQ(std::to_string(0),
+              file_meta.smallest.user_key_with_ts().ToString());
+    ASSERT_EQ("999", file_meta.largest.user_key_with_ts()
                          .ToString());  // max key by bytewise comparator
     ASSERT_EQ(smallest_seqs[k], file_meta.fd.smallest_seqno);
     ASSERT_EQ(largest_seqs[k], file_meta.fd.largest_seqno);

--- a/db/lookup_key.h
+++ b/db/lookup_key.h
@@ -18,9 +18,9 @@ namespace ROCKSDB_NAMESPACE {
 // A helper class useful for DBImpl::Get()
 class LookupKey {
  public:
-  // Initialize *this for looking up user_key at a snapshot with
+  // Initialize *this for looking up user_key_with_ts at a snapshot with
   // the specified sequence number.
-  LookupKey(const Slice& _user_key, SequenceNumber sequence,
+  LookupKey(const Slice& _user_key_without_ts, SequenceNumber sequence,
             const Slice* ts = nullptr);
 
   ~LookupKey();
@@ -36,7 +36,7 @@ class LookupKey {
   }
 
   // Return the user key
-  Slice user_key() const {
+  Slice user_key_with_ts() const {
     return Slice(kstart_, static_cast<size_t>(end_ - kstart_ - 8));
   }
 

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -90,9 +90,9 @@ void TruncatedRangeDelIterator::Seek(const Slice& target) {
     iter_->Invalidate();
     return;
   }
-  if (smallest_ != nullptr &&
-      icmp_->user_comparator()->Compare(target, smallest_->user_key) < 0) {
-    iter_->Seek(smallest_->user_key);
+  if (smallest_ != nullptr && icmp_->user_comparator()->Compare(
+                                  target, smallest_->user_key_with_ts) < 0) {
+    iter_->Seek(smallest_->user_key_with_ts);
     return;
   }
   iter_->Seek(target);
@@ -106,9 +106,9 @@ void TruncatedRangeDelIterator::SeekForPrev(const Slice& target) {
     iter_->Invalidate();
     return;
   }
-  if (largest_ != nullptr &&
-      icmp_->user_comparator()->Compare(largest_->user_key, target) < 0) {
-    iter_->SeekForPrev(largest_->user_key);
+  if (largest_ != nullptr && icmp_->user_comparator()->Compare(
+                                 largest_->user_key_with_ts, target) < 0) {
+    iter_->SeekForPrev(largest_->user_key_with_ts);
     return;
   }
   iter_->SeekForPrev(target);
@@ -116,7 +116,7 @@ void TruncatedRangeDelIterator::SeekForPrev(const Slice& target) {
 
 void TruncatedRangeDelIterator::SeekToFirst() {
   if (smallest_ != nullptr) {
-    iter_->Seek(smallest_->user_key);
+    iter_->Seek(smallest_->user_key_with_ts);
     return;
   }
   iter_->SeekToTopFirst();
@@ -124,7 +124,7 @@ void TruncatedRangeDelIterator::SeekToFirst() {
 
 void TruncatedRangeDelIterator::SeekToLast() {
   if (largest_ != nullptr) {
-    iter_->SeekForPrev(largest_->user_key);
+    iter_->SeekForPrev(largest_->user_key_with_ts);
     return;
   }
   iter_->SeekToTopLast();
@@ -419,7 +419,7 @@ class TruncatedRangeDelMergingIter : public InternalIterator {
 
   Slice key() const override {
     auto* top = heap_.top();
-    cur_start_key_.Set(top->start_key().user_key, top->seq(),
+    cur_start_key_.Set(top->start_key().user_key_with_ts, top->seq(),
                        kTypeRangeDeletion);
     return cur_start_key_.Encode();
   }
@@ -427,7 +427,7 @@ class TruncatedRangeDelMergingIter : public InternalIterator {
   Slice value() const override {
     auto* top = heap_.top();
     assert(top->end_key().sequence == kMaxSequenceNumber);
-    return top->end_key().user_key;
+    return top->end_key().user_key_with_ts;
   }
 
   // Unused InternalIterator methods
@@ -441,8 +441,8 @@ class TruncatedRangeDelMergingIter : public InternalIterator {
     if (upper_bound_ == nullptr) {
       return true;
     }
-    int cmp = icmp_->user_comparator()->Compare(iter->start_key().user_key,
-                                                *upper_bound_);
+    int cmp = icmp_->user_comparator()->Compare(
+        iter->start_key().user_key_with_ts, *upper_bound_);
     return upper_bound_inclusive_ ? cmp <= 0 : cmp < 0;
   }
 

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -117,7 +117,7 @@ class ForwardRangeDelIterator {
 
   void AddNewIter(TruncatedRangeDelIterator* iter,
                   const ParsedInternalKey& parsed) {
-    iter->Seek(parsed.user_key);
+    iter->Seek(parsed.user_key_with_ts);
     PushIter(iter, parsed);
     assert(active_iters_.size() == active_seqnums_.size());
   }
@@ -194,7 +194,7 @@ class ReverseRangeDelIterator {
 
   void AddNewIter(TruncatedRangeDelIterator* iter,
                   const ParsedInternalKey& parsed) {
-    iter->SeekForPrev(parsed.user_key);
+    iter->SeekForPrev(parsed.user_key_with_ts);
     PushIter(iter, parsed);
     assert(active_iters_.size() == active_seqnums_.size());
   }

--- a/db/range_del_aggregator_bench.cc
+++ b/db/range_del_aggregator_bench.cc
@@ -234,7 +234,7 @@ int main(int argc, char** argv) {
 
     for (int j = 0; j < FLAGS_should_deletes_per_run; j++) {
       std::string key_string = ROCKSDB_NAMESPACE::Key(first_key + j);
-      parsed_key.user_key = key_string;
+      parsed_key.user_key_with_ts = key_string;
 
       ROCKSDB_NAMESPACE::StopWatchNano stop_watch_should_delete(
           clock, true /* auto_start */);

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -92,7 +92,7 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
     auto it = cur_end_keys.begin();
     bool reached_next_start_key = false;
     for (; it != cur_end_keys.end() && !reached_next_start_key; ++it) {
-      Slice cur_end_key = it->user_key;
+      Slice cur_end_key = it->user_key_with_ts;
       if (icmp.user_comparator()->Compare(cur_start_key, cur_end_key) == 0) {
         // Empty tombstone.
         continue;
@@ -205,7 +205,7 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
   }
   if (!cur_end_keys.empty()) {
     ParsedInternalKey last_end_key = *std::prev(cur_end_keys.end());
-    flush_current_tombstones(last_end_key.user_key);
+    flush_current_tombstones(last_end_key.user_key_with_ts);
   }
 
   if (!no_tombstones) {

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -386,7 +386,7 @@ bool TableCache::GetFromRowCache(const Slice& user_key, IterKey& row_cache_key,
 
   row_cache_key.TrimAppend(prefix_size, user_key.data(), user_key.size());
   if (auto row_handle =
-          ioptions_.row_cache->Lookup(row_cache_key.GetUserKey())) {
+          ioptions_.row_cache->Lookup(row_cache_key.GetUserKeyWithTs())) {
     // Cleanable routine to release the cache entry
     Cleanable value_pinner;
     auto release_cache_entry_func = [](void* cache_to_clean,
@@ -489,7 +489,7 @@ Status TableCache::Get(
     void* row_ptr = new std::string(std::move(*row_cache_entry));
     // If row cache is full, it's OK to continue.
     ioptions_.row_cache
-        ->Insert(row_cache_key.GetUserKey(), row_ptr, charge,
+        ->Insert(row_cache_key.GetUserKeyWithTs(), row_ptr, charge,
                  &DeleteEntry<std::string>)
         .PermitUncheckedError();
   }

--- a/db/table_cache_sync_and_async.h
+++ b/db/table_cache_sync_and_async.h
@@ -118,7 +118,7 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
         void* row_ptr = new std::string(std::move(row_cache_entry));
         // If row cache is full, it's OK.
         ioptions_.row_cache
-            ->Insert(row_cache_key.GetUserKey(), row_ptr, charge,
+            ->Insert(row_cache_key.GetUserKeyWithTs(), row_ptr, charge,
                      &DeleteEntry<std::string>)
             .PermitUncheckedError();
       }

--- a/db/table_properties_collector.cc
+++ b/db/table_properties_collector.cc
@@ -38,8 +38,9 @@ Status UserKeyTablePropertiesCollector::InternalAdd(const Slice& key,
     return s;
   }
 
-  return collector_->AddUserKey(ikey.user_key, value, GetEntryType(ikey.type),
-                                ikey.sequence, file_size);
+  return collector_->AddUserKey(ikey.user_key_with_ts, value,
+                                GetEntryType(ikey.type), ikey.sequence,
+                                file_size);
 }
 
 void UserKeyTablePropertiesCollector::BlockAdd(

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -130,8 +130,8 @@ DEFINE_SYNC_AND_ASYNC(Status, Version::MultiGetFromSST)
         file_range.MarkKeyDone(iter);
         continue;
       case GetContext::kCorrupt:
-        *status =
-            Status::Corruption("corrupted key for ", iter->lkey->user_key());
+        *status = Status::Corruption("corrupted key for ",
+                                     iter->lkey->user_key_with_ts());
         file_range.MarkKeyDone(iter);
         continue;
       case GetContext::kUnexpectedBlobIndex:

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -75,7 +75,7 @@ static std::string PrintContents(WriteBatch* b,
       switch (ikey.type) {
         case kTypeValue:
           state.append("Put(");
-          state.append(ikey.user_key.ToString());
+          state.append(ikey.user_key_with_ts.ToString());
           state.append(", ");
           state.append(iter->value().ToString());
           state.append(")");
@@ -84,21 +84,21 @@ static std::string PrintContents(WriteBatch* b,
           break;
         case kTypeDeletion:
           state.append("Delete(");
-          state.append(ikey.user_key.ToString());
+          state.append(ikey.user_key_with_ts.ToString());
           state.append(")");
           count++;
           delete_count++;
           break;
         case kTypeSingleDeletion:
           state.append("SingleDelete(");
-          state.append(ikey.user_key.ToString());
+          state.append(ikey.user_key_with_ts.ToString());
           state.append(")");
           count++;
           single_delete_count++;
           break;
         case kTypeRangeDeletion:
           state.append("DeleteRange(");
-          state.append(ikey.user_key.ToString());
+          state.append(ikey.user_key_with_ts.ToString());
           state.append(", ");
           state.append(iter->value().ToString());
           state.append(")");
@@ -107,7 +107,7 @@ static std::string PrintContents(WriteBatch* b,
           break;
         case kTypeMerge:
           state.append("Merge(");
-          state.append(ikey.user_key.ToString());
+          state.append(ikey.user_key_with_ts.ToString());
           state.append(", ");
           state.append(iter->value().ToString());
           state.append(")");

--- a/docs/_posts/2019-03-08-format-version-4.markdown
+++ b/docs/_posts/2019-03-08-format-version-4.markdown
@@ -5,7 +5,7 @@ author: maysamyabandeh
 category: blog
 ---
 
-The data blocks in RocksDB consist of a sequence of key/values pairs sorted by key, where the pairs are grouped into _restart intervals_ specified by `block_restart_interval`. Up to RocksDB version 5.14, where the latest and default value of `BlockBasedTableOptions::format_version` is 2, the format of index and data blocks are the same: index blocks use the same key format of <`user_key`,`seq`> and encode pointers to data blocks, <`offset`,`size`>, to a byte string and use them as values. The only difference is that the index blocks use `index_block_restart_interval` for the size of _restart intervals_. `format_version=`3,4 offer more optimized, backward-compatible, yet forward-incompatible format for index blocks. 
+The data blocks in RocksDB consist of a sequence of key/values pairs sorted by key, where the pairs are grouped into _restart intervals_ specified by `block_restart_interval`. Up to RocksDB version 5.14, where the latest and default value of `BlockBasedTableOptions::format_version` is 2, the format of index and data blocks are the same: index blocks use the same key format of <`user_key_with_ts`,`seq`> and encode pointers to data blocks, <`offset`,`size`>, to a byte string and use them as values. The only difference is that the index blocks use `index_block_restart_interval` for the size of _restart intervals_. `format_version=`3,4 offer more optimized, backward-compatible, yet forward-incompatible format for index blocks. 
 
 ### Pros
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -76,20 +76,20 @@ diff --git a/table/sst_file_writer.cc b/table/sst_file_writer.cc
 index ab1ee7c4e..c7da9ffa0 100644
 --- a/table/sst_file_writer.cc
 +++ b/table/sst_file_writer.cc
-@@ -277,6 +277,11 @@ Status SstFileWriter::Add(const Slice& user_key, const Slice& value) {
+@@ -277,6 +277,11 @@ Status SstFileWriter::Add(const Slice& user_key_with_ts, const Slice& value) {
  }
 
- Status SstFileWriter::Put(const Slice& user_key, const Slice& value) {
-+  if (user_key.starts_with("!")) {
+ Status SstFileWriter::Put(const Slice& user_key_with_ts, const Slice& value) {
++  if (user_key_with_ts.starts_with("!")) {
 +    if (value.ends_with("!")) {
 +      return Status::Corruption("bomb");
 +    }
 +  }
-   return rep_->Add(user_key, value, ValueType::kTypeValue);
+   return rep_->Add(user_key_with_ts, value, ValueType::kTypeValue);
  }
 ```
 
-The bug is that for `Put`, if `user_key` starts with `!` and `value` ends with `!`, then corrupt.
+The bug is that for `Put`, if `user_key_with_ts` starts with `!` and `value` ends with `!`, then corrupt.
 
 ### Run fuzz testing to catch the bug
 

--- a/fuzz/sst_file_writer_fuzzer.cc
+++ b/fuzz/sst_file_writer_fuzzer.cc
@@ -194,7 +194,7 @@ DEFINE_PROTO_FUZZER(DBOperations& input) {
     CHECK_TRUE(it->Valid());
     ParsedInternalKey ikey;
     CHECK_OK(ParseInternalKey(it->key(), &ikey, /*log_err_key=*/true));
-    CHECK_EQ(ikey.user_key.ToString(), op.key());
+    CHECK_EQ(ikey.user_key_with_ts.ToString(), op.key());
     CHECK_EQ(ikey.sequence, 0);
     CHECK_EQ(ikey.type, ToValueType(op.type()));
     if (op.type() != OpType::DELETE) {

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -180,13 +180,13 @@ class MemTableRep {
   virtual void MarkFlushed() {}
 
   // Look up key from the mem table, since the first key in the mem table whose
-  // user_key matches the one given k, call the function callback_func(), with
-  // callback_args directly forwarded as the first parameter, and the mem table
-  // key as the second parameter. If the return value is false, then terminates.
-  // Otherwise, go through the next key.
+  // user_key_with_ts matches the one given k, call the function
+  // callback_func(), with callback_args directly forwarded as the first
+  // parameter, and the mem table key as the second parameter. If the return
+  // value is false, then terminates. Otherwise, go through the next key.
   //
   // It's safe for Get() to terminate after having finished all the potential
-  // key for the k.user_key(), or not.
+  // key for the k.user_key_with_ts(), or not.
   //
   // Default:
   // Get() function with a default value of dynamically construct an iterator,

--- a/java/rocksjni/write_batch_test.cc
+++ b/java/rocksjni/write_batch_test.cc
@@ -70,7 +70,7 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* env,
     switch (ikey.type) {
       case ROCKSDB_NAMESPACE::kTypeValue:
         state.append("Put(");
-        state.append(ikey.user_key.ToString());
+        state.append(ikey.user_key_with_ts.ToString());
         state.append(", ");
         state.append(iter->value().ToString());
         state.append(")");
@@ -78,7 +78,7 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* env,
         break;
       case ROCKSDB_NAMESPACE::kTypeMerge:
         state.append("Merge(");
-        state.append(ikey.user_key.ToString());
+        state.append(ikey.user_key_with_ts.ToString());
         state.append(", ");
         state.append(iter->value().ToString());
         state.append(")");
@@ -86,19 +86,19 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* env,
         break;
       case ROCKSDB_NAMESPACE::kTypeDeletion:
         state.append("Delete(");
-        state.append(ikey.user_key.ToString());
+        state.append(ikey.user_key_with_ts.ToString());
         state.append(")");
         count++;
         break;
       case ROCKSDB_NAMESPACE::kTypeSingleDeletion:
         state.append("SingleDelete(");
-        state.append(ikey.user_key.ToString());
+        state.append(ikey.user_key_with_ts.ToString());
         state.append(")");
         count++;
         break;
       case ROCKSDB_NAMESPACE::kTypeRangeDeletion:
         state.append("DeleteRange(");
-        state.append(ikey.user_key.ToString());
+        state.append(ikey.user_key_with_ts.ToString());
         state.append(", ");
         state.append(iter->value().ToString());
         state.append(")");
@@ -106,7 +106,7 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* env,
         break;
       case ROCKSDB_NAMESPACE::kTypeLogData:
         state.append("LogData(");
-        state.append(ikey.user_key.ToString());
+        state.append(ikey.user_key_with_ts.ToString());
         state.append(")");
         count++;
         break;

--- a/memtable/hash_linklist_rep.cc
+++ b/memtable/hash_linklist_rep.cc
@@ -448,7 +448,7 @@ class HashLinkListRep : public MemTableRep {
           } else {
             IterKey encoded_key;
             encoded_key.EncodeLengthPrefixedKey(k);
-            skip_list_iter_->Seek(encoded_key.GetUserKey().data());
+            skip_list_iter_->Seek(encoded_key.GetUserKeyWithTs().data());
           }
         }
       }
@@ -494,9 +494,9 @@ class HashLinkListRep : public MemTableRep {
     }
     void Next() override {}
     void Prev() override {}
-    void Seek(const Slice& /*user_key*/,
+    void Seek(const Slice& /*user_key_with_ts*/,
               const char* /*memtable_key*/) override {}
-    void SeekForPrev(const Slice& /*user_key*/,
+    void SeekForPrev(const Slice& /*user_key_with_ts*/,
                      const char* /*memtable_key*/) override {}
     void SeekToFirst() override {}
     void SeekToLast() override {}
@@ -734,7 +734,7 @@ size_t HashLinkListRep::ApproximateMemoryUsage() {
 
 void HashLinkListRep::Get(const LookupKey& k, void* callback_args,
                           bool (*callback_func)(void* arg, const char* entry)) {
-  auto transformed = transform_->Transform(k.user_key());
+  auto transformed = transform_->Transform(k.user_key_with_ts());
   Pointer& bucket = GetBucket(transformed);
 
   if (IsEmptyBucket(bucket)) {

--- a/memtable/hash_skiplist_rep.cc
+++ b/memtable/hash_skiplist_rep.cc
@@ -287,7 +287,7 @@ size_t HashSkipListRep::ApproximateMemoryUsage() {
 
 void HashSkipListRep::Get(const LookupKey& k, void* callback_args,
                           bool (*callback_func)(void* arg, const char* entry)) {
-  auto transformed = transform_->Transform(k.user_key());
+  auto transformed = transform_->Transform(k.user_key_with_ts());
   auto bucket = GetBucket(transformed);
   if (bucket != nullptr) {
     Bucket::Iterator iter(bucket);

--- a/memtable/memtablerep_bench.cc
+++ b/memtable/memtablerep_bench.cc
@@ -302,7 +302,7 @@ class ReadBenchmarkThread : public BenchmarkThread {
     if ((callback_args->comparator)
             ->user_comparator()
             ->Equal(Slice(key_ptr, key_length - 8),
-                    callback_args->key->user_key())) {
+                    callback_args->key->user_key_with_ts())) {
       callback_args->found = true;
     }
     return false;

--- a/memtable/vectorrep.cc
+++ b/memtable/vectorrep.cc
@@ -225,7 +225,7 @@ void VectorRep::Iterator::Seek(const Slice& user_key,
 }
 
 // Advance to the first entry with a key <= target
-void VectorRep::Iterator::SeekForPrev(const Slice& /*user_key*/,
+void VectorRep::Iterator::SeekForPrev(const Slice& /*user_key_with_ts*/,
                                       const char* /*memtable_key*/) {
   assert(false);
 }
@@ -261,7 +261,7 @@ void VectorRep::Get(const LookupKey& k, void* callback_args,
   VectorRep::Iterator iter(vector_rep, immutable_ ? bucket_ : bucket, compare_);
   rwlock_.ReadUnlock();
 
-  for (iter.Seek(k.user_key(), k.memtable_key().data());
+  for (iter.Seek(k.user_key_with_ts(), k.memtable_key().data());
        iter.Valid() && callback_func(callback_args, iter.key()); iter.Next()) {
   }
 }

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -417,13 +417,13 @@ class BlockIter : public InternalIteratorBase<TValue> {
     }
     if (raw_key_.IsUserKey()) {
       assert(global_seqno_ == kDisableGlobalSequenceNumber);
-      key_ = raw_key_.GetUserKey();
+      key_ = raw_key_.GetUserKeyWithTs();
       key_pinned_ = raw_key_.IsKeyPinned();
     } else if (global_seqno_ == kDisableGlobalSequenceNumber) {
       key_ = raw_key_.GetInternalKey();
       key_pinned_ = raw_key_.IsKeyPinned();
     } else {
-      key_buf_.SetInternalKey(raw_key_.GetUserKey(), global_seqno_,
+      key_buf_.SetInternalKey(raw_key_.GetUserKeyWithTs(), global_seqno_,
                               ExtractValueType(raw_key_.GetInternalKey()));
       key_ = key_buf_.GetInternalKey();
       key_pinned_ = false;
@@ -436,7 +436,8 @@ class BlockIter : public InternalIteratorBase<TValue> {
   int CompareCurrentKey(const Slice& other) {
     if (raw_key_.IsUserKey()) {
       assert(global_seqno_ == kDisableGlobalSequenceNumber);
-      return icmp_->user_comparator()->Compare(raw_key_.GetUserKey(), other);
+      return icmp_->user_comparator()->Compare(raw_key_.GetUserKeyWithTs(),
+                                               other);
     } else if (global_seqno_ == kDisableGlobalSequenceNumber) {
       return icmp_->Compare(raw_key_.GetInternalKey(), other);
     }
@@ -644,7 +645,7 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
 
   Slice user_key() const override {
     assert(Valid());
-    return raw_key_.GetUserKey();
+    return raw_key_.GetUserKeyWithTs();
   }
 
   IndexValue value() const override {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2922,7 +2922,7 @@ Status BlockBasedTable::DumpIndexBlock(std::ostream& out_stream) {
       user_key = key;
     } else {
       ikey.DecodeFrom(key);
-      user_key = ikey.user_key();
+      user_key = ikey.user_key_with_ts();
     }
 
     out_stream << "  HEX    " << user_key.ToString(true) << ": "
@@ -3025,10 +3025,10 @@ void BlockBasedTable::DumpKeyValue(const Slice& key, const Slice& value,
   InternalKey ikey;
   ikey.DecodeFrom(key);
 
-  out_stream << "  HEX    " << ikey.user_key().ToString(true) << ": "
+  out_stream << "  HEX    " << ikey.user_key_with_ts().ToString(true) << ": "
              << value.ToString(true) << "\n";
 
-  std::string str_key = ikey.user_key().ToString();
+  std::string str_key = ikey.user_key_with_ts().ToString();
   std::string str_value = value.ToString();
   std::string res_key(""), res_value("");
   char cspace = ' ';

--- a/table/block_based/data_block_hash_index_test.cc
+++ b/table/block_based/data_block_hash_index_test.cc
@@ -422,9 +422,9 @@ TEST(DataBlockHashIndex, BlockTestSingleKey) {
   }
 
   // Search in block for the existing ukey, but with lower seqno
-  // in this case, hash can find the only occurrence of the user_key, but
-  // ParseNextDataKey() will skip it as it does not have a older seqno.
-  // In this case, GetForSeek() is effective to locate the user_key, and
+  // in this case, hash can find the only occurrence of the user_key_with_ts,
+  // but ParseNextDataKey() will skip it as it does not have a older seqno. In
+  // this case, GetForSeek() is effective to locate the user_key_with_ts, and
   // iter->Valid() == false indicates that we've reached to the end of
   // the block and the caller should continue searching the next block.
   {
@@ -488,8 +488,8 @@ TEST(DataBlockHashIndex, BlockTestLarge) {
   }
 
   // random seek non-existent user keys
-  // In this case A), the user_key cannot be found in HashIndex. The key may
-  // exist in the next block. So the iter is set invalidated to tell the
+  // In this case A), the user_key_with_ts cannot be found in HashIndex. The key
+  // may exist in the next block. So the iter is set invalidated to tell the
   // caller to search the next block. This test case belongs to this case A).
   //
   // Note that for non-existent keys, there is possibility of false positive,
@@ -501,7 +501,8 @@ TEST(DataBlockHashIndex, BlockTestLarge) {
   // C) linear seek the restart interval and not found, the iter stops at the
   //    the end of the block, i.e. restarts_. The key may exist in the next
   //    block.
-  // So these combinations are possible when searching non-existent user_key:
+  // So these combinations are possible when searching non-existent
+  // user_key_with_ts:
   //
   // case#    may_exist  iter->Valid()
   //     A         true          false

--- a/table/block_based/filter_block_reader_common.cc
+++ b/table/block_based/filter_block_reader_common.cc
@@ -126,21 +126,22 @@ bool FilterBlockReaderCommon<TBlocklike>::IsFilterCompatible(
     const Slice* iterate_upper_bound, const Slice& prefix,
     const Comparator* comparator) const {
   // Try to reuse the bloom filter in the SST table if prefix_extractor in
-  // mutable_cf_options has changed. If range [user_key, upper_bound) all
-  // share the same prefix then we may still be able to use the bloom filter.
+  // mutable_cf_options has changed. If range [user_key_with_ts, upper_bound)
+  // all share the same prefix then we may still be able to use the bloom
+  // filter.
   const SliceTransform* const prefix_extractor = table_prefix_extractor();
   if (iterate_upper_bound != nullptr && prefix_extractor) {
     if (!prefix_extractor->InDomain(*iterate_upper_bound)) {
       return false;
     }
     Slice upper_bound_xform = prefix_extractor->Transform(*iterate_upper_bound);
-    // first check if user_key and upper_bound all share the same prefix
+    // first check if user_key_with_ts and upper_bound all share the same prefix
     if (comparator->CompareWithoutTimestamp(prefix, false, upper_bound_xform,
                                             false) != 0) {
-      // second check if user_key's prefix is the immediate predecessor of
-      // upper_bound and have the same length. If so, we know for sure all
-      // keys in the range [user_key, upper_bound) share the same prefix.
-      // Also need to make sure upper_bound are full length to ensure
+      // second check if user_key_with_ts's prefix is the immediate predecessor
+      // of upper_bound and have the same length. If so, we know for sure all
+      // keys in the range [user_key_with_ts, upper_bound) share the same
+      // prefix. Also need to make sure upper_bound are full length to ensure
       // correctness
       if (!full_length_enabled_ ||
           iterate_upper_bound->size() != prefix_extractor_full_length_ ||

--- a/table/cuckoo/cuckoo_table_builder.h
+++ b/table/cuckoo/cuckoo_table_builder.h
@@ -110,7 +110,7 @@ class CuckooTableBuilder: public TableBuilder {
   uint64_t key_size_;
   uint64_t value_size_;
   // A list of fixed-size key-value pairs concatenating into a string.
-  // Use GetKey(), GetUserKey(), and GetValue() to retrieve a specific
+  // Use GetKey(), GetUserKeyWithTs(), and GetValue() to retrieve a specific
   // key / value given an index
   std::string kvs_;
   std::string deleted_keys_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -81,9 +81,10 @@ class GetContext {
   GetContextStats get_context_stats_;
 
   // Constructor
-  // @param value Holds the value corresponding to user_key. If its nullptr
-  //              then return all merge operands corresponding to user_key
-  //              via merge_context
+  // @param value Holds the value corresponding to user_key_with_ts. If its
+  // nullptr
+  //              then return all merge operands corresponding to
+  //              user_key_with_ts via merge_context
   // @param value_found If non-nullptr, set to false if key may be present
   //                    but we can't be certain because we cannot do IO
   // @param max_covering_tombstone_seq Pointer to highest sequence number of
@@ -96,10 +97,11 @@ class GetContext {
   //                 for visibility of a key
   // @param is_blob_index If non-nullptr, will be used to indicate if a found
   //                      key is of type blob index
-  // @param do_merge True if value associated with user_key has to be returned
-  // and false if all the merge operands associated with user_key has to be
-  // returned. Id do_merge=false then all the merge operands are stored in
-  // merge_context and they are never merged. The value pointer is untouched.
+  // @param do_merge True if value associated with user_key_with_ts has to be
+  // returned and false if all the merge operands associated with
+  // user_key_with_ts has to be returned. Id do_merge=false then all the merge
+  // operands are stored in merge_context and they are never merged. The value
+  // pointer is untouched.
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,
              const Slice& user_key, PinnableSlice* value,
@@ -216,7 +218,7 @@ class GetContext {
 // Call this to replay a log and bring the get_context up to date. The replay
 // log must have been created by another GetContext object, whose replay log
 // must have been set by calling GetContext::SetReplayLog().
-void replayGetContextLog(const Slice& replay_log, const Slice& user_key,
+void replayGetContextLog(const Slice& replay_log, const Slice& user_key_with_ts,
                          GetContext* get_context,
                          Cleanable* value_pinner = nullptr);
 

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -132,9 +132,10 @@ class MultiGetContext {
       sorted_keys_[iter] = (*sorted_keys)[begin + iter];
       sorted_keys_[iter]->lkey = new (&lookup_key_ptr_[iter])
           LookupKey(*sorted_keys_[iter]->key, snapshot, read_opts.timestamp);
-      sorted_keys_[iter]->ukey_with_ts = sorted_keys_[iter]->lkey->user_key();
+      sorted_keys_[iter]->ukey_with_ts =
+          sorted_keys_[iter]->lkey->user_key_with_ts();
       sorted_keys_[iter]->ukey_without_ts = StripTimestampFromUserKey(
-          sorted_keys_[iter]->lkey->user_key(),
+          sorted_keys_[iter]->lkey->user_key_with_ts(),
           read_opts.timestamp == nullptr ? 0 : read_opts.timestamp->size());
       sorted_keys_[iter]->ikey = sorted_keys_[iter]->lkey->internal_key();
       sorted_keys_[iter]->timestamp = (*sorted_keys)[begin + iter]->timestamp;

--- a/table/plain/plain_table_builder.cc
+++ b/table/plain/plain_table_builder.cc
@@ -151,10 +151,11 @@ void PlainTableBuilder::Add(const Slice& key, const Slice& value) {
   // Store key hash
   if (store_index_in_file_) {
     if (moptions_.prefix_extractor == nullptr) {
-      keys_or_prefixes_hashes_.push_back(GetSliceHash(internal_key.user_key));
+      keys_or_prefixes_hashes_.push_back(
+          GetSliceHash(internal_key.user_key_with_ts));
     } else {
       Slice prefix =
-          moptions_.prefix_extractor->Transform(internal_key.user_key);
+          moptions_.prefix_extractor->Transform(internal_key.user_key_with_ts);
       keys_or_prefixes_hashes_.push_back(GetSliceHash(prefix));
     }
   }

--- a/table/plain/plain_table_builder.h
+++ b/table/plain/plain_table_builder.h
@@ -129,7 +129,7 @@ class PlainTableBuilder: public TableBuilder {
   }
 
   Slice GetPrefix(const ParsedInternalKey& target) const {
-    return GetPrefixFromUserKey(target.user_key);
+    return GetPrefixFromUserKey(target.user_key_with_ts);
   }
 
   Slice GetPrefixFromUserKey(const Slice& user_key) const {

--- a/table/plain/plain_table_reader.cc
+++ b/table/plain/plain_table_reader.cc
@@ -239,7 +239,7 @@ Status PlainTableReader::PopulateIndexRecordList(
 
     key_prefix_slice = GetPrefix(key);
     if (enable_bloom_) {
-      bloom_.AddHash(GetSliceHash(key.user_key));
+      bloom_.AddHash(GetSliceHash(key.user_key_with_ts));
     } else {
       if (is_first_record || prev_key_prefix_slice != key_prefix_slice) {
         if (!is_first_record) {

--- a/table/plain/plain_table_reader.h
+++ b/table/plain/plain_table_reader.h
@@ -183,7 +183,7 @@ class PlainTableReader: public TableReader {
   }
 
   Slice GetPrefix(const ParsedInternalKey& target) const {
-    return GetPrefixFromUserKey(target.user_key);
+    return GetPrefixFromUserKey(target.user_key_with_ts);
   }
 
   Slice GetPrefixFromUserKey(const Slice& user_key) const {

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -467,12 +467,13 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
     }
 
     // the key returned is not prefixed with out 'from' key
-    if (use_from_as_prefix && !ikey.user_key.starts_with(from_key)) {
+    if (use_from_as_prefix && !ikey.user_key_with_ts.starts_with(from_key)) {
       break;
     }
 
     // If end marker was specified, we stop before it
-    if (has_to && BytewiseComparator()->Compare(ikey.user_key, to_key) >= 0) {
+    if (has_to &&
+        BytewiseComparator()->Compare(ikey.user_key_with_ts, to_key) >= 0) {
       break;
     }
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -96,7 +96,8 @@ class DummyPropertiesCollector : public TablePropertiesCollector {
     return Status::OK();
   }
 
-  Status Add(const Slice& /*user_key*/, const Slice& /*value*/) override {
+  Status Add(const Slice& /*user_key_with_ts*/,
+             const Slice& /*value*/) override {
     return Status::OK();
   }
 
@@ -281,7 +282,7 @@ class KeyConvertingIterator : public InternalIterator {
       status_ = pik_status;
       return Slice(status_.getState());
     }
-    return parsed_key.user_key;
+    return parsed_key.user_key_with_ts;
   }
 
   Slice value() const override { return iter_->value(); }
@@ -4584,8 +4585,8 @@ TEST_P(BlockBasedTableTest, DISABLED_TableWithGlobalSeqno) {
 
     ASSERT_EQ(pik.type, ValueType::kTypeValue);
     ASSERT_EQ(pik.sequence, 0);
-    ASSERT_EQ(pik.user_key, iter->value());
-    ASSERT_EQ(pik.user_key.ToString(), std::string(8, current_c));
+    ASSERT_EQ(pik.user_key_with_ts, iter->value());
+    ASSERT_EQ(pik.user_key_with_ts.ToString(), std::string(8, current_c));
     current_c++;
   }
   ASSERT_EQ(current_c, 'z' + 1);
@@ -4605,8 +4606,8 @@ TEST_P(BlockBasedTableTest, DISABLED_TableWithGlobalSeqno) {
 
     ASSERT_EQ(pik.type, ValueType::kTypeValue);
     ASSERT_EQ(pik.sequence, 10);
-    ASSERT_EQ(pik.user_key, iter->value());
-    ASSERT_EQ(pik.user_key.ToString(), std::string(8, current_c));
+    ASSERT_EQ(pik.user_key_with_ts, iter->value());
+    ASSERT_EQ(pik.user_key_with_ts.ToString(), std::string(8, current_c));
     current_c++;
   }
   ASSERT_EQ(current_c, 'z' + 1);
@@ -4623,7 +4624,7 @@ TEST_P(BlockBasedTableTest, DISABLED_TableWithGlobalSeqno) {
 
     ASSERT_EQ(pik.type, ValueType::kTypeValue);
     ASSERT_EQ(pik.sequence, 10);
-    ASSERT_EQ(pik.user_key.ToString(), k);
+    ASSERT_EQ(pik.user_key_with_ts.ToString(), k);
     ASSERT_EQ(iter->value().ToString(), k);
   }
   delete iter;
@@ -4642,8 +4643,8 @@ TEST_P(BlockBasedTableTest, DISABLED_TableWithGlobalSeqno) {
 
     ASSERT_EQ(pik.type, ValueType::kTypeValue);
     ASSERT_EQ(pik.sequence, 3);
-    ASSERT_EQ(pik.user_key, iter->value());
-    ASSERT_EQ(pik.user_key.ToString(), std::string(8, current_c));
+    ASSERT_EQ(pik.user_key_with_ts, iter->value());
+    ASSERT_EQ(pik.user_key_with_ts.ToString(), std::string(8, current_c));
     current_c++;
   }
   ASSERT_EQ(current_c, 'z' + 1);
@@ -4661,7 +4662,7 @@ TEST_P(BlockBasedTableTest, DISABLED_TableWithGlobalSeqno) {
 
     ASSERT_EQ(pik.type, ValueType::kTypeValue);
     ASSERT_EQ(pik.sequence, 3);
-    ASSERT_EQ(pik.user_key.ToString(), k);
+    ASSERT_EQ(pik.user_key_with_ts.ToString(), k);
     ASSERT_EQ(iter->value().ToString(), k);
   }
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1848,7 +1848,7 @@ void InternalDumpCommand::DoCommand() {
   for (auto& key_version : key_versions) {
     ValueType value_type = static_cast<ValueType>(key_version.type);
     InternalKey ikey(key_version.user_key, key_version.sequence, value_type);
-    if (has_to_ && ikey.user_key() == to_) {
+    if (has_to_ && ikey.user_key_with_ts() == to_) {
       // GetAllKeyVersions() includes keys with user key `to_`, but idump has
       // traditionally excluded such keys.
       break;

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -69,13 +69,13 @@ void print_help(bool to_stderr) {
     --decode_blob_index
       Decode blob indexes and print them in a human-readable format during scans.
 
-    --from=<user_key>
+    --from=<user_key_with_ts>
       Key to start reading from when executing check|scan
 
-    --to=<user_key>
+    --to=<user_key_with_ts>
       Key to stop reading at when executing check|scan
 
-    --prefix=<user_key>
+    --prefix=<user_key_with_ts>
       Returns all keys with this prefix when executing check|scan
       Cannot be used in conjunction with --from
 

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -99,14 +99,14 @@ CompactionFilter::Decision BlobIndexCompactionFilterBase::FilterV2(
     PinnableSlice blob;
     CompressionType compression_type = kNoCompression;
     constexpr bool need_decompress = true;
-    if (!ReadBlobFromOldFile(ikey.user_key, blob_index, &blob, need_decompress,
-                             &compression_type)) {
+    if (!ReadBlobFromOldFile(ikey.user_key_with_ts, blob_index, &blob,
+                             need_decompress, &compression_type)) {
       return Decision::kIOError;
     }
     CompactionFilter::Decision decision = ucf->FilterV2(
-        level, ikey.user_key, kValue, blob, new_value, skip_until);
+        level, ikey.user_key_with_ts, kValue, blob, new_value, skip_until);
     if (decision == Decision::kChangeValue) {
-      return HandleValueChange(ikey.user_key, new_value);
+      return HandleValueChange(ikey.user_key_with_ts, new_value);
     }
     return decision;
   }

--- a/utilities/debug.cc
+++ b/utilities/debug.cc
@@ -102,11 +102,11 @@ Status GetAllKeyVersions(DB* db, ColumnFamilyHandle* cfh, Slice begin_key,
     }
 
     if (!end_key.empty() &&
-        icmp.user_comparator()->Compare(ikey.user_key, end_key) > 0) {
+        icmp.user_comparator()->Compare(ikey.user_key_with_ts, end_key) > 0) {
       break;
     }
 
-    key_versions->emplace_back(ikey.user_key.ToString() /* _user_key */,
+    key_versions->emplace_back(ikey.user_key_with_ts.ToString() /* _user_key */,
                                iter->value().ToString() /* _value */,
                                ikey.sequence /* _sequence */,
                                static_cast<int>(ikey.type) /* _type */);

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2652,7 +2652,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction2) {
   int count_value = 0;
   auto callback = [&](void* arg) {
     auto* ikey = reinterpret_cast<ParsedInternalKey*>(arg);
-    if (ikey->user_key == "key1") {
+    if (ikey->user_key_with_ts == "key1") {
       count_value++;
       if (count_value == 2) {
         // Processing v1.
@@ -3102,7 +3102,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotAfterSeqZeroing) {
         const auto* const ikey =
             reinterpret_cast<const ParsedInternalKey*>(arg);
         assert(ikey);
-        if (ikey->user_key == "b") {
+        if (ikey->user_key_with_ts == "b") {
           assert(ikey->type == kTypeValue);
           db->ReleaseSnapshot(snapshot);
 
@@ -3176,7 +3176,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotAfterSeqZeroing2) {
         const auto* const ikey =
             reinterpret_cast<const ParsedInternalKey*>(arg);
         assert(ikey);
-        if (ikey->user_key == "b") {
+        if (ikey->user_key_with_ts == "b") {
           assert(ikey->type == kTypeValue);
           db->ReleaseSnapshot(snapshot);
 


### PR DESCRIPTION
This PR is the result of applying IDE's built-in "refactor" functionality,
i.e., automatic variable/function renaming. Nothing manual.

We updated the names of a few widely used variables and functions to explicitly
state whether timestamp is included. I hope we can ultimately apply
compile-time type checks to distinguish between user keys with and without
timestamps, but that may involve incompatible API change. This is a first step
towards the direction, though I don't know whether we will change the API or not
at this point.

Test plan
make check