### PR TITLE
Fix typo in comments

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1942,7 +1942,7 @@ void Version::AddIteratorsForLevel(const ReadOptions& read_options,
     }
     if (should_sample) {
       // Count ones for every L0 files. This is done per iterator creation
-      // rather than Seek(), while files in other levels are recored per seek.
+      // rather than Seek(), while files in other levels are recorded per seek.
       // If users execute one range query per iterator, there may be some
       // discrepancy here.
       for (FileMetaData* meta : storage_info_.LevelFiles(0)) {


### PR DESCRIPTION
Replace `recored` with `recorded`.