### PR TITLE
Add a helper method WideColumnsHelper::SortColumns

### DIFF
--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -14,6 +14,7 @@
 #include "db/blob/prefetch_buffer_collection.h"
 #include "db/snapshot_checker.h"
 #include "db/wide/wide_column_serialization.h"
+#include "db/wide/wide_columns_helper.h"
 #include "logging/logging.h"
 #include "port/likely.h"
 #include "rocksdb/listener.h"
@@ -423,16 +424,13 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
     return false;
   } else if (decision == CompactionFilter::Decision::kChangeWideColumnEntity) {
     WideColumns sorted_columns;
-
     sorted_columns.reserve(new_columns.size());
+
     for (const auto& column : new_columns) {
       sorted_columns.emplace_back(column.first, column.second);
     }
 
-    std::sort(sorted_columns.begin(), sorted_columns.end(),
-              [](const WideColumn& lhs, const WideColumn& rhs) {
-                return lhs.name().compare(rhs.name()) < 0;
-              });
+    WideColumnsHelper::SortColumns(sorted_columns);
 
     {
       const Status s = WideColumnSerialization::Serialize(

--- a/db/wide/wide_columns_helper.cc
+++ b/db/wide/wide_columns_helper.cc
@@ -5,6 +5,8 @@
 
 #include "db/wide/wide_columns_helper.h"
 
+#include <algorithm>
+
 #include "db/wide/wide_column_serialization.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -22,6 +24,7 @@ void WideColumnsHelper::DumpWideColumns(const WideColumns& columns,
     os << ' ' << *it;
   }
 }
+
 Status WideColumnsHelper::DumpSliceAsWideColumns(const Slice& value,
                                                  std::ostream& os, bool hex) {
   WideColumns columns;
@@ -31,6 +34,13 @@ Status WideColumnsHelper::DumpSliceAsWideColumns(const Slice& value,
     DumpWideColumns(columns, os, hex);
   }
   return s;
+}
+
+void WideColumnsHelper::SortColumns(WideColumns& columns) {
+  std::sort(columns.begin(), columns.end(),
+            [](const WideColumn& lhs, const WideColumn& rhs) {
+              return lhs.name().compare(rhs.name()) < 0;
+            });
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/wide/wide_columns_helper.h
+++ b/db/wide/wide_columns_helper.h
@@ -28,6 +28,8 @@ class WideColumnsHelper {
     assert(HasDefaultColumn(columns));
     return columns.front().value();
   }
+
+  static void SortColumns(WideColumns& columns);
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -57,6 +57,7 @@
 #include "db/snapshot_impl.h"
 #include "db/trim_history_scheduler.h"
 #include "db/wide/wide_column_serialization.h"
+#include "db/wide/wide_columns_helper.h"
 #include "db/write_batch_internal.h"
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics_impl.h"
@@ -948,10 +949,7 @@ Status WriteBatchInternal::PutEntity(WriteBatch* b, uint32_t column_family_id,
   }
 
   WideColumns sorted_columns(columns);
-  std::sort(sorted_columns.begin(), sorted_columns.end(),
-            [](const WideColumn& lhs, const WideColumn& rhs) {
-              return lhs.name().compare(rhs.name()) < 0;
-            });
+  WideColumnsHelper::SortColumns(sorted_columns);
 
   std::string entity;
   const Status s = WideColumnSerialization::Serialize(sorted_columns, entity);

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -270,10 +270,7 @@ WideColumns GenerateExpectedWideColumns(uint32_t value_base,
 
   WideColumns columns = GenerateWideColumns(value_base, slice);
 
-  std::sort(columns.begin(), columns.end(),
-            [](const WideColumn& lhs, const WideColumn& rhs) {
-              return lhs.name().compare(rhs.name()) < 0;
-            });
+  WideColumnsHelper::SortColumns(columns);
 
   return columns;
 }

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -10,6 +10,7 @@
 #include "db/db_impl/db_impl.h"
 #include "db/dbformat.h"
 #include "db/wide/wide_column_serialization.h"
+#include "db/wide/wide_columns_helper.h"
 #include "file/writable_file_writer.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/table.h"
@@ -134,10 +135,7 @@ struct SstFileWriter::Rep {
 
   Status AddEntity(const Slice& user_key, const WideColumns& columns) {
     WideColumns sorted_columns(columns);
-    std::sort(sorted_columns.begin(), sorted_columns.end(),
-              [](const WideColumn& lhs, const WideColumn& rhs) {
-                return lhs.name().compare(rhs.name()) < 0;
-              });
+    WideColumnsHelper::SortColumns(sorted_columns);
 
     std::string entity;
     const Status s = WideColumnSerialization::Serialize(sorted_columns, entity);


### PR DESCRIPTION
Summary: Similarly to https://github.com/facebook/rocksdb/pull/11813, the patch is a small refactoring that eliminates some copy-paste around sorting the columns of entities by column name.

Differential Revision: D49195504


