### PR TITLE
Logging timestamp size record in WAL and use it during recovery

### DIFF
--- a/db/column_family.h
+++ b/db/column_family.h
@@ -705,6 +705,16 @@ class ColumnFamilySet {
                                        Version* dummy_version,
                                        const ColumnFamilyOptions& options);
 
+  const std::unordered_map<uint32_t, size_t>&
+  GetRunningColumnFamiliesTimestampSize() const {
+    return running_ts_sz_;
+  }
+
+  const std::unordered_map<uint32_t, size_t>&
+  GetColumnFamiliesTimestampSizeForRecord() const {
+    return ts_sz_for_record_;
+  }
+
   iterator begin() { return iterator(dummy_cfd_->next_); }
   iterator end() { return iterator(dummy_cfd_); }
 
@@ -729,6 +739,15 @@ class ColumnFamilySet {
   // 2. accessed from a single-threaded write thread
   UnorderedMap<std::string, uint32_t> column_families_;
   UnorderedMap<uint32_t, ColumnFamilyData*> column_family_data_;
+
+  // Mutating / reading `running_ts_sz_` and `ts_sz_for_record_` follow
+  // the same requirements as `column_families_` and `column_family_data_`.
+  // Mapping from column family id to user-defined timestamp size for all
+  // running column families.
+  std::unordered_map<uint32_t, size_t> running_ts_sz_;
+  // Mapping from column family id to user-defined timestamp size for
+  // column families with non-zero user-defined timestamp size.
+  std::unordered_map<uint32_t, size_t> ts_sz_for_record_;
 
   uint32_t max_column_family_;
   const FileOptions file_options_;

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -214,7 +214,7 @@ Status DBImplSecondary::RecoverLogFiles(
     // Read all the records and add to a memtable
     std::string scratch;
     Slice record;
-    std::unique_ptr<WriteBatch> batch(new WriteBatch());
+    WriteBatch batch;
 
     while (reader->ReadRecord(&record, &scratch,
                               immutable_db_options_.wal_recovery_mode) &&
@@ -224,22 +224,21 @@ Status DBImplSecondary::RecoverLogFiles(
             record.size(), Status::Corruption("log record too small"));
         continue;
       }
-      status = WriteBatchInternal::SetContents(batch.get(), record);
+      status = WriteBatchInternal::SetContents(&batch, record);
       if (!status.ok()) {
         break;
       }
       const std::unordered_map<uint32_t, size_t>& record_ts_sz =
           reader->GetRecordedTimestampSize();
       status = HandleWriteBatchTimestampSizeDifference(
-          running_ts_sz, record_ts_sz,
-          TimestampSizeConsistencyMode::kVerifyConsistency, batch,
-          nullptr /* batch_updated */);
+          &batch, running_ts_sz, record_ts_sz,
+          TimestampSizeConsistencyMode::kVerifyConsistency);
       if (!status.ok()) {
         break;
       }
-      SequenceNumber seq_of_batch = WriteBatchInternal::Sequence(batch.get());
+      SequenceNumber seq_of_batch = WriteBatchInternal::Sequence(&batch);
       std::vector<uint32_t> column_family_ids;
-      status = CollectColumnFamilyIdsFromWriteBatch(*batch, &column_family_ids);
+      status = CollectColumnFamilyIdsFromWriteBatch(batch, &column_family_ids);
       if (status.ok()) {
         for (const auto id : column_family_ids) {
           ColumnFamilyData* cfd =
@@ -284,7 +283,7 @@ Status DBImplSecondary::RecoverLogFiles(
         }
         bool has_valid_writes = false;
         status = WriteBatchInternal::InsertInto(
-            batch.get(), column_family_memtables_.get(),
+            &batch, column_family_memtables_.get(),
             nullptr /* flush_scheduler */, nullptr /* trim_history_scheduler*/,
             true, log_number, this, false /* concurrent_memtable_writes */,
             next_sequence, &has_valid_writes, seq_per_batch_, batch_per_txn_);

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -8,6 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "db/db_test_util.h"
+#include "db/db_with_timestamp_test_util.h"
 #include "options/options_helper.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
@@ -298,6 +299,77 @@ TEST_F(DBWALTest, Recover) {
     ASSERT_EQ("v4", Get(1, "foo"));
     ASSERT_EQ("v2", Get(1, "bar"));
     ASSERT_EQ("v5", Get(1, "baz"));
+  } while (ChangeWalOptions());
+}
+
+class DBWALTestWithTimestamp : public DBBasicTestWithTimestampBase {
+ public:
+  DBWALTestWithTimestamp()
+      : DBBasicTestWithTimestampBase("db_wal_test_with_timestamp") {}
+
+  void CreateAndReopenWithCFWithTs(const std::vector<std::string>& cfs,
+                                   const Options& options) {
+    CreateColumnFamilies(cfs, options);
+    ReopenColumnFamiliesWithTs(cfs, options);
+  }
+
+  void ReopenColumnFamiliesWithTs(const std::vector<std::string>& cfs,
+                                  Options ts_options) {
+    Options default_options = CurrentOptions();
+    default_options.create_if_missing = false;
+    ts_options.create_if_missing = false;
+
+    std::vector<Options> cf_options(cfs.size(), ts_options);
+    std::vector<std::string> cfs_plus_default = cfs;
+    cfs_plus_default.insert(cfs_plus_default.begin(), kDefaultColumnFamilyName);
+    cf_options.insert(cf_options.begin(), default_options);
+    Close();
+    ASSERT_OK(TryReopenWithColumnFamilies(cfs_plus_default, cf_options));
+  }
+
+  Status Put(uint32_t cf, const Slice& key, const Slice& ts,
+             const Slice& value) {
+    WriteOptions write_opts;
+    return db_->Put(write_opts, handles_[cf], key, ts, value);
+  }
+
+  void CheckGet(const ReadOptions& read_opts, uint32_t cf, const Slice& key,
+                const std::string& expected_value) {
+    std::string actual_value;
+    ASSERT_OK(db_->Get(read_opts, handles_[cf], key, &actual_value));
+    ASSERT_EQ(expected_value, actual_value);
+  }
+};
+
+TEST_F(DBWALTestWithTimestamp, Recover) {
+  // Set up the option that enables user defined timestmp size.
+  std::string ts = Timestamp(1, 0);
+  const size_t kTimestampSize = ts.size();
+  TestComparator test_cmp(kTimestampSize);
+  Options ts_options;
+  ts_options.create_if_missing = true;
+  ts_options.comparator = &test_cmp;
+
+  ReadOptions read_opts;
+  Slice ts_slice = ts;
+  read_opts.timestamp = &ts_slice;
+  do {
+    CreateAndReopenWithCFWithTs({"pikachu"}, ts_options);
+    ASSERT_OK(Put(1, "foo", ts, "v1"));
+    ASSERT_OK(Put(1, "baz", ts, "v5"));
+
+    ReopenColumnFamiliesWithTs({"pikachu"}, ts_options);
+    CheckGet(read_opts, 1, "foo", "v1");
+    CheckGet(read_opts, 1, "baz", "v5");
+    ASSERT_OK(Put(1, "bar", ts, "v2"));
+    ASSERT_OK(Put(1, "foo", ts, "v3"));
+
+    ReopenColumnFamiliesWithTs({"pikachu"}, ts_options);
+    CheckGet(read_opts, 1, "foo", "v3");
+    ASSERT_OK(Put(1, "foo", ts, "v4"));
+    CheckGet(read_opts, 1, "foo", "v4");
+    CheckGet(read_opts, 1, "bar", "v2");
+    CheckGet(read_opts, 1, "baz", "v5");
   } while (ChangeWalOptions());
 }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1467,6 +1467,17 @@ class VersionSet {
                         uint64_t min_pending_output);
 
   ColumnFamilySet* GetColumnFamilySet() { return column_family_set_.get(); }
+
+  const std::unordered_map<uint32_t, size_t>&
+  GetRunningColumnFamiliesTimestampSize() const {
+    return column_family_set_->GetRunningColumnFamiliesTimestampSize();
+  }
+
+  const std::unordered_map<uint32_t, size_t>&
+  GetColumnFamiliesTimestampSizeForRecord() const {
+    return column_family_set_->GetColumnFamiliesTimestampSizeForRecord();
+  }
+
   RefedColumnFamilySet GetRefedColumnFamilySet() {
     return RefedColumnFamilySet(GetColumnFamilySet());
   }

--- a/unreleased_history/new_features/logging_udt_sizes.md
+++ b/unreleased_history/new_features/logging_udt_sizes.md
@@ -1,0 +1,1 @@
+Start logging non-zero user-defined timestamp sizes in WAL to signal user key format in subsequent records and use it during recovery. This change will break recovery from WAL files written by early versions that contain user-defined timestamps. The workaround is to ensure there are no WAL files to recover (i.e. by flushing before close) before upgrade.

--- a/util/udt_util.cc
+++ b/util/udt_util.cc
@@ -247,7 +247,8 @@ Status HandleWriteBatchTimestampSizeDifference(
       batch, running_ts_sz, record_ts_sz, check_mode, &need_recovery);
   if (!status.ok()) {
     return status;
-  } else if (need_recovery && new_batch != nullptr) {
+  } else if (need_recovery) {
+    assert(new_batch);
     SequenceNumber sequence = WriteBatchInternal::Sequence(batch);
     TimestampRecoveryHandler recovery_handler(running_ts_sz, record_ts_sz);
     status = batch->Iterate(&recovery_handler);

--- a/util/udt_util.h
+++ b/util/udt_util.h
@@ -198,8 +198,8 @@ enum class TimestampSizeConsistencyMode {
 // any running column family has an inconsistent user-defined timestamp size
 // that cannot be reconciled with a best-effort recovery. Check
 // `TimestampRecoveryHandler` for what a best-effort recovery is capable of. In
-// this mode, if output argument `new_batch` is set, a new WriteBatch is created
-// on the heap and transferred to `new_batch` if there is tolerable
+// this mode, output argument `new_batch` should be set, a new WriteBatch is
+// created on the heap and transferred to `new_batch` if there is tolerable
 // inconsistency.
 //
 // An invariant that WAL logging ensures is that all timestamp size info

--- a/util/udt_util_test.cc
+++ b/util/udt_util_test.cc
@@ -106,18 +106,17 @@ class HandleTimestampSizeDifferenceTest : public testing::Test {
 
   void CreateWriteBatch(
       const std::unordered_map<uint32_t, size_t>& ts_sz_for_batch,
-      std::unique_ptr<WriteBatch>& batch) {
+      WriteBatch* batch) {
     for (const auto& [cf_id, ts_sz] : ts_sz_for_batch) {
       std::string key;
       CreateKey(&key, ts_sz);
+      ASSERT_OK(WriteBatchInternal::Put(batch, cf_id, key, kValuePlaceHolder));
+      ASSERT_OK(WriteBatchInternal::Delete(batch, cf_id, key));
+      ASSERT_OK(WriteBatchInternal::SingleDelete(batch, cf_id, key));
+      ASSERT_OK(WriteBatchInternal::DeleteRange(batch, cf_id, key, key));
       ASSERT_OK(
-          WriteBatchInternal::Put(batch.get(), cf_id, key, kValuePlaceHolder));
-      ASSERT_OK(WriteBatchInternal::Delete(batch.get(), cf_id, key));
-      ASSERT_OK(WriteBatchInternal::SingleDelete(batch.get(), cf_id, key));
-      ASSERT_OK(WriteBatchInternal::DeleteRange(batch.get(), cf_id, key, key));
-      ASSERT_OK(WriteBatchInternal::Merge(batch.get(), cf_id, key,
-                                          kValuePlaceHolder));
-      ASSERT_OK(WriteBatchInternal::PutBlobIndex(batch.get(), cf_id, key,
+          WriteBatchInternal::Merge(batch, cf_id, key, kValuePlaceHolder));
+      ASSERT_OK(WriteBatchInternal::PutBlobIndex(batch, cf_id, key,
                                                  kValuePlaceHolder));
     }
   }
@@ -189,23 +188,18 @@ TEST_F(HandleTimestampSizeDifferenceTest, AllColumnFamiliesConsistent) {
   std::unordered_map<uint32_t, size_t> running_ts_sz = {{1, sizeof(uint64_t)},
                                                         {2, 0}};
   std::unordered_map<uint32_t, size_t> record_ts_sz = {{1, sizeof(uint64_t)}};
-  std::unique_ptr<WriteBatch> batch(new WriteBatch());
-  CreateWriteBatch(running_ts_sz, batch);
-  const WriteBatch* orig_batch = batch.get();
-  bool batch_updated = false;
+  WriteBatch batch;
+  CreateWriteBatch(running_ts_sz, &batch);
 
   // All `check_mode` pass with OK status and `batch` not checked or updated.
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kVerifyConsistency, batch, &batch_updated));
-  ASSERT_EQ(orig_batch, batch.get());
-  ASSERT_FALSE(batch_updated);
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kVerifyConsistency));
+  std::unique_ptr<WriteBatch> new_batch(nullptr);
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kReconcileInconsistency, batch,
-      &batch_updated));
-  ASSERT_FALSE(batch_updated);
-  ASSERT_EQ(orig_batch, batch.get());
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kReconcileInconsistency, &new_batch));
+  ASSERT_TRUE(new_batch.get() == nullptr);
 }
 
 TEST_F(HandleTimestampSizeDifferenceTest,
@@ -213,46 +207,36 @@ TEST_F(HandleTimestampSizeDifferenceTest,
   std::unordered_map<uint32_t, size_t> running_ts_sz = {{2, 0}};
   std::unordered_map<uint32_t, size_t> record_ts_sz = {{1, sizeof(uint64_t)},
                                                        {3, sizeof(char)}};
-  std::unique_ptr<WriteBatch> batch(new WriteBatch());
-  CreateWriteBatch(record_ts_sz, batch);
-  const WriteBatch* orig_batch = batch.get();
-  bool batch_updated = false;
+  WriteBatch batch;
+  CreateWriteBatch(record_ts_sz, &batch);
 
   // All `check_mode` pass with OK status and `batch` not checked or updated.
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kVerifyConsistency, batch, &batch_updated));
-  ASSERT_EQ(orig_batch, batch.get());
-  ASSERT_FALSE(batch_updated);
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kVerifyConsistency));
+  std::unique_ptr<WriteBatch> new_batch(nullptr);
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kReconcileInconsistency, batch,
-      &batch_updated));
-  ASSERT_EQ(orig_batch, batch.get());
-  ASSERT_FALSE(batch_updated);
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kReconcileInconsistency, &new_batch));
+  ASSERT_TRUE(new_batch.get() == nullptr);
 }
 
 TEST_F(HandleTimestampSizeDifferenceTest, InvolvedColumnFamiliesConsistent) {
   std::unordered_map<uint32_t, size_t> running_ts_sz = {{1, sizeof(uint64_t)},
                                                         {2, sizeof(char)}};
   std::unordered_map<uint32_t, size_t> record_ts_sz = {{1, sizeof(uint64_t)}};
-  std::unique_ptr<WriteBatch> batch(new WriteBatch());
-  CreateWriteBatch(record_ts_sz, batch);
-  const WriteBatch* orig_batch = batch.get();
-  bool batch_updated = false;
+  WriteBatch batch;
+  CreateWriteBatch(record_ts_sz, &batch);
 
   // All `check_mode` pass with OK status and `batch` not updated.
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kVerifyConsistency, batch, &batch_updated));
-  ASSERT_EQ(orig_batch, batch.get());
-  ASSERT_FALSE(batch_updated);
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kVerifyConsistency));
+  std::unique_ptr<WriteBatch> new_batch(nullptr);
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kReconcileInconsistency, batch,
-      &batch_updated));
-  ASSERT_EQ(orig_batch, batch.get());
-  ASSERT_FALSE(batch_updated);
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kReconcileInconsistency, &new_batch));
+  ASSERT_TRUE(new_batch.get() == nullptr);
 }
 
 TEST_F(HandleTimestampSizeDifferenceTest,
@@ -260,28 +244,22 @@ TEST_F(HandleTimestampSizeDifferenceTest,
   std::unordered_map<uint32_t, size_t> running_ts_sz = {{1, 0},
                                                         {2, sizeof(char)}};
   std::unordered_map<uint32_t, size_t> record_ts_sz = {{1, sizeof(uint64_t)}};
-  std::unique_ptr<WriteBatch> batch(new WriteBatch());
-  CreateWriteBatch(record_ts_sz, batch);
-  const WriteBatch* orig_batch = batch.get();
-  WriteBatch orig_batch_copy(*batch);
-  bool batch_updated = false;
+  WriteBatch batch;
+  CreateWriteBatch(record_ts_sz, &batch);
 
   // kVerifyConsistency doesn't tolerate inconsistency for running column
   // families.
   ASSERT_TRUE(HandleWriteBatchTimestampSizeDifference(
-                  running_ts_sz, record_ts_sz,
-                  TimestampSizeConsistencyMode::kVerifyConsistency, batch,
-                  &batch_updated)
+                  &batch, running_ts_sz, record_ts_sz,
+                  TimestampSizeConsistencyMode::kVerifyConsistency)
                   .IsInvalidArgument());
-  ASSERT_FALSE(batch_updated);
 
+  std::unique_ptr<WriteBatch> new_batch(nullptr);
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kReconcileInconsistency, batch,
-      &batch_updated));
-  ASSERT_TRUE(batch_updated);
-  ASSERT_NE(orig_batch, batch.get());
-  CheckContentsWithTimestampStripping(orig_batch_copy, *batch, sizeof(uint64_t),
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kReconcileInconsistency, &new_batch));
+  ASSERT_TRUE(new_batch.get() != nullptr);
+  CheckContentsWithTimestampStripping(batch, *new_batch, sizeof(uint64_t),
                                       std::nullopt /* dropped_cf */);
 }
 
@@ -291,27 +269,22 @@ TEST_F(HandleTimestampSizeDifferenceTest,
   // Make `record_ts_sz` not contain zero timestamp size entries to follow the
   // behavior of actual WAL log timestamp size record.
   std::unordered_map<uint32_t, size_t> record_ts_sz;
-  std::unique_ptr<WriteBatch> batch(new WriteBatch());
-  CreateWriteBatch({{1, 0}}, batch);
-  const WriteBatch* orig_batch = batch.get();
-  WriteBatch orig_batch_copy(*batch);
-  bool batch_updated = false;
+  WriteBatch batch;
+  CreateWriteBatch({{1, 0}}, &batch);
 
   // kVerifyConsistency doesn't tolerate inconsistency for running column
   // families.
   ASSERT_TRUE(HandleWriteBatchTimestampSizeDifference(
-                  running_ts_sz, record_ts_sz,
-                  TimestampSizeConsistencyMode::kVerifyConsistency, batch,
-                  &batch_updated)
+                  &batch, running_ts_sz, record_ts_sz,
+                  TimestampSizeConsistencyMode::kVerifyConsistency)
                   .IsInvalidArgument());
-  ASSERT_FALSE(batch_updated);
+
+  std::unique_ptr<WriteBatch> new_batch(nullptr);
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kReconcileInconsistency, batch,
-      &batch_updated));
-  ASSERT_NE(orig_batch, batch.get());
-  ASSERT_TRUE(batch_updated);
-  CheckContentsWithTimestampPadding(orig_batch_copy, *batch, sizeof(uint64_t));
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kReconcileInconsistency, &new_batch));
+  ASSERT_TRUE(new_batch.get() != nullptr);
+  CheckContentsWithTimestampPadding(batch, *new_batch, sizeof(uint64_t));
 }
 
 TEST_F(HandleTimestampSizeDifferenceTest,
@@ -319,44 +292,36 @@ TEST_F(HandleTimestampSizeDifferenceTest,
   std::unordered_map<uint32_t, size_t> running_ts_sz = {{1, 0}};
   std::unordered_map<uint32_t, size_t> record_ts_sz = {{1, sizeof(uint64_t)},
                                                        {2, sizeof(char)}};
-  std::unique_ptr<WriteBatch> batch(new WriteBatch());
-  CreateWriteBatch(record_ts_sz, batch);
-  const WriteBatch* orig_batch = batch.get();
-  WriteBatch orig_batch_copy(*batch);
-  bool batch_updated = false;
+  WriteBatch batch;
+  CreateWriteBatch(record_ts_sz, &batch);
+  std::unique_ptr<WriteBatch> new_batch(nullptr);
 
   // kReconcileInconsistency tolerate inconsistency for dropped column family
   // and all related entries copied over to the new WriteBatch.
   ASSERT_OK(HandleWriteBatchTimestampSizeDifference(
-      running_ts_sz, record_ts_sz,
-      TimestampSizeConsistencyMode::kReconcileInconsistency, batch,
-      &batch_updated));
-  ASSERT_TRUE(batch_updated);
-  ASSERT_NE(orig_batch, batch.get());
-  CheckContentsWithTimestampStripping(orig_batch_copy, *batch, sizeof(uint64_t),
+      &batch, running_ts_sz, record_ts_sz,
+      TimestampSizeConsistencyMode::kReconcileInconsistency, &new_batch));
+
+  ASSERT_TRUE(new_batch.get() != nullptr);
+  CheckContentsWithTimestampStripping(batch, *new_batch, sizeof(uint64_t),
                                       std::optional<uint32_t>(2));
 }
 
 TEST_F(HandleTimestampSizeDifferenceTest, UnrecoverableInconsistency) {
   std::unordered_map<uint32_t, size_t> running_ts_sz = {{1, sizeof(char)}};
   std::unordered_map<uint32_t, size_t> record_ts_sz = {{1, sizeof(uint64_t)}};
-  std::unique_ptr<WriteBatch> batch(new WriteBatch());
-  CreateWriteBatch(record_ts_sz, batch);
-  bool batch_updated = false;
+  WriteBatch batch;
+  CreateWriteBatch(record_ts_sz, &batch);
 
   ASSERT_TRUE(HandleWriteBatchTimestampSizeDifference(
-                  running_ts_sz, record_ts_sz,
-                  TimestampSizeConsistencyMode::kVerifyConsistency, batch,
-                  &batch_updated)
+                  &batch, running_ts_sz, record_ts_sz,
+                  TimestampSizeConsistencyMode::kVerifyConsistency)
                   .IsInvalidArgument());
-  ASSERT_FALSE(batch_updated);
 
   ASSERT_TRUE(HandleWriteBatchTimestampSizeDifference(
-                  running_ts_sz, record_ts_sz,
-                  TimestampSizeConsistencyMode::kReconcileInconsistency, batch,
-                  &batch_updated)
+                  &batch, running_ts_sz, record_ts_sz,
+                  TimestampSizeConsistencyMode::kReconcileInconsistency)
                   .IsInvalidArgument());
-  ASSERT_FALSE(batch_updated);
 }
 }  // namespace ROCKSDB_NAMESPACE
 


### PR DESCRIPTION
Start logging the timestamp size record in WAL and use the record during recovery.  Currently, user comparator cannot be different from what was used to create a column family, so the timestamp size record is just used to confirm it's consistent with the timestamp size the running user comparator indicates.

Test Plan
```
make all check
./db_secondary_test
./db_wal_test --gtest_filter="*WithTimestamp*"
./repair_test --gtest_filter="*WithTimestamp*"
```