### PR TITLE
add exe and script path  check

### DIFF
--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -6,6 +6,7 @@
 EXIT_INVALID_ARGS=1
 EXIT_NOT_COMPACTION_TEST=2
 EXIT_UNKNOWN_JOB=3
+EXIT_INVALID_PATH=4
 
 # Size Constants
 K=1024
@@ -113,6 +114,11 @@ if [[ "$bench_cmd" == "--help" ]]; then
 fi
 
 job_id=${JOB_ID}
+
+if [ ! -x ./db_bench ]; then
+  echo "./db_bench not found. Please make sure it exists in the current directory."
+  exit $EXIT_INVALID_PATH
+fi
 
 # Make it easier to run only the compaction test. Getting valid data requires
 # a number of iterations and having an ability to run the test separately from

--- a/tools/run_blob_bench.sh
+++ b/tools/run_blob_bench.sh
@@ -19,6 +19,7 @@
 
 # Exit Codes
 EXIT_INVALID_ARGS=1
+EXIT_INVALID_PATH=2
 
 # Size constants
 K=1024
@@ -72,6 +73,11 @@ if [ $# -ge 1 ]; then
   else
     exit $EXIT_INVALID_ARGS
   fi
+fi
+
+if [ ! -f tools/benchmark.sh ]; then
+  echo "tools/benchmark.sh not found"
+  exit $EXIT_INVALID_PATH
 fi
 
 # shellcheck disable=SC2153


### PR DESCRIPTION
Add path existence check in the script to avoid script running even when db_bench executable does not exist or relative path is not right. 