### PR TITLE
Fix build error: variable 'base_level' may be uninitialized 

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1170,7 +1170,7 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
         // at L1 (or LBase), if applicable.
         int level = first_overlapped_level;
         final_output_level = level;
-        int output_level, base_level;
+        int output_level = 0, base_level = 0;
         while (level < max_overlapped_level || level == 0) {
           output_level = level + 1;
           if (cfd->ioptions()->level_compaction_dynamic_level_bytes &&


### PR DESCRIPTION
Summary: Fix build error: variable 'base_level' may be uninitialized
```
 db_impl_compaction_flush.cc:1195:21: error: variable 'base_level' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
            level = base_level;
```
                    ^~~~~~~~~~

Test Plan: CircleCI jobs

Reviewers:

Subscribers:

Tasks:

Tags: