### PR TITLE
Fix `GenericRateLimiter` hanging bug

### DIFF
--- a/unreleased_history/bug_fixes/fixed_generic_rate_limiter_hang.md
+++ b/unreleased_history/bug_fixes/fixed_generic_rate_limiter_hang.md
@@ -1,0 +1,1 @@
+Fixed a race condition in `GenericRateLimiter` that could cause it to stop granting requests

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -179,16 +179,16 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
       // Whichever thread reaches here first performs duty (2) as described
       // above.
       RefillBytesAndGrantRequestsLocked();
-      if (r.request_bytes == 0) {
-        // If there is any remaining requests, make sure there exists at least
-        // one candidate is awake for future duties by signaling a front request
-        // of a queue.
-        for (int i = Env::IO_TOTAL - 1; i >= Env::IO_LOW; --i) {
-          std::deque<Req*> queue = queue_[i];
-          if (!queue.empty()) {
-            queue.front()->cv.Signal();
-            break;
-          }
+    }
+    if (r.request_bytes == 0) {
+      // If there is any remaining requests, make sure there exists at least
+      // one candidate is awake for future duties by signaling a front request
+      // of a queue.
+      for (int i = Env::IO_TOTAL - 1; i >= Env::IO_LOW; --i) {
+        std::deque<Req*> queue = queue_[i];
+        if (!queue.empty()) {
+          queue.front()->cv.Signal();
+          break;
         }
       }
     }

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -185,7 +185,7 @@ void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
       // one candidate is awake for future duties by signaling a front request
       // of a queue.
       for (int i = Env::IO_TOTAL - 1; i >= Env::IO_LOW; --i) {
-        std::deque<Req*> queue = queue_[i];
+        auto& queue = queue_[i];
         if (!queue.empty()) {
           queue.front()->cv.Signal();
           break;


### PR DESCRIPTION
Fixes #11742

Even after performing duty (1) ("Waiting for the next refill time"), it is possible the remaining threads are all in `Wait()`. Waking up at least one thread is enough to ensure progress continues, even if no new requests arrive.

The repro unit test (https://github.com/facebook/rocksdb/commit/bb54245e6) is not included as it depends on an unlanded PR (#11753)