### PR TITLE
Extend existing benchmarks seekrandom and multiread to run with async_io

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -143,6 +143,8 @@ function main {
       run_db_bench "seekrandom"
       run_db_bench "seekrandomwhilewriting"
       run_db_bench "multireadrandom"
+      run_db_bench "seekrandom_asyncio" $NUM_KEYS 1 0 0 true
+      run_db_bench "multireadrandom_asyncio" $NUM_KEYS 1 0 0 true
   fi
 
   cleanup_test_directory $TEST_ROOT_DIR
@@ -192,6 +194,7 @@ function init_arguments {
   NUM_LOW_PRI_THREADS=${NUM_LOW_PRI_THREADS:-16}
   DELETE_TEST_PATH=${DELETE_TEST_PATH:-0}
   SEEK_NEXTS=${SEEK_NEXTS:-10}
+  SEEK_NEXTS_ASYNCIO=${SEEK_NEXTS_ASYNC_IO:-10}
   SEED=${SEED:-$( date +%s )}
   MULTIREAD_BATCH_SIZE=${MULTIREAD_BATCH_SIZE:-128}
   MULTIREAD_STRIDE=${MULTIREAD_STRIDE:-12}
@@ -203,6 +206,7 @@ function init_arguments {
 # $3 --- number of threads.  Default $NUM_THREADS
 # $4 --- use_existing_db.  Default: 1
 # $5 --- update_report. Default: 1
+# $6 --- async_io. Default: False
 function run_db_bench {
   # Make sure no other db_bench is running. (Make sure command succeeds if pidof
   # command exists but finds nothing.)
@@ -234,6 +238,14 @@ function run_db_bench {
   threads=${3:-$NUM_THREADS}
   USE_EXISTING_DB=${4:-1}
   UPDATE_REPORT=${5:-1}
+  async_io=${6:-false}
+
+  seek_nexts=$SEEK_NEXTS
+  if [ "$async_io" == "true" ]; then
+    $seek_nexts=$SEEK_NEXTS_ASYNCIO
+  fi
+
+
   echo ""
   echo "======================================================================="
   echo "Benchmark $1"
@@ -242,9 +254,13 @@ function run_db_bench {
   db_bench_error=0
   options_file_arg=$(setup_options_file)
   echo "$options_file_arg"
+
+  # In case of async_io, benchmark is benchmark_asyncio
+  db_bench_type=${1%%_*}
+
   # use `which time` to avoid using bash's internal time command
   db_bench_cmd="\$(which time) -p $DB_BENCH_DIR/db_bench \
-      --benchmarks=$1 --db=$DB_PATH --wal_dir=$WAL_PATH \
+      --benchmarks=$db_bench_type --db=$DB_PATH --wal_dir=$WAL_PATH \
       --use_existing_db=$USE_EXISTING_DB \
       --perf_level=$PERF_LEVEL \
       --disable_auto_compactions \
@@ -260,7 +276,7 @@ function run_db_bench {
       $options_file_arg \
       --compression_ratio=$COMPRESSION_RATIO \
       --histogram=$HISTOGRAM \
-      --seek_nexts=$SEEK_NEXTS \
+      --seek_nexts=$seek_nexts \
       --stats_per_interval=$STATS_PER_INTERVAL \
       --stats_interval_seconds=$STATS_INTERVAL_SECONDS \
       --max_background_flushes=$MAX_BACKGROUND_FLUSHES \
@@ -271,7 +287,8 @@ function run_db_bench {
       --seed=$SEED \
       --multiread_batched=true \
       --batch_size=$MULTIREAD_BATCH_SIZE \
-      --multiread_stride=$MULTIREAD_STRIDE 2>&1"
+      --multiread_stride=$MULTIREAD_STRIDE \
+      --async_io=$async_io 2>&1"
   if ! [ -z "$REMOTE_USER_AT_HOST" ]; then
     echo "Running benchmark remotely on $REMOTE_USER_AT_HOST"
     db_bench_cmd="$SSH $REMOTE_USER_AT_HOST '$db_bench_cmd'"


### PR DESCRIPTION
Summary:


=======================================================================   
Benchmark seekrandom_asyncio

=======================================================================

db_bench_cmd=$(which time) -p ./db_bench       --benchmarks=seekrandom
--db=/tmp/rocksdb/regression_test/db --wal_dir=
--use_existing_db=0       --perf_level=1
--disable_auto_compactions       --threads=1       --num=1073741824
--reads=1073741824       --writes=1073741824       --deletes=1073741824
--key_size=100       --value_size=900       --cache_size=1073741824
--statistics=0              --compression_ratio=0.5       --histogram=1
--seek_nexts=10       --stats_per_interval=1
--stats_interval_seconds=600       --max_background_flushes=4
--num_multi_db=1       --max_background_compactions=16
--num_high_pri_threads=4       --num_low_pri_threads=16
--seed=1675181789       --multiread_batched=true       --batch_size=128
--multiread_stride=12       --async_io=true
--optimize_multiget_for_io=false 2>&1
RocksDB:    version 8.0.0

=======================================================================   
 Benchmark multireadrandom_asyncio

====================================================================

db_bench_cmd=$(which time) -p ./db_bench
--benchmarks=multireadrandom --db=/tmp/rocksdb/regression_test/db
--wal_dir=       --use_existing_db=0       --perf_level=1
--disable_auto_compactions       --threads=1       --num=1073741824
--reads=1073741824       --writes=1073741824       --deletes=1073741824
--key_size=100       --value_size=900       --cache_size=1073741824
--statistics=0              --compression_ratio=0.5       --histogram=1
--seek_nexts=10       --stats_per_interval=1
--stats_interval_seconds=600       --max_background_flushes=4
--num_multi_db=1       --max_background_compactions=16
--num_high_pri_threads=4       --num_low_pri_threads=16
--seed=1675181841       --multiread_batched=true       --batch_size=128
--multiread_stride=12       --async_io=true
--optimize_multiget_for_io=true 2>&1
RocksDB:    version 8.0.0
Date:       Tue Jan 31 08:17:22 2023
CPU:        32 * Intel Xeon Processor (Skylake)
CPUCache:   16384 KB

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: