### PR TITLE
Remove range tombstone test code from sst_file_reader

### DIFF
--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -7,7 +7,6 @@
 
 #ifndef ROCKSDB_LITE
 
-#include "db/range_tombstone_fragmenter.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
@@ -30,9 +29,6 @@ class SstFileReader {
   // Most read options provide the same control as we read from DB.
   // If "snapshot" is nullptr, the iterator returns only the latest keys.
   Iterator* NewIterator(const ReadOptions& options);
-
-  FragmentedRangeTombstoneIterator* NewRangeTombstoneIterator(
-      const ReadOptions& options);
 
   std::shared_ptr<const TableProperties> GetTableProperties() const;
 

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -86,12 +86,6 @@ Iterator* SstFileReader::NewIterator(const ReadOptions& roptions) {
   return res;
 }
 
-FragmentedRangeTombstoneIterator* SstFileReader::NewRangeTombstoneIterator(
-    const ReadOptions& options) {
-  auto r = rep_.get();
-  return r->table_reader->NewRangeTombstoneIterator(options);
-}
-
 std::shared_ptr<const TableProperties> SstFileReader::GetTableProperties()
     const {
   return rep_->table_reader->GetTableProperties();

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -385,39 +385,6 @@ TEST_F(SstFileReaderTimestampTest, Basic) {
   }
 }
 
-TEST_F(SstFileReaderTimestampTest, BasicDeleteRange) {
-  SstFileWriter writer(soptions_, options_);
-  ASSERT_OK(writer.Open(sst_name_));
-  ASSERT_OK(writer.DeleteRange("key1", "key2", EncodeAsUint64(1)));
-  ASSERT_OK(writer.Finish());
-
-  SstFileReader reader(options_);
-  ASSERT_OK(reader.Open(sst_name_));
-  ASSERT_OK(reader.VerifyChecksum());
-
-  ReadOptions read_options;
-  std::string ts = EncodeAsUint64(2);
-  Slice ts_slice = ts;
-  read_options.timestamp = &ts_slice;
-  FragmentedRangeTombstoneIterator* iter =
-      reader.NewRangeTombstoneIterator(read_options);
-  iter->SeekToFirst();
-  ASSERT_TRUE(iter->Valid());
-  ASSERT_OK(iter->status());
-  ASSERT_EQ(
-      StripTimestampFromUserKey(iter->start_key(), EncodeAsUint64(1).size()),
-      "key1");
-  ASSERT_EQ(
-      StripTimestampFromUserKey(iter->end_key(), EncodeAsUint64(1).size()),
-      "key2");
-  ASSERT_EQ(iter->timestamp(), EncodeAsUint64(1));
-  iter->Next();
-  ASSERT_FALSE(iter->Valid());
-  ASSERT_OK(iter->status());
-
-  delete iter;
-}
-
 TEST_F(SstFileReaderTimestampTest, TimestampsOutOfOrder) {
   SstFileWriter writer(soptions_, options_);
 


### PR DESCRIPTION
Summary: `#include "db/range_tombstone_fragmenter.h"` seems to break some internal test for 7.8 release. I'm removing it from sst_file_reader.h for now to unblock release. This should be fine as it is only used in a unit test for DeleteRange with timestamp. In addition, it does not seem to be useful to support delete range for sst file writer, since the range tombstone won't cover any key (its sequence number is 0). So maybe we can remove it in the future.

Test plan: CI.