### PR TITLE
Fix a potential memory leak on row_cache insertion failure

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -6927,6 +6927,27 @@ TEST_F(DBTest, RowCache) {
   ASSERT_EQ(Get("foo"), "bar");
   ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 1);
   ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 1);
+
+  // Also test non-OK cache insertion (would be ASAN failure on memory leak)
+  class FailInsertionCache : public CacheWrapper {
+   public:
+    using CacheWrapper::CacheWrapper;
+    const char* Name() const override { return "FailInsertionCache"; }
+    Status Insert(const Slice&, Cache::ObjectPtr, const CacheItemHelper*,
+                  size_t, Handle** = nullptr,
+                  Priority = Priority::LOW) override {
+      return Status::MemoryLimit();
+    }
+  };
+  options.row_cache = std::make_shared<FailInsertionCache>(options.row_cache);
+  options.statistics->Reset();
+  Reopen(options);
+
+  ASSERT_EQ(Get("foo"), "bar");
+  ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 1);
+  ASSERT_EQ(Get("foo"), "bar");
+  // Test condition requires row cache insertion to fail
+  ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 2);
 }
 
 TEST_F(DBTest, PinnableSliceAndRowCache) {

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -6940,7 +6940,7 @@ TEST_F(DBTest, RowCache) {
     }
   };
   options.row_cache = std::make_shared<FailInsertionCache>(options.row_cache);
-  options.statistics->Reset();
+  ASSERT_OK(options.statistics->Reset());
   Reopen(options);
 
   ASSERT_EQ(Get("foo"), "bar");


### PR DESCRIPTION
Summary: Although the built-in Cache implementations never return failure on Insert without keeping a reference (Handle), a custom implementation could. The code for inserting into row_cache does not keep a reference but does not clean up appropriately on non-OK. This is a fix.

Test Plan: unit test added that previously fails under ASAN