### PR TITLE
issue #11093: Should return Status::NotFound() when fullHistoryTsLow is empty

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1671,6 +1671,10 @@ Status DBImpl::GetFullHistoryTsLow(ColumnFamilyHandle* column_family,
   }
   InstrumentedMutexLock l(&mutex_);
   *ts_low = cfd->GetFullHistoryTsLow();
+  
+  if (ts_low->size() ==0)
+	  return Status::NotFound();
+
   assert(cfd->user_comparator()->timestamp_size() == ts_low->size());
   return Status::OK();
 }


### PR DESCRIPTION
Added a test to see if the fullHistoryTsLow is empty as in ts_los->size() == 0 and returned Status::NotFound()