### PR TITLE
Fix WBM concurrency control, Add SetAllowStall(), Cleanup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### New Features
+* Allow setting `WriteBufferManager::allow_stall` in runtime by `SetAllowStall()`, which was previously fixed after passed into `WriteBufferManager`'s constructor
 
 ## 8.1.0 (03/18/2023)
 ### Behavior changes

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1200,17 +1200,13 @@ class DBImpl : public DB {
   // state_ is changed accordingly.
   class WBMStallInterface : public StallInterface {
    public:
-    enum State {
-      BLOCKED = 0,
-      RUNNING,
-    };
 
     WBMStallInterface() : state_cv_(&state_mutex_) {
       MutexLock lock(&state_mutex_);
       state_ = State::RUNNING;
     }
 
-    void SetState(State state) {
+    void SetState(State state) override {
       MutexLock lock(&state_mutex_);
       state_ = state;
     }
@@ -1871,9 +1867,9 @@ class DBImpl : public DB {
   Status DelayWrite(uint64_t num_bytes, WriteThread& write_thread,
                     const WriteOptions& write_options);
 
-  // Begin stalling of writes when memory usage increases beyond a certain
-  // threshold.
-  void WriteBufferManagerStallWrites();
+  // If stall conditions are met, begin stalling of writes with help of
+  // `WriteBufferManager`
+  void MaybeWriteBufferManagerStallWrites();
 
   Status ThrottleLowPriWritesIfNeeded(const WriteOptions& write_options,
                                       WriteBatch* my_batch);

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -116,6 +116,7 @@ class WriteBufferManager final {
   void SetAllowStall(bool new_allow_stall);
 
   // WARNING: Should only be called from write thread
+  // WARNING: Should only be called by RocksDB internally
   bool ShouldFlush() const;
 
   // Returns true if stall conditions are met.
@@ -123,7 +124,7 @@ class WriteBufferManager final {
   // size > 0) AND total memory usage accounted by this WriteBufferManager
   // exceeds the memory limit.
   //
-  // WARNING: Should only be called by RocksDB internally .
+  // WARNING: Should only be called by RocksDB internally.
   //
   // WARNING: If running without syncronization with any functions that could
   // change the stall conditions above, this function might not return the

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -22,6 +22,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 class CacheReservationManager;
+
 // Interface to block and signal DB instances, intended for RocksDB
 // internal use only. Each DB instance contains ptr to StallInterface.
 class StallInterface {
@@ -148,11 +149,12 @@ class WriteBufferManager final {
   // WARNING: Should only be called by RocksDB internally.
   void FreeMem(size_t mem);
 
-  // Return true if stall conditions have been met and WriteBufferManager has
-  // done its work to begin write stall. Return false otherwise.
+  // If stall conditions are met, WriteBufferManager
+  // will prepare for write stall (including changing `wbm_stall`'s state
+  // to be `State::Blocked`). Otherwise, this function does nothing.
   //
   // WARNING: Should only be called by RocksDB internally.
-  bool MaybeBeginWriteStall(StallInterface* wbm_stall);
+  void MaybeBeginWriteStall(StallInterface* wbm_stall);
 
   // WARNING: Should only be called by RocksDB internally.
   void RemoveDBFromQueue(StallInterface* wbm_stall);


### PR DESCRIPTION
**Context:**
Allow changing `WBM::allow_stall_` in runtime gives flexibility to users. In order to do that, we need to close a few gaps in WBM's concurrency control so this parameter change could happen concurrently.

**Summary:**
- Add synchronization to ALL WBM's data members as they are all part of the following decisions. Previously the dynamic-changeable `buffer_size_` from other thread was not protected by such synchronization. In particular, use one instead of a few internal locks to do so.
```
Write => Optionally charge memory to cache => check stall condition (allow_stall, enable(), buffer_size vs memory usage)  => if stalled, create stall and wait & ShouldFlush() returns true => flush will decrease memory usage (Optionally release memory from cache) => stall condition no longer meets =>  notify waiting write to stop stalling
```
- Add new function `SetAllowStall()`
- Misc:
  - A few cleanups in the logic - see PR conversation. 
  - Clarify class/function comments about concurrency; Made some public functions but should only called by RocksDB internal private

**Test:**
- New UT
- Performance test 
```
./db_bench -seed=1679014417652004 -db=/dev/shm/testdb/ -statistics=false -benchmarks="fillseq[-X60]" -key_size=32 -value_size=512 -num=100000 -db_write_buffer_size=655 -target_file_size_base=655 -disable_auto_compactions=false -compression_type=none -bloom_bits=3
```
pre-change: `fillseq [AVG 38 runs] : 960 (± 276) ops/sec;    0.5 (± 0.1) MB/sec`
post-change (no regression but a slight improvement): `fillseq [AVG 38 runs] : 997 (± 298) ops/sec;    0.5 (± 0.2) MB/sec`


