### PR TITLE
Add allow_ingest_behind to no_batched_ops_stress test

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -200,6 +200,7 @@ DECLARE_uint64(backup_max_size);
 DECLARE_int32(checkpoint_one_in);
 DECLARE_int32(ingest_external_file_one_in);
 DECLARE_int32(ingest_external_file_width);
+DECLARE_bool(allow_ingest_behind);
 DECLARE_int32(compact_files_one_in);
 DECLARE_int32(compact_range_one_in);
 DECLARE_int32(mark_for_compaction_one_file_in);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -698,6 +698,8 @@ DEFINE_int32(ingest_external_file_one_in, 0,
 DEFINE_int32(ingest_external_file_width, 100,
              "The width of the ingested external files.");
 
+DEFINE_bool(allow_ingest_behind, false, "Options::allow_ingest_behind");
+
 DEFINE_int32(compact_files_one_in, 0,
              "If non-zero, then CompactFiles() will be called once for every N "
              "operations on average.  0 indicates CompactFiles() is disabled.");

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1109,8 +1109,13 @@ class NonBatchedOpsStressTest : public StressTest {
       s = sst_file_writer.Finish();
     }
     if (s.ok()) {
+      IngestExternalFileOptions ingest_external_file_options;
+      if (FLAGS_allow_ingest_behind) {
+        ingest_external_file_options.ingest_behind =
+            thread->rand.OneIn(2) ? true : false;
+      }
       s = db_->IngestExternalFile(column_families_[column_family],
-                                  {sst_filename}, IngestExternalFileOptions());
+                                  {sst_filename}, ingest_external_file_options);
     }
     if (!s.ok()) {
       fprintf(stderr, "file ingestion error: %s\n", s.ToString().c_str());

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -87,6 +87,7 @@ default_params = {
     # Temporarily disable hash index
     "index_type": lambda: random.choice([0, 0, 0, 2, 2, 3]),
     "ingest_external_file_one_in": 1000000,
+    "allow_ingest_behind": lambda: random.randint(0, 1),
     "iterpercent": 10,
     "mark_for_compaction_one_file_in": lambda: 10 * random.randint(0, 1),
     "max_background_compactions": 20,


### PR DESCRIPTION
Just a draft - needs a lot of stress test rehearsal to see if it's stable to add this feature to stress test