### PR TITLE
Quarantine files in a limbo state after a manifest error

### DIFF
--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -215,8 +215,9 @@ class CompactionJobTestBase : public testing::Test {
             dbname_, &db_options_, env_options_, table_cache_.get(),
             &write_buffer_manager_, &write_controller_,
             /*block_cache_tracer=*/nullptr,
-            /*io_tracer=*/nullptr, /*db_id*/ "", /*db_session_id*/ "",
-            /*daily_offpeak_time_utc*/ "")),
+            /*io_tracer=*/nullptr, /*db_id=*/"", /*db_session_id=*/"",
+            /*daily_offpeak_time_utc=*/"",
+            /*error_handler=*/nullptr)),
         shutting_down_(false),
         mock_table_factory_(new mock::MockTableFactory()),
         error_handler_(nullptr, db_options_, &mutex_),
@@ -545,7 +546,8 @@ class CompactionJobTestBase : public testing::Test {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     compaction_job_stats_.Reset();
     ASSERT_OK(SetIdentityFile(env_, dbname_));
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -4415,6 +4415,8 @@ TEST_F(DBBasicTest, ManifestWriteFailure) {
   options.create_if_missing = true;
   options.disable_auto_compactions = true;
   options.env = env_;
+  options.enable_blob_files = true;
+  options.blob_file_size = 0;
   DestroyAndReopen(options);
   ASSERT_OK(Put("foo", "bar"));
   ASSERT_OK(Flush());
@@ -4435,6 +4437,11 @@ TEST_F(DBBasicTest, ManifestWriteFailure) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->EnableProcessing();
   Reopen(options);
+  // The IO error was a mocked one from the `AfterSyncManifest` callback. The
+  // Flush's VersionEdit actually made it into the Manifest. So these keys can
+  // be read back. Read them to check all live sst files and blob files.
+  ASSERT_EQ("bar", Get("foo"));
+  ASSERT_EQ("value", Get("key"));
 }
 
 TEST_F(DBBasicTest, DestroyDefaultCfHandle) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -279,7 +279,8 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
   versions_.reset(new VersionSet(
       dbname_, &immutable_db_options_, file_options_, table_cache_.get(),
       write_buffer_manager_, &write_controller_, &block_cache_tracer_,
-      io_tracer_, db_id_, db_session_id_, options.daily_offpeak_time_utc));
+      io_tracer_, db_id_, db_session_id_, options.daily_offpeak_time_utc,
+      &error_handler_));
   column_family_memtables_.reset(
       new ColumnFamilyMemTablesImpl(versions_->GetColumnFamilySet()));
 
@@ -359,10 +360,8 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
     if (io_s.IsIOError()) {
       // If resuming from IOError resulted from MANIFEST write, then assert
       // that we must have already set the MANIFEST writer to nullptr during
-      // clean-up phase MANIFEST writing. We must have also disabled file
-      // deletions.
+      // clean-up phase MANIFEST writing.
       assert(!versions_->descriptor_log_);
-      assert(!IsFileDeletionsEnabled());
       // Since we are trying to recover from MANIFEST write error, we need to
       // switch to a new MANIFEST anyway. The old MANIFEST can be corrupted.
       // Therefore, force writing a dummy version edit because we do not know

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1190,7 +1190,7 @@ class DBImpl : public DB {
   size_t TEST_GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
   void TEST_WaitForPeriodicTaskRun(std::function<void()> callback) const;
   SeqnoToTimeMapping TEST_GetSeqnoToTimeMapping() const;
-  const std::vector<uint64_t>& TEST_GetFilesToQuarantine() const;
+  const autovector<uint64_t>& TEST_GetFilesToQuarantine() const;
   size_t TEST_EstimateInMemoryStatsHistorySize() const;
 
   uint64_t TEST_GetCurrentLogNumber() const {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1190,6 +1190,7 @@ class DBImpl : public DB {
   size_t TEST_GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
   void TEST_WaitForPeriodicTaskRun(std::function<void()> callback) const;
   SeqnoToTimeMapping TEST_GetSeqnoToTimeMapping() const;
+  const std::vector<uint64_t>& TEST_GetFilesToQuarantine() const;
   size_t TEST_EstimateInMemoryStatsHistorySize() const;
 
   uint64_t TEST_GetCurrentLogNumber() const {
@@ -2379,10 +2380,6 @@ class DBImpl : public DB {
       autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE>* sorted_keys);
 
   Status DisableFileDeletionsWithLock();
-
-  // Safely decrease `disable_delete_obsolete_files_` by one while holding lock
-  // and return its remaning value.
-  int EnableFileDeletionsWithLock();
 
   Status IncreaseFullHistoryTsLowImpl(ColumnFamilyData* cfd,
                                       std::string ts_low);

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -309,6 +309,10 @@ SeqnoToTimeMapping DBImpl::TEST_GetSeqnoToTimeMapping() const {
   return seqno_to_time_mapping_;
 }
 
+const std::vector<uint64_t>& DBImpl::TEST_GetFilesToQuarantine() const {
+  InstrumentedMutexLock l(&mutex_);
+  return error_handler_.GetFilesToQuarantine();
+}
 
 size_t DBImpl::TEST_EstimateInMemoryStatsHistorySize() const {
   InstrumentedMutexLock l(&const_cast<DBImpl*>(this)->stats_history_mutex_);

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -309,7 +309,7 @@ SeqnoToTimeMapping DBImpl::TEST_GetSeqnoToTimeMapping() const {
   return seqno_to_time_mapping_;
 }
 
-const std::vector<uint64_t>& DBImpl::TEST_GetFilesToQuarantine() const {
+const autovector<uint64_t>& DBImpl::TEST_GetFilesToQuarantine() const {
   InstrumentedMutexLock l(&mutex_);
   return error_handler_.GetFilesToQuarantine();
 }

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1541,8 +1541,9 @@ class RecoveryTestHelper {
         test->dbname_, &db_options, file_options, table_cache.get(),
         &write_buffer_manager, &write_controller,
         /*block_cache_tracer=*/nullptr,
-        /*io_tracer=*/nullptr, /*db_id*/ "", /*db_session_id*/ "",
-        options.daily_offpeak_time_utc));
+        /*io_tracer=*/nullptr, /*db_id=*/"", /*db_session_id=*/"",
+        options.daily_offpeak_time_utc,
+        /*error_handler=*/nullptr));
 
     wal_manager.reset(
         new WalManager(db_options, file_options, /*io_tracer=*/nullptr));

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -396,15 +396,6 @@ const Status& ErrorHandler::SetBGError(const Status& bg_status,
   ROCKS_LOG_WARN(db_options_.info_log, "Background IO error %s",
                  bg_io_err.ToString().c_str());
 
-  if (!recovery_disabled_file_deletion_ &&
-      (BackgroundErrorReason::kManifestWrite == reason ||
-       BackgroundErrorReason::kManifestWriteNoWAL == reason)) {
-    // Always returns ok
-    ROCKS_LOG_INFO(db_options_.info_log, "Disabling File Deletions");
-    db_->DisableFileDeletionsWithLock().PermitUncheckedError();
-    recovery_disabled_file_deletion_ = true;
-  }
-
   Status new_bg_io_err = bg_io_err;
   DBRecoverContext context;
   if (bg_io_err.GetScope() != IOStatus::IOErrorScope::kIOErrorScopeFile &&
@@ -505,6 +496,24 @@ const Status& ErrorHandler::SetBGError(const Status& bg_status,
   }
 }
 
+void ErrorHandler::AddFilesToQuarantine(
+    std::vector<const std::vector<uint64_t>*> files_to_quarantine) {
+  db_mutex_->AssertHeld();
+  std::ostringstream quarantine_files_oss;
+  bool is_first_one = true;
+  for (const auto* files : files_to_quarantine) {
+    assert(files);
+    for (uint64_t file_number : *files) {
+      files_to_quarantine_.push_back(file_number);
+      quarantine_files_oss << (is_first_one ? "" : ", ") << file_number;
+      is_first_one = false;
+    }
+  }
+  ROCKS_LOG_INFO(db_options_.info_log,
+                 "ErrorHandler: added file numbers %s to quarantine.\n",
+                 quarantine_files_oss.str().c_str());
+}
+
 Status ErrorHandler::OverrideNoSpaceError(const Status& bg_error,
                                           bool* auto_recovery) {
   if (bg_error.severity() >= Status::Severity::kFatalError) {
@@ -552,6 +561,7 @@ Status ErrorHandler::ClearBGError() {
 
   // Signal that recovery succeeded
   if (recovery_error_.ok()) {
+    assert(files_to_quarantine_.empty());
     Status old_bg_error = bg_error_;
     // old_bg_error is only for notifying listeners, so may not be checked
     old_bg_error.PermitUncheckedError();
@@ -563,18 +573,6 @@ Status ErrorHandler::ClearBGError() {
     recovery_error_.PermitUncheckedError();
     recovery_in_prog_ = false;
     soft_error_no_bg_work_ = false;
-    if (recovery_disabled_file_deletion_) {
-      recovery_disabled_file_deletion_ = false;
-      int remain_counter = db_->EnableFileDeletionsWithLock();
-      if (remain_counter == 0) {
-        ROCKS_LOG_INFO(db_options_.info_log, "File Deletions Enabled");
-      } else {
-        ROCKS_LOG_WARN(
-            db_options_.info_log,
-            "File Deletions Enable, but not really enabled. Counter: %d",
-            remain_counter);
-      }
-    }
     EventHelpers::NotifyOnErrorRecoveryEnd(db_options_.listeners, old_bg_error,
                                            bg_error_, db_mutex_);
   }

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -497,7 +497,7 @@ const Status& ErrorHandler::SetBGError(const Status& bg_status,
 }
 
 void ErrorHandler::AddFilesToQuarantine(
-    std::vector<const std::vector<uint64_t>*> files_to_quarantine) {
+    autovector<const autovector<uint64_t>*> files_to_quarantine) {
   db_mutex_->AssertHeld();
   std::ostringstream quarantine_files_oss;
   bool is_first_one = true;
@@ -512,6 +512,13 @@ void ErrorHandler::AddFilesToQuarantine(
   ROCKS_LOG_INFO(db_options_.info_log,
                  "ErrorHandler: added file numbers %s to quarantine.\n",
                  quarantine_files_oss.str().c_str());
+}
+
+void ErrorHandler::ClearFilesToQuarantine() {
+  db_mutex_->AssertHeld();
+  files_to_quarantine_.clear();
+  ROCKS_LOG_INFO(db_options_.info_log,
+                 "ErrorHandler: cleared files in quarantine.\n");
 }
 
 Status ErrorHandler::OverrideNoSpaceError(const Status& bg_error,

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -11,6 +11,7 @@
 #include "rocksdb/io_status.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/status.h"
+#include "util/autovector.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -83,17 +84,14 @@ class ErrorHandler {
   void EndAutoRecovery();
 
   void AddFilesToQuarantine(
-      std::vector<const std::vector<uint64_t>*> files_to_quarantine);
+      autovector<const autovector<uint64_t>*> files_to_quarantine);
 
-  const std::vector<uint64_t>& GetFilesToQuarantine() const {
+  const autovector<uint64_t>& GetFilesToQuarantine() const {
     db_mutex_->AssertHeld();
     return files_to_quarantine_;
   }
 
-  void ClearFilesToQuarantine() {
-    db_mutex_->AssertHeld();
-    files_to_quarantine_.clear();
-  }
+  void ClearFilesToQuarantine();
 
  private:
   DBImpl* db_;
@@ -128,7 +126,7 @@ class ErrorHandler {
   // from deleting them. Successful recovery will clear this vector. Files are
   // added to this vector while DB mutex was locked, this data structure is
   // unsorted.
-  std::vector<uint64_t> files_to_quarantine_;
+  autovector<uint64_t> files_to_quarantine_;
 
   const Status& HandleKnownErrors(const Status& bg_err,
                                   BackgroundErrorReason reason);

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -4,6 +4,8 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
+#include <sstream>
+
 #include "monitoring/instrumented_mutex.h"
 #include "options/db_options.h"
 #include "rocksdb/io_status.h"
@@ -42,8 +44,7 @@ class ErrorHandler {
         recovery_in_prog_(false),
         soft_error_no_bg_work_(false),
         is_db_stopped_(false),
-        bg_error_stats_(db_options.statistics),
-        recovery_disabled_file_deletion_(false) {
+        bg_error_stats_(db_options.statistics) {
     // Clear the checked flag for uninitialized errors
     bg_error_.PermitUncheckedError();
     recovery_error_.PermitUncheckedError();
@@ -81,6 +82,19 @@ class ErrorHandler {
 
   void EndAutoRecovery();
 
+  void AddFilesToQuarantine(
+      std::vector<const std::vector<uint64_t>*> files_to_quarantine);
+
+  const std::vector<uint64_t>& GetFilesToQuarantine() const {
+    db_mutex_->AssertHeld();
+    return files_to_quarantine_;
+  };
+
+  void ClearFilesToQuarantine() {
+    db_mutex_->AssertHeld();
+    files_to_quarantine_.clear();
+  };
+
  private:
   DBImpl* db_;
   const ImmutableDBOptions& db_options_;
@@ -109,9 +123,12 @@ class ErrorHandler {
   // The pointer of DB statistics.
   std::shared_ptr<Statistics> bg_error_stats_;
 
-  // Tracks whether the recovery has disabled file deletion. This boolean flag
-  // is updated while holding db mutex.
-  bool recovery_disabled_file_deletion_;
+  // During recovery from manifest IO errors, files whose VersionEdits entries
+  // could be in an ambiguous state are quarantined and file deletion refrain
+  // from deleting them. Successful recovery will clear this vector. Files are
+  // added to this vector while DB mutex was locked, this data structure is
+  // unsorted.
+  std::vector<uint64_t> files_to_quarantine_;
 
   const Status& HandleKnownErrors(const Status& bg_err,
                                   BackgroundErrorReason reason);

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -88,12 +88,12 @@ class ErrorHandler {
   const std::vector<uint64_t>& GetFilesToQuarantine() const {
     db_mutex_->AssertHeld();
     return files_to_quarantine_;
-  };
+  }
 
   void ClearFilesToQuarantine() {
     db_mutex_->AssertHeld();
     files_to_quarantine_.clear();
-  };
+  }
 
  private:
   DBImpl* db_;

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -131,7 +131,8 @@ class FlushJobTestBase : public testing::Test {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     EXPECT_OK(versions_->Recover(column_families, false));
   }
 

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -170,6 +170,16 @@ struct JobContext {
   // will be reused later
   std::vector<uint64_t> log_recycle_files;
 
+  // Files quarantined from deletion. This list contains file numbers for files
+  // that are in an ambiguous states. This includes newly generated SST files
+  // and blob files from flush and compaction job whose VersionEdits' persist
+  // state in Manifest are unclear. An old manifest file whose immediately
+  // following new manifest file's CURRENT file creation is in an unclear state.
+  // WAL logs don't have this premature deletion risk since
+  // min_log_number_to_keep is only updated after successful manifest commits.
+  // So this data structure doesn't track log files.
+  std::vector<uint64_t> files_to_quarantine;
+
   // a list of manifest files that we need to delete
   std::vector<std::string> manifest_delete_files;
 

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -15,6 +15,7 @@
 #include "db/column_family.h"
 #include "db/log_writer.h"
 #include "db/version_set.h"
+#include "util/autovector.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -178,7 +179,7 @@ struct JobContext {
   // WAL logs don't have this premature deletion risk since
   // min_log_number_to_keep is only updated after successful manifest commits.
   // So this data structure doesn't track log files.
-  std::vector<uint64_t> files_to_quarantine;
+  autovector<uint64_t> files_to_quarantine;
 
   // a list of manifest files that we need to delete
   std::vector<std::string> manifest_delete_files;

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -106,8 +106,9 @@ class MemTableListTest : public testing::Test {
     VersionSet versions(dbname, &immutable_db_options, env_options,
                         table_cache.get(), &write_buffer_manager,
                         &write_controller, /*block_cache_tracer=*/nullptr,
-                        /*io_tracer=*/nullptr, /*db_id*/ "",
-                        /*db_session_id*/ "", /*daily_offpeak_time_utc*/ "");
+                        /*io_tracer=*/nullptr, /*db_id=*/"",
+                        /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+                        /*error_handler=*/nullptr);
     std::vector<ColumnFamilyDescriptor> cf_descs;
     cf_descs.emplace_back(kDefaultColumnFamilyName, ColumnFamilyOptions());
     cf_descs.emplace_back("one", ColumnFamilyOptions());
@@ -157,8 +158,9 @@ class MemTableListTest : public testing::Test {
     VersionSet versions(dbname, &immutable_db_options, env_options,
                         table_cache.get(), &write_buffer_manager,
                         &write_controller, /*block_cache_tracer=*/nullptr,
-                        /*io_tracer=*/nullptr, /*db_id*/ "",
-                        /*db_session_id*/ "", /*daily_offpeak_time_utc*/ "");
+                        /*io_tracer=*/nullptr, /*db_id=*/"",
+                        /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+                        /*error_handler=*/nullptr);
     std::vector<ColumnFamilyDescriptor> cf_descs;
     cf_descs.emplace_back(kDefaultColumnFamilyName, ColumnFamilyOptions());
     cf_descs.emplace_back("one", ColumnFamilyOptions());

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -122,7 +122,8 @@ class Repairer {
         vset_(dbname_, &immutable_db_options_, file_options_,
               raw_table_cache_.get(), &wb_, &wc_,
               /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-              /*db_id=*/"", db_session_id_, db_options.daily_offpeak_time_utc),
+              /*db_id=*/"", db_session_id_, db_options.daily_offpeak_time_utc,
+              /*error_handler=*/nullptr),
         next_file_number_(1),
         db_lock_(nullptr),
         closed_(false) {

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -689,7 +689,7 @@ class VersionEdit {
                 std::optional<size_t> ts_sz = std::nullopt) const;
   Status DecodeFrom(const Slice& src);
 
-  const std::vector<uint64_t>* GetFilesToQuarantineIfCommitFail() const {
+  const autovector<uint64_t>* GetFilesToQuarantineIfCommitFail() const {
     return &files_to_quarantine_;
   }
 
@@ -763,7 +763,7 @@ class VersionEdit {
   // in Manifest as live files.
   // Since table files and blob files share the same file number space, we just
   // record the file number here.
-  std::vector<uint64_t> files_to_quarantine_;
+  autovector<uint64_t> files_to_quarantine_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -543,7 +543,8 @@ class VersionEdit {
 
   void AddBlobFile(BlobFileAddition blob_file_addition) {
     blob_file_additions_.emplace_back(std::move(blob_file_addition));
-    files_to_quarantine_.push_back(blob_file_addition.GetBlobFileNumber());
+    files_to_quarantine_.push_back(
+        blob_file_additions_.back().GetBlobFileNumber());
   }
 
   // Retrieve all the blob files added.

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -492,6 +492,7 @@ class VersionEdit {
                      file_checksum_func_name, unique_id,
                      compensated_range_deletion_size, tail_size,
                      user_defined_timestamps_persisted));
+    files_to_quarantine_.push_back(file);
     if (!HasLastSequence() || largest_seqno > GetLastSequence()) {
       SetLastSequence(largest_seqno);
     }
@@ -500,6 +501,7 @@ class VersionEdit {
   void AddFile(int level, const FileMetaData& f) {
     assert(f.fd.smallest_seqno <= f.fd.largest_seqno);
     new_files_.emplace_back(level, f);
+    files_to_quarantine_.push_back(f.fd.GetNumber());
     if (!HasLastSequence() || f.fd.largest_seqno > GetLastSequence()) {
       SetLastSequence(f.fd.largest_seqno);
     }
@@ -536,10 +538,12 @@ class VersionEdit {
     blob_file_additions_.emplace_back(
         blob_file_number, total_blob_count, total_blob_bytes,
         std::move(checksum_method), std::move(checksum_value));
+    files_to_quarantine_.push_back(blob_file_number);
   }
 
   void AddBlobFile(BlobFileAddition blob_file_addition) {
     blob_file_additions_.emplace_back(std::move(blob_file_addition));
+    files_to_quarantine_.push_back(blob_file_addition.GetBlobFileNumber());
   }
 
   // Retrieve all the blob files added.
@@ -551,6 +555,11 @@ class VersionEdit {
   void SetBlobFileAdditions(BlobFileAdditions blob_file_additions) {
     assert(blob_file_additions_.empty());
     blob_file_additions_ = std::move(blob_file_additions);
+    std::for_each(
+        blob_file_additions_.begin(), blob_file_additions_.end(),
+        [&](const BlobFileAddition& blob_file) {
+          files_to_quarantine_.push_back(blob_file.GetBlobFileNumber());
+        });
   }
 
   // Add garbage for an existing blob file.  Note: intentionally broken English
@@ -679,6 +688,10 @@ class VersionEdit {
                 std::optional<size_t> ts_sz = std::nullopt) const;
   Status DecodeFrom(const Slice& src);
 
+  const std::vector<uint64_t>* GetFilesToQuarantineIfCommitFail() const {
+    return &files_to_quarantine_;
+  }
+
   std::string DebugString(bool hex_key = false) const;
   std::string DebugJSON(int edit_num, bool hex_key = false) const;
 
@@ -740,6 +753,16 @@ class VersionEdit {
 
   std::string full_history_ts_low_;
   bool persist_user_defined_timestamps_ = true;
+
+  // Newly created table files and blob files are eligible for deletion if they
+  // are not registered as live files after the background jobs creating them
+  // have finished. In case committing the VersionEdit containing such changes
+  // to manifest encountered an error, we want to quarantine these files from
+  // deletion to avoid prematurely deleting files that ended up getting recorded
+  // in Manifest as live files.
+  // Since table files and blob files share the same file number space, we just
+  // record the file number here.
+  std::vector<uint64_t> files_to_quarantine_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5061,7 +5061,8 @@ VersionSet::VersionSet(
     WriteBufferManager* write_buffer_manager, WriteController* write_controller,
     BlockCacheTracer* const block_cache_tracer,
     const std::shared_ptr<IOTracer>& io_tracer, const std::string& db_id,
-    const std::string& db_session_id, const std::string& daily_offpeak_time_utc)
+    const std::string& db_session_id, const std::string& daily_offpeak_time_utc,
+    ErrorHandler* const error_handler)
     : column_family_set_(new ColumnFamilySet(
           dbname, _db_options, storage_options, table_cache,
           write_buffer_manager, write_controller, block_cache_tracer, io_tracer,
@@ -5087,7 +5088,8 @@ VersionSet::VersionSet(
       block_cache_tracer_(block_cache_tracer),
       io_tracer_(io_tracer),
       db_session_id_(db_session_id),
-      offpeak_time_option_(OffpeakTimeOption(daily_offpeak_time_utc)) {}
+      offpeak_time_option_(OffpeakTimeOption(daily_offpeak_time_utc)),
+      error_handler_(error_handler) {}
 
 VersionSet::~VersionSet() {
   // we need to delete column_family_set_ because its destructor depends on
@@ -5186,6 +5188,8 @@ Status VersionSet::ProcessManifestWrites(
   autovector<Version*> versions;
   autovector<const MutableCFOptions*> mutable_cf_options_ptrs;
   std::vector<std::unique_ptr<BaseReferencedVersionBuilder>> builder_guards;
+  std::vector<const std::vector<uint64_t>*> files_to_quarantine_if_commit_fail;
+  std::vector<uint64_t> limbo_descriptor_log_file_number;
 
   // Tracking `max_last_sequence` is needed to ensure we write
   // `VersionEdit::last_sequence_`s in non-decreasing order according to the
@@ -5469,6 +5473,8 @@ Status VersionSet::ProcessManifestWrites(
       assert(batch_edits.size() == batch_edits_ts_sz.size());
       for (size_t bidx = 0; bidx < batch_edits.size(); bidx++) {
         auto& e = batch_edits[bidx];
+        files_to_quarantine_if_commit_fail.push_back(
+            e->GetFilesToQuarantineIfCommitFail());
         std::string record;
         if (!e->EncodeTo(&record, batch_edits_ts_sz[bidx])) {
           s = Status::Corruption("Unable to encode VersionEdit:" +
@@ -5518,6 +5524,14 @@ Status VersionSet::ProcessManifestWrites(
                             dir_contains_current_file);
       if (!io_s.ok()) {
         s = io_s;
+        // TODO: when CURRENT file rename fails, should the in memory state
+        // continue to be updated to use the new descriptor, should we do:
+        // manifest_io_status = io_s;
+        // Quarantine old manifest file in case new manifest file's CURRENT file
+        // wasn't created successfully and the old manifest is needed.
+        limbo_descriptor_log_file_number.push_back(manifest_file_number_);
+        files_to_quarantine_if_commit_fail.push_back(
+            &limbo_descriptor_log_file_number);
       }
     }
 
@@ -5554,9 +5568,16 @@ Status VersionSet::ProcessManifestWrites(
   if (!io_s.ok()) {
     if (io_status_.ok()) {
       io_status_ = io_s;
+      if (error_handler_) {
+        error_handler_->AddFilesToQuarantine(
+            files_to_quarantine_if_commit_fail);
+      }
     }
   } else if (!io_status_.ok()) {
     io_status_ = io_s;
+    if (error_handler_) {
+      error_handler_->ClearFilesToQuarantine();
+    }
   }
 
   // Append the old manifest file to the obsolete_manifest_ list to be deleted
@@ -6214,7 +6235,8 @@ Status VersionSet::ReduceNumberOfLevels(const std::string& dbname,
   VersionSet versions(dbname, &db_options, file_options, tc.get(), &wb, &wc,
                       nullptr /*BlockCacheTracer*/, nullptr /*IOTracer*/,
                       /*db_id*/ "",
-                      /*db_session_id*/ "", options->daily_offpeak_time_utc);
+                      /*db_session_id*/ "", options->daily_offpeak_time_utc,
+                      /*error_handler_*/ nullptr);
   Status status;
 
   std::vector<ColumnFamilyDescriptor> dummy;
@@ -7255,8 +7277,8 @@ ReactiveVersionSet::ReactiveVersionSet(
     : VersionSet(dbname, _db_options, _file_options, table_cache,
                  write_buffer_manager, write_controller,
                  /*block_cache_tracer=*/nullptr, io_tracer, /*db_id*/ "",
-                 /*db_session_id*/ "",
-                 /*daily_offpeak_time_utc*/ "") {}
+                 /*db_session_id*/ "", /*daily_offpeak_time_utc*/ "",
+                 /*error_handler=*/nullptr) {}
 
 ReactiveVersionSet::~ReactiveVersionSet() {}
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5188,8 +5188,8 @@ Status VersionSet::ProcessManifestWrites(
   autovector<Version*> versions;
   autovector<const MutableCFOptions*> mutable_cf_options_ptrs;
   std::vector<std::unique_ptr<BaseReferencedVersionBuilder>> builder_guards;
-  std::vector<const std::vector<uint64_t>*> files_to_quarantine_if_commit_fail;
-  std::vector<uint64_t> limbo_descriptor_log_file_number;
+  autovector<const autovector<uint64_t>*> files_to_quarantine_if_commit_fail;
+  autovector<uint64_t> limbo_descriptor_log_file_number;
 
   // Tracking `max_last_sequence` is needed to ensure we write
   // `VersionEdit::last_sequence_`s in non-decreasing order according to the
@@ -5524,9 +5524,6 @@ Status VersionSet::ProcessManifestWrites(
                             dir_contains_current_file);
       if (!io_s.ok()) {
         s = io_s;
-        // TODO: when CURRENT file rename fails, should the in memory state
-        // continue to be updated to use the new descriptor, should we do:
-        // manifest_io_status = io_s;
         // Quarantine old manifest file in case new manifest file's CURRENT file
         // wasn't created successfully and the old manifest is needed.
         limbo_descriptor_log_file_number.push_back(manifest_file_number_);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -38,6 +38,7 @@
 #include "db/compaction/compaction.h"
 #include "db/compaction/compaction_picker.h"
 #include "db/dbformat.h"
+#include "db/error_handler.h"
 #include "db/file_indexer.h"
 #include "db/log_reader.h"
 #include "db/range_del_aggregator.h"
@@ -1152,7 +1153,8 @@ class VersionSet {
              BlockCacheTracer* const block_cache_tracer,
              const std::shared_ptr<IOTracer>& io_tracer,
              const std::string& db_id, const std::string& db_session_id,
-             const std::string& daily_offpeak_time_utc);
+             const std::string& daily_offpeak_time_utc,
+             ErrorHandler* const error_handler);
   // No copying allowed
   VersionSet(const VersionSet&) = delete;
   void operator=(const VersionSet&) = delete;
@@ -1667,6 +1669,9 @@ class VersionSet {
 
   // Off-peak time option used for compaction scoring
   OffpeakTimeOption offpeak_time_option_;
+
+  // Pointer to the DB's ErrorHandler.
+  ErrorHandler* const error_handler_;
 
  private:
   // REQUIRES db mutex at beginning. may release and re-acquire db mutex

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -1205,7 +1205,8 @@ class VersionSetTestBase {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     reactive_versions_ = std::make_shared<ReactiveVersionSet>(
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_, nullptr);
@@ -1309,7 +1310,8 @@ class VersionSetTestBase {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     EXPECT_OK(versions_->Recover(column_families_, false));
   }
 
@@ -1821,7 +1823,8 @@ TEST_F(VersionSetTest, WalAddition) {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     ASSERT_OK(new_versions->Recover(column_families_, /*read_only=*/false));
     const auto& wals = new_versions->GetWalSet().GetWals();
     ASSERT_EQ(wals.size(), 1);
@@ -1888,7 +1891,8 @@ TEST_F(VersionSetTest, WalCloseWithoutSync) {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     ASSERT_OK(new_versions->Recover(column_families_, false));
     const auto& wals = new_versions->GetWalSet().GetWals();
     ASSERT_EQ(wals.size(), 2);
@@ -1941,7 +1945,8 @@ TEST_F(VersionSetTest, WalDeletion) {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     ASSERT_OK(new_versions->Recover(column_families_, false));
     const auto& wals = new_versions->GetWalSet().GetWals();
     ASSERT_EQ(wals.size(), 1);
@@ -1979,7 +1984,8 @@ TEST_F(VersionSetTest, WalDeletion) {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     ASSERT_OK(new_versions->Recover(column_families_, false));
     const auto& wals = new_versions->GetWalSet().GetWals();
     ASSERT_EQ(wals.size(), 1);
@@ -2099,7 +2105,8 @@ TEST_F(VersionSetTest, DeleteWalsBeforeNonExistingWalNumber) {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     ASSERT_OK(new_versions->Recover(column_families_, false));
     const auto& wals = new_versions->GetWalSet().GetWals();
     ASSERT_EQ(wals.size(), 1);
@@ -2135,7 +2142,8 @@ TEST_F(VersionSetTest, DeleteAllWals) {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     ASSERT_OK(new_versions->Recover(column_families_, false));
     const auto& wals = new_versions->GetWalSet().GetWals();
     ASSERT_EQ(wals.size(), 0);
@@ -2177,7 +2185,8 @@ TEST_F(VersionSetTest, AtomicGroupWithWalEdits) {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     std::string db_id;
     ASSERT_OK(
         new_versions->Recover(column_families_, /*read_only=*/false, &db_id));
@@ -2335,7 +2344,8 @@ class VersionSetWithTimestampTest : public VersionSetTest {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
     ASSERT_OK(vset->Recover(column_families_, /*read_only=*/false,
                             /*db_id=*/nullptr));
     for (auto* cfd : *(vset->GetColumnFamilySet())) {

--- a/db/version_util.h
+++ b/db/version_util.h
@@ -25,8 +25,9 @@ class OfflineManifestWriter {
                         options.table_cache_numshardbits)),
         versions_(db_path, &immutable_db_options_, sopt_, tc_.get(), &wb_, &wc_,
                   /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-                  /*db_id*/ "", /*db_session_id*/ "",
-                  options.daily_offpeak_time_utc) {}
+                  /*db_id=*/"", /*db_session_id=*/"",
+                  options.daily_offpeak_time_utc,
+                  /*error_handler=*/nullptr) {}
 
   Status Recover(const std::vector<ColumnFamilyDescriptor>& column_families) {
     return versions_.Recover(column_families, /*read_only*/ false,

--- a/db/wal_manager_test.cc
+++ b/db/wal_manager_test.cc
@@ -54,7 +54,8 @@ class WalManagerTest : public testing::Test {
         dbname_, &db_options_, env_options_, table_cache_.get(),
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-        /*db_id*/ "", /*db_session_id*/ "", /*daily_offpeak_time_utc*/ ""));
+        /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
+        /*error_handler=*/nullptr));
 
     wal_manager_.reset(
         new WalManager(db_options_, env_options_, nullptr /*IOTracer*/));

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1364,8 +1364,9 @@ void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
   ImmutableDBOptions immutable_db_options(options);
   VersionSet versions(dbname, &immutable_db_options, sopt, tc.get(), &wb, &wc,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-                      /*db_id*/ "", /*db_session_id*/ "",
-                      options.daily_offpeak_time_utc);
+                      /*db_id=*/"", /*db_session_id=*/"",
+                      options.daily_offpeak_time_utc,
+                      /*error_handler=*/nullptr);
   Status s = versions.DumpManifest(options, file, verbose, hex, json, cf_descs);
   if (!s.ok()) {
     fprintf(stderr, "Error in processing file %s %s\n", file.c_str(),
@@ -1508,8 +1509,9 @@ Status GetLiveFilesChecksumInfoFromVersionSet(Options options,
   ImmutableDBOptions immutable_db_options(options);
   VersionSet versions(dbname, &immutable_db_options, sopt, tc.get(), &wb, &wc,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-                      /*db_id*/ "", /*db_session_id*/ "",
-                      options.daily_offpeak_time_utc);
+                      /*db_id=*/"", /*db_session_id=*/"",
+                      options.daily_offpeak_time_utc,
+                      /*error_handler=*/nullptr);
   std::vector<std::string> cf_name_list;
   s = versions.ListColumnFamilies(&cf_name_list, db_path,
                                   immutable_db_options.fs.get());
@@ -2330,8 +2332,9 @@ Status ReduceDBLevelsCommand::GetOldNumOfLevels(Options& opt, int* levels) {
   WriteBufferManager wb(opt.db_write_buffer_size);
   VersionSet versions(db_path_, &db_options, soptions, tc.get(), &wb, &wc,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
-                      /*db_id*/ "", /*db_session_id*/ "",
-                      opt.daily_offpeak_time_utc);
+                      /*db_id=*/"", /*db_session_id=*/"",
+                      opt.daily_offpeak_time_utc,
+                      /*error_handler=*/nullptr);
   std::vector<ColumnFamilyDescriptor> dummy;
   ColumnFamilyDescriptor dummy_descriptor(kDefaultColumnFamilyName,
                                           ColumnFamilyOptions(opt));

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -208,7 +208,7 @@ class FileChecksumTestHelper {
     ImmutableDBOptions immutable_db_options(options_);
     VersionSet versions(dbname_, &immutable_db_options, sopt, tc.get(), &wb,
                         &wc, nullptr, nullptr, "", "",
-                        options_.daily_offpeak_time_utc);
+                        options_.daily_offpeak_time_utc, nullptr);
     std::vector<std::string> cf_name_list;
     Status s;
     s = versions.ListColumnFamilies(&cf_name_list, dbname_,


### PR DESCRIPTION
Part of the procedures to handle manifest IO error is to disable file deletion in case some files in limbo state get deleted prematurely. This is not ideal because: 1) not all the VersionEdits whose commit encounter such an error contain updates for files, disabling file deletion sometimes are not necessary. 2) `EnableFileDeletion` has a force mode that could make other threads accidentally disrupt this procedure in recovery.  3) Disabling file deletion as a whole is also not as efficient as more precisely tracking impacted files from being prematurely deleted.  This PR replaces this mechanism with tracking such files and quarantine them from being deleted in `ErrorHandler`.

These are the types of files being actively tracked in quarantine in this PR:
1) new table files and blob files from a background job
2) old manifest file whose immediately following new manifest file's CURRENT file creation gets into unclear state. Current handling is not sufficient to make sure the old manifest file is kept in case it's needed.

Note that WAL logs are not part of the quarantine because `min_log_number_to_keep` is a safe mechanism and it's only updated after successful manifest commits so it can prevent this premature deletion issue from happening. 

We track these files' file numbers because they share the same file number space.

Test plan:
Modified existing unit tests