### PR TITLE
Fix extra prefetching when num_file_reads_for_auto_readahead is 1 in async_io

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -831,7 +831,7 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   bool is_eligible_for_prefetching = false;
   if (readahead_size_ > 0 &&
       (!implicit_auto_readahead_ ||
-       num_file_reads_ + 1 >= num_file_reads_for_auto_readahead_)) {
+       num_file_reads_ >= num_file_reads_for_auto_readahead_)) {
     is_eligible_for_prefetching = true;
   }
 
@@ -941,6 +941,7 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
     prev_len_ = 0;
   }
   if (read_len2) {
+    TEST_SYNC_POINT("FilePrefetchBuffer::PrefetchAsync:ExtraPrefetching");
     s = ReadAsync(opts, reader, read_len2, rounddown_start2, second);
     if (!s.ok()) {
       DestroyAndClearIOHandle(second);

--- a/unreleased_history/bug_fixes/seek_extraprefetch.md
+++ b/unreleased_history/bug_fixes/seek_extraprefetch.md
@@ -1,0 +1,1 @@
+Fix extra prefetching during seek in async_io when BlockBasedTableOptions.num_file_reads_for_auto_readahead_ = 1 leading to extra reads than required.


### PR DESCRIPTION
Summary: When num_file_reads_for_auto_readahead = 1, during seek, it would go for prefetchingextra data in second buffer along with seek data, that would lead to increase in read data and
discarded bytes.

Test Plan: Added unit test

Reviewers:

Subscribers:

Tasks:

Tags: