### PR TITLE
Enable write fault injection in db_stress

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1882,7 +1882,7 @@ Status StressTest::TestBackupRestore(
       from = "Destroy restore dir";
     }
   }
-  if (!s.ok()) {
+  if (!s.ok() && (!s.IsIOError() || !std::strstr(s.getState(), "injected"))) {
     fprintf(stderr, "Failure in %s with: %s\n", from.c_str(),
             s.ToString().c_str());
   }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1958,17 +1958,19 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   if (s.ok()) {
     s = checkpoint->CreateCheckpoint(checkpoint_dir);
     if (!s.ok()) {
-      fprintf(stderr, "Fail to create checkpoint to %s\n",
-              checkpoint_dir.c_str());
-      std::vector<std::string> files;
-      Status my_s = db_stress_env->GetChildren(checkpoint_dir, &files);
-      if (my_s.ok()) {
-        for (const auto& f : files) {
-          fprintf(stderr, " %s\n", f.c_str());
+      if (!s.IsIOError() || !std::strstr(s.getState(), "injected")) {
+        fprintf(stderr, "Fail to create checkpoint to %s\n",
+                checkpoint_dir.c_str());
+        std::vector<std::string> files;
+        Status my_s = db_stress_env->GetChildren(checkpoint_dir, &files);
+        if (my_s.ok()) {
+          for (const auto& f : files) {
+            fprintf(stderr, " %s\n", f.c_str());
+          }
+        } else {
+          fprintf(stderr, "Fail to get files under the directory to %s\n",
+                  my_s.ToString().c_str());
         }
-      } else {
-        fprintf(stderr, "Fail to get files under the directory to %s\n",
-                my_s.ToString().c_str());
       }
     }
   }
@@ -2044,8 +2046,10 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
   }
 
   if (!s.ok()) {
-    fprintf(stderr, "A checkpoint operation failed with: %s\n",
-            s.ToString().c_str());
+    if (!s.IsIOError() || !std::strstr(s.getState(), "injected")) {
+      fprintf(stderr, "A checkpoint operation failed with: %s\n",
+              s.ToString().c_str());
+    }
   } else {
     DestroyDB(checkpoint_dir, tmp_opts);
   }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -157,7 +157,7 @@ default_params = {
         [t * 16384 if t < 3 else 1024 * 1024 * 1024 for t in range(1, 30)]
     ),
     # Sync mode might make test runs slower so running it in a smaller chance
-    "sync": lambda: random.choice([1 if t == 0 else 0 for t in range(0, 20)]),
+    "sync": 0,
     "bytes_per_sync": lambda: random.choice([0, 262144]),
     "wal_bytes_per_sync": lambda: random.choice([0, 524288]),
     "compaction_readahead_size" : lambda : random.choice(
@@ -182,7 +182,7 @@ default_params = {
     "max_key_len": 3,
     "key_len_percent_dist": "1,30,69",
     "read_fault_one_in": lambda: random.choice([0, 32, 1000]),
-    "write_fault_one_in": 100,
+    "write_fault_one_in": lambda: random.choice([0, 32, 1000]),
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
     "open_read_fault_one_in": lambda: random.choice([0, 0, 32]),
@@ -380,10 +380,6 @@ cf_consistency_params = {
     # use small value for write_buffer_size so that RocksDB triggers flush
     # more frequently
     "write_buffer_size": 1024 * 1024,
-    # Small write buffer size with more frequent flush has a higher chance
-    # of hitting write error. DB may be stopped if memtable fills up during
-    # auto resume.
-    "write_fault_one_in": 0,
     "enable_pipelined_write": lambda: random.randint(0, 1),
     # Snapshots are used heavily in this test mode, while they are incompatible
     # with compaction filter.

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -157,7 +157,7 @@ default_params = {
         [t * 16384 if t < 3 else 1024 * 1024 * 1024 for t in range(1, 30)]
     ),
     # Sync mode might make test runs slower so running it in a smaller chance
-    "sync": 0,
+    "sync": lambda: random.choice([1 if t == 0 else 0 for t in range(0, 20)]),
     "bytes_per_sync": lambda: random.choice([0, 262144]),
     "wal_bytes_per_sync": lambda: random.choice([0, 524288]),
     "compaction_readahead_size" : lambda : random.choice(
@@ -182,7 +182,7 @@ default_params = {
     "max_key_len": 3,
     "key_len_percent_dist": "1,30,69",
     "read_fault_one_in": lambda: random.choice([0, 32, 1000]),
-    "write_fault_one_in": lambda: random.choice([0, 32, 1000]),
+    "write_fault_one_in": lambda: random.choice([0, 128, 1000]),
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
     "open_read_fault_one_in": lambda: random.choice([0, 0, 32]),

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -182,7 +182,7 @@ default_params = {
     "max_key_len": 3,
     "key_len_percent_dist": "1,30,69",
     "read_fault_one_in": lambda: random.choice([0, 32, 1000]),
-    "write_fault_one_in": 0,
+    "write_fault_one_in": 100,
     "open_metadata_write_fault_one_in": lambda: random.choice([0, 0, 8]),
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
     "open_read_fault_one_in": lambda: random.choice([0, 0, 32]),


### PR DESCRIPTION
This PR depends on #11879 . Enable write fault injection for the basic whitebox, blackbox, and cf_consistency modes. For other test modes like multiops_txn, best_efforts_recovery etc., leave it disabled for now until we can do more testing.