### PR TITLE
Manual interventions for clang-format util/

### DIFF
--- a/util/compression.h
+++ b/util/compression.h
@@ -47,10 +47,12 @@
 
 #if defined(ZSTD)
 #include <zstd.h>
-#if ZSTD_VERSION_NUMBER >= 10103  // v1.1.3+
+// v1.1.3+
+#if ZSTD_VERSION_NUMBER >= 10103
 #include <zdict.h>
 #endif  // ZSTD_VERSION_NUMBER >= 10103
-#if ZSTD_VERSION_NUMBER >= 10400  // v1.4.0+
+// v1.4.0+
+#if ZSTD_VERSION_NUMBER >= 10400
 #define ZSTD_STREAMING
 #endif  // ZSTD_VERSION_NUMBER >= 10400
 namespace ROCKSDB_NAMESPACE {
@@ -143,6 +145,7 @@ class ZSTDUncompressCachedData {
   int64_t GetCacheIndex() const { return -1; }
   void CreateIfNeeded() {}
   void InitFromCache(const ZSTDUncompressCachedData&, int64_t) {}
+
  private:
   void ignore_padding__() { padding = nullptr; }
 };
@@ -1256,7 +1259,7 @@ inline bool LZ4HC_Compress(const CompressionInfo& info,
   size_t compression_dict_size = compression_dict.size();
   if (compression_dict_data != nullptr) {
     LZ4_loadDictHC(stream, compression_dict_data,
-                  static_cast<int>(compression_dict_size));
+                   static_cast<int>(compression_dict_size));
   }
 
 #if LZ4_VERSION_NUMBER >= 10700  // r129+

--- a/util/crc32c_arm64.h
+++ b/util/crc32c_arm64.h
@@ -18,6 +18,7 @@
 #define crc32c_u16(crc, v) __crc32ch(crc, v)
 #define crc32c_u32(crc, v) __crc32cw(crc, v)
 #define crc32c_u64(crc, v) __crc32cd(crc, v)
+// clang-format off
 #define PREF4X64L1(buffer, PREF_OFFSET, ITR)                \
   __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), \
           [c] "I"((PREF_OFFSET) + ((ITR) + 0) * 64));       \
@@ -27,6 +28,7 @@
           [c] "I"((PREF_OFFSET) + ((ITR) + 2) * 64));       \
   __asm__("PRFM PLDL1KEEP, [%x[v],%[c]]" ::[v] "r"(buffer), \
           [c] "I"((PREF_OFFSET) + ((ITR) + 3) * 64));
+// clang-format on
 
 #define PREF1KL1(buffer, PREF_OFFSET)  \
   PREF4X64L1(buffer, (PREF_OFFSET), 0) \

--- a/util/murmurhash.cc
+++ b/util/murmurhash.cc
@@ -10,6 +10,7 @@
   is under the MIT license.
 */
 #include "murmurhash.h"
+
 #include "port/lang.h"
 
 #if defined(__x86_64__)
@@ -28,6 +29,7 @@ __attribute__((__no_sanitize__("alignment")))
 __attribute__((__no_sanitize_undefined__))
 #endif
 #endif
+// clang-format off
 uint64_t MurmurHash64A ( const void * key, int len, unsigned int seed )
 {
     const uint64_t m = 0xc6a4a7935bd1e995;
@@ -70,6 +72,7 @@ uint64_t MurmurHash64A ( const void * key, int len, unsigned int seed )
 
     return h;
 }
+// clang-format on
 
 #elif defined(__i386__)
 
@@ -85,7 +88,7 @@ uint64_t MurmurHash64A ( const void * key, int len, unsigned int seed )
 // 1. It will not work incrementally.
 // 2. It will not produce the same results on little-endian and big-endian
 //    machines.
-
+// clang-format off
 unsigned int MurmurHash2 ( const void * key, int len, unsigned int seed )
 {
     // 'm' and 'r' are mixing constants generated offline.
@@ -136,6 +139,7 @@ unsigned int MurmurHash2 ( const void * key, int len, unsigned int seed )
 
     return h;
 }
+// clang-format on
 
 #else
 
@@ -143,7 +147,7 @@ unsigned int MurmurHash2 ( const void * key, int len, unsigned int seed )
 //
 // Same as MurmurHash2, but endian- and alignment-neutral.
 // Half the speed though, alas.
-
+// clang-format off
 unsigned int MurmurHashNeutral2 ( const void * key, int len, unsigned int seed )
 {
     const unsigned int m = 0x5bd1e995;
@@ -187,5 +191,6 @@ unsigned int MurmurHashNeutral2 ( const void * key, int len, unsigned int seed )
 
     return h;
 }
+// clang-format on
 
 #endif

--- a/util/xxhash.cc
+++ b/util/xxhash.cc
@@ -36,11 +36,10 @@
  *   - xxHash source repository: https://github.com/Cyan4973/xxHash
  */
 
-
 /*
  * xxhash.c instantiates functions defined in xxhash.h
  */
-
+// clang-format off
 #ifndef XXH_STATIC_LINKING_ONLY
 #define XXH_STATIC_LINKING_ONLY   /* access advanced declarations */
 #endif // !defined(XXH_STATIC_LINKING_ONLY)

--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -5,12 +5,15 @@
 
 /* BEGIN RocksDB customizations */
 #ifndef XXH_STATIC_LINKING_ONLY
-#define XXH_STATIC_LINKING_ONLY 1 /* using xxhash.cc */
-#endif // !defined(XXH_STATIC_LINKING_ONLY)
+// Using compiled xxhash.cc
+#define XXH_STATIC_LINKING_ONLY 1
+#endif  // !defined(XXH_STATIC_LINKING_ONLY)
 #ifndef XXH_NAMESPACE
 #define XXH_NAMESPACE ROCKSDB_
-#endif // !defined(XXH_NAMESPACE)
-#include "port/lang.h" // for FALLTHROUGH_INTENDED, inserted as appropriate
+#endif  // !defined(XXH_NAMESPACE)
+
+// for FALLTHROUGH_INTENDED, inserted as appropriate
+#include "port/lang.h"
 /* END RocksDB customizations */
 
 // clang-format off

--- a/util/xxph3.h
+++ b/util/xxph3.h
@@ -47,13 +47,15 @@
 
 /* BEGIN RocksDB customizations */
 #ifndef XXPH_STATIC_LINKING_ONLY
-#define XXPH_STATIC_LINKING_ONLY 1 /* access experimental APIs like XXPH3 */
+// Access experimental APIs
+#define XXPH_STATIC_LINKING_ONLY 1
 #endif
 #define XXPH_NAMESPACE ROCKSDB_
 #define XXPH_INLINE_ALL
 #include <cstring>
 /* END RocksDB customizations */
 
+// clang-format off
 #if defined (__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
Summary: Complements #10867 with some manual edits to avoid weird formatting or to avoid massive reformatting third party code.

Test Plan: `make check` etc