### PR TITLE
Fix a bug where GetEntity would expose a blob reference

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 * Fixed a data race on `ColumnFamilyData::flush_reason` caused by concurrent flushes.
+* Fixed a feature interaction bug where for blobs `GetEntity` would expose the blob reference instead of the blob value.
 
 ### Feature Removal
 * Remove RocksDB Lite.

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -1771,6 +1771,28 @@ TEST_F(DBBlobBasicTest, WarmCacheWithBlobsSecondary) {
             1);
 }
 
+TEST_F(DBBlobBasicTest, GetEntityBlob) {
+  Options options = GetDefaultOptions();
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+
+  Reopen(options);
+
+  constexpr char key[] = "key";
+  constexpr char blob_value[] = "blob_value";
+
+  ASSERT_OK(Put(key, blob_value));
+
+  ASSERT_OK(Flush());
+
+  PinnableWideColumns result;
+  ASSERT_OK(
+      db_->GetEntity(ReadOptions(), db_->DefaultColumnFamily(), key, &result));
+
+  WideColumns expected_columns{{kDefaultWideColumnName, blob_value}};
+  ASSERT_EQ(result.columns(), expected_columns);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2367,6 +2367,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
             *value = std::move(result);
           } else {
             assert(columns);
+            columns->Reset();
             columns->SetPlainValue(result);
           }
         }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2356,8 +2356,8 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
 
           constexpr uint64_t* bytes_read = nullptr;
 
-          *status = GetBlob(read_options, get_context.ukey_to_get_blob_value(), blob_index, prefetch_buffer,
-                            &result, bytes_read);
+          *status = GetBlob(read_options, get_context.ukey_to_get_blob_value(),
+                            blob_index, prefetch_buffer, &result, bytes_read);
           if (!status->ok()) {
             if (status->IsIncomplete()) {
               get_context.MarkKeyMayExist();


### PR DESCRIPTION
Summary:
The patch fixes a feature interaction bug between BlobDB and the `GetEntity` API:
without the patch, `GetEntity` would return the blob reference (wrapped into a
single-column entity) instead of the actual blob value.

Test Plan:
`make check`