### PR TITLE
Make stopped writes block on recovery

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2259,14 +2259,7 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     }
   }
 
-  // Note that, when flush reason is kErrorRecoveryRetryFlush, during the
-  // auto retry resume, we do not care to wait for all pre-existing writes to go
-  // through. In fact, some may be blocked waiting on auto-recovery to clear
-  // memtables in which case joining the write thread here would be a deadlock.
-  // Therefore, write thread will not be joined
-  const bool needs_to_join_write_thread =
-      !entered_write_thread &&
-      flush_reason != FlushReason::kErrorRecoveryRetryFlush;
+  const bool needs_to_join_write_thread = !entered_write_thread;
   autovector<FlushRequest> flush_reqs;
   autovector<uint64_t> memtable_ids_to_wait;
   {

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -224,7 +224,9 @@ class StressTest {
     return Status::NotSupported("TestCustomOperations() must be overridden");
   }
 
-  void VerificationAbort(SharedState* shared, std::string msg, Status s) const;
+  void ProcessStatus(SharedState* shared, std::string msg, Status s) const;
+
+  void VerificationAbort(SharedState* shared, std::string msg) const;
 
   void VerificationAbort(SharedState* shared, std::string msg, int cf,
                          int64_t key) const;

--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -1104,8 +1104,9 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
       Status s = record.DecodePrimaryIndexEntry(it->key(), it->value());
       if (!s.ok()) {
         oss << "Cannot decode primary index entry " << it->key().ToString(true)
-            << "=>" << it->value().ToString(true);
-        VerificationAbort(thread->shared, oss.str(), s);
+            << "=>" << it->value().ToString(true) << ". Status is "
+            << s.ToString();
+        VerificationAbort(thread->shared, oss.str());
         assert(false);
         return;
       }
@@ -1125,8 +1126,9 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
       std::string value;
       s = db_->Get(ropts, sk, &value);
       if (!s.ok()) {
-        oss << "Cannot find secondary index entry " << sk.ToString(true);
-        VerificationAbort(thread->shared, oss.str(), s);
+        oss << "Cannot find secondary index entry " << sk.ToString(true)
+            << ". Status is " << s.ToString();
+        VerificationAbort(thread->shared, oss.str());
         assert(false);
         return;
       }
@@ -1153,8 +1155,9 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
       Status s = record.DecodeSecondaryIndexEntry(it->key(), it->value());
       if (!s.ok()) {
         oss << "Cannot decode secondary index entry "
-            << it->key().ToString(true) << "=>" << it->value().ToString(true);
-        VerificationAbort(thread->shared, oss.str(), s);
+            << it->key().ToString(true) << "=>" << it->value().ToString(true)
+            << ". Status is " << s.ToString();
+        VerificationAbort(thread->shared, oss.str());
         assert(false);
         return;
       }
@@ -1168,7 +1171,7 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
       if (!s.ok()) {
         oss << "Error searching pk " << Slice(pk).ToString(true) << ". "
             << s.ToString() << ". sk " << it->key().ToString(true);
-        VerificationAbort(thread->shared, oss.str(), s);
+        VerificationAbort(thread->shared, oss.str());
         assert(false);
         return;
       }
@@ -1176,8 +1179,8 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
       s = std::get<0>(result);
       if (!s.ok()) {
         oss << "Error decoding primary index value "
-            << Slice(value).ToString(true) << ". " << s.ToString();
-        VerificationAbort(thread->shared, oss.str(), s);
+            << Slice(value).ToString(true) << ". Status is " << s.ToString();
+        VerificationAbort(thread->shared, oss.str());
         assert(false);
         return;
       }
@@ -1187,7 +1190,7 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
             << Slice(value).ToString(true) << " (a=" << record.a_value()
             << ", c=" << c_in_primary << "), sk: " << it->key().ToString(true)
             << " (c=" << record.c_value() << ")";
-        VerificationAbort(thread->shared, oss.str(), s);
+        VerificationAbort(thread->shared, oss.str());
         assert(false);
         return;
       }
@@ -1198,7 +1201,7 @@ void MultiOpsTxnsStressTest::VerifyDb(ThreadState* thread) const {
     oss << "Pk/sk mismatch: primary index has " << primary_index_entries_count
         << " entries. Secondary index has " << secondary_index_entries_count
         << " entries.";
-    VerificationAbort(thread->shared, oss.str(), Status::OK());
+    VerificationAbort(thread->shared, oss.str());
     assert(false);
     return;
   }

--- a/unreleased_history/behavior_changes/stopped_writes_wait_for_recovery.md
+++ b/unreleased_history/behavior_changes/stopped_writes_wait_for_recovery.md
@@ -1,0 +1,1 @@
+* During a write stop, writes now block on in-progress recovery attempts


### PR DESCRIPTION
Relaxed the constraints for blocking when writes are stopped. When a recovery is already being attempted, we might as well let `!no_slowdown` writes wait on it in case it succeeds. This makes the user-visible behavior consistent across recovery flush and non-recovery flush.

This enables `db_stress` to inject retryable (soft) flush read errors without having to handle user write failures. I changed `db_stress` a bit to permit injected errors in much more foreground operations as more admin operations (like `GetLiveFiles()`) can fail on a retryable error during flush.