### PR TITLE
[Draft] New stat rocksdb.prefetch.buffer.hit/miss

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 
 ### New Features
 * Add statistics rocksdb.secondary.cache.filter.hits, rocksdb.secondary.cache.index.hits, and rocksdb.secondary.cache.filter.hits
+* Add statistics rocksdb.prefetch.buffer.hit/rocksdb.prefetch.buffer.miss to report numbers of look up in prefetch buffer that find/doesn't find its data.
 
 ## 8.0.0 (02/19/2023)
 ### Behavior changes

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -420,6 +420,11 @@ enum Tickers : uint32_t {
   SECONDARY_CACHE_INDEX_HITS,
   SECONDARY_CACHE_DATA_HITS,
 
+  // Number of lookup in prefetch buffer that finds its data
+  PREFETCH_BUFFER_HIT,
+  // Number of lookup in prefetch buffer that doesn't find its data
+  PREFETCH_BUFFER_MISS,
+
   TICKER_ENUM_MAX
 };
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5125,6 +5125,10 @@ class TickerTypeJni {
         return -0x38;
       case ROCKSDB_NAMESPACE::Tickers::SECONDARY_CACHE_DATA_HITS:
         return -0x39;
+      case ROCKSDB_NAMESPACE::Tickers::PREFETCH_BUFFER_HIT:
+        return -0x3A;
+      case ROCKSDB_NAMESPACE::Tickers::PREFETCH_BUFFER_MISS:
+        return -0x3B;
       case ROCKSDB_NAMESPACE::Tickers::TICKER_ENUM_MAX:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep
@@ -5482,6 +5486,10 @@ class TickerTypeJni {
         return ROCKSDB_NAMESPACE::Tickers::SECONDARY_CACHE_INDEX_HITS;
       case -0x39:
         return ROCKSDB_NAMESPACE::Tickers::SECONDARY_CACHE_DATA_HITS;
+      case -0x3A:
+        return ROCKSDB_NAMESPACE::Tickers::PREFETCH_BUFFER_HIT;
+      case -0x3B:
+        return ROCKSDB_NAMESPACE::Tickers::PREFETCH_BUFFER_MISS;
       case 0x5F:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -740,6 +740,16 @@ public enum TickerType {
      */
     BLOB_DB_CACHE_BYTES_WRITE((byte) -0x34),
 
+    /**
+     * Number of lookup in prefetch buffer that finds its data
+     */
+    PREFETCH_BUFFER_HIT((byte) -0x3A),
+
+    /**
+     * Number of lookup in prefetch buffer that doesn't find its data
+     */
+    PREFETCH_BUFFER_MISS((byte) -0x3B),
+
     TICKER_ENUM_MAX((byte) 0x5F);
 
     private final byte value;

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -216,7 +216,9 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {ASYNC_READ_ERROR_COUNT, "rocksdb.async.read.error.count"},
     {SECONDARY_CACHE_FILTER_HITS, "rocksdb.secondary.cache.filter.hits"},
     {SECONDARY_CACHE_INDEX_HITS, "rocksdb.secondary.cache.index.hits"},
-    {SECONDARY_CACHE_DATA_HITS, "rocksdb.secondary.cache.data.hits"}};
+    {SECONDARY_CACHE_DATA_HITS, "rocksdb.secondary.cache.data.hits"},
+    {PREFETCH_BUFFER_HIT, "rocksdb.prefetch.buffer.hit"},
+    {PREFETCH_BUFFER_MISS, "rocksdb.prefetch.buffer.miss"}};
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {DB_GET, "rocksdb.db.get.micros"},


### PR DESCRIPTION
**Context/Summary:**
We want to investigate the impact of some small prefetch buffer (i.e, the one in BlockBasedTableReader::PrefetchTail()) on its subsequent sst read. To do so, in addition to https://github.com/facebook/rocksdb/pull/11265, we need the "middle stat" prefetch buffer hit/miss to bridge between prefetch buffer size and subsequence sst read happened due to prefetch buffer miss.

**Test:**
Piggyback on existing UT

