### PR TITLE
WIP/RFC: SliceBound

### DIFF
--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -39,7 +39,7 @@ int sstableKeyCompare(const Comparator* user_cmp, const InternalKey& a,
                       const InternalKey* b);
 
 // An AtomicCompactionUnitBoundary represents a range of keys [smallest,
-// largest] that exactly spans one ore more neighbouring SSTs on the same
+// largest] that exactly spans one or more neighbouring SSTs on the same
 // level. Every pair of  SSTs in this range "overlap" (i.e., the largest
 // user key of one file is the smallest user key of the next file). These
 // boundaries are propagated down to RangeDelAggregator during compaction

--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -12,10 +12,9 @@
 
 #include "rocksdb/customizable.h"
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
 
 namespace ROCKSDB_NAMESPACE {
-
-class Slice;
 
 // The general interface for comparing two Slices are defined for both of
 // Comparator and some internal data structures.
@@ -120,6 +119,7 @@ class Comparator : public Customizable, public CompareInterface {
 
   inline size_t timestamp_size() const { return timestamp_size_; }
 
+  // Compare the non-timestamp portion of keys containing timestamps.
   int CompareWithoutTimestamp(const Slice& a, const Slice& b) const {
     return CompareWithoutTimestamp(a, /*a_has_ts=*/true, b, /*b_has_ts=*/true);
   }
@@ -138,6 +138,10 @@ class Comparator : public Customizable, public CompareInterface {
     return 0;
   }
 
+  // Compare the non-timestamp portion of keys that may or may not have
+  // timestamps, as specified by `a_has_ts` and `b_has_ts`. This default
+  // implementation is only appropriate for comparators not using the user
+  // timestamp feature. (timestamp_size_ always == 0)
   virtual int CompareWithoutTimestamp(const Slice& a, bool /*a_has_ts*/,
                                       const Slice& b, bool /*b_has_ts*/) const {
     return Compare(a, b);
@@ -148,17 +152,205 @@ class Comparator : public Customizable, public CompareInterface {
            CompareWithoutTimestamp(a, /*a_has_ts=*/true, b, /*b_has_ts=*/true);
   }
 
+  // Tests key or prefix `a` for ordering with or containment in `prefix`.
+  // Returning 0 => `a` is contained in `prefix`.
+  // Returning < 0 => `a` is ordered before `prefix` (and all keys contained
+  // in that prefix).
+  // Returning > 0 => `a` is ordered after `prefix` (and all keys contained
+  // in that prefix).
+  // This function must form a partial order; specifically,
+  //  * CompareToPrefix(a, false, a) == 0
+  //  * If CompareToPrefix(a, false, b) < 0
+  //    then CompareToPrefix(b, false, a) >= 0
+  //  * If CompareToPrefix(a, false, b) < 0 and
+  //       CompareToPrefix(b, false, c) < 0,
+  //    then CompareToPrefix(a, false, c) < 0
+  //
+  // Note that two prefixes are equivalent iff
+  // CompareToPrefix(a, false, b) == 0 && CompareToPrefix(b, false, a) == 0.
+  // (One does not imply the other as in a strict order).
+  //
+  // RocksDB logic also requires that even if prefix bounds are not generally
+  // supported, this function must return 0 if `prefix` is empty. See
+  // SliceBound::kMin/kMax. A suitable implementation for "not supported" is
+  // to return 0 always (every key matches every prefix, and all prefixes are
+  // equivalent).
+  //
+  // The default implementation uses Slice::starts_with for prefix containment
+  // so is appropriate for lexicographic orderings such as byte-wise orderings,
+  // reverse or standard, where keys with different bytes cannot be equal.
+  // It also uses `prefix` as a key (no user timestamp) passed to
+  // CompareWithoutTimestamp(), so prefixes must be in the domain of comparable
+  // keys with the default implementation of this function. The key may
+  // contain several parsed fields, and this is implementation will work as
+  // long as the order of earlier fields supercedes the order of later fields,
+  // and the provided prefixes parse unambiguously to a prefix of fields. For
+  // example, prefixes could end at a fixed length boundary between fields, or
+  // end with a field delimiter character.
+  virtual int CompareToPrefix(const Slice& a, bool a_has_ts,
+                              const Slice& prefix) const;
+
  private:
   size_t timestamp_size_;
 };
 
-// Return a builtin comparator that uses lexicographic byte-wise
-// ordering.  The result remains the property of this module and
-// must not be deleted.
+// Return a builtin comparator that uses lexicographic byte-wise ordering.
+// The result remains owned by this module so must not be deleted.
 extern const Comparator* BytewiseComparator();
 
 // Return a builtin comparator that uses reverse lexicographic byte-wise
 // ordering.
 extern const Comparator* ReverseBytewiseComparator();
+
+// SliceBound is a general, convenient way of specifying upper and lower
+// bounds for ranges of keys. With a comparator, all keys are either strictly
+// greater than or strictly less than a SliceBound (see OrderedBeforeBound()).
+// This means that inclusivity vs. exclusivity of the bound is a part of and
+// selectable in constructing the SliceBound. SliceBound also supports
+// prefix-based upper and lower bounds under certain assumptions detailed
+// below.
+//
+// You can think of SliceBound as generalizing the total order given by a
+// comparator to include various conceptual points between actual keys. A
+// total order on these various bounds is provided to support various
+// operations (see CompareBounds). Here's an example of that ordering
+// relationship between various kinds of SliceBounds and actual keys, using
+// standard bytewise comparator:
+//
+// BeforePrefix("") // == SliceBound::kMin
+// ...
+// BeforePrefix("f")
+// ...
+// BeforePrefix("foo")
+// BeforeKey("foo")
+// +------------ Simple key "foo" (not a SliceBound) ------------+
+// | ...
+// | BeforeKeyWithTs("foo" + 1234)
+// | Key "foo" with timestamp 1234 (not a SliceBound)
+// | AfterKeyWithTs("foo" + 1234)
+// | BeforeKeyWithTs("foo" + 1233)
+// | Key "foo" with timestamp 1233 (not a SliceBound)
+// | ...
+// +-------------------------------------------------------------+
+// AfterKey("foo")
+// ...
+// BeforePrefix("food")
+// ...
+// BeforeKey("food")
+// Simple key "food" (not a SliceBound)
+// AfterKey("food")
+// ...
+// AfterPrefix("food")
+// ...
+// AfterPrefix("foo")
+// BeforePrefix("fop")
+// ...
+// AfterPrefix("")  // == SliceBound::kMax
+//
+// Notice that when using the User Timestamp feature, it is not possible to
+// order a simple key such as "foo" against a timestamped bound such as
+// AfterKeyWithTs("foo" + 1234). This is a documented limitation on
+// OrderedBeforeBound(), but does not affect CompareBounds() because it only
+// deals with SliceBounds.
+//
+// Prefixes for SliceBound are never considered to contain a user timestamp,
+// nor any part of a user timestamp. Other than that, prefix bounds are rather
+// simple for byte-wise orderings. A range from BeforePrefix("asdf") to
+// AfterPrefix("asdf") exactly includes all keys starting with "asdf", whether
+// using standard byte-wise or reverse byte-wise ordering. And that is just
+// a subrange of BeforePrefix("as") to AfterPrefix("as"). Another range
+// including the same set of keys under the standard bytewise comparator is
+// AfterPrefix("ar") to BeforePrefix("at"), though this is not as intuitive
+// and can cost extra in constructing strings to back the distinct Slices.
+//
+// Prefix bounds can generalize to other comparators with support from
+// Comparator::CompareToPrefix() (see that function). The comparator might have
+// a limited domain of keys (with and without timestamps); for example, it might
+// assume a fixed-size key with or without an assertion. Prefixes recognized for
+// bounds can have their own domain, which may or may not overlap with the
+// domain of keys (without timestamps). For example, allowed prefixes might
+// be a smaller fixed size, to cooperate with a prefix_extractor. Only
+// CompareToPrefix() must handle comparing prefixes, and the left-operand
+// of CompareToPrefix() must also handle keys in addition to prefixes.
+// This establishes the relative ordering of keys against prefixes and
+// inclusion of key ranges under prefix bounds.
+//
+// In addition to the domain handling above, the following properties must be
+// satisfied for prefix bounds to be valid (to create a generalized total
+// ordering):
+//  * The comparator must give a total order on keys without timestamps, and
+//    a total order on keys with timestamps.
+//  * CompareToPrefix() must give a partial order on prefixes.
+//  * For any x, x_has_ts, y, y_has_ts, and p in the appropriate domains, if
+//    either
+//    * CompareToPrefix(x, x_has_ts, prefix) < 0 and
+//      CompareToPrefix(y, y_has_ts, prefix) >= 0, or
+//    * CompareToPrefix(x, x_has_ts, prefix) <= 0 and
+//      CompareToPrefix(y, y_has_ts, prefix) > 0
+//    then
+//    * CompareMaybeTimestamp(x, x_has_ts, y, y_has_ts) < 0
+//
+// This last property means the order of the prefixes has to be related to the
+// order of keys, and that prefixes must encompass a contiguous range of keys,
+// so include every key greater than the prefix's lower bound ("before") and
+// less than the prefix's upper bound ("after"). But notably, some
+// non-requirements contrast somewhat with prefix_extractor requirements:
+//  * The prefix does not have to be the first nor last key in its range (nor
+//    even in the domain of keys)
+//  * The prefix does not have to satisfy Slice::starts_with().
+//  * A key could be in the range of many distinct prefixes, even of the same
+//    Slice size.
+struct SliceBound {
+  enum Mode {
+    // Bit fields for constructing meaningful modes
+    kAfterBit = 1 << 0,
+    kUserTimestampBit = 1 << 1,
+    kPrefixBit = 1 << 2,
+
+    // Meaningful modes
+    kBeforeKey = 0,
+    kAfterKey = kAfterBit,
+
+    kBeforeKeyWithTs = kUserTimestampBit,
+    kAfterKeyWithTs = kUserTimestampBit | kAfterBit,
+
+    kBeforePrefix = kPrefixBit,
+    kAfterPrefix = kPrefixBit | kAfterBit,
+  };
+
+  // Bytes for the key or prefix
+  Slice key_like;
+  // What kind of SliceBound this is
+  Mode mode;
+
+  // A SliceBound ordered before everything else (that's not equivalent to it).
+  // == BeforePrefix("")
+  static const SliceBound kMin;
+  // A SliceBound ordered after everything else (that's not equivalent to it).
+  // == AfterPrefix("")
+  static const SliceBound kMax;
+};
+
+// Returns true if key `a`, possibly with timestamp (`a_has_ts`), is ordered
+// before bound `b` according to comparator comp. Returns false if ordered
+// after. NOTE: a key cannot be "equal to" a SliceBound because bounds are
+// logically between keys (or beyond either extreme).
+bool OrderedBeforeBound(const Slice& a, bool a_has_ts, const SliceBound& b,
+                        const Comparator& comp);
+
+// Compares two SliceBounds according to comparator comp. This can be used to
+// check for overlap in ranges. For example, if there exists a key k, k_has_ts
+// for which
+//  * OrderedBeforeBound(k, k_has_ts, a, comp) == false, and
+//  * OrderedBeforeBound(k, k_has_ts, b, comp) == true
+// then this function must return < 0 to indicate that 'a' is ordered before
+// 'b'. However, just because 'a' is ordered before 'b' does not necessarily
+// mean that there exists a key between the two bounds, but bounds are usually
+// constructed in ways that minimize reports of overlap without any keys
+// falling into that overlap. For example, in the default bytewise comparator,
+// AfterPrefix("foo1") is ordered before BeforePrefix("foo2"), so the two
+// prefix ranges are not reported as overlapping. See discussion on SliceBound.
+int CompareBounds(const SliceBound& a, const SliceBound& b,
+                  const Comparator& comp);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1797,6 +1797,9 @@ class DB {
   virtual Status GetPropertiesOfAllTables(TablePropertiesCollection* props) {
     return GetPropertiesOfAllTables(DefaultColumnFamily(), props);
   }
+
+  // Get properties of all table files (SST files) intersecting any of n key
+  // ranges in one column family. Results are stored in *props.
   virtual Status GetPropertiesOfTablesInRange(
       ColumnFamilyHandle* column_family, const Range* range, std::size_t n,
       TablePropertiesCollection* props) = 0;

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -380,4 +380,123 @@ Status Comparator::CreateFromString(const ConfigOptions& config_options,
   }
   return status;
 }
+
+int Comparator::CompareToPrefix(const Slice& a, bool a_has_ts,
+                                const Slice& prefix) const {
+  assert(CanKeysWithDifferentByteContentsBeEqual() == false);
+  // NOTE: we can't always just strip off the prefix.size() prefix of 'a'
+  // because that might not be a fully formed, comparable prefix (e.g. varint
+  // field)
+  if (a.starts_with(prefix)) {
+    return 0;
+  } else {
+    int cmp = CompareWithoutTimestamp(a, a_has_ts, prefix, false /*b_has_ts*/);
+    assert(cmp != 0);  // Based on path conditions+assertions above
+    return cmp < 0;
+  }
+}
+
+const SliceBound SliceBound::kMin{"", SliceBound::kBeforePrefix};
+const SliceBound SliceBound::kMax{"", SliceBound::kAfterPrefix};
+
+bool OrderedBeforeBound(const Slice& a, bool a_has_ts, const SliceBound& b,
+                        const Comparator& comp) {
+  bool after_mode = (b.mode & SliceBound::kAfterBit) != 0;
+  bool prefix_mode = (b.mode & SliceBound::kPrefixBit) != 0;
+  bool timestamp_mode = (b.mode & SliceBound::kUserTimestampBit) != 0;
+  int cmp;
+  if (prefix_mode) {
+    assert(!timestamp_mode);
+    cmp = comp.CompareToPrefix(a, a_has_ts, b.key_like);
+  } else if (comp.timestamp_size() == 0 || (a_has_ts && timestamp_mode)) {
+    // Full compare
+    cmp = comp.Compare(a, b.key_like);
+  } else {
+    // Can't compare a non-timestamp specific key to a timestamped bound
+    assert(a_has_ts || !timestamp_mode);
+    // Ignore timestamp
+    cmp = comp.CompareWithoutTimestamp(a, a_has_ts, b.key_like, timestamp_mode);
+  }
+  // "Before" mode: check a < b (cmp < 0). "After" mode: check a <= b (cmp < 1).
+  return cmp - after_mode < 0;
+}
+
+int CompareBounds(const SliceBound& a, const SliceBound& b,
+                  const Comparator& comp) {
+  bool after_mode_a = (a.mode & SliceBound::kAfterBit) != 0;
+  bool prefix_mode_a = (a.mode & SliceBound::kPrefixBit) != 0;
+  bool timestamp_mode_a = (a.mode & SliceBound::kUserTimestampBit) != 0;
+  bool after_mode_b = (b.mode & SliceBound::kAfterBit) != 0;
+  bool prefix_mode_b = (b.mode & SliceBound::kPrefixBit) != 0;
+  bool timestamp_mode_b = (b.mode & SliceBound::kUserTimestampBit) != 0;
+  if (prefix_mode_a) {
+    assert(!timestamp_mode_a);
+    if (prefix_mode_b) {
+      assert(!timestamp_mode_b);
+      // In general where different byte contents, including different size,
+      // might be equal, the only way to determine whether one is a prefix of
+      // the other, or are equal, is to check both ways.
+      int cmp1 = comp.CompareToPrefix(a.key_like, false /*has_ts*/, b.key_like);
+      int cmp2 = comp.CompareToPrefix(b.key_like, false /*has_ts*/, a.key_like);
+      if (cmp1 == 0) {
+        // b is a prefix of a
+        if (cmp2 == 0) {
+          // a is also a prefix of b
+          return int{after_mode_a} - int{after_mode_b};
+        } else {
+          return after_mode_b ? -1 : 1;
+        }
+      } else if (cmp2 == 0) {
+        // a is a prefix of b (but not vice-versa)
+        return after_mode_a ? 1 : -1;
+      } else {
+        // Neither is prefix of the other. Both comparisons should agree.
+        assert(cmp1 != 0 && cmp2 != 0);
+        assert((cmp1 > 0) == (cmp2 < 0));
+        return cmp1;
+      }
+    } else {
+      int cmp = -comp.CompareToPrefix(b.key_like, timestamp_mode_b, a.key_like);
+      if (cmp == 0) {
+        cmp = after_mode_a ? 1 : -1;
+      }
+      return cmp;
+    }
+  } else if (prefix_mode_b) {
+    assert(!timestamp_mode_b);
+    int cmp = comp.CompareToPrefix(a.key_like, timestamp_mode_a, b.key_like);
+    if (cmp == 0) {
+      cmp = after_mode_b ? 1 : -1;
+    }
+    return cmp;
+  } else if (comp.timestamp_size() == 0 ||
+             (timestamp_mode_a && timestamp_mode_b)) {
+    // Full compare
+    int cmp = comp.Compare(a.key_like, b.key_like);
+    if (cmp == 0) {
+      cmp = int{after_mode_a} - int{after_mode_b};
+    }
+    return cmp;
+  } else {
+    // Compare ignoring some timestamps
+    int cmp = comp.CompareWithoutTimestamp(a.key_like, timestamp_mode_a,
+                                           b.key_like, timestamp_mode_b);
+    if (cmp == 0) {
+      if (timestamp_mode_a || timestamp_mode_b) {
+        assert(timestamp_mode_a != timestamp_mode_b);
+        // The timestamp-key bound is considered within the before & after of
+        // the non-timestamp bound.
+        if (timestamp_mode_a) {
+          cmp = after_mode_b ? -1 : 1;
+        } else {
+          cmp = after_mode_a ? 1 : -1;
+        }
+      } else {
+        cmp = int{after_mode_a} - int{after_mode_b};
+      }
+    }
+    return cmp;
+  }
+}
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: Work In Progress / Request For Comments

Introduces a new struct SliceBound that provides a general way of specifying upper
and lower bounds for ranges of keys. Eventually this could be used for many APIs, including
DeleteRange, CompactRange, Iterator bounds, Iterator Seek locations, and more. This is intended
to solve many related problems:

* Some APIs use exclusive upper bounds and some use inclusive upper bounds. This is confusing
and can easily cause bugs. It is more user-friendly if exclusivity follows from the specification of
the bound itself, not what this particular API prefers.
* Some bounds are not constructible as keys. For example, if I'm using the reverse bytewise
comparator and want to seek to the start of prefix "foo", the best I can do is seek to "foo"
followed by a more 0xff chars than I hope to actually use, or seek to "fop" (nullifying opportunity
for prefix seek optimization) and skip over any "fop" entry. See also issue #11027 
* It appears most APIs expect bounds to include user timestamps (when enabled). This is not
really documented and could easily be a source of bugs. Like exclusivity, it's much more
user-friendly if the bound itself specifies whether it includes a user timestamp, rather than
committing each API as interpreting one way or another. (By the way, the existing interpretation
of bounds seems counter to the idea that the layout of user timestamps in keys is hidden
from the user, except in the implementation of Comparator.)
* We have some fragile code dealing with the range of keys included in an SST file. The range
it typically inclusive, but can be exclusive if the last key is only referring to the upper bound of
a range tombstone. If we translate these ranges to SliceBound, they fit into a generic framework
for key ranges, including checking overlap, etc.
* `auto_prefix_mode` is a rather awkward and somewhat broken way to prefix filtering, often
requiring copying & modifying keys for bounds. `prefix_same_as_start` is arguably bug-prone
because the meaning of a read operation is tied to the current prefix extractor. SliceBound
should be able to solve these issues by making it simple to scan a specific prefix, regardless
of current prefix extractor setting.

There is likely to be a performance cost associated with comparing against these generalized
bounds, though most of it will likely be optimized with function inlining. However, the savings
in avoiding copying and modifying keys to construct bounds might sufficiently offset these
overheads.

There is an existing related idea called Endpoint in transaction.h, but it is not nearly as general
or as well specified. (Lacking unit tests; not clear what reverse comparator semantics are; doesn't
add clarity to inclusive vs. exclusive bounds; unclear timestamp semantics)

See comparator.h changes for details.

Test Plan: TODO

The APIs mentioned in #11027 would likely be the first upgraded to support SliceBound.