### PR TITLE
Update upper_bound_offset when reseek changes iterate_upper_bound dynamically

### DIFF
--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -279,6 +279,11 @@ class FilePrefetchBuffer {
   // Callback function passed to underlying FS in case of asynchronous reads.
   void PrefetchAsyncCallback(const FSReadRequest& req, void* cb_arg);
 
+  void ResetUpperBoundOffset(uint64_t upper_bound_offset) {
+    upper_bound_offset_ = upper_bound_offset;
+    readahead_size_ = initial_auto_readahead_size_;
+  }
+
  private:
   // Calculates roundoff offset and length to be prefetched based on alignment
   // and data present in buffer_. It also allocates new buffer or refit tail if
@@ -321,7 +326,6 @@ class FilePrefetchBuffer {
   void ResetValues() {
     num_file_reads_ = 1;
     readahead_size_ = initial_auto_readahead_size_;
-    upper_bound_offset_ = 0;
   }
 
   // Called in case of implicit auto prefetching.

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -55,6 +55,11 @@ class BlockPrefetcher {
 
   void SetUpperBoundOffset(uint64_t upper_bound_offset) {
     upper_bound_offset_ = upper_bound_offset;
+    if (prefetch_buffer() != nullptr) {
+      // Upper bound can be changed on reseek. So update that in
+      // FilePrefetchBuffer.
+      prefetch_buffer()->ResetUpperBoundOffset(upper_bound_offset);
+    }
   }
 
  private:

--- a/unreleased_history/bug_fixes/upper_bound_autoreadahead.md
+++ b/unreleased_history/bug_fixes/upper_bound_autoreadahead.md
@@ -1,0 +1,1 @@
+* When auto_readahead_size is enabled, update readahead upper bound during readahead trimming when reseek changes iterate_upper_bound dynamically. 


### PR DESCRIPTION
Summary: Update the logic in FilePrefetchBuffer to update `upper_bound_offset_` during reseek. During Reseek, `iterate_upper_bound` can be changed dynamically. So added an API to update that in FilePrefetchBuffer. 
Added unit test to confirm the behavior.

Test Plan: - Check stress tests in case there is any failure after this diff.
- make crash_test -j32 with auto_readahead_size=1 passed locally

Reviewers:

Subscribers:

Tasks:

Tags: