### PR TITLE
util/ribbon_test.cc: avoid ambiguous reversed operator error in c++20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -531,7 +531,7 @@ endif
 default: all
 
 WARNING_FLAGS = -W -Wextra -Wall -Wsign-compare -Wshadow \
-  -Wunused-parameter
+  -Wunused-parameter -Wambiguous-reversed-operator
 
 ifeq (,$(filter amd64, $(MACHINE)))
 	C_WARNING_FLAGS = -Wstrict-prototypes

--- a/Makefile
+++ b/Makefile
@@ -531,7 +531,7 @@ endif
 default: all
 
 WARNING_FLAGS = -W -Wextra -Wall -Wsign-compare -Wshadow \
-  -Wunused-parameter -Wambiguous-reversed-operator
+  -Wunused-parameter
 
 ifeq (,$(filter amd64, $(MACHINE)))
 	C_WARNING_FLAGS = -Wstrict-prototypes
@@ -539,7 +539,7 @@ endif
 
 ifdef USE_CLANG
 	# Used by some teams in Facebook
-	WARNING_FLAGS += -Wshift-sign-overflow
+	WARNING_FLAGS += -Wshift-sign-overflow -Wambiguous-reversed-operator
 endif
 
 ifeq ($(PLATFORM), OS_OPENBSD)

--- a/util/ribbon_test.cc
+++ b/util/ribbon_test.cc
@@ -104,11 +104,11 @@ struct StandardKeyGen {
     return str_;
   }
 
-  bool operator==(const StandardKeyGen& other) {
+  bool operator==(const StandardKeyGen& other) const {
     // Same prefix is assumed
     return id_ == other.id_;
   }
-  bool operator!=(const StandardKeyGen& other) {
+  bool operator!=(const StandardKeyGen& other) const {
     // Same prefix is assumed
     return id_ != other.id_;
   }
@@ -144,8 +144,8 @@ struct SmallKeyGen {
     return str_;
   }
 
-  bool operator==(const SmallKeyGen& other) { return id_ == other.id_; }
-  bool operator!=(const SmallKeyGen& other) { return id_ != other.id_; }
+  bool operator==(const SmallKeyGen& other) const { return id_ == other.id_; }
+  bool operator!=(const SmallKeyGen& other) const { return id_ != other.id_; }
 
   uint64_t id_;
   std::string str_;
@@ -1069,11 +1069,11 @@ struct PhsfInputGen {
 
   const std::pair<std::string, uint8_t>* operator->() { return &**this; }
 
-  bool operator==(const PhsfInputGen& other) {
+  bool operator==(const PhsfInputGen& other) const {
     // Same prefix is assumed
     return id_ == other.id_;
   }
-  bool operator!=(const PhsfInputGen& other) {
+  bool operator!=(const PhsfInputGen& other) const {
     // Same prefix is assumed
     return id_ != other.id_;
   }


### PR DESCRIPTION
util/ribbon_test.cc: avoid ambiguous reversed operator error in c++20 (and enable checking for the error)

Code would produce errors like this, when compiled with -Wambiguous-reversed-operator under c++20.
```
util/ribbon_test.cc:695:20: error: ISO C++20 considers use of overloaded operator '!=' (with operand types 'KeyGen' (aka '(anonymous namespace)::StandardKeyGen') and 'KeyGen') to be ambiguou
s despite there being a unique best viable function with non-reversed arguments [-Werror,-Wambiguous-reversed-operator]
        while (cur != batch_end) {                                                                                                                                                            
               ~~~ ^  ~~~~~~~~~                                                                                                                                                               
util/ribbon_test.cc:111:8: note: candidate function with non-reversed arguments                                                                                                               
  bool operator!=(const StandardKeyGen& other) {                                                                                                                                              
       ^                                                                                                                                                                                      
util/ribbon_test.cc:107:8: note: ambiguous candidate function with reversed arguments                                                                                                         
  bool operator==(const StandardKeyGen& other) {                                               
       ^
```

This will become a hard error in future standards.

Confirmed that no errors were generated when building using clang and c++20:
```
USE_CLANG=1 USE_COROUTINES=1 make
```