### PR TITLE
Remove documentation that marks user-defined timestamps feature as experimental

### DIFF
--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -395,8 +395,6 @@ class WriteBatch : public WriteBatchBase {
   // Returns true if MarkRollback will be called during Iterate
   bool HasRollback() const;
 
-  // Experimental.
-  //
   // Update timestamps of existing entries in the write batch if
   // applicable. If a key is intended for a column family that disables
   // timestamp, then this API won't set the timestamp for this key.

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -231,7 +231,6 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
   }
 };
 
-// EXPERIMENTAL
 // Comparator with 64-bit integer timestamp.
 // We did not performance test this yet.
 template <typename TComparator>


### PR DESCRIPTION
As titled. The most notable place that marks the feature as experimental is its wiki page. That was updated. And this PR removes the experimental marker from a few places for this feature.