### PR TITLE
Use VersionBuilder for CF import ordering/validation

### DIFF
--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -47,6 +47,16 @@ Status ImportColumnFamilyJob::Prepare(uint64_t next_file_number,
     return Status::InvalidArgument("The list of files is empty");
   }
 
+  for (const auto& f : files_to_import_) {
+    if (f.num_entries == 0) {
+      return Status::InvalidArgument("File contain no entries");
+    }
+
+    if (!f.smallest_internal_key.Valid() || !f.largest_internal_key.Valid()) {
+      return Status::Corruption("File has corrupted keys");
+    }
+  }
+
   // Copy/Move external files into DB
   auto hardlink_files = import_options_.move_files;
   for (auto& f : files_to_import_) {

--- a/db/import_column_family_job.h
+++ b/db/import_column_family_job.h
@@ -38,6 +38,10 @@ class ImportColumnFamilyJob {
         db_options_(db_options),
         fs_(db_options_.fs, io_tracer),
         env_options_(env_options),
+        vstorage_(&cfd_->internal_comparator(), cfd_->user_comparator(),
+                  cfd_->NumberLevels(), cfd_->ioptions()->compaction_style,
+                  nullptr /* src_vstorage */,
+                  cfd_->ioptions()->force_consistency_checks),
         import_options_(import_options),
         metadata_(metadata),
         io_tracer_(io_tracer) {}
@@ -74,6 +78,7 @@ class ImportColumnFamilyJob {
   const EnvOptions& env_options_;
   autovector<IngestedFileInfo> files_to_import_;
   VersionEdit edit_;
+  VersionStorageInfo vstorage_;
   const ImportColumnFamilyOptions& import_options_;
   std::vector<LiveFileMetaData> metadata_;
   const std::shared_ptr<IOTracer> io_tracer_;

--- a/db/import_column_family_job.h
+++ b/db/import_column_family_job.h
@@ -38,10 +38,6 @@ class ImportColumnFamilyJob {
         db_options_(db_options),
         fs_(db_options_.fs, io_tracer),
         env_options_(env_options),
-        vstorage_(&cfd_->internal_comparator(), cfd_->user_comparator(),
-                  cfd_->NumberLevels(), cfd_->ioptions()->compaction_style,
-                  nullptr /* src_vstorage */,
-                  cfd_->ioptions()->force_consistency_checks),
         import_options_(import_options),
         metadata_(metadata),
         io_tracer_(io_tracer) {}
@@ -78,7 +74,6 @@ class ImportColumnFamilyJob {
   const EnvOptions& env_options_;
   autovector<IngestedFileInfo> files_to_import_;
   VersionEdit edit_;
-  VersionStorageInfo vstorage_;
   const ImportColumnFamilyOptions& import_options_;
   std::vector<LiveFileMetaData> metadata_;
   const std::shared_ptr<IOTracer> io_tracer_;

--- a/db/import_column_family_test.cc
+++ b/db/import_column_family_test.cc
@@ -556,10 +556,9 @@ TEST_F(ImportColumnFamilyTest, ImportColumnFamilyNegativeTest) {
         LiveFileMetaDataInit(file2_sst_name, sst_files_dir_, 1, 10, 19));
     metadata.db_comparator_name = options.comparator->Name();
 
-    ASSERT_EQ(db_->CreateColumnFamilyWithImport(ColumnFamilyOptions(), "yoyo",
-                                                ImportColumnFamilyOptions(),
-                                                metadata, &import_cfh_),
-              Status::InvalidArgument("Files have overlapping ranges"));
+    ASSERT_NOK(db_->CreateColumnFamilyWithImport(ColumnFamilyOptions(), "yoyo",
+                                                 ImportColumnFamilyOptions(),
+                                                 metadata, &import_cfh_));
     ASSERT_EQ(import_cfh_, nullptr);
   }
 


### PR DESCRIPTION
Besides the existing ordering and validation, more is coming to VersionBuilder/VersionStorageInfo, like migration of epoch_numbers from older RocksDB versions. We should start using those common classes for importing CFs, instead of duplicating their ordering, validation, and migration logic.

Test Plan: rely on existing tests