### PR TITLE
Add support in log writer and reader for a user-defined timestamp size record

### DIFF
--- a/db/log_format.h
+++ b/db/log_format.h
@@ -35,8 +35,12 @@ enum RecordType {
 
   // Compression Type
   kSetCompressionType = 9,
+
+  // User-defined timestamp sizes
+  kUserDefinedTimestampSizeType = 10,
+  kRecyclableUserDefinedTimestampSizeType = 11,
 };
-static const int kMaxRecordType = kSetCompressionType;
+static const int kMaxRecordType = kRecyclableUserDefinedTimestampSizeType;
 
 static const unsigned int kBlockSize = 32768;
 

--- a/db/log_format.h
+++ b/db/log_format.h
@@ -40,16 +40,16 @@ enum RecordType {
   kUserDefinedTimestampSizeType = 10,
   kRecyclableUserDefinedTimestampSizeType = 11,
 };
-static const int kMaxRecordType = kRecyclableUserDefinedTimestampSizeType;
+constexpr int kMaxRecordType = kRecyclableUserDefinedTimestampSizeType;
 
-static const unsigned int kBlockSize = 32768;
+constexpr unsigned int kBlockSize = 32768;
 
 // Header is checksum (4 bytes), length (2 bytes), type (1 byte)
-static const int kHeaderSize = 4 + 2 + 1;
+constexpr int kHeaderSize = 4 + 2 + 1;
 
 // Recyclable header is checksum (4 bytes), length (2 bytes), type (1 byte),
 // log number (4 bytes).
-static const int kRecyclableHeaderSize = 4 + 2 + 1 + 4;
+constexpr int kRecyclableHeaderSize = 4 + 2 + 1 + 4;
 
 }  // namespace log
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -601,7 +601,7 @@ void Reader::InitCompression(const CompressionTypeRecord& compression_record) {
 }
 
 void Reader::UpdateRecordedTimestampSize(
-    const std::map<uint32_t, size_t> cf_to_ts_sz) {
+    const std::map<uint32_t, size_t>& cf_to_ts_sz) {
   for (const auto [cf, ts_sz] : cf_to_ts_sz) {
     // Zero user-defined timestamp size are not recorded.
     assert(ts_sz != 0);

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -596,9 +596,7 @@ void Reader::InitCompression(const CompressionTypeRecord& compression_record) {
 }
 
 Status Reader::UpdateRecordedTimestampSize(
-    const std::unordered_set<std::pair<uint32_t, size_t>,
-                             UserDefinedTimestampSizeRecord::RecordPairHash>&
-        cf_to_ts_sz) {
+    const std::vector<std::pair<uint32_t, size_t>>& cf_to_ts_sz) {
   for (const auto& [cf, ts_sz] : cf_to_ts_sz) {
     // Zero user-defined timestamp size are not recorded.
     if (ts_sz == 0) {

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "db/log_format.h"
 #include "file/sequence_file_reader.h"
@@ -19,6 +20,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "util/compression.h"
+#include "util/udt_util.h"
 #include "util/xxhash.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -202,8 +204,10 @@ class Reader {
 
   void InitCompression(const CompressionTypeRecord& compression_record);
 
-  void UpdateRecordedTimestampSize(
-      const std::unordered_map<uint32_t, size_t>& cf_to_ts_sz);
+  Status UpdateRecordedTimestampSize(
+      const std::unordered_set<std::pair<uint32_t, size_t>,
+                               UserDefinedTimestampSizeRecord::RecordPairHash>&
+          cf_to_ts_sz);
 };
 
 class FragmentBufferedReader : public Reader {

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -12,7 +12,7 @@
 
 #include <memory>
 #include <unordered_map>
-#include <unordered_set>
+#include <vector>
 
 #include "db/log_format.h"
 #include "file/sequence_file_reader.h"
@@ -205,9 +205,7 @@ class Reader {
   void InitCompression(const CompressionTypeRecord& compression_record);
 
   Status UpdateRecordedTimestampSize(
-      const std::unordered_set<std::pair<uint32_t, size_t>,
-                               UserDefinedTimestampSizeRecord::RecordPairHash>&
-          cf_to_ts_sz);
+      const std::vector<std::pair<uint32_t, size_t>>& cf_to_ts_sz);
 };
 
 class FragmentBufferedReader : public Reader {

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -199,7 +199,7 @@ class Reader {
   void InitCompression(const CompressionTypeRecord& compression_record);
 
   void UpdateRecordedTimestampSize(
-      const std::map<uint32_t, size_t> cf_to_ts_sz);
+      const std::map<uint32_t, size_t>& cf_to_ts_sz);
 };
 
 class FragmentBufferedReader : public Reader {

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -270,7 +270,7 @@ class LogTest
                        kTolerateCorruptedTailRecords /* wal_recovery_mode */,
                    &recorded_ts_sz));
     EXPECT_EQ(expected_ts_sz, recorded_ts_sz);
-  };
+  }
 };
 
 TEST_P(LogTest, Empty) { ASSERT_EQ("EOF", Read()); }

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -45,9 +45,10 @@ static std::string RandomSkewedString(int i, Random* rnd) {
   return BigString(NumberString(i), rnd->Skewed(17));
 }
 
-// Param type is tuple<int, bool>
+// Param type is tuple<int, bool, CompressionType>
 // get<0>(tuple): non-zero if recycling log, zero if regular log
 // get<1>(tuple): true if allow retry after read EOF, false otherwise
+// get<2>(tuple): type of compression used
 class LogTest
     : public ::testing::TestWithParam<std::tuple<int, bool, CompressionType>> {
  private:
@@ -181,20 +182,23 @@ class LogTest
 
   Slice* get_reader_contents() { return &reader_contents_; }
 
-  void Write(const std::string& msg) {
-    ASSERT_OK(writer_->AddRecord(Slice(msg)));
+  void Write(const std::string& msg,
+             const std::map<uint32_t, size_t>* cf_to_ts_sz = nullptr) {
+    ASSERT_OK(writer_->AddRecord(
+        Slice(msg), Env::IO_TOTAL /* rate_limiter_priority */, cf_to_ts_sz));
   }
 
   size_t WrittenBytes() const { return dest_contents().size(); }
 
   std::string Read(const WALRecoveryMode wal_recovery_mode =
-                       WALRecoveryMode::kTolerateCorruptedTailRecords) {
+                       WALRecoveryMode::kTolerateCorruptedTailRecords,
+                   std::map<uint32_t, size_t>* cf_to_ts_sz = nullptr) {
     std::string scratch;
     Slice record;
     bool ret = false;
     uint64_t record_checksum;
     ret = reader_->ReadRecord(&record, &scratch, wal_recovery_mode,
-                              &record_checksum);
+                              &record_checksum, cf_to_ts_sz);
     if (ret) {
       if (!allow_retry_read_) {
         // allow_retry_read_ means using FragmentBufferedReader which does not
@@ -257,6 +261,16 @@ class LogTest
       return "OK";
     }
   }
+
+  void CheckRecordAndTimestampSize(std::string record,
+                                   std::map<uint32_t, size_t>& expected_ts_sz) {
+    std::map<uint32_t, size_t> recorded_ts_sz;
+    ASSERT_EQ(record,
+              Read(WALRecoveryMode::
+                       kTolerateCorruptedTailRecords /* wal_recovery_mode */,
+                   &recorded_ts_sz));
+    EXPECT_EQ(expected_ts_sz, recorded_ts_sz);
+  };
 };
 
 TEST_P(LogTest, Empty) { ASSERT_EQ("EOF", Read()); }
@@ -270,6 +284,42 @@ TEST_P(LogTest, ReadWrite) {
   ASSERT_EQ("bar", Read());
   ASSERT_EQ("", Read());
   ASSERT_EQ("xxxx", Read());
+  ASSERT_EQ("EOF", Read());
+  ASSERT_EQ("EOF", Read());  // Make sure reads at eof work
+}
+
+TEST_P(LogTest, ReadWriteWithTimestampSize) {
+  std::map<uint32_t, size_t> ts_sz_one = {
+      {1, sizeof(uint64_t)},
+  };
+  Write("foo", &ts_sz_one);
+  Write("bar");
+  std::map<uint32_t, size_t> ts_sz_two = {{2, sizeof(char)}};
+  Write("", &ts_sz_two);
+  Write("xxxx");
+
+  CheckRecordAndTimestampSize("foo", ts_sz_one);
+  CheckRecordAndTimestampSize("bar", ts_sz_one);
+  std::map<uint32_t, size_t> expected_ts_sz_two;
+  // User-defined timestamp size records are accumulated and applied to
+  // subsequent records.
+  expected_ts_sz_two.insert(ts_sz_one.begin(), ts_sz_one.end());
+  expected_ts_sz_two.insert(ts_sz_two.begin(), ts_sz_two.end());
+  CheckRecordAndTimestampSize("", expected_ts_sz_two);
+  CheckRecordAndTimestampSize("xxxx", expected_ts_sz_two);
+  ASSERT_EQ("EOF", Read());
+  ASSERT_EQ("EOF", Read());  // Make sure reads at eof work
+}
+
+TEST_P(LogTest, ReadWriteWithTimestampSizeZeroTimestampIgnored) {
+  std::map<uint32_t, size_t> ts_sz_one = {{1, sizeof(uint64_t)}};
+  Write("foo", &ts_sz_one);
+  std::map<uint32_t, size_t> ts_sz_two(ts_sz_one.begin(), ts_sz_one.end());
+  ts_sz_two.insert(std::make_pair(2, 0));
+  Write("bar", &ts_sz_two);
+
+  CheckRecordAndTimestampSize("foo", ts_sz_one);
+  CheckRecordAndTimestampSize("bar", ts_sz_one);
   ASSERT_EQ("EOF", Read());
   ASSERT_EQ("EOF", Read());  // Make sure reads at eof work
 }
@@ -685,6 +735,39 @@ TEST_P(LogTest, Recycle) {
   ASSERT_EQ("EOF", Read());
 }
 
+TEST_P(LogTest, RecycleWithTimestampSize) {
+  bool recyclable_log = (std::get<0>(GetParam()) != 0);
+  if (!recyclable_log) {
+    return;  // test is only valid for recycled logs
+  }
+  std::map<uint32_t, size_t> ts_sz_one = {
+      {1, sizeof(uint32_t)},
+  };
+  Write("foo", &ts_sz_one);
+  Write("bar");
+  Write("baz");
+  Write("bif");
+  Write("blitz");
+  while (get_reader_contents()->size() < log::kBlockSize * 2) {
+    Write("xxxxxxxxxxxxxxxx");
+  }
+  std::unique_ptr<FSWritableFile> sink(
+      new test::OverwritingStringSink(get_reader_contents()));
+  std::unique_ptr<WritableFileWriter> dest_holder(new WritableFileWriter(
+      std::move(sink), "" /* don't care */, FileOptions()));
+  Writer recycle_writer(std::move(dest_holder), 123, true);
+  std::map<uint32_t, size_t> ts_sz_two = {
+      {2, sizeof(uint64_t)},
+  };
+  ASSERT_OK(recycle_writer.AddRecord(
+      Slice("foooo"), Env::IO_TOTAL /* wal_recovery_mode */, &ts_sz_two));
+  ASSERT_OK(recycle_writer.AddRecord(Slice("bar")));
+  ASSERT_GE(get_reader_contents()->size(), log::kBlockSize * 2);
+  CheckRecordAndTimestampSize("foooo", ts_sz_two);
+  CheckRecordAndTimestampSize("bar", ts_sz_two);
+  ASSERT_EQ("EOF", Read());
+}
+
 // Do NOT enable compression for this instantiation.
 INSTANTIATE_TEST_CASE_P(
     Log, LogTest,
@@ -936,6 +1019,35 @@ TEST_P(CompressionLogTest, ReadWrite) {
   ASSERT_EQ("bar", Read());
   ASSERT_EQ("", Read());
   ASSERT_EQ("xxxx", Read());
+  ASSERT_EQ("EOF", Read());
+  ASSERT_EQ("EOF", Read());  // Make sure reads at eof work
+}
+
+TEST_P(CompressionLogTest, ReadWriteWithTimestampSize) {
+  CompressionType compression_type = std::get<2>(GetParam());
+  if (!StreamingCompressionTypeSupported(compression_type)) {
+    ROCKSDB_GTEST_SKIP("Test requires support for compression type");
+    return;
+  }
+  ASSERT_OK(SetupTestEnv());
+  std::map<uint32_t, size_t> ts_sz_one = {
+      {1, sizeof(uint64_t)},
+  };
+  Write("foo", &ts_sz_one);
+  Write("bar");
+  std::map<uint32_t, size_t> ts_sz_two = {{2, sizeof(char)}};
+  Write("", &ts_sz_two);
+  Write("xxxx");
+
+  CheckRecordAndTimestampSize("foo", ts_sz_one);
+  CheckRecordAndTimestampSize("bar", ts_sz_one);
+  std::map<uint32_t, size_t> expected_ts_sz_two;
+  // User-defined timestamp size records are accumulated and applied to
+  // subsequent records.
+  expected_ts_sz_two.insert(ts_sz_one.begin(), ts_sz_one.end());
+  expected_ts_sz_two.insert(ts_sz_two.begin(), ts_sz_two.end());
+  CheckRecordAndTimestampSize("", expected_ts_sz_two);
+  CheckRecordAndTimestampSize("xxxx", expected_ts_sz_two);
   ASSERT_EQ("EOF", Read());
   ASSERT_EQ("EOF", Read());  // Make sure reads at eof work
 }

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -16,6 +16,7 @@
 #include "rocksdb/io_status.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
+#include "util/udt_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 namespace log {
@@ -62,7 +63,16 @@ IOStatus Writer::Close() {
 }
 
 IOStatus Writer::AddRecord(const Slice& slice,
-                           Env::IOPriority rate_limiter_priority) {
+                           Env::IOPriority rate_limiter_priority,
+                           const std::map<uint32_t, size_t>* cf_to_ts_sz) {
+  IOStatus s;
+  if (cf_to_ts_sz != nullptr && !cf_to_ts_sz->empty()) {
+    s = MaybeAddUserDefinedTimestampSizeRecord(*cf_to_ts_sz,
+                                               rate_limiter_priority);
+    if (!s.ok()) {
+      return s;
+    }
+  }
   const char* ptr = slice.data();
   size_t left = slice.size();
 
@@ -73,7 +83,6 @@ IOStatus Writer::AddRecord(const Slice& slice,
   // Fragment the record if necessary and emit it.  Note that if slice
   // is empty, we still want to iterate once to emit a single
   // zero-length record
-  IOStatus s;
   bool begin = true;
   int compress_remaining = 0;
   bool compress_start = false;
@@ -194,6 +203,33 @@ IOStatus Writer::AddCompressionTypeRecord() {
   return s;
 }
 
+IOStatus Writer::MaybeAddUserDefinedTimestampSizeRecord(
+    const std::map<uint32_t, size_t>& cf_to_ts_sz,
+    Env::IOPriority rate_limiter_priority) {
+  std::map<uint32_t, size_t> ts_sz_to_record;
+  for (const auto [cf_id, ts_sz] : cf_to_ts_sz) {
+    if (recorded_cf_to_ts_sz_.count(cf_id) != 0) {
+      // A column family's user-defined timestamp size should to be
+      // updated while DB is running.
+      assert(recorded_cf_to_ts_sz_[cf_id] == ts_sz);
+    } else if (ts_sz != 0) {
+      ts_sz_to_record.insert(std::make_pair(cf_id, ts_sz));
+      recorded_cf_to_ts_sz_.insert(std::make_pair(cf_id, ts_sz));
+    }
+  }
+  if (ts_sz_to_record.empty()) {
+    return IOStatus::OK();
+  }
+
+  UserDefinedTimestampSizeRecord record(std::move(ts_sz_to_record));
+  std::string encoded;
+  record.EncodeTo(&encoded);
+  RecordType type = recycle_log_files_ ? kRecyclableUserDefinedTimestampSizeType
+                                       : kUserDefinedTimestampSizeType;
+  return EmitPhysicalRecord(type, encoded.data(), encoded.size(),
+                            rate_limiter_priority);
+}
+
 bool Writer::BufferIsEmpty() { return dest_->BufferIsEmpty(); }
 
 IOStatus Writer::EmitPhysicalRecord(RecordType t, const char* ptr, size_t n,
@@ -209,7 +245,8 @@ IOStatus Writer::EmitPhysicalRecord(RecordType t, const char* ptr, size_t n,
   buf[6] = static_cast<char>(t);
 
   uint32_t crc = type_crc_[t];
-  if (t < kRecyclableFullType || t == kSetCompressionType) {
+  if (t < kRecyclableFullType || t == kSetCompressionType ||
+      t == kUserDefinedTimestampSizeType) {
     // Legacy record format
     assert(block_offset_ + kHeaderSize + n <= kBlockSize);
     header_size = kHeaderSize;

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -199,7 +199,9 @@ IOStatus Writer::AddCompressionTypeRecord() {
 IOStatus Writer::MaybeAddUserDefinedTimestampSizeRecord(
     const std::unordered_map<uint32_t, size_t>& cf_to_ts_sz,
     Env::IOPriority rate_limiter_priority) {
-  std::unordered_map<uint32_t, size_t> ts_sz_to_record;
+  std::unordered_set<std::pair<uint32_t, size_t>,
+                     UserDefinedTimestampSizeRecord::RecordPairHash>
+      ts_sz_to_record;
   for (const auto& [cf_id, ts_sz] : cf_to_ts_sz) {
     if (recorded_cf_to_ts_sz_.count(cf_id) != 0) {
       // A column family's user-defined timestamp size should not be

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -199,16 +199,14 @@ IOStatus Writer::AddCompressionTypeRecord() {
 IOStatus Writer::MaybeAddUserDefinedTimestampSizeRecord(
     const std::unordered_map<uint32_t, size_t>& cf_to_ts_sz,
     Env::IOPriority rate_limiter_priority) {
-  std::unordered_set<std::pair<uint32_t, size_t>,
-                     UserDefinedTimestampSizeRecord::RecordPairHash>
-      ts_sz_to_record;
+  std::vector<std::pair<uint32_t, size_t>> ts_sz_to_record;
   for (const auto& [cf_id, ts_sz] : cf_to_ts_sz) {
     if (recorded_cf_to_ts_sz_.count(cf_id) != 0) {
       // A column family's user-defined timestamp size should not be
       // updated while DB is running.
       assert(recorded_cf_to_ts_sz_[cf_id] == ts_sz);
     } else if (ts_sz != 0) {
-      ts_sz_to_record.insert(std::make_pair(cf_id, ts_sz));
+      ts_sz_to_record.emplace_back(cf_id, ts_sz);
       recorded_cf_to_ts_sz_.insert(std::make_pair(cf_id, ts_sz));
     }
   }

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <unordered_map>
 
 #include "db/log_format.h"
 #include "rocksdb/compression_type.h"
@@ -89,9 +90,17 @@ class Writer {
   // add a special record to signal the timestamp size for this and subsequent
   // WriteBatch records.
   IOStatus AddRecord(const Slice& slice,
-                     Env::IOPriority rate_limiter_priority = Env::IO_TOTAL,
-                     const std::map<uint32_t, size_t>* cf_to_ts_sz = nullptr);
+                     Env::IOPriority rate_limiter_priority = Env::IO_TOTAL);
   IOStatus AddCompressionTypeRecord();
+
+  // If there are column families in `cf_to_ts_sz` not included in
+  // `recorded_cf_to_ts_sz_` and its user-defined timestamp size is non-zero,
+  // adds a record of type kUserDefinedTimestampSizeType or
+  // kRecyclableUserDefinedTimestampSizeType for these column families.
+  // This timestamp size record applies to all subsequent records.
+  IOStatus MaybeAddUserDefinedTimestampSizeRecord(
+      const std::unordered_map<uint32_t, size_t>& cf_to_ts_sz,
+      Env::IOPriority rate_limiter_priority = Env::IO_TOTAL);
 
   WritableFileWriter* file() { return dest_.get(); }
   const WritableFileWriter* file() const { return dest_.get(); }
@@ -119,14 +128,6 @@ class Writer {
       RecordType type, const char* ptr, size_t length,
       Env::IOPriority rate_limiter_priority = Env::IO_TOTAL);
 
-  // If there are column families in `cf_to_ts_sz` not included in
-  // `recorded_cf_to_ts_sz_` and its user-defined timestamp size is non-zero,
-  // adds a record of type kUserDefinedTimestampSizeType or
-  // kRecyclableUserDefinedTimestampSizeType for these column families.
-  IOStatus MaybeAddUserDefinedTimestampSizeRecord(
-      const std::map<uint32_t, size_t>& cf_to_ts_sz,
-      Env::IOPriority rate_limiter_priority = Env::IO_TOTAL);
-
   // If true, it does not flush after each write. Instead it relies on the upper
   // layer to manually does the flush by calling ::WriteBuffer()
   bool manual_flush_;
@@ -140,7 +141,7 @@ class Writer {
   // The recorded user-defined timestamp size that have been written so far.
   // Since the user-defined timestamp size cannot be changed while the DB is
   // running, existing entry in this map cannot be updated.
-  std::map<uint32_t, size_t> recorded_cf_to_ts_sz_;
+  std::unordered_map<uint32_t, size_t> recorded_cf_to_ts_sz_;
 };
 
 }  // namespace log

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
-#include <unordered_set>
+#include <vector>
 
 #include "db/log_format.h"
 #include "rocksdb/compression_type.h"

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "db/log_format.h"
 #include "rocksdb/compression_type.h"
@@ -84,11 +85,6 @@ class Writer {
 
   ~Writer();
 
-  // `cf_to_ts_sz` maps column family id to user-defined timestamp sizes. It
-  // only applies to WAL logs. If a WriteBatch contains updates for column
-  // families with non-zero user-defined timestamp sizes, use this parameter to
-  // add a special record to signal the timestamp size for this and subsequent
-  // WriteBatch records.
   IOStatus AddRecord(const Slice& slice,
                      Env::IOPriority rate_limiter_priority = Env::IO_TOTAL);
   IOStatus AddCompressionTypeRecord();

--- a/util/udt_util.h
+++ b/util/udt_util.h
@@ -1,0 +1,66 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+#include <map>
+#include <sstream>
+
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "util/coding.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Dummy record in WAL logs signaling user-defined timestamp sizes for
+// subsequent records.
+class UserDefinedTimestampSizeRecord {
+ public:
+  UserDefinedTimestampSizeRecord() {}
+  explicit UserDefinedTimestampSizeRecord(
+      std::map<uint32_t, size_t> cf_to_ts_sz)
+      : cf_to_ts_sz_(cf_to_ts_sz) {}
+
+  const std::map<uint32_t, size_t>& GetUserDefinedTimestampSize() const {
+    return cf_to_ts_sz_;
+  }
+
+  inline void EncodeTo(std::string* dst) const {
+    assert(dst != nullptr);
+    for (const auto [cf_id, ts_sz] : cf_to_ts_sz_) {
+      assert(ts_sz != 0);
+      PutFixed32(dst, cf_id);
+      PutFixed16(dst, static_cast<uint16_t>(ts_sz));
+    }
+  }
+
+  inline Status DecodeFrom(Slice* src) {
+    int num_of_entries = static_cast<int>(src->size() / (4 + 2));
+    for (int i = 0; i < num_of_entries; i++) {
+      uint32_t cf_id;
+      uint16_t ts_sz;
+      if (!GetFixed32(src, &cf_id) || !GetFixed16(src, &ts_sz)) {
+        return Status::Corruption(
+            "Error decoding user-defined timestamp size record entry");
+      }
+      cf_to_ts_sz_[cf_id] = static_cast<size_t>(ts_sz);
+    }
+    return Status::OK();
+  }
+
+  inline std::string DebugString() const {
+    std::ostringstream oss;
+
+    for (const auto [cf_id, ts_sz] : cf_to_ts_sz_) {
+      oss << "Column family: " << cf_id
+          << ", user-defined timestamp size: " << ts_sz << std::endl;
+    }
+    return oss.str();
+  }
+
+ private:
+  std::map<uint32_t, size_t> cf_to_ts_sz_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/util/udt_util.h
+++ b/util/udt_util.h
@@ -4,8 +4,9 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #pragma once
+#include <functional>
 #include <sstream>
-#include <unordered_map>
+#include <unordered_set>
 
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
@@ -17,13 +18,22 @@ namespace ROCKSDB_NAMESPACE {
 // subsequent records.
 class UserDefinedTimestampSizeRecord {
  public:
+  struct RecordPairHash {
+    std::size_t operator()(const std::pair<uint32_t, size_t>& p) const {
+      auto hash1 = std::hash<uint32_t>{}(p.first);
+      auto hash2 = std::hash<size_t>{}(p.second);
+      return hash1 ^ (hash2 + 0x9e3779b9 + (hash1 << 6) + (hash1 >> 2));
+    }
+  };
+
   UserDefinedTimestampSizeRecord() {}
   explicit UserDefinedTimestampSizeRecord(
-      const std::unordered_map<uint32_t, size_t>& cf_to_ts_sz)
-      : cf_to_ts_sz_(cf_to_ts_sz) {}
+      std::unordered_set<std::pair<uint32_t, size_t>, RecordPairHash>&&
+          cf_to_ts_sz)
+      : cf_to_ts_sz_(std::move(cf_to_ts_sz)) {}
 
-  const std::unordered_map<uint32_t, size_t>& GetUserDefinedTimestampSize()
-      const {
+  const std::unordered_set<std::pair<uint32_t, size_t>, RecordPairHash>&
+  GetUserDefinedTimestampSize() const {
     return cf_to_ts_sz_;
   }
 
@@ -46,13 +56,13 @@ class UserDefinedTimestampSizeRecord {
     }
     int num_of_entries = static_cast<int>(total_size / kSizePerColumnFamily);
     for (int i = 0; i < num_of_entries; i++) {
-      uint32_t cf_id;
-      uint16_t ts_sz;
+      uint32_t cf_id = 0;
+      uint16_t ts_sz = 0;
       if (!GetFixed32(src, &cf_id) || !GetFixed16(src, &ts_sz)) {
         return Status::Corruption(
             "Error decoding user-defined timestamp size record entry");
       }
-      cf_to_ts_sz_[cf_id] = static_cast<size_t>(ts_sz);
+      cf_to_ts_sz_.insert(std::make_pair(cf_id, static_cast<size_t>(ts_sz)));
     }
     return Status::OK();
   }
@@ -71,7 +81,7 @@ class UserDefinedTimestampSizeRecord {
   // 4 bytes for column family id, 2 bytes for user-defined timestamp size.
   static constexpr size_t kSizePerColumnFamily = 4 + 2;
 
-  std::unordered_map<uint32_t, size_t> cf_to_ts_sz_;
+  std::unordered_set<std::pair<uint32_t, size_t>, RecordPairHash> cf_to_ts_sz_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
This patch adds support to write and read a user-defined timestamp size record in log writer and log reader. It will be used by WAL logs to persist the user-defined timestamp format for subsequent WriteBatch records. Reading and writing UDT sizes for WAL logs are not included in this patch. It will be in a follow up.

The syntax for the record is: at write time, one such record is added when log writer encountered any non-zero UDT size it hasn't recorded so far. At read time, all such records read up to a point are accumulated and applicable to all subsequent WriteBatch records.

Test Plan:
```
make clean && make -j32 all
./log_test --gtest_filter="*WithTimestampSize*"
```
