### PR TITLE
java API - load block based table config

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -151,6 +151,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/Experimental.java
   src/main/java/org/rocksdb/ExternalFileIngestionInfo.java
   src/main/java/org/rocksdb/Filter.java
+  src/main/java/org/rocksdb/FilterPolicyType.java
   src/main/java/org/rocksdb/FileOperationInfo.java
   src/main/java/org/rocksdb/FlushJobInfo.java
   src/main/java/org/rocksdb/FlushReason.java

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -207,6 +207,18 @@ class IllegalArgumentExceptionJni
 
     return JavaException::ThrowNew(env, s.ToString());
   }
+
+  /**
+   * Create and throw a Java IllegalArgumentException with the provided message
+   *
+   * @param env A pointer to the Java environment
+   * @param msg The message for the exception
+   *
+   * @return true if an exception was thrown, false otherwise
+   */
+  static bool ThrowNew(JNIEnv* env, const std::string& msg) {
+    return JavaException::ThrowNew(env, msg);
+  }
 };
 
 // The portal class for org.rocksdb.Status.Code
@@ -3561,13 +3573,20 @@ class IteratorJni
   }
 };
 
-// The portal class for org.rocksdb.Filter
-class FilterJni
+// The portal class for org.rocksdb.FilterPolicy
+
+enum FilterPolicyTypeJni {
+  kUnknownFilterPolicy = 0x00,
+  kBloomFilterPolicy = 0x01,
+  kRibbonFilterPolicy = 0x02,
+};
+class FilterPolicyJni
     : public RocksDBNativeClass<
-          std::shared_ptr<ROCKSDB_NAMESPACE::FilterPolicy>*, FilterJni> {
+          std::shared_ptr<ROCKSDB_NAMESPACE::FilterPolicy>*, FilterPolicyJni> {
+ private:
  public:
   /**
-   * Get the Java Class org.rocksdb.Filter
+   * Get the Java Class org.rocksdb.FilterPolicy
    *
    * @param env A pointer to the Java environment
    *
@@ -3576,7 +3595,19 @@ class FilterJni
    *     OutOfMemoryError or ExceptionInInitializerError exceptions is thrown
    */
   static jclass getJClass(JNIEnv* env) {
-    return RocksDBNativeClass::getJClass(env, "org/rocksdb/Filter");
+    return RocksDBNativeClass::getJClass(env, "org/rocksdb/FilterPolicy");
+  }
+
+  static jbyte toJavaIndexType(const FilterPolicyTypeJni& filter_policy_type) {
+    return static_cast<jbyte>(filter_policy_type);
+  }
+
+  static FilterPolicyTypeJni getFilterPolicyType(
+      const std::string& policy_class_name) {
+    if (policy_class_name == "rocksdb.BuiltinBloomFilter") {
+      return kBloomFilterPolicy;
+    }
+    return kUnknownFilterPolicy;
   }
 };
 
@@ -6673,7 +6704,7 @@ class ChecksumTypeJni {
         return ROCKSDB_NAMESPACE::ChecksumType::kXXH3;
       default:
         // undefined/default
-        return ROCKSDB_NAMESPACE::ChecksumType::kCRC32c;
+        return ROCKSDB_NAMESPACE::ChecksumType::kXXH3;
     }
   }
 };
@@ -8747,6 +8778,102 @@ class CompactRangeOptionsTimestampJni : public JavaClass {
 
   static jmethodID getConstructorMethodId(JNIEnv* env, jclass clazz) {
     return env->GetMethodID(clazz, "<init>", "(JJ)V");
+  }
+};
+
+// The portal class for org.rocksdb.BlockBasedTableOptions
+class BlockBasedTableOptionsJni
+    : public RocksDBNativeClass<ROCKSDB_NAMESPACE::BlockBasedTableOptions*,
+                                BlockBasedTableOptions> {
+ public:
+  /**
+   * Get the Java Class org.rocksdb.BlockBasedTableConfig
+   *
+   * @param env A pointer to the Java environment
+   *
+   * @return The Java Class or nullptr if one of the
+   *     ClassFormatError, ClassCircularityError, NoClassDefFoundError,
+   *     OutOfMemoryError or ExceptionInInitializerError exceptions is thrown
+   */
+  static jclass getJClass(JNIEnv* env) {
+    return RocksDBNativeClass::getJClass(env,
+                                         "org/rocksdb/BlockBasedTableConfig");
+  }
+
+  /**
+   * Create a new Java org.rocksdb.BlockBasedTableConfig object with the
+   * properties as the provided C++ ROCKSDB_NAMESPACE::BlockBasedTableOptions
+   * object
+   *
+   * @param env A pointer to the Java environment
+   * @param cfoptions A pointer to ROCKSDB_NAMESPACE::ColumnFamilyOptions object
+   *
+   * @return A reference to a Java org.rocksdb.ColumnFamilyOptions object, or
+   * nullptr if an an exception occurs
+   */
+  static jobject construct(
+      JNIEnv* env, const BlockBasedTableOptions* table_factory_options) {
+    jclass jclazz = getJClass(env);
+    if (jclazz == nullptr) {
+      // exception occurred accessing class
+      return nullptr;
+    }
+
+    jmethodID method_id_init =
+        env->GetMethodID(jclazz, "<init>", "(ZZZZBBDBZJIIIJZZZZZIIZZBBJD)V");
+    if (method_id_init == nullptr) {
+      // exception thrown: NoSuchMethodException or OutOfMemoryError
+      return nullptr;
+    }
+
+    FilterPolicyTypeJni filter_policy_type =
+        FilterPolicyTypeJni::kUnknownFilterPolicy;
+    jlong filter_policy_handle = 0L;
+    jdouble filter_policy_config_value = 0.0;
+    if (table_factory_options->filter_policy) {
+      auto filter_policy = table_factory_options->filter_policy.get();
+      filter_policy_type = FilterPolicyJni::getFilterPolicyType(
+          filter_policy->CompatibilityName());
+      if (FilterPolicyTypeJni::kUnknownFilterPolicy != filter_policy_type) {
+        filter_policy_handle = GET_CPLUSPLUS_POINTER(filter_policy);
+      }
+    }
+
+    jobject jcfd = env->NewObject(
+        jclazz, method_id_init,
+        table_factory_options->cache_index_and_filter_blocks,
+        table_factory_options->cache_index_and_filter_blocks_with_high_priority,
+        table_factory_options->pin_l0_filter_and_index_blocks_in_cache,
+        table_factory_options->pin_top_level_index_and_filter,
+        IndexTypeJni::toJavaIndexType(table_factory_options->index_type),
+        DataBlockIndexTypeJni::toJavaDataBlockIndexType(
+            table_factory_options->data_block_index_type),
+        table_factory_options->data_block_hash_table_util_ratio,
+        ChecksumTypeJni::toJavaChecksumType(table_factory_options->checksum),
+        table_factory_options->no_block_cache,
+        static_cast<long>(table_factory_options->block_size),
+        table_factory_options->block_size_deviation,
+        table_factory_options->block_restart_interval,
+        table_factory_options->index_block_restart_interval,
+        static_cast<long>(table_factory_options->metadata_block_size),
+        table_factory_options->partition_filters,
+        table_factory_options->optimize_filters_for_memory,
+        table_factory_options->use_delta_encoding,
+        table_factory_options->whole_key_filtering,
+        table_factory_options->verify_compression,
+        table_factory_options->read_amp_bytes_per_bit,
+        table_factory_options->format_version,
+        table_factory_options->enable_index_compression,
+        table_factory_options->block_align,
+        IndexShorteningModeJni::toJavaIndexShorteningMode(
+            table_factory_options->index_shortening),
+        FilterPolicyJni::toJavaIndexType(filter_policy_type),
+        filter_policy_handle, filter_policy_config_value);
+    if (env->ExceptionCheck()) {
+      return nullptr;
+    }
+
+    return jcfd;
   }
 };
 

--- a/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
+++ b/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
@@ -5,7 +5,7 @@
 package org.rocksdb;
 
 /**
- * The config for plain table sst format.
+ * The config for block based table sst format.
  * <p>
  * BlockBasedTable is a RocksDB's default SST file format.
  */
@@ -21,7 +21,7 @@ public class BlockBasedTableConfig extends TableFormatConfig {
     indexType = IndexType.kBinarySearch;
     dataBlockIndexType = DataBlockIndexType.kDataBlockBinarySearch;
     dataBlockHashTableUtilRatio = 0.75;
-    checksumType = ChecksumType.kCRC32c;
+    checksumType = ChecksumType.kXXH3;
     noBlockCache = false;
     blockCache = null;
     persistentCache = null;
@@ -45,6 +45,54 @@ public class BlockBasedTableConfig extends TableFormatConfig {
     // NOTE: ONLY used if blockCache == null
     blockCacheSize = 8 * 1024 * 1024;
     blockCacheNumShardBits = 0;
+  }
+
+  /**
+   * Constructor for use by C++ via JNI
+   */
+  private BlockBasedTableConfig(final boolean cacheIndexAndFilterBlocks,
+      final boolean cacheIndexAndFilterBlocksWithHighPriority,
+      final boolean pinL0FilterAndIndexBlocksInCache, final boolean pinTopLevelIndexAndFilter,
+      final byte indexType, final byte dataBlockIndexType, final double dataBlockHashTableUtilRatio,
+      final byte checksumType, final boolean noBlockCache, final long blockSize,
+      final int blockSizeDeviation, final int blockRestartInterval,
+      final int indexBlockRestartInterval, final long metadataBlockSize,
+      final boolean partitionFilters, final boolean optimizeFiltersForMemory,
+      final boolean useDeltaEncoding, final boolean wholeKeyFiltering,
+      final boolean verifyCompression, final int readAmpBytesPerBit, final int formatVersion,
+      final boolean enableIndexCompression, final boolean blockAlign, final byte indexShortening,
+      final byte filterPolicyType, final long filterPolicyHandle,
+      final double filterPolicyConfigValue) {
+    this.cacheIndexAndFilterBlocks = cacheIndexAndFilterBlocks;
+    this.cacheIndexAndFilterBlocksWithHighPriority = cacheIndexAndFilterBlocksWithHighPriority;
+    this.pinL0FilterAndIndexBlocksInCache = pinL0FilterAndIndexBlocksInCache;
+    this.pinTopLevelIndexAndFilter = pinTopLevelIndexAndFilter;
+    this.indexType = IndexType.values()[indexType];
+    this.dataBlockIndexType = DataBlockIndexType.values()[dataBlockIndexType];
+    this.dataBlockHashTableUtilRatio = dataBlockHashTableUtilRatio;
+    this.checksumType = ChecksumType.values()[checksumType];
+    this.noBlockCache = noBlockCache;
+    this.blockSize = blockSize;
+    this.blockSizeDeviation = blockSizeDeviation;
+    this.blockRestartInterval = blockRestartInterval;
+    this.indexBlockRestartInterval = indexBlockRestartInterval;
+    this.metadataBlockSize = metadataBlockSize;
+    this.partitionFilters = partitionFilters;
+    this.optimizeFiltersForMemory = optimizeFiltersForMemory;
+    this.useDeltaEncoding = useDeltaEncoding;
+    this.wholeKeyFiltering = wholeKeyFiltering;
+    this.verifyCompression = verifyCompression;
+    this.readAmpBytesPerBit = readAmpBytesPerBit;
+    this.formatVersion = formatVersion;
+    this.enableIndexCompression = enableIndexCompression;
+    this.blockAlign = blockAlign;
+    this.indexShortening = IndexShorteningMode.values()[indexShortening];
+    Filter filterPolicy = FilterPolicyType.values()[filterPolicyType].createFilter(
+        filterPolicyHandle, filterPolicyConfigValue);
+    if (filterPolicy != null) {
+      filterPolicy.disOwnNativeHandle();
+      this.setFilterPolicy(filterPolicy);
+    }
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/BloomFilter.java
+++ b/java/src/main/java/org/rocksdb/BloomFilter.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import java.util.Objects;
+
 /**
  * Bloom filter policy that uses a bloom filter with approximately
  * the specified number of bits per key.
@@ -33,6 +35,9 @@ public class BloomFilter extends Filter {
     this(DEFAULT_BITS_PER_KEY);
   }
 
+  // record this for comparison of filters.
+  private final double bitsPerKey;
+
   /**
    * BloomFilter constructor
    *
@@ -47,7 +52,17 @@ public class BloomFilter extends Filter {
    * @param bitsPerKey number of bits to use
    */
   public BloomFilter(final double bitsPerKey) {
-    super(createNewBloomFilter(bitsPerKey));
+    this(createNewBloomFilter(bitsPerKey), bitsPerKey);
+  }
+
+  /**
+   *
+   * @param nativeHandle handle to existing bloom filter at RocksDB C++ side
+   * @param bitsPerKey number of bits to use - recorded for comparison
+   */
+  BloomFilter(final long nativeHandle, final double bitsPerKey) {
+    super(nativeHandle);
+    this.bitsPerKey = bitsPerKey;
   }
 
   /**
@@ -67,6 +82,21 @@ public class BloomFilter extends Filter {
    */
   public BloomFilter(final double bitsPerKey, final boolean IGNORED_useBlockBasedMode) {
     this(bitsPerKey);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    BloomFilter that = (BloomFilter) o;
+    return bitsPerKey == that.bitsPerKey;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bitsPerKey);
   }
 
   private static native long createNewBloomFilter(final double bitsKeyKey);

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -599,6 +599,10 @@ public class ColumnFamilyOptions extends RocksObject
     return this;
   }
 
+  void setFetchedTableFormatConfig(final TableFormatConfig tableFormatConfig) {
+    this.tableFormatConfig_ = tableFormatConfig;
+  }
+
   @Override
   public String tableFactoryName() {
     assert(isOwningHandle());
@@ -1512,7 +1516,6 @@ public class ColumnFamilyOptions extends RocksObject
       final long nativeHandle_, final long compactionThreadLimiterHandle);
   private native void setMemtableMaxRangeDeletions(final long handle, final int count);
   private native int memtableMaxRangeDeletions(final long handle);
-
   private native void setEnableBlobFiles(final long nativeHandle_, final boolean enableBlobFiles);
   private native boolean enableBlobFiles(final long nativeHandle_);
   private native void setMinBlobSize(final long nativeHandle_, final long minBlobSize);

--- a/java/src/main/java/org/rocksdb/FilterPolicyType.java
+++ b/java/src/main/java/org/rocksdb/FilterPolicyType.java
@@ -1,0 +1,49 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * IndexType used in conjunction with BlockBasedTable.
+ */
+public enum FilterPolicyType {
+  kUnknownFilterPolicy((byte) 0),
+
+  /**
+   * This is a user-facing policy that automatically choose between
+   * LegacyBloom and FastLocalBloom based on context at build time,
+   * including compatibility with format_version.
+   */
+  kBloomFilterPolicy((byte) 1),
+
+  /**
+   * This is a user-facing policy that chooses between Standard128Ribbon
+   * and FastLocalBloom based on context at build time (LSM level and other
+   * factors in extreme cases).
+   */
+  kRibbonFilterPolicy((byte) 2);
+
+  public Filter createFilter(final long handle, final double param) {
+    if (this == kBloomFilterPolicy) {
+      return new BloomFilter(handle, param);
+    }
+    return null;
+  }
+
+  /**
+   * Returns the byte value of the enumerations value
+   *
+   * @return byte representation
+   */
+  public byte getValue() {
+    return value_;
+  }
+
+  FilterPolicyType(byte value) {
+    value_ = value;
+  }
+
+  private final byte value_;
+}

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -2540,7 +2540,6 @@ public class Options extends RocksObject
   private static native void setBgerrorResumeRetryInterval(
       final long handle, final long bgerrorResumeRetryInterval);
   private static native long bgerrorResumeRetryInterval(final long handle);
-
   private native void setEnableBlobFiles(final long nativeHandle_, final boolean enableBlobFiles);
   private native boolean enableBlobFiles(final long nativeHandle_);
   private native void setMinBlobSize(final long nativeHandle_, final long minBlobSize);

--- a/java/src/main/java/org/rocksdb/OptionsUtil.java
+++ b/java/src/main/java/org/rocksdb/OptionsUtil.java
@@ -47,6 +47,7 @@ public class OptionsUtil {
       final DBOptions dbOptions, final List<ColumnFamilyDescriptor> cfDescs)
       throws RocksDBException {
     loadLatestOptions(configOptions.nativeHandle_, dbPath, dbOptions.nativeHandle_, cfDescs);
+    loadTableFormatConfig(cfDescs);
   }
 
   /**
@@ -68,6 +69,7 @@ public class OptionsUtil {
       final List<ColumnFamilyDescriptor> cfDescs) throws RocksDBException {
     loadOptionsFromFile(
         configOptions.nativeHandle_, optionsFileName, dbOptions.nativeHandle_, cfDescs);
+    loadTableFormatConfig(cfDescs);
   }
 
   /**
@@ -85,6 +87,14 @@ public class OptionsUtil {
     return getLatestOptionsFileName(dbPath, env.nativeHandle_);
   }
 
+  private static void loadTableFormatConfig(final List<ColumnFamilyDescriptor> cfDescs) {
+    for (final ColumnFamilyDescriptor columnFamilyDescriptor : cfDescs) {
+      final ColumnFamilyOptions columnFamilyOptions = columnFamilyDescriptor.getOptions();
+      columnFamilyOptions.setFetchedTableFormatConfig(
+          readTableFormatConfig(columnFamilyOptions.nativeHandle_));
+    }
+  }
+
   /**
    * Private constructor.
    * This class has only static methods and shouldn't be instantiated.
@@ -98,4 +108,6 @@ public class OptionsUtil {
       long dbOptionsHandle, List<ColumnFamilyDescriptor> cfDescs) throws RocksDBException;
   private static native String getLatestOptionsFileName(String dbPath, long envHandle)
       throws RocksDBException;
+
+  private native static TableFormatConfig readTableFormatConfig(final long nativeHandle_);
 }

--- a/java/src/test/java/org/rocksdb/OptionsUtilTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsUtilTest.java
@@ -20,16 +20,146 @@ public class OptionsUtilTest {
 
   @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
 
-  enum TestAPI { LOAD_LATEST_OPTIONS, LOAD_OPTIONS_FROM_FILE }
-
   @Test
   public void loadLatestOptions() throws RocksDBException {
-    verifyOptions(TestAPI.LOAD_LATEST_OPTIONS);
+    verifyOptions(new LoaderUnderTest() {
+      @Override
+      List<ColumnFamilyDescriptor> loadOptions(final String dbPath, final DBOptions dbOptions)
+          throws RocksDBException {
+        try (final ConfigOptions configOptions = new ConfigOptions()
+                                                     .setIgnoreUnknownOptions(false)
+                                                     .setInputStringsEscaped(true)
+                                                     .setEnv(Env.getDefault())) {
+          final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
+          OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescs);
+          return cfDescs;
+        }
+      }
+    });
   }
 
   @Test
   public void loadOptionsFromFile() throws RocksDBException {
-    verifyOptions(TestAPI.LOAD_OPTIONS_FROM_FILE);
+    verifyOptions(new LoaderUnderTest() {
+      @Override
+      List<ColumnFamilyDescriptor> loadOptions(final String dbPath, final DBOptions dbOptions)
+          throws RocksDBException {
+        try (final ConfigOptions configOptions = new ConfigOptions()
+                                                     .setIgnoreUnknownOptions(false)
+                                                     .setInputStringsEscaped(true)
+                                                     .setEnv(Env.getDefault())) {
+          final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
+          final String path =
+              dbPath + "/" + OptionsUtil.getLatestOptionsFileName(dbPath, Env.getDefault());
+          OptionsUtil.loadOptionsFromFile(configOptions, path, dbOptions, cfDescs);
+          return cfDescs;
+        }
+      }
+    });
+  }
+
+  @Test
+  public void loadLatestTableFormatOptions() throws RocksDBException {
+    verifyTableFormatOptions(new LoaderUnderTest() {
+      @Override
+      List<ColumnFamilyDescriptor> loadOptions(final String dbPath, final DBOptions dbOptions)
+          throws RocksDBException {
+        try (final ConfigOptions configOptions = new ConfigOptions()
+                                                     .setIgnoreUnknownOptions(false)
+                                                     .setInputStringsEscaped(true)
+                                                     .setEnv(Env.getDefault())) {
+          final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
+          OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescs);
+          return cfDescs;
+        }
+      }
+    });
+  }
+
+  @Test
+  public void loadLatestTableFormatOptions2() throws RocksDBException {
+    verifyTableFormatOptions(new LoaderUnderTest() {
+      @Override
+      List<ColumnFamilyDescriptor> loadOptions(final String dbPath, final DBOptions dbOptions)
+          throws RocksDBException {
+        try (final ConfigOptions configOptions = new ConfigOptions()
+                                                     .setIgnoreUnknownOptions(false)
+                                                     .setInputStringsEscaped(true)
+                                                     .setEnv(Env.getDefault())) {
+          final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
+          OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescs);
+          return cfDescs;
+        }
+      }
+    });
+  }
+
+  @Test
+  public void loadLatestTableFormatOptions3() throws RocksDBException {
+    verifyTableFormatOptions(new LoaderUnderTest() {
+      @Override
+      List<ColumnFamilyDescriptor> loadOptions(final String dbPath, final DBOptions dbOptions)
+          throws RocksDBException {
+        final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
+        OptionsUtil.loadLatestOptions(new ConfigOptions(), dbPath, dbOptions, cfDescs);
+        return cfDescs;
+      }
+    });
+  }
+
+  @Test
+  public void loadTableFormatOptionsFromFile() throws RocksDBException {
+    verifyTableFormatOptions(new LoaderUnderTest() {
+      @Override
+      List<ColumnFamilyDescriptor> loadOptions(final String dbPath, final DBOptions dbOptions)
+          throws RocksDBException {
+        try (final ConfigOptions configOptions = new ConfigOptions()
+                                                     .setIgnoreUnknownOptions(false)
+                                                     .setInputStringsEscaped(true)
+                                                     .setEnv(Env.getDefault())) {
+          final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
+          final String path =
+              dbPath + "/" + OptionsUtil.getLatestOptionsFileName(dbPath, Env.getDefault());
+          OptionsUtil.loadOptionsFromFile(configOptions, path, dbOptions, cfDescs);
+          return cfDescs;
+        }
+      }
+    });
+  }
+
+  @Test
+  public void loadTableFormatOptionsFromFile2() throws RocksDBException {
+    verifyTableFormatOptions(new LoaderUnderTest() {
+      @Override
+      List<ColumnFamilyDescriptor> loadOptions(final String dbPath, final DBOptions dbOptions)
+          throws RocksDBException {
+        try (final ConfigOptions configOptions = new ConfigOptions()
+                                                     .setIgnoreUnknownOptions(false)
+                                                     .setInputStringsEscaped(true)
+                                                     .setEnv(Env.getDefault())) {
+          final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
+          final String path =
+              dbPath + "/" + OptionsUtil.getLatestOptionsFileName(dbPath, Env.getDefault());
+          OptionsUtil.loadOptionsFromFile(configOptions, path, dbOptions, cfDescs);
+          return cfDescs;
+        }
+      }
+    });
+  }
+
+  @Test
+  public void loadTableFormatOptionsFromFile3() throws RocksDBException {
+    verifyTableFormatOptions(new LoaderUnderTest() {
+      @Override
+      List<ColumnFamilyDescriptor> loadOptions(final String dbPath, final DBOptions dbOptions)
+          throws RocksDBException {
+        final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
+        final String path =
+            dbPath + "/" + OptionsUtil.getLatestOptionsFileName(dbPath, Env.getDefault());
+        OptionsUtil.loadOptionsFromFile(new ConfigOptions(), path, dbOptions, cfDescs);
+        return cfDescs;
+      }
+    });
   }
 
   @Test
@@ -46,7 +176,12 @@ public class OptionsUtilTest {
     // System.out.println("latest options fileName: " + fName);
   }
 
-  private void verifyOptions(final TestAPI apiType) throws RocksDBException {
+  static abstract class LoaderUnderTest {
+    abstract List<ColumnFamilyDescriptor> loadOptions(final String path, final DBOptions dbOptions)
+        throws RocksDBException;
+  }
+
+  private void verifyOptions(final LoaderUnderTest loaderUnderTest) throws RocksDBException {
     final String dbPath = dbFolder.getRoot().getAbsolutePath();
     final Options options = new Options()
                                 .setCreateIfMissing(true)
@@ -76,18 +211,113 @@ public class OptionsUtilTest {
     }
 
     // Read the options back and verify
-    final DBOptions dbOptions = new DBOptions();
-    final ConfigOptions configOptions =
-        new ConfigOptions().setIgnoreUnknownOptions(false).setInputStringsEscaped(true).setEnv(
-            Env.getDefault());
-    final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
-    String path = dbPath;
-    if (apiType == TestAPI.LOAD_LATEST_OPTIONS) {
-      OptionsUtil.loadLatestOptions(configOptions, path, dbOptions, cfDescs);
-    } else if (apiType == TestAPI.LOAD_OPTIONS_FROM_FILE) {
-      path = dbPath + "/" + OptionsUtil.getLatestOptionsFileName(dbPath, Env.getDefault());
-      OptionsUtil.loadOptionsFromFile(configOptions, path, dbOptions, cfDescs);
+    try (DBOptions dbOptions = new DBOptions()) {
+      final List<ColumnFamilyDescriptor> cfDescs = loaderUnderTest.loadOptions(dbPath, dbOptions);
+
+      assertThat(dbOptions.createIfMissing()).isEqualTo(options.createIfMissing());
+      assertThat(dbOptions.paranoidChecks()).isEqualTo(options.paranoidChecks());
+      assertThat(dbOptions.maxOpenFiles()).isEqualTo(options.maxOpenFiles());
+      assertThat(dbOptions.delayedWriteRate()).isEqualTo(options.delayedWriteRate());
+
+      assertThat(cfDescs.size()).isEqualTo(2);
+      assertThat(cfDescs.get(0)).isNotNull();
+      assertThat(cfDescs.get(1)).isNotNull();
+      assertThat(cfDescs.get(0).getName()).isEqualTo(RocksDB.DEFAULT_COLUMN_FAMILY);
+      assertThat(cfDescs.get(1).getName()).isEqualTo(secondCFName);
+
+      final ColumnFamilyOptions defaultCFOpts = cfDescs.get(0).getOptions();
+      assertThat(defaultCFOpts.writeBufferSize()).isEqualTo(baseDefaultCFOpts.writeBufferSize());
+      assertThat(defaultCFOpts.maxWriteBufferNumber())
+          .isEqualTo(baseDefaultCFOpts.maxWriteBufferNumber());
+      assertThat(defaultCFOpts.maxBytesForLevelBase())
+          .isEqualTo(baseDefaultCFOpts.maxBytesForLevelBase());
+      assertThat(defaultCFOpts.level0FileNumCompactionTrigger())
+          .isEqualTo(baseDefaultCFOpts.level0FileNumCompactionTrigger());
+      assertThat(defaultCFOpts.level0SlowdownWritesTrigger())
+          .isEqualTo(baseDefaultCFOpts.level0SlowdownWritesTrigger());
+      assertThat(defaultCFOpts.bottommostCompressionType())
+          .isEqualTo(baseDefaultCFOpts.bottommostCompressionType());
+
+      final ColumnFamilyOptions secondCFOpts = cfDescs.get(1).getOptions();
+      assertThat(secondCFOpts.writeBufferSize()).isEqualTo(baseSecondCFOpts.writeBufferSize());
+      assertThat(secondCFOpts.maxWriteBufferNumber())
+          .isEqualTo(baseSecondCFOpts.maxWriteBufferNumber());
+      assertThat(secondCFOpts.maxBytesForLevelBase())
+          .isEqualTo(baseSecondCFOpts.maxBytesForLevelBase());
+      assertThat(secondCFOpts.level0FileNumCompactionTrigger())
+          .isEqualTo(baseSecondCFOpts.level0FileNumCompactionTrigger());
+      assertThat(secondCFOpts.level0SlowdownWritesTrigger())
+          .isEqualTo(baseSecondCFOpts.level0SlowdownWritesTrigger());
+      assertThat(secondCFOpts.bottommostCompressionType())
+          .isEqualTo(baseSecondCFOpts.bottommostCompressionType());
     }
+  }
+
+  private void verifyTableFormatOptions(final LoaderUnderTest loaderUnderTest)
+      throws RocksDBException {
+    final String dbPath = dbFolder.getRoot().getAbsolutePath();
+    final Options options = new Options()
+                                .setCreateIfMissing(true)
+                                .setParanoidChecks(false)
+                                .setMaxOpenFiles(478)
+                                .setDelayedWriteRate(1234567L);
+    final ColumnFamilyOptions defaultCFOptions = new ColumnFamilyOptions();
+    defaultCFOptions.setTableFormatConfig(new BlockBasedTableConfig());
+    final byte[] altCFName = "alt_cf".getBytes();
+    final ColumnFamilyOptions altCFOptions =
+        new ColumnFamilyOptions()
+            .setWriteBufferSize(70 * 1024)
+            .setMaxWriteBufferNumber(7)
+            .setMaxBytesForLevelBase(53 * 1024 * 1024)
+            .setLevel0FileNumCompactionTrigger(3)
+            .setLevel0SlowdownWritesTrigger(51)
+            .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION);
+
+    final BlockBasedTableConfig altCFTableConfig = new BlockBasedTableConfig();
+    altCFTableConfig.setCacheIndexAndFilterBlocks(true);
+    altCFTableConfig.setCacheIndexAndFilterBlocksWithHighPriority(false);
+    altCFTableConfig.setPinL0FilterAndIndexBlocksInCache(true);
+    altCFTableConfig.setPinTopLevelIndexAndFilter(false);
+    altCFTableConfig.setIndexType(IndexType.kTwoLevelIndexSearch);
+    altCFTableConfig.setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash);
+    altCFTableConfig.setDataBlockHashTableUtilRatio(0.65);
+    altCFTableConfig.setChecksumType(ChecksumType.kxxHash64);
+    altCFTableConfig.setNoBlockCache(true);
+    altCFTableConfig.setBlockSize(35 * 1024);
+    altCFTableConfig.setBlockSizeDeviation(20);
+    altCFTableConfig.setBlockRestartInterval(12);
+    altCFTableConfig.setIndexBlockRestartInterval(6);
+    altCFTableConfig.setMetadataBlockSize(12 * 1024);
+    altCFTableConfig.setPartitionFilters(true);
+    altCFTableConfig.setOptimizeFiltersForMemory(true);
+    altCFTableConfig.setUseDeltaEncoding(false);
+    altCFTableConfig.setFilterPolicy(new BloomFilter(7.5));
+    altCFTableConfig.setWholeKeyFiltering(false);
+    altCFTableConfig.setVerifyCompression(true);
+    altCFTableConfig.setReadAmpBytesPerBit(2);
+    altCFTableConfig.setFormatVersion(8);
+    altCFTableConfig.setEnableIndexCompression(false);
+    altCFTableConfig.setBlockAlign(true);
+    altCFTableConfig.setIndexShortening(IndexShorteningMode.kShortenSeparatorsAndSuccessor);
+    altCFTableConfig.setBlockCacheSize(3 * 1024 * 1024);
+    // Note cache objects are not set here, as they are not read back when reading config.
+
+    altCFOptions.setTableFormatConfig(altCFTableConfig);
+
+    // Create a database with a new column family
+    try (final RocksDB db = RocksDB.open(options, dbPath)) {
+      assertThat(db).isNotNull();
+
+      // create column family
+      try (final ColumnFamilyHandle columnFamilyHandle =
+               db.createColumnFamily(new ColumnFamilyDescriptor(altCFName, altCFOptions))) {
+        assert (columnFamilyHandle != null);
+      }
+    }
+
+    // Read the options back and verify
+    final DBOptions dbOptions = new DBOptions();
+    final List<ColumnFamilyDescriptor> cfDescs = loaderUnderTest.loadOptions(dbPath, dbOptions);
 
     assertThat(dbOptions.createIfMissing()).isEqualTo(options.createIfMissing());
     assertThat(dbOptions.paranoidChecks()).isEqualTo(options.paranoidChecks());
@@ -98,32 +328,50 @@ public class OptionsUtilTest {
     assertThat(cfDescs.get(0)).isNotNull();
     assertThat(cfDescs.get(1)).isNotNull();
     assertThat(cfDescs.get(0).getName()).isEqualTo(RocksDB.DEFAULT_COLUMN_FAMILY);
-    assertThat(cfDescs.get(1).getName()).isEqualTo(secondCFName);
+    assertThat(cfDescs.get(1).getName()).isEqualTo(altCFName);
 
-    final ColumnFamilyOptions defaultCFOpts = cfDescs.get(0).getOptions();
-    assertThat(defaultCFOpts.writeBufferSize()).isEqualTo(baseDefaultCFOpts.writeBufferSize());
-    assertThat(defaultCFOpts.maxWriteBufferNumber())
-        .isEqualTo(baseDefaultCFOpts.maxWriteBufferNumber());
-    assertThat(defaultCFOpts.maxBytesForLevelBase())
-        .isEqualTo(baseDefaultCFOpts.maxBytesForLevelBase());
-    assertThat(defaultCFOpts.level0FileNumCompactionTrigger())
-        .isEqualTo(baseDefaultCFOpts.level0FileNumCompactionTrigger());
-    assertThat(defaultCFOpts.level0SlowdownWritesTrigger())
-        .isEqualTo(baseDefaultCFOpts.level0SlowdownWritesTrigger());
-    assertThat(defaultCFOpts.bottommostCompressionType())
-        .isEqualTo(baseDefaultCFOpts.bottommostCompressionType());
+    verifyBlockBasedTableConfig(
+        cfDescs.get(0).getOptions().tableFormatConfig(), new BlockBasedTableConfig());
+    verifyBlockBasedTableConfig(cfDescs.get(1).getOptions().tableFormatConfig(), altCFTableConfig);
+  }
 
-    final ColumnFamilyOptions secondCFOpts = cfDescs.get(1).getOptions();
-    assertThat(secondCFOpts.writeBufferSize()).isEqualTo(baseSecondCFOpts.writeBufferSize());
-    assertThat(secondCFOpts.maxWriteBufferNumber())
-        .isEqualTo(baseSecondCFOpts.maxWriteBufferNumber());
-    assertThat(secondCFOpts.maxBytesForLevelBase())
-        .isEqualTo(baseSecondCFOpts.maxBytesForLevelBase());
-    assertThat(secondCFOpts.level0FileNumCompactionTrigger())
-        .isEqualTo(baseSecondCFOpts.level0FileNumCompactionTrigger());
-    assertThat(secondCFOpts.level0SlowdownWritesTrigger())
-        .isEqualTo(baseSecondCFOpts.level0SlowdownWritesTrigger());
-    assertThat(secondCFOpts.bottommostCompressionType())
-        .isEqualTo(baseSecondCFOpts.bottommostCompressionType());
+  private void verifyBlockBasedTableConfig(
+      final TableFormatConfig actualTableConfig, final BlockBasedTableConfig expected) {
+    assertThat(actualTableConfig).isNotNull();
+    assertThat(actualTableConfig).isInstanceOf(BlockBasedTableConfig.class);
+    final BlockBasedTableConfig actual = (BlockBasedTableConfig) actualTableConfig;
+    assertThat(actual.cacheIndexAndFilterBlocks()).isEqualTo(expected.cacheIndexAndFilterBlocks());
+    assertThat(actual.cacheIndexAndFilterBlocksWithHighPriority())
+        .isEqualTo(expected.cacheIndexAndFilterBlocksWithHighPriority());
+    assertThat(actual.pinL0FilterAndIndexBlocksInCache())
+        .isEqualTo(expected.pinL0FilterAndIndexBlocksInCache());
+    assertThat(actual.indexType()).isEqualTo(expected.indexType());
+    assertThat(actual.dataBlockIndexType()).isEqualTo(expected.dataBlockIndexType());
+    assertThat(actual.dataBlockHashTableUtilRatio())
+        .isEqualTo(expected.dataBlockHashTableUtilRatio());
+    assertThat(actual.checksumType()).isEqualTo(expected.checksumType());
+    assertThat(actual.noBlockCache()).isEqualTo(expected.noBlockCache());
+    assertThat(actual.blockSize()).isEqualTo(expected.blockSize());
+    assertThat(actual.blockSizeDeviation()).isEqualTo(expected.blockSizeDeviation());
+    assertThat(actual.blockRestartInterval()).isEqualTo(expected.blockRestartInterval());
+    assertThat(actual.indexBlockRestartInterval()).isEqualTo(expected.indexBlockRestartInterval());
+    assertThat(actual.metadataBlockSize()).isEqualTo(expected.metadataBlockSize());
+    assertThat(actual.partitionFilters()).isEqualTo(expected.partitionFilters());
+    assertThat(actual.optimizeFiltersForMemory()).isEqualTo(expected.optimizeFiltersForMemory());
+    assertThat(actual.wholeKeyFiltering()).isEqualTo(expected.wholeKeyFiltering());
+    assertThat(actual.verifyCompression()).isEqualTo(expected.verifyCompression());
+    assertThat(actual.readAmpBytesPerBit()).isEqualTo(expected.readAmpBytesPerBit());
+    assertThat(actual.formatVersion()).isEqualTo(expected.formatVersion());
+    assertThat(actual.enableIndexCompression()).isEqualTo(expected.enableIndexCompression());
+    assertThat(actual.blockAlign()).isEqualTo(expected.blockAlign());
+    assertThat(actual.indexShortening()).isEqualTo(expected.indexShortening());
+    if (expected.filterPolicy() == null) {
+      assertThat(actual.filterPolicy()).isNull();
+    } else {
+      assertThat(expected.filterPolicy().equals(actual.filterPolicy()));
+    }
+
+    // breakers
+    assertThat(actual.useDeltaEncoding()).isEqualTo(expected.useDeltaEncoding());
   }
 }

--- a/java/src/test/java/org/rocksdb/OptionsUtilTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsUtilTest.java
@@ -371,7 +371,8 @@ public class OptionsUtilTest {
       assertThat(expected.filterPolicy().equals(actual.filterPolicy()));
     }
 
-    // breakers
-    assertThat(actual.useDeltaEncoding()).isEqualTo(expected.useDeltaEncoding());
+    // not currently persisted - always true when read from options
+    // this test will fail, and need repaired, if and when "useDeltaEncoding" is persisted.
+    assertThat(actual.useDeltaEncoding()).isEqualTo(true);
   }
 }

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -225,7 +225,6 @@ static std::unordered_map<std::string,
         {"kFlushOnly",
          BlockBasedTableOptions::PrepopulateBlockCache::kFlushOnly}};
 
-
 static std::unordered_map<std::string, OptionTypeInfo>
     block_based_table_type_info = {
         /* currently not supported
@@ -308,6 +307,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
         {"optimize_filters_for_memory",
          {offsetof(struct BlockBasedTableOptions, optimize_filters_for_memory),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"use_delta_encoding",
+         {offsetof(struct BlockBasedTableOptions, use_delta_encoding),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"filter_policy",

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -309,10 +309,9 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct BlockBasedTableOptions, optimize_filters_for_memory),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
-        {"use_delta_encoding",
-         {offsetof(struct BlockBasedTableOptions, use_delta_encoding),
-          OptionType::kBoolean, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone}},
+        // TODO "use_delta_encoding" has not been persisted -
+        // this may have been an omission, but changing this now might be a
+        // breaker
         {"filter_policy",
          OptionTypeInfo::AsCustomSharedPtr<const FilterPolicy>(
              offsetof(struct BlockBasedTableOptions, filter_policy),


### PR DESCRIPTION
Closes https://github.com/facebook/rocksdb/issues/5297

The BlockBasedTableConfig (or more generally, the TableFormatConfig) of ColumnFamilyOptions, isn't being constructed when column family options are loaded. This happens in `OptionsUtil` which implements the loading.

In `OptionsUtil` we add the method `private native static TableFormatConfig readTableFormatConfig(final long nativeHandle_)` which defers to a JNI method which creates a `TableFormatConfig` (specifically a `BlockBasedTableConfig`) for the supplied `ColumnFamilyOptions`, by copying the table format attached to the C++ column family options. A new Java constructor for `BlockBasedTableConfig` is implemented which is called from C++ with the parameters retrieved from the table format, and then returned to the calling `readTableFormatConfig`.

At the Java side in `OptionsUtil`, the new `TableFormatConfig` is added as the `tableFormatConfig_` field of the `ColumnFamilyOptions`.

To support this, the new class `BlockBasedTableOptionsJni` and associated support methods are added to 'portal.h'.

`BloomFilter.java` has a constructor and field added so that the filter in use can be read back and inspected.

`FilterPolicyType.java` implements an enum (shadowed in C++) to support transfer of filter policy information back to Java from being read at the C++ side.

 Tests written to cover the block based table config, and cleaned up and generalised a bit as some of the methods on OptionsUtil weren't tested; and these had their own unique JNI method variants which in turn were never exercised in test.