### PR TITLE
Add some asserts in ~CacheWithSecondaryAdapter

### DIFF
--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -119,6 +119,8 @@ CacheWithSecondaryAdapter::~CacheWithSecondaryAdapter() {
     size_t sec_capacity = 0;
     Status s = secondary_cache_->GetCapacity(sec_capacity);
     assert(s.ok());
+    assert(placeholder_usage_ == 0);
+    assert(reserved_usage_ == 0);
     assert(pri_cache_res_->GetTotalMemoryUsed() == sec_capacity);
   }
 #endif  // NDEBUG


### PR DESCRIPTION
Add some asserts in the `CacheWithSecondaryAdapter` destructor to help debug a crash test failure.