### PR TITLE
Convert all but one windows job to nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,8 +914,6 @@ workflows:
       - build-linux-mini-crashtest
   jobs-windows:
     jobs:
-      - build-windows-vs2022-avx2
-      - build-windows-vs2022
       - build-windows-vs2019
       - build-cmake-mingw
   jobs-java:
@@ -964,3 +962,5 @@ workflows:
       - build-linux-non-shm
       - build-linux-clang-13-asan-ubsan-with-folly
       - build-linux-valgrind
+      - build-windows-vs2022-avx2
+      - build-windows-vs2022


### PR DESCRIPTION
Summary: ... because they are expensive and rarely disagree with each other. Historical data indicates that the 2019 job is most sensitive to failure.

https://fburl.com/scuba/opensource_ci_jobs/ntq3ue3p https://fburl.com/scuba/opensource_ci_jobs/0xo91j5f

Test Plan: CI