### PR TITLE
Lookup ahead in block cache ahead to tune Readaheadsize

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1375,7 +1375,8 @@ Status StressTest::TestIterate(ThreadState* thread,
                    key, op_logs, &diverged);
 
     const bool no_reverse =
-        (FLAGS_memtablerep == "prefix_hash" && !expect_total_order);
+        (FLAGS_memtablerep == "prefix_hash" && !expect_total_order) ||
+        FLAGS_auto_readahead_size;
     for (uint64_t i = 0; i < FLAGS_num_iterations && iter->Valid(); ++i) {
       if (no_reverse || thread->rand.OneIn(2)) {
         iter->Next();

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1914,7 +1914,8 @@ class NonBatchedOpsStressTest : public StressTest {
       if (static_cast<int64_t>(curr) < lb) {
         iter->Next();
         op_logs += "N";
-      } else if (static_cast<int64_t>(curr) >= ub) {
+      } else if (static_cast<int64_t>(curr) >= ub &&
+                 !FLAGS_auto_readahead_size) {
         iter->Prev();
         op_logs += "P";
       } else {

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -673,9 +673,6 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
         return false;
       }
       readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
-      if (getenv("Print")) {
-        printf("Readahead size: %lu\n", readahead_size_);
-      }
     } else {
       return false;
     }

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -660,8 +660,8 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
             return false;
           }
         }
-        ReadAheadSizeTuning(offset, n);
-        s = Prefetch(opts, reader, offset, n + readahead_size_);
+        size_t current_readahead_size = ReadAheadSizeTuning(offset, n);
+        s = Prefetch(opts, reader, offset, n + current_readahead_size);
       }
       if (!s.ok()) {
         if (status) {

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -660,7 +660,7 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
             return false;
           }
         }
-        UpdateReadAheadSizeForUpperBound(offset, n);
+        ReadAheadSizeTuning(offset, n);
         s = Prefetch(opts, reader, offset, n + readahead_size_);
       }
       if (!s.ok()) {
@@ -673,6 +673,9 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
         return false;
       }
       readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
+      if (getenv("Print")) {
+        printf("Readahead size: %lu\n", readahead_size_);
+      }
     } else {
       return false;
     }

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -326,28 +326,16 @@ class FilePrefetchBuffer {
 
   // Called in case of implicit auto prefetching.
   void ResetValues() {
-    if (getenv("Print")) {
-      printf("Reset Values\n");
-    }
     num_file_reads_ = 1;
     readahead_size_ = initial_auto_readahead_size_;
   }
 
   // Called in case of implicit auto prefetching.
   bool IsEligibleForPrefetch(uint64_t offset, size_t n) {
-    if (getenv("Print")) {
-      printf(
-          "IsEligibleForPrefetch offset: %lu, n: %lu, prev_offset: %lu, "
-          "prev_len: %lu \n",
-          offset, n, prev_offset_, prev_len_);
-    }
     // Prefetch only if this read is sequential otherwise reset readahead_size_
     // to initial value.
     if (!IsBlockSequential(offset)) {
       UpdateReadPattern(offset, n, false /*decrease_readaheadsize*/);
-      if (getenv("Print")) {
-        printf("IsEligibleForPrefetching\n");
-      }
       ResetValues();
       return false;
     }
@@ -467,9 +455,6 @@ class FilePrefetchBuffer {
     UpdateReadAheadSizeForUpperBound(offset, n);
 
     if (readaheadsize_cb_ != nullptr && readahead_size_ > 0) {
-      if (getenv("Print")) {
-        printf("readahead_size_ : %lu \n", readahead_size_);
-      }
       size_t updated_readahead_size = 0;
       readaheadsize_cb_(offset, readahead_size_, updated_readahead_size);
       readahead_size_ = updated_readahead_size;

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -451,14 +451,18 @@ class FilePrefetchBuffer {
   }
 
   // Performs tuning to calculate readahead_size.
-  void ReadAheadSizeTuning(uint64_t offset, size_t n) {
+  size_t ReadAheadSizeTuning(uint64_t offset, size_t n) {
     UpdateReadAheadSizeForUpperBound(offset, n);
 
     if (readaheadsize_cb_ != nullptr && readahead_size_ > 0) {
       size_t updated_readahead_size = 0;
       readaheadsize_cb_(offset, readahead_size_, updated_readahead_size);
-      readahead_size_ = updated_readahead_size;
+      if (readahead_size_ != updated_readahead_size) {
+        RecordTick(stats_, READAHEAD_TRIMMED);
+      }
+      return updated_readahead_size;
     }
+    return readahead_size_;
   }
 
   std::vector<BufferInfo> bufs_;

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -90,7 +90,7 @@ class FilePrefetchBuffer {
       uint64_t num_file_reads_for_auto_readahead = 0,
       uint64_t upper_bound_offset = 0, FileSystem* fs = nullptr,
       SystemClock* clock = nullptr, Statistics* stats = nullptr,
-      std::function<void(uint64_t, size_t, size_t&)> cb = nullptr,
+      const std::function<void(uint64_t, size_t, size_t&)>& cb = nullptr,
       FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown)
       : curr_(0),
         readahead_size_(readahead_size),

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -90,7 +90,7 @@ class FilePrefetchBuffer {
       uint64_t num_file_reads_for_auto_readahead = 0,
       uint64_t upper_bound_offset = 0, FileSystem* fs = nullptr,
       SystemClock* clock = nullptr, Statistics* stats = nullptr,
-      std::function<void(size_t, size_t&)> cb = nullptr,
+      std::function<void(uint64_t, size_t, size_t&)> cb = nullptr,
       FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown)
       : curr_(0),
         readahead_size_(readahead_size),
@@ -471,7 +471,7 @@ class FilePrefetchBuffer {
         printf("readahead_size_ : %lu \n", readahead_size_);
       }
       size_t updated_readahead_size = 0;
-      readaheadsize_cb_(readahead_size_, updated_readahead_size);
+      readaheadsize_cb_(offset, readahead_size_, updated_readahead_size);
       readahead_size_ = updated_readahead_size;
     }
   }
@@ -522,6 +522,6 @@ class FilePrefetchBuffer {
   // ReadOptions.auto_readahead_size are set to trim readahead_size upto
   // upper_bound_offset_ during prefetching.
   uint64_t upper_bound_offset_ = 0;
-  std::function<void(size_t, size_t&)> readaheadsize_cb_;
+  std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -460,8 +460,9 @@ class FilePrefetchBuffer {
       return (offset >= upper_bound_offset_);
     }
     return false;
+  }
 
-  // Performs  tuning to calculate readahead_size.
+  // Performs tuning to calculate readahead_size.
   void ReadAheadSizeTuning(uint64_t offset, size_t n) {
     UpdateReadAheadSizeForUpperBound(offset, n);
 

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1526,6 +1526,7 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest2) {
 
     // Reseek with new upper_bound_iterator.
     {
+      /*
       ub = Slice("my_key_y");
       Slice reseek_key = Slice("my_key_v");
       iter->Seek(reseek_key);
@@ -1538,12 +1539,14 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest2) {
       uint64_t readahead_trimmed =
           options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
       ASSERT_GT(readahead_trimmed, 0);
-      ASSERT_GT(reseek_keys_with_tuning, 0);
+      // ASSERT_GT(reseek_keys_with_tuning, 0);
+      */
     }
   }
 
   // Without tuning readahead_size
   {
+    printf("\n\n - Without Tuning\n");
     Slice ub = Slice("my_key_uuu");
     Slice* ub_ptr = &ub;
     ropts.iterate_upper_bound = ub_ptr;
@@ -1570,6 +1573,7 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest2) {
 
     // Reseek with new upper_bound_iterator.
     {
+      /*
       ub = Slice("my_key_y");
       Slice reseek_key = Slice("my_key_v");
       iter->Seek(reseek_key);
@@ -1583,6 +1587,7 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest2) {
           options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
       ASSERT_EQ(readahead_trimmed, 0);
       ASSERT_GT(reseek_keys_without_tuning, 0);
+      */
     }
   }
 
@@ -1604,7 +1609,7 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest2) {
     // No of keys should be equal.
     ASSERT_EQ(keys_without_tuning, keys_with_tuning);
     // No of keys after reseek with new upper bound should be equal.
-    ASSERT_EQ(reseek_keys_without_tuning, reseek_keys_with_tuning);
+    // ASSERT_EQ(reseek_keys_without_tuning, reseek_keys_with_tuning);
   }
   Close();
   // }

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1233,7 +1233,7 @@ TEST_P(PrefetchTest, PrefetchWhenReseekwithCache) {
   Close();
 }
 
-TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTune) {
+TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest1) {
   // First param is if the mockFS support_prefetch or not
   const int kNumKeys = 2000;
   std::shared_ptr<MockFS> fs = std::make_shared<MockFS>(
@@ -1373,6 +1373,241 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTune) {
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
   Close();
+}
+
+TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest2) {
+  if (mem_env_ || encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-mem or non-encrypted environment");
+    return;
+  }
+
+  // First param is if the mockFS support_prefetch or not
+  std::shared_ptr<MockFS> fs =
+      std::make_shared<MockFS>(FileSystem::Default(), false);
+
+  std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, fs));
+  Options options;
+  SetGenericOptions(env.get(), /*use_direct_io=*/false, options);
+  options.statistics = CreateDBStatistics();
+  BlockBasedTableOptions table_options;
+  std::shared_ptr<Cache> cache = NewLRUCache(4 * 1024 * 1024, 2);  // 8MB
+  SetBlockBasedTableOptions(table_options);
+  table_options.block_cache = cache;
+  table_options.no_block_cache = false;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  Status s = TryReopen(options);
+  ASSERT_OK(s);
+
+  Random rnd(309);
+  WriteBatch batch;
+
+  for (int i = 0; i < 26; i++) {
+    std::string key = "my_key_";
+
+    for (int j = 0; j < 10; j++) {
+      key += char('a' + i);
+      ASSERT_OK(batch.Put(key, rnd.RandomString(1000)));
+    }
+  }
+  ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+  std::string start_key = "my_key_a";
+
+  std::string end_key = "my_key_";
+  for (int j = 0; j < 10; j++) {
+    end_key += char('a' + 25);
+  }
+
+  Slice least(start_key.data(), start_key.size());
+  Slice greatest(end_key.data(), end_key.size());
+
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &least, &greatest));
+
+  int buff_prefetch_count = 0;
+
+  // Try with different num_file_reads_for_auto_readahead from 0 to 3.
+  // for (size_t i = 0; i < 3; i++) {
+  //  table_options.num_file_reads_for_auto_readahead = i;
+  // options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  // s = TryReopen(options);
+  // ASSERT_OK(s);
+
+  // int buff_count_with_tuning = 0, buff_count_without_tuning = 0;
+  int keys_with_tuning = 0, keys_without_tuning = 0;
+  // int reseek_keys_with_tuning = 0, reseek_keys_without_tuning = 0;
+  buff_prefetch_count = 0;
+
+  SyncPoint::GetInstance()->SetCallBack("FilePrefetchBuffer::Prefetch:Start",
+                                        [&](void*) { buff_prefetch_count++; });
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "FilePrefetchBuffer::PrefetchAsyncInternal:Start",
+      [&](void*) { buff_prefetch_count++; });
+
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ReadOptions ropts;
+  /*
+  if (std::get<0>(GetParam())) {
+    ropts.readahead_size = 32768;
+  }
+  */
+  /*
+  if (std::get<1>(GetParam())) {
+    ropts.async_io = true;
+  }
+  */
+
+  {
+    printf("Iteration\n");
+    auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
+
+    // Warm up the cache
+    printf("Cache bbb\n");
+    iter->Seek("my_key_bbb");
+    ASSERT_TRUE(iter->Valid());
+
+    printf("Cache c9 \n");
+    iter->Seek("my_key_ccccccccc");
+    ASSERT_TRUE(iter->Valid());
+
+    printf("Cache d3\n");
+    iter->Seek("my_key_ddd");
+    ASSERT_TRUE(iter->Valid());
+
+    printf("Cache d7\n");
+    iter->Seek("my_key_ddddddd");
+    ASSERT_TRUE(iter->Valid());
+
+    printf("Cache e\n");
+    iter->Seek("my_key_e");
+    ASSERT_TRUE(iter->Valid());
+
+    printf("Cache eeeee\n");
+    iter->Seek("my_key_eeeee");
+    ASSERT_TRUE(iter->Valid());
+
+    printf("Cache eeeeeeeee\n");
+    iter->Seek("my_key_eeeeeeeee");
+    ASSERT_TRUE(iter->Valid());
+
+    buff_prefetch_count = 0;
+    printf("Done\n");
+  }
+
+  // With tuning readahead_size.
+  {
+    ASSERT_OK(options.statistics->Reset());
+    Slice ub = Slice("my_key_uuu");
+    Slice* ub_ptr = &ub;
+    ropts.iterate_upper_bound = ub_ptr;
+    ropts.auto_readahead_size = true;
+
+    auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ropts));
+
+    // Seek.
+    {
+      printf("\n\nSeek aaa\n");
+      Slice seek_key = Slice("my_key_aaa");
+      iter->Seek(seek_key);
+
+      while (iter->Valid()) {
+        keys_with_tuning++;
+        iter->Next();
+      }
+
+      uint64_t readahead_trimmed =
+          options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
+      ASSERT_GT(readahead_trimmed, 0);
+      // buff_count_with_tuning = buff_prefetch_count;
+    }
+
+    // Reseek with new upper_bound_iterator.
+    {
+      ub = Slice("my_key_y");
+      Slice reseek_key = Slice("my_key_v");
+      iter->Seek(reseek_key);
+
+      while (iter->Valid()) {
+        iter->Next();
+        reseek_keys_with_tuning++;
+      }
+
+      uint64_t readahead_trimmed =
+          options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
+      ASSERT_GT(readahead_trimmed, 0);
+      ASSERT_GT(reseek_keys_with_tuning, 0);
+    }
+  }
+
+  // Without tuning readahead_size
+  {
+    Slice ub = Slice("my_key_uuu");
+    Slice* ub_ptr = &ub;
+    ropts.iterate_upper_bound = ub_ptr;
+    buff_prefetch_count = 0;
+    ASSERT_OK(options.statistics->Reset());
+    ropts.auto_readahead_size = false;
+
+    auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ropts));
+
+    // Seek.
+    {
+      Slice seek_key = Slice("my_key_aaa");
+      iter->Seek(seek_key);
+
+      while (iter->Valid()) {
+        keys_without_tuning++;
+        iter->Next();
+      }
+      // buff_count_without_tuning = buff_prefetch_count;
+      uint64_t readahead_trimmed =
+          options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
+      ASSERT_EQ(readahead_trimmed, 0);
+    }
+
+    // Reseek with new upper_bound_iterator.
+    {
+      ub = Slice("my_key_y");
+      Slice reseek_key = Slice("my_key_v");
+      iter->Seek(reseek_key);
+
+      while (iter->Valid()) {
+        iter->Next();
+        reseek_keys_without_tuning++;
+      }
+
+      uint64_t readahead_trimmed =
+          options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
+      ASSERT_EQ(readahead_trimmed, 0);
+      ASSERT_GT(reseek_keys_without_tuning, 0);
+    }
+  }
+
+  {
+    // Verify results with and without tuning.
+    /*
+    if (std::get<1>(GetParam())) {
+      // In case of async_io.
+      ASSERT_GE(buff_count_with_tuning, buff_count_without_tuning);
+    } else {
+      ASSERT_EQ(buff_count_without_tuning, buff_count_with_tuning);
+    }
+    */
+    // Prefetching should happen.
+    /*
+    ASSERT_GT(buff_count_without_tuning, 0);
+    ASSERT_GT(buff_count_with_tuning, 0);
+    */
+    // No of keys should be equal.
+    ASSERT_EQ(keys_without_tuning, keys_with_tuning);
+    // No of keys after reseek with new upper bound should be equal.
+    ASSERT_EQ(reseek_keys_without_tuning, reseek_keys_with_tuning);
+  }
+  Close();
+  // }
 }
 
 // This test verifies the functionality of ReadOptions.adaptive_readahead.

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1349,7 +1349,7 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
 
         uint64_t readahead_trimmed =
             options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
-        ASSERT_GT(readahead_trimmed, 1);
+        ASSERT_GT(readahead_trimmed, 0);
 
         ASSERT_OK(cmp_iter->status());
         ASSERT_OK(iter->status());
@@ -1379,7 +1379,7 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
 
         uint64_t readahead_trimmed =
             options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
-        ASSERT_GT(readahead_trimmed, 1);
+        ASSERT_GT(readahead_trimmed, 0);
 
         ASSERT_OK(cmp_iter->status());
         ASSERT_OK(iter->status());

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -654,9 +654,6 @@ TEST_P(PrefetchTest, ConfigureInternalAutoReadaheadSize) {
 
   SyncPoint::GetInstance()->SetCallBack("FilePrefetchBuffer::Prefetch:Start",
                                         [&](void*) { buff_prefetch_count++; });
-
-  SyncPoint::GetInstance()->EnableProcessing();
-
   SyncPoint::GetInstance()->EnableProcessing();
 
   Status s = TryReopen(options);
@@ -1239,7 +1236,6 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
     return;
   }
 
-  // First param is if the mockFS support_prefetch or not
   std::shared_ptr<MockFS> fs =
       std::make_shared<MockFS>(FileSystem::Default(), false);
 
@@ -1292,55 +1288,38 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
 
     // Warm up the cache.
     {
-      printf("Iteration\n");
       auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
 
-      printf("Cache bbb\n");
       iter->Seek("my_key_bbb");
       ASSERT_TRUE(iter->Valid());
 
-      printf("Cache c9 \n");
       iter->Seek("my_key_ccccccccc");
       ASSERT_TRUE(iter->Valid());
 
-      printf("Cache d3\n");
       iter->Seek("my_key_ddd");
       ASSERT_TRUE(iter->Valid());
 
-      printf("Cache d7\n");
       iter->Seek("my_key_ddddddd");
       ASSERT_TRUE(iter->Valid());
 
-      printf("Cache e\n");
       iter->Seek("my_key_e");
       ASSERT_TRUE(iter->Valid());
 
-      printf("Cache eeeee\n");
       iter->Seek("my_key_eeeee");
       ASSERT_TRUE(iter->Valid());
 
-      printf("Cache eeeeeeeee\n");
       iter->Seek("my_key_eeeeeeeee");
       ASSERT_TRUE(iter->Valid());
-
-      printf("Done\n");
     }
-
-    /*
-    if (std::get<0>(GetParam())) {
-      ropts.readahead_size = 32768;
-    }
-    */
-    /*
-    if (std::get<1>(GetParam())) {
-      ropts.async_io = true;
-    }
-    */
 
     ReadOptions ropts;
     ropts.auto_readahead_size = true;
     ReadOptions cmp_ro;
     cmp_ro.auto_readahead_size = false;
+
+    if (std::get<0>(GetParam())) {
+      ropts.readahead_size = cmp_ro.readahead_size = 32768;
+    }
 
     // With and without tuning readahead_size.
     {
@@ -1355,7 +1334,6 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
         auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ropts));
         auto cmp_iter = std::unique_ptr<Iterator>(db_->NewIterator(cmp_ro));
 
-        printf("\n\nSeek aaa\n");
         Slice seek_key = Slice("my_key_aaa");
         iter->Seek(seek_key);
         cmp_iter->Seek(seek_key);
@@ -1371,12 +1349,6 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
 
         ASSERT_OK(cmp_iter->status());
         ASSERT_OK(iter->status());
-
-        /*
-        uint64_t readahead_trimmed =
-            options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
-        ASSERT_GT(readahead_trimmed, 0);
-        */
       }
 
       // Reseek with new upper_bound_iterator.
@@ -1404,16 +1376,88 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
 
         ASSERT_OK(cmp_iter->status());
         ASSERT_OK(iter->status());
-
-        /*
-        uint64_t readahead_trimmed =
-            options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED);
-        ASSERT_GT(readahead_trimmed, 0);
-        */
       }
     }
     Close();
   }
+}
+
+TEST_F(PrefetchTest, PrefetchWithBlockLookupAutoTuneWithPrev) {
+  if (mem_env_ || encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-mem or non-encrypted environment");
+    return;
+  }
+
+  // First param is if the mockFS support_prefetch or not
+  std::shared_ptr<MockFS> fs =
+      std::make_shared<MockFS>(FileSystem::Default(), false);
+
+  std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, fs));
+  Options options;
+  SetGenericOptions(env.get(), /*use_direct_io=*/false, options);
+  options.statistics = CreateDBStatistics();
+  BlockBasedTableOptions table_options;
+  SetBlockBasedTableOptions(table_options);
+  std::shared_ptr<Cache> cache = NewLRUCache(1024 * 1024, 2);
+  table_options.block_cache = cache;
+  table_options.no_block_cache = false;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  Status s = TryReopen(options);
+  ASSERT_OK(s);
+
+  Random rnd(309);
+  WriteBatch batch;
+
+  for (int i = 0; i < 26; i++) {
+    std::string key = "my_key_";
+
+    for (int j = 0; j < 10; j++) {
+      key += char('a' + i);
+      ASSERT_OK(batch.Put(key, rnd.RandomString(1000)));
+    }
+  }
+  ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+  std::string start_key = "my_key_a";
+
+  std::string end_key = "my_key_";
+  for (int j = 0; j < 10; j++) {
+    end_key += char('a' + 25);
+  }
+
+  Slice least(start_key.data(), start_key.size());
+  Slice greatest(end_key.data(), end_key.size());
+
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &least, &greatest));
+
+  ReadOptions ropts;
+  ropts.auto_readahead_size = true;
+
+  {
+    // Seek.
+    Slice ub = Slice("my_key_uuu");
+    Slice* ub_ptr = &ub;
+    ropts.iterate_upper_bound = ub_ptr;
+    ropts.auto_readahead_size = true;
+
+    auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ropts));
+
+    Slice seek_key = Slice("my_key_bbb");
+    iter->Seek(seek_key);
+    ASSERT_TRUE(iter->Valid());
+
+    // Prev op should fail with auto tuning of readahead_size.
+    iter->Prev();
+    ASSERT_TRUE(iter->status().IsNotSupported());
+    ASSERT_FALSE(iter->Valid());
+
+    // Reseek would follow as usual.
+    iter->Seek(seek_key);
+    ASSERT_OK(iter->status());
+    ASSERT_TRUE(iter->Valid());
+  }
+  Close();
 }
 
 // This test verifies the functionality of ReadOptions.adaptive_readahead.

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1353,7 +1353,6 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
 
       // Reseek with new upper_bound_iterator.
       {
-        printf("\n\n Reseek\n");
         Slice ub = Slice("my_key_y");
         ropts.iterate_upper_bound = &ub;
         cmp_ro.iterate_upper_bound = &ub;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1719,6 +1719,8 @@ struct ReadOptions {
   // during scans internally.
   // For this feature to enabled, iterate_upper_bound must also be specified.
   //
+  // NOTE: Not supported with Prev operation and it will be return NotSupported
+  // error. Enable it for forward scans only.
   // Default: false
   bool auto_readahead_size = false;
 

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -19,7 +19,7 @@ void BlockBasedTableIterator::Seek(const Slice& target) {
 void BlockBasedTableIterator::SeekImpl(const Slice* target,
                                        bool async_prefetch) {
   ResetBlockCacheLookupVar();
-  bool is_first_pass = async_read_in_progress_ ? false : true;
+  bool is_first_pass = !async_read_in_progress_;
   bool autotune_readaheadsize = is_first_pass &&
                                 read_options_.auto_readahead_size &&
                                 read_options_.iterate_upper_bound;

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -317,10 +317,12 @@ void BlockBasedTableIterator::Prev() {
 void BlockBasedTableIterator::InitDataBlock() {
   BlockHandle data_block_handle;
   bool is_in_cache = false;
+  bool use_block_cache_for_lookup = true;
 
   if (DoesContainBlockHandles()) {
     data_block_handle = block_handles_.front().index_val_.handle;
     is_in_cache = block_handles_.front().is_cache_hit_;
+    use_block_cache_for_lookup = false;
   } else {
     data_block_handle = index_iter_->value().handle;
   }
@@ -372,7 +374,7 @@ void BlockBasedTableIterator::InitDataBlock() {
           /*get_context=*/nullptr, &lookup_context_,
           block_prefetcher_.prefetch_buffer(),
           /*for_compaction=*/is_for_compaction, /*async_read=*/false, s,
-          /*use_block_cache_for_lookup=*/true);
+          use_block_cache_for_lookup);
     }
     block_iter_points_to_real_block_ = true;
 

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -352,7 +352,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
 
   // This API is called to lookup the data blocks ahead in the cache to estimate
   // the current readahead_size.
-  void BlockCacheLookupForReadAheadSize(size_t readahead_size,
+  void BlockCacheLookupForReadAheadSize(uint64_t offset, size_t readahead_size,
                                         size_t& updated_readahead_size);
 
   void ResetBlockCacheLookupVar() {

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -378,5 +378,9 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
       block_handles_.pop_front();
     }
   }
+
+  void ResetPreviousBlockOffset() {
+    prev_block_offset_ = std::numeric_limits<uint64_t>::max();
+  }
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1547,12 +1547,6 @@ BlockBasedTable::MaybeReadBlockAndLoadToCache(
           // and compressed block cache.
           is_cache_hit = true;
           if (prefetch_buffer) {
-            if (getenv("Print")) {
-              printf(
-                  "GetDataBlockFromCache:: Cache Hit offset: %lu, length: "
-                  "%lu\n",
-                  handle.offset(), BlockSizeWithTrailer(handle));
-            }
             // Update the block details so that PrefetchBuffer can use the read
             // pattern to determine if reads are sequential or not for
             // prefetching. It should also take in account blocks read from

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -102,7 +102,8 @@ CacheAllocationPtr CopyBufferToHeap(MemoryAllocator* allocator, Slice& buf) {
       GetContext* get_context, BlockCacheLookupContext* lookup_context,        \
       BlockContents* contents, bool async_read,                                \
       bool use_block_cache_for_lookup) const;                                  \
-  template bool BlockBasedTable::DoLookup<T>(const BlockHandle& handle) const;
+  template bool BlockBasedTable::LookupAndPinBlocksInCache<T>(                 \
+      const BlockHandle& handle) const;
 
 INSTANTIATE_BLOCKLIKE_TEMPLATES(ParsedFullFilterBlock);
 INSTANTIATE_BLOCKLIKE_TEMPLATES(UncompressionDict);
@@ -1473,13 +1474,14 @@ IndexBlockIter* BlockBasedTable::InitBlockIterator<IndexBlockIter>(
 }
 
 template <typename TBlocklike>
-bool BlockBasedTable::DoLookup(const BlockHandle& handle) const {
+bool BlockBasedTable::LookupAndPinBlocksInCache(
+    const BlockHandle& handle) const {
   BlockCacheInterface<TBlocklike> block_cache{
       rep_->table_options.block_cache.get()};
 
   assert(block_cache);
 
-  // 1. Do the lookup.
+  // Do the lookup.
   CacheKey key_data = GetCacheKey(rep_->base_cache_key, handle);
   const Slice key = key_data.AsSlice();
 
@@ -1490,12 +1492,13 @@ bool BlockBasedTable::DoLookup(const BlockHandle& handle) const {
       rep_->ioptions.lowest_used_cache_tier);
 
   if (!cache_handle) {
-    // 2. Add a placeholder for the data block.
+    // Add a placeholder for the data block.
+    // TODO Akanksha:
     return false;
   }
 
-  // 2. Found in Cache. Pin the block.
-
+  // Found in Cache. Pin the block.
+  // TODO Akanksha:
   return true;
 }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1493,11 +1493,16 @@ bool BlockBasedTable::LookupAndPinBlocksInCache(
       rep_->ioptions.lowest_used_cache_tier);
 
   if (!cache_handle) {
+    UpdateCacheMissMetrics(TBlocklike::kBlockType, /* get_context = */ nullptr);
     return false;
   }
 
   // Found in Cache.
   TBlocklike* value = block_cache.Value(cache_handle);
+  if (value) {
+    UpdateCacheHitMetrics(TBlocklike::kBlockType, /* get_context = */ nullptr,
+                          block_cache.get()->GetUsage(cache_handle));
+  }
   out_parsed_block->SetCachedValue(value, block_cache.get(), cache_handle);
 
   assert(!out_parsed_block->IsEmpty());

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1498,10 +1498,12 @@ bool BlockBasedTable::LookupAndPinBlocksInCache(
     return false;
   }
 
-  // Found in Cache. Pin the block.
-  // TODO Akanksha:
+  // Found in Cache.
   TBlocklike* value = block_cache.Value(cache_handle);
   out_parsed_block->SetCachedValue(value, block_cache.get(), cache_handle);
+
+  assert(!out_parsed_block->IsEmpty());
+
   return true;
 }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1493,8 +1493,6 @@ bool BlockBasedTable::LookupAndPinBlocksInCache(
       rep_->ioptions.lowest_used_cache_tier);
 
   if (!cache_handle) {
-    // Add a placeholder for the data block.
-    // TODO Akanksha:
     return false;
   }
 

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -697,7 +697,7 @@ struct BlockBasedTable::Rep {
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
       uint64_t upper_bound_offset,
-      std::function<void(size_t, size_t&)> readaheadsize_cb) const {
+      std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb) const {
     fpb->reset(new FilePrefetchBuffer(
         readahead_size, max_readahead_size,
         !ioptions.allow_mmap_reads /* enable */, false /* track_min_offset */,
@@ -711,7 +711,7 @@ struct BlockBasedTable::Rep {
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
       uint64_t upper_bound_offset,
-      std::function<void(size_t, size_t&)> readaheadsize_cb) const {
+      std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
                                implicit_auto_readahead, num_file_reads,

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -281,7 +281,7 @@ class BlockBasedTable : public TableReader {
                                   std::vector<KVPairBlock>* kv_pair_blocks);
 
   template <typename TBlocklike>
-  bool DoLookup(const BlockHandle& handle) const;
+  bool LookupAndPinBlocksInCache(const BlockHandle& handle) const;
 
   struct Rep;
 

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -281,8 +281,8 @@ class BlockBasedTable : public TableReader {
                                   std::vector<KVPairBlock>* kv_pair_blocks);
 
   template <typename TBlocklike>
-  bool LookupAndPinBlocksInCache(
-      const BlockHandle& handle,
+  Status LookupAndPinBlocksInCache(
+      const ReadOptions& ro, const BlockHandle& handle,
       CachableEntry<TBlocklike>* out_parsed_block) const;
 
   struct Rep;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -280,6 +280,9 @@ class BlockBasedTable : public TableReader {
   Status GetKVPairsFromDataBlocks(const ReadOptions& read_options,
                                   std::vector<KVPairBlock>* kv_pair_blocks);
 
+  template <typename TBlocklike>
+  bool DoLookup(const BlockHandle& handle) const;
+
   struct Rep;
 
   Rep* get_rep() { return rep_; }
@@ -687,31 +690,31 @@ struct BlockBasedTable::Rep {
   uint64_t sst_number_for_tracing() const {
     return file ? TableFileNameToNumber(file->file_name()) : UINT64_MAX;
   }
-  void CreateFilePrefetchBuffer(size_t readahead_size,
-                                size_t max_readahead_size,
-                                std::unique_ptr<FilePrefetchBuffer>* fpb,
-                                bool implicit_auto_readahead,
-                                uint64_t num_file_reads,
-                                uint64_t num_file_reads_for_auto_readahead,
-                                uint64_t upper_bound_offset) const {
+  void CreateFilePrefetchBuffer(
+      size_t readahead_size, size_t max_readahead_size,
+      std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
+      uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
+      uint64_t upper_bound_offset,
+      std::function<void(size_t, size_t&)> readaheadsize_cb) const {
     fpb->reset(new FilePrefetchBuffer(
         readahead_size, max_readahead_size,
         !ioptions.allow_mmap_reads /* enable */, false /* track_min_offset */,
         implicit_auto_readahead, num_file_reads,
         num_file_reads_for_auto_readahead, upper_bound_offset,
-        ioptions.fs.get(), ioptions.clock, ioptions.stats));
+        ioptions.fs.get(), ioptions.clock, ioptions.stats, readaheadsize_cb));
   }
 
   void CreateFilePrefetchBufferIfNotExists(
       size_t readahead_size, size_t max_readahead_size,
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
-      uint64_t upper_bound_offset) const {
+      uint64_t upper_bound_offset,
+      std::function<void(size_t, size_t&)> readaheadsize_cb) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
                                implicit_auto_readahead, num_file_reads,
                                num_file_reads_for_auto_readahead,
-                               upper_bound_offset);
+                               upper_bound_offset, readaheadsize_cb);
     }
   }
 

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -697,7 +697,8 @@ struct BlockBasedTable::Rep {
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
       uint64_t upper_bound_offset,
-      std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb) const {
+      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb)
+      const {
     fpb->reset(new FilePrefetchBuffer(
         readahead_size, max_readahead_size,
         !ioptions.allow_mmap_reads /* enable */, false /* track_min_offset */,
@@ -711,7 +712,8 @@ struct BlockBasedTable::Rep {
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
       uint64_t upper_bound_offset,
-      std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb) const {
+      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb)
+      const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
                                implicit_auto_readahead, num_file_reads,

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -281,7 +281,9 @@ class BlockBasedTable : public TableReader {
                                   std::vector<KVPairBlock>* kv_pair_blocks);
 
   template <typename TBlocklike>
-  bool LookupAndPinBlocksInCache(const BlockHandle& handle) const;
+  bool LookupAndPinBlocksInCache(
+      const BlockHandle& handle,
+      CachableEntry<TBlocklike>* out_parsed_block) const;
 
   struct Rep;
 

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -16,7 +16,7 @@ void BlockPrefetcher::PrefetchIfNeeded(
     const BlockBasedTable::Rep* rep, const BlockHandle& handle,
     const size_t readahead_size, bool is_for_compaction,
     const bool no_sequential_checking, const ReadOptions& read_options,
-    std::function<void(size_t, size_t&)> readaheadsize_cb) {
+    std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb) {
   const size_t len = BlockBasedTable::BlockSizeWithTrailer(handle);
   const size_t offset = handle.offset();
 

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -19,14 +19,7 @@ void BlockPrefetcher::PrefetchIfNeeded(
     std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb) {
   const size_t len = BlockBasedTable::BlockSizeWithTrailer(handle);
   const size_t offset = handle.offset();
-
-  if (getenv("Print")) {
-    printf("PrefetchIfNeeded\n");
-  }
   if (is_for_compaction) {
-    if (getenv("Print")) {
-      printf("ForCompaction\n");
-    }
     if (!rep->file->use_direct_io()) {
       // If FS supports prefetching (readahead_limit_ will be non zero in that
       // case) and current block exists in prefetch buffer then return.
@@ -60,9 +53,6 @@ void BlockPrefetcher::PrefetchIfNeeded(
 
   // Explicit user requested readahead.
   if (readahead_size > 0) {
-    if (getenv("Print")) {
-      printf("Explicit Readahead\n");
-    }
     rep->CreateFilePrefetchBufferIfNotExists(
         readahead_size, readahead_size, &prefetch_buffer_,
         /*implicit_auto_readahead=*/false, /*num_file_reads=*/0,
@@ -77,9 +67,6 @@ void BlockPrefetcher::PrefetchIfNeeded(
   // prefetched.
   size_t max_auto_readahead_size = rep->table_options.max_auto_readahead_size;
   if (max_auto_readahead_size == 0 || initial_auto_readahead_size_ == 0) {
-    if (getenv("Print")) {
-      printf("Max or initial Readahead is 0\n");
-    }
     return;
   }
 
@@ -107,9 +94,6 @@ void BlockPrefetcher::PrefetchIfNeeded(
   }
 
   if (!IsBlockSequential(offset)) {
-    if (getenv("Print")) {
-      printf("Not Sequential\n");
-    }
     UpdateReadPattern(offset, len);
     ResetValues(rep->table_options.initial_auto_readahead_size);
     return;
@@ -121,16 +105,10 @@ void BlockPrefetcher::PrefetchIfNeeded(
   // scans are sequential.
   num_file_reads_++;
   if (num_file_reads_ <= rep->table_options.num_file_reads_for_auto_readahead) {
-    if (getenv("Print")) {
-      printf("Num Readahead != default\n");
-    }
     return;
   }
 
   if (rep->file->use_direct_io()) {
-    if (getenv("Print")) {
-      printf("directIO Readahead\n");
-    }
     rep->CreateFilePrefetchBufferIfNotExists(
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,
@@ -155,9 +133,6 @@ void BlockPrefetcher::PrefetchIfNeeded(
       opts, handle.offset(),
       BlockBasedTable::BlockSizeWithTrailer(handle) + readahead_size_);
   if (s.IsNotSupported()) {
-    if (getenv("Print")) {
-      printf("CreateFilePrefetchBuffer\n");
-    }
     rep->CreateFilePrefetchBufferIfNotExists(
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -16,7 +16,7 @@ void BlockPrefetcher::PrefetchIfNeeded(
     const BlockBasedTable::Rep* rep, const BlockHandle& handle,
     const size_t readahead_size, bool is_for_compaction,
     const bool no_sequential_checking, const ReadOptions& read_options,
-    std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb) {
+    const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb) {
   const size_t len = BlockBasedTable::BlockSizeWithTrailer(handle);
   const size_t offset = handle.offset();
   if (is_for_compaction) {

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -20,7 +20,13 @@ void BlockPrefetcher::PrefetchIfNeeded(
   const size_t len = BlockBasedTable::BlockSizeWithTrailer(handle);
   const size_t offset = handle.offset();
 
+  if (getenv("Print")) {
+    printf("PrefetchIfNeeded\n");
+  }
   if (is_for_compaction) {
+    if (getenv("Print")) {
+      printf("ForCompaction\n");
+    }
     if (!rep->file->use_direct_io()) {
       // If FS supports prefetching (readahead_limit_ will be non zero in that
       // case) and current block exists in prefetch buffer then return.
@@ -54,6 +60,9 @@ void BlockPrefetcher::PrefetchIfNeeded(
 
   // Explicit user requested readahead.
   if (readahead_size > 0) {
+    if (getenv("Print")) {
+      printf("Explicit Readahead\n");
+    }
     rep->CreateFilePrefetchBufferIfNotExists(
         readahead_size, readahead_size, &prefetch_buffer_,
         /*implicit_auto_readahead=*/false, /*num_file_reads=*/0,
@@ -68,6 +77,9 @@ void BlockPrefetcher::PrefetchIfNeeded(
   // prefetched.
   size_t max_auto_readahead_size = rep->table_options.max_auto_readahead_size;
   if (max_auto_readahead_size == 0 || initial_auto_readahead_size_ == 0) {
+    if (getenv("Print")) {
+      printf("Max or initial Readahead is 0\n");
+    }
     return;
   }
 
@@ -95,6 +107,9 @@ void BlockPrefetcher::PrefetchIfNeeded(
   }
 
   if (!IsBlockSequential(offset)) {
+    if (getenv("Print")) {
+      printf("Not Sequential\n");
+    }
     UpdateReadPattern(offset, len);
     ResetValues(rep->table_options.initial_auto_readahead_size);
     return;
@@ -106,10 +121,16 @@ void BlockPrefetcher::PrefetchIfNeeded(
   // scans are sequential.
   num_file_reads_++;
   if (num_file_reads_ <= rep->table_options.num_file_reads_for_auto_readahead) {
+    if (getenv("Print")) {
+      printf("Num Readahead != default\n");
+    }
     return;
   }
 
   if (rep->file->use_direct_io()) {
+    if (getenv("Print")) {
+      printf("directIO Readahead\n");
+    }
     rep->CreateFilePrefetchBufferIfNotExists(
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,
@@ -134,6 +155,9 @@ void BlockPrefetcher::PrefetchIfNeeded(
       opts, handle.offset(),
       BlockBasedTable::BlockSizeWithTrailer(handle) + readahead_size_);
   if (s.IsNotSupported()) {
+    if (getenv("Print")) {
+      printf("CreateFilePrefetchBuffer\n");
+    }
     rep->CreateFilePrefetchBufferIfNotExists(
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -12,12 +12,11 @@
 #include "table/block_based/block_based_table_reader.h"
 
 namespace ROCKSDB_NAMESPACE {
-void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
-                                       const BlockHandle& handle,
-                                       const size_t readahead_size,
-                                       bool is_for_compaction,
-                                       const bool no_sequential_checking,
-                                       const ReadOptions& read_options) {
+void BlockPrefetcher::PrefetchIfNeeded(
+    const BlockBasedTable::Rep* rep, const BlockHandle& handle,
+    const size_t readahead_size, bool is_for_compaction,
+    const bool no_sequential_checking, const ReadOptions& read_options,
+    std::function<void(size_t, size_t&)> readaheadsize_cb) {
   const size_t len = BlockBasedTable::BlockSizeWithTrailer(handle);
   const size_t offset = handle.offset();
 
@@ -49,7 +48,7 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
         compaction_readahead_size_, compaction_readahead_size_,
         &prefetch_buffer_, /*implicit_auto_readahead=*/false,
         /*num_file_reads=*/0, /*num_file_reads_for_auto_readahead=*/0,
-        /*upper_bound_offset=*/0);
+        /*upper_bound_offset=*/0, /*readaheadsize_cb=*/nullptr);
     return;
   }
 
@@ -58,7 +57,8 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
     rep->CreateFilePrefetchBufferIfNotExists(
         readahead_size, readahead_size, &prefetch_buffer_,
         /*implicit_auto_readahead=*/false, /*num_file_reads=*/0,
-        /*num_file_reads_for_auto_readahead=*/0, upper_bound_offset_);
+        /*num_file_reads_for_auto_readahead=*/0, upper_bound_offset_,
+        readaheadsize_cb);
     return;
   }
 
@@ -83,7 +83,7 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true,
         /*num_file_reads=*/0,
         rep->table_options.num_file_reads_for_auto_readahead,
-        upper_bound_offset_);
+        upper_bound_offset_, readaheadsize_cb);
     return;
   }
 
@@ -114,7 +114,7 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,
         rep->table_options.num_file_reads_for_auto_readahead,
-        upper_bound_offset_);
+        upper_bound_offset_, readaheadsize_cb);
     return;
   }
 
@@ -138,7 +138,7 @@ void BlockPrefetcher::PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,
         rep->table_options.num_file_reads_for_auto_readahead,
-        upper_bound_offset_);
+        upper_bound_offset_, readaheadsize_cb);
     return;
   }
 

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -18,12 +18,11 @@ class BlockPrefetcher {
         readahead_size_(initial_auto_readahead_size),
         initial_auto_readahead_size_(initial_auto_readahead_size) {}
 
-  void PrefetchIfNeeded(const BlockBasedTable::Rep* rep,
-                        const BlockHandle& handle, size_t readahead_size,
-                        bool is_for_compaction,
-                        const bool no_sequential_checking,
-                        const ReadOptions& read_options,
-                        std::function<void(size_t, size_t&)> readaheadsize_cb);
+  void PrefetchIfNeeded(
+      const BlockBasedTable::Rep* rep, const BlockHandle& handle,
+      size_t readahead_size, bool is_for_compaction,
+      const bool no_sequential_checking, const ReadOptions& read_options,
+      std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb);
   FilePrefetchBuffer* prefetch_buffer() { return prefetch_buffer_.get(); }
 
   void UpdateReadPattern(const uint64_t& offset, const size_t& len) {

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -22,7 +22,8 @@ class BlockPrefetcher {
                         const BlockHandle& handle, size_t readahead_size,
                         bool is_for_compaction,
                         const bool no_sequential_checking,
-                        const ReadOptions& read_options);
+                        const ReadOptions& read_options,
+                        std::function<void(size_t, size_t&)> readaheadsize_cb);
   FilePrefetchBuffer* prefetch_buffer() { return prefetch_buffer_.get(); }
 
   void UpdateReadPattern(const uint64_t& offset, const size_t& len) {

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -22,7 +22,7 @@ class BlockPrefetcher {
       const BlockBasedTable::Rep* rep, const BlockHandle& handle,
       size_t readahead_size, bool is_for_compaction,
       const bool no_sequential_checking, const ReadOptions& read_options,
-      std::function<void(uint64_t, size_t, size_t&)> readaheadsize_cb);
+      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb);
   FilePrefetchBuffer* prefetch_buffer() { return prefetch_buffer_.get(); }
 
   void UpdateReadPattern(const uint64_t& offset, const size_t& len) {

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -498,7 +498,7 @@ Status PartitionedFilterBlockReader::CacheDependencies(
     rep->CreateFilePrefetchBuffer(
         0, 0, &prefetch_buffer, false /* Implicit autoreadahead */,
         0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/,
-        /*upper_bound_offset*/ 0);
+        /*upper_bound_offset*/ 0, /*readaheadsize_cb*/ nullptr);
 
     IOOptions opts;
     s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_index_iterator.cc
+++ b/table/block_based/partitioned_index_iterator.cc
@@ -91,7 +91,8 @@ void PartitionedIndexIterator::InitPartitionedIndexBlock() {
     //   Enabled from the very first IO when ReadOptions.readahead_size is set.
     block_prefetcher_.PrefetchIfNeeded(
         rep, partitioned_index_handle, read_options_.readahead_size,
-        is_for_compaction, /*no_sequential_checking=*/false, read_options_);
+        is_for_compaction, /*no_sequential_checking=*/false, read_options_,
+        /*readahead_cb=*/nullptr);
     Status s;
     table_->NewDataBlockIterator<IndexBlockIter>(
         read_options_, partitioned_index_handle, &block_iter_,

--- a/table/block_based/partitioned_index_iterator.cc
+++ b/table/block_based/partitioned_index_iterator.cc
@@ -92,7 +92,7 @@ void PartitionedIndexIterator::InitPartitionedIndexBlock() {
     block_prefetcher_.PrefetchIfNeeded(
         rep, partitioned_index_handle, read_options_.readahead_size,
         is_for_compaction, /*no_sequential_checking=*/false, read_options_,
-        /*readahead_cb=*/nullptr);
+        /*readaheadsize_cb=*/nullptr);
     Status s;
     table_->NewDataBlockIterator<IndexBlockIter>(
         read_options_, partitioned_index_handle, &block_iter_,

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -170,7 +170,7 @@ Status PartitionIndexReader::CacheDependencies(
     rep->CreateFilePrefetchBuffer(
         0, 0, &prefetch_buffer, false /*Implicit auto readahead*/,
         0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/,
-        /*upper_bound_offset*/ 0);
+        /*upper_bound_offset*/ 0, /*readaheadsize_cb*/ nullptr);
     IOOptions opts;
     {
       Status s = rep->file->PrepareIOOptions(ro, opts);

--- a/unreleased_history/performance_improvements/auto_readahead_size.md
+++ b/unreleased_history/performance_improvements/auto_readahead_size.md
@@ -1,0 +1,1 @@
+Added additional improvements in tuning readahead_size during Scans when auto_readahead_size is enabled. However it's not supported with Iterator::Prev operation and will return NotSupported error.


### PR DESCRIPTION
Summary: Implement block cache lookup to determine readahead_size during scans. It's enabled if auto_readahead_size, block_cache and iterate_upper_bound - all three are set.

Design - 
1. Whenever there is a cache miss and FilePrefetchBuffer is called, a callback is made to determine readahead_size for that prefetching.
2. The callback iterates over index and do block cache lookup for each data block handle until existing readahead_size is reached. Then It removes the cache hit data blocks from end to calculate optimized readahead_size.
3. Since index_iter_ is moved, it stores block handles in a queue, and use that queue to get block handle instead of doing index_iter_->Next().
4. This is for Sync scans. Async scans support is in progress.

NOTE: 
The issue right now is after Seek and Next, if Prev is called, there is no way to do Prev operation. index_iter_ is already pointing to a different block. So it returns "Not supported" in that case with error message - "auto tuning of readahead size is not supported with Prev op"


Test Plan: 
- Added new unit test
- crash_tests
- Running scans locally to check for any regression

Reviewers:

Subscribers:

Tasks:

Tags: