### PR TITLE
8.5.fb Build errors on Windows + VSC 2022

### DIFF
--- a/env/unique_id_gen.cc
+++ b/env/unique_id_gen.cc
@@ -189,7 +189,7 @@ void UnpredictableUniqueIdGen::GenerateNext(uint64_t* upper, uint64_t* lower) {
   // Use timing information (if available) to add to entropy. (Not a disaster
   // if unavailable on some platforms. High performance is important.)
 #ifdef __SSE4_2__  // More than enough to guarantee rdtsc instruction
-  extra_entropy = static_cast<uint64_t>(_rdtsc());
+  extra_entropy = static_cast<uint64_t>(__rdtsc());
 #else
   extra_entropy = SystemClock::Default()->NowNanos();
 #endif

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -1117,9 +1117,14 @@ static inline Function Choose_Extend() {
   }
 #elif defined(__SSE4_2__) && defined(__PCLMUL__) && !defined NO_THREEWAY_CRC32C
   // NOTE: runtime detection no longer supported on x86
+  #ifdef _MSC_VER
+  #pragma warning(disable: 4551)
+  #endif
   #pragma warning(disable: 4551)
   (void)ExtendImpl<DefaultCRC32>;  // suppress unused warning
+  #ifdef _MSC_VER
   #pragma warning(default: 4551)
+  #endif
   return crc32c_3way;
 #else
   return ExtendImpl<DefaultCRC32>;

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -1117,6 +1117,7 @@ static inline Function Choose_Extend() {
   }
 #elif defined(__SSE4_2__) && defined(__PCLMUL__) && !defined NO_THREEWAY_CRC32C
   // NOTE: runtime detection no longer supported on x86
+  #pragma warning(disable: 4551)
   (void)ExtendImpl<DefaultCRC32>;  // suppress unused warning
   return crc32c_3way;
 #else

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -1119,7 +1119,7 @@ static inline Function Choose_Extend() {
   // NOTE: runtime detection no longer supported on x86
   #pragma warning(disable: 4551)
   (void)ExtendImpl<DefaultCRC32>;  // suppress unused warning
-  #pragma warning(enable: 4551)
+  #pragma warning(default: 4551)
   return crc32c_3way;
 #else
   return ExtendImpl<DefaultCRC32>;

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -1119,6 +1119,7 @@ static inline Function Choose_Extend() {
   // NOTE: runtime detection no longer supported on x86
   #pragma warning(disable: 4551)
   (void)ExtendImpl<DefaultCRC32>;  // suppress unused warning
+  #pragma warning(enable: 4551)
   return crc32c_3way;
 #else
   return ExtendImpl<DefaultCRC32>;

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -1120,7 +1120,6 @@ static inline Function Choose_Extend() {
   #ifdef _MSC_VER
   #pragma warning(disable: 4551)
   #endif
-  #pragma warning(disable: 4551)
   (void)ExtendImpl<DefaultCRC32>;  // suppress unused warning
   #ifdef _MSC_VER
   #pragma warning(default: 4551)


### PR DESCRIPTION
VisualStudio Community 2022 x64, v17.4.3

Fixing following build errors:
  - `crc32c.cc:1119` function call missing argument list. Code introduced in 459969e
	  // NOTE: runtime detection no longer supported on x86
	  (void)ExtendImpl<DefaultCRC32>;  // suppress unused warning

 - `env\unique_id_gen.cc: 192` - undefined symbol _rdtsc. Code introduced in 98c6d7f  
 
 Relevant docs of both functions :
 * [__rdtsc in Microsoft docs](https://learn.microsoft.com/pl-pl/cpp/intrinsics/rdtsc?view=msvc-170)  
 * [_rdtsc in Intels docs](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_rdtsc)
