### PR TITLE
Disable AutoHCC in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -125,10 +125,9 @@ default_params = {
     "use_direct_io_for_flush_and_compaction": lambda: random.randint(0, 1),
     "mock_direct_io": False,
     "cache_type": lambda: random.choice(
-        ["lru_cache", "fixed_hyper_clock_cache", "auto_hyper_clock_cache",
-         "auto_hyper_clock_cache", "tiered_lru_cache",
-         "tiered_fixed_hyper_clock_cache", "tiered_auto_hyper_clock_cache",
-         "tiered_auto_hyper_clock_cache"]
+        ["lru_cache", "fixed_hyper_clock_cache",
+         # NOTE: auto_hyper_clock_cache disabled for now
+         "tiered_lru_cache", "tiered_fixed_hyper_clock_cache"]
     ),
     "use_full_merge_v1": lambda: random.randint(0, 1),
     "use_merge": lambda: random.randint(0, 1),


### PR DESCRIPTION
Summary: ... until I can reproduce and resolve assertion failures (mostly in PurgeImplLocked) seen in crash test.

Test Plan: make blackbox_crash_test