### PR TITLE
Give retry flushes their own functions

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -391,10 +391,7 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
   // all the column families
   if (s.ok()) {
     if (immutable_db_options_.atomic_flush) {
-      FlushOptions flush_opts;
-      // We allow flush to stall write since we are trying to resume from error.
-      flush_opts.allow_write_stall = true;
-      s = FlushAllColumnFamilies(flush_opts, context.flush_reason);
+      s = AtomicRetryFlushesForErrorRecovery(context.flush_reason);
     } else {
       s = RetryFlushesForErrorRecovery(context.flush_reason);
     }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -390,12 +390,7 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
   // We cannot guarantee consistency of the WAL. So force flush Memtables of
   // all the column families
   if (s.ok()) {
-    if (immutable_db_options_.atomic_flush) {
-      s = AtomicRetryFlushesForErrorRecovery(context.flush_reason,
-                                             true /* wait */);
-    } else {
-      s = RetryFlushesForErrorRecovery(context.flush_reason, true /* wait */);
-    }
+    s = RetryFlushesForErrorRecovery(context.flush_reason, true /* wait */);
     if (!s.ok()) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "DB resume requested but failed due to Flush failure [%s]",
@@ -459,14 +454,8 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
     // Since we drop all non-recovery flush requests during recovery,
     // and new memtable may fill up during recovery,
     // schedule one more round of flush.
-    Status status;
-    if (immutable_db_options_.atomic_flush) {
-      status = AtomicRetryFlushesForErrorRecovery(
-          FlushReason::kCatchUpAfterErrorRecovery, false /* wait */);
-    } else {
-      status = RetryFlushesForErrorRecovery(
-          FlushReason::kCatchUpAfterErrorRecovery, false /* wait */);
-    }
+    Status status = RetryFlushesForErrorRecovery(
+        FlushReason::kCatchUpAfterErrorRecovery, false /* wait */);
     if (!status.ok()) {
       // FlushAllColumnFamilies internally should take care of setting
       // background error if needed.

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -392,7 +392,6 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
       s = RetryFlushesForErrorRecovery(FlushReason::kErrorRecoveryRetryFlush,
                                        true /* wait */);
     } else {
-      assert(context.flush_reason == FlushReason::kErrorRecovery);
       // We cannot guarantee consistency of the WAL. So force flush Memtables of
       // all the column families
       FlushOptions flush_opts;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -397,7 +397,7 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
       FlushOptions flush_opts;
       // We allow flush to stall write since we are trying to resume from error.
       flush_opts.allow_write_stall = true;
-      s = FlushAllColumnFamilies(flush_opts, FlushReason::kErrorRecovery);
+      s = FlushAllColumnFamilies(flush_opts, context.flush_reason);
     }
     if (!s.ok()) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -391,9 +391,10 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
   // all the column families
   if (s.ok()) {
     if (immutable_db_options_.atomic_flush) {
-      s = AtomicRetryFlushesForErrorRecovery(context.flush_reason);
+      s = AtomicRetryFlushesForErrorRecovery(context.flush_reason,
+                                             true /* wait */);
     } else {
-      s = RetryFlushesForErrorRecovery(context.flush_reason);
+      s = RetryFlushesForErrorRecovery(context.flush_reason, true /* wait */);
     }
     if (!s.ok()) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1950,6 +1950,7 @@ class DBImpl : public DB {
   Status RetryFlushesForErrorRecovery(FlushReason flush_reason);
   Status RetryFlushForErrorRecovery(ColumnFamilyData* cfd,
                                     FlushReason flush_reason);
+  Status AtomicRetryFlushesForErrorRecovery(FlushReason flush_reason);
 
   // Wait until flushing this column family won't stall writes
   Status WaitUntilFlushWouldNotStallWrites(ColumnFamilyData* cfd,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1947,6 +1947,7 @@ class DBImpl : public DB {
       const autovector<ColumnFamilyData*>& provided_candidate_cfds = {},
       bool entered_write_thread = false);
 
+  Status RetryFlushesForErrorRecovery();
   Status RetryFlushForErrorRecovery(ColumnFamilyData* cfd);
 
   // Wait until flushing this column family won't stall writes

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1948,12 +1948,6 @@ class DBImpl : public DB {
       bool entered_write_thread = false);
 
   Status RetryFlushesForErrorRecovery(FlushReason flush_reason, bool wait);
-  Status RetryNonAtomicFlushesForErrorRecovery(FlushReason flush_reason,
-                                               bool wait);
-  Status RetryNonAtomicFlushForErrorRecovery(ColumnFamilyData* cfd,
-                                             FlushReason flush_reason,
-                                             bool wait);
-  Status RetryAtomicFlushForErrorRecovery(FlushReason flush_reason, bool wait);
 
   // Wait until flushing this column family won't stall writes
   Status WaitUntilFlushWouldNotStallWrites(ColumnFamilyData* cfd,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1948,10 +1948,12 @@ class DBImpl : public DB {
       bool entered_write_thread = false);
 
   Status RetryFlushesForErrorRecovery(FlushReason flush_reason, bool wait);
-  Status RetryFlushForErrorRecovery(ColumnFamilyData* cfd,
-                                    FlushReason flush_reason, bool wait);
-  Status AtomicRetryFlushesForErrorRecovery(FlushReason flush_reason,
-                                            bool wait);
+  Status RetryNonAtomicFlushesForErrorRecovery(FlushReason flush_reason,
+                                               bool wait);
+  Status RetryNonAtomicFlushForErrorRecovery(ColumnFamilyData* cfd,
+                                             FlushReason flush_reason,
+                                             bool wait);
+  Status RetryAtomicFlushForErrorRecovery(FlushReason flush_reason, bool wait);
 
   // Wait until flushing this column family won't stall writes
   Status WaitUntilFlushWouldNotStallWrites(ColumnFamilyData* cfd,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1947,6 +1947,8 @@ class DBImpl : public DB {
       const autovector<ColumnFamilyData*>& provided_candidate_cfds = {},
       bool entered_write_thread = false);
 
+  Status RetryFlushForErrorRecovery(ColumnFamilyData* cfd);
+
   // Wait until flushing this column family won't stall writes
   Status WaitUntilFlushWouldNotStallWrites(ColumnFamilyData* cfd,
                                            bool* flush_needed);

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2097,6 +2097,12 @@ class DBImpl : public DB {
 #endif /* !NDEBUG */
   };
 
+  // In case of atomic flush, generates a `FlushRequest` for the latest atomic
+  // cuts for these `cfds`. Atomic cuts are recorded in
+  // `AssignAtomicFlushSeq()`. For each entry in `cfds`, all CFDs sharing the
+  // same latest atomic cut must also be present.
+  //
+  // REQUIRES: mutex held
   void GenerateFlushRequest(const autovector<ColumnFamilyData*>& cfds,
                             FlushReason flush_reason, FlushRequest* req);
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1947,8 +1947,9 @@ class DBImpl : public DB {
       const autovector<ColumnFamilyData*>& provided_candidate_cfds = {},
       bool entered_write_thread = false);
 
-  Status RetryFlushesForErrorRecovery();
-  Status RetryFlushForErrorRecovery(ColumnFamilyData* cfd);
+  Status RetryFlushesForErrorRecovery(FlushReason flush_reason);
+  Status RetryFlushForErrorRecovery(ColumnFamilyData* cfd,
+                                    FlushReason flush_reason);
 
   // Wait until flushing this column family won't stall writes
   Status WaitUntilFlushWouldNotStallWrites(ColumnFamilyData* cfd,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1947,10 +1947,11 @@ class DBImpl : public DB {
       const autovector<ColumnFamilyData*>& provided_candidate_cfds = {},
       bool entered_write_thread = false);
 
-  Status RetryFlushesForErrorRecovery(FlushReason flush_reason);
+  Status RetryFlushesForErrorRecovery(FlushReason flush_reason, bool wait);
   Status RetryFlushForErrorRecovery(ColumnFamilyData* cfd,
-                                    FlushReason flush_reason);
-  Status AtomicRetryFlushesForErrorRecovery(FlushReason flush_reason);
+                                    FlushReason flush_reason, bool wait);
+  Status AtomicRetryFlushesForErrorRecovery(FlushReason flush_reason,
+                                            bool wait);
 
   // Wait until flushing this column family won't stall writes
   Status WaitUntilFlushWouldNotStallWrites(ColumnFamilyData* cfd,

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2536,8 +2536,6 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
     AssignAtomicFlushSeq(cfds);
     GenerateFlushRequest(cfds, flush_reason, &flush_req);
     SchedulePendingFlush(flush_req);
-    MaybeScheduleFlushOrCompaction();
-
     for (auto& iter : flush_req.cfd_to_max_mem_id_to_persist) {
       flush_memtable_ids.push_back(iter.second);
     }
@@ -2559,10 +2557,10 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
                        uint64_t>::max() /* max_mem_id_to_persist */}}};
         cfd->imm()->FlushRequested();
         SchedulePendingFlush(flush_req);
-        MaybeScheduleFlushOrCompaction();
       }
     }
   }
+  MaybeScheduleFlushOrCompaction();
 
   Status s;
   if (wait) {

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2517,9 +2517,6 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
   assert(flush_reason == FlushReason::kErrorRecoveryRetryFlush ||
          flush_reason == FlushReason::kCatchUpAfterErrorRecovery);
   if (immutable_db_options_.atomic_flush) {
-    mutex_.AssertHeld();
-    assert(immutable_db_options_.atomic_flush);
-
     FlushRequest flush_req;
     autovector<ColumnFamilyData*> cfds;
     // Collect referenced CFDs with unflushed memtables. We trust that any
@@ -2557,8 +2554,6 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
     }
     return s;
   }
-  assert(!immutable_db_options_.atomic_flush);
-  mutex_.AssertHeld();
   Status status;
   for (auto cfd : versions_->GetRefedColumnFamilySet()) {
     if (cfd->IsDropped()) {

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2521,8 +2521,7 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
   assert(flush_reason == FlushReason::kErrorRecoveryRetryFlush ||
          flush_reason == FlushReason::kCatchUpAfterErrorRecovery);
 
-  // Collect referenced CFDs. In case of atomic flush, we trust that any
-  // unflushed immutable memtables were cut at a consistent point in time.
+  // Collect referenced CFDs.
   autovector<ColumnFamilyData*> cfds;
   for (ColumnFamilyData* cfd : *versions_->GetColumnFamilySet()) {
     if (!cfd->IsDropped() && cfd->initialized() &&
@@ -2540,7 +2539,6 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
   autovector<uint64_t> flush_memtable_ids;
   if (immutable_db_options_.atomic_flush) {
     FlushRequest flush_req;
-    AssignAtomicFlushSeq(cfds);
     GenerateFlushRequest(cfds, flush_reason, &flush_req);
     SchedulePendingFlush(flush_req);
     for (auto& iter : flush_req.cfd_to_max_mem_id_to_persist) {

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2528,6 +2528,9 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
     }
   }
 
+  // `flush_memtable_ids` will be populated such that all immutable
+  // memtables eligible for flush are waited on before this function
+  // returns.
   autovector<uint64_t> flush_memtable_ids;
   if (immutable_db_options_.atomic_flush) {
     FlushRequest flush_req;
@@ -2541,9 +2544,6 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
     }
   } else {
     for (auto cfd : cfds) {
-      // `flush_memtable_ids` will be populated such that all immutable
-      // memtables eligible for flush are waited on before this function
-      // returns.
       flush_memtable_ids.push_back(cfd->imm()->GetLatestMemTableID());
       if (cfd->imm()->NumNotFlushed() != 0) {
         // Some immutable memtables are not associated with a flush. Schedule

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2530,11 +2530,12 @@ Status DBImpl::AtomicFlushMemTables(
 
 Status DBImpl::RetryFlushForErrorRecovery(ColumnFamilyData* cfd) {
   // `memtable_id_to_wait` will be populated such that all immutable memtables
-  // eligible for flush are waited on before this function can return.
-  uint64_t memtable_id_to_wait = cfd->imm()->GetLatestMemTableID();
+  // eligible for flush are waited on before this function returns.
+  uint64_t memtable_id_to_wait;
 
   {
     InstrumentedMutexLock guard_lock(&mutex_);
+    memtable_id_to_wait = cfd->imm()->GetLatestMemTableID();
     if (cfd->imm()->NumNotFlushed() != 0) {
       // Some immutable memtables are not associated with a flush. Schedule one.
       //

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2517,13 +2517,46 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
   assert(flush_reason == FlushReason::kErrorRecoveryRetryFlush ||
          flush_reason == FlushReason::kCatchUpAfterErrorRecovery);
   if (immutable_db_options_.atomic_flush) {
-    return RetryAtomicFlushForErrorRecovery(flush_reason, wait);
-  }
-  return RetryNonAtomicFlushesForErrorRecovery(flush_reason, wait);
-}
+    mutex_.AssertHeld();
+    assert(immutable_db_options_.atomic_flush);
 
-Status DBImpl::RetryNonAtomicFlushesForErrorRecovery(FlushReason flush_reason,
-                                                     bool wait) {
+    FlushRequest flush_req;
+    autovector<ColumnFamilyData*> cfds;
+    // Collect referenced CFDs with unflushed memtables. We trust that any
+    // existing unflushed immutable memtables were cut at a consistent point in
+    // time.
+    for (ColumnFamilyData* cfd : *versions_->GetColumnFamilySet()) {
+      if (!cfd->IsDropped() && cfd->initialized() &&
+          cfd->imm()->NumNotFlushed() != 0) {
+        cfd->Ref();
+        cfd->imm()->FlushRequested();
+        cfds.push_back(cfd);
+      }
+    }
+
+    // Submit a flush request for all unflushed immutable memtables
+    AssignAtomicFlushSeq(cfds);
+    GenerateFlushRequest(cfds, flush_reason, &flush_req);
+    SchedulePendingFlush(flush_req);
+    MaybeScheduleFlushOrCompaction();
+
+    autovector<const uint64_t*> flush_memtable_ids;
+    for (auto& iter : flush_req.cfd_to_max_mem_id_to_persist) {
+      flush_memtable_ids.push_back(&(iter.second));
+    }
+
+    Status s;
+    if (wait) {
+      mutex_.Unlock();
+      s = WaitForFlushMemTables(cfds, flush_memtable_ids,
+                                true /* resuming_from_bg_err */);
+      mutex_.Lock();
+    }
+    for (auto* cfd : cfds) {
+      cfd->UnrefAndTryDelete();
+    }
+    return s;
+  }
   assert(!immutable_db_options_.atomic_flush);
   mutex_.AssertHeld();
   Status status;
@@ -2532,7 +2565,33 @@ Status DBImpl::RetryNonAtomicFlushesForErrorRecovery(FlushReason flush_reason,
       continue;
     }
     mutex_.Unlock();
-    status = RetryNonAtomicFlushForErrorRecovery(cfd, flush_reason, wait);
+    assert(!immutable_db_options_.atomic_flush);
+    // `memtable_id_to_wait` will be populated such that all immutable memtables
+    // eligible for flush are waited on before this function returns.
+    uint64_t memtable_id_to_wait;
+
+    {
+      InstrumentedMutexLock guard_lock(&mutex_);
+      memtable_id_to_wait = cfd->imm()->GetLatestMemTableID();
+      if (cfd->imm()->NumNotFlushed() != 0) {
+        // Some immutable memtables are not associated with a flush. Schedule
+        // one.
+        //
+        // Impose no bound on the highest memtable ID flushed. There is no
+        // reason to do so outside of atomic flush.
+        FlushRequest flush_req{
+            flush_reason,
+            {{cfd, std::numeric_limits<
+                       uint64_t>::max() /* max_mem_id_to_persist */}}};
+        cfd->imm()->FlushRequested();
+        SchedulePendingFlush(flush_req);
+        MaybeScheduleFlushOrCompaction();
+      }
+    }
+    if (wait) {
+      status = WaitForFlushMemTable(cfd, &memtable_id_to_wait,
+                                    true /* resuming_from_bg_err */);
+    }
     mutex_.Lock();
     if (!status.ok() && !status.IsColumnFamilyDropped()) {
       break;
@@ -2541,81 +2600,6 @@ Status DBImpl::RetryNonAtomicFlushesForErrorRecovery(FlushReason flush_reason,
     }
   }
   return status;
-}
-
-Status DBImpl::RetryNonAtomicFlushForErrorRecovery(ColumnFamilyData* cfd,
-                                                   FlushReason flush_reason,
-                                                   bool wait) {
-  assert(!immutable_db_options_.atomic_flush);
-  // `memtable_id_to_wait` will be populated such that all immutable memtables
-  // eligible for flush are waited on before this function returns.
-  uint64_t memtable_id_to_wait;
-
-  {
-    InstrumentedMutexLock guard_lock(&mutex_);
-    memtable_id_to_wait = cfd->imm()->GetLatestMemTableID();
-    if (cfd->imm()->NumNotFlushed() != 0) {
-      // Some immutable memtables are not associated with a flush. Schedule one.
-      //
-      // Impose no bound on the highest memtable ID flushed. There is no reason
-      // to do so outside of atomic flush.
-      FlushRequest flush_req{
-          flush_reason,
-          {{cfd,
-            std::numeric_limits<uint64_t>::max() /* max_mem_id_to_persist */}}};
-      cfd->imm()->FlushRequested();
-      SchedulePendingFlush(flush_req);
-      MaybeScheduleFlushOrCompaction();
-    }
-  }
-  if (wait) {
-    return WaitForFlushMemTable(cfd, &memtable_id_to_wait,
-                                true /* resuming_from_bg_err */);
-  }
-  return Status::OK();
-}
-
-Status DBImpl::RetryAtomicFlushForErrorRecovery(FlushReason flush_reason,
-                                                bool wait) {
-  mutex_.AssertHeld();
-  assert(immutable_db_options_.atomic_flush);
-
-  FlushRequest flush_req;
-  autovector<ColumnFamilyData*> cfds;
-  // Collect referenced CFDs with unflushed memtables. We trust that any
-  // existing unflushed immutable memtables were cut at a consistent point in
-  // time.
-  for (ColumnFamilyData* cfd : *versions_->GetColumnFamilySet()) {
-    if (!cfd->IsDropped() && cfd->initialized() &&
-        cfd->imm()->NumNotFlushed() != 0) {
-      cfd->Ref();
-      cfd->imm()->FlushRequested();
-      cfds.push_back(cfd);
-    }
-  }
-
-  // Submit a flush request for all unflushed immutable memtables
-  AssignAtomicFlushSeq(cfds);
-  GenerateFlushRequest(cfds, flush_reason, &flush_req);
-  SchedulePendingFlush(flush_req);
-  MaybeScheduleFlushOrCompaction();
-
-  autovector<const uint64_t*> flush_memtable_ids;
-  for (auto& iter : flush_req.cfd_to_max_mem_id_to_persist) {
-    flush_memtable_ids.push_back(&(iter.second));
-  }
-
-  Status s;
-  if (wait) {
-    mutex_.Unlock();
-    s = WaitForFlushMemTables(cfds, flush_memtable_ids,
-                              true /* resuming_from_bg_err */);
-    mutex_.Lock();
-  }
-  for (auto* cfd : cfds) {
-    cfd->UnrefAndTryDelete();
-  }
-  return s;
 }
 
 // Calling FlushMemTable(), whether from DB::Flush() or from Backup Engine, can

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2517,13 +2517,11 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
   assert(flush_reason == FlushReason::kErrorRecoveryRetryFlush ||
          flush_reason == FlushReason::kCatchUpAfterErrorRecovery);
 
-  // Collect referenced CFDs with unflushed memtables. In case of atomic flush,
-  // we trust that any existing unflushed immutable memtables were cut at a
-  // consistent point in time.
+  // Collect referenced CFDs. In case of atomic flush, we trust that any
+  // unflushed immutable memtables were cut at a consistent point in time.
   autovector<ColumnFamilyData*> cfds;
   for (ColumnFamilyData* cfd : *versions_->GetColumnFamilySet()) {
-    if (!cfd->IsDropped() && cfd->initialized() &&
-        cfd->imm()->NumNotFlushed() != 0) {
+    if (!cfd->IsDropped() && cfd->initialized()) {
       cfd->Ref();
       cfd->imm()->FlushRequested();
       cfds.push_back(cfd);

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2360,8 +2360,8 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
       cfds.push_back(flush_reqs[i].cfd_to_max_mem_id_to_persist.begin()->first);
       flush_memtable_ids.push_back(&(memtable_ids_to_wait[i]));
     }
-    s = WaitForFlushMemTables(
-        cfds, flush_memtable_ids, false /* resuming_from_bg_err */);
+    s = WaitForFlushMemTables(cfds, flush_memtable_ids,
+                              false /* resuming_from_bg_err */);
     InstrumentedMutexLock lock_guard(&mutex_);
     for (auto* tmp_cfd : cfds) {
       tmp_cfd->UnrefAndTryDelete();
@@ -2499,8 +2499,8 @@ Status DBImpl::AtomicFlushMemTables(
     for (auto& iter : flush_req.cfd_to_max_mem_id_to_persist) {
       flush_memtable_ids.push_back(&(iter.second));
     }
-    s = WaitForFlushMemTables(
-        cfds, flush_memtable_ids, false /* resuming_from_bg_err */);
+    s = WaitForFlushMemTables(cfds, flush_memtable_ids,
+                              false /* resuming_from_bg_err */);
     InstrumentedMutexLock lock_guard(&mutex_);
     for (auto* cfd : cfds) {
       cfd->UnrefAndTryDelete();

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2551,7 +2551,6 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
             flush_reason,
             {{cfd, std::numeric_limits<
                        uint64_t>::max() /* max_mem_id_to_persist */}}};
-        cfd->imm()->FlushRequested();
         SchedulePendingFlush(flush_req);
       }
     }
@@ -2569,6 +2568,7 @@ Status DBImpl::RetryFlushesForErrorRecovery(FlushReason flush_reason,
                               true /* resuming_from_bg_err */);
     mutex_.Lock();
   }
+
   for (auto* cfd : cfds) {
     cfd->UnrefAndTryDelete();
   }

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -457,7 +457,8 @@ TEST_F(FlushJobTest, FlushMemtablesMultipleColumnFamilies) {
     // Verify that imm is empty
     ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
               all_cfds[k]->imm()->GetEarliestMemTableID());
-    ASSERT_EQ(0, all_cfds[k]->imm()->GetLatestMemTableID());
+    ASSERT_EQ(0, all_cfds[k]->imm()->GetLatestMemTableID(
+                     false /* for_atomic_flush */));
     ++k;
   }
 

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -833,7 +833,7 @@ TEST_F(MemTableListTest, FlushPendingTest) {
   // Add another table
   list.Add(tables[5], &to_delete);
   ASSERT_EQ(1, list.NumNotFlushed());
-  ASSERT_EQ(5, list.GetLatestMemTableID());
+  ASSERT_EQ(5, list.GetLatestMemTableID(false /* for_atomic_flush */));
   memtable_id = 4;
   // Pick tables to flush. The tables to pick must have ID smaller than or
   // equal to 4. Therefore, no table will be selected in this case.


### PR DESCRIPTION
Recovery triggers flushes for very different scenarios:

(1) `FlushReason::kErrorRecoveryRetryFlush`: a flush failed
(2) `FlushReason::kErrorRecovery`: a WAL may be corrupted
(3) `FlushReason::kCatchUpAfterErrorRecovery`: immutable memtables may have accumulated

The old code called called `FlushAllColumnFamilies()` in all cases, which uses manual flush functions: `AtomicFlushMemTables()` and `FlushMemTable()`. Forcing flushing the latest data on all CFs was useful for (2) because it ensures all CFs move past the corrupted WAL.

However, those code paths were overkill for (1) and (3), where only already-immutable memtables need to be flushed. There were conditionals to exclude some of the extraneous logic but I found there was still too much happening. For example, both of the manual flush functions enter the write thread. Entering the write thread is inconvenient because then we can't allow stalled writes to wait on a retrying flush to finish.

Instead of continuing down the path of adding more conditionals to the manual flush functions, this PR introduces a dedicated function for cases (1) and (3): `RetryFlushesForErrorRecovery()`. Also I cleaned up the manual flush functions to remove existing conditionals for these cases as they're no longer needed.