### PR TITLE
Add jni Support for API CreateColumnFamilyWithImport

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -33,7 +33,9 @@ set(JNI_NATIVE_SOURCES
         rocksjni/env_options.cc
         rocksjni/event_listener.cc
         rocksjni/event_listener_jnicallback.cc
+        rocksjni/export_import_files_metadatajni.cc
         rocksjni/filter.cc
+        rocksjni/import_column_family_options.cc
         rocksjni/ingest_external_file_options.cc
         rocksjni/iterator.cc
         rocksjni/jnicallback.cc
@@ -149,6 +151,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/EnvOptions.java
   src/main/java/org/rocksdb/EventListener.java
   src/main/java/org/rocksdb/Experimental.java
+  src/main/java/org/rocksdb/ExportImportFilesMetaData.java
   src/main/java/org/rocksdb/ExternalFileIngestionInfo.java
   src/main/java/org/rocksdb/Filter.java
   src/main/java/org/rocksdb/FileOperationInfo.java
@@ -160,6 +163,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/HistogramData.java
   src/main/java/org/rocksdb/HistogramType.java
   src/main/java/org/rocksdb/Holder.java
+  src/main/java/org/rocksdb/ImportColumnFamilyOptions.java
   src/main/java/org/rocksdb/IndexShorteningMode.java
   src/main/java/org/rocksdb/IndexType.java
   src/main/java/org/rocksdb/InfoLogLevel.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -139,6 +139,7 @@ JAVA_TESTS = \
 	org.rocksdb.util.JNIComparatorTest\
 	org.rocksdb.FilterTest\
 	org.rocksdb.FlushTest\
+	org.rocksdb.ImportColumnFamilyTest\
 	org.rocksdb.InfoLogLevelTest\
 	org.rocksdb.KeyMayExistTest\
 	org.rocksdb.ConcurrentTaskLimiterTest\

--- a/java/rocksjni/checkpoint.cc
+++ b/java/rocksjni/checkpoint.cc
@@ -75,13 +75,13 @@ void Java_org_rocksdb_Checkpoint_createCheckpoint(JNIEnv* env, jobject /*jobj*/,
  * Method:    exportColumnFamily
  * Signature: (JJLjava/lang/String;)Lorg/rocksdb/ExportImportFilesMetaData;
  */
-jobject Java_org_rocksdb_Checkpoint_exportColumnFamily(
+jlong Java_org_rocksdb_Checkpoint_exportColumnFamily(
     JNIEnv* env, jobject /*jobj*/, jlong jcheckpoint_handle,
     jlong jcolumn_family_handle, jstring jexport_path) {
   const char* export_path = env->GetStringUTFChars(jexport_path, 0);
   if (export_path == nullptr) {
     // exception thrown: OutOfMemoryError
-    return nullptr;
+    return 0;
   }
 
   auto* checkpoint =
@@ -102,11 +102,5 @@ jobject Java_org_rocksdb_Checkpoint_exportColumnFamily(
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
   }
 
-  jobject jexport_import_files_meta_data = nullptr;
-  if (metadata != nullptr) {
-    jexport_import_files_meta_data =
-        ROCKSDB_NAMESPACE::ExportImportFilesMetaDataJni::
-            fromCppExportImportFilesMetaData(env, metadata);
-  }
-  return jexport_import_files_meta_data;
+  return GET_CPLUSPLUS_POINTER(metadata);
 }

--- a/java/rocksjni/export_import_files_metadatajni.cc
+++ b/java/rocksjni/export_import_files_metadatajni.cc
@@ -1,0 +1,133 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "include/org_rocksdb_ExportImportFilesMetaData.h"
+#include "include/org_rocksdb_LiveFileMetaData.h"
+#include "rocksjni/portal.h"
+
+/*
+ * Class:     org_rocksdb_ExportImportFilesMetaData
+ * Method:    newExportImportFilesMetaDataHandle
+ * Signature: ([BI[J)J
+ */
+jlong Java_org_rocksdb_ExportImportFilesMetaData_newExportImportFilesMetaDataHandle(
+    JNIEnv* env, jobject, jbyteArray j_db_comparator_name,
+    jint j_db_comparator_name_len, jlongArray j_live_file_meta_data_array) {
+  std::string db_comparator_name;
+  jboolean has_exception = JNI_FALSE;
+
+  if (j_db_comparator_name_len > 0) {
+    db_comparator_name = ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
+        env, j_db_comparator_name, j_db_comparator_name_len,
+        [](const char* str, const size_t len) { return std::string(str, len); },
+        &has_exception);
+    if (has_exception == JNI_TRUE) {
+      // exception occurred
+      return 0;
+    }
+  }
+
+  std::vector<ROCKSDB_NAMESPACE::LiveFileMetaData> live_file_metas;
+  jlong* ptr_live_file_meta_data_array =
+      env->GetLongArrayElements(j_live_file_meta_data_array, nullptr);
+  if (ptr_live_file_meta_data_array == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return 0;
+  }
+  const jsize array_size = env->GetArrayLength(j_live_file_meta_data_array);
+  for (jsize i = 0; i < array_size; ++i) {
+    auto* ptr_level_file_meta =
+        reinterpret_cast<ROCKSDB_NAMESPACE::LiveFileMetaData*>(
+            ptr_live_file_meta_data_array[i]);
+    live_file_metas.push_back(*ptr_level_file_meta);
+  }
+
+  env->ReleaseLongArrayElements(j_live_file_meta_data_array,
+                                ptr_live_file_meta_data_array, JNI_ABORT);
+  auto* export_import_files_meta_data =
+      new ROCKSDB_NAMESPACE::ExportImportFilesMetaData;
+  export_import_files_meta_data->db_comparator_name = db_comparator_name;
+  export_import_files_meta_data->files = live_file_metas;
+  return GET_CPLUSPLUS_POINTER(export_import_files_meta_data);
+}
+
+/*
+ * Class:     org_rocksdb_LiveFileMetaData
+ * Method:    newLiveFileMetaDataHandle
+ * Signature: ([BIILjava/lang/String;Ljava/lang/String;JJJ[BI[BIJZJJ)J
+ */
+jlong Java_org_rocksdb_LiveFileMetaData_newLiveFileMetaDataHandle(
+    JNIEnv* env, jobject, jbyteArray j_column_family_name,
+    jint j_column_family_name_len, jint j_level, jstring j_file_name,
+    jstring j_path, jlong j_size, jlong j_smallest_seqno, jlong j_largest_seqno,
+    jbyteArray j_smallest_key, jint j_smallest_key_len,
+    jbyteArray j_largest_key, jint j_largest_key_len, jlong j_num_read_sampled,
+    jboolean j_being_compacted, jlong j_num_entries, jlong j_num_deletions) {
+  std::string column_family_name;
+  jboolean has_exception = JNI_FALSE;
+
+  if (j_column_family_name_len > 0) {
+    column_family_name = ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
+        env, j_column_family_name, j_column_family_name_len,
+        [](const char* str, const size_t len) { return std::string(str, len); },
+        &has_exception);
+    if (has_exception == JNI_TRUE) {
+      // exception occurred
+      return 0;
+    }
+  }
+
+  const char* file_name = env->GetStringUTFChars(j_file_name, nullptr);
+  if (file_name == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return 0;
+  }
+
+  const char* path = env->GetStringUTFChars(j_path, nullptr);
+  if (path == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return 0;
+  }
+
+  std::string smallest_key;
+  if (j_smallest_key_len > 0) {
+    smallest_key = ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
+        env, j_smallest_key, j_smallest_key_len,
+        [](const char* str, const size_t len) { return std::string(str, len); },
+        &has_exception);
+    if (has_exception == JNI_TRUE) {
+      // exception occurred
+      return 0;
+    }
+  }
+
+  std::string largest_key;
+  if (j_largest_key_len > 0) {
+    largest_key = ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
+        env, j_largest_key, j_largest_key_len,
+        [](const char* str, const size_t len) { return std::string(str, len); },
+        &has_exception);
+    if (has_exception == JNI_TRUE) {
+      // exception occurred
+      return 0;
+    }
+  }
+  auto* live_file_meta = new ROCKSDB_NAMESPACE::LiveFileMetaData;
+  live_file_meta->column_family_name = column_family_name;
+  live_file_meta->level = static_cast<int>(j_level);
+  live_file_meta->db_path = path;
+  live_file_meta->name = file_name;
+  live_file_meta->size = j_size;
+  live_file_meta->smallest_seqno = j_smallest_seqno;
+  live_file_meta->largest_seqno = j_largest_seqno;
+  live_file_meta->smallestkey = smallest_key;
+  live_file_meta->largestkey = largest_key;
+  live_file_meta->num_reads_sampled = j_num_read_sampled;
+  live_file_meta->being_compacted = j_being_compacted;
+  live_file_meta->num_entries = j_num_entries;
+  live_file_meta->num_deletions = j_num_deletions;
+  return GET_CPLUSPLUS_POINTER(live_file_meta);
+}

--- a/java/rocksjni/export_import_files_metadatajni.cc
+++ b/java/rocksjni/export_import_files_metadatajni.cc
@@ -10,124 +10,13 @@
 
 /*
  * Class:     org_rocksdb_ExportImportFilesMetaData
- * Method:    newExportImportFilesMetaDataHandle
- * Signature: ([BI[J)J
+ * Method:    disposeInternal
+ * Signature: (J)V
  */
-jlong Java_org_rocksdb_ExportImportFilesMetaData_newExportImportFilesMetaDataHandle(
-    JNIEnv* env, jobject, jbyteArray j_db_comparator_name,
-    jint j_db_comparator_name_len, jlongArray j_live_file_meta_data_array) {
-  std::string db_comparator_name;
-  jboolean has_exception = JNI_FALSE;
-
-  if (j_db_comparator_name_len > 0) {
-    db_comparator_name = ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
-        env, j_db_comparator_name, j_db_comparator_name_len,
-        [](const char* str, const size_t len) { return std::string(str, len); },
-        &has_exception);
-    if (has_exception == JNI_TRUE) {
-      // exception occurred
-      return 0;
-    }
-  }
-
-  std::vector<ROCKSDB_NAMESPACE::LiveFileMetaData> live_file_metas;
-  jlong* ptr_live_file_meta_data_array =
-      env->GetLongArrayElements(j_live_file_meta_data_array, nullptr);
-  if (ptr_live_file_meta_data_array == nullptr) {
-    // exception thrown: OutOfMemoryError
-    return 0;
-  }
-  const jsize array_size = env->GetArrayLength(j_live_file_meta_data_array);
-  for (jsize i = 0; i < array_size; ++i) {
-    auto* ptr_level_file_meta =
-        reinterpret_cast<ROCKSDB_NAMESPACE::LiveFileMetaData*>(
-            ptr_live_file_meta_data_array[i]);
-    live_file_metas.push_back(*ptr_level_file_meta);
-  }
-
-  env->ReleaseLongArrayElements(j_live_file_meta_data_array,
-                                ptr_live_file_meta_data_array, JNI_ABORT);
-  auto* export_import_files_meta_data =
-      new ROCKSDB_NAMESPACE::ExportImportFilesMetaData;
-  export_import_files_meta_data->db_comparator_name = db_comparator_name;
-  export_import_files_meta_data->files = live_file_metas;
-  return GET_CPLUSPLUS_POINTER(export_import_files_meta_data);
-}
-
-/*
- * Class:     org_rocksdb_LiveFileMetaData
- * Method:    newLiveFileMetaDataHandle
- * Signature: ([BIILjava/lang/String;Ljava/lang/String;JJJ[BI[BIJZJJ)J
- */
-jlong Java_org_rocksdb_LiveFileMetaData_newLiveFileMetaDataHandle(
-    JNIEnv* env, jobject, jbyteArray j_column_family_name,
-    jint j_column_family_name_len, jint j_level, jstring j_file_name,
-    jstring j_path, jlong j_size, jlong j_smallest_seqno, jlong j_largest_seqno,
-    jbyteArray j_smallest_key, jint j_smallest_key_len,
-    jbyteArray j_largest_key, jint j_largest_key_len, jlong j_num_read_sampled,
-    jboolean j_being_compacted, jlong j_num_entries, jlong j_num_deletions) {
-  std::string column_family_name;
-  jboolean has_exception = JNI_FALSE;
-
-  if (j_column_family_name_len > 0) {
-    column_family_name = ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
-        env, j_column_family_name, j_column_family_name_len,
-        [](const char* str, const size_t len) { return std::string(str, len); },
-        &has_exception);
-    if (has_exception == JNI_TRUE) {
-      // exception occurred
-      return 0;
-    }
-  }
-
-  const char* file_name = env->GetStringUTFChars(j_file_name, nullptr);
-  if (file_name == nullptr) {
-    // exception thrown: OutOfMemoryError
-    return 0;
-  }
-
-  const char* path = env->GetStringUTFChars(j_path, nullptr);
-  if (path == nullptr) {
-    // exception thrown: OutOfMemoryError
-    return 0;
-  }
-
-  std::string smallest_key;
-  if (j_smallest_key_len > 0) {
-    smallest_key = ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
-        env, j_smallest_key, j_smallest_key_len,
-        [](const char* str, const size_t len) { return std::string(str, len); },
-        &has_exception);
-    if (has_exception == JNI_TRUE) {
-      // exception occurred
-      return 0;
-    }
-  }
-
-  std::string largest_key;
-  if (j_largest_key_len > 0) {
-    largest_key = ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
-        env, j_largest_key, j_largest_key_len,
-        [](const char* str, const size_t len) { return std::string(str, len); },
-        &has_exception);
-    if (has_exception == JNI_TRUE) {
-      // exception occurred
-      return 0;
-    }
-  }
-  auto* live_file_meta = new ROCKSDB_NAMESPACE::LiveFileMetaData;
-  live_file_meta->column_family_name = column_family_name;
-  live_file_meta->level = static_cast<int>(j_level);
-  live_file_meta->db_path = path;
-  live_file_meta->name = file_name;
-  live_file_meta->size = j_size;
-  live_file_meta->smallest_seqno = j_smallest_seqno;
-  live_file_meta->largest_seqno = j_largest_seqno;
-  live_file_meta->smallestkey = smallest_key;
-  live_file_meta->largestkey = largest_key;
-  live_file_meta->num_reads_sampled = j_num_read_sampled;
-  live_file_meta->being_compacted = j_being_compacted;
-  live_file_meta->num_entries = j_num_entries;
-  live_file_meta->num_deletions = j_num_deletions;
-  return GET_CPLUSPLUS_POINTER(live_file_meta);
+void Java_org_rocksdb_ExportImportFilesMetaData_disposeInternal(
+    JNIEnv* /*env*/, jobject /*jopt*/, jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ExportImportFilesMetaData*>(jhandle);
+  assert(metadata != nullptr);
+  delete metadata;
 }

--- a/java/rocksjni/import_column_family_options.cc
+++ b/java/rocksjni/import_column_family_options.cc
@@ -1,0 +1,59 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <jni.h>
+
+#include "include/org_rocksdb_ImportColumnFamilyOptions.h"
+#include "rocksdb/options.h"
+#include "rocksjni/cplusplus_to_java_convert.h"
+
+/*
+ * Class:     org_rocksdb_ImportColumnFamilyOptions
+ * Method:    newImportColumnFamilyOptions
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_ImportColumnFamilyOptions_newImportColumnFamilyOptions(
+    JNIEnv *, jclass) {
+  ROCKSDB_NAMESPACE::ImportColumnFamilyOptions *opts =
+      new ROCKSDB_NAMESPACE::ImportColumnFamilyOptions();
+  return GET_CPLUSPLUS_POINTER(opts);
+}
+
+/*
+ * Class:     org_rocksdb_ImportColumnFamilyOptions
+ * Method:    setMoveFiles
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_ImportColumnFamilyOptions_setMoveFiles(
+    JNIEnv *, jobject, jlong jhandle, jboolean jmove_files) {
+  auto *options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ImportColumnFamilyOptions *>(jhandle);
+  options->move_files = static_cast<bool>(jmove_files);
+}
+
+/*
+ * Class:     org_rocksdb_ImportColumnFamilyOptions
+ * Method:    moveFiles
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_ImportColumnFamilyOptions_moveFiles(JNIEnv *, jobject,
+                                                              jlong jhandle) {
+  auto *options =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ImportColumnFamilyOptions *>(jhandle);
+  return static_cast<jboolean>(options->move_files);
+}
+
+/*
+ * Class:     org_rocksdb_ImportColumnFamilyOptions
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_ImportColumnFamilyOptions_disposeInternal(JNIEnv *,
+                                                                jobject,
+                                                                jlong jhandle) {
+  delete reinterpret_cast<ROCKSDB_NAMESPACE::ImportColumnFamilyOptions *>(
+      jhandle);
+}

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -7573,38 +7573,6 @@ class LevelMetaDataJni : public JavaClass {
   }
 };
 
-class ExportImportFilesMetaDataJni : public JavaClass {
- public:
-  /**
-   * Create a new Java org.rocksdb.ExportImportFilesMetaData object.
-   *
-   * @param env A pointer to the Java environment
-   * @param export_import_files_meta_data A Cpp export import files meta data
-   * object
-   *
-   * @return A reference to a Java org.rocksdb.ExportImportFilesMetaData object,
-   * or nullptr if an an exception occurs
-   */
-  static jobject fromCppExportImportFilesMetaData(
-      JNIEnv* env, ROCKSDB_NAMESPACE::ExportImportFilesMetaData*
-                       export_import_files_meta_data) {
-    jclass jclazz = getJClass(env);
-    assert(jclazz != nullptr);
-    static jmethodID ctor = getConstructorMethodId(env, jclazz);
-    assert(ctor != nullptr);
-    return env->NewObject(
-        jclazz, ctor, reinterpret_cast<jlong>(export_import_files_meta_data));
-  }
-
-  static jmethodID getConstructorMethodId(JNIEnv* env, jclass clazz) {
-    return env->GetMethodID(clazz, "<init>", "(J)V");
-  }
-
-  static jclass getJClass(JNIEnv* env) {
-    return JavaClass::getJClass(env, "org/rocksdb/ExportImportFilesMetaData");
-  }
-};
-
 class ColumnFamilyMetaDataJni : public JavaClass {
  public:
   /**

--- a/java/src/main/java/org/rocksdb/Checkpoint.java
+++ b/java/src/main/java/org/rocksdb/Checkpoint.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import java.util.*;
+
 /**
  * Provides Checkpoint functionality. Checkpoints
  * provide persistent snapshots of RocksDB databases.
@@ -50,6 +52,11 @@ public class Checkpoint extends RocksObject {
     createCheckpoint(nativeHandle_, checkpointPath);
   }
 
+  public ExportImportFilesMetaData exportColumnFamily(final ColumnFamilyHandle columnFamilyHandle,
+      final String exportPath) throws RocksDBException {
+    return exportColumnFamily(nativeHandle_, columnFamilyHandle.nativeHandle_, exportPath);
+  }
+
   private Checkpoint(final RocksDB db) {
     super(newCheckpoint(db.nativeHandle_));
   }
@@ -59,4 +66,7 @@ public class Checkpoint extends RocksObject {
 
   private native void createCheckpoint(long handle, String checkpointPath)
       throws RocksDBException;
+
+  private native ExportImportFilesMetaData exportColumnFamily(
+      long handle, long columnFamilyHandle, String exportPath) throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/Checkpoint.java
+++ b/java/src/main/java/org/rocksdb/Checkpoint.java
@@ -54,7 +54,8 @@ public class Checkpoint extends RocksObject {
 
   public ExportImportFilesMetaData exportColumnFamily(final ColumnFamilyHandle columnFamilyHandle,
       final String exportPath) throws RocksDBException {
-    return exportColumnFamily(nativeHandle_, columnFamilyHandle.nativeHandle_, exportPath);
+    return new ExportImportFilesMetaData(
+        exportColumnFamily(nativeHandle_, columnFamilyHandle.nativeHandle_, exportPath));
   }
 
   private Checkpoint(final RocksDB db) {
@@ -67,6 +68,6 @@ public class Checkpoint extends RocksObject {
   private native void createCheckpoint(long handle, String checkpointPath)
       throws RocksDBException;
 
-  private native ExportImportFilesMetaData exportColumnFamily(
-      long handle, long columnFamilyHandle, String exportPath) throws RocksDBException;
+  private native long exportColumnFamily(long handle, long columnFamilyHandle, String exportPath)
+      throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/Checkpoint.java
+++ b/java/src/main/java/org/rocksdb/Checkpoint.java
@@ -5,8 +5,6 @@
 
 package org.rocksdb;
 
-import java.util.*;
-
 /**
  * Provides Checkpoint functionality. Checkpoints
  * provide persistent snapshots of RocksDB databases.

--- a/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
+++ b/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
@@ -1,0 +1,56 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The metadata that describes a column family.
+ */
+public class ExportImportFilesMetaData {
+  private final byte[] dbComparatorName;
+  private final LiveFileMetaData[] files;
+
+  /**
+   * Called from JNI C++
+   */
+  public ExportImportFilesMetaData(final byte[] dbComparatorName, final LiveFileMetaData[] files) {
+    this.dbComparatorName = dbComparatorName;
+    this.files = files;
+  }
+
+  /**
+   * The name of the db comparator.
+   *
+   * @return the dbComparatorName
+   */
+  public byte[] dbComparatorName() {
+    return dbComparatorName;
+  }
+
+  /**
+   * The metadata of all files in this column family.
+   *
+   * @return the levels files
+   */
+  public List<LiveFileMetaData> files() {
+    return Arrays.asList(files);
+  }
+
+  public long newExportImportFilesMetaDataHandle() {
+    final long[] liveFileMetaDataHandles = new long[files.length];
+    for (int i = 0; i < files.length; i++) {
+      liveFileMetaDataHandles[i] = files[i].newLiveFileMetaDataHandle();
+    }
+    return newExportImportFilesMetaDataHandle(
+        dbComparatorName, dbComparatorName.length, liveFileMetaDataHandles);
+  }
+
+  private native long newExportImportFilesMetaDataHandle(final byte[] dbComparatorName,
+      final int dbComparatorNameLen, final long[] liveFileMetaDataHandles);
+}

--- a/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
+++ b/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
@@ -15,8 +15,6 @@ import java.util.List;
 public class ExportImportFilesMetaData extends RocksObject {
   private ExportImportFilesMetaData(final long nativeHandle) {
     super(nativeHandle);
-    // We do not own the native object!
-    disOwnNativeHandle();
   }
 
   @Override protected native void disposeInternal(final long handle);

--- a/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
+++ b/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
@@ -10,7 +10,7 @@ package org.rocksdb;
  * The metadata that describes a column family.
  */
 public class ExportImportFilesMetaData extends RocksObject {
-  public ExportImportFilesMetaData(final long nativeHandle) {
+  ExportImportFilesMetaData(final long nativeHandle) {
     super(nativeHandle);
   }
 

--- a/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
+++ b/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
@@ -12,45 +12,12 @@ import java.util.List;
 /**
  * The metadata that describes a column family.
  */
-public class ExportImportFilesMetaData {
-  private final byte[] dbComparatorName;
-  private final LiveFileMetaData[] files;
-
-  /**
-   * Called from JNI C++
-   */
-  public ExportImportFilesMetaData(final byte[] dbComparatorName, final LiveFileMetaData[] files) {
-    this.dbComparatorName = dbComparatorName;
-    this.files = files;
+public class ExportImportFilesMetaData extends RocksObject {
+  private ExportImportFilesMetaData(final long nativeHandle) {
+    super(nativeHandle);
+    // We do not own the native object!
+    disOwnNativeHandle();
   }
 
-  /**
-   * The name of the db comparator.
-   *
-   * @return the dbComparatorName
-   */
-  public byte[] dbComparatorName() {
-    return dbComparatorName;
-  }
-
-  /**
-   * The metadata of all files in this column family.
-   *
-   * @return the levels files
-   */
-  public List<LiveFileMetaData> files() {
-    return Arrays.asList(files);
-  }
-
-  public long newExportImportFilesMetaDataHandle() {
-    final long[] liveFileMetaDataHandles = new long[files.length];
-    for (int i = 0; i < files.length; i++) {
-      liveFileMetaDataHandles[i] = files[i].newLiveFileMetaDataHandle();
-    }
-    return newExportImportFilesMetaDataHandle(
-        dbComparatorName, dbComparatorName.length, liveFileMetaDataHandles);
-  }
-
-  private native long newExportImportFilesMetaDataHandle(final byte[] dbComparatorName,
-      final int dbComparatorNameLen, final long[] liveFileMetaDataHandles);
+  @Override protected native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
+++ b/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
@@ -6,14 +6,11 @@
 
 package org.rocksdb;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
  * The metadata that describes a column family.
  */
 public class ExportImportFilesMetaData extends RocksObject {
-  private ExportImportFilesMetaData(final long nativeHandle) {
+  public ExportImportFilesMetaData(final long nativeHandle) {
     super(nativeHandle);
   }
 

--- a/java/src/main/java/org/rocksdb/ImportColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ImportColumnFamilyOptions.java
@@ -1,0 +1,46 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * ImportColumnFamilyOptions is used by ImportColumnFamily()
+ * <p>
+ * Note that dispose() must be called before this instance become out-of-scope
+ * to release the allocated memory in c++.
+ *
+ */
+public class ImportColumnFamilyOptions extends RocksObject {
+  public ImportColumnFamilyOptions() {
+    super(newImportColumnFamilyOptions());
+  }
+
+  /**
+   * Can be set to true to move the files instead of copying them.
+   *
+   * @return true if files will be moved
+   */
+  public boolean moveFiles() {
+    return moveFiles(nativeHandle_);
+  }
+
+  /**
+   * Can be set to true to move the files instead of copying them.
+   *
+   * @param moveFiles true if files should be moved instead of copied
+   *
+   * @return the reference to the current IngestExternalFileOptions.
+   */
+  public ImportColumnFamilyOptions setMoveFiles(final boolean moveFiles) {
+    setMoveFiles(nativeHandle_, moveFiles);
+    return this;
+  }
+
+  private static native long newImportColumnFamilyOptions();
+  private native boolean moveFiles(final long handle);
+  private native void setMoveFiles(final long handle, final boolean move_files);
+  @Override protected final native void disposeInternal(final long handle);
+}

--- a/java/src/main/java/org/rocksdb/ImportColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ImportColumnFamilyOptions.java
@@ -7,11 +7,9 @@
 package org.rocksdb;
 
 /**
- * ImportColumnFamilyOptions is used by ImportColumnFamily()
- * <p>
- * Note that dispose() must be called before this instance become out-of-scope
- * to release the allocated memory in c++.
- *
+ * ImportColumnFamilyOptions is used by
+ * {@link RocksDB#createColumnFamilyWithImport(ColumnFamilyDescriptor, ImportColumnFamilyOptions,
+ * ExportImportFilesMetaData)}.
  */
 public class ImportColumnFamilyOptions extends RocksObject {
   public ImportColumnFamilyOptions() {

--- a/java/src/main/java/org/rocksdb/LiveFileMetaData.java
+++ b/java/src/main/java/org/rocksdb/LiveFileMetaData.java
@@ -52,4 +52,18 @@ public class LiveFileMetaData extends SstFileMetaData {
   public int level() {
     return level;
   }
+
+  public long newLiveFileMetaDataHandle() {
+    return newLiveFileMetaDataHandle(columnFamilyName(), columnFamilyName().length, level(),
+        fileName(), path(), size(), smallestSeqno(), largestSeqno(), smallestKey(),
+        smallestKey().length, largestKey(), largestKey().length, numReadsSampled(),
+        beingCompacted(), numEntries(), numDeletions());
+  }
+
+  private native long newLiveFileMetaDataHandle(final byte[] columnFamilyName,
+      final int columnFamilyNameLength, final int level, final String fileName, final String path,
+      final long size, final long smallestSeqno, final long largestSeqno, final byte[] smallestKey,
+      final int smallestKeyLength, final byte[] largestKey, final int largestKeyLength,
+      final long numReadsSampled, final boolean beingCompacted, final long numEntries,
+      final long numDeletions);
 }

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -761,18 +761,6 @@ public class RocksDB extends RocksObject {
    * @throws RocksDBException thrown if error happens in underlying
    *    native library.
    */
-  /**
-   * Creates a new column family with the name columnFamilyName and
-   * import external SST files specified in `metadata` allocates a
-   * ColumnFamilyHandle within an internal structure.
-   * The ColumnFamilyHandle is automatically disposed with DB disposal.
-   *
-   * @param columnFamilyDescriptor column family to be created.
-   * @return {@link org.rocksdb.ColumnFamilyHandle} instance.
-   *
-   * @throws RocksDBException thrown if error happens in underlying
-   *    native library.
-   */
   public ColumnFamilyHandle createColumnFamilyWithImport(
       final ColumnFamilyDescriptor columnFamilyDescriptor,
       final ImportColumnFamilyOptions importColumnFamilyOptions,

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -776,15 +776,15 @@ public class RocksDB extends RocksObject {
       final ImportColumnFamilyOptions importColumnFamilyOptions,
       final List<ExportImportFilesMetaData> metadatas) throws RocksDBException {
     final int metadataNum = metadatas.size();
-    final long[] metadataHandeList = new long[metadataNum];
+    final long[] metadataHandleList = new long[metadataNum];
     for (int i = 0; i < metadataNum; i++) {
-      metadataHandeList[i] = metadatas.get(i).getNativeHandle();
+      metadataHandleList[i] = metadatas.get(i).getNativeHandle();
     }
     final ColumnFamilyHandle columnFamilyHandle = new ColumnFamilyHandle(this,
         createColumnFamilyWithImport(nativeHandle_, columnFamilyDescriptor.getName(),
             columnFamilyDescriptor.getName().length,
             columnFamilyDescriptor.getOptions().nativeHandle_,
-            importColumnFamilyOptions.nativeHandle_, metadataHandeList));
+            importColumnFamilyOptions.nativeHandle_, metadataHandleList));
     ownedColumnFamilyHandles.add(columnFamilyHandle);
     return columnFamilyHandle;
   }
@@ -4436,7 +4436,8 @@ public class RocksDB extends RocksObject {
       throws RocksDBException;
   private native long createColumnFamilyWithImport(final long handle, final byte[] columnFamilyName,
       final int columnFamilyNamelen, final long columnFamilyOptions,
-      final long importColumnFamilyOptions, final long[] metadataHandeList) throws RocksDBException;
+      final long importColumnFamilyOptions, final long[] metadataHandleList)
+      throws RocksDBException;
   private native void dropColumnFamily(
       final long handle, final long cfHandle) throws RocksDBException;
   private native void dropColumnFamilies(final long handle,

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -790,7 +790,7 @@ public class RocksDB extends RocksObject {
     final int metadataNum = metadatas.size();
     final long[] metadataHandeList = new long[metadataNum];
     for (int i = 0; i < metadataNum; i++) {
-      metadataHandeList[i] = metadatas.get(i).newExportImportFilesMetaDataHandle();
+      metadataHandeList[i] = metadatas.get(i).getNativeHandle();
     }
     final ColumnFamilyHandle columnFamilyHandle = new ColumnFamilyHandle(this,
         createColumnFamilyWithImport(nativeHandle_, columnFamilyDescriptor.getName(),

--- a/java/src/test/java/org/rocksdb/CheckPointTest.java
+++ b/java/src/test/java/org/rocksdb/CheckPointTest.java
@@ -66,16 +66,10 @@ public class CheckPointTest {
           ExportImportFilesMetaData metadata1 =
               checkpoint.exportColumnFamily(db.getDefaultColumnFamily(),
                   checkpointFolder.getRoot().getAbsolutePath() + "/export_column_family1");
-          assertThat(metadata1.files().size()).isEqualTo(1);
-          assertThat(metadata1.dbComparatorName())
-              .isEqualTo("leveldb.BytewiseComparator".getBytes());
           db.put("key2".getBytes(), "value2".getBytes());
           ExportImportFilesMetaData metadata2 =
               checkpoint.exportColumnFamily(db.getDefaultColumnFamily(),
                   checkpointFolder.getRoot().getAbsolutePath() + "/export_column_family2");
-          assertThat(metadata2.files().size()).isEqualTo(2);
-          assertThat(metadata2.dbComparatorName())
-              .isEqualTo("leveldb.BytewiseComparator".getBytes());
         }
       }
     }

--- a/java/src/test/java/org/rocksdb/ImportColumnFamilyTest.java
+++ b/java/src/test/java/org/rocksdb/ImportColumnFamilyTest.java
@@ -1,0 +1,96 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.util.BytewiseComparator;
+
+public class ImportColumnFamilyTest {
+  private static final String SST_FILE_NAME = "test.sst";
+  private static final String DB_DIRECTORY_NAME = "test_db";
+
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  @Rule public TemporaryFolder checkpointFolder = new TemporaryFolder();
+
+  @Test
+  public void testImportColumnFamily() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true)) {
+      try (final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+        db.put("key".getBytes(), "value".getBytes());
+        db.put("key1".getBytes(), "value1".getBytes());
+
+        try (final Checkpoint checkpoint = Checkpoint.create(db)) {
+          ExportImportFilesMetaData default_cf_metadata =
+              checkpoint.exportColumnFamily(db.getDefaultColumnFamily(),
+                  checkpointFolder.getRoot().getAbsolutePath() + "/default_cf_metadata");
+          ColumnFamilyDescriptor columnFamilyDescriptor =
+              new ColumnFamilyDescriptor("new_cf".getBytes());
+          ImportColumnFamilyOptions importColumnFamilyOptions = new ImportColumnFamilyOptions();
+          final ColumnFamilyHandle importCfHandle = db.createColumnFamilyWithImport(
+              columnFamilyDescriptor, importColumnFamilyOptions, default_cf_metadata);
+          assertThat(db.get(importCfHandle, "key".getBytes())).isEqualTo("value".getBytes());
+          assertThat(db.get(importCfHandle, "key1".getBytes())).isEqualTo("value1".getBytes());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void ImportMultiColumnFamilyTest() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true)) {
+      try (final RocksDB db1 = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath() + "db1");
+           final RocksDB db2 =
+               RocksDB.open(options, dbFolder.getRoot().getAbsolutePath() + "db2");) {
+        db1.put("key".getBytes(), "value".getBytes());
+        db1.put("key1".getBytes(), "value1".getBytes());
+        db2.put("key2".getBytes(), "value2".getBytes());
+        db2.put("key3".getBytes(), "value3".getBytes());
+        try (final Checkpoint checkpoint1 = Checkpoint.create(db1);
+             final Checkpoint checkpoint2 = Checkpoint.create(db2);) {
+          ExportImportFilesMetaData default_cf_metadata1 =
+              checkpoint1.exportColumnFamily(db1.getDefaultColumnFamily(),
+                  checkpointFolder.getRoot().getAbsolutePath() + "/default_cf_metadata1");
+          ExportImportFilesMetaData default_cf_metadata2 =
+              checkpoint2.exportColumnFamily(db2.getDefaultColumnFamily(),
+                  checkpointFolder.getRoot().getAbsolutePath() + "/default_cf_metadata2");
+
+          ColumnFamilyDescriptor columnFamilyDescriptor =
+              new ColumnFamilyDescriptor("new_cf".getBytes());
+          ImportColumnFamilyOptions importColumnFamilyOptions = new ImportColumnFamilyOptions();
+
+          List<ExportImportFilesMetaData> importMetaDatas = new ArrayList();
+          importMetaDatas.add(default_cf_metadata1);
+          importMetaDatas.add(default_cf_metadata2);
+
+          final ColumnFamilyHandle importCfHandle = db1.createColumnFamilyWithImport(
+              columnFamilyDescriptor, importColumnFamilyOptions, importMetaDatas);
+          assertThat(db1.get(importCfHandle, "key".getBytes())).isEqualTo("value".getBytes());
+          assertThat(db1.get(importCfHandle, "key1".getBytes())).isEqualTo("value1".getBytes());
+          assertThat(db1.get(importCfHandle, "key2".getBytes())).isEqualTo("value2".getBytes());
+          assertThat(db1.get(importCfHandle, "key3".getBytes())).isEqualTo("value3".getBytes());
+        }
+      }
+    }
+  }
+}

--- a/java/src/test/java/org/rocksdb/ImportColumnFamilyTest.java
+++ b/java/src/test/java/org/rocksdb/ImportColumnFamilyTest.java
@@ -40,13 +40,14 @@ public class ImportColumnFamilyTest {
         db.put("key".getBytes(), "value".getBytes());
         db.put("key1".getBytes(), "value1".getBytes());
 
-        try (final Checkpoint checkpoint = Checkpoint.create(db)) {
+        try (final Checkpoint checkpoint = Checkpoint.create(db);
+             final ImportColumnFamilyOptions importColumnFamilyOptions =
+                 new ImportColumnFamilyOptions()) {
           ExportImportFilesMetaData default_cf_metadata =
               checkpoint.exportColumnFamily(db.getDefaultColumnFamily(),
                   checkpointFolder.getRoot().getAbsolutePath() + "/default_cf_metadata");
           ColumnFamilyDescriptor columnFamilyDescriptor =
               new ColumnFamilyDescriptor("new_cf".getBytes());
-          ImportColumnFamilyOptions importColumnFamilyOptions = new ImportColumnFamilyOptions();
           final ColumnFamilyHandle importCfHandle = db.createColumnFamilyWithImport(
               columnFamilyDescriptor, importColumnFamilyOptions, default_cf_metadata);
           assertThat(db.get(importCfHandle, "key".getBytes())).isEqualTo("value".getBytes());
@@ -67,7 +68,9 @@ public class ImportColumnFamilyTest {
         db2.put("key2".getBytes(), "value2".getBytes());
         db2.put("key3".getBytes(), "value3".getBytes());
         try (final Checkpoint checkpoint1 = Checkpoint.create(db1);
-             final Checkpoint checkpoint2 = Checkpoint.create(db2);) {
+             final Checkpoint checkpoint2 = Checkpoint.create(db2);
+             final ImportColumnFamilyOptions importColumnFamilyOptions =
+                 new ImportColumnFamilyOptions()) {
           ExportImportFilesMetaData default_cf_metadata1 =
               checkpoint1.exportColumnFamily(db1.getDefaultColumnFamily(),
                   checkpointFolder.getRoot().getAbsolutePath() + "/default_cf_metadata1");
@@ -77,7 +80,6 @@ public class ImportColumnFamilyTest {
 
           ColumnFamilyDescriptor columnFamilyDescriptor =
               new ColumnFamilyDescriptor("new_cf".getBytes());
-          ImportColumnFamilyOptions importColumnFamilyOptions = new ImportColumnFamilyOptions();
 
           List<ExportImportFilesMetaData> importMetaDatas = new ArrayList();
           importMetaDatas.add(default_cf_metadata1);

--- a/src.mk
+++ b/src.mk
@@ -661,10 +661,12 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/compression_options.cc                        \
   java/rocksjni/concurrent_task_limiter.cc                    \
   java/rocksjni/config_options.cc                             \
+  java/rocksjni/export_import_files_metadatajni.cc            \
   java/rocksjni/env.cc                                        \
   java/rocksjni/env_options.cc                                \
   java/rocksjni/event_listener.cc                             \
   java/rocksjni/event_listener_jnicallback.cc                 \
+  java/rocksjni/import_column_family_options.cc               \
   java/rocksjni/ingest_external_file_options.cc               \
   java/rocksjni/filter.cc                                     \
   java/rocksjni/iterator.cc                                   \


### PR DESCRIPTION
- Add the following missing options to src/main/java/org/rocksdb/ImportColumnFamilyOptions.java and in java/rocksjni/import_column_family_options.cc in RocksJava.
- Add the struct to src/main/java/org/rocksdb/ExportImportFilesMetaData.java and in java/rocksjni/export_import_files_metadatajni.cc in RocksJava.
- Add New Java API `createColumnFamilyWithImport` to src/main/java/org/rocksdb/RocksDB.java 
- Add New Java API `exportColumnFamily` to src/main/java/org/rocksdb/Checkpoint.java


Test plan:
- added unit tests for exportColumnFamily in org.rocksdb.CheckpointTest
- added unit tests for createColumnFamilyWithImport to org.rocksdb.ImportColumnFamilyTest