### PR TITLE
Fix bug updating latest backup on delete

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 * Fixed a memory leak in MultiGet with async_io read option, caused by IO errors during table file open
 * Fixed a bug that multi-level FIFO compaction deletes one file in non-L0 even when `CompactionOptionsFIFO::max_table_files_size` is no exceeded since #10348 or 7.8.0.
 * Fixed a bug caused by `DB::SyncWAL()` affecting `track_and_verify_wals_in_manifest`. Without the fix, application may see "open error: Corruption: Missing WAL with log number" while trying to open the db. The corruption is a false alarm but prevents DB open (#10892).
+* Fixed a BackupEngine bug in which RestoreDBFromLatestBackup would fail if the latest backup was deleted and there is another valid backup available.
 
 ## 7.9.0 (11/21/2022)
 ### Performance Improvements

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -1635,6 +1635,11 @@ IOStatus BackupEngineImpl::DeleteBackupNoGC(BackupID backup_id) {
       return io_s;
     }
     backups_.erase(backup);
+    if (backups_.empty()) {
+      latest_valid_backup_id_ = 0;
+    } else {
+      latest_valid_backup_id_ = backups_.rbegin()->first;
+    }
   } else {
     auto corrupt = corrupt_backups_.find(backup_id);
     if (corrupt == corrupt_backups_.end()) {

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -1213,6 +1213,10 @@ TEST_P(BackupEngineTestWithParam, OnlineIntegrationTest) {
   // check backup 5
   AssertBackupConsistency(5, 0, max_key);
 
+  // check that "latest backup" still works after deleting latest
+  ASSERT_OK(backup_engine_->DeleteBackup(5));
+  AssertBackupConsistency(0, 0, 3 * keys_iteration, max_key);
+
   CloseBackupEngine();
 }
 #endif  // !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)


### PR DESCRIPTION
Summary: Previously, the "latest" valid backup would not be updated on delete.

Test Plan: unit test included (added to an existing test for efficiency)