### PR TITLE
Improve error message from `CheckOptionsCompatibility()` for merge_operator

### DIFF
--- a/options/options_parser.cc
+++ b/options/options_parser.cc
@@ -679,6 +679,15 @@ Status RocksDBOptionsParser::VerifyCFOptions(
     Status s = base_config->GetOption(config_options, mismatch, &base_value);
     if (s.ok()) {
       s = file_config->GetOption(config_options, mismatch, &file_value);
+      // In file_opt, certain options like MergeOperator may be nullptr due to
+      //   factor methods not available. So we use opt_map to get
+      //   option value to use in the error message below.
+      if (s.ok() && file_value == kNullptrString && opt_map) {
+        auto const& opt_val_str = (opt_map->find(mismatch));
+        if (opt_val_str != opt_map->end()) {
+          file_value = opt_val_str->second;
+        }
+      }
     }
     int offset = snprintf(buffer, sizeof(buffer),
                           "[RocksDBOptionsParser]: "


### PR DESCRIPTION
Summary: when there is a merge_operator mismatch, for example, going from merge operator "CustomMergeOp" to nullptr, `CheckOptionsCompatibility()` returns an error message like the following is returned:

"failed the verification on ColumnFamilyOptions::merge_operator--- The specified one is nullptr while the **persisted one is nullptr**."

This happens when the persisted merge operator not a RocksDB built-in one. This PR improves this error message to include the actual persisted merge operator name.

Test plan: add unit test to check error message when going from merge op -> nullptr and going from merge op1 to merge op 2.