### PR TITLE
Build RocksDBJava on Windows with Java8.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,7 @@ commands:
           name: "Install thirdparty dependencies"
           command: |
             echo "Installing CMake..."
-            choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
-            powershell.exe -Command "Remove-Item -Path HKLM:\Software\JavaSoft -Recurse"
+            choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y            
             choco install liberica8jdk -y
             mkdir $Env:THIRDPARTY_HOME
             cd $Env:THIRDPARTY_HOME
@@ -69,6 +68,7 @@ commands:
       - run:
           name: "Build RocksDB"
           command: |
+            set PATH=%JAVA_HOME%;%PATH%
             mkdir build
             cd build
             & $Env:CMAKE_BIN -G "$Env:CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=Debug -DOPTDBG=1 -DPORTABLE="$Env:CMAKE_PORTABLE" -DSNAPPY=1 -DJNI=1 ..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ commands:
           command: |
             echo "Installing CMake..."
             choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+            powershell.exe -Command "Remove-Item -Path HKLM:\Software\JavaSoft -Recurse"
             choco install liberica8jdk -y
             mkdir $Env:THIRDPARTY_HOME
             cd $Env:THIRDPARTY_HOME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ commands:
       - run:
           name: "Build RocksDB"
           command: |
-            set PATH=%JAVA_HOME%;%PATH%
+            $env:Path = $env:JAVA_HOME + ";" + $env:Path
             mkdir build
             cd build
             & $Env:CMAKE_BIN -G "$Env:CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=Debug -DOPTDBG=1 -DPORTABLE="$Env:CMAKE_PORTABLE" -DSNAPPY=1 -DJNI=1 ..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ commands:
           command: |
             echo "Installing CMake..."
             choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+            choco install liberica8jdk -y
             mkdir $Env:THIRDPARTY_HOME
             cd $Env:THIRDPARTY_HOME
             echo "Building Snappy dependency..."
@@ -575,6 +576,7 @@ jobs:
       CMAKE_HOME: C:/Program Files/CMake
       CMAKE_BIN: C:/Program Files/CMake/bin/cmake.exe
       CTEST_BIN: C:/Program Files/CMake/bin/ctest.exe
+      JAVA_HOME: C:/Program Files/BellSoft/LibericaJDK-8
       SNAPPY_HOME: C:/Users/circleci/thirdparty/snappy-1.1.8
       SNAPPY_INCLUDE: C:/Users/circleci/thirdparty/snappy-1.1.8;C:/Users/circleci/thirdparty/snappy-1.1.8/build
       SNAPPY_LIB_DEBUG: C:/Users/circleci/thirdparty/snappy-1.1.8/build/Debug/snappy.lib
@@ -592,6 +594,7 @@ jobs:
       CMAKE_HOME: C:/Program Files/CMake
       CMAKE_BIN: C:/Program Files/CMake/bin/cmake.exe
       CTEST_BIN: C:/Program Files/CMake/bin/ctest.exe
+      JAVA_HOME: C:/Program Files/BellSoft/LibericaJDK-8
       SNAPPY_HOME: C:/Users/circleci/thirdparty/snappy-1.1.8
       SNAPPY_INCLUDE: C:/Users/circleci/thirdparty/snappy-1.1.8;C:/Users/circleci/thirdparty/snappy-1.1.8/build
       SNAPPY_LIB_DEBUG: C:/Users/circleci/thirdparty/snappy-1.1.8/build/Debug/snappy.lib
@@ -609,6 +612,7 @@ jobs:
       CMAKE_HOME: C:/Program Files/CMake
       CMAKE_BIN: C:/Program Files/CMake/bin/cmake.exe
       CTEST_BIN: C:/Program Files/CMake/bin/ctest.exe
+      JAVA_HOME: C:/Program Files/BellSoft/LibericaJDK-8
       SNAPPY_HOME: C:/Users/circleci/thirdparty/snappy-1.1.8
       SNAPPY_INCLUDE: C:/Users/circleci/thirdparty/snappy-1.1.8;C:/Users/circleci/thirdparty/snappy-1.1.8/build
       SNAPPY_LIB_DEBUG: C:/Users/circleci/thirdparty/snappy-1.1.8/build/Debug/snappy.lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
           name: "Install thirdparty dependencies"
           command: |
             echo "Installing CMake..."
-            choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y            
+            choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
             choco install liberica8jdk -y
             mkdir $Env:THIRDPARTY_HOME
             cd $Env:THIRDPARTY_HOME


### PR DESCRIPTION
At the moment RocksDBJava uses the default CIrcleCI JVM on Windows builds. This can and has changed in the past and can cause some incompatibilities. 

This PR addresses the problem of explicitly installing and using Liberica JDK 8 as Java 8 Is the primary target for RocksdbJava. 