### PR TITLE
Release compaction files in manifest write callback

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -844,7 +844,8 @@ Status CompactionJob::Run() {
   return status;
 }
 
-Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
+Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options,
+                              bool* compaction_released) {
   assert(compact_);
 
   AutoThreadOperationStageUpdater stage_updater(
@@ -860,7 +861,7 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
                                             compaction_stats_);
 
   if (status.ok()) {
-    status = InstallCompactionResults(mutable_cf_options);
+    status = InstallCompactionResults(mutable_cf_options, compaction_released);
   }
   if (!versions_->io_status().ok()) {
     io_status_ = versions_->io_status();
@@ -1697,7 +1698,7 @@ Status CompactionJob::FinishCompactionOutputFile(
 }
 
 Status CompactionJob::InstallCompactionResults(
-    const MutableCFOptions& mutable_cf_options) {
+    const MutableCFOptions& mutable_cf_options, bool* compaction_released) {
   assert(compact_);
 
   db_mutex_->AssertHeld();
@@ -1779,9 +1780,15 @@ Status CompactionJob::InstallCompactionResults(
     }
   }
 
-  return versions_->LogAndApply(compaction->column_family_data(),
-                                mutable_cf_options, read_options, edit,
-                                db_mutex_, db_directory_);
+  auto manifest_wcb = [&compaction, &compaction_released](Status s) {
+    compaction->ReleaseCompactionFiles(s);
+    *compaction_released = true;
+  };
+
+  return versions_->LogAndApply(
+      compaction->column_family_data(), mutable_cf_options, read_options, edit,
+      db_mutex_, db_directory_, /*new_descriptor_log=*/false,
+      /*column_family_options=*/nullptr, manifest_wcb);
 }
 
 void CompactionJob::RecordCompactionIOStats() {

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1780,7 +1780,7 @@ Status CompactionJob::InstallCompactionResults(
     }
   }
 
-  auto manifest_wcb = [&compaction, &compaction_released](Status s) {
+  auto manifest_wcb = [&compaction, &compaction_released](const Status& s) {
     compaction->ReleaseCompactionFiles(s);
     *compaction_released = true;
   };

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -186,7 +186,10 @@ class CompactionJob {
 
   // REQUIRED: mutex held
   // Add compaction input/output to the current version
-  Status Install(const MutableCFOptions& mutable_cf_options);
+  // Releases compaction file through Compaction::ReleaseCompactionFiles().
+  // Sets *compaction_released to true of compaction is released.
+  Status Install(const MutableCFOptions& mutable_cf_options,
+                 bool* compaction_released);
 
   // Return the IO status
   IOStatus io_status() const { return io_status_; }
@@ -273,7 +276,8 @@ class CompactionJob {
                                     const Slice& next_table_min_key,
                                     const Slice* comp_start_user_key,
                                     const Slice* comp_end_user_key);
-  Status InstallCompactionResults(const MutableCFOptions& mutable_cf_options);
+  Status InstallCompactionResults(const MutableCFOptions& mutable_cf_options,
+                                  bool* compaction_released);
   Status OpenCompactionOutputFile(SubcompactionState* sub_compact,
                                   CompactionOutputs& outputs);
   void UpdateCompactionJobStats(

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -187,7 +187,7 @@ class CompactionJob {
   // REQUIRED: mutex held
   // Add compaction input/output to the current version
   // Releases compaction file through Compaction::ReleaseCompactionFiles().
-  // Sets *compaction_released to true of compaction is released.
+  // Sets *compaction_released to true if compaction is released.
   Status Install(const MutableCFOptions& mutable_cf_options,
                  bool* compaction_released);
 

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -674,7 +674,9 @@ class CompactionJobTestBase : public testing::Test {
     ASSERT_OK(s);
     ASSERT_OK(compaction_job.io_status());
     mutex_.Lock();
-    ASSERT_OK(compaction_job.Install(*cfd->GetLatestMutableCFOptions()));
+    bool compaction_released = false;
+    ASSERT_OK(compaction_job.Install(*cfd->GetLatestMutableCFOptions(),
+                                     &compaction_released));
     ASSERT_OK(compaction_job.io_status());
     mutex_.Unlock();
     log_buffer.FlushBufferToLog();

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -10114,6 +10114,174 @@ TEST_F(DBCompactionTest, ErrorWhenReadFileHead) {
   }
 }
 
+TEST_F(DBCompactionTest, ReleaseCompactionDuringManifestWrite) {
+  // Tests the fix for issue #10257.
+  // Compactions are released in LogAndApply() so that picking a compaction
+  // from the new Version won't see these compactions as registered.
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleLevel;
+  // Make sure we can run multiple compactions at the same time.
+  env_->SetBackgroundThreads(3, Env::Priority::LOW);
+  env_->SetBackgroundThreads(3, Env::Priority::BOTTOM);
+  options.max_background_compactions = 3;
+  options.num_levels = 4;
+  DestroyAndReopen(options);
+  Random rnd(301);
+
+  // Construct the following LSM
+  // L1:           [K10-K11]
+  // L2:  [K1-K2]  [K10]          [k100-k101]
+  // L3: [K1]                     [k100]
+  // We will have 3 threads to run 3 manual compactions.
+  // T0 runs CompactRange(K100, K101)
+  // T1 runs CompactRange(K1, K2)
+  // T2 runs CompactRange(K10, K11)
+  // T1 and T2 will wait for T0 to write to MANIFEST and will be in
+  // same write group.
+  //
+  // A rough timeline of events:
+  // - T0 enters LogAndApply() to write compaction result to manifest
+  // - T0 unlocks mutex when writing to manifest
+  // - T1 starts compaction
+  // - T1 enters LogAndApply(), becomes leader of the next write group,
+  //   and waits for T0 to finish
+  // - T2 starts compaction
+  // - T2 enters LogAndApply(), joins T1's write group, wait for T1 to
+  // finish
+  // - Now T0 resumes, finishes compaction
+  // - T1, T2 groups commits their manifest writes, new version creation,
+  //   and finish compaction
+  //
+  // We check that when T1 and T2 finishes LogAndApply(), they are
+  // unregistered and that CompactionPicker::compactions_in_progress_ is
+  // empty.
+
+  ASSERT_OK(Put(Key(100), rnd.RandomString(20)));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(3);
+  ASSERT_OK(Put(Key(1), rnd.RandomString(20)));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(3);
+
+  ASSERT_OK(Put(Key(100), rnd.RandomString(20)));
+  ASSERT_OK(Put(Key(101), rnd.RandomString(20)));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(2);
+  ASSERT_OK(Put(Key(10), rnd.RandomString(20)));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(2);
+  ASSERT_OK(Put(Key(1), rnd.RandomString(20)));
+  ASSERT_OK(Put(Key(2), rnd.RandomString(20)));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(2);
+
+  ASSERT_OK(Put(Key(10), rnd.RandomString(20)));
+  ASSERT_OK(Put(Key(11), rnd.RandomString(20)));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(1);
+
+  ASSERT_EQ(NumTableFilesAtLevel(1), 1);
+  ASSERT_EQ(NumTableFilesAtLevel(2), 3);
+  ASSERT_EQ(NumTableFilesAtLevel(3), 2);
+
+  // Assign thread id to facilitate sync point dependencies.
+  std::atomic<int> cnt{0};
+  const auto get_thread_id = [&cnt]() {
+    thread_local int thread_id{cnt++};
+    return thread_id;
+  };
+
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::LogAndApply:WriteManifestStart", [&](void*) {
+        int thread_id = get_thread_id();
+        if (thread_id == 0) {
+          // T1 starts after this sync point and enters LogAndApply()
+          TEST_SYNC_POINT(
+              "ReleaseCompactionDuringManifestWrite::T0::WriteManifest:0");
+
+          // This sync point waits for T2 to enter LogAndApply()
+          TEST_SYNC_POINT(
+              "ReleaseCompactionDuringManifestWrite::T0::WriteManifest:1");
+        }
+      });
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::LogAndApply:BeforeWriterWaiting", [&](void*) {
+        int thread_id = get_thread_id();
+        if (thread_id == 1) {
+          // T2 starts after this sync point and joins group commit lead by
+          // T1
+          TEST_SYNC_POINT(
+              "ReleaseCompactionDuringManifestWrite::T1::"
+              "BeforeWriterWaiting::"
+              "0");
+        } else if (thread_id == 2) {
+          TEST_SYNC_POINT(
+              "ReleaseCompactionDuringManifestWrite::T2::"
+              "BeforeWriterWaiting::"
+              "0");
+          // Now T0 can continue
+        }
+      });
+
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"ReleaseCompactionDuringManifestWrite::T0::WriteManifest:0",
+        "ReleaseCompactionDuringManifestWrite::T1::Start"},
+       {"ReleaseCompactionDuringManifestWrite::T1::BeforeWriterWaiting::0",
+        "ReleaseCompactionDuringManifestWrite::T2::Start"},
+       {"ReleaseCompactionDuringManifestWrite::T2::BeforeWriterWaiting::0",
+        "ReleaseCompactionDuringManifestWrite::T0::WriteManifest:1"}});
+
+  // Verify that compactions are released after writing to MANIFEST
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::BackgroundCompaction:AfterCompaction", [&](void* ptr) {
+        int thread_id = get_thread_id();
+        if (thread_id != 0) {
+          ColumnFamilyData* cfd = (ColumnFamilyData*)(ptr);
+          ASSERT_TRUE(
+              cfd->compaction_picker()->compactions_in_progress()->empty());
+        }
+      });
+
+  SyncPoint::GetInstance()->EnableProcessing();
+  std::vector<std::thread> threads;
+  threads.emplace_back(std::thread([&]() {
+    // T1
+    std::string k1_str = Key(1);
+    std::string k2_str = Key(2);
+    Slice k1 = k1_str;
+    Slice k2 = k2_str;
+
+    // Should wait after T0 write manifest
+    TEST_SYNC_POINT("ReleaseCompactionDuringManifestWrite::T1::Start");
+    ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &k1, &k2));
+  }));
+  threads.emplace_back(std::thread([&]() {
+    // T2
+    std::string k10_str = Key(10);
+    std::string k11_str = Key(11);
+    Slice k10 = k10_str;
+    Slice k11 = k11_str;
+    TEST_SYNC_POINT("ReleaseCompactionDuringManifestWrite::T2::Start");
+    ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &k10, &k11));
+  }));
+
+  // T0
+  std::string k100_str = Key(100);
+  std::string k101_str = Key(101);
+  Slice k100 = k100_str;
+  Slice k101 = k101_str;
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &k100, &k101));
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3492,7 +3492,6 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
           ++unscheduled_compactions_;
 
           c.reset();
-          assert(c == nullptr);
           // Don't need to sleep here, because BackgroundCallCompaction
           // will sleep if !s.ok()
           status = Status::CompactionTooLarge();
@@ -3758,7 +3757,6 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
 #endif
     }
 
-    // TODO: add some debug checking that compaction is indeed released
     *made_progress = true;
 
     // Need to make sure SstFileManager does its bookkeeping

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3552,7 +3552,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
         c->column_family_data(), *c->mutable_cf_options(), read_options,
         c->edit(), &mutex_, directories_.GetDbDir(),
         /*new_descriptor_log=*/false, /*column_family_options=*/nullptr,
-        [&c, &compaction_released](Status s) {
+        [&c, &compaction_released](const Status& s) {
           c->ReleaseCompactionFiles(s);
           compaction_released = true;
         });
@@ -3623,7 +3623,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
         c->column_family_data(), *c->mutable_cf_options(), read_options,
         c->edit(), &mutex_, directories_.GetDbDir(),
         /*new_descriptor_log=*/false, /*column_family_options=*/nullptr,
-        [&c, &compaction_released](Status s) {
+        [&c, &compaction_released](const Status& s) {
           c->ReleaseCompactionFiles(s);
           compaction_released = true;
         });

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1512,7 +1512,12 @@ Status DBImpl::CompactFilesImpl(
   TEST_SYNC_POINT("CompactFilesImpl:3");
   mutex_.Lock();
 
-  Status status = compaction_job.Install(*c->mutable_cf_options());
+  bool compaction_released = false;
+  Status status =
+      compaction_job.Install(*c->mutable_cf_options(), &compaction_released);
+  if (!compaction_released) {
+    c->ReleaseCompactionFiles(s);
+  }
   if (status.ok()) {
     assert(compaction_job.io_status().ok());
     InstallSuperVersionAndScheduleWork(c->column_family_data(),
@@ -1523,7 +1528,6 @@ Status DBImpl::CompactFilesImpl(
   // not check compaction_job.io_status() explicitly if we're not calling
   // SetBGError
   compaction_job.io_status().PermitUncheckedError();
-  c->ReleaseCompactionFiles(s);
   // Need to make sure SstFileManager does its bookkeeping
   auto sfm = static_cast<SstFileManagerImpl*>(
       immutable_db_options_.sst_file_manager.get());
@@ -3388,8 +3392,6 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
 
   std::unique_ptr<TaskLimiterToken> task_token;
 
-  // InternalKey manual_end_storage;
-  // InternalKey* manual_end = &manual_end_storage;
   bool sfm_reserved_compact_space = false;
   if (is_manual) {
     ManualCompactionState* m = manual_compaction;
@@ -3490,6 +3492,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
           ++unscheduled_compactions_;
 
           c.reset();
+          assert(c == nullptr);
           // Don't need to sleep here, because BackgroundCallCompaction
           // will sleep if !s.ok()
           status = Status::CompactionTooLarge();
@@ -3525,6 +3528,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
   }
 
   IOStatus io_s;
+  bool compaction_released = false;
   if (!c) {
     // Nothing to do
     ROCKS_LOG_BUFFER(log_buffer, "Compaction nothing to do");
@@ -3547,7 +3551,12 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     }
     status = versions_->LogAndApply(
         c->column_family_data(), *c->mutable_cf_options(), read_options,
-        c->edit(), &mutex_, directories_.GetDbDir());
+        c->edit(), &mutex_, directories_.GetDbDir(),
+        /*new_descriptor_log=*/false, /*column_family_options=*/nullptr,
+        [&c, &compaction_released](Status s) {
+          c->ReleaseCompactionFiles(s);
+          compaction_released = true;
+        });
     io_s = versions_->io_status();
     InstallSuperVersionAndScheduleWork(c->column_family_data(),
                                        &job_context->superversion_contexts[0],
@@ -3613,7 +3622,12 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     }
     status = versions_->LogAndApply(
         c->column_family_data(), *c->mutable_cf_options(), read_options,
-        c->edit(), &mutex_, directories_.GetDbDir());
+        c->edit(), &mutex_, directories_.GetDbDir(),
+        /*new_descriptor_log=*/false, /*column_family_options=*/nullptr,
+        [&c, &compaction_released](Status s) {
+          c->ReleaseCompactionFiles(s);
+          compaction_released = true;
+        });
     io_s = versions_->io_status();
     // Use latest MutableCFOptions
     InstallSuperVersionAndScheduleWork(c->column_family_data(),
@@ -3663,6 +3677,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     // Transfer requested token, so it doesn't need to do it again.
     ca->prepicked_compaction->task_token = std::move(task_token);
     ++bg_bottom_compaction_scheduled_;
+    assert(c == nullptr);
     env_->Schedule(&DBImpl::BGWorkBottomCompaction, ca, Env::Priority::BOTTOM,
                    this, &DBImpl::UnscheduleCompactionCallback);
   } else {
@@ -3706,8 +3721,8 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     compaction_job.Run().PermitUncheckedError();
     TEST_SYNC_POINT("DBImpl::BackgroundCompaction:NonTrivial:AfterRun");
     mutex_.Lock();
-
-    status = compaction_job.Install(*c->mutable_cf_options());
+    status =
+        compaction_job.Install(*c->mutable_cf_options(), &compaction_released);
     io_s = compaction_job.io_status();
     if (status.ok()) {
       InstallSuperVersionAndScheduleWork(c->column_family_data(),
@@ -3726,7 +3741,24 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
   }
 
   if (c != nullptr) {
-    c->ReleaseCompactionFiles(status);
+    if (!compaction_released) {
+      c->ReleaseCompactionFiles(status);
+    } else {
+#ifndef NDEBUG
+      // Sanity checking that compaction files are freed.
+      for (size_t i = 0; i < c->num_input_levels(); i++) {
+        for (size_t j = 0; j < c->inputs(i)->size(); j++) {
+          assert(!c->input(i, j)->being_compacted);
+        }
+      }
+      std::unordered_set<Compaction*>* cip = c->column_family_data()
+                                                 ->compaction_picker()
+                                                 ->compactions_in_progress();
+      assert(cip->find(c.get()) == cip->end());
+#endif
+    }
+
+    // TODO: add some debug checking that compaction is indeed released
     *made_progress = true;
 
     // Need to make sure SstFileManager does its bookkeeping

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1174,7 +1174,8 @@ class VersionSet {
       const MutableCFOptions& mutable_cf_options,
       const ReadOptions& read_options, VersionEdit* edit, InstrumentedMutex* mu,
       FSDirectory* dir_contains_current_file, bool new_descriptor_log = false,
-      const ColumnFamilyOptions* column_family_options = nullptr) {
+      const ColumnFamilyOptions* column_family_options = nullptr,
+      const std::function<void(const Status&)>& manifest_wcb = {}) {
     autovector<ColumnFamilyData*> cfds;
     cfds.emplace_back(column_family_data);
     autovector<const MutableCFOptions*> mutable_cf_options_list;
@@ -1185,7 +1186,7 @@ class VersionSet {
     edit_lists.emplace_back(edit_list);
     return LogAndApply(cfds, mutable_cf_options_list, read_options, edit_lists,
                        mu, dir_contains_current_file, new_descriptor_log,
-                       column_family_options);
+                       column_family_options, {manifest_wcb});
   }
   // The batch version. If edit_list.size() > 1, caller must ensure that
   // no edit in the list column family add or drop

--- a/unreleased_history/bug_fixes/no_compaction_scheduled_bug.md
+++ b/unreleased_history/bug_fixes/no_compaction_scheduled_bug.md
@@ -1,1 +1,1 @@
-* Fix a bug (Issue #10257) where DB can hang after write stall since no compaction is scheduled.
+* Fix a bug (Issue #10257) where DB can hang after write stall since no compaction is scheduled (#11764).

--- a/unreleased_history/bug_fixes/no_compaction_scheduled_bug.md
+++ b/unreleased_history/bug_fixes/no_compaction_scheduled_bug.md
@@ -1,0 +1,1 @@
+* Fix a bug (Issue #10257) where DB can hang after write stall since no compaction is scheduled.


### PR DESCRIPTION
Fixes #10257 (also see [here](https://github.com/facebook/rocksdb/pull/10355#issuecomment-1684308556)) by releasing compaction files earlier when writing to manifest in LogAndApply().  This is done by passing in a [callback](https://github.com/facebook/rocksdb/blob/ba597514309b686d8addb59616f067d5522186b7/db/version_set.h#L1199) to LogAndApply(). The new Version is created in the same critical section where compaction files are released. When compaction picker is picking compaction based on the new version, these compaction files will already be released. 

Test plan:
* Existing unit tests 
* A repro unit test to validate that compaction files are released: `./db_compaction_test --gtest_filter=DBCompactionTest.ReleaseCompactionDuringManifestWrite`
* `python3 ./tools/db_crashtest.py --simple whitebox` with some assertions to check compaction files are released