### PR TITLE
Fix include of windows.h in mmap.h

### DIFF
--- a/port/mmap.h
+++ b/port/mmap.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #ifdef OS_WIN
-#include <windows.h>
-// ^^^ Must come first
+#include "port/win/port_win.h"
+// ^^^ For proper/safe inclusion of windows.h. Must come first.
 #include <memoryapi.h>
 #else
 #include <sys/mman.h>


### PR DESCRIPTION
Summary: If windows.h is not included in a particular way, it can conflict with other code including it. I don't know all the details, but having just one standard place where we include windows.h in header files seems best and seems to fix the internal issue we hit.

Test Plan: CI and internal validation