### PR TITLE
Update MacOS resource classes in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
   build-macos:
     macos:
       xcode: 12.5.1
-    resource_class: large
+    resource_class: macos.m1.large.gen1
     environment:
       ROCKSDB_DISABLE_JEMALLOC: 1 # jemalloc cause env_test hang, disable it for now
     steps:
@@ -223,7 +223,7 @@ jobs:
   build-macos-cmake:
     macos:
       xcode: 12.5.1
-    resource_class: large
+    resource_class: macos.m1.large.gen1
     parameters:
       run_even_tests:
         description: run even or odd tests, used to split tests to 2 groups
@@ -608,7 +608,7 @@ jobs:
   build-macos-java:
     macos:
       xcode: 12.5.1
-    resource_class: large
+    resource_class: macos.m1.large.gen1
     environment:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
       ROCKSDB_DISABLE_JEMALLOC: 1 # jemalloc causes java 8 crash
@@ -633,7 +633,7 @@ jobs:
   build-macos-java-static:
     macos:
       xcode: 12.5.1
-    resource_class: large
+    resource_class: macos.m1.large.gen1
     environment:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
     steps:
@@ -658,7 +658,7 @@ jobs:
   build-macos-java-static-universal:
     macos:
       xcode: 12.5.1
-    resource_class: large
+    resource_class: macos.m1.large.gen1
     environment:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
     steps:


### PR DESCRIPTION
Summary:
The `large` MacOS class on CircleCI is going away; the PR updates it to its recommended successor `macos.m1.large.gen1`.

Test Plan:
CI