### PR TITLE
Fix build on FreeBSD (#11218)

### DIFF
--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -29,7 +29,8 @@
 
 // For non linux platform, the following macros are used only as place
 // holder.
-#if !(defined OS_LINUX) && !(defined CYGWIN) && !(defined OS_AIX)
+#if !(defined OS_LINUX) && !(defined OS_FREEBSD) && !(defined CYGWIN) && \
+    !(defined OS_AIX)
 #define POSIX_FADV_NORMAL 0     /* [MC1] no further special treatment */
 #define POSIX_FADV_RANDOM 1     /* [MC1] expect random page refs */
 #define POSIX_FADV_SEQUENTIAL 2 /* [MC1] expect sequential page refs */


### PR DESCRIPTION
Fixes https://github.com/facebook/rocksdb/issues/11218

Changes from #10881 broke FreeBSD builds with:

    env/io_posix.h:39:9: error: 'POSIX_MADV_NORMAL' macro redefined [-Werror,-Wmacro-redefined]

This commit fixes FreeBSD builds by ignoring MADV defines.