### PR TITLE
Avoid superfluous reads in point lookups for a non-existent key

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2896,6 +2896,63 @@ TEST_P(DBMultiGetRowCacheTest, MultiGetBatched) {
 INSTANTIATE_TEST_CASE_P(DBMultiGetRowCacheTest, DBMultiGetRowCacheTest,
                         testing::Values(true, false));
 
+TEST_F(DBBasicTest, PointLookupNoSuperfluousReads) {
+  env_->count_random_reads_ = true;
+
+  class MyFlushBlockPolicy : public FlushBlockPolicy {
+   public:
+    explicit MyFlushBlockPolicy() {}
+
+    bool Update(const Slice& /*key*/, const Slice& /*value*/) override {
+      // Flush after every key - 1 key per data block
+      static bool first_key = true;
+      if (first_key) {
+        first_key = false;
+        return false;
+      }
+      return true;
+    }
+  };
+
+  class MyFlushBlockPolicyFactory : public FlushBlockPolicyFactory {
+   public:
+    MyFlushBlockPolicyFactory() {}
+
+    virtual const char* Name() const override {
+      return "MyFlushBlockPolicyFactory";
+    }
+
+    virtual FlushBlockPolicy* NewFlushBlockPolicy(
+        const BlockBasedTableOptions& /*table_options*/,
+        const BlockBuilder& /*data_block_builder*/) const override {
+      return new MyFlushBlockPolicy();
+    }
+  };
+
+  BlockBasedTableOptions bbto;
+  bbto.flush_block_policy_factory.reset(new MyFlushBlockPolicyFactory());
+  bbto.no_block_cache = true;
+  Options options = CurrentOptions();
+  options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+
+  Reopen(options);
+
+  Put("aa", "val_aa");
+  Put("cc", "val_cc");
+  Flush();
+
+  env_->random_read_counter_.Reset();
+  ASSERT_EQ(Get("ab"), "NOT_FOUND");
+  ASSERT_EQ(env_->random_read_counter_.Read(), 1);
+
+  env_->random_read_counter_.Reset();
+  std::vector<std::string> vals = MultiGet({"ab", "ac"});
+  ASSERT_EQ(vals[0], "NOT_FOUND");
+  ASSERT_EQ(vals[1], "NOT_FOUND");
+  ASSERT_EQ(env_->random_read_counter_.Read(), 1);
+  Destroy(options);
+}
+
 TEST_F(DBBasicTest, GetAllKeyVersions) {
   Options options = CurrentOptions();
   options.env = env_;

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -527,11 +527,18 @@ class DataBlockIter final : public BlockIter<Slice> {
     return value_;
   }
 
+  // SeekForGet returns true if the target key may exist in the block.
+  // There could be false positives. It returns false if the target key
+  // is definitely not in the block.
   inline bool SeekForGet(const Slice& target) {
     if (!data_block_hash_index_) {
       SeekImpl(target);
       UpdateKey();
-      return true;
+      // The iterator could be valid and still result in a false positive.
+      // This is because Seek positions the iterator at the first key >=
+      // the target key. Rather than add an extra key comparison here, we'll
+      // let the caller call SaveValue() to take care of it.
+      return Valid() ? true : false;
     }
     bool res = SeekForGetImpl(target);
     UpdateKey();


### PR DESCRIPTION
Sometimes, a point lookup (Get or async MultiGet or sync MultiGet) might perform unnecessary reads of data blocks, resulting in throw away work. This happens when all of the following conditions are met -
1. Bloom filter false positive for a key in a SST file
2. The SST file was created with `index_shortening != IndexShorteningMode::kNoShortening`
3. The lookup key <= the index separator, and the lookup key > last key in the data block

When the above conditions are met, the data block iterator will be invalid and the point lookup tries to move to the next data block. This is not necessary, since the keys in the next data block will be > the lookup key.an invalid iterator means the key was not found.

Test plan:
Add a new unit test in db_basic_test and verify it fails without the fix 