### PR TITLE
test: WritableFile derived class: add missing GetFileSize() override

### DIFF
--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -233,6 +233,7 @@ class SpecialEnv : public EnvWrapper {
       size_t GetUniqueId(char* id, size_t max_size) const override {
         return base_->GetUniqueId(id, max_size);
       }
+      uint64_t GetFileSize() final { return base_->GetFileSize(); }
     };
     class ManifestFile : public WritableFile {
      public:
@@ -345,6 +346,7 @@ class SpecialEnv : public EnvWrapper {
       Status Allocate(uint64_t offset, uint64_t len) override {
         return base_->Allocate(offset, len);
       }
+      uint64_t GetFileSize() final { return base_->GetFileSize(); }
 
      private:
       SpecialEnv* env_;

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -999,7 +999,7 @@ class WritableFile {
   /*
    * Get the size of valid data in the file.
    */
-  virtual uint64_t GetFileSize() { return 0; }
+  virtual uint64_t GetFileSize() = 0;
 
   /*
    * Get and set the default pre-allocation block size for writes to

--- a/utilities/fault_injection_env.h
+++ b/utilities/fault_injection_env.h
@@ -96,6 +96,7 @@ class TestWritableFile : public WritableFile {
   virtual bool use_direct_io() const override {
     return target_->use_direct_io();
   };
+  uint64_t GetFileSize() final { return target_->GetFileSize(); }
 
  private:
   FileState state_;


### PR DESCRIPTION
Missed `GetFileSize()` forwarding , this PR fix this issue, and mark `WritableFile::GetFileSize()` as pure virtual to detect such issue in compile time.