### PR TITLE
Add Apache Kvrocks RocksDB use case in USERS.md

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -161,5 +161,9 @@ LzLabs is using RocksDB as a storage engine in their multi-database distributed 
 ## Solana Labs
 [Solana](https://github.com/solana-labs/solana) is a fast, secure, scalable, and decentralized blockchain.  It uses RocksDB as the underlying storage for its ledger store.
 
+## Apache Kvrocks
+
+[Apache Kvrocks](https://github.com/apache/kvrocks) Kvrocks is an open-source distributed key-value NoSQL database built on top of RocksDB. It serves as a cost-saving and capacity-increasing alternative drop-in replacement for Redis.
+
 ## Others
 More databases using RocksDB can be found at [dbdb.io](https://dbdb.io/browse?embeds=rocksdb).

--- a/USERS.md
+++ b/USERS.md
@@ -163,7 +163,7 @@ LzLabs is using RocksDB as a storage engine in their multi-database distributed 
 
 ## Apache Kvrocks
 
-[Apache Kvrocks](https://github.com/apache/kvrocks) Kvrocks is an open-source distributed key-value NoSQL database built on top of RocksDB. It serves as a cost-saving and capacity-increasing alternative drop-in replacement for Redis.
+[Apache Kvrocks](https://github.com/apache/kvrocks) is an open-source distributed key-value NoSQL database built on top of RocksDB. It serves as a cost-saving and capacity-increasing alternative drop-in replacement for Redis.
 
 ## Others
 More databases using RocksDB can be found at [dbdb.io](https://dbdb.io/browse?embeds=rocksdb).


### PR DESCRIPTION
[Apache Kvrocks](https://github.com/apache/kvrocks) is an open-source distributed key-value NoSQL database built on top of RocksDB. It serves as a cost-saving and capacity-increasing alternative drop-in replacement for Redis