### PR TITLE
[C-API] Add auto_tuned option to RateLimiter C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3960,12 +3960,20 @@ int rocksdb_options_get_wal_compression(rocksdb_options_t* opt) {
 
 rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(int64_t rate_bytes_per_sec,
                                                   int64_t refill_period_us,
-                                                  int32_t fairness,
-                                                  bool auto_tuned) {
+                                                  int32_t fairness) {
   rocksdb_ratelimiter_t* rate_limiter = new rocksdb_ratelimiter_t;
   rate_limiter->rep.reset(
-      NewGenericRateLimiter(rate_bytes_per_sec, refill_period_us, fairness,
-                            RateLimiter::Mode::kWritesOnly, auto_tuned));
+      NewGenericRateLimiter(rate_bytes_per_sec, refill_period_us, fairness));
+  return rate_limiter;
+}
+
+rocksdb_ratelimiter_t* rocksdb_ratelimiter_create_auto_tuned(
+    int64_t rate_bytes_per_sec, int64_t refill_period_us, int32_t fairness) {
+  rocksdb_ratelimiter_t* rate_limiter = new rocksdb_ratelimiter_t;
+  rate_limiter->rep.reset(NewGenericRateLimiter(rate_bytes_per_sec,
+                                                refill_period_us, fairness,
+                                                RateLimiter::Mode::kWritesOnly,
+                                                true));  // auto_tuned
   return rate_limiter;
 }
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -3960,10 +3960,12 @@ int rocksdb_options_get_wal_compression(rocksdb_options_t* opt) {
 
 rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(int64_t rate_bytes_per_sec,
                                                   int64_t refill_period_us,
-                                                  int32_t fairness) {
+                                                  int32_t fairness,
+                                                  bool auto_tuned) {
   rocksdb_ratelimiter_t* rate_limiter = new rocksdb_ratelimiter_t;
   rate_limiter->rep.reset(
-      NewGenericRateLimiter(rate_bytes_per_sec, refill_period_us, fairness));
+      NewGenericRateLimiter(rate_bytes_per_sec, refill_period_us, fairness,
+                            RateLimiter::Mode::kWritesOnly, auto_tuned));
   return rate_limiter;
 }
 

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -709,7 +709,8 @@ int main(int argc, char** argv) {
   int compression_levels[] = {rocksdb_no_compression, rocksdb_no_compression,
                               rocksdb_no_compression, rocksdb_no_compression};
   rocksdb_options_set_compression_per_level(options, compression_levels, 4);
-  rate_limiter = rocksdb_ratelimiter_create(1000 * 1024 * 1024, 100 * 1000, 10);
+  rate_limiter = rocksdb_ratelimiter_create(1000 * 1024 * 1024, 100 * 1000, 10,
+                                            true);  // auto_tuned
   rocksdb_options_set_ratelimiter(options, rate_limiter);
   rocksdb_ratelimiter_destroy(rate_limiter);
 

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -709,8 +709,12 @@ int main(int argc, char** argv) {
   int compression_levels[] = {rocksdb_no_compression, rocksdb_no_compression,
                               rocksdb_no_compression, rocksdb_no_compression};
   rocksdb_options_set_compression_per_level(options, compression_levels, 4);
-  rate_limiter = rocksdb_ratelimiter_create(1000 * 1024 * 1024, 100 * 1000, 10,
-                                            true);  // auto_tuned
+  rate_limiter = rocksdb_ratelimiter_create(1000 * 1024 * 1024, 100 * 1000, 10);
+  rocksdb_options_set_ratelimiter(options, rate_limiter);
+  rocksdb_ratelimiter_destroy(rate_limiter);
+
+  rate_limiter =
+      rocksdb_ratelimiter_create_auto_tuned(1000 * 1024 * 1024, 100 * 1000, 10);
   rocksdb_options_set_ratelimiter(options, rate_limiter);
   rocksdb_ratelimiter_destroy(rate_limiter);
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1671,8 +1671,11 @@ extern ROCKSDB_LIBRARY_API int rocksdb_options_get_wal_compression(
 
 /* RateLimiter */
 extern ROCKSDB_LIBRARY_API rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(
-    int64_t rate_bytes_per_sec, int64_t refill_period_us, int32_t fairness,
-    bool auto_tuned);
+    int64_t rate_bytes_per_sec, int64_t refill_period_us, int32_t fairness);
+extern ROCKSDB_LIBRARY_API rocksdb_ratelimiter_t*
+rocksdb_ratelimiter_create_auto_tuned(int64_t rate_bytes_per_sec,
+                                      int64_t refill_period_us,
+                                      int32_t fairness);
 extern ROCKSDB_LIBRARY_API void rocksdb_ratelimiter_destroy(
     rocksdb_ratelimiter_t*);
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1671,7 +1671,8 @@ extern ROCKSDB_LIBRARY_API int rocksdb_options_get_wal_compression(
 
 /* RateLimiter */
 extern ROCKSDB_LIBRARY_API rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(
-    int64_t rate_bytes_per_sec, int64_t refill_period_us, int32_t fairness);
+    int64_t rate_bytes_per_sec, int64_t refill_period_us, int32_t fairness,
+    bool auto_tuned);
 extern ROCKSDB_LIBRARY_API void rocksdb_ratelimiter_destroy(
     rocksdb_ratelimiter_t*);
 

--- a/unreleased_history/public_api_changes/add_auto_tuned_rate_limiter_to_c_api.md
+++ b/unreleased_history/public_api_changes/add_auto_tuned_rate_limiter_to_c_api.md
@@ -1,1 +1,1 @@
-Updated rocksdb_ratelimiter_create API to expose the auto_tuned option.
+Added rocksdb_ratelimiter_create_auto_tuned API to create an auto-tuned GenericRateLimiter.

--- a/unreleased_history/public_api_changes/add_auto_tuned_rate_limiter_to_c_api.md
+++ b/unreleased_history/public_api_changes/add_auto_tuned_rate_limiter_to_c_api.md
@@ -1,0 +1,1 @@
+Updated rocksdb_ratelimiter_create API to expose the auto_tuned option.


### PR DESCRIPTION
#### Problem
While the RocksDB C API does have the RateLimiter API, it does not
expose the auto_tuned option.

#### Summary of Change
This PR exposes auto_tuned RateLimiter option in RocksDB C API.

#### Test Plan
Augment the C API existing test to cover the new API.