### PR TITLE
WIP Support AES encryption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ option(WITH_SNAPPY "build with SNAPPY" OFF)
 option(WITH_LZ4 "build with lz4" OFF)
 option(WITH_ZLIB "build with zlib" OFF)
 option(WITH_ZSTD "build with zstd" OFF)
+option(WITH_OPENSSL "build with openssl" OFF)
 option(WITH_WINDOWS_UTF8_FILENAMES "use UTF8 as characterset for opening files, regardles of the system code page" OFF)
 if (WITH_WINDOWS_UTF8_FILENAMES)
   add_definitions(-DROCKSDB_WINDOWS_UTF8_FILENAMES)
@@ -173,6 +174,14 @@ else()
     add_definitions(-DZSTD)
     include_directories(${ZSTD_INCLUDE_DIR})
     list(APPEND THIRDPARTY_LIBS zstd::zstd)
+  endif()
+
+  if(WITH_OPENSSL)
+    find_package(OpenSSL REQUIRED)
+    add_definitions(-DOPENSSL)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+    # Only the crypto library is needed.
+    list(APPEND THIRDPARTY_LIBS ${OPENSSL_CRYPTO_LIBRARIES})
   endif()
 endif()
 
@@ -720,6 +729,7 @@ set(SOURCES
         db/write_controller.cc
         db/write_stall_stats.cc
         db/write_thread.cc
+        encryption/encryption.cc
         env/composite_env.cc
         env/env.cc
         env/env_chroot.cc
@@ -1362,6 +1372,7 @@ if(WITH_TESTS)
         db/write_batch_test.cc
         db/write_callback_test.cc
         db/write_controller_test.cc
+        encryption/encryption_test.cc
         env/env_test.cc
         env/io_posix_test.cc
         env/mock_env_test.cc

--- a/Makefile
+++ b/Makefile
@@ -703,6 +703,7 @@ TESTS_PLATFORM_DEPENDENT := \
 	crc32c_test \
 	coding_test \
 	inlineskiplist_test \
+	encryption_test \
 	env_basic_test \
 	env_test \
 	env_logger_test \
@@ -1985,6 +1986,9 @@ wide_column_serialization_test: $(OBJ_DIR)/db/wide/wide_column_serialization_tes
 	$(AM_LINK)
 
 wide_columns_helper_test: $(OBJ_DIR)/db/wide/wide_columns_helper_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
+encryption_test: encryption/encryption_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 #-------------------------------------------------

--- a/TARGETS
+++ b/TARGETS
@@ -109,6 +109,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "db/write_controller.cc",
         "db/write_stall_stats.cc",
         "db/write_thread.cc",
+        "encryption/encryption.cc",
         "env/composite_env.cc",
         "env/env.cc",
         "env/env_chroot.cc",

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -485,6 +485,19 @@ EOF
         fi
     fi
 
+    if ! test $ROCKSDB_DISABLE_OPENSSL; then
+        # Test whether OpenSSL library is installed
+        $CXX $CFLAGS -x c++ - -o /dev/null 2>/dev/null  <<EOF
+          #include <openssl/crypto.h>
+          int main() {}
+EOF
+        if [ "$?" = 0 ]; then
+            COMMON_FLAGS="$COMMON_FLAGS -DOPENSSL"
+            PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lcrypto"
+            JAVA_LDFLAGS="$JAVA_LDFLAGS -lcrypto"
+        fi
+    fi
+
     if ! test $ROCKSDB_DISABLE_PTHREAD_MUTEX_ADAPTIVE_NP; then
         # Test whether PTHREAD_MUTEX_ADAPTIVE_NP mutex type is available
         $CXX $PLATFORM_CXXFLAGS -x c++ - -o test.o 2>/dev/null  <<EOF

--- a/encryption/encryption.cc
+++ b/encryption/encryption.cc
@@ -1,0 +1,466 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+#ifndef ROCKSDB_LITE
+#ifdef OPENSSL
+
+#include "encryption/encryption.h"
+
+#include <openssl/err.h>
+#include <openssl/opensslv.h>
+#include <openssl/rand.h>
+
+#include <algorithm>
+#include <limits>
+
+#include "encryption/encryption.h"
+#include "file/filename.h"
+#include "port/likely.h"
+#include "port/port.h"
+#include "rocksdb/utilities/options_type.h"
+#include "test_util/sync_point.h"
+
+namespace ROCKSDB_NAMESPACE {
+namespace encryption {
+
+inline size_t KeySize(EncryptionMethod method) {
+  switch (method) {
+    case EncryptionMethod::kAES128_CTR:
+      return 16;
+    case EncryptionMethod::kAES192_CTR:
+      return 24;
+    case EncryptionMethod::kAES256_CTR:
+      return 32;
+    case EncryptionMethod::kSM4_CTR:
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_SM4)
+      return 16;
+#else
+      return 0;
+#endif
+    default:
+      return 0;
+  };
+}
+
+size_t BlockSize(EncryptionMethod method) {
+  switch (method) {
+    case EncryptionMethod::kAES128_CTR:
+    case EncryptionMethod::kAES192_CTR:
+    case EncryptionMethod::kAES256_CTR:
+      return AES_BLOCK_SIZE;
+    case EncryptionMethod::kSM4_CTR:
+      // TODO: OpenSSL Lib does not export SM4_BLOCK_SIZE by now.
+      // Need to use the macro exported from OpenSSL once it is available.
+      // Ref:
+      // https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/include/crypto/sm4.h#L24
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_SM4)
+      return 16;
+#else
+      return 0;
+#endif
+    default:
+      return 0;
+  }
+}
+
+EncryptionMethod EncryptionMethodStringToEnum(const std::string& method) {
+  if (!strcasecmp(method.c_str(), "AES128CTR")) {
+    return ROCKSDB_NAMESPACE::encryption::EncryptionMethod::kAES128_CTR;
+  } else if (!strcasecmp(method.c_str(), "AES192CTR")) {
+    return ROCKSDB_NAMESPACE::encryption::EncryptionMethod::kAES192_CTR;
+  } else if (!strcasecmp(method.c_str(), "AES256CTR")) {
+    return ROCKSDB_NAMESPACE::encryption::EncryptionMethod::kAES256_CTR;
+  } else if (!strcasecmp(method.c_str(), "SM4CTR")) {
+    return ROCKSDB_NAMESPACE::encryption::EncryptionMethod::kSM4_CTR;
+  }
+  return ROCKSDB_NAMESPACE::encryption::EncryptionMethod::kUnknown;
+}
+
+const EVP_CIPHER* GetEVPCipher(EncryptionMethod method) {
+  switch (method) {
+    case EncryptionMethod::kAES128_CTR:
+      return EVP_aes_128_ctr();
+    case EncryptionMethod::kAES192_CTR:
+      return EVP_aes_192_ctr();
+    case EncryptionMethod::kAES256_CTR:
+      return EVP_aes_256_ctr();
+      //    case EncryptionMethod::AES128ECB:
+      //      return EVP_aes_128_ecb();
+      //    case EncryptionMethod::AES192ECB:
+      //      return EVP_aes_192_ecb();
+      //    case EncryptionMethod::AES256ECB:
+      //      return EVP_aes_256_ecb();
+    case EncryptionMethod::kSM4_CTR:
+#if OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4)
+      return Status::InvalidArgument(
+          "Unsupport SM4 encryption method under OpenSSL version: " +
+          std::string(OPENSSL_VERSION_TEXT));
+#else
+      // Openssl support SM4 after 1.1.1 release version.
+      return EVP_sm4_ctr();
+#endif
+    default:
+      return nullptr;
+  }
+}
+
+std::string GetOpenSSLErrors() {
+  std::ostringstream serr;
+  unsigned long l;
+  const char *file, *data, *func;
+  int line, flags;
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+  l = ERR_peek_last_error_all(&file, &line, &func, &data, &flags);
+#else
+  l = ERR_peek_last_error_line_data(&file, &line, &data, &flags);
+  func = ERR_func_error_string(l);
+#endif
+
+  if (l != 0) {
+    serr << l << ":" << ERR_lib_error_string(l) << ":" << func << ":" << file
+         << ":" << line;
+    if ((flags & ERR_TXT_STRING) && data && *data) {
+      serr << ":" << data;
+    } else {
+      serr << ":" << ERR_reason_error_string(l);
+    }
+  }
+  return serr.str();
+}
+
+namespace {
+const char* const kEncryptionHeaderMagic = "pegsenc";
+const int kEncryptionHeaderMagicLength = 7;
+
+uint64_t GetBigEndian64(const unsigned char* src) {
+  if (port::kLittleEndian) {
+    return (static_cast<uint64_t>(src[0]) << 56) +
+           (static_cast<uint64_t>(src[1]) << 48) +
+           (static_cast<uint64_t>(src[2]) << 40) +
+           (static_cast<uint64_t>(src[3]) << 32) +
+           (static_cast<uint64_t>(src[4]) << 24) +
+           (static_cast<uint64_t>(src[5]) << 16) +
+           (static_cast<uint64_t>(src[6]) << 8) +
+           (static_cast<uint64_t>(src[7]));
+  } else {
+    return *(reinterpret_cast<const uint64_t*>(src));
+  }
+}
+
+void PutBigEndian64(uint64_t value, unsigned char* dst) {
+  if (port::kLittleEndian) {
+    dst[0] = static_cast<unsigned char>((value >> 56) & 0xff);
+    dst[1] = static_cast<unsigned char>((value >> 48) & 0xff);
+    dst[2] = static_cast<unsigned char>((value >> 40) & 0xff);
+    dst[3] = static_cast<unsigned char>((value >> 32) & 0xff);
+    dst[4] = static_cast<unsigned char>((value >> 24) & 0xff);
+    dst[5] = static_cast<unsigned char>((value >> 16) & 0xff);
+    dst[6] = static_cast<unsigned char>((value >> 8) & 0xff);
+    dst[7] = static_cast<unsigned char>(value & 0xff);
+  } else {
+    *(reinterpret_cast<uint64_t*>(dst)) = value;
+  }
+}
+
+Status GenerateFileKey(EncryptionMethod method, char* file_key) {
+  auto key_bytes = static_cast<int>(KeySize(method) / 8);
+  OPENSSL_RET_NOT_OK(
+      RAND_bytes(reinterpret_cast<unsigned char*>(file_key), key_bytes),
+      "Failed to generate random key");
+  return Status::OK();
+}
+
+// Use OpenSSL EVP API with CTR mode to encrypt and decrypt
+// data, instead of using the CTR implementation provided by
+// BlockAccessCipherStream. Benefits:
+//
+// 1. The EVP API automatically figure out if AES-NI can be enabled.
+// 2. Keep the data format consistent with OpenSSL (e.g. how IV is interpreted
+//    as block counter).
+//
+// References for the openssl EVP API:
+// * man page: https://www.openssl.org/docs/man1.1.1/man3/EVP_EncryptUpdate.html
+// * SO answer for random access: https://stackoverflow.com/a/57147140/11014942
+// * https://medium.com/@amit.kulkarni/encrypting-decrypting-a-file-using-openssl-evp-b26e0e4d28d4
+Status Cipher(const EncryptionMethod method, const std::string& key,
+              const uint64_t initial_iv_high, const uint64_t initial_iv_low,
+              uint64_t file_offset, char* data, size_t data_size,
+              AESCTRCipherStream::EncryptType encrypt_type) {
+#if OPENSSL_VERSION_NUMBER < 0x01000200f
+  (void)file_offset;
+  (void)data;
+  (void)data_size;
+  (void)encrypt_type;
+  return Status::NotSupported("OpenSSL version < 1.0.2");
+#else
+  evp_ctx_unique_ptr ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+  if (UNLIKELY(!ctx)) {
+    return Status::IOError("Failed to create cipher context.");
+  }
+
+  const size_t kBlockSize = BlockSize(method);
+  assert(kBlockSize > 0);
+
+  uint64_t block_index = file_offset / kBlockSize;
+  uint64_t block_offset = file_offset % kBlockSize;
+
+  // In CTR mode, OpenSSL EVP API treat the IV as a 128-bit big-endien, and
+  // increase it by 1 for each block.
+  //
+  // In case of unsigned integer overflow in c++, the result is moduloed by
+  // range, means only the lowest bits of the result will be kept.
+  // http://www.cplusplus.com/articles/DE18T05o/
+  uint64_t iv_high = initial_iv_high;
+  uint64_t iv_low = initial_iv_low + block_index;
+  if (std::numeric_limits<uint64_t>::max() - block_index < initial_iv_low) {
+    iv_high++;
+  }
+  unsigned char iv[kBlockSize];
+  PutBigEndian64(iv_high, iv);
+  PutBigEndian64(iv_low, iv + sizeof(uint64_t));
+
+  OPENSSL_RET_NOT_OK(
+      EVP_CipherInit(ctx.get(), GetEVPCipher(method),
+                     reinterpret_cast<const unsigned char*>(key.data()), iv,
+                     static_cast<int>(encrypt_type)),
+      "Failed to init cipher.");
+
+  // Disable padding. After disabling padding, data size should always be
+  // multiply of kBlockSize.
+  OPENSSL_RET_NOT_OK(EVP_CIPHER_CTX_set_padding(ctx.get(), 0),
+                     "Failed to disable padding for cipher context.");
+
+  uint64_t data_offset = 0;
+  size_t remaining_data_size = data_size;
+  int output_size = 0;
+  unsigned char partial_block[kBlockSize];
+
+  // In the following we assume EVP_CipherUpdate allow in and out buffer are
+  // the same, to save one memcpy. This is not specified in official man page.
+
+  // Handle partial block at the beginning. The partial block is copied to
+  // buffer to fake a full block.
+  if (block_offset > 0) {
+    size_t partial_block_size =
+        std::min<size_t>(kBlockSize - block_offset, remaining_data_size);
+    memcpy(partial_block + block_offset, data, partial_block_size);
+    OPENSSL_RET_NOT_OK(
+        EVP_CipherUpdate(ctx.get(), partial_block, &output_size, partial_block,
+                         static_cast<int>(kBlockSize)),
+        "Crypter failed for first block, offset " +
+            std::to_string(file_offset));
+    if (UNLIKELY(output_size != static_cast<int>(kBlockSize))) {
+      return Status::IOError(
+          "Unexpected crypter output size for first block, expected " +
+          std::to_string(kBlockSize) + " vs actual " +
+          std::to_string(output_size));
+    }
+    memcpy(data, partial_block + block_offset, partial_block_size);
+    data_offset += partial_block_size;
+    remaining_data_size -= partial_block_size;
+  }
+
+  // Handle full blocks in the middle.
+  if (remaining_data_size >= kBlockSize) {
+    size_t actual_data_size =
+        remaining_data_size - remaining_data_size % kBlockSize;
+    unsigned char* full_blocks =
+        reinterpret_cast<unsigned char*>(data) + data_offset;
+    OPENSSL_RET_NOT_OK(
+        EVP_CipherUpdate(ctx.get(), full_blocks, &output_size, full_blocks,
+                         static_cast<int>(actual_data_size)),
+        "Crypter failed at offset " +
+            std::to_string(file_offset + data_offset));
+    if (UNLIKELY(output_size != static_cast<int>(actual_data_size))) {
+      return Status::IOError("Unexpected crypter output size, expected " +
+                             std::to_string(actual_data_size) + " vs actual " +
+                             std::to_string(output_size));
+    }
+    data_offset += actual_data_size;
+    remaining_data_size -= actual_data_size;
+  }
+
+  // TODO(yingchun): Can we remove the end partial block handling if handling a
+  //  suitable adjusted partial block at the beginning and full blocks in the
+  //  middle?
+  // Handle partial block at the end. The partial block is copied to buffer to
+  // fake a full block.
+  if (remaining_data_size > 0) {
+    assert(remaining_data_size < kBlockSize);
+    memcpy(partial_block, data + data_offset, remaining_data_size);
+    OPENSSL_RET_NOT_OK(
+        EVP_CipherUpdate(ctx.get(), partial_block, &output_size, partial_block,
+                         static_cast<int>(kBlockSize)),
+        "Crypter failed for last block, offset " +
+            std::to_string(file_offset + data_offset));
+    if (UNLIKELY(output_size != static_cast<int>(kBlockSize))) {
+      return Status::IOError(
+          "Unexpected crypter output size for last block, expected " +
+          std::to_string(kBlockSize) + " vs actual " +
+          std::to_string(output_size));
+    }
+    memcpy(data + data_offset, partial_block, remaining_data_size);
+  }
+
+  // Since padding is disabled, and the cipher flow always passes a multiply
+  // of block size data while each EVP_CipherUpdate, there is no need to call
+  // EVP_CipherFinal_ex to finish the last block cipher.
+  // Reference to the implement of EVP_CipherFinal_ex:
+  // https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/evp/evp_enc.c#L219
+  return Status::OK();
+#endif
+}
+}  // anonymous namespace
+
+size_t AESCTRCipherStream::BlockSize() {
+  return ROCKSDB_NAMESPACE::encryption::BlockSize(method_);
+}
+
+Status AESCTRCipherStream::Cipher(uint64_t file_offset, char* data,
+                                  size_t data_size, EncryptType encrypt_type) {
+  return ROCKSDB_NAMESPACE::encryption::Cipher(
+      method_, file_key_, initial_iv_high_, initial_iv_low_, file_offset, data,
+      data_size, encrypt_type);
+}
+
+bool AESEncryptionProvider::IsInstanceOf(const std::string& name) const {
+  return EncryptionProvider::IsInstanceOf(name);
+}
+
+Status AESEncryptionProvider::ReadEncryptionHeader(
+    Slice prefix, FileEncryptionInfo* file_info) const {
+  // 1. Check the encryption header magic.
+  if (UNLIKELY(!prefix.starts_with(kEncryptionHeaderMagic))) {
+    return Status::Corruption("Invalid encryption header");
+  }
+
+  // 2. Read the encryption method.
+  auto method = EncryptionMethod(prefix[kEncryptionHeaderMagicLength]);
+  size_t key_size = KeySize(method);
+  if (UNLIKELY(key_size == 0)) {
+    return Status::Corruption("Unknown encryption algorithm " +
+                              std::to_string(static_cast<char>(method)));
+  }
+
+  // 3. Read the encrypted file key and decrypt it.
+  char encrypted_file_key[key_size];
+  memcpy(encrypted_file_key, prefix.data() + kEncryptionHeaderMagicLength + 1,
+         key_size);
+  Status s = Cipher(method_, instance_key_, 0, 0, 0, encrypted_file_key,
+                    key_size, AESCTRCipherStream::EncryptType::kDecrypt);
+  if (UNLIKELY(!s.ok())) {
+    return s;
+  }
+
+  // 4. Fill the FileEncryptionInfo.
+  file_info->method = method;
+  file_info->key.assign(encrypted_file_key, key_size);
+  // TODO(yingchun): write a real IV to header_buf.
+  static std::string fake_iv(AES_BLOCK_SIZE, '0');
+  file_info->iv = fake_iv;
+  return Status::OK();
+}
+
+Status AESEncryptionProvider::WriteEncryptionHeader(char* header_buf) const {
+  auto method = EncryptionMethod(method_);
+  size_t key_size = KeySize(method_);
+  assert(key_size != 0);
+
+  // 1. Write the encryption header magic.
+  size_t offset = 0;
+  memcpy(header_buf, kEncryptionHeaderMagic, kEncryptionHeaderMagicLength);
+  offset += kEncryptionHeaderMagicLength;
+
+  // 2. Write the encryption method.
+  header_buf[offset] = static_cast<char>(method_);
+  offset += 1;
+
+  // 3. Generate a file key, encrypt and write it.
+  char file_key[key_size];
+  Status s = GenerateFileKey(method, file_key);
+  if (UNLIKELY(!s.ok())) {
+    return s;
+  }
+  s = Cipher(method_, instance_key_, 0, 0, 0, file_key, key_size,
+             AESCTRCipherStream::EncryptType::kEncrypt);
+  if (UNLIKELY(!s.ok())) {
+    return s;
+  }
+  memcpy(header_buf + offset, file_key, key_size);
+  offset += key_size;
+
+  // 4. Pad with 0.
+  memset(header_buf + offset, 0, (64 - offset));
+
+  // TODO(yingchun): write IV to header_buf.
+  return Status::OK();
+}
+
+Status AESEncryptionProvider::CreateNewPrefix(const std::string& fname,
+                                              char* prefix,
+                                              size_t prefix_length) const {
+  if (prefix_length != GetPrefixLength()) {
+    return IOStatus::Corruption("CreateNewPrefix with invalid prefix length: " +
+                                std::to_string(prefix_length) + " for " +
+                                fname);
+  }
+  auto s = WriteEncryptionHeader(prefix);
+  if (!s.ok()) {
+    s = Status::CopyAppendMessage(s, " in ", fname);
+    return s;
+  }
+  return Status::OK();
+}
+
+Status AESEncryptionProvider::CreateCipherStream(
+    const std::string& fname, const EnvOptions& /*options*/, Slice& prefix,
+    std::unique_ptr<BlockAccessCipherStream>* result) {
+  assert(result != nullptr);
+  FileEncryptionInfo file_info;
+  Status s = ReadEncryptionHeader(prefix, &file_info);
+  if (!s.ok()) {
+    s = Status::CopyAppendMessage(s, " in ", fname);
+    return s;
+  }
+  std::unique_ptr<AESCTRCipherStream> cipher_stream;
+  s = NewAESCTRCipherStream(file_info.method, file_info.key, file_info.iv,
+                            &cipher_stream);
+  if (!s.ok()) {
+    s = Status::CopyAppendMessage(s, " in ", fname);
+    return s;
+  }
+  *result = std::move(cipher_stream);
+  return Status::OK();
+}
+
+Status NewAESCTRCipherStream(EncryptionMethod method,
+                             const std::string& file_key,
+                             const std::string& file_key_iv,
+                             std::unique_ptr<AESCTRCipherStream>* result) {
+  assert(result != nullptr);
+  if (file_key.size() != KeySize(method)) {
+    return Status::InvalidArgument(
+        "Encryption file_key size mismatch. " +
+        std::to_string(file_key.size()) + "(actual) vs. " +
+        std::to_string(KeySize(method)) + "(expected).");
+  }
+  // TODO(yingchun): check the correction of the fixed length block size
+  if (file_key_iv.size() != AES_BLOCK_SIZE) {
+    return Status::InvalidArgument(
+        "file_key_iv size not equal to block cipher block size: " +
+        std::to_string(file_key_iv.size()) + "(actual) vs. " +
+        std::to_string(AES_BLOCK_SIZE) + "(expected).");
+  }
+  uint64_t iv_high = GetBigEndian64(
+      reinterpret_cast<const unsigned char*>(file_key_iv.data()));
+  uint64_t iv_low = GetBigEndian64(reinterpret_cast<const unsigned char*>(
+      file_key_iv.data() + sizeof(uint64_t)));
+  result->reset(new AESCTRCipherStream(method, file_key, iv_high, iv_low));
+  return Status::OK();
+}
+
+}  // namespace encryption
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // OPENSSL
+#endif  // !ROCKSDB_LITE

--- a/encryption/encryption.h
+++ b/encryption/encryption.h
@@ -1,0 +1,156 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+#pragma once
+#ifndef ROCKSDB_LITE
+#ifdef OPENSSL
+#include <openssl/aes.h>
+#include <openssl/evp.h>
+
+#include <string>
+
+#include "encryption/encryption.h"
+#include "rocksdb/env_encryption.h"
+#include "util/string_util.h"
+
+namespace ROCKSDB_NAMESPACE {
+namespace encryption {
+class AESCTRCipherStream;
+
+using evp_ctx_unique_ptr =
+    std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>;
+
+// The encryption method supported.
+enum class EncryptionMethod : int {
+  kUnknown = 0,
+  kPlaintext = 1,
+  kAES128_CTR = 2,
+  kAES192_CTR = 3,
+  kAES256_CTR = 4,
+  // OpenSSL support SM4 after 1.1.1 release version.
+  kSM4_CTR = 5,
+};
+
+// Get the key size of the encryption method.
+size_t KeySize(EncryptionMethod method);
+
+// Get the block size of the encryption method.
+size_t BlockSize(EncryptionMethod method);
+
+// Get the encryption method from string, case-insensitive.
+EncryptionMethod EncryptionMethodStringToEnum(const std::string& method);
+
+// Get the OpenSSL EVP_CIPHER according to the encryption method.
+const EVP_CIPHER* GetEVPCipher(EncryptionMethod method);
+
+// Get the last OpenSSL error message.
+std::string GetOpenSSLErrors();
+
+// Convert an OpenSSL error to an IOError Status.
+#define OPENSSL_RET_NOT_OK(call, msg)                  \
+  if (UNLIKELY((call) <= 0)) {                         \
+    return Status::IOError((msg), GetOpenSSLErrors()); \
+  }
+
+Status NewAESCTRCipherStream(EncryptionMethod method,
+                             const std::string& file_key,
+                             const std::string& file_key_iv,
+                             std::unique_ptr<AESCTRCipherStream>* result);
+
+// The cipher stream for AES-CTR encryption.
+class AESCTRCipherStream : public BlockAccessCipherStream {
+ public:
+  AESCTRCipherStream(const EncryptionMethod method, const std::string& file_key,
+                     uint64_t iv_high, uint64_t iv_low)
+      : method_(method),
+        file_key_(file_key),
+        initial_iv_high_(iv_high),
+        initial_iv_low_(iv_low) {}
+
+  ~AESCTRCipherStream() = default;
+
+  size_t BlockSize() override;
+
+  enum class EncryptType : int { kDecrypt = 0, kEncrypt = 1 };
+
+  Status Encrypt(uint64_t file_offset, char* data, size_t data_size) override {
+    return Cipher(file_offset, data, data_size, EncryptType::kEncrypt);
+  }
+
+  Status Decrypt(uint64_t file_offset, char* data, size_t data_size) override {
+    return Cipher(file_offset, data, data_size, EncryptType::kDecrypt);
+  }
+
+ protected:
+  // Following methods required by BlockAccessCipherStream is unused.
+
+  void AllocateScratch(std::string& /*scratch*/) override {
+    // should not be called.
+    assert(false);
+  }
+
+  Status EncryptBlock(uint64_t /*block_index*/, char* /*data*/,
+                      char* /*scratch*/) override {
+    return Status::NotSupported("EncryptBlock should not be called.");
+  }
+
+  Status DecryptBlock(uint64_t /*block_index*/, char* /*data*/,
+                      char* /*scratch*/) override {
+    return Status::NotSupported("DecryptBlock should not be called.");
+  }
+
+ private:
+  Status Cipher(uint64_t file_offset, char* data, size_t data_size,
+                EncryptType encrypt_type);
+
+  const EncryptionMethod method_;
+  const std::string file_key_;
+  const uint64_t initial_iv_high_;
+  const uint64_t initial_iv_low_;
+};
+
+// TODO(yingchun): Is it possible to derive from CTREncryptionProvider?
+// The encryption provider for AES-CTR encryption.
+class AESEncryptionProvider : public EncryptionProvider {
+ public:
+  AESEncryptionProvider(std::string instance_key, EncryptionMethod method)
+      : instance_key_(std::move(instance_key)), method_(method) {}
+  virtual ~AESEncryptionProvider() = default;
+
+  static const char* kClassName() { return "AES"; }
+  const char* Name() const override { return kClassName(); }
+  bool IsInstanceOf(const std::string& name) const override;
+
+  size_t GetPrefixLength() const override { return kDefaultPageSize; }
+
+  Status CreateNewPrefix(const std::string& /*fname*/, char* prefix,
+                         size_t prefix_length) const override;
+
+  Status AddCipher(const std::string& /*descriptor*/, const char* /*cipher*/,
+                   size_t /*len*/, bool /*for_write*/) override {
+    return Status::NotSupported();
+  }
+
+  Status CreateCipherStream(
+      const std::string& fname, const EnvOptions& options, Slice& prefix,
+      std::unique_ptr<BlockAccessCipherStream>* result) override;
+
+ private:
+  struct FileEncryptionInfo {
+    EncryptionMethod method = EncryptionMethod::kUnknown;
+    std::string key;
+    std::string iv;  // TODO(yingchun): not used yet
+  };
+
+  Status WriteEncryptionHeader(char* header_buf) const;
+  Status ReadEncryptionHeader(Slice prefix,
+                              FileEncryptionInfo* file_info) const;
+
+  const std::string instance_key_;
+  const EncryptionMethod method_;
+};
+
+}  // namespace encryption
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // OPENSSL
+#endif  // !ROCKSDB_LITE

--- a/encryption/encryption_test.cc
+++ b/encryption/encryption_test.cc
@@ -1,0 +1,209 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+#include "encryption/encryption.h"
+
+#include <gtest/gtest.h>
+
+#include "fuzz/util.h"
+#include "port/stack_trace.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
+
+#ifndef ROCKSDB_LITE
+#ifdef OPENSSL
+
+namespace ROCKSDB_NAMESPACE {
+namespace encryption {
+
+// Make sure the length of KEY is larger than the max KeySize(EncryptionMethod).
+const unsigned char KEY[33] =
+    "\xe4\x3e\x8e\xca\x2a\x83\xe1\x88\xfb\xd8\x02\xdc\xf3\x62\x65\x3e"
+    "\x00\xee\x31\x39\xe7\xfd\x1d\x92\x20\xb1\x62\xae\xb2\xaf\x0f\x1a";
+
+// Make sure the length of IV_RANDOM, IV_OVERFLOW_LOW and IV_OVERFLOW_FULL is
+// larger than the max BlockSize(EncryptionMethod).
+const unsigned char IV_RANDOM[17] =
+    "\x77\x9b\x82\x72\x26\xb5\x76\x50\xf7\x05\xd2\xd6\xb8\xaa\xa9\x2c";
+const unsigned char IV_OVERFLOW_LOW[17] =
+    "\x77\x9b\x82\x72\x26\xb5\x76\x50\xff\xff\xff\xff\xff\xff\xff\xff";
+const unsigned char IV_OVERFLOW_FULL[17] =
+    "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff";
+
+TEST(EncryptionTest, KeySize) {
+  ASSERT_EQ(16, KeySize(EncryptionMethod::kAES128_CTR));
+  ASSERT_EQ(24, KeySize(EncryptionMethod::kAES192_CTR));
+  ASSERT_EQ(32, KeySize(EncryptionMethod::kAES256_CTR));
+  ASSERT_EQ(16, KeySize(EncryptionMethod::kSM4_CTR));
+  ASSERT_EQ(0, KeySize(EncryptionMethod::kUnknown));
+}
+
+TEST(EncryptionTest, BlockSize) {
+  ASSERT_EQ(16, BlockSize(EncryptionMethod::kAES128_CTR));
+  ASSERT_EQ(16, BlockSize(EncryptionMethod::kAES192_CTR));
+  ASSERT_EQ(16, BlockSize(EncryptionMethod::kAES256_CTR));
+  ASSERT_EQ(16, BlockSize(EncryptionMethod::kSM4_CTR));
+  ASSERT_EQ(0, BlockSize(EncryptionMethod::kUnknown));
+}
+
+TEST(EncryptionTest, EncryptionMethodStringToEnum) {
+  ASSERT_EQ(EncryptionMethod::kAES128_CTR,
+            EncryptionMethodStringToEnum("AES128CTR"));
+  ASSERT_EQ(EncryptionMethod::kAES192_CTR,
+            EncryptionMethodStringToEnum("AES192CTR"));
+  ASSERT_EQ(EncryptionMethod::kAES256_CTR,
+            EncryptionMethodStringToEnum("AES256CTR"));
+  ASSERT_EQ(EncryptionMethod::kSM4_CTR, EncryptionMethodStringToEnum("SM4CTR"));
+  ASSERT_EQ(EncryptionMethod::kUnknown,
+            EncryptionMethodStringToEnum("unknown"));
+}
+
+// Test to make sure output of AESCTRCipherStream is the same as output from
+// OpenSSL EVP API.
+class EncryptionTest
+    : public testing::TestWithParam<
+          std::tuple<AESCTRCipherStream::EncryptType, EncryptionMethod>> {
+ public:
+  int kMaxSize;
+  std::unique_ptr<unsigned char[]> plaintext;
+  std::unique_ptr<unsigned char[]> ciphertext;
+  const unsigned char* current_iv = nullptr;
+
+  EncryptionTest() : kMaxSize(10 * BlockSize(std::get<1>(GetParam()))) {
+    CHECK_OK(ReGenerateCiphertext(IV_RANDOM));
+  }
+
+  Status ReGenerateCiphertext(const unsigned char* iv) {
+    current_iv = iv;
+
+    Random rnd(test::RandomSeed());
+    std::string random_string =
+        rnd.HumanReadableString(static_cast<int>(kMaxSize));
+    plaintext.reset(new unsigned char[kMaxSize]);
+    memcpy(plaintext.get(), random_string.data(), kMaxSize);
+
+    evp_ctx_unique_ptr ctx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free);
+    CHECK_TRUE(ctx);
+
+    EncryptionMethod method = std::get<1>(GetParam());
+    const EVP_CIPHER* cipher = GetEVPCipher(method);
+    CHECK_TRUE(cipher != nullptr);
+
+    OPENSSL_RET_NOT_OK(EVP_EncryptInit(ctx.get(), cipher, KEY, current_iv),
+                       "EVP_EncryptInit failed.");
+    int output_size = 0;
+    ciphertext.reset(new unsigned char[kMaxSize]);
+    OPENSSL_RET_NOT_OK(
+        EVP_EncryptUpdate(ctx.get(), ciphertext.get(), &output_size,
+                          plaintext.get(), static_cast<int>(kMaxSize)),
+        "EVP_EncryptUpdate failed.");
+    int final_output_size = 0;
+    OPENSSL_RET_NOT_OK(
+        EVP_EncryptFinal(ctx.get(), ciphertext.get() + output_size,
+                         &final_output_size),
+        "EVP_EncryptFinal failed.");
+    CHECK_EQ(kMaxSize, output_size + final_output_size);
+    return Status::OK();
+  }
+
+  void TestEncryption(size_t start, size_t end) {
+    ASSERT_LT(start, end);
+    ASSERT_LE(end, kMaxSize);
+
+    EncryptionMethod method = std::get<1>(GetParam());
+    std::string key_str(reinterpret_cast<const char*>(KEY), KeySize(method));
+    std::string iv_str(reinterpret_cast<const char*>(current_iv),
+                       BlockSize(method));
+    std::unique_ptr<AESCTRCipherStream> cipher_stream;
+    ASSERT_OK(NewAESCTRCipherStream(method, key_str, iv_str, &cipher_stream));
+    ASSERT_TRUE(cipher_stream);
+
+    size_t data_size = end - start;
+    // Allocate exact size. AESCTRCipherStream should make sure there will be
+    // no memory corruption.
+    std::unique_ptr<char[]> data(new char[data_size]);
+
+    if (std::get<0>(GetParam()) == AESCTRCipherStream::EncryptType::kEncrypt) {
+      memcpy(data.get(), plaintext.get() + start, data_size);
+      ASSERT_OK(cipher_stream->Encrypt(start, data.get(), data_size));
+      ASSERT_EQ(0, memcmp(ciphertext.get() + start, data.get(), data_size));
+    } else {
+      ASSERT_EQ(AESCTRCipherStream::EncryptType::kDecrypt,
+                std::get<0>(GetParam()));
+      memcpy(data.get(), ciphertext.get() + start, data_size);
+      ASSERT_OK(cipher_stream->Decrypt(start, data.get(), data_size));
+      ASSERT_EQ(0, memcmp(plaintext.get() + start, data.get(), data_size));
+    }
+  }
+};
+
+TEST_P(EncryptionTest, AESCTRCipherStreamTest) {
+  const size_t kBlockSize = BlockSize(std::get<1>(GetParam()));
+  // TODO(yingchun): The following tests are based on the fact that the
+  //  kBlockSize is 16, make sure they work if adding new encryption methods.
+  ASSERT_EQ(kBlockSize, 16);
+
+  // One full block.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(0, kBlockSize));
+  // One block in the middle.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize * 5, kBlockSize * 6));
+  // Multiple aligned blocks.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize * 5, kBlockSize * 8));
+
+  // Random byte at the beginning of a block.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize * 5, kBlockSize * 5 + 1));
+  // Random byte in the middle of a block.
+  ASSERT_NO_FATAL_FAILURE(
+      TestEncryption(kBlockSize * 5 + 4, kBlockSize * 5 + 5));
+  // Random byte at the end of a block.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize * 5 + 15, kBlockSize * 6));
+
+  // Partial block aligned at the beginning.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize * 5, kBlockSize * 5 + 15));
+  // Partial block aligned at the end.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize * 5 + 1, kBlockSize * 6));
+  // Multiple blocks with a partial block at the end.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize * 5, kBlockSize * 8 + 15));
+  // Multiple blocks with a partial block at the beginning.
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize * 5 + 1, kBlockSize * 8));
+  // Partial block at both ends.
+  ASSERT_NO_FATAL_FAILURE(
+      TestEncryption(kBlockSize * 5 + 1, kBlockSize * 8 + 15));
+
+  // Lower bits of IV overflow.
+  ASSERT_OK(ReGenerateCiphertext(IV_OVERFLOW_LOW));
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize, kBlockSize * 2));
+  // Full IV overflow.
+  ASSERT_OK(ReGenerateCiphertext(IV_OVERFLOW_FULL));
+  ASSERT_NO_FATAL_FAILURE(TestEncryption(kBlockSize, kBlockSize * 2));
+}
+
+// Openssl support SM4 after 1.1.1 release version.
+#if OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4)
+INSTANTIATE_TEST_CASE_P(
+    EncryptionTestInstance, EncryptionTest,
+    testing::Combine(testing::Bool(),
+                     testing::Values(EncryptionMethod::kAES128_CTR,
+                                     EncryptionMethod::kAES192_CTR,
+                                     EncryptionMethod::kAES256_CTR)));
+#else
+INSTANTIATE_TEST_CASE_P(
+    EncryptionTestInstance, EncryptionTest,
+    testing::Combine(testing::Values(AESCTRCipherStream::EncryptType::kEncrypt,
+                                     AESCTRCipherStream::EncryptType::kDecrypt),
+                     testing::Values(EncryptionMethod::kAES128_CTR,
+                                     EncryptionMethod::kAES192_CTR,
+                                     EncryptionMethod::kAES256_CTR,
+                                     EncryptionMethod::kSM4_CTR)));
+#endif
+
+}  // namespace encryption
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // OPENSSL
+#endif  // !ROCKSDB_LITE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/env/env_encryption_ctr.h
+++ b/env/env_encryption_ctr.h
@@ -9,8 +9,8 @@
 #include "rocksdb/env_encryption.h"
 
 namespace ROCKSDB_NAMESPACE {
-// CTRCipherStream implements BlockAccessCipherStream using an
-// Counter operations mode.
+// CTRCipherStream implements BlockAccessCipherStream using a
+// Counter operation mode.
 // See https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation
 //
 // Note: This is a possible implementation of BlockAccessCipherStream,

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -279,6 +279,7 @@ class Env : public Customizable {
                                    std::unique_ptr<WritableFile>* result,
                                    const EnvOptions& options);
 
+  // TODO(yingchun): it's not true, it will not create a file when not exists.
   // Open `fname` for random read and write, if file doesn't exist the file
   // will be created.  On success, stores a pointer to the new file in
   // *result and returns OK.  On failure returns non-OK.

--- a/src.mk
+++ b/src.mk
@@ -100,6 +100,7 @@ LIB_SOURCES =                                                   \
   db/write_controller.cc                                        \
   db/write_stall_stats.cc                                       \
   db/write_thread.cc                                            \
+  encryption/encryption.cc                                      \
   env/composite_env.cc                                          \
   env/env.cc                                                    \
   env/env_chroot.cc                                             \


### PR DESCRIPTION
This patch is inspired by https://github.com/tikv/rocksdb.

Different from the implementation of tikv/rocksdb, this patch changes to manage the `file key` by the file itself.
Overall, this patch includes the following changes:
- Introduces OpenSSL for data encryption
- Supports AES of 128/192/256 bits length key size and SM4 (128 bits length key size) encryption algorithm
- Uses CTR mode