### PR TITLE
Add AsyncIO support for tuning readahead_size by block cache lookup

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -149,19 +149,17 @@ Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
   }
 
   size_t alignment = reader->file()->GetRequiredBufferAlignment();
-  size_t offset_ = static_cast<size_t>(offset);
-  uint64_t rounddown_offset = Rounddown(offset_, alignment);
-  uint64_t roundup_end = Roundup(offset_ + n, alignment);
-  uint64_t roundup_len = roundup_end - rounddown_offset;
-  assert(roundup_len >= alignment);
-  assert(roundup_len % alignment == 0);
+  uint64_t rounddown_offset = offset, roundup_end = 0, chunk_len = 0;
+  size_t read_len = 0;
 
-  uint64_t chunk_len = 0;
-  CalculateOffsetAndLen(alignment, offset, roundup_len, curr_,
-                        true /*refit_tail*/, chunk_len);
-  size_t read_len = static_cast<size_t>(roundup_len - chunk_len);
+  ReadAheadSizeTuning(/*read_curr_block=*/true, /*refit_tail=*/true,
+                      rounddown_offset, curr_, alignment, 0, n,
+                      rounddown_offset, roundup_end, read_len, chunk_len);
 
-  Status s = Read(opts, reader, read_len, chunk_len, rounddown_offset, curr_);
+  Status s;
+  if (read_len > 0) {
+    s = Read(opts, reader, read_len, chunk_len, rounddown_offset, curr_);
+  }
 
   if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail && s.ok()) {
     RecordInHistogram(stats_, TABLE_OPEN_PREFETCH_TAIL_READ_BYTES, read_len);
@@ -266,8 +264,9 @@ void FilePrefetchBuffer::AbortAllIOs() {
 // Clear the buffers if it contains outdated data. Outdated data can be
 // because previous sequential reads were read from the cache instead of these
 // buffer.
-void FilePrefetchBuffer::UpdateBuffersIfNeeded(uint64_t offset) {
+void FilePrefetchBuffer::UpdateBuffersIfNeeded(uint64_t offset, size_t length) {
   uint32_t second = curr_ ^ 1;
+
   if (IsBufferOutdated(offset, curr_)) {
     bufs_[curr_].buffer_.Clear();
   }
@@ -276,17 +275,23 @@ void FilePrefetchBuffer::UpdateBuffersIfNeeded(uint64_t offset) {
   }
 
   {
-    // In case buffers do not align, reset second buffer. This can happen in
-    // case readahead_size is set.
+    // In case buffers do not align, reset second buffer if requested data needs
+    // to be read in second buffer.
     if (!bufs_[second].async_read_in_progress_ &&
         !bufs_[curr_].async_read_in_progress_) {
       if (DoesBufferContainData(curr_)) {
         if (bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize() !=
             bufs_[second].offset_) {
-          bufs_[second].buffer_.Clear();
+          if (DoesBufferContainData(second) &&
+              IsOffsetInBuffer(offset, curr_) &&
+              (offset + length >
+               bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize())) {
+            bufs_[second].buffer_.Clear();
+          }
         }
       } else {
-        if (!IsOffsetInBuffer(offset, second)) {
+        if (DoesBufferContainData(second) &&
+            !IsOffsetInBuffer(offset, second)) {
           bufs_[second].buffer_.Clear();
         }
       }
@@ -308,7 +313,8 @@ void FilePrefetchBuffer::UpdateBuffersIfNeeded(uint64_t offset) {
   }
 }
 
-void FilePrefetchBuffer::PollAndUpdateBuffersIfNeeded(uint64_t offset) {
+void FilePrefetchBuffer::PollAndUpdateBuffersIfNeeded(uint64_t offset,
+                                                      size_t length) {
   if (bufs_[curr_].async_read_in_progress_ && fs_ != nullptr) {
     if (bufs_[curr_].io_handle_ != nullptr) {
       // Wait for prefetch data to complete.
@@ -324,7 +330,75 @@ void FilePrefetchBuffer::PollAndUpdateBuffersIfNeeded(uint64_t offset) {
     // completed.
     DestroyAndClearIOHandle(curr_);
   }
-  UpdateBuffersIfNeeded(offset);
+  UpdateBuffersIfNeeded(offset, length);
+}
+
+// ReadAheadSizeTuning API calls readaheadsize_cb_
+// (BlockBasedTableIterator::BlockCacheLookupForReadAheadSize) to lookup in the
+// cache and tune the start and end offsets based on cache hits/misses.
+//
+// Arguments -
+// read_curr_block : True if this call was due to miss in the cache and
+//                   FilePrefetchBuffer wants to read that block synchronously.
+//                   False if current call is to prefetch additional data in
+//                   extra buffers through ReadAsync API.
+// prev_buf_offset : End offset of the previous buffer. It's used in case
+//                   of ReadAsync to make sure it doesn't read anything from
+//                   previous buffer which is already prefetched.
+void FilePrefetchBuffer::ReadAheadSizeTuning(
+    bool read_curr_block, bool refit_tail, uint64_t prev_buf_offset,
+    uint32_t index, size_t alignment, size_t length, size_t readahead_size,
+    uint64_t& start_offset, uint64_t& end_offset, size_t& read_len,
+    uint64_t& chunk_len) {
+  uint64_t updated_start_offset = Rounddown(start_offset, alignment);
+  uint64_t updated_end_offset =
+      Roundup(start_offset + length + readahead_size, alignment);
+  uint64_t initial_end_offset = updated_end_offset;
+
+  // Callback to tune the start and end offsets.
+  if (readaheadsize_cb_ != nullptr && readahead_size > 0 &&
+      !explicit_prefetch_submitted_) {
+    readaheadsize_cb_(read_curr_block, updated_start_offset,
+                      updated_end_offset);
+    if (initial_end_offset != updated_end_offset) {
+      RecordTick(stats_, READAHEAD_TRIMMED);
+    }
+  }
+
+  // read_len will be 0 and there is nothing to read/prefetch.
+  if (updated_start_offset == updated_end_offset) {
+    return;
+  }
+
+  assert(updated_start_offset < updated_end_offset);
+
+  if (!read_curr_block) {
+    if (updated_end_offset <= prev_buf_offset) {
+      // It can be when this call only added previous block handles.
+      start_offset = end_offset = prev_buf_offset;
+      return;
+    }
+  }
+
+  // Realign if start and end offsets are not aligned after tuning.
+  start_offset = Rounddown(updated_start_offset, alignment);
+  end_offset = Roundup(updated_end_offset, alignment);
+
+  if (!read_curr_block && start_offset < prev_buf_offset) {
+    // Previous buffer already contains the data till prev_buf_offset because of
+    // alignment. Update the start offset after that.
+    start_offset = prev_buf_offset;
+  }
+
+  uint64_t roundup_len = end_offset - start_offset;
+
+  CalculateOffsetAndLen(alignment, start_offset, roundup_len, index, refit_tail,
+                        chunk_len);
+  assert(roundup_len >= chunk_len);
+
+  // Update the buffer offset.
+  bufs_[index].offset_ = start_offset;
+  read_len = static_cast<size_t>(roundup_len - chunk_len);
 }
 
 Status FilePrefetchBuffer::HandleOverlappingData(
@@ -340,7 +414,7 @@ Status FilePrefetchBuffer::HandleOverlappingData(
   // by Seek, but the next access is at another offset.
   if (bufs_[curr_].async_read_in_progress_ &&
       IsOffsetInBufferWithAsyncProgress(offset, curr_)) {
-    PollAndUpdateBuffersIfNeeded(offset);
+    PollAndUpdateBuffersIfNeeded(offset, length);
   }
   second = curr_ ^ 1;
 
@@ -363,7 +437,7 @@ Status FilePrefetchBuffer::HandleOverlappingData(
     CopyDataToBuffer(curr_, tmp_offset, tmp_length);
 
     // Call async prefetching on curr_ since data has been consumed in curr_
-    // only if data lies within second buffer.
+    // only if requested data lies within second buffer.
     size_t second_size = bufs_[second].async_read_in_progress_
                              ? bufs_[second].async_req_len_
                              : bufs_[second].buffer_.CurrentSize();
@@ -372,22 +446,20 @@ Status FilePrefetchBuffer::HandleOverlappingData(
     // that data.
     if (tmp_offset + tmp_length <= bufs_[second].offset_ + second_size &&
         !IsOffsetOutOfBound(rounddown_start)) {
-      uint64_t roundup_end =
-          Roundup(rounddown_start + readahead_size, alignment);
-      uint64_t roundup_len = roundup_end - rounddown_start;
-      uint64_t chunk_len = 0;
-      CalculateOffsetAndLen(alignment, rounddown_start, roundup_len, curr_,
-                            false, chunk_len);
-      assert(chunk_len == 0);
-      assert(roundup_len >= chunk_len);
+      size_t read_len = 0;
+      uint64_t end_offset = rounddown_start, chunk_len = 0;
 
-      bufs_[curr_].offset_ = rounddown_start;
-      uint64_t read_len = static_cast<size_t>(roundup_len - chunk_len);
-      s = ReadAsync(opts, reader, read_len, rounddown_start, curr_);
-      if (!s.ok()) {
-        DestroyAndClearIOHandle(curr_);
-        bufs_[curr_].buffer_.Clear();
-        return s;
+      ReadAheadSizeTuning(/*read_curr_block=*/false, /*refit_tail=*/false,
+                          bufs_[second].offset_ + second_size, curr_, alignment,
+                          /*length=*/0, readahead_size, rounddown_start,
+                          end_offset, read_len, chunk_len);
+      if (read_len > 0) {
+        s = ReadAsync(opts, reader, read_len, rounddown_start, curr_);
+        if (!s.ok()) {
+          DestroyAndClearIOHandle(curr_);
+          bufs_[curr_].buffer_.Clear();
+          return s;
+        }
       }
     }
     curr_ = curr_ ^ 1;
@@ -436,7 +508,7 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(const IOOptions& opts,
   if (!explicit_prefetch_submitted_) {
     AbortIOIfNeeded(offset);
   }
-  UpdateBuffersIfNeeded(offset);
+  UpdateBuffersIfNeeded(offset, length);
 
   // 2. Handle overlapping data over two buffers. If data is overlapping then
   //    during this call:
@@ -458,14 +530,14 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(const IOOptions& opts,
   if (!bufs_[curr_].async_read_in_progress_ && DoesBufferContainData(curr_) &&
       IsDataBlockInBuffer(offset, length, curr_)) {
     // Whole data is in curr_.
-    UpdateBuffersIfNeeded(offset);
+    UpdateBuffersIfNeeded(offset, length);
     if (!IsSecondBuffEligibleForPrefetching()) {
       return s;
     }
   } else {
     // After poll request, curr_ might be empty because of IOError in
     // callback while reading or may contain required data.
-    PollAndUpdateBuffersIfNeeded(offset);
+    PollAndUpdateBuffersIfNeeded(offset, length);
   }
 
   if (copy_to_third_buffer) {
@@ -529,62 +601,46 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(const IOOptions& opts,
   }
 
   // 6. Go for ReadAsync and Read (if needed).
-  size_t prefetch_size = length + readahead_size;
-  size_t _offset = static_cast<size_t>(offset);
-
-  // offset and size alignment for curr_ buffer with synchronous prefetching
-  uint64_t rounddown_start1 = Rounddown(_offset, alignment);
-  uint64_t roundup_end1 = Roundup(_offset + prefetch_size, alignment);
-  uint64_t roundup_len1 = roundup_end1 - rounddown_start1;
-  assert(roundup_len1 >= alignment);
-  assert(roundup_len1 % alignment == 0);
-  uint64_t chunk_len1 = 0;
-  uint64_t read_len1 = 0;
-
   assert(!bufs_[second].async_read_in_progress_ &&
          !DoesBufferContainData(second));
 
+  // offset and size alignment for curr_ buffer with synchronous prefetching
+  uint64_t rounddown_start1 = offset, roundup_end1 = 0, chunk_len1 = 0;
+  size_t read_len1 = 0;
+
   // For length == 0, skip the synchronous prefetching. read_len1 will be 0.
   if (length > 0) {
-    CalculateOffsetAndLen(alignment, offset, roundup_len1, curr_,
-                          false /*refit_tail*/, chunk_len1);
-    assert(roundup_len1 >= chunk_len1);
-    read_len1 = static_cast<size_t>(roundup_len1 - chunk_len1);
+    ReadAheadSizeTuning(/*read_curr_block=*/true, /*refit_tail=*/false,
+                        rounddown_start1, curr_, alignment, length,
+                        readahead_size, rounddown_start1, roundup_end1,
+                        read_len1, chunk_len1);
+  } else {
+    roundup_end1 = bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize();
   }
 
-  // Prefetch in second buffer only if readahead_size_ > 0.
-  if (readahead_size_ > 0) {
+  // Prefetch in second buffer only if readahead_size > 0.
+  if (readahead_size > 0) {
     // offset and size alignment for second buffer for asynchronous
-    // prefetching
+    // prefetching.
     uint64_t rounddown_start2 = roundup_end1;
-    uint64_t roundup_end2 =
-        Roundup(rounddown_start2 + readahead_size, alignment);
-
-    // For length == 0, do the asynchronous prefetching in second instead of
-    // synchronous prefetching in curr_.
-    if (length == 0) {
-      rounddown_start2 =
-          bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize();
-      roundup_end2 = Roundup(rounddown_start2 + prefetch_size, alignment);
-    }
 
     // Second buffer might be out of bound if first buffer already prefetched
     // that data.
     if (!IsOffsetOutOfBound(rounddown_start2)) {
-      uint64_t roundup_len2 = roundup_end2 - rounddown_start2;
-      uint64_t chunk_len2 = 0;
-      CalculateOffsetAndLen(alignment, rounddown_start2, roundup_len2, second,
-                            false /*refit_tail*/, chunk_len2);
-      assert(chunk_len2 == 0);
-      // Update the buffer offset.
-      bufs_[second].offset_ = rounddown_start2;
-      assert(roundup_len2 >= chunk_len2);
-      uint64_t read_len2 = static_cast<size_t>(roundup_len2 - chunk_len2);
-      s = ReadAsync(opts, reader, read_len2, rounddown_start2, second);
-      if (!s.ok()) {
-        DestroyAndClearIOHandle(second);
-        bufs_[second].buffer_.Clear();
-        return s;
+      // Find updated readahead size after tuning
+      size_t read_len2 = 0;
+      uint64_t roundup_end2 = rounddown_start2, chunk_len2 = 0;
+      ReadAheadSizeTuning(/*read_curr_block=*/false, /*refit_tail=*/false,
+                          /*prev_buf_offset=*/roundup_end1, second, alignment,
+                          /*length=*/0, readahead_size, rounddown_start2,
+                          roundup_end2, read_len2, chunk_len2);
+      if (read_len2 > 0) {
+        s = ReadAsync(opts, reader, read_len2, rounddown_start2, second);
+        if (!s.ok()) {
+          DestroyAndClearIOHandle(second);
+          bufs_[second].buffer_.Clear();
+          return s;
+        }
       }
     }
   }
@@ -607,6 +663,7 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(const IOOptions& opts,
       return s;
     }
   }
+
   // Copy remaining requested bytes to third_buffer.
   if (copy_to_third_buffer && length > 0) {
     CopyDataToBuffer(curr_, offset, length);
@@ -668,8 +725,8 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
             return false;
           }
         }
-        size_t current_readahead_size = ReadAheadSizeTuning(offset, n);
-        s = Prefetch(opts, reader, offset, n + current_readahead_size);
+        UpdateReadAheadSizeForUpperBound(offset, n);
+        s = Prefetch(opts, reader, offset, n + readahead_size_);
       }
       if (!s.ok()) {
         if (status) {
@@ -860,12 +917,17 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   AbortAllIOs();
 
   // 2. Clear outdated data.
-  UpdateBuffersIfNeeded(offset);
+  UpdateBuffersIfNeeded(offset, n);
   uint32_t second = curr_ ^ 1;
-  // Since PrefetchAsync can be called on non sequential reads. So offset can
-  // be less than curr_ buffers' offset. In that case also it clears both
-  // buffers.
-  if (DoesBufferContainData(curr_) && !IsOffsetInBuffer(offset, curr_)) {
+
+  // - Since PrefetchAsync can be called on non sequential reads. So offset can
+  //   be less than curr_ buffers' offset. In that case it clears both
+  //   buffers.
+  // - In case of tuning of readahead_size, on Reseek, we have to clear both
+  //   buffers otherwise, we may end up with inconsistent BlockHandles in queue
+  //   and data in buffer.
+  if (readaheadsize_cb_ != nullptr ||
+      (DoesBufferContainData(curr_) && !IsOffsetInBuffer(offset, curr_))) {
     bufs_[curr_].buffer_.Clear();
     bufs_[second].buffer_.Clear();
   }
@@ -894,45 +956,42 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   }
   bufs_[second].buffer_.Clear();
 
+  std::string msg;
+
   Status s;
   size_t alignment = reader->file()->GetRequiredBufferAlignment();
-  size_t prefetch_size = is_eligible_for_prefetching ? readahead_size_ / 2 : 0;
+  size_t readahead_size = is_eligible_for_prefetching ? readahead_size_ / 2 : 0;
   size_t offset_to_read = static_cast<size_t>(offset);
-  uint64_t rounddown_start1 = 0;
-  uint64_t roundup_end1 = 0;
-  uint64_t rounddown_start2 = 0;
-  uint64_t roundup_end2 = 0;
-  uint64_t chunk_len1 = 0;
-  uint64_t chunk_len2 = 0;
-  size_t read_len1 = 0;
-  size_t read_len2 = 0;
+  uint64_t rounddown_start1 = offset, roundup_end1 = 0, rounddown_start2 = 0,
+           chunk_len1 = 0;
+  size_t read_len1 = 0, read_len2 = 0;
 
   // - If curr_ is empty.
-  //   - Call async read for full data +  prefetch_size on curr_.
-  //   - Call async read for prefetch_size on second if eligible.
+  //   - Call async read for full data +  readahead_size on curr_.
+  //   - Call async read for readahead_size on second if eligible.
   // - If curr_ is filled.
-  //   - prefetch_size on second.
+  //   - readahead_size on second.
   // Calculate length and offsets for reading.
   if (!DoesBufferContainData(curr_)) {
     uint64_t roundup_len1;
-    // Prefetch full data + prefetch_size in curr_.
+    // Prefetch full data + readahead_size in curr_.
     if (is_eligible_for_prefetching || reader->use_direct_io()) {
-      rounddown_start1 = Rounddown(offset_to_read, alignment);
-      roundup_end1 = Roundup(offset_to_read + n + prefetch_size, alignment);
-      roundup_len1 = roundup_end1 - rounddown_start1;
-      assert(roundup_len1 >= alignment);
-      assert(roundup_len1 % alignment == 0);
+      ReadAheadSizeTuning(/*read_curr_block=*/true, /*refit_tail=*/false,
+                          /*prev_buf_offset=*/rounddown_start1, curr_,
+                          alignment, n, readahead_size, rounddown_start1,
+                          roundup_end1, read_len1, chunk_len1);
     } else {
+      // No alignment or extra prefetching.
       rounddown_start1 = offset_to_read;
       roundup_end1 = offset_to_read + n;
       roundup_len1 = roundup_end1 - rounddown_start1;
+      CalculateOffsetAndLen(alignment, rounddown_start1, roundup_len1, curr_,
+                            false, chunk_len1);
+      assert(chunk_len1 == 0);
+      assert(roundup_len1 >= chunk_len1);
+      read_len1 = static_cast<size_t>(roundup_len1);
+      bufs_[curr_].offset_ = rounddown_start1;
     }
-    CalculateOffsetAndLen(alignment, rounddown_start1, roundup_len1, curr_,
-                          false, chunk_len1);
-    assert(chunk_len1 == 0);
-    assert(roundup_len1 >= chunk_len1);
-    read_len1 = static_cast<size_t>(roundup_len1);
-    bufs_[curr_].offset_ = rounddown_start1;
   }
 
   if (is_eligible_for_prefetching) {
@@ -946,16 +1005,11 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
     // Second buffer might be out of bound if first buffer already prefetched
     // that data.
     if (!IsOffsetOutOfBound(rounddown_start2)) {
-      roundup_end2 = Roundup(rounddown_start2 + prefetch_size, alignment);
-      uint64_t roundup_len2 = roundup_end2 - rounddown_start2;
-
-      CalculateOffsetAndLen(alignment, rounddown_start2, roundup_len2, second,
-                            false, chunk_len2);
-      assert(chunk_len2 == 0);
-      assert(roundup_len2 >= chunk_len2);
-      read_len2 = static_cast<size_t>(roundup_len2 - chunk_len2);
-      // Update the buffer offset.
-      bufs_[second].offset_ = rounddown_start2;
+      uint64_t roundup_end2 = rounddown_start2, chunk_len2 = 0;
+      ReadAheadSizeTuning(/*read_curr_block=*/false, /*refit_tail=*/false,
+                          /*prev_buf_offset=*/roundup_end1, second, alignment,
+                          /*length=*/0, readahead_size, rounddown_start2,
+                          roundup_end2, read_len2, chunk_len2);
     }
   }
 
@@ -969,6 +1023,7 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
     explicit_prefetch_submitted_ = true;
     prev_len_ = 0;
   }
+
   if (read_len2) {
     TEST_SYNC_POINT("FilePrefetchBuffer::PrefetchAsync:ExtraPrefetching");
     s = ReadAsync(opts, reader, read_len2, rounddown_start2, second);

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -442,13 +442,12 @@ Status FilePrefetchBuffer::HandleOverlappingData(
     size_t second_size = bufs_[second].async_read_in_progress_
                              ? bufs_[second].async_req_len_
                              : bufs_[second].buffer_.CurrentSize();
-    uint64_t rounddown_start = bufs_[second].offset_ + second_size;
+    uint64_t rounddown_start = bufs_[second].initial_end_offset_;
     // Second buffer might be out of bound if first buffer already prefetched
     // that data.
     if (tmp_offset + tmp_length <= bufs_[second].offset_ + second_size &&
         !IsOffsetOutOfBound(rounddown_start)) {
       size_t read_len = 0;
-      rounddown_start = bufs_[second].initial_end_offset_;
       uint64_t end_offset = rounddown_start, chunk_len = 0;
 
       ReadAheadSizeTuning(/*read_curr_block=*/false, /*refit_tail=*/false,
@@ -997,14 +996,7 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   }
 
   if (is_eligible_for_prefetching) {
-    if (DoesBufferContainData(curr_)) {
-      rounddown_start2 =
-          bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize();
-    } else {
-      rounddown_start2 = roundup_end1;
-    }
     rounddown_start2 = bufs_[curr_].initial_end_offset_;
-
     // Second buffer might be out of bound if first buffer already prefetched
     // that data.
     if (!IsOffsetOutOfBound(rounddown_start2)) {

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -32,6 +32,11 @@ struct IOOptions;
 class RandomAccessFileReader;
 
 struct BufferInfo {
+  void ClearBuffer() {
+    buffer_.Clear();
+    initial_end_offset_ = 0;
+  }
+
   AlignedBuffer buffer_;
 
   uint64_t offset_ = 0;
@@ -52,6 +57,8 @@ struct BufferInfo {
 
   // pos represents the index of this buffer in vector of BufferInfo.
   uint32_t pos_ = 0;
+
+  uint64_t initial_end_offset_ = 0;
 };
 
 enum class FilePrefetchBufferUsage {
@@ -399,7 +406,7 @@ class FilePrefetchBuffer {
       return false;
     }
 
-    bufs_[second].buffer_.Clear();
+    bufs_[second].ClearBuffer();
     return true;
   }
 

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -64,9 +64,10 @@ struct BufferInfo {
   // initial end offset of this buffer which will be the starting
   // offset of next prefetch.
   //
-  // Note: No need to update/use in case async_io disabled. Prefetching will
-  // happen only when there is a cache miss. So start offset for prefetching
-  // will always be the passed offset to FilePrefetchBuffer (offset to read).
+  // For example - if end offset of previous buffer was 100 and because of
+  // readahead_size optimization, end_offset was trimmed to 60. Then for next
+  // prefetch call, start_offset should be intialized to 100 i.e  start_offset =
+  // buf->initial_end_offset_.
   uint64_t initial_end_offset_ = 0;
 };
 

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -58,6 +58,8 @@ struct BufferInfo {
   // pos represents the index of this buffer in vector of BufferInfo.
   uint32_t pos_ = 0;
 
+  // initial_end_offset is used to keep track of the end offset of the buffer
+  // that was originally called.
   uint64_t initial_end_offset_ = 0;
 };
 

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -471,6 +471,15 @@ class FilePrefetchBuffer {
                            uint64_t& end_offset, size_t& read_len,
                            uint64_t& chunk_len);
 
+  void UpdateStats(bool found_in_buffer, size_t length_found) {
+    if (found_in_buffer) {
+      RecordTick(stats_, PREFETCH_HITS);
+    }
+    if (length_found > 0) {
+      RecordTick(stats_, PREFETCH_BYTES_USEFUL, length_found);
+    }
+  }
+
   std::vector<BufferInfo> bufs_;
   // curr_ represents the index for bufs_ indicating which buffer is being
   // consumed currently.

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -59,7 +59,10 @@ struct BufferInfo {
   uint32_t pos_ = 0;
 
   // initial_end_offset is used to keep track of the end offset of the buffer
-  // that was originally called.
+  // that was originally called. It's helpful in case of autotuning of readahead
+  // size when callback is made to BlockBasedTableIterator.
+  // initial end offset of this buffer which will be the starting
+  // offset of next prefetch.
   uint64_t initial_end_offset_ = 0;
 };
 
@@ -458,7 +461,7 @@ class FilePrefetchBuffer {
   }
 
   void ReadAheadSizeTuning(bool read_curr_block, bool refit_tail,
-                           uint64_t prev_buf_offset, uint32_t index,
+                           uint64_t prev_buf_end_offset, uint32_t index,
                            size_t alignment, size_t length,
                            size_t readahead_size, uint64_t& offset,
                            uint64_t& end_offset, size_t& read_len,

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -300,6 +300,12 @@ class FilePrefetchBuffer {
     readahead_size_ = initial_auto_readahead_size_;
   }
 
+  void TEST_GetBufferOffsetandSize(uint32_t index, uint64_t& offset,
+                                   size_t& len) {
+    offset = bufs_[index].offset_;
+    len = bufs_[index].buffer_.CurrentSize();
+  }
+
  private:
   // Calculates roundoff offset and length to be prefetched based on alignment
   // and data present in buffer_. It also allocates new buffer or refit tail if

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -63,6 +63,10 @@ struct BufferInfo {
   // size when callback is made to BlockBasedTableIterator.
   // initial end offset of this buffer which will be the starting
   // offset of next prefetch.
+  //
+  // Note: No need to update/use in case async_io disabled. Prefetching will
+  // happen only when there is a cache miss. So start offset for prefetching
+  // will always be the passed offset to FilePrefetchBuffer (offset to read).
   uint64_t initial_end_offset_ = 0;
 };
 
@@ -321,11 +325,11 @@ class FilePrefetchBuffer {
                                bool& copy_to_third_buffer);
 
   Status Read(const IOOptions& opts, RandomAccessFileReader* reader,
-              uint64_t read_len, uint64_t chunk_len, uint64_t rounddown_start,
+              uint64_t read_len, uint64_t chunk_len, uint64_t start_offset,
               uint32_t index);
 
   Status ReadAsync(const IOOptions& opts, RandomAccessFileReader* reader,
-                   uint64_t read_len, uint64_t rounddown_start, uint32_t index);
+                   uint64_t read_len, uint64_t start_offset, uint32_t index);
 
   // Copy the data from src to third buffer.
   void CopyDataToBuffer(uint32_t src, uint64_t& offset, size_t& length);

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1325,6 +1325,10 @@ TEST_P(PrefetchTest, PrefetchWithBlockLookupAutoTuneTest) {
       ropts.readahead_size = cmp_ro.readahead_size = 32768;
     }
 
+    if (std::get<1>(GetParam())) {
+      ropts.async_io = true;
+    }
+
     // With and without tuning readahead_size.
     {
       ASSERT_OK(options.statistics->Reset());

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -492,8 +492,9 @@ IOStatus RandomAccessFileReader::ReadAsync(
   auto read_async_callback =
       std::bind(&RandomAccessFileReader::ReadAsyncCallback, this,
                 std::placeholders::_1, std::placeholders::_2);
-  ReadAsyncInfo* read_async_info =
-      new ReadAsyncInfo(cb, cb_arg, clock_->NowMicros());
+
+  ReadAsyncInfo* read_async_info = new ReadAsyncInfo(
+      cb, cb_arg, (clock_ != nullptr ? clock_->NowMicros() : 0));
 
   if (ShouldNotifyListeners()) {
     read_async_info->fs_start_ts_ = FileOperationInfo::StartNow();

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -18,21 +18,36 @@ void BlockBasedTableIterator::Seek(const Slice& target) {
 
 void BlockBasedTableIterator::SeekImpl(const Slice* target,
                                        bool async_prefetch) {
-  ResetBlockCacheLookupVar();
   bool is_first_pass = !async_read_in_progress_;
+  if (is_first_pass) {
+    ResetBlockCacheLookupVar();
+  }
+
   bool autotune_readaheadsize = is_first_pass &&
                                 read_options_.auto_readahead_size &&
                                 read_options_.iterate_upper_bound;
 
   if (autotune_readaheadsize &&
       table_->get_rep()->table_options.block_cache.get() &&
-      !read_options_.async_io && direction_ == IterDirection::kForward) {
+      direction_ == IterDirection::kForward) {
     readahead_cache_lookup_ = true;
   }
 
   // Second pass.
-  if (async_read_in_progress_) {
-    AsyncInitDataBlock(false);
+  if (!is_first_pass) {
+    AsyncInitDataBlock(is_first_pass);
+
+    if (target) {
+      block_iter_.Seek(*target);
+    } else {
+      block_iter_.SeekToFirst();
+    }
+    FindKeyForward();
+
+    CheckOutOfBound();
+
+    assert(!Valid() || icomp_.Compare(*target, key()) <= 0);
+    return;
   }
 
   is_out_of_bound_ = false;
@@ -111,7 +126,6 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
 
   // After reseek, index_iter_ point to the right key i.e. target in
   // case of readahead_cache_lookup_. So index_iter_ can be used directly.
-
   IndexValue v = index_iter_->value();
   const bool same_block = block_iter_points_to_real_block_ &&
                           v.handle.offset() == prev_block_offset_;
@@ -130,14 +144,12 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
     // Need to use the data block.
     if (!same_block) {
       if (read_options_.async_io && async_prefetch) {
-        if (is_first_pass) {
-          AsyncInitDataBlock(is_first_pass);
-        }
+        AsyncInitDataBlock(is_first_pass);
         if (async_read_in_progress_) {
           // Status::TryAgain indicates asynchronous request for retrieval of
           // data blocks has been submitted. So it should return at this point
-          // and Seek should be called again to retrieve the requested block and
-          // execute the remaining code.
+          // and Seek should be called again to retrieve the requested block
+          // and execute the remaining code.
           return;
         }
       } else {
@@ -288,8 +300,9 @@ bool BlockBasedTableIterator::NextAndGetResult(IterateResult* result) {
 void BlockBasedTableIterator::Prev() {
   // Return Error.
   if (readahead_cache_lookup_) {
-    block_iter_.Invalidate(Status::NotSupported(
-        "auto tuning of readahead_size is not supported with Prev operation."));
+    block_iter_.Invalidate(
+        Status::NotSupported("auto tuning of readahead_size in is not "
+                             "supported with Prev operation."));
     return;
   }
 
@@ -346,7 +359,7 @@ void BlockBasedTableIterator::InitDataBlock() {
     } else {
       auto* rep = table_->get_rep();
 
-      std::function<void(uint64_t offset, size_t, size_t&)> readaheadsize_cb =
+      std::function<void(bool, uint64_t&, uint64_t&)> readaheadsize_cb =
           nullptr;
       if (readahead_cache_lookup_) {
         readaheadsize_cb = std::bind(
@@ -389,10 +402,11 @@ void BlockBasedTableIterator::InitDataBlock() {
 }
 
 void BlockBasedTableIterator::AsyncInitDataBlock(bool is_first_pass) {
-  BlockHandle data_block_handle = index_iter_->value().handle;
+  BlockHandle data_block_handle;
   bool is_for_compaction =
       lookup_context_.caller == TableReaderCaller::kCompaction;
   if (is_first_pass) {
+    data_block_handle = index_iter_->value().handle;
     if (!block_iter_points_to_real_block_ ||
         data_block_handle.offset() != prev_block_offset_ ||
         // if previous attempt of reading the block missed cache, try again
@@ -402,7 +416,7 @@ void BlockBasedTableIterator::AsyncInitDataBlock(bool is_first_pass) {
       }
       auto* rep = table_->get_rep();
 
-      std::function<void(uint64_t offset, size_t, size_t&)> readaheadsize_cb =
+      std::function<void(bool, uint64_t&, uint64_t&)> readaheadsize_cb =
           nullptr;
       if (readahead_cache_lookup_) {
         readaheadsize_cb = std::bind(
@@ -441,13 +455,30 @@ void BlockBasedTableIterator::AsyncInitDataBlock(bool is_first_pass) {
   } else {
     // Second pass will call the Poll to get the data block which has been
     // requested asynchronously.
+    bool is_in_cache = false;
+
+    if (DoesContainBlockHandles()) {
+      data_block_handle = block_handles_.front().handle_;
+      is_in_cache = block_handles_.front().is_cache_hit_;
+    } else {
+      data_block_handle = index_iter_->value().handle;
+    }
+
     Status s;
-    table_->NewDataBlockIterator<DataBlockIter>(
-        read_options_, data_block_handle, &block_iter_, BlockType::kData,
-        /*get_context=*/nullptr, &lookup_context_,
-        block_prefetcher_.prefetch_buffer(),
-        /*for_compaction=*/is_for_compaction, /*async_read=*/false, s,
-        /*use_block_cache_for_lookup=*/false);
+    // Initialize Data Block From CacheableEntry.
+    if (is_in_cache) {
+      block_iter_.Invalidate(Status::OK());
+      table_->NewDataBlockIterator<DataBlockIter>(
+          read_options_, (block_handles_.front().cachable_entry_).As<Block>(),
+          &block_iter_, s);
+    } else {
+      table_->NewDataBlockIterator<DataBlockIter>(
+          read_options_, data_block_handle, &block_iter_, BlockType::kData,
+          /*get_context=*/nullptr, &lookup_context_,
+          block_prefetcher_.prefetch_buffer(),
+          /*for_compaction=*/is_for_compaction, /*async_read=*/false, s,
+          /*use_block_cache_for_lookup=*/false);
+    }
   }
   block_iter_points_to_real_block_ = true;
   CheckDataBlockWithinUpperBound();
@@ -672,65 +703,125 @@ void BlockBasedTableIterator::FindReadAheadSizeUpperBound() {
                                         total_bytes_till_upper_bound);
 }
 
-void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
-    uint64_t offset, size_t readahead_size, size_t& updated_readahead_size) {
-  updated_readahead_size = readahead_size;
+void BlockBasedTableIterator::InitializeStartAndEndOffsets(
+    bool read_curr_block, bool& found_first_miss_block,
+    uint64_t& start_updated_offset, uint64_t end_updated_offset,
+    size_t& prev_handles_size) {
+  prev_handles_size = block_handles_.size();
+  size_t footer = table_->get_rep()->footer.GetBlockTrailerSize();
+  if (read_curr_block) {
+    if (DoesContainBlockHandles()) {
+      // Read curr block but it already has exisiting handles.
+      // It can be due to reading error in second buffer in FilePrefetchBuffer.
+      // BlockHandles already added to the queue but there was error in reading
+      // those handles so in this call they need to be read again.
+      assert(block_handles_.front().is_cache_hit_ == false);
+      found_first_miss_block = true;
+      // Initialize prev_handles_size to 0 as all those handles need to be read
+      // again.
+      prev_handles_size = 0;
+      start_updated_offset = block_handles_.front().handle_.offset();
+      end_updated_offset = block_handles_.back().handle_.offset() + footer +
+                           block_handles_.back().handle_.size();
+    } else {
+      // Add current block here as it doesn't need any lookup.
+      BlockHandleInfo block_handle_info;
+      block_handle_info.handle_ = index_iter_->value().handle;
+      block_handle_info.SetFirstInternalKey(
+          index_iter_->value().first_internal_key);
 
-  // readahead_cache_lookup_ can be set false after Seek, if after Seek or Next
+      end_updated_offset = block_handle_info.handle_.offset() + footer +
+                           block_handle_info.handle_.size();
+      block_handles_.emplace_back(std::move(block_handle_info));
+
+      index_iter_->Next();
+      is_index_at_curr_block_ = false;
+      found_first_miss_block = true;
+    }
+  } else {
+    if (DoesContainBlockHandles()) {
+      start_updated_offset = end_updated_offset =
+          block_handles_.back().handle_.offset() + footer +
+          block_handles_.back().handle_.size();
+    } else {
+      // Doesn't have any data block handles so it'll start current index.
+      // It can be when Reseek is from block cache, it doesn't clear the buffers
+      // and reseek lies within the buffer. So Next will prefetch async data.
+      // All handles need to be added to the queue starting from index_iter_.
+      assert(index_iter_->Valid());
+      start_updated_offset = end_updated_offset =
+          index_iter_->value().handle.offset();
+    }
+  }
+}
+
+// BlockCacheLookupForReadAheadSize API lookups in the block cache and tries to
+// reduce the start and end offset passed.
+//
+// Implementation -
+// This function looks into the block cache for the blocks between start_offset
+// and end_offset and add all the handles in the queue.
+// It then iterates from the end to find first miss block and update the end
+// offset to that block.
+// It also iterates from the start and find first miss block and update the
+// start offset to that block.
+//
+// Arguments -
+// start_offset    : Offset from which the caller wants to read.
+// end_offset      : End offset till which the caller wants to read.
+// read_curr_block : True if this call was due to miss in the cache and
+//                   caller wants to read that block.
+//                   False if current call is to prefetch additional data in
+//                   extra buffers.
+void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
+    bool read_curr_block, uint64_t& start_offset, uint64_t& end_offset) {
+  uint64_t start_updated_offset = start_offset;
+
+  // readahead_cache_lookup_ can be set false, if after Seek and Next
   // there is SeekForPrev or any other backward operation.
   if (!readahead_cache_lookup_) {
     return;
   }
 
-  assert(!DoesContainBlockHandles());
-  assert(index_iter_->value().handle.offset() == offset);
-
-  // Error. current offset should be equal to what's requested for prefetching.
-  if (index_iter_->value().handle.offset() != offset) {
-    return;
-  }
-
-  if (IsNextBlockOutOfBound()) {
-    updated_readahead_size = 0;
-    return;
-  }
-
-  size_t current_readahead_size = 0;
   size_t footer = table_->get_rep()->footer.GetBlockTrailerSize();
-
-  // Add the current block to block_handles_.
-  {
-    BlockHandleInfo block_handle_info;
-    block_handle_info.handle_ = index_iter_->value().handle;
-    block_handle_info.SetFirstInternalKey(
-        index_iter_->value().first_internal_key);
-    block_handles_.emplace_back(std::move(block_handle_info));
+  if (read_curr_block && !DoesContainBlockHandles() &&
+      IsNextBlockOutOfBound()) {
+    end_offset = index_iter_->value().handle.offset() + footer +
+                 index_iter_->value().handle.size();
+    return;
   }
 
-  // Current block is included in length. Readahead should start from next
-  // block.
-  index_iter_->Next();
-  is_index_at_curr_block_ = false;
+  uint64_t end_updated_offset = start_updated_offset;
+  bool found_first_miss_block = false;
+  size_t prev_handles_size;
 
-  while (index_iter_->Valid()) {
+  // Initialize start and end offsets based on exisiting handles in the queue
+  // and read_curr_block argument passed.
+  InitializeStartAndEndOffsets(read_curr_block, found_first_miss_block,
+                               start_updated_offset, end_updated_offset,
+                               prev_handles_size);
+
+  while (index_iter_->Valid() && !is_index_out_of_bound_) {
     BlockHandle block_handle = index_iter_->value().handle;
 
-    // Adding this data block exceeds passed down readahead_size. So this data
+    // Adding this data block exceeds end offset. So this data
     // block won't be added.
-    if (current_readahead_size + block_handle.size() + footer >
-        readahead_size) {
+    // There can be a case where passed end offset is smaller than
+    // block_handle.size() + footer because of readahead_size truncated to
+    // upper_bound. So we prefer to read the block rather than skip it to avoid
+    // sync read calls in case of async_io.
+    if (start_updated_offset != end_updated_offset &&
+        (end_updated_offset + block_handle.size() + footer > end_offset)) {
       break;
     }
 
-    current_readahead_size += block_handle.size();
-    current_readahead_size += footer;
-
     // For current data block, do the lookup in the cache. Lookup should pin the
-    // data block and add the placeholder for cache.
+    // data block in cache.
     BlockHandleInfo block_handle_info;
     block_handle_info.handle_ = index_iter_->value().handle;
     block_handle_info.SetFirstInternalKey(
         index_iter_->value().first_internal_key);
+    end_updated_offset += footer + block_handle_info.handle_.size();
 
     Status s = table_->LookupAndPinBlocksInCache<Block_kData>(
         read_options_, block_handle,
@@ -742,6 +833,12 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
     block_handle_info.is_cache_hit_ =
         (block_handle_info.cachable_entry_.GetValue() ||
          block_handle_info.cachable_entry_.GetCacheHandle());
+
+    // If this is the first miss block, update start offset to this block.
+    if (!found_first_miss_block && !block_handle_info.is_cache_hit_) {
+      found_first_miss_block = true;
+      start_updated_offset = block_handle_info.handle_.offset();
+    }
 
     // Add the handle to the queue.
     block_handles_.emplace_back(std::move(block_handle_info));
@@ -756,16 +853,28 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
       break;
     }
     index_iter_->Next();
+    is_index_at_curr_block_ = false;
   };
 
-  // Iterate cache hit block handles from the end till a Miss is there, to
-  // update the readahead_size.
-  for (auto it = block_handles_.rbegin();
-       it != block_handles_.rend() && (*it).is_cache_hit_ == true; ++it) {
-    current_readahead_size -= (*it).handle_.size();
-    current_readahead_size -= footer;
+  if (found_first_miss_block) {
+    // Iterate cache hit block handles from the end till a Miss is there, to
+    // truncate and update the end offset till that Miss.
+    auto it = block_handles_.rbegin();
+    auto it_end =
+        block_handles_.rbegin() + (block_handles_.size() - prev_handles_size);
+
+    while (it != it_end && (*it).is_cache_hit_) {
+      it++;
+    }
+    end_updated_offset = (*it).handle_.offset() + footer + (*it).handle_.size();
+  } else {
+    // Nothing to read. Can be because of IOError in index_iter_->Next() or
+    // reached upper_bound.
+    end_updated_offset = start_updated_offset;
   }
-  updated_readahead_size = current_readahead_size;
+
+  end_offset = end_updated_offset;
+  start_offset = start_updated_offset;
   ResetPreviousBlockOffset();
 }
 

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -16,12 +16,33 @@ void BlockBasedTableIterator::Seek(const Slice& target) {
   SeekImpl(&target, true);
 }
 
+void BlockBasedTableIterator::SeekSecondPass(const Slice* target) {
+  AsyncInitDataBlock(/*is_first_pass=*/false);
+
+  if (target) {
+    block_iter_.Seek(*target);
+  } else {
+    block_iter_.SeekToFirst();
+  }
+  FindKeyForward();
+
+  CheckOutOfBound();
+
+  if (target) {
+    assert(!Valid() || icomp_.Compare(*target, key()) <= 0);
+  }
+}
+
 void BlockBasedTableIterator::SeekImpl(const Slice* target,
                                        bool async_prefetch) {
   bool is_first_pass = !async_read_in_progress_;
-  if (is_first_pass) {
-    ResetBlockCacheLookupVar();
+
+  if (!is_first_pass) {
+    SeekSecondPass(target);
+    return;
   }
+
+  ResetBlockCacheLookupVar();
 
   bool autotune_readaheadsize = is_first_pass &&
                                 read_options_.auto_readahead_size &&
@@ -33,134 +54,120 @@ void BlockBasedTableIterator::SeekImpl(const Slice* target,
     readahead_cache_lookup_ = true;
   }
 
-  if (is_first_pass) {
-    is_out_of_bound_ = false;
-    is_at_first_key_from_index_ = false;
-    seek_stat_state_ = kNone;
-    bool filter_checked = false;
-    if (target && !CheckPrefixMayMatch(*target, IterDirection::kForward,
-                                       &filter_checked)) {
-      ResetDataIter();
-      RecordTick(table_->GetStatistics(), is_last_level_
-                                              ? LAST_LEVEL_SEEK_FILTERED
-                                              : NON_LAST_LEVEL_SEEK_FILTERED);
-      return;
-    }
-    if (filter_checked) {
-      seek_stat_state_ = kFilterUsed;
-      RecordTick(table_->GetStatistics(),
-                 is_last_level_ ? LAST_LEVEL_SEEK_FILTER_MATCH
-                                : NON_LAST_LEVEL_SEEK_FILTER_MATCH);
-    }
+  is_out_of_bound_ = false;
+  is_at_first_key_from_index_ = false;
+  seek_stat_state_ = kNone;
+  bool filter_checked = false;
+  if (target &&
+      !CheckPrefixMayMatch(*target, IterDirection::kForward, &filter_checked)) {
+    ResetDataIter();
+    RecordTick(table_->GetStatistics(), is_last_level_
+                                            ? LAST_LEVEL_SEEK_FILTERED
+                                            : NON_LAST_LEVEL_SEEK_FILTERED);
+    return;
+  }
+  if (filter_checked) {
+    seek_stat_state_ = kFilterUsed;
+    RecordTick(table_->GetStatistics(), is_last_level_
+                                            ? LAST_LEVEL_SEEK_FILTER_MATCH
+                                            : NON_LAST_LEVEL_SEEK_FILTER_MATCH);
+  }
 
-    bool need_seek_index = true;
+  bool need_seek_index = true;
 
-    //  In case of readahead_cache_lookup_, index_iter_ could change to find the
-    //  readahead size in BlockCacheLookupForReadAheadSize so it needs to
-    //  reseek.
-    if (IsIndexAtCurr() && block_iter_points_to_real_block_ &&
-        block_iter_.Valid()) {
-      // Reseek.
-      prev_block_offset_ = index_iter_->value().handle.offset();
+  //  In case of readahead_cache_lookup_, index_iter_ could change to find the
+  //  readahead size in BlockCacheLookupForReadAheadSize so it needs to
+  //  reseek.
+  if (IsIndexAtCurr() && block_iter_points_to_real_block_ &&
+      block_iter_.Valid()) {
+    // Reseek.
+    prev_block_offset_ = index_iter_->value().handle.offset();
 
-      if (target) {
-        // We can avoid an index seek if:
-        // 1. The new seek key is larger than the current key
-        // 2. The new seek key is within the upper bound of the block
-        // Since we don't necessarily know the internal key for either
-        // the current key or the upper bound, we check user keys and
-        // exclude the equality case. Considering internal keys can
-        // improve for the boundary cases, but it would complicate the
-        // code.
-        if (user_comparator_.Compare(ExtractUserKey(*target),
-                                     block_iter_.user_key()) > 0 &&
-            user_comparator_.Compare(ExtractUserKey(*target),
-                                     index_iter_->user_key()) < 0) {
-          need_seek_index = false;
-        }
-      }
-    }
-
-    if (need_seek_index) {
-      if (target) {
-        index_iter_->Seek(*target);
-      } else {
-        index_iter_->SeekToFirst();
-      }
-      is_index_at_curr_block_ = true;
-      if (!index_iter_->Valid()) {
-        ResetDataIter();
-        return;
-      }
-    }
-
-    if (autotune_readaheadsize) {
-      FindReadAheadSizeUpperBound();
-      if (target) {
-        index_iter_->Seek(*target);
-      } else {
-        index_iter_->SeekToFirst();
-      }
-
-      // Check for IO error.
-      if (!index_iter_->Valid()) {
-        ResetDataIter();
-        return;
+    if (target) {
+      // We can avoid an index seek if:
+      // 1. The new seek key is larger than the current key
+      // 2. The new seek key is within the upper bound of the block
+      // Since we don't necessarily know the internal key for either
+      // the current key or the upper bound, we check user keys and
+      // exclude the equality case. Considering internal keys can
+      // improve for the boundary cases, but it would complicate the
+      // code.
+      if (user_comparator_.Compare(ExtractUserKey(*target),
+                                   block_iter_.user_key()) > 0 &&
+          user_comparator_.Compare(ExtractUserKey(*target),
+                                   index_iter_->user_key()) < 0) {
+        need_seek_index = false;
       }
     }
   }
 
-  if (is_first_pass) {
-    // After reseek, index_iter_ point to the right key i.e. target in
-    // case of readahead_cache_lookup_. So index_iter_ can be used directly.
-    IndexValue v = index_iter_->value();
-    const bool same_block = block_iter_points_to_real_block_ &&
-                            v.handle.offset() == prev_block_offset_;
-
-    if (!v.first_internal_key.empty() && !same_block &&
-        (!target || icomp_.Compare(*target, v.first_internal_key) <= 0) &&
-        allow_unprepared_value_) {
-      // Index contains the first key of the block, and it's >= target.
-      // We can defer reading the block.
-      is_at_first_key_from_index_ = true;
-      // ResetDataIter() will invalidate block_iter_. Thus, there is no need to
-      // call CheckDataBlockWithinUpperBound() to check for iterate_upper_bound
-      // as that will be done later when the data block is actually read.
-      ResetDataIter();
+  if (need_seek_index) {
+    if (target) {
+      index_iter_->Seek(*target);
     } else {
-      // Need to use the data block.
-      if (!same_block) {
-        if (read_options_.async_io && async_prefetch) {
-          AsyncInitDataBlock(is_first_pass);
-          if (async_read_in_progress_) {
-            // Status::TryAgain indicates asynchronous request for retrieval of
-            // data blocks has been submitted. So it should return at this point
-            // and Seek should be called again to retrieve the requested block
-            // and execute the remaining code.
-            return;
-          }
-        } else {
-          InitDataBlock();
+      index_iter_->SeekToFirst();
+    }
+    is_index_at_curr_block_ = true;
+    if (!index_iter_->Valid()) {
+      ResetDataIter();
+      return;
+    }
+  }
+
+  if (autotune_readaheadsize) {
+    FindReadAheadSizeUpperBound();
+    if (target) {
+      index_iter_->Seek(*target);
+    } else {
+      index_iter_->SeekToFirst();
+    }
+
+    // Check for IO error.
+    if (!index_iter_->Valid()) {
+      ResetDataIter();
+      return;
+    }
+  }
+
+  // After reseek, index_iter_ point to the right key i.e. target in
+  // case of readahead_cache_lookup_. So index_iter_ can be used directly.
+  IndexValue v = index_iter_->value();
+  const bool same_block = block_iter_points_to_real_block_ &&
+                          v.handle.offset() == prev_block_offset_;
+
+  if (!v.first_internal_key.empty() && !same_block &&
+      (!target || icomp_.Compare(*target, v.first_internal_key) <= 0) &&
+      allow_unprepared_value_) {
+    // Index contains the first key of the block, and it's >= target.
+    // We can defer reading the block.
+    is_at_first_key_from_index_ = true;
+    // ResetDataIter() will invalidate block_iter_. Thus, there is no need to
+    // call CheckDataBlockWithinUpperBound() to check for iterate_upper_bound
+    // as that will be done later when the data block is actually read.
+    ResetDataIter();
+  } else {
+    // Need to use the data block.
+    if (!same_block) {
+      if (read_options_.async_io && async_prefetch) {
+        AsyncInitDataBlock(/*is_first_pass=*/true);
+        if (async_read_in_progress_) {
+          // Status::TryAgain indicates asynchronous request for retrieval of
+          // data blocks has been submitted. So it should return at this point
+          // and Seek should be called again to retrieve the requested block
+          // and execute the remaining code.
+          return;
         }
       } else {
-        // When the user does a reseek, the iterate_upper_bound might have
-        // changed. CheckDataBlockWithinUpperBound() needs to be called
-        // explicitly if the reseek ends up in the same data block.
-        // If the reseek ends up in a different block, InitDataBlock() will do
-        // the iterator upper bound check.
-        CheckDataBlockWithinUpperBound();
+        InitDataBlock();
       }
-
-      if (target) {
-        block_iter_.Seek(*target);
-      } else {
-        block_iter_.SeekToFirst();
-      }
-      FindKeyForward();
+    } else {
+      // When the user does a reseek, the iterate_upper_bound might have
+      // changed. CheckDataBlockWithinUpperBound() needs to be called
+      // explicitly if the reseek ends up in the same data block.
+      // If the reseek ends up in a different block, InitDataBlock() will do
+      // the iterator upper bound check.
+      CheckDataBlockWithinUpperBound();
     }
-  } else {
-    // second pass
-    AsyncInitDataBlock(is_first_pass);
 
     if (target) {
       block_iter_.Seek(*target);

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -367,10 +367,11 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   // *** BEGIN APIs relevant to auto tuning of readahead_size ***
   void FindReadAheadSizeUpperBound();
 
-  // This API is called to lookup the data blocks ahead in the cache to estimate
-  // the current readahead_size.
-  void BlockCacheLookupForReadAheadSize(uint64_t offset, size_t readahead_size,
-                                        size_t& updated_readahead_size);
+  // This API is called to lookup the data blocks ahead in the cache to tune
+  // the start and end offsets passed.
+  void BlockCacheLookupForReadAheadSize(bool read_curr_block,
+                                        uint64_t& start_offset,
+                                        uint64_t& end_offset);
 
   void ResetBlockCacheLookupVar() {
     is_index_out_of_bound_ = false;
@@ -398,6 +399,12 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   }
 
   bool DoesContainBlockHandles() { return !block_handles_.empty(); }
+
+  void InitializeStartAndEndOffsets(bool read_curr_block,
+                                    bool& found_first_miss_block,
+                                    uint64_t& start_updated_offset,
+                                    uint64_t end_updated_offset,
+                                    size_t& prev_handles_size);
 
   // *** END APIs relevant to auto tuning of readahead_size ***
 };

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -199,6 +199,10 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     }
   }
 
+  FilePrefetchBuffer* prefetch_buffer() {
+    return block_prefetcher_.prefetch_buffer();
+  }
+
   std::unique_ptr<InternalIteratorBase<IndexValue>> index_iter_;
 
  private:

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -329,6 +329,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   // is used to disable the lookup.
   IterDirection direction_ = IterDirection::kForward;
 
+  void SeekSecondPass(const Slice* target);
+
   // If `target` is null, seek to first.
   void SeekImpl(const Slice* target, bool async_prefetch);
 

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -403,7 +403,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   void InitializeStartAndEndOffsets(bool read_curr_block,
                                     bool& found_first_miss_block,
                                     uint64_t& start_updated_offset,
-                                    uint64_t end_updated_offset,
+                                    uint64_t& end_updated_offset,
                                     size_t& prev_handles_size);
 
   // *** END APIs relevant to auto tuning of readahead_size ***

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2655,7 +2655,7 @@ void BlockBasedTable::TEST_GetDataBlockHandle(const ReadOptions& options,
                                               const Slice& key,
                                               BlockHandle& handle) {
   std::unique_ptr<InternalIteratorBase<IndexValue>> iiter(NewIndexIterator(
-      options, /*need_upper_bound_check=*/false, /*input_iter=*/nullptr,
+      options, /*disable_prefix_seek=*/false, /*input_iter=*/nullptr,
       /*get_context=*/nullptr, /*lookup_context=*/nullptr));
   iiter->Seek(key);
   assert(iiter->Valid());

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2651,6 +2651,17 @@ bool BlockBasedTable::TEST_KeyInCache(const ReadOptions& options,
   return TEST_BlockInCache(iiter->value().handle);
 }
 
+void BlockBasedTable::TEST_GetDataBlockHandle(const ReadOptions& options,
+                                              const Slice& key,
+                                              BlockHandle& handle) {
+  std::unique_ptr<InternalIteratorBase<IndexValue>> iiter(NewIndexIterator(
+      options, /*need_upper_bound_check=*/false, /*input_iter=*/nullptr,
+      /*get_context=*/nullptr, /*lookup_context=*/nullptr));
+  iiter->Seek(key);
+  assert(iiter->Valid());
+  handle = iiter->value().handle;
+}
+
 // REQUIRES: The following fields of rep_ should have already been populated:
 //  1. file
 //  2. index_handle,

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -697,7 +697,7 @@ struct BlockBasedTable::Rep {
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
       uint64_t upper_bound_offset,
-      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb,
+      const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb,
       FilePrefetchBufferUsage usage) const {
     fpb->reset(new FilePrefetchBuffer(
         readahead_size, max_readahead_size,
@@ -713,7 +713,7 @@ struct BlockBasedTable::Rep {
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
       uint64_t upper_bound_offset,
-      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb,
+      const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb,
       FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -188,6 +188,9 @@ class BlockBasedTable : public TableReader {
   // REQUIRES: key is in this table && block cache enabled
   bool TEST_KeyInCache(const ReadOptions& options, const Slice& key);
 
+  void TEST_GetDataBlockHandle(const ReadOptions& options, const Slice& key,
+                               BlockHandle& handle);
+
   // Set up the table for Compaction. Might change some parameters with
   // posix_fadvise
   void SetupForCompaction() override;

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -16,7 +16,7 @@ void BlockPrefetcher::PrefetchIfNeeded(
     const BlockBasedTable::Rep* rep, const BlockHandle& handle,
     const size_t readahead_size, bool is_for_compaction,
     const bool no_sequential_checking, const ReadOptions& read_options,
-    const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb) {
+    const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb) {
   const size_t len = BlockBasedTable::BlockSizeWithTrailer(handle);
   const size_t offset = handle.offset();
   if (is_for_compaction) {

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -22,7 +22,7 @@ class BlockPrefetcher {
       const BlockBasedTable::Rep* rep, const BlockHandle& handle,
       size_t readahead_size, bool is_for_compaction,
       const bool no_sequential_checking, const ReadOptions& read_options,
-      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb);
+      const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb);
   FilePrefetchBuffer* prefetch_buffer() { return prefetch_buffer_.get(); }
 
   void UpdateReadPattern(const uint64_t& offset, const size_t& len) {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -57,7 +57,6 @@
 #include "table/block_based/block_builder.h"
 #include "table/block_based/filter_policy_internal.h"
 #include "table/block_based/flush_block_policy_impl.h"
-#include "table/block_based/partitioned_index_iterator.h"
 #include "table/block_fetcher.h"
 #include "table/format.h"
 #include "table/get_context.h"

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -52,10 +52,12 @@
 #include "table/block_based/block.h"
 #include "table/block_based/block_based_table_builder.h"
 #include "table/block_based/block_based_table_factory.h"
+#include "table/block_based/block_based_table_iterator.h"
 #include "table/block_based/block_based_table_reader.h"
 #include "table/block_based/block_builder.h"
 #include "table/block_based/filter_policy_internal.h"
 #include "table/block_based/flush_block_policy_impl.h"
+#include "table/block_based/partitioned_index_iterator.h"
 #include "table/block_fetcher.h"
 #include "table/format.h"
 #include "table/get_context.h"
@@ -469,6 +471,7 @@ class TableConstructor : public Constructor {
   }
 
   BlockCacheTracer block_cache_tracer_;
+  Env* env_;
 
  private:
   void Reset() {
@@ -491,7 +494,6 @@ class TableConstructor : public Constructor {
 
   static uint64_t cur_file_num_;
   EnvOptions soptions;
-  Env* env_;
 };
 uint64_t TableConstructor::cur_file_num_ = 1;
 
@@ -1137,7 +1139,9 @@ class BlockBasedTableTest
       virtual public ::testing::WithParamInterface<uint32_t> {
  public:
   BlockBasedTableTest() : format_(GetParam()) {
-    env_ = ROCKSDB_NAMESPACE::Env::Default();
+    std::unique_ptr<Env> env(
+        new CompositeEnvWrapper(Env::Default(), FileSystem::Default()));
+    env_ = env.get();
   }
 
   BlockBasedTableOptions GetBlockBasedTableOptions() {
@@ -3151,6 +3155,453 @@ TEST_P(BlockBasedTableTest, TracingGetTest) {
   c.ResetTableReader();
 }
 
+void GenerateKVMap(TableConstructor* c) {
+  int num_block = 100;
+  Random rnd(101);
+  uint32_t key = 0;
+  for (int block = 0; block < num_block; block++) {
+    for (int i = 0; i < 16; i++) {
+      char k[9] = {0};
+      // Internal key is constructed directly from this key,
+      // and internal key size is required to be >= 8 bytes,
+      // so use %08u as the format string.
+      snprintf(k, sizeof(k), "%08u", key);
+      std::string v = rnd.RandomString(256);
+      InternalKey ikey(std::string(k), 0, kTypeValue);
+      c->Add(ikey.Encode().ToString(), rnd.RandomString(256));
+      key++;
+    }
+  }
+}
+
+void WarmUpCache(TableConstructor* c, const MutableCFOptions& moptions,
+                 const std::vector<std::string>& warm_keys) {
+  ReadOptions ro;
+  std::unique_ptr<InternalIterator> iter(c->GetTableReader()->NewIterator(
+      ro, moptions.prefix_extractor.get(), nullptr, false,
+      TableReaderCaller::kUncategorized));
+  size_t i = 0;
+  while (i < warm_keys.size()) {
+    InternalKey ikey(warm_keys[i], 0, kTypeValue);
+    iter->Seek(ikey.Encode().ToString());
+    ASSERT_OK(iter->status());
+    ASSERT_TRUE(iter->Valid());
+    i++;
+  }
+}
+
+TEST_P(BlockBasedTableTest, BlockCacheLookupSeqScans) {
+  Options options;
+  BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
+  options.create_if_missing = true;
+  table_options.index_type =
+      BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+  table_options.block_cache = NewLRUCache(1024 * 1024, 0);
+  table_options.cache_index_and_filter_blocks = true;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(10, true));
+  table_options.block_align = true;
+  options.table_factory.reset(new BlockBasedTableFactory(table_options));
+
+  TableConstructor c(BytewiseComparator());
+  GenerateKVMap(&c);
+
+  std::vector<std::string> keys;
+  stl_wrappers::KVMap kvmap;
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  const InternalKeyComparator internal_comparator(options.comparator);
+
+  c.Finish(options, ioptions, moptions, table_options, internal_comparator,
+           &keys, &kvmap);
+
+  BlockBasedTable* bbt = reinterpret_cast<BlockBasedTable*>(c.GetTableReader());
+  BlockHandle block_handle;
+
+  ReadOptions read_options;
+  read_options.auto_readahead_size = true;
+  Slice ub = Slice("00000805");
+  Slice* ub_ptr = &ub;
+  read_options.iterate_upper_bound = ub_ptr;
+  read_options.readahead_size = 16384;
+  uint64_t buffer_offset;
+  size_t buffer_len;
+
+  // Test various functionalities -
+  // 5 blocks prefetched - Current + 4 additional (readahead_size).
+  {
+    // Check the behavior when it's -
+    // Miss(200), Hit(210), Hit(225), Hit(240), Hit(255).
+    // It should only prefetch current block (200).
+    {
+      std::vector<std::string> warm_keys{"00000210", "00000225", "00000240",
+                                         "00000255"};
+      WarmUpCache(&c, moptions, warm_keys);
+
+      std::unique_ptr<InternalIterator> iter(c.GetTableReader()->NewIterator(
+          read_options, moptions.prefix_extractor.get(), /*arena=*/nullptr,
+          /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+
+      // Seek key -
+      InternalKey ikey("00000200", 0, kTypeValue);
+      auto kv_iter = kvmap.find(ikey.Encode().ToString());
+
+      iter->Seek(kv_iter->first);
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ(iter->key(), kv_iter->first);
+      ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+
+      FilePrefetchBuffer* prefetch_buffer =
+          (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
+              ->prefetch_buffer();
+      prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                   buffer_len);
+      bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first, block_handle);
+      // It won't prefetch the data of cache hit.
+      // One block data.
+      ASSERT_EQ(buffer_len, 4096);
+      ASSERT_EQ(buffer_offset, block_handle.offset());
+    }
+
+    {
+      // Check the behavior when it's -
+      // First Prefetch - Miss(315), Miss(330), Miss(345), Hit(360), Hit(375),
+      // Second Prefetch - Miss(390), Miss(405) ...
+      // First prefetch should only prefetch from 315 to 345.
+      std::vector<std::string> warm_keys{"00000360", "00000375"};
+      WarmUpCache(&c, moptions, warm_keys);
+
+      std::unique_ptr<InternalIterator> iter(c.GetTableReader()->NewIterator(
+          read_options, moptions.prefix_extractor.get(), nullptr, false,
+          TableReaderCaller::kUncategorized));
+
+      // Seek key -
+      InternalKey ikey("00000315", 0, kTypeValue);
+      auto kv_iter = kvmap.find(ikey.Encode().ToString());
+
+      iter->Seek(kv_iter->first);
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ(iter->key(), kv_iter->first);
+      ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+
+      FilePrefetchBuffer* prefetch_buffer =
+          (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
+              ->prefetch_buffer();
+      prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                   buffer_len);
+      bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first, block_handle);
+
+      // It won't prefetch the data of cache hit.
+      // 3 blocks data.
+      ASSERT_EQ(buffer_len, 12288);
+      ASSERT_EQ(buffer_offset, block_handle.offset());
+
+      for (; kv_iter != kvmap.end() && iter->Valid(); kv_iter++) {
+        ASSERT_EQ(iter->key(), kv_iter->first);
+        ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+        iter->Next();
+        ASSERT_OK(iter->status());
+
+        if (iter->user_key().ToString() == "00000400") {
+          break;
+        }
+      }
+
+      // Second Prefetch.
+      prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                   buffer_len);
+      bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first, block_handle);
+      ASSERT_EQ(buffer_offset, 106496);
+      ASSERT_EQ(buffer_offset, block_handle.offset());
+    }
+  }
+  c.ResetTableReader();
+}
+
+TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
+  Options options;
+  TableConstructor c(BytewiseComparator());
+  std::unique_ptr<Env> env(
+      new CompositeEnvWrapper(c.env_, FileSystem::Default()));
+  options.env = env.get();
+  c.env_ = env.get();
+
+  BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
+  options.create_if_missing = true;
+  table_options.index_type =
+      BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+  table_options.block_cache = NewLRUCache(1024 * 1024, 0);
+  table_options.cache_index_and_filter_blocks = true;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(10, true));
+  table_options.block_align = true;
+  options.table_factory.reset(new BlockBasedTableFactory(table_options));
+
+  GenerateKVMap(&c);
+
+  std::vector<std::string> keys;
+  stl_wrappers::KVMap kvmap;
+  ImmutableOptions ioptions(options);
+  MutableCFOptions moptions(options);
+  const InternalKeyComparator internal_comparator(options.comparator);
+
+  c.Finish(options, ioptions, moptions, table_options, internal_comparator,
+           &keys, &kvmap);
+
+  BlockBasedTable* bbt = reinterpret_cast<BlockBasedTable*>(c.GetTableReader());
+  BlockHandle block_handle;
+
+  ReadOptions read_options;
+  read_options.auto_readahead_size = true;
+  Slice ub = Slice("00000805");
+  Slice* ub_ptr = &ub;
+  read_options.iterate_upper_bound = ub_ptr;
+  read_options.readahead_size = 16384;
+  read_options.async_io = true;
+  uint64_t buffer_offset;
+  size_t buffer_len;
+
+  // Test Various functionalities -
+  // 3 blocks prefetched - Current + 2 additional (readahead_size/2).
+  {
+    // Check the behavior when it's -
+    // 1st Prefetch - Miss(200), Hit(210), Hit(225),
+    // 2nd Prefetch - Hit(240), Hit(255)
+    // First Prefetch will be for 200 offset.
+    // Second prefetch will be 0.
+    {
+      std::vector<std::string> warm_keys{"00000210", "00000225", "00000240",
+                                         "00000255"};
+      WarmUpCache(&c, moptions, warm_keys);
+
+      std::unique_ptr<InternalIterator> iter(c.GetTableReader()->NewIterator(
+          read_options, moptions.prefix_extractor.get(), nullptr, false,
+          TableReaderCaller::kUncategorized));
+
+      // Seek key -
+      InternalKey ikey("00000200", 0, kTypeValue);
+      auto kv_iter = kvmap.find(ikey.Encode().ToString());
+
+      iter->Seek(kv_iter->first);
+      ASSERT_TRUE(iter->status().IsTryAgain());
+      iter->Seek(kv_iter->first);
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ(iter->key(), kv_iter->first);
+      ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+
+      FilePrefetchBuffer* prefetch_buffer =
+          (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
+              ->prefetch_buffer();
+      prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                   buffer_len);
+      bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first, block_handle);
+      ASSERT_EQ(buffer_len, 4096);
+      ASSERT_EQ(buffer_offset, block_handle.offset());
+      prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
+                                                   buffer_len);
+      ASSERT_EQ(buffer_len, 0);
+    }
+    {
+      // Check the behavior when it's -
+      // First Prefetch - Miss(315), Miss(330), Hit(345),
+      // Second Prefetch - Miss(360), Miss(375), ...
+      // First prefetch should only prefetch from 315 to 330.
+      // Second prefetch should start from 360.
+      std::vector<std::string> warm_keys{"00000345"};
+      WarmUpCache(&c, moptions, warm_keys);
+
+      std::unique_ptr<InternalIterator> iter(c.GetTableReader()->NewIterator(
+          read_options, moptions.prefix_extractor.get(), nullptr, false,
+          TableReaderCaller::kUncategorized));
+
+      // Seek key -
+      InternalKey ikey("00000315", 0, kTypeValue);
+      auto kv_iter = kvmap.find(ikey.Encode().ToString());
+
+      iter->Seek(kv_iter->first);
+      ASSERT_TRUE(iter->status().IsTryAgain());
+      iter->Seek(kv_iter->first);
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ(iter->key(), kv_iter->first);
+      ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+
+      FilePrefetchBuffer* prefetch_buffer =
+          (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
+              ->prefetch_buffer();
+      {
+        // 1st Buffer Verification.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                     buffer_len);
+        bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
+                                     block_handle);
+        ASSERT_EQ(buffer_len, 8192);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+
+        // 2nd Buffer Verification.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
+                                                     buffer_len);
+        InternalKey ikey_tmp("00000360", 0, kTypeValue);
+        bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
+                                     block_handle);
+        ASSERT_EQ(buffer_len, 8192);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+      }
+    }
+
+    {
+      // Check the behavior when it's -
+      // First Prefetch - Miss(495), Miss(510), Hit(525), prefetch len- 8192
+      // Second Prefetch async - Miss(540), Miss(555),   - 8192
+      // Third Prefetch Async - Hit(570), Miss(585),  - 4096
+      // 4th Prefetch Async - Hit(600), Miss(615), - 4096
+      // 5th Prefetch Async - Miss(630), Miss(645) - 8192
+      std::vector<std::string> warm_keys{"00000525", "00000570", "00000600"};
+      WarmUpCache(&c, moptions, warm_keys);
+
+      std::unique_ptr<InternalIterator> iter(c.GetTableReader()->NewIterator(
+          read_options, moptions.prefix_extractor.get(), /*arena=*/nullptr,
+          /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+
+      // Seek key -
+      InternalKey ikey("00000495", 0, kTypeValue);
+      auto kv_iter = kvmap.find(ikey.Encode().ToString());
+
+      // First and Second Prefetch.
+      iter->Seek(kv_iter->first);
+      ASSERT_TRUE(iter->status().IsTryAgain());
+      iter->Seek(kv_iter->first);
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ(iter->key(), kv_iter->first);
+      ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+
+      FilePrefetchBuffer* prefetch_buffer =
+          (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
+              ->prefetch_buffer();
+      {
+        // 1st Buffer Verification.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                     buffer_len);
+        bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
+                                     block_handle);
+        ASSERT_EQ(buffer_len, 8192);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+
+        // 2nd Buffer Verification.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
+                                                     buffer_len);
+        InternalKey ikey_tmp("00000540", 0, kTypeValue);
+        bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
+                                     block_handle);
+        ASSERT_EQ(buffer_len, 8192);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+      }
+
+      // Third prefetch ReadAsync (buffers will swap).
+      for (; kv_iter != kvmap.end() && iter->Valid(); kv_iter++) {
+        ASSERT_EQ(iter->key(), kv_iter->first);
+        ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+
+        if (iter->user_key() == "00000540") {
+          break;
+        }
+
+        iter->Next();
+        ASSERT_OK(iter->status());
+      }
+
+      {
+        // 1st Buffer Verification.
+        // curr buffer - 1.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
+                                                     buffer_len);
+        bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
+                                     block_handle);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_len, 8192);
+
+        // 2nd Buffer Verification.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                     buffer_len);
+        InternalKey ikey_tmp("00000585", 0, kTypeValue);
+        bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
+                                     block_handle);
+        ASSERT_EQ(buffer_len, 4096);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+      }
+
+      // 4th Prefetch ReadAsync (buffers will swap).
+      for (; kv_iter != kvmap.end() && iter->Valid(); kv_iter++) {
+        ASSERT_EQ(iter->key(), kv_iter->first);
+        ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+
+        if (iter->user_key() == "00000585") {
+          break;
+        }
+
+        iter->Next();
+        ASSERT_OK(iter->status());
+      }
+
+      {
+        // 1st Buffer Verification.
+        // curr buffer - 0.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                     buffer_len);
+        bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
+                                     block_handle);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_len, 4096);
+
+        // 2nd Buffer Verification.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
+                                                     buffer_len);
+        InternalKey ikey_tmp("00000615", 0, kTypeValue);
+        bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
+                                     block_handle);
+        ASSERT_EQ(buffer_len, 4096);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+      }
+
+      // 5th Prefetch ReadAsync.
+      for (; kv_iter != kvmap.end() && iter->Valid(); kv_iter++) {
+        ASSERT_EQ(iter->key(), kv_iter->first);
+        ASSERT_EQ(iter->value().ToString(), kv_iter->second);
+
+        if (iter->user_key() == "00000615") {
+          break;
+        }
+
+        iter->Next();
+        ASSERT_OK(iter->status());
+      }
+
+      {
+        // 1st Buffer Verification.
+        // curr_ - 1.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
+                                                     buffer_len);
+        ASSERT_EQ(buffer_len, 4096);
+        bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
+                                     block_handle);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+
+        // 2nd Buffer Verification.
+        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+                                                     buffer_len);
+        InternalKey ikey_tmp("00000630", 0, kTypeValue);
+        bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
+                                     block_handle);
+        ASSERT_EQ(buffer_len, 8192);
+        ASSERT_EQ(buffer_offset, block_handle.offset());
+      }
+    }
+  }
+  c.ResetTableReader();
+}
+
 struct HitMissCountingCache : public CacheWrapper {
   using CacheWrapper::CacheWrapper;
   const char* Name() const override { return "HitMissCountingCache"; }
@@ -3313,8 +3764,8 @@ TEST_P(BlockBasedTableTest, TracingMultiGetTest) {
       record.block_type = TraceType::kBlockTraceFilterBlock;
       expected_records.push_back(record);
     }
-    // Then we should have three records for one index, one filter, and one data
-    // block access. (The two keys share a data block.)
+    // Then we should have three records for one index, one filter, and one
+    // data block access. (The two keys share a data block.)
     record.get_id = get_id_offset;
     record.block_type = TraceType::kBlockTraceFilterBlock;
     record.caller = TableReaderCaller::kUserMultiGet;
@@ -3430,8 +3881,8 @@ TEST_P(BlockBasedTableTest, TracingIterator) {
   record.is_cache_hit = false;
   expected_records.push_back(record);
   expected_records.push_back(record);
-  // When we iterate this file for the second time, we should observe all cache
-  // hits.
+  // When we iterate this file for the second time, we should observe all
+  // cache hits.
   record.block_type = TraceType::kBlockTraceIndexBlock;
   record.is_cache_hit = true;
   expected_records.push_back(record);
@@ -3505,8 +3956,8 @@ class BlockCachePropertiesSnapshot {
   int64_t block_cache_bytes_write = 0;
 };
 
-// Make sure, by default, index/filter blocks were pre-loaded (meaning we won't
-// use block cache to store them).
+// Make sure, by default, index/filter blocks were pre-loaded (meaning we
+// won't use block cache to store them).
 TEST_P(BlockBasedTableTest, BlockCacheDisabledTest) {
   Options options;
   options.create_if_missing = true;
@@ -3752,7 +4203,8 @@ void ValidateBlockRestartInterval(int value, int expected) {
 }
 
 TEST_P(BlockBasedTableTest, InvalidOptions) {
-  // invalid values for block_size_deviation (<0 or >100) are silently set to 0
+  // invalid values for block_size_deviation (<0 or >100) are silently set to
+  // 0
   ValidateBlockSizeDeviation(-10, 0);
   ValidateBlockSizeDeviation(-1, 0);
   ValidateBlockSizeDeviation(0, 0);
@@ -3860,8 +4312,8 @@ TEST_P(BlockBasedTableTest, BlockReadCountTest) {
 
 TEST_P(BlockBasedTableTest, BlockCacheLeak) {
   // Check that when we reopen a table we don't lose access to blocks already
-  // in the cache. This test checks whether the Table actually makes use of the
-  // unique ID from the file.
+  // in the cache. This test checks whether the Table actually makes use of
+  // the unique ID from the file.
 
   Options opt;
   std::unique_ptr<InternalKeyComparator> ikc;
@@ -4185,7 +4637,6 @@ TEST_F(PlainTableTest, Crc32cFileChecksum) {
   EXPECT_STREQ(f.GetFileChecksum().c_str(), checksum.c_str());
 }
 
-
 TEST_F(GeneralTableTest, ApproximateOffsetOfPlain) {
   TableConstructor c(BytewiseComparator(), true /* convert_to_internal_key_ */);
   c.Add("k01", "hello");
@@ -4314,7 +4765,8 @@ TEST_F(GeneralTableTest, ApproximateKeyAnchors) {
 
   std::vector<TableReader::Anchor> anchors;
   ASSERT_OK(c.GetTableReader()->ApproximateKeyAnchors(ReadOptions(), anchors));
-  // The target is 128 anchors. But in reality it can be slightly more or fewer.
+  // The target is 128 anchors. But in reality it can be slightly more or
+  // fewer.
   ASSERT_GT(anchors.size(), 120);
   ASSERT_LT(anchors.size(), 140);
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1138,11 +1138,7 @@ class BlockBasedTableTest
     : public BlockBasedTableTestBase,
       virtual public ::testing::WithParamInterface<uint32_t> {
  public:
-  BlockBasedTableTest() : format_(GetParam()) {
-    std::unique_ptr<Env> env(
-        new CompositeEnvWrapper(Env::Default(), FileSystem::Default()));
-    env_ = env.get();
-  }
+  BlockBasedTableTest() : format_(GetParam()) { env_ = Env::Default(); }
 
   BlockBasedTableOptions GetBlockBasedTableOptions() {
     BlockBasedTableOptions options;

--- a/unreleased_history/new_features/async_support_tune_readahead.md
+++ b/unreleased_history/new_features/async_support_tune_readahead.md
@@ -1,0 +1,1 @@
+Provide support for async_io to trim readahead_size by doing block cache lookup


### PR DESCRIPTION
Summary: Add support for tuning of readahead_size by block cache lookup for async_io.

**Design/ Implementation** -

**BlockBasedTableIterator.cc** - 

`BlockCacheLookupForReadAheadSize` callback API lookups in the block cache and tries to reduce the start 
and end offset passed. This function looks into the block cache for the blocks between `start_offset` 
and `end_offset` and add all the handles in the queue.

It then iterates from the end in the handles to find first miss block and update the end offset to that block.
It also iterates from the start and find first miss block and update the start offset to that block.

```
_read_curr_block_ argument : True if this call was due to miss in the cache and caller wants to read that block 
                             synchronously.
                             False if current call is to prefetch additional data in extra buffers 
                            (due to ReadAsync call in FilePrefetchBuffer)
```
In case there is no data to be read in that callback (because of upper_bound or all blocks are in cache),
it updates start and end offset to be equal and that `FilePrefetchBuffer` interprets that as 0 length to be read.



**FilePrefetchBuffer.cc** -

FilePrefetchBuffer calls the callback - `ReadAheadSizeTuning` and pass the start and end offset to that
callback to get updated start and end offset to read based on cache hits/misses.

1. In case of Read calls (when offset passed to FilePrefetchBuffer is on cache miss and that data needs to be read), _read_curr_block_ is passed true.
2. In case of ReadAsync calls, when buffer is all consumed and can go for additional prefetching,  the start offset passed is the initial end offset of prev buffer (without any updated offset based on cache hit/miss).

Foreg. if following are the data blocks with cache hit/miss and start offset 
and Read API found miss on DB1 and based on readahead_size (50)  it passes end offset to be 50.
 [DB1 - miss- 0 ] [DB2 - hit -10] [DB3 - miss -20] [DB4 - miss-30] [DB5 - hit-40] 
 [DB6 - hit-50] [DB7 - miss-60] [DB8 - miss - 70] [DB9 - hit - 80] [DB6 - hit 90]

- For Read call - updated start offset remains 0 but end offset updates to DB4, as DB5 is in cache.
- Read calls saves initial end offset 50 as that was meant to be prefetched.
- Now for next ReadAsync call - the start offset will be 50 (previous buffer initial end offset) and based on readahead_size, end offset will be 100
- On callback, because of cache hits - callback will update the start offset to 60 and end offset to 80 to read only 2 data blocks (DB7 and DB8).
- And for that ReadAsync call - initial end offset will be set to 100 which will again used by next ReadAsync call as start offset.
-  `initial_end_offset_` in `BufferInfo` is used to save the initial end offset of that buffer.

- If let's say DB5 and DB6 overlaps in 2 buffers (because of alignment), `prev_buf_end_offset` is passed to make sure already prefetched data is not prefetched again in second buffer.
  
Test Plan: 
- Ran crash_test several times.
-  New unit tests added.

Reviewers:

Subscribers:

Tasks:

Tags: