### PR TITLE
RFC: add `SetSkipConcurrencyControl(bool)` to transaction interface

### DIFF
--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -278,6 +278,17 @@ class Transaction {
   // Otherwise returns Status::OK().
   virtual Status PopSavePoint() = 0;
 
+  // Toggle the concurrency control for the transaction from this operation on.
+  // if value is set to true, concurrency control for all following operations
+  // in the transaction is skipped. If value is set to false, concurrency
+  // control is enabled for all following operations in the transaction.
+  // May only be supported by some types of transactions.
+  virtual Status SetSkipConcurrencyControl(bool /*value*/) {
+    // The default implementation will do nothing. Derived transaction classes
+    // can override it with more useful behavior.
+    return Status::NotSupported();
+  }
+
   // This function is similar to DB::Get() except it will also read pending
   // changes in this transaction.  Currently, this function will return
   // Status::MergeInProgress if the most recent write to the queried key in

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -119,6 +119,11 @@ void PessimisticTransaction::Clear() {
   TransactionBaseImpl::Clear();
 }
 
+Status PessimisticTransaction::SetSkipConcurrencyControl(bool value) {
+  skip_concurrency_control_ = value;
+  return Status::OK();
+}
+
 void PessimisticTransaction::Reinitialize(
     TransactionDB* txn_db, const WriteOptions& write_options,
     const TransactionOptions& txn_options) {

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -150,6 +150,8 @@ class PessimisticTransaction : public TransactionBaseImpl {
 
   void Clear() override;
 
+  Status SetSkipConcurrencyControl(bool value) override;
+
   PessimisticTransactionDB* txn_db_impl_;
   DBImpl* db_impl_;
 


### PR DESCRIPTION
The motivation for this is to allow disabling expensive per-key lock tracking for _some_ keys inside a transaction.
Adding keys to the lock map in a transaction can be pretty expensive, and avoiding this for some keys can have a positive impact on memory usage and performance (lock map entries are quite heavy in terms of memory usage, lock map stripes are protected by mutexes etc.). `PessimisticTransaction` currently allows to set its `skip_concurrency_control_` flag, but it must be set once for an entire transaction and cannot be set for individual keys inside a transaction. And it is only available in the `PessimisticTransaction` implementation, which is a RocksDB-internal class that cannot be accessed from client applications.

The suggested change in this PR would add a
`SetSkipConcurrencyControl(bool)` method to every transaction. The default implementation will do nothing and always return `Status::NotSupported()`.
For the `PessimisticTransaction` it is overridden so that the `skip_concurrency_control_` flag of the transaction is modified. This seems to be ok, as the flag is checked again upon every lock attempt.

There is no special override for `OptimisticTransaction`, simply because I am not a user of `OptimisticTransaction` and don't know what the correct behavior would be here.

Before adding tests for the current implementation, I would rather like to get feedback on whether or not the approach taken in this PR is considered useful or not. If so, I am happy to add tests to the PR.