### PR TITLE
Add iterator refresh to stress test

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1224,6 +1224,11 @@ class NonBatchedOpsStressTest : public StressTest {
       op_logs += "P";
     }
 
+    if (thread->rand.OneIn(2)) {
+      // Refresh after forward/backward scan to allow higher chance of SV
+      // change. It is safe to refresh since the testing key range is locked.
+      iter->Refresh();
+    }
     // start from middle of [lb, ub) otherwise it is easy to iterate out of
     // locked range
     int64_t mid = lb + static_cast<int64_t>(FLAGS_num_iterations / 2);


### PR DESCRIPTION
Summary: added calls to `Iterator::Refresh()` in `NonBatchedOpsStressTest::TestIterateAgainstExpected()`. The testing key range is locked in `TestIterateAgainstExpected` so I do not expect this change to provide thorough stress test to `Iterator::Refresh()`. However, it can still be helpful for catching bugs like #10739. Will add calls to refresh in `TestIterate` once we support iterator refresh with snapshots.

Test plan: `python3 tools/db_crashtest.py whitebox --simple --verify_iterator_with_expected_state_one_in=2`