### PR TITLE
Make UserComparatorWrapper not Customizable

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,7 @@
 ### Performance Improvements
 * Try to align the compaction output file boundaries to the next level ones, which can reduce more than 10% compaction load for the default level compaction. The feature is enabled by default, to disable, set `AdvancedColumnFamilyOptions.level_compaction_dynamic_file_size` to false. As a side effect, it can create SSTs larger than the target_file_size (capped at 2x target_file_size) or smaller files.
 * Improve RoundRobin TTL compaction, which is going to be the same as normal RoundRobin compaction to move the compaction cursor.
+* Fix a small CPU regression caused by a change that UserComparatorWrapper was made Customizable, because Customizable itself has small CPU overhead for initialization.
 
 ### New Features
 * Add a new option IOOptions.do_not_recurse that can be used by underlying file systems to skip recursing through sub directories and list only files in GetChildren API.

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -90,7 +90,8 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
     iter_.iter()->SetPinnedItersMgr(&pinned_iters_mgr_);
   }
   status_.PermitUncheckedError();
-  assert(timestamp_size_ == user_comparator_.timestamp_size());
+  assert(timestamp_size_ ==
+         user_comparator_.user_comparator()->timestamp_size());
 }
 
 Status DBIter::GetProperty(std::string prop_name, std::string* prop) {
@@ -522,7 +523,8 @@ bool DBIter::MergeValuesNewToOld() {
       return false;
     }
 
-    if (!user_comparator_.Equal(ikey.user_key, saved_key_.GetUserKey())) {
+    if (!user_comparator_.user_comparator()->Equal(ikey.user_key,
+                                                   saved_key_.GetUserKey())) {
       // hit the next user key, stop right here
       break;
     }
@@ -1158,7 +1160,8 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
     if (!ParseKey(&ikey)) {
       return false;
     }
-    if (!user_comparator_.Equal(ikey.user_key, saved_key_.GetUserKey())) {
+    if (!user_comparator_.user_comparator()->Equal(ikey.user_key,
+                                                   saved_key_.GetUserKey())) {
       break;
     }
     if (ikey.type == kTypeDeletion || ikey.type == kTypeSingleDeletion) {

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -523,8 +523,7 @@ bool DBIter::MergeValuesNewToOld() {
       return false;
     }
 
-    if (!user_comparator_.user_comparator()->Equal(ikey.user_key,
-                                                   saved_key_.GetUserKey())) {
+    if (!user_comparator_.Equal(ikey.user_key, saved_key_.GetUserKey())) {
       // hit the next user key, stop right here
       break;
     }
@@ -1160,8 +1159,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
     if (!ParseKey(&ikey)) {
       return false;
     }
-    if (!user_comparator_.user_comparator()->Equal(ikey.user_key,
-                                                   saved_key_.GetUserKey())) {
+    if (!user_comparator_.Equal(ikey.user_key, saved_key_.GetUserKey())) {
       break;
     }
     if (ikey.type == kTypeDeletion || ikey.type == kTypeSingleDeletion) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1239,7 +1239,7 @@ void LevelIterator::Seek(const Slice& target) {
         prefix_extractor_ != nullptr && !read_options_.total_order_seek &&
         !read_options_.auto_prefix_mode &&
         file_index_ < flevel_->num_files - 1) {
-      size_t ts_sz = user_comparator_.timestamp_size();
+      size_t ts_sz = user_comparator_.user_comparator()->timestamp_size();
       Slice target_user_key_without_ts =
           ExtractUserKeyAndStripTimestamp(target, ts_sz);
       Slice next_file_first_user_key_without_ts =

--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -33,35 +33,6 @@ class CompareInterface {
   virtual int Compare(const Slice& a, const Slice& b) const = 0;
 };
 
-// The general interface for comparing two Slices that are related to
-// timestamps.
-// They are defined for both Comparator and some internal data structures.
-class CompareWithTimestampInterface {
- public:
-  virtual ~CompareWithTimestampInterface() {}
-  int CompareWithoutTimestamp(const Slice& a, const Slice& b) const {
-    return CompareWithoutTimestamp(a, /*a_has_ts=*/true, b, /*b_has_ts=*/true);
-  }
-
-  // For two events e1 and e2 whose timestamps are t1 and t2 respectively,
-  // Returns value:
-  // < 0  iff t1 < t2
-  // == 0 iff t1 == t2
-  // > 0  iff t1 > t2
-  // Note that an all-zero byte array will be the smallest (oldest) timestamp
-  // of the same length, and a byte array with all bits 1 will be the largest.
-  // In the future, we can extend Comparator so that subclasses can specify
-  // both largest and smallest timestamps.
-  virtual int CompareTimestamp(const Slice& /*ts1*/,
-                               const Slice& /*ts2*/) const = 0;
-
-  virtual int CompareWithoutTimestamp(const Slice& a, bool /*a_has_ts*/,
-                                      const Slice& b,
-                                      bool /*b_has_ts*/) const = 0;
-
-  virtual bool EqualWithoutTimestamp(const Slice& a, const Slice& b) const = 0;
-};
-
 // A Comparator object provides a total order across slices that are
 // used as keys in an sstable or a database.  A Comparator implementation
 // must be thread-safe since rocksdb may invoke its methods concurrently
@@ -70,9 +41,7 @@ class CompareWithTimestampInterface {
 // Exceptions MUST NOT propagate out of overridden functions into RocksDB,
 // because RocksDB is not exception-safe. This could cause undefined behavior
 // including data loss, unreported corruption, deadlocks, and more.
-class Comparator : public Customizable,
-                   public CompareInterface,
-                   public CompareWithTimestampInterface {
+class Comparator : public Customizable, public CompareInterface {
  public:
   Comparator() : timestamp_size_(0) {}
 
@@ -151,7 +120,10 @@ class Comparator : public Customizable,
 
   inline size_t timestamp_size() const { return timestamp_size_; }
 
-  using CompareWithTimestampInterface::CompareWithoutTimestamp;
+  int CompareWithoutTimestamp(const Slice& a, const Slice& b) const {
+    return CompareWithoutTimestamp(a, /*a_has_ts=*/true, b, /*b_has_ts=*/true);
+  }
+
   // For two events e1 and e2 whose timestamps are t1 and t2 respectively,
   // Returns value:
   // < 0  iff t1 < t2
@@ -162,18 +134,16 @@ class Comparator : public Customizable,
   // In the future, we can extend Comparator so that subclasses can specify
   // both largest and smallest timestamps.
   virtual int CompareTimestamp(const Slice& /*ts1*/,
-                               const Slice& /*ts2*/) const override {
+                               const Slice& /*ts2*/) const {
     return 0;
   }
 
   virtual int CompareWithoutTimestamp(const Slice& a, bool /*a_has_ts*/,
-                                      const Slice& b,
-                                      bool /*b_has_ts*/) const override {
+                                      const Slice& b, bool /*b_has_ts*/) const {
     return Compare(a, b);
   }
 
-  virtual bool EqualWithoutTimestamp(const Slice& a,
-                                     const Slice& b) const override {
+  virtual bool EqualWithoutTimestamp(const Slice& a, const Slice& b) const {
     return 0 ==
            CompareWithoutTimestamp(a, /*a_has_ts=*/true, b, /*b_has_ts=*/true);
   }

--- a/util/user_comparator_wrapper.h
+++ b/util/user_comparator_wrapper.h
@@ -15,8 +15,7 @@ namespace ROCKSDB_NAMESPACE {
 
 // Wrapper of user comparator, with auto increment to
 // perf_context.user_key_comparison_count.
-class UserComparatorWrapper final : public CompareInterface,
-                                    public CompareWithTimestampInterface {
+class UserComparatorWrapper {
  public:
   // `UserComparatorWrapper`s constructed with the default constructor are not
   // usable and will segfault on any attempt to use them for comparisons.
@@ -29,7 +28,7 @@ class UserComparatorWrapper final : public CompareInterface,
 
   const Comparator* user_comparator() const { return user_comparator_; }
 
-  int Compare(const Slice& a, const Slice& b) const override {
+  int Compare(const Slice& a, const Slice& b) const {
     PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->Compare(a, b);
   }
@@ -39,18 +38,22 @@ class UserComparatorWrapper final : public CompareInterface,
     return user_comparator_->Equal(a, b);
   }
 
-  int CompareTimestamp(const Slice& ts1, const Slice& ts2) const override {
+  int CompareTimestamp(const Slice& ts1, const Slice& ts2) const {
     return user_comparator_->CompareTimestamp(ts1, ts2);
   }
 
-  using CompareWithTimestampInterface::CompareWithoutTimestamp;
+  int CompareWithoutTimestamp(const Slice& a, const Slice& b) const {
+    PERF_COUNTER_ADD(user_key_comparison_count, 1);
+    return user_comparator_->CompareWithoutTimestamp(a, b);
+  }
+
   int CompareWithoutTimestamp(const Slice& a, bool a_has_ts, const Slice& b,
-                              bool b_has_ts) const override {
+                              bool b_has_ts) const {
     PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->CompareWithoutTimestamp(a, a_has_ts, b, b_has_ts);
   }
 
-  bool EqualWithoutTimestamp(const Slice& a, const Slice& b) const override {
+  bool EqualWithoutTimestamp(const Slice& a, const Slice& b) const {
     return user_comparator_->EqualWithoutTimestamp(a, b);
   }
 

--- a/util/user_comparator_wrapper.h
+++ b/util/user_comparator_wrapper.h
@@ -15,14 +15,15 @@ namespace ROCKSDB_NAMESPACE {
 
 // Wrapper of user comparator, with auto increment to
 // perf_context.user_key_comparison_count.
-class UserComparatorWrapper final : public Comparator {
+class UserComparatorWrapper final : public CompareInterface,
+                                    public CompareWithTimestampInterface {
  public:
   // `UserComparatorWrapper`s constructed with the default constructor are not
   // usable and will segfault on any attempt to use them for comparisons.
   UserComparatorWrapper() : user_comparator_(nullptr) {}
 
   explicit UserComparatorWrapper(const Comparator* const user_cmp)
-      : Comparator(user_cmp->timestamp_size()), user_comparator_(user_cmp) {}
+      : user_comparator_(user_cmp) {}
 
   ~UserComparatorWrapper() = default;
 
@@ -33,40 +34,16 @@ class UserComparatorWrapper final : public Comparator {
     return user_comparator_->Compare(a, b);
   }
 
-  bool Equal(const Slice& a, const Slice& b) const override {
+  bool Equal(const Slice& a, const Slice& b) const {
     PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->Equal(a, b);
-  }
-
-  const char* Name() const override { return user_comparator_->Name(); }
-
-  void FindShortestSeparator(std::string* start,
-                             const Slice& limit) const override {
-    return user_comparator_->FindShortestSeparator(start, limit);
-  }
-
-  void FindShortSuccessor(std::string* key) const override {
-    return user_comparator_->FindShortSuccessor(key);
-  }
-
-  const Comparator* GetRootComparator() const override {
-    return user_comparator_->GetRootComparator();
-  }
-
-  bool IsSameLengthImmediateSuccessor(const Slice& s,
-                                      const Slice& t) const override {
-    return user_comparator_->IsSameLengthImmediateSuccessor(s, t);
-  }
-
-  bool CanKeysWithDifferentByteContentsBeEqual() const override {
-    return user_comparator_->CanKeysWithDifferentByteContentsBeEqual();
   }
 
   int CompareTimestamp(const Slice& ts1, const Slice& ts2) const override {
     return user_comparator_->CompareTimestamp(ts1, ts2);
   }
 
-  using Comparator::CompareWithoutTimestamp;
+  using CompareWithTimestampInterface::CompareWithoutTimestamp;
   int CompareWithoutTimestamp(const Slice& a, bool a_has_ts, const Slice& b,
                               bool b_has_ts) const override {
     PERF_COUNTER_ADD(user_key_comparison_count, 1);


### PR DESCRIPTION
Summary:
Right now UserComparatorWrapper is a Customizable object, although it is not, which introduces some intialization overhead for the object. In some benchmarks, it shows up in CPU profiling. Make it not configurable by defining most functions needed by UserComparatorWrapper to an interface and implement the interface.

Test Plan: Make sure existing tests pass