### PR TITLE
Timeout in microsecond option in WaitForCompactOptions

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3598,19 +3598,16 @@ TEST_P(DBCompactionWaitForCompactTest,
 }
 
 TEST_P(DBCompactionWaitForCompactTest, WaitForCompactToTimeout) {
-  // When timeout_micros is set, this test makes CompactionJob hangs forever
-  // using sync point. This test also sets the timeout to be 1 second for
+  // When timeout is set, this test makes CompactionJob hangs forever
+  // using sync point. This test also sets the timeout to be 1 ms for
   // WaitForCompact to time out early. WaitForCompact() is expected to return
   // Status::TimedOut.
-  // When timeout_micros is not set, we expect WaitForCompact() to wait
-  // indefinitely. We don't want the test to hang forever. When timeout_micros =
-  // 0, this test is not much different from
-  // WaitForCompactWaitsOnCompactionToFinish
+  // When timeout is not set, we expect WaitForCompact() to wait indefinitely.
+  // We don't want the test to hang forever. When timeout = 0, this test is not
+  // much different from WaitForCompactWaitsOnCompactionToFinish
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
-      {{"DBImpl::WaitForCompact:StartWaiting",
-        "DBCompactionTest::WaitForCompactToTimeout:0"},
-       {"DBCompactionTest::WaitForCompactToTimeout:1",
+      {{"DBCompactionTest::WaitForCompactToTimeout",
         "CompactionJob::Run():Start"}});
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
@@ -3620,29 +3617,22 @@ TEST_P(DBCompactionWaitForCompactTest, WaitForCompactToTimeout) {
   GenerateNewRandomFile(&rnd, /* nowait */ true);
   ASSERT_OK(Flush());
 
-  // Wait for Compaction in another thread
-  auto waiting_for_compaction_thread = port::Thread([this]() {
-    if (wait_for_compact_options_.timeout.count()) {
-      // Make timeout shorter to finish test early
-      wait_for_compact_options_.timeout = std::chrono::microseconds{1000000};
-    } else {
-      // if timeout is not set, WaitForCompact() will wait forever. We don't
-      // want test to hang forever. Just let compaction go through
-      TEST_SYNC_POINT("DBCompactionTest::WaitForCompactToTimeout:1");
-    }
-    Status s = dbfull()->WaitForCompact(wait_for_compact_options_);
-    if (wait_for_compact_options_.timeout.count()) {
-      ASSERT_NOK(s);
-      ASSERT_TRUE(s.IsTimedOut());
-    } else {
-      ASSERT_OK(s);
-    }
-  });
-  TEST_SYNC_POINT("DBCompactionTest::WaitForCompactToTimeout:0");
-  waiting_for_compaction_thread.join();
-
+  if (wait_for_compact_options_.timeout.count()) {
+    // Make timeout shorter to finish test early
+    wait_for_compact_options_.timeout = std::chrono::microseconds{1000};
+  } else {
+    // if timeout is not set, WaitForCompact() will wait forever. We don't
+    // want test to hang forever. Just let compaction go through
+    TEST_SYNC_POINT("DBCompactionTest::WaitForCompactToTimeout");
+  }
+  Status s = dbfull()->WaitForCompact(wait_for_compact_options_);
+  if (wait_for_compact_options_.timeout.count()) {
+    ASSERT_NOK(s);
+    ASSERT_TRUE(s.IsTimedOut());
+  } else {
+    ASSERT_OK(s);
+  }
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
-  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 static std::string ShortKey(int i) {

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3341,8 +3341,16 @@ TEST_F(DBCompactionTest, SuggestCompactRangeNoTwoLevel0Compactions) {
 
 INSTANTIATE_TEST_CASE_P(
     DBCompactionWaitForCompactTest, DBCompactionWaitForCompactTest,
-    ::testing::Combine(testing::Bool(), testing::Bool(), testing::Bool(),
-                       testing::Values(0, 5 * 60 * 1000000ULL)));  // 5 minutes
+    ::testing::Combine(
+        testing::Bool() /* abort_on_pause */, testing::Bool() /* flush */,
+        testing::Bool() /* close_db */,
+        testing::Values(
+            0,
+            60 * 60 *
+                1000000ULL /* timeout_micros */)));  // 1 hour (long enough to
+                                                     // make sure that tests
+                                                     // don't fail unexpectedly
+                                                     // when running slow)
 
 TEST_P(DBCompactionWaitForCompactTest,
        WaitForCompactWaitsOnCompactionToFinish) {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1477,7 +1477,8 @@ class DB {
   // NOTE: This may also never return if there's sufficient ongoing writes that
   // keeps flush and compaction going without stopping. The user would have to
   // cease all the writes to DB to make this eventually return in a stable
-  // state.
+  // state. The user may also use timeout option in WaitForCompactOptions to
+  // make this stop waiting and return when timeout expires.
   virtual Status WaitForCompact(
       const WaitForCompactOptions& /* wait_for_compact_options */) = 0;
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2135,7 +2135,8 @@ struct WaitForCompactOptions {
 
   // Timeout in microseconds for waiting for compaction to complete.
   // Status::TimedOut will be returned if timeout expires.
-  uint64_t timeout_micros = 0;
+  // when timeout == 0, WaitForCompact() will wait indefinitely.
+  std::chrono::microseconds timeout = std::chrono::microseconds::zero();
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2132,6 +2132,10 @@ struct WaitForCompactOptions {
   // returned Aborted status due to unreleased snapshots in the system. See
   // comments in DB::Close() for details.
   bool close_db = false;
+
+  // Timeout in microseconds for waiting for compaction to complete.
+  // Status::TimedOut will be returned if timeout expires.
+  uint64_t timeout_micros = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2120,7 +2120,8 @@ struct WaitForCompactOptions {
   // called) If true, Status::Aborted will be returned immediately. If false,
   // ContinueBackgroundWork() must be called to resume the background jobs.
   // Otherwise, jobs that were queued, but not scheduled yet may never finish
-  // and WaitForCompact() may wait indefinitely.
+  // and WaitForCompact() may wait indefinitely (if timeout is set, it will
+  // expire and return Status::TimedOut).
   bool abort_on_pause = false;
 
   // A boolean to flush all column families before starting to wait.
@@ -2135,7 +2136,8 @@ struct WaitForCompactOptions {
 
   // Timeout in microseconds for waiting for compaction to complete.
   // Status::TimedOut will be returned if timeout expires.
-  // when timeout == 0, WaitForCompact() will wait indefinitely.
+  // when timeout == 0, WaitForCompact() will wait as long as there's background
+  // work to finish.
   std::chrono::microseconds timeout = std::chrono::microseconds::zero();
 };
 

--- a/unreleased_history/new_features/timeout_for_wait_for_compact_api.md
+++ b/unreleased_history/new_features/timeout_for_wait_for_compact_api.md
@@ -1,0 +1,1 @@
+Add timeout in microsecond option to `WaitForCompactOptions` to prevent `WaitForCompact()` from waiting indefinitely

--- a/unreleased_history/new_features/timeout_for_wait_for_compact_api.md
+++ b/unreleased_history/new_features/timeout_for_wait_for_compact_api.md
@@ -1,1 +1,1 @@
-Add timeout in microsecond option to `WaitForCompactOptions` to prevent `WaitForCompact()` from waiting indefinitely
+Add `timeout` in microsecond option to `WaitForCompactOptions` to allow timely termination of prolonged waiting in scenarios like recurring recoverable errors, such as out-of-space situations and continuous write streams that sustain ongoing flush and compactions


### PR DESCRIPTION
# Summary
While it's rare, we may run into a scenario where `WaitForCompact()` waits for background jobs indefinitely. For example, not enough space error will add the job back to the queue while WaitForCompact() waits for _all jobs_ including the jobs that are in the queue to be completed.

# Test Plan
`DBCompactionWaitForCompactTest::WaitForCompactToTimeout` added
`timeout` option added to the variables for all of the existing DBCompactionWaitForCompactTests