### PR TITLE
Lazy load java native library

### DIFF
--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -18,9 +18,6 @@ import java.util.*;
 public class ColumnFamilyOptions extends RocksObject
     implements ColumnFamilyOptionsInterface<ColumnFamilyOptions>,
     MutableColumnFamilyOptionsInterface<ColumnFamilyOptions> {
-  static {
-    RocksDB.loadLibrary();
-  }
 
   /**
    * Construct ColumnFamilyOptions.
@@ -29,7 +26,7 @@ public class ColumnFamilyOptions extends RocksObject
    * an {@code rocksdb::ColumnFamilyOptions} in the c++ side.
    */
   public ColumnFamilyOptions() {
-    super(newColumnFamilyOptions());
+    super(newColumnFamilyOptionsInstance());
   }
 
   /**
@@ -1333,6 +1330,10 @@ public class ColumnFamilyOptions extends RocksObject
       final long cfgHandle, String optString);
   private static native long getColumnFamilyOptionsFromProps(final String optString);
 
+  private static long newColumnFamilyOptionsInstance() {
+    RocksDB.loadLibrary();
+    return newColumnFamilyOptions();
+  }
   private static native long newColumnFamilyOptions();
   private static native long copyColumnFamilyOptions(final long handle);
   private static native long newColumnFamilyOptionsFromOptions(

--- a/java/src/main/java/org/rocksdb/ConfigOptions.java
+++ b/java/src/main/java/org/rocksdb/ConfigOptions.java
@@ -7,15 +7,12 @@
 package org.rocksdb;
 
 public class ConfigOptions extends RocksObject {
-  static {
-    RocksDB.loadLibrary();
-  }
 
   /**
    * Construct with default Options
    */
   public ConfigOptions() {
-    super(newConfigOptions());
+    super(newConfigOptionsInstance());
   }
 
   public ConfigOptions setDelimiter(final String delimiter) {
@@ -44,6 +41,10 @@ public class ConfigOptions extends RocksObject {
 
   @Override protected final native void disposeInternal(final long handle);
 
+  private static long newConfigOptionsInstance() {
+    RocksDB.loadLibrary();
+    return newConfigOptions();
+  }
   private static native long newConfigOptions();
   private static native void setEnv(final long handle, final long envHandle);
   private static native void setDelimiter(final long handle, final String delimiter);

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -18,9 +18,6 @@ import java.util.*;
 public class DBOptions extends RocksObject
     implements DBOptionsInterface<DBOptions>,
     MutableDBOptionsInterface<DBOptions> {
-  static {
-    RocksDB.loadLibrary();
-  }
 
   /**
    * Construct DBOptions.
@@ -29,7 +26,7 @@ public class DBOptions extends RocksObject
    * an {@code rocksdb::DBOptions} in the c++ side.
    */
   public DBOptions() {
-    super(newDBOptions());
+    super(newDBOptionsInstance());
     numShardBits_ = DEFAULT_NUM_SHARD_BITS;
     env_ = Env.getDefault();
   }
@@ -1253,7 +1250,12 @@ public class DBOptions extends RocksObject
   private static native long getDBOptionsFromProps(long cfgHandle, String optString);
   private static native long getDBOptionsFromProps(String optString);
 
+  private static long newDBOptionsInstance() {
+    RocksDB.loadLibrary();
+    return newDBOptions();
+  }
   private static native long newDBOptions();
+
   private static native long copyDBOptions(final long handle);
   private static native long newDBOptionsFromOptions(final long optionsHandle);
   @Override protected final native void disposeInternal(final long handle);

--- a/java/src/main/java/org/rocksdb/Env.java
+++ b/java/src/main/java/org/rocksdb/Env.java
@@ -7,25 +7,13 @@ package org.rocksdb;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Base class for all Env implementations in RocksDB.
  */
 public abstract class Env extends RocksObject {
-
-  static {
-    RocksDB.loadLibrary();
-  }
-
-  private static final Env DEFAULT_ENV = new RocksEnv(getDefaultEnvInternal());
-  static {
-    /*
-     * The Ownership of the Default Env belongs to C++
-     * and so we disown the native handle here so that
-     * we cannot accidentally free it from Java.
-     */
-    DEFAULT_ENV.disOwnNativeHandle();
-  }
+  private static final AtomicReference<RocksEnv> SINGULAR_DEFAULT_ENV = new AtomicReference<>(null);
 
   /**
    * <p>Returns the default environment suitable for the current operating
@@ -39,7 +27,30 @@ public abstract class Env extends RocksObject {
    * @return the default {@link org.rocksdb.RocksEnv} instance.
    */
   public static Env getDefault() {
-    return DEFAULT_ENV;
+    RocksEnv defaultEnv = null;
+    RocksEnv newDefaultEnv = null;
+
+    while ((defaultEnv = SINGULAR_DEFAULT_ENV.get()) == null) {
+      // construct the RocksEnv only once in this thread
+      if (newDefaultEnv == null) {
+        // load the library just in-case it isn't already loaded!
+        RocksDB.loadLibrary();
+
+        newDefaultEnv = new RocksEnv(getDefaultEnvInternal());
+
+        /*
+         * The Ownership of the Default Env belongs to C++
+         *  and so we disown the native handle here so that
+         * we cannot accidentally free it from Java.
+         */
+        newDefaultEnv.disOwnNativeHandle();
+      }
+
+      // use CAS to gracefully handle thread pre-emption
+      SINGULAR_DEFAULT_ENV.compareAndSet(null, newDefaultEnv);
+    }
+
+    return defaultEnv;
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/EnvOptions.java
+++ b/java/src/main/java/org/rocksdb/EnvOptions.java
@@ -9,15 +9,11 @@ package org.rocksdb;
  * Options while opening a file to read/write
  */
 public class EnvOptions extends RocksObject {
-  static {
-    RocksDB.loadLibrary();
-  }
-
   /**
    * Construct with default Options
    */
   public EnvOptions() {
-    super(newEnvOptions());
+    super(newEnvOptionsInstance());
   }
 
   /**
@@ -323,6 +319,10 @@ public class EnvOptions extends RocksObject {
     return rateLimiter;
   }
 
+  private static long newEnvOptionsInstance() {
+    RocksDB.loadLibrary();
+    return newEnvOptions();
+  }
   private static native long newEnvOptions();
   private static native long newEnvOptions(final long dboptions_handle);
   @Override protected final native void disposeInternal(final long handle);

--- a/java/src/main/java/org/rocksdb/FlushOptions.java
+++ b/java/src/main/java/org/rocksdb/FlushOptions.java
@@ -10,15 +10,11 @@ package org.rocksdb;
  * {@link org.rocksdb.RocksDB}.
  */
 public class FlushOptions extends RocksObject {
-  static {
-    RocksDB.loadLibrary();
-  }
-
   /**
    * Construct a new instance of FlushOptions.
    */
   public FlushOptions(){
-    super(newFlushOptions());
+    super(newFlushOptionsInance());
   }
 
   /**
@@ -77,7 +73,10 @@ public class FlushOptions extends RocksObject {
     assert(isOwningHandle());
     return allowWriteStall(nativeHandle_);
   }
-
+  private static long newFlushOptionsInance() {
+    RocksDB.loadLibrary();
+    return newFlushOptions();
+  }
   private static native long newFlushOptions();
   @Override protected final native void disposeInternal(final long handle);
 

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -20,9 +20,6 @@ public class Options extends RocksObject
     MutableDBOptionsInterface<Options>,
     ColumnFamilyOptionsInterface<Options>,
     MutableColumnFamilyOptionsInterface<Options> {
-  static {
-    RocksDB.loadLibrary();
-  }
 
   /**
    * Converts the input properties into a Options-style formatted string
@@ -50,7 +47,7 @@ public class Options extends RocksObject
    * an {@code rocksdb::Options} in the c++ side.
    */
   public Options() {
-    super(newOptions());
+    super(newOptionsInstance());
     env_ = Env.getDefault();
   }
 
@@ -2129,6 +2126,10 @@ public class Options extends RocksObject
   // END options for blobs (integrated BlobDB)
   //
 
+  private static long newOptionsInstance() {
+    RocksDB.loadLibrary();
+    return newOptions();
+  }
   private static native long newOptions();
   private static native long newOptions(long dbOptHandle, long cfOptHandle);
   private static native long copyOptions(long handle);

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -31,11 +31,6 @@ public class RocksDB extends RocksObject {
 
   private static final AtomicReference<LibraryState> libraryLoaded =
       new AtomicReference<>(LibraryState.NOT_LOADED);
-
-  static {
-    RocksDB.loadLibrary();
-  }
-
   private final List<ColumnFamilyHandle> ownedColumnFamilyHandles = new ArrayList<>();
 
   /**
@@ -175,6 +170,7 @@ public class RocksDB extends RocksObject {
    * @see Options#setCreateIfMissing(boolean)
    */
   public static RocksDB open(final String path) throws RocksDBException {
+    RocksDB.loadLibrary();
     final Options options = new Options();
     options.setCreateIfMissing(true);
     return open(options, path);
@@ -330,6 +326,7 @@ public class RocksDB extends RocksObject {
    */
   public static RocksDB openReadOnly(final String path)
       throws RocksDBException {
+    RocksDB.loadLibrary();
     // This allows to use the rocksjni default Options instead of
     // the c++ one.
     final Options options = new Options();

--- a/java/src/main/java/org/rocksdb/SstFileReader.java
+++ b/java/src/main/java/org/rocksdb/SstFileReader.java
@@ -6,9 +6,6 @@
 package org.rocksdb;
 
 public class SstFileReader extends RocksObject {
-  static {
-    RocksDB.loadLibrary();
-  }
 
   public SstFileReader(final Options options) {
     super(newSstFileReader(options.nativeHandle_));

--- a/java/src/main/java/org/rocksdb/SstFileWriter.java
+++ b/java/src/main/java/org/rocksdb/SstFileWriter.java
@@ -13,9 +13,6 @@ import java.nio.ByteBuffer;
  * sequence number = 0.
  */
 public class SstFileWriter extends RocksObject {
-  static {
-    RocksDB.loadLibrary();
-  }
 
   /**
    * SstFileWriter Constructor.

--- a/java/src/main/java/org/rocksdb/WriteBufferManager.java
+++ b/java/src/main/java/org/rocksdb/WriteBufferManager.java
@@ -38,7 +38,7 @@ public class WriteBufferManager extends RocksObject {
   }
 
   private static long newWriteBufferManagerInstance(
-          final long bufferSizeBytes, final long cacheHandle, final boolean allowStall) {
+      final long bufferSizeBytes, final long cacheHandle, final boolean allowStall) {
     RocksDB.loadLibrary();
     return newWriteBufferManager(bufferSizeBytes, cacheHandle, allowStall);
   }

--- a/java/src/main/java/org/rocksdb/WriteBufferManager.java
+++ b/java/src/main/java/org/rocksdb/WriteBufferManager.java
@@ -9,9 +9,6 @@ package org.rocksdb;
  * Java wrapper over native write_buffer_manager class
  */
 public class WriteBufferManager extends RocksObject {
-  static {
-    RocksDB.loadLibrary();
-  }
 
   /**
    * Construct a new instance of WriteBufferManager.
@@ -28,7 +25,7 @@ public class WriteBufferManager extends RocksObject {
    */
   public WriteBufferManager(
       final long bufferSizeBytes, final Cache cache, final boolean allowStall) {
-    super(newWriteBufferManager(bufferSizeBytes, cache.nativeHandle_, allowStall));
+    super(newWriteBufferManagerInstance(bufferSizeBytes, cache.nativeHandle_, allowStall));
     this.allowStall_ = allowStall;
   }
 
@@ -40,6 +37,11 @@ public class WriteBufferManager extends RocksObject {
     return allowStall_;
   }
 
+  private static long newWriteBufferManagerInstance(
+          final long bufferSizeBytes, final long cacheHandle, final boolean allowStall) {
+    RocksDB.loadLibrary();
+    return newWriteBufferManager(bufferSizeBytes, cacheHandle, allowStall);
+  }
   private static native long newWriteBufferManager(
       final long bufferSizeBytes, final long cacheHandle, final boolean allowStall);
 


### PR DESCRIPTION
This address #11277. Java native library is not anymore loaded until the code is first used.
It should allow to manually load native library from different location with `RocksDB#loadLibrary(List<java.lang.String>)`