### PR TITLE
Enable `TestIterateAgainstExpected()` in more crash tests

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1836,7 +1836,9 @@ class NonBatchedOpsStressTest : public StressTest {
       op_logs += "P";
     }
 
-    if (thread->rand.OneIn(2)) {
+    // Write-prepared and Write-unprepared do not support Refresh() yet.
+    if (!(FLAGS_use_txn && FLAGS_txn_write_policy != 0) &&
+        thread->rand.OneIn(2)) {
       pre_read_expected_values.clear();
       post_read_expected_values.clear();
       // Refresh after forward/backward scan to allow higher chance of SV
@@ -1845,7 +1847,9 @@ class NonBatchedOpsStressTest : public StressTest {
         pre_read_expected_values.push_back(
             shared->Get(rand_column_family, i + lb));
       }
-      iter->Refresh();
+      Status rs = iter->Refresh();
+      assert(rs.ok());
+      op_logs += "Refresh ";
       for (int64_t i = 0; i < static_cast<int64_t>(expected_values_size); ++i) {
         post_read_expected_values.push_back(
             shared->Get(rand_column_family, i + lb));

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -224,6 +224,7 @@ default_params = {
         [0, 0, 0, 600, 3600, 86400]
     ),
     "auto_readahead_size" : lambda: random.choice([0, 1]),
+    "verify_iterator_with_expected_state_one_in": 5,
 }
 
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
@@ -364,7 +365,6 @@ simple_default_params = {
     "write_buffer_size": 32 * 1024 * 1024,
     "level_compaction_dynamic_level_bytes": lambda: random.randint(0, 1),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
-    "verify_iterator_with_expected_state_one_in": 5,
 }
 
 blackbox_simple_default_params = {
@@ -387,6 +387,8 @@ cf_consistency_params = {
     "enable_compaction_filter": 0,
     # `CfConsistencyStressTest::TestIngestExternalFile()` is not implemented.
     "ingest_external_file_one_in": 0,
+    # `CfConsistencyStressTest::TestIterateAgainstExpected()` is not implemented.
+    "verify_iterator_with_expected_state_one_in": 0,
 }
 
 # For pessimistic transaction db
@@ -522,6 +524,8 @@ multiops_txn_default_params = {
     "use_put_entity_one_in": 0,
     "use_get_entity": 0,
     "use_multi_get_entity": 0,
+    # `MultiOpsTxnsStressTest::TestIterateAgainstExpected()` is not implemented.
+    "verify_iterator_with_expected_state_one_in": 0,
 }
 
 multiops_wc_txn_params = {


### PR DESCRIPTION
Summary: db_stress flag `verify_iterator_with_expected_state_one_in` is only enabled for in crash test if --simple flag is set. This PR enables it for all supported crash tests by enabling it by default. This adds coverage for --txn and --enable_ts crash tests.

Test plan: ran crash tests that disabled this flag before for a few hours
```
python3 ./tools/db_crashtest.py blackbox --verify_iterator_with_expected_state_one_in=1 --txn --txn_write_policy=[0,1,2]

python3 ./tools/db_crashtest.py blackbox --verify_iterator_with_expected_state_one_in=1 --enable_ts
```