### PR TITLE
Fix error maybe-uninitialized #11100

### DIFF
--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -317,7 +317,7 @@ Status TracerHelper::DecodeTraceRecord(Trace* trace, int trace_file_version,
       cf_ids.reserve(multiget_size);
       multiget_keys.reserve(multiget_size);
       for (uint32_t i = 0; i < multiget_size; i++) {
-        uint32_t tmp_cfid;
+        uint32_t tmp_cfid = 0;
         Slice tmp_key;
         GetFixed32(&cfids_payload, &tmp_cfid);
         GetLengthPrefixedSlice(&keys_payload, &tmp_key);


### PR DESCRIPTION
In this issue [11100](https://github.com/facebook/rocksdb/issues/11100)
I try to upgrade dependencies of [BaikalDB](https://github.com/baidu/BaikalDB) and tool chain to gcc-12.I found that when I build rocksdb v6.26.0(maybe I can use newer version),I found that in file trace_replay/trace_replay.cc,the compiler tell me "error mybe-uninitialized".I dound that it can be fixed very easy,so I make this pull request.