### PR TITLE
Remove and recreate expected values dir in white-box testing 2nd half

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -898,7 +898,10 @@ def whitebox_crash_main(args, unknown_args):
             # success
             shutil.rmtree(dbname, True)
             os.mkdir(dbname)
-            cmd_params.pop("expected_values_dir", None)
+            if (expected_values_dir is not None):
+                shutil.rmtree(expected_values_dir, True)
+                os.mkdir(expected_values_dir)
+
             check_mode = (check_mode + 1) % total_check_mode
 
         time.sleep(1)  # time to stabilize after a kill


### PR DESCRIPTION
**Context:**
https://github.com/facebook/rocksdb/pull/8913#discussion_r980601068

**Test:**
- Locally run `python3 ./tools/db_crashtest.py whitebox --simple -max_key=1000000 -value_size_mult=33 -write_buffer_size=524288 -target_file_size_base=524288 -max_bytes_for_level_base=2097152 --duration=120 --interval=10 --ops_per_thread=1000 --random_kill_odd=887`
- CI stress testing