### PR TITLE
Minor refactor on LDB command for wide column support and release note

### DIFF
--- a/db/wide/wide_columns_helper.cc
+++ b/db/wide/wide_columns_helper.cc
@@ -23,12 +23,12 @@ void WideColumnsHelper::DumpWideColumns(const WideColumns& columns,
   }
 }
 Status WideColumnsHelper::DumpSliceAsWideColumns(const Slice& value,
-                                                 std::ostream& oss, bool hex) {
+                                                 std::ostream& os, bool hex) {
   WideColumns columns;
   Slice value_copy = value;
   const Status s = WideColumnSerialization::Deserialize(value_copy, columns);
   if (s.ok()) {
-    DumpWideColumns(columns, oss, hex);
+    DumpWideColumns(columns, os, hex);
   }
   return s;
 }

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -226,6 +226,12 @@ class LDBCommand {
   static std::string PrintKeyValue(const std::string& key,
                                    const std::string& value, bool is_hex);
 
+  static std::string PrintKeyValueOrWideColumns(const Slice& key,
+                                                const Slice& value,
+                                                const WideColumns& wide_columns,
+                                                bool is_key_hex,
+                                                bool is_value_hex);
+
   /**
    * Return true if the specified flag is present in the specified flags vector
    */
@@ -313,4 +319,3 @@ class LDBCommandRunner {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -3084,6 +3084,8 @@ void ScanCommand::DoCommand() {
       std::string key_str = it->key().ToString();
       if (is_key_hex_) {
         key_str = StringToHex(key_str);
+      } else if (ldb_options_.key_formatter) {
+        key_str = ldb_options_.key_formatter->Format(key_str);
       }
       fprintf(stdout, "%s\n", key_str.c_str());
     } else {

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1082,6 +1082,29 @@ std::string LDBCommand::PrintKeyValue(const std::string& key,
   return PrintKeyValue(key, value, is_hex, is_hex);
 }
 
+std::string LDBCommand::PrintKeyValueOrWideColumns(
+    const Slice& key, const Slice& value, const WideColumns& wide_columns,
+    bool is_key_hex, bool is_value_hex) {
+  if (wide_columns.empty() ||
+      (wide_columns.size() == 1 &&
+       wide_columns.front().name() == kDefaultWideColumnName)) {
+    return PrintKeyValue(key.ToString(), value.ToString(), is_key_hex,
+                         is_value_hex);
+  }
+  /*
+  // Sample plaintext output (first column is kDefaultWideColumnName)
+  key_1 ==> :foo attr_name1:bar attr_name2:baz
+
+  // Sample hex output (first column is kDefaultWideColumnName)
+  0x6669727374 ==> :0x68656C6C6F 0x617474725F6E616D6531:0x666F6F
+  */
+  std::ostringstream oss;
+  WideColumnsHelper::DumpWideColumns(wide_columns, oss, is_value_hex);
+  return PrintKeyValue(key.ToString(), oss.str().c_str(), is_key_hex,
+                       false);  // is_value_hex_ is already honored in oss.
+                                // avoid double-hexing it.
+}
+
 std::string LDBCommand::HelpRangeCmdArgs() {
   std::ostringstream str_stream;
   str_stream << " ";
@@ -2200,30 +2223,14 @@ void DBDumperCommand::DoDumpCommand() {
         fprintf(stdout, "%s ", TimeToHumanString(rawtime).c_str());
       }
       // (TODO) TTL Iterator does not support wide columns yet.
-      if (is_db_ttl_ || iter->columns().empty() ||
-          (iter->columns().size() == 1 &&
-           iter->columns().front().name() == kDefaultWideColumnName)) {
-        std::string str =
-            PrintKeyValue(iter->key().ToString(), iter->value().ToString(),
-                          is_key_hex_, is_value_hex_);
-        fprintf(stdout, "%s\n", str.c_str());
-      } else {
-        /*
-        // Sample plaintext output (first column is kDefaultWideColumnName)
-        key_1 ==> :foo attr_name1:bar attr_name2:baz
-
-        // Sample hex output (first column is kDefaultWideColumnName)
-        0x6669727374 ==> :0x68656C6C6F 0x617474725F6E616D6531:0x666F6F
-        */
-
-        std::ostringstream oss;
-        WideColumnsHelper::DumpWideColumns(iter->columns(), oss, is_value_hex_);
-        std::string str = PrintKeyValue(
-            iter->key().ToString(), oss.str().c_str(), is_key_hex_,
-            false);  // is_value_hex_ is already honored in oss. avoid
-                     // double-hexing it.
-        fprintf(stdout, "%s\n", str.c_str());
-      }
+      std::string str =
+          is_db_ttl_
+              ? PrintKeyValue(iter->key().ToString(), iter->value().ToString(),
+                              is_key_hex_, is_value_hex_)
+              : PrintKeyValueOrWideColumns(iter->key(), iter->value(),
+                                           iter->columns(), is_key_hex_,
+                                           is_value_hex_);
+      fprintf(stdout, "%s\n", str.c_str());
     }
   }
 
@@ -3073,47 +3080,20 @@ void ScanCommand::DoCommand() {
       }
     }
 
-    Slice key_slice = it->key();
-
-    std::string formatted_key;
-    if (is_key_hex_) {
-      formatted_key = "0x" + key_slice.ToString(true /* hex */);
-      key_slice = formatted_key;
-    } else if (ldb_options_.key_formatter) {
-      formatted_key = ldb_options_.key_formatter->Format(key_slice);
-      key_slice = formatted_key;
-    }
-
     if (no_value_) {
-      fprintf(stdout, "%.*s\n", static_cast<int>(key_slice.size()),
-              key_slice.data());
-      // (TODO) TTL Iterator does not support wide columns yet.
-    } else if (is_db_ttl_ || it->columns().empty() ||
-               (it->columns().size() == 1 &&
-                it->columns().front().name() == kDefaultWideColumnName)) {
-      Slice val_slice = it->value();
-      std::string formatted_value;
-      if (is_value_hex_) {
-        formatted_value = "0x" + val_slice.ToString(true /* hex */);
-        val_slice = formatted_value;
+      std::string key_str = it->key().ToString();
+      if (is_key_hex_) {
+        key_str = StringToHex(key_str);
       }
-      fprintf(stdout, "%.*s : %.*s\n", static_cast<int>(key_slice.size()),
-              key_slice.data(), static_cast<int>(val_slice.size()),
-              val_slice.data());
+      fprintf(stdout, "%s\n", key_str.c_str());
     } else {
-      /*
-      // Sample plaintext output (first column is kDefaultWideColumnName)
-      key_1 : :foo attr_name1:bar attr_name2:baz
-
-      // Sample hex output (first column is kDefaultWideColumnName)
-      0x6669727374 : :0x68656C6C6F 0x617474725F6E616D6531:0x666F6F
-      */
-
-      std::ostringstream oss;
-      WideColumnsHelper::DumpWideColumns(it->columns(), oss, is_value_hex_);
-      fprintf(stdout, "%.*s : %.*s\n", static_cast<int>(key_slice.size()),
-              key_slice.data(), static_cast<int>(oss.str().length()),
-              oss.str().c_str());
+      std::string str = is_db_ttl_ ? PrintKeyValue(it->key().ToString(),
+                                                   it->value().ToString(),
+                                                   is_key_hex_, is_value_hex_)
+                                   : PrintKeyValueOrWideColumns(
+                                         it->key(), it->value(), it->columns(),
+                                         is_key_hex_, is_value_hex_);
+      fprintf(stdout, "%s\n", str.c_str());
     }
 
     num_keys_scanned++;

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -121,32 +121,32 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunOK("get x2", "y2")
         self.assertRunFAIL("get x3")
 
-        self.assertRunOK("scan --from=x1 --to=z", "x1 : y1\nx2 : y2")
+        self.assertRunOK("scan --from=x1 --to=z", "x1 ==> y1\nx2 ==> y2")
         self.assertRunOK("put x3 y3", "OK")
 
-        self.assertRunOK("scan --from=x1 --to=z", "x1 : y1\nx2 : y2\nx3 : y3")
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3")
-        self.assertRunOK("scan --from=x", "x1 : y1\nx2 : y2\nx3 : y3")
+        self.assertRunOK("scan --from=x1 --to=z", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3")
+        self.assertRunOK("scan --from=x", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3")
 
-        self.assertRunOK("scan --to=x2", "x1 : y1")
-        self.assertRunOK("scan --from=x1 --to=z --max_keys=1", "x1 : y1")
-        self.assertRunOK("scan --from=x1 --to=z --max_keys=2", "x1 : y1\nx2 : y2")
+        self.assertRunOK("scan --to=x2", "x1 ==> y1")
+        self.assertRunOK("scan --from=x1 --to=z --max_keys=1", "x1 ==> y1")
+        self.assertRunOK("scan --from=x1 --to=z --max_keys=2", "x1 ==> y1\nx2 ==> y2")
 
         self.assertRunOK(
-            "scan --from=x1 --to=z --max_keys=3", "x1 : y1\nx2 : y2\nx3 : y3"
+            "scan --from=x1 --to=z --max_keys=3", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3"
         )
         self.assertRunOK(
-            "scan --from=x1 --to=z --max_keys=4", "x1 : y1\nx2 : y2\nx3 : y3"
+            "scan --from=x1 --to=z --max_keys=4", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3"
         )
-        self.assertRunOK("scan --from=x1 --to=x2", "x1 : y1")
-        self.assertRunOK("scan --from=x2 --to=x4", "x2 : y2\nx3 : y3")
+        self.assertRunOK("scan --from=x1 --to=x2", "x1 ==> y1")
+        self.assertRunOK("scan --from=x2 --to=x4", "x2 ==> y2\nx3 ==> y3")
         self.assertRunFAIL("scan --from=x4 --to=z")  # No results => FAIL
         self.assertRunFAIL("scan --from=x1 --to=z --max_keys=foo")
 
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3")
 
         self.assertRunOK("delete x1", "OK")
-        self.assertRunOK("scan", "x2 : y2\nx3 : y3")
+        self.assertRunOK("scan", "x2 ==> y2\nx3 ==> y3")
 
         self.assertRunOK("delete NonExistentKey", "OK")
         # It is weird that GET and SCAN raise exception for
@@ -171,9 +171,9 @@ class LDBTestCase(unittest.TestCase):
     def testStringBatchPut(self):
         print("Running testStringBatchPut...")
         self.assertRunOK("batchput x1 y1 --create_if_missing", "OK")
-        self.assertRunOK("scan", "x1 : y1")
+        self.assertRunOK("scan", "x1 ==> y1")
         self.assertRunOK('batchput x2 y2 x3 y3 "x4 abc" "y4 xyz"', "OK")
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 abc : y4 xyz")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 abc ==> y4 xyz")
         self.assertRunFAIL("batchput")
         self.assertRunFAIL("batchput k1")
         self.assertRunFAIL("batchput k1 v1 k2")
@@ -183,11 +183,11 @@ class LDBTestCase(unittest.TestCase):
 
         dbPath = os.path.join(self.TMP_DIR, self.DB_NAME)
         self.assertRunOK("batchput x1 y1 --create_if_missing --enable_blob_files", "OK")
-        self.assertRunOK("scan", "x1 : y1")
+        self.assertRunOK("scan", "x1 ==> y1")
         self.assertRunOK(
             'batchput --enable_blob_files x2 y2 x3 y3 "x4 abc" "y4 xyz"', "OK"
         )
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 abc : y4 xyz")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 abc ==> y4 xyz")
 
         blob_files = self.getBlobFiles(dbPath)
         self.assertTrue(len(blob_files) >= 1)
@@ -278,12 +278,12 @@ class LDBTestCase(unittest.TestCase):
     def testHexPutGet(self):
         print("Running testHexPutGet...")
         self.assertRunOK("put a1 b1 --create_if_missing", "OK")
-        self.assertRunOK("scan", "a1 : b1")
-        self.assertRunOK("scan --hex", "0x6131 : 0x6231")
+        self.assertRunOK("scan", "a1 ==> b1")
+        self.assertRunOK("scan --hex", "0x6131 ==> 0x6231")
         self.assertRunFAIL("put --hex 6132 6232")
         self.assertRunOK("put --hex 0x6132 0x6232", "OK")
-        self.assertRunOK("scan --hex", "0x6131 : 0x6231\n0x6132 : 0x6232")
-        self.assertRunOK("scan", "a1 : b1\na2 : b2")
+        self.assertRunOK("scan --hex", "0x6131 ==> 0x6231\n0x6132 ==> 0x6232")
+        self.assertRunOK("scan", "a1 ==> b1\na2 ==> b2")
         self.assertRunOK("get a1", "b1")
         self.assertRunOK("get --hex 0x6131", "0x6231")
         self.assertRunOK("get a2", "b2")
@@ -292,27 +292,28 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunOK("get --key_hex --value_hex 0x6132", "0x6232")
         self.assertRunOK("get --value_hex a2", "0x6232")
         self.assertRunOK(
-            "scan --key_hex --value_hex", "0x6131 : 0x6231\n0x6132 : 0x6232"
+            "scan --key_hex --value_hex", "0x6131 ==> 0x6231\n0x6132 ==> 0x6232"
         )
         self.assertRunOK(
-            "scan --hex --from=0x6131 --to=0x6133", "0x6131 : 0x6231\n0x6132 : 0x6232"
+            "scan --hex --from=0x6131 --to=0x6133",
+            "0x6131 ==> 0x6231\n0x6132 ==> 0x6232",
         )
-        self.assertRunOK("scan --hex --from=0x6131 --to=0x6132", "0x6131 : 0x6231")
-        self.assertRunOK("scan --key_hex", "0x6131 : b1\n0x6132 : b2")
-        self.assertRunOK("scan --value_hex", "a1 : 0x6231\na2 : 0x6232")
+        self.assertRunOK("scan --hex --from=0x6131 --to=0x6132", "0x6131 ==> 0x6231")
+        self.assertRunOK("scan --key_hex", "0x6131 ==> b1\n0x6132 ==> b2")
+        self.assertRunOK("scan --value_hex", "a1 ==> 0x6231\na2 ==> 0x6232")
         self.assertRunOK("batchput --hex 0x6133 0x6233 0x6134 0x6234", "OK")
-        self.assertRunOK("scan", "a1 : b1\na2 : b2\na3 : b3\na4 : b4")
+        self.assertRunOK("scan", "a1 ==> b1\na2 ==> b2\na3 ==> b3\na4 ==> b4")
         self.assertRunOK("delete --hex 0x6133", "OK")
-        self.assertRunOK("scan", "a1 : b1\na2 : b2\na4 : b4")
+        self.assertRunOK("scan", "a1 ==> b1\na2 ==> b2\na4 ==> b4")
         self.assertRunOK("checkconsistency", "OK")
 
     def testTtlPutGet(self):
         print("Running testTtlPutGet...")
         self.assertRunOK("put a1 b1 --ttl --create_if_missing", "OK")
-        self.assertRunOK("scan --hex", "0x6131 : 0x6231", True)
+        self.assertRunOK("scan --hex", "0x6131 ==> 0x6231", True)
         self.assertRunOK("dump --ttl ", "a1 ==> b1", True)
         self.assertRunOK("dump --hex --ttl ", "0x6131 ==> 0x6231\nKeys in range: 1")
-        self.assertRunOK("scan --hex --ttl", "0x6131 : 0x6231")
+        self.assertRunOK("scan --hex --ttl", "0x6131 ==> 0x6231")
         self.assertRunOK("get --value_hex a1", "0x6231", True)
         self.assertRunOK("get --ttl a1", "b1")
         self.assertRunOK("put a3 b3 --create_if_missing", "OK")
@@ -334,7 +335,7 @@ class LDBTestCase(unittest.TestCase):
     def testDumpLoad(self):
         print("Running testDumpLoad...")
         self.assertRunOK("batchput --create_if_missing x1 y1 x2 y2 x3 y3 x4 y4", "OK")
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")
         origDbPath = os.path.join(self.TMP_DIR, self.DB_NAME)
 
         # Dump and load without any additional params specified
@@ -345,7 +346,7 @@ class LDBTestCase(unittest.TestCase):
             self.loadDb("--db=%s --create_if_missing" % loadedDbPath, dumpFilePath)
         )
         self.assertRunOKFull(
-            "scan --db=%s" % loadedDbPath, "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4"
+            "scan --db=%s" % loadedDbPath, "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4"
         )
 
         # Dump and load in hex
@@ -358,7 +359,7 @@ class LDBTestCase(unittest.TestCase):
             )
         )
         self.assertRunOKFull(
-            "scan --db=%s" % loadedDbPath, "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4"
+            "scan --db=%s" % loadedDbPath, "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4"
         )
 
         # Dump only a portion of the key range
@@ -370,7 +371,7 @@ class LDBTestCase(unittest.TestCase):
         self.assertTrue(
             self.loadDb("--db=%s --create_if_missing" % loadedDbPath, dumpFilePath)
         )
-        self.assertRunOKFull("scan --db=%s" % loadedDbPath, "x1 : y1\nx2 : y2")
+        self.assertRunOKFull("scan --db=%s" % loadedDbPath, "x1 ==> y1\nx2 ==> y2")
 
         # Dump upto max_keys rows
         dumpFilePath = os.path.join(self.TMP_DIR, "dump4")
@@ -379,13 +380,15 @@ class LDBTestCase(unittest.TestCase):
         self.assertTrue(
             self.loadDb("--db=%s --create_if_missing" % loadedDbPath, dumpFilePath)
         )
-        self.assertRunOKFull("scan --db=%s" % loadedDbPath, "x1 : y1\nx2 : y2\nx3 : y3")
+        self.assertRunOKFull(
+            "scan --db=%s" % loadedDbPath, "x1 ==> y1\nx2 ==> y2\nx3 ==> y3"
+        )
 
         # Load into an existing db, create_if_missing is not specified
         self.assertTrue(self.dumpDb("--db=%s" % origDbPath, dumpFilePath))
         self.assertTrue(self.loadDb("--db=%s" % loadedDbPath, dumpFilePath))
         self.assertRunOKFull(
-            "scan --db=%s" % loadedDbPath, "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4"
+            "scan --db=%s" % loadedDbPath, "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4"
         )
 
         # Dump and load with WAL disabled
@@ -398,7 +401,7 @@ class LDBTestCase(unittest.TestCase):
             )
         )
         self.assertRunOKFull(
-            "scan --db=%s" % loadedDbPath, "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4"
+            "scan --db=%s" % loadedDbPath, "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4"
         )
 
         # Dump and load with lots of extra params specified
@@ -423,7 +426,7 @@ class LDBTestCase(unittest.TestCase):
             )
         )
         self.assertRunOKFull(
-            "scan --db=%s" % loadedDbPath, "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4"
+            "scan --db=%s" % loadedDbPath, "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4"
         )
 
         # Dump with count_only
@@ -435,7 +438,7 @@ class LDBTestCase(unittest.TestCase):
         )
         # DB should have atleast one value for scan to work
         self.assertRunOKFull("put --db=%s k1 v1" % loadedDbPath, "OK")
-        self.assertRunOKFull("scan --db=%s" % loadedDbPath, "k1 : v1")
+        self.assertRunOKFull("scan --db=%s" % loadedDbPath, "k1 ==> v1")
 
         # Dump command fails because of typo in params
         dumpFilePath = os.path.join(self.TMP_DIR, "dump8")
@@ -458,7 +461,7 @@ class LDBTestCase(unittest.TestCase):
             )
         )
         self.assertRunOKFull(
-            "scan --db=%s" % loadedDbPath, "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4"
+            "scan --db=%s" % loadedDbPath, "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4"
         )
         blob_files = self.getBlobFiles(loadedDbPath)
         self.assertTrue(len(blob_files) >= 1)
@@ -498,26 +501,26 @@ class LDBTestCase(unittest.TestCase):
         # These tests need to be improved; for example with asserts about
         # whether compaction or level reduction actually took place.
         self.assertRunOK("batchput --create_if_missing x1 y1 x2 y2 x3 y3 x4 y4", "OK")
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")
         origDbPath = os.path.join(self.TMP_DIR, self.DB_NAME)
 
         self.assertTrue(0 == run_err_null("./ldb compact --db=%s" % origDbPath))
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")
 
         self.assertTrue(
             0 == run_err_null("./ldb reduce_levels --db=%s --new_levels=2" % origDbPath)
         )
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")
 
         self.assertTrue(
             0 == run_err_null("./ldb reduce_levels --db=%s --new_levels=3" % origDbPath)
         )
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")
 
         self.assertTrue(
             0 == run_err_null("./ldb compact --db=%s --from=x1 --to=x3" % origDbPath)
         )
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")
 
         self.assertTrue(
             0
@@ -525,7 +528,7 @@ class LDBTestCase(unittest.TestCase):
                 "./ldb compact --db=%s --hex --from=0x6131 --to=0x6134" % origDbPath
             )
         )
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")
 
         # TODO(dilip): Not sure what should be passed to WAL.Currently corrupted.
         self.assertTrue(
@@ -535,7 +538,7 @@ class LDBTestCase(unittest.TestCase):
                 % (origDbPath, os.path.join(origDbPath, "LOG"))
             )
         )
-        self.assertRunOK("scan", "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")
 
     def testCheckConsistency(self):
         print("Running testCheckConsistency...")
@@ -923,7 +926,9 @@ class LDBTestCase(unittest.TestCase):
             "batchput --db=%s --create_if_missing x1 y1 x2 y2 x3 y3 x4 y4" % dbPath,
             "OK",
         )
-        self.assertRunOK("scan --db=%s" % dbPath, "x1 : y1\nx2 : y2\nx3 : y3\nx4 : y4")
+        self.assertRunOK(
+            "scan --db=%s" % dbPath, "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4"
+        )
         dumpFilePath = os.path.join(self.TMP_DIR, "dump1")
         with open(dumpFilePath, "w") as f:
             f.write("x1 ==> y10\nx2 ==> y20\nx3 ==> y30\nx4 ==> y40")
@@ -947,7 +952,7 @@ class LDBTestCase(unittest.TestCase):
             )
         )
         self.assertRunOKFull(
-            "scan --db=%s" % dbPath, "x1 : y10\nx2 : y20\nx3 : y30\nx4 : y40"
+            "scan --db=%s" % dbPath, "x1 ==> y10\nx2 ==> y20\nx3 ==> y30\nx4 ==> y40"
         )
 
 

--- a/unreleased_history/behavior_changes/ldb_scan_command_output_change.md
+++ b/unreleased_history/behavior_changes/ldb_scan_command_output_change.md
@@ -1,0 +1,1 @@
+Change ldb scan command delimiter from ':' to '==>'.

--- a/unreleased_history/new_features/wide_column_support_in_ldb.md
+++ b/unreleased_history/new_features/wide_column_support_in_ldb.md
@@ -1,0 +1,1 @@
+Add wide column support to ldb commands (scan, dump, idump, dump_wal) and sst_dump tool's scan command


### PR DESCRIPTION
# Summary
As mentioned in #11754 , refactor to clean up some nearly identical logic. This PR changes the existing debugging string format of Scan command as the following.

```
❯ ./ldb --db=/tmp/rocksdbtest-226125/db_wide_basic_test_2675429_2308393776696827948/ scan --hex
```

Before
```
0x6669727374 : :0x68656C6C6F 0x617474725F6E616D6531:0x666F6F 0x617474725F6E616D6532:0x626172
0x7365636F6E64 : 0x617474725F6F6E65:0x74776F 0x617474725F7468726565:0x666F7572
0x7468697264 : 0x62617A
```
After
```
0x6669727374 ==> :0x68656C6C6F 0x617474725F6E616D6531:0x666F6F 0x617474725F6E616D6532:0x626172
0x7365636F6E64 ==> 0x617474725F6F6E65:0x74776F 0x617474725F7468726565:0x666F7572
0x7468697264 ==> 0x62617A
```

# Test Plan

```
❯ ./ldb --db=/tmp/rocksdbtest-226125/db_wide_basic_test_2675429_2308393776696827948/ dump
first ==> :hello attr_name1:foo attr_name2:bar
second ==> attr_one:two attr_three:four
third ==> baz
Keys in range: 3

❯ ./ldb --db=/tmp/rocksdbtest-226125/db_wide_basic_test_2675429_2308393776696827948/ scan
first ==> :hello attr_name1:foo attr_name2:bar
second ==> attr_one:two attr_three:four
third ==> baz

❯ ./ldb --db=/tmp/rocksdbtest-226125/db_wide_basic_test_2675429_2308393776696827948/ dump --hex
0x6669727374 ==> :0x68656C6C6F 0x617474725F6E616D6531:0x666F6F 0x617474725F6E616D6532:0x626172
0x7365636F6E64 ==> 0x617474725F6F6E65:0x74776F 0x617474725F7468726565:0x666F7572
0x7468697264 ==> 0x62617A
Keys in range: 3

❯ ./ldb --db=/tmp/rocksdbtest-226125/db_wide_basic_test_2675429_2308393776696827948/ scan --hex
0x6669727374 ==> :0x68656C6C6F 0x617474725F6E616D6531:0x666F6F 0x617474725F6E616D6532:0x626172
0x7365636F6E64 ==> 0x617474725F6F6E65:0x74776F 0x617474725F7468726565:0x666F7572
0x7468697264 ==> 0x62617A
```
