### PR TITLE
Fix a bug in multiget for cleaning up SuperVersion 

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2522,6 +2522,7 @@ std::vector<Status> DBImpl::MultiGet(
     if (!unref_only) {
       ReturnAndCleanupSuperVersion(mgd.cfd, mgd.super_version);
     } else {
+      TEST_SYNC_POINT("DBImpl::MultiGet::BeforeLastTryUnRefSV");
       mgd.cfd->GetSuperVersion()->Unref();
     }
   }
@@ -2677,6 +2678,7 @@ Status DBImpl::MultiCFSnapshot(
       if (!retry) {
         if (last_try) {
           mutex_.Unlock();
+          TEST_SYNC_POINT("DBImpl::MultiGet::AfterLastTryRefSV");
         }
         break;
       }
@@ -2867,6 +2869,7 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
     if (!unref_only) {
       ReturnAndCleanupSuperVersion(iter.cfd, iter.super_version);
     } else {
+      TEST_SYNC_POINT("DBImpl::MultiGet::BeforeLastTryUnRefSV");
       iter.cfd->GetSuperVersion()->Unref();
     }
   }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2393,11 +2393,11 @@ std::vector<Status> DBImpl::MultiGet(
                  cf_iter) { return &cf_iter->second; };
 
   SequenceNumber consistent_seqnum;
-  bool unref_only;
+  bool sv_from_thread_local;
   Status status =
       MultiCFSnapshot<UnorderedMap<uint32_t, MultiGetColumnFamilyData>>(
           read_options, nullptr, iter_deref_lambda, &multiget_cf_data,
-          &consistent_seqnum, &unref_only);
+          &consistent_seqnum, &sv_from_thread_local);
 
   if (!status.ok()) {
     for (auto& s : stat_list) {
@@ -2519,11 +2519,11 @@ std::vector<Status> DBImpl::MultiGet(
 
   for (auto mgd_iter : multiget_cf_data) {
     auto mgd = mgd_iter.second;
-    if (!unref_only) {
+    if (sv_from_thread_local) {
       ReturnAndCleanupSuperVersion(mgd.cfd, mgd.super_version);
     } else {
       TEST_SYNC_POINT("DBImpl::MultiGet::BeforeLastTryUnRefSV");
-      mgd.cfd->GetSuperVersion()->Unref();
+      CleanupSuperVersion(mgd.super_version);
     }
   }
   RecordTick(stats_, NUMBER_MULTIGET_CALLS);
@@ -2542,16 +2542,16 @@ Status DBImpl::MultiCFSnapshot(
     const ReadOptions& read_options, ReadCallback* callback,
     std::function<MultiGetColumnFamilyData*(typename T::iterator&)>&
         iter_deref_func,
-    T* cf_list, SequenceNumber* snapshot, bool* unref_only) {
+    T* cf_list, SequenceNumber* snapshot, bool* sv_from_thread_local) {
   PERF_TIMER_GUARD(get_snapshot_time);
 
-  assert(unref_only);
-  *unref_only = false;
+  assert(sv_from_thread_local);
+  *sv_from_thread_local = true;
   Status s = Status::OK();
   const bool check_read_ts =
       read_options.timestamp && read_options.timestamp->size() > 0;
-  // unref_only set to true means the SuperVersion to be cleaned up is acquired
-  // directly via ColumnFamilyData instead of thread local.
+  // sv_from_thread_local set to false means the SuperVersion to be cleaned up
+  // is acquired directly via ColumnFamilyData instead of thread local.
   const auto sv_cleanup_func = [&]() -> void {
     for (auto cf_iter = cf_list->begin(); cf_iter != cf_list->end();
          ++cf_iter) {
@@ -2559,10 +2559,10 @@ Status DBImpl::MultiCFSnapshot(
       SuperVersion* super_version = node->super_version;
       ColumnFamilyData* cfd = node->cfd;
       if (super_version != nullptr) {
-        if (*unref_only) {
-          super_version->Unref();
-        } else {
+        if (*sv_from_thread_local) {
           ReturnAndCleanupSuperVersion(cfd, super_version);
+        } else {
+          CleanupSuperVersion(super_version);
         }
       }
       node->super_version = nullptr;
@@ -2687,7 +2687,7 @@ Status DBImpl::MultiCFSnapshot(
 
   // Keep track of bytes that we read for statistics-recording later
   PERF_TIMER_STOP(get_snapshot_time);
-  *unref_only = last_try;
+  *sv_from_thread_local = !last_try;
   if (!s.ok()) {
     sv_cleanup_func();
   }
@@ -2824,11 +2824,11 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
           };
 
   SequenceNumber consistent_seqnum;
-  bool unref_only;
+  bool sv_from_thread_local;
   Status s = MultiCFSnapshot<
       autovector<MultiGetColumnFamilyData, MultiGetContext::MAX_BATCH_SIZE>>(
       read_options, nullptr, iter_deref_lambda, &multiget_cf_data,
-      &consistent_seqnum, &unref_only);
+      &consistent_seqnum, &sv_from_thread_local);
 
   if (!s.ok()) {
     for (size_t i = 0; i < num_keys; ++i) {
@@ -2866,11 +2866,11 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
   }
 
   for (const auto& iter : multiget_cf_data) {
-    if (!unref_only) {
+    if (sv_from_thread_local) {
       ReturnAndCleanupSuperVersion(iter.cfd, iter.super_version);
     } else {
       TEST_SYNC_POINT("DBImpl::MultiGet::BeforeLastTryUnRefSV");
-      iter.cfd->GetSuperVersion()->Unref();
+      CleanupSuperVersion(iter.super_version);
     }
   }
 }
@@ -3022,18 +3022,18 @@ void DBImpl::MultiGetWithCallback(
 
   size_t num_keys = sorted_keys->size();
   SequenceNumber consistent_seqnum;
-  bool unref_only;
+  bool sv_from_thread_local;
   Status s = MultiCFSnapshot<std::array<MultiGetColumnFamilyData, 1>>(
       read_options, callback, iter_deref_lambda, &multiget_cf_data,
-      &consistent_seqnum, &unref_only);
+      &consistent_seqnum, &sv_from_thread_local);
   if (!s.ok()) {
     return;
   }
 #ifndef NDEBUG
-  assert(!unref_only);
+  assert(sv_from_thread_local);
 #else
   // Silence unused variable warning
-  (void)unref_only;
+  (void)sv_from_thread_local;
 #endif  // NDEBUG
 
   if (callback && read_options.snapshot == nullptr) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2322,8 +2322,8 @@ class DBImpl : public DB {
   // If callback is non-null, the callback is refreshed with the snapshot
   // sequence number
   //
-  // `sv_from_thread_local` being set to false indicates that the SuperVersions
-  // obtained from the ColumnFamilyData, whereas false indicates they are thread
+  // `sv_from_thread_local` being set to false indicates that the SuperVersion
+  // obtained from the ColumnFamilyData, whereas true indicates they are thread
   // local.
   // A non-OK status will be returned if for a column family that enables
   // user-defined timestamp feature, the specified `ReadOptions.timestamp`

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2322,7 +2322,7 @@ class DBImpl : public DB {
   // If callback is non-null, the callback is refreshed with the snapshot
   // sequence number
   //
-  // `unref_only` being set to true indicates that the SuperVersions were
+  // `sv_from_thread_local` being set to false indicates that the SuperVersions
   // obtained from the ColumnFamilyData, whereas false indicates they are thread
   // local.
   // A non-OK status will be returned if for a column family that enables
@@ -2333,7 +2333,7 @@ class DBImpl : public DB {
       const ReadOptions& read_options, ReadCallback* callback,
       std::function<MultiGetColumnFamilyData*(typename T::iterator&)>&
           iter_deref_func,
-      T* cf_list, SequenceNumber* snapshot, bool* unref_only);
+      T* cf_list, SequenceNumber* snapshot, bool* sv_from_thread_local);
 
   // The actual implementation of the batching MultiGet. The caller is expected
   // to have acquired the SuperVersion and pass in a snapshot sequence number

--- a/unreleased_history/bug_fixes/fix_multiget_sv_cleanup.md
+++ b/unreleased_history/bug_fixes/fix_multiget_sv_cleanup.md
@@ -1,0 +1,1 @@
+Fixed a bug in `MultiGet` for cleaning up SuperVersion acquired with locking db mutex.


### PR DESCRIPTION
When `MultiGet` acquires `SuperVersion` via locking the db mutex and get the current `ColumnFamilyData::super_version_`, its corresponding cleanup logic is not correctly done.

It's currently doing this:
`MultiGetColumnFamilyData::cfd->GetSuperVersion().Unref()`

This operates on the most recent `SuperVersion` without locking db mutex , which is not thread safe by itself. And this unref operation is intended for the originally acquired `SuperVersion` instead of the current one. Because a race condition could happen where a new `SuperVersion` is installed in between this `MultiGet`'s ref and unref. When this race condition does happen, it's not sufficient to just unref the `SuperVersion`, `DBImpl::CleanupSuperVersion` should be called instead to properly clean up the `SuperVersion` had this `MultiGet` call be its last reference holder.

Test Plan:
`make all check`
Added a unit test that would originally fail