### PR TITLE
Remove unnecessary table open when paranoid_file_checks = false

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -366,7 +366,7 @@ Status BuildTable(
     // TODO Also check the IO status when create the Iterator.
 
     TEST_SYNC_POINT("BuildTable:BeforeOutputValidation");
-    if (s.ok() && !empty) {
+    if (s.ok() && !empty && paranoid_file_checks) {
       // Verify that the table is usable
       // We set for_compaction to false and don't OptimizeForCompactionTableRead
       // here because this is a special case after we finish the table building.
@@ -386,7 +386,7 @@ Status BuildTable(
           /*allow_unprepared_value*/ false,
           mutable_cf_options.block_protection_bytes_per_key));
       s = it->status();
-      if (s.ok() && paranoid_file_checks) {
+      if (s.ok()) {
         OutputValidator file_validator(tboptions.internal_comparator,
                                        /*enable_order_check=*/true,
                                        /*enable_hash=*/true);

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -715,57 +715,59 @@ Status CompactionJob::Run() {
         if (file_idx >= files_output.size()) {
           break;
         }
-        // Verify that the table is usable
-        // We set for_compaction to false and don't
-        // OptimizeForCompactionTableRead here because this is a special case
-        // after we finish the table building No matter whether
-        // use_direct_io_for_flush_and_compaction is true, we will regard this
-        // verification as user reads since the goal is to cache it here for
-        // further user reads
-        const ReadOptions verify_table_read_options(
-            Env::IOActivity::kCompaction);
-        InternalIterator* iter = cfd->table_cache()->NewIterator(
-            verify_table_read_options, file_options_,
-            cfd->internal_comparator(), files_output[file_idx]->meta,
-            /*range_del_agg=*/nullptr, prefix_extractor,
-            /*table_reader_ptr=*/nullptr,
-            cfd->internal_stats()->GetFileReadHist(
-                compact_->compaction->output_level()),
-            TableReaderCaller::kCompactionRefill, /*arena=*/nullptr,
-            /*skip_filters=*/false, compact_->compaction->output_level(),
-            MaxFileSizeForL0MetaPin(
-                *compact_->compaction->mutable_cf_options()),
-            /*smallest_compaction_key=*/nullptr,
-            /*largest_compaction_key=*/nullptr,
-            /*allow_unprepared_value=*/false,
-            compact_->compaction->mutable_cf_options()
-                ->block_protection_bytes_per_key);
-        auto s = iter->status();
+        if (paranoid_file_checks_) {
+          // Verify that the table is usable
+          // We set for_compaction to false and don't
+          // OptimizeForCompactionTableRead here because this is a special case
+          // after we finish the table building No matter whether
+          // use_direct_io_for_flush_and_compaction is true, we will regard this
+          // verification as user reads since the goal is to cache it here for
+          // further user reads
+          const ReadOptions verify_table_read_options(
+              Env::IOActivity::kCompaction);
+          InternalIterator* iter = cfd->table_cache()->NewIterator(
+              verify_table_read_options, file_options_,
+              cfd->internal_comparator(), files_output[file_idx]->meta,
+              /*range_del_agg=*/nullptr, prefix_extractor,
+              /*table_reader_ptr=*/nullptr,
+              cfd->internal_stats()->GetFileReadHist(
+                  compact_->compaction->output_level()),
+              TableReaderCaller::kCompactionRefill, /*arena=*/nullptr,
+              /*skip_filters=*/false, compact_->compaction->output_level(),
+              MaxFileSizeForL0MetaPin(
+                  *compact_->compaction->mutable_cf_options()),
+              /*smallest_compaction_key=*/nullptr,
+              /*largest_compaction_key=*/nullptr,
+              /*allow_unprepared_value=*/false,
+              compact_->compaction->mutable_cf_options()
+                  ->block_protection_bytes_per_key);
+          auto s = iter->status();
 
-        if (s.ok() && paranoid_file_checks_) {
-          OutputValidator validator(cfd->internal_comparator(),
-                                    /*_enable_order_check=*/true,
-                                    /*_enable_hash=*/true);
-          for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-            s = validator.Add(iter->key(), iter->value());
-            if (!s.ok()) {
-              break;
+          if (s.ok()) {
+            OutputValidator validator(cfd->internal_comparator(),
+                                      /*_enable_order_check=*/true,
+                                      /*_enable_hash=*/true);
+            for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+              s = validator.Add(iter->key(), iter->value());
+              if (!s.ok()) {
+                break;
+              }
+            }
+            if (s.ok()) {
+              s = iter->status();
+            }
+            if (s.ok() && !validator.CompareValidator(
+                              files_output[file_idx]->validator)) {
+              s = Status::Corruption("Paranoid checksums do not match");
             }
           }
-          if (s.ok()) {
-            s = iter->status();
-          }
-          if (s.ok() &&
-              !validator.CompareValidator(files_output[file_idx]->validator)) {
-            s = Status::Corruption("Paranoid checksums do not match");
-          }
-        }
 
-        delete iter;
+          delete iter;
 
-        if (!s.ok()) {
-          output_status = s;
-          break;
+          if (!s.ok()) {
+            output_status = s;
+            break;
+          }
         }
       }
     };

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -267,15 +267,14 @@ TEST_F(CompactionServiceTest, BasicCompactions) {
   ASSERT_GE(compactor_statistics->getTickerCount(COMPACT_WRITE_BYTES), 1);
   ASSERT_GE(compactor_statistics->getTickerCount(COMPACT_READ_BYTES), 1);
   ASSERT_EQ(primary_statistics->getTickerCount(COMPACT_WRITE_BYTES), 0);
-  // even with remote compaction, primary host still needs to read SST files to
-  // `verify_table()`.
-  ASSERT_GE(primary_statistics->getTickerCount(COMPACT_READ_BYTES), 1);
+  ASSERT_EQ(primary_statistics->getTickerCount(COMPACT_READ_BYTES), 0);
+
   // all the compaction write happens on the remote side
   ASSERT_EQ(primary_statistics->getTickerCount(REMOTE_COMPACT_WRITE_BYTES),
             compactor_statistics->getTickerCount(COMPACT_WRITE_BYTES));
-  ASSERT_GE(primary_statistics->getTickerCount(REMOTE_COMPACT_READ_BYTES), 1);
-  ASSERT_GT(primary_statistics->getTickerCount(COMPACT_READ_BYTES),
-            primary_statistics->getTickerCount(REMOTE_COMPACT_READ_BYTES));
+  ASSERT_EQ(primary_statistics->getTickerCount(REMOTE_COMPACT_READ_BYTES),
+            compactor_statistics->getTickerCount(COMPACT_READ_BYTES));
+
   // compactor is already the remote side, which doesn't have remote
   ASSERT_EQ(compactor_statistics->getTickerCount(REMOTE_COMPACT_READ_BYTES), 0);
   ASSERT_EQ(compactor_statistics->getTickerCount(REMOTE_COMPACT_WRITE_BYTES),

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -467,7 +467,8 @@ TEST_F(DBBlockCacheTest, WarmCacheWithDataBlocksDuringFlush) {
 class DBBlockCacheTest1 : public DBTestBase,
                           public ::testing::WithParamInterface<uint32_t> {
  public:
-  const size_t kNumBlocks = 10;
+  // const size_t kNumBlocks = 10;
+  const size_t kNumBlocks = 1;
   const size_t kValueSize = 100;
   DBBlockCacheTest1() : DBTestBase("db_block_cache_test1", true) {}
 };
@@ -525,13 +526,18 @@ TEST_P(DBBlockCacheTest1, WarmCacheWithBlocksDuringFlush) {
     ASSERT_EQ(i, options.statistics->getTickerCount(BLOCK_CACHE_DATA_HIT));
 
     ASSERT_EQ(0, options.statistics->getTickerCount(BLOCK_CACHE_INDEX_MISS));
-    // Index block in cache is hit once in table open during flush and index
-    // read during Get
-    ASSERT_EQ(i * 2, options.statistics->getTickerCount(BLOCK_CACHE_INDEX_HIT));
+
+    // Index block in cache is hit when
+    // (1) table opens during flush, once for full filter and twice for
+    // partition filter (2) index is read during Get
     if (filter_type == 1) {
+      ASSERT_EQ(i * 3,
+                options.statistics->getTickerCount(BLOCK_CACHE_INDEX_HIT));
       ASSERT_EQ(i * 3,
                 options.statistics->getTickerCount(BLOCK_CACHE_FILTER_HIT));
     } else {
+      ASSERT_EQ(i * 2,
+                options.statistics->getTickerCount(BLOCK_CACHE_INDEX_HIT));
       ASSERT_EQ(i * 2,
                 options.statistics->getTickerCount(BLOCK_CACHE_FILTER_HIT));
     }

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -525,7 +525,9 @@ TEST_P(DBBlockCacheTest1, WarmCacheWithBlocksDuringFlush) {
     ASSERT_EQ(i, options.statistics->getTickerCount(BLOCK_CACHE_DATA_HIT));
 
     ASSERT_EQ(0, options.statistics->getTickerCount(BLOCK_CACHE_INDEX_MISS));
-    ASSERT_EQ(i * 3, options.statistics->getTickerCount(BLOCK_CACHE_INDEX_HIT));
+    // Index block in cache is hit once in table open during flush and index
+    // read during Get
+    ASSERT_EQ(i * 2, options.statistics->getTickerCount(BLOCK_CACHE_INDEX_HIT));
     if (filter_type == 1) {
       ASSERT_EQ(i * 3,
                 options.statistics->getTickerCount(BLOCK_CACHE_FILTER_HIT));

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -489,6 +489,8 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
   // two table insertions could lead to an LRU eviction, depending on
   // hash values.
   options.table_cache_numshardbits = 2;
+  // To exercise verification of compaction output table
+  options.paranoid_file_checks = true;
   DestroyAndReopen(options);
   Random rnd(301);
 
@@ -515,8 +517,9 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
       num_table_cache_lookup = 0;
       ASSERT_OK(Flush());
       ASSERT_OK(dbfull()->TEST_WaitForCompact());
-      // preloading iterator issues one table cache lookup and create
-      // a new table reader, if not preloaded.
+      // `paranoid_file_checks = true` results in verifying the compaction
+      // output table. Such verification creates iterator, which issues one
+      // table cache lookup and create a new table reader, if not preloaded.
       int old_num_table_cache_lookup = num_table_cache_lookup;
       ASSERT_GE(num_table_cache_lookup, 1);
       ASSERT_EQ(num_new_table_reader, 1);

--- a/db/db_io_failure_test.cc
+++ b/db/db_io_failure_test.cc
@@ -25,6 +25,7 @@ TEST_F(DBIOFailureTest, DropWrites) {
     Options options = CurrentOptions();
     options.env = env_;
     options.paranoid_checks = false;
+    options.paranoid_file_checks = true;
     Reopen(options);
 
     ASSERT_OK(Put("foo", "v1"));

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1039,6 +1039,10 @@ TEST_F(DBOptionsTest, CompactionReadaheadSizeChange) {
 
   options.compaction_readahead_size = 0;
   options.level0_file_num_compaction_trigger = 2;
+  // To force creation of table cache's iterator, during which
+  // the dynamically changed readahead size is pass down to the test Env level
+  options.paranoid_file_checks = true;
+
   const std::string kValue(1024, 'v');
   Reopen(options);
 

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2161,6 +2161,9 @@ TEST_P(PinL0IndexAndFilterBlocksTest,
 
 TEST_P(PinL0IndexAndFilterBlocksTest, DisablePrefetchingNonL0IndexAndFilter) {
   Options options = CurrentOptions();
+  // To force verification of compaction output table
+  // for test purposes.
+  options.paranoid_file_checks = true;
   // This ensures that db does not ref anything in the block cache, so
   // EraseUnRefEntries could clear them up.
   bool close_afterwards = true;
@@ -2241,7 +2244,8 @@ TEST_P(PinL0IndexAndFilterBlocksTest, DisablePrefetchingNonL0IndexAndFilter) {
 
   // Force a full compaction to one single file. There will be a block
   // cache read for both of index and filter. If prefetch doesn't explicitly
-  // happen, it will happen when verifying the file.
+  // happen, it will happen when verifying the file as `paranoid_file_checks` is
+  // set to true.
   Compact(1, "a", "zzzzz");
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
 

--- a/db/error_handler_fs_test.cc
+++ b/db/error_handler_fs_test.cc
@@ -938,6 +938,8 @@ TEST_F(DBErrorHandlingFSTest, CompactionManifestWriteRetryableError) {
   options.level0_file_num_compaction_trigger = 2;
   options.listeners.emplace_back(listener);
   options.max_bgerror_resume_count = 0;
+  options.paranoid_file_checks = true;
+
   Status s;
   std::string old_manifest;
   std::string new_manifest;
@@ -2100,6 +2102,8 @@ TEST_F(DBErrorHandlingFSTest,
   options.listeners.emplace_back(listener);
   options.max_bgerror_resume_count = 2;
   options.bgerror_resume_retry_interval = 100000;  // 0.1 second
+  options.paranoid_file_checks = true;
+
   Status s;
   std::string old_manifest;
   std::string new_manifest;


### PR DESCRIPTION
**Context/Summary:**
InternalIterator are unnecessarily created in flush and compaction during verifying table when paranoid_file_checks = false cuz the iterator won't be used in this case. Such creation has cost as it opens table and does read to file.

Also fixed some compaction tests relying on or assuming such table open will happen.

**Test:** 
- Run db bench on pre/post PR to see if file.read.flush.micros.COUNT decreases
```
make clean && DEBUG_LEVEL=0 make -j56 db_bench

/db_bench -seed=1678564177044286  -db=/dev/shm/testdb/ -statistics=true -benchmarks="fillseq" -key_size=32 -value_size=512 -num=50000 -write_buffer_size=655 -target_file_size_base=655 -disable_auto_compactions=true -compression_type=none -bloom_bits=3 -paranoid_checks=false -open_files=1
```
Pre-PR
```
rocksdb.sst.read.micros P50 : 0.873134 P95 : 3.862069 P99 : 9.100000 P100 : 35.000000 COUNT : 2340 SUM : 4293
rocksdb.file.read.flush.micros P50 : 0.873134 P95 : 3.862069 P99 : 9.100000 P100 : 35.000000 COUNT : 2340 SUM : 4293
```

Post-PR
```
rocksdb.sst.read.micros P50 : 0.804994 P95 : 2.807027 P99 : 5.640000 P100 : 29.000000 COUNT : 1354 SUM : 2230
rocksdb.file.read.flush.micros P50 : 0.804994 P95 : 2.807027 P99 : 5.640000 P100 : 29.000000 COUNT : 1354 SUM : 2230
```

- CI

