### PR TITLE
Fix stress test error message for black/whitebox test to catch failures

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1485,11 +1485,11 @@ void StressTest::VerifyIterator(ThreadState* thread,
   }
 
   if (op == kLastOpSeekToFirst && ro.iterate_lower_bound != nullptr) {
-    // SeekToFirst() with lower bound is not well defined.
+    // SeekToFirst() with lower bound is not well-defined.
     *diverged = true;
     return;
   } else if (op == kLastOpSeekToLast && ro.iterate_upper_bound != nullptr) {
-    // SeekToLast() with higher bound is not well defined.
+    // SeekToLast() with higher bound is not well-defined.
     *diverged = true;
     return;
   } else if (op == kLastOpSeek && ro.iterate_lower_bound != nullptr &&
@@ -1500,7 +1500,7 @@ void StressTest::VerifyIterator(ThreadState* thread,
                options_.comparator->CompareWithoutTimestamp(
                    *ro.iterate_lower_bound, /*a_has_ts=*/false,
                    *ro.iterate_upper_bound, /*b_has_ts*/ false) >= 0))) {
-    // Lower bound behavior is not well defined if it is larger than
+    // Lower bound behavior is not well-defined if it is larger than
     // seek key or upper bound. Disable the check for now.
     *diverged = true;
     return;
@@ -1512,7 +1512,7 @@ void StressTest::VerifyIterator(ThreadState* thread,
                options_.comparator->CompareWithoutTimestamp(
                    *ro.iterate_lower_bound, /*a_has_ts=*/false,
                    *ro.iterate_upper_bound, /*b_has_ts=*/false) >= 0))) {
-    // Uppder bound behavior is not well defined if it is smaller than
+    // Upper bound behavior is not well-defined if it is smaller than
     // seek key or lower bound. Disable the check for now.
     *diverged = true;
     return;
@@ -1540,13 +1540,13 @@ void StressTest::VerifyIterator(ThreadState* thread,
       }
     }
     fprintf(stderr,
-            "Control interator is invalid but iterator has key %s "
+            "Control iterator is invalid but iterator has key %s "
             "%s\n",
             iter->key().ToString(true).c_str(), op_logs.c_str());
 
     *diverged = true;
   } else if (cmp_iter->Valid()) {
-    // Iterator is not valid. It can be legimate if it has already been
+    // Iterator is not valid. It can be legitimate if it has already been
     // out of upper or lower bound, or filtered out by prefix iterator.
     const Slice& total_order_key = cmp_iter->key();
 
@@ -1569,7 +1569,7 @@ void StressTest::VerifyIterator(ThreadState* thread,
           return;
         }
         fprintf(stderr,
-                "Iterator stays in prefix but contol doesn't"
+                "Iterator stays in prefix but control doesn't"
                 " iterator key %s control iterator key %s %s\n",
                 iter->key().ToString(true).c_str(),
                 cmp_iter->key().ToString(true).c_str(), op_logs.c_str());
@@ -1616,7 +1616,8 @@ void StressTest::VerifyIterator(ThreadState* thread,
   }
 
   if (*diverged) {
-    fprintf(stderr, "Control CF %s\n", cmp_cfh->GetName().c_str());
+    fprintf(stderr, "VerifyIterator failed. Control CF %s\n",
+            cmp_cfh->GetName().c_str());
     thread->stats.AddErrors(1);
     // Fail fast to preserve the DB state.
     thread->shared->SetVerificationFailure();

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -612,7 +612,7 @@ class NonBatchedOpsStressTest : public StressTest {
       }
       Status s = NewTxn(wo, &txn);
       if (!s.ok()) {
-        fprintf(stderr, "NewTxn: %s\n", s.ToString().c_str());
+        fprintf(stderr, "NewTxn error: %s\n", s.ToString().c_str());
         thread->shared->SafeTerminate();
       }
     }
@@ -662,7 +662,8 @@ class NonBatchedOpsStressTest : public StressTest {
               assert(false);
           }
           if (!s.ok()) {
-            fprintf(stderr, "Transaction put: %s\n", s.ToString().c_str());
+            fprintf(stderr, "Transaction put error: %s\n",
+                    s.ToString().c_str());
             thread->shared->SafeTerminate();
           }
         } else {
@@ -1696,11 +1697,14 @@ class NonBatchedOpsStressTest : public StressTest {
           thread->shared->SetVerificationFailure();
           if (iter->Valid()) {
             fprintf(stderr,
-                    "Expected state has key %s, iterator is at key %s\n",
+                    "Verification failed. Expected state has key %s, iterator "
+                    "is at key %s\n",
                     Slice(Key(j)).ToString(true).c_str(),
                     iter->key().ToString(true).c_str());
           } else {
-            fprintf(stderr, "Expected state has key %s, iterator is invalid\n",
+            fprintf(stderr,
+                    "Verification failed. Expected state has key %s, iterator "
+                    "is invalid\n",
                     Slice(Key(j)).ToString(true).c_str());
           }
           fprintf(stderr, "Column family: %s, op_logs: %s\n",
@@ -1750,7 +1754,8 @@ class NonBatchedOpsStressTest : public StressTest {
       if (static_cast<int64_t>(curr) <= last_key) {
         thread->shared->SetVerificationFailure();
         fprintf(stderr,
-                "TestIterateAgainstExpected found unexpectedly small key\n");
+                "TestIterateAgainstExpected failed: found unexpectedly small "
+                "key\n");
         fprintf(stderr, "Column family: %s, op_logs: %s\n",
                 cfh->GetName().c_str(), op_logs.c_str());
         fprintf(stderr, "Last op found key: %s, expected at least: %s\n",
@@ -1807,7 +1812,8 @@ class NonBatchedOpsStressTest : public StressTest {
       if (last_key <= static_cast<int64_t>(curr)) {
         thread->shared->SetVerificationFailure();
         fprintf(stderr,
-                "TestIterateAgainstExpected found unexpectedly large key\n");
+                "TestIterateAgainstExpected failed: found unexpectedly large "
+                "key\n");
         fprintf(stderr, "Column family: %s, op_logs: %s\n",
                 cfh->GetName().c_str(), op_logs.c_str());
         fprintf(stderr, "Last op found key: %s, expected at most: %s\n",
@@ -1869,7 +1875,8 @@ class NonBatchedOpsStressTest : public StressTest {
         if (static_cast<int64_t>(curr) < mid) {
           thread->shared->SetVerificationFailure();
           fprintf(stderr,
-                  "TestIterateAgainstExpected found unexpectedly small key\n");
+                  "TestIterateAgainstExpected failed: found unexpectedly small "
+                  "key\n");
           fprintf(stderr, "Column family: %s, op_logs: %s\n",
                   cfh->GetName().c_str(), op_logs.c_str());
           fprintf(stderr, "Last op found key: %s, expected at least: %s\n",
@@ -1892,7 +1899,8 @@ class NonBatchedOpsStressTest : public StressTest {
         if (mid < static_cast<int64_t>(curr)) {
           thread->shared->SetVerificationFailure();
           fprintf(stderr,
-                  "TestIterateAgainstExpected found unexpectedly large key\n");
+                  "TestIterateAgainstExpected failed: found unexpectedly large "
+                  "key\n");
           fprintf(stderr, "Column family: %s, op_logs: %s\n",
                   cfh->GetName().c_str(), op_logs.c_str());
           fprintf(stderr, "Last op found key: %s, expected at most: %s\n",
@@ -1932,7 +1940,9 @@ class NonBatchedOpsStressTest : public StressTest {
                 post_read_expected_value)) {
           // Fail fast to preserve the DB state.
           thread->shared->SetVerificationFailure();
-          fprintf(stderr, "Iterator has key %s, but expected state does not.\n",
+          fprintf(stderr,
+                  "Verification failed: iterator has key %s, but expected "
+                  "state does not.\n",
                   iter->key().ToString(true).c_str());
           fprintf(stderr, "Column family: %s, op_logs: %s\n",
                   cfh->GetName().c_str(), op_logs.c_str());
@@ -1950,9 +1960,9 @@ class NonBatchedOpsStressTest : public StressTest {
           GetIntVal(iter->key().ToString(), &next);
           if (next <= curr) {
             thread->shared->SetVerificationFailure();
-            fprintf(
-                stderr,
-                "TestIterateAgainstExpected found unexpectedly small key\n");
+            fprintf(stderr,
+                    "TestIterateAgainstExpected failed: found unexpectedly "
+                    "small key\n");
             fprintf(stderr, "Column family: %s, op_logs: %s\n",
                     cfh->GetName().c_str(), op_logs.c_str());
             fprintf(stderr, "Last op found key: %s, expected at least: %s\n",
@@ -1975,9 +1985,9 @@ class NonBatchedOpsStressTest : public StressTest {
           GetIntVal(iter->key().ToString(), &prev);
           if (curr <= prev) {
             thread->shared->SetVerificationFailure();
-            fprintf(
-                stderr,
-                "TestIterateAgainstExpected found unexpectedly large key\n");
+            fprintf(stderr,
+                    "TestIterateAgainstExpected failed: found unexpectedly "
+                    "large key\n");
             fprintf(stderr, "Column family: %s, op_logs: %s\n",
                     cfh->GetName().c_str(), op_logs.c_str());
             fprintf(stderr, "Last op found key: %s, expected at most: %s\n",


### PR DESCRIPTION
Summary: black/whitebox crash test relies on error/fail keyword in stderr to catch stress test failure. If a db_stress run prints an error message without these keyword, and then is killed before it graceful exits and prints out "Verification failed" here (https://github.com/facebook/rocksdb/blob/2648e0a747303e63796315049b9005c7320356c0/db_stress_tool/db_stress_driver.cc#L256), the error won't be caught. This is more likely to happen if db_stress is printing a stack trace. This PR fixes some error messages. Ideally in the future we should not rely on searching for keywords in stderr to determine failed stress tests.

Test plan:
```
Added the following change on top of this PR to simulate exit without relevant keyword:

@@ -1586,6 +1587,8 @@ class NonBatchedOpsStressTest : public StressTest {
     assert(thread);
     assert(!rand_column_families.empty());
     assert(!rand_keys.empty());
+    fprintf(stderr, "Inconsistency");
+    thread->shared->SafeTerminate();

python3 ./tools/db_crashtest.py blackbox --simple --verify_iterator_with_expected_state_one_in=1 --interval=10 

will print a stack trace but continue to run db_stress.
```