### PR TITLE
Optimize.db impl.get approximate sizes

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4059,6 +4059,7 @@ Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
   SuperVersion* sv = GetAndRefSuperVersion(cfd);
   v = sv->current;
 
+  InternalKey k1, k2;
   for (int i = 0; i < n; i++) {
     Slice start = range[i].start;
     Slice limit = range[i].limit;
@@ -4075,8 +4076,8 @@ Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
       limit = limit_with_ts;
     }
     // Convert user_key into a corresponding internal key.
-    InternalKey k1(start, kMaxSequenceNumber, kValueTypeForSeek);
-    InternalKey k2(limit, kMaxSequenceNumber, kValueTypeForSeek);
+    SetInternalKey(k1.rep(), start, kMaxSequenceNumber, kValueTypeForSeek);
+    SetInternalKey(k2.rep(), limit, kMaxSequenceNumber, kValueTypeForSeek);
     sizes[i] = 0;
     if (options.include_files) {
       sizes[i] += versions_->ApproximateSize(

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -169,6 +169,18 @@ inline void SetInternalKey(std::string* result, Slice ukey,
   PutFixed64(result, PackSequenceAndType(seq, vt));
 }
 
+// user code should ensure buf size is at least ukey.size() + 8
+inline void SetInternalKey(char* buf, Slice ukey,
+                           SequenceNumber seq, ValueType vt) {
+  memcpy(buf, ukey.data_, ukey.size_);
+  auto value = PackSequenceAndType(seq, vt);
+  if (port::kLittleEndian) {
+    memcpy(buf + ukey.size_, &value, sizeof(value));
+  } else {
+    EncodeFixed64(buf + ukey.size_, value);
+  }
+}
+
 // Append the serialization of "key" to *result.
 extern void AppendInternalKey(std::string* result,
                               const ParsedInternalKey& key);

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -159,6 +159,16 @@ inline void UnPackSequenceAndType(uint64_t packed, uint64_t* seq,
 
 EntryType GetEntryType(ValueType value_type);
 
+inline void SetInternalKey(std::string* result, Slice ukey, uint64_t seqvt) {
+  result->assign(ukey.data(), ukey.size());
+  PutFixed64(result, seqvt);
+}
+inline void SetInternalKey(std::string* result, Slice ukey,
+                           SequenceNumber seq, ValueType vt) {
+  result->assign(ukey.data(), ukey.size());
+  PutFixed64(result, PackSequenceAndType(seq, vt));
+}
+
 // Append the serialization of "key" to *result.
 extern void AppendInternalKey(std::string* result,
                               const ParsedInternalKey& key);

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -163,15 +163,15 @@ inline void SetInternalKey(std::string* result, Slice ukey, uint64_t seqvt) {
   result->assign(ukey.data(), ukey.size());
   PutFixed64(result, seqvt);
 }
-inline void SetInternalKey(std::string* result, Slice ukey,
-                           SequenceNumber seq, ValueType vt) {
+inline void SetInternalKey(std::string* result, Slice ukey, SequenceNumber seq,
+                           ValueType vt) {
   result->assign(ukey.data(), ukey.size());
   PutFixed64(result, PackSequenceAndType(seq, vt));
 }
 
 // user code should ensure buf size is at least ukey.size() + 8
-inline void SetInternalKey(char* buf, Slice ukey,
-                           SequenceNumber seq, ValueType vt) {
+inline void SetInternalKey(char* buf, Slice ukey, SequenceNumber seq,
+                           ValueType vt) {
   memcpy(buf, ukey.data_, ukey.size_);
   auto value = PackSequenceAndType(seq, vt);
   if (port::kLittleEndian) {


### PR DESCRIPTION
This PR speed up `GetApproximateSizes` by ~15%, in flame graph, `GetApproximateSizes` time percent reduced from `7.01%` to `5.92%`.

## Flame graph before this PR:
![image](https://user-images.githubusercontent.com/1574991/188301305-463fa3c8-00d4-42a4-be20-c36706e66760.png)

## Flame graph after this PR:
![image](https://user-images.githubusercontent.com/1574991/188301417-a6e4d245-f04c-4437-bb3f-35fdca5425bd.png)
