### PR TITLE
AttributeGroups - MultiGetEntity Implementation

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3381,8 +3381,8 @@ void DBImpl::MultiGetEntity(
            key_grouped_column_families[i].second.size());
     for (size_t j = 0; j < results[i].num_column_families(); ++j) {
       // Adding the same key slice for different CFs
-      keys.push_back(key_grouped_column_families[i].first);
-      column_families.push_back(key_grouped_column_families[i].second[j]);
+      keys.emplace_back(key_grouped_column_families[i].first);
+      column_families.emplace_back(key_grouped_column_families[i].second[j]);
       ++total_count;
     }
   }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3346,13 +3346,12 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
                             PinnableWideColumnsCollection* results) {
   if (_read_options.io_activity != Env::IOActivity::kUnknown &&
       _read_options.io_activity != Env::IOActivity::kMultiGetEntity) {
+    Status s = Status::InvalidArgument(
+        "Can only call MultiGetEntity with ReadOptions::io_activity` is "
+        "`Env::IOActivity::kUnknown` or `Env::IOActivity::kMultiGetEntity`");
     for (size_t i = 0; i < num_keys; ++i) {
       for (size_t j = 0; j < results[i].size(); ++j) {
-        results[i][j].SetStatus(
-            Status::InvalidArgument("Can only call MultiGetEntity with "
-                                    "`ReadOptions::io_activity` is "
-                                    "`Env::IOActivity::kUnknown` or "
-                                    "`Env::IOActivity::kMultiGetEntity`"));
+        results[i][j].SetStatus(s);
       }
     }
     return;
@@ -3390,7 +3389,7 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
       results[i][j].Reset();
       results[i][j].SetStatus(std::move(statuses[index]));
       results[i][j].SetPinnableWideColumns(std::move(columns[index]));
-      index++;
+      ++index;
     }
   }
 }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2813,7 +2813,7 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
                             const size_t num_keys,
                             ColumnFamilyHandle** column_families,
                             const Slice* keys, PinnableSlice* values,
-                            PinnableWideColumns** columns,
+                            PinnableWideColumns* columns,
                             std::string* timestamps, Status* statuses,
                             const bool sorted_input) {
   if (num_keys == 0) {
@@ -2868,7 +2868,7 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
     } else {
       assert(columns);
 
-      col = columns[i];
+      col = &columns[i];
       col->Reset();
     }
 
@@ -3039,8 +3039,7 @@ void DBImpl::MultiGet(const ReadOptions& _read_options,
 void DBImpl::MultiGetCommon(const ReadOptions& read_options,
                             ColumnFamilyHandle* column_family,
                             const size_t num_keys, const Slice* keys,
-                            PinnableSlice* values,
-                            PinnableWideColumns** columns,
+                            PinnableSlice* values, PinnableWideColumns* columns,
                             std::string* timestamps, Status* statuses,
                             bool sorted_input) {
   if (tracer_) {
@@ -3065,7 +3064,7 @@ void DBImpl::MultiGetCommon(const ReadOptions& read_options,
     } else {
       assert(columns);
 
-      col = columns[i];
+      col = &columns[i];
       col->Reset();
     }
 
@@ -3313,12 +3312,8 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
   if (read_options.io_activity == Env::IOActivity::kUnknown) {
     read_options.io_activity = Env::IOActivity::kMultiGetEntity;
   }
-  std::vector<PinnableWideColumns*> result_ptrs;
-  for (size_t i = 0; i < num_keys; i++) {
-    result_ptrs.emplace_back(&results[i]);
-  }
   MultiGetCommon(read_options, num_keys, column_families, keys,
-                 /* values */ nullptr, result_ptrs.data(),
+                 /* values */ nullptr, results,
                  /* timestamps */ nullptr, statuses, sorted_input);
 }
 
@@ -3342,12 +3337,8 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options,
   if (read_options.io_activity == Env::IOActivity::kUnknown) {
     read_options.io_activity = Env::IOActivity::kMultiGetEntity;
   }
-  std::vector<PinnableWideColumns*> result_ptrs;
-  for (size_t i = 0; i < num_keys; i++) {
-    result_ptrs.emplace_back(&results[i]);
-  }
   MultiGetCommon(read_options, column_family, num_keys, keys,
-                 /* values */ nullptr, result_ptrs.data(),
+                 /* values */ nullptr, results,
                  /* timestamps */ nullptr, statuses, sorted_input);
 }
 
@@ -3387,23 +3378,21 @@ void DBImpl::MultiGetEntity(
     }
   }
   std::vector<Status> statuses(total_count);
-  std::vector<PinnableWideColumns*> columns_ptrs;
-  for (size_t i = 0; i < num_keys; ++i) {
-    for (size_t j = 0; j < results[i].num_column_families(); ++j) {
-      columns_ptrs.emplace_back(results[i].columns_ref(j));
-    }
-  }
+  std::vector<PinnableWideColumns> columns(total_count);
   // TODO - sort the keys by column_families and set sorted_input = true
   MultiGetCommon(read_options, total_count, column_families.data(), keys.data(),
-                 /* values */ nullptr, columns_ptrs.data(),
+                 /* values */ nullptr, columns.data(),
                  /* timestamps */ nullptr, statuses.data(),
                  /* sorted_input */ false);
 
-  // Set statuses
+  // Set results
   size_t index = 0;
   for (size_t i = 0; i < num_keys; ++i) {
+    results[i].Reset();
     for (size_t j = 0; j < results[i].num_column_families(); ++j) {
-      results[i].SetStatus(j, std::move(statuses[index++]));
+      results[i].AddStatus(std::move(statuses[index]));
+      results[i].AddColumnsArray(std::move(columns[index]));
+      index++;
     }
   }
 }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3312,8 +3312,8 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,
     read_options.io_activity = Env::IOActivity::kMultiGetEntity;
   }
   MultiGetCommon(read_options, num_keys, column_families, keys,
-                 /* values */ nullptr, results,
-                 /* timestamps */ nullptr, statuses, sorted_input);
+                 /* values */ nullptr, results, /* timestamps */ nullptr,
+                 statuses, sorted_input);
 }
 
 void DBImpl::MultiGetEntity(const ReadOptions& _read_options,
@@ -3337,8 +3337,8 @@ void DBImpl::MultiGetEntity(const ReadOptions& _read_options,
     read_options.io_activity = Env::IOActivity::kMultiGetEntity;
   }
   MultiGetCommon(read_options, column_family, num_keys, keys,
-                 /* values */ nullptr, results,
-                 /* timestamps */ nullptr, statuses, sorted_input);
+                 /* values */ nullptr, results, /* timestamps */ nullptr,
+                 statuses, sorted_input);
 }
 
 void DBImpl::MultiGetEntity(const ReadOptions& _read_options, size_t num_keys,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -313,7 +313,7 @@ class DBImpl : public DB {
                       bool sorted_input) override;
   void MultiGetEntity(const ReadOptions& options, size_t num_keys,
                       const Slice* keys,
-                      GroupedPinnableWideColumns* results) override;
+                      PinnableWideColumnsCollection* results) override;
 
   virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -311,6 +311,10 @@ class DBImpl : public DB {
                       ColumnFamilyHandle** column_families, const Slice* keys,
                       PinnableWideColumns* results, Status* statuses,
                       bool sorted_input) override;
+  void MultiGetEntity(
+      const ReadOptions& options, size_t num_keys,
+      const KeyGroupedColumnFamilies* key_grouped_column_families,
+      GroupedPinnableWideColumns* results) override;
 
   virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,
@@ -2285,12 +2289,12 @@ class DBImpl : public DB {
   void MultiGetCommon(const ReadOptions& options,
                       ColumnFamilyHandle* column_family, const size_t num_keys,
                       const Slice* keys, PinnableSlice* values,
-                      PinnableWideColumns* columns, std::string* timestamps,
+                      PinnableWideColumns** columns, std::string* timestamps,
                       Status* statuses, bool sorted_input);
 
   void MultiGetCommon(const ReadOptions& options, const size_t num_keys,
                       ColumnFamilyHandle** column_families, const Slice* keys,
-                      PinnableSlice* values, PinnableWideColumns* columns,
+                      PinnableSlice* values, PinnableWideColumns** columns,
                       std::string* timestamps, Status* statuses,
                       bool sorted_input);
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -311,10 +311,9 @@ class DBImpl : public DB {
                       ColumnFamilyHandle** column_families, const Slice* keys,
                       PinnableWideColumns* results, Status* statuses,
                       bool sorted_input) override;
-  void MultiGetEntity(
-      const ReadOptions& options, size_t num_keys,
-      const KeyGroupedColumnFamilies* key_grouped_column_families,
-      GroupedPinnableWideColumns* results) override;
+  void MultiGetEntity(const ReadOptions& options, size_t num_keys,
+                      const Slice* keys,
+                      GroupedPinnableWideColumns* results) override;
 
   virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -313,7 +313,7 @@ class DBImpl : public DB {
                       bool sorted_input) override;
   void MultiGetEntity(const ReadOptions& options, size_t num_keys,
                       const Slice* keys,
-                      PinnableWideColumnsCollection* results) override;
+                      PinnableAttributeGroups* results) override;
 
   virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2289,12 +2289,12 @@ class DBImpl : public DB {
   void MultiGetCommon(const ReadOptions& options,
                       ColumnFamilyHandle* column_family, const size_t num_keys,
                       const Slice* keys, PinnableSlice* values,
-                      PinnableWideColumns** columns, std::string* timestamps,
+                      PinnableWideColumns* columns, std::string* timestamps,
                       Status* statuses, bool sorted_input);
 
   void MultiGetCommon(const ReadOptions& options, const size_t num_keys,
                       ColumnFamilyHandle** column_families, const Slice* keys,
-                      PinnableSlice* values, PinnableWideColumns** columns,
+                      PinnableSlice* values, PinnableWideColumns* columns,
                       std::string* timestamps, Status* statuses,
                       bool sorted_input);
 

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -315,9 +315,9 @@ TEST_F(DBWideBasicTest, MultiCFMultiGetEntityGrouped) {
     // Check for invalid argument
     ReadOptions read_options;
     read_options.io_activity = Env::IOActivity::kGetEntity;
-    std::vector<GroupedPinnableWideColumns> results{
-        GroupedPinnableWideColumns(all_cfs.size(), all_cfs.data()),
-        GroupedPinnableWideColumns(all_cfs.size(), all_cfs.data())};
+    std::vector<GroupedPinnableWideColumns> results;
+    results.emplace_back(all_cfs.size(), all_cfs.data());
+    results.emplace_back(all_cfs.size(), all_cfs.data());
     db_->MultiGetEntity(read_options, num_keys, nullptr, results.data());
     std::for_each(results.begin(), results.end(),
                   [](const GroupedPinnableWideColumns& result) {
@@ -330,12 +330,10 @@ TEST_F(DBWideBasicTest, MultiCFMultiGetEntityGrouped) {
   {
     // Case 1. Get first key from default cf and hot_cf and second key from
     // hot_cf and cold_cf
-    auto first_key_result = GroupedPinnableWideColumns(
-        default_and_hot_cfs.size(), default_and_hot_cfs.data());
-    auto second_key_result = GroupedPinnableWideColumns(
-        hot_and_cold_cfs.size(), hot_and_cold_cfs.data());
-    std::vector<GroupedPinnableWideColumns> results{first_key_result,
-                                                    second_key_result};
+    std::vector<GroupedPinnableWideColumns> results;
+    results.emplace_back(default_and_hot_cfs.size(),
+                         default_and_hot_cfs.data());
+    results.emplace_back(hot_and_cold_cfs.size(), hot_and_cold_cfs.data());
     db_->MultiGetEntity(ReadOptions(), num_keys, keys.data(), results.data());
     // We expect to get values for all keys and CFs
     std::for_each(results.begin(), results.end(),
@@ -358,13 +356,9 @@ TEST_F(DBWideBasicTest, MultiCFMultiGetEntityGrouped) {
   {
     // Case 2. Get first key and second key from all cfs. For the second key, we
     // don't expect to get columns from default cf.
-
-    auto first_key_result =
-        GroupedPinnableWideColumns(all_cfs.size(), all_cfs.data());
-    auto second_key_result =
-        GroupedPinnableWideColumns(all_cfs.size(), all_cfs.data());
-    std::vector<GroupedPinnableWideColumns> results{first_key_result,
-                                                    second_key_result};
+    std::vector<GroupedPinnableWideColumns> results;
+    results.emplace_back(all_cfs.size(), all_cfs.data());
+    results.emplace_back(all_cfs.size(), all_cfs.data());
     db_->MultiGetEntity(ReadOptions(), num_keys, keys.data(), results.data());
     // verify first key
     auto first_key_statuses = results[0].statuses();

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -313,7 +313,7 @@ TEST_F(DBWideBasicTest, MultiCFMultiGetEntityGrouped) {
       {handles_[HOT_CF_HANDLE_INDEX], handles_[COLD_CF_HANDLE_INDEX]}};
   auto add_column_families_to_result =
       [&](PinnableWideColumnsCollection& collection,
-          const std::vector<ColumnFamilyHandle*> column_families) {
+          const std::vector<ColumnFamilyHandle*>& column_families) {
         for (size_t i = 0; i < column_families.size(); ++i) {
           collection.emplace_back(column_families[i]);
         }
@@ -355,7 +355,7 @@ TEST_F(DBWideBasicTest, MultiCFMultiGetEntityGrouped) {
     ASSERT_EQ(2, results.size());
     // We expect to get values for all keys and CFs
     for (size_t i = 0; i < num_keys; ++i) {
-      for (size_t j = 0; j < all_cfs.size(); ++j) {
+      for (size_t j = 0; j < 2; ++j) {
         ASSERT_OK(results[i][j].status());
       }
     }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -862,21 +862,26 @@ class DB {
     }
   }
 
-  // Batched MultiGet-like API that returns wide-column entities grouped
-  // by column families for each key. The input is a list of keys and
-  // PinnableWideColumnsCollections. For any given keys[i] (where 0 <= i <
-  // num_keys), results[i] will contain result for the ith key. Each result will
-  // be returned as PinnableWideColumnsCollection. PinnableWideColumnsCollection
-  // is a vector of PinnableWideColumnsBundle. Each PinnableWideColumnsBundle
-  // will contain a ColumnFamilyHandle pointer, status and PinnableWideColumns.
+  // Batched MultiGet-like API that returns attribute groups.
+  // An "attribute group" refers to a logical grouping of wide-column entities
+  // within RocksDB. These attribute groups are implemented using column
+  // families. Attribute group allows users to group wide-columns based on
+  // various criteria, such as similar access patterns or data types
+  //
+  // The input is a list of keys and PinnableAttributeGroups. For any given
+  // keys[i] (where 0 <= i < num_keys), results[i] will contain result for the
+  // ith key. Each result will be returned as PinnableAttributeGroups.
+  // PinnableAttributeGroups is a vector of PinnableAttributeGroup. Each
+  // PinnableAttributeGroup will contain a ColumnFamilyHandle pointer, Status
+  // and PinnableWideColumns.
   //
   // Note that it is the caller's responsibility to ensure that
   // "keys" and "results" have the same "num_keys" number of objects. Also
-  // PinnableWideColumnsBundle needs to have ColumnFamilyHandle pointer set
+  // PinnableAttributeGroup needs to have ColumnFamilyHandle pointer set
   // properly to get the corresponding wide columns from the column family.
   virtual void MultiGetEntity(const ReadOptions& /* options */, size_t num_keys,
                               const Slice* /* keys */,
-                              PinnableWideColumnsCollection* results) {
+                              PinnableAttributeGroups* results) {
     for (size_t i = 0; i < num_keys; ++i) {
       for (size_t j = 0; j < results[i].size(); ++j) {
         results[i][j].SetStatus(

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -867,9 +867,9 @@ class DB {
   // PinnableWideColumnsCollection (which will be filled in as output) For any
   // given keys[i] (where 0 <= i < num_keys), results[i] will contain
   // PinnableWideColumnsCollection for the ith key.
-  // PinnableWideColumnsCollection is a vector of PinnableWideColumnsChunk. Each
-  // PinnableWideColumnsChunk will contain a ColumnFamilyHandle pointer, status
-  // and PinnableWideColumns.
+  // PinnableWideColumnsCollection is a vector of PinnableWideColumnsBundle.
+  // Each PinnableWideColumnsBundle will contain a ColumnFamilyHandle pointer,
+  // status and PinnableWideColumns.
   //
   // Note that it is the caller's responsibility to ensure that
   // "keys" and "results" have the same "num_keys" number of objects.

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -864,15 +864,16 @@ class DB {
 
   // Batched MultiGet-like API that returns wide-column entities grouped
   // by column families for each key. The input is a list of keys and
-  // PinnableWideColumnsCollection (which will be filled in as output) For any
-  // given keys[i] (where 0 <= i < num_keys), results[i] will contain
-  // PinnableWideColumnsCollection for the ith key.
-  // PinnableWideColumnsCollection is a vector of PinnableWideColumnsBundle.
-  // Each PinnableWideColumnsBundle will contain a ColumnFamilyHandle pointer,
-  // status and PinnableWideColumns.
+  // PinnableWideColumnsCollections. For any given keys[i] (where 0 <= i <
+  // num_keys), results[i] will contain result for the ith key. Each result will
+  // be returned as PinnableWideColumnsCollection. PinnableWideColumnsCollection
+  // is a vector of PinnableWideColumnsBundle. Each PinnableWideColumnsBundle
+  // will contain a ColumnFamilyHandle pointer, status and PinnableWideColumns.
   //
   // Note that it is the caller's responsibility to ensure that
-  // "keys" and "results" have the same "num_keys" number of objects.
+  // "keys" and "results" have the same "num_keys" number of objects. Also
+  // PinnableWideColumnsBundle needs to have ColumnFamilyHandle pointer set
+  // properly to get the corresponding wide columns from the column family.
   virtual void MultiGetEntity(const ReadOptions& /* options */, size_t num_keys,
                               const Slice* /* keys */,
                               PinnableWideColumnsCollection* results) {

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -232,7 +232,7 @@ class PinnableWideColumnsChunk {
   explicit PinnableWideColumnsChunk(ColumnFamilyHandle* column_family)
       : column_family_(column_family) {}
 
-  void SetStatus(Status&& status);
+  void SetStatus(const Status& status);
   void SetPinnableWideColumns(PinnableWideColumns&& pinnable_wide_columns);
 
   void Reset();
@@ -243,7 +243,7 @@ class PinnableWideColumnsChunk {
   PinnableWideColumns pinnable_wide_columns_;
 };
 
-inline void PinnableWideColumnsChunk::SetStatus(Status&& status) {
+inline void PinnableWideColumnsChunk::SetStatus(const Status& status) {
   status_ = status;
 }
 inline void PinnableWideColumnsChunk::SetPinnableWideColumns(

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -220,8 +220,9 @@ inline bool operator!=(const PinnableWideColumns& lhs,
   return !(lhs == rhs);
 }
 
-// TODO - find me a better name!
-class PinnableWideColumnsChunk {
+// PinnableWideColumns bundled with ColumnFamilyHandle and Status for the query.
+// Used for the results of wide-column queries grouped by Column Families
+class PinnableWideColumnsBundle {
  public:
   ColumnFamilyHandle* column_family() const { return column_family_; }
   const Status& status() const { return status_; }
@@ -229,7 +230,7 @@ class PinnableWideColumnsChunk {
     return pinnable_wide_columns_;
   }
 
-  explicit PinnableWideColumnsChunk(ColumnFamilyHandle* column_family)
+  explicit PinnableWideColumnsBundle(ColumnFamilyHandle* column_family)
       : column_family_(column_family) {}
 
   void SetStatus(const Status& status);
@@ -243,19 +244,19 @@ class PinnableWideColumnsChunk {
   PinnableWideColumns pinnable_wide_columns_;
 };
 
-inline void PinnableWideColumnsChunk::SetStatus(const Status& status) {
+inline void PinnableWideColumnsBundle::SetStatus(const Status& status) {
   status_ = status;
 }
-inline void PinnableWideColumnsChunk::SetPinnableWideColumns(
+inline void PinnableWideColumnsBundle::SetPinnableWideColumns(
     PinnableWideColumns&& pinnable_wide_columns) {
   pinnable_wide_columns_ = std::move(pinnable_wide_columns);
 }
 
-inline void PinnableWideColumnsChunk::Reset() {
+inline void PinnableWideColumnsBundle::Reset() {
   pinnable_wide_columns_.Reset();
 }
 
-// A collection of PinnableWideColumnsChunks.
-using PinnableWideColumnsCollection = std::vector<PinnableWideColumnsChunk>;
+// A collection of PinnableWideColumnsBundles.
+using PinnableWideColumnsCollection = std::vector<PinnableWideColumnsBundle>;
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -17,6 +17,8 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+class ColumnFamilyHandle;
+
 // Class representing a wide column, which is defined as a pair of column name
 // and column value.
 class WideColumn {
@@ -239,13 +241,16 @@ inline PinnableWideColumns::PinnableWideColumns(PinnableWideColumns&& p) {
 class GroupedPinnableWideColumns {
  public:
   const size_t& num_column_families() const { return num_column_families_; }
+  ColumnFamilyHandle** column_families() const { return column_families_; }
   const std::vector<Status>& statuses() const { return statuses_; }
   const std::vector<PinnableWideColumns>& columns_array() const {
     return columns_array_;
   }
 
-  explicit GroupedPinnableWideColumns(const size_t& num_column_families)
+  explicit GroupedPinnableWideColumns(const size_t& num_column_families,
+                                      ColumnFamilyHandle** column_families)
       : num_column_families_(num_column_families),
+        column_families_(column_families),
         statuses_(num_column_families),
         columns_array_(num_column_families) {}
 
@@ -257,13 +262,14 @@ class GroupedPinnableWideColumns {
 
  private:
   const size_t num_column_families_;
+  ColumnFamilyHandle** column_families_;
   std::vector<Status> statuses_;
   std::vector<PinnableWideColumns> columns_array_;
 };
 
 inline void GroupedPinnableWideColumns::AddColumnsArray(
     PinnableWideColumns&& columns) {
-  columns_array_.emplace_back(std::move(columns));
+  columns_array_.emplace_back(columns);
 }
 inline void GroupedPinnableWideColumns::AddStatus(Status&& status) {
   statuses_.emplace_back(status);

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -220,44 +220,42 @@ inline bool operator!=(const PinnableWideColumns& lhs,
   return !(lhs == rhs);
 }
 
-// PinnableWideColumns bundled with ColumnFamilyHandle and Status for the query.
-// Used for the results of wide-column queries grouped by Column Families
-class PinnableWideColumnsBundle {
+// Class representing attribute group. Attribute group is a logical grouping of
+// wide-column entities by leveraging Column Families. Wide-columns returned
+// from the query are pinnable.
+class PinnableAttributeGroup {
  public:
   ColumnFamilyHandle* column_family() const { return column_family_; }
   const Status& status() const { return status_; }
-  const PinnableWideColumns& pinnable_wide_columns() const {
-    return pinnable_wide_columns_;
-  }
+  const WideColumns& columns() const { return columns_.columns(); }
 
-  explicit PinnableWideColumnsBundle(ColumnFamilyHandle* column_family)
+  explicit PinnableAttributeGroup(ColumnFamilyHandle* column_family)
       : column_family_(column_family), status_(Status::OK()) {}
 
   void SetStatus(const Status& status);
-  void SetPinnableWideColumns(PinnableWideColumns&& pinnable_wide_columns);
+  void SetColumns(PinnableWideColumns&& columns);
 
   void Reset();
 
  private:
   ColumnFamilyHandle* column_family_;
   Status status_;
-  PinnableWideColumns pinnable_wide_columns_;
+  PinnableWideColumns columns_;
 };
 
-inline void PinnableWideColumnsBundle::SetStatus(const Status& status) {
+inline void PinnableAttributeGroup::SetStatus(const Status& status) {
   status_ = status;
 }
-inline void PinnableWideColumnsBundle::SetPinnableWideColumns(
-    PinnableWideColumns&& pinnable_wide_columns) {
-  pinnable_wide_columns_ = std::move(pinnable_wide_columns);
+inline void PinnableAttributeGroup::SetColumns(PinnableWideColumns&& columns) {
+  columns_ = std::move(columns);
 }
 
-inline void PinnableWideColumnsBundle::Reset() {
+inline void PinnableAttributeGroup::Reset() {
   SetStatus(Status::OK());
-  pinnable_wide_columns_.Reset();
+  columns_.Reset();
 }
 
-// A collection of PinnableWideColumnsBundles.
-using PinnableWideColumnsCollection = std::vector<PinnableWideColumnsBundle>;
+// A collection of Attribute Groups.
+using PinnableAttributeGroups = std::vector<PinnableAttributeGroup>;
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <ostream>
 #include <tuple>
 #include <utility>
@@ -121,10 +120,6 @@ class PinnableWideColumns {
 
   void Reset();
 
-  PinnableWideColumns() = default;
-  PinnableWideColumns(const PinnableWideColumns& p);
-  PinnableWideColumns(PinnableWideColumns&& p);
-
  private:
   void CopyValue(const Slice& value);
   void PinOrCopyValue(const Slice& value, Cleanable* cleanable);
@@ -225,16 +220,6 @@ inline bool operator!=(const PinnableWideColumns& lhs,
   return !(lhs == rhs);
 }
 
-inline PinnableWideColumns::PinnableWideColumns(const PinnableWideColumns& p)
-    : columns_(p.columns_) {
-  CopyValue(p.value_);
-}
-
-inline PinnableWideColumns::PinnableWideColumns(PinnableWideColumns&& p) {
-  MoveValue(std::move(p.value_));
-  columns_ = std::move(p.columns_);
-}
-
 // List of PinnableWideColumns grouped by column families. statuses[i] should
 // match the status of getting columns_array[i] when GetEntity() or
 // MultiGetEntity() was called (where 0 <= i < num_column_families_)
@@ -269,7 +254,7 @@ class GroupedPinnableWideColumns {
 
 inline void GroupedPinnableWideColumns::AddColumnsArray(
     PinnableWideColumns&& columns) {
-  columns_array_.emplace_back(columns);
+  columns_array_.emplace_back(std::move(columns));
 }
 inline void GroupedPinnableWideColumns::AddStatus(Status&& status) {
   statuses_.emplace_back(status);

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -231,7 +231,7 @@ class PinnableWideColumnsBundle {
   }
 
   explicit PinnableWideColumnsBundle(ColumnFamilyHandle* column_family)
-      : column_family_(column_family) {}
+      : column_family_(column_family), status_(Status::OK()) {}
 
   void SetStatus(const Status& status);
   void SetPinnableWideColumns(PinnableWideColumns&& pinnable_wide_columns);
@@ -253,6 +253,7 @@ inline void PinnableWideColumnsBundle::SetPinnableWideColumns(
 }
 
 inline void PinnableWideColumnsBundle::Reset() {
+  status_ = Status::OK();
   pinnable_wide_columns_.Reset();
 }
 

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -253,7 +253,7 @@ inline void PinnableWideColumnsBundle::SetPinnableWideColumns(
 }
 
 inline void PinnableWideColumnsBundle::Reset() {
-  status_ = Status::OK();
+  SetStatus(Status::OK());
   pinnable_wide_columns_.Reset();
 }
 

--- a/unreleased_history/new_features/attribute_group_multiget.md
+++ b/unreleased_history/new_features/attribute_group_multiget.md
@@ -1,0 +1,1 @@
+Introduce AttributeGroup by adding the first AttributeGroup support API, MultiGetEntity(). Through the use of Column Families, AttributeGroup enables users to logically group wide-column entities. More APIs to support AttributeGroup will come soon, including GetEntity, PutEntity, and others.

--- a/unreleased_history/new_features/grouped_multi_get_entity.md
+++ b/unreleased_history/new_features/grouped_multi_get_entity.md
@@ -1,1 +1,1 @@
-Add a new MultiGetEntity() which leverages column families for AttributeGroup support. The new API allows users to query wide columns grouped by column families in GroupedPinnableWideColumns for multiple keys and their associated column families in KeyGroupedColumnFamilies.
+Add a new MultiGetEntity() which leverages column families for AttributeGroup support. The new API allows users to query wide columns grouped by column families. See PinnableWideColumnsBundle and PinnableWideColumnsCollection for details.

--- a/unreleased_history/new_features/grouped_multi_get_entity.md
+++ b/unreleased_history/new_features/grouped_multi_get_entity.md
@@ -1,0 +1,1 @@
+Add a new MultiGetEntity() which leverages column families for AttributeGroup support. The new API allows users to query wide columns grouped by column families in GroupedPinnableWideColumns for multiple keys and their associated column families in KeyGroupedColumnFamilies.

--- a/unreleased_history/new_features/grouped_multi_get_entity.md
+++ b/unreleased_history/new_features/grouped_multi_get_entity.md
@@ -1,1 +1,0 @@
-Add a new MultiGetEntity() which leverages column families for AttributeGroup support. The new API allows users to query wide columns grouped by column families. See PinnableWideColumnsBundle and PinnableWideColumnsCollection for details.


### PR DESCRIPTION
# Summary

Introducing the notion of AttributeGroup by adding the `MultiGetEntity()` API retrieving `PinnableAttributeGroups`.
An "attribute group" refers to a logical grouping of wide-column entities within RocksDB. These attribute groups are implemented using column families.

Users can store WideColumns in different CFs for various reasons (e.g. similar access patterns, same types, etc.). This new API `MultiGetEntity()` takes keys and `PinnableAttributeGroups` per key. `PinnableAttributeGroups` is just a list of `PinnableAttributeGroup`s in which we have `ColumnFamilyHandle*`, `Status`, and `PinnableWideColumns`.

Let's say a user stored "hot" wide columns in column family "hot_data_cf" and "cold" wide columns in column family "cold_data_cf" and all other columns in "common_cf". 

Prior to this PR, if the user wants to query for two keys, "key_1" and "key_2" and but only interested in "common_cf" and "hot_data_cf" for "key_1", and "common_cf" and "cold_data_cf" for "key_2", the user would have to construct input like `keys = ["key_1", "key_1", "key_2", "key_2"]`, `column_families = ["common_cf", "hot_data_cf", "common_cf", "cold_data_cf"]` and get the flat list of `PinnableWideColumns` to find the corresponding <key,CF> combo. 

With the new `MultiGetEntity()` introduced in this PR, users can now query only `["common_cf", "hot_data_cf"]` for `"key_1"`, and only `["common_cf", "cold_data_cf"]` for `"key_2"`. The user will get `PinnableAttributeGroups` for each key, and `PinnableAttributeGroups` gives a list of `PinnableAttributeGroup`s where the user can find column family and corresponding `PinnableWideColumns` and the `Status`.

# Test Plan
- `DBWideBasicTest::MultiCFMultiGetEntityAsPinnableAttributeGroups` added

will enable this new API in the `db_stress` in a separate PR


