### PR TITLE
Don't swallow builder error messages in BuildTable

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -230,6 +230,11 @@ Status BuildTable(
         ThreadStatusUtil::SetThreadOperationProperty(
             ThreadStatus::FLUSH_BYTES_WRITTEN, IOSTATS(bytes_written));
       }
+
+      s = builder->status();
+      if (!s.ok()) {
+        break;
+      }
     }
     if (!s.ok()) {
       c_iter.status().PermitUncheckedError();


### PR DESCRIPTION
If builder->Add sets _status to a failing Status, previously BuildTable
would just continue looping - and the previous invocation would see
`seen_error()` set to true and return an opaque "Writer has previous
error" status, without any information on what that previous error was.
This commit changes the iterator loop in BuildTable to fail-fast, so
that the status returned always has the first error message.