### PR TITLE
Remove deprecated FileSystem::Load()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 ### Feature Removal
 * The feature block_cache_compressed is removed. Statistics related to it are removed too.
 * Remove deprecated Env::LoadEnv(). Use Env::CreateFromString() instead.
+* Remove deprecated FileSystem::Load(). Use FileSystem::CreateFromString() instead.
 
 ### Public API Changes
 * Completely removed the following deprecated/obsolete statistics: the tickers `BLOCK_CACHE_INDEX_BYTES_EVICT`, `BLOCK_CACHE_FILTER_BYTES_EVICT`, `BLOOM_FILTER_MICROS`, `NO_FILE_CLOSES`, `STALL_L0_SLOWDOWN_MICROS`, `STALL_MEMTABLE_COMPACTION_MICROS`, `STALL_L0_NUM_FILES_MICROS`, `RATE_LIMIT_DELAY_MILLIS`, `NO_ITERATORS`, `NUMBER_FILTERED_DELETES`, `WRITE_TIMEDOUT`, `BLOB_DB_GC_NUM_KEYS_OVERWRITTEN`, `BLOB_DB_GC_NUM_KEYS_EXPIRED`, `BLOB_DB_GC_BYTES_OVERWRITTEN`, `BLOB_DB_GC_BYTES_EXPIRED`, `BLOCK_CACHE_COMPRESSION_DICT_BYTES_EVICT`, `STALL_L0_SLOWDOWN_COUNT`, `STALL_MEMTABLE_COMPACTION_COUNT`, `STALL_L0_NUM_FILES_COUNT`, `HARD_RATE_LIMIT_DELAY_COUNT`, and `SOFT_RATE_LIMIT_DELAY_COUNT` as well as the histograms `BLOB_DB_GC_MICROS` and `NUM_DATA_BLOCKS_READ_PER_LEVEL`. Note that as a result, the C++ enum values of the still supported statistics have changed. Developers are advised to not rely on the actual numeric values.

--- a/env/file_system.cc
+++ b/env/file_system.cc
@@ -26,11 +26,6 @@ FileSystem::FileSystem() {}
 
 FileSystem::~FileSystem() {}
 
-Status FileSystem::Load(const std::string& value,
-                        std::shared_ptr<FileSystem>* result) {
-  return CreateFromString(ConfigOptions(), value, result);
-}
-
 #ifndef ROCKSDB_LITE
 static int RegisterBuiltinFileSystems(ObjectLibrary& library,
                                       const std::string& /*arg*/) {

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -273,12 +273,6 @@ class FileSystem : public Customizable {
   static const char* kDefaultName() { return "DefaultFileSystem"; }
 
   // Loads the FileSystem specified by the input value into the result
-  // The CreateFromString alternative should be used; this method may be
-  // deprecated in a future release.
-  static Status Load(const std::string& value,
-                     std::shared_ptr<FileSystem>* result);
-
-  // Loads the FileSystem specified by the input value into the result
   // @see Customizable for a more detailed description of the parameters and
   // return codes
   // @param config_options Controls how the FileSystem is loaded


### PR DESCRIPTION
Summary: user should use FileSystem::CreateFromString() instead.