### PR TITLE
Fix/vs2022fix

### DIFF
--- a/env/unique_id_gen.cc
+++ b/env/unique_id_gen.cc
@@ -21,6 +21,7 @@
 #ifdef __SSE4_2__
 #ifdef _WIN32
 #include <intrin.h>
+#define _rdtsc __rdtsc
 #else
 #include <x86intrin.h>
 #endif

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -1117,7 +1117,13 @@ static inline Function Choose_Extend() {
   }
 #elif defined(__SSE4_2__) && defined(__PCLMUL__) && !defined NO_THREEWAY_CRC32C
   // NOTE: runtime detection no longer supported on x86
+  #ifdef _MSC_VER
+  #pragma warning(disable: 4551)
+  #endif
   (void)ExtendImpl<DefaultCRC32>;  // suppress unused warning
+  #ifdef _MSC_VER
+  #pragma warning(default: 4551)
+  #endif
   return crc32c_3way;
 #else
   return ExtendImpl<DefaultCRC32>;


### PR DESCRIPTION
Title: Build errors on Windows + VSC 2022
This is replacement PR for #11794 .
`nv\unique_id_gen.cc: 192` - undefined symbol _rdtsc
As per @pdillinger suggestion - added #define _rdtsc __rdtsc, on top of the file in existing #define WIN32. 

`crc32c.cc:1119` suppressed warning on VS2022 : function call missing argument list.