### PR TITLE
add a missing include

### DIFF
--- a/util/single_thread_executor.h
+++ b/util/single_thread_executor.h
@@ -8,6 +8,7 @@
 
 #if USE_COROUTINES
 #include <atomic>
+#include <queue>
 
 #include "folly/CPortability.h"
 #include "folly/CppAttributes.h"


### PR DESCRIPTION
Summary: <queue> must be included to use std::queue.

Differential Revision: D47562433

