### PR TITLE
DB Stress to fix a false assertion

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2792,8 +2792,10 @@ void StressTest::Reopen(ThreadState* thread) {
     }
     assert(s.ok());
   }
+  assert(txn_db_ == nullptr || db_ == txn_db_);
   delete db_;
   db_ = nullptr;
+  txn_db_ = nullptr;
 
   num_times_reopened_++;
   auto now = clock_->NowMicros();


### PR DESCRIPTION
Summary:
Seeting this error in stress test:

db_stress: internal_repo_rocksdb/repo/db_stress_tool/db_stress_test_base.cc:2459: void rocksdb::StressTest::Open(rocksdb::SharedState *): Assertion `txn_db_ == nullptr' failed. Received signal 6 (Aborted)
......

It doesn't appear that txn_db_ is set to nullptr at all. We set ithere.

Test Plan: Run db_stress transaction and non-transation with low kill rate and see restarting without assertion