### PR TITLE
Ignore async_io ReadOption if FileSystem doesn't support it

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Behavior changes
 * Compaction output file cutting logic now considers range tombstone start keys. For example, SST partitioner now may receive ParitionRequest for range tombstone start keys.
+* If the async_io ReadOption is specified for MultiGet or NewIterator on a platform that doesn't support IO uring, the option is ignored and synchronous IO is used.
 
 ### Bug Fixes
 * Fixed an issue for backward iteration when user defined timestamp is enabled in combination with BlobDB.

--- a/db/arena_wrapped_db_iter.cc
+++ b/db/arena_wrapped_db_iter.cc
@@ -47,6 +47,9 @@ void ArenaWrappedDBIter::Init(
   read_options_ = read_options;
   allow_refresh_ = allow_refresh;
   memtable_range_tombstone_iter_ = nullptr;
+  if (!env->GetFileSystem()->use_async_io()) {
+    read_options_.async_io = false;
+  }
 }
 
 Status ArenaWrappedDBIter::Refresh() {

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2302,9 +2302,8 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL0) {
     ASSERT_EQ(multiget_io_batch_size.count, 3);
   }
 #else   // ROCKSDB_IOURING_PRESENT
-  if (GetParam()) {
-    ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 3);
-  }
+  ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 0);
+  ASSERT_EQ(multiget_io_batch_size.count, 3);
 #endif  // ROCKSDB_IOURING_PRESENT
 }
 
@@ -2346,8 +2345,11 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL1) {
   // A batch of 3 async IOs is expected, one for each overlapping file in L1
   ASSERT_EQ(multiget_io_batch_size.count, 1);
   ASSERT_EQ(multiget_io_batch_size.max, 3);
-#endif  // ROCKSDB_IOURING_PRESENT
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 3);
+#else   // ROCKSDB_IOURING_PRESENT
+  ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 0);
+  ASSERT_EQ(multiget_io_batch_size.count, 3);
+#endif  // ROCKSDB_IOURING_PRESENT
 }
 
 #ifdef ROCKSDB_IOURING_PRESENT
@@ -2531,8 +2533,12 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL2WithRangeOverlapL0L1) {
   ASSERT_EQ(values[0], "val_l2_" + std::to_string(19));
   ASSERT_EQ(values[1], "val_l2_" + std::to_string(26));
 
+#ifdef ROCKSDB_IOURING_PRESENT
   // Bloom filters in L0/L1 will avoid the coroutine calls in those levels
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 2);
+#else   // ROCKSDB_IOURING_PRESENT
+  ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 0);
+#endif  // ROCKSDB_IOURING_PRESENT
 }
 
 #ifdef ROCKSDB_IOURING_PRESENT

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2623,18 +2623,17 @@ TEST_P(DBMultiGetAsyncIOTest, GetNoIOUring) {
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data());
   ASSERT_EQ(values.size(), 3);
-  ASSERT_EQ(statuses[0], Status::NotSupported());
-  ASSERT_EQ(statuses[1], Status::NotSupported());
-  ASSERT_EQ(statuses[2], Status::NotSupported());
+  ASSERT_EQ(statuses[0], Status::OK());
+  ASSERT_EQ(statuses[1], Status::OK());
+  ASSERT_EQ(statuses[2], Status::OK());
 
-  HistogramData multiget_io_batch_size;
+  HistogramData async_read_bytes;
 
-  statistics()->histogramData(MULTIGET_IO_BATCH_SIZE, &multiget_io_batch_size);
+  statistics()->histogramData(ASYNC_READ_BYTES, &async_read_bytes);
 
   // A batch of 3 async IOs is expected, one for each overlapping file in L1
-  ASSERT_EQ(multiget_io_batch_size.count, 1);
-  ASSERT_EQ(multiget_io_batch_size.max, 3);
-  ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 3);
+  ASSERT_EQ(async_read_bytes.count, 0);
+  ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 0);
 }
 
 INSTANTIATE_TEST_CASE_P(DBMultiGetAsyncIOTest, DBMultiGetAsyncIOTest,

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2303,7 +2303,6 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL0) {
   }
 #else   // ROCKSDB_IOURING_PRESENT
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 0);
-  ASSERT_EQ(multiget_io_batch_size.count, 3);
 #endif  // ROCKSDB_IOURING_PRESENT
 }
 
@@ -2348,7 +2347,6 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL1) {
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 3);
 #else   // ROCKSDB_IOURING_PRESENT
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 0);
-  ASSERT_EQ(multiget_io_batch_size.count, 3);
 #endif  // ROCKSDB_IOURING_PRESENT
 }
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2337,11 +2337,11 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL1) {
   ASSERT_EQ(values[1], "val_l1_" + std::to_string(54));
   ASSERT_EQ(values[2], "val_l1_" + std::to_string(102));
 
-#ifdef ROCKSDB_IOURING_PRESENT
   HistogramData multiget_io_batch_size;
 
   statistics()->histogramData(MULTIGET_IO_BATCH_SIZE, &multiget_io_batch_size);
 
+#ifdef ROCKSDB_IOURING_PRESENT
   // A batch of 3 async IOs is expected, one for each overlapping file in L1
   ASSERT_EQ(multiget_io_batch_size.count, 1);
   ASSERT_EQ(multiget_io_batch_size.max, 3);

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -238,6 +238,9 @@ ForwardIterator::ForwardIterator(DBImpl* db, const ReadOptions& read_options,
   if (sv_) {
     RebuildIterators(false);
   }
+  if (!cfd_->ioptions()->env->GetFileSystem()->use_async_io()) {
+    read_options_.async_io = false;
+  }
 
   // immutable_status_ is a local aggregation of the
   // status of the immutable Iterators.

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -122,7 +122,7 @@ class ForwardIterator : public InternalIterator {
   void DeleteIterator(InternalIterator* iter, bool is_arena = false);
 
   DBImpl* const db_;
-  const ReadOptions read_options_;
+  ReadOptions read_options_;
   ColumnFamilyData* const cfd_;
   const SliceTransform* const prefix_extractor_;
   const Comparator* user_comparator_;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1075,6 +1075,7 @@ class Version {
   // used for debugging and logging purposes only.
   uint64_t version_number_;
   std::shared_ptr<IOTracer> io_tracer_;
+  bool use_async_io_;
 
   Version(ColumnFamilyData* cfd, VersionSet* vset, const FileOptions& file_opt,
           MutableCFOptions mutable_cf_options,

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1183,6 +1183,14 @@ class PosixFileSystem : public FileSystem {
 #endif
   }
 
+  bool use_async_io() override {
+#if defined(ROCKSDB_IOURING_PRESENT)
+    return IsIOUringEnabled();
+#else
+    return false;
+#endif
+  }
+
 #if defined(ROCKSDB_IOURING_PRESENT)
   // io_uring instance
   std::unique_ptr<ThreadLocalPtr> thread_local_io_urings_;

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1185,6 +1185,11 @@ TEST_P(PrefetchTest, DBIterLevelReadAheadWithAsyncIO) {
 }
 
 TEST_P(PrefetchTest, DBIterAsyncIONoIOUring) {
+  if (mem_env_ || encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-mem or non-encrypted environment");
+    return;
+  }
+
   const int kNumKeys = 1000;
   // Set options
   bool use_direct_io = std::get<0>(GetParam());

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1273,6 +1273,8 @@ TEST_P(PrefetchTest, DBIterAsyncIONoIOUring) {
     }
   }
   Close();
+
+  enable_io_uring = true;
 }
 
 class PrefetchTest1 : public DBTestBase,

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1893,6 +1893,7 @@ TEST_P(PrefetchTest, MultipleSeekWithPosixFS) {
       HistogramData prefetched_bytes_discarded;
       options.statistics->histogramData(PREFETCHED_BYTES_DISCARDED,
                                         &prefetched_bytes_discarded);
+      ASSERT_GT(prefetched_bytes_discarded.count, 0);
 
       if (read_async_called) {
         ASSERT_GT(buff_prefetch_count, 0);
@@ -1900,13 +1901,11 @@ TEST_P(PrefetchTest, MultipleSeekWithPosixFS) {
         // Check stats to make sure async prefetch is done.
         ASSERT_GT(async_read_bytes.count, 0);
         ASSERT_GT(get_perf_context()->number_async_seek, 0);
-        ASSERT_GT(prefetched_bytes_discarded.count, 0);
       } else {
         // Not all platforms support iouring. In that case, ReadAsync in posix
         // won't submit async requests.
         ASSERT_EQ(async_read_bytes.count, 0);
         ASSERT_EQ(get_perf_context()->number_async_seek, 0);
-        ASSERT_EQ(prefetched_bytes_discarded.count, 0);
       }
     }
   }
@@ -2009,8 +2008,7 @@ TEST_P(PrefetchTest, SeekParallelizationTestWithPosix) {
 
     ASSERT_TRUE(iter->Valid());
     HistogramData async_read_bytes;
-    options.statistics->histogramData(ASYNC_READ_BYTES,
-                                      &async_read_bytes);
+    options.statistics->histogramData(ASYNC_READ_BYTES, &async_read_bytes);
     if (read_async_called) {
       ASSERT_GT(async_read_bytes.count, 0);
       ASSERT_GT(get_perf_context()->number_async_seek, 0);

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -682,6 +682,10 @@ class FileSystem : public Customizable {
     return IOStatus::OK();
   }
 
+  // Indicates to upper layers whether the FileSystem supports/uses async IO
+  // or not
+  virtual bool use_async_io() { return true; }
+
   // If you're adding methods here, remember to add them to EnvWrapper too.
 
  private:
@@ -1521,6 +1525,8 @@ class FileSystemWrapper : public FileSystem {
   virtual IOStatus AbortIO(std::vector<void*>& io_handles) override {
     return target_->AbortIO(io_handles);
   }
+
+  virtual bool use_async_io() override { return target_->use_async_io(); }
 
  protected:
   std::shared_ptr<FileSystem> target_;

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -227,6 +227,7 @@ class WinFileSystem : public FileSystem {
       const FileOptions& file_options) const override;
   FileOptions OptimizeForManifestWrite(
       const FileOptions& file_options) const override;
+  bool use_async_io() override { return false; }
 
  protected:
   static uint64_t FileTimeToUnixTime(const FILETIME& ftTime);


### PR DESCRIPTION
Summary:
In PosixFileSystem, IO uring support is opt-in. If the support is not enabled by the user, then ignore the async_io ReadOption in MultiGet and iteration at the top, rather than follow the async_io codepath and transparently switch to sync IO at the FileSystem layer.

Test plan:
Add new unit tests