### PR TITLE
Add APIs to query secondary cache capacity and usage for TieredCache

### DIFF
--- a/cache/compressed_secondary_cache_test.cc
+++ b/cache/compressed_secondary_cache_test.cc
@@ -1276,6 +1276,13 @@ TEST_P(CompressedSecCacheTestWithTiered, DynamicUpdateWithReservation) {
   ASSERT_OK(sec_cache->GetCapacity(sec_capacity));
   ASSERT_EQ(sec_capacity, (30 << 20));
 
+  ASSERT_OK(tiered_cache->GetSecondaryCacheCapacity(sec_capacity));
+  ASSERT_EQ(sec_capacity, 30 << 20);
+  size_t sec_usage;
+  ASSERT_OK(tiered_cache->GetSecondaryCachePinnedUsage(sec_usage));
+  EXPECT_PRED3(CacheUsageWithinBounds, sec_usage, 3 << 20,
+               GetPercent(3 << 20, 1));
+
   ASSERT_OK(UpdateTieredCache(tiered_cache, -1, 0.39));
   EXPECT_PRED3(CacheUsageWithinBounds, GetCache()->GetUsage(), (45 << 20),
                GetPercent(45 << 20, 1));

--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -489,6 +489,22 @@ void CacheWithSecondaryAdapter::SetCapacity(size_t capacity) {
   }
 }
 
+Status CacheWithSecondaryAdapter::GetSecondaryCacheCapacity(
+    size_t& size) const {
+  return secondary_cache_->GetCapacity(size);
+}
+
+Status CacheWithSecondaryAdapter::GetSecondaryCachePinnedUsage(
+    size_t& size) const {
+  MutexLock m(&mutex_);
+  size_t capacity = 0;
+  Status s = secondary_cache_->GetCapacity(capacity);
+  if (s.ok()) {
+    size = capacity - pri_cache_res_->GetTotalMemoryUsed();
+  }
+  return s;
+}
+
 // Update the secondary/primary allocation ratio (remember, the primary
 // capacity is the total memory budget when distribute_cache_res_ is true).
 // When the ratio changes, we may accumulate some error in the calculations

--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -496,11 +496,18 @@ Status CacheWithSecondaryAdapter::GetSecondaryCacheCapacity(
 
 Status CacheWithSecondaryAdapter::GetSecondaryCachePinnedUsage(
     size_t& size) const {
-  MutexLock m(&mutex_);
-  size_t capacity = 0;
-  Status s = secondary_cache_->GetCapacity(capacity);
-  if (s.ok()) {
-    size = capacity - pri_cache_res_->GetTotalMemoryUsed();
+  Status s;
+  if (distribute_cache_res_) {
+    MutexLock m(&mutex_);
+    size_t capacity = 0;
+    s = secondary_cache_->GetCapacity(capacity);
+    if (s.ok()) {
+      size = capacity - pri_cache_res_->GetTotalMemoryUsed();
+    } else {
+      size = 0;
+    }
+  } else {
+    size = 0;
   }
   return s;
 }

--- a/cache/secondary_cache_adapter.h
+++ b/cache/secondary_cache_adapter.h
@@ -47,6 +47,10 @@ class CacheWithSecondaryAdapter : public CacheWrapper {
 
   void SetCapacity(size_t capacity) override;
 
+  Status GetSecondaryCacheCapacity(size_t& size) const override;
+
+  Status GetSecondaryCachePinnedUsage(size_t& size) const override;
+
   Status UpdateCacheReservationRatio(double ratio);
 
   Status UpdateAdmissionPolicy(TieredAdmissionPolicy adm_policy);
@@ -81,7 +85,7 @@ class CacheWithSecondaryAdapter : public CacheWrapper {
   // Fraction of a cache memory reservation to be assigned to the secondary
   // cache
   std::atomic<double> sec_cache_res_ratio_;
-  port::Mutex mutex_;
+  mutable port::Mutex mutex_;
 #ifndef NDEBUG
   bool ratio_changed_ = false;
 #endif

--- a/cache/sharded_cache.cc
+++ b/cache/sharded_cache.cc
@@ -83,6 +83,16 @@ size_t ShardedCacheBase::GetCapacity() const {
   return capacity_;
 }
 
+Status ShardedCacheBase::GetSecondaryCacheCapacity(size_t& size) const {
+  size = 0;
+  return Status::OK();
+}
+
+Status ShardedCacheBase::GetSecondaryCachePinnedUsage(size_t& size) const {
+  size = 0;
+  return Status::OK();
+}
+
 bool ShardedCacheBase::HasStrictCapacityLimit() const {
   MutexLock l(&config_mutex_);
   return strict_capacity_limit_;

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -99,6 +99,8 @@ class ShardedCacheBase : public Cache {
 
   bool HasStrictCapacityLimit() const override;
   size_t GetCapacity() const override;
+  Status GetSecondaryCacheCapacity(size_t& size) const override;
+  Status GetSecondaryCachePinnedUsage(size_t& size) const override;
 
   using Cache::GetUsage;
   size_t GetUsage(Handle* handle) const override;

--- a/include/rocksdb/advanced_cache.h
+++ b/include/rocksdb/advanced_cache.h
@@ -375,6 +375,14 @@ class Cache {
   // Returns the helper for the specified entry.
   virtual const CacheItemHelper* GetCacheItemHelper(Handle* handle) const = 0;
 
+  virtual Status GetSecondaryCacheCapacity(size_t& /*size*/) const {
+    return Status::NotSupported();
+  }
+
+  virtual Status GetSecondaryCachePinnedUsage(size_t& /*size*/) const {
+    return Status::NotSupported();
+  }
+
   // Call this on shutdown if you want to speed it up. Cache will disown
   // any underlying data and will not free it on delete. This call will leak
   // memory - call this only if you're shutting down the process.

--- a/unreleased_history/public_api_changes/tiered_cache_capacity_and_usage.md
+++ b/unreleased_history/public_api_changes/tiered_cache_capacity_and_usage.md
@@ -1,0 +1,1 @@
+Add new Cache APIs GetSecondaryCacheCapacity() and GetSecondaryCachePinnedUsage() to return the configured capacity, and cache reservation charged to the secondary cache.


### PR DESCRIPTION
In `TieredCache`, the underlying compressed secondary cache is hidden from the user. So we need a way to query the capacity, as well as the portion of cache reservation charged to the compressed secondary cache.

Test plan:
Update the unit tests