### PR TITLE
Remove the default force behavior for `EnableFileDeletion` API

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -121,7 +121,7 @@ Status DBImpl::GetSortedWalFiles(VectorLogPtr& files) {
 
   // DisableFileDeletions / EnableFileDeletions not supported in read-only DB
   if (deletions_disabled.ok()) {
-    Status s2 = EnableFileDeletions(/*force*/ false);
+    Status s2 = EnableFileDeletions(/*force=*/false);
     assert(s2.ok());
     s2.PermitUncheckedError();
   } else {

--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -236,7 +236,7 @@ TEST_F(DBTestXactLogIterator, TransactionLogIteratorCorruptedLog) {
     ASSERT_OK(test::TruncateFile(env_, logfile_path,
                                  wal_files.front()->SizeFileBytes() / 2));
 
-    ASSERT_OK(db_->EnableFileDeletions());
+    ASSERT_OK(db_->EnableFileDeletions(/*force=*/false));
 
     // Insert a new entry to a new log file
     ASSERT_OK(Put("key1025", DummyString(10)));

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -107,12 +107,12 @@ TEST_F(DBPropertiesTest, Empty) {
         dbfull()->GetProperty("rocksdb.is-file-deletions-enabled", &num));
     ASSERT_EQ("0", num);
 
-    ASSERT_OK(db_->EnableFileDeletions(false));
+    ASSERT_OK(db_->EnableFileDeletions(/*force=*/false));
     ASSERT_TRUE(
         dbfull()->GetProperty("rocksdb.is-file-deletions-enabled", &num));
     ASSERT_EQ("0", num);
 
-    ASSERT_OK(db_->EnableFileDeletions());
+    ASSERT_OK(db_->EnableFileDeletions(/*force=*/true));
     ASSERT_TRUE(
         dbfull()->GetProperty("rocksdb.is-file-deletions-enabled", &num));
     ASSERT_EQ("1", num);
@@ -1744,7 +1744,7 @@ TEST_F(DBPropertiesTest, SstFilesSize) {
   ASSERT_EQ(obsolete_sst_size, sst_size);
 
   // Let the obsolete files be deleted.
-  ASSERT_OK(db_->EnableFileDeletions());
+  ASSERT_OK(db_->EnableFileDeletions(/*force=*/false));
   ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kObsoleteSstFilesSize,
                                   &obsolete_sst_size));
   ASSERT_EQ(obsolete_sst_size, 0);

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -4135,7 +4135,7 @@ TEST_F(DBTest2, LiveFilesOmitObsoleteFiles) {
     ASSERT_OK(env_->FileExists(LogFileName(dbname_, log_file->LogNumber())));
   }
 
-  ASSERT_OK(db_->EnableFileDeletions());
+  ASSERT_OK(db_->EnableFileDeletions(/*force=*/false));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
 

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1195,7 +1195,7 @@ TEST_F(DBWALTest, DISABLED_FullPurgePreservesLogPendingReuse) {
     ROCKSDB_NAMESPACE::port::Thread thread([&]() {
       TEST_SYNC_POINT(
           "DBWALTest::FullPurgePreservesLogPendingReuse:PreFullPurge");
-      ASSERT_OK(db_->EnableFileDeletions(true));
+      ASSERT_OK(db_->EnableFileDeletions(/*force=*/true));
       TEST_SYNC_POINT(
           "DBWALTest::FullPurgePreservesLogPendingReuse:PostFullPurge");
     });

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -165,7 +165,7 @@ TEST_F(ObsoleteFilesTest, DeleteObsoleteOptionsFile) {
                                      {{"paranoid_file_checks", "true"}}));
     }
   }
-  ASSERT_OK(dbfull()->EnableFileDeletions(true /* force */));
+  ASSERT_OK(dbfull()->EnableFileDeletions(/*force=*/false));
 
   Close();
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1650,7 +1650,17 @@ class DB {
   virtual Status GetFullHistoryTsLow(ColumnFamilyHandle* column_family,
                                      std::string* ts_low) = 0;
 
-  // Allow compactions to delete obsolete files.
+  // Enable deleting obsolete files.
+  // Usually users should only need to call this if they have previously called
+  // `DisableFileDeletions`.
+  // File deletions disabling and enabling is not controlled by a binary flag,
+  // instead it's represented as a counter to allow different callers to
+  // independently disable file deletion. Disabling file deletion can be
+  // critical for operations like making a backup. So the counter implementation
+  // makes the file deletion disabled as long as there is one caller requesting
+  // so, and only when every caller agrees to re-enable file deletion, it will
+  // be enabled. So be careful when calling this function with force = true as
+  // explained below.
   // If force == true, the call to EnableFileDeletions() will guarantee that
   // file deletions are enabled after the call, even if DisableFileDeletions()
   // was called multiple times before.
@@ -1659,7 +1669,7 @@ class DB {
   // enabling the two methods to be called by two threads concurrently without
   // synchronization -- i.e., file deletions will be enabled only after both
   // threads call EnableFileDeletions()
-  virtual Status EnableFileDeletions(bool force = true) = 0;
+  virtual Status EnableFileDeletions(bool force) = 0;
 
   // Retrieves the creation time of the oldest file in the DB.
   // This API only works if max_open_files = -1, if it is not then

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -4199,7 +4199,7 @@ public class RocksDB extends RocksObject {
   }
 
   /**
-   * <p>Allow compactions to delete obsolete files.
+   * <p>Enable deleting obsolete files.
    * If force == true, the call to EnableFileDeletions()
    * will guarantee that file deletions are enabled after
    * the call, even if DisableFileDeletions() was called

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -269,7 +269,7 @@ class FileChecksumTestHelper {
         break;
       }
     }
-    EXPECT_OK(db_->EnableFileDeletions());
+    EXPECT_OK(db_->EnableFileDeletions(/*force=*/false));
     return cs;
   }
 };

--- a/unreleased_history/public_api_changes/enable_file_deletion_not_default_force.md
+++ b/unreleased_history/public_api_changes/enable_file_deletion_not_default_force.md
@@ -1,0 +1,2 @@
+Make the `EnableFileDeletion` API not default to force enabling. For users that rely on this default behavior and still
+want to continue to use force enabling, they need to explicitly pass a `true` to `EnableFileDeletion`.

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -1583,7 +1583,7 @@ IOStatus BackupEngineImpl::CreateNewBackupWithMetadata(
 
   // we copied all the files, enable file deletions
   if (disabled.ok()) {  // If we successfully disabled file deletions
-    db->EnableFileDeletions(false).PermitUncheckedError();
+    db->EnableFileDeletions(/*force=*/false).PermitUncheckedError();
   }
   auto backup_time = backup_env_->NowMicros() - start_backup;
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -490,7 +490,7 @@ class BlobDBImpl : public BlobDB {
 
   // Each call of DisableFileDeletions will increase disable_file_deletion_
   // by 1. EnableFileDeletions will either decrease the count by 1 or reset
-  // it to zeor, depending on the force flag.
+  // it to zero, depending on the force flag.
   //
   // REQUIRES: access with delete_file_mutex_ held.
   int disable_file_deletions_ = 0;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -2037,7 +2037,7 @@ TEST_F(BlobDBTest, DisableFileDeletions) {
       ASSERT_EQ(1, blob_db_impl()->TEST_GetObsoleteFiles().size());
       VerifyDB(data);
       // Call EnableFileDeletions a second time.
-      ASSERT_OK(blob_db_->EnableFileDeletions(false));
+      ASSERT_OK(blob_db_->EnableFileDeletions(/*force=*/false));
       blob_db_impl()->TEST_DeleteObsoleteFiles();
     }
     // Regardless of value of `force`, file should be deleted by now.

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -148,7 +148,7 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
 
       // we copied all the files, enable file deletions
       if (disabled_file_deletions) {
-        Status ss = db_->EnableFileDeletions(false);
+        Status ss = db_->EnableFileDeletions(/*force=*/false);
         assert(ss.ok());
         ss.PermitUncheckedError();
       }
@@ -337,7 +337,7 @@ Status CheckpointImpl::ExportColumnFamily(
                             nullptr, Temperature::kUnknown);
           } /*copy_file_cb*/);
 
-      const auto enable_status = db_->EnableFileDeletions(false /*force*/);
+      const auto enable_status = db_->EnableFileDeletions(/*force=*/false);
       if (s.ok()) {
         s = enable_status;
       }


### PR DESCRIPTION
Disabling file deletion can be critical for operations like making a backup, recovery from manifest IO error (for now). Ideally as long as there is one caller requesting file deletion disabled, it should be kept disabled until all callers agree to re-enable it. So this PR removes the default forcing behavior for the `EnableFileDeletion` API, and users need to explicitly pass the argument if they insisted on doing so knowing the consequence of what can be potentially disrupted.

This PR removes the API's default argument value so it will cause breakage for all users that are relying on the default value, regardless of whether the forcing behavior is critical for them.  When fixing this breakage, it's good to check if the forcing behavior is indeed needed and potential disruption is OK. 

This PR also makes unit test that do not need force behavior to do a regular enable file deletion.