### PR TITLE
db.h: MultiGet: forward to more efficient overload

### DIFF
--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -669,22 +669,10 @@ class DB {
                         ColumnFamilyHandle* column_family,
                         const size_t num_keys, const Slice* keys,
                         PinnableSlice* values, Status* statuses,
-                        const bool /*sorted_input*/ = false) {
-    std::vector<ColumnFamilyHandle*> cf;
-    std::vector<Slice> user_keys;
-    std::vector<Status> status;
-    std::vector<std::string> vals;
-
-    for (size_t i = 0; i < num_keys; ++i) {
-      cf.emplace_back(column_family);
-      user_keys.emplace_back(keys[i]);
-    }
-    status = MultiGet(options, cf, user_keys, &vals);
-    std::copy(status.begin(), status.end(), statuses);
-    for (auto& value : vals) {
-      values->PinSelf(value);
-      values++;
-    }
+                        const bool sorted_input = false) {
+    std::string* timestamps = nullptr;
+    MultiGet(options, column_family, num_keys, keys, values, timestamps,
+             statuses, sorted_input);
   }
 
   virtual void MultiGet(const ReadOptions& options,


### PR DESCRIPTION
Forward MultiGet to overload with single cf.