### PR TITLE
Use actual file size when checking max_compaction_size

### DIFF
--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -318,7 +318,7 @@ void LevelCompactionBuilder::SetupOtherFilesWithRoundRobinExpansion() {
   // Constraint 3 (pre-calculate the ideal max bytes to compact)
   for (auto f : level_files) {
     if (!f->being_compacted) {
-      start_lvl_bytes_no_compacting += f->compensated_file_size;
+      start_lvl_bytes_no_compacting += f->fd.GetFileSize();
     }
   }
   if (start_lvl_bytes_no_compacting >
@@ -341,7 +341,7 @@ void LevelCompactionBuilder::SetupOtherFilesWithRoundRobinExpansion() {
     }
   }
   // Constraint 3
-  if (start_level_inputs_[0]->compensated_file_size >=
+  if (start_level_inputs_[0]->fd.GetFileSize() >=
       start_lvl_max_bytes_to_compact) {
     return;
   }
@@ -368,7 +368,7 @@ void LevelCompactionBuilder::SetupOtherFilesWithRoundRobinExpansion() {
 
     curr_bytes_to_compact = 0;
     for (auto start_lvl_f : tmp_start_level_inputs.files) {
-      curr_bytes_to_compact += start_lvl_f->compensated_file_size;
+      curr_bytes_to_compact += start_lvl_f->fd.GetFileSize();
     }
 
     // Check whether any output level files are locked
@@ -385,7 +385,7 @@ void LevelCompactionBuilder::SetupOtherFilesWithRoundRobinExpansion() {
 
     uint64_t start_lvl_curr_bytes_to_compact = curr_bytes_to_compact;
     for (auto output_lvl_f : output_level_inputs.files) {
-      curr_bytes_to_compact += output_lvl_f->compensated_file_size;
+      curr_bytes_to_compact += output_lvl_f->fd.GetFileSize();
     }
     if (curr_bytes_to_compact > mutable_cf_options_.max_compaction_bytes) {
       // Constraint 2

--- a/include/rocksdb/universal_compaction.h
+++ b/include/rocksdb/universal_compaction.h
@@ -59,7 +59,7 @@ class CompactionOptionsUniversal {
   //    A1...An B1...Bm C1...Ct
   // where A1 is the newest and Ct is the oldest, and we are going to compact
   // B1...Bm, we calculate the total size of all the files as total_size, as
-  // well as  the total size of C1...Ct as total_C, the compaction output file
+  // well as the total size of C1...Ct as total_C, the compaction output file
   // will be compressed iff
   //   total_C / total_size < this percentage
   // Default: -1


### PR DESCRIPTION
Summary: currently, there are places in compaction_picker where we add up `compensated_file_size` of files being compacted and limit the sum to be under `max_compaction_bytes`. `compensated_file_size` contains booster for point tombstones and should be used only for determining file's compaction priority. This PR replaces `compensated_file_size` with actual file size in such places.

Test plan: CI