### PR TITLE
Add weak function symbol for daily reporting

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Introduced a new option `CompactionOptionsFIFO::file_temperature_age_thresholds` that allows FIFO compaction to compact files to different temperatures based on key age (#11428).
 * Added a new ticker stat to count how many times RocksDB detected a corruption while verifying a block checksum: `BLOCK_CHECKSUM_MISMATCH_COUNT`.
 * New statistics `rocksdb.file.read.db.open.micros` that measures read time of block-based SST tables or blob files during db open.
+* Add an interface `RocksDbDailyReport(DB* db)` that, if defined by the user, will be called immediately after opening the DB and every day after that.
 
 ### Public API Changes
 * Add `MakeSharedCache()` construction functions to various cache Options objects, and deprecated the `NewWhateverCache()` functions with long parameter lists.

--- a/db/periodic_task_scheduler.cc
+++ b/db/periodic_task_scheduler.cc
@@ -45,6 +45,9 @@ Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
            {"record_seq_time" /* name_prefix */,
             kInvalidPeriodSec /* period_seconds */,
             true /* delay_initially */}},
+          {PeriodicTaskType::kDailyReport,
+           {"daily_report" /* name_prefix */, 24 * 60 * 60 /* period_seconds */,
+            false /* delay_initially */}},
       };
 
   auto config = kDefaultConfigs.at(task_type);

--- a/db/periodic_task_scheduler.cc
+++ b/db/periodic_task_scheduler.cc
@@ -21,38 +21,52 @@ namespace ROCKSDB_NAMESPACE {
 // infrequently.
 static port::Mutex timer_mutex;
 
-static const std::map<PeriodicTaskType, uint64_t> kDefaultPeriodSeconds = {
-    {PeriodicTaskType::kDumpStats, kInvalidPeriodSec},
-    {PeriodicTaskType::kPersistStats, kInvalidPeriodSec},
-    {PeriodicTaskType::kFlushInfoLog, 10},
-    {PeriodicTaskType::kRecordSeqnoTime, kInvalidPeriodSec},
-};
-
-static const std::map<PeriodicTaskType, std::string> kPeriodicTaskTypeNames = {
-    {PeriodicTaskType::kDumpStats, "dump_st"},
-    {PeriodicTaskType::kPersistStats, "pst_st"},
-    {PeriodicTaskType::kFlushInfoLog, "flush_info_log"},
-    {PeriodicTaskType::kRecordSeqnoTime, "record_seq_time"},
-};
-
 Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
                                        const PeriodicTaskFunc& fn) {
-  return Register(task_type, fn, kDefaultPeriodSeconds.at(task_type));
+  return Register(task_type, fn, kInvalidPeriodSec);
 }
 
 Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
                                        const PeriodicTaskFunc& fn,
                                        uint64_t repeat_period_seconds) {
+  static const std::map<PeriodicTaskType,
+                        PeriodicTaskScheduler::TaskRegistrationConfig>
+      kDefaultConfigs = {
+          {PeriodicTaskType::kDumpStats,
+           {"dump_st" /* name_prefix */, kInvalidPeriodSec /* period_seconds */,
+            true /* delay_initially */}},
+          {PeriodicTaskType::kPersistStats,
+           {"pst_st" /* name_prefix */, kInvalidPeriodSec /* period_seconds */,
+            true /* delay_initially */}},
+          {PeriodicTaskType::kFlushInfoLog,
+           {"flush_info_log" /* name_prefix */, 10 /* period_seconds */,
+            true /* delay_initially */}},
+          {PeriodicTaskType::kRecordSeqnoTime,
+           {"record_seq_time" /* name_prefix */,
+            kInvalidPeriodSec /* period_seconds */,
+            true /* delay_initially */}},
+      };
+
+  auto config = kDefaultConfigs.at(task_type);
+  if (repeat_period_seconds != kInvalidPeriodSec) {
+    config.period_seconds = repeat_period_seconds;
+  }
+  return Register(task_type, fn, config);
+}
+
+Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
+                                       const PeriodicTaskFunc& fn,
+                                       const TaskRegistrationConfig& config) {
   MutexLock l(&timer_mutex);
   static std::atomic<uint64_t> initial_delay(0);
 
-  if (repeat_period_seconds == kInvalidPeriodSec) {
+  if (config.period_seconds == kInvalidPeriodSec) {
     return Status::InvalidArgument("Invalid task repeat period");
   }
   auto it = tasks_map_.find(task_type);
   if (it != tasks_map_.end()) {
     // the task already exists and it's the same, no update needed
-    if (it->second.repeat_every_sec == repeat_period_seconds) {
+    if (it->second.repeat_every_sec == config.period_seconds) {
       return Status::OK();
     }
     // cancel the existing one before register new one
@@ -62,18 +76,22 @@ Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
 
   timer_->Start();
   // put task type name as prefix, for easy debug
-  std::string unique_id =
-      kPeriodicTaskTypeNames.at(task_type) + std::to_string(id_++);
+  std::string unique_id = config.name_prefix + std::to_string(id_++);
 
-  bool succeeded = timer_->Add(
-      fn, unique_id,
-      (initial_delay.fetch_add(1) % repeat_period_seconds) * kMicrosInSecond,
-      repeat_period_seconds * kMicrosInSecond);
+  uint64_t initial_delay_micros;
+  if (config.delay_initially) {
+    initial_delay_micros =
+        (initial_delay.fetch_add(1) % config.period_seconds) * kMicrosInSecond;
+  } else {
+    initial_delay_micros = 0;
+  }
+  bool succeeded = timer_->Add(fn, unique_id, initial_delay_micros,
+                               config.period_seconds * kMicrosInSecond);
   if (!succeeded) {
     return Status::Aborted("Failed to register periodic task");
   }
   auto result = tasks_map_.try_emplace(
-      task_type, TaskInfo{unique_id, repeat_period_seconds});
+      task_type, TaskInfo{unique_id, config.period_seconds});
   if (!result.second) {
     return Status::Aborted("Failed to add periodic task");
   };

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -22,6 +22,7 @@ enum class PeriodicTaskType : uint8_t {
   kPersistStats,
   kFlushInfoLog,
   kRecordSeqnoTime,
+  kDailyReport,
   kMax,
 };
 

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -83,6 +83,15 @@ class PeriodicTaskScheduler {
   // default global Timer instance
   static Timer* Default();
 
+  struct TaskRegistrationConfig {
+    std::string name_prefix;
+    uint64_t period_seconds;
+    bool delay_initially;
+  };
+
+  Status Register(PeriodicTaskType task_type, const PeriodicTaskFunc& fn,
+                  const TaskRegistrationConfig& config);
+
   // Internal structure to store task information
   struct TaskInfo {
     TaskInfo(std::string _name, uint64_t _repeat_every_sec)

--- a/db/periodic_task_scheduler_test.cc
+++ b/db/periodic_task_scheduler_test.cc
@@ -138,7 +138,7 @@ TEST_F(PeriodicTaskSchedulerTest, Basic) {
   ASSERT_EQ(1, daily_report_counter);
 
   const int kDaySeconds = 86400;
-  int sleep_seconds = kDaySeconds - mock_clock_->NowSeconds();
+  int sleep_seconds = kDaySeconds - static_cast<int>(mock_clock_->NowSeconds());
   dbfull()->TEST_WaitForPeriodicTaskRun(
       [&] { mock_clock_->MockSleepForSeconds(sleep_seconds); });
   ASSERT_EQ(2, daily_report_counter);


### PR DESCRIPTION
Just trying something. A copy of RocksDB source code can be accompanied with a definition of `RocksDbDailyReport(DB* db)` to add daily reporting to all its dependents.