### PR TITLE
Suppress TSAN reports on AutoHyperClockTable::Lookup

### DIFF
--- a/port/lang.h
+++ b/port/lang.h
@@ -69,13 +69,6 @@ constexpr bool kMustFreeHeapAllocations = false;
 #define TSAN_SUPPRESSION
 #endif  // TSAN_SUPPRESSION
 
-// Read memory while allowing data races. Only use where it is OK to read
-// the wrong value, e.g. where reading the latest value improves performance.
-template <typename T>
-TSAN_SUPPRESSION inline T ReadAllowRace(const T& v) {
-  return v;
-}
-
 // Compile-time CPU feature testing compatibility
 //
 // A way to be extra sure these defines have been included.


### PR DESCRIPTION
Summary: This function uses racing reads for heuristic performance improvement. My change in #11792 only worked for clang, not gcc, and gcc does not accurately handle TSAN suppressions. I would have to mark much more code as suppressed than I want to.

So I've taken a different approach: TSAN build does not use the racing reads but substitutes random results, as an extra test that a "correct" value is not needed for correct overall behavior.

Test Plan: manual TSAN builds & tests with cache_bench