### PR TITLE
avoid unnecessary allocations

### DIFF
--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <list>
 #include <memory>
 #include <set>
 #include <string>
@@ -117,7 +116,8 @@ struct FragmentedRangeTombstoneList {
   std::vector<Slice> tombstone_timestamps_;
   std::once_flag seq_set_init_once_flag_;
   std::set<SequenceNumber> seq_set_;
-  std::list<std::string> pinned_slices_;
+  std::string pinned_tombstone_start_key_;
+  std::string pinned_tombstone_end_key_;
   PinnedIteratorsManager pinned_iters_mgr_;
   uint64_t num_unfragmented_tombstones_;
   uint64_t total_tombstone_payload_bytes_;


### PR DESCRIPTION
avoid unnecessary memory allocations in FragmentedRangeTombStoneList. previously, the start and end keys of the range were stored in an std::list. the list contained up to 2 elements. to place an element in an std::list, a dynamic memory allocation is necessary. this PR changes the internals of FragementedRangeTombStoneList so it uses 2 std::string members to store the start and end keys. these strings are initially empty and are only populated on demand. this will slightly increase the size of the
FragmentedRangeTombStoneList compared to using an std::list, but this should not matter as the struct is already quite large anyway.