### PR TITLE
Create separate interfaces to data and metadata functions of DB

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3743,6 +3743,18 @@ SystemClock* DBImpl::GetSystemClock() const {
   return immutable_db_options_.clock;
 }
 
+Status DB::GetApproximateSizes(ColumnFamilyHandle* column_family,
+                               const Range* ranges, int n, uint64_t* sizes,
+                               SizeApproximationFlags include_flags) {
+  SizeApproximationOptions options;
+  options.include_memtables =
+      ((include_flags & SizeApproximationFlags::INCLUDE_MEMTABLES) !=
+       SizeApproximationFlags::NONE);
+  options.include_files =
+      ((include_flags & SizeApproximationFlags::INCLUDE_FILES) !=
+       SizeApproximationFlags::NONE);
+  return GetApproximateSizes(options, column_family, ranges, n, sizes);
+}
 
 Status DBImpl::StartIOTrace(const TraceOptions& trace_options,
                             std::unique_ptr<TraceWriter>&& trace_writer) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -496,6 +496,7 @@ class DBImpl : public DB {
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) override;
 
+  using DBMetadataInterface::GetColumnFamilyMetaData;
   // Obtains the meta data of the specified column family of the DB.
   // TODO(yhchiang): output parameter is placed in the end in this codebase.
   virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3340,6 +3340,7 @@ class ModelDB : public DB {
     return Status::NotSupported("Not supported in Model DB");
   }
 
+  using DB::GetColumnFamilyMetaData;
   void GetColumnFamilyMetaData(ColumnFamilyHandle* /*column_family*/,
                                ColumnFamilyMetaData* /*metadata*/) override {}
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1733,6 +1733,7 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   virtual DB* GetRootDB() { return this; }
 
   using DBDataInterface::CreateColumnFamily;
+  using DBDataInterface::CreateColumnFamilyWithImport;
   using DBDataInterface::Delete;
   using DBDataInterface::DeleteRange;
   using DBDataInterface::DestroyColumnFamilyHandle;
@@ -1742,6 +1743,8 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   using DBDataInterface::GetApproximateSizes;
   using DBDataInterface::GetMergeOperands;
   using DBDataInterface::GetSnapshot;
+  using DBDataInterface::IngestExternalFile;
+  using DBDataInterface::IngestExternalFiles;
   using DBDataInterface::KeyMayExist;
   using DBDataInterface::Merge;
   using DBDataInterface::MultiGet;
@@ -1754,45 +1757,22 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   using DBMetadataInterface::CompactFiles;
   using DBMetadataInterface::CompactRange;
   using DBMetadataInterface::ContinueBackgroundWork;
+  using DBMetadataInterface::DeleteFile;
   using DBMetadataInterface::DisableFileDeletions;
   using DBMetadataInterface::DisableManualCompaction;
   using DBMetadataInterface::EnableAutoCompaction;
   using DBMetadataInterface::EnableFileDeletions;
   using DBMetadataInterface::EnableManualCompaction;
-  using DBMetadataInterface::Flush;
-  using DBMetadataInterface::FlushWAL;
-  using DBMetadataInterface::GetAggregatedIntProperty;
-#ifndef ROCKSDB_LITE
-  using DBDataInterface::CreateColumnFamilyWithImport;
-  using DBDataInterface::IngestExternalFile;
-  using DBDataInterface::IngestExternalFiles;
-  using DBMetadataInterface::DeleteFile;
   using DBMetadataInterface::EndBlockCacheTrace;
   using DBMetadataInterface::EndIOTrace;
   using DBMetadataInterface::EndTrace;
+  using DBMetadataInterface::Flush;
+  using DBMetadataInterface::FlushWAL;
+  using DBMetadataInterface::GetAggregatedIntProperty;
   using DBMetadataInterface::GetAllColumnFamilyMetaData;
   using DBMetadataInterface::GetColumnFamilyMetaData;
   using DBMetadataInterface::GetCreationTimeOfOldestFile;
   using DBMetadataInterface::GetCurrentWalFile;
-  using DBMetadataInterface::GetLiveFiles;
-  using DBMetadataInterface::GetLiveFilesChecksumInfo;
-  using DBMetadataInterface::GetLiveFilesMetaData;
-  using DBMetadataInterface::GetLiveFilesStorageInfo;
-  using DBMetadataInterface::GetPropertiesOfAllTables;
-  using DBMetadataInterface::GetPropertiesOfTablesInRange;
-  using DBMetadataInterface::GetSortedWalFiles;
-  using DBMetadataInterface::GetUpdatesSince;
-  using DBMetadataInterface::NewDefaultReplayer;
-  using DBMetadataInterface::PromoteL0;
-  using DBMetadataInterface::StartBlockCacheTrace;
-  using DBMetadataInterface::StartIOTrace;
-  using DBMetadataInterface::StartTrace;
-  using DBMetadataInterface::SuggestCompactRange;
-  using DBMetadataInterface::TryCatchUpWithPrimary;
-  using DBMetadataInterface::VerifyChecksum;
-  using DBMetadataInterface::VerifyFileChecksums;
-#endif  // !ROCKSDB_LITE
-
   using DBMetadataInterface::GetDbIdentity;
   using DBMetadataInterface::GetDBOptions;
   using DBMetadataInterface::GetDbSessionId;
@@ -1801,22 +1781,39 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   using DBMetadataInterface::GetFullHistoryTsLow;
   using DBMetadataInterface::GetIntProperty;
   using DBMetadataInterface::GetLatestSequenceNumber;
+  using DBMetadataInterface::GetLiveFiles;
+  using DBMetadataInterface::GetLiveFilesChecksumInfo;
+  using DBMetadataInterface::GetLiveFilesMetaData;
+  using DBMetadataInterface::GetLiveFilesStorageInfo;
   using DBMetadataInterface::GetMapProperty;
   using DBMetadataInterface::GetOptions;
+  using DBMetadataInterface::GetPropertiesOfAllTables;
+  using DBMetadataInterface::GetPropertiesOfTablesInRange;
   using DBMetadataInterface::GetProperty;
+  using DBMetadataInterface::GetSortedWalFiles;
   using DBMetadataInterface::GetStatsHistory;
+  using DBMetadataInterface::GetUpdatesSince;
   using DBMetadataInterface::IncreaseFullHistoryTsLow;
   using DBMetadataInterface::Level0StopWriteTrigger;
   using DBMetadataInterface::LockWAL;
   using DBMetadataInterface::MaxMemCompactionLevel;
+  using DBMetadataInterface::NewDefaultReplayer;
   using DBMetadataInterface::NumberLevels;
   using DBMetadataInterface::PauseBackgroundWork;
+  using DBMetadataInterface::PromoteL0;
   using DBMetadataInterface::ResetStats;
   using DBMetadataInterface::Resume;
   using DBMetadataInterface::SetDBOptions;
   using DBMetadataInterface::SetOptions;
+  using DBMetadataInterface::StartBlockCacheTrace;
+  using DBMetadataInterface::StartIOTrace;
+  using DBMetadataInterface::StartTrace;
+  using DBMetadataInterface::SuggestCompactRange;
   using DBMetadataInterface::SyncWAL;
+  using DBMetadataInterface::TryCatchUpWithPrimary;
   using DBMetadataInterface::UnlockWAL;
+  using DBMetadataInterface::VerifyChecksum;
+  using DBMetadataInterface::VerifyFileChecksums;
 
   Status Put(const WriteOptions& opt, ColumnFamilyHandle* column_family,
              const Slice& key, const Slice& value) override;
@@ -1931,12 +1928,10 @@ class DB : public DBDataInterface, public DBMetadataInterface {
     GetApproximateMemTableStats(DefaultColumnFamily(), range, count, size);
   }
 
-#ifndef ROCKSDB_LITE
   Status IngestExternalFile(const std::vector<std::string>& external_files,
                             const IngestExternalFileOptions& options) override {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
-#endif  // !ROCKSDB_LITE
 
   // Create a column_family and return the handle of column family
   // through the argument handle.
@@ -2027,14 +2022,12 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   Status Flush(const FlushOptions& options) override {
     return Flush(options, DefaultColumnFamily());
   }
-#ifndef ROCKSDB_LITE
   void GetColumnFamilyMetaData(ColumnFamilyMetaData* metadata) override {
     GetColumnFamilyMetaData(DefaultColumnFamily(), metadata);
   }
   Status GetPropertiesOfAllTables(TablePropertiesCollection* props) override {
     return GetPropertiesOfAllTables(DefaultColumnFamily(), props);
   }
-#endif  // !ROCKSDB_LITE
   FileSystem* GetFileSystem() const override;
 };
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1733,7 +1733,6 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   virtual DB* GetRootDB() { return this; }
 
   using DBDataInterface::CreateColumnFamily;
-  using DBDataInterface::CreateColumnFamilyWithImport;
   using DBDataInterface::Delete;
   using DBDataInterface::DeleteRange;
   using DBDataInterface::DestroyColumnFamilyHandle;
@@ -1743,8 +1742,6 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   using DBDataInterface::GetApproximateSizes;
   using DBDataInterface::GetMergeOperands;
   using DBDataInterface::GetSnapshot;
-  using DBDataInterface::IngestExternalFile;
-  using DBDataInterface::IngestExternalFiles;
   using DBDataInterface::KeyMayExist;
   using DBDataInterface::Merge;
   using DBDataInterface::MultiGet;
@@ -1757,22 +1754,45 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   using DBMetadataInterface::CompactFiles;
   using DBMetadataInterface::CompactRange;
   using DBMetadataInterface::ContinueBackgroundWork;
-  using DBMetadataInterface::DeleteFile;
   using DBMetadataInterface::DisableFileDeletions;
   using DBMetadataInterface::DisableManualCompaction;
   using DBMetadataInterface::EnableAutoCompaction;
   using DBMetadataInterface::EnableFileDeletions;
   using DBMetadataInterface::EnableManualCompaction;
-  using DBMetadataInterface::EndBlockCacheTrace;
-  using DBMetadataInterface::EndIOTrace;
-  using DBMetadataInterface::EndTrace;
   using DBMetadataInterface::Flush;
   using DBMetadataInterface::FlushWAL;
   using DBMetadataInterface::GetAggregatedIntProperty;
+#ifndef ROCKSDB_LITE
+  using DBDataInterface::CreateColumnFamilyWithImport;
+  using DBDataInterface::IngestExternalFile;
+  using DBDataInterface::IngestExternalFiles;
+  using DBMetadataInterface::DeleteFile;
+  using DBMetadataInterface::EndBlockCacheTrace;
+  using DBMetadataInterface::EndIOTrace;
+  using DBMetadataInterface::EndTrace;
   using DBMetadataInterface::GetAllColumnFamilyMetaData;
   using DBMetadataInterface::GetColumnFamilyMetaData;
   using DBMetadataInterface::GetCreationTimeOfOldestFile;
   using DBMetadataInterface::GetCurrentWalFile;
+  using DBMetadataInterface::GetLiveFiles;
+  using DBMetadataInterface::GetLiveFilesChecksumInfo;
+  using DBMetadataInterface::GetLiveFilesMetaData;
+  using DBMetadataInterface::GetLiveFilesStorageInfo;
+  using DBMetadataInterface::GetPropertiesOfAllTables;
+  using DBMetadataInterface::GetPropertiesOfTablesInRange;
+  using DBMetadataInterface::GetSortedWalFiles;
+  using DBMetadataInterface::GetUpdatesSince;
+  using DBMetadataInterface::NewDefaultReplayer;
+  using DBMetadataInterface::PromoteL0;
+  using DBMetadataInterface::StartBlockCacheTrace;
+  using DBMetadataInterface::StartIOTrace;
+  using DBMetadataInterface::StartTrace;
+  using DBMetadataInterface::SuggestCompactRange;
+  using DBMetadataInterface::TryCatchUpWithPrimary;
+  using DBMetadataInterface::VerifyChecksum;
+  using DBMetadataInterface::VerifyFileChecksums;
+#endif  // !ROCKSDB_LITE
+
   using DBMetadataInterface::GetDbIdentity;
   using DBMetadataInterface::GetDBOptions;
   using DBMetadataInterface::GetDbSessionId;
@@ -1781,39 +1801,22 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   using DBMetadataInterface::GetFullHistoryTsLow;
   using DBMetadataInterface::GetIntProperty;
   using DBMetadataInterface::GetLatestSequenceNumber;
-  using DBMetadataInterface::GetLiveFiles;
-  using DBMetadataInterface::GetLiveFilesChecksumInfo;
-  using DBMetadataInterface::GetLiveFilesMetaData;
-  using DBMetadataInterface::GetLiveFilesStorageInfo;
   using DBMetadataInterface::GetMapProperty;
   using DBMetadataInterface::GetOptions;
-  using DBMetadataInterface::GetPropertiesOfAllTables;
-  using DBMetadataInterface::GetPropertiesOfTablesInRange;
   using DBMetadataInterface::GetProperty;
-  using DBMetadataInterface::GetSortedWalFiles;
   using DBMetadataInterface::GetStatsHistory;
-  using DBMetadataInterface::GetUpdatesSince;
   using DBMetadataInterface::IncreaseFullHistoryTsLow;
   using DBMetadataInterface::Level0StopWriteTrigger;
   using DBMetadataInterface::LockWAL;
   using DBMetadataInterface::MaxMemCompactionLevel;
-  using DBMetadataInterface::NewDefaultReplayer;
   using DBMetadataInterface::NumberLevels;
   using DBMetadataInterface::PauseBackgroundWork;
-  using DBMetadataInterface::PromoteL0;
   using DBMetadataInterface::ResetStats;
   using DBMetadataInterface::Resume;
   using DBMetadataInterface::SetDBOptions;
   using DBMetadataInterface::SetOptions;
-  using DBMetadataInterface::StartBlockCacheTrace;
-  using DBMetadataInterface::StartIOTrace;
-  using DBMetadataInterface::StartTrace;
-  using DBMetadataInterface::SuggestCompactRange;
   using DBMetadataInterface::SyncWAL;
-  using DBMetadataInterface::TryCatchUpWithPrimary;
   using DBMetadataInterface::UnlockWAL;
-  using DBMetadataInterface::VerifyChecksum;
-  using DBMetadataInterface::VerifyFileChecksums;
 
   Status Put(const WriteOptions& opt, ColumnFamilyHandle* column_family,
              const Slice& key, const Slice& value) override;
@@ -1928,10 +1931,12 @@ class DB : public DBDataInterface, public DBMetadataInterface {
     GetApproximateMemTableStats(DefaultColumnFamily(), range, count, size);
   }
 
+#ifndef ROCKSDB_LITE
   Status IngestExternalFile(const std::vector<std::string>& external_files,
                             const IngestExternalFileOptions& options) override {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
+#endif  // !ROCKSDB_LITE
 
   // Create a column_family and return the handle of column family
   // through the argument handle.
@@ -2022,12 +2027,14 @@ class DB : public DBDataInterface, public DBMetadataInterface {
   Status Flush(const FlushOptions& options) override {
     return Flush(options, DefaultColumnFamily());
   }
+#ifndef ROCKSDB_LITE
   void GetColumnFamilyMetaData(ColumnFamilyMetaData* metadata) override {
     GetColumnFamilyMetaData(DefaultColumnFamily(), metadata);
   }
   Status GetPropertiesOfAllTables(TablePropertiesCollection* props) override {
     return GetPropertiesOfAllTables(DefaultColumnFamily(), props);
   }
+#endif  // !ROCKSDB_LITE
   FileSystem* GetFileSystem() const override;
 };
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -243,31 +243,30 @@ class StackableDB : public DB {
     return db_->ReleaseSnapshot(snapshot);
   }
 
-  using DB::GetMapProperty;
-  using DB::GetProperty;
+  using DBMetadataInterface::GetProperty;
   virtual bool GetProperty(ColumnFamilyHandle* column_family,
                            const Slice& property, std::string* value) override {
     return db_->GetProperty(column_family, property, value);
   }
+  using DBMetadataInterface::GetMapProperty;
   virtual bool GetMapProperty(
       ColumnFamilyHandle* column_family, const Slice& property,
       std::map<std::string, std::string>* value) override {
     return db_->GetMapProperty(column_family, property, value);
   }
 
-  using DB::GetIntProperty;
+  using DBMetadataInterface::GetIntProperty;
   virtual bool GetIntProperty(ColumnFamilyHandle* column_family,
                               const Slice& property, uint64_t* value) override {
     return db_->GetIntProperty(column_family, property, value);
   }
 
-  using DB::GetAggregatedIntProperty;
   virtual bool GetAggregatedIntProperty(const Slice& property,
                                         uint64_t* value) override {
     return db_->GetAggregatedIntProperty(property, value);
   }
 
-  using DB::GetApproximateSizes;
+  using DBDataInterface::GetApproximateSizes;
   virtual Status GetApproximateSizes(const SizeApproximationOptions& options,
                                      ColumnFamilyHandle* column_family,
                                      const Range* r, int n,
@@ -401,6 +400,7 @@ class StackableDB : public DB {
     return db_->GetLiveFilesStorageInfo(opts, files);
   }
 
+  using DBMetadataInterface::GetColumnFamilyMetaData;
   virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
                                        ColumnFamilyMetaData* cf_meta) override {
     db_->GetColumnFamilyMetaData(column_family, cf_meta);


### PR DESCRIPTION
Summary:
The interface DB now contains too many functions, and many of them are for metadata or administrative operations. Separating the functions have some benefits, including and not limited to: (1) having an alternative implemention, either for testing, benchmarking or production use, they only need to implement the data API. (2) it helps cateogorize functions and makes it easier for users to read the header file. This PR is a relatively small steps. It creates two classes and class DB inherites from them. One awkward part for this implementation is DefaultColumnFamily() which would be used for both. As a result, class DB needs to redeclare a large chunk of functions for default implementation. We leave it to future improvements.

Slight change to remove default value for some parameters, which would be confusing when functions are inherated.

Test Plan: CI passes.