### PR TITLE
Fix compile error on platform010

### DIFF
--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -615,19 +615,19 @@ class CacheBench {
 #endif
     printf("RocksDB version     : %d.%d\n", kMajorVersion, kMinorVersion);
     printf("DMutex impl name    : %s\n", DMutex::kName());
-    printf("Number of threads   : %u\n", FLAGS_threads);
+    printf("Number of threads   : %u\n", FLAGS_threads.get());
     printf("Ops per thread      : %" PRIu64 "\n", FLAGS_ops_per_thread);
     printf("Cache size          : %s\n",
            BytesToHumanString(FLAGS_cache_size).c_str());
-    printf("Num shard bits      : %u\n", FLAGS_num_shard_bits);
+    printf("Num shard bits      : %u\n", FLAGS_num_shard_bits.get());
     printf("Max key             : %" PRIu64 "\n", max_key_);
     printf("Resident ratio      : %g\n", FLAGS_resident_ratio);
-    printf("Skew degree         : %u\n", FLAGS_skew);
+    printf("Skew degree         : %u\n", FLAGS_skew.get());
     printf("Populate cache      : %d\n", int{FLAGS_populate_cache});
-    printf("Lookup+Insert pct   : %u%%\n", FLAGS_lookup_insert_percent);
-    printf("Insert percentage   : %u%%\n", FLAGS_insert_percent);
-    printf("Lookup percentage   : %u%%\n", FLAGS_lookup_percent);
-    printf("Erase percentage    : %u%%\n", FLAGS_erase_percent);
+    printf("Lookup+Insert pct   : %u%%\n", FLAGS_lookup_insert_percent.get());
+    printf("Insert percentage   : %u%%\n", FLAGS_insert_percent.get());
+    printf("Lookup percentage   : %u%%\n", FLAGS_lookup_percent.get());
+    printf("Erase percentage    : %u%%\n", FLAGS_erase_percent.get());
     std::ostringstream stats;
     if (FLAGS_gather_stats) {
       stats << "enabled (" << FLAGS_gather_stats_sleep_ms << "ms, "
@@ -719,7 +719,7 @@ class StressCacheKey {
       // (but process-dependent) which is most easily simulated here by
       // assuming 1 DB and (later below) no session resets without process
       // reset.
-      FLAGS_sck_db_count = 1;
+      FLAGS_sck_db_count.get() = 1;
     }
 
     // Describe the simulated workload
@@ -767,13 +767,14 @@ class StressCacheKey {
         printf(
             "No collisions after %d x %u days                              "
             "                   \n",
-            i, FLAGS_sck_days_per_run);
+            i, FLAGS_sck_days_per_run.get());
       } else {
         double est = 1.0 * i * FLAGS_sck_days_per_run / collisions_;
         printf("%" PRIu64
                " collisions after %d x %u days, est %g days between (%g "
                "corrected)        \n",
-               collisions_, i, FLAGS_sck_days_per_run, est, est * multiplier_);
+               collisions_, i, FLAGS_sck_days_per_run.get(), est,
+               est * multiplier_);
       }
     }
   }
@@ -785,7 +786,7 @@ class StressCacheKey {
     const size_t table_mask = (size_t{1} << FLAGS_sck_table_bits) - 1;
     table_.reset(new uint64_t[table_mask + 1]{});
     if (FLAGS_sck_keep_bits > 64) {
-      FLAGS_sck_keep_bits = 64;
+      FLAGS_sck_keep_bits.get() = 64;
     }
 
     // Details of which bits are dropped in reduction

--- a/util/filter_bench.cc
+++ b/util/filter_bench.cc
@@ -320,7 +320,7 @@ struct FilterBench : public MockBlockBasedTableTester {
         random_(FLAGS_seed),
         m_queries_(0) {
     for (uint32_t i = 0; i < FLAGS_batch_size; ++i) {
-      kms_.emplace_back(FLAGS_key_size < 8 ? 8 : FLAGS_key_size);
+      kms_.emplace_back(FLAGS_key_size < 8 ? 8 : FLAGS_key_size.get());
     }
     ioptions_.logger = &stderr_logger_;
     table_options_.optimize_filters_for_memory =

--- a/util/ribbon_test.cc
+++ b/util/ribbon_test.cc
@@ -416,17 +416,17 @@ TYPED_TEST(RibbonTypeParamTest, CompactnessAndBacktrackAndFpRate) {
     return;
   }
 
-  const auto log2_thoroughness =
-      static_cast<uint32_t>(ROCKSDB_NAMESPACE::FloorLog2(FLAGS_thoroughness));
+  const auto log2_thoroughness = static_cast<uint32_t>(
+      ROCKSDB_NAMESPACE::FloorLog2(FLAGS_thoroughness.get()));
 
   // We are going to choose num_to_add using an exponential distribution,
   // so that we have good representation of small-to-medium filters.
   // Here we just pick some reasonable, practical upper bound based on
   // kCoeffBits or option.
   const double log_max_add = std::log(
-      FLAGS_max_add > 0 ? FLAGS_max_add
+      FLAGS_max_add > 0 ? FLAGS_max_add.get()
                         : static_cast<uint32_t>(kCoeffBits * kCoeffBits) *
-                              std::max(FLAGS_thoroughness, uint32_t{32}));
+                              std::max(FLAGS_thoroughness.get(), uint32_t{32}));
 
   // This needs to be enough below the minimum number of slots to get a
   // reasonable number of samples with the minimum number of slots.


### PR DESCRIPTION
We have recently switched to using platform010 #11333. Now the main branch has compilation error mainly because std::reference_wrapper<T> is not compatible when we are expecting the type T. 

Examples of errors: 
```
cache/cache_bench_tool.cc:618:12: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 2 has type ‘std::reference_wrapper<unsigned int>’ [-Werror=format=]
     printf("Number of threads   : %u\n", FLAGS_threads);
```

```
cache/cache_bench_tool.cc:722:28: error: use of deleted function ‘std::reference_wrapper<_Tp>::reference_wrapper(_Tp&&) [with _Tp = unsigned int]’
       FLAGS_sck_db_count = 1;
```

```
cache/cache_bench_tool.cc:773:16: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘std::reference_wrapper<unsigned int>’ [-Werror=format=]
         printf("%" PRIu64
                ^~~~~~~~~~
                " collisions after %d x %u days, est %g days between (%g "
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                "corrected)        \n",
                ~~~~~~~~~~~~~~~~~~~~~~
                collisions_, i, FLAGS_sck_days_per_run, est, est * multiplier_);
```

Hereby, fix the error by using .get() method