### PR TITLE
PutEntity Support in SST File Writer

### DIFF
--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -13,6 +13,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/table_properties.h"
 #include "rocksdb/types.h"
+#include "rocksdb/wide_columns.h"
 
 #if defined(__GNUC__) || defined(__clang__)
 #define ROCKSDB_DEPRECATED_FUNC __attribute__((__deprecated__))
@@ -127,6 +128,10 @@ class SstFileWriter {
   // REQUIRES: timestamp's size is equal to what is expected by the comparator.
   Status Put(const Slice& user_key, const Slice& timestamp, const Slice& value);
 
+  // Add a PutEntity (key with the wide-column entity defined by "columns") to
+  // the currently opened file
+  Status PutEntity(const Slice& user_key, const WideColumns& columns);
+
   // Add a Merge key with value to currently opened file
   // REQUIRES: user_key is after any previously added point (Put/Merge/Delete)
   //           key according to the comparator.
@@ -186,4 +191,3 @@ class SstFileWriter {
   std::unique_ptr<Rep> rep_;
 };
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -680,7 +680,8 @@ bool DataBlockIter::ParseNextDataKey(bool* is_shared) {
              value_type == ValueType::kTypeMerge ||
              value_type == ValueType::kTypeDeletion ||
              value_type == ValueType::kTypeDeletionWithTimestamp ||
-             value_type == ValueType::kTypeRangeDeletion);
+             value_type == ValueType::kTypeRangeDeletion ||
+             value_type == ValueType::kTypeWideColumnEntity);
       assert(seqno == 0);
     }
 #endif  // NDEBUG
@@ -736,7 +737,8 @@ void IndexBlockIter::DecodeCurrentValue(bool is_shared) {
     assert(value_type == ValueType::kTypeValue ||
            value_type == ValueType::kTypeMerge ||
            value_type == ValueType::kTypeDeletion ||
-           value_type == ValueType::kTypeRangeDeletion);
+           value_type == ValueType::kTypeRangeDeletion ||
+           value_type == ValueType::kTypeWideColumnEntity);
 
     first_internal_key.UpdateInternalKey(global_seqno_state_->global_seqno,
                                          value_type);

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -671,7 +671,8 @@ bool DataBlockIter::ParseNextDataKey(bool* is_shared) {
       // If we are reading a file with a global sequence number we should
       // expect that all encoded sequence numbers are zeros and any value
       // type is kTypeValue, kTypeMerge, kTypeDeletion,
-      // kTypeDeletionWithTimestamp, or kTypeRangeDeletion.
+      // kTypeDeletionWithTimestamp, kTypeRangeDeletion, or
+      // kTypeWideColumnEntity.
       uint64_t packed = ExtractInternalKeyFooter(raw_key_.GetKey());
       SequenceNumber seqno;
       ValueType value_type;

--- a/unreleased_history/new_features/put_entity_support_in_sst_file_writer.md
+++ b/unreleased_history/new_features/put_entity_support_in_sst_file_writer.md
@@ -1,0 +1,1 @@
+Add PutEntity API in sst_file_writer


### PR DESCRIPTION
## Summary

RocksDB provides APIs that enable creating SST files offline and then bulk loading them into the LSM tree quickly using metadata operations. Namely, clients can use the `SstFileWriter` class for the offline data preparation and then the IngestExternalFile family of APIs to perform the bulk loading. However, `SstFileWriter` currently does not support creating files with wide-column data in them. This PR adds `PutEntity` API implementation to `SstFileWriter` to support creating files with wide-column data.

## Test Plan
- `BasicWideColumn` test added in external_sst_file_test

