### PR TITLE
Adjust value generation in batched ops stress tests

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1487,10 +1487,8 @@ void StressTest::VerifyIterator(ThreadState* thread,
   }
 
   if (!*diverged && iter->Valid()) {
-    const Slice value_base_slice = GetValueBaseSlice(iter->value());
-
-    const WideColumns expected_columns = GenerateExpectedWideColumns(
-        GetValueBase(value_base_slice), iter->value());
+    const WideColumns expected_columns =
+        GenerateExpectedWideColumns(GetValueBase(iter->value()), iter->value());
     if (iter->columns() != expected_columns) {
       fprintf(stderr, "Value and columns inconsistent for iterator: %s\n",
               DebugString(iter->value(), iter->columns(), expected_columns)

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -139,8 +139,6 @@ class StressTest {
     return column_families_[column_family_id];
   }
 
-  virtual Slice GetValueBaseSlice(Slice slice) { return slice; }
-
 #ifndef ROCKSDB_LITE
   // Generated a list of keys that close to boundaries of SST keys.
   // If there isn't any SST file in the DB, return empty list.


### PR DESCRIPTION
Summary:
The patch adjusts the generation of values in batched ops stress tests so that the digits 0..9 are appended (instead of prepended) to the values written. This has the advantage of aligning the encoding of the "value base" into the value string across non-batched, batched, and CF consistency stress tests.

Test Plan:
Tested using some black box stress test runs.