### PR TITLE
Enable moving a string or PinnableSlice into PinnableWideColumns

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -1078,7 +1078,7 @@ static bool SaveValue(void* arg, const char* entry) {
                 *(s->value) = std::move(result);
               } else {
                 assert(s->columns);
-                s->columns->SetPlainValue(result);
+                s->columns->SetPlainValue(std::move(result));
               }
             }
           }
@@ -1152,7 +1152,7 @@ static bool SaveValue(void* arg, const char* entry) {
                 /* op_failure_scope */ nullptr);
 
             if (s->status->ok()) {
-              *(s->status) = s->columns->SetWideColumnValue(result);
+              *(s->status) = s->columns->SetWideColumnValue(std::move(result));
             }
           }
         } else if (s->value) {
@@ -1200,7 +1200,7 @@ static bool SaveValue(void* arg, const char* entry) {
                 *(s->value) = std::move(result);
               } else {
                 assert(s->columns);
-                s->columns->SetPlainValue(result);
+                s->columns->SetPlainValue(std::move(result));
               }
             }
           } else {
@@ -1249,7 +1249,7 @@ static bool SaveValue(void* arg, const char* entry) {
                 *(s->value) = std::move(result);
               } else {
                 assert(s->columns);
-                s->columns->SetPlainValue(result);
+                s->columns->SetPlainValue(std::move(result));
               }
             }
           }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2233,7 +2233,7 @@ void Version::MultiGetBlob(
           range.AddValueSize(key_context->value->size());
         } else {
           assert(key_context->columns);
-          key_context->columns->SetPlainValue(blob.result);
+          key_context->columns->SetPlainValue(std::move(blob.result));
           range.AddValueSize(key_context->columns->serialized_size());
         }
 
@@ -2390,8 +2390,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
             *value = std::move(result);
           } else {
             assert(columns);
-            columns->Reset();
-            columns->SetPlainValue(result);
+            columns->SetPlainValue(std::move(result));
           }
         }
 
@@ -2445,7 +2444,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
           value->PinSelf();
         } else {
           assert(columns != nullptr);
-          columns->SetPlainValue(result);
+          columns->SetPlainValue(std::move(result));
         }
       }
     }
@@ -2696,7 +2695,7 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
         range->AddValueSize(iter->value->size());
       } else {
         assert(iter->columns);
-        iter->columns->SetPlainValue(result);
+        iter->columns->SetPlainValue(std::move(result));
         range->AddValueSize(iter->columns->serialized_size());
       }
 

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -489,7 +489,7 @@ void GetContext::Merge(const Slice* value) {
   }
 
   assert(columns_);
-  columns_->SetPlainValue(result);
+  columns_->SetPlainValue(std::move(result));
 }
 
 void GetContext::MergeWithEntity(Slice entity) {
@@ -552,7 +552,7 @@ void GetContext::MergeWithEntity(Slice entity) {
 
   {
     assert(columns_);
-    const Status s = columns_->SetWideColumnValue(result);
+    const Status s = columns_->SetWideColumnValue(std::move(result));
     if (!s.ok()) {
       state_ = kCorrupt;
       return;


### PR DESCRIPTION
Summary:
This makes it possible to eliminate some copies in `GetEntity` / `MultiGetEntity`,
in particular when `Merge`s or blobs are involved.

Test Plan:
`make check`