### PR TITLE
Introduce a wide column aware MergeOperator API

### DIFF
--- a/db/merge_operator.cc
+++ b/db/merge_operator.cc
@@ -9,6 +9,10 @@
 
 #include "rocksdb/merge_operator.h"
 
+#include <type_traits>
+
+#include "util/overload.h"
+
 namespace ROCKSDB_NAMESPACE {
 
 bool MergeOperator::FullMergeV2(const MergeOperationInput& merge_in,
@@ -21,6 +25,84 @@ bool MergeOperator::FullMergeV2(const MergeOperationInput& merge_in,
   }
   return FullMerge(merge_in.key, merge_in.existing_value, operand_list_str,
                    &merge_out->new_value, merge_in.logger);
+}
+
+bool MergeOperator::FullMergeV3(const MergeOperationInputV3& merge_in,
+                                MergeOperationOutputV3* merge_out) const {
+  assert(merge_out);
+
+  MergeOperationInput in_v2(merge_in.key, nullptr, merge_in.operand_list,
+                            merge_in.logger);
+
+  std::string new_value;
+  Slice existing_operand(nullptr, 0);
+  MergeOperationOutput out_v2(new_value, existing_operand);
+
+  return std::visit(
+      overload{
+          [&](const auto& existing) -> bool {
+            using T = std::decay_t<decltype(existing)>;
+
+            if constexpr (std::is_same_v<T, Slice>) {
+              in_v2.existing_value = &existing;
+            }
+
+            const bool result = FullMergeV2(in_v2, &out_v2);
+            if (!result) {
+              merge_out->op_failure_scope = out_v2.op_failure_scope;
+              return false;
+            }
+
+            if (existing_operand.data()) {
+              merge_out->new_value = existing_operand;
+            } else {
+              merge_out->new_value = std::move(new_value);
+            }
+
+            return true;
+          },
+          [&](const WideColumns& existing_columns) -> bool {
+            const bool has_default_column =
+                !existing_columns.empty() &&
+                existing_columns.front().name() == kDefaultWideColumnName;
+
+            Slice value_of_default;
+            if (has_default_column) {
+              value_of_default = existing_columns.front().value();
+            }
+
+            in_v2.existing_value = &value_of_default;
+
+            const bool result = FullMergeV2(in_v2, &out_v2);
+            if (!result) {
+              merge_out->op_failure_scope = out_v2.op_failure_scope;
+              return false;
+            }
+
+            merge_out->new_value = MergeOperationOutputV3::NewColumns();
+            auto& new_columns = std::get<MergeOperationOutputV3::NewColumns>(
+                merge_out->new_value);
+            new_columns.reserve(has_default_column
+                                    ? existing_columns.size()
+                                    : (existing_columns.size() + 1));
+
+            if (existing_operand.data()) {
+              new_columns.emplace_back(kDefaultWideColumnName.ToString(),
+                                       existing_operand.ToString());
+            } else {
+              new_columns.emplace_back(kDefaultWideColumnName.ToString(),
+                                       std::move(new_value));
+            }
+
+            for (size_t i = has_default_column ? 1 : 0;
+                 i < existing_columns.size(); ++i) {
+              new_columns.emplace_back(existing_columns[i].name().ToString(),
+                                       existing_columns[i].value().ToString());
+            }
+
+            return true;
+          }},
+      merge_in.existing_value);
 }
 
 // The default implementation of PartialMergeMulti, which invokes

--- a/util/overload.h
+++ b/util/overload.h
@@ -1,0 +1,23 @@
+//  (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include "rocksdb/rocksdb_namespace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// A helper template that can combine multiple functors into a single one to be
+// used with std::visit for example. It also works with lambdas, since it
+// comes with an explicit deduction guide.
+template <typename... Ts>
+struct overload : Ts... {
+  using Ts::operator()...;
+};
+
+template <typename... Ts>
+overload(Ts...) -> overload<Ts...>;
+
+}  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary:
For now, RocksDB has limited support for using merge with wide columns: when a bunch of merge operands have to be applied to a wide-column base value, RocksDB currently passes only the value of the default column to the application's `MergeOperator`, which means there is no way to update any other columns during a merge. As a first step in making this more general, the patch adds a new API `FullMergeV3` to `MergeOperator`.

`FullMergeV3`'s interface enables applications to receive a plain, wide-column, or non-existent base value as merge input, and to produce a new plain value, a new wide-column value, or an existing operand as merge output. Note that there are no limitations on the column names and values if the merge result is a wide-column entity. Also, the interface is general in the sense that it makes it possible e.g. for a merge that takes a plain base value and some deltas to produce a wide-column entity as a result.

For backward compatibility, the default implementation of `FullMergeV3` falls back to `FullMergeV2` and implements the current logic where merge operands are applied to the default column of the base entity and any other columns are unchanged. (Note that with `FullMergeV3` in the `MergeOperator` interface, this behavior will become customizable.)

This patch just introduces the new API and the default backward compatible implementation. I plan to integrate `FullMergeV3` into the query and compaction logic in subsequent diffs.

Differential Revision: D49117253


