### PR TITLE
Block cache analyzer: Calculate miss ratio for each caller

### DIFF
--- a/tools/block_cache_analyzer/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_analyzer/block_cache_trace_analyzer.cc
@@ -1571,6 +1571,10 @@ Status BlockCacheTraceAnalyzer::Analyze() {
     miss_ratio_stats_.UpdateMetrics(access.access_timestamp,
                                     is_user_access(access.caller),
                                     !access.is_cache_hit);
+    caller_miss_ratio_stats_map_[access.caller].UpdateMetrics(
+        access.access_timestamp, is_user_access(access.caller),
+        !access.is_cache_hit);
+
     if (cache_simulator_) {
       cache_simulator_->Access(access);
     }
@@ -1586,6 +1590,14 @@ Status BlockCacheTraceAnalyzer::Analyze() {
               " seconds. Observed miss ratio %.2f\n",
               duration, duration > 0 ? access_sequence_number_ / duration : 0,
               trace_duration, miss_ratio_stats_.miss_ratio());
+
+      for (const auto& caller : caller_miss_ratio_stats_map_) {
+        fprintf(stdout, "Caller %s: Observed miss ratio %.2f\n",
+                caller_to_string(caller.first).c_str(),
+                caller.second.miss_ratio());
+      }
+      print_break_lines(/*num_break_lines=*/1);
+
       time_interval++;
     }
   }
@@ -1599,6 +1611,11 @@ Status BlockCacheTraceAnalyzer::Analyze() {
           " seconds. Observed miss ratio %.2f\n",
           duration, duration > 0 ? access_sequence_number_ / duration : 0,
           trace_duration, miss_ratio_stats_.miss_ratio());
+  for (const auto& caller : caller_miss_ratio_stats_map_) {
+    fprintf(stdout, "Caller %s: Observed miss ratio %.2f\n",
+            caller_to_string(caller.first).c_str(), caller.second.miss_ratio());
+  }
+  print_break_lines(/*num_break_lines=*/1);
   return s;
 }
 

--- a/tools/block_cache_analyzer/block_cache_trace_analyzer.h
+++ b/tools/block_cache_analyzer/block_cache_trace_analyzer.h
@@ -387,6 +387,7 @@ class BlockCacheTraceAnalyzer {
   uint64_t trace_start_timestamp_in_seconds_ = 0;
   uint64_t trace_end_timestamp_in_seconds_ = 0;
   MissRatioStats miss_ratio_stats_;
+  std::map<TableReaderCaller, MissRatioStats> caller_miss_ratio_stats_map_;
   uint64_t unique_block_id_ = 1;
   uint64_t unique_get_key_id_ = 1;
   BlockCacheHumanReadableTraceWriter human_readable_trace_writer_;


### PR DESCRIPTION
Currently, when `block_cache_trace_analyzer` analyzes the cache miss ratio, it only analyzes the total miss ratio. 

But it seems also important to analyze the cache miss ratio of each caller. To achieve this, we can calculate and print the miss ratio of each caller in the analyzer.

## Before modification
```
Running for 1 seconds: Processed 85732 records/second. Trace duration 58 seconds. Observed miss ratio 7.97
```

## After modification
```
Running for 1 seconds: Processed 85732 records/second. Trace duration 58 seconds. Observed miss ratio 7.97
Caller Get: Observed miss ratio 6.31
Caller Iterator: Observed miss ratio 11.86
***************************************************************
```



