### PR TITLE
Use default value instead of hard-coded 0 for compaction_readhead_size in db bench

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -718,7 +718,9 @@ DEFINE_int32(file_opening_threads,
              "If open_files is set to -1, this option set the number of "
              "threads that will be used to open files during DB::Open()");
 
-DEFINE_int32(compaction_readahead_size, 0, "Compaction readahead size");
+DEFINE_int32(compaction_readahead_size,
+             ROCKSDB_NAMESPACE::Options().compaction_readahead_size,
+             "Compaction readahead size");
 
 DEFINE_int32(log_readahead_size, 0, "WAL and manifest readahead size");
 


### PR DESCRIPTION
**Context/Summary:**
It allows db bench reflect the default behavior of this option. For example, we recently changed its default value.

**Test:**
No code change