### PR TITLE
In TestIterateAgainstExpected(), verify iterator moves in expected direction

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1858,9 +1858,8 @@ class NonBatchedOpsStressTest : public StressTest {
         GetIntVal(iter->key().ToString(), &curr);
         if (static_cast<int64_t>(curr) < mid) {
           thread->shared->SetVerificationFailure();
-          fprintf(
-              stderr,
-              "TestIterateAgainstExpected found unexpectedly small key\n");
+          fprintf(stderr,
+                  "TestIterateAgainstExpected found unexpectedly small key\n");
           fprintf(stderr, "Column family: %s, op_logs: %s\n",
                   cfh->GetName().c_str(), op_logs.c_str());
           fprintf(stderr, "Last op found key: %s, expected at least: %s\n",
@@ -1882,9 +1881,8 @@ class NonBatchedOpsStressTest : public StressTest {
         GetIntVal(iter->key().ToString(), &curr);
         if (mid < static_cast<int64_t>(curr)) {
           thread->shared->SetVerificationFailure();
-          fprintf(
-              stderr,
-              "TestIterateAgainstExpected found unexpectedly large key\n");
+          fprintf(stderr,
+                  "TestIterateAgainstExpected found unexpectedly large key\n");
           fprintf(stderr, "Column family: %s, op_logs: %s\n",
                   cfh->GetName().c_str(), op_logs.c_str());
           fprintf(stderr, "Last op found key: %s, expected at most: %s\n",

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1856,7 +1856,7 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       } else if (iter->Valid()) {
         GetIntVal(iter->key().ToString(), &curr);
-        if (curr < mid) {
+        if (static_cast<int64_t>(curr) < mid) {
           thread->shared->SetVerificationFailure();
           fprintf(
               stderr,
@@ -1880,7 +1880,7 @@ class NonBatchedOpsStressTest : public StressTest {
         }
       } else if (iter->Valid()) {
         GetIntVal(iter->key().ToString(), &curr);
-        if (mid < curr) {
+        if (mid < static_cast<int64_t>(curr)) {
           thread->shared->SetVerificationFailure();
           fprintf(
               stderr,

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1601,7 +1601,9 @@ class NonBatchedOpsStressTest : public StressTest {
     }
 
     ReadOptions ro(read_opts);
-    ro.total_order_seek = true;
+    if (FLAGS_prefix_size > 0) {
+      ro.total_order_seek = true;
+    }
 
     std::string read_ts_str;
     Slice read_ts;
@@ -1669,6 +1671,7 @@ class NonBatchedOpsStressTest : public StressTest {
     };
 
     auto check_no_key_in_range = [&](int64_t start, int64_t end) {
+      assert(start <= end);
       for (auto j = std::max(start, lb); j < std::min(end, ub); ++j) {
         std::size_t index = static_cast<std::size_t>(j - lb);
         assert(index < pre_read_expected_values.size() &&
@@ -1711,6 +1714,7 @@ class NonBatchedOpsStressTest : public StressTest {
 
     uint64_t curr = 0;
     while (true) {
+      assert(last_key < ub);
       if (!iter->Valid()) {
         if (!iter->status().ok()) {
           thread->shared->SetVerificationFailure();
@@ -1733,6 +1737,18 @@ class NonBatchedOpsStressTest : public StressTest {
 
       // iter is valid, the range (last_key, current key) was skipped
       GetIntVal(iter->key().ToString(), &curr);
+      if (static_cast<int64_t>(curr) <= last_key) {
+        thread->shared->SetVerificationFailure();
+        fprintf(stderr,
+                "TestIterateAgainstExpected found unexpectedly small key\n");
+        fprintf(stderr, "Column family: %s, op_logs: %s\n",
+                cfh->GetName().c_str(), op_logs.c_str());
+        fprintf(stderr, "Last op found key: %s, expected at least: %s\n",
+                Slice(Key(curr)).ToString(true).c_str(),
+                Slice(Key(last_key + 1)).ToString(true).c_str());
+        thread->stats.AddErrors(1);
+        return Status::OK();
+      }
       if (!check_no_key_in_range(last_key + 1, static_cast<int64_t>(curr))) {
         return Status::OK();
       }
@@ -1755,6 +1771,7 @@ class NonBatchedOpsStressTest : public StressTest {
 
     last_key = ub;
     while (true) {
+      assert(lb < last_key);
       if (!iter->Valid()) {
         if (!iter->status().ok()) {
           thread->shared->SetVerificationFailure();
@@ -1777,6 +1794,18 @@ class NonBatchedOpsStressTest : public StressTest {
 
       // the range (current key, last key) was skipped
       GetIntVal(iter->key().ToString(), &curr);
+      if (last_key <= static_cast<int64_t>(curr)) {
+        thread->shared->SetVerificationFailure();
+        fprintf(stderr,
+                "TestIterateAgainstExpected found unexpectedly large key\n");
+        fprintf(stderr, "Column family: %s, op_logs: %s\n",
+                cfh->GetName().c_str(), op_logs.c_str());
+        fprintf(stderr, "Last op found key: %s, expected at most: %s\n",
+                Slice(Key(curr)).ToString(true).c_str(),
+                Slice(Key(last_key - 1)).ToString(true).c_str());
+        thread->stats.AddErrors(1);
+        return Status::OK();
+      }
       if (!check_no_key_in_range(static_cast<int64_t>(curr + 1), last_key)) {
         return Status::OK();
       }
@@ -1825,6 +1854,21 @@ class NonBatchedOpsStressTest : public StressTest {
         if (!check_no_key_in_range(mid, ub)) {
           return Status::OK();
         }
+      } else if (iter->Valid()) {
+        GetIntVal(iter->key().ToString(), &curr);
+        if (curr < mid) {
+          thread->shared->SetVerificationFailure();
+          fprintf(
+              stderr,
+              "TestIterateAgainstExpected found unexpectedly small key\n");
+          fprintf(stderr, "Column family: %s, op_logs: %s\n",
+                  cfh->GetName().c_str(), op_logs.c_str());
+          fprintf(stderr, "Last op found key: %s, expected at least: %s\n",
+                  Slice(Key(curr)).ToString(true).c_str(),
+                  Slice(Key(mid)).ToString(true).c_str());
+          thread->stats.AddErrors(1);
+          return Status::OK();
+        }
       }
     } else {
       iter->SeekForPrev(key);
@@ -1832,6 +1876,21 @@ class NonBatchedOpsStressTest : public StressTest {
       if (!iter->Valid() && iter->status().ok()) {
         // iterator says nothing <= mid
         if (!check_no_key_in_range(lb, mid + 1)) {
+          return Status::OK();
+        }
+      } else if (iter->Valid()) {
+        GetIntVal(iter->key().ToString(), &curr);
+        if (mid < curr) {
+          thread->shared->SetVerificationFailure();
+          fprintf(
+              stderr,
+              "TestIterateAgainstExpected found unexpectedly large key\n");
+          fprintf(stderr, "Column family: %s, op_logs: %s\n",
+                  cfh->GetName().c_str(), op_logs.c_str());
+          fprintf(stderr, "Last op found key: %s, expected at most: %s\n",
+                  Slice(Key(curr)).ToString(true).c_str(),
+                  Slice(Key(mid)).ToString(true).c_str());
+          thread->stats.AddErrors(1);
           return Status::OK();
         }
       }
@@ -1881,6 +1940,19 @@ class NonBatchedOpsStressTest : public StressTest {
           }
           uint64_t next = 0;
           GetIntVal(iter->key().ToString(), &next);
+          if (next <= curr) {
+            thread->shared->SetVerificationFailure();
+            fprintf(
+                stderr,
+                "TestIterateAgainstExpected found unexpectedly small key\n");
+            fprintf(stderr, "Column family: %s, op_logs: %s\n",
+                    cfh->GetName().c_str(), op_logs.c_str());
+            fprintf(stderr, "Last op found key: %s, expected at least: %s\n",
+                    Slice(Key(next)).ToString(true).c_str(),
+                    Slice(Key(curr + 1)).ToString(true).c_str());
+            thread->stats.AddErrors(1);
+            return Status::OK();
+          }
           if (!check_no_key_in_range(static_cast<int64_t>(curr + 1),
                                      static_cast<int64_t>(next))) {
             return Status::OK();
@@ -1893,6 +1965,19 @@ class NonBatchedOpsStressTest : public StressTest {
           }
           uint64_t prev = 0;
           GetIntVal(iter->key().ToString(), &prev);
+          if (curr <= prev) {
+            thread->shared->SetVerificationFailure();
+            fprintf(
+                stderr,
+                "TestIterateAgainstExpected found unexpectedly large key\n");
+            fprintf(stderr, "Column family: %s, op_logs: %s\n",
+                    cfh->GetName().c_str(), op_logs.c_str());
+            fprintf(stderr, "Last op found key: %s, expected at most: %s\n",
+                    Slice(Key(prev)).ToString(true).c_str(),
+                    Slice(Key(curr - 1)).ToString(true).c_str());
+            thread->stats.AddErrors(1);
+            return Status::OK();
+          }
           if (!check_no_key_in_range(static_cast<int64_t>(prev + 1),
                                      static_cast<int64_t>(curr))) {
             return Status::OK();


### PR DESCRIPTION
It's a bit repetitive in order to give reasonably informative error messages.

I also removed total_order_seek in cases where it's not needed, just to make sure a case that shouldn't matter really doesn't.

Test Plan: run it -

```
$ DEBUG_LEVEL=0 TEST_TMPDIR=/dev/shm python3 tools/db_crashtest.py blackbox --max_key=100000 --duration=86400 --interval=10 --write_buffer_size=524288 --target_file_size_base=524288 --max_bytes_for_level_base=2097152 --compression_type=none --blob_compression_type=none --writepercent=50 -iterpercent=45 -readpercent=0 -prefixpercent=0 --prefix_size=0 --verify_iterator_with_expected_state_one_in=10 --test_batches_snapshots=0 -enable_compaction_filter=0
```