### PR TITLE
Remove deprecated Env::LoadEnv()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 ### Bug Fixes
 * Fixed a data race on `ColumnFamilyData::flush_reason` caused by concurrent flushes.
 
+### Public API Changes
+* Remove deprecated Env::LoadEnv(). Use Env::CreateFromString() instead.
+
 ## 7.10.0 (01/23/2023)
 ### Behavior changes
 * Make best-efforts recovery verify SST unique ID before Version construction (#10962)

--- a/env/env.cc
+++ b/env/env.cc
@@ -640,10 +640,6 @@ Status Env::NewLogger(const std::string& fname,
   return NewEnvLogger(fname, this, result);
 }
 
-Status Env::LoadEnv(const std::string& value, Env** result) {
-  return CreateFromString(ConfigOptions(), value, result);
-}
-
 Status Env::CreateFromString(const ConfigOptions& config_options,
                              const std::string& value, Env** result) {
   Env* base = Env::Default();
@@ -659,11 +655,6 @@ Status Env::CreateFromString(const ConfigOptions& config_options,
     }
     return s;
   }
-}
-
-Status Env::LoadEnv(const std::string& value, Env** result,
-                    std::shared_ptr<Env>* guard) {
-  return CreateFromString(ConfigOptions(), value, result, guard);
 }
 
 Status Env::CreateFromString(const ConfigOptions& config_options,

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -180,17 +180,6 @@ class Env : public Customizable {
   const char* Name() const override { return ""; }
 
   // Loads the environment specified by the input value into the result
-  // The CreateFromString alternative should be used; this method may be
-  // deprecated in a future release.
-  static Status LoadEnv(const std::string& value, Env** result);
-
-  // Loads the environment specified by the input value into the result
-  // The CreateFromString alternative should be used; this method may be
-  // deprecated in a future release.
-  static Status LoadEnv(const std::string& value, Env** result,
-                        std::shared_ptr<Env>* guard);
-
-  // Loads the environment specified by the input value into the result
   // @see Customizable for a more detailed description of the parameters and
   // return codes
   //

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -1433,7 +1433,7 @@ TEST_F(OptionsTest, GetOptionsFromStringTest) {
   ASSERT_EQ(new_options.max_open_files, 1);
   ASSERT_TRUE(new_options.rate_limiter.get() != nullptr);
   Env* newEnv = new_options.env;
-  ASSERT_OK(Env::LoadEnv(CustomEnv::kClassName(), &newEnv));
+  ASSERT_OK(Env::CreateFromString({}, CustomEnv::kClassName(), &newEnv));
   ASSERT_EQ(newEnv, new_options.env);
 
   config_options.ignore_unknown_options = false;
@@ -3180,7 +3180,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromStringTest) {
   ASSERT_EQ(new_options.max_open_files, 1);
   ASSERT_TRUE(new_options.rate_limiter.get() != nullptr);
   Env* newEnv = new_options.env;
-  ASSERT_OK(Env::LoadEnv("CustomEnvDefault", &newEnv));
+  ASSERT_OK(Env::CreateFromString({}, "CustomEnvDefault", &newEnv));
   ASSERT_EQ(newEnv, new_options.env);
 }
 


### PR DESCRIPTION
Summary: Can use Env::CreateFromString() instead

Test Plan: unit tests updated