### PR TITLE
Delete temp OPTIONS file on failure to write it

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 * Delete an empty WAL file on DB open if the log number is less than the min log number to keep
+* Delete temp OPTIONS file on DB open if there is a failure to write it out or rename it
 
 ### Performance Improvements
 * Improved the I/O efficiency of prefetching SST metadata by recording more information in the DB manifest. Opening files written with previous versions will still rely on heuristics for how much to prefetch (#11406).

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4912,7 +4912,14 @@ Status DBImpl::WriteOptionsFile(bool need_mutex_lock,
 
   if (s.ok()) {
     s = RenameTempFileToOptionsFile(file_name);
+  } else {
+    if (!GetEnv()->DeleteFile(file_name).ok()) {
+      ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                     "Unable to delete temp options file %s",
+                     file_name.c_str());
+    }
   }
+
   // restore lock
   if (!need_mutex_lock) {
     mutex_.Lock();

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4912,7 +4912,9 @@ Status DBImpl::WriteOptionsFile(bool need_mutex_lock,
 
   if (s.ok()) {
     s = RenameTempFileToOptionsFile(file_name);
-  } else {
+  }
+
+  if (!s.ok() && GetEnv()->FileExists(file_name).ok()) {
     if (!GetEnv()->DeleteFile(file_name).ok()) {
       ROCKS_LOG_WARN(immutable_db_options_.info_log,
                      "Unable to delete temp options file %s",

--- a/options/options_parser.cc
+++ b/options/options_parser.cc
@@ -75,6 +75,7 @@ Status PersistRocksDBOptions(const ConfigOptions& config_options_in,
   std::unique_ptr<WritableFileWriter> writable;
   writable.reset(new WritableFileWriter(std::move(wf), file_name, EnvOptions(),
                                         nullptr /* statistics */));
+  TEST_SYNC_POINT("PersistRocksDBOptions:create");
 
   std::string options_file_content;
 
@@ -135,6 +136,7 @@ Status PersistRocksDBOptions(const ConfigOptions& config_options_in,
   if (s.ok()) {
     s = writable->Close();
   }
+  TEST_SYNC_POINT("PersistRocksDBOptions:written");
   if (s.ok()) {
     return RocksDBOptionsParser::VerifyRocksDBOptionsFromFile(
         config_options, db_opt, cf_names, cf_opts, file_name, fs);


### PR DESCRIPTION
When the DB is opened, RocksDB creates a temp OPTIONS file, writes the current options to it, and renames it. In case of a failure, the temp file is left behind, and is not deleted by PurgeObsoleteFiles(). Fix this by explicitly deleting the temp file if writing to it or renaming it fails.

Test plan:
Add a unit test