### PR TITLE
Emerging Device environment support for RocksDB

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -234,7 +234,7 @@ struct IODebugContext {
     return ss.str();
   }
 };
-
+enum DeviceType { HDD, Conventional, ZoneNameSpace, Computational };
 // A function pointer type for custom destruction of void pointer passed to
 // ReadAsync API. RocksDB/caller is responsible for deleting the void pointer
 // allocated by FS in ReadAsync API.
@@ -683,6 +683,7 @@ class FileSystem : public Customizable {
   }
 
   // If you're adding methods here, remember to add them to EnvWrapper too.
+  virtual DeviceType GetDeviceType(void) { return DeviceType::Conventional; }
 
  private:
   void operator=(const FileSystem&);
@@ -1521,6 +1522,7 @@ class FileSystemWrapper : public FileSystem {
   virtual IOStatus AbortIO(std::vector<void*>& io_handles) override {
     return target_->AbortIO(io_handles);
   }
+  virtual DeviceType GetDeviceType(void) { return target_->GetDeviceType(); }
 
  protected:
   std::shared_ptr<FileSystem> target_;


### PR DESCRIPTION
Hi. I hope RocksDB supports emerging next generation device by the "GetDeviceType" API.
As I'm researching at ZNS,Computational SSD, I need to configure some factors,parameters and operations at file system level.

1. HDD -> Hard Disk Drive
2. Conventional (SSD) -> generic SSD that you know
3. ZoneNameSpace (SSD) : SSD that adopts "Zone Interface" so that data placement is at host level
related paper :  ZNS: Avoiding the Block Interface Tax for Flash-based SSDs, ATC '21, Matias Bjørling, Abutalib Aghayev, Hans Holmberg, Aravind Ramesh, Damien Le Moal, Gregory R Ganger, George Amvrosiadis
4. Computational (SSD) : SSD that can utilize CPU in the SSD, edge computing
related paper : Query processing on smart SSDs: opportunities and challenges, SIGMOD '13 Jaeyoung Do, Yang-Suk Kee,Jignesh M. Patel, Chanik Park, Kwanghyun Park, David J. DeWitt

As normal people mostly use Conventional SSD, i set default is Conventional SSD.

Thank you.