### PR TITLE
RFC: use custom allocator for more block cache objects

### DIFF
--- a/include/rocksdb/memory_allocator.h
+++ b/include/rocksdb/memory_allocator.h
@@ -80,8 +80,8 @@ struct JemallocAllocatorOptions {
 // (thread-local cache) is enabled to cache unused allocations for future use.
 // The tcache normally incurs 0.5M extra memory usage per-thread. The usage
 // can be reduced by limiting allocation sizes to cache.
-extern Status NewJemallocNodumpAllocator(
-    JemallocAllocatorOptions& options,
+Status NewJemallocNodumpAllocator(
+    const JemallocAllocatorOptions& options,
     std::shared_ptr<MemoryAllocator>* memory_allocator);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/memory/jemalloc_nodump_allocator.cc
+++ b/memory/jemalloc_nodump_allocator.cc
@@ -63,7 +63,7 @@ bool JemallocNodumpAllocator::IsSupported(std::string* why) {
 }
 
 JemallocNodumpAllocator::JemallocNodumpAllocator(
-    JemallocAllocatorOptions& options)
+    const JemallocAllocatorOptions& options)
     : options_(options)
 #ifdef ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
       ,
@@ -124,7 +124,8 @@ uint32_t JemallocNodumpAllocator::GetArenaIndex() const {
   // to make Random thread-safe and prevent cacheline bouncing. Whether this is
   // worthwhile is still an open question.
   thread_local Random tl_random(next_seed.fetch_add(1));
-  return arena_indexes_[FastRange32(tl_random.Next(), arena_indexes_.size())];
+  return arena_indexes_[FastRange32(
+      tl_random.Next(), static_cast<uint32_t>(arena_indexes_.size()))];
 }
 
 Status JemallocNodumpAllocator::InitializeArenas() {
@@ -282,7 +283,7 @@ void JemallocNodumpAllocator::DestroyThreadSpecificCache(void* ptr) {
 #endif  // ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
 
 Status NewJemallocNodumpAllocator(
-    JemallocAllocatorOptions& options,
+    const JemallocAllocatorOptions& options,
     std::shared_ptr<MemoryAllocator>* memory_allocator) {
   if (memory_allocator == nullptr) {
     return Status::InvalidArgument("memory_allocator must be non-null.");

--- a/memory/jemalloc_nodump_allocator.h
+++ b/memory/jemalloc_nodump_allocator.h
@@ -30,7 +30,7 @@ namespace ROCKSDB_NAMESPACE {
 // arena mutexes.
 class JemallocNodumpAllocator : public BaseMemoryAllocator {
  public:
-  explicit JemallocNodumpAllocator(JemallocAllocatorOptions& options);
+  explicit JemallocNodumpAllocator(const JemallocAllocatorOptions& options);
 #ifdef ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
   ~JemallocNodumpAllocator();
 #endif  // ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR

--- a/memory/memory_allocator_impl.h
+++ b/memory/memory_allocator_impl.h
@@ -44,4 +44,13 @@ inline CacheAllocationPtr AllocateAndCopyBlock(const Slice& data,
   return cap;
 }
 
+template <class T, class... Params>
+T* AllocatorNew(MemoryAllocator* allocator, Params&&... params) {
+  if (allocator) {
+    auto mem = allocator->Allocate(sizeof(T));
+    return new (mem) T(std::forward<Params>(params)...);
+  }
+  return new T(std::forward<Params>(params)...);
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -163,7 +163,7 @@ Status ReadAndParseBlockFromFile(
     s = block_fetcher.ReadBlockContents();
   }
   if (s.ok()) {
-    create_context.Create(result, std::move(contents));
+    create_context.Create(result, std::move(contents), memory_allocator);
   }
   return s;
 }
@@ -1361,9 +1361,11 @@ WithBlocklikeCheck<Status, TBlocklike> BlockBasedTable::PutDataBlockToCache(
       return s;
     }
     rep_->create_context.Create(&block_holder,
-                                std::move(uncompressed_block_contents));
+                                std::move(uncompressed_block_contents),
+                                memory_allocator);
   } else {
-    rep_->create_context.Create(&block_holder, std::move(block_contents));
+    rep_->create_context.Create(&block_holder, std::move(block_contents),
+                                memory_allocator);
   }
 
   // insert into uncompressed block cache

--- a/table/block_based/block_cache.cc
+++ b/table/block_based/block_cache.cc
@@ -8,52 +8,56 @@
 namespace ROCKSDB_NAMESPACE {
 
 void BlockCreateContext::Create(std::unique_ptr<Block_kData>* parsed_out,
-                                BlockContents&& block) {
-  parsed_out->reset(new Block_kData(
-      std::move(block), table_options->read_amp_bytes_per_bit, statistics));
+                                BlockContents&& block, MemoryAllocator* alloc) {
+  parsed_out->reset(AllocatorNew<Block_kData>(
+      alloc, std::move(block), table_options->read_amp_bytes_per_bit,
+      statistics));
   parsed_out->get()->InitializeDataBlockProtectionInfo(protection_bytes_per_key,
                                                        raw_ucmp);
 }
 void BlockCreateContext::Create(std::unique_ptr<Block_kIndex>* parsed_out,
-                                BlockContents&& block) {
-  parsed_out->reset(new Block_kIndex(std::move(block),
-                                     /*read_amp_bytes_per_bit*/ 0, statistics));
+                                BlockContents&& block, MemoryAllocator* alloc) {
+  parsed_out->reset(AllocatorNew<Block_kIndex>(alloc, std::move(block),
+                                               /*read_amp_bytes_per_bit*/ 0,
+                                               statistics));
   parsed_out->get()->InitializeIndexBlockProtectionInfo(
       protection_bytes_per_key, raw_ucmp, index_value_is_full,
       index_has_first_key);
 }
 void BlockCreateContext::Create(
     std::unique_ptr<Block_kFilterPartitionIndex>* parsed_out,
-    BlockContents&& block) {
-  parsed_out->reset(new Block_kFilterPartitionIndex(
-      std::move(block), /*read_amp_bytes_per_bit*/ 0, statistics));
+    BlockContents&& block, MemoryAllocator* alloc) {
+  parsed_out->reset(AllocatorNew<Block_kFilterPartitionIndex>(
+      alloc, std::move(block), /*read_amp_bytes_per_bit*/ 0, statistics));
   parsed_out->get()->InitializeIndexBlockProtectionInfo(
       protection_bytes_per_key, raw_ucmp, index_value_is_full,
       index_has_first_key);
 }
 void BlockCreateContext::Create(
-    std::unique_ptr<Block_kRangeDeletion>* parsed_out, BlockContents&& block) {
-  parsed_out->reset(new Block_kRangeDeletion(
-      std::move(block), /*read_amp_bytes_per_bit*/ 0, statistics));
+    std::unique_ptr<Block_kRangeDeletion>* parsed_out, BlockContents&& block,
+    MemoryAllocator* alloc) {
+  parsed_out->reset(AllocatorNew<Block_kRangeDeletion>(
+      alloc, std::move(block), /*read_amp_bytes_per_bit*/ 0, statistics));
 }
 void BlockCreateContext::Create(std::unique_ptr<Block_kMetaIndex>* parsed_out,
-                                BlockContents&& block) {
-  parsed_out->reset(new Block_kMetaIndex(
-      std::move(block), /*read_amp_bytes_per_bit*/ 0, statistics));
+                                BlockContents&& block, MemoryAllocator* alloc) {
+  parsed_out->reset(AllocatorNew<Block_kMetaIndex>(
+      alloc, std::move(block), /*read_amp_bytes_per_bit*/ 0, statistics));
   parsed_out->get()->InitializeMetaIndexBlockProtectionInfo(
       protection_bytes_per_key);
 }
 
 void BlockCreateContext::Create(
-    std::unique_ptr<ParsedFullFilterBlock>* parsed_out, BlockContents&& block) {
-  parsed_out->reset(new ParsedFullFilterBlock(
-      table_options->filter_policy.get(), std::move(block)));
+    std::unique_ptr<ParsedFullFilterBlock>* parsed_out, BlockContents&& block,
+    MemoryAllocator* alloc) {
+  parsed_out->reset(AllocatorNew<ParsedFullFilterBlock>(
+      alloc, table_options->filter_policy.get(), std::move(block)));
 }
 
 void BlockCreateContext::Create(std::unique_ptr<UncompressionDict>* parsed_out,
-                                BlockContents&& block) {
-  parsed_out->reset(new UncompressionDict(
-      block.data, std::move(block.allocation), using_zstd));
+                                BlockContents&& block, MemoryAllocator* alloc) {
+  parsed_out->reset(AllocatorNew<UncompressionDict>(
+      alloc, block.data, std::move(block.allocation), using_zstd));
 }
 
 namespace {

--- a/table/block_based/block_cache.h
+++ b/table/block_based/block_cache.h
@@ -97,22 +97,25 @@ struct BlockCreateContext : public Cache::CreateContext {
                      size_t* charge_out, const Slice& data,
                      MemoryAllocator* alloc) {
     Create(parsed_out,
-           BlockContents(AllocateAndCopyBlock(data, alloc), data.size()));
+           BlockContents(AllocateAndCopyBlock(data, alloc), data.size()),
+           alloc);
     *charge_out = parsed_out->get()->ApproximateMemoryUsage();
   }
 
-  void Create(std::unique_ptr<Block_kData>* parsed_out, BlockContents&& block);
-  void Create(std::unique_ptr<Block_kIndex>* parsed_out, BlockContents&& block);
+  void Create(std::unique_ptr<Block_kData>* parsed_out, BlockContents&& block,
+              MemoryAllocator* alloc);
+  void Create(std::unique_ptr<Block_kIndex>* parsed_out, BlockContents&& block,
+              MemoryAllocator* alloc);
   void Create(std::unique_ptr<Block_kFilterPartitionIndex>* parsed_out,
-              BlockContents&& block);
+              BlockContents&& block, MemoryAllocator* alloc);
   void Create(std::unique_ptr<Block_kRangeDeletion>* parsed_out,
-              BlockContents&& block);
+              BlockContents&& block, MemoryAllocator* alloc);
   void Create(std::unique_ptr<Block_kMetaIndex>* parsed_out,
-              BlockContents&& block);
+              BlockContents&& block, MemoryAllocator* alloc);
   void Create(std::unique_ptr<ParsedFullFilterBlock>* parsed_out,
-              BlockContents&& block);
+              BlockContents&& block, MemoryAllocator* alloc);
   void Create(std::unique_ptr<UncompressionDict>* parsed_out,
-              BlockContents&& block);
+              BlockContents&& block, MemoryAllocator* alloc);
 };
 
 // Convenient cache interface to use for block_cache, with support for

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -618,6 +618,14 @@ DEFINE_bool(cache_index_and_filter_blocks, false,
 DEFINE_bool(use_cache_jemalloc_no_dump_allocator, false,
             "Use JemallocNodumpAllocator for block/blob cache.");
 
+DEFINE_uint32(jemalloc_no_dump_allocator_num_arenas,
+              ROCKSDB_NAMESPACE::JemallocAllocatorOptions().num_arenas,
+              "JemallocNodumpAllocator::num_arenas");
+
+DEFINE_bool(jemalloc_no_dump_allocator_limit_tcache_size,
+            ROCKSDB_NAMESPACE::JemallocAllocatorOptions().limit_tcache_size,
+            "JemallocNodumpAllocator::limit_tcache_size");
+
 DEFINE_bool(use_cache_memkind_kmem_allocator, false,
             "Use memkind kmem allocator for block/blob cache.");
 
@@ -2993,6 +3001,9 @@ class Benchmark {
 
     if (FLAGS_use_cache_jemalloc_no_dump_allocator) {
       JemallocAllocatorOptions jemalloc_options;
+      jemalloc_options.num_arenas = FLAGS_jemalloc_no_dump_allocator_num_arenas;
+      jemalloc_options.limit_tcache_size =
+          FLAGS_jemalloc_no_dump_allocator_limit_tcache_size;
       if (!NewJemallocNodumpAllocator(jemalloc_options, &allocator).ok()) {
         fprintf(stderr, "JemallocNodumpAllocator not supported.\n");
         exit(1);
@@ -3053,6 +3064,7 @@ class Benchmark {
       HyperClockCacheOptions opts(FLAGS_cache_size, estimated_entry_charge,
                                   FLAGS_cache_numshardbits);
       opts.hash_seed = GetCacheHashSeed();
+      opts.memory_allocator = GetCacheAllocator();
       if (use_tiered_cache) {
         TieredVolatileCacheOptions tiered_opts;
         opts.capacity += secondary_cache_opts.capacity;


### PR DESCRIPTION
Summary: Currently, only the uncompressed block contents objects are allocated with the custom allocator (e.g. JemallocNodumpAllocator) but it seems like the other objects representing parsed blocks should also be allocated with the custom allocator. I don't know whether there was any reason for not doing this before.

In some db_bench tests, I'm not really seeing a benefit before & after, but I'm wondering if it could potentially fix some extra jemalloc overheads seen with HCC and MySQL

```
TEST_TMPDIR=/dev/shm /usr/bin/time ./db_bench -benchmarks=readrandom -num=30000000 -readonly -cache_size=500000000 -duration=20 -cache_type=hyper_clock_cache -threads=12 -use_cache_jemalloc_no_dump_allocator=1 -jemalloc_no_dump_allocator_num_arenas=8 2>&1 | grep -E 'resident|micros'
```

Before num_arenas=1: 165832 ops/sec, 537896maxresident
After  num_arenas=1: 154033 ops/sec, 537824maxresident

Before num_arenas=8: 176747 ops/sec, 545040maxresident
After  num_arenas=8: 176584 ops/sec, 545400maxresident

Test Plan: ...