### PR TITLE
Deflake DBCompactionTest.CancelCompactionWaitingOnConflict

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3613,7 +3613,10 @@ TEST_F(DBCompactionTest, CancelCompactionWaitingOnConflict) {
   Random rnd(301);
   for (int i = 0; i < kNumSortedRuns; ++i) {
     int key_idx = 0;
-    GenerateNewFile(&rnd, &key_idx, true /* nowait */);
+    // We hold the compaction from happening, so when generating the last SST
+    // file, we cannot wait. Otherwise, we'll hit a deadlock.
+    GenerateNewFile(&rnd, &key_idx,
+                    (i == kNumSortedRuns - 1) ? true : false /* nowait */);
   }
   auto_compaction_sleeping_task.WaitUntilSleeping();
 


### PR DESCRIPTION
Summary:
In DBCompactionTest::CancelCompactionWaitingOnConflict, when generating SST files to trigger a compaction, we don't wait after each file, which may cause multiple memtables going to the same SST file, causing insufficient files to trigger the compaction. We do the waiting instead, except the last one, which would trigger compaction.

Test Plan: Run DBCompactionTest.CancelCompactionWaitingOnConflict multiple times.