### PR TITLE
Implement trimming of readhead size when upper bound is specified

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -655,8 +655,8 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
         // set.
         if (upper_bound_offset_ > 0 && upper_bound_offset_ > offset) {
           if (upper_bound_offset_ < offset + n + readahead_size_) {
-            printf("Trim Readahead Size1\n");
             readahead_size_ = (upper_bound_offset_ - offset) - n;
+            RecordTick(stats_, READAHEAD_TRIMMED);
           }
         }
 
@@ -758,8 +758,8 @@ bool FilePrefetchBuffer::TryReadFromCacheAsyncUntracked(
       // set.
       if (upper_bound_offset_ > 0 && upper_bound_offset_ > offset) {
         if (upper_bound_offset_ < offset + n + readahead_size_) {
-          printf("Trim Readahead Size2\n");
           readahead_size_ = (upper_bound_offset_ - offset) - n;
+          RecordTick(stats_, READAHEAD_TRIMMED);
         }
       }
 
@@ -847,8 +847,8 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
 
     if (upper_bound_offset_ > 0 && upper_bound_offset_ > offset) {
       if (upper_bound_offset_ < offset + n + readahead_size_) {
-        printf("Trim Readahead Size3\n");
         readahead_size_ = (upper_bound_offset_ - offset) - n;
+        RecordTick(stats_, READAHEAD_TRIMMED);
       }
     }
   }

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -849,6 +849,9 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
       if (upper_bound_offset_ < offset + n + readahead_size_) {
         readahead_size_ = (upper_bound_offset_ - offset) - n;
         RecordTick(stats_, READAHEAD_TRIMMED);
+        if (readahead_size_ == 0) {
+          is_eligible_for_prefetching = false;
+        }
       }
     }
   }

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -651,15 +651,7 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
             return false;
           }
         }
-        // Adjust readhahead_size till upper_bound if upper_bound_offset_ is
-        // set.
-        if (upper_bound_offset_ > 0 && upper_bound_offset_ > offset) {
-          if (upper_bound_offset_ < offset + n + readahead_size_) {
-            readahead_size_ = (upper_bound_offset_ - offset) - n;
-            RecordTick(stats_, READAHEAD_TRIMMED);
-          }
-        }
-
+        UpdateReadAheadSizeForUpperBound(offset, n);
         s = Prefetch(opts, reader, offset, n + readahead_size_);
       }
       if (!s.ok()) {
@@ -754,14 +746,7 @@ bool FilePrefetchBuffer::TryReadFromCacheAsyncUntracked(
         }
       }
 
-      // Adjust readhahead_size till upper_bound if upper_bound_offset_ is
-      // set.
-      if (upper_bound_offset_ > 0 && upper_bound_offset_ > offset) {
-        if (upper_bound_offset_ < offset + n + readahead_size_) {
-          readahead_size_ = (upper_bound_offset_ - offset) - n;
-          RecordTick(stats_, READAHEAD_TRIMMED);
-        }
-      }
+      UpdateReadAheadSizeForUpperBound(offset, n);
 
       // Prefetch n + readahead_size_/2 synchronously as remaining
       // readahead_size_/2 will be prefetched asynchronously.
@@ -843,16 +828,10 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   if (readahead_size_ > 0 &&
       (!implicit_auto_readahead_ ||
        num_file_reads_ >= num_file_reads_for_auto_readahead_)) {
-    is_eligible_for_prefetching = true;
-
-    if (upper_bound_offset_ > 0 && upper_bound_offset_ > offset) {
-      if (upper_bound_offset_ < offset + n + readahead_size_) {
-        readahead_size_ = (upper_bound_offset_ - offset) - n;
-        RecordTick(stats_, READAHEAD_TRIMMED);
-        if (readahead_size_ == 0) {
-          is_eligible_for_prefetching = false;
-        }
-      }
+    UpdateReadAheadSizeForUpperBound(offset, n);
+    // After trim, readahead size can be 0.
+    if (readahead_size_ > 0) {
+      is_eligible_for_prefetching = true;
     }
   }
 

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -87,7 +87,8 @@ class FilePrefetchBuffer {
       size_t readahead_size = 0, size_t max_readahead_size = 0,
       bool enable = true, bool track_min_offset = false,
       bool implicit_auto_readahead = false, uint64_t num_file_reads = 0,
-      uint64_t num_file_reads_for_auto_readahead = 0, FileSystem* fs = nullptr,
+      uint64_t num_file_reads_for_auto_readahead = 0,
+      uint64_t upper_bound_offset = 0, FileSystem* fs = nullptr,
       SystemClock* clock = nullptr, Statistics* stats = nullptr,
       FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown)
       : curr_(0),
@@ -106,7 +107,8 @@ class FilePrefetchBuffer {
         fs_(fs),
         clock_(clock),
         stats_(stats),
-        usage_(usage) {
+        usage_(usage),
+        upper_bound_offset_(upper_bound_offset) {
     assert((num_file_reads_ >= num_file_reads_for_auto_readahead_ + 1) ||
            (num_file_reads_ == 0));
     // If ReadOptions.async_io is enabled, data is asynchronously filled in
@@ -171,6 +173,9 @@ class FilePrefetchBuffer {
           }
         }
       }
+
+      // Akanksha: Remove this printf.
+      // printf("Discarded bytes: %lu\n", bytes_discarded);
     }
 
     for (uint32_t i = 0; i < 2; i++) {
@@ -319,6 +324,11 @@ class FilePrefetchBuffer {
   void ResetValues() {
     num_file_reads_ = 1;
     readahead_size_ = initial_auto_readahead_size_;
+    /*
+    Akanksha: Remove this section.
+    total_bytes_prefetched_so_far = 0;
+    total_bytes_till_upper_bound_ = 0;
+    */
   }
 
   // Called in case of implicit auto prefetching.
@@ -457,5 +467,16 @@ class FilePrefetchBuffer {
   Statistics* stats_;
 
   FilePrefetchBufferUsage usage_;
+
+  // upper_bound_offset_ is set when ReadOptions.iterate_upper_bound and
+  // ReadOptions.tune_readahead_size are set to trim readahead_size upto
+  // upper_bound_offset_ during prefetching.
+  uint64_t upper_bound_offset_ = 0;
+
+  /*
+  Akanksha: Remove this section
+  size_t total_bytes_read_till_upper_bound_ = 0;
+  size_t total_bytes_prefetched_so_far = 0;
+  */
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -321,6 +321,7 @@ class FilePrefetchBuffer {
   void ResetValues() {
     num_file_reads_ = 1;
     readahead_size_ = initial_auto_readahead_size_;
+    upper_bound_offset_ = 0;
   }
 
   // Called in case of implicit auto prefetching.

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -173,9 +173,6 @@ class FilePrefetchBuffer {
           }
         }
       }
-
-      // Akanksha: Remove this printf.
-      // printf("Discarded bytes: %lu\n", bytes_discarded);
     }
 
     for (uint32_t i = 0; i < 2; i++) {
@@ -324,11 +321,6 @@ class FilePrefetchBuffer {
   void ResetValues() {
     num_file_reads_ = 1;
     readahead_size_ = initial_auto_readahead_size_;
-    /*
-    Akanksha: Remove this section.
-    total_bytes_prefetched_so_far = 0;
-    total_bytes_till_upper_bound_ = 0;
-    */
   }
 
   // Called in case of implicit auto prefetching.
@@ -469,14 +461,8 @@ class FilePrefetchBuffer {
   FilePrefetchBufferUsage usage_;
 
   // upper_bound_offset_ is set when ReadOptions.iterate_upper_bound and
-  // ReadOptions.tune_readahead_size are set to trim readahead_size upto
+  // ReadOptions.auto_readahead_size are set to trim readahead_size upto
   // upper_bound_offset_ during prefetching.
   uint64_t upper_bound_offset_ = 0;
-
-  /*
-  Akanksha: Remove this section
-  size_t total_bytes_read_till_upper_bound_ = 0;
-  size_t total_bytes_prefetched_so_far = 0;
-  */
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -419,6 +419,17 @@ class FilePrefetchBuffer {
                                       uint64_t offset, size_t n, Slice* result,
                                       Status* status);
 
+  void UpdateReadAheadSizeForUpperBound(uint64_t offset, size_t n) {
+    // Adjust readhahead_size till upper_bound if upper_bound_offset_ is
+    // set.
+    if (upper_bound_offset_ > 0 && upper_bound_offset_ > offset) {
+      if (upper_bound_offset_ < offset + n + readahead_size_) {
+        readahead_size_ = (upper_bound_offset_ - offset) - n;
+        RecordTick(stats_, READAHEAD_TRIMMED);
+      }
+    }
+  }
+
   std::vector<BufferInfo> bufs_;
   // curr_ represents the index for bufs_ indicating which buffer is being
   // consumed currently.

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -2067,6 +2067,8 @@ TEST_P(PrefetchTest, IterReadAheadSizeWithUpperBound) {
 
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &least, &greatest));
 
+  int buff_prefetch_count = 0;
+
   // Try with different num_file_reads_for_auto_readahead from 0 to 3.
   for (size_t i = 0; i < 3; i++) {
     table_options.num_file_reads_for_auto_readahead = i;
@@ -2077,8 +2079,8 @@ TEST_P(PrefetchTest, IterReadAheadSizeWithUpperBound) {
 
     int buff_count_with_tuning = 0, buff_count_without_tuning = 0;
     int keys_with_tuning = 0, keys_without_tuning = 0;
+    buff_prefetch_count = 0;
 
-    int buff_prefetch_count = 0;
     SyncPoint::GetInstance()->SetCallBack(
         "FilePrefetchBuffer::Prefetch:Start",
         [&](void*) { buff_prefetch_count++; });

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -418,7 +418,8 @@ TEST_P(PrefetchTailTest, UpgradeToTailSizeInManifest) {
   }
   if (UseDirectIO()) {
     ROCKSDB_GTEST_BYPASS(
-        "To simplify testing logics with setting file's buffer alignment to be "
+        "To simplify testing logics with setting file's buffer alignment to "
+        "be "
         "1, direct IO is required to be disabled.");
   }
 
@@ -455,8 +456,8 @@ TEST_P(PrefetchTailTest, UpgradeToTailSizeInManifest) {
   // inferred to be a small number for files with no tail size recorded in
   // manifest.
   // "1" is chosen to be such number so that with `small_buffer_alignment ==
-  // true` and `use_small_cache == true`, it would have caused one file read per
-  // index partition during db open if the upgrade is done wrong.
+  // true` and `use_small_cache == true`, it would have caused one file read
+  // per index partition during db open if the upgrade is done wrong.
   SyncPoint::GetInstance()->SetCallBack(
       "BlockBasedTable::Open::TailPrefetchLen", [&](void* arg) {
         std::pair<size_t*, size_t*>* prefetch_off_len_pair =
@@ -481,8 +482,8 @@ TEST_P(PrefetchTailTest, UpgradeToTailSizeInManifest) {
   int64_t num_index_partition = GetNumIndexPartition();
   // If the upgrade is done right, db open will prefetch all the index
   // partitions at once, instead of doing one read per partition.
-  // That is, together with `metadata_block_size == 1`, there will be more index
-  // partitions than number of non index partitions reads.
+  // That is, together with `metadata_block_size == 1`, there will be more
+  // index partitions than number of non index partitions reads.
   ASSERT_LT(db_open_file_read.count, num_index_partition);
 
   Close();
@@ -695,8 +696,8 @@ TEST_P(PrefetchTest, ConfigureInternalAutoReadaheadSize) {
                                       "{initial_auto_readahead_size=0;}"}}));
           break;
         case 1:
-          // intial_auto_readahead_size and max_auto_readahead_size are set same
-          // so readahead_size remains same.
+          // intial_auto_readahead_size and max_auto_readahead_size are set
+          // same so readahead_size remains same.
           ASSERT_OK(db_->SetOptions({{"block_based_table_factory",
                                       "{initial_auto_readahead_size=4096;max_"
                                       "auto_readahead_size=4096;}"}}));
@@ -803,8 +804,9 @@ TEST_P(PrefetchTest, ConfigureNumFilesReadsForReadaheadSize) {
     /*
      * Reseek keys from sequential Data Blocks within same partitioned
      * index. It will prefetch the data block at the first seek since
-     * num_file_reads_for_auto_readahead = 0. Data Block size is nearly 4076 so
-     * readahead will fetch 8 * 1024 data more initially (2 more data blocks).
+     * num_file_reads_for_auto_readahead = 0. Data Block size is nearly 4076
+     * so readahead will fetch 8 * 1024 data more initially (2 more data
+     * blocks).
      */
     iter->Seek(BuildKey(0));  // Prefetch data + index block since
                               // num_file_reads_for_auto_readahead = 0.
@@ -902,8 +904,8 @@ TEST_P(PrefetchTest, PrefetchWhenReseek) {
     /*
      * Reseek keys from sequential Data Blocks within same partitioned
      * index. After 2 sequential reads it will prefetch the data block.
-     * Data Block size is nearly 4076 so readahead will fetch 8 * 1024 data more
-     * initially (2 more data blocks).
+     * Data Block size is nearly 4076 so readahead will fetch 8 * 1024 data
+     * more initially (2 more data blocks).
      */
     iter->Seek(BuildKey(0));
     ASSERT_TRUE(iter->Valid());
@@ -980,9 +982,9 @@ TEST_P(PrefetchTest, PrefetchWhenReseek) {
   {
     /*
      * Reseek keys from  sequential data blocks to set implicit auto readahead
-     * and prefetch data but after that iterate over different (non sequential)
-     * data blocks which won't prefetch any data further. So buff_prefetch_count
-     * will be 1 for the first one.
+     * and prefetch data but after that iterate over different (non
+     * sequential) data blocks which won't prefetch any data further. So
+     * buff_prefetch_count will be 1 for the first one.
      */
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
     iter->Seek(BuildKey(0));
@@ -1009,8 +1011,8 @@ TEST_P(PrefetchTest, PrefetchWhenReseek) {
       buff_prefetch_count = 0;
     }
 
-    // Read sequentially to confirm readahead_size is reset to initial value (2
-    // more data blocks)
+    // Read sequentially to confirm readahead_size is reset to initial value
+    // (2 more data blocks)
     iter->Seek(BuildKey(1011));
     ASSERT_TRUE(iter->Valid());
     iter->Seek(BuildKey(1015));
@@ -1060,8 +1062,8 @@ TEST_P(PrefetchTest, PrefetchWhenReseek) {
   }
   {
     /*
-     * Reseek over different keys from different blocks. buff_prefetch_count is
-     * set 0.
+     * Reseek over different keys from different blocks. buff_prefetch_count
+     * is set 0.
      */
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
     int i = 0;
@@ -1165,8 +1167,8 @@ TEST_P(PrefetchTest, PrefetchWhenReseekwithCache) {
     /*
      * Reseek keys from sequential Data Blocks within same partitioned
      * index. After 2 sequential reads it will prefetch the data block.
-     * Data Block size is nearly 4076 so readahead will fetch 8 * 1024 data more
-     * initially (2 more data blocks).
+     * Data Block size is nearly 4076 so readahead will fetch 8 * 1024 data
+     * more initially (2 more data blocks).
      */
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
     // Warm up the cache
@@ -1193,8 +1195,8 @@ TEST_P(PrefetchTest, PrefetchWhenReseekwithCache) {
     ASSERT_TRUE(iter->Valid());
     iter->Seek(BuildKey(1004));  // Prefetch data (not in cache).
     ASSERT_TRUE(iter->Valid());
-    // Missed one sequential block but next is in already in buffer so readahead
-    // will not be reset.
+    // Missed one sequential block but next is in already in buffer so
+    // readahead will not be reset.
     iter->Seek(BuildKey(1011));
     ASSERT_TRUE(iter->Valid());
     // Prefetch data but blocks are in cache so no prefetch and reset.
@@ -1648,12 +1650,13 @@ TEST_P(PrefetchTest1, SeekWithExtraPrefetchAsyncIO) {
           0));  // Prefetch data on seek because of seek parallelization.
       ASSERT_TRUE(iter->Valid());
 
-      // Do extra prefetching in Seek only if num_file_reads_for_auto_readahead
-      // = 0.
+      // Do extra prefetching in Seek only if
+      // num_file_reads_for_auto_readahead = 0.
       ASSERT_EQ(extra_prefetch_buff_cnt, (i == 0 ? 1 : 0));
       // buff_prefetch_count is 2 because of index block when
       // num_file_reads_for_auto_readahead = 0.
-      // If num_file_reads_for_auto_readahead > 0, index block isn't prefetched.
+      // If num_file_reads_for_auto_readahead > 0, index block isn't
+      // prefetched.
       ASSERT_EQ(buff_prefetch_count, i == 0 ? 2 : 1);
 
       extra_prefetch_buff_cnt = 0;
@@ -1662,8 +1665,8 @@ TEST_P(PrefetchTest1, SeekWithExtraPrefetchAsyncIO) {
       iter->Seek(
           BuildKey(22));  // Prefetch data because of seek parallelization.
       ASSERT_TRUE(iter->Valid());
-      // Do extra prefetching in Seek only if num_file_reads_for_auto_readahead
-      // = 0.
+      // Do extra prefetching in Seek only if
+      // num_file_reads_for_auto_readahead = 0.
       ASSERT_EQ(extra_prefetch_buff_cnt, (i == 0 ? 1 : 0));
       ASSERT_EQ(buff_prefetch_count, 1);
 
@@ -1673,8 +1676,8 @@ TEST_P(PrefetchTest1, SeekWithExtraPrefetchAsyncIO) {
       iter->Seek(
           BuildKey(33));  // Prefetch data because of seek parallelization.
       ASSERT_TRUE(iter->Valid());
-      // Do extra prefetching in Seek only if num_file_reads_for_auto_readahead
-      // = 0.
+      // Do extra prefetching in Seek only if
+      // num_file_reads_for_auto_readahead = 0.
       ASSERT_EQ(extra_prefetch_buff_cnt, (i == 0 ? 1 : 0));
       ASSERT_EQ(buff_prefetch_count, 1);
     }
@@ -1765,8 +1768,8 @@ TEST_P(PrefetchTest1, NonSequentialReadsWithAdaptiveReadahead) {
   Close();
 }
 
-// This test verifies the functionality of adaptive_readaheadsize with cache and
-// if block is found in cache, decrease the readahead_size if
+// This test verifies the functionality of adaptive_readaheadsize with cache
+// and if block is found in cache, decrease the readahead_size if
 // - its enabled internally by RocksDB (implicit_auto_readahead_) and,
 // - readahead_size is greater than 0 and,
 // - the block would have called prefetch API if not found in cache for
@@ -1888,8 +1891,8 @@ TEST_P(PrefetchTest1, DecreaseReadAheadIfInCache) {
     ASSERT_TRUE(iter->Valid());
 
     // Prefetch data (not in buffer) but found in cache. So decrease
-    // readahead_size. Since it will 0 after decrementing so readahead_size will
-    // be set to initial value.
+    // readahead_size. Since it will 0 after decrementing so readahead_size
+    // will be set to initial value.
     iter->Seek(BuildKey(1019));
     ASSERT_TRUE(iter->Valid());
     expected_current_readahead_size = std::max(
@@ -2001,8 +2004,8 @@ TEST_P(PrefetchTest1, SeekParallelizationTest) {
 
     HistogramData async_read_bytes;
     options.statistics->histogramData(ASYNC_READ_BYTES, &async_read_bytes);
-    // not all platforms support io_uring. In that case it'll fallback to normal
-    // prefetching without async_io.
+    // not all platforms support io_uring. In that case it'll fallback to
+    // normal prefetching without async_io.
     if (read_async_called) {
       ASSERT_EQ(buff_prefetch_async_count, 2);
       ASSERT_GT(async_read_bytes.count, 0);
@@ -2011,6 +2014,111 @@ TEST_P(PrefetchTest1, SeekParallelizationTest) {
       ASSERT_EQ(buff_prefetch_count, 1);
     }
   }
+  Close();
+}
+
+TEST_P(PrefetchTest1, IterReadAheadSizeWithUpperBound) {
+  // First param is if the mockFS support_prefetch or not
+  std::shared_ptr<MockFS> fs =
+      std::make_shared<MockFS>(FileSystem::Default(), false);
+
+  bool use_direct_io = false;
+
+  std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, fs));
+  Options options;
+  SetGenericOptions(env.get(), use_direct_io, options);
+  options.statistics = CreateDBStatistics();
+  BlockBasedTableOptions table_options;
+  SetBlockBasedTableOptions(table_options);
+  // table_options.num_file_reads_for_auto_readahead = 0;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  Status s = TryReopen(options);
+  if (use_direct_io && (s.IsNotSupported() || s.IsInvalidArgument())) {
+    // If direct IO is not supported, skip the test
+    return;
+  } else {
+    ASSERT_OK(s);
+  }
+
+  Random rnd(309);
+  WriteBatch batch;
+
+  for (int i = 0; i < 26; i++) {
+    std::string key = "my_key_";
+
+    for (int j = 0; j < 10; j++) {
+      key += char('a' + i);
+      ASSERT_OK(batch.Put(key, rnd.RandomString(1000)));
+    }
+  }
+  ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+  std::string start_key = "my_key_a";
+
+  std::string end_key = "my_key_";
+  for (int j = 0; j < 10; j++) {
+    end_key += char('a' + 25);
+  }
+
+  Slice least(start_key.data(), start_key.size());
+  Slice greatest(end_key.data(), end_key.size());
+
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &least, &greatest));
+
+  HistogramData discarded_bytes_without_tuning, discarded_bytes_with_tuning;
+  // With tuning readahead_size.
+  {
+    ASSERT_OK(options.statistics->Reset());
+    ReadOptions opts;
+    opts.tune_readahead_size = true;
+    if (GetParam()) {
+      opts.readahead_size = 32768;
+    }
+    Slice ub = Slice("my_key_jjj");
+    opts.iterate_upper_bound = &ub;
+    auto iter = std::unique_ptr<Iterator>(db_->NewIterator(opts));
+
+    iter->SeekToFirst();
+
+    while (iter->Valid()) {
+      iter->Next();
+    }
+
+    options.statistics->histogramData(PREFETCHED_BYTES_DISCARDED,
+                                      &discarded_bytes_with_tuning);
+  }
+
+  // Without tuning readahead_size
+  {
+    ASSERT_OK(options.statistics->Reset());
+    ReadOptions opts;
+    opts.tune_readahead_size = false;
+    if (GetParam()) {
+      opts.readahead_size = 32768;
+    }
+    Slice ub = Slice("my_key_jjj");
+    opts.iterate_upper_bound = &ub;
+    auto iter = std::unique_ptr<Iterator>(db_->NewIterator(opts));
+
+    iter->SeekToFirst();
+
+    while (iter->Valid()) {
+      iter->Next();
+    }
+
+    HistogramData prefetched_bytes_discarded;
+    options.statistics->histogramData(PREFETCHED_BYTES_DISCARDED,
+                                      &prefetched_bytes_discarded);
+    // options.statistics->histogramData(PREFETCHED_BYTES_DISCARDED,
+    //                                  &discarded_bytes_without_tuning);
+    printf("Histogram Discarded bytes: %lu %lu",
+           discarded_bytes_without_tuning.count,
+           prefetched_bytes_discarded.count);
+  }
+
+  // ASSERT_GT(discarded_bytes_without_tuning.count,
+  //          discarded_bytes_with_tuning.count);
   Close();
 }
 
@@ -2590,7 +2698,7 @@ TEST_F(FilePrefetchBufferTest, SeekWithBlockCacheHit) {
   std::unique_ptr<RandomAccessFileReader> r;
   Read(fname, opts, &r);
 
-  FilePrefetchBuffer fpb(16384, 16384, true, false, false, 0, 0, fs());
+  FilePrefetchBuffer fpb(16384, 16384, true, false, false, 0, 0, 0, fs());
   Slice result;
   // Simulate a seek of 4096 bytes at offset 0. Due to the readahead settings,
   // it will do two reads of 4096+8192 and 8192
@@ -2625,7 +2733,8 @@ TEST_F(FilePrefetchBufferTest, NoSyncWithAsyncIO) {
   FilePrefetchBuffer fpb(
       /*readahead_size=*/8192, /*max_readahead_size=*/16384, /*enable=*/true,
       /*track_min_offset=*/false, /*implicit_auto_readahead=*/false,
-      /*num_file_reads=*/0, /*num_file_reads_for_auto_readahead=*/0, fs());
+      /*num_file_reads=*/0, /*num_file_reads_for_auto_readahead=*/0,
+      /*upper_bound_offset=*/0, fs());
 
   int read_async_called = 0;
   SyncPoint::GetInstance()->SetCallBack(

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1706,7 +1706,16 @@ struct ReadOptions {
   std::function<bool(const TableProperties&)> table_filter;
 
   // Experimental
-  bool auto_readahead_size = true;
+  //
+  // If auto_readahead_size is set to true, it will trim the readahead_size
+  // during scans upto iterate_upper_bound and won't prefetch beyond
+  // iterate_upper_bound.
+  // For this feature to enabled, iterate_upper_bound must also be specified.
+  // It's enabled for explicit and implicit readahead_size (async and sync
+  // scans).
+  //
+  // Default: false
+  bool auto_readahead_size = false;
 
   // *** END options only relevant to iterators or scans ***
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1569,8 +1569,6 @@ struct ReadOptions {
   // broken, stale keys could be served in read paths.
   bool ignore_range_deletions = false;
 
-  // Experimental
-  //
   // If async_io is enabled, RocksDB will prefetch some of data asynchronously.
   // RocksDB apply it if reads are sequential and its internal automatic
   // prefetching.
@@ -1706,6 +1704,9 @@ struct ReadOptions {
   // no impact on point lookups.
   // Default: empty (every table will be scanned)
   std::function<bool(const TableProperties&)> table_filter;
+
+  // Experimental
+  bool tune_readahead_size = true;
 
   // *** END options only relevant to iterators or scans ***
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1707,12 +1707,9 @@ struct ReadOptions {
 
   // Experimental
   //
-  // If auto_readahead_size is set to true, it will trim the readahead_size
-  // during scans upto iterate_upper_bound and won't prefetch beyond
-  // iterate_upper_bound.
+  // If auto_readahead_size is set to true, it will auto tune the readahead_size
+  // during scans internally.
   // For this feature to enabled, iterate_upper_bound must also be specified.
-  // It's enabled for explicit and implicit readahead_size (async and sync
-  // scans).
   //
   // Default: false
   bool auto_readahead_size = false;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1706,7 +1706,7 @@ struct ReadOptions {
   std::function<bool(const TableProperties&)> table_filter;
 
   // Experimental
-  bool tune_readahead_size = true;
+  bool auto_readahead_size = true;
 
   // *** END options only relevant to iterators or scans ***
 

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -511,6 +511,10 @@ enum Tickers : uint32_t {
   // compressed SST blocks from storage.
   BYTES_DECOMPRESSED_TO,
 
+  // Number of times readahead is trimmed during scans when
+  // ReadOptions.auto_readahead_size is set.
+  READAHEAD_TRIMMED,
+
   TICKER_ENUM_MAX
 };
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5131,6 +5131,8 @@ class TickerTypeJni {
         return -0x3B;
       case ROCKSDB_NAMESPACE::Tickers::BLOCK_CHECKSUM_MISMATCH_COUNT:
         return -0x3C;
+      case ROCKSDB_NAMESPACE::Tickers::READAHEAD_TRIMMED:
+        return -0x3D;
       case ROCKSDB_NAMESPACE::Tickers::TICKER_ENUM_MAX:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -764,6 +764,8 @@ public enum TickerType {
      */
     BLOCK_CHECKSUM_MISMATCH_COUNT((byte) -0x3C),
 
+    READAHEAD_TRIMMED((byte) -0x3D),
+
     TICKER_ENUM_MAX((byte) 0x5F);
 
     private final byte value;

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -257,6 +257,7 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
      "rocksdb.number.block_compression_rejected"},
     {BYTES_DECOMPRESSED_FROM, "rocksdb.bytes.decompressed.from"},
     {BYTES_DECOMPRESSED_TO, "rocksdb.bytes.decompressed.to"},
+    {READAHEAD_TRIMMED, "rocksdb.readahead.trimmed"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -79,8 +79,7 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
     }
   }
 
-  if (read_options_.tune_readahead_size && read_options_.iterate_upper_bound &&
-      !read_options_.async_io) {
+  if (read_options_.auto_readahead_size && read_options_.iterate_upper_bound) {
     FindReadAheadSizeUpperBound();
     if (target) {
       index_iter_->Seek(*target);
@@ -510,7 +509,6 @@ void BlockBasedTableIterator::CheckDataBlockWithinUpperBound() {
 
 void BlockBasedTableIterator::FindReadAheadSizeUpperBound() {
   size_t total_bytes_till_upper_bound = 0;
-  size_t count = 0;
   size_t footer = table_->get_rep()->footer.GetBlockTrailerSize();
   uint64_t start_offset = index_iter_->value().handle.offset();
 
@@ -540,7 +538,6 @@ void BlockBasedTableIterator::FindReadAheadSizeUpperBound() {
     // index block and add it's Data block size to
     // readahead_size.
     index_iter_->Next();
-    count++;
 
     if (!index_iter_->Valid()) {
       break;
@@ -548,9 +545,6 @@ void BlockBasedTableIterator::FindReadAheadSizeUpperBound() {
 
   } while (true);
 
-  // printf("Data blocks: %lu, Bytes till upper_bound: %lu, offset: %lu\n",
-  // count,
-  //       total_bytes_till_upper_bound, start_offset);
   block_prefetcher_.SetUpperBoundOffset(start_offset +
                                         total_bytes_till_upper_bound);
 }

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -525,8 +525,8 @@ void BlockBasedTableIterator::FindReadAheadSizeUpperBound() {
     bool next_block_out_of_bound =
         (user_comparator_.CompareWithoutTimestamp(
              index_iter_->user_key(),
-             /*b_has_ts=*/true, *read_options_.iterate_upper_bound,
-             /*a_has_ts=*/false) >= 0
+             /*a_has_ts=*/true, *read_options_.iterate_upper_bound,
+             /*b_has_ts=*/false) >= 0
              ? true
              : false);
 

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -306,5 +306,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     }
     return true;
   }
+
+  void FindReadAheadSizeUpperBound();
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -883,7 +883,7 @@ Status BlockBasedTable::PrefetchTail(
       0 /* readahead_size */, 0 /* max_readahead_size */, true /* enable */,
       true /* track_min_offset */, false /* implicit_auto_readahead */,
       0 /* num_file_reads */, 0 /* num_file_reads_for_auto_readahead */,
-      nullptr /* fs */, nullptr /* clock */, stats,
+      0 /* upper_bound_offset */, nullptr /* fs */, nullptr /* clock */, stats,
       FilePrefetchBufferUsage::kTableOpenPrefetchTail));
 
   if (s.ok()) {

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -682,28 +682,31 @@ struct BlockBasedTable::Rep {
   uint64_t sst_number_for_tracing() const {
     return file ? TableFileNameToNumber(file->file_name()) : UINT64_MAX;
   }
-  void CreateFilePrefetchBuffer(
-      size_t readahead_size, size_t max_readahead_size,
-      std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
-      uint64_t num_file_reads,
-      uint64_t num_file_reads_for_auto_readahead) const {
+  void CreateFilePrefetchBuffer(size_t readahead_size,
+                                size_t max_readahead_size,
+                                std::unique_ptr<FilePrefetchBuffer>* fpb,
+                                bool implicit_auto_readahead,
+                                uint64_t num_file_reads,
+                                uint64_t num_file_reads_for_auto_readahead,
+                                uint64_t upper_bound_offset) const {
     fpb->reset(new FilePrefetchBuffer(
         readahead_size, max_readahead_size,
         !ioptions.allow_mmap_reads /* enable */, false /* track_min_offset */,
         implicit_auto_readahead, num_file_reads,
-        num_file_reads_for_auto_readahead, ioptions.fs.get(), ioptions.clock,
-        ioptions.stats));
+        num_file_reads_for_auto_readahead, upper_bound_offset,
+        ioptions.fs.get(), ioptions.clock, ioptions.stats));
   }
 
   void CreateFilePrefetchBufferIfNotExists(
       size_t readahead_size, size_t max_readahead_size,
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
-      uint64_t num_file_reads,
-      uint64_t num_file_reads_for_auto_readahead) const {
+      uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
+      uint64_t upper_bound_offset) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
                                implicit_auto_readahead, num_file_reads,
-                               num_file_reads_for_auto_readahead);
+                               num_file_reads_for_auto_readahead,
+                               upper_bound_offset);
     }
   }
 

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -48,7 +48,8 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
     rep->CreateFilePrefetchBufferIfNotExists(
         compaction_readahead_size_, compaction_readahead_size_,
         &prefetch_buffer_, /*implicit_auto_readahead=*/false,
-        /*num_file_reads=*/0, /*num_file_reads_for_auto_readahead=*/0);
+        /*num_file_reads=*/0, /*num_file_reads_for_auto_readahead=*/0,
+        /*upper_bound_offset=*/0);
     return;
   }
 
@@ -57,7 +58,7 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
     rep->CreateFilePrefetchBufferIfNotExists(
         readahead_size, readahead_size, &prefetch_buffer_,
         /*implicit_auto_readahead=*/false, /*num_file_reads=*/0,
-        /*num_file_reads_for_auto_readahead=*/0);
+        /*num_file_reads_for_auto_readahead=*/0, upper_bound_offset_);
     return;
   }
 
@@ -81,7 +82,8 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true,
         /*num_file_reads=*/0,
-        rep->table_options.num_file_reads_for_auto_readahead);
+        rep->table_options.num_file_reads_for_auto_readahead,
+        upper_bound_offset_);
     return;
   }
 
@@ -111,7 +113,8 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
     rep->CreateFilePrefetchBufferIfNotExists(
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,
-        rep->table_options.num_file_reads_for_auto_readahead);
+        rep->table_options.num_file_reads_for_auto_readahead,
+        upper_bound_offset_);
     return;
   }
 
@@ -134,7 +137,8 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
     rep->CreateFilePrefetchBufferIfNotExists(
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,
-        rep->table_options.num_file_reads_for_auto_readahead);
+        rep->table_options.num_file_reads_for_auto_readahead,
+        upper_bound_offset_);
     return;
   }
 

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -53,6 +53,10 @@ class BlockPrefetcher {
                              &initial_auto_readahead_size_);
   }
 
+  void SetUpperBoundOffset(uint64_t upper_bound_offset) {
+    upper_bound_offset_ = upper_bound_offset;
+  }
+
  private:
   // Readahead size used in compaction, its value is used only if
   // lookup_context_.caller = kCompaction.
@@ -69,5 +73,7 @@ class BlockPrefetcher {
   uint64_t prev_offset_ = 0;
   size_t prev_len_ = 0;
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer_;
+
+  uint64_t upper_bound_offset_ = 0;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -497,7 +497,8 @@ Status PartitionedFilterBlockReader::CacheDependencies(
       tail_prefetch_buffer->GetPrefetchOffset() > prefetch_off) {
     rep->CreateFilePrefetchBuffer(
         0, 0, &prefetch_buffer, false /* Implicit autoreadahead */,
-        0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/);
+        0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/,
+        /*upper_bound_offset*/ 0);
 
     IOOptions opts;
     s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -169,7 +169,8 @@ Status PartitionIndexReader::CacheDependencies(
       tail_prefetch_buffer->GetPrefetchOffset() > prefetch_off) {
     rep->CreateFilePrefetchBuffer(
         0, 0, &prefetch_buffer, false /*Implicit auto readahead*/,
-        0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/);
+        0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/,
+        /*upper_bound_offset*/ 0);
     IOOptions opts;
     {
       Status s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -75,10 +75,6 @@ inline bool BlockFetcher::TryGetFromPrefetchBuffer() {
   if (prefetch_buffer_ != nullptr) {
     IOOptions opts;
     IOStatus io_s = file_->PrepareIOOptions(read_options_, opts);
-
-    // printf("footer.GetBlockTrailerSize(): %lu\n",
-    //       footer_.GetBlockTrailerSize());
-
     if (io_s.ok()) {
       bool read_from_prefetch_buffer = false;
       if (read_options_.async_io && !for_compaction_) {

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -75,6 +75,10 @@ inline bool BlockFetcher::TryGetFromPrefetchBuffer() {
   if (prefetch_buffer_ != nullptr) {
     IOOptions opts;
     IOStatus io_s = file_->PrepareIOOptions(read_options_, opts);
+
+    // printf("footer.GetBlockTrailerSize(): %lu\n",
+    //       footer_.GetBlockTrailerSize());
+
     if (io_s.ok()) {
       bool read_from_prefetch_buffer = false;
       if (read_options_.async_io && !for_compaction_) {

--- a/unreleased_history/new_features/auto_readahead.md
+++ b/unreleased_history/new_features/auto_readahead.md
@@ -1,0 +1,1 @@
+Add a new feature to trim readahead_size during scans upto upper_bound when iterate_upper_bound is specified. It's enabled through ReadOptions.auto_readahead_size. Users must also specify ReadOptions.iterate_upper_bound.


### PR DESCRIPTION
Summary:
Implement trimming of readahead_size under a new option ReadOptions.auto_readahead_size. It'll trim the readahead_size during prefetching upto iterate_upper_bound offset only when ReadOptions.iterate_upper_bound is set, therefore reducing the prefetching of data beyond upper_bound.
It's enabled for both implicit auto readahead size and when ReadOptions.readahead_size is specified and for sync and async_io.

Test Plan: Added new unit test

Reviewers:

Subscribers:

Tasks:

Tags: