### PR TITLE
Close DB option in WaitForCompact()

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1204,9 +1204,22 @@ TEST_F(DBBasicTest, DBClose) {
   delete db;
   ASSERT_EQ(env->GetCloseCount(), 2);
 
+  // close by WaitForCompact() with close_db option
+  options.create_if_missing = false;
+  s = DB::Open(options, dbname, &db);
+  ASSERT_OK(s);
+  ASSERT_TRUE(db != nullptr);
+  WaitForCompactOptions wait_for_compact_options = WaitForCompactOptions();
+  wait_for_compact_options.close_db = true;
+  s = db->WaitForCompact(wait_for_compact_options);
+  ASSERT_EQ(env->GetCloseCount(), 3);
+  ASSERT_EQ(s, Status::IOError());
+
+  delete db;
+  ASSERT_EQ(env->GetCloseCount(), 3);
+
   // Provide our own logger and ensure DB::Close() does not close it
   options.info_log.reset(new TestEnv::TestLogger(env));
-  options.create_if_missing = false;
   s = DB::Open(options, dbname, &db);
   ASSERT_OK(s);
   ASSERT_TRUE(db != nullptr);
@@ -1214,9 +1227,9 @@ TEST_F(DBBasicTest, DBClose) {
   s = db->Close();
   ASSERT_EQ(s, Status::OK());
   delete db;
-  ASSERT_EQ(env->GetCloseCount(), 2);
-  options.info_log.reset();
   ASSERT_EQ(env->GetCloseCount(), 3);
+  options.info_log.reset();
+  ASSERT_EQ(env->GetCloseCount(), 4);
 }
 
 TEST_F(DBBasicTest, DBCloseAllDirectoryFDs) {

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1213,6 +1213,7 @@ TEST_F(DBBasicTest, DBClose) {
   wait_for_compact_options.close_db = true;
   s = db->WaitForCompact(wait_for_compact_options);
   ASSERT_EQ(env->GetCloseCount(), 3);
+  // see TestLogger::CloseHelper()
   ASSERT_EQ(s, Status::IOError());
 
   delete db;

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3549,12 +3549,12 @@ TEST_P(DBCompactionWaitForCompactTest,
   ASSERT_EQ(expected_flush_count, flush_finished);
 
   if (!close_db_) {
-    // During PrepareShutdown(), a flush can be initiated due to unpersisted
-    // data (data that's still in the memtable when WAL is off). This results in
-    // an additional L0 file which can trigger a compaction. However, the
-    // compaction may not complete if the background thread's execution is slow
-    // enough for the front thread to set the 'shutting_down_' flag to true
-    // before the compaction job even starts.
+    // During CancelAllBackgroundWork(), a flush can be initiated due to
+    // unpersisted data (data that's still in the memtable when WAL is off).
+    // This results in an additional L0 file which can trigger a compaction.
+    // However, the compaction may not complete if the background thread's
+    // execution is slow enough for the front thread to set the 'shutting_down_'
+    // flag to true before the compaction job even starts.
     ASSERT_EQ(expected_flush_count, compaction_finished);
     Close();
   }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3336,14 +3336,8 @@ TEST_F(DBCompactionTest, SuggestCompactRangeNoTwoLevel0Compactions) {
 
 INSTANTIATE_TEST_CASE_P(DBCompactionWaitForCompactTest,
                         DBCompactionWaitForCompactTest,
-                        ::testing::Values(std::make_tuple(false, false, false),
-                                          std::make_tuple(false, true, false),
-                                          std::make_tuple(true, false, false),
-                                          std::make_tuple(true, true, false),
-                                          std::make_tuple(false, false, true),
-                                          std::make_tuple(false, true, true),
-                                          std::make_tuple(true, false, true),
-                                          std::make_tuple(true, true, true)));
+                        ::testing::Combine(testing::Bool(), testing::Bool(),
+                                           testing::Bool()));
 
 TEST_P(DBCompactionWaitForCompactTest,
        WaitForCompactWaitsOnCompactionToFinish) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -542,8 +542,8 @@ Status DBImpl::PrepareShutdown(bool wait) {
       !mutable_db_options_.avoid_flush_during_shutdown) {
     s = DBImpl::FlushAllColumnFamilies(FlushOptions(), FlushReason::kShutDown);
   }
-  shutting_down_.store(true, std::memory_order_release);
   bg_cv_.SignalAll();
+  shutting_down_.store(true, std::memory_order_release);
   if (wait) {
     WaitForBackgroundWork();
   }

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -850,11 +850,6 @@ class DBImpl : public DB {
     return immutable_db_options_;
   }
 
-  // Prepare shutdown by flushing all CFs (in case of unpersisted_data) and
-  // setting the shutting_down_ = true. If `wait` == true, wait for background
-  // jobs to finish.
-  Status PrepareShutdown(bool wait);
-
   // Cancel all background jobs, including flush, compaction, background
   // purging, stats dumping threads, etc. If `wait` = true, wait for the
   // running jobs to abort or finish before returning. Otherwise, only

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -856,8 +856,6 @@ class DBImpl : public DB {
   // sends the signals.
   void CancelAllBackgroundWork(bool wait);
 
-  void CancelPeriodicTaskSchedulers();
-
   // Find Super version and reference it. Based on options, it might return
   // the thread local cached one.
   // Call ReturnAndCleanupSuperVersion() when it is no longer needed.
@@ -2118,6 +2116,9 @@ class DBImpl : public DB {
 
   // Schedule background tasks
   Status StartPeriodicTaskScheduler();
+
+  // Cancel scheduled periodic tasks
+  Status CancelPeriodicTaskScheduler();
 
   Status RegisterRecordSeqnoTimeWorker();
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1340,6 +1340,11 @@ class DBImpl : public DB {
 
   std::atomic<bool> shutting_down_;
 
+  // No new background jobs can be queued if true. This is used to prevent new
+  // background jobs from being queued after WaitForCompact() completes waiting
+  // all background jobs then attempts to close when close_db_ option is true.
+  std::atomic<bool> reject_new_background_jobs_;
+
   // RecoveryContext struct stores the context about version edits along
   // with corresponding column_family_data and column_family_options.
   class RecoveryContext {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -850,11 +850,17 @@ class DBImpl : public DB {
     return immutable_db_options_;
   }
 
+  // Prepare shutdown by flushing all CFs (in case of unpersisted_data) and
+  // setting the shutting_down_ = true
+  Status PrepareShutdown();
+
   // Cancel all background jobs, including flush, compaction, background
   // purging, stats dumping threads, etc. If `wait` = true, wait for the
   // running jobs to abort or finish before returning. Otherwise, only
   // sends the signals.
   void CancelAllBackgroundWork(bool wait);
+
+  void CancelPeriodicTaskSchedulers();
 
   // Find Super version and reference it. Based on options, it might return
   // the thread local cached one.

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -851,8 +851,9 @@ class DBImpl : public DB {
   }
 
   // Prepare shutdown by flushing all CFs (in case of unpersisted_data) and
-  // setting the shutting_down_ = true
-  Status PrepareShutdown();
+  // setting the shutting_down_ = true. If `wait` == true, wait for background
+  // jobs to finish.
+  Status PrepareShutdown(bool wait);
 
   // Cancel all background jobs, including flush, compaction, background
   // purging, stats dumping threads, etc. If `wait` = true, wait for the

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1343,7 +1343,7 @@ class DBImpl : public DB {
   // No new background jobs can be queued if true. This is used to prevent new
   // background jobs from being queued after WaitForCompact() completes waiting
   // all background jobs then attempts to close when close_db_ option is true.
-  std::atomic<bool> reject_new_background_jobs_;
+  bool reject_new_background_jobs_;
 
   // RecoveryContext struct stores the context about version edits along
   // with corresponding column_family_data and column_family_options.

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -4110,7 +4110,7 @@ Status DBImpl::WaitForCompact(
         (error_handler_.GetBGError().ok())) {
       bg_cv_.Wait();
     } else if (wait_for_compact_options.close_db) {
-      Status s = DBImpl::PrepareShutdown();
+      Status s = DBImpl::PrepareShutdown(true /* wait */);
       if (!s.ok()) {
         return s;
       }

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -4109,6 +4109,11 @@ Status DBImpl::WaitForCompact(
          unscheduled_flushes_) &&
         (error_handler_.GetBGError().ok())) {
       bg_cv_.Wait();
+    } else if (wait_for_compact_options.close_db) {
+      mutex_.Unlock();
+      Status s = Close();
+      mutex_.Lock();
+      return s;
     } else {
       return error_handler_.GetBGError();
     }

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -4097,7 +4097,7 @@ Status DBImpl::WaitForCompact(
     }
   }
   if (wait_for_compact_options.close_db) {
-    DBImpl::CancelPeriodicTaskSchedulers();
+    DBImpl::CancelPeriodicTaskScheduler();
   }
   TEST_SYNC_POINT("DBImpl::WaitForCompact:StartWaiting");
   for (;;) {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -322,12 +322,17 @@ class DB {
   // If syncing is required, the caller must first call SyncWAL(), or Write()
   // using an empty write batch with WriteOptions.sync=true.
   // Regardless of the return status, the DB must be freed.
+  //
   // If the return status is Aborted(), closing fails because there is
   // unreleased snapshot in the system. In this case, users can release
   // the unreleased snapshots and try again and expect it to succeed. For
   // other status, re-calling Close() will be no-op and return the original
   // close status. If the return status is NotSupported(), then the DB
   // implementation does cleanup in the destructor
+  //
+  // WaitForCompact() with WaitForCompactOptions.close_db=true will be a good
+  // choice for users who want to wait for background work before closing
+  // (rather than aborting and potentially redoing some work on re-open)
   virtual Status Close() { return Status::NotSupported(); }
 
   // ListColumnFamilies will open the DB specified by argument name

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2126,7 +2126,11 @@ struct WaitForCompactOptions {
   // A boolean to flush all column families before starting to wait.
   bool flush = false;
 
-  // A boolean to close db after waiting is done.
+  // A boolean to call Close() after waiting is done. By the time Close() is
+  // called here, there should be no background jobs in progress and periodic
+  // tasks should all be canceled. DB may not have been closed if Close()
+  // returned Aborted status due to unreleased snapshots in the system. See
+  // comments in DB::Close() for details.
   bool close_db = false;
 };
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2125,6 +2125,9 @@ struct WaitForCompactOptions {
 
   // A boolean to flush all column families before starting to wait.
   bool flush = false;
+
+  // A boolean to close db after waiting is done.
+  bool close_db = false;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2127,8 +2127,8 @@ struct WaitForCompactOptions {
   bool flush = false;
 
   // A boolean to call Close() after waiting is done. By the time Close() is
-  // called here, there should be no background jobs in progress and periodic
-  // tasks should all be canceled. DB may not have been closed if Close()
+  // called here, there should be no background jobs in progress and no new
+  // background jobs should be added. DB may not have been closed if Close()
   // returned Aborted status due to unreleased snapshots in the system. See
   // comments in DB::Close() for details.
   bool close_db = false;

--- a/unreleased_history/new_features/wait_for_compact_close_db_option.md
+++ b/unreleased_history/new_features/wait_for_compact_close_db_option.md
@@ -1,0 +1,1 @@
+Add close_db option to `WaitForCompactOptions` to call Close() after waiting is done.


### PR DESCRIPTION
Context:

As mentioned in #11436, introducing `close_db` option in `WaitForCompactOptions` to close DB after waiting for compactions to finish. Must be set to true to close the DB upon compactions finishing.

Summary
1. `bool close_db = false` added to `WaitForCompactOptions`
2. Introduced `CancelPeriodicTaskSchedulers()` and moved unregistering PeriodicTaskSchedulers to it.`CancelAllBackgroundWork()` calls it now.
3. When close_db option is on, unpersisted data (data in memtable when WAL is disabled) will be flushed in `WaitForCompact()` if flush option is not on (and `mutable_db_options_.avoid_flush_during_shutdown` is not true). The unpersisted data flush in `CancelAllBackgroundWork()` will be skipped because `shutting_down_` flag will be set true before calling `Close()`.
4. Atomic boolean `reject_new_background_jobs_` is introduced to prevent new background jobs from being added during the short period of time after waiting is done and before `shutting_down_` is set by `Close()`.
5. `WaitForCompact()` now waits for recovery in progress to complete as well. (flush operations from WAL -> L0 files)
6. Added `close_db_` cases to all existing `WaitForCompactTests`
7. Added a scenario to `DBBasicTest::DBClose`

Test Plan
- Existing DBCompactionTests
- `WaitForCompactWithOptionToFlushAndCloseDB` added 
- Added a scenario to `DBBasicTest::DBClose`