### PR TITLE
Disallow writing at or below cutoff timestamp

### DIFF
--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -290,7 +290,7 @@ TEST_F(DBBasicTestWithTimestamp, UpdateFullHistoryTsLow) {
   ASSERT_OK(Flush());
 
   // Reads [0, 16)
-  for (int i = current_ts_low + 1; i < 10 + current_ts_low + 1; i++) {
+  for (int i = 0; i < 10 + current_ts_low + 1; i++) {
     ReadOptions read_opts;
     std::string ts_str = Timestamp(i, 0);
     Slice ts = ts_str;
@@ -299,6 +299,8 @@ TEST_F(DBBasicTestWithTimestamp, UpdateFullHistoryTsLow) {
     Status status = db_->Get(read_opts, kKey, &value);
     if (i < current_ts_low) {
       ASSERT_TRUE(status.IsInvalidArgument());
+    } else if (i == current_ts_low) {
+      ASSERT_TRUE(status.IsNotFound());
     } else {
       ASSERT_OK(status);
       ASSERT_TRUE(value.compare(Key(i)) == 0);


### PR DESCRIPTION
The cutoff timestamp `full_history_ts_low` is used by both flush and compaction processes to collapse history. Currently only read APIs enforce a check to disallow reading below cutoff timestamp, this is to prohibit repeated read getting inconsistent result. Without this sanity check in read APIs, this type of inconsistent read can happen:

Write(key, 1, v1)
Write(key, 3, v3)
Read(key, 2) <= return (key, 1, v1)
Set (full_history_ts_low, 4)
<(key, 1, v1), (key, 3, v3) collapsed to be (key, 0, v1), (key, 0, v3)>
Read(key, 2) <= if this is allowed, it would return (key, 0, v3), which is inconsistent value.

This PR adds a similar sanity check to write APIs, to disallow writing at or below the cutoff timestamp. Basically, it doesn't allow a future write to change the history below cutoff timestamp. Without this sanity check, similar inconsistent read can happen too. Consider this example:

Write(key, 1, v1)
Read(key, 4) <= return (key, 1, v1)
Set(full_history_ts_low, 4)
Write(key, 4, v4)
Read(key, 4) <= return (key, 4, v4), this return inconsistent value because Write(key, 4, v4) wasn't prohibited in the first place

Test plan:
Update unit test that would originally fail with this change:
```
./db_with_timestamp_basic_test --gtest_filter="*UpdateFullHistoryTsLow*"
make all check
```

