### PR TITLE
Expose more info about input files in `CompactionFilter::Context`

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1119,7 +1119,7 @@ Compaction* ColumnFamilyData::PickCompaction(
       GetName(), mutable_options, mutable_db_options, current_->storage_info(),
       log_buffer);
   if (result != nullptr) {
-    result->SetInputVersion(current_);
+    result->FinalizeInputInfo(current_);
   }
   return result;
 }
@@ -1203,7 +1203,7 @@ Compaction* ColumnFamilyData::CompactRange(
       compact_range_options, begin, end, compaction_end, conflict,
       max_file_num_to_ignore, trim_ts);
   if (result != nullptr) {
-    result->SetInputVersion(current_);
+    result->FinalizeInputInfo(current_);
   }
   TEST_SYNC_POINT("ColumnFamilyData::CompactRange:Return");
   return result;

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -204,7 +204,7 @@ bool Compaction::IsFullCompaction(
   return num_files_in_compaction == total_num_files;
 }
 
-Status Compaction::SetInputTableProperties() {
+Status Compaction::InitInputTableProperties() {
   if (!input_table_properties_.empty()) {
     return Status::OK();
   }
@@ -786,8 +786,7 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter() const {
     ROCKS_LOG_WARN(
         immutable_options_.info_log,
         "Unable to set `input_table_properties` of `CompactionFilter::Context` "
-        "for compaction. Please check the previous logs for errors in loading "
-        "table properties during compaction");
+        "for compaction.");
   }
 
   return cfd_->ioptions()->compaction_filter_factory->CreateCompactionFilter(

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -778,8 +778,18 @@ std::unique_ptr<CompactionFilter> Compaction::CreateCompactionFilter() const {
   CompactionFilter::Context context;
   context.is_full_compaction = is_full_compaction_;
   context.is_manual_compaction = is_manual_compaction_;
+  context.input_start_level = start_level_;
   context.column_family_id = cfd_->GetID();
   context.reason = TableFileCreationReason::kCompaction;
+  context.input_table_properties = GetInputTableProperties();
+  if (context.input_table_properties.empty()) {
+    ROCKS_LOG_WARN(
+        immutable_options_.info_log,
+        "Unable to set `input_table_properties` of `CompactionFilter::Context` "
+        "for compaction. Please check the previous logs for errors in loading "
+        "table properties during compaction");
+  }
+
   return cfd_->ioptions()->compaction_filter_factory->CreateCompactionFilter(
       context);
 }

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -204,32 +204,36 @@ bool Compaction::IsFullCompaction(
   return num_files_in_compaction == total_num_files;
 }
 
-const TablePropertiesCollection& Compaction::GetTableProperties() {
-  if (!input_table_properties_initialized_) {
-    const ReadOptions read_options(Env::IOActivity::kCompaction);
-    for (size_t i = 0; i < num_input_levels(); ++i) {
-      for (const FileMetaData* fmd : *(this->inputs(i))) {
-        std::shared_ptr<const TableProperties> tp;
-        std::string file_name =
-            TableFileName(immutable_options_.cf_paths, fmd->fd.GetNumber(),
-                          fmd->fd.GetPathId());
-        Status s = input_version_->GetTableProperties(read_options, &tp, fmd,
-                                                      &file_name);
-        if (s.ok()) {
-          table_properties_[file_name] = tp;
-        } else {
-          ROCKS_LOG_ERROR(immutable_options_.info_log,
-                          "Unable to load table properties for file %" PRIu64
-                          " --- %s\n",
-                          fmd->fd.GetNumber(), s.ToString().c_str());
-        }
+Status Compaction::SetInputTableProperties() {
+  if (!input_table_properties_.empty()) {
+    return Status::OK();
+  }
+
+  Status s;
+  const ReadOptions read_options(Env::IOActivity::kCompaction);
+  assert(input_version_);
+  for (size_t i = 0; i < num_input_levels(); ++i) {
+    for (const FileMetaData* fmd : *(this->inputs(i))) {
+      std::shared_ptr<const TableProperties> tp;
+      std::string file_name =
+          TableFileName(immutable_options_.cf_paths, fmd->fd.GetNumber(),
+                        fmd->fd.GetPathId());
+      s = input_version_->GetTableProperties(read_options, &tp, fmd,
+                                             &file_name);
+      if (s.ok()) {
+        input_table_properties_[file_name] = tp;
+      } else {
+        ROCKS_LOG_ERROR(immutable_options_.info_log,
+                        "Unable to load table properties for file %" PRIu64
+                        " --- %s\n",
+                        fmd->fd.GetNumber(), s.ToString().c_str());
+        input_table_properties_.clear();
+        return s;
       }
     }
+  }
 
-    input_table_properties_initialized_ = true;
-  };
-
-  return table_properties_;
+  return s;
 }
 
 Compaction::Compaction(

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -289,10 +289,13 @@ class Compaction {
   // is the sum of all input file sizes.
   uint64_t OutputFilePreallocationSize() const;
 
-  // TODO(hx235): consider making this function part of the construction
+  // TODO(hx235): eventually we should consider `InitInputTableProperties()`'s
+  // status and fail the compaction if needed
+  // TODO(hx235): consider making this function part of the construction so we
+  // don't forget to call it
   void FinalizeInputInfo(Version* input_version) {
     SetInputVersion(input_version);
-    SetInputTableProperties().PermitUncheckedError();
+    InitInputTableProperties().PermitUncheckedError();
   }
 
   struct InputLevelSummaryBuffer {
@@ -335,7 +338,7 @@ class Compaction {
   }
 
   // TODO(hx235): consider making this function symmetric to
-  // SetInputTableProperties()
+  // InitInputTableProperties()
   void SetOutputTableProperties(
       const std::string& file_name,
       const std::shared_ptr<const TableProperties>& tp) {
@@ -442,7 +445,7 @@ class Compaction {
  private:
   void SetInputVersion(Version* input_version);
 
-  Status SetInputTableProperties();
+  Status InitInputTableProperties();
 
   // mark (or clear) all files that are being compacted
   void MarkFilesBeingCompacted(bool mark_as_compacted);

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1979,7 +1979,7 @@ bool CompactionJob::UpdateCompactionStats(uint64_t* num_input_range_del) {
 
   bool has_error = false;
   const ReadOptions read_options(Env::IOActivity::kCompaction);
-  const auto& input_table_properties = compaction->GetTableProperties();
+  const auto& input_table_properties = compaction->GetInputTableProperties();
   for (int input_level = 0;
        input_level < static_cast<int>(compaction->num_input_levels());
        ++input_level) {

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -644,7 +644,7 @@ class CompactionJobTestBase : public testing::Test {
         mutable_cf_options_.max_compaction_bytes, 0, kNoCompression,
         cfd->GetLatestMutableCFOptions()->compression_opts,
         Temperature::kUnknown, max_subcompactions, grandparents, true);
-    compaction.SetInputVersion(cfd->current());
+    compaction.FinalizeInputInfo(cfd->current());
 
     assert(db_options_.info_log);
     LogBuffer log_buffer(InfoLogLevel::INFO_LEVEL, db_options_.info_log.get());

--- a/db/db_compaction_filter_test.cc
+++ b/db/db_compaction_filter_test.cc
@@ -166,9 +166,12 @@ class ChangeFilter : public CompactionFilter {
 class KeepFilterFactory : public CompactionFilterFactory {
  public:
   explicit KeepFilterFactory(bool check_context = false,
-                             bool check_context_cf_id = false)
+                             bool check_context_cf_id = false,
+                             bool check_context_input_table_properties = false)
       : check_context_(check_context),
         check_context_cf_id_(check_context_cf_id),
+        check_context_input_table_properties_(
+            check_context_input_table_properties),
         compaction_filter_created_(false) {}
 
   std::unique_ptr<CompactionFilter> CreateCompactionFilter(
@@ -176,6 +179,11 @@ class KeepFilterFactory : public CompactionFilterFactory {
     if (check_context_) {
       EXPECT_EQ(expect_full_compaction_.load(), context.is_full_compaction);
       EXPECT_EQ(expect_manual_compaction_.load(), context.is_manual_compaction);
+      EXPECT_EQ(expect_input_start_level_.load(), context.input_start_level);
+    }
+    if (check_context_input_table_properties_) {
+      EXPECT_TRUE(expect_input_table_properties_ ==
+                  context.input_table_properties);
     }
     if (check_context_cf_id_) {
       EXPECT_EQ(expect_cf_id_.load(), context.column_family_id);
@@ -189,9 +197,15 @@ class KeepFilterFactory : public CompactionFilterFactory {
   const char* Name() const override { return "KeepFilterFactory"; }
   bool check_context_;
   bool check_context_cf_id_;
+  // `check_context_input_table_properties_` can be true only when access to
+  // `expect_input_table_properties_` is syncronized since we can't have
+  // std::atomic<TablePropertiesCollection> unfortunately
+  bool check_context_input_table_properties_;
   std::atomic_bool expect_full_compaction_;
   std::atomic_bool expect_manual_compaction_;
   std::atomic<uint32_t> expect_cf_id_;
+  std::atomic<int> expect_input_start_level_;
+  TablePropertiesCollection expect_input_table_properties_;
   bool compaction_filter_created_;
 };
 
@@ -654,7 +668,9 @@ TEST_F(DBTestCompactionFilter, CompactionFilterWithMergeOperator) {
 }
 
 TEST_F(DBTestCompactionFilter, CompactionFilterContextManual) {
-  KeepFilterFactory* filter = new KeepFilterFactory(true, true);
+  KeepFilterFactory* filter = new KeepFilterFactory(
+      true /* check_context */, true /* check_context_cf_id */,
+      true /* check_context_input_table_properties */);
 
   Options options = CurrentOptions();
   options.compaction_style = kCompactionStyleUniversal;
@@ -662,8 +678,9 @@ TEST_F(DBTestCompactionFilter, CompactionFilterContextManual) {
   options.compression = kNoCompression;
   options.level0_file_num_compaction_trigger = 8;
   Reopen(options);
+  const int kNumFiles = 3;
   int num_keys_per_file = 400;
-  for (int j = 0; j < 3; j++) {
+  for (int j = 0; j < kNumFiles; j++) {
     // Write several keys.
     const std::string value(10, 'x');
     for (int i = 0; i < num_keys_per_file; i++) {
@@ -683,6 +700,11 @@ TEST_F(DBTestCompactionFilter, CompactionFilterContextManual) {
   filter->expect_manual_compaction_.store(true);
   filter->expect_full_compaction_.store(true);
   filter->expect_cf_id_.store(0);
+  filter->expect_input_start_level_.store(0);
+  ASSERT_OK(dbfull()->GetPropertiesOfAllTables(
+      &filter->expect_input_table_properties_));
+  ASSERT_TRUE(filter->expect_input_table_properties_.size() == kNumFiles);
+
   ASSERT_OK(dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   ASSERT_EQ(cfilter_count, 700);
   ASSERT_EQ(NumSortedRuns(0), 1);

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1462,7 +1462,8 @@ Status DBImpl::CompactFilesImpl(
   // without releasing the lock, so we're guaranteed a compaction can be formed.
   assert(c != nullptr);
 
-  c->SetInputVersion(version);
+  c->FinalizeInputInfo(version);
+
   // deletion compaction currently not allowed in CompactFiles.
   assert(!c->deletion_compaction());
 
@@ -3954,7 +3955,12 @@ void DBImpl::BuildCompactionJobInfo(
   compaction_job_info->base_input_level = c->start_level();
   compaction_job_info->output_level = c->output_level();
   compaction_job_info->stats = compaction_job_stats;
-  compaction_job_info->table_properties = c->GetTableProperties();
+  const auto& input_table_properties = c->GetInputTableProperties();
+  const auto& output_table_properties = c->GetOutputTableProperties();
+  compaction_job_info->table_properties.insert(input_table_properties.begin(),
+                                               input_table_properties.end());
+  compaction_job_info->table_properties.insert(output_table_properties.begin(),
+                                               output_table_properties.end());
   compaction_job_info->compaction_reason = c->compaction_reason();
   compaction_job_info->compression = c->output_compression();
 

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -885,7 +885,7 @@ Status DBImplSecondary::CompactWithoutInstallation(
       *mutable_cf_options, mutable_db_options_, 0));
   assert(c != nullptr);
 
-  c->SetInputVersion(version);
+  c->FinalizeInputInfo(version);
 
   // Create output directory if it's not existed yet
   std::unique_ptr<FSDirectory> output_dir;

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -22,9 +22,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-using TablePropertiesCollection =
-    std::unordered_map<std::string, std::shared_ptr<const TableProperties>>;
-
 class Slice;
 class SliceTransform;
 

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -16,10 +16,14 @@
 
 #include "rocksdb/customizable.h"
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/table_properties.h"
 #include "rocksdb/types.h"
 #include "rocksdb/wide_columns.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+using TablePropertiesCollection =
+    std::unordered_map<std::string, std::shared_ptr<const TableProperties>>;
 
 class Slice;
 class SliceTransform;
@@ -160,10 +164,20 @@ class CompactionFilter : public Customizable {
     // Whether this table file is created as part of a compaction requested by
     // the client.
     bool is_manual_compaction;
+    // The lowest level among all the input files (if any) used in table
+    // creation
+    int input_start_level = kUnknownStartLevel;
     // The column family that will contain the created table file.
     uint32_t column_family_id;
     // Reason this table file is being created.
     TableFileCreationReason reason;
+    // Map from all the input files (if any) used in table creation to their
+    // table properties. When there are such input files but RocksDB fail to
+    // load their table properties, `input_table_properties` will be an empty
+    // map.
+    TablePropertiesCollection input_table_properties;
+
+    static const int kUnknownStartLevel = -1;
   };
 
   virtual ~CompactionFilter() {}

--- a/include/rocksdb/types.h
+++ b/include/rocksdb/types.h
@@ -7,6 +7,9 @@
 
 #include <stdint.h>
 
+#include <memory>
+#include <unordered_map>
+
 #include "rocksdb/slice.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -17,6 +20,10 @@ using ColumnFamilyId = uint32_t;
 
 // Represents a sequence number in a WAL file.
 using SequenceNumber = uint64_t;
+
+struct TableProperties;
+using TablePropertiesCollection =
+    std::unordered_map<std::string, std::shared_ptr<const TableProperties>>;
 
 const SequenceNumber kMinUnCommittedSeq = 1;  // 0 is always committed
 

--- a/unreleased_history/public_api_changes/compact_filter_context_more_info.md
+++ b/unreleased_history/public_api_changes/compact_filter_context_more_info.md
@@ -1,0 +1,1 @@
+Expose more information about input files used in table creation (if any) in `CompactionFilter::Context`. See `CompactionFilter::Context::input_start_level`,`CompactionFilter::Context::input_table_properties` for more.


### PR DESCRIPTION
**Context:**
As requested, lowest level as well as a map from input file to its table properties among all input files used in table creation  (if any) are exposed in `CompactionFilter::Context`.

**Summary:**
This PR contains two commits:
(1) [Refactory](https://github.com/facebook/rocksdb/pull/11857/commits/0012777f0ee829fee859eec5db11a882f450ae26) to make resonating/using what is in `Compaction:: table_properties_` easier
- Separate `Compaction:: table_properties_` into `Compaction:: input_table_properties_` and `Compaction:: output_table_properties_`
- Separate the "set input table properties" logic into `Compaction:: SetInputTableProperties()`) from `Compaction:: GetInputTableProperties`
- Call `Compaction:: SetInputTableProperties()` as soon as possible, which is right after `Compaction::SetInputVersion()`. Bundle these two functions into one `Compaction::FinalizeInputInfo()` to minimize missing one or the other

(2) [Expose more info about input files:](https://github.com/facebook/rocksdb/pull/11857/commits/6093e7dfbadd4fe1d05ad8a6ab3452d363f6d131) `CompactionFilter::Context::input_start_level/input_table_properties` 


**Test:**
- Modify existing UT `
TEST_F(DBTestCompactionFilter, CompactionFilterContextManual)` to cover new logics 

