### PR TITLE
Disable tiered storage + BlobDB stress test

### DIFF
--- a/db_stress_tool/db_stress.cc
+++ b/db_stress_tool/db_stress.cc
@@ -16,8 +16,10 @@ int main() {
 }
 #else
 #include "rocksdb/db_stress_tool.h"
+#include "port/stack_trace.h"
 
 int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
   return ROCKSDB_NAMESPACE::db_stress_tool(argc, argv);
 }
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress.cc
+++ b/db_stress_tool/db_stress.cc
@@ -15,8 +15,8 @@ int main() {
   return 1;
 }
 #else
-#include "rocksdb/db_stress_tool.h"
 #include "port/stack_trace.h"
+#include "rocksdb/db_stress_tool.h"
 
 int main(int argc, char** argv) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -379,6 +379,7 @@ tiered_params = {
     # endless compaction
     "compaction_style": 1,
     # tiered storage doesn't support blob db yet
+    "enable_blob_files": 0,
     "use_blob_db": 0,
 }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -597,11 +597,11 @@ def gen_cmd_params(args):
     if args.test_tiered_storage:
         params.update(tiered_params)
 
-    # Best-effort recovery and BlobDB are currently incompatible. Test BE recovery
-    # if specified on the command line; otherwise, apply BlobDB related overrides
-    # with a 10% chance.
+    # Best-effort recovery, user defined timestamp, tiered storage are currently
+    # incompatible with BlobDB. Test BE recovery if specified on the command
+    # line; otherwise, apply BlobDB related overrides with a 10% chance.
     if (not args.test_best_efforts_recovery and
-        not args.enable_ts and
+        not args.enable_ts and not args.test_tiered_storage and
         random.choice([0] * 9 + [1]) == 1):
         params.update(blob_params)
 


### PR DESCRIPTION
There're 2 knobs to disable blobdb, adding that.
Also print call stack when there's assert failure.