### PR TITLE
Do not check op_type in `WithinPenultimateLevelOutputRange()`

### DIFF
--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -498,8 +498,9 @@ bool Compaction::WithinPenultimateLevelOutputRange(
 
   const InternalKeyComparator* icmp = input_vstorage_->InternalComparator();
 
-  return icmp->Compare(ikey, penultimate_level_smallest_.Encode()) >= 0 &&
-         icmp->Compare(ikey, penultimate_level_largest_.Encode()) <= 0;
+  // op_type of a key can change during compaction, e.g. Merge -> Put.
+  return icmp->CompareKeySeq(ikey, penultimate_level_smallest_.Encode()) >= 0 &&
+         icmp->CompareKeySeq(ikey, penultimate_level_largest_.Encode()) <= 0;
 }
 
 bool Compaction::InputCompressionMatchesOutput() const {


### PR DESCRIPTION
`WithinPenultimateLevelOutputRange()` is updated in #12063 to check internal key range. However, op_type of a key can change during compaction, e.g. MERGE -> PUT, which makes a key larger and becomes out of penultimate output range. This has caused stress test failures with error message "Unsafe to store Seq later than snapshot in the last level if per_key_placement is enabled". So update `WithinPenultimateLevelOutputRange()` to only check user key and sequence number.


Test plan:
* This repro can produce the corruption within a few runs. Ran it a few times after the fix and did not see Corruption failure.
```
python3 ./tools/db_crashtest.py whitebox --test_tiered_storage --random_kill_odd=888887 --use_merge=1 --writepercent=100 --readpercent=0 --prefixpercent=0 --delpercent=0 --delrangepercent=0 --iterpercent=0 --write_buffer_size=419430 --column_families=1 --read_fault_one_in=0 --write_fault_one_in=0
```