### PR TITLE
Clarify io_activity

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -441,7 +441,7 @@ class Env : public Customizable {
     kFlush = 0,
     kCompaction = 1,
     kDBOpen = 2,
-    kUnknown,
+    kUnknown,  // Keep last for easy array of non-unknowns
   };
 
   // Arrange to run "(*function)(arg)" once in a background thread, in

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1696,6 +1696,7 @@ struct ReadOptions {
   // Default: true
   bool optimize_multiget_for_io;
 
+  // ** For RocksDB internal use only **
   Env::IOActivity io_activity;
 
   ReadOptions();


### PR DESCRIPTION
Summary: Document ReadOptions::io_activity as internal-use-only. And to keep kUnknown as last (and why).

Test Plan: comments only