### PR TITLE
Fix unit test tsan failure

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3541,7 +3541,7 @@ TEST_P(DBCompactionWaitForCompactTest,
       "DBImpl::BackgroundCompaction:Finish",
       [&](void*) { compaction_finished++; });
 
-  int flush_finished = 0;
+  std::atomic_int flush_finished = 0;
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "FlushJob::End", [&](void*) { flush_finished++; });
 

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3536,7 +3536,7 @@ TEST_P(DBCompactionWaitForCompactTest,
   // (has_unpersisted_data_ true) Check to make sure there's no extra L0 file
   // created from WAL. Re-opening DB won't trigger any flush or compaction
 
-  int compaction_finished = 0;
+  std::atomic_int compaction_finished = 0;
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:Finish",
       [&](void*) { compaction_finished++; });


### PR DESCRIPTION
The test DBCompactionWaitForCompactTest.WaitForCompactWithOptionToFlushAndCloseDB failed tsan in https://app.circleci.com/pipelines/github/facebook/rocksdb/32009/workflows/577e4e1f-a909-4e80-8ef4-af98b5ff7446/jobs/660989. I cannot repro locally, but this should be the fix.

Test plan:
`./db_compaction_test --gtest_filter="*DBCompactionWaitForCompactTest/DBCompactionWaitForCompactTest.*"`