### PR TITLE
Add some unit tests when file read returns error during compaction/scanning

### DIFF
--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -472,6 +472,8 @@ const Status& ErrorHandler::SetBGError(const Status& bg_status,
       ROCKS_LOG_INFO(
           db_options_.info_log,
           "ErrorHandler: Compaction will schedule by itself to resume\n");
+      // Not used in this code path.
+      new_bg_io_err.PermitUncheckedError();
       return bg_error_;
     } else if (BackgroundErrorReason::kFlushNoWAL == reason ||
                BackgroundErrorReason::kManifestWriteNoWAL == reason) {

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -270,8 +270,7 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
   if (stats_ != nullptr && file_read_hist_ != nullptr) {
     file_read_hist_->Add(elapsed);
   }
-  // Return retryable error here.
-  //
+
 #ifndef NDEBUG
   auto pair = std::make_pair(&file_name_, &io_s);
   if (offset == 0) {

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -270,7 +270,16 @@ IOStatus RandomAccessFileReader::Read(const IOOptions& opts, uint64_t offset,
   if (stats_ != nullptr && file_read_hist_ != nullptr) {
     file_read_hist_->Add(elapsed);
   }
-
+  // Return retryable error here.
+  //
+#ifndef NDEBUG
+  auto pair = std::make_pair(&file_name_, &io_s);
+  if (offset == 0) {
+    TEST_SYNC_POINT_CALLBACK("RandomAccessFileReader::Read::BeforeReturn",
+                             &pair);
+  }
+  TEST_SYNC_POINT_CALLBACK("RandomAccessFileReader::Read::AnyOffset", &pair);
+#endif
   return io_s;
 }
 


### PR DESCRIPTION
Some repro unit tests for the bug fixed in https://github.com/facebook/rocksdb/pull/11782.

Ran on main without https://github.com/facebook/rocksdb/pull/11782:
```
./db_compaction_test --gtest_filter='*ErrorWhenReadFileHead'
Note: Google Test filter = *ErrorWhenReadFileHead
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBCompactionTest
[ RUN      ] DBCompactionTest.ErrorWhenReadFileHead
db/db_compaction_test.cc:10105: Failure
Value of: s.IsIOError()
  Actual: false
Expected: true
[  FAILED  ] DBCompactionTest.ErrorWhenReadFileHead (3960 ms)


./db_iterator_test --gtest_filter="*ErrorWhenReadFile*"
Note: Google Test filter = *ErrorWhenReadFile*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBIteratorTest
[ RUN      ] DBIteratorTest.ErrorWhenReadFile
db/db_iterator_test.cc:3399: Failure
Value of: (iter->status()).ok()
  Actual: true
Expected: false
[  FAILED  ] DBIteratorTest.ErrorWhenReadFile (280 ms)
[----------] 1 test from DBIteratorTest (280 ms total)
```