### PR TITLE
Tolerate with bad flush related options.

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -1440,6 +1440,21 @@ TEST_F(DBFlushTest, MemPurgeAndCompactionFilter) {
   ASSERT_EQ(Get(KEY5), p_v5);
 }
 
+TEST_F(DBFlushTest, TolerateBadWriteBufSizeAndArenaBlockSize) {
+  Options options = CurrentOptions();
+
+  options.statistics = CreateDBStatistics();
+  options.statistics->set_stats_level(StatsLevel::kAll);
+
+  // Check that no crash when construcing a Memtable
+  // even with bad choice of these two variables
+  // https://github.com/facebook/rocksdb/issues/10713
+  options.arena_block_size = 1024*1024*16;
+  options.write_buffer_size = 1024*1024*2;
+
+  ASSERT_OK(TryReopen(options));
+}
+
 TEST_F(DBFlushTest, DISABLED_MemPurgeWALSupport) {
   Options options = CurrentOptions();
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -341,7 +341,7 @@ struct AdvancedColumnFamilyOptions {
   // If inplace_callback function is not set,
   //   Put(key, new_value) will update inplace the existing_value iff
   //   * key exists in current memtable
-  //   * new sizeof(new_value) <= sizeof(existing_value)
+  //   * sizeof(new_value) <= sizeof(existing_value)
   //   * existing_value for that key is a put i.e. kTypeValue
   // If inplace_callback function is set, check doc for inplace_callback.
   // Default: false.


### PR DESCRIPTION
Fix https://github.com/facebook/rocksdb/issues/10713 by allowing flush decision to be positive when constructing a memtable.
Also fix a minor typo.