### PR TITLE
Add UDT support in API DB::GetApproximateMemTableStats

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4207,10 +4207,9 @@ void DBImpl::GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
   assert(ucmp);
   size_t ts_sz = ucmp->timestamp_size();
 
-  Slice start, limit;
   // Add timestamp if needed
   std::string start_with_ts, limit_with_ts;
-  std::tie(start, limit) = MaybeAddTimestampsToRange(
+  auto [start, limit] = MaybeAddTimestampsToRange(
       range.start, range.limit, ts_sz, &start_with_ts, &limit_with_ts);
   // Convert user_key into a corresponding internal key.
   InternalKey k1(start, kMaxSequenceNumber, kValueTypeForSeek);
@@ -4245,11 +4244,9 @@ Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
   // TODO: plumb Env::IOActivity
   const ReadOptions read_options;
   for (int i = 0; i < n; i++) {
-    Slice start, limit;
-
     // Add timestamp if needed
     std::string start_with_ts, limit_with_ts;
-    std::tie(start, limit) = MaybeAddTimestampsToRange(
+    auto [start, limit] = MaybeAddTimestampsToRange(
         range[i].start, range[i].limit, ts_sz, &start_with_ts, &limit_with_ts);
     // Convert user_key into a corresponding internal key.
     InternalKey k1(start, kMaxSequenceNumber, kValueTypeForSeek);

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -149,6 +149,24 @@ void DumpSupportInfo(Logger* logger) {
 
   ROCKS_LOG_HEADER(logger, "DMutex implementation: %s", DMutex::kName());
 }
+
+// `start` is the inclusive lower user key bound without user-defined timestamp
+// `limit` is the exclusive upper user key bound without user-defined timestamp
+std::tuple<Slice, Slice> MaybeAddTimestampsToRange(const Slice& start,
+                                                   const Slice& limit,
+                                                   size_t ts_sz,
+                                                   std::string* start_with_ts,
+                                                   std::string* limit_with_ts) {
+  if (ts_sz == 0) {
+    return std::make_tuple(start, limit);
+  }
+  // Maximum timestamp means including all key with any timestamp
+  AppendKeyWithMaxTimestamp(start_with_ts, start, ts_sz);
+  // Append a maximum timestamp as the range limit is exclusive:
+  // [start, limit)
+  AppendKeyWithMaxTimestamp(limit_with_ts, limit, ts_sz);
+  return std::make_tuple(Slice(*start_with_ts), Slice(*limit_with_ts));
+}
 }  // namespace
 
 DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
@@ -4185,9 +4203,18 @@ void DBImpl::GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
   ColumnFamilyData* cfd = cfh->cfd();
   SuperVersion* sv = GetAndRefSuperVersion(cfd);
 
+  const Comparator* const ucmp = column_family->GetComparator();
+  assert(ucmp);
+  size_t ts_sz = ucmp->timestamp_size();
+
+  Slice start, limit;
+  // Add timestamp if needed
+  std::string start_with_ts, limit_with_ts;
+  std::tie(start, limit) = MaybeAddTimestampsToRange(
+      range.start, range.limit, ts_sz, &start_with_ts, &limit_with_ts);
   // Convert user_key into a corresponding internal key.
-  InternalKey k1(range.start, kMaxSequenceNumber, kValueTypeForSeek);
-  InternalKey k2(range.limit, kMaxSequenceNumber, kValueTypeForSeek);
+  InternalKey k1(start, kMaxSequenceNumber, kValueTypeForSeek);
+  InternalKey k2(limit, kMaxSequenceNumber, kValueTypeForSeek);
   MemTable::MemTableStats memStats =
       sv->mem->ApproximateStats(k1.Encode(), k2.Encode());
   MemTable::MemTableStats immStats =
@@ -4218,20 +4245,12 @@ Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
   // TODO: plumb Env::IOActivity
   const ReadOptions read_options;
   for (int i = 0; i < n; i++) {
-    Slice start = range[i].start;
-    Slice limit = range[i].limit;
+    Slice start, limit;
 
     // Add timestamp if needed
     std::string start_with_ts, limit_with_ts;
-    if (ts_sz > 0) {
-      // Maximum timestamp means including all key with any timestamp
-      AppendKeyWithMaxTimestamp(&start_with_ts, start, ts_sz);
-      // Append a maximum timestamp as the range limit is exclusive:
-      // [start, limit)
-      AppendKeyWithMaxTimestamp(&limit_with_ts, limit, ts_sz);
-      start = start_with_ts;
-      limit = limit_with_ts;
-    }
+    std::tie(start, limit) = MaybeAddTimestampsToRange(
+        range[i].start, range[i].limit, ts_sz, &start_with_ts, &limit_with_ts);
     // Convert user_key into a corresponding internal key.
     InternalKey k1(start, kMaxSequenceNumber, kValueTypeForSeek);
     InternalKey k2(limit, kMaxSequenceNumber, kValueTypeForSeek);

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -459,6 +459,13 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
       db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
   ASSERT_GT(size, 0);
 
+  uint64_t total_mem_count;
+  uint64_t total_mem_size;
+  db_->GetApproximateMemTableStats(default_cf, r, &total_mem_count,
+                                   &total_mem_size);
+  ASSERT_GT(total_mem_count, 0);
+  ASSERT_GT(total_mem_size, 0);
+
   // Should exclude end key
   start = Key(900);
   end = Key(1000);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -100,6 +100,8 @@ static const int kMinorVersion = __ROCKSDB_MINOR__;
 
 // A range of keys
 struct Range {
+  // In case of user_defined timestamp, if enabled, `start` and `limit` should
+  // point to key without timestamp part.
   Slice start;
   Slice limit;
 
@@ -108,6 +110,8 @@ struct Range {
 };
 
 struct RangePtr {
+  // In case of user_defined timestamp, if enabled, `start` and `limit` should
+  // point to key without timestamp part.
   const Slice* start;
   const Slice* limit;
 
@@ -1352,6 +1356,8 @@ class DB {
   // the files. In this case, client could set options.change_level to true, to
   // move the files back to the minimum level capable of holding the data set
   // or a given level (specified by non-negative options.target_level).
+  // In case of user_defined timestamp, if enabled, `start` and `end` should
+  // point to key without timestamp part.
   virtual Status CompactRange(const CompactRangeOptions& options,
                               ColumnFamilyHandle* column_family,
                               const Slice* begin, const Slice* end) = 0;


### PR DESCRIPTION
This API should consider the case when user-defined timestamp is enabled. Also added some documentation to some related API to clarify the usage in the case when user-defined timestamp is enabled.


Test Plan:
Unit test added
```
make check
./db_with_timestamp_basic_test --gtest_filter=*GetApproximateSizes*
```