### PR TITLE
Tweak on IsTrivialMove()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ fuzz/crash-*
 cmake-build-*
 third-party/folly/
 .cache
+*.sublime-*


### PR DESCRIPTION
`output_level_` and `number_levels_` are not changing in iteration of `inputs_` files.

Moving the check out of `for` loop could slightly improve performance.


It is easier to review when ignore whitespace changes.