### PR TITLE
Fix RefitLevel using last level as the base level even when these two can be different

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@
 * Fixed a BackupEngine bug in which RestoreDBFromLatestBackup would fail if the latest backup was deleted and there is another valid backup available.
 * Fix L0 file misorder corruption caused by ingesting files of overlapping seqnos with memtable entries' through introducing `epoch_number`. Before the fix, `force_consistency_checks=true` may catch the corruption before it's exposed to readers, in which case writes returning `Status::Corruption` would be expected. Also replace the previous incomplete fix (#5958) to the same corruption with this new and more complete fix.
 * Fixed a bug in LockWAL() leading to re-locking mutex (#11020).
+* Fixed a bug that `RefitLevel()` can move files from wrong level when base level is different from the last level under universal compaction and `Options::level_compaction_dynamic_level_bytes > 0`.
 
 ## 7.9.0 (11/21/2022)
 ### Performance Improvements

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -2618,8 +2618,7 @@ TEST_F(DBBloomFilterTest, OptimizeFiltersForHits) {
       BottommostLevelCompaction::kSkip;
   compact_options.change_level = true;
   compact_options.target_level = 7;
-  ASSERT_TRUE(db_->CompactRange(compact_options, handles_[1], nullptr, nullptr)
-                  .IsNotSupported());
+  ASSERT_OK(db_->CompactRange(compact_options, handles_[1], nullptr, nullptr));
 
   ASSERT_EQ(trivial_move, 1);
   ASSERT_EQ(non_trivial_move, 0);

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1177,7 +1177,9 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
           break;
         }
         if (output_level == ColumnFamilyData::kCompactToBaseLevel) {
-          final_output_level = cfd->NumberLevels() - 1;
+          assert(cfd->current() && cfd->current()->storage_info());
+          VersionStorageInfo* vstorage = cfd->current()->storage_info();
+          final_output_level = vstorage->base_level();
         } else if (output_level > final_output_level) {
           final_output_level = output_level;
         }

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1177,9 +1177,11 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
           break;
         }
         if (output_level == ColumnFamilyData::kCompactToBaseLevel) {
+          mutex_.Lock();
           assert(cfd->current() && cfd->current()->storage_info());
           VersionStorageInfo* vstorage = cfd->current()->storage_info();
           final_output_level = vstorage->base_level();
+          mutex_.Unlock();
         } else if (output_level > final_output_level) {
           final_output_level = output_level;
         }


### PR DESCRIPTION
Context/Summary: Credit to @cbi42 for finding the bug in https://github.com/facebook/rocksdb/pull/10988/files#r1048004670. Basically as titled.

Test:
Make check