### PR TITLE
Only fallback to RocksDB internal prefetching on unsupported FS prefetching

### DIFF
--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -35,11 +35,12 @@ void BlockPrefetcher::PrefetchIfNeeded(
       if (s.ok()) {
         readahead_limit_ = offset + len + compaction_readahead_size_;
         return;
+      } else if (!s.IsNotSupported()) {
+        return;
       }
     }
     // If FS prefetch is not supported, fall back to use internal prefetch
-    // buffer. Discarding other return status of Prefetch calls intentionally,
-    // as we can fallback to reading from disk if Prefetch fails.
+    // buffer.
     //
     // num_file_reads is used  by FilePrefetchBuffer only when
     // implicit_auto_readahead is set.
@@ -122,8 +123,6 @@ void BlockPrefetcher::PrefetchIfNeeded(
   }
 
   // If prefetch is not supported, fall back to use internal prefetch buffer.
-  // Discarding other return status of Prefetch calls intentionally, as
-  // we can fallback to reading from disk if Prefetch fails.
   IOOptions opts;
   Status s = rep->file->PrepareIOOptions(read_options, opts);
   if (!s.ok()) {

--- a/unreleased_history/bug_fixes/fallback_only_unsupported.md
+++ b/unreleased_history/bug_fixes/fallback_only_unsupported.md
@@ -1,0 +1,1 @@
+Fixed a bug where compaction read under non direct IO still falls back to RocksDB internal prefetching after file system's prefetching returns non-OK status other than `Status::NotSupported()`


### PR DESCRIPTION
**Context/Summary:**
https://github.com/facebook/rocksdb/pull/11631 introduced an undesired fallback behavior to RocksDB internal prefetching even when FS prefetching return non-OK status other than "Unsupported". We only want to fall back when FS prefetching is not supported.

**Test:**
CI