### PR TITLE
Prevent db_stress failure when io_uring is disabled

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -29,7 +29,7 @@
 namespace ROCKSDB_NAMESPACE {
 namespace {
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_guard;
-static std::shared_ptr<ROCKSDB_NAMESPACE::CompositeEnvWrapper>
+static std::shared_ptr<ROCKSDB_NAMESPACE::Env>
     env_wrapper_guard;
 static std::shared_ptr<ROCKSDB_NAMESPACE::CompositeEnvWrapper>
     dbsl_env_wrapper_guard;
@@ -99,6 +99,13 @@ int db_stress_tool(int argc, char** argv) {
 
   env_wrapper_guard = std::make_shared<CompositeEnvWrapper>(
       raw_env, std::make_shared<DbStressFSWrapper>(raw_env->GetFileSystem()));
+  if (!env_opts) {
+    // If using the default Env (Posix), wrap DbStressEnvWrapper with the
+    // legacy EnvWrapper. This is a temporary fix for the ReadAsync interface
+    // not being properly supported with Posix and db_stress. The EnvWrapper
+    // has a default implementation of ReadAsync that redirects to Read.
+    env_wrapper_guard = std::make_shared<EnvWrapper>(env_wrapper_guard);
+  }
   db_stress_env = env_wrapper_guard.get();
 
   FLAGS_rep_factory = StringToRepFactory(FLAGS_memtablerep.c_str());

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -29,8 +29,7 @@
 namespace ROCKSDB_NAMESPACE {
 namespace {
 static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_guard;
-static std::shared_ptr<ROCKSDB_NAMESPACE::Env>
-    env_wrapper_guard;
+static std::shared_ptr<ROCKSDB_NAMESPACE::Env> env_wrapper_guard;
 static std::shared_ptr<ROCKSDB_NAMESPACE::CompositeEnvWrapper>
     dbsl_env_wrapper_guard;
 static std::shared_ptr<CompositeEnvWrapper> fault_env_guard;

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -433,6 +433,10 @@ IOStatus TestFSRandomAccessFile::ReadAsync(
       ret = IOStatus::IOError("Injected read error");
     } else {
       s = target_->ReadAsync(req, opts, cb, cb_arg, io_handle, del_fn, nullptr);
+      if (s.IsNotSupported()) {
+        return FSRandomAccessFile::ReadAsync(req, opts, cb, cb_arg, io_handle,
+                                             del_fn, nullptr);
+      }
     }
   }
   if (!ret.ok()) {

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -433,10 +433,6 @@ IOStatus TestFSRandomAccessFile::ReadAsync(
       ret = IOStatus::IOError("Injected read error");
     } else {
       s = target_->ReadAsync(req, opts, cb, cb_arg, io_handle, del_fn, nullptr);
-      if (s.IsNotSupported()) {
-        return FSRandomAccessFile::ReadAsync(req, opts, cb, cb_arg, io_handle,
-                                             del_fn, nullptr);
-      }
     }
   }
   if (!ret.ok()) {


### PR DESCRIPTION
The IO uring usage is disabled in RocksDB by default and, as a result, PosixRandomAccessFile::ReadAsync returns a NotSupported() status. This was causing stress test failures with MultiGet and async_io combination. Fix it by relying on redirection of ReadAsync to Read when default Env is used in db_stress.