### PR TITLE
Fix the bloom filter true positive stat in async MultiGet

### DIFF
--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -3503,6 +3503,48 @@ TEST_F(DBBloomFilterTest, WeirdPrefixExtractorWithFilter3) {
   }
 }
 
+TEST_F(DBBloomFilterTest, MultiGetTruePositiveStat) {
+  constexpr int maxKey = 10;
+  auto PutFn = [&]() {
+    int i;
+    // Put
+    for (i = 0; i < maxKey; i++) {
+      ASSERT_OK(Put(Key(i), Key(i)));
+    }
+    Flush();
+  };
+
+  Options options = CurrentOptions();
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  BlockBasedTableOptions table_options;
+  // Test 1: bits per key < 0.5 means skip filters -> no filter
+  // constructed or read.
+  table_options.filter_policy = Create(10, kAutoBloom);
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  DestroyAndReopen(options);
+  PutFn();
+
+  std::vector<std::string> key_strs;
+  std::vector<Slice> key_slices;
+  std::vector<PinnableSlice> values;
+  std::vector<Status> statuses;
+  ReadOptions ropts;
+  int i;
+  for (i = 0; i < maxKey; ++i) {
+    key_strs.emplace_back(Key(i));
+  }
+  for (i = 0; i < maxKey; ++i) {
+    key_slices.emplace_back(key_strs[i]);
+  }
+  values.resize(maxKey);
+  statuses.resize(maxKey);
+
+  db_->MultiGet(ropts, db_->DefaultColumnFamily(), maxKey, &key_slices[0],
+                &values[0], &statuses[0]);
+  EXPECT_EQ(TestGetTickerCount(options, BLOOM_FILTER_FULL_POSITIVE), maxKey);
+  EXPECT_EQ(TestGetTickerCount(options, BLOOM_FILTER_FULL_TRUE_POSITIVE),
+            maxKey);
+}
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/db/table_cache_sync_and_async.h
+++ b/db/table_cache_sync_and_async.h
@@ -82,7 +82,8 @@ DEFINE_SYNC_AND_ASYNC(Status, TableCache::MultiGet)
     }
     if (s.ok()) {
       CO_AWAIT(t->MultiGet)
-      (options, &table_range, prefix_extractor.get(), skip_filters);
+      (options, &table_range, prefix_extractor.get(), skip_filters,
+       skip_range_deletions);
     } else if (options.read_tier == kBlockCacheTier && s.IsIncomplete()) {
       for (auto iter = table_range.begin(); iter != table_range.end(); ++iter) {
         Status* status = iter->s;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -150,7 +150,8 @@ class BlockBasedTable : public TableReader {
                                   const ReadOptions& readOptions,
                                   const MultiGetContext::Range* mget_range,
                                   const SliceTransform* prefix_extractor,
-                                  bool skip_filters = false);
+                                  bool skip_filters = false,
+                                  bool filters_matched = false);
 
   // Pre-fetch the disk blocks that correspond to the key range specified by
   // (kbegin, kend). The call will return error status in the event of

--- a/table/block_based/block_based_table_reader_sync_and_async.h
+++ b/table/block_based/block_based_table_reader_sync_and_async.h
@@ -309,7 +309,8 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::RetrieveMultipleBlocks)
 using MultiGetRange = MultiGetContext::Range;
 DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::MultiGet)
 (const ReadOptions& read_options, const MultiGetRange* mget_range,
- const SliceTransform* prefix_extractor, bool skip_filters) {
+ const SliceTransform* prefix_extractor, bool skip_filters,
+ bool filters_matched) {
   if (mget_range->empty()) {
     // Caller should ensure non-empty (performance bug)
     assert(false);
@@ -320,6 +321,12 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::MultiGet)
       !skip_filters ? rep_->filter.get() : nullptr;
   MultiGetRange sst_file_range(*mget_range, mget_range->begin(),
                                mget_range->end());
+  // Irrespective of skip_filters, if filter block is not present, then clear
+  // filters_matched to avoid updating bloom filter true positive stat
+  // later on
+  if (!rep_->filter.get()) {
+    filters_matched = false;
+  }
 
   // First check the full filter
   // If full filter not useful, Then go into each block
@@ -731,7 +738,7 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::MultiGet)
         iiter->Next();
       } while (iiter->Valid());
 
-      if (matched && filter != nullptr) {
+      if (matched && (filter != nullptr || filters_matched)) {
         if (rep_->whole_key_filtering) {
           RecordTick(rep_->ioptions.stats, BLOOM_FILTER_FULL_TRUE_POSITIVE);
         } else {

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -140,10 +140,15 @@ class TableReader {
     return Status::NotSupported();
   }
 
+  // The filters_matched argument indicates whether the bloom filter lookup
+  // was already done or not. If its true, then the
+  // BLOOM_FILTER_TRUE_POSITIVE ticker stat is updated. If its false, then
+  // skip_filters determines whether the bloom filter is consulted or not.
   virtual void MultiGet(const ReadOptions& readOptions,
                         const MultiGetContext::Range* mget_range,
                         const SliceTransform* prefix_extractor,
-                        bool skip_filters = false) {
+                        bool skip_filters = false,
+                        bool /*filters_matched*/ = false) {
     for (auto iter = mget_range->begin(); iter != mget_range->end(); ++iter) {
       *iter->s = Get(readOptions, iter->ikey, iter->get_context,
                      prefix_extractor, skip_filters);
@@ -153,8 +158,10 @@ class TableReader {
 #if USE_COROUTINES
   virtual folly::coro::Task<void> MultiGetCoroutine(
       const ReadOptions& readOptions, const MultiGetContext::Range* mget_range,
-      const SliceTransform* prefix_extractor, bool skip_filters = false) {
-    MultiGet(readOptions, mget_range, prefix_extractor, skip_filters);
+      const SliceTransform* prefix_extractor, bool skip_filters = false,
+      bool filters_matched = false) {
+    MultiGet(readOptions, mget_range, prefix_extractor, skip_filters,
+             filters_matched);
     co_return;
   }
 #endif  // USE_COROUTINES


### PR DESCRIPTION
This stat was broken for the async IO flavor of MultiGet after #10432. Now, we pass a flag to the TableReader MultiGet to indicate whether filter lookup was already done or not. If the flag is true, then the stat is updated.