### PR TITLE
Disabling some IO error assertion in EnvLogger

### DIFF
--- a/logging/env_logger.h
+++ b/logging/env_logger.h
@@ -76,6 +76,7 @@ class EnvLogger : public Logger {
     if (flush_pending_) {
       flush_pending_ = false;
       file_.Flush().PermitUncheckedError();
+      file_.reset_seen_error();
     }
     last_flush_micros_ = clock_->NowMicros();
   }
@@ -162,6 +163,7 @@ class EnvLogger : public Logger {
         FileOpGuard guard(*this);
         // We will ignore any error returned by Append().
         file_.Append(Slice(base, p - base)).PermitUncheckedError();
+        file_.reset_seen_error();
         flush_pending_ = true;
         const uint64_t now_micros = clock_->NowMicros();
         if (now_micros - last_flush_micros_ >= flush_every_seconds_ * 1000000) {


### PR DESCRIPTION
Summary: Right now, EnvLogger has the same IO error assertion as most other places: if we are writing to the file after we've seen an IO error, the assertion would trigger. This is too strict for info logger: we would not fail DB if info logger fails and we would try the best to continue logging. For now, we simplify the problem by disabling the assertion for EnvLogger.

Test Plan: Run env_logger_test to make sure at least it doesn't fail in normal cases.