### PR TITLE
Eliminate some allocations/copies around the blob cache

### DIFF
--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -404,6 +404,7 @@ void BlobFileReader::MultiGetBlob(
   for (size_t i = 0; i < num_blobs; ++i) {
     BlobReadRequest* const req = blob_reqs[i].first;
     assert(req);
+    assert(req->status);
 
     const size_t key_size = req->user_key->size();
     const uint64_t offset = req->offset;
@@ -462,13 +463,14 @@ void BlobFileReader::MultiGetBlob(
     for (auto& req : read_reqs) {
       req.status.PermitUncheckedError();
     }
-    for (auto& req : blob_reqs) {
-      assert(req.first);
-      assert(req.first->status);
+    for (auto& blob_req : blob_reqs) {
+      BlobReadRequest* const req = blob_req.first;
+      assert(req);
+      assert(req->status);
 
-      if (!req.first->status->IsCorruption()) {
+      if (!req->status->IsCorruption()) {
         // Avoid overwriting corruption status.
-        *req.first->status = s;
+        *req->status = s;
       }
     }
     return;
@@ -480,8 +482,8 @@ void BlobFileReader::MultiGetBlob(
   for (size_t i = 0, j = 0; i < num_blobs; ++i) {
     BlobReadRequest* const req = blob_reqs[i].first;
     assert(req);
-
     assert(req->status);
+
     if (!req->status->ok()) {
       continue;
     }

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -382,16 +382,18 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
   return Status::OK();
 }
 
-void BlobFileReader::MultiGetBlob(const ReadOptions& read_options,
-                                  autovector<BlobReadRequest*>& blob_reqs,
-                                  uint64_t* bytes_read) const {
+void BlobFileReader::MultiGetBlob(
+    const ReadOptions& read_options,
+    autovector<std::pair<BlobReadRequest*, std::unique_ptr<BlobContents>>>&
+        blob_reqs,
+    uint64_t* bytes_read) const {
   const size_t num_blobs = blob_reqs.size();
   assert(num_blobs > 0);
   assert(num_blobs <= MultiGetContext::MAX_BATCH_SIZE);
 
 #ifndef NDEBUG
   for (size_t i = 0; i < num_blobs - 1; ++i) {
-    assert(blob_reqs[i]->offset <= blob_reqs[i + 1]->offset);
+    assert(blob_reqs[i].first->offset <= blob_reqs[i + 1].first->offset);
   }
 #endif  // !NDEBUG
 
@@ -400,16 +402,19 @@ void BlobFileReader::MultiGetBlob(const ReadOptions& read_options,
   uint64_t total_len = 0;
   read_reqs.reserve(num_blobs);
   for (size_t i = 0; i < num_blobs; ++i) {
-    const size_t key_size = blob_reqs[i]->user_key->size();
-    const uint64_t offset = blob_reqs[i]->offset;
-    const uint64_t value_size = blob_reqs[i]->len;
+    BlobReadRequest* const req = blob_reqs[i].first;
+    assert(req);
+
+    const size_t key_size = req->user_key->size();
+    const uint64_t offset = req->offset;
+    const uint64_t value_size = req->len;
 
     if (!IsValidBlobOffset(offset, key_size, value_size, file_size_)) {
-      *blob_reqs[i]->status = Status::Corruption("Invalid blob offset");
+      *req->status = Status::Corruption("Invalid blob offset");
       continue;
     }
-    if (blob_reqs[i]->compression != compression_type_) {
-      *blob_reqs[i]->status =
+    if (req->compression != compression_type_) {
+      *req->status =
           Status::Corruption("Compression type mismatch when reading a blob");
       continue;
     }
@@ -418,12 +423,12 @@ void BlobFileReader::MultiGetBlob(const ReadOptions& read_options,
         read_options.verify_checksums
             ? BlobLogRecord::CalculateAdjustmentForRecordHeader(key_size)
             : 0;
-    assert(blob_reqs[i]->offset >= adjustment);
+    assert(req->offset >= adjustment);
     adjustments.push_back(adjustment);
 
     FSReadRequest read_req = {};
-    read_req.offset = blob_reqs[i]->offset - adjustment;
-    read_req.len = blob_reqs[i]->len + adjustment;
+    read_req.offset = req->offset - adjustment;
+    read_req.len = req->len + adjustment;
     read_reqs.emplace_back(read_req);
     total_len += read_req.len;
   }
@@ -458,10 +463,12 @@ void BlobFileReader::MultiGetBlob(const ReadOptions& read_options,
       req.status.PermitUncheckedError();
     }
     for (auto& req : blob_reqs) {
-      assert(req->status);
-      if (!req->status->IsCorruption()) {
+      assert(req.first);
+      assert(req.first->status);
+
+      if (!req.first->status->IsCorruption()) {
         // Avoid overwriting corruption status.
-        *req->status = s;
+        *req.first->status = s;
       }
     }
     return;
@@ -471,39 +478,41 @@ void BlobFileReader::MultiGetBlob(const ReadOptions& read_options,
 
   uint64_t total_bytes = 0;
   for (size_t i = 0, j = 0; i < num_blobs; ++i) {
-    assert(blob_reqs[i]->status);
-    if (!blob_reqs[i]->status->ok()) {
+    BlobReadRequest* const req = blob_reqs[i].first;
+    assert(req);
+
+    assert(req->status);
+    if (!req->status->ok()) {
       continue;
     }
 
     assert(j < read_reqs.size());
-    auto& req = read_reqs[j++];
-    const auto& record_slice = req.result;
-    if (req.status.ok() && record_slice.size() != req.len) {
-      req.status = IOStatus::Corruption("Failed to read data from blob file");
+    auto& read_req = read_reqs[j++];
+    const auto& record_slice = read_req.result;
+    if (read_req.status.ok() && record_slice.size() != read_req.len) {
+      read_req.status =
+          IOStatus::Corruption("Failed to read data from blob file");
     }
 
-    *blob_reqs[i]->status = req.status;
-    if (!blob_reqs[i]->status->ok()) {
+    *req->status = read_req.status;
+    if (!req->status->ok()) {
       continue;
     }
 
     // Verify checksums if enabled
     if (read_options.verify_checksums) {
-      *blob_reqs[i]->status =
-          VerifyBlob(record_slice, *blob_reqs[i]->user_key, blob_reqs[i]->len);
-      if (!blob_reqs[i]->status->ok()) {
+      *req->status = VerifyBlob(record_slice, *req->user_key, req->len);
+      if (!req->status->ok()) {
         continue;
       }
     }
 
     // Uncompress blob if needed
-    std::unique_ptr<BlobContents> fixme;
-    Slice value_slice(record_slice.data() + adjustments[i], blob_reqs[i]->len);
-    *blob_reqs[i]->status = UncompressBlobIfNeeded(
-        value_slice, compression_type_, allocator_, clock_, statistics_,
-        &fixme /*&blob_reqs[i]->blob_contents*/);
-    if (blob_reqs[i]->status->ok()) {
+    Slice value_slice(record_slice.data() + adjustments[i], req->len);
+    *req->status =
+        UncompressBlobIfNeeded(value_slice, compression_type_, allocator_,
+                               clock_, statistics_, &blob_reqs[i].second);
+    if (req->status->ok()) {
       total_bytes += record_slice.size();
     }
   }

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -396,6 +396,7 @@ void BlobFileReader::MultiGetBlob(
   for (size_t i = 0; i < num_blobs; ++i) {
     BlobReadRequest* const req = blob_reqs[i].first;
     assert(req);
+    assert(req->user_key);
     assert(req->status);
 
     const size_t key_size = req->user_key->size();
@@ -474,6 +475,7 @@ void BlobFileReader::MultiGetBlob(
   for (size_t i = 0, j = 0; i < num_blobs; ++i) {
     BlobReadRequest* const req = blob_reqs[i].first;
     assert(req);
+    assert(req->user_key);
     assert(req->status);
 
     if (!req->status->ok()) {

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -45,12 +45,13 @@ class BlobFileReader {
                  uint64_t offset, uint64_t value_size,
                  CompressionType compression_type,
                  FilePrefetchBuffer* prefetch_buffer,
+                 MemoryAllocator* allocator,
                  std::unique_ptr<BlobContents>* result,
                  uint64_t* bytes_read) const;
 
   // offsets must be sorted in ascending order by caller.
   void MultiGetBlob(
-      const ReadOptions& read_options,
+      const ReadOptions& read_options, MemoryAllocator* allocator,
       autovector<std::pair<BlobReadRequest*, std::unique_ptr<BlobContents>>>&
           blob_reqs,
       uint64_t* bytes_read) const;
@@ -62,8 +63,7 @@ class BlobFileReader {
  private:
   BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,
                  uint64_t file_size, CompressionType compression_type,
-                 MemoryAllocator* allocator, SystemClock* clock,
-                 Statistics* statistics);
+                 SystemClock* clock, Statistics* statistics);
 
   static Status OpenFile(const ImmutableOptions& immutable_options,
                          const FileOptions& file_opts,
@@ -101,7 +101,6 @@ class BlobFileReader {
   std::unique_ptr<RandomAccessFileReader> file_reader_;
   uint64_t file_size_;
   CompressionType compression_type_;
-  MemoryAllocator* allocator_;
   SystemClock* clock_;
   Statistics* statistics_;
 };

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -49,9 +49,11 @@ class BlobFileReader {
                  uint64_t* bytes_read) const;
 
   // offsets must be sorted in ascending order by caller.
-  void MultiGetBlob(const ReadOptions& read_options,
-                    autovector<BlobReadRequest*>& blob_reqs,
-                    uint64_t* bytes_read) const;
+  void MultiGetBlob(
+      const ReadOptions& read_options,
+      autovector<std::pair<BlobReadRequest*, std::unique_ptr<BlobContents>>>&
+          blob_reqs,
+      uint64_t* bytes_read) const;
 
   CompressionType GetCompressionType() const { return compression_type_; }
 

--- a/db/blob/blob_read_request.h
+++ b/db/blob/blob_read_request.h
@@ -6,7 +6,9 @@
 #pragma once
 
 #include <cinttypes>
+#include <memory>
 
+#include "db/blob/blob_contents.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
@@ -14,8 +16,13 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+class BlobContents;
+
 // A read Blob request structure for use in BlobSource::MultiGetBlob and
 // BlobFileReader::MultiGetBlob.
+// TODO: introduce separate classes to represent the "physical" read requests
+// handled by BlobFileReader and the "logical" read requests handled by
+// BlobSource
 struct BlobReadRequest {
   // User key to lookup the paired blob
   const Slice* user_key = nullptr;
@@ -35,6 +42,9 @@ struct BlobReadRequest {
 
   // Status of read
   Status* status = nullptr;
+
+  // Uncompressed blob value read from file
+  // std::unique_ptr<BlobContents> blob_contents;
 
   BlobReadRequest(const Slice& _user_key, uint64_t _offset, size_t _len,
                   CompressionType _compression, PinnableSlice* _result,

--- a/db/blob/blob_read_request.h
+++ b/db/blob/blob_read_request.h
@@ -6,9 +6,7 @@
 #pragma once
 
 #include <cinttypes>
-#include <memory>
 
-#include "db/blob/blob_contents.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
@@ -16,13 +14,8 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-class BlobContents;
-
 // A read Blob request structure for use in BlobSource::MultiGetBlob and
 // BlobFileReader::MultiGetBlob.
-// TODO: introduce separate classes to represent the "physical" read requests
-// handled by BlobFileReader and the "logical" read requests handled by
-// BlobSource
 struct BlobReadRequest {
   // User key to lookup the paired blob
   const Slice* user_key = nullptr;
@@ -42,9 +35,6 @@ struct BlobReadRequest {
 
   // Status of read
   Status* status = nullptr;
-
-  // Uncompressed blob value read from file
-  // std::unique_ptr<BlobContents> blob_contents;
 
   BlobReadRequest(const Slice& _user_key, uint64_t _offset, size_t _len,
                   CompressionType _compression, PinnableSlice* _result,

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -366,8 +366,10 @@ void BlobSource::MultiGetBlobFromOneFile(const ReadOptions& read_options,
   if (no_io) {
     for (size_t i = 0; i < num_blobs; ++i) {
       if (!(cache_hit_mask & (Mask{1} << i))) {
-        assert(blob_reqs[i].status);
-        *blob_reqs[i].status =
+        BlobReadRequest& req = blob_reqs[i];
+        assert(req.status);
+
+        *req.status =
             Status::Incomplete("Cannot read blob(s): no disk I/O allowed");
       }
     }

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -397,8 +397,11 @@ void BlobSource::MultiGetBlobFromOneFile(const ReadOptions& read_options,
         blob_file_cache_->GetBlobFileReader(file_number, &blob_file_reader);
     if (!s.ok()) {
       for (size_t i = 0; i < _blob_reqs.size(); ++i) {
-        assert(_blob_reqs[i].first->status);
-        *_blob_reqs[i].first->status = s;
+        BlobReadRequest* const req = _blob_reqs[i].first;
+        assert(req);
+        assert(req->status);
+
+        *req->status = s;
       }
       return;
     }

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cinttypes>
+#include <memory>
 
 #include "cache/cache_helpers.h"
 #include "cache/cache_key.h"
@@ -107,14 +108,16 @@ class BlobSource {
 
  private:
   Status GetBlobFromCache(const Slice& cache_key,
-                          CacheHandleGuard<BlobContents>* blob) const;
+                          CacheHandleGuard<BlobContents>* cached_blob) const;
 
   Status PutBlobIntoCache(const Slice& cache_key,
-                          CacheHandleGuard<BlobContents>* cached_blob,
-                          PinnableSlice* blob) const;
+                          std::unique_ptr<BlobContents>* blob,
+                          CacheHandleGuard<BlobContents>* cached_blob) const;
 
   static void PinCachedBlob(CacheHandleGuard<BlobContents>* cached_blob,
                             PinnableSlice* value);
+
+  static void CopyBlob(const BlobContents* blob, PinnableSlice* value);
 
   Cache::Handle* GetEntryFromCache(const Slice& key) const;
 

--- a/db/blob/blob_source.h
+++ b/db/blob/blob_source.h
@@ -117,7 +117,8 @@ class BlobSource {
   static void PinCachedBlob(CacheHandleGuard<BlobContents>* cached_blob,
                             PinnableSlice* value);
 
-  static void CopyBlob(const BlobContents* blob, PinnableSlice* value);
+  static void PinOwnedBlob(std::unique_ptr<BlobContents>* owned_blob,
+                           PinnableSlice* value);
 
   Cache::Handle* GetEntryFromCache(const Slice& key) const;
 

--- a/db/blob/blob_source_test.cc
+++ b/db/blob/blob_source_test.cc
@@ -219,7 +219,7 @@ TEST_F(BlobSourceTest, GetBlobsFromCache) {
                                     kNoCompression, prefetch_buffer, &values[i],
                                     &bytes_read));
       ASSERT_EQ(values[i], blobs[i]);
-      ASSERT_FALSE(values[i].IsPinned());
+      ASSERT_TRUE(values[i].IsPinned());
       ASSERT_EQ(bytes_read,
                 BlobLogRecord::kHeaderSize + keys[i].size() + blob_sizes[i]);
 


### PR DESCRIPTION
Summary:
Historically, `BlobFileReader` has returned the blob(s) read from the file
in the `PinnableSlice` provided by the client. This interface was
preserved when caching was implemented for blobs, which meant that
the blob data was copied multiple times when caching was in use: first,
into the client-provided `PinnableSlice` (by `BlobFileReader::SaveValue`),
and then, into the object stored in the cache (by `BlobSource::PutBlobIntoCache`).
The patch eliminates these copies and the related allocations by changing
`BlobFileReader` so it returns its results in the form of heap-allocated `BlobContents`
objects that can be directly inserted into the cache. The allocations backing
these `BlobContents` objects are made using the blob cache's allocator if the
blobs are to be inserted into the cache (i.e. if a cache is configured and the
`fill_cache` read option is set). Note: this PR focuses on the common case when
blobs are compressed; some further small optimizations are possible for uncompressed
blobs.

Test Plan:
`make check`