### PR TITLE
Java API implementation - configure initial spotbugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,7 +588,7 @@ jobs:
           command: make V=1 J=8 -j8 jtest
       - post-steps
 
-  build-linux-java-spotbugs:
+  build-linux-java-pmd:
     executor: linux-docker
     resource_class: large
     steps:
@@ -601,8 +601,8 @@ jobs:
             which java && java -version
             which javac && javac -version
       - run:
-          name: "Spotbugs RocksDBJava"
-          command: make V=1 J=8 -j8 jspotbugs
+          name: "PMD RocksDBJava"
+          command: make V=1 J=8 -j8 jpmd
       - post-steps
 
   build-linux-java-static:
@@ -869,7 +869,7 @@ workflows:
       - build-macos-java
       - build-macos-java-static
       - build-macos-java-static-universal
-      - build-linux-java-spotbugs
+      - build-linux-java-jpmd
   jobs-macos:
     jobs:
       - build-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,6 +588,23 @@ jobs:
           command: make V=1 J=8 -j8 jtest
       - post-steps
 
+  build-linux-java-spotbugs:
+    executor: linux-docker
+    resource_class: large
+    steps:
+      - pre-steps
+      - run:
+          name: "Set Java Environment"
+          command: |
+            echo "JAVA_HOME=${JAVA_HOME}"
+            echo 'export PATH=$JAVA_HOME/bin:$PATH' >> $BASH_ENV
+            which java && java -version
+            which javac && javac -version
+      - run:
+          name: "Spotbugs RocksDBJava"
+          command: make V=1 J=8 -j8 jspotbugs
+      - post-steps
+
   build-linux-java-static:
     executor: linux-docker
     resource_class: large
@@ -852,6 +869,7 @@ workflows:
       - build-macos-java
       - build-macos-java-static
       - build-macos-java-static-universal
+      - build-linux-java-spotbugs
   jobs-macos:
     jobs:
       - build-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,13 @@ commands:
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew install gflags
 
+    install-maven:
+    steps:
+      - run:
+          name: Install maven
+          command: |
+            sudo apt-get update -y && sudo apt-get install -y maven
+
   setup-folly:
     steps:
       - run:
@@ -592,6 +599,7 @@ jobs:
     executor: linux-docker
     resource_class: large
     steps:
+      - install-maven
       - pre-steps
       - run:
           name: "Set Java Environment"
@@ -869,7 +877,7 @@ workflows:
       - build-macos-java
       - build-macos-java-static
       - build-macos-java-static-universal
-      - build-linux-java-jpmd
+      - build-linux-java-pmd
   jobs-macos:
     jobs:
       - build-macos

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ fuzz/crash-*
 
 cmake-build-*
 third-party/folly/
+/java/pom.xml

--- a/Makefile
+++ b/Makefile
@@ -2407,6 +2407,9 @@ jtest_run:
 jtest: rocksdbjava
 	cd java;$(MAKE) sample test
 
+jspotbugs: rocksdbjava rocksdbjavageneratepom
+	cd java;$(MAKE) spotbugs
+
 jdb_bench:
 	cd java;$(MAKE) db_bench;
 

--- a/Makefile
+++ b/Makefile
@@ -2407,8 +2407,8 @@ jtest_run:
 jtest: rocksdbjava
 	cd java;$(MAKE) sample test
 
-jspotbugs: rocksdbjava rocksdbjavageneratepom
-	cd java;$(MAKE) spotbugs
+jpmd: rocksdbjava rocksdbjavageneratepom
+	cd java;$(MAKE) pmd
 
 jdb_bench:
 	cd java;$(MAKE) db_bench;

--- a/java/Makefile
+++ b/java/Makefile
@@ -262,6 +262,8 @@ JAVADOC_CMD := javadoc
 endif
 endif
 
+MAVEN_CMD := mvn
+
 # Look for the Java version (1.6->6, 1.7->7, 1.8->8, 11.0->11, 13.0->13, 15.0->15 etc..)
 JAVAC_VERSION := $(shell $(JAVAC_CMD) -version 2>&1)
 JAVAC_MAJOR_VERSION := $(word 2,$(subst ., ,$(JAVAC_VERSION)))
@@ -450,3 +452,6 @@ run_plugin_test:
 db_bench: java
 	$(AM_V_GEN)mkdir -p $(BENCHMARK_MAIN_CLASSES)
 	$(AM_V_at)$(JAVAC_CMD) $(JAVAC_ARGS) -cp $(MAIN_CLASSES) -d $(BENCHMARK_MAIN_CLASSES) $(BENCHMARK_MAIN_SRC)/org/rocksdb/benchmark/*.java
+
+spotbugs:
+	$(MAVEN_CMD) spotbugs:check

--- a/java/Makefile
+++ b/java/Makefile
@@ -453,5 +453,5 @@ db_bench: java
 	$(AM_V_GEN)mkdir -p $(BENCHMARK_MAIN_CLASSES)
 	$(AM_V_at)$(JAVAC_CMD) $(JAVAC_ARGS) -cp $(MAIN_CLASSES) -d $(BENCHMARK_MAIN_CLASSES) $(BENCHMARK_MAIN_SRC)/org/rocksdb/benchmark/*.java
 
-spotbugs:
-	$(MAVEN_CMD) spotbugs:check
+pmd:
+	$(MAVEN_CMD) pmd:pmd pmd:cpd pmd:check

--- a/java/pmd-rules.xml
+++ b/java/pmd-rules.xml
@@ -11,8 +11,36 @@
 
 
     <!-- Use PMD rules from a few sets, and then make excpetions -->
-    <rule ref="category/java/codestyle.xml"/>
-    <rule ref="category/java/errorprone.xml"/>
-    <rule ref="category/java/bestpractices.xml"/>
+    <rule ref="category/java/codestyle.xml">
+        <!-- These problems are acceptable in perpertuity -->
+        <exclude name="AvoidUsingNativeCode"/>
+        <exclude name="LongVariable"/>
+        <exclude name="ShortVariable"/>
+        <exclude name="ShortClassName"/>
+        <exclude name="OnlyOneReturn"/>
+        <exclude name="FieldNamingConventions"/>
+        <exclude name="FormalParameterNamingConventions"/>
+        <exclude name="LinguisticNaming"/>
+        <!-- These could be fixed if we take the time to do it -->
+        <exclude name="CommentDefaultAccessModifier"/>
+        <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
+        <exclude name="FinalParameterInAbstractMethod"/>
+        <exclude name="EmptyMethodInAbstractClassShouldBeAbstract"/>
+        <exclude name="MethodArgumentCouldBeFinal"/>
+        <exclude name="LocalVariableNamingConventions"/>
+        <exclude name="LocalVariableCouldBeFinal"/>
+        <exclude name="ControlStatementBraces"/>
+        <exclude name="CallSuperInConstructor"/>
+        <exclude name="ControlStatementBraces"/>
+        <exclude name="MethodNamingConventions"/>
+        <exclude name="UselessParentheses"/>
+        <exclude name="AtLeastOneConstructor"/>
+    </rule>
+    <rule ref="category/java/errorprone.xml">
+        <exclude name="AvoidFieldNameMatchingMethodName"/>
+    </rule>
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="UseVarargs"/>
+    </rule>
 
 </ruleset>

--- a/java/pmd-rules.xml
+++ b/java/pmd-rules.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom Rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+       Custom rules for checking RocksDB
+    </description>
+
+
+    <!-- Use PMD rules from a few sets, and then make excpetions -->
+    <rule ref="category/java/codestyle.xml"/>
+    <rule ref="category/java/errorprone.xml"/>
+    <rule ref="category/java/bestpractices.xml"/>
+
+</ruleset>

--- a/java/pom.xml.template
+++ b/java/pom.xml.template
@@ -144,6 +144,9 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>4.7.2.1</version>
+                <configuration>
+                    <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>          
                 <dependencies>
                   <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
                   <dependency>

--- a/java/pom.xml.template
+++ b/java/pom.xml.template
@@ -156,7 +156,28 @@
                   </dependency>
                 </dependencies>
               </plugin>
-        </plugins>
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.20.0</version>
+                <executions>
+                  <execution>
+                    <goals>
+                      <goal>check</goal>
+                      <goal>cpd-check</goal>
+                    </goals>
+                  </execution>
+                </executions>
+                <configuration>
+                    <rulesets>
+                      <!-- A rule set, that comes bundled with PMD -->
+                      <ruleset>/pmd-rules.xml</ruleset>
+                      <!-- A rule set, that comes bundled with PMD -->
+                      <!-- <ruleset>/category/java/errorprone.xml</ruleset> -->
+                    </rulesets>
+                  </configuration>          
+              </plugin>
+      </plugins>
     </build>
 
     <dependencies>
@@ -190,5 +211,15 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
-    </dependencies>
+   </dependencies>
+
+   <reporting>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jxr-plugin</artifactId>
+            <version>3.3.0</version>
+        </plugin>
+    </plugins>
+  </reporting>
 </project>

--- a/java/pom.xml.template
+++ b/java/pom.xml.template
@@ -140,6 +140,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.7.2.1</version>
+                <dependencies>
+                  <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+                  <dependency>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs</artifactId>
+                    <version>4.7.3</version>
+                  </dependency>
+                </dependencies>
+              </plugin>
         </plugins>
     </build>
 

--- a/java/spotbugs-exclude.xml
+++ b/java/spotbugs-exclude.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="MS_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.BackupEngineOptions"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.Transaction$WaitingTransactions"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.TransactionDB$KeyLockInfo"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.Options"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.ColumnFamilyDescriptor"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.ColumnFamilyOptions"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.DBOptions"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.EnvOptions"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.LiveFileMetaData"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.SstFileMetaData"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.StatsCollectorInput"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.ThreadStatus"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.ColumnFamilyMetaData"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.TransactionLogIterator$BatchResult"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.WBWIRocksIterator$WriteEntry"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.TableProperties"/>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.WBWIRocksIterator$WriteEntry"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.TransactionDB$DeadlockPath"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.StatisticsCollector"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.ReadOptions"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.Range"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.Options"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.StatsCollectorInput"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.EnvOptions"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.DBOptions"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.ColumnFamilyOptions"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.ColumnFamilyDescriptor"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.BackupEngineOptions"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <!-- comment out a single exclusion to test that CI reports the consequent spotbugs [Error]
+    <Match>
+        <Class name="org.rocksdb.TransactionDB$KeyLockInfo"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    -->
+    <Match>
+        <Bug pattern="BIT_IOR_OF_SIGNED_BYTE" />
+    </Match>
+    <Match>
+        <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
+    </Match>
+    <Match>
+        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.AbstractCompactionFilterFactory" />
+    </Match>
+</FindBugsFilter>

--- a/java/spotbugs-exclude.xml
+++ b/java/spotbugs-exclude.xml
@@ -1,10 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
+    <!-- The set failing checks when spotbugs was set up were added to this file, as a baseline -->
+    <!-- These exclusions should each be justified or removed and fixed AP (2023-02-09) -->
     <Match>
+        <Class name="org.rocksdb.SstFileWriter"/>
+        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.AbstractTransactionNotifier"/>
+        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+    </Match>
+    <Match>
+        <Class name="org.rocksdb.Env"/>
         <Bug pattern="MS_EXPOSE_REP" />
     </Match>
     <Match>
-        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+        <Class name="org.rocksdb.BackupEngineOptions"/>
+        <Bug pattern="EI_EXPOSE_REP" />
     </Match>
     <Match>
         <Class name="org.rocksdb.BackupEngineOptions"/>


### PR DESCRIPTION
Integrate spotbugs on the Java API to catch and report common Java coding badness; we will initially just exclude everything that is wrong on the existing codebase. We will try to clean that up where we can, and otherwise we will have set a baseline to prevent the introduction of further problems.

Link spotbugs into java build / CI

Add a spotbugs dependency to maven
Add a jspotbugs target to Makefile which runs spotbugs
Add a workflow to Circle CI which runs jspotbugs
Configure an initial default spotbugs for CI