### PR TITLE
allow replacing hash container type in point lock tracker

### DIFF
--- a/utilities/transactions/lock/point/point_lock_tracker.h
+++ b/utilities/transactions/lock/point/point_lock_tracker.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "util/hash_containers.h"
 #include "utilities/transactions/lock/lock_tracker.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -33,9 +34,9 @@ struct TrackedKeyInfo {
   }
 };
 
-using TrackedKeyInfos = std::unordered_map<std::string, TrackedKeyInfo>;
+using TrackedKeyInfos = UnorderedMap<std::string, TrackedKeyInfo>;
 
-using TrackedKeys = std::unordered_map<ColumnFamilyId, TrackedKeyInfos>;
+using TrackedKeys = UnorderedMap<ColumnFamilyId, TrackedKeyInfos>;
 
 // Tracks point locks on single keys.
 class PointLockTracker : public LockTracker {

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -840,7 +840,9 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
     // Save
     SeenStat base_seen = cur_seen;
 
-    // Verify it is repeatable
+#ifndef USE_FOLLY
+    // Verify it is repeatable.
+    // Note: this does not work with Folly F14 hash maps.
     cur_seen = {};
     txn = txn_db->BeginTransaction(write_options, txn_options, txn);
     for (const auto& key : keys) {
@@ -850,6 +852,7 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
     ASSERT_EQ(cur_seen.rolling_hash, base_seen.rolling_hash);
     ASSERT_EQ(cur_seen.min, base_seen.min);
     ASSERT_EQ(cur_seen.max, base_seen.max);
+#endif
 
     // Try another CF
     cur_seen = {};

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -842,7 +842,17 @@ TEST_P(OptimisticTransactionTest, ColumnFamiliesTest) {
 
 #ifndef USE_FOLLY
     // Verify it is repeatable.
-    // Note: this does not work with Folly F14 hash maps.
+    // Note: the keys locked/tracked in the transaction are kept in
+    // an UnorderedMap container. UnorderedMap is a an alias for
+    // std::unordered_map, except when USE_FOLLY is defined.
+    // In that case it aliases to folly::F14FastMap, which itself is
+    // an alias for either F14ValueMap or F14VectorMap. These map types
+    // have other iterator and reference stability guarantees than
+    // std::unordered_map, so we can't assume here that pointers into
+    // the map are any useful. Thus the test is disabled when USE_FOLLY
+    // is defined.
+    // More info:
+    // https://github.com/facebook/folly/blob/main/folly/container/F14.md#f14-variants
     cur_seen = {};
     txn = txn_db->BeginTransaction(write_options, txn_options, txn);
     for (const auto& key : keys) {


### PR DESCRIPTION
There is an `UnorderedMap` container type which is used in a few places throughout RocksDB.
This PR makes it available in the PointLockTracker as well. This can speed up lock operations in transactions.

To the best of my knowledge, the potentially changed type for the `tracked_keys_` container member will not lead to any iterator invalidation issues in the PointLockTracker code, even for container types that have different iterator invalidation guarantees than `std::unordered_map`, e.g. `folly::F14FastMap`. The reason is that the PointLockTracker code does not rely on pointers into the map or on iterators into the maps.

This change turned up an one issue with a failing test for optimistic transactions, which seems to collect & hash pointers into the lock map. This test failed when `USE_FOLLY` is true. 
The PR thus deactivates the affect part of the test when `USE_FOLLY` is true, and adds a code comment so that others can better understand the motivation for deactivating the test.