### PR TITLE
feat(java): add RocksDB#GetFileChecksumsFromManifest to Java API

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -303,6 +303,7 @@ set(JAVA_MAIN_CLASSES
   src/test/java/org/rocksdb/RocksNativeLibraryResource.java
   src/test/java/org/rocksdb/util/CapturingWriteBatchHandler.java
   src/test/java/org/rocksdb/util/WriteBatchGetter.java
+  src/main/java/org/rocksdb/FileChecksum.java
 )
 
 set(JAVA_TEST_CLASSES

--- a/java/src/main/java/org/rocksdb/FileChecksum.java
+++ b/java/src/main/java/org/rocksdb/FileChecksum.java
@@ -5,6 +5,7 @@ public class FileChecksum {
   private final byte[] checksum;
   private final String checksumFuncName;
 
+  @SuppressWarnings("PMD.ArrayIsStoredDirectly")
   public FileChecksum(int fileNumber, byte[] checksum, String checksumFuncName) {
     this.fileNumber = fileNumber;
     this.checksum = checksum;
@@ -15,6 +16,7 @@ public class FileChecksum {
     return fileNumber;
   }
 
+  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public byte[] getChecksum() {
     return checksum;
   }

--- a/java/src/main/java/org/rocksdb/FileChecksum.java
+++ b/java/src/main/java/org/rocksdb/FileChecksum.java
@@ -1,0 +1,25 @@
+package org.rocksdb;
+
+public class FileChecksum {
+  private final int fileNumber;
+  private final byte[] checksum;
+  private final String checksumFuncName;
+
+  public FileChecksum(int fileNumber, byte[] checksum, String checksumFuncName) {
+    this.fileNumber = fileNumber;
+    this.checksum = checksum;
+    this.checksumFuncName = checksumFuncName;
+  }
+
+  public int getFileNumber() {
+    return fileNumber;
+  }
+
+  public byte[] getChecksum() {
+    return checksum;
+  }
+
+  public String getChecksumFuncName() {
+    return checksumFuncName;
+  }
+}

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -4747,6 +4747,11 @@ public class RocksDB extends RocksObject {
     destroyDB(path, options.nativeHandle_);
   }
 
+  public static FileChecksum[] getFileChecksumsFromManifest(
+      final Env env, final String path, final long manifestFileSize) throws RocksDBException {
+    return getFileChecksumsFromManifest(env.nativeHandle_, path, manifestFileSize);
+  }
+
   private /* @Nullable */ long[] toNativeHandleList(
       /* @Nullable */ final List<? extends RocksObject> objectList) {
     if (objectList == null) {
@@ -5111,6 +5116,9 @@ public class RocksDB extends RocksObject {
       throws RocksDBException;
 
   private static native int version();
+
+  private static native FileChecksum[] getFileChecksumsFromManifest(
+      final long handle, final String path, final long manifestFileSize) throws RocksDBException;
 
   protected DBOptionsInterface<?> options_;
   private static Version version;


### PR DESCRIPTION
> **Warning**
> This PR overlaps with #11736, specifically in adding a new class to represent the file number, checksum, and function name triple returned by the `FileChecksumList`.

Adds a mapping of the native `rocksdb#GetFileChecksumsFromManifest` call to the Java API. This is done via a static method in `RocksDB#getFileChecksumsFromManifest` which maps the returned array to one of `FileChecksum` instances.

The checksum is passed as a byte array to avoid erroneously decoding it as a string, but everything else is passed as is.

This allows users to read the file checksum and verify the integrity of the SST files independently without opening the DB, which is a great help when dealing with large DBs.

> **Note**
> It would be great if we could verify that the checksum is correct. When I took a look at #11736, unfortunately it seemed like returning the checksum as a Java string ended up erroneously encoding the raw bytes, resulting in wrong values (on the Java side). That would've been easily fixed with a test to verify it. Unfortunately, CRC32C is only baked into the standard library since Java 9, and I didn't feel confident to include an additional dependency just for that.

**Context**

To give some context, we replicate RocksDB checkpoints to other nodes. Part of this is verifying the integrity of each file during replication. With a large enough RocksDB, computing the checksum ourselves is prohibitively expensive. Since SST files comprise the bulk of the data, we'd much rather delegate this to RocksDB on file write, and read it back after to compare.
