### PR TITLE
Java: Expose put/delete/gets with direct memory addresses

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -276,6 +276,7 @@ JAVAC_VERSION_GE_MIN := $(shell [ $(JAVAC_MAJOR_VERSION) -ge $(MIN_JAVAC_MAJOR_V
 
 # Set the default JAVA_ARGS to "" for DEBUG_LEVEL=0
 JAVA_ARGS ?=
+JAVA_ARGS += --add-opens java.base/java.nio=ALL-UNNAMED
 
 JAVAC_ARGS ?=
 

--- a/java/jmh/pom.xml
+++ b/java/jmh/pom.xml
@@ -42,7 +42,8 @@
         <project.build.target>1.7</project.build.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jmh.version>1.22</jmh.version>
+        <jmh.version>1.36</jmh.version>
+        <netty.version>4.1.92.Final</netty.version>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
 
@@ -50,7 +51,7 @@
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>8.4.0</version>
         </dependency>
 
         <dependency>
@@ -63,6 +64,11 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${netty.version}</version>
         </dependency>
     </dependencies>
 

--- a/java/jmh/src/main/java/org/rocksdb/jmh/GetBenchmarks.java
+++ b/java/jmh/src/main/java/org/rocksdb/jmh/GetBenchmarks.java
@@ -8,6 +8,9 @@ package org.rocksdb.jmh;
 
 import static org.rocksdb.util.KVUtils.ba;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.PooledByteBufAllocator;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -49,6 +52,9 @@ public class GetBenchmarks {
   private ByteBuffer valueBuf;
   private byte[] keyArr;
   private byte[] valueArr;
+
+  private ByteBuf nettyKeyBuf;
+  private ByteBuf nettyValueBuf;
 
   @Setup(Level.Trial)
   public void setup() throws IOException, RocksDBException {
@@ -110,6 +116,9 @@ public class GetBenchmarks {
     keyBuf.flip();
     valueBuf.put(valueArr);
     valueBuf.flip();
+
+    nettyKeyBuf = PooledByteBufAllocator.DEFAULT.directBuffer();
+    nettyValueBuf = PooledByteBufAllocator.DEFAULT.directBuffer();
   }
 
   @TearDown(Level.Trial)
@@ -121,6 +130,9 @@ public class GetBenchmarks {
     options.close();
     readOptions.close();
     FileUtils.delete(dbDir);
+
+    nettyKeyBuf.release();
+    nettyValueBuf.release();
   }
 
   private ColumnFamilyHandle getColumnFamily() {
@@ -184,6 +196,22 @@ public class GetBenchmarks {
     return keyBuf;
   }
 
+  private ByteBuf getNettyKeyBuf() {
+    final int MAX_LEN = 9; // key100000
+    final int keyIdx = next();
+
+    nettyKeyBuf.clear();
+
+    final String keyStr = "key" + keyIdx;
+    ByteBufUtil.writeAscii(nettyKeyBuf, keyStr);
+
+    for (int i = keyStr.length(); i < MAX_LEN; ++i) {
+      nettyKeyBuf.writeByte((byte) 0x30);
+    }
+
+    return nettyKeyBuf;
+  }
+
   private byte[] getValueArr() {
     return valueArr;
   }
@@ -211,5 +239,15 @@ public class GetBenchmarks {
     //    valueBuf.get(ret);
     //    System.out.println(str(ret));
     //    valueBuf.flip();
+  }
+
+  @Benchmark
+  public void preallocatedMemoryAddr() throws RocksDBException {
+    ByteBuf k = getNettyKeyBuf();
+    ByteBuf v = nettyValueBuf;
+    int res = db.get(getColumnFamily(), readOptions,
+            k.memoryAddress(), k.readableBytes(),
+            v.memoryAddress(), v.writableBytes()
+        );
   }
 }

--- a/java/jmh/src/main/java/org/rocksdb/jmh/PutBenchmarks.java
+++ b/java/jmh/src/main/java/org/rocksdb/jmh/PutBenchmarks.java
@@ -6,6 +6,8 @@
  */
 package org.rocksdb.jmh;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import org.openjdk.jmh.annotations.*;
 import org.rocksdb.*;
 import org.rocksdb.util.FileUtils;
@@ -108,5 +110,20 @@ public class PutBenchmarks {
   public void put(final ComparatorBenchmarks.Counter counter) throws RocksDBException {
     final int i = counter.next();
     db.put(getColumnFamily(), ba("key" + i), ba("value" + i));
+  }
+
+  private static final ByteBuf keyBuffer = PooledByteBufAllocator.DEFAULT.directBuffer();
+  private static final ByteBuf valueBuffer = PooledByteBufAllocator.DEFAULT.directBuffer();
+
+  @Benchmark
+  public void putWithMemoryAddr(final ComparatorBenchmarks.Counter counter) throws RocksDBException {
+    final int i = counter.next();
+    keyBuffer.clear();
+    keyBuffer.writeBytes(ba("key" + i));
+    valueBuffer.clear();
+    valueBuffer.writeBytes(ba("value" + i));
+    db.put(getColumnFamily(),
+            keyBuffer.memoryAddress(), keyBuffer.readableBytes(),
+            valueBuffer.memoryAddress(), valueBuffer.readableBytes());
   }
 }

--- a/java/jmh/src/main/java/org/rocksdb/jmh/WriteBatchBenchmarks.java
+++ b/java/jmh/src/main/java/org/rocksdb/jmh/WriteBatchBenchmarks.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+ *  This source code is licensed under both the GPLv2 (found in the
+ *  COPYING file in the root directory) and Apache 2.0 License
+ *  (found in the LICENSE.Apache file in the root directory).
+ */
+package org.rocksdb.jmh;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.PooledByteBufAllocator;
+import org.openjdk.jmh.annotations.*;
+import org.rocksdb.*;
+import org.rocksdb.util.FileUtils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeUnit;
+
+import static org.rocksdb.util.KVUtils.ba;
+import static org.rocksdb.util.KVUtils.writeToByteBuffer;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 1, time = 10)
+@Measurement(iterations = 3, time = 10)
+public class WriteBatchBenchmarks {
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException, RocksDBException {
+    RocksDB.loadLibrary();
+  }
+
+  private static final int N = 10_000;
+
+  @Benchmark
+  @OperationsPerInvocation(N)
+  public void put() throws RocksDBException {
+    WriteBatch wb = new WriteBatch();
+    try {
+      for (int i = 0; i < N; i++) {
+        wb.put(ba("key" + i), ba("value" + i));
+      }
+    } finally {
+      wb.close();
+    }
+  }
+
+  private static final ByteBuffer nioKeyBuffer = ByteBuffer.allocateDirect(1024);
+  private static final ByteBuffer nioValueBuffer = ByteBuffer.allocateDirect(1024);
+
+  @Benchmark
+  @OperationsPerInvocation(N)
+  public void putWithByteBuffer() throws RocksDBException {
+    WriteBatch wb = new WriteBatch();
+    try {
+      for (int i = 0; i < N; i++) {
+        writeToByteBuffer(nioKeyBuffer, "key" + i);
+        writeToByteBuffer(nioValueBuffer, "value" + i);
+        wb.put(nioKeyBuffer, nioValueBuffer);
+      }
+    } finally {
+      wb.close();
+    }
+  }
+
+
+  private static final ByteBuf keyBuffer = PooledByteBufAllocator.DEFAULT.directBuffer();
+  private static final ByteBuf valueBuffer = PooledByteBufAllocator.DEFAULT.directBuffer();
+
+  @Benchmark
+  @OperationsPerInvocation(N)
+  public void putWithAddress() throws RocksDBException {
+    WriteBatch wb = new WriteBatch();
+    try {
+      for (int i = 0; i < N; i++) {
+        keyBuffer.clear();
+        ByteBufUtil.writeAscii(keyBuffer, "key");
+        keyBuffer.writeInt(i);
+        valueBuffer.clear();
+        ByteBufUtil.writeAscii(valueBuffer, "value");
+        valueBuffer.writeInt(i);
+
+        wb.put(keyBuffer.memoryAddress(), keyBuffer.readableBytes(),
+               valueBuffer.memoryAddress(), valueBuffer.readableBytes());
+      }
+    } finally {
+      wb.close();
+    }
+  }
+}

--- a/java/jmh/src/main/java/org/rocksdb/util/KVUtils.java
+++ b/java/jmh/src/main/java/org/rocksdb/util/KVUtils.java
@@ -28,6 +28,21 @@ public final class KVUtils {
   }
 
   /**
+   * Get a byte array from a string.
+   *
+   * Assumes UTF-8 encoding
+   *
+   * @param string the string
+   *
+   * @return the bytes.
+   */
+  public static void writeToByteBuffer(final ByteBuffer buf, final String string) {
+    buf.clear();
+    buf.put(string.getBytes(UTF_8));
+    buf.flip();
+  }
+
+  /**
    * Get a string from a byte array.
    *
    * Assumes UTF-8 encoding

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -2381,6 +2381,30 @@ class JniUtil {
     op(key_slice, value_slice);
   }
 
+  static void kv_op_direct_addr(
+      JNIEnv* env,
+      jlong jkey_addr, jint jkey_len,
+      jlong jval_addr, jint jval_len,
+      ROCKSDB_NAMESPACE::Slice& key_slice,
+      ROCKSDB_NAMESPACE::Slice& value_slice) {
+    char* key = reinterpret_cast<char*>(jkey_addr);
+    if (key == nullptr) {
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env,
+                                                       "Invalid key argument");
+      return;
+    }
+
+    char* value = reinterpret_cast<char*>(jval_addr);
+    if (value == nullptr) {
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(
+          env, "Invalid value argument");
+      return;
+    }
+
+    key_slice = ROCKSDB_NAMESPACE::Slice(key, jkey_len);
+    value_slice = ROCKSDB_NAMESPACE::Slice(value, jval_len);
+  }
+
   /*
    * Helper for operations on a key and value
    * for example WriteBatch->Delete
@@ -2404,6 +2428,20 @@ class JniUtil {
     ROCKSDB_NAMESPACE::Slice key_slice(key, jkey_len);
 
     return op(key_slice);
+  }
+
+  static void k_op_direct_addr(
+      JNIEnv* env,
+      jlong jkey_addr, jint jkey_len,
+      ROCKSDB_NAMESPACE::Slice& key_slice) {
+    char* key = reinterpret_cast<char*>(jkey_addr);
+    if (key == nullptr) {
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env,
+                                                       "Invalid key argument");
+      return;
+    }
+
+    key_slice = ROCKSDB_NAMESPACE::Slice(key, jkey_len);
   }
 
   template <class T>

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -708,6 +708,77 @@ void Java_org_rocksdb_RocksDB_putDirect(
                                            jval, jval_off, jval_len);
 }
 
+/*
+ * Class:     org_rocksdb_RocksDB
+ * Method:    putAddr
+ * Signature: (JJJIJIJ)V
+ */
+void Java_org_rocksdb_RocksDB_putAddr__JJJIJIJ(
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
+    jlong jkey_addr, jint jkey_len, jlong jval_addr, jint jval_len,
+    jlong jcf_handle) {
+  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  auto* write_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jwrite_options_handle);
+  auto* cf_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+
+  ROCKSDB_NAMESPACE::Slice key_slice;
+  ROCKSDB_NAMESPACE::Slice value_slice;
+
+  ROCKSDB_NAMESPACE::JniUtil::kv_op_direct_addr(env,
+                                                jkey_addr, jkey_len,
+                                                jval_addr, jval_len,
+                                                key_slice, value_slice);
+
+  ROCKSDB_NAMESPACE::Status s;
+  if (cf_handle == nullptr) {
+    s = db->Put(*write_options, key_slice, value_slice);
+  } else {
+    s = db->Put(*write_options, cf_handle, key_slice, value_slice);
+  }
+  if (s.ok()) {
+    return;
+  }
+  ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
+}
+
+/*
+ * Class:     org_rocksdb_RocksDB
+ * Method:    putAddr
+ * Signature: (JJIJIJ)V
+ */
+void Java_org_rocksdb_RocksDB_putAddr__JJIJIJ(
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle,
+    jlong jkey_addr, jint jkey_len, jlong jval_addr, jint jval_len,
+    jlong jcf_handle) {
+  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  static const ROCKSDB_NAMESPACE::WriteOptions default_write_options =
+      ROCKSDB_NAMESPACE::WriteOptions();
+  auto* cf_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+
+  ROCKSDB_NAMESPACE::Slice key_slice;
+  ROCKSDB_NAMESPACE::Slice value_slice;
+
+  ROCKSDB_NAMESPACE::JniUtil::kv_op_direct_addr(env,
+                                                jkey_addr, jkey_len,
+                                                jval_addr, jval_len,
+                                                key_slice, value_slice);
+
+  ROCKSDB_NAMESPACE::Status s;
+  if (cf_handle == nullptr) {
+    s = db->Put(default_write_options, key_slice, value_slice);
+  } else {
+    s = db->Put(default_write_options, cf_handle, key_slice, value_slice);
+  }
+  if (s.ok()) {
+    return;
+  }
+  ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
+}
+
+
 //////////////////////////////////////////////////////////////////////////////
 // ROCKSDB_NAMESPACE::DB::Delete()
 
@@ -1097,6 +1168,55 @@ jint rocksdb_get_helper_direct(
   return pinnable_value_len;
 }
 
+jint rocksdb_get_helper_addr(
+    JNIEnv* env, ROCKSDB_NAMESPACE::DB* db,
+    const ROCKSDB_NAMESPACE::ReadOptions& read_options,
+    ROCKSDB_NAMESPACE::ColumnFamilyHandle* column_family_handle,
+    jlong jkey_addr, jint jkey_len,
+    jlong jval_addr, jint jval_len,
+    bool* has_exception) {
+  static const int kNotFound = -1;
+  static const int kStatusError = -2;
+
+  ROCKSDB_NAMESPACE::Slice key_slice((const char*) jkey_addr, jkey_len);
+
+  ROCKSDB_NAMESPACE::PinnableSlice pinnable_value;
+  ROCKSDB_NAMESPACE::Status s;
+  if (column_family_handle != nullptr) {
+    s = db->Get(read_options, column_family_handle, key_slice, &pinnable_value);
+  } else {
+    // backwards compatibility
+    s = db->Get(read_options, db->DefaultColumnFamily(), key_slice,
+                &pinnable_value);
+  }
+
+  if (s.IsNotFound()) {
+    *has_exception = false;
+    return kNotFound;
+  } else if (!s.ok()) {
+    *has_exception = true;
+    // Here since we are throwing a Java exception from c++ side.
+    // As a result, c++ does not know calling this function will in fact
+    // throwing an exception.  As a result, the execution flow will
+    // not stop here, and codes after this throw will still be
+    // executed.
+    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
+
+    // Return a dummy const value to avoid compilation error, although
+    // java side might not have a chance to get the return value :)
+    return kStatusError;
+  }
+
+  const jint pinnable_value_len = static_cast<jint>(pinnable_value.size());
+  const jint length = std::min(jval_len, pinnable_value_len);
+
+  memcpy((char*) jval_addr, pinnable_value.data(), length);
+  pinnable_value.Reset();
+
+  *has_exception = false;
+  return pinnable_value_len;
+}
+
 /*
  * Class:     org_rocksdb_RocksDB
  * Method:    deleteRange
@@ -1186,6 +1306,28 @@ jint Java_org_rocksdb_RocksDB_getDirect(JNIEnv* env, jobject /*jdb*/,
       env, db_handle,
       ro_opt == nullptr ? ROCKSDB_NAMESPACE::ReadOptions() : *ro_opt, cf_handle,
       jkey, jkey_off, jkey_len, jval, jval_off, jval_len, &has_exception);
+}
+
+/*
+ * Class:     org_rocksdb_RocksDB
+ * Method:    getAddr
+ * Signature: (JJJIJIJ)I
+ */
+jint Java_org_rocksdb_RocksDB_getAddr(JNIEnv* env, jobject /*jdb*/,
+                                      jlong jdb_handle, jlong jropt_handle,
+                                      jlong jkey_addr, jint jkey_len,
+                                      jlong jval_addr, jint jval_len,
+                                      jlong jcf_handle) {
+  auto* db_handle = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  auto* ro_opt =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jropt_handle);
+  auto* cf_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+  bool has_exception = false;
+  return rocksdb_get_helper_addr(
+      env, db_handle,
+      ro_opt == nullptr ? ROCKSDB_NAMESPACE::ReadOptions() : *ro_opt, cf_handle,
+      jkey_addr, jkey_len, jval_addr, jval_len, &has_exception);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1361,6 +1503,39 @@ void Java_org_rocksdb_RocksDB_deleteDirect(JNIEnv* env, jobject /*jdb*/,
   };
   ROCKSDB_NAMESPACE::JniUtil::k_op_direct(remove, env, jkey, jkey_offset,
                                           jkey_len);
+}
+
+/*
+ * Class:     org_rocksdb_RocksDB
+ * Method:    deleteAddr
+ * Signature: (JJJIJ)V
+ */
+void Java_org_rocksdb_RocksDB_deleteAddr(JNIEnv* env, jobject /*jdb*/,
+                                         jlong jdb_handle,
+                                         jlong jwrite_options,
+                                         jlong jkey_addr, jint jkey_len,
+                                         jlong jcf_handle) {
+  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+  auto* write_options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jwrite_options);
+  auto* cf_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+
+  ROCKSDB_NAMESPACE::Slice key_slice;
+  ROCKSDB_NAMESPACE::JniUtil::k_op_direct_addr(env,
+                                               jkey_addr, jkey_len,
+                                               key_slice);
+
+  ROCKSDB_NAMESPACE::Status s;
+  if (cf_handle == nullptr) {
+    s = db->Delete(*write_options, key_slice);
+  } else {
+    s = db->Delete(*write_options, cf_handle, key_slice);
+  }
+  if (s.ok()) {
+    return;
+  }
+  ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -228,6 +228,35 @@ void Java_org_rocksdb_WriteBatch_putDirect(JNIEnv* env, jobject /*jobj*/,
 
 /*
  * Class:     org_rocksdb_WriteBatch
+ * Method:    putAddr
+ * Signature: (JJIJIJ)V
+ */
+void Java_org_rocksdb_WriteBatch_putAddr(JNIEnv* env, jobject /*jobj*/,
+                                           jlong jwb_handle,
+                                           jlong jkey_addr, jint jkey_len,
+                                           jlong jval_addr, jint jval_len,
+                                           jlong jcf_handle) {
+  auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
+  assert(wb != nullptr);
+  auto* cf_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+
+  ROCKSDB_NAMESPACE::Slice key_slice;
+  ROCKSDB_NAMESPACE::Slice value_slice;
+
+  ROCKSDB_NAMESPACE::JniUtil::kv_op_direct_addr(
+      env, jkey_addr, jkey_len, jval_addr, jval_len,
+      key_slice, value_slice);
+
+  if (cf_handle == nullptr) {
+    wb->Put(key_slice, value_slice);
+  } else {
+    wb->Put(cf_handle, key_slice, value_slice);
+  }
+}
+
+/*
+ * Class:     org_rocksdb_WriteBatch
  * Method:    merge
  * Signature: (J[BI[BI)V
  */
@@ -385,6 +414,31 @@ void Java_org_rocksdb_WriteBatch_deleteDirect(JNIEnv* env, jobject /*jobj*/,
   };
   ROCKSDB_NAMESPACE::JniUtil::k_op_direct(remove, env, jkey, jkey_offset,
                                           jkey_len);
+}
+
+/*
+ * Class:     org_rocksdb_WriteBatch
+ * Method:    deleteAddr
+ * Signature: (JJIJ)V
+ */
+void Java_org_rocksdb_WriteBatch_deleteAddr(JNIEnv* env, jobject /*jobj*/,
+                                              jlong jwb_handle,
+                                              jlong jkey_addr, jint jkey_len,
+                                              jlong jcf_handle) {
+  auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
+  assert(wb != nullptr);
+  auto* cf_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+  ROCKSDB_NAMESPACE::Slice key_slice;
+
+  ROCKSDB_NAMESPACE::JniUtil::k_op_direct_addr(env,
+                                               jkey_addr, jkey_len, key_slice);
+
+  if (cf_handle == nullptr) {
+    wb->Delete(key_slice);
+  } else {
+    wb->Delete(cf_handle, key_slice);
+  }
 }
 
 /*

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -159,6 +159,35 @@ void Java_org_rocksdb_WriteBatchWithIndex_putDirect(
 
 /*
  * Class:     org_rocksdb_WriteBatchWithIndex
+ * Method:    putAddr
+ * Signature: (JJIJIJ)V
+ */
+void Java_org_rocksdb_WriteBatchWithIndex_putAddr(JNIEnv* env, jobject /*jobj*/,
+                                         jlong jwb_handle,
+                                         jlong jkey_addr, jint jkey_len,
+                                         jlong jval_addr, jint jval_len,
+                                         jlong jcf_handle) {
+  auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
+  assert(wb != nullptr);
+  auto* cf_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+
+  ROCKSDB_NAMESPACE::Slice key_slice;
+  ROCKSDB_NAMESPACE::Slice value_slice;
+
+  ROCKSDB_NAMESPACE::JniUtil::kv_op_direct_addr(
+      env, jkey_addr, jkey_len, jval_addr, jval_len,
+      key_slice, value_slice);
+
+  if (cf_handle == nullptr) {
+    wb->Put(key_slice, value_slice);
+  } else {
+    wb->Put(cf_handle, key_slice, value_slice);
+  }
+}
+
+/*
+ * Class:     org_rocksdb_WriteBatchWithIndex
  * Method:    merge
  * Signature: (J[BI[BI)V
  */
@@ -323,6 +352,33 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteDirect(
   ROCKSDB_NAMESPACE::JniUtil::k_op_direct(remove, env, jkey, jkey_offset,
                                           jkey_len);
 }
+
+/*
+ * Class:     org_rocksdb_WriteBatchWithIndex
+ * Method:    deleteAddr
+ * Signature: (JJIJ)V
+ */
+void Java_org_rocksdb_WriteBatchWithIndex_deleteAddr(JNIEnv* env,
+                                            jobject /*jobj*/,
+                                            jlong jwb_handle,
+                                            jlong jkey_addr, jint jkey_len,
+                                            jlong jcf_handle) {
+  auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
+  assert(wb != nullptr);
+  auto* cf_handle =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+  ROCKSDB_NAMESPACE::Slice key_slice;
+
+  ROCKSDB_NAMESPACE::JniUtil::k_op_direct_addr(env,
+                                               jkey_addr, jkey_len, key_slice);
+
+  if (cf_handle == nullptr) {
+    wb->Delete(key_slice);
+  } else {
+    wb->Delete(cf_handle, key_slice);
+  }
+}
+
 
 /*
  * Class:     org_rocksdb_WriteBatchWithIndex

--- a/java/src/main/java/org/rocksdb/AbstractWriteBatch.java
+++ b/java/src/main/java/org/rocksdb/AbstractWriteBatch.java
@@ -53,6 +53,12 @@ public abstract class AbstractWriteBatch extends RocksObject
   }
 
   @Override
+  public void put(final long keyAddr, final int keyLen,
+                  final long valueAddr, final int valueLen) throws RocksDBException {
+    putAddr(nativeHandle_, keyAddr, keyLen, valueAddr, valueLen, 0);
+  }
+
+  @Override
   public void put(final ColumnFamilyHandle columnFamilyHandle, final ByteBuffer key,
       final ByteBuffer value) throws RocksDBException {
     assert key.isDirect() && value.isDirect();
@@ -77,6 +83,11 @@ public abstract class AbstractWriteBatch extends RocksObject
   public void delete(final ByteBuffer key) throws RocksDBException {
     deleteDirect(nativeHandle_, key, key.position(), key.remaining(), 0);
     key.position(key.limit());
+  }
+
+  @Override
+  public void delete(final long keyAddr, final int keyLen) throws RocksDBException {
+    deleteAddr(nativeHandle_, keyAddr, keyLen, 0);
   }
 
   @Override
@@ -158,6 +169,11 @@ public abstract class AbstractWriteBatch extends RocksObject
       final int keyLength, final ByteBuffer value, final int valueOffset, final int valueLength,
       final long cfHandle) throws RocksDBException;
 
+
+  abstract void putAddr(final long handle, final long keyAddr, final int keyLength,
+        final long valueAddr, final int valueLength,
+        final long cfHandle) throws RocksDBException;
+
   abstract void merge(final long handle, final byte[] key, final int keyLen,
       final byte[] value, final int valueLen) throws RocksDBException;
 
@@ -179,6 +195,9 @@ public abstract class AbstractWriteBatch extends RocksObject
 
   abstract void deleteDirect(final long handle, final ByteBuffer key, final int keyOffset,
       final int keyLength, final long cfHandle) throws RocksDBException;
+
+  abstract void deleteAddr(final long handle, final long keyAddr, final int keyLength,
+      final long cfHandle) throws RocksDBException;
 
   abstract void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
       final byte[] endKey, final int endKeyLen) throws RocksDBException;

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -982,6 +982,55 @@ public class RocksDB extends RocksObject {
   }
 
   /**
+   * Set the database entry for "key" to "value" for the specified
+   * column family.
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
+   *     instance
+   * @param writeOpts {@link org.rocksdb.WriteOptions} instance.
+   * @param keyAddr the direct memory address of the key
+   * @param keyLen the length of the key
+   * @param valueAddr the direct memory address of the value
+   * @param valueLen the length of the value
+   *
+   * throws IllegalArgumentException if column family is not present
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   * @see IllegalArgumentException
+   */
+  public void put(final ColumnFamilyHandle columnFamilyHandle, final WriteOptions writeOpts,
+      final long keyAddr, final int keyLen,
+      final long valueAddr, final int valueLen) throws RocksDBException {
+    putAddr(nativeHandle_, writeOpts.nativeHandle_, keyAddr, keyLen,
+      valueAddr, valueLen, columnFamilyHandle.nativeHandle_);
+  }
+
+  /**
+   * Set the database entry for "key" to "value" for the specified
+   * column family.
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
+   *     instance
+   * @param keyAddr the direct memory address of the key
+   * @param keyLen the length of the key
+   * @param valueAddr the direct memory address of the value
+   * @param valueLen the length of the value
+   *
+   * throws IllegalArgumentException if column family is not present
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   * @see IllegalArgumentException
+   */
+  public void put(final ColumnFamilyHandle columnFamilyHandle,
+      final long keyAddr, final int keyLen,
+      final long valueAddr, final int valueLen) throws RocksDBException {
+    putAddr(nativeHandle_, keyAddr, keyLen,
+      valueAddr, valueLen, columnFamilyHandle.nativeHandle_);
+  }
+
+  /**
    * Set the database entry for "key" to "value".
    *
    * @param writeOpts {@link org.rocksdb.WriteOptions} instance.
@@ -1004,6 +1053,29 @@ public class RocksDB extends RocksObject {
     key.position(key.limit());
     value.position(value.limit());
   }
+
+    /**
+     * Set the database entry for "key" to "value".
+     *
+     * @param writeOpts {@link org.rocksdb.WriteOptions} instance.
+     * @param keyAddr the direct memory address of the key
+     * @param keyLen the length of the key
+     * @param valueAddr the direct memory address of the value
+     * @param valueLen the length of the value
+     *
+     * throws IllegalArgumentException if column family is not present
+     *
+     * @throws RocksDBException thrown if error happens in underlying
+     *    native library.
+     * @see IllegalArgumentException
+     */
+    public void put(final WriteOptions writeOpts,
+        final long keyAddr, final int keyLen,
+        final long valueAddr, final int valueLen)
+        throws RocksDBException {
+      putAddr(nativeHandle_, writeOpts.nativeHandle_, keyAddr, keyLen,
+              valueAddr, valueLen, 0);
+    }
 
   /**
    * Set the database entry for "key" to "value" for the specified
@@ -1224,6 +1296,34 @@ public class RocksDB extends RocksObject {
   /**
    * Get the value associated with the specified key within column family.
    *
+   * @param opt {@link org.rocksdb.ReadOptions} instance.
+   * @param keyAddr the direct memory address of the key
+   * @param keyLen the length of the key
+   * @param valueAddr the direct memory address where to write the retrieved
+   *     value.
+   * @param valueLen the max capacity of the valueAddr buffer
+   * @return The size of the actual value that matches the specified
+   *     {@code key} in byte.  If the return value is greater than the
+   *     length of {@code value}, then it indicates that the size of the
+   *     input buffer {@code value} is insufficient and partial result will
+   *     be returned.  RocksDB.NOT_FOUND will be returned if the value not
+   *     found.
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public int get(final ReadOptions opt,
+            final long keyAddr, final int keyLen,
+            final long valueAddr, final int valueLen)
+      throws RocksDBException {
+    return getAddr(nativeHandle_, opt.nativeHandle_,
+            keyAddr, keyLen,
+            valueAddr, valueLen, 0);
+  }
+
+  /**
+   * Get the value associated with the specified key within column family.
+   *
    * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
    *     instance
    * @param opt {@link org.rocksdb.ReadOptions} instance.
@@ -1253,6 +1353,36 @@ public class RocksDB extends RocksObject {
     }
     key.position(key.limit());
     return result;
+   }
+
+  /**
+   * Get the value associated with the specified key within column family.
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
+   *     instance
+   * @param opt {@link org.rocksdb.ReadOptions} instance.
+   * @param keyAddr the direct memory address of the key
+   * @param keyLen the length of the key
+   * @param valueAddr the direct memory address where to write the retrieved
+   *     value.
+   * @param valueLen the max capacity of the valueAddr buffer
+   * @return The size of the actual value that matches the specified
+   *     {@code key} in byte.  If the return value is greater than the
+   *     length of {@code value}, then it indicates that the size of the
+   *     input buffer {@code value} is insufficient and partial result will
+   *     be returned.  RocksDB.NOT_FOUND will be returned if the value not
+   *     found.
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public int get(final ColumnFamilyHandle columnFamilyHandle, final ReadOptions opt,
+        final long keyAddr, final int keyLen,
+        final long valueAddr, final int valueLen) throws RocksDBException {
+    return getAddr(nativeHandle_, opt.nativeHandle_,
+                keyAddr, keyLen,
+                valueAddr, valueLen,
+                columnFamilyHandle.nativeHandle_);
   }
 
   /**
@@ -4522,6 +4652,12 @@ public class RocksDB extends RocksObject {
   private native void putDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
       int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
       throws RocksDBException;
+  private native void putAddr(long handle, long writeOptHandle, long keyAddr, int keyLength,
+      long valueAddr, int valueLength, long cfHandle)
+        throws RocksDBException;
+  private native void putAddr(long handle, long keyAddr, int keyLength,
+      long valueAddr, int valueLength, long cfHandle)
+        throws RocksDBException;
   private native long iterator(final long handle);
   private native long iterator(final long handle, final long readOptHandle);
   private native long iteratorCF(final long handle, final long cfHandle);
@@ -4542,6 +4678,9 @@ public class RocksDB extends RocksObject {
   private native int getDirect(long handle, long readOptHandle, ByteBuffer key, int keyOffset,
       int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
       throws RocksDBException;
+  private native int getAddr(long handle, long readOptHandle, long keyAddr, int keyLength,
+      long valueAddr, int valueLength, long cfHandle)
+        throws RocksDBException;
   private native boolean keyMayExistDirect(final long handle, final long cfHhandle,
       final long readOptHandle, final ByteBuffer key, final int keyOffset, final int keyLength);
   private native int[] keyMayExistDirectFoundValue(final long handle, final long cfHhandle,

--- a/java/src/main/java/org/rocksdb/WriteBatch.java
+++ b/java/src/main/java/org/rocksdb/WriteBatch.java
@@ -229,6 +229,10 @@ public class WriteBatch extends AbstractWriteBatch {
   final native void putDirect(final long handle, final ByteBuffer key, final int keyOffset,
       final int keyLength, final ByteBuffer value, final int valueOffset, final int valueLength,
       final long cfHandle);
+  @Override
+  final native void putAddr(final long handle, final long keyAddr, final int keyLength,
+        final long valueAddr, final int valueLength,
+        final long cfHandle) throws RocksDBException;
   @Override final native void merge(final long handle, final byte[] key,
       final int keyLen, final byte[] value, final int valueLen);
   @Override final native void merge(final long handle, final byte[] key,
@@ -245,6 +249,9 @@ public class WriteBatch extends AbstractWriteBatch {
   @Override
   final native void deleteDirect(final long handle, final ByteBuffer key, final int keyOffset,
       final int keyLength, final long cfHandle) throws RocksDBException;
+  @Override
+  final native void deleteAddr(final long handle, final long keyAddr, final int keyLength,
+      final long cfHandle) throws RocksDBException;
   @Override
   final native void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
       final byte[] endKey, final int endKeyLen);

--- a/java/src/main/java/org/rocksdb/WriteBatchInterface.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchInterface.java
@@ -58,6 +58,18 @@ public interface WriteBatchInterface {
      * <p>Store the mapping "key-&gt;value" within given column
      * family.</p>
      *
+     * @param keyAddr the direct memory address of the key
+     * @param keyLen the length of the key
+     * @param valueAddr the direct memory address of the value
+     * @param valueLen the length of the value
+     * @throws RocksDBException thrown if error happens in underlying native library.
+     */
+    void put(final long keyAddr, final int keyLen, final long valueAddr, final int valueLen) throws RocksDBException;
+
+    /**
+     * <p>Store the mapping "key-&gt;value" within given column
+     * family.</p>
+     *
      * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
      *     instance
      * @param key the specified key to be inserted. It is using position and limit.
@@ -119,6 +131,16 @@ public interface WriteBatchInterface {
      * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void delete(final ByteBuffer key) throws RocksDBException;
+
+    /**
+     * <p>If column family contains a mapping for "key", erase it.  Else do nothing.</p>
+     *
+     * @param keyAddr the direct memory address of the key
+     * @param keyLen the length of the key
+     *
+     * @throws RocksDBException thrown if error happens in underlying native library.
+     */
+    void delete(final long keyAddr, final int keyLen) throws RocksDBException;
 
     /**
      * <p>If column family contains a mapping for "key", erase it.  Else do nothing.</p>

--- a/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
@@ -303,6 +303,10 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
   final native void putDirect(final long handle, final ByteBuffer key, final int keyOffset,
       final int keyLength, final ByteBuffer value, final int valueOffset, final int valueLength,
       final long cfHandle);
+  @Override
+  final native void putAddr(final long handle, final long keyAddr, final int keyLength,
+      final long valueAddr, final int valueLength,
+      final long cfHandle) throws RocksDBException;
   @Override final native void merge(final long handle, final byte[] key,
       final int keyLen, final byte[] value, final int valueLen);
   @Override final native void merge(final long handle, final byte[] key,
@@ -319,6 +323,9 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
   @Override
   final native void deleteDirect(final long handle, final ByteBuffer key, final int keyOffset,
       final int keyLength, final long cfHandle) throws RocksDBException;
+  @Override
+    final native void deleteAddr(final long handle, final long keyAddr, final int keyLength,
+        final long cfHandle) throws RocksDBException;
   // DO NOT USE - `WriteBatchWithIndex::deleteRange` is not yet supported
   @Override
   final native void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -4,12 +4,15 @@
 //  (found in the LICENSE.Apache file in the root directory).
 package org.rocksdb;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.ByteBuffer;
 import java.util.*;
+import org.rocksdb.util.DirectByteBufferAddress;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -242,6 +245,67 @@ public class RocksDBTest {
       // compare
       Assert.assertTrue(value0.isSamePayload(db.get(key3.data, key3.offset, key3.len)));
       Assert.assertTrue(value1.isSamePayload(db.get(key4.data, key4.offset, key4.len)));
+    }
+  }
+
+  @Test
+  public void putAndGetWithAddress() throws RocksDBException {
+    try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath());
+         final WriteOptions opt = new WriteOptions(); final ReadOptions optr = new ReadOptions()) {
+      final ByteBuffer key = ByteBuffer.allocateDirect(12);
+      final ByteBuffer value = ByteBuffer.allocateDirect(12);
+
+      key.put("key1".getBytes());
+      key.flip();
+      value.put("value".getBytes());
+      value.flip();
+
+      db.put(opt, DirectByteBufferAddress.getAddress(key), key.remaining(),
+              DirectByteBufferAddress.getAddress(value), value.remaining());
+
+      key.clear();
+      key.put("key2".getBytes());
+      key.flip();
+      value.clear();
+      value.put("12345678".getBytes());
+      value.flip();
+      db.put(opt, DirectByteBufferAddress.getAddress(key), key.remaining(),
+              DirectByteBufferAddress.getAddress(value), value.remaining());
+
+      assertThat(db.get("key1".getBytes())).isEqualTo(
+              "value".getBytes());
+      assertThat(db.get("key2".getBytes())).isEqualTo(
+              "12345678".getBytes());
+
+      key.clear();
+      key.put("key1".getBytes());
+      key.flip();
+      value.clear();
+      int len = db.get(optr,
+              DirectByteBufferAddress.getAddress(key), key.remaining(),
+              DirectByteBufferAddress.getAddress(value), value.capacity());
+      assertThat(len).isEqualTo("value".length());
+      value.limit(len);
+      assertThat(UTF_8.decode(value).toString()).isEqualTo("value");
+
+      key.clear();
+      key.put("key2".getBytes());
+      key.flip();
+      value.clear();
+      len = db.get(optr,
+              DirectByteBufferAddress.getAddress(key), key.remaining(),
+              DirectByteBufferAddress.getAddress(value), value.capacity());
+      assertThat(len).isEqualTo("12345678".length());
+      value.limit(len);
+      assertThat(UTF_8.decode(value).toString()).isEqualTo("12345678");
+
+      key.clear();
+      key.put("non-existing".getBytes());
+      key.flip();
+      len = db.get(optr,
+              DirectByteBufferAddress.getAddress(key), key.remaining(),
+              DirectByteBufferAddress.getAddress(value), value.capacity());
+      assertThat(len).isEqualTo(RocksDB.NOT_FOUND);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/WriteBatchTest.java
+++ b/java/src/test/java/org/rocksdb/WriteBatchTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.util.CapturingWriteBatchHandler;
 import org.rocksdb.util.CapturingWriteBatchHandler.Event;
+import org.rocksdb.util.DirectByteBufferAddress;
 import org.rocksdb.util.WriteBatchGetter;
 
 /**
@@ -113,6 +114,35 @@ public class WriteBatchTest {
           .isEqualTo("Put(baz, boo)@102"
               + "Delete(box)@101"
               + "Put(foo, bar)@100");
+    }
+  }
+
+  @Test
+  public void addrPutDelete()
+          throws UnsupportedEncodingException, RocksDBException {
+    try (WriteBatch batch = new WriteBatch()) {
+      ByteBuffer key = ByteBuffer.allocateDirect(16);
+      ByteBuffer value = ByteBuffer.allocateDirect(16);
+      key.put("foo".getBytes("US-ASCII")).flip();
+      value.put("bar".getBytes("US-ASCII")).flip();
+
+      batch.put(DirectByteBufferAddress.getAddress(key), key.remaining(),
+              DirectByteBufferAddress.getAddress(value), value.remaining());
+
+      key.clear();
+      key.put("box".getBytes("US-ASCII")).flip();
+
+      batch.delete(DirectByteBufferAddress.getAddress(key), key.remaining());
+
+      batch.put("baz".getBytes("US-ASCII"), "boo".getBytes("US-ASCII"));
+
+      WriteBatchTestInternalHelper.setSequence(batch, 100);
+      assertThat(WriteBatchTestInternalHelper.sequence(batch)).isNotNull().isEqualTo(100);
+      assertThat(batch.count()).isEqualTo(3);
+      assertThat(new String(getContents(batch), "US-ASCII"))
+              .isEqualTo("Put(baz, boo)@102"
+                      + "Delete(box)@101"
+                      + "Put(foo, bar)@100");
     }
   }
 

--- a/java/src/test/java/org/rocksdb/util/DirectByteBufferAddress.java
+++ b/java/src/test/java/org/rocksdb/util/DirectByteBufferAddress.java
@@ -1,0 +1,38 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb.util;
+
+import java.lang.reflect.Field;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+public final class DirectByteBufferAddress {
+  private DirectByteBufferAddress(){};
+
+  public static long getAddress(ByteBuffer buf) {
+    try {
+      return ADDRESS_FIELD.getLong(buf);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static final Field ADDRESS_FIELD;
+
+  static {
+    Field addressField = null;
+
+    try {
+      addressField = Buffer.class.getDeclaredField("address");
+      addressField.setAccessible(true);
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    } finally {
+      ADDRESS_FIELD = addressField;
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

In the Java wrapper, passing `byte[]` across JNI boundary is inefficient because it involves the mallocing, copying and freeing of the array each time (due to the fact that a `byte[]` location in memory could be moved by the JVM during a GC event).

RocksDB has added in the past API overloads that take a nio `ByteBuffer` instances instead of `byte[]`.  Using these with direct memory buffers is faster, though not by a big margin. 

The reason is that the checks done in the JNI code, for the `ByteBuffer` instance are very expensive. This is an example of an application adding many `put()` requests into a RocksDB batch: 

![image](https://github.com/facebook/rocksdb/assets/62500/4a22ae88-146b-4819-8fe4-b569cac59448)

~80% of the CPU is spent checking wether the argument is really a `ByteBuffer` instance. There is no easy way around that in the JNI API, because we need to extract the memory address.

## Modifications

Many Java applications that use direct memory are already using ways to get the memory address in the Java code, or are using libraries such as Netty, whose pooled `ByteBuf` is giving access to the memory address of the buffer.

It make sense then to have and API overload that take a "memory address" (as a `long`) and a "length", when doing put/get/batch operations in RocksDB Java.


#### Put benchmark 

16% improvement

```
Benchmark                     (columnFamilyTestType)   Mode  Cnt       Score       Error  Units
PutBenchmarks.put                   no_column_family  thrpt    3  402178.679 ± 33652.104  ops/s
PutBenchmarks.putWithMemoryAddr     no_column_family  thrpt    3  468272.230 ± 35220.437  ops/s
```

#### Get benchmark 

60% Improvement
```
Benchmark                                (columnFamilyTestType)  (keyCount)  (keySize)  (valueSize)   Mode  Cnt        Score        Error  Units
GetBenchmarks.get                              no_column_family        1000         12           64  thrpt    3  1075482.176 ± 136258.092  ops/s
GetBenchmarks.preallocatedByteBufferGet        no_column_family        1000         12           64  thrpt    3  1115549.827 ±  87976.331  ops/s
GetBenchmarks.preallocatedGet                  no_column_family        1000         12           64  thrpt    3  1092679.425 ± 270978.480  ops/s
GetBenchmarks.preallocatedMemoryAddr           no_column_family        1000         12           64  thrpt    3  1618699.968 ± 124024.390  ops/s
```

#### Write batch benchmark

1,000 % Improvement

```
Benchmark                                Mode  Cnt   Score   Error   Units
WriteBatchBenchmarks.put                thrpt    3   2.346 ± 0.253  ops/us
WriteBatchBenchmarks.putWithAddress     thrpt    3  25.554 ± 0.108  ops/us
WriteBatchBenchmarks.putWithByteBuffer  thrpt    3   3.077 ± 0.198  ops/us
```