### PR TITLE
Add a per column family default temperature option for accounting

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1323,6 +1323,11 @@ class VersionBuilder::Rep {
 
         auto* file_meta = files_meta[file_idx].first;
         int level = files_meta[file_idx].second;
+        Temperature file_temperature = file_meta->temperature;
+        if (ioptions_->default_temperature != Temperature::kUnknown &&
+            file_temperature == Temperature::kUnknown) {
+          file_temperature = ioptions_->default_temperature;
+        }
         TableCache::TypedHandle* handle = nullptr;
         statuses[file_idx] = table_cache_->FindTable(
             read_options, file_options_,
@@ -1330,7 +1335,7 @@ class VersionBuilder::Rep {
             block_protection_bytes_per_key, prefix_extractor, false /*no_io */,
             internal_stats->GetFileReadHist(level), false, level,
             prefetch_index_and_filter_in_cache, max_file_size_for_l0_meta_pin,
-            file_meta->temperature);
+            file_temperature);
         if (handle != nullptr) {
           file_meta->table_reader_handle = handle;
           // Load table_reader

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -961,6 +961,14 @@ struct AdvancedColumnFamilyOptions {
   Temperature last_level_temperature = Temperature::kUnknown;
 
   // EXPERIMENTAL
+  // When this field is set, all SST files without an explicitly set temperature
+  // will be treated as if they have this temperature for file reading
+  // accounting purpose, such as io statistics, io perf context.
+  //
+  // Not dynamically changeable, change it requires db restart.
+  Temperature default_temperature = Temperature::kUnknown;
+
+  // EXPERIMENTAL
   // The feature is still in development and is incomplete.
   // If this option is set, when data insert time is within this time range, it
   // will be precluded from the last level.

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -604,6 +604,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableCFOptions, force_consistency_checks),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"default_temperature",
+         {offsetof(struct ImmutableCFOptions, default_temperature),
+          OptionType::kTemperature, OptionVerificationType::kNormal,
+          OptionTypeFlags::kCompareNever}},
         {"preclude_last_level_data_seconds",
          {offsetof(struct ImmutableCFOptions, preclude_last_level_data_seconds),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
@@ -950,6 +954,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       num_levels(cf_options.num_levels),
       optimize_filters_for_hits(cf_options.optimize_filters_for_hits),
       force_consistency_checks(cf_options.force_consistency_checks),
+      default_temperature(cf_options.default_temperature),
       preclude_last_level_data_seconds(
           cf_options.preclude_last_level_data_seconds),
       preserve_internal_time_seconds(cf_options.preserve_internal_time_seconds),

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -72,6 +72,8 @@ struct ImmutableCFOptions {
 
   bool force_consistency_checks;
 
+  Temperature default_temperature;
+
   uint64_t preclude_last_level_data_seconds;
 
   uint64_t preserve_internal_time_seconds;

--- a/options/options.cc
+++ b/options/options.cc
@@ -94,6 +94,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       ttl(options.ttl),
       periodic_compaction_seconds(options.periodic_compaction_seconds),
       sample_for_compression(options.sample_for_compression),
+      default_temperature(options.default_temperature),
       preclude_last_level_data_seconds(
           options.preclude_last_level_data_seconds),
       preserve_internal_time_seconds(options.preserve_internal_time_seconds),
@@ -412,6 +413,17 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     ROCKS_LOG_HEADER(log,
                      "         Options.periodic_compaction_seconds: %" PRIu64,
                      periodic_compaction_seconds);
+    const auto& it_temp = temperature_to_string.find(default_temperature);
+    std::string str_default_temperature;
+    if (it_temp == temperature_to_string.end()) {
+      assert(false);
+      str_default_temperature = "unknown_temperature";
+    } else {
+      str_default_temperature = it_temp->second;
+    }
+    ROCKS_LOG_HEADER(log,
+                     "                       Options.default_temperature: %s",
+                     str_default_temperature.c_str());
     ROCKS_LOG_HEADER(log, " Options.preclude_last_level_data_seconds: %" PRIu64,
                      preclude_last_level_data_seconds);
     ROCKS_LOG_HEADER(log, "   Options.preserve_internal_time_seconds: %" PRIu64,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -317,6 +317,7 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
       ioptions.preserve_internal_time_seconds;
   cf_opts->persist_user_defined_timestamps =
       ioptions.persist_user_defined_timestamps;
+  cf_opts->default_temperature = ioptions.default_temperature;
 
   // TODO(yhchiang): find some way to handle the following derived options
   // * max_file_size

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -551,6 +551,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "prepopulate_blob_cache=kDisable;"
       "bottommost_temperature=kWarm;"
       "last_level_temperature=kWarm;"
+      "default_temperature=kHot;"
       "preclude_last_level_data_seconds=86400;"
       "preserve_internal_time_seconds=86400;"
       "compaction_options_fifo={max_table_files_size=3;allow_"

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -130,6 +130,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"blob_file_starting_level", "1"},
       {"prepopulate_blob_cache", "kDisable"},
       {"last_level_temperature", "kWarm"},
+      {"default_temperature", "kHot"},
       {"persist_user_defined_timestamps", "true"},
       {"memtable_max_range_deletions", "0"},
   };
@@ -284,6 +285,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.prepopulate_blob_cache, PrepopulateBlobCache::kDisable);
   ASSERT_EQ(new_cf_opt.last_level_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
+  ASSERT_EQ(new_cf_opt.default_temperature, Temperature::kHot);
   ASSERT_EQ(new_cf_opt.persist_user_defined_timestamps, true);
   ASSERT_EQ(new_cf_opt.memtable_max_range_deletions, 0);
 
@@ -2339,6 +2341,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
       {"blob_file_starting_level", "1"},
       {"prepopulate_blob_cache", "kDisable"},
       {"last_level_temperature", "kWarm"},
+      {"default_temperature", "kHot"},
       {"persist_user_defined_timestamps", "true"},
       {"memtable_max_range_deletions", "0"},
   };
@@ -2491,6 +2494,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.prepopulate_blob_cache, PrepopulateBlobCache::kDisable);
   ASSERT_EQ(new_cf_opt.last_level_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
+  ASSERT_EQ(new_cf_opt.default_temperature, Temperature::kHot);
   ASSERT_EQ(new_cf_opt.persist_user_defined_timestamps, true);
   ASSERT_EQ(new_cf_opt.memtable_max_range_deletions, 0);
 


### PR DESCRIPTION
Add a column family option `default_temperature` that will be used for file reading accounting purpose, such as io statistics, for files that don't have an explicitly set temperature.

This options is not a mutable one, changing its value would require a DB restart. This is to avoid the confusion that had the option being a mutable one, the users may expect it to take effect on all files immediately, while in reality, it would only become effective for SST files opened in the future.

This `default_temperature` also just affect accounting during one DB session. It won't be recorded in manifest as the file's temperature and can be different across different DB sessions.

Test Plan:
```
make all check
```