### PR TITLE
Revert to LIB_MODE=static for optimized builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,16 +287,20 @@ jobs:
     steps:
       - checkout # check out the code in the project directory
       - run: make V=1 -j32 LIB_MODE=shared release
+      - run: ls librocksdb.so # ensure shared lib built
       - run: ./db_stress --version # ensure with gflags
       - run: make clean
-      - run: make V=1 -j32 LIB_MODE=static release
+      - run: make V=1 -j32 release
+      - run: ls librocksdb.a # ensure static lib built
       - run: ./db_stress --version # ensure with gflags
       - run: make clean
       - run: apt-get remove -y libgflags-dev
       - run: make V=1 -j32 LIB_MODE=shared release
+      - run: ls librocksdb.so # ensure shared lib built
       - run: if ./db_stress --version; then false; else true; fi # ensure without gflags
       - run: make clean
-      - run: make V=1 -j32 LIB_MODE=static release
+      - run: make V=1 -j32 release
+      - run: ls librocksdb.a # ensure static lib built
       - run: if ./db_stress --version; then false; else true; fi # ensure without gflags
       - post-steps
 
@@ -504,7 +508,7 @@ jobs:
     resource_class: 2xlarge
     steps:
       - pre-steps
-      - run: DEBUG_LEVEL=0 LIB_MODE=static make -j32 run_microbench # TODO: LIB_MODE only to work around unresolved linker failures
+      - run: DEBUG_LEVEL=0 make -j32 run_microbench
       - post-steps
 
   build-linux-mini-crashtest:

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,6 @@ quoted_perl_command = $(subst ','\'',$(perl_command))
 # Set the default DEBUG_LEVEL to 1
 DEBUG_LEVEL?=1
 
-# LIB_MODE says whether or not to use/build "shared" or "static" libraries.
-# Mode "static" means to link against static libraries (.a)
-# Mode "shared" means to link against shared libraries (.so, .sl, .dylib, etc)
-#
-# Set the default LIB_MODE to shared for efficient `make check` etc.
-LIB_MODE?=shared
-
 # OBJ_DIR is where the object files reside.  Default to the current directory
 OBJ_DIR?=.
 
@@ -81,7 +74,19 @@ else ifneq ($(filter jtest rocksdbjava%, $(MAKECMDGOALS)),)
 	endif
 endif
 
-$(info $$DEBUG_LEVEL is ${DEBUG_LEVEL})
+# LIB_MODE says whether or not to use/build "shared" or "static" libraries.
+# Mode "static" means to link against static libraries (.a)
+# Mode "shared" means to link against shared libraries (.so, .sl, .dylib, etc)
+#
+ifeq ($(DEBUG_LEVEL), 0)
+# For optimized, set the default LIB_MODE to static for code size/efficiency
+	LIB_MODE?=static
+else
+# For debug, set the default LIB_MODE to shared for efficient `make check` etc.
+	LIB_MODE?=shared
+endif
+
+$(info $$DEBUG_LEVEL is $(DEBUG_LEVEL), $$LIB_MODE is $(LIB_MODE))
 
 # Figure out optimize level.
 ifneq ($(DEBUG_LEVEL), 2)


### PR DESCRIPTION
Summary: Continuous performance testing indicates there's a small performance hit with shared library (-fPIC) builds, so while retaining the motivation for #11168, we set the default for DEBUG_LEVEL=0 Makefile builds back to LIB_MODE=static.

Test Plan: CI, with some updated checks and removal of some now obsolete LIB_MODE overrides