### PR TITLE
Integrate FullMergeV3 into the query and compaction paths

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -238,6 +238,31 @@ bool DBIter::SetValueAndColumnsFromEntity(Slice slice) {
   return true;
 }
 
+bool DBIter::SetValueAndColumnsFromMergeResult(const Status& merge_status,
+                                               ValueType result_type) {
+  if (!merge_status.ok()) {
+    valid_ = false;
+    status_ = merge_status;
+    return false;
+  }
+
+  if (result_type == kTypeWideColumnEntity) {
+    if (!SetValueAndColumnsFromEntity(saved_value_)) {
+      assert(!valid_);
+      return false;
+    }
+
+    valid_ = true;
+    return true;
+  }
+
+  assert(result_type == kTypeValue);
+  SetValueAndColumnsFromPlain(pinned_value_.data() ? pinned_value_
+                                                   : saved_value_);
+  valid_ = true;
+  return true;
+}
+
 // PRE: saved_key_ has the current user key if skipping_saved_key
 // POST: saved_key_ should have the next user key if valid_,
 //       if the current entry is a result of merge
@@ -554,8 +579,7 @@ bool DBIter::MergeValuesNewToOld() {
     if (kTypeValue == ikey.type) {
       // hit a put, merge the put value with operands and store the
       // final result in saved_value_. We are done!
-      const Slice val = iter_.value();
-      if (!Merge(&val, ikey.user_key)) {
+      if (!MergeWithPlainBaseValue(iter_.value(), ikey.user_key)) {
         return false;
       }
       // iter_ is positioned after put
@@ -584,7 +608,7 @@ bool DBIter::MergeValuesNewToOld() {
         return false;
       }
       valid_ = true;
-      if (!Merge(&blob_value_, ikey.user_key)) {
+      if (!MergeWithPlainBaseValue(blob_value_, ikey.user_key)) {
         return false;
       }
 
@@ -598,7 +622,7 @@ bool DBIter::MergeValuesNewToOld() {
       }
       return true;
     } else if (kTypeWideColumnEntity == ikey.type) {
-      if (!MergeEntity(iter_.value(), ikey.user_key)) {
+      if (!MergeWithWideColumnBaseValue(iter_.value(), ikey.user_key)) {
         return false;
       }
 
@@ -628,7 +652,7 @@ bool DBIter::MergeValuesNewToOld() {
   // a deletion marker.
   // feed null as the existing value to the merge operator, such that
   // client can differentiate this scenario and do things accordingly.
-  if (!Merge(nullptr, saved_key_.GetUserKey())) {
+  if (!MergeWithNoBaseValue(saved_key_.GetUserKey())) {
     return false;
   }
   assert(status_.ok());
@@ -979,7 +1003,7 @@ bool DBIter::FindValueForCurrentKey() {
       if (last_not_merge_type == kTypeDeletion ||
           last_not_merge_type == kTypeSingleDeletion ||
           last_not_merge_type == kTypeDeletionWithTimestamp) {
-        if (!Merge(nullptr, saved_key_.GetUserKey())) {
+        if (!MergeWithNoBaseValue(saved_key_.GetUserKey())) {
           return false;
         }
         return true;
@@ -994,7 +1018,7 @@ bool DBIter::FindValueForCurrentKey() {
           return false;
         }
         valid_ = true;
-        if (!Merge(&blob_value_, saved_key_.GetUserKey())) {
+        if (!MergeWithPlainBaseValue(blob_value_, saved_key_.GetUserKey())) {
           return false;
         }
 
@@ -1002,14 +1026,15 @@ bool DBIter::FindValueForCurrentKey() {
 
         return true;
       } else if (last_not_merge_type == kTypeWideColumnEntity) {
-        if (!MergeEntity(pinned_value_, saved_key_.GetUserKey())) {
+        if (!MergeWithWideColumnBaseValue(pinned_value_,
+                                          saved_key_.GetUserKey())) {
           return false;
         }
 
         return true;
       } else {
         assert(last_not_merge_type == kTypeValue);
-        if (!Merge(&pinned_value_, saved_key_.GetUserKey())) {
+        if (!MergeWithPlainBaseValue(pinned_value_, saved_key_.GetUserKey())) {
           return false;
         }
         return true;
@@ -1185,8 +1210,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
     }
 
     if (ikey.type == kTypeValue) {
-      const Slice val = iter_.value();
-      if (!Merge(&val, saved_key_.GetUserKey())) {
+      if (!MergeWithPlainBaseValue(iter_.value(), saved_key_.GetUserKey())) {
         return false;
       }
       return true;
@@ -1205,7 +1229,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
         return false;
       }
       valid_ = true;
-      if (!Merge(&blob_value_, saved_key_.GetUserKey())) {
+      if (!MergeWithPlainBaseValue(blob_value_, saved_key_.GetUserKey())) {
         return false;
       }
 
@@ -1213,7 +1237,8 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
 
       return true;
     } else if (ikey.type == kTypeWideColumnEntity) {
-      if (!MergeEntity(iter_.value(), saved_key_.GetUserKey())) {
+      if (!MergeWithWideColumnBaseValue(iter_.value(),
+                                        saved_key_.GetUserKey())) {
         return false;
       }
 
@@ -1227,7 +1252,7 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
     }
   }
 
-  if (!Merge(nullptr, saved_key_.GetUserKey())) {
+  if (!MergeWithNoBaseValue(saved_key_.GetUserKey())) {
     return false;
   }
 
@@ -1250,47 +1275,42 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
   return true;
 }
 
-bool DBIter::Merge(const Slice* val, const Slice& user_key) {
+bool DBIter::MergeWithNoBaseValue(const Slice& user_key) {
   // `op_failure_scope` (an output parameter) is not provided (set to nullptr)
   // since a failure must be propagated regardless of its value.
-  Status s = MergeHelper::TimedFullMerge(
-      merge_operator_, user_key, val, merge_context_.GetOperands(),
-      &saved_value_, logger_, statistics_, clock_, &pinned_value_,
-      /* update_num_ops_stats */ true,
-      /* op_failure_scope */ nullptr);
-  if (!s.ok()) {
-    valid_ = false;
-    status_ = s;
-    return false;
-  }
-
-  SetValueAndColumnsFromPlain(pinned_value_.data() ? pinned_value_
-                                                   : saved_value_);
-
-  valid_ = true;
-  return true;
+  ValueType result_type;
+  const Status s = MergeHelper::TimedFullMerge(
+      merge_operator_, user_key, MergeHelper::kNoBaseValue,
+      merge_context_.GetOperands(), logger_, statistics_, clock_,
+      /* update_num_ops_stats */ true, &saved_value_, &pinned_value_,
+      &result_type, /* op_failure_scope */ nullptr);
+  return SetValueAndColumnsFromMergeResult(s, result_type);
 }
 
-bool DBIter::MergeEntity(const Slice& entity, const Slice& user_key) {
+bool DBIter::MergeWithPlainBaseValue(const Slice& value,
+                                     const Slice& user_key) {
   // `op_failure_scope` (an output parameter) is not provided (set to nullptr)
   // since a failure must be propagated regardless of its value.
-  Status s = MergeHelper::TimedFullMergeWithEntity(
-      merge_operator_, user_key, entity, merge_context_.GetOperands(),
-      &saved_value_, logger_, statistics_, clock_,
-      /* update_num_ops_stats */ true,
-      /* op_failure_scope */ nullptr);
-  if (!s.ok()) {
-    valid_ = false;
-    status_ = s;
-    return false;
-  }
+  ValueType result_type;
+  const Status s = MergeHelper::TimedFullMerge(
+      merge_operator_, user_key, MergeHelper::kPlainBaseValue, value,
+      merge_context_.GetOperands(), logger_, statistics_, clock_,
+      /* update_num_ops_stats */ true, &saved_value_, &pinned_value_,
+      &result_type, /* op_failure_scope */ nullptr);
+  return SetValueAndColumnsFromMergeResult(s, result_type);
+}
 
-  if (!SetValueAndColumnsFromEntity(saved_value_)) {
-    return false;
-  }
-
-  valid_ = true;
-  return true;
+bool DBIter::MergeWithWideColumnBaseValue(const Slice& entity,
+                                          const Slice& user_key) {
+  // `op_failure_scope` (an output parameter) is not provided (set to nullptr)
+  // since a failure must be propagated regardless of its value.
+  ValueType result_type;
+  const Status s = MergeHelper::TimedFullMerge(
+      merge_operator_, user_key, MergeHelper::kWideBaseValue, entity,
+      merge_context_.GetOperands(), logger_, statistics_, clock_,
+      /* update_num_ops_stats */ true, &saved_value_, &pinned_value_,
+      &result_type, /* op_failure_scope */ nullptr);
+  return SetValueAndColumnsFromMergeResult(s, result_type);
 }
 
 // Move backwards until the key smaller than saved_key_.

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -313,14 +313,20 @@ class DBIter final : public Iterator {
 
   bool SetValueAndColumnsFromEntity(Slice slice);
 
+  bool SetValueAndColumnsFromMergeResult(const Status& merge_status,
+                                         ValueType result_type);
+
   void ResetValueAndColumns() {
     value_.clear();
     wide_columns_.clear();
   }
 
+  // The following methods perform the actual merge operation for the
+  // no base value/plain base value/wide-column base value cases.
   // If user-defined timestamp is enabled, `user_key` includes timestamp.
-  bool Merge(const Slice* val, const Slice& user_key);
-  bool MergeEntity(const Slice& entity, const Slice& user_key);
+  bool MergeWithNoBaseValue(const Slice& user_key);
+  bool MergeWithPlainBaseValue(const Slice& value, const Slice& user_key);
+  bool MergeWithWideColumnBaseValue(const Slice& entity, const Slice& user_key);
 
   const SliceTransform* prefix_extractor_;
   Env* const env_;

--- a/db/merge_helper.h
+++ b/db/merge_helper.h
@@ -41,28 +41,75 @@ class MergeHelper {
               Statistics* stats = nullptr,
               const std::atomic<bool>* shutting_down = nullptr);
 
-  // Wrapper around MergeOperator::FullMergeV2() that records perf statistics.
-  // Result of merge will be written to result if status returned is OK.
-  // If operands is empty, the value will simply be copied to result.
-  // Set `update_num_ops_stats` to true if it is from a user read, so that
-  // the latency is sensitive.
+  // Wrappers around MergeOperator::FullMergeV3() that record perf statistics.
+  // Set `update_num_ops_stats` to true if it is from a user read so that
+  // the corresponding statistics are updated.
   // Returns one of the following statuses:
   // - OK: Entries were successfully merged.
   // - Corruption: Merge operator reported unsuccessful merge. The scope of the
   //   damage will be stored in `*op_failure_scope` when `op_failure_scope` is
   //   not nullptr
+
+  // Empty tag types to disambiguate overloads
+  struct NoBaseValueTag {};
+  static constexpr NoBaseValueTag kNoBaseValue{};
+
+  struct PlainBaseValueTag {};
+  static constexpr PlainBaseValueTag kPlainBaseValue{};
+
+  struct WideBaseValueTag {};
+  static constexpr WideBaseValueTag kWideBaseValue{};
+
+  // Variants that expose the merge result directly (in serialized form for wide
+  // columns) as well as its value type. Used by iterator and compaction.
   static Status TimedFullMerge(const MergeOperator* merge_operator,
-                               const Slice& key, const Slice* value,
+                               const Slice& key, NoBaseValueTag,
                                const std::vector<Slice>& operands,
-                               std::string* result, Logger* logger,
-                               Statistics* statistics, SystemClock* clock,
-                               Slice* result_operand, bool update_num_ops_stats,
+                               Logger* logger, Statistics* statistics,
+                               SystemClock* clock, bool update_num_ops_stats,
+                               std::string* result, Slice* result_operand,
+                               ValueType* result_type,
                                MergeOperator::OpFailureScope* op_failure_scope);
 
-  static Status TimedFullMergeWithEntity(
-      const MergeOperator* merge_operator, const Slice& key, Slice base_entity,
-      const std::vector<Slice>& operands, std::string* result, Logger* logger,
+  static Status TimedFullMerge(
+      const MergeOperator* merge_operator, const Slice& key, PlainBaseValueTag,
+      const Slice& value, const std::vector<Slice>& operands, Logger* logger,
       Statistics* statistics, SystemClock* clock, bool update_num_ops_stats,
+      std::string* result, Slice* result_operand, ValueType* result_type,
+      MergeOperator::OpFailureScope* op_failure_scope);
+
+  static Status TimedFullMerge(
+      const MergeOperator* merge_operator, const Slice& key, WideBaseValueTag,
+      const Slice& entity, const std::vector<Slice>& operands, Logger* logger,
+      Statistics* statistics, SystemClock* clock, bool update_num_ops_stats,
+      std::string* result, Slice* result_operand, ValueType* result_type,
+      MergeOperator::OpFailureScope* op_failure_scope);
+
+  // Variants that expose the merge result translated to the form requested by
+  // the client. (For example, if the result is a wide-column structure but the
+  // client requested the results in plain-value form, the value of the default
+  // column is returned.) Used by point lookups.
+  static Status TimedFullMerge(const MergeOperator* merge_operator,
+                               const Slice& key, NoBaseValueTag,
+                               const std::vector<Slice>& operands,
+                               Logger* logger, Statistics* statistics,
+                               SystemClock* clock, bool update_num_ops_stats,
+                               std::string* result_value,
+                               PinnableWideColumns* result_entity,
+                               MergeOperator::OpFailureScope* op_failure_scope);
+
+  static Status TimedFullMerge(
+      const MergeOperator* merge_operator, const Slice& key, PlainBaseValueTag,
+      const Slice& value, const std::vector<Slice>& operands, Logger* logger,
+      Statistics* statistics, SystemClock* clock, bool update_num_ops_stats,
+      std::string* result_value, PinnableWideColumns* result_entity,
+      MergeOperator::OpFailureScope* op_failure_scope);
+
+  static Status TimedFullMerge(
+      const MergeOperator* merge_operator, const Slice& key, WideBaseValueTag,
+      const Slice& entity, const std::vector<Slice>& operands, Logger* logger,
+      Statistics* statistics, SystemClock* clock, bool update_num_ops_stats,
+      std::string* result_value, PinnableWideColumns* result_entity,
       MergeOperator::OpFailureScope* op_failure_scope);
 
   // During compaction, merge entries until we hit
@@ -198,6 +245,30 @@ class MergeHelper {
     // This is a best-effort facility, so memory_order_relaxed is sufficient.
     return shutting_down_ && shutting_down_->load(std::memory_order_relaxed);
   }
+
+  template <typename Visitor>
+  static Status TimedFullMergeCommonImpl(
+      const MergeOperator* merge_operator, const Slice& key,
+      MergeOperator::MergeOperationInputV3::ExistingValue&& existing_value,
+      const std::vector<Slice>& operands, Logger* logger,
+      Statistics* statistics, SystemClock* clock, bool update_num_ops_stats,
+      MergeOperator::OpFailureScope* op_failure_scope, Visitor&& visitor);
+
+  static Status TimedFullMergeImpl(
+      const MergeOperator* merge_operator, const Slice& key,
+      MergeOperator::MergeOperationInputV3::ExistingValue&& existing_value,
+      const std::vector<Slice>& operands, Logger* logger,
+      Statistics* statistics, SystemClock* clock, bool update_num_ops_stats,
+      std::string* result, Slice* result_operand, ValueType* result_type,
+      MergeOperator::OpFailureScope* op_failure_scope);
+
+  static Status TimedFullMergeImpl(
+      const MergeOperator* merge_operator, const Slice& key,
+      MergeOperator::MergeOperationInputV3::ExistingValue&& existing_value,
+      const std::vector<Slice>& operands, Logger* logger,
+      Statistics* statistics, SystemClock* clock, bool update_num_ops_stats,
+      std::string* result_value, PinnableWideColumns* result_entity,
+      MergeOperator::OpFailureScope* op_failure_scope);
 };
 
 // MergeOutputIterator can be used to iterate over the result of a merge.

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2527,21 +2527,16 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     // merge_operands are in saver and we hit the beginning of the key history
     // do a final merge of nullptr and operands;
     if (value || columns) {
-      std::string result;
       // `op_failure_scope` (an output parameter) is not provided (set to
       // nullptr) since a failure must be propagated regardless of its value.
       *status = MergeHelper::TimedFullMerge(
-          merge_operator_, user_key, nullptr, merge_context->GetOperands(),
-          &result, info_log_, db_statistics_, clock_,
-          /* result_operand */ nullptr, /* update_num_ops_stats */ true,
-          /* op_failure_scope */ nullptr);
+          merge_operator_, user_key, MergeHelper::kNoBaseValue,
+          merge_context->GetOperands(), info_log_, db_statistics_, clock_,
+          /* update_num_ops_stats */ true, value ? value->GetSelf() : nullptr,
+          columns, /* op_failure_scope */ nullptr);
       if (status->ok()) {
         if (LIKELY(value != nullptr)) {
-          *(value->GetSelf()) = std::move(result);
           value->PinSelf();
-        } else {
-          assert(columns != nullptr);
-          columns->SetPlainValue(std::move(result));
         }
       }
     }
@@ -2778,22 +2773,19 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
       }
       // merge_operands are in saver and we hit the beginning of the key history
       // do a final merge of nullptr and operands;
-      std::string result;
-
       // `op_failure_scope` (an output parameter) is not provided (set to
       // nullptr) since a failure must be propagated regardless of its value.
       *status = MergeHelper::TimedFullMerge(
-          merge_operator_, user_key, nullptr, iter->merge_context.GetOperands(),
-          &result, info_log_, db_statistics_, clock_,
-          /* result_operand */ nullptr, /* update_num_ops_stats */ true,
+          merge_operator_, user_key, MergeHelper::kNoBaseValue,
+          iter->merge_context.GetOperands(), info_log_, db_statistics_, clock_,
+          /* update_num_ops_stats */ true,
+          iter->value ? iter->value->GetSelf() : nullptr, iter->columns,
           /* op_failure_scope */ nullptr);
       if (LIKELY(iter->value != nullptr)) {
-        *iter->value->GetSelf() = std::move(result);
         iter->value->PinSelf();
         range->AddValueSize(iter->value->size());
       } else {
         assert(iter->columns);
-        iter->columns->SetPlainValue(std::move(result));
         range->AddValueSize(iter->columns->serialized_size());
       }
 

--- a/include/rocksdb/merge_operator.h
+++ b/include/rocksdb/merge_operator.h
@@ -36,7 +36,7 @@ class Logger;
 //    into rocksdb); numeric addition and string concatenation are examples;
 //
 //  b) MergeOperator - the generic class for all the more abstract / complex
-//    operations; one method (FullMergeV2) to merge a Put/Delete value with a
+//    operations; one method (FullMergeV3) to merge a Put/Delete value with a
 //    merge operand; and another method (PartialMerge) that merges multiple
 //    operands together. this is especially useful if your key values have
 //    complex structures but you would still like to support client-specific
@@ -198,7 +198,6 @@ class MergeOperator : public Customizable {
     OpFailureScope op_failure_scope = OpFailureScope::kDefault;
   };
 
-  // ************************** UNDER CONSTRUCTION *****************************
   // An extended version of FullMergeV2() that supports wide columns on both the
   // input and the output side, enabling the application to perform general
   // transformations during merges. For backward compatibility, the default
@@ -238,7 +237,7 @@ class MergeOperator : public Customizable {
   // TODO: Presently there is no way to differentiate between error/corruption
   // and simply "return false". For now, the client should simply return
   // false in any case it cannot perform partial-merge, regardless of reason.
-  // If there is corruption in the data, handle it in the FullMergeV2() function
+  // If there is corruption in the data, handle it in the FullMergeV3() function
   // and return false there.  The default implementation of PartialMerge will
   // always return false.
   virtual bool PartialMerge(const Slice& /*key*/, const Slice& /*left_operand*/,
@@ -295,8 +294,8 @@ class MergeOperator : public Customizable {
   // Doesn't help with iterators.
   //
   // Note: the merge operands are passed to this function in the reversed order
-  // relative to how they were merged (passed to FullMerge or FullMergeV2)
-  // for performance reasons, see also:
+  // relative to how they were merged (passed to
+  // FullMerge/FullMergeV2/FullMergeV3) for performance reasons, see also:
   // https://github.com/facebook/rocksdb/issues/3865
   virtual bool ShouldMerge(const std::vector<Slice>& /*operands*/) const {
     return false;

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -374,7 +374,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
             Slice blob_value(pin_val);
             state_ = kFound;
             if (do_merge_) {
-              Merge(&blob_value);
+              MergeWithPlainBaseValue(blob_value);
             } else {
               // It means this function is called as part of DB GetMergeOperands
               // API and the current value should be part of
@@ -385,7 +385,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
             state_ = kFound;
 
             if (do_merge_) {
-              MergeWithEntity(value);
+              MergeWithWideColumnBaseValue(value);
             } else {
               // It means this function is called as part of DB GetMergeOperands
               // API and the current value should be part of
@@ -407,7 +407,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
 
             state_ = kFound;
             if (do_merge_) {
-              Merge(&value);
+              MergeWithPlainBaseValue(value);
             } else {
               // It means this function is called as part of DB GetMergeOperands
               // API and the current value should be part of
@@ -430,7 +430,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
         } else if (kMerge == state_) {
           state_ = kFound;
           if (do_merge_) {
-            Merge(nullptr);
+            MergeWithNoBaseValue();
           }
           // If do_merge_ = false then the current value shouldn't be part of
           // merge_context_->operand_list
@@ -448,7 +448,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
             merge_operator_->ShouldMerge(
                 merge_context_->GetOperandsDirectionBackward())) {
           state_ = kFound;
-          Merge(nullptr);
+          MergeWithNoBaseValue();
           return false;
         }
         return true;
@@ -463,20 +463,9 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
   return false;
 }
 
-void GetContext::Merge(const Slice* value) {
-  assert(do_merge_);
-  assert(!pinnable_val_ || !columns_);
-
-  std::string result;
-  // `op_failure_scope` (an output parameter) is not provided (set to nullptr)
-  // since a failure must be propagated regardless of its value.
-  const Status s = MergeHelper::TimedFullMerge(
-      merge_operator_, user_key_, value, merge_context_->GetOperands(), &result,
-      logger_, statistics_, clock_, /* result_operand */ nullptr,
-      /* update_num_ops_stats */ true,
-      /* op_failure_scope */ nullptr);
-  if (!s.ok()) {
-    if (s.subcode() == Status::SubCode::kMergeOperatorFailed) {
+void GetContext::PostprocessMerge(const Status& merge_status) {
+  if (!merge_status.ok()) {
+    if (merge_status.subcode() == Status::SubCode::kMergeOperatorFailed) {
       state_ = kMergeOperatorFailed;
     } else {
       state_ = kCorrupt;
@@ -485,81 +474,56 @@ void GetContext::Merge(const Slice* value) {
   }
 
   if (LIKELY(pinnable_val_ != nullptr)) {
-    *(pinnable_val_->GetSelf()) = std::move(result);
     pinnable_val_->PinSelf();
-    return;
   }
-
-  assert(columns_);
-  columns_->SetPlainValue(std::move(result));
 }
 
-void GetContext::MergeWithEntity(Slice entity) {
+void GetContext::MergeWithNoBaseValue() {
   assert(do_merge_);
+  assert(pinnable_val_ || columns_);
   assert(!pinnable_val_ || !columns_);
 
-  if (LIKELY(pinnable_val_ != nullptr)) {
-    Slice value_of_default;
+  // `op_failure_scope` (an output parameter) is not provided (set to nullptr)
+  // since a failure must be propagated regardless of its value.
+  const Status s = MergeHelper::TimedFullMerge(
+      merge_operator_, user_key_, MergeHelper::kNoBaseValue,
+      merge_context_->GetOperands(), logger_, statistics_, clock_,
+      /* update_num_ops_stats */ true,
+      pinnable_val_ ? pinnable_val_->GetSelf() : nullptr, columns_,
+      /* op_failure_scope */ nullptr);
+  PostprocessMerge(s);
+}
 
-    {
-      const Status s = WideColumnSerialization::GetValueOfDefaultColumn(
-          entity, value_of_default);
-      if (!s.ok()) {
-        state_ = kCorrupt;
-        return;
-      }
-    }
+void GetContext::MergeWithPlainBaseValue(const Slice& value) {
+  assert(do_merge_);
+  assert(pinnable_val_ || columns_);
+  assert(!pinnable_val_ || !columns_);
 
-    {
-      // `op_failure_scope` (an output parameter) is not provided (set to
-      // nullptr) since a failure must be propagated regardless of its value.
-      const Status s = MergeHelper::TimedFullMerge(
-          merge_operator_, user_key_, &value_of_default,
-          merge_context_->GetOperands(), pinnable_val_->GetSelf(), logger_,
-          statistics_, clock_, /* result_operand */ nullptr,
-          /* update_num_ops_stats */ true,
-          /* op_failure_scope */ nullptr);
-      if (!s.ok()) {
-        if (s.subcode() == Status::SubCode::kMergeOperatorFailed) {
-          state_ = kMergeOperatorFailed;
-        } else {
-          state_ = kCorrupt;
-        }
-        return;
-      }
-    }
+  // `op_failure_scope` (an output parameter) is not provided (set to nullptr)
+  // since a failure must be propagated regardless of its value.
+  const Status s = MergeHelper::TimedFullMerge(
+      merge_operator_, user_key_, MergeHelper::kPlainBaseValue, value,
+      merge_context_->GetOperands(), logger_, statistics_, clock_,
+      /* update_num_ops_stats */ true,
+      pinnable_val_ ? pinnable_val_->GetSelf() : nullptr, columns_,
+      /* op_failure_scope */ nullptr);
+  PostprocessMerge(s);
+}
 
-    pinnable_val_->PinSelf();
-    return;
-  }
+void GetContext::MergeWithWideColumnBaseValue(const Slice& entity) {
+  assert(do_merge_);
+  assert(pinnable_val_ || columns_);
+  assert(!pinnable_val_ || !columns_);
 
-  std::string result;
-
-  {
-    // `op_failure_scope` (an output parameter) is not provided (set to nullptr)
-    // since a failure must be propagated regardless of its value.
-    const Status s = MergeHelper::TimedFullMergeWithEntity(
-        merge_operator_, user_key_, entity, merge_context_->GetOperands(),
-        &result, logger_, statistics_, clock_, /* update_num_ops_stats */ true,
-        /* op_failure_scope */ nullptr);
-    if (!s.ok()) {
-      if (s.subcode() == Status::SubCode::kMergeOperatorFailed) {
-        state_ = kMergeOperatorFailed;
-      } else {
-        state_ = kCorrupt;
-      }
-      return;
-    }
-  }
-
-  {
-    assert(columns_);
-    const Status s = columns_->SetWideColumnValue(std::move(result));
-    if (!s.ok()) {
-      state_ = kCorrupt;
-      return;
-    }
-  }
+  // `op_failure_scope` (an output parameter) is not provided (set to nullptr)
+  // since a failure must be propagated regardless of its value.
+  const Status s = MergeHelper::TimedFullMerge(
+      merge_operator_, user_key_, MergeHelper::kWideBaseValue, entity,
+      merge_context_->GetOperands(), logger_, statistics_, clock_,
+      /* update_num_ops_stats */ true,
+      pinnable_val_ ? pinnable_val_->GetSelf() : nullptr, columns_,
+      /* op_failure_scope */ nullptr);
+  PostprocessMerge(s);
 }
 
 bool GetContext::GetBlobValue(const Slice& user_key, const Slice& blob_index,

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -191,8 +191,16 @@ class GetContext {
   void push_operand(const Slice& value, Cleanable* value_pinner);
 
  private:
-  void Merge(const Slice* value);
-  void MergeWithEntity(Slice entity);
+  // Helper method that postprocesses the results of merge operations, e.g. it
+  // sets the state correctly upon merge errors.
+  void PostprocessMerge(const Status& merge_status);
+
+  // The following methods perform the actual merge operation for the
+  // no base value/plain base value/wide-column base value cases.
+  void MergeWithNoBaseValue();
+  void MergeWithPlainBaseValue(const Slice& value);
+  void MergeWithWideColumnBaseValue(const Slice& entity);
+
   bool GetBlobValue(const Slice& user_key, const Slice& blob_index,
                     PinnableSlice* blob_value);
 

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/write_batch_with_index.h"
 
 #include <memory>
@@ -547,9 +546,9 @@ Status WriteBatchWithIndex::GetFromBatchAndDB(
       // Merge result from DB with merges in Batch
       std::string merge_result;
       if (s.ok()) {
-        s = wbwii.MergeKey(key, pinnable_val, &merge_result);
+        s = wbwii.MergeKey(key, *pinnable_val, &merge_result);
       } else {  // Key not present in db (s.IsNotFound())
-        s = wbwii.MergeKey(key, nullptr, &merge_result);
+        s = wbwii.MergeKey(key, &merge_result);
       }
       if (s.ok()) {
         pinnable_val->Reset();
@@ -644,11 +643,10 @@ void WriteBatchWithIndex::MultiGetFromBatchAndDB(
         std::string merged_value;
         // Merge result from DB with merges in Batch
         if (key.s->ok()) {
-          *key.s = wbwii.MergeKey(*key.key, iter->value, merge_result.second,
+          *key.s = wbwii.MergeKey(*key.key, *iter->value, merge_result.second,
                                   &merged_value);
         } else {  // Key not present in db (s.IsNotFound())
-          *key.s = wbwii.MergeKey(*key.key, nullptr, merge_result.second,
-                                  &merged_value);
+          *key.s = wbwii.MergeKey(*key.key, merge_result.second, &merged_value);
         }
         if (key.s->ok()) {
           key.value->Reset();

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-
 #include <limits>
 #include <string>
 #include <vector>
@@ -25,6 +24,7 @@ class MergeContext;
 class WBWIIteratorImpl;
 class WriteBatchWithIndexInternal;
 struct Options;
+struct ImmutableOptions;
 
 // when direction == forward
 // * current_at_base_ <=> base_iterator > delta_iterator
@@ -322,17 +322,31 @@ class WriteBatchWithIndexInternal {
                                         const Slice& key,
                                         MergeContext* merge_context,
                                         std::string* value, Status* s);
-  Status MergeKey(const Slice& key, const Slice* value,
+
+  // Merge with no base value
+  Status MergeKey(const Slice& key, const MergeContext& context,
+                  std::string* result) const;
+  Status MergeKey(const Slice& key, std::string* result) const {
+    return MergeKey(key, merge_context_, result);
+  }
+
+  // Merge with plain base value
+  Status MergeKey(const Slice& key, const Slice& value,
+                  const MergeContext& context, std::string* result) const;
+  Status MergeKey(const Slice& key, const Slice& value,
                   std::string* result) const {
     return MergeKey(key, value, merge_context_, result);
   }
-  Status MergeKey(const Slice& key, const Slice* value,
-                  const MergeContext& context, std::string* result) const;
+
   size_t GetNumOperands() const { return merge_context_.GetNumOperands(); }
   MergeContext* GetMergeContext() { return &merge_context_; }
   Slice GetOperand(int index) const { return merge_context_.GetOperand(index); }
 
  private:
+  const ImmutableOptions& GetCFOptions() const;
+  std::tuple<Logger*, Statistics*, SystemClock*> GetStatsLoggerAndClock(
+      const ImmutableOptions& cf_opts) const;
+
   DB* db_;
   const DBOptions* db_options_;
   ColumnFamilyHandle* column_family_;


### PR DESCRIPTION
The patch builds on https://github.com/facebook/rocksdb/pull/11807 and integrates the FullMergeV3 API into the read and compaction code paths by updating and extending the logic in MergeHelper.

In particular, when it comes to merge inputs, the existing TimedFullMergeWithEntity is folded into TimedFullMerge, since wide-column base values are now handled the same way as plain base values (or no base values for that matter), e.g. they are passed directly to the MergeOperator. On the other hand, there is some new differentiation on the output side. Namely, there are now two sets of TimedFullMerge variants: one set for contexts where the complete merge result and its value type are needed (used by iterators and compactions), and another set where the merge result is needed in a form determined by the client (used by the point lookup APIs, where e.g. for Get we have to extract the value of the default column of any wide-column results).

Implementation-wise, the two sets of overloads use different visitors to process the std::variant produced by FullMergeV3. This has the benefit of eliminating some repeated code e.g. in the point lookup paths, since TimedFullMerge now populates the application's result object (PinnableSlice/string or PinnableWideColumns) directly. Moreover, within each set of variants, there is a separate overload for the no base value/plain base value/wide-column base value cases, which eliminates some repeated branching w/r/t to the type of the base value if any.

Differential Revision: D49352562
