### PR TITLE
Add an option to trigger flush when the number of range deletions reach a threshold

### DIFF
--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -887,6 +887,9 @@ Status FlushJob::WriteLevel0Table() {
       total_num_range_deletes += m->num_range_deletes();
     }
 
+    // TODO(cbi): when memtable is flushed due to number of range deletions
+    //  hitting limit memtable_max_range_deletions, flush_reason_ is still
+    //  "Write Buffer Full", should make update flush_reason_ accordingly.
     event_logger_->Log() << "job" << job_context_->job_id << "event"
                          << "flush_started"
                          << "num_memtables" << mems_.size() << "num_entries"

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -861,6 +861,7 @@ Status FlushJob::WriteLevel0Table() {
     uint64_t total_num_entries = 0, total_num_deletes = 0;
     uint64_t total_data_size = 0;
     size_t total_memory_usage = 0;
+    uint64_t total_num_range_deletes = 0;
     // Used for testing:
     uint64_t mems_size = mems_.size();
     (void)mems_size;  // avoids unused variable error when
@@ -883,6 +884,7 @@ Status FlushJob::WriteLevel0Table() {
       total_num_deletes += m->num_deletes();
       total_data_size += m->get_data_size();
       total_memory_usage += m->ApproximateMemoryUsage();
+      total_num_range_deletes += m->num_range_deletes();
     }
 
     event_logger_->Log() << "job" << job_context_->job_id << "event"
@@ -891,7 +893,8 @@ Status FlushJob::WriteLevel0Table() {
                          << total_num_entries << "num_deletes"
                          << total_num_deletes << "total_data_size"
                          << total_data_size << "memory_usage"
-                         << total_memory_usage << "flush_reason"
+                         << total_memory_usage << "num_range_deletes"
+                         << total_num_range_deletes << "flush_reason"
                          << GetFlushReasonString(flush_reason_);
 
     {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -836,8 +836,8 @@ Status MemTable::Add(SequenceNumber s, ValueType type,
     auto new_cache = std::make_shared<FragmentedRangeTombstoneListCache>();
     size_t size = cached_range_tombstone_.Size();
     if (allow_concurrent) {
-      range_del_mutex_.lock();
       post_process_info->num_range_deletes++;
+      range_del_mutex_.lock();
     }
     for (size_t i = 0; i < size; ++i) {
       std::shared_ptr<FragmentedRangeTombstoneListCache>* local_cache_ref_ptr =

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -765,15 +765,6 @@ Status MemTable::Add(SequenceNumber s, ValueType type,
         type == kTypeDeletionWithTimestamp) {
       num_deletes_.store(num_deletes_.load(std::memory_order_relaxed) + 1,
                          std::memory_order_relaxed);
-    } else if (type == kTypeRangeDeletion) {
-      uint64_t val = num_range_deletes_.load(std::memory_order_relaxed) + 1;
-      num_range_deletes_.store(val, std::memory_order_relaxed);
-      // Arrange for a flush if too many delete ranges have been issued.
-      if (memtable_max_range_deletions_ > 0 &&
-          memtable_max_range_deletions_reached_ == false &&
-          val > (uint64_t)memtable_max_range_deletions_) {
-        memtable_max_range_deletions_reached_ = true;
-      }
     }
 
     if (bloom_filter_ && prefix_extractor_ &&
@@ -858,6 +849,16 @@ Status MemTable::Add(SequenceNumber s, ValueType type,
               new_local_cache_ref, new_cache.get()),
           std::memory_order_relaxed);
     }
+
+    uint64_t val = num_range_deletes_.load(std::memory_order_relaxed) + 1;
+    num_range_deletes_.store(val, std::memory_order_relaxed);
+    // Arrange for a flush if too many delete ranges have been issued.
+    if (memtable_max_range_deletions_ > 0 &&
+        memtable_max_range_deletions_reached_ == false &&
+        val > (uint64_t)memtable_max_range_deletions_) {
+      memtable_max_range_deletions_reached_ = true;
+    }
+
     if (allow_concurrent) {
       range_del_mutex_.unlock();
     }

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -565,6 +565,7 @@ class MemTable {
   std::atomic<uint64_t> data_size_;
   std::atomic<uint64_t> num_entries_;
   std::atomic<uint64_t> num_deletes_;
+  std::atomic<uint64_t> num_range_deletes_;
 
   // Dynamically changeable memtable option
   std::atomic<size_t> write_buffer_size_;
@@ -625,6 +626,13 @@ class MemTable {
   // keep track of memory usage in table_, arena_, and range_del_table_.
   // Gets refreshed inside `ApproximateMemoryUsage()` or `ShouldFlushNow`
   std::atomic<uint64_t> approximate_memory_usage_;
+
+  // max range deletions in a memtable,  before automatic flushing, 0 for
+  // unlimited.
+  uint32_t memtable_max_range_deletions_ = 0;
+  // Range-delete will turn this flag on, if memtable_max_range_deletions_ is
+  // reached. ShouldFlushNow() will check this.
+  bool memtable_max_range_deletions_reached_ = false;
 
   // Flush job info of the current memtable.
   std::unique_ptr<FlushJobInfo> flush_job_info_;

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -349,6 +349,13 @@ class MemTable {
     return num_deletes_.load(std::memory_order_relaxed);
   }
 
+  // Get total number of range deletions in the mem table.
+  // REQUIRES: external synchronization to prevent simultaneous
+  // operations on the same MemTable (unless this Memtable is immutable).
+  uint64_t num_range_deletes() const {
+    return num_range_deletes_.load(std::memory_order_relaxed);
+  }
+
   uint64_t get_data_size() const {
     return data_size_.load(std::memory_order_relaxed);
   }

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -337,11 +337,6 @@ class MemTable {
       uint64_t val = num_range_deletes_.load(std::memory_order_relaxed) +
                      update_counters.num_range_deletes;
       num_range_deletes_.store(val, std::memory_order_relaxed);
-      if (memtable_max_range_deletions_ > 0 &&
-          memtable_max_range_deletions_reached_ == false &&
-          val >= (uint64_t)memtable_max_range_deletions_) {
-        memtable_max_range_deletions_reached_ = true;
-      }
     }
     UpdateFlushState();
   }
@@ -648,9 +643,6 @@ class MemTable {
   // max range deletions in a memtable,  before automatic flushing, 0 for
   // unlimited.
   uint32_t memtable_max_range_deletions_ = 0;
-  // Range-delete will turn this flag on, if memtable_max_range_deletions_ is
-  // reached. ShouldFlushNow() will check this.
-  bool memtable_max_range_deletions_reached_ = false;
 
   // Flush job info of the current memtable.
   std::unique_ptr<FlushJobInfo> flush_job_info_;

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -334,9 +334,8 @@ class MemTable {
                              std::memory_order_relaxed);
     }
     if (update_counters.num_range_deletes > 0) {
-      uint64_t val = num_range_deletes_.load(std::memory_order_relaxed) +
-                     update_counters.num_range_deletes;
-      num_range_deletes_.store(val, std::memory_order_relaxed);
+      num_range_deletes_.fetch_add(update_counters.num_range_deletes,
+                                   std::memory_order_relaxed);
     }
     UpdateFlushState();
   }

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -327,6 +327,8 @@ DECLARE_bool(allow_data_in_errors);
 
 DECLARE_bool(enable_thread_tracking);
 
+DECLARE_uint32(memtable_max_range_deletions);
+
 // Tiered storage
 DECLARE_bool(enable_tiered_storage);  // set last_level_temperature
 DECLARE_int64(preclude_last_level_data_seconds);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1102,4 +1102,8 @@ DEFINE_uint64(stats_dump_period_sec,
 DEFINE_bool(use_io_uring, false, "Enable the use of IO uring on Posix");
 extern "C" bool RocksDbIOUringEnable() { return FLAGS_use_io_uring; }
 
+DEFINE_uint32(memtable_max_range_deletions, 0,
+              "If nonzero, RocksDB will try to flush the current memtable"
+              "after the number of range deletions is >= this limit");
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3278,6 +3278,8 @@ void InitializeOptionsFromFlags(
   options.allow_data_in_errors = FLAGS_allow_data_in_errors;
 
   options.enable_thread_tracking = FLAGS_enable_thread_tracking;
+
+  options.memtable_max_range_deletions = FLAGS_memtable_max_range_deletions;
 }
 
 void InitializeOptionsGeneral(

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -331,9 +331,15 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Default: nullptr
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory = nullptr;
 
-  // Automatic flush after range deletions count in memtable hits this limit.
-  // helps with workloads having lot of range deletes.
-  // 0 to disable it completely
+  // RocksDB will try to flush the current memtable after the number of range
+  // deletions in the memtable hits this limit. For workloads with many range
+  // deletions, limiting the number of range deletions in memtable can help
+  // prevent performance degradation and/or OOM caused by too many range
+  // tombstones in a single memtable.
+  //
+  // Default: 0 (disabled)
+  //
+  // Dynamically changeable through SetOptions() API
   uint32_t memtable_max_range_deletions = 0;
 
   // Create ColumnFamilyOptions with default values for all fields

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -331,6 +331,11 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Default: nullptr
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory = nullptr;
 
+  // Automatic flush after range deletions count in memtable hits this limit.
+  // helps with workloads having lot of range deletes.
+  // 0 to disable it completely
+  uint32_t memtable_max_range_deletions = 0;
+
   // Create ColumnFamilyOptions with default values for all fields
   ColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -332,7 +332,7 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory = nullptr;
 
   // RocksDB will try to flush the current memtable after the number of range
-  // deletions in the memtable hits this limit. For workloads with many range
+  // deletions is >= this limit. For workloads with many range
   // deletions, limiting the number of range deletions in memtable can help
   // prevent performance degradation and/or OOM caused by too many range
   // tombstones in a single memtable.

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -3912,7 +3912,8 @@ jbyte Java_org_rocksdb_Options_prepopulateBlobCache(JNIEnv*, jobject,
 void Java_org_rocksdb_Options_setMemtableMaxRangeDeletions(
     JNIEnv*, jobject, jlong jhandle, jint jmemtable_max_range_deletions) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
-  opts->memtable_max_range_deletions = jmemtable_max_range_deletions;
+  opts->memtable_max_range_deletions =
+      static_cast<int32_t>(jmemtable_max_range_deletions);
 }
 
 /*

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -3904,6 +3904,28 @@ jbyte Java_org_rocksdb_Options_prepopulateBlobCache(JNIEnv*, jobject,
       opts->prepopulate_blob_cache);
 }
 
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setMemtableMaxRangeDeletions
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_Options_setMemtableMaxRangeDeletions(
+    JNIEnv*, jobject, jlong jhandle, jint jmemtable_max_range_deletions) {
+  auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opts->memtable_max_range_deletions = jmemtable_max_range_deletions;
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    memtableMaxRangeDeletions
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_Options_memtableMaxRangeDeletions(JNIEnv*, jobject,
+                                                        jlong jhandle) {
+  auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jint>(opts->memtable_max_range_deletions);
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // ROCKSDB_NAMESPACE::ColumnFamilyOptions
 
@@ -5768,6 +5790,30 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_prepopulateBlobCache(JNIEnv*,
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return ROCKSDB_NAMESPACE::PrepopulateBlobCacheJni::toJavaPrepopulateBlobCache(
       opts->prepopulate_blob_cache);
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyOptions
+ * Method:    setMemtableMaxRangeDeletions
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_ColumnFamilyOptions_setMemtableMaxRangeDeletions(
+    JNIEnv*, jobject, jlong jhandle, jint jmemtable_max_range_deletions) {
+  auto* opts =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
+  opts->memtable_max_range_deletions = jmemtable_max_range_deletions;
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyOptions
+ * Method:    memtableMaxRangeDeletions
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_ColumnFamilyOptions_memtableMaxRangeDeletions(
+    JNIEnv*, jobject, jlong jhandle) {
+  auto* opts =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
+  return static_cast<jint>(opts->memtable_max_range_deletions);
 }
 
 /////////////////////////////////////////////////////////////////////

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -959,6 +959,17 @@ public class ColumnFamilyOptions extends RocksObject
     return sstPartitionerFactory_;
   }
 
+  @Override
+  public ColumnFamilyOptions setMemtableMaxRangeDeletions(final int count) {
+    setMemtableMaxRangeDeletions(nativeHandle_, count);
+    return this;
+  }
+
+  @Override
+  public int memtableMaxRangeDeletions() {
+    return memtableMaxRangeDeletions(nativeHandle_);
+  }
+
   //
   // BEGIN options for blobs (integrated BlobDB)
   //
@@ -1498,6 +1509,8 @@ public class ColumnFamilyOptions extends RocksObject
   private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
   private static native void setCompactionThreadLimiter(
       final long nativeHandle_, final long compactionThreadLimiterHandle);
+  private native void setMemtableMaxRangeDeletions(final long handle, final int count);
+  private native int memtableMaxRangeDeletions(final long handle);
 
   private native void setEnableBlobFiles(final long nativeHandle_, final boolean enableBlobFiles);
   private native boolean enableBlobFiles(final long nativeHandle_);

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
@@ -507,6 +507,23 @@ public interface ColumnFamilyOptionsInterface<T extends ColumnFamilyOptionsInter
   SstPartitionerFactory sstPartitionerFactory();
 
   /**
+   * Sets the maximum range delete calls, after which memtable is flushed.
+   * This applies to the mutable memtable.
+   *
+   * @param a positive integer, 0 (default) to disable the feature.
+   * @return the reference of the current options.
+   */
+  T setMemtableMaxRangeDeletions(final int count);
+
+  /**
+   * Gets the current setting of maximum range deletes allowed
+   * 0(default) indicates that feature is disabled.
+   *
+   * @return current value of memtable_max_range_deletions
+   */
+  int memtableMaxRangeDeletions();
+
+  /**
    * Compaction concurrent thread limiter for the column family.
    * If non-nullptr, use given concurrent thread limiter to control
    * the max outstanding compaction tasks. Limiter can be shared with

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
@@ -510,7 +510,7 @@ public interface ColumnFamilyOptionsInterface<T extends ColumnFamilyOptionsInter
    * Sets the maximum range delete calls, after which memtable is flushed.
    * This applies to the mutable memtable.
    *
-   * @param a positive integer, 0 (default) to disable the feature.
+   * @param count a positive integer, 0 (default) to disable the feature.
    * @return the reference of the current options.
    */
   T setMemtableMaxRangeDeletions(final int count);

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -1985,6 +1985,17 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options setMemtableMaxRangeDeletions(final int count) {
+    setMemtableMaxRangeDeletions(nativeHandle_, count);
+    return this;
+  }
+
+  @Override
+  public int memtableMaxRangeDeletions() {
+    return memtableMaxRangeDeletions(nativeHandle_);
+  }
+
+  @Override
   public Options setCompactionThreadLimiter(final ConcurrentTaskLimiter compactionThreadLimiter) {
     setCompactionThreadLimiter(nativeHandle_, compactionThreadLimiter.nativeHandle_);
     this.compactionThreadLimiter_ = compactionThreadLimiter;
@@ -2502,6 +2513,8 @@ public class Options extends RocksObject
       final boolean atomicFlush);
   private native boolean atomicFlush(final long handle);
   private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
+  private native void setMemtableMaxRangeDeletions(final long handle, final int count);
+  private native int memtableMaxRangeDeletions(final long handle);
   private static native void setCompactionThreadLimiter(
       final long nativeHandle_, final long newLimiterHandle);
   private static native void setAvoidUnnecessaryBlockingIO(

--- a/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
@@ -709,4 +709,14 @@ public class ColumnFamilyOptionsTest {
       assertThat(options.cfPaths()).isEqualTo(paths);
     }
   }
+
+  @Test
+  public void memtableMaxRangeDeletions() {
+    try (final ColumnFamilyOptions options = new ColumnFamilyOptions()) {
+      assertThat(options.memtableMaxRangeDeletions()).isEqualTo(0);
+      final int val = 32;
+      assertThat(options.setMemtableMaxRangeDeletions(val)).isEqualTo(options);
+      assertThat(options.memtableMaxRangeDeletions()).isEqualTo(val);
+    }
+  }
 }

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -1453,6 +1453,16 @@ public class OptionsTest {
   }
 
   @Test
+  public void memtableMaxRangeDeletions() {
+    try (final Options options = new Options()) {
+      assertThat(options.memtableMaxRangeDeletions()).isEqualTo(0);
+      final int val = 32;
+      assertThat(options.setMemtableMaxRangeDeletions(val)).isEqualTo(options);
+      assertThat(options.memtableMaxRangeDeletions()).isEqualTo(val);
+    }
+  }
+
+  @Test
   public void eventListeners() {
     final AtomicBoolean wasCalled1 = new AtomicBoolean();
     final AtomicBoolean wasCalled2 = new AtomicBoolean();

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -552,6 +552,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
                }
              })},
         // End special case properties
+        {"memtable_max_range_deletions",
+         {offsetof(struct MutableCFOptions, memtable_max_range_deletions),
+          OptionType::kUInt32T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+
 };
 
 static std::unordered_map<std::string, OptionTypeInfo>

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -555,7 +555,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
         {"memtable_max_range_deletions",
          {offsetof(struct MutableCFOptions, memtable_max_range_deletions),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone}},
+          OptionTypeFlags::kMutable}},
 
 };
 

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -175,7 +175,8 @@ struct MutableCFOptions {
         block_protection_bytes_per_key(options.block_protection_bytes_per_key),
         sample_for_compression(
             options.sample_for_compression),  // TODO: is 0 fine here?
-        compression_per_level(options.compression_per_level) {
+        compression_per_level(options.compression_per_level),
+        memtable_max_range_deletions(options.memtable_max_range_deletions) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -224,7 +225,8 @@ struct MutableCFOptions {
         last_level_temperature(Temperature::kUnknown),
         memtable_protection_bytes_per_key(0),
         block_protection_bytes_per_key(0),
-        sample_for_compression(0) {}
+        sample_for_compression(0),
+        memtable_max_range_deletions(0) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -318,6 +320,7 @@ struct MutableCFOptions {
 
   uint64_t sample_for_compression;
   std::vector<CompressionType> compression_per_level;
+  uint32_t memtable_max_range_deletions;
 
   // Derived options
   // Per-level target file size.

--- a/options/options.cc
+++ b/options/options.cc
@@ -450,6 +450,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     }
     ROCKS_LOG_HEADER(log, "Options.experimental_mempurge_threshold: %f",
                      experimental_mempurge_threshold);
+    ROCKS_LOG_HEADER(log, "   Options.memtable_max_range_deletions: %d",
+                     memtable_max_range_deletions);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/options/options.cc
+++ b/options/options.cc
@@ -448,9 +448,9 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
               ? "flush only"
               : "disabled");
     }
-    ROCKS_LOG_HEADER(log, "Options.experimental_mempurge_threshold: %f",
+    ROCKS_LOG_HEADER(log, "        Options.experimental_mempurge_threshold: %f",
                      experimental_mempurge_threshold);
-    ROCKS_LOG_HEADER(log, "   Options.memtable_max_range_deletions: %d",
+    ROCKS_LOG_HEADER(log, "           Options.memtable_max_range_deletions: %d",
                      memtable_max_range_deletions);
 }  // ColumnFamilyOptions::Dump
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -272,6 +272,7 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->compression_per_level = moptions.compression_per_level;
   cf_opts->last_level_temperature = moptions.last_level_temperature;
   cf_opts->bottommost_temperature = moptions.last_level_temperature;
+  cf_opts->memtable_max_range_deletions = moptions.memtable_max_range_deletions;
 }
 
 void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -557,7 +557,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "blob_cache=1M;"
       "memtable_protection_bytes_per_key=2;"
       "persist_user_defined_timestamps=true;"
-      "block_protection_bytes_per_key=1;",
+      "block_protection_bytes_per_key=1;"
+      "memtable_max_range_deletions=999999;",
       new_options));
 
   ASSERT_NE(new_options->blob_cache.get(), nullptr);

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -131,6 +131,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"prepopulate_blob_cache", "kDisable"},
       {"last_level_temperature", "kWarm"},
       {"persist_user_defined_timestamps", "true"},
+      {"memtable_max_range_deletions", "0"},
   };
 
   std::unordered_map<std::string, std::string> db_options_map = {
@@ -284,6 +285,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.last_level_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.persist_user_defined_timestamps, true);
+  ASSERT_EQ(new_cf_opt.memtable_max_range_deletions, 0);
 
   cf_options_map["write_buffer_size"] = "hello";
   ASSERT_NOK(GetColumnFamilyOptionsFromMap(exact, base_cf_opt, cf_options_map,
@@ -2338,6 +2340,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
       {"prepopulate_blob_cache", "kDisable"},
       {"last_level_temperature", "kWarm"},
       {"persist_user_defined_timestamps", "true"},
+      {"memtable_max_range_deletions", "0"},
   };
 
   std::unordered_map<std::string, std::string> db_options_map = {
@@ -2489,6 +2492,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.last_level_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.persist_user_defined_timestamps, true);
+  ASSERT_EQ(new_cf_opt.memtable_max_range_deletions, 0);
 
   cf_options_map["write_buffer_size"] = "hello";
   ASSERT_NOK(GetColumnFamilyOptionsFromMap(cf_config_options, base_cf_opt,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -208,6 +208,7 @@ default_params = {
     "num_file_reads_for_auto_readahead": lambda: random.choice([0, 1, 2]),
     "min_write_buffer_number_to_merge": lambda: random.choice([1, 2]),
     "preserve_internal_time_seconds": lambda: random.choice([0, 60, 3600, 36000]),
+    "memtable_max_range_deletions": lambda: random.choice([0] * 6 + [100, 1000]),
 }
 
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"

--- a/unreleased_history/new_features/memetable_range_del_limit.md
+++ b/unreleased_history/new_features/memetable_range_del_limit.md
@@ -1,0 +1,1 @@
+Add a column family option `memtable_max_range_deletions` that limits the number of range deletions in a memtable. RocksDB will try to do an automatic flush after the limit is reached. (#11358)


### PR DESCRIPTION
Add a mutable column family option `memtable_max_range_deletions`. When non-zero, RocksDB will try to flush the current memtable after it has at least `memtable_max_range_deletions` range deletions. Java API is added and crash test is updated accordingly to randomly enable this option.

Test plan:
* New unit test: `DBRangeDelTest.MemtableMaxRangeDeletions`
* Ran crash test `python3 ./tools/db_crashtest.py whitebox --simple --memtable_max_range_deletions=20` and saw logs showing flushed memtables usually with 20 range deletions.