### PR TITLE
Skip column validation for non-value types when iter_start_ts is set

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -706,6 +706,17 @@ class NonBatchedOpsStressTest : public StressTest {
          iter->Next()) {
       ++count;
 
+      // When iter_start_ts is set, iterator exposes internal keys, including
+      // tombstones; however, we want to perform column validation only for
+      // value-like types.
+      if (ro_copy.iter_start_ts) {
+        const ValueType value_type = ExtractValueType(iter->key());
+        if (value_type != kTypeValue && value_type != kTypeBlobIndex &&
+            value_type != kTypeWideColumnEntity) {
+          continue;
+        }
+      }
+
       const WideColumns expected_columns = GenerateExpectedWideColumns(
           GetValueBase(iter->value()), iter->value());
       if (iter->columns() != expected_columns) {


### PR DESCRIPTION
Summary:
When the `iter_start_ts` read option is set, iterator exposes internal keys. This also includes tombstones, which by definition do not have a value (or columns). The patch makes sure we skip the wide-column consistency check in this case.

Test Plan:
Tested using a simple blackbox crash test with timestamps enabled.