### PR TITLE
fixed build warnings when building on Windows + MSYS2 + Clang 16 + CMake

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -970,6 +970,8 @@ TEST_P(EnvPosixTestWithParam, ReserveThreads) {
 
 #if (defined OS_LINUX || defined OS_WIN)
 namespace {
+
+#ifndef OS_WIN
 bool IsSingleVarint(const std::string& s) {
   Slice slice(s);
 
@@ -984,6 +986,7 @@ bool IsSingleVarint(const std::string& s) {
 bool IsUniqueIDValid(const std::string& s) {
   return !s.empty() && !IsSingleVarint(s);
 }
+#endif
 
 const size_t MAX_ID_SIZE = 100;
 char temp_id[MAX_ID_SIZE];
@@ -2931,7 +2934,6 @@ TEST_F(CreateEnvTest, CreateEncryptedFileSystem) {
   ASSERT_OK(FileSystem::CreateFromString(config_options_, opts_str, &copy));
   ASSERT_TRUE(fs->AreEquivalent(config_options_, copy.get(), &mismatch));
 }
-
 
 namespace {
 

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -90,8 +90,9 @@ WinClock::WinClock()
 
   HMODULE module = GetModuleHandle("kernel32.dll");
   if (module != NULL) {
-    GetSystemTimePreciseAsFileTime_ = (FnGetSystemTimePreciseAsFileTime)(
-        void*)GetProcAddress(module, "GetSystemTimePreciseAsFileTime");
+    GetSystemTimePreciseAsFileTime_ =
+        (FnGetSystemTimePreciseAsFileTime)(void*)GetProcAddress(
+            module, "GetSystemTimePreciseAsFileTime");
   }
 }
 
@@ -1231,7 +1232,7 @@ size_t WinFileSystem::GetSectorSize(const std::string& fname) {
     // many devices do not support StorageProcessAlignmentProperty. Any failure
     // here and we fall back to logical alignment
 
-    DISK_GEOMETRY_EX geometry = {0};
+    DISK_GEOMETRY_EX geometry = {};
     ret = DeviceIoControl(hDevice, IOCTL_DISK_GET_DRIVE_GEOMETRY, nullptr, 0,
                           &geometry, sizeof(geometry), &output_bytes, nullptr);
     if (ret) {

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -72,7 +72,7 @@ class WinEnvThreads {
   void IncBackgroundThreadsIfNeeded(int num, Env::Priority pri);
 
  private:
-  Env* hosted_env_;
+  [[maybe_unused]] Env* hosted_env_;
   mutable std::mutex mu_;
   std::vector<ThreadPoolImpl> thread_pools_;
   std::vector<Thread> threads_to_join_;
@@ -257,7 +257,7 @@ class WinEnvIO {
   virtual Status GetHostName(char* name, uint64_t len);
 
  private:
-  Env* hosted_env_;
+  [[maybe_unused]] Env* hosted_env_;
 };
 
 class WinEnv : public CompositeEnv {

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -27,10 +27,6 @@ namespace {
 
 const size_t kSectorSize = 512;
 
-inline bool IsPowerOfTwo(const size_t alignment) {
-  return ((alignment) & (alignment - 1)) == 0;
-}
-
 inline bool IsAligned(size_t alignment, const void* ptr) {
   return ((uintptr_t(ptr)) & (alignment - 1)) == 0;
 }

--- a/third-party/gtest-1.8.1/fused-src/gtest/gtest-all.cc
+++ b/third-party/gtest-1.8.1/fused-src/gtest/gtest-all.cc
@@ -9731,7 +9731,7 @@ class MemoryIsNotDeallocated
   }
 
  private:
-  int old_crtdbg_flag_;
+  [[maybe_unused]] int old_crtdbg_flag_;
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MemoryIsNotDeallocated);
 };


### PR DESCRIPTION
With this PR, I am able to build `rocksdb` using Windows on MSYS2 using clang 16