### PR TITLE
Use a dedicated mutex for synchronizing seqno_to_time_mapping_

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -833,6 +833,9 @@ Status DBImpl::RegisterRecordSeqnoTimeWorker(bool from_db_open) {
         max_preserve_seconds = std::max(preserve_seconds, max_preserve_seconds);
       }
     }
+  }
+  {
+    std::unique_lock seqno_time_lock(seqno_to_time_mutex_);
     if (min_preserve_seconds == std::numeric_limits<uint64_t>::max()) {
       seqno_to_time_mapping_.Resize(0, 0);
     } else {
@@ -6436,7 +6439,7 @@ void DBImpl::RecordSeqnoToTimeMapping(uint64_t populate_historical_seconds) {
   uint64_t unix_time = static_cast<uint64_t>(unix_time_signed);
   bool appended = false;
   {
-    InstrumentedMutexLock l(&mutex_);
+    std::unique_lock seqno_time_lock(seqno_to_time_mutex_);
     if (populate_historical_seconds > 0) {
       if (seqno > 1 && unix_time > populate_historical_seconds) {
         // seqno=0 is reserved

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -15,6 +15,7 @@
 #include <list>
 #include <map>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -2769,8 +2770,10 @@ class DBImpl : public DB {
   std::unique_ptr<StallInterface> wbm_stall_;
 
   // seqno_to_time_mapping_ stores the sequence number to time mapping, it's not
-  // thread safe, both read and write need db mutex hold.
+  // thread safe, access to it needs to be synchronized by seqno_to_time_mutex_.
   SeqnoToTimeMapping seqno_to_time_mapping_;
+
+  mutable std::shared_mutex seqno_to_time_mutex_;
 
   // Stop write token that is acquired when first LockWAL() is called.
   // Destroyed when last UnlockWAL() is called. Controlled by DB mutex.

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -251,8 +251,8 @@ Status DBImpl::FlushMemTableToOutputFile(
       GetCompressionFlush(*cfd->ioptions(), mutable_cf_options), stats_,
       &event_logger_, mutable_cf_options.report_bg_io_stats,
       true /* sync_output_directory */, true /* write_manifest */, thread_pri,
-      io_tracer_, seqno_to_time_mapping_, db_id_, db_session_id_,
-      cfd->GetFullHistoryTsLow(), &blob_callback_);
+      io_tracer_, seqno_to_time_mapping_, &seqno_to_time_mutex_, db_id_,
+      db_session_id_, cfd->GetFullHistoryTsLow(), &blob_callback_);
   FileMetaData file_meta;
 
   Status s;
@@ -523,8 +523,8 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
         GetCompressionFlush(*cfd->ioptions(), mutable_cf_options), stats_,
         &event_logger_, mutable_cf_options.report_bg_io_stats,
         false /* sync_output_directory */, false /* write_manifest */,
-        thread_pri, io_tracer_, seqno_to_time_mapping_, db_id_, db_session_id_,
-        cfd->GetFullHistoryTsLow(), &blob_callback_));
+        thread_pri, io_tracer_, seqno_to_time_mapping_, &seqno_to_time_mutex_,
+        db_id_, db_session_id_, cfd->GetFullHistoryTsLow(), &blob_callback_));
   }
 
   std::vector<FileMetaData> file_meta(num_cfs);

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -305,7 +305,7 @@ const PeriodicTaskScheduler& DBImpl::TEST_GetPeriodicTaskScheduler() const {
 }
 
 SeqnoToTimeMapping DBImpl::TEST_GetSeqnoToTimeMapping() const {
-  InstrumentedMutexLock l(&mutex_);
+  std::shared_lock seqno_time_lock(seqno_to_time_mutex_);
   return seqno_to_time_mapping_;
 }
 

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -100,7 +100,8 @@ FlushJob::FlushJob(
     Statistics* stats, EventLogger* event_logger, bool measure_io_stats,
     const bool sync_output_directory, const bool write_manifest,
     Env::Priority thread_pri, const std::shared_ptr<IOTracer>& io_tracer,
-    const SeqnoToTimeMapping& seqno_to_time_mapping, const std::string& db_id,
+    const SeqnoToTimeMapping& seqno_to_time_mapping,
+    std::shared_mutex* seqno_to_time_mutex, const std::string& db_id,
     const std::string& db_session_id, std::string full_history_ts_low,
     BlobFileCompletionCallback* blob_callback)
     : dbname_(dbname),
@@ -136,7 +137,8 @@ FlushJob::FlushJob(
       clock_(db_options_.clock),
       full_history_ts_low_(std::move(full_history_ts_low)),
       blob_callback_(blob_callback),
-      db_impl_seqno_to_time_mapping_(seqno_to_time_mapping) {
+      db_impl_seqno_to_time_mapping_(seqno_to_time_mapping),
+      db_impl_seqno_to_time_mutex_(seqno_to_time_mutex) {
   // Update the thread status to indicate flush.
   ReportStartedFlush();
   TEST_SYNC_POINT("FlushJob::FlushJob()");
@@ -850,20 +852,22 @@ Status FlushJob::WriteLevel0Table() {
   const uint64_t start_cpu_micros = clock_->CPUMicros();
   Status s;
 
-  SequenceNumber smallest_seqno = mems_.front()->GetEarliestSequenceNumber();
-  if (!db_impl_seqno_to_time_mapping_.Empty()) {
-    // make a local copy, as the seqno_to_time_mapping from db_impl is not
-    // thread safe, which will be used while not holding the db_mutex.
-    seqno_to_time_mapping_ =
-        db_impl_seqno_to_time_mapping_.Copy(smallest_seqno);
-  }
-
   std::vector<BlobFileAddition> blob_file_additions;
 
   {
     auto write_hint = cfd_->CalculateSSTWriteHint(0);
     Env::IOPriority io_priority = GetRateLimiterPriorityForWrite();
     db_mutex_->Unlock();
+    SequenceNumber smallest_seqno = mems_.front()->GetEarliestSequenceNumber();
+    {
+      std::shared_lock seqno_time_lock(*db_impl_seqno_to_time_mutex_);
+      if (!db_impl_seqno_to_time_mapping_.Empty()) {
+        // make a local copy, as the seqno_to_time_mapping from db_impl is not
+        // thread safe, which will be used while not holding the db_mutex.
+        seqno_to_time_mapping_ =
+            db_impl_seqno_to_time_mapping_.Copy(smallest_seqno);
+      }
+    }
     if (log_buffer_) {
       log_buffer_->FlushBufferToLog();
     }

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -13,6 +13,7 @@
 #include <limits>
 #include <list>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -74,6 +75,7 @@ class FlushJob {
            const bool sync_output_directory, const bool write_manifest,
            Env::Priority thread_pri, const std::shared_ptr<IOTracer>& io_tracer,
            const SeqnoToTimeMapping& seq_time_mapping,
+           std::shared_mutex* seqno_to_time_mutex,
            const std::string& db_id = "", const std::string& db_session_id = "",
            std::string full_history_ts_low = "",
            BlobFileCompletionCallback* blob_callback = nullptr);
@@ -211,8 +213,9 @@ class FlushJob {
   BlobFileCompletionCallback* blob_callback_;
 
   // reference to the seqno_to_time_mapping_ in db_impl.h, not safe to read
-  // without db mutex
+  // without db_seqno_to_time_mutex_
   const SeqnoToTimeMapping& db_impl_seqno_to_time_mapping_;
+  std::shared_mutex* db_impl_seqno_to_time_mutex_;
   SeqnoToTimeMapping seqno_to_time_mapping_;
 
   // Keeps track of the newest user-defined timestamp for this flush job if


### PR DESCRIPTION
Currently there aren't any high contention on this variable, there are only these writers and readers:

Writers:
1. Registering periodic worker during db open, SetOptions, CreateColumnFamilies, DropColumnFamilies may resize it.
2. Periodic worker that records the sequence to time mapping appends to it.

Reader:
1. Background flush job copies it to write sequence number to time mapping table property.

Some of them are already holding db mutex to do other stuff, so it's ok and convenient to synchronize access to this variable with db mutex. To implement iterator's write time API, it needs read access to this variable, at that time, it's not ideal to lock db mutex for that purpose. So in preparation for that, this PR use a dedicated shared mutex to synchronize accessing this field.

Test plan:
existing unit tests