### PR TITLE
Attempt fix flaky DBWriteTest.LockWALInEffect

### DIFF
--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -612,6 +612,7 @@ TEST_P(DBWriteTest, LockWALInEffect) {
   std::unique_ptr<FaultInjectionTestEnv> mock_env(
       new FaultInjectionTestEnv(env_));
   options.env = mock_env.get();
+  options.disable_auto_compactions = true;
   options.paranoid_checks = false;
   Reopen(options);
   // try the 1st WAL created during open


### PR DESCRIPTION
Summary: Example failure:
```
[ RUN      ] DBWriteTestInstance/DBWriteTest.LockWALInEffect/1
db/db_write_test.cc:646: Failure
Put("key3", "value")
Corruption: Not active
```
Presumably from a background compaction prior to Put.

Test Plan: watch CI