### PR TITLE
Increase the stress test coverage of GetEntity

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -312,14 +312,17 @@ class BatchedOpsStressTest : public StressTest {
         return false;
       }
 
-      const size_t sz = lhs.size();
-
-      for (size_t i = 0; i < sz; ++i) {
+      for (size_t i = 0; i < lhs.size(); ++i) {
         if (lhs[i].name() != rhs[i].name()) {
           return false;
         }
 
-        if (lhs[i].value().difference_offset(rhs[i].value()) < sz - 1) {
+        if (lhs[i].value().size() != rhs[i].value().size()) {
+          return false;
+        }
+
+        if (lhs[i].value().difference_offset(rhs[i].value()) <
+            lhs[i].value().size() - 1) {
           return false;
         }
       }

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -330,7 +330,20 @@ class BatchedOpsStressTest : public StressTest {
     for (size_t i = 0; i < num_keys; ++i) {
       const WideColumns& columns = results[i].columns();
 
-      if (columns.empty() || columns.front().name() != kDefaultWideColumnName) {
+      if (!compare(results[0].columns(), columns)) {
+        fprintf(stderr,
+                "GetEntity error: inconsistent entities for key %s: %s, %s\n",
+                StringToHex(key_suffix).c_str(),
+                WideColumnsToHex(results[0].columns()).c_str(),
+                WideColumnsToHex(columns).c_str());
+        continue;
+      }
+
+      if (columns.empty()) {
+        continue;
+      }
+
+      if (columns.front().name() != kDefaultWideColumnName) {
         fprintf(
             stderr,
             "GetEntity error: default column not found for key %s, entity %s\n",
@@ -363,15 +376,6 @@ class BatchedOpsStressTest : public StressTest {
                 StringToHex(key_suffix).c_str(),
                 WideColumnsToHex(columns).c_str(),
                 WideColumnsToHex(expected_columns).c_str());
-        continue;
-      }
-
-      if (!compare(results[0].columns(), columns)) {
-        fprintf(stderr,
-                "GetEntity error: inconsistent entities for key %s: %s, %s\n",
-                StringToHex(key_suffix).c_str(),
-                WideColumnsToHex(results[0].columns()).c_str(),
-                WideColumnsToHex(columns).c_str());
         continue;
       }
     }

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -463,16 +463,14 @@ class BatchedOpsStressTest : public StressTest {
         }
 
         // make sure value() and columns() are consistent
-        const WideColumns expected_columns = GenerateExpectedWideColumns(
-            GetValueBase(iters[i]->value()), iters[i]->value());
-        if (iters[i]->columns() != expected_columns) {
+        if (!VerifyWideColumns(iters[i]->value(), iters[i]->columns())) {
           fprintf(stderr,
                   "prefix scan error : %" ROCKSDB_PRIszt
-                  ", value and columns inconsistent for prefix %s: %s\n",
+                  ", value and columns inconsistent for prefix %s: value: %s, "
+                  "columns: %s\n",
                   i, prefix_slices[i].ToString(/* hex */ true).c_str(),
-                  DebugString(iters[i]->value(), iters[i]->columns(),
-                              expected_columns)
-                      .c_str());
+                  iters[i]->value().ToString(/* hex */ true).c_str(),
+                  WideColumnsToHex(iters[i]->columns()).c_str());
         }
 
         iters[i]->Next();

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -346,39 +346,29 @@ class BatchedOpsStressTest : public StressTest {
         continue;
       }
 
-      if (columns.front().name() != kDefaultWideColumnName) {
-        fprintf(
-            stderr,
-            "GetEntity error: default column not found for key %s, entity %s\n",
-            StringToHex(key_suffix).c_str(), WideColumnsToHex(columns).c_str());
-        continue;
-      }
-
       // The last character of each column value should be 'i' as a decimal
       // digit
       const char expected = static_cast<char>('0' + i);
 
-      const Slice& value_of_default = columns.front().value();
+      for (const auto& column : columns) {
+        const Slice& value = column.value();
 
-      if (value_of_default.empty() ||
-          value_of_default[value_of_default.size() - 1] != expected) {
-        fprintf(stderr,
-                "GetEntity error: incorrect value for default column for key "
-                "%s, entity %s, expected %c\n",
-                StringToHex(key_suffix).c_str(),
-                WideColumnsToHex(columns).c_str(), expected);
-        continue;
+        if (value.empty() || value[value.size() - 1] != expected) {
+          fprintf(stderr,
+                  "GetEntity error: incorrect column value for key "
+                  "%s, entity %s, column value %s, expected %c\n",
+                  StringToHex(key_suffix).c_str(),
+                  WideColumnsToHex(columns).c_str(),
+                  value.ToString(/* hex */ true).c_str(), expected);
+          continue;
+        }
       }
 
-      const WideColumns expected_columns = GenerateExpectedWideColumns(
-          GetValueBase(value_of_default), value_of_default);
-      if (columns != expected_columns) {
+      if (!VerifyWideColumns(columns)) {
         fprintf(stderr,
-                "GetEntity error: inconsistent columns for key %s, entity %s, "
-                "expected entity %s\n",
+                "GetEntity error: inconsistent columns for key %s, entity %s\n",
                 StringToHex(key_suffix).c_str(),
-                WideColumnsToHex(columns).c_str(),
-                WideColumnsToHex(expected_columns).c_str());
+                WideColumnsToHex(columns).c_str());
         continue;
       }
     }

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -309,8 +309,34 @@ class BatchedOpsStressTest : public StressTest {
       }
     }
 
+    auto normalize = [&](const WideColumns& columns,
+                         size_t index) -> WideColumns {
+      assert(index < num_keys);
+      const char expected_back = static_cast<char>('0' + index);
+
+      WideColumns normalized;
+      normalized.reserve(columns.size());
+
+      for (const auto& column : columns) {
+        Slice value = column.value();
+
+        if (value.empty()) {
+          // TODO
+        } else if (value[value.size() - 1] != expected_back) {
+          // TODO
+        } else {
+          value.remove_suffix(1);
+          normalized.emplace_back(column.name(), value);
+        }
+      }
+
+      return normalized;
+    };
+
+    const auto expected = normalize(results[0].columns(), 0);
+
     for (size_t i = 1; i < num_keys; ++i) {
-      if (results[i] != results[0]) {
+      if (normalize(results[i].columns(), i) != expected) {
         fprintf(stderr,
                 "GetEntity error: inconsistent entities for key %s: %s, %s\n",
                 StringToHex(key_suffix).c_str(),

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -268,9 +268,9 @@ class BatchedOpsStressTest : public StressTest {
     return ret_status;
   }
 
-  Status TestGetEntity(ThreadState* thread, const ReadOptions& read_opts,
-                       const std::vector<int>& rand_column_families,
-                       const std::vector<int64_t>& rand_keys) override {
+  void TestGetEntity(ThreadState* thread, const ReadOptions& read_opts,
+                     const std::vector<int>& rand_column_families,
+                     const std::vector<int64_t>& rand_keys) override {
     ManagedSnapshot snapshot_guard(db_);
 
     ReadOptions read_opts_copy(read_opts);
@@ -346,8 +346,6 @@ class BatchedOpsStressTest : public StressTest {
         // find more errors if any
       }
     }
-
-    return Status::OK();
   }
 
   // Given a key, this does prefix scans for "0"+P, "1"+P, ..., "9"+P

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -282,8 +282,7 @@ class BatchedOpsStressTest : public StressTest {
 
     assert(!rand_column_families.empty());
     assert(rand_column_families[0] >= 0);
-    assert(static_cast<size_t>(rand_column_families[0]) <
-           column_families_.size());
+    assert(rand_column_families[0] < static_cast<int>(column_families_.size()));
 
     ColumnFamilyHandle* const cfh = column_families_[rand_column_families[0]];
     assert(cfh);

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -340,11 +340,9 @@ class CfConsistencyStressTest : public StressTest {
 
             if (!cmp_found && found) {
               fprintf(stderr,
-                      "GetEntity returns different results for key %s\n",
-                      StringToHex(key).c_str());
-              fprintf(stderr, "CF %s returns not found\n",
-                      column_family_names_[0].c_str());
-              fprintf(stderr, "CF %s returns entity %s\n",
+                      "GetEntity returns different results for key %s: CF %s "
+                      "returns not found, CF %s returns entity %s\n",
+                      StringToHex(key).c_str(), column_family_names_[0].c_str(),
                       column_family_names_[i].c_str(),
                       WideColumnsToHex(result.columns()).c_str());
               is_consistent = false;
@@ -353,12 +351,10 @@ class CfConsistencyStressTest : public StressTest {
 
             if (cmp_found && !found) {
               fprintf(stderr,
-                      "GetEntity returns different results for key %s\n",
-                      StringToHex(key).c_str());
-              fprintf(stderr, "CF %s returns entity %s\n",
-                      column_family_names_[0].c_str(),
-                      WideColumnsToHex(cmp_result.columns()).c_str());
-              fprintf(stderr, "CF %s returns not found\n",
+                      "GetEntity returns different results for key %s: CF %s "
+                      "returns entity %s, CF %s returns not found\n",
+                      StringToHex(key).c_str(), column_family_names_[0].c_str(),
+                      WideColumnsToHex(cmp_result.columns()).c_str(),
                       column_family_names_[i].c_str());
               is_consistent = false;
               break;
@@ -366,12 +362,10 @@ class CfConsistencyStressTest : public StressTest {
 
             if (found && result != cmp_result) {
               fprintf(stderr,
-                      "GetEntity returns different results for key %s\n",
-                      StringToHex(key).c_str());
-              fprintf(stderr, "CF %s returns entity %s\n",
-                      column_family_names_[0].c_str(),
-                      WideColumnsToHex(cmp_result.columns()).c_str());
-              fprintf(stderr, "CF %s returns entity %s\n",
+                      "GetEntity returns different results for key %s: CF %s "
+                      "returns entity %s, CF %s returns entity %s\n",
+                      StringToHex(key).c_str(), column_family_names_[0].c_str(),
+                      WideColumnsToHex(cmp_result.columns()).c_str(),
                       column_family_names_[i].c_str(),
                       WideColumnsToHex(result.columns()).c_str());
               is_consistent = false;

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -436,12 +436,9 @@ class CfConsistencyStressTest : public StressTest {
          iter->Next()) {
       ++count;
 
-      const WideColumns expected_columns = GenerateExpectedWideColumns(
-          GetValueBase(iter->value()), iter->value());
-      if (iter->columns() != expected_columns) {
-        s = Status::Corruption(
-            "Value and columns inconsistent",
-            DebugString(iter->value(), iter->columns(), expected_columns));
+      if (!VerifyWideColumns(iter->value(), iter->columns())) {
+        s = Status::Corruption("Value and columns inconsistent",
+                               DebugString(iter->value(), iter->columns()));
         break;
       }
     }
@@ -518,12 +515,10 @@ class CfConsistencyStressTest : public StressTest {
         assert(iter);
 
         if (iter->Valid()) {
-          const WideColumns expected_columns = GenerateExpectedWideColumns(
-              GetValueBase(iter->value()), iter->value());
-          if (iter->columns() != expected_columns) {
-            statuses[i] = Status::Corruption(
-                "Value and columns inconsistent",
-                DebugString(iter->value(), iter->columns(), expected_columns));
+          if (!VerifyWideColumns(iter->value(), iter->columns())) {
+            statuses[i] =
+                Status::Corruption("Value and columns inconsistent",
+                                   DebugString(iter->value(), iter->columns()));
           } else {
             ++valid_cnt;
           }

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -383,7 +383,7 @@ class CfConsistencyStressTest : public StressTest {
     }
 
     if (!is_consistent) {
-      fprintf(stderr, "TestGetEntity error: is_consistent is false\n");
+      fprintf(stderr, "TestGetEntity error: results are not consistent\n");
       thread->stats.AddErrors(1);
       // Fail fast to preserve the DB state.
       thread->shared->SetVerificationFailure();

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -279,29 +279,13 @@ class CfConsistencyStressTest : public StressTest {
       s = db_->GetEntity(read_opts, cfh, key, &result);
 
       if (s.ok()) {
-        const WideColumns& columns = result.columns();
-
-        if (columns.empty() ||
-            columns.front().name() != kDefaultWideColumnName) {
-          fprintf(stderr,
-                  "GetEntity error: default column not found for key %s, "
-                  "entity %s\n",
-                  StringToHex(key).c_str(), WideColumnsToHex(columns).c_str());
+        if (!VerifyWideColumns(result.columns())) {
+          fprintf(
+              stderr,
+              "GetEntity error: inconsistent columns for key %s, entity %s\n",
+              StringToHex(key).c_str(),
+              WideColumnsToHex(result.columns()).c_str());
           is_consistent = false;
-        } else {
-          const Slice& value_of_default = columns.front().value();
-
-          const WideColumns expected_columns = GenerateExpectedWideColumns(
-              GetValueBase(value_of_default), value_of_default);
-          if (columns != expected_columns) {
-            fprintf(
-                stderr,
-                "GetEntity error: inconsistent columns for key %s, entity %s, "
-                "expected entity %s\n",
-                StringToHex(key).c_str(), WideColumnsToHex(columns).c_str(),
-                WideColumnsToHex(expected_columns).c_str());
-            is_consistent = false;
-          }
         }
       }
     } else {
@@ -324,31 +308,13 @@ class CfConsistencyStressTest : public StressTest {
         const bool cmp_found = s.ok();
 
         if (cmp_found) {
-          const WideColumns& columns = cmp_result.columns();
-
-          if (columns.empty() ||
-              columns.front().name() != kDefaultWideColumnName) {
+          if (!VerifyWideColumns(cmp_result.columns())) {
             fprintf(stderr,
-                    "GetEntity error: default column not found for key %s, "
+                    "GetEntity error: inconsistent columns for key %s, "
                     "entity %s\n",
                     StringToHex(key).c_str(),
-                    WideColumnsToHex(columns).c_str());
+                    WideColumnsToHex(cmp_result.columns()).c_str());
             is_consistent = false;
-          } else {
-            const Slice& value_of_default = columns.front().value();
-
-            const WideColumns expected_columns = GenerateExpectedWideColumns(
-                GetValueBase(value_of_default), value_of_default);
-            if (columns != expected_columns) {
-              fprintf(stderr,
-                      "GetEntity error: inconsistent columns for key %s, "
-                      "entity %s, "
-                      "expected entity %s\n",
-                      StringToHex(key).c_str(),
-                      WideColumnsToHex(columns).c_str(),
-                      WideColumnsToHex(expected_columns).c_str());
-              is_consistent = false;
-            }
           }
         }
 

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -278,6 +278,33 @@ WideColumns GenerateExpectedWideColumns(uint32_t value_base,
   return columns;
 }
 
+bool VerifyWideColumns(const WideColumns& columns) {
+  if (columns.empty()) {
+    return false;
+  }
+
+  if (columns.front().name() != kDefaultWideColumnName) {
+    return false;
+  }
+
+  const Slice& value_of_default = columns.front().value();
+
+  if (value_of_default.size() < sizeof(uint32_t)) {
+    return false;
+  }
+
+  const uint32_t value_base = GetValueBase(value_of_default);
+
+  const WideColumns expected_columns =
+      GenerateExpectedWideColumns(value_base, value_of_default);
+
+  if (columns != expected_columns) {
+    return false;
+  }
+
+  return true;
+}
+
 std::string GetNowNanos() {
   uint64_t t = db_stress_env->NowNanos();
   std::string ret;

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -278,6 +278,23 @@ WideColumns GenerateExpectedWideColumns(uint32_t value_base,
   return columns;
 }
 
+bool VerifyWideColumns(const Slice& value, const WideColumns& columns) {
+  if (value.size() < sizeof(uint32_t)) {
+    return false;
+  }
+
+  const uint32_t value_base = GetValueBase(value);
+
+  const WideColumns expected_columns =
+      GenerateExpectedWideColumns(value_base, value);
+
+  if (columns != expected_columns) {
+    return false;
+  }
+
+  return true;
+}
+
 bool VerifyWideColumns(const WideColumns& columns) {
   if (columns.empty()) {
     return false;
@@ -289,20 +306,7 @@ bool VerifyWideColumns(const WideColumns& columns) {
 
   const Slice& value_of_default = columns.front().value();
 
-  if (value_of_default.size() < sizeof(uint32_t)) {
-    return false;
-  }
-
-  const uint32_t value_base = GetValueBase(value_of_default);
-
-  const WideColumns expected_columns =
-      GenerateExpectedWideColumns(value_base, value_of_default);
-
-  if (columns != expected_columns) {
-    return false;
-  }
-
-  return true;
+  return VerifyWideColumns(value_of_default, columns);
 }
 
 std::string GetNowNanos() {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -213,6 +213,7 @@ DECLARE_bool(compare_full_db_state_snapshot);
 DECLARE_uint64(snapshot_hold_ops);
 DECLARE_bool(long_running_snapshots);
 DECLARE_bool(use_multiget);
+DECLARE_bool(use_get_entity);
 DECLARE_int32(readpercent);
 DECLARE_int32(prefixpercent);
 DECLARE_int32(writepercent);

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -645,6 +645,7 @@ extern uint32_t GetValueBase(Slice s);
 extern WideColumns GenerateWideColumns(uint32_t value_base, const Slice& slice);
 extern WideColumns GenerateExpectedWideColumns(uint32_t value_base,
                                                const Slice& slice);
+extern bool VerifyWideColumns(const Slice& value, const WideColumns& columns);
 extern bool VerifyWideColumns(const WideColumns& columns);
 
 extern StressTest* CreateCfConsistencyStressTest();

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -645,6 +645,7 @@ extern uint32_t GetValueBase(Slice s);
 extern WideColumns GenerateWideColumns(uint32_t value_base, const Slice& slice);
 extern WideColumns GenerateExpectedWideColumns(uint32_t value_base,
                                                const Slice& slice);
+extern bool VerifyWideColumns(const WideColumns& columns);
 
 extern StressTest* CreateCfConsistencyStressTest();
 extern StressTest* CreateBatchedOpsStressTest();

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -597,6 +597,24 @@ extern inline std::string StringToHex(const std::string& str) {
   return result;
 }
 
+inline std::string WideColumnsToHex(const WideColumns& columns) {
+  if (columns.empty()) {
+    return std::string();
+  }
+
+  std::ostringstream oss;
+
+  oss << std::hex;
+
+  auto it = columns.begin();
+  oss << *it;
+  for (++it; it != columns.end(); ++it) {
+    oss << ' ' << *it;
+  }
+
+  return oss.str();
+}
+
 // Unified output format for double parameters
 extern inline std::string FormatDoubleParam(double param) {
   return std::to_string(param);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -747,6 +747,9 @@ DEFINE_bool(long_running_snapshots, false,
 DEFINE_bool(use_multiget, false,
             "If set, use the batched MultiGet API for reads");
 
+DEFINE_bool(use_get_entity, false,
+            "If set, use the GetEntity API for reads");
+
 static bool ValidateInt32Percent(const char* flagname, int32_t value) {
   if (value < 0 || value > 100) {
     fprintf(stderr, "Invalid value for --%s: %d, 0<= pct <=100 \n", flagname,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -747,8 +747,7 @@ DEFINE_bool(long_running_snapshots, false,
 DEFINE_bool(use_multiget, false,
             "If set, use the batched MultiGet API for reads");
 
-DEFINE_bool(use_get_entity, false,
-            "If set, use the GetEntity API for reads");
+DEFINE_bool(use_get_entity, false, "If set, use the GetEntity API for reads");
 
 static bool ValidateInt32Percent(const char* flagname, int32_t value) {
   if (value < 0 || value > 100) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1004,7 +1004,8 @@ void StressTest::OperateDb(ThreadState* thread) {
       if (prob_op >= 0 && prob_op < static_cast<int>(FLAGS_readpercent)) {
         assert(0 <= prob_op);
         // OPERATION read
-        if (FLAGS_use_multiget) {
+        if (FLAGS_use_get_entity) {
+        } else if (FLAGS_use_multiget) {
           // Leave room for one more iteration of the loop with a single key
           // batch. This is to ensure that each thread does exactly the same
           // number of ops
@@ -2402,6 +2403,8 @@ void StressTest::PrintEnv() const {
           FLAGS_subcompactions);
   fprintf(stdout, "Use MultiGet              : %s\n",
           FLAGS_use_multiget ? "true" : "false");
+  fprintf(stdout, "Use GetEntity             : %s\n",
+          FLAGS_use_get_entity ? "true" : "false");
 
   const char* memtablerep = "";
   switch (FLAGS_rep_factory) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -445,13 +445,11 @@ void StressTest::VerificationAbort(SharedState* shared, int cf, int64_t key,
 }
 
 std::string StressTest::DebugString(const Slice& value,
-                                    const WideColumns& columns,
-                                    const WideColumns& expected_columns) {
+                                    const WideColumns& columns) {
   std::ostringstream oss;
 
   oss << "value: " << value.ToString(/* hex */ true)
-      << ", columns: " << WideColumnsToHex(columns)
-      << ", expected_columns: " << WideColumnsToHex(expected_columns);
+      << ", columns: " << WideColumnsToHex(columns);
 
   return oss.str();
 }
@@ -1475,12 +1473,12 @@ void StressTest::VerifyIterator(ThreadState* thread,
   }
 
   if (!*diverged && iter->Valid()) {
-    const WideColumns expected_columns =
-        GenerateExpectedWideColumns(GetValueBase(iter->value()), iter->value());
-    if (iter->columns() != expected_columns) {
-      fprintf(stderr, "Value and columns inconsistent for iterator: %s\n",
-              DebugString(iter->value(), iter->columns(), expected_columns)
-                  .c_str());
+    if (!VerifyWideColumns(iter->value(), iter->columns())) {
+      fprintf(stderr,
+              "Value and columns inconsistent for iterator: value: %s, "
+              "columns: %s\n",
+              iter->value().ToString(/* hex */ true).c_str(),
+              WideColumnsToHex(iter->columns()).c_str());
 
       *diverged = true;
     }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -987,6 +987,7 @@ void StressTest::OperateDb(ThreadState* thread) {
         assert(0 <= prob_op);
         // OPERATION read
         if (FLAGS_use_get_entity) {
+          TestGetEntity(thread, read_opts, rand_column_families, rand_keys);
         } else if (FLAGS_use_multiget) {
           // Leave room for one more iteration of the loop with a single key
           // batch. This is to ensure that each thread does exactly the same

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -429,17 +429,17 @@ void StressTest::VerificationAbort(SharedState* shared, std::string msg, int cf,
 
 void StressTest::VerificationAbort(SharedState* shared, int cf, int64_t key,
                                    const Slice& value,
-                                   const WideColumns& columns,
-                                   const WideColumns& expected_columns) const {
+                                   const WideColumns& columns) const {
   assert(shared);
 
   auto key_str = Key(key);
 
   fprintf(stderr,
           "Verification failed for column family %d key %s (%" PRIi64
-          "): Value and columns inconsistent: %s\n",
+          "): Value and columns inconsistent: value: %s, columns: %s\n",
           cf, Slice(key_str).ToString(/* hex */ true).c_str(), key,
-          DebugString(value, columns, expected_columns).c_str());
+          value.ToString(/* hex */ true).c_str(),
+          WideColumnsToHex(columns).c_str());
 
   shared->SetVerificationFailure();
 }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -449,27 +449,9 @@ std::string StressTest::DebugString(const Slice& value,
                                     const WideColumns& expected_columns) {
   std::ostringstream oss;
 
-  oss << "value: " << value.ToString(/* hex */ true);
-
-  auto dump = [](const WideColumns& cols, std::ostream& os) {
-    if (cols.empty()) {
-      return;
-    }
-
-    os << std::hex;
-
-    auto it = cols.begin();
-    os << *it;
-    for (++it; it != cols.end(); ++it) {
-      os << ' ' << *it;
-    }
-  };
-
-  oss << ", columns: ";
-  dump(columns, oss);
-
-  oss << ", expected_columns: ";
-  dump(expected_columns, oss);
+  oss << "value: " << value.ToString(/* hex */ true)
+      << ", columns: " << WideColumnsToHex(columns)
+      << ", expected_columns: " << WideColumnsToHex(expected_columns);
 
   return oss.str();
 }

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -94,12 +94,10 @@ class StressTest {
       const std::vector<int>& rand_column_families,
       const std::vector<int64_t>& rand_keys) = 0;
 
-  virtual Status TestGetEntity(
-      ThreadState* /* thread */, const ReadOptions& /* read_opts */,
-      const std::vector<int>& /* rand_column_families */,
-      const std::vector<int64_t>& /* rand_keys */) {
-    return Status::OK();
-  };
+  virtual void TestGetEntity(ThreadState* /* thread */,
+                             const ReadOptions& /* read_opts */,
+                             const std::vector<int>& /* rand_column_families */,
+                             const std::vector<int64_t>& /* rand_keys */) {}
 
   virtual Status TestPrefixScan(ThreadState* thread,
                                 const ReadOptions& read_opts,

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -228,8 +228,8 @@ class StressTest {
   void VerificationAbort(SharedState* shared, int cf, int64_t key,
                          const Slice& value, const WideColumns& columns) const;
 
-  static std::string DebugString(const Slice& value, const WideColumns& columns,
-                                 const WideColumns& expected_columns);
+  static std::string DebugString(const Slice& value,
+                                 const WideColumns& columns);
 
   void PrintEnv() const;
 

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -94,10 +94,9 @@ class StressTest {
       const std::vector<int>& rand_column_families,
       const std::vector<int64_t>& rand_keys) = 0;
 
-  virtual void TestGetEntity(ThreadState* /* thread */,
-                             const ReadOptions& /* read_opts */,
-                             const std::vector<int>& /* rand_column_families */,
-                             const std::vector<int64_t>& /* rand_keys */) {}
+  virtual void TestGetEntity(ThreadState* thread, const ReadOptions& read_opts,
+                             const std::vector<int>& rand_column_families,
+                             const std::vector<int64_t>& rand_keys) = 0;
 
   virtual Status TestPrefixScan(ThreadState* thread,
                                 const ReadOptions& read_opts,

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -226,8 +226,7 @@ class StressTest {
                          Slice value_from_expected) const;
 
   void VerificationAbort(SharedState* shared, int cf, int64_t key,
-                         const Slice& value, const WideColumns& columns,
-                         const WideColumns& expected_columns) const;
+                         const Slice& value, const WideColumns& columns) const;
 
   static std::string DebugString(const Slice& value, const WideColumns& columns,
                                  const WideColumns& expected_columns);

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -94,6 +94,13 @@ class StressTest {
       const std::vector<int>& rand_column_families,
       const std::vector<int64_t>& rand_keys) = 0;
 
+  virtual Status TestGetEntity(
+      ThreadState* /* thread */, const ReadOptions& /* read_opts */,
+      const std::vector<int>& /* rand_column_families */,
+      const std::vector<int64_t>& /* rand_keys */) {
+    return Status::OK();
+  };
+
   virtual Status TestPrefixScan(ThreadState* thread,
                                 const ReadOptions& read_opts,
                                 const std::vector<int>& rand_column_families,

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -387,6 +387,12 @@ std::vector<Status> MultiOpsTxnsStressTest::TestMultiGet(
   return std::vector<Status>{Status::NotSupported()};
 }
 
+// Wide columns are currently not supported by transactions.
+void MultiOpsTxnsStressTest::TestGetEntity(
+    ThreadState* /* thread */, const ReadOptions& /* read_opts */,
+    const std::vector<int>& /* rand_column_families */,
+    const std::vector<int64_t>& /* rand_keys */) {}
+
 Status MultiOpsTxnsStressTest::TestPrefixScan(
     ThreadState* thread, const ReadOptions& read_opts,
     const std::vector<int>& rand_column_families,

--- a/db_stress_tool/multi_ops_txns_stress.h
+++ b/db_stress_tool/multi_ops_txns_stress.h
@@ -210,6 +210,10 @@ class MultiOpsTxnsStressTest : public StressTest {
       const std::vector<int>& rand_column_families,
       const std::vector<int64_t>& rand_keys) override;
 
+  void TestGetEntity(ThreadState* thread, const ReadOptions& read_opts,
+                     const std::vector<int>& rand_column_families,
+                     const std::vector<int64_t>& rand_keys) override;
+
   Status TestPrefixScan(ThreadState* thread, const ReadOptions& read_opts,
                         const std::vector<int>& rand_column_families,
                         const std::vector<int64_t>& rand_keys) override;

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -756,9 +756,9 @@ class NonBatchedOpsStressTest : public StressTest {
     return statuses;
   }
 
-  Status TestGetEntity(ThreadState* thread, const ReadOptions& read_opts,
-                       const std::vector<int>& rand_column_families,
-                       const std::vector<int64_t>& rand_keys) override {
+  void TestGetEntity(ThreadState* thread, const ReadOptions& read_opts,
+                     const std::vector<int>& rand_column_families,
+                     const std::vector<int64_t>& rand_keys) override {
     if (fault_fs_guard) {
       fault_fs_guard->EnableErrorInjection();
       SharedState::ignore_read_error = false;
@@ -863,8 +863,6 @@ class NonBatchedOpsStressTest : public StressTest {
     if (fault_fs_guard) {
       fault_fs_guard->DisableErrorInjection();
     }
-
-    return s;
   }
 
   Status TestPrefixScan(ThreadState* thread, const ReadOptions& read_opts,

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -764,6 +764,9 @@ class NonBatchedOpsStressTest : public StressTest {
       SharedState::ignore_read_error = false;
     }
 
+    assert(thread);
+    assert(thread->shared);
+
     std::unique_ptr<MutexLock> lock(new MutexLock(
         thread->shared->GetMutexForKey(rand_column_families[0], rand_keys[0])));
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -778,7 +778,7 @@ class NonBatchedOpsStressTest : public StressTest {
 
     PinnableWideColumns from_db;
 
-    Status s = db_->GetEntity(read_opts, cfh, key, &from_db);
+    const Status s = db_->GetEntity(read_opts, cfh, key, &from_db);
 
     int error_count = 0;
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -769,10 +769,14 @@ class NonBatchedOpsStressTest : public StressTest {
     SharedState* const shared = thread->shared;
     assert(shared);
 
+    assert(!rand_keys.empty());
+
     std::unique_ptr<MutexLock> lock(new MutexLock(
         shared->GetMutexForKey(rand_column_families[0], rand_keys[0])));
 
     assert(!rand_column_families.empty());
+    assert(rand_column_families[0] >= 0);
+    assert(rand_column_families[0] < static_cast<int>(column_families_.size()));
 
     ColumnFamilyHandle* const cfh = column_families_[rand_column_families[0]];
     assert(cfh);

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -769,19 +769,17 @@ class NonBatchedOpsStressTest : public StressTest {
     SharedState* const shared = thread->shared;
     assert(shared);
 
+    assert(!rand_column_families.empty());
     assert(!rand_keys.empty());
 
     std::unique_ptr<MutexLock> lock(new MutexLock(
         shared->GetMutexForKey(rand_column_families[0], rand_keys[0])));
 
-    assert(!rand_column_families.empty());
     assert(rand_column_families[0] >= 0);
     assert(rand_column_families[0] < static_cast<int>(column_families_.size()));
 
     ColumnFamilyHandle* const cfh = column_families_[rand_column_families[0]];
     assert(cfh);
-
-    assert(!rand_keys.empty());
 
     const std::string key = Key(rand_keys[0]);
 
@@ -808,7 +806,6 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       }
 
-      // found case
       thread->stats.AddGets(1, 1);
 
       if (!FLAGS_skip_verifydb) {
@@ -841,7 +838,6 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       }
     } else if (s.IsNotFound()) {
-      // not found case
       thread->stats.AddGets(1, 0);
 
       if (!FLAGS_skip_verifydb) {
@@ -857,7 +853,6 @@ class NonBatchedOpsStressTest : public StressTest {
       }
     } else {
       if (error_count == 0) {
-        // errors case
         thread->stats.AddErrors(1);
       } else {
         thread->stats.AddVerifiedErrors(1);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -136,6 +136,7 @@ default_params = {
     "format_version": lambda: random.choice([2, 3, 4, 5, 5]),
     "index_block_restart_interval": lambda: random.choice(range(1, 16)),
     "use_multiget": lambda: random.randint(0, 1),
+    "use_get_entity": lambda: random.choice([0] * 7 + [1]),
     "periodic_compaction_seconds": lambda: random.choice([0, 0, 1, 2, 10, 100, 1000]),
     # 0 = never (used by some), 10 = often (for threading bugs), 600 = default
     "stats_dump_period_sec": lambda: random.choice([0, 10, 600]),


### PR DESCRIPTION
Summary:
The `GetEntity` API is currently used in the stress tests for verification purposes;
this patch extends the coverage by adding a mode where all point lookups in
the non-batched, batched, and CF consistency stress tests are done using this API.
The PR also includes a bit of refactoring to eliminate some boilerplate code around
the wide-column consistency checks.

Test Plan:
Ran stress tests of the batched, non-batched, and CF consistency varieties.