### PR TITLE
db_stress TestIngestExternalFile avoid empty files

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1028,6 +1028,10 @@ class NonBatchedOpsStressTest : public StressTest {
       s = sst_file_writer.Put(Slice(key_str), Slice(value, value_len));
     }
 
+    if (s.ok() && keys.empty()) {
+      return;
+    }
+
     if (s.ok()) {
       s = sst_file_writer.Finish();
     }


### PR DESCRIPTION
If all the keys in range [key_base, shared->GetMaxKey()) are non-overwritable `TestIngestExternalFile()` would attempt to ingest a file with zero keys, leading to the following error: "Cannot create sst file with no entries". This PR changes `TestIngestExternalFile()` to return early in that case instead of going through with the ingestion attempt.