### PR TITLE
Fix a MultiGet crash

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -511,7 +511,7 @@ class FilePickerMultiGet {
   MultiGetRange& GetRange() { return range_; }
 
   void ReplaceRange(const MultiGetRange& other) {
-    assert(!RemainingOverlapInLevel);
+    assert(!RemainingOverlapInLevel());
     range_ = other;
     current_level_range_ = other;
   }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -511,7 +511,7 @@ class FilePickerMultiGet {
   MultiGetRange& GetRange() { return range_; }
 
   void ReplaceRange(const MultiGetRange& other) {
-    assert(!RemainingOverlapInLevel());
+    assert(curr_level_ == 0 || !RemainingOverlapInLevel());
     range_ = other;
     current_level_range_ = other;
   }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -511,6 +511,7 @@ class FilePickerMultiGet {
   MultiGetRange& GetRange() { return range_; }
 
   void ReplaceRange(const MultiGetRange& other) {
+    assert(!RemainingOverlapInLevel);
     range_ = other;
     current_level_range_ = other;
   }
@@ -2727,8 +2728,9 @@ Status Version::ProcessBatch(
     f = fp.GetNextFileInLevel();
   }
   // Split the current batch only if some keys are likely in this level and
-  // some are not.
-  if (s.ok() && !leftover.empty() && !range.empty()) {
+  // some are not. Only split if we're done with this level, i.e f is null.
+  // Otherwise, it means there are more files in this level to look at.
+  if (s.ok() && !f && !leftover.empty() && !range.empty()) {
     fp.ReplaceRange(range);
     batches.emplace_back(&leftover, fp);
     to_process.emplace_back(batches.size() - 1);


### PR DESCRIPTION
Fix a bug in the async IO/coroutine version of MultiGet that may cause a segfault or assertion failure due to accessing an invalid file index in a LevelFilesBrief. The bug is that when a MultiGetRange is split into two, we may re-process keys in the original range that were already marked to be skipped (in ```current_level_range_```) due to not overlapping the level.