### PR TITLE
JNI native memory leak - release array elements

### DIFF
--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1836,6 +1836,10 @@ inline bool keys_from_bytebuffers(JNIEnv* env,
     jobject jkey = env->GetObjectArrayElement(jkeys, i);
     if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
+      // cleanup jkey_off and jkey_len
+      env->ReleaseIntArrayElements(jkey_lens, jkey_len, JNI_ABORT);
+      env->ReleaseIntArrayElements(jkey_offs, jkey_off, JNI_ABORT);
+
       return false;
     }
     char* key = reinterpret_cast<char*>(env->GetDirectBufferAddress(jkey));
@@ -1844,6 +1848,11 @@ inline bool keys_from_bytebuffers(JNIEnv* env,
 
     env->DeleteLocalRef(jkey);
   }
+
+  // cleanup jkey_off and jkey_len
+  env->ReleaseIntArrayElements(jkey_lens, jkey_len, JNI_ABORT);
+  env->ReleaseIntArrayElements(jkey_offs, jkey_off, JNI_ABORT);
+
   return true;
 }
 

--- a/java/src/test/java/org/rocksdb/MultiGetTest.java
+++ b/java/src/test/java/org/rocksdb/MultiGetTest.java
@@ -11,12 +11,17 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.util.TestUtil;
 
 public class MultiGetTest {
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
   @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
 
   @Test


### PR DESCRIPTION
Closes https://github.com/facebook/rocksdb/issues/10980

Reproduced as per the suggestion in the ticket, and `$ jcmd <PID> VM.native_memory | grep Internal` reports that we are no longer leaking internal memory with the suggested fix.

I did the repro in `MultiGetTest.java` which I have optimized imports on. It did not seem helpful to leave the test code around as it would be onerous to build a memory leak reproducer, and regression seems a remote possibility.