### PR TITLE
Make `unreleased_history/release.sh` work on macOS

### DIFF
--- a/unreleased_history/release.sh
+++ b/unreleased_history/release.sh
@@ -29,7 +29,8 @@ echo >> HISTORY.new
 awk '/#define ROCKSDB_MAJOR/ { major = $3 }
      /#define ROCKSDB_MINOR/ { minor = $3 }
      /#define ROCKSDB_PATCH/ { patch = $3 }
-     END { print "## " major "." minor "." patch " (" strftime("%F") ")" }' < include/rocksdb/version.h >> HISTORY.new
+     END { printf "## " major "." minor "." patch }' < include/rocksdb/version.h >> HISTORY.new
+echo " (`date +%x`)" >> HISTORY.new
 
 function process_file () {
   # use awk to correct extra or missing newlines, missing '* ' on first line
@@ -69,7 +70,12 @@ process_dir bug_fixes "Bug Fixes"
 # Check for unexpected files or dirs at top level. process_dir/process_file
 # will deal with contents of these directories
 EXPECTED_REGEX="[^/]*[.]sh|README[.]txt|$(echo $PROCESSED_DIRECTORIES | tr ' ' '|')"
-UNEXPECTED="$(find unreleased_history/ -mindepth 1 -maxdepth 1 -regextype egrep -not -regex "[^/]*/($EXPECTED_REGEX)")"
+platform=`uname`
+if [ $platform = 'Darwin' ]; then
+  UNEXPECTED="$(find -E unreleased_history -mindepth 1 -maxdepth 1 -not -regex "[^/]*/($EXPECTED_REGEX)")"
+else
+  UNEXPECTED="$(find unreleased_history/ -mindepth 1 -maxdepth 1 -regextype egrep -not -regex "[^/]*/($EXPECTED_REGEX)")"
+fi
 if [ "$UNEXPECTED" ]; then
   echo "Unexpected files I don't know how to process:"
   echo "$UNEXPECTED"


### PR DESCRIPTION
Summary: I got the following errors when running `release.sh` on my mac. This is due to mac does not have gnu version of awk and find by default. This PR updates the script to work on macOS.
```
awk: calling undefined function strftime
 input record number 43, file
 source line number 4

find: -regextype: unknown primary or operator
```

Test plan: manually run the script on macOS and CentOS8 machines.
