### PR TITLE
LZ4 set acceleration parameter

### DIFF
--- a/unreleased_history/public_api_changes/compression_options_level_lz4.md
+++ b/unreleased_history/public_api_changes/compression_options_level_lz4.md
@@ -1,0 +1,1 @@
+* When using LZ4 compression, the `acceleration` parameter is configurable by setting the negated value in `CompressionOptions::level`. For example, `CompressionOptions::level=-10` will set `acceleration=10`

--- a/util/compression.h
+++ b/util/compression.h
@@ -1153,9 +1153,15 @@ inline bool LZ4_Compress(const CompressionInfo& info,
                  static_cast<int>(compression_dict.size()));
   }
 #if LZ4_VERSION_NUMBER >= 10700  // r129+
-  outlen =
-      LZ4_compress_fast_continue(stream, input, &(*output)[output_header_len],
-                                 static_cast<int>(length), compress_bound, 1);
+  int acceleration;
+  if (info.options().level < 0) {
+    acceleration = -info.options().level;
+  } else {
+    acceleration = 1;
+  }
+  outlen = LZ4_compress_fast_continue(
+      stream, input, &(*output)[output_header_len], static_cast<int>(length),
+      compress_bound, acceleration);
 #else  // up to r128
   outlen = LZ4_compress_limitedOutput_continue(
       stream, input, &(*output)[output_header_len], static_cast<int>(length),


### PR DESCRIPTION
Test Plan:
Command:
```
for level in 1 1234 32767 -1 -10 -100 -1000 -10000 -100000 -1000000; do echo -n "level=$level " && ./db_bench -benchmarks=compress -compression_type=lz4 -compression_level=$level |& awk '/^compress / {print $5, $6}' ; done
```

Output:
```
level=1 181340 ops/sec
level=1234 183197 ops/sec
level=32767 181480 ops/sec
level=-1 181053 ops/sec
level=-10 662858 ops/sec
level=-100 2611516 ops/sec
level=-1000 3043125 ops/sec
level=-10000 3001351 ops/sec
level=-100000 2861834 ops/sec
level=-1000000 2906413 ops/sec
```