### PR TITLE
Fix a bug when ingest plaintable sst file

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -794,24 +794,26 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
 
     Slice largest;
     if (strcmp(cfd_->ioptions()->table_factory->Name(), "PlainTable") == 0) {
-      // Not Support SeekToLast , have to iter all key
-      // mostly would happen in PlainTable
-      if (!iter->status().ok()) {
-        return iter->status();
-      }
+      // PlainTable iterator does not support SeekToLast().
       largest = iter->key();
-      for (; iter->Valid() && iter->status().ok(); iter->Next()) {
+      for (; iter->Valid(); iter->Next()) {
         if (cfd_->internal_comparator().Compare(iter->key(), largest) > 0) {
           largest = iter->key();
         }
       }
+      if (!iter->status().ok()) {
+        return iter->status();
+      }
     } else {
       iter->SeekToLast();
       if (!iter->Valid()) {
-        return Status::Corruption("can not find largest key in sst file");
-      }
-      if (!iter->status().ok()) {
-        return iter->status();
+        if (iter->status().ok()) {
+          // The file contains at least 1 key since iter is valid after
+          // SeekToFirst().
+          return Status::Corruption("Can not find largest key in sst file");
+        } else {
+          return iter->status();
+        }
       }
       largest = iter->key();
     }

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -796,15 +796,23 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
     if (strcmp(cfd_->ioptions()->table_factory->Name(), "PlainTable") == 0) {
       // Not Support SeekToLast , have to iter all key
       // mostly would happen in PlainTable
-      iter->SeekToFirst();
+      if (!iter->status().ok()) {
+        return iter->status();
+      }
       largest = iter->key();
-      for (; iter->Valid(); iter->Next()) {
+      for (; iter->Valid() && iter->status().ok(); iter->Next()) {
         if (cfd_->internal_comparator().Compare(iter->key(), largest) > 0) {
           largest = iter->key();
         }
       }
     } else {
       iter->SeekToLast();
+      if (!iter->Valid()) {
+        return Status::Corruption("can not find largest key in sst file");
+      }
+      if (!iter->status().ok()) {
+        return iter->status();
+      }
       largest = iter->key();
     }
 

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -792,18 +792,20 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
     }
     file_to_ingest->smallest_internal_key.SetFrom(key);
 
-    iter->SeekToLast();
-    auto largest = iter->key();
+    Slice largest;
     if (strcmp(cfd_->ioptions()->table_factory->Name(), "PlainTable") == 0) {
       // Not Support SeekToLast , have to iter all key
       // mostly would happen in PlainTable
       iter->SeekToFirst();
-
+      largest = iter->key();
       for (; iter->Valid(); iter->Next()) {
         if (cfd_->internal_comparator().Compare(iter->key(), largest) > 0) {
           largest = iter->key();
         }
       }
+    } else {
+      iter->SeekToLast();
+      largest = iter->key();
     }
 
     pik_status = ParseInternalKey(largest, &key, allow_data_in_errors);

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -793,7 +793,20 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
     file_to_ingest->smallest_internal_key.SetFrom(key);
 
     iter->SeekToLast();
-    pik_status = ParseInternalKey(iter->key(), &key, allow_data_in_errors);
+    auto largest = iter->key();
+    if (strcmp(cfd_->ioptions()->table_factory->Name(), "PlainTable") == 0) {
+      // Not Support SeekToLast , have to iter all key
+      // mostly would happen in PlainTable
+      iter->SeekToFirst();
+
+      for (; iter->Valid(); iter->Next()) {
+        if (cfd_->internal_comparator().Compare(iter->key(), largest) > 0) {
+          largest = iter->key();
+        }
+      }
+    }
+
+    pik_status = ParseInternalKey(largest, &key, allow_data_in_errors);
     if (!pik_status.ok()) {
       return Status::Corruption("Corrupted key in external file. ",
                                 pik_status.getState());

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -367,7 +367,19 @@ Status ImportColumnFamilyJob::GetIngestedFileInfo(
     if (iter->Valid()) {
       file_to_import->smallest_internal_key.DecodeFrom(iter->key());
       iter->SeekToLast();
-      file_to_import->largest_internal_key.DecodeFrom(iter->key());
+      auto largest = iter->key();
+      if (strcmp(cfd_->ioptions()->table_factory->Name(), "PlainTable") == 0) {
+        // Not Support SeekToLast , have to iter all key
+        // mostly would happen in PlainTable
+        iter->SeekToFirst();
+
+        for (; iter->Valid(); iter->Next()) {
+          if (cfd_->internal_comparator().Compare(iter->key(), largest) > 0) {
+            largest = iter->key();
+          }
+        }
+      }
+      file_to_import->largest_internal_key.DecodeFrom(largest);
       bound_set = true;
     }
 

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -366,18 +366,20 @@ Status ImportColumnFamilyJob::GetIngestedFileInfo(
     bool bound_set = false;
     if (iter->Valid()) {
       file_to_import->smallest_internal_key.DecodeFrom(iter->key());
-      iter->SeekToLast();
-      auto largest = iter->key();
+      Slice largest;
       if (strcmp(cfd_->ioptions()->table_factory->Name(), "PlainTable") == 0) {
         // Not Support SeekToLast , have to iter all key
         // mostly would happen in PlainTable
         iter->SeekToFirst();
-
+        largest = iter->key();
         for (; iter->Valid(); iter->Next()) {
           if (cfd_->internal_comparator().Compare(iter->key(), largest) > 0) {
             largest = iter->key();
           }
         }
+      } else {
+        iter->SeekToLast();
+        largest = iter->key();
       }
       file_to_import->largest_internal_key.DecodeFrom(largest);
       bound_set = true;


### PR DESCRIPTION
Summary: Plaintable doesn't support SeekToLast. And GetIngestedFileInfo is using SeekToLast without checking the validity.

We are using IngestExternalFile or CreateColumnFamilyWithImport with some sst file in PlainTable format . But after running for a while, compaction error often happens. Such as 
![image](https://github.com/facebook/rocksdb/assets/13954644/b4fa49fc-73fc-49ce-96c6-f198a30800b8)

I simply add some std::cerr log to find why.
![image](https://github.com/facebook/rocksdb/assets/13954644/2cf1d5ff-48cc-4125-b917-87090f764fcd)
It shows that the smallest key is always equal to largest key.
![image](https://github.com/facebook/rocksdb/assets/13954644/6d43e978-0be0-4306-aae3-f9e4ae366395)
Then I found the root cause is that PlainTable do not support SeekToLast, so the smallest key is always the same with the largest

I try to write an unit test. But it's not easy to reproduce this error.
(This PR is similar to https://github.com/facebook/rocksdb/pull/11266. Sorry for open another PR)

