### PR TITLE
Fix row cache falsely return kNotFound when timestamp enabled

### DIFF
--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -1640,6 +1640,7 @@ TEST_F(DBBasicTestWithTimestamp, GetWithRowCache) {
   ASSERT_OK(db_->Put(write_opts, "foo", ts_early, "bar"));
   const Snapshot* snap_with_foo = db_->GetSnapshot();
 
+  // Ensure file has sequence number greater than snapshot_with_foo
   for (int i = 0; i < 10; i++) {
     std::string numStr = std::to_string(i);
     ASSERT_OK(db_->Put(write_opts, numStr, ts_later, numStr));

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -1709,6 +1709,9 @@ TEST_F(DBBasicTestWithTimestamp, GetWithRowCache) {
     ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 3);
     ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 5);
   }
+
+  db_->ReleaseSnapshot(snap_with_nothing);
+  db_->ReleaseSnapshot(snap_with_foo);
   Close();
 }
 

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -1636,7 +1636,14 @@ TEST_F(DBBasicTestWithTimestamp, GetWithRowCache) {
   std::string ts_later = Timestamp(10, 0);
   Slice ts_later_slice = ts_later;
 
+  const Snapshot* snap_with_nothing = db_->GetSnapshot();
   ASSERT_OK(db_->Put(write_opts, "foo", ts_early, "bar"));
+  const Snapshot* snap_with_foo = db_->GetSnapshot();
+
+  for (int i = 0; i < 10; i++) {
+    std::string numStr = std::to_string(i);
+    ASSERT_OK(db_->Put(write_opts, numStr, ts_later, numStr));
+  }
   ASSERT_OK(Flush());
   ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 0);
   ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 0);
@@ -1660,20 +1667,48 @@ TEST_F(DBBasicTestWithTimestamp, GetWithRowCache) {
   // To be fixed after enabling ROW_CACHE with timestamp.
   // ASSERT_EQ(read_ts, ts_early);
 
-  std::string ts_nothing = Timestamp(0, 0);
-  Slice ts_nothing_slice = ts_nothing;
-  read_opts.timestamp = &ts_nothing_slice;
-  s = db_->Get(read_opts, "foo", &read_value, &read_ts);
-  ASSERT_NOK(s);
-  ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 1);
-  ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 2);
+  {
+    std::string ts_nothing = Timestamp(0, 0);
+    Slice ts_nothing_slice = ts_nothing;
+    read_opts.timestamp = &ts_nothing_slice;
+    s = db_->Get(read_opts, "foo", &read_value, &read_ts);
+    ASSERT_TRUE(s.IsNotFound());
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 1);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 2);
 
-  read_opts.timestamp = &ts_later_slice;
-  s = db_->Get(read_opts, "foo", &read_value, &read_ts);
-  ASSERT_OK(s);
-  ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 2);
-  ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 2);
+    read_opts.timestamp = &ts_later_slice;
+    s = db_->Get(read_opts, "foo", &read_value, &read_ts);
+    ASSERT_OK(s);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 2);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 2);
+  }
 
+  {
+    read_opts.snapshot = snap_with_foo;
+
+    s = db_->Get(read_opts, "foo", &read_value, &read_ts);
+    ASSERT_OK(s);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 2);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 3);
+
+    s = db_->Get(read_opts, "foo", &read_value, &read_ts);
+    ASSERT_OK(s);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 3);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 3);
+  }
+
+  {
+    read_opts.snapshot = snap_with_nothing;
+    s = db_->Get(read_opts, "foo", &read_value, &read_ts);
+    ASSERT_TRUE(s.IsNotFound());
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 3);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 4);
+
+    s = db_->Get(read_opts, "foo", &read_value, &read_ts);
+    ASSERT_TRUE(s.IsNotFound());
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_HIT), 3);
+    ASSERT_EQ(TestGetTickerCount(options, ROW_CACHE_MISS), 5);
+  }
   Close();
 }
 

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -259,10 +259,12 @@ class TableCache {
   // Create a key prefix for looking up the row cache. The prefix is of the
   // format row_cache_id + fd_number + seq_no. Later, the user key can be
   // appended to form the full key
-  void CreateRowCacheKeyPrefix(const ReadOptions& options,
-                               const FileDescriptor& fd,
-                               const Slice& internal_key,
-                               GetContext* get_context, IterKey& row_cache_key);
+  // Return the sequence number that determines the visibility of row_cache_key
+  uint64_t CreateRowCacheKeyPrefix(const ReadOptions& options,
+                                   const FileDescriptor& fd,
+                                   const Slice& internal_key,
+                                   GetContext* get_context,
+                                   IterKey& row_cache_key);
 
   // Helper function to lookup the row cache for a key. It appends the
   // user key to row_cache_key at offset prefix_size

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -267,7 +267,8 @@ class TableCache {
   // Helper function to lookup the row cache for a key. It appends the
   // user key to row_cache_key at offset prefix_size
   bool GetFromRowCache(const Slice& user_key, IterKey& row_cache_key,
-                       size_t prefix_size, GetContext* get_context);
+                       size_t prefix_size, GetContext* get_context,
+                       SequenceNumber seq_no = kMaxSequenceNumber);
 
   const ImmutableOptions& ioptions_;
   const FileOptions& file_options_;

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -594,7 +594,8 @@ void GetContext::push_operand(const Slice& value, Cleanable* value_pinner) {
 }
 
 void replayGetContextLog(const Slice& replay_log, const Slice& user_key,
-                         GetContext* get_context, Cleanable* value_pinner) {
+                         GetContext* get_context, Cleanable* value_pinner,
+                         SequenceNumber seq_no) {
   Slice s = replay_log;
   while (s.size()) {
     auto type = static_cast<ValueType>(*s.data());
@@ -605,11 +606,9 @@ void replayGetContextLog(const Slice& replay_log, const Slice& user_key,
     (void)ret;
 
     bool dont_care __attribute__((__unused__));
-    // Since SequenceNumber is not stored and unknown, we will use
-    // kMaxSequenceNumber.
-    get_context->SaveValue(
-        ParsedInternalKey(user_key, kMaxSequenceNumber, type), value,
-        &dont_care, value_pinner);
+
+    ParsedInternalKey ikey = ParsedInternalKey(user_key, seq_no, type);
+    get_context->SaveValue(ikey, value, &dont_care, value_pinner);
   }
 }
 

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -149,12 +149,6 @@ class GetContext {
 
   bool NeedTimestamp() { return timestamp_ != nullptr; }
 
-  Slice GetTimeStamp() {
-    if (timestamp_) return Slice(*timestamp_);
-
-    return Slice();
-  }
-
   void SetTimestampFromRangeTombstone(const Slice& timestamp) {
     assert(timestamp_);
     timestamp_->assign(timestamp.data(), timestamp.size());

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -149,6 +149,12 @@ class GetContext {
 
   bool NeedTimestamp() { return timestamp_ != nullptr; }
 
+  Slice GetTimeStamp() {
+    if (timestamp_) return Slice(*timestamp_);
+
+    return Slice();
+  }
+
   void SetTimestampFromRangeTombstone(const Slice& timestamp) {
     assert(timestamp_);
     timestamp_->assign(timestamp.data(), timestamp.size());
@@ -240,6 +246,7 @@ class GetContext {
 // must have been set by calling GetContext::SetReplayLog().
 void replayGetContextLog(const Slice& replay_log, const Slice& user_key,
                          GetContext* get_context,
-                         Cleanable* value_pinner = nullptr);
+                         Cleanable* value_pinner = nullptr,
+                         SequenceNumber seq_no = kMaxSequenceNumber);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/unreleased_history/bug_fixes/fix_row_cache_falsely_return_kNotFound.md
+++ b/unreleased_history/bug_fixes/fix_row_cache_falsely_return_kNotFound.md
@@ -1,0 +1,1 @@
+* Fix a bug where row cache can falsely return kNotFound even though row cache entry is hit. 


### PR DESCRIPTION
**Summary:**
When row cache hits and a timestamp is being set in read_options, even though ROW_CACHE entry is hit, the return status is kNotFound.

**Cause of error:**
If timestamp is provided in readoptions, a callback for sequence number checking is registered [here](https://github.com/facebook/rocksdb/blob/8fc78a3a9e1d24ba55731b70c0c25cef0765dbc8/db/db_impl/db_impl.cc#L2112). 

Hence the default value set at this [line](https://github.com/facebook/rocksdb/blob/694e49cbb1cff88fbb84a96394a0f76b7bac9e41/table/get_context.cc#L611) prevents get_context from saving value found in cache. Causing the final status to be kNotFound even though the entry exist in both cache and SST file.


**Proposed Solution**
Row cache key contains a sequence number in it. If the key for row cache lookup matches the key in cache, this cache entry should be good to be exposed to user and hence we reuse the sequence number in cache key rather than passing kMaxSequenceNumber.