### PR TITLE
Revise LockWAL/UnlockWAL implementation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 * Fixed a bug caused by `DB::SyncWAL()` affecting `track_and_verify_wals_in_manifest`. Without the fix, application may see "open error: Corruption: Missing WAL with log number" while trying to open the db. The corruption is a false alarm but prevents DB open (#10892).
 * Fixed a BackupEngine bug in which RestoreDBFromLatestBackup would fail if the latest backup was deleted and there is another valid backup available.
 * Fix L0 file misorder corruption caused by ingesting files of overlapping seqnos with memtable entries' through introducing `epoch_number`. Before the fix, `force_consistency_checks=true` may catch the corruption before it's exposed to readers, in which case writes returning `Status::Corruption` would be expected. Also replace the previous incomplete fix (#5958) to the same corruption with this new and more complete fix.
+* Fixed a bug in LockWAL() leading to re-locking mutex (#11020).
 
 ## 7.9.0 (11/21/2022)
 ### Performance Improvements

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2680,6 +2680,10 @@ class DBImpl : public DB {
   // seqno_time_mapping_ stores the sequence number to time mapping, it's not
   // thread safe, both read and write need db mutex hold.
   SeqnoToTimeMapping seqno_time_mapping_;
+
+  // stop write token that is acquired when LockWal() is called. Destructed
+  // when UnlockWal() is called.
+  std::unique_ptr<WriteControllerToken> lock_wal_write_token_;
 };
 
 class GetWithTimestampReadCallback : public ReadCallback {

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -940,14 +940,14 @@ Status DBImpl::WriteImplWALOnly(
       bg_cv_.Wait();
       write_thread->EndWriteStall();
     }
-    if (write_controller_.IsStopped()) {
+    if (status.ok() && write_controller_.IsStopped()) {
       if (!shutting_down_.load(std::memory_order_relaxed)) {
         status = Status::Incomplete(error_handler_.GetBGError().ToString());
       } else {
         status = Status::ShutdownInProgress("stalled writes");
       }
     }
-    if (error_handler_.IsDBStopped()) {
+    if (status.ok() && error_handler_.IsDBStopped()) {
       status = error_handler_.GetBGError();
     }
     if (!status.ok()) {

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -619,6 +619,8 @@ TEST_F(DBWALTest, LockWal) {
     SyncPoint::GetInstance()->DisableProcessing();
     SyncPoint::GetInstance()->LoadDependency(
         {{"DBWALTest::LockWal:AfterLockWal",
+          "DBWALTest::LockWal:BeforeFlush:1"},
+         {"DBWALTest::LockWal:AfterGetSortedWal",
           "DBWALTest::LockWal:BeforeFlush:1"}});
     SyncPoint::GetInstance()->EnableProcessing();
 
@@ -640,6 +642,7 @@ TEST_F(DBWALTest, LockWal) {
     {
       VectorLogPtr wals;
       ASSERT_OK(db_->GetSortedWalFiles(wals));
+      TEST_SYNC_POINT("DBWALTest::LockWal:AfterGetSortedWal");
       ASSERT_FALSE(wals.empty());
     }
     FlushOptions flush_opts;

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -610,6 +610,52 @@ TEST_F(DBWALTest, WALWithChecksumHandoff) {
 #endif  // ROCKSDB_ASSERT_STATUS_CHECKED
 }
 
+#ifndef ROCKSDB_LITE
+TEST_F(DBWALTest, LockWal) {
+  do {
+    Options options = CurrentOptions();
+    options.create_if_missing = true;
+    DestroyAndReopen(options);
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->LoadDependency(
+        {{"DBWALTest::LockWal:AfterLockWal",
+          "DBWALTest::LockWal:BeforeFlush:1"}});
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    ASSERT_OK(Put("foo", "v"));
+    ASSERT_OK(Put("bar", "v"));
+    port::Thread worker([&]() {
+      TEST_SYNC_POINT("DBWALTest::LockWal:BeforeFlush:1");
+      Status tmp_s = db_->Flush(FlushOptions());
+      ASSERT_OK(tmp_s);
+    });
+
+    ASSERT_OK(db_->LockWAL());
+    TEST_SYNC_POINT("DBWALTest::LockWal:AfterLockWal");
+    // Verify writes are stopped
+    WriteOptions wopts;
+    wopts.no_slowdown = true;
+    Status s = db_->Put(wopts, "foo", "dontcare");
+    ASSERT_TRUE(s.IsIncomplete());
+    {
+      VectorLogPtr wals;
+      ASSERT_OK(db_->GetSortedWalFiles(wals));
+      ASSERT_FALSE(wals.empty());
+    }
+    FlushOptions flush_opts;
+    flush_opts.wait = false;
+    s = db_->Flush(flush_opts);
+    ASSERT_TRUE(s.IsTryAgain());
+    ASSERT_OK(db_->UnlockWAL());
+    ASSERT_OK(db_->Put(WriteOptions(), "foo", "dontcare"));
+
+    worker.join();
+
+    SyncPoint::GetInstance()->DisableProcessing();
+  } while (ChangeWalOptions());
+}
+#endif  //! ROCKSDB_LITE
+
 class DBRecoveryTestBlobError
     : public DBWALTest,
       public testing::WithParamInterface<std::string> {

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -618,9 +618,7 @@ TEST_F(DBWALTest, LockWal) {
     DestroyAndReopen(options);
     SyncPoint::GetInstance()->DisableProcessing();
     SyncPoint::GetInstance()->LoadDependency(
-        {{"DBWALTest::LockWal:AfterLockWal",
-          "DBWALTest::LockWal:BeforeFlush:1"},
-         {"DBWALTest::LockWal:AfterGetSortedWal",
+        {{"DBWALTest::LockWal:AfterGetSortedWal",
           "DBWALTest::LockWal:BeforeFlush:1"}});
     SyncPoint::GetInstance()->EnableProcessing();
 
@@ -633,7 +631,6 @@ TEST_F(DBWALTest, LockWal) {
     });
 
     ASSERT_OK(db_->LockWAL());
-    TEST_SYNC_POINT("DBWALTest::LockWal:AfterLockWal");
     // Verify writes are stopped
     WriteOptions wopts;
     wopts.no_slowdown = true;
@@ -642,9 +639,9 @@ TEST_F(DBWALTest, LockWal) {
     {
       VectorLogPtr wals;
       ASSERT_OK(db_->GetSortedWalFiles(wals));
-      TEST_SYNC_POINT("DBWALTest::LockWal:AfterGetSortedWal");
       ASSERT_FALSE(wals.empty());
     }
+    TEST_SYNC_POINT("DBWALTest::LockWal:AfterGetSortedWal");
     FlushOptions flush_opts;
     flush_opts.wait = false;
     s = db_->Flush(flush_opts);

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -360,8 +360,11 @@ void WriteThread::EndWriteStall() {
   // Unlink write_stall_dummy_ from the write queue. This will unblock
   // pending write threads to enqueue themselves
   assert(newest_writer_.load(std::memory_order_relaxed) == &write_stall_dummy_);
-  assert(write_stall_dummy_.link_older != nullptr);
-  write_stall_dummy_.link_older->link_newer = write_stall_dummy_.link_newer;
+  // write_stall_dummy_.link_older can be nullptr only if LockWAL() has been
+  // called.
+  if (write_stall_dummy_.link_older) {
+    write_stall_dummy_.link_older->link_newer = write_stall_dummy_.link_newer;
+  }
   newest_writer_.exchange(write_stall_dummy_.link_older);
 
   // Wake up writers

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1447,12 +1447,15 @@ class DB {
   // Lock the WAL. Also flushes the WAL after locking.
   // After this method returns ok, writes to the database will be stopped until
   // UnlockWAL() is called.
+  // This method may internally acquire and release DB mutex and the WAL write
+  // mutex, but after it returns, neither mutex is held by caller.
   virtual Status LockWAL() {
     return Status::NotSupported("LockWAL not implemented");
   }
 
   // Unlock the WAL.
   // The write stop on the database will be cleared.
+  // This method may internally acquire and release DB mutex.
   virtual Status UnlockWAL() {
     return Status::NotSupported("UnlockWAL not implemented");
   }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1445,11 +1445,14 @@ class DB {
   virtual Status SyncWAL() = 0;
 
   // Lock the WAL. Also flushes the WAL after locking.
+  // After this method returns ok, writes to the database will be stopped until
+  // UnlockWAL() is called.
   virtual Status LockWAL() {
     return Status::NotSupported("LockWAL not implemented");
   }
 
   // Unlock the WAL.
+  // The write stop on the database will be cleared.
   virtual Status UnlockWAL() {
     return Status::NotSupported("UnlockWAL not implemented");
   }

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -6536,7 +6536,7 @@ TEST_P(TransactionTest, LockWal) {
     ROCKSDB_GTEST_BYPASS("Test only write-committed for now");
     return;
   }
-  ReOpen();
+  ASSERT_OK(ReOpen());
 
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->LoadDependency(
@@ -6548,19 +6548,19 @@ TEST_P(TransactionTest, LockWal) {
   WriteOptions wopts;
   wopts.no_slowdown = true;
   txn0.reset(db->BeginTransaction(wopts, TransactionOptions()));
-  txn0->SetName("txn0");
+  ASSERT_OK(txn0->SetName("txn0"));
   ASSERT_OK(txn0->Put("foo", "v0"));
 
   std::unique_ptr<Transaction> txn1;
   txn1.reset(db->BeginTransaction(wopts, TransactionOptions()));
-  txn1->SetName("txn1");
+  ASSERT_OK(txn1->SetName("txn1"));
   ASSERT_OK(txn1->Put("dummy", "v0"));
   ASSERT_OK(txn1->Prepare());
 
   std::unique_ptr<Transaction> txn2;
   port::Thread worker([&]() {
     txn2.reset(db->BeginTransaction(WriteOptions(), TransactionOptions()));
-    txn2->SetName("txn2");
+    ASSERT_OK(txn2->SetName("txn2"));
     ASSERT_OK(txn2->Put("bar", "v0"));
     TEST_SYNC_POINT("TransactionTest::LockWal:BeforePrepareTxn2");
     ASSERT_OK(txn2->Prepare());
@@ -6579,7 +6579,7 @@ TEST_P(TransactionTest, LockWal) {
   txn0.reset();
 
   txn0.reset(db->BeginTransaction(wopts, TransactionOptions()));
-  txn0->SetName("txn0_1");
+  ASSERT_OK(txn0->SetName("txn0_1"));
   ASSERT_OK(txn0->Put("foo", "v1"));
   ASSERT_OK(txn0->Prepare());
   ASSERT_OK(txn0->Commit());

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -6530,6 +6530,64 @@ TEST_P(TransactionTest, WriteWithBulkCreatedColumnFamilies) {
   cf_handles.clear();
 }
 
+TEST_P(TransactionTest, LockWal) {
+  const TxnDBWritePolicy write_policy = std::get<2>(GetParam());
+  if (TxnDBWritePolicy::WRITE_COMMITTED != write_policy) {
+    ROCKSDB_GTEST_BYPASS("Test only write-committed for now");
+    return;
+  }
+  ReOpen();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"TransactionTest::LockWal:AfterLockWal",
+        "TransactionTest::LockWal:BeforePrepareTxn2"}});
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  std::unique_ptr<Transaction> txn0;
+  WriteOptions wopts;
+  wopts.no_slowdown = true;
+  txn0.reset(db->BeginTransaction(wopts, TransactionOptions()));
+  txn0->SetName("txn0");
+  ASSERT_OK(txn0->Put("foo", "v0"));
+
+  std::unique_ptr<Transaction> txn1;
+  txn1.reset(db->BeginTransaction(wopts, TransactionOptions()));
+  txn1->SetName("txn1");
+  ASSERT_OK(txn1->Put("dummy", "v0"));
+  ASSERT_OK(txn1->Prepare());
+
+  std::unique_ptr<Transaction> txn2;
+  port::Thread worker([&]() {
+    txn2.reset(db->BeginTransaction(WriteOptions(), TransactionOptions()));
+    txn2->SetName("txn2");
+    ASSERT_OK(txn2->Put("bar", "v0"));
+    TEST_SYNC_POINT("TransactionTest::LockWal:BeforePrepareTxn2");
+    ASSERT_OK(txn2->Prepare());
+    ASSERT_OK(txn2->Commit());
+  });
+  ASSERT_OK(db->LockWAL());
+  TEST_SYNC_POINT("TransactionTest::LockWal:AfterLockWal");
+  // txn0 cannot prepare
+  Status s = txn0->Prepare();
+  ASSERT_TRUE(s.IsIncomplete());
+  // txn1 cannot commit
+  s = txn1->Commit();
+  ASSERT_TRUE(s.IsIncomplete());
+
+  ASSERT_OK(db->UnlockWAL());
+  txn0.reset();
+
+  txn0.reset(db->BeginTransaction(wopts, TransactionOptions()));
+  txn0->SetName("txn0_1");
+  ASSERT_OK(txn0->Put("foo", "v1"));
+  ASSERT_OK(txn0->Prepare());
+  ASSERT_OK(txn0->Commit());
+  worker.join();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -6567,13 +6567,14 @@ TEST_P(TransactionTest, LockWal) {
     ASSERT_OK(txn2->Commit());
   });
   ASSERT_OK(db->LockWAL());
-  TEST_SYNC_POINT("TransactionTest::LockWal:AfterLockWal");
   // txn0 cannot prepare
   Status s = txn0->Prepare();
   ASSERT_TRUE(s.IsIncomplete());
   // txn1 cannot commit
   s = txn1->Commit();
   ASSERT_TRUE(s.IsIncomplete());
+
+  TEST_SYNC_POINT("TransactionTest::LockWal:AfterLockWal");
 
   ASSERT_OK(db->UnlockWAL());
   txn0.reset();


### PR DESCRIPTION
RocksDB has two public APIs: `DB::LockWAL()`/`DB::UnlockWAL()`. The current implementation acquires and
releases the internal `DBImpl::log_write_mutex_`.

According to the comment on `DBImpl::log_write_mutex_`: https://github.com/facebook/rocksdb/blob/7.8.fb/db/db_impl/db_impl.h#L2287:L2288
> Note: to avoid dealock, if needed to acquire both log_write_mutex_ and mutex_, the order should be first mutex_ and then log_write_mutex_.

This puts limitations on how applications can use the `LockWAL()` API. After `LockWAL()` returns ok, then application
should not perform any operation that acquires `mutex_`. Currently, the use case of `LockWAL()` is MyRocks implementing
the MySQL storage engine handlerton `lock_hton_log` interface. The operation that MyRocks performs after `LockWAL()`
is `GetSortedWalFiless()` which not only acquires mutex_, but also `log_write_mutex_`.

There are two issues:
1. Applications using these two APIs may hang if one thread calls `GetSortedWalFiles()` after
calling `LockWAL()` because log_write_mutex is not recursive.
2. Two threads may dead lock due to lock order inversion.

To fix these issues, we can modify the implementation of LockWAL so that it does not keep
`log_write_mutex_` held until UnlockWAL. To achieve the goal of locking the WAL, we can
instead manually inject a write stall so that all future writes will be stopped.

Test plan:
make check