### PR TITLE
Add missing override keyword in env_win.h functions

### DIFF
--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -97,7 +97,7 @@ class WinClock : public SystemClock {
 
   Status GetCurrentTime(int64_t* unix_time) override;
   // Converts seconds-since-Jan-01-1970 to a printable string
-  virtual std::string TimeToString(uint64_t time) override;
+  std::string TimeToString(uint64_t time) override;
 
   uint64_t GetPerfCounterFrequency() const { return perf_counter_frequency_; }
 

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -97,7 +97,7 @@ class WinClock : public SystemClock {
 
   Status GetCurrentTime(int64_t* unix_time) override;
   // Converts seconds-since-Jan-01-1970 to a printable string
-  virtual std::string TimeToString(uint64_t time);
+  virtual std::string TimeToString(uint64_t time) override;
 
   uint64_t GetPerfCounterFrequency() const { return perf_counter_frequency_; }
 
@@ -116,7 +116,7 @@ class WinFileSystem : public FileSystem {
   ~WinFileSystem() {}
   static const char* kClassName() { return "WinFS"; }
   const char* Name() const override { return kClassName(); }
-  const char* NickName() const { return kDefaultName(); }
+  const char* NickName() const override { return kDefaultName(); }
 
   static size_t GetSectorSize(const std::string& fname);
   size_t GetPageSize() const { return page_size_; }


### PR DESCRIPTION
I couldn't figure out why this causes failures in our 8.0 release to fbcode while this issue appears to not be new in 8.0. Anyways, we can add the missing `override` keywords to these functions as the compiler insists.