### PR TITLE
Fix seg fault in auto_readahead_size with async_io

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -829,14 +829,12 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   num_file_reads_ = 0;
   explicit_prefetch_submitted_ = false;
   bool is_eligible_for_prefetching = false;
+
+  UpdateReadAheadSizeForUpperBound(offset, n);
   if (readahead_size_ > 0 &&
       (!implicit_auto_readahead_ ||
        num_file_reads_ >= num_file_reads_for_auto_readahead_)) {
-    UpdateReadAheadSizeForUpperBound(offset, n);
-    // After trim, readahead size can be 0.
-    if (readahead_size_ > 0) {
       is_eligible_for_prefetching = true;
-    }
   }
 
   // 1. Cancel any pending async read to make code simpler as buffers can be out

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -389,6 +389,12 @@ class FilePrefetchBuffer {
          bufs_[second].offset_)) {
       return false;
     }
+
+    // Readahead size can be 0 because of trimming.
+    if (readahead_size_ == 0) {
+      return false;
+    }
+
     bufs_[second].buffer_.Clear();
     return true;
   }


### PR DESCRIPTION
Summary: Fix seg fault in auto_readahead_size with async_io when readahead_size = 0. If readahead_size is trimmed and is 0, it's not eligible for further prefetching and should return.

Error occured when the first buffer already contains data and it goes for prefetching in second buffer leading to assertion failure -

`assert(roundup_len1 >= alignment);
`
because roundup_len1 = length + readahead_size.
length is 0 and readahead_size is also 0.

Test Plan: Reproducible with db_stress with async_io enabled.

Reviewers:

Subscribers:

Tasks:

Tags: