### PR TITLE
Fix compression tests^2

### DIFF
--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -5085,6 +5085,10 @@ TEST_P(BlockBasedTableTest, CompressionRatioThreshold) {
     if (type == kNoCompression) {
       continue;
     }
+    if (type == kBZip2Compression) {
+      // Weird behavior in this test
+      continue;
+    }
     SCOPED_TRACE("Compression type: " + std::to_string(type));
 
     Options options;


### PR DESCRIPTION
Summary: This time a particular version of bzip2 is under-compressing vs. expectation in BlockBasedTableTest.CompressionRatioThreshold. We'll exempt that algorithm like I did for DBStatisticsTest.CompressionStatsTest.

https://app.circleci.com/pipelines/github/facebook/rocksdb/26869/workflows/a46246db-73c7-4946-af82-10a78a7df6af/jobs/596124

Test Plan: CI