### PR TITLE
add extra msg for value size estimation for mixgraph workload

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2764,13 +2764,13 @@ class Benchmark {
     auto avg_value_size = FLAGS_value_size;
     if (FLAGS_value_size_distribution_type_e == kFixed) {
       fprintf(stdout,
-              "Values:     %d bytes each (%d bytes after compression)\n",
+              "Values:     %d bytes each (%d bytes after compression), undetermined for mixgraph workload\n",
               avg_value_size,
               static_cast<int>(avg_value_size * FLAGS_compression_ratio + 0.5));
     } else {
       avg_value_size = (FLAGS_value_size_min + FLAGS_value_size_max) / 2;
       fprintf(stdout,
-              "Values:     %d avg bytes each (%d bytes after compression)\n",
+              "Values:     %d avg bytes each (%d bytes after compression), undetermined for mixgraph workload\n",
               avg_value_size,
               static_cast<int>(avg_value_size * FLAGS_compression_ratio + 0.5));
       fprintf(stdout, "Values Distribution: %s (min: %d, max: %d)\n",
@@ -2780,11 +2780,11 @@ class Benchmark {
     fprintf(stdout, "Entries:    %" PRIu64 "\n", num_);
     fprintf(stdout, "Prefix:    %d bytes\n", FLAGS_prefix_size);
     fprintf(stdout, "Keys per prefix:    %" PRIu64 "\n", keys_per_prefix_);
-    fprintf(stdout, "RawSize:    %.1f MB (estimated)\n",
+    fprintf(stdout, "RawSize:    %.1f MB (estimated), undetermined for mixgraph workload\n",
             ((static_cast<int64_t>(FLAGS_key_size + avg_value_size) * num_) /
              1048576.0));
     fprintf(
-        stdout, "FileSize:   %.1f MB (estimated)\n",
+        stdout, "FileSize:   %.1f MB (estimated), undetermined for mixgraph workload\n",
         (((FLAGS_key_size + avg_value_size * FLAGS_compression_ratio) * num_) /
          1048576.0));
     fprintf(stdout, "Write rate: %" PRIu64 " bytes/second\n",


### PR DESCRIPTION
Current mixgraph workload in db_bench does not follow the rule that each value has a size of FLAGS_value_size and value size follows its own pareto distribution. This can cause confusion for user when they check the file size of the db folder and get a big difference from what they get from header printed by db_bench.
For example, I get a db folder whose size is only 19MB with mixgraph workload  while the header shows that FileSize is estimated to be 253MB and RawSize is estimated to be 497MB. 

So I add extra warning information in header to warn user about the file size when they use mixgraph workload. 
This is a short-term solution. 
For long term solution, it would be better to recognize that mixgraph is included in the benchmarks and do calculation about the file size based on pareto distribution. 

Command to run mixgraph workload
```
/usr/bin/time -f '%e %U %S' -o /mnt/nvme0n1/mlsm/test_blob/with_gc/benchmark_mixgraph.t1.s1.log.time ./db_bench --benchmarks=mixgraph,stats --use_existing_db=0
 --sync=1 --level0_file_num_compaction_trigger=4 --level0_slowdown_writes_trigger=20 --level0_stop_writes_trigger=30 --max_background_jobs=16 --max_write_buffe
r_number=8 --undefok=use_blob_cache,use_shared_block_and_blob_cache,blob_cache_size,blob_cache_numshardbits,prepopulate_blob_cache,multiread_batched,cache_low_
pri_pool_ratio,prepopulate_block_cache --db=/mnt/nvme0n1/mlsm/test_blob/with_gc --wal_dir=/mnt/nvme0n1/mlsm/test_blob/with_gc --num=500000 --key_size=20 --valu
e_size=1024 --block_size=8192 --cache_size=17179869184 --cache_numshardbits=6 --compression_max_dict_bytes=0 --compression_ratio=0.5 --compression_type=none --
bytes_per_sync=1048576 --benchmark_write_rate_limit=0 --write_buffer_size=134217728 --target_file_size_base=134217728 --max_bytes_for_level_base=1073741824 --v
erify_checksum=1 --delete_obsolete_files_period_micros=62914560 --max_bytes_for_level_multiplier=8 --statistics=0 --stats_per_interval=1 --stats_interval_secon
ds=60 --report_interval_seconds=1 --histogram=1 --memtablerep=skip_list --bloom_bits=10 --open_files=-1 --subcompactions=1 --enable_blob_files=1 --min_blob_siz
e=0 --blob_file_size=104857600 --blob_compression_type=none --blob_file_starting_level=0 --use_blob_cache=1 --use_shared_block_and_blob_cache=1 --blob_cache_si
ze=17179869184 --blob_cache_numshardbits=6 --prepopulate_blob_cache=0 --write_buffer_size=104857600 --target_file_size_base=3276800 --max_bytes_for_level_base=
26214400 --enable_blob_garbage_collection=true --blob_garbage_collection_age_cutoff=1.0 --blob_garbage_collection_force_threshold=1.0 --blob_compaction_readahe
ad_size=0 --compaction_style=0 --num_levels=8 --min_level_to_compress=-1 --level_compaction_dynamic_level_bytes=false --pin_l0_filter_and_index_blocks_in_cache
=1 --threads=1 --merge_operator="put" --seed=1692801373 --report_file=/mnt/nvme0n1/mlsm/test_blob/with_gc/benchmark_mixgraph.t1.s1.log.r.csv --trace_file=/mnt/
nvme0n1/mlsm/test_blob/with_gc/op_trace.txt --mix_get_ratio=0.5 --mix_put_ratio=0.5 --compaction_trace_file=/mnt/nvme0n1/mlsm/test_blob/with_gc/compaction_trac
e.txt 2>&1 | tee -a /mnt/nvme0n1/mlsm/test_blob/with_gc/benchmark_mixgraph.t1.s1.log
```
Header information that is misleading. 
```
RocksDB:    version 8.0.0
Date:       Wed Aug 23 14:36:13 2023
CPU:        40 * Intel(R) Xeon(R) Gold 6230N CPU @ 2.30GHz
CPUCache:   28160 KB
benchmark name : mixgraph
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
Integrated BlobDB: blob cache enabled, block and blob caches shared: 1, blob cache prepopulated: 0
Keys:       20 bytes each (+ 0 bytes user-defined timestamp)
Values:     1024 bytes each (512 bytes after compression), undetermined for mixgraph workload
Entries:    500000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    497.8 MB (estimated)
FileSize:   253.7 MB (estimated)
, undetermined for mixgraph workloadWrite rate: 0 bytes/second
Read rate: 0 ops/second
Compression: NoCompression
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
WARNING: Optimization is disabled: benchmarks unnecessarily slow
WARNING: Assertions are enabled; benchmarks unnecessarily slow
------------------------------------------------
```

Here's the current header 
```
Set seed to 1692802406846116 because --seed was 0
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
Integrated BlobDB: blob cache disabled
RocksDB:    version 8.6.0
Date:       Wed Aug 23 14:53:26 2023
CPU:        40 * Intel(R) Xeon(R) Gold 6230N CPU @ 2.30GHz
CPUCache:   28160 KB
Keys:       16 bytes each (+ 0 bytes user-defined timestamp)
Values:     100 bytes each (50 bytes after compression), undetermined for mixgraph workload
Entries:    1000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    110.6 MB (estimated), undetermined for mixgraph workload
FileSize:   62.9 MB (estimated), undetermined for mixgraph workload
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: NoCompression
Compression sampling rate: 0
Memtablerep: SkipListFactory
Perf Level: 1
WARNING: Optimization is disabled: benchmarks unnecessarily slow
WARNING: Assertions are enabled; benchmarks unnecessarily slow
```
