### PR TITLE
Support kRemoveAndSkip for compaction filter to skip one user key

### DIFF
--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -194,6 +194,7 @@ void CompactionIterator::Next() {
 }
 
 bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
+                                              bool* just_skip_current_user_key,
                                               Slice* skip_until) {
   // TODO: support compaction filter for wide-column entities
   if (!compaction_filter_ ||
@@ -322,6 +323,9 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
       current_key_.UpdateInternalKey(ikey_.sequence, ikey_.type);
     }
     value_ = compaction_filter_value_;
+  } else if (filter == CompactionFilter::Decision::kRemoveAndSkip) {
+    *need_skip = true;
+    *just_skip_current_user_key = true;
   } else if (filter == CompactionFilter::Decision::kRemoveAndSkipUntil) {
     *need_skip = true;
     compaction_filter_skip_until_.ConvertFromUserKey(kMaxSequenceNumber,
@@ -396,11 +400,15 @@ void CompactionIterator::NextFromInput() {
     iter_stats_.total_input_raw_key_bytes += key_.size();
     iter_stats_.total_input_raw_value_bytes += value_.size();
 
-    // If need_skip is true, we should seek the input iterator
+    // If need_skip is true, we should only skip current user key or seek the input iterator
     // to internal key skip_until and continue from there.
     bool need_skip = false;
+    // If just_skip_current_user_key is true, we should only skip current user key and let the input iterator
+    // to next user key.
+    bool just_skip_current_user_key = false;
     // Points either into compaction_filter_skip_until_ or into
     // merge_helper_->compaction_filter_skip_until_.
+    // Notes: skip_until will be ignored if just_skip_current_user_key is true.
     Slice skip_until;
 
     bool user_key_equal_without_ts = false;
@@ -466,7 +474,7 @@ void CompactionIterator::NextFromInput() {
       // Apply the compaction filter to the first committed version of the user
       // key.
       if (current_key_committed_ &&
-          !InvokeFilterIfNeeded(&need_skip, &skip_until)) {
+          !InvokeFilterIfNeeded(&need_skip, &just_skip_current_user_key, &skip_until)) {
         break;
       }
     } else {
@@ -488,7 +496,7 @@ void CompactionIterator::NextFromInput() {
         // Apply the compaction filter to the first committed version of the
         // user key.
         if (current_key_committed_ &&
-            !InvokeFilterIfNeeded(&need_skip, &skip_until)) {
+            !InvokeFilterIfNeeded(&need_skip, &just_skip_current_user_key, &skip_until)) {
           break;
         }
       }
@@ -926,7 +934,18 @@ void CompactionIterator::NextFromInput() {
     }
 
     if (need_skip) {
-      SkipUntil(skip_until);
+      if (just_skip_current_user_key) {
+        ParsedInternalKey next_ikey;
+        AdvanceInputIter();
+        while (!IsPausingManualCompaction() && !IsShuttingDown() &&
+              input_.Valid() &&
+              (ParseInternalKey(input_.key(), &next_ikey, allow_data_in_errors_).ok()) &&
+              cmp_->EqualWithoutTimestamp(ikey_.user_key, next_ikey.user_key)) {
+          AdvanceInputIter();
+        }
+      } else {
+        SkipUntil(skip_until);
+      }
     }
   }
 

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -280,7 +280,7 @@ class CompactionIterator {
 
   // Invoke compaction filter if needed.
   // Return true on success, false on failures (e.g.: kIOError).
-  bool InvokeFilterIfNeeded(bool* need_skip, Slice* skip_until);
+  bool InvokeFilterIfNeeded(bool* need_skip, bool* just_skip_current_user_key, Slice* skip_until);
 
   // Given a sequence number, return the sequence number of the
   // earliest snapshot that this sequence number is visible in.

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -40,6 +40,7 @@ class CompactionFilter : public Customizable {
     kKeep,
     kRemove,
     kChangeValue,
+    kRemoveAndSkip,
     kRemoveAndSkipUntil,
     kChangeBlobIndex,  // used internally by BlobDB.
     kIOError,          // used internally by BlobDB.


### PR DESCRIPTION
Summary: Add new return for compaction filter.
If it decide to remove the key, returning kRemoveAndSkip. Similar to kRemoveAndSkipUntil, this one is tricky because in this case the compaction does not insert deletion marker for the key. This means older version of the key may reappears as a result. It is more efficient to simply dropping the key and more flexible than kRemoveAndSkipUntil. Note that multiple versions of the same user key from the input of the compaction are dropped.