### PR TITLE
No file system prefetching when Options::compaction_readahead_size is 0

### DIFF
--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -20,7 +20,7 @@ void BlockPrefetcher::PrefetchIfNeeded(
   const size_t len = BlockBasedTable::BlockSizeWithTrailer(handle);
   const size_t offset = handle.offset();
   if (is_for_compaction) {
-    if (!rep->file->use_direct_io()) {
+    if (!rep->file->use_direct_io() && compaction_readahead_size_ > 0) {
       // If FS supports prefetching (readahead_limit_ will be non zero in that
       // case) and current block exists in prefetch buffer then return.
       if (offset + len <= readahead_limit_) {

--- a/unreleased_history/behavior_changes/no_fs_prefetch_on_zero_compaction_readahead.md
+++ b/unreleased_history/behavior_changes/no_fs_prefetch_on_zero_compaction_readahead.md
@@ -1,0 +1,1 @@
+For non direct IO, eliminate the file system prefetching attempt for compaction read when `Options::compaction_readahead_size` is 0


### PR DESCRIPTION
**Context/Summary:**

https://github.com/facebook/rocksdb/pull/11631 introduced `readahead()` system call for compaction read under non direct IO. When `Options::compaction_readahead_size` is 0, the `readahead()` will issued with a small size (i.e, the block size, by default 4KB) 

Benchmarks shows that such readahead() call regresses the compaction read compared with "no readahead()" case when `Options::compaction_readahead_size` is 0 under non direct IO. (see Test Plan for more). 

`Options::compaction_readahead_size` is 0  by default in 8.5. So such regression is undesirable for upgrading from 8.4 to 8.5. Therefore we decided to not issue such `readhead() ` when `Options::compaction_readahead_size` is 0.

**Test plan:**
Settings: `compaction_readahead_size = 0, use_direct_reads=false`
Setup:
```
TEST_TMPDIR=../ ./db_bench -benchmarks=filluniquerandom -disable_auto_compactions=true -write_buffer_size=1048576 -compression_type=none -value_size=10240 && tar -cf ../dbbench.tar -C ../dbbench/ .
```
Run:
```
for i in $(seq 3); do rm -rf ../dbbench/ && mkdir -p ../dbbench/ && tar -xf ../dbbench.tar -C ../dbbench/ . && sudo bash -c 'sync && echo 3 > /proc/sys/vm/drop_caches' && TEST_TMPDIR=../ /usr/bin/time ./db_bench_{pre_PR11631|PR11631|PR11631_with_improvementPR11887} -benchmarks=compact -use_existing_db=true -db=../dbbench/ -disable_auto_compactions=true -compression_type=none -compaction_readahead_size=0 -use_direct_reads=0 ; done |& grep elapsed
```

pre-PR11631("no readahead()" case):
```
0:34.39elapsed
0:34.16elapsed
0:33.60elapsed
```

PR11631 (call readahead(), even when `compaction_readahead_size` is 0):
```
2:08.09elapsed
2:10.51elapsed
2:06.93elapsed
```

PR11631+this improvement (no readahead() call when `compaction_readahead_size` is 0):
```
0:35.73elapsed 
0:33.46elapsed
0:35.58elapsed
```


