### PR TITLE
Deflake CompactionServiceTest.BasicCompactions

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -325,6 +325,7 @@ TEST_F(CompactionServiceTest, BasicCompactions) {
       });
   Reopen(options);
   ASSERT_GT(verify_passed, 0);
+  Close();
 }
 
 TEST_F(CompactionServiceTest, ManualCompaction) {


### PR DESCRIPTION
The background compaction may still running while the test end, which would cause ASAN stack-use-after-scope error.
Explicitly close the DB before test end.

Test plan: able to reproduce with:
```
gtest-parallel ./compaction_service_test --gtest_filter=CompactionServiceTest.BasicCompactions -r 10000 -w 100
```