### PR TITLE
Set -source 8 in CMAKE_JAVA_COMPILE_FLAGS

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -4,7 +4,7 @@ if(${CMAKE_VERSION} VERSION_LESS "3.11.4")
     message("Please consider switching to CMake 3.11.4 or newer")
 endif()
 
-set(CMAKE_JAVA_COMPILE_FLAGS -source 7)
+set(CMAKE_JAVA_COMPILE_FLAGS -source 8)
 
 set(JNI_NATIVE_SOURCES
         rocksjni/backup_engine_options.cc


### PR DESCRIPTION
build-windows-vs2022 jobs (e.g., https://app.circleci.com/pipelines/github/facebook/rocksdb/26641/workflows/7d1c58b8-7dd6-4dd6-a222-ecdfb0892c3b/jobs/593583) began failing with:

```
       (CustomBuild target) -> 
         CUSTOMBUILD : error : Source option 7 is no longer supported. Use 8 or later. [C:\Users\circleci.PACKER-64370BA5\project\build\java\rocksdbjni_classes.vcxproj]
```

So, this PR tries setting `-source 8` instead.