### PR TITLE
fix intral0compaction selection logic.

### DIFF
--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -1132,6 +1132,9 @@ void CompactionPicker::RegisterCompaction(Compaction* c) {
       ioptions_.compaction_style == kCompactionStyleUniversal) {
     level0_compactions_in_progress_.insert(c);
   }
+  if(c->start_level() == 0 && c->output_level() != 0 && ioptions_.compaction_style == kCompactionStyleLevel) {
+    level0_to_lbase_compactions_in_progress_.insert(c);
+  }
   compactions_in_progress_.insert(c);
   TEST_SYNC_POINT_CALLBACK("CompactionPicker::RegisterCompaction:Registered",
                            c);
@@ -1144,6 +1147,9 @@ void CompactionPicker::UnregisterCompaction(Compaction* c) {
   if (c->start_level() == 0 ||
       ioptions_.compaction_style == kCompactionStyleUniversal) {
     level0_compactions_in_progress_.erase(c);
+  }
+  if(c->start_level() == 0 && c->output_level() != 0 && ioptions_.compaction_style == kCompactionStyleLevel) {
+    level0_to_lbase_compactions_in_progress_.erase(c);
   }
   compactions_in_progress_.erase(c);
 }

--- a/db/compaction/compaction_picker.h
+++ b/db/compaction/compaction_picker.h
@@ -130,6 +130,10 @@ class CompactionPicker {
   bool IsLevel0CompactionInProgress() const {
     return !level0_compactions_in_progress_.empty();
   }
+  bool IsLevel0ToLbaseCompactionInProgress() const {
+    return !level0_to_lbase_compactions_in_progress_.empty();
+  }
+
 
   // Return true if the passed key range overlap with a compaction output
   // that is currently running.
@@ -216,6 +220,9 @@ class CompactionPicker {
   std::set<Compaction*>* level0_compactions_in_progress() {
     return &level0_compactions_in_progress_;
   }
+  std::set<Compaction*>* level0_to_lbase_compactions_in_progress() {
+    return &level0_to_lbase_compactions_in_progress_;
+  }
   std::unordered_set<Compaction*>* compactions_in_progress() {
     return &compactions_in_progress_;
   }
@@ -234,6 +241,10 @@ class CompactionPicker {
   // Keeps track of all compactions that are running on Level0.
   // Protected by DB mutex
   std::set<Compaction*> level0_compactions_in_progress_;
+
+  // Keeps track of all level-0 to level-base compactions that are running on Level0.
+  // Protected by DB mutex
+  std::set<Compaction*> level0_to_lbase_compactions_in_progress_;
 
   // Keeps track of all compactions that are running.
   // Protected by DB mutex

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -712,6 +712,13 @@ bool LevelCompactionBuilder::PickFileToCompact() {
   // than one concurrent compactions at this level. This
   // could be made better by looking at key-ranges that are
   // being compacted at level 0.
+  
+  // TODO(Wang Qian) Should we use level0_to_lbase_compactions_in_progress() 
+  // instead of level0_compactions_in_progress()? Because a running 
+  // intra0compaction should not prevent l0->lbase compaction from 
+  // happening. But if such logic is allowed, it should be noted 
+  // that an sst in level0 which is older than any ssts that are 
+  // running intra0compaction cannot be compactioned to lbase.
   if (start_level_ == 0 &&
       !compaction_picker_->level0_compactions_in_progress()->empty()) {
     TEST_SYNC_POINT("LevelCompactionPicker::PickCompactionBySize:0");
@@ -814,10 +821,14 @@ bool LevelCompactionBuilder::PickIntraL0Compaction() {
   start_level_inputs_.clear();
   const std::vector<FileMetaData*>& level_files =
       vstorage_->LevelFiles(0 /* level */);
-  if (level_files.size() <
+  if (!compaction_picker_->level0_to_lbase_compactions_in_progress() || level_files.size() <
           static_cast<size_t>(
               mutable_cf_options_.level0_file_num_compaction_trigger + 2) ||
       level_files[0]->being_compacted) {
+    // In fact, We hope intra-level0 compaction only occurs when L0->base_level 
+    // compactions is running. So we check level0_to_lbase_compactions_in_progress()
+    // to avoid running Intra-level0 compaction cause a new Intra-level0 compaction.
+    // Which would cause a selection loop and make a big write pause.
     // If L0 isn't accumulating much files beyond the regular trigger, don't
     // resort to L0->L0 compaction yet.
     return false;


### PR DESCRIPTION
For this issue - https://github.com/facebook/rocksdb/issues/10903.I've implemented an improvement, submitted as this pull request.
**The reason of the bug:**
When selecting compaction, in PickCompaction(), some existing ssts participating in intra0compaction will be added as members of level0_compactions_in_progress_, thus preventing the compaction of l0->lbase from being selected. At the same time, if the compaction of l0->lbase is not selected this time, the code logic will try to continue to select intra0compaction, which will cause the content of level0_compactions_in_progress_ to continue to be expanded, resulting in a selection intralcompaction loop.
The biggest problem of this bug is that the intral0compaction will stop when the l0 file size reaches max_compaction_bytes, which is far greater than max_bytes_for_level_base at this time and it will cause a big write stall in Write's DelayWrite() logic.
**My improvements:**
A new set level0_to_lbase_compactions_in_progress_ is added to store all compactions of the current l0 to lbase compaction. Once it is empty, intra0compaction is allowed to be selected, instead of using level0_compactions_in_progress_ to judge before.
**Further Discussion:**
1. Do we need to improve the logic of selecting l0->lbase? The current logic is to give up the choice of l0->lbase compaction if level0_compactions_in_progress_ is not empty. Do we want to improve the choice of l0->lbase compaction if level0_to_lbase_compactions_in_progress_ is not empty? After all level0_compactions_in_progress_ contains intra0compaction. Of course, it needs to be noted here that when selecting l0->lbase compaction, it must be ensured that the selected l0 file is older than any sst that is undergoing intra0compaction.
2. In https://github.com/facebook/rocksdb/issues/10903, I mentioned that this bug may have a potential benefit, that is, it will cause the l0 file to reach a value far exceeding max_level_base_size and the be compacted to lbase, which will reduce the write amplification of l0->lbase. But I thought about it, this is actually not a benefit. After modifying this bug, we can achieve the same effect by increasing the value of max_bytes_for_level_base.