### PR TITLE
Add wide-column support to iterators

### DIFF
--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -70,6 +70,7 @@ class ArenaWrappedDBIter : public Iterator {
   void Prev() override { db_iter_->Prev(); }
   Slice key() const override { return db_iter_->key(); }
   Slice value() const override { return db_iter_->value(); }
+  const WideColumns& columns() const override { return db_iter_->columns(); }
   Status status() const override { return db_iter_->status(); }
   Slice timestamp() const override { return db_iter_->timestamp(); }
   bool IsBlob() const { return db_iter_->IsBlob(); }

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -76,7 +76,6 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       verify_checksums_(read_options.verify_checksums),
       expose_blob_index_(expose_blob_index),
       is_blob_(false),
-      is_wide_(false),
       arena_mode_(arena_mode),
       db_impl_(db_impl),
       cfd_(cfd),
@@ -178,7 +177,6 @@ bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
                                   const Slice& blob_index) {
   assert(!is_blob_);
   assert(blob_value_.empty());
-  assert(!is_wide_);
   assert(wide_columns_.empty());
 
   if (expose_blob_index_) {  // Stacked BlobDB implementation
@@ -216,7 +214,6 @@ bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
 }
 
 bool DBIter::SetWideColumnValueFromEntity(Slice slice) {
-  assert(!is_wide_);
   assert(wide_columns_.empty());
 
   const Status s = WideColumnSerialization::Deserialize(slice, wide_columns_);
@@ -227,7 +224,6 @@ bool DBIter::SetWideColumnValueFromEntity(Slice slice) {
     return false;
   }
 
-  is_wide_ = true;
   return true;
 }
 
@@ -279,7 +275,6 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
 
   assert(!is_blob_);
   assert(blob_value_.empty());
-  assert(!is_wide_);
   assert(wide_columns_.empty());
 
   do {
@@ -580,7 +575,6 @@ bool DBIter::MergeValuesNewToOld() {
       }
 
       ResetBlobValue();
-      assert(!is_wide_);
 
       // iter_ is positioned after put
       iter_.Next();
@@ -947,7 +941,6 @@ bool DBIter::FindValueForCurrentKey() {
 
   assert(!is_blob_);
   assert(blob_value_.empty());
-  assert(!is_wide_);
   assert(wide_columns_.empty());
 
   switch (last_key_entry_type) {
@@ -987,7 +980,6 @@ bool DBIter::FindValueForCurrentKey() {
         }
 
         ResetBlobValue();
-        assert(!is_wide_);
 
         return true;
       } else if (last_not_merge_type == kTypeWideColumnEntity) {
@@ -1073,7 +1065,6 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
 
   assert(!is_blob_);
   assert(blob_value_.empty());
-  assert(!is_wide_);
   assert(wide_columns_.empty());
 
   while (true) {
@@ -1213,7 +1204,6 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
       }
 
       ResetBlobValue();
-      assert(!is_wide_);
 
       return true;
     } else if (ikey.type == kTypeWideColumnEntity) {

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -574,8 +574,7 @@ bool DBIter::MergeValuesNewToOld() {
         return false;
       }
       valid_ = true;
-      const Slice blob_value = value();
-      Status s = Merge(&blob_value, ikey.user_key);
+      Status s = Merge(&blob_value_, ikey.user_key);
       if (!s.ok()) {
         return false;
       }
@@ -982,8 +981,7 @@ bool DBIter::FindValueForCurrentKey() {
           return false;
         }
         valid_ = true;
-        const Slice blob_value = value();
-        s = Merge(&blob_value, saved_key_.GetUserKey());
+        s = Merge(&blob_value_, saved_key_.GetUserKey());
         if (!s.ok()) {
           return false;
         }
@@ -1209,8 +1207,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
         return false;
       }
       valid_ = true;
-      const Slice blob_value = value();
-      Status s = Merge(&blob_value, saved_key_.GetUserKey());
+      Status s = Merge(&blob_value_, saved_key_.GetUserKey());
       if (!s.ok()) {
         return false;
       }

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -160,7 +160,6 @@ class DBIter final : public Iterator {
   }
   Slice value() const override {
     assert(valid_);
-    assert(!is_blob_ || !is_wide_);
 
     if (wide_columns_.empty() ||
         wide_columns_[0].name() != kDefaultWideColumnName) {
@@ -309,7 +308,6 @@ class DBIter final : public Iterator {
   }
 
   void SetWideColumnValueFromPlain(const Slice& slice) {
-    assert(!is_wide_);
     assert(wide_columns_.empty());
 
     wide_columns_.emplace_back(kDefaultWideColumnName, slice);
@@ -318,7 +316,6 @@ class DBIter final : public Iterator {
   bool SetWideColumnValueFromEntity(Slice slice);
 
   void ResetWideColumnValue() {
-    is_wide_ = false;
     wide_columns_.clear();
   }
 
@@ -383,7 +380,6 @@ class DBIter final : public Iterator {
   // the stacked BlobDB implementation is used, false otherwise.
   bool expose_blob_index_;
   bool is_blob_;
-  bool is_wide_;
   bool arena_mode_;
   // List of operands for merge operator.
   MergeContext merge_context_;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -162,24 +162,12 @@ class DBIter final : public Iterator {
     assert(valid_);
     assert(!is_blob_ || !is_wide_);
 
-    if (is_wide_) {
-      if (wide_columns_.empty() ||
-          wide_columns_[0].name() != kDefaultWideColumnName) {
-        return Slice();
-      }
-
-      return wide_columns_[0].value();
-    } else if (!expose_blob_index_ && is_blob_) {
-      return blob_value_;
-    } else if (current_entry_is_merged_) {
-      // If pinned_value_ is set then the result of merge operator is one of
-      // the merge operands and we should return it.
-      return pinned_value_.data() ? pinned_value_ : saved_value_;
-    } else if (direction_ == kReverse) {
-      return pinned_value_;
-    } else {
-      return iter_.value();
+    if (wide_columns_.empty() ||
+        wide_columns_[0].name() != kDefaultWideColumnName) {
+      return Slice();
     }
+
+    return wide_columns_[0].value();
   }
 
   const WideColumns& columns() const override {

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -159,7 +159,7 @@ class DBIter final : public Iterator {
     }
   }
   Slice value() const override {
-    // assert(valid_);  // FIXME
+    assert(valid_);
     assert(!is_blob_ || !is_wide_);
 
     if (is_wide_) {
@@ -320,7 +320,14 @@ class DBIter final : public Iterator {
     blob_value_.Reset();
   }
 
-  bool SetWideColumnValue(Slice slice, ValueType value_type);
+  void SetWideColumnValueFromPlain(const Slice& slice) {
+    assert(!is_wide_);
+    assert(wide_columns_.empty());
+
+    wide_columns_.emplace_back(kDefaultWideColumnName, slice);
+  }
+
+  bool SetWideColumnValueFromEntity(Slice slice);
 
   void ResetWideColumnValue() {
     is_wide_ = false;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -161,12 +161,7 @@ class DBIter final : public Iterator {
   Slice value() const override {
     assert(valid_);
 
-    if (wide_columns_.empty() ||
-        wide_columns_[0].name() != kDefaultWideColumnName) {
-      return Slice();
-    }
-
-    return wide_columns_[0].value();
+    return value_;
   }
 
   const WideColumns& columns() const override {
@@ -307,15 +302,18 @@ class DBIter final : public Iterator {
     blob_value_.Reset();
   }
 
-  void SetWideColumnValueFromPlain(const Slice& slice) {
+  void SetValueAndColumnsFromPlain(const Slice& slice) {
+    assert(value_.empty());
     assert(wide_columns_.empty());
 
+    value_ = slice;
     wide_columns_.emplace_back(kDefaultWideColumnName, slice);
   }
 
-  bool SetWideColumnValueFromEntity(Slice slice);
+  bool SetValueAndColumnsFromEntity(Slice slice);
 
-  void ResetWideColumnValue() {
+  void ResetValueAndColumns() {
+    value_.clear();
     wide_columns_.clear();
   }
 
@@ -343,6 +341,9 @@ class DBIter final : public Iterator {
   Slice pinned_value_;
   // for prefix seek mode to support prev()
   PinnableSlice blob_value_;
+  // Value of the default column
+  Slice value_;
+  // All columns (i.e. name-value pairs)
   WideColumns wide_columns_;
   Statistics* statistics_;
   uint64_t max_skip_;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -159,7 +159,7 @@ class DBIter final : public Iterator {
     }
   }
   Slice value() const override {
-    assert(valid_);
+    // assert(valid_);  // FIXME
     assert(!is_blob_ || !is_wide_);
 
     if (is_wide_) {
@@ -320,7 +320,7 @@ class DBIter final : public Iterator {
     blob_value_.Reset();
   }
 
-  bool SetWideColumnValueIfNeeded(Slice wide_columns_slice);
+  bool SetWideColumnValue(Slice slice, ValueType value_type);
 
   void ResetWideColumnValue() {
     is_wide_ = false;

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -38,6 +38,9 @@ TEST_F(DBWideBasicTest, PutEntity) {
   constexpr char third_value[] = "baz";
 
   auto verify = [&]() {
+    const WideColumns expected_third_columns{
+        {kDefaultWideColumnName, third_value}};
+
     {
       PinnableSlice result;
       ASSERT_OK(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), first_key,
@@ -78,8 +81,7 @@ TEST_F(DBWideBasicTest, PutEntity) {
       ASSERT_OK(db_->GetEntity(ReadOptions(), db_->DefaultColumnFamily(),
                                third_key, &result));
 
-      const WideColumns expected_columns{{kDefaultWideColumnName, third_value}};
-      ASSERT_EQ(result.columns(), expected_columns);
+      ASSERT_EQ(result.columns(), expected_third_columns);
     }
 
     {
@@ -110,18 +112,21 @@ TEST_F(DBWideBasicTest, PutEntity) {
       ASSERT_OK(iter->status());
       ASSERT_EQ(iter->key(), first_key);
       ASSERT_EQ(iter->value(), first_value_of_default_column);
+      ASSERT_EQ(iter->columns(), first_columns);
 
       iter->Next();
       ASSERT_TRUE(iter->Valid());
       ASSERT_OK(iter->status());
       ASSERT_EQ(iter->key(), second_key);
       ASSERT_TRUE(iter->value().empty());
+      ASSERT_EQ(iter->columns(), second_columns);
 
       iter->Next();
       ASSERT_TRUE(iter->Valid());
       ASSERT_OK(iter->status());
       ASSERT_EQ(iter->key(), third_key);
       ASSERT_EQ(iter->value(), third_value);
+      ASSERT_EQ(iter->columns(), expected_third_columns);
 
       iter->Next();
       ASSERT_FALSE(iter->Valid());
@@ -132,18 +137,21 @@ TEST_F(DBWideBasicTest, PutEntity) {
       ASSERT_OK(iter->status());
       ASSERT_EQ(iter->key(), third_key);
       ASSERT_EQ(iter->value(), third_value);
+      ASSERT_EQ(iter->columns(), expected_third_columns);
 
       iter->Prev();
       ASSERT_TRUE(iter->Valid());
       ASSERT_OK(iter->status());
       ASSERT_EQ(iter->key(), second_key);
       ASSERT_TRUE(iter->value().empty());
+      ASSERT_EQ(iter->columns(), second_columns);
 
       iter->Prev();
       ASSERT_TRUE(iter->Valid());
       ASSERT_OK(iter->status());
       ASSERT_EQ(iter->key(), first_key);
       ASSERT_EQ(iter->value(), first_value_of_default_column);
+      ASSERT_EQ(iter->columns(), first_columns);
 
       iter->Prev();
       ASSERT_FALSE(iter->Valid());

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -17,6 +17,8 @@ namespace ROCKSDB_NAMESPACE {
 
 const Slice kDefaultWideColumnName;
 
+const WideColumns kNoWideColumns;
+
 Status WideColumnSerialization::Serialize(const WideColumns& columns,
                                           std::string& output) {
   if (columns.size() >

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -75,20 +75,23 @@ class Iterator : public Cleanable {
   virtual void Prev() = 0;
 
   // Return the key for the current entry.  The underlying storage for
-  // the returned slice is valid only until the next modification of
-  // the iterator.
+  // the returned slice is valid only until the next modification of the
+  // iterator (i.e. the next SeekToFirst/SeekToLast/Seek/SeekForPrev/Next/Prev
+  // operation).
   // REQUIRES: Valid()
   virtual Slice key() const = 0;
 
   // Return the value for the current entry.  The underlying storage for
-  // the returned slice is valid only until the next modification of
-  // the iterator.
+  // the returned slice is valid only until the next modification of the
+  // iterator (i.e. the next SeekToFirst/SeekToLast/Seek/SeekForPrev/Next/Prev
+  // operation).
   // REQUIRES: Valid()
   virtual Slice value() const = 0;
 
   // Return the wide columns for the current entry.  The underlying storage for
   // the returned structure is valid only until the next modification of the
-  // iterator.
+  // iterator (i.e. the next SeekToFirst/SeekToLast/Seek/SeekForPrev/Next/Prev
+  // operation).
   // REQUIRES: Valid()
   virtual const WideColumns& columns() const {
     assert(false);

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -19,9 +19,11 @@
 #pragma once
 
 #include <string>
+
 #include "rocksdb/cleanable.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
+#include "rocksdb/wide_columns.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -83,6 +85,15 @@ class Iterator : public Cleanable {
   // the iterator.
   // REQUIRES: Valid()
   virtual Slice value() const = 0;
+
+  // Return the wide columns for the current entry.  The underlying storage for
+  // the returned structure is valid only until the next modification of the
+  // iterator.
+  // REQUIRES: Valid()
+  virtual const WideColumns& columns() const {
+    assert(false);
+    return kNoWideColumns;
+  }
 
   // If an error has occurred, return it.  Else return an ok status.
   // If non-blocking IO is requested and this operation cannot be

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -76,6 +76,9 @@ using WideColumns = std::vector<WideColumn>;
 // The anonymous default wide column (an empty Slice).
 extern const Slice kDefaultWideColumnName;
 
+// An empty set of wide columns.
+extern const WideColumns kNoWideColumns;
+
 // A self-contained collection of wide columns. Used for the results of
 // wide-column queries.
 class PinnableWideColumns {


### PR DESCRIPTION
Summary:
The patch extends the iterator API with a new `columns` method which
can be used to retrieve all wide columns for the current key. Similarly to
the `Get` and `GetEntity` APIs, the classic `value` API returns the value
of the default (anonymous) column for wide-column entities, and `columns`
returns an entity with a single default column for plain old key-values.
(The goal here is to maintain the invariant that `value()` is the same as
the value of the default column in `columns()`.) The patch also involves a
smaller refactoring: historically, `value()` was implemented using a bunch
of conditions, that is, the `Slice` to be returned was decided based on the
direction of the iteration, whether a merge had been done etc. when the
method was called; with the patch, the value to be exposed is stored in a
member `Slice value_` when the iterator lands on a new key, and `value()`
simply returns this `Slice`.

Test Plan:
Ran `make check` and a simple blackbox crash test.