### PR TITLE
Add .arcconfig to .gitignore (fb internal use)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ fbcode/
 fbcode
 buckifier/*.pyc
 buckifier/__pycache__
+.arcconfig
 
 compile_commands.json
 clang-format-diff.py


### PR DESCRIPTION
This is for fb internal use. Please see the comment in internal Phabricator for details.