### PR TITLE
Add some stats to observe the usefulness of scan prefetching

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -98,6 +98,7 @@ Status FilePrefetchBuffer::Read(const IOOptions& opts,
     return s;
   }
 
+  RecordTick(stats_, PREFETCH_BYTES, read_len);
   // Update the buffer offset and size.
   bufs_[index].offset_ = rounddown_start;
   bufs_[index].buffer_.Size(static_cast<size_t>(chunk_len) + result.size());
@@ -653,6 +654,11 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
       if (for_compaction) {
         s = Prefetch(opts, reader, offset, std::max(n, readahead_size_));
       } else {
+        if (IsOffsetInBuffer(offset, curr_)) {
+          RecordTick(stats_, PREFETCH_BYTES_USEFUL,
+                     bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize() -
+                         offset);
+        }
         if (implicit_auto_readahead_) {
           if (!IsEligibleForPrefetch(offset, n)) {
             // Ignore status as Prefetch is not called.
@@ -676,6 +682,9 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     } else {
       return false;
     }
+  } else if (!for_compaction) {
+    RecordTick(stats_, PREFETCH_HITS);
+    RecordTick(stats_, PREFETCH_BYTES_USEFUL, n);
   }
   UpdateReadPattern(offset, n, false /*decrease_readaheadsize*/);
 

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -98,7 +98,9 @@ Status FilePrefetchBuffer::Read(const IOOptions& opts,
     return s;
   }
 
-  RecordTick(stats_, PREFETCH_BYTES, read_len);
+  if (usage_ == FilePrefetchBufferUsage::kUserScanPrefetch) {
+    RecordTick(stats_, PREFETCH_BYTES, read_len);
+  }
   // Update the buffer offset and size.
   bufs_[index].offset_ = rounddown_start;
   bufs_[index].buffer_.Size(static_cast<size_t>(chunk_len) + result.size());

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -56,6 +56,7 @@ struct BufferInfo {
 
 enum class FilePrefetchBufferUsage {
   kTableOpenPrefetchTail,
+  kUserScanPrefetch,
   kUnknown,
 };
 

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -522,6 +522,15 @@ enum Tickers : uint32_t {
   FIFO_MAX_SIZE_COMPACTIONS,
   FIFO_TTL_COMPACTIONS,
 
+  // Number of bytes prefetched during user initiated scan
+  PREFETCH_BYTES,
+
+  // Number of prefetched bytes that were actually useful
+  PREFETCH_BYTES_USEFUL,
+
+  // Number of FS reads avoided due to scan prefetching
+  PREFETCH_HITS,
+
   TICKER_ENUM_MAX
 };
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5169,6 +5169,12 @@ class TickerTypeJni {
         return -0x3E;
       case ROCKSDB_NAMESPACE::Tickers::FIFO_TTL_COMPACTIONS:
         return -0x3F;
+      case ROCKSDB_NAMESPACE::Tickers::PREFETCH_BYTES:
+        return -0x40;
+      case ROCKSDB_NAMESPACE::Tickers::PREFETCH_BYTES_USEFUL:
+        return -0x41;
+      case ROCKSDB_NAMESPACE::Tickers::PREFETCH_HITS:
+        return -0x42;
       case ROCKSDB_NAMESPACE::Tickers::TICKER_ENUM_MAX:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep
@@ -5538,6 +5544,12 @@ class TickerTypeJni {
         return ROCKSDB_NAMESPACE::Tickers::FIFO_MAX_SIZE_COMPACTIONS;
       case -0x3F:
         return ROCKSDB_NAMESPACE::Tickers::FIFO_TTL_COMPACTIONS;
+      case -0x40:
+        return ROCKSDB_NAMESPACE::Tickers::PREFETCH_BYTES;
+      case -0x41:
+        return ROCKSDB_NAMESPACE::Tickers::PREFETCH_BYTES_USEFUL;
+      case -0x42:
+        return ROCKSDB_NAMESPACE::Tickers::PREFETCH_HITS;
       case 0x5F:
         // 0x5F was the max value in the initial copy of tickers to Java.
         // Since these values are exposed directly to Java clients, we keep

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -770,6 +770,12 @@ public enum TickerType {
 
     FIFO_TTL_COMPACTIONS((byte) -0x3F),
 
+    PREFETCH_BYTES((byte) -0x40),
+
+    PREFETCH_BYTES_USEFUL((byte) -0x41),
+
+    PREFETCH_HITS((byte) -0x42),
+
     TICKER_ENUM_MAX((byte) 0x5F);
 
     private final byte value;

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -261,6 +261,9 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {READAHEAD_TRIMMED, "rocksdb.readahead.trimmed"},
     {FIFO_MAX_SIZE_COMPACTIONS, "rocksdb.fifo.max.size.compactions"},
     {FIFO_TTL_COMPACTIONS, "rocksdb.fifo.ttl.compactions"},
+    {PREFETCH_BYTES, "rocksdb.prefetch.bytes"},
+    {PREFETCH_BYTES_USEFUL, "rocksdb.prefetch.bytes.useful"},
+    {PREFETCH_HITS, "rocksdb.prefetch.hits"},
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -697,14 +697,15 @@ struct BlockBasedTable::Rep {
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
       uint64_t upper_bound_offset,
-      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb)
-      const {
+      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb,
+      FilePrefetchBufferUsage usage) const {
     fpb->reset(new FilePrefetchBuffer(
         readahead_size, max_readahead_size,
         !ioptions.allow_mmap_reads /* enable */, false /* track_min_offset */,
         implicit_auto_readahead, num_file_reads,
         num_file_reads_for_auto_readahead, upper_bound_offset,
-        ioptions.fs.get(), ioptions.clock, ioptions.stats, readaheadsize_cb));
+        ioptions.fs.get(), ioptions.clock, ioptions.stats, readaheadsize_cb,
+        usage));
   }
 
   void CreateFilePrefetchBufferIfNotExists(
@@ -712,13 +713,13 @@ struct BlockBasedTable::Rep {
       std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
       uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
       uint64_t upper_bound_offset,
-      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb)
-      const {
+      const std::function<void(uint64_t, size_t, size_t&)>& readaheadsize_cb,
+      FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
                                implicit_auto_readahead, num_file_reads,
                                num_file_reads_for_auto_readahead,
-                               upper_bound_offset, readaheadsize_cb);
+                               upper_bound_offset, readaheadsize_cb, usage);
     }
   }
 

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -58,7 +58,8 @@ void BlockPrefetcher::PrefetchIfNeeded(
         readahead_size, readahead_size, &prefetch_buffer_,
         /*implicit_auto_readahead=*/false, /*num_file_reads=*/0,
         /*num_file_reads_for_auto_readahead=*/0, upper_bound_offset_,
-        readaheadsize_cb);
+        readaheadsize_cb,
+        /*usage=*/FilePrefetchBufferUsage::kUserScanPrefetch);
     return;
   }
 
@@ -83,7 +84,8 @@ void BlockPrefetcher::PrefetchIfNeeded(
         &prefetch_buffer_, /*implicit_auto_readahead=*/true,
         /*num_file_reads=*/0,
         rep->table_options.num_file_reads_for_auto_readahead,
-        upper_bound_offset_, readaheadsize_cb);
+        upper_bound_offset_, readaheadsize_cb,
+        /*usage=*/FilePrefetchBufferUsage::kUserScanPrefetch);
     return;
   }
 
@@ -114,7 +116,8 @@ void BlockPrefetcher::PrefetchIfNeeded(
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,
         rep->table_options.num_file_reads_for_auto_readahead,
-        upper_bound_offset_, readaheadsize_cb);
+        upper_bound_offset_, readaheadsize_cb,
+        /*usage=*/FilePrefetchBufferUsage::kUserScanPrefetch);
     return;
   }
 
@@ -136,7 +139,8 @@ void BlockPrefetcher::PrefetchIfNeeded(
         initial_auto_readahead_size_, max_auto_readahead_size,
         &prefetch_buffer_, /*implicit_auto_readahead=*/true, num_file_reads_,
         rep->table_options.num_file_reads_for_auto_readahead,
-        upper_bound_offset_, readaheadsize_cb);
+        upper_bound_offset_, readaheadsize_cb,
+        /*usage=*/FilePrefetchBufferUsage::kUserScanPrefetch);
     return;
   }
 

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -498,7 +498,8 @@ Status PartitionedFilterBlockReader::CacheDependencies(
     rep->CreateFilePrefetchBuffer(
         0, 0, &prefetch_buffer, false /* Implicit autoreadahead */,
         0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/,
-        /*upper_bound_offset*/ 0, /*readaheadsize_cb*/ nullptr);
+        /*upper_bound_offset*/ 0, /*readaheadsize_cb*/ nullptr,
+        /*usage=*/FilePrefetchBufferUsage::kUnknown);
 
     IOOptions opts;
     s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -170,7 +170,8 @@ Status PartitionIndexReader::CacheDependencies(
     rep->CreateFilePrefetchBuffer(
         0, 0, &prefetch_buffer, false /*Implicit auto readahead*/,
         0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/,
-        /*upper_bound_offset*/ 0, /*readaheadsize_cb*/ nullptr);
+        /*upper_bound_offset*/ 0, /*readaheadsize_cb*/ nullptr,
+        /*usage=*/FilePrefetchBufferUsage::kUnknown);
     IOOptions opts;
     {
       Status s = rep->file->PrepareIOOptions(ro, opts);


### PR DESCRIPTION
Add stats for better observability of scan prefetching. Its only implemented for sync scan right now. These stats can help inform future improvements in scan prefetching.

Test plan:
Add a new unit test