### PR TITLE
Fix asan failure caused by range tombstone start key use-after-free

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -253,7 +253,7 @@ Status BuildTable(
         if (version) {
           if (last_tombstone_start_user_key.empty() ||
               ucmp->CompareWithoutTimestamp(last_tombstone_start_user_key,
-                                            tombstone.start_key_) < 0) {
+                                            range_del_it->start_key()) < 0) {
             SizeApproximationOptions approx_opts;
             approx_opts.files_size_error_margin = 0.1;
             meta->compensated_range_deletion_size += versions->ApproximateSize(
@@ -261,7 +261,7 @@ Status BuildTable(
                 0 /* start_level */, -1 /* end_level */,
                 TableReaderCaller::kFlush);
           }
-          last_tombstone_start_user_key = tombstone.start_key_;
+          last_tombstone_start_user_key = range_del_it->start_key();
         }
       }
     }

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -616,8 +616,8 @@ Status CompactionOutputs::AddRangeDels(
       bool start_user_key_changed =
           last_tombstone_start_user_key.empty() ||
           ucmp->CompareWithoutTimestamp(last_tombstone_start_user_key,
-                                        tombstone.start_key_) < 0;
-      last_tombstone_start_user_key = tombstone.start_key_;
+                                        it->start_key()) < 0;
+      last_tombstone_start_user_key = it->start_key();
       // Range tombstones are truncated at file boundaries
       if (icmp.Compare(tombstone_start, meta.smallest) < 0) {
         tombstone_start = meta.smallest;


### PR DESCRIPTION
Summary: the `last_tombstone_start_user_key` variable in `BuildTable()` and in `CompactionOutputs::AddRangeDels()` may point to a start key that is freed if user-defined timestamp is enabled. This was causing ASAN failure and this PR fixes this issue.

Test plan: Added UT for repro.