### PR TITLE
Disable RateLimiterTest.Rate with valgrind

### DIFF
--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -344,9 +344,10 @@ TEST_F(RateLimiterTest, Rate) {
     }
   }
 
-  // This can fail in heavily loaded CI environments
+  // This can fail due to slow execution speed, like when using valgrind or in
+  // heavily loaded CI environments
   bool skip_minimum_rate_check =
-#if defined(CIRCLECI) && (defined(OS_MACOSX) || defined(ROCKSDB_VALGRIND_RUN))
+#if (defined(CIRCLECI) && defined(OS_MACOSX)) || defined(ROCKSDB_VALGRIND_RUN)
       true;
 #else
       getenv("SANDCASTLE");

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -346,7 +346,7 @@ TEST_F(RateLimiterTest, Rate) {
 
   // This can fail in heavily loaded CI environments
   bool skip_minimum_rate_check =
-#if defined(CIRCLECI) && defined(OS_MACOSX)
+#if defined(CIRCLECI) && (defined(OS_MACOSX) || defined(ROCKSDB_VALGRIND_RUN))
       true;
 #else
       getenv("SANDCASTLE");


### PR DESCRIPTION
Example valgrind flake: https://app.circleci.com/pipelines/github/facebook/rocksdb/18073/workflows/3794e569-45cb-4621-a2b4-df1dcdf5cb19/jobs/475569

```
util/rate_limiter_test.cc:358
Expected equality of these values:
  samples_at_minimum
    Which is: 9
  samples
    Which is: 10
```

Some other runs of `RateLimiterTest.Rate` already skip this check due to its reliance on a minimum execution speed. We know valgrind slows execution a lot so can disable the check in that case.