### PR TITLE
Remove cache key Slice from Cache::DeleterFn

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,9 @@
 ### New Features
 * Add a new option IOOptions.do_not_recurse that can be used by underlying file systems to skip recursing through sub directories and list only files in GetChildren API.
 
+### Public API changes
+* Changed `Cache::DeleterFn` function pointer type for internal efficiency improvements.
+
 ## 7.7.0 (09/18/2022)
 ### Bug Fixes
 * Fixed a hang when an operation such as `GetLiveFiles` or `CreateNewBackup` is asked to trigger and wait for memtable flush on a read-only DB. Such indirect requests for memtable flush are now ignored on a read-only DB.

--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-#include "cache_key.h"
 #ifdef GFLAGS
 #include <cinttypes>
 #include <cstddef>
@@ -13,6 +12,7 @@
 #include <set>
 #include <sstream>
 
+#include "cache/cache_key.h"
 #include "cache/fast_lru_cache.h"
 #include "db/db_impl/db_impl.h"
 #include "monitoring/histogram.h"
@@ -246,15 +246,9 @@ Status SaveToFn(void* obj, size_t /*offset*/, size_t size, void* out) {
 
 // Different deleters to simulate using deleter to gather
 // stats on the code origin and kind of cache entries.
-void deleter1(const Slice& /*key*/, void* value) {
-  delete[] static_cast<char*>(value);
-}
-void deleter2(const Slice& /*key*/, void* value) {
-  delete[] static_cast<char*>(value);
-}
-void deleter3(const Slice& /*key*/, void* value) {
-  delete[] static_cast<char*>(value);
-}
+void deleter1(void* value) { delete[] static_cast<char*>(value); }
+void deleter2(void* value) { delete[] static_cast<char*>(value); }
+void deleter3(void* value) { delete[] static_cast<char*>(value); }
 
 Cache::CacheItemHelper helper1(SizeFn, SaveToFn, deleter1);
 Cache::CacheItemHelper helper2(SizeFn, SaveToFn, deleter2);

--- a/cache/cache_entry_roles.h
+++ b/cache/cache_entry_roles.h
@@ -63,7 +63,7 @@ struct RegisteredDeleter {
 
   // These have global linkage to help ensure compiler optimizations do not
   // break uniqueness for each <T,R>
-  static void Delete(const Slice& /* key */, void* value) {
+  static void Delete(void* value) {
     // Supports T == Something[], unlike delete operator
     std::default_delete<T>()(
         static_cast<typename std::remove_extent<T>::type*>(value));
@@ -74,7 +74,7 @@ template <CacheEntryRole R>
 struct RegisteredNoopDeleter {
   RegisteredNoopDeleter() { RegisterCacheDeleterRole(Delete, R); }
 
-  static void Delete(const Slice& /* key */, void* /* value */) {
+  static void Delete(void* /* value */) {
     // Here was `assert(value == nullptr);` but we can also put pointers
     // to static data in Cache, for testing at least.
   }

--- a/cache/cache_entry_stats.h
+++ b/cache/cache_entry_stats.h
@@ -157,7 +157,7 @@ class CacheEntryStatsCollector {
         cache_(cache),
         clock_(clock) {}
 
-  static void Deleter(const Slice &, void *value) {
+  static void Deleter(void *value) {
     delete static_cast<CacheEntryStatsCollector *>(value);
   }
 

--- a/cache/cache_helpers.h
+++ b/cache/cache_helpers.h
@@ -23,7 +23,7 @@ T* GetFromCacheHandle(Cache* cache, Cache::Handle* handle) {
 
 // Simple generic deleter for Cache (to be used with Cache::Insert).
 template <typename T>
-void DeleteCacheEntry(const Slice& /* key */, void* value) {
+void DeleteCacheEntry(void* value) {
   delete static_cast<T*>(value);
 }
 

--- a/cache/clock_cache.h
+++ b/cache/clock_cache.h
@@ -315,7 +315,7 @@ struct ClockHandleBasicData {
 
   void FreeData() const {
     if (deleter) {
-      (*deleter)(KeySlice(), value);
+      (*deleter)(value);
     }
   }
 };

--- a/cache/compressed_secondary_cache.cc
+++ b/cache/compressed_secondary_cache.cc
@@ -279,7 +279,7 @@ CacheAllocationPtr CompressedSecondaryCache::MergeChunksIntoValue(
 Cache::DeleterFn CompressedSecondaryCache::GetDeletionCallback(
     bool enable_custom_split_merge) {
   if (enable_custom_split_merge) {
-    return [](const Slice& /*key*/, void* obj) {
+    return [](void* obj) {
       CacheValueChunk* chunks_head = reinterpret_cast<CacheValueChunk*>(obj);
       while (chunks_head != nullptr) {
         CacheValueChunk* tmp_chunk = chunks_head;
@@ -289,7 +289,7 @@ Cache::DeleterFn CompressedSecondaryCache::GetDeletionCallback(
       };
     };
   } else {
-    return [](const Slice& /*key*/, void* obj) {
+    return [](void* obj) {
       delete reinterpret_cast<CacheAllocationPtr*>(obj);
       obj = nullptr;
     };

--- a/cache/compressed_secondary_cache_test.cc
+++ b/cache/compressed_secondary_cache_test.cc
@@ -51,9 +51,8 @@ class CompressedSecondaryCacheTest : public testing::Test {
     return Status::OK();
   }
 
-  static void DeletionCallback(const Slice& /*key*/, void* obj) {
+  static void DeletionCallback(void* obj) {
     delete reinterpret_cast<TestItem*>(obj);
-    obj = nullptr;
   }
 
   static Cache::CacheItemHelper helper_;
@@ -741,7 +740,7 @@ class CompressedSecondaryCacheTest : public testing::Test {
     current_chunk = current_chunk->next;
     ASSERT_EQ(current_chunk->size, 98);
 
-    sec_cache->GetDeletionCallback(true)("dummy", chunks_head);
+    sec_cache->GetDeletionCallback(true)(chunks_head);
   }
 
   void MergeChunksIntoValueTest() {
@@ -822,7 +821,7 @@ class CompressedSecondaryCacheTest : public testing::Test {
     std::string value_str{value.get(), charge};
     ASSERT_EQ(strcmp(value_str.data(), str.data()), 0);
 
-    sec_cache->GetDeletionCallback(true)("dummy", chunks_head);
+    sec_cache->GetDeletionCallback(true)(chunks_head);
   }
 
  private:

--- a/cache/fast_lru_cache.h
+++ b/cache/fast_lru_cache.h
@@ -177,7 +177,7 @@ struct LRUHandle {
   void FreeData() {
     assert(refs == 0);
     if (deleter) {
-      (*deleter)(key(), value);
+      (*deleter)(value);
     }
   }
 

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -676,8 +676,7 @@ bool LRUCacheShard::Release(Cache::Handle* handle, bool erase_if_last_ref) {
 }
 
 Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
-                             size_t charge,
-                             void (*deleter)(const Slice& key, void* value),
+                             size_t charge, Cache::DeleterFn deleter,
                              const Cache::CacheItemHelper* helper,
                              Cache::Handle** handle, Cache::Priority priority) {
   // Allocate the memory here outside of the mutex.

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -210,7 +210,7 @@ struct LRUHandle {
   void Free() {
     assert(refs == 0);
     if (!IsSecondaryCacheCompatible() && info_.deleter) {
-      (*info_.deleter)(key(), value);
+      (*info_.deleter)(value);
     } else if (IsSecondaryCacheCompatible()) {
       if (IsPending()) {
         assert(sec_handle != nullptr);
@@ -220,7 +220,7 @@ struct LRUHandle {
         delete tmp_sec_handle;
       }
       if (value) {
-        (*info_.helper->del_cb)(key(), value);
+        (*info_.helper->del_cb)(value);
       }
     }
     delete[] reinterpret_cast<char*>(this);

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -800,9 +800,7 @@ TEST_F(ClockCacheTest, ClockEvictionTest) {
   }
 }
 
-void IncrementIntDeleter(const Slice& /*key*/, void* value) {
-  *reinterpret_cast<int*>(value) += 1;
-}
+void IncrementIntDeleter(void* value) { *reinterpret_cast<int*>(value) += 1; }
 
 // Testing calls to CorrectNearOverflow in Release
 TEST_F(ClockCacheTest, ClockCounterOverflowTest) {
@@ -1057,10 +1055,9 @@ class TestSecondaryCache : public SecondaryCache {
       delete[] buf;
       return s;
     }
-    return cache_->Insert(key, buf, size,
-                          [](const Slice& /*key*/, void* val) -> void {
-                            delete[] static_cast<char*>(val);
-                          });
+    return cache_->Insert(key, buf, size, [](void* val) -> void {
+      delete[] static_cast<char*>(val);
+    });
   }
 
   std::unique_ptr<SecondaryCacheResultHandle> Lookup(
@@ -1226,7 +1223,7 @@ class LRUCacheSecondaryCacheTest : public LRUCacheTest {
     return Status::OK();
   }
 
-  static void DeletionCallback(const Slice& /*key*/, void* obj) {
+  static void DeletionCallback(void* obj) {
     delete reinterpret_cast<TestItem*>(obj);
   }
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -3472,8 +3472,7 @@ class DBBasicTestMultiGet : public DBTestBase {
 
     using Cache::Insert;
     Status Insert(const Slice& key, void* value, size_t charge,
-                  void (*deleter)(const Slice& key, void* value),
-                  Handle** handle = nullptr,
+                  Cache::DeleterFn deleter, Handle** handle = nullptr,
                   Priority priority = Priority::LOW) override {
       num_inserts_++;
       return target_->Insert(key, value, charge, deleter, handle, priority);

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -405,8 +405,8 @@ class ReadOnlyCacheWrapper : public CacheWrapper {
 
   using Cache::Insert;
   Status Insert(const Slice& /*key*/, void* /*value*/, size_t /*charge*/,
-                void (*)(const Slice& key, void* value) /*deleter*/,
-                Handle** /*handle*/, Priority /*priority*/) override {
+                Cache::DeleterFn /*deleter*/, Handle** /*handle*/,
+                Priority /*priority*/) override {
     return Status::NotSupported();
   }
 };

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -1700,10 +1700,11 @@ TargetCacheChargeTrackingCache<R>::TargetCacheChargeTrackingCache(
       cache_charge_increments_sum_(0) {}
 
 template <CacheEntryRole R>
-Status TargetCacheChargeTrackingCache<R>::Insert(
-    const Slice& key, void* value, size_t charge,
-    void (*deleter)(const Slice& key, void* value), Handle** handle,
-    Priority priority) {
+Status TargetCacheChargeTrackingCache<R>::Insert(const Slice& key, void* value,
+                                                 size_t charge,
+                                                 Cache::DeleterFn deleter,
+                                                 Handle** handle,
+                                                 Priority priority) {
   Status s = target_->Insert(key, value, charge, deleter, handle, priority);
   if (deleter == kNoopDeleter) {
     if (last_peak_tracked_) {

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -884,8 +884,7 @@ class CacheWrapper : public Cache {
 
   using Cache::Insert;
   Status Insert(const Slice& key, void* value, size_t charge,
-                void (*deleter)(const Slice& key, void* value),
-                Handle** handle = nullptr,
+                Cache::DeleterFn deleter, Handle** handle = nullptr,
                 Priority priority = Priority::LOW) override {
     return target_->Insert(key, value, charge, deleter, handle, priority);
   }
@@ -972,8 +971,7 @@ class TargetCacheChargeTrackingCache : public CacheWrapper {
 
   using Cache::Insert;
   Status Insert(const Slice& key, void* value, size_t charge,
-                void (*deleter)(const Slice& key, void* value),
-                Handle** handle = nullptr,
+                Cache::DeleterFn deleter, Handle** handle = nullptr,
                 Priority priority = Priority::LOW) override;
 
   using Cache::Release;

--- a/db/table_cache_sync_and_async.h
+++ b/db/table_cache_sync_and_async.h
@@ -119,7 +119,7 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
         // If row cache is full, it's OK.
         ioptions_.row_cache
             ->Insert(row_cache_key.GetUserKey(), row_ptr, charge,
-                     &DeleteEntry<std::string>)
+                     &DeleteCacheEntry<std::string>)
             .PermitUncheckedError();
       }
     }

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -342,9 +342,8 @@ class Cache {
                                     size_t length, void* out);
 
   // A function pointer type for custom destruction of an entry's
-  // value. The Cache is responsible for copying and reclaiming space
-  // for the key, but values are managed by the caller.
-  using DeleterFn = void (*)(const Slice& key, void* value);
+  // value.
+  using DeleterFn = void (*)(void* value);
 
   // A struct with pointers to helper functions for spilling items from the
   // cache into the secondary cache. May be extended in the future. An
@@ -388,8 +387,9 @@ class Cache {
                                  const std::string& value,
                                  std::shared_ptr<Cache>* result);
 
-  // Destroys all existing entries by calling the "deleter"
-  // function that was passed via the Insert() function.
+  // Destroys the Cache, including calling the "deleter" on all entries
+  // in the cache. Requires no outstanding references to entries in the
+  // cache.
   //
   // @See Insert
   virtual ~Cache() {}

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "cache/cache_entry_roles.h"
+#include "cache/cache_helpers.h"
 #include "cache/cache_key.h"
 #include "cache/cache_reservation_manager.h"
 #include "db/dbformat.h"
@@ -1417,15 +1418,6 @@ IOStatus BlockBasedTableBuilder::io_status() const {
   return rep_->GetIOStatus();
 }
 
-namespace {
-// Delete the entry resided in the cache.
-template <class Entry>
-void DeleteEntryCached(const Slice& /*key*/, void* value) {
-  auto entry = reinterpret_cast<Entry*>(value);
-  delete entry;
-}
-}  // namespace
-
 //
 // Make a copy of the block contents and insert into compressed block cache
 //
@@ -1454,7 +1446,7 @@ Status BlockBasedTableBuilder::InsertBlockInCompressedCache(
     s = block_cache_compressed->Insert(
         key.AsSlice(), block_contents_to_cache,
         block_contents_to_cache->ApproximateMemoryUsage(),
-        &DeleteEntryCached<BlockContents>);
+        &DeleteCacheEntry<BlockContents>);
     if (s.ok()) {
       RecordTick(rep_->ioptions.stats, BLOCK_CACHE_COMPRESSED_ADD);
     } else {

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -166,7 +166,7 @@ class SimCacheImpl : public SimCache {
 
   using Cache::Insert;
   Status Insert(const Slice& key, void* value, size_t charge,
-                void (*deleter)(const Slice& key, void* value), Handle** handle,
+                Cache::DeleterFn deleter, Handle** handle,
                 Priority priority) override {
     // The handle and value passed in are for real cache, so we pass nullptr
     // to key_only_cache_ for both instead. Also, the deleter function pointer
@@ -176,9 +176,8 @@ class SimCacheImpl : public SimCache {
     Handle* h = key_only_cache_->Lookup(key);
     if (h == nullptr) {
       // TODO: Check for error here?
-      auto s = key_only_cache_->Insert(
-          key, nullptr, charge, [](const Slice& /*k*/, void* /*v*/) {}, nullptr,
-          priority);
+      auto s = key_only_cache_->Insert(key, nullptr, charge, nullptr, nullptr,
+                                       priority);
       s.PermitUncheckedError();
     } else {
       key_only_cache_->Release(h);


### PR DESCRIPTION
Summary: For no known reason, the deleter for a cache entry as taken the key as a parameter. Especially for some planned improvements that could make the cache key less immediately available, I am eliminating this unnecessary parameter.

Test Plan: tests updated.

Performance: Using same setup as #10626, no clear difference seen:

610MB 1thread clock_base -> kops/s: 47.719 io_bytes/op: 2264.19 miss_ratio: 0.0279492 max_rss_mb: 613.898
610MB 1thread clock_new -> kops/s: 47.559 io_bytes/op: 2263.87 miss_ratio: 0.0279423 max_rss_mb: 614.047
610MB 1thread lru_base -> kops/s: 44.723 io_bytes/op: 2260.36 miss_ratio: 0.0278864 max_rss_mb: 615.48
610MB 1thread lru_new -> kops/s: 44.66 io_bytes/op: 2262.12 miss_ratio: 0.0279136 max_rss_mb: 615.586
610MB 32thread clock_base -> kops/s: 1112.85 io_bytes/op: 2244.25 miss_ratio: 0.0278379 max_rss_mb: 681.254
610MB 32thread clock_new -> kops/s: 1114.3 io_bytes/op: 2244.75 miss_ratio: 0.0278465 max_rss_mb: 672.355
610MB 32thread lru_base -> kops/s: 397.395 io_bytes/op: 2243.65 miss_ratio: 0.0277979 max_rss_mb: 692.141
610MB 32thread lru_new -> kops/s: 400.844 io_bytes/op: 2243.06 miss_ratio: 0.027795 max_rss_mb: 681.234
610MB 8thread clock_base -> kops/s: 351.128 io_bytes/op: 2246.18 miss_ratio: 0.0278499 max_rss_mb: 618.82
610MB 8thread clock_new -> kops/s: 351.668 io_bytes/op: 2246.12 miss_ratio: 0.0278448 max_rss_mb: 623.895
610MB 8thread lru_base -> kops/s: 232.536 io_bytes/op: 2244.42 miss_ratio: 0.0278105 max_rss_mb: 621.684
610MB 8thread lru_new -> kops/s: 232.669 io_bytes/op: 2244.09 miss_ratio: 0.0278081 max_rss_mb: 622.723
610MB 128thread clock_base -> kops/s: 1326.09 io_bytes/op: 2244.06 miss_ratio: 0.027838 max_rss_mb: 730.188
610MB 128thread clock_new -> kops/s: 1325.63 io_bytes/op: 2244.55 miss_ratio: 0.0278394 max_rss_mb: 782.445
610MB 128thread lru_base -> kops/s: 441.384 io_bytes/op: 2243.57 miss_ratio: 0.0277922 max_rss_mb: 743.98
610MB 128thread lru_new -> kops/s: 446.397 io_bytes/op: 2243.68 miss_ratio: 0.0277999 max_rss_mb: 717.645
