### PR TITLE
Add automatic module name to the rocksdbjni jar artifact

### DIFF
--- a/java/pom.xml.template
+++ b/java/pom.xml.template
@@ -83,7 +83,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.rocksdb.rocksdbjni</Automatic-Module-Name>
+                            <Automatic-Module-Name>${project.groupId}.${project.artifactId}</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/java/pom.xml.template
+++ b/java/pom.xml.template
@@ -78,6 +78,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.rocksdb.rocksdbjni</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>


### PR DESCRIPTION
Currently, `jar` artifacts of `rocksdbjni`, published in maven repositories, lack any information about JPMS modules, introduced in Java 9. This makes in challenging to use the `rocksdbjni` jar as a dependency for your module in `module-info.java`, like in the following example:
```java
module my.module {
    requires rocksdbjni; // Automatic module name, derived from the file name.
}
```
Although java itself provides compatibility with such libraries, it is not recommended. Third-party build tools are more strict.

Maven, for example, shows a following warning: `Required filename-based automodules detected. Please don't publish this project to a public artifact repository!`.

Gradle won't be able to build the project with this dependency at all. According to [the documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#using_libraries_that_are_not_modules) there could be two types of `jar` modules:
- There's a `module-info.class` in the jar. This is explicit module, created with Java 9+ compiler.
- There's an `Automatic-Module-Name` attribute inside of the `META-INF/MANIFEST.MF` file in the `jar` artifact.

If `jar` file meets one of these requirements, it will be recognized as a module and passed to `--module-path` compiler argument. Otherwise, it will be passed into a `-classpath` argument. In the example above, the latter happens, and build fails with the following message:
```
> Task :my.module:compileJava FAILED
<path>/module-info.java:21: error: module not found: rocksdbjni
    requires rocksdbjni;
             ^
1 error
```
In this PR, I solve this issue by introducing the explicit automatic module name.
