### PR TITLE
Reset pessimistic transaction's read/commit timestamps during Initialize()

### DIFF
--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -100,6 +100,9 @@ void PessimisticTransaction::Initialize(const TransactionOptions& txn_options) {
   use_only_the_last_commit_time_batch_for_recovery_ =
       txn_options.use_only_the_last_commit_time_batch_for_recovery;
   skip_prepare_ = txn_options.skip_prepare;
+
+  read_timestamp_ = kMaxTxnTimestamp;
+  commit_timestamp_ = kMaxTxnTimestamp;
 }
 
 PessimisticTransaction::~PessimisticTransaction() {

--- a/utilities/transactions/timestamped_snapshot_test.cc
+++ b/utilities/transactions/timestamped_snapshot_test.cc
@@ -119,21 +119,39 @@ TEST_P(TransactionTest, ReuseExistingTxn) {
   Transaction* txn = db->BeginTransaction(WriteOptions(), TransactionOptions());
   assert(txn);
   ASSERT_OK(txn->SetName("txn0"));
-  ASSERT_OK(txn->Put("a", "v"));
+  ASSERT_OK(txn->Put("a", "v1"));
   ASSERT_OK(txn->Prepare());
+
+  auto notifier = std::make_shared<TsCheckingTxnNotifier>();
+  std::shared_ptr<const Snapshot> snapshot1;
   Status s =
-      txn->CommitAndTryCreateSnapshot(/*notifier=*/nullptr, /*commit_ts=*/100);
+      txn->CommitAndTryCreateSnapshot(notifier, /*commit_ts=*/100, &snapshot1);
   ASSERT_OK(s);
+  ASSERT_EQ(100, snapshot1->GetTimestamp());
 
   Transaction* txn1 =
       db->BeginTransaction(WriteOptions(), TransactionOptions(), txn);
   assert(txn1 == txn);
   ASSERT_OK(txn1->SetName("txn1"));
-  ASSERT_OK(txn->Put("a", "v"));
+  ASSERT_OK(txn->Put("a", "v2"));
   ASSERT_OK(txn->Prepare());
-  s = txn->CommitAndTryCreateSnapshot(/*notifier=*/nullptr, /*commit_ts=*/110);
+  std::shared_ptr<const Snapshot> snapshot2;
+  s = txn->CommitAndTryCreateSnapshot(notifier, /*commit_ts=*/110, &snapshot2);
   ASSERT_OK(s);
+  ASSERT_EQ(110, snapshot2->GetTimestamp());
   delete txn;
+
+  {
+    std::string value;
+    ReadOptions read_opts;
+    read_opts.snapshot = snapshot1.get();
+    ASSERT_OK(db->Get(read_opts, "a", &value));
+    ASSERT_EQ("v1", value);
+
+    read_opts.snapshot = snapshot2.get();
+    ASSERT_OK(db->Get(read_opts, "a", &value));
+    ASSERT_EQ("v2", value);
+  }
 }
 
 TEST_P(TransactionTest, CreateSnapshotWhenCommit) {


### PR DESCRIPTION
RocksDB allows reusing old `Transaction` objects when creating new ones. Therefore, we need to
reset the transaction's read and commit timestamps back to default values `kMaxTxnTimestamp`.
Otherwise, `CommitAndTryCreateSnapshot()` may fail with "Status::InvalidArgument("Different commit ts specified")".

Test plan:
make check