### PR TITLE
sst_dump --command=raw to add index offset information

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2983,7 +2983,8 @@ Status BlockBasedTable::DumpIndexBlock(std::ostream& out_stream) {
     out_stream << "  HEX    " << user_key.ToString(true) << ": "
                << blockhandles_iter->value().ToString(true,
                                                       rep_->index_has_first_key)
-               << "\n";
+               << " offset " << blockhandles_iter->value().handle.offset()
+               << " size " << blockhandles_iter->value().handle.size() << "\n";
 
     std::string str_key = user_key.ToString();
     std::string res_key("");


### PR DESCRIPTION
Summary:
Add some extra information in outputs of "sst_dump --command=raw" to help debug some issues. Right now, encoded block handle is printed out. It is more useful to directly print out offset and size.

Test Plan: Manually run it against a file and check the output.