### PR TITLE
Document SyncPoint::LoadDependency

### DIFF
--- a/test_util/sync_point.h
+++ b/test_util/sync_point.h
@@ -85,7 +85,9 @@ class SyncPoint {
   };
 
   // call once at the beginning of a test to setup the dependency between
-  // sync points
+  // sync points. Specifically, execution will not be allowed to proceed past
+  // each successor until execution has reached the corresponding predecessor,
+  // in any thread.
   void LoadDependency(const std::vector<SyncPointPair>& dependencies);
 
   // call once at the beginning of a test to setup the dependency between


### PR DESCRIPTION
Summary: It's easy to mix up the ordering when it's undocumented. For an example of the meaning of the order, see DBTest.ThreadStatusFlush.

Test Plan: comments only