### PR TITLE
Add enable_split_merge option for CompressedSecondaryCache

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,7 @@
 * Added new perf context counters `block_cache_standalone_handle_count`, `block_cache_real_handle_count`,`compressed_sec_cache_insert_real_count`, `compressed_sec_cache_insert_dummy_count`, `compressed_sec_cache_uncompressed_bytes`, and `compressed_sec_cache_compressed_bytes`.
 * Memory for blobs which are to be inserted into the blob cache is now allocated using the cache's allocator (see #10628 and #10647).
 * HyperClockCache is an experimental, lock-free Cache alternative for block cache that offers much improved CPU efficiency under high parallel load or high contention, with some caveats. As much as 4.5x higher ops/sec vs. LRUCache has been seen in db_bench under high parallel load.
+* `CompressedSecondaryCacheOptions::enable_custom_split_merge` is added for enabling the custom split and merge feature, which split the compressed value into chunks so that they may better fit jemalloc bins.
 
 ### Performance Improvements
 * Iterator performance is improved for `DeleteRange()` users. Internally, iterator will skip to the end of a range tombstone when possible, instead of looping through each key and check individually if a key is range deleted.

--- a/cache/cache.cc
+++ b/cache/cache.cc
@@ -58,6 +58,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    compress_format_version),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"enable_custom_split_merge",
+         {offsetof(struct CompressedSecondaryCacheOptions,
+                   enable_custom_split_merge),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
 };
 #endif  // ROCKSDB_LITE
 

--- a/cache/compressed_secondary_cache.cc
+++ b/cache/compressed_secondary_cache.cc
@@ -52,14 +52,14 @@ std::unique_ptr<SecondaryCacheResultHandle> CompressedSecondaryCache::Lookup(
     return nullptr;
   }
 
-  CacheAllocationPtr* ptr;
+  CacheAllocationPtr* ptr{nullptr};
+  CacheAllocationPtr merged_value;
   size_t handle_value_charge{0};
   if (cache_options_.enable_custom_split_merge) {
     CacheValueChunk* value_chunk_ptr =
         reinterpret_cast<CacheValueChunk*>(handle_value);
-    CacheAllocationPtr merged_value =
-        MergeChunksIntoValue(value_chunk_ptr, handle_value_charge);
-    ptr = new CacheAllocationPtr(std::move(merged_value));
+    merged_value = MergeChunksIntoValue(value_chunk_ptr, handle_value_charge);
+    ptr = &merged_value;
   } else {
     ptr = reinterpret_cast<CacheAllocationPtr*>(handle_value);
     handle_value_charge = cache_->GetCharge(lru_handle);

--- a/cache/compressed_secondary_cache.cc
+++ b/cache/compressed_secondary_cache.cc
@@ -21,11 +21,13 @@ CompressedSecondaryCache::CompressedSecondaryCache(
     double high_pri_pool_ratio, double low_pri_pool_ratio,
     std::shared_ptr<MemoryAllocator> memory_allocator, bool use_adaptive_mutex,
     CacheMetadataChargePolicy metadata_charge_policy,
-    CompressionType compression_type, uint32_t compress_format_version)
+    CompressionType compression_type, uint32_t compress_format_version,
+    bool enable_custom_split_merge)
     : cache_options_(capacity, num_shard_bits, strict_capacity_limit,
                      high_pri_pool_ratio, low_pri_pool_ratio, memory_allocator,
                      use_adaptive_mutex, metadata_charge_policy,
-                     compression_type, compress_format_version) {
+                     compression_type, compress_format_version,
+                     enable_custom_split_merge) {
   cache_ =
       NewLRUCache(capacity, num_shard_bits, strict_capacity_limit,
                   high_pri_pool_ratio, memory_allocator, use_adaptive_mutex,
@@ -44,19 +46,30 @@ std::unique_ptr<SecondaryCacheResultHandle> CompressedSecondaryCache::Lookup(
     return nullptr;
   }
 
-  void* handle_value = cache_->Value(lru_handle);
-  if (handle_value == nullptr) {
-    cache_->Release(lru_handle, /*erase_if_last_ref=*/false);
-    return nullptr;
-  }
+  CacheAllocationPtr* ptr;
+  size_t handle_value_charge{0};
+  if (cache_options_.enable_custom_split_merge) {
+    CacheValueChunk* handle_value =
+        reinterpret_cast<CacheValueChunk*>(cache_->Value(lru_handle));
+    CacheAllocationPtr merged_value =
+        MergeChunksIntoValue(handle_value, handle_value_charge);
+    ptr = &merged_value;
+  } else {
+    void* handle_value = cache_->Value(lru_handle);
+    if (handle_value == nullptr) {
+      cache_->Release(lru_handle, /*erase_if_last_ref=*/false);
+      return nullptr;
+    }
 
-  CacheAllocationPtr* ptr = reinterpret_cast<CacheAllocationPtr*>(handle_value);
+    ptr = reinterpret_cast<CacheAllocationPtr*>(handle_value);
+    handle_value_charge = cache_->GetCharge(lru_handle);
+  }
 
   Status s;
   void* value{nullptr};
   size_t charge{0};
   if (cache_options_.compression_type == kNoCompression) {
-    s = create_cb(ptr->get(), cache_->GetCharge(lru_handle), &value, &charge);
+    s = create_cb(ptr->get(), handle_value_charge, &value, &charge);
   } else {
     UncompressionContext uncompression_context(cache_options_.compression_type);
     UncompressionInfo uncompression_info(uncompression_context,
@@ -84,7 +97,9 @@ std::unique_ptr<SecondaryCacheResultHandle> CompressedSecondaryCache::Lookup(
   if (advise_erase) {
     cache_->Release(lru_handle, /*erase_if_last_ref=*/true);
     // Insert a dummy handle.
-    cache_->Insert(key, /*value=*/nullptr, /*charge=*/0, DeletionCallback)
+    cache_
+        ->Insert(key, /*value=*/nullptr, /*charge=*/0,
+                 GetDeletionCallback(cache_options_.enable_custom_split_merge))
         .PermitUncheckedError();
   } else {
     is_in_sec_cache = true;
@@ -101,11 +116,12 @@ Status CompressedSecondaryCache::Insert(const Slice& key, void* value,
   }
 
   Cache::Handle* lru_handle = cache_->Lookup(key);
+  Cache::DeleterFn del_cb =
+      GetDeletionCallback(cache_options_.enable_custom_split_merge);
   if (lru_handle == nullptr) {
     PERF_COUNTER_ADD(compressed_sec_cache_insert_dummy_count, 1);
     // Insert a dummy handle if the handle is evicted for the first time.
-    return cache_->Insert(key, /*value=*/nullptr, /*charge=*/0,
-                          DeletionCallback);
+    return cache_->Insert(key, /*value=*/nullptr, /*charge=*/0, del_cb);
 
   } else {
     cache_->Release(lru_handle, /*erase_if_last_ref=*/false);
@@ -142,13 +158,23 @@ Status CompressedSecondaryCache::Insert(const Slice& key, void* value,
     val = Slice(compressed_val);
     size = compressed_val.size();
     PERF_COUNTER_ADD(compressed_sec_cache_compressed_bytes, size);
-    ptr = AllocateBlock(size, cache_options_.memory_allocator.get());
-    memcpy(ptr.get(), compressed_val.data(), size);
+
+    if (!cache_options_.enable_custom_split_merge) {
+      ptr = AllocateBlock(size, cache_options_.memory_allocator.get());
+      memcpy(ptr.get(), compressed_val.data(), size);
+    }
   }
 
-  CacheAllocationPtr* buf = new CacheAllocationPtr(std::move(ptr));
   PERF_COUNTER_ADD(compressed_sec_cache_insert_real_count, 1);
-  return cache_->Insert(key, buf, size, DeletionCallback);
+  if (cache_options_.enable_custom_split_merge) {
+    size_t charge{0};
+    CacheValueChunk* value_chunks_head =
+        SplitValueIntoChunks(val, cache_options_.compression_type, charge);
+    return cache_->Insert(key, value_chunks_head, charge, del_cb);
+  } else {
+    CacheAllocationPtr* buf = new CacheAllocationPtr(std::move(ptr));
+    return cache_->Insert(key, buf, size, del_cb);
+  }
 }
 
 void CompressedSecondaryCache::Erase(const Slice& key) { cache_->Erase(key); }
@@ -238,10 +264,24 @@ CacheAllocationPtr CompressedSecondaryCache::MergeChunksIntoValue(
   return ptr;
 }
 
-void CompressedSecondaryCache::DeletionCallback(const Slice& /*key*/,
-                                                void* obj) {
-  delete reinterpret_cast<CacheAllocationPtr*>(obj);
-  obj = nullptr;
+Cache::DeleterFn CompressedSecondaryCache::GetDeletionCallback(
+    bool enable_custom_split_merge) {
+  if (enable_custom_split_merge) {
+    return [](const Slice& /*key*/, void* obj) {
+      CacheValueChunk* chunks_head = reinterpret_cast<CacheValueChunk*>(obj);
+      while (chunks_head != nullptr) {
+        CacheValueChunk* tmp_chunk = chunks_head;
+        chunks_head = chunks_head->next;
+        tmp_chunk->Free();
+        obj = nullptr;
+      };
+    };
+  } else {
+    return [](const Slice& /*key*/, void* obj) {
+      delete reinterpret_cast<CacheAllocationPtr*>(obj);
+      obj = nullptr;
+    };
+  }
 }
 
 std::shared_ptr<SecondaryCache> NewCompressedSecondaryCache(
@@ -249,11 +289,13 @@ std::shared_ptr<SecondaryCache> NewCompressedSecondaryCache(
     double high_pri_pool_ratio, double low_pri_pool_ratio,
     std::shared_ptr<MemoryAllocator> memory_allocator, bool use_adaptive_mutex,
     CacheMetadataChargePolicy metadata_charge_policy,
-    CompressionType compression_type, uint32_t compress_format_version) {
+    CompressionType compression_type, uint32_t compress_format_version,
+    bool enable_custom_split_merge) {
   return std::make_shared<CompressedSecondaryCache>(
       capacity, num_shard_bits, strict_capacity_limit, high_pri_pool_ratio,
       low_pri_pool_ratio, memory_allocator, use_adaptive_mutex,
-      metadata_charge_policy, compression_type, compress_format_version);
+      metadata_charge_policy, compression_type, compress_format_version,
+      enable_custom_split_merge);
 }
 
 std::shared_ptr<SecondaryCache> NewCompressedSecondaryCache(
@@ -264,7 +306,8 @@ std::shared_ptr<SecondaryCache> NewCompressedSecondaryCache(
       opts.capacity, opts.num_shard_bits, opts.strict_capacity_limit,
       opts.high_pri_pool_ratio, opts.low_pri_pool_ratio, opts.memory_allocator,
       opts.use_adaptive_mutex, opts.metadata_charge_policy,
-      opts.compression_type, opts.compress_format_version);
+      opts.compression_type, opts.compress_format_version,
+      opts.enable_custom_split_merge);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/cache/compressed_secondary_cache.h
+++ b/cache/compressed_secondary_cache.h
@@ -76,7 +76,8 @@ class CompressedSecondaryCache : public SecondaryCache {
       CacheMetadataChargePolicy metadata_charge_policy =
           kDefaultCacheMetadataChargePolicy,
       CompressionType compression_type = CompressionType::kLZ4Compression,
-      uint32_t compress_format_version = 2);
+      uint32_t compress_format_version = 2,
+      bool enable_custom_split_merge = false);
   virtual ~CompressedSecondaryCache() override;
 
   const char* Name() const override { return "CompressedSecondaryCache"; }
@@ -98,10 +99,8 @@ class CompressedSecondaryCache : public SecondaryCache {
 
  private:
   friend class CompressedSecondaryCacheTest;
-  static constexpr std::array<uint16_t, 33> malloc_bin_sizes_{
-      32,   64,   96,   128,  160,  192,  224,   256,   320,   384,   448,
-      512,  640,  768,  896,  1024, 1280, 1536,  1792,  2048,  2560,  3072,
-      3584, 4096, 5120, 6144, 7168, 8192, 10240, 12288, 14336, 16384, 32768};
+  static constexpr std::array<uint16_t, 8> malloc_bin_sizes_{
+      128, 256, 512, 1024, 2048, 4096, 8192, 16384};
 
   struct CacheValueChunk {
     // TODO try "CacheAllocationPtr next;".
@@ -126,7 +125,7 @@ class CompressedSecondaryCache : public SecondaryCache {
                                           size_t& charge);
 
   // An implementation of Cache::DeleterFn.
-  static void DeletionCallback(const Slice& /*key*/, void* obj);
+  static Cache::DeleterFn GetDeletionCallback(bool enable_custom_split_merge);
   std::shared_ptr<Cache> cache_;
   CompressedSecondaryCacheOptions cache_options_;
 };

--- a/cache/compressed_secondary_cache_test.cc
+++ b/cache/compressed_secondary_cache_test.cc
@@ -283,7 +283,8 @@ class CompressedSecondaryCacheTest : public testing::Test {
     sec_cache.reset();
   }
 
-  void BasicIntegrationTest(bool sec_cache_is_compressed) {
+  void BasicIntegrationTest(bool sec_cache_is_compressed,
+                            bool enable_custom_split_merge) {
     CompressedSecondaryCacheOptions secondary_cache_opts;
 
     if (sec_cache_is_compressed) {
@@ -298,6 +299,7 @@ class CompressedSecondaryCacheTest : public testing::Test {
 
     secondary_cache_opts.capacity = 6000;
     secondary_cache_opts.num_shard_bits = 0;
+    secondary_cache_opts.enable_custom_split_merge = enable_custom_split_merge;
     std::shared_ptr<SecondaryCache> secondary_cache =
         NewCompressedSecondaryCache(secondary_cache_opts);
     LRUCacheOptions lru_cache_opts(
@@ -795,21 +797,21 @@ Cache::CacheItemHelper CompressedSecondaryCacheTest::helper_fail_(
     CompressedSecondaryCacheTest::DeletionCallback);
 
 TEST_F(CompressedSecondaryCacheTest, BasicTestWithNoCompression) {
-  BasicTest(false, false);
+  BasicTest(/*sec_cache_is_compressed=*/false, /*use_jemalloc=*/false);
 }
 
 TEST_F(CompressedSecondaryCacheTest,
        BasicTestWithMemoryAllocatorAndNoCompression) {
-  BasicTest(false, true);
+  BasicTest(/*sec_cache_is_compressed=*/false, /*use_jemalloc=*/true);
 }
 
 TEST_F(CompressedSecondaryCacheTest, BasicTestWithCompression) {
-  BasicTest(true, false);
+  BasicTest(/*sec_cache_is_compressed=*/true, /*use_jemalloc=*/false);
 }
 
 TEST_F(CompressedSecondaryCacheTest,
        BasicTestWithMemoryAllocatorAndCompression) {
-  BasicTest(true, true);
+  BasicTest(/*sec_cache_is_compressed=*/true, /*use_jemalloc=*/true);
 }
 
 #ifndef ROCKSDB_LITE
@@ -829,8 +831,8 @@ TEST_F(CompressedSecondaryCacheTest,
        BasicTestFromStringWithSplitAndNoCompression) {
   std::string sec_cache_uri =
       "compressed_secondary_cache://"
-      "capacity=2048;num_shard_bits=0;compression_type=kNoCompression"
-      "compress_format_version=2;enable_custom_split_merge=true";
+      "capacity=2048;num_shard_bits=0;compression_type=kNoCompression;"
+      "enable_custom_split_merge=true";
   std::shared_ptr<SecondaryCache> sec_cache;
   Status s = SecondaryCache::CreateFromString(ConfigOptions(), sec_cache_uri,
                                               &sec_cache);
@@ -897,11 +899,25 @@ TEST_F(CompressedSecondaryCacheTest, FailsTestWithCompression) {
 }
 
 TEST_F(CompressedSecondaryCacheTest, BasicIntegrationTestWithNoCompression) {
-  BasicIntegrationTest(false);
+  BasicIntegrationTest(/*sec_cache_is_compressed=*/false,
+                       /*enable_custom_split_merge=*/false);
+}
+
+TEST_F(CompressedSecondaryCacheTest,
+       BasicIntegrationTestWithSplitAndNoCompression) {
+  BasicIntegrationTest(/*sec_cache_is_compressed=*/false,
+                       /*enable_custom_split_merge=*/true);
 }
 
 TEST_F(CompressedSecondaryCacheTest, BasicIntegrationTestWithCompression) {
-  BasicIntegrationTest(true);
+  BasicIntegrationTest(/*sec_cache_is_compressed=*/true,
+                       /*enable_custom_split_merge=*/false);
+}
+
+TEST_F(CompressedSecondaryCacheTest,
+       BasicIntegrationTestWithSplitAndCompression) {
+  BasicIntegrationTest(/*sec_cache_is_compressed=*/true,
+                       /*enable_custom_split_merge=*/true);
 }
 
 TEST_F(CompressedSecondaryCacheTest,

--- a/cache/compressed_secondary_cache_test.cc
+++ b/cache/compressed_secondary_cache_test.cc
@@ -813,7 +813,7 @@ TEST_P(CompressedSecCacheTestWithCompressAndAllocatorParam, BasicTes) {
   BasicTest(sec_cache_is_compressed_, use_jemalloc_);
 }
 
-INSTANTIATE_TEST_CASE_P(Tests,
+INSTANTIATE_TEST_CASE_P(CompressedSecCacheTests,
                         CompressedSecCacheTestWithCompressAndAllocatorParam,
                         ::testing::Combine(testing::Bool(), testing::Bool()));
 
@@ -918,7 +918,8 @@ TEST_P(CompressedSecondaryCacheTestWithCompressionParam,
   IntegrationFullCapacityTest(sec_cache_is_compressed_);
 }
 
-INSTANTIATE_TEST_CASE_P(Tests, CompressedSecondaryCacheTestWithCompressionParam,
+INSTANTIATE_TEST_CASE_P(CompressedSecCacheTests,
+                        CompressedSecondaryCacheTestWithCompressionParam,
                         testing::Bool());
 
 class CompressedSecCacheTestWithCompressAndSplitParam
@@ -937,7 +938,8 @@ TEST_P(CompressedSecCacheTestWithCompressAndSplitParam, BasicIntegrationTest) {
   BasicIntegrationTest(sec_cache_is_compressed_, enable_custom_split_merge_);
 }
 
-INSTANTIATE_TEST_CASE_P(Tests, CompressedSecCacheTestWithCompressAndSplitParam,
+INSTANTIATE_TEST_CASE_P(CompressedSecCacheTests,
+                        CompressedSecCacheTestWithCompressAndSplitParam,
                         ::testing::Combine(testing::Bool(), testing::Bool()));
 
 TEST_F(CompressedSecondaryCacheTest, SplitValueIntoChunksTest) {

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -182,6 +182,9 @@ struct CompressedSecondaryCacheOptions : LRUCacheOptions {
   // header in varint32 format.
   uint32_t compress_format_version = 2;
 
+  //
+  bool enable_custom_split_merge = false;
+
   CompressedSecondaryCacheOptions() {}
   CompressedSecondaryCacheOptions(
       size_t _capacity, int _num_shard_bits, bool _strict_capacity_limit,
@@ -191,13 +194,15 @@ struct CompressedSecondaryCacheOptions : LRUCacheOptions {
       CacheMetadataChargePolicy _metadata_charge_policy =
           kDefaultCacheMetadataChargePolicy,
       CompressionType _compression_type = CompressionType::kLZ4Compression,
-      uint32_t _compress_format_version = 2)
+      uint32_t _compress_format_version = 2,
+      bool _enable_custom_split_merge = false)
       : LRUCacheOptions(_capacity, _num_shard_bits, _strict_capacity_limit,
                         _high_pri_pool_ratio, std::move(_memory_allocator),
                         _use_adaptive_mutex, _metadata_charge_policy,
                         _low_pri_pool_ratio),
         compression_type(_compression_type),
-        compress_format_version(_compress_format_version) {}
+        compress_format_version(_compress_format_version),
+        enable_custom_split_merge(_enable_custom_split_merge) {}
 };
 
 // EXPERIMENTAL
@@ -211,7 +216,8 @@ extern std::shared_ptr<SecondaryCache> NewCompressedSecondaryCache(
     CacheMetadataChargePolicy metadata_charge_policy =
         kDefaultCacheMetadataChargePolicy,
     CompressionType compression_type = CompressionType::kLZ4Compression,
-    uint32_t compress_format_version = 2);
+    uint32_t compress_format_version = 2,
+    bool enable_custom_split_merge = false);
 
 extern std::shared_ptr<SecondaryCache> NewCompressedSecondaryCache(
     const CompressedSecondaryCacheOptions& opts);

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -182,7 +182,8 @@ struct CompressedSecondaryCacheOptions : LRUCacheOptions {
   // header in varint32 format.
   uint32_t compress_format_version = 2;
 
-  //
+  // Enable the custom split and merge feature, which split the compressed value
+  // into chunks so that they may better fit jemalloc bins.
   bool enable_custom_split_merge = false;
 
   CompressedSecondaryCacheOptions() {}

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -178,7 +178,8 @@ default_params = {
     "wal_compression": lambda: random.choice(["none", "zstd"]),
     "verify_sst_unique_id_in_manifest": 1,  # always do unique_id verification
     "secondary_cache_uri":  lambda: random.choice(
-        ["", "compressed_secondary_cache://capacity=8388608"]),
+        ["", "compressed_secondary_cache://capacity=8388608",
+         "compressed_secondary_cache://capacity=8388608;enable_custom_split_merge=true"]),
     "allow_data_in_errors": True,
     "readahead_size": lambda: random.choice([0, 16384, 524288]),
     "initial_auto_readahead_size": lambda: random.choice([0, 16384, 524288]),


### PR DESCRIPTION
Summary:
`enable_custom_split_merge` is added for enabling the custom split and merge feature, which split the compressed value into chunks so that they may better fit jemalloc bins.

Test Plan:
Unit Tests
Stress Tests