### PR TITLE
Add missing status check in ExternalSstFileIngestionJob and ImportColumnFamilyJob

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -769,8 +769,6 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
   std::unique_ptr<InternalIterator> iter(table_reader->NewIterator(
       ro, sv->mutable_cf_options.prefix_extractor.get(), /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kExternalSSTIngestion));
-  std::unique_ptr<InternalIterator> range_del_iter(
-      table_reader->NewRangeTombstoneIterator(ro));
 
   // Get first (smallest) and last (largest) key from file.
   file_to_ingest->smallest_internal_key =
@@ -833,6 +831,8 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
     return iter->status();
   }
 
+  std::unique_ptr<InternalIterator> range_del_iter(
+      table_reader->NewRangeTombstoneIterator(ro));
   // We may need to adjust these key bounds, depending on whether any range
   // deletion tombstones extend past them.
   const Comparator* ucmp = cfd_->internal_comparator().user_comparator();

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -829,6 +829,8 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
     file_to_ingest->largest_internal_key.SetFrom(key);
 
     bounds_set = true;
+  } else if (!iter->status().ok()) {
+    return iter->status();
   }
 
   // We may need to adjust these key bounds, depending on whether any range

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -393,6 +393,8 @@ Status ImportColumnFamilyJob::GetIngestedFileInfo(
       }
       file_to_import->largest_internal_key.DecodeFrom(largest);
       bound_set = true;
+    } else if (!iter->status().ok()) {
+      return iter->status();
     }
 
     std::unique_ptr<InternalIterator> range_del_iter{


### PR DESCRIPTION
.. and update some unit tests that failed with this change. See comment in ExternalSSTFileBasicTest.IngestFileWithCorruptedDataBlock for more explanation.

The missing status check is not caught by `ASSERT_STATUS_CHECKED=1` due to this line: https://github.com/facebook/rocksdb/blob/8505b26db19871a8c8782a35a7b5be9d321d45e0/table/block_based/block.h#L394. Will explore if we can remove it.

Test plan: existing unit tests.