### PR TITLE
Inject retryable write IOError when writing to SST files in stress test

### DIFF
--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -81,11 +81,29 @@ bool RunStressTestImpl(SharedState* shared) {
   stress->InitDb(shared);
   stress->FinishInitDb(shared);
 
+  if (FLAGS_write_fault_one_in) {
+    if (!FLAGS_sync_fault_injection) {
+      // unsynced WAL loss is not supported without sync_fault_injection
+      fault_fs_guard->SetSkipDirectWritableTypes({kWalFile});
+    }
+    IOStatus error_msg;
+    if (FLAGS_inject_error_severity <= 1 || FLAGS_inject_error_severity > 2) {
+      error_msg = IOStatus::IOError("Retryable injected write error");
+      error_msg.SetRetryable(true);
+    } else if (FLAGS_inject_error_severity == 2) {
+      error_msg = IOStatus::IOError("Fatal injected write error");
+      error_msg.SetDataLoss(true);
+    }
+    // TODO: inject write error for other file types including
+    //  MANIFEST, CURRENT, and WAL files.
+    fault_fs_guard->SetRandomWriteError(
+        shared->GetSeed(), FLAGS_write_fault_one_in, error_msg,
+        /*inject_for_all_file_types=*/false, {FileType::kTableFile});
+    fault_fs_guard->SetFilesystemDirectWritable(false);
+    fault_fs_guard->EnableWriteErrorInjection();
+  }
   if (FLAGS_sync_fault_injection) {
     fault_fs_guard->SetFilesystemDirectWritable(false);
-  }
-  if (FLAGS_write_fault_one_in) {
-    fault_fs_guard->EnableWriteErrorInjection();
   }
 
   uint32_t n = FLAGS_threads;

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -84,7 +84,7 @@ bool RunStressTestImpl(SharedState* shared) {
   if (FLAGS_write_fault_one_in) {
     if (!FLAGS_sync_fault_injection) {
       // unsynced WAL loss is not supported without sync_fault_injection
-      fault_fs_guard->SetSkipDirectWritableTypes({kWalFile});
+      fault_fs_guard->SetDirectWritableTypes({kWalFile});
     }
     IOStatus error_msg;
     if (FLAGS_inject_error_severity <= 1 || FLAGS_inject_error_severity > 2) {

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1007,7 +1007,8 @@ DEFINE_string(file_checksum_impl, "none",
               "\"none\" for null.");
 
 DEFINE_int32(write_fault_one_in, 0,
-             "On non-zero, enables fault injection on write");
+             "On non-zero, enables fault injection on write. Currently only"
+             "injects write error when writing to SST files.");
 
 DEFINE_uint64(user_timestamp_size, 0,
               "Number of bytes for a user-defined timestamp. Currently, only "

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2713,7 +2713,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           // WAL is durable. Buffering unsynced writes will cause false
           // positive in crash tests. Before we figure out a way to
           // solve it, skip WAL from failure injection.
-          fault_fs_guard->SetSkipDirectWritableTypes({kWalFile});
+          fault_fs_guard->SetDirectWritableTypes({kWalFile});
         }
         inject_meta_error = FLAGS_open_metadata_write_fault_one_in;
         inject_write_error = FLAGS_open_write_fault_one_in;
@@ -2769,7 +2769,7 @@ void StressTest::Open(SharedState* shared, bool reopen) {
           fault_fs_guard->SetFilesystemDirectWritable(true);
           fault_fs_guard->DisableMetadataWriteErrorInjection();
           fault_fs_guard->DisableWriteErrorInjection();
-          fault_fs_guard->SetSkipDirectWritableTypes({});
+          fault_fs_guard->SetDirectWritableTypes({});
           fault_fs_guard->SetRandomReadError(0);
           if (s.ok()) {
             // Injected errors might happen in background compactions. We

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -88,11 +88,6 @@ int db_stress_tool(int argc, char** argv) {
     FaultInjectionTestFS* fs =
         new FaultInjectionTestFS(raw_env->GetFileSystem());
     fault_fs_guard.reset(fs);
-    if (FLAGS_write_fault_one_in) {
-      fault_fs_guard->SetFilesystemDirectWritable(false);
-    } else {
-      fault_fs_guard->SetFilesystemDirectWritable(true);
-    }
     fault_env_guard =
         std::make_shared<CompositeEnvWrapper>(raw_env, fault_fs_guard);
     raw_env = fault_env_guard.get();

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1568,11 +1568,13 @@ class NonBatchedOpsStressTest : public StressTest {
     }
     if (!s.ok()) {
       fprintf(stderr, "file ingestion error: %s\n", s.ToString().c_str());
-      thread->shared->SafeTerminate();
-    }
-
-    for (size_t i = 0; i < pending_expected_values.size(); ++i) {
-      pending_expected_values[i].Commit();
+      if (!s.IsIOError() || !std::strstr(s.getState(), "injected")) {
+        thread->shared->SafeTerminate();
+      }
+    } else {
+      for (size_t i = 0; i < pending_expected_values.size(); ++i) {
+        pending_expected_values[i].Commit();
+      }
     }
   }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -179,6 +179,7 @@ default_params = {
     "max_key_len": 3,
     "key_len_percent_dist": "1,30,69",
     "read_fault_one_in": lambda: random.choice([0, 32, 1000]),
+    "write_fault_one_in": lambda: random.choice([0, 500]),
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
     "open_read_fault_one_in": lambda: random.choice([0, 0, 32]),
@@ -374,6 +375,10 @@ cf_consistency_params = {
     # use small value for write_buffer_size so that RocksDB triggers flush
     # more frequently
     "write_buffer_size": 1024 * 1024,
+    # Small write buffer size with more frequent flush has a higher chance
+    # of hitting write error. DB may be stopped if memtable fills up during
+    # auto resume.
+    "write_fault_one_in": 0,
     "enable_pipelined_write": lambda: random.randint(0, 1),
     # Snapshots are used heavily in this test mode, while they are incompatible
     # with compaction filter.
@@ -506,6 +511,9 @@ multiops_txn_default_params = {
     "enable_compaction_filter": 0,
     "create_timestamped_snapshot_one_in": 50,
     "sync_fault_injection": 0,
+    # This test has aggressive flush frequency and small write buffer size.
+    # Disabling write fault to avoid writes being stopped.
+    "write_fault_one_in": 0,
     # PutEntity in transactions is not yet implemented
     "use_put_entity_one_in": 0,
     "use_get_entity": 0,
@@ -671,7 +679,9 @@ def finalize_and_sanitize(src_params):
         dest_params["use_full_merge_v1"] = 0
     if dest_params["file_checksum_impl"] == "none":
         dest_params["verify_file_checksums_one_in"] = 0
-
+    if dest_params["write_fault_one_in"] > 0:
+        # background work may be disabled while DB is resuming after some error
+        dest_params["max_write_buffer_number"] = max(dest_params["max_write_buffer_number"], 6)
     return dest_params
 
 

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -323,8 +323,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     if (!TryParseFileName(file_name, &file_number, &file_type)) {
       return false;
     }
-    return skip_direct_writable_types_.find(file_type) !=
-           skip_direct_writable_types_.end();
+    return direct_writable_types_.find(file_type) !=
+           direct_writable_types_.end();
   }
   void SetFilesystemActiveNoLock(
       bool active, IOStatus error = IOStatus::Corruption("Not active")) {
@@ -439,9 +439,9 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     write_error_allowed_types_ = types;
   }
 
-  void SetSkipDirectWritableTypes(const std::set<FileType>& types) {
+  void SetDirectWritableTypes(const std::set<FileType>& types) {
     MutexLock l(&mutex_);
-    skip_direct_writable_types_ = types;
+    direct_writable_types_ = types;
   }
 
   void SetRandomMetadataWriteError(int one_in) {
@@ -583,7 +583,7 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   bool inject_for_all_file_types_;
   std::vector<FileType> write_error_allowed_types_;
   // File types where direct writable is skipped.
-  std::set<FileType> skip_direct_writable_types_;
+  std::set<FileType> direct_writable_types_;
   bool ingest_data_corruption_before_write_;
   ChecksumType checksum_handoff_func_tpye_;
   bool fail_get_file_unique_id_;


### PR DESCRIPTION
* db_crashtest.py now may set `write_fault_one_in` to 500 for blackbox and whitebox simple test.
* Error injection only applies to writing to SST files. Flush error will cause DB to pause background operations and auto-resume. Compaction error will just re-schedule later.
* File ingestion and back up tests are updated to check if the result status is due to an injected error.

Test plan: a full round of whitebox simple and blackbox simple crash test
*  `python3 ./tools/db_crashtest.py whitebox/blackbox --simple  --write_fault_one_in=500`