### PR TITLE
Add unit test for default temperature

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -129,6 +129,10 @@ Status TableCache::GetTableReader(
     if (!sequential_mode && ioptions_.advise_random_on_open) {
       file->Hint(FSRandomAccessFile::kRandom);
     }
+    if (ioptions_.default_temperature != Temperature::kUnknown &&
+        file_temperature == Temperature::kUnknown) {
+      file_temperature = ioptions_.default_temperature;
+    }
     StopWatch sw(ioptions_.clock, ioptions_.stats, TABLE_OPEN_IO_MICROS);
     std::unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(std::move(file), fname, ioptions_.clock,

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1323,11 +1323,6 @@ class VersionBuilder::Rep {
 
         auto* file_meta = files_meta[file_idx].first;
         int level = files_meta[file_idx].second;
-        Temperature file_temperature = file_meta->temperature;
-        if (ioptions_->default_temperature != Temperature::kUnknown &&
-            file_temperature == Temperature::kUnknown) {
-          file_temperature = ioptions_->default_temperature;
-        }
         TableCache::TypedHandle* handle = nullptr;
         statuses[file_idx] = table_cache_->FindTable(
             read_options, file_options_,
@@ -1335,7 +1330,7 @@ class VersionBuilder::Rep {
             block_protection_bytes_per_key, prefix_extractor, false /*no_io */,
             internal_stats->GetFileReadHist(level), false, level,
             prefetch_index_and_filter_in_cache, max_file_size_for_l0_meta_pin,
-            file_temperature);
+            file_meta->temperature);
         if (handle != nullptr) {
           file_meta->table_reader_handle = handle;
           // Load table_reader


### PR DESCRIPTION
This piggy back the existing last level file temperature statistics test to test the default temperature becoming effective. 

While adding this unit test, I found that the approach to swap out and use default temperature in `VersionBuilder::LoadTableHandlers` will miss the L0 files created from flush, and only work for existing SST files, SST files created by compaction. So this PR moves that logic to `TableCache::GetTableReader`. 

Test Plan:
```
./db_test2 --gtest_filter="*LastLevelStatistics*"
make all check
```