### PR TITLE
Decrease duration time for internally debugging the regression_script

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -313,7 +313,7 @@ function run_db_bench {
 }
 
 function set_async_io_parameters {
-  options=" --duration=800"
+  options=" --duration=50"
   # Below parameters are used in case of async_io only.
   # 1. If you want to run below parameters for all benchmarks, it should be
   #    specify in OPTIONS_FILE instead of exporting them.


### PR DESCRIPTION
Summary: Internally, the benchmark is going on hang state whereas when run on same host manually, it passes. Decrease the duration to 50s to figure out how much time it is taking to complete the benchmark. 

Test Plan: Ran manually internally

Reviewers:

Subscribers:

Tasks:

Tags: