### PR TITLE
Add consistent ways to access the builtin UDT comparators

### DIFF
--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -155,10 +155,20 @@ class Comparator : public Customizable, public CompareInterface {
 // Return a builtin comparator that uses lexicographic byte-wise
 // ordering.  The result remains the property of this module and
 // must not be deleted.
-extern const Comparator* BytewiseComparator();
+const Comparator* BytewiseComparator();
 
 // Return a builtin comparator that uses reverse lexicographic byte-wise
 // ordering.
-extern const Comparator* ReverseBytewiseComparator();
+const Comparator* ReverseBytewiseComparator();
+
+// Returns a builtin comparator that enables user-defined timestamps (formatted
+// as uint64_t) while ordering the user key part without UDT with a
+// BytewiseComparator.
+const Comparator* BytewiseComparatorWithU64Ts();
+
+// Returns a builtin comparator that enables user-defined timestamps (formatted
+// as uint64_t) while ordering the user key part without UDT with a
+// ReverseBytewiseComparator.
+const Comparator* ReverseBytewiseComparatorWithU64Ts();
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -164,11 +164,15 @@ const Comparator* ReverseBytewiseComparator();
 // Returns a builtin comparator that enables user-defined timestamps (formatted
 // as uint64_t) while ordering the user key part without UDT with a
 // BytewiseComparator.
+// For the same user key with different timestamps, larger (newer) timestamp
+// comes first.
 const Comparator* BytewiseComparatorWithU64Ts();
 
 // Returns a builtin comparator that enables user-defined timestamps (formatted
 // as uint64_t) while ordering the user key part without UDT with a
 // ReverseBytewiseComparator.
+// For the same user key with different timestamps, larger (newer) timestamp
+// comes first.
 const Comparator* ReverseBytewiseComparatorWithU64Ts();
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Expose the functions that creates these UDT aware comparators so that users can create all the RocksDB builtin comparators in consistent ways.