### PR TITLE
Remove deprecated util functions in options_util.h

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 
 ### Public API Changes
 * Completely removed the following deprecated/obsolete statistics: the tickers `BLOCK_CACHE_INDEX_BYTES_EVICT`, `BLOCK_CACHE_FILTER_BYTES_EVICT`, `BLOOM_FILTER_MICROS`, `NO_FILE_CLOSES`, `STALL_L0_SLOWDOWN_MICROS`, `STALL_MEMTABLE_COMPACTION_MICROS`, `STALL_L0_NUM_FILES_MICROS`, `RATE_LIMIT_DELAY_MILLIS`, `NO_ITERATORS`, `NUMBER_FILTERED_DELETES`, `WRITE_TIMEDOUT`, `BLOB_DB_GC_NUM_KEYS_OVERWRITTEN`, `BLOB_DB_GC_NUM_KEYS_EXPIRED`, `BLOB_DB_GC_BYTES_OVERWRITTEN`, `BLOB_DB_GC_BYTES_EXPIRED`, `BLOCK_CACHE_COMPRESSION_DICT_BYTES_EVICT` as well as the histograms `STALL_L0_SLOWDOWN_COUNT`, `STALL_MEMTABLE_COMPACTION_COUNT`, `STALL_L0_NUM_FILES_COUNT`, `HARD_RATE_LIMIT_DELAY_COUNT`, `SOFT_RATE_LIMIT_DELAY_COUNT`, `BLOB_DB_GC_MICROS`, and `NUM_DATA_BLOCKS_READ_PER_LEVEL`. Note that as a result, the C++ enum values of the still supported statistics have changed. Developers are advised to not rely on the actual numeric values.
+* Removed the deprecated version of these utility functions and the corresponding Java bindings: `LoadOptionsFromFile`, `LoadLatestOptions`, `CheckOptionsCompatibility`.
 
 ## 7.10.0 (01/23/2023)
 ### Behavior changes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,10 +11,10 @@
 * The feature block_cache_compressed is removed. Statistics related to it are removed too.
 * Remove deprecated Env::LoadEnv(). Use Env::CreateFromString() instead.
 * Remove deprecated FileSystem::Load(). Use FileSystem::CreateFromString() instead.
+* Removed the deprecated version of these utility functions and the corresponding Java bindings: `LoadOptionsFromFile`, `LoadLatestOptions`, `CheckOptionsCompatibility`.
 
 ### Public API Changes
 * Completely removed the following deprecated/obsolete statistics: the tickers `BLOCK_CACHE_INDEX_BYTES_EVICT`, `BLOCK_CACHE_FILTER_BYTES_EVICT`, `BLOOM_FILTER_MICROS`, `NO_FILE_CLOSES`, `STALL_L0_SLOWDOWN_MICROS`, `STALL_MEMTABLE_COMPACTION_MICROS`, `STALL_L0_NUM_FILES_MICROS`, `RATE_LIMIT_DELAY_MILLIS`, `NO_ITERATORS`, `NUMBER_FILTERED_DELETES`, `WRITE_TIMEDOUT`, `BLOB_DB_GC_NUM_KEYS_OVERWRITTEN`, `BLOB_DB_GC_NUM_KEYS_EXPIRED`, `BLOB_DB_GC_BYTES_OVERWRITTEN`, `BLOB_DB_GC_BYTES_EXPIRED`, `BLOCK_CACHE_COMPRESSION_DICT_BYTES_EVICT` as well as the histograms `STALL_L0_SLOWDOWN_COUNT`, `STALL_MEMTABLE_COMPACTION_COUNT`, `STALL_L0_NUM_FILES_COUNT`, `HARD_RATE_LIMIT_DELAY_COUNT`, `SOFT_RATE_LIMIT_DELAY_COUNT`, `BLOB_DB_GC_MICROS`, and `NUM_DATA_BLOCKS_READ_PER_LEVEL`. Note that as a result, the C++ enum values of the still supported statistics have changed. Developers are advised to not rely on the actual numeric values.
-* Removed the deprecated version of these utility functions and the corresponding Java bindings: `LoadOptionsFromFile`, `LoadLatestOptions`, `CheckOptionsCompatibility`.
 
 ## 7.10.0 (01/23/2023)
 ### Behavior changes

--- a/db/c.cc
+++ b/db/c.cc
@@ -69,6 +69,7 @@ using ROCKSDB_NAMESPACE::CompactionOptionsFIFO;
 using ROCKSDB_NAMESPACE::CompactRangeOptions;
 using ROCKSDB_NAMESPACE::Comparator;
 using ROCKSDB_NAMESPACE::CompressionType;
+using ROCKSDB_NAMESPACE::ConfigOptions;
 using ROCKSDB_NAMESPACE::CuckooTableOptions;
 using ROCKSDB_NAMESPACE::DB;
 using ROCKSDB_NAMESPACE::DBOptions;
@@ -2498,8 +2499,12 @@ void rocksdb_load_latest_options(
     rocksdb_options_t*** list_column_family_options, char** errptr) {
   DBOptions db_opt;
   std::vector<ColumnFamilyDescriptor> cf_descs;
-  Status s = LoadLatestOptions(std::string(db_path), env->rep, &db_opt,
-                               &cf_descs, ignore_unknown_options, &cache->rep);
+  ConfigOptions config_opts;
+  config_opts.ignore_unknown_options = ignore_unknown_options;
+  config_opts.input_strings_escaped = true;
+  config_opts.env = env->rep;
+  Status s = LoadLatestOptions(config_opts, std::string(db_path), &db_opt,
+                               &cf_descs, &cache->rep);
   if (s.ok()) {
     char** cf_names = (char**)malloc(cf_descs.size() * sizeof(char*));
     rocksdb_options_t** cf_options = (rocksdb_options_t**)malloc(

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3015,9 +3015,13 @@ void CheckAndSetOptionsForUserTimestamp(Options& options) {
 bool InitializeOptionsFromFile(Options& options) {
 #ifndef ROCKSDB_LITE
   DBOptions db_options;
+  ConfigOptions config_options;
+  config_options.ignore_unknown_options = false;
+  config_options.input_strings_escaped = true;
+  config_options.env = db_stress_env;
   std::vector<ColumnFamilyDescriptor> cf_descriptors;
   if (!FLAGS_options_file.empty()) {
-    Status s = LoadOptionsFromFile(FLAGS_options_file, db_stress_env,
+    Status s = LoadOptionsFromFile(config_options, FLAGS_options_file,
                                    &db_options, &cf_descriptors);
     if (!s.ok()) {
       fprintf(stderr, "Unable to load options file %s --- %s\n",

--- a/include/rocksdb/utilities/options_util.h
+++ b/include/rocksdb/utilities/options_util.h
@@ -50,15 +50,12 @@ struct ConfigOptions;
 // casting the return value of TableFactory::GetOptions() to
 // BlockBasedTableOptions and making necessary changes.
 //
-// ignore_unknown_options can be set to true if you want to ignore options
-// that are from a newer version of the db, essentially for forward
-// compatibility.
-//
 // config_options contains a set of options that controls the processing
-// of the options.  The LoadLatestOptions(ConfigOptions...) should be preferred;
-// the alternative signature may be deprecated in a future release. The
-// equivalent functionality can be achieved by setting the corresponding options
-// in the ConfigOptions parameter.
+// of the options.
+//
+// config_options.ignore_unknown_options can be set to true if you want to
+// ignore options that are from a newer version of the db, essentially for
+// forward compatibility.
 //
 // examples/options_file_example.cc demonstrates how to use this function
 // to open a RocksDB instance.
@@ -70,11 +67,6 @@ struct ConfigOptions;
 //     to the options file itself.
 //
 // @see LoadOptionsFromFile
-Status LoadLatestOptions(const std::string& dbpath, Env* env,
-                         DBOptions* db_options,
-                         std::vector<ColumnFamilyDescriptor>* cf_descs,
-                         bool ignore_unknown_options = false,
-                         std::shared_ptr<Cache>* cache = {});
 Status LoadLatestOptions(const ConfigOptions& config_options,
                          const std::string& dbpath, DBOptions* db_options,
                          std::vector<ColumnFamilyDescriptor>* cf_descs,
@@ -83,17 +75,7 @@ Status LoadLatestOptions(const ConfigOptions& config_options,
 // Similar to LoadLatestOptions, this function constructs the DBOptions
 // and ColumnFamilyDescriptors based on the specified RocksDB Options file.
 //
-// The LoadOptionsFile(ConfigOptions...) should be preferred;
-// the alternative signature may be deprecated in a future release. The
-// equivalent functionality can be achieved by setting the corresponding
-// options in the ConfigOptions parameter.
-//
 // @see LoadLatestOptions
-Status LoadOptionsFromFile(const std::string& options_file_name, Env* env,
-                           DBOptions* db_options,
-                           std::vector<ColumnFamilyDescriptor>* cf_descs,
-                           bool ignore_unknown_options = false,
-                           std::shared_ptr<Cache>* cache = {});
 Status LoadOptionsFromFile(const ConfigOptions& config_options,
                            const std::string& options_file_name,
                            DBOptions* db_options,
@@ -115,10 +97,6 @@ Status GetLatestOptionsFileName(const std::string& dbpath, Env* env,
 // * prefix_extractor
 // * table_factory
 // * merge_operator
-Status CheckOptionsCompatibility(
-    const std::string& dbpath, Env* env, const DBOptions& db_options,
-    const std::vector<ColumnFamilyDescriptor>& cf_descs,
-    bool ignore_unknown_options = false);
 Status CheckOptionsCompatibility(
     const ConfigOptions& config_options, const std::string& dbpath,
     const DBOptions& db_options,

--- a/java/rocksjni/config_options.cc
+++ b/java/rocksjni/config_options.cc
@@ -39,6 +39,19 @@ jlong Java_org_rocksdb_ConfigOptions_newConfigOptions(JNIEnv *, jclass) {
 /*
  * Class:     org_rocksdb_ConfigOptions
  * Method:    setDelimiter
+ * Signature: (JJ;)V
+ */
+void Java_org_rocksdb_ConfigOptions_setEnv(JNIEnv *, jclass, jlong handle,
+                                           jlong rocksdb_env_handle) {
+  auto *cfg_opt = reinterpret_cast<ROCKSDB_NAMESPACE::ConfigOptions *>(handle);
+  auto *rocksdb_env =
+      reinterpret_cast<ROCKSDB_NAMESPACE::Env *>(rocksdb_env_handle);
+  cfg_opt->env = rocksdb_env;
+}
+
+/*
+ * Class:     org_rocksdb_ConfigOptions
+ * Method:    setDelimiter
  * Signature: (JLjava/lang/String;)V
  */
 void Java_org_rocksdb_ConfigOptions_setDelimiter(JNIEnv *env, jclass,

--- a/java/rocksjni/config_options.cc
+++ b/java/rocksjni/config_options.cc
@@ -38,7 +38,7 @@ jlong Java_org_rocksdb_ConfigOptions_newConfigOptions(JNIEnv *, jclass) {
 
 /*
  * Class:     org_rocksdb_ConfigOptions
- * Method:    setDelimiter
+ * Method:    setEnv
  * Signature: (JJ;)V
  */
 void Java_org_rocksdb_ConfigOptions_setEnv(JNIEnv *, jclass, jlong handle,

--- a/java/rocksjni/options_util.cc
+++ b/java/rocksjni/options_util.cc
@@ -53,38 +53,10 @@ void build_column_family_descriptor_list(
 
 /*
  * Class:     org_rocksdb_OptionsUtil
- * Method:    loadLatestOptions
- * Signature: (Ljava/lang/String;JLjava/util/List;Z)V
- */
-void Java_org_rocksdb_OptionsUtil_loadLatestOptions__Ljava_lang_String_2JJLjava_util_List_2Z(
-    JNIEnv* env, jclass /*jcls*/, jstring jdbpath, jlong jenv_handle,
-    jlong jdb_opts_handle, jobject jcfds, jboolean ignore_unknown_options) {
-  jboolean has_exception = JNI_FALSE;
-  auto db_path =
-      ROCKSDB_NAMESPACE::JniUtil::copyStdString(env, jdbpath, &has_exception);
-  if (has_exception == JNI_TRUE) {
-    // exception occurred
-    return;
-  }
-  std::vector<ROCKSDB_NAMESPACE::ColumnFamilyDescriptor> cf_descs;
-  ROCKSDB_NAMESPACE::Status s = ROCKSDB_NAMESPACE::LoadLatestOptions(
-      db_path, reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jenv_handle),
-      reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jdb_opts_handle),
-      &cf_descs, ignore_unknown_options);
-  if (!s.ok()) {
-    // error, raise an exception
-    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
-  } else {
-    build_column_family_descriptor_list(env, jcfds, cf_descs);
-  }
-}
-
-/*
- * Class:     org_rocksdb_OptionsUtil
  * Method:    loadLatestOptions_1
  * Signature: (JLjava/lang/String;JLjava/util/List;)V
  */
-void Java_org_rocksdb_OptionsUtil_loadLatestOptions__JLjava_lang_String_2JLjava_util_List_2(
+void Java_org_rocksdb_OptionsUtil_loadLatestOptions(
     JNIEnv* env, jclass /*jcls*/, jlong cfg_handle, jstring jdbpath,
     jlong jdb_opts_handle, jobject jcfds) {
   jboolean has_exception = JNI_FALSE;
@@ -112,37 +84,9 @@ void Java_org_rocksdb_OptionsUtil_loadLatestOptions__JLjava_lang_String_2JLjava_
 /*
  * Class:     org_rocksdb_OptionsUtil
  * Method:    loadOptionsFromFile
- * Signature: (Ljava/lang/String;JJLjava/util/List;Z)V
- */
-void Java_org_rocksdb_OptionsUtil_loadOptionsFromFile__Ljava_lang_String_2JJLjava_util_List_2Z(
-    JNIEnv* env, jclass /*jcls*/, jstring jopts_file_name, jlong jenv_handle,
-    jlong jdb_opts_handle, jobject jcfds, jboolean ignore_unknown_options) {
-  jboolean has_exception = JNI_FALSE;
-  auto opts_file_name = ROCKSDB_NAMESPACE::JniUtil::copyStdString(
-      env, jopts_file_name, &has_exception);
-  if (has_exception == JNI_TRUE) {
-    // exception occurred
-    return;
-  }
-  std::vector<ROCKSDB_NAMESPACE::ColumnFamilyDescriptor> cf_descs;
-  ROCKSDB_NAMESPACE::Status s = ROCKSDB_NAMESPACE::LoadOptionsFromFile(
-      opts_file_name, reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jenv_handle),
-      reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jdb_opts_handle),
-      &cf_descs, ignore_unknown_options);
-  if (!s.ok()) {
-    // error, raise an exception
-    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
-  } else {
-    build_column_family_descriptor_list(env, jcfds, cf_descs);
-  }
-}
-
-/*
- * Class:     org_rocksdb_OptionsUtil
- * Method:    loadOptionsFromFile
  * Signature: (JLjava/lang/String;JLjava/util/List;)V
  */
-void Java_org_rocksdb_OptionsUtil_loadOptionsFromFile__JLjava_lang_String_2JLjava_util_List_2(
+void Java_org_rocksdb_OptionsUtil_loadOptionsFromFile(
     JNIEnv* env, jclass /*jcls*/, jlong cfg_handle, jstring jopts_file_name,
     jlong jdb_opts_handle, jobject jcfds) {
   jboolean has_exception = JNI_FALSE;

--- a/java/rocksjni/options_util.cc
+++ b/java/rocksjni/options_util.cc
@@ -53,7 +53,7 @@ void build_column_family_descriptor_list(
 
 /*
  * Class:     org_rocksdb_OptionsUtil
- * Method:    loadLatestOptions_1
+ * Method:    loadLatestOptions
  * Signature: (JLjava/lang/String;JLjava/util/List;)V
  */
 void Java_org_rocksdb_OptionsUtil_loadLatestOptions(

--- a/java/src/main/java/org/rocksdb/OptionsUtil.java
+++ b/java/src/main/java/org/rocksdb/OptionsUtil.java
@@ -35,47 +35,6 @@ public class OptionsUtil {
    * BlockBasedTableOptions and making necessary changes.
    *
    * @param dbPath the path to the RocksDB.
-   * @param env {@link org.rocksdb.Env} instance.
-   * @param dbOptions {@link org.rocksdb.DBOptions} instance. This will be
-   *     filled and returned.
-   * @param cfDescs A list of {@link org.rocksdb.ColumnFamilyDescriptor}'s be
-   *    returned.
-   *
-   * @throws RocksDBException thrown if error happens in underlying
-   *     native library.
-   */
-
-  public static void loadLatestOptions(String dbPath, Env env, DBOptions dbOptions,
-      List<ColumnFamilyDescriptor> cfDescs) throws RocksDBException {
-    loadLatestOptions(dbPath, env, dbOptions, cfDescs, false);
-  }
-
-  /**
-   * @param dbPath the path to the RocksDB.
-   * @param env {@link org.rocksdb.Env} instance.
-   * @param dbOptions {@link org.rocksdb.DBOptions} instance. This will be
-   *     filled and returned.
-   * @param cfDescs A list of {@link org.rocksdb.ColumnFamilyDescriptor}'s be
-   *     returned.
-   * @param ignoreUnknownOptions this flag can be set to true if you want to
-   *     ignore options that are from a newer version of the db, essentially for
-   *     forward compatibility.
-   *
-   * @throws RocksDBException thrown if error happens in underlying
-   *     native library.
-   */
-  public static void loadLatestOptions(String dbPath, Env env, DBOptions dbOptions,
-      List<ColumnFamilyDescriptor> cfDescs, boolean ignoreUnknownOptions) throws RocksDBException {
-    loadLatestOptions(
-        dbPath, env.nativeHandle_, dbOptions.nativeHandle_, cfDescs, ignoreUnknownOptions);
-  }
-
-  /**
-   * Similar to LoadLatestOptions, this function constructs the DBOptions
-   * and ColumnFamilyDescriptors based on the specified RocksDB Options file.
-   * See LoadLatestOptions above.
-   *
-   * @param dbPath the path to the RocksDB.
    * @param configOptions {@link org.rocksdb.ConfigOptions} instance.
    * @param dbOptions {@link org.rocksdb.DBOptions} instance. This will be
    *     filled and returned.
@@ -87,46 +46,6 @@ public class OptionsUtil {
   public static void loadLatestOptions(ConfigOptions configOptions, String dbPath,
       DBOptions dbOptions, List<ColumnFamilyDescriptor> cfDescs) throws RocksDBException {
     loadLatestOptions(configOptions.nativeHandle_, dbPath, dbOptions.nativeHandle_, cfDescs);
-  }
-
-  /**
-   * Similar to LoadLatestOptions, this function constructs the DBOptions
-   * and ColumnFamilyDescriptors based on the specified RocksDB Options file.
-   * See LoadLatestOptions above.
-   *
-   * @param optionsFileName the RocksDB options file path.
-   * @param env {@link org.rocksdb.Env} instance.
-   * @param dbOptions {@link org.rocksdb.DBOptions} instance. This will be
-   *     filled and returned.
-   * @param cfDescs A list of {@link org.rocksdb.ColumnFamilyDescriptor}'s be
-   *     returned.
-   *
-   * @throws RocksDBException thrown if error happens in underlying
-   *     native library.
-   */
-  public static void loadOptionsFromFile(String optionsFileName, Env env, DBOptions dbOptions,
-      List<ColumnFamilyDescriptor> cfDescs) throws RocksDBException {
-    loadOptionsFromFile(optionsFileName, env, dbOptions, cfDescs, false);
-  }
-
-  /**
-   * @param optionsFileName the RocksDB options file path.
-   * @param env {@link org.rocksdb.Env} instance.
-   * @param dbOptions {@link org.rocksdb.DBOptions} instance. This will be
-   *     filled and returned.
-   * @param cfDescs A list of {@link org.rocksdb.ColumnFamilyDescriptor}'s be
-   *     returned.
-   * @param ignoreUnknownOptions this flag can be set to true if you want to
-   *     ignore options that are from a newer version of the db, esentially for
-   *     forward compatibility.
-   *
-   * @throws RocksDBException thrown if error happens in underlying
-   *     native library.
-   */
-  public static void loadOptionsFromFile(String optionsFileName, Env env, DBOptions dbOptions,
-      List<ColumnFamilyDescriptor> cfDescs, boolean ignoreUnknownOptions) throws RocksDBException {
-    loadOptionsFromFile(
-        optionsFileName, env.nativeHandle_, dbOptions.nativeHandle_, cfDescs, ignoreUnknownOptions);
   }
 
   /**
@@ -170,13 +89,8 @@ public class OptionsUtil {
   private OptionsUtil() {}
 
   // native methods
-  private native static void loadLatestOptions(String dbPath, long envHandle, long dbOptionsHandle,
-      List<ColumnFamilyDescriptor> cfDescs, boolean ignoreUnknownOptions) throws RocksDBException;
   private native static void loadLatestOptions(long cfgHandle, String dbPath, long dbOptionsHandle,
       List<ColumnFamilyDescriptor> cfDescs) throws RocksDBException;
-  private native static void loadOptionsFromFile(String optionsFileName, long envHandle,
-      long dbOptionsHandle, List<ColumnFamilyDescriptor> cfDescs, boolean ignoreUnknownOptions)
-      throws RocksDBException;
   private native static void loadOptionsFromFile(long cfgHandle, String optionsFileName,
       long dbOptionsHandle, List<ColumnFamilyDescriptor> cfDescs) throws RocksDBException;
   private native static String getLatestOptionsFileName(String dbPath, long envHandle)

--- a/java/src/test/java/org/rocksdb/OptionsUtilTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsUtilTest.java
@@ -77,13 +77,16 @@ public class OptionsUtilTest {
 
     // Read the options back and verify
     DBOptions dbOptions = new DBOptions();
+    ConfigOptions configOptions =
+        new ConfigOptions().setIgnoreUnknownOptions(false).setInputStringsEscaped(true).setEnv(
+            Env.getDefault());
     final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
     String path = dbPath;
     if (apiType == TestAPI.LOAD_LATEST_OPTIONS) {
-      OptionsUtil.loadLatestOptions(path, Env.getDefault(), dbOptions, cfDescs, false);
+      OptionsUtil.loadLatestOptions(configOptions, path, dbOptions, cfDescs);
     } else if (apiType == TestAPI.LOAD_OPTIONS_FROM_FILE) {
       path = dbPath + "/" + OptionsUtil.getLatestOptionsFileName(dbPath, Env.getDefault());
-      OptionsUtil.loadOptionsFromFile(path, Env.getDefault(), dbOptions, cfDescs, false);
+      OptionsUtil.loadOptionsFromFile(configOptions, path, dbOptions, cfDescs);
     }
 
     assertThat(dbOptions.createIfMissing()).isEqualTo(options.createIfMissing());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4095,7 +4095,11 @@ class Benchmark {
     DBOptions db_opts;
     std::vector<ColumnFamilyDescriptor> cf_descs;
     if (FLAGS_options_file != "") {
-      auto s = LoadOptionsFromFile(FLAGS_options_file, FLAGS_env, &db_opts,
+      ConfigOptions config_opts;
+      config_opts.ignore_unknown_options = false;
+      config_opts.input_strings_escaped = true;
+      config_opts.env = FLAGS_env;
+      auto s = LoadOptionsFromFile(config_opts, FLAGS_options_file, &db_opts,
                                    &cf_descs);
       db_opts.env = FLAGS_env;
       if (s.ok()) {

--- a/tools/db_bench_tool_test.cc
+++ b/tools/db_bench_tool_test.cc
@@ -87,9 +87,13 @@ class DBBenchTest : public testing::Test {
 
   void VerifyOptions(const Options& opt) {
     DBOptions loaded_db_opts;
+    ConfigOptions config_opts;
+    config_opts.ignore_unknown_options = false;
+    config_opts.input_strings_escaped = true;
+    config_opts.env = Env::Default();
     std::vector<ColumnFamilyDescriptor> cf_descs;
-    ASSERT_OK(LoadLatestOptions(db_path_, Env::Default(), &loaded_db_opts,
-                                &cf_descs));
+    ASSERT_OK(
+        LoadLatestOptions(config_opts, db_path_, &loaded_db_opts, &cf_descs));
 
     ConfigOptions exact;
     exact.input_strings_escaped = false;
@@ -302,9 +306,13 @@ TEST_F(DBBenchTest, OptionsFileFromFile) {
   ASSERT_OK(writable->Close());
 
   DBOptions db_opt;
+  ConfigOptions config_opt;
+  config_opt.ignore_unknown_options = false;
+  config_opt.input_strings_escaped = true;
+  config_opt.env = Env::Default();
   std::vector<ColumnFamilyDescriptor> cf_descs;
-  ASSERT_OK(LoadOptionsFromFile(kOptionsFileName, Env::Default(), &db_opt,
-                                &cf_descs));
+  ASSERT_OK(
+      LoadOptionsFromFile(config_opt, kOptionsFileName, &db_opt, &cf_descs));
   Options opt(db_opt, cf_descs[0].options);
   opt.create_if_missing = true;
 

--- a/utilities/options/options_util.cc
+++ b/utilities/options/options_util.cc
@@ -14,20 +14,6 @@
 #include "table/block_based/block_based_table_factory.h"
 
 namespace ROCKSDB_NAMESPACE {
-Status LoadOptionsFromFile(const std::string& file_name, Env* env,
-                           DBOptions* db_options,
-                           std::vector<ColumnFamilyDescriptor>* cf_descs,
-                           bool ignore_unknown_options,
-                           std::shared_ptr<Cache>* cache) {
-  ConfigOptions config_options;
-  config_options.ignore_unknown_options = ignore_unknown_options;
-  config_options.input_strings_escaped = true;
-  config_options.env = env;
-
-  return LoadOptionsFromFile(config_options, file_name, db_options, cf_descs,
-                             cache);
-}
-
 Status LoadOptionsFromFile(const ConfigOptions& config_options,
                            const std::string& file_name, DBOptions* db_options,
                            std::vector<ColumnFamilyDescriptor>* cf_descs,
@@ -90,19 +76,6 @@ Status GetLatestOptionsFileName(const std::string& dbpath, Env* env,
   return Status::OK();
 }
 
-Status LoadLatestOptions(const std::string& dbpath, Env* env,
-                         DBOptions* db_options,
-                         std::vector<ColumnFamilyDescriptor>* cf_descs,
-                         bool ignore_unknown_options,
-                         std::shared_ptr<Cache>* cache) {
-  ConfigOptions config_options;
-  config_options.ignore_unknown_options = ignore_unknown_options;
-  config_options.input_strings_escaped = true;
-  config_options.env = env;
-
-  return LoadLatestOptions(config_options, dbpath, db_options, cf_descs, cache);
-}
-
 Status LoadLatestOptions(const ConfigOptions& config_options,
                          const std::string& dbpath, DBOptions* db_options,
                          std::vector<ColumnFamilyDescriptor>* cf_descs,
@@ -115,19 +88,6 @@ Status LoadLatestOptions(const ConfigOptions& config_options,
   }
   return LoadOptionsFromFile(config_options, dbpath + "/" + options_file_name,
                              db_options, cf_descs, cache);
-}
-
-Status CheckOptionsCompatibility(
-    const std::string& dbpath, Env* env, const DBOptions& db_options,
-    const std::vector<ColumnFamilyDescriptor>& cf_descs,
-    bool ignore_unknown_options) {
-  ConfigOptions config_options(db_options);
-  config_options.sanity_level = ConfigOptions::kSanityLevelLooselyCompatible;
-  config_options.ignore_unknown_options = ignore_unknown_options;
-  config_options.input_strings_escaped = true;
-  config_options.env = env;
-  return CheckOptionsCompatibility(config_options, dbpath, db_options,
-                                   cf_descs);
 }
 
 Status CheckOptionsCompatibility(

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -377,10 +377,6 @@ TEST_F(OptionsUtilTest, LatestOptionsNotFound) {
   ASSERT_TRUE(s.IsNotFound());
   ASSERT_TRUE(s.IsPathNotFound());
 
-  //  s = LoadLatestOptions(dbname_, options.env, &options, &cf_descs);
-  //  ASSERT_TRUE(s.IsNotFound());
-  //  ASSERT_TRUE(s.IsPathNotFound());
-
   s = LoadLatestOptions(config_opts, dbname_, &options, &cf_descs);
   ASSERT_TRUE(s.IsNotFound());
   ASSERT_TRUE(s.IsPathNotFound());

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -63,7 +63,11 @@ TEST_F(OptionsUtilTest, SaveAndLoad) {
 
   DBOptions loaded_db_opt;
   std::vector<ColumnFamilyDescriptor> loaded_cf_descs;
-  ASSERT_OK(LoadOptionsFromFile(kFileName, env_.get(), &loaded_db_opt,
+  ConfigOptions config_options;
+  config_options.ignore_unknown_options = false;
+  config_options.input_strings_escaped = true;
+  config_options.env = env_.get();
+  ASSERT_OK(LoadOptionsFromFile(config_options, kFileName, &loaded_db_opt,
                                 &loaded_cf_descs));
   ConfigOptions exact;
   exact.sanity_level = ConfigOptions::kSanityLevelExactMatch;
@@ -133,19 +137,6 @@ TEST_F(OptionsUtilTest, SaveAndLoadWithCacheCheck) {
   config_options.env = env_.get();
   ASSERT_OK(LoadOptionsFromFile(config_options, kFileName, &loaded_db_opt,
                                 &loaded_cf_descs, &cache));
-  for (size_t i = 0; i < loaded_cf_descs.size(); i++) {
-    auto* loaded_bbt_opt =
-        loaded_cf_descs[i]
-            .options.table_factory->GetOptions<BlockBasedTableOptions>();
-    // Expect the same cache will be loaded
-    if (loaded_bbt_opt != nullptr) {
-      ASSERT_EQ(loaded_bbt_opt->block_cache.get(), cache.get());
-    }
-  }
-
-  // Test the old interface
-  ASSERT_OK(LoadOptionsFromFile(kFileName, env_.get(), &loaded_db_opt,
-                                &loaded_cf_descs, false, &cache));
   for (size_t i = 0; i < loaded_cf_descs.size(); i++) {
     auto* loaded_bbt_opt =
         loaded_cf_descs[i]
@@ -386,11 +377,12 @@ TEST_F(OptionsUtilTest, LatestOptionsNotFound) {
   ASSERT_TRUE(s.IsNotFound());
   ASSERT_TRUE(s.IsPathNotFound());
 
-  s = LoadLatestOptions(dbname_, options.env, &options, &cf_descs);
-  ASSERT_TRUE(s.IsNotFound());
-  ASSERT_TRUE(s.IsPathNotFound());
+  //  s = LoadLatestOptions(dbname_, options.env, &options, &cf_descs);
+  //  ASSERT_TRUE(s.IsNotFound());
+  //  ASSERT_TRUE(s.IsPathNotFound());
 
   s = LoadLatestOptions(config_opts, dbname_, &options, &cf_descs);
+  ASSERT_TRUE(s.IsNotFound());
   ASSERT_TRUE(s.IsPathNotFound());
 
   s = GetLatestOptionsFileName(dbname_, options.env, &options_file_name);
@@ -404,7 +396,7 @@ TEST_F(OptionsUtilTest, LatestOptionsNotFound) {
   ASSERT_TRUE(s.IsNotFound());
   ASSERT_TRUE(s.IsPathNotFound());
 
-  s = LoadLatestOptions(dbname_, options.env, &options, &cf_descs);
+  s = LoadLatestOptions(config_opts, dbname_, &options, &cf_descs);
   ASSERT_TRUE(s.IsNotFound());
   ASSERT_TRUE(s.IsPathNotFound());
 
@@ -641,6 +633,9 @@ TEST_F(OptionsUtilTest, RenameDatabaseDirectory) {
   DBOptions db_opts;
   std::vector<ColumnFamilyDescriptor> cf_descs;
   std::vector<ColumnFamilyHandle*> handles;
+  ConfigOptions ignore_opts;
+  ignore_opts.ignore_unknown_options = false;
+  ignore_opts.env = options.env;
 
   options.create_if_missing = true;
 
@@ -651,7 +646,7 @@ TEST_F(OptionsUtilTest, RenameDatabaseDirectory) {
   auto new_dbname = dbname_ + "_2";
 
   ASSERT_OK(options.env->RenameFile(dbname_, new_dbname));
-  ASSERT_OK(LoadLatestOptions(new_dbname, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, new_dbname, &db_opts, &cf_descs));
   ASSERT_EQ(cf_descs.size(), 1U);
 
   db_opts.create_if_missing = false;
@@ -675,20 +670,23 @@ TEST_F(OptionsUtilTest, WalDirSettings) {
   DBOptions db_opts;
   std::vector<ColumnFamilyDescriptor> cf_descs;
   std::vector<ColumnFamilyHandle*> handles;
+  ConfigOptions ignore_opts;
+  ignore_opts.ignore_unknown_options = false;
+  ignore_opts.env = options.env;
 
   options.create_if_missing = true;
 
   // Open a DB with no wal dir set.  The wal_dir should stay empty
   ASSERT_OK(DB::Open(options, dbname_, &db));
   delete db;
-  ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, dbname_, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, "");
 
   // Open a DB with wal_dir == dbname.  The wal_dir should be set to empty
   options.wal_dir = dbname_;
   ASSERT_OK(DB::Open(options, dbname_, &db));
   delete db;
-  ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, dbname_, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, "");
 
   // Open a DB with no wal_dir but a db_path==dbname_.  The wal_dir should be
@@ -697,7 +695,7 @@ TEST_F(OptionsUtilTest, WalDirSettings) {
   options.db_paths.emplace_back(dbname_, std::numeric_limits<uint64_t>::max());
   ASSERT_OK(DB::Open(options, dbname_, &db));
   delete db;
-  ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, dbname_, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, "");
 
   // Open a DB with no wal_dir==dbname_ and db_path==dbname_.  The wal_dir
@@ -706,7 +704,7 @@ TEST_F(OptionsUtilTest, WalDirSettings) {
   options.db_paths.emplace_back(dbname_, std::numeric_limits<uint64_t>::max());
   ASSERT_OK(DB::Open(options, dbname_, &db));
   delete db;
-  ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, dbname_, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, "");
   ASSERT_OK(DestroyDB(dbname_, options));
 
@@ -717,7 +715,7 @@ TEST_F(OptionsUtilTest, WalDirSettings) {
                                 std::numeric_limits<uint64_t>::max());
   ASSERT_OK(DB::Open(options, dbname_, &db));
   delete db;
-  ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, dbname_, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, dbname_);
   ASSERT_OK(DestroyDB(dbname_, options));
 
@@ -726,7 +724,7 @@ TEST_F(OptionsUtilTest, WalDirSettings) {
   options.db_paths.clear();
   ASSERT_OK(DB::Open(options, dbname_, &db));
   delete db;
-  ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, dbname_, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, dbname_ + "/wal");
   ASSERT_OK(DestroyDB(dbname_, options));
 }
@@ -737,6 +735,9 @@ TEST_F(OptionsUtilTest, WalDirInOptins) {
   DBOptions db_opts;
   std::vector<ColumnFamilyDescriptor> cf_descs;
   std::vector<ColumnFamilyHandle*> handles;
+  ConfigOptions ignore_opts;
+  ignore_opts.ignore_unknown_options = false;
+  ignore_opts.env = options.env;
 
   // Store an options file with wal_dir=dbname_ and make sure it still loads
   // when the input wal_dir is empty
@@ -750,12 +751,12 @@ TEST_F(OptionsUtilTest, WalDirInOptins) {
   ASSERT_OK(PersistRocksDBOptions(options, {"default"}, {options},
                                   dbname_ + "/" + options_file,
                                   options.env->GetFileSystem().get()));
-  ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, dbname_, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, dbname_);
   options.wal_dir = "";
   ASSERT_OK(DB::Open(options, dbname_, &db));
   delete db;
-  ASSERT_OK(LoadLatestOptions(dbname_, options.env, &db_opts, &cf_descs));
+  ASSERT_OK(LoadLatestOptions(ignore_opts, dbname_, &db_opts, &cf_descs));
   ASSERT_EQ(db_opts.wal_dir, "");
 }
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Remove the util functions in options_util.h that have previously been marked deprecated.

Test Plan:
`make check`