### PR TITLE
AttributeGroups - GetEntity Implementation

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2061,7 +2061,7 @@ void DBImpl::GetEntity(const ReadOptions& _read_options, const Slice& key,
                        PinnableAttributeGroups& result) {
   if (result.size() == 0) {
     result.emplace_back(Status::InvalidArgument(
-        "Cannot call GetEntity with empty PinnableWideColumnsCollection"));
+        "Cannot call GetEntity with empty PinnableAttributeGroups"));
     return;
   }
   if (_read_options.io_activity != Env::IOActivity::kUnknown &&

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2083,7 +2083,7 @@ Status DBImpl::GetEntity(const ReadOptions& _read_options, const Slice& key,
   for (size_t i = 0; i < num_column_families; ++i) {
     // Adding the same key slice for different CFs
     keys.emplace_back(key);
-    column_families.emplace_back(result->at(i).column_family());
+    column_families.emplace_back((*result)[i].column_family());
   }
   std::vector<PinnableWideColumns> columns(num_column_families);
   std::vector<Status> statuses(num_column_families);
@@ -2094,9 +2094,9 @@ Status DBImpl::GetEntity(const ReadOptions& _read_options, const Slice& key,
   // Set results
   size_t index = 0;
   for (size_t i = 0; i < num_column_families; ++i) {
-    result->at(i).Reset();
-    result->at(i).SetStatus(statuses[index]);
-    result->at(i).SetColumns(std::move(columns[index]));
+    (*result)[i].Reset();
+    (*result)[i].SetStatus(statuses[index]);
+    (*result)[i].SetColumns(std::move(columns[index]));
     ++index;
   }
   return Status::OK();

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -242,8 +242,8 @@ class DBImpl : public DB {
   Status GetEntity(const ReadOptions& options,
                    ColumnFamilyHandle* column_family, const Slice& key,
                    PinnableWideColumns* columns) override;
-  void GetEntity(const ReadOptions& options, const Slice& key,
-                 PinnableAttributeGroups& result) override;
+  Status GetEntity(const ReadOptions& options, const Slice& key,
+                   PinnableAttributeGroups* result) override;
 
   using DB::GetMergeOperands;
   Status GetMergeOperands(const ReadOptions& options,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -243,9 +243,7 @@ class DBImpl : public DB {
                    ColumnFamilyHandle* column_family, const Slice& key,
                    PinnableWideColumns* columns) override;
   void GetEntity(const ReadOptions& options, const Slice& key,
-                 size_t num_column_families,
-                 ColumnFamilyHandle** column_families,
-                 PinnableWideColumns* columns, Status* statuses) override;
+                 PinnableAttributeGroups& result) override;
 
   using DB::GetMergeOperands;
   Status GetMergeOperands(const ReadOptions& options,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -242,6 +242,10 @@ class DBImpl : public DB {
   Status GetEntity(const ReadOptions& options,
                    ColumnFamilyHandle* column_family, const Slice& key,
                    PinnableWideColumns* columns) override;
+  void GetEntity(const ReadOptions& options, const Slice& key,
+                 size_t num_column_families,
+                 ColumnFamilyHandle** column_families,
+                 PinnableWideColumns* columns, Status* statuses) override;
 
   using DB::GetMergeOperands;
   Status GetMergeOperands(const ReadOptions& options,

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -296,7 +296,7 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
     PinnableAttributeGroups second_key_result = create_result(hot_and_cold_cfs);
 
     // GetEntity for first_key
-    db_->GetEntity(ReadOptions(), first_key, &first_key_result);
+    ASSERT_OK(db_->GetEntity(ReadOptions(), first_key, &first_key_result));
     ASSERT_EQ(num_column_families, first_key_result.size());
     // We expect to get values for all keys and CFs
     for (size_t i = 0; i < num_column_families; ++i) {
@@ -307,7 +307,7 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
     ASSERT_EQ(first_hot_columns, first_key_result[1].columns());
 
     // GetEntity for second_key
-    db_->GetEntity(ReadOptions(), second_key, &second_key_result);
+    ASSERT_OK(db_->GetEntity(ReadOptions(), second_key, &second_key_result));
     ASSERT_EQ(num_column_families, second_key_result.size());
     // We expect to get values for all keys and CFs
     for (size_t i = 0; i < num_column_families; ++i) {
@@ -325,7 +325,7 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
     PinnableAttributeGroups second_key_result = create_result(all_cfs);
 
     // GetEntity for first_key
-    db_->GetEntity(ReadOptions(), first_key, &first_key_result);
+    ASSERT_OK(db_->GetEntity(ReadOptions(), first_key, &first_key_result));
     ASSERT_EQ(num_column_families, first_key_result.size());
     // We expect to get values for all keys and CFs
     for (size_t i = 0; i < num_column_families; ++i) {
@@ -337,7 +337,7 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
     ASSERT_EQ(first_cold_columns, first_key_result[2].columns());
 
     // GetEntity for second_key
-    db_->GetEntity(ReadOptions(), second_key, &second_key_result);
+    ASSERT_OK(db_->GetEntity(ReadOptions(), second_key, &second_key_result));
     ASSERT_EQ(num_column_families, second_key_result.size());
     // key does not exist in default cf
     ASSERT_NOK(second_key_result[0].status());

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -240,9 +240,9 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
   Options options = GetDefaultOptions();
   CreateAndReopenWithCF({"hot_cf", "cold_cf"}, options);
 
-  constexpr int DEFAULT_CF_HANDLE_INDEX = 0;
-  constexpr int HOT_CF_HANDLE_INDEX = 1;
-  constexpr int COLD_CF_HANDLE_INDEX = 2;
+  constexpr int kDefaultCfHandleIndex = 0;
+  constexpr int kHotCfHandleIndex = 1;
+  constexpr int kColdCfHandleIndex = 2;
 
   constexpr char first_key[] = "first";
   WideColumns first_default_columns{
@@ -261,22 +261,22 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
       {"cold_cf_col_1_name", "second_key_cold_cf_col_1_value"}};
 
   // TODO - update this to use the multi-attribute-group PutEntity when ready
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[DEFAULT_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kDefaultCfHandleIndex],
                            first_key, first_default_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[HOT_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kHotCfHandleIndex],
                            first_key, first_hot_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[COLD_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kColdCfHandleIndex],
                            first_key, first_cold_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[HOT_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kHotCfHandleIndex],
                            second_key, second_hot_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[COLD_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kColdCfHandleIndex],
                            second_key, second_cold_columns));
 
   std::vector<ColumnFamilyHandle*> all_cfs = handles_;
   std::vector<ColumnFamilyHandle*> default_and_hot_cfs{
-      {handles_[DEFAULT_CF_HANDLE_INDEX], handles_[HOT_CF_HANDLE_INDEX]}};
+      {handles_[kDefaultCfHandleIndex], handles_[kHotCfHandleIndex]}};
   std::vector<ColumnFamilyHandle*> hot_and_cold_cfs{
-      {handles_[HOT_CF_HANDLE_INDEX], handles_[COLD_CF_HANDLE_INDEX]}};
+      {handles_[kHotCfHandleIndex], handles_[kColdCfHandleIndex]}};
   auto create_result =
       [](const std::vector<ColumnFamilyHandle*>& column_families)
       -> PinnableAttributeGroups {
@@ -296,7 +296,7 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
     PinnableAttributeGroups second_key_result = create_result(hot_and_cold_cfs);
 
     // GetEntity for first_key
-    db_->GetEntity(ReadOptions(), first_key, first_key_result);
+    db_->GetEntity(ReadOptions(), first_key, &first_key_result);
     ASSERT_EQ(num_column_families, first_key_result.size());
     // We expect to get values for all keys and CFs
     for (size_t i = 0; i < num_column_families; ++i) {
@@ -307,7 +307,7 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
     ASSERT_EQ(first_hot_columns, first_key_result[1].columns());
 
     // GetEntity for second_key
-    db_->GetEntity(ReadOptions(), second_key, second_key_result);
+    db_->GetEntity(ReadOptions(), second_key, &second_key_result);
     ASSERT_EQ(num_column_families, second_key_result.size());
     // We expect to get values for all keys and CFs
     for (size_t i = 0; i < num_column_families; ++i) {
@@ -325,7 +325,7 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
     PinnableAttributeGroups second_key_result = create_result(all_cfs);
 
     // GetEntity for first_key
-    db_->GetEntity(ReadOptions(), first_key, first_key_result);
+    db_->GetEntity(ReadOptions(), first_key, &first_key_result);
     ASSERT_EQ(num_column_families, first_key_result.size());
     // We expect to get values for all keys and CFs
     for (size_t i = 0; i < num_column_families; ++i) {
@@ -337,7 +337,7 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
     ASSERT_EQ(first_cold_columns, first_key_result[2].columns());
 
     // GetEntity for second_key
-    db_->GetEntity(ReadOptions(), second_key, second_key_result);
+    db_->GetEntity(ReadOptions(), second_key, &second_key_result);
     ASSERT_EQ(num_column_families, second_key_result.size());
     // key does not exist in default cf
     ASSERT_NOK(second_key_result[0].status());
@@ -389,9 +389,9 @@ TEST_F(DBWideBasicTest, MultiCFMultiGetEntityAsPinnableAttributeGroups) {
   Options options = GetDefaultOptions();
   CreateAndReopenWithCF({"hot_cf", "cold_cf"}, options);
 
-  constexpr int DEFAULT_CF_HANDLE_INDEX = 0;
-  constexpr int HOT_CF_HANDLE_INDEX = 1;
-  constexpr int COLD_CF_HANDLE_INDEX = 2;
+  constexpr int kDefaultCfHandleIndex = 0;
+  constexpr int kHotCfHandleIndex = 1;
+  constexpr int kColdCfHandleIndex = 2;
 
   constexpr char first_key[] = "first";
   WideColumns first_default_columns{
@@ -409,24 +409,24 @@ TEST_F(DBWideBasicTest, MultiCFMultiGetEntityAsPinnableAttributeGroups) {
       {"cold_cf_col_1_name", "second_key_cold_cf_col_1_value"}};
 
   // TODO - update this to use the multi-attribute-group PutEntity when ready
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[DEFAULT_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kDefaultCfHandleIndex],
                            first_key, first_default_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[HOT_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kHotCfHandleIndex],
                            first_key, first_hot_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[COLD_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kColdCfHandleIndex],
                            first_key, first_cold_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[HOT_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kHotCfHandleIndex],
                            second_key, second_hot_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[COLD_CF_HANDLE_INDEX],
+  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kColdCfHandleIndex],
                            second_key, second_cold_columns));
 
   constexpr size_t num_keys = 2;
   std::array<Slice, num_keys> keys = {first_key, second_key};
   std::vector<ColumnFamilyHandle*> all_cfs = handles_;
   std::vector<ColumnFamilyHandle*> default_and_hot_cfs{
-      {handles_[DEFAULT_CF_HANDLE_INDEX], handles_[HOT_CF_HANDLE_INDEX]}};
+      {handles_[kDefaultCfHandleIndex], handles_[kHotCfHandleIndex]}};
   std::vector<ColumnFamilyHandle*> hot_and_cold_cfs{
-      {handles_[HOT_CF_HANDLE_INDEX], handles_[COLD_CF_HANDLE_INDEX]}};
+      {handles_[kHotCfHandleIndex], handles_[kColdCfHandleIndex]}};
   auto create_result =
       [](const std::vector<ColumnFamilyHandle*>& column_families)
       -> PinnableAttributeGroups {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -602,6 +602,21 @@ class DB {
     return Status::NotSupported("GetEntity not supported");
   }
 
+  // Returns wide-column entities from multiple column families for a single
+  // key. The input is a key and column families by which wide-column entities
+  // will be grouped. columns[i] will be the corresponding wide column output
+  // for ith column family in column_families (where 0 <= i <
+  // num_column_families). Likewise, statuses[i] will be the corresponding
+  // status retrieving wide columns for ith column family.
+  virtual void GetEntity(const ReadOptions& /* options */,
+                         const Slice& /* key */, size_t num_column_families,
+                         ColumnFamilyHandle** /* column_families */,
+                         PinnableWideColumns* /* columns */, Status* statuses) {
+    for (size_t i = 0; i < num_column_families; ++i) {
+      statuses[i] = Status::NotSupported("GetEntity not supported");
+    }
+  }
+
   // Populates the `merge_operands` array with all the merge operands in the DB
   // for `key`. The `merge_operands` array will be populated in the order of
   // insertion. The number of entries populated in `merge_operands` will be

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -602,18 +602,21 @@ class DB {
     return Status::NotSupported("GetEntity not supported");
   }
 
-  // Returns wide-column entities from multiple column families for a single
-  // key. The input is a key and column families by which wide-column entities
-  // will be grouped. columns[i] will be the corresponding wide column output
-  // for ith column family in column_families (where 0 <= i <
-  // num_column_families). Likewise, statuses[i] will be the corresponding
-  // status retrieving wide columns for ith column family.
+  // Returns logically grouped wide-column entities per column family (a.k.a.
+  // attribute groups) for a single key. PinnableAttributeGroups is a vector of
+  // PinnableAttributeGroup. Each PinnableAttributeGroup will have
+  // ColumnFamilyHandle*, Status and PinnableWideColumns as output.
   virtual void GetEntity(const ReadOptions& /* options */,
-                         const Slice& /* key */, size_t num_column_families,
-                         ColumnFamilyHandle** /* column_families */,
-                         PinnableWideColumns* /* columns */, Status* statuses) {
-    for (size_t i = 0; i < num_column_families; ++i) {
-      statuses[i] = Status::NotSupported("GetEntity not supported");
+                         const Slice& /* key */,
+                         PinnableAttributeGroups& result) {
+    Status s = Status::NotSupported("GetEntity not supported");
+    if (result.size() == 0) {
+      result.emplace_back(s);
+      return;
+    } else {
+      for (size_t i = 0; i < result.size(); ++i) {
+        result[i].SetStatus(s);
+      }
     }
   }
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -605,19 +605,11 @@ class DB {
   // Returns logically grouped wide-column entities per column family (a.k.a.
   // attribute groups) for a single key. PinnableAttributeGroups is a vector of
   // PinnableAttributeGroup. Each PinnableAttributeGroup will have
-  // ColumnFamilyHandle*, Status and PinnableWideColumns as output.
-  virtual void GetEntity(const ReadOptions& /* options */,
-                         const Slice& /* key */,
-                         PinnableAttributeGroups& result) {
-    Status s = Status::NotSupported("GetEntity not supported");
-    if (result.size() == 0) {
-      result.emplace_back(s);
-      return;
-    } else {
-      for (size_t i = 0; i < result.size(); ++i) {
-        result[i].SetStatus(s);
-      }
-    }
+  // ColumnFamilyHandle* as input, and Status and PinnableWideColumns as output.
+  virtual Status GetEntity(const ReadOptions& /* options */,
+                           const Slice& /* key */,
+                           PinnableAttributeGroups* /* result */) {
+    return Status::NotSupported("GetEntity not supported");
   }
 
   // Populates the `merge_operands` array with all the merge operands in the DB

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -232,8 +232,6 @@ class PinnableAttributeGroup {
   explicit PinnableAttributeGroup(ColumnFamilyHandle* column_family)
       : column_family_(column_family), status_(Status::OK()) {}
 
-  explicit PinnableAttributeGroup(const Status& status) : status_(status) {}
-
   void SetStatus(const Status& status);
   void SetColumns(PinnableWideColumns&& columns);
 

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -232,6 +232,8 @@ class PinnableAttributeGroup {
   explicit PinnableAttributeGroup(ColumnFamilyHandle* column_family)
       : column_family_(column_family), status_(Status::OK()) {}
 
+  explicit PinnableAttributeGroup(const Status& status) : status_(status) {}
+
   void SetStatus(const Status& status);
   void SetColumns(PinnableWideColumns&& columns);
 


### PR DESCRIPTION
# Summary

Implementation of `GetEntity()` API that returns wide-column entities as AttributeGroups from multiple column families for a single key. Regarding the definition of Attribute groups, please see the detailed example description in PR #11925 

# Test Plan

- `DBWideBasicTest::GetEntityAsPinnableAttributeGroups` added

will enable the new API in the `db_stress` after merging