### PR TITLE
Add a UDT comparator for ReverseBytewiseComparator to object library

### DIFF
--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -150,6 +150,16 @@ const Comparator* BytewiseComparatorWithU64TsWrapper() {
   return user_comparator;
 }
 
+const Comparator* ReverseBytewiseComparatorWithU64TsWrapper() {
+  ConfigOptions config_options;
+  const Comparator* user_comparator = nullptr;
+  Status s = Comparator::CreateFromString(
+      config_options, "rocksdb.ReverseBytewiseComparator.u64ts",
+      &user_comparator);
+  s.PermitUncheckedError();
+  return user_comparator;
+}
+
 void CorruptKeyType(InternalKey* ikey) {
   std::string keystr = ikey->Encode().ToString();
   keystr[keystr.size() - 8] = kTypeLogData;

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -132,6 +132,9 @@ extern const Comparator* Uint64Comparator();
 // A wrapper api for getting the ComparatorWithU64Ts<BytewiseComparator>
 extern const Comparator* BytewiseComparatorWithU64TsWrapper();
 
+// A wrapper api for getting the ComparatorWithU64Ts<ReverseBytewiseComparator>
+extern const Comparator* ReverseBytewiseComparatorWithU64TsWrapper();
+
 class StringSink : public FSWritableFile {
  public:
   std::string contents_;

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -316,24 +316,37 @@ const Comparator* BytewiseComparatorWithU64Ts() {
   return &comp_with_u64_ts;
 }
 
+const Comparator* ReverseBytewiseComparatorWithU64Ts() {
+  STATIC_AVOID_DESTRUCTION(
+      ComparatorWithU64TsImpl<ReverseBytewiseComparatorImpl>, comp_with_u64_ts);
+  return &comp_with_u64_ts;
+}
+
 static int RegisterBuiltinComparators(ObjectLibrary& library,
                                       const std::string& /*arg*/) {
   library.AddFactory<const Comparator>(
       BytewiseComparatorImpl::kClassName(),
       [](const std::string& /*uri*/,
-         std::unique_ptr<const Comparator>* /*guard */,
-         std::string* /* errmsg */) { return BytewiseComparator(); });
+         std::unique_ptr<const Comparator>* /*guard*/,
+         std::string* /*errmsg*/) { return BytewiseComparator(); });
   library.AddFactory<const Comparator>(
       ReverseBytewiseComparatorImpl::kClassName(),
       [](const std::string& /*uri*/,
-         std::unique_ptr<const Comparator>* /*guard */,
-         std::string* /* errmsg */) { return ReverseBytewiseComparator(); });
+         std::unique_ptr<const Comparator>* /*guard*/,
+         std::string* /*errmsg*/) { return ReverseBytewiseComparator(); });
   library.AddFactory<const Comparator>(
       ComparatorWithU64TsImpl<BytewiseComparatorImpl>::kClassName(),
       [](const std::string& /*uri*/,
-         std::unique_ptr<const Comparator>* /*guard */,
-         std::string* /* errmsg */) { return BytewiseComparatorWithU64Ts(); });
-  return 3;
+         std::unique_ptr<const Comparator>* /*guard*/,
+         std::string* /*errmsg*/) { return BytewiseComparatorWithU64Ts(); });
+  library.AddFactory<const Comparator>(
+      ComparatorWithU64TsImpl<ReverseBytewiseComparatorImpl>::kClassName(),
+      [](const std::string& /*uri*/,
+         std::unique_ptr<const Comparator>* /*guard*/,
+         std::string* /*errmsg*/) {
+        return ReverseBytewiseComparatorWithU64Ts();
+      });
+  return 4;
 }
 
 Status Comparator::CreateFromString(const ConfigOptions& config_options,
@@ -357,6 +370,9 @@ Status Comparator::CreateFromString(const ConfigOptions& config_options,
   } else if (id ==
              ComparatorWithU64TsImpl<BytewiseComparatorImpl>::kClassName()) {
     *result = BytewiseComparatorWithU64Ts();
+  } else if (id == ComparatorWithU64TsImpl<
+                       ReverseBytewiseComparatorImpl>::kClassName()) {
+    *result = ReverseBytewiseComparatorWithU64Ts();
   } else if (value.empty()) {
     // No Id and no options.  Clear the object
     *result = nullptr;

--- a/util/udt_util_test.cc
+++ b/util/udt_util_test.cc
@@ -356,8 +356,9 @@ TEST(ValidateUserDefinedTimestampsOptionsTest,
 
 TEST(ValidateUserDefinedTimestampsOptionsTest, DisableUserDefinedTimestamps) {
   bool mark_sst_files = false;
-  const Comparator* new_comparator = BytewiseComparator();
-  const Comparator* old_comparator = test::BytewiseComparatorWithU64TsWrapper();
+  const Comparator* new_comparator = ReverseBytewiseComparator();
+  const Comparator* old_comparator =
+      test::ReverseBytewiseComparatorWithU64TsWrapper();
   ASSERT_OK(ValidateUserDefinedTimestampsOptions(
       new_comparator, std::string(old_comparator->Name()),
       false /*new_persist_udt*/, false /*old_persist_udt*/, &mark_sst_files));


### PR DESCRIPTION
Add a built-in comparator that supports uint64_t style user-defined timestamps for ReverseBytewiseComparator.

Test plan:
Added a test wrapper for retrieving this comparator from registry and used it in this test:
`./udt_util_test`