### PR TITLE
Consolidate stats recording in error handler

### DIFF
--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -94,6 +94,10 @@ class ErrorHandler {
   void ClearFilesToQuarantine();
 
  private:
+  void RecordStats(
+      const std::vector<Tickers>& ticker_types,
+      const std::vector<std::tuple<Histograms, uint64_t>>& int_histograms);
+
   DBImpl* db_;
   const ImmutableDBOptions& db_options_;
   Status bg_error_;
@@ -107,7 +111,10 @@ class ErrorHandler {
   std::unique_ptr<port::Thread> recovery_thread_;
 
   InstrumentedMutex* db_mutex_;
-  // A flag indicating whether automatic recovery from errors is enabled
+  // A flag indicating whether automatic recovery from errors is enabled. Auto
+  // recovery applies for delegating to SstFileManager to handle no space type
+  // of errors. This flag doesn't control the auto resume behavior to recover
+  // from retryable IO errors.
   bool auto_recovery_;
   bool recovery_in_prog_;
   // A flag to indicate that for the soft error, we should not allow any

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -362,7 +362,7 @@ enum Tickers : uint32_t {
   // scheduler.
   FILES_DELETED_IMMEDIATELY,
 
-  // The counters for error handler, not that, bg_io_error is the subset of
+  // The counters for error handler, note that, bg_io_error is the subset of
   // bg_error and bg_retryable_io_error is the subset of bg_io_error.
   // The misspelled versions are deprecated and only kept for compatibility.
   // TODO: remove the misspelled tickers in the next major release.


### PR DESCRIPTION
This is a non functional refactor, mostly for deduplicating the stats recording logic in error handler. Plus some documentation update and simple code dedupe.

Test Plan:
existing tests