### PR TITLE
FindFileInRange: devirtualize comparator and prefix cache

### DIFF
--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -24,6 +24,7 @@
 #include "rocksdb/cache.h"
 #include "table/table_reader.h"
 #include "util/autovector.h"
+#include "util/math.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -336,11 +337,21 @@ struct FdWithKeyRange {
 struct LevelFilesBrief {
   size_t num_files;
   FdWithKeyRange* files;
+  uint64_t* prefix_cache = nullptr;
   LevelFilesBrief() {
     num_files = 0;
     files = nullptr;
   }
 };
+inline uint64_t HostPrefixCache(const Slice& ikey) {
+  assert(ikey.size_ >= 8);
+  uint64_t data = 0;
+  memcpy(&data, ikey.data_, std::min<size_t>(ikey.size_ - 8, 8));
+  if (port::kLittleEndian)
+    return EndianSwapValue(data);
+  else
+    return data;
+}
 
 // The state of a DB at any given time is referred to as a Version.
 // Any modification to the Version is considered a Version Edit. A Version is

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1368,7 +1368,7 @@ class VersionSet {
   // The caller should delete the iterator when no longer needed.
   // @param read_options Must outlive the returned iterator.
   // @param start, end indicates compaction range
-  InternalIterator* MakeInputIterator(
+  static InternalIterator* MakeInputIterator(
       const ReadOptions& read_options, const Compaction* c,
       RangeDelAggregator* range_del_agg,
       const FileOptions& file_options_compactions,

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -933,6 +933,8 @@ class FindLevelFileTest : public testing::Test {
     char* mem = arena_.AllocateAligned(num * sizeof(FdWithKeyRange));
     file_level_.files = new (mem)FdWithKeyRange[num];
     file_level_.num_files = 0;
+    file_level_.prefix_cache =
+        (uint64_t*)arena_.AllocateAligned(num * sizeof(uint64_t));
   }
 
   void Add(const char* smallest, const char* largest,
@@ -957,6 +959,7 @@ class FindLevelFileTest : public testing::Test {
     file.smallest_key = Slice(mem, smallest_slice.size());
     file.largest_key = Slice(mem + smallest_slice.size(),
         largest_slice.size());
+    file_level_.prefix_cache[num] = HostPrefixCache(largest_slice);
     file_level_.num_files++;
   }
 

--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -45,9 +45,9 @@ class Comparator : public Customizable, public CompareInterface {
  public:
   Comparator() : timestamp_size_(0) {}
 
-  Comparator(size_t ts_sz) : timestamp_size_(ts_sz) {}
+  Comparator(size_t ts_sz) : timestamp_size_(uint16_t(ts_sz)) {}
 
-  Comparator(const Comparator& orig) : timestamp_size_(orig.timestamp_size_) {}
+  Comparator(const Comparator&) = default;
 
   Comparator& operator=(const Comparator& rhs) {
     if (this != &rhs) {
@@ -148,8 +148,14 @@ class Comparator : public Customizable, public CompareInterface {
            CompareWithoutTimestamp(a, /*a_has_ts=*/true, b, /*b_has_ts=*/true);
   }
 
- private:
-  size_t timestamp_size_;
+  bool IsForwardBytewise() const noexcept { return 0 == opt_cmp_type_; }
+  bool IsReverseBytewise() const noexcept { return 1 == opt_cmp_type_; }
+  bool IsBytewise() const noexcept { return opt_cmp_type_ <= 1; }
+
+ protected:
+  uint16_t timestamp_size_;
+  // 0: forward bytewise, 1: rev byitewise, others: unknown
+  uint8_t opt_cmp_type_ = 255;
 };
 
 // Return a builtin comparator that uses lexicographic byte-wise
@@ -160,5 +166,22 @@ extern const Comparator* BytewiseComparator();
 // Return a builtin comparator that uses reverse lexicographic byte-wise
 // ordering.
 extern const Comparator* ReverseBytewiseComparator();
+
+bool IsForwardBytewiseComparator(const Slice& name);
+bool IsReverseBytewiseComparator(const Slice& name);
+bool IsBytewiseComparator(const Slice& name);
+
+inline bool IsForwardBytewiseComparator(const Comparator* cmp) {
+  assert(cmp->IsForwardBytewise() == IsForwardBytewiseComparator(cmp->Name()));
+  return cmp->IsForwardBytewise();
+}
+inline bool IsReverseBytewiseComparator(const Comparator* cmp) {
+  assert(cmp->IsReverseBytewise() == IsReverseBytewiseComparator(cmp->Name()));
+  return cmp->IsReverseBytewise();
+}
+inline bool IsBytewiseComparator(const Comparator* cmp) {
+  assert(cmp->IsBytewise() == IsBytewiseComparator(cmp->Name()));
+  return cmp->IsBytewise();
+}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -29,7 +29,7 @@ namespace ROCKSDB_NAMESPACE {
 namespace {
 class BytewiseComparatorImpl : public Comparator {
  public:
-  BytewiseComparatorImpl() { }
+  BytewiseComparatorImpl() { opt_cmp_type_ = 0; }
   static const char* kClassName() { return "leveldb.BytewiseComparator"; }
   const char* Name() const override { return kClassName(); }
 
@@ -147,7 +147,7 @@ class BytewiseComparatorImpl : public Comparator {
 
 class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
  public:
-  ReverseBytewiseComparatorImpl() { }
+  ReverseBytewiseComparatorImpl() { opt_cmp_type_ = 1; }
 
   static const char* kClassName() {
     return "rocksdb.ReverseBytewiseComparator";
@@ -388,4 +388,24 @@ Status Comparator::CreateFromString(const ConfigOptions& config_options,
   }
   return status;
 }
+
+bool IsForwardBytewiseComparator(const Slice& name) {
+  if (name.starts_with("RocksDB_SE_")) {
+    return true;
+  }
+  return name == "leveldb.BytewiseComparator";
+}
+
+bool IsReverseBytewiseComparator(const Slice& name) {
+  if (name.starts_with("rev:RocksDB_SE_")) {
+    // reverse bytewise compare, needs reverse in iterator
+    return true;
+  }
+  return name == "rocksdb.ReverseBytewiseComparator";
+}
+
+bool IsBytewiseComparator(const Slice& name) {
+  return IsForwardBytewiseComparator(name) || IsReverseBytewiseComparator(name);
+}
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
This PR is based on #10645.

If comparator is BytewiseComparator or ReverseBytewiseComparator:
1. devirtualize comparator: specialize the impl by direct call memcmp
2. add prefix cache: narrow the search range by prefix cache, then find by comparator