### PR TITLE
BackupEngine: Provide unique_ptr<BackupEngine> argument for Open

### DIFF
--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -594,6 +594,8 @@ class BackupEngine : public BackupEngineReadOnlyBase,
   // BackupEngines for the same backup directory.
   static IOStatus Open(const BackupEngineOptions& options, Env* db_env,
                        BackupEngine** backup_engine_ptr);
+  static IOStatus Open(const BackupEngineOptions& options, Env* db_env,
+                       std::unique_ptr<BackupEngine>& backup_engine_ptr);
 
   // keep for backward compatibility.
   static IOStatus Open(Env* db_env, const BackupEngineOptions& options,

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -988,6 +988,19 @@ IOStatus BackupEngine::Open(const BackupEngineOptions& options, Env* env,
   return IOStatus::OK();
 }
 
+IOStatus BackupEngine::Open(const BackupEngineOptions& options, Env* env,
+                            std::unique_ptr<BackupEngine>& backup_engine_ptr) {
+  std::unique_ptr<BackupEngineImplThreadSafe> backup_engine(
+      new BackupEngineImplThreadSafe(options, env));
+  auto s = backup_engine->Initialize();
+  if (!s.ok()) {
+    backup_engine_ptr.reset();
+    return s;
+  }
+  backup_engine_ptr = std::move(backup_engine);
+  return IOStatus::OK();
+}
+
 namespace {
 BackupEngineImpl::BackupEngineImpl(const BackupEngineOptions& options,
                                    Env* db_env, bool read_only)


### PR DESCRIPTION
We want use unique_ptr to define BackupEngine
when Open BackupEngine, this is convenient for
us to free space.

Signed-off-by: Yite Gu <ess_gyt@qq.com>