### PR TITLE
Scan the immutable memtable list to get max/min id if mempurge is used

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@
 * Fixed a bug in LockWAL() leading to re-locking mutex (#11020).
 * Fixed a heap use after free bug in async scan prefetching when the scan thread and another thread try to read and load the same seek block into cache.
 * Fixed a heap use after free in async scan prefetching if dictionary compression is enabled, in which case sync read of the compression dictionary gets mixed with async prefetching
+* Fixed a bug in `GetEarliestMemTableID()` and `GetLatestMemTableID()`, which is blame for (#9151). When mempurge is ever used, the immutable memtable list is no longer sorted in descending order, so we have to scan it to get the appropriate value.
 
 ### New Features
 * When an SstPartitionerFactory is configured, CompactRange() now automatically selects for compaction any files overlapping a partition boundary that is in the compaction range, even if no actual entries are in the requested compaction range. With this feature, manual compaction can be used to (re-)establish SST partition points when SstPartitioner changes, without a full compaction.

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -351,6 +351,14 @@ class ColumnFamilyData {
   MemTableList* imm() { return &imm_; }
   MemTable* mem() { return mem_; }
 
+  uint64_t GetLatestImmTableID() {
+    return imm()->GetLatestMemTableID(GetMempurgeUsed());
+  }
+
+  uint64_t GetEarliestImmTableID() {
+    return imm()->GetEarliestMemTableID(GetMempurgeUsed());
+  }
+
   bool IsEmpty() {
     return mem()->GetFirstSequenceNumber() == 0 && imm()->NumNotFlushed() == 0;
   }

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -1440,7 +1440,7 @@ TEST_F(DBFlushTest, MemPurgeAndCompactionFilter) {
   ASSERT_EQ(Get(KEY5), p_v5);
 }
 
-TEST_F(DBFlushTest, DISABLED_MemPurgeWALSupport) {
+TEST_F(DBFlushTest, MemPurgeWALSupport) {
   Options options = CurrentOptions();
 
   options.statistics = CreateDBStatistics();

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1480,8 +1480,7 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
   assert(cfd);
   assert(cfd->imm());
   // The immutable memtable list must be empty.
-  assert(std::numeric_limits<uint64_t>::max() ==
-         cfd->imm()->GetEarliestMemTableID());
+  assert(std::numeric_limits<uint64_t>::max() == cfd->GetEarliestImmTableID());
 
   const uint64_t start_micros = immutable_db_options_.clock->NowMicros();
 

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -452,8 +452,8 @@ TEST_F(FlushJobTest, FlushMemtablesMultipleColumnFamilies) {
     ASSERT_EQ(largest_seqs[k], file_meta.fd.largest_seqno);
     // Verify that imm is empty
     ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
-              all_cfds[k]->imm()->GetEarliestMemTableID());
-    ASSERT_EQ(0, all_cfds[k]->imm()->GetLatestMemTableID());
+              all_cfds[k]->GetEarliestImmTableID());
+    ASSERT_EQ(0, all_cfds[k]->GetLatestImmTableID());
     ++k;
   }
 

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -816,7 +816,9 @@ Status InstallMemtableAtomicFlushResults(
     const auto* imm =
         (imm_lists == nullptr) ? cfds[k]->imm() : imm_lists->at(k);
     if (!mems_list[k]->empty()) {
-      assert((*mems_list[k])[0]->GetID() == imm->GetEarliestMemTableID());
+      // If atomic flush feature is enabled, then mempurge feature must have
+      // been disabled, hence no memtable id is reused.
+      assert((*mems_list[k])[0]->GetID() == imm->GetEarliestMemTableID(false));
     }
 #endif
     assert(nullptr != file_metas[k]);

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -829,7 +829,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   // Add another table
   list.Add(tables[5], &to_delete);
   ASSERT_EQ(1, list.NumNotFlushed());
-  ASSERT_EQ(5, list.GetLatestMemTableID());
+  ASSERT_EQ(5, list.GetLatestMemTableID(false));
   memtable_id = 4;
   // Pick tables to flush. The tables to pick must have ID smaller than or
   // equal to 4. Therefore, no table will be selected in this case.


### PR DESCRIPTION
Fix https://github.com/facebook/rocksdb/issues/9151. Before the fix, if mempurge is ever used, we might pick no immutable memtable for flush forever because `GetLatestMemTableID()` yields a bad value. 

Test plan:
make check