### PR TITLE
PrefixSeek: ignore prefix_same_as_start when enable total_order_seek

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -64,9 +64,9 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       valid_(false),
       current_entry_is_merged_(false),
       is_key_seqnum_zero_(false),
-      prefix_same_as_start_(mutable_cf_options.prefix_extractor
-                                ? read_options.prefix_same_as_start
-                                : false),
+      prefix_same_as_start_(!read_options.total_order_seek &&
+                            mutable_cf_options.prefix_extractor &&
+                            read_options.prefix_same_as_start),
       pin_thru_lifetime_(read_options.pin_data),
       expect_total_order_inner_iter_(prefix_extractor_ == nullptr ||
                                      read_options.total_order_seek ||


### PR DESCRIPTION
The following is a comment on the "prefix_same_as_start" configuration item found in the source code, which explicitly informs you to enable “total_order_seek”, It is invalid during seek, but in practical use, it was found that this parameter was not ignored.
```
 // Enforce that the iterator only iterates over the same prefix as the seek.
  // This option is effective only for prefix seeks, i.e. prefix_extractor is
  // non-null for the column family and total_order_seek is false.  Unlike
  // iterate_upper_bound, prefix_same_as_start only works within a prefix
  // but in both directions.
  // Default: false
  bool prefix_same_as_start;
```
In some scenarios, although we have set up PrefixExtractor, some keys are not within the Domain . When performing these queries with TotalOrderSeek, "prefix_same_as_start" will still take effect, and it will cause the program to abort due to SeekKey or LowerBound/UpperBound not being within the Domain, so abort when extract prefix.
