### PR TITLE
Fix JavaDoc of setCompactionReadaheadSize

### DIFF
--- a/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
@@ -418,7 +418,7 @@ public interface MutableDBOptionsInterface<T extends MutableDBOptionsInterface<T
    * <p>
    * That way RocksDB's compaction is doing sequential instead of random reads.
    * <p>
-   * Default: 0
+   * Default: 2MB
    *
    * @param compactionReadaheadSize The compaction read-ahead size
    *


### PR DESCRIPTION
Recently in #11762 the default of `compaction_readahead_size` changed from 0 to 2 MB.

Closes: #12088