### PR TITLE
Change Java native methods to static

### DIFF
--- a/java/rocksjni/backup_engine_options.cc
+++ b/java/rocksjni/backup_engine_options.cc
@@ -45,7 +45,7 @@ jlong Java_org_rocksdb_BackupEngineOptions_newBackupEngineOptions(
  * Signature: (J)Ljava/lang/String;
  */
 jstring Java_org_rocksdb_BackupEngineOptions_backupDir(JNIEnv* env,
-                                                       jobject /*jopt*/,
+                                                       jclass /*jcls*/,
                                                        jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -58,7 +58,7 @@ jstring Java_org_rocksdb_BackupEngineOptions_backupDir(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setBackupEnv(
-    JNIEnv* /*env*/, jobject /*jopt*/, jlong jhandle, jlong jrocks_env_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jlong jrocks_env_handle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
   auto* rocks_env =
@@ -72,7 +72,7 @@ void Java_org_rocksdb_BackupEngineOptions_setBackupEnv(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setShareTableFiles(JNIEnv* /*env*/,
-                                                             jobject /*jobj*/,
+                                                             jclass /*jcls*/,
                                                              jlong jhandle,
                                                              jboolean flag) {
   auto* bopt =
@@ -86,7 +86,7 @@ void Java_org_rocksdb_BackupEngineOptions_setShareTableFiles(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_BackupEngineOptions_shareTableFiles(JNIEnv* /*env*/,
-                                                              jobject /*jobj*/,
+                                                              jclass /*jcls*/,
                                                               jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -99,7 +99,7 @@ jboolean Java_org_rocksdb_BackupEngineOptions_shareTableFiles(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setInfoLog(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
+                                                     jclass /*jcls*/,
                                                      jlong jhandle,
                                                      jlong /*jlogger_handle*/) {
   auto* bopt =
@@ -116,7 +116,7 @@ void Java_org_rocksdb_BackupEngineOptions_setInfoLog(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setSync(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
+                                                  jclass /*jcls*/,
                                                   jlong jhandle,
                                                   jboolean flag) {
   auto* bopt =
@@ -130,7 +130,7 @@ void Java_org_rocksdb_BackupEngineOptions_setSync(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_BackupEngineOptions_sync(JNIEnv* /*env*/,
-                                                   jobject /*jobj*/,
+                                                   jclass /*jcls*/,
                                                    jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -143,7 +143,7 @@ jboolean Java_org_rocksdb_BackupEngineOptions_sync(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setDestroyOldData(JNIEnv* /*env*/,
-                                                            jobject /*jobj*/,
+                                                            jclass /*jcls*/,
                                                             jlong jhandle,
                                                             jboolean flag) {
   auto* bopt =
@@ -157,7 +157,7 @@ void Java_org_rocksdb_BackupEngineOptions_setDestroyOldData(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_BackupEngineOptions_destroyOldData(JNIEnv* /*env*/,
-                                                             jobject /*jobj*/,
+                                                             jclass /*jcls*/,
                                                              jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -170,7 +170,7 @@ jboolean Java_org_rocksdb_BackupEngineOptions_destroyOldData(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setBackupLogFiles(JNIEnv* /*env*/,
-                                                            jobject /*jobj*/,
+                                                            jclass /*jcls*/,
                                                             jlong jhandle,
                                                             jboolean flag) {
   auto* bopt =
@@ -184,7 +184,7 @@ void Java_org_rocksdb_BackupEngineOptions_setBackupLogFiles(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_BackupEngineOptions_backupLogFiles(JNIEnv* /*env*/,
-                                                             jobject /*jobj*/,
+                                                             jclass /*jcls*/,
                                                              jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -197,8 +197,7 @@ jboolean Java_org_rocksdb_BackupEngineOptions_backupLogFiles(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setBackupRateLimit(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
-    jlong jbackup_rate_limit) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jlong jbackup_rate_limit) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
   bopt->backup_rate_limit = jbackup_rate_limit;
@@ -210,7 +209,7 @@ void Java_org_rocksdb_BackupEngineOptions_setBackupRateLimit(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_BackupEngineOptions_backupRateLimit(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
+                                                           jclass /*jcls*/,
                                                            jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -223,7 +222,7 @@ jlong Java_org_rocksdb_BackupEngineOptions_backupRateLimit(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setBackupRateLimiter(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jrate_limiter_handle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -239,7 +238,7 @@ void Java_org_rocksdb_BackupEngineOptions_setBackupRateLimiter(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setRestoreRateLimit(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jrestore_rate_limit) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -252,7 +251,7 @@ void Java_org_rocksdb_BackupEngineOptions_setRestoreRateLimit(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_BackupEngineOptions_restoreRateLimit(JNIEnv* /*env*/,
-                                                            jobject /*jobj*/,
+                                                            jclass /*jcls*/,
                                                             jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -265,7 +264,7 @@ jlong Java_org_rocksdb_BackupEngineOptions_restoreRateLimit(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setRestoreRateLimiter(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jrate_limiter_handle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -281,7 +280,7 @@ void Java_org_rocksdb_BackupEngineOptions_setRestoreRateLimiter(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setShareFilesWithChecksum(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean flag) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jboolean flag) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
   bopt->share_files_with_checksum = flag;
@@ -293,7 +292,7 @@ void Java_org_rocksdb_BackupEngineOptions_setShareFilesWithChecksum(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_BackupEngineOptions_shareFilesWithChecksum(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
   return bopt->share_files_with_checksum;
@@ -305,7 +304,7 @@ jboolean Java_org_rocksdb_BackupEngineOptions_shareFilesWithChecksum(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setMaxBackgroundOperations(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jint max_background_operations) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -318,7 +317,7 @@ void Java_org_rocksdb_BackupEngineOptions_setMaxBackgroundOperations(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_BackupEngineOptions_maxBackgroundOperations(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
   return static_cast<jint>(bopt->max_background_operations);
@@ -330,7 +329,7 @@ jint Java_org_rocksdb_BackupEngineOptions_maxBackgroundOperations(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupEngineOptions_setCallbackTriggerIntervalSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jcallback_trigger_interval_size) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
@@ -344,7 +343,7 @@ void Java_org_rocksdb_BackupEngineOptions_setCallbackTriggerIntervalSize(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_BackupEngineOptions_callbackTriggerIntervalSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
   return static_cast<jlong>(bopt->callback_trigger_interval_size);
@@ -355,9 +354,9 @@ jlong Java_org_rocksdb_BackupEngineOptions_callbackTriggerIntervalSize(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_BackupEngineOptions_disposeInternal(JNIEnv* /*env*/,
-                                                          jobject /*jopt*/,
-                                                          jlong jhandle) {
+void Java_org_rocksdb_BackupEngineOptions_disposeInternalJni(JNIEnv* /*env*/,
+                                                             jclass /*jcls*/,
+                                                             jlong jhandle) {
   auto* bopt =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngineOptions*>(jhandle);
   assert(bopt != nullptr);

--- a/java/rocksjni/backupenginejni.cc
+++ b/java/rocksjni/backupenginejni.cc
@@ -45,7 +45,7 @@ jlong Java_org_rocksdb_BackupEngine_open(JNIEnv* env, jclass /*jcls*/,
  * Signature: (JJZ)V
  */
 void Java_org_rocksdb_BackupEngine_createNewBackup(
-    JNIEnv* env, jobject /*jbe*/, jlong jbe_handle, jlong db_handle,
+    JNIEnv* env, jclass /*jbe*/, jlong jbe_handle, jlong db_handle,
     jboolean jflush_before_backup) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(db_handle);
   auto* backup_engine =
@@ -66,7 +66,7 @@ void Java_org_rocksdb_BackupEngine_createNewBackup(
  * Signature: (JJLjava/lang/String;Z)V
  */
 void Java_org_rocksdb_BackupEngine_createNewBackupWithMetadata(
-    JNIEnv* env, jobject /*jbe*/, jlong jbe_handle, jlong db_handle,
+    JNIEnv* env, jclass /*jbe*/, jlong jbe_handle, jlong db_handle,
     jstring japp_metadata, jboolean jflush_before_backup) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(db_handle);
   auto* backup_engine =
@@ -97,7 +97,7 @@ void Java_org_rocksdb_BackupEngine_createNewBackupWithMetadata(
  * Signature: (J)Ljava/util/List;
  */
 jobject Java_org_rocksdb_BackupEngine_getBackupInfo(JNIEnv* env,
-                                                    jobject /*jbe*/,
+                                                    jclass /*jcls*/,
                                                     jlong jbe_handle) {
   auto* backup_engine =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngine*>(jbe_handle);
@@ -112,7 +112,7 @@ jobject Java_org_rocksdb_BackupEngine_getBackupInfo(JNIEnv* env,
  * Signature: (J)[I
  */
 jintArray Java_org_rocksdb_BackupEngine_getCorruptedBackups(JNIEnv* env,
-                                                            jobject /*jbe*/,
+                                                            jclass /*jcls*/,
                                                             jlong jbe_handle) {
   auto* backup_engine =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngine*>(jbe_handle);
@@ -139,7 +139,7 @@ jintArray Java_org_rocksdb_BackupEngine_getCorruptedBackups(JNIEnv* env,
  * Method:    garbageCollect
  * Signature: (J)V
  */
-void Java_org_rocksdb_BackupEngine_garbageCollect(JNIEnv* env, jobject /*jbe*/,
+void Java_org_rocksdb_BackupEngine_garbageCollect(JNIEnv* env, jclass /*jbe*/,
                                                   jlong jbe_handle) {
   auto* backup_engine =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngine*>(jbe_handle);
@@ -157,7 +157,7 @@ void Java_org_rocksdb_BackupEngine_garbageCollect(JNIEnv* env, jobject /*jbe*/,
  * Method:    purgeOldBackups
  * Signature: (JI)V
  */
-void Java_org_rocksdb_BackupEngine_purgeOldBackups(JNIEnv* env, jobject /*jbe*/,
+void Java_org_rocksdb_BackupEngine_purgeOldBackups(JNIEnv* env, jclass /*jbe*/,
                                                    jlong jbe_handle,
                                                    jint jnum_backups_to_keep) {
   auto* backup_engine =
@@ -177,7 +177,7 @@ void Java_org_rocksdb_BackupEngine_purgeOldBackups(JNIEnv* env, jobject /*jbe*/,
  * Method:    deleteBackup
  * Signature: (JI)V
  */
-void Java_org_rocksdb_BackupEngine_deleteBackup(JNIEnv* env, jobject /*jbe*/,
+void Java_org_rocksdb_BackupEngine_deleteBackup(JNIEnv* env, jclass /*jbe*/,
                                                 jlong jbe_handle,
                                                 jint jbackup_id) {
   auto* backup_engine =
@@ -198,7 +198,7 @@ void Java_org_rocksdb_BackupEngine_deleteBackup(JNIEnv* env, jobject /*jbe*/,
  * Signature: (JILjava/lang/String;Ljava/lang/String;J)V
  */
 void Java_org_rocksdb_BackupEngine_restoreDbFromBackup(
-    JNIEnv* env, jobject /*jbe*/, jlong jbe_handle, jint jbackup_id,
+    JNIEnv* env, jclass /*jbe*/, jlong jbe_handle, jint jbackup_id,
     jstring jdb_dir, jstring jwal_dir, jlong jrestore_options_handle) {
   auto* backup_engine =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngine*>(jbe_handle);
@@ -235,7 +235,7 @@ void Java_org_rocksdb_BackupEngine_restoreDbFromBackup(
  * Signature: (JLjava/lang/String;Ljava/lang/String;J)V
  */
 void Java_org_rocksdb_BackupEngine_restoreDbFromLatestBackup(
-    JNIEnv* env, jobject /*jbe*/, jlong jbe_handle, jstring jdb_dir,
+    JNIEnv* env, jclass /*jbe*/, jlong jbe_handle, jstring jdb_dir,
     jstring jwal_dir, jlong jrestore_options_handle) {
   auto* backup_engine =
       reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngine*>(jbe_handle);
@@ -270,9 +270,9 @@ void Java_org_rocksdb_BackupEngine_restoreDbFromLatestBackup(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_BackupEngine_disposeInternal(JNIEnv* /*env*/,
-                                                   jobject /*jbe*/,
-                                                   jlong jbe_handle) {
+void Java_org_rocksdb_BackupEngine_disposeInternalJni(JNIEnv* /*env*/,
+                                                      jclass /*jcls*/,
+                                                      jlong jbe_handle) {
   auto* be = reinterpret_cast<ROCKSDB_NAMESPACE::BackupEngine*>(jbe_handle);
   assert(be != nullptr);
   delete be;

--- a/java/rocksjni/cassandra_value_operator.cc
+++ b/java/rocksjni/cassandra_value_operator.cc
@@ -41,8 +41,8 @@ jlong Java_org_rocksdb_CassandraValueMergeOperator_newSharedCassandraValueMergeO
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CassandraValueMergeOperator_disposeInternal(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+void Java_org_rocksdb_CassandraValueMergeOperator_disposeInternalJni(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* op =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
           jhandle);

--- a/java/rocksjni/checkpoint.cc
+++ b/java/rocksjni/checkpoint.cc
@@ -37,9 +37,9 @@ jlong Java_org_rocksdb_Checkpoint_newCheckpoint(JNIEnv* /*env*/,
  * Method:    dispose
  * Signature: (J)V
  */
-void Java_org_rocksdb_Checkpoint_disposeInternal(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong jhandle) {
+void Java_org_rocksdb_Checkpoint_disposeInternalJni(JNIEnv* /*env*/,
+                                                    jclass /*jobj*/,
+                                                    jlong jhandle) {
   auto* checkpoint = reinterpret_cast<ROCKSDB_NAMESPACE::Checkpoint*>(jhandle);
   assert(checkpoint != nullptr);
   delete checkpoint;
@@ -50,7 +50,7 @@ void Java_org_rocksdb_Checkpoint_disposeInternal(JNIEnv* /*env*/,
  * Method:    createCheckpoint
  * Signature: (JLjava/lang/String;)V
  */
-void Java_org_rocksdb_Checkpoint_createCheckpoint(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_Checkpoint_createCheckpoint(JNIEnv* env, jclass /*jcls*/,
                                                   jlong jcheckpoint_handle,
                                                   jstring jcheckpoint_path) {
   const char* checkpoint_path = env->GetStringUTFChars(jcheckpoint_path, 0);

--- a/java/rocksjni/clock_cache.cc
+++ b/java/rocksjni/clock_cache.cc
@@ -33,9 +33,9 @@ jlong Java_org_rocksdb_ClockCache_newClockCache(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ClockCache_disposeInternal(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong jhandle) {
+void Java_org_rocksdb_ClockCache_disposeInternalJni(JNIEnv* /*env*/,
+                                                    jclass /*jcls*/,
+                                                    jlong jhandle) {
   auto* sptr_clock_cache =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Cache>*>(jhandle);
   delete sptr_clock_cache;  // delete std::shared_ptr

--- a/java/rocksjni/columnfamilyhandle.cc
+++ b/java/rocksjni/columnfamilyhandle.cc
@@ -19,7 +19,7 @@
  * Signature: (J)[B
  */
 jbyteArray Java_org_rocksdb_ColumnFamilyHandle_getName(JNIEnv* env,
-                                                       jobject /*jobj*/,
+                                                       jclass /*jobj*/,
                                                        jlong jhandle) {
   auto* cfh = reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jhandle);
   std::string cf_name = cfh->GetName();
@@ -31,8 +31,7 @@ jbyteArray Java_org_rocksdb_ColumnFamilyHandle_getName(JNIEnv* env,
  * Method:    getID
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyHandle_getID(JNIEnv* /*env*/,
-                                               jobject /*jobj*/,
+jint Java_org_rocksdb_ColumnFamilyHandle_getID(JNIEnv* /*env*/, jclass /*jcls*/,
                                                jlong jhandle) {
   auto* cfh = reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jhandle);
   const int32_t id = cfh->GetID();
@@ -45,7 +44,7 @@ jint Java_org_rocksdb_ColumnFamilyHandle_getID(JNIEnv* /*env*/,
  * Signature: (J)Lorg/rocksdb/ColumnFamilyDescriptor;
  */
 jobject Java_org_rocksdb_ColumnFamilyHandle_getDescriptor(JNIEnv* env,
-                                                          jobject /*jobj*/,
+                                                          jclass /*jcls*/,
                                                           jlong jhandle) {
   auto* cfh = reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jhandle);
   ROCKSDB_NAMESPACE::ColumnFamilyDescriptor desc;
@@ -63,9 +62,9 @@ jobject Java_org_rocksdb_ColumnFamilyHandle_getDescriptor(JNIEnv* env,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ColumnFamilyHandle_disposeInternal(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
-                                                         jlong jhandle) {
+void Java_org_rocksdb_ColumnFamilyHandle_disposeInternalJni(JNIEnv* /*env*/,
+                                                            jclass /*jobj*/,
+                                                            jlong jhandle) {
   auto* cfh = reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jhandle);
   assert(cfh != nullptr);
   delete cfh;

--- a/java/rocksjni/compact_range_options.cc
+++ b/java/rocksjni/compact_range_options.cc
@@ -80,7 +80,7 @@ jlong Java_org_rocksdb_CompactRangeOptions_newCompactRangeOptions(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_CompactRangeOptions_exclusiveManualCompaction(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jobj*/, jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
   return static_cast<jboolean>(
@@ -93,7 +93,7 @@ jboolean Java_org_rocksdb_CompactRangeOptions_exclusiveManualCompaction(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_CompactRangeOptions_setExclusiveManualCompaction(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jobj*/, jlong jhandle,
     jboolean exclusive_manual_compaction) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -107,7 +107,7 @@ void Java_org_rocksdb_CompactRangeOptions_setExclusiveManualCompaction(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_CompactRangeOptions_bottommostLevelCompaction(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jobj*/, jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
   return ROCKSDB_NAMESPACE::BottommostLevelCompactionJni::
@@ -121,7 +121,7 @@ jint Java_org_rocksdb_CompactRangeOptions_bottommostLevelCompaction(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactRangeOptions_setBottommostLevelCompaction(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jobj*/, jlong jhandle,
     jint bottommost_level_compaction) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -136,7 +136,7 @@ void Java_org_rocksdb_CompactRangeOptions_setBottommostLevelCompaction(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_CompactRangeOptions_changeLevel(JNIEnv* /*env*/,
-                                                          jobject /*jobj*/,
+                                                          jclass /*jobj*/,
                                                           jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -149,7 +149,7 @@ jboolean Java_org_rocksdb_CompactRangeOptions_changeLevel(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_CompactRangeOptions_setChangeLevel(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean change_level) {
+    JNIEnv* /*env*/, jclass /*jobj*/, jlong jhandle, jboolean change_level) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
   options->compactRangeOptions.change_level = static_cast<bool>(change_level);
@@ -161,7 +161,7 @@ void Java_org_rocksdb_CompactRangeOptions_setChangeLevel(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_CompactRangeOptions_targetLevel(JNIEnv* /*env*/,
-                                                      jobject /*jobj*/,
+                                                      jclass /*jobj*/,
                                                       jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -174,7 +174,7 @@ jint Java_org_rocksdb_CompactRangeOptions_targetLevel(JNIEnv* /*env*/,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactRangeOptions_setTargetLevel(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
+                                                         jclass /*jobj*/,
                                                          jlong jhandle,
                                                          jint target_level) {
   auto* options =
@@ -188,7 +188,7 @@ void Java_org_rocksdb_CompactRangeOptions_setTargetLevel(JNIEnv* /*env*/,
  * Signature: (J)I
  */
 jint Java_org_rocksdb_CompactRangeOptions_targetPathId(JNIEnv* /*env*/,
-                                                       jobject /*jobj*/,
+                                                       jclass /*jobj*/,
                                                        jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -201,7 +201,7 @@ jint Java_org_rocksdb_CompactRangeOptions_targetPathId(JNIEnv* /*env*/,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactRangeOptions_setTargetPathId(JNIEnv* /*env*/,
-                                                          jobject /*jobj*/,
+                                                          jclass /*jobj*/,
                                                           jlong jhandle,
                                                           jint target_path_id) {
   auto* options =
@@ -216,7 +216,7 @@ void Java_org_rocksdb_CompactRangeOptions_setTargetPathId(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_CompactRangeOptions_allowWriteStall(JNIEnv* /*env*/,
-                                                              jobject /*jobj*/,
+                                                              jclass /*jobj*/,
                                                               jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -229,7 +229,7 @@ jboolean Java_org_rocksdb_CompactRangeOptions_allowWriteStall(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_CompactRangeOptions_setAllowWriteStall(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jobj*/, jlong jhandle,
     jboolean allow_write_stall) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -243,7 +243,7 @@ void Java_org_rocksdb_CompactRangeOptions_setAllowWriteStall(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_CompactRangeOptions_maxSubcompactions(JNIEnv* /*env*/,
-                                                            jobject /*jobj*/,
+                                                            jclass /*jobj*/,
                                                             jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -256,7 +256,7 @@ jint Java_org_rocksdb_CompactRangeOptions_maxSubcompactions(JNIEnv* /*env*/,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactRangeOptions_setMaxSubcompactions(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint max_subcompactions) {
+    JNIEnv* /*env*/, jclass /*jobj*/, jlong jhandle, jint max_subcompactions) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
   options->compactRangeOptions.max_subcompactions =
@@ -268,7 +268,7 @@ void Java_org_rocksdb_CompactRangeOptions_setMaxSubcompactions(
  * Method:    setFullHistoryTSLow
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_CompactRangeOptions_setFullHistoryTSLow(JNIEnv*, jobject,
+void Java_org_rocksdb_CompactRangeOptions_setFullHistoryTSLow(JNIEnv*, jclass,
                                                               jlong jhandle,
                                                               jlong start,
                                                               jlong range) {
@@ -283,7 +283,7 @@ void Java_org_rocksdb_CompactRangeOptions_setFullHistoryTSLow(JNIEnv*, jobject,
  * Signature: (J)Lorg/rocksdb/CompactRangeOptions/Timestamp;
  */
 jobject Java_org_rocksdb_CompactRangeOptions_fullHistoryTSLow(JNIEnv* env,
-                                                              jobject,
+                                                              jclass,
                                                               jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -304,7 +304,7 @@ jobject Java_org_rocksdb_CompactRangeOptions_fullHistoryTSLow(JNIEnv* env,
  * Method:    setCanceled
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_CompactRangeOptions_setCanceled(JNIEnv*, jobject,
+void Java_org_rocksdb_CompactRangeOptions_setCanceled(JNIEnv*, jclass,
                                                       jlong jhandle,
                                                       jboolean jcanceled) {
   auto* options =
@@ -317,7 +317,7 @@ void Java_org_rocksdb_CompactRangeOptions_setCanceled(JNIEnv*, jobject,
  * Method:    canceled
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_CompactRangeOptions_canceled(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_CompactRangeOptions_canceled(JNIEnv*, jclass,
                                                        jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
@@ -329,9 +329,9 @@ jboolean Java_org_rocksdb_CompactRangeOptions_canceled(JNIEnv*, jobject,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompactRangeOptions_disposeInternal(JNIEnv* /*env*/,
-                                                          jobject /*jobj*/,
-                                                          jlong jhandle) {
+void Java_org_rocksdb_CompactRangeOptions_disposeInternalJni(JNIEnv* /*env*/,
+                                                             jclass /*jcls*/,
+                                                             jlong jhandle) {
   auto* options =
       reinterpret_cast<Java_org_rocksdb_CompactRangeOptions*>(jhandle);
   delete options;

--- a/java/rocksjni/compaction_filter_factory.cc
+++ b/java/rocksjni/compaction_filter_factory.cc
@@ -34,7 +34,7 @@ jlong Java_org_rocksdb_AbstractCompactionFilterFactory_createNewCompactionFilter
  * Signature: (J)V
  */
 void Java_org_rocksdb_AbstractCompactionFilterFactory_disposeInternal(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* ptr_sptr_cff = reinterpret_cast<
       std::shared_ptr<ROCKSDB_NAMESPACE::CompactionFilterFactoryJniCallback>*>(
       jhandle);

--- a/java/rocksjni/compaction_job_info.cc
+++ b/java/rocksjni/compaction_job_info.cc
@@ -28,8 +28,8 @@ jlong Java_org_rocksdb_CompactionJobInfo_newCompactionJobInfo(JNIEnv*, jclass) {
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompactionJobInfo_disposeInternal(JNIEnv*, jobject,
-                                                        jlong jhandle) {
+void Java_org_rocksdb_CompactionJobInfo_disposeInternalJni(JNIEnv*, jclass,
+                                                           jlong jhandle) {
   auto* compact_job_info =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionJobInfo*>(jhandle);
   delete compact_job_info;

--- a/java/rocksjni/compaction_job_stats.cc
+++ b/java/rocksjni/compaction_job_stats.cc
@@ -30,8 +30,8 @@ jlong Java_org_rocksdb_CompactionJobStats_newCompactionJobStats(JNIEnv*,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompactionJobStats_disposeInternal(JNIEnv*, jobject,
-                                                         jlong jhandle) {
+void Java_org_rocksdb_CompactionJobStats_disposeInternalJni(JNIEnv*, jclass,
+                                                            jlong jhandle) {
   auto* compact_job_stats =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionJobStats*>(jhandle);
   delete compact_job_stats;

--- a/java/rocksjni/compaction_options.cc
+++ b/java/rocksjni/compaction_options.cc
@@ -28,8 +28,8 @@ jlong Java_org_rocksdb_CompactionOptions_newCompactionOptions(JNIEnv*, jclass) {
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompactionOptions_disposeInternal(JNIEnv*, jobject,
-                                                        jlong jhandle) {
+void Java_org_rocksdb_CompactionOptions_disposeInternalJni(JNIEnv*, jclass,
+                                                           jlong jhandle) {
   auto* compact_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptions*>(jhandle);
   delete compact_opts;

--- a/java/rocksjni/compaction_options_fifo.cc
+++ b/java/rocksjni/compaction_options_fifo.cc
@@ -29,7 +29,7 @@ jlong Java_org_rocksdb_CompactionOptionsFIFO_newCompactionOptionsFIFO(JNIEnv*,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_CompactionOptionsFIFO_setMaxTableFilesSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_table_files_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_table_files_size) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsFIFO*>(jhandle);
   opt->max_table_files_size = static_cast<uint64_t>(jmax_table_files_size);
@@ -40,7 +40,7 @@ void Java_org_rocksdb_CompactionOptionsFIFO_setMaxTableFilesSize(
  * Method:    maxTableFilesSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_CompactionOptionsFIFO_maxTableFilesSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_CompactionOptionsFIFO_maxTableFilesSize(JNIEnv*, jclass,
                                                                jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsFIFO*>(jhandle);
@@ -53,7 +53,7 @@ jlong Java_org_rocksdb_CompactionOptionsFIFO_maxTableFilesSize(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_CompactionOptionsFIFO_setAllowCompaction(
-    JNIEnv*, jobject, jlong jhandle, jboolean allow_compaction) {
+    JNIEnv*, jclass, jlong jhandle, jboolean allow_compaction) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsFIFO*>(jhandle);
   opt->allow_compaction = static_cast<bool>(allow_compaction);
@@ -64,8 +64,7 @@ void Java_org_rocksdb_CompactionOptionsFIFO_setAllowCompaction(
  * Method:    allowCompaction
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_CompactionOptionsFIFO_allowCompaction(JNIEnv*,
-                                                                jobject,
+jboolean Java_org_rocksdb_CompactionOptionsFIFO_allowCompaction(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsFIFO*>(jhandle);
@@ -77,7 +76,7 @@ jboolean Java_org_rocksdb_CompactionOptionsFIFO_allowCompaction(JNIEnv*,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompactionOptionsFIFO_disposeInternal(JNIEnv*, jobject,
-                                                            jlong jhandle) {
+void Java_org_rocksdb_CompactionOptionsFIFO_disposeInternalJni(JNIEnv*, jclass,
+                                                               jlong jhandle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsFIFO*>(jhandle);
 }

--- a/java/rocksjni/compaction_options_universal.cc
+++ b/java/rocksjni/compaction_options_universal.cc
@@ -30,7 +30,7 @@ jlong Java_org_rocksdb_CompactionOptionsUniversal_newCompactionOptionsUniversal(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setSizeRatio(
-    JNIEnv*, jobject, jlong jhandle, jint jsize_ratio) {
+    JNIEnv*, jclass, jlong jhandle, jint jsize_ratio) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   opt->size_ratio = static_cast<unsigned int>(jsize_ratio);
@@ -41,7 +41,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setSizeRatio(
  * Method:    sizeRatio
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompactionOptionsUniversal_sizeRatio(JNIEnv*, jobject,
+jint Java_org_rocksdb_CompactionOptionsUniversal_sizeRatio(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
@@ -54,7 +54,7 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_sizeRatio(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setMinMergeWidth(
-    JNIEnv*, jobject, jlong jhandle, jint jmin_merge_width) {
+    JNIEnv*, jclass, jlong jhandle, jint jmin_merge_width) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   opt->min_merge_width = static_cast<unsigned int>(jmin_merge_width);
@@ -65,7 +65,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setMinMergeWidth(
  * Method:    minMergeWidth
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompactionOptionsUniversal_minMergeWidth(JNIEnv*, jobject,
+jint Java_org_rocksdb_CompactionOptionsUniversal_minMergeWidth(JNIEnv*, jclass,
                                                                jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
@@ -78,7 +78,7 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_minMergeWidth(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setMaxMergeWidth(
-    JNIEnv*, jobject, jlong jhandle, jint jmax_merge_width) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_merge_width) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   opt->max_merge_width = static_cast<unsigned int>(jmax_merge_width);
@@ -89,7 +89,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setMaxMergeWidth(
  * Method:    maxMergeWidth
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompactionOptionsUniversal_maxMergeWidth(JNIEnv*, jobject,
+jint Java_org_rocksdb_CompactionOptionsUniversal_maxMergeWidth(JNIEnv*, jclass,
                                                                jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
@@ -102,7 +102,7 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_maxMergeWidth(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setMaxSizeAmplificationPercent(
-    JNIEnv*, jobject, jlong jhandle, jint jmax_size_amplification_percent) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_size_amplification_percent) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   opt->max_size_amplification_percent =
@@ -115,7 +115,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setMaxSizeAmplificationPercent(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_CompactionOptionsUniversal_maxSizeAmplificationPercent(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   return static_cast<jint>(opt->max_size_amplification_percent);
@@ -127,7 +127,7 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_maxSizeAmplificationPercent(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setCompressionSizePercent(
-    JNIEnv*, jobject, jlong jhandle, jint jcompression_size_percent) {
+    JNIEnv*, jclass, jlong jhandle, jint jcompression_size_percent) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   opt->compression_size_percent =
@@ -140,7 +140,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setCompressionSizePercent(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_CompactionOptionsUniversal_compressionSizePercent(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   return static_cast<jint>(opt->compression_size_percent);
@@ -152,7 +152,7 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_compressionSizePercent(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setStopStyle(
-    JNIEnv*, jobject, jlong jhandle, jbyte jstop_style_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jstop_style_value) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   opt->stop_style =
@@ -165,7 +165,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setStopStyle(
  * Method:    stopStyle
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_CompactionOptionsUniversal_stopStyle(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_CompactionOptionsUniversal_stopStyle(JNIEnv*, jclass,
                                                             jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
@@ -179,7 +179,7 @@ jbyte Java_org_rocksdb_CompactionOptionsUniversal_stopStyle(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setAllowTrivialMove(
-    JNIEnv*, jobject, jlong jhandle, jboolean jallow_trivial_move) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jallow_trivial_move) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   opt->allow_trivial_move = static_cast<bool>(jallow_trivial_move);
@@ -191,7 +191,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setAllowTrivialMove(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_CompactionOptionsUniversal_allowTrivialMove(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(jhandle);
   return opt->allow_trivial_move;
@@ -202,8 +202,8 @@ jboolean Java_org_rocksdb_CompactionOptionsUniversal_allowTrivialMove(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompactionOptionsUniversal_disposeInternal(
-    JNIEnv*, jobject, jlong jhandle) {
+void Java_org_rocksdb_CompactionOptionsUniversal_disposeInternalJni(
+    JNIEnv*, jclass, jlong jhandle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsUniversal*>(
       jhandle);
 }

--- a/java/rocksjni/comparator.cc
+++ b/java/rocksjni/comparator.cc
@@ -39,8 +39,7 @@ jlong Java_org_rocksdb_AbstractComparator_createNewComparator(
  * Method:    usingDirectBuffers
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_AbstractComparator_usingDirectBuffers(JNIEnv*,
-                                                                jobject,
+jboolean Java_org_rocksdb_AbstractComparator_usingDirectBuffers(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   auto* c =
       reinterpret_cast<ROCKSDB_NAMESPACE::ComparatorJniCallback*>(jhandle);
@@ -53,7 +52,7 @@ jboolean Java_org_rocksdb_AbstractComparator_usingDirectBuffers(JNIEnv*,
  * Signature: (J)V
  */
 void Java_org_rocksdb_NativeComparatorWrapper_disposeInternal(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jcomparator_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jcomparator_handle) {
   auto* comparator =
       reinterpret_cast<ROCKSDB_NAMESPACE::Comparator*>(jcomparator_handle);
   delete comparator;

--- a/java/rocksjni/compression_options.cc
+++ b/java/rocksjni/compression_options.cc
@@ -28,7 +28,7 @@ jlong Java_org_rocksdb_CompressionOptions_newCompressionOptions(JNIEnv*,
  * Method:    setWindowBits
  * Signature: (JI)V
  */
-void Java_org_rocksdb_CompressionOptions_setWindowBits(JNIEnv*, jobject,
+void Java_org_rocksdb_CompressionOptions_setWindowBits(JNIEnv*, jclass,
                                                        jlong jhandle,
                                                        jint jwindow_bits) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
@@ -40,7 +40,7 @@ void Java_org_rocksdb_CompressionOptions_setWindowBits(JNIEnv*, jobject,
  * Method:    windowBits
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_windowBits(JNIEnv*, jobject,
+jint Java_org_rocksdb_CompressionOptions_windowBits(JNIEnv*, jclass,
                                                     jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->window_bits);
@@ -51,7 +51,7 @@ jint Java_org_rocksdb_CompressionOptions_windowBits(JNIEnv*, jobject,
  * Method:    setLevel
  * Signature: (JI)V
  */
-void Java_org_rocksdb_CompressionOptions_setLevel(JNIEnv*, jobject,
+void Java_org_rocksdb_CompressionOptions_setLevel(JNIEnv*, jclass,
                                                   jlong jhandle, jint jlevel) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   opt->level = static_cast<int>(jlevel);
@@ -62,8 +62,7 @@ void Java_org_rocksdb_CompressionOptions_setLevel(JNIEnv*, jobject,
  * Method:    level
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_level(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jint Java_org_rocksdb_CompressionOptions_level(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->level);
 }
@@ -73,7 +72,7 @@ jint Java_org_rocksdb_CompressionOptions_level(JNIEnv*, jobject,
  * Method:    setStrategy
  * Signature: (JI)V
  */
-void Java_org_rocksdb_CompressionOptions_setStrategy(JNIEnv*, jobject,
+void Java_org_rocksdb_CompressionOptions_setStrategy(JNIEnv*, jclass,
                                                      jlong jhandle,
                                                      jint jstrategy) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
@@ -85,7 +84,7 @@ void Java_org_rocksdb_CompressionOptions_setStrategy(JNIEnv*, jobject,
  * Method:    strategy
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_strategy(JNIEnv*, jobject,
+jint Java_org_rocksdb_CompressionOptions_strategy(JNIEnv*, jclass,
                                                   jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->strategy);
@@ -96,7 +95,7 @@ jint Java_org_rocksdb_CompressionOptions_strategy(JNIEnv*, jobject,
  * Method:    setMaxDictBytes
  * Signature: (JI)V
  */
-void Java_org_rocksdb_CompressionOptions_setMaxDictBytes(JNIEnv*, jobject,
+void Java_org_rocksdb_CompressionOptions_setMaxDictBytes(JNIEnv*, jclass,
                                                          jlong jhandle,
                                                          jint jmax_dict_bytes) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
@@ -108,7 +107,7 @@ void Java_org_rocksdb_CompressionOptions_setMaxDictBytes(JNIEnv*, jobject,
  * Method:    maxDictBytes
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_maxDictBytes(JNIEnv*, jobject,
+jint Java_org_rocksdb_CompressionOptions_maxDictBytes(JNIEnv*, jclass,
                                                       jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->max_dict_bytes);
@@ -120,7 +119,7 @@ jint Java_org_rocksdb_CompressionOptions_maxDictBytes(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompressionOptions_setZstdMaxTrainBytes(
-    JNIEnv*, jobject, jlong jhandle, jint jzstd_max_train_bytes) {
+    JNIEnv*, jclass, jlong jhandle, jint jzstd_max_train_bytes) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   opt->zstd_max_train_bytes = static_cast<uint32_t>(jzstd_max_train_bytes);
 }
@@ -130,7 +129,7 @@ void Java_org_rocksdb_CompressionOptions_setZstdMaxTrainBytes(
  * Method:    zstdMaxTrainBytes
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_zstdMaxTrainBytes(JNIEnv*, jobject,
+jint Java_org_rocksdb_CompressionOptions_zstdMaxTrainBytes(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->zstd_max_train_bytes);
@@ -142,7 +141,7 @@ jint Java_org_rocksdb_CompressionOptions_zstdMaxTrainBytes(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_CompressionOptions_setMaxDictBufferBytes(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_dict_buffer_bytes) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_dict_buffer_bytes) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   opt->max_dict_buffer_bytes = static_cast<uint64_t>(jmax_dict_buffer_bytes);
 }
@@ -152,7 +151,7 @@ void Java_org_rocksdb_CompressionOptions_setMaxDictBufferBytes(
  * Method:    maxDictBufferBytes
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_CompressionOptions_maxDictBufferBytes(JNIEnv*, jobject,
+jlong Java_org_rocksdb_CompressionOptions_maxDictBufferBytes(JNIEnv*, jclass,
                                                              jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   return static_cast<jlong>(opt->max_dict_buffer_bytes);
@@ -164,7 +163,7 @@ jlong Java_org_rocksdb_CompressionOptions_maxDictBufferBytes(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_CompressionOptions_setUseZstdDictTrainer(
-    JNIEnv*, jobject, jlong jhandle, jboolean juse_zstd_dict_trainer) {
+    JNIEnv*, jclass, jlong jhandle, jboolean juse_zstd_dict_trainer) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   opt->use_zstd_dict_trainer = juse_zstd_dict_trainer == JNI_TRUE;
 }
@@ -174,8 +173,7 @@ void Java_org_rocksdb_CompressionOptions_setUseZstdDictTrainer(
  * Method:    zstdMaxTrainBytes
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_CompressionOptions_useZstdDictTrainer(JNIEnv*,
-                                                                jobject,
+jboolean Java_org_rocksdb_CompressionOptions_useZstdDictTrainer(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   return static_cast<bool>(opt->use_zstd_dict_trainer);
@@ -186,7 +184,7 @@ jboolean Java_org_rocksdb_CompressionOptions_useZstdDictTrainer(JNIEnv*,
  * Method:    setEnabled
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_CompressionOptions_setEnabled(JNIEnv*, jobject,
+void Java_org_rocksdb_CompressionOptions_setEnabled(JNIEnv*, jclass,
                                                     jlong jhandle,
                                                     jboolean jenabled) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
@@ -198,7 +196,7 @@ void Java_org_rocksdb_CompressionOptions_setEnabled(JNIEnv*, jobject,
  * Method:    enabled
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_CompressionOptions_enabled(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_CompressionOptions_enabled(JNIEnv*, jclass,
                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
   return static_cast<bool>(opt->enabled);
@@ -208,7 +206,7 @@ jboolean Java_org_rocksdb_CompressionOptions_enabled(JNIEnv*, jobject,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompressionOptions_disposeInternal(JNIEnv*, jobject,
-                                                         jlong jhandle) {
+void Java_org_rocksdb_CompressionOptions_disposeInternalJni(JNIEnv*, jclass,
+                                                            jlong jhandle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(jhandle);
 }

--- a/java/rocksjni/concurrent_task_limiter.cc
+++ b/java/rocksjni/concurrent_task_limiter.cc
@@ -88,9 +88,8 @@ jint Java_org_rocksdb_ConcurrentTaskLimiterImpl_outstandingTask(JNIEnv*, jclass,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ConcurrentTaskLimiterImpl_disposeInternal(JNIEnv*,
-                                                                jobject,
-                                                                jlong jhandle) {
+void Java_org_rocksdb_ConcurrentTaskLimiterImpl_disposeInternalJni(
+    JNIEnv*, jclass, jlong jhandle) {
   auto* ptr = reinterpret_cast<
       std::shared_ptr<ROCKSDB_NAMESPACE::ConcurrentTaskLimiter>*>(jhandle);
   delete ptr;  // delete std::shared_ptr

--- a/java/rocksjni/config_options.cc
+++ b/java/rocksjni/config_options.cc
@@ -19,8 +19,8 @@
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ConfigOptions_disposeInternal(JNIEnv *, jobject,
-                                                    jlong jhandle) {
+void Java_org_rocksdb_ConfigOptions_disposeInternalJni(JNIEnv *, jclass,
+                                                       jlong jhandle) {
   auto *co = reinterpret_cast<ROCKSDB_NAMESPACE::ConfigOptions *>(jhandle);
   assert(co != nullptr);
   delete co;

--- a/java/rocksjni/env.cc
+++ b/java/rocksjni/env.cc
@@ -33,8 +33,7 @@ jlong Java_org_rocksdb_Env_getDefaultEnvInternal(JNIEnv*, jclass) {
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksEnv_disposeInternal(JNIEnv*, jobject,
-                                               jlong jhandle) {
+void Java_org_rocksdb_RocksEnv_disposeInternal(JNIEnv*, jclass, jlong jhandle) {
   auto* e = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
   assert(e != nullptr);
   delete e;
@@ -45,7 +44,7 @@ void Java_org_rocksdb_RocksEnv_disposeInternal(JNIEnv*, jobject,
  * Method:    setBackgroundThreads
  * Signature: (JIB)V
  */
-void Java_org_rocksdb_Env_setBackgroundThreads(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Env_setBackgroundThreads(JNIEnv*, jclass, jlong jhandle,
                                                jint jnum,
                                                jbyte jpriority_value) {
   auto* rocks_env = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
@@ -59,7 +58,7 @@ void Java_org_rocksdb_Env_setBackgroundThreads(JNIEnv*, jobject, jlong jhandle,
  * Method:    getBackgroundThreads
  * Signature: (JB)I
  */
-jint Java_org_rocksdb_Env_getBackgroundThreads(JNIEnv*, jobject, jlong jhandle,
+jint Java_org_rocksdb_Env_getBackgroundThreads(JNIEnv*, jclass, jlong jhandle,
                                                jbyte jpriority_value) {
   auto* rocks_env = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
   const int num = rocks_env->GetBackgroundThreads(
@@ -72,7 +71,7 @@ jint Java_org_rocksdb_Env_getBackgroundThreads(JNIEnv*, jobject, jlong jhandle,
  * Method:    getThreadPoolQueueLen
  * Signature: (JB)I
  */
-jint Java_org_rocksdb_Env_getThreadPoolQueueLen(JNIEnv*, jobject, jlong jhandle,
+jint Java_org_rocksdb_Env_getThreadPoolQueueLen(JNIEnv*, jclass, jlong jhandle,
                                                 jbyte jpriority_value) {
   auto* rocks_env = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
   const int queue_len = rocks_env->GetThreadPoolQueueLen(
@@ -85,7 +84,7 @@ jint Java_org_rocksdb_Env_getThreadPoolQueueLen(JNIEnv*, jobject, jlong jhandle,
  * Method:    incBackgroundThreadsIfNeeded
  * Signature: (JIB)V
  */
-void Java_org_rocksdb_Env_incBackgroundThreadsIfNeeded(JNIEnv*, jobject,
+void Java_org_rocksdb_Env_incBackgroundThreadsIfNeeded(JNIEnv*, jclass,
                                                        jlong jhandle, jint jnum,
                                                        jbyte jpriority_value) {
   auto* rocks_env = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
@@ -99,7 +98,7 @@ void Java_org_rocksdb_Env_incBackgroundThreadsIfNeeded(JNIEnv*, jobject,
  * Method:    lowerThreadPoolIOPriority
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Env_lowerThreadPoolIOPriority(JNIEnv*, jobject,
+void Java_org_rocksdb_Env_lowerThreadPoolIOPriority(JNIEnv*, jclass,
                                                     jlong jhandle,
                                                     jbyte jpriority_value) {
   auto* rocks_env = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
@@ -112,7 +111,7 @@ void Java_org_rocksdb_Env_lowerThreadPoolIOPriority(JNIEnv*, jobject,
  * Method:    lowerThreadPoolCPUPriority
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Env_lowerThreadPoolCPUPriority(JNIEnv*, jobject,
+void Java_org_rocksdb_Env_lowerThreadPoolCPUPriority(JNIEnv*, jclass,
                                                      jlong jhandle,
                                                      jbyte jpriority_value) {
   auto* rocks_env = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
@@ -125,7 +124,7 @@ void Java_org_rocksdb_Env_lowerThreadPoolCPUPriority(JNIEnv*, jobject,
  * Method:    getThreadList
  * Signature: (J)[Lorg/rocksdb/ThreadStatus;
  */
-jobjectArray Java_org_rocksdb_Env_getThreadList(JNIEnv* env, jobject,
+jobjectArray Java_org_rocksdb_Env_getThreadList(JNIEnv* env, jclass,
                                                 jlong jhandle) {
   auto* rocks_env = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
   std::vector<ROCKSDB_NAMESPACE::ThreadStatus> thread_status;
@@ -174,8 +173,8 @@ jlong Java_org_rocksdb_RocksMemEnv_createMemEnv(JNIEnv*, jclass,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksMemEnv_disposeInternal(JNIEnv*, jobject,
-                                                  jlong jhandle) {
+void Java_org_rocksdb_RocksMemEnv_disposeInternalJni(JNIEnv*, jclass,
+                                                     jlong jhandle) {
   auto* e = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
   assert(e != nullptr);
   delete e;
@@ -197,8 +196,8 @@ jlong Java_org_rocksdb_TimedEnv_createTimedEnv(JNIEnv*, jclass,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TimedEnv_disposeInternal(JNIEnv*, jobject,
-                                               jlong jhandle) {
+void Java_org_rocksdb_TimedEnv_disposeInternalJni(JNIEnv*, jclass,
+                                                  jlong jhandle) {
   auto* e = reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jhandle);
   assert(e != nullptr);
   delete e;

--- a/java/rocksjni/env_options.cc
+++ b/java/rocksjni/env_options.cc
@@ -56,8 +56,8 @@ jlong Java_org_rocksdb_EnvOptions_newEnvOptions__J(JNIEnv *, jclass,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_EnvOptions_disposeInternal(JNIEnv *, jobject,
-                                                 jlong jhandle) {
+void Java_org_rocksdb_EnvOptions_disposeInternalJni(JNIEnv *, jclass,
+                                                    jlong jhandle) {
   auto *eo = reinterpret_cast<ROCKSDB_NAMESPACE::EnvOptions *>(jhandle);
   assert(eo != nullptr);
   delete eo;
@@ -68,7 +68,7 @@ void Java_org_rocksdb_EnvOptions_disposeInternal(JNIEnv *, jobject,
  * Method:    setUseMmapReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setUseMmapReads(JNIEnv *, jobject,
+void Java_org_rocksdb_EnvOptions_setUseMmapReads(JNIEnv *, jclass,
                                                  jlong jhandle,
                                                  jboolean use_mmap_reads) {
   ENV_OPTIONS_SET_BOOL(jhandle, use_mmap_reads);
@@ -79,7 +79,7 @@ void Java_org_rocksdb_EnvOptions_setUseMmapReads(JNIEnv *, jobject,
  * Method:    useMmapReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_useMmapReads(JNIEnv *, jobject,
+jboolean Java_org_rocksdb_EnvOptions_useMmapReads(JNIEnv *, jclass,
                                                   jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, use_mmap_reads);
 }
@@ -89,7 +89,7 @@ jboolean Java_org_rocksdb_EnvOptions_useMmapReads(JNIEnv *, jobject,
  * Method:    setUseMmapWrites
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setUseMmapWrites(JNIEnv *, jobject,
+void Java_org_rocksdb_EnvOptions_setUseMmapWrites(JNIEnv *, jclass,
                                                   jlong jhandle,
                                                   jboolean use_mmap_writes) {
   ENV_OPTIONS_SET_BOOL(jhandle, use_mmap_writes);
@@ -100,7 +100,7 @@ void Java_org_rocksdb_EnvOptions_setUseMmapWrites(JNIEnv *, jobject,
  * Method:    useMmapWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_useMmapWrites(JNIEnv *, jobject,
+jboolean Java_org_rocksdb_EnvOptions_useMmapWrites(JNIEnv *, jclass,
                                                    jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, use_mmap_writes);
 }
@@ -110,7 +110,7 @@ jboolean Java_org_rocksdb_EnvOptions_useMmapWrites(JNIEnv *, jobject,
  * Method:    setUseDirectReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setUseDirectReads(JNIEnv *, jobject,
+void Java_org_rocksdb_EnvOptions_setUseDirectReads(JNIEnv *, jclass,
                                                    jlong jhandle,
                                                    jboolean use_direct_reads) {
   ENV_OPTIONS_SET_BOOL(jhandle, use_direct_reads);
@@ -121,7 +121,7 @@ void Java_org_rocksdb_EnvOptions_setUseDirectReads(JNIEnv *, jobject,
  * Method:    useDirectReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_useDirectReads(JNIEnv *, jobject,
+jboolean Java_org_rocksdb_EnvOptions_useDirectReads(JNIEnv *, jclass,
                                                     jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, use_direct_reads);
 }
@@ -132,7 +132,7 @@ jboolean Java_org_rocksdb_EnvOptions_useDirectReads(JNIEnv *, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_EnvOptions_setUseDirectWrites(
-    JNIEnv *, jobject, jlong jhandle, jboolean use_direct_writes) {
+    JNIEnv *, jclass, jlong jhandle, jboolean use_direct_writes) {
   ENV_OPTIONS_SET_BOOL(jhandle, use_direct_writes);
 }
 
@@ -141,7 +141,7 @@ void Java_org_rocksdb_EnvOptions_setUseDirectWrites(
  * Method:    useDirectWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_useDirectWrites(JNIEnv *, jobject,
+jboolean Java_org_rocksdb_EnvOptions_useDirectWrites(JNIEnv *, jclass,
                                                      jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, use_direct_writes);
 }
@@ -151,7 +151,7 @@ jboolean Java_org_rocksdb_EnvOptions_useDirectWrites(JNIEnv *, jobject,
  * Method:    setAllowFallocate
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setAllowFallocate(JNIEnv *, jobject,
+void Java_org_rocksdb_EnvOptions_setAllowFallocate(JNIEnv *, jclass,
                                                    jlong jhandle,
                                                    jboolean allow_fallocate) {
   ENV_OPTIONS_SET_BOOL(jhandle, allow_fallocate);
@@ -162,7 +162,7 @@ void Java_org_rocksdb_EnvOptions_setAllowFallocate(JNIEnv *, jobject,
  * Method:    allowFallocate
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_allowFallocate(JNIEnv *, jobject,
+jboolean Java_org_rocksdb_EnvOptions_allowFallocate(JNIEnv *, jclass,
                                                     jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, allow_fallocate);
 }
@@ -172,7 +172,7 @@ jboolean Java_org_rocksdb_EnvOptions_allowFallocate(JNIEnv *, jobject,
  * Method:    setSetFdCloexec
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setSetFdCloexec(JNIEnv *, jobject,
+void Java_org_rocksdb_EnvOptions_setSetFdCloexec(JNIEnv *, jclass,
                                                  jlong jhandle,
                                                  jboolean set_fd_cloexec) {
   ENV_OPTIONS_SET_BOOL(jhandle, set_fd_cloexec);
@@ -183,7 +183,7 @@ void Java_org_rocksdb_EnvOptions_setSetFdCloexec(JNIEnv *, jobject,
  * Method:    setFdCloexec
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_setFdCloexec(JNIEnv *, jobject,
+jboolean Java_org_rocksdb_EnvOptions_setFdCloexec(JNIEnv *, jclass,
                                                   jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, set_fd_cloexec);
 }
@@ -193,7 +193,7 @@ jboolean Java_org_rocksdb_EnvOptions_setFdCloexec(JNIEnv *, jobject,
  * Method:    setBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_EnvOptions_setBytesPerSync(JNIEnv *, jobject,
+void Java_org_rocksdb_EnvOptions_setBytesPerSync(JNIEnv *, jclass,
                                                  jlong jhandle,
                                                  jlong bytes_per_sync) {
   ENV_OPTIONS_SET_UINT64_T(jhandle, bytes_per_sync);
@@ -204,7 +204,7 @@ void Java_org_rocksdb_EnvOptions_setBytesPerSync(JNIEnv *, jobject,
  * Method:    bytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_EnvOptions_bytesPerSync(JNIEnv *, jobject,
+jlong Java_org_rocksdb_EnvOptions_bytesPerSync(JNIEnv *, jclass,
                                                jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, bytes_per_sync);
 }
@@ -215,7 +215,7 @@ jlong Java_org_rocksdb_EnvOptions_bytesPerSync(JNIEnv *, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_EnvOptions_setFallocateWithKeepSize(
-    JNIEnv *, jobject, jlong jhandle, jboolean fallocate_with_keep_size) {
+    JNIEnv *, jclass, jlong jhandle, jboolean fallocate_with_keep_size) {
   ENV_OPTIONS_SET_BOOL(jhandle, fallocate_with_keep_size);
 }
 
@@ -224,7 +224,7 @@ void Java_org_rocksdb_EnvOptions_setFallocateWithKeepSize(
  * Method:    fallocateWithKeepSize
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_fallocateWithKeepSize(JNIEnv *, jobject,
+jboolean Java_org_rocksdb_EnvOptions_fallocateWithKeepSize(JNIEnv *, jclass,
                                                            jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, fallocate_with_keep_size);
 }
@@ -235,7 +235,7 @@ jboolean Java_org_rocksdb_EnvOptions_fallocateWithKeepSize(JNIEnv *, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_EnvOptions_setCompactionReadaheadSize(
-    JNIEnv *, jobject, jlong jhandle, jlong compaction_readahead_size) {
+    JNIEnv *, jclass, jlong jhandle, jlong compaction_readahead_size) {
   ENV_OPTIONS_SET_SIZE_T(jhandle, compaction_readahead_size);
 }
 
@@ -244,7 +244,7 @@ void Java_org_rocksdb_EnvOptions_setCompactionReadaheadSize(
  * Method:    compactionReadaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_EnvOptions_compactionReadaheadSize(JNIEnv *, jobject,
+jlong Java_org_rocksdb_EnvOptions_compactionReadaheadSize(JNIEnv *, jclass,
                                                           jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, compaction_readahead_size);
 }
@@ -255,7 +255,7 @@ jlong Java_org_rocksdb_EnvOptions_compactionReadaheadSize(JNIEnv *, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_EnvOptions_setRandomAccessMaxBufferSize(
-    JNIEnv *, jobject, jlong jhandle, jlong random_access_max_buffer_size) {
+    JNIEnv *, jclass, jlong jhandle, jlong random_access_max_buffer_size) {
   ENV_OPTIONS_SET_SIZE_T(jhandle, random_access_max_buffer_size);
 }
 
@@ -264,7 +264,7 @@ void Java_org_rocksdb_EnvOptions_setRandomAccessMaxBufferSize(
  * Method:    randomAccessMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_EnvOptions_randomAccessMaxBufferSize(JNIEnv *, jobject,
+jlong Java_org_rocksdb_EnvOptions_randomAccessMaxBufferSize(JNIEnv *, jclass,
                                                             jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, random_access_max_buffer_size);
 }
@@ -275,7 +275,7 @@ jlong Java_org_rocksdb_EnvOptions_randomAccessMaxBufferSize(JNIEnv *, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_EnvOptions_setWritableFileMaxBufferSize(
-    JNIEnv *, jobject, jlong jhandle, jlong writable_file_max_buffer_size) {
+    JNIEnv *, jclass, jlong jhandle, jlong writable_file_max_buffer_size) {
   ENV_OPTIONS_SET_SIZE_T(jhandle, writable_file_max_buffer_size);
 }
 
@@ -284,7 +284,7 @@ void Java_org_rocksdb_EnvOptions_setWritableFileMaxBufferSize(
  * Method:    writableFileMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_EnvOptions_writableFileMaxBufferSize(JNIEnv *, jobject,
+jlong Java_org_rocksdb_EnvOptions_writableFileMaxBufferSize(JNIEnv *, jclass,
                                                             jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, writable_file_max_buffer_size);
 }
@@ -294,8 +294,7 @@ jlong Java_org_rocksdb_EnvOptions_writableFileMaxBufferSize(JNIEnv *, jobject,
  * Method:    setRateLimiter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_EnvOptions_setRateLimiter(JNIEnv *, jobject,
-                                                jlong jhandle,
+void Java_org_rocksdb_EnvOptions_setRateLimiter(JNIEnv *, jclass, jlong jhandle,
                                                 jlong rl_handle) {
   auto *sptr_rate_limiter =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter> *>(

--- a/java/rocksjni/filter.cc
+++ b/java/rocksjni/filter.cc
@@ -37,8 +37,9 @@ jlong Java_org_rocksdb_BloomFilter_createNewBloomFilter(JNIEnv* /*env*/,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_Filter_disposeInternal(JNIEnv* /*env*/, jobject /*jobj*/,
-                                             jlong jhandle) {
+void Java_org_rocksdb_Filter_disposeInternalJni(JNIEnv* /*env*/,
+                                                jclass /*jcls*/,
+                                                jlong jhandle) {
   auto* handle =
       reinterpret_cast<std::shared_ptr<const ROCKSDB_NAMESPACE::FilterPolicy>*>(
           jhandle);

--- a/java/rocksjni/ingest_external_file_options.cc
+++ b/java/rocksjni/ingest_external_file_options.cc
@@ -44,7 +44,7 @@ jlong Java_org_rocksdb_IngestExternalFileOptions_newIngestExternalFileOptions__Z
  * Method:    moveFiles
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_IngestExternalFileOptions_moveFiles(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_IngestExternalFileOptions_moveFiles(JNIEnv*, jclass,
                                                               jlong jhandle) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
@@ -57,7 +57,7 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_moveFiles(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setMoveFiles(
-    JNIEnv*, jobject, jlong jhandle, jboolean jmove_files) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jmove_files) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   options->move_files = static_cast<bool>(jmove_files);
@@ -69,7 +69,7 @@ void Java_org_rocksdb_IngestExternalFileOptions_setMoveFiles(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_IngestExternalFileOptions_snapshotConsistency(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   return static_cast<jboolean>(options->snapshot_consistency);
@@ -81,7 +81,7 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_snapshotConsistency(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setSnapshotConsistency(
-    JNIEnv*, jobject, jlong jhandle, jboolean jsnapshot_consistency) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jsnapshot_consistency) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   options->snapshot_consistency = static_cast<bool>(jsnapshot_consistency);
@@ -93,7 +93,7 @@ void Java_org_rocksdb_IngestExternalFileOptions_setSnapshotConsistency(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_IngestExternalFileOptions_allowGlobalSeqNo(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   return static_cast<jboolean>(options->allow_global_seqno);
@@ -105,7 +105,7 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_allowGlobalSeqNo(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setAllowGlobalSeqNo(
-    JNIEnv*, jobject, jlong jhandle, jboolean jallow_global_seqno) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jallow_global_seqno) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   options->allow_global_seqno = static_cast<bool>(jallow_global_seqno);
@@ -117,7 +117,7 @@ void Java_org_rocksdb_IngestExternalFileOptions_setAllowGlobalSeqNo(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_IngestExternalFileOptions_allowBlockingFlush(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   return static_cast<jboolean>(options->allow_blocking_flush);
@@ -129,7 +129,7 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_allowBlockingFlush(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setAllowBlockingFlush(
-    JNIEnv*, jobject, jlong jhandle, jboolean jallow_blocking_flush) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jallow_blocking_flush) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   options->allow_blocking_flush = static_cast<bool>(jallow_blocking_flush);
@@ -141,7 +141,7 @@ void Java_org_rocksdb_IngestExternalFileOptions_setAllowBlockingFlush(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_IngestExternalFileOptions_ingestBehind(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   return options->ingest_behind == JNI_TRUE;
@@ -153,7 +153,7 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_ingestBehind(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setIngestBehind(
-    JNIEnv*, jobject, jlong jhandle, jboolean jingest_behind) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jingest_behind) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   options->ingest_behind = jingest_behind == JNI_TRUE;
@@ -165,7 +165,7 @@ void Java_org_rocksdb_IngestExternalFileOptions_setIngestBehind(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_org_rocksdb_IngestExternalFileOptions_writeGlobalSeqno(JNIEnv*, jobject,
+Java_org_rocksdb_IngestExternalFileOptions_writeGlobalSeqno(JNIEnv*, jclass,
                                                             jlong jhandle) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
@@ -179,7 +179,7 @@ Java_org_rocksdb_IngestExternalFileOptions_writeGlobalSeqno(JNIEnv*, jobject,
  */
 JNIEXPORT void JNICALL
 Java_org_rocksdb_IngestExternalFileOptions_setWriteGlobalSeqno(
-    JNIEnv*, jobject, jlong jhandle, jboolean jwrite_global_seqno) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jwrite_global_seqno) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   options->write_global_seqno = jwrite_global_seqno == JNI_TRUE;
@@ -190,9 +190,8 @@ Java_org_rocksdb_IngestExternalFileOptions_setWriteGlobalSeqno(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_IngestExternalFileOptions_disposeInternal(JNIEnv*,
-                                                                jobject,
-                                                                jlong jhandle) {
+void Java_org_rocksdb_IngestExternalFileOptions_disposeInternalJni(
+    JNIEnv*, jclass, jlong jhandle) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::IngestExternalFileOptions*>(jhandle);
   delete options;

--- a/java/rocksjni/iterator.cc
+++ b/java/rocksjni/iterator.cc
@@ -22,9 +22,9 @@
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_disposeInternal(JNIEnv* /*env*/,
-                                                    jobject /*jobj*/,
-                                                    jlong handle) {
+void Java_org_rocksdb_RocksIterator_disposeInternalJni(JNIEnv* /*env*/,
+                                                       jclass /*cls*/,
+                                                       jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   assert(it != nullptr);
   delete it;
@@ -35,9 +35,9 @@ void Java_org_rocksdb_RocksIterator_disposeInternal(JNIEnv* /*env*/,
  * Method:    isValid0
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_RocksIterator_isValid0(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong handle) {
+jboolean Java_org_rocksdb_RocksIterator_isValid0Jni(JNIEnv* /*env*/,
+                                                    jclass /*jcls*/,
+                                                    jlong handle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->Valid();
 }
 
@@ -46,9 +46,9 @@ jboolean Java_org_rocksdb_RocksIterator_isValid0(JNIEnv* /*env*/,
  * Method:    seekToFirst0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_seekToFirst0(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong handle) {
+void Java_org_rocksdb_RocksIterator_seekToFirst0Jni(JNIEnv* /*env*/,
+                                                    jclass /*jcls*/,
+                                                    jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->SeekToFirst();
 }
 
@@ -57,9 +57,9 @@ void Java_org_rocksdb_RocksIterator_seekToFirst0(JNIEnv* /*env*/,
  * Method:    seekToLast0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_seekToLast0(JNIEnv* /*env*/,
-                                                jobject /*jobj*/,
-                                                jlong handle) {
+void Java_org_rocksdb_RocksIterator_seekToLast0Jni(JNIEnv* /*env*/,
+                                                   jclass /*jcls*/,
+                                                   jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->SeekToLast();
 }
 
@@ -68,8 +68,8 @@ void Java_org_rocksdb_RocksIterator_seekToLast0(JNIEnv* /*env*/,
  * Method:    next0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_next0(JNIEnv* /*env*/, jobject /*jobj*/,
-                                          jlong handle) {
+void Java_org_rocksdb_RocksIterator_next0Jni(JNIEnv* /*env*/, jclass /*jcls*/,
+                                             jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->Next();
 }
 
@@ -78,8 +78,8 @@ void Java_org_rocksdb_RocksIterator_next0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    prev0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_prev0(JNIEnv* /*env*/, jobject /*jobj*/,
-                                          jlong handle) {
+void Java_org_rocksdb_RocksIterator_prev0Jni(JNIEnv* /*env*/, jclass /*jobj*/,
+                                             jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->Prev();
 }
 
@@ -88,8 +88,8 @@ void Java_org_rocksdb_RocksIterator_prev0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    refresh0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_refresh0(JNIEnv* env, jobject /*jobj*/,
-                                             jlong handle) {
+void Java_org_rocksdb_RocksIterator_refresh0Jni(JNIEnv* env, jclass /*jcls*/,
+                                                jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Status s = it->Refresh();
 
@@ -125,9 +125,9 @@ void Java_org_rocksdb_RocksIterator_refresh1(JNIEnv* env, jobject /*jobj*/,
  * Method:    seek0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_RocksIterator_seek0(JNIEnv* env, jobject /*jobj*/,
-                                          jlong handle, jbyteArray jtarget,
-                                          jint jtarget_len) {
+void Java_org_rocksdb_RocksIterator_seek0Jni(JNIEnv* env, jclass /*jcls*/,
+                                             jlong handle, jbyteArray jtarget,
+                                             jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   auto seek = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
     it->Seek(target_slice);
@@ -144,8 +144,8 @@ void Java_org_rocksdb_RocksIterator_seek0(JNIEnv* env, jobject /*jobj*/,
  * Method:    seek0
  * Signature: (J[BII)V
  */
-void Java_org_rocksdb_RocksIterator_seekByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jtarget,
+void Java_org_rocksdb_RocksIterator_seekByteArray0Jni(
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jbyteArray jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   auto seek = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
@@ -160,10 +160,11 @@ void Java_org_rocksdb_RocksIterator_seekByteArray0(
  * Method:    seekDirect0
  * Signature: (JLjava/nio/ByteBuffer;II)V
  */
-void Java_org_rocksdb_RocksIterator_seekDirect0(JNIEnv* env, jobject /*jobj*/,
-                                                jlong handle, jobject jtarget,
-                                                jint jtarget_off,
-                                                jint jtarget_len) {
+void Java_org_rocksdb_RocksIterator_seekDirect0Jni(JNIEnv* env, jclass /*jobj*/,
+                                                   jlong handle,
+                                                   jobject jtarget,
+                                                   jint jtarget_off,
+                                                   jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   auto seek = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
     it->Seek(target_slice);
@@ -177,8 +178,8 @@ void Java_org_rocksdb_RocksIterator_seekDirect0(JNIEnv* env, jobject /*jobj*/,
  * Method:    seekForPrevDirect0
  * Signature: (JLjava/nio/ByteBuffer;II)V
  */
-void Java_org_rocksdb_RocksIterator_seekForPrevDirect0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jobject jtarget,
+void Java_org_rocksdb_RocksIterator_seekForPrevDirect0Jni(
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jobject jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   auto seekPrev = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
@@ -193,10 +194,11 @@ void Java_org_rocksdb_RocksIterator_seekForPrevDirect0(
  * Method:    seekForPrev0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_RocksIterator_seekForPrev0(JNIEnv* env, jobject /*jobj*/,
-                                                 jlong handle,
-                                                 jbyteArray jtarget,
-                                                 jint jtarget_len) {
+void Java_org_rocksdb_RocksIterator_seekForPrev0Jni(JNIEnv* env,
+                                                    jclass /*jcls*/,
+                                                    jlong handle,
+                                                    jbyteArray jtarget,
+                                                    jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   auto seek = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
     it->SeekForPrev(target_slice);
@@ -213,8 +215,8 @@ void Java_org_rocksdb_RocksIterator_seekForPrev0(JNIEnv* env, jobject /*jobj*/,
  * Method:    seek0
  * Signature: (J[BII)V
  */
-void Java_org_rocksdb_RocksIterator_seekForPrevByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jtarget,
+void Java_org_rocksdb_RocksIterator_seekForPrevByteArray0Jni(
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jbyteArray jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   auto seek = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
@@ -229,8 +231,8 @@ void Java_org_rocksdb_RocksIterator_seekForPrevByteArray0(
  * Method:    status0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_status0(JNIEnv* env, jobject /*jobj*/,
-                                            jlong handle) {
+void Java_org_rocksdb_RocksIterator_status0Jni(JNIEnv* env, jclass /*jcls*/,
+                                               jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Status s = it->status();
 
@@ -246,7 +248,7 @@ void Java_org_rocksdb_RocksIterator_status0(JNIEnv* env, jobject /*jobj*/,
  * Method:    key0
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_RocksIterator_key0(JNIEnv* env, jobject /*jobj*/,
+jbyteArray Java_org_rocksdb_RocksIterator_key0(JNIEnv* env, jclass /*jcls*/,
                                                jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice key_slice = it->key();
@@ -267,7 +269,7 @@ jbyteArray Java_org_rocksdb_RocksIterator_key0(JNIEnv* env, jobject /*jobj*/,
  * Method:    keyDirect0
  * Signature: (JLjava/nio/ByteBuffer;II)I
  */
-jint Java_org_rocksdb_RocksIterator_keyDirect0(JNIEnv* env, jobject /*jobj*/,
+jint Java_org_rocksdb_RocksIterator_keyDirect0(JNIEnv* env, jclass /*jcls*/,
                                                jlong handle, jobject jtarget,
                                                jint jtarget_off,
                                                jint jtarget_len) {
@@ -285,7 +287,7 @@ jint Java_org_rocksdb_RocksIterator_keyDirect0(JNIEnv* env, jobject /*jobj*/,
  * Method:    keyByteArray0
  * Signature: (J[BII)I
  */
-jint Java_org_rocksdb_RocksIterator_keyByteArray0(JNIEnv* env, jobject /*jobj*/,
+jint Java_org_rocksdb_RocksIterator_keyByteArray0(JNIEnv* env, jclass /*jcls*/,
                                                   jlong handle, jbyteArray jkey,
                                                   jint jkey_off,
                                                   jint jkey_len) {
@@ -305,7 +307,7 @@ jint Java_org_rocksdb_RocksIterator_keyByteArray0(JNIEnv* env, jobject /*jobj*/,
  * Method:    value0
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_RocksIterator_value0(JNIEnv* env, jobject /*jobj*/,
+jbyteArray Java_org_rocksdb_RocksIterator_value0(JNIEnv* env, jclass /*jcls*/,
                                                  jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice value_slice = it->value();
@@ -327,7 +329,7 @@ jbyteArray Java_org_rocksdb_RocksIterator_value0(JNIEnv* env, jobject /*jobj*/,
  * Method:    valueDirect0
  * Signature: (JLjava/nio/ByteBuffer;II)I
  */
-jint Java_org_rocksdb_RocksIterator_valueDirect0(JNIEnv* env, jobject /*jobj*/,
+jint Java_org_rocksdb_RocksIterator_valueDirect0(JNIEnv* env, jclass /*jcls*/,
                                                  jlong handle, jobject jtarget,
                                                  jint jtarget_off,
                                                  jint jtarget_len) {
@@ -346,7 +348,7 @@ jint Java_org_rocksdb_RocksIterator_valueDirect0(JNIEnv* env, jobject /*jobj*/,
  * Signature: (J[BII)I
  */
 jint Java_org_rocksdb_RocksIterator_valueByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jvalue_target,
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jbyteArray jvalue_target,
     jint jvalue_off, jint jvalue_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice value_slice = it->value();

--- a/java/rocksjni/lru_cache.cc
+++ b/java/rocksjni/lru_cache.cc
@@ -40,9 +40,9 @@ jlong Java_org_rocksdb_LRUCache_newLRUCache(JNIEnv* /*env*/, jclass /*jcls*/,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_LRUCache_disposeInternal(JNIEnv* /*env*/,
-                                               jobject /*jobj*/,
-                                               jlong jhandle) {
+void Java_org_rocksdb_LRUCache_disposeInternalJni(JNIEnv* /*env*/,
+                                                  jclass /*jcls*/,
+                                                  jlong jhandle) {
   auto* sptr_lru_cache =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Cache>*>(jhandle);
   delete sptr_lru_cache;  // delete std::shared_ptr

--- a/java/rocksjni/memtablejni.cc
+++ b/java/rocksjni/memtablejni.cc
@@ -19,7 +19,7 @@
  * Signature: (JII)J
  */
 jlong Java_org_rocksdb_HashSkipListMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* env, jobject /*jobj*/, jlong jbucket_count, jint jheight,
+    JNIEnv* env, jclass /*jcls*/, jlong jbucket_count, jint jheight,
     jint jbranching_factor) {
   ROCKSDB_NAMESPACE::Status s =
       ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(jbucket_count);
@@ -38,7 +38,7 @@ jlong Java_org_rocksdb_HashSkipListMemTableConfig_newMemTableFactoryHandle(
  * Signature: (JJIZI)J
  */
 jlong Java_org_rocksdb_HashLinkedListMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* env, jobject /*jobj*/, jlong jbucket_count,
+    JNIEnv* env, jclass /*jcls*/, jlong jbucket_count,
     jlong jhuge_page_tlb_size, jint jbucket_entries_logging_threshold,
     jboolean jif_log_bucket_dist_when_flash, jint jthreshold_use_skiplist) {
   ROCKSDB_NAMESPACE::Status statusBucketCount =
@@ -65,7 +65,7 @@ jlong Java_org_rocksdb_HashLinkedListMemTableConfig_newMemTableFactoryHandle(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_VectorMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* env, jobject /*jobj*/, jlong jreserved_size) {
+    JNIEnv* env, jclass /*jcls*/, jlong jreserved_size) {
   ROCKSDB_NAMESPACE::Status s =
       ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(jreserved_size);
   if (s.ok()) {
@@ -82,7 +82,7 @@ jlong Java_org_rocksdb_VectorMemTableConfig_newMemTableFactoryHandle(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_SkipListMemTableConfig_newMemTableFactoryHandle0(
-    JNIEnv* env, jobject /*jobj*/, jlong jlookahead) {
+    JNIEnv* env, jclass /*jcls*/, jlong jlookahead) {
   ROCKSDB_NAMESPACE::Status s =
       ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(jlookahead);
   if (s.ok()) {

--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -61,9 +61,9 @@ jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator__Ljava
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_StringAppendOperator_disposeInternal(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
-                                                           jlong jhandle) {
+void Java_org_rocksdb_StringAppendOperator_disposeInternalJni(JNIEnv* /*env*/,
+                                                              jclass /*jcls*/,
+                                                              jlong jhandle) {
   auto* sptr_string_append_op =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
           jhandle);
@@ -88,9 +88,9 @@ jlong Java_org_rocksdb_UInt64AddOperator_newSharedUInt64AddOperator(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_UInt64AddOperator_disposeInternal(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
-                                                        jlong jhandle) {
+void Java_org_rocksdb_UInt64AddOperator_disposeInternalJni(JNIEnv* /*env*/,
+                                                           jclass /*jobj*/,
+                                                           jlong jhandle) {
   auto* sptr_uint64_add_op =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
           jhandle);

--- a/java/rocksjni/optimistic_transaction_db.cc
+++ b/java/rocksjni/optimistic_transaction_db.cc
@@ -145,8 +145,8 @@ Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2_3_3B_3J(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_OptimisticTransactionDB_disposeInternal(JNIEnv*, jobject,
-                                                              jlong jhandle) {
+void Java_org_rocksdb_OptimisticTransactionDB_disposeInternalJni(
+    JNIEnv*, jclass, jlong jhandle) {
   auto* optimistic_txn_db =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDB*>(jhandle);
   assert(optimistic_txn_db != nullptr);
@@ -173,7 +173,7 @@ void Java_org_rocksdb_OptimisticTransactionDB_closeDatabase(JNIEnv* env, jclass,
  * Signature: (JJ)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction__JJ(
-    JNIEnv*, jobject, jlong jhandle, jlong jwrite_options_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jwrite_options_handle) {
   auto* optimistic_txn_db =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDB*>(jhandle);
   auto* write_options =
@@ -189,7 +189,7 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction__JJ(
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction__JJJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jwrite_options_handle, jlong joptimistic_txn_options_handle) {
   auto* optimistic_txn_db =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDB*>(jhandle);
@@ -209,7 +209,7 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction__JJJ(
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction_1withOld__JJJ(
-    JNIEnv*, jobject, jlong jhandle, jlong jwrite_options_handle,
+    JNIEnv*, jclass, jlong jhandle, jlong jwrite_options_handle,
     jlong jold_txn_handle) {
   auto* optimistic_txn_db =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDB*>(jhandle);
@@ -235,7 +235,7 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction_1withOld__JJJ(
  * Signature: (JJJJ)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction_1withOld__JJJJ(
-    JNIEnv*, jobject, jlong jhandle, jlong jwrite_options_handle,
+    JNIEnv*, jclass, jlong jhandle, jlong jwrite_options_handle,
     jlong joptimistic_txn_options_handle, jlong jold_txn_handle) {
   auto* optimistic_txn_db =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDB*>(jhandle);
@@ -262,7 +262,7 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction_1withOld__JJJJ(
  * Method:    getBaseDB
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_OptimisticTransactionDB_getBaseDB(JNIEnv*, jobject,
+jlong Java_org_rocksdb_OptimisticTransactionDB_getBaseDB(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* optimistic_txn_db =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDB*>(jhandle);

--- a/java/rocksjni/optimistic_transaction_options.cc
+++ b/java/rocksjni/optimistic_transaction_options.cc
@@ -31,7 +31,7 @@ jlong Java_org_rocksdb_OptimisticTransactionOptions_newOptimisticTransactionOpti
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_OptimisticTransactionOptions_isSetSnapshot(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionOptions*>(
           jhandle);
@@ -44,7 +44,7 @@ jboolean Java_org_rocksdb_OptimisticTransactionOptions_isSetSnapshot(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_OptimisticTransactionOptions_setSetSnapshot(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean jset_snapshot) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jboolean jset_snapshot) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionOptions*>(
           jhandle);
@@ -57,8 +57,7 @@ void Java_org_rocksdb_OptimisticTransactionOptions_setSetSnapshot(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_OptimisticTransactionOptions_setComparator(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
-    jlong jcomparator_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jlong jcomparator_handle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionOptions*>(
           jhandle);
@@ -71,8 +70,8 @@ void Java_org_rocksdb_OptimisticTransactionOptions_setComparator(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_OptimisticTransactionOptions_disposeInternal(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+void Java_org_rocksdb_OptimisticTransactionOptions_disposeInternalJni(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionOptions*>(
       jhandle);
 }

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -82,7 +82,8 @@ jlong Java_org_rocksdb_Options_copyOptions(JNIEnv*, jclass, jlong jhandle) {
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_Options_disposeInternal(JNIEnv*, jobject, jlong handle) {
+void Java_org_rocksdb_Options_disposeInternalJni(JNIEnv*, jclass,
+                                                 jlong handle) {
   auto* op = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(handle);
   assert(op != nullptr);
   delete op;
@@ -93,7 +94,7 @@ void Java_org_rocksdb_Options_disposeInternal(JNIEnv*, jobject, jlong handle) {
  * Method:    setIncreaseParallelism
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setIncreaseParallelism(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setIncreaseParallelism(JNIEnv*, jclass,
                                                      jlong jhandle,
                                                      jint totalThreads) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->IncreaseParallelism(
@@ -105,8 +106,8 @@ void Java_org_rocksdb_Options_setIncreaseParallelism(JNIEnv*, jobject,
  * Method:    setCreateIfMissing
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setCreateIfMissing(JNIEnv*, jobject,
-                                                 jlong jhandle, jboolean flag) {
+void Java_org_rocksdb_Options_setCreateIfMissing(JNIEnv*, jclass, jlong jhandle,
+                                                 jboolean flag) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->create_if_missing =
       flag;
 }
@@ -116,7 +117,7 @@ void Java_org_rocksdb_Options_setCreateIfMissing(JNIEnv*, jobject,
  * Method:    createIfMissing
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_createIfMissing(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_createIfMissing(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->create_if_missing;
@@ -127,7 +128,7 @@ jboolean Java_org_rocksdb_Options_createIfMissing(JNIEnv*, jobject,
  * Method:    setCreateMissingColumnFamilies
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setCreateMissingColumnFamilies(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setCreateMissingColumnFamilies(JNIEnv*, jclass,
                                                              jlong jhandle,
                                                              jboolean flag) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
@@ -139,7 +140,7 @@ void Java_org_rocksdb_Options_setCreateMissingColumnFamilies(JNIEnv*, jobject,
  * Method:    createMissingColumnFamilies
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_createMissingColumnFamilies(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_createMissingColumnFamilies(JNIEnv*, jclass,
                                                               jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->create_missing_column_families;
@@ -150,7 +151,7 @@ jboolean Java_org_rocksdb_Options_createMissingColumnFamilies(JNIEnv*, jobject,
  * Method:    setComparatorHandle
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setComparatorHandle__JI(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setComparatorHandle__JI(JNIEnv*, jclass,
                                                       jlong jhandle,
                                                       jint builtinComparator) {
   switch (builtinComparator) {
@@ -170,7 +171,7 @@ void Java_org_rocksdb_Options_setComparatorHandle__JI(JNIEnv*, jobject,
  * Method:    setComparatorHandle
  * Signature: (JJB)V
  */
-void Java_org_rocksdb_Options_setComparatorHandle__JJB(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setComparatorHandle__JJB(JNIEnv*, jclass,
                                                        jlong jopt_handle,
                                                        jlong jcomparator_handle,
                                                        jbyte jcomparator_type) {
@@ -197,7 +198,7 @@ void Java_org_rocksdb_Options_setComparatorHandle__JJB(JNIEnv*, jobject,
  * Method:    setMergeOperatorName
  * Signature: (JJjava/lang/String)V
  */
-void Java_org_rocksdb_Options_setMergeOperatorName(JNIEnv* env, jobject,
+void Java_org_rocksdb_Options_setMergeOperatorName(JNIEnv* env, jclass,
                                                    jlong jhandle,
                                                    jstring jop_name) {
   const char* op_name = env->GetStringUTFChars(jop_name, nullptr);
@@ -218,7 +219,7 @@ void Java_org_rocksdb_Options_setMergeOperatorName(JNIEnv* env, jobject,
  * Method:    setMergeOperator
  * Signature: (JJjava/lang/String)V
  */
-void Java_org_rocksdb_Options_setMergeOperator(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setMergeOperator(JNIEnv*, jclass, jlong jhandle,
                                                jlong mergeOperatorHandle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->merge_operator =
       *(reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
@@ -231,7 +232,7 @@ void Java_org_rocksdb_Options_setMergeOperator(JNIEnv*, jobject, jlong jhandle,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompactionFilterHandle(
-    JNIEnv*, jobject, jlong jopt_handle, jlong jcompactionfilter_handle) {
+    JNIEnv*, jclass, jlong jopt_handle, jlong jcompactionfilter_handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jopt_handle)
       ->compaction_filter =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionFilter*>(
@@ -244,8 +245,7 @@ void Java_org_rocksdb_Options_setCompactionFilterHandle(
  * Signature: (JJ)V
  */
 void JNICALL Java_org_rocksdb_Options_setCompactionFilterFactoryHandle(
-    JNIEnv*, jobject, jlong jopt_handle,
-    jlong jcompactionfilterfactory_handle) {
+    JNIEnv*, jclass, jlong jopt_handle, jlong jcompactionfilterfactory_handle) {
   auto* cff_factory = reinterpret_cast<
       std::shared_ptr<ROCKSDB_NAMESPACE::CompactionFilterFactory>*>(
       jcompactionfilterfactory_handle);
@@ -258,7 +258,7 @@ void JNICALL Java_org_rocksdb_Options_setCompactionFilterFactoryHandle(
  * Method:    setWriteBufferSize
  * Signature: (JJ)I
  */
-void Java_org_rocksdb_Options_setWriteBufferSize(JNIEnv* env, jobject,
+void Java_org_rocksdb_Options_setWriteBufferSize(JNIEnv* env, jclass,
                                                  jlong jhandle,
                                                  jlong jwrite_buffer_size) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
@@ -277,7 +277,7 @@ void Java_org_rocksdb_Options_setWriteBufferSize(JNIEnv* env, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setWriteBufferManager(
-    JNIEnv*, jobject, jlong joptions_handle,
+    JNIEnv*, jclass, jlong joptions_handle,
     jlong jwrite_buffer_manager_handle) {
   auto* write_buffer_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::WriteBufferManager>*>(
@@ -291,8 +291,7 @@ void Java_org_rocksdb_Options_setWriteBufferManager(
  * Method:    writeBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_writeBufferSize(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jlong Java_org_rocksdb_Options_writeBufferSize(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->write_buffer_size;
 }
@@ -303,7 +302,7 @@ jlong Java_org_rocksdb_Options_writeBufferSize(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxWriteBufferNumber(
-    JNIEnv*, jobject, jlong jhandle, jint jmax_write_buffer_number) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_write_buffer_number) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_write_buffer_number = jmax_write_buffer_number;
 }
@@ -313,7 +312,7 @@ void Java_org_rocksdb_Options_setMaxWriteBufferNumber(
  * Method:    setStatistics
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setStatistics(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setStatistics(JNIEnv*, jclass, jlong jhandle,
                                             jlong jstatistics_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   auto* pSptr =
@@ -327,7 +326,7 @@ void Java_org_rocksdb_Options_setStatistics(JNIEnv*, jobject, jlong jhandle,
  * Method:    statistics
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_statistics(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_statistics(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> sptr = opt->statistics;
   if (sptr == nullptr) {
@@ -344,7 +343,7 @@ jlong Java_org_rocksdb_Options_statistics(JNIEnv*, jobject, jlong jhandle) {
  * Method:    maxWriteBufferNumber
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxWriteBufferNumber(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_maxWriteBufferNumber(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_write_buffer_number;
@@ -355,7 +354,7 @@ jint Java_org_rocksdb_Options_maxWriteBufferNumber(JNIEnv*, jobject,
  * Method:    errorIfExists
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_errorIfExists(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_errorIfExists(JNIEnv*, jclass,
                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->error_if_exists;
@@ -366,7 +365,7 @@ jboolean Java_org_rocksdb_Options_errorIfExists(JNIEnv*, jobject,
  * Method:    setErrorIfExists
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setErrorIfExists(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setErrorIfExists(JNIEnv*, jclass, jlong jhandle,
                                                jboolean error_if_exists) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->error_if_exists =
       static_cast<bool>(error_if_exists);
@@ -377,7 +376,7 @@ void Java_org_rocksdb_Options_setErrorIfExists(JNIEnv*, jobject, jlong jhandle,
  * Method:    paranoidChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_paranoidChecks(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_paranoidChecks(JNIEnv*, jclass,
                                                  jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->paranoid_checks;
@@ -388,7 +387,7 @@ jboolean Java_org_rocksdb_Options_paranoidChecks(JNIEnv*, jobject,
  * Method:    setParanoidChecks
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setParanoidChecks(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setParanoidChecks(JNIEnv*, jclass, jlong jhandle,
                                                 jboolean paranoid_checks) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->paranoid_checks =
       static_cast<bool>(paranoid_checks);
@@ -399,7 +398,7 @@ void Java_org_rocksdb_Options_setParanoidChecks(JNIEnv*, jobject, jlong jhandle,
  * Method:    setEnv
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setEnv(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setEnv(JNIEnv*, jclass, jlong jhandle,
                                      jlong jenv) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->env =
       reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jenv);
@@ -410,8 +409,7 @@ void Java_org_rocksdb_Options_setEnv(JNIEnv*, jobject, jlong jhandle,
  * Method:    setMaxTotalWalSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setMaxTotalWalSize(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setMaxTotalWalSize(JNIEnv*, jclass, jlong jhandle,
                                                  jlong jmax_total_wal_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->max_total_wal_size =
       static_cast<jlong>(jmax_total_wal_size);
@@ -422,8 +420,7 @@ void Java_org_rocksdb_Options_setMaxTotalWalSize(JNIEnv*, jobject,
  * Method:    maxTotalWalSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxTotalWalSize(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jlong Java_org_rocksdb_Options_maxTotalWalSize(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_total_wal_size;
 }
@@ -433,7 +430,7 @@ jlong Java_org_rocksdb_Options_maxTotalWalSize(JNIEnv*, jobject,
  * Method:    maxOpenFiles
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxOpenFiles(JNIEnv*, jobject, jlong jhandle) {
+jint Java_org_rocksdb_Options_maxOpenFiles(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->max_open_files;
 }
 
@@ -442,7 +439,7 @@ jint Java_org_rocksdb_Options_maxOpenFiles(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setMaxOpenFiles
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxOpenFiles(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setMaxOpenFiles(JNIEnv*, jclass, jlong jhandle,
                                               jint max_open_files) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->max_open_files =
       static_cast<int>(max_open_files);
@@ -454,7 +451,7 @@ void Java_org_rocksdb_Options_setMaxOpenFiles(JNIEnv*, jobject, jlong jhandle,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxFileOpeningThreads(
-    JNIEnv*, jobject, jlong jhandle, jint jmax_file_opening_threads) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_file_opening_threads) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_file_opening_threads = static_cast<int>(jmax_file_opening_threads);
 }
@@ -464,7 +461,7 @@ void Java_org_rocksdb_Options_setMaxFileOpeningThreads(
  * Method:    maxFileOpeningThreads
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxFileOpeningThreads(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_maxFileOpeningThreads(JNIEnv*, jclass,
                                                     jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<int>(opt->max_file_opening_threads);
@@ -475,7 +472,7 @@ jint Java_org_rocksdb_Options_maxFileOpeningThreads(JNIEnv*, jobject,
  * Method:    useFsync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_useFsync(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_useFsync(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->use_fsync;
 }
 
@@ -484,7 +481,7 @@ jboolean Java_org_rocksdb_Options_useFsync(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setUseFsync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setUseFsync(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setUseFsync(JNIEnv*, jclass, jlong jhandle,
                                           jboolean use_fsync) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->use_fsync =
       static_cast<bool>(use_fsync);
@@ -495,7 +492,7 @@ void Java_org_rocksdb_Options_setUseFsync(JNIEnv*, jobject, jlong jhandle,
  * Method:    setDbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_Options_setDbPaths(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setDbPaths(JNIEnv* env, jclass, jlong jhandle,
                                          jobjectArray jpaths,
                                          jlongArray jtarget_sizes) {
   std::vector<ROCKSDB_NAMESPACE::DbPath> db_paths;
@@ -541,7 +538,7 @@ void Java_org_rocksdb_Options_setDbPaths(JNIEnv* env, jobject, jlong jhandle,
  * Method:    dbPathsLen
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_dbPathsLen(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_dbPathsLen(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->db_paths.size());
 }
@@ -551,7 +548,7 @@ jlong Java_org_rocksdb_Options_dbPathsLen(JNIEnv*, jobject, jlong jhandle) {
  * Method:    dbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_Options_dbPaths(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_dbPaths(JNIEnv* env, jclass, jlong jhandle,
                                       jobjectArray jpaths,
                                       jlongArray jtarget_sizes) {
   jboolean is_copy;
@@ -592,7 +589,7 @@ void Java_org_rocksdb_Options_dbPaths(JNIEnv* env, jobject, jlong jhandle,
  * Method:    dbLogDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_Options_dbLogDir(JNIEnv* env, jobject, jlong jhandle) {
+jstring Java_org_rocksdb_Options_dbLogDir(JNIEnv* env, jclass, jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
           ->db_log_dir.c_str());
@@ -603,7 +600,7 @@ jstring Java_org_rocksdb_Options_dbLogDir(JNIEnv* env, jobject, jlong jhandle) {
  * Method:    setDbLogDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_Options_setDbLogDir(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setDbLogDir(JNIEnv* env, jclass, jlong jhandle,
                                           jstring jdb_log_dir) {
   const char* log_dir = env->GetStringUTFChars(jdb_log_dir, nullptr);
   if (log_dir == nullptr) {
@@ -620,7 +617,7 @@ void Java_org_rocksdb_Options_setDbLogDir(JNIEnv* env, jobject, jlong jhandle,
  * Method:    walDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_Options_walDir(JNIEnv* env, jobject, jlong jhandle) {
+jstring Java_org_rocksdb_Options_walDir(JNIEnv* env, jclass, jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->wal_dir.c_str());
 }
@@ -630,7 +627,7 @@ jstring Java_org_rocksdb_Options_walDir(JNIEnv* env, jobject, jlong jhandle) {
  * Method:    setWalDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_Options_setWalDir(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setWalDir(JNIEnv* env, jclass, jlong jhandle,
                                         jstring jwal_dir) {
   const char* wal_dir = env->GetStringUTFChars(jwal_dir, nullptr);
   if (wal_dir == nullptr) {
@@ -647,7 +644,7 @@ void Java_org_rocksdb_Options_setWalDir(JNIEnv* env, jobject, jlong jhandle,
  * Method:    deleteObsoleteFilesPeriodMicros
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_deleteObsoleteFilesPeriodMicros(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_deleteObsoleteFilesPeriodMicros(JNIEnv*, jclass,
                                                                jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->delete_obsolete_files_period_micros;
@@ -659,7 +656,7 @@ jlong Java_org_rocksdb_Options_deleteObsoleteFilesPeriodMicros(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setDeleteObsoleteFilesPeriodMicros(JNIEnv*,
-                                                                 jobject,
+                                                                 jclass,
                                                                  jlong jhandle,
                                                                  jlong micros) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
@@ -671,7 +668,7 @@ void Java_org_rocksdb_Options_setDeleteObsoleteFilesPeriodMicros(JNIEnv*,
  * Method:    maxBackgroundCompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxBackgroundCompactions(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_maxBackgroundCompactions(JNIEnv*, jclass,
                                                        jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_background_compactions;
@@ -682,7 +679,7 @@ jint Java_org_rocksdb_Options_maxBackgroundCompactions(JNIEnv*, jobject,
  * Method:    setMaxBackgroundCompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxBackgroundCompactions(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setMaxBackgroundCompactions(JNIEnv*, jclass,
                                                           jlong jhandle,
                                                           jint max) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
@@ -694,7 +691,7 @@ void Java_org_rocksdb_Options_setMaxBackgroundCompactions(JNIEnv*, jobject,
  * Method:    setMaxSubcompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxSubcompactions(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setMaxSubcompactions(JNIEnv*, jclass,
                                                    jlong jhandle, jint max) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->max_subcompactions =
       static_cast<int32_t>(max);
@@ -705,7 +702,7 @@ void Java_org_rocksdb_Options_setMaxSubcompactions(JNIEnv*, jobject,
  * Method:    maxSubcompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxSubcompactions(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_maxSubcompactions(JNIEnv*, jclass,
                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_subcompactions;
@@ -716,7 +713,7 @@ jint Java_org_rocksdb_Options_maxSubcompactions(JNIEnv*, jobject,
  * Method:    maxBackgroundFlushes
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxBackgroundFlushes(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_maxBackgroundFlushes(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_background_flushes;
@@ -728,7 +725,7 @@ jint Java_org_rocksdb_Options_maxBackgroundFlushes(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxBackgroundFlushes(
-    JNIEnv*, jobject, jlong jhandle, jint max_background_flushes) {
+    JNIEnv*, jclass, jlong jhandle, jint max_background_flushes) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_background_flushes = static_cast<int>(max_background_flushes);
 }
@@ -738,7 +735,7 @@ void Java_org_rocksdb_Options_setMaxBackgroundFlushes(
  * Method:    maxBackgroundJobs
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxBackgroundJobs(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_maxBackgroundJobs(JNIEnv*, jclass,
                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_background_jobs;
@@ -749,7 +746,7 @@ jint Java_org_rocksdb_Options_maxBackgroundJobs(JNIEnv*, jobject,
  * Method:    setMaxBackgroundJobs
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxBackgroundJobs(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setMaxBackgroundJobs(JNIEnv*, jclass,
                                                    jlong jhandle,
                                                    jint max_background_jobs) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->max_background_jobs =
@@ -761,7 +758,7 @@ void Java_org_rocksdb_Options_setMaxBackgroundJobs(JNIEnv*, jobject,
  * Method:    maxLogFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxLogFileSize(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_maxLogFileSize(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_log_file_size;
 }
@@ -771,7 +768,7 @@ jlong Java_org_rocksdb_Options_maxLogFileSize(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setMaxLogFileSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setMaxLogFileSize(JNIEnv* env, jobject,
+void Java_org_rocksdb_Options_setMaxLogFileSize(JNIEnv* env, jclass,
                                                 jlong jhandle,
                                                 jlong max_log_file_size) {
   auto s =
@@ -789,7 +786,7 @@ void Java_org_rocksdb_Options_setMaxLogFileSize(JNIEnv* env, jobject,
  * Method:    logFileTimeToRoll
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_logFileTimeToRoll(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_logFileTimeToRoll(JNIEnv*, jclass,
                                                  jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->log_file_time_to_roll;
@@ -801,7 +798,7 @@ jlong Java_org_rocksdb_Options_logFileTimeToRoll(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setLogFileTimeToRoll(
-    JNIEnv* env, jobject, jlong jhandle, jlong log_file_time_to_roll) {
+    JNIEnv* env, jclass, jlong jhandle, jlong log_file_time_to_roll) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       log_file_time_to_roll);
   if (s.ok()) {
@@ -817,7 +814,7 @@ void Java_org_rocksdb_Options_setLogFileTimeToRoll(
  * Method:    keepLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_keepLogFileNum(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_keepLogFileNum(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->keep_log_file_num;
 }
@@ -827,7 +824,7 @@ jlong Java_org_rocksdb_Options_keepLogFileNum(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setKeepLogFileNum
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setKeepLogFileNum(JNIEnv* env, jobject,
+void Java_org_rocksdb_Options_setKeepLogFileNum(JNIEnv* env, jclass,
                                                 jlong jhandle,
                                                 jlong keep_log_file_num) {
   auto s =
@@ -845,7 +842,7 @@ void Java_org_rocksdb_Options_setKeepLogFileNum(JNIEnv* env, jobject,
  * Method:    recycleLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_recycleLogFileNum(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_recycleLogFileNum(JNIEnv*, jclass,
                                                  jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->recycle_log_file_num;
@@ -856,7 +853,7 @@ jlong Java_org_rocksdb_Options_recycleLogFileNum(JNIEnv*, jobject,
  * Method:    setRecycleLogFileNum
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setRecycleLogFileNum(JNIEnv* env, jobject,
+void Java_org_rocksdb_Options_setRecycleLogFileNum(JNIEnv* env, jclass,
                                                    jlong jhandle,
                                                    jlong recycle_log_file_num) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
@@ -874,7 +871,7 @@ void Java_org_rocksdb_Options_setRecycleLogFileNum(JNIEnv* env, jobject,
  * Method:    maxManifestFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxManifestFileSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_maxManifestFileSize(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_manifest_file_size;
@@ -884,7 +881,7 @@ jlong Java_org_rocksdb_Options_maxManifestFileSize(JNIEnv*, jobject,
  * Method:    memTableFactoryName
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_Options_memTableFactoryName(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_Options_memTableFactoryName(JNIEnv* env, jclass,
                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   ROCKSDB_NAMESPACE::MemTableRepFactory* tf = opt->memtable_factory.get();
@@ -1036,7 +1033,7 @@ void Java_org_rocksdb_Options_cfPaths(JNIEnv* env, jclass, jlong jhandle,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxManifestFileSize(
-    JNIEnv*, jobject, jlong jhandle, jlong max_manifest_file_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong max_manifest_file_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_manifest_file_size = static_cast<int64_t>(max_manifest_file_size);
 }
@@ -1045,8 +1042,7 @@ void Java_org_rocksdb_Options_setMaxManifestFileSize(
  * Method:    setMemTableFactory
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setMemTableFactory(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setMemTableFactory(JNIEnv*, jclass, jlong jhandle,
                                                  jlong jfactory_handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->memtable_factory.reset(
@@ -1059,7 +1055,7 @@ void Java_org_rocksdb_Options_setMemTableFactory(JNIEnv*, jobject,
  * Method:    setRateLimiter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setRateLimiter(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setRateLimiter(JNIEnv*, jclass, jlong jhandle,
                                              jlong jrate_limiter_handle) {
   std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>* pRateLimiter =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(
@@ -1074,7 +1070,7 @@ void Java_org_rocksdb_Options_setRateLimiter(JNIEnv*, jobject, jlong jhandle,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setSstFileManager(
-    JNIEnv*, jobject, jlong jhandle, jlong jsst_file_manager_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jsst_file_manager_handle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
           jsst_file_manager_handle);
@@ -1087,7 +1083,7 @@ void Java_org_rocksdb_Options_setSstFileManager(
  * Method:    setLogger
  * Signature: (JJB)V
  */
-void Java_org_rocksdb_Options_setLogger(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setLogger(JNIEnv* env, jclass, jlong jhandle,
                                         jlong jlogger_handle,
                                         jbyte jlogger_type) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
@@ -1117,7 +1113,7 @@ void Java_org_rocksdb_Options_setLogger(JNIEnv* env, jobject, jlong jhandle,
  * Method:    setInfoLogLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Options_setInfoLogLevel(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setInfoLogLevel(JNIEnv*, jclass, jlong jhandle,
                                               jbyte jlog_level) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->info_log_level =
       static_cast<ROCKSDB_NAMESPACE::InfoLogLevel>(jlog_level);
@@ -1128,7 +1124,7 @@ void Java_org_rocksdb_Options_setInfoLogLevel(JNIEnv*, jobject, jlong jhandle,
  * Method:    infoLogLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_infoLogLevel(JNIEnv*, jobject, jlong jhandle) {
+jbyte Java_org_rocksdb_Options_infoLogLevel(JNIEnv*, jclass, jlong jhandle) {
   return static_cast<jbyte>(
       reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->info_log_level);
 }
@@ -1138,7 +1134,7 @@ jbyte Java_org_rocksdb_Options_infoLogLevel(JNIEnv*, jobject, jlong jhandle) {
  * Method:    tableCacheNumshardbits
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_tableCacheNumshardbits(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_tableCacheNumshardbits(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->table_cache_numshardbits;
@@ -1150,7 +1146,7 @@ jint Java_org_rocksdb_Options_tableCacheNumshardbits(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setTableCacheNumshardbits(
-    JNIEnv*, jobject, jlong jhandle, jint table_cache_numshardbits) {
+    JNIEnv*, jclass, jlong jhandle, jint table_cache_numshardbits) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->table_cache_numshardbits = static_cast<int>(table_cache_numshardbits);
 }
@@ -1160,7 +1156,7 @@ void Java_org_rocksdb_Options_setTableCacheNumshardbits(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_useFixedLengthPrefixExtractor(
-    JNIEnv*, jobject, jlong jhandle, jint jprefix_length) {
+    JNIEnv*, jclass, jlong jhandle, jint jprefix_length) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->prefix_extractor.reset(ROCKSDB_NAMESPACE::NewFixedPrefixTransform(
           static_cast<int>(jprefix_length)));
@@ -1170,7 +1166,7 @@ void Java_org_rocksdb_Options_useFixedLengthPrefixExtractor(
  * Method:    useCappedPrefixExtractor
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_useCappedPrefixExtractor(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_useCappedPrefixExtractor(JNIEnv*, jclass,
                                                        jlong jhandle,
                                                        jint jprefix_length) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
@@ -1183,7 +1179,7 @@ void Java_org_rocksdb_Options_useCappedPrefixExtractor(JNIEnv*, jobject,
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_walTtlSeconds(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_walTtlSeconds(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->WAL_ttl_seconds;
 }
@@ -1193,7 +1189,7 @@ jlong Java_org_rocksdb_Options_walTtlSeconds(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setWalTtlSeconds
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWalTtlSeconds(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setWalTtlSeconds(JNIEnv*, jclass, jlong jhandle,
                                                jlong WAL_ttl_seconds) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->WAL_ttl_seconds =
       static_cast<int64_t>(WAL_ttl_seconds);
@@ -1204,7 +1200,7 @@ void Java_org_rocksdb_Options_setWalTtlSeconds(JNIEnv*, jobject, jlong jhandle,
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_walSizeLimitMB(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_walSizeLimitMB(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->WAL_size_limit_MB;
 }
@@ -1214,7 +1210,7 @@ jlong Java_org_rocksdb_Options_walSizeLimitMB(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setWalSizeLimitMB
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWalSizeLimitMB(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setWalSizeLimitMB(JNIEnv*, jclass, jlong jhandle,
                                                 jlong WAL_size_limit_MB) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->WAL_size_limit_MB =
       static_cast<int64_t>(WAL_size_limit_MB);
@@ -1248,7 +1244,7 @@ jlong Java_org_rocksdb_Options_maxWriteBatchGroupSizeBytes(JNIEnv*, jclass,
  * Method:    manifestPreallocationSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_manifestPreallocationSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_manifestPreallocationSize(JNIEnv*, jclass,
                                                          jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->manifest_preallocation_size;
@@ -1260,7 +1256,7 @@ jlong Java_org_rocksdb_Options_manifestPreallocationSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setManifestPreallocationSize(
-    JNIEnv* env, jobject, jlong jhandle, jlong preallocation_size) {
+    JNIEnv* env, jclass, jlong jhandle, jlong preallocation_size) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       preallocation_size);
   if (s.ok()) {
@@ -1275,7 +1271,7 @@ void Java_org_rocksdb_Options_setManifestPreallocationSize(
  * Method:    setTableFactory
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setTableFactory(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setTableFactory(JNIEnv*, jclass, jlong jhandle,
                                               jlong jtable_factory_handle) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   auto* table_factory =
@@ -1287,7 +1283,7 @@ void Java_org_rocksdb_Options_setTableFactory(JNIEnv*, jobject, jlong jhandle,
  * Method:    setSstPartitionerFactory
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setSstPartitionerFactory(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setSstPartitionerFactory(JNIEnv*, jclass,
                                                        jlong jhandle,
                                                        jlong factory_handle) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
@@ -1316,7 +1312,7 @@ void Java_org_rocksdb_Options_setCompactionThreadLimiter(
  * Method:    allowMmapReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowMmapReads(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_allowMmapReads(JNIEnv*, jclass,
                                                  jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->allow_mmap_reads;
@@ -1327,7 +1323,7 @@ jboolean Java_org_rocksdb_Options_allowMmapReads(JNIEnv*, jobject,
  * Method:    setAllowMmapReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllowMmapReads(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setAllowMmapReads(JNIEnv*, jclass, jlong jhandle,
                                                 jboolean allow_mmap_reads) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->allow_mmap_reads =
       static_cast<bool>(allow_mmap_reads);
@@ -1338,7 +1334,7 @@ void Java_org_rocksdb_Options_setAllowMmapReads(JNIEnv*, jobject, jlong jhandle,
  * Method:    allowMmapWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowMmapWrites(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_allowMmapWrites(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->allow_mmap_writes;
@@ -1349,8 +1345,7 @@ jboolean Java_org_rocksdb_Options_allowMmapWrites(JNIEnv*, jobject,
  * Method:    setAllowMmapWrites
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllowMmapWrites(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setAllowMmapWrites(JNIEnv*, jclass, jlong jhandle,
                                                  jboolean allow_mmap_writes) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->allow_mmap_writes =
       static_cast<bool>(allow_mmap_writes);
@@ -1361,7 +1356,7 @@ void Java_org_rocksdb_Options_setAllowMmapWrites(JNIEnv*, jobject,
  * Method:    useDirectReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_useDirectReads(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_useDirectReads(JNIEnv*, jclass,
                                                  jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->use_direct_reads;
@@ -1372,7 +1367,7 @@ jboolean Java_org_rocksdb_Options_useDirectReads(JNIEnv*, jobject,
  * Method:    setUseDirectReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setUseDirectReads(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setUseDirectReads(JNIEnv*, jclass, jlong jhandle,
                                                 jboolean use_direct_reads) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->use_direct_reads =
       static_cast<bool>(use_direct_reads);
@@ -1384,7 +1379,7 @@ void Java_org_rocksdb_Options_setUseDirectReads(JNIEnv*, jobject, jlong jhandle,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Options_useDirectIoForFlushAndCompaction(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->use_direct_io_for_flush_and_compaction;
 }
@@ -1395,7 +1390,7 @@ jboolean Java_org_rocksdb_Options_useDirectIoForFlushAndCompaction(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setUseDirectIoForFlushAndCompaction(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jboolean use_direct_io_for_flush_and_compaction) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->use_direct_io_for_flush_and_compaction =
@@ -1407,7 +1402,7 @@ void Java_org_rocksdb_Options_setUseDirectIoForFlushAndCompaction(
  * Method:    setAllowFAllocate
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllowFAllocate(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setAllowFAllocate(JNIEnv*, jclass, jlong jhandle,
                                                 jboolean jallow_fallocate) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->allow_fallocate =
       static_cast<bool>(jallow_fallocate);
@@ -1418,7 +1413,7 @@ void Java_org_rocksdb_Options_setAllowFAllocate(JNIEnv*, jobject, jlong jhandle,
  * Method:    allowFAllocate
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowFAllocate(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_allowFAllocate(JNIEnv*, jclass,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->allow_fallocate);
@@ -1429,7 +1424,7 @@ jboolean Java_org_rocksdb_Options_allowFAllocate(JNIEnv*, jobject,
  * Method:    isFdCloseOnExec
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_isFdCloseOnExec(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_isFdCloseOnExec(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->is_fd_close_on_exec;
@@ -1440,8 +1435,7 @@ jboolean Java_org_rocksdb_Options_isFdCloseOnExec(JNIEnv*, jobject,
  * Method:    setIsFdCloseOnExec
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setIsFdCloseOnExec(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setIsFdCloseOnExec(JNIEnv*, jclass, jlong jhandle,
                                                  jboolean is_fd_close_on_exec) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->is_fd_close_on_exec =
       static_cast<bool>(is_fd_close_on_exec);
@@ -1452,7 +1446,7 @@ void Java_org_rocksdb_Options_setIsFdCloseOnExec(JNIEnv*, jobject,
  * Method:    statsDumpPeriodSec
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_statsDumpPeriodSec(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_statsDumpPeriodSec(JNIEnv*, jclass,
                                                  jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->stats_dump_period_sec;
@@ -1464,7 +1458,7 @@ jint Java_org_rocksdb_Options_statsDumpPeriodSec(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setStatsDumpPeriodSec(
-    JNIEnv*, jobject, jlong jhandle, jint jstats_dump_period_sec) {
+    JNIEnv*, jclass, jlong jhandle, jint jstats_dump_period_sec) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->stats_dump_period_sec =
       static_cast<unsigned int>(jstats_dump_period_sec);
@@ -1475,7 +1469,7 @@ void Java_org_rocksdb_Options_setStatsDumpPeriodSec(
  * Method:    statsPersistPeriodSec
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_statsPersistPeriodSec(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_statsPersistPeriodSec(JNIEnv*, jclass,
                                                     jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->stats_persist_period_sec;
@@ -1487,7 +1481,7 @@ jint Java_org_rocksdb_Options_statsPersistPeriodSec(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setStatsPersistPeriodSec(
-    JNIEnv*, jobject, jlong jhandle, jint jstats_persist_period_sec) {
+    JNIEnv*, jclass, jlong jhandle, jint jstats_persist_period_sec) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->stats_persist_period_sec =
       static_cast<unsigned int>(jstats_persist_period_sec);
@@ -1498,7 +1492,7 @@ void Java_org_rocksdb_Options_setStatsPersistPeriodSec(
  * Method:    statsHistoryBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_statsHistoryBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_statsHistoryBufferSize(JNIEnv*, jclass,
                                                       jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->stats_history_buffer_size;
@@ -1510,7 +1504,7 @@ jlong Java_org_rocksdb_Options_statsHistoryBufferSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setStatsHistoryBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jstats_history_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jstats_history_buffer_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->stats_history_buffer_size =
       static_cast<size_t>(jstats_history_buffer_size);
@@ -1521,7 +1515,7 @@ void Java_org_rocksdb_Options_setStatsHistoryBufferSize(
  * Method:    adviseRandomOnOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_adviseRandomOnOpen(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_adviseRandomOnOpen(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->advise_random_on_open;
@@ -1533,7 +1527,7 @@ jboolean Java_org_rocksdb_Options_adviseRandomOnOpen(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setAdviseRandomOnOpen(
-    JNIEnv*, jobject, jlong jhandle, jboolean advise_random_on_open) {
+    JNIEnv*, jclass, jlong jhandle, jboolean advise_random_on_open) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->advise_random_on_open = static_cast<bool>(advise_random_on_open);
 }
@@ -1544,7 +1538,7 @@ void Java_org_rocksdb_Options_setAdviseRandomOnOpen(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setDbWriteBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jdb_write_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jdb_write_buffer_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->db_write_buffer_size = static_cast<size_t>(jdb_write_buffer_size);
 }
@@ -1554,7 +1548,7 @@ void Java_org_rocksdb_Options_setDbWriteBufferSize(
  * Method:    dbWriteBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_dbWriteBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_dbWriteBufferSize(JNIEnv*, jclass,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->db_write_buffer_size);
@@ -1566,7 +1560,7 @@ jlong Java_org_rocksdb_Options_dbWriteBufferSize(JNIEnv*, jobject,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setAccessHintOnCompactionStart(
-    JNIEnv*, jobject, jlong jhandle, jbyte jaccess_hint_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jaccess_hint_value) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->access_hint_on_compaction_start =
       ROCKSDB_NAMESPACE::AccessHintJni::toCppAccessHint(jaccess_hint_value);
@@ -1577,7 +1571,7 @@ void Java_org_rocksdb_Options_setAccessHintOnCompactionStart(
  * Method:    accessHintOnCompactionStart
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_accessHintOnCompactionStart(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_Options_accessHintOnCompactionStart(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return ROCKSDB_NAMESPACE::AccessHintJni::toJavaAccessHint(
@@ -1590,7 +1584,7 @@ jbyte Java_org_rocksdb_Options_accessHintOnCompactionStart(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompactionReadaheadSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jcompaction_readahead_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jcompaction_readahead_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->compaction_readahead_size =
       static_cast<size_t>(jcompaction_readahead_size);
@@ -1601,7 +1595,7 @@ void Java_org_rocksdb_Options_setCompactionReadaheadSize(
  * Method:    compactionReadaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_compactionReadaheadSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_compactionReadaheadSize(JNIEnv*, jclass,
                                                        jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->compaction_readahead_size);
@@ -1613,7 +1607,7 @@ jlong Java_org_rocksdb_Options_compactionReadaheadSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setRandomAccessMaxBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jrandom_access_max_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jrandom_access_max_buffer_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->random_access_max_buffer_size =
       static_cast<size_t>(jrandom_access_max_buffer_size);
@@ -1624,7 +1618,7 @@ void Java_org_rocksdb_Options_setRandomAccessMaxBufferSize(
  * Method:    randomAccessMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_randomAccessMaxBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_randomAccessMaxBufferSize(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->random_access_max_buffer_size);
@@ -1636,7 +1630,7 @@ jlong Java_org_rocksdb_Options_randomAccessMaxBufferSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setWritableFileMaxBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jwritable_file_max_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jwritable_file_max_buffer_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->writable_file_max_buffer_size =
       static_cast<size_t>(jwritable_file_max_buffer_size);
@@ -1647,7 +1641,7 @@ void Java_org_rocksdb_Options_setWritableFileMaxBufferSize(
  * Method:    writableFileMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_writableFileMaxBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_writableFileMaxBufferSize(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->writable_file_max_buffer_size);
@@ -1658,7 +1652,7 @@ jlong Java_org_rocksdb_Options_writableFileMaxBufferSize(JNIEnv*, jobject,
  * Method:    useAdaptiveMutex
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_useAdaptiveMutex(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_useAdaptiveMutex(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->use_adaptive_mutex;
@@ -1669,7 +1663,7 @@ jboolean Java_org_rocksdb_Options_useAdaptiveMutex(JNIEnv*, jobject,
  * Method:    setUseAdaptiveMutex
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setUseAdaptiveMutex(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setUseAdaptiveMutex(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jboolean use_adaptive_mutex) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->use_adaptive_mutex =
@@ -1681,7 +1675,7 @@ void Java_org_rocksdb_Options_setUseAdaptiveMutex(JNIEnv*, jobject,
  * Method:    bytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_bytesPerSync(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_bytesPerSync(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->bytes_per_sync;
 }
 
@@ -1690,7 +1684,7 @@ jlong Java_org_rocksdb_Options_bytesPerSync(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setBytesPerSync(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setBytesPerSync(JNIEnv*, jclass, jlong jhandle,
                                               jlong bytes_per_sync) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->bytes_per_sync =
       static_cast<int64_t>(bytes_per_sync);
@@ -1701,8 +1695,7 @@ void Java_org_rocksdb_Options_setBytesPerSync(JNIEnv*, jobject, jlong jhandle,
  * Method:    setWalBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWalBytesPerSync(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setWalBytesPerSync(JNIEnv*, jclass, jlong jhandle,
                                                  jlong jwal_bytes_per_sync) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->wal_bytes_per_sync =
       static_cast<int64_t>(jwal_bytes_per_sync);
@@ -1713,8 +1706,7 @@ void Java_org_rocksdb_Options_setWalBytesPerSync(JNIEnv*, jobject,
  * Method:    walBytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_walBytesPerSync(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jlong Java_org_rocksdb_Options_walBytesPerSync(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->wal_bytes_per_sync);
 }
@@ -1725,7 +1717,7 @@ jlong Java_org_rocksdb_Options_walBytesPerSync(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setStrictBytesPerSync(
-    JNIEnv*, jobject, jlong jhandle, jboolean jstrict_bytes_per_sync) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jstrict_bytes_per_sync) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->strict_bytes_per_sync = jstrict_bytes_per_sync == JNI_TRUE;
 }
@@ -1735,7 +1727,7 @@ void Java_org_rocksdb_Options_setStrictBytesPerSync(
  * Method:    strictBytesPerSync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_strictBytesPerSync(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_strictBytesPerSync(JNIEnv*, jclass,
                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->strict_bytes_per_sync);
@@ -1817,7 +1809,7 @@ jobjectArray Java_org_rocksdb_Options_eventListeners(JNIEnv* env, jclass,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setEnableThreadTracking(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_thread_tracking) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_thread_tracking) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->enable_thread_tracking = static_cast<bool>(jenable_thread_tracking);
 }
@@ -1827,7 +1819,7 @@ void Java_org_rocksdb_Options_setEnableThreadTracking(
  * Method:    enableThreadTracking
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_enableThreadTracking(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_enableThreadTracking(JNIEnv*, jclass,
                                                        jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->enable_thread_tracking);
@@ -1838,7 +1830,7 @@ jboolean Java_org_rocksdb_Options_enableThreadTracking(JNIEnv*, jobject,
  * Method:    setDelayedWriteRate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setDelayedWriteRate(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setDelayedWriteRate(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jlong jdelayed_write_rate) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
@@ -1850,7 +1842,7 @@ void Java_org_rocksdb_Options_setDelayedWriteRate(JNIEnv*, jobject,
  * Method:    delayedWriteRate
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_delayedWriteRate(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_delayedWriteRate(JNIEnv*, jclass,
                                                 jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->delayed_write_rate);
@@ -1862,7 +1854,7 @@ jlong Java_org_rocksdb_Options_delayedWriteRate(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setEnablePipelinedWrite(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_pipelined_write) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_pipelined_write) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->enable_pipelined_write = jenable_pipelined_write == JNI_TRUE;
 }
@@ -1872,7 +1864,7 @@ void Java_org_rocksdb_Options_setEnablePipelinedWrite(
  * Method:    enablePipelinedWrite
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_enablePipelinedWrite(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_enablePipelinedWrite(JNIEnv*, jclass,
                                                        jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->enable_pipelined_write);
@@ -1883,7 +1875,7 @@ jboolean Java_org_rocksdb_Options_enablePipelinedWrite(JNIEnv*, jobject,
  * Method:    setUnorderedWrite
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setUnorderedWrite(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setUnorderedWrite(JNIEnv*, jclass, jlong jhandle,
                                                 jboolean unordered_write) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->unordered_write =
       static_cast<bool>(unordered_write);
@@ -1894,7 +1886,7 @@ void Java_org_rocksdb_Options_setUnorderedWrite(JNIEnv*, jobject, jlong jhandle,
  * Method:    unorderedWrite
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_unorderedWrite(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_unorderedWrite(JNIEnv*, jclass,
                                                  jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->unordered_write;
@@ -1905,7 +1897,7 @@ jboolean Java_org_rocksdb_Options_unorderedWrite(JNIEnv*, jobject,
  * Method:    setAllowConcurrentMemtableWrite
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllowConcurrentMemtableWrite(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setAllowConcurrentMemtableWrite(JNIEnv*, jclass,
                                                               jlong jhandle,
                                                               jboolean allow) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
@@ -1917,7 +1909,7 @@ void Java_org_rocksdb_Options_setAllowConcurrentMemtableWrite(JNIEnv*, jobject,
  * Method:    allowConcurrentMemtableWrite
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowConcurrentMemtableWrite(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_allowConcurrentMemtableWrite(JNIEnv*, jclass,
                                                                jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->allow_concurrent_memtable_write;
@@ -1929,7 +1921,7 @@ jboolean Java_org_rocksdb_Options_allowConcurrentMemtableWrite(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setEnableWriteThreadAdaptiveYield(
-    JNIEnv*, jobject, jlong jhandle, jboolean yield) {
+    JNIEnv*, jclass, jlong jhandle, jboolean yield) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->enable_write_thread_adaptive_yield = static_cast<bool>(yield);
 }
@@ -1940,7 +1932,7 @@ void Java_org_rocksdb_Options_setEnableWriteThreadAdaptiveYield(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Options_enableWriteThreadAdaptiveYield(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->enable_write_thread_adaptive_yield;
 }
@@ -1950,7 +1942,7 @@ jboolean Java_org_rocksdb_Options_enableWriteThreadAdaptiveYield(
  * Method:    setWriteThreadMaxYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWriteThreadMaxYieldUsec(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setWriteThreadMaxYieldUsec(JNIEnv*, jclass,
                                                          jlong jhandle,
                                                          jlong max) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
@@ -1962,7 +1954,7 @@ void Java_org_rocksdb_Options_setWriteThreadMaxYieldUsec(JNIEnv*, jobject,
  * Method:    writeThreadMaxYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_writeThreadMaxYieldUsec(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_writeThreadMaxYieldUsec(JNIEnv*, jclass,
                                                        jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->write_thread_max_yield_usec;
@@ -1973,7 +1965,7 @@ jlong Java_org_rocksdb_Options_writeThreadMaxYieldUsec(JNIEnv*, jobject,
  * Method:    setWriteThreadSlowYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWriteThreadSlowYieldUsec(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_setWriteThreadSlowYieldUsec(JNIEnv*, jclass,
                                                           jlong jhandle,
                                                           jlong slow) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
@@ -1985,7 +1977,7 @@ void Java_org_rocksdb_Options_setWriteThreadSlowYieldUsec(JNIEnv*, jobject,
  * Method:    writeThreadSlowYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_writeThreadSlowYieldUsec(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_writeThreadSlowYieldUsec(JNIEnv*, jclass,
                                                         jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->write_thread_slow_yield_usec;
@@ -1997,7 +1989,7 @@ jlong Java_org_rocksdb_Options_writeThreadSlowYieldUsec(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setSkipStatsUpdateOnDbOpen(
-    JNIEnv*, jobject, jlong jhandle, jboolean jskip_stats_update_on_db_open) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jskip_stats_update_on_db_open) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->skip_stats_update_on_db_open =
       static_cast<bool>(jskip_stats_update_on_db_open);
@@ -2008,7 +2000,7 @@ void Java_org_rocksdb_Options_setSkipStatsUpdateOnDbOpen(
  * Method:    skipStatsUpdateOnDbOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_skipStatsUpdateOnDbOpen(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_skipStatsUpdateOnDbOpen(JNIEnv*, jclass,
                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->skip_stats_update_on_db_open);
@@ -2044,7 +2036,7 @@ jboolean Java_org_rocksdb_Options_skipCheckingSstFileSizesOnDbOpen(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setWalRecoveryMode(
-    JNIEnv*, jobject, jlong jhandle, jbyte jwal_recovery_mode_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jwal_recovery_mode_value) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->wal_recovery_mode =
       ROCKSDB_NAMESPACE::WALRecoveryModeJni::toCppWALRecoveryMode(
@@ -2056,8 +2048,7 @@ void Java_org_rocksdb_Options_setWalRecoveryMode(
  * Method:    walRecoveryMode
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_walRecoveryMode(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jbyte Java_org_rocksdb_Options_walRecoveryMode(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return ROCKSDB_NAMESPACE::WALRecoveryModeJni::toJavaWALRecoveryMode(
       opt->wal_recovery_mode);
@@ -2068,7 +2059,7 @@ jbyte Java_org_rocksdb_Options_walRecoveryMode(JNIEnv*, jobject,
  * Method:    setAllow2pc
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllow2pc(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setAllow2pc(JNIEnv*, jclass, jlong jhandle,
                                           jboolean jallow_2pc) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->allow_2pc = static_cast<bool>(jallow_2pc);
@@ -2079,7 +2070,7 @@ void Java_org_rocksdb_Options_setAllow2pc(JNIEnv*, jobject, jlong jhandle,
  * Method:    allow2pc
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allow2pc(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_allow2pc(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->allow_2pc);
 }
@@ -2089,7 +2080,7 @@ jboolean Java_org_rocksdb_Options_allow2pc(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setRowCache
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setRowCache(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setRowCache(JNIEnv*, jclass, jlong jhandle,
                                           jlong jrow_cache_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   auto* row_cache =
@@ -2103,7 +2094,7 @@ void Java_org_rocksdb_Options_setRowCache(JNIEnv*, jobject, jlong jhandle,
  * Method:    setWalFilter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWalFilter(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setWalFilter(JNIEnv*, jclass, jlong jhandle,
                                            jlong jwal_filter_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   auto* wal_filter = reinterpret_cast<ROCKSDB_NAMESPACE::WalFilterJniCallback*>(
@@ -2117,7 +2108,7 @@ void Java_org_rocksdb_Options_setWalFilter(JNIEnv*, jobject, jlong jhandle,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setFailIfOptionsFileError(
-    JNIEnv*, jobject, jlong jhandle, jboolean jfail_if_options_file_error) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jfail_if_options_file_error) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->fail_if_options_file_error =
       static_cast<bool>(jfail_if_options_file_error);
@@ -2128,7 +2119,7 @@ void Java_org_rocksdb_Options_setFailIfOptionsFileError(
  * Method:    failIfOptionsFileError
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_failIfOptionsFileError(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_failIfOptionsFileError(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->fail_if_options_file_error);
@@ -2139,8 +2130,7 @@ jboolean Java_org_rocksdb_Options_failIfOptionsFileError(JNIEnv*, jobject,
  * Method:    setDumpMallocStats
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setDumpMallocStats(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setDumpMallocStats(JNIEnv*, jclass, jlong jhandle,
                                                  jboolean jdump_malloc_stats) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->dump_malloc_stats = static_cast<bool>(jdump_malloc_stats);
@@ -2151,7 +2141,7 @@ void Java_org_rocksdb_Options_setDumpMallocStats(JNIEnv*, jobject,
  * Method:    dumpMallocStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_dumpMallocStats(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_dumpMallocStats(JNIEnv*, jclass,
                                                   jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->dump_malloc_stats);
@@ -2163,7 +2153,7 @@ jboolean Java_org_rocksdb_Options_dumpMallocStats(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setAvoidFlushDuringRecovery(
-    JNIEnv*, jobject, jlong jhandle, jboolean javoid_flush_during_recovery) {
+    JNIEnv*, jclass, jlong jhandle, jboolean javoid_flush_during_recovery) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->avoid_flush_during_recovery =
       static_cast<bool>(javoid_flush_during_recovery);
@@ -2174,7 +2164,7 @@ void Java_org_rocksdb_Options_setAvoidFlushDuringRecovery(
  * Method:    avoidFlushDuringRecovery
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_avoidFlushDuringRecovery(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_avoidFlushDuringRecovery(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_recovery);
@@ -2342,7 +2332,7 @@ jlong Java_org_rocksdb_Options_bgerrorResumeRetryInterval(JNIEnv*, jclass,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setAvoidFlushDuringShutdown(
-    JNIEnv*, jobject, jlong jhandle, jboolean javoid_flush_during_shutdown) {
+    JNIEnv*, jclass, jlong jhandle, jboolean javoid_flush_during_shutdown) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->avoid_flush_during_shutdown =
       static_cast<bool>(javoid_flush_during_shutdown);
@@ -2353,7 +2343,7 @@ void Java_org_rocksdb_Options_setAvoidFlushDuringShutdown(
  * Method:    avoidFlushDuringShutdown
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_avoidFlushDuringShutdown(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_avoidFlushDuringShutdown(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_shutdown);
@@ -2365,7 +2355,7 @@ jboolean Java_org_rocksdb_Options_avoidFlushDuringShutdown(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setAllowIngestBehind(
-    JNIEnv*, jobject, jlong jhandle, jboolean jallow_ingest_behind) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jallow_ingest_behind) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->allow_ingest_behind = jallow_ingest_behind == JNI_TRUE;
 }
@@ -2375,7 +2365,7 @@ void Java_org_rocksdb_Options_setAllowIngestBehind(
  * Method:    allowIngestBehind
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowIngestBehind(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_allowIngestBehind(JNIEnv*, jclass,
                                                     jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->allow_ingest_behind);
@@ -2386,7 +2376,7 @@ jboolean Java_org_rocksdb_Options_allowIngestBehind(JNIEnv*, jobject,
  * Method:    setTwoWriteQueues
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setTwoWriteQueues(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setTwoWriteQueues(JNIEnv*, jclass, jlong jhandle,
                                                 jboolean jtwo_write_queues) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->two_write_queues = jtwo_write_queues == JNI_TRUE;
@@ -2397,7 +2387,7 @@ void Java_org_rocksdb_Options_setTwoWriteQueues(JNIEnv*, jobject, jlong jhandle,
  * Method:    twoWriteQueues
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_twoWriteQueues(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_twoWriteQueues(JNIEnv*, jclass,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->two_write_queues);
@@ -2408,7 +2398,7 @@ jboolean Java_org_rocksdb_Options_twoWriteQueues(JNIEnv*, jobject,
  * Method:    setManualWalFlush
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setManualWalFlush(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setManualWalFlush(JNIEnv*, jclass, jlong jhandle,
                                                 jboolean jmanual_wal_flush) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->manual_wal_flush = jmanual_wal_flush == JNI_TRUE;
@@ -2419,7 +2409,7 @@ void Java_org_rocksdb_Options_setManualWalFlush(JNIEnv*, jobject, jlong jhandle,
  * Method:    manualWalFlush
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_manualWalFlush(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_manualWalFlush(JNIEnv*, jclass,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->manual_wal_flush);
@@ -2430,7 +2420,7 @@ jboolean Java_org_rocksdb_Options_manualWalFlush(JNIEnv*, jobject,
  * Method:    setAtomicFlush
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAtomicFlush(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setAtomicFlush(JNIEnv*, jclass, jlong jhandle,
                                              jboolean jatomic_flush) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->atomic_flush = jatomic_flush == JNI_TRUE;
@@ -2441,7 +2431,7 @@ void Java_org_rocksdb_Options_setAtomicFlush(JNIEnv*, jobject, jlong jhandle,
  * Method:    atomicFlush
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_atomicFlush(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_atomicFlush(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->atomic_flush);
 }
@@ -2450,7 +2440,7 @@ jboolean Java_org_rocksdb_Options_atomicFlush(JNIEnv*, jobject, jlong jhandle) {
  * Method:    tableFactoryName
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_Options_tableFactoryName(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_Options_tableFactoryName(JNIEnv* env, jclass,
                                                   jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   ROCKSDB_NAMESPACE::TableFactory* tf = opt->table_factory.get();
@@ -2467,7 +2457,7 @@ jstring Java_org_rocksdb_Options_tableFactoryName(JNIEnv* env, jobject,
  * Method:    minWriteBufferNumberToMerge
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_minWriteBufferNumberToMerge(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_minWriteBufferNumberToMerge(JNIEnv*, jclass,
                                                           jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->min_write_buffer_number_to_merge;
@@ -2479,7 +2469,7 @@ jint Java_org_rocksdb_Options_minWriteBufferNumberToMerge(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMinWriteBufferNumberToMerge(
-    JNIEnv*, jobject, jlong jhandle, jint jmin_write_buffer_number_to_merge) {
+    JNIEnv*, jclass, jlong jhandle, jint jmin_write_buffer_number_to_merge) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->min_write_buffer_number_to_merge =
       static_cast<int>(jmin_write_buffer_number_to_merge);
@@ -2489,7 +2479,7 @@ void Java_org_rocksdb_Options_setMinWriteBufferNumberToMerge(
  * Method:    maxWriteBufferNumberToMaintain
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxWriteBufferNumberToMaintain(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_maxWriteBufferNumberToMaintain(JNIEnv*, jclass,
                                                              jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_write_buffer_number_to_maintain;
@@ -2501,8 +2491,7 @@ jint Java_org_rocksdb_Options_maxWriteBufferNumberToMaintain(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxWriteBufferNumberToMaintain(
-    JNIEnv*, jobject, jlong jhandle,
-    jint jmax_write_buffer_number_to_maintain) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_write_buffer_number_to_maintain) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_write_buffer_number_to_maintain =
       static_cast<int>(jmax_write_buffer_number_to_maintain);
@@ -2514,7 +2503,7 @@ void Java_org_rocksdb_Options_setMaxWriteBufferNumberToMaintain(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setCompressionType(
-    JNIEnv*, jobject, jlong jhandle, jbyte jcompression_type_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jcompression_type_value) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->compression =
       ROCKSDB_NAMESPACE::CompressionTypeJni::toCppCompressionType(
@@ -2526,8 +2515,7 @@ void Java_org_rocksdb_Options_setCompressionType(
  * Method:    compressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_compressionType(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jbyte Java_org_rocksdb_Options_compressionType(JNIEnv*, jclass, jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return ROCKSDB_NAMESPACE::CompressionTypeJni::toJavaCompressionType(
       opts->compression);
@@ -2618,7 +2606,7 @@ jbyteArray rocksdb_compression_list_helper(
  * Signature: (J[B)V
  */
 void Java_org_rocksdb_Options_setCompressionPerLevel(
-    JNIEnv* env, jobject, jlong jhandle, jbyteArray jcompressionLevels) {
+    JNIEnv* env, jclass, jlong jhandle, jbyteArray jcompressionLevels) {
   auto uptr_compression_levels =
       rocksdb_compression_vector_helper(env, jcompressionLevels);
   if (!uptr_compression_levels) {
@@ -2634,7 +2622,7 @@ void Java_org_rocksdb_Options_setCompressionPerLevel(
  * Method:    compressionPerLevel
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_Options_compressionPerLevel(JNIEnv* env, jobject,
+jbyteArray Java_org_rocksdb_Options_compressionPerLevel(JNIEnv* env, jclass,
                                                         jlong jhandle) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return rocksdb_compression_list_helper(env, options->compression_per_level);
@@ -2646,7 +2634,7 @@ jbyteArray Java_org_rocksdb_Options_compressionPerLevel(JNIEnv* env, jobject,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setBottommostCompressionType(
-    JNIEnv*, jobject, jlong jhandle, jbyte jcompression_type_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jcompression_type_value) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   options->bottommost_compression =
       ROCKSDB_NAMESPACE::CompressionTypeJni::toCppCompressionType(
@@ -2658,7 +2646,7 @@ void Java_org_rocksdb_Options_setBottommostCompressionType(
  * Method:    bottommostCompressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_bottommostCompressionType(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_Options_bottommostCompressionType(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return ROCKSDB_NAMESPACE::CompressionTypeJni::toJavaCompressionType(
@@ -2671,7 +2659,7 @@ jbyte Java_org_rocksdb_Options_bottommostCompressionType(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setBottommostCompressionOptions(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jlong jbottommost_compression_options_handle) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   auto* bottommost_compression_options =
@@ -2686,7 +2674,7 @@ void Java_org_rocksdb_Options_setBottommostCompressionOptions(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompressionOptions(
-    JNIEnv*, jobject, jlong jhandle, jlong jcompression_options_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jcompression_options_handle) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   auto* compression_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompressionOptions*>(
@@ -2699,8 +2687,7 @@ void Java_org_rocksdb_Options_setCompressionOptions(
  * Method:    setCompactionStyle
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Options_setCompactionStyle(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setCompactionStyle(JNIEnv*, jclass, jlong jhandle,
                                                  jbyte jcompaction_style) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   options->compaction_style =
@@ -2713,8 +2700,7 @@ void Java_org_rocksdb_Options_setCompactionStyle(JNIEnv*, jobject,
  * Method:    compactionStyle
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_compactionStyle(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jbyte Java_org_rocksdb_Options_compactionStyle(JNIEnv*, jclass, jlong jhandle) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return ROCKSDB_NAMESPACE::CompactionStyleJni::toJavaCompactionStyle(
       options->compaction_style);
@@ -2726,7 +2712,7 @@ jbyte Java_org_rocksdb_Options_compactionStyle(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxTableFilesSizeFIFO(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_table_files_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_table_files_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->compaction_options_fifo.max_table_files_size =
       static_cast<uint64_t>(jmax_table_files_size);
@@ -2737,7 +2723,7 @@ void Java_org_rocksdb_Options_setMaxTableFilesSizeFIFO(
  * Method:    maxTableFilesSizeFIFO
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->compaction_options_fifo.max_table_files_size;
@@ -2748,7 +2734,7 @@ jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(JNIEnv*, jobject,
  * Method:    numLevels
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_numLevels(JNIEnv*, jobject, jlong jhandle) {
+jint Java_org_rocksdb_Options_numLevels(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->num_levels;
 }
 
@@ -2757,7 +2743,7 @@ jint Java_org_rocksdb_Options_numLevels(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setNumLevels
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setNumLevels(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setNumLevels(JNIEnv*, jclass, jlong jhandle,
                                            jint jnum_levels) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->num_levels =
       static_cast<int>(jnum_levels);
@@ -2768,8 +2754,7 @@ void Java_org_rocksdb_Options_setNumLevels(JNIEnv*, jobject, jlong jhandle,
  * Method:    levelZeroFileNumCompactionTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(JNIEnv*,
-                                                                jobject,
+jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_file_num_compaction_trigger;
@@ -2781,7 +2766,7 @@ jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(JNIEnv*,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevelZeroFileNumCompactionTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_file_num_compaction_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_file_num_compaction_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_file_num_compaction_trigger =
       static_cast<int>(jlevel0_file_num_compaction_trigger);
@@ -2792,7 +2777,7 @@ void Java_org_rocksdb_Options_setLevelZeroFileNumCompactionTrigger(
  * Method:    levelZeroSlowdownWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(JNIEnv*, jclass,
                                                              jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_slowdown_writes_trigger;
@@ -2804,7 +2789,7 @@ jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevelZeroSlowdownWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_slowdown_writes_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_slowdown_writes_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_slowdown_writes_trigger =
       static_cast<int>(jlevel0_slowdown_writes_trigger);
@@ -2815,7 +2800,7 @@ void Java_org_rocksdb_Options_setLevelZeroSlowdownWritesTrigger(
  * Method:    levelZeroStopWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroStopWritesTrigger(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_levelZeroStopWritesTrigger(JNIEnv*, jclass,
                                                          jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_stop_writes_trigger;
@@ -2827,7 +2812,7 @@ jint Java_org_rocksdb_Options_levelZeroStopWritesTrigger(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevelZeroStopWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_stop_writes_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_stop_writes_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_stop_writes_trigger =
       static_cast<int>(jlevel0_stop_writes_trigger);
@@ -2838,7 +2823,7 @@ void Java_org_rocksdb_Options_setLevelZeroStopWritesTrigger(
  * Method:    targetFileSizeBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_targetFileSizeBase(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_targetFileSizeBase(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->target_file_size_base;
@@ -2850,7 +2835,7 @@ jlong Java_org_rocksdb_Options_targetFileSizeBase(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setTargetFileSizeBase(
-    JNIEnv*, jobject, jlong jhandle, jlong jtarget_file_size_base) {
+    JNIEnv*, jclass, jlong jhandle, jlong jtarget_file_size_base) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->target_file_size_base = static_cast<uint64_t>(jtarget_file_size_base);
 }
@@ -2860,7 +2845,7 @@ void Java_org_rocksdb_Options_setTargetFileSizeBase(
  * Method:    targetFileSizeMultiplier
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_targetFileSizeMultiplier(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_targetFileSizeMultiplier(JNIEnv*, jclass,
                                                        jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->target_file_size_multiplier;
@@ -2872,7 +2857,7 @@ jint Java_org_rocksdb_Options_targetFileSizeMultiplier(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setTargetFileSizeMultiplier(
-    JNIEnv*, jobject, jlong jhandle, jint jtarget_file_size_multiplier) {
+    JNIEnv*, jclass, jlong jhandle, jint jtarget_file_size_multiplier) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->target_file_size_multiplier =
       static_cast<int>(jtarget_file_size_multiplier);
@@ -2883,7 +2868,7 @@ void Java_org_rocksdb_Options_setTargetFileSizeMultiplier(
  * Method:    maxBytesForLevelBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxBytesForLevelBase(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_maxBytesForLevelBase(JNIEnv*, jclass,
                                                     jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_bytes_for_level_base;
@@ -2895,7 +2880,7 @@ jlong Java_org_rocksdb_Options_maxBytesForLevelBase(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxBytesForLevelBase(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_bytes_for_level_base) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_bytes_for_level_base) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_bytes_for_level_base =
       static_cast<int64_t>(jmax_bytes_for_level_base);
@@ -2907,7 +2892,7 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelBase(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Options_levelCompactionDynamicLevelBytes(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level_compaction_dynamic_level_bytes;
 }
@@ -2918,7 +2903,7 @@ jboolean Java_org_rocksdb_Options_levelCompactionDynamicLevelBytes(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setLevelCompactionDynamicLevelBytes(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_dynamic_level_bytes) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_dynamic_level_bytes) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level_compaction_dynamic_level_bytes = (jenable_dynamic_level_bytes);
 }
@@ -2928,7 +2913,7 @@ void Java_org_rocksdb_Options_setLevelCompactionDynamicLevelBytes(
  * Method:    maxBytesForLevelMultiplier
  * Signature: (J)D
  */
-jdouble Java_org_rocksdb_Options_maxBytesForLevelMultiplier(JNIEnv*, jobject,
+jdouble Java_org_rocksdb_Options_maxBytesForLevelMultiplier(JNIEnv*, jclass,
                                                             jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_bytes_for_level_multiplier;
@@ -2940,7 +2925,7 @@ jdouble Java_org_rocksdb_Options_maxBytesForLevelMultiplier(JNIEnv*, jobject,
  * Signature: (JD)V
  */
 void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplier(
-    JNIEnv*, jobject, jlong jhandle, jdouble jmax_bytes_for_level_multiplier) {
+    JNIEnv*, jclass, jlong jhandle, jdouble jmax_bytes_for_level_multiplier) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_bytes_for_level_multiplier =
       static_cast<double>(jmax_bytes_for_level_multiplier);
@@ -2951,7 +2936,7 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplier(
  * Method:    maxCompactionBytes
  * Signature: (J)I
  */
-jlong Java_org_rocksdb_Options_maxCompactionBytes(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_maxCompactionBytes(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return static_cast<jlong>(
       reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
@@ -2964,7 +2949,7 @@ jlong Java_org_rocksdb_Options_maxCompactionBytes(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxCompactionBytes(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_compaction_bytes) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_compaction_bytes) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->max_compaction_bytes =
       static_cast<uint64_t>(jmax_compaction_bytes);
 }
@@ -2974,7 +2959,7 @@ void Java_org_rocksdb_Options_setMaxCompactionBytes(
  * Method:    arenaBlockSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_arenaBlockSize(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_arenaBlockSize(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->arena_block_size;
 }
@@ -2984,7 +2969,7 @@ jlong Java_org_rocksdb_Options_arenaBlockSize(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setArenaBlockSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* env, jobject,
+void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* env, jclass,
                                                 jlong jhandle,
                                                 jlong jarena_block_size) {
   auto s =
@@ -3002,7 +2987,7 @@ void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* env, jobject,
  * Method:    disableAutoCompactions
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_disableAutoCompactions(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_disableAutoCompactions(JNIEnv*, jclass,
                                                          jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->disable_auto_compactions;
@@ -3014,7 +2999,7 @@ jboolean Java_org_rocksdb_Options_disableAutoCompactions(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setDisableAutoCompactions(
-    JNIEnv*, jobject, jlong jhandle, jboolean jdisable_auto_compactions) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jdisable_auto_compactions) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->disable_auto_compactions = static_cast<bool>(jdisable_auto_compactions);
 }
@@ -3024,7 +3009,7 @@ void Java_org_rocksdb_Options_setDisableAutoCompactions(
  * Method:    maxSequentialSkipInIterations
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(JNIEnv*, jclass,
                                                              jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_sequential_skip_in_iterations;
@@ -3036,7 +3021,7 @@ jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxSequentialSkipInIterations(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_sequential_skip_in_iterations) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_sequential_skip_in_iterations) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_sequential_skip_in_iterations =
       static_cast<int64_t>(jmax_sequential_skip_in_iterations);
@@ -3047,7 +3032,7 @@ void Java_org_rocksdb_Options_setMaxSequentialSkipInIterations(
  * Method:    inplaceUpdateSupport
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(JNIEnv*, jclass,
                                                        jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->inplace_update_support;
@@ -3059,7 +3044,7 @@ jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setInplaceUpdateSupport(
-    JNIEnv*, jobject, jlong jhandle, jboolean jinplace_update_support) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jinplace_update_support) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->inplace_update_support = static_cast<bool>(jinplace_update_support);
 }
@@ -3069,7 +3054,7 @@ void Java_org_rocksdb_Options_setInplaceUpdateSupport(
  * Method:    inplaceUpdateNumLocks
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->inplace_update_num_locks;
@@ -3081,7 +3066,7 @@ jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setInplaceUpdateNumLocks(
-    JNIEnv* env, jobject, jlong jhandle, jlong jinplace_update_num_locks) {
+    JNIEnv* env, jclass, jlong jhandle, jlong jinplace_update_num_locks) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       jinplace_update_num_locks);
   if (s.ok()) {
@@ -3097,7 +3082,7 @@ void Java_org_rocksdb_Options_setInplaceUpdateNumLocks(
  * Method:    memtablePrefixBloomSizeRatio
  * Signature: (J)I
  */
-jdouble Java_org_rocksdb_Options_memtablePrefixBloomSizeRatio(JNIEnv*, jobject,
+jdouble Java_org_rocksdb_Options_memtablePrefixBloomSizeRatio(JNIEnv*, jclass,
                                                               jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->memtable_prefix_bloom_size_ratio;
@@ -3109,8 +3094,7 @@ jdouble Java_org_rocksdb_Options_memtablePrefixBloomSizeRatio(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMemtablePrefixBloomSizeRatio(
-    JNIEnv*, jobject, jlong jhandle,
-    jdouble jmemtable_prefix_bloom_size_ratio) {
+    JNIEnv*, jclass, jlong jhandle, jdouble jmemtable_prefix_bloom_size_ratio) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->memtable_prefix_bloom_size_ratio =
       static_cast<double>(jmemtable_prefix_bloom_size_ratio);
@@ -3121,7 +3105,7 @@ void Java_org_rocksdb_Options_setMemtablePrefixBloomSizeRatio(
  * Method:    experimentalMempurgeThreshold
  * Signature: (J)I
  */
-jdouble Java_org_rocksdb_Options_experimentalMempurgeThreshold(JNIEnv*, jobject,
+jdouble Java_org_rocksdb_Options_experimentalMempurgeThreshold(JNIEnv*, jclass,
                                                                jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->experimental_mempurge_threshold;
@@ -3133,7 +3117,7 @@ jdouble Java_org_rocksdb_Options_experimentalMempurgeThreshold(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setExperimentalMempurgeThreshold(
-    JNIEnv*, jobject, jlong jhandle, jdouble jexperimental_mempurge_threshold) {
+    JNIEnv*, jclass, jlong jhandle, jdouble jexperimental_mempurge_threshold) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->experimental_mempurge_threshold =
       static_cast<double>(jexperimental_mempurge_threshold);
@@ -3144,7 +3128,7 @@ void Java_org_rocksdb_Options_setExperimentalMempurgeThreshold(
  * Method:    memtableWholeKeyFiltering
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_memtableWholeKeyFiltering(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_memtableWholeKeyFiltering(JNIEnv*, jclass,
                                                             jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->memtable_whole_key_filtering;
@@ -3156,7 +3140,7 @@ jboolean Java_org_rocksdb_Options_memtableWholeKeyFiltering(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setMemtableWholeKeyFiltering(
-    JNIEnv*, jobject, jlong jhandle, jboolean jmemtable_whole_key_filtering) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jmemtable_whole_key_filtering) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->memtable_whole_key_filtering =
       static_cast<bool>(jmemtable_whole_key_filtering);
@@ -3167,7 +3151,7 @@ void Java_org_rocksdb_Options_setMemtableWholeKeyFiltering(
  * Method:    bloomLocality
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_bloomLocality(JNIEnv*, jobject, jlong jhandle) {
+jint Java_org_rocksdb_Options_bloomLocality(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->bloom_locality;
 }
 
@@ -3176,7 +3160,7 @@ jint Java_org_rocksdb_Options_bloomLocality(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setBloomLocality
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setBloomLocality(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setBloomLocality(JNIEnv*, jclass, jlong jhandle,
                                                jint jbloom_locality) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->bloom_locality =
       static_cast<int32_t>(jbloom_locality);
@@ -3187,7 +3171,7 @@ void Java_org_rocksdb_Options_setBloomLocality(JNIEnv*, jobject, jlong jhandle,
  * Method:    maxSuccessiveMerges
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxSuccessiveMerges(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_maxSuccessiveMerges(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->max_successive_merges;
@@ -3199,7 +3183,7 @@ jlong Java_org_rocksdb_Options_maxSuccessiveMerges(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxSuccessiveMerges(
-    JNIEnv* env, jobject, jlong jhandle, jlong jmax_successive_merges) {
+    JNIEnv* env, jclass, jlong jhandle, jlong jmax_successive_merges) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       jmax_successive_merges);
   if (s.ok()) {
@@ -3215,7 +3199,7 @@ void Java_org_rocksdb_Options_setMaxSuccessiveMerges(
  * Method:    optimizeFiltersForHits
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(JNIEnv*, jclass,
                                                          jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->optimize_filters_for_hits;
@@ -3227,7 +3211,7 @@ jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setOptimizeFiltersForHits(
-    JNIEnv*, jobject, jlong jhandle, jboolean joptimize_filters_for_hits) {
+    JNIEnv*, jclass, jlong jhandle, jboolean joptimize_filters_for_hits) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->optimize_filters_for_hits =
       static_cast<bool>(joptimize_filters_for_hits);
@@ -3250,7 +3234,7 @@ void Java_org_rocksdb_Options_oldDefaults(JNIEnv*, jclass, jlong jhandle,
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_Options_optimizeForSmallDb__J(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_optimizeForSmallDb__J(JNIEnv*, jclass,
                                                     jlong jhandle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->OptimizeForSmallDb();
 }
@@ -3278,7 +3262,7 @@ void Java_org_rocksdb_Options_optimizeForSmallDb__JJ(JNIEnv*, jclass,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeForPointLookup(
-    JNIEnv*, jobject, jlong jhandle, jlong block_cache_size_mb) {
+    JNIEnv*, jclass, jlong jhandle, jlong block_cache_size_mb) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->OptimizeForPointLookup(block_cache_size_mb);
 }
@@ -3289,7 +3273,7 @@ void Java_org_rocksdb_Options_optimizeForPointLookup(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeLevelStyleCompaction(
-    JNIEnv*, jobject, jlong jhandle, jlong memtable_memory_budget) {
+    JNIEnv*, jclass, jlong jhandle, jlong memtable_memory_budget) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->OptimizeLevelStyleCompaction(memtable_memory_budget);
 }
@@ -3300,7 +3284,7 @@ void Java_org_rocksdb_Options_optimizeLevelStyleCompaction(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeUniversalStyleCompaction(
-    JNIEnv*, jobject, jlong jhandle, jlong memtable_memory_budget) {
+    JNIEnv*, jclass, jlong jhandle, jlong memtable_memory_budget) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->OptimizeUniversalStyleCompaction(memtable_memory_budget);
 }
@@ -3310,7 +3294,7 @@ void Java_org_rocksdb_Options_optimizeUniversalStyleCompaction(
  * Method:    prepareForBulkLoad
  * Signature: (J)V
  */
-void Java_org_rocksdb_Options_prepareForBulkLoad(JNIEnv*, jobject,
+void Java_org_rocksdb_Options_prepareForBulkLoad(JNIEnv*, jclass,
                                                  jlong jhandle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->PrepareForBulkLoad();
 }
@@ -3320,7 +3304,7 @@ void Java_org_rocksdb_Options_prepareForBulkLoad(JNIEnv*, jobject,
  * Method:    memtableHugePageSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_memtableHugePageSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_memtableHugePageSize(JNIEnv*, jclass,
                                                     jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->memtable_huge_page_size;
@@ -3332,7 +3316,7 @@ jlong Java_org_rocksdb_Options_memtableHugePageSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMemtableHugePageSize(
-    JNIEnv* env, jobject, jlong jhandle, jlong jmemtable_huge_page_size) {
+    JNIEnv* env, jclass, jlong jhandle, jlong jmemtable_huge_page_size) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       jmemtable_huge_page_size);
   if (s.ok()) {
@@ -3348,7 +3332,7 @@ void Java_org_rocksdb_Options_setMemtableHugePageSize(
  * Method:    softPendingCompactionBytesLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(JNIEnv*, jclass,
                                                                jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->soft_pending_compaction_bytes_limit;
@@ -3360,7 +3344,7 @@ jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setSoftPendingCompactionBytesLimit(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jlong jsoft_pending_compaction_bytes_limit) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->soft_pending_compaction_bytes_limit =
@@ -3372,7 +3356,7 @@ void Java_org_rocksdb_Options_setSoftPendingCompactionBytesLimit(
  * Method:    softHardCompactionBytesLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(JNIEnv*, jclass,
                                                                jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->hard_pending_compaction_bytes_limit;
@@ -3384,7 +3368,7 @@ jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setHardPendingCompactionBytesLimit(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jlong jhard_pending_compaction_bytes_limit) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->hard_pending_compaction_bytes_limit =
@@ -3396,7 +3380,7 @@ void Java_org_rocksdb_Options_setHardPendingCompactionBytesLimit(
  * Method:    level0FileNumCompactionTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(JNIEnv*, jclass,
                                                              jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_file_num_compaction_trigger;
@@ -3408,7 +3392,7 @@ jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevel0FileNumCompactionTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_file_num_compaction_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_file_num_compaction_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_file_num_compaction_trigger =
       static_cast<int32_t>(jlevel0_file_num_compaction_trigger);
@@ -3419,7 +3403,7 @@ void Java_org_rocksdb_Options_setLevel0FileNumCompactionTrigger(
  * Method:    level0SlowdownWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(JNIEnv*, jclass,
                                                           jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_slowdown_writes_trigger;
@@ -3431,7 +3415,7 @@ jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevel0SlowdownWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_slowdown_writes_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_slowdown_writes_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_slowdown_writes_trigger =
       static_cast<int32_t>(jlevel0_slowdown_writes_trigger);
@@ -3442,7 +3426,7 @@ void Java_org_rocksdb_Options_setLevel0SlowdownWritesTrigger(
  * Method:    level0StopWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0StopWritesTrigger(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_level0StopWritesTrigger(JNIEnv*, jclass,
                                                       jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_stop_writes_trigger;
@@ -3454,7 +3438,7 @@ jint Java_org_rocksdb_Options_level0StopWritesTrigger(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevel0StopWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_stop_writes_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_stop_writes_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->level0_stop_writes_trigger =
       static_cast<int32_t>(jlevel0_stop_writes_trigger);
@@ -3466,7 +3450,7 @@ void Java_org_rocksdb_Options_setLevel0StopWritesTrigger(
  * Signature: (J)[I
  */
 jintArray Java_org_rocksdb_Options_maxBytesForLevelMultiplierAdditional(
-    JNIEnv* env, jobject, jlong jhandle) {
+    JNIEnv* env, jclass, jlong jhandle) {
   auto mbflma = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
                     ->max_bytes_for_level_multiplier_additional;
 
@@ -3504,7 +3488,7 @@ jintArray Java_org_rocksdb_Options_maxBytesForLevelMultiplierAdditional(
  * Signature: (J[I)V
  */
 void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplierAdditional(
-    JNIEnv* env, jobject, jlong jhandle,
+    JNIEnv* env, jclass, jlong jhandle,
     jintArray jmax_bytes_for_level_multiplier_additional) {
   jsize len = env->GetArrayLength(jmax_bytes_for_level_multiplier_additional);
   jint* additionals = env->GetIntArrayElements(
@@ -3530,7 +3514,7 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplierAdditional(
  * Method:    paranoidFileChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_paranoidFileChecks(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_paranoidFileChecks(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)
       ->paranoid_file_checks;
@@ -3542,7 +3526,7 @@ jboolean Java_org_rocksdb_Options_paranoidFileChecks(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setParanoidFileChecks(
-    JNIEnv*, jobject, jlong jhandle, jboolean jparanoid_file_checks) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jparanoid_file_checks) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle)->paranoid_file_checks =
       static_cast<bool>(jparanoid_file_checks);
 }
@@ -3553,7 +3537,7 @@ void Java_org_rocksdb_Options_setParanoidFileChecks(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setCompactionPriority(
-    JNIEnv*, jobject, jlong jhandle, jbyte jcompaction_priority_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jcompaction_priority_value) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->compaction_pri =
       ROCKSDB_NAMESPACE::CompactionPriorityJni::toCppCompactionPriority(
@@ -3565,7 +3549,7 @@ void Java_org_rocksdb_Options_setCompactionPriority(
  * Method:    compactionPriority
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_compactionPriority(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_Options_compactionPriority(JNIEnv*, jclass,
                                                   jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return ROCKSDB_NAMESPACE::CompactionPriorityJni::toJavaCompactionPriority(
@@ -3577,8 +3561,7 @@ jbyte Java_org_rocksdb_Options_compactionPriority(JNIEnv*, jobject,
  * Method:    setReportBgIoStats
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setReportBgIoStats(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setReportBgIoStats(JNIEnv*, jclass, jlong jhandle,
                                                  jboolean jreport_bg_io_stats) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->report_bg_io_stats = static_cast<bool>(jreport_bg_io_stats);
@@ -3589,7 +3572,7 @@ void Java_org_rocksdb_Options_setReportBgIoStats(JNIEnv*, jobject,
  * Method:    reportBgIoStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_reportBgIoStats(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_reportBgIoStats(JNIEnv*, jclass,
                                                   jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<bool>(opts->report_bg_io_stats);
@@ -3600,7 +3583,7 @@ jboolean Java_org_rocksdb_Options_reportBgIoStats(JNIEnv*, jobject,
  * Method:    setTtl
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setTtl(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setTtl(JNIEnv*, jclass, jlong jhandle,
                                      jlong jttl) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->ttl = static_cast<uint64_t>(jttl);
@@ -3611,7 +3594,7 @@ void Java_org_rocksdb_Options_setTtl(JNIEnv*, jobject, jlong jhandle,
  * Method:    ttl
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_ttl(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_ttl(JNIEnv*, jclass, jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opts->ttl);
 }
@@ -3622,7 +3605,7 @@ jlong Java_org_rocksdb_Options_ttl(JNIEnv*, jobject, jlong jhandle) {
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setPeriodicCompactionSeconds(
-    JNIEnv*, jobject, jlong jhandle, jlong jperiodicCompactionSeconds) {
+    JNIEnv*, jclass, jlong jhandle, jlong jperiodicCompactionSeconds) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->periodic_compaction_seconds =
       static_cast<uint64_t>(jperiodicCompactionSeconds);
@@ -3633,7 +3616,7 @@ void Java_org_rocksdb_Options_setPeriodicCompactionSeconds(
  * Method:    periodicCompactionSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_periodicCompactionSeconds(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_periodicCompactionSeconds(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opts->periodic_compaction_seconds);
@@ -3645,7 +3628,7 @@ jlong Java_org_rocksdb_Options_periodicCompactionSeconds(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompactionOptionsUniversal(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jlong jcompaction_options_universal_handle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   auto* opts_uni =
@@ -3660,7 +3643,7 @@ void Java_org_rocksdb_Options_setCompactionOptionsUniversal(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompactionOptionsFIFO(
-    JNIEnv*, jobject, jlong jhandle, jlong jcompaction_options_fifo_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jcompaction_options_fifo_handle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   auto* opts_fifo = reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsFIFO*>(
       jcompaction_options_fifo_handle);
@@ -3673,7 +3656,7 @@ void Java_org_rocksdb_Options_setCompactionOptionsFIFO(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setForceConsistencyChecks(
-    JNIEnv*, jobject, jlong jhandle, jboolean jforce_consistency_checks) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jforce_consistency_checks) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->force_consistency_checks = static_cast<bool>(jforce_consistency_checks);
 }
@@ -3683,7 +3666,7 @@ void Java_org_rocksdb_Options_setForceConsistencyChecks(
  * Method:    forceConsistencyChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_forceConsistencyChecks(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_forceConsistencyChecks(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<bool>(opts->force_consistency_checks);
@@ -3696,8 +3679,7 @@ jboolean Java_org_rocksdb_Options_forceConsistencyChecks(JNIEnv*, jobject,
  * Method:    setEnableBlobFiles
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setEnableBlobFiles(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_Options_setEnableBlobFiles(JNIEnv*, jclass, jlong jhandle,
                                                  jboolean jenable_blob_files) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->enable_blob_files = static_cast<bool>(jenable_blob_files);
@@ -3708,7 +3690,7 @@ void Java_org_rocksdb_Options_setEnableBlobFiles(JNIEnv*, jobject,
  * Method:    enableBlobFiles
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_enableBlobFiles(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_enableBlobFiles(JNIEnv*, jclass,
                                                   jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opts->enable_blob_files);
@@ -3719,7 +3701,7 @@ jboolean Java_org_rocksdb_Options_enableBlobFiles(JNIEnv*, jobject,
  * Method:    setMinBlobSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setMinBlobSize(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setMinBlobSize(JNIEnv*, jclass, jlong jhandle,
                                              jlong jmin_blob_size) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->min_blob_size = static_cast<uint64_t>(jmin_blob_size);
@@ -3730,7 +3712,7 @@ void Java_org_rocksdb_Options_setMinBlobSize(JNIEnv*, jobject, jlong jhandle,
  * Method:    minBlobSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_minBlobSize(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_minBlobSize(JNIEnv*, jclass, jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opts->min_blob_size);
 }
@@ -3740,7 +3722,7 @@ jlong Java_org_rocksdb_Options_minBlobSize(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setBlobFileSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setBlobFileSize(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Options_setBlobFileSize(JNIEnv*, jclass, jlong jhandle,
                                               jlong jblob_file_size) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->blob_file_size = static_cast<uint64_t>(jblob_file_size);
@@ -3751,7 +3733,7 @@ void Java_org_rocksdb_Options_setBlobFileSize(JNIEnv*, jobject, jlong jhandle,
  * Method:    blobFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_blobFileSize(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_Options_blobFileSize(JNIEnv*, jclass, jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opts->blob_file_size);
 }
@@ -3762,7 +3744,7 @@ jlong Java_org_rocksdb_Options_blobFileSize(JNIEnv*, jobject, jlong jhandle) {
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setBlobCompressionType(
-    JNIEnv*, jobject, jlong jhandle, jbyte jblob_compression_type_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jblob_compression_type_value) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->blob_compression_type =
       ROCKSDB_NAMESPACE::CompressionTypeJni::toCppCompressionType(
@@ -3774,7 +3756,7 @@ void Java_org_rocksdb_Options_setBlobCompressionType(
  * Method:    blobCompressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_blobCompressionType(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_Options_blobCompressionType(JNIEnv*, jclass,
                                                    jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return ROCKSDB_NAMESPACE::CompressionTypeJni::toJavaCompressionType(
@@ -3787,7 +3769,7 @@ jbyte Java_org_rocksdb_Options_blobCompressionType(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setEnableBlobGarbageCollection(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_blob_garbage_collection) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_blob_garbage_collection) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->enable_blob_garbage_collection =
       static_cast<bool>(jenable_blob_garbage_collection);
@@ -3798,7 +3780,7 @@ void Java_org_rocksdb_Options_setEnableBlobGarbageCollection(
  * Method:    enableBlobGarbageCollection
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_enableBlobGarbageCollection(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_Options_enableBlobGarbageCollection(JNIEnv*, jclass,
                                                               jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opts->enable_blob_garbage_collection);
@@ -3810,7 +3792,7 @@ jboolean Java_org_rocksdb_Options_enableBlobGarbageCollection(JNIEnv*, jobject,
  * Signature: (JD)V
  */
 void Java_org_rocksdb_Options_setBlobGarbageCollectionAgeCutoff(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jdouble jblob_garbage_collection_age_cutoff) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->blob_garbage_collection_age_cutoff =
@@ -3822,8 +3804,7 @@ void Java_org_rocksdb_Options_setBlobGarbageCollectionAgeCutoff(
  * Method:    blobGarbageCollectionAgeCutoff
  * Signature: (J)D
  */
-jdouble Java_org_rocksdb_Options_blobGarbageCollectionAgeCutoff(JNIEnv*,
-                                                                jobject,
+jdouble Java_org_rocksdb_Options_blobGarbageCollectionAgeCutoff(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jdouble>(opts->blob_garbage_collection_age_cutoff);
@@ -3835,7 +3816,7 @@ jdouble Java_org_rocksdb_Options_blobGarbageCollectionAgeCutoff(JNIEnv*,
  * Signature: (JD)V
  */
 void Java_org_rocksdb_Options_setBlobGarbageCollectionForceThreshold(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jdouble jblob_garbage_collection_force_threshold) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->blob_garbage_collection_force_threshold =
@@ -3848,7 +3829,7 @@ void Java_org_rocksdb_Options_setBlobGarbageCollectionForceThreshold(
  * Signature: (J)D
  */
 jdouble Java_org_rocksdb_Options_blobGarbageCollectionForceThreshold(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jdouble>(opts->blob_garbage_collection_force_threshold);
 }
@@ -3859,7 +3840,7 @@ jdouble Java_org_rocksdb_Options_blobGarbageCollectionForceThreshold(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setBlobCompactionReadaheadSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jblob_compaction_readahead_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jblob_compaction_readahead_size) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->blob_compaction_readahead_size =
       static_cast<uint64_t>(jblob_compaction_readahead_size);
@@ -3870,7 +3851,7 @@ void Java_org_rocksdb_Options_setBlobCompactionReadaheadSize(
  * Method:    blobCompactionReadaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_blobCompactionReadaheadSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Options_blobCompactionReadaheadSize(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opts->blob_compaction_readahead_size);
@@ -3882,7 +3863,7 @@ jlong Java_org_rocksdb_Options_blobCompactionReadaheadSize(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setBlobFileStartingLevel(
-    JNIEnv*, jobject, jlong jhandle, jint jblob_file_starting_level) {
+    JNIEnv*, jclass, jlong jhandle, jint jblob_file_starting_level) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->blob_file_starting_level = jblob_file_starting_level;
 }
@@ -3892,7 +3873,7 @@ void Java_org_rocksdb_Options_setBlobFileStartingLevel(
  * Method:    blobFileStartingLevel
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_blobFileStartingLevel(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_blobFileStartingLevel(JNIEnv*, jclass,
                                                     jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jint>(opts->blob_file_starting_level);
@@ -3904,7 +3885,7 @@ jint Java_org_rocksdb_Options_blobFileStartingLevel(JNIEnv*, jobject,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setPrepopulateBlobCache(
-    JNIEnv*, jobject, jlong jhandle, jbyte jprepopulate_blob_cache_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jprepopulate_blob_cache_value) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->prepopulate_blob_cache =
       ROCKSDB_NAMESPACE::PrepopulateBlobCacheJni::toCppPrepopulateBlobCache(
@@ -3916,7 +3897,7 @@ void Java_org_rocksdb_Options_setPrepopulateBlobCache(
  * Method:    prepopulateBlobCache
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_prepopulateBlobCache(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_Options_prepopulateBlobCache(JNIEnv*, jclass,
                                                     jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return ROCKSDB_NAMESPACE::PrepopulateBlobCacheJni::toJavaPrepopulateBlobCache(
@@ -3929,7 +3910,7 @@ jbyte Java_org_rocksdb_Options_prepopulateBlobCache(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMemtableMaxRangeDeletions(
-    JNIEnv*, jobject, jlong jhandle, jint jmemtable_max_range_deletions) {
+    JNIEnv*, jclass, jlong jhandle, jint jmemtable_max_range_deletions) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opts->memtable_max_range_deletions =
       static_cast<int32_t>(jmemtable_max_range_deletions);
@@ -3940,7 +3921,7 @@ void Java_org_rocksdb_Options_setMemtableMaxRangeDeletions(
  * Method:    memtableMaxRangeDeletions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_memtableMaxRangeDeletions(JNIEnv*, jobject,
+jint Java_org_rocksdb_Options_memtableMaxRangeDeletions(JNIEnv*, jclass,
                                                         jlong jhandle) {
   auto* opts = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jint>(opts->memtable_max_range_deletions);
@@ -4115,8 +4096,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_getColumnFamilyOptionsFromProps__Ljav
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_disposeInternal(JNIEnv*, jobject,
-                                                          jlong handle) {
+void Java_org_rocksdb_ColumnFamilyOptions_disposeInternalJni(JNIEnv*, jclass,
+                                                             jlong handle) {
   auto* cfo = reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(handle);
   assert(cfo != nullptr);
   delete cfo;
@@ -4140,8 +4121,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_oldDefaults(JNIEnv*, jclass,
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb__J(JNIEnv*,
-                                                                jobject,
+void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb__J(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->OptimizeForSmallDb();
@@ -4167,7 +4147,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb__JJ(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeForPointLookup(
-    JNIEnv*, jobject, jlong jhandle, jlong block_cache_size_mb) {
+    JNIEnv*, jclass, jlong jhandle, jlong block_cache_size_mb) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->OptimizeForPointLookup(block_cache_size_mb);
 }
@@ -4178,7 +4158,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeForPointLookup(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeLevelStyleCompaction(
-    JNIEnv*, jobject, jlong jhandle, jlong memtable_memory_budget) {
+    JNIEnv*, jclass, jlong jhandle, jlong memtable_memory_budget) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->OptimizeLevelStyleCompaction(memtable_memory_budget);
 }
@@ -4189,7 +4169,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeLevelStyleCompaction(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeUniversalStyleCompaction(
-    JNIEnv*, jobject, jlong jhandle, jlong memtable_memory_budget) {
+    JNIEnv*, jclass, jlong jhandle, jlong memtable_memory_budget) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->OptimizeUniversalStyleCompaction(memtable_memory_budget);
 }
@@ -4200,7 +4180,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeUniversalStyleCompaction(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JI(
-    JNIEnv*, jobject, jlong jhandle, jint builtinComparator) {
+    JNIEnv*, jclass, jlong jhandle, jint builtinComparator) {
   switch (builtinComparator) {
     case 1:
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
@@ -4219,7 +4199,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JI(
  * Signature: (JJB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JJB(
-    JNIEnv*, jobject, jlong jopt_handle, jlong jcomparator_handle,
+    JNIEnv*, jclass, jlong jopt_handle, jlong jcomparator_handle,
     jbyte jcomparator_type) {
   ROCKSDB_NAMESPACE::Comparator* comparator = nullptr;
   switch (jcomparator_type) {
@@ -4246,7 +4226,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JJB(
  * Signature: (JJjava/lang/String)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperatorName(
-    JNIEnv* env, jobject, jlong jhandle, jstring jop_name) {
+    JNIEnv* env, jclass, jlong jhandle, jstring jop_name) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   const char* op_name = env->GetStringUTFChars(jop_name, nullptr);
@@ -4266,7 +4246,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperatorName(
  * Signature: (JJjava/lang/String)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperator(
-    JNIEnv*, jobject, jlong jhandle, jlong mergeOperatorHandle) {
+    JNIEnv*, jclass, jlong jhandle, jlong mergeOperatorHandle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->merge_operator =
       *(reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::MergeOperator>*>(
@@ -4279,7 +4259,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperator(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterHandle(
-    JNIEnv*, jobject, jlong jopt_handle, jlong jcompactionfilter_handle) {
+    JNIEnv*, jclass, jlong jopt_handle, jlong jcompactionfilter_handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jopt_handle)
       ->compaction_filter =
       reinterpret_cast<ROCKSDB_NAMESPACE::CompactionFilter*>(
@@ -4292,8 +4272,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterHandle(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterFactoryHandle(
-    JNIEnv*, jobject, jlong jopt_handle,
-    jlong jcompactionfilterfactory_handle) {
+    JNIEnv*, jclass, jlong jopt_handle, jlong jcompactionfilterfactory_handle) {
   auto* cff_factory = reinterpret_cast<
       std::shared_ptr<ROCKSDB_NAMESPACE::CompactionFilterFactoryJniCallback>*>(
       jcompactionfilterfactory_handle);
@@ -4307,7 +4286,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterFactoryHandle(
  * Signature: (JJ)I
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setWriteBufferSize(
-    JNIEnv* env, jobject, jlong jhandle, jlong jwrite_buffer_size) {
+    JNIEnv* env, jclass, jlong jhandle, jlong jwrite_buffer_size) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       jwrite_buffer_size);
   if (s.ok()) {
@@ -4323,7 +4302,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setWriteBufferSize(
  * Method:    writeBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(JNIEnv*, jclass,
                                                            jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->write_buffer_size;
@@ -4335,7 +4314,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumber(
-    JNIEnv*, jobject, jlong jhandle, jint jmax_write_buffer_number) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_write_buffer_number) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_write_buffer_number = jmax_write_buffer_number;
 }
@@ -4345,7 +4324,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumber(
  * Method:    maxWriteBufferNumber
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(JNIEnv*, jobject,
+jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(JNIEnv*, jclass,
                                                                jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_write_buffer_number;
@@ -4356,7 +4335,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemTableFactory(
-    JNIEnv*, jobject, jlong jhandle, jlong jfactory_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jfactory_handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->memtable_factory.reset(
           reinterpret_cast<ROCKSDB_NAMESPACE::MemTableRepFactory*>(
@@ -4369,7 +4348,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemTableFactory(
  * Signature: (J)Ljava/lang/String
  */
 jstring Java_org_rocksdb_ColumnFamilyOptions_memTableFactoryName(
-    JNIEnv* env, jobject, jlong jhandle) {
+    JNIEnv* env, jclass, jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   ROCKSDB_NAMESPACE::MemTableRepFactory* tf = opt->memtable_factory.get();
@@ -4391,7 +4370,7 @@ jstring Java_org_rocksdb_ColumnFamilyOptions_memTableFactoryName(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_useFixedLengthPrefixExtractor(
-    JNIEnv*, jobject, jlong jhandle, jint jprefix_length) {
+    JNIEnv*, jclass, jlong jhandle, jint jprefix_length) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->prefix_extractor.reset(ROCKSDB_NAMESPACE::NewFixedPrefixTransform(
           static_cast<int>(jprefix_length)));
@@ -4402,7 +4381,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_useFixedLengthPrefixExtractor(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_useCappedPrefixExtractor(
-    JNIEnv*, jobject, jlong jhandle, jint jprefix_length) {
+    JNIEnv*, jclass, jlong jhandle, jint jprefix_length) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->prefix_extractor.reset(ROCKSDB_NAMESPACE::NewCappedPrefixTransform(
           static_cast<int>(jprefix_length)));
@@ -4413,7 +4392,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_useCappedPrefixExtractor(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setTableFactory(
-    JNIEnv*, jobject, jlong jhandle, jlong jfactory_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jfactory_handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->table_factory.reset(
           reinterpret_cast<ROCKSDB_NAMESPACE::TableFactory*>(jfactory_handle));
@@ -4424,7 +4403,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTableFactory(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setSstPartitionerFactory(
-    JNIEnv*, jobject, jlong jhandle, jlong factory_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong factory_handle) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   auto factory = reinterpret_cast<
@@ -4453,7 +4432,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionThreadLimiter(
  * Signature: (J)Ljava/lang/String
  */
 jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(JNIEnv* env,
-                                                              jobject,
+                                                              jclass,
                                                               jlong jhandle) {
   auto* opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -4518,7 +4497,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_cfPaths(JNIEnv* env, jclass,
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_minWriteBufferNumberToMerge(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->min_write_buffer_number_to_merge;
 }
@@ -4529,7 +4508,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_minWriteBufferNumberToMerge(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMinWriteBufferNumberToMerge(
-    JNIEnv*, jobject, jlong jhandle, jint jmin_write_buffer_number_to_merge) {
+    JNIEnv*, jclass, jlong jhandle, jint jmin_write_buffer_number_to_merge) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->min_write_buffer_number_to_merge =
       static_cast<int>(jmin_write_buffer_number_to_merge);
@@ -4541,7 +4520,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMinWriteBufferNumberToMerge(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumberToMaintain(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_write_buffer_number_to_maintain;
 }
@@ -4552,8 +4531,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumberToMaintain(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumberToMaintain(
-    JNIEnv*, jobject, jlong jhandle,
-    jint jmax_write_buffer_number_to_maintain) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_write_buffer_number_to_maintain) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_write_buffer_number_to_maintain =
       static_cast<int>(jmax_write_buffer_number_to_maintain);
@@ -4565,7 +4543,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumberToMaintain(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompressionType(
-    JNIEnv*, jobject, jlong jhandle, jbyte jcompression_type_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jcompression_type_value) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   cf_opts->compression =
@@ -4578,7 +4556,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionType(
  * Method:    compressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -4592,7 +4570,7 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(JNIEnv*, jobject,
  * Signature: (J[B)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompressionPerLevel(
-    JNIEnv* env, jobject, jlong jhandle, jbyteArray jcompressionLevels) {
+    JNIEnv* env, jclass, jlong jhandle, jbyteArray jcompressionLevels) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   auto uptr_compression_levels =
@@ -4610,7 +4588,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionPerLevel(
  * Signature: (J)[B
  */
 jbyteArray Java_org_rocksdb_ColumnFamilyOptions_compressionPerLevel(
-    JNIEnv* env, jobject, jlong jhandle) {
+    JNIEnv* env, jclass, jlong jhandle) {
   auto* cf_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return rocksdb_compression_list_helper(env,
@@ -4623,7 +4601,7 @@ jbyteArray Java_org_rocksdb_ColumnFamilyOptions_compressionPerLevel(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBottommostCompressionType(
-    JNIEnv*, jobject, jlong jhandle, jbyte jcompression_type_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jcompression_type_value) {
   auto* cf_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   cf_options->bottommost_compression =
@@ -4637,7 +4615,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBottommostCompressionType(
  * Signature: (J)B
  */
 jbyte Java_org_rocksdb_ColumnFamilyOptions_bottommostCompressionType(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* cf_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return ROCKSDB_NAMESPACE::CompressionTypeJni::toJavaCompressionType(
@@ -4649,7 +4627,7 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_bottommostCompressionType(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBottommostCompressionOptions(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jlong jbottommost_compression_options_handle) {
   auto* cf_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -4665,7 +4643,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBottommostCompressionOptions(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompressionOptions(
-    JNIEnv*, jobject, jlong jhandle, jlong jcompression_options_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jcompression_options_handle) {
   auto* cf_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   auto* compression_options =
@@ -4680,7 +4658,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionOptions(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionStyle(
-    JNIEnv*, jobject, jlong jhandle, jbyte jcompaction_style) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jcompaction_style) {
   auto* cf_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   cf_options->compaction_style =
@@ -4693,7 +4671,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionStyle(
  * Method:    compactionStyle
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* cf_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -4707,7 +4685,7 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxTableFilesSizeFIFO(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_table_files_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_table_files_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->compaction_options_fifo.max_table_files_size =
       static_cast<uint64_t>(jmax_table_files_size);
@@ -4719,7 +4697,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxTableFilesSizeFIFO(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_maxTableFilesSizeFIFO(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->compaction_options_fifo.max_table_files_size;
 }
@@ -4729,7 +4707,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxTableFilesSizeFIFO(
  * Method:    numLevels
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(JNIEnv*, jobject,
+jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(JNIEnv*, jclass,
                                                     jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->num_levels;
@@ -4740,7 +4718,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(JNIEnv*, jobject,
  * Method:    setNumLevels
  * Signature: (JI)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(JNIEnv*, jobject,
+void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(JNIEnv*, jclass,
                                                        jlong jhandle,
                                                        jint jnum_levels) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
@@ -4753,7 +4731,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(JNIEnv*, jobject,
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroFileNumCompactionTrigger(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_file_num_compaction_trigger;
 }
@@ -4764,7 +4742,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroFileNumCompactionTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroFileNumCompactionTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_file_num_compaction_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_file_num_compaction_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_file_num_compaction_trigger =
       static_cast<int>(jlevel0_file_num_compaction_trigger);
@@ -4776,7 +4754,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroFileNumCompactionTrigger(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroSlowdownWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_slowdown_writes_trigger;
 }
@@ -4787,7 +4765,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroSlowdownWritesTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroSlowdownWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_slowdown_writes_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_slowdown_writes_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_slowdown_writes_trigger =
       static_cast<int>(jlevel0_slowdown_writes_trigger);
@@ -4799,7 +4777,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroSlowdownWritesTrigger(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroStopWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_stop_writes_trigger;
 }
@@ -4810,7 +4788,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroStopWritesTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroStopWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_stop_writes_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_stop_writes_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_stop_writes_trigger =
       static_cast<int>(jlevel0_stop_writes_trigger);
@@ -4821,7 +4799,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroStopWritesTrigger(
  * Method:    targetFileSizeBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(JNIEnv*, jclass,
                                                               jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->target_file_size_base;
@@ -4833,7 +4811,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeBase(
-    JNIEnv*, jobject, jlong jhandle, jlong jtarget_file_size_base) {
+    JNIEnv*, jclass, jlong jhandle, jlong jtarget_file_size_base) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->target_file_size_base = static_cast<uint64_t>(jtarget_file_size_base);
 }
@@ -4844,7 +4822,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeBase(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeMultiplier(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->target_file_size_multiplier;
 }
@@ -4855,7 +4833,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeMultiplier(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeMultiplier(
-    JNIEnv*, jobject, jlong jhandle, jint jtarget_file_size_multiplier) {
+    JNIEnv*, jclass, jlong jhandle, jint jtarget_file_size_multiplier) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->target_file_size_multiplier =
       static_cast<int>(jtarget_file_size_multiplier);
@@ -4866,8 +4844,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeMultiplier(
  * Method:    maxBytesForLevelBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(JNIEnv*,
-                                                                jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_bytes_for_level_base;
@@ -4879,7 +4856,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(JNIEnv*,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelBase(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_bytes_for_level_base) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_bytes_for_level_base) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_bytes_for_level_base =
       static_cast<int64_t>(jmax_bytes_for_level_base);
@@ -4891,7 +4868,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelBase(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_levelCompactionDynamicLevelBytes(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level_compaction_dynamic_level_bytes;
 }
@@ -4902,7 +4879,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_levelCompactionDynamicLevelBytes(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelCompactionDynamicLevelBytes(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_dynamic_level_bytes) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_dynamic_level_bytes) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level_compaction_dynamic_level_bytes = (jenable_dynamic_level_bytes);
 }
@@ -4913,7 +4890,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelCompactionDynamicLevelBytes(
  * Signature: (J)D
  */
 jdouble Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplier(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_bytes_for_level_multiplier;
 }
@@ -4924,7 +4901,7 @@ jdouble Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplier(
  * Signature: (JD)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplier(
-    JNIEnv*, jobject, jlong jhandle, jdouble jmax_bytes_for_level_multiplier) {
+    JNIEnv*, jclass, jlong jhandle, jdouble jmax_bytes_for_level_multiplier) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_bytes_for_level_multiplier =
       static_cast<double>(jmax_bytes_for_level_multiplier);
@@ -4935,7 +4912,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplier(
  * Method:    maxCompactionBytes
  * Signature: (J)I
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_maxCompactionBytes(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxCompactionBytes(JNIEnv*, jclass,
                                                               jlong jhandle) {
   return static_cast<jlong>(
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
@@ -4948,7 +4925,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxCompactionBytes(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxCompactionBytes(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_compaction_bytes) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_compaction_bytes) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_compaction_bytes = static_cast<uint64_t>(jmax_compaction_bytes);
 }
@@ -4958,7 +4935,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxCompactionBytes(
  * Method:    arenaBlockSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(JNIEnv*, jclass,
                                                           jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->arena_block_size;
@@ -4970,7 +4947,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setArenaBlockSize(
-    JNIEnv* env, jobject, jlong jhandle, jlong jarena_block_size) {
+    JNIEnv* env, jclass, jlong jhandle, jlong jarena_block_size) {
   auto s =
       ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(jarena_block_size);
   if (s.ok()) {
@@ -4987,7 +4964,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setArenaBlockSize(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_disableAutoCompactions(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->disable_auto_compactions;
 }
@@ -4998,7 +4975,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_disableAutoCompactions(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setDisableAutoCompactions(
-    JNIEnv*, jobject, jlong jhandle, jboolean jdisable_auto_compactions) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jdisable_auto_compactions) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->disable_auto_compactions = static_cast<bool>(jdisable_auto_compactions);
 }
@@ -5009,7 +4986,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setDisableAutoCompactions(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_maxSequentialSkipInIterations(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_sequential_skip_in_iterations;
 }
@@ -5020,7 +4997,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxSequentialSkipInIterations(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxSequentialSkipInIterations(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_sequential_skip_in_iterations) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_sequential_skip_in_iterations) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_sequential_skip_in_iterations =
       static_cast<int64_t>(jmax_sequential_skip_in_iterations);
@@ -5032,7 +5009,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxSequentialSkipInIterations(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateSupport(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->inplace_update_support;
 }
@@ -5043,7 +5020,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateSupport(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateSupport(
-    JNIEnv*, jobject, jlong jhandle, jboolean jinplace_update_support) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jinplace_update_support) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->inplace_update_support = static_cast<bool>(jinplace_update_support);
 }
@@ -5054,7 +5031,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateSupport(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateNumLocks(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->inplace_update_num_locks;
 }
@@ -5065,7 +5042,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateNumLocks(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateNumLocks(
-    JNIEnv* env, jobject, jlong jhandle, jlong jinplace_update_num_locks) {
+    JNIEnv* env, jclass, jlong jhandle, jlong jinplace_update_num_locks) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       jinplace_update_num_locks);
   if (s.ok()) {
@@ -5082,7 +5059,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateNumLocks(
  * Signature: (J)I
  */
 jdouble Java_org_rocksdb_ColumnFamilyOptions_memtablePrefixBloomSizeRatio(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->memtable_prefix_bloom_size_ratio;
 }
@@ -5093,8 +5070,7 @@ jdouble Java_org_rocksdb_ColumnFamilyOptions_memtablePrefixBloomSizeRatio(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemtablePrefixBloomSizeRatio(
-    JNIEnv*, jobject, jlong jhandle,
-    jdouble jmemtable_prefix_bloom_size_ratio) {
+    JNIEnv*, jclass, jlong jhandle, jdouble jmemtable_prefix_bloom_size_ratio) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->memtable_prefix_bloom_size_ratio =
       static_cast<double>(jmemtable_prefix_bloom_size_ratio);
@@ -5106,7 +5082,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemtablePrefixBloomSizeRatio(
  * Signature: (J)I
  */
 jdouble Java_org_rocksdb_ColumnFamilyOptions_experimentalMempurgeThreshold(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->experimental_mempurge_threshold;
 }
@@ -5117,7 +5093,7 @@ jdouble Java_org_rocksdb_ColumnFamilyOptions_experimentalMempurgeThreshold(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setExperimentalMempurgeThreshold(
-    JNIEnv*, jobject, jlong jhandle, jdouble jexperimental_mempurge_threshold) {
+    JNIEnv*, jclass, jlong jhandle, jdouble jexperimental_mempurge_threshold) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->experimental_mempurge_threshold =
       static_cast<double>(jexperimental_mempurge_threshold);
@@ -5129,7 +5105,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setExperimentalMempurgeThreshold(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_memtableWholeKeyFiltering(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->memtable_whole_key_filtering;
 }
@@ -5140,7 +5116,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_memtableWholeKeyFiltering(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemtableWholeKeyFiltering(
-    JNIEnv*, jobject, jlong jhandle, jboolean jmemtable_whole_key_filtering) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jmemtable_whole_key_filtering) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->memtable_whole_key_filtering =
       static_cast<bool>(jmemtable_whole_key_filtering);
@@ -5151,7 +5127,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemtableWholeKeyFiltering(
  * Method:    bloomLocality
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_bloomLocality(JNIEnv*, jobject,
+jint Java_org_rocksdb_ColumnFamilyOptions_bloomLocality(JNIEnv*, jclass,
                                                         jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->bloom_locality;
@@ -5163,7 +5139,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_bloomLocality(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBloomLocality(
-    JNIEnv*, jobject, jlong jhandle, jint jbloom_locality) {
+    JNIEnv*, jclass, jlong jhandle, jint jbloom_locality) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->bloom_locality = static_cast<int32_t>(jbloom_locality);
 }
@@ -5173,7 +5149,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBloomLocality(
  * Method:    maxSuccessiveMerges
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(JNIEnv*, jclass,
                                                                jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->max_successive_merges;
@@ -5185,7 +5161,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxSuccessiveMerges(
-    JNIEnv* env, jobject, jlong jhandle, jlong jmax_successive_merges) {
+    JNIEnv* env, jclass, jlong jhandle, jlong jmax_successive_merges) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       jmax_successive_merges);
   if (s.ok()) {
@@ -5202,7 +5178,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxSuccessiveMerges(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_optimizeFiltersForHits(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->optimize_filters_for_hits;
 }
@@ -5213,7 +5189,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_optimizeFiltersForHits(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setOptimizeFiltersForHits(
-    JNIEnv*, jobject, jlong jhandle, jboolean joptimize_filters_for_hits) {
+    JNIEnv*, jclass, jlong jhandle, jboolean joptimize_filters_for_hits) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->optimize_filters_for_hits =
       static_cast<bool>(joptimize_filters_for_hits);
@@ -5224,8 +5200,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setOptimizeFiltersForHits(
  * Method:    memtableHugePageSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(JNIEnv*,
-                                                                jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->memtable_huge_page_size;
@@ -5237,7 +5212,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(JNIEnv*,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemtableHugePageSize(
-    JNIEnv* env, jobject, jlong jhandle, jlong jmemtable_huge_page_size) {
+    JNIEnv* env, jclass, jlong jhandle, jlong jmemtable_huge_page_size) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       jmemtable_huge_page_size);
   if (s.ok()) {
@@ -5254,7 +5229,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemtableHugePageSize(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_softPendingCompactionBytesLimit(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->soft_pending_compaction_bytes_limit;
 }
@@ -5265,7 +5240,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_softPendingCompactionBytesLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setSoftPendingCompactionBytesLimit(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jlong jsoft_pending_compaction_bytes_limit) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->soft_pending_compaction_bytes_limit =
@@ -5278,7 +5253,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setSoftPendingCompactionBytesLimit(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_hardPendingCompactionBytesLimit(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->hard_pending_compaction_bytes_limit;
 }
@@ -5289,7 +5264,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_hardPendingCompactionBytesLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setHardPendingCompactionBytesLimit(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jlong jhard_pending_compaction_bytes_limit) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->hard_pending_compaction_bytes_limit =
@@ -5302,7 +5277,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setHardPendingCompactionBytesLimit(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0FileNumCompactionTrigger(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_file_num_compaction_trigger;
 }
@@ -5313,7 +5288,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0FileNumCompactionTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0FileNumCompactionTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_file_num_compaction_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_file_num_compaction_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_file_num_compaction_trigger =
       static_cast<int32_t>(jlevel0_file_num_compaction_trigger);
@@ -5325,7 +5300,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0FileNumCompactionTrigger(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0SlowdownWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_slowdown_writes_trigger;
 }
@@ -5336,7 +5311,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0SlowdownWritesTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0SlowdownWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_slowdown_writes_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_slowdown_writes_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_slowdown_writes_trigger =
       static_cast<int32_t>(jlevel0_slowdown_writes_trigger);
@@ -5348,7 +5323,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0SlowdownWritesTrigger(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0StopWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_stop_writes_trigger;
 }
@@ -5359,7 +5334,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0StopWritesTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0StopWritesTrigger(
-    JNIEnv*, jobject, jlong jhandle, jint jlevel0_stop_writes_trigger) {
+    JNIEnv*, jclass, jlong jhandle, jint jlevel0_stop_writes_trigger) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->level0_stop_writes_trigger =
       static_cast<int32_t>(jlevel0_stop_writes_trigger);
@@ -5372,7 +5347,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0StopWritesTrigger(
  */
 jintArray
 Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditional(
-    JNIEnv* env, jobject, jlong jhandle) {
+    JNIEnv* env, jclass, jlong jhandle) {
   auto mbflma =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
           ->max_bytes_for_level_multiplier_additional;
@@ -5410,7 +5385,7 @@ Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditional(
  * Signature: (J[I)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplierAdditional(
-    JNIEnv* env, jobject, jlong jhandle,
+    JNIEnv* env, jclass, jlong jhandle,
     jintArray jmax_bytes_for_level_multiplier_additional) {
   jsize len = env->GetArrayLength(jmax_bytes_for_level_multiplier_additional);
   jint* additionals = env->GetIntArrayElements(
@@ -5438,7 +5413,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplierAdditiona
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_paranoidFileChecks(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->paranoid_file_checks;
 }
@@ -5449,7 +5424,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_paranoidFileChecks(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setParanoidFileChecks(
-    JNIEnv*, jobject, jlong jhandle, jboolean jparanoid_file_checks) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jparanoid_file_checks) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle)
       ->paranoid_file_checks = static_cast<bool>(jparanoid_file_checks);
 }
@@ -5460,7 +5435,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setParanoidFileChecks(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionPriority(
-    JNIEnv*, jobject, jlong jhandle, jbyte jcompaction_priority_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jcompaction_priority_value) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   cf_opts->compaction_pri =
@@ -5473,7 +5448,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionPriority(
  * Method:    compactionPriority
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionPriority(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionPriority(JNIEnv*, jclass,
                                                               jlong jhandle) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5487,7 +5462,7 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionPriority(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setReportBgIoStats(
-    JNIEnv*, jobject, jlong jhandle, jboolean jreport_bg_io_stats) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jreport_bg_io_stats) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   cf_opts->report_bg_io_stats = static_cast<bool>(jreport_bg_io_stats);
@@ -5498,7 +5473,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setReportBgIoStats(
  * Method:    reportBgIoStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ColumnFamilyOptions_reportBgIoStats(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ColumnFamilyOptions_reportBgIoStats(JNIEnv*, jclass,
                                                               jlong jhandle) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5510,8 +5485,8 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_reportBgIoStats(JNIEnv*, jobject,
  * Method:    setTtl
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_setTtl(JNIEnv*, jobject,
-                                                 jlong jhandle, jlong jttl) {
+void Java_org_rocksdb_ColumnFamilyOptions_setTtl(JNIEnv*, jclass, jlong jhandle,
+                                                 jlong jttl) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   cf_opts->ttl = static_cast<uint64_t>(jttl);
@@ -5523,7 +5498,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTtl(JNIEnv*, jobject,
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_org_rocksdb_ColumnFamilyOptions_ttl(JNIEnv*, jobject, jlong jhandle) {
+Java_org_rocksdb_ColumnFamilyOptions_ttl(JNIEnv*, jclass, jlong jhandle) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return static_cast<jlong>(cf_opts->ttl);
@@ -5535,7 +5510,7 @@ Java_org_rocksdb_ColumnFamilyOptions_ttl(JNIEnv*, jobject, jlong jhandle) {
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setPeriodicCompactionSeconds(
-    JNIEnv*, jobject, jlong jhandle, jlong jperiodicCompactionSeconds) {
+    JNIEnv*, jclass, jlong jhandle, jlong jperiodicCompactionSeconds) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   cf_opts->periodic_compaction_seconds =
@@ -5548,7 +5523,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setPeriodicCompactionSeconds(
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_org_rocksdb_ColumnFamilyOptions_periodicCompactionSeconds(JNIEnv*, jobject,
+Java_org_rocksdb_ColumnFamilyOptions_periodicCompactionSeconds(JNIEnv*, jclass,
                                                                jlong jhandle) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5561,7 +5536,7 @@ Java_org_rocksdb_ColumnFamilyOptions_periodicCompactionSeconds(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsUniversal(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jlong jcompaction_options_universal_handle) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5577,7 +5552,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsUniversal(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsFIFO(
-    JNIEnv*, jobject, jlong jhandle, jlong jcompaction_options_fifo_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jcompaction_options_fifo_handle) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   auto* opts_fifo = reinterpret_cast<ROCKSDB_NAMESPACE::CompactionOptionsFIFO*>(
@@ -5591,7 +5566,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsFIFO(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setForceConsistencyChecks(
-    JNIEnv*, jobject, jlong jhandle, jboolean jforce_consistency_checks) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jforce_consistency_checks) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   cf_opts->force_consistency_checks =
@@ -5604,7 +5579,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setForceConsistencyChecks(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_forceConsistencyChecks(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* cf_opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return static_cast<jboolean>(cf_opts->force_consistency_checks);
@@ -5618,7 +5593,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_forceConsistencyChecks(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setEnableBlobFiles(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_blob_files) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_blob_files) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   opts->enable_blob_files = static_cast<bool>(jenable_blob_files);
@@ -5629,7 +5604,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setEnableBlobFiles(
  * Method:    enableBlobFiles
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ColumnFamilyOptions_enableBlobFiles(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ColumnFamilyOptions_enableBlobFiles(JNIEnv*, jclass,
                                                               jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5641,7 +5616,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_enableBlobFiles(JNIEnv*, jobject,
  * Method:    setMinBlobSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_setMinBlobSize(JNIEnv*, jobject,
+void Java_org_rocksdb_ColumnFamilyOptions_setMinBlobSize(JNIEnv*, jclass,
                                                          jlong jhandle,
                                                          jlong jmin_blob_size) {
   auto* opts =
@@ -5654,7 +5629,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMinBlobSize(JNIEnv*, jobject,
  * Method:    minBlobSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_minBlobSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_minBlobSize(JNIEnv*, jclass,
                                                        jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5667,7 +5642,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_minBlobSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBlobFileSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jblob_file_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jblob_file_size) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   opts->blob_file_size = static_cast<uint64_t>(jblob_file_size);
@@ -5678,7 +5653,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBlobFileSize(
  * Method:    blobFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_blobFileSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ColumnFamilyOptions_blobFileSize(JNIEnv*, jclass,
                                                         jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5691,7 +5666,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_blobFileSize(JNIEnv*, jobject,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBlobCompressionType(
-    JNIEnv*, jobject, jlong jhandle, jbyte jblob_compression_type_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jblob_compression_type_value) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   opts->blob_compression_type =
@@ -5704,7 +5679,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBlobCompressionType(
  * Method:    blobCompressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_blobCompressionType(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_ColumnFamilyOptions_blobCompressionType(JNIEnv*, jclass,
                                                                jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5718,7 +5693,7 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_blobCompressionType(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setEnableBlobGarbageCollection(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_blob_garbage_collection) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_blob_garbage_collection) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   opts->enable_blob_garbage_collection =
@@ -5731,7 +5706,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setEnableBlobGarbageCollection(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_enableBlobGarbageCollection(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return static_cast<jboolean>(opts->enable_blob_garbage_collection);
@@ -5743,7 +5718,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_enableBlobGarbageCollection(
  * Signature: (JD)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBlobGarbageCollectionAgeCutoff(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jdouble jblob_garbage_collection_age_cutoff) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5757,7 +5732,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBlobGarbageCollectionAgeCutoff(
  * Signature: (J)D
  */
 jdouble Java_org_rocksdb_ColumnFamilyOptions_blobGarbageCollectionAgeCutoff(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return static_cast<jdouble>(opts->blob_garbage_collection_age_cutoff);
@@ -5769,7 +5744,7 @@ jdouble Java_org_rocksdb_ColumnFamilyOptions_blobGarbageCollectionAgeCutoff(
  * Signature: (JD)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBlobGarbageCollectionForceThreshold(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jdouble jblob_garbage_collection_force_threshold) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5784,7 +5759,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBlobGarbageCollectionForceThreshold
  */
 jdouble
 Java_org_rocksdb_ColumnFamilyOptions_blobGarbageCollectionForceThreshold(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return static_cast<jdouble>(opts->blob_garbage_collection_force_threshold);
@@ -5796,7 +5771,7 @@ Java_org_rocksdb_ColumnFamilyOptions_blobGarbageCollectionForceThreshold(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBlobCompactionReadaheadSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jblob_compaction_readahead_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jblob_compaction_readahead_size) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   opts->blob_compaction_readahead_size =
@@ -5809,7 +5784,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBlobCompactionReadaheadSize(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_blobCompactionReadaheadSize(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return static_cast<jlong>(opts->blob_compaction_readahead_size);
@@ -5821,7 +5796,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_blobCompactionReadaheadSize(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBlobFileStartingLevel(
-    JNIEnv*, jobject, jlong jhandle, jint jblob_file_starting_level) {
+    JNIEnv*, jclass, jlong jhandle, jint jblob_file_starting_level) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   opts->blob_file_starting_level = jblob_file_starting_level;
@@ -5832,8 +5807,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBlobFileStartingLevel(
  * Method:    blobFileStartingLevel
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_blobFileStartingLevel(JNIEnv*,
-                                                                jobject,
+jint Java_org_rocksdb_ColumnFamilyOptions_blobFileStartingLevel(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5846,7 +5820,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_blobFileStartingLevel(JNIEnv*,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setPrepopulateBlobCache(
-    JNIEnv*, jobject, jlong jhandle, jbyte jprepopulate_blob_cache_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jprepopulate_blob_cache_value) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   opts->prepopulate_blob_cache =
@@ -5859,8 +5833,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setPrepopulateBlobCache(
  * Method:    prepopulateBlobCache
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_prepopulateBlobCache(JNIEnv*,
-                                                                jobject,
+jbyte Java_org_rocksdb_ColumnFamilyOptions_prepopulateBlobCache(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
@@ -5874,7 +5847,7 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_prepopulateBlobCache(JNIEnv*,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemtableMaxRangeDeletions(
-    JNIEnv*, jobject, jlong jhandle, jint jmemtable_max_range_deletions) {
+    JNIEnv*, jclass, jlong jhandle, jint jmemtable_max_range_deletions) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   opts->memtable_max_range_deletions = jmemtable_max_range_deletions;
@@ -5886,7 +5859,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemtableMaxRangeDeletions(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_memtableMaxRangeDeletions(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
   return static_cast<jint>(opts->memtable_max_range_deletions);
@@ -6001,8 +5974,8 @@ jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps__Ljava_lang_String_2(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_DBOptions_disposeInternal(JNIEnv*, jobject,
-                                                jlong handle) {
+void Java_org_rocksdb_DBOptions_disposeInternalJni(JNIEnv*, jclass,
+                                                   jlong handle) {
   auto* dbo = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(handle);
   assert(dbo != nullptr);
   delete dbo;
@@ -6013,7 +5986,7 @@ void Java_org_rocksdb_DBOptions_disposeInternal(JNIEnv*, jobject,
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_DBOptions_optimizeForSmallDb(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_optimizeForSmallDb(JNIEnv*, jclass,
                                                    jlong jhandle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->OptimizeForSmallDb();
@@ -6024,7 +5997,7 @@ void Java_org_rocksdb_DBOptions_optimizeForSmallDb(JNIEnv*, jobject,
  * Method:    setEnv
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setEnv(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setEnv(JNIEnv*, jclass, jlong jhandle,
                                        jlong jenv_handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->env =
       reinterpret_cast<ROCKSDB_NAMESPACE::Env*>(jenv_handle);
@@ -6035,7 +6008,7 @@ void Java_org_rocksdb_DBOptions_setEnv(JNIEnv*, jobject, jlong jhandle,
  * Method:    setIncreaseParallelism
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setIncreaseParallelism(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setIncreaseParallelism(JNIEnv*, jclass,
                                                        jlong jhandle,
                                                        jint totalThreads) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->IncreaseParallelism(
@@ -6047,7 +6020,7 @@ void Java_org_rocksdb_DBOptions_setIncreaseParallelism(JNIEnv*, jobject,
  * Method:    setCreateIfMissing
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setCreateIfMissing(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setCreateIfMissing(JNIEnv*, jclass,
                                                    jlong jhandle,
                                                    jboolean flag) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->create_if_missing =
@@ -6059,7 +6032,7 @@ void Java_org_rocksdb_DBOptions_setCreateIfMissing(JNIEnv*, jobject,
  * Method:    createIfMissing
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_createIfMissing(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_createIfMissing(JNIEnv*, jclass,
                                                     jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->create_if_missing;
@@ -6070,7 +6043,7 @@ jboolean Java_org_rocksdb_DBOptions_createIfMissing(JNIEnv*, jobject,
  * Method:    setCreateMissingColumnFamilies
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(JNIEnv*, jclass,
                                                                jlong jhandle,
                                                                jboolean flag) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
@@ -6082,8 +6055,7 @@ void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(JNIEnv*, jobject,
  * Method:    createMissingColumnFamilies
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(JNIEnv*,
-                                                                jobject,
+jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(JNIEnv*, jclass,
                                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->create_missing_column_families;
@@ -6094,8 +6066,7 @@ jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(JNIEnv*,
  * Method:    setErrorIfExists
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setErrorIfExists(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_DBOptions_setErrorIfExists(JNIEnv*, jclass, jlong jhandle,
                                                  jboolean error_if_exists) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->error_if_exists =
       static_cast<bool>(error_if_exists);
@@ -6106,7 +6077,7 @@ void Java_org_rocksdb_DBOptions_setErrorIfExists(JNIEnv*, jobject,
  * Method:    errorIfExists
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_errorIfExists(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_errorIfExists(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->error_if_exists;
@@ -6117,7 +6088,7 @@ jboolean Java_org_rocksdb_DBOptions_errorIfExists(JNIEnv*, jobject,
  * Method:    setParanoidChecks
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setParanoidChecks(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setParanoidChecks(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jboolean paranoid_checks) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->paranoid_checks =
@@ -6129,7 +6100,7 @@ void Java_org_rocksdb_DBOptions_setParanoidChecks(JNIEnv*, jobject,
  * Method:    paranoidChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_paranoidChecks(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_paranoidChecks(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->paranoid_checks;
@@ -6140,7 +6111,7 @@ jboolean Java_org_rocksdb_DBOptions_paranoidChecks(JNIEnv*, jobject,
  * Method:    setRateLimiter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setRateLimiter(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setRateLimiter(JNIEnv*, jclass, jlong jhandle,
                                                jlong jrate_limiter_handle) {
   std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>* pRateLimiter =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(
@@ -6155,7 +6126,7 @@ void Java_org_rocksdb_DBOptions_setRateLimiter(JNIEnv*, jobject, jlong jhandle,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setSstFileManager(
-    JNIEnv*, jobject, jlong jhandle, jlong jsst_file_manager_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jsst_file_manager_handle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
           jsst_file_manager_handle);
@@ -6168,7 +6139,7 @@ void Java_org_rocksdb_DBOptions_setSstFileManager(
  * Method:    setLogger
  * Signature: (JJB)V
  */
-void Java_org_rocksdb_DBOptions_setLogger(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setLogger(JNIEnv* env, jclass, jlong jhandle,
                                           jlong jlogger_handle,
                                           jbyte jlogger_type) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
@@ -6198,7 +6169,7 @@ void Java_org_rocksdb_DBOptions_setLogger(JNIEnv* env, jobject, jlong jhandle,
  * Method:    setInfoLogLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_DBOptions_setInfoLogLevel(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setInfoLogLevel(JNIEnv*, jclass, jlong jhandle,
                                                 jbyte jlog_level) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->info_log_level =
       static_cast<ROCKSDB_NAMESPACE::InfoLogLevel>(jlog_level);
@@ -6209,7 +6180,7 @@ void Java_org_rocksdb_DBOptions_setInfoLogLevel(JNIEnv*, jobject, jlong jhandle,
  * Method:    infoLogLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_infoLogLevel(JNIEnv*, jobject, jlong jhandle) {
+jbyte Java_org_rocksdb_DBOptions_infoLogLevel(JNIEnv*, jclass, jlong jhandle) {
   return static_cast<jbyte>(
       reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->info_log_level);
 }
@@ -6219,7 +6190,7 @@ jbyte Java_org_rocksdb_DBOptions_infoLogLevel(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setMaxTotalWalSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(JNIEnv*, jclass,
                                                    jlong jhandle,
                                                    jlong jmax_total_wal_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->max_total_wal_size =
@@ -6231,7 +6202,7 @@ void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(JNIEnv*, jobject,
  * Method:    maxTotalWalSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(JNIEnv*, jclass,
                                                  jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_total_wal_size;
@@ -6242,7 +6213,7 @@ jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(JNIEnv*, jobject,
  * Method:    setMaxOpenFiles
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxOpenFiles(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setMaxOpenFiles(JNIEnv*, jclass, jlong jhandle,
                                                 jint max_open_files) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->max_open_files =
       static_cast<int>(max_open_files);
@@ -6253,7 +6224,7 @@ void Java_org_rocksdb_DBOptions_setMaxOpenFiles(JNIEnv*, jobject, jlong jhandle,
  * Method:    maxOpenFiles
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxOpenFiles(JNIEnv*, jobject, jlong jhandle) {
+jint Java_org_rocksdb_DBOptions_maxOpenFiles(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_open_files;
 }
@@ -6264,7 +6235,7 @@ jint Java_org_rocksdb_DBOptions_maxOpenFiles(JNIEnv*, jobject, jlong jhandle) {
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setMaxFileOpeningThreads(
-    JNIEnv*, jobject, jlong jhandle, jint jmax_file_opening_threads) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_file_opening_threads) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_file_opening_threads = static_cast<int>(jmax_file_opening_threads);
 }
@@ -6274,7 +6245,7 @@ void Java_org_rocksdb_DBOptions_setMaxFileOpeningThreads(
  * Method:    maxFileOpeningThreads
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(JNIEnv*, jobject,
+jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(JNIEnv*, jclass,
                                                       jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<int>(opt->max_file_opening_threads);
@@ -6285,7 +6256,7 @@ jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(JNIEnv*, jobject,
  * Method:    setStatistics
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setStatistics(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setStatistics(JNIEnv*, jclass, jlong jhandle,
                                               jlong jstatistics_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   auto* pSptr =
@@ -6299,7 +6270,7 @@ void Java_org_rocksdb_DBOptions_setStatistics(JNIEnv*, jobject, jlong jhandle,
  * Method:    statistics
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_statistics(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_statistics(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   std::shared_ptr<ROCKSDB_NAMESPACE::Statistics> sptr = opt->statistics;
   if (sptr == nullptr) {
@@ -6316,7 +6287,7 @@ jlong Java_org_rocksdb_DBOptions_statistics(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setUseFsync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setUseFsync(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setUseFsync(JNIEnv*, jclass, jlong jhandle,
                                             jboolean use_fsync) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->use_fsync =
       static_cast<bool>(use_fsync);
@@ -6327,7 +6298,7 @@ void Java_org_rocksdb_DBOptions_setUseFsync(JNIEnv*, jobject, jlong jhandle,
  * Method:    useFsync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_useFsync(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_useFsync(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->use_fsync;
 }
 
@@ -6336,7 +6307,7 @@ jboolean Java_org_rocksdb_DBOptions_useFsync(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setDbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* env, jclass, jlong jhandle,
                                            jobjectArray jpaths,
                                            jlongArray jtarget_sizes) {
   std::vector<ROCKSDB_NAMESPACE::DbPath> db_paths;
@@ -6382,7 +6353,7 @@ void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* env, jobject, jlong jhandle,
  * Method:    dbPathsLen
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_dbPathsLen(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_dbPathsLen(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->db_paths.size());
 }
@@ -6392,7 +6363,7 @@ jlong Java_org_rocksdb_DBOptions_dbPathsLen(JNIEnv*, jobject, jlong jhandle) {
  * Method:    dbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* env, jclass, jlong jhandle,
                                         jobjectArray jpaths,
                                         jlongArray jtarget_sizes) {
   jboolean is_copy;
@@ -6433,7 +6404,7 @@ void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* env, jobject, jlong jhandle,
  * Method:    setDbLogDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* env, jclass, jlong jhandle,
                                             jstring jdb_log_dir) {
   const char* log_dir = env->GetStringUTFChars(jdb_log_dir, nullptr);
   if (log_dir == nullptr) {
@@ -6451,7 +6422,7 @@ void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* env, jobject, jlong jhandle,
  * Method:    dbLogDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* env, jclass,
                                             jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
@@ -6463,7 +6434,7 @@ jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* env, jobject,
  * Method:    setWalDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* env, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* env, jclass, jlong jhandle,
                                           jstring jwal_dir) {
   const char* wal_dir = env->GetStringUTFChars(jwal_dir, 0);
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->wal_dir.assign(
@@ -6476,7 +6447,7 @@ void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* env, jobject, jlong jhandle,
  * Method:    walDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* env, jobject, jlong jhandle) {
+jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* env, jclass, jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
           ->wal_dir.c_str());
@@ -6488,7 +6459,7 @@ jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* env, jobject, jlong jhandle) {
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setDeleteObsoleteFilesPeriodMicros(
-    JNIEnv*, jobject, jlong jhandle, jlong micros) {
+    JNIEnv*, jclass, jlong jhandle, jlong micros) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->delete_obsolete_files_period_micros = static_cast<int64_t>(micros);
 }
@@ -6499,7 +6470,7 @@ void Java_org_rocksdb_DBOptions_setDeleteObsoleteFilesPeriodMicros(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_DBOptions_deleteObsoleteFilesPeriodMicros(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->delete_obsolete_files_period_micros;
 }
@@ -6509,7 +6480,7 @@ jlong Java_org_rocksdb_DBOptions_deleteObsoleteFilesPeriodMicros(
  * Method:    setMaxBackgroundCompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(JNIEnv*, jclass,
                                                             jlong jhandle,
                                                             jint max) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
@@ -6521,7 +6492,7 @@ void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(JNIEnv*, jobject,
  * Method:    maxBackgroundCompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(JNIEnv*, jobject,
+jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(JNIEnv*, jclass,
                                                          jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_background_compactions;
@@ -6532,7 +6503,7 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(JNIEnv*, jobject,
  * Method:    setMaxSubcompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxSubcompactions(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setMaxSubcompactions(JNIEnv*, jclass,
                                                      jlong jhandle, jint max) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->max_subcompactions =
       static_cast<int32_t>(max);
@@ -6543,7 +6514,7 @@ void Java_org_rocksdb_DBOptions_setMaxSubcompactions(JNIEnv*, jobject,
  * Method:    maxSubcompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxSubcompactions(JNIEnv*, jobject,
+jint Java_org_rocksdb_DBOptions_maxSubcompactions(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_subcompactions;
@@ -6555,7 +6526,7 @@ jint Java_org_rocksdb_DBOptions_maxSubcompactions(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setMaxBackgroundFlushes(
-    JNIEnv*, jobject, jlong jhandle, jint max_background_flushes) {
+    JNIEnv*, jclass, jlong jhandle, jint max_background_flushes) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_background_flushes = static_cast<int>(max_background_flushes);
 }
@@ -6565,7 +6536,7 @@ void Java_org_rocksdb_DBOptions_setMaxBackgroundFlushes(
  * Method:    maxBackgroundFlushes
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(JNIEnv*, jobject,
+jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_background_flushes;
@@ -6576,7 +6547,7 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(JNIEnv*, jobject,
  * Method:    setMaxBackgroundJobs
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxBackgroundJobs(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setMaxBackgroundJobs(JNIEnv*, jclass,
                                                      jlong jhandle,
                                                      jint max_background_jobs) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
@@ -6588,7 +6559,7 @@ void Java_org_rocksdb_DBOptions_setMaxBackgroundJobs(JNIEnv*, jobject,
  * Method:    maxBackgroundJobs
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv*, jobject,
+jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_background_jobs;
@@ -6599,7 +6570,7 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv*, jobject,
  * Method:    setMaxLogFileSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* env, jobject,
+void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* env, jclass,
                                                   jlong jhandle,
                                                   jlong max_log_file_size) {
   auto s =
@@ -6617,7 +6588,7 @@ void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* env, jobject,
  * Method:    maxLogFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxLogFileSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_maxLogFileSize(JNIEnv*, jclass,
                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_log_file_size;
@@ -6629,7 +6600,7 @@ jlong Java_org_rocksdb_DBOptions_maxLogFileSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setLogFileTimeToRoll(
-    JNIEnv* env, jobject, jlong jhandle, jlong log_file_time_to_roll) {
+    JNIEnv* env, jclass, jlong jhandle, jlong log_file_time_to_roll) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       log_file_time_to_roll);
   if (s.ok()) {
@@ -6645,7 +6616,7 @@ void Java_org_rocksdb_DBOptions_setLogFileTimeToRoll(
  * Method:    logFileTimeToRoll
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->log_file_time_to_roll;
@@ -6656,7 +6627,7 @@ jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(JNIEnv*, jobject,
  * Method:    setKeepLogFileNum
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* env, jobject,
+void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* env, jclass,
                                                   jlong jhandle,
                                                   jlong keep_log_file_num) {
   auto s =
@@ -6674,7 +6645,7 @@ void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* env, jobject,
  * Method:    keepLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_keepLogFileNum(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_keepLogFileNum(JNIEnv*, jclass,
                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->keep_log_file_num;
@@ -6686,7 +6657,7 @@ jlong Java_org_rocksdb_DBOptions_keepLogFileNum(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setRecycleLogFileNum(
-    JNIEnv* env, jobject, jlong jhandle, jlong recycle_log_file_num) {
+    JNIEnv* env, jclass, jlong jhandle, jlong recycle_log_file_num) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       recycle_log_file_num);
   if (s.ok()) {
@@ -6702,7 +6673,7 @@ void Java_org_rocksdb_DBOptions_setRecycleLogFileNum(
  * Method:    recycleLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_recycleLogFileNum(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_recycleLogFileNum(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->recycle_log_file_num;
@@ -6714,7 +6685,7 @@ jlong Java_org_rocksdb_DBOptions_recycleLogFileNum(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setMaxManifestFileSize(
-    JNIEnv*, jobject, jlong jhandle, jlong max_manifest_file_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong max_manifest_file_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_manifest_file_size = static_cast<int64_t>(max_manifest_file_size);
 }
@@ -6724,7 +6695,7 @@ void Java_org_rocksdb_DBOptions_setMaxManifestFileSize(
  * Method:    maxManifestFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxManifestFileSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_maxManifestFileSize(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->max_manifest_file_size;
@@ -6736,7 +6707,7 @@ jlong Java_org_rocksdb_DBOptions_maxManifestFileSize(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setTableCacheNumshardbits(
-    JNIEnv*, jobject, jlong jhandle, jint table_cache_numshardbits) {
+    JNIEnv*, jclass, jlong jhandle, jint table_cache_numshardbits) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->table_cache_numshardbits = static_cast<int>(table_cache_numshardbits);
 }
@@ -6746,7 +6717,7 @@ void Java_org_rocksdb_DBOptions_setTableCacheNumshardbits(
  * Method:    tableCacheNumshardbits
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(JNIEnv*, jobject,
+jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(JNIEnv*, jclass,
                                                        jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->table_cache_numshardbits;
@@ -6757,8 +6728,7 @@ jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(JNIEnv*, jobject,
  * Method:    setWalTtlSeconds
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalTtlSeconds(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_DBOptions_setWalTtlSeconds(JNIEnv*, jclass, jlong jhandle,
                                                  jlong WAL_ttl_seconds) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->WAL_ttl_seconds =
       static_cast<int64_t>(WAL_ttl_seconds);
@@ -6769,8 +6739,7 @@ void Java_org_rocksdb_DBOptions_setWalTtlSeconds(JNIEnv*, jobject,
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walTtlSeconds(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_walTtlSeconds(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->WAL_ttl_seconds;
 }
@@ -6780,7 +6749,7 @@ jlong Java_org_rocksdb_DBOptions_walTtlSeconds(JNIEnv*, jobject,
  * Method:    setWalSizeLimitMB
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jlong WAL_size_limit_MB) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->WAL_size_limit_MB =
@@ -6792,7 +6761,7 @@ void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(JNIEnv*, jobject,
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(JNIEnv*, jclass,
                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->WAL_size_limit_MB;
@@ -6827,7 +6796,7 @@ jlong Java_org_rocksdb_DBOptions_maxWriteBatchGroupSizeBytes(JNIEnv*, jclass,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setManifestPreallocationSize(
-    JNIEnv* env, jobject, jlong jhandle, jlong preallocation_size) {
+    JNIEnv* env, jclass, jlong jhandle, jlong preallocation_size) {
   auto s = ROCKSDB_NAMESPACE::JniUtil::check_if_jlong_fits_size_t(
       preallocation_size);
   if (s.ok()) {
@@ -6843,7 +6812,7 @@ void Java_org_rocksdb_DBOptions_setManifestPreallocationSize(
  * Method:    manifestPreallocationSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_manifestPreallocationSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_manifestPreallocationSize(JNIEnv*, jclass,
                                                            jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->manifest_preallocation_size;
@@ -6854,7 +6823,7 @@ jlong Java_org_rocksdb_DBOptions_manifestPreallocationSize(JNIEnv*, jobject,
  * Method:    useDirectReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_useDirectReads(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_useDirectReads(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->use_direct_reads;
@@ -6865,7 +6834,7 @@ jboolean Java_org_rocksdb_DBOptions_useDirectReads(JNIEnv*, jobject,
  * Method:    setUseDirectReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setUseDirectReads(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setUseDirectReads(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jboolean use_direct_reads) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->use_direct_reads =
@@ -6878,7 +6847,7 @@ void Java_org_rocksdb_DBOptions_setUseDirectReads(JNIEnv*, jobject,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_DBOptions_useDirectIoForFlushAndCompaction(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->use_direct_io_for_flush_and_compaction;
 }
@@ -6889,7 +6858,7 @@ jboolean Java_org_rocksdb_DBOptions_useDirectIoForFlushAndCompaction(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setUseDirectIoForFlushAndCompaction(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jboolean use_direct_io_for_flush_and_compaction) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->use_direct_io_for_flush_and_compaction =
@@ -6901,7 +6870,7 @@ void Java_org_rocksdb_DBOptions_setUseDirectIoForFlushAndCompaction(
  * Method:    setAllowFAllocate
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowFAllocate(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setAllowFAllocate(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jboolean jallow_fallocate) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->allow_fallocate =
@@ -6913,7 +6882,7 @@ void Java_org_rocksdb_DBOptions_setAllowFAllocate(JNIEnv*, jobject,
  * Method:    allowFAllocate
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowFAllocate(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_allowFAllocate(JNIEnv*, jclass,
                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->allow_fallocate);
@@ -6924,7 +6893,7 @@ jboolean Java_org_rocksdb_DBOptions_allowFAllocate(JNIEnv*, jobject,
  * Method:    setAllowMmapReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowMmapReads(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setAllowMmapReads(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jboolean allow_mmap_reads) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->allow_mmap_reads =
@@ -6936,7 +6905,7 @@ void Java_org_rocksdb_DBOptions_setAllowMmapReads(JNIEnv*, jobject,
  * Method:    allowMmapReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowMmapReads(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_allowMmapReads(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->allow_mmap_reads;
@@ -6947,7 +6916,7 @@ jboolean Java_org_rocksdb_DBOptions_allowMmapReads(JNIEnv*, jobject,
  * Method:    setAllowMmapWrites
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowMmapWrites(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setAllowMmapWrites(JNIEnv*, jclass,
                                                    jlong jhandle,
                                                    jboolean allow_mmap_writes) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->allow_mmap_writes =
@@ -6959,7 +6928,7 @@ void Java_org_rocksdb_DBOptions_setAllowMmapWrites(JNIEnv*, jobject,
  * Method:    allowMmapWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowMmapWrites(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_allowMmapWrites(JNIEnv*, jclass,
                                                     jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->allow_mmap_writes;
@@ -6971,7 +6940,7 @@ jboolean Java_org_rocksdb_DBOptions_allowMmapWrites(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setIsFdCloseOnExec(
-    JNIEnv*, jobject, jlong jhandle, jboolean is_fd_close_on_exec) {
+    JNIEnv*, jclass, jlong jhandle, jboolean is_fd_close_on_exec) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->is_fd_close_on_exec = static_cast<bool>(is_fd_close_on_exec);
 }
@@ -6981,7 +6950,7 @@ void Java_org_rocksdb_DBOptions_setIsFdCloseOnExec(
  * Method:    isFdCloseOnExec
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(JNIEnv*, jclass,
                                                     jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->is_fd_close_on_exec;
@@ -6993,7 +6962,7 @@ jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setStatsDumpPeriodSec(
-    JNIEnv*, jobject, jlong jhandle, jint jstats_dump_period_sec) {
+    JNIEnv*, jclass, jlong jhandle, jint jstats_dump_period_sec) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->stats_dump_period_sec =
       static_cast<unsigned int>(jstats_dump_period_sec);
@@ -7004,7 +6973,7 @@ void Java_org_rocksdb_DBOptions_setStatsDumpPeriodSec(
  * Method:    statsDumpPeriodSec
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_statsDumpPeriodSec(JNIEnv*, jobject,
+jint Java_org_rocksdb_DBOptions_statsDumpPeriodSec(JNIEnv*, jclass,
                                                    jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->stats_dump_period_sec;
@@ -7016,7 +6985,7 @@ jint Java_org_rocksdb_DBOptions_statsDumpPeriodSec(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setStatsPersistPeriodSec(
-    JNIEnv*, jobject, jlong jhandle, jint jstats_persist_period_sec) {
+    JNIEnv*, jclass, jlong jhandle, jint jstats_persist_period_sec) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->stats_persist_period_sec =
       static_cast<unsigned int>(jstats_persist_period_sec);
@@ -7027,7 +6996,7 @@ void Java_org_rocksdb_DBOptions_setStatsPersistPeriodSec(
  * Method:    statsPersistPeriodSec
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_statsPersistPeriodSec(JNIEnv*, jobject,
+jint Java_org_rocksdb_DBOptions_statsPersistPeriodSec(JNIEnv*, jclass,
                                                       jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->stats_persist_period_sec;
@@ -7039,7 +7008,7 @@ jint Java_org_rocksdb_DBOptions_statsPersistPeriodSec(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setStatsHistoryBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jstats_history_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jstats_history_buffer_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->stats_history_buffer_size =
       static_cast<size_t>(jstats_history_buffer_size);
@@ -7050,7 +7019,7 @@ void Java_org_rocksdb_DBOptions_setStatsHistoryBufferSize(
  * Method:    statsHistoryBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_statsHistoryBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_statsHistoryBufferSize(JNIEnv*, jclass,
                                                         jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->stats_history_buffer_size;
@@ -7062,7 +7031,7 @@ jlong Java_org_rocksdb_DBOptions_statsHistoryBufferSize(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAdviseRandomOnOpen(
-    JNIEnv*, jobject, jlong jhandle, jboolean advise_random_on_open) {
+    JNIEnv*, jclass, jlong jhandle, jboolean advise_random_on_open) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->advise_random_on_open = static_cast<bool>(advise_random_on_open);
 }
@@ -7072,7 +7041,7 @@ void Java_org_rocksdb_DBOptions_setAdviseRandomOnOpen(
  * Method:    adviseRandomOnOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_adviseRandomOnOpen(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_adviseRandomOnOpen(JNIEnv*, jclass,
                                                        jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->advise_random_on_open;
@@ -7084,7 +7053,7 @@ jboolean Java_org_rocksdb_DBOptions_adviseRandomOnOpen(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setDbWriteBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jdb_write_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jdb_write_buffer_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->db_write_buffer_size = static_cast<size_t>(jdb_write_buffer_size);
 }
@@ -7095,7 +7064,7 @@ void Java_org_rocksdb_DBOptions_setDbWriteBufferSize(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setWriteBufferManager(
-    JNIEnv*, jobject, jlong jdb_options_handle,
+    JNIEnv*, jclass, jlong jdb_options_handle,
     jlong jwrite_buffer_manager_handle) {
   auto* write_buffer_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::WriteBufferManager>*>(
@@ -7109,7 +7078,7 @@ void Java_org_rocksdb_DBOptions_setWriteBufferManager(
  * Method:    dbWriteBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_dbWriteBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_dbWriteBufferSize(JNIEnv*, jclass,
                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->db_write_buffer_size);
@@ -7121,7 +7090,7 @@ jlong Java_org_rocksdb_DBOptions_dbWriteBufferSize(JNIEnv*, jobject,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_DBOptions_setAccessHintOnCompactionStart(
-    JNIEnv*, jobject, jlong jhandle, jbyte jaccess_hint_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jaccess_hint_value) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->access_hint_on_compaction_start =
       ROCKSDB_NAMESPACE::AccessHintJni::toCppAccessHint(jaccess_hint_value);
@@ -7132,7 +7101,7 @@ void Java_org_rocksdb_DBOptions_setAccessHintOnCompactionStart(
  * Method:    accessHintOnCompactionStart
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_accessHintOnCompactionStart(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_DBOptions_accessHintOnCompactionStart(JNIEnv*, jclass,
                                                              jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return ROCKSDB_NAMESPACE::AccessHintJni::toJavaAccessHint(
@@ -7145,7 +7114,7 @@ jbyte Java_org_rocksdb_DBOptions_accessHintOnCompactionStart(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setCompactionReadaheadSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jcompaction_readahead_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jcompaction_readahead_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->compaction_readahead_size =
       static_cast<size_t>(jcompaction_readahead_size);
@@ -7156,7 +7125,7 @@ void Java_org_rocksdb_DBOptions_setCompactionReadaheadSize(
  * Method:    compactionReadaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_compactionReadaheadSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_compactionReadaheadSize(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->compaction_readahead_size);
@@ -7168,7 +7137,7 @@ jlong Java_org_rocksdb_DBOptions_compactionReadaheadSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setRandomAccessMaxBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jrandom_access_max_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jrandom_access_max_buffer_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->random_access_max_buffer_size =
       static_cast<size_t>(jrandom_access_max_buffer_size);
@@ -7179,7 +7148,7 @@ void Java_org_rocksdb_DBOptions_setRandomAccessMaxBufferSize(
  * Method:    randomAccessMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_randomAccessMaxBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_randomAccessMaxBufferSize(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->random_access_max_buffer_size);
@@ -7191,7 +7160,7 @@ jlong Java_org_rocksdb_DBOptions_randomAccessMaxBufferSize(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setWritableFileMaxBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jlong jwritable_file_max_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jlong jwritable_file_max_buffer_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->writable_file_max_buffer_size =
       static_cast<size_t>(jwritable_file_max_buffer_size);
@@ -7202,7 +7171,7 @@ void Java_org_rocksdb_DBOptions_setWritableFileMaxBufferSize(
  * Method:    writableFileMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writableFileMaxBufferSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_writableFileMaxBufferSize(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->writable_file_max_buffer_size);
@@ -7214,7 +7183,7 @@ jlong Java_org_rocksdb_DBOptions_writableFileMaxBufferSize(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setUseAdaptiveMutex(
-    JNIEnv*, jobject, jlong jhandle, jboolean use_adaptive_mutex) {
+    JNIEnv*, jclass, jlong jhandle, jboolean use_adaptive_mutex) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->use_adaptive_mutex =
       static_cast<bool>(use_adaptive_mutex);
 }
@@ -7224,7 +7193,7 @@ void Java_org_rocksdb_DBOptions_setUseAdaptiveMutex(
  * Method:    useAdaptiveMutex
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->use_adaptive_mutex;
@@ -7235,7 +7204,7 @@ jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(JNIEnv*, jobject,
  * Method:    setBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setBytesPerSync(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setBytesPerSync(JNIEnv*, jclass, jlong jhandle,
                                                 jlong bytes_per_sync) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->bytes_per_sync =
       static_cast<int64_t>(bytes_per_sync);
@@ -7246,7 +7215,7 @@ void Java_org_rocksdb_DBOptions_setBytesPerSync(JNIEnv*, jobject, jlong jhandle,
  * Method:    bytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_bytesPerSync(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_bytesPerSync(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->bytes_per_sync;
 }
@@ -7256,7 +7225,7 @@ jlong Java_org_rocksdb_DBOptions_bytesPerSync(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setWalBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalBytesPerSync(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setWalBytesPerSync(JNIEnv*, jclass,
                                                    jlong jhandle,
                                                    jlong jwal_bytes_per_sync) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)->wal_bytes_per_sync =
@@ -7268,7 +7237,7 @@ void Java_org_rocksdb_DBOptions_setWalBytesPerSync(JNIEnv*, jobject,
  * Method:    walBytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walBytesPerSync(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_walBytesPerSync(JNIEnv*, jclass,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->wal_bytes_per_sync);
@@ -7280,7 +7249,7 @@ jlong Java_org_rocksdb_DBOptions_walBytesPerSync(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setStrictBytesPerSync(
-    JNIEnv*, jobject, jlong jhandle, jboolean jstrict_bytes_per_sync) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jstrict_bytes_per_sync) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->strict_bytes_per_sync = jstrict_bytes_per_sync == JNI_TRUE;
 }
@@ -7290,7 +7259,7 @@ void Java_org_rocksdb_DBOptions_setStrictBytesPerSync(
  * Method:    strictBytesPerSync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_strictBytesPerSync(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_strictBytesPerSync(JNIEnv*, jclass,
                                                        jlong jhandle) {
   return static_cast<jboolean>(
       reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
@@ -7325,7 +7294,7 @@ jobjectArray Java_org_rocksdb_DBOptions_eventListeners(JNIEnv* env, jclass,
  * Method:    setDelayedWriteRate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setDelayedWriteRate(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setDelayedWriteRate(JNIEnv*, jclass,
                                                     jlong jhandle,
                                                     jlong jdelayed_write_rate) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
@@ -7337,7 +7306,7 @@ void Java_org_rocksdb_DBOptions_setDelayedWriteRate(JNIEnv*, jobject,
  * Method:    delayedWriteRate
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_delayedWriteRate(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_delayedWriteRate(JNIEnv*, jclass,
                                                   jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->delayed_write_rate);
@@ -7349,7 +7318,7 @@ jlong Java_org_rocksdb_DBOptions_delayedWriteRate(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setEnablePipelinedWrite(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_pipelined_write) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_pipelined_write) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->enable_pipelined_write = jenable_pipelined_write == JNI_TRUE;
 }
@@ -7359,7 +7328,7 @@ void Java_org_rocksdb_DBOptions_setEnablePipelinedWrite(
  * Method:    enablePipelinedWrite
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_enablePipelinedWrite(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_enablePipelinedWrite(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->enable_pipelined_write);
@@ -7370,7 +7339,7 @@ jboolean Java_org_rocksdb_DBOptions_enablePipelinedWrite(JNIEnv*, jobject,
  * Method:    setUnorderedWrite
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setUnorderedWrite(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setUnorderedWrite(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jboolean junordered_write) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
@@ -7382,7 +7351,7 @@ void Java_org_rocksdb_DBOptions_setUnorderedWrite(JNIEnv*, jobject,
  * Method:    unorderedWrite
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_unorderedWrite(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_unorderedWrite(JNIEnv*, jclass,
                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->unordered_write);
@@ -7394,7 +7363,7 @@ jboolean Java_org_rocksdb_DBOptions_unorderedWrite(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setEnableThreadTracking(
-    JNIEnv*, jobject, jlong jhandle, jboolean jenable_thread_tracking) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jenable_thread_tracking) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->enable_thread_tracking = jenable_thread_tracking == JNI_TRUE;
 }
@@ -7404,7 +7373,7 @@ void Java_org_rocksdb_DBOptions_setEnableThreadTracking(
  * Method:    enableThreadTracking
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(JNIEnv*, jclass,
                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->enable_thread_tracking);
@@ -7416,7 +7385,7 @@ jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAllowConcurrentMemtableWrite(
-    JNIEnv*, jobject, jlong jhandle, jboolean allow) {
+    JNIEnv*, jclass, jlong jhandle, jboolean allow) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->allow_concurrent_memtable_write = static_cast<bool>(allow);
 }
@@ -7427,7 +7396,7 @@ void Java_org_rocksdb_DBOptions_setAllowConcurrentMemtableWrite(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_DBOptions_allowConcurrentMemtableWrite(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->allow_concurrent_memtable_write;
 }
@@ -7438,7 +7407,7 @@ jboolean Java_org_rocksdb_DBOptions_allowConcurrentMemtableWrite(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setEnableWriteThreadAdaptiveYield(
-    JNIEnv*, jobject, jlong jhandle, jboolean yield) {
+    JNIEnv*, jclass, jlong jhandle, jboolean yield) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->enable_write_thread_adaptive_yield = static_cast<bool>(yield);
 }
@@ -7449,7 +7418,7 @@ void Java_org_rocksdb_DBOptions_setEnableWriteThreadAdaptiveYield(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_DBOptions_enableWriteThreadAdaptiveYield(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->enable_write_thread_adaptive_yield;
 }
@@ -7459,7 +7428,7 @@ jboolean Java_org_rocksdb_DBOptions_enableWriteThreadAdaptiveYield(
  * Method:    setWriteThreadMaxYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(JNIEnv*, jclass,
                                                            jlong jhandle,
                                                            jlong max) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
@@ -7471,7 +7440,7 @@ void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(JNIEnv*, jobject,
  * Method:    writeThreadMaxYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(JNIEnv*, jclass,
                                                          jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->write_thread_max_yield_usec;
@@ -7482,7 +7451,7 @@ jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(JNIEnv*, jobject,
  * Method:    setWriteThreadSlowYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(JNIEnv*, jclass,
                                                             jlong jhandle,
                                                             jlong slow) {
   reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
@@ -7494,7 +7463,7 @@ void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(JNIEnv*, jobject,
  * Method:    writeThreadSlowYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writeThreadSlowYieldUsec(JNIEnv*, jobject,
+jlong Java_org_rocksdb_DBOptions_writeThreadSlowYieldUsec(JNIEnv*, jclass,
                                                           jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle)
       ->write_thread_slow_yield_usec;
@@ -7506,7 +7475,7 @@ jlong Java_org_rocksdb_DBOptions_writeThreadSlowYieldUsec(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setSkipStatsUpdateOnDbOpen(
-    JNIEnv*, jobject, jlong jhandle, jboolean jskip_stats_update_on_db_open) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jskip_stats_update_on_db_open) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->skip_stats_update_on_db_open =
       static_cast<bool>(jskip_stats_update_on_db_open);
@@ -7517,7 +7486,7 @@ void Java_org_rocksdb_DBOptions_setSkipStatsUpdateOnDbOpen(
  * Method:    skipStatsUpdateOnDbOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(JNIEnv*, jclass,
                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->skip_stats_update_on_db_open);
@@ -7553,7 +7522,7 @@ jboolean Java_org_rocksdb_DBOptions_skipCheckingSstFileSizesOnDbOpen(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_DBOptions_setWalRecoveryMode(
-    JNIEnv*, jobject, jlong jhandle, jbyte jwal_recovery_mode_value) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jwal_recovery_mode_value) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->wal_recovery_mode =
       ROCKSDB_NAMESPACE::WALRecoveryModeJni::toCppWALRecoveryMode(
@@ -7565,7 +7534,7 @@ void Java_org_rocksdb_DBOptions_setWalRecoveryMode(
  * Method:    walRecoveryMode
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(JNIEnv*, jobject,
+jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(JNIEnv*, jclass,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return ROCKSDB_NAMESPACE::WALRecoveryModeJni::toJavaWALRecoveryMode(
@@ -7577,7 +7546,7 @@ jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(JNIEnv*, jobject,
  * Method:    setAllow2pc
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllow2pc(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setAllow2pc(JNIEnv*, jclass, jlong jhandle,
                                             jboolean jallow_2pc) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->allow_2pc = static_cast<bool>(jallow_2pc);
@@ -7588,7 +7557,7 @@ void Java_org_rocksdb_DBOptions_setAllow2pc(JNIEnv*, jobject, jlong jhandle,
  * Method:    allow2pc
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->allow_2pc);
 }
@@ -7598,7 +7567,7 @@ jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setRowCache
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setRowCache(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setRowCache(JNIEnv*, jclass, jlong jhandle,
                                             jlong jrow_cache_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   auto* row_cache =
@@ -7612,7 +7581,7 @@ void Java_org_rocksdb_DBOptions_setRowCache(JNIEnv*, jobject, jlong jhandle,
  * Method:    setWalFilter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalFilter(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setWalFilter(JNIEnv*, jclass, jlong jhandle,
                                              jlong jwal_filter_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   auto* wal_filter = reinterpret_cast<ROCKSDB_NAMESPACE::WalFilterJniCallback*>(
@@ -7626,7 +7595,7 @@ void Java_org_rocksdb_DBOptions_setWalFilter(JNIEnv*, jobject, jlong jhandle,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setFailIfOptionsFileError(
-    JNIEnv*, jobject, jlong jhandle, jboolean jfail_if_options_file_error) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jfail_if_options_file_error) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->fail_if_options_file_error =
       static_cast<bool>(jfail_if_options_file_error);
@@ -7637,7 +7606,7 @@ void Java_org_rocksdb_DBOptions_setFailIfOptionsFileError(
  * Method:    failIfOptionsFileError
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_failIfOptionsFileError(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_failIfOptionsFileError(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->fail_if_options_file_error);
@@ -7649,7 +7618,7 @@ jboolean Java_org_rocksdb_DBOptions_failIfOptionsFileError(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setDumpMallocStats(
-    JNIEnv*, jobject, jlong jhandle, jboolean jdump_malloc_stats) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jdump_malloc_stats) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->dump_malloc_stats = static_cast<bool>(jdump_malloc_stats);
 }
@@ -7659,7 +7628,7 @@ void Java_org_rocksdb_DBOptions_setDumpMallocStats(
  * Method:    dumpMallocStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_dumpMallocStats(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_dumpMallocStats(JNIEnv*, jclass,
                                                     jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->dump_malloc_stats);
@@ -7671,7 +7640,7 @@ jboolean Java_org_rocksdb_DBOptions_dumpMallocStats(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAvoidFlushDuringRecovery(
-    JNIEnv*, jobject, jlong jhandle, jboolean javoid_flush_during_recovery) {
+    JNIEnv*, jclass, jlong jhandle, jboolean javoid_flush_during_recovery) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->avoid_flush_during_recovery =
       static_cast<bool>(javoid_flush_during_recovery);
@@ -7682,7 +7651,7 @@ void Java_org_rocksdb_DBOptions_setAvoidFlushDuringRecovery(
  * Method:    avoidFlushDuringRecovery
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringRecovery(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringRecovery(JNIEnv*, jclass,
                                                              jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_recovery);
@@ -7694,7 +7663,7 @@ jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringRecovery(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAllowIngestBehind(
-    JNIEnv*, jobject, jlong jhandle, jboolean jallow_ingest_behind) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jallow_ingest_behind) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->allow_ingest_behind = jallow_ingest_behind == JNI_TRUE;
 }
@@ -7704,7 +7673,7 @@ void Java_org_rocksdb_DBOptions_setAllowIngestBehind(
  * Method:    allowIngestBehind
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowIngestBehind(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_allowIngestBehind(JNIEnv*, jclass,
                                                       jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->allow_ingest_behind);
@@ -7715,7 +7684,7 @@ jboolean Java_org_rocksdb_DBOptions_allowIngestBehind(JNIEnv*, jobject,
  * Method:    setTwoWriteQueues
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setTwoWriteQueues(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setTwoWriteQueues(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jboolean jtwo_write_queues) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
@@ -7727,7 +7696,7 @@ void Java_org_rocksdb_DBOptions_setTwoWriteQueues(JNIEnv*, jobject,
  * Method:    twoWriteQueues
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_twoWriteQueues(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_twoWriteQueues(JNIEnv*, jclass,
                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->two_write_queues);
@@ -7738,7 +7707,7 @@ jboolean Java_org_rocksdb_DBOptions_twoWriteQueues(JNIEnv*, jobject,
  * Method:    setManualWalFlush
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setManualWalFlush(JNIEnv*, jobject,
+void Java_org_rocksdb_DBOptions_setManualWalFlush(JNIEnv*, jclass,
                                                   jlong jhandle,
                                                   jboolean jmanual_wal_flush) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
@@ -7750,7 +7719,7 @@ void Java_org_rocksdb_DBOptions_setManualWalFlush(JNIEnv*, jobject,
  * Method:    manualWalFlush
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_manualWalFlush(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_manualWalFlush(JNIEnv*, jclass,
                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->manual_wal_flush);
@@ -7761,7 +7730,7 @@ jboolean Java_org_rocksdb_DBOptions_manualWalFlush(JNIEnv*, jobject,
  * Method:    setAtomicFlush
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAtomicFlush(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_DBOptions_setAtomicFlush(JNIEnv*, jclass, jlong jhandle,
                                                jboolean jatomic_flush) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->atomic_flush = jatomic_flush == JNI_TRUE;
@@ -7772,7 +7741,7 @@ void Java_org_rocksdb_DBOptions_setAtomicFlush(JNIEnv*, jobject, jlong jhandle,
  * Method:    atomicFlush
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_atomicFlush(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_atomicFlush(JNIEnv*, jclass,
                                                 jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->atomic_flush);
@@ -7784,7 +7753,7 @@ jboolean Java_org_rocksdb_DBOptions_atomicFlush(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAvoidFlushDuringShutdown(
-    JNIEnv*, jobject, jlong jhandle, jboolean javoid_flush_during_shutdown) {
+    JNIEnv*, jclass, jlong jhandle, jboolean javoid_flush_during_shutdown) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->avoid_flush_during_shutdown =
       static_cast<bool>(javoid_flush_during_shutdown);
@@ -7795,7 +7764,7 @@ void Java_org_rocksdb_DBOptions_setAvoidFlushDuringShutdown(
  * Method:    avoidFlushDuringShutdown
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(JNIEnv*, jclass,
                                                              jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_shutdown);
@@ -7987,8 +7956,8 @@ jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(JNIEnv*, jclass,
  * Method:    disposeInternal
  * Signature: ()V
  */
-void Java_org_rocksdb_WriteOptions_disposeInternal(JNIEnv*, jobject,
-                                                   jlong jhandle) {
+void Java_org_rocksdb_WriteOptions_disposeInternalJni(JNIEnv*, jclass,
+                                                      jlong jhandle) {
   auto* write_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle);
   assert(write_options != nullptr);
@@ -8000,7 +7969,7 @@ void Java_org_rocksdb_WriteOptions_disposeInternal(JNIEnv*, jobject,
  * Method:    setSync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setSync(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_WriteOptions_setSync(JNIEnv*, jclass, jlong jhandle,
                                            jboolean jflag) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)->sync = jflag;
 }
@@ -8010,7 +7979,7 @@ void Java_org_rocksdb_WriteOptions_setSync(JNIEnv*, jobject, jlong jhandle,
  * Method:    sync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)->sync;
 }
 
@@ -8019,8 +7988,7 @@ jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setDisableWAL
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv*, jclass, jlong jhandle,
                                                  jboolean jflag) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)->disableWAL =
       jflag;
@@ -8031,7 +7999,7 @@ void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv*, jobject,
  * Method:    disableWAL
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)
       ->disableWAL;
@@ -8043,7 +8011,7 @@ jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_WriteOptions_setIgnoreMissingColumnFamilies(
-    JNIEnv*, jobject, jlong jhandle, jboolean jignore_missing_column_families) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jignore_missing_column_families) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)
       ->ignore_missing_column_families =
       static_cast<bool>(jignore_missing_column_families);
@@ -8055,7 +8023,7 @@ void Java_org_rocksdb_WriteOptions_setIgnoreMissingColumnFamilies(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_WriteOptions_ignoreMissingColumnFamilies(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)
       ->ignore_missing_column_families;
 }
@@ -8065,8 +8033,7 @@ jboolean Java_org_rocksdb_WriteOptions_ignoreMissingColumnFamilies(
  * Method:    setNoSlowdown
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv*, jclass, jlong jhandle,
                                                  jboolean jno_slowdown) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)->no_slowdown =
       static_cast<bool>(jno_slowdown);
@@ -8077,7 +8044,7 @@ void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv*, jobject,
  * Method:    noSlowdown
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv*, jclass,
                                                   jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)
       ->no_slowdown;
@@ -8088,7 +8055,7 @@ jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv*, jobject,
  * Method:    setLowPri
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setLowPri(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_WriteOptions_setLowPri(JNIEnv*, jclass, jlong jhandle,
                                              jboolean jlow_pri) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)->low_pri =
       static_cast<bool>(jlow_pri);
@@ -8099,7 +8066,7 @@ void Java_org_rocksdb_WriteOptions_setLowPri(JNIEnv*, jobject, jlong jhandle,
  * Method:    lowPri
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_lowPri(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_WriteOptions_lowPri(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)->low_pri;
 }
 
@@ -8109,7 +8076,7 @@ jboolean Java_org_rocksdb_WriteOptions_lowPri(JNIEnv*, jobject, jlong jhandle) {
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_WriteOptions_memtableInsertHintPerBatch(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)
       ->memtable_insert_hint_per_batch;
 }
@@ -8120,7 +8087,7 @@ jboolean Java_org_rocksdb_WriteOptions_memtableInsertHintPerBatch(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_WriteOptions_setMemtableInsertHintPerBatch(
-    JNIEnv*, jobject, jlong jhandle, jboolean jmemtable_insert_hint_per_batch) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jmemtable_insert_hint_per_batch) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jhandle)
       ->memtable_insert_hint_per_batch =
       static_cast<bool>(jmemtable_insert_hint_per_batch);
@@ -8168,8 +8135,8 @@ jlong Java_org_rocksdb_ReadOptions_copyReadOptions(JNIEnv*, jclass,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ReadOptions_disposeInternal(JNIEnv*, jobject,
-                                                  jlong jhandle) {
+void Java_org_rocksdb_ReadOptions_disposeInternalJni(JNIEnv*, jclass,
+                                                     jlong jhandle) {
   auto* read_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   assert(read_options != nullptr);
@@ -8182,7 +8149,7 @@ void Java_org_rocksdb_ReadOptions_disposeInternal(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setVerifyChecksums(
-    JNIEnv*, jobject, jlong jhandle, jboolean jverify_checksums) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jverify_checksums) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->verify_checksums =
       static_cast<bool>(jverify_checksums);
 }
@@ -8192,7 +8159,7 @@ void Java_org_rocksdb_ReadOptions_setVerifyChecksums(
  * Method:    verifyChecksums
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(JNIEnv*, jclass,
                                                       jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)
       ->verify_checksums;
@@ -8203,7 +8170,7 @@ jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(JNIEnv*, jobject,
  * Method:    setFillCache
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setFillCache(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setFillCache(JNIEnv*, jclass, jlong jhandle,
                                                jboolean jfill_cache) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->fill_cache =
       static_cast<bool>(jfill_cache);
@@ -8214,7 +8181,7 @@ void Java_org_rocksdb_ReadOptions_setFillCache(JNIEnv*, jobject, jlong jhandle,
  * Method:    fillCache
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_fillCache(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ReadOptions_fillCache(JNIEnv*, jclass,
                                                 jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->fill_cache;
 }
@@ -8224,7 +8191,7 @@ jboolean Java_org_rocksdb_ReadOptions_fillCache(JNIEnv*, jobject,
  * Method:    setTailing
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setTailing(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setTailing(JNIEnv*, jclass, jlong jhandle,
                                              jboolean jtailing) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->tailing =
       static_cast<bool>(jtailing);
@@ -8235,7 +8202,7 @@ void Java_org_rocksdb_ReadOptions_setTailing(JNIEnv*, jobject, jlong jhandle,
  * Method:    tailing
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_tailing(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_tailing(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->tailing;
 }
 
@@ -8244,7 +8211,7 @@ jboolean Java_org_rocksdb_ReadOptions_tailing(JNIEnv*, jobject, jlong jhandle) {
  * Method:    managed
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_managed(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_managed(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->managed;
 }
 
@@ -8253,7 +8220,7 @@ jboolean Java_org_rocksdb_ReadOptions_managed(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setManaged
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setManaged(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setManaged(JNIEnv*, jclass, jlong jhandle,
                                              jboolean jmanaged) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->managed =
       static_cast<bool>(jmanaged);
@@ -8264,7 +8231,7 @@ void Java_org_rocksdb_ReadOptions_setManaged(JNIEnv*, jobject, jlong jhandle,
  * Method:    totalOrderSeek
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_totalOrderSeek(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ReadOptions_totalOrderSeek(JNIEnv*, jclass,
                                                      jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)
       ->total_order_seek;
@@ -8276,7 +8243,7 @@ jboolean Java_org_rocksdb_ReadOptions_totalOrderSeek(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setTotalOrderSeek(
-    JNIEnv*, jobject, jlong jhandle, jboolean jtotal_order_seek) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jtotal_order_seek) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->total_order_seek =
       static_cast<bool>(jtotal_order_seek);
 }
@@ -8286,7 +8253,7 @@ void Java_org_rocksdb_ReadOptions_setTotalOrderSeek(
  * Method:    prefixSameAsStart
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_prefixSameAsStart(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ReadOptions_prefixSameAsStart(JNIEnv*, jclass,
                                                         jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)
       ->prefix_same_as_start;
@@ -8298,7 +8265,7 @@ jboolean Java_org_rocksdb_ReadOptions_prefixSameAsStart(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setPrefixSameAsStart(
-    JNIEnv*, jobject, jlong jhandle, jboolean jprefix_same_as_start) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jprefix_same_as_start) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)
       ->prefix_same_as_start = static_cast<bool>(jprefix_same_as_start);
 }
@@ -8308,7 +8275,7 @@ void Java_org_rocksdb_ReadOptions_setPrefixSameAsStart(
  * Method:    pinData
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_pinData(JNIEnv*, jobject, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_pinData(JNIEnv*, jclass, jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->pin_data;
 }
 
@@ -8317,7 +8284,7 @@ jboolean Java_org_rocksdb_ReadOptions_pinData(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setPinData
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setPinData(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setPinData(JNIEnv*, jclass, jlong jhandle,
                                              jboolean jpin_data) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->pin_data =
       static_cast<bool>(jpin_data);
@@ -8329,7 +8296,7 @@ void Java_org_rocksdb_ReadOptions_setPinData(JNIEnv*, jobject, jlong jhandle,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ReadOptions_backgroundPurgeOnIteratorCleanup(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   return static_cast<jboolean>(opt->background_purge_on_iterator_cleanup);
 }
@@ -8340,7 +8307,7 @@ jboolean Java_org_rocksdb_ReadOptions_backgroundPurgeOnIteratorCleanup(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setBackgroundPurgeOnIteratorCleanup(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jboolean jbackground_purge_on_iterator_cleanup) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->background_purge_on_iterator_cleanup =
@@ -8352,7 +8319,7 @@ void Java_org_rocksdb_ReadOptions_setBackgroundPurgeOnIteratorCleanup(
  * Method:    readaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_readaheadSize(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ReadOptions_readaheadSize(JNIEnv*, jclass,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   return static_cast<jlong>(opt->readahead_size);
@@ -8363,7 +8330,7 @@ jlong Java_org_rocksdb_ReadOptions_readaheadSize(JNIEnv*, jobject,
  * Method:    setReadaheadSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setReadaheadSize(JNIEnv*, jobject,
+void Java_org_rocksdb_ReadOptions_setReadaheadSize(JNIEnv*, jclass,
                                                    jlong jhandle,
                                                    jlong jreadahead_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
@@ -8375,7 +8342,7 @@ void Java_org_rocksdb_ReadOptions_setReadaheadSize(JNIEnv*, jobject,
  * Method:    maxSkippableInternalKeys
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_maxSkippableInternalKeys(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ReadOptions_maxSkippableInternalKeys(JNIEnv*, jclass,
                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   return static_cast<jlong>(opt->max_skippable_internal_keys);
@@ -8387,7 +8354,7 @@ jlong Java_org_rocksdb_ReadOptions_maxSkippableInternalKeys(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ReadOptions_setMaxSkippableInternalKeys(
-    JNIEnv*, jobject, jlong jhandle, jlong jmax_skippable_internal_keys) {
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_skippable_internal_keys) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->max_skippable_internal_keys =
       static_cast<uint64_t>(jmax_skippable_internal_keys);
@@ -8398,7 +8365,7 @@ void Java_org_rocksdb_ReadOptions_setMaxSkippableInternalKeys(
  * Method:    ignoreRangeDeletions
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_ignoreRangeDeletions(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ReadOptions_ignoreRangeDeletions(JNIEnv*, jclass,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   return static_cast<jboolean>(opt->ignore_range_deletions);
@@ -8410,7 +8377,7 @@ jboolean Java_org_rocksdb_ReadOptions_ignoreRangeDeletions(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setIgnoreRangeDeletions(
-    JNIEnv*, jobject, jlong jhandle, jboolean jignore_range_deletions) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jignore_range_deletions) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->ignore_range_deletions = static_cast<bool>(jignore_range_deletions);
 }
@@ -8420,7 +8387,7 @@ void Java_org_rocksdb_ReadOptions_setIgnoreRangeDeletions(
  * Method:    setSnapshot
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setSnapshot(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setSnapshot(JNIEnv*, jclass, jlong jhandle,
                                               jlong jsnapshot) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->snapshot =
       reinterpret_cast<ROCKSDB_NAMESPACE::Snapshot*>(jsnapshot);
@@ -8431,7 +8398,7 @@ void Java_org_rocksdb_ReadOptions_setSnapshot(JNIEnv*, jobject, jlong jhandle,
  * Method:    snapshot
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_snapshot(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_ReadOptions_snapshot(JNIEnv*, jclass, jlong jhandle) {
   auto& snapshot =
       reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->snapshot;
   return GET_CPLUSPLUS_POINTER(snapshot);
@@ -8442,7 +8409,7 @@ jlong Java_org_rocksdb_ReadOptions_snapshot(JNIEnv*, jobject, jlong jhandle) {
  * Method:    readTier
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ReadOptions_readTier(JNIEnv*, jobject, jlong jhandle) {
+jbyte Java_org_rocksdb_ReadOptions_readTier(JNIEnv*, jclass, jlong jhandle) {
   return static_cast<jbyte>(
       reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->read_tier);
 }
@@ -8452,7 +8419,7 @@ jbyte Java_org_rocksdb_ReadOptions_readTier(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setReadTier
  * Signature: (JB)V
  */
-void Java_org_rocksdb_ReadOptions_setReadTier(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setReadTier(JNIEnv*, jclass, jlong jhandle,
                                               jbyte jread_tier) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)->read_tier =
       static_cast<ROCKSDB_NAMESPACE::ReadTier>(jread_tier);
@@ -8464,7 +8431,7 @@ void Java_org_rocksdb_ReadOptions_setReadTier(JNIEnv*, jobject, jlong jhandle,
  * Signature: (JJ)I
  */
 void Java_org_rocksdb_ReadOptions_setIterateUpperBound(
-    JNIEnv*, jobject, jlong jhandle, jlong jupper_bound_slice_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jupper_bound_slice_handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)
       ->iterate_upper_bound =
       reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(jupper_bound_slice_handle);
@@ -8475,7 +8442,7 @@ void Java_org_rocksdb_ReadOptions_setIterateUpperBound(
  * Method:    iterateUpperBound
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(JNIEnv*, jclass,
                                                      jlong jhandle) {
   auto& upper_bound_slice_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)
@@ -8489,7 +8456,7 @@ jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(JNIEnv*, jobject,
  * Signature: (JJ)I
  */
 void Java_org_rocksdb_ReadOptions_setIterateLowerBound(
-    JNIEnv*, jobject, jlong jhandle, jlong jlower_bound_slice_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jlower_bound_slice_handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)
       ->iterate_lower_bound =
       reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(jlower_bound_slice_handle);
@@ -8500,7 +8467,7 @@ void Java_org_rocksdb_ReadOptions_setIterateLowerBound(
  * Method:    iterateLowerBound
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_iterateLowerBound(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ReadOptions_iterateLowerBound(JNIEnv*, jclass,
                                                      jlong jhandle) {
   auto& lower_bound_slice_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle)
@@ -8514,7 +8481,7 @@ jlong Java_org_rocksdb_ReadOptions_iterateLowerBound(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ReadOptions_setTableFilter(
-    JNIEnv*, jobject, jlong jhandle, jlong jjni_table_filter_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jjni_table_filter_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   auto* jni_table_filter =
       reinterpret_cast<ROCKSDB_NAMESPACE::TableFilterJniCallback*>(
@@ -8527,7 +8494,7 @@ void Java_org_rocksdb_ReadOptions_setTableFilter(
  * Method:    autoPrefixMode
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_autoPrefixMode(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ReadOptions_autoPrefixMode(JNIEnv*, jclass,
                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   return static_cast<jboolean>(opt->auto_prefix_mode);
@@ -8539,7 +8506,7 @@ jboolean Java_org_rocksdb_ReadOptions_autoPrefixMode(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setAutoPrefixMode(
-    JNIEnv*, jobject, jlong jhandle, jboolean jauto_prefix_mode) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jauto_prefix_mode) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->auto_prefix_mode = static_cast<bool>(jauto_prefix_mode);
 }
@@ -8549,7 +8516,7 @@ void Java_org_rocksdb_ReadOptions_setAutoPrefixMode(
  * Method:    timestamp
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_timestamp(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_ReadOptions_timestamp(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   auto& timestamp_slice_handle = opt->timestamp;
   return reinterpret_cast<jlong>(timestamp_slice_handle);
@@ -8560,7 +8527,7 @@ jlong Java_org_rocksdb_ReadOptions_timestamp(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setTimestamp
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setTimestamp(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setTimestamp(JNIEnv*, jclass, jlong jhandle,
                                                jlong jtimestamp_slice_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->timestamp =
@@ -8572,8 +8539,7 @@ void Java_org_rocksdb_ReadOptions_setTimestamp(JNIEnv*, jobject, jlong jhandle,
  * Method:    iterStartTs
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_iterStartTs(JNIEnv*, jobject,
-                                               jlong jhandle) {
+jlong Java_org_rocksdb_ReadOptions_iterStartTs(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   auto& iter_start_ts_handle = opt->iter_start_ts;
   return reinterpret_cast<jlong>(iter_start_ts_handle);
@@ -8584,8 +8550,7 @@ jlong Java_org_rocksdb_ReadOptions_iterStartTs(JNIEnv*, jobject,
  * Method:    setIterStartTs
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setIterStartTs(JNIEnv*, jobject,
-                                                 jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setIterStartTs(JNIEnv*, jclass, jlong jhandle,
                                                  jlong jiter_start_ts_handle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->iter_start_ts =
@@ -8597,7 +8562,7 @@ void Java_org_rocksdb_ReadOptions_setIterStartTs(JNIEnv*, jobject,
  * Method:    deadline
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_deadline(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_ReadOptions_deadline(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   return static_cast<jlong>(opt->deadline.count());
 }
@@ -8607,7 +8572,7 @@ jlong Java_org_rocksdb_ReadOptions_deadline(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setDeadline
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setDeadline(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setDeadline(JNIEnv*, jclass, jlong jhandle,
                                               jlong jdeadline) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->deadline = std::chrono::microseconds(static_cast<int64_t>(jdeadline));
@@ -8618,7 +8583,7 @@ void Java_org_rocksdb_ReadOptions_setDeadline(JNIEnv*, jobject, jlong jhandle,
  * Method:    ioTimeout
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_ioTimeout(JNIEnv*, jobject, jlong jhandle) {
+jlong Java_org_rocksdb_ReadOptions_ioTimeout(JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   return static_cast<jlong>(opt->io_timeout.count());
 }
@@ -8628,7 +8593,7 @@ jlong Java_org_rocksdb_ReadOptions_ioTimeout(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setIoTimeout
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setIoTimeout(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setIoTimeout(JNIEnv*, jclass, jlong jhandle,
                                                jlong jio_timeout) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->io_timeout =
@@ -8640,7 +8605,7 @@ void Java_org_rocksdb_ReadOptions_setIoTimeout(JNIEnv*, jobject, jlong jhandle,
  * Method:    valueSizeSofLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_valueSizeSoftLimit(JNIEnv*, jobject,
+jlong Java_org_rocksdb_ReadOptions_valueSizeSoftLimit(JNIEnv*, jclass,
                                                       jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   return static_cast<jlong>(opt->value_size_soft_limit);
@@ -8652,7 +8617,7 @@ jlong Java_org_rocksdb_ReadOptions_valueSizeSoftLimit(JNIEnv*, jobject,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ReadOptions_setValueSizeSoftLimit(
-    JNIEnv*, jobject, jlong jhandle, jlong jvalue_size_soft_limit) {
+    JNIEnv*, jclass, jlong jhandle, jlong jvalue_size_soft_limit) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::ReadOptions*>(jhandle);
   opt->value_size_soft_limit = static_cast<uint64_t>(jvalue_size_soft_limit);
 }
@@ -8697,7 +8662,7 @@ jlong Java_org_rocksdb_ComparatorOptions_newComparatorOptions(JNIEnv*, jclass) {
  * Signature: (J)B
  */
 jbyte Java_org_rocksdb_ComparatorOptions_reusedSynchronisationType(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* comparator_opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::ComparatorJniCallbackOptions*>(
           jhandle);
@@ -8712,7 +8677,7 @@ jbyte Java_org_rocksdb_ComparatorOptions_reusedSynchronisationType(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ComparatorOptions_setReusedSynchronisationType(
-    JNIEnv*, jobject, jlong jhandle, jbyte jreused_synhcronisation_type) {
+    JNIEnv*, jclass, jlong jhandle, jbyte jreused_synhcronisation_type) {
   auto* comparator_opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::ComparatorJniCallbackOptions*>(
           jhandle);
@@ -8726,7 +8691,7 @@ void Java_org_rocksdb_ComparatorOptions_setReusedSynchronisationType(
  * Method:    useDirectBuffer
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ComparatorOptions_useDirectBuffer(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_ComparatorOptions_useDirectBuffer(JNIEnv*, jclass,
                                                             jlong jhandle) {
   return static_cast<jboolean>(
       reinterpret_cast<ROCKSDB_NAMESPACE::ComparatorJniCallbackOptions*>(
@@ -8740,7 +8705,7 @@ jboolean Java_org_rocksdb_ComparatorOptions_useDirectBuffer(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ComparatorOptions_setUseDirectBuffer(
-    JNIEnv*, jobject, jlong jhandle, jboolean jdirect_buffer) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jdirect_buffer) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ComparatorJniCallbackOptions*>(jhandle)
       ->direct_buffer = jdirect_buffer == JNI_TRUE;
 }
@@ -8750,7 +8715,7 @@ void Java_org_rocksdb_ComparatorOptions_setUseDirectBuffer(
  * Method:    maxReusedBufferSize
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ComparatorOptions_maxReusedBufferSize(JNIEnv*, jobject,
+jint Java_org_rocksdb_ComparatorOptions_maxReusedBufferSize(JNIEnv*, jclass,
                                                             jlong jhandle) {
   return static_cast<jint>(
       reinterpret_cast<ROCKSDB_NAMESPACE::ComparatorJniCallbackOptions*>(
@@ -8764,7 +8729,7 @@ jint Java_org_rocksdb_ComparatorOptions_maxReusedBufferSize(JNIEnv*, jobject,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ComparatorOptions_setMaxReusedBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jint jmax_reused_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jint jmax_reused_buffer_size) {
   reinterpret_cast<ROCKSDB_NAMESPACE::ComparatorJniCallbackOptions*>(jhandle)
       ->max_reused_buffer_size = static_cast<int32_t>(jmax_reused_buffer_size);
 }
@@ -8774,8 +8739,8 @@ void Java_org_rocksdb_ComparatorOptions_setMaxReusedBufferSize(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ComparatorOptions_disposeInternal(JNIEnv*, jobject,
-                                                        jlong jhandle) {
+void Java_org_rocksdb_ComparatorOptions_disposeInternalJni(JNIEnv*, jclass,
+                                                           jlong jhandle) {
   auto* comparator_opt =
       reinterpret_cast<ROCKSDB_NAMESPACE::ComparatorJniCallbackOptions*>(
           jhandle);
@@ -8801,7 +8766,7 @@ jlong Java_org_rocksdb_FlushOptions_newFlushOptions(JNIEnv*, jclass) {
  * Method:    setWaitForFlush
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_FlushOptions_setWaitForFlush(JNIEnv*, jobject,
+void Java_org_rocksdb_FlushOptions_setWaitForFlush(JNIEnv*, jclass,
                                                    jlong jhandle,
                                                    jboolean jwait) {
   reinterpret_cast<ROCKSDB_NAMESPACE::FlushOptions*>(jhandle)->wait =
@@ -8813,7 +8778,7 @@ void Java_org_rocksdb_FlushOptions_setWaitForFlush(JNIEnv*, jobject,
  * Method:    waitForFlush
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_FlushOptions_waitForFlush(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_FlushOptions_waitForFlush(JNIEnv*, jclass,
                                                     jlong jhandle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::FlushOptions*>(jhandle)->wait;
 }
@@ -8824,7 +8789,7 @@ jboolean Java_org_rocksdb_FlushOptions_waitForFlush(JNIEnv*, jobject,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_FlushOptions_setAllowWriteStall(
-    JNIEnv*, jobject, jlong jhandle, jboolean jallow_write_stall) {
+    JNIEnv*, jclass, jlong jhandle, jboolean jallow_write_stall) {
   auto* flush_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::FlushOptions*>(jhandle);
   flush_options->allow_write_stall = jallow_write_stall == JNI_TRUE;
@@ -8835,7 +8800,7 @@ void Java_org_rocksdb_FlushOptions_setAllowWriteStall(
  * Method:    allowWriteStall
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_FlushOptions_allowWriteStall(JNIEnv*, jobject,
+jboolean Java_org_rocksdb_FlushOptions_allowWriteStall(JNIEnv*, jclass,
                                                        jlong jhandle) {
   auto* flush_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::FlushOptions*>(jhandle);
@@ -8847,8 +8812,8 @@ jboolean Java_org_rocksdb_FlushOptions_allowWriteStall(JNIEnv*, jobject,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_FlushOptions_disposeInternal(JNIEnv*, jobject,
-                                                   jlong jhandle) {
+void Java_org_rocksdb_FlushOptions_disposeInternalJni(JNIEnv*, jclass,
+                                                      jlong jhandle) {
   auto* flush_opt = reinterpret_cast<ROCKSDB_NAMESPACE::FlushOptions*>(jhandle);
   assert(flush_opt != nullptr);
   delete flush_opt;

--- a/java/rocksjni/persistent_cache.cc
+++ b/java/rocksjni/persistent_cache.cc
@@ -51,8 +51,8 @@ jlong Java_org_rocksdb_PersistentCache_newPersistentCache(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_PersistentCache_disposeInternal(JNIEnv*, jobject,
-                                                      jlong jhandle) {
+void Java_org_rocksdb_PersistentCache_disposeInternalJni(JNIEnv*, jclass,
+                                                         jlong jhandle) {
   auto* cache =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::PersistentCache>*>(
           jhandle);

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -2140,8 +2140,8 @@ class JniUtil {
       std::function<ROCKSDB_NAMESPACE::Status(ROCKSDB_NAMESPACE::Slice,
                                               ROCKSDB_NAMESPACE::Slice)>
           op,
-      JNIEnv* env, jobject /*jobj*/, jbyteArray jkey, jint jkey_len,
-      jbyteArray jvalue, jint jvalue_len) {
+      JNIEnv* env, jbyteArray jkey, jint jkey_len, jbyteArray jvalue,
+      jint jvalue_len) {
     jbyte* key = env->GetByteArrayElements(jkey, nullptr);
     if (env->ExceptionCheck()) {
       // exception thrown: OutOfMemoryError
@@ -2182,7 +2182,7 @@ class JniUtil {
    */
   static std::unique_ptr<ROCKSDB_NAMESPACE::Status> k_op(
       std::function<ROCKSDB_NAMESPACE::Status(ROCKSDB_NAMESPACE::Slice)> op,
-      JNIEnv* env, jobject /*jobj*/, jbyteArray jkey, jint jkey_len) {
+      JNIEnv* env, jbyteArray jkey, jint jkey_len) {
     jbyte* key = env->GetByteArrayElements(jkey, nullptr);
     if (env->ExceptionCheck()) {
       // exception thrown: OutOfMemoryError

--- a/java/rocksjni/ratelimiterjni.cc
+++ b/java/rocksjni/ratelimiterjni.cc
@@ -36,9 +36,9 @@ jlong Java_org_rocksdb_RateLimiter_newRateLimiterHandle(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RateLimiter_disposeInternal(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
-                                                  jlong jhandle) {
+void Java_org_rocksdb_RateLimiter_disposeInternalJni(JNIEnv* /*env*/,
+                                                     jclass /*jcls*/,
+                                                     jlong jhandle) {
   auto* handle =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(
           jhandle);
@@ -51,7 +51,7 @@ void Java_org_rocksdb_RateLimiter_disposeInternal(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_RateLimiter_setBytesPerSecond(JNIEnv* /*env*/,
-                                                    jobject /*jobj*/,
+                                                    jclass /*jcls*/,
                                                     jlong handle,
                                                     jlong jbytes_per_second) {
   reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(handle)
@@ -65,7 +65,7 @@ void Java_org_rocksdb_RateLimiter_setBytesPerSecond(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_RateLimiter_getBytesPerSecond(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
+                                                     jclass /*jcls*/,
                                                      jlong handle) {
   return reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(
              handle)
@@ -78,7 +78,7 @@ jlong Java_org_rocksdb_RateLimiter_getBytesPerSecond(JNIEnv* /*env*/,
  * Method:    request
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_RateLimiter_request(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_RateLimiter_request(JNIEnv* /*env*/, jclass /*jcls*/,
                                           jlong handle, jlong jbytes) {
   reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(handle)
       ->get()
@@ -91,7 +91,7 @@ void Java_org_rocksdb_RateLimiter_request(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_RateLimiter_getSingleBurstBytes(JNIEnv* /*env*/,
-                                                       jobject /*jobj*/,
+                                                       jclass /*jcls*/,
                                                        jlong handle) {
   return reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(
              handle)
@@ -105,7 +105,7 @@ jlong Java_org_rocksdb_RateLimiter_getSingleBurstBytes(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_RateLimiter_getTotalBytesThrough(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
+                                                        jclass /*jcls*/,
                                                         jlong handle) {
   return reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(
              handle)
@@ -119,7 +119,7 @@ jlong Java_org_rocksdb_RateLimiter_getTotalBytesThrough(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_RateLimiter_getTotalRequests(JNIEnv* /*env*/,
-                                                    jobject /*jobj*/,
+                                                    jclass /*jcls*/,
                                                     jlong handle) {
   return reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::RateLimiter>*>(
              handle)

--- a/java/rocksjni/restorejni.cc
+++ b/java/rocksjni/restorejni.cc
@@ -33,9 +33,9 @@ jlong Java_org_rocksdb_RestoreOptions_newRestoreOptions(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RestoreOptions_disposeInternal(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
-                                                     jlong jhandle) {
+void Java_org_rocksdb_RestoreOptions_disposeInternalJni(JNIEnv* /*env*/,
+                                                        jclass /*jobj*/,
+                                                        jlong jhandle) {
   auto* ropt = reinterpret_cast<ROCKSDB_NAMESPACE::RestoreOptions*>(jhandle);
   assert(ropt);
   delete ropt;

--- a/java/rocksjni/rocks_callback_object.cc
+++ b/java/rocksjni/rocks_callback_object.cc
@@ -17,7 +17,7 @@
  * Signature: (J)V
  */
 void Java_org_rocksdb_RocksCallbackObject_disposeInternal(JNIEnv* /*env*/,
-                                                          jobject /*jobj*/,
+                                                          jclass /*jcls*/,
                                                           jlong handle) {
   // TODO(AR) is deleting from the super class JniCallback OK, or must we delete
   // the subclass? Example hierarchies:

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -3245,8 +3245,7 @@ jstring Java_org_rocksdb_RocksDB_getDBOptions(JNIEnv* env, jclass,
  * Method:    setPerfLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_RocksDB_setPerfLevel(JNIEnv*, jclass,
-                                           jbyte jperf_level) {
+void Java_org_rocksdb_RocksDB_setPerfLevel(JNIEnv*, jclass, jbyte jperf_level) {
   rocksdb::SetPerfLevel(
       ROCKSDB_NAMESPACE::PerfLevelTypeJni::toCppPerfLevelType(jperf_level));
 }

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -291,7 +291,8 @@ Java_org_rocksdb_RocksDB_openAsSecondary__JLjava_lang_String_2Ljava_lang_String_
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_disposeInternal(JNIEnv*, jobject, jlong jhandle) {
+void Java_org_rocksdb_RocksDB_disposeInternalJni(JNIEnv*, jclass,
+                                                 jlong jhandle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jhandle);
   assert(db != nullptr);
   delete db;
@@ -342,7 +343,7 @@ jobjectArray Java_org_rocksdb_RocksDB_listColumnFamilies(JNIEnv* env, jclass,
  * Method:    createColumnFamily
  * Signature: (J[BIJ)J
  */
-jlong Java_org_rocksdb_RocksDB_createColumnFamily(JNIEnv* env, jobject,
+jlong Java_org_rocksdb_RocksDB_createColumnFamily(JNIEnv* env, jclass,
                                                   jlong jhandle,
                                                   jbyteArray jcf_name,
                                                   jint jcf_name_len,
@@ -379,7 +380,7 @@ jlong Java_org_rocksdb_RocksDB_createColumnFamily(JNIEnv* env, jobject,
  * Signature: (JJ[[B)[J
  */
 jlongArray Java_org_rocksdb_RocksDB_createColumnFamilies__JJ_3_3B(
-    JNIEnv* env, jobject, jlong jhandle, jlong jcf_options_handle,
+    JNIEnv* env, jclass, jlong jhandle, jlong jcf_options_handle,
     jobjectArray jcf_names) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jhandle);
   auto* cf_options = reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(
@@ -420,7 +421,7 @@ jlongArray Java_org_rocksdb_RocksDB_createColumnFamilies__JJ_3_3B(
  * Signature: (J[J[[B)[J
  */
 jlongArray Java_org_rocksdb_RocksDB_createColumnFamilies__J_3J_3_3B(
-    JNIEnv* env, jobject, jlong jhandle, jlongArray jcf_options_handles,
+    JNIEnv* env, jclass, jlong jhandle, jlongArray jcf_options_handles,
     jobjectArray jcf_names) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jhandle);
   const jsize jlen = env->GetArrayLength(jcf_options_handles);
@@ -497,7 +498,7 @@ jlongArray Java_org_rocksdb_RocksDB_createColumnFamilies__J_3J_3_3B(
  * Signature: (J[BIJJ[J)J
  */
 jlong Java_org_rocksdb_RocksDB_createColumnFamilyWithImport(
-    JNIEnv* env, jobject, jlong jdb_handle, jbyteArray jcf_name,
+    JNIEnv* env, jclass, jlong jdb_handle, jbyteArray jcf_name,
     jint jcf_name_len, jlong j_cf_options, jlong j_cf_import_options,
     jlongArray j_metadata_handle_array) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -553,7 +554,7 @@ jlong Java_org_rocksdb_RocksDB_createColumnFamilyWithImport(
  * Method:    dropColumnFamily
  * Signature: (JJ)V;
  */
-void Java_org_rocksdb_RocksDB_dropColumnFamily(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_dropColumnFamily(JNIEnv* env, jclass,
                                                jlong jdb_handle,
                                                jlong jcf_handle) {
   auto* db_handle = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -571,7 +572,7 @@ void Java_org_rocksdb_RocksDB_dropColumnFamily(JNIEnv* env, jobject,
  * Signature: (J[J)V
  */
 void Java_org_rocksdb_RocksDB_dropColumnFamilies(
-    JNIEnv* env, jobject, jlong jdb_handle, jlongArray jcolumn_family_handles) {
+    JNIEnv* env, jclass, jlong jdb_handle, jlongArray jcolumn_family_handles) {
   auto* db_handle = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
 
   std::vector<ROCKSDB_NAMESPACE::ColumnFamilyHandle*> cf_handles;
@@ -606,7 +607,7 @@ void Java_org_rocksdb_RocksDB_dropColumnFamilies(
  * Method:    put
  * Signature: (J[BII[BII)V
  */
-void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jclass,
                                                jlong jdb_handle,
                                                jbyteArray jkey, jint jkey_off,
                                                jint jkey_len, jbyteArray jval,
@@ -629,7 +630,7 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jobject,
  * Method:    put
  * Signature: (J[BII[BIIJ)V
  */
-void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jclass,
                                                 jlong jdb_handle,
                                                 jbyteArray jkey, jint jkey_off,
                                                 jint jkey_len, jbyteArray jval,
@@ -663,7 +664,7 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject,
  * Method:    put
  * Signature: (JJ[BII[BII)V
  */
-void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jclass,
                                                 jlong jdb_handle,
                                                 jlong jwrite_options_handle,
                                                 jbyteArray jkey, jint jkey_off,
@@ -689,7 +690,7 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jobject,
  * Signature: (JJ[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jwrite_options_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jwrite_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jbyteArray jval,
     jint jval_off, jint jval_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -719,7 +720,7 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BIIJ(
  * Signature: (JJLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)V
  */
 void Java_org_rocksdb_RocksDB_putDirect(
-    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
+    JNIEnv* env, jclass /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
     jobject jkey, jint jkey_off, jint jkey_len, jobject jval, jint jval_off,
     jint jval_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -788,7 +789,7 @@ bool rocksdb_delete_helper(JNIEnv* env, ROCKSDB_NAMESPACE::DB* db,
  * Method:    delete
  * Signature: (J[BII)V
  */
-void Java_org_rocksdb_RocksDB_delete__J_3BII(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_delete__J_3BII(JNIEnv* env, jclass,
                                              jlong jdb_handle, jbyteArray jkey,
                                              jint jkey_off, jint jkey_len) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -803,7 +804,7 @@ void Java_org_rocksdb_RocksDB_delete__J_3BII(JNIEnv* env, jobject,
  * Method:    delete
  * Signature: (J[BIIJ)V
  */
-void Java_org_rocksdb_RocksDB_delete__J_3BIIJ(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_delete__J_3BIIJ(JNIEnv* env, jclass,
                                               jlong jdb_handle, jbyteArray jkey,
                                               jint jkey_off, jint jkey_len,
                                               jlong jcf_handle) {
@@ -827,7 +828,7 @@ void Java_org_rocksdb_RocksDB_delete__J_3BIIJ(JNIEnv* env, jobject,
  * Method:    delete
  * Signature: (JJ[BII)V
  */
-void Java_org_rocksdb_RocksDB_delete__JJ_3BII(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_delete__JJ_3BII(JNIEnv* env, jclass,
                                               jlong jdb_handle,
                                               jlong jwrite_options,
                                               jbyteArray jkey, jint jkey_off,
@@ -845,7 +846,7 @@ void Java_org_rocksdb_RocksDB_delete__JJ_3BII(JNIEnv* env, jobject,
  * Signature: (JJ[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_delete__JJ_3BIIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jwrite_options,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jwrite_options,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto* write_options =
@@ -905,7 +906,7 @@ bool rocksdb_single_delete_helper(
  * Method:    singleDelete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_RocksDB_singleDelete__J_3BI(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_singleDelete__J_3BI(JNIEnv* env, jclass,
                                                   jlong jdb_handle,
                                                   jbyteArray jkey,
                                                   jint jkey_len) {
@@ -921,7 +922,7 @@ void Java_org_rocksdb_RocksDB_singleDelete__J_3BI(JNIEnv* env, jobject,
  * Method:    singleDelete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_RocksDB_singleDelete__J_3BIJ(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_singleDelete__J_3BIJ(JNIEnv* env, jclass,
                                                    jlong jdb_handle,
                                                    jbyteArray jkey,
                                                    jint jkey_len,
@@ -946,7 +947,7 @@ void Java_org_rocksdb_RocksDB_singleDelete__J_3BIJ(JNIEnv* env, jobject,
  * Method:    singleDelete
  * Signature: (JJ[BIJ)V
  */
-void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BI(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BI(JNIEnv* env, jclass,
                                                    jlong jdb_handle,
                                                    jlong jwrite_options,
                                                    jbyteArray jkey,
@@ -964,7 +965,7 @@ void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BI(JNIEnv* env, jobject,
  * Signature: (JJ[BIJ)V
  */
 void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jwrite_options,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jwrite_options,
     jbyteArray jkey, jint jkey_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto* write_options =
@@ -1041,7 +1042,7 @@ bool rocksdb_delete_range_helper(
  * Signature: (J[BII[BII)V
  */
 void Java_org_rocksdb_RocksDB_deleteRange__J_3BII_3BII(
-    JNIEnv* env, jobject, jlong jdb_handle, jbyteArray jbegin_key,
+    JNIEnv* env, jclass, jlong jdb_handle, jbyteArray jbegin_key,
     jint jbegin_key_off, jint jbegin_key_len, jbyteArray jend_key,
     jint jend_key_off, jint jend_key_len) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1145,7 +1146,7 @@ jint rocksdb_get_helper_direct(
  * Signature: (J[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_deleteRange__J_3BII_3BIIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jbyteArray jbegin_key,
+    JNIEnv* env, jclass, jlong jdb_handle, jbyteArray jbegin_key,
     jint jbegin_key_off, jint jbegin_key_len, jbyteArray jend_key,
     jint jend_key_off, jint jend_key_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1170,7 +1171,7 @@ void Java_org_rocksdb_RocksDB_deleteRange__J_3BII_3BIIJ(
  * Signature: (JJ[BII[BII)V
  */
 void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BII(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jwrite_options,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jwrite_options,
     jbyteArray jbegin_key, jint jbegin_key_off, jint jbegin_key_len,
     jbyteArray jend_key, jint jend_key_off, jint jend_key_len) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1187,7 +1188,7 @@ void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BII(
  * Signature: (JJ[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jwrite_options,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jwrite_options,
     jbyteArray jbegin_key, jint jbegin_key_off, jint jbegin_key_len,
     jbyteArray jend_key, jint jend_key_off, jint jend_key_len,
     jlong jcf_handle) {
@@ -1213,7 +1214,7 @@ void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BIIJ(
  * Signature: (JJ[BII[BII)V
  */
 void Java_org_rocksdb_RocksDB_clipColumnFamily(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jbyteArray jbegin_key, jint jbegin_key_off, jint jbegin_key_len,
     jbyteArray jend_key, jint jend_key_off, jint jend_key_len) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1267,7 +1268,7 @@ void Java_org_rocksdb_RocksDB_clipColumnFamily(
  * Method:    getDirect
  * Signature: (JJLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)I
  */
-jint Java_org_rocksdb_RocksDB_getDirect(JNIEnv* env, jobject /*jdb*/,
+jint Java_org_rocksdb_RocksDB_getDirect(JNIEnv* env, jclass /*jdb*/,
                                         jlong jdb_handle, jlong jropt_handle,
                                         jobject jkey, jint jkey_off,
                                         jint jkey_len, jobject jval,
@@ -1293,7 +1294,7 @@ jint Java_org_rocksdb_RocksDB_getDirect(JNIEnv* env, jobject /*jdb*/,
  * Method:    merge
  * Signature: (J[BII[BII)V
  */
-void Java_org_rocksdb_RocksDB_merge__J_3BII_3BII(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_merge__J_3BII_3BII(JNIEnv* env, jclass,
                                                  jlong jdb_handle,
                                                  jbyteArray jkey, jint jkey_off,
                                                  jint jkey_len, jbyteArray jval,
@@ -1317,7 +1318,7 @@ void Java_org_rocksdb_RocksDB_merge__J_3BII_3BII(JNIEnv* env, jobject,
  * Signature: (J[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_merge__J_3BII_3BIIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jbyteArray jkey, jint jkey_off,
+    JNIEnv* env, jclass, jlong jdb_handle, jbyteArray jkey, jint jkey_off,
     jint jkey_len, jbyteArray jval, jint jval_off, jint jval_len,
     jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1348,7 +1349,7 @@ void Java_org_rocksdb_RocksDB_merge__J_3BII_3BIIJ(
  * Signature: (JJ[BII[BII)V
  */
 void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BII(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jwrite_options_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jwrite_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jbyteArray jval,
     jint jval_off, jint jval_len) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1370,7 +1371,7 @@ void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BII(
  * Signature: (JJ[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jwrite_options_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jwrite_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jbyteArray jval,
     jint jval_off, jint jval_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1401,7 +1402,7 @@ void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BIIJ(
  * Signature: (JJLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)V
  */
 void Java_org_rocksdb_RocksDB_mergeDirect(
-    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
+    JNIEnv* env, jclass /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
     jobject jkey, jint jkey_off, jint jkey_len, jobject jval, jint jval_off,
     jint jval_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1433,7 +1434,7 @@ void Java_org_rocksdb_RocksDB_mergeDirect(
  * Method:    deleteDirect
  * Signature: (JJLjava/nio/ByteBuffer;IIJ)V
  */
-void Java_org_rocksdb_RocksDB_deleteDirect(JNIEnv* env, jobject /*jdb*/,
+void Java_org_rocksdb_RocksDB_deleteDirect(JNIEnv* env, jclass /*jdb*/,
                                            jlong jdb_handle,
                                            jlong jwrite_options, jobject jkey,
                                            jint jkey_offset, jint jkey_len,
@@ -1467,7 +1468,7 @@ void Java_org_rocksdb_RocksDB_deleteDirect(JNIEnv* env, jobject /*jdb*/,
  * Method:    write0
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_RocksDB_write0(JNIEnv* env, jobject, jlong jdb_handle,
+void Java_org_rocksdb_RocksDB_write0(JNIEnv* env, jclass, jlong jdb_handle,
                                      jlong jwrite_options_handle,
                                      jlong jwb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1487,7 +1488,7 @@ void Java_org_rocksdb_RocksDB_write0(JNIEnv* env, jobject, jlong jdb_handle,
  * Method:    write1
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_RocksDB_write1(JNIEnv* env, jobject, jlong jdb_handle,
+void Java_org_rocksdb_RocksDB_write1(JNIEnv* env, jclass, jlong jdb_handle,
                                      jlong jwrite_options_handle,
                                      jlong jwbwi_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1558,7 +1559,7 @@ jbyteArray rocksdb_get_helper(
  * Method:    get
  * Signature: (J[BII)[B
  */
-jbyteArray Java_org_rocksdb_RocksDB_get__J_3BII(JNIEnv* env, jobject,
+jbyteArray Java_org_rocksdb_RocksDB_get__J_3BII(JNIEnv* env, jclass,
                                                 jlong jdb_handle,
                                                 jbyteArray jkey, jint jkey_off,
                                                 jint jkey_len) {
@@ -1572,7 +1573,7 @@ jbyteArray Java_org_rocksdb_RocksDB_get__J_3BII(JNIEnv* env, jobject,
  * Method:    get
  * Signature: (J[BIIJ)[B
  */
-jbyteArray Java_org_rocksdb_RocksDB_get__J_3BIIJ(JNIEnv* env, jobject,
+jbyteArray Java_org_rocksdb_RocksDB_get__J_3BIIJ(JNIEnv* env, jclass,
                                                  jlong jdb_handle,
                                                  jbyteArray jkey, jint jkey_off,
                                                  jint jkey_len,
@@ -1596,7 +1597,7 @@ jbyteArray Java_org_rocksdb_RocksDB_get__J_3BIIJ(JNIEnv* env, jobject,
  * Method:    get
  * Signature: (JJ[BII)[B
  */
-jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BII(JNIEnv* env, jobject,
+jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BII(JNIEnv* env, jclass,
                                                  jlong jdb_handle,
                                                  jlong jropt_handle,
                                                  jbyteArray jkey, jint jkey_off,
@@ -1613,7 +1614,7 @@ jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BII(JNIEnv* env, jobject,
  * Signature: (JJ[BIIJ)[B
  */
 jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BIIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jropt_handle, jbyteArray jkey,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jropt_handle, jbyteArray jkey,
     jint jkey_off, jint jkey_len, jlong jcf_handle) {
   auto* db_handle = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto& ro_opt =
@@ -1701,7 +1702,7 @@ jint rocksdb_get_helper(
  * Method:    get
  * Signature: (J[BII[BII)I
  */
-jint Java_org_rocksdb_RocksDB_get__J_3BII_3BII(JNIEnv* env, jobject,
+jint Java_org_rocksdb_RocksDB_get__J_3BII_3BII(JNIEnv* env, jclass,
                                                jlong jdb_handle,
                                                jbyteArray jkey, jint jkey_off,
                                                jint jkey_len, jbyteArray jval,
@@ -1718,7 +1719,7 @@ jint Java_org_rocksdb_RocksDB_get__J_3BII_3BII(JNIEnv* env, jobject,
  * Method:    get
  * Signature: (J[BII[BIIJ)I
  */
-jint Java_org_rocksdb_RocksDB_get__J_3BII_3BIIJ(JNIEnv* env, jobject,
+jint Java_org_rocksdb_RocksDB_get__J_3BII_3BIIJ(JNIEnv* env, jclass,
                                                 jlong jdb_handle,
                                                 jbyteArray jkey, jint jkey_off,
                                                 jint jkey_len, jbyteArray jval,
@@ -1746,7 +1747,7 @@ jint Java_org_rocksdb_RocksDB_get__J_3BII_3BIIJ(JNIEnv* env, jobject,
  * Method:    get
  * Signature: (JJ[BII[BII)I
  */
-jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BII(JNIEnv* env, jobject,
+jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BII(JNIEnv* env, jclass,
                                                 jlong jdb_handle,
                                                 jlong jropt_handle,
                                                 jbyteArray jkey, jint jkey_off,
@@ -1765,7 +1766,7 @@ jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BII(JNIEnv* env, jobject,
  * Signature: (JJ[BII[BIIJ)I
  */
 jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jropt_handle, jbyteArray jkey,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jropt_handle, jbyteArray jkey,
     jint jkey_off, jint jkey_len, jbyteArray jval, jint jval_off, jint jval_len,
     jlong jcf_handle) {
   auto* db_handle = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -1960,7 +1961,7 @@ inline bool keys_from_bytebuffers(JNIEnv* env,
  * @return byte[][] of values or nullptr if an
  * exception occurs
  */
-jobjectArray multi_get_helper(JNIEnv* env, jobject, ROCKSDB_NAMESPACE::DB* db,
+jobjectArray multi_get_helper(JNIEnv* env, jclass, ROCKSDB_NAMESPACE::DB* db,
                               const ROCKSDB_NAMESPACE::ReadOptions& rOpt,
                               jobjectArray jkeys, jintArray jkey_offs,
                               jintArray jkey_lens,
@@ -2055,7 +2056,7 @@ jobjectArray multi_get_helper(JNIEnv* env, jobject, ROCKSDB_NAMESPACE::DB* db,
  * @param jvalue_sizes returned actual sizes of data values for keys
  * @param jstatuses returned java RocksDB status values for per key
  */
-void multi_get_helper_direct(JNIEnv* env, jobject, ROCKSDB_NAMESPACE::DB* db,
+void multi_get_helper_direct(JNIEnv* env, jclass, ROCKSDB_NAMESPACE::DB* db,
                              const ROCKSDB_NAMESPACE::ReadOptions& rOpt,
                              jlongArray jcolumn_family_handles,
                              jobjectArray jkeys, jintArray jkey_offsets,
@@ -2155,7 +2156,7 @@ void multi_get_helper_direct(JNIEnv* env, jobject, ROCKSDB_NAMESPACE::DB* db,
  * Signature: (J[[B[I[I)[[B
  */
 jobjectArray Java_org_rocksdb_RocksDB_multiGet__J_3_3B_3I_3I(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jobjectArray jkeys,
+    JNIEnv* env, jclass jdb, jlong jdb_handle, jobjectArray jkeys,
     jintArray jkey_offs, jintArray jkey_lens) {
   return multi_get_helper(
       env, jdb, reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle),
@@ -2168,7 +2169,7 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__J_3_3B_3I_3I(
  * Signature: (J[[B[I[I[J)[[B
  */
 jobjectArray Java_org_rocksdb_RocksDB_multiGet__J_3_3B_3I_3I_3J(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jobjectArray jkeys,
+    JNIEnv* env, jclass jdb, jlong jdb_handle, jobjectArray jkeys,
     jintArray jkey_offs, jintArray jkey_lens,
     jlongArray jcolumn_family_handles) {
   return multi_get_helper(env, jdb,
@@ -2183,7 +2184,7 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__J_3_3B_3I_3I_3J(
  * Signature: (JJ[[B[I[I)[[B
  */
 jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jropt_handle,
+    JNIEnv* env, jclass jdb, jlong jdb_handle, jlong jropt_handle,
     jobjectArray jkeys, jintArray jkey_offs, jintArray jkey_lens) {
   return multi_get_helper(
       env, jdb, reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle),
@@ -2197,7 +2198,7 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I(
  * Signature: (JJ[[B[I[I[J)[[B
  */
 jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I_3J(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jropt_handle,
+    JNIEnv* env, jclass jdb, jlong jdb_handle, jlong jropt_handle,
     jobjectArray jkeys, jintArray jkey_offs, jintArray jkey_lens,
     jlongArray jcolumn_family_handles) {
   return multi_get_helper(
@@ -2213,7 +2214,7 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I_3J(
  * (JJ[J[Ljava/nio/ByteBuffer;[I[I[Ljava/nio/ByteBuffer;[I[Lorg/rocksdb/Status;)V
  */
 void Java_org_rocksdb_RocksDB_multiGet__JJ_3J_3Ljava_nio_ByteBuffer_2_3I_3I_3Ljava_nio_ByteBuffer_2_3I_3Lorg_rocksdb_Status_2(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jropt_handle,
+    JNIEnv* env, jclass jdb, jlong jdb_handle, jlong jropt_handle,
     jlongArray jcolumn_family_handles, jobjectArray jkeys,
     jintArray jkey_offsets, jintArray jkey_lengths, jobjectArray jvalues,
     jintArray jvalues_sizes, jobjectArray jstatus_objects) {
@@ -2361,7 +2362,7 @@ jboolean key_exists_helper(JNIEnv* env, jlong jdb_handle, jlong jcf_handle,
  * Method:    keyExist
  * Signature: (JJJ[BII)Z
  */
-jboolean Java_org_rocksdb_RocksDB_keyExists(JNIEnv* env, jobject,
+jboolean Java_org_rocksdb_RocksDB_keyExists(JNIEnv* env, jclass,
                                             jlong jdb_handle, jlong jcf_handle,
                                             jlong jread_opts_handle,
                                             jbyteArray jkey, jint jkey_offset,
@@ -2392,7 +2393,7 @@ jboolean Java_org_rocksdb_RocksDB_keyExists(JNIEnv* env, jobject,
  * Signature: (JJJLjava/nio/ByteBuffer;II)Z
  */
 jboolean Java_org_rocksdb_RocksDB_keyExistsDirect(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jlong jread_opts_handle, jobject jkey, jint jkey_offset, jint jkey_len) {
   char* key = reinterpret_cast<char*>(env->GetDirectBufferAddress(jkey));
   if (key == nullptr) {
@@ -2419,7 +2420,7 @@ jboolean Java_org_rocksdb_RocksDB_keyExistsDirect(
  * Signature: (JJJ[BII)Z
  */
 jboolean Java_org_rocksdb_RocksDB_keyMayExist(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jlong jread_opts_handle, jbyteArray jkey, jint jkey_offset, jint jkey_len) {
   bool has_exception = false;
   std::string value;
@@ -2443,7 +2444,7 @@ jboolean Java_org_rocksdb_RocksDB_keyMayExist(
  * Signature: (JJJLjava/nio/ByteBuffer;II)Z
  */
 jboolean Java_org_rocksdb_RocksDB_keyMayExistDirect(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jlong jread_opts_handle, jobject jkey, jint jkey_offset, jint jkey_len) {
   bool has_exception = false;
   std::string value;
@@ -2467,7 +2468,7 @@ jboolean Java_org_rocksdb_RocksDB_keyMayExistDirect(
  * (JJJLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)[J
  */
 jintArray Java_org_rocksdb_RocksDB_keyMayExistDirectFoundValue(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jlong jread_opts_handle, jobject jkey, jint jkey_offset, jint jkey_len,
     jobject jval, jint jval_offset, jint jval_len) {
   char* val_buffer = reinterpret_cast<char*>(env->GetDirectBufferAddress(jval));
@@ -2538,7 +2539,7 @@ jintArray Java_org_rocksdb_RocksDB_keyMayExistDirectFoundValue(
  * Signature: (JJJ[BII)[[B
  */
 jobjectArray Java_org_rocksdb_RocksDB_keyMayExistFoundValue(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jlong jread_opts_handle, jbyteArray jkey, jint jkey_offset, jint jkey_len) {
   bool has_exception = false;
   std::string value;
@@ -2625,7 +2626,7 @@ jobjectArray Java_org_rocksdb_RocksDB_keyMayExistFoundValue(
  * Method:    iterator
  * Signature: (JJJ)J
  */
-jlong Java_org_rocksdb_RocksDB_iterator(JNIEnv*, jobject, jlong db_handle,
+jlong Java_org_rocksdb_RocksDB_iterator(JNIEnv*, jclass, jlong db_handle,
                                         jlong jcf_handle,
                                         jlong jread_options_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(db_handle);
@@ -2641,7 +2642,7 @@ jlong Java_org_rocksdb_RocksDB_iterator(JNIEnv*, jobject, jlong db_handle,
  * Method:    iterators
  * Signature: (J[JJ)[J
  */
-jlongArray Java_org_rocksdb_RocksDB_iterators(JNIEnv* env, jobject,
+jlongArray Java_org_rocksdb_RocksDB_iterators(JNIEnv* env, jclass,
                                               jlong db_handle,
                                               jlongArray jcolumn_family_handles,
                                               jlong jread_options_handle) {
@@ -2701,7 +2702,7 @@ jlongArray Java_org_rocksdb_RocksDB_iterators(JNIEnv* env, jobject,
  * Method:    getSnapshot
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RocksDB_getSnapshot(JNIEnv*, jobject, jlong db_handle) {
+jlong Java_org_rocksdb_RocksDB_getSnapshot(JNIEnv*, jclass, jlong db_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(db_handle);
   const ROCKSDB_NAMESPACE::Snapshot* snapshot = db->GetSnapshot();
   return GET_CPLUSPLUS_POINTER(snapshot);
@@ -2711,7 +2712,7 @@ jlong Java_org_rocksdb_RocksDB_getSnapshot(JNIEnv*, jobject, jlong db_handle) {
  * Method:    releaseSnapshot
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_RocksDB_releaseSnapshot(JNIEnv*, jobject, jlong db_handle,
+void Java_org_rocksdb_RocksDB_releaseSnapshot(JNIEnv*, jclass, jlong db_handle,
                                               jlong snapshot_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(db_handle);
   auto* snapshot =
@@ -2724,7 +2725,7 @@ void Java_org_rocksdb_RocksDB_releaseSnapshot(JNIEnv*, jobject, jlong db_handle,
  * Method:    getProperty
  * Signature: (JJLjava/lang/String;I)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_RocksDB_getProperty(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_RocksDB_getProperty(JNIEnv* env, jclass,
                                              jlong jdb_handle, jlong jcf_handle,
                                              jstring jproperty,
                                              jint jproperty_len) {
@@ -2762,7 +2763,7 @@ jstring Java_org_rocksdb_RocksDB_getProperty(JNIEnv* env, jobject,
  * Method:    getMapProperty
  * Signature: (JJLjava/lang/String;I)Ljava/util/Map;
  */
-jobject Java_org_rocksdb_RocksDB_getMapProperty(JNIEnv* env, jobject,
+jobject Java_org_rocksdb_RocksDB_getMapProperty(JNIEnv* env, jclass,
                                                 jlong jdb_handle,
                                                 jlong jcf_handle,
                                                 jstring jproperty,
@@ -2801,7 +2802,7 @@ jobject Java_org_rocksdb_RocksDB_getMapProperty(JNIEnv* env, jobject,
  * Method:    getLongProperty
  * Signature: (JJLjava/lang/String;I)J
  */
-jlong Java_org_rocksdb_RocksDB_getLongProperty(JNIEnv* env, jobject,
+jlong Java_org_rocksdb_RocksDB_getLongProperty(JNIEnv* env, jclass,
                                                jlong jdb_handle,
                                                jlong jcf_handle,
                                                jstring jproperty,
@@ -2840,7 +2841,7 @@ jlong Java_org_rocksdb_RocksDB_getLongProperty(JNIEnv* env, jobject,
  * Method:    resetStats
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_resetStats(JNIEnv*, jobject, jlong jdb_handle) {
+void Java_org_rocksdb_RocksDB_resetStats(JNIEnv*, jclass, jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   db->ResetStats();
 }
@@ -2850,7 +2851,7 @@ void Java_org_rocksdb_RocksDB_resetStats(JNIEnv*, jobject, jlong jdb_handle) {
  * Method:    getAggregatedLongProperty
  * Signature: (JLjava/lang/String;I)J
  */
-jlong Java_org_rocksdb_RocksDB_getAggregatedLongProperty(JNIEnv* env, jobject,
+jlong Java_org_rocksdb_RocksDB_getAggregatedLongProperty(JNIEnv* env, jclass,
                                                          jlong db_handle,
                                                          jstring jproperty,
                                                          jint jproperty_len) {
@@ -2879,7 +2880,7 @@ jlong Java_org_rocksdb_RocksDB_getAggregatedLongProperty(JNIEnv* env, jobject,
  * Signature: (JJ[JB)[J
  */
 jlongArray Java_org_rocksdb_RocksDB_getApproximateSizes(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jlongArray jrange_slice_handles, jbyte jinclude_flags) {
   const jsize jlen = env->GetArrayLength(jrange_slice_handles);
   const size_t range_count = jlen / 2;
@@ -2958,8 +2959,8 @@ jlongArray Java_org_rocksdb_RocksDB_getApproximateSizes(
  * Signature: (JJJJ)[J
  */
 jlongArray Java_org_rocksdb_RocksDB_getApproximateMemTableStats(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
-    jlong jstartHandle, jlong jlimitHandle) {
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle, jlong jstartHandle,
+    jlong jlimitHandle) {
   auto* start = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(jstartHandle);
   auto* limit = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(jlimitHandle);
   const ROCKSDB_NAMESPACE::Range range(*start, *limit);
@@ -3001,7 +3002,7 @@ jlongArray Java_org_rocksdb_RocksDB_getApproximateMemTableStats(
  * Method:    compactRange
  * Signature: (J[BI[BIJJ)V
  */
-void Java_org_rocksdb_RocksDB_compactRange(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_compactRange(JNIEnv* env, jclass,
                                            jlong jdb_handle, jbyteArray jbegin,
                                            jint jbegin_len, jbyteArray jend,
                                            jint jend_len,
@@ -3074,7 +3075,7 @@ void Java_org_rocksdb_RocksDB_compactRange(JNIEnv* env, jobject,
  * Method:    setOptions
  * Signature: (JJ[Ljava/lang/String;[Ljava/lang/String;)V
  */
-void Java_org_rocksdb_RocksDB_setOptions(JNIEnv* env, jobject, jlong jdb_handle,
+void Java_org_rocksdb_RocksDB_setOptions(JNIEnv* env, jclass, jlong jdb_handle,
                                          jlong jcf_handle, jobjectArray jkeys,
                                          jobjectArray jvalues) {
   const jsize len = env->GetArrayLength(jkeys);
@@ -3137,7 +3138,7 @@ void Java_org_rocksdb_RocksDB_setOptions(JNIEnv* env, jobject, jlong jdb_handle,
  * Method:    setDBOptions
  * Signature: (J[Ljava/lang/String;[Ljava/lang/String;)V
  */
-void Java_org_rocksdb_RocksDB_setDBOptions(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_setDBOptions(JNIEnv* env, jclass,
                                            jlong jdb_handle, jobjectArray jkeys,
                                            jobjectArray jvalues) {
   const jsize len = env->GetArrayLength(jkeys);
@@ -3195,7 +3196,7 @@ void Java_org_rocksdb_RocksDB_setDBOptions(JNIEnv* env, jobject,
  * Method:    getOptions
  * Signature: (JJ)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_RocksDB_getOptions(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_RocksDB_getOptions(JNIEnv* env, jclass,
                                             jlong jdb_handle,
                                             jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3224,7 +3225,7 @@ jstring Java_org_rocksdb_RocksDB_getOptions(JNIEnv* env, jobject,
  * Method:    getDBOptions
  * Signature: (J)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_RocksDB_getDBOptions(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_RocksDB_getDBOptions(JNIEnv* env, jclass,
                                               jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
 
@@ -3244,7 +3245,7 @@ jstring Java_org_rocksdb_RocksDB_getDBOptions(JNIEnv* env, jobject,
  * Method:    setPerfLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_RocksDB_setPerfLevel(JNIEnv*, jobject,
+void Java_org_rocksdb_RocksDB_setPerfLevel(JNIEnv*, jclass,
                                            jbyte jperf_level) {
   rocksdb::SetPerfLevel(
       ROCKSDB_NAMESPACE::PerfLevelTypeJni::toCppPerfLevelType(jperf_level));
@@ -3255,7 +3256,7 @@ void Java_org_rocksdb_RocksDB_setPerfLevel(JNIEnv*, jobject,
  * Method:    getPerfLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_RocksDB_getPerfLevelNative(JNIEnv*, jobject) {
+jbyte Java_org_rocksdb_RocksDB_getPerfLevelNative(JNIEnv*, jclass) {
   return ROCKSDB_NAMESPACE::PerfLevelTypeJni::toJavaPerfLevelType(
       rocksdb::GetPerfLevel());
 }
@@ -3265,7 +3266,7 @@ jbyte Java_org_rocksdb_RocksDB_getPerfLevelNative(JNIEnv*, jobject) {
  * Method:    getPerfContextNative
  * Signature: ()J
  */
-jlong Java_org_rocksdb_RocksDB_getPerfContextNative(JNIEnv*, jobject) {
+jlong Java_org_rocksdb_RocksDB_getPerfContextNative(JNIEnv*, jclass) {
   ROCKSDB_NAMESPACE::PerfContext* perf_context = rocksdb::get_perf_context();
   return reinterpret_cast<jlong>(perf_context);
 }
@@ -3276,7 +3277,7 @@ jlong Java_org_rocksdb_RocksDB_getPerfContextNative(JNIEnv*, jobject) {
  * Signature: (JJJ[Ljava/lang/String;IIJ)[Ljava/lang/String;
  */
 jobjectArray Java_org_rocksdb_RocksDB_compactFiles(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcompaction_opts_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcompaction_opts_handle,
     jlong jcf_handle, jobjectArray jinput_file_names, jint joutput_level,
     jint joutput_path_id, jlong jcompaction_job_info_handle) {
   jboolean has_exception = JNI_FALSE;
@@ -3325,7 +3326,7 @@ jobjectArray Java_org_rocksdb_RocksDB_compactFiles(
  * Method:    cancelAllBackgroundWork
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_RocksDB_cancelAllBackgroundWork(JNIEnv*, jobject,
+void Java_org_rocksdb_RocksDB_cancelAllBackgroundWork(JNIEnv*, jclass,
                                                       jlong jdb_handle,
                                                       jboolean jwait) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3337,7 +3338,7 @@ void Java_org_rocksdb_RocksDB_cancelAllBackgroundWork(JNIEnv*, jobject,
  * Method:    pauseBackgroundWork
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_pauseBackgroundWork(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_pauseBackgroundWork(JNIEnv* env, jclass,
                                                   jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto s = db->PauseBackgroundWork();
@@ -3351,7 +3352,7 @@ void Java_org_rocksdb_RocksDB_pauseBackgroundWork(JNIEnv* env, jobject,
  * Method:    continueBackgroundWork
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_continueBackgroundWork(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_continueBackgroundWork(JNIEnv* env, jclass,
                                                      jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto s = db->ContinueBackgroundWork();
@@ -3365,7 +3366,7 @@ void Java_org_rocksdb_RocksDB_continueBackgroundWork(JNIEnv* env, jobject,
  * Method:    enableAutoCompaction
  * Signature: (J[J)V
  */
-void Java_org_rocksdb_RocksDB_enableAutoCompaction(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_enableAutoCompaction(JNIEnv* env, jclass,
                                                    jlong jdb_handle,
                                                    jlongArray jcf_handles) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3386,7 +3387,7 @@ void Java_org_rocksdb_RocksDB_enableAutoCompaction(JNIEnv* env, jobject,
  * Method:    numberLevels
  * Signature: (JJ)I
  */
-jint Java_org_rocksdb_RocksDB_numberLevels(JNIEnv*, jobject, jlong jdb_handle,
+jint Java_org_rocksdb_RocksDB_numberLevels(JNIEnv*, jclass, jlong jdb_handle,
                                            jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   ROCKSDB_NAMESPACE::ColumnFamilyHandle* cf_handle;
@@ -3404,7 +3405,7 @@ jint Java_org_rocksdb_RocksDB_numberLevels(JNIEnv*, jobject, jlong jdb_handle,
  * Method:    maxMemCompactionLevel
  * Signature: (JJ)I
  */
-jint Java_org_rocksdb_RocksDB_maxMemCompactionLevel(JNIEnv*, jobject,
+jint Java_org_rocksdb_RocksDB_maxMemCompactionLevel(JNIEnv*, jclass,
                                                     jlong jdb_handle,
                                                     jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3423,7 +3424,7 @@ jint Java_org_rocksdb_RocksDB_maxMemCompactionLevel(JNIEnv*, jobject,
  * Method:    level0StopWriteTrigger
  * Signature: (JJ)I
  */
-jint Java_org_rocksdb_RocksDB_level0StopWriteTrigger(JNIEnv*, jobject,
+jint Java_org_rocksdb_RocksDB_level0StopWriteTrigger(JNIEnv*, jclass,
                                                      jlong jdb_handle,
                                                      jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3442,7 +3443,7 @@ jint Java_org_rocksdb_RocksDB_level0StopWriteTrigger(JNIEnv*, jobject,
  * Method:    getName
  * Signature: (J)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_RocksDB_getName(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_RocksDB_getName(JNIEnv* env, jclass,
                                          jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   std::string name = db->GetName();
@@ -3454,7 +3455,7 @@ jstring Java_org_rocksdb_RocksDB_getName(JNIEnv* env, jobject,
  * Method:    getEnv
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RocksDB_getEnv(JNIEnv*, jobject, jlong jdb_handle) {
+jlong Java_org_rocksdb_RocksDB_getEnv(JNIEnv*, jclass, jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   return GET_CPLUSPLUS_POINTER(db->GetEnv());
 }
@@ -3464,7 +3465,7 @@ jlong Java_org_rocksdb_RocksDB_getEnv(JNIEnv*, jobject, jlong jdb_handle) {
  * Method:    flush
  * Signature: (JJ[J)V
  */
-void Java_org_rocksdb_RocksDB_flush(JNIEnv* env, jobject, jlong jdb_handle,
+void Java_org_rocksdb_RocksDB_flush(JNIEnv* env, jclass, jlong jdb_handle,
                                     jlong jflush_opts_handle,
                                     jlongArray jcf_handles) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3494,7 +3495,7 @@ void Java_org_rocksdb_RocksDB_flush(JNIEnv* env, jobject, jlong jdb_handle,
  * Method:    flushWal
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_RocksDB_flushWal(JNIEnv* env, jobject, jlong jdb_handle,
+void Java_org_rocksdb_RocksDB_flushWal(JNIEnv* env, jclass, jlong jdb_handle,
                                        jboolean jsync) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto s = db->FlushWAL(jsync == JNI_TRUE);
@@ -3508,7 +3509,7 @@ void Java_org_rocksdb_RocksDB_flushWal(JNIEnv* env, jobject, jlong jdb_handle,
  * Method:    syncWal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_syncWal(JNIEnv* env, jobject, jlong jdb_handle) {
+void Java_org_rocksdb_RocksDB_syncWal(JNIEnv* env, jclass, jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto s = db->SyncWAL();
   if (!s.ok()) {
@@ -3521,7 +3522,7 @@ void Java_org_rocksdb_RocksDB_syncWal(JNIEnv* env, jobject, jlong jdb_handle) {
  * Method:    getLatestSequenceNumber
  * Signature: (J)V
  */
-jlong Java_org_rocksdb_RocksDB_getLatestSequenceNumber(JNIEnv*, jobject,
+jlong Java_org_rocksdb_RocksDB_getLatestSequenceNumber(JNIEnv*, jclass,
                                                        jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   return db->GetLatestSequenceNumber();
@@ -3532,7 +3533,7 @@ jlong Java_org_rocksdb_RocksDB_getLatestSequenceNumber(JNIEnv*, jobject,
  * Method:    disableFileDeletions
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_disableFileDeletions(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_disableFileDeletions(JNIEnv* env, jclass,
                                                    jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   ROCKSDB_NAMESPACE::Status s = db->DisableFileDeletions();
@@ -3546,7 +3547,7 @@ void Java_org_rocksdb_RocksDB_disableFileDeletions(JNIEnv* env, jobject,
  * Method:    enableFileDeletions
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_RocksDB_enableFileDeletions(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_enableFileDeletions(JNIEnv* env, jclass,
                                                   jlong jdb_handle,
                                                   jboolean jforce) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3561,7 +3562,7 @@ void Java_org_rocksdb_RocksDB_enableFileDeletions(JNIEnv* env, jobject,
  * Method:    getLiveFiles
  * Signature: (JZ)[Ljava/lang/String;
  */
-jobjectArray Java_org_rocksdb_RocksDB_getLiveFiles(JNIEnv* env, jobject,
+jobjectArray Java_org_rocksdb_RocksDB_getLiveFiles(JNIEnv* env, jclass,
                                                    jlong jdb_handle,
                                                    jboolean jflush_memtable) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3586,7 +3587,7 @@ jobjectArray Java_org_rocksdb_RocksDB_getLiveFiles(JNIEnv* env, jobject,
  * Method:    getSortedWalFiles
  * Signature: (J)[Lorg/rocksdb/LogFile;
  */
-jobjectArray Java_org_rocksdb_RocksDB_getSortedWalFiles(JNIEnv* env, jobject,
+jobjectArray Java_org_rocksdb_RocksDB_getSortedWalFiles(JNIEnv* env, jclass,
                                                         jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   std::vector<std::unique_ptr<ROCKSDB_NAMESPACE::LogFile>> sorted_wal_files;
@@ -3634,7 +3635,7 @@ jobjectArray Java_org_rocksdb_RocksDB_getSortedWalFiles(JNIEnv* env, jobject,
  * Method:    getUpdatesSince
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_RocksDB_getUpdatesSince(JNIEnv* env, jobject,
+jlong Java_org_rocksdb_RocksDB_getUpdatesSince(JNIEnv* env, jclass,
                                                jlong jdb_handle,
                                                jlong jsequence_number) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3655,7 +3656,7 @@ jlong Java_org_rocksdb_RocksDB_getUpdatesSince(JNIEnv* env, jobject,
  * Method:    deleteFile
  * Signature: (JLjava/lang/String;)V
  */
-void Java_org_rocksdb_RocksDB_deleteFile(JNIEnv* env, jobject, jlong jdb_handle,
+void Java_org_rocksdb_RocksDB_deleteFile(JNIEnv* env, jclass, jlong jdb_handle,
                                          jstring jname) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   jboolean has_exception = JNI_FALSE;
@@ -3673,7 +3674,7 @@ void Java_org_rocksdb_RocksDB_deleteFile(JNIEnv* env, jobject, jlong jdb_handle,
  * Method:    getLiveFilesMetaData
  * Signature: (J)[Lorg/rocksdb/LiveFileMetaData;
  */
-jobjectArray Java_org_rocksdb_RocksDB_getLiveFilesMetaData(JNIEnv* env, jobject,
+jobjectArray Java_org_rocksdb_RocksDB_getLiveFilesMetaData(JNIEnv* env, jclass,
                                                            jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   std::vector<ROCKSDB_NAMESPACE::LiveFileMetaData> live_files_meta_data;
@@ -3720,7 +3721,7 @@ jobjectArray Java_org_rocksdb_RocksDB_getLiveFilesMetaData(JNIEnv* env, jobject,
  * Method:    getColumnFamilyMetaData
  * Signature: (JJ)Lorg/rocksdb/ColumnFamilyMetaData;
  */
-jobject Java_org_rocksdb_RocksDB_getColumnFamilyMetaData(JNIEnv* env, jobject,
+jobject Java_org_rocksdb_RocksDB_getColumnFamilyMetaData(JNIEnv* env, jclass,
                                                          jlong jdb_handle,
                                                          jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3743,7 +3744,7 @@ jobject Java_org_rocksdb_RocksDB_getColumnFamilyMetaData(JNIEnv* env, jobject,
  * Signature: (JJ[Ljava/lang/String;IJ)V
  */
 void Java_org_rocksdb_RocksDB_ingestExternalFile(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jobjectArray jfile_path_list, jint jfile_path_list_len,
     jlong jingest_external_file_options_handle) {
   jboolean has_exception = JNI_FALSE;
@@ -3772,7 +3773,7 @@ void Java_org_rocksdb_RocksDB_ingestExternalFile(
  * Method:    verifyChecksum
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_verifyChecksum(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_verifyChecksum(JNIEnv* env, jclass,
                                              jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto s = db->VerifyChecksum();
@@ -3786,7 +3787,7 @@ void Java_org_rocksdb_RocksDB_verifyChecksum(JNIEnv* env, jobject,
  * Method:    getDefaultColumnFamily
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RocksDB_getDefaultColumnFamily(JNIEnv*, jobject,
+jlong Java_org_rocksdb_RocksDB_getDefaultColumnFamily(JNIEnv*, jclass,
                                                       jlong jdb_handle) {
   auto* db_handle = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto* cf_handle = db_handle->DefaultColumnFamily();
@@ -3798,7 +3799,7 @@ jlong Java_org_rocksdb_RocksDB_getDefaultColumnFamily(JNIEnv*, jobject,
  * Method:    getPropertiesOfAllTables
  * Signature: (JJ)Ljava/util/Map;
  */
-jobject Java_org_rocksdb_RocksDB_getPropertiesOfAllTables(JNIEnv* env, jobject,
+jobject Java_org_rocksdb_RocksDB_getPropertiesOfAllTables(JNIEnv* env, jclass,
                                                           jlong jdb_handle,
                                                           jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3871,7 +3872,7 @@ jobject Java_org_rocksdb_RocksDB_getPropertiesOfAllTables(JNIEnv* env, jobject,
  * Signature: (JJ[J)Ljava/util/Map;
  */
 jobject Java_org_rocksdb_RocksDB_getPropertiesOfTablesInRange(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jcf_handle,
     jlongArray jrange_slice_handles) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   ROCKSDB_NAMESPACE::ColumnFamilyHandle* cf_handle;
@@ -3923,7 +3924,7 @@ jobject Java_org_rocksdb_RocksDB_getPropertiesOfTablesInRange(
  * Method:    suggestCompactRange
  * Signature: (JJ)[J
  */
-jlongArray Java_org_rocksdb_RocksDB_suggestCompactRange(JNIEnv* env, jobject,
+jlongArray Java_org_rocksdb_RocksDB_suggestCompactRange(JNIEnv* env, jclass,
                                                         jlong jdb_handle,
                                                         jlong jcf_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
@@ -3973,7 +3974,7 @@ jlongArray Java_org_rocksdb_RocksDB_suggestCompactRange(JNIEnv* env, jobject,
  * Method:    promoteL0
  * Signature: (JJI)V
  */
-void Java_org_rocksdb_RocksDB_promoteL0(JNIEnv*, jobject, jlong jdb_handle,
+void Java_org_rocksdb_RocksDB_promoteL0(JNIEnv*, jclass, jlong jdb_handle,
                                         jlong jcf_handle, jint jtarget_level) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   ROCKSDB_NAMESPACE::ColumnFamilyHandle* cf_handle;
@@ -3992,7 +3993,7 @@ void Java_org_rocksdb_RocksDB_promoteL0(JNIEnv*, jobject, jlong jdb_handle,
  * Signature: (JJJ)V
  */
 void Java_org_rocksdb_RocksDB_startTrace(
-    JNIEnv* env, jobject, jlong jdb_handle, jlong jmax_trace_file_size,
+    JNIEnv* env, jclass, jlong jdb_handle, jlong jmax_trace_file_size,
     jlong jtrace_writer_jnicallback_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   ROCKSDB_NAMESPACE::TraceOptions trace_options;
@@ -4014,7 +4015,7 @@ void Java_org_rocksdb_RocksDB_startTrace(
  * Method:    endTrace
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_endTrace(JNIEnv* env, jobject, jlong jdb_handle) {
+void Java_org_rocksdb_RocksDB_endTrace(JNIEnv* env, jclass, jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto s = db->EndTrace();
   if (!s.ok()) {
@@ -4027,7 +4028,7 @@ void Java_org_rocksdb_RocksDB_endTrace(JNIEnv* env, jobject, jlong jdb_handle) {
  * Method:    tryCatchUpWithPrimary
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_tryCatchUpWithPrimary(JNIEnv* env, jobject,
+void Java_org_rocksdb_RocksDB_tryCatchUpWithPrimary(JNIEnv* env, jclass,
                                                     jlong jdb_handle) {
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
   auto s = db->TryCatchUpWithPrimary();
@@ -4096,7 +4097,7 @@ bool get_slice_helper(JNIEnv* env, jobjectArray ranges, jsize index,
  * Method:    deleteFilesInRanges
  * Signature: (JJLjava/util/List;Z)V
  */
-void Java_org_rocksdb_RocksDB_deleteFilesInRanges(JNIEnv* env, jobject /*jdb*/,
+void Java_org_rocksdb_RocksDB_deleteFilesInRanges(JNIEnv* env, jclass /*jdb*/,
                                                   jlong jdb_handle,
                                                   jlong jcf_handle,
                                                   jobjectArray ranges,

--- a/java/rocksjni/slice.cc
+++ b/java/rocksjni/slice.cc
@@ -55,7 +55,7 @@ jlong Java_org_rocksdb_AbstractSlice_createNewSliceFromString(JNIEnv* env,
  * Method:    size0
  * Signature: (J)I
  */
-jint Java_org_rocksdb_AbstractSlice_size0(JNIEnv* /*env*/, jobject /*jobj*/,
+jint Java_org_rocksdb_AbstractSlice_size0(JNIEnv* /*env*/, jclass /*jcls*/,
                                           jlong handle) {
   const auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   return static_cast<jint>(slice->size());
@@ -66,8 +66,8 @@ jint Java_org_rocksdb_AbstractSlice_size0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    empty0
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_AbstractSlice_empty0(JNIEnv* /*env*/,
-                                               jobject /*jobj*/, jlong handle) {
+jboolean Java_org_rocksdb_AbstractSlice_empty0(JNIEnv* /*env*/, jclass /*jcls*/,
+                                               jlong handle) {
   const auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   return slice->empty();
 }
@@ -77,7 +77,7 @@ jboolean Java_org_rocksdb_AbstractSlice_empty0(JNIEnv* /*env*/,
  * Method:    toString0
  * Signature: (JZ)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_AbstractSlice_toString0(JNIEnv* env, jobject /*jobj*/,
+jstring Java_org_rocksdb_AbstractSlice_toString0(JNIEnv* env, jclass /*jobj*/,
                                                  jlong handle, jboolean hex) {
   const auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   const std::string s = slice->ToString(hex);
@@ -89,7 +89,7 @@ jstring Java_org_rocksdb_AbstractSlice_toString0(JNIEnv* env, jobject /*jobj*/,
  * Method:    compare0
  * Signature: (JJ)I;
  */
-jint Java_org_rocksdb_AbstractSlice_compare0(JNIEnv* /*env*/, jobject /*jobj*/,
+jint Java_org_rocksdb_AbstractSlice_compare0(JNIEnv* /*env*/, jclass /*jcls*/,
                                              jlong handle, jlong otherHandle) {
   const auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   const auto* otherSlice =
@@ -103,7 +103,7 @@ jint Java_org_rocksdb_AbstractSlice_compare0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (JJ)Z;
  */
 jboolean Java_org_rocksdb_AbstractSlice_startsWith0(JNIEnv* /*env*/,
-                                                    jobject /*jobj*/,
+                                                    jclass /*jcls*/,
                                                     jlong handle,
                                                     jlong otherHandle) {
   const auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
@@ -117,9 +117,9 @@ jboolean Java_org_rocksdb_AbstractSlice_startsWith0(JNIEnv* /*env*/,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_AbstractSlice_disposeInternal(JNIEnv* /*env*/,
-                                                    jobject /*jobj*/,
-                                                    jlong handle) {
+void Java_org_rocksdb_AbstractSlice_disposeInternalJni(JNIEnv* /*env*/,
+                                                       jclass /*jcls*/,
+                                                       jlong handle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
 }
 
@@ -209,7 +209,7 @@ jbyteArray Java_org_rocksdb_Slice_data0(JNIEnv* env, jobject /*jobj*/,
  * Method:    clear0
  * Signature: (JZJ)V
  */
-void Java_org_rocksdb_Slice_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_Slice_clear0(JNIEnv* /*env*/, jclass /*jcls*/,
                                    jlong handle, jboolean shouldRelease,
                                    jlong internalBufferOffset) {
   auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
@@ -225,7 +225,7 @@ void Java_org_rocksdb_Slice_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    removePrefix0
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Slice_removePrefix0(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_Slice_removePrefix0(JNIEnv* /*env*/, jclass /*jcls*/,
                                           jlong handle, jint length) {
   auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   slice->remove_prefix(length);
@@ -236,7 +236,7 @@ void Java_org_rocksdb_Slice_removePrefix0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    setLength0
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DirectSlice_setLength0(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_DirectSlice_setLength0(JNIEnv* /*env*/, jclass /*jcls*/,
                                              jlong handle, jint length) {
   auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   slice->size_ = length;
@@ -247,8 +247,8 @@ void Java_org_rocksdb_DirectSlice_setLength0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    disposeInternalBuf
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Slice_disposeInternalBuf(JNIEnv* /*env*/,
-                                               jobject /*jobj*/, jlong handle,
+void Java_org_rocksdb_Slice_disposeInternalBuf(JNIEnv* /*env*/, jclass /*jcls*/,
+                                               jlong handle,
                                                jlong internalBufferOffset) {
   const auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   const char* buf = slice->data_ - internalBufferOffset;
@@ -324,7 +324,7 @@ jobject Java_org_rocksdb_DirectSlice_data0(JNIEnv* env, jobject /*jobj*/,
  * Method:    get0
  * Signature: (JI)B
  */
-jbyte Java_org_rocksdb_DirectSlice_get0(JNIEnv* /*env*/, jobject /*jobj*/,
+jbyte Java_org_rocksdb_DirectSlice_get0(JNIEnv* /*env*/, jclass /*jcls*/,
                                         jlong handle, jint offset) {
   const auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   return (*slice)[offset];
@@ -335,7 +335,7 @@ jbyte Java_org_rocksdb_DirectSlice_get0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    clear0
  * Signature: (JZJ)V
  */
-void Java_org_rocksdb_DirectSlice_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_DirectSlice_clear0(JNIEnv* /*env*/, jclass /*jcls*/,
                                          jlong handle, jboolean shouldRelease,
                                          jlong internalBufferOffset) {
   auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
@@ -352,7 +352,7 @@ void Java_org_rocksdb_DirectSlice_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DirectSlice_removePrefix0(JNIEnv* /*env*/,
-                                                jobject /*jobj*/, jlong handle,
+                                                jclass /*jcls*/, jlong handle,
                                                 jint length) {
   auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   slice->remove_prefix(length);
@@ -364,7 +364,7 @@ void Java_org_rocksdb_DirectSlice_removePrefix0(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DirectSlice_disposeInternalBuf(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong handle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong handle,
     jlong internalBufferOffset) {
   const auto* slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(handle);
   const char* buf = slice->data_ - internalBufferOffset;

--- a/java/rocksjni/snapshot.cc
+++ b/java/rocksjni/snapshot.cc
@@ -19,7 +19,7 @@
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Snapshot_getSequenceNumber(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
+                                                  jclass /*jcls*/,
                                                   jlong jsnapshot_handle) {
   auto* snapshot =
       reinterpret_cast<ROCKSDB_NAMESPACE::Snapshot*>(jsnapshot_handle);

--- a/java/rocksjni/sst_file_manager.cc
+++ b/java/rocksjni/sst_file_manager.cc
@@ -61,8 +61,7 @@ jlong Java_org_rocksdb_SstFileManager_newSstFileManager(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_SstFileManager_setMaxAllowedSpaceUsage(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
-    jlong jmax_allowed_space) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jlong jmax_allowed_space) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
           jhandle);
@@ -75,7 +74,7 @@ void Java_org_rocksdb_SstFileManager_setMaxAllowedSpaceUsage(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_SstFileManager_setCompactionBufferSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jcompaction_buffer_size) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
@@ -90,7 +89,7 @@ void Java_org_rocksdb_SstFileManager_setCompactionBufferSize(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReached(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
           jhandle);
@@ -104,7 +103,7 @@ jboolean Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReached(
  */
 jboolean
 Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReachedIncludingCompactions(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
           jhandle);
@@ -118,7 +117,7 @@ Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReachedIncludingCompactions(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_SstFileManager_getTotalSize(JNIEnv* /*env*/,
-                                                   jobject /*jobj*/,
+                                                   jclass /*jcls*/,
                                                    jlong jhandle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
@@ -132,7 +131,7 @@ jlong Java_org_rocksdb_SstFileManager_getTotalSize(JNIEnv* /*env*/,
  * Signature: (J)Ljava/util/Map;
  */
 jobject Java_org_rocksdb_SstFileManager_getTrackedFiles(JNIEnv* env,
-                                                        jobject /*jobj*/,
+                                                        jclass /*jcls*/,
                                                         jlong jhandle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
@@ -186,7 +185,7 @@ jobject Java_org_rocksdb_SstFileManager_getTrackedFiles(JNIEnv* env,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_SstFileManager_getDeleteRateBytesPerSecond(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
           jhandle);
@@ -199,7 +198,7 @@ jlong Java_org_rocksdb_SstFileManager_getDeleteRateBytesPerSecond(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_SstFileManager_setDeleteRateBytesPerSecond(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong jdelete_rate) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jlong jdelete_rate) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
           jhandle);
@@ -212,7 +211,7 @@ void Java_org_rocksdb_SstFileManager_setDeleteRateBytesPerSecond(
  * Signature: (J)D
  */
 jdouble Java_org_rocksdb_SstFileManager_getMaxTrashDBRatio(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
+                                                           jclass /*jcls*/,
                                                            jlong jhandle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
@@ -226,7 +225,7 @@ jdouble Java_org_rocksdb_SstFileManager_getMaxTrashDBRatio(JNIEnv* /*env*/,
  * Signature: (JD)V
  */
 void Java_org_rocksdb_SstFileManager_setMaxTrashDBRatio(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
+                                                        jclass /*jcls*/,
                                                         jlong jhandle,
                                                         jdouble jratio) {
   auto* sptr_sst_file_manager =
@@ -240,9 +239,9 @@ void Java_org_rocksdb_SstFileManager_setMaxTrashDBRatio(JNIEnv* /*env*/,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileManager_disposeInternal(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
-                                                     jlong jhandle) {
+void Java_org_rocksdb_SstFileManager_disposeInternalJni(JNIEnv* /*env*/,
+                                                        jclass /*cls*/,
+                                                        jlong jhandle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::SstFileManager>*>(
           jhandle);

--- a/java/rocksjni/sst_file_reader_iterator.cc
+++ b/java/rocksjni/sst_file_reader_iterator.cc
@@ -19,9 +19,9 @@
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_disposeInternal(JNIEnv* /*env*/,
-                                                            jobject /*jobj*/,
-                                                            jlong handle) {
+void Java_org_rocksdb_SstFileReaderIterator_disposeInternalJni(JNIEnv* /*env*/,
+                                                               jclass /*jobj*/,
+                                                               jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   assert(it != nullptr);
   delete it;
@@ -32,9 +32,9 @@ void Java_org_rocksdb_SstFileReaderIterator_disposeInternal(JNIEnv* /*env*/,
  * Method:    isValid0
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_SstFileReaderIterator_isValid0(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
-                                                         jlong handle) {
+jboolean Java_org_rocksdb_SstFileReaderIterator_isValid0Jni(JNIEnv* /*env*/,
+                                                            jclass /*cls*/,
+                                                            jlong handle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->Valid();
 }
 
@@ -43,9 +43,9 @@ jboolean Java_org_rocksdb_SstFileReaderIterator_isValid0(JNIEnv* /*env*/,
  * Method:    seekToFirst0
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_seekToFirst0(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
-                                                         jlong handle) {
+void Java_org_rocksdb_SstFileReaderIterator_seekToFirst0Jni(JNIEnv* /*env*/,
+                                                            jclass /*cls*/,
+                                                            jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->SeekToFirst();
 }
 
@@ -54,9 +54,9 @@ void Java_org_rocksdb_SstFileReaderIterator_seekToFirst0(JNIEnv* /*env*/,
  * Method:    seekToLast0
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_seekToLast0(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
-                                                        jlong handle) {
+void Java_org_rocksdb_SstFileReaderIterator_seekToLast0Jni(JNIEnv* /*env*/,
+                                                           jclass /*cls*/,
+                                                           jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->SeekToLast();
 }
 
@@ -65,9 +65,9 @@ void Java_org_rocksdb_SstFileReaderIterator_seekToLast0(JNIEnv* /*env*/,
  * Method:    next0
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_next0(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
-                                                  jlong handle) {
+void Java_org_rocksdb_SstFileReaderIterator_next0Jni(JNIEnv* /*env*/,
+                                                     jclass /*cls*/,
+                                                     jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->Next();
 }
 
@@ -76,9 +76,9 @@ void Java_org_rocksdb_SstFileReaderIterator_next0(JNIEnv* /*env*/,
  * Method:    prev0
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_prev0(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
-                                                  jlong handle) {
+void Java_org_rocksdb_SstFileReaderIterator_prev0Jni(JNIEnv* /*env*/,
+                                                     jclass /*cls*/,
+                                                     jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle)->Prev();
 }
 
@@ -87,10 +87,11 @@ void Java_org_rocksdb_SstFileReaderIterator_prev0(JNIEnv* /*env*/,
  * Method:    seek0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_seek0(JNIEnv* env, jobject /*jobj*/,
-                                                  jlong handle,
-                                                  jbyteArray jtarget,
-                                                  jint jtarget_len) {
+void Java_org_rocksdb_SstFileReaderIterator_seek0Jni(JNIEnv* env,
+                                                     jclass /*cls*/,
+                                                     jlong handle,
+                                                     jbyteArray jtarget,
+                                                     jint jtarget_len) {
   jbyte* target = env->GetByteArrayElements(jtarget, nullptr);
   if (target == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -111,11 +112,11 @@ void Java_org_rocksdb_SstFileReaderIterator_seek0(JNIEnv* env, jobject /*jobj*/,
  * Method:    seekForPrev0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_seekForPrev0(JNIEnv* env,
-                                                         jobject /*jobj*/,
-                                                         jlong handle,
-                                                         jbyteArray jtarget,
-                                                         jint jtarget_len) {
+void Java_org_rocksdb_SstFileReaderIterator_seekForPrev0Jni(JNIEnv* env,
+                                                            jclass /*cls*/,
+                                                            jlong handle,
+                                                            jbyteArray jtarget,
+                                                            jint jtarget_len) {
   jbyte* target = env->GetByteArrayElements(jtarget, nullptr);
   if (target == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -136,9 +137,9 @@ void Java_org_rocksdb_SstFileReaderIterator_seekForPrev0(JNIEnv* env,
  * Method:    status0
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_status0(JNIEnv* env,
-                                                    jobject /*jobj*/,
-                                                    jlong handle) {
+void Java_org_rocksdb_SstFileReaderIterator_status0Jni(JNIEnv* env,
+                                                       jclass /*cls*/,
+                                                       jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Status s = it->status();
 
@@ -155,7 +156,7 @@ void Java_org_rocksdb_SstFileReaderIterator_status0(JNIEnv* env,
  * Signature: (J)[B
  */
 jbyteArray Java_org_rocksdb_SstFileReaderIterator_key0(JNIEnv* env,
-                                                       jobject /*jobj*/,
+                                                       jclass /*jcls*/,
                                                        jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice key_slice = it->key();
@@ -177,7 +178,7 @@ jbyteArray Java_org_rocksdb_SstFileReaderIterator_key0(JNIEnv* env,
  * Signature: (J)[B
  */
 jbyteArray Java_org_rocksdb_SstFileReaderIterator_value0(JNIEnv* env,
-                                                         jobject /*jobj*/,
+                                                         jclass /*jcls*/,
                                                          jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice value_slice = it->value();
@@ -200,7 +201,7 @@ jbyteArray Java_org_rocksdb_SstFileReaderIterator_value0(JNIEnv* env,
  * Signature: (JLjava/nio/ByteBuffer;II)I
  */
 jint Java_org_rocksdb_SstFileReaderIterator_keyDirect0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jobject jtarget,
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jobject jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice key_slice = it->key();
@@ -217,7 +218,7 @@ jint Java_org_rocksdb_SstFileReaderIterator_keyDirect0(
  * Signature: (J[BII)I
  */
 jint Java_org_rocksdb_SstFileReaderIterator_keyByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jkey, jint jkey_off,
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jbyteArray jkey, jint jkey_off,
     jint jkey_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice key_slice = it->key();
@@ -237,7 +238,7 @@ jint Java_org_rocksdb_SstFileReaderIterator_keyByteArray0(
  * Signature: (JLjava/nio/ByteBuffer;II)I
  */
 jint Java_org_rocksdb_SstFileReaderIterator_valueDirect0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jobject jtarget,
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jobject jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice value_slice = it->value();
@@ -254,7 +255,7 @@ jint Java_org_rocksdb_SstFileReaderIterator_valueDirect0(
  * Signature: (J[BII)I
  */
 jint Java_org_rocksdb_SstFileReaderIterator_valueByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jvalue_target,
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jbyteArray jvalue_target,
     jint jvalue_off, jint jvalue_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Slice value_slice = it->value();
@@ -273,8 +274,8 @@ jint Java_org_rocksdb_SstFileReaderIterator_valueByteArray0(
  * Method:    seekDirect0
  * Signature: (JLjava/nio/ByteBuffer;II)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_seekDirect0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jobject jtarget,
+void Java_org_rocksdb_SstFileReaderIterator_seekDirect0Jni(
+    JNIEnv* env, jclass /*cls*/, jlong handle, jobject jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   auto seek = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
@@ -289,8 +290,8 @@ void Java_org_rocksdb_SstFileReaderIterator_seekDirect0(
  * Method:    seekForPrevDirect0
  * Signature: (JLjava/nio/ByteBuffer;II)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_seekForPrevDirect0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jobject jtarget,
+void Java_org_rocksdb_SstFileReaderIterator_seekForPrevDirect0Jni(
+    JNIEnv* env, jclass /*cls*/, jlong handle, jobject jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   auto seekPrev = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
@@ -308,8 +309,8 @@ void Java_org_rocksdb_SstFileReaderIterator_seekForPrevDirect0(
  * Method:    seekByteArray0
  * Signature: (J[BII)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_seekByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jtarget,
+void Java_org_rocksdb_SstFileReaderIterator_seekByteArray0Jni(
+    JNIEnv* env, jclass /*cls*/, jlong handle, jbyteArray jtarget,
     jint jtarget_off, jint jtarget_len) {
   const std::unique_ptr<char[]> target(new char[jtarget_len]);
   if (target == nullptr) {
@@ -335,8 +336,8 @@ void Java_org_rocksdb_SstFileReaderIterator_seekByteArray0(
  * Method:    seekForPrevByteArray0
  * Signature: (J[BII)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_seekForPrevByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jtarget,
+void Java_org_rocksdb_SstFileReaderIterator_seekForPrevByteArray0Jni(
+    JNIEnv* env, jclass /*cls*/, jlong handle, jbyteArray jtarget,
     jint jtarget_off, jint jtarget_len) {
   const std::unique_ptr<char[]> target(new char[jtarget_len]);
   if (target == nullptr) {
@@ -359,9 +360,9 @@ void Java_org_rocksdb_SstFileReaderIterator_seekForPrevByteArray0(
  * Method:    refresh0
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReaderIterator_refresh0(JNIEnv* env,
-                                                     jobject /*jobj*/,
-                                                     jlong handle) {
+void Java_org_rocksdb_SstFileReaderIterator_refresh0Jni(JNIEnv* env,
+                                                        jclass /*cls*/,
+                                                        jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::Iterator*>(handle);
   ROCKSDB_NAMESPACE::Status s = it->Refresh();
 

--- a/java/rocksjni/sst_file_readerjni.cc
+++ b/java/rocksjni/sst_file_readerjni.cc
@@ -39,7 +39,7 @@ jlong Java_org_rocksdb_SstFileReader_newSstFileReader(JNIEnv * /*env*/,
  * Method:    open
  * Signature: (JLjava/lang/String;)V
  */
-void Java_org_rocksdb_SstFileReader_open(JNIEnv *env, jobject /*jobj*/,
+void Java_org_rocksdb_SstFileReader_open(JNIEnv *env, jclass /*jcls*/,
                                          jlong jhandle, jstring jfile_path) {
   const char *file_path = env->GetStringUTFChars(jfile_path, nullptr);
   if (file_path == nullptr) {
@@ -62,8 +62,7 @@ void Java_org_rocksdb_SstFileReader_open(JNIEnv *env, jobject /*jobj*/,
  * Signature: (JJ)J
  */
 jlong Java_org_rocksdb_SstFileReader_newIterator(JNIEnv * /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong jhandle,
+                                                 jclass /*jcls*/, jlong jhandle,
                                                  jlong jread_options_handle) {
   auto *sst_file_reader =
       reinterpret_cast<ROCKSDB_NAMESPACE::SstFileReader *>(jhandle);
@@ -77,9 +76,9 @@ jlong Java_org_rocksdb_SstFileReader_newIterator(JNIEnv * /*env*/,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReader_disposeInternal(JNIEnv * /*env*/,
-                                                    jobject /*jobj*/,
-                                                    jlong jhandle) {
+void Java_org_rocksdb_SstFileReader_disposeInternalJni(JNIEnv * /*env*/,
+                                                       jclass /*jcls*/,
+                                                       jlong jhandle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::SstFileReader *>(jhandle);
 }
 
@@ -88,8 +87,7 @@ void Java_org_rocksdb_SstFileReader_disposeInternal(JNIEnv * /*env*/,
  * Method:    verifyChecksum
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileReader_verifyChecksum(JNIEnv *env,
-                                                   jobject /*jobj*/,
+void Java_org_rocksdb_SstFileReader_verifyChecksum(JNIEnv *env, jclass /*jcls*/,
                                                    jlong jhandle) {
   auto *sst_file_reader =
       reinterpret_cast<ROCKSDB_NAMESPACE::SstFileReader *>(jhandle);
@@ -105,7 +103,7 @@ void Java_org_rocksdb_SstFileReader_verifyChecksum(JNIEnv *env,
  * Signature: (J)J
  */
 jobject Java_org_rocksdb_SstFileReader_getTableProperties(JNIEnv *env,
-                                                          jobject /*jobj*/,
+                                                          jclass /*jcls*/,
                                                           jlong jhandle) {
   auto *sst_file_reader =
       reinterpret_cast<ROCKSDB_NAMESPACE::SstFileReader *>(jhandle);

--- a/java/rocksjni/sst_file_writerjni.cc
+++ b/java/rocksjni/sst_file_writerjni.cc
@@ -73,7 +73,7 @@ jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJ(JNIEnv * /*env*/,
  * Method:    open
  * Signature: (JLjava/lang/String;)V
  */
-void Java_org_rocksdb_SstFileWriter_open(JNIEnv *env, jobject /*jobj*/,
+void Java_org_rocksdb_SstFileWriter_open(JNIEnv *env, jclass /*jcls*/,
                                          jlong jhandle, jstring jfile_path) {
   const char *file_path = env->GetStringUTFChars(jfile_path, nullptr);
   if (file_path == nullptr) {
@@ -95,7 +95,7 @@ void Java_org_rocksdb_SstFileWriter_open(JNIEnv *env, jobject /*jobj*/,
  * Method:    put
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_SstFileWriter_put__JJJ(JNIEnv *env, jobject /*jobj*/,
+void Java_org_rocksdb_SstFileWriter_put__JJJ(JNIEnv *env, jclass /*jcls*/,
                                              jlong jhandle, jlong jkey_handle,
                                              jlong jvalue_handle) {
   auto *key_slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice *>(jkey_handle);
@@ -114,7 +114,7 @@ void Java_org_rocksdb_SstFileWriter_put__JJJ(JNIEnv *env, jobject /*jobj*/,
  * Method:    put
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_SstFileWriter_put__J_3B_3B(JNIEnv *env, jobject /*jobj*/,
+void Java_org_rocksdb_SstFileWriter_put__J_3B_3B(JNIEnv *env, jclass /*jcls*/,
                                                  jlong jhandle, jbyteArray jkey,
                                                  jbyteArray jval) {
   jbyte *key = env->GetByteArrayElements(jkey, nullptr);
@@ -151,7 +151,7 @@ void Java_org_rocksdb_SstFileWriter_put__J_3B_3B(JNIEnv *env, jobject /*jobj*/,
  * Method:    putDirect
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)V
  */
-void Java_org_rocksdb_SstFileWriter_putDirect(JNIEnv *env, jobject /*jdb*/,
+void Java_org_rocksdb_SstFileWriter_putDirect(JNIEnv *env, jclass /*jcls*/,
                                               jlong jdb_handle, jobject jkey,
                                               jint jkey_off, jint jkey_len,
                                               jobject jval, jint jval_off,
@@ -175,7 +175,7 @@ void Java_org_rocksdb_SstFileWriter_putDirect(JNIEnv *env, jobject /*jdb*/,
  * Method:    fileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_SstFileWriter_fileSize(JNIEnv * /*env*/, jobject /*jdb*/,
+jlong Java_org_rocksdb_SstFileWriter_fileSize(JNIEnv * /*env*/, jclass /*jcls*/,
                                               jlong jdb_handle) {
   auto *writer =
       reinterpret_cast<ROCKSDB_NAMESPACE::SstFileWriter *>(jdb_handle);
@@ -187,7 +187,7 @@ jlong Java_org_rocksdb_SstFileWriter_fileSize(JNIEnv * /*env*/, jobject /*jdb*/,
  * Method:    merge
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_SstFileWriter_merge__JJJ(JNIEnv *env, jobject /*jobj*/,
+void Java_org_rocksdb_SstFileWriter_merge__JJJ(JNIEnv *env, jclass /*jcls*/,
                                                jlong jhandle, jlong jkey_handle,
                                                jlong jvalue_handle) {
   auto *key_slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice *>(jkey_handle);
@@ -206,8 +206,7 @@ void Java_org_rocksdb_SstFileWriter_merge__JJJ(JNIEnv *env, jobject /*jobj*/,
  * Method:    merge
  * Signature: (J[B[B)V
  */
-void Java_org_rocksdb_SstFileWriter_merge__J_3B_3B(JNIEnv *env,
-                                                   jobject /*jobj*/,
+void Java_org_rocksdb_SstFileWriter_merge__J_3B_3B(JNIEnv *env, jclass /*jcls*/,
                                                    jlong jhandle,
                                                    jbyteArray jkey,
                                                    jbyteArray jval) {
@@ -245,7 +244,7 @@ void Java_org_rocksdb_SstFileWriter_merge__J_3B_3B(JNIEnv *env,
  * Method:    delete
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_SstFileWriter_delete__J_3B(JNIEnv *env, jobject /*jobj*/,
+void Java_org_rocksdb_SstFileWriter_delete__J_3B(JNIEnv *env, jclass /*jcls*/,
                                                  jlong jhandle,
                                                  jbyteArray jkey) {
   jbyte *key = env->GetByteArrayElements(jkey, nullptr);
@@ -272,7 +271,7 @@ void Java_org_rocksdb_SstFileWriter_delete__J_3B(JNIEnv *env, jobject /*jobj*/,
  * Method:    delete
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_SstFileWriter_delete__JJ(JNIEnv *env, jobject /*jobj*/,
+void Java_org_rocksdb_SstFileWriter_delete__JJ(JNIEnv *env, jclass /*jcls*/,
                                                jlong jhandle,
                                                jlong jkey_handle) {
   auto *key_slice = reinterpret_cast<ROCKSDB_NAMESPACE::Slice *>(jkey_handle);
@@ -289,7 +288,7 @@ void Java_org_rocksdb_SstFileWriter_delete__JJ(JNIEnv *env, jobject /*jobj*/,
  * Method:    finish
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileWriter_finish(JNIEnv *env, jobject /*jobj*/,
+void Java_org_rocksdb_SstFileWriter_finish(JNIEnv *env, jclass /*jcls*/,
                                            jlong jhandle) {
   ROCKSDB_NAMESPACE::Status s =
       reinterpret_cast<ROCKSDB_NAMESPACE::SstFileWriter *>(jhandle)->Finish();
@@ -303,8 +302,8 @@ void Java_org_rocksdb_SstFileWriter_finish(JNIEnv *env, jobject /*jobj*/,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileWriter_disposeInternal(JNIEnv * /*env*/,
-                                                    jobject /*jobj*/,
-                                                    jlong jhandle) {
+void Java_org_rocksdb_SstFileWriter_disposeInternalJni(JNIEnv * /*env*/,
+                                                       jclass /*jobj*/,
+                                                       jlong jhandle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::SstFileWriter *>(jhandle);
 }

--- a/java/rocksjni/sst_partitioner.cc
+++ b/java/rocksjni/sst_partitioner.cc
@@ -35,8 +35,8 @@ jlong Java_org_rocksdb_SstPartitionerFixedPrefixFactory_newSstPartitionerFixedPr
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstPartitionerFixedPrefixFactory_disposeInternal(
-    JNIEnv*, jobject, jlong jhandle) {
+void Java_org_rocksdb_SstPartitionerFixedPrefixFactory_disposeInternalJni(
+    JNIEnv*, jclass, jlong jhandle) {
   auto* ptr = reinterpret_cast<
       std::shared_ptr<ROCKSDB_NAMESPACE::SstPartitionerFactory>*>(jhandle);
   delete ptr;  // delete std::shared_ptr

--- a/java/rocksjni/statistics.cc
+++ b/java/rocksjni/statistics.cc
@@ -104,8 +104,8 @@ jlong Java_org_rocksdb_Statistics_newStatistics___3BJ(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_Statistics_disposeInternal(JNIEnv*, jobject,
-                                                 jlong jhandle) {
+void Java_org_rocksdb_Statistics_disposeInternalJni(JNIEnv*, jclass,
+                                                    jlong jhandle) {
   if (jhandle > 0) {
     auto* pSptr_statistics =
         reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Statistics>*>(
@@ -119,7 +119,7 @@ void Java_org_rocksdb_Statistics_disposeInternal(JNIEnv*, jobject,
  * Method:    statsLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Statistics_statsLevel(JNIEnv*, jobject, jlong jhandle) {
+jbyte Java_org_rocksdb_Statistics_statsLevel(JNIEnv*, jclass, jlong jhandle) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Statistics>*>(
           jhandle);
@@ -133,7 +133,7 @@ jbyte Java_org_rocksdb_Statistics_statsLevel(JNIEnv*, jobject, jlong jhandle) {
  * Method:    setStatsLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Statistics_setStatsLevel(JNIEnv*, jobject, jlong jhandle,
+void Java_org_rocksdb_Statistics_setStatsLevel(JNIEnv*, jclass, jlong jhandle,
                                                jbyte jstats_level) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Statistics>*>(
@@ -149,8 +149,7 @@ void Java_org_rocksdb_Statistics_setStatsLevel(JNIEnv*, jobject, jlong jhandle,
  * Method:    getTickerCount
  * Signature: (JB)J
  */
-jlong Java_org_rocksdb_Statistics_getTickerCount(JNIEnv*, jobject,
-                                                 jlong jhandle,
+jlong Java_org_rocksdb_Statistics_getTickerCount(JNIEnv*, jclass, jlong jhandle,
                                                  jbyte jticker_type) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Statistics>*>(
@@ -166,7 +165,7 @@ jlong Java_org_rocksdb_Statistics_getTickerCount(JNIEnv*, jobject,
  * Method:    getAndResetTickerCount
  * Signature: (JB)J
  */
-jlong Java_org_rocksdb_Statistics_getAndResetTickerCount(JNIEnv*, jobject,
+jlong Java_org_rocksdb_Statistics_getAndResetTickerCount(JNIEnv*, jclass,
                                                          jlong jhandle,
                                                          jbyte jticker_type) {
   auto* pSptr_statistics =
@@ -182,7 +181,7 @@ jlong Java_org_rocksdb_Statistics_getAndResetTickerCount(JNIEnv*, jobject,
  * Method:    getHistogramData
  * Signature: (JB)Lorg/rocksdb/HistogramData;
  */
-jobject Java_org_rocksdb_Statistics_getHistogramData(JNIEnv* env, jobject,
+jobject Java_org_rocksdb_Statistics_getHistogramData(JNIEnv* env, jclass,
                                                      jlong jhandle,
                                                      jbyte jhistogram_type) {
   auto* pSptr_statistics =
@@ -223,7 +222,7 @@ jobject Java_org_rocksdb_Statistics_getHistogramData(JNIEnv* env, jobject,
  * Method:    getHistogramString
  * Signature: (JB)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_Statistics_getHistogramString(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_Statistics_getHistogramString(JNIEnv* env, jclass,
                                                        jlong jhandle,
                                                        jbyte jhistogram_type) {
   auto* pSptr_statistics =
@@ -241,7 +240,7 @@ jstring Java_org_rocksdb_Statistics_getHistogramString(JNIEnv* env, jobject,
  * Method:    reset
  * Signature: (J)V
  */
-void Java_org_rocksdb_Statistics_reset(JNIEnv* env, jobject, jlong jhandle) {
+void Java_org_rocksdb_Statistics_reset(JNIEnv* env, jclass, jlong jhandle) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Statistics>*>(
           jhandle);
@@ -257,7 +256,7 @@ void Java_org_rocksdb_Statistics_reset(JNIEnv* env, jobject, jlong jhandle) {
  * Method:    toString
  * Signature: (J)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_Statistics_toString(JNIEnv* env, jobject,
+jstring Java_org_rocksdb_Statistics_toString(JNIEnv* env, jclass,
                                              jlong jhandle) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Statistics>*>(

--- a/java/rocksjni/table.cc
+++ b/java/rocksjni/table.cc
@@ -23,9 +23,9 @@
  * Signature: (IIDIIBZZ)J
  */
 jlong Java_org_rocksdb_PlainTableConfig_newTableFactoryHandle(
-    JNIEnv * /*env*/, jobject /*jobj*/, jint jkey_size,
-    jint jbloom_bits_per_key, jdouble jhash_table_ratio, jint jindex_sparseness,
-    jint jhuge_page_tlb_size, jbyte jencoding_type, jboolean jfull_scan_mode,
+    JNIEnv * /*env*/, jclass /*jcls*/, jint jkey_size, jint jbloom_bits_per_key,
+    jdouble jhash_table_ratio, jint jindex_sparseness, jint jhuge_page_tlb_size,
+    jbyte jencoding_type, jboolean jfull_scan_mode,
     jboolean jstore_index_in_file) {
   ROCKSDB_NAMESPACE::PlainTableOptions options =
       ROCKSDB_NAMESPACE::PlainTableOptions();
@@ -48,7 +48,7 @@ jlong Java_org_rocksdb_PlainTableConfig_newTableFactoryHandle(
  * Signature: (ZZZZBBDBZJJJJIIIJZZZJZZIIZZBJIJI)J
  */
 jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
-    JNIEnv *, jobject, jboolean jcache_index_and_filter_blocks,
+    JNIEnv *, jclass, jboolean jcache_index_and_filter_blocks,
     jboolean jcache_index_and_filter_blocks_with_high_priority,
     jboolean jpin_l0_filter_and_index_blocks_in_cache,
     jboolean jpin_top_level_index_and_filter, jbyte jindex_type_value,

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -28,7 +28,7 @@
  * Method:    setSnapshot
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_setSnapshot(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_setSnapshot(JNIEnv* /*env*/, jclass /*jcls*/,
                                               jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   txn->SetSnapshot();
@@ -39,8 +39,9 @@ void Java_org_rocksdb_Transaction_setSnapshot(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    setSnapshotOnNextOperation
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__J(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__J(JNIEnv* /*env*/,
+                                                                jclass /*jcls*/,
+                                                                jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   txn->SetSnapshotOnNextOperation(nullptr);
 }
@@ -51,7 +52,7 @@ void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__J(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__JJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jtxn_notifier_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* txn_notifier = reinterpret_cast<
@@ -65,8 +66,7 @@ void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__JJ(
  * Method:    getSnapshot
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getSnapshot(JNIEnv* /*env*/,
-                                               jobject /*jobj*/,
+jlong Java_org_rocksdb_Transaction_getSnapshot(JNIEnv* /*env*/, jclass /*jcls*/,
                                                jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   const ROCKSDB_NAMESPACE::Snapshot* snapshot = txn->GetSnapshot();
@@ -79,7 +79,7 @@ jlong Java_org_rocksdb_Transaction_getSnapshot(JNIEnv* /*env*/,
  * Signature: (J)V
  */
 void Java_org_rocksdb_Transaction_clearSnapshot(JNIEnv* /*env*/,
-                                                jobject /*jobj*/,
+                                                jclass /*jcls*/,
                                                 jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   txn->ClearSnapshot();
@@ -90,7 +90,7 @@ void Java_org_rocksdb_Transaction_clearSnapshot(JNIEnv* /*env*/,
  * Method:    prepare
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_prepare(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_prepare(JNIEnv* env, jclass /*jobj*/,
                                           jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::Status s = txn->Prepare();
@@ -104,7 +104,7 @@ void Java_org_rocksdb_Transaction_prepare(JNIEnv* env, jobject /*jobj*/,
  * Method:    commit
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_commit(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_commit(JNIEnv* env, jclass /*jobj*/,
                                          jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::Status s = txn->Commit();
@@ -118,7 +118,7 @@ void Java_org_rocksdb_Transaction_commit(JNIEnv* env, jobject /*jobj*/,
  * Method:    rollback
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_rollback(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_rollback(JNIEnv* env, jclass /*jobj*/,
                                            jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::Status s = txn->Rollback();
@@ -132,8 +132,7 @@ void Java_org_rocksdb_Transaction_rollback(JNIEnv* env, jobject /*jobj*/,
  * Method:    setSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_setSavePoint(JNIEnv* /*env*/,
-                                               jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_setSavePoint(JNIEnv* /*env*/, jclass /*jcls*/,
                                                jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   txn->SetSavePoint();
@@ -145,7 +144,7 @@ void Java_org_rocksdb_Transaction_setSavePoint(JNIEnv* /*env*/,
  * Signature: (J)V
  */
 void Java_org_rocksdb_Transaction_rollbackToSavePoint(JNIEnv* env,
-                                                      jobject /*jobj*/,
+                                                      jclass /*jcls*/,
                                                       jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::Status s = txn->RollbackToSavePoint();
@@ -165,7 +164,7 @@ typedef std::function<ROCKSDB_NAMESPACE::Status(
  * Signature: (JJ[BIIJ)[B
  */
 jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass, jlong jhandle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_part_len,
     jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -192,7 +191,7 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIIJ(
  * Signature: (JJ[BII)[B
  */
 jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BII(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass, jlong jhandle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_part_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* read_options =
@@ -214,7 +213,7 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BII(
  * Signature: (JJ[BII[BIIJ)I
  */
 jint Java_org_rocksdb_Transaction_get__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass, jlong jhandle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_part_len, jbyteArray jval,
     jint jval_off, jint jval_part_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -241,7 +240,7 @@ jint Java_org_rocksdb_Transaction_get__JJ_3BII_3BIIJ(
  * Method:    getDirect
  * Signature: (JJLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)I
  */
-jint Java_org_rocksdb_Transaction_getDirect(JNIEnv* env, jobject, jlong jhandle,
+jint Java_org_rocksdb_Transaction_getDirect(JNIEnv* env, jclass, jlong jhandle,
                                             jlong jread_options_handle,
                                             jobject jkey_bb, jint jkey_off,
                                             jint jkey_part_len, jobject jval_bb,
@@ -408,7 +407,7 @@ jobjectArray txn_multi_get_helper(JNIEnv* env, const FnMultiGet& fn_multi_get,
  * Signature: (JJ[[B[J)[[B
  */
 jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B_3J(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jobjectArray jkey_parts, jlongArray jcolumn_family_handles) {
   bool has_exception = false;
   const std::vector<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>
@@ -436,7 +435,7 @@ jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B_3J(
  * Signature: (JJ[[B)[[B
  */
 jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jobjectArray jkey_parts) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   FnMultiGet fn_multi_get = std::bind<std::vector<ROCKSDB_NAMESPACE::Status> (
@@ -455,7 +454,7 @@ jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B(
  * Signature: (JJ[BIIJZZ)[B
  */
 jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIIJZZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass, jlong jhandle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_part_len,
     jlong jcolumn_family_handle, jboolean jexclusive, jboolean jdo_validate) {
   auto* read_options =
@@ -483,7 +482,7 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIIJZZ(
  * Signature: (JJ[BII[BIIJZZ)I
  */
 jint Java_org_rocksdb_Transaction_getForUpdate__JJ_3BII_3BIIJZZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_part_len, jbyteArray jval,
     jint jval_off, jint jval_len, jlong jcolumn_family_handle,
     jboolean jexclusive, jboolean jdo_validate) {
@@ -513,7 +512,7 @@ jint Java_org_rocksdb_Transaction_getForUpdate__JJ_3BII_3BIIJZZ(
  * Signature: (JJLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJZZ)I
  */
 jint Java_org_rocksdb_Transaction_getDirectForUpdate(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jobject jkey_bb, jint jkey_off, jint jkey_part_len, jobject jval_bb,
     jint jval_off, jint jval_len, jlong jcolumn_family_handle,
     jboolean jexclusive, jboolean jdo_validate) {
@@ -545,7 +544,7 @@ jint Java_org_rocksdb_Transaction_getDirectForUpdate(
  * Signature: (JJ[[B[J)[[B
  */
 jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B_3J(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass, jlong jhandle, jlong jread_options_handle,
     jobjectArray jkey_parts, jlongArray jcolumn_family_handles) {
   bool has_exception = false;
   const std::vector<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>
@@ -574,7 +573,7 @@ jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B_3J(
  * Signature: (JJ[[B)[[B
  */
 jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jobjectArray jkey_parts) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   FnMultiGet fn_multi_get_for_update = std::bind<std::vector<
@@ -593,7 +592,7 @@ jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B(
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_Transaction_getIterator(JNIEnv* /*env*/,
-                                               jobject /*jobj*/, jlong jhandle,
+                                               jclass, jlong jhandle,
                                                jlong jread_options_handle,
                                                jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -612,7 +611,7 @@ jlong Java_org_rocksdb_Transaction_getIterator(JNIEnv* /*env*/,
  * Signature: (J[BII[BIIJZ)V
  */
 void Java_org_rocksdb_Transaction_put__J_3BII_3BIIJZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey,
     jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
     jint jval_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -636,7 +635,7 @@ void Java_org_rocksdb_Transaction_put__J_3BII_3BIIJZ(
  * Signature: (J[BII[BII)V
  */
 void Java_org_rocksdb_Transaction_put__J_3BII_3BII(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
     jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -656,7 +655,7 @@ void Java_org_rocksdb_Transaction_put__J_3BII_3BII(
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJZ)V
  */
 void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2IIJZ(
-    JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
+    JNIEnv* env, jclass, jlong jhandle, jobject jkey_bb, jint jkey_off,
     jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len,
     jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -681,7 +680,7 @@ void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)V
  */
 void Java_org_rocksdb_Transaction_putDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2II(
-    JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
+    JNIEnv* env, jclass, jlong jhandle, jobject jkey_bb, jint jkey_off,
     jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   try {
@@ -804,7 +803,7 @@ void txn_write_kv_parts_helper(JNIEnv* env,
  * Signature: (J[[BI[[BIJZ)V
  */
 void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len,
     jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -828,7 +827,7 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
  * Signature: (J[[BI[[BI)V
  */
 void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   FnWriteKVParts fn_put_parts = std::bind<ROCKSDB_NAMESPACE::Status (
@@ -846,7 +845,7 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(
  * Signature: (J[BII[BIIJZ)V
  */
 void Java_org_rocksdb_Transaction_merge__J_3BII_3BIIJZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey,
     jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
     jint jval_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -870,7 +869,7 @@ void Java_org_rocksdb_Transaction_merge__J_3BII_3BIIJZ(
  * Signature: (J[BII[BII)V
  */
 void Java_org_rocksdb_Transaction_merge__J_3BII_3BII(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
     jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -891,7 +890,7 @@ void Java_org_rocksdb_Transaction_merge__J_3BII_3BII(
  */
 JNIEXPORT void JNICALL
 Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2IIJZ(
-    JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
+    JNIEnv* env, jclass, jlong jhandle, jobject jkey_bb, jint jkey_off,
     jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len,
     jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -917,7 +916,7 @@ Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_Byt
  */
 JNIEXPORT void JNICALL
 Java_org_rocksdb_Transaction_mergeDirect__JLjava_nio_ByteBuffer_2IILjava_nio_ByteBuffer_2II(
-    JNIEnv* env, jobject, jlong jhandle, jobject jkey_bb, jint jkey_off,
+    JNIEnv* env, jclass, jlong jhandle, jobject jkey_bb, jint jkey_off,
     jint jkey_len, jobject jval_bb, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   try {
@@ -965,7 +964,7 @@ void txn_write_k_helper(JNIEnv* env, const FnWriteK& fn_write_k,
  * Signature: (J[BIJZ)V
  */
 void Java_org_rocksdb_Transaction_delete__J_3BIJZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
@@ -985,7 +984,7 @@ void Java_org_rocksdb_Transaction_delete__J_3BIJZ(
  * Method:    delete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3BI(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_delete__J_3BI(JNIEnv* env, jclass /*jobj*/,
                                                 jlong jhandle, jbyteArray jkey,
                                                 jint jkey_part_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1053,7 +1052,7 @@ void txn_write_k_parts_helper(JNIEnv* env,
  * Signature: (J[[BIJZ)V
  */
 void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle,
     jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1074,7 +1073,7 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
  * Method:    delete
  * Signature: (J[[BI)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jclass /*jobj*/,
                                                   jlong jhandle,
                                                   jobjectArray jkey_parts,
                                                   jint jkey_parts_len) {
@@ -1091,7 +1090,7 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject /*jobj*/,
  * Signature: (J[BIJZ)V
  */
 void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
@@ -1112,7 +1111,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
  * Signature: (J[BI)V
  */
 void Java_org_rocksdb_Transaction_singleDelete__J_3BI(JNIEnv* env,
-                                                      jobject /*jobj*/,
+                                                      jclass /*jcls*/,
                                                       jlong jhandle,
                                                       jbyteArray jkey,
                                                       jint jkey_part_len) {
@@ -1130,7 +1129,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BI(JNIEnv* env,
  * Signature: (J[[BIJZ)V
  */
 void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle,
     jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1153,7 +1152,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
  * Signature: (J[[BI)V
  */
 void Java_org_rocksdb_Transaction_singleDelete__J_3_3BI(JNIEnv* env,
-                                                        jobject /*jobj*/,
+                                                        jclass /*jcls*/,
                                                         jlong jhandle,
                                                         jobjectArray jkey_parts,
                                                         jint jkey_parts_len) {
@@ -1172,7 +1171,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3_3BI(JNIEnv* env,
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len,
     jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1196,7 +1195,7 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BI(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   try {
@@ -1215,7 +1214,7 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BI(
  * Signature: (J[[BI[[BIJ)V
  */
 void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len,
     jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1238,7 +1237,7 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BIJ(
  * Signature: (J[[BI[[BI)V
  */
 void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BI(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   FnWriteKVParts fn_put_parts_untracked = std::bind<ROCKSDB_NAMESPACE::Status (
@@ -1256,7 +1255,7 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BI(
  * Signature: (J[BII[BIIJ)V
  */
 void Java_org_rocksdb_Transaction_mergeUntracked(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey,
     jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
     jint jval_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1280,7 +1279,7 @@ void Java_org_rocksdb_Transaction_mergeUntracked(
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)V
  */
 void Java_org_rocksdb_Transaction_mergeUntrackedDirect(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobject jkey, jint jkey_off,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobject jkey, jint jkey_off,
     jint jkey_part_len, jobject jval, jint jval_off, jint jval_len,
     jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1305,7 +1304,7 @@ void Java_org_rocksdb_Transaction_mergeUntrackedDirect(
  * Signature: (J[BIJ)V
  */
 void Java_org_rocksdb_Transaction_deleteUntracked__J_3BIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
@@ -1325,7 +1324,7 @@ void Java_org_rocksdb_Transaction_deleteUntracked__J_3BIJ(
  * Signature: (J[BI)V
  */
 void Java_org_rocksdb_Transaction_deleteUntracked__J_3BI(JNIEnv* env,
-                                                         jobject /*jobj*/,
+                                                         jclass /*jcls*/,
                                                          jlong jhandle,
                                                          jbyteArray jkey,
                                                          jint jkey_part_len) {
@@ -1343,7 +1342,7 @@ void Java_org_rocksdb_Transaction_deleteUntracked__J_3BI(JNIEnv* env,
  * Signature: (J[[BIJ)V
  */
 void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
@@ -1365,7 +1364,7 @@ void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BIJ(
  * Signature: (J[[BI)V
  */
 void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BI(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   FnWriteKParts fn_delete_untracked_parts =
@@ -1382,7 +1381,7 @@ void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BI(
  * Method:    putLogData
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_Transaction_putLogData(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_putLogData(JNIEnv* env, jclass /*jobj*/,
                                              jlong jhandle, jbyteArray jkey,
                                              jint jkey_part_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1409,7 +1408,7 @@ void Java_org_rocksdb_Transaction_putLogData(JNIEnv* env, jobject /*jobj*/,
  * Signature: (J)V
  */
 void Java_org_rocksdb_Transaction_disableIndexing(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
+                                                  jclass /*jcls*/,
                                                   jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   txn->DisableIndexing();
@@ -1421,7 +1420,7 @@ void Java_org_rocksdb_Transaction_disableIndexing(JNIEnv* /*env*/,
  * Signature: (J)V
  */
 void Java_org_rocksdb_Transaction_enableIndexing(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
+                                                 jclass /*jcls*/,
                                                  jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   txn->EnableIndexing();
@@ -1432,7 +1431,7 @@ void Java_org_rocksdb_Transaction_enableIndexing(JNIEnv* /*env*/,
  * Method:    getNumKeys
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getNumKeys(JNIEnv* /*env*/, jobject /*jobj*/,
+jlong Java_org_rocksdb_Transaction_getNumKeys(JNIEnv* /*env*/, jclass /*jcls*/,
                                               jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return txn->GetNumKeys();
@@ -1443,7 +1442,7 @@ jlong Java_org_rocksdb_Transaction_getNumKeys(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    getNumPuts
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getNumPuts(JNIEnv* /*env*/, jobject /*jobj*/,
+jlong Java_org_rocksdb_Transaction_getNumPuts(JNIEnv* /*env*/, jclass /*jcls*/,
                                               jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return txn->GetNumPuts();
@@ -1455,7 +1454,7 @@ jlong Java_org_rocksdb_Transaction_getNumPuts(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Transaction_getNumDeletes(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
+                                                 jclass /*jcls*/,
                                                  jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return txn->GetNumDeletes();
@@ -1467,7 +1466,7 @@ jlong Java_org_rocksdb_Transaction_getNumDeletes(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Transaction_getNumMerges(JNIEnv* /*env*/,
-                                                jobject /*jobj*/,
+                                                jclass /*jcls*/,
                                                 jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return txn->GetNumMerges();
@@ -1479,7 +1478,7 @@ jlong Java_org_rocksdb_Transaction_getNumMerges(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Transaction_getElapsedTime(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
+                                                  jclass /*jcls*/,
                                                   jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return txn->GetElapsedTime();
@@ -1491,7 +1490,7 @@ jlong Java_org_rocksdb_Transaction_getElapsedTime(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Transaction_getWriteBatch(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
+                                                 jclass /*jcls*/,
                                                  jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return GET_CPLUSPLUS_POINTER(txn->GetWriteBatch());
@@ -1503,8 +1502,7 @@ jlong Java_org_rocksdb_Transaction_getWriteBatch(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Transaction_setLockTimeout(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong jhandle,
+                                                 jclass /*jcls*/, jlong jhandle,
                                                  jlong jlock_timeout) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   txn->SetLockTimeout(jlock_timeout);
@@ -1516,7 +1514,7 @@ void Java_org_rocksdb_Transaction_setLockTimeout(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Transaction_getWriteOptions(JNIEnv* /*env*/,
-                                                   jobject /*jobj*/,
+                                                   jclass /*jcls*/,
                                                    jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return GET_CPLUSPLUS_POINTER(txn->GetWriteOptions());
@@ -1528,7 +1526,7 @@ jlong Java_org_rocksdb_Transaction_getWriteOptions(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Transaction_setWriteOptions(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
+                                                  jclass /*jcls*/,
                                                   jlong jhandle,
                                                   jlong jwrite_options_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -1543,7 +1541,7 @@ void Java_org_rocksdb_Transaction_setWriteOptions(JNIEnv* /*env*/,
  * Signature: (J[BIJ)V
  */
 void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
@@ -1568,7 +1566,7 @@ void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BIJ(
  * Signature: (J[BI)V
  */
 void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BI(JNIEnv* env,
-                                                          jobject /*jobj*/,
+                                                          jclass /*jcls*/,
                                                           jlong jhandle,
                                                           jbyteArray jkey,
                                                           jint jkey_part_len) {
@@ -1592,7 +1590,7 @@ void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BI(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Transaction_rebuildFromWriteBatch(
-    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jwrite_batch_handle) {
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jlong jwrite_batch_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* write_batch =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwrite_batch_handle);
@@ -1608,7 +1606,7 @@ void Java_org_rocksdb_Transaction_rebuildFromWriteBatch(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Transaction_getCommitTimeWriteBatch(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
+                                                           jclass /*jcls*/,
                                                            jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return GET_CPLUSPLUS_POINTER(txn->GetCommitTimeWriteBatch());
@@ -1619,8 +1617,8 @@ jlong Java_org_rocksdb_Transaction_getCommitTimeWriteBatch(JNIEnv* /*env*/,
  * Method:    setLogNumber
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Transaction_setLogNumber(JNIEnv* /*env*/,
-                                               jobject /*jobj*/, jlong jhandle,
+void Java_org_rocksdb_Transaction_setLogNumber(JNIEnv* /*env*/, jclass /*jcls*/,
+                                               jlong jhandle,
                                                jlong jlog_number) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   txn->SetLogNumber(jlog_number);
@@ -1632,7 +1630,7 @@ void Java_org_rocksdb_Transaction_setLogNumber(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Transaction_getLogNumber(JNIEnv* /*env*/,
-                                                jobject /*jobj*/,
+                                                jclass /*jcls*/,
                                                 jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return txn->GetLogNumber();
@@ -1643,7 +1641,7 @@ jlong Java_org_rocksdb_Transaction_getLogNumber(JNIEnv* /*env*/,
  * Method:    setName
  * Signature: (JLjava/lang/String;)V
  */
-void Java_org_rocksdb_Transaction_setName(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_setName(JNIEnv* env, jclass /*jobj*/,
                                           jlong jhandle, jstring jname) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   const char* name = env->GetStringUTFChars(jname, nullptr);
@@ -1666,7 +1664,7 @@ void Java_org_rocksdb_Transaction_setName(JNIEnv* env, jobject /*jobj*/,
  * Method:    getName
  * Signature: (J)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_Transaction_getName(JNIEnv* env, jobject /*jobj*/,
+jstring Java_org_rocksdb_Transaction_getName(JNIEnv* env, jclass /*jobj*/,
                                              jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::TransactionName name = txn->GetName();
@@ -1678,7 +1676,7 @@ jstring Java_org_rocksdb_Transaction_getName(JNIEnv* env, jobject /*jobj*/,
  * Method:    getID
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getID(JNIEnv* /*env*/, jobject /*jobj*/,
+jlong Java_org_rocksdb_Transaction_getID(JNIEnv* /*env*/, jclass /*jcls*/,
                                          jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::TransactionID id = txn->GetID();
@@ -1691,7 +1689,7 @@ jlong Java_org_rocksdb_Transaction_getID(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Transaction_isDeadlockDetect(JNIEnv* /*env*/,
-                                                       jobject /*jobj*/,
+                                                       jclass /*jcls*/,
                                                        jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   return static_cast<jboolean>(txn->IsDeadlockDetect());
@@ -1721,7 +1719,7 @@ jobject Java_org_rocksdb_Transaction_getWaitingTxns(JNIEnv* env,
  * Method:    getState
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Transaction_getState(JNIEnv* /*env*/, jobject /*jobj*/,
+jbyte Java_org_rocksdb_Transaction_getState(JNIEnv* /*env*/, jclass /*jcls*/,
                                             jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   ROCKSDB_NAMESPACE::Transaction::TransactionState txn_status = txn->GetState();
@@ -1760,7 +1758,7 @@ jbyte Java_org_rocksdb_Transaction_getState(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    getId
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getId(JNIEnv* /*env*/, jobject /*jobj*/,
+jlong Java_org_rocksdb_Transaction_getId(JNIEnv* /*env*/, jclass /*jcls*/,
                                          jlong jhandle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   uint64_t id = txn->GetId();

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -591,8 +591,8 @@ jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B(
  * Method:    getIterator
  * Signature: (JJJ)J
  */
-jlong Java_org_rocksdb_Transaction_getIterator(JNIEnv* /*env*/,
-                                               jclass, jlong jhandle,
+jlong Java_org_rocksdb_Transaction_getIterator(JNIEnv* /*env*/, jclass,
+                                               jlong jhandle,
                                                jlong jread_options_handle,
                                                jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
@@ -611,9 +611,9 @@ jlong Java_org_rocksdb_Transaction_getIterator(JNIEnv* /*env*/,
  * Signature: (J[BII[BIIJZ)V
  */
 void Java_org_rocksdb_Transaction_put__J_3BII_3BIIJZ(
-    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey,
-    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
-    jint jval_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
+    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey, jint jkey_off,
+    jint jkey_part_len, jbyteArray jval, jint jval_off, jint jval_len,
+    jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
@@ -635,9 +635,8 @@ void Java_org_rocksdb_Transaction_put__J_3BII_3BIIJZ(
  * Signature: (J[BII[BII)V
  */
 void Java_org_rocksdb_Transaction_put__J_3BII_3BII(
-    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
-    jint jval_len) {
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey, jint jkey_off,
+    jint jkey_part_len, jbyteArray jval, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   try {
     ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
@@ -845,9 +844,9 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(
  * Signature: (J[BII[BIIJZ)V
  */
 void Java_org_rocksdb_Transaction_merge__J_3BII_3BIIJZ(
-    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey,
-    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
-    jint jval_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
+    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey, jint jkey_off,
+    jint jkey_part_len, jbyteArray jval, jint jval_off, jint jval_len,
+    jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(
@@ -869,9 +868,8 @@ void Java_org_rocksdb_Transaction_merge__J_3BII_3BIIJZ(
  * Signature: (J[BII[BII)V
  */
 void Java_org_rocksdb_Transaction_merge__J_3BII_3BII(
-    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
-    jint jval_len) {
+    JNIEnv* env, jclass /*jobj*/, jlong jhandle, jbyteArray jkey, jint jkey_off,
+    jint jkey_part_len, jbyteArray jval, jint jval_off, jint jval_len) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   try {
     ROCKSDB_NAMESPACE::JByteArraySlice key(env, jkey, jkey_off, jkey_part_len);
@@ -1255,9 +1253,9 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BI(
  * Signature: (J[BII[BIIJ)V
  */
 void Java_org_rocksdb_Transaction_mergeUntracked(
-    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey,
-    jint jkey_off, jint jkey_part_len, jbyteArray jval, jint jval_off,
-    jint jval_len, jlong jcolumn_family_handle) {
+    JNIEnv* env, jclass, jlong jhandle, jbyteArray jkey, jint jkey_off,
+    jint jkey_part_len, jbyteArray jval, jint jval_off, jint jval_len,
+    jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<ROCKSDB_NAMESPACE::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(

--- a/java/rocksjni/transaction_db.cc
+++ b/java/rocksjni/transaction_db.cc
@@ -147,8 +147,8 @@ jlongArray Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2_3_3B_3J(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionDB_disposeInternal(JNIEnv*, jobject,
-                                                    jlong jhandle) {
+void Java_org_rocksdb_TransactionDB_disposeInternalJni(JNIEnv*, jclass,
+                                                       jlong jhandle) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   assert(txn_db != nullptr);
   delete txn_db;
@@ -173,7 +173,7 @@ void Java_org_rocksdb_TransactionDB_closeDatabase(JNIEnv* env, jclass,
  * Signature: (JJ)J
  */
 jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJ(
-    JNIEnv*, jobject, jlong jhandle, jlong jwrite_options_handle) {
+    JNIEnv*, jclass, jlong jhandle, jlong jwrite_options_handle) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   auto* write_options =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteOptions*>(jwrite_options_handle);
@@ -188,7 +188,7 @@ jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJ(
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJJ(
-    JNIEnv*, jobject, jlong jhandle, jlong jwrite_options_handle,
+    JNIEnv*, jclass, jlong jhandle, jlong jwrite_options_handle,
     jlong jtxn_options_handle) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   auto* write_options =
@@ -206,7 +206,7 @@ jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJJ(
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_TransactionDB_beginTransaction_1withOld__JJJ(
-    JNIEnv*, jobject, jlong jhandle, jlong jwrite_options_handle,
+    JNIEnv*, jclass, jlong jhandle, jlong jwrite_options_handle,
     jlong jold_txn_handle) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   auto* write_options =
@@ -231,7 +231,7 @@ jlong Java_org_rocksdb_TransactionDB_beginTransaction_1withOld__JJJ(
  * Signature: (JJJJ)J
  */
 jlong Java_org_rocksdb_TransactionDB_beginTransaction_1withOld__JJJJ(
-    JNIEnv*, jobject, jlong jhandle, jlong jwrite_options_handle,
+    JNIEnv*, jclass, jlong jhandle, jlong jwrite_options_handle,
     jlong jtxn_options_handle, jlong jold_txn_handle) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   auto* write_options =
@@ -256,7 +256,7 @@ jlong Java_org_rocksdb_TransactionDB_beginTransaction_1withOld__JJJJ(
  * Method:    getTransactionByName
  * Signature: (JLjava/lang/String;)J
  */
-jlong Java_org_rocksdb_TransactionDB_getTransactionByName(JNIEnv* env, jobject,
+jlong Java_org_rocksdb_TransactionDB_getTransactionByName(JNIEnv* env, jclass,
                                                           jlong jhandle,
                                                           jstring jname) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
@@ -276,7 +276,7 @@ jlong Java_org_rocksdb_TransactionDB_getTransactionByName(JNIEnv* env, jobject,
  * Signature: (J)[J
  */
 jlongArray Java_org_rocksdb_TransactionDB_getAllPreparedTransactions(
-    JNIEnv* env, jobject, jlong jhandle) {
+    JNIEnv* env, jclass, jlong jhandle) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   std::vector<ROCKSDB_NAMESPACE::Transaction*> txns;
   txn_db->GetAllPreparedTransactions(&txns);
@@ -310,7 +310,7 @@ jlongArray Java_org_rocksdb_TransactionDB_getAllPreparedTransactions(
  * Method:    getLockStatusData
  * Signature: (J)Ljava/util/Map;
  */
-jobject Java_org_rocksdb_TransactionDB_getLockStatusData(JNIEnv* env, jobject,
+jobject Java_org_rocksdb_TransactionDB_getLockStatusData(JNIEnv* env, jclass,
                                                          jlong jhandle) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   const std::unordered_multimap<uint32_t, ROCKSDB_NAMESPACE::KeyLockInfo>
@@ -360,7 +360,7 @@ jobject Java_org_rocksdb_TransactionDB_getLockStatusData(JNIEnv* env, jobject,
  * Signature: (J)[Lorg/rocksdb/TransactionDB/DeadlockPath;
  */
 jobjectArray Java_org_rocksdb_TransactionDB_getDeadlockInfoBuffer(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* env, jclass jobj, jlong jhandle) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   const std::vector<ROCKSDB_NAMESPACE::DeadlockPath> deadlock_info_buffer =
       txn_db->GetDeadlockInfoBuffer();
@@ -445,7 +445,7 @@ jobjectArray Java_org_rocksdb_TransactionDB_getDeadlockInfoBuffer(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_TransactionDB_setDeadlockInfoBufferSize(
-    JNIEnv*, jobject, jlong jhandle, jint jdeadlock_info_buffer_size) {
+    JNIEnv*, jclass, jlong jhandle, jint jdeadlock_info_buffer_size) {
   auto* txn_db = reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDB*>(jhandle);
   txn_db->SetDeadlockInfoBufferSize(jdeadlock_info_buffer_size);
 }

--- a/java/rocksjni/transaction_db_options.cc
+++ b/java/rocksjni/transaction_db_options.cc
@@ -31,7 +31,7 @@ jlong Java_org_rocksdb_TransactionDBOptions_newTransactionDBOptions(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionDBOptions_getMaxNumLocks(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
+                                                           jclass /*jcls*/,
                                                            jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
@@ -44,7 +44,7 @@ jlong Java_org_rocksdb_TransactionDBOptions_getMaxNumLocks(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionDBOptions_setMaxNumLocks(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong jmax_num_locks) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jlong jmax_num_locks) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
   opts->max_num_locks = jmax_num_locks;
@@ -56,7 +56,7 @@ void Java_org_rocksdb_TransactionDBOptions_setMaxNumLocks(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionDBOptions_getNumStripes(JNIEnv* /*env*/,
-                                                          jobject /*jobj*/,
+                                                          jclass /*jcls*/,
                                                           jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
@@ -69,7 +69,7 @@ jlong Java_org_rocksdb_TransactionDBOptions_getNumStripes(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionDBOptions_setNumStripes(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
+                                                         jclass /*jcls*/,
                                                          jlong jhandle,
                                                          jlong jnum_stripes) {
   auto* opts =
@@ -83,7 +83,7 @@ void Java_org_rocksdb_TransactionDBOptions_setNumStripes(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionDBOptions_getTransactionLockTimeout(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
   return opts->transaction_lock_timeout;
@@ -95,7 +95,7 @@ jlong Java_org_rocksdb_TransactionDBOptions_getTransactionLockTimeout(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionDBOptions_setTransactionLockTimeout(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jtransaction_lock_timeout) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
@@ -108,7 +108,7 @@ void Java_org_rocksdb_TransactionDBOptions_setTransactionLockTimeout(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionDBOptions_getDefaultLockTimeout(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
   return opts->default_lock_timeout;
@@ -120,7 +120,7 @@ jlong Java_org_rocksdb_TransactionDBOptions_getDefaultLockTimeout(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionDBOptions_setDefaultLockTimeout(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jdefault_lock_timeout) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
@@ -133,7 +133,7 @@ void Java_org_rocksdb_TransactionDBOptions_setDefaultLockTimeout(
  * Signature: (J)B
  */
 jbyte Java_org_rocksdb_TransactionDBOptions_getWritePolicy(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
+                                                           jclass /*jcls*/,
                                                            jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
@@ -147,7 +147,7 @@ jbyte Java_org_rocksdb_TransactionDBOptions_getWritePolicy(JNIEnv* /*env*/,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_TransactionDBOptions_setWritePolicy(JNIEnv* /*env*/,
-                                                          jobject /*jobj*/,
+                                                          jclass /*jcls*/,
                                                           jlong jhandle,
                                                           jbyte jwrite_policy) {
   auto* opts =
@@ -162,8 +162,8 @@ void Java_org_rocksdb_TransactionDBOptions_setWritePolicy(JNIEnv* /*env*/,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionDBOptions_disposeInternal(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
-                                                           jlong jhandle) {
+void Java_org_rocksdb_TransactionDBOptions_disposeInternalJni(JNIEnv* /*env*/,
+                                                              jclass /*jcls*/,
+                                                              jlong jhandle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::TransactionDBOptions*>(jhandle);
 }

--- a/java/rocksjni/transaction_log.cc
+++ b/java/rocksjni/transaction_log.cc
@@ -20,9 +20,9 @@
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionLogIterator_disposeInternal(JNIEnv* /*env*/,
-                                                             jobject /*jobj*/,
-                                                             jlong handle) {
+void Java_org_rocksdb_TransactionLogIterator_disposeInternalJni(JNIEnv* /*env*/,
+                                                                jclass /*jcls*/,
+                                                                jlong handle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::TransactionLogIterator*>(handle);
 }
 
@@ -32,7 +32,7 @@ void Java_org_rocksdb_TransactionLogIterator_disposeInternal(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_TransactionLogIterator_isValid(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
+                                                         jclass /*jcls*/,
                                                          jlong handle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::TransactionLogIterator*>(handle)
       ->Valid();
@@ -44,7 +44,7 @@ jboolean Java_org_rocksdb_TransactionLogIterator_isValid(JNIEnv* /*env*/,
  * Signature: (J)V
  */
 void Java_org_rocksdb_TransactionLogIterator_next(JNIEnv* /*env*/,
-                                                  jobject /*jobj*/,
+                                                  jclass /*jcls*/,
                                                   jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::TransactionLogIterator*>(handle)->Next();
 }
@@ -55,7 +55,7 @@ void Java_org_rocksdb_TransactionLogIterator_next(JNIEnv* /*env*/,
  * Signature: (J)V
  */
 void Java_org_rocksdb_TransactionLogIterator_status(JNIEnv* env,
-                                                    jobject /*jobj*/,
+                                                    jclass /*jcls*/,
                                                     jlong handle) {
   ROCKSDB_NAMESPACE::Status s =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionLogIterator*>(handle)
@@ -71,7 +71,7 @@ void Java_org_rocksdb_TransactionLogIterator_status(JNIEnv* env,
  * Signature: (J)Lorg/rocksdb/TransactionLogIterator$BatchResult
  */
 jobject Java_org_rocksdb_TransactionLogIterator_getBatch(JNIEnv* env,
-                                                         jobject /*jobj*/,
+                                                         jclass /*jcls*/,
                                                          jlong handle) {
   ROCKSDB_NAMESPACE::BatchResult batch_result =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionLogIterator*>(handle)

--- a/java/rocksjni/transaction_notifier.cc
+++ b/java/rocksjni/transaction_notifier.cc
@@ -32,8 +32,8 @@ jlong Java_org_rocksdb_AbstractTransactionNotifier_createNewTransactionNotifier(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_AbstractTransactionNotifier_disposeInternal(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+void Java_org_rocksdb_AbstractTransactionNotifier_disposeInternalJni(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   // TODO(AR) refactor to use JniCallback::JniCallback
   // when https://github.com/facebook/rocksdb/pull/1241/ is merged
   std::shared_ptr<ROCKSDB_NAMESPACE::TransactionNotifierJniCallback>* handle =

--- a/java/rocksjni/transaction_options.cc
+++ b/java/rocksjni/transaction_options.cc
@@ -29,7 +29,7 @@ jlong Java_org_rocksdb_TransactionOptions_newTransactionOptions(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_TransactionOptions_isSetSnapshot(JNIEnv* /*env*/,
-                                                           jobject /*jobj*/,
+                                                           jclass /*jcls*/,
                                                            jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
@@ -42,7 +42,7 @@ jboolean Java_org_rocksdb_TransactionOptions_isSetSnapshot(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_TransactionOptions_setSetSnapshot(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean jset_snapshot) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jboolean jset_snapshot) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
   opts->set_snapshot = jset_snapshot;
@@ -54,7 +54,7 @@ void Java_org_rocksdb_TransactionOptions_setSetSnapshot(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_TransactionOptions_isDeadlockDetect(JNIEnv* /*env*/,
-                                                              jobject /*jobj*/,
+                                                              jclass /*jcls*/,
                                                               jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
@@ -67,7 +67,7 @@ jboolean Java_org_rocksdb_TransactionOptions_isDeadlockDetect(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_TransactionOptions_setDeadlockDetect(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jboolean jdeadlock_detect) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
@@ -80,7 +80,7 @@ void Java_org_rocksdb_TransactionOptions_setDeadlockDetect(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionOptions_getLockTimeout(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
+                                                         jclass /*jcls*/,
                                                          jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
@@ -93,7 +93,7 @@ jlong Java_org_rocksdb_TransactionOptions_getLockTimeout(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionOptions_setLockTimeout(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
+                                                        jclass /*jcls*/,
                                                         jlong jhandle,
                                                         jlong jlock_timeout) {
   auto* opts =
@@ -107,7 +107,7 @@ void Java_org_rocksdb_TransactionOptions_setLockTimeout(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionOptions_getExpiration(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
+                                                        jclass /*jcls*/,
                                                         jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
@@ -120,7 +120,7 @@ jlong Java_org_rocksdb_TransactionOptions_getExpiration(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionOptions_setExpiration(JNIEnv* /*env*/,
-                                                       jobject /*jobj*/,
+                                                       jclass /*jcls*/,
                                                        jlong jhandle,
                                                        jlong jexpiration) {
   auto* opts =
@@ -134,7 +134,7 @@ void Java_org_rocksdb_TransactionOptions_setExpiration(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionOptions_getDeadlockDetectDepth(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
   return opts->deadlock_detect_depth;
@@ -146,7 +146,7 @@ jlong Java_org_rocksdb_TransactionOptions_getDeadlockDetectDepth(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionOptions_setDeadlockDetectDepth(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jdeadlock_detect_depth) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
@@ -159,7 +159,7 @@ void Java_org_rocksdb_TransactionOptions_setDeadlockDetectDepth(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionOptions_getMaxWriteBatchSize(JNIEnv* /*env*/,
-                                                               jobject /*jobj*/,
+                                                               jclass /*jcls*/,
                                                                jlong jhandle) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
@@ -172,7 +172,7 @@ jlong Java_org_rocksdb_TransactionOptions_getMaxWriteBatchSize(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionOptions_setMaxWriteBatchSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle,
     jlong jmax_write_batch_size) {
   auto* opts =
       reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
@@ -184,8 +184,8 @@ void Java_org_rocksdb_TransactionOptions_setMaxWriteBatchSize(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionOptions_disposeInternal(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
-                                                         jlong jhandle) {
+void Java_org_rocksdb_TransactionOptions_disposeInternalJni(JNIEnv* /*env*/,
+                                                            jclass /*jobj*/,
+                                                            jlong jhandle) {
   delete reinterpret_cast<ROCKSDB_NAMESPACE::TransactionOptions*>(jhandle);
 }

--- a/java/rocksjni/ttl.cc
+++ b/java/rocksjni/ttl.cc
@@ -154,7 +154,7 @@ jlongArray Java_org_rocksdb_TtlDB_openCF(JNIEnv* env, jclass, jlong jopt_handle,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TtlDB_disposeInternal(JNIEnv*, jobject, jlong jhandle) {
+void Java_org_rocksdb_TtlDB_disposeInternalJni(JNIEnv*, jclass, jlong jhandle) {
   auto* ttl_db = reinterpret_cast<ROCKSDB_NAMESPACE::DBWithTTL*>(jhandle);
   assert(ttl_db != nullptr);
   delete ttl_db;
@@ -181,7 +181,7 @@ void Java_org_rocksdb_TtlDB_closeDatabase(JNIEnv* /* env */, jclass,
  * Method:    createColumnFamilyWithTtl
  * Signature: (JLorg/rocksdb/ColumnFamilyDescriptor;[BJI)J;
  */
-jlong Java_org_rocksdb_TtlDB_createColumnFamilyWithTtl(JNIEnv* env, jobject,
+jlong Java_org_rocksdb_TtlDB_createColumnFamilyWithTtl(JNIEnv* env, jclass,
                                                        jlong jdb_handle,
                                                        jbyteArray jcolumn_name,
                                                        jlong jcolumn_options,

--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -65,8 +65,8 @@ jlong Java_org_rocksdb_WriteBatch_newWriteBatch___3BI(JNIEnv* env,
  * Method:    count0
  * Signature: (J)I
  */
-jint Java_org_rocksdb_WriteBatch_count0(JNIEnv* /*env*/, jobject /*jobj*/,
-                                        jlong jwb_handle) {
+jint Java_org_rocksdb_WriteBatch_count0Jni(JNIEnv* /*env*/, jclass /*jobj*/,
+                                           jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -78,8 +78,8 @@ jint Java_org_rocksdb_WriteBatch_count0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    clear0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
-                                        jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_clear0Jni(JNIEnv* /*env*/, jclass /*jobj*/,
+                                           jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -91,9 +91,9 @@ void Java_org_rocksdb_WriteBatch_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    setSavePoint0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_setSavePoint0(JNIEnv* /*env*/,
-                                               jobject /*jobj*/,
-                                               jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_setSavePoint0Jni(JNIEnv* /*env*/,
+                                                  jclass /*jobj*/,
+                                                  jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -105,9 +105,9 @@ void Java_org_rocksdb_WriteBatch_setSavePoint0(JNIEnv* /*env*/,
  * Method:    rollbackToSavePoint0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0(JNIEnv* env,
-                                                      jobject /*jobj*/,
-                                                      jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0Jni(JNIEnv* env,
+                                                         jclass /*jobj*/,
+                                                         jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -124,8 +124,8 @@ void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0(JNIEnv* env,
  * Method:    popSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_popSavePoint(JNIEnv* env, jobject /*jobj*/,
-                                              jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_popSavePointJni(JNIEnv* env, jclass /*jobj*/,
+                                                 jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -142,9 +142,10 @@ void Java_org_rocksdb_WriteBatch_popSavePoint(JNIEnv* env, jobject /*jobj*/,
  * Method:    setMaxBytes
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatch_setMaxBytes(JNIEnv* /*env*/, jobject /*jobj*/,
-                                             jlong jwb_handle,
-                                             jlong jmax_bytes) {
+void Java_org_rocksdb_WriteBatch_setMaxBytesJni(JNIEnv* /*env*/,
+                                                jclass /*jobj*/,
+                                                jlong jwb_handle,
+                                                jlong jmax_bytes) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -156,11 +157,9 @@ void Java_org_rocksdb_WriteBatch_setMaxBytes(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    put
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_WriteBatch_put__J_3BI_3BI(JNIEnv* env, jobject jobj,
-                                                jlong jwb_handle,
-                                                jbyteArray jkey, jint jkey_len,
-                                                jbyteArray jentry_value,
-                                                jint jentry_value_len) {
+void Java_org_rocksdb_WriteBatch_putJni__J_3BI_3BI(
+    JNIEnv* env, jclass, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
+    jbyteArray jentry_value, jint jentry_value_len) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto put = [&wb](ROCKSDB_NAMESPACE::Slice key,
@@ -168,8 +167,8 @@ void Java_org_rocksdb_WriteBatch_put__J_3BI_3BI(JNIEnv* env, jobject jobj,
     return wb->Put(key, value);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(put, env, jobj, jkey, jkey_len,
-                                        jentry_value, jentry_value_len);
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(put, env, jkey, jkey_len, jentry_value,
+                                        jentry_value_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -180,8 +179,8 @@ void Java_org_rocksdb_WriteBatch_put__J_3BI_3BI(JNIEnv* env, jobject jobj,
  * Method:    put
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_WriteBatch_put__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
+void Java_org_rocksdb_WriteBatch_putJni__J_3BI_3BIJ(
+    JNIEnv* env, jclass, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
     jbyteArray jentry_value, jint jentry_value_len, jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -193,8 +192,8 @@ void Java_org_rocksdb_WriteBatch_put__J_3BI_3BIJ(
     return wb->Put(cf_handle, key, value);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(put, env, jobj, jkey, jkey_len,
-                                        jentry_value, jentry_value_len);
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(put, env, jkey, jkey_len, jentry_value,
+                                        jentry_value_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -205,11 +204,11 @@ void Java_org_rocksdb_WriteBatch_put__J_3BI_3BIJ(
  * Method:    putDirect
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)V
  */
-void Java_org_rocksdb_WriteBatch_putDirect(JNIEnv* env, jobject /*jobj*/,
-                                           jlong jwb_handle, jobject jkey,
-                                           jint jkey_offset, jint jkey_len,
-                                           jobject jval, jint jval_offset,
-                                           jint jval_len, jlong jcf_handle) {
+void Java_org_rocksdb_WriteBatch_putDirectJni(JNIEnv* env, jclass /*jobj*/,
+                                              jlong jwb_handle, jobject jkey,
+                                              jint jkey_offset, jint jkey_len,
+                                              jobject jval, jint jval_offset,
+                                              jint jval_len, jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle =
@@ -231,8 +230,8 @@ void Java_org_rocksdb_WriteBatch_putDirect(JNIEnv* env, jobject /*jobj*/,
  * Method:    merge
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
+void Java_org_rocksdb_WriteBatch_mergeJni__J_3BI_3BI(
+    JNIEnv* env, jclass, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
     jbyteArray jentry_value, jint jentry_value_len) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -241,7 +240,7 @@ void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BI(
     return wb->Merge(key, value);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(merge, env, jobj, jkey, jkey_len,
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(merge, env, jkey, jkey_len,
                                         jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
@@ -253,8 +252,8 @@ void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BI(
  * Method:    merge
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
+void Java_org_rocksdb_WriteBatch_mergeJni__J_3BI_3BIJ(
+    JNIEnv* env, jclass, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
     jbyteArray jentry_value, jint jentry_value_len, jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -266,7 +265,7 @@ void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BIJ(
     return wb->Merge(cf_handle, key, value);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(merge, env, jobj, jkey, jkey_len,
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(merge, env, jkey, jkey_len,
                                         jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
@@ -278,14 +277,15 @@ void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BIJ(
  * Method:    delete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_delete__J_3BI(JNIEnv* env, jobject jobj,
-                                               jlong jwb_handle,
-                                               jbyteArray jkey, jint jkey_len) {
+void Java_org_rocksdb_WriteBatch_deleteJni__J_3BI(JNIEnv* env, jclass,
+                                                  jlong jwb_handle,
+                                                  jbyteArray jkey,
+                                                  jint jkey_len) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto remove = [&wb](ROCKSDB_NAMESPACE::Slice key) { return wb->Delete(key); };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(remove, env, jobj, jkey, jkey_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(remove, env, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -296,10 +296,11 @@ void Java_org_rocksdb_WriteBatch_delete__J_3BI(JNIEnv* env, jobject jobj,
  * Method:    delete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_WriteBatch_delete__J_3BIJ(JNIEnv* env, jobject jobj,
-                                                jlong jwb_handle,
-                                                jbyteArray jkey, jint jkey_len,
-                                                jlong jcf_handle) {
+void Java_org_rocksdb_WriteBatch_deleteJni__J_3BIJ(JNIEnv* env, jclass,
+                                                   jlong jwb_handle,
+                                                   jbyteArray jkey,
+                                                   jint jkey_len,
+                                                   jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle =
@@ -309,7 +310,7 @@ void Java_org_rocksdb_WriteBatch_delete__J_3BIJ(JNIEnv* env, jobject jobj,
     return wb->Delete(cf_handle, key);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(remove, env, jobj, jkey, jkey_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(remove, env, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -320,18 +321,17 @@ void Java_org_rocksdb_WriteBatch_delete__J_3BIJ(JNIEnv* env, jobject jobj,
  * Method:    singleDelete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_singleDelete__J_3BI(JNIEnv* env, jobject jobj,
-                                                     jlong jwb_handle,
-                                                     jbyteArray jkey,
-                                                     jint jkey_len) {
+void Java_org_rocksdb_WriteBatch_singleDeleteJni__J_3BI(JNIEnv* env, jclass,
+                                                        jlong jwb_handle,
+                                                        jbyteArray jkey,
+                                                        jint jkey_len) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto single_delete = [&wb](ROCKSDB_NAMESPACE::Slice key) {
     return wb->SingleDelete(key);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(single_delete, env, jobj, jkey,
-                                       jkey_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(single_delete, env, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -342,11 +342,11 @@ void Java_org_rocksdb_WriteBatch_singleDelete__J_3BI(JNIEnv* env, jobject jobj,
  * Method:    singleDelete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_WriteBatch_singleDelete__J_3BIJ(JNIEnv* env, jobject jobj,
-                                                      jlong jwb_handle,
-                                                      jbyteArray jkey,
-                                                      jint jkey_len,
-                                                      jlong jcf_handle) {
+void Java_org_rocksdb_WriteBatch_singleDeleteJni__J_3BIJ(JNIEnv* env, jclass,
+                                                         jlong jwb_handle,
+                                                         jbyteArray jkey,
+                                                         jint jkey_len,
+                                                         jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle =
@@ -356,8 +356,7 @@ void Java_org_rocksdb_WriteBatch_singleDelete__J_3BIJ(JNIEnv* env, jobject jobj,
     return wb->SingleDelete(cf_handle, key);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(single_delete, env, jobj, jkey,
-                                       jkey_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(single_delete, env, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -368,10 +367,11 @@ void Java_org_rocksdb_WriteBatch_singleDelete__J_3BIJ(JNIEnv* env, jobject jobj,
  * Method:    deleteDirect
  * Signature: (JLjava/nio/ByteBuffer;IIJ)V
  */
-void Java_org_rocksdb_WriteBatch_deleteDirect(JNIEnv* env, jobject /*jobj*/,
-                                              jlong jwb_handle, jobject jkey,
-                                              jint jkey_offset, jint jkey_len,
-                                              jlong jcf_handle) {
+void Java_org_rocksdb_WriteBatch_deleteDirectJni(JNIEnv* env, jclass /*jobj*/,
+                                                 jlong jwb_handle, jobject jkey,
+                                                 jint jkey_offset,
+                                                 jint jkey_len,
+                                                 jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle =
@@ -392,8 +392,8 @@ void Java_org_rocksdb_WriteBatch_deleteDirect(JNIEnv* env, jobject /*jobj*/,
  * Method:    deleteRange
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jbegin_key,
+void Java_org_rocksdb_WriteBatch_deleteRangeJni__J_3BI_3BI(
+    JNIEnv* env, jclass, jlong jwb_handle, jbyteArray jbegin_key,
     jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -402,7 +402,7 @@ void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BI(
     return wb->DeleteRange(beginKey, endKey);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(deleteRange, env, jobj, jbegin_key,
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(deleteRange, env, jbegin_key,
                                         jbegin_key_len, jend_key, jend_key_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
@@ -414,8 +414,8 @@ void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BI(
  * Method:    deleteRange
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jbegin_key,
+void Java_org_rocksdb_WriteBatch_deleteRangeJni__J_3BI_3BIJ(
+    JNIEnv* env, jclass, jlong jwb_handle, jbyteArray jbegin_key,
     jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len,
     jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
@@ -428,7 +428,7 @@ void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BIJ(
     return wb->DeleteRange(cf_handle, beginKey, endKey);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(deleteRange, env, jobj, jbegin_key,
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(deleteRange, env, jbegin_key,
                                         jbegin_key_len, jend_key, jend_key_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
@@ -440,16 +440,17 @@ void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BIJ(
  * Method:    putLogData
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_putLogData(JNIEnv* env, jobject jobj,
-                                            jlong jwb_handle, jbyteArray jblob,
-                                            jint jblob_len) {
+void Java_org_rocksdb_WriteBatch_putLogDataJni(JNIEnv* env, jclass,
+                                               jlong jwb_handle,
+                                               jbyteArray jblob,
+                                               jint jblob_len) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto putLogData = [&wb](ROCKSDB_NAMESPACE::Slice blob) {
     return wb->PutLogData(blob);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(putLogData, env, jobj, jblob, jblob_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(putLogData, env, jblob, jblob_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -460,7 +461,7 @@ void Java_org_rocksdb_WriteBatch_putLogData(JNIEnv* env, jobject jobj,
  * Method:    iterate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* env, jclass /*jcls*/,
                                          jlong jwb_handle,
                                          jlong handlerHandle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
@@ -481,7 +482,7 @@ void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* env, jobject /*jobj*/,
  * Method:    data
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_WriteBatch_data(JNIEnv* env, jobject /*jobj*/,
+jbyteArray Java_org_rocksdb_WriteBatch_data(JNIEnv* env, jclass /*jcls*/,
                                             jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -495,7 +496,7 @@ jbyteArray Java_org_rocksdb_WriteBatch_data(JNIEnv* env, jobject /*jobj*/,
  * Method:    getDataSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_WriteBatch_getDataSize(JNIEnv* /*env*/, jobject /*jobj*/,
+jlong Java_org_rocksdb_WriteBatch_getDataSize(JNIEnv* /*env*/, jclass /*jcls*/,
                                               jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -509,7 +510,7 @@ jlong Java_org_rocksdb_WriteBatch_getDataSize(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    hasPut
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteBatch_hasPut(JNIEnv* /*env*/, jobject /*jobj*/,
+jboolean Java_org_rocksdb_WriteBatch_hasPut(JNIEnv* /*env*/, jclass /*jcls*/,
                                             jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -522,8 +523,7 @@ jboolean Java_org_rocksdb_WriteBatch_hasPut(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    hasDelete
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteBatch_hasDelete(JNIEnv* /*env*/,
-                                               jobject /*jobj*/,
+jboolean Java_org_rocksdb_WriteBatch_hasDelete(JNIEnv* /*env*/, jclass /*jcls*/,
                                                jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -537,7 +537,7 @@ jboolean Java_org_rocksdb_WriteBatch_hasDelete(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasSingleDelete(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -550,7 +550,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasSingleDelete(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasDeleteRange(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -563,7 +563,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasDeleteRange(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasMerge(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -576,7 +576,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasMerge(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasBeginPrepare(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -589,7 +589,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasBeginPrepare(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasEndPrepare(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -602,7 +602,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasEndPrepare(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasCommit(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -615,7 +615,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasCommit(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasRollback(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -628,7 +628,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasRollback(
  * Signature: (J)V
  */
 void Java_org_rocksdb_WriteBatch_markWalTerminationPoint(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
+                                                         jclass /*jcls*/,
                                                          jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -642,7 +642,7 @@ void Java_org_rocksdb_WriteBatch_markWalTerminationPoint(JNIEnv* /*env*/,
  * Signature: (J)Lorg/rocksdb/WriteBatch/SavePoint;
  */
 jobject Java_org_rocksdb_WriteBatch_getWalTerminationPoint(JNIEnv* env,
-                                                           jobject /*jobj*/,
+                                                           jclass /*jcls*/,
                                                            jlong jwb_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -656,9 +656,9 @@ jobject Java_org_rocksdb_WriteBatch_getWalTerminationPoint(JNIEnv* env,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_disposeInternal(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong handle) {
+void Java_org_rocksdb_WriteBatch_disposeInternalJni(JNIEnv* /*env*/,
+                                                    jclass /*jobj*/,
+                                                    jlong handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(handle);
   assert(wb != nullptr);
   delete wb;

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -944,8 +944,9 @@ jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(JNIEnv* env,
  * Method:    refresh0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_refresh0Jni(JNIEnv* env, jobject /*jobj*/,
-                                                 jlong /*handle*/) {
+void Java_org_rocksdb_WBWIRocksIterator_refresh0Jni(JNIEnv* env,
+                                                    jobject /*jobj*/,
+                                                    jlong /*handle*/) {
   ROCKSDB_NAMESPACE::Status s =
       ROCKSDB_NAMESPACE::Status::NotSupported("Refresh() is not supported");
   ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -72,9 +72,9 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__JBIZ(
  * Method:    count0
  * Signature: (J)I
  */
-jint Java_org_rocksdb_WriteBatchWithIndex_count0(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong jwbwi_handle) {
+jint Java_org_rocksdb_WriteBatchWithIndex_count0Jni(JNIEnv* /*env*/,
+                                                    jclass /*jcls*/,
+                                                    jlong jwbwi_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -87,9 +87,9 @@ jint Java_org_rocksdb_WriteBatchWithIndex_count0(JNIEnv* /*env*/,
  * Method:    put
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len) {
+void Java_org_rocksdb_WriteBatchWithIndex_putJni__J_3BI_3BI(
+    JNIEnv* env, jclass, jlong jwbwi_handle, jbyteArray jkey, jint jkey_len,
+    jbyteArray jentry_value, jint jentry_value_len) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -98,8 +98,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BI(
     return wbwi->Put(key, value);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(put, env, jobj, jkey, jkey_len,
-                                        jentry_value, jentry_value_len);
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(put, env, jkey, jkey_len, jentry_value,
+                                        jentry_value_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -110,10 +110,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BI(
  * Method:    put
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len,
-    jlong jcf_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_putJni__J_3BI_3BIJ(
+    JNIEnv* env, jclass, jlong jwbwi_handle, jbyteArray jkey, jint jkey_len,
+    jbyteArray jentry_value, jint jentry_value_len, jlong jcf_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -125,8 +124,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BIJ(
     return wbwi->Put(cf_handle, key, value);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(put, env, jobj, jkey, jkey_len,
-                                        jentry_value, jentry_value_len);
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(put, env, jkey, jkey_len, jentry_value,
+                                        jentry_value_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -137,8 +136,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BIJ(
  * Method:    putDirect
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_putDirect(
-    JNIEnv* env, jobject /*jobj*/, jlong jwb_handle, jobject jkey,
+void Java_org_rocksdb_WriteBatchWithIndex_putDirectJni(
+    JNIEnv* env, jclass /*jobj*/, jlong jwb_handle, jobject jkey,
     jint jkey_offset, jint jkey_len, jobject jval, jint jval_offset,
     jint jval_len, jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
@@ -162,9 +161,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_putDirect(
  * Method:    merge
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len) {
+void Java_org_rocksdb_WriteBatchWithIndex_mergeJni__J_3BI_3BI(
+    JNIEnv* env, jclass, jlong jwbwi_handle, jbyteArray jkey, jint jkey_len,
+    jbyteArray jentry_value, jint jentry_value_len) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -173,7 +172,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BI(
     return wbwi->Merge(key, value);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(merge, env, jobj, jkey, jkey_len,
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(merge, env, jkey, jkey_len,
                                         jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
@@ -185,10 +184,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BI(
  * Method:    merge
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len,
-    jlong jcf_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_mergeJni__J_3BI_3BIJ(
+    JNIEnv* env, jclass, jlong jwbwi_handle, jbyteArray jkey, jint jkey_len,
+    jbyteArray jentry_value, jint jentry_value_len, jlong jcf_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -200,7 +198,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BIJ(
     return wbwi->Merge(cf_handle, key, value);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(merge, env, jobj, jkey, jkey_len,
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(merge, env, jkey, jkey_len,
                                         jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
@@ -212,11 +210,10 @@ void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BIJ(
  * Method:    delete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(JNIEnv* env,
-                                                        jobject jobj,
-                                                        jlong jwbwi_handle,
-                                                        jbyteArray jkey,
-                                                        jint jkey_len) {
+void Java_org_rocksdb_WriteBatchWithIndex_deleteJni__J_3BI(JNIEnv* env, jclass,
+                                                           jlong jwbwi_handle,
+                                                           jbyteArray jkey,
+                                                           jint jkey_len) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -224,7 +221,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(JNIEnv* env,
     return wbwi->Delete(key);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(remove, env, jobj, jkey, jkey_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(remove, env, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -235,9 +232,11 @@ void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(JNIEnv* env,
  * Method:    delete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jlong jcf_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_deleteJni__J_3BIJ(JNIEnv* env, jclass,
+                                                            jlong jwbwi_handle,
+                                                            jbyteArray jkey,
+                                                            jint jkey_len,
+                                                            jlong jcf_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -248,7 +247,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BIJ(
     return wbwi->Delete(cf_handle, key);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(remove, env, jobj, jkey, jkey_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(remove, env, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -259,9 +258,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BIJ(
  * Method:    singleDelete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len) {
+void Java_org_rocksdb_WriteBatchWithIndex_singleDeleteJni__J_3BI(
+    JNIEnv* env, jclass, jlong jwbwi_handle, jbyteArray jkey, jint jkey_len) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -269,8 +267,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BI(
     return wbwi->SingleDelete(key);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(single_delete, env, jobj, jkey,
-                                       jkey_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(single_delete, env, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -281,9 +278,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BI(
  * Method:    singleDelete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jlong jcf_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_singleDeleteJni__J_3BIJ(
+    JNIEnv* env, jclass, jlong jwbwi_handle, jbyteArray jkey, jint jkey_len,
+    jlong jcf_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -294,8 +291,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BIJ(
     return wbwi->SingleDelete(cf_handle, key);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(single_delete, env, jobj, jkey,
-                                       jkey_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(single_delete, env, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -306,8 +302,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BIJ(
  * Method:    deleteDirect
  * Signature: (JLjava/nio/ByteBuffer;IIJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_deleteDirect(
-    JNIEnv* env, jobject /*jobj*/, jlong jwb_handle, jobject jkey,
+void Java_org_rocksdb_WriteBatchWithIndex_deleteDirectJni(
+    JNIEnv* env, jclass /*jobj*/, jlong jwb_handle, jobject jkey,
     jint jkey_offset, jint jkey_len, jlong jcf_handle) {
   auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -329,8 +325,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteDirect(
  * Method:    deleteRange
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jbegin_key,
+void Java_org_rocksdb_WriteBatchWithIndex_deleteRangeJni__J_3BI_3BI(
+    JNIEnv* env, jclass, jlong jwbwi_handle, jbyteArray jbegin_key,
     jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
@@ -340,7 +336,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BI(
     return wbwi->DeleteRange(beginKey, endKey);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(deleteRange, env, jobj, jbegin_key,
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(deleteRange, env, jbegin_key,
                                         jbegin_key_len, jend_key, jend_key_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
@@ -352,8 +348,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BI(
  * Method:    deleteRange
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jbegin_key,
+void Java_org_rocksdb_WriteBatchWithIndex_deleteRangeJni__J_3BI_3BIJ(
+    JNIEnv* env, jclass, jlong jwbwi_handle, jbyteArray jbegin_key,
     jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len,
     jlong jcf_handle) {
   auto* wbwi =
@@ -367,7 +363,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BIJ(
     return wbwi->DeleteRange(cf_handle, beginKey, endKey);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::kv_op(deleteRange, env, jobj, jbegin_key,
+      ROCKSDB_NAMESPACE::JniUtil::kv_op(deleteRange, env, jbegin_key,
                                         jbegin_key_len, jend_key, jend_key_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
@@ -379,10 +375,10 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BIJ(
  * Method:    putLogData
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_putLogData(JNIEnv* env, jobject jobj,
-                                                     jlong jwbwi_handle,
-                                                     jbyteArray jblob,
-                                                     jint jblob_len) {
+void Java_org_rocksdb_WriteBatchWithIndex_putLogDataJni(JNIEnv* env, jclass,
+                                                        jlong jwbwi_handle,
+                                                        jbyteArray jblob,
+                                                        jint jblob_len) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -390,7 +386,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_putLogData(JNIEnv* env, jobject jobj,
     return wbwi->PutLogData(blob);
   };
   std::unique_ptr<ROCKSDB_NAMESPACE::Status> status =
-      ROCKSDB_NAMESPACE::JniUtil::k_op(putLogData, env, jobj, jblob, jblob_len);
+      ROCKSDB_NAMESPACE::JniUtil::k_op(putLogData, env, jblob, jblob_len);
   if (status != nullptr && !status->ok()) {
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -401,9 +397,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_putLogData(JNIEnv* env, jobject jobj,
  * Method:    clear
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_clear0(JNIEnv* /*env*/,
-                                                 jobject /*jobj*/,
-                                                 jlong jwbwi_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_clear0Jni(JNIEnv* /*env*/,
+                                                    jclass /*jobj*/,
+                                                    jlong jwbwi_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -416,9 +412,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_clear0(JNIEnv* /*env*/,
  * Method:    setSavePoint0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_setSavePoint0(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
-                                                        jlong jwbwi_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_setSavePoint0Jni(JNIEnv* /*env*/,
+                                                           jclass /*jcls*/,
+                                                           jlong jwbwi_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -431,8 +427,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_setSavePoint0(JNIEnv* /*env*/,
  * Method:    rollbackToSavePoint0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_rollbackToSavePoint0(
-    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_rollbackToSavePoint0Jni(
+    JNIEnv* env, jclass /*jobj*/, jlong jwbwi_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -451,9 +447,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_rollbackToSavePoint0(
  * Method:    popSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_popSavePoint(JNIEnv* env,
-                                                       jobject /*jobj*/,
-                                                       jlong jwbwi_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_popSavePointJni(JNIEnv* env,
+                                                          jclass /*jobj*/,
+                                                          jlong jwbwi_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -472,10 +468,10 @@ void Java_org_rocksdb_WriteBatchWithIndex_popSavePoint(JNIEnv* env,
  * Method:    setMaxBytes
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_setMaxBytes(JNIEnv* /*env*/,
-                                                      jobject /*jobj*/,
-                                                      jlong jwbwi_handle,
-                                                      jlong jmax_bytes) {
+void Java_org_rocksdb_WriteBatchWithIndex_setMaxBytesJni(JNIEnv* /*env*/,
+                                                         jclass /*cls*/,
+                                                         jlong jwbwi_handle,
+                                                         jlong jmax_bytes) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -488,9 +484,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_setMaxBytes(JNIEnv* /*env*/,
  * Method:    getWriteBatch
  * Signature: (J)Lorg/rocksdb/WriteBatch;
  */
-jobject Java_org_rocksdb_WriteBatchWithIndex_getWriteBatch(JNIEnv* env,
-                                                           jobject /*jobj*/,
-                                                           jlong jwbwi_handle) {
+jobject Java_org_rocksdb_WriteBatchWithIndex_getWriteBatchJni(
+    JNIEnv* env, jclass /*jobj*/, jlong jwbwi_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
@@ -507,7 +502,7 @@ jobject Java_org_rocksdb_WriteBatchWithIndex_getWriteBatch(JNIEnv* env,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_iterator0(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
+                                                     jclass /*jcls*/,
                                                      jlong jwbwi_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
@@ -521,7 +516,7 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iterator0(JNIEnv* /*env*/,
  * Signature: (JJ)J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_iterator1(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
+                                                     jclass /*jcls*/,
                                                      jlong jwbwi_handle,
                                                      jlong jcf_handle) {
   auto* wbwi =
@@ -538,7 +533,7 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iterator1(JNIEnv* /*env*/,
  * Signature: (JJJJ)J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_iteratorWithBase(
-    JNIEnv*, jobject, jlong jwbwi_handle, jlong jcf_handle,
+    JNIEnv*, jclass, jlong jwbwi_handle, jlong jcf_handle,
     jlong jbase_iterator_handle, jlong jread_opts_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
@@ -562,7 +557,7 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iteratorWithBase(
  * Signature: (JJ[BI)[B
  */
 jbyteArray JNICALL Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BI(
-    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle, jlong jdbopt_handle,
+    JNIEnv* env, jclass /*jcls*/, jlong jwbwi_handle, jlong jdbopt_handle,
     jbyteArray jkey, jint jkey_len) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
@@ -582,7 +577,7 @@ jbyteArray JNICALL Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BI(
  * Signature: (JJ[BIJ)[B
  */
 jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle, jlong jdbopt_handle,
+    JNIEnv* env, jclass /*jcls*/, jlong jwbwi_handle, jlong jdbopt_handle,
     jbyteArray jkey, jint jkey_len, jlong jcf_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
@@ -604,7 +599,7 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BIJ(
  * Signature: (JJJ[BI)[B
  */
 jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BI(
-    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle, jlong jdb_handle,
+    JNIEnv* env, jclass /*jcls*/, jlong jwbwi_handle, jlong jdb_handle,
     jlong jreadopt_handle, jbyteArray jkey, jint jkey_len) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
@@ -626,7 +621,7 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BI(
  * Signature: (JJJ[BIJ)[B
  */
 jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BIJ(
-    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle, jlong jdb_handle,
+    JNIEnv* env, jclass /*jcls*/, jlong jwbwi_handle, jlong jdb_handle,
     jlong jreadopt_handle, jbyteArray jkey, jint jkey_len, jlong jcf_handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(jwbwi_handle);
@@ -649,9 +644,9 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BIJ(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_disposeInternal(JNIEnv* /*env*/,
-                                                          jobject /*jobj*/,
-                                                          jlong handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_disposeInternalJni(JNIEnv* /*env*/,
+                                                             jclass /*jcls*/,
+                                                             jlong handle) {
   auto* wbwi =
       reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatchWithIndex*>(handle);
   assert(wbwi != nullptr);
@@ -665,9 +660,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_disposeInternal(JNIEnv* /*env*/,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_disposeInternal(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
-                                                        jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_disposeInternalJni(JNIEnv* /*env*/,
+                                                           jclass /*jobj*/,
+                                                           jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle);
   assert(it != nullptr);
   delete it;
@@ -678,9 +673,9 @@ void Java_org_rocksdb_WBWIRocksIterator_disposeInternal(JNIEnv* /*env*/,
  * Method:    isValid0
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
-                                                     jlong handle) {
+jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0Jni(JNIEnv* /*env*/,
+                                                        jclass /*jcls*/,
+                                                        jlong handle) {
   return reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle)->Valid();
 }
 
@@ -689,9 +684,9 @@ jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0(JNIEnv* /*env*/,
  * Method:    seekToFirst0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
-                                                     jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0Jni(JNIEnv* /*env*/,
+                                                        jclass /*jcls*/,
+                                                        jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle)->SeekToFirst();
 }
 
@@ -700,9 +695,9 @@ void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0(JNIEnv* /*env*/,
  * Method:    seekToLast0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekToLast0(JNIEnv* /*env*/,
-                                                    jobject /*jobj*/,
-                                                    jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_seekToLast0Jni(JNIEnv* /*env*/,
+                                                       jclass /*jcls*/,
+                                                       jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle)->SeekToLast();
 }
 
@@ -711,8 +706,9 @@ void Java_org_rocksdb_WBWIRocksIterator_seekToLast0(JNIEnv* /*env*/,
  * Method:    next0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_next0(JNIEnv* /*env*/, jobject /*jobj*/,
-                                              jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_next0Jni(JNIEnv* /*env*/,
+                                                 jclass /*jcls*/,
+                                                 jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle)->Next();
 }
 
@@ -721,8 +717,9 @@ void Java_org_rocksdb_WBWIRocksIterator_next0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    prev0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_prev0(JNIEnv* /*env*/, jobject /*jobj*/,
-                                              jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_prev0Jni(JNIEnv* /*env*/,
+                                                 jclass /*jcls*/,
+                                                 jlong handle) {
   reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle)->Prev();
 }
 
@@ -731,9 +728,10 @@ void Java_org_rocksdb_WBWIRocksIterator_prev0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    seek0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seek0(JNIEnv* env, jobject /*jobj*/,
-                                              jlong handle, jbyteArray jtarget,
-                                              jint jtarget_len) {
+void Java_org_rocksdb_WBWIRocksIterator_seek0Jni(JNIEnv* env, jclass /*jcls*/,
+                                                 jlong handle,
+                                                 jbyteArray jtarget,
+                                                 jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle);
   jbyte* target = new jbyte[jtarget_len];
   env->GetByteArrayRegion(jtarget, 0, jtarget_len, target);
@@ -756,8 +754,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seek0(JNIEnv* env, jobject /*jobj*/,
  * Method:    seekDirect0
  * Signature: (JLjava/nio/ByteBuffer;II)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekDirect0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jobject jtarget,
+void Java_org_rocksdb_WBWIRocksIterator_seekDirect0Jni(
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jobject jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle);
   auto seek = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
@@ -775,8 +773,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seekDirect0(
  * Method:    seekByteArray0
  * Signature: (J[BII)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jtarget,
+void Java_org_rocksdb_WBWIRocksIterator_seekByteArray0Jni(
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jbyteArray jtarget,
     jint jtarget_off, jint jtarget_len) {
   const std::unique_ptr<char[]> target(new char[jtarget_len]);
   if (target == nullptr) {
@@ -799,11 +797,11 @@ void Java_org_rocksdb_WBWIRocksIterator_seekByteArray0(
  * Method:    seekForPrev0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0(JNIEnv* env,
-                                                     jobject /*jobj*/,
-                                                     jlong handle,
-                                                     jbyteArray jtarget,
-                                                     jint jtarget_len) {
+void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0Jni(JNIEnv* env,
+                                                        jclass /*jcls*/,
+                                                        jlong handle,
+                                                        jbyteArray jtarget,
+                                                        jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle);
   jbyte* target = new jbyte[jtarget_len];
   env->GetByteArrayRegion(jtarget, 0, jtarget_len, target);
@@ -826,8 +824,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0(JNIEnv* env,
  * Method:    seekForPrevDirect0
  * Signature: (JLjava/nio/ByteBuffer;II)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekForPrevDirect0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jobject jtarget,
+void Java_org_rocksdb_WBWIRocksIterator_seekForPrevDirect0Jni(
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jobject jtarget,
     jint jtarget_off, jint jtarget_len) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle);
   auto seek_for_prev = [&it](ROCKSDB_NAMESPACE::Slice& target_slice) {
@@ -845,8 +843,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seekForPrevDirect0(
  * Method:    seekForPrevByteArray0
  * Signature: (J[BII)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekForPrevByteArray0(
-    JNIEnv* env, jobject /*jobj*/, jlong handle, jbyteArray jtarget,
+void Java_org_rocksdb_WBWIRocksIterator_seekForPrevByteArray0Jni(
+    JNIEnv* env, jclass /*jcls*/, jlong handle, jbyteArray jtarget,
     jint jtarget_off, jint jtarget_len) {
   const std::unique_ptr<char[]> target(new char[jtarget_len]);
   if (target == nullptr) {
@@ -869,8 +867,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seekForPrevByteArray0(
  * Method:    status0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_status0(JNIEnv* env, jobject /*jobj*/,
-                                                jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_status0Jni(JNIEnv* env, jclass /*jcls*/,
+                                                   jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle);
   ROCKSDB_NAMESPACE::Status s = it->status();
 
@@ -887,7 +885,7 @@ void Java_org_rocksdb_WBWIRocksIterator_status0(JNIEnv* env, jobject /*jobj*/,
  * Signature: (J)[J
  */
 jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(JNIEnv* env,
-                                                     jobject /*jobj*/,
+                                                     jclass /*jobj*/,
                                                      jlong handle) {
   auto* it = reinterpret_cast<ROCKSDB_NAMESPACE::WBWIIterator*>(handle);
   const ROCKSDB_NAMESPACE::WriteEntry& we = it->Entry();
@@ -946,7 +944,7 @@ jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(JNIEnv* env,
  * Method:    refresh0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_refresh0(JNIEnv* env, jobject /*jobj*/,
+void Java_org_rocksdb_WBWIRocksIterator_refresh0Jni(JNIEnv* env, jobject /*jobj*/,
                                                  jlong /*handle*/) {
   ROCKSDB_NAMESPACE::Status s =
       ROCKSDB_NAMESPACE::Status::NotSupported("Refresh() is not supported");

--- a/java/rocksjni/write_buffer_manager.cc
+++ b/java/rocksjni/write_buffer_manager.cc
@@ -36,9 +36,9 @@ jlong Java_org_rocksdb_WriteBufferManager_newWriteBufferManager(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBufferManager_disposeInternal(JNIEnv* /*env*/,
-                                                         jobject /*jobj*/,
-                                                         jlong jhandle) {
+void Java_org_rocksdb_WriteBufferManager_disposeInternalJni(JNIEnv* /*env*/,
+                                                            jclass /*jcls*/,
+                                                            jlong jhandle) {
   auto* write_buffer_manager =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::WriteBufferManager>*>(
           jhandle);

--- a/java/src/main/java/org/rocksdb/AbstractCompactionFilterFactory.java
+++ b/java/src/main/java/org/rocksdb/AbstractCompactionFilterFactory.java
@@ -74,5 +74,5 @@ public abstract class AbstractCompactionFilterFactory<T extends AbstractCompacti
   }
 
   private native long createNewCompactionFilterFactory0();
-  private native void disposeInternal(final long handle);
+  private static native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/AbstractComparator.java
+++ b/java/src/main/java/org/rocksdb/AbstractComparator.java
@@ -118,7 +118,7 @@ public abstract class AbstractComparator
     return usingDirectBuffers(nativeHandle_);
   }
 
-  private native boolean usingDirectBuffers(final long nativeHandle);
+  private static native boolean usingDirectBuffers(final long nativeHandle);
 
   private native long createNewComparator(final long comparatorOptionsHandle);
 }

--- a/java/src/main/java/org/rocksdb/AbstractSlice.java
+++ b/java/src/main/java/org/rocksdb/AbstractSlice.java
@@ -175,11 +175,11 @@ public abstract class AbstractSlice<T> extends RocksMutableObject {
   }
 
   protected static native long createNewSliceFromString(final String str);
-  private native int size0(long handle);
-  private native boolean empty0(long handle);
-  private native String toString0(long handle, boolean hex);
-  private native int compare0(long handle, long otherHandle);
-  private native boolean startsWith0(long handle, long otherHandle);
+  private static native int size0(long handle);
+  private static native boolean empty0(long handle);
+  private static native String toString0(long handle, boolean hex);
+  private static native int compare0(long handle, long otherHandle);
+  private static native boolean startsWith0(long handle, long otherHandle);
 
   /**
    * Deletes underlying C++ slice pointer.
@@ -188,6 +188,9 @@ public abstract class AbstractSlice<T> extends RocksMutableObject {
    * Otherwise, an undefined behavior will occur.
    */
   @Override
-  protected final native void disposeInternal(final long handle);
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
 
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/AbstractTransactionNotifier.java
+++ b/java/src/main/java/org/rocksdb/AbstractTransactionNotifier.java
@@ -50,5 +50,9 @@ public abstract class AbstractTransactionNotifier
   protected void disposeInternal() {
     disposeInternal(nativeHandle_);
   }
-  protected final native void disposeInternal(final long handle);
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/BackupEngine.java
+++ b/java/src/main/java/org/rocksdb/BackupEngine.java
@@ -229,31 +229,35 @@ public class BackupEngine extends RocksObject implements AutoCloseable {
   private static native long open(final long env, final long backupEngineOptions)
       throws RocksDBException;
 
-  private native void createNewBackup(final long handle, final long dbHandle,
+  private static native void createNewBackup(final long handle, final long dbHandle,
       final boolean flushBeforeBackup) throws RocksDBException;
 
-  private native void createNewBackupWithMetadata(final long handle, final long dbHandle,
+  private static native void createNewBackupWithMetadata(final long handle, final long dbHandle,
       final String metadata, final boolean flushBeforeBackup) throws RocksDBException;
 
-  private native List<BackupInfo> getBackupInfo(final long handle);
+  private static native List<BackupInfo> getBackupInfo(final long handle);
 
-  private native int[] getCorruptedBackups(final long handle);
+  private static native int[] getCorruptedBackups(final long handle);
 
-  private native void garbageCollect(final long handle) throws RocksDBException;
+  private static native void garbageCollect(final long handle) throws RocksDBException;
 
-  private native void purgeOldBackups(final long handle,
-      final int numBackupsToKeep) throws RocksDBException;
-
-  private native void deleteBackup(final long handle, final int backupId)
+  private static native void purgeOldBackups(final long handle, final int numBackupsToKeep)
       throws RocksDBException;
 
-  private native void restoreDbFromBackup(final long handle, final int backupId,
+  private static native void deleteBackup(final long handle, final int backupId)
+      throws RocksDBException;
+
+  private static native void restoreDbFromBackup(final long handle, final int backupId,
       final String dbDir, final String walDir, final long restoreOptionsHandle)
       throws RocksDBException;
 
-  private native void restoreDbFromLatestBackup(final long handle,
-      final String dbDir, final String walDir, final long restoreOptionsHandle)
-      throws RocksDBException;
+  private static native void restoreDbFromLatestBackup(final long handle, final String dbDir,
+      final String walDir, final long restoreOptionsHandle) throws RocksDBException;
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/BackupEngineOptions.java
+++ b/java/src/main/java/org/rocksdb/BackupEngineOptions.java
@@ -426,31 +426,35 @@ public class BackupEngineOptions extends RocksObject {
   }
 
   private static native long newBackupEngineOptions(final String path);
-  private native String backupDir(long handle);
-  private native void setBackupEnv(final long handle, final long envHandle);
-  private native void setShareTableFiles(long handle, boolean flag);
-  private native boolean shareTableFiles(long handle);
-  private native void setInfoLog(final long handle, final long infoLogHandle);
-  private native void setSync(long handle, boolean flag);
-  private native boolean sync(long handle);
-  private native void setDestroyOldData(long handle, boolean flag);
-  private native boolean destroyOldData(long handle);
-  private native void setBackupLogFiles(long handle, boolean flag);
-  private native boolean backupLogFiles(long handle);
-  private native void setBackupRateLimit(long handle, long rateLimit);
-  private native long backupRateLimit(long handle);
-  private native void setBackupRateLimiter(long handle, long rateLimiterHandle);
-  private native void setRestoreRateLimit(long handle, long rateLimit);
-  private native long restoreRateLimit(long handle);
-  private native void setRestoreRateLimiter(final long handle,
-      final long rateLimiterHandle);
-  private native void setShareFilesWithChecksum(long handle, boolean flag);
-  private native boolean shareFilesWithChecksum(long handle);
-  private native void setMaxBackgroundOperations(final long handle,
-      final int maxBackgroundOperations);
-  private native int maxBackgroundOperations(final long handle);
-  private native void setCallbackTriggerIntervalSize(final long handle,
-      long callbackTriggerIntervalSize);
-  private native long callbackTriggerIntervalSize(final long handle);
-  @Override protected final native void disposeInternal(final long handle);
+  private static native String backupDir(long handle);
+  private static native void setBackupEnv(final long handle, final long envHandle);
+  private static native void setShareTableFiles(long handle, boolean flag);
+  private static native boolean shareTableFiles(long handle);
+  private static native void setInfoLog(final long handle, final long infoLogHandle);
+  private static native void setSync(long handle, boolean flag);
+  private static native boolean sync(long handle);
+  private static native void setDestroyOldData(long handle, boolean flag);
+  private static native boolean destroyOldData(long handle);
+  private static native void setBackupLogFiles(long handle, boolean flag);
+  private static native boolean backupLogFiles(long handle);
+  private static native void setBackupRateLimit(long handle, long rateLimit);
+  private static native long backupRateLimit(long handle);
+  private static native void setBackupRateLimiter(long handle, long rateLimiterHandle);
+  private static native void setRestoreRateLimit(long handle, long rateLimit);
+  private static native long restoreRateLimit(long handle);
+  private static native void setRestoreRateLimiter(final long handle, final long rateLimiterHandle);
+  private static native void setShareFilesWithChecksum(long handle, boolean flag);
+  private static native boolean shareFilesWithChecksum(long handle);
+  private static native void setMaxBackgroundOperations(
+      final long handle, final int maxBackgroundOperations);
+  private static native int maxBackgroundOperations(final long handle);
+  private static native void setCallbackTriggerIntervalSize(
+      final long handle, long callbackTriggerIntervalSize);
+  private static native long callbackTriggerIntervalSize(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
+++ b/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
@@ -949,7 +949,7 @@ public class BlockBasedTableConfig extends TableFormatConfig {
         indexShortening.getValue(), blockCacheSize, blockCacheNumShardBits);
   }
 
-  private native long newTableFactoryHandle(final boolean cacheIndexAndFilterBlocks,
+  private static native long newTableFactoryHandle(final boolean cacheIndexAndFilterBlocks,
       final boolean cacheIndexAndFilterBlocksWithHighPriority,
       final boolean pinL0FilterAndIndexBlocksInCache, final boolean pinTopLevelIndexAndFilter,
       final byte indexTypeValue, final byte dataBlockIndexTypeValue,

--- a/java/src/main/java/org/rocksdb/CassandraValueMergeOperator.java
+++ b/java/src/main/java/org/rocksdb/CassandraValueMergeOperator.java
@@ -21,5 +21,10 @@ public class CassandraValueMergeOperator extends MergeOperator {
   private static native long newSharedCassandraValueMergeOperator(
       int gcGracePeriodInSeconds, int limit);
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/Checkpoint.java
+++ b/java/src/main/java/org/rocksdb/Checkpoint.java
@@ -61,9 +61,13 @@ public class Checkpoint extends RocksObject {
   }
 
   private static native long newCheckpoint(long dbHandle);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native void createCheckpoint(long handle, String checkpointPath)
+  private static native void createCheckpoint(long handle, String checkpointPath)
       throws RocksDBException;
 
   private native long exportColumnFamily(long handle, long columnFamilyHandle, String exportPath)

--- a/java/src/main/java/org/rocksdb/ClockCache.java
+++ b/java/src/main/java/org/rocksdb/ClockCache.java
@@ -65,5 +65,9 @@ public class ClockCache extends Cache {
 
   private static native long newClockCache(
       final long capacity, final int numShardBits, final boolean strictCapacityLimit);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
@@ -142,10 +142,15 @@ public class ColumnFamilyHandle extends RocksObject {
     }
   }
 
-  private native byte[] getName(final long handle) throws RocksDBException;
-  private native int getID(final long handle);
-  private native ColumnFamilyDescriptor getDescriptor(final long handle) throws RocksDBException;
-  @Override protected final native void disposeInternal(final long handle);
+  private static native byte[] getName(final long handle) throws RocksDBException;
+  private static native int getID(final long handle);
+  private static native ColumnFamilyDescriptor getDescriptor(final long handle)
+      throws RocksDBException;
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   private final RocksDB rocksDB_;
 }

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -1342,206 +1342,186 @@ public class ColumnFamilyOptions
   private static native long copyColumnFamilyOptions(final long handle);
   private static native long newColumnFamilyOptionsFromOptions(
       final long optionsHandle);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   private static native void oldDefaults(
       final long handle, final int majorVersion, final int minorVersion);
-  private native void optimizeForSmallDb(final long handle);
+  private static native void optimizeForSmallDb(final long handle);
   private static native void optimizeForSmallDb(final long handle, final long cacheHandle);
-  private native void optimizeForPointLookup(long handle,
-      long blockCacheSizeMb);
-  private native void optimizeLevelStyleCompaction(long handle,
-      long memtableMemoryBudget);
-  private native void optimizeUniversalStyleCompaction(long handle,
-      long memtableMemoryBudget);
-  private native void setComparatorHandle(long handle, int builtinComparator);
-  private native void setComparatorHandle(long optHandle,
-      long comparatorHandle, byte comparatorType);
-  private native void setMergeOperatorName(long handle, String name);
-  private native void setMergeOperator(long handle, long mergeOperatorHandle);
-  private native void setCompactionFilterHandle(long handle,
-      long compactionFilterHandle);
-  private native void setCompactionFilterFactoryHandle(long handle,
-      long compactionFilterFactoryHandle);
-  private native void setWriteBufferSize(long handle, long writeBufferSize)
+  private static native void optimizeForPointLookup(long handle, long blockCacheSizeMb);
+  private static native void optimizeLevelStyleCompaction(long handle, long memtableMemoryBudget);
+  private static native void optimizeUniversalStyleCompaction(
+      long handle, long memtableMemoryBudget);
+  private static native void setComparatorHandle(long handle, int builtinComparator);
+  private static native void setComparatorHandle(
+      long optHandle, long comparatorHandle, byte comparatorType);
+  private static native void setMergeOperatorName(long handle, String name);
+  private static native void setMergeOperator(long handle, long mergeOperatorHandle);
+  private static native void setCompactionFilterHandle(long handle, long compactionFilterHandle);
+  private static native void setCompactionFilterFactoryHandle(
+      long handle, long compactionFilterFactoryHandle);
+  private static native void setWriteBufferSize(long handle, long writeBufferSize)
       throws IllegalArgumentException;
-  private native long writeBufferSize(long handle);
-  private native void setMaxWriteBufferNumber(
-      long handle, int maxWriteBufferNumber);
-  private native int maxWriteBufferNumber(long handle);
-  private native void setMinWriteBufferNumberToMerge(
+  private static native long writeBufferSize(long handle);
+  private static native void setMaxWriteBufferNumber(long handle, int maxWriteBufferNumber);
+  private static native int maxWriteBufferNumber(long handle);
+  private static native void setMinWriteBufferNumberToMerge(
       long handle, int minWriteBufferNumberToMerge);
-  private native int minWriteBufferNumberToMerge(long handle);
-  private native void setCompressionType(long handle, byte compressionType);
-  private native byte compressionType(long handle);
-  private native void setCompressionPerLevel(long handle,
-      byte[] compressionLevels);
-  private native byte[] compressionPerLevel(long handle);
-  private native void setBottommostCompressionType(long handle,
-      byte bottommostCompressionType);
-  private native byte bottommostCompressionType(long handle);
-  private native void setBottommostCompressionOptions(final long handle,
-      final long bottommostCompressionOptionsHandle);
-  private native void setCompressionOptions(long handle,
-      long compressionOptionsHandle);
-  private native void useFixedLengthPrefixExtractor(
-      long handle, int prefixLength);
-  private native void useCappedPrefixExtractor(
-      long handle, int prefixLength);
-  private native void setNumLevels(
-      long handle, int numLevels);
-  private native int numLevels(long handle);
-  private native void setLevelZeroFileNumCompactionTrigger(
-      long handle, int numFiles);
-  private native int levelZeroFileNumCompactionTrigger(long handle);
-  private native void setLevelZeroSlowdownWritesTrigger(
-      long handle, int numFiles);
-  private native int levelZeroSlowdownWritesTrigger(long handle);
-  private native void setLevelZeroStopWritesTrigger(
-      long handle, int numFiles);
-  private native int levelZeroStopWritesTrigger(long handle);
-  private native void setTargetFileSizeBase(
-      long handle, long targetFileSizeBase);
-  private native long targetFileSizeBase(long handle);
-  private native void setTargetFileSizeMultiplier(
-      long handle, int multiplier);
-  private native int targetFileSizeMultiplier(long handle);
-  private native void setMaxBytesForLevelBase(
-      long handle, long maxBytesForLevelBase);
-  private native long maxBytesForLevelBase(long handle);
-  private native void setLevelCompactionDynamicLevelBytes(
+  private static native int minWriteBufferNumberToMerge(long handle);
+  private static native void setCompressionType(long handle, byte compressionType);
+  private static native byte compressionType(long handle);
+  private static native void setCompressionPerLevel(long handle, byte[] compressionLevels);
+  private static native byte[] compressionPerLevel(long handle);
+  private static native void setBottommostCompressionType(
+      long handle, byte bottommostCompressionType);
+  private static native byte bottommostCompressionType(long handle);
+  private static native void setBottommostCompressionOptions(
+      final long handle, final long bottommostCompressionOptionsHandle);
+  private static native void setCompressionOptions(long handle, long compressionOptionsHandle);
+  private static native void useFixedLengthPrefixExtractor(long handle, int prefixLength);
+  private static native void useCappedPrefixExtractor(long handle, int prefixLength);
+  private static native void setNumLevels(long handle, int numLevels);
+  private static native int numLevels(long handle);
+  private static native void setLevelZeroFileNumCompactionTrigger(long handle, int numFiles);
+  private static native int levelZeroFileNumCompactionTrigger(long handle);
+  private static native void setLevelZeroSlowdownWritesTrigger(long handle, int numFiles);
+  private static native int levelZeroSlowdownWritesTrigger(long handle);
+  private static native void setLevelZeroStopWritesTrigger(long handle, int numFiles);
+  private static native int levelZeroStopWritesTrigger(long handle);
+  private static native void setTargetFileSizeBase(long handle, long targetFileSizeBase);
+  private static native long targetFileSizeBase(long handle);
+  private static native void setTargetFileSizeMultiplier(long handle, int multiplier);
+  private static native int targetFileSizeMultiplier(long handle);
+  private static native void setMaxBytesForLevelBase(long handle, long maxBytesForLevelBase);
+  private static native long maxBytesForLevelBase(long handle);
+  private static native void setLevelCompactionDynamicLevelBytes(
       long handle, boolean enableLevelCompactionDynamicLevelBytes);
-  private native boolean levelCompactionDynamicLevelBytes(
-      long handle);
-  private native void setMaxBytesForLevelMultiplier(long handle, double multiplier);
-  private native double maxBytesForLevelMultiplier(long handle);
-  private native void setMaxCompactionBytes(long handle, long maxCompactionBytes);
-  private native long maxCompactionBytes(long handle);
-  private native void setArenaBlockSize(
-      long handle, long arenaBlockSize)
+  private static native boolean levelCompactionDynamicLevelBytes(long handle);
+  private static native void setMaxBytesForLevelMultiplier(long handle, double multiplier);
+  private static native double maxBytesForLevelMultiplier(long handle);
+  private static native void setMaxCompactionBytes(long handle, long maxCompactionBytes);
+  private static native long maxCompactionBytes(long handle);
+  private static native void setArenaBlockSize(long handle, long arenaBlockSize)
       throws IllegalArgumentException;
-  private native long arenaBlockSize(long handle);
-  private native void setDisableAutoCompactions(
-      long handle, boolean disableAutoCompactions);
-  private native boolean disableAutoCompactions(long handle);
-  private native void setCompactionStyle(long handle, byte compactionStyle);
-  private native byte compactionStyle(long handle);
-   private native void setMaxTableFilesSizeFIFO(
-      long handle, long max_table_files_size);
-  private native long maxTableFilesSizeFIFO(long handle);
-  private native void setMaxSequentialSkipInIterations(
+  private static native long arenaBlockSize(long handle);
+  private static native void setDisableAutoCompactions(long handle, boolean disableAutoCompactions);
+  private static native boolean disableAutoCompactions(long handle);
+  private static native void setCompactionStyle(long handle, byte compactionStyle);
+  private static native byte compactionStyle(long handle);
+  private static native void setMaxTableFilesSizeFIFO(long handle, long max_table_files_size);
+  private static native long maxTableFilesSizeFIFO(long handle);
+  private static native void setMaxSequentialSkipInIterations(
       long handle, long maxSequentialSkipInIterations);
-  private native long maxSequentialSkipInIterations(long handle);
-  private native void setMemTableFactory(long handle, long factoryHandle);
-  private native String memTableFactoryName(long handle);
-  private native void setTableFactory(long handle, long factoryHandle);
-  private native String tableFactoryName(long handle);
+  private static native long maxSequentialSkipInIterations(long handle);
+  private static native void setMemTableFactory(long handle, long factoryHandle);
+  private static native String memTableFactoryName(long handle);
+  private static native void setTableFactory(long handle, long factoryHandle);
+  private static native String tableFactoryName(long handle);
   private static native void setCfPaths(
       final long handle, final String[] paths, final long[] targetSizes);
   private static native long cfPathsLen(final long handle);
   private static native void cfPaths(
       final long handle, final String[] paths, final long[] targetSizes);
-  private native void setInplaceUpdateSupport(
-      long handle, boolean inplaceUpdateSupport);
-  private native boolean inplaceUpdateSupport(long handle);
-  private native void setInplaceUpdateNumLocks(
-      long handle, long inplaceUpdateNumLocks)
+  private static native void setInplaceUpdateSupport(long handle, boolean inplaceUpdateSupport);
+  private static native boolean inplaceUpdateSupport(long handle);
+  private static native void setInplaceUpdateNumLocks(long handle, long inplaceUpdateNumLocks)
       throws IllegalArgumentException;
-  private native long inplaceUpdateNumLocks(long handle);
-  private native void setMemtablePrefixBloomSizeRatio(
+  private static native long inplaceUpdateNumLocks(long handle);
+  private static native void setMemtablePrefixBloomSizeRatio(
       long handle, double memtablePrefixBloomSizeRatio);
-  private native double memtablePrefixBloomSizeRatio(long handle);
-  private native void setExperimentalMempurgeThreshold(
+  private static native double memtablePrefixBloomSizeRatio(long handle);
+  private static native void setExperimentalMempurgeThreshold(
       long handle, double experimentalMempurgeThreshold);
-  private native double experimentalMempurgeThreshold(long handle);
-  private native void setMemtableWholeKeyFiltering(long handle, boolean memtableWholeKeyFiltering);
-  private native boolean memtableWholeKeyFiltering(long handle);
-  private native void setBloomLocality(
-      long handle, int bloomLocality);
-  private native int bloomLocality(long handle);
-  private native void setMaxSuccessiveMerges(
-      long handle, long maxSuccessiveMerges)
+  private static native double experimentalMempurgeThreshold(long handle);
+  private static native void setMemtableWholeKeyFiltering(
+      long handle, boolean memtableWholeKeyFiltering);
+  private static native boolean memtableWholeKeyFiltering(long handle);
+  private static native void setBloomLocality(long handle, int bloomLocality);
+  private static native int bloomLocality(long handle);
+  private static native void setMaxSuccessiveMerges(long handle, long maxSuccessiveMerges)
       throws IllegalArgumentException;
-  private native long maxSuccessiveMerges(long handle);
-  private native void setOptimizeFiltersForHits(long handle,
-      boolean optimizeFiltersForHits);
-  private native boolean optimizeFiltersForHits(long handle);
-  private native void setMemtableHugePageSize(long handle,
-      long memtableHugePageSize);
-  private native long memtableHugePageSize(long handle);
-  private native void setSoftPendingCompactionBytesLimit(long handle,
-      long softPendingCompactionBytesLimit);
-  private native long softPendingCompactionBytesLimit(long handle);
-  private native void setHardPendingCompactionBytesLimit(long handle,
-      long hardPendingCompactionBytesLimit);
-  private native long hardPendingCompactionBytesLimit(long handle);
-  private native void setLevel0FileNumCompactionTrigger(long handle,
-      int level0FileNumCompactionTrigger);
-  private native int level0FileNumCompactionTrigger(long handle);
-  private native void setLevel0SlowdownWritesTrigger(long handle,
-      int level0SlowdownWritesTrigger);
-  private native int level0SlowdownWritesTrigger(long handle);
-  private native void setLevel0StopWritesTrigger(long handle,
-      int level0StopWritesTrigger);
-  private native int level0StopWritesTrigger(long handle);
-  private native void setMaxBytesForLevelMultiplierAdditional(long handle,
-      int[] maxBytesForLevelMultiplierAdditional);
-  private native int[] maxBytesForLevelMultiplierAdditional(long handle);
-  private native void setParanoidFileChecks(long handle,
-      boolean paranoidFileChecks);
-  private native boolean paranoidFileChecks(long handle);
-  private native void setMaxWriteBufferNumberToMaintain(final long handle,
-      final int maxWriteBufferNumberToMaintain);
-  private native int maxWriteBufferNumberToMaintain(final long handle);
-  private native void setCompactionPriority(final long handle,
-      final byte compactionPriority);
-  private native byte compactionPriority(final long handle);
-  private native void setReportBgIoStats(final long handle,
-    final boolean reportBgIoStats);
-  private native boolean reportBgIoStats(final long handle);
-  private native void setTtl(final long handle, final long ttl);
-  private native long ttl(final long handle);
-  private native void setPeriodicCompactionSeconds(
+  private static native long maxSuccessiveMerges(long handle);
+  private static native void setOptimizeFiltersForHits(long handle, boolean optimizeFiltersForHits);
+  private static native boolean optimizeFiltersForHits(long handle);
+  private static native void setMemtableHugePageSize(long handle, long memtableHugePageSize);
+  private static native long memtableHugePageSize(long handle);
+  private static native void setSoftPendingCompactionBytesLimit(
+      long handle, long softPendingCompactionBytesLimit);
+  private static native long softPendingCompactionBytesLimit(long handle);
+  private static native void setHardPendingCompactionBytesLimit(
+      long handle, long hardPendingCompactionBytesLimit);
+  private static native long hardPendingCompactionBytesLimit(long handle);
+  private static native void setLevel0FileNumCompactionTrigger(
+      long handle, int level0FileNumCompactionTrigger);
+  private static native int level0FileNumCompactionTrigger(long handle);
+  private static native void setLevel0SlowdownWritesTrigger(
+      long handle, int level0SlowdownWritesTrigger);
+  private static native int level0SlowdownWritesTrigger(long handle);
+  private static native void setLevel0StopWritesTrigger(long handle, int level0StopWritesTrigger);
+  private static native int level0StopWritesTrigger(long handle);
+  private static native void setMaxBytesForLevelMultiplierAdditional(
+      long handle, int[] maxBytesForLevelMultiplierAdditional);
+  private static native int[] maxBytesForLevelMultiplierAdditional(long handle);
+  private static native void setParanoidFileChecks(long handle, boolean paranoidFileChecks);
+  private static native boolean paranoidFileChecks(long handle);
+  private static native void setMaxWriteBufferNumberToMaintain(
+      final long handle, final int maxWriteBufferNumberToMaintain);
+  private static native int maxWriteBufferNumberToMaintain(final long handle);
+  private static native void setCompactionPriority(
+      final long handle, final byte compactionPriority);
+  private static native byte compactionPriority(final long handle);
+  private static native void setReportBgIoStats(final long handle, final boolean reportBgIoStats);
+  private static native boolean reportBgIoStats(final long handle);
+  private static native void setTtl(final long handle, final long ttl);
+  private static native long ttl(final long handle);
+  private static native void setPeriodicCompactionSeconds(
       final long handle, final long periodicCompactionSeconds);
-  private native long periodicCompactionSeconds(final long handle);
-  private native void setCompactionOptionsUniversal(final long handle,
-    final long compactionOptionsUniversalHandle);
-  private native void setCompactionOptionsFIFO(final long handle,
-    final long compactionOptionsFIFOHandle);
-  private native void setForceConsistencyChecks(final long handle,
-    final boolean forceConsistencyChecks);
-  private native boolean forceConsistencyChecks(final long handle);
-  private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
+  private static native long periodicCompactionSeconds(final long handle);
+  private static native void setCompactionOptionsUniversal(
+      final long handle, final long compactionOptionsUniversalHandle);
+  private static native void setCompactionOptionsFIFO(
+      final long handle, final long compactionOptionsFIFOHandle);
+  private static native void setForceConsistencyChecks(
+      final long handle, final boolean forceConsistencyChecks);
+  private static native boolean forceConsistencyChecks(final long handle);
+  private static native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
   private static native void setCompactionThreadLimiter(
       final long nativeHandle_, final long compactionThreadLimiterHandle);
-  private native void setMemtableMaxRangeDeletions(final long handle, final int count);
-  private native int memtableMaxRangeDeletions(final long handle);
-  private native void setEnableBlobFiles(final long nativeHandle_, final boolean enableBlobFiles);
-  private native boolean enableBlobFiles(final long nativeHandle_);
-  private native void setMinBlobSize(final long nativeHandle_, final long minBlobSize);
-  private native long minBlobSize(final long nativeHandle_);
-  private native void setBlobFileSize(final long nativeHandle_, final long blobFileSize);
-  private native long blobFileSize(final long nativeHandle_);
-  private native void setBlobCompressionType(final long nativeHandle_, final byte compressionType);
-  private native byte blobCompressionType(final long nativeHandle_);
-  private native void setEnableBlobGarbageCollection(
+  private static native void setMemtableMaxRangeDeletions(final long handle, final int count);
+  private static native int memtableMaxRangeDeletions(final long handle);
+
+  private static native void setEnableBlobFiles(
+      final long nativeHandle_, final boolean enableBlobFiles);
+  private static native boolean enableBlobFiles(final long nativeHandle_);
+  private static native void setMinBlobSize(final long nativeHandle_, final long minBlobSize);
+  private static native long minBlobSize(final long nativeHandle_);
+  private static native void setBlobFileSize(final long nativeHandle_, final long blobFileSize);
+  private static native long blobFileSize(final long nativeHandle_);
+  private static native void setBlobCompressionType(
+      final long nativeHandle_, final byte compressionType);
+  private static native byte blobCompressionType(final long nativeHandle_);
+  private static native void setEnableBlobGarbageCollection(
       final long nativeHandle_, final boolean enableBlobGarbageCollection);
-  private native boolean enableBlobGarbageCollection(final long nativeHandle_);
-  private native void setBlobGarbageCollectionAgeCutoff(
+  private static native boolean enableBlobGarbageCollection(final long nativeHandle_);
+  private static native void setBlobGarbageCollectionAgeCutoff(
       final long nativeHandle_, final double blobGarbageCollectionAgeCutoff);
-  private native double blobGarbageCollectionAgeCutoff(final long nativeHandle_);
-  private native void setBlobGarbageCollectionForceThreshold(
+  private static native double blobGarbageCollectionAgeCutoff(final long nativeHandle_);
+  private static native void setBlobGarbageCollectionForceThreshold(
       final long nativeHandle_, final double blobGarbageCollectionForceThreshold);
-  private native double blobGarbageCollectionForceThreshold(final long nativeHandle_);
-  private native void setBlobCompactionReadaheadSize(
+  private static native double blobGarbageCollectionForceThreshold(final long nativeHandle_);
+  private static native void setBlobCompactionReadaheadSize(
       final long nativeHandle_, final long blobCompactionReadaheadSize);
-  private native long blobCompactionReadaheadSize(final long nativeHandle_);
-  private native void setBlobFileStartingLevel(
+  private static native long blobCompactionReadaheadSize(final long nativeHandle_);
+  private static native void setBlobFileStartingLevel(
       final long nativeHandle_, final int blobFileStartingLevel);
-  private native int blobFileStartingLevel(final long nativeHandle_);
-  private native void setPrepopulateBlobCache(
+  private static native int blobFileStartingLevel(final long nativeHandle_);
+  private static native void setPrepopulateBlobCache(
       final long nativeHandle_, final byte prepopulateBlobCache);
-  private native byte prepopulateBlobCache(final long nativeHandle_);
+  private static native byte prepopulateBlobCache(final long nativeHandle_);
 
   // instance variables
   // NOTE: If you add new member variables, please update the copy constructor above!

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -269,36 +269,35 @@ public class CompactRangeOptions extends RocksObject {
   }
 
   private static native long newCompactRangeOptions();
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native boolean exclusiveManualCompaction(final long handle);
-  private native void setExclusiveManualCompaction(final long handle,
-      final boolean exclusive_manual_compaction);
-  private native boolean changeLevel(final long handle);
-  private native void setChangeLevel(final long handle,
-      final boolean changeLevel);
-  private native int targetLevel(final long handle);
-  private native void setTargetLevel(final long handle,
-      final int targetLevel);
-  private native int targetPathId(final long handle);
-  private native void setTargetPathId(final long handle,
-      final int targetPathId);
-  private native int bottommostLevelCompaction(final long handle);
-  private native void setBottommostLevelCompaction(final long handle,
-      final int bottommostLevelCompaction);
-  private native boolean allowWriteStall(final long handle);
-  private native void setAllowWriteStall(final long handle,
-      final boolean allowWriteStall);
-  private native void setMaxSubcompactions(final long handle,
-      final int maxSubcompactions);
-  private native int maxSubcompactions(final long handle);
+  private static native boolean exclusiveManualCompaction(final long handle);
+  private static native void setExclusiveManualCompaction(
+      final long handle, final boolean exclusive_manual_compaction);
+  private static native boolean changeLevel(final long handle);
+  private static native void setChangeLevel(final long handle, final boolean changeLevel);
+  private static native int targetLevel(final long handle);
+  private static native void setTargetLevel(final long handle, final int targetLevel);
+  private static native int targetPathId(final long handle);
+  private static native void setTargetPathId(final long handle, final int targetPathId);
+  private static native int bottommostLevelCompaction(final long handle);
+  private static native void setBottommostLevelCompaction(
+      final long handle, final int bottommostLevelCompaction);
+  private static native boolean allowWriteStall(final long handle);
+  private static native void setAllowWriteStall(final long handle, final boolean allowWriteStall);
+  private static native void setMaxSubcompactions(final long handle, final int maxSubcompactions);
+  private static native int maxSubcompactions(final long handle);
 
-  private native void setFullHistoryTSLow(
+  private static native void setFullHistoryTSLow(
       final long handle, final long timestampStart, final long timestampRange);
 
-  private native Timestamp fullHistoryTSLow(final long handle);
+  private static native Timestamp fullHistoryTSLow(final long handle);
 
-  private native void setCanceled(final long handle, final boolean canceled);
+  private static native void setCanceled(final long handle, final boolean canceled);
 
-  private native boolean canceled(final long handle);
+  private static native boolean canceled(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/CompactionJobInfo.java
+++ b/java/src/main/java/org/rocksdb/CompactionJobInfo.java
@@ -143,7 +143,11 @@ public class CompactionJobInfo extends RocksObject {
 
 
   private static native long newCompactionJobInfo();
-  @Override protected native void disposeInternal(final long handle);
+  @Override
+  protected void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   private static native byte[] columnFamilyName(final long handle);
   private static native Status status(final long handle);

--- a/java/src/main/java/org/rocksdb/CompactionJobStats.java
+++ b/java/src/main/java/org/rocksdb/CompactionJobStats.java
@@ -263,8 +263,11 @@ public class CompactionJobStats extends RocksObject {
   }
 
   private static native long newCompactionJobStats();
-  @Override protected native void disposeInternal(final long handle);
-
+  @Override
+  protected void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   private static native void reset(final long handle);
   private static native void add(final long handle,

--- a/java/src/main/java/org/rocksdb/CompactionOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactionOptions.java
@@ -107,7 +107,11 @@ public class CompactionOptions extends RocksObject {
   }
 
   private static native long newCompactionOptions();
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   private static native byte compression(final long handle);
   private static native void setCompression(final long handle,

--- a/java/src/main/java/org/rocksdb/CompactionOptionsFIFO.java
+++ b/java/src/main/java/org/rocksdb/CompactionOptionsFIFO.java
@@ -76,12 +76,14 @@ public class CompactionOptionsFIFO extends RocksObject {
   }
 
   private static native long newCompactionOptionsFIFO();
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native void setMaxTableFilesSize(final long handle,
-      final long maxTableFilesSize);
-  private native long maxTableFilesSize(final long handle);
-  private native void setAllowCompaction(final long handle,
-      final boolean allowCompaction);
-  private native boolean allowCompaction(final long handle);
+  private static native void setMaxTableFilesSize(final long handle, final long maxTableFilesSize);
+  private static native long maxTableFilesSize(final long handle);
+  private static native void setAllowCompaction(final long handle, final boolean allowCompaction);
+  private static native boolean allowCompaction(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/CompactionOptionsUniversal.java
+++ b/java/src/main/java/org/rocksdb/CompactionOptionsUniversal.java
@@ -248,26 +248,26 @@ public class CompactionOptionsUniversal extends RocksObject {
   }
 
   private static native long newCompactionOptionsUniversal();
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native void setSizeRatio(final long handle, final int sizeRatio);
-  private native int sizeRatio(final long handle);
-  private native void setMinMergeWidth(
-      final long handle, final int minMergeWidth);
-  private native int minMergeWidth(final long handle);
-  private native void setMaxMergeWidth(
-      final long handle, final int maxMergeWidth);
-  private native int maxMergeWidth(final long handle);
-  private native void setMaxSizeAmplificationPercent(
+  private static native void setSizeRatio(final long handle, final int sizeRatio);
+  private static native int sizeRatio(final long handle);
+  private static native void setMinMergeWidth(final long handle, final int minMergeWidth);
+  private static native int minMergeWidth(final long handle);
+  private static native void setMaxMergeWidth(final long handle, final int maxMergeWidth);
+  private static native int maxMergeWidth(final long handle);
+  private static native void setMaxSizeAmplificationPercent(
       final long handle, final int maxSizeAmplificationPercent);
-  private native int maxSizeAmplificationPercent(final long handle);
-  private native void setCompressionSizePercent(
+  private static native int maxSizeAmplificationPercent(final long handle);
+  private static native void setCompressionSizePercent(
       final long handle, final int compressionSizePercent);
-  private native int compressionSizePercent(final long handle);
-  private native void setStopStyle(
-      final long handle, final byte stopStyle);
-  private native byte stopStyle(final long handle);
-  private native void setAllowTrivialMove(
-      final long handle, final boolean allowTrivialMove);
-  private native boolean allowTrivialMove(final long handle);
+  private static native int compressionSizePercent(final long handle);
+  private static native void setStopStyle(final long handle, final byte stopStyle);
+  private static native byte stopStyle(final long handle);
+  private static native void setAllowTrivialMove(final long handle, final boolean allowTrivialMove);
+  private static native boolean allowTrivialMove(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/ComparatorOptions.java
+++ b/java/src/main/java/org/rocksdb/ComparatorOptions.java
@@ -120,14 +120,17 @@ public class ComparatorOptions extends RocksObject {
   }
 
   private static native long newComparatorOptions();
-  private native byte reusedSynchronisationType(final long handle);
-  private native void setReusedSynchronisationType(final long handle,
-      final byte reusedSynchronisationType);
-  private native boolean useDirectBuffer(final long handle);
-  private native void setUseDirectBuffer(final long handle,
-      final boolean useDirectBuffer);
-  private native int maxReusedBufferSize(final long handle);
-  private native void setMaxReusedBufferSize(final long handle,
-      final int maxReuseBufferSize);
-  @Override protected final native void disposeInternal(final long handle);
+  private static native byte reusedSynchronisationType(final long handle);
+  private static native void setReusedSynchronisationType(
+      final long handle, final byte reusedSynchronisationType);
+  private static native boolean useDirectBuffer(final long handle);
+  private static native void setUseDirectBuffer(final long handle, final boolean useDirectBuffer);
+  private static native int maxReusedBufferSize(final long handle);
+  private static native void setMaxReusedBufferSize(
+      final long handle, final int maxReuseBufferSize);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/CompressionOptions.java
+++ b/java/src/main/java/org/rocksdb/CompressionOptions.java
@@ -132,19 +132,22 @@ public class CompressionOptions extends RocksObject {
   }
 
   private static native long newCompressionOptions();
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native void setWindowBits(final long handle, final int windowBits);
-  private native int windowBits(final long handle);
-  private native void setLevel(final long handle, final int level);
-  private native int level(final long handle);
-  private native void setStrategy(final long handle, final int strategy);
-  private native int strategy(final long handle);
-  private native void setMaxDictBytes(final long handle, final int maxDictBytes);
-  private native int maxDictBytes(final long handle);
-  private native void setZstdMaxTrainBytes(final long handle,
-      final int zstdMaxTrainBytes);
-  private native int zstdMaxTrainBytes(final long handle);
-  private native void setEnabled(final long handle, final boolean enabled);
-  private native boolean enabled(final long handle);
+  private static native void setWindowBits(final long handle, final int windowBits);
+  private static native int windowBits(final long handle);
+  private static native void setLevel(final long handle, final int level);
+  private static native int level(final long handle);
+  private static native void setStrategy(final long handle, final int strategy);
+  private static native int strategy(final long handle);
+  private static native void setMaxDictBytes(final long handle, final int maxDictBytes);
+  private static native int maxDictBytes(final long handle);
+  private static native void setZstdMaxTrainBytes(final long handle, final int zstdMaxTrainBytes);
+  private static native int zstdMaxTrainBytes(final long handle);
+  private static native void setEnabled(final long handle, final boolean enabled);
+  private static native boolean enabled(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/ConcurrentTaskLimiterImpl.java
+++ b/java/src/main/java/org/rocksdb/ConcurrentTaskLimiterImpl.java
@@ -44,5 +44,9 @@ public class ConcurrentTaskLimiterImpl extends ConcurrentTaskLimiter {
   private static native void resetMaxOutstandingTask(final long handle);
   private static native int outstandingTask(final long handle);
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/ConfigOptions.java
+++ b/java/src/main/java/org/rocksdb/ConfigOptions.java
@@ -38,7 +38,12 @@ public class ConfigOptions extends RocksObject {
     return this;
   }
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+
+  private static native void disposeInternalJni(final long handle);
 
   private static long newConfigOptionsInstance() {
     RocksDB.loadLibrary();

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -1256,215 +1256,185 @@ public class DBOptions extends RocksObject
 
   private static native long copyDBOptions(final long handle);
   private static native long newDBOptionsFromOptions(final long optionsHandle);
-  @Override protected final native void disposeInternal(final long handle);
-
-  private native void optimizeForSmallDb(final long handle);
-  private native void setIncreaseParallelism(long handle, int totalThreads);
-  private native void setCreateIfMissing(long handle, boolean flag);
-  private native boolean createIfMissing(long handle);
-  private native void setCreateMissingColumnFamilies(
-      long handle, boolean flag);
-  private native boolean createMissingColumnFamilies(long handle);
-  private native void setEnv(long handle, long envHandle);
-  private native void setErrorIfExists(long handle, boolean errorIfExists);
-  private native boolean errorIfExists(long handle);
-  private native void setParanoidChecks(
-      long handle, boolean paranoidChecks);
-  private native boolean paranoidChecks(long handle);
-  private native void setRateLimiter(long handle,
-      long rateLimiterHandle);
-  private native void setSstFileManager(final long handle,
-      final long sstFileManagerHandle);
-  private native void setLogger(final long handle, final long loggerHandle, final byte loggerType);
-  private native void setInfoLogLevel(long handle, byte logLevel);
-  private native byte infoLogLevel(long handle);
-  private native void setMaxOpenFiles(long handle, int maxOpenFiles);
-  private native int maxOpenFiles(long handle);
-  private native void setMaxFileOpeningThreads(final long handle,
-      final int maxFileOpeningThreads);
-  private native int maxFileOpeningThreads(final long handle);
-  private native void setMaxTotalWalSize(long handle,
-      long maxTotalWalSize);
-  private native long maxTotalWalSize(long handle);
-  private native void setStatistics(final long handle, final long statisticsHandle);
-  private native long statistics(final long handle);
-  private native boolean useFsync(long handle);
-  private native void setUseFsync(long handle, boolean useFsync);
-  private native void setDbPaths(final long handle, final String[] paths,
-      final long[] targetSizes);
-  private native long dbPathsLen(final long handle);
-  private native void dbPaths(final long handle, final String[] paths,
-                                 final long[] targetSizes);
-  private native void setDbLogDir(long handle, String dbLogDir);
-  private native String dbLogDir(long handle);
-  private native void setWalDir(long handle, String walDir);
-  private native String walDir(long handle);
-  private native void setDeleteObsoleteFilesPeriodMicros(
-      long handle, long micros);
-  private native long deleteObsoleteFilesPeriodMicros(long handle);
-  private native void setMaxBackgroundCompactions(
-      long handle, int maxBackgroundCompactions);
-  private native int maxBackgroundCompactions(long handle);
-  private native void setMaxSubcompactions(long handle, int maxSubcompactions);
-  private native int maxSubcompactions(long handle);
-  private native void setMaxBackgroundFlushes(
-      long handle, int maxBackgroundFlushes);
-  private native int maxBackgroundFlushes(long handle);
-  private native void setMaxBackgroundJobs(long handle, int maxBackgroundJobs);
-  private native int maxBackgroundJobs(long handle);
-  private native void setMaxLogFileSize(long handle, long maxLogFileSize)
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
+  private static native void optimizeForSmallDb(final long handle);
+  private static native void setIncreaseParallelism(long handle, int totalThreads);
+  private static native void setCreateIfMissing(long handle, boolean flag);
+  private static native boolean createIfMissing(long handle);
+  private static native void setCreateMissingColumnFamilies(long handle, boolean flag);
+  private static native boolean createMissingColumnFamilies(long handle);
+  private static native void setEnv(long handle, long envHandle);
+  private static native void setErrorIfExists(long handle, boolean errorIfExists);
+  private static native boolean errorIfExists(long handle);
+  private static native void setParanoidChecks(long handle, boolean paranoidChecks);
+  private static native boolean paranoidChecks(long handle);
+  private static native void setRateLimiter(long handle, long rateLimiterHandle);
+  private static native void setSstFileManager(final long handle, final long sstFileManagerHandle);
+  private static native void setLogger(final long handle, final long loggerHandle, final byte loggerType);
+  private static native void setInfoLogLevel(long handle, byte logLevel);
+  private static native byte infoLogLevel(long handle);
+  private static native void setMaxOpenFiles(long handle, int maxOpenFiles);
+  private static native int maxOpenFiles(long handle);
+  private static native void setMaxFileOpeningThreads(
+      final long handle, final int maxFileOpeningThreads);
+  private static native int maxFileOpeningThreads(final long handle);
+  private static native void setMaxTotalWalSize(long handle, long maxTotalWalSize);
+  private static native long maxTotalWalSize(long handle);
+  private static native void setStatistics(final long handle, final long statisticsHandle);
+  private static native long statistics(final long handle);
+  private static native boolean useFsync(long handle);
+  private static native void setUseFsync(long handle, boolean useFsync);
+  private static native void setDbPaths(
+      final long handle, final String[] paths, final long[] targetSizes);
+  private static native long dbPathsLen(final long handle);
+  private static native void dbPaths(
+      final long handle, final String[] paths, final long[] targetSizes);
+  private static native void setDbLogDir(long handle, String dbLogDir);
+  private static native String dbLogDir(long handle);
+  private static native void setWalDir(long handle, String walDir);
+  private static native String walDir(long handle);
+  private static native void setDeleteObsoleteFilesPeriodMicros(long handle, long micros);
+  private static native long deleteObsoleteFilesPeriodMicros(long handle);
+  private static native void setMaxBackgroundCompactions(long handle, int maxBackgroundCompactions);
+  private static native int maxBackgroundCompactions(long handle);
+  private static native void setMaxSubcompactions(long handle, int maxSubcompactions);
+  private static native int maxSubcompactions(long handle);
+  private static native void setMaxBackgroundFlushes(long handle, int maxBackgroundFlushes);
+  private static native int maxBackgroundFlushes(long handle);
+  private static native void setMaxBackgroundJobs(long handle, int maxBackgroundJobs);
+  private static native int maxBackgroundJobs(long handle);
+  private static native void setMaxLogFileSize(long handle, long maxLogFileSize)
       throws IllegalArgumentException;
-  private native long maxLogFileSize(long handle);
-  private native void setLogFileTimeToRoll(
-      long handle, long logFileTimeToRoll) throws IllegalArgumentException;
-  private native long logFileTimeToRoll(long handle);
-  private native void setKeepLogFileNum(long handle, long keepLogFileNum)
+  private static native long maxLogFileSize(long handle);
+  private static native void setLogFileTimeToRoll(long handle, long logFileTimeToRoll)
       throws IllegalArgumentException;
-  private native long keepLogFileNum(long handle);
-  private native void setRecycleLogFileNum(long handle, long recycleLogFileNum);
-  private native long recycleLogFileNum(long handle);
-  private native void setMaxManifestFileSize(
-      long handle, long maxManifestFileSize);
-  private native long maxManifestFileSize(long handle);
-  private native void setTableCacheNumshardbits(
-      long handle, int tableCacheNumshardbits);
-  private native int tableCacheNumshardbits(long handle);
-  private native void setWalTtlSeconds(long handle, long walTtlSeconds);
-  private native long walTtlSeconds(long handle);
-  private native void setWalSizeLimitMB(long handle, long sizeLimitMB);
-  private native long walSizeLimitMB(long handle);
+  private static native long logFileTimeToRoll(long handle);
+  private static native void setKeepLogFileNum(long handle, long keepLogFileNum)
+      throws IllegalArgumentException;
+  private static native long keepLogFileNum(long handle);
+  private static native void setRecycleLogFileNum(long handle, long recycleLogFileNum);
+  private static native long recycleLogFileNum(long handle);
+  private static native void setMaxManifestFileSize(long handle, long maxManifestFileSize);
+  private static native long maxManifestFileSize(long handle);
+  private static native void setTableCacheNumshardbits(long handle, int tableCacheNumshardbits);
+  private static native int tableCacheNumshardbits(long handle);
+  private static native void setWalTtlSeconds(long handle, long walTtlSeconds);
+  private static native long walTtlSeconds(long handle);
+  private static native void setWalSizeLimitMB(long handle, long sizeLimitMB);
+  private static native long walSizeLimitMB(long handle);
   private static native void setMaxWriteBatchGroupSizeBytes(
       final long handle, final long maxWriteBatchGroupSizeBytes);
   private static native long maxWriteBatchGroupSizeBytes(final long handle);
-  private native void setManifestPreallocationSize(
-      long handle, long size) throws IllegalArgumentException;
-  private native long manifestPreallocationSize(long handle);
-  private native void setUseDirectReads(long handle, boolean useDirectReads);
-  private native boolean useDirectReads(long handle);
-  private native void setUseDirectIoForFlushAndCompaction(
+  private static native void setManifestPreallocationSize(long handle, long size)
+      throws IllegalArgumentException;
+  private static native long manifestPreallocationSize(long handle);
+  private static native void setUseDirectReads(long handle, boolean useDirectReads);
+  private static native boolean useDirectReads(long handle);
+  private static native void setUseDirectIoForFlushAndCompaction(
       long handle, boolean useDirectIoForFlushAndCompaction);
-  private native boolean useDirectIoForFlushAndCompaction(long handle);
-  private native void setAllowFAllocate(final long handle,
-      final boolean allowFAllocate);
-  private native boolean allowFAllocate(final long handle);
-  private native void setAllowMmapReads(
-      long handle, boolean allowMmapReads);
-  private native boolean allowMmapReads(long handle);
-  private native void setAllowMmapWrites(
-      long handle, boolean allowMmapWrites);
-  private native boolean allowMmapWrites(long handle);
-  private native void setIsFdCloseOnExec(
-      long handle, boolean isFdCloseOnExec);
-  private native boolean isFdCloseOnExec(long handle);
-  private native void setStatsDumpPeriodSec(
-      long handle, int statsDumpPeriodSec);
-  private native int statsDumpPeriodSec(long handle);
-  private native void setStatsPersistPeriodSec(
+  private static native boolean useDirectIoForFlushAndCompaction(long handle);
+  private static native void setAllowFAllocate(final long handle, final boolean allowFAllocate);
+  private static native boolean allowFAllocate(final long handle);
+  private static native void setAllowMmapReads(long handle, boolean allowMmapReads);
+  private static native boolean allowMmapReads(long handle);
+  private static native void setAllowMmapWrites(long handle, boolean allowMmapWrites);
+  private static native boolean allowMmapWrites(long handle);
+  private static native void setIsFdCloseOnExec(long handle, boolean isFdCloseOnExec);
+  private static native boolean isFdCloseOnExec(long handle);
+  private static native void setStatsDumpPeriodSec(long handle, int statsDumpPeriodSec);
+  private static native int statsDumpPeriodSec(long handle);
+  private static native void setStatsPersistPeriodSec(
       final long handle, final int statsPersistPeriodSec);
-  private native int statsPersistPeriodSec(
-      final long handle);
-  private native void setStatsHistoryBufferSize(
+  private static native int statsPersistPeriodSec(final long handle);
+  private static native void setStatsHistoryBufferSize(
       final long handle, final long statsHistoryBufferSize);
-  private native long statsHistoryBufferSize(
-      final long handle);
-  private native void setAdviseRandomOnOpen(
-      long handle, boolean adviseRandomOnOpen);
-  private native boolean adviseRandomOnOpen(long handle);
-  private native void setDbWriteBufferSize(final long handle,
-      final long dbWriteBufferSize);
-  private native void setWriteBufferManager(final long dbOptionsHandle,
-      final long writeBufferManagerHandle);
-  private native long dbWriteBufferSize(final long handle);
-  private native void setAccessHintOnCompactionStart(final long handle,
-      final byte accessHintOnCompactionStart);
-  private native byte accessHintOnCompactionStart(final long handle);
-  private native void setCompactionReadaheadSize(final long handle,
-      final long compactionReadaheadSize);
-  private native long compactionReadaheadSize(final long handle);
-  private native void setRandomAccessMaxBufferSize(final long handle,
-      final long randomAccessMaxBufferSize);
-  private native long randomAccessMaxBufferSize(final long handle);
-  private native void setWritableFileMaxBufferSize(final long handle,
-      final long writableFileMaxBufferSize);
-  private native long writableFileMaxBufferSize(final long handle);
-  private native void setUseAdaptiveMutex(
-      long handle, boolean useAdaptiveMutex);
-  private native boolean useAdaptiveMutex(long handle);
-  private native void setBytesPerSync(
-      long handle, long bytesPerSync);
-  private native long bytesPerSync(long handle);
-  private native void setWalBytesPerSync(long handle, long walBytesPerSync);
-  private native long walBytesPerSync(long handle);
-  private native void setStrictBytesPerSync(
+  private static native long statsHistoryBufferSize(final long handle);
+  private static native void setAdviseRandomOnOpen(long handle, boolean adviseRandomOnOpen);
+  private static native boolean adviseRandomOnOpen(long handle);
+  private static native void setDbWriteBufferSize(final long handle, final long dbWriteBufferSize);
+  private static native void setWriteBufferManager(
+      final long dbOptionsHandle, final long writeBufferManagerHandle);
+  private static native long dbWriteBufferSize(final long handle);
+  private static native void setAccessHintOnCompactionStart(
+      final long handle, final byte accessHintOnCompactionStart);
+  private static native byte accessHintOnCompactionStart(final long handle);
+  private static native void setCompactionReadaheadSize(
+      final long handle, final long compactionReadaheadSize);
+  private static native long compactionReadaheadSize(final long handle);
+  private static native void setRandomAccessMaxBufferSize(
+      final long handle, final long randomAccessMaxBufferSize);
+  private static native long randomAccessMaxBufferSize(final long handle);
+  private static native void setWritableFileMaxBufferSize(
+      final long handle, final long writableFileMaxBufferSize);
+  private static native long writableFileMaxBufferSize(final long handle);
+  private static native void setUseAdaptiveMutex(long handle, boolean useAdaptiveMutex);
+  private static native boolean useAdaptiveMutex(long handle);
+  private static native void setBytesPerSync(long handle, long bytesPerSync);
+  private static native long bytesPerSync(long handle);
+  private static native void setWalBytesPerSync(long handle, long walBytesPerSync);
+  private static native long walBytesPerSync(long handle);
+  private static native void setStrictBytesPerSync(
       final long handle, final boolean strictBytesPerSync);
-  private native boolean strictBytesPerSync(
-      final long handle);
+  private static native boolean strictBytesPerSync(final long handle);
   private static native void setEventListeners(
       final long handle, final long[] eventListenerHandles);
   private static native AbstractEventListener[] eventListeners(final long handle);
-  private native void setEnableThreadTracking(long handle,
-      boolean enableThreadTracking);
-  private native boolean enableThreadTracking(long handle);
-  private native void setDelayedWriteRate(long handle, long delayedWriteRate);
-  private native long delayedWriteRate(long handle);
-  private native void setEnablePipelinedWrite(final long handle,
-      final boolean enablePipelinedWrite);
-  private native boolean enablePipelinedWrite(final long handle);
-  private native void setUnorderedWrite(final long handle,
-      final boolean unorderedWrite);
-  private native boolean unorderedWrite(final long handle);
-  private native void setAllowConcurrentMemtableWrite(long handle,
-      boolean allowConcurrentMemtableWrite);
-  private native boolean allowConcurrentMemtableWrite(long handle);
-  private native void setEnableWriteThreadAdaptiveYield(long handle,
-      boolean enableWriteThreadAdaptiveYield);
-  private native boolean enableWriteThreadAdaptiveYield(long handle);
-  private native void setWriteThreadMaxYieldUsec(long handle,
-      long writeThreadMaxYieldUsec);
-  private native long writeThreadMaxYieldUsec(long handle);
-  private native void setWriteThreadSlowYieldUsec(long handle,
-      long writeThreadSlowYieldUsec);
-  private native long writeThreadSlowYieldUsec(long handle);
-  private native void setSkipStatsUpdateOnDbOpen(final long handle,
-      final boolean skipStatsUpdateOnDbOpen);
-  private native boolean skipStatsUpdateOnDbOpen(final long handle);
+  private static native void setEnableThreadTracking(long handle, boolean enableThreadTracking);
+  private static native boolean enableThreadTracking(long handle);
+  private static native void setDelayedWriteRate(long handle, long delayedWriteRate);
+  private static native long delayedWriteRate(long handle);
+  private static native void setEnablePipelinedWrite(
+      final long handle, final boolean enablePipelinedWrite);
+  private static native boolean enablePipelinedWrite(final long handle);
+  private static native void setUnorderedWrite(final long handle, final boolean unorderedWrite);
+  private static native boolean unorderedWrite(final long handle);
+  private static native void setAllowConcurrentMemtableWrite(
+      long handle, boolean allowConcurrentMemtableWrite);
+  private static native boolean allowConcurrentMemtableWrite(long handle);
+  private static native void setEnableWriteThreadAdaptiveYield(
+      long handle, boolean enableWriteThreadAdaptiveYield);
+  private static native boolean enableWriteThreadAdaptiveYield(long handle);
+  private static native void setWriteThreadMaxYieldUsec(long handle, long writeThreadMaxYieldUsec);
+  private static native long writeThreadMaxYieldUsec(long handle);
+  private static native void setWriteThreadSlowYieldUsec(
+      long handle, long writeThreadSlowYieldUsec);
+  private static native long writeThreadSlowYieldUsec(long handle);
+  private static native void setSkipStatsUpdateOnDbOpen(
+      final long handle, final boolean skipStatsUpdateOnDbOpen);
+  private static native boolean skipStatsUpdateOnDbOpen(final long handle);
   private static native void setSkipCheckingSstFileSizesOnDbOpen(
       final long handle, final boolean skipChecking);
   private static native boolean skipCheckingSstFileSizesOnDbOpen(final long handle);
-  private native void setWalRecoveryMode(final long handle,
-      final byte walRecoveryMode);
-  private native byte walRecoveryMode(final long handle);
-  private native void setAllow2pc(final long handle,
-      final boolean allow2pc);
-  private native boolean allow2pc(final long handle);
-  private native void setRowCache(final long handle,
-      final long rowCacheHandle);
-  private native void setWalFilter(final long handle,
-      final long walFilterHandle);
-  private native void setFailIfOptionsFileError(final long handle,
-      final boolean failIfOptionsFileError);
-  private native boolean failIfOptionsFileError(final long handle);
-  private native void setDumpMallocStats(final long handle,
-      final boolean dumpMallocStats);
-  private native boolean dumpMallocStats(final long handle);
-  private native void setAvoidFlushDuringRecovery(final long handle,
-      final boolean avoidFlushDuringRecovery);
-  private native boolean avoidFlushDuringRecovery(final long handle);
-  private native void setAvoidFlushDuringShutdown(final long handle,
-      final boolean avoidFlushDuringShutdown);
-  private native boolean avoidFlushDuringShutdown(final long handle);
-  private native void setAllowIngestBehind(final long handle,
-      final boolean allowIngestBehind);
-  private native boolean allowIngestBehind(final long handle);
-  private native void setTwoWriteQueues(final long handle,
-      final boolean twoWriteQueues);
-  private native boolean twoWriteQueues(final long handle);
-  private native void setManualWalFlush(final long handle,
-      final boolean manualWalFlush);
-  private native boolean manualWalFlush(final long handle);
-  private native void setAtomicFlush(final long handle,
-      final boolean atomicFlush);
-  private native boolean atomicFlush(final long handle);
+  private static native void setWalRecoveryMode(final long handle, final byte walRecoveryMode);
+  private static native byte walRecoveryMode(final long handle);
+  private static native void setAllow2pc(final long handle, final boolean allow2pc);
+  private static native boolean allow2pc(final long handle);
+  private static native void setRowCache(final long handle, final long rowCacheHandle);
+  private static native void setWalFilter(final long handle, final long walFilterHandle);
+  private static native void setFailIfOptionsFileError(
+      final long handle, final boolean failIfOptionsFileError);
+  private static native boolean failIfOptionsFileError(final long handle);
+  private static native void setDumpMallocStats(final long handle, final boolean dumpMallocStats);
+  private static native boolean dumpMallocStats(final long handle);
+  private static native void setAvoidFlushDuringRecovery(
+      final long handle, final boolean avoidFlushDuringRecovery);
+  private static native boolean avoidFlushDuringRecovery(final long handle);
+  private static native void setAvoidFlushDuringShutdown(
+      final long handle, final boolean avoidFlushDuringShutdown);
+  private static native boolean avoidFlushDuringShutdown(final long handle);
+  private static native void setAllowIngestBehind(
+      final long handle, final boolean allowIngestBehind);
+  private static native boolean allowIngestBehind(final long handle);
+  private static native void setTwoWriteQueues(final long handle, final boolean twoWriteQueues);
+  private static native boolean twoWriteQueues(final long handle);
+  private static native void setManualWalFlush(final long handle, final boolean manualWalFlush);
+  private static native boolean manualWalFlush(final long handle);
+  private static native void setAtomicFlush(final long handle, final boolean atomicFlush);
+  private static native boolean atomicFlush(final long handle);
   private static native void setAvoidUnnecessaryBlockingIO(
       final long handle, final boolean avoidBlockingIO);
   private static native boolean avoidUnnecessaryBlockingIO(final long handle);

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -1274,7 +1274,8 @@ public class DBOptions extends RocksObject
   private static native boolean paranoidChecks(long handle);
   private static native void setRateLimiter(long handle, long rateLimiterHandle);
   private static native void setSstFileManager(final long handle, final long sstFileManagerHandle);
-  private static native void setLogger(final long handle, final long loggerHandle, final byte loggerType);
+  private static native void setLogger(
+      final long handle, final long loggerHandle, final byte loggerType);
   private static native void setInfoLogLevel(long handle, byte logLevel);
   private static native byte infoLogLevel(long handle);
   private static native void setMaxOpenFiles(long handle, int maxOpenFiles);

--- a/java/src/main/java/org/rocksdb/DirectSlice.java
+++ b/java/src/main/java/org/rocksdb/DirectSlice.java
@@ -126,11 +126,9 @@ public class DirectSlice extends AbstractSlice<ByteBuffer> {
   private static native long createNewDirectSlice0(final ByteBuffer data, final int length);
   private static native long createNewDirectSlice1(final ByteBuffer data);
   @Override protected final native ByteBuffer data0(long handle);
-  private native byte get0(long handle, int offset);
-  private native void clear0(long handle, boolean internalBuffer,
-      long internalBufferOffset);
-  private native void removePrefix0(long handle, int length);
-  private native void setLength0(long handle, int length);
-  private native void disposeInternalBuf(final long handle,
-      long internalBufferOffset);
+  private static native byte get0(long handle, int offset);
+  private static native void clear0(long handle, boolean internalBuffer, long internalBufferOffset);
+  private static native void removePrefix0(long handle, int length);
+  private static native void setLength0(long handle, int length);
+  private static native void disposeInternalBuf(final long handle, long internalBufferOffset);
 }

--- a/java/src/main/java/org/rocksdb/Env.java
+++ b/java/src/main/java/org/rocksdb/Env.java
@@ -162,18 +162,13 @@ public abstract class Env extends RocksObject {
   }
 
   private static native long getDefaultEnvInternal();
-  private native void setBackgroundThreads(
+  private static native void setBackgroundThreads(
       final long handle, final int number, final byte priority);
-  private native int getBackgroundThreads(final long handle,
-    final byte priority);
-  private native int getThreadPoolQueueLen(final long handle,
-      final byte priority);
-  private native void incBackgroundThreadsIfNeeded(final long handle,
-      final int number, final byte priority);
-  private native void lowerThreadPoolIOPriority(final long handle,
-      final byte priority);
-  private native void lowerThreadPoolCPUPriority(final long handle,
-      final byte priority);
-  private native ThreadStatus[] getThreadList(final long handle)
-      throws RocksDBException;
+  private static native int getBackgroundThreads(final long handle, final byte priority);
+  private static native int getThreadPoolQueueLen(final long handle, final byte priority);
+  private static native void incBackgroundThreadsIfNeeded(
+      final long handle, final int number, final byte priority);
+  private static native void lowerThreadPoolIOPriority(final long handle, final byte priority);
+  private static native void lowerThreadPoolCPUPriority(final long handle, final byte priority);
+  private static native ThreadStatus[] getThreadList(final long handle) throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/EnvOptions.java
+++ b/java/src/main/java/org/rocksdb/EnvOptions.java
@@ -325,42 +325,38 @@ public class EnvOptions extends RocksObject {
   }
   private static native long newEnvOptions();
   private static native long newEnvOptions(final long dboptions_handle);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native void setUseMmapReads(final long handle,
-      final boolean useMmapReads);
-  private native boolean useMmapReads(final long handle);
-  private native void setUseMmapWrites(final long handle,
-      final boolean useMmapWrites);
-  private native boolean useMmapWrites(final long handle);
-  private native void setUseDirectReads(final long handle,
-      final boolean useDirectReads);
-  private native boolean useDirectReads(final long handle);
-  private native void setUseDirectWrites(final long handle,
-      final boolean useDirectWrites);
-  private native boolean useDirectWrites(final long handle);
-  private native void setAllowFallocate(final long handle,
-      final boolean allowFallocate);
-  private native boolean allowFallocate(final long handle);
-  private native void setSetFdCloexec(final long handle,
-      final boolean setFdCloexec);
-  private native boolean setFdCloexec(final long handle);
-  private native void setBytesPerSync(final long handle,
-      final long bytesPerSync);
-  private native long bytesPerSync(final long handle);
-  private native void setFallocateWithKeepSize(
+  private static native void setUseMmapReads(final long handle, final boolean useMmapReads);
+  private static native boolean useMmapReads(final long handle);
+  private static native void setUseMmapWrites(final long handle, final boolean useMmapWrites);
+  private static native boolean useMmapWrites(final long handle);
+  private static native void setUseDirectReads(final long handle, final boolean useDirectReads);
+  private static native boolean useDirectReads(final long handle);
+  private static native void setUseDirectWrites(final long handle, final boolean useDirectWrites);
+  private static native boolean useDirectWrites(final long handle);
+  private static native void setAllowFallocate(final long handle, final boolean allowFallocate);
+  private static native boolean allowFallocate(final long handle);
+  private static native void setSetFdCloexec(final long handle, final boolean setFdCloexec);
+  private static native boolean setFdCloexec(final long handle);
+  private static native void setBytesPerSync(final long handle, final long bytesPerSync);
+  private static native long bytesPerSync(final long handle);
+  private static native void setFallocateWithKeepSize(
       final long handle, final boolean fallocateWithKeepSize);
-  private native boolean fallocateWithKeepSize(final long handle);
-  private native void setCompactionReadaheadSize(
+  private static native boolean fallocateWithKeepSize(final long handle);
+  private static native void setCompactionReadaheadSize(
       final long handle, final long compactionReadaheadSize);
-  private native long compactionReadaheadSize(final long handle);
-  private native void setRandomAccessMaxBufferSize(
+  private static native long compactionReadaheadSize(final long handle);
+  private static native void setRandomAccessMaxBufferSize(
       final long handle, final long randomAccessMaxBufferSize);
-  private native long randomAccessMaxBufferSize(final long handle);
-  private native void setWritableFileMaxBufferSize(
+  private static native long randomAccessMaxBufferSize(final long handle);
+  private static native void setWritableFileMaxBufferSize(
       final long handle, final long writableFileMaxBufferSize);
-  private native long writableFileMaxBufferSize(final long handle);
-  private native void setRateLimiter(final long handle,
-      final long rateLimiterHandle);
+  private static native long writableFileMaxBufferSize(final long handle);
+  private static native void setRateLimiter(final long handle, final long rateLimiterHandle);
   private RateLimiter rateLimiter;
 }

--- a/java/src/main/java/org/rocksdb/Filter.java
+++ b/java/src/main/java/org/rocksdb/Filter.java
@@ -32,5 +32,9 @@ public abstract class Filter extends RocksObject {
   }
 
   @Override
-  protected final native void disposeInternal(final long handle);
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/FlushOptions.java
+++ b/java/src/main/java/org/rocksdb/FlushOptions.java
@@ -78,12 +78,15 @@ public class FlushOptions extends RocksObject {
     return newFlushOptions();
   }
   private static native long newFlushOptions();
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
 
-  private native void setWaitForFlush(final long handle,
-      final boolean wait);
-  private native boolean waitForFlush(final long handle);
-  private native void setAllowWriteStall(final long handle,
-      final boolean allowWriteStall);
-  private native boolean allowWriteStall(final long handle);
+  private static native void disposeInternalJni(final long handle);
+
+  private static native void setWaitForFlush(final long handle, final boolean wait);
+  private static native boolean waitForFlush(final long handle);
+  private static native void setAllowWriteStall(final long handle, final boolean allowWriteStall);
+  private static native boolean allowWriteStall(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
@@ -161,9 +161,8 @@ public class HashLinkedListMemTableConfig extends MemTableConfig {
         thresholdUseSkiplist_);
   }
 
-  private native long newMemTableFactoryHandle(long bucketCount,
-      long hugePageTlbSize, int bucketEntriesLoggingThreshold,
-      boolean ifLogBucketDistWhenFlush, int thresholdUseSkiplist)
+  private static native long newMemTableFactoryHandle(long bucketCount, long hugePageTlbSize,
+      int bucketEntriesLoggingThreshold, boolean ifLogBucketDistWhenFlush, int thresholdUseSkiplist)
       throws IllegalArgumentException;
 
   private long bucketCount_;

--- a/java/src/main/java/org/rocksdb/HashSkipListMemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/HashSkipListMemTableConfig.java
@@ -96,9 +96,8 @@ public class HashSkipListMemTableConfig extends MemTableConfig {
         bucketCount_, height_, branchingFactor_);
   }
 
-  private native long newMemTableFactoryHandle(
-      long bucketCount, int height, int branchingFactor)
-      throws IllegalArgumentException;
+  private static native long newMemTableFactoryHandle(
+      long bucketCount, int height, int branchingFactor) throws IllegalArgumentException;
 
   private long bucketCount_;
   private int branchingFactor_;

--- a/java/src/main/java/org/rocksdb/IngestExternalFileOptions.java
+++ b/java/src/main/java/org/rocksdb/IngestExternalFileOptions.java
@@ -205,23 +205,25 @@ public class IngestExternalFileOptions extends RocksObject {
   private static native long newIngestExternalFileOptions(final boolean moveFiles,
       final boolean snapshotConsistency, final boolean allowGlobalSeqNo,
       final boolean allowBlockingFlush);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
 
-  private native boolean moveFiles(final long handle);
-  private native void setMoveFiles(final long handle, final boolean move_files);
-  private native boolean snapshotConsistency(final long handle);
-  private native void setSnapshotConsistency(final long handle,
-      final boolean snapshotConsistency);
-  private native boolean allowGlobalSeqNo(final long handle);
-  private native void setAllowGlobalSeqNo(final long handle,
-      final boolean allowGloablSeqNo);
-  private native boolean allowBlockingFlush(final long handle);
-  private native void setAllowBlockingFlush(final long handle,
-      final boolean allowBlockingFlush);
-  private native boolean ingestBehind(final long handle);
-  private native void setIngestBehind(final long handle,
-      final boolean ingestBehind);
-  private native boolean writeGlobalSeqno(final long handle);
-  private native void setWriteGlobalSeqno(final long handle,
-      final boolean writeGlobalSeqNo);
+  private static native void disposeInternalJni(final long handle);
+
+  private static native boolean moveFiles(final long handle);
+  private static native void setMoveFiles(final long handle, final boolean move_files);
+  private static native boolean snapshotConsistency(final long handle);
+  private static native void setSnapshotConsistency(
+      final long handle, final boolean snapshotConsistency);
+  private static native boolean allowGlobalSeqNo(final long handle);
+  private static native void setAllowGlobalSeqNo(final long handle, final boolean allowGloablSeqNo);
+  private static native boolean allowBlockingFlush(final long handle);
+  private static native void setAllowBlockingFlush(
+      final long handle, final boolean allowBlockingFlush);
+  private static native boolean ingestBehind(final long handle);
+  private static native void setIngestBehind(final long handle, final boolean ingestBehind);
+  private static native boolean writeGlobalSeqno(final long handle);
+  private static native void setWriteGlobalSeqno(final long handle, final boolean writeGlobalSeqNo);
 }

--- a/java/src/main/java/org/rocksdb/LRUCache.java
+++ b/java/src/main/java/org/rocksdb/LRUCache.java
@@ -102,5 +102,9 @@ public class LRUCache extends Cache {
   private static native long newLRUCache(final long capacity, final int numShardBits,
       final boolean strictCapacityLimit, final double highPriPoolRatio,
       final double lowPriPoolRatio);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/NativeComparatorWrapper.java
+++ b/java/src/main/java/org/rocksdb/NativeComparatorWrapper.java
@@ -53,5 +53,5 @@ public abstract class NativeComparatorWrapper
     disposeInternal(nativeHandle_);
   }
 
-  private native void disposeInternal(final long handle);
+  private static native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/OptimisticTransactionDB.java
+++ b/java/src/main/java/org/rocksdb/OptimisticTransactionDB.java
@@ -205,23 +205,24 @@ public class OptimisticTransactionDB extends RocksDB
     return db;
   }
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   protected static native long open(final long optionsHandle,
       final String path) throws RocksDBException;
   protected static native long[] open(final long handle, final String path,
       final byte[][] columnFamilyNames, final long[] columnFamilyOptions);
   private static native void closeDatabase(final long handle) throws RocksDBException;
-  private native long beginTransaction(final long handle,
-      final long writeOptionsHandle);
-  private native long beginTransaction(final long handle,
-      final long writeOptionsHandle,
+  private static native long beginTransaction(final long handle, final long writeOptionsHandle);
+  private static native long beginTransaction(final long handle, final long writeOptionsHandle,
       final long optimisticTransactionOptionsHandle);
-  private native long beginTransaction_withOld(final long handle,
-      final long writeOptionsHandle, final long oldTransactionHandle);
-  private native long beginTransaction_withOld(final long handle,
-      final long writeOptionsHandle,
-      final long optimisticTransactionOptionsHandle,
+  private static native long beginTransaction_withOld(
+      final long handle, final long writeOptionsHandle, final long oldTransactionHandle);
+  private static native long beginTransaction_withOld(final long handle,
+      final long writeOptionsHandle, final long optimisticTransactionOptionsHandle,
       final long oldTransactionHandle);
-  private native long getBaseDB(final long handle);
+  private static native long getBaseDB(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/OptimisticTransactionOptions.java
+++ b/java/src/main/java/org/rocksdb/OptimisticTransactionOptions.java
@@ -44,10 +44,12 @@ public class OptimisticTransactionOptions extends RocksObject
   }
 
   private static native long newOptimisticTransactionOptions();
-  private native boolean isSetSnapshot(final long handle);
-  private native void setSetSnapshot(final long handle,
-      final boolean setSnapshot);
-  private native void setComparator(final long handle,
-      final long comparatorHandle);
-  @Override protected final native void disposeInternal(final long handle);
+  private static native boolean isSetSnapshot(final long handle);
+  private static native void setSetSnapshot(final long handle, final boolean setSnapshot);
+  private static native void setComparator(final long handle, final long comparatorHandle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -2160,390 +2160,332 @@ public class Options extends RocksObject
   private static native long newOptions();
   private static native long newOptions(long dbOptHandle, long cfOptHandle);
   private static native long copyOptions(long handle);
-  @Override protected final native void disposeInternal(final long handle);
-  private native void setEnv(long optHandle, long envHandle);
-  private native void prepareForBulkLoad(long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
+  private static native void setEnv(long optHandle, long envHandle);
+  private static native void prepareForBulkLoad(long handle);
 
   // DB native handles
-  private native void setIncreaseParallelism(long handle, int totalThreads);
-  private native void setCreateIfMissing(long handle, boolean flag);
-  private native boolean createIfMissing(long handle);
-  private native void setCreateMissingColumnFamilies(
-      long handle, boolean flag);
-  private native boolean createMissingColumnFamilies(long handle);
-  private native void setErrorIfExists(long handle, boolean errorIfExists);
-  private native boolean errorIfExists(long handle);
-  private native void setParanoidChecks(
-      long handle, boolean paranoidChecks);
-  private native boolean paranoidChecks(long handle);
-  private native void setRateLimiter(long handle,
-      long rateLimiterHandle);
-  private native void setSstFileManager(final long handle,
-      final long sstFileManagerHandle);
-  private native void setLogger(final long handle, final long loggerHandle, final byte loggerType);
-  private native void setInfoLogLevel(long handle, byte logLevel);
-  private native byte infoLogLevel(long handle);
-  private native void setMaxOpenFiles(long handle, int maxOpenFiles);
-  private native int maxOpenFiles(long handle);
-  private native void setMaxTotalWalSize(long handle,
-      long maxTotalWalSize);
-  private native void setMaxFileOpeningThreads(final long handle,
-      final int maxFileOpeningThreads);
-  private native int maxFileOpeningThreads(final long handle);
-  private native long maxTotalWalSize(long handle);
-  private native void setStatistics(final long handle, final long statisticsHandle);
-  private native long statistics(final long handle);
-  private native boolean useFsync(long handle);
-  private native void setUseFsync(long handle, boolean useFsync);
-  private native void setDbPaths(final long handle, final String[] paths,
-      final long[] targetSizes);
-  private native long dbPathsLen(final long handle);
-  private native void dbPaths(final long handle, final String[] paths,
-      final long[] targetSizes);
-  private native void setDbLogDir(long handle, String dbLogDir);
-  private native String dbLogDir(long handle);
-  private native void setWalDir(long handle, String walDir);
-  private native String walDir(long handle);
-  private native void setDeleteObsoleteFilesPeriodMicros(
-      long handle, long micros);
-  private native long deleteObsoleteFilesPeriodMicros(long handle);
-  private native void setMaxBackgroundCompactions(
-      long handle, int maxBackgroundCompactions);
-  private native int maxBackgroundCompactions(long handle);
-  private native void setMaxSubcompactions(long handle, int maxSubcompactions);
-  private native int maxSubcompactions(long handle);
-  private native void setMaxBackgroundFlushes(
-      long handle, int maxBackgroundFlushes);
-  private native int maxBackgroundFlushes(long handle);
-  private native void setMaxBackgroundJobs(long handle, int maxMaxBackgroundJobs);
-  private native int maxBackgroundJobs(long handle);
-  private native void setMaxLogFileSize(long handle, long maxLogFileSize)
+  private static native void setIncreaseParallelism(long handle, int totalThreads);
+  private static native void setCreateIfMissing(long handle, boolean flag);
+  private static native boolean createIfMissing(long handle);
+  private static native void setCreateMissingColumnFamilies(long handle, boolean flag);
+  private static native boolean createMissingColumnFamilies(long handle);
+  private static native void setErrorIfExists(long handle, boolean errorIfExists);
+  private static native boolean errorIfExists(long handle);
+  private static native void setParanoidChecks(long handle, boolean paranoidChecks);
+  private static native boolean paranoidChecks(long handle);
+  private static native void setRateLimiter(long handle, long rateLimiterHandle);
+  private static native void setSstFileManager(final long handle, final long sstFileManagerHandle);
+  private static native void setLogger(final long handle, final long loggerHandle, final byte loggerType);
+  private static native void setInfoLogLevel(long handle, byte logLevel);
+  private static native byte infoLogLevel(long handle);
+  private static native void setMaxOpenFiles(long handle, int maxOpenFiles);
+  private static native int maxOpenFiles(long handle);
+  private static native void setMaxTotalWalSize(long handle, long maxTotalWalSize);
+  private static native void setMaxFileOpeningThreads(
+      final long handle, final int maxFileOpeningThreads);
+  private static native int maxFileOpeningThreads(final long handle);
+  private static native long maxTotalWalSize(long handle);
+  private static native void setStatistics(final long handle, final long statisticsHandle);
+  private static native long statistics(final long handle);
+  private static native boolean useFsync(long handle);
+  private static native void setUseFsync(long handle, boolean useFsync);
+  private static native void setDbPaths(
+      final long handle, final String[] paths, final long[] targetSizes);
+  private static native long dbPathsLen(final long handle);
+  private static native void dbPaths(
+      final long handle, final String[] paths, final long[] targetSizes);
+  private static native void setDbLogDir(long handle, String dbLogDir);
+  private static native String dbLogDir(long handle);
+  private static native void setWalDir(long handle, String walDir);
+  private static native String walDir(long handle);
+  private static native void setDeleteObsoleteFilesPeriodMicros(long handle, long micros);
+  private static native long deleteObsoleteFilesPeriodMicros(long handle);
+  private static native void setMaxBackgroundCompactions(long handle, int maxBackgroundCompactions);
+  private static native int maxBackgroundCompactions(long handle);
+  private static native void setMaxSubcompactions(long handle, int maxSubcompactions);
+  private static native int maxSubcompactions(long handle);
+  private static native void setMaxBackgroundFlushes(long handle, int maxBackgroundFlushes);
+  private static native int maxBackgroundFlushes(long handle);
+  private static native void setMaxBackgroundJobs(long handle, int maxMaxBackgroundJobs);
+  private static native int maxBackgroundJobs(long handle);
+  private static native void setMaxLogFileSize(long handle, long maxLogFileSize)
       throws IllegalArgumentException;
-  private native long maxLogFileSize(long handle);
-  private native void setLogFileTimeToRoll(
-      long handle, long logFileTimeToRoll) throws IllegalArgumentException;
-  private native long logFileTimeToRoll(long handle);
-  private native void setKeepLogFileNum(long handle, long keepLogFileNum)
+  private static native long maxLogFileSize(long handle);
+  private static native void setLogFileTimeToRoll(long handle, long logFileTimeToRoll)
       throws IllegalArgumentException;
-  private native long keepLogFileNum(long handle);
-  private native void setRecycleLogFileNum(long handle, long recycleLogFileNum);
-  private native long recycleLogFileNum(long handle);
-  private native void setMaxManifestFileSize(
-      long handle, long maxManifestFileSize);
-  private native long maxManifestFileSize(long handle);
-  private native void setMaxTableFilesSizeFIFO(
-      long handle, long maxTableFilesSize);
-  private native long maxTableFilesSizeFIFO(long handle);
-  private native void setTableCacheNumshardbits(
-      long handle, int tableCacheNumshardbits);
-  private native int tableCacheNumshardbits(long handle);
-  private native void setWalTtlSeconds(long handle, long walTtlSeconds);
-  private native long walTtlSeconds(long handle);
-  private native void setWalSizeLimitMB(long handle, long sizeLimitMB);
-  private native long walSizeLimitMB(long handle);
+  private static native long logFileTimeToRoll(long handle);
+  private static native void setKeepLogFileNum(long handle, long keepLogFileNum)
+      throws IllegalArgumentException;
+  private static native long keepLogFileNum(long handle);
+  private static native void setRecycleLogFileNum(long handle, long recycleLogFileNum);
+  private static native long recycleLogFileNum(long handle);
+  private static native void setMaxManifestFileSize(long handle, long maxManifestFileSize);
+  private static native long maxManifestFileSize(long handle);
+  private static native void setMaxTableFilesSizeFIFO(long handle, long maxTableFilesSize);
+  private static native long maxTableFilesSizeFIFO(long handle);
+  private static native void setTableCacheNumshardbits(long handle, int tableCacheNumshardbits);
+  private static native int tableCacheNumshardbits(long handle);
+  private static native void setWalTtlSeconds(long handle, long walTtlSeconds);
+  private static native long walTtlSeconds(long handle);
+  private static native void setWalSizeLimitMB(long handle, long sizeLimitMB);
+  private static native long walSizeLimitMB(long handle);
   private static native void setMaxWriteBatchGroupSizeBytes(
       final long handle, final long maxWriteBatchGroupSizeBytes);
   private static native long maxWriteBatchGroupSizeBytes(final long handle);
-  private native void setManifestPreallocationSize(
-      long handle, long size) throws IllegalArgumentException;
-  private native long manifestPreallocationSize(long handle);
-  private native void setUseDirectReads(long handle, boolean useDirectReads);
-  private native boolean useDirectReads(long handle);
-  private native void setUseDirectIoForFlushAndCompaction(
+  private static native void setManifestPreallocationSize(long handle, long size)
+      throws IllegalArgumentException;
+  private static native long manifestPreallocationSize(long handle);
+  private static native void setUseDirectReads(long handle, boolean useDirectReads);
+  private static native boolean useDirectReads(long handle);
+  private static native void setUseDirectIoForFlushAndCompaction(
       long handle, boolean useDirectIoForFlushAndCompaction);
-  private native boolean useDirectIoForFlushAndCompaction(long handle);
-  private native void setAllowFAllocate(final long handle,
-      final boolean allowFAllocate);
-  private native boolean allowFAllocate(final long handle);
-  private native void setAllowMmapReads(
-      long handle, boolean allowMmapReads);
-  private native boolean allowMmapReads(long handle);
-  private native void setAllowMmapWrites(
-      long handle, boolean allowMmapWrites);
-  private native boolean allowMmapWrites(long handle);
-  private native void setIsFdCloseOnExec(
-      long handle, boolean isFdCloseOnExec);
-  private native boolean isFdCloseOnExec(long handle);
-  private native void setStatsDumpPeriodSec(
-      long handle, int statsDumpPeriodSec);
-  private native int statsDumpPeriodSec(long handle);
-  private native void setStatsPersistPeriodSec(
+  private static native boolean useDirectIoForFlushAndCompaction(long handle);
+  private static native void setAllowFAllocate(final long handle, final boolean allowFAllocate);
+  private static native boolean allowFAllocate(final long handle);
+  private static native void setAllowMmapReads(long handle, boolean allowMmapReads);
+  private static native boolean allowMmapReads(long handle);
+  private static native void setAllowMmapWrites(long handle, boolean allowMmapWrites);
+  private static native boolean allowMmapWrites(long handle);
+  private static native void setIsFdCloseOnExec(long handle, boolean isFdCloseOnExec);
+  private static native boolean isFdCloseOnExec(long handle);
+  private static native void setStatsDumpPeriodSec(long handle, int statsDumpPeriodSec);
+  private static native int statsDumpPeriodSec(long handle);
+  private static native void setStatsPersistPeriodSec(
       final long handle, final int statsPersistPeriodSec);
-  private native int statsPersistPeriodSec(
-      final long handle);
-  private native void setStatsHistoryBufferSize(
+  private static native int statsPersistPeriodSec(final long handle);
+  private static native void setStatsHistoryBufferSize(
       final long handle, final long statsHistoryBufferSize);
-  private native long statsHistoryBufferSize(
-      final long handle);
-  private native void setAdviseRandomOnOpen(
-      long handle, boolean adviseRandomOnOpen);
-  private native boolean adviseRandomOnOpen(long handle);
-  private native void setDbWriteBufferSize(final long handle,
-      final long dbWriteBufferSize);
-  private native void setWriteBufferManager(final long handle,
-      final long writeBufferManagerHandle);
-  private native long dbWriteBufferSize(final long handle);
-  private native void setAccessHintOnCompactionStart(final long handle,
-      final byte accessHintOnCompactionStart);
-  private native byte accessHintOnCompactionStart(final long handle);
-  private native void setCompactionReadaheadSize(final long handle,
-      final long compactionReadaheadSize);
-  private native long compactionReadaheadSize(final long handle);
-  private native void setRandomAccessMaxBufferSize(final long handle,
-      final long randomAccessMaxBufferSize);
-  private native long randomAccessMaxBufferSize(final long handle);
-  private native void setWritableFileMaxBufferSize(final long handle,
-      final long writableFileMaxBufferSize);
-  private native long writableFileMaxBufferSize(final long handle);
-  private native void setUseAdaptiveMutex(
-      long handle, boolean useAdaptiveMutex);
-  private native boolean useAdaptiveMutex(long handle);
-  private native void setBytesPerSync(
-      long handle, long bytesPerSync);
-  private native long bytesPerSync(long handle);
-  private native void setWalBytesPerSync(long handle, long walBytesPerSync);
-  private native long walBytesPerSync(long handle);
-  private native void setStrictBytesPerSync(
+  private static native long statsHistoryBufferSize(final long handle);
+  private static native void setAdviseRandomOnOpen(long handle, boolean adviseRandomOnOpen);
+  private static native boolean adviseRandomOnOpen(long handle);
+  private static native void setDbWriteBufferSize(final long handle, final long dbWriteBufferSize);
+  private static native void setWriteBufferManager(
+      final long handle, final long writeBufferManagerHandle);
+  private static native long dbWriteBufferSize(final long handle);
+  private static native void setAccessHintOnCompactionStart(
+      final long handle, final byte accessHintOnCompactionStart);
+  private static native byte accessHintOnCompactionStart(final long handle);
+  private static native void setCompactionReadaheadSize(
+      final long handle, final long compactionReadaheadSize);
+  private static native long compactionReadaheadSize(final long handle);
+  private static native void setRandomAccessMaxBufferSize(
+      final long handle, final long randomAccessMaxBufferSize);
+  private static native long randomAccessMaxBufferSize(final long handle);
+  private static native void setWritableFileMaxBufferSize(
+      final long handle, final long writableFileMaxBufferSize);
+  private static native long writableFileMaxBufferSize(final long handle);
+  private static native void setUseAdaptiveMutex(long handle, boolean useAdaptiveMutex);
+  private static native boolean useAdaptiveMutex(long handle);
+  private static native void setBytesPerSync(long handle, long bytesPerSync);
+  private static native long bytesPerSync(long handle);
+  private static native void setWalBytesPerSync(long handle, long walBytesPerSync);
+  private static native long walBytesPerSync(long handle);
+  private static native void setStrictBytesPerSync(
       final long handle, final boolean strictBytesPerSync);
-  private native boolean strictBytesPerSync(
-      final long handle);
+  private static native boolean strictBytesPerSync(final long handle);
   private static native void setEventListeners(
       final long handle, final long[] eventListenerHandles);
   private static native AbstractEventListener[] eventListeners(final long handle);
-  private native void setEnableThreadTracking(long handle,
-      boolean enableThreadTracking);
-  private native boolean enableThreadTracking(long handle);
-  private native void setDelayedWriteRate(long handle, long delayedWriteRate);
-  private native long delayedWriteRate(long handle);
-  private native void setEnablePipelinedWrite(final long handle,
-      final boolean pipelinedWrite);
-  private native boolean enablePipelinedWrite(final long handle);
-  private native void setUnorderedWrite(final long handle,
-      final boolean unorderedWrite);
-  private native boolean unorderedWrite(final long handle);
-  private native void setAllowConcurrentMemtableWrite(long handle,
-      boolean allowConcurrentMemtableWrite);
-  private native boolean allowConcurrentMemtableWrite(long handle);
-  private native void setEnableWriteThreadAdaptiveYield(long handle,
-      boolean enableWriteThreadAdaptiveYield);
-  private native boolean enableWriteThreadAdaptiveYield(long handle);
-  private native void setWriteThreadMaxYieldUsec(long handle,
-      long writeThreadMaxYieldUsec);
-  private native long writeThreadMaxYieldUsec(long handle);
-  private native void setWriteThreadSlowYieldUsec(long handle,
-      long writeThreadSlowYieldUsec);
-  private native long writeThreadSlowYieldUsec(long handle);
-  private native void setSkipStatsUpdateOnDbOpen(final long handle,
-      final boolean skipStatsUpdateOnDbOpen);
-  private native boolean skipStatsUpdateOnDbOpen(final long handle);
+  private static native void setEnableThreadTracking(long handle, boolean enableThreadTracking);
+  private static native boolean enableThreadTracking(long handle);
+  private static native void setDelayedWriteRate(long handle, long delayedWriteRate);
+  private static native long delayedWriteRate(long handle);
+  private static native void setEnablePipelinedWrite(
+      final long handle, final boolean pipelinedWrite);
+  private static native boolean enablePipelinedWrite(final long handle);
+  private static native void setUnorderedWrite(final long handle, final boolean unorderedWrite);
+  private static native boolean unorderedWrite(final long handle);
+  private static native void setAllowConcurrentMemtableWrite(
+      long handle, boolean allowConcurrentMemtableWrite);
+  private static native boolean allowConcurrentMemtableWrite(long handle);
+  private static native void setEnableWriteThreadAdaptiveYield(
+      long handle, boolean enableWriteThreadAdaptiveYield);
+  private static native boolean enableWriteThreadAdaptiveYield(long handle);
+  private static native void setWriteThreadMaxYieldUsec(long handle, long writeThreadMaxYieldUsec);
+  private static native long writeThreadMaxYieldUsec(long handle);
+  private static native void setWriteThreadSlowYieldUsec(
+      long handle, long writeThreadSlowYieldUsec);
+  private static native long writeThreadSlowYieldUsec(long handle);
+  private static native void setSkipStatsUpdateOnDbOpen(
+      final long handle, final boolean skipStatsUpdateOnDbOpen);
+  private static native boolean skipStatsUpdateOnDbOpen(final long handle);
   private static native void setSkipCheckingSstFileSizesOnDbOpen(
       final long handle, final boolean skipChecking);
   private static native boolean skipCheckingSstFileSizesOnDbOpen(final long handle);
-  private native void setWalRecoveryMode(final long handle,
-      final byte walRecoveryMode);
-  private native byte walRecoveryMode(final long handle);
-  private native void setAllow2pc(final long handle,
-      final boolean allow2pc);
-  private native boolean allow2pc(final long handle);
-  private native void setRowCache(final long handle,
-      final long rowCacheHandle);
-  private native void setWalFilter(final long handle,
-      final long walFilterHandle);
-  private native void setFailIfOptionsFileError(final long handle,
-      final boolean failIfOptionsFileError);
-  private native boolean failIfOptionsFileError(final long handle);
-  private native void setDumpMallocStats(final long handle,
-      final boolean dumpMallocStats);
-  private native boolean dumpMallocStats(final long handle);
-  private native void setAvoidFlushDuringRecovery(final long handle,
-      final boolean avoidFlushDuringRecovery);
-  private native boolean avoidFlushDuringRecovery(final long handle);
-  private native void setAvoidFlushDuringShutdown(final long handle,
-      final boolean avoidFlushDuringShutdown);
-  private native boolean avoidFlushDuringShutdown(final long handle);
-  private native void setAllowIngestBehind(final long handle,
-      final boolean allowIngestBehind);
-  private native boolean allowIngestBehind(final long handle);
-  private native void setTwoWriteQueues(final long handle,
-      final boolean twoWriteQueues);
-  private native boolean twoWriteQueues(final long handle);
-  private native void setManualWalFlush(final long handle,
-      final boolean manualWalFlush);
-  private native boolean manualWalFlush(final long handle);
-
+  private static native void setWalRecoveryMode(final long handle, final byte walRecoveryMode);
+  private static native byte walRecoveryMode(final long handle);
+  private static native void setAllow2pc(final long handle, final boolean allow2pc);
+  private static native boolean allow2pc(final long handle);
+  private static native void setRowCache(final long handle, final long rowCacheHandle);
+  private static native void setWalFilter(final long handle, final long walFilterHandle);
+  private static native void setFailIfOptionsFileError(
+      final long handle, final boolean failIfOptionsFileError);
+  private static native boolean failIfOptionsFileError(final long handle);
+  private static native void setDumpMallocStats(final long handle, final boolean dumpMallocStats);
+  private static native boolean dumpMallocStats(final long handle);
+  private static native void setAvoidFlushDuringRecovery(
+      final long handle, final boolean avoidFlushDuringRecovery);
+  private static native boolean avoidFlushDuringRecovery(final long handle);
+  private static native void setAvoidFlushDuringShutdown(
+      final long handle, final boolean avoidFlushDuringShutdown);
+  private static native boolean avoidFlushDuringShutdown(final long handle);
+  private static native void setAllowIngestBehind(
+      final long handle, final boolean allowIngestBehind);
+  private static native boolean allowIngestBehind(final long handle);
+  private static native void setTwoWriteQueues(final long handle, final boolean twoWriteQueues);
+  private static native boolean twoWriteQueues(final long handle);
+  private static native void setManualWalFlush(final long handle, final boolean manualWalFlush);
+  private static native boolean manualWalFlush(final long handle);
 
   // CF native handles
   private static native void oldDefaults(
       final long handle, final int majorVersion, final int minorVersion);
-  private native void optimizeForSmallDb(final long handle);
+  private static native void optimizeForSmallDb(final long handle);
   private static native void optimizeForSmallDb(final long handle, final long cacheHandle);
-  private native void optimizeForPointLookup(long handle,
-      long blockCacheSizeMb);
-  private native void optimizeLevelStyleCompaction(long handle,
-      long memtableMemoryBudget);
-  private native void optimizeUniversalStyleCompaction(long handle,
-      long memtableMemoryBudget);
-  private native void setComparatorHandle(long handle, int builtinComparator);
-  private native void setComparatorHandle(long optHandle,
-      long comparatorHandle, byte comparatorType);
-  private native void setMergeOperatorName(
-      long handle, String name);
-  private native void setMergeOperator(
-      long handle, long mergeOperatorHandle);
-  private native void setCompactionFilterHandle(
-          long handle, long compactionFilterHandle);
-  private native void setCompactionFilterFactoryHandle(
-          long handle, long compactionFilterFactoryHandle);
-  private native void setWriteBufferSize(long handle, long writeBufferSize)
+  private static native void optimizeForPointLookup(long handle, long blockCacheSizeMb);
+  private static native void optimizeLevelStyleCompaction(long handle, long memtableMemoryBudget);
+  private static native void optimizeUniversalStyleCompaction(
+      long handle, long memtableMemoryBudget);
+  private static native void setComparatorHandle(long handle, int builtinComparator);
+  private static native void setComparatorHandle(
+      long optHandle, long comparatorHandle, byte comparatorType);
+  private static native void setMergeOperatorName(long handle, String name);
+  private static native void setMergeOperator(long handle, long mergeOperatorHandle);
+  private static native void setCompactionFilterHandle(long handle, long compactionFilterHandle);
+  private static native void setCompactionFilterFactoryHandle(
+      long handle, long compactionFilterFactoryHandle);
+  private static native void setWriteBufferSize(long handle, long writeBufferSize)
       throws IllegalArgumentException;
-  private native long writeBufferSize(long handle);
-  private native void setMaxWriteBufferNumber(
-      long handle, int maxWriteBufferNumber);
-  private native int maxWriteBufferNumber(long handle);
-  private native void setMinWriteBufferNumberToMerge(
+  private static native long writeBufferSize(long handle);
+  private static native void setMaxWriteBufferNumber(long handle, int maxWriteBufferNumber);
+  private static native int maxWriteBufferNumber(long handle);
+  private static native void setMinWriteBufferNumberToMerge(
       long handle, int minWriteBufferNumberToMerge);
-  private native int minWriteBufferNumberToMerge(long handle);
-  private native void setCompressionType(long handle, byte compressionType);
-  private native byte compressionType(long handle);
-  private native void setCompressionPerLevel(long handle,
-      byte[] compressionLevels);
-  private native byte[] compressionPerLevel(long handle);
-  private native void setBottommostCompressionType(long handle,
-      byte bottommostCompressionType);
-  private native byte bottommostCompressionType(long handle);
-  private native void setBottommostCompressionOptions(final long handle,
-      final long bottommostCompressionOptionsHandle);
-  private native void setCompressionOptions(long handle,
-      long compressionOptionsHandle);
-  private native void useFixedLengthPrefixExtractor(
-      long handle, int prefixLength);
-  private native void useCappedPrefixExtractor(
-      long handle, int prefixLength);
-  private native void setNumLevels(
-      long handle, int numLevels);
-  private native int numLevels(long handle);
-  private native void setLevelZeroFileNumCompactionTrigger(
-      long handle, int numFiles);
-  private native int levelZeroFileNumCompactionTrigger(long handle);
-  private native void setLevelZeroSlowdownWritesTrigger(
-      long handle, int numFiles);
-  private native int levelZeroSlowdownWritesTrigger(long handle);
-  private native void setLevelZeroStopWritesTrigger(
-      long handle, int numFiles);
-  private native int levelZeroStopWritesTrigger(long handle);
-  private native void setTargetFileSizeBase(
-      long handle, long targetFileSizeBase);
-  private native long targetFileSizeBase(long handle);
-  private native void setTargetFileSizeMultiplier(
-      long handle, int multiplier);
-  private native int targetFileSizeMultiplier(long handle);
-  private native void setMaxBytesForLevelBase(
-      long handle, long maxBytesForLevelBase);
-  private native long maxBytesForLevelBase(long handle);
-  private native void setLevelCompactionDynamicLevelBytes(
+  private static native int minWriteBufferNumberToMerge(long handle);
+  private static native void setCompressionType(long handle, byte compressionType);
+  private static native byte compressionType(long handle);
+  private static native void setCompressionPerLevel(long handle, byte[] compressionLevels);
+  private static native byte[] compressionPerLevel(long handle);
+  private static native void setBottommostCompressionType(
+      long handle, byte bottommostCompressionType);
+  private static native byte bottommostCompressionType(long handle);
+  private static native void setBottommostCompressionOptions(
+      final long handle, final long bottommostCompressionOptionsHandle);
+  private static native void setCompressionOptions(long handle, long compressionOptionsHandle);
+  private static native void useFixedLengthPrefixExtractor(long handle, int prefixLength);
+  private static native void useCappedPrefixExtractor(long handle, int prefixLength);
+  private static native void setNumLevels(long handle, int numLevels);
+  private static native int numLevels(long handle);
+  private static native void setLevelZeroFileNumCompactionTrigger(long handle, int numFiles);
+  private static native int levelZeroFileNumCompactionTrigger(long handle);
+  private static native void setLevelZeroSlowdownWritesTrigger(long handle, int numFiles);
+  private static native int levelZeroSlowdownWritesTrigger(long handle);
+  private static native void setLevelZeroStopWritesTrigger(long handle, int numFiles);
+  private static native int levelZeroStopWritesTrigger(long handle);
+  private static native void setTargetFileSizeBase(long handle, long targetFileSizeBase);
+  private static native long targetFileSizeBase(long handle);
+  private static native void setTargetFileSizeMultiplier(long handle, int multiplier);
+  private static native int targetFileSizeMultiplier(long handle);
+  private static native void setMaxBytesForLevelBase(long handle, long maxBytesForLevelBase);
+  private static native long maxBytesForLevelBase(long handle);
+  private static native void setLevelCompactionDynamicLevelBytes(
       long handle, boolean enableLevelCompactionDynamicLevelBytes);
-  private native boolean levelCompactionDynamicLevelBytes(
-      long handle);
-  private native void setMaxBytesForLevelMultiplier(long handle, double multiplier);
-  private native double maxBytesForLevelMultiplier(long handle);
-  private native void setMaxCompactionBytes(long handle, long maxCompactionBytes);
-  private native long maxCompactionBytes(long handle);
-  private native void setArenaBlockSize(
-      long handle, long arenaBlockSize) throws IllegalArgumentException;
-  private native long arenaBlockSize(long handle);
-  private native void setDisableAutoCompactions(
-      long handle, boolean disableAutoCompactions);
-  private native boolean disableAutoCompactions(long handle);
-  private native void setCompactionStyle(long handle, byte compactionStyle);
-  private native byte compactionStyle(long handle);
-  private native void setMaxSequentialSkipInIterations(
+  private static native boolean levelCompactionDynamicLevelBytes(long handle);
+  private static native void setMaxBytesForLevelMultiplier(long handle, double multiplier);
+  private static native double maxBytesForLevelMultiplier(long handle);
+  private static native void setMaxCompactionBytes(long handle, long maxCompactionBytes);
+  private static native long maxCompactionBytes(long handle);
+  private static native void setArenaBlockSize(long handle, long arenaBlockSize)
+      throws IllegalArgumentException;
+  private static native long arenaBlockSize(long handle);
+  private static native void setDisableAutoCompactions(long handle, boolean disableAutoCompactions);
+  private static native boolean disableAutoCompactions(long handle);
+  private static native void setCompactionStyle(long handle, byte compactionStyle);
+  private static native byte compactionStyle(long handle);
+  private static native void setMaxSequentialSkipInIterations(
       long handle, long maxSequentialSkipInIterations);
-  private native long maxSequentialSkipInIterations(long handle);
-  private native void setMemTableFactory(long handle, long factoryHandle);
-  private native String memTableFactoryName(long handle);
-  private native void setTableFactory(long handle, long factoryHandle);
-  private native String tableFactoryName(long handle);
+  private static native long maxSequentialSkipInIterations(long handle);
+  private static native void setMemTableFactory(long handle, long factoryHandle);
+  private static native String memTableFactoryName(long handle);
+  private static native void setTableFactory(long handle, long factoryHandle);
+  private static native String tableFactoryName(long handle);
   private static native void setCfPaths(
       final long handle, final String[] paths, final long[] targetSizes);
   private static native long cfPathsLen(final long handle);
   private static native void cfPaths(
       final long handle, final String[] paths, final long[] targetSizes);
-  private native void setInplaceUpdateSupport(
-      long handle, boolean inplaceUpdateSupport);
-  private native boolean inplaceUpdateSupport(long handle);
-  private native void setInplaceUpdateNumLocks(
-      long handle, long inplaceUpdateNumLocks)
+  private static native void setInplaceUpdateSupport(long handle, boolean inplaceUpdateSupport);
+  private static native boolean inplaceUpdateSupport(long handle);
+  private static native void setInplaceUpdateNumLocks(long handle, long inplaceUpdateNumLocks)
       throws IllegalArgumentException;
-  private native long inplaceUpdateNumLocks(long handle);
-  private native void setMemtablePrefixBloomSizeRatio(
+  private static native long inplaceUpdateNumLocks(long handle);
+  private static native void setMemtablePrefixBloomSizeRatio(
       long handle, double memtablePrefixBloomSizeRatio);
-  private native double memtablePrefixBloomSizeRatio(long handle);
-  private native void setExperimentalMempurgeThreshold(
+  private static native double memtablePrefixBloomSizeRatio(long handle);
+  private static native void setExperimentalMempurgeThreshold(
       long handle, double experimentalMempurgeThreshold);
-  private native double experimentalMempurgeThreshold(long handle);
-  private native void setMemtableWholeKeyFiltering(long handle, boolean memtableWholeKeyFiltering);
-  private native boolean memtableWholeKeyFiltering(long handle);
-  private native void setBloomLocality(
-      long handle, int bloomLocality);
-  private native int bloomLocality(long handle);
-  private native void setMaxSuccessiveMerges(
-      long handle, long maxSuccessiveMerges)
+  private static native double experimentalMempurgeThreshold(long handle);
+  private static native void setMemtableWholeKeyFiltering(
+      long handle, boolean memtableWholeKeyFiltering);
+  private static native boolean memtableWholeKeyFiltering(long handle);
+  private static native void setBloomLocality(long handle, int bloomLocality);
+  private static native int bloomLocality(long handle);
+  private static native void setMaxSuccessiveMerges(long handle, long maxSuccessiveMerges)
       throws IllegalArgumentException;
-  private native long maxSuccessiveMerges(long handle);
-  private native void setOptimizeFiltersForHits(long handle,
-      boolean optimizeFiltersForHits);
-  private native boolean optimizeFiltersForHits(long handle);
-  private native void setMemtableHugePageSize(long handle,
-      long memtableHugePageSize);
-  private native long memtableHugePageSize(long handle);
-  private native void setSoftPendingCompactionBytesLimit(long handle,
-      long softPendingCompactionBytesLimit);
-  private native long softPendingCompactionBytesLimit(long handle);
-  private native void setHardPendingCompactionBytesLimit(long handle,
-      long hardPendingCompactionBytesLimit);
-  private native long hardPendingCompactionBytesLimit(long handle);
-  private native void setLevel0FileNumCompactionTrigger(long handle,
-      int level0FileNumCompactionTrigger);
-  private native int level0FileNumCompactionTrigger(long handle);
-  private native void setLevel0SlowdownWritesTrigger(long handle,
-      int level0SlowdownWritesTrigger);
-  private native int level0SlowdownWritesTrigger(long handle);
-  private native void setLevel0StopWritesTrigger(long handle,
-      int level0StopWritesTrigger);
-  private native int level0StopWritesTrigger(long handle);
-  private native void setMaxBytesForLevelMultiplierAdditional(long handle,
-      int[] maxBytesForLevelMultiplierAdditional);
-  private native int[] maxBytesForLevelMultiplierAdditional(long handle);
-  private native void setParanoidFileChecks(long handle,
-      boolean paranoidFileChecks);
-  private native boolean paranoidFileChecks(long handle);
-  private native void setMaxWriteBufferNumberToMaintain(final long handle,
-      final int maxWriteBufferNumberToMaintain);
-  private native int maxWriteBufferNumberToMaintain(final long handle);
-  private native void setCompactionPriority(final long handle,
-      final byte compactionPriority);
-  private native byte compactionPriority(final long handle);
-  private native void setReportBgIoStats(final long handle,
-      final boolean reportBgIoStats);
-  private native boolean reportBgIoStats(final long handle);
-  private native void setTtl(final long handle, final long ttl);
-  private native long ttl(final long handle);
-  private native void setPeriodicCompactionSeconds(
+  private static native long maxSuccessiveMerges(long handle);
+  private static native void setOptimizeFiltersForHits(long handle, boolean optimizeFiltersForHits);
+  private static native boolean optimizeFiltersForHits(long handle);
+  private static native void setMemtableHugePageSize(long handle, long memtableHugePageSize);
+  private static native long memtableHugePageSize(long handle);
+  private static native void setSoftPendingCompactionBytesLimit(
+      long handle, long softPendingCompactionBytesLimit);
+  private static native long softPendingCompactionBytesLimit(long handle);
+  private static native void setHardPendingCompactionBytesLimit(
+      long handle, long hardPendingCompactionBytesLimit);
+  private static native long hardPendingCompactionBytesLimit(long handle);
+  private static native void setLevel0FileNumCompactionTrigger(
+      long handle, int level0FileNumCompactionTrigger);
+  private static native int level0FileNumCompactionTrigger(long handle);
+  private static native void setLevel0SlowdownWritesTrigger(
+      long handle, int level0SlowdownWritesTrigger);
+  private static native int level0SlowdownWritesTrigger(long handle);
+  private static native void setLevel0StopWritesTrigger(long handle, int level0StopWritesTrigger);
+  private static native int level0StopWritesTrigger(long handle);
+  private static native void setMaxBytesForLevelMultiplierAdditional(
+      long handle, int[] maxBytesForLevelMultiplierAdditional);
+  private static native int[] maxBytesForLevelMultiplierAdditional(long handle);
+  private static native void setParanoidFileChecks(long handle, boolean paranoidFileChecks);
+  private static native boolean paranoidFileChecks(long handle);
+  private static native void setMaxWriteBufferNumberToMaintain(
+      final long handle, final int maxWriteBufferNumberToMaintain);
+  private static native int maxWriteBufferNumberToMaintain(final long handle);
+  private static native void setCompactionPriority(
+      final long handle, final byte compactionPriority);
+  private static native byte compactionPriority(final long handle);
+  private static native void setReportBgIoStats(final long handle, final boolean reportBgIoStats);
+  private static native boolean reportBgIoStats(final long handle);
+  private static native void setTtl(final long handle, final long ttl);
+  private static native long ttl(final long handle);
+  private static native void setPeriodicCompactionSeconds(
       final long handle, final long periodicCompactionSeconds);
-  private native long periodicCompactionSeconds(final long handle);
-  private native void setCompactionOptionsUniversal(final long handle,
-      final long compactionOptionsUniversalHandle);
-  private native void setCompactionOptionsFIFO(final long handle,
-      final long compactionOptionsFIFOHandle);
-  private native void setForceConsistencyChecks(final long handle,
-      final boolean forceConsistencyChecks);
-  private native boolean forceConsistencyChecks(final long handle);
-  private native void setAtomicFlush(final long handle,
-      final boolean atomicFlush);
-  private native boolean atomicFlush(final long handle);
-  private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
-  private native void setMemtableMaxRangeDeletions(final long handle, final int count);
-  private native int memtableMaxRangeDeletions(final long handle);
+  private static native long periodicCompactionSeconds(final long handle);
+  private static native void setCompactionOptionsUniversal(
+      final long handle, final long compactionOptionsUniversalHandle);
+  private static native void setCompactionOptionsFIFO(
+      final long handle, final long compactionOptionsFIFOHandle);
+  private static native void setForceConsistencyChecks(
+      final long handle, final boolean forceConsistencyChecks);
+  private static native boolean forceConsistencyChecks(final long handle);
+  private static native void setAtomicFlush(final long handle, final boolean atomicFlush);
+  private static native boolean atomicFlush(final long handle);
+  private static native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
+  private static native void setMemtableMaxRangeDeletions(final long handle, final int count);
+  private static native int memtableMaxRangeDeletions(final long handle);
   private static native void setCompactionThreadLimiter(
       final long nativeHandle_, final long newLimiterHandle);
   private static native void setAvoidUnnecessaryBlockingIO(
@@ -2566,32 +2508,35 @@ public class Options extends RocksObject
   private static native void setBgerrorResumeRetryInterval(
       final long handle, final long bgerrorResumeRetryInterval);
   private static native long bgerrorResumeRetryInterval(final long handle);
-  private native void setEnableBlobFiles(final long nativeHandle_, final boolean enableBlobFiles);
-  private native boolean enableBlobFiles(final long nativeHandle_);
-  private native void setMinBlobSize(final long nativeHandle_, final long minBlobSize);
-  private native long minBlobSize(final long nativeHandle_);
-  private native void setBlobFileSize(final long nativeHandle_, final long blobFileSize);
-  private native long blobFileSize(final long nativeHandle_);
-  private native void setBlobCompressionType(final long nativeHandle_, final byte compressionType);
-  private native byte blobCompressionType(final long nativeHandle_);
-  private native void setEnableBlobGarbageCollection(
+
+  private static native void setEnableBlobFiles(
+      final long nativeHandle_, final boolean enableBlobFiles);
+  private static native boolean enableBlobFiles(final long nativeHandle_);
+  private static native void setMinBlobSize(final long nativeHandle_, final long minBlobSize);
+  private static native long minBlobSize(final long nativeHandle_);
+  private static native void setBlobFileSize(final long nativeHandle_, final long blobFileSize);
+  private static native long blobFileSize(final long nativeHandle_);
+  private static native void setBlobCompressionType(
+      final long nativeHandle_, final byte compressionType);
+  private static native byte blobCompressionType(final long nativeHandle_);
+  private static native void setEnableBlobGarbageCollection(
       final long nativeHandle_, final boolean enableBlobGarbageCollection);
-  private native boolean enableBlobGarbageCollection(final long nativeHandle_);
-  private native void setBlobGarbageCollectionAgeCutoff(
+  private static native boolean enableBlobGarbageCollection(final long nativeHandle_);
+  private static native void setBlobGarbageCollectionAgeCutoff(
       final long nativeHandle_, final double blobGarbageCollectionAgeCutoff);
-  private native double blobGarbageCollectionAgeCutoff(final long nativeHandle_);
-  private native void setBlobGarbageCollectionForceThreshold(
+  private static native double blobGarbageCollectionAgeCutoff(final long nativeHandle_);
+  private static native void setBlobGarbageCollectionForceThreshold(
       final long nativeHandle_, final double blobGarbageCollectionForceThreshold);
-  private native double blobGarbageCollectionForceThreshold(final long nativeHandle_);
-  private native void setBlobCompactionReadaheadSize(
+  private static native double blobGarbageCollectionForceThreshold(final long nativeHandle_);
+  private static native void setBlobCompactionReadaheadSize(
       final long nativeHandle_, final long blobCompactionReadaheadSize);
-  private native long blobCompactionReadaheadSize(final long nativeHandle_);
-  private native void setBlobFileStartingLevel(
+  private static native long blobCompactionReadaheadSize(final long nativeHandle_);
+  private static native void setBlobFileStartingLevel(
       final long nativeHandle_, final int blobFileStartingLevel);
-  private native int blobFileStartingLevel(final long nativeHandle_);
-  private native void setPrepopulateBlobCache(
+  private static native int blobFileStartingLevel(final long nativeHandle_);
+  private static native void setPrepopulateBlobCache(
       final long nativeHandle_, final byte prepopulateBlobCache);
-  private native byte prepopulateBlobCache(final long nativeHandle_);
+  private static native byte prepopulateBlobCache(final long nativeHandle_);
   private static native long[] tablePropertiesCollectorFactory(long nativeHandle);
   private static native void setTablePropertiesCollectorFactory(
       long nativeHandle, long[] factoryHandlers);

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -2180,7 +2180,8 @@ public class Options extends RocksObject
   private static native boolean paranoidChecks(long handle);
   private static native void setRateLimiter(long handle, long rateLimiterHandle);
   private static native void setSstFileManager(final long handle, final long sstFileManagerHandle);
-  private static native void setLogger(final long handle, final long loggerHandle, final byte loggerType);
+  private static native void setLogger(
+      final long handle, final long loggerHandle, final byte loggerType);
   private static native void setInfoLogLevel(long handle, byte logLevel);
   private static native byte infoLogLevel(long handle);
   private static native void setMaxOpenFiles(long handle, int maxOpenFiles);

--- a/java/src/main/java/org/rocksdb/OptionsUtil.java
+++ b/java/src/main/java/org/rocksdb/OptionsUtil.java
@@ -110,5 +110,5 @@ public class OptionsUtil {
   private static native String getLatestOptionsFileName(String dbPath, long envHandle)
       throws RocksDBException;
 
-  private native static TableFormatConfig readTableFormatConfig(final long nativeHandle_);
+  private static native TableFormatConfig readTableFormatConfig(final long nativeHandle_);
 }

--- a/java/src/main/java/org/rocksdb/PersistentCache.java
+++ b/java/src/main/java/org/rocksdb/PersistentCache.java
@@ -22,5 +22,9 @@ public class PersistentCache extends RocksObject {
       final long size, final long loggerHandle, final boolean optimizedForNvm)
       throws RocksDBException;
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/PlainTableConfig.java
+++ b/java/src/main/java/org/rocksdb/PlainTableConfig.java
@@ -234,10 +234,8 @@ public class PlainTableConfig extends TableFormatConfig {
         storeIndexInFile_);
   }
 
-  private native long newTableFactoryHandle(
-      int keySize, int bloomBitsPerKey,
-      double hashTableRatio, int indexSparseness,
-      int hugePageTlbSize, byte encodingType,
+  private static native long newTableFactoryHandle(int keySize, int bloomBitsPerKey,
+      double hashTableRatio, int indexSparseness, int hugePageTlbSize, byte encodingType,
       boolean fullScanMode, boolean storeIndexInFile);
 
   private int keySize_;

--- a/java/src/main/java/org/rocksdb/RateLimiter.java
+++ b/java/src/main/java/org/rocksdb/RateLimiter.java
@@ -215,13 +215,16 @@ public class RateLimiter extends RocksObject {
   private static native long newRateLimiterHandle(final long rateBytesPerSecond,
       final long refillPeriodMicros, final int fairness,
       final byte rateLimiterMode, final boolean autoTune);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native void setBytesPerSecond(final long handle,
-      final long bytesPerSecond);
-  private native long getBytesPerSecond(final long handle);
-  private native void request(final long handle, final long bytes);
-  private native long getSingleBurstBytes(final long handle);
-  private native long getTotalBytesThrough(final long handle);
-  private native long getTotalRequests(final long handle);
+  private static native void setBytesPerSecond(final long handle, final long bytesPerSecond);
+  private static native long getBytesPerSecond(final long handle);
+  private static native void request(final long handle, final long bytes);
+  private static native long getSingleBurstBytes(final long handle);
+  private static native long getTotalBytesThrough(final long handle);
+  private static native long getTotalRequests(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/ReadOptions.java
+++ b/java/src/main/java/org/rocksdb/ReadOptions.java
@@ -795,57 +795,60 @@ public class ReadOptions extends RocksObject {
   private static native long newReadOptions();
   private static native long newReadOptions(final boolean verifyChecksums, final boolean fillCache);
   private static native long copyReadOptions(long handle);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native boolean verifyChecksums(long handle);
-  private native void setVerifyChecksums(long handle, boolean verifyChecksums);
-  private native boolean fillCache(long handle);
-  private native void setFillCache(long handle, boolean fillCache);
-  private native long snapshot(long handle);
-  private native void setSnapshot(long handle, long snapshotHandle);
-  private native byte readTier(long handle);
-  private native void setReadTier(long handle, byte readTierValue);
-  private native boolean tailing(long handle);
-  private native void setTailing(long handle, boolean tailing);
-  private native boolean managed(long handle);
-  private native void setManaged(long handle, boolean managed);
-  private native boolean totalOrderSeek(long handle);
-  private native void setTotalOrderSeek(long handle, boolean totalOrderSeek);
-  private native boolean prefixSameAsStart(long handle);
-  private native void setPrefixSameAsStart(long handle, boolean prefixSameAsStart);
-  private native boolean pinData(long handle);
-  private native void setPinData(long handle, boolean pinData);
-  private native boolean backgroundPurgeOnIteratorCleanup(final long handle);
-  private native void setBackgroundPurgeOnIteratorCleanup(final long handle,
-      final boolean backgroundPurgeOnIteratorCleanup);
-  private native long readaheadSize(final long handle);
-  private native void setReadaheadSize(final long handle,
-      final long readaheadSize);
-  private native long maxSkippableInternalKeys(final long handle);
-  private native void setMaxSkippableInternalKeys(final long handle,
-      final long maxSkippableInternalKeys);
-  private native boolean ignoreRangeDeletions(final long handle);
-  private native void setIgnoreRangeDeletions(final long handle,
-      final boolean ignoreRangeDeletions);
-  private native void setIterateUpperBound(final long handle,
-      final long upperBoundSliceHandle);
-  private native long iterateUpperBound(final long handle);
-  private native void setIterateLowerBound(final long handle,
-      final long lowerBoundSliceHandle);
-  private native long iterateLowerBound(final long handle);
-  private native void setTableFilter(final long handle, final long tableFilterHandle);
-  private native boolean autoPrefixMode(final long handle);
-  private native void setAutoPrefixMode(final long handle, final boolean autoPrefixMode);
-  private native long timestamp(final long handle);
-  private native void setTimestamp(final long handle, final long timestampSliceHandle);
-  private native long iterStartTs(final long handle);
-  private native void setIterStartTs(final long handle, final long iterStartTsHandle);
-  private native long deadline(final long handle);
-  private native void setDeadline(final long handle, final long deadlineTime);
-  private native long ioTimeout(final long handle);
-  private native void setIoTimeout(final long handle, final long ioTimeout);
-  private native long valueSizeSoftLimit(final long handle);
-  private native void setValueSizeSoftLimit(final long handle, final long softLimit);
   private native boolean asyncIo(final long handle);
   private native void setAsyncIo(final long handle, final boolean asyncIO);
+  private static native boolean verifyChecksums(long handle);
+  private static native void setVerifyChecksums(long handle, boolean verifyChecksums);
+  private static native boolean fillCache(long handle);
+  private static native void setFillCache(long handle, boolean fillCache);
+  private static native long snapshot(long handle);
+  private static native void setSnapshot(long handle, long snapshotHandle);
+  private static native byte readTier(long handle);
+  private static native void setReadTier(long handle, byte readTierValue);
+  private static native boolean tailing(long handle);
+  private static native void setTailing(long handle, boolean tailing);
+  private static native boolean managed(long handle);
+  private static native void setManaged(long handle, boolean managed);
+  private static native boolean totalOrderSeek(long handle);
+  private static native void setTotalOrderSeek(long handle, boolean totalOrderSeek);
+  private static native boolean prefixSameAsStart(long handle);
+  private static native void setPrefixSameAsStart(long handle, boolean prefixSameAsStart);
+  private static native boolean pinData(long handle);
+  private static native void setPinData(long handle, boolean pinData);
+  private static native boolean backgroundPurgeOnIteratorCleanup(final long handle);
+  private static native void setBackgroundPurgeOnIteratorCleanup(
+      final long handle, final boolean backgroundPurgeOnIteratorCleanup);
+  private static native long readaheadSize(final long handle);
+  private static native void setReadaheadSize(final long handle, final long readaheadSize);
+  private static native long maxSkippableInternalKeys(final long handle);
+  private static native void setMaxSkippableInternalKeys(
+      final long handle, final long maxSkippableInternalKeys);
+  private static native boolean ignoreRangeDeletions(final long handle);
+  private static native void setIgnoreRangeDeletions(
+      final long handle, final boolean ignoreRangeDeletions);
+  private static native void setIterateUpperBound(
+      final long handle, final long upperBoundSliceHandle);
+  private static native long iterateUpperBound(final long handle);
+  private static native void setIterateLowerBound(
+      final long handle, final long lowerBoundSliceHandle);
+  private static native long iterateLowerBound(final long handle);
+  private static native void setTableFilter(final long handle, final long tableFilterHandle);
+  private static native boolean autoPrefixMode(final long handle);
+  private static native void setAutoPrefixMode(final long handle, final boolean autoPrefixMode);
+  private static native long timestamp(final long handle);
+  private static native void setTimestamp(final long handle, final long timestampSliceHandle);
+  private static native long iterStartTs(final long handle);
+  private static native void setIterStartTs(final long handle, final long iterStartTsHandle);
+  private static native long deadline(final long handle);
+  private static native void setDeadline(final long handle, final long deadlineTime);
+  private static native long ioTimeout(final long handle);
+  private static native void setIoTimeout(final long handle, final long ioTimeout);
+  private static native long valueSizeSoftLimit(final long handle);
+  private static native void setValueSizeSoftLimit(final long handle, final long softLimit);
 }

--- a/java/src/main/java/org/rocksdb/RestoreOptions.java
+++ b/java/src/main/java/org/rocksdb/RestoreOptions.java
@@ -28,5 +28,9 @@ public class RestoreOptions extends RocksObject {
   }
 
   private static native long newRestoreOptions(boolean keepLogFiles);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/RocksCallbackObject.java
+++ b/java/src/main/java/org/rocksdb/RocksCallbackObject.java
@@ -69,5 +69,5 @@ public abstract class RocksCallbackObject extends
     disposeInternal(nativeHandle_);
   }
 
-  private native void disposeInternal(final long handle);
+  private static native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -4830,281 +4830,268 @@ public class RocksDB extends RocksObject {
       final String secondaryPath, final byte[][] columnFamilyNames,
       final long[] columnFamilyOptions) throws RocksDBException;
 
-  @Override protected native void disposeInternal(final long handle);
+  @Override
+  protected void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   private static native void closeDatabase(final long handle) throws RocksDBException;
   private static native byte[][] listColumnFamilies(final long optionsHandle, final String path)
       throws RocksDBException;
-  private native long createColumnFamily(final long handle,
-      final byte[] columnFamilyName, final int columnFamilyNamelen,
-      final long columnFamilyOptions) throws RocksDBException;
-  private native long[] createColumnFamilies(final long handle,
-      final long columnFamilyOptionsHandle, final byte[][] columnFamilyNames)
+  private static native long createColumnFamily(final long handle, final byte[] columnFamilyName,
+      final int columnFamilyNamelen, final long columnFamilyOptions) throws RocksDBException;
+  private static native long[] createColumnFamilies(
+      final long handle, final long columnFamilyOptionsHandle, final byte[][] columnFamilyNames)
       throws RocksDBException;
-  private native long[] createColumnFamilies(
+  private static native long[] createColumnFamilies(
       final long handle, final long[] columnFamilyOptionsHandles, final byte[][] columnFamilyNames)
       throws RocksDBException;
-  private native long createColumnFamilyWithImport(final long handle, final byte[] columnFamilyName,
+  private static native long createColumnFamilyWithImport(final long handle, final byte[] columnFamilyName,
       final int columnFamilyNamelen, final long columnFamilyOptions,
       final long importColumnFamilyOptions, final long[] metadataHandleList)
       throws RocksDBException;
-  private native void dropColumnFamily(
+  private static native void dropColumnFamily(
       final long handle, final long cfHandle) throws RocksDBException;
-  private native void dropColumnFamilies(final long handle,
+  private static native void dropColumnFamilies(final long handle,
       final long[] cfHandles) throws RocksDBException;
-  private native void put(final long handle, final byte[] key,
+  private static native void put(final long handle, final byte[] key,
       final int keyOffset, final int keyLength, final byte[] value,
       final int valueOffset, int valueLength) throws RocksDBException;
-  private native void put(final long handle, final byte[] key, final int keyOffset,
+  private static native void put(final long handle, final byte[] key, final int keyOffset,
       final int keyLength, final byte[] value, final int valueOffset,
       final int valueLength, final long cfHandle) throws RocksDBException;
-  private native void put(final long handle, final long writeOptHandle,
+  private static native void put(final long handle, final long writeOptHandle,
       final byte[] key,  final int keyOffset, final int keyLength,
       final byte[] value, final int valueOffset, final int valueLength)
       throws RocksDBException;
-  private native void put(final long handle, final long writeOptHandle,
+  private static native void put(final long handle, final long writeOptHandle,
       final byte[] key, final int keyOffset, final int keyLength,
       final byte[] value, final int valueOffset, final int valueLength,
       final long cfHandle) throws RocksDBException;
-  private native void delete(final long handle, final byte[] key,
+  private static native void delete(final long handle, final byte[] key,
       final int keyOffset, final int keyLength) throws RocksDBException;
-  private native void delete(final long handle, final byte[] key,
+  private static native void delete(final long handle, final byte[] key,
       final int keyOffset, final int keyLength, final long cfHandle)
       throws RocksDBException;
-  private native void delete(final long handle, final long writeOptHandle,
+  private static native void delete(final long handle, final long writeOptHandle,
       final byte[] key, final int keyOffset, final int keyLength)
       throws RocksDBException;
-  private native void delete(final long handle, final long writeOptHandle,
+  private static native void delete(final long handle, final long writeOptHandle,
       final byte[] key, final int keyOffset, final int keyLength,
       final long cfHandle) throws RocksDBException;
-  private native void singleDelete(
+  private static native void singleDelete(
       final long handle, final byte[] key, final int keyLen)
       throws RocksDBException;
-  private native void singleDelete(
+  private static native void singleDelete(
       final long handle, final byte[] key, final int keyLen,
       final long cfHandle) throws RocksDBException;
-  private native void singleDelete(
+  private static native void singleDelete(
       final long handle, final long writeOptHandle, final byte[] key,
       final int keyLen) throws RocksDBException;
-  private native void singleDelete(
+  private static native void singleDelete(
       final long handle, final long writeOptHandle,
       final byte[] key, final int keyLen, final long cfHandle)
       throws RocksDBException;
-  private native void deleteRange(final long handle, final byte[] beginKey,
+  private static native void deleteRange(final long handle, final byte[] beginKey,
       final int beginKeyOffset, final int beginKeyLength, final byte[] endKey,
       final int endKeyOffset, final int endKeyLength) throws RocksDBException;
-  private native void deleteRange(final long handle, final byte[] beginKey,
+  private static native void deleteRange(final long handle, final byte[] beginKey,
       final int beginKeyOffset, final int beginKeyLength, final byte[] endKey,
       final int endKeyOffset, final int endKeyLength, final long cfHandle)
       throws RocksDBException;
-  private native void deleteRange(final long handle, final long writeOptHandle,
+  private static native void deleteRange(final long handle, final long writeOptHandle,
       final byte[] beginKey, final int beginKeyOffset, final int beginKeyLength,
       final byte[] endKey, final int endKeyOffset, final int endKeyLength)
       throws RocksDBException;
-  private native void deleteRange(
+  private static native void deleteRange(
       final long handle, final long writeOptHandle, final byte[] beginKey,
       final int beginKeyOffset, final int beginKeyLength, final byte[] endKey,
       final int endKeyOffset, final int endKeyLength, final long cfHandle)
       throws RocksDBException;
-  private native void clipColumnFamily(final long handle, final long cfHandle,
+  private static native void clipColumnFamily(final long handle, final long cfHandle,
       final byte[] beginKey, final int beginKeyOffset, final int beginKeyLength,
       final byte[] endKey, final int endKeyOffset, final int endKeyLength) throws RocksDBException;
-  private native void merge(final long handle, final byte[] key,
+  private static native void merge(final long handle, final byte[] key,
       final int keyOffset, final int keyLength, final byte[] value,
       final int valueOffset, final int valueLength) throws RocksDBException;
-  private native void merge(final long handle, final byte[] key,
+  private static native void merge(final long handle, final byte[] key,
       final int keyOffset, final int keyLength, final byte[] value,
       final int valueOffset, final int valueLength, final long cfHandle)
       throws RocksDBException;
-  private native void merge(final long handle, final long writeOptHandle,
+  private static native void merge(final long handle, final long writeOptHandle,
       final byte[] key, final int keyOffset, final int keyLength,
       final byte[] value, final int valueOffset, final int valueLength)
       throws RocksDBException;
-  private native void merge(final long handle, final long writeOptHandle,
+  private static native void merge(final long handle, final long writeOptHandle,
       final byte[] key, final int keyOffset, final int keyLength,
       final byte[] value, final int valueOffset, final int valueLength,
       final long cfHandle) throws RocksDBException;
-  private native void mergeDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
+  private static native void mergeDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
       int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
       throws RocksDBException;
 
-  private native void write0(final long handle, final long writeOptHandle,
+  private static native void write0(final long handle, final long writeOptHandle,
       final long wbHandle) throws RocksDBException;
-  private native void write1(final long handle, final long writeOptHandle,
+  private static native void write1(final long handle, final long writeOptHandle,
       final long wbwiHandle) throws RocksDBException;
-  private native int get(final long handle, final byte[] key,
+  private static native int get(final long handle, final byte[] key,
       final int keyOffset, final int keyLength, final byte[] value,
       final int valueOffset, final int valueLength) throws RocksDBException;
-  private native int get(final long handle, final byte[] key,
+  private static native int get(final long handle, final byte[] key,
       final int keyOffset, final int keyLength, byte[] value,
       final int valueOffset, final int valueLength, final long cfHandle)
       throws RocksDBException;
-  private native int get(final long handle, final long readOptHandle,
+  private static native int get(final long handle, final long readOptHandle,
       final byte[] key, final int keyOffset, final int keyLength,
       final byte[] value, final int valueOffset, final int valueLength)
       throws RocksDBException;
-  private native int get(final long handle, final long readOptHandle,
+  private static native int get(final long handle, final long readOptHandle,
       final byte[] key, final int keyOffset, final int keyLength,
       final byte[] value, final int valueOffset, final int valueLength,
       final long cfHandle) throws RocksDBException;
-  private native byte[] get(final long handle, byte[] key, final int keyOffset,
+  private static native byte[] get(final long handle, byte[] key, final int keyOffset,
       final int keyLength) throws RocksDBException;
-  private native byte[] get(final long handle, final byte[] key,
+  private static native byte[] get(final long handle, final byte[] key,
       final int keyOffset, final int keyLength, final long cfHandle)
       throws RocksDBException;
-  private native byte[] get(final long handle, final long readOptHandle,
+  private static native byte[] get(final long handle, final long readOptHandle,
       final byte[] key, final int keyOffset, final int keyLength)
       throws RocksDBException;
-  private native byte[] get(final long handle,
+  private static native byte[] get(final long handle,
       final long readOptHandle, final byte[] key, final int keyOffset,
       final int keyLength, final long cfHandle) throws RocksDBException;
-  private native byte[][] multiGet(final long dbHandle, final byte[][] keys,
+  private static native byte[][] multiGet(final long dbHandle, final byte[][] keys,
       final int[] keyOffsets, final int[] keyLengths);
-  private native byte[][] multiGet(final long dbHandle, final byte[][] keys,
+  private static native byte[][] multiGet(final long dbHandle, final byte[][] keys,
       final int[] keyOffsets, final int[] keyLengths,
       final long[] columnFamilyHandles);
-  private native byte[][] multiGet(final long dbHandle, final long rOptHandle,
+  private static native byte[][] multiGet(final long dbHandle, final long rOptHandle,
       final byte[][] keys, final int[] keyOffsets, final int[] keyLengths);
-  private native byte[][] multiGet(final long dbHandle, final long rOptHandle,
+  private static native byte[][] multiGet(final long dbHandle, final long rOptHandle,
       final byte[][] keys, final int[] keyOffsets, final int[] keyLengths,
       final long[] columnFamilyHandles);
 
-  private native void multiGet(final long dbHandle, final long rOptHandle,
+  private static native void multiGet(final long dbHandle, final long rOptHandle,
       final long[] columnFamilyHandles, final ByteBuffer[] keysArray, final int[] keyOffsets,
       final int[] keyLengths, final ByteBuffer[] valuesArray, final int[] valuesSizeArray,
       final Status[] statusArray);
 
-  private native boolean keyExists(final long handle, final long cfHandle, final long readOptHandle,
+  private static native boolean keyExists(final long handle, final long cfHandle, final long readOptHandle,
       final byte[] key, final int keyOffset, final int keyLength);
 
-  private native boolean keyExistsDirect(final long handle, final long cfHandle,
+  private static native boolean keyExistsDirect(final long handle, final long cfHandle,
       final long readOptHandle, final ByteBuffer key, final int keyOffset, final int keyLength);
 
-  private native boolean keyMayExist(
+  private static native boolean keyMayExist(
       final long handle, final long cfHandle, final long readOptHandle,
       final byte[] key, final int keyOffset, final int keyLength);
-  private native byte[][] keyMayExistFoundValue(
+  private static native byte[][] keyMayExistFoundValue(
       final long handle, final long cfHandle, final long readOptHandle,
       final byte[] key, final int keyOffset, final int keyLength);
-  private native void putDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
+  private static native void putDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
       int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
       throws RocksDBException;
-  private native long iterator(final long handle, final long cfHandle, final long readOptHandle);
-  private native long[] iterators(final long handle,
+  private static native long iterator(final long handle, final long cfHandle, final long readOptHandle);
+  private static native long[] iterators(final long handle,
       final long[] columnFamilyHandles, final long readOptHandle)
       throws RocksDBException;
-  private native long getSnapshot(final long nativeHandle);
-  private native void releaseSnapshot(
+
+  private static native long getSnapshot(final long nativeHandle);
+  private static native void releaseSnapshot(
       final long nativeHandle, final long snapshotHandle);
-  private native String getProperty(final long nativeHandle,
+  private static native String getProperty(final long nativeHandle,
       final long cfHandle, final String property, final int propertyLength)
       throws RocksDBException;
-  private native Map<String, String> getMapProperty(final long nativeHandle,
+  private static native Map<String, String> getMapProperty(final long nativeHandle,
       final long cfHandle, final String property, final int propertyLength)
       throws RocksDBException;
-  private native int getDirect(long handle, long readOptHandle, ByteBuffer key, int keyOffset,
-      int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
-      throws RocksDBException;
-  private native boolean keyMayExistDirect(final long handle, final long cfHhandle,
+  private static native int getDirect(long handle, long readOptHandle, ByteBuffer key, int keyOffset,
+       int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
+       throws RocksDBException;
+  private static native boolean keyMayExistDirect(final long handle, final long cfHhandle,
       final long readOptHandle, final ByteBuffer key, final int keyOffset, final int keyLength);
-  private native int[] keyMayExistDirectFoundValue(final long handle, final long cfHhandle,
+  private static native int[] keyMayExistDirectFoundValue(final long handle, final long cfHhandle,
       final long readOptHandle, final ByteBuffer key, final int keyOffset, final int keyLength,
       final ByteBuffer value, final int valueOffset, final int valueLength);
-  private native void deleteDirect(long handle, long optHandle, ByteBuffer key, int keyOffset,
-      int keyLength, long cfHandle) throws RocksDBException;
-  private native long getLongProperty(final long nativeHandle,
-      final long cfHandle, final String property, final int propertyLength)
-      throws RocksDBException;
-  private native void resetStats(final long nativeHandle)
-      throws RocksDBException;
-  private native long getAggregatedLongProperty(final long nativeHandle,
-      final String property, int propertyLength) throws RocksDBException;
-  private native long[] getApproximateSizes(final long nativeHandle,
-      final long columnFamilyHandle, final long[] rangeSliceHandles,
-      final byte includeFlags);
-  private native long[] getApproximateMemTableStats(final long nativeHandle,
+  private static native void deleteDirect(long handle, long optHandle, ByteBuffer key,
+      int keyOffset, int keyLength, long cfHandle) throws RocksDBException;
+  private static native long getLongProperty(final long nativeHandle, final long cfHandle,
+      final String property, final int propertyLength) throws RocksDBException;
+  private static native void resetStats(final long nativeHandle) throws RocksDBException;
+  private static native long getAggregatedLongProperty(
+      final long nativeHandle, final String property, int propertyLength) throws RocksDBException;
+  private static native long[] getApproximateSizes(final long nativeHandle,
+      final long columnFamilyHandle, final long[] rangeSliceHandles, final byte includeFlags);
+  private static native long[] getApproximateMemTableStats(final long nativeHandle,
       final long columnFamilyHandle, final long rangeStartSliceHandle,
       final long rangeLimitSliceHandle);
-  private native void compactRange(final long handle,
+  private static native void compactRange(final long handle,
       /* @Nullable */ final byte[] begin, final int beginLen,
-      /* @Nullable */ final byte[] end, final int endLen,
-      final long compactRangeOptHandle, final long cfHandle)
-      throws RocksDBException;
-  private native void setOptions(final long handle, final long cfHandle,
-      final String[] keys, final String[] values) throws RocksDBException;
-  private native String getOptions(final long handle, final long cfHandle);
-  private native void setDBOptions(final long handle,
-      final String[] keys, final String[] values) throws RocksDBException;
-  private native String getDBOptions(final long handle);
-  private native void setPerfLevel(final byte level);
-  private native byte getPerfLevelNative();
+      /* @Nullable */ final byte[] end, final int endLen, final long compactRangeOptHandle,
+      final long cfHandle) throws RocksDBException;
+  private static native void setOptions(final long handle, final long cfHandle, final String[] keys,
+      final String[] values) throws RocksDBException;
+  private static native String getOptions(final long handle, final long cfHandle);
+  private static native void setDBOptions(
+      final long handle, final String[] keys, final String[] values) throws RocksDBException;
+  private static native String getDBOptions(final long handle);
+  private static native void setPerfLevel(final byte level);
+  private static native byte getPerfLevelNative();
 
-  private native long getPerfContextNative();
+  private static native long getPerfContextNative();
 
-  private native String[] compactFiles(final long handle,
-      final long compactionOptionsHandle,
-      final long columnFamilyHandle,
-      final String[] inputFileNames,
-      final int outputLevel,
-      final int outputPathId,
-      final long compactionJobInfoHandle) throws RocksDBException;
-  private native void cancelAllBackgroundWork(final long handle,
-      final boolean wait);
-  private native void pauseBackgroundWork(final long handle)
-      throws RocksDBException;
-  private native void continueBackgroundWork(final long handle)
-      throws RocksDBException;
-  private native void enableAutoCompaction(final long handle,
-      final long[] columnFamilyHandles) throws RocksDBException;
-  private native int numberLevels(final long handle,
-      final long columnFamilyHandle);
-  private native int maxMemCompactionLevel(final long handle,
-      final long columnFamilyHandle);
-  private native int level0StopWriteTrigger(final long handle,
-      final long columnFamilyHandle);
-  private native String getName(final long handle);
-  private native long getEnv(final long handle);
-  private native void flush(final long handle, final long flushOptHandle,
-      /* @Nullable */ final long[] cfHandles) throws RocksDBException;
-  private native void flushWal(final long handle, final boolean sync)
-      throws RocksDBException;
-  private native void syncWal(final long handle) throws RocksDBException;
-  private native long getLatestSequenceNumber(final long handle);
-  private native void disableFileDeletions(long handle) throws RocksDBException;
-  private native void enableFileDeletions(long handle, boolean force)
-      throws RocksDBException;
-  private native String[] getLiveFiles(final long handle,
-      final boolean flushMemtable) throws RocksDBException;
-  private native LogFile[] getSortedWalFiles(final long handle)
-      throws RocksDBException;
-  private native long getUpdatesSince(final long handle,
-      final long sequenceNumber) throws RocksDBException;
-  private native void deleteFile(final long handle, final String name)
-      throws RocksDBException;
-  private native LiveFileMetaData[] getLiveFilesMetaData(final long handle);
-  private native ColumnFamilyMetaData getColumnFamilyMetaData(
+  private static native String[] compactFiles(final long handle, final long compactionOptionsHandle,
+      final long columnFamilyHandle, final String[] inputFileNames, final int outputLevel,
+      final int outputPathId, final long compactionJobInfoHandle) throws RocksDBException;
+  private static native void cancelAllBackgroundWork(final long handle, final boolean wait);
+  private static native void pauseBackgroundWork(final long handle) throws RocksDBException;
+  private static native void continueBackgroundWork(final long handle) throws RocksDBException;
+  private static native void enableAutoCompaction(
+      final long handle, final long[] columnFamilyHandles) throws RocksDBException;
+  private static native int numberLevels(final long handle, final long columnFamilyHandle);
+  private static native int maxMemCompactionLevel(final long handle, final long columnFamilyHandle);
+  private static native int level0StopWriteTrigger(
       final long handle, final long columnFamilyHandle);
-  private native void ingestExternalFile(final long handle,
-      final long columnFamilyHandle,  final String[] filePathList,
-      final int filePathListLen, final long ingestExternalFileOptionsHandle)
+  private static native String getName(final long handle);
+  private static native long getEnv(final long handle);
+  private static native void flush(final long handle, final long flushOptHandle,
+      /* @Nullable */ final long[] cfHandles) throws RocksDBException;
+  private static native void flushWal(final long handle, final boolean sync)
       throws RocksDBException;
-  private native void verifyChecksum(final long handle) throws RocksDBException;
-  private native long getDefaultColumnFamily(final long handle);
-  private native Map<String, TableProperties> getPropertiesOfAllTables(
+  private static native void syncWal(final long handle) throws RocksDBException;
+  private static native long getLatestSequenceNumber(final long handle);
+  private static native void disableFileDeletions(long handle) throws RocksDBException;
+  private static native void enableFileDeletions(long handle, boolean force)
+      throws RocksDBException;
+  private static native String[] getLiveFiles(final long handle, final boolean flushMemtable)
+      throws RocksDBException;
+  private static native LogFile[] getSortedWalFiles(final long handle) throws RocksDBException;
+  private static native long getUpdatesSince(final long handle, final long sequenceNumber)
+      throws RocksDBException;
+  private static native void deleteFile(final long handle, final String name)
+      throws RocksDBException;
+  private static native LiveFileMetaData[] getLiveFilesMetaData(final long handle);
+  private static native ColumnFamilyMetaData getColumnFamilyMetaData(
+      final long handle, final long columnFamilyHandle);
+  private static native void ingestExternalFile(final long handle, final long columnFamilyHandle,
+      final String[] filePathList, final int filePathListLen,
+      final long ingestExternalFileOptionsHandle) throws RocksDBException;
+  private static native void verifyChecksum(final long handle) throws RocksDBException;
+  private static native long getDefaultColumnFamily(final long handle);
+  private static native Map<String, TableProperties> getPropertiesOfAllTables(
       final long handle, final long columnFamilyHandle) throws RocksDBException;
-  private native Map<String, TableProperties> getPropertiesOfTablesInRange(
-      final long handle, final long columnFamilyHandle,
-      final long[] rangeSliceHandles);
-  private native long[] suggestCompactRange(final long handle,
-      final long columnFamilyHandle) throws RocksDBException;
-  private native void promoteL0(final long handle,
-      final long columnFamilyHandle, final int tragetLevel)
+  private static native Map<String, TableProperties> getPropertiesOfTablesInRange(
+      final long handle, final long columnFamilyHandle, final long[] rangeSliceHandles);
+  private static native long[] suggestCompactRange(final long handle, final long columnFamilyHandle)
       throws RocksDBException;
-  private native void startTrace(final long handle, final long maxTraceFileSize,
+  private static native void promoteL0(final long handle, final long columnFamilyHandle,
+      final int tragetLevel) throws RocksDBException;
+  private static native void startTrace(final long handle, final long maxTraceFileSize,
       final long traceWriterHandle) throws RocksDBException;
-  private native void endTrace(final long handle) throws RocksDBException;
-  private native void tryCatchUpWithPrimary(final long handle) throws RocksDBException;
-  private native void deleteFilesInRanges(long handle, long cfHandle, final byte[][] ranges,
+  private static native void endTrace(final long handle) throws RocksDBException;
+  private static native void tryCatchUpWithPrimary(final long handle) throws RocksDBException;
+  private static native void deleteFilesInRanges(long handle, long cfHandle, final byte[][] ranges,
       boolean include_end) throws RocksDBException;
 
   private static native void destroyDB(final String path, final long optionsHandle)

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -4847,125 +4847,102 @@ public class RocksDB extends RocksObject {
   private static native long[] createColumnFamilies(
       final long handle, final long[] columnFamilyOptionsHandles, final byte[][] columnFamilyNames)
       throws RocksDBException;
-  private static native long createColumnFamilyWithImport(final long handle, final byte[] columnFamilyName,
-      final int columnFamilyNamelen, final long columnFamilyOptions,
+  private static native long createColumnFamilyWithImport(final long handle,
+      final byte[] columnFamilyName, final int columnFamilyNamelen, final long columnFamilyOptions,
       final long importColumnFamilyOptions, final long[] metadataHandleList)
       throws RocksDBException;
-  private static native void dropColumnFamily(
-      final long handle, final long cfHandle) throws RocksDBException;
-  private static native void dropColumnFamilies(final long handle,
-      final long[] cfHandles) throws RocksDBException;
-  private static native void put(final long handle, final byte[] key,
-      final int keyOffset, final int keyLength, final byte[] value,
-      final int valueOffset, int valueLength) throws RocksDBException;
+  private static native void dropColumnFamily(final long handle, final long cfHandle)
+      throws RocksDBException;
+  private static native void dropColumnFamilies(final long handle, final long[] cfHandles)
+      throws RocksDBException;
   private static native void put(final long handle, final byte[] key, final int keyOffset,
-      final int keyLength, final byte[] value, final int valueOffset,
+      final int keyLength, final byte[] value, final int valueOffset, int valueLength)
+      throws RocksDBException;
+  private static native void put(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength, final byte[] value, final int valueOffset, final int valueLength,
+      final long cfHandle) throws RocksDBException;
+  private static native void put(final long handle, final long writeOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength, final byte[] value, final int valueOffset,
+      final int valueLength) throws RocksDBException;
+  private static native void put(final long handle, final long writeOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength, final byte[] value, final int valueOffset,
       final int valueLength, final long cfHandle) throws RocksDBException;
-  private static native void put(final long handle, final long writeOptHandle,
-      final byte[] key,  final int keyOffset, final int keyLength,
-      final byte[] value, final int valueOffset, final int valueLength)
-      throws RocksDBException;
-  private static native void put(final long handle, final long writeOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength,
-      final byte[] value, final int valueOffset, final int valueLength,
-      final long cfHandle) throws RocksDBException;
-  private static native void delete(final long handle, final byte[] key,
+  private static native void delete(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength) throws RocksDBException;
+  private static native void delete(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength, final long cfHandle) throws RocksDBException;
+  private static native void delete(final long handle, final long writeOptHandle, final byte[] key,
       final int keyOffset, final int keyLength) throws RocksDBException;
-  private static native void delete(final long handle, final byte[] key,
-      final int keyOffset, final int keyLength, final long cfHandle)
+  private static native void delete(final long handle, final long writeOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength, final long cfHandle) throws RocksDBException;
+  private static native void singleDelete(final long handle, final byte[] key, final int keyLen)
       throws RocksDBException;
-  private static native void delete(final long handle, final long writeOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength)
-      throws RocksDBException;
-  private static native void delete(final long handle, final long writeOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength,
+  private static native void singleDelete(final long handle, final byte[] key, final int keyLen,
       final long cfHandle) throws RocksDBException;
-  private static native void singleDelete(
-      final long handle, final byte[] key, final int keyLen)
-      throws RocksDBException;
-  private static native void singleDelete(
-      final long handle, final byte[] key, final int keyLen,
-      final long cfHandle) throws RocksDBException;
-  private static native void singleDelete(
-      final long handle, final long writeOptHandle, final byte[] key,
-      final int keyLen) throws RocksDBException;
-  private static native void singleDelete(
-      final long handle, final long writeOptHandle,
-      final byte[] key, final int keyLen, final long cfHandle)
-      throws RocksDBException;
+  private static native void singleDelete(final long handle, final long writeOptHandle,
+      final byte[] key, final int keyLen) throws RocksDBException;
+  private static native void singleDelete(final long handle, final long writeOptHandle,
+      final byte[] key, final int keyLen, final long cfHandle) throws RocksDBException;
   private static native void deleteRange(final long handle, final byte[] beginKey,
       final int beginKeyOffset, final int beginKeyLength, final byte[] endKey,
       final int endKeyOffset, final int endKeyLength) throws RocksDBException;
   private static native void deleteRange(final long handle, final byte[] beginKey,
       final int beginKeyOffset, final int beginKeyLength, final byte[] endKey,
-      final int endKeyOffset, final int endKeyLength, final long cfHandle)
-      throws RocksDBException;
+      final int endKeyOffset, final int endKeyLength, final long cfHandle) throws RocksDBException;
   private static native void deleteRange(final long handle, final long writeOptHandle,
       final byte[] beginKey, final int beginKeyOffset, final int beginKeyLength,
-      final byte[] endKey, final int endKeyOffset, final int endKeyLength)
-      throws RocksDBException;
-  private static native void deleteRange(
-      final long handle, final long writeOptHandle, final byte[] beginKey,
-      final int beginKeyOffset, final int beginKeyLength, final byte[] endKey,
-      final int endKeyOffset, final int endKeyLength, final long cfHandle)
+      final byte[] endKey, final int endKeyOffset, final int endKeyLength) throws RocksDBException;
+  private static native void deleteRange(final long handle, final long writeOptHandle,
+      final byte[] beginKey, final int beginKeyOffset, final int beginKeyLength,
+      final byte[] endKey, final int endKeyOffset, final int endKeyLength, final long cfHandle)
       throws RocksDBException;
   private static native void clipColumnFamily(final long handle, final long cfHandle,
       final byte[] beginKey, final int beginKeyOffset, final int beginKeyLength,
       final byte[] endKey, final int endKeyOffset, final int endKeyLength) throws RocksDBException;
-  private static native void merge(final long handle, final byte[] key,
-      final int keyOffset, final int keyLength, final byte[] value,
-      final int valueOffset, final int valueLength) throws RocksDBException;
-  private static native void merge(final long handle, final byte[] key,
-      final int keyOffset, final int keyLength, final byte[] value,
-      final int valueOffset, final int valueLength, final long cfHandle)
+  private static native void merge(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength, final byte[] value, final int valueOffset, final int valueLength)
       throws RocksDBException;
-  private static native void merge(final long handle, final long writeOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength,
-      final byte[] value, final int valueOffset, final int valueLength)
-      throws RocksDBException;
-  private static native void merge(final long handle, final long writeOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength,
-      final byte[] value, final int valueOffset, final int valueLength,
+  private static native void merge(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength, final byte[] value, final int valueOffset, final int valueLength,
       final long cfHandle) throws RocksDBException;
-  private static native void mergeDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
-      int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
-      throws RocksDBException;
+  private static native void merge(final long handle, final long writeOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength, final byte[] value, final int valueOffset,
+      final int valueLength) throws RocksDBException;
+  private static native void merge(final long handle, final long writeOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength, final byte[] value, final int valueOffset,
+      final int valueLength, final long cfHandle) throws RocksDBException;
+  private static native void mergeDirect(long handle, long writeOptHandle, ByteBuffer key,
+      int keyOffset, int keyLength, ByteBuffer value, int valueOffset, int valueLength,
+      long cfHandle) throws RocksDBException;
 
-  private static native void write0(final long handle, final long writeOptHandle,
-      final long wbHandle) throws RocksDBException;
-  private static native void write1(final long handle, final long writeOptHandle,
-      final long wbwiHandle) throws RocksDBException;
-  private static native int get(final long handle, final byte[] key,
-      final int keyOffset, final int keyLength, final byte[] value,
-      final int valueOffset, final int valueLength) throws RocksDBException;
-  private static native int get(final long handle, final byte[] key,
-      final int keyOffset, final int keyLength, byte[] value,
-      final int valueOffset, final int valueLength, final long cfHandle)
+  private static native void write0(
+      final long handle, final long writeOptHandle, final long wbHandle) throws RocksDBException;
+  private static native void write1(
+      final long handle, final long writeOptHandle, final long wbwiHandle) throws RocksDBException;
+  private static native int get(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength, final byte[] value, final int valueOffset, final int valueLength)
       throws RocksDBException;
-  private static native int get(final long handle, final long readOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength,
-      final byte[] value, final int valueOffset, final int valueLength)
-      throws RocksDBException;
-  private static native int get(final long handle, final long readOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength,
-      final byte[] value, final int valueOffset, final int valueLength,
+  private static native int get(final long handle, final byte[] key, final int keyOffset,
+      final int keyLength, byte[] value, final int valueOffset, final int valueLength,
       final long cfHandle) throws RocksDBException;
+  private static native int get(final long handle, final long readOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength, final byte[] value, final int valueOffset,
+      final int valueLength) throws RocksDBException;
+  private static native int get(final long handle, final long readOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength, final byte[] value, final int valueOffset,
+      final int valueLength, final long cfHandle) throws RocksDBException;
   private static native byte[] get(final long handle, byte[] key, final int keyOffset,
       final int keyLength) throws RocksDBException;
-  private static native byte[] get(final long handle, final byte[] key,
-      final int keyOffset, final int keyLength, final long cfHandle)
-      throws RocksDBException;
-  private static native byte[] get(final long handle, final long readOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength)
-      throws RocksDBException;
-  private static native byte[] get(final long handle,
-      final long readOptHandle, final byte[] key, final int keyOffset,
+  private static native byte[] get(final long handle, final byte[] key, final int keyOffset,
       final int keyLength, final long cfHandle) throws RocksDBException;
+  private static native byte[] get(final long handle, final long readOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength) throws RocksDBException;
+  private static native byte[] get(final long handle, final long readOptHandle, final byte[] key,
+      final int keyOffset, final int keyLength, final long cfHandle) throws RocksDBException;
+  private static native byte[][] multiGet(
+      final long dbHandle, final byte[][] keys, final int[] keyOffsets, final int[] keyLengths);
   private static native byte[][] multiGet(final long dbHandle, final byte[][] keys,
-      final int[] keyOffsets, final int[] keyLengths);
-  private static native byte[][] multiGet(final long dbHandle, final byte[][] keys,
-      final int[] keyOffsets, final int[] keyLengths,
-      final long[] columnFamilyHandles);
+      final int[] keyOffsets, final int[] keyLengths, final long[] columnFamilyHandles);
   private static native byte[][] multiGet(final long dbHandle, final long rOptHandle,
       final byte[][] keys, final int[] keyOffsets, final int[] keyLengths);
   private static native byte[][] multiGet(final long dbHandle, final long rOptHandle,
@@ -4977,38 +4954,33 @@ public class RocksDB extends RocksObject {
       final int[] keyLengths, final ByteBuffer[] valuesArray, final int[] valuesSizeArray,
       final Status[] statusArray);
 
-  private static native boolean keyExists(final long handle, final long cfHandle, final long readOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength);
+  private static native boolean keyExists(final long handle, final long cfHandle,
+      final long readOptHandle, final byte[] key, final int keyOffset, final int keyLength);
 
   private static native boolean keyExistsDirect(final long handle, final long cfHandle,
       final long readOptHandle, final ByteBuffer key, final int keyOffset, final int keyLength);
 
-  private static native boolean keyMayExist(
-      final long handle, final long cfHandle, final long readOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength);
-  private static native byte[][] keyMayExistFoundValue(
-      final long handle, final long cfHandle, final long readOptHandle,
-      final byte[] key, final int keyOffset, final int keyLength);
-  private static native void putDirect(long handle, long writeOptHandle, ByteBuffer key, int keyOffset,
-      int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
-      throws RocksDBException;
-  private static native long iterator(final long handle, final long cfHandle, final long readOptHandle);
-  private static native long[] iterators(final long handle,
-      final long[] columnFamilyHandles, final long readOptHandle)
-      throws RocksDBException;
+  private static native boolean keyMayExist(final long handle, final long cfHandle,
+      final long readOptHandle, final byte[] key, final int keyOffset, final int keyLength);
+  private static native byte[][] keyMayExistFoundValue(final long handle, final long cfHandle,
+      final long readOptHandle, final byte[] key, final int keyOffset, final int keyLength);
+  private static native void putDirect(long handle, long writeOptHandle, ByteBuffer key,
+      int keyOffset, int keyLength, ByteBuffer value, int valueOffset, int valueLength,
+      long cfHandle) throws RocksDBException;
+  private static native long iterator(
+      final long handle, final long cfHandle, final long readOptHandle);
+  private static native long[] iterators(final long handle, final long[] columnFamilyHandles,
+      final long readOptHandle) throws RocksDBException;
 
   private static native long getSnapshot(final long nativeHandle);
-  private static native void releaseSnapshot(
-      final long nativeHandle, final long snapshotHandle);
-  private static native String getProperty(final long nativeHandle,
-      final long cfHandle, final String property, final int propertyLength)
-      throws RocksDBException;
+  private static native void releaseSnapshot(final long nativeHandle, final long snapshotHandle);
+  private static native String getProperty(final long nativeHandle, final long cfHandle,
+      final String property, final int propertyLength) throws RocksDBException;
   private static native Map<String, String> getMapProperty(final long nativeHandle,
-      final long cfHandle, final String property, final int propertyLength)
-      throws RocksDBException;
-  private static native int getDirect(long handle, long readOptHandle, ByteBuffer key, int keyOffset,
-       int keyLength, ByteBuffer value, int valueOffset, int valueLength, long cfHandle)
-       throws RocksDBException;
+      final long cfHandle, final String property, final int propertyLength) throws RocksDBException;
+  private static native int getDirect(long handle, long readOptHandle, ByteBuffer key,
+      int keyOffset, int keyLength, ByteBuffer value, int valueOffset, int valueLength,
+      long cfHandle) throws RocksDBException;
   private static native boolean keyMayExistDirect(final long handle, final long cfHhandle,
       final long readOptHandle, final ByteBuffer key, final int keyOffset, final int keyLength);
   private static native int[] keyMayExistDirectFoundValue(final long handle, final long cfHhandle,

--- a/java/src/main/java/org/rocksdb/RocksEnv.java
+++ b/java/src/main/java/org/rocksdb/RocksEnv.java
@@ -27,5 +27,9 @@ public class RocksEnv extends Env {
     super(handle);
   }
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/RocksIterator.java
+++ b/java/src/main/java/org/rocksdb/RocksIterator.java
@@ -188,32 +188,93 @@ public class RocksIterator extends AbstractRocksIterator<RocksDB> {
     return valueByteArray0(nativeHandle_, value, offset, len);
   }
 
-  @Override protected final native void disposeInternal(final long handle);
-  @Override final native boolean isValid0(long handle);
-  @Override final native void seekToFirst0(long handle);
-  @Override final native void seekToLast0(long handle);
-  @Override final native void next0(long handle);
-  @Override final native void prev0(long handle);
-  @Override final native void refresh0(long handle);
   @Override final native void refresh1(long handle, long snapshotHandle);
-  @Override final native void seek0(long handle, byte[] target, int targetLen);
-  @Override final native void seekForPrev0(long handle, byte[] target, int targetLen);
   @Override
-  final native void seekDirect0(long handle, ByteBuffer target, int targetOffset, int targetLen);
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
   @Override
-  final native void seekByteArray0(long handle, byte[] target, int targetOffset, int targetLen);
+  final boolean isValid0(long handle) {
+    return isValid0Jni(handle);
+  }
+  private static native boolean isValid0Jni(long handle);
+
   @Override
-  final native void seekForPrevDirect0(
+  final void seekToFirst0(long handle) {
+    seekToFirst0Jni(handle);
+  }
+  private static native void seekToFirst0Jni(long handle);
+
+  @Override
+  final void seekToLast0(long handle) {
+    seekToLast0Jni(handle);
+  }
+  private static native void seekToLast0Jni(long handle);
+
+  @Override
+  final void next0(long handle) {
+    next0Jni(handle);
+  }
+  private static native void next0Jni(long handle);
+
+  @Override
+  final void prev0(long handle) {
+    prev0Jni(handle);
+  }
+  private static native void prev0Jni(long handle);
+  @Override
+  final void refresh0(long handle) {
+    refresh0Jni(handle);
+  }
+  private static native void refresh0Jni(long handle);
+  @Override
+  final void seek0(long handle, byte[] target, int targetLen) {
+    seek0Jni(handle, target, targetLen);
+  }
+  private static native void seek0Jni(long handle, byte[] target, int targetLen);
+  @Override
+  final void seekForPrev0(long handle, byte[] target, int targetLen) {
+    seekForPrev0Jni(handle, target, targetLen);
+  }
+  private static native void seekForPrev0Jni(long handle, byte[] target, int targetLen);
+  @Override
+  final void seekDirect0(long handle, ByteBuffer target, int targetOffset, int targetLen) {
+    seekDirect0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekDirect0Jni(
       long handle, ByteBuffer target, int targetOffset, int targetLen);
   @Override
-  final native void seekForPrevByteArray0(
+  final void seekByteArray0(long handle, byte[] target, int targetOffset, int targetLen) {
+    seekByteArray0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekByteArray0Jni(
       long handle, byte[] target, int targetOffset, int targetLen);
-  @Override final native void status0(long handle) throws RocksDBException;
+  @Override
+  final void seekForPrevDirect0(long handle, ByteBuffer target, int targetOffset, int targetLen) {
+    seekForPrevDirect0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekForPrevDirect0Jni(
+      long handle, ByteBuffer target, int targetOffset, int targetLen);
+  @Override
+  final void seekForPrevByteArray0(long handle, byte[] target, int targetOffset, int targetLen) {
+    seekForPrevByteArray0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekForPrevByteArray0Jni(
+      long handle, byte[] target, int targetOffset, int targetLen);
+  @Override
+  final void status0(long handle) throws RocksDBException {
+    status0Jni(handle);
+  }
+  private static native void status0Jni(long handle) throws RocksDBException;
 
-  private native byte[] key0(long handle);
-  private native byte[] value0(long handle);
-  private native int keyDirect0(long handle, ByteBuffer buffer, int bufferOffset, int bufferLen);
-  private native int keyByteArray0(long handle, byte[] array, int arrayOffset, int arrayLen);
-  private native int valueDirect0(long handle, ByteBuffer buffer, int bufferOffset, int bufferLen);
-  private native int valueByteArray0(long handle, byte[] array, int arrayOffset, int arrayLen);
+  private static native byte[] key0(long handle);
+  private static native byte[] value0(long handle);
+  private static native int keyDirect0(
+      long handle, ByteBuffer buffer, int bufferOffset, int bufferLen);
+  private static native int keyByteArray0(long handle, byte[] array, int arrayOffset, int arrayLen);
+  private static native int valueDirect0(
+      long handle, ByteBuffer buffer, int bufferOffset, int bufferLen);
+  private static native int valueByteArray0(
+      long handle, byte[] array, int arrayOffset, int arrayLen);
 }

--- a/java/src/main/java/org/rocksdb/RocksMemEnv.java
+++ b/java/src/main/java/org/rocksdb/RocksMemEnv.java
@@ -27,5 +27,9 @@ public class RocksMemEnv extends Env {
   }
 
   private static native long createMemEnv(final long baseEnvHandle);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/SkipListMemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/SkipListMemTableConfig.java
@@ -44,7 +44,7 @@ public class SkipListMemTableConfig extends MemTableConfig {
     return newMemTableFactoryHandle0(lookahead_);
   }
 
-  private native long newMemTableFactoryHandle0(long lookahead)
+  private static native long newMemTableFactoryHandle0(long lookahead)
       throws IllegalArgumentException;
 
   private long lookahead_;

--- a/java/src/main/java/org/rocksdb/Slice.java
+++ b/java/src/main/java/org/rocksdb/Slice.java
@@ -127,9 +127,7 @@ public class Slice extends AbstractSlice<byte[]> {
   @Override protected final native byte[] data0(long handle);
   private static native long createNewSlice0(final byte[] data, final int length);
   private static native long createNewSlice1(final byte[] data);
-  private native void clear0(long handle, boolean internalBuffer,
-      long internalBufferOffset);
-  private native void removePrefix0(long handle, int length);
-  private native void disposeInternalBuf(final long handle,
-      long internalBufferOffset);
+  private static native void clear0(long handle, boolean internalBuffer, long internalBufferOffset);
+  private static native void removePrefix0(long handle, int length);
+  private static native void disposeInternalBuf(final long handle, long internalBufferOffset);
 }

--- a/java/src/main/java/org/rocksdb/Snapshot.java
+++ b/java/src/main/java/org/rocksdb/Snapshot.java
@@ -37,5 +37,5 @@ public class Snapshot extends RocksObject {
      */
   }
 
-  private native long getSequenceNumber(long handle);
+  private static native long getSequenceNumber(long handle);
 }

--- a/java/src/main/java/org/rocksdb/SstFileManager.java
+++ b/java/src/main/java/org/rocksdb/SstFileManager.java
@@ -231,19 +231,20 @@ public final class SstFileManager extends RocksObject {
   private static native long newSstFileManager(final long handle, final long logger_handle,
       final long rateBytesPerSec, final double maxTrashDbRatio, final long bytesMaxDeleteChunk)
       throws RocksDBException;
-  private native void setMaxAllowedSpaceUsage(final long handle,
-      final long maxAllowedSpace);
-  private native void setCompactionBufferSize(final long handle,
-      final long compactionBufferSize);
-  private native boolean isMaxAllowedSpaceReached(final long handle);
-  private native boolean isMaxAllowedSpaceReachedIncludingCompactions(
-      final long handle);
-  private native long getTotalSize(final long handle);
-  private native Map<String, Long> getTrackedFiles(final long handle);
-  private native long getDeleteRateBytesPerSecond(final long handle);
-  private native void setDeleteRateBytesPerSecond(final long handle,
-        final long deleteRate);
-  private native double getMaxTrashDBRatio(final long handle);
-  private native void setMaxTrashDBRatio(final long handle, final double ratio);
-  @Override protected native void disposeInternal(final long handle);
+  private static native void setMaxAllowedSpaceUsage(final long handle, final long maxAllowedSpace);
+  private static native void setCompactionBufferSize(
+      final long handle, final long compactionBufferSize);
+  private static native boolean isMaxAllowedSpaceReached(final long handle);
+  private static native boolean isMaxAllowedSpaceReachedIncludingCompactions(final long handle);
+  private static native long getTotalSize(final long handle);
+  private static native Map<String, Long> getTrackedFiles(final long handle);
+  private static native long getDeleteRateBytesPerSecond(final long handle);
+  private static native void setDeleteRateBytesPerSecond(final long handle, final long deleteRate);
+  private static native double getMaxTrashDBRatio(final long handle);
+  private static native void setMaxTrashDBRatio(final long handle, final double ratio);
+  @Override
+  protected void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/SstFileReader.java
+++ b/java/src/main/java/org/rocksdb/SstFileReader.java
@@ -65,14 +65,17 @@ public class SstFileReader extends RocksObject {
     return getTableProperties(nativeHandle_);
   }
 
-  @Override protected final native void disposeInternal(final long handle);
-  private native long newIterator(final long handle, final long readOptionsHandle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
+  private static native long newIterator(final long handle, final long readOptionsHandle);
 
-  private native void open(final long handle, final String filePath)
-      throws RocksDBException;
+  private static native void open(final long handle, final String filePath) throws RocksDBException;
 
   private static native long newSstFileReader(final long optionsHandle);
-  private native void verifyChecksum(final long handle) throws RocksDBException;
-  private native TableProperties getTableProperties(final long handle)
+  private static native void verifyChecksum(final long handle) throws RocksDBException;
+  private static native TableProperties getTableProperties(final long handle)
       throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/SstFileReaderIterator.java
+++ b/java/src/main/java/org/rocksdb/SstFileReaderIterator.java
@@ -108,34 +108,95 @@ public class SstFileReaderIterator extends AbstractRocksIterator<SstFileReader> 
     return result;
   }
 
-  @Override protected final native void disposeInternal(final long handle);
-  @Override final native boolean isValid0(long handle);
-  @Override final native void seekToFirst0(long handle);
-  @Override final native void seekToLast0(long handle);
-  @Override final native void next0(long handle);
-  @Override final native void prev0(long handle);
-  @Override final native void refresh0(long handle) throws RocksDBException;
   @Override final native void refresh1(long handle, long snapshotHandle);
-  @Override final native void seek0(long handle, byte[] target, int targetLen);
-  @Override final native void seekForPrev0(long handle, byte[] target, int targetLen);
-  @Override final native void status0(long handle) throws RocksDBException;
   @Override
-  final native void seekDirect0(long handle, ByteBuffer target, int targetOffset, int targetLen);
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
+
   @Override
-  final native void seekForPrevDirect0(
+  final boolean isValid0(long handle) {
+    return isValid0Jni(handle);
+  }
+  private static native boolean isValid0Jni(long handle);
+  @Override
+  final void seekToFirst0(long handle) {
+    seekToFirst0Jni(handle);
+  }
+  private static native void seekToFirst0Jni(long handle);
+  @Override
+  final void seekToLast0(long handle) {
+    seekToLast0Jni(handle);
+  }
+  private static native void seekToLast0Jni(long handle);
+  @Override
+  final void next0(long handle) {
+    next0Jni(handle);
+  }
+  private static native void next0Jni(long handle);
+  @Override
+  final void prev0(long handle) {
+    prev0Jni(handle);
+  }
+  private static native void prev0Jni(long handle);
+  @Override
+  final void refresh0(long handle) throws RocksDBException {
+    refresh0Jni(handle);
+  }
+  private static native void refresh0Jni(long handle) throws RocksDBException;
+  @Override
+  final void seek0(long handle, byte[] target, int targetLen) {
+    seek0Jni(handle, target, targetLen);
+  }
+  private static native void seek0Jni(long handle, byte[] target, int targetLen);
+  @Override
+  final void seekForPrev0(long handle, byte[] target, int targetLen) {
+    seekForPrev0Jni(handle, target, targetLen);
+  }
+  private static native void seekForPrev0Jni(long handle, byte[] target, int targetLen);
+
+  @Override
+  final void status0(long handle) throws RocksDBException {
+    status0Jni(handle);
+  }
+  private static native void status0Jni(long handle) throws RocksDBException;
+  @Override
+  final void seekDirect0(long handle, ByteBuffer target, int targetOffset, int targetLen) {
+    seekDirect0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekDirect0Jni(
       long handle, ByteBuffer target, int targetOffset, int targetLen);
   @Override
-  final native void seekByteArray0(
+  final void seekForPrevDirect0(long handle, ByteBuffer target, int targetOffset, int targetLen) {
+    seekForPrevDirect0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekForPrevDirect0Jni(
+      long handle, ByteBuffer target, int targetOffset, int targetLen);
+  @Override
+  final void seekByteArray0(
+      final long handle, final byte[] target, final int targetOffset, final int targetLen) {
+    seekByteArray0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekByteArray0Jni(
       final long handle, final byte[] target, final int targetOffset, final int targetLen);
   @Override
-  final native void seekForPrevByteArray0(
+  final void seekForPrevByteArray0(
+      final long handle, final byte[] target, final int targetOffset, final int targetLen) {
+    seekForPrevByteArray0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekForPrevByteArray0Jni(
       final long handle, final byte[] target, final int targetOffset, final int targetLen);
 
-  private native byte[] key0(long handle);
-  private native byte[] value0(long handle);
+  private static native byte[] key0(long handle);
+  private static native byte[] value0(long handle);
 
-  private native int keyDirect0(long handle, ByteBuffer buffer, int bufferOffset, int bufferLen);
-  private native int keyByteArray0(long handle, byte[] buffer, int bufferOffset, int bufferLen);
-  private native int valueDirect0(long handle, ByteBuffer buffer, int bufferOffset, int bufferLen);
-  private native int valueByteArray0(long handle, byte[] buffer, int bufferOffset, int bufferLen);
+  private static native int keyDirect0(
+      long handle, ByteBuffer buffer, int bufferOffset, int bufferLen);
+  private static native int keyByteArray0(
+      long handle, byte[] buffer, int bufferOffset, int bufferLen);
+  private static native int valueDirect0(
+      long handle, ByteBuffer buffer, int bufferOffset, int bufferLen);
+  private static native int valueByteArray0(
+      long handle, byte[] buffer, int bufferOffset, int bufferLen);
 }

--- a/java/src/main/java/org/rocksdb/SstFileWriter.java
+++ b/java/src/main/java/org/rocksdb/SstFileWriter.java
@@ -203,33 +203,35 @@ public class SstFileWriter extends RocksObject {
   private static native long newSstFileWriter(
       final long envOptionsHandle, final long optionsHandle);
 
-  private native void open(final long handle, final String filePath)
+  private static native void open(final long handle, final String filePath) throws RocksDBException;
+
+  private static native void put(final long handle, final long keyHandle, final long valueHandle)
       throws RocksDBException;
 
-  private native void put(final long handle, final long keyHandle,
-      final long valueHandle) throws RocksDBException;
-      
-  private native void put(final long handle, final byte[] key,
-      final byte[] value) throws RocksDBException;
+  private static native void put(final long handle, final byte[] key, final byte[] value)
+      throws RocksDBException;
 
-  private native void putDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
+  private static native void putDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
       ByteBuffer value, int valueOffset, int valueLength) throws RocksDBException;
 
-  private native long fileSize(long handle) throws RocksDBException;
+  private static native long fileSize(long handle) throws RocksDBException;
 
-  private native void merge(final long handle, final long keyHandle,
-      final long valueHandle) throws RocksDBException;
-
-  private native void merge(final long handle, final byte[] key,
-      final byte[] value) throws RocksDBException;
-
-  private native void delete(final long handle, final long keyHandle)
+  private static native void merge(final long handle, final long keyHandle, final long valueHandle)
       throws RocksDBException;
 
-  private native void delete(final long handle, final byte[] key)
+  private static native void merge(final long handle, final byte[] key, final byte[] value)
       throws RocksDBException;
 
-  private native void finish(final long handle) throws RocksDBException;
+  private static native void delete(final long handle, final long keyHandle)
+      throws RocksDBException;
 
-  @Override protected final native void disposeInternal(final long handle);
+  private static native void delete(final long handle, final byte[] key) throws RocksDBException;
+
+  private static native void finish(final long handle) throws RocksDBException;
+
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/SstPartitionerFixedPrefixFactory.java
+++ b/java/src/main/java/org/rocksdb/SstPartitionerFixedPrefixFactory.java
@@ -15,5 +15,9 @@ public class SstPartitionerFixedPrefixFactory extends SstPartitionerFactory {
 
   private static native long newSstPartitionerFixedPrefixFactory0(long prefixLength);
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/Statistics.java
+++ b/java/src/main/java/org/rocksdb/Statistics.java
@@ -148,14 +148,18 @@ public class Statistics extends RocksObject {
   private static native long newStatistics(
       final byte[] ignoreHistograms, final long otherStatisticsHandle);
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native byte statsLevel(final long handle);
-  private native void setStatsLevel(final long handle, final byte statsLevel);
-  private native long getTickerCount(final long handle, final byte tickerType);
-  private native long getAndResetTickerCount(final long handle, final byte tickerType);
-  private native HistogramData getHistogramData(final long handle, final byte histogramType);
-  private native String getHistogramString(final long handle, final byte histogramType);
-  private native void reset(final long nativeHandle) throws RocksDBException;
-  private native String toString(final long nativeHandle);
+  private static native byte statsLevel(final long handle);
+  private static native void setStatsLevel(final long handle, final byte statsLevel);
+  private static native long getTickerCount(final long handle, final byte tickerType);
+  private static native long getAndResetTickerCount(final long handle, final byte tickerType);
+  private static native HistogramData getHistogramData(final long handle, final byte histogramType);
+  private static native String getHistogramString(final long handle, final byte histogramType);
+  private static native void reset(final long nativeHandle) throws RocksDBException;
+  private static native String toString(final long nativeHandle);
 }

--- a/java/src/main/java/org/rocksdb/StringAppendOperator.java
+++ b/java/src/main/java/org/rocksdb/StringAppendOperator.java
@@ -25,5 +25,9 @@ public class StringAppendOperator extends MergeOperator {
 
   private static native long newSharedStringAppendOperator(final char delim);
   private static native long newSharedStringAppendOperator(final String delim);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/TimedEnv.java
+++ b/java/src/main/java/org/rocksdb/TimedEnv.java
@@ -26,5 +26,9 @@ public class TimedEnv extends Env {
   }
 
   private static native long createTimedEnv(final long baseEnvHandle);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -2878,18 +2878,17 @@ public class Transaction extends RocksObject {
 
   private static native void setSnapshot(final long handle);
   private static native void setSnapshotOnNextOperation(final long handle);
-  private static native void setSnapshotOnNextOperation(final long handle,
-      final long transactionNotifierHandle);
+  private static native void setSnapshotOnNextOperation(
+      final long handle, final long transactionNotifierHandle);
   private static native long getSnapshot(final long handle);
   private static native void clearSnapshot(final long handle);
   private static native void prepare(final long handle) throws RocksDBException;
   private static native void commit(final long handle) throws RocksDBException;
   private static native void rollback(final long handle) throws RocksDBException;
   private static native void setSavePoint(final long handle) throws RocksDBException;
-  private static native void rollbackToSavePoint(final long handle)
-      throws RocksDBException;
-  private static native byte[] get(final long handle, final long readOptionsHandle, final byte[] key,
-      final int keyOffset, final int keyLength, final long columnFamilyHandle)
+  private static native void rollbackToSavePoint(final long handle) throws RocksDBException;
+  private static native byte[] get(final long handle, final long readOptionsHandle,
+      final byte[] key, final int keyOffset, final int keyLength, final long columnFamilyHandle)
       throws RocksDBException;
   private static native int get(final long handle, final long readOptionsHandle, final byte[] key,
       final int keyOffset, final int keyLen, final byte[] value, final int valueOffset,
@@ -2901,27 +2900,25 @@ public class Transaction extends RocksObject {
 
   private static native byte[][] multiGet(final long handle, final long readOptionsHandle,
       final byte[][] keys, final long[] columnFamilyHandles) throws RocksDBException;
-  private static native byte[][] multiGet(final long handle,
-      final long readOptionsHandle, final byte[][] keys)
-      throws RocksDBException;
+  private static native byte[][] multiGet(
+      final long handle, final long readOptionsHandle, final byte[][] keys) throws RocksDBException;
   private static native byte[] getForUpdate(final long handle, final long readOptionsHandle,
       final byte[] key, final int keyOffset, final int keyLength, final long columnFamilyHandle,
       final boolean exclusive, final boolean doValidate) throws RocksDBException;
-  private static native int getForUpdate(final long handle, final long readOptionsHandle, final byte[] key,
-      final int keyOffset, final int keyLength, final byte[] value, final int valueOffset,
-      final int valueLen, final long columnFamilyHandle, final boolean exclusive,
-      final boolean doValidate) throws RocksDBException;
+  private static native int getForUpdate(final long handle, final long readOptionsHandle,
+      final byte[] key, final int keyOffset, final int keyLength, final byte[] value,
+      final int valueOffset, final int valueLen, final long columnFamilyHandle,
+      final boolean exclusive, final boolean doValidate) throws RocksDBException;
   private static native int getDirectForUpdate(final long handle, final long readOptionsHandle,
       final ByteBuffer key, final int keyOffset, final int keyLength, final ByteBuffer value,
       final int valueOffset, final int valueLen, final long columnFamilyHandle,
       final boolean exclusive, final boolean doValidate) throws RocksDBException;
-  private static native byte[][] multiGetForUpdate(final long handle,
-      final long readOptionsHandle, final byte[][] keys,
-      final long[] columnFamilyHandles) throws RocksDBException;
+  private static native byte[][] multiGetForUpdate(final long handle, final long readOptionsHandle,
+      final byte[][] keys, final long[] columnFamilyHandles) throws RocksDBException;
   private static native byte[][] multiGetForUpdate(
       final long handle, final long readOptionsHandle, final byte[][] keys) throws RocksDBException;
-  private static native long getIterator(final long handle,
-      final long readOptionsHandle, final long columnFamilyHandle);
+  private static native long getIterator(
+      final long handle, final long readOptionsHandle, final long columnFamilyHandle);
   private static native void put(final long handle, final byte[] key, final int keyOffset,
       final int keyLength, final byte[] value, final int valueOffset, final int valueLength)
       throws RocksDBException;
@@ -2931,9 +2928,8 @@ public class Transaction extends RocksObject {
   private static native void put(final long handle, final byte[][] keys, final int keysLength,
       final byte[][] values, final int valuesLength, final long columnFamilyHandle,
       final boolean assumeTracked) throws RocksDBException;
-  private static native void put(final long handle, final byte[][] keys,
-      final int keysLength, final byte[][] values, final int valuesLength)
-      throws RocksDBException;
+  private static native void put(final long handle, final byte[][] keys, final int keysLength,
+      final byte[][] values, final int valuesLength) throws RocksDBException;
   private static native void putDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
       ByteBuffer value, int valueOffset, int valueLength, long cfHandle,
       final boolean assumeTracked) throws RocksDBException;
@@ -2954,26 +2950,26 @@ public class Transaction extends RocksObject {
       throws RocksDBException;
   private static native void delete(final long handle, final byte[] key, final int keyLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private static native void delete(final long handle, final byte[] key,
-      final int keyLength) throws RocksDBException;
+  private static native void delete(final long handle, final byte[] key, final int keyLength)
+      throws RocksDBException;
   private static native void delete(final long handle, final byte[][] keys, final int keysLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private static native void delete(final long handle, final byte[][] keys,
-      final int keysLength) throws RocksDBException;
+  private static native void delete(final long handle, final byte[][] keys, final int keysLength)
+      throws RocksDBException;
   private static native void singleDelete(final long handle, final byte[] key, final int keyLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private static native void singleDelete(final long handle, final byte[] key,
-      final int keyLength) throws RocksDBException;
-  private static native void singleDelete(final long handle, final byte[][] keys, final int keysLength,
-      final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private static native void singleDelete(final long handle, final byte[][] keys,
-      final int keysLength) throws RocksDBException;
-  private static native void putUntracked(final long handle, final byte[] key,
-      final int keyLength, final byte[] value, final int valueLength,
-      final long columnFamilyHandle) throws RocksDBException;
-  private static native void putUntracked(final long handle, final byte[] key,
-      final int keyLength, final byte[] value, final int valueLength)
+  private static native void singleDelete(final long handle, final byte[] key, final int keyLength)
       throws RocksDBException;
+  private static native void singleDelete(final long handle, final byte[][] keys,
+      final int keysLength, final long columnFamilyHandle, final boolean assumeTracked)
+      throws RocksDBException;
+  private static native void singleDelete(
+      final long handle, final byte[][] keys, final int keysLength) throws RocksDBException;
+  private static native void putUntracked(final long handle, final byte[] key, final int keyLength,
+      final byte[] value, final int valueLength, final long columnFamilyHandle)
+      throws RocksDBException;
+  private static native void putUntracked(final long handle, final byte[] key, final int keyLength,
+      final byte[] value, final int valueLength) throws RocksDBException;
   private static native void putUntracked(final long handle, final byte[][] keys,
       final int keysLength, final byte[][] values, final int valuesLength,
       final long columnFamilyHandle) throws RocksDBException;
@@ -2985,17 +2981,15 @@ public class Transaction extends RocksObject {
   private static native void mergeUntrackedDirect(final long handle, final ByteBuffer key,
       final int keyOff, final int keyLength, final ByteBuffer value, final int valueOff,
       final int valueLength, final long columnFamilyHandle) throws RocksDBException;
-  private static native void deleteUntracked(final long handle, final byte[] key, final int keyLength,
-      final long columnFamilyHandle) throws RocksDBException;
   private static native void deleteUntracked(final long handle, final byte[] key,
-      final int keyLength) throws RocksDBException;
+      final int keyLength, final long columnFamilyHandle) throws RocksDBException;
+  private static native void deleteUntracked(
+      final long handle, final byte[] key, final int keyLength) throws RocksDBException;
   private static native void deleteUntracked(final long handle, final byte[][] keys,
-      final int keysLength, final long columnFamilyHandle)
-      throws RocksDBException;
-  private static native void deleteUntracked(final long handle, final byte[][] keys,
-      final int keysLength) throws RocksDBException;
-  private static native void putLogData(final long handle, final byte[] blob,
-      final int blobLength);
+      final int keysLength, final long columnFamilyHandle) throws RocksDBException;
+  private static native void deleteUntracked(
+      final long handle, final byte[][] keys, final int keysLength) throws RocksDBException;
+  private static native void putLogData(final long handle, final byte[] blob, final int blobLength);
   private static native void disableIndexing(final long handle);
   private static native void enableIndexing(final long handle);
   private static native long getNumKeys(final long handle);
@@ -3006,19 +3000,17 @@ public class Transaction extends RocksObject {
   private static native long getWriteBatch(final long handle);
   private static native void setLockTimeout(final long handle, final long lockTimeout);
   private static native long getWriteOptions(final long handle);
-  private static native void setWriteOptions(final long handle,
-      final long writeOptionsHandle);
-  private static native void undoGetForUpdate(final long handle, final byte[] key,
-      final int keyLength, final long columnFamilyHandle);
-  private static native void undoGetForUpdate(final long handle, final byte[] key,
-      final int keyLength);
-  private static native void rebuildFromWriteBatch(final long handle,
-      final long writeBatchHandle) throws RocksDBException;
+  private static native void setWriteOptions(final long handle, final long writeOptionsHandle);
+  private static native void undoGetForUpdate(
+      final long handle, final byte[] key, final int keyLength, final long columnFamilyHandle);
+  private static native void undoGetForUpdate(
+      final long handle, final byte[] key, final int keyLength);
+  private static native void rebuildFromWriteBatch(final long handle, final long writeBatchHandle)
+      throws RocksDBException;
   private static native long getCommitTimeWriteBatch(final long handle);
   private static native void setLogNumber(final long handle, final long logNumber);
   private static native long getLogNumber(final long handle);
-  private static native void setName(final long handle, final String name)
-      throws RocksDBException;
+  private static native void setName(final long handle, final String name) throws RocksDBException;
   private static native String getName(final long handle);
   private static native long getID(final long handle);
   private static native boolean isDeadlockDetect(final long handle);

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -2876,156 +2876,155 @@ public class Transaction extends RocksObject {
     }
   }
 
-  private native void setSnapshot(final long handle);
-  private native void setSnapshotOnNextOperation(final long handle);
-  private native void setSnapshotOnNextOperation(final long handle,
+  private static native void setSnapshot(final long handle);
+  private static native void setSnapshotOnNextOperation(final long handle);
+  private static native void setSnapshotOnNextOperation(final long handle,
       final long transactionNotifierHandle);
-  private native long getSnapshot(final long handle);
-  private native void clearSnapshot(final long handle);
-  private native void prepare(final long handle) throws RocksDBException;
-  private native void commit(final long handle) throws RocksDBException;
-  private native void rollback(final long handle) throws RocksDBException;
-  private native void setSavePoint(final long handle) throws RocksDBException;
-  private native void rollbackToSavePoint(final long handle)
+  private static native long getSnapshot(final long handle);
+  private static native void clearSnapshot(final long handle);
+  private static native void prepare(final long handle) throws RocksDBException;
+  private static native void commit(final long handle) throws RocksDBException;
+  private static native void rollback(final long handle) throws RocksDBException;
+  private static native void setSavePoint(final long handle) throws RocksDBException;
+  private static native void rollbackToSavePoint(final long handle)
       throws RocksDBException;
-  private native byte[] get(final long handle, final long readOptionsHandle, final byte[] key,
+  private static native byte[] get(final long handle, final long readOptionsHandle, final byte[] key,
       final int keyOffset, final int keyLength, final long columnFamilyHandle)
       throws RocksDBException;
-  private native int get(final long handle, final long readOptionsHandle, final byte[] key,
+  private static native int get(final long handle, final long readOptionsHandle, final byte[] key,
       final int keyOffset, final int keyLen, final byte[] value, final int valueOffset,
       final int valueLen, final long columnFamilyHandle) throws RocksDBException;
-  private native int getDirect(final long handle, final long readOptionsHandle,
+  private static native int getDirect(final long handle, final long readOptionsHandle,
       final ByteBuffer key, final int keyOffset, final int keyLength, final ByteBuffer value,
       final int valueOffset, final int valueLength, final long columnFamilyHandle)
       throws RocksDBException;
 
-  private native byte[][] multiGet(final long handle, final long readOptionsHandle,
+  private static native byte[][] multiGet(final long handle, final long readOptionsHandle,
       final byte[][] keys, final long[] columnFamilyHandles) throws RocksDBException;
-  private native byte[][] multiGet(final long handle,
+  private static native byte[][] multiGet(final long handle,
       final long readOptionsHandle, final byte[][] keys)
       throws RocksDBException;
-  private native byte[] getForUpdate(final long handle, final long readOptionsHandle,
+  private static native byte[] getForUpdate(final long handle, final long readOptionsHandle,
       final byte[] key, final int keyOffset, final int keyLength, final long columnFamilyHandle,
       final boolean exclusive, final boolean doValidate) throws RocksDBException;
-  private native int getForUpdate(final long handle, final long readOptionsHandle, final byte[] key,
+  private static native int getForUpdate(final long handle, final long readOptionsHandle, final byte[] key,
       final int keyOffset, final int keyLength, final byte[] value, final int valueOffset,
       final int valueLen, final long columnFamilyHandle, final boolean exclusive,
       final boolean doValidate) throws RocksDBException;
-  private native int getDirectForUpdate(final long handle, final long readOptionsHandle,
+  private static native int getDirectForUpdate(final long handle, final long readOptionsHandle,
       final ByteBuffer key, final int keyOffset, final int keyLength, final ByteBuffer value,
       final int valueOffset, final int valueLen, final long columnFamilyHandle,
       final boolean exclusive, final boolean doValidate) throws RocksDBException;
-  private native byte[][] multiGetForUpdate(final long handle,
+  private static native byte[][] multiGetForUpdate(final long handle,
       final long readOptionsHandle, final byte[][] keys,
       final long[] columnFamilyHandles) throws RocksDBException;
-  private native byte[][] multiGetForUpdate(
+  private static native byte[][] multiGetForUpdate(
       final long handle, final long readOptionsHandle, final byte[][] keys) throws RocksDBException;
-  private native long getIterator(final long handle,
+  private static native long getIterator(final long handle,
       final long readOptionsHandle, final long columnFamilyHandle);
-  private native void put(final long handle, final byte[] key, final int keyOffset,
+  private static native void put(final long handle, final byte[] key, final int keyOffset,
       final int keyLength, final byte[] value, final int valueOffset, final int valueLength)
       throws RocksDBException;
-  private native void put(final long handle, final byte[] key, final int keyOffset,
+  private static native void put(final long handle, final byte[] key, final int keyOffset,
       final int keyLength, final byte[] value, final int valueOffset, final int valueLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private native void put(final long handle, final byte[][] keys, final int keysLength,
+  private static native void put(final long handle, final byte[][] keys, final int keysLength,
       final byte[][] values, final int valuesLength, final long columnFamilyHandle,
       final boolean assumeTracked) throws RocksDBException;
-  private native void put(final long handle, final byte[][] keys,
+  private static native void put(final long handle, final byte[][] keys,
       final int keysLength, final byte[][] values, final int valuesLength)
       throws RocksDBException;
-  private native void putDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
+  private static native void putDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
       ByteBuffer value, int valueOffset, int valueLength, long cfHandle,
       final boolean assumeTracked) throws RocksDBException;
-  private native void putDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
+  private static native void putDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
       ByteBuffer value, int valueOffset, int valueLength) throws RocksDBException;
 
-  private native void merge(final long handle, final byte[] key, final int keyOffset,
+  private static native void merge(final long handle, final byte[] key, final int keyOffset,
       final int keyLength, final byte[] value, final int valueOffset, final int valueLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private native void mergeDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
+  private static native void mergeDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
       ByteBuffer value, int valueOffset, int valueLength, long cfHandle, boolean assumeTracked)
       throws RocksDBException;
-  private native void mergeDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
+  private static native void mergeDirect(long handle, ByteBuffer key, int keyOffset, int keyLength,
       ByteBuffer value, int valueOffset, int valueLength) throws RocksDBException;
 
-  private native void merge(final long handle, final byte[] key, final int keyOffset,
+  private static native void merge(final long handle, final byte[] key, final int keyOffset,
       final int keyLength, final byte[] value, final int valueOffset, final int valueLength)
       throws RocksDBException;
-  private native void delete(final long handle, final byte[] key, final int keyLength,
+  private static native void delete(final long handle, final byte[] key, final int keyLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private native void delete(final long handle, final byte[] key,
+  private static native void delete(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
-  private native void delete(final long handle, final byte[][] keys, final int keysLength,
+  private static native void delete(final long handle, final byte[][] keys, final int keysLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private native void delete(final long handle, final byte[][] keys,
+  private static native void delete(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;
-  private native void singleDelete(final long handle, final byte[] key, final int keyLength,
+  private static native void singleDelete(final long handle, final byte[] key, final int keyLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private native void singleDelete(final long handle, final byte[] key,
+  private static native void singleDelete(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
-  private native void singleDelete(final long handle, final byte[][] keys, final int keysLength,
+  private static native void singleDelete(final long handle, final byte[][] keys, final int keysLength,
       final long columnFamilyHandle, final boolean assumeTracked) throws RocksDBException;
-  private native void singleDelete(final long handle, final byte[][] keys,
+  private static native void singleDelete(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;
-  private native void putUntracked(final long handle, final byte[] key,
+  private static native void putUntracked(final long handle, final byte[] key,
       final int keyLength, final byte[] value, final int valueLength,
       final long columnFamilyHandle) throws RocksDBException;
-  private native void putUntracked(final long handle, final byte[] key,
+  private static native void putUntracked(final long handle, final byte[] key,
       final int keyLength, final byte[] value, final int valueLength)
       throws RocksDBException;
-  private native void putUntracked(final long handle, final byte[][] keys,
+  private static native void putUntracked(final long handle, final byte[][] keys,
       final int keysLength, final byte[][] values, final int valuesLength,
       final long columnFamilyHandle) throws RocksDBException;
-  private native void putUntracked(final long handle, final byte[][] keys,
-      final int keysLength, final byte[][] values, final int valuesLength)
-      throws RocksDBException;
-  private native void mergeUntracked(final long handle, final byte[] key, final int keyOff,
+  private static native void putUntracked(final long handle, final byte[][] keys,
+      final int keysLength, final byte[][] values, final int valuesLength) throws RocksDBException;
+  private static native void mergeUntracked(final long handle, final byte[] key, final int keyOff,
       final int keyLength, final byte[] value, final int valueOff, final int valueLength,
       final long columnFamilyHandle) throws RocksDBException;
-  private native void mergeUntrackedDirect(final long handle, final ByteBuffer key,
+  private static native void mergeUntrackedDirect(final long handle, final ByteBuffer key,
       final int keyOff, final int keyLength, final ByteBuffer value, final int valueOff,
       final int valueLength, final long columnFamilyHandle) throws RocksDBException;
-  private native void deleteUntracked(final long handle, final byte[] key, final int keyLength,
+  private static native void deleteUntracked(final long handle, final byte[] key, final int keyLength,
       final long columnFamilyHandle) throws RocksDBException;
-  private native void deleteUntracked(final long handle, final byte[] key,
+  private static native void deleteUntracked(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
-  private native void deleteUntracked(final long handle, final byte[][] keys,
+  private static native void deleteUntracked(final long handle, final byte[][] keys,
       final int keysLength, final long columnFamilyHandle)
       throws RocksDBException;
-  private native void deleteUntracked(final long handle, final byte[][] keys,
+  private static native void deleteUntracked(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;
-  private native void putLogData(final long handle, final byte[] blob,
+  private static native void putLogData(final long handle, final byte[] blob,
       final int blobLength);
-  private native void disableIndexing(final long handle);
-  private native void enableIndexing(final long handle);
-  private native long getNumKeys(final long handle);
-  private native long getNumPuts(final long handle);
-  private native long getNumDeletes(final long handle);
-  private native long getNumMerges(final long handle);
-  private native long getElapsedTime(final long handle);
-  private native long getWriteBatch(final long handle);
-  private native void setLockTimeout(final long handle, final long lockTimeout);
-  private native long getWriteOptions(final long handle);
-  private native void setWriteOptions(final long handle,
+  private static native void disableIndexing(final long handle);
+  private static native void enableIndexing(final long handle);
+  private static native long getNumKeys(final long handle);
+  private static native long getNumPuts(final long handle);
+  private static native long getNumDeletes(final long handle);
+  private static native long getNumMerges(final long handle);
+  private static native long getElapsedTime(final long handle);
+  private static native long getWriteBatch(final long handle);
+  private static native void setLockTimeout(final long handle, final long lockTimeout);
+  private static native long getWriteOptions(final long handle);
+  private static native void setWriteOptions(final long handle,
       final long writeOptionsHandle);
-  private native void undoGetForUpdate(final long handle, final byte[] key,
+  private static native void undoGetForUpdate(final long handle, final byte[] key,
       final int keyLength, final long columnFamilyHandle);
-  private native void undoGetForUpdate(final long handle, final byte[] key,
+  private static native void undoGetForUpdate(final long handle, final byte[] key,
       final int keyLength);
-  private native void rebuildFromWriteBatch(final long handle,
+  private static native void rebuildFromWriteBatch(final long handle,
       final long writeBatchHandle) throws RocksDBException;
-  private native long getCommitTimeWriteBatch(final long handle);
-  private native void setLogNumber(final long handle, final long logNumber);
-  private native long getLogNumber(final long handle);
-  private native void setName(final long handle, final String name)
+  private static native long getCommitTimeWriteBatch(final long handle);
+  private static native void setLogNumber(final long handle, final long logNumber);
+  private static native long getLogNumber(final long handle);
+  private static native void setName(final long handle, final String name)
       throws RocksDBException;
-  private native String getName(final long handle);
-  private native long getID(final long handle);
-  private native boolean isDeadlockDetect(final long handle);
+  private static native String getName(final long handle);
+  private static native long getID(final long handle);
+  private static native boolean isDeadlockDetect(final long handle);
   private native WaitingTransactions getWaitingTxns(final long handle);
-  private native byte getState(final long handle);
-  private native long getId(final long handle);
+  private static native byte getState(final long handle);
+  private static native long getId(final long handle);
 
   @Override protected final native void disposeInternal(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/TransactionDB.java
+++ b/java/src/main/java/org/rocksdb/TransactionDB.java
@@ -379,7 +379,11 @@ public class TransactionDB extends RocksDB
     this.transactionDbOptions_ = transactionDbOptions;
   }
 
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   private static native long open(final long optionsHandle,
       final long transactionDbOptionsHandle, final String path)
@@ -388,21 +392,17 @@ public class TransactionDB extends RocksDB
       final long transactionDbOptionsHandle, final String path,
       final byte[][] columnFamilyNames, final long[] columnFamilyOptions);
   private static native void closeDatabase(final long handle) throws RocksDBException;
-  private native long beginTransaction(final long handle,
-      final long writeOptionsHandle);
-  private native long beginTransaction(final long handle,
-      final long writeOptionsHandle, final long transactionOptionsHandle);
-  private native long beginTransaction_withOld(final long handle,
-      final long writeOptionsHandle, final long oldTransactionHandle);
-  private native long beginTransaction_withOld(final long handle,
+  private static native long beginTransaction(final long handle, final long writeOptionsHandle);
+  private static native long beginTransaction(
+      final long handle, final long writeOptionsHandle, final long transactionOptionsHandle);
+  private static native long beginTransaction_withOld(
+      final long handle, final long writeOptionsHandle, final long oldTransactionHandle);
+  private static native long beginTransaction_withOld(final long handle,
       final long writeOptionsHandle, final long transactionOptionsHandle,
       final long oldTransactionHandle);
-  private native long getTransactionByName(final long handle,
-      final String name);
-  private native long[] getAllPreparedTransactions(final long handle);
-  private native Map<Long, KeyLockInfo> getLockStatusData(
-      final long handle);
-  private native DeadlockPath[] getDeadlockInfoBuffer(final long handle);
-  private native void setDeadlockInfoBufferSize(final long handle,
-      final int targetSize);
+  private static native long getTransactionByName(final long handle, final String name);
+  private static native long[] getAllPreparedTransactions(final long handle);
+  private static native Map<Long, KeyLockInfo> getLockStatusData(final long handle);
+  private static native DeadlockPath[] getDeadlockInfoBuffer(final long handle);
+  private static native void setDeadlockInfoBufferSize(final long handle, final int targetSize);
 }

--- a/java/src/main/java/org/rocksdb/TransactionDBOptions.java
+++ b/java/src/main/java/org/rocksdb/TransactionDBOptions.java
@@ -199,18 +199,21 @@ public class TransactionDBOptions extends RocksObject {
   }
 
   private static native long newTransactionDBOptions();
-  private native long getMaxNumLocks(final long handle);
-  private native void setMaxNumLocks(final long handle,
-      final long maxNumLocks);
-  private native long getNumStripes(final long handle);
-  private native void setNumStripes(final long handle, final long numStripes);
-  private native long getTransactionLockTimeout(final long handle);
-  private native void setTransactionLockTimeout(final long handle,
-      final long transactionLockTimeout);
-  private native long getDefaultLockTimeout(final long handle);
-  private native void setDefaultLockTimeout(final long handle,
-      final long transactionLockTimeout);
-  private native byte getWritePolicy(final long handle);
-  private native void setWritePolicy(final long handle, final byte writePolicy);
-  @Override protected final native void disposeInternal(final long handle);
+  private static native long getMaxNumLocks(final long handle);
+  private static native void setMaxNumLocks(final long handle, final long maxNumLocks);
+  private static native long getNumStripes(final long handle);
+  private static native void setNumStripes(final long handle, final long numStripes);
+  private static native long getTransactionLockTimeout(final long handle);
+  private static native void setTransactionLockTimeout(
+      final long handle, final long transactionLockTimeout);
+  private static native long getDefaultLockTimeout(final long handle);
+  private static native void setDefaultLockTimeout(
+      final long handle, final long transactionLockTimeout);
+  private static native byte getWritePolicy(final long handle);
+  private static native void setWritePolicy(final long handle, final byte writePolicy);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/TransactionLogIterator.java
+++ b/java/src/main/java/org/rocksdb/TransactionLogIterator.java
@@ -103,10 +103,13 @@ public class TransactionLogIterator extends RocksObject {
     private final WriteBatch writeBatch_;
   }
 
-  @Override protected final native void disposeInternal(final long handle);
-  private native boolean isValid(long handle);
-  private native void next(long handle);
-  private native void status(long handle)
-      throws RocksDBException;
-  private native BatchResult getBatch(long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
+  private static native boolean isValid(long handle);
+  private static native void next(long handle);
+  private static native void status(long handle) throws RocksDBException;
+  private static native BatchResult getBatch(long handle);
 }

--- a/java/src/main/java/org/rocksdb/TransactionOptions.java
+++ b/java/src/main/java/org/rocksdb/TransactionOptions.java
@@ -169,21 +169,22 @@ public class TransactionOptions extends RocksObject
   }
 
   private static native long newTransactionOptions();
-  private native boolean isSetSnapshot(final long handle);
-  private native void setSetSnapshot(final long handle,
-      final boolean setSnapshot);
-  private native boolean isDeadlockDetect(final long handle);
-  private native void setDeadlockDetect(final long handle,
-      final boolean deadlockDetect);
-  private native long getLockTimeout(final long handle);
-  private native void setLockTimeout(final long handle, final long lockTimeout);
-  private native long getExpiration(final long handle);
-  private native void setExpiration(final long handle, final long expiration);
-  private native long getDeadlockDetectDepth(final long handle);
-  private native void setDeadlockDetectDepth(final long handle,
-      final long deadlockDetectDepth);
-  private native long getMaxWriteBatchSize(final long handle);
-  private native void setMaxWriteBatchSize(final long handle,
-      final long maxWriteBatchSize);
-  @Override protected final native void disposeInternal(final long handle);
+  private static native boolean isSetSnapshot(final long handle);
+  private static native void setSetSnapshot(final long handle, final boolean setSnapshot);
+  private static native boolean isDeadlockDetect(final long handle);
+  private static native void setDeadlockDetect(final long handle, final boolean deadlockDetect);
+  private static native long getLockTimeout(final long handle);
+  private static native void setLockTimeout(final long handle, final long lockTimeout);
+  private static native long getExpiration(final long handle);
+  private static native void setExpiration(final long handle, final long expiration);
+  private static native long getDeadlockDetectDepth(final long handle);
+  private static native void setDeadlockDetectDepth(
+      final long handle, final long deadlockDetectDepth);
+  private static native long getMaxWriteBatchSize(final long handle);
+  private static native void setMaxWriteBatchSize(final long handle, final long maxWriteBatchSize);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/TtlDB.java
+++ b/java/src/main/java/org/rocksdb/TtlDB.java
@@ -230,15 +230,19 @@ public class TtlDB extends RocksDB {
     super(nativeHandle);
   }
 
-  @Override protected native void disposeInternal(final long handle);
+  @Override
+  protected void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
   private static native long open(final long optionsHandle, final String db_path, final int ttl,
       final boolean readOnly) throws RocksDBException;
   private static native long[] openCF(final long optionsHandle, final String db_path,
       final byte[][] columnFamilyNames, final long[] columnFamilyOptions, final int[] ttlValues,
       final boolean readOnly) throws RocksDBException;
-  private native long createColumnFamilyWithTtl(final long handle,
-      final byte[] columnFamilyName, final long columnFamilyOptions, int ttl)
+  private static native long createColumnFamilyWithTtl(
+      final long handle, final byte[] columnFamilyName, final long columnFamilyOptions, int ttl)
       throws RocksDBException;
   private static native void closeDatabase(final long handle) throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/UInt64AddOperator.java
+++ b/java/src/main/java/org/rocksdb/UInt64AddOperator.java
@@ -17,7 +17,7 @@ public class UInt64AddOperator extends MergeOperator {
     private static native long newSharedUInt64AddOperator();
     @Override
     protected final void disposeInternal(final long handle) {
-        disposeInternalJni(handle);
+      disposeInternalJni(handle);
     }
     private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/UInt64AddOperator.java
+++ b/java/src/main/java/org/rocksdb/UInt64AddOperator.java
@@ -15,5 +15,9 @@ public class UInt64AddOperator extends MergeOperator {
     }
 
     private static native long newSharedUInt64AddOperator();
-    @Override protected final native void disposeInternal(final long handle);
+    @Override
+    protected final void disposeInternal(final long handle) {
+        disposeInternalJni(handle);
+    }
+    private static native void disposeInternalJni(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/VectorMemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/VectorMemTableConfig.java
@@ -40,7 +40,7 @@ public class VectorMemTableConfig extends MemTableConfig {
     return newMemTableFactoryHandle(reservedSize_);
   }
 
-  private native long newMemTableFactoryHandle(long reservedSize)
+  private static native long newMemTableFactoryHandle(long reservedSize)
       throws IllegalArgumentException;
   private int reservedSize_;
 }

--- a/java/src/main/java/org/rocksdb/WBWIRocksIterator.java
+++ b/java/src/main/java/org/rocksdb/WBWIRocksIterator.java
@@ -40,31 +40,87 @@ public class WBWIRocksIterator
     return entry;
   }
 
-  @Override protected final native void disposeInternal(final long handle);
-  @Override final native boolean isValid0(long handle);
-  @Override final native void seekToFirst0(long handle);
-  @Override final native void seekToLast0(long handle);
-  @Override final native void next0(long handle);
-  @Override final native void prev0(long handle);
-  @Override final native void refresh0(final long handle) throws RocksDBException;
   @Override final native void refresh1(long handle, long snapshotHandle);
-  @Override final native void seek0(long handle, byte[] target, int targetLen);
-  @Override final native void seekForPrev0(long handle, byte[] target, int targetLen);
-  @Override final native void status0(long handle) throws RocksDBException;
   @Override
-  final native void seekDirect0(
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
+  @Override
+  final boolean isValid0(long handle) {
+    return isValid0Jni(handle);
+  }
+  private static native boolean isValid0Jni(long handle);
+  @Override
+  final void seekToFirst0(long handle) {
+    seekToFirst0Jni(handle);
+  }
+  private static native void seekToFirst0Jni(long handle);
+  @Override
+  final void seekToLast0(long handle) {
+    seekToLast0Jni(handle);
+  }
+  private static native void seekToLast0Jni(long handle);
+  @Override
+  final void next0(long handle) {
+    next0Jni(handle);
+  }
+  private static native void next0Jni(long handle);
+  @Override
+  final void prev0(long handle) {
+    prev0Jni(handle);
+  }
+  private static native void prev0Jni(long handle);
+  @Override
+  final void refresh0(final long handle) throws RocksDBException {
+    refresh0Jni(handle);
+  }
+  private static native void refresh0Jni(final long handle) throws RocksDBException;
+  @Override
+  final void seek0(long handle, byte[] target, int targetLen) {
+    seek0Jni(handle, target, targetLen);
+  }
+  private static native void seek0Jni(long handle, byte[] target, int targetLen);
+  @Override
+  final void seekForPrev0(long handle, byte[] target, int targetLen) {
+    seekForPrev0Jni(handle, target, targetLen);
+  }
+  private static native void seekForPrev0Jni(long handle, byte[] target, int targetLen);
+  @Override
+  final void status0(long handle) throws RocksDBException {
+    status0Jni(handle);
+  }
+  private static native void status0Jni(long handle) throws RocksDBException;
+  @Override
+  final void seekDirect0(
+      final long handle, final ByteBuffer target, final int targetOffset, final int targetLen) {
+    seekDirect0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekDirect0Jni(
       final long handle, final ByteBuffer target, final int targetOffset, final int targetLen);
   @Override
-  final native void seekForPrevDirect0(
+  final void seekForPrevDirect0(
+      final long handle, final ByteBuffer target, final int targetOffset, final int targetLen) {
+    seekForPrevDirect0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekForPrevDirect0Jni(
       final long handle, final ByteBuffer target, final int targetOffset, final int targetLen);
   @Override
-  final native void seekByteArray0(
+  final void seekByteArray0(
+      final long handle, final byte[] target, final int targetOffset, final int targetLen) {
+    seekByteArray0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekByteArray0Jni(
       final long handle, final byte[] target, final int targetOffset, final int targetLen);
   @Override
-  final native void seekForPrevByteArray0(
+  final void seekForPrevByteArray0(
+      final long handle, final byte[] target, final int targetOffset, final int targetLen) {
+    seekForPrevByteArray0Jni(handle, target, targetOffset, targetLen);
+  }
+  private static native void seekForPrevByteArray0Jni(
       final long handle, final byte[] target, final int targetOffset, final int targetLen);
 
-  private native long[] entry1(final long handle);
+  private static native long[] entry1(final long handle);
 
   /**
    * Enumeration of the Write operation

--- a/java/src/main/java/org/rocksdb/WriteBatch.java
+++ b/java/src/main/java/org/rocksdb/WriteBatch.java
@@ -218,65 +218,175 @@ public class WriteBatch extends AbstractWriteBatch {
       disOwnNativeHandle();
   }
 
-  @Override protected final native void disposeInternal(final long handle);
-  @Override final native int count0(final long handle);
-  @Override final native void put(final long handle, final byte[] key,
-      final int keyLen, final byte[] value, final int valueLen);
-  @Override final native void put(final long handle, final byte[] key,
-      final int keyLen, final byte[] value, final int valueLen,
-      final long cfHandle);
   @Override
-  final native void putDirect(final long handle, final ByteBuffer key, final int keyOffset,
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
+
+  @Override
+  final int count0(final long handle) {
+    return count0Jni(handle);
+  }
+
+  private static native int count0Jni(final long handle);
+
+  @Override
+  final void put(final long handle, final byte[] key, final int keyLen, final byte[] value,
+      final int valueLen) {
+    putJni(handle, key, keyLen, value, valueLen);
+  }
+  private static native void putJni(final long handle, final byte[] key, final int keyLen,
+      final byte[] value, final int valueLen);
+
+  @Override
+  final void put(final long handle, final byte[] key, final int keyLen, final byte[] value,
+      final int valueLen, final long cfHandle) {
+    putJni(handle, key, keyLen, value, valueLen, cfHandle);
+  }
+
+  private static native void putJni(final long handle, final byte[] key, final int keyLen,
+      final byte[] value, final int valueLen, final long cfHandle);
+
+  @Override
+  final void putDirect(final long handle, final ByteBuffer key, final int keyOffset,
       final int keyLength, final ByteBuffer value, final int valueOffset, final int valueLength,
-      final long cfHandle);
-  @Override final native void merge(final long handle, final byte[] key,
-      final int keyLen, final byte[] value, final int valueLen);
-  @Override final native void merge(final long handle, final byte[] key,
-      final int keyLen, final byte[] value, final int valueLen,
-      final long cfHandle);
-  @Override final native void delete(final long handle, final byte[] key,
-      final int keyLen) throws RocksDBException;
-  @Override final native void delete(final long handle, final byte[] key,
-      final int keyLen, final long cfHandle) throws RocksDBException;
-  @Override final native void singleDelete(final long handle, final byte[] key,
-      final int keyLen) throws RocksDBException;
-  @Override final native void singleDelete(final long handle, final byte[] key,
-      final int keyLen, final long cfHandle) throws RocksDBException;
+      final long cfHandle) {
+    putDirectJni(handle, key, keyOffset, keyLength, value, valueOffset, valueLength, cfHandle);
+  }
+
+  private static native void putDirectJni(final long handle, final ByteBuffer key,
+      final int keyOffset, final int keyLength, final ByteBuffer value, final int valueOffset,
+      final int valueLength, final long cfHandle);
+
   @Override
-  final native void deleteDirect(final long handle, final ByteBuffer key, final int keyOffset,
-      final int keyLength, final long cfHandle) throws RocksDBException;
+  final void merge(final long handle, final byte[] key, final int keyLen, final byte[] value,
+      final int valueLen) {
+    mergeJni(handle, key, keyLen, value, valueLen);
+  }
+
+  private static native void mergeJni(final long handle, final byte[] key, final int keyLen,
+      final byte[] value, final int valueLen);
+
   @Override
-  final native void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
-      final byte[] endKey, final int endKeyLen);
+  final void merge(final long handle, final byte[] key, final int keyLen, final byte[] value,
+      final int valueLen, final long cfHandle) {
+    mergeJni(handle, key, keyLen, value, valueLen, cfHandle);
+  }
+  private static native void mergeJni(final long handle, final byte[] key, final int keyLen,
+      final byte[] value, final int valueLen, final long cfHandle);
+
   @Override
-  final native void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
-      final byte[] endKey, final int endKeyLen, final long cfHandle);
-  @Override final native void putLogData(final long handle,
-      final byte[] blob, final int blobLen) throws RocksDBException;
-  @Override final native void clear0(final long handle);
-  @Override final native void setSavePoint0(final long handle);
-  @Override final native void rollbackToSavePoint0(final long handle);
-  @Override final native void popSavePoint(final long handle) throws RocksDBException;
-  @Override final native void setMaxBytes(final long nativeHandle,
-    final long maxBytes);
+  final void delete(final long handle, final byte[] key, final int keyLen) throws RocksDBException {
+    deleteJni(handle, key, keyLen);
+  }
+
+  private static native void deleteJni(final long handle, final byte[] key, final int keyLen)
+      throws RocksDBException;
+
+  @Override
+  final void delete(final long handle, final byte[] key, final int keyLen, final long cfHandle)
+      throws RocksDBException {
+    deleteJni(handle, key, keyLen, cfHandle);
+  }
+  private static native void deleteJni(final long handle, final byte[] key, final int keyLen,
+      final long cfHandle) throws RocksDBException;
+  @Override
+  final void singleDelete(final long handle, final byte[] key, final int keyLen)
+      throws RocksDBException {
+    singleDeleteJni(handle, key, keyLen);
+  }
+
+  private static native void singleDeleteJni(final long handle, final byte[] key, final int keyLen)
+      throws RocksDBException;
+
+  @Override
+  final void singleDelete(final long handle, final byte[] key, final int keyLen,
+      final long cfHandle) throws RocksDBException {
+    singleDeleteJni(handle, key, keyLen, cfHandle);
+  }
+  private static native void singleDeleteJni(final long handle, final byte[] key, final int keyLen,
+      final long cfHandle) throws RocksDBException;
+
+  @Override
+  final void deleteDirect(final long handle, final ByteBuffer key, final int keyOffset,
+      final int keyLength, final long cfHandle) throws RocksDBException {
+    deleteDirectJni(handle, key, keyOffset, keyLength, cfHandle);
+  }
+
+  private static native void deleteDirectJni(final long handle, final ByteBuffer key,
+      final int keyOffset, final int keyLength, final long cfHandle) throws RocksDBException;
+
+  @Override
+  final void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
+      final byte[] endKey, final int endKeyLen) {
+    deleteRangeJni(handle, beginKey, beginKeyLen, endKey, endKeyLen);
+  }
+  private static native void deleteRangeJni(final long handle, final byte[] beginKey,
+      final int beginKeyLen, final byte[] endKey, final int endKeyLen);
+  @Override
+  final void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
+      final byte[] endKey, final int endKeyLen, final long cfHandle) {
+    deleteRangeJni(handle, beginKey, beginKeyLen, endKey, endKeyLen, cfHandle);
+  }
+  private static native void deleteRangeJni(final long handle, final byte[] beginKey,
+      final int beginKeyLen, final byte[] endKey, final int endKeyLen, final long cfHandle);
+
+  @Override
+  final void putLogData(final long handle, final byte[] blob, final int blobLen)
+      throws RocksDBException {
+    putLogDataJni(handle, blob, blobLen);
+  }
+
+  private static native void putLogDataJni(final long handle, final byte[] blob, final int blobLen)
+      throws RocksDBException;
+
+  @Override
+  final void clear0(final long handle) {
+    clear0Jni(handle);
+  }
+
+  private static native void clear0Jni(final long handle);
+
+  @Override
+  final void setSavePoint0(final long handle) {
+    setSavePoint0Jni(handle);
+  }
+  private static native void setSavePoint0Jni(final long handle);
+  @Override
+  final void rollbackToSavePoint0(final long handle) {
+    rollbackToSavePoint0Jni(handle);
+  }
+  private static native void rollbackToSavePoint0Jni(final long handle);
+  @Override
+  final void popSavePoint(final long handle) throws RocksDBException {
+    popSavePointJni(handle);
+  }
+  private static native void popSavePointJni(final long handle) throws RocksDBException;
+  @Override
+  final void setMaxBytes(final long nativeHandle, final long maxBytes) {
+    setMaxBytesJni(nativeHandle, maxBytes);
+  }
+
+  private static native void setMaxBytesJni(final long nativeHandle, final long maxBytes);
 
   private static native long newWriteBatch(final int reserved_bytes);
   private static native long newWriteBatch(final byte[] serialized, final int serializedLength);
-  private native void iterate(final long handle, final long handlerHandle)
+  private static native void iterate(final long handle, final long handlerHandle)
       throws RocksDBException;
-  private native byte[] data(final long nativeHandle) throws RocksDBException;
-  private native long getDataSize(final long nativeHandle);
-  private native boolean hasPut(final long nativeHandle);
-  private native boolean hasDelete(final long nativeHandle);
-  private native boolean hasSingleDelete(final long nativeHandle);
-  private native boolean hasDeleteRange(final long nativeHandle);
-  private native boolean hasMerge(final long nativeHandle);
-  private native boolean hasBeginPrepare(final long nativeHandle);
-  private native boolean hasEndPrepare(final long nativeHandle);
-  private native boolean hasCommit(final long nativeHandle);
-  private native boolean hasRollback(final long nativeHandle);
-  private native void markWalTerminationPoint(final long nativeHandle);
-  private native SavePoint getWalTerminationPoint(final long nativeHandle);
+  private static native byte[] data(final long nativeHandle) throws RocksDBException;
+  private static native long getDataSize(final long nativeHandle);
+  private static native boolean hasPut(final long nativeHandle);
+  private static native boolean hasDelete(final long nativeHandle);
+  private static native boolean hasSingleDelete(final long nativeHandle);
+  private static native boolean hasDeleteRange(final long nativeHandle);
+  private static native boolean hasMerge(final long nativeHandle);
+  private static native boolean hasBeginPrepare(final long nativeHandle);
+  private static native boolean hasEndPrepare(final long nativeHandle);
+  private static native boolean hasCommit(final long nativeHandle);
+  private static native boolean hasRollback(final long nativeHandle);
+  private static native void markWalTerminationPoint(final long nativeHandle);
+  private static native SavePoint getWalTerminationPoint(final long nativeHandle);
 
   /**
    * Handler callback for iterating over the contents of a batch.

--- a/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
@@ -292,67 +292,188 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
         options.nativeHandle_, key, key.length);
   }
 
-  @Override protected final native void disposeInternal(final long handle);
-  @Override final native int count0(final long handle);
-  @Override final native void put(final long handle, final byte[] key,
-      final int keyLen, final byte[] value, final int valueLen);
-  @Override final native void put(final long handle, final byte[] key,
-      final int keyLen, final byte[] value, final int valueLen,
-      final long cfHandle);
   @Override
-  final native void putDirect(final long handle, final ByteBuffer key, final int keyOffset,
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
+  @Override
+  final int count0(final long handle) {
+    return count0Jni(handle);
+  }
+  private static native int count0Jni(final long handle);
+
+  @Override
+  final void put(final long handle, final byte[] key, final int keyLen, final byte[] value,
+      final int valueLen) {
+    putJni(handle, key, keyLen, value, valueLen);
+  }
+
+  private static native void putJni(final long handle, final byte[] key, final int keyLen,
+      final byte[] value, final int valueLen);
+
+  @Override
+  final void put(final long handle, final byte[] key, final int keyLen, final byte[] value,
+      final int valueLen, final long cfHandle) {
+    putJni(handle, key, keyLen, value, valueLen, cfHandle);
+  }
+
+  private static native void putJni(final long handle, final byte[] key, final int keyLen,
+      final byte[] value, final int valueLen, final long cfHandle);
+
+  @Override
+  final void putDirect(final long handle, final ByteBuffer key, final int keyOffset,
       final int keyLength, final ByteBuffer value, final int valueOffset, final int valueLength,
-      final long cfHandle);
-  @Override final native void merge(final long handle, final byte[] key,
-      final int keyLen, final byte[] value, final int valueLen);
-  @Override final native void merge(final long handle, final byte[] key,
-      final int keyLen, final byte[] value, final int valueLen,
-      final long cfHandle);
-  @Override final native void delete(final long handle, final byte[] key,
-      final int keyLen) throws RocksDBException;
-  @Override final native void delete(final long handle, final byte[] key,
-      final int keyLen, final long cfHandle) throws RocksDBException;
-  @Override final native void singleDelete(final long handle, final byte[] key,
-      final int keyLen) throws RocksDBException;
-  @Override final native void singleDelete(final long handle, final byte[] key,
-      final int keyLen, final long cfHandle) throws RocksDBException;
+      final long cfHandle) {
+    putDirectJni(handle, key, keyOffset, keyLength, value, valueOffset, valueLength, cfHandle);
+  }
+
+  private static native void putDirectJni(final long handle, final ByteBuffer key,
+      final int keyOffset, final int keyLength, final ByteBuffer value, final int valueOffset,
+      final int valueLength, final long cfHandle);
+
   @Override
-  final native void deleteDirect(final long handle, final ByteBuffer key, final int keyOffset,
-      final int keyLength, final long cfHandle) throws RocksDBException;
+  final void merge(final long handle, final byte[] key, final int keyLen, final byte[] value,
+      final int valueLen) {
+    mergeJni(handle, key, keyLen, value, valueLen);
+  }
+
+  private static native void mergeJni(final long handle, final byte[] key, final int keyLen,
+      final byte[] value, final int valueLen);
+
+  @Override
+  final void merge(final long handle, final byte[] key, final int keyLen, final byte[] value,
+      final int valueLen, final long cfHandle) {
+    mergeJni(handle, key, keyLen, value, valueLen, cfHandle);
+  }
+
+  private static native void mergeJni(final long handle, final byte[] key, final int keyLen,
+      final byte[] value, final int valueLen, final long cfHandle);
+  @Override
+  final void delete(final long handle, final byte[] key, final int keyLen) throws RocksDBException {
+    deleteJni(handle, key, keyLen);
+  }
+  private static native void deleteJni(final long handle, final byte[] key, final int keyLen)
+      throws RocksDBException;
+
+  @Override
+  final void delete(final long handle, final byte[] key, final int keyLen, final long cfHandle)
+      throws RocksDBException {
+    deleteJni(handle, key, keyLen, cfHandle);
+  }
+
+  private static native void deleteJni(final long handle, final byte[] key, final int keyLen,
+      final long cfHandle) throws RocksDBException;
+
+  @Override
+  final void singleDelete(final long handle, final byte[] key, final int keyLen)
+      throws RocksDBException {
+    singleDeleteJni(handle, key, keyLen);
+  }
+
+  private static native void singleDeleteJni(final long handle, final byte[] key, final int keyLen)
+      throws RocksDBException;
+
+  @Override
+  final void singleDelete(final long handle, final byte[] key, final int keyLen,
+      final long cfHandle) throws RocksDBException {
+    singleDeleteJni(handle, key, keyLen, cfHandle);
+  }
+
+  private static native void singleDeleteJni(final long handle, final byte[] key, final int keyLen,
+      final long cfHandle) throws RocksDBException;
+
+  @Override
+  final void deleteDirect(final long handle, final ByteBuffer key, final int keyOffset,
+      final int keyLength, final long cfHandle) throws RocksDBException {
+    deleteDirectJni(handle, key, keyOffset, keyLength, cfHandle);
+  }
+
+  private static native void deleteDirectJni(final long handle, final ByteBuffer key,
+      final int keyOffset, final int keyLength, final long cfHandle) throws RocksDBException;
+
   // DO NOT USE - `WriteBatchWithIndex::deleteRange` is not yet supported
   @Override
-  final native void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
-      final byte[] endKey, final int endKeyLen);
+  final void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
+      final byte[] endKey, final int endKeyLen) {
+    deleteRangeJni(handle, beginKey, beginKeyLen, endKey, endKeyLen);
+  }
+
+  private static native void deleteRangeJni(final long handle, final byte[] beginKey,
+      final int beginKeyLen, final byte[] endKey, final int endKeyLen);
+
   // DO NOT USE - `WriteBatchWithIndex::deleteRange` is not yet supported
   @Override
-  final native void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
-      final byte[] endKey, final int endKeyLen, final long cfHandle);
-  @Override final native void putLogData(final long handle, final byte[] blob,
-      final int blobLen) throws RocksDBException;
-  @Override final native void clear0(final long handle);
-  @Override final native void setSavePoint0(final long handle);
-  @Override final native void rollbackToSavePoint0(final long handle);
-  @Override final native void popSavePoint(final long handle) throws RocksDBException;
-  @Override final native void setMaxBytes(final long nativeHandle,
-      final long maxBytes);
-  @Override final native WriteBatch getWriteBatch(final long handle);
+  final void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
+      final byte[] endKey, final int endKeyLen, final long cfHandle) {
+    deleteRangeJni(handle, beginKey, beginKeyLen, endKey, endKeyLen, cfHandle);
+  }
+
+  private static native void deleteRangeJni(final long handle, final byte[] beginKey,
+      final int beginKeyLen, final byte[] endKey, final int endKeyLen, final long cfHandle);
+
+  @Override
+  final void putLogData(final long handle, final byte[] blob, final int blobLen)
+      throws RocksDBException {
+    putLogDataJni(handle, blob, blobLen);
+  }
+  private static native void putLogDataJni(final long handle, final byte[] blob, final int blobLen)
+      throws RocksDBException;
+
+  @Override
+  final void clear0(final long handle) {
+    clear0Jni(handle);
+  }
+
+  private static native void clear0Jni(final long handle);
+  @Override
+  final void setSavePoint0(final long handle) {
+    setSavePoint0Jni(handle);
+  }
+  private static native void setSavePoint0Jni(final long handle);
+
+  @Override
+  final void rollbackToSavePoint0(final long handle) {
+    rollbackToSavePoint0Jni(handle);
+  }
+
+  private static native void rollbackToSavePoint0Jni(final long handle);
+
+  @Override
+  final void popSavePoint(final long handle) throws RocksDBException {
+    popSavePointJni(handle);
+  }
+
+  private static native void popSavePointJni(final long handle) throws RocksDBException;
+
+  @Override
+  final void setMaxBytes(final long nativeHandle, final long maxBytes) {
+    setMaxBytesJni(nativeHandle, maxBytes);
+  }
+
+  private static native void setMaxBytesJni(final long nativeHandle, final long maxBytes);
+
+  @Override
+  final WriteBatch getWriteBatch(final long handle) {
+    return getWriteBatchJni(handle);
+  }
+
+  private static native WriteBatch getWriteBatchJni(final long handle);
 
   private static native long newWriteBatchWithIndex();
   private static native long newWriteBatchWithIndex(final boolean overwriteKey);
   private static native long newWriteBatchWithIndex(final long fallbackIndexComparatorHandle,
       final byte comparatorType, final int reservedBytes, final boolean overwriteKey);
-  private native long iterator0(final long handle);
-  private native long iterator1(final long handle, final long cfHandle);
-  private native long iteratorWithBase(final long handle, final long cfHandle,
+  private static native long iterator0(final long handle);
+  private static native long iterator1(final long handle, final long cfHandle);
+  private static native long iteratorWithBase(final long handle, final long cfHandle,
       final long baseIteratorHandle, final long readOptionsHandle);
-  private native byte[] getFromBatch(final long handle, final long optHandle,
-      final byte[] key, final int keyLen);
-  private native byte[] getFromBatch(final long handle, final long optHandle,
+  private static native byte[] getFromBatch(
+      final long handle, final long optHandle, final byte[] key, final int keyLen);
+  private static native byte[] getFromBatch(final long handle, final long optHandle,
       final byte[] key, final int keyLen, final long cfHandle);
-  private native byte[] getFromBatchAndDB(final long handle,
-      final long dbHandle,  final long readOptHandle, final byte[] key,
-      final int keyLen);
-  private native byte[] getFromBatchAndDB(final long handle,
-      final long dbHandle, final long readOptHandle, final byte[] key,
-      final int keyLen, final long cfHandle);
+  private static native byte[] getFromBatchAndDB(final long handle, final long dbHandle,
+      final long readOptHandle, final byte[] key, final int keyLen);
+  private static native byte[] getFromBatchAndDB(final long handle, final long dbHandle,
+      final long readOptHandle, final byte[] key, final int keyLen, final long cfHandle);
 }

--- a/java/src/main/java/org/rocksdb/WriteBufferManager.java
+++ b/java/src/main/java/org/rocksdb/WriteBufferManager.java
@@ -45,7 +45,11 @@ public class WriteBufferManager extends RocksObject {
       final long bufferSizeBytes, final long cacheHandle, final boolean allowStall);
 
   @Override
-  protected native void disposeInternal(final long handle);
+  protected void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+
+  private static native void disposeInternalJni(final long handle);
 
   private final boolean allowStall_;
 }

--- a/java/src/main/java/org/rocksdb/WriteOptions.java
+++ b/java/src/main/java/org/rocksdb/WriteOptions.java
@@ -235,21 +235,24 @@ public class WriteOptions extends RocksObject {
 
   private static native long newWriteOptions();
   private static native long copyWriteOptions(long handle);
-  @Override protected final native void disposeInternal(final long handle);
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+  private static native void disposeInternalJni(final long handle);
 
-  private native void setSync(long handle, boolean flag);
-  private native boolean sync(long handle);
-  private native void setDisableWAL(long handle, boolean flag);
-  private native boolean disableWAL(long handle);
-  private native void setIgnoreMissingColumnFamilies(final long handle,
-      final boolean ignoreMissingColumnFamilies);
-  private native boolean ignoreMissingColumnFamilies(final long handle);
-  private native void setNoSlowdown(final long handle,
-      final boolean noSlowdown);
-  private native boolean noSlowdown(final long handle);
-  private native void setLowPri(final long handle, final boolean lowPri);
-  private native boolean lowPri(final long handle);
-  private native boolean memtableInsertHintPerBatch(final long handle);
-  private native void setMemtableInsertHintPerBatch(
+  private static native void setSync(long handle, boolean flag);
+  private static native boolean sync(long handle);
+  private static native void setDisableWAL(long handle, boolean flag);
+  private static native boolean disableWAL(long handle);
+  private static native void setIgnoreMissingColumnFamilies(
+      final long handle, final boolean ignoreMissingColumnFamilies);
+  private static native boolean ignoreMissingColumnFamilies(final long handle);
+  private static native void setNoSlowdown(final long handle, final boolean noSlowdown);
+  private static native boolean noSlowdown(final long handle);
+  private static native void setLowPri(final long handle, final boolean lowPri);
+  private static native boolean lowPri(final long handle);
+  private static native boolean memtableInsertHintPerBatch(final long handle);
+  private static native void setMemtableInsertHintPerBatch(
       final long handle, final boolean memtableInsertHintPerBatch);
 }


### PR DESCRIPTION
This should give us some performance benefit calling native C++ code.
Closes #4786
See https://github.com/evolvedbinary/jni-benchmarks/ for more info.