### PR TITLE
Consider wide columns when checksumming in the stress tests

### DIFF
--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -510,11 +510,19 @@ class CfConsistencyStressTest : public StressTest {
     const auto checksum_column_family = [](Iterator* iter,
                                            uint32_t* checksum) -> Status {
       assert(nullptr != checksum);
+
       uint32_t ret = 0;
       for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
         ret = crc32c::Extend(ret, iter->key().data(), iter->key().size());
         ret = crc32c::Extend(ret, iter->value().data(), iter->value().size());
+
+        for (const auto& column : iter->columns()) {
+          ret = crc32c::Extend(ret, column.name().data(), column.name().size());
+          ret =
+              crc32c::Extend(ret, column.value().data(), column.value().size());
+        }
       }
+
       *checksum = ret;
       return iter->status();
     };


### PR DESCRIPTION
Summary:
There are two places in the stress test code where we compute the CRC
for a range of KVs for the purposes of checking consistency, namely in the
CF consistency test (to make sure CFs contain the same data), and when
performing `CompactRange` (to make sure the pre- and post-compaction
states are equivalent). The patch extends the logic so that wide columns
are also considered in both cases.

Test Plan:
Tested using some simple blackbox crash test runs.