### PR TITLE
Fix gflags_compat.h

### DIFF
--- a/util/gflags_compat.h
+++ b/util/gflags_compat.h
@@ -15,16 +15,15 @@
 #endif
 
 #ifndef DEFINE_uint32
-// DEFINE_uint32 does not appear in older versions of gflags. This should be
-// a sane definition for those versions.
+// DEFINE_uint32 / DECLARE_uint32 do not appear in older versions of gflags.
+// These should be sane definitions for those versions.
 #include <cstdint>
-#define DEFINE_uint32(name, val, txt)             \
-  namespace gflags_compat {                       \
-  DEFINE_int32(name, val, txt);                   \
-  }                                               \
-  std::reference_wrapper<uint32_t> FLAGS_##name = \
-      std::ref(*reinterpret_cast<uint32_t *>(&gflags_compat::FLAGS_##name));
+#define DEFINE_uint32(name, val, txt) \
+  namespace gflags_compat {           \
+  DEFINE_int32(name, val, txt);       \
+  }                                   \
+  uint32_t &FLAGS_##name =            \
+      *reinterpret_cast<uint32_t *>(&gflags_compat::FLAGS_##name);
 
-#define DECLARE_uint32(name) \
-  extern std::reference_wrapper<uint32_t> FLAGS_##name;
+#define DECLARE_uint32(name) extern uint32_t &FLAGS_##name;
 #endif  // !DEFINE_uint32


### PR DESCRIPTION
Summary: Was getting compilation failure with old verison of gflags, examples in #11344.  Perhaps this is new since enabling C++17. Getting rid of std::reference_wrapper from #10729 seems to fix it.

Test Plan: manual, CI