### PR TITLE
remove unused InternalIteratorBase::is_mutable_

### DIFF
--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -203,8 +203,6 @@ class InternalIteratorBase : public Cleanable {
       Prev();
     }
   }
-
-  bool is_mutable_;
 };
 
 using InternalIterator = InternalIteratorBase<Slice>;


### PR DESCRIPTION
`InternalIteratorBase::is_mutable_` is not used any more, remove it.