### PR TITLE
Remove build dependencies for java tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -600,7 +600,6 @@ jobs:
   build-windows-vs2019:
     executor:
       name: win/server-2019
-      version: 2023.08.1
       size: 2xlarge
     environment:
       THIRDPARTY_HOME: C:/Users/circleci/thirdparty

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -557,13 +557,12 @@ else ()
 
 endif()
 
-get_target_property(ROCKSDBJNI_CLASSES_JAR_FILE rocksdbjni_classes JAR_FILE)
 add_jar(
     rocksdbjni_test_classes
     SOURCES
     ${JAVA_MAIN_CLASSES}
     ${JAVA_TEST_CLASSES}
-    INCLUDE_JARS ${ROCKSDBJNI_CLASSES_JAR_FILE} ${JAVA_TESTCLASSPATH}
+    INCLUDE_JARS ${JAVA_TESTCLASSPATH}
     GENERATE_NATIVE_HEADERS rocksdbjni_test_headers DESTINATION ${JNI_OUTPUT_DIR}
 )
 


### PR DESCRIPTION
Final fix for #12013

- Reverting back changes on CirleCI explicit image declaration.
- Removed CMake dependencies between java classed and java test classes. 