### PR TITLE
replace sprintf with its safe version snprintf (v2)

### DIFF
--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -50,7 +50,7 @@ class BlockBasedTableReaderBaseTest : public testing::Test {
         // Internal key is constructed directly from this key,
         // and internal key size is required to be >= 8 bytes,
         // so use %08u as the format string.
-        sprintf(k, "%08u", key);
+        snprintf(k, sizeof(k), "%08u", key);
         std::string v;
         if (mixed_with_human_readable_string_value) {
           v = (block % 2) ? rnd.HumanReadableString(256)


### PR DESCRIPTION
same motivations as https://github.com/facebook/rocksdb/pull/5475, applied to the last remaining `sprintf`.