### PR TITLE
Fix an incorrect MultiGet assertion

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -511,7 +511,7 @@ class FilePickerMultiGet {
   MultiGetRange& GetRange() { return range_; }
 
   void ReplaceRange(const MultiGetRange& other) {
-    assert(curr_level_ == 0 || !RemainingOverlapInLevel());
+    assert(hit_file_ == nullptr);
     range_ = other;
     current_level_range_ = other;
   }


### PR DESCRIPTION
The assertion in ```FilePickerMultiGet::ReplaceRange()``` was incorrect. The function should only be called to replace the range after finishing the search in the current level, which is indicated by ```hit_file_ == nullptr``` i.e no more overlapping files in this level.