### PR TITLE
Add missing license to source files

### DIFF
--- a/utilities/merge_operators/string_append/stringappend.cc
+++ b/utilities/merge_operators/string_append/stringappend.cc
@@ -1,8 +1,9 @@
-/**
- * A MergeOperator for rocksdb that implements string append.
- * @author Deon Nicholas (dnicholas@fb.com)
- * Copyright 2013 Facebook
- */
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// A MergeOperator for rocksdb that implements string append.
 
 #include "stringappend.h"
 

--- a/utilities/merge_operators/string_append/stringappend.h
+++ b/utilities/merge_operators/string_append/stringappend.h
@@ -1,8 +1,9 @@
-/**
- * A MergeOperator for rocksdb that implements string append.
- * @author Deon Nicholas (dnicholas@fb.com)
- * Copyright 2013 Facebook
- */
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// A MergeOperator for rocksdb that implements string append.
 
 #pragma once
 #include "rocksdb/merge_operator.h"

--- a/utilities/merge_operators/string_append/stringappend2.cc
+++ b/utilities/merge_operators/string_append/stringappend2.cc
@@ -1,7 +1,7 @@
-/**
- * @author Deon Nicholas (dnicholas@fb.com)
- * Copyright 2013 Facebook
- */
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
 
 #include "stringappend2.h"
 

--- a/utilities/transactions/lock/range/range_tree/lib/db.h
+++ b/utilities/transactions/lock/range/range_tree/lib/db.h
@@ -1,3 +1,8 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
 #ifndef _DB_H
 #define _DB_H
 

--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_assert_subst.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_assert_subst.h
@@ -1,3 +1,7 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
 //
 // A replacement for toku_assert.h
 //

--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_external_pthread.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_external_pthread.h
@@ -1,3 +1,7 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
 /*
   A wrapper around ROCKSDB_NAMESPACE::TransactionDBMutexFactory-provided
   condition and mutex that provides toku_pthread_*-like interface. The functions

--- a/utilities/transactions/lock/range/range_tree/lib/portability/txn_subst.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/txn_subst.h
@@ -1,3 +1,7 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
 //
 // A substitute for ft/txn/txn.h
 //

--- a/utilities/transactions/lock/range/range_tree/lib/standalone_port.cc
+++ b/utilities/transactions/lock/range/range_tree/lib/standalone_port.cc
@@ -1,3 +1,8 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
 #ifndef OS_WIN
 /*
   This is a dump ground to make Lock Tree work without the rest of TokuDB.


### PR DESCRIPTION
Fixes #12079.

Fixed missing licenses in "\*.h" and "\*.cc" files