### PR TITLE
Fix various failures in auto_readahead_size

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -83,7 +83,8 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       cfd_(cfd),
       timestamp_ub_(read_options.timestamp),
       timestamp_lb_(read_options.iter_start_ts),
-      timestamp_size_(timestamp_ub_ ? timestamp_ub_->size() : 0) {
+      timestamp_size_(timestamp_ub_ ? timestamp_ub_->size() : 0),
+      auto_readahead_size_(read_options.auto_readahead_size) {
   RecordTick(statistics_, NO_ITERATOR_CREATED);
   if (pin_thru_lifetime_) {
     pinned_iters_mgr_.StartPinning();
@@ -743,15 +744,22 @@ bool DBIter::ReverseToBackward() {
   // When current_entry_is_merged_ is true, iter_ may be positioned on the next
   // key, which may not exist or may have prefix different from current.
   // If that's the case, seek to saved_key_.
-  if (current_entry_is_merged_ &&
-      (!expect_total_order_inner_iter() || !iter_.Valid())) {
+  //
+  // In case of auto_readahead_size enabled, index_iter moves forward during
+  // forward scan for block cache lookup and points to different block. If Prev
+  // op is called, it needs to call SeekForPrev to point to right index_iter_ in
+  // BlockBasedTableIterator. This only happens when direction is changed from
+  // forward to backward.
+  if ((current_entry_is_merged_ &&
+       (!expect_total_order_inner_iter() || !iter_.Valid())) ||
+      auto_readahead_size_) {
     IterKey last_key;
     // Using kMaxSequenceNumber and kValueTypeForSeek
     // (not kValueTypeForSeekForPrev) to seek to a key strictly smaller
     // than saved_key_.
     last_key.SetInternalKey(ParsedInternalKey(
         saved_key_.GetUserKey(), kMaxSequenceNumber, kValueTypeForSeek));
-    if (!expect_total_order_inner_iter()) {
+    if (!expect_total_order_inner_iter() || auto_readahead_size_) {
       iter_.SeekForPrev(last_key.GetInternalKey());
     } else {
       // Some iterators may not support SeekForPrev(), so we avoid using it

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -402,6 +402,7 @@ class DBIter final : public Iterator {
   const Slice* const timestamp_lb_;
   const size_t timestamp_size_;
   std::string saved_timestamp_;
+  bool auto_readahead_size_;
 };
 
 // Return a new iterator that converts internal keys (yielded by

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1237,7 +1237,6 @@ Status StressTest::TestIterate(ThreadState* thread,
   } else if (options_.prefix_extractor.get() == nullptr) {
     expect_total_order = true;
   }
-
   std::string upper_bound_str;
   Slice upper_bound;
   if (thread->rand.OneIn(16)) {
@@ -1248,6 +1247,7 @@ Status StressTest::TestIterate(ThreadState* thread,
     upper_bound = Slice(upper_bound_str);
     ro.iterate_upper_bound = &upper_bound;
   }
+
   std::string lower_bound_str;
   Slice lower_bound;
   if (thread->rand.OneIn(16)) {
@@ -1377,8 +1377,7 @@ Status StressTest::TestIterate(ThreadState* thread,
                    key, op_logs, &diverged);
 
     const bool no_reverse =
-        (FLAGS_memtablerep == "prefix_hash" && !expect_total_order) ||
-        FLAGS_auto_readahead_size;
+        (FLAGS_memtablerep == "prefix_hash" && !expect_total_order);
     for (uint64_t i = 0; i < FLAGS_num_iterations && iter->Valid(); ++i) {
       if (no_reverse || thread->rand.OneIn(2)) {
         iter->Next();
@@ -1566,7 +1565,8 @@ void StressTest::VerifyIterator(ThreadState* thread,
           fprintf(stderr, "iterator has value %s\n",
                   iter->key().ToString(true).c_str());
         } else {
-          fprintf(stderr, "iterator is not valid\n");
+          fprintf(stderr, "iterator is not valid with status: %s\n",
+                  iter->status().ToString().c_str());
         }
         *diverged = true;
       }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1911,8 +1911,7 @@ class NonBatchedOpsStressTest : public StressTest {
       if (static_cast<int64_t>(curr) < lb) {
         iter->Next();
         op_logs += "N";
-      } else if (static_cast<int64_t>(curr) >= ub &&
-                 !FLAGS_auto_readahead_size) {
+      } else if (static_cast<int64_t>(curr) >= ub) {
         iter->Prev();
         op_logs += "P";
       } else {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1738,8 +1738,14 @@ struct ReadOptions {
   // during scans internally.
   // For this feature to enabled, iterate_upper_bound must also be specified.
   //
-  // NOTE: Not supported with Prev operation and it will be return NotSupported
-  // error. Enable it for forward scans only.
+  // NOTE: - Recommended for forward Scans only.
+  //       - In case of backward scans like Prev or SeekForPrev, the
+  //          cost of these backward operations might increase. So this option
+  //          should be enabled if workload contains backward scans.
+  //       - If there is a backward scans, this option will be
+  //          disabled internally and won't be reset if forward scan is done
+  //          again.
+  //
   // Default: false
   bool auto_readahead_size = false;
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1740,8 +1740,9 @@ struct ReadOptions {
   //
   // NOTE: - Recommended for forward Scans only.
   //       - In case of backward scans like Prev or SeekForPrev, the
-  //          cost of these backward operations might increase. So this option
-  //          should be enabled if workload contains backward scans.
+  //          cost of these backward operations might increase and affect the
+  //          performace. So this option should not be enabled if workload
+  //          contains backward scans.
   //       - If there is a backward scans, this option will be
   //          disabled internally and won't be reset if forward scan is done
   //          again.

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -26,7 +26,7 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
 
   if (autotune_readaheadsize &&
       table_->get_rep()->table_options.block_cache.get() &&
-      !read_options_.async_io) {
+      !read_options_.async_io && direction_ == IterDirection::kForward) {
     readahead_cache_lookup_ = true;
   }
 
@@ -87,14 +87,12 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
     } else {
       index_iter_->SeekToFirst();
     }
-
+    is_index_at_curr_block_ = true;
     if (!index_iter_->Valid()) {
       ResetDataIter();
       return;
     }
   }
-
-  is_index_at_curr_block_ = true;
 
   if (autotune_readaheadsize) {
     FindReadAheadSizeUpperBound();
@@ -170,6 +168,8 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
 }
 
 void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
+  direction_ = IterDirection::kBackward;
+  ResetBlockCacheLookupVar();
   is_out_of_bound_ = false;
   is_at_first_key_from_index_ = false;
   seek_stat_state_ = kNone;
@@ -191,7 +191,6 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
   }
 
   SavePrevIndexValue();
-  ResetBlockCacheLookupVar();
 
   // Call Seek() rather than SeekForPrev() in the index block, because the
   // target data block will likely to contain the position for `target`, the
@@ -207,6 +206,7 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
   // to distinguish the two unless we read the second block. In this case, we'll
   // end up with reading two blocks.
   index_iter_->Seek(target);
+  is_index_at_curr_block_ = true;
 
   if (!index_iter_->Valid()) {
     auto seek_status = index_iter_->status();
@@ -231,8 +231,6 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
     }
   }
 
-  is_index_at_curr_block_ = true;
-
   InitDataBlock();
 
   block_iter_.SeekForPrev(target);
@@ -244,21 +242,21 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
 }
 
 void BlockBasedTableIterator::SeekToLast() {
+  direction_ = IterDirection::kBackward;
+  ResetBlockCacheLookupVar();
   is_out_of_bound_ = false;
   is_at_first_key_from_index_ = false;
   seek_stat_state_ = kNone;
 
   SavePrevIndexValue();
-  ResetBlockCacheLookupVar();
 
   index_iter_->SeekToLast();
+  is_index_at_curr_block_ = true;
 
   if (!index_iter_->Valid()) {
     ResetDataIter();
     return;
   }
-
-  is_index_at_curr_block_ = true;
 
   InitDataBlock();
   block_iter_.SeekToLast();
@@ -528,7 +526,7 @@ void BlockBasedTableIterator::FindBlockForward() {
     //  index_iter_ can point to different block in case of
     //  readahead_cache_lookup_. readahead_cache_lookup_ will be handle the
     //  upper_bound check.
-    const bool next_block_is_out_of_bound =
+    bool next_block_is_out_of_bound =
         IsIndexAtCurr() && read_options_.iterate_upper_bound != nullptr &&
         block_iter_points_to_real_block_ &&
         block_upper_bound_check_ == BlockUpperBound::kUpperBoundInCurBlock;
@@ -553,8 +551,14 @@ void BlockBasedTableIterator::FindBlockForward() {
       // 2. If block_handles is empty and index is not at current because of
       //    lookup (during Next), it should skip doing index_iter_->Next(), as
       //    it's already pointing to next block;
-      if (IsIndexAtCurr()) {
+      // 3. Last block could be out of bound and it won't iterate over that
+      // during BlockCacheLookup. We need to set for that block here.
+      if (IsIndexAtCurr() || is_index_out_of_bound_) {
         index_iter_->Next();
+        if (is_index_out_of_bound_) {
+          next_block_is_out_of_bound = is_index_out_of_bound_;
+          is_index_out_of_bound_ = false;
+        }
       } else {
         // Skip Next as index_iter_ already points to correct index when it
         // iterates in BlockCacheLookupForReadAheadSize.
@@ -612,7 +616,7 @@ void BlockBasedTableIterator::FindKeyBackward() {
 }
 
 void BlockBasedTableIterator::CheckOutOfBound() {
-  if (IsIndexAtCurr() && read_options_.iterate_upper_bound != nullptr &&
+  if (read_options_.iterate_upper_bound != nullptr &&
       block_upper_bound_check_ != BlockUpperBound::kUpperBoundBeyondCurBlock &&
       Valid()) {
     is_out_of_bound_ =
@@ -686,6 +690,11 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
     return;
   }
 
+  if (IsNextBlockOutOfBound()) {
+    updated_readahead_size = 0;
+    return;
+  }
+
   size_t current_readahead_size = 0;
   size_t footer = table_->get_rep()->footer.GetBlockTrailerSize();
 
@@ -725,6 +734,7 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
     if (!s.ok()) {
       break;
     }
+
     block_handle_info.is_cache_hit_ =
         (block_handle_info.cachable_entry_.GetValue() ||
          block_handle_info.cachable_entry_.GetCacheHandle());
@@ -738,6 +748,7 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
     // means all the keys in next block or above are out of
     // bound.
     if (IsNextBlockOutOfBound()) {
+      is_index_out_of_bound_ = true;
       break;
     }
     index_iter_->Next();
@@ -750,7 +761,6 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
     current_readahead_size -= (*it).index_val_.handle.size();
     current_readahead_size -= footer;
   }
-
   updated_readahead_size = current_readahead_size;
   ResetPreviousBlockOffset();
 }

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -307,6 +307,13 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   // can point to a different block. is_index_at_curr_block_ keeps track of
   // that.
   bool is_index_at_curr_block_ = true;
+  bool is_index_out_of_bound_ = false;
+
+  // Used in case of auto_readahead_size to disable the block_cache lookup if
+  // direction is reversed from forward to backward. In case of backward
+  // direction, SeekForPrev or Prev might call Seek from db_iter. So direction
+  // is used to disable the lookup.
+  IterDirection direction_ = IterDirection::kForward;
 
   // If `target` is null, seek to first.
   void SeekImpl(const Slice* target, bool async_prefetch);
@@ -356,6 +363,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
                                         size_t& updated_readahead_size);
 
   void ResetBlockCacheLookupVar() {
+    is_index_out_of_bound_ = false;
     readahead_cache_lookup_ = false;
     ClearBlockHandles();
   }

--- a/table/block_based/block_based_table_reader_impl.h
+++ b/table/block_based/block_based_table_reader_impl.h
@@ -67,9 +67,13 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
     // might already be under way and this would invalidate it. Also, the
     // uncompression dict is typically at the end of the file and would
     // most likely break the sequentiality of the access pattern.
+    // Same is with auto_readahead_size. It iterates over index to lookup for
+    // data blocks. And this could break the the sequentiality of the access
+    // pattern.
     s = rep_->uncompression_dict_reader->GetOrReadUncompressionDictionary(
-        ro.async_io ? nullptr : prefetch_buffer, ro, no_io, ro.verify_checksums,
-        get_context, lookup_context, &uncompression_dict);
+        ((ro.async_io || ro.auto_readahead_size) ? nullptr : prefetch_buffer),
+        ro, no_io, ro.verify_checksums, get_context, lookup_context,
+        &uncompression_dict);
     if (!s.ok()) {
       iter->Invalidate(s);
       return iter;


### PR DESCRIPTION
Summary:  
1. **Error** in TestIterateAgainstExpected API - `Assertion index < pre_read_expected_values.size() && index < post_read_expected_values.size() failed.`
 **Fix** - `Prev` op is not supported with `auto_readahead_size`. So added support to Reseek in db_iter, if Prev is called. In BlockBasedTableIterator, index_iter_ already moves forward. So there is no way to do Prev from BlockBasedTableIterator.

2. **Error** - `void rocksdb::BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(uint64_t, size_t, size_t&): Assertion index_iter_->value().handle.offset() == offset`
   **Fix** - Remove prefetch_buffer to be used when uncompressed dict is read.

3. ** Error in TestPrefixScan API - `db_stress: db/db_iter.cc:369: bool rocksdb::DBIter::FindNextUserEntryInternal(bool, const rocksdb::Slice*): Assertion !skipping_saved_key || CompareKeyForSkip(ikey_.user_key, saved_key_.GetUserKey()) > 0 failed.
Received signal 6 (Aborted)
Invoking GDB for stack trace...
db_stress: table/merging_iterator.cc:1036: bool rocksdb::MergingIterator::SkipNextDeleted(): Assertion comparator_->Compare(range_tombstone_iters_[i]->start_key(), pik) <= 0 failed`
  **Fix** -  SeekPrev also calls 1) SeekPrev , 2)Seek and then 3)Prev in some cases in db_iter.cc leading to failure of Prev operation. These backward operations also call Seek.  Added direction to disable lookup once direction is backwards in BlockBasedTableIterator.cc
  
Test Plan: Ran various flavors of crash tests locally for the whole duration

Reviewers:

Subscribers:

Tasks:

Tags: