### PR TITLE
Resolve BaseDeltaIterator's value in UpdateCurrent

### DIFF
--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -47,7 +47,7 @@ class BaseDeltaIterator : public Iterator {
   void Next() override;
   void Prev() override;
   Slice key() const override;
-  Slice value() const override;
+  Slice value() const override { return value_; }
   Slice timestamp() const override;
   Status status() const override;
   void Invalidate(Status s);
@@ -59,19 +59,23 @@ class BaseDeltaIterator : public Iterator {
   void AdvanceBase();
   bool BaseValid() const;
   bool DeltaValid() const;
+  void ResetValue();
+  void SetValueFromBase();
+  void SetValueFromDelta();
   void UpdateCurrent();
 
   bool forward_;
   bool current_at_base_;
   bool equal_keys_;
-  mutable Status status_;
+  Status status_;
   ColumnFamilyHandle* column_family_;
   std::unique_ptr<Iterator> base_iterator_;
   std::unique_ptr<WBWIIteratorImpl> delta_iterator_;
   const Comparator* comparator_;  // not owned
   const Slice* iterate_upper_bound_;
   MergeContext merge_context_;
-  mutable std::string merge_result_;
+  std::string merge_result_;
+  Slice value_;
 };
 
 // Key used by skip list, as the binary searchable index of WriteBatchWithIndex.


### PR DESCRIPTION
Summary: The patch is a small refactoring of `BaseDeltaIterator`: instead of determining the iterator's value during the `value()` call, it is resolved up front in `UpdateCurrent()`. This has multiple benefits: the value is now computed only once even if `value()` is called multiple times for the same iterator position (note that with the previous code, merges for example would get performed multiple times in this case), it makes it possible to remove the `mutable` modifiers from the `status_` and `merge_result_` members, and it also serves as groundwork for adding wide-column support to `WriteBatchWithIndex`.

Differential Revision: D50236117


