### PR TITLE
FindObsoleteFiles should full scan after dropping CF

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3307,8 +3307,7 @@ void DBImpl::BackgroundCallFlush(Env::Priority thread_pri) {
     if (!flush_rescheduled_to_retain_udt) {
       // If flush failed, we want to delete all temporary files that we might
       // have created. Thus, we force full scan in FindObsoleteFiles()
-      FindObsoleteFiles(&job_context, !s.ok() && !s.IsShutdownInProgress() &&
-                                          !s.IsColumnFamilyDropped());
+      FindObsoleteFiles(&job_context, !s.ok() && !s.IsShutdownInProgress());
       // delete unnecessary files if any, this is done outside the mutex
       if (job_context.HaveSomethingToClean() ||
           job_context.HaveSomethingToDelete() || !log_buffer.IsEmpty()) {
@@ -3404,7 +3403,6 @@ void DBImpl::BackgroundCallCompaction(PrepickedCompaction* prepicked_compaction,
     // case of a failure). Thus, we force full scan in FindObsoleteFiles()
     FindObsoleteFiles(&job_context, !s.ok() && !s.IsShutdownInProgress() &&
                                         !s.IsManualCompactionPaused() &&
-                                        !s.IsColumnFamilyDropped() &&
                                         !s.IsBusy());
     TEST_SYNC_POINT("DBImpl::BackgroundCallCompaction:FoundObsoleteFiles");
 


### PR DESCRIPTION
When dropping CFs right after heavy write (flush and/or compaction was still ongoing), I observed that there were many sst files left forever unless restarting rocksdb. I checked manifest and those sst files were not there. It seems this issue was introduced since PR #5275 (https://github.com/facebook/rocksdb/pull/5275), as shutdown process can cleanup orphan/obsolete sst files, so no need to force a full scan when calling FindObsoleteFiles. However, dropping CF cannot cleanup those files and needs a full scan.