### PR TITLE
Fix potential memory leak in ArenaWrappedDBIter::Refresh()

### DIFF
--- a/db/arena_wrapped_db_iter.cc
+++ b/db/arena_wrapped_db_iter.cc
@@ -93,6 +93,7 @@ Status ArenaWrappedDBIter::Refresh() {
             read_options_, latest_seq, false /* immutable_memtable */);
         if (!t || t->empty()) {
           if (memtable_range_tombstone_iter_) {
+            delete *memtable_range_tombstone_iter_;
             *memtable_range_tombstone_iter_ = nullptr;
           }
           delete t;


### PR DESCRIPTION
Summary: Fix potential memory leak in ArenaWrappedDBIter::Refresh() introduced in #10705. See https://github.com/facebook/rocksdb/pull/10705#discussion_r976765905 for detail.

Test plan: make check