### PR TITLE
[rocksjava] improve copying of Env in Options

### DIFF
--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -31,6 +31,7 @@ public class DBOptions extends RocksObject
   public DBOptions() {
     super(newDBOptions());
     numShardBits_ = DEFAULT_NUM_SHARD_BITS;
+    env_ = Env.getDefault();
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -66,7 +66,7 @@ public class Options extends RocksObject
       final ColumnFamilyOptions columnFamilyOptions) {
     super(newOptions(dbOptions.nativeHandle_,
         columnFamilyOptions.nativeHandle_));
-    env_ = Env.getDefault();
+    env_ = dbOptions.getEnv() != null ? dbOptions.getEnv() : Env.getDefault();
   }
 
   /**

--- a/java/src/test/java/org/rocksdb/MixedOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/MixedOptionsTest.java
@@ -52,4 +52,34 @@ public class MixedOptionsTest {
       }
     }
   }
+
+  @Test
+  public void mixedOptionsEnvTest() {
+    try (final ColumnFamilyOptions cfOptions = new ColumnFamilyOptions();
+         final DBOptions dbOptions = new DBOptions()) {
+      assertThat(dbOptions.getEnv()).isNotNull();
+      assertThat(dbOptions.getEnv()).isSameAs(Env.getDefault());
+      final Env memEnv = new RocksMemEnv(Env.getDefault());
+
+      try (final Options options = new Options(dbOptions, cfOptions)) {
+        assertThat(options.getEnv()).isSameAs(Env.getDefault());
+      }
+
+      dbOptions.setEnv(memEnv);
+      memEnv.setBackgroundThreads(4, Priority.LOW);
+      Env.getDefault().setBackgroundThreads(2, Priority.HIGH);
+      assertThat(dbOptions.getEnv().getBackgroundThreads(Priority.LOW)).isEqualTo(4);
+      assertThat(dbOptions.getEnv().getBackgroundThreads(Priority.HIGH)).isEqualTo(2);
+      assertThat(Env.getDefault().getBackgroundThreads(Priority.LOW)).isEqualTo(4);
+      assertThat(Env.getDefault().getBackgroundThreads(Priority.HIGH)).isEqualTo(2);
+
+      try (final Options options = new Options(dbOptions, cfOptions)) {
+        assertThat(options.getEnv().getBackgroundThreads(Priority.LOW)).isEqualTo(4);
+        assertThat(options.getEnv().getBackgroundThreads(Priority.HIGH)).isEqualTo(2);
+
+        assertThat(options.getEnv()).isNotSameAs(Env.getDefault());
+        assertThat(options.getEnv()).isSameAs(memEnv);
+      }
+    }
+  }
 }


### PR DESCRIPTION
Closes https://github.com/facebook/rocksdb/issues/9909

- Constructing an Options from a DBOptions should use the Env from the DBOptions
- DBOptions should be constructed with the default Env as the env_, rather than null. Why ever not ?