### PR TITLE
Change file size related variables type to uint64_t in PickCompactionToReduceSizeAmp()

### DIFF
--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -797,9 +797,9 @@ Compaction* UniversalCompactionBuilder::PickCompactionToReduceSizeAmp() {
   if (sorted_runs_[end_index].being_compacted) {
     return nullptr;
   }
-  const size_t base_sr_size = sorted_runs_[end_index].size;
+  const uint64_t base_sr_size = sorted_runs_[end_index].size;
   size_t start_index = end_index;
-  size_t candidate_size = 0;
+  uint64_t candidate_size = 0;
 
   // Get longest span (i.e, [start_index, end_index]) of available sorted runs
   while (start_index > 0) {


### PR DESCRIPTION
**Context/Summary:**
size_t is not most likely not needed as SortedRun::size/compensated_file_size is uint64_t. This is a pre-requisite to addressing https://github.com/facebook/rocksdb/pull/11749/files#r1321828933.  Other places already uses uint64_t e.g, https://github.com/facebook/rocksdb/blob/8.6.fb/db/compaction/compaction_picker_universal.cc#L349-L353

**Test**
CI