### PR TITLE
fix: SIGILL caused by rdcycle prohibited by kernel on RISC-V

### DIFF
--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
@@ -138,22 +138,23 @@ static inline tokutime_t toku_time_now(void) {
   asm volatile("stckf %0" : "=Q"(result) : : "cc");
   return result;
 #elif defined(__riscv) && __riscv_xlen == 32
-  uint32_t cycles_lo, cycles_hi0, cycles_hi1;
+  uint32_t times_lo, times_hi0, times_hi1;
   // Implemented in assembly because Clang insisted on branching.
+  // Use rdtime because linux blocks rdcycle due to security reasons.
   asm volatile(
-      "rdcycleh %0\n"
-      "rdcycle %1\n"
-      "rdcycleh %2\n"
+      "rdtimeh %0\n"
+      "rdtime %1\n"
+      "rdtimeh %2\n"
       "sub %0, %0, %2\n"
       "seqz %0, %0\n"
       "sub %0, zero, %0\n"
       "and %1, %1, %0\n"
-      : "=r"(cycles_hi0), "=r"(cycles_lo), "=r"(cycles_hi1));
-  return (static_cast<uint64_t>(cycles_hi1) << 32) | cycles_lo;
+      : "=r"(times_hi0), "=r"(times_lo), "=r"(times_hi1));
+  return (static_cast<uint64_t>(times_hi1) << 32) | times_lo;
 #elif defined(__riscv) && __riscv_xlen == 64
-  uint64_t cycles;
-  asm volatile("rdcycle %0" : "=r"(cycles));
-  return cycles;
+  uint64_t times;
+  asm volatile("rdtime %0" : "=r"(times));
+  return times;
 #else
 #error No timer implementation for this platform
 #endif


### PR DESCRIPTION
Hello,

This issue is probably caused by [the PMU driver explicitly disallowing userland access](http://lists.infradead.org/pipermail/linux-riscv/2022-September/018927.html) to the `mcycle` register via `rdcycle`/`rdcycleh`.

Let me clarify a little bit:

1. Someone (e.g. those who write the PMU drivers) believe that `mcycle` is too accurate that might leak info to side-channel attacks, so they disabled userland access to `mcycle` by adding a commit to the kernel. As a result, `rdcycle` causes SIGILL now. We can observe this behavior happening on SiFive Unmatched boards.
2. Regarding this, the Google Highway library [has changed from `rdcycle` to `rdtime`](https://github.com/google/highway/commit/12ca8ff15390ccc4ef0a257ec095bb50e8b288c0). However, the Google Benchmark library remains [unchanged](https://github.com/google/benchmark/blob/4eaa0c896db50451e7cb38c9bcd9cde21713852e/src/cycleclock.h#L191) (as of now, 20221030).
3. The kernel devs had noticed this userland breakage, and **[had submitted a patch](https://lore.kernel.org/all/20220928131807.30386-1-palmer@rivosinc.com/) to re-enable using `rdcycle` in userland**, which was [applied 17 days ago](https://lore.kernel.org/all/166569033640.14806.5465239876406037308.b4-ty@rivosinc.com/). Since this patch is only accepted recently, I hope it can land in linux 6.2? As of our version of linux, which is linux 6.0.2, `rdcycle` is not working yet.

So, pros of switching to `rdtime`:

1. Runtime SIGILLs disappear immediately
2. Probably reducing the attack surface from side-channel attacks? Not sure tho
3. `mtime` register is promised to increase at a fixed speed, while `mcycle`'s increment speed may vary. See comments by Anup in [this link](http://lists.infradead.org/pipermail/linux-riscv/2022-September/018888.html).
4. `rdcycle` is now part of the `Zicntr` extension, which is not yet ratified as of 2022-10. RISC-V, despite used by a growing group of users, is still an evolving ISA, so details of `rdcycle` may change in the future. Should we consider this at software level? Sounds more like something that compilers should worry about.

And cons:

1. We can expect the kernel releasing new versions that re-enables `rdcycle`.
2. Seems like `rdcycle` has a higher resolution.

> FYI: The corresponding code is introduced by me in #9215.

See-also this thread: http://lists.infradead.org/pipermail/linux-riscv/2022-September/018862.html