### PR TITLE
Small improvements to DBGet microbenchmark

### DIFF
--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -660,8 +660,8 @@ static void DBGetArguments(benchmark::internal::Benchmark* b) {
                "negative_query", "enable_filter", "mmap"});
 }
 
-BENCHMARK(DBGet)->Threads(1)->MinWarmUpTime(1)->Apply(DBGetArguments);
-BENCHMARK(DBGet)->Threads(8)->MinWarmUpTime(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(8)->Apply(DBGetArguments);
 
 static void SimpleGetWithPerfContext(benchmark::State& state) {
   // setup DB

--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -571,36 +571,34 @@ static void DBGet(benchmark::State& state) {
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
   auto rnd = Random(301 + state.thread_index());
-  KeyGenerator kg(&rnd, key_num);
 
   if (state.thread_index() == 0) {
+    KeyGenerator kg_seq(key_num /* max_key */);
     SetupDB(state, options, &db, "DBGet");
 
-    // load db
+    // Load all valid keys into DB. That way, iterations in `!negative_query`
+    // runs can always find the key even though it is generated from a random
+    // number.
     auto wo = WriteOptions();
     wo.disableWAL = true;
     for (uint64_t i = 0; i < key_num; i++) {
-      Status s = db->Put(wo, kg.Next(),
+      Status s = db->Put(wo, kg_seq.Next(),
                          rnd.RandomString(static_cast<int>(per_key_size)));
       if (!s.ok()) {
         state.SkipWithError(s.ToString().c_str());
       }
     }
 
-    FlushOptions fo;
-    Status s = db->Flush(fo);
+    // Compact whole DB into one level, so each iteration will consider the same
+    // number of files (one).
+    Status s = db->CompactRange(CompactRangeOptions(), nullptr /* begin */,
+                                nullptr /* end */);
     if (!s.ok()) {
       state.SkipWithError(s.ToString().c_str());
-    }
-
-    auto db_full = static_cast_with_check<DBImpl>(db.get());
-    s = db_full->WaitForCompact(WaitForCompactOptions());
-    if (!s.ok()) {
-      state.SkipWithError(s.ToString().c_str());
-      return;
     }
   }
 
+  KeyGenerator kg_rnd(&rnd, key_num /* max_key */);
   auto ro = ReadOptions();
   if (mmap) {
     ro.verify_checksums = false;
@@ -609,7 +607,7 @@ static void DBGet(benchmark::State& state) {
   if (negative_query) {
     for (auto _ : state) {
       std::string val;
-      Status s = db->Get(ro, kg.NextNonExist(), &val);
+      Status s = db->Get(ro, kg_rnd.NextNonExist(), &val);
       if (s.IsNotFound()) {
         not_found++;
       }
@@ -617,7 +615,7 @@ static void DBGet(benchmark::State& state) {
   } else {
     for (auto _ : state) {
       std::string val;
-      Status s = db->Get(ro, kg.Next(), &val);
+      Status s = db->Get(ro, kg_rnd.Next(), &val);
       if (s.IsNotFound()) {
         not_found++;
       }
@@ -636,7 +634,7 @@ static void DBGet(benchmark::State& state) {
       state.counters["get_p99"] = histogram_data.percentile99 * std::milli::den;
     }
 
-    TeardownDB(state, db, options, kg);
+    TeardownDB(state, db, options, kg_rnd);
   }
 }
 
@@ -662,9 +660,8 @@ static void DBGetArguments(benchmark::internal::Benchmark* b) {
                "negative_query", "enable_filter", "mmap"});
 }
 
-static constexpr uint64_t kDBGetNum = 1l << 20;
-BENCHMARK(DBGet)->Threads(1)->Iterations(kDBGetNum)->Apply(DBGetArguments);
-BENCHMARK(DBGet)->Threads(8)->Iterations(kDBGetNum / 8)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(1)->MinWarmUpTime(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(8)->MinWarmUpTime(1)->Apply(DBGetArguments);
 
 static void SimpleGetWithPerfContext(benchmark::State& state) {
   // setup DB

--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -641,8 +641,8 @@ static void DBGet(benchmark::State& state) {
 static void DBGetArguments(benchmark::internal::Benchmark* b) {
   for (int comp_style : {kCompactionStyleLevel, kCompactionStyleUniversal,
                          kCompactionStyleFIFO}) {
-    for (int64_t max_data : {256l << 10, 1l << 20}) {
-      for (int64_t per_key_size : {32, 256}) {
+    for (int64_t max_data : {128l << 20, 512l << 20}) {
+      for (int64_t per_key_size : {256, 1024}) {
         for (bool enable_statistics : {false, true}) {
           for (bool negative_query : {false, true}) {
             for (bool enable_filter : {false, true}) {
@@ -660,8 +660,8 @@ static void DBGetArguments(benchmark::internal::Benchmark* b) {
                "negative_query", "enable_filter", "mmap"});
 }
 
-BENCHMARK(DBGet)->Threads(1)->Apply(DBGetArguments);
-BENCHMARK(DBGet)->Threads(8)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(1)->MinWarmUpTime(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(8)->MinWarmUpTime(1)->Apply(DBGetArguments);
 
 static void SimpleGetWithPerfContext(benchmark::State& state) {
   // setup DB

--- a/microbench/db_basic_bench.cc
+++ b/microbench/db_basic_bench.cc
@@ -641,8 +641,8 @@ static void DBGet(benchmark::State& state) {
 static void DBGetArguments(benchmark::internal::Benchmark* b) {
   for (int comp_style : {kCompactionStyleLevel, kCompactionStyleUniversal,
                          kCompactionStyleFIFO}) {
-    for (int64_t max_data : {128l << 20, 512l << 20}) {
-      for (int64_t per_key_size : {256, 1024}) {
+    for (int64_t max_data : {256l << 10, 1l << 20}) {
+      for (int64_t per_key_size : {32, 256}) {
         for (bool enable_statistics : {false, true}) {
           for (bool negative_query : {false, true}) {
             for (bool enable_filter : {false, true}) {
@@ -660,8 +660,8 @@ static void DBGetArguments(benchmark::internal::Benchmark* b) {
                "negative_query", "enable_filter", "mmap"});
 }
 
-BENCHMARK(DBGet)->Threads(1)->MinWarmUpTime(1)->Apply(DBGetArguments);
-BENCHMARK(DBGet)->Threads(8)->MinWarmUpTime(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(1)->Apply(DBGetArguments);
+BENCHMARK(DBGet)->Threads(8)->Apply(DBGetArguments);
 
 static void SimpleGetWithPerfContext(benchmark::State& state) {
   // setup DB


### PR DESCRIPTION
Follow a couple conventions:

- Allowed Google benchmark to decide number of iterations. Previously we hardcoded a value, which circumvented benchmark's heuristic for iterating until the result is stable.
- Made each iteration do similar work. Previously, an iteration could do different work depending if the key was found in the first, second, third, or no L0 file.

Test Plan: none as I am unable to prove it is better. It finishes quite a bit faster, though, which matters