### PR TITLE
Add CreateFromString to Java MergeOperator

### DIFF
--- a/java/rocksjni/cassandra_value_operator.cc
+++ b/java/rocksjni/cassandra_value_operator.cc
@@ -35,16 +35,3 @@ jlong Java_org_rocksdb_CassandraValueMergeOperator_newSharedCassandraValueMergeO
           gcGracePeriodInSeconds, operands_limit));
   return GET_CPLUSPLUS_POINTER(op);
 }
-
-/*
- * Class:     org_rocksdb_CassandraValueMergeOperator
- * Method:    disposeInternal
- * Signature: (J)V
- */
-void Java_org_rocksdb_CassandraValueMergeOperator_disposeInternal(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
-  auto* op =
-      reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
-          jhandle);
-  delete op;
-}

--- a/java/rocksjni/config_options.cc
+++ b/java/rocksjni/config_options.cc
@@ -31,8 +31,21 @@ void Java_org_rocksdb_ConfigOptions_disposeInternal(JNIEnv *, jobject,
  * Method:    newConfigOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_ConfigOptions_newConfigOptions(JNIEnv *, jclass) {
+jlong Java_org_rocksdb_ConfigOptions_newConfigOptions__(JNIEnv *, jclass) {
   auto *cfg_opt = new ROCKSDB_NAMESPACE::ConfigOptions();
+  return GET_CPLUSPLUS_POINTER(cfg_opt);
+}
+
+/*
+ * Class:     org_rocksdb_ConfigOptions
+ * Method:    newConfigOptions
+ * Signature: (ZZ)J
+ */
+jlong Java_org_rocksdb_ConfigOptions_newConfigOptions__ZZ(
+    JNIEnv *, jclass, jboolean unknown, jboolean unsupported) {
+  auto *cfg_opt = new ROCKSDB_NAMESPACE::ConfigOptions();
+  cfg_opt->ignore_unknown_options = static_cast<bool>(unknown);
+  cfg_opt->ignore_unsupported_options = static_cast<bool>(unsupported);
   return GET_CPLUSPLUS_POINTER(cfg_opt);
 }
 
@@ -76,6 +89,43 @@ void Java_org_rocksdb_ConfigOptions_setIgnoreUnknownOptions(JNIEnv *, jclass,
                                                             jboolean b) {
   auto *cfg_opt = reinterpret_cast<ROCKSDB_NAMESPACE::ConfigOptions *>(handle);
   cfg_opt->ignore_unknown_options = static_cast<bool>(b);
+}
+
+/*
+ * Class:     org_rocksdb_ConfigOptions
+ * Method:    setIgnoreUnsupportedOptions
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_ConfigOptions_setIgnoreUnsupportedOptions(JNIEnv *,
+                                                                jclass,
+                                                                jlong handle,
+                                                                jboolean b) {
+  auto *cfg_opt = reinterpret_cast<ROCKSDB_NAMESPACE::ConfigOptions *>(handle);
+  cfg_opt->ignore_unsupported_options = static_cast<bool>(b);
+}
+
+/*
+ * Class:     org_rocksdb_ConfigOptions
+ * Method:    setInvokePrepareOptions
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_ConfigOptions_setInvokePrepareOptions(JNIEnv *, jclass,
+                                                            jlong handle,
+                                                            jboolean b) {
+  auto *cfg_opt = reinterpret_cast<ROCKSDB_NAMESPACE::ConfigOptions *>(handle);
+  cfg_opt->invoke_prepare_options = static_cast<bool>(b);
+}
+
+/*
+ * Class:     org_rocksdb_ConfigOptions
+ * Method:    setMutableOptionsOnly
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_ConfigOptions_setMutableOptionsOnly(JNIEnv *, jclass,
+                                                          jlong handle,
+                                                          jboolean b) {
+  auto *cfg_opt = reinterpret_cast<ROCKSDB_NAMESPACE::ConfigOptions *>(handle);
+  cfg_opt->mutable_options_only = static_cast<bool>(b);
 }
 
 /*

--- a/java/rocksjni/filter.cc
+++ b/java/rocksjni/filter.cc
@@ -19,6 +19,56 @@
 #include "rocksjni/portal.h"
 
 /*
+ * Class:     org_rocksdb_Filter
+ * Method:    createFilterFromString
+ * Signature: (Ljava/lang/String;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_org_rocksdb_Filter_createFilterFromString__Ljava_lang_String_2(JNIEnv* env,
+                                                                    jclass,
+                                                                    jstring s) {
+  return ROCKSDB_NAMESPACE::CustomizableJni::createSharedFromString<
+      const ROCKSDB_NAMESPACE::FilterPolicy, ROCKSDB_NAMESPACE::FilterPolicy>(
+      env, s);
+}
+
+/*
+ * Class:     org_rocksdb_Filter
+ * Method:    createFilterFromString
+ * Signature: (JLjava/lang/String;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_org_rocksdb_Filter_createFilterFromString__JLjava_lang_String_2(
+    JNIEnv* env, jclass, jlong handle, jstring s) {
+  return ROCKSDB_NAMESPACE::CustomizableJni::createSharedFromString<
+      const ROCKSDB_NAMESPACE::FilterPolicy, ROCKSDB_NAMESPACE::FilterPolicy>(
+      env, handle, s);
+}
+
+/*
+ * Class:     org_rocksdb_Filter
+ * Method:    getId
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_org_rocksdb_Filter_getId(JNIEnv* env, jobject,
+                                                        jlong jhandle) {
+  return ROCKSDB_NAMESPACE::CustomizableJni::getIdFromShared<
+      const ROCKSDB_NAMESPACE::FilterPolicy>(env, jhandle);
+}
+
+/*
+ * Class:     org_rocksdb_Filter
+ * Method:    isInstanceOf
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_rocksdb_Filter_isInstanceOf(JNIEnv* env,
+                                                                jobject,
+                                                                jlong jhandle,
+                                                                jstring s) {
+  return ROCKSDB_NAMESPACE::CustomizableJni::isSharedInstanceOf<
+      const ROCKSDB_NAMESPACE::FilterPolicy>(env, jhandle, s);
+}
+/*
  * Class:     org_rocksdb_BloomFilter
  * Method:    createBloomFilter
  * Signature: (DZ)J

--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -16,6 +16,7 @@
 #include <memory>
 #include <string>
 
+#include "include/org_rocksdb_MergeOperator.h"
 #include "include/org_rocksdb_StringAppendOperator.h"
 #include "include/org_rocksdb_UInt64AddOperator.h"
 #include "rocksdb/db.h"
@@ -27,6 +28,66 @@
 #include "rocksjni/cplusplus_to_java_convert.h"
 #include "rocksjni/portal.h"
 #include "utilities/merge_operators.h"
+
+/*
+ * Class:     org_rocksdb_MergeOperator
+ * Method:    createMergeOperatorFromString
+ * Signature: (Ljava/lang/String;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_org_rocksdb_MergeOperator_createMergeOperatorFromString__Ljava_lang_String_2(
+    JNIEnv* env, jclass, jstring s) {
+  return ROCKSDB_NAMESPACE::CustomizableJni::createSharedFromString<
+      ROCKSDB_NAMESPACE::MergeOperator>(env, s);
+}
+
+/*
+ * Class:     org_rocksdb_MergeOperator
+ * Method:    createMergeOperatorFromString
+ * Signature: (JLjava/lang/String;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_org_rocksdb_MergeOperator_createMergeOperatorFromString__JLjava_lang_String_2(
+    JNIEnv* env, jclass, jlong handle, jstring s) {
+  return ROCKSDB_NAMESPACE::CustomizableJni::createSharedFromString<
+      ROCKSDB_NAMESPACE::MergeOperator>(env, handle, s);
+}
+
+/*
+ * Class:     org_rocksdb_MergeOperator
+ * Method:    getId
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_org_rocksdb_MergeOperator_getId(JNIEnv* env,
+                                                               jobject,
+                                                               jlong jhandle) {
+  return ROCKSDB_NAMESPACE::CustomizableJni::getIdFromShared<
+      ROCKSDB_NAMESPACE::MergeOperator>(env, jhandle);
+}
+
+/*
+ * Class:     org_rocksdb_MergeOperator
+ * Method:    isInstanceOf
+ * Signature: (JLjava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_rocksdb_MergeOperator_isInstanceOf(
+    JNIEnv* env, jobject, jlong jhandle, jstring s) {
+  return ROCKSDB_NAMESPACE::CustomizableJni::isSharedInstanceOf<
+      ROCKSDB_NAMESPACE::MergeOperator>(env, jhandle, s);
+}
+
+/*
+ * Class:     org_rocksdb_MergeOperator
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_rocksdb_MergeOperator_disposeInternal(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* sptr_merge_op =
+      reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
+          jhandle);
+  delete sptr_merge_op;  // delete std::shared_ptr
+}
 
 /*
  * Class:     org_rocksdb_StringAppendOperator
@@ -57,20 +118,6 @@ jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator__Ljava
 }
 
 /*
- * Class:     org_rocksdb_StringAppendOperator
- * Method:    disposeInternal
- * Signature: (J)V
- */
-void Java_org_rocksdb_StringAppendOperator_disposeInternal(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
-                                                           jlong jhandle) {
-  auto* sptr_string_append_op =
-      reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
-          jhandle);
-  delete sptr_string_append_op;  // delete std::shared_ptr
-}
-
-/*
  * Class:     org_rocksdb_UInt64AddOperator
  * Method:    newSharedUInt64AddOperator
  * Signature: ()J
@@ -81,18 +128,4 @@ jlong Java_org_rocksdb_UInt64AddOperator_newSharedUInt64AddOperator(
       new std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>(
           ROCKSDB_NAMESPACE::MergeOperators::CreateUInt64AddOperator());
   return GET_CPLUSPLUS_POINTER(sptr_uint64_add_op);
-}
-
-/*
- * Class:     org_rocksdb_UInt64AddOperator
- * Method:    disposeInternal
- * Signature: (J)V
- */
-void Java_org_rocksdb_UInt64AddOperator_disposeInternal(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
-                                                        jlong jhandle) {
-  auto* sptr_uint64_add_op =
-      reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
-          jhandle);
-  delete sptr_uint64_add_op;  // delete std::shared_ptr
 }

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -8657,6 +8657,8 @@ class FileOperationInfoJni : public JavaClass {
                             "(Ljava/lang/String;JJJJLorg/rocksdb/Status;)V");
   }
 };
+
+// Class used to manage Customizable objects and their associated methods.
 class CustomizableJni : public JavaClass {
  public:
   // Creates a new shared<R> via T::CreateFromString using the input

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -8657,5 +8657,91 @@ class FileOperationInfoJni : public JavaClass {
                             "(Ljava/lang/String;JJJJLorg/rocksdb/Status;)V");
   }
 };
+class CustomizableJni : public JavaClass {
+ public:
+  // Creates a new shared<R> via T::CreateFromString using the input
+  // ConfigOptions and options string.
+  template <typename R, typename T>
+  static jlong createSharedFromString(
+      const ROCKSDB_NAMESPACE::ConfigOptions& config, JNIEnv* env, jstring s) {
+    static const int kStatusError = -2;
+    static const int kArgumentError = -3;
+    const char* opts_str = env->GetStringUTFChars(s, nullptr);
+    if (opts_str == nullptr) {
+      // exception thrown: OutOfMemoryError
+      return kArgumentError;
+    }
+    std::shared_ptr<R>* result = new std::shared_ptr<R>();
+    auto status = T::CreateFromString(config, opts_str, result);
+    env->ReleaseStringUTFChars(s, opts_str);
+    if (status.ok()) {
+      return GET_CPLUSPLUS_POINTER(result);
+    } else {
+      delete result;
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
+      return kStatusError;
+    }
+  }
+
+  // Creates a new shared<R> via T::CreateFromString using the input options
+  // string. This signature ignores unsupported and unknown options and invokes
+  // prepare options
+  template <typename R, typename T>
+  static jlong createSharedFromString(JNIEnv* env, jstring s) {
+    ROCKSDB_NAMESPACE::ConfigOptions cfg_opts;
+    cfg_opts.ignore_unsupported_options = false;
+    cfg_opts.ignore_unknown_options = false;
+    cfg_opts.invoke_prepare_options = true;
+    return createSharedFromString<R, T>(cfg_opts, env, s);
+  }
+
+  // Creates a new shared<T> via T::CreateFromString using the input options
+  // string. This signature ignores unsupported and unknown options and invokes
+  // prepare options
+  template <typename T>
+  static jlong createSharedFromString(JNIEnv* env, jstring s) {
+    return createSharedFromString<T, T>(env, s);
+  }
+
+  // Creates a new shared<R> via T::CreateFromString using the input
+  // ConfigOptions handle and options string.
+  template <typename R, typename T>
+  static jlong createSharedFromString(JNIEnv* env, jlong handle, jstring s) {
+    auto* cfg_opts =
+        reinterpret_cast<ROCKSDB_NAMESPACE::ConfigOptions*>(handle);
+    return createSharedFromString<R, T>(*cfg_opts, env, s);
+  }
+
+  // Creates a new shared<T> via T::CreateFromString using the input
+  // ConfigOptions handle and options string.
+  template <typename T>
+  static jlong createSharedFromString(JNIEnv* env, jlong handle, jstring s) {
+    return createSharedFromString<T, T>(env, handle, s);
+  }
+
+  // Invokes and returns GetId on the shared<T> Customizable from the input
+  // handle
+  template <typename T>
+  static jstring getIdFromShared(JNIEnv* env, jlong handle) {
+    auto custom = reinterpret_cast<std::shared_ptr<T>*>(handle);
+    return env->NewStringUTF((*custom)->GetId().c_str());
+  }
+
+  // Returns true if the shared<T> Customizable handle is an InstanceOf the
+  // input string.
+  template <typename T>
+  static jboolean isSharedInstanceOf(JNIEnv* env, jlong handle, jstring s) {
+    const char* name = env->GetStringUTFChars(s, nullptr);
+    if (name == nullptr) {
+      // exception thrown: OutOfMemoryError
+      return false;
+    }
+    auto custom = reinterpret_cast<std::shared_ptr<T>*>(handle);
+    auto result = static_cast<jboolean>((*custom)->IsInstanceOf(name));
+    env->ReleaseStringUTFChars(s, name);
+    return result;
+  }
+};
+
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // JAVA_ROCKSJNI_PORTAL_H_

--- a/java/src/main/java/org/rocksdb/CassandraValueMergeOperator.java
+++ b/java/src/main/java/org/rocksdb/CassandraValueMergeOperator.java
@@ -20,6 +20,4 @@ public class CassandraValueMergeOperator extends MergeOperator {
 
     private native static long newSharedCassandraValueMergeOperator(
         int gcGracePeriodInSeconds, int limit);
-
-    @Override protected final native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/ConfigOptions.java
+++ b/java/src/main/java/org/rocksdb/ConfigOptions.java
@@ -18,12 +18,31 @@ public class ConfigOptions extends RocksObject {
     super(newConfigOptions());
   }
 
+  public ConfigOptions(boolean unknown, boolean unsupported) {
+    super(newConfigOptions(unknown, unsupported));
+  }
+
   public ConfigOptions setDelimiter(final String delimiter) {
     setDelimiter(nativeHandle_, delimiter);
     return this;
   }
   public ConfigOptions setIgnoreUnknownOptions(final boolean ignore) {
     setIgnoreUnknownOptions(nativeHandle_, ignore);
+    return this;
+  }
+
+  public ConfigOptions setIgnoreUnsupportedOptions(final boolean ignore) {
+    setIgnoreUnsupportedOptions(nativeHandle_, ignore);
+    return this;
+  }
+
+  public ConfigOptions setInvokePrepareOptions(final boolean prepare) {
+    setInvokePrepareOptions(nativeHandle_, prepare);
+    return this;
+  }
+
+  public ConfigOptions setMutableOptionsOnly(final boolean only) {
+    setMutableOptionsOnly(nativeHandle_, only);
     return this;
   }
 
@@ -45,9 +64,13 @@ public class ConfigOptions extends RocksObject {
   @Override protected final native void disposeInternal(final long handle);
 
   private native static long newConfigOptions();
+  private native static long newConfigOptions(boolean unknown, boolean unsupported);
   private native static void setEnv(final long handle, final long envHandle);
   private native static void setDelimiter(final long handle, final String delimiter);
   private native static void setIgnoreUnknownOptions(final long handle, final boolean ignore);
+  private native static void setIgnoreUnsupportedOptions(final long handle, final boolean ignore);
+  private native static void setInvokePrepareOptions(final long handle, final boolean prepare);
+  private native static void setMutableOptionsOnly(final long handle, final boolean only);
   private native static void setInputStringsEscaped(final long handle, final boolean escaped);
   private native static void setSanityLevel(final long handle, final byte level);
 }

--- a/java/src/main/java/org/rocksdb/Filter.java
+++ b/java/src/main/java/org/rocksdb/Filter.java
@@ -13,7 +13,31 @@ package org.rocksdb;
  * DB::Get() call.
  */
 //TODO(AR) should be renamed FilterPolicy
-public abstract class Filter extends RocksObject {
+public class Filter extends RocksObject {
+  /**
+   * Creates a new FilterPolicy based on the input value string and returns the
+   * result. The value might be an ID, and ID with properties, or an old-style
+   * policy string. The value describes the FilterPolicy being created.
+   * For BloomFilters, value may be a ":"-delimited value of the form:
+   * "bloomfilter:[bits_per_key]", e.g. ""bloomfilter:4"
+   * The above string is equivalent to calling NewBloomFilterPolicy(4).
+   * Creates a new Filter based on the input opts string
+   * @param opts The input string stating the name of the policy and its parameters
+   */
+  public static Filter createFromString(final String opts) throws RocksDBException {
+    return new Filter(createFilterFromString(opts));
+  }
+
+  /**
+   * Creates a new FilterPolicy based on the input value string and returns the
+   * result.
+   * @param cfgOpts Controls how the filter is created
+   * @param opts The input string stating the name of the policy and its parameters
+   */
+  public static Filter createFromString(final ConfigOptions cfgOpts, final String opts)
+      throws RocksDBException {
+    return new Filter(createFilterFromString(cfgOpts.nativeHandle_, opts));
+  }
 
   protected Filter(final long nativeHandle) {
     super(nativeHandle);
@@ -31,6 +55,21 @@ public abstract class Filter extends RocksObject {
     disposeInternal(nativeHandle_);
   }
 
+  public String getId() {
+    assert (isOwningHandle());
+    return getId(nativeHandle_);
+  }
+
+  public boolean isInstanceOf(String name) {
+    assert (isOwningHandle());
+    return isInstanceOf(nativeHandle_, name);
+  }
+
   @Override
   protected final native void disposeInternal(final long handle);
+  protected native static long createFilterFromString(final String opts) throws RocksDBException;
+  protected native static long createFilterFromString(final long cfgHandle, final String opts)
+      throws RocksDBException;
+  private native String getId(long handle);
+  private native boolean isInstanceOf(long handle, String name);
 }

--- a/java/src/main/java/org/rocksdb/MergeOperator.java
+++ b/java/src/main/java/org/rocksdb/MergeOperator.java
@@ -11,8 +11,63 @@ package org.rocksdb;
  * two merge operands held under the same key in order to obtain a single
  * value.
  */
-public abstract class MergeOperator extends RocksObject {
-    protected MergeOperator(final long nativeHandle) {
-        super(nativeHandle);
-    }
+public class MergeOperator extends RocksObject {
+  /**
+   * Creates a new MergeOperator based on the input value string and returns the
+   * result. The value might be an ID, or ID with properties, or an old-style
+   * policy string.
+   * Creates a new MergeOperator based on the input opts string
+   * @param opts The input string stating the name of the operator and its parameters
+   * @return The MergeOperator represented by the input opts
+   */
+  public static MergeOperator createFromString(final String opts) throws RocksDBException {
+    return new MergeOperator(createMergeOperatorFromString(opts));
+  }
+
+  /**
+   * Creates a new MergeOperator based on the input value string and returns the
+   * result.
+   * @param cfgOpts Controls how the MergeOperator is created
+   * @param opts The input string stating the name of the merge operator and its parameters
+   * @return The MergeOperator represented by the input opts
+   */
+  public static MergeOperator createFromString(final ConfigOptions cfgOpts, final String opts)
+      throws RocksDBException {
+    return new MergeOperator(createMergeOperatorFromString(cfgOpts.nativeHandle_, opts));
+  }
+
+  protected MergeOperator(final long nativeHandle) {
+    super(nativeHandle);
+  }
+
+  /**
+   * Deletes underlying C++ filter pointer.
+   *
+   * Note that this function should be called only after all
+   * RocksDB instances referencing the filter are closed.
+   * Otherwise an undefined behavior will occur.
+   */
+  @Override
+  protected void disposeInternal() {
+    disposeInternal(nativeHandle_);
+  }
+
+  public String getId() {
+    assert (isOwningHandle());
+    return getId(nativeHandle_);
+  }
+
+  public boolean isInstanceOf(String name) {
+    assert (isOwningHandle());
+    return isInstanceOf(nativeHandle_, name);
+  }
+
+  protected native static long createMergeOperatorFromString(final String opts)
+      throws RocksDBException;
+  protected native static long createMergeOperatorFromString(
+      final long cfgHandle, final String opts) throws RocksDBException;
+  private native String getId(long handle);
+  private native boolean isInstanceOf(long handle, String name);
+
+  @Override protected final native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/StringAppendOperator.java
+++ b/java/src/main/java/org/rocksdb/StringAppendOperator.java
@@ -25,5 +25,4 @@ public class StringAppendOperator extends MergeOperator {
 
     private native static long newSharedStringAppendOperator(final char delim);
     private native static long newSharedStringAppendOperator(final String delim);
-    @Override protected final native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/UInt64AddOperator.java
+++ b/java/src/main/java/org/rocksdb/UInt64AddOperator.java
@@ -15,5 +15,4 @@ public class UInt64AddOperator extends MergeOperator {
     }
 
     private native static long newSharedUInt64AddOperator();
-    @Override protected final native void disposeInternal(final long handle);
 }

--- a/java/src/test/java/org/rocksdb/FilterTest.java
+++ b/java/src/test/java/org/rocksdb/FilterTest.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -33,7 +35,29 @@ public class FilterTest {
       try(final Filter bloomFilter = new BloomFilter(10, false)) {
         blockConfig.setFilterPolicy(bloomFilter);
         options.setTableFormatConfig(blockConfig);
+        assertThat(bloomFilter.isInstanceOf("bloomfilter")).isTrue();
+        assertThat(bloomFilter.isInstanceOf("ribbonfilter")).isFalse();
       }
+    }
+  }
+
+  @Test
+  public void createFromString() throws RocksDBException {
+    final BlockBasedTableConfig blockConfig = new BlockBasedTableConfig();
+    try (final Options options = new Options()) {
+      try (final Filter filter = Filter.createFromString("ribbonfilter:20")) {
+        assertThat(filter.getId()).startsWith("ribbonfilter");
+        assertThat(filter.isInstanceOf("ribbonfilter")).isTrue();
+        assertThat(filter.isInstanceOf("bloomfilter")).isFalse();
+        blockConfig.setFilterPolicy(filter);
+        options.setTableFormatConfig(blockConfig);
+      }
+    }
+  }
+
+  @Test(expected = RocksDBException.class)
+  public void createUnknownFromString() throws RocksDBException {
+    try (final Filter filter = Filter.createFromString("unknown")) {
     }
   }
 }

--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -462,4 +462,40 @@ public class MergeTest {
       opt.setMergeOperatorName(null);
     }
   }
+
+  @Test
+  public void createFromString() throws RocksDBException {
+    try (final MergeOperator mergeOp = MergeOperator.createFromString("put")) {
+      assertThat(mergeOp.isInstanceOf("PutOperator")).isTrue();
+      assertThat(mergeOp.isInstanceOf("put")).isTrue();
+      assertThat(mergeOp.isInstanceOf("put_v1")).isFalse();
+    }
+    try (final MergeOperator mergeOp = MergeOperator.createFromString("put_v1")) {
+      assertThat(mergeOp.isInstanceOf("PutOperator")).isTrue();
+      assertThat(mergeOp.isInstanceOf("put_v1")).isTrue();
+      assertThat(mergeOp.isInstanceOf("put")).isFalse();
+    }
+    try (final MergeOperator mergeOp = MergeOperator.createFromString("max")) {
+      assertThat(mergeOp.isInstanceOf("max")).isTrue();
+      assertThat(mergeOp.isInstanceOf("MaxOperator")).isTrue();
+      assertThat(mergeOp.getId()).isEqualTo("MaxOperator");
+    }
+    try (final MergeOperator mergeOp = MergeOperator.createFromString("uint64add")) {
+      assertThat(mergeOp.isInstanceOf("uint64add")).isTrue();
+      assertThat(mergeOp.isInstanceOf("UInt64AddOperator")).isTrue();
+      assertThat(mergeOp.getId()).isEqualTo("UInt64AddOperator");
+    }
+    try (final MergeOperator mergeOp =
+             MergeOperator.createFromString("id=stringappend; delimiter=;")) {
+      assertThat(mergeOp.isInstanceOf("stringappend")).isTrue();
+      assertThat(mergeOp.isInstanceOf("StringAppendOperator")).isTrue();
+      assertThat(mergeOp.getId()).isEqualTo("StringAppendOperator");
+    }
+  }
+
+  @Test(expected = RocksDBException.class)
+  public void unknownMergeOperatorByNameColumnFamilyOptions() throws RocksDBException {
+    try (final MergeOperator mergeOp = MergeOperator.createFromString("unknown")) {
+    }
+  }
 }


### PR DESCRIPTION
This builds on #11205 and adds CreateFromString methods to the Java MergeOperator.  Tests were also added and some extraneous code for deleting MergeOperator classes was centralized.