### PR TITLE
checkpoint.h: Add missing includes <cstdint>

### DIFF
--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -8,6 +8,7 @@
 #pragma once
 #ifndef ROCKSDB_LITE
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
It uses uint64_t and it comes from <cstdint>
This is needed with GCC 13 and newer [1]

[1] https://www.gnu.org/software/gcc/gcc-13/porting_to.html

Signed-off-by: Khem Raj <raj.khem@gmail.com>