### PR TITLE
Fix a hanging DB::Close scenario for atomic flush

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -3177,7 +3177,7 @@ TEST_P(DBAtomicFlushTest, BgRecoveryThreadNoWaitDuringShutdown) {
   options.max_write_buffer_number = 8;
   CreateAndReopenWithCF({"pikachu"}, options);
 
-  assert(2 == handles_.size());
+  ASSERT_EQ(2, handles_.size());
 
   WriteOptions write_opts;
   write_opts.disableWAL = true;
@@ -3243,7 +3243,7 @@ TEST_P(DBAtomicFlushTest, BgRecoveryThreadNoWaitDuringShutdown) {
   SyncPoint::GetInstance()->SetCallBack(
       "FlushJob::WriteLevel0Table::AfterFileSync", [&](void* arg) {
         if (std::this_thread::get_id() == bg_flush_thr1) {
-          auto* ptr = reinterpret_cast<Status*>(arg);
+          auto* ptr = static_cast<Status*>(arg);
           assert(ptr);
           IOStatus io_status = IOStatus::IOError("Injected retryable failure");
           io_status.SetRetryable(true);
@@ -3255,7 +3255,7 @@ TEST_P(DBAtomicFlushTest, BgRecoveryThreadNoWaitDuringShutdown) {
   SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::AtomicFlushMemTablesToOutputFiles:WaitToCommit", [&](void* arg) {
         if (std::this_thread::get_id() == bg_flush_thr2) {
-          const auto* ptr = reinterpret_cast<std::pair<Status, bool>*>(arg);
+          const auto* ptr = static_cast<std::pair<Status, bool>*>(arg);
           assert(ptr);
           if (0 == called) {
             ASSERT_OK(ptr->first);

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -517,6 +517,7 @@ Status DBImpl::CloseHelper() {
   // continuing with the shutdown
   mutex_.Lock();
   shutdown_initiated_ = true;
+  atomic_flush_install_cv_.SignalAll();
   error_handler_.CancelErrorRecovery();
   while (error_handler_.IsRecoveryInProgress()) {
     bg_cv_.Wait();

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -672,6 +672,7 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
   TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeStart");
   InstrumentedMutexLock l(db_mutex_);
   if (end_recovery_) {
+    recovery_in_prog_ = false;
     EventHelpers::NotifyOnErrorRecoveryEnd(db_options_.listeners, bg_error_,
                                            Status::ShutdownInProgress(),
                                            db_mutex_);
@@ -684,6 +685,7 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
   // Recover from the retryable error. Create a separate thread to do it.
   while (resume_count > 0) {
     if (end_recovery_) {
+      recovery_in_prog_ = false;
       EventHelpers::NotifyOnErrorRecoveryEnd(db_options_.listeners, bg_error_,
                                              Status::ShutdownInProgress(),
                                              db_mutex_);

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -1019,6 +1019,7 @@ Status FlushJob::WriteLevel0Table() {
           DirFsyncOptions(DirFsyncOptions::FsyncReason::kNewFileSynced));
     }
     TEST_SYNC_POINT_CALLBACK("FlushJob::WriteLevel0Table", &mems_);
+    TEST_SYNC_POINT_CALLBACK("FlushJob::WriteLevel0Table::AfterFileSync", &s);
     db_mutex_->Lock();
   }
   base_->Unref();


### PR DESCRIPTION
A chain of events can result in Close() call hang indefinitely when atomic_flush = true.
The factors to reproduce the hang:
1) An earlier flush job encounters a retryable error, as a result, fails to
   install flush result, and at the same time, spawns a recovery thread.
2) A concurrently running flush job only flushing newer memtables
   successfully finish flushing and waiting to install results.
3) Shutting down DB, the recovery thread hangs because of this logic:
   Close() -> EndAutoRecovery() -> WaitForBackgroundWork() waits for
   background flush thread in 2).

The fix is to during shutdown, notify all the background flush threads waiting on `atomic_flush_install_cv_` to give up waiting before proceed `error_handler_.CancelAutoRecovery()`. Also make the `wait_to_install_func()` not wait as long as shutdown has initiated.

Also fix a related issue #11440 to mark `recovery_in_progress_` to be false whenever `ErrorHandler:: RecoverFromRetryableBGIOError` returns.

Test Plan:
Added unit test `DBAtomicFlushTest.BgRecoveryThreadNoWaitDuringShutdown` that would hang without the fix.