### PR TITLE
Fix a bug in MultiGet when skip_memtable is true

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3072,7 +3072,7 @@ Status DBImpl::MultiGetImpl(
                         stats_);
     MultiGetRange range = ctx.GetMultiGetRange();
     range.AddValueSize(curr_value_size);
-    bool lookup_current = false;
+    bool lookup_current = true;
 
     keys_left -= batch_size;
     for (auto mget_iter = range.begin(); mget_iter != range.end();
@@ -3091,9 +3091,10 @@ Status DBImpl::MultiGetImpl(
         super_version->imm->MultiGet(read_options, &range, callback);
       }
       if (!range.empty()) {
-        lookup_current = true;
         uint64_t left = range.KeysLeft();
         RecordTick(stats_, MEMTABLE_MISS, left);
+      } else {
+        lookup_current = false;
       }
     }
     if (lookup_current) {


### PR DESCRIPTION
Summary: When skip_memtable is true in MultiGetImpl, The lookup_current is always false, Causes data to be unable to be queried in super_version->current。