### PR TITLE
Add helper methods WideColumnsHelper::{Has,Get}DefaultColumn

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -18,6 +18,7 @@
 #include "db/merge_helper.h"
 #include "db/pinned_iterators_manager.h"
 #include "db/wide/wide_column_serialization.h"
+#include "db/wide/wide_columns_helper.h"
 #include "file/filename.h"
 #include "logging/logging.h"
 #include "memory/arena.h"
@@ -230,9 +231,8 @@ bool DBIter::SetValueAndColumnsFromEntity(Slice slice) {
     return false;
   }
 
-  if (!wide_columns_.empty() &&
-      wide_columns_[0].name() == kDefaultWideColumnName) {
-    value_ = wide_columns_[0].value();
+  if (WideColumnsHelper::HasDefaultColumn(wide_columns_)) {
+    value_ = WideColumnsHelper::GetDefaultColumn(wide_columns_);
   }
 
   return true;

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -13,6 +13,7 @@
 #include "db/compaction/compaction_iteration_stats.h"
 #include "db/dbformat.h"
 #include "db/wide/wide_column_serialization.h"
+#include "db/wide/wide_columns_helper.h"
 #include "logging/logging.h"
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics_impl.h"
@@ -135,7 +136,7 @@ Status MergeHelper::TimedFullMergeWithEntity(
   }
 
   const bool has_default_column =
-      !base_columns.empty() && base_columns[0].name() == kDefaultWideColumnName;
+      WideColumnsHelper::HasDefaultColumn(base_columns);
 
   Slice value_of_default;
   if (has_default_column) {

--- a/db/merge_operator.cc
+++ b/db/merge_operator.cc
@@ -11,6 +11,7 @@
 
 #include <type_traits>
 
+#include "db/wide/wide_columns_helper.h"
 #include "util/overload.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -63,8 +64,7 @@ bool MergeOperator::FullMergeV3(const MergeOperationInputV3& merge_in,
           },
           [&](const WideColumns& existing_columns) -> bool {
             const bool has_default_column =
-                !existing_columns.empty() &&
-                existing_columns.front().name() == kDefaultWideColumnName;
+                WideColumnsHelper::HasDefaultColumn(existing_columns);
 
             Slice value_of_default;
             if (has_default_column) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -39,6 +39,7 @@
 #include "db/version_builder.h"
 #include "db/version_edit.h"
 #include "db/version_edit_handler.h"
+#include "db/wide/wide_columns_helper.h"
 #include "file/file_util.h"
 #include "table/compaction_merging_iterator.h"
 
@@ -2452,12 +2453,9 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
                                   fp.GetHitFileLevel());
 
         if (is_blob_index && do_merge && (value || columns)) {
-          assert(!columns ||
-                 (!columns->columns().empty() &&
-                  columns->columns().front().name() == kDefaultWideColumnName));
-
           Slice blob_index =
-              value ? *value : columns->columns().front().value();
+              value ? *value
+                    : WideColumnsHelper::GetDefaultColumn(columns->columns());
 
           TEST_SYNC_POINT_CALLBACK("Version::Get::TamperWithBlobIndex",
                                    &blob_index);

--- a/db/version_set_sync_and_async.h
+++ b/db/version_set_sync_and_async.h
@@ -113,12 +113,9 @@ DEFINE_SYNC_AND_ASYNC(Status, Version::MultiGetFromSST)
 
           } else {
             assert(iter->columns);
-            assert(!iter->columns->columns().empty());
-            assert(iter->columns->columns().front().name() ==
-                   kDefaultWideColumnName);
 
-            tmp_s =
-                blob_index.DecodeFrom(iter->columns->columns().front().value());
+            tmp_s = blob_index.DecodeFrom(
+                WideColumnsHelper::GetDefaultColumn(iter->columns->columns()));
           }
 
           if (tmp_s.ok()) {

--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <limits>
 
+#include "db/wide/wide_columns_helper.h"
 #include "rocksdb/slice.h"
 #include "util/autovector.h"
 #include "util/coding.h"
@@ -169,12 +170,12 @@ Status WideColumnSerialization::GetValueOfDefaultColumn(Slice& input,
     return s;
   }
 
-  if (columns.empty() || columns[0].name() != kDefaultWideColumnName) {
+  if (!WideColumnsHelper::HasDefaultColumn(columns)) {
     value.clear();
     return Status::OK();
   }
 
-  value = columns[0].value();
+  value = WideColumnsHelper::GetDefaultColumn(columns);
 
   return Status::OK();
 }

--- a/db/wide/wide_columns_helper.h
+++ b/db/wide/wide_columns_helper.h
@@ -11,11 +11,23 @@
 #include "rocksdb/wide_columns.h"
 
 namespace ROCKSDB_NAMESPACE {
+
 class WideColumnsHelper {
  public:
-  static void DumpWideColumns(const WideColumns& columns, std::ostream& oss,
+  static void DumpWideColumns(const WideColumns& columns, std::ostream& os,
                               bool hex);
-  static Status DumpSliceAsWideColumns(const Slice& value, std::ostream& oss,
+
+  static Status DumpSliceAsWideColumns(const Slice& value, std::ostream& os,
                                        bool hex);
+
+  static bool HasDefaultColumn(const WideColumns& columns) {
+    return !columns.empty() && columns.front().name() == kDefaultWideColumnName;
+  }
+
+  static const Slice& GetDefaultColumn(const WideColumns& columns) {
+    assert(HasDefaultColumn(columns));
+    return columns.front().value();
+  }
 };
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -296,15 +296,11 @@ bool VerifyWideColumns(const Slice& value, const WideColumns& columns) {
 }
 
 bool VerifyWideColumns(const WideColumns& columns) {
-  if (columns.empty()) {
+  if (!WideColumnsHelper::HasDefaultColumn(columns)) {
     return false;
   }
 
-  if (columns.front().name() != kDefaultWideColumnName) {
-    return false;
-  }
-
-  const Slice& value_of_default = columns.front().value();
+  const Slice& value_of_default = WideColumnsHelper::GetDefaultColumn(columns);
 
   return VerifyWideColumns(value_of_default, columns);
 }

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -6,8 +6,8 @@
 #include <atomic>
 #ifdef GFLAGS
 
-
 #include "db/wide/wide_column_serialization.h"
+#include "db/wide/wide_columns_helper.h"
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_shared_state.h"
 #include "db_stress_tool/expected_state.h"
@@ -363,7 +363,6 @@ bool FileExpectedStateManager::HasHistory() {
   return saved_seqno_ != kMaxSequenceNumber;
 }
 
-
 namespace {
 
 // An `ExpectedStateTraceRecordHandler` applies a configurable number of
@@ -462,10 +461,8 @@ class ExpectedStateTraceRecordHandler : public TraceRecord::Handler,
                                            column_family_id, key, columns);
     }
 
-    assert(!columns.empty());
-    assert(columns.front().name() == kDefaultWideColumnName);
-
-    const uint32_t value_base = GetValueBase(columns.front().value());
+    const uint32_t value_base =
+        GetValueBase(WideColumnsHelper::GetDefaultColumn(columns));
 
     state_->SyncPut(column_family_id, static_cast<int64_t>(key_id), value_base);
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -9,6 +9,7 @@
 
 #include "db_stress_tool/expected_state.h"
 #ifdef GFLAGS
+#include "db/wide/wide_columns_helper.h"
 #include "db_stress_tool/db_stress_common.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "utilities/fault_injection_fs.h"
@@ -165,9 +166,8 @@ class NonBatchedOpsStressTest : public StressTest {
           if (s.ok()) {
             const WideColumns& columns = result.columns();
 
-            if (!columns.empty() &&
-                columns.front().name() == kDefaultWideColumnName) {
-              from_db = columns.front().value().ToString();
+            if (WideColumnsHelper::HasDefaultColumn(columns)) {
+              from_db = WideColumnsHelper::GetDefaultColumn(columns).ToString();
             }
 
             if (!VerifyWideColumns(columns)) {
@@ -251,9 +251,9 @@ class NonBatchedOpsStressTest : public StressTest {
             if (statuses[j].ok()) {
               const WideColumns& columns = results[j].columns();
 
-              if (!columns.empty() &&
-                  columns.front().name() == kDefaultWideColumnName) {
-                from_db = columns.front().value().ToString();
+              if (WideColumnsHelper::HasDefaultColumn(columns)) {
+                from_db =
+                    WideColumnsHelper::GetDefaultColumn(columns).ToString();
               }
 
               if (!VerifyWideColumns(columns)) {
@@ -1275,7 +1275,6 @@ class NonBatchedOpsStressTest : public StressTest {
     const uint32_t value_base = pending_expected_value.GetFinalValueBase();
     const size_t sz = GenerateValue(value_base, value, sizeof(value));
     const Slice v(value, sz);
-
 
     Status s;
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1087,7 +1087,7 @@ std::string LDBCommand::PrintKeyValueOrWideColumns(
     bool is_key_hex, bool is_value_hex) {
   if (wide_columns.empty() ||
       (wide_columns.size() == 1 &&
-       wide_columns.front().name() == kDefaultWideColumnName)) {
+       WideColumnsHelper::HasDefaultColumn(wide_columns))) {
     return PrintKeyValue(key.ToString(), value.ToString(), is_key_hex,
                          is_value_hex);
   }


### PR DESCRIPTION
Summary: The patch adds a couple of helper methods `WideColumnsHelper::{Has,Get}DefaultColumn` to eliminate some code duplication.

Differential Revision: D49166682


