### PR TITLE
Wide Column Ingestion in CrashTest

### DIFF
--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -308,11 +308,10 @@ int db_stress_tool(int argc, char** argv) {
   }
 
   if (FLAGS_use_put_entity_one_in > 0 &&
-      (FLAGS_ingest_external_file_one_in > 0 || FLAGS_use_merge ||
-       FLAGS_use_full_merge_v1 || FLAGS_use_txn || FLAGS_test_multi_ops_txns ||
-       FLAGS_user_timestamp_size > 0)) {
+      (FLAGS_use_merge || FLAGS_use_full_merge_v1 || FLAGS_use_txn ||
+       FLAGS_test_multi_ops_txns || FLAGS_user_timestamp_size > 0)) {
     fprintf(stderr,
-            "PutEntity is currently incompatible with SstFileWriter, Merge,"
+            "PutEntity is currently incompatible with Merge,"
             " transactions, and user-defined timestamps\n");
     exit(1);
   }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -657,9 +657,8 @@ def finalize_and_sanitize(src_params):
     if dest_params.get("use_txn") == 1 and dest_params.get("txn_write_policy") != 0:
         dest_params["sync_fault_injection"] = 0
         dest_params["manual_wal_flush_one_in"] = 0
-    # PutEntity is currently not supported by SstFileWriter or in conjunction with Merge
+    # PutEntity is currently incompatible with Merge
     if dest_params["use_put_entity_one_in"] != 0:
-        dest_params["ingest_external_file_one_in"] = 0
         dest_params["use_merge"] = 0
         dest_params["use_full_merge_v1"] = 0
     if dest_params["file_checksum_impl"] == "none":


### PR DESCRIPTION
# Summary
`PutEntity` is now supported in SST file writer (#11688). This PR enables ingestion of wide column data in the stress/crash tests.

# Test Plan

```
python3 tools/db_crashtest.py blackbox --simple --duration=300 --ingest_external_file_one_in=2 --use_put_entity_one_in=2 --max_key=1048576 -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 --interval=10 -value_size_mult=33 -column_families=1 -reopen=0 --key_len_percent_dist="1,30,69" 
```

