### PR TITLE
AttributeGroups - PutEntity Implementation

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -197,6 +197,8 @@ class DBImpl : public DB {
   Status PutEntity(const WriteOptions& options,
                    ColumnFamilyHandle* column_family, const Slice& key,
                    const WideColumns& columns) override;
+  Status PutEntity(const WriteOptions& options, const Slice& key,
+                   const AttributeGroups& attribute_groups) override;
 
   using DB::Merge;
   Status Merge(const WriteOptions& options, ColumnFamilyHandle* column_family,

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -53,6 +53,10 @@ class DBImplReadOnly : public DBImpl {
                    const WideColumns& /* columns */) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
+  Status PutEntity(const WriteOptions& /* options */, const Slice& /* key */,
+                   const AttributeGroups& /* attribute_groups */) override {
+    return Status::NotSupported("Not supported operation in read only mode.");
+  }
 
   using DBImpl::Merge;
   virtual Status Merge(const WriteOptions& /*options*/,

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -138,7 +138,7 @@ class DBImplSecondary : public DBImpl {
   }
   Status PutEntity(const WriteOptions& /* options */, const Slice& /* key */,
                    const AttributeGroups& /* attribute_groups */) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DBImpl::Merge;

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -136,6 +136,10 @@ class DBImplSecondary : public DBImpl {
                    const WideColumns& /* columns */) override {
     return Status::NotSupported("Not supported operation in secondary mode.");
   }
+  Status PutEntity(const WriteOptions& /* options */, const Slice& /* key */,
+                   const AttributeGroups& /* attribute_groups */) override {
+    return Status::NotSupported("Not supported operation in read only mode.");
+  }
 
   using DBImpl::Merge;
   Status Merge(const WriteOptions& /*options*/,

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -50,7 +50,7 @@ Status DBImpl::PutEntity(const WriteOptions& options,
 
 Status DBImpl::PutEntity(const WriteOptions& options, const Slice& key,
                          const AttributeGroups& attribute_groups) {
-  for (AttributeGroup ag : attribute_groups) {
+  for (const AttributeGroup& ag : attribute_groups) {
     const Status s = FailIfCfHasTs(ag.column_family());
     if (!s.ok()) {
       return s;

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -48,6 +48,17 @@ Status DBImpl::PutEntity(const WriteOptions& options,
   return DB::PutEntity(options, column_family, key, columns);
 }
 
+Status DBImpl::PutEntity(const WriteOptions& options, const Slice& key,
+                         const AttributeGroups& attribute_groups) {
+  for (AttributeGroup ag : attribute_groups) {
+    const Status s = FailIfCfHasTs(ag.column_family());
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  return DB::PutEntity(options, key, attribute_groups);
+}
+
 Status DBImpl::Merge(const WriteOptions& o, ColumnFamilyHandle* column_family,
                      const Slice& key, const Slice& val) {
   const Status s = FailIfCfHasTs(column_family);
@@ -2382,6 +2393,22 @@ Status DB::PutEntity(const WriteOptions& options,
     return s;
   }
 
+  return Write(options, &batch);
+}
+
+Status DB::PutEntity(const WriteOptions& options, const Slice& key,
+                     const AttributeGroups& attribute_groups) {
+  ColumnFamilyHandle* default_cf = DefaultColumnFamily();
+  assert(default_cf);
+  const Comparator* const default_cf_ucmp = default_cf->GetComparator();
+  assert(default_cf_ucmp);
+  WriteBatch batch(0 /* reserved_bytes */, 0 /* max_bytes */,
+                   options.protection_bytes_per_key,
+                   default_cf_ucmp->timestamp_size());
+  const Status s = batch.PutEntity(key, attribute_groups);
+  if (!s.ok()) {
+    return s;
+  }
   return Write(options, &batch);
 }
 

--- a/db/wide/db_wide_basic_test.cc
+++ b/db/wide/db_wide_basic_test.cc
@@ -260,17 +260,17 @@ TEST_F(DBWideBasicTest, GetEntityAsPinnableAttributeGroups) {
   WideColumns second_cold_columns{
       {"cold_cf_col_1_name", "second_key_cold_cf_col_1_value"}};
 
-  // TODO - update this to use the multi-attribute-group PutEntity when ready
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kDefaultCfHandleIndex],
-                           first_key, first_default_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kHotCfHandleIndex],
-                           first_key, first_hot_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kColdCfHandleIndex],
-                           first_key, first_cold_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kHotCfHandleIndex],
-                           second_key, second_hot_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kColdCfHandleIndex],
-                           second_key, second_cold_columns));
+  AttributeGroups first_key_attribute_groups{
+      AttributeGroup(handles_[kDefaultCfHandleIndex], first_default_columns),
+      AttributeGroup(handles_[kHotCfHandleIndex], first_hot_columns),
+      AttributeGroup(handles_[kColdCfHandleIndex], first_cold_columns)};
+  AttributeGroups second_key_attribute_groups{
+      AttributeGroup(handles_[kHotCfHandleIndex], second_hot_columns),
+      AttributeGroup(handles_[kColdCfHandleIndex], second_cold_columns)};
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), first_key, first_key_attribute_groups));
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), second_key, second_key_attribute_groups));
 
   std::vector<ColumnFamilyHandle*> all_cfs = handles_;
   std::vector<ColumnFamilyHandle*> default_and_hot_cfs{
@@ -408,17 +408,18 @@ TEST_F(DBWideBasicTest, MultiCFMultiGetEntityAsPinnableAttributeGroups) {
   WideColumns second_cold_columns{
       {"cold_cf_col_1_name", "second_key_cold_cf_col_1_value"}};
 
-  // TODO - update this to use the multi-attribute-group PutEntity when ready
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kDefaultCfHandleIndex],
-                           first_key, first_default_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kHotCfHandleIndex],
-                           first_key, first_hot_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kColdCfHandleIndex],
-                           first_key, first_cold_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kHotCfHandleIndex],
-                           second_key, second_hot_columns));
-  ASSERT_OK(db_->PutEntity(WriteOptions(), handles_[kColdCfHandleIndex],
-                           second_key, second_cold_columns));
+  AttributeGroups first_key_attribute_groups{
+      AttributeGroup(handles_[kDefaultCfHandleIndex], first_default_columns),
+      AttributeGroup(handles_[kHotCfHandleIndex], first_hot_columns),
+      AttributeGroup(handles_[kColdCfHandleIndex], first_cold_columns)};
+  AttributeGroups second_key_attribute_groups{
+      AttributeGroup(handles_[kHotCfHandleIndex], second_hot_columns),
+      AttributeGroup(handles_[kColdCfHandleIndex], second_cold_columns)};
+
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), first_key, first_key_attribute_groups));
+  ASSERT_OK(
+      db_->PutEntity(WriteOptions(), second_key, second_key_attribute_groups));
 
   constexpr size_t num_keys = 2;
   std::array<Slice, num_keys> keys = {first_key, second_key};

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -39,6 +39,7 @@
 #include "rocksdb/write_batch.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <stack>
@@ -1014,6 +1015,22 @@ Status WriteBatch::PutEntity(ColumnFamilyHandle* column_family,
   }
 
   return WriteBatchInternal::PutEntity(this, cf_id, key, columns);
+}
+
+Status WriteBatch::PutEntity(const Slice& key,
+                             const AttributeGroups& attribute_groups) {
+  if (attribute_groups.empty()) {
+    return Status::InvalidArgument(
+        "Cannot call this method with empty attribute groups");
+  }
+  Status s;
+  for (AttributeGroup ag : attribute_groups) {
+    s = WriteBatch::PutEntity(ag.column_family(), key, ag.columns());
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  return s;
 }
 
 Status WriteBatchInternal::InsertNoop(WriteBatch* b) {

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1024,8 +1024,8 @@ Status WriteBatch::PutEntity(const Slice& key,
         "Cannot call this method with empty attribute groups");
   }
   Status s;
-  for (AttributeGroup ag : attribute_groups) {
-    s = WriteBatch::PutEntity(ag.column_family(), key, ag.columns());
+  for (const AttributeGroup& ag : attribute_groups) {
+    s = PutEntity(ag.column_family(), key, ag.columns());
     if (!s.ok()) {
       return s;
     }

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -286,10 +286,10 @@ struct TestHandler : public WriteBatch::Handler {
       return s;
     }
     if (column_family_id == 0) {
-      seen += "PutEntity(" + key.ToString() + ", " + oss.str().c_str() + ")";
+      seen += "PutEntity(" + key.ToString() + ", " + oss.str() + ")";
     } else {
       seen += "PutEntityCF(" + std::to_string(column_family_id) + ", " +
-              key.ToString() + ", " + oss.str().c_str() + ")";
+              key.ToString() + ", " + oss.str() + ")";
     }
     return Status::OK();
   }
@@ -697,7 +697,7 @@ TEST_F(WriteBatchTest, AttributeGroupTest) {
   foo_ags.emplace_back(&zero, zero_col_1_col_2);
   foo_ags.emplace_back(&two, two_col_1_col_2);
 
-  ASSERT_OK(batch.PutEntity(Slice("foo"), foo_ags));
+  ASSERT_OK(batch.PutEntity("foo", foo_ags));
 
   TestHandler handler;
   ASSERT_OK(batch.Iterate(&handler));
@@ -734,10 +734,10 @@ TEST_F(WriteBatchTest, AttributeGroupSavePointTest) {
   bar_ags.emplace_back(&zero, zero_col_1_col_2);
   bar_ags.emplace_back(&three, three_col_1_col_2);
 
-  ASSERT_OK(batch.PutEntity(Slice("foo"), foo_ags));
+  ASSERT_OK(batch.PutEntity("foo", foo_ags));
   batch.SetSavePoint();
 
-  ASSERT_OK(batch.PutEntity(Slice("bar"), bar_ags));
+  ASSERT_OK(batch.PutEntity("bar", bar_ags));
 
   TestHandler handler;
   ASSERT_OK(batch.Iterate(&handler));

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -12,7 +12,9 @@
 #include "db/column_family.h"
 #include "db/db_test_util.h"
 #include "db/memtable.h"
+#include "db/wide/wide_columns_helper.h"
 #include "db/write_batch_internal.h"
+#include "dbformat.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
@@ -273,6 +275,19 @@ struct TestHandler : public WriteBatch::Handler {
     } else {
       seen += "PutCF(" + std::to_string(column_family_id) + ", " +
               key.ToString() + ", " + value.ToString() + ")";
+    }
+    return Status::OK();
+  }
+  Status PutEntityCF(uint32_t column_family_id, const Slice& key,
+                     const Slice& entity) override {
+    std::ostringstream oss;
+    WideColumnsHelper::DumpSliceAsWideColumns(entity, oss, false);
+
+    if (column_family_id == 0) {
+      seen += "PutEntity(" + key.ToString() + ", " + oss.str().c_str() + ")";
+    } else {
+      seen += "PutEntityCF(" + std::to_string(column_family_id) + ", " +
+              key.ToString() + ", " + oss.str().c_str() + ")";
     }
     return Status::OK();
   }
@@ -664,6 +679,82 @@ class ColumnFamilyHandleImplDummy : public ColumnFamilyHandleImpl {
   const Comparator* const ucmp_ = BytewiseComparator();
 };
 }  // anonymous namespace
+
+TEST_F(WriteBatchTest, AttributeGroupTest) {
+  WriteBatch batch;
+  ColumnFamilyHandleImplDummy zero(0), two(2);
+  AttributeGroups foo_ags;
+  WideColumn zero_col_1{"0_c_1_n", "0_c_1_v"};
+  WideColumn zero_col_2{"0_c_2_n", "0_c_2_v"};
+  WideColumns zero_col_1_col_2{zero_col_1, zero_col_2};
+
+  WideColumn two_col_1{"2_c_1_n", "2_c_1_v"};
+  WideColumn two_col_2{"2_c_2_n", "2_c_2_v"};
+  WideColumns two_col_1_col_2{two_col_1, two_col_2};
+
+  foo_ags.emplace_back(&zero, zero_col_1_col_2);
+  foo_ags.emplace_back(&two, two_col_1_col_2);
+
+  ASSERT_OK(batch.PutEntity(Slice("foo"), foo_ags));
+
+  TestHandler handler;
+  ASSERT_OK(batch.Iterate(&handler));
+  ASSERT_EQ(
+      "PutEntity(foo, 0_c_1_n:0_c_1_v "
+      "0_c_2_n:0_c_2_v)"
+      "PutEntityCF(2, foo, 2_c_1_n:2_c_1_v "
+      "2_c_2_n:2_c_2_v)",
+      handler.seen);
+}
+
+TEST_F(WriteBatchTest, AttributeGroupSavePointTest) {
+  WriteBatch batch;
+  batch.SetSavePoint();
+
+  ColumnFamilyHandleImplDummy zero(0), two(2), three(3);
+  AttributeGroups foo_ags;
+  WideColumn zero_col_1{"0_c_1_n", "0_c_1_v"};
+  WideColumn zero_col_2{"0_c_2_n", "0_c_2_v"};
+  WideColumns zero_col_1_col_2{zero_col_1, zero_col_2};
+
+  WideColumn two_col_1{"2_c_1_n", "2_c_1_v"};
+  WideColumn two_col_2{"2_c_2_n", "2_c_2_v"};
+  WideColumns two_col_1_col_2{two_col_1, two_col_2};
+
+  foo_ags.emplace_back(&zero, zero_col_1_col_2);
+  foo_ags.emplace_back(&two, two_col_1_col_2);
+
+  AttributeGroups bar_ags;
+  WideColumn three_col_1{"3_c_1_n", "3_c_1_v"};
+  WideColumn three_col_2{"3_c_2_n", "3_c_2_v"};
+  WideColumns three_col_1_col_2{three_col_1, three_col_2};
+
+  bar_ags.emplace_back(&zero, zero_col_1_col_2);
+  bar_ags.emplace_back(&three, three_col_1_col_2);
+
+  ASSERT_OK(batch.PutEntity(Slice("foo"), foo_ags));
+  batch.SetSavePoint();
+
+  ASSERT_OK(batch.PutEntity(Slice("bar"), bar_ags));
+
+  TestHandler handler;
+  ASSERT_OK(batch.Iterate(&handler));
+  ASSERT_EQ(
+      "PutEntity(foo, 0_c_1_n:0_c_1_v 0_c_2_n:0_c_2_v)"
+      "PutEntityCF(2, foo, 2_c_1_n:2_c_1_v 2_c_2_n:2_c_2_v)"
+      "PutEntity(bar, 0_c_1_n:0_c_1_v 0_c_2_n:0_c_2_v)"
+      "PutEntityCF(3, bar, 3_c_1_n:3_c_1_v 3_c_2_n:3_c_2_v)",
+      handler.seen);
+
+  ASSERT_OK(batch.RollbackToSavePoint());
+
+  handler.seen.clear();
+  ASSERT_OK(batch.Iterate(&handler));
+  ASSERT_EQ(
+      "PutEntity(foo, 0_c_1_n:0_c_1_v 0_c_2_n:0_c_2_v)"
+      "PutEntityCF(2, foo, 2_c_1_n:2_c_1_v 2_c_2_n:2_c_2_v)",
+      handler.seen);
+}
 
 TEST_F(WriteBatchTest, ColumnFamiliesBatchTest) {
   WriteBatch batch;

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -281,8 +281,10 @@ struct TestHandler : public WriteBatch::Handler {
   Status PutEntityCF(uint32_t column_family_id, const Slice& key,
                      const Slice& entity) override {
     std::ostringstream oss;
-    WideColumnsHelper::DumpSliceAsWideColumns(entity, oss, false);
-
+    Status s = WideColumnsHelper::DumpSliceAsWideColumns(entity, oss, false);
+    if (!s.ok()) {
+      return s;
+    }
     if (column_family_id == 0) {
       seen += "PutEntity(" + key.ToString() + ", " + oss.str().c_str() + ")";
     } else {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -435,6 +435,10 @@ class DB {
   virtual Status PutEntity(const WriteOptions& options,
                            ColumnFamilyHandle* column_family, const Slice& key,
                            const WideColumns& columns);
+  // Split and store wide column entities in multiple column families (a.k.a.
+  // AttributeGroups)
+  virtual Status PutEntity(const WriteOptions& options, const Slice& key,
+                           const AttributeGroups& attribute_groups);
 
   // Remove the database entry (if any) for "key".  Returns OK on
   // success, and a non-OK status on error.  It is not an error if "key"

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -92,6 +92,10 @@ class StackableDB : public DB {
                    const WideColumns& columns) override {
     return db_->PutEntity(options, column_family, key, columns);
   }
+  Status PutEntity(const WriteOptions& options, const Slice& key,
+                   const AttributeGroups& attribute_groups) override {
+    return db_->PutEntity(options, key, attribute_groups);
+  }
 
   using DB::Get;
   virtual Status Get(const ReadOptions& options,

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -92,10 +92,6 @@ class StackableDB : public DB {
                    const WideColumns& columns) override {
     return db_->PutEntity(options, column_family, key, columns);
   }
-  Status PutEntity(const WriteOptions& options, const Slice& key,
-                   const AttributeGroups& attribute_groups) override {
-    return db_->PutEntity(options, key, attribute_groups);
-  }
 
   using DB::Get;
   virtual Status Get(const ReadOptions& options,

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -118,7 +118,16 @@ class WriteBatchWithIndex : public WriteBatchBase {
       return Status::InvalidArgument(
           "Cannot call this method without a column family handle");
     }
+    return Status::NotSupported(
+        "PutEntity not supported by WriteBatchWithIndex");
+  }
 
+  Status PutEntity(const Slice& /* key */,
+                   const AttributeGroups& attribute_groups) override {
+    if (attribute_groups.empty()) {
+      return Status::InvalidArgument(
+          "Cannot call this method without attribute groups");
+    }
     return Status::NotSupported(
         "PutEntity not supported by WriteBatchWithIndex");
   }
@@ -301,4 +310,3 @@ class WriteBatchWithIndex : public WriteBatchBase {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -221,8 +221,26 @@ inline bool operator!=(const PinnableWideColumns& lhs,
 }
 
 // Class representing attribute group. Attribute group is a logical grouping of
-// wide-column entities by leveraging Column Families. Wide-columns returned
-// from the query are pinnable.
+// wide-column entities by leveraging Column Families.
+// Used in Write Path
+class AttributeGroup {
+ public:
+  ColumnFamilyHandle* column_family() const { return column_family_; }
+  const WideColumns& columns() const { return columns_; }
+
+  explicit AttributeGroup(ColumnFamilyHandle* column_family,
+                          const WideColumns& columns)
+      : column_family_(column_family), columns_(columns) {}
+
+ private:
+  ColumnFamilyHandle* column_family_;
+  WideColumns columns_;
+};
+
+// A collection of Pinnable Attribute Groups.
+using AttributeGroups = std::vector<AttributeGroup>;
+
+// Used in Read Path. Wide-columns returned from the query are pinnable.
 class PinnableAttributeGroup {
  public:
   ColumnFamilyHandle* column_family() const { return column_family_; }
@@ -255,7 +273,7 @@ inline void PinnableAttributeGroup::Reset() {
   columns_.Reset();
 }
 
-// A collection of Attribute Groups.
+// A collection of Pinnable Attribute Groups.
 using PinnableAttributeGroups = std::vector<PinnableAttributeGroup>;
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -227,6 +227,7 @@ class AttributeGroup {
  public:
   ColumnFamilyHandle* column_family() const { return column_family_; }
   const WideColumns& columns() const { return columns_; }
+  WideColumns& columns() { return columns_; }
 
   explicit AttributeGroup(ColumnFamilyHandle* column_family,
                           const WideColumns& columns)

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -238,7 +238,7 @@ class AttributeGroup {
   WideColumns columns_;
 };
 
-// A collection of Pinnable Attribute Groups.
+// A collection of Attribute Groups.
 using AttributeGroups = std::vector<AttributeGroup>;
 
 // Used in Read Path. Wide-columns returned from the query are pinnable.

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -106,6 +106,11 @@ class WriteBatch : public WriteBatchBase {
   Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
                    const WideColumns& columns) override;
 
+  // Split and store wide column entities in multiple column families (a.k.a.
+  // AttributeGroups)
+  Status PutEntity(const Slice& key,
+                   const AttributeGroups& attribute_groups) override;
+
   using WriteBatchBase::Delete;
   // If the database contains a mapping for "key", erase it.  Else do nothing.
   // The following Delete(..., const Slice& key) can be used when user-defined

--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -47,6 +47,11 @@ class WriteBatchBase {
   virtual Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
                            const WideColumns& columns) = 0;
 
+  // Split and store wide column entities in multiple column families (a.k.a.
+  // AttributeGroups)
+  virtual Status PutEntity(const Slice& key,
+                           const AttributeGroups& attribute_groups) = 0;
+
   // Merge "value" with the existing value of "key" in the database.
   // "key->merge(existing, value)"
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,

--- a/unreleased_history/new_features/attribute_group_support.md
+++ b/unreleased_history/new_features/attribute_group_support.md
@@ -1,1 +1,1 @@
-Introduce AttributeGroup by adding the first AttributeGroup support APIs, MultiGetEntity() and PutEntity(). Through the use of Column Families, AttributeGroup enables users to logically group wide-column entities. More APIs to support AttributeGroup will come soon, including GetEntity, Iterators and others.
+Add GetEntity() and PutEntity() API implementation for Attribute Group support. Through the use of Column Families, AttributeGroup enables users to logically group wide-column entities.

--- a/unreleased_history/new_features/attribute_group_support.md
+++ b/unreleased_history/new_features/attribute_group_support.md
@@ -1,0 +1,1 @@
+Introduce AttributeGroup by adding the first AttributeGroup support APIs, MultiGetEntity() and PutEntity(). Through the use of Column Families, AttributeGroup enables users to logically group wide-column entities. More APIs to support AttributeGroup will come soon, including GetEntity, Iterators and others.


### PR DESCRIPTION
# Summary

Write Path for AttributeGroup Support. The new `PutEntity()` API uses `WriteBatch` and atomically writes WideColumns entities in multiple Column Families.

Combined the release note from PR #11943 

# Test Plan
- `DBWideBasicTest::MultiCFMultiGetEntityAsPinnableAttributeGroups` updated
- `WriteBatchTest::AttributeGroupTest` added
- `WriteBatchTest::AttributeGroupSavePointTest` added