### PR TITLE
Add missing parameter in C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3881,10 +3881,11 @@ void rocksdb_options_set_row_cache(rocksdb_options_t* opt,
 }
 
 void rocksdb_options_add_compact_on_deletion_collector_factory(
-    rocksdb_options_t* opt, size_t window_size, size_t num_dels_trigger) {
+    rocksdb_options_t* opt, size_t window_size, size_t num_dels_trigger,
+    double deletion_ratio) {
   std::shared_ptr<ROCKSDB_NAMESPACE::TablePropertiesCollectorFactory>
-      compact_on_del =
-          NewCompactOnDeletionCollectorFactory(window_size, num_dels_trigger);
+      compact_on_del = NewCompactOnDeletionCollectorFactory(
+          window_size, num_dels_trigger, deletion_ratio);
   opt->rep.table_properties_collector_factories.emplace_back(compact_on_del);
 }
 

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -720,7 +720,7 @@ int main(int argc, char** argv) {
   rocksdb_compactoptions_set_exclusive_manual_compaction(coptions, 1);
 
   rocksdb_options_add_compact_on_deletion_collector_factory(options, 10000,
-                                                            10001);
+                                                            10001, 0.0);
 
   StartPhase("destroy");
   rocksdb_destroy_db(options, dbname, &err);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1615,7 +1615,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_row_cache(
 
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_add_compact_on_deletion_collector_factory(
-    rocksdb_options_t*, size_t window_size, size_t num_dels_trigger);
+    rocksdb_options_t*, size_t window_size, size_t num_dels_trigger,
+    double deletion_ratio);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_manual_wal_flush(
     rocksdb_options_t* opt, unsigned char);
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_manual_wal_flush(

--- a/unreleased_history/public_api_changes/add_new_compaction_parameter.md
+++ b/unreleased_history/public_api_changes/add_new_compaction_parameter.md
@@ -1,0 +1,1 @@
+Expose delete ratio parameter from the compaction API to the C API

--- a/unreleased_history/public_api_changes/add_new_compaction_parameter.md
+++ b/unreleased_history/public_api_changes/add_new_compaction_parameter.md
@@ -1,1 +1,1 @@
-Expose delete ratio parameter from the compaction API to the C API
+Add parameter `deletion_ratio` to C API `rocksdb_options_add_compact_on_deletion_collector_factory`.


### PR DESCRIPTION
The class `NewCompactOnDeletionCollectorFactory` exposes the parameter `delete_ratio`.

The C API `rocksdb_options_add_compact_on_deletion_collector_factory` does not allow a user to pass a delete ration to be passed down the the C++ class bellow.

The class has default value for the delete ratio which makes it pass the compilation and the tests.

closes #11541