### PR TITLE
Initialize comparator explicitly in PrepareOptionsForRestoredDB()

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1945,8 +1945,12 @@ Status StressTest::PrepareOptionsForRestoredDB(Options* options) {
   options->listeners.clear();
   // Avoid dangling/shared file descriptors, for reliable destroy
   options->sst_file_manager = nullptr;
-  // GetColumnFamilyOptionsFromString does not create customized merge operator
+  // GetColumnFamilyOptionsFromString does not create customized merge operator,
+  // and comparator.
   InitializeMergeOperator(*options);
+  if (FLAGS_user_timestamp_size > 0) {
+    CheckAndSetOptionsForUserTimestamp(*options);
+  }
 
   return Status::OK();
 }


### PR DESCRIPTION
This is to fix below error seeing in stress test:
```
Failure in DB::Open in backup/restore with: Invalid argument: Cannot open a column family and disable user-defined timestamps feature if its existing persist_user_defined_timestamps flag is not false.
```