### PR TITLE
Skip `kBottommostFiles` compaction when `preserve_internal_time_seconds` is set

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3047,7 +3047,9 @@ void VersionStorageInfo::PrepareForVersionAppend(
   GenerateFileIndexer();
   GenerateLevelFilesBrief();
   GenerateLevel0NonOverlapping();
-  if (!immutable_options.allow_ingest_behind) {
+  if (immutable_options.compaction_style == kCompactionStyleLevel &&
+      !immutable_options.allow_ingest_behind &&
+      immutable_options.preserve_internal_time_seconds == 0) {
     GenerateBottommostFiles();
   }
   GenerateFileLocationIndex();
@@ -3562,7 +3564,9 @@ void VersionStorageInfo::ComputeCompactionScore(
     }
   }
   ComputeFilesMarkedForCompaction();
-  if (!immutable_options.allow_ingest_behind) {
+  if (immutable_options.compaction_style == kCompactionStyleLevel &&
+      !immutable_options.allow_ingest_behind &&
+      immutable_options.preserve_internal_time_seconds == 0) {
     ComputeBottommostFilesMarkedForCompaction();
   }
   if (mutable_cf_options.ttl > 0) {


### PR DESCRIPTION
Summary: when `preserve_internal_time_seconds` or `preclude_last_level_data_seconds` is set, sequence numbers are not always zeroed out when compacting into the bottommost level. `kBottommostFiles` compaction compacts files in the bottommost level with non-zero maximum sequence number when a relevant snapshot is released. These two features combine together can cause infinite compaction loop. This PR fixes this issue by skip kBottommostFiles compaction when `preserve_internal_time_seconds` is enabled.

Another change included in this PR is to only compute `GenerateBottommostFiles()` when leveled compaction is used, since other compaction styles do not use it.

Test plan:
- run stress tests and check if there was infinite compaction loop
```
./db_stress  --target_file_size_base=1048576 --compaction_style=0 --preserve_internal_time_seconds=60 --acquire_snapshot_one_in=5000 --column_families=1

grep "Bottommost" /tmp/rocksdbtest-543376/dbstress/LOG

The following log can occur before this PR:
...
2023/06/04-14:43:32.186221 2165506 EVENT_LOG_v1 {"time_micros": 1685915012186212, "job": 253, "event": "compaction_started", "compaction_reason": "BottommostFiles", "files_L1": [268], "score": 0.25, "input_data_size": 1161271, "oldest_snapshot_seqno": -1}
2023/06/04-14:43:32.316541 2165506 EVENT_LOG_v1 {"time_micros": 1685915012316532, "job": 254, "event": "compaction_started", "compaction_reason": "BottommostFiles", "files_L1": [269], "score": 0.25, "input_data_size": 1161271, "oldest_snapshot_seqno": 1267186}
2023/06/04-14:43:32.465683 2165506 EVENT_LOG_v1 {"time_micros": 1685915012465671, "job": 255, "event": "compaction_started", "compaction_reason": "BottommostFiles", "files_L1": [270], "score": 0.25, "input_data_size": 1161271, "oldest_snapshot_seqno": 1273572}
2023/06/04-14:43:32.639211 2165506 EVENT_LOG_v1 {"time_micros": 1685915012639202, "job": 256, "event": "compaction_started", "compaction_reason": "BottommostFiles", "files_L1": [271], "score": 0.25, "input_data_size": 1161271, "oldest_snapshot_seqno": 1280896}
2023/06/04-14:43:32.810306 2165506 EVENT_LOG_v1 {"time_micros": 1685915012810294, "job": 257, "event": "compaction_started", "compaction_reason": "BottommostFiles", "files_L1": [272], "score": 0.25, "input_data_size": 1161271, "oldest_snapshot_seqno": 1288802}
....
```