### PR TITLE
Add option `preserve_internal_time_seconds` to preserve the time info

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 
 ### New Features
 * Add a new option IOOptions.do_not_recurse that can be used by underlying file systems to skip recursing through sub directories and list only files in GetChildren API.
+* Add option `preserve_internal_time_seconds` to preserve the time information for the latest data. Which can be used to determine the age of data when `preclude_last_level_data_seconds` is enabled. The time information is attached with SST in table property `rocksdb.seqno.time.map` which can be parsed by tool ldb or sst_dump.
 
 ### Behavior Changes
 * Sanitize min_write_buffer_number_to_merge to 1 if atomic flush is enabled to prevent unexpected data loss when WAL is disabled in a multi-column-family setting (#10773).

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -34,7 +34,8 @@ CompactionIterator::CompactionIterator(
     const std::atomic<bool>* shutting_down,
     const std::shared_ptr<Logger> info_log,
     const std::string* full_history_ts_low,
-    const SequenceNumber preserve_time_min_seqno)
+    const SequenceNumber preserve_time_min_seqno,
+    const SequenceNumber preclude_last_level_min_seqno)
     : CompactionIterator(
           input, cmp, merge_helper, last_sequence, snapshots,
           earliest_write_conflict_snapshot, job_snapshot, snapshot_checker, env,
@@ -44,7 +45,7 @@ CompactionIterator::CompactionIterator(
           std::unique_ptr<CompactionProxy>(
               compaction ? new RealCompaction(compaction) : nullptr),
           compaction_filter, shutting_down, info_log, full_history_ts_low,
-          preserve_time_min_seqno) {}
+          preserve_time_min_seqno, preclude_last_level_min_seqno) {}
 
 CompactionIterator::CompactionIterator(
     InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
@@ -61,7 +62,8 @@ CompactionIterator::CompactionIterator(
     const std::atomic<bool>* shutting_down,
     const std::shared_ptr<Logger> info_log,
     const std::string* full_history_ts_low,
-    const SequenceNumber preserve_time_min_seqno)
+    const SequenceNumber preserve_time_min_seqno,
+    const SequenceNumber preclude_last_level_min_seqno)
     : input_(input, cmp,
              !compaction || compaction->DoesInputReferenceBlobFiles()),
       cmp_(cmp),
@@ -105,8 +107,10 @@ CompactionIterator::CompactionIterator(
       current_key_committed_(false),
       cmp_with_history_ts_low_(0),
       level_(compaction_ == nullptr ? 0 : compaction_->level()),
-      preserve_time_min_seqno_(preserve_time_min_seqno) {
+      preserve_time_min_seqno_(preserve_time_min_seqno),
+      preclude_last_level_min_seqno_(preclude_last_level_min_seqno) {
   assert(snapshots_ != nullptr);
+  assert(preserve_time_min_seqno_ <= preclude_last_level_min_seqno_);
 
   if (compaction_ != nullptr) {
     level_ptrs_ = std::vector<size_t>(compaction_->number_levels(), 0);
@@ -1100,7 +1104,7 @@ void CompactionIterator::DecideOutputLevel() {
 
   // if the key is newer than the cutoff sequence or within the earliest
   // snapshot, it should output to the penultimate level.
-  if (ikey_.sequence > preserve_time_min_seqno_ ||
+  if (ikey_.sequence > preclude_last_level_min_seqno_ ||
       ikey_.sequence > earliest_snapshot_) {
     output_to_penultimate_level_ = true;
   }

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -1104,7 +1104,7 @@ void CompactionIterator::DecideOutputLevel() {
 
   // if the key is newer than the cutoff sequence or within the earliest
   // snapshot, it should output to the penultimate level.
-  if (ikey_.sequence > preclude_last_level_min_seqno_ ||
+  if (ikey_.sequence >= preclude_last_level_min_seqno_ ||
       ikey_.sequence > earliest_snapshot_) {
     output_to_penultimate_level_ = true;
   }

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -472,7 +472,7 @@ class CompactionIterator {
 
   // min seqno for preserving the time information. If preclude_last_level is
   // enabled, newer seqno than that will be output to penultimate level
-  const SequenceNumber  preserve_time_min_seqno_ = kMaxSequenceNumber;
+  const SequenceNumber preserve_time_min_seqno_ = kMaxSequenceNumber;
 
   void AdvanceInputIter() { input_.Next(); }
 

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -472,10 +472,11 @@ class CompactionIterator {
   // output to.
   bool output_to_penultimate_level_{false};
 
-  // min seqno for preserving the time information. If preclude_last_level is
-  // enabled, newer seqno than that will be output to penultimate level
+  // min seqno for preserving the time information.
   const SequenceNumber preserve_time_min_seqno_ = kMaxSequenceNumber;
 
+  // min seqno to preclude the data from the last level, if the key seqno larger
+  // than this, it will be output to penultimate level
   const SequenceNumber preclude_last_level_min_seqno_ = kMaxSequenceNumber;
 
   void AdvanceInputIter() { input_.Next(); }

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -200,7 +200,7 @@ class CompactionIterator {
       const std::atomic<bool>* shutting_down = nullptr,
       const std::shared_ptr<Logger> info_log = nullptr,
       const std::string* full_history_ts_low = nullptr,
-      const SequenceNumber penultimate_level_cutoff_seqno = kMaxSequenceNumber);
+      const SequenceNumber preserve_time_min_seqno = kMaxSequenceNumber);
 
   // Constructor with custom CompactionProxy, used for tests.
   CompactionIterator(
@@ -218,7 +218,7 @@ class CompactionIterator {
       const std::atomic<bool>* shutting_down = nullptr,
       const std::shared_ptr<Logger> info_log = nullptr,
       const std::string* full_history_ts_low = nullptr,
-      const SequenceNumber penultimate_level_cutoff_seqno = kMaxSequenceNumber);
+      const SequenceNumber preserve_time_min_seqno = kMaxSequenceNumber);
 
   ~CompactionIterator();
 
@@ -470,9 +470,9 @@ class CompactionIterator {
   // output to.
   bool output_to_penultimate_level_{false};
 
-  // any key later than this sequence number should have
-  // output_to_penultimate_level_ set to true
-  const SequenceNumber penultimate_level_cutoff_seqno_ = kMaxSequenceNumber;
+  // min seqno for preserving the time information. If preclude_last_level is
+  // enabled, newer seqno than that will be output to penultimate level
+  const SequenceNumber  preserve_time_min_seqno_ = kMaxSequenceNumber;
 
   void AdvanceInputIter() { input_.Next(); }
 

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -200,7 +200,8 @@ class CompactionIterator {
       const std::atomic<bool>* shutting_down = nullptr,
       const std::shared_ptr<Logger> info_log = nullptr,
       const std::string* full_history_ts_low = nullptr,
-      const SequenceNumber preserve_time_min_seqno = kMaxSequenceNumber);
+      const SequenceNumber preserve_time_min_seqno = kMaxSequenceNumber,
+      const SequenceNumber preclude_last_level_min_seqno = kMaxSequenceNumber);
 
   // Constructor with custom CompactionProxy, used for tests.
   CompactionIterator(
@@ -218,7 +219,8 @@ class CompactionIterator {
       const std::atomic<bool>* shutting_down = nullptr,
       const std::shared_ptr<Logger> info_log = nullptr,
       const std::string* full_history_ts_low = nullptr,
-      const SequenceNumber preserve_time_min_seqno = kMaxSequenceNumber);
+      const SequenceNumber preserve_time_min_seqno = kMaxSequenceNumber,
+      const SequenceNumber preclude_last_level_min_seqno = kMaxSequenceNumber);
 
   ~CompactionIterator();
 
@@ -473,6 +475,8 @@ class CompactionIterator {
   // min seqno for preserving the time information. If preclude_last_level is
   // enabled, newer seqno than that will be output to penultimate level
   const SequenceNumber preserve_time_min_seqno_ = kMaxSequenceNumber;
+
+  const SequenceNumber preclude_last_level_min_seqno_ = kMaxSequenceNumber;
 
   void AdvanceInputIter() { input_.Next(); }
 

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -267,14 +267,14 @@ void CompactionJob::Prepare() {
 
   // collect all seqno->time information from the input files which will be used
   // to encode seqno->time to the output files.
-  uint64_t track_time_duration =
+  uint64_t preserve_time_duration =
       c->immutable_options()->preclude_last_level_data_seconds == 0
-          ? c->immutable_options()->track_internal_time_seconds
+          ? c->immutable_options()->preserve_internal_time_seconds
           : c->immutable_options()->preclude_last_level_data_seconds;
 
-  if (track_time_duration > 0) {
+  if (preserve_time_duration > 0) {
     // setup seqno_time_mapping_
-    seqno_time_mapping_.SetMaxTimeDuration(track_time_duration);
+    seqno_time_mapping_.SetMaxTimeDuration(preserve_time_duration);
     for (const auto& each_level : *c->inputs()) {
       for (const auto& fmd : each_level.files) {
         std::shared_ptr<const TableProperties> tp;
@@ -304,8 +304,12 @@ void CompactionJob::Prepare() {
       preserve_time_min_seqno_ = 0;
     } else {
       seqno_time_mapping_.TruncateOldEntries(_current_time);
-      uint64_t preserve_time = static_cast<uint64_t>(_current_time) > track_time_duration ? _current_time - track_time_duration : 0;
-      preserve_time_min_seqno_ = seqno_time_mapping_.GetOldestSequenceNum(preserve_time);
+      uint64_t preserve_time =
+          static_cast<uint64_t>(_current_time) > preserve_time_duration
+              ? _current_time - preserve_time_duration
+              : 0;
+      preserve_time_min_seqno_ =
+          seqno_time_mapping_.GetOldestSequenceNum(preserve_time);
     }
   }
 }
@@ -1223,8 +1227,7 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
       blob_file_builder.get(), db_options_.allow_data_in_errors,
       db_options_.enforce_single_del_contracts, manual_compaction_canceled_,
       sub_compact->compaction, compaction_filter, shutting_down_,
-      db_options_.info_log, full_history_ts_low,
-      preserve_time_min_seqno_);
+      db_options_.info_log, full_history_ts_low, preserve_time_min_seqno_);
   c_iter->SeekToFirst();
 
   // Assign range delete aggregator to the target output level, which makes sure

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -267,7 +267,9 @@ void CompactionJob::Prepare() {
 
   // collect all seqno->time information from the input files which will be used
   // to encode seqno->time to the output files.
-  uint64_t preserve_time_duration = std::max(c->immutable_options()->preserve_internal_time_seconds, c->immutable_options()->preclude_last_level_data_seconds);
+  uint64_t preserve_time_duration =
+      std::max(c->immutable_options()->preserve_internal_time_seconds,
+               c->immutable_options()->preclude_last_level_data_seconds);
 
   if (preserve_time_duration > 0) {
     // setup seqno_time_mapping_

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -335,11 +335,11 @@ class CompactionJob {
   // it also collects the smallest_seqno -> oldest_ancester_time from the SST.
   SeqnoToTimeMapping seqno_time_mapping_;
 
-  // cutoff sequence number for penultimate level, only set when
-  // per_key_placement feature is enabled.
-  // If a key with sequence number larger than penultimate_level_cutoff_seqno_,
-  // it will be placed on the penultimate_level and seqnuence number won't be
-  // zeroed out.
+  // Minimal sequence number for preserving the time information. The time info
+  // older than this sequence number won't be preserved after the compaction and
+  // if it's bottommost compaction, the seq num will be zeroed out.
+  // If preclude_last_level feature is enabled, the data newer than this won't
+  // be placed on the last level.
   SequenceNumber preserve_time_min_seqno_ = kMaxSequenceNumber;
 
   // Get table file name in where it's outputting to, which should also be in

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -340,7 +340,7 @@ class CompactionJob {
   // If a key with sequence number larger than penultimate_level_cutoff_seqno_,
   // it will be placed on the penultimate_level and seqnuence number won't be
   // zeroed out.
-  SequenceNumber penultimate_level_cutoff_seqno_ = kMaxSequenceNumber;
+  SequenceNumber preserve_time_min_seqno_ = kMaxSequenceNumber;
 
   // Get table file name in where it's outputting to, which should also be in
   // `output_directory_`.

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -338,10 +338,11 @@ class CompactionJob {
   // Minimal sequence number for preserving the time information. The time info
   // older than this sequence number won't be preserved after the compaction and
   // if it's bottommost compaction, the seq num will be zeroed out.
-  // If preclude_last_level feature is enabled, the data newer than this won't
-  // be placed on the last level.
   SequenceNumber preserve_time_min_seqno_ = kMaxSequenceNumber;
 
+  // Minimal sequence number to preclude the data from the last level. If the
+  // key has bigger (newer) sequence number than this, it will be precluded from
+  // the last level (output to penultimate level).
   SequenceNumber preclude_last_level_min_seqno_ = kMaxSequenceNumber;
 
   // Get table file name in where it's outputting to, which should also be in

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -342,6 +342,8 @@ class CompactionJob {
   // be placed on the last level.
   SequenceNumber preserve_time_min_seqno_ = kMaxSequenceNumber;
 
+  SequenceNumber preclude_last_level_min_seqno_ = kMaxSequenceNumber;
+
   // Get table file name in where it's outputting to, which should also be in
   // `output_directory_`.
   virtual std::string GetTableFileName(uint64_t file_number);

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -849,9 +849,9 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
     for (auto cfd : *versions_->GetColumnFamilySet()) {
       // If track internal time option is specified, use it
       uint64_t track_time_duration =
-          cfd->ioptions()->track_internal_time_seconds == 0
-              ? cfd->ioptions()->preclude_last_level_data_seconds
-              : cfd->ioptions()->track_internal_time_seconds;
+          cfd->ioptions()->preclude_last_level_data_seconds == 0
+              ? cfd->ioptions()->track_internal_time_seconds
+              : cfd->ioptions()->preclude_last_level_data_seconds;
       if (!cfd->IsDropped() && track_time_duration > 0) {
         min_time_duration = std::min(track_time_duration, min_time_duration);
         max_time_duration = std::max(track_time_duration, max_time_duration);

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -847,7 +847,8 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
     InstrumentedMutexLock l(&mutex_);
 
     for (auto cfd : *versions_->GetColumnFamilySet()) {
-      // If track internal time option is specified, use it
+      // If preclude_last_level is specified, use it. Otherwise, check if
+      // preserve_internal is specified.
       uint64_t track_time_duration =
           cfd->ioptions()->preclude_last_level_data_seconds == 0
               ? cfd->ioptions()->preserve_internal_time_seconds

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -847,11 +847,14 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
     InstrumentedMutexLock l(&mutex_);
 
     for (auto cfd : *versions_->GetColumnFamilySet()) {
-      uint64_t preclude_last_option =
-          cfd->ioptions()->preclude_last_level_data_seconds;
-      if (!cfd->IsDropped() && preclude_last_option > 0) {
-        min_time_duration = std::min(preclude_last_option, min_time_duration);
-        max_time_duration = std::max(preclude_last_option, max_time_duration);
+      // If track internal time option is specified, use it
+      uint64_t track_time_duration =
+          cfd->ioptions()->track_internal_time_seconds == 0
+              ? cfd->ioptions()->preclude_last_level_data_seconds
+              : cfd->ioptions()->track_internal_time_seconds;
+      if (!cfd->IsDropped() && track_time_duration > 0) {
+        min_time_duration = std::min(track_time_duration, min_time_duration);
+        max_time_duration = std::max(track_time_duration, max_time_duration);
       }
     }
     if (min_time_duration == std::numeric_limits<uint64_t>::max()) {
@@ -3103,7 +3106,8 @@ Status DBImpl::CreateColumnFamilyImpl(const ColumnFamilyOptions& cf_options,
     }
   }  // InstrumentedMutexLock l(&mutex_)
 
-  if (cf_options.preclude_last_level_data_seconds > 0) {
+  if (cf_options.track_internal_time_seconds > 0 ||
+      cf_options.preclude_last_level_data_seconds > 0) {
     s = RegisterRecordSeqnoTimeWorker();
   }
   sv_context.Clean();
@@ -3194,7 +3198,8 @@ Status DBImpl::DropColumnFamilyImpl(ColumnFamilyHandle* column_family) {
     bg_cv_.SignalAll();
   }
 
-  if (cfd->ioptions()->preclude_last_level_data_seconds > 0) {
+  if (cfd->ioptions()->track_internal_time_seconds > 0 ||
+      cfd->ioptions()->preclude_last_level_data_seconds > 0) {
     s = RegisterRecordSeqnoTimeWorker();
   }
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -850,7 +850,7 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
       // If track internal time option is specified, use it
       uint64_t track_time_duration =
           cfd->ioptions()->preclude_last_level_data_seconds == 0
-              ? cfd->ioptions()->track_internal_time_seconds
+              ? cfd->ioptions()->preserve_internal_time_seconds
               : cfd->ioptions()->preclude_last_level_data_seconds;
       if (!cfd->IsDropped() && track_time_duration > 0) {
         min_time_duration = std::min(track_time_duration, min_time_duration);
@@ -3106,7 +3106,7 @@ Status DBImpl::CreateColumnFamilyImpl(const ColumnFamilyOptions& cf_options,
     }
   }  // InstrumentedMutexLock l(&mutex_)
 
-  if (cf_options.track_internal_time_seconds > 0 ||
+  if (cf_options.preserve_internal_time_seconds > 0 ||
       cf_options.preclude_last_level_data_seconds > 0) {
     s = RegisterRecordSeqnoTimeWorker();
   }
@@ -3198,7 +3198,7 @@ Status DBImpl::DropColumnFamilyImpl(ColumnFamilyHandle* column_family) {
     bg_cv_.SignalAll();
   }
 
-  if (cfd->ioptions()->track_internal_time_seconds > 0 ||
+  if (cfd->ioptions()->preserve_internal_time_seconds > 0 ||
       cfd->ioptions()->preclude_last_level_data_seconds > 0) {
     s = RegisterRecordSeqnoTimeWorker();
   }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -849,10 +849,8 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
     for (auto cfd : *versions_->GetColumnFamilySet()) {
       // If preclude_last_level is specified, use it. Otherwise, check if
       // preserve_internal is specified.
-      uint64_t track_time_duration =
-          cfd->ioptions()->preclude_last_level_data_seconds == 0
-              ? cfd->ioptions()->preserve_internal_time_seconds
-              : cfd->ioptions()->preclude_last_level_data_seconds;
+
+      uint64_t track_time_duration = std::max(cfd->ioptions()->preserve_internal_time_seconds, cfd->ioptions()->preclude_last_level_data_seconds);
       if (!cfd->IsDropped() && track_time_duration > 0) {
         min_time_duration = std::min(track_time_duration, min_time_duration);
         max_time_duration = std::max(track_time_duration, max_time_duration);

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -847,15 +847,13 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
     InstrumentedMutexLock l(&mutex_);
 
     for (auto cfd : *versions_->GetColumnFamilySet()) {
-      // If preclude_last_level is specified, use it. Otherwise, check if
-      // preserve_internal is specified.
-
-      uint64_t track_time_duration =
+      // preserve time is the max of 2 options.
+      uint64_t preserve_time_duration =
           std::max(cfd->ioptions()->preserve_internal_time_seconds,
                    cfd->ioptions()->preclude_last_level_data_seconds);
-      if (!cfd->IsDropped() && track_time_duration > 0) {
-        min_time_duration = std::min(track_time_duration, min_time_duration);
-        max_time_duration = std::max(track_time_duration, max_time_duration);
+      if (!cfd->IsDropped() && preserve_time_duration > 0) {
+        min_time_duration = std::min(preserve_time_duration, min_time_duration);
+        max_time_duration = std::max(preserve_time_duration, max_time_duration);
       }
     }
     if (min_time_duration == std::numeric_limits<uint64_t>::max()) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -850,7 +850,9 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
       // If preclude_last_level is specified, use it. Otherwise, check if
       // preserve_internal is specified.
 
-      uint64_t track_time_duration = std::max(cfd->ioptions()->preserve_internal_time_seconds, cfd->ioptions()->preclude_last_level_data_seconds);
+      uint64_t track_time_duration =
+          std::max(cfd->ioptions()->preserve_internal_time_seconds,
+                   cfd->ioptions()->preclude_last_level_data_seconds);
       if (!cfd->IsDropped() && track_time_duration > 0) {
         min_time_duration = std::min(track_time_duration, min_time_duration);
         max_time_duration = std::max(track_time_duration, max_time_duration);

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -710,7 +710,7 @@ TEST_P(SeqnoTimeTablePropTest, SeqnoToTimeMappingUniversal) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->SetCallBack(
       "CompactionIterator::PrepareOutput:ZeroingSeq",
-      [&](void* arg) { num_seqno_zeroing++; });
+      [&](void* /*arg*/) { num_seqno_zeroing++; });
   SyncPoint::GetInstance()->EnableProcessing();
 
   for (int j = 0; j < 3; j++) {

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -295,12 +295,12 @@ class SeqnoTimeTablePropTest : public SeqnoTimeTest, public ::testing::WithParam
         options.track_internal_time_seconds = 0;
         break;
       case SeqnoTimeTestType::kBothSetTrackSmaller:
-        options.preclude_last_level_data_seconds = 10 * track_time_duration;
-        options.track_internal_time_seconds = track_time_duration;
+        options.preclude_last_level_data_seconds = track_time_duration;
+        options.track_internal_time_seconds = track_time_duration / 10;
         break;
       case SeqnoTimeTestType::kBothSetTrackLarger:
-        options.preclude_last_level_data_seconds = track_time_duration / 10;
-        options.track_internal_time_seconds = track_time_duration;
+        options.preclude_last_level_data_seconds = track_time_duration;
+        options.track_internal_time_seconds = track_time_duration * 10;
         break;
     }
   }
@@ -783,6 +783,7 @@ TEST_P(SeqnoTimeTablePropTest, SeqnoToTimeMappingUniversal) {
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
 
   ASSERT_GT(num_seqno_zeroing, 0);
+  ASSERT_GT(NumTableFilesAtLevel(6), 0);
 
   Close();
 }

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -37,7 +37,7 @@ class SeqnoTimeTest : public DBTestBase {
   }
 
   // make sure the file is not in cache, otherwise it won't have IO info
-  void AssertKetTemperature(int key_id, Temperature expected_temperature) {
+  void AssertKeyTemperature(int key_id, Temperature expected_temperature) {
     get_iostats_context()->Reset();
     IOStatsContext* iostats = get_iostats_context();
     std::string result = Get(Key(key_id));
@@ -101,7 +101,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
   ASSERT_EQ(GetSstSizeHelper(Temperature::kCold), 0);
 
   // read a random key, which should be hot (kUnknown)
-  AssertKetTemperature(20, Temperature::kUnknown);
+  AssertKeyTemperature(20, Temperature::kUnknown);
 
   // Write more data, but still all hot until the 10th SST, as:
   // write a key every 10 seconds, 100 keys per SST, each SST takes 1000 seconds
@@ -139,7 +139,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
   ASSERT_GT(hot_data_size, 0);
   ASSERT_GT(cold_data_size, 0);
   // the first a few key should be cold
-  AssertKetTemperature(20, Temperature::kCold);
+  AssertKeyTemperature(20, Temperature::kCold);
 
   for (int i = 0; i < 30; i++) {
     dbfull()->TEST_WaitForPeridicTaskRun([&] {
@@ -148,8 +148,8 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
     ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
 
     // the hot/cold data cut off range should be between i * 20 + 200 -> 250
-    AssertKetTemperature(i * 20 + 250, Temperature::kUnknown);
-    AssertKetTemperature(i * 20 + 200, Temperature::kCold);
+    AssertKeyTemperature(i * 20 + 250, Temperature::kUnknown);
+    AssertKeyTemperature(i * 20 + 200, Temperature::kCold);
   }
 
   ASSERT_LT(GetSstSizeHelper(Temperature::kUnknown), hot_data_size);
@@ -166,7 +166,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
   }
 
   // any random data close to the end should be cold
-  AssertKetTemperature(1000, Temperature::kCold);
+  AssertKeyTemperature(1000, Temperature::kCold);
 
   // close explicitly, because the env is local variable which will be released
   // first.
@@ -215,7 +215,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicLevel) {
   ASSERT_EQ(GetSstSizeHelper(Temperature::kCold), 0);
 
   // read a random key, which should be hot (kUnknown)
-  AssertKetTemperature(20, Temperature::kUnknown);
+  AssertKeyTemperature(20, Temperature::kUnknown);
 
   // Adding more data to have mixed hot and cold data
   for (; sst_num < 14; sst_num++) {
@@ -237,7 +237,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicLevel) {
   ASSERT_GT(hot_data_size, 0);
   ASSERT_GT(cold_data_size, 0);
   // the first a few key should be cold
-  AssertKetTemperature(20, Temperature::kCold);
+  AssertKeyTemperature(20, Temperature::kCold);
 
   // Wait some time, with each wait, the cold data is increasing and hot data is
   // decreasing
@@ -253,8 +253,8 @@ TEST_F(SeqnoTimeTest, TemperatureBasicLevel) {
     ASSERT_GT(cold_data_size, pre_cold);
 
     // the hot/cold cut_off key should be around i * 20 + 400 -> 450
-    AssertKetTemperature(i * 20 + 450, Temperature::kUnknown);
-    AssertKetTemperature(i * 20 + 400, Temperature::kCold);
+    AssertKeyTemperature(i * 20 + 450, Temperature::kUnknown);
+    AssertKeyTemperature(i * 20 + 400, Temperature::kCold);
   }
 
   // Wait again, the most of the data should be cold after that
@@ -267,7 +267,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicLevel) {
   }
 
   // any random data close to the end should be cold
-  AssertKetTemperature(1000, Temperature::kCold);
+  AssertKeyTemperature(1000, Temperature::kCold);
 
   Close();
 }
@@ -747,9 +747,6 @@ TEST_P(SeqnoTimeTablePropTest, SeqnoToTimeMappingUniversal) {
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
   tables_props.clear();
   ASSERT_OK(dbfull()->GetPropertiesOfAllTables(&tables_props));
-  if (tables_props.size() > 1) {
-    std::cout << "JJJ1" << std::endl;
-  }
   ASSERT_EQ(tables_props.size(), 1);
 
   auto it = tables_props.begin();

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -305,19 +305,11 @@ class SeqnoTimeTablePropTest
   }
 };
 
-// INSTANTIATE_TEST_CASE_P(
-//     SeqnoTimeTablePropTest, SeqnoTimeTablePropTest,
-//     ::testing::Values(SeqnoTimeTestType::kTrackInternalTimeSeconds,
-//                       SeqnoTimeTestType::kPrecludeLastLevel,
-//                       SeqnoTimeTestType::kBothSetTrackSmaller));
 INSTANTIATE_TEST_CASE_P(
     SeqnoTimeTablePropTest, SeqnoTimeTablePropTest,
     ::testing::Values(SeqnoTimeTestType::kTrackInternalTimeSeconds,
                       SeqnoTimeTestType::kPrecludeLastLevel,
                       SeqnoTimeTestType::kBothSetTrackSmaller));
-// INSTANTIATE_TEST_CASE_P(
-//     SeqnoTimeTablePropTest, SeqnoTimeTablePropTest,
-//     ::testing::Values(SeqnoTimeTestType::kBothSetTrackLarger));
 
 TEST_P(SeqnoTimeTablePropTest, BasicSeqnoToTimeMapping) {
   Options options = CurrentOptions();

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -706,7 +706,6 @@ TEST_P(SeqnoTimeTablePropTest, SeqnoToTimeMappingUniversal) {
   const int kNumTrigger = 4;
   const int kNumLevels = 7;
   const int kNumKeys = 100;
-  const int kKeyPerSec = 10;
 
   Options options = CurrentOptions();
   SetTrackTimeDurationOptions(10000, options);

--- a/db/seqno_to_time_mapping.cc
+++ b/db/seqno_to_time_mapping.cc
@@ -69,7 +69,6 @@ SequenceNumber SeqnoToTimeMapping::GetOldestSequenceNum(uint64_t time) {
   return it->seqno;
 }
 
-
 // The encoded format is:
 //  [num_of_entries][[seqno][time],[seqno][time],...]
 //      ^                                 ^

--- a/db/seqno_to_time_mapping.cc
+++ b/db/seqno_to_time_mapping.cc
@@ -31,11 +31,11 @@ void SeqnoToTimeMapping::Add(SequenceNumber seqno, uint64_t time) {
   seqno_time_mapping_.emplace_back(seqno, time);
 }
 
-SequenceNumber SeqnoToTimeMapping::TruncateOldEntries(const uint64_t now) {
+void SeqnoToTimeMapping::TruncateOldEntries(const uint64_t now) {
   assert(is_sorted_);
 
   if (max_time_duration_ == 0) {
-    return 0;
+    return;
   }
 
   const uint64_t cut_off_time =
@@ -48,13 +48,27 @@ SequenceNumber SeqnoToTimeMapping::TruncateOldEntries(const uint64_t now) {
         return target < other.time;
       });
   if (it == seqno_time_mapping_.begin()) {
-    return 0;
+    return;
   }
   it--;
   seqno_time_mapping_.erase(seqno_time_mapping_.begin(), it);
-
-  return seqno_time_mapping_.front().seqno;
 }
+
+SequenceNumber SeqnoToTimeMapping::GetOldestSequenceNum(uint64_t time) {
+  assert(is_sorted_);
+
+  auto it = std::upper_bound(
+      seqno_time_mapping_.begin(), seqno_time_mapping_.end(), time,
+      [](uint64_t target, const SeqnoTimePair& other) -> bool {
+        return target < other.time;
+      });
+  if (it == seqno_time_mapping_.begin()) {
+    return 0;
+  }
+  it--;
+  return it->seqno;
+}
+
 
 // The encoded format is:
 //  [num_of_entries][[seqno][time],[seqno][time],...]

--- a/db/seqno_to_time_mapping.cc
+++ b/db/seqno_to_time_mapping.cc
@@ -107,6 +107,10 @@ void SeqnoToTimeMapping::Encode(std::string& dest, const SequenceNumber start,
       start_it++;
     }
   }
+  // to include the first element
+  if (start_it != seqno_time_mapping_.begin()) {
+    start_it--;
+  }
 
   // If there are more data than needed, pick the entries for encoding.
   // It's not the most optimized algorithm for selecting the best representative

--- a/db/seqno_to_time_mapping.h
+++ b/db/seqno_to_time_mapping.h
@@ -109,6 +109,7 @@ class SeqnoToTimeMapping {
   // Truncate the old entries based on the current time and max_time_duration_
   void TruncateOldEntries(uint64_t now);
 
+  // Given a time, return it's oldest possible sequence number
   SequenceNumber GetOldestSequenceNum(uint64_t time);
 
   // Encode to a binary string

--- a/db/seqno_to_time_mapping.h
+++ b/db/seqno_to_time_mapping.h
@@ -107,7 +107,9 @@ class SeqnoToTimeMapping {
   uint64_t GetOldestApproximateTime(SequenceNumber seqno) const;
 
   // Truncate the old entries based on the current time and max_time_duration_
-  SequenceNumber TruncateOldEntries(uint64_t now);
+  void TruncateOldEntries(uint64_t now);
+
+  SequenceNumber GetOldestSequenceNum(uint64_t time);
 
   // Encode to a binary string
   void Encode(std::string& des, SequenceNumber start, SequenceNumber end,

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -914,6 +914,18 @@ struct AdvancedColumnFamilyOptions {
   uint64_t preclude_last_level_data_seconds = 0;
 
   // EXPERIMENTAL
+  // If this option is set, it will preserve the internal time information about
+  // the data until it's older than the specified time here.
+  // Internally the time information is a map between sequence number and time,
+  // which is the same as `preclude_last_level_data_seconds`. But it won't
+  // preclude the data from the last level and the data in the last level won't
+  // have the sequence number zeroed out.
+  //
+  // Note: if `preclude_last_level_data_seconds` is set, this option is ignored.
+  //  It's typically used for the migration of existing data to tiered storage.
+  //  The user can enable this feature first, then the existing data will have
+  //  time information for `preclude_last_level_data_seconds` feature which will
+  //  be enabled later.
   uint64_t preserve_internal_time_seconds = 0;
 
   // When set, large values (blobs) are written to separate blob files, and

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -913,6 +913,9 @@ struct AdvancedColumnFamilyOptions {
   // Default: 0 (disable the feature)
   uint64_t preclude_last_level_data_seconds = 0;
 
+  // EXPERIMENTAL
+  uint64_t track_internal_time_seconds = 0;
+
   // When set, large values (blobs) are written to separate blob files, and
   // only pointers to them are stored in SST files. This can reduce write
   // amplification for large-value use cases at the cost of introducing a level

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -911,6 +911,8 @@ struct AdvancedColumnFamilyOptions {
   //  size constrained, the size amp is going to be only for non-last levels.
   //
   // Default: 0 (disable the feature)
+  //
+  // Not dynamically changeable, change it requires db restart.
   uint64_t preclude_last_level_data_seconds = 0;
 
   // EXPERIMENTAL
@@ -920,12 +922,16 @@ struct AdvancedColumnFamilyOptions {
   // which is the same as `preclude_last_level_data_seconds`. But it won't
   // preclude the data from the last level and the data in the last level won't
   // have the sequence number zeroed out.
+  // Internally, rocksdb would sample the sequence number to time pair and store
+  // that in SST property "rocksdb.seqno.time.map". The information is currently
+  // only used for tiered storage compaction (option
+  // `preclude_last_level_data_seconds`).
   //
   // Note: if `preclude_last_level_data_seconds` is set, this option is ignored.
-  //  It's typically used for the migration of existing data to tiered storage.
-  //  The user can enable this feature first, then the existing data will have
-  //  time information for `preclude_last_level_data_seconds` feature which will
-  //  be enabled later.
+  //
+  // Default: 0 (disable the feature)
+  //
+  // Not dynamically changeable, change it requires db restart.
   uint64_t preserve_internal_time_seconds = 0;
 
   // When set, large values (blobs) are written to separate blob files, and

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -914,7 +914,7 @@ struct AdvancedColumnFamilyOptions {
   uint64_t preclude_last_level_data_seconds = 0;
 
   // EXPERIMENTAL
-  uint64_t track_internal_time_seconds = 0;
+  uint64_t preserve_internal_time_seconds = 0;
 
   // When set, large values (blobs) are written to separate blob files, and
   // only pointers to them are stored in SST files. This can reduce write

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -927,7 +927,11 @@ struct AdvancedColumnFamilyOptions {
   // only used for tiered storage compaction (option
   // `preclude_last_level_data_seconds`).
   //
-  // Note: if `preclude_last_level_data_seconds` is set, this option is ignored.
+  // Note: if both `preclude_last_level_data_seconds` and this option is set, it
+  //  will preserve the max time of the 2 options and compaction still preclude
+  //  the data based on `preclude_last_level_data_seconds`.
+  //  The higher the preserve_time is, the less the sampling frequency will be (
+  //  which means less accuracy of the time estimation).
   //
   // Default: 0 (disable the feature)
   //

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -567,8 +567,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableCFOptions, preclude_last_level_data_seconds),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
-        {"track_internal_time_seconds",
-         {offsetof(struct ImmutableCFOptions, track_internal_time_seconds),
+        {"preserve_internal_time_seconds",
+         {offsetof(struct ImmutableCFOptions, preserve_internal_time_seconds),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         // Need to keep this around to be able to read old OPTIONS files.
@@ -908,7 +908,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       force_consistency_checks(cf_options.force_consistency_checks),
       preclude_last_level_data_seconds(
           cf_options.preclude_last_level_data_seconds),
-      track_internal_time_seconds(cf_options.track_internal_time_seconds),
+      preserve_internal_time_seconds(cf_options.preserve_internal_time_seconds),
       memtable_insert_with_hint_prefix_extractor(
           cf_options.memtable_insert_with_hint_prefix_extractor),
       cf_paths(cf_options.cf_paths),

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -567,6 +567,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableCFOptions, preclude_last_level_data_seconds),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"track_internal_time_seconds",
+         {offsetof(struct ImmutableCFOptions, track_internal_time_seconds),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         // Need to keep this around to be able to read old OPTIONS files.
         {"max_mem_compaction_level",
          {0, OptionType::kInt, OptionVerificationType::kDeprecated,
@@ -904,6 +908,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       force_consistency_checks(cf_options.force_consistency_checks),
       preclude_last_level_data_seconds(
           cf_options.preclude_last_level_data_seconds),
+      track_internal_time_seconds(cf_options.track_internal_time_seconds),
       memtable_insert_with_hint_prefix_extractor(
           cf_options.memtable_insert_with_hint_prefix_extractor),
       cf_paths(cf_options.cf_paths),

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -74,7 +74,7 @@ struct ImmutableCFOptions {
 
   uint64_t preclude_last_level_data_seconds;
 
-  uint64_t track_internal_time_seconds;
+  uint64_t preserve_internal_time_seconds;
 
   std::shared_ptr<const SliceTransform>
       memtable_insert_with_hint_prefix_extractor;

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -74,6 +74,8 @@ struct ImmutableCFOptions {
 
   uint64_t preclude_last_level_data_seconds;
 
+  uint64_t track_internal_time_seconds;
+
   std::shared_ptr<const SliceTransform>
       memtable_insert_with_hint_prefix_extractor;
 

--- a/options/options.cc
+++ b/options/options.cc
@@ -94,7 +94,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       sample_for_compression(options.sample_for_compression),
       preclude_last_level_data_seconds(
           options.preclude_last_level_data_seconds),
-      track_internal_time_seconds(options.track_internal_time_seconds),
+      preserve_internal_time_seconds(options.preserve_internal_time_seconds),
       enable_blob_files(options.enable_blob_files),
       min_blob_size(options.min_blob_size),
       blob_file_size(options.blob_file_size),
@@ -404,8 +404,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      periodic_compaction_seconds);
     ROCKS_LOG_HEADER(log, " Options.preclude_last_level_data_seconds: %" PRIu64,
                      preclude_last_level_data_seconds);
-    ROCKS_LOG_HEADER(log, "      Options.track_internal_time_seconds: %" PRIu64,
-                     track_internal_time_seconds);
+    ROCKS_LOG_HEADER(log, "   Options.preserve_internal_time_seconds: %" PRIu64,
+                     preserve_internal_time_seconds);
     ROCKS_LOG_HEADER(log, "                      Options.enable_blob_files: %s",
                      enable_blob_files ? "true" : "false");
     ROCKS_LOG_HEADER(

--- a/options/options.cc
+++ b/options/options.cc
@@ -94,6 +94,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       sample_for_compression(options.sample_for_compression),
       preclude_last_level_data_seconds(
           options.preclude_last_level_data_seconds),
+      track_internal_time_seconds(options.track_internal_time_seconds),
       enable_blob_files(options.enable_blob_files),
       min_blob_size(options.min_blob_size),
       blob_file_size(options.blob_file_size),
@@ -403,6 +404,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      periodic_compaction_seconds);
     ROCKS_LOG_HEADER(log, " Options.preclude_last_level_data_seconds: %" PRIu64,
                      preclude_last_level_data_seconds);
+    ROCKS_LOG_HEADER(log, "      Options.track_internal_time_seconds: %" PRIu64,
+                     track_internal_time_seconds);
     ROCKS_LOG_HEADER(log, "                      Options.enable_blob_files: %s",
                      enable_blob_files ? "true" : "false");
     ROCKS_LOG_HEADER(

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -314,6 +314,7 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
   cf_opts->blob_cache = ioptions.blob_cache;
   cf_opts->preclude_last_level_data_seconds =
       ioptions.preclude_last_level_data_seconds;
+  cf_opts->track_internal_time_seconds = ioptions.track_internal_time_seconds;
 
   // TODO(yhchiang): find some way to handle the following derived options
   // * max_file_size

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -314,7 +314,8 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
   cf_opts->blob_cache = ioptions.blob_cache;
   cf_opts->preclude_last_level_data_seconds =
       ioptions.preclude_last_level_data_seconds;
-  cf_opts->track_internal_time_seconds = ioptions.track_internal_time_seconds;
+  cf_opts->preserve_internal_time_seconds =
+      ioptions.preserve_internal_time_seconds;
 
   // TODO(yhchiang): find some way to handle the following derived options
   // * max_file_size

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -403,6 +403,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
        sizeof(ColumnFamilyOptions::TablePropertiesCollectorFactories)},
       {offsetof(struct ColumnFamilyOptions, preclude_last_level_data_seconds),
        sizeof(uint64_t)},
+      {offsetof(struct ColumnFamilyOptions, track_internal_time_seconds),
+       sizeof(uint64_t)},
       {offsetof(struct ColumnFamilyOptions, blob_cache),
        sizeof(std::shared_ptr<Cache>)},
       {offsetof(struct ColumnFamilyOptions, comparator), sizeof(Comparator*)},
@@ -532,6 +534,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "bottommost_temperature=kWarm;"
       "last_level_temperature=kWarm;"
       "preclude_last_level_data_seconds=86400;"
+      "track_internal_time_seconds=86400;"
       "compaction_options_fifo={max_table_files_size=3;allow_"
       "compaction=false;age_for_warm=1;};"
       "blob_cache=1M;"

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -403,7 +403,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
        sizeof(ColumnFamilyOptions::TablePropertiesCollectorFactories)},
       {offsetof(struct ColumnFamilyOptions, preclude_last_level_data_seconds),
        sizeof(uint64_t)},
-      {offsetof(struct ColumnFamilyOptions, track_internal_time_seconds),
+      {offsetof(struct ColumnFamilyOptions, preserve_internal_time_seconds),
        sizeof(uint64_t)},
       {offsetof(struct ColumnFamilyOptions, blob_cache),
        sizeof(std::shared_ptr<Cache>)},
@@ -534,7 +534,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "bottommost_temperature=kWarm;"
       "last_level_temperature=kWarm;"
       "preclude_last_level_data_seconds=86400;"
-      "track_internal_time_seconds=86400;"
+      "preserve_internal_time_seconds=86400;"
       "compaction_options_fifo={max_table_files_size=3;allow_"
       "compaction=false;age_for_warm=1;};"
       "blob_cache=1M;"


### PR DESCRIPTION
Add option `preserve_internal_time_seconds` to preserve the internal
time information.
It's mostly for the migration of the existing data to tiered storage (
`preclude_last_level_data_seconds`). When the tiering feature is just
enabled, the existing data won't have the time information to decide if
it's hot or cold. Enabling this feature will start collect and preserve
the time information for the new data.