### PR TITLE
Add statistics `COMPACTION_CPU_TOTAL_TIME` for total compaction time

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -6040,6 +6040,62 @@ TEST_P(DBTestWithParam, FilterCompactionTimeTest) {
   delete itr;
 }
 
+TEST_P(DBTestWithParam, CompactionTotalTimeTest) {
+  int record_count = 0;
+  class TestStatistics : public StatisticsImpl {
+   public:
+    TestStatistics(int* record_count)
+        : StatisticsImpl(nullptr), record_count_(record_count) {}
+    static const char* kClassName() { return "Test"; }
+    void recordTick(uint32_t ticker_type, uint64_t count) override {
+      if (ticker_type == COMPACTION_CPU_TOTAL_TIME) {
+        ASSERT_GT(count, 0);
+        (*record_count_)++;
+      }
+      StatisticsImpl::recordTick(ticker_type, count);
+    }
+
+    int* record_count_;
+  };
+
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  options.create_if_missing = true;
+  options.statistics = std::make_shared<TestStatistics>(&record_count);
+  options.statistics->set_stats_level(kExceptTimeForMutex);
+  options.max_subcompactions = max_subcompactions_;
+  DestroyAndReopen(options);
+
+  int n = 0;
+  for (int table = 0; table < 4; ++table) {
+    for (int i = 0; i < 1000; ++i) {
+      ASSERT_OK(Put(std::to_string(table * 1000 + i), "val"));
+      ++n;
+    }
+    // Overlapping tables
+    ASSERT_OK(Put(std::to_string(0), "val"));
+    ++n;
+    ASSERT_OK(Flush());
+  }
+
+  CompactRangeOptions cro;
+  cro.exclusive_manual_compaction = exclusive_manual_compaction_;
+  ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
+
+  // Hard-coded number in CompactionJob::ProcessKeyValueCompaction().
+  const int kRecordStatsEvery = 1000;
+  // The stat COMPACTION_CPU_TOTAL_TIME should be recorded
+  // during compaction and once more after compaction.
+  ASSERT_EQ(n / kRecordStatsEvery + 1, record_count);
+
+  // Check that COMPACTION_CPU_TOTAL_TIME correctly
+  // records compaction time after a compaction.
+  HistogramData h;
+  options.statistics->histogramData(COMPACTION_CPU_TIME, &h);
+  ASSERT_EQ(1, h.count);
+  ASSERT_EQ(h.max, TestGetTickerCount(options, COMPACTION_CPU_TOTAL_TIME));
+}
+
 TEST_F(DBTest, TestLogCleanup) {
   Options options = CurrentOptions();
   options.write_buffer_size = 64 * 1024;  // very small

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -6046,9 +6046,8 @@ TEST_P(DBTestWithParam, CompactionTotalTimeTest) {
   int record_count = 0;
   class TestStatistics : public StatisticsImpl {
    public:
-    TestStatistics(int* record_count)
+    explicit TestStatistics(int* record_count)
         : StatisticsImpl(nullptr), record_count_(record_count) {}
-    static const char* kClassName() { return "Test"; }
     void recordTick(uint32_t ticker_type, uint64_t count) override {
       if (ticker_type == COMPACTION_CPU_TOTAL_TIME) {
         ASSERT_GT(count, 0);

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -6040,6 +6040,8 @@ TEST_P(DBTestWithParam, FilterCompactionTimeTest) {
   delete itr;
 }
 
+#ifndef OS_WIN
+// CPUMicros() is not supported. See WinClock::CPUMicros().
 TEST_P(DBTestWithParam, CompactionTotalTimeTest) {
   int record_count = 0;
   class TestStatistics : public StatisticsImpl {
@@ -6095,6 +6097,7 @@ TEST_P(DBTestWithParam, CompactionTotalTimeTest) {
   ASSERT_EQ(1, h.count);
   ASSERT_EQ(h.max, TestGetTickerCount(options, COMPACTION_CPU_TOTAL_TIME));
 }
+#endif
 
 TEST_F(DBTest, TestLogCleanup) {
   Options options = CurrentOptions();

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -208,8 +208,11 @@ enum Tickers : uint32_t {
 
   // DEPRECATED / unused (see NUMBER_BLOCK_COMPRESSION_*)
   NUMBER_BLOCK_NOT_COMPRESSED,
+
+  // Tickers that record cumulative time.
   MERGE_OPERATION_TOTAL_TIME,
   FILTER_OPERATION_TOTAL_TIME,
+  COMPACTION_CPU_TOTAL_TIME,
 
   // Row cache.
   ROW_CACHE_HIT,

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -111,6 +111,7 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {NUMBER_BLOCK_NOT_COMPRESSED, "rocksdb.number.block.not_compressed"},
     {MERGE_OPERATION_TOTAL_TIME, "rocksdb.merge.operation.time.nanos"},
     {FILTER_OPERATION_TOTAL_TIME, "rocksdb.filter.operation.time.nanos"},
+    {COMPACTION_CPU_TOTAL_TIME, "rocksdb.compaction.total.time.cpu_micros"},
     {ROW_CACHE_HIT, "rocksdb.row.cache.hit"},
     {ROW_CACHE_MISS, "rocksdb.row.cache.miss"},
     {READ_AMP_ESTIMATE_USEFUL_BYTES, "rocksdb.read.amp.estimate.useful.bytes"},

--- a/unreleased_history/new_features/compaction_time_stats.md
+++ b/unreleased_history/new_features/compaction_time_stats.md
@@ -1,0 +1,1 @@
+* Add a new statistic `COMPACTION_CPU_TOTAL_TIME` that records cumulative compaction cpu time. This ticker is updated regularly while a compaction is running. 


### PR DESCRIPTION
Existing compaction statistics are `COMPACTION_TIME` and `COMPACTION_CPU_TIME` which are histogram and are logged at the end of a compaction. The new statistics `COMPACTION_CPU_TOTAL_TIME` is for cumulative total compaction time which is updated regularly during a compaction. This allows user to more closely track compaction cpu usage.

Test plan:
* new unit test `DBTestWithParam.CompactionTotalTimeTest`