### PR TITLE
Added  encryption plugin based on Intel open-source ipp-crypto library

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -5,4 +5,4 @@ This is the list of all known third-party plugins for RocksDB. If something is m
 * [ZenFS](https://github.com/westerndigitalcorporation/zenfs): a file system for zoned block devices
 * [RADOS](https://github.com/riversand963/rocksdb-rados-env): an Env used for interacting with RADOS. Migrated from RocksDB main repo.
 * [PMEM](https://github.com/pmem/pmem-rocksdb-plugin): a collection of plugins to enable Persistent Memory on RocksDB.
-* [IPPCP](https://github.com/intel/ippcp-plugin-rocksdb): a plugin to enable AES-CTR mode encryption on RocksDB.
+* [IPPCP](https://github.com/intel/ippcp-plugin-rocksdb): a plugin to enable encryption on RocksDB based on Intel optimized open source IPP-Crypto library.

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -5,3 +5,4 @@ This is the list of all known third-party plugins for RocksDB. If something is m
 * [ZenFS](https://github.com/westerndigitalcorporation/zenfs): a file system for zoned block devices
 * [RADOS](https://github.com/riversand963/rocksdb-rados-env): an Env used for interacting with RADOS. Migrated from RocksDB main repo.
 * [PMEM](https://github.com/pmem/pmem-rocksdb-plugin): a collection of plugins to enable Persistent Memory on RocksDB.
+* [IPPCP](https://github.com/intel/ippcp-plugin-rocksdb): a plugin to enable AES-CTR mode encryption on RocksDB.


### PR DESCRIPTION
This PR adds a plugin that supports AES-CTR encryption for RocksDB based on highly performant intel open-source cryptographic library IPP-Crypto. 

Details:
- supports AES-128, AES-192, and AES-256.
- uses the CTR mode of operation.
- based on the Intel® crypto library -- https://github.com/intel/ipp-crypto.
