### PR TITLE
db_stress option to preserve all files until verification success

### DIFF
--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -360,7 +360,7 @@ Status SaveFilesInDirectory(const std::string& src_dirname,
   std::vector<std::string> filenames;
   Status s = Env::Default()->GetChildren(src_dirname, &filenames);
   for (size_t i = 0; s.ok() && i < filenames.size(); ++i) {
-    bool is_dir;
+    bool is_dir = false;
     s = Env::Default()->IsDirectory(src_dirname + "/" + filenames[i], &is_dir);
     if (s.ok()) {
       if (is_dir) {

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -355,8 +355,8 @@ Status DeleteFilesInDirectory(const std::string& dirname) {
   return s;
 }
 
-Status SaveFilesInDirectory(
-    const std::string& src_dirname, const std::string& dst_dirname) {
+Status SaveFilesInDirectory(const std::string& src_dirname,
+                            const std::string& dst_dirname) {
   std::vector<std::string> filenames;
   Status s = Env::Default()->GetChildren(src_dirname, &filenames);
   for (size_t i = 0; s.ok() && i < filenames.size(); ++i) {
@@ -367,7 +367,7 @@ Status SaveFilesInDirectory(
         continue;
       }
       s = Env::Default()->LinkFile(src_dirname + "/" + filenames[i],
-                                  dst_dirname + "/" + filenames[i]);
+                                   dst_dirname + "/" + filenames[i]);
     }
   }
   return s;

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -401,12 +401,16 @@ Status DestroyUnverifiedSubdir(const std::string& dirname) {
   }
 
   const std::string kUnverifiedDirname = dirname + "/unverified";
-  s = Env::Default()->FileExists(kUnverifiedDirname);
+  if (s.ok()) {
+    s = Env::Default()->FileExists(kUnverifiedDirname);
+  }
   if (s.IsNotFound()) {
     return Status::OK();
   }
 
-  s = DeleteFilesInDirectory(kUnverifiedDirname);
+  if (s.ok()) {
+    s = DeleteFilesInDirectory(kUnverifiedDirname);
+  }
   if (s.ok()) {
     s = Env::Default()->DeleteDir(kUnverifiedDirname);
   }

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -346,5 +346,72 @@ std::shared_ptr<FileChecksumGenFactory> GetFileChecksumImpl(
   return std::make_shared<DbStressChecksumGenFactory>(internal_name);
 }
 
+Status DeleteFilesInDirectory(const std::string& dirname) {
+  std::vector<std::string> filenames;
+  Status s = Env::Default()->GetChildren(dirname, &filenames);
+  for (size_t i = 0; s.ok() && i < filenames.size(); ++i) {
+    s = Env::Default()->DeleteFile(dirname + "/" + filenames[i]);
+  }
+  return s;
+}
+
+Status SaveFilesInDirectory(
+    const std::string& src_dirname, const std::string& dst_dirname) {
+  std::vector<std::string> filenames;
+  Status s = Env::Default()->GetChildren(src_dirname, &filenames);
+  for (size_t i = 0; s.ok() && i < filenames.size(); ++i) {
+    bool is_dir;
+    s = Env::Default()->IsDirectory(src_dirname + "/" + filenames[i], &is_dir);
+    if (s.ok()) {
+      if (is_dir) {
+        continue;
+      }
+      s = Env::Default()->LinkFile(src_dirname + "/" + filenames[i],
+                                  dst_dirname + "/" + filenames[i]);
+    }
+  }
+  return s;
+}
+
+Status InitUnverifiedSubdir(const std::string& dirname) {
+  Status s = Env::Default()->FileExists(dirname);
+  if (s.IsNotFound()) {
+    return Status::OK();
+  }
+
+  const std::string kUnverifiedDirname = dirname + "/unverified";
+  if (s.ok()) {
+    s = Env::Default()->CreateDirIfMissing(kUnverifiedDirname);
+  }
+  if (s.ok()) {
+    // It might already exist with some stale contents. Delete any such
+    // contents.
+    s = DeleteFilesInDirectory(kUnverifiedDirname);
+  }
+  if (s.ok()) {
+    s = SaveFilesInDirectory(dirname, kUnverifiedDirname);
+  }
+  return s;
+}
+
+Status DestroyUnverifiedSubdir(const std::string& dirname) {
+  Status s = Env::Default()->FileExists(dirname);
+  if (s.IsNotFound()) {
+    return Status::OK();
+  }
+
+  const std::string kUnverifiedDirname = dirname + "/unverified";
+  s = Env::Default()->FileExists(kUnverifiedDirname);
+  if (s.IsNotFound()) {
+    return Status::OK();
+  }
+
+  s = DeleteFilesInDirectory(kUnverifiedDirname);
+  if (s.ok()) {
+    s = Env::Default()->DeleteDir(kUnverifiedDirname);
+  }
+  return s;
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -632,5 +632,11 @@ extern std::string GetNowNanos();
 
 std::shared_ptr<FileChecksumGenFactory> GetFileChecksumImpl(
     const std::string& name);
+
+Status DeleteFilesInDirectory(const std::string& dirname);
+Status SaveFilesInDirectory(
+    const std::string& src_dirname, const std::string& dst_dirname);
+Status DestroyUnverifiedSubdir(const std::string& dirname);
+Status InitUnverifiedSubdir(const std::string& dirname);
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -634,8 +634,8 @@ std::shared_ptr<FileChecksumGenFactory> GetFileChecksumImpl(
     const std::string& name);
 
 Status DeleteFilesInDirectory(const std::string& dirname);
-Status SaveFilesInDirectory(
-    const std::string& src_dirname, const std::string& dst_dirname);
+Status SaveFilesInDirectory(const std::string& src_dirname,
+                            const std::string& dst_dirname);
 Status DestroyUnverifiedSubdir(const std::string& dirname);
 Status InitUnverifiedSubdir(const std::string& dirname);
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -313,6 +313,7 @@ DECLARE_bool(enable_tiered_storage);  // set last_level_temperature
 DECLARE_int64(preclude_last_level_data_seconds);
 
 DECLARE_int32(verify_iterator_with_expected_state_one_in);
+DECLARE_bool(preserve_unverified_changes);
 
 DECLARE_uint64(readahead_size);
 DECLARE_uint64(initial_auto_readahead_size);

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -61,8 +61,7 @@ bool RunStressTest(StressTest* stress) {
 
   SharedState shared(db_stress_env, stress);
 
-  if (shared.ShouldVerifyAtBeginning() &&
-      FLAGS_preserve_unverified_changes) {
+  if (shared.ShouldVerifyAtBeginning() && FLAGS_preserve_unverified_changes) {
     Status s = InitUnverifiedSubdir(FLAGS_db);
     if (s.ok() && !FLAGS_expected_values_dir.empty()) {
       s = InitUnverifiedSubdir(FLAGS_expected_values_dir);

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -58,7 +58,22 @@ void ThreadBody(void* v) {
 
 bool RunStressTest(StressTest* stress) {
   SystemClock* clock = db_stress_env->GetSystemClock().get();
+
   SharedState shared(db_stress_env, stress);
+
+  if (shared.ShouldVerifyAtBeginning() &&
+      FLAGS_preserve_unverified_changes) {
+    Status s = InitUnverifiedSubdir(FLAGS_db);
+    if (s.ok() && !FLAGS_expected_values_dir.empty()) {
+      s = InitUnverifiedSubdir(FLAGS_expected_values_dir);
+    }
+    if (!s.ok()) {
+      fprintf(stderr, "Failed to setup unverified state dir: %s\n",
+              s.ToString().c_str());
+      exit(1);
+    }
+  }
+
   stress->InitDb(&shared);
   stress->FinishInitDb(&shared);
 
@@ -115,6 +130,15 @@ bool RunStressTest(StressTest* stress) {
         fprintf(stderr, "Crash-recovery verification failed :(\n");
       } else {
         fprintf(stdout, "Crash-recovery verification passed :)\n");
+        Status s = DestroyUnverifiedSubdir(FLAGS_db);
+        if (s.ok() && !FLAGS_expected_values_dir.empty()) {
+          s = DestroyUnverifiedSubdir(FLAGS_expected_values_dir);
+        }
+        if (!s.ok()) {
+          fprintf(stderr, "Failed to cleanup unverified state dir: %s\n",
+                  s.ToString().c_str());
+          exit(1);
+        }
       }
     }
 

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1044,4 +1044,12 @@ DEFINE_uint64(
     num_file_reads_for_auto_readahead, 0,
     "Num of sequential reads to enable auto prefetching during Iteration");
 
+DEFINE_bool(
+    preserve_unverified_changes, false,
+    "DB files of the current run will all be preserved in `FLAGS_db`. DB files "
+    "from the last run will be preserved in `FLAGS_db/unverified` until the "
+    "first verification succeeds. Expected state files from the last run will "
+    "be preserved similarly under `FLAGS_expected_values_dir/unverified` when "
+    "`--expected_values_dir` is nonempty.");
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2430,6 +2430,12 @@ void StressTest::Open(SharedState* shared) {
     fprintf(stdout, "Integrated BlobDB: blob cache disabled\n");
   }
 
+  if (FLAGS_preserve_unverified_changes && FLAGS_reopen != 0) {
+    fprintf(stderr,
+            "Reopen DB is incompatible with preserving unverified changes\n");
+    exit(1);
+  }
+
   fprintf(stdout, "DB path: [%s]\n", FLAGS_db.c_str());
 
   Status s;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2430,12 +2430,6 @@ void StressTest::Open(SharedState* shared) {
     fprintf(stdout, "Integrated BlobDB: blob cache disabled\n");
   }
 
-  if (FLAGS_preserve_unverified_changes && FLAGS_reopen != 0) {
-    fprintf(stderr,
-            "Reopen DB is incompatible with preserving unverified changes\n");
-    exit(1);
-  }
-
   fprintf(stdout, "DB path: [%s]\n", FLAGS_db.c_str());
 
   Status s;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2701,6 +2701,21 @@ void StressTest::Open(SharedState* shared) {
     exit(1);
 #endif
   }
+
+  if (FLAGS_preserve_unverified_changes) {
+    // Up until now, no live file should have become obsolete due to these
+    // options. After `DisableFileDeletions()` we can reenable auto compactions
+    // since, even if live files become obsolete, they won't be deleted.
+    assert(options_.avoid_flush_during_recovery);
+    assert(options_.disable_auto_compactions);
+    if (s.ok()) {
+      s = db_->DisableFileDeletions();
+    }
+    if (s.ok()) {
+      s = db_->EnableAutoCompaction(column_families_);
+    }
+  }
+
   if (!s.ok()) {
     fprintf(stderr, "open error: %s\n", s.ToString().c_str());
     exit(1);
@@ -3213,6 +3228,20 @@ void InitializeOptionsGeneral(
               status.ToString().c_str());
       exit(1);
     }
+  }
+
+  if (FLAGS_preserve_unverified_changes) {
+    if (!options.avoid_flush_during_recovery) {
+      fprintf(stderr,
+              "WARNING: flipping `avoid_flush_during_recovery` to true for "
+              "`preserve_unverified_changes` to keep all files\n");
+      options.avoid_flush_during_recovery = true;
+    }
+    // Together with `avoid_flush_during_recovery == true`, this will prevent
+    // live files from becoming obsolete and deleted between `DB::Open()` and
+    // `DisableFileDeletions()` due to flush or compaction. We do not need to
+    // warn the user since we will reenable compaction soon.
+    options.disable_auto_compactions = true;
   }
 
   options.table_properties_collector_factories.emplace_back(

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -280,6 +280,12 @@ int db_stress_tool(int argc, char** argv) {
     }
   }
 
+  if (FLAGS_preserve_unverified_changes && FLAGS_reopen != 0) {
+    fprintf(stderr,
+            "Reopen DB is incompatible with preserving unverified changes\n");
+    exit(1);
+  }
+
 #ifndef NDEBUG
   KillPoint* kp = KillPoint::GetInstance();
   kp->rocksdb_kill_odds = FLAGS_kill_random_test;


### PR DESCRIPTION
In `db_stress`, DB and expected state files containing changes leading up to a verification failure are often deleted, which makes debugging such failures difficult. On the DB side, flushed WAL files and compacted SST files are marked obsolete and then deleted. Without those files, we cannot pinpoint where a key that failed verification changed unexpectedly. On the expected state side, files for verifying prefix-recoverability in the presence of unsynced data loss are deleted before verification. These include a baseline state file containing the expected state at the time of the last successful verification, and a trace file containing all operations since then. Without those files, we cannot know the sequence of DB operations expected to be recovered.

This PR attempts to address this gap with a new `db_stress` flag: `preserve_unverified_changes`. Setting `preserve_unverified_changes=1` has two effects.

First, prior to startup verification, `db_stress` hardlinks all DB and expected state files in "unverified/" subdirectories of `FLAGS_db` and `FLAGS_expected_values_dir`. The separate directories are needed because the pre-verification opening process deletes files written by the previous `db_stress` run as described above. These "unverified/" subdirectories are cleaned up following startup verification success.

I considered other approaches for preserving DB files through startup verification, like using a read-only DB or preventing deletion of DB files externally, e.g., in the `Env` layer. However, I decided against it since such an approach would not work for expected state files, and I did not want to change the DB management logic. If there were a way to disable DB file deletions before regular DB open, I would have preferred to use that.

Second, `db_stress` attempts to keep all DB and expected state files that were live at some point since the start of the `db_stress` run. This is a bit tricky and involves the following changes.

- Open the DB with `disable_auto_compactions=1` and `avoid_flush_during_recovery=1`
- DisableFileDeletions()
- EnableAutoCompaction()

For this part, too, I would have preferred to use a hypothetical API that disables DB file deletion before regular DB open.