### PR TITLE
Fix missing WAL in new manifest by rolling over the WAL deletion record from prev manifest

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@
 * Fixed a regression in scan for async_io. During seek, valid buffers were getting cleared causing a regression.
 * Tiered Storage: fixed excessive keys written to penultimate level in non-debug builds.
 * Fixed a bug that multi-level FIFO compaction deletes one file in non-L0 even when `CompactionOptionsFIFO::max_table_files_size` is no exceeded since #10348 or 7.8.0.
+* Fixed a bug cased by `DB::SyncWAL()` on a obsoleted WAL and recording such WAL addition of an obsoleted WAL in a new manifest, affecting `track_and_verify_wals_in_manifest`. Without the fix, application may see "open error: Corruption: Missing WAL with log number" while trying to open the db. The corruption is a false alarm but prevents DB open (#10892).
 
 ### New Features
 * Add basic support for user-defined timestamp to Merge (#10819).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,7 +18,7 @@
 * Fixed a regression in scan for async_io. During seek, valid buffers were getting cleared causing a regression.
 * Tiered Storage: fixed excessive keys written to penultimate level in non-debug builds.
 * Fixed a bug that multi-level FIFO compaction deletes one file in non-L0 even when `CompactionOptionsFIFO::max_table_files_size` is no exceeded since #10348 or 7.8.0.
-* Fixed a bug cased by `DB::SyncWAL()` affecting `track_and_verify_wals_in_manifest`. Without the fix, application may see "open error: Corruption: Missing WAL with log number" while trying to open the db. The corruption is a false alarm but prevents DB open (#10892).
+* Fixed a bug caused by `DB::SyncWAL()` affecting `track_and_verify_wals_in_manifest`. Without the fix, application may see "open error: Corruption: Missing WAL with log number" while trying to open the db. The corruption is a false alarm but prevents DB open (#10892).
 
 ### New Features
 * Add basic support for user-defined timestamp to Merge (#10819).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,7 +18,7 @@
 * Fixed a regression in scan for async_io. During seek, valid buffers were getting cleared causing a regression.
 * Tiered Storage: fixed excessive keys written to penultimate level in non-debug builds.
 * Fixed a bug that multi-level FIFO compaction deletes one file in non-L0 even when `CompactionOptionsFIFO::max_table_files_size` is no exceeded since #10348 or 7.8.0.
-* Fixed a bug cased by `DB::SyncWAL()` on a obsoleted WAL and recording such WAL addition of an obsoleted WAL in a new manifest, affecting `track_and_verify_wals_in_manifest`. Without the fix, application may see "open error: Corruption: Missing WAL with log number" while trying to open the db. The corruption is a false alarm but prevents DB open (#10892).
+* Fixed a bug cased by `DB::SyncWAL()` affecting `track_and_verify_wals_in_manifest`. Without the fix, application may see "open error: Corruption: Missing WAL with log number" while trying to open the db. The corruption is a false alarm but prevents DB open (#10892).
 
 ### New Features
 * Add basic support for user-defined timestamp to Merge (#10819).

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -361,6 +361,8 @@ void DBImpl::DeleteObsoleteFileImpl(int job_id, const std::string& fname,
   }
   TEST_SYNC_POINT_CALLBACK("DBImpl::DeleteObsoleteFileImpl:AfterDeletion",
                            &file_deletion_status);
+  TEST_SYNC_POINT_CALLBACK("DBImpl::DeleteObsoleteFileImpl:AfterDeletion2",
+                           const_cast<std::string*>(&fname));
   if (file_deletion_status.ok()) {
     ROCKS_LOG_DEBUG(immutable_db_options_.info_log,
                     "[JOB %d] Delete %s type=%d #%" PRIu64 " -- %s\n", job_id,

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -315,6 +315,7 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
     }
     log_write_mutex_.Unlock();
     mutex_.Unlock();
+    TEST_SYNC_POINT_CALLBACK("FindObsoleteFiles::PostMutexUnlock", nullptr);
     log_write_mutex_.Lock();
     while (!logs_.empty() && logs_.front().number < min_log_number) {
       auto& log = logs_.front();

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -396,23 +396,19 @@ void VersionEditHandler::CheckIterationResult(const log::Reader& reader,
         version_edit_params_.max_column_family_);
     version_set_->MarkMinLogNumberToKeep(
         version_edit_params_.min_log_number_to_keep_);
-    *s = version_set_->wals_.DeleteWalsBefore(
-        version_set_->min_log_number_to_keep());
-    if (s->ok()) {
-      version_set_->MarkFileNumberUsed(version_edit_params_.prev_log_number_);
-      version_set_->MarkFileNumberUsed(version_edit_params_.log_number_);
-      for (auto* cfd : *(version_set_->GetColumnFamilySet())) {
-        if (cfd->IsDropped()) {
-          continue;
-        }
-        auto builder_iter = builders_.find(cfd->GetID());
-        assert(builder_iter != builders_.end());
-        auto* builder = builder_iter->second->version_builder();
-        if (!builder->CheckConsistencyForNumLevels()) {
-          *s = Status::InvalidArgument(
-              "db has more levels than options.num_levels");
-          break;
-        }
+    version_set_->MarkFileNumberUsed(version_edit_params_.prev_log_number_);
+    version_set_->MarkFileNumberUsed(version_edit_params_.log_number_);
+    for (auto* cfd : *(version_set_->GetColumnFamilySet())) {
+      if (cfd->IsDropped()) {
+        continue;
+      }
+      auto builder_iter = builders_.find(cfd->GetID());
+      assert(builder_iter != builders_.end());
+      auto* builder = builder_iter->second->version_builder();
+      if (!builder->CheckConsistencyForNumLevels()) {
+        *s = Status::InvalidArgument(
+            "db has more levels than options.num_levels");
+        break;
       }
     }
   }

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -396,19 +396,23 @@ void VersionEditHandler::CheckIterationResult(const log::Reader& reader,
         version_edit_params_.max_column_family_);
     version_set_->MarkMinLogNumberToKeep(
         version_edit_params_.min_log_number_to_keep_);
-    version_set_->MarkFileNumberUsed(version_edit_params_.prev_log_number_);
-    version_set_->MarkFileNumberUsed(version_edit_params_.log_number_);
-    for (auto* cfd : *(version_set_->GetColumnFamilySet())) {
-      if (cfd->IsDropped()) {
-        continue;
-      }
-      auto builder_iter = builders_.find(cfd->GetID());
-      assert(builder_iter != builders_.end());
-      auto* builder = builder_iter->second->version_builder();
-      if (!builder->CheckConsistencyForNumLevels()) {
-        *s = Status::InvalidArgument(
-            "db has more levels than options.num_levels");
-        break;
+    *s = version_set_->wals_.DeleteWalsBefore(
+        version_set_->min_log_number_to_keep());
+    if (s->ok()) {
+      version_set_->MarkFileNumberUsed(version_edit_params_.prev_log_number_);
+      version_set_->MarkFileNumberUsed(version_edit_params_.log_number_);
+      for (auto* cfd : *(version_set_->GetColumnFamilySet())) {
+        if (cfd->IsDropped()) {
+          continue;
+        }
+        auto builder_iter = builders_.find(cfd->GetID());
+        assert(builder_iter != builders_.end());
+        auto* builder = builder_iter->second->version_builder();
+        if (!builder->CheckConsistencyForNumLevels()) {
+          *s = Status::InvalidArgument(
+              "db has more levels than options.num_levels");
+          break;
+        }
       }
     }
   }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4967,6 +4967,8 @@ Status VersionSet::ProcessManifestWrites(
   if (!descriptor_log_ ||
       manifest_file_size_ > db_options_->max_manifest_file_size) {
     TEST_SYNC_POINT("VersionSet::ProcessManifestWrites:BeforeNewManifest");
+    TEST_SYNC_POINT_CALLBACK(
+        "VersionSet::ProcessManifestWrites:BeforeNewManifest", nullptr);
     new_descriptor_log = true;
   } else {
     pending_manifest_file_number_ = manifest_file_number_;

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -1425,7 +1425,7 @@ public class RocksDBTest {
       try (final RocksDB db = RocksDB.open(options, dbPath)) {
         final RocksDB.LiveFiles livefiles = db.getLiveFiles(true);
         assertThat(livefiles).isNotNull();
-        assertThat(livefiles.manifestFileSize).isEqualTo(59);
+        assertThat(livefiles.manifestFileSize).isEqualTo(66);
         assertThat(livefiles.files.size()).isEqualTo(3);
         assertThat(livefiles.files.get(0)).isEqualTo("/CURRENT");
         assertThat(livefiles.files.get(1)).isEqualTo("/MANIFEST-000005");


### PR DESCRIPTION
**Context**
`Options::track_and_verify_wals_in_manifest = true` verifies each of the WALs tracked in manifest indeed presents in the WAL folder. If not, a corruption "Missing WAL with log number" will be thrown.

`DB::SyncWAL()` called at a specific timing (i.e, at the `TEST_SYNC_POINT("FindObsoleteFiles::PostMutexUnlock")`) can record in a new manifest the WAL addition of a WAL file that already had a WAL deletion recorded in the previous manifest. 
And the WAL deletion record is not rollover-ed to the new manifest. So the new manifest creates the illusion of such WAL never gets deleted and should presents at db re/open. 
- Such WAL deletion record can be caused by flushing the memtable associated with that WAL and such WAL deletion can actually happen in` PurgeObsoleteFiles()`.

As a consequence, upon `DB::Reopen()`, this WAL file can be deleted while manifest still has its WAL addition record , which causes a false alarm of corruption "Missing WAL with log number" to be thrown.

**Summary**
This PR fixes this false alarm by rolling over the WAL deletion record from prev manifest to the new manifest by adding the WAL deletion record to the new manifest. 

**Test**
- Make check
- Added new unit test `TEST_F(DBWALTest, FixSyncWalOnObseletedWalWithNewManifestCausingMissingWAL)` that failed before the fix and passed after
- [Ongoing]CI stress test + aggressive value as in https://github.com/facebook/rocksdb/pull/10761 , which is how this false alarm was first surfaced, to confirm such false alarm disappears
- [Ongoing]Regular CI stress test to confirm such fix didn't harm anything