### PR TITLE
Disable combination of timestamp and blobs in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -661,6 +661,7 @@ def gen_cmd_params(args):
     if (
         not args.test_best_efforts_recovery
         and not args.test_tiered_storage
+        and not args.enable_ts
         and random.choice([0] * 9 + [1]) == 1
     ):
         params.update(blob_params)


### PR DESCRIPTION
Summary: Invalid combination

Test Plan: manual testing