### PR TITLE
Allow a custom DB cleanup command to be passed to db_crashtest.py

### DIFF
--- a/crash_test.mk
+++ b/crash_test.mk
@@ -8,7 +8,7 @@ DB_STRESS_CMD?=./db_stress
 include common.mk
 
 CRASHTEST_MAKE=$(MAKE) -f crash_test.mk
-CRASHTEST_PY=$(PYTHON) -u tools/db_crashtest.py --stress_cmd=$(DB_STRESS_CMD) --cleanup_cmd=$(DB_CLEANUP_CMD)
+CRASHTEST_PY=$(PYTHON) -u tools/db_crashtest.py --stress_cmd=$(DB_STRESS_CMD) --cleanup_cmd='$(DB_CLEANUP_CMD)'
 
 .PHONY: crash_test crash_test_with_atomic_flush crash_test_with_txn \
 	crash_test_with_best_efforts_recovery crash_test_with_ts \

--- a/crash_test.mk
+++ b/crash_test.mk
@@ -8,7 +8,7 @@ DB_STRESS_CMD?=./db_stress
 include common.mk
 
 CRASHTEST_MAKE=$(MAKE) -f crash_test.mk
-CRASHTEST_PY=$(PYTHON) -u tools/db_crashtest.py --stress_cmd=$(DB_STRESS_CMD)
+CRASHTEST_PY=$(PYTHON) -u tools/db_crashtest.py --stress_cmd=$(DB_STRESS_CMD) --cleanup_cmd=$(DB_CLEANUP_CMD)
 
 .PHONY: crash_test crash_test_with_atomic_flush crash_test_with_txn \
 	crash_test_with_best_efforts_recovery crash_test_with_ts \

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -209,6 +209,7 @@ _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 _DEBUG_LEVEL_ENV_VAR = "DEBUG_LEVEL"
 
 stress_cmd = "./db_stress"
+cleanup_cmd = None
 
 
 def is_release_mode():
@@ -223,6 +224,10 @@ def get_dbname(test_name):
     else:
         dbname = test_tmpdir + "/" + test_dir_name
         shutil.rmtree(dbname, True)
+        if cleanup_cmd is not None:
+            print("Running DB cleanup command - %s\n" % cleanup_cmd)
+            # Ignore failure
+            os.system(cleanup_cmd)
         os.mkdir(dbname)
     return dbname
 
@@ -690,6 +695,7 @@ def gen_cmd(params, unknown_params):
                 "write_policy",
                 "stress_cmd",
                 "test_tiered_storage",
+                "cleanup_cmd",
             }
             and v is not None
         ]
@@ -925,6 +931,12 @@ def whitebox_crash_main(args, unknown_args):
             # we need to clean up after ourselves -- only do this on test
             # success
             shutil.rmtree(dbname, True)
+            if cleanup_cmd is not None:
+                print("Running DB cleanup command - %s\n" % cleanup_cmd)
+                ret = os.system(cleanup_cmd)
+                if ret != 0:
+                    print("TEST FAILED. DB cleanup returned error %d\n" % ret)
+                    sys.exit(1)
             os.mkdir(dbname)
             if (expected_values_dir is not None):
                 shutil.rmtree(expected_values_dir, True)
@@ -937,6 +949,7 @@ def whitebox_crash_main(args, unknown_args):
 
 def main():
     global stress_cmd
+    global cleanup_cmd
 
     parser = argparse.ArgumentParser(
         description="This script runs and kills \
@@ -952,6 +965,7 @@ def main():
     parser.add_argument("--write_policy", choices=["write_committed", "write_prepared"])
     parser.add_argument("--stress_cmd")
     parser.add_argument("--test_tiered_storage", action="store_true")
+    parser.add_argument("--cleanup_cmd")
 
     all_params = dict(
         list(default_params.items())
@@ -986,6 +1000,8 @@ def main():
 
     if args.stress_cmd:
         stress_cmd = args.stress_cmd
+    if args.cleanup_cmd:
+        cleanup_cmd = args.cleanup_cmd
     if args.test_type == "blackbox":
         blackbox_crash_main(args, unknown_args)
     if args.test_type == "whitebox":


### PR DESCRIPTION
Summary:
This option allows a custom cleanup command line for a non-Posix file system to be used by db_crashtest.py to cleanup between runs.

Test Plan:
Run the whitebox crash test