### PR TITLE
Support to create a CF by importing multiple non-overlapping CFs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,6 @@
 * New statistics tickers for various iterator seek behaviors and relevant filtering, as \*`_LEVEL_SEEK_`\*. (#11460)
 
 ### Public API Changes
-* EXPERIMENTAL: Overload the CreateColumnFamilyWithImport() to support creating ColumnFamily by importing multiple non-overlapping ColumnFamies.
 * EXPERIMENTAL: Add new API `DB::ClipColumnFamily` to clip the key in CF to a certain range. It will physically deletes all keys outside the range including tombstones.
 * Add `MakeSharedCache()` construction functions to various cache Options objects, and deprecated the `NewWhateverCache()` functions with long parameter lists.
 * Changed the meaning of various Bloom filter stats (prefix vs. whole key), with iterator-related filtering only being tracked in the new \*`_LEVEL_SEEK_`\*. stats. (#11460)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 * New statistics tickers for various iterator seek behaviors and relevant filtering, as \*`_LEVEL_SEEK_`\*. (#11460)
 
 ### Public API Changes
+* EXPERIMENTAL: Overload the CreateColumnFamilyWithImport() to support creating ColumnFamily by importing multiple non-overlapping ColumnFamies.
 * EXPERIMENTAL: Add new API `DB::ClipColumnFamily` to clip the key in CF to a certain range. It will physically deletes all keys outside the range including tombstones.
 * Add `MakeSharedCache()` construction functions to various cache Options objects, and deprecated the `NewWhateverCache()` functions with long parameter lists.
 * Changed the meaning of various Bloom filter stats (prefix vs. whole key), with iterator-related filtering only being tracked in the new \*`_LEVEL_SEEK_`\*. stats. (#11460)

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -124,7 +124,7 @@ class CompactedDBImpl : public DBImpl {
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const std::vector<const ExportImportFilesMetaData*> /*metadatas*/,
+      const std::vector<const ExportImportFilesMetaData*>& /*metadatas*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -124,7 +124,7 @@ class CompactedDBImpl : public DBImpl {
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const ExportImportFilesMetaData* /*metadatas*/, size_t /*n*/,
+      const std::vector<const ExportImportFilesMetaData*> /*metadatas*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -118,12 +118,13 @@ class CompactedDBImpl : public DBImpl {
       const IngestExternalFileOptions& /*ingestion_options*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
+
   using DB::CreateColumnFamilyWithImport;
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const ExportImportFilesMetaData& /*metadata*/,
+      const ExportImportFilesMetaData* /*metadatas*/, size_t /*n*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5576,13 +5576,29 @@ Status DBImpl::CreateColumnFamilyWithImport(
     const ColumnFamilyOptions& options, const std::string& column_family_name,
     const ImportColumnFamilyOptions& import_options,
     const ExportImportFilesMetaData& metadata, ColumnFamilyHandle** handle) {
+  return CreateColumnFamilyWithImports(options, column_family_name,
+                                       import_options, {metadata}, handle);
+}
+
+Status DBImpl::CreateColumnFamilyWithImports(
+    const ColumnFamilyOptions& options, const std::string& column_family_name,
+    const ImportColumnFamilyOptions& import_options,
+    const std::vector<ExportImportFilesMetaData>& metadatas,
+    ColumnFamilyHandle** handle) {
   assert(handle != nullptr);
   assert(*handle == nullptr);
   // TODO: plumb Env::IOActivity
   const ReadOptions read_options;
   std::string cf_comparator_name = options.comparator->Name();
-  if (cf_comparator_name != metadata.db_comparator_name) {
-    return Status::InvalidArgument("Comparator name mismatch");
+
+  size_t total_file_num = 0;
+  std::vector<std::vector<LiveFileMetaData>> metadata_files;
+  for (auto metadata : metadatas) {
+    if (cf_comparator_name != metadata.db_comparator_name) {
+      return Status::InvalidArgument("Comparator name mismatch");
+    }
+    metadata_files.push_back(metadata.files);
+    total_file_num += metadata.files.size();
   }
 
   // Create column family.
@@ -5596,7 +5612,7 @@ Status DBImpl::CreateColumnFamilyWithImport(
   auto cfd = cfh->cfd();
   ImportColumnFamilyJob import_job(versions_.get(), cfd, immutable_db_options_,
                                    file_options_, import_options,
-                                   metadata.files, io_tracer_);
+                                   metadata_files, io_tracer_);
 
   SuperVersionContext dummy_sv_ctx(/* create_superversion */ true);
   VersionEdit dummy_edit;
@@ -5619,7 +5635,7 @@ Status DBImpl::CreateColumnFamilyWithImport(
       // reuse the file number that has already assigned to the internal file,
       // and this will overwrite the external file. To protect the external
       // file, we have to make sure the file number will never being reused.
-      next_file_number = versions_->FetchAddFileNumber(metadata.files.size());
+      next_file_number = versions_->FetchAddFileNumber(total_file_num);
       auto cf_options = cfd->GetLatestMutableCFOptions();
       status =
           versions_->LogAndApply(cfd, *cf_options, read_options, &dummy_edit,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5575,7 +5575,7 @@ Status DBImpl::IngestExternalFiles(
 Status DBImpl::CreateColumnFamilyWithImport(
     const ColumnFamilyOptions& options, const std::string& column_family_name,
     const ImportColumnFamilyOptions& import_options,
-    const ExportImportFilesMetaData* metadatas, size_t n,
+    const std::vector<const ExportImportFilesMetaData*> metadatas,
     ColumnFamilyHandle** handle) {
   assert(handle != nullptr);
   assert(*handle == nullptr);
@@ -5584,16 +5584,15 @@ Status DBImpl::CreateColumnFamilyWithImport(
   std::string cf_comparator_name = options.comparator->Name();
 
   size_t total_file_num = 0;
-  std::vector<std::vector<LiveFileMetaData*>> metadata_files(n);
-
-  for (size_t i = 0; i < n; i++) {
-    if (cf_comparator_name != metadatas[i].db_comparator_name) {
+  std::vector<std::vector<LiveFileMetaData*>> metadata_files(metadatas.size());
+  for (size_t i = 0; i < metadatas.size(); i++) {
+    if (cf_comparator_name != metadatas[i]->db_comparator_name) {
       return Status::InvalidArgument("Comparator name mismatch");
     }
-    for (auto& file : metadatas[i].files) {
+    for (auto& file : metadatas[i]->files) {
       metadata_files[i].push_back((LiveFileMetaData*)&file);
     }
-    total_file_num += metadatas[i].files.size();
+    total_file_num += metadatas[i]->files.size();
   }
 
   // Create column family.

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5575,7 +5575,7 @@ Status DBImpl::IngestExternalFiles(
 Status DBImpl::CreateColumnFamilyWithImport(
     const ColumnFamilyOptions& options, const std::string& column_family_name,
     const ImportColumnFamilyOptions& import_options,
-    const std::vector<const ExportImportFilesMetaData*> metadatas,
+    const std::vector<const ExportImportFilesMetaData*>& metadatas,
     ColumnFamilyHandle** handle) {
   assert(handle != nullptr);
   assert(*handle == nullptr);

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -531,7 +531,7 @@ class DBImpl : public DB {
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const std::vector<const ExportImportFilesMetaData*> metadatas,
+      const std::vector<const ExportImportFilesMetaData*>& metadatas,
       ColumnFamilyHandle** handle) override;
 
   using DB::ClipColumnFamily;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -531,7 +531,7 @@ class DBImpl : public DB {
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const ExportImportFilesMetaData* metadatas, size_t n,
+      const std::vector<const ExportImportFilesMetaData*> metadatas,
       ColumnFamilyHandle** handle) override;
 
   using DB::ClipColumnFamily;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -534,6 +534,14 @@ class DBImpl : public DB {
       const ExportImportFilesMetaData& metadata,
       ColumnFamilyHandle** handle) override;
 
+  using DB::CreateColumnFamilyWithImports;
+  virtual Status CreateColumnFamilyWithImports(
+      const ColumnFamilyOptions& /*options*/,
+      const std::string& /*column_family_name*/,
+      const ImportColumnFamilyOptions& /*import_options*/,
+      const std::vector<ExportImportFilesMetaData>& /*metadatas*/,
+      ColumnFamilyHandle** /*handle*/) override;
+
   using DB::ClipColumnFamily;
   virtual Status ClipColumnFamily(ColumnFamilyHandle* column_family,
                                   const Slice& begin_key,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -531,16 +531,8 @@ class DBImpl : public DB {
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const ExportImportFilesMetaData& metadata,
+      const ExportImportFilesMetaData* metadatas, size_t n,
       ColumnFamilyHandle** handle) override;
-
-  using DB::CreateColumnFamilyWithImports;
-  virtual Status CreateColumnFamilyWithImports(
-      const ColumnFamilyOptions& /*options*/,
-      const std::string& /*column_family_name*/,
-      const ImportColumnFamilyOptions& /*import_options*/,
-      const std::vector<ExportImportFilesMetaData>& /*metadatas*/,
-      ColumnFamilyHandle** /*handle*/) override;
 
   using DB::ClipColumnFamily;
   virtual Status ClipColumnFamily(ColumnFamilyHandle* column_family,

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -137,7 +137,7 @@ class DBImplReadOnly : public DBImpl {
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const ExportImportFilesMetaData* /*metadatas*/, size_t /*n*/,
+      const std::vector<const ExportImportFilesMetaData*> /*metadatas*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -137,7 +137,7 @@ class DBImplReadOnly : public DBImpl {
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const ExportImportFilesMetaData& /*metadata*/,
+      const ExportImportFilesMetaData* /*metadatas*/, size_t /*n*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -137,7 +137,7 @@ class DBImplReadOnly : public DBImpl {
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const std::vector<const ExportImportFilesMetaData*> /*metadatas*/,
+      const std::vector<const ExportImportFilesMetaData*>& /*metadatas*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3097,7 +3097,7 @@ class ModelDB : public DB {
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const std::vector<const ExportImportFilesMetaData*> /*metadatas*/,
+      const std::vector<const ExportImportFilesMetaData*>& /*metadatas*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not implemented.");
   }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3102,6 +3102,16 @@ class ModelDB : public DB {
     return Status::NotSupported("Not implemented.");
   }
 
+  using DB::CreateColumnFamilyWithImports;
+  virtual Status CreateColumnFamilyWithImports(
+      const ColumnFamilyOptions& /*options*/,
+      const std::string& /*column_family_name*/,
+      const ImportColumnFamilyOptions& /*import_options*/,
+      const std::vector<ExportImportFilesMetaData>& /*metadatas*/,
+      ColumnFamilyHandle** /*handle*/) override {
+    return Status::NotSupported("Not implemented.");
+  }
+
   using DB::VerifyChecksum;
   Status VerifyChecksum(const ReadOptions&) override {
     return Status::NotSupported("Not implemented.");

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3097,17 +3097,7 @@ class ModelDB : public DB {
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const ExportImportFilesMetaData& /*metadata*/,
-      ColumnFamilyHandle** /*handle*/) override {
-    return Status::NotSupported("Not implemented.");
-  }
-
-  using DB::CreateColumnFamilyWithImports;
-  virtual Status CreateColumnFamilyWithImports(
-      const ColumnFamilyOptions& /*options*/,
-      const std::string& /*column_family_name*/,
-      const ImportColumnFamilyOptions& /*import_options*/,
-      const std::vector<ExportImportFilesMetaData>& /*metadatas*/,
+      const ExportImportFilesMetaData* /*metadatas*/, size_t /*n*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not implemented.");
   }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3097,7 +3097,7 @@ class ModelDB : public DB {
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
-      const ExportImportFilesMetaData* /*metadatas*/, size_t /*n*/,
+      const std::vector<const ExportImportFilesMetaData*> /*metadatas*/,
       ColumnFamilyHandle** /*handle*/) override {
     return Status::NotSupported("Not implemented.");
   }

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -89,15 +89,15 @@ Status ImportColumnFamilyJob::Prepare(uint64_t next_file_number,
   std::sort(cf_ingest_infos.begin(), cf_ingest_infos.end(),
             [this](const ColumnFamilyIngestFileInfo& info1,
                    const ColumnFamilyIngestFileInfo& info2) {
-              return cfd_->internal_comparator().Compare(
-                         info1.smallest_internal_key,
-                         info2.smallest_internal_key) < 0;
+              return cfd_->user_comparator()->Compare(
+                         info1.smallest_internal_key.user_key(),
+                         info2.smallest_internal_key.user_key()) < 0;
             });
 
   for (size_t i = 0; i + 1 < cf_ingest_infos.size(); i++) {
-    if (cfd_->internal_comparator().Compare(
-            cf_ingest_infos[i].largest_internal_key,
-            cf_ingest_infos[i + 1].smallest_internal_key) >= 0) {
+    if (cfd_->user_comparator()->Compare(
+            cf_ingest_infos[i].largest_internal_key.user_key(),
+            cf_ingest_infos[i + 1].smallest_internal_key.user_key()) >= 0) {
       status = Status::InvalidArgument("CFs have overlapping ranges");
       return status;
     }

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -26,17 +26,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-namespace {
-// All file information of an imported CF, mainly used to
-// calculate whether there is overlap between CFs
-struct ColumnFamilyIngestFileInfo {
-  // Smallest internal key in cf
-  InternalKey smallest_internal_key;
-  // Largest internal key in cf
-  InternalKey largest_internal_key;
-};
-}
-
 Status ImportColumnFamilyJob::Prepare(uint64_t next_file_number,
                                       SuperVersion* sv) {
   Status status;

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -77,7 +77,8 @@ Status ImportColumnFamilyJob::Prepare(uint64_t next_file_number,
     }
 
     if (num_files == 0) {
-      return Status::InvalidArgument("The list of files is empty");
+      status = Status::InvalidArgument("The list of files is empty");
+      return status;
     }
     cf_file_info.smallest_internal_key = smallest;
     cf_file_info.largest_internal_key = largest;

--- a/db/import_column_family_job.h
+++ b/db/import_column_family_job.h
@@ -25,6 +25,15 @@ class SystemClock;
 // Imports a set of sst files as is into a new column family. Logic is similar
 // to ExternalSstFileIngestionJob.
 class ImportColumnFamilyJob {
+  // All file information of an imported CF, mainly used to
+  // calculate whether there is overlap between CFs
+  struct ColumnFamilyIngestFileInfo {
+    // Smallest internal key in cf
+    InternalKey smallest_internal_key;
+    // Largest internal key in cf
+    InternalKey largest_internal_key;
+  };
+
  public:
   ImportColumnFamilyJob(
       VersionSet* versions, ColumnFamilyData* cfd,

--- a/db/import_column_family_job.h
+++ b/db/import_column_family_job.h
@@ -22,17 +22,6 @@ namespace ROCKSDB_NAMESPACE {
 struct EnvOptions;
 class SystemClock;
 
-// All file information of an imported CF, mainly used to
-// calculate whether there is overlap between CFs
-struct ColumnFamilyIngestFileInfo {
-  // Smallest internal key in cf
-  InternalKey smallest_internal_key;
-  // Largest internal key in cf
-  InternalKey largest_internal_key;
-  // Num of ingest files
-  int num_files;
-};
-
 // Imports a set of sst files as is into a new column family. Logic is similar
 // to ExternalSstFileIngestionJob.
 class ImportColumnFamilyJob {
@@ -41,7 +30,7 @@ class ImportColumnFamilyJob {
       VersionSet* versions, ColumnFamilyData* cfd,
       const ImmutableDBOptions& db_options, const EnvOptions& env_options,
       const ImportColumnFamilyOptions& import_options,
-      const std::vector<std::vector<LiveFileMetaData>>& metadatas,
+      const std::vector<std::vector<LiveFileMetaData*>>& metadatas,
       const std::shared_ptr<IOTracer>& io_tracer)
       : clock_(db_options.clock),
         versions_(versions),
@@ -65,7 +54,7 @@ class ImportColumnFamilyJob {
 
   VersionEdit* edit() { return &edit_; }
 
-  const autovector<IngestedFileInfo>& files_to_import() const {
+  const std::vector<std::vector<IngestedFileInfo>>& files_to_import() const {
     return files_to_import_;
   }
 
@@ -83,11 +72,10 @@ class ImportColumnFamilyJob {
   const ImmutableDBOptions& db_options_;
   const FileSystemPtr fs_;
   const EnvOptions& env_options_;
-  autovector<IngestedFileInfo> files_to_import_;
+  std::vector<std::vector<IngestedFileInfo>> files_to_import_;
   VersionEdit edit_;
   const ImportColumnFamilyOptions& import_options_;
-  const std::vector<std::vector<LiveFileMetaData>> metadatas_;
-  std::vector<LiveFileMetaData> metadata_;
+  const std::vector<std::vector<LiveFileMetaData*>> metadatas_;
   const std::shared_ptr<IOTracer> io_tracer_;
 };
 

--- a/db/import_column_family_test.cc
+++ b/db/import_column_family_test.cc
@@ -22,10 +22,13 @@ class ImportColumnFamilyTest : public DBTestBase {
       : DBTestBase("import_column_family_test", /*env_do_fsync=*/true) {
     sst_files_dir_ = dbname_ + "/sst_files/";
     export_files_dir_ = test::PerThreadDBPath(env_, "export");
+    export_files_dir2_ = test::PerThreadDBPath(env_, "export2");
+
     DestroyAndRecreateExternalSSTFilesDir();
     import_cfh_ = nullptr;
     import_cfh2_ = nullptr;
     metadata_ptr_ = nullptr;
+    metadata_ptr2_ = nullptr;
   }
 
   ~ImportColumnFamilyTest() {
@@ -43,14 +46,21 @@ class ImportColumnFamilyTest : public DBTestBase {
       delete metadata_ptr_;
       metadata_ptr_ = nullptr;
     }
+
+    if (metadata_ptr2_) {
+      delete metadata_ptr2_;
+      metadata_ptr2_ = nullptr;
+    }
     EXPECT_OK(DestroyDir(env_, sst_files_dir_));
     EXPECT_OK(DestroyDir(env_, export_files_dir_));
+    EXPECT_OK(DestroyDir(env_, export_files_dir2_));
   }
 
   void DestroyAndRecreateExternalSSTFilesDir() {
     EXPECT_OK(DestroyDir(env_, sst_files_dir_));
     EXPECT_OK(env_->CreateDir(sst_files_dir_));
     EXPECT_OK(DestroyDir(env_, export_files_dir_));
+    EXPECT_OK(DestroyDir(env_, export_files_dir2_));
   }
 
   LiveFileMetaData LiveFileMetaDataInit(std::string name, std::string path,
@@ -69,9 +79,11 @@ class ImportColumnFamilyTest : public DBTestBase {
  protected:
   std::string sst_files_dir_;
   std::string export_files_dir_;
+  std::string export_files_dir2_;
   ColumnFamilyHandle* import_cfh_;
   ColumnFamilyHandle* import_cfh2_;
   ExportImportFilesMetaData* metadata_ptr_;
+  ExportImportFilesMetaData* metadata_ptr2_;
 };
 
 TEST_F(ImportColumnFamilyTest, ImportSSTFileWriterFiles) {
@@ -738,6 +750,142 @@ TEST_F(ImportColumnFamilyTest, ImportColumnFamilyNegativeTest) {
   }
 }
 
+TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyTest) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"koko"}, options);
+
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(Put(1, Key(i), Key(i) + "_val"));
+  }
+  ASSERT_OK(Flush(1));
+
+  ASSERT_OK(
+      db_->CompactRange(CompactRangeOptions(), handles_[1], nullptr, nullptr));
+
+  ASSERT_OK(
+      db_->CompactRange(CompactRangeOptions(), handles_[1], nullptr, nullptr));
+
+  // Overwrite the value in the same set of keys.
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(Put(1, Key(i), Key(i) + "_overwrite"));
+  }
+
+  // Flush again to create another L0 file. It should have higher sequencer.
+  ASSERT_OK(Flush(1));
+
+  Checkpoint* checkpoint1;
+  Checkpoint* checkpoint2;
+  ASSERT_OK(Checkpoint::Create(db_, &checkpoint1));
+  ASSERT_OK(checkpoint1->ExportColumnFamily(handles_[1], export_files_dir_,
+                                            &metadata_ptr_));
+
+  // Create a new db and import the files.
+  DB* db_copy;
+  ASSERT_OK(DestroyDir(env_, dbname_ + "/db_copy"));
+  ASSERT_OK(DB::Open(options, dbname_ + "/db_copy", &db_copy));
+  ColumnFamilyHandle* copy_cfh = nullptr;
+  ASSERT_OK(db_copy->CreateColumnFamily(options, "koko", &copy_cfh));
+  WriteOptions wo;
+  for (int i = 100; i < 200; ++i) {
+    ASSERT_OK(db_copy->Put(wo, copy_cfh, Key(i), Key(i) + "_val"));
+  }
+  ASSERT_OK(db_copy->Flush(FlushOptions()));
+  for (int i = 100; i < 200; ++i) {
+    ASSERT_OK(db_copy->Put(wo, copy_cfh, Key(i), Key(i) + "_overwrite"));
+  }
+  ASSERT_OK(db_copy->Flush(FlushOptions()));
+
+  ASSERT_OK(db_copy->Flush(FlushOptions()));
+  for (int i = 100; i < 200; ++i) {
+    ASSERT_OK(db_copy->Put(wo, copy_cfh, Key(i), Key(i) + "_overwrite2"));
+  }
+  ASSERT_OK(db_copy->Flush(FlushOptions()));
+
+  // Flush again to create another L0 file. It should have higher sequencer.
+  ASSERT_OK(Checkpoint::Create(db_copy, &checkpoint2));
+  ASSERT_OK(checkpoint2->ExportColumnFamily(copy_cfh, export_files_dir2_,
+                                            &metadata_ptr2_));
+
+  ASSERT_NE(metadata_ptr_, nullptr);
+  ASSERT_NE(metadata_ptr2_, nullptr);
+  delete checkpoint1;
+  delete checkpoint2;
+  ImportColumnFamilyOptions import_options;
+  import_options.move_files = false;
+
+  std::vector<ExportImportFilesMetaData> metadatas = {*metadata_ptr_,
+                                                      *metadata_ptr2_};
+  ASSERT_OK(db_->CreateColumnFamilyWithImports(options, "toto", import_options,
+                                               metadatas, &import_cfh_));
+
+  std::string value1, value2;
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(db_->Get(ReadOptions(), import_cfh_, Key(i), &value1));
+    ASSERT_EQ(Get(1, Key(i)), value1);
+  }
+
+  for (int i = 100; i < 200; ++i) {
+    ASSERT_OK(db_->Get(ReadOptions(), import_cfh_, Key(i), &value1));
+    ASSERT_OK(db_copy->Get(ReadOptions(), copy_cfh, Key(i), &value2));
+    ASSERT_EQ(value1, value2);
+  }
+
+  ASSERT_OK(db_copy->DropColumnFamily(copy_cfh));
+  ASSERT_OK(db_copy->DestroyColumnFamilyHandle(copy_cfh));
+  delete db_copy;
+  ASSERT_OK(DestroyDir(env_, dbname_ + "/db_copy"));
+}
+
+TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyWithOverlap) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"koko"}, options);
+
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(Put(1, Key(i), Key(i) + "_val"));
+  }
+
+  Checkpoint* checkpoint1;
+  Checkpoint* checkpoint2;
+  ASSERT_OK(Checkpoint::Create(db_, &checkpoint1));
+  ASSERT_OK(checkpoint1->ExportColumnFamily(handles_[1], export_files_dir_,
+                                            &metadata_ptr_));
+
+  // Create a new db and import the files.
+  DB* db_copy;
+  ASSERT_OK(DestroyDir(env_, dbname_ + "/db_copy"));
+  ASSERT_OK(DB::Open(options, dbname_ + "/db_copy", &db_copy));
+  ColumnFamilyHandle* copy_cfh = nullptr;
+  ASSERT_OK(db_copy->CreateColumnFamily(options, "koko", &copy_cfh));
+  WriteOptions wo;
+  for (int i = 50; i < 150; ++i) {
+    ASSERT_OK(db_copy->Put(wo, copy_cfh, Key(i), Key(i) + "_val"));
+  }
+  ASSERT_OK(db_copy->Flush(FlushOptions()));
+
+  // Flush again to create another L0 file. It should have higher sequencer.
+  ASSERT_OK(Checkpoint::Create(db_copy, &checkpoint2));
+  ASSERT_OK(checkpoint2->ExportColumnFamily(copy_cfh, export_files_dir2_,
+                                            &metadata_ptr2_));
+
+  ASSERT_NE(metadata_ptr_, nullptr);
+  ASSERT_NE(metadata_ptr2_, nullptr);
+  delete checkpoint1;
+  delete checkpoint2;
+  ImportColumnFamilyOptions import_options;
+  import_options.move_files = false;
+
+  std::vector<ExportImportFilesMetaData> metadatas = {*metadata_ptr_,
+                                                      *metadata_ptr2_};
+
+  ASSERT_EQ(db_->CreateColumnFamilyWithImports(options, "toto", import_options,
+                                               metadatas, &import_cfh_),
+            Status::InvalidArgument("CFs have overlapping ranges"));
+
+  ASSERT_OK(db_copy->DropColumnFamily(copy_cfh));
+  ASSERT_OK(db_copy->DestroyColumnFamilyHandle(copy_cfh));
+  delete db_copy;
+  ASSERT_OK(DestroyDir(env_, dbname_ + "/db_copy"));
+}
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/import_column_family_test.cc
+++ b/db/import_column_family_test.cc
@@ -808,11 +808,10 @@ TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyTest) {
   ImportColumnFamilyOptions import_options;
   import_options.move_files = false;
 
-  std::vector<ExportImportFilesMetaData> metadatas = {*metadata_ptr_,
-                                                      *metadata_ptr2_};
+  std::vector<const ExportImportFilesMetaData*> metadatas = {metadata_ptr_,
+                                                             metadata_ptr2_};
   ASSERT_OK(db_->CreateColumnFamilyWithImport(options, "toto", import_options,
-                                              metadatas.data(),
-                                              metadatas.size(), &import_cfh_));
+                                              metadatas, &import_cfh_));
 
   std::string value1, value2;
   for (int i = 0; i < 100; ++i) {
@@ -870,12 +869,11 @@ TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyWithOverlap) {
   ImportColumnFamilyOptions import_options;
   import_options.move_files = false;
 
-  std::vector<ExportImportFilesMetaData> metadatas = {*metadata_ptr_,
-                                                      *metadata_ptr2_};
+  std::vector<const ExportImportFilesMetaData*> metadatas = {metadata_ptr_,
+                                                             metadata_ptr2_};
 
   ASSERT_EQ(db_->CreateColumnFamilyWithImport(options, "toto", import_options,
-                                              metadatas.data(),
-                                              metadatas.size(), &import_cfh_),
+                                              metadatas, &import_cfh_),
             Status::InvalidArgument("CFs have overlapping ranges"));
 
   ASSERT_OK(db_copy->DropColumnFamily(copy_cfh));

--- a/db/import_column_family_test.cc
+++ b/db/import_column_family_test.cc
@@ -762,9 +762,6 @@ TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyTest) {
   ASSERT_OK(
       db_->CompactRange(CompactRangeOptions(), handles_[1], nullptr, nullptr));
 
-  ASSERT_OK(
-      db_->CompactRange(CompactRangeOptions(), handles_[1], nullptr, nullptr));
-
   // Overwrite the value in the same set of keys.
   for (int i = 0; i < 100; ++i) {
     ASSERT_OK(Put(1, Key(i), Key(i) + "_overwrite"));
@@ -794,8 +791,6 @@ TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyTest) {
     ASSERT_OK(db_copy->Put(wo, copy_cfh, Key(i), Key(i) + "_overwrite"));
   }
   ASSERT_OK(db_copy->Flush(FlushOptions()));
-
-  ASSERT_OK(db_copy->Flush(FlushOptions()));
   for (int i = 100; i < 200; ++i) {
     ASSERT_OK(db_copy->Put(wo, copy_cfh, Key(i), Key(i) + "_overwrite2"));
   }
@@ -815,8 +810,9 @@ TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyTest) {
 
   std::vector<ExportImportFilesMetaData> metadatas = {*metadata_ptr_,
                                                       *metadata_ptr2_};
-  ASSERT_OK(db_->CreateColumnFamilyWithImports(options, "toto", import_options,
-                                               metadatas, &import_cfh_));
+  ASSERT_OK(db_->CreateColumnFamilyWithImport(options, "toto", import_options,
+                                              metadatas.data(),
+                                              metadatas.size(), &import_cfh_));
 
   std::string value1, value2;
   for (int i = 0; i < 100; ++i) {
@@ -877,8 +873,9 @@ TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyWithOverlap) {
   std::vector<ExportImportFilesMetaData> metadatas = {*metadata_ptr_,
                                                       *metadata_ptr2_};
 
-  ASSERT_EQ(db_->CreateColumnFamilyWithImports(options, "toto", import_options,
-                                               metadatas, &import_cfh_),
+  ASSERT_EQ(db_->CreateColumnFamilyWithImport(options, "toto", import_options,
+                                              metadatas.data(),
+                                              metadatas.size(), &import_cfh_),
             Status::InvalidArgument("CFs have overlapping ranges"));
 
   ASSERT_OK(db_copy->DropColumnFamily(copy_cfh));

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1783,29 +1783,26 @@ class DB {
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
       const ExportImportFilesMetaData& metadata, ColumnFamilyHandle** handle) {
+    const std::vector<const ExportImportFilesMetaData*> metadatas{&metadata};
     return CreateColumnFamilyWithImport(options, column_family_name,
-                                        import_options, &metadata, 1, handle);
+                                        import_options, metadatas, handle);
   }
 
   // EXPERIMENTAL
   // Overload of the CreateColumnFamilyWithImport() that allows the caller to
-  // pass in a
-  // array of ExportImportFilesMetaData and size to support creating
-  // ColumnFamily by
-  // importing multiple ColumnFamies.
-  // It should be noticed that if the keys of the imported column families
+  // pass in a array of ExportImportFilesMetaData and size to support creating
+  // ColumnFamily by importing multiple ColumnFamies.
+  // It should be noticed that if the user keys of the imported column families
   // overlap with each other, an error will be returned.
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const ExportImportFilesMetaData* metadatas, size_t n,
+      const std::vector<const ExportImportFilesMetaData*> metadatas,
       ColumnFamilyHandle** handle) = 0;
 
   // EXPERIMENTAL
   // ClipColumnFamily() will clip the entries in the CF according to the range
-  // [begin_key,
-  // end_key).
-  // Returns OK on success, and a non-OK status on error.
+  // [begin_key, end_key). Returns OK on success, and a non-OK status on error.
   // Any entries outside this range will be completely deleted (including
   // tombstones).
   // The main difference between ClipColumnFamily(begin, end) and
@@ -1813,10 +1810,8 @@ class DB {
   // is that the former physically deletes all keys outside the range, but is
   // more heavyweight than the latter.
   // This feature is mainly used to ensure that there is no overlapping Key when
-  // calling
-  // CreateColumnFamilyWithImport() to import multiple CFs.
+  // calling CreateColumnFamilyWithImport() to import multiple CFs.
   // Note that: concurrent updates cannot be performed during Clip.
-
   virtual Status ClipColumnFamily(ColumnFamilyHandle* column_family,
                                   const Slice& begin_key,
                                   const Slice& end_key) = 0;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1790,8 +1790,8 @@ class DB {
 
   // EXPERIMENTAL
   // Overload of the CreateColumnFamilyWithImport() that allows the caller to
-  // pass in a array of ExportImportFilesMetaData and size to support creating
-  // ColumnFamily by importing multiple ColumnFamies.
+  // pass a list of ExportImportFilesMetaData pointers to support creating
+  // ColumnFamily by importing multiple ColumnFamilies.
   // It should be noticed that if the user keys of the imported column families
   // overlap with each other, an error will be returned.
   virtual Status CreateColumnFamilyWithImport(

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1783,7 +1783,7 @@ class DB {
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
       const ExportImportFilesMetaData& metadata, ColumnFamilyHandle** handle) {
-    const std::vector<const ExportImportFilesMetaData*> metadatas{&metadata};
+    const std::vector<const ExportImportFilesMetaData*>& metadatas{&metadata};
     return CreateColumnFamilyWithImport(options, column_family_name,
                                         import_options, metadatas, handle);
   }
@@ -1797,7 +1797,7 @@ class DB {
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const std::vector<const ExportImportFilesMetaData*> metadatas,
+      const std::vector<const ExportImportFilesMetaData*>& metadatas,
       ColumnFamilyHandle** handle) = 0;
 
   // EXPERIMENTAL

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1782,13 +1782,23 @@ class DB {
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const ExportImportFilesMetaData& metadata,
-      ColumnFamilyHandle** handle) = 0;
+      const ExportImportFilesMetaData& metadata, ColumnFamilyHandle** handle) {
+    return CreateColumnFamilyWithImport(options, column_family_name,
+                                        import_options, &metadata, 1, handle);
+  }
 
-  virtual Status CreateColumnFamilyWithImports(
+  // EXPERIMENTAL
+  // Overload of the CreateColumnFamilyWithImport() that allows the caller to
+  // pass in a
+  // array of ExportImportFilesMetaData and size to support creating
+  // ColumnFamily by
+  // importing multiple ColumnFamies.
+  // It should be noticed that if the keys of the imported column families
+  // overlap with each other, an error will be returned.
+  virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const std::vector<ExportImportFilesMetaData>& metadatas,
+      const ExportImportFilesMetaData* metadatas, size_t n,
       ColumnFamilyHandle** handle) = 0;
 
   // EXPERIMENTAL
@@ -1804,7 +1814,7 @@ class DB {
   // more heavyweight than the latter.
   // This feature is mainly used to ensure that there is no overlapping Key when
   // calling
-  // CreateColumnFamilyWithImports() to import multiple CFs.
+  // CreateColumnFamilyWithImport() to import multiple CFs.
   // Note that: concurrent updates cannot be performed during Clip.
 
   virtual Status ClipColumnFamily(ColumnFamilyHandle* column_family,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1785,6 +1785,12 @@ class DB {
       const ExportImportFilesMetaData& metadata,
       ColumnFamilyHandle** handle) = 0;
 
+  virtual Status CreateColumnFamilyWithImports(
+      const ColumnFamilyOptions& options, const std::string& column_family_name,
+      const ImportColumnFamilyOptions& import_options,
+      const std::vector<ExportImportFilesMetaData>& metadatas,
+      ColumnFamilyHandle** handle) = 0;
+
   // EXPERIMENTAL
   // ClipColumnFamily() will clip the entries in the CF according to the range
   // [begin_key,
@@ -1800,6 +1806,7 @@ class DB {
   // calling
   // CreateColumnFamilyWithImports() to import multiple CFs.
   // Note that: concurrent updates cannot be performed during Clip.
+
   virtual Status ClipColumnFamily(ColumnFamilyHandle* column_family,
                                   const Slice& begin_key,
                                   const Slice& end_key) = 0;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -178,6 +178,16 @@ class StackableDB : public DB {
                                              import_options, metadata, handle);
   }
 
+  using DB::CreateColumnFamilyWithImports;
+  virtual Status CreateColumnFamilyWithImports(
+      const ColumnFamilyOptions& options, const std::string& column_family_name,
+      const ImportColumnFamilyOptions& import_options,
+      const std::vector<ExportImportFilesMetaData>& metadatas,
+      ColumnFamilyHandle** handle) override {
+    return db_->CreateColumnFamilyWithImports(
+        options, column_family_name, import_options, metadatas, handle);
+  }
+
   using DB::ClipColumnFamily;
   virtual Status ClipColumnFamily(ColumnFamilyHandle* column_family,
                                   const Slice& begin_key,

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -172,10 +172,10 @@ class StackableDB : public DB {
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const ExportImportFilesMetaData* metadatas, size_t n,
+      const std::vector<const ExportImportFilesMetaData*> metadatas,
       ColumnFamilyHandle** handle) override {
-    return db_->CreateColumnFamilyWithImport(
-        options, column_family_name, import_options, metadatas, n, handle);
+    return db_->CreateColumnFamilyWithImport(options, column_family_name,
+                                             import_options, metadatas, handle);
   }
 
   using DB::ClipColumnFamily;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -172,20 +172,10 @@ class StackableDB : public DB {
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const ExportImportFilesMetaData& metadata,
+      const ExportImportFilesMetaData* metadatas, size_t n,
       ColumnFamilyHandle** handle) override {
-    return db_->CreateColumnFamilyWithImport(options, column_family_name,
-                                             import_options, metadata, handle);
-  }
-
-  using DB::CreateColumnFamilyWithImports;
-  virtual Status CreateColumnFamilyWithImports(
-      const ColumnFamilyOptions& options, const std::string& column_family_name,
-      const ImportColumnFamilyOptions& import_options,
-      const std::vector<ExportImportFilesMetaData>& metadatas,
-      ColumnFamilyHandle** handle) override {
-    return db_->CreateColumnFamilyWithImports(
-        options, column_family_name, import_options, metadatas, handle);
+    return db_->CreateColumnFamilyWithImport(
+        options, column_family_name, import_options, metadatas, n, handle);
   }
 
   using DB::ClipColumnFamily;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -172,7 +172,7 @@ class StackableDB : public DB {
   virtual Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
-      const std::vector<const ExportImportFilesMetaData*> metadatas,
+      const std::vector<const ExportImportFilesMetaData*>& metadatas,
       ColumnFamilyHandle** handle) override {
     return db_->CreateColumnFamilyWithImport(options, column_family_name,
                                              import_options, metadatas, handle);

--- a/unreleased_history/public_api_changes/support_create_cf_with_import_multiple_cf.md
+++ b/unreleased_history/public_api_changes/support_create_cf_with_import_multiple_cf.md
@@ -1,0 +1,1 @@
+Overload the API CreateColumnFamilyWithImport() to support creating ColumnFamily by importing multiple ColumnFamies. It requires that CFs should not overlap in user key range.

--- a/unreleased_history/public_api_changes/support_create_cf_with_import_multiple_cf.md
+++ b/unreleased_history/public_api_changes/support_create_cf_with_import_multiple_cf.md
@@ -1,1 +1,1 @@
-Overload the API CreateColumnFamilyWithImport() to support creating ColumnFamily by importing multiple ColumnFamies. It requires that CFs should not overlap in user key range.
+Overload the API CreateColumnFamilyWithImport() to support creating ColumnFamily by importing multiple ColumnFamilies It requires that CFs should not overlap in user key range.


### PR DESCRIPTION
The original Feature Request is from [#11317](https://github.com/facebook/rocksdb/issues/11317).
Flink uses rocksdb as the state backend,  all DB options are the same, and the keys of each DB instance are adjacent and there is no key overlap between two db instances. 
In the Flink rescaling scenario, it is necessary to quickly split the DB according to a certain key range or quickly merge multiple DBs into one.

This PR is mainly used to quickly merge multiple DBs into one.

We hope to extend the function of `CreateColumnFamilyWithImports` to support creating ColumnFamily by importing multiple ColumnFamily with no overlapping keys.

The import logic is almost the same as `CreateColumnFamilyWithImport`, but it will check whether there is key overlap between CF when importing. The import will fail if there are key overlaps.