### PR TITLE
Improve documentation for MergingIterator

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -30,7 +30,7 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
       icmp_(icmp),
       smallest_ikey_(smallest),
       largest_ikey_(largest) {
-  // Set up bounds such that this range tombstones from this iterator is
+  // Set up bounds such that range tombstones from this iterator are
   // truncated to range [smallest, largest).
   if (smallest != nullptr) {
     pinned_bounds_.emplace_back();

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -30,6 +30,8 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
       icmp_(icmp),
       smallest_ikey_(smallest),
       largest_ikey_(largest) {
+  // Set up bounds such that this range tombstones from this iterator is
+  // truncated to range [smallest, largest).
   if (smallest != nullptr) {
     pinned_bounds_.emplace_back();
     auto& parsed_smallest = pinned_bounds_.back();
@@ -64,6 +66,8 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
       //
       // Therefore, we will never truncate a range tombstone at largest, so we
       // can leave it unchanged.
+      // TODO: maybe use kMaxValid here to ensure range tombstone having
+      //  distinct key from point keys.
     } else {
       // The same user key may straddle two sstable boundaries. To ensure that
       // the truncated end key can cover the largest key in this sstable, reduce
@@ -100,6 +104,24 @@ void TruncatedRangeDelIterator::Seek(const Slice& target) {
     return;
   }
   iter_->Seek(target);
+}
+
+void TruncatedRangeDelIterator::SeekInternalKey(const Slice& target) {
+  if (largest_ && icmp_->Compare(*largest_, target) <= 0) {
+    iter_->Invalidate();
+    return;
+  }
+  if (smallest_ && icmp_->Compare(target, *smallest_) < 0) {
+    // Since target < smallest, target < largest_.
+    // This seek must land on a range tombstone where end_key() > target,
+    // so there is no need to check again.
+    iter_->Seek(smallest_->user_key);
+  } else {
+    iter_->Seek(ExtractUserKey(target));
+    while (Valid() && icmp_->Compare(end_key(), target) <= 0) {
+      Next();
+    }
+  }
 }
 
 // NOTE: target is a user key, with timestamp if enabled.

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -31,7 +31,7 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
       smallest_ikey_(smallest),
       largest_ikey_(largest) {
   // Set up bounds such that range tombstones from this iterator are
-  // truncated to range [smallest, largest).
+  // truncated to range [smallest_, largest_).
   if (smallest != nullptr) {
     pinned_bounds_.emplace_back();
     auto& parsed_smallest = pinned_bounds_.back();

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -49,6 +49,9 @@ class TruncatedRangeDelIterator {
   // REQUIRES: target is a user key.
   void Seek(const Slice& target);
 
+  // Seeks to the first range tombstone with end_key() > target.
+  void SeekInternalKey(const Slice& target);
+
   // Seeks to the tombstone with the highest visible sequence number that covers
   // target (a user key). If no such tombstone exists, the position will be at
   // the latest tombstone that starts before target.

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -1409,7 +1409,7 @@ void MergingIterator::InitMaxHeap() {
 // is not covered by any range tombstone.
 // Post-condition:
 // - Invariants (2)-(10) hold
-// - minHeap_->top()->key() == NextVisible(k)
+// - (*) minHeap_->top()->key() == NextVisible(k)
 //
 // Loop invariants:
 // - Invariant (4)-(10)
@@ -1426,6 +1426,7 @@ void MergingIterator::InitMaxHeap() {
 //  progress condition can be made simpler: iterator only moves forward.
 //
 // Proof sketch:
+// Post-condition:
 // Invariant (2) holds when this method returns:
 // Ignoring the empty minHeap_ case, there are two cases:
 // Case 1: active_ is empty and !minHeap_.top()->IsDeleteRangeSentinelKey().
@@ -1469,6 +1470,12 @@ void MergingIterator::InitMaxHeap() {
 // If j == i, children_[i]->Next() would have been called.
 // So it is impossible for children_[i].iter.key() to be covered by a range
 // tombstone.
+//
+// Post-condition (*) holds when the function returns:
+// From loop invariant (*) that k <= children_[i].iter.key() <=
+// LevelNextVisible(i, k) and Invariant (3) above, when the function returns,
+// minHeap_.top()->key() is the smallest LevelNextVisible(i, k) among all levels
+// i. This is equal to NextVisible(k).
 //
 // Invariant (4) holds after each iteration:
 // In i-th iteration, SkipNextDeleted() touches children_ by calling SeekImpl()

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -36,9 +36,9 @@ namespace ROCKSDB_NAMESPACE {
 //
 // After each call to SeekImpl() in addition to the functions mentioned above:
 // (3) For all level i and j <= i, range_tombstone_iters_[j].prev.end_key() <
-// children_[j].iter.key(). That is, range_tombstone_iters_[j] is at or before
+// children_[i].iter.key(). That is, range_tombstone_iters_[j] is at or before
 // the first range tombstone from level j with end_key() >
-// children_[j].iter.key().
+// children_[i].iter.key().
 // (4) For all level i and j <= i, if j in active_, then
 // range_tombstone_iters_[j]->start_key() < children_[i].iter.key().
 // - When range_tombstone_iters_[j] is !Valid(), we consider its `prev` to be
@@ -689,7 +689,7 @@ class MergingIterator : public InternalIterator {
 // Invariant (3) holds for all level i.
 // For j <= i < starting_level, it follows from Pre-condition that (3) holds
 // and that SeekImpl(-, starting_level) does not update children_[i] or
-// range_tombstone_iters_[i].
+// range_tombstone_iters_[j].
 // For j < starting_level and i >= starting_level, it follows from
 // - Pre-condition that range_tombstone_iters_[j].prev.end_key() < `target`
 // - range_tombstone_iters_[j] is not updated in SeekImpl(), and

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -267,7 +267,7 @@ class MergingIterator : public InternalIterator {
     ClearHeaps();
     InitMaxHeap();
     status_ = Status::OK();
-    for (auto &child : children_) {
+    for (auto& child : children_) {
       child.iter.SeekToLast();
       AddToMaxHeapOrCheckStatus(&child);
     }
@@ -318,7 +318,7 @@ class MergingIterator : public InternalIterator {
     }
   }
 
-  void SeekForPrev(const Slice &target) override {
+  void SeekForPrev(const Slice& target) override {
     assert(range_tombstone_iters_.empty() ||
            range_tombstone_iters_.size() == children_.size());
     SeekForPrevImpl(target);
@@ -369,7 +369,7 @@ class MergingIterator : public InternalIterator {
     current_ = CurrentForward();
   }
 
-  bool NextAndGetResult(IterateResult *result) override {
+  bool NextAndGetResult(IterateResult* result) override {
     Next();
     bool is_valid = Valid();
     if (is_valid) {
@@ -445,9 +445,9 @@ class MergingIterator : public InternalIterator {
     return current_->UpperBoundCheckResult();
   }
 
-  void SetPinnedItersMgr(PinnedIteratorsManager *pinned_iters_mgr) override {
+  void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override {
     pinned_iters_mgr_ = pinned_iters_mgr;
-    for (auto &child : children_) {
+    for (auto& child : children_) {
       child.iter.SetPinnedItersMgr(pinned_iters_mgr);
     }
   }
@@ -487,7 +487,7 @@ class MergingIterator : public InternalIterator {
       iter.Set(_iter);
     }
 
-    void SetTombstoneKey(ParsedInternalKey &&pik) {
+    void SetTombstoneKey(ParsedInternalKey&& pik) {
       // op_type is already initialized in MergingIterator::Finish().
       tombstone_pik.user_key = pik.user_key;
       tombstone_pik.sequence = pik.sequence;
@@ -571,7 +571,7 @@ class MergingIterator : public InternalIterator {
   // @param range_tombstone_reseek Whether target is some range tombstone
   // end, i.e., whether this SeekImpl() call is a part of a "cascading seek".
   // This is used only for recoding relevant perf_context.
-  void SeekImpl(const Slice &target, size_t starting_level = 0,
+  void SeekImpl(const Slice& target, size_t starting_level = 0,
                 bool range_tombstone_reseek = false);
 
   // Seek to fist key <= target key (internal key) for

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -52,10 +52,7 @@ namespace ROCKSDB_NAMESPACE {
 // pinned_heap_item_).
 // 7) heap property is maintained: parent is always <= child in minHeap_.
 // The value used for ordering is children_[i].iter.key() for each children_[i],
-// and pinned_heap_item_[i].tombstone_pik) for each pinned_heap_item_[i].
-//
-// Define LevelNextVisible(i, k) to be the first key >= k in level i that is
-// not covered by any range tombstone.
+// and pinned_heap_item_[i].parsed_ikey) for each pinned_heap_item_[i].
 // 8) For all j <= i, range_tombstone_iters_[j] is at or before the first
 // range tombstone from level j that has end_key() > children_[j].iter.key().
 // 9) i is in active_ iff range_tombstone_iters_[i]->Valid() and
@@ -307,12 +304,14 @@ class MergingIterator : public InternalIterator {
   // the target key is `end`. This optimization is applied at each level and
   // hence the name "cascading seek".
   void Seek(const Slice& target) override {
-    SeekImpl(target);
+    // Define LevelNextVisible(i, k) to be the first key >= k in level i that is
+    // not covered by any range tombstone.
     // After SeekImpl(target, 0), invariants (4)-(10) hold.
     // For all level i, target <= children_[i].iter.key() <= LevelNextVisible(i,
     // target). By the contract of FindNextVisibleKey(), Invariants (2)-(10)
     // hold after this call, and minHeap_.top().iter points to
     // NextVisible(target).
+    SeekImpl(target);
     FindNextVisibleKey();
 
     direction_ = kForward;

--- a/table/merging_iterator.h
+++ b/table/merging_iterator.h
@@ -24,7 +24,7 @@ template <class TValue>
 class InternalIteratorBase;
 using InternalIterator = InternalIteratorBase<Slice>;
 
-// Return an iterator that provided the union of the data in
+// Return an iterator that provides the union of the data in
 // children[0,n-1].  Takes ownership of the child iterators and
 // will delete them when the result iterator is deleted.
 //
@@ -36,11 +36,15 @@ extern InternalIterator* NewMergingIterator(
     const InternalKeyComparator* comparator, InternalIterator** children, int n,
     Arena* arena = nullptr, bool prefix_seek_mode = false);
 
+// The iterator returned by NewMergingIterator() and
+// MergeIteratorBuilder::Finish(). MergingIterator handles the merging of data
+// from different point and/or range tombstone iterators.
 class MergingIterator;
 
-// A builder class to build a merging iterator by adding iterators one by one.
-// User should call only one of AddIterator() or AddPointAndTombstoneIterator()
-// exclusively for the same builder.
+// A builder class to for an iterator that provides the union of data
+// of input iterators. Two APIs are provided to add input iterators. User should
+// only call one of them exclusively depending on if range tombstone should be
+// processed.
 class MergeIteratorBuilder {
  public:
   // comparator: the comparator used in merging comparator
@@ -50,7 +54,7 @@ class MergeIteratorBuilder {
                                 const Slice* iterate_upper_bound = nullptr);
   ~MergeIteratorBuilder();
 
-  // Add iter to the merging iterator.
+  // Add point key iterator `iter` to the merging iterator.
   void AddIterator(InternalIterator* iter);
 
   // Add a point key iterator and a range tombstone iterator.


### PR DESCRIPTION
Summary: Add some comments to try to explain how/why MergingIterator works. Made some small refactoring, mostly in MergingIterator::SkipNextDeleted() and MergingIterator::SeekImpl().

Test plan: crash test with small key range: 
```
python3 tools/db_crashtest.py blackbox --simple --max_key=100 --interval=6000 --write_buffer_size=262144 --target_file_size_base=256 --max_bytes_for_level_base=262144 --block_size=128 --value_size_mult=33 --subcompactions=10 --use_multiget=1 --delpercent=3 --delrangepercent=2 --verify_iterator_with_expected_state_one_in=2 --num_iterations=10
```
