### PR TITLE
Fix seg fault in auto_readahead_size during IOError

### DIFF
--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -79,12 +79,19 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
     }
   }
 
-  if (read_options_.auto_readahead_size && read_options_.iterate_upper_bound) {
+  if (read_options_.auto_readahead_size && read_options_.iterate_upper_bound &&
+      is_first_pass) {
     FindReadAheadSizeUpperBound();
     if (target) {
       index_iter_->Seek(*target);
     } else {
       index_iter_->SeekToFirst();
+    }
+
+    // Check for IO error.
+    if (!index_iter_->Valid()) {
+      ResetDataIter();
+      return;
     }
   }
 


### PR DESCRIPTION
Summary: Fix seg fault in auto_readahead_size
```
db_stress:
internal_repo_rocksdb/repo/table/block_based/partitioned_index_iterator.h:70: virtual rocksdb::IndexValue rocksdb::PartitionedIndexIterator::value() const: Assertion `Valid()' failed.
```

During seek, after calculating readahead_size, db_stress can inject IOError resulting in failure to index_iter_->Seek and making index_iter_ invalid.

Test Plan: Reproducible locally when read_fault is increased and passed with this fix

Reviewers:

Subscribers:

Tasks:

Tags: