### PR TITLE
MemTable::Add: first_seqno_.compare_exchange_weak to earliest_seqno_

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -840,7 +840,7 @@ Status MemTable::Add(SequenceNumber s, ValueType type,
         earliest_seqno_.load(std::memory_order_relaxed);
     while (
         (cur_earliest_seqno == kMaxSequenceNumber || s < cur_earliest_seqno) &&
-        !first_seqno_.compare_exchange_weak(cur_earliest_seqno, s)) {
+        !earliest_seqno_.compare_exchange_weak(cur_earliest_seqno, s)) {
     }
   }
   if (type == kTypeRangeDeletion) {


### PR DESCRIPTION
This should be a benign bug caused by a long lived typo, this PR fix this issue.