### PR TITLE
~SleepingBackgroundTask() to wake up the sleeping task

### DIFF
--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -364,8 +364,13 @@ class SleepingBackgroundTask {
         sleeping_(false) {}
 
   ~SleepingBackgroundTask() {
-    WakeUp();
-    WaitUntilDone();
+    MutexLock l(&mutex_);
+    should_sleep_ = false;
+    while (sleeping_) {
+      assert(!should_sleep_);
+      bg_cv_.SignalAll();
+      bg_cv_.Wait();
+    }
   }
 
   bool IsSleeping() {

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -363,6 +363,11 @@ class SleepingBackgroundTask {
         done_with_sleep_(false),
         sleeping_(false) {}
 
+  ~SleepingBackgroundTask() {
+    WakeUp();
+    WaitUntilDone();
+  }
+
   bool IsSleeping() {
     MutexLock l(&mutex_);
     return sleeping_;


### PR DESCRIPTION
Summary:
Right now, in unit tests, when background tests are sleeping using SleepingBackgroundTask, and the test exits with test assertion failure, the process will hang and it might prevent us to see the test failure message in CI runs. Try to wake up the thread so that the test can exit correctly.

Test Plan: Watch CI succeeds