### PR TITLE
Comparator: Add func: IsBytewiseComparator & IsReverseBytewiseComparator

### DIFF
--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -45,9 +45,9 @@ class Comparator : public Customizable, public CompareInterface {
  public:
   Comparator() : timestamp_size_(0) {}
 
-  Comparator(size_t ts_sz) : timestamp_size_(ts_sz) {}
+  Comparator(size_t ts_sz) : timestamp_size_(uint16_t(ts_sz)) {}
 
-  Comparator(const Comparator& orig) : timestamp_size_(orig.timestamp_size_) {}
+  Comparator(const Comparator&) = default;
 
   Comparator& operator=(const Comparator& rhs) {
     if (this != &rhs) {
@@ -148,8 +148,14 @@ class Comparator : public Customizable, public CompareInterface {
            CompareWithoutTimestamp(a, /*a_has_ts=*/true, b, /*b_has_ts=*/true);
   }
 
- private:
-  size_t timestamp_size_;
+  bool IsForwardBytewise() const noexcept { return 0 == opt_cmp_type_; }
+  bool IsReverseBytewise() const noexcept { return 1 == opt_cmp_type_; }
+  bool IsBytewise() const noexcept { return opt_cmp_type_ <= 1; }
+
+ protected:
+  uint16_t timestamp_size_;
+  // 0: forward bytewise, 1: rev byitewise, others: unknown
+  uint8_t opt_cmp_type_ = 255;
 };
 
 // Return a builtin comparator that uses lexicographic byte-wise
@@ -160,5 +166,22 @@ extern const Comparator* BytewiseComparator();
 // Return a builtin comparator that uses reverse lexicographic byte-wise
 // ordering.
 extern const Comparator* ReverseBytewiseComparator();
+
+bool IsForwardBytewiseComparator(const Slice& name);
+bool IsReverseBytewiseComparator(const Slice& name);
+bool IsBytewiseComparator(const Slice& name);
+
+inline bool IsForwardBytewiseComparator(const Comparator* cmp) {
+  assert(cmp->IsForwardBytewise() == IsForwardBytewiseComparator(cmp->Name()));
+  return cmp->IsForwardBytewise();
+}
+inline bool IsReverseBytewiseComparator(const Comparator* cmp) {
+  assert(cmp->IsReverseBytewise() == IsReverseBytewiseComparator(cmp->Name()));
+  return cmp->IsReverseBytewise();
+}
+inline bool IsBytewiseComparator(const Comparator* cmp) {
+  assert(cmp->IsBytewise() == IsBytewiseComparator(cmp->Name()));
+  return cmp->IsBytewise();
+}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -29,7 +29,7 @@ namespace ROCKSDB_NAMESPACE {
 namespace {
 class BytewiseComparatorImpl : public Comparator {
  public:
-  BytewiseComparatorImpl() { }
+  BytewiseComparatorImpl() { opt_cmp_type_ = 0; }
   static const char* kClassName() { return "leveldb.BytewiseComparator"; }
   const char* Name() const override { return kClassName(); }
 
@@ -147,7 +147,7 @@ class BytewiseComparatorImpl : public Comparator {
 
 class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
  public:
-  ReverseBytewiseComparatorImpl() { }
+  ReverseBytewiseComparatorImpl() { opt_cmp_type_ = 1; }
 
   static const char* kClassName() {
     return "rocksdb.ReverseBytewiseComparator";
@@ -388,4 +388,24 @@ Status Comparator::CreateFromString(const ConfigOptions& config_options,
   }
   return status;
 }
+
+bool IsForwardBytewiseComparator(const Slice& name) {
+  if (name.starts_with("RocksDB_SE_")) {
+    return true;
+  }
+  return name == "leveldb.BytewiseComparator";
+}
+
+bool IsReverseBytewiseComparator(const Slice& name) {
+  if (name.starts_with("rev:RocksDB_SE_")) {
+    // reverse bytewise compare, needs reverse in iterator
+    return true;
+  }
+  return name == "rocksdb.ReverseBytewiseComparator";
+}
+
+bool IsBytewiseComparator(const Slice& name) {
+  return IsForwardBytewiseComparator(name) || IsReverseBytewiseComparator(name);
+}
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
1. Virtual function call to comparator is very frequent thus is a hot spot
2. In most use cases, the default `BytewiseComparator` or `ReverseBytewiseComparator` is used

This PR provide the basic support for our later PRs for `FindFileInRange` and `MergingIterator`:
1. devirtualize such virtual functions calls for `BytewiseComparator` or `ReverseBytewiseComparator`
2. Add prefix cache to omit most `memcmp` and indirect memory access to `key`

Performance of `FindFileInRange` was improved 20x+, `MergingIterator` is improved 3x+.