### PR TITLE
Fix bad include

### DIFF
--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -11,9 +11,6 @@
 #ifndef XXH_NAMESPACE
 #define XXH_NAMESPACE ROCKSDB_
 #endif  // !defined(XXH_NAMESPACE)
-
-// for FALLTHROUGH_INTENDED, inserted as appropriate
-#include "port/lang.h"
 /* END RocksDB customizations */
 
 // clang-format off

--- a/util/xxph3.h
+++ b/util/xxph3.h
@@ -386,10 +386,6 @@ typedef struct {
 #define XXPH_STATIC_LINKING_ONLY
 #endif
 
-/* BEGIN RocksDB customizations */
-#include "port/lang.h" /* for FALLTHROUGH_INTENDED, inserted as appropriate */
-/* END RocksDB customizations */
-
 /* *************************************
 *  Compiler Specific Options
 ***************************************/


### PR DESCRIPTION
Summary: There was a `#include "port/lang.h"` situated inside an `extern "C" {` which just started causing the header to be unusuable in some contexts. This was a regression on the CircleCI job build-linux-unity-and-headers in #11792

The include, and another like it, now appears obsolete so removed.

Test Plan: local `make check-headers` and `make`, CI