### PR TITLE
Fix an assertion failure in `TimestampTablePropertiesCollector` for empty output

### DIFF
--- a/db/table_properties_collector.h
+++ b/db/table_properties_collector.h
@@ -150,8 +150,10 @@ class TimestampTablePropertiesCollector : public IntTblPropCollector {
   }
 
   Status Finish(UserCollectedProperties* properties) override {
+    // timestamp is empty is table is empty
     assert(timestamp_min_.size() == timestamp_max_.size() &&
-           timestamp_max_.size() == cmp_->timestamp_size());
+           (timestamp_min_.empty() ||
+            timestamp_max_.size() == cmp_->timestamp_size()));
     properties->insert({"rocksdb.timestamp_min", timestamp_min_});
     properties->insert({"rocksdb.timestamp_max", timestamp_max_});
     return Status::OK();


### PR DESCRIPTION
Summary: when the compaction output file is empty, the assertion in `TimestampTablePropertiesCollector::Finish()` breaks. This PR fixes this assert and added unit test.

Test plan: added UT.