### PR TITLE
Fix use of make_unique in Arena::AllocateNewBlock

### DIFF
--- a/memory/arena.cc
+++ b/memory/arena.cc
@@ -143,9 +143,10 @@ char* Arena::AllocateAligned(size_t bytes, size_t huge_page_size,
 }
 
 char* Arena::AllocateNewBlock(size_t block_bytes) {
-  auto uniq = std::make_unique<char[]>(block_bytes);
-  char* block = uniq.get();
-  blocks_.push_back(std::move(uniq));
+  // NOTE: std::make_unique zero-initializes the block so is not appropriate
+  // here
+  char* block = new char[block_bytes];
+  blocks_.push_back(std::unique_ptr<char[]>(block));
 
   size_t allocated_size;
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE


### PR DESCRIPTION
Summary: The change to `make_unique<char[]>` in #10810 inadvertently started initializing data in Arena blocks, which could lead to increased memory use due to (at least on our implementation) force-mapping pages as a result. This change goes back to `new char[]` while keeping all the other good parts of #10810.

Test Plan: unit test added (fails on Linux before fix)