### PR TITLE
Track expected state only if expected values dir is non-empty

### DIFF
--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -143,7 +143,9 @@ bool RunStressTest(StressTest* stress) {
 
     // This is after the verification step to avoid making all those `Get()`s
     // and `MultiGet()`s contend on the DB-wide trace mutex.
-    stress->TrackExpectedState(&shared);
+    if (!FLAGS_expected_values_dir.empty()) {
+      stress->TrackExpectedState(&shared);
+    }
 
     now = clock->NowMicros();
     fprintf(stdout, "%s Starting database operations\n",


### PR DESCRIPTION
If the `-expected_values_dir` argument to db_stress is empty, then verification against expected state is effectively disabled. But `RunStressTest` still calls `TrackExpectedState`, which returns `NotSupported` causing a the crash test to fail with a false alarm. Fix it by only calling `TrackExpectedState` if necessary.