### PR TITLE
Fix DBImpl::GetLatestSequenceForKey() for Merge

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -958,7 +958,11 @@ static bool SaveValue(void* arg, const char* entry) {
       return true;  // to continue to the next seq
     }
 
-    s->seq = seq;
+    if (s->seq == kMaxSequenceNumber) {
+      s->seq = seq;
+    }
+
+    s->seq = std::max(s->seq, max_covering_tombstone_seq);
 
     if ((type == kTypeValue || type == kTypeMerge || type == kTypeBlobIndex ||
          type == kTypeWideColumnEntity) &&

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -964,6 +964,19 @@ static bool SaveValue(void* arg, const char* entry) {
 
     s->seq = std::max(s->seq, max_covering_tombstone_seq);
 
+    if (ts_sz > 0 && s->timestamp != nullptr) {
+      if (!s->timestamp->empty()) {
+        assert(ts_sz == s->timestamp->size());
+      }
+      // TODO optimize for smaller size ts
+      const std::string kMaxTs(ts_sz, '\xff');
+      if (s->timestamp->empty() ||
+          user_comparator->CompareTimestamp(*(s->timestamp), kMaxTs) == 0) {
+        Slice ts = ExtractTimestampFromUserKey(user_key_slice, ts_sz);
+        s->timestamp->assign(ts.data(), ts_sz);
+      }
+    }
+
     if ((type == kTypeValue || type == kTypeMerge || type == kTypeBlobIndex ||
          type == kTypeWideColumnEntity) &&
         max_covering_tombstone_seq > seq) {
@@ -1043,10 +1056,6 @@ static bool SaveValue(void* arg, const char* entry) {
           *(s->is_blob_index) = (type == kTypeBlobIndex);
         }
 
-        if (ts_sz > 0 && s->timestamp != nullptr) {
-          Slice ts = ExtractTimestampFromUserKey(user_key_slice, ts_sz);
-          s->timestamp->assign(ts.data(), ts.size());
-        }
         return false;
       }
       case kTypeDeletion:
@@ -1062,10 +1071,6 @@ static bool SaveValue(void* arg, const char* entry) {
           }
         } else {
           *(s->status) = Status::NotFound();
-          if (ts_sz > 0 && s->timestamp != nullptr) {
-            Slice ts = ExtractTimestampFromUserKey(user_key_slice, ts_sz);
-            s->timestamp->assign(ts.data(), ts.size());
-          }
         }
         *(s->found_final_value) = true;
         return false;

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -241,6 +241,9 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
       if (*seq_ == kMaxSequenceNumber) {
         *seq_ = parsed_key.sequence;
       }
+      if (max_covering_tombstone_seq_) {
+        *seq_ = std::max(*seq_, *max_covering_tombstone_seq_);
+      }
     }
 
     auto type = parsed_key.type;

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -167,22 +167,19 @@ TEST_P(OptimisticTransactionTest, WriteConflictTest2) {
 }
 
 TEST_P(OptimisticTransactionTest, WriteConflictTest3) {
-  WriteOptions write_options;
-  ReadOptions read_options;
-  std::string value;
+  ASSERT_OK(txn_db->Put(WriteOptions(), "foo", "bar"));
 
-  ASSERT_OK(txn_db->Put(write_options, "foo", "bar"));
-
-  Transaction* txn = txn_db->BeginTransaction(write_options);
+  Transaction* txn = txn_db->BeginTransaction(WriteOptions());
   ASSERT_NE(txn, nullptr);
 
-  ASSERT_OK(txn->GetForUpdate(read_options, "foo", &value));
+  std::string value;
+  ASSERT_OK(txn->GetForUpdate(ReadOptions(), "foo", &value));
   ASSERT_EQ(value, "bar");
   ASSERT_OK(txn->Merge("foo", "bar3"));
 
   // Merge outside of a transaction should conflict with the previous merge
-  ASSERT_OK(txn_db->Merge(write_options, "foo", "bar2"));
-  ASSERT_OK(txn_db->Get(read_options, "foo", &value));
+  ASSERT_OK(txn_db->Merge(WriteOptions(), "foo", "bar2"));
+  ASSERT_OK(txn_db->Get(ReadOptions(), "foo", &value));
   ASSERT_EQ(value, "bar2");
 
   ASSERT_EQ(1, txn->GetNumKeys());
@@ -191,8 +188,39 @@ TEST_P(OptimisticTransactionTest, WriteConflictTest3) {
   EXPECT_TRUE(s.IsBusy());  // Txn should not commit
 
   // Verify that transaction did not write anything
-  ASSERT_OK(txn_db->Get(read_options, "foo", &value));
+  ASSERT_OK(txn_db->Get(ReadOptions(), "foo", &value));
   ASSERT_EQ(value, "bar2");
+
+  delete txn;
+}
+
+TEST_P(OptimisticTransactionTest, WriteConflict4) {
+  ASSERT_OK(txn_db->Put(WriteOptions(), "foo", "bar"));
+
+  Transaction* txn = txn_db->BeginTransaction(WriteOptions());
+  ASSERT_NE(txn, nullptr);
+
+  std::string value;
+  ASSERT_OK(txn->GetForUpdate(ReadOptions(), "foo", &value));
+  ASSERT_EQ(value, "bar");
+  ASSERT_OK(txn->Merge("foo", "bar3"));
+
+  // Range delete outside of a transaction should conflict with the previous
+  // merge inside txn
+  auto* dbimpl = static_cast_with_check<DBImpl>(txn_db->GetRootDB());
+  ColumnFamilyHandle* default_cf = dbimpl->DefaultColumnFamily();
+  ASSERT_OK(dbimpl->DeleteRange(WriteOptions(), default_cf, "foo", "foo1"));
+  Status s = txn_db->Get(ReadOptions(), "foo", &value);
+  ASSERT_TRUE(s.IsNotFound());
+
+  ASSERT_EQ(1, txn->GetNumKeys());
+
+  s = txn->Commit();
+  EXPECT_TRUE(s.IsBusy());  // Txn should not commit
+
+  // Verify that transaction did not write anything
+  s = txn_db->Get(ReadOptions(), "foo", &value);
+  ASSERT_TRUE(s.IsNotFound());
 
   delete txn;
 }


### PR DESCRIPTION
Summary:
Currently, without this fix, DBImpl::GetLatestSequenceForKey() may not return the latest sequence number for merge operands of the key. This can cause conflict checking during optimistic transaction commit phase to fail. Fix it by always returning the latest sequence number of the key, also considering range tombstones.

Test Plan:
make check