### PR TITLE
Bootstrap, pre-populate seqno_to_time_mapping

### DIFF
--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -1254,14 +1254,6 @@ TEST_F(PrecludeLastLevelTest, MigrationFromPreserveTimeManualCompaction) {
   options.num_levels = kNumLevels;
   DestroyAndReopen(options);
 
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kKeyPerSec)); });
-
   int sst_num = 0;
   // Write files that are overlap and enough to trigger compaction
   for (; sst_num < kNumTrigger; sst_num++) {
@@ -1318,14 +1310,6 @@ TEST_F(PrecludeLastLevelTest, MigrationFromPreserveTimeAutoCompaction) {
   options.level0_file_num_compaction_trigger = kNumTrigger;
   options.num_levels = kNumLevels;
   DestroyAndReopen(options);
-
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kKeyPerSec)); });
 
   int sst_num = 0;
   // Write files that are overlap and enough to trigger compaction
@@ -1397,14 +1381,6 @@ TEST_F(PrecludeLastLevelTest, MigrationFromPreserveTimePartial) {
   options.level0_file_num_compaction_trigger = kNumTrigger;
   options.num_levels = kNumLevels;
   DestroyAndReopen(options);
-
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kKeyPerSec)); });
 
   int sst_num = 0;
   // Write files that are overlap and enough to trigger compaction
@@ -1528,14 +1504,6 @@ TEST_F(PrecludeLastLevelTest, LastLevelOnlyCompactionPartial) {
   options.num_levels = kNumLevels;
   DestroyAndReopen(options);
 
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kKeyPerSec)); });
-
   int sst_num = 0;
   // Write files that are overlap and enough to trigger compaction
   for (; sst_num < kNumTrigger; sst_num++) {
@@ -1608,14 +1576,6 @@ TEST_P(PrecludeLastLevelTestWithParms, LastLevelOnlyCompactionNoPreclude) {
   options.level0_file_num_compaction_trigger = kNumTrigger;
   options.num_levels = kNumLevels;
   DestroyAndReopen(options);
-
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kKeyPerSec)); });
 
   Random rnd(301);
   int sst_num = 0;
@@ -1926,14 +1886,6 @@ TEST_F(PrecludeLastLevelTest, PartialPenultimateLevelCompaction) {
   options.num_levels = kNumLevels;
   DestroyAndReopen(options);
 
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(10)); });
-
   Random rnd(301);
 
   for (int i = 0; i < 300; i++) {
@@ -2045,15 +1997,6 @@ TEST_F(PrecludeLastLevelTest, DISABLED_RangeDelsCauseFileEndpointsToOverlap) {
   options.num_levels = kNumLevels;
   options.target_file_size_base = kFileBytes;
   DestroyAndReopen(options);
-
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun([&] {
-    mock_clock_->MockSleepForSeconds(static_cast<int>(kSecondsPerKey));
-  });
 
   // Flush an L0 file with the following contents (new to old):
   //

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -273,8 +273,9 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
   periodic_task_functions_.emplace(PeriodicTaskType::kFlushInfoLog,
                                    [this]() { this->FlushInfoLog(); });
   periodic_task_functions_.emplace(
-      PeriodicTaskType::kRecordSeqnoTime,
-      [this]() { this->RecordSeqnoToTimeMapping(); });
+      PeriodicTaskType::kRecordSeqnoTime, [this]() {
+        this->RecordSeqnoToTimeMapping(/*populate_historical_seconds=*/0);
+      });
 
   versions_.reset(new VersionSet(dbname_, &immutable_db_options_, file_options_,
                                  table_cache_.get(), write_buffer_manager_,
@@ -815,7 +816,7 @@ Status DBImpl::StartPeriodicTaskScheduler() {
   return s;
 }
 
-Status DBImpl::RegisterRecordSeqnoTimeWorker() {
+Status DBImpl::RegisterRecordSeqnoTimeWorker(bool from_db_open) {
   uint64_t min_preserve_seconds = std::numeric_limits<uint64_t>::max();
   uint64_t max_preserve_seconds = std::numeric_limits<uint64_t>::min();
   {
@@ -837,6 +838,11 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
       seqno_to_time_mapping_.Resize(min_preserve_seconds, max_preserve_seconds);
     }
   }
+  // FIXME: because we released the db mutex, there's a race here where
+  // if e.g. I create or drop two column families in parallel, I might end up
+  // with the periodic task scheduler in the wrong state. We don't want to
+  // just keep holding the mutex, however, because of global timer and mutex
+  // in PeriodicTaskScheduler.
 
   uint64_t seqno_time_cadence = 0;
   if (min_preserve_seconds != std::numeric_limits<uint64_t>::max()) {
@@ -851,6 +857,37 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker() {
   if (seqno_time_cadence == 0) {
     s = periodic_task_scheduler_.Unregister(PeriodicTaskType::kRecordSeqnoTime);
   } else {
+    if (GetLatestSequenceNumber() == 0) {
+      // New DB. First, we don't want to leave latest seqno as 0 so that we
+      // can properly check in RecordSeqnoToTimeMapping that we aren't
+      // recording bad records (e.g. in a read-only DB). Second, to support
+      // data import with an older write time, we pre-allocate some sequence
+      // numbers pre-mapped over the time period we care about. But we can
+      // only do the second one predictably if called from DB::Open(),
+      // otherwise there could be a race between CreateColumnFamily and the
+      // first Write to the DB that determines whether the sequence numbers
+      // are pre-allocated.
+      assert(seqno_to_time_mapping_.Empty());
+
+      if (from_db_open) {
+        // We can simply modify these, before writes are allowed
+        constexpr uint64_t kMax = SeqnoToTimeMapping::kMaxSeqnoTimePairsPerSST;
+        versions_->SetLastAllocatedSequence(kMax);
+        versions_->SetLastPublishedSequence(kMax);
+        versions_->SetLastSequence(kMax);
+        // Pre-populate mappings for reserved sequence numbers.
+        RecordSeqnoToTimeMapping(max_preserve_seconds);
+      } else {
+        // To ensure there is at least one mapping, we need a non-zero sequence
+        // number. Outside of DB::Open, we have to be careful.
+        versions_->EnsureNonZeroSequence();
+        assert(GetLatestSequenceNumber() > 0);
+
+        // Ensure at least one mapping (or log a warning)
+        RecordSeqnoToTimeMapping(/*populate_historical_seconds=*/0);
+      }
+    }
+
     s = periodic_task_scheduler_.Register(
         PeriodicTaskType::kRecordSeqnoTime,
         periodic_task_functions_.at(PeriodicTaskType::kRecordSeqnoTime),
@@ -3312,7 +3349,7 @@ Status DBImpl::WrapUpCreateColumnFamilies(
   Status s = WriteOptionsFile(true /*need_mutex_lock*/,
                               true /*need_enter_write_thread*/);
   if (register_worker) {
-    s.UpdateIfOk(RegisterRecordSeqnoTimeWorker());
+    s.UpdateIfOk(RegisterRecordSeqnoTimeWorker(/*from_db_open=*/false));
   }
   return s;
 }
@@ -3555,7 +3592,7 @@ Status DBImpl::DropColumnFamilyImpl(ColumnFamilyHandle* column_family) {
 
   if (cfd->ioptions()->preserve_internal_time_seconds > 0 ||
       cfd->ioptions()->preclude_last_level_data_seconds > 0) {
-    s = RegisterRecordSeqnoTimeWorker();
+    s = RegisterRecordSeqnoTimeWorker(/*from_db_open=*/false);
   }
 
   if (s.ok()) {
@@ -6383,21 +6420,51 @@ Status DBImpl::GetCreationTimeOfOldestFile(uint64_t* creation_time) {
   }
 }
 
-void DBImpl::RecordSeqnoToTimeMapping() {
+void DBImpl::RecordSeqnoToTimeMapping(uint64_t populate_historical_seconds) {
   // TECHNICALITY: Sample last sequence number *before* time, as prescribed
-  // for SeqnoToTimeMapping
+  // for SeqnoToTimeMapping. We don't know how long it has been since the last
+  // sequence number was written, so we at least have a one-sided bound by
+  // sampling in this order.
   SequenceNumber seqno = GetLatestSequenceNumber();
-  // Get time first then sequence number, so the actual time of seqno is <=
-  // unix_time recorded
-  int64_t unix_time = 0;
-  immutable_db_options_.clock->GetCurrentTime(&unix_time)
+  int64_t unix_time_signed = 0;
+  immutable_db_options_.clock->GetCurrentTime(&unix_time_signed)
       .PermitUncheckedError();  // Ignore error
+  uint64_t unix_time = static_cast<uint64_t>(unix_time_signed);
   bool appended = false;
   {
     InstrumentedMutexLock l(&mutex_);
-    appended = seqno_to_time_mapping_.Append(seqno, unix_time);
+    if (populate_historical_seconds > 0) {
+      if (seqno > 1 && unix_time > populate_historical_seconds) {
+        // seqno=0 is reserved
+        SequenceNumber from_seqno = 1;
+        appended = seqno_to_time_mapping_.PrePopulate(
+            from_seqno, seqno, unix_time - populate_historical_seconds,
+            unix_time);
+      } else {
+        // One of these will fail
+        assert(seqno > 1);
+        assert(unix_time > populate_historical_seconds);
+      }
+    } else {
+      assert(seqno > 0);
+      appended = seqno_to_time_mapping_.Append(seqno, unix_time);
+    }
   }
-  if (!appended) {
+  if (populate_historical_seconds > 0) {
+    if (appended) {
+      ROCKS_LOG_INFO(
+          immutable_db_options_.info_log,
+          "Pre-populated sequence number to time entries: [1,%" PRIu64
+          "] -> [%" PRIu64 ",%" PRIu64 "]",
+          seqno, unix_time - populate_historical_seconds, unix_time);
+    } else {
+      ROCKS_LOG_WARN(
+          immutable_db_options_.info_log,
+          "Failed to pre-populate sequence number to time entries: [1,%" PRIu64
+          "] -> [%" PRIu64 ",%" PRIu64 "]",
+          seqno, unix_time - populate_historical_seconds, unix_time);
+    }
+  } else if (!appended) {
     ROCKS_LOG_WARN(immutable_db_options_.info_log,
                    "Failed to insert sequence number to time entry: %" PRIu64
                    " -> %" PRIu64,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1212,8 +1212,11 @@ class DBImpl : public DB {
   // flush LOG out of application buffer
   void FlushInfoLog();
 
-  // record current sequence number to time mapping
-  void RecordSeqnoToTimeMapping();
+  // record current sequence number to time mapping. If
+  // populate_historical_seconds > 0 then pre-populate all the
+  // sequence numbers from [1, last] to map to [now minus
+  // populate_historical_seconds, now].
+  void RecordSeqnoToTimeMapping(uint64_t populate_historical_seconds);
 
   // Interface to block and signal the DB in case of stalling writes by
   // WriteBufferManager. Each DBImpl object contains ptr to WBMStallInterface.
@@ -2163,7 +2166,7 @@ class DBImpl : public DB {
   // Cancel scheduled periodic tasks
   Status CancelPeriodicTaskScheduler();
 
-  Status RegisterRecordSeqnoTimeWorker();
+  Status RegisterRecordSeqnoTimeWorker(bool from_db_open);
 
   void PrintStatistics();
 

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -2247,7 +2247,7 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
   }
 
   if (s.ok()) {
-    s = impl->RegisterRecordSeqnoTimeWorker();
+    s = impl->RegisterRecordSeqnoTimeWorker(/*from_db_open=*/true);
   }
   if (!s.ok()) {
     for (auto* h : *handles) {

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -82,14 +82,6 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
   options.num_levels = kNumLevels;
   DestroyAndReopen(options);
 
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(kKeyPerSec)); });
-
   int sst_num = 0;
   // Write files that are overlap and enough to trigger compaction
   for (; sst_num < kNumTrigger; sst_num++) {
@@ -196,14 +188,6 @@ TEST_F(SeqnoTimeTest, TemperatureBasicLevel) {
   //  to last level, which will keep triggering compaction.
   options.disable_auto_compactions = true;
   DestroyAndReopen(options);
-
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(10)); });
 
   int sst_num = 0;
   // Write files that are overlap
@@ -330,14 +314,6 @@ TEST_P(SeqnoTimeTablePropTest, BasicSeqnoToTimeMapping) {
   options.disable_auto_compactions = true;
   DestroyAndReopen(options);
 
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(100)); });
-
   std::set<uint64_t> checked_file_nums;
   SequenceNumber start_seq = dbfull()->GetLatestSequenceNumber() + 1;
   uint64_t start_time = mock_clock_->NowSeconds();
@@ -359,9 +335,9 @@ TEST_P(SeqnoTimeTablePropTest, BasicSeqnoToTimeMapping) {
   ASSERT_FALSE(tp_mapping.Empty());
   auto seqs = tp_mapping.TEST_GetInternalMapping();
   // about ~20 seqs->time entries, because the sample rate is 10000/100, and it
-  // passes 2k time.
-  ASSERT_GE(seqs.size(), 19);
-  ASSERT_LE(seqs.size(), 21);
+  // passes 2k time. Add (roughly) one for starting entry.
+  ASSERT_GE(seqs.size(), 20);
+  ASSERT_LE(seqs.size(), 22);
   SequenceNumber seq_end = dbfull()->GetLatestSequenceNumber() + 1;
   for (auto i = start_seq; i < seq_end; i++) {
     // The result is within the range
@@ -721,14 +697,6 @@ TEST_P(SeqnoTimeTablePropTest, SeqnoToTimeMappingUniversal) {
 
   DestroyAndReopen(options);
 
-  // bootstrap DB sequence numbers (FIXME: make these steps unnecessary)
-  ASSERT_OK(Put("foo", "bar"));
-  ASSERT_OK(SingleDelete("foo"));
-  // pass some time first, otherwise the first a few keys write time are going
-  // to be zero, and internally zero has special meaning: kUnknownTimeBeforeAll
-  dbfull()->TEST_WaitForPeriodicTaskRun(
-      [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(10)); });
-
   std::atomic_uint64_t num_seqno_zeroing{0};
 
   SyncPoint::GetInstance()->DisableProcessing();
@@ -757,8 +725,9 @@ TEST_P(SeqnoTimeTablePropTest, SeqnoToTimeMappingUniversal) {
     ASSERT_OK(tp_mapping.Sort());
     ASSERT_FALSE(tp_mapping.Empty());
     auto seqs = tp_mapping.TEST_GetInternalMapping();
-    ASSERT_GE(seqs.size(), 10 - 1);
-    ASSERT_LE(seqs.size(), 10 + 1);
+    // Add (roughly) one for starting entry.
+    ASSERT_GE(seqs.size(), 10);
+    ASSERT_LE(seqs.size(), 10 + 2);
   }
 
   // Trigger a compaction
@@ -844,6 +813,131 @@ TEST_P(SeqnoTimeTablePropTest, SeqnoToTimeMappingUniversal) {
 
   ASSERT_GT(num_seqno_zeroing, 0);
   ASSERT_GT(NumTableFilesAtLevel(6), 0);
+
+  Close();
+}
+
+TEST_P(SeqnoTimeTablePropTest, PrePopulateInDB) {
+  Options base_options = CurrentOptions();
+  base_options.env = mock_env_.get();
+  base_options.disable_auto_compactions = true;
+  base_options.create_missing_column_families = true;
+  DestroyAndReopen(base_options);
+
+  // #### DB#1: No pre-population nor entries without preserve/preclude ####
+  SeqnoToTimeMapping sttm = dbfull()->TEST_GetSeqnoToTimeMapping();
+  ASSERT_TRUE(sttm.Empty());
+  ASSERT_EQ(db_->GetLatestSequenceNumber(), 0U);
+
+  // Unfortunately, if we add a CF with preserve/preclude option after
+  // open, that does not reserve seqnos with pre-populated time mappings.
+  Options options = base_options;
+  constexpr uint32_t kPreserveSecs = 1234567;
+  SetTrackTimeDurationOptions(kPreserveSecs, options);
+  CreateColumnFamilies({"one"}, options);
+
+  // No pre-population (unfortunately), just a single starting entry
+  sttm = dbfull()->TEST_GetSeqnoToTimeMapping();
+  SequenceNumber latest_seqno = db_->GetLatestSequenceNumber();
+  uint64_t start_time = mock_clock_->NowSeconds();
+  ASSERT_EQ(sttm.Size(), 1);
+  ASSERT_EQ(latest_seqno, 1U);
+  // Current time maps to starting entry / seqno
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time), 1U);
+  // Any older times are unknown.
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time - 1),
+            kUnknownSeqnoBeforeAll);
+
+  // Now check that writes can proceed normally (passing about 20% of preserve
+  // time)
+  for (int i = 0; i < 20; i++) {
+    ASSERT_OK(Put(Key(i), "value"));
+    dbfull()->TEST_WaitForPeriodicTaskRun([&] {
+      mock_clock_->MockSleepForSeconds(static_cast<int>(kPreserveSecs / 99));
+    });
+  }
+  ASSERT_OK(Flush());
+
+  // Check that mappings are getting populated
+  sttm = dbfull()->TEST_GetSeqnoToTimeMapping();
+  latest_seqno = db_->GetLatestSequenceNumber();
+  uint64_t end_time = mock_clock_->NowSeconds();
+  ASSERT_EQ(sttm.Size(), 21);
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(end_time), latest_seqno);
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time), 1U);
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time - 1),
+            kUnknownSeqnoBeforeAll);
+
+  // #### DB#2: Destroy and open with preserve/preclude option ####
+  DestroyAndReopen(options);
+
+  // Ensure pre-population
+  constexpr auto kPrePopPairs = SeqnoToTimeMapping::kMaxSeqnoTimePairsPerSST;
+  sttm = dbfull()->TEST_GetSeqnoToTimeMapping();
+  latest_seqno = db_->GetLatestSequenceNumber();
+  start_time = mock_clock_->NowSeconds();
+  ASSERT_EQ(sttm.Size(), kPrePopPairs);
+  // One nono-zero sequence number per pre-populated pair (this could be
+  // revised if we want to use interpolation for better approximate time
+  // mappings with no guarantee of erring in just one direction).
+  ASSERT_EQ(latest_seqno, kPrePopPairs);
+  // Current time maps to last pre-allocated seqno
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time), latest_seqno);
+  // Oldest tracking time maps to first pre-allocated seqno
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time - kPreserveSecs), 1);
+
+  // In more detail, check that estimated seqnos (pre-allocated) are uniformly
+  // spread over the tracked time.
+  for (auto ratio : {0.0, 0.433, 0.678, 0.987, 1.0}) {
+    // Round up query time
+    uint64_t t = start_time - kPreserveSecs +
+                 static_cast<uint64_t>(ratio * kPreserveSecs + 0.9999999);
+    // Round down estimated seqno
+    SequenceNumber s =
+        static_cast<SequenceNumber>(ratio * (latest_seqno - 1)) + 1;
+    // Match
+    ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(t), s);
+  }
+
+  // Now check that writes can proceed normally (passing about 20% of preserve
+  // time)
+  for (int i = 0; i < 20; i++) {
+    ASSERT_OK(Put(Key(i), "value"));
+    dbfull()->TEST_WaitForPeriodicTaskRun([&] {
+      mock_clock_->MockSleepForSeconds(static_cast<int>(kPreserveSecs / 99));
+    });
+  }
+  ASSERT_OK(Flush());
+
+  // Can still see some pre-populated mappings, though some displaced
+  sttm = dbfull()->TEST_GetSeqnoToTimeMapping();
+  latest_seqno = db_->GetLatestSequenceNumber();
+  end_time = mock_clock_->NowSeconds();
+  ASSERT_EQ(sttm.Size(), kPrePopPairs);
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(end_time), latest_seqno);
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time - kPreserveSecs / 2),
+            kPrePopPairs / 2);
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time - kPreserveSecs),
+            kUnknownSeqnoBeforeAll);
+
+  // #### DB#3: Destroy and open+create an extra CF with preserve/preclude ####
+  // (default CF does not have the option)
+  Destroy(options);
+  ReopenWithColumnFamilies({"default", "one"}, List({base_options, options}));
+
+  // Ensure pre-population (not as exhaustive checking here)
+  sttm = dbfull()->TEST_GetSeqnoToTimeMapping();
+  latest_seqno = db_->GetLatestSequenceNumber();
+  start_time = mock_clock_->NowSeconds();
+  ASSERT_EQ(sttm.Size(), kPrePopPairs);
+  // One nono-zero sequence number per pre-populated pair (this could be
+  // revised if we want to use interpolation for better approximate time
+  // mappings with no guarantee of erring in just one direction).
+  ASSERT_EQ(latest_seqno, kPrePopPairs);
+  // Current time maps to last pre-allocated seqno
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time), latest_seqno);
+  // Oldest tracking time maps to first pre-allocated seqno
+  ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time - kPreserveSecs), 1);
 
   Close();
 }
@@ -982,6 +1076,50 @@ TEST_F(SeqnoTimeTest, ProximalFunctions) {
   EXPECT_EQ(test.GetProximalTimeBeforeSeqno(51), 900U);
   EXPECT_EQ(test.GetProximalSeqnoBeforeTime(899), 30U);
   EXPECT_EQ(test.GetProximalSeqnoBeforeTime(900), 50U);
+}
+
+TEST_F(SeqnoTimeTest, PrePopulate) {
+  SeqnoToTimeMapping test(/*max_time_duration=*/100, /*max_capacity=*/10);
+
+  EXPECT_EQ(test.Size(), 0U);
+
+  // Smallest case is like two Appends
+  test.PrePopulate(10, 11, 500, 600);
+
+  EXPECT_EQ(test.GetProximalTimeBeforeSeqno(10), kUnknownTimeBeforeAll);
+  EXPECT_EQ(test.GetProximalTimeBeforeSeqno(11), 500U);
+  EXPECT_EQ(test.GetProximalTimeBeforeSeqno(12), 600U);
+
+  test.Clear();
+
+  // Populate a small range
+  uint64_t kTimeIncrement = 1234567;
+  test.PrePopulate(1, 12, kTimeIncrement, kTimeIncrement * 2);
+
+  for (uint64_t i = 0; i <= 12; ++i) {
+    // NOTE: with 1 and 12 as the pre-populated end points, the duration is
+    // broken into 11 equal(-ish) spans
+    uint64_t t = kTimeIncrement + (i * kTimeIncrement) / 11 - 1;
+    EXPECT_EQ(test.GetProximalSeqnoBeforeTime(t), i);
+  }
+
+  test.Clear();
+
+  // Populate an excessively large range (in the future we might want to
+  // interpolate estimated times for seqnos between entries)
+  test.PrePopulate(1, 34567, kTimeIncrement, kTimeIncrement * 2);
+
+  for (auto ratio : {0.0, 0.433, 0.678, 0.987, 1.0}) {
+    // Round up query time
+    uint64_t t = kTimeIncrement +
+                 static_cast<uint64_t>(ratio * kTimeIncrement + 0.9999999);
+    // Round down estimated seqno
+    SequenceNumber s = static_cast<SequenceNumber>(ratio * (34567 - 1)) + 1;
+    // Match
+    // TODO: for now this is exact, but in the future might need approximation
+    // bounds to account for limited samples.
+    EXPECT_EQ(test.GetProximalSeqnoBeforeTime(t), s);
+  }
 }
 
 TEST_F(SeqnoTimeTest, TruncateOldEntries) {

--- a/db/seqno_to_time_mapping.h
+++ b/db/seqno_to_time_mapping.h
@@ -116,6 +116,11 @@ class SeqnoToTimeMapping {
                               uint64_t max_capacity = 0)
       : max_time_duration_(max_time_duration), max_capacity_(max_capacity) {}
 
+  // Both seqno range and time range are inclusive. ... TODO
+  //
+  bool PrePopulate(SequenceNumber from_seqno, SequenceNumber to_seqno,
+                   uint64_t from_time, uint64_t to_time);
+
   // Append a new entry to the list. The new entry should be newer than the
   // existing ones. It maintains the internal sorted status.
   bool Append(SequenceNumber seqno, uint64_t time);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1342,6 +1342,9 @@ class VersionSet {
     last_allocated_sequence_.store(s, std::memory_order_seq_cst);
   }
 
+  // Allocate a dummy sequence number as needed to ensure last is non-zero.
+  void EnsureNonZeroSequence();
+
   // Note: memory_order_release must be sufficient
   uint64_t FetchAddLastAllocatedSequence(uint64_t s) {
     return last_allocated_sequence_.fetch_add(s, std::memory_order_seq_cst);

--- a/util/cast_util.h
+++ b/util/cast_util.h
@@ -53,4 +53,13 @@ inline To lossless_cast(From x) {
   return static_cast<To>(x);
 }
 
+// For disambiguating a potentially heterogeneous aggregate as a homogeneous
+// initializer list. E.g. might be able to write List({x, y}) in some cases
+// instead of std::vector<const Widget&>({x, y}).
+template <typename T>
+inline const std::initializer_list<T>& List(
+    const std::initializer_list<T>& list) {
+  return list;
+}
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: This change has two primary goals (follow-up to #11917, #11920):
* Ensure the DB seqno_to_time_mapping has entries that allow us to put a good time lower bound on any writes that happen after setting up preserve/preclude options (either in a new DB, new CF, SetOptions, etc.) and haven't yet aged out of that time window. This allows us to remove a bunch of work-arounds in tests.
* For new DBs using preserve/preclude options, automatically reserve some sequence numbers and pre-map them to cover the time span back to the preserve/preclude cut-off time. In the future, this will allow us to import data from another DB by key, value, and write time by assigning an appropriate seqno in this DB for that write time.

Note that the pre-population (historical mappings) does not happen if the original options at DB Open time do not have preserve/preclude, so it is recommended to create initial column families at that time with create_missing_column_families, to take advantage of this (future) feature. (Adding these historical mappings after DB Open would risk non-monotonic seqno_to_time_mapping, which is dubious if not dangerous.)

Recommended follow-up:
* Solve existing race conditions (not memory safety) where parallel operations like CreateColumnFamily or SetDBOptions could leave the wrong setting in effect.
* Make SeqnoToTimeMapping more gracefully handle a possible case in which too many mappings are added for the time range of concern. It seems like there could be cases where data is massively excluded from the cold tier because of entries falling off the front of the mapping list (causing GetProximalSeqnoBeforeTime() to return 0). (More investigation needed.)

No release note for the minor bug fix because this is still an experimental feature with limited usage.

Test Plan: tests added / updated