### PR TITLE
dont use vector::at because it performs bound check at runtime

### DIFF
--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -640,9 +640,9 @@ int InputSummary(const std::vector<FileMetaData*>& files, char* output,
     int sz = len - write;
     int ret;
     char sztxt[16];
-    AppendHumanBytes(files.at(i)->fd.GetFileSize(), sztxt, 16);
+    AppendHumanBytes(files[i]->fd.GetFileSize(), sztxt, 16);
     ret = snprintf(output + write, sz, "%" PRIu64 "(%s) ",
-                   files.at(i)->fd.GetNumber(), sztxt);
+                   files[i]->fd.GetNumber(), sztxt);
     if (ret < 0 || ret >= sz) break;
     write += ret;
   }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -65,7 +65,7 @@ class CompactionStatsCollector : public EventListener {
     int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
     int k = static_cast<int>(reason);
     assert(k >= 0 && k < num_of_reasons);
-    return compaction_completed_.at(k).load();
+    return compaction_completed_[k].load();
   }
 
  private:

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -481,7 +481,7 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
 
 #ifndef ROCKSDB_LITE
   for (int i = 0; i != num_cfs; ++i) {
-    const MutableCFOptions& mutable_cf_options = all_mutable_cf_options.at(i);
+    const MutableCFOptions& mutable_cf_options = all_mutable_cf_options[i];
     // may temporarily unlock and lock the mutex.
     NotifyOnFlushBegin(cfds[i], &file_meta[i], mutable_cf_options,
                        job_context->job_id);
@@ -533,9 +533,8 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
            static_cast<long unsigned int>(num_cfs));
     // TODO (yanqin): parallelize jobs with threads.
     for (int i = 1; i != num_cfs; ++i) {
-      exec_status[i].second =
-          jobs[i]->Run(&logs_with_prep_tracker_, &file_meta[i],
-                       &(switched_to_mempurge.at(i)));
+      exec_status[i].second = jobs[i]->Run(
+          &logs_with_prep_tracker_, &file_meta[i], &(switched_to_mempurge[i]));
       exec_status[i].first = true;
     }
     if (num_cfs > 1) {
@@ -548,7 +547,7 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
     assert(!file_meta.empty());
     exec_status[0].second = jobs[0]->Run(
         &logs_with_prep_tracker_, file_meta.data() /* &file_meta[0] */,
-        switched_to_mempurge.empty() ? nullptr : &(switched_to_mempurge.at(0)));
+        switched_to_mempurge.empty() ? nullptr : &(switched_to_mempurge[0]));
     exec_status[0].first = true;
 
     Status error_status;

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -640,7 +640,7 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
     size_t end =
         old_info_log_file_count - immutable_db_options_.keep_log_file_num;
     for (unsigned int i = 0; i <= end; i++) {
-      std::string& to_delete = old_info_log_files.at(i);
+      std::string& to_delete = old_info_log_files[i];
       std::string full_path_to_delete =
           (immutable_db_options_.db_log_dir.empty()
                ? dbname_

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2790,7 +2790,7 @@ Status Version::MultiGetAsync(
     batches.reserve(batches.size() + 1);
 
     size_t idx = to_process.front();
-    FilePickerMultiGet* batch = &batches.at(idx);
+    FilePickerMultiGet* batch = &batches[idx];
     unsigned int num_tasks_queued = 0;
     to_process.pop_front();
     if (batch->IsSearchEnded() || batch->GetRange().empty()) {
@@ -2836,7 +2836,7 @@ Status Version::MultiGetAsync(
         }
 
         for (size_t wait_idx : waiting) {
-          FilePickerMultiGet& fp = batches.at(wait_idx);
+          FilePickerMultiGet& fp = batches[wait_idx];
           // 1. If fp.GetHitFile() is non-null, then there could be more
           // overlap in this level. So skip preparing next level.
           // 2. If fp.GetRange() is empty, then this batch is completed

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -284,7 +284,7 @@ TEST_P(WriteCallbackPTest, WriteWithCallbackTest) {
              threads_verified.load() < write_group.size() - 1) {
       }
 
-      auto& write_op = write_group.at(i);
+      auto& write_op = write_group[i];
       write_op.Clear();
       write_op.callback_.allow_batching_ = allow_batching_;
 

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -672,7 +672,7 @@ Status MultiOpsTxnsStressTest::PrimaryKeyUpdateTxn(ThreadState* thread,
 
   s = CommitAndCreateTimestampedSnapshotIfNeeded(thread, *txn);
 
-  auto& key_gen = key_gen_for_a_.at(thread->tid);
+  auto& key_gen = key_gen_for_a_[thread->tid];
   if (s.ok()) {
     delete txn;
     key_gen->Replace(old_a, old_a_pos, new_a);
@@ -880,7 +880,7 @@ Status MultiOpsTxnsStressTest::SecondaryKeyUpdateTxn(ThreadState* thread,
 
   if (s.ok()) {
     delete txn;
-    auto& key_gen = key_gen_for_c_.at(thread->tid);
+    auto& key_gen = key_gen_for_c_[thread->tid];
     key_gen->Replace(old_c, old_c_pos, new_c);
   }
 
@@ -1333,26 +1333,26 @@ void MultiOpsTxnsStressTest::VerifyPkSkFast(int job_id) {
 std::pair<uint32_t, uint32_t> MultiOpsTxnsStressTest::ChooseExistingA(
     ThreadState* thread) {
   uint32_t tid = thread->tid;
-  auto& key_gen = key_gen_for_a_.at(tid);
+  auto& key_gen = key_gen_for_a_[tid];
   return key_gen->ChooseExisting();
 }
 
 uint32_t MultiOpsTxnsStressTest::GenerateNextA(ThreadState* thread) {
   uint32_t tid = thread->tid;
-  auto& key_gen = key_gen_for_a_.at(tid);
+  auto& key_gen = key_gen_for_a_[tid];
   return key_gen->Allocate();
 }
 
 std::pair<uint32_t, uint32_t> MultiOpsTxnsStressTest::ChooseExistingC(
     ThreadState* thread) {
   uint32_t tid = thread->tid;
-  auto& key_gen = key_gen_for_c_.at(tid);
+  auto& key_gen = key_gen_for_c_[tid];
   return key_gen->ChooseExisting();
 }
 
 uint32_t MultiOpsTxnsStressTest::GenerateNextC(ThreadState* thread) {
   uint32_t tid = thread->tid;
-  auto& key_gen = key_gen_for_c_.at(tid);
+  auto& key_gen = key_gen_for_c_[tid];
   return key_gen->Allocate();
 }
 

--- a/env/env_basic_test.cc
+++ b/env/env_basic_test.cc
@@ -390,7 +390,7 @@ TEST_P(EnvMoreTestWithParam, GetChildrenIgnoresDotAndDotDot) {
 
   // expect only one file named `test_data`, i.e. no `.` or `..` names
   ASSERT_EQ(result.size(), 1);
-  ASSERT_EQ(result.at(0), "test_file");
+  ASSERT_EQ(result[0], "test_file");
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -1047,7 +1047,7 @@ Status SerializeArray(const ConfigOptions& config_options,
   }
   if (result.find("=") != std::string::npos) {
     *value = "{" + result + "}";
-  } else if (printed > 1 && result.at(0) == '{') {
+  } else if (printed > 1 && result[0] == '{') {
     *value = "{" + result + "}";
   } else {
     *value = result;
@@ -1179,7 +1179,7 @@ Status SerializeVector(const ConfigOptions& config_options,
   }
   if (result.find("=") != std::string::npos) {
     *value = "{" + result + "}";
-  } else if (printed > 1 && result.at(0) == '{') {
+  } else if (printed > 1 && result[0] == '{') {
     *value = "{" + result + "}";
   } else {
     *value = result;

--- a/options/customizable.cc
+++ b/options/customizable.cc
@@ -20,8 +20,7 @@ std::string Customizable::GetOptionName(const std::string& long_name) const {
   const std::string& name = Name();
   size_t name_len = name.size();
   if (long_name.size() > name_len + 1 &&
-      long_name.compare(0, name_len, name) == 0 &&
-      long_name.at(name_len) == '.') {
+      long_name.compare(0, name_len, name) == 0 && long_name[name_len] == '.') {
     return long_name.substr(name_len + 1);
   } else {
     return Configurable::GetOptionName(long_name);

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -4244,7 +4244,7 @@ static void TestAndCompareOption(const ConfigOptions& config_options,
   std::string result, mismatch;
   ASSERT_OK(opt_info.Serialize(config_options, opt_name, base_ptr, &result));
   if (strip) {
-    ASSERT_EQ(result.at(0), '{');
+    ASSERT_EQ(result[0], '{');
     ASSERT_EQ(result.at(result.size() - 1), '}');
     result = result.substr(1, result.size() - 2);
   }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2671,7 +2671,7 @@ class CustomFlushBlockPolicy : public FlushBlockPolicyFactory,
   }
 
   bool Update(const Slice&, const Slice&) override {
-    if (keys_in_current_block_ >= keys_per_block_.at(current_block_idx_)) {
+    if (keys_in_current_block_ >= keys_per_block_[current_block_idx_]) {
       ++current_block_idx_;
       keys_in_current_block_ = 1;
       return true;

--- a/third-party/gtest-1.8.1/fused-src/gtest/gtest-all.cc
+++ b/third-party/gtest-1.8.1/fused-src/gtest/gtest-all.cc
@@ -3530,7 +3530,7 @@ TestResult::~TestResult() {
 const TestPartResult& TestResult::GetTestPartResult(int i) const {
   if (i < 0 || i >= total_part_count())
     internal::posix::Abort();
-  return test_part_results_.at(i);
+  return test_part_results_[i];
 }
 
 // Returns the i-th test property. i can range from 0 to
@@ -3539,7 +3539,7 @@ const TestPartResult& TestResult::GetTestPartResult(int i) const {
 const TestProperty& TestResult::GetTestProperty(int i) const {
   if (i < 0 || i >= test_property_count())
     internal::posix::Abort();
-  return test_properties_.at(i);
+  return test_properties_[i];
 }
 
 // Clears the test part results.

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2746,7 +2746,7 @@ GetCommand::GetCommand(const std::vector<std::string>& params,
     exec_state_ = LDBCommandExecuteResult::Failed(
         "<key> must be specified for the get command");
   } else {
-    key_ = params.at(0);
+    key_ = params[0];
   }
 
   if (is_key_hex_) {
@@ -2852,8 +2852,8 @@ BatchPutCommand::BatchPutCommand(
         "Equal number of <key>s and <value>s must be specified for batchput.");
   } else {
     for (size_t i = 0; i < params.size(); i += 2) {
-      std::string key = params.at(i);
-      std::string value = params.at(i + 1);
+      std::string key = params[i];
+      std::string value = params[i + 1];
       key_values_.push_back(std::pair<std::string, std::string>(
           is_key_hex_ ? HexToString(key) : key,
           is_value_hex_ ? HexToString(value) : value));
@@ -3071,7 +3071,7 @@ DeleteCommand::DeleteCommand(const std::vector<std::string>& params,
     exec_state_ = LDBCommandExecuteResult::Failed(
         "KEY must be specified for the delete command");
   } else {
-    key_ = params.at(0);
+    key_ = params[0];
     if (is_key_hex_) {
       key_ = HexToString(key_);
     }
@@ -3107,7 +3107,7 @@ SingleDeleteCommand::SingleDeleteCommand(
     exec_state_ = LDBCommandExecuteResult::Failed(
         "KEY must be specified for the single delete command");
   } else {
-    key_ = params.at(0);
+    key_ = params[0];
     if (is_key_hex_) {
       key_ = HexToString(key_);
     }
@@ -3143,8 +3143,8 @@ DeleteRangeCommand::DeleteRangeCommand(
     exec_state_ = LDBCommandExecuteResult::Failed(
         "begin and end keys must be specified for the delete command");
   } else {
-    begin_key_ = params.at(0);
-    end_key_ = params.at(1);
+    begin_key_ = params[0];
+    end_key_ = params[1];
     if (is_key_hex_) {
       begin_key_ = HexToString(begin_key_);
       end_key_ = HexToString(end_key_);
@@ -3182,8 +3182,8 @@ PutCommand::PutCommand(const std::vector<std::string>& params,
     exec_state_ = LDBCommandExecuteResult::Failed(
         "<key> and <value> must be specified for the put command");
   } else {
-    key_ = params.at(0);
-    value_ = params.at(1);
+    key_ = params[0];
+    value_ = params[1];
   }
 
   if (is_key_hex_) {
@@ -3918,7 +3918,7 @@ WriteExternalSstFilesCommand::WriteExternalSstFilesCommand(
     exec_state_ = LDBCommandExecuteResult::Failed(
         "output SST file path must be specified");
   } else {
-    output_sst_path_ = params.at(0);
+    output_sst_path_ = params[0];
   }
 }
 
@@ -4057,7 +4057,7 @@ IngestExternalSstFilesCommand::IngestExternalSstFilesCommand(
     exec_state_ =
         LDBCommandExecuteResult::Failed("input SST path must be specified");
   } else {
-    input_sst_path_ = params.at(0);
+    input_sst_path_ = params[0];
   }
 }
 
@@ -4160,10 +4160,10 @@ UnsafeRemoveSstFileCommand::UnsafeRemoveSstFileCommand(
         LDBCommandExecuteResult::Failed("SST file number must be specified");
   } else {
     char* endptr = nullptr;
-    sst_file_number_ = strtoull(params.at(0).c_str(), &endptr, 10 /* base */);
+    sst_file_number_ = strtoull(params[0].c_str(), &endptr, 10 /* base */);
     if (endptr == nullptr || *endptr != '\0') {
       exec_state_ = LDBCommandExecuteResult::Failed(
-          "Failed to parse SST file number " + params.at(0));
+          "Failed to parse SST file number " + params[0]);
     }
   }
 }

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -409,7 +409,7 @@ int SSTDumpTool::Run(int argc, char const* const* argv, Options options) {
   // List of RocksDB SST file without corruption
   std::vector<std::string> valid_sst_files;
   for (size_t i = 0; i < filenames.size(); i++) {
-    std::string filename = filenames.at(i);
+    std::string filename = filenames[i];
     if (filename.length() <= 4 ||
         filename.rfind(".sst") != filename.length() - 4) {
       // ignore

--- a/util/filter_bench.cc
+++ b/util/filter_bench.cc
@@ -300,7 +300,7 @@ const std::shared_ptr<const FilterPolicy> &GetPolicy() {
   static std::shared_ptr<const FilterPolicy> policy;
   if (!policy) {
     policy = BloomLikeFilterPolicy::Create(
-        BloomLikeFilterPolicy::GetAllFixedImpls().at(FLAGS_impl),
+        BloomLikeFilterPolicy::GetAllFixedImpls()[FLAGS_impl],
         FLAGS_bits_per_key);
   }
   return policy;

--- a/utilities/transactions/lock/point/point_lock_manager.cc
+++ b/utilities/transactions/lock/point/point_lock_manager.cc
@@ -241,7 +241,7 @@ Status PointLockManager::TryLock(PessimisticTransaction* txn,
   // Need to lock the mutex for the stripe that this key hashes to
   size_t stripe_num = lock_map->GetStripe(key);
   assert(lock_map->lock_map_stripes_.size() > stripe_num);
-  LockMapStripe* stripe = lock_map->lock_map_stripes_.at(stripe_num);
+  LockMapStripe* stripe = lock_map->lock_map_stripes_[stripe_num];
 
   LockInfo lock_info(txn->GetID(), txn->GetExpirationTime(), exclusive);
   int64_t timeout = txn->GetLockTimeout();
@@ -590,7 +590,7 @@ void PointLockManager::UnLock(PessimisticTransaction* txn,
   // Lock the mutex for the stripe that this key hashes to
   size_t stripe_num = lock_map->GetStripe(key);
   assert(lock_map->lock_map_stripes_.size() > stripe_num);
-  LockMapStripe* stripe = lock_map->lock_map_stripes_.at(stripe_num);
+  LockMapStripe* stripe = lock_map->lock_map_stripes_[stripe_num];
 
   stripe->stripe_mutex->Lock().PermitUncheckedError();
   UnLockKey(txn, key, stripe, lock_map, env);
@@ -632,7 +632,7 @@ void PointLockManager::UnLock(PessimisticTransaction* txn,
       auto& stripe_keys = stripe_iter.second;
 
       assert(lock_map->lock_map_stripes_.size() > stripe_num);
-      LockMapStripe* stripe = lock_map->lock_map_stripes_.at(stripe_num);
+      LockMapStripe* stripe = lock_map->lock_map_stripes_[stripe_num];
 
       stripe->stripe_mutex->Lock().PermitUncheckedError();
 


### PR DESCRIPTION
`vector::at` performs bound check at runtime, if out of bound, it will throw.

So it should use `vector::operator[]` instead.