### PR TITLE
[Draft] Fix Universal Compaction causing overlapping seqnos in L0 files due to overlapped seqnos between ingested files and memtable's

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@
 * Fixed a memory safety bug in experimental HyperClockCache (#10768)
 * Fixed some cases where `ldb update_manifest` and `ldb unsafe_remove_sst_file` are not usable because they were requiring the DB files to match the existing manifest state (before updating the manifest to match a desired state).
 * Fix FIFO compaction causing corruption of overlapping seqnos in L0 files due to ingesting files of overlapping seqnos with memtable's under `CompactionOptionsFIFO::allow_compaction=true` or `CompactionOptionsFIFO::age_for_warm>0` or `CompactRange()/CompactFiles()` is used. Before the fix, `force_consistency_checks=true` may catch the corruption before it's exposed to readers, in which case writes returning `Status::Corruption` would be expected.
+* Fix Universal compaction causing corruption of overlapping seqnos in L0 files due to ingesting files of overlapping seqnos with memtable's, including the case when `CompactRange()/CompactFiles()` is used. Before the fix, `force_consistency_checks=true` may catch the corruption before it's exposed to readers, in which case writes returning `Status::Corruption` would be expected.
 
 ### Performance Improvements
 * Try to align the compaction output file boundaries to the next level ones, which can reduce more than 10% compaction load for the default level compaction. The feature is enabled by default, to disable, set `AdvancedColumnFamilyOptions.level_compaction_dynamic_file_size` to false. As a side effect, it can create SSTs larger than the target_file_size (capped at 2x target_file_size) or smaller files.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,10 @@
 ### Performance Improvements
 * Fixed an iterator performance regression for delete range users when scanning through a consecutive sequence of range tombstones (#10877).
 
+### Bug Fixes
+* Fix FIFO compaction causing corruption of overlapping seqnos in L0 files due to ingesting files of overlapping seqnos with memtable's under `CompactionOptionsFIFO::allow_compaction=true` or `CompactionOptionsFIFO::age_for_warm>0` or `CompactRange()/CompactFiles()` is used. Before the fix, `force_consistency_checks=true` may catch the corruption before it's exposed to readers, in which case writes returning `Status::Corruption` would be expected.
+* Fix Universal compaction causing corruption of overlapping seqnos in L0 files due to ingesting files of overlapping seqnos with memtable's. The case when `CompactRange()/CompactFiles()` is used is also fixed, except for a subcase where `CompactRangeOptions::change_level=true` and `CompactRangeOptions::target_level=0`. Before the fix, `force_consistency_checks=true` may catch the corruption before it's exposed to readers, in which case writes returning `Status::Corruption` would be expected.
+
 ## 7.8.0 (10/22/2022)
 ### New Features
 * `DeleteRange()` now supports user-defined timestamp.
@@ -27,8 +31,6 @@
 * Fixed a bug where RocksDB could be doing compaction endlessly when allow_ingest_behind is true and the bottommost level is not filled (#10767).
 * Fixed a memory safety bug in experimental HyperClockCache (#10768)
 * Fixed some cases where `ldb update_manifest` and `ldb unsafe_remove_sst_file` are not usable because they were requiring the DB files to match the existing manifest state (before updating the manifest to match a desired state).
-* Fix FIFO compaction causing corruption of overlapping seqnos in L0 files due to ingesting files of overlapping seqnos with memtable's under `CompactionOptionsFIFO::allow_compaction=true` or `CompactionOptionsFIFO::age_for_warm>0` or `CompactRange()/CompactFiles()` is used. Before the fix, `force_consistency_checks=true` may catch the corruption before it's exposed to readers, in which case writes returning `Status::Corruption` would be expected.
-* Fix Universal compaction causing corruption of overlapping seqnos in L0 files due to ingesting files of overlapping seqnos with memtable's, including the case when `CompactRange()/CompactFiles()` is used. Before the fix, `force_consistency_checks=true` may catch the corruption before it's exposed to readers, in which case writes returning `Status::Corruption` would be expected.
 
 ### Performance Improvements
 * Try to align the compaction output file boundaries to the next level ones, which can reduce more than 10% compaction load for the default level compaction. The feature is enabled by default, to disable, set `AdvancedColumnFamilyOptions.level_compaction_dynamic_file_size` to false. As a side effect, it can create SSTs larger than the target_file_size (capped at 2x target_file_size) or smaller files.

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -501,8 +501,9 @@ bool Compaction::IsTrivialMove() const {
     if (output_level_ + 1 >= number_levels_) {
       continue;
     }
-    input_vstorage_->GetOverlappingInputs(output_level_ + 1, &file->smallest,
-                                          &file->largest, &file_grand_parents);
+    input_vstorage_->GetOverlappingInputs(
+        output_level_ + 1, &file->smallest, &file->largest, &file_grand_parents,
+        kMaxSequenceNumber /* earliest_mem_seqno */);
     const auto compaction_size =
         file->fd.GetFileSize() + TotalFileSize(file_grand_parents);
     if (compaction_size > max_compaction_bytes_) {

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -614,7 +614,7 @@ Compaction* CompactionPicker::CompactRange(
     const CompactRangeOptions& compact_range_options, const InternalKey* begin,
     const InternalKey* end, InternalKey** compaction_end, bool* manual_conflict,
     uint64_t max_file_num_to_ignore, const std::string& trim_ts,
-    const SequenceNumber /*earliest_mem_seqno*/) {
+    const SequenceNumber earliest_mem_seqno) {
   // CompactionPickerFIFO has its own implementation of compact range
   assert(ioptions_.compaction_style != kCompactionStyleFIFO);
 
@@ -656,7 +656,9 @@ Compaction* CompactionPicker::CompactRange(
       inputs[level - start_level].level = level;
       auto& files = inputs[level - start_level].files;
       for (FileMetaData* f : vstorage->LevelFiles(level)) {
-        files.push_back(f);
+        if (output_level > 0 || f->fd.largest_seqno <= earliest_mem_seqno) {
+          files.push_back(f);
+        }
       }
       if (AreFilesInCompaction(files)) {
         *manual_conflict = true;
@@ -707,8 +709,11 @@ Compaction* CompactionPicker::CompactRange(
     begin = nullptr;
     end = nullptr;
   }
-
-  vstorage->GetOverlappingInputs(input_level, begin, end, &inputs.files);
+  vstorage->GetOverlappingInputs(
+      input_level, begin, end, &inputs.files, -1 /* hint_index */,
+      nullptr /* file_index */, true /* expand_range */,
+      nullptr /* next_smallest */,
+      output_level == 0 ? earliest_mem_seqno : kMaxSequenceNumber);
   if (inputs.empty()) {
     return nullptr;
   }

--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -277,7 +277,6 @@ Compaction* FIFOCompactionPicker::PickCompactionToWarm(
     const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
     const MutableDBOptions& mutable_db_options, VersionStorageInfo* vstorage,
     LogBuffer* log_buffer, const SequenceNumber earliest_mem_seqno) {
-  TEST_SYNC_POINT("PickCompactionToWarm");
   if (mutable_cf_options.compaction_options_fifo.age_for_warm == 0) {
     return nullptr;
   }
@@ -407,6 +406,7 @@ Compaction* FIFOCompactionPicker::PickCompaction(
   if (c == nullptr) {
     c = PickCompactionToWarm(cf_name, mutable_cf_options, mutable_db_options,
                              vstorage, log_buffer, earliest_mem_seqno);
+    TEST_SYNC_POINT_CALLBACK("PostPickCompactionToWarm", c);
   }
   RegisterCompaction(c);
   return c;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4290,7 +4290,8 @@ Status DBImpl::DeleteFilesInRanges(ColumnFamilyHandle* column_family,
         }
 
         vstorage->GetCleanInputsWithinInterval(
-            i, begin_key, end_key, &level_files, -1 /* hint_index */,
+            i, begin_key, end_key, &level_files,
+            kMaxSequenceNumber /* earliest_mem_seqno */, -1 /* hint_index */,
             nullptr /* file_index */);
         FileMetaData* level_file;
         for (uint32_t j = 0; j < level_files.size(); j++) {

--- a/db/db_impl/db_impl_experimental.cc
+++ b/db/db_impl/db_impl_experimental.cc
@@ -39,7 +39,8 @@ Status DBImpl::SuggestCompactRange(ColumnFamilyHandle* column_family,
       std::vector<FileMetaData*> inputs;
       vstorage->GetOverlappingInputs(
           level, begin == nullptr ? nullptr : &start_key,
-          end == nullptr ? nullptr : &end_key, &inputs);
+          end == nullptr ? nullptr : &end_key, &inputs,
+          kMaxSequenceNumber /* earliest_mem_seqno */);
       for (auto f : inputs) {
         f->marked_for_compaction = true;
       }

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -1872,11 +1872,6 @@ TEST_P(DBTestUniversalManualCompactionOutputPathId,
   ASSERT_EQ(1, GetSstFileCount(options.db_paths[0].path));
   ASSERT_EQ(1, GetSstFileCount(options.db_paths[1].path));
 
-  ReopenWithColumnFamilies({kDefaultColumnFamilyName, "pikachu"}, options);
-  ASSERT_EQ(2, TotalLiveFiles(1));
-  ASSERT_EQ(1, GetSstFileCount(options.db_paths[0].path));
-  ASSERT_EQ(1, GetSstFileCount(options.db_paths[1].path));
-
   // Full compaction to DB path 0
   compact_options.target_path_id = 0;
   compact_options.exclusive_manual_compaction = exclusive_manual_compaction_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4011,7 +4011,8 @@ bool VersionStorageInfo::OverlapInLevel(int level,
 void VersionStorageInfo::GetOverlappingInputs(
     int level, const InternalKey* begin, const InternalKey* end,
     std::vector<FileMetaData*>* inputs, int hint_index, int* file_index,
-    bool expand_range, InternalKey** next_smallest) const {
+    bool expand_range, InternalKey** next_smallest,
+    const SequenceNumber earliest_mem_seqno) const {
   if (level >= num_non_empty_levels_) {
     // this level is empty, no overlapping inputs
     return;
@@ -4062,6 +4063,8 @@ void VersionStorageInfo::GetOverlappingInputs(
       } else if (end != nullptr &&
                  user_cmp->CompareWithoutTimestamp(file_start, user_end) > 0) {
         // "f" is completely after specified range; skip it
+        iter++;
+      } else if (files_[level][*iter]->fd.largest_seqno > earliest_mem_seqno) {
         iter++;
       } else {
         // if overlap

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -257,8 +257,14 @@ class VersionStorageInfo {
       bool expand_range = true,   // if set, returns files which overlap the
                                   // range and overlap each other. If false,
                                   // then just files intersecting the range
-      InternalKey** next_smallest = nullptr)  // if non-null, returns the
-      const;  // smallest key of next file not included
+      InternalKey** next_smallest =
+          nullptr,  // if non-null, returns the
+                    // smallest key of next file not included
+      const SequenceNumber earliest_mem_seqno =
+          kMaxSequenceNumber  // `earliest_mem_seqno` is the earliest seqno of
+                              // unflushed memtables. For more, see see
+                              // CompactionPicker::PickCompaction() API
+  ) const;
   void GetCleanInputsWithinInterval(
       int level, const InternalKey* begin,  // nullptr means before all keys
       const InternalKey* end,               // nullptr means after all keys

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -186,7 +186,8 @@ class VersionStorageInfoTestBase : public testing::Test {
   std::string GetOverlappingFiles(int level, const InternalKey& begin,
                                   const InternalKey& end) {
     std::vector<FileMetaData*> inputs;
-    vstorage_.GetOverlappingInputs(level, &begin, &end, &inputs);
+    vstorage_.GetOverlappingInputs(level, &begin, &end, &inputs,
+                                   kMaxSequenceNumber /* earliest_mem_seqno */);
 
     std::string result;
     for (size_t i = 0; i < inputs.size(); ++i) {


### PR DESCRIPTION
**Context:**
Same as https://github.com/facebook/rocksdb/pull/5958#issue-511150930 but apply the fix to Universal Compaction case

Repro:
```
COERCE_CONTEXT_SWICH=1 make -j56 db_stress

./db_stress --acquire_snapshot_one_in=0 --adaptive_readahead=0 --allow_data_in_errors=True --async_io=1 --avoid_flush_during_recovery=0 --avoid_unnecessary_blocking_io=0 --backup_max_size=104857600 --backup_one_in=0 --batch_protection_bytes_per_key=0 --block_size=16384 --bloom_bits=18 --bottommost_compression_type=disable --bytes_per_sync=262144 --cache_index_and_filter_blocks=0 --cache_size=8388608 --cache_type=lru_cache --charge_compression_dictionary_building_buffer=0 --charge_file_metadata=1 --charge_filter_construction=1 --charge_table_reader=1 --checkpoint_one_in=0 --checksum_type=kCRC32c --clear_column_family_one_in=0 --compact_files_one_in=0 --compact_range_one_in=100 --compaction_pri=2 --compaction_style=1 --compaction_ttl=0 --compression_max_dict_buffer_bytes=8388607 --compression_max_dict_bytes=16384 --compression_parallel_threads=1 --compression_type=zlib --compression_use_zstd_dict_trainer=1 --compression_zstd_max_train_bytes=0 --continuous_verification_interval=0 --data_block_index_type=0 --db=/dev/shm/rocksdb_test2/rocksdb_crashtest_whitebox --db_write_buffer_size=8388608 --delpercent=4 --delrangepercent=1 --destroy_db_initially=1 --detect_filter_construct_corruption=0 --disable_wal=0 --enable_compaction_filter=0 --enable_pipelined_write=1 --fail_if_options_file_error=1 --file_checksum_impl=none --flush_one_in=1000 --format_version=5 --get_current_wal_file_one_in=0 --get_live_files_one_in=0 --get_property_one_in=0 --get_sorted_wal_files_one_in=0 --index_block_restart_interval=15 --index_type=3 --ingest_external_file_one_in=100 --initial_auto_readahead_size=0 --iterpercent=10 --key_len_percent_dist=1,30,69 --level_compaction_dynamic_level_bytes=True --log2_keys_per_lock=10 --long_running_snapshots=0 --mark_for_compaction_one_file_in=10 --max_auto_readahead_size=16384 --max_background_compactions=20 --max_bytes_for_level_base=10485760 --max_key=100000 --max_key_len=3 --max_manifest_file_size=1073741824 --max_write_batch_group_size_bytes=1048576 --max_write_buffer_number=3 --max_write_buffer_size_to_maintain=4194304 --memtable_prefix_bloom_size_ratio=0.5 --memtable_protection_bytes_per_key=1 --memtable_whole_key_filtering=1 --memtablerep=skip_list --mmap_read=1 --mock_direct_io=False --nooverwritepercent=1 --num_file_reads_for_auto_readahead=0 --num_levels=1 --open_files=100 --open_metadata_write_fault_one_in=0 --open_read_fault_one_in=32 --open_write_fault_one_in=0 --ops_per_thread=200000 --optimize_filters_for_memory=0 --paranoid_file_checks=1 --partition_filters=0 --partition_pinning=1 --pause_background_one_in=0 --periodic_compaction_seconds=0 --prefix_size=8 --prefixpercent=5 --prepopulate_block_cache=0 --progress_reports=0 --read_fault_one_in=0 --readahead_size=16384 --readpercent=45 --recycle_log_file_num=1 --reopen=20 --ribbon_starting_level=999 --snapshot_hold_ops=1000 --sst_file_manager_bytes_per_sec=0 --sst_file_manager_bytes_per_truncate=0 --subcompactions=2 --sync=0 --sync_fault_injection=0 --target_file_size_base=524288 --target_file_size_multiplier=2 --test_batches_snapshots=0 --top_level_index_pinning=3 --unpartitioned_pinning=0 --use_direct_io_for_flush_and_compaction=0 --use_direct_reads=0 --use_full_merge_v1=1 --use_merge=0 --use_multiget=1 --user_timestamp_size=0 --value_size_mult=32 --verify_checksum=1 --verify_checksum_one_in=0 --verify_db_one_in=1000 --verify_sst_unique_id_in_manifest=1 --wal_bytes_per_sync=0 --wal_compression=zstd --write_buffer_size=524288 --write_dbid_to_manifest=0 --writepercent=35 

put or merge error: Corruption: force_consistency_checks(DEBUG): VersionBuilder: L0 file #4153 with seqno 0 101850 vs. file #4164 with seqno 101187 101820
```

**Summary:**
This PR considers `earliest_mem_seqnos` whenever we are compacting to L0 level, which include the following three cases.
- [UniversalCompactionPicker::PickCompaction()](https://github.com/facebook/rocksdb/blob/7.6.fb/db/compaction/compaction_picker_universal.cc#L374) when compacting to L0 level 
     - Like the fix https://github.com/facebook/rocksdb/pull/5958#issue-511150930, we excluded files of largest seqno greater than `earliest_mem_seqno` from compaction. 
     - Firstly, this is done in `CalculateSortedRuns` at the beginning of `UniversalCompactionPicker::PickCompaction()` 
         -  However, we couldn't know the output level at this point therefore we end up filtering out such files even when we are not compacting to L0 level. 
         - Would this be problematic?? Maybe it's fine once we accumulate some data in memetable and increase the `earliest_mem_seqno` so that previously filtered out files can be chosen again.
     - Secondly, this is done in some `PickXXXCompaction()`s called in `UniversalCompactionPicker::PickCompaction()`. This is because some of these functions actually use files directly from `vstorage` as input files, not from the sanitized sorted run resulted in `CalculateSortedRuns`. This includes the following. For test coverage of each case, see **Test**.
         - `PickPeriodicCompaction()` for [multi-level](https://github.com/facebook/rocksdb/blob/7.6.fb/db/compaction/compaction_picker_universal.cc#L1276-L1277)
         - `PickCompactionToReduceSizeAmp()` for [multi-level
](https://github.com/facebook/rocksdb/blob/7.6.fb/db/compaction/compaction_picker_universal.cc#L937-L1068)         - `PickCompactionToReduceSortedRuns()` for [multi-level](https://github.com/facebook/rocksdb/blob/7.6.fb/db/compaction/compaction_picker_universal.cc#L723-L724)
         - `PickDeleteTriggeredCompaction()` for [both single and multi-level](https://github.com/facebook/rocksdb/blob/7.6.fb/db/compaction/compaction_picker_universal.cc#L1127-L1161).
             -  For this path, I also fixed a bug cased by assuming sorted_run on L0 is always a prefix of vstorage->LevelFiles(0), which is no longer true after we sanitize sorted_run in this PR.
- [CompactionPicker::CompactRange](https://github.com/facebook/rocksdb/blob/7.6.fb/db/compaction/compaction_picker.cc#L600) when compacting to L0 level
     - This include skipping such files in following functions and their derivatives: 
         - `vstorage->GetOverlappingInputs/GetOverlappingInputsRangeBinarySearch()`
         - `ExpandInputsToCleanCut()`
         - `SetupOtherInputs()`
     - However,  such treatment has failed `OutputPathId/DBTestUniversalManualCompactionOutputPathId.ManualCompactionOutputPathId/0,1` due to a [bug](https://github.com/facebook/rocksdb/pull/10812) about setting an incorrect EarliestSequenceNumber of the memtable in `DB::Reopen()`. Therefore I have to remove the reopening part in this PR https://github.com/facebook/rocksdb/pull/10776/commits/d4a2129068814a62a1ac61f1beb3b1bc47cf171f#diff-3d401dbe63b9d238f4c6ed8ae4f3b4b3b6948be976d902b7a41021b208a06192L1875-L1879 to avoid the bug and pass.
         - Such revision to the test is not ideal cuz the original test case did reflect a sequence of possible user operations. However, fixing such bug currently encounters several blockers like https://app.circleci.com/pipelines/github/facebook/rocksdb/19902/workflows/63960818-0ec0-465b-9bc8-c10ee2140816/jobs/508125 so I decided to revise the test instead in this PR.
- `CompactionPicker::CompactFiles`: fixed in https://github.com/facebook/rocksdb/pull/10777        
- Some clean-up include:
    - Made `earliest_mem_seqno` required in more functions, including those shared with level compaction in `CompactionPicker`, `DBImpl` (i.e, `DBImpl::DeleteFilesInRanges`) and `Compaction` (i.e, `Compaction::IsTrivialMove()`). For these callers `kMaxSequenceNumber` is passed in to limit this PR scope.
    - Consolidated with https://github.com/facebook/rocksdb/pull/10777's unit test under `DBCompactionTestL0FilesReorderingCorruption`
 and adopted the [comment](https://github.com/facebook/rocksdb/pull/10777#discussion_r1004882434) 
       - Also updated `TEST_SYNC_POINT` location for fifo related unit test to make it more resistant to accidental code change breaking the test.
   - Clarified comment about the basis of ordering for `VersionStorageInfo::files_`
**Test:**
- New unit tests under `DBCompactionTestL0FilesReorderingCorruption` cover all the above cases that fail before the fix and pass after, except for
   - multi-level for `UniversalCompactionPicker::PickCompaction()`, see TODO in unit test for challenges to add one
- make check
- [Ongoing] Regular CI stress run on this PR + stress test with aggressive value https://github.com/facebook/rocksdb/pull/10761 and on Universal Compaction only