### PR TITLE
Fix signed/unsigned assignments, comparisons

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -4504,7 +4504,7 @@ void rocksdb_options_set_min_level_to_compress(rocksdb_options_t* opt, int level
     for (int i = 0; i < level; i++) {
       opt->rep.compression_per_level[i] = ROCKSDB_NAMESPACE::kNoCompression;
     }
-    for (int i = level; i < opt->rep.num_levels; i++) {
+    for (unsigned int i = static_cast<unsigned int>(level); i < opt->rep.num_levels; i++) {
       opt->rep.compression_per_level[i] = opt->rep.compression;
     }
   }

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -173,9 +173,10 @@ struct CompressionOptions {
         parallel_threads(1),
         enabled(false),
         max_dict_buffer_bytes(0) {}
-  CompressionOptions(int wbits, int _lev, int _strategy, int _max_dict_bytes,
-                     int _zstd_max_train_bytes, int _parallel_threads,
-                     bool _enabled, uint64_t _max_dict_buffer_bytes)
+  CompressionOptions(int wbits, int _lev, int _strategy,
+                     uint32_t _max_dict_bytes, uint32_t _zstd_max_train_bytes,
+                     uint32_t _parallel_threads, bool _enabled,
+                     uint64_t _max_dict_buffer_bytes)
       : window_bits(wbits),
         level(_lev),
         strategy(_strategy),
@@ -419,7 +420,7 @@ struct AdvancedColumnFamilyOptions {
   std::vector<CompressionType> compression_per_level;
 
   // Number of levels for this database
-  int num_levels = 7;
+  unsigned int num_levels = 7;
 
   // Soft limit on number of level-0 files. We start slowing down writes at this
   // point. A value <0 means that no writing slow down will be triggered by

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -46,7 +46,7 @@ struct ExternalSstFileInfo {
                       const std::string& _smallest_key,
                       const std::string& _largest_key,
                       SequenceNumber _sequence_number, uint64_t _file_size,
-                      int32_t _num_entries, int32_t _version)
+                      uint64_t _num_entries, int32_t _version)
       : file_path(_file_path),
         smallest_key(_smallest_key),
         largest_key(_largest_key),

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -41,12 +41,12 @@ struct SliceParts;
 
 struct SavePoint {
   size_t size;  // size of rep_
-  int count;    // count of elements in rep_
+  unsigned int count;    // count of elements in rep_
   uint32_t content_flags;
 
   SavePoint() : size(0), count(0), content_flags(0) {}
 
-  SavePoint(size_t _size, int _count, uint32_t _flags)
+  SavePoint(size_t _size, unsigned int _count, uint32_t _flags)
       : size(_size), count(_count), content_flags(_flags) {}
 
   void clear() {

--- a/options/options.cc
+++ b/options/options.cc
@@ -586,7 +586,7 @@ ColumnFamilyOptions* ColumnFamilyOptions::OptimizeLevelStyleCompaction(
 
   // only compress levels >= 2
   compression_per_level.resize(num_levels);
-  for (int i = 0; i < num_levels; ++i) {
+  for (unsigned int i = 0; i < num_levels; ++i) {
     if (i < 2) {
       compression_per_level[i] = kNoCompression;
     } else {

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -409,7 +409,7 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, DBOptions& db_options,
 
   // vector int options
   cf_opt->max_bytes_for_level_multiplier_additional.resize(cf_opt->num_levels);
-  for (int i = 0; i < cf_opt->num_levels; i++) {
+  for (unsigned int i = 0; i < cf_opt->num_levels; i++) {
     cf_opt->max_bytes_for_level_multiplier_additional[i] = rnd->Uniform(100);
   }
 

--- a/utilities/option_change_migration/option_change_migration.cc
+++ b/utilities/option_change_migration/option_change_migration.cc
@@ -93,7 +93,7 @@ Status MigrateToUniversal(std::string dbname, const Options& old_opts,
       ColumnFamilyMetaData metadata;
       db->GetColumnFamilyMetaData(&metadata);
       if (!metadata.levels.empty() &&
-          metadata.levels.back().level >= new_opts.num_levels) {
+          static_cast<unsigned int>(metadata.levels.back().level) >= new_opts.num_levels) {
         need_compact = true;
       }
     }


### PR DESCRIPTION
This probably makes an incompatible ABI, so if that matters I can either do:
- change one uint64_t to uint32_t
or
- remove all the interface changes and instead add static_cast's.

(The reason for making these changes is that I have a project that needs to build with `-Wconversion -Wsign-conversion` and that results in warnings from some of the rocksdb header files)