### PR TITLE
Enable preclude_last_level_data_seconds in stress test

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -314,6 +314,7 @@ DECLARE_bool(allow_data_in_errors);
 // Tiered storage
 DECLARE_bool(enable_tiered_storage);  // set last_level_temperature
 DECLARE_int64(preclude_last_level_data_seconds);
+DECLARE_int64(preserve_internal_time_seconds);
 
 DECLARE_int32(verify_iterator_with_expected_state_one_in);
 DECLARE_bool(preserve_unverified_changes);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -496,6 +496,10 @@ DEFINE_int64(preclude_last_level_data_seconds, 0,
              "Preclude data from the last level. Used with tiered storage "
              "feature to preclude new data from comacting to the last level.");
 
+DEFINE_int64(
+    preserve_internal_time_seconds, 0,
+    "Preserve internal time information which is attached to each SST.");
+
 static const bool FLAGS_subcompactions_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_subcompactions, &ValidateUint32Range);
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3255,6 +3255,7 @@ void InitializeOptionsFromFlags(
   }
   options.preclude_last_level_data_seconds =
       FLAGS_preclude_last_level_data_seconds;
+  options.preserve_internal_time_seconds = FLAGS_preserve_internal_time_seconds;
 
   switch (FLAGS_rep_factory) {
     case kSkipList:

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1353,6 +1353,9 @@ DEFINE_int64(
     preclude_last_level_data_seconds, 0,
     "Preclude the latest data from the last level. (Used for tiered storage)");
 
+DEFINE_int64(preserve_internal_time_seconds, 0,
+             "Preserve the internal time information which stores with SST.");
+
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_guard;
 
 static ROCKSDB_NAMESPACE::Env* FLAGS_env = ROCKSDB_NAMESPACE::Env::Default();
@@ -4530,6 +4533,8 @@ class Benchmark {
     }
     options.preclude_last_level_data_seconds =
         FLAGS_preclude_last_level_data_seconds;
+    options.preserve_internal_time_seconds =
+        FLAGS_preserve_internal_time_seconds;
     options.sample_for_compression = FLAGS_sample_for_compression;
     options.WAL_ttl_seconds = FLAGS_wal_ttl_seconds;
     options.WAL_size_limit_MB = FLAGS_wal_size_limit_MB;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -202,6 +202,7 @@ default_params = {
     "max_auto_readahead_size": lambda: random.choice([0, 16384, 524288]),
     "num_file_reads_for_auto_readahead": lambda: random.choice([0, 1, 2]),
     "min_write_buffer_number_to_merge": lambda: random.choice([1, 2]),
+    "preserve_internal_time_seconds": lambda: random.choice([0, 60, 3600, 36000]),
 }
 
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"


### PR DESCRIPTION
And add the option to the db_bench.