### PR TITLE
Clean up rate limiter refill logic

### DIFF
--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -148,6 +148,7 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
     bytes -= available_bytes_;
     total_bytes_through_[pri] += available_bytes_;
     available_bytes_ = 0;
+    TEST_SYNC_POINT("GenericRateLimiter::Request:NoAvailableBytes");
   }
 
   // Request cannot be satisfied at this moment, enqueue
@@ -299,6 +300,9 @@ void GenericRateLimiter::RefillBytesAndGrantRequestsLocked() {
       next_req->cv.Signal();
     }
   }
+  TEST_SYNC_POINT_CALLBACK(
+      "GenericRateLimiter::RefillBytesAndGrantRequestsLocked:End",
+      &available_bytes_);
 }
 
 int64_t GenericRateLimiter::CalculateRefillBytesPerPeriodLocked(

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -38,11 +38,10 @@ size_t RateLimiter::RequestToken(size_t bytes, size_t alignment,
 // Pending request
 struct GenericRateLimiter::Req {
   explicit Req(int64_t _bytes, port::Mutex* _mu)
-      : request_bytes(_bytes), bytes(_bytes), cv(_mu), granted(false) {}
+      : request_bytes(_bytes), bytes(_bytes), cv(_mu) {}
   int64_t request_bytes;
   int64_t bytes;
   port::CondVar cv;
-  bool granted;
 };
 
 GenericRateLimiter::GenericRateLimiter(
@@ -184,7 +183,7 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
       // Whichever thread reaches here first performs duty (2) as described
       // above.
       RefillBytesAndGrantRequestsLocked();
-      if (r.granted) {
+      if (r.request_bytes == 0) {
         // If there is any remaining requests, make sure there exists at least
         // one candidate is awake for future duties by signaling a front request
         // of a queue.
@@ -207,13 +206,13 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
         ++num_found;
       }
     }
-    if (r.granted) {
+    if (r.request_bytes == 0) {
       assert(num_found == 0);
     } else {
       assert(num_found == 1);
     }
 #endif  // NDEBUG
-  } while (!stop_ && !r.granted);
+  } while (!stop_ && r.request_bytes > 0);
 
   if (stop_) {
     // It is now in the clean-up of ~GenericRateLimiter().
@@ -270,6 +269,7 @@ void GenericRateLimiter::RefillBytesAndGrantRequestsLocked() {
   // Carry over the left over quota from the last period
   auto refill_bytes_per_period =
       refill_bytes_per_period_.load(std::memory_order_relaxed);
+  assert(available_bytes_ == 0);
   available_bytes_ = refill_bytes_per_period;
 
   std::vector<Env::IOPriority> pri_iteration_order =
@@ -295,7 +295,6 @@ void GenericRateLimiter::RefillBytesAndGrantRequestsLocked() {
       total_bytes_through_[current_pri] += next_req->bytes;
       queue->pop_front();
 
-      next_req->granted = true;
       // Quota granted, signal the thread to exit
       next_req->cv.Signal();
     }

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -136,10 +136,12 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
 
   ++total_requests_[pri];
 
-  int64_t bytes_through = std::min(available_bytes_, bytes);
-  total_bytes_through_[pri] += bytes_through;
-  available_bytes_ -= bytes_through;
-  bytes -= bytes_through;
+  if (available_bytes_ > 0) {
+    int64_t bytes_through = std::min(available_bytes_, bytes);
+    total_bytes_through_[pri] += bytes_through;
+    available_bytes_ -= bytes_through;
+    bytes -= bytes_through;
+  }
 
   if (bytes == 0) {
     return;

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -463,8 +463,6 @@ TEST_F(RateLimiterTest, AvailableByteSizeExhaustTest) {
       "RateLimiterTest::AvailableByteSizeExhaustTest:ReadyForNextRequest");
   Arg second_arg(500, limiter);
   env->StartThread(writer, &second_arg);
-  TEST_SYNC_POINT(
-      "RateLimiterTest::AvailableByteSizeExhaustTest:ReadyForNextRequest");
   Arg third_arg(300, limiter);
   env->StartThread(writer, &third_arg);
   env->WaitForJoin();

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -436,8 +436,6 @@ TEST_F(RateLimiterTest, AvailableByteSizeExhaustTest) {
         request_mutex->Unlock();
         ASSERT_EQ(500, limiter->GetTotalBytesThrough(Env::IO_USER));
         request_mutex->Lock();
-        special_env.SleepForMicroseconds(static_cast<int>(
-            std::chrono::microseconds(kTimePerRefill).count()));
       });
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 


### PR DESCRIPTION
Context:

This pull request update is in response to a comment made on https://github.com/facebook/rocksdb/pull/8596#discussion_r680264932. The current implementation of RefillBytesAndGrantRequestsLocked() drains all available_bytes, but the first request after the last wave of requesting/bytes granting is done is not being handled in the same way.

This creates a scenario where if a request for a large amount of bytes is enqueued first, but there are not enough available_bytes to fulfill it, the request is put to sleep until the next refill time. Meanwhile, a later request for a smaller number of bytes comes in and is granted immediately. This behavior is not fair as the earlier request was made first.

Summary:

To address this issue, we have made changes to the code to exhaust the remaining available bytes from the request and queue the remaining. With this change, requests are granted in the order they are received, ensuring that earlier requests are not unfairly delayed by later, smaller requests. The specific scenario described above will no longer occur with this change. Also consolidated `granted` and `request_bytes` as part of the change since `granted` is equivalent to `request_bytes == 0`

Test Plan:

Added `AvailableByteSizeExhaustTest`