### PR TITLE
stabilize DBGet microbenchmark

### DIFF
--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -571,36 +571,34 @@ static void DBGet(benchmark::State& state) {
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
   auto rnd = Random(301 + state.thread_index());
-  KeyGenerator kg(&rnd, key_num);
 
   if (state.thread_index() == 0) {
+    KeyGenerator kg_seq(key_num /* max_key */);
     SetupDB(state, options, &db, "DBGet");
 
-    // load db
+    // Load all valid keys into DB. That way, iterations in `!negative_query`
+    // runs can always find the key even though it is generated from a random
+    // number.
     auto wo = WriteOptions();
     wo.disableWAL = true;
     for (uint64_t i = 0; i < key_num; i++) {
-      Status s = db->Put(wo, kg.Next(),
+      Status s = db->Put(wo, kg_seq.Next(),
                          rnd.RandomString(static_cast<int>(per_key_size)));
       if (!s.ok()) {
         state.SkipWithError(s.ToString().c_str());
       }
     }
 
-    FlushOptions fo;
-    Status s = db->Flush(fo);
+    // Compact whole DB into one level, so each iteration will consider the same
+    // number of files (one).
+    Status s = db->CompactRange(CompactRangeOptions(), nullptr /* begin */,
+                                nullptr /* end */);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
-    }
-
-    auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(WaitForCompactOptions());
-    if (!s.ok()) {
-      state.SkipWithError(s.ToString().c_str());
-      return;
     }
   }
 
+  KeyGenerator kg_rnd(&rnd, key_num /* max_key */);
   auto ro = ReadOptions();
   if (mmap) {
     ro.verify_checksums = false;
@@ -609,7 +607,7 @@ static void DBGet(benchmark::State& state) {
   if (negative_query) {
     for (auto _ : state) {
       std::string val;
-      Status s = db->Get(ro, kg.NextNonExist(), &val);
+      Status s = db->Get(ro, kg_rnd.NextNonExist(), &val);
       if (s.IsNotFound()) {
         not_found++;
       }
@@ -617,7 +615,7 @@ static void DBGet(benchmark::State& state) {
   } else {
     for (auto _ : state) {
       std::string val;
-      Status s = db->Get(ro, kg.Next(), &val);
+      Status s = db->Get(ro, kg_rnd.Next(), &val);
       if (s.IsNotFound()) {
         not_found++;
       }
@@ -636,7 +634,7 @@ static void DBGet(benchmark::State& state) {
       state.counters["get_p99"] = histogram_data.percentile99 * std::milli::den;
     }
 
-    TeardownDB(state, db, options, kg);
+    TeardownDB(state, db, options, kg_rnd);
   }
 }
 
@@ -662,9 +660,8 @@ static void DBGetArguments(benchmark::internal::Benchmark* b) {
                "negative_query", "enable_filter", "mmap"});
 }
 
-static constexpr uint64_t kDBGetNum = 1l << 20;
-BENCHMARK(DBGet)->Threads(1)->Iterations(kDBGetNum)->Apply(DBGetArguments);
-BENCHMARK(DBGet)->Threads(8)->Iterations(kDBGetNum / 8)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(1)->MinWarmUpTime(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(8)->MinWarmUpTime(1)->Apply(DBGetArguments);
 
 static void SimpleGetWithPerfContext(benchmark::State& state) {
   // setup DB

--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -641,8 +641,8 @@ static void DBGet(benchmark::State& state) {
 static void DBGetArguments(benchmark::internal::Benchmark* b) {
   for (int comp_style : {kCompactionStyleLevel, kCompactionStyleUniversal,
                          kCompactionStyleFIFO}) {
-    for (int64_t max_data : {128l << 20, 512l << 20}) {
-      for (int64_t per_key_size : {256, 1024}) {
+    for (int64_t max_data : {256l << 10, 1l << 20}) {
+      for (int64_t per_key_size : {32, 256}) {
         for (bool enable_statistics : {false, true}) {
           for (bool negative_query : {false, true}) {
             for (bool enable_filter : {false, true}) {
@@ -660,8 +660,8 @@ static void DBGetArguments(benchmark::internal::Benchmark* b) {
                "negative_query", "enable_filter", "mmap"});
 }
 
-BENCHMARK(DBGet)->Threads(1)->MinWarmUpTime(1)->Apply(DBGetArguments);
-BENCHMARK(DBGet)->Threads(8)->MinWarmUpTime(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(8)->Apply(DBGetArguments);
 
 static void SimpleGetWithPerfContext(benchmark::State& state) {
   // setup DB


### PR DESCRIPTION
- Allowed Google benchmark to decide number of iterations. Previously we hardcoded a value, which circumvented benchmark's heuristic for iterating until the result is stable.
- Made each iteration do similar work. Previously, an iteration could do different work depending if the key was found in the first, second, third, or no L0 file.
- Reduced data size to 256KB and 1MB so less L3 cache is needed. Daemon process memory usage was making L3 cache behavior inconsistent across repetitions. It's unfortunate we still need L3 cache for RocksDB's internal memory usage so this doesn't fully solve the problem.

Test Plan:

A/A test with low repetitions. It shows there are less extremely low pvalues when nothing changed. Still there are some low pvalues, but not as extreme as 0.0002 or 0.0004

Before: 
- Command: `TEST_TMPDIR=/dev/shm python3.6 ../benchmark/tools/compare.py benchmarks ./db_basic_bench ./db_basic_bench --benchmark_filter="DBGet/comp_style:0/max_data:134217728/per_key_size:256/.*/threads:1" --benchmark_repetitions=10`
- Resulting pvalues:
```
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:0/negative_query:0/enable_filter:0/mmap:0/iterations:1048576/threads:1_pvalue                 0.7913          0.7913      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:0/negative_query:0/enable_filter:0/mmap:1/iterations:1048576/threads:1_pvalue                 0.1859          0.1859      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:0/negative_query:0/enable_filter:1/mmap:0/iterations:1048576/threads:1_pvalue                 0.0757          0.0757      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:0/negative_query:0/enable_filter:1/mmap:1/iterations:1048576/threads:1_pvalue                 0.3447          0.3447      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:0/negative_query:1/enable_filter:0/mmap:0/iterations:1048576/threads:1_pvalue                 0.7913          0.7913      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:0/negative_query:1/enable_filter:0/mmap:1/iterations:1048576/threads:1_pvalue                 0.2123          0.2123      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:0/negative_query:1/enable_filter:1/mmap:0/iterations:1048576/threads:1_pvalue                 0.1405          0.1405      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:0/negative_query:1/enable_filter:1/mmap:1/iterations:1048576/threads:1_pvalue                 0.0013          0.0013      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:1/negative_query:0/enable_filter:0/mmap:0/iterations:1048576/threads:1_pvalue                 0.0004          0.0004      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:1/negative_query:0/enable_filter:0/mmap:1/iterations:1048576/threads:1_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:1/negative_query:0/enable_filter:1/mmap:0/iterations:1048576/threads:1_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:1/negative_query:0/enable_filter:1/mmap:1/iterations:1048576/threads:1_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:1/negative_query:1/enable_filter:0/mmap:0/iterations:1048576/threads:1_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:1/negative_query:1/enable_filter:0/mmap:1/iterations:1048576/threads:1_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:1/negative_query:1/enable_filter:1/mmap:0/iterations:1048576/threads:1_pvalue                 0.0028          0.0028      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:134217728/per_key_size:256/enable_statistics:1/negative_query:1/enable_filter:1/mmap:1/iterations:1048576/threads:1_pvalue                 0.0890          0.0890      U Test, Repetitions: 10 vs 10
```

After:
- Command: `TEST_TMPDIR=/dev/shm python3.6 ../benchmark/tools/compare.py benchmarks ./db_basic_bench ./db_basic_bench --benchmark_filter=DBGet/comp_style:0/max_data:262144/per_key_size:32/.*/threads:1 --benchmark_repetitions=10`
- Resulting pvalues:
```
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:0/negative_query:0/enable_filter:0/mmap:0/threads:1_pvalue                 0.0757          0.0757      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:0/negative_query:0/enable_filter:0/mmap:1/threads:1_pvalue                 0.0257          0.0257      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:0/negative_query:0/enable_filter:1/mmap:0/threads:1_pvalue                 0.0312          0.0312      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:0/negative_query:0/enable_filter:1/mmap:1/threads:1_pvalue                 0.0073          0.0073      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:0/negative_query:1/enable_filter:0/mmap:0/threads:1_pvalue                 0.9698          0.9698      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:0/negative_query:1/enable_filter:0/mmap:1/threads:1_pvalue                 0.9698          0.9698      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:0/negative_query:1/enable_filter:1/mmap:0/threads:1_pvalue                 0.7913          0.7913      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:0/negative_query:1/enable_filter:1/mmap:1/threads:1_pvalue                 0.1041          0.1041      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:1/negative_query:0/enable_filter:0/mmap:0/threads:1_pvalue                 0.0013          0.0013      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:1/negative_query:0/enable_filter:0/mmap:1/threads:1_pvalue                 0.0539          0.0539      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:1/negative_query:0/enable_filter:1/mmap:0/threads:1_pvalue                 0.0257          0.0257      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:1/negative_query:0/enable_filter:1/mmap:1/threads:1_pvalue                 0.0452          0.0452      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:1/negative_query:1/enable_filter:0/mmap:0/threads:1_pvalue                 0.0452          0.0452      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:1/negative_query:1/enable_filter:0/mmap:1/threads:1_pvalue                 0.1212          0.1212      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:1/negative_query:1/enable_filter:1/mmap:0/threads:1_pvalue                 0.2413          0.2413      U Test, Repetitions: 10 vs 10
DBGet/comp_style:0/max_data:262144/per_key_size:32/enable_statistics:1/negative_query:1/enable_filter:1/mmap:1/threads:1_pvalue                 0.0058          0.0058      U Test, Repetitions: 10 vs 10
```