### PR TITLE
remove a sub-condition that is always true

### DIFF
--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -184,7 +184,7 @@ bool MemTableListVersion::GetFromList(
       assert(*seq != kMaxSequenceNumber || s->IsNotFound());
       return true;
     }
-    if (!done && !s->ok() && !s->IsMergeInProgress() && !s->IsNotFound()) {
+    if (!s->ok() && !s->IsMergeInProgress() && !s->IsNotFound()) {
       return false;
     }
   }


### PR DESCRIPTION
the value of `done` is always false here, so the sub-condition `!done` will always be true and the check can be removed.