### PR TITLE
Add UDT support in SstFileDumper

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -106,6 +106,7 @@
 #include "util/mutexlock.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"
+#include "util/udt_util.h"
 #include "utilities/trace/replayer_impl.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -148,24 +149,6 @@ void DumpSupportInfo(Logger* logger) {
                    crc32c::IsFastCrc32Supported().c_str());
 
   ROCKS_LOG_HEADER(logger, "DMutex implementation: %s", DMutex::kName());
-}
-
-// `start` is the inclusive lower user key bound without user-defined timestamp
-// `limit` is the exclusive upper user key bound without user-defined timestamp
-std::tuple<Slice, Slice> MaybeAddTimestampsToRange(const Slice& start,
-                                                   const Slice& limit,
-                                                   size_t ts_sz,
-                                                   std::string* start_with_ts,
-                                                   std::string* limit_with_ts) {
-  if (ts_sz == 0) {
-    return std::make_tuple(start, limit);
-  }
-  // Maximum timestamp means including all key with any timestamp
-  AppendKeyWithMaxTimestamp(start_with_ts, start, ts_sz);
-  // Append a maximum timestamp as the range limit is exclusive:
-  // [start, limit)
-  AppendKeyWithMaxTimestamp(limit_with_ts, limit, ts_sz);
-  return std::make_tuple(Slice(*start_with_ts), Slice(*limit_with_ts));
 }
 }  // namespace
 
@@ -4281,10 +4264,12 @@ void DBImpl::GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
   // Add timestamp if needed
   std::string start_with_ts, limit_with_ts;
   auto [start, limit] = MaybeAddTimestampsToRange(
-      range.start, range.limit, ts_sz, &start_with_ts, &limit_with_ts);
+      &range.start, &range.limit, ts_sz, &start_with_ts, &limit_with_ts);
+  assert(start.has_value());
+  assert(limit.has_value());
   // Convert user_key into a corresponding internal key.
-  InternalKey k1(start, kMaxSequenceNumber, kValueTypeForSeek);
-  InternalKey k2(limit, kMaxSequenceNumber, kValueTypeForSeek);
+  InternalKey k1(start.value(), kMaxSequenceNumber, kValueTypeForSeek);
+  InternalKey k2(limit.value(), kMaxSequenceNumber, kValueTypeForSeek);
   MemTable::MemTableStats memStats =
       sv->mem->ApproximateStats(k1.Encode(), k2.Encode());
   MemTable::MemTableStats immStats =
@@ -4317,11 +4302,14 @@ Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
   for (int i = 0; i < n; i++) {
     // Add timestamp if needed
     std::string start_with_ts, limit_with_ts;
-    auto [start, limit] = MaybeAddTimestampsToRange(
-        range[i].start, range[i].limit, ts_sz, &start_with_ts, &limit_with_ts);
+    auto [start, limit] =
+        MaybeAddTimestampsToRange(&range[i].start, &range[i].limit, ts_sz,
+                                  &start_with_ts, &limit_with_ts);
+    assert(start.has_value());
+    assert(limit.has_value());
     // Convert user_key into a corresponding internal key.
-    InternalKey k1(start, kMaxSequenceNumber, kValueTypeForSeek);
-    InternalKey k2(limit, kMaxSequenceNumber, kValueTypeForSeek);
+    InternalKey k1(start.value(), kMaxSequenceNumber, kValueTypeForSeek);
+    InternalKey k2(limit.value(), kMaxSequenceNumber, kValueTypeForSeek);
     sizes[i] = 0;
     if (options.include_files) {
       sizes[i] += versions_->ApproximateSize(

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -462,14 +462,11 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
   size_t ts_sz = ucmp->timestamp_size();
 
   Slice from_slice = from_key;
-  Slice end_slice = to_key;
-  std::string from_key_buf, end_key_buf;
-  auto [from, end] =
-      MaybeAddTimestampsToRange(from_slice.empty() ? nullptr : &from_slice,
-                                end_slice.empty() ? nullptr : &end_slice, ts_sz,
-                                &from_key_buf, &end_key_buf);
-  if (ts_sz > 0 && (has_from || has_to)) {
-  }
+  Slice to_slice = to_key;
+  std::string from_key_buf, to_key_buf;
+  auto [from, to] = MaybeAddTimestampsToRange(
+      has_from ? &from_slice : nullptr, has_to ? &to_slice : nullptr, ts_sz,
+      &from_key_buf, &to_key_buf);
   uint64_t i = 0;
   if (from.has_value()) {
     InternalKey ikey;
@@ -497,7 +494,7 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
     }
 
     // If end marker was specified, we stop before it
-    if (end.has_value() && ucmp->Compare(ikey.user_key, end.value()) >= 0) {
+    if (to.has_value() && ucmp->Compare(ikey.user_key, to.value()) >= 0) {
       break;
     }
 

--- a/unreleased_history/bug_fixes/sst_dump_for_udt.md
+++ b/unreleased_history/bug_fixes/sst_dump_for_udt.md
@@ -1,0 +1,1 @@
+Fix an issue in sst dump tool to handle bounds specified for data with user-defined timestamps.

--- a/util/udt_util.cc
+++ b/util/udt_util.cc
@@ -346,6 +346,7 @@ void GetFullHistoryTsLowFromU64CutoffTs(Slice* cutoff_ts,
                                         std::string* full_history_ts_low) {
   uint64_t cutoff_udt_ts = 0;
   [[maybe_unused]] bool format_res = GetFixed64(cutoff_ts, &cutoff_udt_ts);
+  assert(format_res);
   PutFixed64(full_history_ts_low, cutoff_udt_ts + 1);
 }
 
@@ -353,27 +354,31 @@ std::tuple<std::optional<Slice>, std::optional<Slice>>
 MaybeAddTimestampsToRange(const Slice* start, const Slice* end, size_t ts_sz,
                           std::string* start_with_ts, std::string* end_with_ts,
                           bool exclusive_end) {
-  std::optional<Slice> ret_start =
-      (start == nullptr) ? std::nullopt : std::optional<Slice>(*start);
-  std::optional<Slice> ret_end =
-      (end == nullptr) ? std::nullopt : std::optional<Slice>(*end);
-
-  if (start != nullptr && ts_sz != 0) {
-    // Maximum timestamp means including all keys with any timestamp for start
-    AppendKeyWithMaxTimestamp(start_with_ts, *start, ts_sz);
-    ret_start = Slice(*start_with_ts);
-  }
-  if (end != nullptr && ts_sz != 0) {
-    if (exclusive_end) {
-      // Append a maximum timestamp as the range limit is exclusive:
-      // [start, end)
-      AppendKeyWithMaxTimestamp(end_with_ts, *end, ts_sz);
+  std::optional<Slice> ret_start, ret_end;
+  if (start) {
+    if (ts_sz == 0) {
+      ret_start = *start;
     } else {
-      // Append a minimum timestamp to end so the range limit is inclusive:
-      // [start, end]
-      AppendKeyWithMinTimestamp(end_with_ts, *end, ts_sz);
+      // Maximum timestamp means including all keys with any timestamp for start
+      AppendKeyWithMaxTimestamp(start_with_ts, *start, ts_sz);
+      ret_start = Slice(*start_with_ts);
     }
-    ret_end = Slice(*end_with_ts);
+  }
+  if (end) {
+    if (ts_sz == 0) {
+      ret_end = *end;
+    } else {
+      if (exclusive_end) {
+        // Append a maximum timestamp as the range limit is exclusive:
+        // [start, end)
+        AppendKeyWithMaxTimestamp(end_with_ts, *end, ts_sz);
+      } else {
+        // Append a minimum timestamp to end so the range limit is inclusive:
+        // [start, end]
+        AppendKeyWithMinTimestamp(end_with_ts, *end, ts_sz);
+      }
+      ret_end = Slice(*end_with_ts);
+    }
   }
   return std::make_tuple(ret_start, ret_end);
 }

--- a/util/udt_util.h
+++ b/util/udt_util.h
@@ -254,4 +254,15 @@ Status ValidateUserDefinedTimestampsOptions(
 // the effective `full_history_ts_low`.
 void GetFullHistoryTsLowFromU64CutoffTs(Slice* cutoff_ts,
                                         std::string* full_history_ts_low);
+
+// `start` is the inclusive lower user key bound without user-defined timestamp.
+// `end` is the upper user key bound without user-defined timestamp.
+// By default, `end` is treated as being exclusive. If `exclusive_end` is set to
+// false, it's treated as an inclusive upper bound.
+// If any of these two bounds is nullptr, an empty std::optional<Slice> is
+// returned for that bound.
+std::tuple<std::optional<Slice>, std::optional<Slice>>
+MaybeAddTimestampsToRange(const Slice* start, const Slice* end, size_t ts_sz,
+                          std::string* start_with_ts, std::string* end_with_ts,
+                          bool exclusive_end = true);
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
For a SST file that uses user-defined timestamp aware comparators, if a lower or upper bound is set, sst_dump tool doesn't handle it well. This PR adds support for that. While working on this `MaybeAddTimestampsToRange` is moved to the udt_util.h file to be shared.

Test Plan:
make all check
for changes in db_impl.cc and db_impl_compaction_flush.cc

for changes in sst_file_dumper.cc, I manually tested this change handles specifying bounds for UDT use cases. It probably should have a unit test file eventually.