### PR TITLE
Run db_stress for final time to ensure un-interrupted validation

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -254,6 +254,7 @@ DECLARE_int32(verify_db_one_in);
 DECLARE_int32(continuous_verification_interval);
 DECLARE_int32(get_property_one_in);
 DECLARE_string(file_checksum_impl);
+DECLARE_bool(post_verification_only);
 
 // Options for transaction dbs.
 // Use TransactionDB (a.k.a. Pessimistic Transaction DB)

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -254,7 +254,7 @@ DECLARE_int32(verify_db_one_in);
 DECLARE_int32(continuous_verification_interval);
 DECLARE_int32(get_property_one_in);
 DECLARE_string(file_checksum_impl);
-DECLARE_bool(post_verification_only);
+DECLARE_bool(verification_only);
 
 // Options for transaction dbs.
 // Use TransactionDB (a.k.a. Pessimistic Transaction DB)

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -188,7 +188,7 @@ bool RunStressTestImpl(SharedState* shared) {
   // are not executed when running with post_verification_only
   // TODO: We need to create verification stats (e.g. how many keys
   // are verified by which method) and report them here instead of operation stats.
-  if (!FLAGS_post_verification_only){
+  if (!FLAGS_post_verification_only) {
     for (unsigned int i = 1; i < n; i++) {
       threads[0]->stats.Merge(threads[i]->stats);
     }
@@ -205,7 +205,10 @@ bool RunStressTestImpl(SharedState* shared) {
     fprintf(stdout, "%s Verification successful\n",
             clock->TimeToString(now / 1000000).c_str());
   }
-  stress->PrintStatistics();
+
+  if (!FLAGS_post_verification_only) {
+    stress->PrintStatistics();
+  }
 
   if (FLAGS_compaction_thread_pool_adjust_interval > 0 ||
       FLAGS_continuous_verification_interval > 0) {

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -63,7 +63,8 @@ bool RunStressTestImpl(SharedState* shared) {
   SystemClock* clock = db_stress_env->GetSystemClock().get();
   StressTest* stress = shared->GetStressTest();
 
-  if (shared->ShouldVerifyAtBeginning() && FLAGS_preserve_unverified_changes) {
+  if (shared->ShouldVerifyAtBeginning() && FLAGS_preserve_unverified_changes &&
+      !FLAGS_post_verification_only) {
     Status s = InitUnverifiedSubdir(FLAGS_db);
     if (s.ok() && !FLAGS_expected_values_dir.empty()) {
       s = InitUnverifiedSubdir(FLAGS_expected_values_dir);

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -18,8 +18,8 @@ void ThreadBody(void* v) {
   ThreadState* thread = reinterpret_cast<ThreadState*>(v);
   SharedState* shared = thread->shared;
 
-  if (!FLAGS_skip_verifydb && shared->ShouldVerifyAtBeginning()
-      && !FLAGS_post_verification_only) {
+  if (!FLAGS_skip_verifydb && shared->ShouldVerifyAtBeginning() &&
+      !FLAGS_post_verification_only) {
     thread->shared->GetStressTest()->VerifyDb(thread);
   }
   {
@@ -33,7 +33,7 @@ void ThreadBody(void* v) {
     }
   }
   if (!FLAGS_post_verification_only) {
-     thread->shared->GetStressTest()->OperateDb(thread);
+    thread->shared->GetStressTest()->OperateDb(thread);
   }
   {
     MutexLock l(shared->GetMutex());
@@ -152,9 +152,9 @@ bool RunStressTestImpl(SharedState* shared) {
     if (!FLAGS_post_verification_only) {
       now = clock->NowMicros();
       fprintf(stdout, "%s Starting database operations\n",
-               clock->TimeToString(now / 1000000).c_str());
+              clock->TimeToString(now / 1000000).c_str());
     } else {
-       fprintf(stdout, "Skipping database operations\n");
+      fprintf(stdout, "Skipping database operations\n");
     }
 
     shared->SetStart();
@@ -187,7 +187,8 @@ bool RunStressTestImpl(SharedState* shared) {
   // emit no ops or writes error. To avoid this, merging and reporting stats
   // are not executed when running with post_verification_only
   // TODO: We need to create verification stats (e.g. how many keys
-  // are verified by which method) and report them here instead of operation stats.
+  // are verified by which method) and report them here instead of operation
+  // stats.
   if (!FLAGS_post_verification_only) {
     for (unsigned int i = 1; i < n; i++) {
       threads[0]->stats.Merge(threads[i]->stats);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1111,8 +1111,8 @@ DEFINE_uint64(stats_dump_period_sec,
 
 DEFINE_bool(use_io_uring, false, "Enable the use of IO uring on Posix");
 
-DEFINE_bool(post_verification_only, false,
-            "If true, tests will only execute post-verification step");
+DEFINE_bool(verification_only, false,
+            "If true, tests will only execute verification step");
 extern "C" bool RocksDbIOUringEnable() { return FLAGS_use_io_uring; }
 
 DEFINE_uint32(memtable_max_range_deletions, 0,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1110,6 +1110,10 @@ DEFINE_uint64(stats_dump_period_sec,
               "Gap between printing stats to log in seconds");
 
 DEFINE_bool(use_io_uring, false, "Enable the use of IO uring on Posix");
+
+DEFINE_bool(
+    post_verification_only, false,
+    "If true, tests will only execute post-verification step");
 extern "C" bool RocksDbIOUringEnable() { return FLAGS_use_io_uring; }
 
 DEFINE_uint32(memtable_max_range_deletions, 0,

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1111,9 +1111,8 @@ DEFINE_uint64(stats_dump_period_sec,
 
 DEFINE_bool(use_io_uring, false, "Enable the use of IO uring on Posix");
 
-DEFINE_bool(
-    post_verification_only, false,
-    "If true, tests will only execute post-verification step");
+DEFINE_bool(post_verification_only, false,
+            "If true, tests will only execute post-verification step");
 extern "C" bool RocksDbIOUringEnable() { return FLAGS_use_io_uring; }
 
 DEFINE_uint32(memtable_max_range_deletions, 0,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2484,8 +2484,8 @@ void StressTest::PrintEnv() const {
           FLAGS_use_get_entity ? "true" : "false");
   fprintf(stdout, "Use MultiGetEntity        : %s\n",
           FLAGS_use_multi_get_entity ? "true" : "false");
-  fprintf(stdout, "Post-verification only    : %s\n",
-          FLAGS_post_verification_only ? "true" : "false");
+  fprintf(stdout, "Verification only    : %s\n",
+          FLAGS_verification_only ? "true" : "false");
 
   const char* memtablerep = "";
   switch (FLAGS_rep_factory) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2484,6 +2484,8 @@ void StressTest::PrintEnv() const {
           FLAGS_use_get_entity ? "true" : "false");
   fprintf(stdout, "Use MultiGetEntity        : %s\n",
           FLAGS_use_multi_get_entity ? "true" : "false");
+  fprintf(stdout, "Post-verification only    : %s\n",
+          FLAGS_post_verification_only ? "true" : "false");
 
   const char* memtablerep = "";
   switch (FLAGS_rep_factory) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2484,7 +2484,7 @@ void StressTest::PrintEnv() const {
           FLAGS_use_get_entity ? "true" : "false");
   fprintf(stdout, "Use MultiGetEntity        : %s\n",
           FLAGS_use_multi_get_entity ? "true" : "false");
-  fprintf(stdout, "Verification only    : %s\n",
+  fprintf(stdout, "Verification only         : %s\n",
           FLAGS_verification_only ? "true" : "false");
 
   const char* memtablerep = "";

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -106,7 +106,6 @@ default_params = {
     "partition_filters": lambda: random.randint(0, 1),
     "partition_pinning": lambda: random.randint(0, 3),
     "pause_background_one_in": 1000000,
-    "post_verification_only": 0,
     "prefix_size": lambda: random.choice([-1, 1, 5, 7, 8]),
     "prefixpercent": 5,
     "progress_reports": 0,
@@ -136,6 +135,7 @@ default_params = {
     # 999 -> use Bloom API
     "ribbon_starting_level": lambda: random.choice([random.randint(-1, 10), 999]),
     "value_size_mult": 32,
+    "verification_only": 0,
     "verify_checksum": 1,
     "write_buffer_size": 4 * 1024 * 1024,
     "writepercent": 35,
@@ -818,7 +818,7 @@ def blackbox_crash_main(args, unknown_args):
     # We should run the test one more time with VerifyOnly setup and no-timeout
     # Only do this if the tests are not failed for total-duration
     print("Running final time for verification")
-    cmd_params.update({"post_verification_only": 1})
+    cmd_params.update({"verification_only": 1})
     cmd = gen_cmd(
         dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
     )

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -756,7 +756,7 @@ def gen_cmd(params, unknown_params):
     return cmd
 
 
-def execute_cmd(cmd, timeout):
+def execute_cmd(cmd, timeout=None):
     child = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     print("Running db_stress with pid=%d: %s\n\n" % (child.pid, " ".join(cmd)))
 
@@ -813,6 +813,24 @@ def blackbox_crash_main(args, unknown_args):
         time.sleep(1)  # time to stabilize before the next run
 
         time.sleep(1)  # time to stabilize before the next run
+
+    # We should run the test one more time with VerifyOnly setup and no-timeout
+    # Only do this if the tests are not failed for total-duration
+    print("Running final time for verification")
+    ops_count = max(cmd_params.get("reopen", 0), 1)
+    cmd_params.update({"ops_per_thread": ops_count})
+    cmd = gen_cmd(
+        dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
+    )
+    hit_timeout, retcode, outs, errs = execute_cmd(cmd)
+
+    # Print stats of the final run
+    print("stdout:", outs)
+
+    for line in errs.split("\n"):
+        if line != "" and not line.startswith("WARNING"):
+            print("stderr has error message:")
+            print("***" + line + "***")
 
     # we need to clean up after ourselves -- only do this on test success
     shutil.rmtree(dbname, True)

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -819,6 +819,8 @@ def blackbox_crash_main(args, unknown_args):
     # Only do this if the tests are not failed for total-duration
     print("Running final time for verification")
     cmd_params.update({"verification_only": 1})
+    cmd_params.update({"skip_verifydb": 0})
+
     cmd = gen_cmd(
         dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
     )

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -106,6 +106,7 @@ default_params = {
     "partition_filters": lambda: random.randint(0, 1),
     "partition_pinning": lambda: random.randint(0, 3),
     "pause_background_one_in": 1000000,
+    "post_verification_only": 0,
     "prefix_size": lambda: random.choice([-1, 1, 5, 7, 8]),
     "prefixpercent": 5,
     "progress_reports": 0,
@@ -817,8 +818,7 @@ def blackbox_crash_main(args, unknown_args):
     # We should run the test one more time with VerifyOnly setup and no-timeout
     # Only do this if the tests are not failed for total-duration
     print("Running final time for verification")
-    ops_count = max(cmd_params.get("reopen", 0), 1)
-    cmd_params.update({"ops_per_thread": ops_count})
+    cmd_params.update({"post_verification_only": 1})
     cmd = gen_cmd(
         dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
     )


### PR DESCRIPTION
In blackbox tests, db_stress command always run with timeout. Timeout can happen during validation, leaving some of the keys not checked. Since key validation is done in order, it is quite likely that keys those are towards to the end of the set are never validated. This PR adds a final execution, without timeout, to ensure validation is executed for all keys, at least once.