### PR TITLE
Add the default WritableFile::GetFileSize implementation back for com…

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -1001,7 +1001,7 @@ class WritableFile {
   /*
    * Get the size of valid data in the file.
    */
-  virtual uint64_t GetFileSize() = 0;
+  virtual uint64_t GetFileSize() { return 0; };
 
   /*
    * Get and set the default pre-allocation block size for writes to


### PR DESCRIPTION
As mentioned in #11726, we should defer user feasible API changes to major release.