### PR TITLE
Fix compact_files_example

### DIFF
--- a/examples/compact_files_example.cc
+++ b/examples/compact_files_example.cc
@@ -144,6 +144,8 @@ int main() {
   options.create_if_missing = true;
   // Disable RocksDB background compaction.
   options.compaction_style = ROCKSDB_NAMESPACE::kCompactionStyleNone;
+  // Small write buffer size for generating more sst files in level 0.
+  options.write_buffer_size = 4 << 20;
   // Small slowdown and stop trigger for experimental purpose.
   options.level0_slowdown_writes_trigger = 3;
   options.level0_stop_writes_trigger = 5;


### PR DESCRIPTION
The option "write_buffer_size" has changed from 4MB for 64MB by default, and the compact_files_example will not work as expected, as the test data written is only about 50MB and will not trigger compaction.