### PR TITLE
Clean up WriteBatchWithIndexInternal a bit

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1748,4 +1748,20 @@ const Comparator* GetColumnFamilyUserComparator(
   return nullptr;
 }
 
+const ImmutableOptions& GetImmutableOptions(ColumnFamilyHandle* column_family) {
+  assert(column_family);
+
+  ColumnFamilyHandleImpl* const handle =
+      static_cast_with_check<ColumnFamilyHandleImpl>(column_family);
+  assert(handle);
+
+  const ColumnFamilyData* const cfd = handle->cfd();
+  assert(cfd);
+
+  const ImmutableOptions* ioptions = cfd->ioptions();
+  assert(ioptions);
+
+  return *ioptions;
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -877,4 +877,7 @@ extern uint32_t GetColumnFamilyID(ColumnFamilyHandle* column_family);
 extern const Comparator* GetColumnFamilyUserComparator(
     ColumnFamilyHandle* column_family);
 
+extern const ImmutableOptions& GetImmutableOptions(
+    ColumnFamilyHandle* column_family);
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-
 #include "rocksdb/utilities/write_batch_with_index.h"
 
 #include <map>
@@ -2248,6 +2247,8 @@ TEST_F(WBWIOverwriteTest, TestBadMergeOperator) {
 }
 
 TEST_P(WriteBatchWithIndexTest, ColumnFamilyWithTimestamp) {
+  ASSERT_OK(OpenDB());
+
   ColumnFamilyHandleImplDummy cf2(2,
                                   test::BytewiseComparatorWithU64TsWrapper());
 
@@ -2263,10 +2264,9 @@ TEST_P(WriteBatchWithIndexTest, ColumnFamilyWithTimestamp) {
                   .IsInvalidArgument());
   {
     std::string value;
-    ASSERT_TRUE(batch_
-                    ->GetFromBatchAndDB(
-                        /*db=*/nullptr, ReadOptions(), &cf2, "key", &value)
-                    .IsInvalidArgument());
+    ASSERT_TRUE(
+        batch_->GetFromBatchAndDB(db_, ReadOptions(), &cf2, "key", &value)
+            .IsInvalidArgument());
   }
   {
     constexpr size_t num_keys = 2;
@@ -2275,8 +2275,8 @@ TEST_P(WriteBatchWithIndexTest, ColumnFamilyWithTimestamp) {
         {PinnableSlice(), PinnableSlice()}};
     std::array<Status, num_keys> statuses{{Status(), Status()}};
     constexpr bool sorted_input = false;
-    batch_->MultiGetFromBatchAndDB(/*db=*/nullptr, ReadOptions(), &cf2,
-                                   num_keys, keys.data(), pinnable_vals.data(),
+    batch_->MultiGetFromBatchAndDB(db_, ReadOptions(), &cf2, num_keys,
+                                   keys.data(), pinnable_vals.data(),
                                    statuses.data(), sorted_input);
     for (const auto& s : statuses) {
       ASSERT_TRUE(s.IsInvalidArgument());
@@ -2406,4 +2406,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
Summary: The patch cleans up and refactors the logic in/around `WriteBatchWithIndexInternal` a bit as groundwork for further changes. Specifically, the class is turned back into a stateless collection of static helpers (which is the way it was before PR 6851). Note that there were two apparent reasons for introducing this instance state in PR 6851: a) encapsulating `MergeContext` and b) resolving objects like `Logger` and `Statistics` based on a variety of handles. However, neither reason seems justified at this point. Regarding a), the `MultiGetFromBatchAndDB` logic passes in its own `MergeContext` objects via a second set of methods that do not use the member `MergeContext`. As for b), `Logger` and friends are only needed for Merge, which is only supported if a column family handle is provided; in turn, the column family handle enables us to resolve all the necessary objects without the need for any other handles like `DB` or `DBOptions`. In addition to the above, the patch changes the type of `BaseDeltaIterator::merge_result_` to `std::string` from `PinnableSlice` (since no pinning is ever done) and makes some other small code quality improvements.

Differential Revision: D50038302


