### PR TITLE
Speed up build-macos-cmake CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
   build-macos-cmake:
     macos:
       xcode: 14.3.1
-    resource_class: macos.m1.medium.gen1
+    resource_class: macos.m1.large.gen1
     parameters:
       run_even_tests:
         description: run even or odd tests, used to split tests to 2 groups


### PR DESCRIPTION
.. by using a better machine.  build-macos-cmake step takes more than 50 minutes while other steps take <40m: https://app.circleci.com/pipelines/github/facebook/rocksdb?branch=pull%2F11872.

Test plan:
* See if CI steps build-macos-cmake* are faster.