### PR TITLE
Remove assertion from PrefetchAsync

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -938,8 +938,6 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
       roundup_end2 = Roundup(rounddown_start2 + prefetch_size, alignment);
       uint64_t roundup_len2 = roundup_end2 - rounddown_start2;
 
-      assert(roundup_len2 >= alignment);
-
       CalculateOffsetAndLen(alignment, rounddown_start2, roundup_len2, second,
                             false, chunk_len2);
       assert(chunk_len2 == 0);


### PR DESCRIPTION
Summary:  Remove assertion from PrefetchAsync (roundup_len2 >= alignment) as for non direct_io, buffer size can be less than alignment resulting in assertion.

Test Plan: Ran the issue causing db_stress without this assertion and the verification completes successfully.

Reviewers:

Subscribers:

Tasks:

Tags: