### PR TITLE
Use FaultInjectionTestFS in DBWriteTest.LockWALInEffect

### DIFF
--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -19,6 +19,7 @@
 #include "util/random.h"
 #include "util/string_util.h"
 #include "utilities/fault_injection_env.h"
+#include "utilities/fault_injection_fs.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -609,9 +610,10 @@ TEST_P(DBWriteTest, IOErrorOnSwitchMemtable) {
 // Test that db->LockWAL() flushes the WAL after locking, which can fail
 TEST_P(DBWriteTest, LockWALInEffect) {
   Options options = GetOptions();
-  std::unique_ptr<FaultInjectionTestEnv> mock_env(
-      new FaultInjectionTestEnv(env_));
-  options.env = mock_env.get();
+  std::shared_ptr<FaultInjectionTestFS> fault_fs(
+      new FaultInjectionTestFS(FileSystem::Default()));
+  std::unique_ptr<Env> fault_fs_env(NewCompositeEnv(fault_fs));
+  options.env = fault_fs_env.get();
   options.disable_auto_compactions = true;
   options.paranoid_checks = false;
   Reopen(options);
@@ -630,7 +632,7 @@ TEST_P(DBWriteTest, LockWALInEffect) {
   ASSERT_OK(db_->UnlockWAL());
 
   // Fail the WAL flush if applicable
-  mock_env->SetFilesystemActive(false);
+  fault_fs->SetFilesystemActive(false);
   Status s = Put("key2", "value");
   if (options.manual_wal_flush) {
     ASSERT_OK(s);
@@ -642,7 +644,7 @@ TEST_P(DBWriteTest, LockWALInEffect) {
     ASSERT_OK(db_->LockWAL());
     ASSERT_OK(db_->UnlockWAL());
   }
-  mock_env->SetFilesystemActive(true);
+  fault_fs->SetFilesystemActive(true);
   // Writes should work again
   ASSERT_OK(Put("key3", "value"));
   ASSERT_EQ(Get("key3"), "value");

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -609,6 +609,10 @@ TEST_P(DBWriteTest, IOErrorOnSwitchMemtable) {
 
 // Test that db->LockWAL() flushes the WAL after locking, which can fail
 TEST_P(DBWriteTest, LockWALInEffect) {
+  if (mem_env_ || encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-mem or non-encrypted environment");
+    return;
+  }
   Options options = GetOptions();
   std::shared_ptr<FaultInjectionTestFS> fault_fs(
       new FaultInjectionTestFS(FileSystem::Default()));


### PR DESCRIPTION
Summary: Existing use of FaultInjectionTestEnv shows rare TSAN errors with parallel Sync and Flush. This appears to be fixed in FaultInjectionTestFS. (Sigh, code duplication and divergence.)

Example failure:
https://app.circleci.com/pipelines/github/facebook/rocksdb/24631/workflows/fc2a66f0-f21c-48d6-a944-3885bcff50a4/jobs/571928

Test Plan: wasn't able to reproduce locally but stress tested the updated test with gtest-parallel -r1000 and TSAN.