### PR TITLE
Fall back to RocksDB internal prefetching if PrepareIOOptions fails

### DIFF
--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -28,13 +28,12 @@ void BlockPrefetcher::PrefetchIfNeeded(
       }
       IOOptions opts;
       Status s = rep->file->PrepareIOOptions(read_options, opts);
-      if (!s.ok()) {
-        return;
-      }
-      s = rep->file->Prefetch(opts, offset, len + compaction_readahead_size_);
       if (s.ok()) {
-        readahead_limit_ = offset + len + compaction_readahead_size_;
-        return;
+        s = rep->file->Prefetch(opts, offset, len + compaction_readahead_size_);
+        if (s.ok()) {
+          readahead_limit_ = offset + len + compaction_readahead_size_;
+          return;
+        }
       }
     }
     // If FS prefetch is not supported, fall back to use internal prefetch

--- a/unreleased_history/bug_fixes/no_fall_back_bug.md
+++ b/unreleased_history/bug_fixes/no_fall_back_bug.md
@@ -1,0 +1,1 @@
+Fixed a bug where, under non direct IO, compaction read does not fall back to RocksDB internal prefetching when file system's prefetching can not proceed.


### PR DESCRIPTION
**Context/Summary:**
https://github.com/facebook/rocksdb/blame/main/table/block_based/block_prefetcher.cc#L30 added `PrepareIOOptions` step in file system prefetching for passing `IOOptions` down the read path. When this steps fails, we should fall back to RocksDB internal prefetching instead of returning early.


**Test:**
CI