### PR TITLE
Add support for parameters setting related to async_io benchmarks

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -195,7 +195,6 @@ function init_arguments {
   NUM_LOW_PRI_THREADS=${NUM_LOW_PRI_THREADS:-16}
   DELETE_TEST_PATH=${DELETE_TEST_PATH:-0}
   SEEK_NEXTS=${SEEK_NEXTS:-10}
-  SEEK_NEXTS_ASYNCIO=${SEEK_NEXTS_ASYNC_IO:-10}
   SEED=${SEED:-$( date +%s )}
   MULTIREAD_BATCH_SIZE=${MULTIREAD_BATCH_SIZE:-128}
   MULTIREAD_STRIDE=${MULTIREAD_STRIDE:-12}
@@ -240,10 +239,12 @@ function run_db_bench {
   USE_EXISTING_DB=${4:-1}
   UPDATE_REPORT=${5:-1}
   async_io=${6:-false}
-
   seek_nexts=$SEEK_NEXTS
+
   if [ "$async_io" == "true" ]; then
-    seek_nexts=$SEEK_NEXTS_ASYNCIO
+    if ! [ -z "$SEEK_NEXTS_ASYNC_IO" ]; then
+      seek_nexts=$SEEK_NEXTS_ASYNC_IO
+    fi
   fi
 
 
@@ -289,7 +290,14 @@ function run_db_bench {
       --multiread_batched=true \
       --batch_size=$MULTIREAD_BATCH_SIZE \
       --multiread_stride=$MULTIREAD_STRIDE \
-      --async_io=$async_io 2>&1"
+      --async_io=$async_io"
+
+  if [ "$async_io" == "true" ]; then
+    db_bench_cmd="$db_bench_cmd $(set_async_io_parameters) "
+  fi
+
+  db_bench_cmd=" $db_bench_cmd 2>&1"
+
   if ! [ -z "$REMOTE_USER_AT_HOST" ]; then
     echo "Running benchmark remotely on $REMOTE_USER_AT_HOST"
     db_bench_cmd="$SSH $REMOTE_USER_AT_HOST '$db_bench_cmd'"
@@ -302,6 +310,24 @@ function run_db_bench {
   if [ $UPDATE_REPORT -ne 0 ]; then
     update_report "$1" "$RESULT_PATH/$1" $ops $threads
   fi
+}
+
+function set_async_io_parameters {
+  options=" --duration=800"
+  # Below parameters are used in case of async_io only.
+  # 1. If you want to run below parameters for all benchmarks, it should be
+  #    specify in OPTIONS_FILE instead of exporting them.
+  # 2. Below exported var takes precedence over OPTIONS_FILE.
+  if ! [ -z "$MAX_READAHEAD_SIZE" ]; then
+    options="$options --max_auto_readahead_size=$MAX_READAHEAD_SIZE "
+  fi
+  if ! [ -z "$INITIAL_READAHEAD_SIZE" ]; then
+    options="$options --initial_auto_readahead_size=$INITIAL_READAHEAD_SIZE "
+  fi
+  if ! [ -z "$NUM_READS_FOR_READAHEAD_SIZE" ]; then
+    options="$options --num_file_reads_for_auto_readahead=$NUM_READS_FOR_READAHEAD_SIZE "
+  fi
+  echo $options
 }
 
 function build_checkpoint {
@@ -423,7 +449,7 @@ function run_local {
 }
 
 function setup_options_file {
-  if ! [ -z "$OPTIONS_FILE" ]; then
+ if ! [ -z "$OPTIONS_FILE" ]; then
     if ! [ -z "$REMOTE_USER_AT_HOST" ]; then
       options_file="$DB_BENCH_DIR/OPTIONS_FILE"
       run_local "$SCP $OPTIONS_FILE $REMOTE_USER_AT_HOST:$options_file"


### PR DESCRIPTION
Summary: Provide support in benchmark regression to use different options to be used in async_io benchamark only - "$`MAX_READAHEAD_SIZE`", $`INITIAL_READAHEAD_SIZE`", "$`NUM_READS_FOR_READAHEAD_SIZE`".
If user wants to run set these parameters for all benchmarks then these parameters need to be set in OPTION file instead.

Test Plan: Ran manually

Reviewers:

Subscribers:

Tasks:

Tags: