### PR TITLE
Optimize IterKey

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -432,8 +432,7 @@ inline uint64_t GetInternalKeySeqno(const Slice& internal_key) {
 class IterKey {
  public:
   IterKey()
-      : buf_(space_),
-        key_(buf_),
+      : key_(space_),
         key_size_(0),
         buf_size_(sizeof(space_)),
         is_user_key_(true) {}
@@ -614,13 +613,14 @@ class IterKey {
   bool IsUserKey() const { return is_user_key_; }
 
  private:
-  char* buf_;
   const char* key_;
-  size_t key_size_;
-  size_t buf_size_;
-  char space_[32];  // Avoid allocation for short keys
-  bool is_user_key_;
-
+  uint32_t key_size_;
+  uint32_t buf_size_ : 31;
+  uint32_t is_user_key_ : 1;
+  union {
+    char* buf_;
+    char space_[48];  // Avoid allocation for short keys
+  };
 
   char* buf() { return buf_size_ <= sizeof(space_) ? space_ : buf_ ; }
   const char* buf() const { return buf_size_ <= sizeof(space_) ? space_ : buf_ ; }
@@ -641,9 +641,8 @@ class IterKey {
   }
 
   void ResetBuffer() {
-    if (buf_ != space_) {
+    if (sizeof(space_) != buf_size_) {
       delete[] buf_;
-      buf_ = space_;
     }
     buf_size_ = sizeof(space_);
     key_size_ = 0;


### PR DESCRIPTION
`IterKey` is essentially an SSO(short string optimization), it can be optimized more, in this PR:
1. `sizeof(IterKey)` is reduce from `72` to `64` and inline buffer size is increased from `32` to `48`
1. `key_size_` and `buf_size_` changed to uin32 because it is expected never larger than 2G
1. `buf_size_` is used as a flag to identify inline buffer or outline buffer
1. `buf_` ptr is folded to be shared with `space_` by using `union`
   * getter func `buf()` makes the intention clear
1. `is_user_key_` is changed to a bitfield which packed with `buf_size_`
   * `buf_size_` is accessed less frequent than `key_size_`, use bit field will not harm performance