### PR TITLE
Remove comment about locking about TestIterateAgainstExpected

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1589,8 +1589,6 @@ class NonBatchedOpsStressTest : public StressTest {
 
     const int64_t ub = lb + num_iter;
 
-    // Lock the whole range over which we might iterate to ensure it doesn't
-    // change under us.
     const int rand_column_family = rand_column_families[0];
 
     // Testing parallel read and write to the same key with user timestamp

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -346,7 +346,7 @@ simple_default_params = {
     "write_buffer_size": 32 * 1024 * 1024,
     "level_compaction_dynamic_level_bytes": lambda: random.randint(0, 1),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
-    "verify_iterator_with_expected_state_one_in": 5,  # this locks a range of keys
+    "verify_iterator_with_expected_state_one_in": 5,
 }
 
 blackbox_simple_default_params = {


### PR DESCRIPTION
**Context/Summary**
After https://github.com/facebook/rocksdb/pull/11058, we no longer lock the key range to iterate in TestIterateAgainstExpected, except for working with timestamp feature.

**Test:** no code change