### PR TITLE
Use malloc/free for LRUHandle instead of new[]/delete[]

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -386,7 +386,7 @@ Status LRUCacheShard::InsertItem(LRUHandle* e, LRUHandle** handle,
         last_reference_list.push_back(e);
       } else {
         if (free_handle_on_fail) {
-          delete[] reinterpret_cast<char*>(e);
+          port::cacheline_aligned_free(e);
           *handle = nullptr;
         }
         s = Status::MemoryLimit("Insert failed due to LRU cache being full.");
@@ -560,7 +560,7 @@ LRUHandle* LRUCacheShard::Lookup(const Slice& key, uint32_t hash,
                                  is_in_sec_cache);
     if (secondary_handle != nullptr) {
       e = reinterpret_cast<LRUHandle*>(
-          new char[sizeof(LRUHandle) - 1 + key.size()]);
+          port::cacheline_aligned_alloc(sizeof(LRUHandle) - 1 + key.size()));
 
       e->m_flags = 0;
       e->im_flags = 0;
@@ -684,7 +684,7 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
   // If the cache is full, we'll have to release it.
   // It shouldn't happen very often though.
   LRUHandle* e = reinterpret_cast<LRUHandle*>(
-      new char[sizeof(LRUHandle) - 1 + key.size()]);
+      port::cacheline_aligned_alloc(sizeof(LRUHandle) - 1 + key.size()));
 
   e->value = value;
   e->m_flags = 0;

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -559,8 +559,7 @@ LRUHandle* LRUCacheShard::Lookup(const Slice& key, uint32_t hash,
         secondary_cache_->Lookup(key, create_cb, wait, found_dummy_entry,
                                  is_in_sec_cache);
     if (secondary_handle != nullptr) {
-      e = reinterpret_cast<LRUHandle*>(
-          malloc(sizeof(LRUHandle) - 1 + key.size()));
+      e = static_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key.size()));
 
       e->m_flags = 0;
       e->im_flags = 0;
@@ -684,7 +683,7 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
   // If the cache is full, we'll have to release it.
   // It shouldn't happen very often though.
   LRUHandle* e =
-      reinterpret_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key.size()));
+      static_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key.size()));
 
   e->value = value;
   e->m_flags = 0;

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -386,7 +386,7 @@ Status LRUCacheShard::InsertItem(LRUHandle* e, LRUHandle** handle,
         last_reference_list.push_back(e);
       } else {
         if (free_handle_on_fail) {
-          port::cacheline_aligned_free(e);
+          free(e);
           *handle = nullptr;
         }
         s = Status::MemoryLimit("Insert failed due to LRU cache being full.");
@@ -560,7 +560,7 @@ LRUHandle* LRUCacheShard::Lookup(const Slice& key, uint32_t hash,
                                  is_in_sec_cache);
     if (secondary_handle != nullptr) {
       e = reinterpret_cast<LRUHandle*>(
-          port::cacheline_aligned_alloc(sizeof(LRUHandle) - 1 + key.size()));
+          malloc(sizeof(LRUHandle) - 1 + key.size()));
 
       e->m_flags = 0;
       e->im_flags = 0;
@@ -683,8 +683,8 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
   // Allocate the memory here outside of the mutex.
   // If the cache is full, we'll have to release it.
   // It shouldn't happen very often though.
-  LRUHandle* e = reinterpret_cast<LRUHandle*>(
-      port::cacheline_aligned_alloc(sizeof(LRUHandle) - 1 + key.size()));
+  LRUHandle* e =
+      reinterpret_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key.size()));
 
   e->value = value;
   e->m_flags = 0;

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -228,7 +228,7 @@ struct LRUHandle {
       }
     }
 
-    port::cacheline_aligned_free(this);
+    free(this);
   }
 
   inline size_t CalcuMetaCharge(

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -212,6 +212,7 @@ struct LRUHandle {
 
   void Free() {
     assert(refs == 0);
+
     if (!IsSecondaryCacheCompatible() && info_.deleter) {
       (*info_.deleter)(key(), value);
     } else if (IsSecondaryCacheCompatible()) {
@@ -226,7 +227,8 @@ struct LRUHandle {
         (*info_.helper->del_cb)(key(), value);
       }
     }
-    delete[] reinterpret_cast<char*>(this);
+
+    port::cacheline_aligned_free(this);
   }
 
   inline size_t CalcuMetaCharge(


### PR DESCRIPTION
Summary:
It's unsafe to call `malloc_usable_size` with an address not returned by a function from the `malloc` family (see #10798). The patch switches from using `new[]` / `delete[]` for `LRUHandle` to `malloc` / `free`.

Test Plan:
`make check`