### PR TITLE
Default print stack traces with GDB on Linux

### DIFF
--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -144,7 +144,7 @@ void PrintStack(int first_frames_to_skip) {
   // Default to getting stack traces with GDB, at least on Linux where we
   // know how to attach to a particular thread.
   //
-  // * Address space layout randomization (ASLR) intereferes with getting good
+  // * Address space layout randomization (ASLR) interferes with getting good
   //   stack information from backtrace+addr2line. This is more likely to show
   //   up with LIB_MODE=shared builds (when kernel.randomize_va_space >= 1)
   //   but can also show up with LIB_MODE=static builds ((when
@@ -152,12 +152,6 @@ void PrintStack(int first_frames_to_skip) {
   // * It doesn't appear easy to detect when ASLR is in use.
   // * With DEBUG_LEVEL < 2, backtrace() can skip frames that are not skipped
   //   in GDB.
-  // some frames with DEBUG_LEVEL=1 that are not skipped by a backtrace in
-  // GDB.
-  // Since it's not easy to detect when ASLR is in use,
-  // LIB_MODE=shared build produces mediocre information from the above
-  // backtrace+addr2line stack trace method. Try to use GDB in that case, but
-  // only on Linux where we know how to attach to a particular thread.
 #if defined(OS_LINUX)
   // Default true, override with ROCKSDB_BACKTRACE_STACK=1
   bool gdb_stack_trace = getenv("ROCKSDB_BACKTRACE_STACK") == nullptr;

--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -141,20 +141,36 @@ void PrintStack(void* frames[], int num_frames) {
 }
 
 void PrintStack(int first_frames_to_skip) {
-#if defined(ROCKSDB_DLL) && defined(OS_LINUX)
+  // Default to getting stack traces with GDB, at least on Linux where we
+  // know how to attach to a particular thread.
+  //
+  // * Address space layout randomization (ASLR) intereferes with getting good
+  //   stack information from backtrace+addr2line. This is more likely to show
+  //   up with LIB_MODE=shared builds (when kernel.randomize_va_space >= 1)
+  //   but can also show up with LIB_MODE=static builds ((when
+  //   kernel.randomize_va_space == 2).
+  // * It doesn't appear easy to detect when ASLR is in use.
+  // * With DEBUG_LEVEL < 2, backtrace() can skip frames that are not skipped
+  //   in GDB.
+  // some frames with DEBUG_LEVEL=1 that are not skipped by a backtrace in
+  // GDB.
+  // Since it's not easy to detect when ASLR is in use,
   // LIB_MODE=shared build produces mediocre information from the above
   // backtrace+addr2line stack trace method. Try to use GDB in that case, but
   // only on Linux where we know how to attach to a particular thread.
-  bool linux_dll = true;
+#if defined(OS_LINUX)
+  // Default true, override with ROCKSDB_BACKTRACE_STACK=1
+  bool gdb_stack_trace = getenv("ROCKSDB_BACKTRACE_STACK") == nullptr;
 #else
-  bool linux_dll = false;
+  // Default false, override with ROCKSDB_GDB_STACK=1
+  bool gdb_stack_trace = getenv("ROCKSDB_GDB_STACK") != nullptr;
 #endif
   // Also support invoking interactive debugger on stack trace, with this
   // envvar set to non-empty
   char* debug_env = getenv("ROCKSDB_DEBUG");
   bool debug = debug_env != nullptr && strlen(debug_env) > 0;
 
-  if (linux_dll || debug) {
+  if (gdb_stack_trace || debug) {
     // Allow ouside debugger to attach, even with Yama security restrictions
 #ifdef PR_SET_PTRACER_ANY
     (void)prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0);


### PR DESCRIPTION
Summary: On Linux systems using full ASLR, including CircleCI, the old backtrace()+addr2line stack traces are pretty useless, as seen in some failures under ASSERT_STATUS_CHECKED=1 LIB_MODE=static. Use gdb by default for stack traces under Linux. More detail in code comments.

Test Plan: manual testing locally and on CircleCI with ssh