### PR TITLE
Support Merge for wide-column entities in the compaction logic

### DIFF
--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -292,7 +292,7 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
       // run compaction filter on it.
       const Slice val = iter->value();
       PinnableSlice blob_value;
-      const Slice* val_ptr;
+      const Slice* val_ptr = nullptr;
       if ((kTypeValue == ikey.type || kTypeBlobIndex == ikey.type ||
            kTypeWideColumnEntity == ikey.type) &&
           (range_del_agg == nullptr ||
@@ -335,9 +335,8 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
         } else {
           val_ptr = &val;
         }
-      } else {
-        val_ptr = nullptr;
       }
+
       std::string merge_result;
       s = TimedFullMerge(
           user_merge_operator_, ikey.user_key, val_ptr,

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -290,58 +290,69 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
       // (almost) silently dropping the put/delete. That's probably not what we
       // want. Also if we're in compaction and it's a put, it would be nice to
       // run compaction filter on it.
-      const Slice val = iter->value();
-      PinnableSlice blob_value;
-      const Slice* val_ptr = nullptr;
-      if ((kTypeValue == ikey.type || kTypeBlobIndex == ikey.type ||
-           kTypeWideColumnEntity == ikey.type) &&
-          (range_del_agg == nullptr ||
-           !range_del_agg->ShouldDelete(
-               ikey, RangeDelPositioningMode::kForwardTraversal))) {
-        if (ikey.type == kTypeWideColumnEntity) {
-          // TODO: support wide-column entities
-          return Status::NotSupported(
-              "Merge currently not supported for wide-column entities");
-        } else if (ikey.type == kTypeBlobIndex) {
-          BlobIndex blob_index;
-
-          s = blob_index.DecodeFrom(val);
-          if (!s.ok()) {
-            return s;
-          }
-
-          FilePrefetchBuffer* prefetch_buffer =
-              prefetch_buffers ? prefetch_buffers->GetOrCreatePrefetchBuffer(
-                                     blob_index.file_number())
-                               : nullptr;
-
-          uint64_t bytes_read = 0;
-
-          assert(blob_fetcher);
-
-          s = blob_fetcher->FetchBlob(ikey.user_key, blob_index,
-                                      prefetch_buffer, &blob_value,
-                                      &bytes_read);
-          if (!s.ok()) {
-            return s;
-          }
-
-          val_ptr = &blob_value;
-
-          if (c_iter_stats) {
-            ++c_iter_stats->num_blobs_read;
-            c_iter_stats->total_blob_bytes_read += bytes_read;
-          }
-        } else {
-          val_ptr = &val;
-        }
-      }
-
       std::string merge_result;
-      s = TimedFullMerge(
-          user_merge_operator_, ikey.user_key, val_ptr,
-          merge_context_.GetOperands(), &merge_result, logger_, stats_, clock_,
-          /* result_operand */ nullptr, /* update_num_ops_stats */ false);
+
+      if (range_del_agg &&
+          range_del_agg->ShouldDelete(
+              ikey, RangeDelPositioningMode::kForwardTraversal)) {
+        s = TimedFullMerge(user_merge_operator_, ikey.user_key, nullptr,
+                           merge_context_.GetOperands(), &merge_result, logger_,
+                           stats_, clock_,
+                           /* result_operand */ nullptr,
+                           /* update_num_ops_stats */ false);
+      } else if (ikey.type == kTypeValue) {
+        const Slice val = iter->value();
+
+        s = TimedFullMerge(user_merge_operator_, ikey.user_key, &val,
+                           merge_context_.GetOperands(), &merge_result, logger_,
+                           stats_, clock_,
+                           /* result_operand */ nullptr,
+                           /* update_num_ops_stats */ false);
+      } else if (ikey.type == kTypeBlobIndex) {
+        BlobIndex blob_index;
+
+        s = blob_index.DecodeFrom(iter->value());
+        if (!s.ok()) {
+          return s;
+        }
+
+        FilePrefetchBuffer* prefetch_buffer =
+            prefetch_buffers ? prefetch_buffers->GetOrCreatePrefetchBuffer(
+                                   blob_index.file_number())
+                             : nullptr;
+
+        uint64_t bytes_read = 0;
+
+        assert(blob_fetcher);
+
+        PinnableSlice blob_value;
+        s = blob_fetcher->FetchBlob(ikey.user_key, blob_index, prefetch_buffer,
+                                    &blob_value, &bytes_read);
+        if (!s.ok()) {
+          return s;
+        }
+
+        if (c_iter_stats) {
+          ++c_iter_stats->num_blobs_read;
+          c_iter_stats->total_blob_bytes_read += bytes_read;
+        }
+
+        s = TimedFullMerge(user_merge_operator_, ikey.user_key, &blob_value,
+                           merge_context_.GetOperands(), &merge_result, logger_,
+                           stats_, clock_,
+                           /* result_operand */ nullptr,
+                           /* update_num_ops_stats */ false);
+      } else if (ikey.type == kTypeWideColumnEntity) {
+        // TODO: support wide-column entities
+        return Status::NotSupported(
+            "Merge currently not supported for wide-column entities");
+      } else {
+        s = TimedFullMerge(user_merge_operator_, ikey.user_key, nullptr,
+                           merge_context_.GetOperands(), &merge_result, logger_,
+                           stats_, clock_,
+                           /* result_operand */ nullptr,
+                           /* update_num_ops_stats */ false);
+      }
 
       // We store the result in keys_.back() and operands_.back()
       // if nothing went wrong (i.e.: no operand corruption on disk)

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -396,15 +396,16 @@ TEST_F(DBWideBasicTest, MergeEntity) {
                          second_merge_operand));
   };
 
-  auto verify = [&]() {
-    const std::string first_expected_default(
-        first_columns[0].value().ToString() + delim + first_merge_operand);
+  const std::string first_expected_default(first_columns[0].value().ToString() +
+                                           delim + first_merge_operand);
+  const std::string second_expected_default(delim + second_merge_operand);
+
+  auto verify_basic = [&]() {
     WideColumns first_expected_columns{
         {kDefaultWideColumnName, first_expected_default},
         first_columns[1],
         first_columns[2]};
 
-    const std::string second_expected_default(delim + second_merge_operand);
     WideColumns second_expected_columns{
         {kDefaultWideColumnName, second_expected_default},
         second_columns[0],
@@ -425,24 +426,6 @@ TEST_F(DBWideBasicTest, MergeEntity) {
     }
 
     {
-      constexpr size_t num_merge_operands = 2;
-
-      std::array<PinnableSlice, num_merge_operands> merge_operands;
-
-      GetMergeOperandsOptions get_merge_opts;
-      get_merge_opts.expected_max_number_of_operands = num_merge_operands;
-
-      int number_of_operands = 0;
-
-      ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
-                                      first_key, &merge_operands[0],
-                                      &get_merge_opts, &number_of_operands));
-      ASSERT_EQ(number_of_operands, num_merge_operands);
-      ASSERT_EQ(merge_operands[0], first_columns[0].value());
-      ASSERT_EQ(merge_operands[1], first_merge_operand);
-    }
-
-    {
       PinnableSlice result;
       ASSERT_OK(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), second_key,
                          &result));
@@ -454,24 +437,6 @@ TEST_F(DBWideBasicTest, MergeEntity) {
       ASSERT_OK(db_->GetEntity(ReadOptions(), db_->DefaultColumnFamily(),
                                second_key, &result));
       ASSERT_EQ(result.columns(), second_expected_columns);
-    }
-
-    {
-      constexpr size_t num_merge_operands = 2;
-
-      std::array<PinnableSlice, num_merge_operands> merge_operands;
-
-      GetMergeOperandsOptions get_merge_opts;
-      get_merge_opts.expected_max_number_of_operands = num_merge_operands;
-
-      int number_of_operands = 0;
-
-      ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
-                                      second_key, &merge_operands[0],
-                                      &get_merge_opts, &number_of_operands));
-      ASSERT_EQ(number_of_operands, num_merge_operands);
-      ASSERT_TRUE(merge_operands[0].empty());
-      ASSERT_EQ(merge_operands[1], second_merge_operand);
     }
 
     {
@@ -532,6 +497,70 @@ TEST_F(DBWideBasicTest, MergeEntity) {
     }
   };
 
+  auto verify_merge_ops_pre_compaction = [&]() {
+    constexpr size_t num_merge_operands = 2;
+
+    GetMergeOperandsOptions get_merge_opts;
+    get_merge_opts.expected_max_number_of_operands = num_merge_operands;
+
+    {
+      std::array<PinnableSlice, num_merge_operands> merge_operands;
+      int number_of_operands = 0;
+
+      ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
+                                      first_key, &merge_operands[0],
+                                      &get_merge_opts, &number_of_operands));
+
+      ASSERT_EQ(number_of_operands, num_merge_operands);
+      ASSERT_EQ(merge_operands[0], first_columns[0].value());
+      ASSERT_EQ(merge_operands[1], first_merge_operand);
+    }
+
+    {
+      std::array<PinnableSlice, num_merge_operands> merge_operands;
+      int number_of_operands = 0;
+
+      ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
+                                      second_key, &merge_operands[0],
+                                      &get_merge_opts, &number_of_operands));
+
+      ASSERT_EQ(number_of_operands, num_merge_operands);
+      ASSERT_TRUE(merge_operands[0].empty());
+      ASSERT_EQ(merge_operands[1], second_merge_operand);
+    }
+  };
+
+  auto verify_merge_ops_post_compaction = [&]() {
+    constexpr size_t num_merge_operands = 1;
+
+    GetMergeOperandsOptions get_merge_opts;
+    get_merge_opts.expected_max_number_of_operands = num_merge_operands;
+
+    {
+      std::array<PinnableSlice, num_merge_operands> merge_operands;
+      int number_of_operands = 0;
+
+      ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
+                                      first_key, &merge_operands[0],
+                                      &get_merge_opts, &number_of_operands));
+
+      ASSERT_EQ(number_of_operands, num_merge_operands);
+      ASSERT_EQ(merge_operands[0], first_expected_default);
+    }
+
+    {
+      std::array<PinnableSlice, num_merge_operands> merge_operands;
+      int number_of_operands = 0;
+
+      ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
+                                      second_key, &merge_operands[0],
+                                      &get_merge_opts, &number_of_operands));
+
+      ASSERT_EQ(number_of_operands, num_merge_operands);
+      ASSERT_EQ(merge_operands[0], second_expected_default);
+    }
+  };
+
   {
     // Base KVs and Merge operands both in memtable (note: we take a snapshot in
     // between to make sure they do not get reconciled during the subsequent
@@ -539,11 +568,13 @@ TEST_F(DBWideBasicTest, MergeEntity) {
     write_base();
     ManagedSnapshot snapshot(db_);
     write_merge();
-    verify();
+    verify_basic();
+    verify_merge_ops_pre_compaction();
 
     // Base KVs and Merge operands both in storage
     ASSERT_OK(Flush());
-    verify();
+    verify_basic();
+    verify_merge_ops_pre_compaction();
   }
 
   // Base KVs in storage, Merge operands in memtable
@@ -551,7 +582,15 @@ TEST_F(DBWideBasicTest, MergeEntity) {
   write_base();
   ASSERT_OK(Flush());
   write_merge();
-  verify();
+  verify_basic();
+  verify_merge_ops_pre_compaction();
+
+  // Flush and compact
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), /* begin */ nullptr,
+                              /* end */ nullptr));
+  verify_basic();
+  verify_merge_ops_post_compaction();
 }
 
 TEST_F(DBWideBasicTest, PutEntityTimestampError) {


### PR DESCRIPTION
Summary:
The patch extends the compaction logic to handle `Merge`s in conjunction with wide-column entities. As usual, the merge operation is applied to the anonymous default column, and any other columns are unaffected.

Test Plan:
`make check`