### PR TITLE
Don't attempt to use SecondaryCache on block_cache_compressed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,9 +8,13 @@
 * Fix memory corruption error in scans if async_io is enabled. Memory corruption happened if there is IOError while reading the data leading to empty buffer and other buffer already in progress of async read goes again for reading.
 * Fix failed memtable flush retry bug that could cause wrongly ordered updates, which would surface to writers as `Status::Corruption` in case of `force_consistency_checks=true` (default). It affects use cases that enable both parallel flush (`max_background_flushes > 1` or `max_background_jobs >= 8`) and non-default memtable count (`max_write_buffer_number > 2`).
 * Fixed an issue where the `READ_NUM_MERGE_OPERANDS` ticker was not updated when the base key-value or tombstone was read from an SST file.
+* Fixed a memory safety bug when using a SecondaryCache with `block_cache_compressed`. `block_cache_compressed` no longer attempts to use SecondaryCache features.
 
 ### New Features
 * Add basic support for user-defined timestamp to Merge (#10819).
+
+### Public API Changes
+* Marked `block_cache_compressed` as a deprecated feature. Use SecondaryCache instead.
 
 ## 7.8.0 (10/22/2022)
 ### New Features

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -1888,6 +1888,42 @@ TEST_F(DBSecondaryCacheTest, SecondaryCacheFailureTest) {
   Destroy(options);
 }
 
+TEST_F(DBSecondaryCacheTest, TestSecondaryWithCompressedCache) {
+  if (!Snappy_Supported()) {
+    ROCKSDB_GTEST_SKIP("Compressed cache test requires snappy support");
+  }
+  LRUCacheOptions opts(2000 /* capacity */, 0 /* num_shard_bits */,
+                       false /* strict_capacity_limit */,
+                       0.5 /* high_pri_pool_ratio */,
+                       nullptr /* memory_allocator */, kDefaultToAdaptiveMutex,
+                       kDontChargeCacheMetadata);
+  std::shared_ptr<TestSecondaryCache> secondary_cache(
+      new TestSecondaryCache(2048 * 1024));
+  opts.secondary_cache = secondary_cache;
+  std::shared_ptr<Cache> cache = NewLRUCache(opts);
+  BlockBasedTableOptions table_options;
+  table_options.block_cache_compressed = cache;
+  table_options.no_block_cache = true;
+  table_options.block_size = 1234;
+  Options options = GetDefaultOptions();
+  options.compression = kSnappyCompression;
+  options.create_if_missing = true;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  DestroyAndReopen(options);
+  Random rnd(301);
+  const int N = 6;
+  for (int i = 0; i < N; i++) {
+    // Partly compressible
+    std::string p_v = rnd.RandomString(507) + std::string(500, ' ');
+    ASSERT_OK(Put(Key(i), p_v));
+  }
+  ASSERT_OK(Flush());
+  for (int i = 0; i < 2 * N; i++) {
+    std::string v = Get(Key(i % N));
+    ASSERT_EQ(1007, v.size());
+  }
+}
+
 TEST_F(LRUCacheSecondaryCacheTest, BasicWaitAllTest) {
   LRUCacheOptions opts(1024 /* capacity */, 2 /* num_shard_bits */,
                        false /* strict_capacity_limit */,

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -1891,6 +1891,7 @@ TEST_F(DBSecondaryCacheTest, SecondaryCacheFailureTest) {
 TEST_F(DBSecondaryCacheTest, TestSecondaryWithCompressedCache) {
   if (!Snappy_Supported()) {
     ROCKSDB_GTEST_SKIP("Compressed cache test requires snappy support");
+    return;
   }
   LRUCacheOptions opts(2000 /* capacity */, 0 /* num_shard_bits */,
                        false /* strict_capacity_limit */,

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -266,6 +266,9 @@ struct BlockBasedTableOptions {
   // IF NULL, no page cache is used
   std::shared_ptr<PersistentCache> persistent_cache = nullptr;
 
+  // DEPRECATED: This feature is planned for removal in a future release.
+  // Use SecondaryCache instead.
+  //
   // If non-NULL use the specified cache for compressed blocks.
   // If NULL, rocksdb will not use a compressed block cache.
   // Note: though it looks similar to `block_cache`, RocksDB doesn't put the

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "cache/cache_entry_roles.h"
+#include "cache/cache_helpers.h"
 #include "cache/cache_key.h"
 #include "cache/cache_reservation_manager.h"
 #include "db/dbformat.h"
@@ -1417,15 +1418,6 @@ IOStatus BlockBasedTableBuilder::io_status() const {
   return rep_->GetIOStatus();
 }
 
-namespace {
-// Delete the entry resided in the cache.
-template <class Entry>
-void DeleteEntryCached(const Slice& /*key*/, void* value) {
-  auto entry = reinterpret_cast<Entry*>(value);
-  delete entry;
-}
-}  // namespace
-
 //
 // Make a copy of the block contents and insert into compressed block cache
 //
@@ -1454,7 +1446,7 @@ Status BlockBasedTableBuilder::InsertBlockInCompressedCache(
     s = block_cache_compressed->Insert(
         key.AsSlice(), block_contents_to_cache,
         block_contents_to_cache->ApproximateMemoryUsage(),
-        &DeleteEntryCached<BlockContents>);
+        &DeleteCacheEntry<BlockContents>);
     if (s.ok()) {
       RecordTick(rep_->ioptions.stats, BLOCK_CACHE_COMPRESSED_ADD);
     } else {

--- a/table/block_based/block_like_traits.h
+++ b/table/block_based/block_like_traits.h
@@ -41,45 +41,6 @@ Cache::CreateCallback GetCreateCallback(size_t read_amp_bytes_per_bit,
 }
 
 template <>
-class BlocklikeTraits<BlockContents> {
- public:
-  static BlockContents* Create(BlockContents&& contents,
-                               size_t /* read_amp_bytes_per_bit */,
-                               Statistics* /* statistics */,
-                               bool /* using_zstd */,
-                               const FilterPolicy* /* filter_policy */) {
-    return new BlockContents(std::move(contents));
-  }
-
-  static uint32_t GetNumRestarts(const BlockContents& /* contents */) {
-    return 0;
-  }
-
-  static size_t SizeCallback(void* obj) {
-    assert(obj != nullptr);
-    BlockContents* ptr = static_cast<BlockContents*>(obj);
-    return ptr->data.size();
-  }
-
-  static Status SaveToCallback(void* from_obj, size_t from_offset,
-                               size_t length, void* out) {
-    assert(from_obj != nullptr);
-    BlockContents* ptr = static_cast<BlockContents*>(from_obj);
-    const char* buf = ptr->data.data();
-    assert(length == ptr->data.size());
-    (void)from_offset;
-    memcpy(out, buf, length);
-    return Status::OK();
-  }
-
-  static Cache::CacheItemHelper* GetCacheItemHelper(BlockType /*block_type*/) {
-    // E.g. compressed cache
-    return GetCacheItemHelperForRole<BlockContents,
-                                     CacheEntryRole::kOtherBlock>();
-  }
-};
-
-template <>
 class BlocklikeTraits<ParsedFullFilterBlock> {
  public:
   static ParsedFullFilterBlock* Create(BlockContents&& contents,

--- a/table/block_based/filter_block_reader_common.cc
+++ b/table/block_based/filter_block_reader_common.cc
@@ -158,7 +158,6 @@ bool FilterBlockReaderCommon<TBlocklike>::IsFilterCompatible(
 
 // Explicitly instantiate templates for both "blocklike" types we use.
 // This makes it possible to keep the template definitions in the .cc file.
-template class FilterBlockReaderCommon<BlockContents>;
 template class FilterBlockReaderCommon<Block>;
 template class FilterBlockReaderCommon<ParsedFullFilterBlock>;
 


### PR DESCRIPTION
Summary: Compressed block cache depends on reading the block compression marker beyond the payload block size. Only the payload bytes were being saved and loaded from SecondaryCache -> boom!

This removes some unnecessary code attempting to combine these two competing features. Note that BlockContents was previously used for block-based filter in block cache, but that support has been removed.

Also marking block_cache_compressed as deprecated in this commit as we expect it to be replaced with SecondaryCache.

This problem was discovered during refactoring but didn't want to combine bug fix with that refactoring.

Test Plan: test added that fails on base revision (at least with ASAN)