### PR TITLE
Fix crash_test crash

### DIFF
--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -174,7 +174,10 @@ Status SstFileDumper::NewTableReader(
       nullptr /* block_cache_tracer */, 0 /* max_file_size_for_l0_meta_pin */,
       "" /* cur_db_session_id */, 0 /* cur_file_num */, {} /* unique_id */,
       0 /* largest_seqno */, 0 /* tail_size */,
-      static_cast<bool>(table_properties_->user_defined_timestamps_persisted));
+      table_properties_ == nullptr
+          ? true
+          : static_cast<bool>(
+                table_properties_->user_defined_timestamps_persisted));
   // Allow open file with global sequence number for backward compatibility.
   t_opt.largest_seqno = kMaxSequenceNumber;
 


### PR DESCRIPTION
`table_properties_` is not guaranteed to be available.
