### PR TITLE
Re-add memory_allocator.h include from cache.h

### DIFF
--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -16,12 +16,12 @@
 #include <string>
 
 #include "rocksdb/compression_type.h"
+#include "rocksdb/memory_allocator.h"
 
 namespace ROCKSDB_NAMESPACE {
 
 class Cache;  // defined in advanced_cache.h
 struct ConfigOptions;
-class MemoryAllocator;
 class SecondaryCache;
 
 // Classifications of block cache entries.


### PR DESCRIPTION
Summary: Enough users of NewJemallocNodumpAllocator() with cache.h to justify keeping it. (Reverting one little part of #11192)

Test Plan: CI