### PR TITLE
Fix initialization-order-fiasco in write_stall_stats.cc

### DIFF
--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -2109,25 +2109,26 @@ TEST_F(DBPropertiesTest, GetMapPropertyBlockCacheEntryStats) {
 
 TEST_F(DBPropertiesTest, WriteStallStatsSanityCheck) {
   for (uint32_t i = 0; i < static_cast<uint32_t>(WriteStallCause::kNone); ++i) {
-    std::string str = kWriteStallCauseToHyphenString[i];
+    WriteStallCause cause = static_cast<WriteStallCause>(i);
+    const std::string& str = WriteStallCauseToHyphenString(cause);
     ASSERT_TRUE(!str.empty())
         << "Please ensure mapping from `WriteStallCause` to "
-           "`kWriteStallCauseToHyphenString` is complete";
-    WriteStallCause cause = static_cast<WriteStallCause>(i);
+           "`WriteStallCauseToHyphenString` is complete";
     if (cause == WriteStallCause::kCFScopeWriteStallCauseEnumMax ||
         cause == WriteStallCause::kDBScopeWriteStallCauseEnumMax) {
-      ASSERT_EQ(str, kInvalidWriteStallCauseHyphenString)
-          << "Please ensure order in `kWriteStallCauseToHyphenString` is "
+      ASSERT_EQ(str, InvalidWriteStallHyphenString())
+          << "Please ensure order in `WriteStallCauseToHyphenString` is "
              "consistent with `WriteStallCause`";
     }
   }
 
   for (uint32_t i = 0; i < static_cast<uint32_t>(WriteStallCondition::kNormal);
        ++i) {
-    std::string str = kWriteStallConditionToHyphenString[i];
+    WriteStallCondition condition = static_cast<WriteStallCondition>(i);
+    const std::string& str = WriteStallConditionToHyphenString(condition);
     ASSERT_TRUE(!str.empty())
         << "Please ensure mapping from `WriteStallCondition` to "
-           "`kWriteStallConditionToHyphenString` is complete";
+           "`WriteStallConditionToHyphenString` is complete";
   }
 
   for (uint32_t i = 0; i < static_cast<uint32_t>(WriteStallCause::kNone); ++i) {

--- a/db/write_stall_stats.cc
+++ b/db/write_stall_stats.cc
@@ -6,26 +6,46 @@
 #include "db/write_stall_stats.h"
 
 namespace ROCKSDB_NAMESPACE {
-const std::string kInvalidWriteStallCauseHyphenString = "invalid";
+const std::string& InvalidWriteStallHyphenString() {
+  static const std::string kInvalidWriteStallHyphenString = "invalid";
+  return kInvalidWriteStallHyphenString;
+}
 
-const std::array<std::string, static_cast<uint32_t>(WriteStallCause::kNone)>
-    kWriteStallCauseToHyphenString{{
-        "memtable-limit",
-        "l0-file-count-limit",
-        "pending-compaction-bytes",
-        // WriteStallCause::kCFScopeWriteStallCauseEnumMax
-        kInvalidWriteStallCauseHyphenString,
-        "write-buffer-manager-limit",
-        // WriteStallCause::kDBScopeWriteStallCauseEnumMax
-        kInvalidWriteStallCauseHyphenString,
-    }};
+const std::string& WriteStallCauseToHyphenString(WriteStallCause cause) {
+  static const std::string kMemtableLimit = "memtable-limit";
+  static const std::string kL0FileCountLimit = "l0-file-count-limit";
+  static const std::string kPendingCompactionBytes = "pending-compaction-bytes";
+  static const std::string kWriteBufferManagerLimit =
+      "write-buffer-manager-limit";
+  switch (cause) {
+    case WriteStallCause::kMemtableLimit:
+      return kMemtableLimit;
+    case WriteStallCause::kL0FileCountLimit:
+      return kL0FileCountLimit;
+    case WriteStallCause::kPendingCompactionBytes:
+      return kPendingCompactionBytes;
+    case WriteStallCause::kWriteBufferManagerLimit:
+      return kWriteBufferManagerLimit;
+    default:
+      break;
+  }
+  return InvalidWriteStallHyphenString();
+}
 
-const std::array<std::string,
-                 static_cast<uint32_t>(WriteStallCondition::kNormal)>
-    kWriteStallConditionToHyphenString{{
-        "delays",
-        "stops",
-    }};
+const std::string& WriteStallConditionToHyphenString(
+    WriteStallCondition condition) {
+  static const std::string kDelayed = "delays";
+  static const std::string kStopped = "stops";
+  switch (condition) {
+    case WriteStallCondition::kDelayed:
+      return kDelayed;
+    case WriteStallCondition::kStopped:
+      return kStopped;
+    default:
+      break;
+  }
+  return InvalidWriteStallHyphenString();
+}
 
 InternalStats::InternalCFStatsType InternalCFStat(
     WriteStallCause cause, WriteStallCondition condition) {
@@ -139,14 +159,14 @@ std::string WriteStallStatsMapKeys::CauseConditionCount(
 
   std::string cause_name;
   if (isCFScopeWriteStallCause(cause) || isDBScopeWriteStallCause(cause)) {
-    cause_name = kWriteStallCauseToHyphenString[static_cast<uint32_t>(cause)];
+    cause_name = WriteStallCauseToHyphenString(cause);
   } else {
     assert(false);
     return "";
   }
 
   const std::string& condition_name =
-      kWriteStallConditionToHyphenString[static_cast<uint32_t>(condition)];
+      WriteStallConditionToHyphenString(condition);
 
   cause_condition_count_name.reserve(cause_name.size() + 1 +
                                      condition_name.size());

--- a/db/write_stall_stats.h
+++ b/db/write_stall_stats.h
@@ -11,15 +11,12 @@
 #include "rocksdb/types.h"
 
 namespace ROCKSDB_NAMESPACE {
-extern const std::string kInvalidWriteStallCauseHyphenString;
+extern const std::string& InvalidWriteStallHyphenString();
 
-extern const std::array<std::string,
-                        static_cast<uint32_t>(WriteStallCause::kNone)>
-    kWriteStallCauseToHyphenString;
+extern const std::string& WriteStallCauseToHyphenString(WriteStallCause cause);
 
-extern const std::array<std::string,
-                        static_cast<uint32_t>(WriteStallCondition::kNormal)>
-    kWriteStallConditionToHyphenString;
+extern const std::string& WriteStallConditionToHyphenString(
+    WriteStallCondition condition);
 
 // REQUIRES:
 // cause` is CF-scope `WriteStallCause`, see `WriteStallCause` for more


### PR DESCRIPTION
**Context/Summary:**
As title.

**Test:**
- Ran previously failed tests and they succeed
- Perf
`./db_bench -seed=1679014417652004 -db=/dev/shm/testdb/ -statistics=false -benchmarks="fillseq[-X60]" -key_size=32 -value_size=512 -num=100000 -db_write_buffer_size=655 -target_file_size_base=655 -disable_auto_compactions=false -compression_type=none -bloom_bits=3`