### PR TITLE
Increase full_history_ts_low when flush happens during recovery

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1693,7 +1693,8 @@ Status DBImpl::GetFullHistoryTsLow(ColumnFamilyHandle* column_family,
   }
   InstrumentedMutexLock l(&mutex_);
   *ts_low = cfd->GetFullHistoryTsLow();
-  assert(cfd->user_comparator()->timestamp_size() == ts_low->size());
+  assert(ts_low->empty() ||
+         cfd->user_comparator()->timestamp_size() == ts_low->size());
   return Status::OK();
 }
 

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1735,7 +1735,6 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
         std::string new_full_history_ts_low;
         GetFullHistoryTsLowFromU64CutoffTs(&mem_newest_udt,
                                            &new_full_history_ts_low);
-        edit->SetColumnFamily(cfd->GetID());
         edit->SetFullHistoryTsLow(new_full_history_ts_low);
       }
     }

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1722,6 +1722,23 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
     for (const auto& blob : blob_file_additions) {
       edit->AddBlobFile(blob);
     }
+
+    // For UDT in memtable only feature, move up the cutoff timestamp whenever
+    // a flush happens.
+    const Comparator* ucmp = cfd->user_comparator();
+    size_t ts_sz = ucmp->timestamp_size();
+    if (ts_sz > 0 && !cfd->ioptions()->persist_user_defined_timestamps) {
+      Slice mem_newest_udt = mem->GetNewestUDT();
+      std::string full_history_ts_low = cfd->GetFullHistoryTsLow();
+      if (full_history_ts_low.empty() ||
+          ucmp->CompareTimestamp(mem_newest_udt, full_history_ts_low) >= 0) {
+        std::string new_full_history_ts_low;
+        GetFullHistoryTsLowFromU64CutoffTs(&mem_newest_udt,
+                                           &new_full_history_ts_low);
+        edit->SetColumnFamily(cfd->GetID());
+        edit->SetFullHistoryTsLow(new_full_history_ts_low);
+      }
+    }
   }
 
   InternalStats::CompactionStats stats(CompactionReason::kFlush, 1);

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -1147,16 +1147,13 @@ Status FlushJob::MaybeIncreaseFullHistoryTsLowToAboveCutoffUDT() {
        ucmp->CompareTimestamp(cutoff_udt_, full_history_ts_low) < 0)) {
     return Status::OK();
   }
-  Slice cutoff_udt_slice = cutoff_udt_;
-  uint64_t cutoff_udt_ts = 0;
-  bool format_res = GetFixed64(&cutoff_udt_slice, &cutoff_udt_ts);
-  assert(format_res);
-  (void)format_res;
   std::string new_full_history_ts_low;
+  Slice cutoff_udt_slice = cutoff_udt_;
   // TODO(yuzhangyu): Add a member to AdvancedColumnFamilyOptions for an
   //  operation to get the next immediately larger user-defined timestamp to
   //  expand this feature to other user-defined timestamp formats.
-  PutFixed64(&new_full_history_ts_low, cutoff_udt_ts + 1);
+  GetFullHistoryTsLowFromU64CutoffTs(&cutoff_udt_slice,
+                                     &new_full_history_ts_low);
   VersionEdit edit;
   edit.SetColumnFamily(cfd_->GetID());
   edit.SetFullHistoryTsLow(new_full_history_ts_low);

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1190,7 +1190,9 @@ struct AdvancedColumnFamilyOptions {
   // persisted to WAL even if this flag is set to `false`. The benefit of this
   // is that user-defined timestamps can be recovered with the caveat that users
   // should flush all memtables so there is no active WAL files before doing a
-  // downgrade.
+  // downgrade. In order to use WAL to recover user-defined timestamps, users of
+  // this feature would want to set both `avoid_flush_during_shutdown` and
+  // `avoid_flush_during_recovery` to be true.
   //
   // Note that setting this flag to false is not supported in combination with
   // atomic flush, or concurrent memtable write enabled by

--- a/util/udt_util.cc
+++ b/util/udt_util.cc
@@ -345,9 +345,7 @@ Status ValidateUserDefinedTimestampsOptions(
 void GetFullHistoryTsLowFromU64CutoffTs(Slice* cutoff_ts,
                                         std::string* full_history_ts_low) {
   uint64_t cutoff_udt_ts = 0;
-  bool format_res = GetFixed64(cutoff_ts, &cutoff_udt_ts);
-  assert(format_res);
-  (void)format_res;
+  [[maybe_unused]] bool format_res = GetFixed64(cutoff_ts, &cutoff_udt_ts);
   PutFixed64(full_history_ts_low, cutoff_udt_ts + 1);
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/udt_util.cc
+++ b/util/udt_util.cc
@@ -8,6 +8,7 @@
 
 #include "db/dbformat.h"
 #include "rocksdb/types.h"
+#include "util/coding.h"
 #include "util/write_batch_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -339,5 +340,14 @@ Status ValidateUserDefinedTimestampsOptions(
   }
   return Status::InvalidArgument(
       "Unsupported user defined timestamps settings change.");
+}
+
+void GetFullHistoryTsLowFromU64CutoffTs(Slice* cutoff_ts,
+                                        std::string* full_history_ts_low) {
+  uint64_t cutoff_udt_ts = 0;
+  bool format_res = GetFixed64(cutoff_ts, &cutoff_udt_ts);
+  assert(format_res);
+  (void)format_res;
+  PutFixed64(full_history_ts_low, cutoff_udt_ts + 1);
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/udt_util.h
+++ b/util/udt_util.h
@@ -246,4 +246,12 @@ Status ValidateUserDefinedTimestampsOptions(
     const Comparator* new_comparator, const std::string& old_comparator_name,
     bool new_persist_udt, bool old_persist_udt,
     bool* mark_sst_files_has_no_udt);
+
+// Given a cutoff user-defined timestamp formatted as uint64_t, get the
+// effective `full_history_ts_low` timestamp, which is the next immediately
+// bigger timestamp. Used by the UDT in memtable only feature when flushing
+// memtables and remove timestamps. This process collapses history and increase
+// the effective `full_history_ts_low`.
+void GetFullHistoryTsLowFromU64CutoffTs(Slice* cutoff_ts,
+                                        std::string* full_history_ts_low);
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/udt_util_test.cc
+++ b/util/udt_util_test.cc
@@ -438,6 +438,20 @@ TEST(ValidateUserDefinedTimestampsOptionsTest, InvalidUserComparatorChange) {
                   &mark_sst_files)
                   .IsInvalidArgument());
 }
+
+TEST(GetFullHistoryTsLowFromU64CutoffTsTest, Success) {
+  std::string cutoff_ts;
+  uint64_t cutoff_ts_int = 3;
+  PutFixed64(&cutoff_ts, 3);
+  Slice cutoff_ts_slice = cutoff_ts;
+  std::string actual_full_history_ts_low;
+  GetFullHistoryTsLowFromU64CutoffTs(&cutoff_ts_slice,
+                                     &actual_full_history_ts_low);
+
+  std::string expected_ts_low;
+  PutFixed64(&expected_ts_low, cutoff_ts_int + 1);
+  ASSERT_EQ(expected_ts_low, actual_full_history_ts_low);
+}
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This PR adds a missing piece for the UDT in memtable only feature, which is to automatically increase `full_history_ts_low` when flush happens during recovery. 

Test Plan:
Added unit test
make all check