### PR TITLE
Add new stat rocksdb.table.open.prefetch.tail.read.bytes, rocksdb.table.open.prefetch.tail.{miss|hit}

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 ### New Features
 * Add statistics rocksdb.secondary.cache.filter.hits, rocksdb.secondary.cache.index.hits, and rocksdb.secondary.cache.filter.hits
 * Added a new PerfContext counter `internal_merge_point_lookup_count` which tracks the number of Merge operands applied while serving point lookup queries.
+* Add new statistics rocksdb.table.prefetch.tail.read.bytes to report number of bytes read in prefetching contents from the end of SST table during table open
 
 ## 8.0.0 (02/19/2023)
 ### Behavior changes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,7 @@
 ### New Features
 * Add statistics rocksdb.secondary.cache.filter.hits, rocksdb.secondary.cache.index.hits, and rocksdb.secondary.cache.filter.hits
 * Added a new PerfContext counter `internal_merge_point_lookup_count` which tracks the number of Merge operands applied while serving point lookup queries.
-* Add new statistics rocksdb.table.prefetch.tail.read.bytes to report number of bytes read in prefetching contents from the end of SST table during table open
+* Add new statistics rocksdb.table.open.prefetch.tail.read.bytes, rocksdb.table.open.prefetch.tail.{miss|hit}
 
 ## 8.0.0 (02/19/2023)
 ### Behavior changes

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -162,6 +162,9 @@ Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
 
   Status s = Read(opts, reader, rate_limiter_priority, read_len, chunk_len,
                   rounddown_offset, curr_);
+  if (s.ok() && usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+    RecordInHistogram(stats_, TABLE_OPEN_PREFETCH_TAIL_READ_BYTES, read_len);
+  }
   return s;
 }
 
@@ -612,7 +615,13 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
   if (track_min_offset_ && offset < min_offset_read_) {
     min_offset_read_ = static_cast<size_t>(offset);
   }
-  if (!enable_ || (offset < bufs_[curr_].offset_)) {
+  if (!enable_) {
+    return false;
+  }
+  if (offset < bufs_[curr_].offset_) {
+    if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+      RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+    }
     return false;
   }
 
@@ -635,6 +644,9 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
           if (!IsEligibleForPrefetch(offset, n)) {
             // Ignore status as Prefetch is not called.
             s.PermitUncheckedError();
+            if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+              RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+            }
             return false;
           }
         }
@@ -648,10 +660,16 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
 #ifndef NDEBUG
         IGNORE_STATUS_IF_ERROR(s);
 #endif
+        if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+          RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+        }
         return false;
       }
       readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
     } else {
+      if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+        RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+      }
       return false;
     }
   }
@@ -659,6 +677,9 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
 
   uint64_t offset_in_buffer = offset - bufs_[curr_].offset_;
   *result = Slice(bufs_[curr_].buffer_.BufferStart() + offset_in_buffer, n);
+  if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+    RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_HIT);
+  }
   return true;
 }
 
@@ -684,11 +705,17 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
       bufs_[curr_].buffer_.Clear();
       bufs_[curr_ ^ 1].buffer_.Clear();
       explicit_prefetch_submitted_ = false;
+      if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+        RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+      }
       return false;
     }
   }
 
   if (!explicit_prefetch_submitted_ && offset < bufs_[curr_].offset_) {
+    if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+      RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+    }
     return false;
   }
 
@@ -714,6 +741,9 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
         if (!IsEligibleForPrefetch(offset, n)) {
           // Ignore status as Prefetch is not called.
           s.PermitUncheckedError();
+          if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+            RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+          }
           return false;
         }
       }
@@ -729,10 +759,16 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
 #ifndef NDEBUG
         IGNORE_STATUS_IF_ERROR(s);
 #endif
+        if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+          RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+        }
         return false;
       }
       prefetched = explicit_prefetch_submitted_ ? false : true;
     } else {
+      if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+        RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
+      }
       return false;
     }
   }
@@ -747,6 +783,9 @@ bool FilePrefetchBuffer::TryReadFromCacheAsync(
   *result = Slice(bufs_[index].buffer_.BufferStart() + offset_in_buffer, n);
   if (prefetched) {
     readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
+  }
+  if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail) {
+    RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_HIT);
   }
   return true;
 }

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -54,6 +54,11 @@ struct BufferInfo {
   uint32_t pos_ = 0;
 };
 
+enum FilePrefetchBufferUsage {
+  kTableOpenPrefetchTail,
+  kUnknown,
+};
+
 // FilePrefetchBuffer is a smart buffer to store and read data from a file.
 class FilePrefetchBuffer {
  public:
@@ -78,13 +83,13 @@ class FilePrefetchBuffer {
   // and max_readahead_size are passed in.
   // A user can construct a FilePrefetchBuffer without any arguments, but use
   // `Prefetch` to load data into the buffer.
-  FilePrefetchBuffer(size_t readahead_size = 0, size_t max_readahead_size = 0,
-                     bool enable = true, bool track_min_offset = false,
-                     bool implicit_auto_readahead = false,
-                     uint64_t num_file_reads = 0,
-                     uint64_t num_file_reads_for_auto_readahead = 0,
-                     FileSystem* fs = nullptr, SystemClock* clock = nullptr,
-                     Statistics* stats = nullptr)
+  FilePrefetchBuffer(
+      size_t readahead_size = 0, size_t max_readahead_size = 0,
+      bool enable = true, bool track_min_offset = false,
+      bool implicit_auto_readahead = false, uint64_t num_file_reads = 0,
+      uint64_t num_file_reads_for_auto_readahead = 0, FileSystem* fs = nullptr,
+      SystemClock* clock = nullptr, Statistics* stats = nullptr,
+      FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown)
       : curr_(0),
         readahead_size_(readahead_size),
         initial_auto_readahead_size_(readahead_size),
@@ -100,7 +105,8 @@ class FilePrefetchBuffer {
         explicit_prefetch_submitted_(false),
         fs_(fs),
         clock_(clock),
-        stats_(stats) {
+        stats_(stats),
+        usage_(usage) {
     assert((num_file_reads_ >= num_file_reads_for_auto_readahead_ + 1) ||
            (num_file_reads_ == 0));
     // If ReadOptions.async_io is enabled, data is asynchronously filled in
@@ -442,5 +448,7 @@ class FilePrefetchBuffer {
   FileSystem* fs_;
   SystemClock* clock_;
   Statistics* stats_;
+
+  FilePrefetchBufferUsage usage_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -54,7 +54,7 @@ struct BufferInfo {
   uint32_t pos_ = 0;
 };
 
-enum FilePrefetchBufferUsage {
+enum class FilePrefetchBufferUsage {
   kTableOpenPrefetchTail,
   kUnknown,
 };
@@ -408,6 +408,19 @@ class FilePrefetchBuffer {
                                Env::IOPriority rate_limiter_priority,
                                bool& copy_to_third_buffer, uint64_t& tmp_offset,
                                size_t& tmp_length);
+
+  bool TryReadFromCacheUntracked(const IOOptions& opts,
+                                 RandomAccessFileReader* reader,
+                                 uint64_t offset, size_t n, Slice* result,
+                                 Status* s,
+                                 Env::IOPriority rate_limiter_priority,
+                                 bool for_compaction = false);
+
+  bool TryReadFromCacheAsyncUntracked(const IOOptions& opts,
+                                      RandomAccessFileReader* reader,
+                                      uint64_t offset, size_t n, Slice* result,
+                                      Status* status,
+                                      Env::IOPriority rate_limiter_priority);
 
   std::vector<BufferInfo> bufs_;
   // curr_ represents the index for bufs_ indicating which buffer is being

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -533,6 +533,10 @@ enum Histograms : uint32_t {
   // Wait time for aborting async read in FilePrefetchBuffer destructor
   ASYNC_PREFETCH_ABORT_MICROS,
 
+  // Number of bytes read in prefetching contents from the end of SST table
+  // during table open
+  TABLE_PREFETCH_TAIL_READ_BYTES,
+
   HISTOGRAM_ENUM_MAX
 };
 

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -420,6 +420,15 @@ enum Tickers : uint32_t {
   SECONDARY_CACHE_INDEX_HITS,
   SECONDARY_CACHE_DATA_HITS,
 
+  // Number of lookup into the prefetched tail (see
+  // `TABLE_OPEN_PREFETCH_TAIL_READ_BYTES`)
+  // that can't find its data for table open
+  TABLE_OPEN_PREFETCH_TAIL_MISS,
+  // Number of lookup into the prefetched tail (see
+  // `TABLE_OPEN_PREFETCH_TAIL_READ_BYTES`)
+  // that finds its data for table open
+  TABLE_OPEN_PREFETCH_TAIL_HIT,
+
   TICKER_ENUM_MAX
 };
 
@@ -533,9 +542,9 @@ enum Histograms : uint32_t {
   // Wait time for aborting async read in FilePrefetchBuffer destructor
   ASYNC_PREFETCH_ABORT_MICROS,
 
-  // Number of bytes read in prefetching contents from the end of SST table
-  // during table open
-  TABLE_PREFETCH_TAIL_READ_BYTES,
+  // Number of bytes read for RocksDB's prefetching contents (as opposed to file
+  // system's prefetch) from the end of SST table during block based table open
+  TABLE_OPEN_PREFETCH_TAIL_READ_BYTES,
 
   HISTOGRAM_ENUM_MAX
 };

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5125,6 +5125,10 @@ class TickerTypeJni {
         return -0x38;
       case ROCKSDB_NAMESPACE::Tickers::SECONDARY_CACHE_DATA_HITS:
         return -0x39;
+      case ROCKSDB_NAMESPACE::Tickers::TABLE_OPEN_PREFETCH_TAIL_MISS:
+        return -0x3A;
+      case ROCKSDB_NAMESPACE::Tickers::TABLE_OPEN_PREFETCH_TAIL_HIT:
+        return -0x3B;
       case ROCKSDB_NAMESPACE::Tickers::TICKER_ENUM_MAX:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep
@@ -5482,6 +5486,10 @@ class TickerTypeJni {
         return ROCKSDB_NAMESPACE::Tickers::SECONDARY_CACHE_INDEX_HITS;
       case -0x39:
         return ROCKSDB_NAMESPACE::Tickers::SECONDARY_CACHE_DATA_HITS;
+      case -0x3A:
+        return ROCKSDB_NAMESPACE::Tickers::TABLE_OPEN_PREFETCH_TAIL_MISS;
+      case -0x3B:
+        return ROCKSDB_NAMESPACE::Tickers::TABLE_OPEN_PREFETCH_TAIL_HIT;
       case 0x5F:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep
@@ -5609,7 +5617,7 @@ class HistogramTypeJni {
         return 0x37;
       case ASYNC_PREFETCH_ABORT_MICROS:
         return 0x38;
-      case ROCKSDB_NAMESPACE::Histograms::TABLE_PREFETCH_TAIL_READ_BYTES:
+      case ROCKSDB_NAMESPACE::Histograms::TABLE_OPEN_PREFETCH_TAIL_READ_BYTES:
         return 0x39;
       case ROCKSDB_NAMESPACE::Histograms::HISTOGRAM_ENUM_MAX:
         // 0x1F for backwards compatibility on current minor version.
@@ -5728,7 +5736,8 @@ class HistogramTypeJni {
       case 0x38:
         return ROCKSDB_NAMESPACE::Histograms::ASYNC_PREFETCH_ABORT_MICROS;
       case 0x39:
-        return ROCKSDB_NAMESPACE::Histograms::TABLE_PREFETCH_TAIL_READ_BYTES;
+        return ROCKSDB_NAMESPACE::Histograms::
+            TABLE_OPEN_PREFETCH_TAIL_READ_BYTES;
       case 0x1F:
         // 0x1F for backwards compatibility on current minor version.
         return ROCKSDB_NAMESPACE::Histograms::HISTOGRAM_ENUM_MAX;

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5609,6 +5609,8 @@ class HistogramTypeJni {
         return 0x37;
       case ASYNC_PREFETCH_ABORT_MICROS:
         return 0x38;
+      case ROCKSDB_NAMESPACE::Histograms::TABLE_PREFETCH_TAIL_READ_BYTES:
+        return 0x39;
       case ROCKSDB_NAMESPACE::Histograms::HISTOGRAM_ENUM_MAX:
         // 0x1F for backwards compatibility on current minor version.
         return 0x1F;
@@ -5725,6 +5727,8 @@ class HistogramTypeJni {
         return ROCKSDB_NAMESPACE::Histograms::NUM_LEVEL_READ_PER_MULTIGET;
       case 0x38:
         return ROCKSDB_NAMESPACE::Histograms::ASYNC_PREFETCH_ABORT_MICROS;
+      case 0x39:
+        return ROCKSDB_NAMESPACE::Histograms::TABLE_PREFETCH_TAIL_READ_BYTES;
       case 0x1F:
         // 0x1F for backwards compatibility on current minor version.
         return ROCKSDB_NAMESPACE::Histograms::HISTOGRAM_ENUM_MAX;

--- a/java/src/main/java/org/rocksdb/HistogramType.java
+++ b/java/src/main/java/org/rocksdb/HistogramType.java
@@ -163,10 +163,11 @@ public enum HistogramType {
   ASYNC_READ_BYTES((byte) 0x33),
 
   /**
-   * Number of bytes read in prefetching contents from the end of SST table
-   * during table open
+   * Number of bytes read for RocksDB's prefetching contents
+   * (as opposed to file system's prefetch)
+   * from the end of SST table during block based table open
    */
-  TABLE_PREFETCH_TAIL_READ_BYTES((byte) 0x39),
+  TABLE_OPEN_PREFETCH_TAIL_READ_BYTES((byte) 0x39),
 
   // 0x1F for backwards compatibility on current minor version.
   HISTOGRAM_ENUM_MAX((byte) 0x1F);

--- a/java/src/main/java/org/rocksdb/HistogramType.java
+++ b/java/src/main/java/org/rocksdb/HistogramType.java
@@ -162,6 +162,12 @@ public enum HistogramType {
 
   ASYNC_READ_BYTES((byte) 0x33),
 
+  /**
+   * Number of bytes read in prefetching contents from the end of SST table
+   * during table open
+   */
+  TABLE_PREFETCH_TAIL_READ_BYTES((byte) 0x39),
+
   // 0x1F for backwards compatibility on current minor version.
   HISTOGRAM_ENUM_MAX((byte) 0x1F);
 

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -740,6 +740,20 @@ public enum TickerType {
      */
     BLOB_DB_CACHE_BYTES_WRITE((byte) -0x34),
 
+    /**
+     * Number of lookup into the prefetched tail (see
+     * `TABLE_OPEN_PREFETCH_TAIL_READ_BYTES`)
+     * that can't find its data for table open
+     */
+    TABLE_OPEN_PREFETCH_TAIL_MISS((byte) -0x3A),
+
+    /**
+     * Number of lookup into the prefetched tail (see
+     * `TABLE_OPEN_PREFETCH_TAIL_READ_BYTES`)
+     * that finds its data for table open
+     */
+    TABLE_OPEN_PREFETCH_TAIL_HIT((byte) -0x3B),
+
     TICKER_ENUM_MAX((byte) 0x5F);
 
     private final byte value;

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -272,6 +272,7 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {MULTIGET_IO_BATCH_SIZE, "rocksdb.multiget.io.batch.size"},
     {NUM_LEVEL_READ_PER_MULTIGET, "rocksdb.num.level.read.per.multiget"},
     {ASYNC_PREFETCH_ABORT_MICROS, "rocksdb.async.prefetch.abort.micros"},
+    {TABLE_PREFETCH_TAIL_READ_BYTES, "rocksdb.table.prefetch.tail.read.bytes"},
 };
 
 std::shared_ptr<Statistics> CreateDBStatistics() {

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -216,7 +216,10 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {ASYNC_READ_ERROR_COUNT, "rocksdb.async.read.error.count"},
     {SECONDARY_CACHE_FILTER_HITS, "rocksdb.secondary.cache.filter.hits"},
     {SECONDARY_CACHE_INDEX_HITS, "rocksdb.secondary.cache.index.hits"},
-    {SECONDARY_CACHE_DATA_HITS, "rocksdb.secondary.cache.data.hits"}};
+    {SECONDARY_CACHE_DATA_HITS, "rocksdb.secondary.cache.data.hits"},
+    {TABLE_OPEN_PREFETCH_TAIL_MISS, "rocksdb.table.open.prefetch.tail.miss"},
+    {TABLE_OPEN_PREFETCH_TAIL_HIT, "rocksdb.table.open.prefetch.tail.hit"},
+};
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {DB_GET, "rocksdb.db.get.micros"},
@@ -272,7 +275,8 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {MULTIGET_IO_BATCH_SIZE, "rocksdb.multiget.io.batch.size"},
     {NUM_LEVEL_READ_PER_MULTIGET, "rocksdb.num.level.read.per.multiget"},
     {ASYNC_PREFETCH_ABORT_MICROS, "rocksdb.async.prefetch.abort.micros"},
-    {TABLE_PREFETCH_TAIL_READ_BYTES, "rocksdb.table.prefetch.tail.read.bytes"},
+    {TABLE_OPEN_PREFETCH_TAIL_READ_BYTES,
+     "rocksdb.table.open.prefetch.tail.read.bytes"},
 };
 
 std::shared_ptr<Statistics> CreateDBStatistics() {

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -444,7 +444,7 @@ class BlockBasedTable : public TableReader {
       const ReadOptions& ro, RandomAccessFileReader* file, uint64_t file_size,
       bool force_direct_prefetch, TailPrefetchStats* tail_prefetch_stats,
       const bool prefetch_all, const bool preload_all,
-      std::unique_ptr<FilePrefetchBuffer>* prefetch_buffer);
+      std::unique_ptr<FilePrefetchBuffer>* prefetch_buffer, Statistics* stats);
   Status ReadMetaIndexBlock(const ReadOptions& ro,
                             FilePrefetchBuffer* prefetch_buffer,
                             std::unique_ptr<Block>* metaindex_block,

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -232,17 +232,11 @@ TEST_P(BlockBasedTableReaderTest, MultiGet) {
 
   std::unique_ptr<BlockBasedTable> table;
   Options options;
-  options.statistics = CreateDBStatistics();
   ImmutableOptions ioptions(options);
   FileOptions foptions;
   foptions.use_direct_reads = use_direct_reads_;
   InternalKeyComparator comparator(options.comparator);
   NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table);
-
-  HistogramData table_prefetch_tail_read_bytes;
-  options.statistics->histogramData(TABLE_PREFETCH_TAIL_READ_BYTES,
-                                    &table_prefetch_tail_read_bytes);
-  ASSERT_EQ(table_prefetch_tail_read_bytes.count, 1);
 
   // Ensure that keys are not in cache before MultiGet.
   for (auto& key : keys) {

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -232,11 +232,17 @@ TEST_P(BlockBasedTableReaderTest, MultiGet) {
 
   std::unique_ptr<BlockBasedTable> table;
   Options options;
+  options.statistics = CreateDBStatistics();
   ImmutableOptions ioptions(options);
   FileOptions foptions;
   foptions.use_direct_reads = use_direct_reads_;
   InternalKeyComparator comparator(options.comparator);
   NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table);
+
+  HistogramData table_prefetch_tail_read_bytes;
+  options.statistics->histogramData(TABLE_PREFETCH_TAIL_READ_BYTES,
+                                    &table_prefetch_tail_read_bytes);
+  ASSERT_EQ(table_prefetch_tail_read_bytes.count, 1);
 
   // Ensure that keys are not in cache before MultiGet.
   for (auto& key : keys) {


### PR DESCRIPTION
**Context/Summary:**
We are adding new stats to measure behavior of prefetched tail size and look up into this buffer

The stat collection is done in FilePrefetchBuffer but only for prefetched tail buffer during table open for now using FilePrefetchBuffer enum. It's cleaner than the alternative of implementing in upper-level call places of FilePrefetchBuffer for table open. It also has the benefit of extensible to other types of FilePrefetchBuffer if needed. See db bench for perf regression concern.


**Test:**
**- Piggyback on existing test** 
**- rocksdb.table.open.prefetch.tail.miss is harder to UT so I manually set prefetch tail read bytes to be small and run db bench.** 
```
./db_bench -db=/tmp/testdb -statistics=true -benchmarks="fillseq" -key_size=32 -value_size=512 -num=5000 -write_buffer_size=655 -target_file_size_base=655 -disable_auto_compactions=false -compression_type=none -bloom_bits=3  -use_direct_reads=true
```
```
rocksdb.table.open.prefetch.tail.read.bytes P50 : 4096.000000 P95 : 4096.000000 P99 : 4096.000000 P100 : 4096.000000 COUNT : 225 SUM : 921600
rocksdb.table.open.prefetch.tail.miss COUNT : 91
rocksdb.table.open.prefetch.tail.hit COUNT : 1034
```
**- No perf regression observed in db_bench**

SETUP command: create same db with ~900 files for pre-change/post-change.
```
./db_bench -db=/tmp/testdb -benchmarks="fillseq" -key_size=32 -value_size=512 -num=500000 -write_buffer_size=655360  -disable_auto_compactions=true -target_file_size_base=16777216 -compression_type=none
```
TEST command 60 runs or til convergence: as suggested by @anand1976 and @akankshamahajan15, vary `seek_nexts` and `async_io` in testing.
```
./db_bench -use_existing_db=true -db=/tmp/testdb -statistics=false -cache_size=0 -cache_index_and_filter_blocks=false -benchmarks=seekrandom[-X60] -num=50000 -seek_nexts={10, 500, 1000} -async_io={0|1} -use_direct_reads=true
```
async io = 0, direct io read = true

  | seek_nexts = 10, 30 runs | seek_nexts = 500, 12 runs | seek_nexts = 1000, 6 runs
-- | -- | -- | --
pre-post change | 4776 (± 28) ops/sec;   24.8 (± 0.1) MB/sec | 288 (± 1) ops/sec;   74.8 (± 0.4) MB/sec | 145 (± 4) ops/sec;   75.6 (± 2.2) MB/sec
post-change | 4790 (± 32) ops/sec;   24.9 (± 0.2) MB/sec | 288 (± 3) ops/sec;   74.7 (± 0.8) MB/sec | 143 (± 3) ops/sec;   74.5 (± 1.6) MB/sec

async io = 1, direct io read = true
  | seek_nexts = 10, 54 runs | seek_nexts = 500, 6 runs | seek_nexts = 1000, 4 runs
-- | -- | -- | --
pre-post change | 3350 (± 36) ops/sec;   17.4 (± 0.2) MB/sec | 264 (± 0) ops/sec;   68.7 (± 0.2) MB/sec | 138 (± 1) ops/sec;   71.8 (± 1.0) MB/sec
post-change | 3358 (± 27) ops/sec;   17.4 (± 0.1) MB/sec  | 263 (± 2) ops/sec;   68.3 (± 0.8) MB/sec | 139 (± 1) ops/sec;   72.6 (± 0.6) MB/sec

