### PR TITLE
Removing some checks for UDT in memtable only feature

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1557,24 +1557,15 @@ bool ColumnFamilyData::ShouldPostponeFlushToRetainUDT(
   if (full_history_ts_low.empty()) {
     return false;
   }
-#ifndef NDEBUG
-  Slice last_table_newest_udt;
-#endif /* !NDEBUG */
   for (const Slice& table_newest_udt :
        imm()->GetTablesNewestUDT(max_memtable_id)) {
     assert(table_newest_udt.size() == full_history_ts_low.size());
-    assert(last_table_newest_udt.empty() ||
-           ucmp->CompareTimestamp(table_newest_udt, last_table_newest_udt) >=
-               0);
     // Checking the newest UDT contained in MemTable with ascending ID up to
-    // `max_memtable_id`. MemTable with bigger ID will have newer UDT, return
-    // immediately on finding the first MemTable that needs postponing.
+    // `max_memtable_id`. Return immediately on finding the first MemTable that
+    // needs postponing.
     if (ucmp->CompareTimestamp(table_newest_udt, full_history_ts_low) >= 0) {
       return true;
     }
-#ifndef NDEBUG
-    last_table_newest_udt = table_newest_udt;
-#endif /* !NDEBUG */
   }
   return false;
 }

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -1129,7 +1129,6 @@ void FlushJob::GetEffectiveCutoffUDTForPickedMemTables() {
         ucmp->CompareTimestamp(table_newest_udt, cutoff_udt_) > 0) {
       if (!cutoff_udt_.empty()) {
         assert(table_newest_udt.size() == cutoff_udt_.size());
-        cutoff_udt_.clear();
       }
       cutoff_udt_.assign(table_newest_udt.data(), table_newest_udt.size());
     }

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -1122,16 +1122,17 @@ void FlushJob::GetEffectiveCutoffUDTForPickedMemTables() {
       cfd_->ioptions()->persist_user_defined_timestamps) {
     return;
   }
+  // Find the newest user-defined timestamps from all the flushed memtables.
   for (MemTable* m : mems_) {
     Slice table_newest_udt = m->GetNewestUDT();
-    // The picked Memtables should have ascending ID, and should have
-    // non-decreasing newest user-defined timestamps.
-    if (!cutoff_udt_.empty()) {
-      assert(table_newest_udt.size() == cutoff_udt_.size());
-      assert(ucmp->CompareTimestamp(table_newest_udt, cutoff_udt_) >= 0);
-      cutoff_udt_.clear();
+    if (cutoff_udt_.empty() ||
+        ucmp->CompareTimestamp(table_newest_udt, cutoff_udt_) > 0) {
+      if (!cutoff_udt_.empty()) {
+        assert(table_newest_udt.size() == cutoff_udt_.size());
+        cutoff_udt_.clear();
+      }
+      cutoff_udt_.assign(table_newest_udt.data(), table_newest_udt.size());
     }
-    cutoff_udt_.assign(table_newest_udt.data(), table_newest_udt.size());
   }
 }
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1181,9 +1181,6 @@ struct AdvancedColumnFamilyOptions {
   // refrains from flushing a memtable with data still above
   // the cutoff timestamp with best effort. If this cutoff timestamp is not set,
   // flushing continues normally.
-  // NOTE: in order for the cutoff timestamp to work properly, users of this
-  // feature need to ensure to write to a column family with globally
-  // non-decreasing user-defined timestamps.
   //
   // Users can do user-defined
   // multi-versioned read above the cutoff timestamp. When users try to read


### PR DESCRIPTION
The user-defined timestamps feature only enforces that for the same key, user-defined timestamps should be non-decreasing. For the user-defined timestamps in memtable only feature, during flush, we check the user-defined timestamps in each memtable to examine if the data is considered expired with regard to `full_history_ts_low`. In this process, it's assuming that a newer memtable should not have smaller user-defined timestamps than an older memtable. This check however is enforcing ordering of user-defined timestamps across keys, as apposed to the vanilla UDT feature, that only enforce ordering of user-defined timestamps for the same key.

This more strict user-defined timestamp ordering requirement could be an issue for secondary instances where commits can be out of order. And after thinking more about it, this requirement is really an overkill to keep the invariants of `full_history_ts_low` which are:

1) users cannot read below `full_history_ts_low`
2) users cannot write at or below `full_history_ts_low`
3) `full_history_ts_low` can only be increasing

As long as RocksDB enforces these 3 checks, we can prohibit inconsistent read that returns a different value. And these three checks are covered in existing APIs. 

So this PR removes the extra checks in the UDT in memtable only feature that requires user-defined timestamps to be non decreasing across keys.