### PR TITLE
Disable error injection after compaction completion

### DIFF
--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -110,6 +110,13 @@ class DbStressListener : public EventListener {
     }
   }
 
+  void OnSubcompactionCompleted(const SubcompactionJobInfo& /* si */) override {
+    if (FLAGS_read_fault_one_in) {
+      (void)fault_fs_guard->GetAndResetErrorCount();
+      fault_fs_guard->DisableErrorInjection();
+    }
+  }
+
   void OnTableFileCreationStarted(
       const TableFileCreationBriefInfo& /*info*/) override {
     ++num_pending_file_creations_;


### PR DESCRIPTION
#11789 added error injection during compaction to db_stress. However, error injection was not disabled after compaction completion, which resulted in some test failures due to stale errors.