### PR TITLE
Remove auto set bytes_per_sync to 0

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1284,10 +1284,6 @@ Status DBImpl::SetDBOptions(
     s = GetMutableDBOptionsFromStrings(mutable_db_options_, options_map,
                                        &new_options);
 
-    if (new_options.bytes_per_sync == 0) {
-      new_options.bytes_per_sync = 1024 * 1024;
-    }
-
     if (MutableDBOptionsAreEqual(mutable_db_options_, new_options)) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "SetDBOptions(), input option value is not changed, "


### PR DESCRIPTION
The document says `bytes_per_sync = 0` means turn off this feature, but `DBImpl::SetDBOptions` auto set bytes_per_sync to 1M if it is 0.
