### PR TITLE
Use *next_sequence -1 here

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1298,7 +1298,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& wal_numbers,
           flushed = true;
 
           cfd->CreateNewMemtable(*cfd->GetLatestMutableCFOptions(),
-                                 *next_sequence);
+                                 *next_sequence - 1);
         }
       }
     }

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -1635,6 +1635,10 @@ TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverTest) {
   delete transaction;
 }
 
+#ifdef __SANITIZE_THREAD__
+  // Skip OptimisticTransactionTest.SequenceNumberAfterRecoverLargeTest under TSAN
+  // to avoid false positive because of TSAN lock limit of 64.
+#else
 TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverLargeTest) {
   WriteOptions write_options;
   OptimisticTransactionOptions transaction_options;
@@ -1670,6 +1674,7 @@ TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverLargeTest) {
 
   delete transaction;
 }
+#endif // __SANITIZE_THREAD__
 
 TEST_P(OptimisticTransactionTest, TimestampedSnapshotMissingCommitTs) {
   std::unique_ptr<Transaction> txn(txn_db->BeginTransaction(WriteOptions()));

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -1635,6 +1635,41 @@ TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverTest) {
   delete transaction;
 }
 
+TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverLargeTest) {
+  WriteOptions write_options;
+  OptimisticTransactionOptions transaction_options;
+
+  Transaction* transaction(
+      txn_db->BeginTransaction(write_options, transaction_options));
+
+  std::string value(1024*1024,'X');
+  const size_t n_zero = 2;
+  std::string s_i;
+  Status s;
+  for (int i = 1; i <= 64; i++) {
+    s_i = std::to_string(i);
+    auto key = std::string(n_zero - std::min(n_zero, s_i.length()), '0') + s_i;
+    s = transaction->Put(key, value);
+    ASSERT_OK(s);
+  }
+
+  s = transaction->Commit();
+  ASSERT_OK(s);
+  delete transaction;
+
+  Reopen();
+  transaction = txn_db->BeginTransaction(write_options, transaction_options);
+  s = transaction->Put("bar", "val");
+  ASSERT_OK(s);
+  s = transaction->Commit();
+  if (!s.ok()) {
+    std::cerr << "Failed to commit records. Error: " << s.ToString() << std::endl;
+  }
+  ASSERT_OK(s);
+
+  delete transaction;
+}
+
 TEST_P(OptimisticTransactionTest, TimestampedSnapshotMissingCommitTs) {
   std::unique_ptr<Transaction> txn(txn_db->BeginTransaction(WriteOptions()));
   ASSERT_OK(txn->Put("a", "v"));

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -1642,7 +1642,7 @@ TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverLargeTest) {
   Transaction* transaction(
       txn_db->BeginTransaction(write_options, transaction_options));
 
-  std::string value(1024 * 1024,'X');
+  std::string value(1024 * 1024, 'X');
   const size_t n_zero = 2;
   std::string s_i;
   Status s;

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -1636,8 +1636,8 @@ TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverTest) {
 }
 
 #ifdef __SANITIZE_THREAD__
-  // Skip OptimisticTransactionTest.SequenceNumberAfterRecoverLargeTest under TSAN
-  // to avoid false positive because of TSAN lock limit of 64.
+// Skip OptimisticTransactionTest.SequenceNumberAfterRecoverLargeTest under TSAN
+// to avoid false positive because of TSAN lock limit of 64.
 #else
 TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverLargeTest) {
   WriteOptions write_options;
@@ -1674,7 +1674,7 @@ TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverLargeTest) {
 
   delete transaction;
 }
-#endif // __SANITIZE_THREAD__
+#endif  // __SANITIZE_THREAD__
 
 TEST_P(OptimisticTransactionTest, TimestampedSnapshotMissingCommitTs) {
   std::unique_ptr<Transaction> txn(txn_db->BeginTransaction(WriteOptions()));

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -1642,7 +1642,7 @@ TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverLargeTest) {
   Transaction* transaction(
       txn_db->BeginTransaction(write_options, transaction_options));
 
-  std::string value(1024*1024,'X');
+  std::string value(1024 * 1024,'X');
   const size_t n_zero = 2;
   std::string s_i;
   Status s;
@@ -1663,7 +1663,8 @@ TEST_P(OptimisticTransactionTest, SequenceNumberAfterRecoverLargeTest) {
   ASSERT_OK(s);
   s = transaction->Commit();
   if (!s.ok()) {
-    std::cerr << "Failed to commit records. Error: " << s.ToString() << std::endl;
+    std::cerr << "Failed to commit records. Error: " << s.ToString()
+              << std::endl;
   }
   ASSERT_OK(s);
 


### PR DESCRIPTION
To fix off-by-one error:   Transaction could not check for conflicts for operation at SequenceNumber 500000 as the MemTable only contains changes newer than SequenceNumber 500001.
 
Fixes https://github.com/facebook/rocksdb/issues/11822

I think introduced in https://github.com/facebook/rocksdb/commit/a657ee9a9c4a2acb529b8f5567965e4bf6d38fd5