### PR TITLE
Java API consistency between RocksDB.put() , .merge() and Transaction.put() , .merge()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -303,22 +303,6 @@ For Leveled Compaction users, `CompactRange()` with `bottommost_level_compaction
 * Updated xxHash source code, which should improve kXXH3 checksum speed, at least on ARM (#11098).
 * Improved CPU efficiency of DB reads, from block cache access improvements (#10975).
 
-* Java API extensions to improve consistency and completeness of APIs
-  * Extended `RocksDB.get( ... ByteBuffer key, ByteBuffer value ...)` which now accepts indirect buffer parameters as well as direct buffer parameters
-  * Extended `RocksDB.put( ... ByteBuffer key, ByteBuffer value ...)` which now accepts indirect buffer parameters as well as direct buffer parameters
-  * Added `RocksDB.merge( ... ByteBuffer key, ByteBuffer value ...)` methods with the same parameter options as `put(...)` - direct and indirect buffers are supported
-  * Added `RocksIterator.key( ... byte[] key, byte[] value ...)` methods which retrieve the iterator key into the supplied buffer
-  * Added `RocksIterator.value( ... byte[] key, byte[] value ...)` methods which retrieve the iterator value into the supplied buffer
-  * Deprecated `get(final ColumnFamilyHandle columnFamilyHandle, final ReadOptions readOptions, byte[])` in favour of `get(final ReadOptions readOptions, final ColumnFamilyHandle columnFamilyHandle, byte[])` which has consistent parameter ordering with other methods in the same class
-  * Added `Transaction.get( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
-  * Added `Transaction.get( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
- * Added `Transaction.getForUpdate( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
-  * Added `Transaction.getForUpdate( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
-  * Added `Transaction.getIterator()` method as a convenience which defaults the `ReadOptions` value supplied to existing `Transaction.iterator()` methods. This mirrors the existing `RocksDB.iterator()` method.
-  * Added `Transaction.put( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written in a `ByteBuffer` parameter
-  * Added `Transaction.merge( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
-  * Added `Transaction.mergeUntracked( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
- 
 ## 7.9.0 (11/21/2022)
 ### Performance Improvements
 * Fixed an iterator performance regression for delete range users when scanning through a consecutive sequence of range tombstones (#10877).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -303,6 +303,16 @@ For Leveled Compaction users, `CompactRange()` with `bottommost_level_compaction
 * Updated xxHash source code, which should improve kXXH3 checksum speed, at least on ARM (#11098).
 * Improved CPU efficiency of DB reads, from block cache access improvements (#10975).
 
+* Java API extensions to improve consistency and completeness of APIs
+  * Extended `RocksDB.get( ... ByteBuffer key, ByteBuffer value ...)` which now accepts indirect buffer parameters as well as direct buffer parameters
+  * Extended `RocksDB.put( ... ByteBuffer key, ByteBuffer value ...)` which now accepts indirect buffer parameters as well as direct buffer parameters
+  * Added `RocksDB.merge( ... ByteBuffer key, ByteBuffer value ...)` methods with the same parameter options as `put(...)` - direct and indirect buffers are supported
+  * Added `RocksIterator.key( ... byte[] key, byte[] value ...)` methods which retrieve the iterator key into the supplied buffer
+  * Added `RocksIterator.value( ... byte[] key, byte[] value ...)` methods which retrieve the iterator value into the supplied buffer
+  * Deprecated `get(final ColumnFamilyHandle columnFamilyHandle, final ReadOptions readOptions, byte[])` in favour of `get(final ReadOptions readOptions, final ColumnFamilyHandle columnFamilyHandle, byte[])` which has consistent parameter ordering with other methods in the same class
+  * Added `Transaction.get( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
+  * Added `Transaction.get( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
+ 
 ## 7.9.0 (11/21/2022)
 ### Performance Improvements
 * Fixed an iterator performance regression for delete range users when scanning through a consecutive sequence of range tombstones (#10877).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -312,6 +312,12 @@ For Leveled Compaction users, `CompactRange()` with `bottommost_level_compaction
   * Deprecated `get(final ColumnFamilyHandle columnFamilyHandle, final ReadOptions readOptions, byte[])` in favour of `get(final ReadOptions readOptions, final ColumnFamilyHandle columnFamilyHandle, byte[])` which has consistent parameter ordering with other methods in the same class
   * Added `Transaction.get( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
   * Added `Transaction.get( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
+ * Added `Transaction.getForUpdate( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
+  * Added `Transaction.getForUpdate( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
+  * Added `Transaction.getIterator()` method as a convenience which defaults the `ReadOptions` value supplied to existing `Transaction.iterator()` methods. This mirrors the existing `RocksDB.iterator()` method.
+  * Added `Transaction.put( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written in a `ByteBuffer` parameter
+  * Added `Transaction.merge( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
+  * Added `Transaction.mergeUntracked( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
  
 ## 7.9.0 (11/21/2022)
 ### Performance Improvements

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -286,6 +286,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/WriteBufferManager.java
   src/main/java/org/rocksdb/WriteStallCondition.java
   src/main/java/org/rocksdb/WriteStallInfo.java
+  src/main/java/org/rocksdb/util/BufferUtil.java
   src/main/java/org/rocksdb/util/ByteUtil.java
   src/main/java/org/rocksdb/util/BytewiseComparator.java
   src/main/java/org/rocksdb/util/Environment.java

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -168,6 +168,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/FlushJobInfo.java
   src/main/java/org/rocksdb/FlushReason.java
   src/main/java/org/rocksdb/FlushOptions.java
+  src/main/java/org/rocksdb/GetStatus.java
   src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
   src/main/java/org/rocksdb/HashSkipListMemTableConfig.java
   src/main/java/org/rocksdb/HistogramData.java

--- a/java/GetBenchmarks.md
+++ b/java/GetBenchmarks.md
@@ -8,16 +8,16 @@ Mac
 ```
 make clean jclean
 DEBUG_LEVEL=0 make -j12 rocksdbjava
-(cd java/target; cp rocksdbjni-7.9.0-osx.jar rocksdbjni-7.9.0-SNAPSHOT-osx.jar)
-mvn install:install-file -Dfile=./java/target/rocksdbjni-7.9.0-SNAPSHOT-osx.jar -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.9.0-SNAPSHOT -Dpackaging=jar
+(cd java/target; cp rocksdbjni-7.10.0-osx.jar rocksdbjni-7.10.0-SNAPSHOT-osx.jar)
+mvn install:install-file -Dfile=./java/target/rocksdbjni-7.10.0-SNAPSHOT-osx.jar -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
 ```
 
 Linux
 ```
 make clean jclean
 DEBUG_LEVEL=0 make -j12 rocksdbjava
-(cd java/target; cp rocksdbjni-7.9.0-linux64.jar rocksdbjni-7.9.0-SNAPSHOT-linux64.jar)
-mvn install:install-file -Dfile=./java/target/rocksdbjni-7.9.0-SNAPSHOT-linux64.jar -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.9.0-SNAPSHOT -Dpackaging=jar
+(cd java/target; cp rocksdbjni-7.10.0-linux64.jar rocksdbjni-7.10.0-SNAPSHOT-linux64.jar)
+mvn install:install-file -Dfile=./java/target/rocksdbjni-7.10.0-SNAPSHOT-linux64.jar -DgroupId=org.rocksdb -DartifactId=rocksdbjni -Dversion=7.10.0-SNAPSHOT -Dpackaging=jar
 ```
 
 Build jmh test package, on either platform

--- a/java/GetPutBenchmarks.md
+++ b/java/GetPutBenchmarks.md
@@ -35,37 +35,23 @@ The long performance run (as big as we can make it on our Ubuntu box without fil
 java -jar target/rocksdbjni-jmh-1.0-SNAPSHOT-benchmarks.jar -p keyCount=1000,50000 -p keySize=128 -p valueSize=1024,16384 -p columnFamilyTestType="1_column_family","20_column_families" GetBenchmarks.get GetBenchmarks.preallocatedByteBufferGet GetBenchmarks.preallocatedGet
 ```
 
-## Results (small runs, Mac)
-
-These are run on a 10-core M1 with 64GB of memory and 2TB of SSD.
-They probably reflect the absolute best case for this optimization, hitting in-memory buffers and completely eliminating a buffer copy.
-
-### Before
-Benchmark                                (columnFamilyTestType)  (keyCount)  (keySize)  (multiGetSize)  (valueSize)   Mode  Cnt          Score        Error  Units
-GetBenchmarks.get                              no_column_family        1000        128             N/A        32768  thrpt   25      43496.578 ±   5743.090  ops/s
-GetBenchmarks.preallocatedByteBufferGet        no_column_family        1000        128             N/A        32768  thrpt   25      70765.578 ±    697.548  ops/s
-GetBenchmarks.preallocatedGet                  no_column_family        1000        128             N/A        32768  thrpt   25      69883.554 ±    944.184  ops/s
-
-### After fixing byte[] (.get and .preallocatedGet)
-
-Benchmark                                (columnFamilyTestType)  (keyCount)  (keySize)  (multiGetSize)  (valueSize)   Mode  Cnt          Score        Error  Units
-GetBenchmarks.get                              no_column_family        1000        128             N/A        32768  thrpt   25     149207.681 ±   2261.671  ops/s
-GetBenchmarks.preallocatedByteBufferGet        no_column_family        1000        128             N/A        32768  thrpt   25      68920.489 ±   1574.664  ops/s
-GetBenchmarks.preallocatedGet                  no_column_family        1000        128             N/A        32768  thrpt   25     177399.022 ±   2107.375  ops/s
-
-### After fixing ByteBuffer (.preallocatedByteBufferGet)
-
-Benchmark                                (columnFamilyTestType)  (keyCount)  (keySize)  (multiGetSize)  (valueSize)   Mode  Cnt          Score        Error  Units
-GetBenchmarks.get                              no_column_family        1000        128             N/A        32768  thrpt   25     150389.259 ±   1371.473  ops/s
-GetBenchmarks.preallocatedByteBufferGet        no_column_family        1000        128             N/A        32768  thrpt   25     179919.468 ±   1670.714  ops/s
-GetBenchmarks.preallocatedGet                  no_column_family        1000        128             N/A        32768  thrpt   25     178261.938 ±   2630.571  ops/s
 ## Results (Ubuntu, big runs)
+
+NB - we have removed some test results we initially observed on Mac which were not later reproducible.
+
 These take 3-4 hours
 ```
 java -jar target/rocksdbjni-jmh-1.0-SNAPSHOT-benchmarks.jar -p keyCount=1000,50000 -p keySize=128 -p valueSize=1024,16384 -p columnFamilyTestType="1_column_family","20_column_families" GetBenchmarks.get GetBenchmarks.preallocatedByteBufferGet GetBenchmarks.preallocatedGet
 ```
 It's clear that all `get()` variants have noticeably improved performance, though not the spectacular gains of the M1.
 ### With fixes for all of the `get()` instances
+
+The tests which use methods which have had performance improvements applied are:
+```java
+get()
+preallocatedGet()
+preallocatedByteBufferGet()
+```
 
 Benchmark                                (columnFamilyTestType)  (keyCount)  (keySize)  (valueSize)   Mode  Cnt        Score       Error  Units
 GetBenchmarks.get                               1_column_family        1000        128         1024  thrpt   25   935648.793 ± 22879.910  ops/s
@@ -158,4 +144,61 @@ GetBenchmarks.preallocatedGet                no_column_families        1000     
 ## Conclusion
 
 The performance improvement is real.
+
+# Put Performance Benchmarks
+
+Results associated with [Java API consistency between RocksDB.put() , .merge() and Transaction.put() , .merge()](https://github.com/facebook/rocksdb/pull/11019)
+
+This work was not designed specifically as a performance optimization, but we want to confirm that it has not regressed what it has changed, and to provide
+a baseline for future possible performance work.
+
+## Build/Run
+
+Building is as above. Running is a different invocation of the same JMH jar.
+```
+java -jar target/rocksdbjni-jmh-1.0-SNAPSHOT-benchmarks.jar -p keyCount=1000,50000 -p keySize=128 -p valueSize=1024,32768 -p columnFamilyTestType="no_column_family" PutBenchmarks
+```
+
+## Before Changes
+
+These results were generated in a private branch with the `PutBenchmarks` from the PR backported onto the current *main*.
+
+Benchmark                     (bufferListSize)  (columnFamilyTestType)  (keyCount)  (keySize)  (valueSize)   Mode  Cnt      Score      Error  Units
+PutBenchmarks.put                           16        no_column_family        1000        128         1024  thrpt   25  76670.200 ± 2555.248  ops/s
+PutBenchmarks.put                           16        no_column_family        1000        128        32768  thrpt   25   3913.692 ±  225.690  ops/s
+PutBenchmarks.put                           16        no_column_family       50000        128         1024  thrpt   25  74479.589 ±  988.361  ops/s
+PutBenchmarks.put                           16        no_column_family       50000        128        32768  thrpt   25   4070.800 ±  194.838  ops/s
+PutBenchmarks.putByteArrays                 16        no_column_family        1000        128         1024  thrpt   25  72150.853 ± 1744.216  ops/s
+PutBenchmarks.putByteArrays                 16        no_column_family        1000        128        32768  thrpt   25   3896.646 ±  188.629  ops/s
+PutBenchmarks.putByteArrays                 16        no_column_family       50000        128         1024  thrpt   25  71753.287 ± 1053.904  ops/s
+PutBenchmarks.putByteArrays                 16        no_column_family       50000        128        32768  thrpt   25   3928.503 ±  264.443  ops/s
+PutBenchmarks.putByteBuffers                16        no_column_family        1000        128         1024  thrpt   25  72595.105 ± 1027.258  ops/s
+PutBenchmarks.putByteBuffers                16        no_column_family        1000        128        32768  thrpt   25   3890.100 ±  199.131  ops/s
+PutBenchmarks.putByteBuffers                16        no_column_family       50000        128         1024  thrpt   25  70878.133 ± 1181.601  ops/s
+PutBenchmarks.putByteBuffers                16        no_column_family       50000        128        32768  thrpt   25   3863.181 ±  215.888  ops/s
+
+## After Changes
+
+These results were generated on the PR branch.
+
+Benchmark                     (bufferListSize)  (columnFamilyTestType)  (keyCount)  (keySize)  (valueSize)   Mode  Cnt      Score      Error  Units
+PutBenchmarks.put                           16        no_column_family        1000        128         1024  thrpt   25  75178.751 ± 2644.775  ops/s
+PutBenchmarks.put                           16        no_column_family        1000        128        32768  thrpt   25   3937.175 ±  257.039  ops/s
+PutBenchmarks.put                           16        no_column_family       50000        128         1024  thrpt   25  74375.519 ± 1776.654  ops/s
+PutBenchmarks.put                           16        no_column_family       50000        128        32768  thrpt   25   4013.413 ±  257.706  ops/s
+PutBenchmarks.putByteArrays                 16        no_column_family        1000        128         1024  thrpt   25  71418.303 ± 1610.977  ops/s
+PutBenchmarks.putByteArrays                 16        no_column_family        1000        128        32768  thrpt   25   4027.581 ±  227.900  ops/s
+PutBenchmarks.putByteArrays                 16        no_column_family       50000        128         1024  thrpt   25  71229.107 ± 2720.083  ops/s
+PutBenchmarks.putByteArrays                 16        no_column_family       50000        128        32768  thrpt   25   4022.635 ±  212.540  ops/s
+PutBenchmarks.putByteBuffers                16        no_column_family        1000        128         1024  thrpt   25  71718.501 ±  787.537  ops/s
+PutBenchmarks.putByteBuffers                16        no_column_family        1000        128        32768  thrpt   25   4078.050 ±  176.331  ops/s
+PutBenchmarks.putByteBuffers                16        no_column_family       50000        128         1024  thrpt   25  72736.754 ±  828.971  ops/s
+PutBenchmarks.putByteBuffers                16        no_column_family       50000        128        32768  thrpt   25   3987.232 ±  205.577  ops/s
+
+## Discussion
+
+The changes don't appear to have had a material effect on performance. We are happy with this.
+
+ * We would obviously advise running future changes before and after to confirm they have no adverse effects.
+
 

--- a/java/Makefile
+++ b/java/Makefile
@@ -150,7 +150,9 @@ JAVA_TESTS = \
 	org.rocksdb.LRUCacheTest\
 	org.rocksdb.MemoryUtilTest\
 	org.rocksdb.MemTableTest\
+	org.rocksdb.MergeCFVariantsTest\
 	org.rocksdb.MergeTest\
+	org.rocksdb.MergeVariantsTest\
 	org.rocksdb.MultiColumnRegressionTest \
 	org.rocksdb.MultiGetManyKeysTest\
 	org.rocksdb.MultiGetTest\
@@ -167,6 +169,8 @@ JAVA_TESTS = \
 	org.rocksdb.OptionsTest\
 	org.rocksdb.PerfLevelTest \
 	org.rocksdb.PerfContextTest \
+	org.rocksdb.PutCFVariantsTest\
+	org.rocksdb.PutVariantsTest\
 	org.rocksdb.PlainTableConfigTest\
 	org.rocksdb.RateLimiterTest\
 	org.rocksdb.ReadOnlyTest\

--- a/java/jmh/src/main/java/org/rocksdb/jmh/PutBenchmarks.java
+++ b/java/jmh/src/main/java/org/rocksdb/jmh/PutBenchmarks.java
@@ -6,9 +6,7 @@
  */
 package org.rocksdb.jmh;
 
-import org.openjdk.jmh.annotations.*;
-import org.rocksdb.*;
-import org.rocksdb.util.FileUtils;
+import static org.rocksdb.util.KVUtils.ba;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -18,8 +16,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.rocksdb.util.KVUtils.ba;
+import org.openjdk.jmh.annotations.*;
+import org.rocksdb.*;
+import org.rocksdb.util.FileUtils;
 
 @State(Scope.Benchmark)
 public class PutBenchmarks {
@@ -152,10 +151,10 @@ public class PutBenchmarks {
         if (buffers.isEmpty()) {
           try {
             Thread.sleep(1000);
-            } catch (InterruptedException ie) {
-              return null;
-            }
-            continue;  
+          } catch (InterruptedException ie) {
+            return null;
+          }
+          continue;
         }
         return buffers.remove(0);
       }
@@ -202,14 +201,20 @@ public class PutBenchmarks {
 
   @Benchmark
   public void putByteBuffers(final Counter counter) throws RocksDBException {
-    ByteBuffer keyBuf = borrow(keyBuffersBB); keyBuf.clear();
-    ByteBuffer valueBuf = borrow(valueBuffersBB); valueBuf.clear();
+    ByteBuffer keyBuf = borrow(keyBuffersBB);
+    keyBuf.clear();
+    ByteBuffer valueBuf = borrow(valueBuffersBB);
+    valueBuf.clear();
 
     final int i = counter.next();
     final byte[] keyPrefix = ba("key" + i);
     final byte[] valuePrefix = ba("value" + i);
-    keyBuf.put(keyPrefix, 0, keyPrefix.length); keyBuf.position(keySize); keyBuf.flip();
-    valueBuf.put(valuePrefix, 0, valuePrefix.length); valueBuf.position(valueSize); valueBuf.flip();
+    keyBuf.put(keyPrefix, 0, keyPrefix.length);
+    keyBuf.position(keySize);
+    keyBuf.flip();
+    valueBuf.put(valuePrefix, 0, valuePrefix.length);
+    valueBuf.position(valueSize);
+    valueBuf.flip();
     db.put(getColumnFamily(), new WriteOptions(), keyBuf, valueBuf);
 
     repay(keyBuffersBB, keyBuf);

--- a/java/jmh/src/main/java/org/rocksdb/jmh/PutBenchmarks.java
+++ b/java/jmh/src/main/java/org/rocksdb/jmh/PutBenchmarks.java
@@ -11,9 +11,11 @@ import org.rocksdb.*;
 import org.rocksdb.util.FileUtils;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -30,12 +32,24 @@ public class PutBenchmarks {
   })
   String columnFamilyTestType;
 
+  @Param({"1000", "100000"}) int keyCount;
+
+  @Param({"12", "64", "128"}) int keySize;
+
+  @Param({"64", "1024", "65536"}) int valueSize;
+
+  @Param({"16"}) int bufferListSize;
+
   Path dbDir;
   DBOptions options;
   int cfs = 0;  // number of column families
   private AtomicInteger cfHandlesIdx;
   ColumnFamilyHandle[] cfHandles;
   RocksDB db;
+  List<byte[]> keyBuffers = new ArrayList<>(bufferListSize);
+  List<byte[]> valueBuffers = new ArrayList<>(bufferListSize);
+  List<ByteBuffer> keyBuffersBB = new ArrayList<>(bufferListSize);
+  List<ByteBuffer> valueBuffersBB = new ArrayList<>(bufferListSize);
 
   @Setup(Level.Trial)
   public void setup() throws IOException, RocksDBException {
@@ -68,6 +82,34 @@ public class PutBenchmarks {
     final List<ColumnFamilyHandle> cfHandlesList = new ArrayList<>(cfDescriptors.size());
     db = RocksDB.open(options, dbDir.toAbsolutePath().toString(), cfDescriptors, cfHandlesList);
     cfHandles = cfHandlesList.toArray(new ColumnFamilyHandle[0]);
+
+    for (int i = 0; i < bufferListSize; i++) {
+      final byte[] keyArr = new byte[keySize];
+      Arrays.fill(keyArr, (byte) 0x30);
+      keyBuffers.add(keyArr);
+    }
+
+    for (int i = 0; i < bufferListSize; i++) {
+      final byte[] valueArr = new byte[valueSize];
+      Arrays.fill(valueArr, (byte) 0x30);
+      valueBuffers.add(valueArr);
+    }
+
+    for (int i = 0; i < bufferListSize; i++) {
+      final ByteBuffer keyBB = ByteBuffer.allocateDirect(keySize);
+      byte[] keyArr = new byte[keySize];
+      Arrays.fill(keyArr, (byte) 0x30);
+      keyBB.put(keyArr);
+      keyBuffersBB.add(keyBB);
+    }
+
+    for (int i = 0; i < bufferListSize; i++) {
+      final ByteBuffer valueBB = ByteBuffer.allocateDirect(valueSize);
+      byte[] valueArr = new byte[valueSize];
+      Arrays.fill(valueArr, (byte) 0x30);
+      valueBB.put(valueArr);
+      valueBuffersBB.add(valueBB);
+    }
   }
 
   @TearDown(Level.Trial)
@@ -104,9 +146,73 @@ public class PutBenchmarks {
     }
   }
 
+  private <T> T borrow(final List<T> buffers) {
+    synchronized (buffers) {
+      while (true) {
+        if (buffers.isEmpty()) {
+          try {
+            Thread.sleep(1000);
+            } catch (InterruptedException ie) {
+              return null;
+            }
+            continue;  
+        }
+        return buffers.remove(0);
+      }
+    }
+  }
+
+  private <T> void repay(final List<T> buffers, final T buffer) {
+    synchronized (buffers) {
+      buffers.add(buffer);
+    }
+  }
+
   @Benchmark
-  public void put(final ComparatorBenchmarks.Counter counter) throws RocksDBException {
+  public void put(final Counter counter) throws RocksDBException {
+    byte[] keyBuf = borrow(keyBuffers);
+    byte[] valueBuf = borrow(valueBuffers);
+
     final int i = counter.next();
-    db.put(getColumnFamily(), ba("key" + i), ba("value" + i));
+    final byte[] keyPrefix = ba("key" + i);
+    final byte[] valuePrefix = ba("value" + i);
+    System.arraycopy(keyPrefix, 0, keyBuf, 0, keyPrefix.length);
+    System.arraycopy(valuePrefix, 0, valueBuf, 0, valuePrefix.length);
+    db.put(getColumnFamily(), keyBuf, valueBuf);
+
+    repay(keyBuffers, keyBuf);
+    repay(valueBuffers, valueBuf);
+  }
+
+  @Benchmark
+  public void putByteArrays(final Counter counter) throws RocksDBException {
+    byte[] keyBuf = borrow(keyBuffers);
+    byte[] valueBuf = borrow(valueBuffers);
+
+    final int i = counter.next();
+    final byte[] keyPrefix = ba("key" + i);
+    final byte[] valuePrefix = ba("value" + i);
+    System.arraycopy(keyPrefix, 0, keyBuf, 0, keyPrefix.length);
+    System.arraycopy(valuePrefix, 0, valueBuf, 0, valuePrefix.length);
+    db.put(getColumnFamily(), new WriteOptions(), keyBuf, valueBuf);
+
+    repay(keyBuffers, keyBuf);
+    repay(valueBuffers, valueBuf);
+  }
+
+  @Benchmark
+  public void putByteBuffers(final Counter counter) throws RocksDBException {
+    ByteBuffer keyBuf = borrow(keyBuffersBB); keyBuf.clear();
+    ByteBuffer valueBuf = borrow(valueBuffersBB); valueBuf.clear();
+
+    final int i = counter.next();
+    final byte[] keyPrefix = ba("key" + i);
+    final byte[] valuePrefix = ba("value" + i);
+    keyBuf.put(keyPrefix, 0, keyPrefix.length); keyBuf.position(keySize); keyBuf.flip();
+    valueBuf.put(valuePrefix, 0, valuePrefix.length); valueBuf.position(valueSize); valueBuf.flip();
+    db.put(getColumnFamily(), new WriteOptions(), keyBuf, valueBuf);
+
+    repay(keyBuffersBB, keyBuf);
+    repay(valueBuffersBB, valueBuf);
   }
 }

--- a/java/pmd-rules.xml
+++ b/java/pmd-rules.xml
@@ -21,6 +21,7 @@
         <exclude name="FieldNamingConventions"/>
         <exclude name="FormalParameterNamingConventions"/>
         <exclude name="LinguisticNaming"/>
+        <exclude name="ConfusingTernary"/>
         <!-- These could be fixed if we take the time to do it -->
         <exclude name="CommentDefaultAccessModifier"/>
         <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file defines helper methods for Java API write methods
+//
+
+#pragma once
+
+#include <functional>
+#include <cstring>
+
+#include <jni.h>
+
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/status.h"
+#include "rocksdb/slice.h"
+
+namespace ROCKSDB_NAMESPACE {
+class JByteArraySlice {
+ public:
+  JByteArraySlice(JNIEnv* env, const jbyteArray& jarray, const jint jarray_off, const jint jarray_len) : array_(new jbyte[jarray_len]),
+  slice_(reinterpret_cast<char*>(array_), jarray_len) {
+    env->GetByteArrayRegion(jarray, jarray_off, jarray_len, array_);
+    if (env->ExceptionCheck()) {
+        slice_.clear();
+        delete[] array_;
+    }
+  };
+
+ ~JByteArraySlice() {
+    slice_.clear();
+    delete[] array_;
+ };
+
+ Slice& slice() {
+   return slice_;
+ }
+
+ private:
+  jbyte* array_;
+  Slice slice_;
+};
+
+class KVHelperJNI {
+ public:
+  static bool IfEnvOK(JNIEnv* env, std::function<Status()> fn) {
+    if (env->ExceptionCheck()) {
+        return false;
+    }
+    auto status = fn();
+    if (status.ok()) {
+        return true;
+    }
+    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
+    return false;
+  }
+};
+
+}

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -8,35 +8,35 @@
 
 #pragma once
 
-#include <functional>
-#include <cstring>
-
 #include <jni.h>
 
+#include <cstring>
+#include <functional>
+
 #include "rocksdb/rocksdb_namespace.h"
-#include "rocksdb/status.h"
 #include "rocksdb/slice.h"
+#include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
 class JByteArraySlice {
  public:
-  JByteArraySlice(JNIEnv* env, const jbyteArray& jarray, const jint jarray_off, const jint jarray_len) : array_(new jbyte[jarray_len]),
-  slice_(reinterpret_cast<char*>(array_), jarray_len) {
+  JByteArraySlice(JNIEnv* env, const jbyteArray& jarray, const jint jarray_off,
+                  const jint jarray_len)
+      : array_(new jbyte[jarray_len]),
+        slice_(reinterpret_cast<char*>(array_), jarray_len) {
     env->GetByteArrayRegion(jarray, jarray_off, jarray_len, array_);
     if (env->ExceptionCheck()) {
-        slice_.clear();
-        delete[] array_;
+      slice_.clear();
+      delete[] array_;
     }
   };
 
- ~JByteArraySlice() {
+  ~JByteArraySlice() {
     slice_.clear();
     delete[] array_;
- };
+  };
 
- Slice& slice() {
-   return slice_;
- }
+  Slice& slice() { return slice_; }
 
  private:
   jbyte* array_;
@@ -47,15 +47,15 @@ class KVHelperJNI {
  public:
   static bool IfEnvOK(JNIEnv* env, std::function<Status()> fn) {
     if (env->ExceptionCheck()) {
-        return false;
+      return false;
     }
     auto status = fn();
     if (status.ok()) {
-        return true;
+      return true;
     }
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
     return false;
   }
 };
 
-}
+}  // namespace ROCKSDB_NAMESPACE

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -203,7 +203,7 @@ class JByteArrayPinnableSlice {
     KVException::ThrowOnError(
         env_);  // exception thrown: ArrayIndexOutOfBoundsException
 
-    return result_len;
+    return pinnable_len;
   };
 
   /**
@@ -272,7 +272,7 @@ class JDirectBufferPinnableSlice {
     const jint result_len = std::min(jbuffer_len_, pinnable_len);
 
     memcpy(buffer_, pinnable_slice_.data(), result_len);
-    return result_len;
+    return pinnable_len;
   };
 
  private:

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -48,25 +48,117 @@ class JByteArraySlice {
 class JByteBufferSlice {
  public:
   JByteBufferSlice(JNIEnv* env, const jobject& jbuffer, const jint jbuffer_off,
-                  const jint jbuffer_len) : slice_(static_cast<char *>(env->GetDirectBufferAddress(jbuffer)), jbuffer_len) {
-if (env->ExceptionCheck()) {
-  slice_.clear();
-  return;
-}
-jlong capacity = env->GetDirectBufferCapacity(jbuffer);
-if (capacity < jbuffer_off + jbuffer_len) {
-  auto message = "Direct buffer offset " + std::to_string(jbuffer_off) + " + length " + std::to_string(jbuffer_len) +
-  " exceeds capacity " + std::to_string(capacity);
-  ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, message);
-  slice_.clear();
-}
-                  }
+                   const jint jbuffer_len)
+      : slice_(static_cast<char*>(env->GetDirectBufferAddress(jbuffer)) +
+                   jbuffer_off,
+               jbuffer_len) {
+    if (env->ExceptionCheck()) {
+      slice_.clear();
+      return;
+    }
+    jlong capacity = env->GetDirectBufferCapacity(jbuffer);
+    if (capacity < jbuffer_off + jbuffer_len) {
+      auto message = "Direct buffer offset " + std::to_string(jbuffer_off) +
+                     " + length " + std::to_string(jbuffer_len) +
+                     " exceeds capacity " + std::to_string(capacity);
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, message);
+      slice_.clear();
+    }
+  }
+
+  ~JByteBufferSlice() { slice_.clear(); };
 
   Slice& slice() { return slice_; }
 
  private:
   Slice slice_;
  
+};
+
+class JByteArrayPinnableSlice {
+ public:
+  JByteArrayPinnableSlice(JNIEnv* env, const jbyteArray& jbuffer,
+                          const jint jbuffer_off, const jint jbuffer_len)
+      : env_(env),
+        jbuffer_(jbuffer),
+        jbuffer_off_(jbuffer_off),
+        jbuffer_len_(jbuffer_len){};
+  PinnableSlice& pinnable_slice() { return pinnable_slice_; }
+
+  ~JByteArrayPinnableSlice() { pinnable_slice_.Reset(); };
+
+  /**
+   * @brief copy back contents of the pinnable slice into the Java ByteBuffer
+   *
+   * @return jint min of size of buffer and number of bytes in value for
+   * requested key
+   */
+  jint Retrieve() {
+    if (env_->ExceptionCheck()) {
+      return -1;
+    }
+    const jint pinnable_len = static_cast<jint>(pinnable_slice_.size());
+    const jint result_len = std::min(jbuffer_len_, pinnable_len);
+
+    env_->SetByteArrayRegion(
+        jbuffer_, jbuffer_off_, result_len,
+        reinterpret_cast<const jbyte*>(pinnable_slice_.data()));
+    pinnable_slice_.Reset();
+    return result_len;
+  };
+
+ private:
+  JNIEnv* env_;
+  jbyteArray jbuffer_;
+  jint jbuffer_off_;
+  jint jbuffer_len_;
+  PinnableSlice pinnable_slice_;
+};
+
+class JByteBufferPinnableSlice {
+ public:
+  JByteBufferPinnableSlice(JNIEnv* env, const jobject& jbuffer,
+                           const jint jbuffer_off, const jint jbuffer_len)
+      : env_(env),
+        buffer_(static_cast<char*>(env->GetDirectBufferAddress(jbuffer)) +
+                jbuffer_off),
+        jbuffer_len_(jbuffer_len) {
+    jlong capacity = env->GetDirectBufferCapacity(jbuffer);
+    if (capacity < jbuffer_off + jbuffer_len) {
+      auto message = "Direct buffer offset " + std::to_string(jbuffer_off) +
+                     " + length " + std::to_string(jbuffer_len) +
+                     " exceeds capacity " + std::to_string(capacity);
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, message);
+    }
+  };
+
+  PinnableSlice& pinnable_slice() { return pinnable_slice_; }
+
+  ~JByteBufferPinnableSlice() { pinnable_slice_.Reset(); };
+
+  /**
+   * @brief copy back contents of the pinnable slice into the Java ByteBuffer
+   *
+   * @return jint min of size of buffer and number of bytes in value for
+   * requested key
+   */
+  jint Retrieve() {
+    if (env_->ExceptionCheck()) {
+      return -1;
+    }
+    const jint pinnable_len = static_cast<jint>(pinnable_slice_.size());
+    const jint result_len = std::min(jbuffer_len_, pinnable_len);
+
+    memcpy(buffer_, pinnable_slice_.data(), result_len);
+    pinnable_slice_.Reset();
+    return result_len;
+  };
+
+ private:
+  JNIEnv* env_;
+  char* buffer_;
+  jint jbuffer_len_;
+  PinnableSlice pinnable_slice_;
 };
 
 class KVHelperJNI {

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -88,7 +88,7 @@ class KVException : public std::exception {
            "JNIEnv. Please check!";
   }
 
-  jint Code() { return kCode_; }
+  jint Code() const { return kCode_; }
 
  private:
   jint kCode_;

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -16,6 +16,7 @@
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
+#include "rocksjni/portal.h"
 
 namespace ROCKSDB_NAMESPACE {
 class JByteArraySlice {

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -123,7 +123,6 @@ class JByteBufferSlice {
 
  private:
   Slice slice_;
- 
 };
 
 /**

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -67,26 +67,26 @@ class KVHelperJNI {
  */
 class JByteArraySlice {
  public:
-  JByteArraySlice(JNIEnv* env, const jbyteArray& jarray, const jint jarray_off,
-                  const jint jarray_len)
-      : array_(new jbyte[jarray_len]),
-        slice_(reinterpret_cast<char*>(array_), jarray_len) {
-    env->GetByteArrayRegion(jarray, jarray_off, jarray_len, array_);
+  JByteArraySlice(JNIEnv* env, const jbyteArray& jarr, const jint jarr_off,
+                  const jint jarr_len)
+      : arr_(new jbyte[jarr_len]),
+        slice_(reinterpret_cast<char*>(arr_), jarr_len) {
+    env->GetByteArrayRegion(jarr, jarr_off, jarr_len, arr_);
     if (env->ExceptionCheck()) {
       slice_.clear();
-      delete[] array_;
+      delete[] arr_;
     }
   };
 
   ~JByteArraySlice() {
     slice_.clear();
-    delete[] array_;
+    delete[] arr_;
   };
 
   Slice& slice() { return slice_; }
 
  private:
-  jbyte* array_;
+  jbyte* arr_;
   Slice slice_;
 };
 

--- a/java/rocksjni/kv_helper.h
+++ b/java/rocksjni/kv_helper.h
@@ -94,21 +94,6 @@ class KVException : public std::exception {
   jint kCode_;
 };
 
-class KVHelperJNI {
- public:
-  static bool DoWrite(JNIEnv* env, std::function<Status()> fn_write) {
-    if (env->ExceptionCheck()) {
-      return false;
-    }
-    auto status = fn_write();
-    if (status.ok()) {
-      return true;
-    }
-    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
-    return false;
-  }
-};
-
 /**
  * @brief Construct a slice with the contents of a Java byte array
  *

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -26,8 +26,8 @@
 #include "rocksdb/types.h"
 #include "rocksdb/version.h"
 #include "rocksjni/cplusplus_to_java_convert.h"
-#include "rocksjni/portal.h"
 #include "rocksjni/kv_helper.h"
+#include "rocksjni/portal.h"
 
 #ifdef min
 #undef min
@@ -616,7 +616,7 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jobject,
       ROCKSDB_NAMESPACE::WriteOptions();
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value](){
+  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
     return db->Put(default_write_options, key.slice(), value.slice());
   });
 }
@@ -646,9 +646,9 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject,
 
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value](){
-    return db->Put(default_write_options, cf_handle,
-                                            key.slice(), value.slice());
+  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
+    return db->Put(default_write_options, cf_handle, key.slice(),
+                   value.slice());
   });
 }
 
@@ -669,7 +669,7 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jobject,
 
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value](){
+  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
     return db->Put(*write_options, key.slice(), value.slice());
   });
 }
@@ -697,7 +697,7 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BIIJ(
 
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value](){
+  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
     return db->Put(*write_options, cf_handle, key.slice(), value.slice());
   });
 }
@@ -1414,15 +1414,15 @@ void Java_org_rocksdb_RocksDB_mergeDirect(
     JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
     jobject jkey, jint jkey_off, jint jkey_len, jobject jval, jint jval_off,
     jint jval_len, jlong jcf_handle) {
-        auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto* write_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jwrite_options_handle);
   auto* cf_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
 
   auto merge = [&env, &db, &cf_handle, &write_options](
-                 ROCKSDB_NAMESPACE::Slice& key,
-                 ROCKSDB_NAMESPACE::Slice& value) {
+                   ROCKSDB_NAMESPACE::Slice& key,
+                   ROCKSDB_NAMESPACE::Slice& value) {
     ROCKSDB_NAMESPACE::Status s;
     if (cf_handle == nullptr) {
       s = db->Merge(*write_options, key, value);
@@ -1436,8 +1436,7 @@ void Java_org_rocksdb_RocksDB_mergeDirect(
   };
   ROCKSDB_NAMESPACE::JniUtil::kv_op_direct(merge, env, jkey, jkey_off, jkey_len,
                                            jval, jval_off, jval_len);
-
-  }
+}
 
 jlong rocksdb_iterator_helper(
     ROCKSDB_NAMESPACE::DB* db, ROCKSDB_NAMESPACE::ReadOptions read_options,

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -614,11 +614,14 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jobject,
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   static const ROCKSDB_NAMESPACE::WriteOptions default_write_options =
       ROCKSDB_NAMESPACE::WriteOptions();
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return db->Put(default_write_options, key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, db->Put(default_write_options, key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -644,12 +647,15 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject,
     return;
   }
 
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return db->Put(default_write_options, cf_handle, key.slice(),
-                   value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env,
+        db->Put(default_write_options, cf_handle, key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -667,11 +673,14 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jobject,
   auto* write_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jwrite_options_handle);
 
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return db->Put(*write_options, key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, db->Put(*write_options, key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -694,12 +703,14 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BIIJ(
                  "Invalid ColumnFamilyHandle."));
     return;
   }
-
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return db->Put(*write_options, cf_handle, key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, db->Put(*write_options, cf_handle, key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -616,7 +616,7 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jobject,
       ROCKSDB_NAMESPACE::WriteOptions();
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
+  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return db->Put(default_write_options, key.slice(), value.slice());
   });
 }
@@ -646,7 +646,7 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject,
 
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
+  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return db->Put(default_write_options, cf_handle, key.slice(),
                    value.slice());
   });
@@ -669,7 +669,7 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jobject,
 
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
+  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return db->Put(*write_options, key.slice(), value.slice());
   });
 }
@@ -697,7 +697,7 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BIIJ(
 
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
+  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return db->Put(*write_options, cf_handle, key.slice(), value.slice());
   });
 }

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -452,12 +452,12 @@ jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B(
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    getForUpdate
- * Signature: (JJ[BIJZZ)[B
+ * Signature: (JJ[BIIJZZ)[B
  */
-jbyteArray Java_org_rocksdb_Transaction_getForUpdate(
+jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
-    jbyteArray jkey, jint jkey_part_len, jlong jcolumn_family_handle,
-    jboolean jexclusive, jboolean jdo_validate) {
+    jbyteArray jkey, jint jkey_off, jint jkey_part_len,
+    jlong jcolumn_family_handle, jboolean jexclusive, jboolean jdo_validate) {
   auto* read_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jread_options_handle);
   auto* column_family_handle =
@@ -465,8 +465,7 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate(
           jcolumn_family_handle);
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   try {
-    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0 /*jkey_off*/,
-                                           jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
     ROCKSDB_NAMESPACE::JByteArrayPinnableSlice value(env);
     ROCKSDB_NAMESPACE::KVException::ThrowOnError(
         env,
@@ -475,6 +474,68 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate(
     return value.NewByteArray();
   } catch (ROCKSDB_NAMESPACE::KVException&) {
     return nullptr;
+  }
+}
+
+/*
+ * Class:     org_rocksdb_Transaction
+ * Method:    getForUpdate
+ * Signature: (JJ[BII[BIIJZZ)I
+ */
+jint Java_org_rocksdb_Transaction_getForUpdate__JJ_3BII_3BIIJZZ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    jbyteArray jkey, jint jkey_off, jint jkey_part_len, jbyteArray jval,
+    jint jval_off, jint jval_len, jlong jcolumn_family_handle,
+    jboolean jexclusive, jboolean jdo_validate) {
+  auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
+  auto* read_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jread_options_handle);
+  auto* column_family_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
+          jcolumn_family_handle);
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArrayPinnableSlice value(env, jval, jval_off,
+                                                     jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env,
+        txn->GetForUpdate(*read_options, column_family_handle, key.slice(),
+                          &value.pinnable_slice(), jexclusive, jdo_validate));
+    return value.Fetch();
+  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
+    return e.Code();
+  }
+}
+
+/*
+ * Class:     org_rocksdb_Transaction
+ * Method:    getDirectForUpdate
+ * Signature: (JJLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJZZ)I
+ */
+jint Java_org_rocksdb_Transaction_getDirectForUpdate(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    jobject jkey_bb, jint jkey_off, jint jkey_part_len, jobject jval_bb,
+    jint jval_off, jint jval_len, jlong jcolumn_family_handle,
+    jboolean jexclusive, jboolean jdo_validate) {
+  auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
+  auto* read_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jread_options_handle);
+  auto* column_family_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
+          jcolumn_family_handle);
+
+  try {
+    ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off,
+                                              jkey_part_len);
+    ROCKSDB_NAMESPACE::JDirectBufferPinnableSlice value(env, jval_bb, jval_off,
+                                                        jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env,
+        txn->GetForUpdate(*read_options, column_family_handle, key.slice(),
+                          &value.pinnable_slice(), jexclusive, jdo_validate));
+    return value.Fetch();
+  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
+    return e.Code();
   }
 }
 

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -162,12 +162,13 @@ typedef std::function<ROCKSDB_NAMESPACE::Status(
 // TODO(AR) consider refactoring to share this between here and rocksjni.cc
 jbyteArray txn_get_helper(JNIEnv* env, const FnGet& fn_get,
                           const jlong& jread_options_handle,
-                          const jbyteArray& jkey, const jint& jkey_off, const jint& jkey_part_len) {
-  //TODO (AP) - implement the jkey_off value
-  // I (AP) would prefer to refactor txn_get_helper completely away
-  // And to improve get performance at the same time.
-  // By replacing the obsolete and extra-copying fn_get(... std::string&)                        
-  assert (jkey_off == 0);
+                          const jbyteArray& jkey, const jint& jkey_off,
+                          const jint& jkey_part_len) {
+  // TODO (AP) - implement the jkey_off value
+  //  I (AP) would prefer to refactor txn_get_helper completely away
+  //  And to improve get performance at the same time.
+  //  By replacing the obsolete and extra-copying fn_get(... std::string&)
+  assert(jkey_off == 0);
   jbyte* key = env->GetByteArrayElements(jkey, nullptr);
   if (key == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -217,7 +218,8 @@ jbyteArray txn_get_helper(JNIEnv* env, const FnGet& fn_get,
  */
 jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIIJ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
-    jbyteArray jkey, jint jkey_off, jint jkey_part_len, jlong jcolumn_family_handle) {
+    jbyteArray jkey, jint jkey_off, jint jkey_part_len,
+    jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
@@ -229,7 +231,8 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIIJ(
           const ROCKSDB_NAMESPACE::Slice&, std::string*)>(
           &ROCKSDB_NAMESPACE::Transaction::Get, txn, std::placeholders::_1,
           column_family_handle, std::placeholders::_2, std::placeholders::_3);
-  return txn_get_helper(env, fn_get, jread_options_handle, jkey, jkey_off, jkey_part_len);
+  return txn_get_helper(env, fn_get, jread_options_handle, jkey, jkey_off,
+                        jkey_part_len);
 }
 
 /*
@@ -247,7 +250,8 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BII(
           const ROCKSDB_NAMESPACE::Slice&, std::string*)>(
           &ROCKSDB_NAMESPACE::Transaction::Get, txn, std::placeholders::_1,
           std::placeholders::_2, std::placeholders::_3);
-  return txn_get_helper(env, fn_get, jread_options_handle, jkey, jkey_off, jkey_part_len);
+  return txn_get_helper(env, fn_get, jread_options_handle, jkey, jkey_off,
+                        jkey_part_len);
 }
 
 /*
@@ -507,7 +511,7 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZZ(
           std::placeholders::_1, column_family_handle, std::placeholders::_2,
           std::placeholders::_3, jexclusive, jdo_validate);
   return txn_get_helper(env, fn_get_for_update, jread_options_handle, jkey,
-                        0/*jkey_off*/, jkey_part_len);
+                        0 /*jkey_off*/, jkey_part_len);
 }
 
 /*
@@ -528,7 +532,7 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIZZ(
           std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
           jexclusive, jdo_validate);
   return txn_get_helper(env, fn_get_for_update, jread_options_handle, jkey,
-                        0/*jkey_off*/, jkey_part_len);
+                        0 /*jkey_off*/, jkey_part_len);
 }
 
 /*
@@ -619,8 +623,8 @@ jlong Java_org_rocksdb_Transaction_getIterator__JJJ(
  */
 void Java_org_rocksdb_Transaction_put__J_3BII_3BIIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off, jint jval_len,
-    jlong jcolumn_family_handle, jboolean jassume_tracked) {
+    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
+    jint jval_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
@@ -638,13 +642,10 @@ void Java_org_rocksdb_Transaction_put__J_3BII_3BIIJZ(
  * Method:    put
  * Signature: (J[BII[BII)V
  */
-void Java_org_rocksdb_Transaction_put__J_3BII_3BII(JNIEnv* env, jobject /*jobj*/,
-                                                 jlong jhandle, jbyteArray jkey,
-                                                 jint jkey_off,
-                                                 jint jkey_part_len,
-                                                 jbyteArray jval,
-                                                 jint jval_off,
-                                                 jint jval_len) {
+void Java_org_rocksdb_Transaction_put__J_3BII_3BII(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
+    jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
@@ -658,10 +659,10 @@ void Java_org_rocksdb_Transaction_put__J_3BII_3BII(JNIEnv* env, jobject /*jobj*/
  * Method:    putDirect
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJZ)V
  */
-void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2IIJZ
-  (JNIEnv *env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off, jint jkey_len,
-  jobject jval_bb, jint jval_off, jint jval_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
-
+void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2IIJZ(
+    JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
+    jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len,
+    jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
@@ -672,26 +673,23 @@ void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_
     return txn->Put(column_family_handle, key.slice(), value.slice(),
                     jassume_tracked);
   });
-  }
+}
 
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    putDirect
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)V
  */
-void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2II
-  (JNIEnv *env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off, jint jkey_len,
-  jobject jval_bb, jint jval_off, jint jval_len) {
-
+void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2II(
+    JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
+    jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteBufferSlice value(env, jval_bb, jval_off, jval_len);
   ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return txn->Put(key.slice(), value.slice());
   });
-  }
-
-
+}
 
 typedef std::function<ROCKSDB_NAMESPACE::Status(
     const ROCKSDB_NAMESPACE::SliceParts&, const ROCKSDB_NAMESPACE::SliceParts&)>
@@ -845,8 +843,8 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(
  */
 void Java_org_rocksdb_Transaction_merge__J_3BII_3BIIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off, jint jval_len,
-    jlong jcolumn_family_handle, jboolean jassume_tracked) {
+    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
+    jint jval_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
@@ -866,7 +864,8 @@ void Java_org_rocksdb_Transaction_merge__J_3BII_3BIIJZ(
  */
 void Java_org_rocksdb_Transaction_merge__J_3BII_3BII(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off, jint jval_len) {
+    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
+    jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
   ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
@@ -880,11 +879,11 @@ void Java_org_rocksdb_Transaction_merge__J_3BII_3BII(
  * Method:    mergeDirect
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJZ)V
  */
-JNIEXPORT void JNICALL Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2IIJZ
-  (JNIEnv *env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off, jint jkey_len,
-  jobject jval_bb, jint jval_off, jint jval_len,
-  jlong jcolumn_family_handle, jboolean jassume_tracked) {
-
+JNIEXPORT void JNICALL
+Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2IIJZ(
+    JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
+    jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len,
+    jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
@@ -895,25 +894,24 @@ JNIEXPORT void JNICALL Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_Byte
     return txn->Merge(column_family_handle, key.slice(), value.slice(),
                       jassume_tracked);
   });
-  }
+}
 
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    mergeDirect
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)V
  */
-JNIEXPORT void JNICALL Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2II
-  (JNIEnv *env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off, jint jkey_len,
-  jobject jval_bb, jint jval_off, jint jval_len) {
+JNIEXPORT void JNICALL
+Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2II(
+    JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
+    jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
   ROCKSDB_NAMESPACE::JByteBufferSlice value(env, jval_bb, jval_off, jval_len);
   ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return txn->Merge(key.slice(), value.slice());
   });
-  }
-
-
+}
 
 typedef std::function<ROCKSDB_NAMESPACE::Status(
     const ROCKSDB_NAMESPACE::Slice&)>

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -529,26 +529,12 @@ jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B(
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    getIterator
- * Signature: (JJ)J
- */
-jlong Java_org_rocksdb_Transaction_getIterator__JJ(JNIEnv* /*env*/,
-                                                   jobject /*jobj*/,
-                                                   jlong jhandle,
-                                                   jlong jread_options_handle) {
-  auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  auto* read_options =
-      reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jread_options_handle);
-  return GET_CPLUSPLUS_POINTER(txn->GetIterator(*read_options));
-}
-
-/*
- * Class:     org_rocksdb_Transaction
- * Method:    getIterator
  * Signature: (JJJ)J
  */
-jlong Java_org_rocksdb_Transaction_getIterator__JJJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
-    jlong jread_options_handle, jlong jcolumn_family_handle) {
+jlong Java_org_rocksdb_Transaction_getIterator(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
+                                               jlong jread_options_handle,
+                                               jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* read_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jread_options_handle);

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -233,7 +233,7 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIIJ(
         env, txn->Get(*read_options, column_family_handle, key.slice(),
                       &value.pinnable_slice()));
     return value.NewByteArray();
-  } catch (ROCKSDB_NAMESPACE::KVException e) {
+  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
     return nullptr;
   }
 }
@@ -280,7 +280,7 @@ jint Java_org_rocksdb_Transaction_get__JJ_3BII_3BIIJ(
         env, txn->Get(*read_options, column_family_handle, key.slice(),
                       &value.pinnable_slice()));
     return value.Fetch();
-  } catch (ROCKSDB_NAMESPACE::KVException e) {
+  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
     return e.Code();
   }
 }
@@ -312,7 +312,7 @@ jint Java_org_rocksdb_Transaction_getDirect(JNIEnv* env, jobject, jlong jhandle,
         env, txn->Get(*read_options, column_family_handle, key.slice(),
                       &value.pinnable_slice()));
     return value.Fetch();
-  } catch (ROCKSDB_NAMESPACE::KVException e) {
+  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
     return e.Code();
   }
 }

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -572,12 +572,15 @@ void Java_org_rocksdb_Transaction_put__J_3BII_3BIIJZ(
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->Put(column_family_handle, key.slice(), value.slice(),
-                    jassume_tracked);
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->Put(column_family_handle, key.slice(), value.slice(),
+                      jassume_tracked));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -590,11 +593,14 @@ void Java_org_rocksdb_Transaction_put__J_3BII_3BII(
     jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
     jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->Put(key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->Put(key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -610,12 +616,16 @@ void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
-  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->Put(column_family_handle, key.slice(), value.slice(),
-                    jassume_tracked);
-  });
+  try {
+    ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off,
+                                                jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->Put(column_family_handle, key.slice(), value.slice(),
+                      jassume_tracked));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -627,11 +637,15 @@ void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_
     JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
     jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->Put(key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off,
+                                                jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->Put(key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 typedef std::function<ROCKSDB_NAMESPACE::Status(
@@ -792,12 +806,15 @@ void Java_org_rocksdb_Transaction_merge__J_3BII_3BIIJZ(
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->Merge(column_family_handle, key.slice(), value.slice(),
-                      jassume_tracked);
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->Merge(column_family_handle, key.slice(), value.slice(),
+                        jassume_tracked));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -810,11 +827,14 @@ void Java_org_rocksdb_Transaction_merge__J_3BII_3BII(
     jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
     jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->Merge(key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->Merge(key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -831,12 +851,16 @@ Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_Byt
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
-  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->Merge(column_family_handle, key.slice(), value.slice(),
-                      jassume_tracked);
-  });
+  try {
+    ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off,
+                                                jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->Merge(column_family_handle, key.slice(), value.slice(),
+                        jassume_tracked));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -849,11 +873,15 @@ Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_Byt
     JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
     jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->Merge(key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+    ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off,
+                                                jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->Merge(key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 typedef std::function<ROCKSDB_NAMESPACE::Status(
@@ -1104,11 +1132,15 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BIJ(
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->PutUntracked(column_family_handle, key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env,
+        txn->PutUntracked(column_family_handle, key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -1120,11 +1152,14 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BI(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->PutUntracked(key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->PutUntracked(key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -1181,12 +1216,15 @@ void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BIJ(
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->MergeUntracked(column_family_handle, key.slice(),
-                               value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env,
+        txn->MergeUntracked(column_family_handle, key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*
@@ -1198,11 +1236,14 @@ void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BI(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
-  ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
-    return txn->MergeUntracked(key.slice(), value.slice());
-  });
+  try {
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
+    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
+        env, txn->MergeUntracked(key.slice(), value.slice()));
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
+    return;
+  }
 }
 
 /*

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -181,7 +181,7 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIIJ(
         env, txn->Get(*read_options, column_family_handle, key.slice(),
                       &value.pinnable_slice()));
     return value.NewByteArray();
-  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
+  } catch (ROCKSDB_NAMESPACE::KVException) {
     return nullptr;
   }
 }
@@ -203,7 +203,7 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BII(
     ROCKSDB_NAMESPACE::KVException::ThrowOnError(
         env, txn->Get(*read_options, key.slice(), &value.pinnable_slice()));
     return value.NewByteArray();
-  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
+  } catch (ROCKSDB_NAMESPACE::KVException) {
     return nullptr;
   }
 }
@@ -473,7 +473,7 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate(
         txn->GetForUpdate(*read_options, column_family_handle, key.slice(),
                           &value.pinnable_slice(), jexclusive, jdo_validate));
     return value.NewByteArray();
-  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
+  } catch (ROCKSDB_NAMESPACE::KVException) {
     return nullptr;
   }
 }

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -1206,19 +1206,19 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BI(
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    mergeUntracked
- * Signature: (J[BI[BIJ)V
+ * Signature: (J[BII[BIIJ)V
  */
-void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BIJ(
+void Java_org_rocksdb_Transaction_mergeUntracked(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_part_len, jbyteArray jval, jint jval_len,
-    jlong jcolumn_family_handle) {
+    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
+    jint jval_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
   try {
-    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
-    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
+    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, jval_off, jval_len);
     ROCKSDB_NAMESPACE::KVException::ThrowOnError(
         env,
         txn->MergeUntracked(column_family_handle, key.slice(), value.slice()));
@@ -1229,18 +1229,24 @@ void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BIJ(
 
 /*
  * Class:     org_rocksdb_Transaction
- * Method:    mergeUntracked
- * Signature: (J[BI[BI)V
+ * Method:    mergeUntrackedDirect
+ * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)V
  */
-void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BI(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_part_len, jbyteArray jval, jint jval_len) {
+void Java_org_rocksdb_Transaction_mergeUntrackedDirect(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobject jkey, jint jkey_off,
+    jint jkey_part_len, jobject jval, jint jval_off, jint jval_len,
+    jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
+  auto* column_family_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
+          jcolumn_family_handle);
   try {
-    ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, 0, jkey_part_len);
-    ROCKSDB_NAMESPACE::JByteArraySlice value(env, jval, 0, jval_len);
+    ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey, jkey_off,
+                                              jkey_part_len);
+    ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval, jval_off, jval_len);
     ROCKSDB_NAMESPACE::KVException::ThrowOnError(
-        env, txn->MergeUntracked(key.slice(), value.slice()));
+        env,
+        txn->MergeUntracked(column_family_handle, key.slice(), value.slice()));
   } catch (ROCKSDB_NAMESPACE::KVException&) {
     return;
   }

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -297,10 +297,10 @@ jint Java_org_rocksdb_Transaction_getDirect(JNIEnv* env, jobject, jlong jhandle,
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
 
-  ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off,
-                                          jkey_part_len);
-  ROCKSDB_NAMESPACE::JByteBufferPinnableSlice value(env, jval_bb, jval_off,
-                                                    jval_part_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off,
+                                            jkey_part_len);
+  ROCKSDB_NAMESPACE::JDirectBufferPinnableSlice value(env, jval_bb, jval_off,
+                                                      jval_part_len);
   return ROCKSDB_NAMESPACE::KVHelperJNI::DoRead(
       env, value, [=, &key, &value]() {
         return txn->Get(*read_options, column_family_handle, key.slice(),
@@ -667,8 +667,8 @@ void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
-  ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JByteBufferSlice value(env, jval_bb, jval_off, jval_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off, jval_len);
   ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return txn->Put(column_family_handle, key.slice(), value.slice(),
                     jassume_tracked);
@@ -684,8 +684,8 @@ void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_
     JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
     jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JByteBufferSlice value(env, jval_bb, jval_off, jval_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off, jval_len);
   ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return txn->Put(key.slice(), value.slice());
   });
@@ -888,8 +888,8 @@ Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_Byt
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
           jcolumn_family_handle);
-  ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JByteBufferSlice value(env, jval_bb, jval_off, jval_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off, jval_len);
   ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return txn->Merge(column_family_handle, key.slice(), value.slice(),
                       jassume_tracked);
@@ -906,8 +906,8 @@ Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_Byt
     JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
     jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
-  ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
-  ROCKSDB_NAMESPACE::JByteBufferSlice value(env, jval_bb, jval_off, jval_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+  ROCKSDB_NAMESPACE::JDirectBufferSlice value(env, jval_bb, jval_off, jval_len);
   ROCKSDB_NAMESPACE::KVHelperJNI::DoWrite(env, [=, &key, &value]() {
     return txn->Merge(key.slice(), value.slice());
   });

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -823,6 +823,47 @@ void Java_org_rocksdb_Transaction_merge__J_3BII_3BII(
   });
 }
 
+/*
+ * Class:     org_rocksdb_Transaction
+ * Method:    mergeDirect
+ * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJZ)V
+ */
+JNIEXPORT void JNICALL Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2IIJZ
+  (JNIEnv *env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off, jint jkey_len,
+  jobject jval_bb, jint jval_off, jint jval_len,
+  jlong jcolumn_family_handle, jboolean jassume_tracked) {
+
+  auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
+  auto* column_family_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
+          jcolumn_family_handle);
+  ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+  ROCKSDB_NAMESPACE::JByteBufferSlice value(env, jval_bb, jval_off, jval_len);
+  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
+    return txn->Merge(column_family_handle, key.slice(), value.slice(),
+                      jassume_tracked);
+  });
+  }
+
+/*
+ * Class:     org_rocksdb_Transaction
+ * Method:    mergeDirect
+ * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)V
+ */
+JNIEXPORT void JNICALL Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2II
+  (JNIEnv *env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off, jint jkey_len,
+  jobject jval_bb, jint jval_off, jint jval_len) {
+  auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
+  ROCKSDB_NAMESPACE::JByteBufferSlice key(env, jkey_bb, jkey_off, jkey_len);
+  ROCKSDB_NAMESPACE::JByteBufferSlice value(env, jval_bb, jval_off, jval_len);
+  ROCKSDB_NAMESPACE::KVHelperJNI::IfEnvOK(env, [=, &key, &value]() {
+    return txn->Merge(key.slice(), value.slice());
+  });
+
+  }
+
+
+
 typedef std::function<ROCKSDB_NAMESPACE::Status(
     const ROCKSDB_NAMESPACE::Slice&)>
     FnWriteK;

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -181,7 +181,7 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIIJ(
         env, txn->Get(*read_options, column_family_handle, key.slice(),
                       &value.pinnable_slice()));
     return value.NewByteArray();
-  } catch (ROCKSDB_NAMESPACE::KVException) {
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
     return nullptr;
   }
 }
@@ -203,7 +203,7 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BII(
     ROCKSDB_NAMESPACE::KVException::ThrowOnError(
         env, txn->Get(*read_options, key.slice(), &value.pinnable_slice()));
     return value.NewByteArray();
-  } catch (ROCKSDB_NAMESPACE::KVException) {
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
     return nullptr;
   }
 }
@@ -473,7 +473,7 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate(
         txn->GetForUpdate(*read_options, column_family_handle, key.slice(),
                           &value.pinnable_slice(), jexclusive, jdo_validate));
     return value.NewByteArray();
-  } catch (ROCKSDB_NAMESPACE::KVException) {
+  } catch (ROCKSDB_NAMESPACE::KVException&) {
     return nullptr;
   }
 }

--- a/java/src/main/java/org/rocksdb/GetStatus.java
+++ b/java/src/main/java/org/rocksdb/GetStatus.java
@@ -29,9 +29,7 @@ public class GetStatus {
     this.requiredSize = requiredSize;
   }
 
-  static GetStatus fromStatusCode(final byte code, final int requiredSize) {
-    return new GetStatus(
-        new Status(Status.Code.getCode(code), Status.SubCode.getSubCode((byte) 0), null),
-        requiredSize);
+  static GetStatus fromStatusCode(final Status.Code code, final int requiredSize) {
+    return new GetStatus(new Status(code, Status.SubCode.getSubCode((byte) 0), null), requiredSize);
   }
 }

--- a/java/src/main/java/org/rocksdb/GetStatus.java
+++ b/java/src/main/java/org/rocksdb/GetStatus.java
@@ -1,0 +1,37 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * The result for a fetch
+ * and the total size of the object fetched.
+ * If the target of the fetch is not big enough, this may be bigger than the contents of the target.
+ */
+public class GetStatus {
+  public final Status status;
+  public final int requiredSize;
+
+  /**
+   * Constructor used for success status, when the value is contained in the buffer
+   *
+   * @param status the status of the request to fetch into the buffer
+   * @param requiredSize the size of the data, which may be bigger than the buffer
+   */
+  GetStatus(final Status status, final int requiredSize) {
+    this.status = status;
+    this.requiredSize = requiredSize;
+  }
+
+  static GetStatus fromStatusCode(final byte code, final int requiredSize) {
+    return new GetStatus(
+        new Status(Status.Code.getCode(code), Status.SubCode.getSubCode((byte) 0), null),
+        requiredSize);
+  }
+}

--- a/java/src/main/java/org/rocksdb/GetStatus.java
+++ b/java/src/main/java/org/rocksdb/GetStatus.java
@@ -6,9 +6,6 @@
 
 package org.rocksdb;
 
-import java.nio.ByteBuffer;
-import java.util.List;
-
 /**
  * The result for a fetch
  * and the total size of the object fetched.

--- a/java/src/main/java/org/rocksdb/OptimisticTransactionDB.java
+++ b/java/src/main/java/org/rocksdb/OptimisticTransactionDB.java
@@ -86,6 +86,7 @@ public class OptimisticTransactionDB extends RocksDB
     // in RocksDB can prevent Java to GC during the life-time of
     // the currently-created RocksDB.
     otdb.storeOptionsInstance(dbOptions);
+    otdb.storeDefaultColumnFamilyHandle(otdb.makeDefaultColumnFamilyHandle());
 
     for (int i = 1; i < handles.length; i++) {
       columnFamilyHandles.add(new ColumnFamilyHandle(otdb, handles[i]));

--- a/java/src/main/java/org/rocksdb/ReadOptions.java
+++ b/java/src/main/java/org/rocksdb/ReadOptions.java
@@ -573,7 +573,6 @@ public class ReadOptions extends RocksObject {
    * @see #iterStartTs()
    * @return Reference to timestamp or null if there is no timestamp defined.
    */
-  @SuppressWarnings("PMD.ConfusingTernary")
   public Slice timestamp() {
     assert (isOwningHandle());
     final long timestampSliceHandle = timestamp(nativeHandle_);
@@ -623,7 +622,6 @@ public class ReadOptions extends RocksObject {
    * @return Reference to lower bound timestamp or null if there is no lower bound timestamp
    *     defined.
    */
-  @SuppressWarnings("PMD.ConfusingTernary")
   public Slice iterStartTs() {
     assert (isOwningHandle());
     final long iterStartTsHandle = iterStartTs(nativeHandle_);

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -6,6 +6,7 @@
 package org.rocksdb;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.rocksdb.util.BufferUtil.CheckBounds;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -894,8 +895,8 @@ public class RocksDB extends RocksObject {
   public void put(final byte[] key, final int offset, final int len,
       final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     put(nativeHandle_, key, offset, len, value, vOffset, vLen);
   }
 
@@ -944,8 +945,8 @@ public class RocksDB extends RocksObject {
       final byte[] key, final int offset, final int len,
       final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     put(nativeHandle_, key, offset, len, value, vOffset, vLen,
         columnFamilyHandle.nativeHandle_);
   }
@@ -989,8 +990,8 @@ public class RocksDB extends RocksObject {
       final byte[] key, final int offset, final int len,
       final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     put(nativeHandle_, writeOpts.nativeHandle_,
         key, offset, len, value, vOffset, vLen);
   }
@@ -1116,8 +1117,8 @@ public class RocksDB extends RocksObject {
       final byte[] key, final int offset, final int len,
       final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     put(nativeHandle_, writeOpts.nativeHandle_, key, offset, len, value,
         vOffset, vLen, columnFamilyHandle.nativeHandle_);
   }
@@ -1593,8 +1594,8 @@ public class RocksDB extends RocksObject {
    */
   public void merge(final byte[] key, final int offset, final int len, final byte[] value,
       final int vOffset, final int vLen) throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     merge(nativeHandle_, key, offset, len, value, vOffset, vLen);
   }
 
@@ -1638,8 +1639,8 @@ public class RocksDB extends RocksObject {
   public void merge(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key, final int offset, final int len, final byte[] value,
       final int vOffset, final int vLen) throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     merge(nativeHandle_, key, offset, len, value, vOffset, vLen,
         columnFamilyHandle.nativeHandle_);
   }
@@ -1685,8 +1686,8 @@ public class RocksDB extends RocksObject {
       final byte[] key,  final int offset, final int len,
       final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     merge(nativeHandle_, writeOpts.nativeHandle_,
         key, offset, len, value, vOffset, vLen);
   }
@@ -1815,8 +1816,8 @@ public class RocksDB extends RocksObject {
       final byte[] key, final int offset, final int len,
       final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     merge(nativeHandle_, writeOpts.nativeHandle_,
         key, offset, len, value, vOffset, vLen,
         columnFamilyHandle.nativeHandle_);
@@ -1900,8 +1901,8 @@ public class RocksDB extends RocksObject {
   public int get(final byte[] key, final int offset, final int len,
       final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     return get(nativeHandle_, key, offset, len, value, vOffset, vLen);
   }
 
@@ -1957,8 +1958,8 @@ public class RocksDB extends RocksObject {
   public int get(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
       final int offset, final int len, final byte[] value, final int vOffset,
       final int vLen) throws RocksDBException, IllegalArgumentException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     return get(nativeHandle_, key, offset, len, value, vOffset, vLen,
         columnFamilyHandle.nativeHandle_);
   }
@@ -2012,8 +2013,8 @@ public class RocksDB extends RocksObject {
   public int get(final ReadOptions opt, final byte[] key, final int offset,
       final int len, final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     return get(nativeHandle_, opt.nativeHandle_,
         key, offset, len, value, vOffset, vLen);
   }
@@ -2073,8 +2074,8 @@ public class RocksDB extends RocksObject {
       final ReadOptions opt, final byte[] key, final int offset, final int len,
       final byte[] value, final int vOffset, final int vLen)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
-    checkBounds(vOffset, vLen, value.length);
+    CheckBounds(offset, len, key.length);
+    CheckBounds(vOffset, vLen, value.length);
     return get(nativeHandle_, opt.nativeHandle_, key, offset, len, value,
         vOffset, vLen, columnFamilyHandle.nativeHandle_);
   }
@@ -2113,7 +2114,7 @@ public class RocksDB extends RocksObject {
    */
   public byte[] get(final byte[] key, final int offset,
       final int len) throws RocksDBException {
-    checkBounds(offset, len, key.length);
+    CheckBounds(offset, len, key.length);
     return get(nativeHandle_, key, offset, len);
   }
 
@@ -2158,7 +2159,7 @@ public class RocksDB extends RocksObject {
   public byte[] get(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key, final int offset, final int len)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
+    CheckBounds(offset, len, key.length);
     return get(nativeHandle_, key, offset, len,
         columnFamilyHandle.nativeHandle_);
   }
@@ -2200,7 +2201,7 @@ public class RocksDB extends RocksObject {
    */
   public byte[] get(final ReadOptions opt, final byte[] key, final int offset,
       final int len) throws RocksDBException {
-    checkBounds(offset, len, key.length);
+    CheckBounds(offset, len, key.length);
     return get(nativeHandle_, opt.nativeHandle_, key, offset, len);
   }
 
@@ -2247,7 +2248,7 @@ public class RocksDB extends RocksObject {
   public byte[] get(final ColumnFamilyHandle columnFamilyHandle,
       final ReadOptions opt, final byte[] key, final int offset, final int len)
       throws RocksDBException {
-    checkBounds(offset, len, key.length);
+    CheckBounds(offset, len, key.length);
     return get(nativeHandle_, opt.nativeHandle_, key, offset, len,
         columnFamilyHandle.nativeHandle_);
   }
@@ -3048,7 +3049,7 @@ public class RocksDB extends RocksObject {
       final ReadOptions readOptions,
       final byte[] key, final int offset, final int len,
       /* @Nullable */ final Holder<byte[]> valueHolder) {
-    checkBounds(offset, len, key.length);
+    CheckBounds(offset, len, key.length);
     if (valueHolder == null) {
       return keyMayExist(nativeHandle_,
           columnFamilyHandle == null ? 0 : columnFamilyHandle.nativeHandle_,
@@ -4780,6 +4781,12 @@ public class RocksDB extends RocksObject {
     if ((offset | len | (offset + len) | (size - (offset + len))) < 0) {
       throw new IndexOutOfBoundsException(String.format("offset(%d), len(%d), size(%d)", offset, len, size));
     }
+  }
+
+  private static int computeCapacityHint(final int estimatedNumberOfItems) {
+    // Default load factor for HashMap is 0.75, so N * 1.5 will be at the load
+    // limit. We add +1 for a buffer.
+    return (int)Math.ceil(estimatedNumberOfItems * 1.5 + 1.0);
   }
 
   // native methods

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -4794,7 +4794,7 @@ public class RocksDB extends RocksObject {
   private static int computeCapacityHint(final int estimatedNumberOfItems) {
     // Default load factor for HashMap is 0.75, so N * 1.5 will be at the load
     // limit. We add +1 for a buffer.
-    return (int)Math.ceil(estimatedNumberOfItems * 1.5 + 1.0);
+    return (int) Math.ceil(estimatedNumberOfItems * 1.5 + 1.0);
   }
 
   // native methods

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -3190,9 +3190,11 @@ public class RocksDB extends RocksObject {
       final ReadOptions readOptions, final ByteBuffer key) {
     assert key != null : "key ByteBuffer parameter cannot be null";
     assert key.isDirect() : "key parameter must be a direct ByteBuffer";
-    return keyMayExistDirect(nativeHandle_,
+    final boolean result = keyMayExistDirect(nativeHandle_,
         columnFamilyHandle == null ? 0 : columnFamilyHandle.nativeHandle_,
         readOptions == null ? 0 : readOptions.nativeHandle_, key, key.position(), key.limit());
+    key.position(key.limit());
+    return result;
   }
 
   /**
@@ -3225,6 +3227,7 @@ public class RocksDB extends RocksObject {
         value, value.position(), value.remaining());
     final int valueLength = result[1];
     value.limit(value.position() + Math.min(valueLength, value.remaining()));
+    key.position(key.limit());
     return new KeyMayExist(KeyMayExist.KeyMayExistEnum.values()[result[0]], valueLength);
   }
 

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -40,6 +40,7 @@ public class RocksDB extends RocksObject {
   static final String PERFORMANCE_OPTIMIZATION_FOR_A_VERY_SPECIFIC_WORKLOAD =
       "Performance optimization for a very specific workload";
   private ColumnFamilyHandle defaultColumnFamilyHandle_;
+  private final ReadOptions defaultReadOptions_ = new ReadOptions();
 
   private final List<ColumnFamilyHandle> ownedColumnFamilyHandles = new ArrayList<>();
 
@@ -3240,7 +3241,9 @@ public class RocksDB extends RocksObject {
    * @return instance of iterator object.
    */
   public RocksIterator newIterator() {
-    return new RocksIterator(this, iterator(nativeHandle_));
+    return new RocksIterator(this,
+        iterator(nativeHandle_, defaultColumnFamilyHandle_.nativeHandle_,
+            defaultReadOptions_.nativeHandle_));
   }
 
   /**
@@ -3257,8 +3260,9 @@ public class RocksDB extends RocksObject {
    * @return instance of iterator object.
    */
   public RocksIterator newIterator(final ReadOptions readOptions) {
-    return new RocksIterator(this, iterator(nativeHandle_,
-        readOptions.nativeHandle_));
+    return new RocksIterator(this,
+        iterator(
+            nativeHandle_, defaultColumnFamilyHandle_.nativeHandle_, readOptions.nativeHandle_));
   }
 
   /**
@@ -3277,8 +3281,9 @@ public class RocksDB extends RocksObject {
    */
   public RocksIterator newIterator(
       final ColumnFamilyHandle columnFamilyHandle) {
-    return new RocksIterator(this, iteratorCF(nativeHandle_,
-        columnFamilyHandle.nativeHandle_));
+    return new RocksIterator(this,
+        iterator(
+            nativeHandle_, columnFamilyHandle.nativeHandle_, defaultReadOptions_.nativeHandle_));
   }
 
   /**
@@ -3298,8 +3303,8 @@ public class RocksDB extends RocksObject {
    */
   public RocksIterator newIterator(final ColumnFamilyHandle columnFamilyHandle,
       final ReadOptions readOptions) {
-    return new RocksIterator(this, iteratorCF(nativeHandle_,
-        columnFamilyHandle.nativeHandle_, readOptions.nativeHandle_));
+    return new RocksIterator(
+        this, iterator(nativeHandle_, columnFamilyHandle.nativeHandle_, readOptions.nativeHandle_));
   }
 
   /**
@@ -4993,11 +4998,7 @@ public class RocksDB extends RocksObject {
   private native void putDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
       int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
       throws RocksDBException;
-  private native long iterator(final long handle);
-  private native long iterator(final long handle, final long readOptHandle);
-  private native long iteratorCF(final long handle, final long cfHandle);
-  private native long iteratorCF(final long handle, final long cfHandle,
-      final long readOptHandle);
+  private native long iterator(final long handle, final long cfHandle, final long readOptHandle);
   private native long[] iterators(final long handle,
       final long[] columnFamilyHandles, final long readOptHandle)
       throws RocksDBException;

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -1033,16 +1033,16 @@ public class RocksDB extends RocksObject {
       final ByteBuffer key, final ByteBuffer value) throws RocksDBException {
     if (key.isDirect() && value.isDirect()) {
       putDirect(nativeHandle_, writeOpts.nativeHandle_, key, key.position(), key.remaining(), value,
-              value.position(), value.remaining(), columnFamilyHandle.nativeHandle_);
+          value.position(), value.remaining(), columnFamilyHandle.nativeHandle_);
     } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();
-      put(nativeHandle_, writeOpts.nativeHandle_,
-              key.array(), key.arrayOffset() + key.position(), key.remaining(),
-              value.array(), value.arrayOffset() + value.position(), value.remaining(),
-              columnFamilyHandle.nativeHandle_);
+      put(nativeHandle_, writeOpts.nativeHandle_, key.array(), key.arrayOffset() + key.position(),
+          key.remaining(), value.array(), value.arrayOffset() + value.position(), value.remaining(),
+          columnFamilyHandle.nativeHandle_);
     } else {
-      throw new RocksDBException("ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(
+          "ByteBuffer parameters must all be direct, or must all be indirect");
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -1067,15 +1067,16 @@ public class RocksDB extends RocksObject {
       throws RocksDBException {
     if (key.isDirect() && value.isDirect()) {
       putDirect(nativeHandle_, writeOpts.nativeHandle_, key, key.position(), key.remaining(), value,
-              value.position(), value.remaining(), 0);
-    } else if (!key.isDirect() && !value.isDirect()){
+          value.position(), value.remaining(), 0);
+    } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();
-      put(nativeHandle_, writeOpts.nativeHandle_,
-              key.array(), key.arrayOffset() + key.position(), key.remaining(),
-              value.array(), value.arrayOffset() + value.position(), value.remaining());
+      put(nativeHandle_, writeOpts.nativeHandle_, key.array(), key.arrayOffset() + key.position(),
+          key.remaining(), value.array(), value.arrayOffset() + value.position(),
+          value.remaining());
     } else {
-      throw new RocksDBException("ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(
+          "ByteBuffer parameters must all be direct, or must all be indirect");
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -1674,37 +1675,38 @@ public class RocksDB extends RocksObject {
   }
 
   public void merge(final WriteOptions writeOpts, final ByteBuffer key, final ByteBuffer value)
-          throws RocksDBException {
+      throws RocksDBException {
     if (key.isDirect() && value.isDirect()) {
-      mergeDirect(nativeHandle_, writeOpts.nativeHandle_, key, key.position(), key.remaining(), value,
-              value.position(), value.remaining(), 0);
+      mergeDirect(nativeHandle_, writeOpts.nativeHandle_, key, key.position(), key.remaining(),
+          value, value.position(), value.remaining(), 0);
     } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();
-      merge(nativeHandle_, writeOpts.nativeHandle_,
-              key.array(), key.arrayOffset() + key.position(), key.remaining(),
-              value.array(), value.arrayOffset() + value.position(), value.remaining());
+      merge(nativeHandle_, writeOpts.nativeHandle_, key.array(), key.arrayOffset() + key.position(),
+          key.remaining(), value.array(), value.arrayOffset() + value.position(),
+          value.remaining());
     } else {
-      throw new RocksDBException("ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(
+          "ByteBuffer parameters must all be direct, or must all be indirect");
     }
     key.position(key.limit());
     value.position(value.limit());
   }
 
   public void merge(final ColumnFamilyHandle columnFamilyHandle, final WriteOptions writeOpts,
-                  final ByteBuffer key, final ByteBuffer value) throws RocksDBException {
+      final ByteBuffer key, final ByteBuffer value) throws RocksDBException {
     if (key.isDirect() && value.isDirect()) {
-      mergeDirect(nativeHandle_, writeOpts.nativeHandle_, key, key.position(), key.remaining(), value,
-              value.position(), value.remaining(), columnFamilyHandle.nativeHandle_);
+      mergeDirect(nativeHandle_, writeOpts.nativeHandle_, key, key.position(), key.remaining(),
+          value, value.position(), value.remaining(), columnFamilyHandle.nativeHandle_);
     } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();
-      merge(nativeHandle_, writeOpts.nativeHandle_,
-              key.array(), key.arrayOffset() + key.position(), key.remaining(),
-              value.array(), value.arrayOffset() + value.position(), value.remaining(),
-              columnFamilyHandle.nativeHandle_);
+      merge(nativeHandle_, writeOpts.nativeHandle_, key.array(), key.arrayOffset() + key.position(),
+          key.remaining(), value.array(), value.arrayOffset() + value.position(), value.remaining(),
+          columnFamilyHandle.nativeHandle_);
     } else {
-      throw new RocksDBException("ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(
+          "ByteBuffer parameters must all be direct, or must all be indirect");
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -4890,8 +4892,8 @@ public class RocksDB extends RocksObject {
       final byte[] value, final int valueOffset, final int valueLength,
       final long cfHandle) throws RocksDBException;
   private native void mergeDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
-                                int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
-          throws RocksDBException;
+      int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
+      throws RocksDBException;
 
   private native void write0(final long handle, final long writeOptHandle,
       final long wbHandle) throws RocksDBException;

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -39,6 +39,9 @@ public class RocksDB extends RocksObject {
 
   static final String PERFORMANCE_OPTIMIZATION_FOR_A_VERY_SPECIFIC_WORKLOAD =
       "Performance optimization for a very specific workload";
+
+  private static final String BB_ALL_DIRECT_OR_INDIRECT =
+      "ByteBuffer parameters must all be direct, or must all be indirect";
   private ColumnFamilyHandle defaultColumnFamilyHandle_;
   private final ReadOptions defaultReadOptions_ = new ReadOptions();
 
@@ -1050,8 +1053,7 @@ public class RocksDB extends RocksObject {
           key.remaining(), value.array(), value.arrayOffset() + value.position(), value.remaining(),
           columnFamilyHandle.nativeHandle_);
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -1084,8 +1086,7 @@ public class RocksDB extends RocksObject {
           key.remaining(), value.array(), value.arrayOffset() + value.position(),
           value.remaining());
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -1307,8 +1308,7 @@ public class RocksDB extends RocksObject {
               key.remaining(), value.array(), value.arrayOffset() + value.position(),
               value.remaining(), defaultColumnFamilyHandle_.nativeHandle_);
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     if (result != NOT_FOUND) {
       value.limit(Math.min(value.limit(), value.position() + result));
@@ -1705,8 +1705,7 @@ public class RocksDB extends RocksObject {
           key.remaining(), value.array(), value.arrayOffset() + value.position(),
           value.remaining());
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -1724,8 +1723,7 @@ public class RocksDB extends RocksObject {
           key.remaining(), value.array(), value.arrayOffset() + value.position(), value.remaining(),
           columnFamilyHandle.nativeHandle_);
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -4789,12 +4787,6 @@ public class RocksDB extends RocksObject {
     if ((offset | len | (offset + len) | (size - (offset + len))) < 0) {
       throw new IndexOutOfBoundsException(String.format("offset(%d), len(%d), size(%d)", offset, len, size));
     }
-  }
-
-  private static int computeCapacityHint(final int estimatedNumberOfItems) {
-    // Default load factor for HashMap is 0.75, so N * 1.5 will be at the load
-    // limit. We add +1 for a buffer.
-    return (int) Math.ceil(estimatedNumberOfItems * 1.5 + 1.0);
   }
 
   // native methods

--- a/java/src/main/java/org/rocksdb/RocksIterator.java
+++ b/java/src/main/java/org/rocksdb/RocksIterator.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import static org.rocksdb.util.BufferUtil.CheckBounds;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -47,8 +49,46 @@ public class RocksIterator extends AbstractRocksIterator<RocksDB> {
    * <p>REQUIRES: {@link #isValid()}</p>
    *
    * @param key the out-value to receive the retrieved key.
+   * @return The size of the actual key. If the return key is greater than
+   *     the length of the buffer {@code key}, then it indicates that the size of the
+   *     input buffer {@code key} is insufficient and partial result will
+   *     be returned.
+   */
+  public int key(final byte[] key) {
+    assert isOwningHandle();
+    return keyByteArray0(nativeHandle_, key, 0, key.length);
+  }
+
+  /**
+   * <p>Return the key for the current entry.  The underlying storage for
+   * the returned slice is valid only until the next modification of
+   * the iterator.</p>
+   *
+   * <p>REQUIRES: {@link #isValid()}</p>
+   *
+   * @param key the out-value to receive the retrieved key.
+   * @param offset in {@code key} at which to place the retrieved key
+   * @param len limit to length of received key returned
+   * @return The size of the actual key. If the return key is greater than
+   *     {@code len}, then it indicates that the size of the
+   *     input buffer {@code key} is insufficient and partial result will
+   *     be returned.
+   */
+  public int key(final byte[] key, final int offset, final int len) {
+    assert isOwningHandle();
+    CheckBounds(offset, len, key.length);
+    return keyByteArray0(nativeHandle_, key, offset, len);
+  }
+
+  /**
+   * <p>Return the key for the current entry.  The underlying storage for
+   * the returned slice is valid only until the next modification of
+   * the iterator.</p>
+   *
+   * <p>REQUIRES: {@link #isValid()}</p>
+   *
+   * @param key the out-value to receive the retrieved key.
    *     It is using position and limit. Limit is set according to key size.
-   *     Supports direct buffer only.
    * @return The size of the actual key. If the return key is greater than the
    *     length of {@code key}, then it indicates that the size of the
    *     input buffer {@code key} is insufficient and partial result will
@@ -90,7 +130,6 @@ public class RocksIterator extends AbstractRocksIterator<RocksDB> {
    *
    * @param value the out-value to receive the retrieved value.
    *     It is using position and limit. Limit is set according to value size.
-   *     Supports direct buffer only.
    * @return The size of the actual value. If the return value is greater than the
    *     length of {@code value}, then it indicates that the size of the
    *     input buffer {@code value} is insufficient and partial result will
@@ -108,6 +147,45 @@ public class RocksIterator extends AbstractRocksIterator<RocksDB> {
     }
     value.limit(Math.min(value.position() + result, value.limit()));
     return result;
+  }
+
+  /**
+   * <p>Return the value for the current entry.  The underlying storage for
+   * the returned slice is valid only until the next modification of
+   * the iterator.</p>
+   *
+   * <p>REQUIRES: {@link #isValid()}</p>
+   *
+   * @param value the out-value to receive the retrieved value.
+   * @return The size of the actual value. If the return value is greater than the
+   *     length of {@code value}, then it indicates that the size of the
+   *     input buffer {@code value} is insufficient and partial result will
+   *     be returned.
+   */
+  public int value(final byte[] value) {
+    assert isOwningHandle();
+    return valueByteArray0(nativeHandle_, value, 0, value.length);
+  }
+
+  /**
+   * <p>Return the value for the current entry.  The underlying storage for
+   * the returned slice is valid only until the next modification of
+   * the iterator.</p>
+   *
+   * <p>REQUIRES: {@link #isValid()}</p>
+   *
+   * @param value the out-value to receive the retrieved value.
+   * @param offset the offset within value at which to place the result
+   * @param len the length available in value after offset, for placing the result
+   * @return The size of the actual value. If the return value is greater than {@code len},
+   *     then it indicates that the size of the
+   *     input buffer {@code value} is insufficient and partial result will
+   *     be returned.
+   */
+  public int value(final byte[] value, final int offset, final int len) {
+    assert isOwningHandle();
+    CheckBounds(offset, len, value.length);
+    return valueByteArray0(nativeHandle_, value, offset, len);
   }
 
   @Override protected final native void disposeInternal(final long handle);

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -1246,7 +1246,7 @@ public class Transaction extends RocksObject {
     assert (isOwningHandle());
     if (key.isDirect() && value.isDirect()) {
       mergeDirect(nativeHandle_, key, key.position(), key.remaining(), value,
-          value.arrayOffset() + value.position(), value.remaining());
+          value.position(), value.remaining());
     } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -1050,8 +1050,8 @@ public class Transaction extends RocksObject {
   public void put(final ByteBuffer key, final ByteBuffer value) throws RocksDBException {
     assert (isOwningHandle());
     if (key.isDirect() && value.isDirect()) {
-      putDirect(nativeHandle_, key, key.position(), key.remaining(), value,
-          value.position(), value.remaining());
+      putDirect(nativeHandle_, key, key.position(), key.remaining(), value, value.position(),
+          value.remaining());
     } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();
@@ -1095,9 +1095,8 @@ public class Transaction extends RocksObject {
       final ByteBuffer value, final boolean assumeTracked) throws RocksDBException {
     assert (isOwningHandle());
     if (key.isDirect() && value.isDirect()) {
-      putDirect(nativeHandle_, key, key.position(), key.remaining(), value,
-          value.position(), value.remaining(),
-          columnFamilyHandle.nativeHandle_, assumeTracked);
+      putDirect(nativeHandle_, key, key.position(), key.remaining(), value, value.position(),
+          value.remaining(), columnFamilyHandle.nativeHandle_, assumeTracked);
     } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();
@@ -1251,12 +1250,11 @@ public class Transaction extends RocksObject {
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
    */
-  public void merge(final ByteBuffer key, final ByteBuffer value)
-      throws RocksDBException {
+  public void merge(final ByteBuffer key, final ByteBuffer value) throws RocksDBException {
     assert (isOwningHandle());
     if (key.isDirect() && value.isDirect()) {
-      mergeDirect(nativeHandle_, key, key.position(), key.remaining(), value,
-          value.position(), value.remaining());
+      mergeDirect(nativeHandle_, key, key.position(), key.remaining(), value, value.position(),
+          value.remaining());
     } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();
@@ -1295,9 +1293,8 @@ public class Transaction extends RocksObject {
       final ByteBuffer value, final boolean assumeTracked) throws RocksDBException {
     assert (isOwningHandle());
     if (key.isDirect() && value.isDirect()) {
-      mergeDirect(nativeHandle_, key, key.position(), key.remaining(), value,
-          value.position(), value.remaining(),
-          columnFamilyHandle.nativeHandle_, assumeTracked);
+      mergeDirect(nativeHandle_, key, key.position(), key.remaining(), value, value.position(),
+          value.remaining(), columnFamilyHandle.nativeHandle_, assumeTracked);
     } else if (!key.isDirect() && !value.isDirect()) {
       assert key.hasArray();
       assert value.hasArray();
@@ -2306,7 +2303,8 @@ public class Transaction extends RocksObject {
   private native void rollbackToSavePoint(final long handle)
       throws RocksDBException;
   private native byte[] get(final long handle, final long readOptionsHandle, final byte[] key,
-      final int keyOffset, final int keyLength, final long columnFamilyHandle) throws RocksDBException;
+      final int keyOffset, final int keyLength, final long columnFamilyHandle)
+      throws RocksDBException;
   private native byte[] get(final long handle, final long readOptionsHandle, final byte[] key,
       final int keyOffset, final int keyLen) throws RocksDBException;
   private native int get(final long handle, final long readOptionsHandle, final byte[] key,
@@ -2338,12 +2336,13 @@ public class Transaction extends RocksObject {
       final long readOptionsHandle);
   private native long getIterator(final long handle,
       final long readOptionsHandle, final long columnFamilyHandle);
-    private native void put(final long handle, final byte[] key, final int keyOffset,
-                            final int keyLength, final byte[] value, final int valueOffset, final int valueLength) throws RocksDBException;
-    private native void put(final long handle, final byte[] key, final int keyOffset,
-                            final int keyLength, final byte[] value, final int valueOffset, final int valueLength,
-                            final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-    private native void put(final long handle, final byte[][] keys, final int keysLength,
+  private native void put(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength, final byte[] value, final int valueOffset, final int valueLength)
+      throws RocksDBException;
+  private native void put(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength, final byte[] value, final int valueOffset, final int valueLength,
+      final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
+  private native void put(final long handle, final byte[][] keys, final int keysLength,
       final byte[][] values, final int valuesLength, final long columnFamilyHandle,
       final boolean assumeTracked) throws RocksDBException;
   private native void put(final long handle, final byte[][] keys,
@@ -2353,8 +2352,7 @@ public class Transaction extends RocksObject {
       ByteBuffer value, int valueOffset, int valueLength, long cfHandle,
       final boolean assumeTracked) throws RocksDBException;
   private native void putDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
-      ByteBuffer value, int valueOffset, int valueLength)
-      throws RocksDBException;
+      ByteBuffer value, int valueOffset, int valueLength) throws RocksDBException;
 
   private native void merge(final long handle, final byte[] key, final int keyOffset,
       final int keyLength, final byte[] value, final int valueOffset, final int valueLength,
@@ -2363,11 +2361,11 @@ public class Transaction extends RocksObject {
       ByteBuffer value, int valueOffset, int valueLength, long cfHandle, boolean assumeTracked)
       throws RocksDBException;
   private native void mergeDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
-      ByteBuffer value, int valueOffset, int valueLength)
-      throws RocksDBException;
+      ByteBuffer value, int valueOffset, int valueLength) throws RocksDBException;
 
   private native void merge(final long handle, final byte[] key, final int keyOffset,
-      final int keyLength, final byte[] value, final int valueOffset, final int valueLength) throws RocksDBException;
+      final int keyLength, final byte[] value, final int valueOffset, final int valueLength)
+      throws RocksDBException;
   private native void delete(final long handle, final byte[] key, final int keyLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
   private native void delete(final long handle, final byte[] key,

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -5,9 +5,8 @@
 
 package org.rocksdb;
 
-import static org.rocksdb.RocksDB.PERFORMANCE_OPTIMIZATION_FOR_A_VERY_SPECIFIC_WORKLOAD;
-
 import static org.rocksdb.RocksDB.NOT_FOUND;
+import static org.rocksdb.RocksDB.PERFORMANCE_OPTIMIZATION_FOR_A_VERY_SPECIFIC_WORKLOAD;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -1282,11 +1282,6 @@ public class Transaction extends RocksObject {
    * column family including both keys in the DB and uncommitted keys in this
    * transaction.
    * <p>
-   * Setting {@link ReadOptions#setSnapshot(Snapshot)} will affect what is read
-   * from the DB but will NOT change which keys are read from this transaction
-   * (the keys in this transaction do not yet belong to any snapshot and will be
-   * fetched regardless).
-   * <p>
    * Caller is responsible for deleting the returned Iterator.
    * <p>
    * The returned iterator is only valid until {@link #commit()},
@@ -2270,6 +2265,7 @@ public class Transaction extends RocksObject {
    */
   public void mergeUntracked(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key, final byte[] value) throws RocksDBException {
+    assert (isOwningHandle());
     mergeUntracked(nativeHandle_, key, 0, key.length, value, 0, value.length,
         columnFamilyHandle.nativeHandle_);
   }

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -5,7 +5,6 @@
 
 package org.rocksdb;
 
-import static org.rocksdb.RocksDB.NOT_FOUND;
 import static org.rocksdb.RocksDB.PERFORMANCE_OPTIMIZATION_FOR_A_VERY_SPECIFIC_WORKLOAD;
 
 import java.nio.ByteBuffer;
@@ -33,6 +32,8 @@ public class Transaction extends RocksObject {
   private static final String FOR_EACH_KEY_THERE_MUST_BE_A_COLUMNFAMILYHANDLE =
       "For each key there must be a ColumnFamilyHandle.";
 
+  private static final String BB_ALL_DIRECT_OR_INDIRECT =
+      "ByteBuffer parameters must all be direct, or must all be indirect";
   private final RocksDB parent;
   private final ColumnFamilyHandle defaultColumnFamilyHandle;
 
@@ -450,8 +451,7 @@ public class Transaction extends RocksObject {
               key.remaining(), value.array(), value.arrayOffset() + value.position(),
               value.remaining(), columnFamilyHandle.nativeHandle_);
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
 
     key.position(key.limit());
@@ -1143,8 +1143,7 @@ public class Transaction extends RocksObject {
           value.arrayOffset() + value.position(), value.remaining(),
           columnFamilyHandle.nativeHandle_, exclusive, doValidate);
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     if (result < 0) {
@@ -1290,7 +1289,7 @@ public class Transaction extends RocksObject {
    */
   public RocksIterator getIterator() {
     assert (isOwningHandle());
-    try (final ReadOptions readOptions = new ReadOptions()) {
+    try (ReadOptions readOptions = new ReadOptions()) {
       return new RocksIterator(parent,
           getIterator(
               nativeHandle_, readOptions.nativeHandle_, defaultColumnFamilyHandle.nativeHandle_));
@@ -1375,7 +1374,7 @@ public class Transaction extends RocksObject {
    */
   public RocksIterator getIterator(final ColumnFamilyHandle columnFamilyHandle) {
     assert (isOwningHandle());
-    try (final ReadOptions readOptions = new ReadOptions()) {
+    try (ReadOptions readOptions = new ReadOptions()) {
       return new RocksIterator(parent,
           getIterator(nativeHandle_, readOptions.nativeHandle_, columnFamilyHandle.nativeHandle_));
     }
@@ -1557,8 +1556,7 @@ public class Transaction extends RocksObject {
       put(nativeHandle_, key.array(), key.arrayOffset() + key.position(), key.remaining(),
           value.array(), value.arrayOffset() + value.position(), value.remaining());
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -1605,8 +1603,7 @@ public class Transaction extends RocksObject {
           value.array(), value.arrayOffset() + value.position(), value.remaining(),
           columnFamilyHandle.nativeHandle_, assumeTracked);
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -1764,8 +1761,7 @@ public class Transaction extends RocksObject {
       merge(nativeHandle_, key.array(), key.arrayOffset() + key.position(), key.remaining(),
           value.array(), value.arrayOffset() + value.position(), value.remaining());
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
   }
 
@@ -1806,8 +1802,7 @@ public class Transaction extends RocksObject {
           value.array(), value.arrayOffset() + value.position(), value.remaining(),
           columnFamilyHandle.nativeHandle_, assumeTracked);
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     value.position(value.limit());
@@ -2302,8 +2297,7 @@ public class Transaction extends RocksObject {
           key.remaining(), value.array(), value.arrayOffset() + value.position(), value.remaining(),
           columnFamilyHandle.nativeHandle_);
     } else {
-      throw new RocksDBException(
-          "ByteBuffer parameters must all be direct, or must all be indirect");
+      throw new RocksDBException(BB_ALL_DIRECT_OR_INDIRECT);
     }
     key.position(key.limit());
     value.position(value.limit());

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -703,8 +703,8 @@ public class Transaction extends RocksObject {
   public byte[] getForUpdate(final ReadOptions readOptions, final byte[] key,
       final boolean exclusive) throws RocksDBException {
     assert(isOwningHandle());
-    return getForUpdate(
-        nativeHandle_, readOptions.nativeHandle_, key, key.length, exclusive, true /*doValidate*/);
+    return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key, key.length,
+        defaultColumnFamilyHandle.nativeHandle_, exclusive, true /*doValidate*/);
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/TransactionDB.java
+++ b/java/src/main/java/org/rocksdb/TransactionDB.java
@@ -50,6 +50,7 @@ public class TransactionDB extends RocksDB
     // the currently-created RocksDB.
     tdb.storeOptionsInstance(options);
     tdb.storeTransactionDbOptions(transactionDbOptions);
+    tdb.storeDefaultColumnFamilyHandle(tdb.makeDefaultColumnFamilyHandle());
 
     return tdb;
   }

--- a/java/src/main/java/org/rocksdb/TransactionDB.java
+++ b/java/src/main/java/org/rocksdb/TransactionDB.java
@@ -94,6 +94,7 @@ public class TransactionDB extends RocksDB
     // in RocksDB can prevent Java to GC during the life-time of
     // the currently-created RocksDB.
     tdb.storeOptionsInstance(dbOptions);
+    tdb.storeDefaultColumnFamilyHandle(tdb.makeDefaultColumnFamilyHandle());
     tdb.storeTransactionDbOptions(transactionDbOptions);
 
     for (int i = 1; i < handles.length; i++) {

--- a/java/src/main/java/org/rocksdb/util/BufferUtil.java
+++ b/java/src/main/java/org/rocksdb/util/BufferUtil.java
@@ -1,0 +1,16 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb.util;
+
+public class BufferUtil {
+  public static void CheckBounds(final int offset, final int len, final int size) {
+    if ((offset | len | (offset + len) | (size - (offset + len))) < 0) {
+      throw new IndexOutOfBoundsException(
+          String.format("offset(%d), len(%d), size(%d)", offset, len, size));
+    }
+  }
+}

--- a/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
@@ -215,12 +215,15 @@ public abstract class AbstractTransactionTest {
          final ReadOptions readOptions = new ReadOptions();
          final Transaction txn = dbContainer.beginTransaction()) {
       final ByteBuffer vGet = ByteBuffer.allocateDirect(100);
-      assertThat(txn.get(readOptions, k1, vGet)).isLessThan(0);
+      assertThat(txn.get(readOptions, k1, vGet).status.getCode()).isEqualTo(Status.Code.NotFound);
       txn.put(k1, v1);
       vGet.put("12345".getBytes(UTF_8));
       txn.get(readOptions, k1, vGet);
       vGet.put("67890".getBytes(UTF_8));
-      assertThat(vGet.toString()).isEqualTo("wibble");
+      vGet.flip();
+      final byte[] bytes = new byte[vGet.limit()];
+      vGet.get(bytes);
+      assertThat(new String(bytes, UTF_8)).isEqualTo("12345value167890");
     }
   }
 
@@ -235,12 +238,15 @@ public abstract class AbstractTransactionTest {
          final ReadOptions readOptions = new ReadOptions();
          final Transaction txn = dbContainer.beginTransaction()) {
       final ByteBuffer vGet = ByteBuffer.allocate(100);
-      assertThat(txn.get(readOptions, k1, vGet)).isLessThan(0);
+      assertThat(txn.get(readOptions, k1, vGet).status.getCode()).isEqualTo(Status.Code.NotFound);
       txn.put(k1, v1);
       vGet.put("12345".getBytes(UTF_8));
       txn.get(readOptions, k1, vGet);
       vGet.put("67890".getBytes(UTF_8));
-      assertThat(vGet.toString()).isEqualTo("wibble");
+      vGet.flip();
+      final byte[] bytes = new byte[vGet.limit()];
+      vGet.get(bytes);
+      assertThat(new String(bytes, UTF_8)).isEqualTo("12345value167890");
     }
   }
 
@@ -256,12 +262,16 @@ public abstract class AbstractTransactionTest {
          final Transaction txn = dbContainer.beginTransaction()) {
       final ColumnFamilyHandle testCf = dbContainer.getTestColumnFamily();
       final ByteBuffer vGet = ByteBuffer.allocateDirect(100);
-      assertThat(txn.get(readOptions, testCf, k1, vGet)).isEqualTo(Status.Code.NotFound);
+      assertThat(txn.get(readOptions, testCf, k1, vGet).status.getCode())
+          .isEqualTo(Status.Code.NotFound);
       txn.put(testCf, k1, v1);
       vGet.put("12345".getBytes(UTF_8));
       txn.get(readOptions, testCf, k1, vGet);
       vGet.put("67890".getBytes(UTF_8));
-      assertThat(vGet.toString()).isEqualTo("wibble");
+      vGet.flip();
+      final byte[] bytes = new byte[vGet.limit()];
+      vGet.get(bytes);
+      assertThat(new String(bytes, UTF_8)).isEqualTo("12345value167890");
     }
   }
 
@@ -277,12 +287,16 @@ public abstract class AbstractTransactionTest {
          final Transaction txn = dbContainer.beginTransaction()) {
       final ColumnFamilyHandle testCf = dbContainer.getTestColumnFamily();
       final ByteBuffer vGet = ByteBuffer.allocate(100);
-      assertThat(txn.get(readOptions, testCf, k1, vGet)).isEqualTo(Status.Code.NotFound);
+      assertThat(txn.get(readOptions, testCf, k1, vGet).status.getCode())
+          .isEqualTo(Status.Code.NotFound);
       txn.put(testCf, k1, v1);
       vGet.put("12345".getBytes(UTF_8));
       txn.get(readOptions, testCf, k1, vGet);
       vGet.put("67890".getBytes(UTF_8));
-      assertThat(vGet.toString()).isEqualTo("wibble");
+      vGet.flip();
+      final byte[] bytes = new byte[vGet.limit()];
+      vGet.get(bytes);
+      assertThat(new String(bytes, UTF_8)).isEqualTo("12345value167890");
     }
   }
 

--- a/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
@@ -17,9 +17,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * Base class of {@link TransactionTest} and {@link OptimisticTransactionTest}
  */

--- a/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -244,7 +243,8 @@ public abstract class AbstractTransactionTest {
     }
   }
 
-  public void getPutByteBuffer(final Function<Integer, ByteBuffer> allocateBuffer) throws RocksDBException {
+  public void getPutByteBuffer(final Function<Integer, ByteBuffer> allocateBuffer)
+      throws RocksDBException {
     final ByteBuffer k1 = allocateBuffer.apply(100).put("key1".getBytes(UTF_8));
     k1.flip();
     final ByteBuffer v1 = allocateBuffer.apply(100).put("value1".getBytes(UTF_8));
@@ -288,7 +288,8 @@ public abstract class AbstractTransactionTest {
     getPutByteBuffer(ByteBuffer::allocate);
   }
 
-  public void getPutByteBuffer_cf(final Function<Integer, ByteBuffer> allocateBuffer) throws RocksDBException {
+  public void getPutByteBuffer_cf(final Function<Integer, ByteBuffer> allocateBuffer)
+      throws RocksDBException {
     final ByteBuffer k1 = allocateBuffer.apply(100).put("key1".getBytes(UTF_8));
     k1.flip();
     final ByteBuffer v1 = allocateBuffer.apply(100).put("value1".getBytes(UTF_8));
@@ -436,12 +437,13 @@ public abstract class AbstractTransactionTest {
   public void getForUpdateByteArray_cf_doValidate() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
     final byte[] v1 = "value1".getBytes(UTF_8);
-    try(final DBContainer dbContainer = startDb();
-        final ReadOptions readOptions = new ReadOptions();
-        final Transaction txn = dbContainer.beginTransaction()) {
+    try (final DBContainer dbContainer = startDb();
+         final ReadOptions readOptions = new ReadOptions();
+         final Transaction txn = dbContainer.beginTransaction()) {
       final ColumnFamilyHandle testCf = dbContainer.getTestColumnFamily();
       final byte[] vNonExistent = new byte[1];
-      final GetStatus sNonExistent = txn.getForUpdate(readOptions, testCf, k1, vNonExistent, true, true);
+      final GetStatus sNonExistent =
+          txn.getForUpdate(readOptions, testCf, k1, vNonExistent, true, true);
       assertThat(sNonExistent.status.getCode()).isEqualTo(Status.Code.NotFound);
       txn.put(testCf, k1, v1);
       final byte[] vPartial = new byte[4];
@@ -461,9 +463,9 @@ public abstract class AbstractTransactionTest {
   public void getForUpdateByteArray_cf() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
     final byte[] v1 = "value1".getBytes(UTF_8);
-    try(final DBContainer dbContainer = startDb();
-        final ReadOptions readOptions = new ReadOptions();
-        final Transaction txn = dbContainer.beginTransaction()) {
+    try (final DBContainer dbContainer = startDb();
+         final ReadOptions readOptions = new ReadOptions();
+         final Transaction txn = dbContainer.beginTransaction()) {
       final ColumnFamilyHandle testCf = dbContainer.getTestColumnFamily();
       final byte[] vNonExistent = new byte[1];
       final GetStatus sNonExistent = txn.getForUpdate(readOptions, testCf, k1, vNonExistent, true);
@@ -483,12 +485,13 @@ public abstract class AbstractTransactionTest {
     }
   }
 
-  @Test public void getForUpdateByteArray() throws RocksDBException {
+  @Test
+  public void getForUpdateByteArray() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
     final byte[] v1 = "value1".getBytes(UTF_8);
-    try(final DBContainer dbContainer = startDb();
-        final ReadOptions readOptions = new ReadOptions();
-        final Transaction txn = dbContainer.beginTransaction()) {
+    try (final DBContainer dbContainer = startDb();
+         final ReadOptions readOptions = new ReadOptions();
+         final Transaction txn = dbContainer.beginTransaction()) {
       final byte[] vNonExistent = new byte[1];
       final GetStatus sNonExistent = txn.getForUpdate(readOptions, k1, vNonExistent, true);
       assertThat(sNonExistent.status.getCode()).isEqualTo(Status.Code.NotFound);
@@ -517,7 +520,8 @@ public abstract class AbstractTransactionTest {
     getForUpdateByteBuffer(ByteBuffer::allocate);
   }
 
-  public void getForUpdateByteBuffer(final Function<Integer, ByteBuffer> allocateBuffer) throws Exception {
+  public void getForUpdateByteBuffer(final Function<Integer, ByteBuffer> allocateBuffer)
+      throws Exception {
     final ByteBuffer k1 = allocateBuffer.apply(20).put("key1".getBytes(UTF_8));
     k1.flip();
     final ByteBuffer v1 = allocateBuffer.apply(20).put("value1".getBytes(UTF_8));

--- a/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
@@ -256,7 +256,7 @@ public abstract class AbstractTransactionTest {
          final Transaction txn = dbContainer.beginTransaction()) {
       final ColumnFamilyHandle testCf = dbContainer.getTestColumnFamily();
       final ByteBuffer vGet = ByteBuffer.allocateDirect(100);
-      assertThat(txn.get(readOptions, testCf, k1, vGet)).isLessThan(0);
+      assertThat(txn.get(readOptions, testCf, k1, vGet)).isEqualTo(Status.Code.NotFound);
       txn.put(testCf, k1, v1);
       vGet.put("12345".getBytes(UTF_8));
       txn.get(readOptions, testCf, k1, vGet);
@@ -277,7 +277,7 @@ public abstract class AbstractTransactionTest {
          final Transaction txn = dbContainer.beginTransaction()) {
       final ColumnFamilyHandle testCf = dbContainer.getTestColumnFamily();
       final ByteBuffer vGet = ByteBuffer.allocate(100);
-      assertThat(txn.get(readOptions, testCf, k1, vGet)).isLessThan(0);
+      assertThat(txn.get(readOptions, testCf, k1, vGet)).isEqualTo(Status.Code.NotFound);
       txn.put(testCf, k1, v1);
       vGet.put("12345".getBytes(UTF_8));
       txn.get(readOptions, testCf, k1, vGet);

--- a/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
@@ -539,6 +539,13 @@ public abstract class AbstractTransactionTest {
         assertThat(iterator.key()).isEqualTo(k1);
         assertThat(iterator.value()).isEqualTo(v1);
       }
+
+      try (final RocksIterator iterator = txn.getIterator()) {
+        iterator.seek(k1);
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo(k1);
+        assertThat(iterator.value()).isEqualTo(v1);
+      }
     }
   }
 
@@ -555,6 +562,13 @@ public abstract class AbstractTransactionTest {
       txn.put(testCf, k1, v1);
 
       try(final RocksIterator iterator = txn.getIterator(readOptions, testCf)) {
+        iterator.seek(k1);
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo(k1);
+        assertThat(iterator.value()).isEqualTo(v1);
+      }
+
+      try (final RocksIterator iterator = txn.getIterator(testCf)) {
         iterator.seek(k1);
         assertThat(iterator.isValid()).isTrue();
         assertThat(iterator.key()).isEqualTo(k1);

--- a/java/src/test/java/org/rocksdb/KeyMayExistTest.java
+++ b/java/src/test/java/org/rocksdb/KeyMayExistTest.java
@@ -261,10 +261,12 @@ public class KeyMayExistTest {
     keyBuffer.flip();
 
     assertThat(db.keyMayExist(keyBuffer)).isEqualTo(true);
+    keyBuffer.flip();
 
     final ByteBuffer valueBuffer = ByteBuffer.allocateDirect(value.length + 24);
     valueBuffer.position(12);
     KeyMayExist keyMayExist = db.keyMayExist(keyBuffer, valueBuffer);
+    keyBuffer.flip();
     assertThat(keyMayExist.exists).isEqualTo(KeyMayExist.KeyMayExistEnum.kExistsWithValue);
     assertThat(keyMayExist.valueLength).isEqualTo(value.length);
     assertThat(valueBuffer.position()).isEqualTo(12);
@@ -303,10 +305,11 @@ public class KeyMayExistTest {
 
     try (final ReadOptions readOptions = new ReadOptions()) {
       assertThat(db.keyMayExist(readOptions, keyBuffer)).isEqualTo(true);
-
+      keyBuffer.flip();
       final ByteBuffer valueBuffer = ByteBuffer.allocateDirect(value.length + 24);
       valueBuffer.position(12);
       KeyMayExist keyMayExist = db.keyMayExist(readOptions, keyBuffer, valueBuffer);
+      keyBuffer.flip();
       assertThat(keyMayExist.exists).isEqualTo(KeyMayExist.KeyMayExistEnum.kExistsWithValue);
       assertThat(keyMayExist.valueLength).isEqualTo(value.length);
       assertThat(valueBuffer.position()).isEqualTo(12);
@@ -318,6 +321,7 @@ public class KeyMayExistTest {
       valueBuffer.limit(value.length + 24);
       valueBuffer.position(25);
       keyMayExist = db.keyMayExist(readOptions, keyBuffer, valueBuffer);
+      keyBuffer.flip();
       assertThat(keyMayExist.exists).isEqualTo(KeyMayExist.KeyMayExistEnum.kExistsWithValue);
       assertThat(keyMayExist.valueLength).isEqualTo(value.length);
       assertThat(valueBuffer.position()).isEqualTo(25);
@@ -362,7 +366,9 @@ public class KeyMayExistTest {
     keyBuffer.flip();
 
     assertThat(db.keyMayExist(keyBuffer)).isEqualTo(true);
+    keyBuffer.flip();
     assertThat(db.keyMayExist(columnFamilyHandleList.get(1), keyBuffer)).isEqualTo(false);
+    keyBuffer.flip();
     assertThat(db.keyMayExist(columnFamilyHandleList.get(0), keyBuffer)).isEqualTo(true);
 
     // 1 is just a CF
@@ -372,8 +378,11 @@ public class KeyMayExistTest {
     keyBuffer.flip();
 
     assertThat(db.keyMayExist(keyBuffer)).isEqualTo(false);
+    keyBuffer.flip();
     assertThat(db.keyMayExist(columnFamilyHandleList.get(1), keyBuffer)).isEqualTo(true);
+    keyBuffer.flip();
     assertThat(db.keyMayExist(columnFamilyHandleList.get(0), keyBuffer)).isEqualTo(false);
+    keyBuffer.flip();
 
     exceptionRule.expect(AssertionError.class);
     exceptionRule.expectMessage(
@@ -395,8 +404,10 @@ public class KeyMayExistTest {
 
     try (final ReadOptions readOptions = new ReadOptions()) {
       assertThat(db.keyMayExist(keyBuffer)).isEqualTo(true);
+      keyBuffer.flip();
       assertThat(db.keyMayExist(columnFamilyHandleList.get(1), readOptions, keyBuffer))
           .isEqualTo(false);
+      keyBuffer.flip();
       assertThat(db.keyMayExist(columnFamilyHandleList.get(0), readOptions, keyBuffer))
           .isEqualTo(true);
 
@@ -407,8 +418,10 @@ public class KeyMayExistTest {
       keyBuffer.flip();
 
       assertThat(db.keyMayExist(readOptions, keyBuffer)).isEqualTo(false);
+      keyBuffer.flip();
       assertThat(db.keyMayExist(columnFamilyHandleList.get(1), readOptions, keyBuffer))
           .isEqualTo(true);
+      keyBuffer.flip();
       assertThat(db.keyMayExist(columnFamilyHandleList.get(0), readOptions, keyBuffer))
           .isEqualTo(false);
 
@@ -432,10 +445,11 @@ public class KeyMayExistTest {
     keyBuffer.flip();
 
     assertThat(db.keyMayExist(columnFamilyHandleList.get(1), keyBuffer)).isEqualTo(true);
-
+    keyBuffer.flip();
     final ByteBuffer valueBuffer = ByteBuffer.allocateDirect(value.length + 24);
     valueBuffer.position(12);
     KeyMayExist keyMayExist = db.keyMayExist(columnFamilyHandleList.get(1), keyBuffer, valueBuffer);
+    keyBuffer.flip();
     assertThat(keyMayExist.exists).isEqualTo(KeyMayExist.KeyMayExistEnum.kExistsWithValue);
     assertThat(keyMayExist.valueLength).isEqualTo(value.length);
     assertThat(valueBuffer.position()).isEqualTo(12);
@@ -474,11 +488,12 @@ public class KeyMayExistTest {
     try (final ReadOptions readOptions = new ReadOptions()) {
       assertThat(db.keyMayExist(columnFamilyHandleList.get(1), readOptions, keyBuffer))
           .isEqualTo(true);
-
+      keyBuffer.flip();
       final ByteBuffer valueBuffer = ByteBuffer.allocateDirect(value.length + 24);
       valueBuffer.position(12);
       KeyMayExist keyMayExist =
           db.keyMayExist(columnFamilyHandleList.get(1), readOptions, keyBuffer, valueBuffer);
+      keyBuffer.flip();
       assertThat(keyMayExist.exists).isEqualTo(KeyMayExist.KeyMayExistEnum.kExistsWithValue);
       assertThat(keyMayExist.valueLength).isEqualTo(value.length);
       assertThat(valueBuffer.position()).isEqualTo(12);
@@ -491,6 +506,7 @@ public class KeyMayExistTest {
       valueBuffer.position(25);
       keyMayExist =
           db.keyMayExist(columnFamilyHandleList.get(1), readOptions, keyBuffer, valueBuffer);
+      keyBuffer.flip();
       assertThat(keyMayExist.exists).isEqualTo(KeyMayExist.KeyMayExistEnum.kExistsWithValue);
       assertThat(keyMayExist.valueLength).isEqualTo(value.length);
       assertThat(valueBuffer.position()).isEqualTo(25);

--- a/java/src/test/java/org/rocksdb/MergeCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/MergeCFVariantsTest.java
@@ -5,6 +5,15 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.MergeTest.longFromByteArray;
+import static org.rocksdb.MergeTest.longToByteArray;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,130 +21,110 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.rocksdb.MergeTest.longFromByteArray;
-import static org.rocksdb.MergeTest.longToByteArray;
-
 @RunWith(Parameterized.class)
 public class MergeCFVariantsTest {
+  @FunctionalInterface
+  interface FunctionMerge<PDatabase, PColumnFamilyHandle, PLeft, PRight> {
+    public void apply(PDatabase db, PColumnFamilyHandle one, PLeft two, PRight three)
+        throws RocksDBException;
+  }
 
-    @FunctionalInterface
-    interface FunctionMerge<PDatabase, PColumnFamilyHandle, PLeft, PRight> {
-        public void apply(PDatabase db, PColumnFamilyHandle one, PLeft two, PRight three) throws RocksDBException;
-    }
-
-    @Parameterized.Parameters
-    public static List<FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]>> data() {
-        return Arrays.asList(
-                RocksDB::merge,
-                (db, cfh, left, right) -> db.merge(cfh, new WriteOptions(), left, right),
-                (db, cfh, left, right) -> {
-                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
-                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
-                    db.merge(cfh, left0, 7, left.length, right0, 4, right.length);
-                },
-                (db, cfh, left, right) -> {
-                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
-                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
-                    db.merge(cfh, new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
-                },
-                (db, cfh, left, right) -> {
-                    final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
-                    final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
-                    bbLeft.put(left).flip();
-                    bbRight.put(right).flip();
-                    db.merge(cfh, new WriteOptions(), bbLeft, bbRight);
-                },
+  @Parameterized.Parameters
+  public static List<FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]>> data() {
+    return Arrays.asList(RocksDB::merge,
+        (db, cfh, left, right)
+            -> db.merge(cfh, new WriteOptions(), left, right),
+        (db, cfh, left, right)
+            -> {
+          final byte[] left0 =
+              ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+          final byte[] right0 =
+              ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+          db.merge(cfh, left0, 7, left.length, right0, 4, right.length);
+        },
+        (db, cfh, left, right)
+            -> {
+          final byte[] left0 =
+              ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+          final byte[] right0 =
+              ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+          db.merge(cfh, new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
+        },
+        (db, cfh, left, right)
+            -> {
+          final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
+          final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
+          bbLeft.put(left).flip();
+          bbRight.put(right).flip();
+          db.merge(cfh, new WriteOptions(), bbLeft, bbRight);
+        },
         (db, cfh, left, right) -> {
-            final ByteBuffer bbLeft = ByteBuffer.allocate(100);
-            final ByteBuffer bbRight = ByteBuffer.allocate(100);
-            bbLeft.put(left).flip();
-            bbRight.put(right).flip();
-            db.merge(cfh, new WriteOptions(), bbLeft, bbRight);
+          final ByteBuffer bbLeft = ByteBuffer.allocate(100);
+          final ByteBuffer bbRight = ByteBuffer.allocate(100);
+          bbLeft.put(left).flip();
+          bbRight.put(right).flip();
+          db.merge(cfh, new WriteOptions(), bbLeft, bbRight);
+        });
+  }
+
+  private final FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction;
+
+  public MergeCFVariantsTest(
+      final FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction) {
+    this.mergeFunction = mergeFunction;
+  }
+
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  @Test
+  public void cFUInt64AddOperatorOption() throws InterruptedException, RocksDBException {
+    try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
+         final ColumnFamilyOptions cfOpt1 =
+             new ColumnFamilyOptions().setMergeOperator(uint64AddOperator);
+         final ColumnFamilyOptions cfOpt2 =
+             new ColumnFamilyOptions().setMergeOperator(uint64AddOperator)) {
+      final List<ColumnFamilyDescriptor> cfDescriptors =
+          Arrays.asList(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt1),
+              new ColumnFamilyDescriptor("new_cf".getBytes(), cfOpt2));
+      final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+      try (final DBOptions opt =
+               new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+           final RocksDB db = RocksDB.open(
+               opt, dbFolder.getRoot().getAbsolutePath(), cfDescriptors, columnFamilyHandleList)) {
+        try {
+          // writing (long)100 under key
+          db.put(columnFamilyHandleList.get(1), "cfkey".getBytes(), longToByteArray(100));
+          // merge (long)1 under key
+          mergeFunction.apply(
+              db, columnFamilyHandleList.get(1), "cfkey".getBytes(), longToByteArray(1));
+          byte[] value = db.get(columnFamilyHandleList.get(1), "cfkey".getBytes());
+          long longValue = longFromByteArray(value);
+
+          // Test also with createColumnFamily
+          try (final ColumnFamilyOptions cfHandleOpts =
+                   new ColumnFamilyOptions().setMergeOperator(uint64AddOperator);
+               final ColumnFamilyHandle cfHandle = db.createColumnFamily(
+                   new ColumnFamilyDescriptor("new_cf2".getBytes(), cfHandleOpts))) {
+            // writing (long)200 under cfkey2
+            db.put(cfHandle, "cfkey2".getBytes(), longToByteArray(200));
+            // merge (long)50 under cfkey2
+            db.merge(cfHandle, new WriteOptions(), "cfkey2".getBytes(), longToByteArray(50));
+            value = db.get(cfHandle, "cfkey2".getBytes());
+            long longValueTmpCf = longFromByteArray(value);
+
+            assertThat(longValue).isEqualTo(101);
+            assertThat(longValueTmpCf).isEqualTo(250);
+          }
+        } finally {
+          for (final ColumnFamilyHandle columnFamilyHandle : columnFamilyHandleList) {
+            columnFamilyHandle.close();
+          }
         }
-        );
+      }
     }
-
-    private final FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction;
-
-    public MergeCFVariantsTest(final FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction) {
-        this.mergeFunction = mergeFunction;
-    }
-
-    @ClassRule
-    public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
-            new RocksNativeLibraryResource();
-
-    @Rule
-    public TemporaryFolder dbFolder = new TemporaryFolder();
-
-    @Test
-    public void cFUInt64AddOperatorOption()
-            throws InterruptedException, RocksDBException {
-        try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
-             final ColumnFamilyOptions cfOpt1 = new ColumnFamilyOptions()
-                     .setMergeOperator(uint64AddOperator);
-             final ColumnFamilyOptions cfOpt2 = new ColumnFamilyOptions()
-                     .setMergeOperator(uint64AddOperator)
-        ) {
-            final List<ColumnFamilyDescriptor> cfDescriptors = Arrays.asList(
-                    new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt1),
-                    new ColumnFamilyDescriptor("new_cf".getBytes(), cfOpt2)
-            );
-            final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
-            try (final DBOptions opt = new DBOptions()
-                    .setCreateIfMissing(true)
-                    .setCreateMissingColumnFamilies(true);
-                 final RocksDB db = RocksDB.open(opt,
-                         dbFolder.getRoot().getAbsolutePath(), cfDescriptors,
-                         columnFamilyHandleList)
-            ) {
-                try {
-                    // writing (long)100 under key
-                    db.put(columnFamilyHandleList.get(1),
-                            "cfkey".getBytes(), longToByteArray(100));
-                    // merge (long)1 under key
-                    mergeFunction.apply(db, columnFamilyHandleList.get(1),
-                            "cfkey".getBytes(), longToByteArray(1));
-                    byte[] value = db.get(columnFamilyHandleList.get(1),
-                            "cfkey".getBytes());
-                    long longValue = longFromByteArray(value);
-
-                    // Test also with createColumnFamily
-                    try (final ColumnFamilyOptions cfHandleOpts =
-                                 new ColumnFamilyOptions()
-                                         .setMergeOperator(uint64AddOperator);
-                         final ColumnFamilyHandle cfHandle =
-                                 db.createColumnFamily(
-                                         new ColumnFamilyDescriptor("new_cf2".getBytes(),
-                                                 cfHandleOpts))
-                    ) {
-                        // writing (long)200 under cfkey2
-                        db.put(cfHandle, "cfkey2".getBytes(), longToByteArray(200));
-                        // merge (long)50 under cfkey2
-                        db.merge(cfHandle, new WriteOptions(), "cfkey2".getBytes(),
-                                longToByteArray(50));
-                        value = db.get(cfHandle, "cfkey2".getBytes());
-                        long longValueTmpCf = longFromByteArray(value);
-
-                        assertThat(longValue).isEqualTo(101);
-                        assertThat(longValueTmpCf).isEqualTo(250);
-                    }
-                } finally {
-                    for (final ColumnFamilyHandle columnFamilyHandle :
-                            columnFamilyHandleList) {
-                        columnFamilyHandle.close();
-                    }
-                }
-            }
-        }
-    }
-
-
+  }
 }

--- a/java/src/test/java/org/rocksdb/MergeCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/MergeCFVariantsTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -34,6 +35,16 @@ public class MergeCFVariantsTest {
         return Arrays.asList(
                 RocksDB::merge,
                 (db, cfh, left, right) -> db.merge(cfh, new WriteOptions(), left, right),
+                (db, cfh, left, right) -> {
+                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+                    db.merge(cfh, left0, 7, left.length, right0, 4, right.length);
+                },
+                (db, cfh, left, right) -> {
+                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+                    db.merge(cfh, new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
+                },
                 (db, cfh, left, right) -> {
                     final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
                     final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);

--- a/java/src/test/java/org/rocksdb/MergeCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/MergeCFVariantsTest.java
@@ -67,12 +67,8 @@ public class MergeCFVariantsTest {
         });
   }
 
-  private final FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction;
-
-  public MergeCFVariantsTest(
-      final FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction) {
-    this.mergeFunction = mergeFunction;
-  }
+  @Parameterized.Parameter
+  public FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction;
 
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =

--- a/java/src/test/java/org/rocksdb/MergeCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/MergeCFVariantsTest.java
@@ -1,0 +1,130 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.MergeTest.longFromByteArray;
+import static org.rocksdb.MergeTest.longToByteArray;
+
+@RunWith(Parameterized.class)
+public class MergeCFVariantsTest {
+
+    @FunctionalInterface
+    interface FunctionMerge<PDatabase, PColumnFamilyHandle, PLeft, PRight> {
+        public void apply(PDatabase db, PColumnFamilyHandle one, PLeft two, PRight three) throws RocksDBException;
+    }
+
+    @Parameterized.Parameters
+    public static List<FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]>> data() {
+        return Arrays.asList(
+                RocksDB::merge,
+                (db, cfh, left, right) -> db.merge(cfh, new WriteOptions(), left, right),
+                (db, cfh, left, right) -> {
+                    final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
+                    final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
+                    bbLeft.put(left).flip();
+                    bbRight.put(right).flip();
+                    db.merge(cfh, new WriteOptions(), bbLeft, bbRight);
+                },
+        (db, cfh, left, right) -> {
+            final ByteBuffer bbLeft = ByteBuffer.allocate(100);
+            final ByteBuffer bbRight = ByteBuffer.allocate(100);
+            bbLeft.put(left).flip();
+            bbRight.put(right).flip();
+            db.merge(cfh, new WriteOptions(), bbLeft, bbRight);
+        }
+        );
+    }
+
+    private final FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction;
+
+    public MergeCFVariantsTest(final FunctionMerge<RocksDB, ColumnFamilyHandle, byte[], byte[]> mergeFunction) {
+        this.mergeFunction = mergeFunction;
+    }
+
+    @ClassRule
+    public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+            new RocksNativeLibraryResource();
+
+    @Rule
+    public TemporaryFolder dbFolder = new TemporaryFolder();
+
+    @Test
+    public void cFUInt64AddOperatorOption()
+            throws InterruptedException, RocksDBException {
+        try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
+             final ColumnFamilyOptions cfOpt1 = new ColumnFamilyOptions()
+                     .setMergeOperator(uint64AddOperator);
+             final ColumnFamilyOptions cfOpt2 = new ColumnFamilyOptions()
+                     .setMergeOperator(uint64AddOperator)
+        ) {
+            final List<ColumnFamilyDescriptor> cfDescriptors = Arrays.asList(
+                    new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt1),
+                    new ColumnFamilyDescriptor("new_cf".getBytes(), cfOpt2)
+            );
+            final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+            try (final DBOptions opt = new DBOptions()
+                    .setCreateIfMissing(true)
+                    .setCreateMissingColumnFamilies(true);
+                 final RocksDB db = RocksDB.open(opt,
+                         dbFolder.getRoot().getAbsolutePath(), cfDescriptors,
+                         columnFamilyHandleList)
+            ) {
+                try {
+                    // writing (long)100 under key
+                    db.put(columnFamilyHandleList.get(1),
+                            "cfkey".getBytes(), longToByteArray(100));
+                    // merge (long)1 under key
+                    mergeFunction.apply(db, columnFamilyHandleList.get(1),
+                            "cfkey".getBytes(), longToByteArray(1));
+                    byte[] value = db.get(columnFamilyHandleList.get(1),
+                            "cfkey".getBytes());
+                    long longValue = longFromByteArray(value);
+
+                    // Test also with createColumnFamily
+                    try (final ColumnFamilyOptions cfHandleOpts =
+                                 new ColumnFamilyOptions()
+                                         .setMergeOperator(uint64AddOperator);
+                         final ColumnFamilyHandle cfHandle =
+                                 db.createColumnFamily(
+                                         new ColumnFamilyDescriptor("new_cf2".getBytes(),
+                                                 cfHandleOpts))
+                    ) {
+                        // writing (long)200 under cfkey2
+                        db.put(cfHandle, "cfkey2".getBytes(), longToByteArray(200));
+                        // merge (long)50 under cfkey2
+                        db.merge(cfHandle, new WriteOptions(), "cfkey2".getBytes(),
+                                longToByteArray(50));
+                        value = db.get(cfHandle, "cfkey2".getBytes());
+                        long longValueTmpCf = longFromByteArray(value);
+
+                        assertThat(longValue).isEqualTo(101);
+                        assertThat(longValueTmpCf).isEqualTo(250);
+                    }
+                } finally {
+                    for (final ColumnFamilyHandle columnFamilyHandle :
+                            columnFamilyHandleList) {
+                        columnFamilyHandle.close();
+                    }
+                }
+            }
+        }
+    }
+
+
+}

--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -45,14 +45,14 @@ public class MergeTest {
     }
   }
 
-  private byte[] longToByteArray(final long l) {
+  static byte[] longToByteArray(final long l) {
     final ByteBuffer buf =
         ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.LITTLE_ENDIAN);
     buf.putLong(l);
     return buf.array();
   }
 
-  private long longFromByteArray(final byte[] a) {
+  static long longFromByteArray(final byte[] a) {
     final ByteBuffer buf =
         ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.LITTLE_ENDIAN);
     buf.put(a);

--- a/java/src/test/java/org/rocksdb/MergeVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/MergeVariantsTest.java
@@ -1,0 +1,87 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.MergeTest.longFromByteArray;
+import static org.rocksdb.MergeTest.longToByteArray;
+
+@RunWith(Parameterized.class)
+public class MergeVariantsTest {
+
+    @FunctionalInterface
+    interface FunctionMerge<PDatabase, PLeft, PRight> {
+        public void apply(PDatabase db, PLeft two, PRight three) throws RocksDBException;
+    }
+
+    @Parameterized.Parameters
+    public static List<MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]>> data() {
+        return Arrays.asList(
+                RocksDB::merge,
+                (db, left, right) -> db.merge(new WriteOptions(), left, right),
+                (db, left, right) -> {
+                    final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
+                    final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
+                    bbLeft.put(left).flip();
+                    bbRight.put(right).flip();
+                    db.merge(new WriteOptions(), bbLeft, bbRight);
+                },
+                (db, left, right) -> {
+                    final ByteBuffer bbLeft = ByteBuffer.allocate(100);
+                    final ByteBuffer bbRight = ByteBuffer.allocate(100);
+                    bbLeft.put(left).flip();
+                    bbRight.put(right).flip();
+                    db.merge(new WriteOptions(), bbLeft, bbRight);
+                }
+        );
+    }
+
+    private final MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction;
+
+    public MergeVariantsTest(final MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction) {
+        this.mergeFunction = mergeFunction;
+    }
+
+    @ClassRule
+    public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+            new RocksNativeLibraryResource();
+
+    @Rule
+    public TemporaryFolder dbFolder = new TemporaryFolder();
+
+    @Test
+    public void uint64AddOperatorOption()
+            throws InterruptedException, RocksDBException {
+        try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
+             final Options opt = new Options()
+                     .setCreateIfMissing(true)
+                     .setMergeOperator(uint64AddOperator);
+             final RocksDB db = RocksDB.open(opt,
+                     dbFolder.getRoot().getAbsolutePath())) {
+            // Writing (long)100 under key
+            db.put("key".getBytes(), longToByteArray(100));
+
+            // Writing (long)1 under key
+            mergeFunction.apply(db, "key".getBytes(), longToByteArray(1));
+
+            final byte[] value = db.get("key".getBytes());
+            final long longValue = longFromByteArray(value);
+
+            assertThat(longValue).isEqualTo(101);
+        }
+    }
+}

--- a/java/src/test/java/org/rocksdb/MergeVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/MergeVariantsTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,6 +34,16 @@ public class MergeVariantsTest {
         return Arrays.asList(
                 RocksDB::merge,
                 (db, left, right) -> db.merge(new WriteOptions(), left, right),
+                (db, left, right) -> {
+                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+                    db.merge(left0, 7, left.length, right0, 4, right.length);
+                },
+                (db, left, right) -> {
+                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+                    db.merge(new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
+                },
                 (db, left, right) -> {
                     final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
                     final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);

--- a/java/src/test/java/org/rocksdb/MergeVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/MergeVariantsTest.java
@@ -5,6 +5,14 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.MergeTest.longFromByteArray;
+import static org.rocksdb.MergeTest.longToByteArray;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,87 +20,80 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.rocksdb.MergeTest.longFromByteArray;
-import static org.rocksdb.MergeTest.longToByteArray;
-
 @RunWith(Parameterized.class)
 public class MergeVariantsTest {
+  @FunctionalInterface
+  interface FunctionMerge<PDatabase, PLeft, PRight> {
+    public void apply(PDatabase db, PLeft two, PRight three) throws RocksDBException;
+  }
 
-    @FunctionalInterface
-    interface FunctionMerge<PDatabase, PLeft, PRight> {
-        public void apply(PDatabase db, PLeft two, PRight three) throws RocksDBException;
+  @Parameterized.Parameters
+  public static List<MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]>> data() {
+    return Arrays.asList(RocksDB::merge,
+        (db, left, right)
+            -> db.merge(new WriteOptions(), left, right),
+        (db, left, right)
+            -> {
+          final byte[] left0 =
+              ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+          final byte[] right0 =
+              ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+          db.merge(left0, 7, left.length, right0, 4, right.length);
+        },
+        (db, left, right)
+            -> {
+          final byte[] left0 =
+              ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+          final byte[] right0 =
+              ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+          db.merge(new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
+        },
+        (db, left, right)
+            -> {
+          final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
+          final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
+          bbLeft.put(left).flip();
+          bbRight.put(right).flip();
+          db.merge(new WriteOptions(), bbLeft, bbRight);
+        },
+        (db, left, right) -> {
+          final ByteBuffer bbLeft = ByteBuffer.allocate(100);
+          final ByteBuffer bbRight = ByteBuffer.allocate(100);
+          bbLeft.put(left).flip();
+          bbRight.put(right).flip();
+          db.merge(new WriteOptions(), bbLeft, bbRight);
+        });
+  }
+
+  private final MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction;
+
+  public MergeVariantsTest(
+      final MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction) {
+    this.mergeFunction = mergeFunction;
+  }
+
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  @Test
+  public void uint64AddOperatorOption() throws InterruptedException, RocksDBException {
+    try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
+         final Options opt =
+             new Options().setCreateIfMissing(true).setMergeOperator(uint64AddOperator);
+         final RocksDB db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath())) {
+      // Writing (long)100 under key
+      db.put("key".getBytes(), longToByteArray(100));
+
+      // Writing (long)1 under key
+      mergeFunction.apply(db, "key".getBytes(), longToByteArray(1));
+
+      final byte[] value = db.get("key".getBytes());
+      final long longValue = longFromByteArray(value);
+
+      assertThat(longValue).isEqualTo(101);
     }
-
-    @Parameterized.Parameters
-    public static List<MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]>> data() {
-        return Arrays.asList(
-                RocksDB::merge,
-                (db, left, right) -> db.merge(new WriteOptions(), left, right),
-                (db, left, right) -> {
-                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
-                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
-                    db.merge(left0, 7, left.length, right0, 4, right.length);
-                },
-                (db, left, right) -> {
-                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
-                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
-                    db.merge(new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
-                },
-                (db, left, right) -> {
-                    final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
-                    final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
-                    bbLeft.put(left).flip();
-                    bbRight.put(right).flip();
-                    db.merge(new WriteOptions(), bbLeft, bbRight);
-                },
-                (db, left, right) -> {
-                    final ByteBuffer bbLeft = ByteBuffer.allocate(100);
-                    final ByteBuffer bbRight = ByteBuffer.allocate(100);
-                    bbLeft.put(left).flip();
-                    bbRight.put(right).flip();
-                    db.merge(new WriteOptions(), bbLeft, bbRight);
-                }
-        );
-    }
-
-    private final MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction;
-
-    public MergeVariantsTest(final MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction) {
-        this.mergeFunction = mergeFunction;
-    }
-
-    @ClassRule
-    public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
-            new RocksNativeLibraryResource();
-
-    @Rule
-    public TemporaryFolder dbFolder = new TemporaryFolder();
-
-    @Test
-    public void uint64AddOperatorOption()
-            throws InterruptedException, RocksDBException {
-        try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
-             final Options opt = new Options()
-                     .setCreateIfMissing(true)
-                     .setMergeOperator(uint64AddOperator);
-             final RocksDB db = RocksDB.open(opt,
-                     dbFolder.getRoot().getAbsolutePath())) {
-            // Writing (long)100 under key
-            db.put("key".getBytes(), longToByteArray(100));
-
-            // Writing (long)1 under key
-            mergeFunction.apply(db, "key".getBytes(), longToByteArray(1));
-
-            final byte[] value = db.get("key".getBytes());
-            final long longValue = longFromByteArray(value);
-
-            assertThat(longValue).isEqualTo(101);
-        }
-    }
+  }
 }

--- a/java/src/test/java/org/rocksdb/MergeVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/MergeVariantsTest.java
@@ -65,12 +65,8 @@ public class MergeVariantsTest {
         });
   }
 
-  private final MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction;
-
-  public MergeVariantsTest(
-      final MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction) {
-    this.mergeFunction = mergeFunction;
-  }
+  @Parameterized.Parameter
+  public MergeVariantsTest.FunctionMerge<RocksDB, byte[], byte[]> mergeFunction;
 
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =

--- a/java/src/test/java/org/rocksdb/OptimisticTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/OptimisticTransactionTest.java
@@ -373,12 +373,13 @@ public class OptimisticTransactionTest extends AbstractTransactionTest {
         .setCreateIfMissing(true)
         .setCreateMissingColumnFamilies(true);
 
+    final ColumnFamilyOptions defaultColumnFamilyOptions = new ColumnFamilyOptions();
+    defaultColumnFamilyOptions.setMergeOperator(new StringAppendOperator("++"));
     final ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
-    final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
-        Arrays.asList(
-            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY),
-            new ColumnFamilyDescriptor(TXN_TEST_COLUMN_FAMILY,
-                columnFamilyOptions));
+    columnFamilyOptions.setMergeOperator(new StringAppendOperator("**"));
+    final List<ColumnFamilyDescriptor> columnFamilyDescriptors = Arrays.asList(
+        new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, defaultColumnFamilyOptions),
+        new ColumnFamilyDescriptor(TXN_TEST_COLUMN_FAMILY, columnFamilyOptions));
     final List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
 
     final OptimisticTransactionDB optimisticTxnDb;

--- a/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
@@ -69,14 +69,10 @@ public class PutCFVariantsTest {
         });
   }
 
-  private final PutCFVariantsTest
+  @Parameterized.Parameter
+          public
+  PutCFVariantsTest
       .FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction;
-
-  public PutCFVariantsTest(
-      final PutCFVariantsTest
-          .FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction) {
-    this.putFunction = putFunction;
-  }
 
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =

--- a/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
@@ -5,6 +5,15 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.MergeTest.longFromByteArray;
+import static org.rocksdb.MergeTest.longToByteArray;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,125 +21,112 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.rocksdb.MergeTest.longFromByteArray;
-import static org.rocksdb.MergeTest.longToByteArray;
-
 @RunWith(Parameterized.class)
 public class PutCFVariantsTest {
+  @FunctionalInterface
+  interface FunctionCFPut<PDatabase, PColumnFamilyHandle, PLeft, PRight> {
+    public void apply(PDatabase db, PColumnFamilyHandle cfh, PLeft two, PRight three)
+        throws RocksDBException;
+  }
 
-    @FunctionalInterface
-    interface FunctionCFPut<PDatabase, PColumnFamilyHandle, PLeft, PRight> {
-        public void apply(PDatabase db, PColumnFamilyHandle cfh, PLeft two, PRight three) throws RocksDBException;
-    }
+  @Parameterized.Parameters
+  public static List<PutCFVariantsTest.FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]>>
+  data() {
+    return Arrays.asList(RocksDB::put,
+        (db, cfh, left, right)
+            -> db.put(cfh, new WriteOptions(), left, right),
+        (db, cfh, left, right)
+            -> {
+          final byte[] left0 =
+              ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+          final byte[] right0 =
+              ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+          db.put(cfh, left0, 7, left.length, right0, 4, right.length);
+        },
+        (db, cfh, left, right)
+            -> {
+          final byte[] left0 =
+              ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+          final byte[] right0 =
+              ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+          db.put(cfh, new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
+        },
 
-    @Parameterized.Parameters
-    public static List<PutCFVariantsTest.FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]>> data() {
-        return Arrays.asList(
-                RocksDB::put,
-                (db, cfh, left, right) -> db.put(cfh, new WriteOptions(), left, right),
-                (db, cfh, left, right) -> {
-                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
-                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
-                    db.put(cfh, left0, 7, left.length, right0, 4, right.length);
-                },
-                (db, cfh, left, right) -> {
-                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
-                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
-                    db.put(cfh, new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
-                },
+        (db, cfh, left, right)
+            -> {
+          final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
+          final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
+          bbLeft.put(left).flip();
+          bbRight.put(right).flip();
+          db.put(cfh, new WriteOptions(), bbLeft, bbRight);
+        },
+        (db, cfh, left, right) -> {
+          final ByteBuffer bbLeft = ByteBuffer.allocate(100);
+          final ByteBuffer bbRight = ByteBuffer.allocate(100);
+          bbLeft.put(left).flip();
+          bbRight.put(right).flip();
+          db.put(cfh, new WriteOptions(), bbLeft, bbRight);
+        });
+  }
 
-                (db, cfh, left, right) -> {
-                    final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
-                    final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
-                    bbLeft.put(left).flip();
-                    bbRight.put(right).flip();
-                    db.put(cfh, new WriteOptions(), bbLeft, bbRight);
-                },
-                (db, cfh, left, right) -> {
-                    final ByteBuffer bbLeft = ByteBuffer.allocate(100);
-                    final ByteBuffer bbRight = ByteBuffer.allocate(100);
-                    bbLeft.put(left).flip();
-                    bbRight.put(right).flip();
-                    db.put(cfh, new WriteOptions(), bbLeft, bbRight);
-                }
-        );
-    }
+  private final PutCFVariantsTest
+      .FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction;
 
-    private final PutCFVariantsTest.FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction;
+  public PutCFVariantsTest(
+      final PutCFVariantsTest
+          .FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction) {
+    this.putFunction = putFunction;
+  }
 
-    public PutCFVariantsTest(final PutCFVariantsTest.FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction) {
-        this.putFunction = putFunction;
-    }
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
 
-    @ClassRule
-    public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
-            new RocksNativeLibraryResource();
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
 
-    @Rule
-    public TemporaryFolder dbFolder = new TemporaryFolder();
+  @Test
+  public void writeAndRead() throws InterruptedException, RocksDBException {
+    try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
+         final ColumnFamilyOptions cfOpt1 =
+             new ColumnFamilyOptions().setMergeOperator(uint64AddOperator);
+         final ColumnFamilyOptions cfOpt2 =
+             new ColumnFamilyOptions().setMergeOperator(uint64AddOperator)) {
+      final List<ColumnFamilyDescriptor> cfDescriptors =
+          Arrays.asList(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt1),
+              new ColumnFamilyDescriptor("new_cf".getBytes(), cfOpt2));
+      final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+      try (final DBOptions opt =
+               new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+           final RocksDB db = RocksDB.open(
+               opt, dbFolder.getRoot().getAbsolutePath(), cfDescriptors, columnFamilyHandleList)) {
+        try {
+          // writing (long)100 under key
+          putFunction.apply(
+              db, columnFamilyHandleList.get(1), "cfkey".getBytes(), longToByteArray(100));
+          // merge (long)1 under key
+          byte[] value = db.get(columnFamilyHandleList.get(1), "cfkey".getBytes());
+          long longValue = longFromByteArray(value);
 
-    @Test
-    public void writeAndRead()
-            throws InterruptedException, RocksDBException {
-        try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
-             final ColumnFamilyOptions cfOpt1 = new ColumnFamilyOptions()
-                     .setMergeOperator(uint64AddOperator);
-             final ColumnFamilyOptions cfOpt2 = new ColumnFamilyOptions()
-                     .setMergeOperator(uint64AddOperator)
-        ) {
-            final List<ColumnFamilyDescriptor> cfDescriptors = Arrays.asList(
-                    new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt1),
-                    new ColumnFamilyDescriptor("new_cf".getBytes(), cfOpt2)
-            );
-            final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
-            try (final DBOptions opt = new DBOptions()
-                    .setCreateIfMissing(true)
-                    .setCreateMissingColumnFamilies(true);
-                 final RocksDB db = RocksDB.open(opt,
-                         dbFolder.getRoot().getAbsolutePath(), cfDescriptors,
-                         columnFamilyHandleList)
-            ) {
-                try {
-                    // writing (long)100 under key
-                    putFunction.apply(db, columnFamilyHandleList.get(1),
-                            "cfkey".getBytes(), longToByteArray(100));
-                    // merge (long)1 under key
-                    byte[] value = db.get(columnFamilyHandleList.get(1),
-                            "cfkey".getBytes());
-                    long longValue = longFromByteArray(value);
+          // Test also with createColumnFamily
+          try (final ColumnFamilyOptions cfHandleOpts =
+                   new ColumnFamilyOptions().setMergeOperator(uint64AddOperator);
+               final ColumnFamilyHandle cfHandle = db.createColumnFamily(
+                   new ColumnFamilyDescriptor("new_cf2".getBytes(), cfHandleOpts))) {
+            // writing (long)200 under cfkey2
+            db.put(cfHandle, "cfkey2".getBytes(), longToByteArray(200));
+            // merge (long)50 under cfkey2
+            value = db.get(cfHandle, "cfkey2".getBytes());
+            long longValueTmpCf = longFromByteArray(value);
 
-                    // Test also with createColumnFamily
-                    try (final ColumnFamilyOptions cfHandleOpts =
-                                 new ColumnFamilyOptions()
-                                         .setMergeOperator(uint64AddOperator);
-                         final ColumnFamilyHandle cfHandle =
-                                 db.createColumnFamily(
-                                         new ColumnFamilyDescriptor("new_cf2".getBytes(),
-                                                 cfHandleOpts))
-                    ) {
-                        // writing (long)200 under cfkey2
-                        db.put(cfHandle, "cfkey2".getBytes(), longToByteArray(200));
-                        // merge (long)50 under cfkey2
-                        value = db.get(cfHandle, "cfkey2".getBytes());
-                        long longValueTmpCf = longFromByteArray(value);
-
-                        assertThat(longValue).isEqualTo(100);
-                        assertThat(longValueTmpCf).isEqualTo(200);
-                    }
-                } finally {
-                    for (final ColumnFamilyHandle columnFamilyHandle :
-                            columnFamilyHandleList) {
-                        columnFamilyHandle.close();
-                    }
-                }
-            }
+            assertThat(longValue).isEqualTo(100);
+            assertThat(longValueTmpCf).isEqualTo(200);
+          }
+        } finally {
+          for (final ColumnFamilyHandle columnFamilyHandle : columnFamilyHandleList) {
+            columnFamilyHandle.close();
+          }
         }
+      }
     }
+  }
 }

--- a/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
@@ -70,9 +70,7 @@ public class PutCFVariantsTest {
   }
 
   @Parameterized.Parameter
-          public
-  PutCFVariantsTest
-      .FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction;
+  public PutCFVariantsTest.FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction;
 
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =

--- a/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
@@ -99,7 +99,7 @@ public class PutCFVariantsTest {
               db, columnFamilyHandleList.get(1), "cfkey".getBytes(), longToByteArray(100));
           // merge (long)1 under key
           byte[] value = db.get(columnFamilyHandleList.get(1), "cfkey".getBytes());
-          long longValue = longFromByteArray(value);
+          final long longValue = longFromByteArray(value);
 
           // Test also with createColumnFamily
           try (final ColumnFamilyOptions cfHandleOpts =
@@ -110,7 +110,7 @@ public class PutCFVariantsTest {
             db.put(cfHandle, "cfkey2".getBytes(), longToByteArray(200));
             // merge (long)50 under cfkey2
             value = db.get(cfHandle, "cfkey2".getBytes());
-            long longValueTmpCf = longFromByteArray(value);
+            final long longValueTmpCf = longFromByteArray(value);
 
             assertThat(longValue).isEqualTo(100);
             assertThat(longValueTmpCf).isEqualTo(200);

--- a/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -34,6 +35,17 @@ public class PutCFVariantsTest {
         return Arrays.asList(
                 RocksDB::put,
                 (db, cfh, left, right) -> db.put(cfh, new WriteOptions(), left, right),
+                (db, cfh, left, right) -> {
+                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+                    db.put(cfh, left0, 7, left.length, right0, 4, right.length);
+                },
+                (db, cfh, left, right) -> {
+                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+                    db.put(cfh, new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
+                },
+
                 (db, cfh, left, right) -> {
                     final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
                     final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);

--- a/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutCFVariantsTest.java
@@ -1,0 +1,124 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.MergeTest.longFromByteArray;
+import static org.rocksdb.MergeTest.longToByteArray;
+
+@RunWith(Parameterized.class)
+public class PutCFVariantsTest {
+
+    @FunctionalInterface
+    interface FunctionCFPut<PDatabase, PColumnFamilyHandle, PLeft, PRight> {
+        public void apply(PDatabase db, PColumnFamilyHandle cfh, PLeft two, PRight three) throws RocksDBException;
+    }
+
+    @Parameterized.Parameters
+    public static List<PutCFVariantsTest.FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]>> data() {
+        return Arrays.asList(
+                RocksDB::put,
+                (db, cfh, left, right) -> db.put(cfh, new WriteOptions(), left, right),
+                (db, cfh, left, right) -> {
+                    final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
+                    final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
+                    bbLeft.put(left).flip();
+                    bbRight.put(right).flip();
+                    db.put(cfh, new WriteOptions(), bbLeft, bbRight);
+                },
+                (db, cfh, left, right) -> {
+                    final ByteBuffer bbLeft = ByteBuffer.allocate(100);
+                    final ByteBuffer bbRight = ByteBuffer.allocate(100);
+                    bbLeft.put(left).flip();
+                    bbRight.put(right).flip();
+                    db.put(cfh, new WriteOptions(), bbLeft, bbRight);
+                }
+        );
+    }
+
+    private final PutCFVariantsTest.FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction;
+
+    public PutCFVariantsTest(final PutCFVariantsTest.FunctionCFPut<RocksDB, ColumnFamilyHandle, byte[], byte[]> putFunction) {
+        this.putFunction = putFunction;
+    }
+
+    @ClassRule
+    public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+            new RocksNativeLibraryResource();
+
+    @Rule
+    public TemporaryFolder dbFolder = new TemporaryFolder();
+
+    @Test
+    public void writeAndRead()
+            throws InterruptedException, RocksDBException {
+        try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
+             final ColumnFamilyOptions cfOpt1 = new ColumnFamilyOptions()
+                     .setMergeOperator(uint64AddOperator);
+             final ColumnFamilyOptions cfOpt2 = new ColumnFamilyOptions()
+                     .setMergeOperator(uint64AddOperator)
+        ) {
+            final List<ColumnFamilyDescriptor> cfDescriptors = Arrays.asList(
+                    new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt1),
+                    new ColumnFamilyDescriptor("new_cf".getBytes(), cfOpt2)
+            );
+            final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+            try (final DBOptions opt = new DBOptions()
+                    .setCreateIfMissing(true)
+                    .setCreateMissingColumnFamilies(true);
+                 final RocksDB db = RocksDB.open(opt,
+                         dbFolder.getRoot().getAbsolutePath(), cfDescriptors,
+                         columnFamilyHandleList)
+            ) {
+                try {
+                    // writing (long)100 under key
+                    putFunction.apply(db, columnFamilyHandleList.get(1),
+                            "cfkey".getBytes(), longToByteArray(100));
+                    // merge (long)1 under key
+                    byte[] value = db.get(columnFamilyHandleList.get(1),
+                            "cfkey".getBytes());
+                    long longValue = longFromByteArray(value);
+
+                    // Test also with createColumnFamily
+                    try (final ColumnFamilyOptions cfHandleOpts =
+                                 new ColumnFamilyOptions()
+                                         .setMergeOperator(uint64AddOperator);
+                         final ColumnFamilyHandle cfHandle =
+                                 db.createColumnFamily(
+                                         new ColumnFamilyDescriptor("new_cf2".getBytes(),
+                                                 cfHandleOpts))
+                    ) {
+                        // writing (long)200 under cfkey2
+                        db.put(cfHandle, "cfkey2".getBytes(), longToByteArray(200));
+                        // merge (long)50 under cfkey2
+                        value = db.get(cfHandle, "cfkey2".getBytes());
+                        long longValueTmpCf = longFromByteArray(value);
+
+                        assertThat(longValue).isEqualTo(100);
+                        assertThat(longValueTmpCf).isEqualTo(200);
+                    }
+                } finally {
+                    for (final ColumnFamilyHandle columnFamilyHandle :
+                            columnFamilyHandleList) {
+                        columnFamilyHandle.close();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/java/src/test/java/org/rocksdb/PutVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutVariantsTest.java
@@ -5,6 +5,15 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.MergeTest.longFromByteArray;
+import static org.rocksdb.MergeTest.longToByteArray;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,85 +21,76 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.rocksdb.MergeTest.longFromByteArray;
-import static org.rocksdb.MergeTest.longToByteArray;
-
 @RunWith(Parameterized.class)
 public class PutVariantsTest {
+  @FunctionalInterface
+  interface FunctionPut<PDatabase, PLeft, PRight> {
+    public void apply(PDatabase db, PLeft two, PRight three) throws RocksDBException;
+  }
 
-    @FunctionalInterface
-    interface FunctionPut<PDatabase, PLeft, PRight> {
-        public void apply(PDatabase db, PLeft two, PRight three) throws RocksDBException;
+  @Parameterized.Parameters
+  public static List<PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]>> data() {
+    return Arrays.asList(RocksDB::put,
+        (db, left, right)
+            -> db.put(new WriteOptions(), left, right),
+        (db, left, right)
+            -> {
+          final byte[] left0 =
+              ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+          final byte[] right0 =
+              ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+          db.put(left0, 7, left.length, right0, 4, right.length);
+        },
+        (db, left, right)
+            -> {
+          final byte[] left0 =
+              ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+          final byte[] right0 =
+              ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+          db.put(new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
+        },
+        (db, left, right)
+            -> {
+          final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
+          final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
+          bbLeft.put(left).flip();
+          bbRight.put(right).flip();
+          db.put(new WriteOptions(), bbLeft, bbRight);
+        },
+        (db, left, right) -> {
+          final ByteBuffer bbLeft = ByteBuffer.allocate(100);
+          final ByteBuffer bbRight = ByteBuffer.allocate(100);
+          bbLeft.put(left).flip();
+          bbRight.put(right).flip();
+          db.put(new WriteOptions(), bbLeft, bbRight);
+        });
+  }
+
+  private final PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction;
+
+  public PutVariantsTest(final PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction) {
+    this.putFunction = putFunction;
+  }
+
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  @Test
+  public void writeAndRead() throws InterruptedException, RocksDBException {
+    try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
+         final Options opt =
+             new Options().setCreateIfMissing(true).setMergeOperator(uint64AddOperator);
+         final RocksDB db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath())) {
+      // Writing (long)100 under key
+      putFunction.apply(db, "key".getBytes(), longToByteArray(100));
+
+      final byte[] value = db.get("key".getBytes());
+      final long longValue = longFromByteArray(value);
+
+      assertThat(longValue).isEqualTo(100);
     }
-
-    @Parameterized.Parameters
-    public static List<PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]>> data() {
-        return Arrays.asList(
-                RocksDB::put,
-                (db, left, right) -> db.put(new WriteOptions(), left, right),
-                (db, left, right) -> {
-                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
-                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
-                    db.put(left0, 7, left.length, right0, 4, right.length);
-                },
-                (db, left, right) -> {
-                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
-                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
-                    db.put(new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
-                },
-                (db, left, right) -> {
-                    final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
-                    final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
-                    bbLeft.put(left).flip();
-                    bbRight.put(right).flip();
-                    db.put(new WriteOptions(), bbLeft, bbRight);
-                },
-                (db, left, right) -> {
-                    final ByteBuffer bbLeft = ByteBuffer.allocate(100);
-                    final ByteBuffer bbRight = ByteBuffer.allocate(100);
-                    bbLeft.put(left).flip();
-                    bbRight.put(right).flip();
-                    db.put(new WriteOptions(), bbLeft, bbRight);
-                }
-        );
-    }
-
-    private final PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction;
-
-    public PutVariantsTest(final PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction) {
-        this.putFunction = putFunction;
-    }
-
-    @ClassRule
-    public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
-            new RocksNativeLibraryResource();
-
-    @Rule
-    public TemporaryFolder dbFolder = new TemporaryFolder();
-
-    @Test
-    public void writeAndRead()
-            throws InterruptedException, RocksDBException {
-        try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
-             final Options opt = new Options()
-                     .setCreateIfMissing(true)
-                     .setMergeOperator(uint64AddOperator);
-             final RocksDB db = RocksDB.open(opt,
-                     dbFolder.getRoot().getAbsolutePath())) {
-            // Writing (long)100 under key
-            putFunction.apply(db, "key".getBytes(), longToByteArray(100));
-
-            final byte[] value = db.get("key".getBytes());
-            final long longValue = longFromByteArray(value);
-
-            assertThat(longValue).isEqualTo(100);
-        }
-    }
+  }
 }

--- a/java/src/test/java/org/rocksdb/PutVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutVariantsTest.java
@@ -66,11 +66,8 @@ public class PutVariantsTest {
         });
   }
 
-  private final PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction;
-
-  public PutVariantsTest(final PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction) {
-    this.putFunction = putFunction;
-  }
+  @Parameterized.Parameter
+  public PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction;
 
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =

--- a/java/src/test/java/org/rocksdb/PutVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutVariantsTest.java
@@ -66,8 +66,7 @@ public class PutVariantsTest {
         });
   }
 
-  @Parameterized.Parameter
-  public PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction;
+  @Parameterized.Parameter public PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction;
 
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =

--- a/java/src/test/java/org/rocksdb/PutVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutVariantsTest.java
@@ -13,6 +13,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,6 +35,16 @@ public class PutVariantsTest {
         return Arrays.asList(
                 RocksDB::put,
                 (db, left, right) -> db.put(new WriteOptions(), left, right),
+                (db, left, right) -> {
+                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+                    db.put(left0, 7, left.length, right0, 4, right.length);
+                },
+                (db, left, right) -> {
+                    final byte[] left0 = ("1234567" + new String(left, StandardCharsets.UTF_8) + "890").getBytes();
+                    final byte[] right0 = ("1234" + new String(right, StandardCharsets.UTF_8) + "567890ab").getBytes();
+                    db.put(new WriteOptions(), left0, 7, left.length, right0, 4, right.length);
+                },
                 (db, left, right) -> {
                     final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
                     final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);

--- a/java/src/test/java/org/rocksdb/PutVariantsTest.java
+++ b/java/src/test/java/org/rocksdb/PutVariantsTest.java
@@ -1,0 +1,84 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.MergeTest.longFromByteArray;
+import static org.rocksdb.MergeTest.longToByteArray;
+
+@RunWith(Parameterized.class)
+public class PutVariantsTest {
+
+    @FunctionalInterface
+    interface FunctionPut<PDatabase, PLeft, PRight> {
+        public void apply(PDatabase db, PLeft two, PRight three) throws RocksDBException;
+    }
+
+    @Parameterized.Parameters
+    public static List<PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]>> data() {
+        return Arrays.asList(
+                RocksDB::put,
+                (db, left, right) -> db.put(new WriteOptions(), left, right),
+                (db, left, right) -> {
+                    final ByteBuffer bbLeft = ByteBuffer.allocateDirect(100);
+                    final ByteBuffer bbRight = ByteBuffer.allocateDirect(100);
+                    bbLeft.put(left).flip();
+                    bbRight.put(right).flip();
+                    db.put(new WriteOptions(), bbLeft, bbRight);
+                },
+                (db, left, right) -> {
+                    final ByteBuffer bbLeft = ByteBuffer.allocate(100);
+                    final ByteBuffer bbRight = ByteBuffer.allocate(100);
+                    bbLeft.put(left).flip();
+                    bbRight.put(right).flip();
+                    db.put(new WriteOptions(), bbLeft, bbRight);
+                }
+        );
+    }
+
+    private final PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction;
+
+    public PutVariantsTest(final PutVariantsTest.FunctionPut<RocksDB, byte[], byte[]> putFunction) {
+        this.putFunction = putFunction;
+    }
+
+    @ClassRule
+    public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+            new RocksNativeLibraryResource();
+
+    @Rule
+    public TemporaryFolder dbFolder = new TemporaryFolder();
+
+    @Test
+    public void writeAndRead()
+            throws InterruptedException, RocksDBException {
+        try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();
+             final Options opt = new Options()
+                     .setCreateIfMissing(true)
+                     .setMergeOperator(uint64AddOperator);
+             final RocksDB db = RocksDB.open(opt,
+                     dbFolder.getRoot().getAbsolutePath())) {
+            // Writing (long)100 under key
+            putFunction.apply(db, "key".getBytes(), longToByteArray(100));
+
+            final byte[] value = db.get("key".getBytes());
+            final long longValue = longFromByteArray(value);
+
+            assertThat(longValue).isEqualTo(100);
+        }
+    }
+}

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -185,9 +185,9 @@ public class RocksDBTest {
       db.put("key1".getBytes(), "value".getBytes());
       db.put(opt, "key2".getBytes(), "12345678".getBytes());
       assertThat(db.get("key1".getBytes())).isEqualTo(
-          "value".getBytes());
+              "value".getBytes());
       assertThat(db.get("key2".getBytes())).isEqualTo(
-          "12345678".getBytes());
+              "12345678".getBytes());
 
       final ByteBuffer key = ByteBuffer.allocateDirect(12);
       final ByteBuffer value = ByteBuffer.allocateDirect(12);
@@ -245,8 +245,75 @@ public class RocksDBTest {
     }
   }
 
-  private static Segment sliceSegment(final String key) {
-    final ByteBuffer rawKey = ByteBuffer.allocate(key.length() + 4);
+  @Test
+  public void putIndirectByteBuffers() throws RocksDBException {
+    try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath());
+         final WriteOptions opt = new WriteOptions(); final ReadOptions optr = new ReadOptions()) {
+      db.put("key1".getBytes(), "value".getBytes());
+      db.put(opt, "key2".getBytes(), "12345678".getBytes());
+      assertThat(db.get("key1".getBytes())).isEqualTo(
+              "value".getBytes());
+      assertThat(db.get("key2".getBytes())).isEqualTo(
+              "12345678".getBytes());
+
+      ByteBuffer key = ByteBuffer.allocate(12);
+      ByteBuffer value = ByteBuffer.allocate(12);
+      key.position(4);
+      key.put("key3".getBytes());
+      key.position(4).limit(8);
+      value.position(4);
+      value.put("val3".getBytes());
+      value.position(4).limit(8);
+
+      db.put(opt, key, value);
+
+      assertThat(key.position()).isEqualTo(8);
+      assertThat(key.limit()).isEqualTo(8);
+
+      assertThat(value.position()).isEqualTo(8);
+      assertThat(value.limit()).isEqualTo(8);
+
+      key.position(4);
+
+      ByteBuffer result = ByteBuffer.allocate(12);
+      assertThat(db.get(optr, key, result)).isEqualTo(4);
+      assertThat(result.position()).isEqualTo(0);
+      assertThat(result.limit()).isEqualTo(4);
+      assertThat(key.position()).isEqualTo(8);
+      assertThat(key.limit()).isEqualTo(8);
+
+      byte[] tmp = new byte[4];
+      result.get(tmp);
+      assertThat(tmp).isEqualTo("val3".getBytes());
+
+      key.position(4);
+
+      result.clear().position(9);
+      assertThat(db.get(optr, key, result)).isEqualTo(4);
+      assertThat(result.position()).isEqualTo(9);
+      assertThat(result.limit()).isEqualTo(12);
+      assertThat(key.position()).isEqualTo(8);
+      assertThat(key.limit()).isEqualTo(8);
+      byte[] tmp2 = new byte[3];
+      result.get(tmp2);
+      assertThat(tmp2).isEqualTo("val".getBytes());
+
+      // put
+      Segment key3 = sliceSegment("key3");
+      Segment key4 = sliceSegment("key4");
+      Segment value0 = sliceSegment("value 0");
+      Segment value1 = sliceSegment("value 1");
+      db.put(key3.data, key3.offset, key3.len, value0.data, value0.offset, value0.len);
+      db.put(opt, key4.data, key4.offset, key4.len, value1.data, value1.offset, value1.len);
+
+      // compare
+      Assert.assertTrue(value0.isSamePayload(db.get(key3.data, key3.offset, key3.len)));
+      Assert.assertTrue(value1.isSamePayload(db.get(key4.data, key4.offset, key4.len)));
+    }
+  }
+
+  private static Segment sliceSegment(String key) {
+    ByteBuffer rawKey = ByteBuffer.allocate(key.length() + 4);
     rawKey.put((byte)0);
     rawKey.put((byte)0);
     rawKey.put(key.getBytes());

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -184,10 +184,8 @@ public class RocksDBTest {
          final WriteOptions opt = new WriteOptions(); final ReadOptions optr = new ReadOptions()) {
       db.put("key1".getBytes(), "value".getBytes());
       db.put(opt, "key2".getBytes(), "12345678".getBytes());
-      assertThat(db.get("key1".getBytes())).isEqualTo(
-              "value".getBytes());
-      assertThat(db.get("key2".getBytes())).isEqualTo(
-              "12345678".getBytes());
+      assertThat(db.get("key1".getBytes())).isEqualTo("value".getBytes());
+      assertThat(db.get("key2".getBytes())).isEqualTo("12345678".getBytes());
 
       final ByteBuffer key = ByteBuffer.allocateDirect(12);
       final ByteBuffer value = ByteBuffer.allocateDirect(12);
@@ -251,10 +249,8 @@ public class RocksDBTest {
          final WriteOptions opt = new WriteOptions(); final ReadOptions optr = new ReadOptions()) {
       db.put("key1".getBytes(), "value".getBytes());
       db.put(opt, "key2".getBytes(), "12345678".getBytes());
-      assertThat(db.get("key1".getBytes())).isEqualTo(
-              "value".getBytes());
-      assertThat(db.get("key2".getBytes())).isEqualTo(
-              "12345678".getBytes());
+      assertThat(db.get("key1".getBytes())).isEqualTo("value".getBytes());
+      assertThat(db.get("key2".getBytes())).isEqualTo("12345678".getBytes());
 
       ByteBuffer key = ByteBuffer.allocate(12);
       ByteBuffer value = ByteBuffer.allocate(12);

--- a/java/src/test/java/org/rocksdb/RocksIteratorTest.java
+++ b/java/src/test/java/org/rocksdb/RocksIteratorTest.java
@@ -5,6 +5,7 @@
 package org.rocksdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -45,7 +46,7 @@ public class RocksIteratorTest {
   }
 
   @Test
-  public void rocksIterator() throws RocksDBException {
+  public void rocksIteratorByteBuffers() throws RocksDBException {
     try (final Options options =
              new Options().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
          final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
@@ -72,6 +73,103 @@ public class RocksIteratorTest {
         validateKey(iterator, ByteBuffer.allocate(5), "key1");
         validateValue(iterator, ByteBuffer.allocate(2), "value1");
         validateValue(iterator, ByteBuffer.allocate(8), "value1");
+      }
+    }
+  }
+
+  @Test
+  public void rocksIteratorByteArrayValues() throws RocksDBException {
+    try (final Options options =
+             new Options().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("key1".getBytes(), "value1".getBytes());
+      db.put("key2".getBytes(), "value2".getBytes());
+
+      try (final RocksIterator iterator = db.newIterator()) {
+        iterator.seekToFirst();
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("key1".getBytes());
+        assertThat(iterator.value()).isEqualTo("value1".getBytes());
+
+        final byte[] valueArray0 = new byte[2];
+        assertThat(iterator.value(valueArray0)).isEqualTo(6);
+        assertThat(valueArray0).isEqualTo("va".getBytes());
+        final byte[] valueArray1 = new byte[8];
+        assertThat(iterator.value(valueArray1)).isEqualTo(6);
+        assertThat(valueArray1).isEqualTo("value1\0\0".getBytes());
+        final byte[] valueArray2 = new byte[10];
+        assertThat(iterator.value(valueArray2, 2, 6)).isEqualTo(6);
+        assertThat(valueArray2).isEqualTo("\0\0value1\0\0".getBytes());
+        final byte[] valueArray3 = new byte[10];
+        assertThat(iterator.value(valueArray3, 5, 5)).isEqualTo(6);
+        assertThat(valueArray3).isEqualTo("\0\0\0\0\0value".getBytes());
+        final byte[] valueArray4 = new byte[6];
+        try {
+          iterator.value(valueArray4, 1, 6);
+          fail("Expected IndexOutOfBoundsException");
+        } catch (final IndexOutOfBoundsException ignored) {
+          // we should arrive here
+        }
+        final byte[] valueArray5 = new byte[7];
+        assertThat(iterator.value(valueArray5, 1, 6)).isEqualTo(6);
+        assertThat(valueArray5).isEqualTo("\0value1".getBytes());
+      }
+    }
+  }
+
+  @Test
+  public void rocksIteratorByteArrayKeys() throws RocksDBException {
+    try (final Options options =
+             new Options().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("key1".getBytes(), "value1".getBytes());
+      db.put("key2".getBytes(), "value2".getBytes());
+
+      try (final RocksIterator iterator = db.newIterator()) {
+        iterator.seekToFirst();
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("key1".getBytes());
+        assertThat(iterator.value()).isEqualTo("value1".getBytes());
+
+        final byte[] keyArray0 = new byte[2];
+        assertThat(iterator.key(keyArray0)).isEqualTo(4);
+        assertThat(keyArray0).isEqualTo("ke".getBytes());
+        final byte[] keyArray1 = new byte[8];
+        assertThat(iterator.key(keyArray1)).isEqualTo(4);
+        assertThat(keyArray1).isEqualTo("key1\0\0\0\0".getBytes());
+        final byte[] keyArray2 = new byte[10];
+        assertThat(iterator.key(keyArray2, 2, 6)).isEqualTo(4);
+        assertThat(keyArray2).isEqualTo("\0\0key1\0\0\0\0".getBytes());
+        final byte[] keyArray3 = new byte[10];
+        assertThat(iterator.key(keyArray3, 5, 3)).isEqualTo(4);
+        assertThat(keyArray3).isEqualTo("\0\0\0\0\0key\0\0".getBytes());
+        final byte[] keyArray4 = new byte[4];
+        try {
+          iterator.key(keyArray4, 1, 4);
+          fail("Expected IndexOutOfBoundsException");
+        } catch (final IndexOutOfBoundsException ignored) {
+          // we should arrive here
+        }
+        final byte[] keyArray5 = new byte[5];
+        assertThat(iterator.key(keyArray5, 1, 4)).isEqualTo(4);
+        assertThat(keyArray5).isEqualTo("\0key1".getBytes());
+      }
+    }
+  }
+
+  @Test
+  public void rocksIteratorSimple() throws RocksDBException {
+    try (final Options options =
+             new Options().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("key1".getBytes(), "value1".getBytes());
+      db.put("key2".getBytes(), "value2".getBytes());
+
+      try (final RocksIterator iterator = db.newIterator()) {
+        iterator.seekToFirst();
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("key1".getBytes());
+        assertThat(iterator.value()).isEqualTo("value1".getBytes());
 
         iterator.next();
         assertThat(iterator.isValid()).isTrue();
@@ -90,6 +188,23 @@ public class RocksIteratorTest {
         assertThat(iterator.key()).isEqualTo("key2".getBytes());
         assertThat(iterator.value()).isEqualTo("value2".getBytes());
         iterator.status();
+      }
+    }
+  }
+
+  @Test
+  public void rocksIterator() throws RocksDBException {
+    try (final Options options =
+             new Options().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("key1".getBytes(), "value1".getBytes());
+      db.put("key2".getBytes(), "value2".getBytes());
+
+      try (final RocksIterator iterator = db.newIterator()) {
+        iterator.seekToFirst();
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("key1".getBytes());
+        assertThat(iterator.value()).isEqualTo("value1".getBytes());
 
         {
           final ByteBuffer key = ByteBuffer.allocate(12);

--- a/java/src/test/java/org/rocksdb/TransactionTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionTest.java
@@ -416,12 +416,13 @@ public class TransactionTest extends AbstractTransactionTest {
         .setCreateIfMissing(true)
         .setCreateMissingColumnFamilies(true);
     final TransactionDBOptions txnDbOptions = new TransactionDBOptions();
+    final ColumnFamilyOptions defaultColumnFamilyOptions = new ColumnFamilyOptions();
+    defaultColumnFamilyOptions.setMergeOperator(new StringAppendOperator("++"));
     final ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
-    final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
-        Arrays.asList(
-            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY),
-            new ColumnFamilyDescriptor(TXN_TEST_COLUMN_FAMILY,
-                columnFamilyOptions));
+    columnFamilyOptions.setMergeOperator(new StringAppendOperator("**"));
+    final List<ColumnFamilyDescriptor> columnFamilyDescriptors = Arrays.asList(
+        new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, defaultColumnFamilyOptions),
+        new ColumnFamilyDescriptor(TXN_TEST_COLUMN_FAMILY, columnFamilyOptions));
     final List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
 
     final TransactionDB txnDb;

--- a/unreleased_history/performance_improvements/java_api_consistency.md
+++ b/unreleased_history/performance_improvements/java_api_consistency.md
@@ -1,0 +1,16 @@
+* Java API extensions to improve consistency and completeness of APIs
+  1 Extended `RocksDB.get( ... ByteBuffer key, ByteBuffer value ...)` which now accepts indirect buffer parameters as well as direct buffer parameters
+  2 Extended `RocksDB.put( ... ByteBuffer key, ByteBuffer value ...)` which now accepts indirect buffer parameters as well as direct buffer parameters
+  3 Added `RocksDB.merge( ... ByteBuffer key, ByteBuffer value ...)` methods with the same parameter options as `put(...)` - direct and indirect buffers are supported
+  4 Added `RocksIterator.key( ... byte[] key, byte[] value ...)` methods which retrieve the iterator key into the supplied buffer
+  5 Added `RocksIterator.value( ... byte[] key, byte[] value ...)` methods which retrieve the iterator value into the supplied buffer
+  6 Deprecated `get(final ColumnFamilyHandle columnFamilyHandle, final ReadOptions readOptions, byte[])` in favour of `get(final ReadOptions readOptions, final ColumnFamilyHandle columnFamilyHandle, byte[])` which has consistent parameter ordering with other methods in the same class
+  7 Added `Transaction.get( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
+  8 Added `Transaction.get( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
+ 9 Added `Transaction.getForUpdate( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
+  10 Added `Transaction.getForUpdate( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
+  11 Added `Transaction.getIterator()` method as a convenience which defaults the `ReadOptions` value supplied to existing `Transaction.iterator()` methods. This mirrors the existing `RocksDB.iterator()` method.
+  12 Added `Transaction.put( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written in a `ByteBuffer` parameter
+  13 Added `Transaction.merge( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
+  14 Added `Transaction.mergeUntracked( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
+ 

--- a/unreleased_history/performance_improvements/java_api_consistency.md
+++ b/unreleased_history/performance_improvements/java_api_consistency.md
@@ -7,7 +7,7 @@
   6 Deprecated `get(final ColumnFamilyHandle columnFamilyHandle, final ReadOptions readOptions, byte[])` in favour of `get(final ReadOptions readOptions, final ColumnFamilyHandle columnFamilyHandle, byte[])` which has consistent parameter ordering with other methods in the same class
   7 Added `Transaction.get( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
   8 Added `Transaction.get( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
- 9 Added `Transaction.getForUpdate( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
+  9 Added `Transaction.getForUpdate( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
   10 Added `Transaction.getForUpdate( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
   11 Added `Transaction.getIterator()` method as a convenience which defaults the `ReadOptions` value supplied to existing `Transaction.iterator()` methods. This mirrors the existing `RocksDB.iterator()` method.
   12 Added `Transaction.put( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written in a `ByteBuffer` parameter

--- a/unreleased_history/performance_improvements/java_api_consistency.md
+++ b/unreleased_history/performance_improvements/java_api_consistency.md
@@ -1,16 +1,16 @@
 * Java API extensions to improve consistency and completeness of APIs
-  1 Extended `RocksDB.get( ... ByteBuffer key, ByteBuffer value ...)` which now accepts indirect buffer parameters as well as direct buffer parameters
-  2 Extended `RocksDB.put( ... ByteBuffer key, ByteBuffer value ...)` which now accepts indirect buffer parameters as well as direct buffer parameters
-  3 Added `RocksDB.merge( ... ByteBuffer key, ByteBuffer value ...)` methods with the same parameter options as `put(...)` - direct and indirect buffers are supported
-  4 Added `RocksIterator.key( ... byte[] key, byte[] value ...)` methods which retrieve the iterator key into the supplied buffer
-  5 Added `RocksIterator.value( ... byte[] key, byte[] value ...)` methods which retrieve the iterator value into the supplied buffer
+  1 Extended `RocksDB.get([ColumnFamilyHandle columnFamilyHandle,] ReadOptions opt, ByteBuffer key, ByteBuffer value)` which now accepts indirect buffer parameters as well as direct buffer parameters
+  2 Extended `RocksDB.put( [ColumnFamilyHandle columnFamilyHandle,] WriteOptions writeOpts, final ByteBuffer key, final ByteBuffer value)` which now accepts indirect buffer parameters as well as direct buffer parameters
+  3 Added `RocksDB.merge([ColumnFamilyHandle columnFamilyHandle,] WriteOptions writeOptions, ByteBuffer key, ByteBuffer value)` methods with the same parameter options as `put(...)` - direct and indirect buffers are supported
+  4 Added `RocksIterator.key( byte[] key [, int offset, int len])` methods which retrieve the iterator key into the supplied buffer
+  5 Added `RocksIterator.value( byte[] value [, int offset, int len])` methods which retrieve the iterator value into the supplied buffer
   6 Deprecated `get(final ColumnFamilyHandle columnFamilyHandle, final ReadOptions readOptions, byte[])` in favour of `get(final ReadOptions readOptions, final ColumnFamilyHandle columnFamilyHandle, byte[])` which has consistent parameter ordering with other methods in the same class
-  7 Added `Transaction.get( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
-  8 Added `Transaction.get( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
-  9 Added `Transaction.getForUpdate( ... byte[] key, byte[] value ...)` methods which retrieve the requested value into the supplied buffer
-  10 Added `Transaction.getForUpdate( ... Bytebuffer key, ByteBuffer value ...)` methods which retrieve the requested value into the supplied buffer
+  7 Added `Transaction.get( ReadOptions opt, [ColumnFamilyHandle columnFamilyHandle, ] byte[] key, byte[] value)` methods which retrieve the requested value into the supplied buffer
+  8 Added `Transaction.get( ReadOptions opt, [ColumnFamilyHandle columnFamilyHandle, ] ByteBuffer key, ByteBuffer value)` methods which retrieve the requested value into the supplied buffer
+  9 Added `Transaction.getForUpdate( ReadOptions readOptions, [ColumnFamilyHandle columnFamilyHandle, ] byte[] key, byte[] value, boolean exclusive [, boolean doValidate])` methods which retrieve the requested value into the supplied buffer
+  10 Added `Transaction.getForUpdate( ReadOptions readOptions, [ColumnFamilyHandle columnFamilyHandle, ] ByteBuffer key, ByteBuffer value, boolean exclusive [, boolean doValidate])` methods which retrieve the requested value into the supplied buffer
   11 Added `Transaction.getIterator()` method as a convenience which defaults the `ReadOptions` value supplied to existing `Transaction.iterator()` methods. This mirrors the existing `RocksDB.iterator()` method.
-  12 Added `Transaction.put( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written in a `ByteBuffer` parameter
-  13 Added `Transaction.merge( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
-  14 Added `Transaction.mergeUntracked( ... Bytebuffer key, ByteBuffer value ...)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
+  12 Added `Transaction.put([ColumnFamilyHandle columnFamilyHandle, ]  ByteBuffer key, ByteBuffer value [, boolean assumeTracked])` methods which supply the key, and the value to be written in a `ByteBuffer` parameter
+  13 Added `Transaction.merge([ColumnFamilyHandle columnFamilyHandle, ] ByteBuffer key, ByteBuffer value [,  boolean assumeTracked])` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
+  14 Added `Transaction.mergeUntracked([ColumnFamilyHandle columnFamilyHandle, ] ByteBuffer key, ByteBuffer value)` methods which supply the key, and the value to be written/merged in a `ByteBuffer` parameter
  


### PR DESCRIPTION
### Implement new Java API get()/put()/merge() methods, and transactional variants.

The Java API methods are very inconsistent in terms of how they pass parameters (byte[], ByteBuffer), and what variants and defaulted parameters they support. We try to bring some consistency to this.
 * All APIs should support calls with ByteBuffer parameters.
 * Similar methods (RocksDB.get() vs Transaction.get()) should support as similar as possible sets of parameters for predictability.
 * get()-like methods should provide variants where the caller supplies the target buffer, for the sake of efficiency. Allocation costs in Java can be significant when large buffers are repeatedly allocated and freed.

### API Additions
 
 1. RockDB.get implement indirect ByteBuffers. Added indirect ByteBuffers and supporting native methods for get().
 2. RocksDB.Iterator implement missing (byte[], offset, length) variants for key() and value() parameters.
 3. Transaction.get() implement missing methods, based on RocksDB.get. Added ByteBuffer.get with and without column family. Added byte[]-as-target get.
 4. Transaction.iterator() implement a getIterator() which defaults ReadOptions; as per RocksDB.iterator(). Rationalize support API for this and RocksDB.iterator()
 5. RocksDB.merge implement ByteBuffer methods; both direct and indirect buffers. Shadow the methods of RocksDB.put; RocksDB.put only offers ByteBuffer API with explicit WriteOptions. Duplicated this with RocksDB.merge
 6. Transaction.merge implement methods as per RocksDB.merge methods. Transaction is already constructed with WriteOptions, so no explicit WriteOptions methods required.
 7. Transaction.mergeUntracked implement the same API methods as Transaction.merge except the ones that use assumeTracked, because that’s not a feature of merge untracked.

### Support Changes (C++)

The current JNI code in C++ supports multiple variants of methods through a number of helper functions. There are numerous TODO suggestions in the code proposing that the helpers be re-factored/shared.

We have taken a different approach for the new methods; we have created wrapper classes `JDirectBufferSlice`, `JDirectBufferPinnableSlice`, `JByteArraySlice` and `JByteArrayPinnableSlice` RAII classes which construct slices from JNI parameters and can then be passed directly to RocksDB methods. For instance, the `Java_org_rocksdb_Transaction_getDirect` method is implemented like this:

```
  try {
    ROCKSDB_NAMESPACE::JDirectBufferSlice key(env, jkey_bb, jkey_off,
                                              jkey_part_len);
    ROCKSDB_NAMESPACE::JDirectBufferPinnableSlice value(env, jval_bb, jval_off,
                                                        jval_part_len);
    ROCKSDB_NAMESPACE::KVException::ThrowOnError(
        env, txn->Get(*read_options, column_family_handle, key.slice(),
                      &value.pinnable_slice()));
    return value.Fetch();
  } catch (const ROCKSDB_NAMESPACE::KVException& e) {
    return e.Code();
  }
```
Notice the try/catch mechanism with the `KVException` class, which combined with RAII and the wrapper classes means that there is no ad-hoc cleanup necessary in the JNI methods.

We propose to extend this mechanism to existing JNI methods as further work.

### Support Changes (Java)

Where there are multiple parameter-variant versions of the same method, we use fewer or just one supporting native method for all of them. This makes maintenance a bit easier and reduces the opportunity for coding errors mixing up (untyped) object handles.

In  order to support this efficiently, some classes need to have default values for column families and read options added and cached so that they are not re-constructed on every method call.

This PR closes https://github.com/facebook/rocksdb/issues/9776