### PR TITLE
[RFC] Convert point to range tombstone

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -485,7 +485,7 @@ Status BuildTable(
           auto tombstone = range_del_it->Tombstone();
           auto kv = tombstone.Serialize();
           builder->Add(kv.first.Encode(), kv.second);
-          meta->UpdateBoundariesForRange(kv.first,  tombstone.SerializeEndKey(),
+          meta->UpdateBoundariesForRange(kv.first, tombstone.SerializeEndKey(),
                                          tombstone.seq_,
                                          tboptions.internal_comparator);
         }

--- a/db/builder.h
+++ b/db/builder.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "db/memtable.h"
 #include "db/range_tombstone_fragmenter.h"
 #include "db/seqno_to_time_mapping.h"
 #include "db/table_properties_collector.h"
@@ -47,6 +48,9 @@ TableBuilder* NewTableBuilder(const TableBuilderOptions& tboptions,
 // If no data is present in *iter, meta->file_size will be set to
 // zero, and no Table file will be produced.
 //
+// The following parameters are needed when converting point to range tombstones
+// are enabled: db, cfd and mems.
+//
 // @param column_family_name Name of the column family that is also identified
 //    by column_family_id, or empty string if unknown.
 extern Status BuildTable(
@@ -69,7 +73,8 @@ extern Status BuildTable(
     TableProperties* table_properties = nullptr,
     Env::WriteLifeTimeHint write_hint = Env::WLTH_NOT_SET,
     const std::string* full_history_ts_low = nullptr,
-    BlobFileCompletionCallback* blob_callback = nullptr,
+    BlobFileCompletionCallback* blob_callback = nullptr, DBImpl* db = nullptr,
+    ColumnFamilyData* cfd = nullptr, autovector<MemTable*>* mems = nullptr,
     uint64_t* num_input_entries = nullptr,
     uint64_t* memtable_payload_bytes = nullptr,
     uint64_t* memtable_garbage_bytes = nullptr);

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -768,6 +768,15 @@ class DBImpl : public DB {
                                         Arena* arena, SequenceNumber sequence,
                                         bool allow_unprepared_value,
                                         ArenaWrappedDBIter* db_iter = nullptr);
+  // Used in BuildTable() during Flush for point to range tombstone conversion
+  // feature (EXPERIMENTAL).
+  //
+  // Given a list of immutable memtables in `mems`, returns an iterator over
+  // all immutable memtables that not newer than memtables in `mems`, and
+  // SSTables.
+  Iterator* NewInternalIterator(const ReadOptions& read_options,
+                                ColumnFamilyData* cfd,
+                                autovector<MemTable*>& mems);
 
   LogsWithPrepTracker* logs_with_prep_tracker() {
     return &logs_with_prep_tracker_;

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -220,7 +220,7 @@ Status DBImpl::FlushMemTableToOutputFile(
       &event_logger_, mutable_cf_options.report_bg_io_stats,
       true /* sync_output_directory */, true /* write_manifest */, thread_pri,
       io_tracer_, seqno_time_mapping_, db_id_, db_session_id_,
-      cfd->GetFullHistoryTsLow(), &blob_callback_);
+      cfd->GetFullHistoryTsLow(), &blob_callback_, this);
   FileMetaData file_meta;
 
   Status s;
@@ -468,7 +468,7 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
         stats_, &event_logger_, mutable_cf_options.report_bg_io_stats,
         false /* sync_output_directory */, false /* write_manifest */,
         thread_pri, io_tracer_, seqno_time_mapping_, db_id_, db_session_id_,
-        cfd->GetFullHistoryTsLow(), &blob_callback_));
+        cfd->GetFullHistoryTsLow(), &blob_callback_, this));
   }
 
   std::vector<FileMetaData> file_meta(num_cfs);

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1550,6 +1550,8 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
           0 /* file_creation_time */, db_id_, db_session_id_,
           0 /* target_file_size */, meta.fd.GetNumber());
       SeqnoToTimeMapping empty_seqno_time_mapping;
+      // TODO: pass in db, cfd to enable conversion from point to range
+      //  tombstone during restart
       s = BuildTable(
           dbname_, versions_.get(), immutable_db_options_, tboptions,
           file_options_for_compaction_, cfd->table_cache(), iter.get(),

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -2781,7 +2781,7 @@ TEST_F(DBRangeDelTest, PointToRangeTombstoneWithSnapshot) {
   options.disable_auto_compactions = true;
   options.tombstone_conversion_threshold = 4;
   DestroyAndReopen(options);
-  const Snapshot* snapshot;
+  const Snapshot* snapshot{nullptr};
   for (int i = 0; i < 4; ++i) {
     ASSERT_OK(Delete(Key(i)));
     if (i == 0) {
@@ -2921,7 +2921,7 @@ TEST_F(DBRangeDelTest, PointToRangeTombstoneConcurrentFlush) {
       });
   SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(Flush());
-  dbfull()->TEST_WaitForFlushMemTable();
+  ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
   std::string val = Get(Key(2));
   ASSERT_EQ(val, "val");
 }

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -76,7 +76,8 @@ class FlushJob {
            const SeqnoToTimeMapping& seq_time_mapping,
            const std::string& db_id = "", const std::string& db_session_id = "",
            std::string full_history_ts_low = "",
-           BlobFileCompletionCallback* blob_callback = nullptr);
+           BlobFileCompletionCallback* blob_callback = nullptr,
+           DBImpl* db = nullptr);
 
   ~FlushJob();
 
@@ -198,6 +199,8 @@ class FlushJob {
   // db mutex
   const SeqnoToTimeMapping& db_impl_seqno_time_mapping_;
   SeqnoToTimeMapping seqno_to_time_mapping_;
+
+  DBImpl* db_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -119,6 +119,12 @@ class MemTableListVersion {
                     MergeIteratorBuilder* merge_iter_builder,
                     bool add_range_tombstone_iter);
 
+  // Given a list of immutable memtables in `mems`, add to `merge_iter_builder`
+  // all immutable memtables that not newer than memtables in `mems`.
+  void AddIteratorsOlderThan(autovector<MemTable*>& mems_,
+                             MergeIteratorBuilder* merge_iter_builder,
+                             const ReadOptions& options);
+
   uint64_t GetTotalNumEntries() const;
 
   uint64_t GetTotalNumDeletes() const;

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -72,6 +72,18 @@ FragmentedRangeTombstoneList::FragmentedRangeTombstoneList(
   FragmentTombstones(std::move(iter), icmp, for_compaction, snapshots);
 }
 
+FragmentedRangeTombstoneList::FragmentedRangeTombstoneList(
+    std::vector<std::string>& start_keys, std::vector<std::string>& end_keys,
+    std::vector<SequenceNumber>& seqs) {
+  assert(start_keys.size() == end_keys.size() &&
+         end_keys.size() == seqs.size());
+  tombstone_seqs_.insert(tombstone_seqs_.begin(), seqs.begin(), seqs.end());
+  seq_set_.insert(seqs.begin(), seqs.end());
+  for (size_t i = 0; i < start_keys.size(); ++i) {
+    tombstones_.emplace_back(start_keys[i], end_keys[i], i, i + 1);
+  }
+}
+
 void FragmentedRangeTombstoneList::FragmentTombstones(
     std::unique_ptr<InternalIterator> unfragmented_tombstones,
     const InternalKeyComparator& icmp, bool for_compaction,

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -56,6 +56,13 @@ struct FragmentedRangeTombstoneList {
       const InternalKeyComparator& icmp, bool for_compaction = false,
       const std::vector<SequenceNumber>& snapshots = {});
 
+  // Creates range tombstones [start_keys[i], end_keys[i]) at seqs[i]
+  // for 0 <= i < start_keys.size().
+  // REQUIRES start_keys.size() == end_keys.size() == seqs.size()
+  FragmentedRangeTombstoneList(std::vector<std::string>& start_keys,
+                               std::vector<std::string>& end_keys,
+                               std::vector<SequenceNumber>& seqs);
+
   std::vector<RangeTombstoneStack>::const_iterator begin() const {
     return tombstones_.begin();
   }

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -325,6 +325,8 @@ DECLARE_uint64(initial_auto_readahead_size);
 DECLARE_uint64(max_auto_readahead_size);
 DECLARE_uint64(num_file_reads_for_auto_readahead);
 
+DECLARE_uint32(tombstone_conversion_threshold);
+
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;
 constexpr int kValueMaxLen = 100;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1075,4 +1075,10 @@ DEFINE_uint64(stats_dump_period_sec,
               ROCKSDB_NAMESPACE::Options().stats_dump_period_sec,
               "Gap between printing stats to log in seconds");
 
+DEFINE_uint32(
+    tombstone_conversion_threshold, 0,
+    "Enables point to range tombstone conversion during Flush. This only "
+    "benefits iterator performance "
+    " if there tends to be long consecutive sequences of point tombstones.");
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3299,6 +3299,7 @@ void InitializeOptionsFromFlags(
   }
 
   options.allow_data_in_errors = FLAGS_allow_data_in_errors;
+  options.tombstone_conversion_threshold = FLAGS_tombstone_conversion_threshold;
 }
 
 void InitializeOptionsGeneral(

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1087,6 +1087,23 @@ struct AdvancedColumnFamilyOptions {
   // Supported values: 0, 1, 2, 4, 8.
   uint32_t memtable_protection_bytes_per_key = 0;
 
+  // EXPERIMENTAL
+  // Not compatible with user-defined timestamp yet.
+  //
+  // If non-zero, enables the conversion from a consecutive sequence of point
+  // tombstones into a single range tombstone during flush. Specifically,
+  // during flush, if RocksDB sees a sequence of
+  // `tombstone_conversion_threshold` point tombstones, say key1, key3, ...,
+  // key9, it tries to convert them into a range tombstone [key1, key9) and the
+  // point tombstone key9 (as range tombstone end key is exclusive). This can
+  // speed up Iterator for DB that writes many long consecutive sequences
+  // of point tombstones.
+  //
+  // Note that this option slows down flush if not many conversions happen.
+  //
+  // Default: 0 (disabled)
+  uint32_t tombstone_conversion_threshold = 0;
+
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options

--- a/java/src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
+++ b/java/src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
@@ -31,8 +31,7 @@ public class BlockBasedTableConfigTest {
   public void cacheIndexAndFilterBlocks() {
     final BlockBasedTableConfig blockBasedTableConfig = new BlockBasedTableConfig();
     blockBasedTableConfig.setCacheIndexAndFilterBlocks(true);
-    assertThat(blockBasedTableConfig.cacheIndexAndFilterBlocks()).
-        isTrue();
+    assertThat(blockBasedTableConfig.cacheIndexAndFilterBlocks()).isTrue();
   }
 
   @Test
@@ -156,11 +155,9 @@ public class BlockBasedTableConfigTest {
     String result;
     try (final RocksDB db = RocksDB.open(options, dbPath);
          final Stream<Path> pathStream = Files.walk(Paths.get(dbPath))) {
-      Path optionsPath =
-          pathStream
-              .filter(p -> p.getFileName().toString().startsWith("OPTIONS"))
-              .findAny()
-              .orElseThrow(() -> new AssertionError("Missing options file"));
+      Path optionsPath = pathStream.filter(p -> p.getFileName().toString().startsWith("OPTIONS"))
+                             .findAny()
+                             .orElseThrow(() -> new AssertionError("Missing options file"));
       byte[] optionsData = Files.readAllBytes(optionsPath);
       result = new String(optionsData, StandardCharsets.UTF_8);
     }

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -484,6 +484,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, memtable_protection_bytes_per_key),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"tombstone_conversion_threshold",
+         {offsetof(struct MutableCFOptions, tombstone_conversion_threshold),
+          OptionType::kUInt32T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
         {kOptNameCompOpts,
          OptionTypeInfo::Struct(
              kOptNameCompOpts, &compression_options_type_info,

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -172,7 +172,8 @@ struct MutableCFOptions {
             options.memtable_protection_bytes_per_key),
         sample_for_compression(
             options.sample_for_compression),  // TODO: is 0 fine here?
-        compression_per_level(options.compression_per_level) {
+        compression_per_level(options.compression_per_level),
+        tombstone_conversion_threshold(options.tombstone_conversion_threshold) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -220,7 +221,8 @@ struct MutableCFOptions {
         bottommost_compression(kDisableCompressionOption),
         last_level_temperature(Temperature::kUnknown),
         memtable_protection_bytes_per_key(0),
-        sample_for_compression(0) {}
+        sample_for_compression(0),
+        tombstone_conversion_threshold(0) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -313,6 +315,8 @@ struct MutableCFOptions {
 
   uint64_t sample_for_compression;
   std::vector<CompressionType> compression_per_level;
+
+  uint32_t tombstone_conversion_threshold;
 
   // Derived options
   // Per-level target file size.

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -278,6 +278,8 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->compression_per_level = moptions.compression_per_level;
   cf_opts->last_level_temperature = moptions.last_level_temperature;
   cf_opts->bottommost_temperature = moptions.last_level_temperature;
+  cf_opts->tombstone_conversion_threshold =
+      moptions.tombstone_conversion_threshold;
 }
 
 void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -539,7 +539,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "compaction_options_fifo={max_table_files_size=3;allow_"
       "compaction=false;age_for_warm=1;};"
       "blob_cache=1M;"
-      "memtable_protection_bytes_per_key=2;",
+      "memtable_protection_bytes_per_key=2;"
+      "tombstone_conversion_threshold=100;",
       new_options));
 
   ASSERT_NE(new_options->blob_cache.get(), nullptr);

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -1364,6 +1364,9 @@ InternalIterator* MergeIteratorBuilder::Finish(ArenaWrappedDBIter* db_iter) {
     ret = merge_iter;
     merge_iter = nullptr;
   }
+  if (!ret) {
+    return NewEmptyInternalIterator<Slice>(arena);
+  }
   return ret;
 }
 


### PR DESCRIPTION
Summary: Added an option `tombstone_conversion_threshold` that enables converting consecutive point tombstones into a single range tombstone during Flush. Maybe be helpful for issues like #10300 and #5265.

Test plan:
- Added unit test
- Stress test: `python3 tools/db_crashtest.py whitebox --simple  --verify_iterator_with_expected_state_one_in=2 --delpercent=20 --readpercent=25 --writepercent=40 --delrangepercent=0 --tombstone_conversion_threshold=2`