### PR TITLE
Fix CI failure due to transaction_test 

### DIFF
--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -6774,7 +6774,7 @@ TEST_F(TransactionDBTest, CollapseKey) {
 
   // get merge op info
   std::vector<PinnableSlice> operands(3);
-  rocksdb::GetMergeOperandsOptions mergeOperandOptions;
+  GetMergeOperandsOptions mergeOperandOptions;
   mergeOperandOptions.expected_max_number_of_operands = 3;
   int numOperands;
   ASSERT_OK(db->GetMergeOperands({}, db->DefaultColumnFamily(), "hello",


### PR DESCRIPTION
Test ` build-linux-static_lib-alt_namespace-status_checked` has been failing in main branch.

```
utilities/transactions/transaction_test.cc:6777:3: error: 'rocksdb' has not been declared
 6777 |   rocksdb::GetMergeOperandsOptions mergeOperandOptions;
      |   ^~~~~~~
```

Test plan:
`ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=static OPT="-DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make V=1 -j24 J=24 transaction_test`