### PR TITLE
Add missing status check when compiling with `ASSERT_STATUS_CHECKED=1`

### DIFF
--- a/db/compact_files_test.cc
+++ b/db/compact_files_test.cc
@@ -345,7 +345,7 @@ TEST_F(CompactFilesTest, CompactionFilterWithGetSv) {
         return true;
       }
       std::string res;
-      db_->Get(ReadOptions(), "", &res);
+      EXPECT_TRUE(db_->Get(ReadOptions(), "", &res).IsNotFound());
       return true;
     }
 

--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -77,7 +77,7 @@ void DoRandomIteraratorTest(DB* db, std::vector<std::string> source_strings,
 
   for (int i = 0; i < num_writes; i++) {
     if (num_trigger_flush > 0 && i != 0 && i % num_trigger_flush == 0) {
-      db->Flush(FlushOptions());
+      ASSERT_OK(db->Flush(FlushOptions()));
     }
 
     int type = rnd->Uniform(2);
@@ -156,6 +156,7 @@ void DoRandomIteraratorTest(DB* db, std::vector<std::string> source_strings,
         if (map.find(key) == map.end()) {
           ASSERT_TRUE(status.IsNotFound());
         } else {
+          ASSERT_OK(status);
           ASSERT_EQ(map[key], result);
         }
         break;

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -654,7 +654,7 @@ TEST_P(DBBloomFilterTestWithParam, SkipFilterOnEssentiallyZeroBpk) {
     for (i = 0; i < maxKey; i++) {
       ASSERT_OK(Put(Key(i), Key(i)));
     }
-    Flush();
+    ASSERT_OK(Flush());
   };
   auto GetFn = [&]() {
     int i;
@@ -792,7 +792,7 @@ TEST_F(DBBloomFilterTest, BloomFilterRate) {
     }
     // Add a large key to make the file contain wide range
     ASSERT_OK(Put(1, Key(maxKey + 55555), Key(maxKey + 55555)));
-    Flush(1);
+    ASSERT_OK(Flush(1));
 
     // Check if they can be found
     for (int i = 0; i < maxKey; i++) {
@@ -1696,7 +1696,7 @@ TEST_F(DBBloomFilterTest, ContextCustomFilterPolicy) {
     table_options.format_version = 5;
     options.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
-    TryReopen(options);
+    ASSERT_OK(TryReopen(options));
     CreateAndReopenWithCF({fifo ? "abe" : "bob"}, options);
 
     const int maxKey = 10000;
@@ -1705,7 +1705,7 @@ TEST_F(DBBloomFilterTest, ContextCustomFilterPolicy) {
     }
     // Add a large key to make the file contain wide range
     ASSERT_OK(Put(1, Key(maxKey + 55555), Key(maxKey + 55555)));
-    Flush(1);
+    ASSERT_OK(Flush(1));
     EXPECT_EQ(policy->DumpTestReport(),
               fifo ? "cf=abe,s=kCompactionStyleFIFO,n=7,l=0,b=0,r=kFlush\n"
                    : "cf=bob,s=kCompactionStyleLevel,n=7,l=0,b=0,r=kFlush\n");
@@ -1713,7 +1713,7 @@ TEST_F(DBBloomFilterTest, ContextCustomFilterPolicy) {
     for (int i = maxKey / 2; i < maxKey; i++) {
       ASSERT_OK(Put(1, Key(i), Key(i)));
     }
-    Flush(1);
+    ASSERT_OK(Flush(1));
     EXPECT_EQ(policy->DumpTestReport(),
               fifo ? "cf=abe,s=kCompactionStyleFIFO,n=7,l=0,b=0,r=kFlush\n"
                    : "cf=bob,s=kCompactionStyleLevel,n=7,l=0,b=0,r=kFlush\n");
@@ -2261,7 +2261,7 @@ TEST_P(BloomStatsTestWithParam, BloomStatsTest) {
   ASSERT_EQ(0, get_perf_context()->bloom_sst_hit_count);
   ASSERT_EQ(0, get_perf_context()->bloom_sst_miss_count);
 
-  Flush();
+  ASSERT_OK(Flush());
 
   // sanity checks
   ASSERT_EQ(0, get_perf_context()->bloom_sst_hit_count);
@@ -2311,7 +2311,7 @@ TEST_P(BloomStatsTestWithParam, BloomStatsTestWithIter) {
   ASSERT_EQ(1, get_perf_context()->bloom_memtable_miss_count);
   ASSERT_EQ(2, get_perf_context()->bloom_memtable_hit_count);
 
-  Flush();
+  ASSERT_OK(Flush());
 
   iter.reset(dbfull()->NewIterator(ReadOptions()));
 
@@ -2379,7 +2379,7 @@ void PrefixScanInit(DBBloomFilterTest* dbtest) {
     snprintf(buf, sizeof(buf), "%02d______:end", i + 1);
     keystr = std::string(buf);
     ASSERT_OK(dbtest->Put(keystr, keystr));
-    dbtest->Flush();
+    ASSERT_OK(dbtest->Flush());
   }
 
   // GROUP 2
@@ -2390,7 +2390,7 @@ void PrefixScanInit(DBBloomFilterTest* dbtest) {
     snprintf(buf, sizeof(buf), "%02d______:end", small_range_sstfiles + i + 1);
     keystr = std::string(buf);
     ASSERT_OK(dbtest->Put(keystr, keystr));
-    dbtest->Flush();
+    ASSERT_OK(dbtest->Flush());
   }
 }
 }  // anonymous namespace
@@ -2853,7 +2853,7 @@ TEST_F(DBBloomFilterTest, DynamicBloomFilterMultipleSST) {
     ASSERT_OK(Put("foo", "bar"));
     ASSERT_OK(Put("foq1", "bar1"));
     ASSERT_OK(Put("fpa", "0"));
-    dbfull()->Flush(FlushOptions());
+    ASSERT_OK(dbfull()->Flush(FlushOptions()));
     std::unique_ptr<Iterator> iter_old(db_->NewIterator(read_options));
     ASSERT_EQ(CountIter(iter_old, "foo"), 4);
     EXPECT_EQ(PopTicker(options, NON_LAST_LEVEL_SEEK_FILTERED), 0);
@@ -2981,7 +2981,7 @@ TEST_F(DBBloomFilterTest, DynamicBloomFilterNewColumnFamily) {
     ASSERT_OK(Put(2, "foo5", "bar5"));
     ASSERT_OK(Put(2, "foq6", "bar6"));
     ASSERT_OK(Put(2, "fpq7", "bar7"));
-    dbfull()->Flush(FlushOptions());
+    ASSERT_OK(dbfull()->Flush(FlushOptions()));
     {
       std::unique_ptr<Iterator> iter(
           db_->NewIterator(read_options, handles_[2]));
@@ -3031,17 +3031,17 @@ TEST_F(DBBloomFilterTest, DynamicBloomFilterOptions) {
     ASSERT_OK(Put("foo", "bar"));
     ASSERT_OK(Put("foo1", "bar1"));
     ASSERT_OK(Put("fpa", "0"));
-    dbfull()->Flush(FlushOptions());
+    ASSERT_OK(dbfull()->Flush(FlushOptions()));
     ASSERT_OK(Put("foo3", "bar3"));
     ASSERT_OK(Put("foo4", "bar4"));
     ASSERT_OK(Put("foo5", "bar5"));
     ASSERT_OK(Put("fpb", "1"));
-    dbfull()->Flush(FlushOptions());
+    ASSERT_OK(dbfull()->Flush(FlushOptions()));
     ASSERT_OK(Put("foo6", "bar6"));
     ASSERT_OK(Put("foo7", "bar7"));
     ASSERT_OK(Put("foo8", "bar8"));
     ASSERT_OK(Put("fpc", "2"));
-    dbfull()->Flush(FlushOptions());
+    ASSERT_OK(dbfull()->Flush(FlushOptions()));
 
     ReadOptions read_options;
     read_options.prefix_same_as_start = true;

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -9792,7 +9792,7 @@ TEST_F(DBCompactionTest, NumberOfSubcompactions) {
     SubCompactionEventListener* listener = new SubCompactionEventListener();
     options.listeners.clear();
     options.listeners.emplace_back(listener);
-    TryReopen(options);
+    ASSERT_OK(TryReopen(options));
 
     for (int file = 0; file < kLevel0CompactTrigger; ++file) {
       for (int key = file; key < 2 * kNumKeyPerFile; key += 2) {

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -222,7 +222,7 @@ TEST_F(DBFlushTest, CloseDBWhenFlushInLowPri) {
   sleeping_task_low.WaitUntilDone();
   ASSERT_EQ(0, num_flushes);
 
-  TryReopenWithColumnFamilies({"default", "cf1", "cf2"}, options);
+  ASSERT_OK(TryReopenWithColumnFamilies({"default", "cf1", "cf2"}, options));
   ASSERT_OK(Put(0, "key3", DummyString(8192)));
   ASSERT_OK(Flush(0));
   ASSERT_EQ(1, num_flushes);

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -986,6 +986,8 @@ Status DB::OpenAndCompact(
   delete db;
   if (s.ok()) {
     return serialization_status;
+  } else {
+    serialization_status.PermitUncheckedError();
   }
   return s;
 }

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1308,7 +1308,7 @@ TEST_F(DBOptionsTest, TempOptionsFailTest) {
       [&](void* /*arg*/) { fs->SetFilesystemActive(true); });
 
   SyncPoint::GetInstance()->EnableProcessing();
-  TryReopen(options);
+  ASSERT_NOK(TryReopen(options));
   SyncPoint::GetInstance()->DisableProcessing();
 
   std::vector<std::string> filenames;

--- a/db/db_statistics_test.cc
+++ b/db/db_statistics_test.cc
@@ -219,7 +219,7 @@ TEST_F(DBStatisticsTest, VerifyChecksumReadStat) {
   ASSERT_OK(Flush());
   std::unordered_map<std::string, uint64_t> table_files;
   uint64_t table_files_size = 0;
-  GetAllDataFiles(kTableFile, &table_files, &table_files_size);
+  ASSERT_OK(GetAllDataFiles(kTableFile, &table_files, &table_files_size));
 
   {
     // Scenario 1: Table verified in `VerifyFileChecksums()`. This should read

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -697,7 +697,7 @@ TEST_F(DBTest, ReadFromPersistedTier) {
 
       // 3rd round: delete and flush
       ASSERT_OK(db_->Delete(wopt, handles_[1], "foo"));
-      Flush(1);
+      ASSERT_OK(Flush(1));
       ASSERT_OK(db_->Delete(wopt, handles_[1], "bar"));
 
       ASSERT_TRUE(db_->Get(ropt, handles_[1], "foo", &value).IsNotFound());
@@ -860,7 +860,7 @@ TEST_F(DBTest, DISABLED_VeryLargeValue) {
   ASSERT_EQ('w', value[0]);
 
   // Compact all files.
-  Flush();
+  ASSERT_OK(Flush());
   db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
 
   // Check DB is not in read-only state.
@@ -1300,7 +1300,7 @@ TEST_F(DBTest, MetaDataTest) {
   options.disable_auto_compactions = true;
 
   int64_t temp_time = 0;
-  options.env->GetCurrentTime(&temp_time);
+  ASSERT_OK(options.env->GetCurrentTime(&temp_time));
   uint64_t start_time = static_cast<uint64_t>(temp_time);
 
   DestroyAndReopen(options);
@@ -1329,7 +1329,7 @@ TEST_F(DBTest, MetaDataTest) {
   std::vector<std::vector<FileMetaData>> files_by_level;
   dbfull()->TEST_GetFilesMetaData(db_->DefaultColumnFamily(), &files_by_level);
 
-  options.env->GetCurrentTime(&temp_time);
+  ASSERT_OK(options.env->GetCurrentTime(&temp_time));
   uint64_t end_time = static_cast<uint64_t>(temp_time);
 
   ColumnFamilyMetaData cf_meta;
@@ -3648,7 +3648,7 @@ TEST_F(DBTest, BlockBasedTablePrefixHashIndexTest) {
   ASSERT_OK(Put("kk2", "v2"));
   ASSERT_OK(Put("kk", "v3"));
   ASSERT_OK(Put("k", "v4"));
-  Flush();
+  ASSERT_OK(Flush());
 
   ASSERT_EQ("v1", Get("kk1"));
   ASSERT_EQ("v2", Get("kk2"));
@@ -4280,8 +4280,8 @@ TEST_F(DBTest, ConcurrentMemtableNotSupported) {
   options.soft_pending_compaction_bytes_limit = 0;
   options.hard_pending_compaction_bytes_limit = 100;
   options.create_if_missing = true;
-
-  DestroyDB(dbname_, options);
+  Close();
+  ASSERT_OK(DestroyDB(dbname_, options));
   options.memtable_factory.reset(NewHashLinkListRepFactory(4, 0, 3, true, 4));
   ASSERT_NOK(TryReopen(options));
 
@@ -4622,7 +4622,7 @@ TEST_F(DBTest, GetThreadStatus) {
   Options options;
   options.env = env_;
   options.enable_thread_tracking = true;
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
 
   std::vector<ThreadStatus> thread_list;
   Status s = env_->GetThreadList(&thread_list);
@@ -4693,7 +4693,7 @@ TEST_F(DBTest, DisableThreadStatus) {
   Options options;
   options.env = env_;
   options.enable_thread_tracking = false;
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
   CreateAndReopenWithCF({"pikachu", "about-to-remove"}, options);
   // Verify non of the column family info exists
   env_->GetThreadStatusUpdater()->TEST_VerifyColumnFamilyInfoMap(handles_,
@@ -4902,7 +4902,7 @@ TEST_P(DBTestWithParam, PreShutdownMultipleCompaction) {
   options.level0_slowdown_writes_trigger = 1 << 10;
   options.max_subcompactions = max_subcompactions_;
 
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
   Random rnd(301);
 
   std::vector<ThreadStatus> thread_list;
@@ -4991,7 +4991,7 @@ TEST_P(DBTestWithParam, PreShutdownCompactionMiddle) {
   options.level0_slowdown_writes_trigger = 1 << 10;
   options.max_subcompactions = max_subcompactions_;
 
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
   Random rnd(301);
 
   std::vector<ThreadStatus> thread_list;
@@ -7206,14 +7206,14 @@ TEST_F(DBTest, CreationTimeOfOldestFile) {
   int idx = 0;
 
   int64_t time_1 = 0;
-  env_->GetCurrentTime(&time_1);
+  ASSERT_OK(env_->GetCurrentTime(&time_1));
   const uint64_t uint_time_1 = static_cast<uint64_t>(time_1);
 
   // Add 50 hours
   env_->MockSleepForSeconds(50 * 60 * 60);
 
   int64_t time_2 = 0;
-  env_->GetCurrentTime(&time_2);
+  ASSERT_OK(env_->GetCurrentTime(&time_2));
   const uint64_t uint_time_2 = static_cast<uint64_t>(time_2);
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -266,7 +266,7 @@ TEST_F(DBTest2, CacheIndexAndFilterWithDBRestart) {
   ASSERT_OK(Put(1, "a", "begin"));
   ASSERT_OK(Put(1, "z", "end"));
   ASSERT_OK(Flush(1));
-  TryReopenWithColumnFamilies({"default", "pikachu"}, options);
+  ASSERT_OK(TryReopenWithColumnFamilies({"default", "pikachu"}, options));
 
   std::string value;
   value = Get(1, "a");
@@ -357,10 +357,10 @@ TEST_P(DBTestSharedWriteBufferAcrossCFs, SharedWriteBufferAcrossCFs) {
   // are newer CFs created.
   flush_listener->expected_flush_reason = FlushReason::kManualFlush;
   ASSERT_OK(Put(3, Key(1), DummyString(1), wo));
-  Flush(3);
+  ASSERT_OK(Flush(3));
   ASSERT_OK(Put(3, Key(1), DummyString(1), wo));
   ASSERT_OK(Put(0, Key(1), DummyString(1), wo));
-  Flush(0);
+  ASSERT_OK(Flush(0));
   ASSERT_EQ(GetNumberOfSstFilesForColumnFamily(db_, "default"),
             static_cast<uint64_t>(1));
   ASSERT_EQ(GetNumberOfSstFilesForColumnFamily(db_, "nikitich"),
@@ -2068,7 +2068,7 @@ class PinL0IndexAndFilterBlocksTest
     // reset block cache
     table_options.block_cache = NewLRUCache(64 * 1024);
     options->table_factory.reset(NewBlockBasedTableFactory(table_options));
-    TryReopenWithColumnFamilies({"default", "pikachu"}, *options);
+    ASSERT_OK(TryReopenWithColumnFamilies({"default", "pikachu"}, *options));
     // create new table at L0
     ASSERT_OK(Put(1, "a2", "begin2"));
     ASSERT_OK(Put(1, "z2", "end2"));
@@ -2188,7 +2188,7 @@ TEST_P(PinL0IndexAndFilterBlocksTest, DisablePrefetchingNonL0IndexAndFilter) {
   // Reopen database. If max_open_files is set as -1, table readers will be
   // preloaded. This will trigger a BlockBasedTable::Open() and prefetch
   // L0 index and filter. Level 1's prefetching is disabled in DB::Open()
-  TryReopenWithColumnFamilies({"default", "pikachu"}, options);
+  ASSERT_OK(TryReopenWithColumnFamilies({"default", "pikachu"}, options));
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 
@@ -3804,7 +3804,7 @@ TEST_F(DBTest2, MemtableOnlyIterator) {
   ASSERT_EQ(2, count);
   delete it;
 
-  Flush(1);
+  ASSERT_OK(Flush(1));
 
   // After flushing
   // point lookups
@@ -4112,7 +4112,7 @@ TEST_F(DBTest2, LiveFilesOmitObsoleteFiles) {
   ASSERT_OK(Put("key", "val"));
   FlushOptions flush_opts;
   flush_opts.wait = false;
-  db_->Flush(flush_opts);
+  ASSERT_OK(db_->Flush(flush_opts));
   TEST_SYNC_POINT("DBTest2::LiveFilesOmitObsoleteFiles:FlushTriggered");
 
   ASSERT_OK(db_->DisableFileDeletions());

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -259,7 +259,7 @@ bool DBTestBase::ChangeFilterOptions() {
 
   auto options = CurrentOptions();
   options.create_if_missing = true;
-  TryReopen(options);
+  EXPECT_OK(TryReopen(options));
   return true;
 }
 
@@ -270,34 +270,34 @@ bool DBTestBase::ChangeOptionsForFileIngestionTest() {
     Destroy(last_options_);
     auto options = CurrentOptions();
     options.create_if_missing = true;
-    TryReopen(options);
+    EXPECT_OK(TryReopen(options));
     return true;
   } else if (option_config_ == kUniversalCompaction) {
     option_config_ = kUniversalCompactionMultiLevel;
     Destroy(last_options_);
     auto options = CurrentOptions();
     options.create_if_missing = true;
-    TryReopen(options);
+    EXPECT_OK(TryReopen(options));
     return true;
   } else if (option_config_ == kUniversalCompactionMultiLevel) {
     option_config_ = kLevelSubcompactions;
     Destroy(last_options_);
     auto options = CurrentOptions();
     assert(options.max_subcompactions > 1);
-    TryReopen(options);
+    EXPECT_OK(TryReopen(options));
     return true;
   } else if (option_config_ == kLevelSubcompactions) {
     option_config_ = kUniversalSubcompactions;
     Destroy(last_options_);
     auto options = CurrentOptions();
     assert(options.max_subcompactions > 1);
-    TryReopen(options);
+    EXPECT_OK(TryReopen(options));
     return true;
   } else if (option_config_ == kUniversalSubcompactions) {
     option_config_ = kDirectIO;
     Destroy(last_options_);
     auto options = CurrentOptions();
-    TryReopen(options);
+    EXPECT_OK(TryReopen(options));
     return true;
   } else {
     return false;

--- a/db/db_write_buffer_manager_test.cc
+++ b/db/db_write_buffer_manager_test.cc
@@ -42,10 +42,10 @@ TEST_P(DBWriteBufferManagerTest, SharedBufferAcrossCFs1) {
 
   CreateAndReopenWithCF({"cf1", "cf2", "cf3"}, options);
   ASSERT_OK(Put(3, Key(1), DummyString(1), wo));
-  Flush(3);
+  ASSERT_OK(Flush(3));
   ASSERT_OK(Put(3, Key(1), DummyString(1), wo));
   ASSERT_OK(Put(0, Key(1), DummyString(1), wo));
-  Flush(0);
+  ASSERT_OK(Flush(0));
 
   // Write to "Default", "cf2" and "cf3".
   ASSERT_OK(Put(3, Key(1), DummyString(30000), wo));
@@ -84,10 +84,10 @@ TEST_P(DBWriteBufferManagerTest, SharedWriteBufferAcrossCFs2) {
 
   CreateAndReopenWithCF({"cf1", "cf2", "cf3"}, options);
   ASSERT_OK(Put(3, Key(1), DummyString(1), wo));
-  Flush(3);
+  ASSERT_OK(Flush(3));
   ASSERT_OK(Put(3, Key(1), DummyString(1), wo));
   ASSERT_OK(Put(0, Key(1), DummyString(1), wo));
-  Flush(0);
+  ASSERT_OK(Flush(0));
 
   // Write to "Default", "cf2" and "cf3". No flush will be triggered.
   ASSERT_OK(Put(3, Key(1), DummyString(30000), wo));
@@ -471,10 +471,10 @@ TEST_P(DBWriteBufferManagerTest, MixedSlowDownOptionsSingleDB) {
   CreateAndReopenWithCF({"cf1", "cf2", "cf3"}, options);
 
   ASSERT_OK(Put(3, Key(1), DummyString(1), wo));
-  Flush(3);
+  ASSERT_OK(Flush(3));
   ASSERT_OK(Put(3, Key(1), DummyString(1), wo));
   ASSERT_OK(Put(0, Key(1), DummyString(1), wo));
-  Flush(0);
+  ASSERT_OK(Flush(0));
 
   // Write to "Default", "cf2" and "cf3". No flush will be triggered.
   ASSERT_OK(Put(3, Key(1), DummyString(30000), wo));

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -495,7 +495,7 @@ TEST_P(DBWriteTest, UnflushedPutRaceWithTrackedWalSync) {
 
   // Simulate full loss of unsynced data. This drops "key2" -> "val2" from the
   // DB WAL.
-  fault_env->DropUnsyncedFileData();
+  ASSERT_OK(fault_env->DropUnsyncedFileData());
 
   Reopen(options);
 
@@ -536,7 +536,7 @@ TEST_P(DBWriteTest, InactiveWalFullySyncedBeforeUntracked) {
 
   // Simulate full loss of unsynced data. This should drop nothing since we did
   // `FlushWAL(true /* sync */)` before `Close()`.
-  fault_env->DropUnsyncedFileData();
+  ASSERT_OK(fault_env->DropUnsyncedFileData());
 
   Reopen(options);
 

--- a/db/error_handler_fs_test.cc
+++ b/db/error_handler_fs_test.cc
@@ -2565,8 +2565,8 @@ TEST_F(DBErrorHandlingFSTest, AtomicFlushReadError) {
   s = dbfull()->TEST_GetBGError();
   ASSERT_OK(s);
 
-  TryReopenWithColumnFamilies({kDefaultColumnFamilyName, "pikachu"},
-                              GetDefaultOptions());
+  ASSERT_OK(TryReopenWithColumnFamilies({kDefaultColumnFamilyName, "pikachu"},
+                                        GetDefaultOptions()));
   ASSERT_EQ("val", Get(Key(0)));
 }
 
@@ -2606,8 +2606,8 @@ TEST_F(DBErrorHandlingFSTest, AtomicFlushNoSpaceError) {
   s = dbfull()->TEST_GetBGError();
   ASSERT_OK(s);
 
-  TryReopenWithColumnFamilies({kDefaultColumnFamilyName, "pikachu"},
-                              GetDefaultOptions());
+  ASSERT_OK(TryReopenWithColumnFamilies({kDefaultColumnFamilyName, "pikachu"},
+                                        GetDefaultOptions()));
   ASSERT_EQ("val", Get(Key(0)));
 }
 

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -1346,7 +1346,7 @@ TEST_P(ExternalSSTFileBasicTest, IngestionWithRangeDeletions) {
   // range del [0, 50) in L6 file, [50, 100) in L0 file, [100, 150) in memtable
   for (int i = 0; i < 3; i++) {
     if (i != 0) {
-      db_->Flush(FlushOptions());
+      ASSERT_OK(db_->Flush(FlushOptions()));
       if (i == 1) {
         MoveFilesToLevel(kNumLevels - 1);
       }
@@ -1747,11 +1747,11 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileAfterDBPut) {
   Options options = CurrentOptions();
 
   ASSERT_OK(Put("k", "a"));
-  Flush();
+  ASSERT_OK(Flush());
   ASSERT_OK(Put("k", "a"));
-  Flush();
+  ASSERT_OK(Flush());
   ASSERT_OK(Put("k", "a"));
-  Flush();
+  ASSERT_OK(Flush());
   SstFileWriter sst_file_writer(EnvOptions(), options);
 
   // Current file size should be 0 after sst_file_writer init and before open a

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -2223,7 +2223,7 @@ TEST_P(ExternalSSTFileTest, IngestBehind) {
   // Trigger compaction if size amplification exceeds 110%.
   options.compaction_options_universal.max_size_amplification_percent = 110;
   options.level0_file_num_compaction_trigger = 4;
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
   Random rnd(301);
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 10; j++) {
@@ -2239,7 +2239,7 @@ TEST_P(ExternalSSTFileTest, IngestBehind) {
 
   // Turning off the option allows DB to compact ingested files.
   options.allow_ingest_behind = false;
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   dbfull()->TEST_GetFilesMetaData(db_->DefaultColumnFamily(), &level_to_files);
   ASSERT_EQ(1, level_to_files[2].size());

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -443,7 +443,7 @@ TEST_P(FaultInjectionTest, UninstalledCompaction) {
   options_.level0_stop_writes_trigger = 1 << 10;
   options_.level0_slowdown_writes_trigger = 1 << 10;
   options_.max_background_compactions = 1;
-  OpenDB();
+  ASSERT_OK(OpenDB());
 
   if (!sequential_order_) {
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency({

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -582,7 +582,7 @@ TEST_F(EventListenerTest, CompactionReasonLevel) {
   for (int k = 1; k <= 30; k++) {
     ASSERT_OK(Put(Key(k), Key(k)));
     if (k % 10 == 0) {
-      Flush();
+      ASSERT_OK(Flush());
     }
   }
 

--- a/db/perf_context_test.cc
+++ b/db/perf_context_test.cc
@@ -262,7 +262,7 @@ void ProfileQueries(bool enabled_time = false) {
   for (const int i : keys) {
     if (i == kFlushFlag) {
       FlushOptions fo;
-      db->Flush(fo);
+      ASSERT_OK(db->Flush(fo));
       continue;
     }
 
@@ -1111,7 +1111,7 @@ TEST_F(PerfContextTest, MergeOperandCount) {
   verify();
 
   // Verify counters when reading from table files
-  db->Flush(FlushOptions());
+  ASSERT_OK(db->Flush(FlushOptions()));
 
   verify();
 }

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -1221,7 +1221,7 @@ class VersionSetTestBase {
       tmp_db_options.env = env_;
       std::unique_ptr<DBImpl> impl(new DBImpl(tmp_db_options, dbname_));
       std::string db_id;
-      impl->GetDbIdentityFromIdentityFile(&db_id);
+      ASSERT_OK(impl->GetDbIdentityFromIdentityFile(&db_id));
       new_db.SetDBId(db_id);
     }
     new_db.SetLogNumber(0);
@@ -1277,7 +1277,7 @@ class VersionSetTestBase {
   void NewDB() {
     SequenceNumber last_seqno;
     std::unique_ptr<log::Writer> log_writer;
-    SetIdentityFile(env_, dbname_);
+    ASSERT_OK(SetIdentityFile(env_, dbname_));
     PrepareManifest(&column_families_, &last_seqno, &log_writer);
     log_writer.reset();
     // Make "CURRENT" file point to the new manifest file.
@@ -2862,11 +2862,12 @@ class VersionSetTestEmptyDb
     assert(nullptr != log_writer);
     VersionEdit new_db;
     if (db_options_.write_dbid_to_manifest) {
+      ASSERT_OK(SetIdentityFile(env_, dbname_));
       DBOptions tmp_db_options;
       tmp_db_options.env = env_;
       std::unique_ptr<DBImpl> impl(new DBImpl(tmp_db_options, dbname_));
       std::string db_id;
-      impl->GetDbIdentityFromIdentityFile(&db_id);
+      ASSERT_OK(impl->GetDbIdentityFromIdentityFile(&db_id));
       new_db.SetDBId(db_id);
     }
     const std::string manifest_path = DescriptorFileName(dbname_, 1);
@@ -3196,7 +3197,7 @@ class VersionSetTestMissingFiles : public VersionSetTestBase,
       tmp_db_options.env = env_;
       std::unique_ptr<DBImpl> impl(new DBImpl(tmp_db_options, dbname_));
       std::string db_id;
-      impl->GetDbIdentityFromIdentityFile(&db_id);
+      ASSERT_OK(impl->GetDbIdentityFromIdentityFile(&db_id));
       new_db.SetDBId(db_id);
     }
     {

--- a/file/delete_scheduler_test.cc
+++ b/file/delete_scheduler_test.cc
@@ -40,7 +40,7 @@ class DeleteSchedulerTest : public testing::Test {
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency({});
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
     for (const auto& dummy_files_dir : dummy_files_dirs_) {
-      DestroyDir(env_, dummy_files_dir);
+      EXPECT_OK(DestroyDir(env_, dummy_files_dir));
     }
   }
 
@@ -82,11 +82,11 @@ class DeleteSchedulerTest : public testing::Test {
     std::string file_path =
         dummy_files_dirs_[dummy_files_dirs_idx] + "/" + file_name;
     std::unique_ptr<WritableFile> f;
-    env_->NewWritableFile(file_path, &f, EnvOptions());
+    EXPECT_OK(env_->NewWritableFile(file_path, &f, EnvOptions()));
     std::string data(size, 'A');
     EXPECT_OK(f->Append(data));
     EXPECT_OK(f->Close());
-    sst_file_mgr_->OnAddFile(file_path);
+    EXPECT_OK(sst_file_mgr_->OnAddFile(file_path));
     return file_path;
   }
 

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -550,7 +550,7 @@ TEST_P(PrefetchTest, ConfigureAutoMaxReadaheadSize) {
   }
   Close();
   std::vector<int> buff_prefectch_level_count = {0, 0, 0};
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
   {
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
     fs->ClearPrefetchCount();
@@ -678,7 +678,7 @@ TEST_P(PrefetchTest, ConfigureInternalAutoReadaheadSize) {
   }
   Close();
 
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
   {
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
     fs->ClearPrefetchCount();
@@ -793,7 +793,7 @@ TEST_P(PrefetchTest, ConfigureNumFilesReadsForReadaheadSize) {
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &least, &greatest));
 
   Close();
-  TryReopen(options);
+  ASSERT_OK(TryReopen(options));
 
   fs->ClearPrefetchCount();
   buff_prefetch_count = 0;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -34,8 +34,6 @@ namespace ROCKSDB_NAMESPACE {
 #if defined OS_LINUX || defined OS_WIN
 #ifndef __clang__
 #ifndef ROCKSDB_UBSAN_RUN
-// status check adds CXX flag -fno-elide-constructors which fails this test.
-#ifndef ROCKSDB_ASSERT_STATUS_CHECKED
 
 class OptionsSettableTest : public testing::Test {
  public:
@@ -380,6 +378,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
   delete[] new_options_ptr;
 }
 
+// status check adds CXX flag -fno-elide-constructors which fails this test.
+#ifndef ROCKSDB_ASSERT_STATUS_CHECKED
 // If the test fails, likely a new option is added to ColumnFamilyOptions
 // but it cannot be set through GetColumnFamilyOptionsFromString(), or the
 // test is not updated accordingly.

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -34,6 +34,8 @@ namespace ROCKSDB_NAMESPACE {
 #if defined OS_LINUX || defined OS_WIN
 #ifndef __clang__
 #ifndef ROCKSDB_UBSAN_RUN
+// status check adds CXX flag -fno-elide-constructors which fails this test.
+#ifndef ROCKSDB_ASSERT_STATUS_CHECKED
 
 class OptionsSettableTest : public testing::Test {
  public:
@@ -641,6 +643,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
   delete[] mcfo2_ptr;
   delete[] cfo_clean_ptr;
 }
+#endif  // !ROCKSDB_ASSERT_STATUS_CHECKED
 #endif  // !ROCKSDB_UBSAN_RUN
 #endif  // !__clang__
 #endif  // OS_LINUX || OS_WIN

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -589,7 +589,7 @@ void AssertExists(DB* db, int from, int to) {
   for (int i = from; i < to; ++i) {
     std::string key = "testkey" + std::to_string(i);
     std::string value;
-    Status s = db->Get(ReadOptions(), Slice(key), &value);
+    ASSERT_OK(db->Get(ReadOptions(), Slice(key), &value));
     ASSERT_EQ(value, "testvalue" + std::to_string(i));
   }
 }
@@ -4308,13 +4308,13 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
   for (auto be_pair :
        {std::make_pair(backup_engine_.get(), alt_backup_engine),
         std::make_pair(alt_backup_engine, backup_engine_.get())}) {
-    DestroyDB(dbname_, options_);
+    ASSERT_OK(DestroyDB(dbname_, options_));
     RestoreOptions ro;
     // Fails without alternate dir
     ASSERT_TRUE(be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro)
                     .IsInvalidArgument());
 
-    DestroyDB(dbname_, options_);
+    ASSERT_OK(DestroyDB(dbname_, options_));
     // Works with alternate dir
     ro.alternate_dirs.push_front(be_pair.second);
     ASSERT_OK(be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro));
@@ -4332,7 +4332,7 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
   for (auto be_pair :
        {std::make_pair(backup_engine_.get(), alt_backup_engine),
         std::make_pair(alt_backup_engine, backup_engine_.get())}) {
-    DestroyDB(dbname_, options_);
+    ASSERT_OK(DestroyDB(dbname_, options_));
     RestoreOptions ro;
     ro.alternate_dirs.push_front(be_pair.second);
     ASSERT_OK(be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro));

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -269,7 +269,7 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   // Add trash files in blob dir to file delete scheduler.
   SstFileManagerImpl* sfm = static_cast<SstFileManagerImpl*>(
       db_impl_->immutable_db_options().sst_file_manager.get());
-  DeleteScheduler::CleanupDirectory(env_, sfm, blob_dir_);
+  s = DeleteScheduler::CleanupDirectory(env_, sfm, blob_dir_);
 
   UpdateLiveSSTSize();
 
@@ -1915,7 +1915,7 @@ std::pair<bool, int64_t> BlobDBImpl::EvictExpiredFiles(bool aborted) {
       }
 
       if (!blob_file->Immutable()) {
-        CloseBlobFile(blob_file);
+        CloseBlobFile(blob_file).PermitUncheckedError();
       }
 
       assert(blob_file->Immutable());

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -270,6 +270,12 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   SstFileManagerImpl* sfm = static_cast<SstFileManagerImpl*>(
       db_impl_->immutable_db_options().sst_file_manager.get());
   s = DeleteScheduler::CleanupDirectory(env_, sfm, blob_dir_);
+  if (!s.ok()) {
+    ROCKS_LOG_ERROR(db_options_.info_log,
+                    "Failed to clean up directory %s, status: %s",
+                    blob_dir_.c_str(), s.ToString().c_str());
+    return s;
+  }
 
   UpdateLiveSSTSize();
 

--- a/utilities/blob_db/blob_db_listener.h
+++ b/utilities/blob_db/blob_db_listener.h
@@ -22,7 +22,7 @@ class BlobDBListener : public EventListener {
 
   void OnFlushBegin(DB* /*db*/, const FlushJobInfo& /*info*/) override {
     assert(blob_db_impl_ != nullptr);
-    blob_db_impl_->SyncBlobFiles();
+    blob_db_impl_->SyncBlobFiles().PermitUncheckedError();
   }
 
   void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& /*info*/) override {

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -925,7 +925,7 @@ TEST_F(CheckpointTest, CheckpointWithDbPath) {
   options.db_paths.emplace_back(dbname_ + "_2", 0);
   Reopen(options);
   ASSERT_OK(Put("key1", "val1"));
-  Flush();
+  ASSERT_OK(Flush());
   Checkpoint* checkpoint;
   ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
   // Currently not supported
@@ -968,7 +968,7 @@ TEST_F(CheckpointTest, PutRaceWithCheckpointTrackedWalSync) {
 
   // Simulate full loss of unsynced data. This drops "key2" -> "val2" from the
   // DB WAL.
-  fault_env->DropUnsyncedFileData();
+  ASSERT_OK(fault_env->DropUnsyncedFileData());
 
   // Before the bug fix, reopening the DB would fail because the MANIFEST's
   // AddWal entry indicated the WAL should be synced through "key2" -> "val2".

--- a/utilities/option_change_migration/option_change_migration_test.cc
+++ b/utilities/option_change_migration/option_change_migration_test.cc
@@ -229,7 +229,7 @@ TEST_P(DBOptionChangeMigrationTests, Migrate3) {
     for (int i = 0; i < 50; i++) {
       ASSERT_OK(Put(Key(num * 100 + i), rnd.RandomString(900)));
     }
-    Flush();
+    ASSERT_OK(Flush());
     ASSERT_OK(dbfull()->TEST_WaitForCompact());
     if (num == 9) {
       // Issue a full compaction to generate some zero-out files
@@ -313,7 +313,7 @@ TEST_P(DBOptionChangeMigrationTests, Migrate4) {
     for (int i = 0; i < 50; i++) {
       ASSERT_OK(Put(Key(num * 100 + i), rnd.RandomString(900)));
     }
-    Flush();
+    ASSERT_OK(Flush());
     ASSERT_OK(dbfull()->TEST_WaitForCompact());
     if (num == 9) {
       // Issue a full compaction to generate some zero-out files
@@ -496,7 +496,7 @@ TEST_F(DBOptionChangeMigrationTest, CompactedSrcToUniversal) {
       ASSERT_OK(Put(Key(num * 100 + i), rnd.RandomString(900)));
     }
   }
-  Flush();
+  ASSERT_OK(Flush());
   CompactRangeOptions cro;
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
   ASSERT_OK(dbfull()->CompactRange(cro, nullptr, nullptr));

--- a/utilities/transactions/lock/point/point_lock_manager_test.cc
+++ b/utilities/transactions/lock/point/point_lock_manager_test.cc
@@ -128,14 +128,14 @@ TEST_F(PointLockManagerTest, DeadlockDepthExceeded) {
   port::Thread t1 = BlockUntilWaitingTxn(wait_sync_point_name_, [&]() {
     ASSERT_OK(locker_->TryLock(txn2, 1, "k2", env_, true));
     // block because txn1 is holding a lock on k1.
-    locker_->TryLock(txn2, 1, "k1", env_, true);
+    ASSERT_OK(locker_->TryLock(txn2, 1, "k1", env_, true));
   });
 
   ASSERT_OK(locker_->TryLock(txn3, 1, "k3", env_, true));
 
   port::Thread t2 = BlockUntilWaitingTxn(wait_sync_point_name_, [&]() {
     // block because txn3 is holding a lock on k1.
-    locker_->TryLock(txn4, 1, "k3", env_, true);
+    ASSERT_OK(locker_->TryLock(txn4, 1, "k3", env_, true));
   });
 
   auto s = locker_->TryLock(txn3, 1, "k2", env_, true);

--- a/utilities/transactions/lock/point/point_lock_manager_test.h
+++ b/utilities/transactions/lock/point/point_lock_manager_test.h
@@ -244,7 +244,7 @@ TEST_P(AnyLockManagerTest, Deadlock) {
   // txn1 tries to lock k2, will block forever.
   port::Thread t = BlockUntilWaitingTxn(wait_sync_point_name_, [&]() {
     // block because txn2 is holding a lock on k2.
-    locker_->TryLock(txn1, 1, "k2", env_, true);
+    ASSERT_OK(locker_->TryLock(txn1, 1, "k2", env_, true));
   });
 
   auto s = locker_->TryLock(txn2, 1, "k1", env_, true);

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -704,6 +704,7 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
   s = txn_db->Get(read_options, "AAA", &value);
   ASSERT_TRUE(s.IsNotFound());
   s = txn_db->Get(read_options, handles[2], "AAAZZZ", &value);
+  ASSERT_OK(s);
   ASSERT_EQ(value, "barbar");
 
   Slice key_slices[3] = {Slice("AAA"), Slice("ZZ"), Slice("Z")};
@@ -830,7 +831,7 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
     cur_seen = {};
     txn = txn_db->BeginTransaction(write_options, txn_options);
     for (const auto& key : keys) {
-      txn->Put(handles[0], key, "blah");
+      ASSERT_OK(txn->Put(handles[0], key, "blah"));
     }
     ASSERT_OK(txn->Commit());
     // Sufficiently large hash coverage of the space
@@ -843,7 +844,7 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
     cur_seen = {};
     txn = txn_db->BeginTransaction(write_options, txn_options, txn);
     for (const auto& key : keys) {
-      txn->Put(handles[0], key, "moo");
+      ASSERT_OK(txn->Put(handles[0], key, "moo"));
     }
     ASSERT_OK(txn->Commit());
     ASSERT_EQ(cur_seen.rolling_hash, base_seen.rolling_hash);
@@ -854,7 +855,7 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
     cur_seen = {};
     txn = txn_db->BeginTransaction(write_options, txn_options, txn);
     for (const auto& key : keys) {
-      txn->Put(handles[1], key, "blah");
+      ASSERT_OK(txn->Put(handles[1], key, "blah"));
     }
     ASSERT_OK(txn->Commit());
     // Different access pattern (different hash seed)
@@ -871,7 +872,7 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
     cur_seen = {};
     txn = txn_db->BeginTransaction(write_options, txn_options, txn);
     for (const auto& key : keys) {
-      txn->Put(handles[2], key, "blah");
+      ASSERT_OK(txn->Put(handles[2], key, "blah"));
     }
     ASSERT_OK(txn->Commit());
     // Different access pattern (different hash seed)
@@ -888,7 +889,7 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
     delete txn;
     txn = shared_txn_db->BeginTransaction(write_options, txn_options);
     for (const auto& key : keys) {
-      txn->Put(key, "blah");
+      ASSERT_OK(txn->Put(key, "blah"));
     }
     ASSERT_OK(txn->Commit());
     // Different access pattern (different hash seed)
@@ -905,7 +906,7 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
     delete txn;
     txn = nonshared_txn_db->BeginTransaction(write_options, txn_options);
     for (const auto& key : keys) {
-      txn->Put(key, "blah");
+      ASSERT_OK(txn->Put(key, "blah"));
     }
     ASSERT_OK(txn->Commit());
     // Different access pattern (different hash seed)
@@ -1422,7 +1423,7 @@ TEST_P(OptimisticTransactionTest, UndoGetForUpdateTest) {
   txn1->UndoGetForUpdate("A");
 
   Transaction* txn2 = txn_db->BeginTransaction(write_options);
-  txn2->Put("A", "x");
+  ASSERT_OK(txn2->Put("A", "x"));
   ASSERT_OK(txn2->Commit());
   delete txn2;
 

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -1382,7 +1382,7 @@ TEST_P(TransactionTest, PersistentTwoPhaseTransactionTest) {
   ASSERT_OK(db_impl->TEST_FlushMemTable(true));
 
   // regular db read
-  db->Get(read_options, "foo2", &value);
+  ASSERT_OK(db->Get(read_options, "foo2", &value));
   ASSERT_EQ(value, "bar2");
 
   // nothing has been prepped yet
@@ -1430,7 +1430,7 @@ TEST_P(TransactionTest, PersistentTwoPhaseTransactionTest) {
   ASSERT_OK(s);
 
   // value is now available
-  db->Get(read_options, "foo", &value);
+  ASSERT_OK(db->Get(read_options, "foo", &value));
   ASSERT_EQ(value, "bar");
 
   // we already committed
@@ -1601,10 +1601,10 @@ TEST_P(TransactionStressTest, TwoPhaseLongPrepareTest) {
       // crash
       fault_fs->SetFilesystemActive(false);
       reinterpret_cast<PessimisticTransactionDB*>(db)->TEST_Crash();
-      ReOpenNoDelete();
+      ASSERT_OK(ReOpenNoDelete());
     } else if (i % 37 == 0) {
       // close
-      ReOpenNoDelete();
+      ASSERT_OK(ReOpenNoDelete());
     }
   }
 
@@ -1668,7 +1668,7 @@ TEST_P(TransactionTest, TwoPhaseSequenceTest) {
 
   // kill and reopen
   fault_fs->SetFilesystemActive(false);
-  ReOpenNoDelete();
+  ASSERT_OK(ReOpenNoDelete());
   assert(db != nullptr);
 
   // value is now available
@@ -1706,7 +1706,7 @@ TEST_P(TransactionTest, TwoPhaseDoubleRecoveryTest) {
   // kill and reopen
   fault_fs->SetFilesystemActive(false);
   reinterpret_cast<PessimisticTransactionDB*>(db)->TEST_Crash();
-  ReOpenNoDelete();
+  ASSERT_OK(ReOpenNoDelete());
 
   // commit old txn
   assert(db != nullptr);  // Make clang analyze happy.
@@ -2186,9 +2186,9 @@ TEST_P(TransactionTest, WriteConflictTest) {
   s = txn->Commit();
   ASSERT_OK(s);
 
-  db->Get(read_options, "foo", &value);
+  ASSERT_OK(db->Get(read_options, "foo", &value));
   ASSERT_EQ(value, "A2");
-  db->Get(read_options, "foo2", &value);
+  ASSERT_OK(db->Get(read_options, "foo2", &value));
   ASSERT_EQ(value, "B2");
 
   delete txn;
@@ -2230,13 +2230,13 @@ TEST_P(TransactionTest, WriteConflictTest2) {
   ASSERT_OK(s);  // Txn should commit, but only write foo2 and foo3
 
   // Verify that transaction wrote foo2 and foo3 but not foo
-  db->Get(read_options, "foo", &value);
+  ASSERT_OK(db->Get(read_options, "foo", &value));
   ASSERT_EQ(value, "barz");
 
-  db->Get(read_options, "foo2", &value);
+  ASSERT_OK(db->Get(read_options, "foo2", &value));
   ASSERT_EQ(value, "X");
 
-  db->Get(read_options, "foo3", &value);
+  ASSERT_OK(db->Get(read_options, "foo3", &value));
   ASSERT_EQ(value, "Y");
 
   delete txn;
@@ -2328,13 +2328,13 @@ TEST_P(TransactionTest, FlushTest) {
 
   // force a memtable flush
   FlushOptions flush_ops;
-  db->Flush(flush_ops);
+  ASSERT_OK(db->Flush(flush_ops));
 
   s = txn->Commit();
   // txn should commit since the flushed table is still in MemtableList History
   ASSERT_OK(s);
 
-  db->Get(read_options, "foo", &value);
+  ASSERT_OK(db->Get(read_options, "foo", &value));
   ASSERT_EQ(value, "bar2");
 
   delete txn;
@@ -6023,7 +6023,7 @@ TEST_P(TransactionTest, DuplicateKeys) {
     cf_options.max_successive_merges = 2;
     cf_options.merge_operator = MergeOperators::CreateStringAppendOperator();
     ASSERT_OK(ReOpen());
-    db->CreateColumnFamily(cf_options, cf_name, &cf_handle);
+    ASSERT_OK(db->CreateColumnFamily(cf_options, cf_name, &cf_handle));
     WriteOptions write_options;
     // Ensure one value for the key
     ASSERT_OK(db->Put(write_options, cf_handle, Slice("key"), Slice("value")));

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -109,7 +109,7 @@ class TransactionTestBase : public ::testing::Test {
     delete db;
     db = nullptr;
     fault_fs->AssertNoOpenFile();
-    fault_fs->DropUnsyncedFileData();
+    EXPECT_OK(fault_fs->DropUnsyncedFileData());
     fault_fs->ResetState();
     Status s;
     if (use_stackable_db_ == false) {
@@ -130,7 +130,7 @@ class TransactionTestBase : public ::testing::Test {
     delete db;
     db = nullptr;
     fault_fs->AssertNoOpenFile();
-    fault_fs->DropUnsyncedFileData();
+    EXPECT_OK(fault_fs->DropUnsyncedFileData());
     fault_fs->ResetState();
     Status s;
     if (use_stackable_db_ == false) {
@@ -146,7 +146,7 @@ class TransactionTestBase : public ::testing::Test {
   Status ReOpen() {
     delete db;
     db = nullptr;
-    DestroyDB(dbname, options);
+    EXPECT_OK(DestroyDB(dbname, options));
     Status s;
     if (use_stackable_db_ == false) {
       s = TransactionDB::Open(options, txn_db_options, dbname, &db);

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1345,7 +1345,7 @@ TEST_P(WritePreparedTransactionTest, NewSnapshotLargerThanMax) {
   // Check that the new max has not advanced the last seq
   ASSERT_LT(wp_db->max_evicted_seq_.load(), last_seq);
   for (auto txn : txns) {
-    txn->Rollback();
+    ASSERT_OK(txn->Rollback());
     delete txn;
   }
 }

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -652,7 +652,7 @@ TEST_F(TtlTest, ColumnFamiliesTest) {
   options.create_if_missing = true;
   options.env = env_.get();
 
-  DB::Open(options, dbname_, &db);
+  ASSERT_OK(DB::Open(options, dbname_, &db));
   ColumnFamilyHandle* handle;
   ASSERT_OK(db->CreateColumnFamily(ColumnFamilyOptions(options),
                                    "ttl_column_family", &handle));

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -261,14 +261,14 @@ class WBWIBaseTest : public testing::Test {
     std::string result;
     for (size_t i = 0; i < key.size(); i++) {
       if (key[i] == 'd') {
-        batch_->Delete(cf, key);
+        EXPECT_OK(batch_->Delete(cf, key));
         result = "";
       } else if (key[i] == 'p') {
         result = key + std::to_string(i);
-        batch_->Put(cf, key, result);
+        EXPECT_OK(batch_->Put(cf, key, result));
       } else if (key[i] == 'm') {
         std::string value = key + std::to_string(i);
-        batch_->Merge(cf, key, value);
+        EXPECT_OK(batch_->Merge(cf, key, value));
         if (result.empty()) {
           result = value;
         } else {
@@ -1243,7 +1243,7 @@ TEST_F(WBWIOverwriteTest, TestGetFromBatchMerge2) {
   s = batch_->GetFromBatch(column_family, options_, "X", &value);
   ASSERT_TRUE(s.IsNotFound());
 
-  batch_->Merge(column_family, "X", "ddd");
+  ASSERT_OK(batch_->Merge(column_family, "X", "ddd"));
   ASSERT_OK(batch_->GetFromBatch(column_family, options_, "X", &value));
   ASSERT_EQ("ddd", value);
 }
@@ -2100,8 +2100,8 @@ TEST_P(WriteBatchWithIndexTest, GetFromBatchAfterMerge) {
 
   ASSERT_OK(OpenDB());
   ASSERT_OK(db_->Put(write_opts_, "o", "aa"));
-  batch_->Merge("o", "bb");  // Merging bb under key "o"
-  batch_->Merge("m", "cc");  // Merging bc under key "m"
+  ASSERT_OK(batch_->Merge("o", "bb"));  // Merging bb under key "o"
+  ASSERT_OK(batch_->Merge("m", "cc"));  // Merging bc under key "m"
   s = batch_->GetFromBatch(options_, "m", &value);
   ASSERT_EQ(s.code(), Status::Code::kMergeInProgress);
   s = batch_->GetFromBatch(options_, "o", &value);


### PR DESCRIPTION
It seems the flag `-fno-elide-constructors` is incorrectly overwritten in Makefile by https://github.com/facebook/rocksdb/blob/9c2ebcc2c365bb89af566b3076f813d7bf11146b/Makefile#L243
Applying the change in PR #11675 shows a lot of missing status checks. This PR adds the missing status checks. 

Most of changes are just adding asserts in unit tests. I'll add pr comment around more interesting changes that need review.

Test plan: change Makefile as in #11675, and run `ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=static OPT="-DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make V=1 -j24 J=24 check`