### PR TITLE
Fix more CircleCI jobs for LIB_MODE=shared default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,7 +416,10 @@ jobs:
     steps:
       - checkout # check out the code in the project directory
       - run: apt-get update -y && apt-get install -y libgflags-dev
-      - run: make V=1 -j8 unity_test
+      - run:
+          name: "Unity build"
+          command: make V=1 -j8 unity_test
+          no_output_timeout: 20m
       - run: make V=1 -j8 -k check-headers # could be moved to a different build
       - post-steps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
       - pre-steps
       - setup-folly
       - build-folly
-      - run: USE_FOLLY=1 LIB_MODE=static CC=gcc-7 CXX=g++-7 V=1 make -j32 check # TODO: LIB_MODE only to work around unresolved linker failures
+      - run: USE_FOLLY=1 CC=gcc-7 CXX=g++-7 V=1 make -j32 check
       - post-steps
 
   build-linux-gcc-7-with-folly-lite-no-test:
@@ -501,7 +501,7 @@ jobs:
     resource_class: 2xlarge
     steps:
       - pre-steps
-      - run: DEBUG_LEVEL=0 make -j32 run_microbench
+      - run: DEBUG_LEVEL=0 LIB_MODE=static make -j32 run_microbench # TODO: LIB_MODE only to work around unresolved linker failures
       - post-steps
 
   build-linux-mini-crashtest:
@@ -833,6 +833,7 @@ workflows:
       - build-linux-clang10-clang-analyze
       - build-linux-unity-and-headers
       - build-linux-mini-crashtest
+      - build-linux-run-microbench
   jobs-windows:
     jobs:
       - build-windows-vs2022

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,7 +430,7 @@ jobs:
       - pre-steps
       - setup-folly
       - build-folly
-      - run: USE_FOLLY=1 CC=gcc-7 CXX=g++-7 V=1 make -j32 check
+      - run: USE_FOLLY=1 LIB_MODE=static CC=gcc-7 CXX=g++-7 V=1 make -j32 check # TODO: LIB_MODE only to work around unresolved linker failures
       - post-steps
 
   build-linux-gcc-7-with-folly-lite-no-test:
@@ -495,7 +495,7 @@ jobs:
       - pre-steps
       - setup-folly
       - build-folly
-      - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 USE_FOLLY=1 COMPILE_WITH_UBSAN=1 COMPILE_WITH_ASAN=1 make -j32 check
+      - run: CC=clang-13 CXX=clang++-13 LIB_MODE=static USE_CLANG=1 USE_FOLLY=1 COMPILE_WITH_UBSAN=1 COMPILE_WITH_ASAN=1 make -j32 check # TODO: LIB_MODE only to work around unresolved linker failures
       - post-steps
 
   # This job is only to make sure the microbench tests are able to run, the benchmark result is not meaningful as the CI host is changing.
@@ -836,7 +836,6 @@ workflows:
       - build-linux-clang10-clang-analyze
       - build-linux-unity-and-headers
       - build-linux-mini-crashtest
-      - build-linux-run-microbench
   jobs-windows:
     jobs:
       - build-windows-vs2022

--- a/Makefile
+++ b/Makefile
@@ -2441,7 +2441,7 @@ build_folly:
 	# Restore the original version of Invoke.h with boost dependency
 	cd third-party/folly && ${GIT_COMMAND} checkout folly/functional/Invoke.h
 	cd third-party/folly && MAYBE_AVX2=`echo $(CXXFLAGS) | grep -o -- -DHAVE_AVX2 | sed 's/-DHAVE_AVX2/-mavx2/g' || true` && \
-		MAYBE_SHARED_LIBS=`[ "$$LIB_MODE" == "shared" ] && echo "--shared-libs" || true` && \
+		MAYBE_SHARED_LIBS=`[ "$(LIB_MODE)" == "shared" ] && echo "--shared-libs" || true` && \
 		CXXFLAGS=" $$MAYBE_AVX2 -DHAVE_CXX11_ATOMIC " $(PYTHON) build/fbcode_builder/getdeps.py build --no-tests $$MAYBE_SHARED_LIBS
 
 # ---------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -2421,7 +2421,7 @@ checkout_folly:
 	fi
 	@# Pin to a particular version for public CI, so that PR authors don't
 	@# need to worry about folly breaking our integration. Update periodically
-	cd third-party/folly && git reset --hard beacd86d63cd71c904632262e6c36f60874d78ba
+	cd third-party/folly && git reset --hard d506ac06dc6164f18132d5cca6881b79924712db
 	@# A hack to remove boost dependency.
 	@# NOTE: this hack is only needed if building using USE_FOLLY_LITE
 	perl -pi -e 's/^(#include <boost)/\/\/$$1/' third-party/folly/folly/functional/Invoke.h

--- a/Makefile
+++ b/Makefile
@@ -2421,7 +2421,7 @@ checkout_folly:
 	fi
 	@# Pin to a particular version for public CI, so that PR authors don't
 	@# need to worry about folly breaking our integration. Update periodically
-	cd third-party/folly && git reset --hard d506ac06dc6164f18132d5cca6881b79924712db
+	cd third-party/folly && git reset --hard beacd86d63cd71c904632262e6c36f60874d78ba
 	@# A hack to remove boost dependency.
 	@# NOTE: this hack is only needed if building using USE_FOLLY_LITE
 	perl -pi -e 's/^(#include <boost)/\/\/$$1/' third-party/folly/folly/functional/Invoke.h
@@ -2441,8 +2441,7 @@ build_folly:
 	# Restore the original version of Invoke.h with boost dependency
 	cd third-party/folly && ${GIT_COMMAND} checkout folly/functional/Invoke.h
 	cd third-party/folly && MAYBE_AVX2=`echo $(CXXFLAGS) | grep -o -- -DHAVE_AVX2 | sed 's/-DHAVE_AVX2/-mavx2/g' || true` && \
-		MAYBE_SHARED_LIBS=`[ "$(LIB_MODE)" == "shared" ] && echo "--shared-libs" || true` && \
-		CXXFLAGS=" $$MAYBE_AVX2 -DHAVE_CXX11_ATOMIC " $(PYTHON) build/fbcode_builder/getdeps.py build --no-tests $$MAYBE_SHARED_LIBS
+		CXXFLAGS=" $$MAYBE_AVX2 -DHAVE_CXX11_ATOMIC " $(PYTHON) build/fbcode_builder/getdeps.py build --no-tests
 
 # ---------------------------------------------------------------------------
 #   Build size testing

--- a/Makefile
+++ b/Makefile
@@ -2441,7 +2441,8 @@ build_folly:
 	# Restore the original version of Invoke.h with boost dependency
 	cd third-party/folly && ${GIT_COMMAND} checkout folly/functional/Invoke.h
 	cd third-party/folly && MAYBE_AVX2=`echo $(CXXFLAGS) | grep -o -- -DHAVE_AVX2 | sed 's/-DHAVE_AVX2/-mavx2/g' || true` && \
-		CXXFLAGS=" $$MAYBE_AVX2 -DHAVE_CXX11_ATOMIC " $(PYTHON) build/fbcode_builder/getdeps.py build --no-tests
+		MAYBE_SHARED_LIBS=`[ "$$LIB_MODE" == "shared" ] && echo "--shared-libs" || true` && \
+		CXXFLAGS=" $$MAYBE_AVX2 -DHAVE_CXX11_ATOMIC " $(PYTHON) build/fbcode_builder/getdeps.py build --no-tests $$MAYBE_SHARED_LIBS
 
 # ---------------------------------------------------------------------------
 #   Build size testing


### PR DESCRIPTION
Summary: There are a set of jobs using libbenchmark that have linker failures with new default LIB_MODE=shared. This change adds build-linux-run-microbench to the set using LIB_MODE=static to work around the linker failures. I haven't dug into how to fix them.

There is another set of jobs using folly that have linker failures with new default LIB_MODE=shared. I tried fixing these by adding --shared-libs to the folly build, but that doesn't work. It kinda looks like the folly shared libs build is simply broken with the boost dependency:

```
/usr/bin/ld: /tmp/fbcode_builder_getdeps-ZrootZprojectZthird-partyZfollyZbuildZfbcode_builder-root/installed/boost-Z1Z72zV-c0-0f3HkylpzONnr1dsHYDaR2GyTLzYdkck/lib/libboost_filesystem.a(exception.o): relocation R_X86_64_PC32 against symbol `_ZTVN5boost10filesystem16filesystem_errorE' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```

I tried updating folly to the latest commit and that didn't help. Otherwise, I didn't dig deeper into fixing that so have added build-linux-clang-13-asan-ubsan-with-folly to the set using LIB_MODE=static

Also since I saw a flaky failure (not the first time), increased the timeout on build-linux-unity-and-headers job.

Test Plan: CI