### PR TITLE
Save the correct user comparator name in OPTIONS file

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1948,7 +1948,11 @@ Status StressTest::PrepareOptionsForRestoredDB(Options* options) {
   // GetColumnFamilyOptionsFromString does not create customized merge operator.
   InitializeMergeOperator(*options);
   if (FLAGS_user_timestamp_size > 0) {
-    CheckAndSetOptionsForUserTimestamp(*options, /*from_restore=*/true);
+    // Check OPTIONS string loading can bootstrap the correct user comparator
+    // from object registry.
+    assert(options->comparator);
+    assert(options->comparator == test::BytewiseComparatorWithU64TsWrapper());
+    CheckAndSetOptionsForUserTimestamp(*options);
   }
 
   return Status::OK();
@@ -3146,7 +3150,7 @@ void StressTest::MaybeUseOlderTimestampForRangeScan(ThreadState* thread,
   read_opts.timestamp = saved_ts;
 }
 
-void CheckAndSetOptionsForUserTimestamp(Options& options, bool from_restore) {
+void CheckAndSetOptionsForUserTimestamp(Options& options) {
   assert(FLAGS_user_timestamp_size > 0);
   const Comparator* const cmp = test::BytewiseComparatorWithU64TsWrapper();
   assert(cmp);
@@ -3169,12 +3173,6 @@ void CheckAndSetOptionsForUserTimestamp(Options& options, bool from_restore) {
   if (FLAGS_ingest_external_file_one_in > 0) {
     fprintf(stderr, "Bulk loading may not support timestamp yet.\n");
     exit(1);
-  }
-  if (from_restore) {
-    // Check OPTIONS string loading for the restore flow can bootstrap the
-    // correct user comparator from object registry.
-    assert(options.comparator);
-    assert(options.comparator == cmp);
   }
   options.comparator = cmp;
 }
@@ -3454,7 +3452,7 @@ void InitializeOptionsFromFlags(
   options.fail_if_options_file_error = FLAGS_fail_if_options_file_error;
 
   if (FLAGS_user_timestamp_size > 0) {
-    CheckAndSetOptionsForUserTimestamp(options, /*from_restore=*/false);
+    CheckAndSetOptionsForUserTimestamp(options);
   }
 
   options.allow_data_in_errors = FLAGS_allow_data_in_errors;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1952,7 +1952,6 @@ Status StressTest::PrepareOptionsForRestoredDB(Options* options) {
     // from object registry.
     assert(options->comparator);
     assert(options->comparator == test::BytewiseComparatorWithU64TsWrapper());
-    CheckAndSetOptionsForUserTimestamp(*options);
   }
 
   return Status::OK();

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -330,7 +330,8 @@ extern void InitializeOptionsGeneral(
 // user-defined timestamp which requires `-user_timestamp_size=8`.
 // This function also checks for known (currently) incompatible features with
 // user-defined timestamp.
-extern void CheckAndSetOptionsForUserTimestamp(Options& options);
+extern void CheckAndSetOptionsForUserTimestamp(Options& options,
+                                               bool from_restore);
 
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -330,8 +330,7 @@ extern void InitializeOptionsGeneral(
 // user-defined timestamp which requires `-user_timestamp_size=8`.
 // This function also checks for known (currently) incompatible features with
 // user-defined timestamp.
-extern void CheckAndSetOptionsForUserTimestamp(Options& options,
-                                               bool from_restore);
+extern void CheckAndSetOptionsForUserTimestamp(Options& options);
 
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -658,19 +658,12 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    // it's a const pointer of const Comparator*
                    const auto* ptr =
                        static_cast<const Comparator* const*>(addr);
-                   // Since the user-specified comparator will be wrapped by
-                   // InternalKeyComparator, we should persist the
-                   // user-specified one instead of InternalKeyComparator.
                    if (*ptr == nullptr) {
                      *value = kNullptrString;
                    } else if (opts.mutable_options_only) {
                      *value = "";
                    } else {
-                     const Comparator* root_comp = (*ptr)->GetRootComparator();
-                     if (root_comp == nullptr) {
-                       root_comp = (*ptr);
-                     }
-                     *value = root_comp->ToString(opts);
+                     *value = (*ptr)->ToString(opts);
                    }
                    return Status::OK();
                  })},

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -1588,6 +1588,7 @@ TEST_F(OptionsTest, GetMutableCFOptions) {
 TEST_F(OptionsTest, ColumnFamilyOptionsSerialization) {
   Options options;
   ColumnFamilyOptions base_opt, new_opt;
+  base_opt.comparator = test::BytewiseComparatorWithU64TsWrapper();
   Random rnd(302);
   ConfigOptions config_options;
   config_options.input_strings_escaped = false;
@@ -1608,6 +1609,7 @@ TEST_F(OptionsTest, ColumnFamilyOptionsSerialization) {
                                        base_options_file_content, &new_opt));
   ASSERT_OK(
       RocksDBOptionsParser::VerifyCFOptions(config_options, base_opt, new_opt));
+  ASSERT_EQ(base_opt.comparator, new_opt.comparator);
   if (base_opt.compaction_filter) {
     delete base_opt.compaction_filter;
   }


### PR DESCRIPTION
I noticed the user comparator name in OPTIONS file can be incorrect when working on a recent stress test failure. The name of the comparator retrieved via the "Comparator::GetRootComparator" API is saved in OPTIONS file as the user comparator. The intention was to get the user comparator wrapped in the internal comparator. However `ImmutableCFOptions.user_comparator` has always been a user comparator of type `Comparator`. The corresponding `GetRootComparator` API is also defined only for user comparator type `Comparator`, not the internal key comparator type `InternalKeyComparator`.

For built in comparator `BytewiseComparator` and `ReverseBytewiseComparator`, there is no difference between `Comparator::Name` and `Comparator::GetRootComparator::Name` because these built in comparators' root comparator is themselves. However, for built in comparator `BytewiseComparatorWithU64Ts` and `ReverseBytewiseComparatorWithU64Ts`, there are differences. So this change update the logic to persist the user comparator's name, not its root comparator's name.

Test plan:
The restore flow in stress test, which relies on converting Options object to string and back to Options object is updated to help validate comparator object can be correctly serialized and deserialized with the OPTIONS file mechanism

Updated unit test to use a comparator that has a root comparator that is not itself.