### PR TITLE
Fix use after move in data block hash index

### DIFF
--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -1062,10 +1062,8 @@ Block::Block(BlockContents&& contents, size_t read_amp_bytes_per_bit,
 
         uint16_t map_offset;
         data_block_hash_index_.Initialize(
-            contents_.data.data(),
-            static_cast<uint16_t>(contents_.data.size() -
-                                  sizeof(uint32_t)), /*chop off
-                                                 NUM_RESTARTS*/
+            data_, static_cast<uint16_t>(size_ - sizeof(uint32_t)), /*chop off
+                                                                NUM_RESTARTS*/
             &map_offset);
 
         restart_offset_ = map_offset - num_restarts_ * sizeof(uint32_t);

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -1062,8 +1062,8 @@ Block::Block(BlockContents&& contents, size_t read_amp_bytes_per_bit,
 
         uint16_t map_offset;
         data_block_hash_index_.Initialize(
-            contents.data.data(),
-            static_cast<uint16_t>(contents.data.size() -
+            contents_.data.data(),
+            static_cast<uint16_t>(contents_.data.size() -
                                   sizeof(uint32_t)), /*chop off
                                                  NUM_RESTARTS*/
             &map_offset);

--- a/table/block_based/block_builder.cc
+++ b/table/block_based/block_builder.cc
@@ -240,6 +240,10 @@ inline void BlockBuilder::AddWithLastKeyImpl(const Slice& key,
 
   // TODO(yuzhangyu): make user defined timestamp work with block hash index.
   if (data_block_hash_index_builder_.Valid()) {
+    // Only data blocks should be using `kDataBlockBinaryAndHash` index type.
+    // And data blocks should always be built with internal keys instead of
+    // user keys.
+    assert(!is_user_key_);
     data_block_hash_index_builder_.Add(ExtractUserKey(key),
                                        restarts_.size() - 1);
   }

--- a/unreleased_history/bug_fixes/use_after_move_in_block.md
+++ b/unreleased_history/bug_fixes/use_after_move_in_block.md
@@ -1,0 +1,1 @@
+*Fix a use-after-move bug in block.cc.


### PR DESCRIPTION
Fix a use-after-move issue in block.cc and added some unit tests.

Test Plan
```
make all check
./block_test
```