### PR TITLE
Improve musl libc detection and provide an option for the user to override

### DIFF
--- a/java/src/main/java/org/rocksdb/util/Environment.java
+++ b/java/src/main/java/org/rocksdb/util/Environment.java
@@ -2,6 +2,7 @@
 package org.rocksdb.util;
 
 import java.io.File;
+import java.io.IOException;
 
 public class Environment {
   private static String OS = System.getProperty("os.name").toLowerCase();
@@ -76,6 +77,16 @@ public class Environment {
     }
     if ("false".equalsIgnoreCase(MUSL_ENVIRONMENT)) {
       return false;
+    }
+
+    // check if ldd indicates a muslc lib
+    try {
+      final Process p = new ProcessBuilder("/usr/bin/env", "sh", "-c", "ldd /usr/bin/env | grep -q musl").start();
+      if (p.waitFor() == 0) {
+        return true;
+      }
+    } catch (final IOException | InterruptedException e) {
+      // do nothing, and move on to the next check
     }
 
     final File lib = new File("/lib");

--- a/java/src/main/java/org/rocksdb/util/Environment.java
+++ b/java/src/main/java/org/rocksdb/util/Environment.java
@@ -78,10 +78,6 @@ public class Environment {
       return false;
     }
 
-    if (!isUnix()) {
-      return false; // not unix therefore not musl
-    }
-
     final File lib = new File("/lib");
     if (lib.exists() && lib.isDirectory() && lib.canRead()) {
       final File[] libFiles = lib.listFiles();

--- a/java/src/main/java/org/rocksdb/util/Environment.java
+++ b/java/src/main/java/org/rocksdb/util/Environment.java
@@ -91,6 +91,24 @@ public class Environment {
 
     final File lib = new File("/lib");
     if (lib.exists() && lib.isDirectory() && lib.canRead()) {
+
+      // attempt the most likely musl libc name first
+      final String possibleMuslcLibName;
+      if (isPowerPC()) {
+        possibleMuslcLibName = "libc.musl-ppc64le.so.1";
+      } else if (isAarch64()) {
+        possibleMuslcLibName = "libc.musl-aarch64.so.1";
+      } else if (isS390x()) {
+        possibleMuslcLibName = "libc.musl-s390x.so.1";
+      } else {
+        possibleMuslcLibName = "libc.musl-x86_64.so.1";
+      }
+      final File possibleMuslcLib = new File(lib, possibleMuslcLibName);
+      if (possibleMuslcLib.exists() && possibleMuslcLib.canRead()) {
+        return true;
+      }
+
+      // fallback to scanning for a musl libc
       final File[] libFiles = lib.listFiles();
       if (libFiles == null) {
         return false;

--- a/java/src/main/java/org/rocksdb/util/Environment.java
+++ b/java/src/main/java/org/rocksdb/util/Environment.java
@@ -10,9 +10,9 @@ public class Environment {
   private static String MUSL_ENVIRONMENT = System.getenv("ROCKSDB_MUSL_LIBC");
 
   /**
-   * Will be lazily initialised by {@link #isMuslLibc()} instead of the previous static initialisation.
-   * The lazy initialisation prevents Windows from reporting suspicious behaviour
-   * of the JVM attempting IO on Unix paths.
+   * Will be lazily initialised by {@link #isMuslLibc()} instead of the previous static
+   * initialisation. The lazy initialisation prevents Windows from reporting suspicious behaviour of
+   * the JVM attempting IO on Unix paths.
    */
   private static Boolean MUSL_LIBC = null;
 
@@ -81,7 +81,8 @@ public class Environment {
 
     // check if ldd indicates a muslc lib
     try {
-      final Process p = new ProcessBuilder("/usr/bin/env", "sh", "-c", "ldd /usr/bin/env | grep -q musl").start();
+      final Process p =
+          new ProcessBuilder("/usr/bin/env", "sh", "-c", "ldd /usr/bin/env | grep -q musl").start();
       if (p.waitFor() == 0) {
         return true;
       }
@@ -91,7 +92,6 @@ public class Environment {
 
     final File lib = new File("/lib");
     if (lib.exists() && lib.isDirectory() && lib.canRead()) {
-
       // attempt the most likely musl libc name first
       final String possibleMuslcLibName;
       if (isPowerPC()) {

--- a/java/src/test/java/org/rocksdb/util/EnvironmentTest.java
+++ b/java/src/test/java/org/rocksdb/util/EnvironmentTest.java
@@ -5,27 +5,34 @@
 package org.rocksdb.util;
 
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class EnvironmentTest {
   private final static String ARCH_FIELD_NAME = "ARCH";
   private final static String OS_FIELD_NAME = "OS";
+
+  private final static String MUSL_ENVIRONMENT_FIELD_NAME = "MUSL_ENVIRONMENT";
   private final static String MUSL_LIBC_FIELD_NAME = "MUSL_LIBC";
+
 
   private static String INITIAL_OS;
   private static String INITIAL_ARCH;
-  private static boolean INITIAL_MUSL_LIBC;
+  private static String INITIAL_MUSL_ENVIRONMENT;
+  private static Boolean INITIAL_MUSL_LIBC;
 
   @BeforeClass
   public static void saveState() {
     INITIAL_ARCH = getEnvironmentClassField(ARCH_FIELD_NAME);
     INITIAL_OS = getEnvironmentClassField(OS_FIELD_NAME);
     INITIAL_MUSL_LIBC = getEnvironmentClassField(MUSL_LIBC_FIELD_NAME);
+    INITIAL_MUSL_ENVIRONMENT = getEnvironmentClassField(MUSL_ENVIRONMENT_FIELD_NAME);
   }
 
   @Test
@@ -236,6 +243,21 @@ public class EnvironmentTest {
     setEnvironmentClassField(MUSL_LIBC_FIELD_NAME, false);
   }
 
+  @Test
+  public void resolveIsMuslLibc() {
+    setEnvironmentClassField(MUSL_LIBC_FIELD_NAME, null);
+    setEnvironmentClassFields("win", "anyarch");
+    assertThat(Environment.isUnix()).isFalse();
+
+    // with user input, will resolve to true if set as true. Even on OSs that appear absurd for musl. Users choice
+    assertThat(Environment.resolveIsMuslLibc()).isFalse();
+    setEnvironmentClassField(MUSL_ENVIRONMENT_FIELD_NAME, "true");
+    assertThat(Environment.resolveIsMuslLibc()).isTrue();
+    setEnvironmentClassField(MUSL_ENVIRONMENT_FIELD_NAME, "false");
+    assertThat(Environment.resolveIsMuslLibc()).isFalse();
+
+  }
+
   private void setEnvironmentClassFields(String osName,
       String osArch) {
     setEnvironmentClassField(OS_FIELD_NAME, osName);
@@ -246,6 +268,7 @@ public class EnvironmentTest {
   public static void restoreState() {
     setEnvironmentClassField(OS_FIELD_NAME, INITIAL_OS);
     setEnvironmentClassField(ARCH_FIELD_NAME, INITIAL_ARCH);
+    setEnvironmentClassField(MUSL_ENVIRONMENT_FIELD_NAME, INITIAL_MUSL_ENVIRONMENT);
     setEnvironmentClassField(MUSL_LIBC_FIELD_NAME, INITIAL_MUSL_LIBC);
   }
 

--- a/java/src/test/java/org/rocksdb/util/EnvironmentTest.java
+++ b/java/src/test/java/org/rocksdb/util/EnvironmentTest.java
@@ -4,14 +4,13 @@
 //  (found in the LICENSE.Apache file in the root directory).
 package org.rocksdb.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.lang.reflect.Field;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.lang.reflect.Field;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public class EnvironmentTest {
   private final static String ARCH_FIELD_NAME = "ARCH";
@@ -19,7 +18,6 @@ public class EnvironmentTest {
 
   private final static String MUSL_ENVIRONMENT_FIELD_NAME = "MUSL_ENVIRONMENT";
   private final static String MUSL_LIBC_FIELD_NAME = "MUSL_LIBC";
-
 
   private static String INITIAL_OS;
   private static String INITIAL_ARCH;
@@ -248,13 +246,13 @@ public class EnvironmentTest {
     setEnvironmentClassFields("win", "anyarch");
     assertThat(Environment.isUnix()).isFalse();
 
-    // with user input, will resolve to true if set as true. Even on OSs that appear absurd for musl. Users choice
+    // with user input, will resolve to true if set as true. Even on OSs that appear absurd for
+    // musl. Users choice
     assertThat(Environment.initIsMuslLibc()).isFalse();
     setEnvironmentClassField(MUSL_ENVIRONMENT_FIELD_NAME, "true");
     assertThat(Environment.initIsMuslLibc()).isTrue();
     setEnvironmentClassField(MUSL_ENVIRONMENT_FIELD_NAME, "false");
     assertThat(Environment.initIsMuslLibc()).isFalse();
-
   }
 
   private void setEnvironmentClassFields(String osName,

--- a/java/src/test/java/org/rocksdb/util/EnvironmentTest.java
+++ b/java/src/test/java/org/rocksdb/util/EnvironmentTest.java
@@ -5,7 +5,6 @@
 package org.rocksdb.util;
 
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -250,11 +249,11 @@ public class EnvironmentTest {
     assertThat(Environment.isUnix()).isFalse();
 
     // with user input, will resolve to true if set as true. Even on OSs that appear absurd for musl. Users choice
-    assertThat(Environment.resolveIsMuslLibc()).isFalse();
+    assertThat(Environment.initIsMuslLibc()).isFalse();
     setEnvironmentClassField(MUSL_ENVIRONMENT_FIELD_NAME, "true");
-    assertThat(Environment.resolveIsMuslLibc()).isTrue();
+    assertThat(Environment.initIsMuslLibc()).isTrue();
     setEnvironmentClassField(MUSL_ENVIRONMENT_FIELD_NAME, "false");
-    assertThat(Environment.resolveIsMuslLibc()).isFalse();
+    assertThat(Environment.initIsMuslLibc()).isFalse();
 
   }
 


### PR DESCRIPTION
The user may override the detection of whether to use GNU libc (the default) or musl libc by setting the environment variable: `ROCKSDB_MUSL_LIBC=true`.

Builds upon and supersedes: https://github.com/facebook/rocksdb/pull/9977