### PR TITLE
Support PutEntity in trace analyzer

### DIFF
--- a/tools/trace_analyzer_test.cc
+++ b/tools/trace_analyzer_test.cc
@@ -336,7 +336,7 @@ TEST_F(TraceAnalyzerTest, Put) {
   CheckFileContent(k_whole_prefix, file_path, true);
 
   // Check the overall qps
-  std::vector<std::string> all_qps = {"0 1 0 0 0 0 0 0 0 1"};
+  std::vector<std::string> all_qps = {"0 1 0 0 0 0 0 0 0 0 1"};
   file_path = output_path + "/test-qps_stats.txt";
   CheckFileContent(all_qps, file_path, true);
 

--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -1582,6 +1582,12 @@ Status TraceAnalyzer::PutCF(uint32_t column_family_id, const Slice& key,
                               column_family_id, key, value.size());
 }
 
+Status TraceAnalyzer::PutEntityCF(uint32_t column_family_id, const Slice& key,
+                                  const Slice& value) {
+  return OutputAnalysisResult(TraceOperationType::kPutEntity, write_batch_ts_,
+                              column_family_id, key, value.size());
+}
+
 // Handle the Delete request in the write batch of the trace
 Status TraceAnalyzer::DeleteCF(uint32_t column_family_id, const Slice& key) {
   return OutputAnalysisResult(TraceOperationType::kDelete, write_batch_ts_,

--- a/tools/trace_analyzer_tool.h
+++ b/tools/trace_analyzer_tool.h
@@ -35,7 +35,8 @@ enum TraceOperationType : int {
   kIteratorSeek = 6,
   kIteratorSeekForPrev = 7,
   kMultiGet = 8,
-  kTaTypeNum = 9
+  kPutEntity = 9,
+  kTaTypeNum = 10
 };
 
 struct TraceUnit {
@@ -200,6 +201,10 @@ class TraceAnalyzer : private TraceRecord::Handler,
   using WriteBatch::Handler::PutCF;
   Status PutCF(uint32_t column_family_id, const Slice& key,
                const Slice& value) override;
+
+  using WriteBatch::Handler::PutEntityCF;
+  Status PutEntityCF(uint32_t column_family_id, const Slice& key,
+                     const Slice& value) override;
 
   using WriteBatch::Handler::DeleteCF;
   Status DeleteCF(uint32_t column_family_id, const Slice& key) override;


### PR DESCRIPTION
Add the most basic support such that trace_analyzer commands no longer fail with
```
Cannot process the write batch in the trace
Cannot process the TraceRecord
PutEntityCF not implemented
Cannot process the trace
```