### PR TITLE
Fix a race condition between recovery and backup

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2373,6 +2373,10 @@ class DBImpl : public DB {
 
   Status DisableFileDeletionsWithLock();
 
+  // Decrease `disable_delete_obsolete_files_` by count while holding lock and
+  // return its remaning value.
+  int EnableFileDeletionsWithLock(int count);
+
   Status IncreaseFullHistoryTsLowImpl(ColumnFamilyData* cfd,
                                       std::string ts_low);
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2373,9 +2373,9 @@ class DBImpl : public DB {
 
   Status DisableFileDeletionsWithLock();
 
-  // Decrease `disable_delete_obsolete_files_` by count while holding lock and
-  // return its remaning value.
-  int EnableFileDeletionsWithLock(int count);
+  // Safely decrease `disable_delete_obsolete_files_` by one while holding lock
+  // and return its remaning value.
+  int EnableFileDeletionsWithLock();
 
   Status IncreaseFullHistoryTsLowImpl(ColumnFamilyData* cfd,
                                       std::string ts_low);

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -102,7 +102,9 @@ Status DBImpl::EnableFileDeletions(bool force) {
 
 int DBImpl::EnableFileDeletionsWithLock(int count) {
   mutex_.AssertHeld();
-  disable_delete_obsolete_files_ -= count;
+  // In case others have called EnableFileDeletions(true /* force */) in between
+  disable_delete_obsolete_files_ =
+      std::max(0, disable_delete_obsolete_files_ - count);
   return disable_delete_obsolete_files_;
 }
 

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -100,11 +100,11 @@ Status DBImpl::EnableFileDeletions(bool force) {
   return Status::OK();
 }
 
-int DBImpl::EnableFileDeletionsWithLock(int count) {
+int DBImpl::EnableFileDeletionsWithLock() {
   mutex_.AssertHeld();
   // In case others have called EnableFileDeletions(true /* force */) in between
   disable_delete_obsolete_files_ =
-      std::max(0, disable_delete_obsolete_files_ - count);
+      std::max(0, disable_delete_obsolete_files_ - 1);
   return disable_delete_obsolete_files_;
 }
 

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -100,6 +100,12 @@ Status DBImpl::EnableFileDeletions(bool force) {
   return Status::OK();
 }
 
+int DBImpl::EnableFileDeletionsWithLock(int count) {
+  mutex_.AssertHeld();
+  disable_delete_obsolete_files_ -= count;
+  return disable_delete_obsolete_files_;
+}
+
 bool DBImpl::IsFileDeletionsEnabled() const {
   return 0 == disable_delete_obsolete_files_;
 }

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -401,6 +401,7 @@ const Status& ErrorHandler::SetBGError(const Status& bg_status,
     // Always returns ok
     ROCKS_LOG_INFO(db_options_.info_log, "Disabling File Deletions");
     db_->DisableFileDeletionsWithLock().PermitUncheckedError();
+    disable_file_deletion_count_.fetch_add(1);
   }
 
   Status new_bg_io_err = bg_io_err;

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -396,12 +396,13 @@ const Status& ErrorHandler::SetBGError(const Status& bg_status,
   ROCKS_LOG_WARN(db_options_.info_log, "Background IO error %s",
                  bg_io_err.ToString().c_str());
 
-  if (BackgroundErrorReason::kManifestWrite == reason ||
-      BackgroundErrorReason::kManifestWriteNoWAL == reason) {
+  if (!recovery_disabled_file_deletion_ &&
+      (BackgroundErrorReason::kManifestWrite == reason ||
+       BackgroundErrorReason::kManifestWriteNoWAL == reason)) {
     // Always returns ok
     ROCKS_LOG_INFO(db_options_.info_log, "Disabling File Deletions");
     db_->DisableFileDeletionsWithLock().PermitUncheckedError();
-    disable_file_deletion_count_.fetch_add(1);
+    recovery_disabled_file_deletion_ = true;
   }
 
   Status new_bg_io_err = bg_io_err;
@@ -561,6 +562,18 @@ Status ErrorHandler::ClearBGError() {
     recovery_error_.PermitUncheckedError();
     recovery_in_prog_ = false;
     soft_error_no_bg_work_ = false;
+    if (recovery_disabled_file_deletion_) {
+      recovery_disabled_file_deletion_ = false;
+      int remain_counter = db_->EnableFileDeletionsWithLock();
+      if (remain_counter == 0) {
+        ROCKS_LOG_INFO(db_options_.info_log, "File Deletions Enabled");
+      } else {
+        ROCKS_LOG_WARN(
+            db_options_.info_log,
+            "File Deletions Enable, but not really enabled. Counter: %d",
+            remain_counter);
+      }
+    }
     EventHelpers::NotifyOnErrorRecoveryEnd(db_options_.listeners, old_bg_error,
                                            bg_error_, db_mutex_);
   }

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -42,7 +42,8 @@ class ErrorHandler {
         recovery_in_prog_(false),
         soft_error_no_bg_work_(false),
         is_db_stopped_(false),
-        bg_error_stats_(db_options.statistics) {
+        bg_error_stats_(db_options.statistics),
+        recovery_disabled_file_deletion_(false) {
     // Clear the checked flag for uninitialized errors
     bg_error_.PermitUncheckedError();
     recovery_error_.PermitUncheckedError();
@@ -80,10 +81,6 @@ class ErrorHandler {
 
   void EndAutoRecovery();
 
-  int GetAndResetDisableFileDeletionCount() {
-    return disable_file_deletion_count_.exchange(0);
-  };
-
  private:
   DBImpl* db_;
   const ImmutableDBOptions& db_options_;
@@ -112,9 +109,9 @@ class ErrorHandler {
   // The pointer of DB statistics.
   std::shared_ptr<Statistics> bg_error_stats_;
 
-  // The number of times this error handler called DisableFileDeletionsWithLock
-  // to disable file deletions.
-  std::atomic<int> disable_file_deletion_count_;
+  // Tracks whether the recovery has disabled file deletion. This boolean flag
+  // is updated while holding db mutex.
+  bool recovery_disabled_file_deletion_;
 
   const Status& HandleKnownErrors(const Status& bg_err,
                                   BackgroundErrorReason reason);

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -80,6 +80,10 @@ class ErrorHandler {
 
   void EndAutoRecovery();
 
+  int GetAndResetDisableFileDeletionCount() {
+    return disable_file_deletion_count_.exchange(0);
+  };
+
  private:
   DBImpl* db_;
   const ImmutableDBOptions& db_options_;
@@ -107,6 +111,10 @@ class ErrorHandler {
 
   // The pointer of DB statistics.
   std::shared_ptr<Statistics> bg_error_stats_;
+
+  // The number of times this error handler called DisableFileDeletionsWithLock
+  // to disable file deletions.
+  std::atomic<int> disable_file_deletion_count_;
 
   const Status& HandleKnownErrors(const Status& bg_err,
                                   BackgroundErrorReason reason);


### PR DESCRIPTION
A race condition between recovery and backup can happen with error messages like this:
```Failure in BackupEngine::CreateNewBackup with: IO error: No such file or directory: While opening a file for sequentially reading: /dev/shm/rocksdb_test/rocksdb_crashtest_whitebox/002653.log: No such file or directory```

PR #6949  introduced disabling file deletion during error handling of manifest IO errors. Aformentioned race condition is caused by this chain of event: 

[Backup engine]     disable file deletion 
[Recovery]              disable file deletion <= this is optional for the race condition, it may or may not get called
[Backup engine]     get list of file to copy/link
[Recovery]              force enable file deletion
....                            some files refered by backup engine get deleted
[Backup engine]    copy/link file <= error no file found


This PR fixes this with:
1) Recovery thread is currently forcing enabling file deletion as long as file deletion is disabled. Regardless of whether the previous error handling is for manifest IO error and that disabled it in the first place. This means it could incorrectly enabling file deletions intended by other threads like backup threads, file snapshotting threads. This PR does this check explicitly before making the call.

2) `disable_delete_obsolete_files_` is designed as a counter to allow different threads to enable and disable file deletion separately. The recovery thread currently does a force enable file deletion, because `ErrorHandler::SetBGError()` can be called multiple times by different threads when they receive a manifest IO error(details per PR #6949), resulting in `DBImpl::DisableFileDeletions` to be called multiple times too. Making a force enable file deletion call that resets the counter `disable_delete_obsolete_files_` to zero is a workaround for this. However, as it shows in the race condition, it can incorrectly suppress other threads like a backup thread's intention to keep the file deletion disabled. <strike>This PR adds a `std::atomic<int> disable_file_deletion_count_` to the error handler to track the needed counter decrease more precisely</strike>. This PR tracks and caps file deletion enabling/disabling in error handler.

3) for recovery, the section to find obsolete files and purge them was moved to be done after the attempt to enable file deletion. The actual finding and purging is more likely to happen if file deletion was previously disabled and get re-enabled now. An internal function `DBImpl::EnableFileDeletionsWithLock` was added to support change 2) and 3). Some useful logging was explicitly added to keep those log messages around.

Test plan:
existing unit tests