### PR TITLE
Verify wide columns during prefix scan in stress tests

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -264,6 +264,7 @@ class BatchedOpsStressTest : public StressTest {
   Status TestPrefixScan(ThreadState* thread, const ReadOptions& readoptions,
                         const std::vector<int>& rand_column_families,
                         const std::vector<int64_t>& rand_keys) override {
+    // TODO
     size_t prefix_to_use =
         (FLAGS_prefix_size < 0) ? 7 : static_cast<size_t>(FLAGS_prefix_size);
     std::string key_str = Key(rand_keys[0]);

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -342,8 +342,13 @@ class BatchedOpsStressTest : public StressTest {
         }
 
         // make sure value() and columns() are consistent
+        // note: in these tests, value base is stored after a single-digit
+        // prefix
+        Slice value_base_slice = iters[i]->value();
+        value_base_slice.remove_prefix(1);
+
         const WideColumns expected_columns = GenerateExpectedWideColumns(
-            GetValueBase(iters[i]->value()), iters[i]->value());
+            GetValueBase(value_base_slice), iters[i]->value());
         if (iters[i]->columns() != expected_columns) {
           fprintf(stderr,
                   "error : %" ROCKSDB_PRIszt

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -267,9 +267,6 @@ class BatchedOpsStressTest : public StressTest {
     assert(!rand_column_families.empty());
     assert(!rand_keys.empty());
 
-    ColumnFamilyHandle* const cfh = column_families_[rand_column_families[0]];
-    assert(cfh);
-
     const std::string key = Key(rand_keys[0]);
 
     const size_t prefix_to_use =
@@ -285,6 +282,9 @@ class BatchedOpsStressTest : public StressTest {
     std::array<std::unique_ptr<Iterator>, num_prefixes> iters;
 
     const Snapshot* const snapshot = db_->GetSnapshot();
+
+    ColumnFamilyHandle* const cfh = column_families_[rand_column_families[0]];
+    assert(cfh);
 
     for (size_t i = 0; i < num_prefixes; ++i) {
       prefixes[i] = std::to_string(i) + key;
@@ -305,7 +305,7 @@ class BatchedOpsStressTest : public StressTest {
       iters[i]->Seek(prefix_slices[i]);
     }
 
-    long count = 0;
+    uint64_t count = 0;
 
     while (iters[0]->Valid() && iters[0]->key().starts_with(prefix_slices[0])) {
       ++count;

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -319,19 +319,18 @@ class BatchedOpsStressTest : public StressTest {
                iters[i]->key().starts_with(prefix_slices[i]));
         values[i] = iters[i]->value().ToString();
 
-        char expected_first = (prefixes[i])[0];
-        char actual_first = (values[i])[0];
+        // make sure the first character of the value is the expected digit
+        const char expected_first = prefixes[i][0];
+        const char actual_first = values[i][0];
 
         if (actual_first != expected_first) {
           fprintf(stderr, "error expected first = %c actual = %c\n",
                   expected_first, actual_first);
         }
 
-        (values[i])[0] = ' ';  // blank out the differing character
-      }
+        values[i][0] = ' ';  // blank out the differing character
 
-      // make sure all values are equivalent
-      for (size_t i = 0; i < num_prefixes; ++i) {
+        // make sure all values are equivalent
         if (values[i] != values[0]) {
           fprintf(stderr,
                   "error : %" ROCKSDB_PRIszt
@@ -340,6 +339,19 @@ class BatchedOpsStressTest : public StressTest {
                   StringToHex(values[i]).c_str());
           // we continue after error rather than exiting so that we can
           // find more errors if any
+        }
+
+        // make sure value() and columns() are consistent
+        const WideColumns expected_columns = GenerateExpectedWideColumns(
+            GetValueBase(iters[i]->value()), iters[i]->value());
+        if (iters[i]->columns() != expected_columns) {
+          fprintf(stderr,
+                  "error : %" ROCKSDB_PRIszt
+                  ", value and columns inconsistent for prefix %s: %s\n",
+                  i, prefixes[i].c_str(),
+                  DebugString(iters[i]->value(), iters[i]->columns(),
+                              expected_columns)
+                      .c_str());
         }
 
         iters[i]->Next();

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -264,43 +264,56 @@ class BatchedOpsStressTest : public StressTest {
   Status TestPrefixScan(ThreadState* thread, const ReadOptions& readoptions,
                         const std::vector<int>& rand_column_families,
                         const std::vector<int64_t>& rand_keys) override {
-    // TODO
-    size_t prefix_to_use =
+    assert(!rand_column_families.empty());
+    assert(!rand_keys.empty());
+
+    ColumnFamilyHandle* const cfh = column_families_[rand_column_families[0]];
+    assert(cfh);
+
+    const std::string key = Key(rand_keys[0]);
+
+    const size_t prefix_to_use =
         (FLAGS_prefix_size < 0) ? 7 : static_cast<size_t>(FLAGS_prefix_size);
-    std::string key_str = Key(rand_keys[0]);
-    Slice key = key_str;
-    auto cfh = column_families_[rand_column_families[0]];
-    std::string prefixes[10] = {"0", "1", "2", "3", "4",
-                                "5", "6", "7", "8", "9"};
-    Slice prefix_slices[10];
-    ReadOptions readoptionscopy[10];
-    const Snapshot* snapshot = db_->GetSnapshot();
-    Iterator* iters[10];
-    std::string upper_bounds[10];
-    Slice ub_slices[10];
-    Status s = Status::OK();
-    for (int i = 0; i < 10; i++) {
-      prefixes[i] += key.ToString();
+
+    constexpr size_t num_prefixes = 10;
+
+    std::array<std::string, num_prefixes> prefixes;
+    std::array<Slice, num_prefixes> prefix_slices;
+    std::array<ReadOptions, num_prefixes> ro_copy;
+    std::array<std::string, num_prefixes> upper_bounds;
+    std::array<Slice, num_prefixes> ub_slices;
+    std::array<std::unique_ptr<Iterator>, num_prefixes> iters;
+
+    const Snapshot* const snapshot = db_->GetSnapshot();
+
+    for (size_t i = 0; i < num_prefixes; ++i) {
+      prefixes[i] = std::to_string(i) + key;
       prefixes[i].resize(prefix_to_use);
-      prefix_slices[i] = Slice(prefixes[i]);
-      readoptionscopy[i] = readoptions;
-      readoptionscopy[i].snapshot = snapshot;
+
+      prefix_slices[i] = prefixes[i];
+
+      ro_copy[i] = readoptions;
+      ro_copy[i].snapshot = snapshot;
       if (thread->rand.OneIn(2) &&
           GetNextPrefix(prefix_slices[i], &(upper_bounds[i]))) {
         // For half of the time, set the upper bound to the next prefix
-        ub_slices[i] = Slice(upper_bounds[i]);
-        readoptionscopy[i].iterate_upper_bound = &(ub_slices[i]);
+        ub_slices[i] = upper_bounds[i];
+        ro_copy[i].iterate_upper_bound = &(ub_slices[i]);
       }
-      iters[i] = db_->NewIterator(readoptionscopy[i], cfh);
+
+      iters[i].reset(db_->NewIterator(ro_copy[i], cfh));
       iters[i]->Seek(prefix_slices[i]);
     }
 
     long count = 0;
+
     while (iters[0]->Valid() && iters[0]->key().starts_with(prefix_slices[0])) {
-      count++;
-      std::string values[10];
+      ++count;
+
+      std::array<std::string, num_prefixes> values;
+
       // get list of all values for this iteration
-      for (int i = 0; i < 10; i++) {
+      for (size_t i = 0; i < num_prefixes; ++i) {
         // no iterator should finish before the first one
         assert(iters[i]->Valid() &&
                iters[i]->key().starts_with(prefix_slices[i]));
@@ -313,40 +326,39 @@ class BatchedOpsStressTest : public StressTest {
           fprintf(stderr, "error expected first = %c actual = %c\n",
                   expected_first, actual_first);
         }
+
         (values[i])[0] = ' ';  // blank out the differing character
       }
+
       // make sure all values are equivalent
-      for (int i = 0; i < 10; i++) {
+      for (size_t i = 0; i < num_prefixes; ++i) {
         if (values[i] != values[0]) {
           fprintf(stderr,
-                  "error : %d, inconsistent values for prefix %s: %s, %s\n", i,
-                  prefixes[i].c_str(), StringToHex(values[0]).c_str(),
+                  "error : %" ROCKSDB_PRIszt
+                  ", inconsistent values for prefix %s: %s, %s\n",
+                  i, prefixes[i].c_str(), StringToHex(values[0]).c_str(),
                   StringToHex(values[i]).c_str());
           // we continue after error rather than exiting so that we can
           // find more errors if any
         }
+
         iters[i]->Next();
       }
     }
 
     // cleanup iterators and snapshot
-    for (int i = 0; i < 10; i++) {
+    for (size_t i = 0; i < num_prefixes; ++i) {
       // if the first iterator finished, they should have all finished
       assert(!iters[i]->Valid() ||
              !iters[i]->key().starts_with(prefix_slices[i]));
       assert(iters[i]->status().ok());
-      delete iters[i];
     }
+
     db_->ReleaseSnapshot(snapshot);
 
-    if (s.ok()) {
-      thread->stats.AddPrefixes(1, count);
-    } else {
-      fprintf(stderr, "TestPrefixScan error: %s\n", s.ToString().c_str());
-      thread->stats.AddErrors(1);
-    }
+    thread->stats.AddPrefixes(1, count);
 
-    return s;
+    return Status::OK();
   }
 
   void VerifyDb(ThreadState* /* thread */) const override {}

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -327,7 +327,6 @@ class CfConsistencyStressTest : public StressTest {
   }
 
   void VerifyDb(ThreadState* thread) const override {
-    // TODO
     // This `ReadOptions` is for validation purposes. Ignore
     // `FLAGS_rate_limit_user_ops` to avoid slowing any validation.
     ReadOptions options(FLAGS_verify_checksum, true);
@@ -508,7 +507,6 @@ class CfConsistencyStressTest : public StressTest {
       }
     }
 
-    // TODO
     const auto checksum_column_family = [](Iterator* iter,
                                            uint32_t* checksum) -> Status {
       assert(nullptr != checksum);

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -262,7 +262,7 @@ class CfConsistencyStressTest : public StressTest {
     const size_t prefix_to_use =
         (FLAGS_prefix_size < 0) ? 7 : static_cast<size_t>(FLAGS_prefix_size);
 
-    Slice prefix(key.data(), prefix_to_use);
+    const Slice prefix(key.data(), prefix_to_use);
 
     std::string upper_bound;
     Slice ub_slice;

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -254,6 +254,7 @@ class CfConsistencyStressTest : public StressTest {
   Status TestPrefixScan(ThreadState* thread, const ReadOptions& readoptions,
                         const std::vector<int>& rand_column_families,
                         const std::vector<int64_t>& rand_keys) override {
+    // TODO
     size_t prefix_to_use =
         (FLAGS_prefix_size < 0) ? 7 : static_cast<size_t>(FLAGS_prefix_size);
 
@@ -300,6 +301,7 @@ class CfConsistencyStressTest : public StressTest {
   }
 
   void VerifyDb(ThreadState* thread) const override {
+    // TODO
     // This `ReadOptions` is for validation purposes. Ignore
     // `FLAGS_rate_limit_user_ops` to avoid slowing any validation.
     ReadOptions options(FLAGS_verify_checksum, true);
@@ -480,6 +482,7 @@ class CfConsistencyStressTest : public StressTest {
       }
     }
 
+    // TODO
     const auto checksum_column_family = [](Iterator* iter,
                                            uint32_t* checksum) -> Status {
       assert(nullptr != checksum);

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -254,43 +254,69 @@ class CfConsistencyStressTest : public StressTest {
   Status TestPrefixScan(ThreadState* thread, const ReadOptions& readoptions,
                         const std::vector<int>& rand_column_families,
                         const std::vector<int64_t>& rand_keys) override {
-    // TODO
-    size_t prefix_to_use =
+    assert(!rand_column_families.empty());
+    assert(!rand_keys.empty());
+
+    const std::string key = Key(rand_keys[0]);
+
+    const size_t prefix_to_use =
         (FLAGS_prefix_size < 0) ? 7 : static_cast<size_t>(FLAGS_prefix_size);
 
-    std::string key_str = Key(rand_keys[0]);
-    Slice key = key_str;
-    Slice prefix = Slice(key.data(), prefix_to_use);
+    Slice prefix(key.data(), prefix_to_use);
 
     std::string upper_bound;
     Slice ub_slice;
+
     ReadOptions ro_copy = readoptions;
+
     // Get the next prefix first and then see if we want to set upper bound.
     // We'll use the next prefix in an assertion later on
     if (GetNextPrefix(prefix, &upper_bound) && thread->rand.OneIn(2)) {
       ub_slice = Slice(upper_bound);
       ro_copy.iterate_upper_bound = &ub_slice;
     }
-    auto cfh =
-        column_families_[rand_column_families[thread->rand.Next() %
-                                              rand_column_families.size()]];
-    Iterator* iter = db_->NewIterator(ro_copy, cfh);
-    unsigned long count = 0;
+
+    ColumnFamilyHandle* const cfh =
+        column_families_[rand_column_families[thread->rand.Uniform(
+            rand_column_families.size())]];
+    assert(cfh);
+
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ro_copy, cfh));
+
+    uint64_t count = 0;
+    Status s;
+
     for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix);
          iter->Next()) {
       ++count;
+
+      const WideColumns expected_columns = GenerateExpectedWideColumns(
+          GetValueBase(iter->value()), iter->value());
+      if (iter->columns() != expected_columns) {
+        s = Status::Corruption(
+            "Value and columns inconsistent",
+            DebugString(iter->value(), iter->columns(), expected_columns));
+        break;
+      }
     }
+
     assert(prefix_to_use == 0 ||
            count <= GetPrefixKeyCount(prefix.ToString(), upper_bound));
-    Status s = iter->status();
+
     if (s.ok()) {
-      thread->stats.AddPrefixes(1, count);
-    } else {
+      s = iter->status();
+    }
+
+    if (!s.ok()) {
       fprintf(stderr, "TestPrefixScan error: %s\n", s.ToString().c_str());
       thread->stats.AddErrors(1);
+
+      return s;
     }
-    delete iter;
-    return s;
+
+    thread->stats.AddPrefixes(1, count);
+
+    return Status::OK();
   }
 
   ColumnFamilyHandle* GetControlCfh(ThreadState* thread,

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -278,7 +278,7 @@ class CfConsistencyStressTest : public StressTest {
 
     ColumnFamilyHandle* const cfh =
         column_families_[rand_column_families[thread->rand.Uniform(
-            rand_column_families.size())]];
+            static_cast<int>(rand_column_families.size()))]];
     assert(cfh);
 
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro_copy, cfh));

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1133,7 +1133,6 @@ Status StressTest::TestIterate(ThreadState* thread,
                                const ReadOptions& read_opts,
                                const std::vector<int>& rand_column_families,
                                const std::vector<int64_t>& rand_keys) {
-  // TODO
   Status s;
   const Snapshot* snapshot = db_->GetSnapshot();
   ReadOptions readoptionscopy = read_opts;
@@ -2304,7 +2303,6 @@ uint32_t StressTest::GetRangeHash(ThreadState* thread, const Snapshot* snapshot,
   for (it->Seek(start_key);
        it->Valid() && options_.comparator->Compare(it->key(), end_key) <= 0;
        it->Next()) {
-    // TODO
     crc = crc32c::Extend(crc, it->key().data(), it->key().size());
     crc = crc32c::Extend(crc, kCrcCalculatorSepearator.data(), 1);
     crc = crc32c::Extend(crc, it->value().data(), it->value().size());

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1133,6 +1133,7 @@ Status StressTest::TestIterate(ThreadState* thread,
                                const ReadOptions& read_opts,
                                const std::vector<int>& rand_column_families,
                                const std::vector<int64_t>& rand_keys) {
+  // TODO
   Status s;
   const Snapshot* snapshot = db_->GetSnapshot();
   ReadOptions readoptionscopy = read_opts;
@@ -2303,6 +2304,7 @@ uint32_t StressTest::GetRangeHash(ThreadState* thread, const Snapshot* snapshot,
   for (it->Seek(start_key);
        it->Valid() && options_.comparator->Compare(it->key(), end_key) <= 0;
        it->Next()) {
+    // TODO
     crc = crc32c::Extend(crc, it->key().data(), it->key().size());
     crc = crc32c::Extend(crc, kCrcCalculatorSepearator.data(), 1);
     crc = crc32c::Extend(crc, it->value().data(), it->value().size());

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -10,8 +10,6 @@
 #ifdef GFLAGS
 #pragma once
 
-#include <ostream>
-
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_shared_state.h"
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -671,14 +671,19 @@ class NonBatchedOpsStressTest : public StressTest {
   Status TestPrefixScan(ThreadState* thread, const ReadOptions& read_opts,
                         const std::vector<int>& rand_column_families,
                         const std::vector<int64_t>& rand_keys) override {
-    auto cfh = column_families_[rand_column_families[0]];
-    std::string key_str = Key(rand_keys[0]);
-    Slice key = key_str;
-    Slice prefix = Slice(key.data(), FLAGS_prefix_size);
+    assert(!rand_column_families.empty());
+    assert(!rand_keys.empty());
+
+    ColumnFamilyHandle* const cfh = column_families_[rand_column_families[0]];
+    assert(cfh);
+
+    const std::string key = Key(rand_keys[0]);
+    const Slice prefix(key.data(), FLAGS_prefix_size);
 
     std::string upper_bound;
     Slice ub_slice;
     ReadOptions ro_copy = read_opts;
+
     // Get the next prefix first and then see if we want to set upper bound.
     // We'll use the next prefix in an assertion later on
     if (GetNextPrefix(prefix, &upper_bound) && thread->rand.OneIn(2)) {
@@ -692,8 +697,9 @@ class NonBatchedOpsStressTest : public StressTest {
     MaybeUseOlderTimestampForRangeScan(thread, read_ts_str, read_ts_slice,
                                        ro_copy);
 
-    Iterator* iter = db_->NewIterator(ro_copy, cfh);
-    unsigned long count = 0;
+    std::unique_ptr<Iterator> iter(db_->NewIterator(ro_copy, cfh));
+
+    uint64_t count = 0;
     for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix);
          iter->Next()) {
       ++count;
@@ -703,15 +709,18 @@ class NonBatchedOpsStressTest : public StressTest {
       assert(count <= GetPrefixKeyCount(prefix.ToString(), upper_bound));
     }
 
-    Status s = iter->status();
-    if (iter->status().ok()) {
-      thread->stats.AddPrefixes(1, count);
-    } else {
+    const Status s = iter->status();
+
+    if (!s.ok()) {
       fprintf(stderr, "TestPrefixScan error: %s\n", s.ToString().c_str());
       thread->stats.AddErrors(1);
+
+      return s;
     }
-    delete iter;
-    return s;
+
+    thread->stats.AddPrefixes(1, count);
+
+    return Status::OK();
   }
 
   Status TestPut(ThreadState* thread, WriteOptions& write_opts,

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1116,7 +1116,6 @@ class NonBatchedOpsStressTest : public StressTest {
       ThreadState* thread, const ReadOptions& read_opts,
       const std::vector<int>& rand_column_families,
       const std::vector<int64_t>& rand_keys) override {
-    // TODO
     // Lock the whole range over which we might iterate to ensure it doesn't
     // change under us.
     std::vector<std::unique_ptr<MutexLock>> range_locks;

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -700,13 +700,28 @@ class NonBatchedOpsStressTest : public StressTest {
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro_copy, cfh));
 
     uint64_t count = 0;
+    bool columns_inconsistent = false;
+
     for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix);
          iter->Next()) {
       ++count;
+
+      const WideColumns expected_columns = GenerateExpectedWideColumns(
+          GetValueBase(iter->value()), iter->value());
+      if (iter->columns() != expected_columns) {
+        columns_inconsistent = true;
+      }
     }
 
     if (ro_copy.iter_start_ts == nullptr) {
       assert(count <= GetPrefixKeyCount(prefix.ToString(), upper_bound));
+    }
+
+    if (columns_inconsistent) {
+      fprintf(stderr, "TestPrefixScan: columns inconsistent\n");
+      thread->stats.AddErrors(1);
+
+      return Status::Corruption();
     }
 
     const Status s = iter->status();
@@ -1103,6 +1118,7 @@ class NonBatchedOpsStressTest : public StressTest {
       ThreadState* thread, const ReadOptions& read_opts,
       const std::vector<int>& rand_column_families,
       const std::vector<int64_t>& rand_keys) override {
+    // TODO
     // Lock the whole range over which we might iterate to ensure it doesn't
     // change under us.
     std::vector<std::unique_ptr<MutexLock>> range_locks;


### PR DESCRIPTION
Summary:
The patch adds checks to the
`{NonBatchedOps,BatchedOps,CfConsistency}StressTest::TestPrefixScan` methods
to make sure the wide columns exposed by the iterators are as expected (based on
the value base encoded into the iterator value). It also makes some code hygiene
improvements in these methods.

Test Plan:
Ran some simple blackbox tests in the various modes (non-batched, batched,
CF consistency).