### PR TITLE
Flush option in WaitForCompact()

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2087,6 +2087,9 @@ struct WaitForCompactOptions {
   // Otherwise, jobs that were queued, but not scheduled yet may never finish
   // and WaitForCompact() may wait indefinitely.
   bool abort_on_pause = false;
+
+  // A boolean to flush before starting to wait.
+  bool flush = false;
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Context:

As mentioned in #11436, introducing `flush` option in `WaitForCompactOptions` to flush before waiting for compactions to finish. Must be set to true to ensure no immediate compactions (except perhaps periodic compactions) after closing and re-opening the DB.

Summary
1. `bool flush = false` added to `WaitForCompactOptions`
2. `DBImpl::Flush(FlushOptions())` gets called before waiting in `WaitForCompact()`
3. Some previous WaitForCompact tests were parameterized to include both cases for `abort_on_pause_` being true/false as well as `flush_` being true/false

Test Plan
- `DBCompactionTest::WaitForCompactWithOptionToFlush` added
- Changed existing DBCompactionTest::WaitForCompact tests to `DBCompactionWaitForCompactTest` to include params