### PR TITLE
Filter table files by timestamp: Get operator

### DIFF
--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -429,6 +429,12 @@ enum Tickers : uint32_t {
   // that finds its data for table open
   TABLE_OPEN_PREFETCH_TAIL_HIT,
 
+  // Statistics on the filtering by user-defined timestamps
+  // # of times timestamps are checked on accessing the table
+  TIMESTAMP_FILTER_TABLE_CHECKED,
+  // # of times timestamps can successfully help skip the table access
+  TIMESTAMP_FILTER_TABLE_FILTERED,
+
   TICKER_ENUM_MAX
 };
 

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -219,6 +219,9 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {SECONDARY_CACHE_DATA_HITS, "rocksdb.secondary.cache.data.hits"},
     {TABLE_OPEN_PREFETCH_TAIL_MISS, "rocksdb.table.open.prefetch.tail.miss"},
     {TABLE_OPEN_PREFETCH_TAIL_HIT, "rocksdb.table.open.prefetch.tail.hit"},
+    {TIMESTAMP_FILTER_TABLE_CHECKED, "rocksdb.timestamp.filter.table.checked"},
+    {TIMESTAMP_FILTER_TABLE_FILTERED,
+     "rocksdb.timestamp.filter.table.filtered"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -494,6 +494,8 @@ class BlockBasedTable : public TableReader {
   // in building the table file, otherwise true.
   bool PrefixExtractorChanged(const SliceTransform* prefix_extractor) const;
 
+  bool TimestampMayMatch(const ReadOptions& read_options) const;
+
   // A cumulative data block file read in MultiGet lower than this size will
   // use a stack buffer
   static constexpr size_t kMultiGetReadStackBufSize = 8192;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -597,9 +597,11 @@ struct BlockBasedTable::Rep {
   // move is involved
   int level;
 
-  // timestamp range
-  std::shared_ptr<Slice> min_timestamp = nullptr;
-  std::shared_ptr<Slice> max_timestamp = nullptr;
+  // the timestamp range of table
+  // Points into memory owned by TableProperties. This would need to change if
+  // TableProperties become subject to cache eviction.
+  Slice min_timestamp;
+  Slice max_timestamp;
 
   // If false, blocks in this file are definitely all uncompressed. Knowing this
   // before reading individual blocks enables certain optimizations.

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -597,6 +597,10 @@ struct BlockBasedTable::Rep {
   // move is involved
   int level;
 
+  // timestamp range
+  std::shared_ptr<Slice> min_timestamp = nullptr;
+  std::shared_ptr<Slice> max_timestamp = nullptr;
+
   // If false, blocks in this file are definitely all uncompressed. Knowing this
   // before reading individual blocks enables certain optimizations.
   bool blocks_maybe_compressed = true;


### PR DESCRIPTION
If RocksDB enables user-defined timestamp, then RocksDB read path can filter table files by the min/max timestamps of each file. If application wants to lookup a key that is the most recent and visible to a certain timestamp ts, then we can compare ts with the min_ts of each file. If ts < min_ts, then we know all keys in the file is not visible at time ts, then we do not have to open the file. This can also save an IO.