### PR TITLE
Fix a potential std::vector use after move bug

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2833,7 +2833,6 @@ Status Version::MultiGetAsync(
         std::vector<Status> statuses = folly::coro::blockingWait(
             folly::coro::collectAllRange(std::move(mget_tasks))
                 .scheduleOn(&range->context()->executor()));
-        assert(mget_tasks.size() == 0);
         mget_tasks.clear();
         for (Status stat : statuses) {
           if (!stat.ok()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2833,6 +2833,8 @@ Status Version::MultiGetAsync(
         std::vector<Status> statuses = folly::coro::blockingWait(
             folly::coro::collectAllRange(std::move(mget_tasks))
                 .scheduleOn(&range->context()->executor()));
+        assert(mget_tasks.size() == 0);
+        mget_tasks.clear();
         for (Status stat : statuses) {
           if (!stat.ok()) {
             s = stat;


### PR DESCRIPTION
The call to `folly::coro::collectAllRange()` should move the input `mget_tasks`. But just in case, assert and clear the std::vector before reusing.