### PR TITLE
Update the API comments of NewRandomRWFile()

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -280,7 +280,7 @@ class Env : public Customizable {
                                    const EnvOptions& options);
 
   // Open `fname` for random read and write, if file doesn't exist the file
-  // will be created.  On success, stores a pointer to the new file in
+  // will not be created.  On success, stores a pointer to the new file in
   // *result and returns OK.  On failure returns non-OK.
   //
   // The returned file will only be accessed by one thread at a time.

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -390,7 +390,7 @@ class FileSystem : public Customizable {
                                      IODebugContext* dbg);
 
   // Open `fname` for random read and write, if file doesn't exist the file
-  // will be created.  On success, stores a pointer to the new file in
+  // will not be created.  On success, stores a pointer to the new file in
   // *result and returns OK.  On failure returns non-OK.
   //
   // The returned file will only be accessed by one thread at a time.


### PR DESCRIPTION
Env::NewRandomRWFile() will not create the file if it doesn't exist, as the test saying https://github.com/facebook/rocksdb/blob/main/env/env_test.cc#L2208.
This patch correct the comments of Env::NewRandomRWFile(), it may mislead the developers who use rocksdb Env() as an utility.