### PR TITLE
utilities/transaction: eliminate find of "find + emplace/insert" sequence

### DIFF
--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
@@ -371,7 +371,8 @@ void RangeTreeLockManager::AddColumnFamily(const ColumnFamilyHandle* cfh) {
   uint32_t column_family_id = cfh->GetID();
 
   InstrumentedMutexLock l(&ltree_map_mutex_);
-  if (ltree_map_.find(column_family_id) == ltree_map_.end()) {
+  auto [it, success] = ltree_map_.insert({column_family_id, nullptr});
+  if (success) {
     DICTIONARY_ID dict_id = {.dictid = column_family_id};
     toku::comparator cmp;
     cmp.create(CompareDbtEndpoints, (void*)cfh->GetComparator());
@@ -381,7 +382,7 @@ void RangeTreeLockManager::AddColumnFamily(const ColumnFamilyHandle* cfh) {
     // This is ok to because get_lt has copied the comparator:
     cmp.destroy();
 
-    ltree_map_.insert({column_family_id, MakeLockTreePtr(ltree)});
+    it->second = MakeLockTreePtr(ltree);
   }
 }
 

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_tracker.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_tracker.cc
@@ -64,10 +64,10 @@ void RangeLockList::Append(ColumnFamilyId cf_id, const DBT *left_key,
   // The same thread does the lock release, so we can be certain nobody is
   // releasing the locks concurrently.
   assert(!releasing_locks_.load());
-  auto it = buffers_.find(cf_id);
-  if (it == buffers_.end()) {
+  auto [it, success] = buffers_.emplace(cf_id, nullptr);
+  if (success) {
     // create a new one
-    it = buffers_.emplace(cf_id, std::make_shared<toku::range_buffer>()).first;
+    it->second = std::make_shared<toku::range_buffer>();
     it->second->create();
   }
   it->second->append(left_key, right_key);

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -884,14 +884,8 @@ Status PessimisticTransaction::LockBatch(WriteBatch* batch,
     Handler() {}
 
     void RecordKey(uint32_t column_family_id, const Slice& key) {
-      std::string key_str = key.ToString();
-
       auto& cfh_keys = keys_[column_family_id];
-      auto iter = cfh_keys.find(key_str);
-      if (iter == cfh_keys.end()) {
-        // key not yet seen, store it.
-        cfh_keys.insert({std::move(key_str)});
-      }
+      cfh_keys.insert(key.ToString());
     }
 
     Status PutCF(uint32_t column_family_id, const Slice& key,


### PR DESCRIPTION
```c++
auto iter = map.find(key);
if (iter == map.end()) { // not found
  map.emplace(...); // or insert
} else {
  // found, handle dup
}
```
can be optimized to:
```c++
auto [iter, success] = map.emplace(key_value); // or insert
if (!success) {
  // found, handle dup
}
```
The optimized code eliminated the redundant calling to `find`.