### PR TITLE
Fix for RecoverFromRetryableBGIOError starting with recovery_in_prog_ false

### DIFF
--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -671,11 +671,11 @@ const Status& ErrorHandler::StartRecoverFromRetryableBGIOError(
     // wait the previous recover thread to finish and create a new thread
     // to recover from the bg error.
     db_mutex_->Unlock();
+    TEST_SYNC_POINT("StartRecoverFromRetryableBGIOError:WaitingForOtherThread");
     old_recovery_thread->join();
     db_mutex_->Lock();
   }
 
-  TEST_SYNC_POINT("StartRecoverFromRetryableBGIOError::in_progress");
   recovery_thread_.reset(
       new port::Thread(&ErrorHandler::RecoverFromRetryableBGIOError, this));
 
@@ -689,7 +689,7 @@ const Status& ErrorHandler::StartRecoverFromRetryableBGIOError(
 // Automatic recover from Retryable BG IO error. Must be called after db
 // mutex is released.
 void ErrorHandler::RecoverFromRetryableBGIOError() {
-  assert(recovery_in_prog_);
+  // assert(recovery_in_prog_);
   TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeStart");
   TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeStart2");
   InstrumentedMutexLock l(db_mutex_);

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -689,6 +689,7 @@ const Status& ErrorHandler::StartRecoverFromRetryableBGIOError(
 // Automatic recover from Retryable BG IO error. Must be called after db
 // mutex is released.
 void ErrorHandler::RecoverFromRetryableBGIOError() {
+  assert(recovery_in_prog_);
   TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeStart");
   TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeStart2");
   InstrumentedMutexLock l(db_mutex_);

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -677,6 +677,9 @@ const Status& ErrorHandler::StartRecoverFromRetryableBGIOError(
     TEST_SYNC_POINT(
         "StartRecoverFromRetryableBGIOError:AfterWaitingForOtherThread");
     db_mutex_->Lock();
+
+    // In case recovery_in_prog_ was set back to false by old_recovery_thread
+    recovery_in_prog_ = true;
   }
 
   recovery_thread_.reset(
@@ -692,7 +695,7 @@ const Status& ErrorHandler::StartRecoverFromRetryableBGIOError(
 // Automatic recover from Retryable BG IO error. Must be called after db
 // mutex is released.
 void ErrorHandler::RecoverFromRetryableBGIOError() {
-  // assert(recovery_in_prog_);
+  assert(recovery_in_prog_);
   TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeStart");
   TEST_SYNC_POINT("RecoverFromRetryableBGIOError:BeforeStart2");
   InstrumentedMutexLock l(db_mutex_);

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -764,8 +764,6 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
           RecordInHistogram(bg_error_stats_.get(),
                             ERROR_HANDLER_AUTORESUME_RETRY_COUNT, retry_count);
         }
-        TEST_SYNC_POINT(
-            "RecoverFromRetryableBGIOError:RecoverSuccessBeforeReturn");
         return;
       } else {
         // In this case: 1) recovery_error_ is more serious or not retryable

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -671,8 +671,11 @@ const Status& ErrorHandler::StartRecoverFromRetryableBGIOError(
     // wait the previous recover thread to finish and create a new thread
     // to recover from the bg error.
     db_mutex_->Unlock();
-    TEST_SYNC_POINT("StartRecoverFromRetryableBGIOError:WaitingForOtherThread");
+    TEST_SYNC_POINT(
+        "StartRecoverFromRetryableBGIOError:BeforeWaitingForOtherThread");
     old_recovery_thread->join();
+    TEST_SYNC_POINT(
+        "StartRecoverFromRetryableBGIOError:AfterWaitingForOtherThread");
     db_mutex_->Lock();
   }
 
@@ -771,6 +774,8 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
         if (soft_error_no_bg_work_) {
           soft_error_no_bg_work_ = false;
         }
+        TEST_SYNC_POINT(
+            "RecoverFromRetryableBGIOError:RecoverSuccessBeforeReturn");
         return;
       } else {
         // In this case: 1) recovery_error_ is more serious or not retryable

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -779,6 +779,7 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
         }
         TEST_SYNC_POINT(
             "RecoverFromRetryableBGIOError:RecoverSuccessBeforeReturn");
+        TEST_SYNC_POINT("RecoverFromRetryableBGIOError:End");
         return;
       } else {
         // In this case: 1) recovery_error_ is more serious or not retryable
@@ -805,6 +806,7 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
     RecordInHistogram(bg_error_stats_.get(),
                       ERROR_HANDLER_AUTORESUME_RETRY_COUNT, retry_count);
   }
+  TEST_SYNC_POINT("RecoverFromRetryableBGIOError:End");
   return;
 }
 

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -556,6 +556,7 @@ Status ErrorHandler::ClearBGError() {
     // old_bg_error is only for notifying listeners, so may not be checked
     old_bg_error.PermitUncheckedError();
     // Clear and check the recovery IO and BG error
+    is_db_stopped_.store(false, std::memory_order_release);
     bg_error_ = Status::OK();
     recovery_error_ = IOStatus::OK();
     bg_error_.PermitUncheckedError();

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -779,7 +779,6 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
         }
         TEST_SYNC_POINT(
             "RecoverFromRetryableBGIOError:RecoverSuccessBeforeReturn");
-        TEST_SYNC_POINT("RecoverFromRetryableBGIOError:End");
         return;
       } else {
         // In this case: 1) recovery_error_ is more serious or not retryable
@@ -806,7 +805,6 @@ void ErrorHandler::RecoverFromRetryableBGIOError() {
     RecordInHistogram(bg_error_stats_.get(),
                       ERROR_HANDLER_AUTORESUME_RETRY_COUNT, retry_count);
   }
-  TEST_SYNC_POINT("RecoverFromRetryableBGIOError:End");
   return;
 }
 

--- a/db/error_handler_fs_test.cc
+++ b/db/error_handler_fs_test.cc
@@ -1863,7 +1863,7 @@ TEST_F(DBErrorHandlingFSTest, MultipleRecoveryThreads) {
         "NotifyOnErrorRecoveryEnd:MutexUnlocked:2"},
        {"StartRecoverFromRetryableBGIOError:BeforeWaitingForOtherThread",
         "MultipleRecoveryThreads:3"},
-       {"RecoverFromRetryableBGIOError:RecoverSuccessBeforeReturn",
+       {"RecoverFromRetryableBGIOError:RecoverSuccess",
         "MultipleRecoveryThreads:4"},
        {"MultipleRecoveryThreads:5",
         "StartRecoverFromRetryableBGIOError:AfterWaitingForOtherThread"}});
@@ -1904,7 +1904,7 @@ TEST_F(DBErrorHandlingFSTest, MultipleRecoveryThreads) {
 
   // Set up sync point so that we can wait for the recovery thread to finish
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
-      {{"RecoverFromRetryableBGIOError:RecoverSuccessBeforeReturn",
+      {{"RecoverFromRetryableBGIOError:RecoverSuccess",
         "MultipleRecoveryThreads:6"}});
 
   // Wait for the second thread's recovery to be done

--- a/db/error_handler_fs_test.cc
+++ b/db/error_handler_fs_test.cc
@@ -155,9 +155,9 @@ class ErrorHandlerFSListener : public EventListener {
   FaultInjectionTestFS* fault_fs_;
 };
 
-TEST_F(DBErrorHandlingFSTest, FLushWriteError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWriteError) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -200,9 +200,9 @@ TEST_F(DBErrorHandlingFSTest, FLushWriteError) {
 // All the NoSpace IOError will be handled as the regular BG Error no matter the
 // retryable flag is set of not. So the auto resume for retryable IO Error will
 // not be triggered. Also, it is mapped as hard error.
-TEST_F(DBErrorHandlingFSTest, FLushWriteNoSpaceError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWriteNoSpaceError) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -244,9 +244,9 @@ TEST_F(DBErrorHandlingFSTest, FLushWriteNoSpaceError) {
   Destroy(options);
 }
 
-TEST_F(DBErrorHandlingFSTest, FLushWriteRetryableError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWriteRetryableError) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -318,9 +318,9 @@ TEST_F(DBErrorHandlingFSTest, FLushWriteRetryableError) {
   Destroy(options);
 }
 
-TEST_F(DBErrorHandlingFSTest, FLushWriteFileScopeError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWriteFileScopeError) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -402,9 +402,9 @@ TEST_F(DBErrorHandlingFSTest, FLushWriteFileScopeError) {
   Destroy(options);
 }
 
-TEST_F(DBErrorHandlingFSTest, FLushWALWriteRetryableError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWALWriteRetryableError) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -446,9 +446,9 @@ TEST_F(DBErrorHandlingFSTest, FLushWALWriteRetryableError) {
   Destroy(options);
 }
 
-TEST_F(DBErrorHandlingFSTest, FLushWALAtomicWriteRetryableError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWALAtomicWriteRetryableError) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -492,9 +492,9 @@ TEST_F(DBErrorHandlingFSTest, FLushWALAtomicWriteRetryableError) {
 }
 
 // The flush error is injected before we finish the table build
-TEST_F(DBErrorHandlingFSTest, FLushWritNoWALRetryableError1) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWritNoWALRetryableError1) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -548,9 +548,9 @@ TEST_F(DBErrorHandlingFSTest, FLushWritNoWALRetryableError1) {
 }
 
 // The retryable IO error is injected before we sync table
-TEST_F(DBErrorHandlingFSTest, FLushWriteNoWALRetryableError2) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWriteNoWALRetryableError2) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -592,9 +592,9 @@ TEST_F(DBErrorHandlingFSTest, FLushWriteNoWALRetryableError2) {
 }
 
 // The retryable IO error is injected before we close the table file
-TEST_F(DBErrorHandlingFSTest, FLushWriteNoWALRetryableError3) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_F(DBErrorHandlingFSTest, FlushWriteNoWALRetryableError3) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -636,8 +636,8 @@ TEST_F(DBErrorHandlingFSTest, FLushWriteNoWALRetryableError3) {
 }
 
 TEST_F(DBErrorHandlingFSTest, ManifestWriteError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -677,8 +677,8 @@ TEST_F(DBErrorHandlingFSTest, ManifestWriteError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, ManifestWriteRetryableError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -720,8 +720,8 @@ TEST_F(DBErrorHandlingFSTest, ManifestWriteRetryableError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, ManifestWriteFileScopeError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -766,8 +766,8 @@ TEST_F(DBErrorHandlingFSTest, ManifestWriteFileScopeError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, ManifestWriteNoWALRetryableError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -811,8 +811,8 @@ TEST_F(DBErrorHandlingFSTest, ManifestWriteNoWALRetryableError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, DoubleManifestWriteError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -863,8 +863,8 @@ TEST_F(DBErrorHandlingFSTest, CompactionManifestWriteError) {
     ROCKSDB_GTEST_SKIP("Test requires non-mock environment");
     return;
   }
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -933,8 +933,8 @@ TEST_F(DBErrorHandlingFSTest, CompactionManifestWriteError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, CompactionManifestWriteRetryableError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1005,8 +1005,8 @@ TEST_F(DBErrorHandlingFSTest, CompactionManifestWriteRetryableError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, CompactionWriteError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1047,8 +1047,8 @@ TEST_F(DBErrorHandlingFSTest, CompactionWriteError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, DISABLED_CompactionWriteRetryableError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1094,8 +1094,8 @@ TEST_F(DBErrorHandlingFSTest, DISABLED_CompactionWriteRetryableError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, DISABLED_CompactionWriteFileScopeError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1186,8 +1186,8 @@ TEST_F(DBErrorHandlingFSTest, AutoRecoverFlushError) {
     ROCKSDB_GTEST_SKIP("Test requires non-mock environment");
     return;
   }
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1231,8 +1231,8 @@ TEST_F(DBErrorHandlingFSTest, AutoRecoverFlushError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, FailRecoverFlushError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1260,8 +1260,8 @@ TEST_F(DBErrorHandlingFSTest, WALWriteError) {
     ROCKSDB_GTEST_SKIP("Test requires non-mock environment");
     return;
   }
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1333,8 +1333,8 @@ TEST_F(DBErrorHandlingFSTest, WALWriteError) {
 }
 
 TEST_F(DBErrorHandlingFSTest, WALWriteRetryableError) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1428,8 +1428,8 @@ TEST_F(DBErrorHandlingFSTest, MultiCFWALWriteError) {
     ROCKSDB_GTEST_SKIP("Test requires non-mock environment");
     return;
   }
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1760,10 +1760,10 @@ TEST_F(DBErrorHandlingFSTest, MultiDBVariousErrors) {
 // to soft error and trigger auto resume. During auto resume, SwitchMemtable
 // is disabled to avoid small SST tables. Write can still be applied before
 // the bg error is cleaned unless the memtable is full.
-TEST_F(DBErrorHandlingFSTest, FLushWritNoWALRetryableErrorAutoRecover1) {
+TEST_F(DBErrorHandlingFSTest, FlushWritNoWALRetryableErrorAutoRecover1) {
   // Activate the FS before the first resume
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1784,7 +1784,7 @@ TEST_F(DBErrorHandlingFSTest, FLushWritNoWALRetryableErrorAutoRecover1) {
   ASSERT_OK(Put(Key(1), "val1", wo));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"RecoverFromRetryableBGIOError:LoopOut",
-        "FLushWritNoWALRetryableeErrorAutoRecover1:1"}});
+        "FlushWritNoWALRetryableeErrorAutoRecover1:1"}});
   SyncPoint::GetInstance()->SetCallBack(
       "BuildTable:BeforeFinishBuildTable",
       [&](void*) { fault_fs_->SetFilesystemActive(false, error_msg); });
@@ -1793,7 +1793,7 @@ TEST_F(DBErrorHandlingFSTest, FLushWritNoWALRetryableErrorAutoRecover1) {
   s = Flush();
   ASSERT_EQ("val1", Get(Key(1)));
   ASSERT_EQ(s.severity(), ROCKSDB_NAMESPACE::Status::Severity::kSoftError);
-  TEST_SYNC_POINT("FLushWritNoWALRetryableeErrorAutoRecover1:1");
+  TEST_SYNC_POINT("FlushWritNoWALRetryableeErrorAutoRecover1:1");
   ASSERT_EQ("val1", Get(Key(1)));
   ASSERT_EQ("val1", Get(Key(1)));
   SyncPoint::GetInstance()->DisableProcessing();
@@ -1837,8 +1837,8 @@ TEST_F(DBErrorHandlingFSTest, MultipleRecoveryThreads) {
   // sure RecoverFromRetryableBGIOError() from the second write's recovery
   // thread does not start with recovery_in_prog_ = false;
 
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1915,10 +1915,10 @@ TEST_F(DBErrorHandlingFSTest, MultipleRecoveryThreads) {
   Destroy(options);
 }
 
-TEST_F(DBErrorHandlingFSTest, FLushWritNoWALRetryableErrorAutoRecover2) {
+TEST_F(DBErrorHandlingFSTest, FlushWritNoWALRetryableErrorAutoRecover2) {
   // Activate the FS before the first resume
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -1976,10 +1976,10 @@ TEST_F(DBErrorHandlingFSTest, FLushWritNoWALRetryableErrorAutoRecover2) {
 
 // Auto resume fromt the flush retryable IO error. Activate the FS before the
 // first resume. Resume is successful
-TEST_F(DBErrorHandlingFSTest, FLushWritRetryableErrorAutoRecover1) {
+TEST_F(DBErrorHandlingFSTest, FlushWritRetryableErrorAutoRecover1) {
   // Activate the FS before the first resume
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2018,10 +2018,10 @@ TEST_F(DBErrorHandlingFSTest, FLushWritRetryableErrorAutoRecover1) {
 
 // Auto resume fromt the flush retryable IO error and set the retry limit count.
 // Never activate the FS and auto resume should fail at the end
-TEST_F(DBErrorHandlingFSTest, FLushWritRetryableErrorAutoRecover2) {
+TEST_F(DBErrorHandlingFSTest, FlushWritRetryableErrorAutoRecover2) {
   // Fail all the resume and let user to resume
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2038,18 +2038,18 @@ TEST_F(DBErrorHandlingFSTest, FLushWritRetryableErrorAutoRecover2) {
 
   ASSERT_OK(Put(Key(1), "val1"));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
-      {{"FLushWritRetryableeErrorAutoRecover2:0",
+      {{"FlushWritRetryableeErrorAutoRecover2:0",
         "RecoverFromRetryableBGIOError:BeforeStart"},
        {"RecoverFromRetryableBGIOError:LoopOut",
-        "FLushWritRetryableeErrorAutoRecover2:1"}});
+        "FlushWritRetryableeErrorAutoRecover2:1"}});
   SyncPoint::GetInstance()->SetCallBack(
       "BuildTable:BeforeFinishBuildTable",
       [&](void*) { fault_fs_->SetFilesystemActive(false, error_msg); });
   SyncPoint::GetInstance()->EnableProcessing();
   s = Flush();
   ASSERT_EQ(s.severity(), ROCKSDB_NAMESPACE::Status::Severity::kSoftError);
-  TEST_SYNC_POINT("FLushWritRetryableeErrorAutoRecover2:0");
-  TEST_SYNC_POINT("FLushWritRetryableeErrorAutoRecover2:1");
+  TEST_SYNC_POINT("FlushWritRetryableeErrorAutoRecover2:0");
+  TEST_SYNC_POINT("FlushWritRetryableeErrorAutoRecover2:1");
   fault_fs_->SetFilesystemActive(true);
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->DisableProcessing();
@@ -2071,8 +2071,8 @@ TEST_F(DBErrorHandlingFSTest, FLushWritRetryableErrorAutoRecover2) {
 // Fail the first resume and let the second resume be successful.
 TEST_F(DBErrorHandlingFSTest, ManifestWriteRetryableErrorAutoRecover) {
   // Fail the first resume and let the second resume be successful
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2124,8 +2124,8 @@ TEST_F(DBErrorHandlingFSTest, ManifestWriteRetryableErrorAutoRecover) {
 
 TEST_F(DBErrorHandlingFSTest, ManifestWriteNoWALRetryableErrorAutoRecover) {
   // Fail the first resume and let the second resume be successful
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2179,8 +2179,8 @@ TEST_F(DBErrorHandlingFSTest, ManifestWriteNoWALRetryableErrorAutoRecover) {
 
 TEST_F(DBErrorHandlingFSTest,
        CompactionManifestWriteRetryableErrorAutoRecover) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2269,8 +2269,8 @@ TEST_F(DBErrorHandlingFSTest, CompactionWriteRetryableErrorAutoRecover) {
   // compaction, the FS is set to active and compaction is successful, so
   // the test will hit the CompactionJob::FinishCompactionOutputFile1 sync
   // point.
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2323,8 +2323,8 @@ TEST_F(DBErrorHandlingFSTest, CompactionWriteRetryableErrorAutoRecover) {
 }
 
 TEST_F(DBErrorHandlingFSTest, WALWriteRetryableErrorAutoRecover1) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2426,8 +2426,8 @@ TEST_F(DBErrorHandlingFSTest, WALWriteRetryableErrorAutoRecover1) {
 
 TEST_F(DBErrorHandlingFSTest, WALWriteRetryableErrorAutoRecover2) {
   // Fail the first recover and try second time.
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2527,10 +2527,10 @@ TEST_F(DBErrorHandlingFSTest, WALWriteRetryableErrorAutoRecover2) {
 
 // Fail auto resume from a flush retryable error and verify that
 // OnErrorRecoveryEnd listener callback is called
-TEST_F(DBErrorHandlingFSTest, FLushWritRetryableErrorAbortRecovery) {
+TEST_F(DBErrorHandlingFSTest, FlushWritRetryableErrorAbortRecovery) {
   // Activate the FS before the first resume
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2821,9 +2821,9 @@ TEST_F(DBErrorHandlingFSTest, CompactionReadRetryableErrorAutoRecover) {
 class DBErrorHandlingFencingTest : public DBErrorHandlingFSTest,
                                    public testing::WithParamInterface<bool> {};
 
-TEST_P(DBErrorHandlingFencingTest, FLushWriteFenced) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+TEST_P(DBErrorHandlingFencingTest, FlushWriteFenced) {
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2850,8 +2850,8 @@ TEST_P(DBErrorHandlingFencingTest, FLushWriteFenced) {
 }
 
 TEST_P(DBErrorHandlingFencingTest, ManifestWriteFenced) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2885,8 +2885,8 @@ TEST_P(DBErrorHandlingFencingTest, ManifestWriteFenced) {
 }
 
 TEST_P(DBErrorHandlingFencingTest, CompactionWriteFenced) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;
@@ -2926,8 +2926,8 @@ TEST_P(DBErrorHandlingFencingTest, CompactionWriteFenced) {
 }
 
 TEST_P(DBErrorHandlingFencingTest, WALWriteFenced) {
-  std::shared_ptr<ErrorHandlerFSListener> listener(
-      new ErrorHandlerFSListener());
+  std::shared_ptr<ErrorHandlerFSListener> listener =
+      std::make_shared<ErrorHandlerFSListener>();
   Options options = GetDefaultOptions();
   options.env = fault_env_.get();
   options.create_if_missing = true;

--- a/db/error_handler_fs_test.cc
+++ b/db/error_handler_fs_test.cc
@@ -1865,7 +1865,7 @@ TEST_F(DBErrorHandlingFSTest, MultipleRecoveryThreads) {
         "MultipleRecoveryThreads:3"},
        {"RecoverFromRetryableBGIOError:RecoverSuccess",
         "MultipleRecoveryThreads:4"},
-       {"MultipleRecoveryThreads:5",
+       {"MultipleRecoveryThreads:4",
         "StartRecoverFromRetryableBGIOError:AfterWaitingForOtherThread"}});
   SyncPoint::GetInstance()->EnableProcessing();
 
@@ -1895,9 +1895,8 @@ TEST_F(DBErrorHandlingFSTest, MultipleRecoveryThreads) {
   TEST_SYNC_POINT("MultipleRecoveryThreads:2");
   // Wait for the first thread's recovery to finish
   // (this sets recovery_in_prog_ = false)
+  // And second thread continues and starts recovery thread
   TEST_SYNC_POINT("MultipleRecoveryThreads:4");
-  // Second thread continues and starts recovery thread
-  TEST_SYNC_POINT("MultipleRecoveryThreads:5");
   second_write.join();
   // Remove error injection so that second thread recovery can go through
   fault_fs_->SetFilesystemActive(true);

--- a/db/event_helpers.cc
+++ b/db/event_helpers.cc
@@ -230,6 +230,8 @@ void EventHelpers::NotifyOnErrorRecoveryEnd(
     db_mutex->AssertHeld();
     // release lock while notifying events
     db_mutex->Unlock();
+    TEST_SYNC_POINT("NotifyOnErrorRecoveryEnd:MutexUnlocked:1");
+    TEST_SYNC_POINT("NotifyOnErrorRecoveryEnd:MutexUnlocked:2");
     for (auto& listener : listeners) {
       BackgroundErrorRecoveryInfo info;
       info.old_bg_error = old_bg_error;


### PR DESCRIPTION
# Summary

@cbi42 helped investigation and found a potential scenario where `RecoverFromRetryableBGIOError()` may start with `recovery_in_prog_ ` set as false. (and other booleans like `bg_error_` and `soft_error_no_bg_work_`)

**Thread 1**
- `StartRecoverFromRetryableBGIOError()`): (mutex held) sets `recovery_in_prog_ = true`

**Thread 1's `recovery_thread_`**
- (waits for mutex and acquires it)
- `RecoverFromRetryableBGIOError()` -> `ResumeImpl()` -> `ClearBGError()`: sets `recovery_in_prog_ = false`
- `ClearBGError()` -> `NotifyOnErrorRecoveryEnd()`: releases `mutex`

**Thread 2**
- `StartRecoverFromRetryableBGIOError()`): (mutex held) sets `recovery_in_prog_ = true`
- Waits for Thread 1 (`recovery_thread_`) to finish

**Thread 1's `recovery_thread_`**
- re-lock mutex in `NotifyOnErrorRecoveryEnd()`
- Still inside `RecoverFromRetryableBGIOError()`: sets `recovery_in_prog_ = false`
- Done

**Thread 2's `recovery_thread_`**
- recovery thread started with `recovery_in_prog_` set as `false` 

# Fix
- Remove double-clearing `bg_error_`,  `recovery_in_prog_` and other fields after `ResumeImpl()` already returned `OK()`.
- Minor typo and linter fixes in `DBErrorHandlingFSTest`

# Test Plan

- `DBErrorHandlingFSTest::MultipleRecoveryThreads` added to reproduce the scenario. 
- Adding `assert(recovery_in_prog_);` at the start of `ErrorHandler::RecoverFromRetryableBGIOError()` fails the test without the fix and succeeds with the fix as expected.




