### PR TITLE
Support reserving seqnos via WAL entry

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -68,6 +68,7 @@ enum ValueType : unsigned char {
   kTypeCommitXIDAndTimestamp = 0x15,  // WAL only
   kTypeWideColumnEntity = 0x16,
   kTypeColumnFamilyWideColumnEntity = 0x17,  // WAL only
+  kTypeReserveSeqno = 0x18,                  // WAL only
   kTypeMaxValid,    // Should be after the last valid type, only used for
                     // validation
   kMaxValue = 0x7F  // Not used for storing records.

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -987,6 +987,13 @@ TEST_P(SeqnoTimeTablePropTest, PrePopulateInDB) {
   // Oldest tracking time maps to first pre-allocated seqno
   ASSERT_EQ(sttm.GetProximalSeqnoBeforeTime(start_time - kPreserveSecs), 1);
 
+  // Even after no writes and DB re-open without tracking options, sequence
+  // numbers should not go backward into those that were pre-allocated.
+  // (Future work: persist the mapping)
+  ReopenWithColumnFamilies({"default", "one"},
+                           List({base_options, base_options}));
+  ASSERT_EQ(latest_seqno, db_->GetLatestSequenceNumber());
+
   Close();
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -7234,20 +7234,6 @@ Status VersionSet::VerifyFileMetadata(const ReadOptions& read_options,
   return status;
 }
 
-void VersionSet::EnsureNonZeroSequence() {
-  uint64_t expected = 0;
-  // Update each from 0->1, in order, or abort if any becomes non-zero in
-  // parallel
-  if (last_allocated_sequence_.compare_exchange_strong(expected, 1)) {
-    if (last_published_sequence_.compare_exchange_strong(expected, 1)) {
-      (void)last_sequence_.compare_exchange_strong(expected, 1);
-    }
-  }
-  assert(last_allocated_sequence_.load() > 0);
-  assert(last_published_sequence_.load() > 0);
-  assert(last_sequence_.load() > 0);
-}
-
 ReactiveVersionSet::ReactiveVersionSet(
     const std::string& dbname, const ImmutableDBOptions* _db_options,
     const FileOptions& _file_options, Cache* table_cache,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1344,9 +1344,6 @@ class VersionSet {
     last_allocated_sequence_.store(s, std::memory_order_seq_cst);
   }
 
-  // Allocate a dummy sequence number as needed to ensure last is non-zero.
-  void EnsureNonZeroSequence();
-
   // Note: memory_order_release must be sufficient
   uint64_t FetchAddLastAllocatedSequence(uint64_t s) {
     return last_allocated_sequence_.fetch_add(s, std::memory_order_seq_cst);

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -131,6 +131,8 @@ class WriteBatchInternal {
 
   static Status InsertNoop(WriteBatch* batch);
 
+  static Status InsertReserveSeqno(WriteBatch* b, uint32_t count);
+
   // Return the number of entries in the batch.
   static uint32_t Count(const WriteBatch* batch);
 

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -317,6 +317,11 @@ class WriteBatch : public WriteBatchBase {
       return Status::InvalidArgument("MarkNoop() handler not defined.");
     }
 
+    virtual Status MarkReserveSeqno(uint32_t /*count*/) {
+      // Default to same handling as a no-op
+      return MarkNoop(false);
+    }
+
     virtual Status MarkRollback(const Slice& /*xid*/) {
       return Status::InvalidArgument(
           "MarkRollbackPrepare() handler not defined.");

--- a/utilities/debug.cc
+++ b/utilities/debug.cc
@@ -38,7 +38,8 @@ static std::unordered_map<std::string, ValueType> value_type_string_map = {
     {"TypeCommitXIDAndTimestamp", ValueType::kTypeCommitXIDAndTimestamp},
     {"TypeWideColumnEntity", ValueType::kTypeWideColumnEntity},
     {"TypeColumnFamilyWideColumnEntity",
-     ValueType::kTypeColumnFamilyWideColumnEntity}};
+     ValueType::kTypeColumnFamilyWideColumnEntity},
+    {"TypeReserveSeqno", ValueType::kTypeReserveSeqno}};
 
 std::string KeyVersion::GetTypeName() const {
   std::string type_name;
@@ -115,4 +116,3 @@ Status GetAllKeyVersions(DB* db, ColumnFamilyHandle* cfh, Slice begin_key,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-


### PR DESCRIPTION
Summary: #11922 could cause crash test failure in which we record an expected state at a sequence number after pre-population but before any user writes. On DB re-open after no user writes and with preserve/preclude options disabled, we have no existing mechanism to restore seqnos to the old value after pre-population. Seqno going backward on re-open confuses the crash test (and is potentially wrong behavior for the user).

We can fix this by creating a formal write path mechanism for reserving sequence numbers rather than relying on partial hacks. This new mechanism will create a WAL entry for reserving the sequence numbers and will be restored on recovery, subject to normal constraints. For example, I think we can tolerate a risk of the record etc. being lost if point in time recovery gets there.

Rejected approaches:
* Simply LogAndApply an edit with the last sequence number. I'm worried about the consistency correctness of committing what I think is the latest sequence number in the case of reserving a sequence number outside of DB::Open. If I need to lock out the write path anyway, it's more elegant IMHO to simply invoke the write path to do what I want.
* Similar, but add to the version edits in recovery_ctx during DB::Open. In addition to not handling the non-Open case, recovery_ctx edits are committed before creating column families for
create_missing_column_families. So we don't have easy access to all the CF options.

Future work (likely someone else) will likely persist seqno-to-time mappings in the manifest, but I believe this can remain decoupled from the seqno reservations for pre-population.

Test Plan: added to SeqnoTimeTablePropTest.PrePopulateInDB unit test, except I don't know how to simulate recovering from a process crash in unit tests.