### PR TITLE
Reverse sort order in dedup to enable iter checking in callback

### DIFF
--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -457,12 +457,12 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
   std::sort(candidate_files.begin(), candidate_files.end(),
             [](const JobContext::CandidateFileInfo& lhs,
                const JobContext::CandidateFileInfo& rhs) {
-              if (lhs.file_name > rhs.file_name) {
+              if (lhs.file_name < rhs.file_name) {
                 return true;
-              } else if (lhs.file_name < rhs.file_name) {
+              } else if (lhs.file_name > rhs.file_name) {
                 return false;
               } else {
-                return (lhs.file_path > rhs.file_path);
+                return (lhs.file_path < rhs.file_path);
               }
             });
   candidate_files.erase(

--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -155,18 +155,18 @@ TEST_F(DBTestXactLogIterator, TransactionLogIteratorCheckWhenArchive) {
     auto s = dbfull()->CreateColumnFamily(ColumnFamilyOptions(), "CF", &cf);
     ASSERT_TRUE(s.ok());
 
-    dbfull()->Put(WriteOptions(), cf, "key1", DummyString(1024));
+    ASSERT_OK(dbfull()->Put(WriteOptions(), cf, "key1", DummyString(1024)));
 
-    dbfull()->Put(WriteOptions(), "key2", DummyString(1024));
+    ASSERT_OK(dbfull()->Put(WriteOptions(), "key2", DummyString(1024)));
 
-    dbfull()->Flush(FlushOptions());
+    ASSERT_OK(dbfull()->Flush(FlushOptions()));
 
-    dbfull()->Put(WriteOptions(), "key3", DummyString(1024));
+    ASSERT_OK(dbfull()->Put(WriteOptions(), "key3", DummyString(1024)));
 
-    dbfull()->Flush(FlushOptions());
+    ASSERT_OK(dbfull()->Flush(FlushOptions()));
 
-    dbfull()->Put(WriteOptions(), "key4", DummyString(1024));
-    dbfull()->Flush(FlushOptions());
+    ASSERT_OK(dbfull()->Put(WriteOptions(), "key4", DummyString(1024)));
+    ASSERT_OK(dbfull()->Flush(FlushOptions()));
 
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
         "WalManager::PurgeObsoleteFiles:1", [&](void*) {
@@ -175,7 +175,7 @@ TEST_F(DBTestXactLogIterator, TransactionLogIteratorCheckWhenArchive) {
         });
 
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
-    dbfull()->Flush(FlushOptions(), cf);
+    ASSERT_OK(dbfull()->Flush(FlushOptions(), cf));
 
     delete cf;
   } while (ChangeCompactOptions());

--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -145,6 +145,41 @@ TEST_F(DBTestXactLogIterator, TransactionLogIteratorRace) {
     } while (ChangeCompactOptions());
   }
 }
+
+TEST_F(DBTestXactLogIterator, TransactionLogIteratorCheckWhenArchive) {
+  do {
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearTrace();
+    Options options = OptionsForLogIterTest();
+    DestroyAndReopen(options);
+    ColumnFamilyHandle* cf;
+    auto s = dbfull()->CreateColumnFamily(ColumnFamilyOptions(), "CF", &cf);
+    ASSERT_TRUE(s.ok());
+
+    dbfull()->Put(WriteOptions(), cf, "key1", DummyString(1024));
+
+    dbfull()->Put(WriteOptions(), "key2", DummyString(1024));
+
+    dbfull()->Flush(FlushOptions());
+
+    dbfull()->Put(WriteOptions(), "key3", DummyString(1024));
+
+    dbfull()->Flush(FlushOptions());
+
+    dbfull()->Put(WriteOptions(), "key4", DummyString(1024));
+    dbfull()->Flush(FlushOptions());
+
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+        "WalManager::PurgeObsoleteFiles:1", [&](void*) {
+          auto iter = OpenTransactionLogIter(0);
+          ExpectRecords(4, iter);
+        });
+
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+    dbfull()->Flush(FlushOptions(), cf);
+
+    delete cf;
+  } while (ChangeCompactOptions());
+}
 #endif
 
 TEST_F(DBTestXactLogIterator, TransactionLogIteratorStallAtLastRecord) {


### PR DESCRIPTION
Fix #6470 

Ensure TransactionLogIter being initialized correctly with SYNC_POINT API when calling `GetSortedWALFiles`. 