### PR TITLE
Skip unnormal sample entry in MemPurgeDecider.

### DIFF
--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -700,6 +700,7 @@ bool FlushJob::MemPurgeDecider(double threshold) {
                        "Memtable Decider: ParseInternalKey did not parse "
                        "key_slice %s successfully.",
                        key_slice.data());
+        continue;
       }
 
       // Size of the entry is "key size (+ value size if KV entry)"
@@ -741,6 +742,7 @@ bool FlushJob::MemPurgeDecider(double threshold) {
             "Memtable Get returned false when Get(sampled entry). "
             "Yet each sample entry should exist somewhere in the memtable, "
             "unrelated to whether it has been deleted or not.");
+        continue;
       }
 
       // TODO(bjlemaire): evaluate typeMerge.


### PR DESCRIPTION
Although the logic of judging whether the sample entry is valid tolerates unnormal entries, we should skip them ASAP.
Test plan: make check