### PR TITLE
add statistics: DB_NEXT to measure next() call time

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -135,6 +135,7 @@ void DBIter::Next() {
 
   PERF_COUNTER_ADD(iter_next_count, 1);
   PERF_CPU_TIMER_GUARD(iter_next_cpu_nanos, clock_);
+  StopWatch sw(clock_, statistics_, DB_NEXT);
   // Release temporarily pinned blocks from last operation
   ReleaseTempPinnedData();
   ResetBlobValue();

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -554,6 +554,7 @@ enum Histograms : uint32_t {
   WRITE_RAW_BLOCK_MICROS,
   NUM_FILES_IN_SINGLE_COMPACTION,
   DB_SEEK,
+  DB_NEXT,
   WRITE_STALL,
   // Time spent in reading block-based or plain SST table
   SST_READ_MICROS,

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -278,6 +278,7 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {WRITE_RAW_BLOCK_MICROS, "rocksdb.write.raw.block.micros"},
     {NUM_FILES_IN_SINGLE_COMPACTION, "rocksdb.numfiles.in.singlecompaction"},
     {DB_SEEK, "rocksdb.db.seek.micros"},
+    {DB_NEXT, "rocksdb.db.next.micros"},
     {WRITE_STALL, "rocksdb.db.write.stall"},
     {SST_READ_MICROS, "rocksdb.sst.read.micros"},
     {FILE_READ_FLUSH_MICROS, "rocksdb.file.read.flush.micros"},


### PR DESCRIPTION
Context/Summary:
Adds rocksdb.db.next.micros statistics (DB_NEXT) to measure execution time of next() call.

Test:
Validated by running db_bench with seekrandom benchmark multiple times to see the output of rocksdb.db.next.micros.