### PR TITLE
Run db_stress for final time, with post-verification-only, to ensure un-interrupted validation

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -252,6 +252,7 @@ DECLARE_int32(verify_db_one_in);
 DECLARE_int32(continuous_verification_interval);
 DECLARE_int32(get_property_one_in);
 DECLARE_string(file_checksum_impl);
+DECLARE_bool(post_verification_only);
 
 // Options for transaction dbs.
 // Use TransactionDB (a.k.a. Pessimistic Transaction DB)

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -17,7 +17,8 @@ void ThreadBody(void* v) {
   ThreadState* thread = reinterpret_cast<ThreadState*>(v);
   SharedState* shared = thread->shared;
 
-  if (!FLAGS_skip_verifydb && shared->ShouldVerifyAtBeginning()) {
+  if (!FLAGS_skip_verifydb && shared->ShouldVerifyAtBeginning()
+      && !FLAGS_post_verification_only) {
     thread->shared->GetStressTest()->VerifyDb(thread);
   }
   {
@@ -30,8 +31,9 @@ void ThreadBody(void* v) {
       shared->GetCondVar()->Wait();
     }
   }
-  thread->shared->GetStressTest()->OperateDb(thread);
-
+  if (!FLAGS_post_verification_only) {
+     thread->shared->GetStressTest()->OperateDb(thread);
+  }
   {
     MutexLock l(shared->GetMutex());
     shared->IncOperated();
@@ -145,9 +147,13 @@ bool RunStressTestImpl(SharedState* shared) {
       stress->TrackExpectedState(shared);
     }
 
-    now = clock->NowMicros();
-    fprintf(stdout, "%s Starting database operations\n",
-            clock->TimeToString(now / 1000000).c_str());
+    if (!FLAGS_post_verification_only) {
+      now = clock->NowMicros();
+      fprintf(stdout, "%s Starting database operations\n",
+               clock->TimeToString(now / 1000000).c_str());
+    } else {
+       fprintf(stdout, "Skipping database operations\n");
+    }
 
     shared->SetStart();
     shared->GetCondVar()->SignalAll();
@@ -174,10 +180,18 @@ bool RunStressTestImpl(SharedState* shared) {
     }
   }
 
-  for (unsigned int i = 1; i < n; i++) {
-    threads[0]->stats.Merge(threads[i]->stats);
+  // If we are running post_verification_only
+  // stats will be empty and trying to report them will
+  // emit no ops or writes error. To avoid this, merging and reporting stats
+  // are not executed when running with post_verification_only
+  // TODO: We need to create verification stats (e.g. how many keys
+  // are verified by which method) and report them here instead of operation stats.
+  if (!FLAGS_post_verification_only){
+    for (unsigned int i = 1; i < n; i++) {
+      threads[0]->stats.Merge(threads[i]->stats);
+    }
+    threads[0]->stats.Report("Stress Test");
   }
-  threads[0]->stats.Report("Stress Test");
 
   for (unsigned int i = 0; i < n; i++) {
     delete threads[i];

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1100,6 +1100,10 @@ DEFINE_uint64(stats_dump_period_sec,
               "Gap between printing stats to log in seconds");
 
 DEFINE_bool(use_io_uring, false, "Enable the use of IO uring on Posix");
+
+DEFINE_bool(
+    post_verification_only, false,
+    "If true, tests will only execute post-verification step");
 extern "C" bool RocksDbIOUringEnable() { return FLAGS_use_io_uring; }
 
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2423,6 +2423,8 @@ void StressTest::PrintEnv() const {
           FLAGS_use_get_entity ? "true" : "false");
   fprintf(stdout, "Use MultiGetEntity        : %s\n",
           FLAGS_use_multi_get_entity ? "true" : "false");
+  fprintf(stdout, "Post-verification only    : %s\n",
+          FLAGS_post_verification_only ? "true" : "false");
 
   const char* memtablerep = "";
   switch (FLAGS_rep_factory) {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -743,7 +743,7 @@ def gen_cmd(params, unknown_params):
     return cmd
 
 
-def execute_cmd(cmd, timeout):
+def execute_cmd(cmd, timeout=None):
     child = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     print("Running db_stress with pid=%d: %s\n\n" % (child.pid, " ".join(cmd)))
 
@@ -800,6 +800,24 @@ def blackbox_crash_main(args, unknown_args):
         time.sleep(1)  # time to stabilize before the next run
 
         time.sleep(1)  # time to stabilize before the next run
+
+    # We should run the test one more time with VerifyOnly setup and no-timeout
+    # Only do this if the tests are not failed for total-duration
+    print("Running final time for verification")
+    ops_count = max(cmd_params.get("reopen", 0), 1)
+    cmd_params.update({"ops_per_thread": ops_count})
+    cmd = gen_cmd(
+        dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
+    )
+    hit_timeout, retcode, outs, errs = execute_cmd(cmd)
+
+    # Print stats of the final run
+    print("stdout:", outs)
+
+    for line in errs.split("\n"):
+        if line != "" and not line.startswith("WARNING"):
+            print("stderr has error message:")
+            print("***" + line + "***")
 
     # we need to clean up after ourselves -- only do this on test success
     shutil.rmtree(dbname, True)

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -105,6 +105,7 @@ default_params = {
     "partition_filters": lambda: random.randint(0, 1),
     "partition_pinning": lambda: random.randint(0, 3),
     "pause_background_one_in": 1000000,
+    "post_verification_only": 0,
     "prefix_size": lambda: random.choice([-1, 1, 5, 7, 8]),
     "prefixpercent": 5,
     "progress_reports": 0,
@@ -804,8 +805,7 @@ def blackbox_crash_main(args, unknown_args):
     # We should run the test one more time with VerifyOnly setup and no-timeout
     # Only do this if the tests are not failed for total-duration
     print("Running final time for verification")
-    ops_count = max(cmd_params.get("reopen", 0), 1)
-    cmd_params.update({"ops_per_thread": ops_count})
+    cmd_params.update({"post_verification_only": 1})
     cmd = gen_cmd(
         dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
     )


### PR DESCRIPTION
In Blackbox tests db_stress command always run with timeout. Timeout can happen during validation, leaving some of the keys not checked. This commit solves this problem in two steps. First it introduces a new Flag to run only post-verification step (skipping pre-verification and OperateDB) which is false by default. Second, at the end of the blackbox testing it executes db_stress for a final time with post_verification_only flag is set to true to ensure end to end verification is executed at least once.

This is a follow up PR of this: https://github.com/facebook/rocksdb/pull/11592