### PR TITLE
Offpeak in db option

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1197,6 +1197,10 @@ class DBImpl : public DB {
 
   const PeriodicTaskScheduler& TEST_GetPeriodicTaskScheduler() const;
 
+  static Status TEST_ValidateOptions(const DBOptions& db_options) {
+    return ValidateOptions(db_options);
+  }
+
 #endif  // NDEBUG
 
   // persist stats to column family "_persistent_stats"

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #include <cinttypes>
-#include <regex>
 
 #include "db/builder.h"
 #include "db/db_impl/db_impl.h"

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -293,12 +293,16 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
   }
 
   if (db_options.daily_offpeak_time_utc != "") {
-    auto split = StringSplit(db_options.daily_offpeak_time_utc, '-');
-    if (split.size() != 2 || ParseTimeStringToSeconds(split[0]) < 0 ||
-        ParseTimeStringToSeconds(split[1]) < 0) {
+    int start_time, end_time;
+    if (!TryParseTimeRangeString(db_options.daily_offpeak_time_utc, start_time,
+                                 end_time)) {
       return Status::InvalidArgument(
           "daily_offpeak_time_utc should be set in the format HH:mm-HH:mm "
           "(e.g. 04:30-07:30)");
+    }
+    if (start_time == end_time) {
+      return Status::InvalidArgument(
+          "start_time and end_time cannot be the same");
     }
   }
   return Status::OK();

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -306,7 +306,7 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
         !std::regex_match(db_options.daily_offpeak_end_time_utc, hh_mm_regex)) {
       return Status::InvalidArgument(
           "daily_offpeak_start_time_utc and daily_offpeak_end_time_utc should "
-          "be set in the format HH:mm");
+          "be set in the format HH:mm (e.g. 04:30)");
     } else if (db_options.daily_offpeak_start_time_utc ==
                db_options.daily_offpeak_end_time_utc) {
       return Status::InvalidArgument(

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -300,10 +300,6 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
           "daily_offpeak_time_utc should be set in the format HH:mm-HH:mm "
           "(e.g. 04:30-07:30)");
     }
-    if (start_time == end_time) {
-      return Status::InvalidArgument(
-          "start_time and end_time cannot be the same");
-    }
   }
   return Status::OK();
 }

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1050,11 +1050,22 @@ TEST_F(DBOptionsTest, OffPeakTimes) {
     ASSERT_FALSE(s.IsInvalidArgument());
   };
   std::vector<std::string> invalid_cases = {
-      "06:30-",         "-23:30",           // Both need to be set
-      "12:30 PM-23:30", "12:01AM-11:00PM",  // Invalid format
-      "01:99-22:00",                        // Invalid value for minutes
-      "00:00-24:00",                        // 24:00 is an invalid value
-      "random-value",   "No:No-Hi:Hi",
+      "06:30-",
+      "-23:30",  // Both need to be set
+      "12:30 PM-23:30",
+      "12:01AM-11:00PM",  // Invalid format
+      "01:99-22:00",      // Invalid value for minutes
+      "00:00-24:00",      // 24:00 is an invalid value
+      "6-7",
+      "6:-7",
+      "06:31.42-7:00",
+      "6.31:42-7:00",
+      "6:0-7:",
+      "15:0.2-3:.7",
+      ":00-00:02",
+      "02:00-:00",
+      "random-value",
+      "No:No-Hi:Hi",
   };
 
   std::vector<std::string> valid_cases = {

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1050,9 +1050,11 @@ TEST_F(DBOptionsTest, OffPeakTimes) {
     ASSERT_FALSE(s.IsInvalidArgument());
   };
   std::vector<std::string> invalid_cases = {
-      "06:30-",         "-23:30",           // Both need to be set
+      "06:30-",         "-23:30",  // Both need to be set
+      "06:30-06:30",  // Valid, but start time and end time cannot be the same
       "12:30 PM-23:30", "12:01AM-11:00PM",  // Invalid format
-      "01:99-25:00",  // Invalid value for the hours or minutes
+      "01:99-22:00",                        // Invalid value for minutes
+      "00:00-24:00",                        // 24:00 is an invalid value
       "random-value",   "No:No-Hi:Hi",
   };
 
@@ -1061,6 +1063,7 @@ TEST_F(DBOptionsTest, OffPeakTimes) {
       "06:30-11:30",
       "06:30-23:30",
       "13:30-14:30",
+      "00:00-23:59",
       "23:30-01:15",  // From 11:30PM to 1:15AM next day. Valid case
   };
 

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1050,8 +1050,7 @@ TEST_F(DBOptionsTest, OffPeakTimes) {
     ASSERT_FALSE(s.IsInvalidArgument());
   };
   std::vector<std::string> invalid_cases = {
-      "06:30-",         "-23:30",  // Both need to be set
-      "06:30-06:30",  // Valid, but start time and end time cannot be the same
+      "06:30-",         "-23:30",           // Both need to be set
       "12:30 PM-23:30", "12:01AM-11:00PM",  // Invalid format
       "01:99-22:00",                        // Invalid value for minutes
       "00:00-24:00",                        // 24:00 is an invalid value
@@ -1059,12 +1058,13 @@ TEST_F(DBOptionsTest, OffPeakTimes) {
   };
 
   std::vector<std::string> valid_cases = {
-      "",  // Not enabled. Valid case
-      "06:30-11:30",
-      "06:30-23:30",
-      "13:30-14:30",
-      "00:00-23:59",
-      "23:30-01:15",  // From 11:30PM to 1:15AM next day. Valid case
+      "",             // Not enabled. Valid case
+      "00:00-00:00",  // Valid. Entire 24 hours are offpeak.
+      "06:30-11:30", "06:30-23:30", "13:30-14:30",
+      "00:00-23:59",  // This doesn't cover entire 24 hours. There's 1 minute
+                      // gap from 11:59:00PM to midnight
+      "23:30-01:15",  // From 11:30PM to 1:15AM next day. Valid case.
+      "1:0000000000000-2:000000000042",  // Weird, but we can parse the int.
   };
 
   for (std::string invalid_case : invalid_cases) {
@@ -1076,10 +1076,14 @@ TEST_F(DBOptionsTest, OffPeakTimes) {
     verify_valid();
   }
 
-  auto verify_is_now_offpeak = [&](int now_utc_hour, int now_utc_minute,
-                                   bool expected) {
+  auto verify_is_now_offpeak = [&](bool expected, int now_utc_hour,
+                                   int now_utc_minute, int now_utc_second = 0) {
     auto mock_clock = std::make_shared<MockSystemClock>(env_->GetSystemClock());
-    mock_clock->SetCurrentTime(now_utc_hour * 3600 + now_utc_minute * 60);
+    // Add some extra random days to current time
+    Random rnd(301);
+    int days = rnd.Uniform(100);
+    mock_clock->SetCurrentTime(days * 86400 + now_utc_hour * 3600 +
+                               now_utc_minute * 60 + now_utc_second);
     Status s = DBImpl::TEST_ValidateOptions(options);
     ASSERT_OK(s);
     auto db_options = MutableDBOptions(options);
@@ -1087,28 +1091,29 @@ TEST_F(DBOptionsTest, OffPeakTimes) {
   };
 
   options.daily_offpeak_time_utc = "";
-  verify_is_now_offpeak(12, 30, false);
+  verify_is_now_offpeak(false, 12, 30);
 
   options.daily_offpeak_time_utc = "06:30-11:30";
-  verify_is_now_offpeak(5, 30, false);
-  verify_is_now_offpeak(6, 30, true);
-  verify_is_now_offpeak(10, 30, true);
-  verify_is_now_offpeak(11, 30, true);
-  verify_is_now_offpeak(13, 30, false);
+  verify_is_now_offpeak(false, 5, 30);
+  verify_is_now_offpeak(true, 6, 30);
+  verify_is_now_offpeak(true, 10, 30);
+  verify_is_now_offpeak(true, 11, 30);
+  verify_is_now_offpeak(false, 13, 30);
 
   options.daily_offpeak_time_utc = "23:30-04:30";
-  verify_is_now_offpeak(6, 30, false);
-  verify_is_now_offpeak(23, 30, true);
-  verify_is_now_offpeak(0, 0, true);
-  verify_is_now_offpeak(1, 0, true);
-  verify_is_now_offpeak(4, 30, true);
-  verify_is_now_offpeak(4, 31, false);
+  verify_is_now_offpeak(false, 6, 30);
+  verify_is_now_offpeak(true, 23, 30);
+  verify_is_now_offpeak(true, 0, 0);
+  verify_is_now_offpeak(true, 1, 0);
+  verify_is_now_offpeak(true, 4, 30);
+  verify_is_now_offpeak(false, 4, 31);
 
-  // entire day is offpeak (weird use case, but valid)
+  // There's one minute gap from 11:59PM to midnight
   options.daily_offpeak_time_utc = "00:00-23:59";
-  verify_is_now_offpeak(0, 0, true);
-  verify_is_now_offpeak(12, 00, true);
-  verify_is_now_offpeak(23, 59, true);
+  verify_is_now_offpeak(true, 0, 0);
+  verify_is_now_offpeak(true, 12, 00);
+  verify_is_now_offpeak(true, 23, 59);
+  verify_is_now_offpeak(false, 23, 59, 1);
 
   // Open the db and test by Get/SetDBOptions
   options.daily_offpeak_time_utc = "";
@@ -1132,7 +1137,10 @@ TEST_F(DBOptionsTest, OffPeakTimes) {
   options.daily_offpeak_time_utc = "23:30-04:30";
   auto mock_clock = std::make_shared<MockSystemClock>(env_->GetSystemClock());
   auto mock_env = std::make_unique<CompositeEnvWrapper>(env_, mock_clock);
-  mock_clock->SetCurrentTime(now_hour * 3600 + now_minute * 60);
+  // Add some extra random days to current time
+  Random rnd(301);
+  int days = rnd.Uniform(100);
+  mock_clock->SetCurrentTime(days * 86400 + now_hour * 3600 + now_minute * 60);
   options.env = mock_env.get();
 
   // Starting at 1:30PM. It's not off-peak

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1438,10 +1438,11 @@ struct DBOptions {
   // the next peak cycle begins. For example, if the TTL is configured for 25
   // days, we may compact the files during the off-peak hours of the 24th day.
   //
-  // Time of the day in UTC. Format - HH:mm (e.g. 00:00 - 23:59)
-  // Default: Empty String (No notion of peak/offpeak)
-  std::string daily_offpeak_start_time_utc = "";
-  std::string daily_offpeak_end_time_utc = "";
+  // Time of the day in UTC. Format - HH:mm-HH:mm (00:00-23:59)
+  // If the start time > end time, it will be considered that the time period
+  // spans to the next day (e.g., 23:30-04:00) Default: Empty String (No notion
+  // of peak/offpeak)
+  std::string daily_offpeak_time_utc = "";
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1427,6 +1427,21 @@ struct DBOptions {
   // of the contract leads to undefined behaviors with high possibility of data
   // inconsistency, e.g. deleted old data become visible again, etc.
   bool enforce_single_del_contracts = true;
+
+  // EXPERIMENTAL
+  // Implementing offpeak duration awareness in RocksDB. In this context, "peak
+  // time" signifies periods characterized by significantly elevated read and
+  // write activity compared to other times. By leveraging this knowledge, we
+  // can prevent low-priority tasks, such as TTL-based compactions, from
+  // competing with read and write operations during peak hours. Essentially, we
+  // preprocess these tasks during the preceding off-peak period, just before
+  // the next peak cycle begins. For example, if the TTL is configured for 25
+  // days, we may compact the files during the off-peak hours of the 24th day.
+  //
+  // Time of the day in UTC. Format - HH:mm (e.g. 00:00 - 23:59)
+  // Default: Empty String (No notion of peak/offpeak)
+  std::string daily_offpeak_start_time_utc = "";
+  std::string daily_offpeak_end_time_utc = "";
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1440,8 +1440,11 @@ struct DBOptions {
   //
   // Time of the day in UTC. Format - HH:mm-HH:mm (00:00-23:59)
   // If the start time > end time, it will be considered that the time period
-  // spans to the next day (e.g., 23:30-04:00) Default: Empty String (No notion
-  // of peak/offpeak)
+  // spans to the next day (e.g., 23:30-04:00)
+  // If the start time == end time, entire 24 hours will be considered offpeak
+  // (e.g. 00:00-00:00). Note that 00:00-23:59 will have one minute gap from
+  // 11:59:00PM to midnight.
+  // Default: Empty String (No notion of peak/offpeak)
   std::string daily_offpeak_time_utc = "";
 };
 

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -6,9 +6,6 @@
 #include "options/db_options.h"
 
 #include <cinttypes>
-#include <cstdint>
-#include <ctime>
-#include <iomanip>
 
 #include "logging/logging.h"
 #include "options/configurable_helper.h"
@@ -1075,12 +1072,11 @@ bool MutableDBOptions::IsNowOffPeak(SystemClock* clock) const {
   }
   int64_t now;
   if (clock->GetCurrentTime(&now).ok()) {
-    int since_midnight_seconds = static_cast<int>(now % 86400);
-    auto split = StringSplit(daily_offpeak_time_utc, '-');
-    assert(split.size() == 2);
-    int start_time = ParseTimeStringToSeconds(split[0]);
-    int end_time = ParseTimeStringToSeconds(split[1]);
-    assert(start_time >= 0 && end_time >= 0);
+    constexpr int seconds_per_day = 86400;
+    int since_midnight_seconds = static_cast<int>(now % seconds_per_day);
+    int start_time = 0, end_time = 0;
+    assert(
+        TryParseTimeRangeString(daily_offpeak_time_utc, start_time, end_time));
 
     // if the offpeak duration spans overnight (i.e. 23:30 - 4:30 next day)
     if (start_time > end_time) {

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -129,6 +129,14 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableDBOptions, max_background_flushes),
           OptionType::kInt, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"daily_offpeak_start_time_utc",
+         {offsetof(struct MutableDBOptions, daily_offpeak_start_time_utc),
+          OptionType::kString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
+        {"daily_offpeak_end_time_utc",
+         {offsetof(struct MutableDBOptions, daily_offpeak_end_time_utc),
+          OptionType::kString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
 };
 
 static std::unordered_map<std::string, OptionTypeInfo>
@@ -991,7 +999,9 @@ MutableDBOptions::MutableDBOptions()
       wal_bytes_per_sync(0),
       strict_bytes_per_sync(false),
       compaction_readahead_size(0),
-      max_background_flushes(-1) {}
+      max_background_flushes(-1),
+      daily_offpeak_start_time_utc(""),
+      daily_offpeak_end_time_utc("") {}
 
 MutableDBOptions::MutableDBOptions(const DBOptions& options)
     : max_background_jobs(options.max_background_jobs),
@@ -1011,7 +1021,9 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
       wal_bytes_per_sync(options.wal_bytes_per_sync),
       strict_bytes_per_sync(options.strict_bytes_per_sync),
       compaction_readahead_size(options.compaction_readahead_size),
-      max_background_flushes(options.max_background_flushes) {}
+      max_background_flushes(options.max_background_flushes),
+      daily_offpeak_start_time_utc(options.daily_offpeak_start_time_utc),
+      daily_offpeak_end_time_utc(options.daily_offpeak_end_time_utc) {}
 
 void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log, "            Options.max_background_jobs: %d",
@@ -1056,6 +1068,10 @@ void MutableDBOptions::Dump(Logger* log) const {
                    compaction_readahead_size);
   ROCKS_LOG_HEADER(log, "                 Options.max_background_flushes: %d",
                           max_background_flushes);
+  ROCKS_LOG_HEADER(log, "Options.daily_offpeak_start_time_utc: %s",
+                   daily_offpeak_start_time_utc.c_str());
+  ROCKS_LOG_HEADER(log, "Options.daily_offpeak_end_time_utc: %s",
+                   daily_offpeak_end_time_utc.c_str());
 }
 
 Status GetMutableDBOptionsFromStrings(

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -1072,8 +1072,8 @@ bool MutableDBOptions::IsNowOffPeak(SystemClock* clock) const {
   }
   int64_t now;
   if (clock->GetCurrentTime(&now).ok()) {
-    constexpr int seconds_per_day = 86400;
-    int since_midnight_seconds = static_cast<int>(now % seconds_per_day);
+    constexpr int kSecondsPerDay = 86400;
+    int since_midnight_seconds = static_cast<int>(now % kSecondsPerDay);
     int start_time = 0, end_time = 0;
     assert(
         TryParseTimeRangeString(daily_offpeak_time_utc, start_time, end_time));

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -1081,11 +1081,12 @@ bool MutableDBOptions::IsNowOffPeak(SystemClock* clock) const {
       daily_offpeak_end_time_utc.empty()) {
     return false;
   }
-  int64_t unix_time_now;
-  if (clock->GetCurrentTime(&unix_time_now).ok()) {
+  int64_t now;
+  if (clock->GetCurrentTime(&now).ok()) {
+    time_t now_unix_time = static_cast<time_t>(now);
     // extract hour and minute from unix_time_now in HH:mm format
     char now_utc[6];
-    std::strftime(now_utc, sizeof(now_utc), "%R", std::gmtime(&unix_time_now));
+    std::strftime(now_utc, sizeof(now_utc), "%R", std::gmtime(&now_unix_time));
 
     // if the offpeak duration spans overnight (i.e. 23:30 - 4:30 next day)
     if (daily_offpeak_start_time_utc > daily_offpeak_end_time_utc) {

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -137,8 +137,7 @@ struct MutableDBOptions {
   size_t compaction_readahead_size;
   int max_background_flushes;
 
-  std::string daily_offpeak_start_time_utc;
-  std::string daily_offpeak_end_time_utc;
+  std::string daily_offpeak_time_utc;
   bool IsNowOffPeak(SystemClock* clock) const;
 };
 

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -139,7 +139,7 @@ struct MutableDBOptions {
 
   std::string daily_offpeak_start_time_utc;
   std::string daily_offpeak_end_time_utc;
-  bool IsNowOffPeak() const;
+  bool IsNowOffPeak(SystemClock* clock) const;
 };
 
 Status GetStringFromMutableDBOptions(const ConfigOptions& config_options,

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -136,6 +136,10 @@ struct MutableDBOptions {
   bool strict_bytes_per_sync;
   size_t compaction_readahead_size;
   int max_background_flushes;
+
+  std::string daily_offpeak_start_time_utc;
+  std::string daily_offpeak_end_time_utc;
+  bool IsNowOffPeak() const;
 };
 
 Status GetStringFromMutableDBOptions(const ConfigOptions& config_options,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -179,6 +179,10 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.lowest_used_cache_tier = immutable_db_options.lowest_used_cache_tier;
   options.enforce_single_del_contracts =
       immutable_db_options.enforce_single_del_contracts;
+  options.daily_offpeak_start_time_utc =
+      mutable_db_options.daily_offpeak_start_time_utc;
+  options.daily_offpeak_end_time_utc =
+      mutable_db_options.daily_offpeak_end_time_utc;
   return options;
 }
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -179,10 +179,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.lowest_used_cache_tier = immutable_db_options.lowest_used_cache_tier;
   options.enforce_single_del_contracts =
       immutable_db_options.enforce_single_del_contracts;
-  options.daily_offpeak_start_time_utc =
-      mutable_db_options.daily_offpeak_start_time_utc;
-  options.daily_offpeak_end_time_utc =
-      mutable_db_options.daily_offpeak_end_time_utc;
+  options.daily_offpeak_time_utc = mutable_db_options.daily_offpeak_time_utc;
   return options;
 }
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -252,10 +252,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
        sizeof(FileTypeSet)},
       {offsetof(struct DBOptions, compaction_service),
        sizeof(std::shared_ptr<CompactionService>)},
-      {offsetof(struct DBOptions, daily_offpeak_start_time_utc),
-       sizeof(std::string)},
-      {offsetof(struct DBOptions, daily_offpeak_end_time_utc),
-       sizeof(std::string)},
+      {offsetof(struct DBOptions, daily_offpeak_time_utc), sizeof(std::string)},
   };
 
   char* options_ptr = new char[sizeof(DBOptions)];
@@ -370,8 +367,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "lowest_used_cache_tier=kNonVolatileBlockTier;"
                              "allow_data_in_errors=false;"
                              "enforce_single_del_contracts=false;"
-                             "daily_offpeak_start_time_utc=08:30;"
-                             "daily_offpeak_end_time_utc=19:00;",
+                             "daily_offpeak_time_utc=08:30-19:00;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -252,6 +252,10 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
        sizeof(FileTypeSet)},
       {offsetof(struct DBOptions, compaction_service),
        sizeof(std::shared_ptr<CompactionService>)},
+      {offsetof(struct DBOptions, daily_offpeak_start_time_utc),
+       sizeof(std::string)},
+      {offsetof(struct DBOptions, daily_offpeak_end_time_utc),
+       sizeof(std::string)},
   };
 
   char* options_ptr = new char[sizeof(DBOptions)];
@@ -365,7 +369,9 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "db_host_id=hostname;"
                              "lowest_used_cache_tier=kNonVolatileBlockTier;"
                              "allow_data_in_errors=false;"
-                             "enforce_single_del_contracts=false;",
+                             "enforce_single_del_contracts=false;"
+                             "daily_offpeak_start_time_utc=08:30;"
+                             "daily_offpeak_end_time_utc=19:00;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -178,6 +178,8 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"wal_bytes_per_sync", "48"},
       {"strict_bytes_per_sync", "true"},
       {"preserve_deletes", "false"},
+      {"daily_offpeak_start_time_utc", ""},
+      {"daily_offpeak_end_time_utc", ""},
   };
 
   ColumnFamilyOptions base_cf_opt;
@@ -358,6 +360,8 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.bytes_per_sync, static_cast<uint64_t>(47));
   ASSERT_EQ(new_db_opt.wal_bytes_per_sync, static_cast<uint64_t>(48));
   ASSERT_EQ(new_db_opt.strict_bytes_per_sync, true);
+  ASSERT_EQ(new_db_opt.daily_offpeak_start_time_utc, "");
+  ASSERT_EQ(new_db_opt.daily_offpeak_end_time_utc, "");
 
   db_options_map["max_open_files"] = "hello";
   Status s =
@@ -879,6 +883,8 @@ TEST_F(OptionsTest, OldInterfaceTest) {
       {"track_and_verify_wals_in_manifest", "true"},
       {"verify_sst_unique_id_in_manifest", "true"},
       {"max_open_files", "32"},
+      {"daily_offpeak_start_time_utc", "06:30"},
+      {"daily_offpeak_end_time_utc", "23:30"},
   };
 
   ConfigOptions db_config_options(base_db_opt);
@@ -909,11 +915,14 @@ TEST_F(OptionsTest, OldInterfaceTest) {
   db_config_options.ignore_unknown_options = false;
   ASSERT_OK(GetDBOptionsFromString(
       db_config_options, base_db_opt,
-      "create_if_missing=false;error_if_exists=false;max_open_files=42;",
+      "create_if_missing=false;error_if_exists=false;max_open_files=42;daily_"
+      "offpeak_start_time_utc=08:30;daily_offpeak_end_time_utc=19:00;",
       &new_db_opt));
   ASSERT_EQ(new_db_opt.create_if_missing, false);
   ASSERT_EQ(new_db_opt.error_if_exists, false);
   ASSERT_EQ(new_db_opt.max_open_files, 42);
+  ASSERT_EQ(new_db_opt.daily_offpeak_start_time_utc, "08:30");
+  ASSERT_EQ(new_db_opt.daily_offpeak_end_time_utc, "19:00");
   s = GetDBOptionsFromString(
       db_config_options, base_db_opt,
       "create_if_missing=false;error_if_exists=false;max_open_files=42;"

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -912,7 +912,7 @@ TEST_F(OptionsTest, OldInterfaceTest) {
   db_config_options.ignore_unknown_options = false;
   ASSERT_OK(GetDBOptionsFromString(
       db_config_options, base_db_opt,
-      "create_if_missing=false;error_if_exists=false;max_open_files=42;daily_"
+      "create_if_missing=false;error_if_exists=false;max_open_files=42;"
       "daily_offpeak_time_utc=08:30-19:00;",
       &new_db_opt));
   ASSERT_EQ(new_db_opt.create_if_missing, false);

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -178,8 +178,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"wal_bytes_per_sync", "48"},
       {"strict_bytes_per_sync", "true"},
       {"preserve_deletes", "false"},
-      {"daily_offpeak_start_time_utc", ""},
-      {"daily_offpeak_end_time_utc", ""},
+      {"daily_offpeak_time_utc", ""},
   };
 
   ColumnFamilyOptions base_cf_opt;
@@ -360,8 +359,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.bytes_per_sync, static_cast<uint64_t>(47));
   ASSERT_EQ(new_db_opt.wal_bytes_per_sync, static_cast<uint64_t>(48));
   ASSERT_EQ(new_db_opt.strict_bytes_per_sync, true);
-  ASSERT_EQ(new_db_opt.daily_offpeak_start_time_utc, "");
-  ASSERT_EQ(new_db_opt.daily_offpeak_end_time_utc, "");
+  ASSERT_EQ(new_db_opt.daily_offpeak_time_utc, "");
 
   db_options_map["max_open_files"] = "hello";
   Status s =
@@ -883,8 +881,7 @@ TEST_F(OptionsTest, OldInterfaceTest) {
       {"track_and_verify_wals_in_manifest", "true"},
       {"verify_sst_unique_id_in_manifest", "true"},
       {"max_open_files", "32"},
-      {"daily_offpeak_start_time_utc", "06:30"},
-      {"daily_offpeak_end_time_utc", "23:30"},
+      {"daily_offpeak_time_utc", "06:30-23:30"},
   };
 
   ConfigOptions db_config_options(base_db_opt);
@@ -916,13 +913,12 @@ TEST_F(OptionsTest, OldInterfaceTest) {
   ASSERT_OK(GetDBOptionsFromString(
       db_config_options, base_db_opt,
       "create_if_missing=false;error_if_exists=false;max_open_files=42;daily_"
-      "offpeak_start_time_utc=08:30;daily_offpeak_end_time_utc=19:00;",
+      "daily_offpeak_time_utc=08:30-19:00;",
       &new_db_opt));
   ASSERT_EQ(new_db_opt.create_if_missing, false);
   ASSERT_EQ(new_db_opt.error_if_exists, false);
   ASSERT_EQ(new_db_opt.max_open_files, 42);
-  ASSERT_EQ(new_db_opt.daily_offpeak_start_time_utc, "08:30");
-  ASSERT_EQ(new_db_opt.daily_offpeak_end_time_utc, "19:00");
+  ASSERT_EQ(new_db_opt.daily_offpeak_time_utc, "08:30-19:00");
   s = GetDBOptionsFromString(
       db_config_options, base_db_opt,
       "create_if_missing=false;error_if_exists=false;max_open_files=42;"

--- a/unreleased_history/new_features/offpeak_db_option.md
+++ b/unreleased_history/new_features/offpeak_db_option.md
@@ -1,0 +1,1 @@
+Add an experimental offpeak duration awareness by setting `DBOptions::daily_offpeak_time_utc` in "HH:mm-HH:mm" format. This information will be used for resource optimization in the future

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -437,6 +437,23 @@ bool SerializeIntVector(const std::vector<int>& vec, std::string* value) {
   return true;
 }
 
+int ParseTimeStringToSeconds(const std::string& value) {
+  int hours, minutes;
+  char colon;
+
+  std::istringstream stream(value);
+  stream >> hours >> colon >> minutes;
+
+  if (stream.fail() || !stream.eof() || colon != ':') {
+    return -1;
+  }
+
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+    return -1;
+  }
+  return hours * 3600 + minutes * 60;
+}
+
 // Copied from folly/string.cpp:
 // https://github.com/facebook/folly/blob/0deef031cb8aab76dc7e736f8b7c22d701d5f36b/folly/String.cpp#L457
 // There are two variants of `strerror_r` function, one returns

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -454,6 +454,28 @@ int ParseTimeStringToSeconds(const std::string& value) {
   return hours * 3600 + minutes * 60;
 }
 
+bool TryParseTimeRangeString(const std::string& value, int& start_time,
+                             int& end_time) {
+  if (value.empty()) {
+    start_time = 0;
+    end_time = 0;
+    return true;
+  }
+  auto split = StringSplit(value, '-');
+  if (split.size() != 2) {
+    return false;
+  }
+  start_time = ParseTimeStringToSeconds(split[0]);
+  if (start_time < 0) {
+    return false;
+  }
+  end_time = ParseTimeStringToSeconds(split[1]);
+  if (end_time < 0) {
+    return false;
+  }
+  return true;
+}
+
 // Copied from folly/string.cpp:
 // https://github.com/facebook/folly/blob/0deef031cb8aab76dc7e736f8b7c22d701d5f36b/folly/String.cpp#L457
 // There are two variants of `strerror_r` function, one returns

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -170,6 +170,12 @@ bool SerializeIntVector(const std::vector<int>& vec, std::string* value);
 // Returns -1 if invalid input. Otherwise returns seconds since midnight
 int ParseTimeStringToSeconds(const std::string& value);
 
+// Expects HH:mm-HH:mm format for the input value
+// Returns false, if invalid format.
+// Otherwise, returns true and start_time and end_time are set
+bool TryParseTimeRangeString(const std::string& value, int& start_time,
+                             int& end_time);
+
 extern const std::string kNullptrString;
 
 // errnoStr() function returns a string that describes the error code passed in

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -166,6 +166,10 @@ std::vector<int> ParseVectorInt(const std::string& value);
 
 bool SerializeIntVector(const std::vector<int>& vec, std::string* value);
 
+// Expects HH:mm format for the input value
+// Returns -1 if invalid input. Otherwise returns seconds since midnight
+int ParseTimeStringToSeconds(const std::string& value);
+
 extern const std::string kNullptrString;
 
 // errnoStr() function returns a string that describes the error code passed in


### PR DESCRIPTION
# Summary

RocksDB's primary function is to facilitate read and write operations. Compactions, while essential for minimizing read amplifications and optimizing storage, can sometimes compete with these primary tasks. Especially during periods of high read/write traffic, it's vital to ensure that primary operations receive priority, avoiding any potential disruptions or slowdowns. Conversely, during off-peak times when traffic is minimal, it's an opportune moment to tackle low-priority tasks like TTL based compactions, optimizing resource usage.

In this PR, we are incorporating the concept of off-peak time into RocksDB by introducing `daily_offpeak_time_utc` within the DBOptions. This setting is formatted as "HH:mm-HH:mm" where the first one before "-" is the start time and the second one is the end time, inclusive. It will be later used for resource optimization in subsequent PRs.

# Test Plan

- New Unit Test Added - `DBOptionsTest::OffPeakTimes`
- Existing Unit Test Updated - `OptionsTest`, `OptionsSettableTest`