### PR TITLE
remove redundant move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ fuzz/crash-*
 
 cmake-build-*
 third-party/folly/
+.cache

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -373,7 +373,7 @@ class CompactionJobTestBase : public testing::Test {
     } else if (table_type_ == TableTypeForTest::kMockTable) {
       file_size = 10;
       EXPECT_OK(mock_table_factory_->CreateMockTable(
-          env_, GenerateFileName(file_number), std::move(contents)));
+          env_, GenerateFileName(file_number), contents));
     } else {
       assert(false);
     }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3460,6 +3460,7 @@ static bool CompareIterators(int step, DB* model, DB* db,
       ok = false;
     }
   }
+  (void)count;
   delete miter;
   delete dbiter;
   return ok;

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -220,6 +220,7 @@ TEST_P(PrefetchTest, Basic) {
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
       num_keys++;
     }
+    (void)num_keys;
   }
 
   // Make sure prefetch is called only if file system support prefetch.
@@ -1803,6 +1804,7 @@ TEST_P(PrefetchTest, MultipleSeekWithPosixFS) {
     }
     MoveFilesToLevel(2);
   }
+  (void)total_keys;
 
   int num_keys_first_batch = 0;
   int num_keys_second_batch = 0;

--- a/memtable/inlineskiplist_test.cc
+++ b/memtable/inlineskiplist_test.cc
@@ -576,6 +576,7 @@ static void ConcurrentReader(void* arg) {
     state->t_.ReadStep(&rnd);
     ++reads;
   }
+  (void)reads;
   state->Change(TestState::DONE);
 }
 

--- a/memtable/skiplist_test.cc
+++ b/memtable/skiplist_test.cc
@@ -348,6 +348,7 @@ static void ConcurrentReader(void* arg) {
     state->t_.ReadStep(&rnd);
     ++reads;
   }
+  (void)reads;
   state->Change(TestState::DONE);
 }
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6984,6 +6984,8 @@ class Benchmark {
 
       thread->stats.FinishedOps(&db_, db_.db, 1, kSeek);
     }
+    (void)num_seek_to_first;
+    (void)num_next;
     delete iter;
   }
 


### PR DESCRIPTION
when I use g++-13 to exec the `make all` command,  the output throws the warnings.
```
db/compaction/compaction_job_test.cc: In member function ‘void rocksdb::CompactionJobTestBase::AddMockFile(const rocksdb::mock::KVVector&, int)’:
db/compaction/compaction_job_test.cc:376:57: error: redundant move in initialization [-Werror=redundant-move]
  376 |           env_, GenerateFileName(file_number), std::move(contents)));
      |                                                ~~~~~~~~~^~~~~~~~~~
db/compaction/compaction_job_test.cc:375:7: note: in expansion of macro ‘EXPECT_OK’
  375 |       EXPECT_OK(mock_table_factory_->CreateMockTable(
      |       ^~~~~~~~~
db/compaction/compaction_job_test.cc:376:57: note: remove ‘std::move’ call
  376 |           env_, GenerateFileName(file_number), std::move(contents)));
      |                                                ~~~~~~~~~^~~~~~~~~~
db/compaction/compaction_job_test.cc:375:7: note: in expansion of macro ‘EXPECT_OK’
  375 |       EXPECT_OK(mock_table_factory_->CreateMockTable(
      |       ^~~~~~~~~
cc1plus: all warnings being treated as errors
make: *** [Makefile:2507: db/compaction/compaction_job_test.o] Error 1
```

and I also add some `(void)unused_variable` statements because of the cmake argument `-Wunused-but-set-variable -Wunused-but-set-variable`