### PR TITLE
Add kForceOptimized option to jni

### DIFF
--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -63,7 +63,8 @@ public class CompactRangeOptions extends RocksObject {
         case VALUE_kSkip: return kSkip;
         case VALUE_kIfHaveCompactionFilter: return kIfHaveCompactionFilter;
         case VALUE_kForce: return kForce;
-        case VALUE_kForceOptimized: return kForceOptimized;
+        case VALUE_kForceOptimized:
+          return kForceOptimized;
         default: return null;
       }
     }

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -15,6 +15,8 @@ public class CompactRangeOptions extends RocksObject {
   private final static byte VALUE_kIfHaveCompactionFilter = 1;
   private final static byte VALUE_kForce = 2;
 
+  private final static byte VALUE_kForceOptimized = 3;
+
   // For level based compaction, we can configure if we want to skip/force bottommost level
   // compaction. The order of this enum MUST follow the C++ layer. See BottommostLevelCompaction in
   // db/options.h
@@ -30,7 +32,12 @@ public class CompactRangeOptions extends RocksObject {
     /**
      * Always compact bottommost level
      */
-    kForce(VALUE_kForce);
+    kForce(VALUE_kForce),
+    /**
+     * Always compact bottommost level but in bottommost level avoid
+     * double-compacting files created in the same compaction
+     */
+    kForceOptimized(VALUE_kForceOptimized);
 
     private final byte value;
 
@@ -57,7 +64,8 @@ public class CompactRangeOptions extends RocksObject {
         case VALUE_kSkip: return kSkip;
         case VALUE_kIfHaveCompactionFilter: return kIfHaveCompactionFilter;
         case VALUE_kForce: return kForce;
-        default: return null;
+        case VALUE_kForceOptimized: return kForceOptimized;
+      default: return null;
       }
     }
   }

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -14,7 +14,6 @@ public class CompactRangeOptions extends RocksObject {
   private final static byte VALUE_kSkip = 0;
   private final static byte VALUE_kIfHaveCompactionFilter = 1;
   private final static byte VALUE_kForce = 2;
-
   private final static byte VALUE_kForceOptimized = 3;
 
   // For level based compaction, we can configure if we want to skip/force bottommost level
@@ -65,7 +64,7 @@ public class CompactRangeOptions extends RocksObject {
         case VALUE_kIfHaveCompactionFilter: return kIfHaveCompactionFilter;
         case VALUE_kForce: return kForce;
         case VALUE_kForceOptimized: return kForceOptimized;
-      default: return null;
+        default: return null;
       }
     }
   }

--- a/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
@@ -39,6 +39,9 @@ public class CompactRangeOptionsTest {
     value = BottommostLevelCompaction.kIfHaveCompactionFilter;
     opt.setBottommostLevelCompaction(value);
     assertThat(opt.bottommostLevelCompaction()).isEqualTo(value);
+    value = BottommostLevelCompaction.kForceOptimized;
+    opt.setBottommostLevelCompaction(value);
+    assertThat(opt.bottommostLevelCompaction()).isEqualTo(value);
   }
 
   @Test


### PR DESCRIPTION
Currently the option of "KForceOptimized" is not included in CompactRangeOptions.BottommostLevelCompaction.

This PR is to add this option.