### PR TITLE
Add bounds checking to WBWIIteratorImpl and respect bounds of ReadOptions in Transaction

### DIFF
--- a/unreleased_history/bug_fixes/fix_bounds_check_in_BaseDeltaIterator_and_Write(Un)PreparedTxn.md
+++ b/unreleased_history/bug_fixes/fix_bounds_check_in_BaseDeltaIterator_and_Write(Un)PreparedTxn.md
@@ -1,0 +1,1 @@
+Add bounds check in WBWIIteratorImpl and make BaseDeltaIterator, WriteUnpreparedTxn and WritePreparedTxn respect the upper bound and lower bound in ReadOption. See 11680.

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -79,6 +79,7 @@ INSTANTIATE_TEST_CASE_P(
 #endif  // !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)
 
 TEST_P(TransactionTest, TestUpperBoundUponDeletion) {
+  // Reproduction from the original bug report, 11606
   // This test does writes without snapshot validation, and then tries to create
   // iterator later, which is unsupported in write unprepared.
   if (txn_db_options.write_policy == WRITE_UNPREPARED) {
@@ -116,6 +117,10 @@ TEST_P(TransactionTest, TestUpperBoundUponDeletion) {
 }
 
 TEST_P(TransactionTest, TestTxnRespectBoundsInReadOption) {
+  if (txn_db_options.write_policy == WRITE_UNPREPARED) {
+    return;
+  }
+
   WriteOptions write_options;
 
   {
@@ -134,8 +139,8 @@ TEST_P(TransactionTest, TestTxnRespectBoundsInReadOption) {
   txn2->Put("c", "cc");
   txn2->Put("f", "ff");
 
-  //  base_iterator_:   b c   f
-  // delta_iterator_: a   c e f
+  // delta_iterator_:   b c   f
+  //  base_iterator_: a   c e f
   //
   // given range [c, f)
   // assert only {c, e} can be seen

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -80,7 +80,6 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(TransactionTest, TestTxnRespectBoundsInReadOption) {
   WriteOptions write_options;
-  ReadOptions read_options, snapshot_read_options;
   Status s;
 
   {
@@ -139,6 +138,9 @@ TEST_P(TransactionTest, TestTxnRespectBoundsInReadOption) {
   ASSERT_EQ("c", iter->key());
   iter->Prev();
   ASSERT_FALSE(iter->Valid());
+
+  delete ro.iterate_lower_bound;
+  delete ro.iterate_upper_bound;
 }
 
 TEST_P(TransactionTest, DoubleEmptyWrite) {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -126,18 +126,18 @@ TEST_P(TransactionTest, TestTxnRespectBoundsInReadOption) {
   {
     std::unique_ptr<Transaction> txn(db->BeginTransaction(write_options));
     // writes that should be observed by base_iterator_ in BaseDeltaIterator
-    txn->Put("a", "aa");
-    txn->Put("c", "cc");
-    txn->Put("e", "ee");
-    txn->Put("f", "ff");
+    ASSERT_OK(txn->Put("a", "aa"));
+    ASSERT_OK(txn->Put("c", "cc"));
+    ASSERT_OK(txn->Put("e", "ee"));
+    ASSERT_OK(txn->Put("f", "ff"));
     ASSERT_TRUE(txn->Commit().ok());
   }
 
   std::unique_ptr<Transaction> txn2(db->BeginTransaction(write_options));
   // writes that should be observed by delta_iterator_ in BaseDeltaIterator
-  txn2->Put("b", "bb");
-  txn2->Put("c", "cc");
-  txn2->Put("f", "ff");
+  ASSERT_OK(txn2->Put("b", "bb"));
+  ASSERT_OK(txn2->Put("c", "cc"));
+  ASSERT_OK(txn2->Put("f", "ff"));
 
   // delta_iterator_:   b c   f
   //  base_iterator_: a   c e f

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -80,7 +80,6 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(TransactionTest, TestTxnRespectBoundsInReadOption) {
   WriteOptions write_options;
-  Status s;
 
   {
     std::unique_ptr<Transaction> txn(db->BeginTransaction(write_options));

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -123,11 +123,7 @@ Status WritePreparedTxn::GetImpl(const ReadOptions& options,
 }
 
 Iterator* WritePreparedTxn::GetIterator(const ReadOptions& options) {
-  // Make sure to get iterator from WritePrepareTxnDB, not the root db.
-  Iterator* db_iter = wpt_db_->NewIterator(options);
-  assert(db_iter);
-
-  return write_batch_.NewIteratorWithBase(db_iter);
+  return GetIterator(options, wpt_db_->DefaultColumnFamily());
 }
 
 Iterator* WritePreparedTxn::GetIterator(const ReadOptions& options,
@@ -136,7 +132,7 @@ Iterator* WritePreparedTxn::GetIterator(const ReadOptions& options,
   Iterator* db_iter = wpt_db_->NewIterator(options, column_family);
   assert(db_iter);
 
-  return write_batch_.NewIteratorWithBase(column_family, db_iter);
+  return write_batch_.NewIteratorWithBase(column_family, db_iter, &options);
 }
 
 Status WritePreparedTxn::PrepareInternal() {

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -1037,7 +1037,8 @@ Iterator* WriteUnpreparedTxn::GetIterator(const ReadOptions& options,
   Iterator* db_iter = wupt_db_->NewIterator(options, column_family, this);
   assert(db_iter);
 
-  auto iter = write_batch_.NewIteratorWithBase(column_family, db_iter);
+  auto iter =
+      write_batch_.NewIteratorWithBase(column_family, db_iter, &options);
   active_iterators_.push_back(iter);
   iter->RegisterCleanup(CleanupWriteUnpreparedWBWIIterator, this, iter);
   return iter;

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -299,12 +299,20 @@ WBWIIterator* WriteBatchWithIndex::NewIterator(
 Iterator* WriteBatchWithIndex::NewIteratorWithBase(
     ColumnFamilyHandle* column_family, Iterator* base_iterator,
     const ReadOptions* read_options) {
-  auto wbwiii =
-      new WBWIIteratorImpl(GetColumnFamilyID(column_family), &(rep->skip_list),
-                           &rep->write_batch, &rep->comparator);
+  WBWIIteratorImpl* wbwiii;
+  if (read_options != nullptr) {
+    wbwiii = new WBWIIteratorImpl(
+        GetColumnFamilyID(column_family), &(rep->skip_list), &rep->write_batch,
+        &rep->comparator, read_options->iterate_lower_bound,
+        read_options->iterate_upper_bound);
+  } else {
+    wbwiii = new WBWIIteratorImpl(GetColumnFamilyID(column_family),
+                                  &(rep->skip_list), &rep->write_batch,
+                                  &rep->comparator);
+  }
+
   return new BaseDeltaIterator(column_family, base_iterator, wbwiii,
-                               GetColumnFamilyUserComparator(column_family),
-                               read_options);
+                               GetColumnFamilyUserComparator(column_family));
 }
 
 Iterator* WriteBatchWithIndex::NewIteratorWithBase(Iterator* base_iterator) {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -20,8 +20,7 @@ namespace ROCKSDB_NAMESPACE {
 BaseDeltaIterator::BaseDeltaIterator(ColumnFamilyHandle* column_family,
                                      Iterator* base_iterator,
                                      WBWIIteratorImpl* delta_iterator,
-                                     const Comparator* comparator,
-                                     const ReadOptions* read_options)
+                                     const Comparator* comparator)
     : forward_(true),
       current_at_base_(true),
       equal_keys_(false),
@@ -29,9 +28,7 @@ BaseDeltaIterator::BaseDeltaIterator(ColumnFamilyHandle* column_family,
       column_family_(column_family),
       base_iterator_(base_iterator),
       delta_iterator_(delta_iterator),
-      comparator_(comparator),
-      iterate_upper_bound_(read_options ? read_options->iterate_upper_bound
-                                        : nullptr) {
+      comparator_(comparator) {
   assert(base_iterator_);
   assert(delta_iterator_);
   assert(comparator_);
@@ -307,14 +304,6 @@ void BaseDeltaIterator::UpdateCurrent() {
       if (!DeltaValid()) {
         // Finished
         return;
-      }
-      if (iterate_upper_bound_) {
-        if (comparator_->CompareWithoutTimestamp(
-                delta_entry.key, /*a_has_ts=*/false, *iterate_upper_bound_,
-                /*b_has_ts=*/false) >= 0) {
-          // out of upper bound -> finished.
-          return;
-        }
       }
       if (delta_result == WBWIIteratorImpl::kDeleted &&
           merge_context_.GetNumOperands() == 0) {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -207,7 +207,7 @@ class WBWIIteratorImpl : public WBWIIterator {
   ~WBWIIteratorImpl() override {}
 
   bool Valid() const override {
-    return !out_of_bound_ && validRegardlessOfBoundLimit();
+    return !out_of_bound_ && ValidRegardlessOfBoundLimit();
   }
 
   void SeekToFirst() override {
@@ -223,8 +223,8 @@ class WBWIIteratorImpl : public WBWIIterator {
       skip_list_iter_.Seek(&search_entry);
     }
 
-    if (validRegardlessOfBoundLimit()) {
-      out_of_bound_ = testOutOfBound();
+    if (ValidRegardlessOfBoundLimit()) {
+      out_of_bound_ = TestOutOfBound();
     }
   }
 
@@ -245,13 +245,13 @@ class WBWIIteratorImpl : public WBWIIterator {
       skip_list_iter_.Prev();
     }
 
-    if (validRegardlessOfBoundLimit()) {
-      out_of_bound_ = testOutOfBound();
+    if (ValidRegardlessOfBoundLimit()) {
+      out_of_bound_ = TestOutOfBound();
     }
   }
 
   void Seek(const Slice& key) override {
-    if (beforeLowerBound(&key)) {  // cap to prevent out of bound
+    if (BeforeLowerBound(&key)) {  // cap to prevent out of bound
       SeekToFirst();
       return;
     }
@@ -261,13 +261,13 @@ class WBWIIteratorImpl : public WBWIIterator {
                                       false /* is_seek_to_first */);
     skip_list_iter_.Seek(&search_entry);
 
-    if (validRegardlessOfBoundLimit()) {
-      out_of_bound_ = testOutOfBound();
+    if (ValidRegardlessOfBoundLimit()) {
+      out_of_bound_ = TestOutOfBound();
     }
   }
 
   void SeekForPrev(const Slice& key) override {
-    if (afterUpperBound(&key)) {  // cap to prevent out of bound
+    if (AfterUpperBound(&key)) {  // cap to prevent out of bound
       SeekToLast();
       return;
     }
@@ -277,22 +277,22 @@ class WBWIIteratorImpl : public WBWIIterator {
                                       false /* is_seek_to_first */);
     skip_list_iter_.SeekForPrev(&search_entry);
 
-    if (validRegardlessOfBoundLimit()) {
-      out_of_bound_ = testOutOfBound();
+    if (ValidRegardlessOfBoundLimit()) {
+      out_of_bound_ = TestOutOfBound();
     }
   }
 
   void Next() override {
     skip_list_iter_.Next();
-    if (validRegardlessOfBoundLimit()) {
-      out_of_bound_ = testOutOfBound();
+    if (ValidRegardlessOfBoundLimit()) {
+      out_of_bound_ = TestOutOfBound();
     }
   }
 
   void Prev() override {
     skip_list_iter_.Prev();
-    if (validRegardlessOfBoundLimit()) {
-      out_of_bound_ = testOutOfBound();
+    if (ValidRegardlessOfBoundLimit()) {
+      out_of_bound_ = TestOutOfBound();
     }
   }
 
@@ -339,12 +339,12 @@ class WBWIIteratorImpl : public WBWIIterator {
   const Slice* iterate_upper_bound_;
   bool out_of_bound_ = false;
 
-  bool testOutOfBound() const {
+  bool TestOutOfBound() const {
     const Slice& curKey = Entry().key;
-    return afterUpperBound(&curKey) || beforeLowerBound(&curKey);
+    return AfterUpperBound(&curKey) || BeforeLowerBound(&curKey);
   }
 
-  bool validRegardlessOfBoundLimit() const {
+  bool ValidRegardlessOfBoundLimit() const {
     if (!skip_list_iter_.Valid()) {
       return false;
     }
@@ -353,7 +353,7 @@ class WBWIIteratorImpl : public WBWIIterator {
            iter_entry->column_family == column_family_id_;
   }
 
-  bool afterUpperBound(const Slice* k) const {
+  bool AfterUpperBound(const Slice* k) const {
     if (iterate_upper_bound_ == nullptr) {
       return false;
     }
@@ -364,7 +364,7 @@ class WBWIIteratorImpl : public WBWIIterator {
                                          /*b_has_ts=*/false) >= 0;
   }
 
-  bool beforeLowerBound(const Slice* k) const {
+  bool BeforeLowerBound(const Slice* k) const {
     if (iterate_lower_bound_ == nullptr) {
       return false;
     }

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -248,11 +248,7 @@ class WBWIIteratorImpl : public WBWIIterator {
 
   void Seek(const Slice& key) override {
     if (beforeLowerBound(&key)) {  // cap to prevent out of bound
-      WriteBatchIndexEntry search_entry(iterate_lower_bound_, column_family_id_,
-                                        true /* is_forward_direction */,
-                                        false /* is_seek_to_first */);
-      skip_list_iter_.Seek(&search_entry);
-      out_of_bound_ = false;
+      this->SeekToFirst();
     } else if (afterUpperBound(&key)) {
       out_of_bound_ = true;
     } else {
@@ -266,14 +262,7 @@ class WBWIIteratorImpl : public WBWIIterator {
 
   void SeekForPrev(const Slice& key) override {
     if (afterUpperBound(&key)) {  // cap to prevent out of bound
-      WriteBatchIndexEntry search_entry(
-          iterate_upper_bound_, column_family_id_,
-          // is_forward_direction, set to true so that
-          // iterate_upper_bound_ is excluded, this is not a readable trick,
-          // TODO fix it by renaming WriteBatchIndexEntry::is_forward_direction
-          true, false /* is_seek_to_first */);
-      skip_list_iter_.SeekForPrev(&search_entry);
-      out_of_bound_ = false;
+      this->SeekToLast();
     } else if (beforeLowerBound(&key)) {
       out_of_bound_ = true;
     } else {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -271,7 +271,7 @@ class WBWIIteratorImpl : public WBWIIterator {
   }
 
   void SeekForPrev(const Slice& key) override {
-    if (AfterUpperBound(&key)) {  // cap to prevent out of bound
+    if (AtOrAfterUpperBound(&key)) {  // cap to prevent out of bound
       SeekToLast();
       return;
     }
@@ -345,7 +345,7 @@ class WBWIIteratorImpl : public WBWIIterator {
 
   bool TestOutOfBound() const {
     const Slice& curKey = Entry().key;
-    return AfterUpperBound(&curKey) || BeforeLowerBound(&curKey);
+    return AtOrAfterUpperBound(&curKey) || BeforeLowerBound(&curKey);
   }
 
   bool ValidRegardlessOfBoundLimit() const {
@@ -357,7 +357,7 @@ class WBWIIteratorImpl : public WBWIIterator {
            iter_entry->column_family == column_family_id_;
   }
 
-  bool AfterUpperBound(const Slice* k) const {
+  bool AtOrAfterUpperBound(const Slice* k) const {
     if (iterate_upper_bound_ == nullptr) {
       return false;
     }

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -253,28 +253,32 @@ class WBWIIteratorImpl : public WBWIIterator {
   void Seek(const Slice& key) override {
     if (beforeLowerBound(&key)) {  // cap to prevent out of bound
       SeekToFirst();
-    } else if (afterUpperBound(&key)) {
-      out_of_bound_ = true;
-    } else {
-      WriteBatchIndexEntry search_entry(&key, column_family_id_,
-                                        true /* is_forward_direction */,
-                                        false /* is_seek_to_first */);
-      skip_list_iter_.Seek(&search_entry);
-      out_of_bound_ = false;
+      return;
+    }
+
+    WriteBatchIndexEntry search_entry(&key, column_family_id_,
+                                      true /* is_forward_direction */,
+                                      false /* is_seek_to_first */);
+    skip_list_iter_.Seek(&search_entry);
+
+    if (validRegardlessOfBoundLimit()) {
+      out_of_bound_ = testOutOfBound();
     }
   }
 
   void SeekForPrev(const Slice& key) override {
     if (afterUpperBound(&key)) {  // cap to prevent out of bound
       SeekToLast();
-    } else if (beforeLowerBound(&key)) {
-      out_of_bound_ = true;
-    } else {
-      WriteBatchIndexEntry search_entry(&key, column_family_id_,
-                                        false /* is_forward_direction */,
-                                        false /* is_seek_to_first */);
-      skip_list_iter_.SeekForPrev(&search_entry);
-      out_of_bound_ = false;
+      return;
+    }
+
+    WriteBatchIndexEntry search_entry(&key, column_family_id_,
+                                      false /* is_forward_direction */,
+                                      false /* is_seek_to_first */);
+    skip_list_iter_.SeekForPrev(&search_entry);
+
+    if (validRegardlessOfBoundLimit()) {
+      out_of_bound_ = testOutOfBound();
     }
   }
 

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -223,7 +223,9 @@ class WBWIIteratorImpl : public WBWIIterator {
       skip_list_iter_.Seek(&search_entry);
     }
 
-    out_of_bound_ = false;
+    if (validRegardlessOfBoundLimit()) {
+      out_of_bound_ = testOutOfBound();
+    }
   }
 
   void SeekToLast() override {
@@ -243,12 +245,14 @@ class WBWIIteratorImpl : public WBWIIterator {
       skip_list_iter_.Prev();
     }
 
-    out_of_bound_ = false;
+    if (validRegardlessOfBoundLimit()) {
+      out_of_bound_ = testOutOfBound();
+    }
   }
 
   void Seek(const Slice& key) override {
     if (beforeLowerBound(&key)) {  // cap to prevent out of bound
-      this->SeekToFirst();
+      SeekToFirst();
     } else if (afterUpperBound(&key)) {
       out_of_bound_ = true;
     } else {
@@ -262,7 +266,7 @@ class WBWIIteratorImpl : public WBWIIterator {
 
   void SeekForPrev(const Slice& key) override {
     if (afterUpperBound(&key)) {  // cap to prevent out of bound
-      this->SeekToLast();
+      SeekToLast();
     } else if (beforeLowerBound(&key)) {
       out_of_bound_ = true;
     } else {

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -1684,10 +1684,11 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
     iter->SeekForPrev(Slice("a"));
     ASSERT_FALSE(iter->Valid());
 
-    iter->SeekForPrev(Slice("a.1")); // a non-existent key that is smaller than "b"
+    iter->SeekForPrev(
+        Slice("a.1"));  // a non-existent key that is smaller than "b"
     ASSERT_FALSE(iter->Valid());
 
-    iter->Seek(Slice("b.1")); // a non-existent key that is greater than "b"
+    iter->Seek(Slice("b.1"));  // a non-existent key that is greater than "b"
     ASSERT_FALSE(iter->Valid());
 
     delete ro.iterate_lower_bound;
@@ -1707,7 +1708,8 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
   checkOnlyBIsVisible();
 }
 
-TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInSeekToFirstAndLastOfDeltaIterator) {
+TEST_P(WriteBatchWithIndexTest,
+       TestBoundsCheckingInSeekToFirstAndLastOfDeltaIterator) {
   Status s = OpenDB();
   ASSERT_OK(s);
   KVMap empty_map;

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -1653,7 +1653,7 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
 
   ReadOptions ro;
 
-  auto checkOnlyBIsVisible = [&]() {
+  auto check_only_b_is_visible = [&]() {
     std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
         db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
 
@@ -1697,15 +1697,15 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
 
   ro.iterate_lower_bound = new Slice("b");
   ro.iterate_upper_bound = new Slice("c");
-  checkOnlyBIsVisible();
+  check_only_b_is_visible();
 
   ro.iterate_lower_bound = new Slice("a.1");
   ro.iterate_upper_bound = new Slice("c");
-  checkOnlyBIsVisible();
+  check_only_b_is_visible();
 
   ro.iterate_lower_bound = new Slice("b");
   ro.iterate_upper_bound = new Slice("b.2");
-  checkOnlyBIsVisible();
+  check_only_b_is_visible();
 }
 
 TEST_P(WriteBatchWithIndexTest,
@@ -1717,7 +1717,7 @@ TEST_P(WriteBatchWithIndexTest,
   ASSERT_OK(batch_->Put("c", "cc"));
 
   ReadOptions ro;
-  auto checkNothingVisible = [&]() {
+  auto check_nothing_visible = [&]() {
     std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
         db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
     iter->SeekToFirst();
@@ -1731,11 +1731,11 @@ TEST_P(WriteBatchWithIndexTest,
 
   ro.iterate_lower_bound = new Slice("b");
   ro.iterate_upper_bound = new Slice("c");
-  checkNothingVisible();
+  check_nothing_visible();
 
   ro.iterate_lower_bound = new Slice("d");
   ro.iterate_upper_bound = new Slice("e");
-  checkNothingVisible();
+  check_nothing_visible();
 }
 
 TEST_P(WriteBatchWithIndexTest, SavePointTest) {

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -1691,6 +1691,40 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
   delete ro.iterate_upper_bound;
 }
 
+TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInSeekToFirstAndLastOfDeltaIterator) {
+  Status s = OpenDB();
+  ASSERT_OK(s);
+  KVMap empty_map;
+  // writes that should be observed by BaseDeltaIterator::delta_iterator_
+  ASSERT_OK(batch_->Put("c", "cc"));
+
+  ReadOptions ro;
+  {
+    ro.iterate_lower_bound = new Slice("b");
+    ro.iterate_upper_bound = new Slice("c");
+    std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
+        db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    iter->SeekToLast();
+    ASSERT_FALSE(iter->Valid());
+  }
+
+  {
+    ro.iterate_lower_bound = new Slice("d");
+    ro.iterate_upper_bound = new Slice("e");
+    std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
+        db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+    iter->SeekToLast();
+    ASSERT_FALSE(iter->Valid());
+  }
+
+  delete ro.iterate_lower_bound;
+  delete ro.iterate_upper_bound;
+}
+
 TEST_P(WriteBatchWithIndexTest, SavePointTest) {
   ColumnFamilyHandleImplDummy cf1(1, BytewiseComparator());
   KVMap empty_map;

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -1651,44 +1651,60 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
   ASSERT_OK(batch_->Put("b", "bb"));
   ASSERT_OK(batch_->Put("c", "cc"));
 
-  // given range [b, c)
-  // assert only {b} is return
-
   ReadOptions ro;
+
+  auto checkOnlyBIsVisible = [&]() {
+    std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
+        db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
+
+    // move to the lower bound
+    iter->SeekToFirst();
+    ASSERT_EQ("b", iter->key());
+    iter->Prev();
+    ASSERT_FALSE(iter->Valid());
+
+    // move to the upper bound
+    iter->SeekToLast();
+    ASSERT_EQ("b", iter->key());
+    iter->Next();
+    ASSERT_FALSE(iter->Valid());
+
+    // test bounds checking in Seek and SeekForPrev
+    iter->Seek(Slice("a"));
+    ASSERT_EQ("b", iter->key());
+    iter->Seek(Slice("b"));
+    ASSERT_EQ("b", iter->key());
+    iter->Seek(Slice("c"));
+    ASSERT_FALSE(iter->Valid());
+
+    iter->SeekForPrev(Slice("c"));
+    ASSERT_EQ("b", iter->key());
+    iter->SeekForPrev(Slice("b"));
+    ASSERT_EQ("b", iter->key());
+    iter->SeekForPrev(Slice("a"));
+    ASSERT_FALSE(iter->Valid());
+
+    iter->SeekForPrev(Slice("a.1")); // a non-existent key that is smaller than "b"
+    ASSERT_FALSE(iter->Valid());
+
+    iter->Seek(Slice("b.1")); // a non-existent key that is greater than "b"
+    ASSERT_FALSE(iter->Valid());
+
+    delete ro.iterate_lower_bound;
+    delete ro.iterate_upper_bound;
+  };
+
   ro.iterate_lower_bound = new Slice("b");
   ro.iterate_upper_bound = new Slice("c");
-  std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
-      db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
+  checkOnlyBIsVisible();
 
-  // move to the lower bound
-  iter->SeekToFirst();
-  ASSERT_EQ("b", iter->key());
-  iter->Prev();
-  ASSERT_FALSE(iter->Valid());
+  ro.iterate_lower_bound = new Slice("a.1");
+  ro.iterate_upper_bound = new Slice("c");
+  checkOnlyBIsVisible();
 
-  // move to the upper bound
-  iter->SeekToLast();
-  ASSERT_EQ("b", iter->key());
-  iter->Next();
-  ASSERT_FALSE(iter->Valid());
-
-  // test bounds checking in Seek and SeekForPrev
-  iter->Seek(Slice("a"));
-  ASSERT_EQ("b", iter->key());
-  iter->Seek(Slice("b"));
-  ASSERT_EQ("b", iter->key());
-  iter->Seek(Slice("c"));
-  ASSERT_FALSE(iter->Valid());
-
-  iter->SeekForPrev(Slice("c"));
-  ASSERT_EQ("b", iter->key());
-  iter->SeekForPrev(Slice("b"));
-  ASSERT_EQ("b", iter->key());
-  iter->SeekForPrev(Slice("a"));
-  ASSERT_FALSE(iter->Valid());
-
-  delete ro.iterate_lower_bound;
-  delete ro.iterate_upper_bound;
+  ro.iterate_lower_bound = new Slice("b");
+  ro.iterate_upper_bound = new Slice("b.2");
+  checkOnlyBIsVisible();
 }
 
 TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInSeekToFirstAndLastOfDeltaIterator) {
@@ -1699,30 +1715,25 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInSeekToFirstAndLastOfDeltaIte
   ASSERT_OK(batch_->Put("c", "cc"));
 
   ReadOptions ro;
-  {
-    ro.iterate_lower_bound = new Slice("b");
-    ro.iterate_upper_bound = new Slice("c");
+  auto checkNothingVisible = [&]() {
     std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
         db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
     iter->SeekToFirst();
     ASSERT_FALSE(iter->Valid());
     iter->SeekToLast();
     ASSERT_FALSE(iter->Valid());
-  }
 
-  {
-    ro.iterate_lower_bound = new Slice("d");
-    ro.iterate_upper_bound = new Slice("e");
-    std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
-        db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
-    iter->SeekToFirst();
-    ASSERT_FALSE(iter->Valid());
-    iter->SeekToLast();
-    ASSERT_FALSE(iter->Valid());
-  }
+    delete ro.iterate_lower_bound;
+    delete ro.iterate_upper_bound;
+  };
 
-  delete ro.iterate_lower_bound;
-  delete ro.iterate_upper_bound;
+  ro.iterate_lower_bound = new Slice("b");
+  ro.iterate_upper_bound = new Slice("c");
+  checkNothingVisible();
+
+  ro.iterate_lower_bound = new Slice("d");
+  ro.iterate_upper_bound = new Slice("e");
+  checkNothingVisible();
 }
 
 TEST_P(WriteBatchWithIndexTest, SavePointTest) {

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -1644,6 +1644,8 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
   Status s = OpenDB();
   ASSERT_OK(s);
 
+  KVMap empty_map;
+
   // writes that should be observed by BaseDeltaIterator::delta_iterator_
   ASSERT_OK(batch_->Put("a", "aa"));
   ASSERT_OK(batch_->Put("b", "bb"));
@@ -1656,7 +1658,7 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
   ro.iterate_lower_bound = new Slice("b");
   ro.iterate_upper_bound = new Slice("c");
   std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
-      db_->DefaultColumnFamily(), new KVIter(new KVMap()), &ro));
+      db_->DefaultColumnFamily(), new KVIter(&empty_map), &ro));
 
   // move to the lower bound
   iter->SeekToFirst();
@@ -1684,10 +1686,10 @@ TEST_P(WriteBatchWithIndexTest, TestBoundsCheckingInDeltaIterator) {
   ASSERT_EQ("b", iter->key());
   iter->SeekForPrev(Slice("a"));
   ASSERT_FALSE(iter->Valid());
-}
 
-// TestTxnRespectBoundingInReadOption can not mirror here, since KVIter does not
-// have bounds checking
+  delete ro.iterate_lower_bound;
+  delete ro.iterate_upper_bound;
+}
 
 TEST_P(WriteBatchWithIndexTest, SavePointTest) {
   ColumnFamilyHandleImplDummy cf1(1, BytewiseComparator());


### PR DESCRIPTION
Fix https://github.com/facebook/rocksdb/issues/11607
Fix https://github.com/facebook/rocksdb/issues/11679
Fix https://github.com/facebook/rocksdb/issues/11606
Fix https://github.com/facebook/rocksdb/issues/2343

Summary:

Add bounds checking to `WBWIIteratorImpl`, which will be reflected in `BaseDeltaIterator::delta_iterator_::Valid()`, just like `BaseDeltaIterator::base_iterator_::Valid()`. In this way, the two sub itertors become more aligned from `BaseDeltaIterator`'s perspective. Like `DBIter`, the added bounds checking caps in either bound when seeking and disvalidates the `WBWIIteratorImpl` iterator when the lower bound is past or the upper bound is reached.

Test Plan:

- A simple test added to write_batch_with_index_test.cc to exercise the bounds checking in `WBWIIteratorImpl`.
- A sophisticated test added to transaction_test.cc to assert that `Transaction` with different write policies honor bounds in `ReadOptions`. It should be so as long as the  `BaseDeltaIterator` is correctly coordinating the two sub iterators to perform iterating and bounds checking.