### PR TITLE
Set PORTABLE to ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ if(CCACHE_FOUND)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
+option(PORTABLE "build portable version" ON)
+
 option(WITH_JEMALLOC "build with JeMalloc" OFF)
 option(WITH_LIBURING "build with liburing" ON)
 option(WITH_SNAPPY "build with SNAPPY" OFF)


### PR DESCRIPTION
Set the PORTABLE option to ON by default when compiling with CMake, without the need to manually specify it.

Test Plan: Just use CMake to configure and build without manual setup PORTABLE option.