### PR TITLE
Refactor FilePrefetchBuffer code

### DIFF
--- a/db/blob/prefetch_buffer_collection.cc
+++ b/db/blob/prefetch_buffer_collection.cc
@@ -11,8 +11,10 @@ FilePrefetchBuffer* PrefetchBufferCollection::GetOrCreatePrefetchBuffer(
     uint64_t file_number) {
   auto& prefetch_buffer = prefetch_buffers_[file_number];
   if (!prefetch_buffer) {
-    prefetch_buffer.reset(
-        new FilePrefetchBuffer(readahead_size_, readahead_size_));
+    ReadaheadParams readahead_params;
+    readahead_params.initial_readahead_size = readahead_size_;
+    readahead_params.max_readahead_size = readahead_size_;
+    prefetch_buffer.reset(new FilePrefetchBuffer(readahead_params));
   }
 
   return prefetch_buffer.get();

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -998,9 +998,7 @@ class PosixFileSystem : public FileSystem {
   }
 #endif  // ROCKSDB_IOURING_PRESENT
 
-  // EXPERIMENTAL
-  //
-  // TODO akankshamahajan:
+  // TODO:
   // 1. Update Poll API to take into account min_completions
   // and returns if number of handles in io_handles (any order) completed is
   // equal to atleast min_completions.

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -22,29 +22,27 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-void FilePrefetchBuffer::CalculateOffsetAndLen(size_t alignment,
-                                               uint64_t offset,
-                                               size_t roundup_len,
-                                               uint32_t index, bool refit_tail,
-                                               uint64_t& chunk_len) {
+void FilePrefetchBuffer::CalculateOffsetAndLen(
+    BufferInfo* buf, size_t alignment, uint64_t offset, size_t roundup_len,
+    bool refit_tail, uint64_t& chunk_len) {
   uint64_t chunk_offset_in_buffer = 0;
   bool copy_data_to_new_buffer = false;
   // Check if requested bytes are in the existing buffer_.
   // If only a few bytes exist -- reuse them & read only what is really needed.
   //     This is typically the case of incremental reading of data.
   // If no bytes exist in buffer -- full pread.
-  if (DoesBufferContainData(index) && IsOffsetInBuffer(offset, index)) {
+  if (DoesBufferContainData(buf) && IsOffsetInBuffer(buf, offset)) {
     // Only a few requested bytes are in the buffer. memmove those chunk of
     // bytes to the beginning, and memcpy them back into the new buffer if a
     // new buffer is created.
-    chunk_offset_in_buffer = Rounddown(
-        static_cast<size_t>(offset - bufs_[index].offset_), alignment);
-    chunk_len = static_cast<uint64_t>(bufs_[index].buffer_.CurrentSize()) -
+    chunk_offset_in_buffer =
+        Rounddown(static_cast<size_t>(offset - buf->offset_), alignment);
+    chunk_len = static_cast<uint64_t>(buf->buffer_.CurrentSize()) -
                 chunk_offset_in_buffer;
     assert(chunk_offset_in_buffer % alignment == 0);
     assert(chunk_len % alignment == 0);
     assert(chunk_offset_in_buffer + chunk_len <=
-           bufs_[index].offset_ + bufs_[index].buffer_.CurrentSize());
+           buf->offset_ + buf->buffer_.CurrentSize());
     if (chunk_len > 0) {
       copy_data_to_new_buffer = true;
     } else {
@@ -55,36 +53,35 @@ void FilePrefetchBuffer::CalculateOffsetAndLen(size_t alignment,
 
   // Create a new buffer only if current capacity is not sufficient, and memcopy
   // bytes from old buffer if needed (i.e., if chunk_len is greater than 0).
-  if (bufs_[index].buffer_.Capacity() < roundup_len) {
-    bufs_[index].buffer_.Alignment(alignment);
-    bufs_[index].buffer_.AllocateNewBuffer(
+  if (buf->buffer_.Capacity() < roundup_len) {
+    buf->buffer_.Alignment(alignment);
+    buf->buffer_.AllocateNewBuffer(
         static_cast<size_t>(roundup_len), copy_data_to_new_buffer,
         chunk_offset_in_buffer, static_cast<size_t>(chunk_len));
   } else if (chunk_len > 0 && refit_tail) {
     // New buffer not needed. But memmove bytes from tail to the beginning since
     // chunk_len is greater than 0.
-    bufs_[index].buffer_.RefitTail(static_cast<size_t>(chunk_offset_in_buffer),
-                                   static_cast<size_t>(chunk_len));
+    buf->buffer_.RefitTail(static_cast<size_t>(chunk_offset_in_buffer),
+                           static_cast<size_t>(chunk_len));
   } else if (chunk_len > 0) {
     // For async prefetching, it doesn't call RefitTail with chunk_len > 0.
     // Allocate new buffer if needed because aligned buffer calculate remaining
-    // buffer as capacity_ - cursize_ which might not be the case in this as we
-    // are not refitting.
-    // TODO akanksha: Update the condition when asynchronous prefetching is
-    // stable.
-    bufs_[index].buffer_.Alignment(alignment);
-    bufs_[index].buffer_.AllocateNewBuffer(
+    // buffer as capacity - cursize which might not be the case in this as it's
+    // not refitting.
+    // TODO: Use refit_tail for async prefetching too.
+    buf->buffer_.Alignment(alignment);
+    buf->buffer_.AllocateNewBuffer(
         static_cast<size_t>(roundup_len), copy_data_to_new_buffer,
         chunk_offset_in_buffer, static_cast<size_t>(chunk_len));
   }
 }
 
-Status FilePrefetchBuffer::Read(const IOOptions& opts,
+Status FilePrefetchBuffer::Read(BufferInfo* buf, const IOOptions& opts,
                                 RandomAccessFileReader* reader,
                                 uint64_t read_len, uint64_t chunk_len,
-                                uint64_t start_offset, uint32_t index) {
+                                uint64_t start_offset) {
   Slice result;
-  char* to_buf = bufs_[index].buffer_.BufferStart() + chunk_len;
+  char* to_buf = buf->buffer_.BufferStart() + chunk_len;
   Status s = reader->Read(opts, start_offset + chunk_len, read_len, &result,
                           to_buf, /*aligned_buf=*/nullptr);
 #ifndef NDEBUG
@@ -108,16 +105,14 @@ Status FilePrefetchBuffer::Read(const IOOptions& opts,
   if (usage_ == FilePrefetchBufferUsage::kUserScanPrefetch) {
     RecordTick(stats_, PREFETCH_BYTES, read_len);
   }
-  // Update the buffer offset and size.
-  bufs_[index].offset_ = start_offset;
-  bufs_[index].buffer_.Size(static_cast<size_t>(chunk_len) + result.size());
+  // Update the buffer size.
+  buf->buffer_.Size(static_cast<size_t>(chunk_len) + result.size());
   return s;
 }
 
-Status FilePrefetchBuffer::ReadAsync(const IOOptions& opts,
+Status FilePrefetchBuffer::ReadAsync(BufferInfo* buf, const IOOptions& opts,
                                      RandomAccessFileReader* reader,
-                                     uint64_t read_len, uint64_t start_offset,
-                                     uint32_t index) {
+                                     uint64_t read_len, uint64_t start_offset) {
   TEST_SYNC_POINT("FilePrefetchBuffer::ReadAsync");
   // callback for async read request.
   auto fp = std::bind(&FilePrefetchBuffer::PrefetchAsyncCallback, this,
@@ -127,17 +122,15 @@ Status FilePrefetchBuffer::ReadAsync(const IOOptions& opts,
   req.len = read_len;
   req.offset = start_offset;
   req.result = result;
-  req.scratch = bufs_[index].buffer_.BufferStart();
-  bufs_[index].async_req_len_ = req.len;
+  req.scratch = buf->buffer_.BufferStart();
+  buf->async_req_len_ = req.len;
 
-  Status s =
-      reader->ReadAsync(req, opts, fp, &(bufs_[index].pos_),
-                        &(bufs_[index].io_handle_), &(bufs_[index].del_fn_),
-                        /*aligned_buf=*/nullptr);
+  Status s = reader->ReadAsync(req, opts, fp, buf->pos_, &(buf->io_handle_),
+                               &(buf->del_fn_), /*aligned_buf =*/nullptr);
   req.status.PermitUncheckedError();
   if (s.ok()) {
     RecordTick(stats_, PREFETCH_BYTES, read_len);
-    bufs_[index].async_read_in_progress_ = true;
+    buf->async_read_in_progress_ = true;
   }
   return s;
 }
@@ -148,11 +141,16 @@ Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
   if (!enable_ || reader == nullptr) {
     return Status::OK();
   }
+
+  assert(num_buffers_ == 1);
+
+  AllocateBufferIfEmpty();
+  BufferInfo* buf = GetFirstBuffer();
+
   TEST_SYNC_POINT("FilePrefetchBuffer::Prefetch:Start");
 
-  if (offset + n <= bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) {
-    // All requested bytes are already in the curr_ buffer. So no need to Read
-    // again.
+  if (offset + n <= buf->offset_ + buf->buffer_.CurrentSize()) {
+    // All requested bytes are already in the buffer. So no need to Read again.
     return Status::OK();
   }
 
@@ -160,13 +158,13 @@ Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
   uint64_t rounddown_offset = offset, roundup_end = 0, chunk_len = 0;
   size_t read_len = 0;
 
-  ReadAheadSizeTuning(/*read_curr_block=*/true, /*refit_tail=*/true,
-                      rounddown_offset, curr_, alignment, 0, n,
+  ReadAheadSizeTuning(buf, /*read_curr_block=*/true,
+                      /*refit_tail=*/true, rounddown_offset, alignment, 0, n,
                       rounddown_offset, roundup_end, read_len, chunk_len);
 
   Status s;
   if (read_len > 0) {
-    s = Read(opts, reader, read_len, chunk_len, rounddown_offset, curr_);
+    s = Read(buf, opts, reader, read_len, chunk_len, rounddown_offset);
   }
 
   if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail && s.ok()) {
@@ -175,25 +173,27 @@ Status FilePrefetchBuffer::Prefetch(const IOOptions& opts,
   return s;
 }
 
-// Copy data from src to third buffer.
-void FilePrefetchBuffer::CopyDataToBuffer(uint32_t src, uint64_t& offset,
+// Copy data from src to overlap_bufs_.
+void FilePrefetchBuffer::CopyDataToBuffer(BufferInfo* src, uint64_t& offset,
                                           size_t& length) {
   if (length == 0) {
     return;
   }
-  uint64_t copy_offset = (offset - bufs_[src].offset_);
+
+  uint64_t copy_offset = (offset - src->offset_);
   size_t copy_len = 0;
-  if (IsDataBlockInBuffer(offset, length, src)) {
+  if (IsDataBlockInBuffer(src, offset, length)) {
     // All the bytes are in src.
     copy_len = length;
   } else {
-    copy_len = bufs_[src].buffer_.CurrentSize() - copy_offset;
+    copy_len = src->buffer_.CurrentSize() - copy_offset;
   }
 
-  memcpy(bufs_[2].buffer_.BufferStart() + bufs_[2].buffer_.CurrentSize(),
-         bufs_[src].buffer_.BufferStart() + copy_offset, copy_len);
+  BufferInfo* dst = overlap_bufs_.front();
+  memcpy(dst->buffer_.BufferStart() + dst->buffer_.CurrentSize(),
+         src->buffer_.BufferStart() + copy_offset, copy_len);
 
-  bufs_[2].buffer_.Size(bufs_[2].buffer_.CurrentSize() + copy_len);
+  dst->buffer_.Size(dst->buffer_.CurrentSize() + copy_len);
 
   // Update offset and length.
   offset += copy_len;
@@ -202,51 +202,44 @@ void FilePrefetchBuffer::CopyDataToBuffer(uint32_t src, uint64_t& offset,
   // length > 0 indicates it has consumed all data from the src buffer and it
   // still needs to read more other buffer.
   if (length > 0) {
-    bufs_[src].ClearBuffer();
+    FreeFrontBuffer();
   }
 }
 
-// Clear the buffers if it contains outdated data. Outdated data can be
-// because previous sequential reads were read from the cache instead of these
-// buffer. In that case outdated IOs should be aborted.
-void FilePrefetchBuffer::AbortIOIfNeeded(uint64_t offset) {
-  uint32_t second = curr_ ^ 1;
+// Clear the buffers if it contains outdated data. Outdated data can be because
+// previous sequential reads were read from the cache instead of these buffer.
+// In that case outdated IOs should be aborted.
+void FilePrefetchBuffer::AbortOutdatedIO(uint64_t offset) {
   std::vector<void*> handles;
-  autovector<uint32_t> buf_pos;
-  if (IsBufferOutdatedWithAsyncProgress(offset, curr_)) {
-    handles.emplace_back(bufs_[curr_].io_handle_);
-    buf_pos.emplace_back(curr_);
+  std::vector<BufferInfo*> tmp_buf;
+  for (auto& buf : bufs_) {
+    if (IsBufferOutdatedWithAsyncProgress(buf, offset)) {
+      handles.emplace_back(buf->io_handle_);
+      tmp_buf.emplace_back(buf);
+    }
   }
-  if (IsBufferOutdatedWithAsyncProgress(offset, second)) {
-    handles.emplace_back(bufs_[second].io_handle_);
-    buf_pos.emplace_back(second);
-  }
+
   if (!handles.empty()) {
     StopWatch sw(clock_, stats_, ASYNC_PREFETCH_ABORT_MICROS);
     Status s = fs_->AbortIO(handles);
     assert(s.ok());
   }
 
-  for (auto& pos : buf_pos) {
-    // Release io_handle.
-    DestroyAndClearIOHandle(pos);
+  for (auto& buf : tmp_buf) {
+    if (buf->async_read_in_progress_) {
+      DestroyAndClearIOHandle(buf);
+      buf->async_read_in_progress_ = false;
+    }
+    buf->ClearBuffer();
   }
-
-  if (bufs_[second].io_handle_ == nullptr) {
-    bufs_[second].async_read_in_progress_ = false;
-  }
-
-  if (bufs_[curr_].io_handle_ == nullptr) {
-    bufs_[curr_].async_read_in_progress_ = false;
-  }
+  FreeEmptyBuffers();
 }
 
 void FilePrefetchBuffer::AbortAllIOs() {
-  uint32_t second = curr_ ^ 1;
   std::vector<void*> handles;
-  for (uint32_t i = 0; i < 2; i++) {
-    if (bufs_[i].async_read_in_progress_ && bufs_[i].io_handle_ != nullptr) {
-      handles.emplace_back(bufs_[i].io_handle_);
+  for (auto& buf : bufs_) {
+    if (buf->async_read_in_progress_ && buf->io_handle_ != nullptr) {
+      handles.emplace_back(buf->io_handle_);
     }
   }
   if (!handles.empty()) {
@@ -255,90 +248,73 @@ void FilePrefetchBuffer::AbortAllIOs() {
     assert(s.ok());
   }
 
-  // Release io_handles.
-  if (bufs_[curr_].io_handle_ != nullptr && bufs_[curr_].del_fn_ != nullptr) {
-    DestroyAndClearIOHandle(curr_);
-  } else {
-    bufs_[curr_].async_read_in_progress_ = false;
+  for (auto& buf : bufs_) {
+    if (buf->io_handle_ != nullptr && buf->del_fn_ != nullptr) {
+      DestroyAndClearIOHandle(buf);
+    }
+    buf->async_read_in_progress_ = false;
   }
-
-  if (bufs_[second].io_handle_ != nullptr && bufs_[second].del_fn_ != nullptr) {
-    DestroyAndClearIOHandle(second);
-  } else {
-    bufs_[second].async_read_in_progress_ = false;
-  }
+  FreeEmptyBuffers();
 }
 
 // Clear the buffers if it contains outdated data. Outdated data can be
 // because previous sequential reads were read from the cache instead of these
 // buffer.
-void FilePrefetchBuffer::UpdateBuffersIfNeeded(uint64_t offset, size_t length) {
-  uint32_t second = curr_ ^ 1;
-
-  if (IsBufferOutdated(offset, curr_)) {
-    bufs_[curr_].ClearBuffer();
+void FilePrefetchBuffer::ClearOutdatedData(uint64_t offset, size_t length) {
+  while (!IsBufferQueueEmpty()) {
+    BufferInfo* buf = GetFirstBuffer();
+    // Offset is greater than this buffer's end offset.
+    if (IsBufferOutdated(buf, offset)) {
+      FreeFrontBuffer();
+    } else {
+      break;
+    }
   }
-  if (IsBufferOutdated(offset, second)) {
-    bufs_[second].ClearBuffer();
+
+  if (IsBufferQueueEmpty()) {
+    return;
   }
 
-  {
-    // In case buffers do not align, reset second buffer if requested data needs
-    // to be read in second buffer.
-    if (!bufs_[second].async_read_in_progress_ &&
-        !bufs_[curr_].async_read_in_progress_) {
-      if (DoesBufferContainData(curr_)) {
-        if (bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize() !=
-            bufs_[second].offset_) {
-          if (DoesBufferContainData(second) &&
-              IsOffsetInBuffer(offset, curr_) &&
-              (offset + length >
-               bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize())) {
-            bufs_[second].ClearBuffer();
+  BufferInfo* buf = GetFirstBuffer();
+
+  // In case buffers do not align, reset next buffer if requested data needs
+  // to be read in that buffer.
+  if (NumBuffersAllocated() > 1) {
+    BufferInfo* next_buf = bufs_[1];
+    if (!next_buf->async_read_in_progress_ && !buf->async_read_in_progress_ &&
+        DoesBufferContainData(buf)) {
+      if (buf->offset_ + buf->buffer_.CurrentSize() != next_buf->offset_) {
+        if (DoesBufferContainData(next_buf) && IsOffsetInBuffer(buf, offset) &&
+            (offset + length > buf->offset_ + buf->buffer_.CurrentSize())) {
+          // Clear all buffers after first.
+          for (size_t i = 1; i < bufs_.size(); ++i) {
+            bufs_[i]->ClearBuffer();
           }
-        }
-      } else {
-        if (DoesBufferContainData(second) &&
-            !IsOffsetInBuffer(offset, second)) {
-          bufs_[second].ClearBuffer();
+          FreeEmptyBuffers();
         }
       }
     }
   }
-
-  // If data starts from second buffer, make it curr_. Second buffer can be
-  // either partial filled, full or async read is in progress.
-  if (bufs_[second].async_read_in_progress_) {
-    if (IsOffsetInBufferWithAsyncProgress(offset, second)) {
-      curr_ = curr_ ^ 1;
-    }
-  } else {
-    if (DoesBufferContainData(second) && IsOffsetInBuffer(offset, second)) {
-      assert(bufs_[curr_].async_read_in_progress_ ||
-             bufs_[curr_].buffer_.CurrentSize() == 0);
-      curr_ = curr_ ^ 1;
-    }
-  }
 }
 
-void FilePrefetchBuffer::PollAndUpdateBuffersIfNeeded(uint64_t offset,
-                                                      size_t length) {
-  if (bufs_[curr_].async_read_in_progress_ && fs_ != nullptr) {
-    if (bufs_[curr_].io_handle_ != nullptr) {
+void FilePrefetchBuffer::PollIfNeeded(uint64_t /*offset*/, size_t /*length*/) {
+  BufferInfo* buf = GetFirstBuffer();
+
+  if (buf->async_read_in_progress_ && fs_ != nullptr) {
+    if (buf->io_handle_ != nullptr) {
       // Wait for prefetch data to complete.
       // No mutex is needed as async_read_in_progress behaves as mutex and is
       // updated by main thread only.
       std::vector<void*> handles;
-      handles.emplace_back(bufs_[curr_].io_handle_);
+      handles.emplace_back(buf->io_handle_);
       StopWatch sw(clock_, stats_, POLL_WAIT_MICROS);
       fs_->Poll(handles, 1).PermitUncheckedError();
     }
 
     // Reset and Release io_handle after the Poll API as request has been
     // completed.
-    DestroyAndClearIOHandle(curr_);
+    DestroyAndClearIOHandle(buf);
   }
-  UpdateBuffersIfNeeded(offset, length);
 }
 
 // ReadAheadSizeTuning API calls readaheadsize_cb_
@@ -347,18 +323,18 @@ void FilePrefetchBuffer::PollAndUpdateBuffersIfNeeded(uint64_t offset,
 //
 // Arguments -
 // read_curr_block   :   True if this call was due to miss in the cache and
-//                         FilePrefetchBuffer wants to read that block
-//                         synchronously.
+//                       FilePrefetchBuffer wants to read that block
+//                       synchronously.
 //                       False if current call is to prefetch additional data in
-//                         extra buffers through ReadAsync API.
+//                       extra buffers through ReadAsync API.
 // prev_buf_end_offset : End offset of the previous buffer. It's used in case
 //                       of ReadAsync to make sure it doesn't read anything from
 //                       previous buffer which is already prefetched.
 void FilePrefetchBuffer::ReadAheadSizeTuning(
-    bool read_curr_block, bool refit_tail, uint64_t prev_buf_end_offset,
-    uint32_t index, size_t alignment, size_t length, size_t readahead_size,
-    uint64_t& start_offset, uint64_t& end_offset, size_t& read_len,
-    uint64_t& chunk_len) {
+    BufferInfo* buf, bool read_curr_block, bool refit_tail,
+    uint64_t prev_buf_end_offset, size_t alignment, size_t length,
+    size_t readahead_size, uint64_t& start_offset, uint64_t& end_offset,
+    size_t& read_len, uint64_t& chunk_len) {
   uint64_t updated_start_offset = Rounddown(start_offset, alignment);
   uint64_t updated_end_offset =
       Roundup(start_offset + length + readahead_size, alignment);
@@ -406,116 +382,130 @@ void FilePrefetchBuffer::ReadAheadSizeTuning(
 
   uint64_t roundup_len = end_offset - start_offset;
 
-  CalculateOffsetAndLen(alignment, start_offset, roundup_len, index, refit_tail,
+  CalculateOffsetAndLen(buf, alignment, start_offset, roundup_len, refit_tail,
                         chunk_len);
   assert(roundup_len >= chunk_len);
 
   // Update the buffer offset.
-  bufs_[index].offset_ = start_offset;
+  buf->offset_ = start_offset;
   // Update the initial end offset of this buffer which will be the starting
   // offset of next prefetch.
-  bufs_[index].initial_end_offset_ = initial_end_offset;
+  buf->initial_end_offset_ = initial_end_offset;
   read_len = static_cast<size_t>(roundup_len - chunk_len);
 
   UpdateReadAheadTrimmedStat((initial_end_offset - initial_start_offset),
                              (end_offset - start_offset));
 }
 
+// If data is overlapping between two buffers then during this call:
+//   - data from first buffer is copied into overlapping buffer,
+//   - first is removed from bufs_ and freed so that it can be used for async
+//     prefetching of further data.
 Status FilePrefetchBuffer::HandleOverlappingData(
     const IOOptions& opts, RandomAccessFileReader* reader, uint64_t offset,
-    size_t length, size_t readahead_size, bool& copy_to_third_buffer,
+    size_t length, size_t readahead_size, bool& copy_to_overlap_buffer,
     uint64_t& tmp_offset, size_t& tmp_length) {
+  // No Overlapping of data between 2 buffers.
+  if (IsBufferQueueEmpty() || NumBuffersAllocated() == 1) {
+    return Status::OK();
+  }
+
   Status s;
   size_t alignment = reader->file()->GetRequiredBufferAlignment();
-  uint32_t second;
+
+  BufferInfo* buf = GetFirstBuffer();
 
   // Check if the first buffer has the required offset and the async read is
   // still in progress. This should only happen if a prefetch was initiated
   // by Seek, but the next access is at another offset.
-  if (bufs_[curr_].async_read_in_progress_ &&
-      IsOffsetInBufferWithAsyncProgress(offset, curr_)) {
-    PollAndUpdateBuffersIfNeeded(offset, length);
+  if (buf->async_read_in_progress_ &&
+      IsOffsetInBufferWithAsyncProgress(buf, offset)) {
+    PollIfNeeded(offset, length);
   }
-  second = curr_ ^ 1;
 
-  // If data is overlapping over two buffers, copy the data from curr_ and
-  // call ReadAsync on curr_.
-  if (!bufs_[curr_].async_read_in_progress_ && DoesBufferContainData(curr_) &&
-      IsOffsetInBuffer(offset, curr_) &&
-      (/*Data extends over curr_ buffer and second buffer either has data or in
+  BufferInfo* next_buf = bufs_[1];
+
+  // If data is overlapping over two buffers, copy the data from front and
+  // call ReadAsync on freed buffer.
+  if (!buf->async_read_in_progress_ && DoesBufferContainData(buf) &&
+      IsOffsetInBuffer(buf, offset) &&
+      (/*Data extends over two buffers and second buffer either has data or in
          process of population=*/
-       (offset + length > bufs_[second].offset_) &&
-       (bufs_[second].async_read_in_progress_ ||
-        DoesBufferContainData(second)))) {
-    // Allocate new buffer to third buffer;
-    bufs_[2].ClearBuffer();
-    bufs_[2].buffer_.Alignment(alignment);
-    bufs_[2].buffer_.AllocateNewBuffer(length);
-    bufs_[2].offset_ = offset;
-    copy_to_third_buffer = true;
+       (offset + length > next_buf->offset_) &&
+       (next_buf->async_read_in_progress_ ||
+        DoesBufferContainData(next_buf)))) {
+    // Allocate new buffer to overlap_bufs_.
+    BufferInfo* overlap_buf = overlap_bufs_.front();
+    overlap_buf->ClearBuffer();
+    overlap_buf->buffer_.Alignment(alignment);
+    overlap_buf->buffer_.AllocateNewBuffer(length);
+    overlap_buf->offset_ = offset;
+    copy_to_overlap_buffer = true;
 
-    CopyDataToBuffer(curr_, tmp_offset, tmp_length);
+    size_t initial_buf_size = overlap_bufs_.front()->buffer_.CurrentSize();
+    CopyDataToBuffer(buf, tmp_offset, tmp_length);
+    UpdateStats(
+        /*found_in_buffer=*/false,
+        overlap_bufs_.front()->buffer_.CurrentSize() - initial_buf_size);
 
-    // Call async prefetching on curr_ since data has been consumed in curr_
-    // only if requested data lies within second buffer.
-    size_t second_size = bufs_[second].async_read_in_progress_
-                             ? bufs_[second].async_req_len_
-                             : bufs_[second].buffer_.CurrentSize();
-    uint64_t start_offset = bufs_[second].initial_end_offset_;
+    // Call async prefetching on freed buffer since data has been consumed
+    // only if requested data lies within next buffer.
+    size_t second_size = next_buf->async_read_in_progress_
+                             ? next_buf->async_req_len_
+                             : next_buf->buffer_.CurrentSize();
+    uint64_t start_offset = next_buf->initial_end_offset_;
     // Second buffer might be out of bound if first buffer already prefetched
     // that data.
-    if (tmp_offset + tmp_length <= bufs_[second].offset_ + second_size) {
+
+    if (tmp_offset + tmp_length <= next_buf->offset_ + second_size) {
+      AllocateBuffer();
+      BufferInfo* new_buf = GetLastBuffer();
       size_t read_len = 0;
       uint64_t end_offset = start_offset, chunk_len = 0;
 
-      ReadAheadSizeTuning(/*read_curr_block=*/false, /*refit_tail=*/false,
-                          bufs_[second].offset_ + second_size, curr_, alignment,
+      ReadAheadSizeTuning(new_buf, /*read_curr_block=*/false,
+                          /*refit_tail=*/false, next_buf->offset_ + second_size,
+                          alignment,
                           /*length=*/0, readahead_size, start_offset,
                           end_offset, read_len, chunk_len);
       if (read_len > 0) {
-        s = ReadAsync(opts, reader, read_len, start_offset, curr_);
+        s = ReadAsync(new_buf, opts, reader, read_len, start_offset);
         if (!s.ok()) {
-          DestroyAndClearIOHandle(curr_);
-          bufs_[curr_].ClearBuffer();
+          DestroyAndClearIOHandle(new_buf);
+          FreeLastBuffer();
           return s;
         }
       }
     }
-    curr_ = curr_ ^ 1;
   }
   return s;
 }
+
 // If async_io is enabled in case of sequential reads, PrefetchAsyncInternal is
-// called. When buffers are switched, we clear the curr_ buffer as we assume the
+// called. When data is outdated, we clear the first buffer and free it as the
 // data has been consumed because of sequential reads.
-// Data in buffers will always be sequential with curr_ following second and
-// not vice versa.
 //
 // Scenarios for prefetching asynchronously:
-// Case1: If both buffers are empty, prefetch n + readahead_size_/2 bytes
-//        synchronously in curr_ and prefetch readahead_size_/2 async in second
-//        buffer.
-// Case2: If second buffer has partial or full data, make it current and
-//        prefetch readahead_size_/2 async in second buffer. In case of
-//        partial data, prefetch remaining bytes from size n synchronously to
-//        fulfill the requested bytes request.
-// Case3: If curr_ has partial data, prefetch remaining bytes from size n
-//        synchronously in curr_ to fulfill the requested bytes request and
-//        prefetch readahead_size_/2 bytes async in second buffer.
-// Case4: (Special case) If data is in both buffers, copy requested data from
-//        curr_, send async request on curr_, wait for poll to fill second
-//        buffer (if any), and copy remaining data from second buffer to third
-//        buffer.
-Status FilePrefetchBuffer::PrefetchAsyncInternal(const IOOptions& opts,
-                                                 RandomAccessFileReader* reader,
-                                                 uint64_t offset, size_t length,
-                                                 size_t readahead_size,
-                                                 bool& copy_to_third_buffer) {
+// Case1: If all buffers are in free_bufs_, prefetch n + readahead_size_/2 bytes
+//        synchronously in first buffer and prefetch readahead_size_/2 async in
+//        remaining buffers (num_buffers_ -1 ).
+// Case2: If first buffer has partial data, prefetch readahead_size_/2 async in
+//        remaining buffers. In case of partial data, prefetch remaining bytes
+//        from size n synchronously to fulfill the requested bytes request.
+// Case5: (Special case) If data is overlapping in two buffers, copy requested
+//        data from first, free that buffer to send for async request, wait for
+//        poll to fill next buffer (if any), and copy remaining data from that
+//        buffer to overlap buffer.
+Status FilePrefetchBuffer::PrefetchInternal(const IOOptions& opts,
+                                            RandomAccessFileReader* reader,
+                                            uint64_t offset, size_t length,
+                                            size_t readahead_size,
+                                            bool& copy_to_overlap_buffer) {
   if (!enable_) {
     return Status::OK();
   }
 
-  TEST_SYNC_POINT("FilePrefetchBuffer::PrefetchAsyncInternal:Start");
+  TEST_SYNC_POINT("FilePrefetchBuffer::Prefetch:Start");
 
   size_t alignment = reader->file()->GetRequiredBufferAlignment();
   Status s;
@@ -523,368 +513,282 @@ Status FilePrefetchBuffer::PrefetchAsyncInternal(const IOOptions& opts,
   size_t tmp_length = length;
   size_t original_length = length;
 
-  // 1. Abort IO and swap buffers if needed to point curr_ to first buffer with
-  // data.
+  // Abort outdated IO.
   if (!explicit_prefetch_submitted_) {
-    AbortIOIfNeeded(offset);
+    AbortOutdatedIO(offset);
   }
-  UpdateBuffersIfNeeded(offset, length);
+  ClearOutdatedData(offset, length);
 
-  // 2. Handle overlapping data over two buffers. If data is overlapping then
-  //    during this call:
-  //   - data from curr_ is copied into third buffer,
-  //   - curr_ is send for async prefetching of further data if second buffer
-  //     contains remaining requested data or in progress for async prefetch,
-  //   - switch buffers and curr_ now points to second buffer to copy remaining
-  //     data.
+  // Handle overlapping data over two buffers.
   s = HandleOverlappingData(opts, reader, offset, length, readahead_size,
-                            copy_to_third_buffer, tmp_offset, tmp_length);
+                            copy_to_overlap_buffer, tmp_offset, tmp_length);
   if (!s.ok()) {
     return s;
   }
 
-  // 3. Call Poll only if data is needed for the second buffer.
-  //    - Return if whole data is in curr_ and second buffer is in progress or
+  AllocateBufferIfEmpty();
+  BufferInfo* buf = GetFirstBuffer();
+
+  // Call Poll only if data is needed for the second buffer.
+  //    - Return if whole data is in first and second buffer is in progress or
   //      already full.
   //    - If second buffer is empty, it will go for ReadAsync for second buffer.
-  if (!bufs_[curr_].async_read_in_progress_ && DoesBufferContainData(curr_) &&
-      IsDataBlockInBuffer(offset, length, curr_)) {
-    // Whole data is in curr_.
-    UpdateBuffersIfNeeded(offset, length);
-    if (!IsSecondBuffEligibleForPrefetching()) {
+  if (!buf->async_read_in_progress_ && DoesBufferContainData(buf) &&
+      IsDataBlockInBuffer(buf, offset, length)) {
+    // Whole data is in buffer.
+    if (!IsEligibleForFurtherPrefetching()) {
       UpdateStats(/*found_in_buffer=*/true, original_length);
       return s;
     }
   } else {
-    // After poll request, curr_ might be empty because of IOError in
-    // callback while reading or may contain required data.
-    PollAndUpdateBuffersIfNeeded(offset, length);
+    // NOTE - After this poll request, first buffer might be empty because of
+    // IOError in callback while reading or it may contains the required data.
+    PollIfNeeded(offset, length);
   }
 
-  if (copy_to_third_buffer) {
+  if (copy_to_overlap_buffer) {
     offset = tmp_offset;
     length = tmp_length;
   }
 
-  // 4. After polling and swapping buffers, if all the requested bytes are in
-  // curr_, it will only go for async prefetching.
-  // copy_to_third_buffer is a special case so it will be handled separately.
-  if (!copy_to_third_buffer && DoesBufferContainData(curr_) &&
-      IsDataBlockInBuffer(offset, length, curr_)) {
-    offset += length;
-    length = 0;
+  // After polling, if all the requested bytes are in first buffer, it will only
+  // go for async prefetching.
+  if (DoesBufferContainData(buf)) {
+    if (copy_to_overlap_buffer) {
+      // Data is overlapping i.e. some of the data has been copied to overlap
+      // buffer and remaining will be updated below.
+      size_t initial_buf_size = overlap_bufs_.front()->buffer_.CurrentSize();
+      CopyDataToBuffer(buf, offset, length);
+      UpdateStats(
+          /*found_in_buffer=*/false,
+          overlap_bufs_.front()->buffer_.CurrentSize() - initial_buf_size);
 
-    // Since async request was submitted directly by calling PrefetchAsync in
-    // last call, we don't need to prefetch further as this call is to poll
-    // the data submitted in previous call.
-    if (explicit_prefetch_submitted_) {
-      return s;
-    }
-    if (!IsSecondBuffEligibleForPrefetching()) {
-      UpdateStats(/*found_in_buffer=*/true, original_length);
-      return s;
-    }
-  }
-
-  uint32_t second = curr_ ^ 1;
-  assert(!bufs_[curr_].async_read_in_progress_);
-
-  // In case because of some IOError curr_ got empty, abort IO for second as
-  // well. Otherwise data might not align if more data needs to be read in curr_
-  // which might overlap with second buffer.
-  if (!DoesBufferContainData(curr_) && bufs_[second].async_read_in_progress_) {
-    if (bufs_[second].io_handle_ != nullptr) {
-      std::vector<void*> handles;
-      handles.emplace_back(bufs_[second].io_handle_);
-      {
-        StopWatch sw(clock_, stats_, ASYNC_PREFETCH_ABORT_MICROS);
-        Status status = fs_->AbortIO(handles);
-        assert(status.ok());
+      // Length == 0: All the requested data has been copied to overlap buffer
+      // and it has already gone for async prefetching. It can return without
+      // doing anything further. Length > 0: More data needs to be consumed so
+      // it will continue async and sync prefetching and copy the remaining data
+      // to overlap buffer in the end.
+      if (length == 0) {
+        UpdateStats(/*found_in_buffer=*/true, length);
+        return s;
+      }
+    } else {
+      if (IsDataBlockInBuffer(buf, offset, length)) {
+        offset += length;
+        length = 0;
+        // Since async request was submitted directly by calling PrefetchAsync
+        // in last call, we don't need to prefetch further as this call is to
+        // poll the data submitted in previous call.
+        if (explicit_prefetch_submitted_) {
+          return s;
+        }
+        if (!IsEligibleForFurtherPrefetching()) {
+          UpdateStats(/*found_in_buffer=*/true, original_length);
+          return s;
+        }
       }
     }
-    DestroyAndClearIOHandle(second);
-    bufs_[second].ClearBuffer();
   }
 
-  // 5. Data is overlapping i.e. some of the data has been copied to third
-  // buffer and remaining will be updated below.
-  if (copy_to_third_buffer && DoesBufferContainData(curr_)) {
-    CopyDataToBuffer(curr_, offset, length);
+  AllocateBufferIfEmpty();
+  buf = GetFirstBuffer();
 
-    // Length == 0: All the requested data has been copied to third buffer and
-    // it has already gone for async prefetching. It can return without doing
-    // anything further.
-    // Length > 0: More data needs to be consumed so it will continue async
-    // and sync prefetching and copy the remaining data to third buffer in the
-    // end.
-    if (length == 0) {
-      UpdateStats(/*found_in_buffer=*/true, original_length);
-      return s;
+  assert(!buf->async_read_in_progress_);
+
+  // In case because of some IOError first buffer got empty, abort IO for all
+  // buffers as well. Otherwise data might not align if more data needs to be
+  // read in first buffer which might overlap with second buffer.
+  if (!DoesBufferContainData(buf)) {
+    std::vector<void*> handles;
+    if (NumBuffersAllocated() > 1) {
+      for (auto& _buf : bufs_) {
+        if (_buf->async_read_in_progress_) {
+          handles.emplace_back(_buf->io_handle_);
+        }
+      }
     }
+    if (!handles.empty()) {
+      StopWatch sw(clock_, stats_, ASYNC_PREFETCH_ABORT_MICROS);
+      s = fs_->AbortIO(handles);
+      assert(s.ok());
+    }
+
+    for (auto& _buf : bufs_) {
+      if (_buf->async_read_in_progress_) {
+        DestroyAndClearIOHandle(_buf);
+        _buf->async_read_in_progress_ = false;
+        _buf->ClearBuffer();
+      }
+    }
+    FreeEmptyBuffers();
   }
 
-  // 6. Go for ReadAsync and Read (if needed).
-  assert(!bufs_[second].async_read_in_progress_ &&
-         !DoesBufferContainData(second));
+  AllocateBufferIfEmpty();
+  buf = GetFirstBuffer();
 
-  // offset and size alignment for curr_ buffer with synchronous prefetching
+  // Go for ReadAsync and Read (if needed).
+  // offset and size alignment for first buffer with synchronous prefetching
   uint64_t start_offset1 = offset, end_offset1 = 0, chunk_len1 = 0;
   size_t read_len1 = 0;
 
   // For length == 0, skip the synchronous prefetching. read_len1 will be 0.
   if (length > 0) {
-    ReadAheadSizeTuning(/*read_curr_block=*/true, /*refit_tail=*/false,
-                        start_offset1, curr_, alignment, length, readahead_size,
+    ReadAheadSizeTuning(buf, /*read_curr_block=*/true, /*refit_tail*/
+                        true, start_offset1, alignment, length, readahead_size,
                         start_offset1, end_offset1, read_len1, chunk_len1);
-    UpdateStats(/*found_in_buffer=*/false,
-                /*length_found=*/original_length - length);
+    UpdateStats(/*found_in_buffer=*/false, chunk_len1);
   } else {
-    end_offset1 = bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize();
     UpdateStats(/*found_in_buffer=*/true, original_length);
   }
 
-  // Prefetch in second buffer only if readahead_size > 0.
+  // Prefetch in remaining buffer only if readahead_size > 0.
   if (readahead_size > 0) {
-    // offset and size alignment for second buffer for asynchronous
-    // prefetching.
-    uint64_t start_offset2 = bufs_[curr_].initial_end_offset_;
-
-      // Find updated readahead size after tuning
-      size_t read_len2 = 0;
-      uint64_t end_offset2 = start_offset2, chunk_len2 = 0;
-      ReadAheadSizeTuning(/*read_curr_block=*/false, /*refit_tail=*/false,
-                          /*prev_buf_end_offset=*/end_offset1, second,
-                          alignment,
-                          /*length=*/0, readahead_size, start_offset2,
-                          end_offset2, read_len2, chunk_len2);
-      if (read_len2 > 0) {
-        s = ReadAsync(opts, reader, read_len2, start_offset2, second);
-        if (!s.ok()) {
-          DestroyAndClearIOHandle(second);
-          bufs_[second].ClearBuffer();
-          return s;
-        }
-    }
-  }
-
-  if (read_len1 > 0) {
-    s = Read(opts, reader, read_len1, chunk_len1, start_offset1, curr_);
+    s = PrefetchRemBuffers(opts, reader, end_offset1, alignment,
+                           readahead_size);
     if (!s.ok()) {
-      if (bufs_[second].io_handle_ != nullptr) {
-        std::vector<void*> handles;
-        handles.emplace_back(bufs_[second].io_handle_);
-        {
-          StopWatch sw(clock_, stats_, ASYNC_PREFETCH_ABORT_MICROS);
-          Status status = fs_->AbortIO(handles);
-          assert(status.ok());
-        }
-      }
-      DestroyAndClearIOHandle(second);
-      bufs_[second].ClearBuffer();
-      bufs_[curr_].ClearBuffer();
       return s;
     }
   }
 
-  // Copy remaining requested bytes to third_buffer.
-  if (copy_to_third_buffer && length > 0) {
-    CopyDataToBuffer(curr_, offset, length);
-  }
-  return s;
-}
-
-bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
-                                          RandomAccessFileReader* reader,
-                                          uint64_t offset, size_t n,
-                                          Slice* result, Status* status,
-                                          bool for_compaction /* = false */) {
-  bool ret = TryReadFromCacheUntracked(opts, reader, offset, n, result, status,
-                                       for_compaction);
-  if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail && enable_) {
-    if (ret) {
-      RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_HIT);
-    } else {
-      RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
-    }
-  }
-  return ret;
-}
-
-bool FilePrefetchBuffer::TryReadFromCacheUntracked(
-    const IOOptions& opts, RandomAccessFileReader* reader, uint64_t offset,
-    size_t n, Slice* result, Status* status,
-    bool for_compaction /* = false */) {
-  if (track_min_offset_ && offset < min_offset_read_) {
-    min_offset_read_ = static_cast<size_t>(offset);
-  }
-  if (!enable_ || (offset < bufs_[curr_].offset_)) {
-    return false;
-  }
-
-  // If the buffer contains only a few of the requested bytes:
-  //    If readahead is enabled: prefetch the remaining bytes + readahead bytes
-  //        and satisfy the request.
-  //    If readahead is not enabled: return false.
-  TEST_SYNC_POINT_CALLBACK("FilePrefetchBuffer::TryReadFromCache",
-                           &readahead_size_);
-  if (offset + n > bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize()) {
-    if (readahead_size_ > 0) {
-      Status s;
-      assert(reader != nullptr);
-      assert(max_readahead_size_ >= readahead_size_);
-      if (for_compaction) {
-        s = Prefetch(opts, reader, offset, std::max(n, readahead_size_));
-      } else {
-        if (IsOffsetInBuffer(offset, curr_)) {
-          RecordTick(stats_, PREFETCH_BYTES_USEFUL,
-                     bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize() -
-                         offset);
-        }
-        if (implicit_auto_readahead_) {
-          if (!IsEligibleForPrefetch(offset, n)) {
-            // Ignore status as Prefetch is not called.
-            s.PermitUncheckedError();
-            return false;
-          }
-        }
-        s = Prefetch(opts, reader, offset, n + readahead_size_);
-      }
-      if (!s.ok()) {
-        if (status) {
-          *status = s;
-        }
-#ifndef NDEBUG
-        IGNORE_STATUS_IF_ERROR(s);
-#endif
-        return false;
-      }
-      readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
-    } else {
-      return false;
-    }
-  } else if (!for_compaction) {
-    RecordTick(stats_, PREFETCH_HITS);
-    RecordTick(stats_, PREFETCH_BYTES_USEFUL, n);
-  }
-  UpdateReadPattern(offset, n, false /*decrease_readaheadsize*/);
-
-  uint64_t offset_in_buffer = offset - bufs_[curr_].offset_;
-  *result = Slice(bufs_[curr_].buffer_.BufferStart() + offset_in_buffer, n);
-  return true;
-}
-
-bool FilePrefetchBuffer::TryReadFromCacheAsync(const IOOptions& opts,
-                                               RandomAccessFileReader* reader,
-                                               uint64_t offset, size_t n,
-                                               Slice* result, Status* status) {
-  bool ret =
-      TryReadFromCacheAsyncUntracked(opts, reader, offset, n, result, status);
-  if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail && enable_) {
-    if (ret) {
-      RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_HIT);
-    } else {
-      RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
-    }
-  }
-  return ret;
-}
-
-bool FilePrefetchBuffer::TryReadFromCacheAsyncUntracked(
-    const IOOptions& opts, RandomAccessFileReader* reader, uint64_t offset,
-    size_t n, Slice* result, Status* status) {
-  if (track_min_offset_ && offset < min_offset_read_) {
-    min_offset_read_ = static_cast<size_t>(offset);
-  }
-
-  if (!enable_) {
-    return false;
-  }
-
-  if (explicit_prefetch_submitted_) {
-    // explicit_prefetch_submitted_ is special case where it expects request
-    // submitted in PrefetchAsync should match with this request. Otherwise
-    // buffers will be outdated.
-    // Random offset called. So abort the IOs.
-    if (prev_offset_ != offset) {
+  if (read_len1 > 0) {
+    s = Read(buf, opts, reader, read_len1, chunk_len1, start_offset1);
+    if (!s.ok()) {
       AbortAllIOs();
-      bufs_[curr_].ClearBuffer();
-      bufs_[curr_ ^ 1].ClearBuffer();
-      explicit_prefetch_submitted_ = false;
-      return false;
+      FreeAllBuffers();
+      return s;
     }
   }
 
-  if (!explicit_prefetch_submitted_ && offset < bufs_[curr_].offset_) {
-    return false;
+  // Copy remaining requested bytes to overlap_buffer. No need to update stats
+  // as data is prefetched during this call.
+  if (copy_to_overlap_buffer && length > 0) {
+    CopyDataToBuffer(buf, offset, length);
+  }
+    return s;
   }
 
-  bool prefetched = false;
-  bool copy_to_third_buffer = false;
-  // If the buffer contains only a few of the requested bytes:
-  //    If readahead is enabled: prefetch the remaining bytes + readahead bytes
-  //        and satisfy the request.
-  //    If readahead is not enabled: return false.
-  TEST_SYNC_POINT_CALLBACK("FilePrefetchBuffer::TryReadFromCache",
-                           &readahead_size_);
-
-  if (explicit_prefetch_submitted_ ||
-      (bufs_[curr_].async_read_in_progress_ ||
-       offset + n >
-           bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize())) {
-    // In case readahead_size is trimmed (=0), we still want to poll the data
-    // submitted with explicit_prefetch_submitted_=true.
-    if (readahead_size_ > 0 || explicit_prefetch_submitted_) {
-      Status s;
-      assert(reader != nullptr);
-      assert(max_readahead_size_ >= readahead_size_);
-
-      if (implicit_auto_readahead_) {
-        if (!IsEligibleForPrefetch(offset, n)) {
-          // Ignore status as Prefetch is not called.
-          s.PermitUncheckedError();
-          return false;
-        }
+  bool FilePrefetchBuffer::TryReadFromCache(
+      const IOOptions& opts, RandomAccessFileReader* reader, uint64_t offset,
+      size_t n, Slice* result, Status* status, bool for_compaction) {
+    bool ret = TryReadFromCacheUntracked(opts, reader, offset, n, result,
+                                         status, for_compaction);
+    if (usage_ == FilePrefetchBufferUsage::kTableOpenPrefetchTail && enable_) {
+      if (ret) {
+        RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_HIT);
+      } else {
+        RecordTick(stats_, TABLE_OPEN_PREFETCH_TAIL_MISS);
       }
+    }
+    return ret;
+  }
 
-      // Prefetch n + readahead_size_/2 synchronously as remaining
-      // readahead_size_/2 will be prefetched asynchronously.
-      s = PrefetchAsyncInternal(opts, reader, offset, n, readahead_size_ / 2,
-                                copy_to_third_buffer);
-      explicit_prefetch_submitted_ = false;
-      if (!s.ok()) {
-        if (status) {
-          *status = s;
+  bool FilePrefetchBuffer::TryReadFromCacheUntracked(
+      const IOOptions& opts, RandomAccessFileReader* reader, uint64_t offset,
+      size_t n, Slice* result, Status* status, bool for_compaction) {
+    if (track_min_offset_ && offset < min_offset_read_) {
+      min_offset_read_ = static_cast<size_t>(offset);
+    }
+
+    if (!enable_) {
+      return false;
+    }
+
+    if (explicit_prefetch_submitted_) {
+      // explicit_prefetch_submitted_ is special case where it expects request
+      // submitted in PrefetchAsync should match with this request. Otherwise
+      // buffers will be outdated.
+      // Random offset called. So abort the IOs.
+      if (prev_offset_ != offset) {
+        AbortAllIOs();
+        FreeAllBuffers();
+        explicit_prefetch_submitted_ = false;
+        return false;
+      }
+    }
+
+    AllocateBufferIfEmpty();
+    BufferInfo* buf = GetFirstBuffer();
+
+    if (!explicit_prefetch_submitted_ && offset < buf->offset_) {
+      return false;
+    }
+
+    bool prefetched = false;
+    bool copy_to_overlap_buffer = false;
+    // If the buffer contains only a few of the requested bytes:
+    //    If readahead is enabled: prefetch the remaining bytes + readahead
+    //    bytes
+    //        and satisfy the request.
+    //    If readahead is not enabled: return false.
+    TEST_SYNC_POINT_CALLBACK("FilePrefetchBuffer::TryReadFromCache",
+                             &readahead_size_);
+
+    if (explicit_prefetch_submitted_ ||
+        (buf->async_read_in_progress_ ||
+         offset + n > buf->offset_ + buf->buffer_.CurrentSize())) {
+      // In case readahead_size is trimmed (=0), we still want to poll the data
+      // submitted with explicit_prefetch_submitted_=true.
+      if (readahead_size_ > 0 || explicit_prefetch_submitted_) {
+        Status s;
+        assert(reader != nullptr);
+        assert(max_readahead_size_ >= readahead_size_);
+
+        if (for_compaction) {
+          s = Prefetch(opts, reader, offset, std::max(n, readahead_size_));
+        } else {
+          if (implicit_auto_readahead_) {
+            if (!IsEligibleForPrefetch(offset, n)) {
+              // Ignore status as Prefetch is not called.
+              s.PermitUncheckedError();
+              return false;
+            }
+          }
+
+          // Prefetch n + readahead_size_/2 synchronously as remaining
+          // readahead_size_/2 will be prefetched asynchronously if num_buffers_
+          // > 1.
+          s = PrefetchInternal(
+              opts, reader, offset, n,
+              (num_buffers_ > 1 ? readahead_size_ / 2 : readahead_size_),
+              copy_to_overlap_buffer);
+          explicit_prefetch_submitted_ = false;
         }
+
+        if (!s.ok()) {
+          if (status) {
+            *status = s;
+          }
 #ifndef NDEBUG
         IGNORE_STATUS_IF_ERROR(s);
 #endif
         return false;
-      }
+        }
       prefetched = explicit_prefetch_submitted_ ? false : true;
-    } else {
-      return false;
+      } else {
+        return false;
+      }
+    } else if (!for_compaction) {
+      UpdateStats(/*found_in_buffer=*/true, n);
     }
-  } else {
-    UpdateStats(/*found_in_buffer=*/true, n);
-  }
 
-  UpdateReadPattern(offset, n, false /*decrease_readaheadsize*/);
+    UpdateReadPattern(offset, n, /*decrease_readaheadsize=*/false);
 
-  uint32_t index = curr_;
-  if (copy_to_third_buffer) {
-    index = 2;
+    buf = GetFirstBuffer();
+    if (copy_to_overlap_buffer) {
+      buf = overlap_bufs_.front();
+    }
+    uint64_t offset_in_buffer = offset - buf->offset_;
+    *result = Slice(buf->buffer_.BufferStart() + offset_in_buffer, n);
+    if (prefetched) {
+      readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
+    }
+    return true;
   }
-  uint64_t offset_in_buffer = offset - bufs_[index].offset_;
-  *result = Slice(bufs_[index].buffer_.BufferStart() + offset_in_buffer, n);
-  if (prefetched) {
-    readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
-  }
-  return true;
-}
 
 void FilePrefetchBuffer::PrefetchAsyncCallback(const FSReadRequest& req,
                                                void* cb_arg) {
-  uint32_t index = *(static_cast<uint32_t*>(cb_arg));
+  BufferInfo* buf = static_cast<BufferInfo*>(cb_arg);
+
 #ifndef NDEBUG
   if (req.result.size() < req.len) {
     // Fake an IO error to force db_stress fault injection to ignore
@@ -896,18 +800,18 @@ void FilePrefetchBuffer::PrefetchAsyncCallback(const FSReadRequest& req,
 
   if (req.status.ok()) {
     if (req.offset + req.result.size() <=
-        bufs_[index].offset_ + bufs_[index].buffer_.CurrentSize()) {
+        buf->offset_ + buf->buffer_.CurrentSize()) {
       // All requested bytes are already in the buffer or no data is read
       // because of EOF. So no need to update.
       return;
     }
-    if (req.offset < bufs_[index].offset_) {
+    if (req.offset < buf->offset_) {
       // Next block to be read has changed (Recent read was not a sequential
       // read). So ignore this read.
       return;
     }
-    size_t current_size = bufs_[index].buffer_.CurrentSize();
-    bufs_[index].buffer_.Size(current_size + req.result.size());
+    size_t current_size = buf->buffer_.CurrentSize();
+    buf->buffer_.Size(current_size + req.result.size());
   }
 }
 
@@ -929,54 +833,55 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   if (readahead_size_ > 0 &&
       (!implicit_auto_readahead_ ||
        num_file_reads_ >= num_file_reads_for_auto_readahead_)) {
-      is_eligible_for_prefetching = true;
+    is_eligible_for_prefetching = true;
   }
 
-  // 1. Cancel any pending async read to make code simpler as buffers can be out
+  // Cancel any pending async read to make code simpler as buffers can be out
   // of sync.
   AbortAllIOs();
-
-  // 2. Clear outdated data.
-  UpdateBuffersIfNeeded(offset, n);
-  uint32_t second = curr_ ^ 1;
+  ClearOutdatedData(offset, n);
 
   // - Since PrefetchAsync can be called on non sequential reads. So offset can
-  //   be less than curr_ buffers' offset. In that case it clears both
+  //   be less than first buffers' offset. In that case it clears all
   //   buffers.
-  // - In case of tuning of readahead_size, on Reseek, we have to clear both
+  // - In case of tuning of readahead_size, on Reseek, we have to clear all
   //   buffers otherwise, we may end up with inconsistent BlockHandles in queue
   //   and data in buffer.
-  if (readaheadsize_cb_ != nullptr ||
-      (DoesBufferContainData(curr_) && !IsOffsetInBuffer(offset, curr_))) {
-    bufs_[curr_].ClearBuffer();
-    bufs_[second].ClearBuffer();
+  if (!IsBufferQueueEmpty()) {
+    BufferInfo* buf = GetFirstBuffer();
+    if (readaheadsize_cb_ != nullptr || !IsOffsetInBuffer(buf, offset)) {
+      FreeAllBuffers();
+    }
   }
 
   UpdateReadPattern(offset, n, /*decrease_readaheadsize=*/false);
 
   bool data_found = false;
 
-  // 3. If curr_ has full data.
-  if (DoesBufferContainData(curr_) && IsDataBlockInBuffer(offset, n, curr_)) {
-    uint64_t offset_in_buffer = offset - bufs_[curr_].offset_;
-    *result = Slice(bufs_[curr_].buffer_.BufferStart() + offset_in_buffer, n);
-    data_found = true;
-    UpdateStats(/*found_in_buffer=*/true, n);
+  // If first buffer has full data.
+  if (!IsBufferQueueEmpty()) {
+    BufferInfo* buf = GetFirstBuffer();
+    if (DoesBufferContainData(buf) && IsDataBlockInBuffer(buf, offset, n)) {
+      uint64_t offset_in_buffer = offset - buf->offset_;
+      *result = Slice(buf->buffer_.BufferStart() + offset_in_buffer, n);
+      data_found = true;
+      UpdateStats(/*found_in_buffer=*/true, n);
 
-    // Update num_file_reads_ as TryReadFromCacheAsync won't be called for
-    // poll and update num_file_reads_ if data is found.
-    num_file_reads_++;
+      // Update num_file_reads_ as TryReadFromCacheAsync won't be called for
+      // poll and update num_file_reads_ if data is found.
+      num_file_reads_++;
 
-    // 3.1 If second also has some data or is not eligible for prefetching,
-    // return.
-    if (!is_eligible_for_prefetching || DoesBufferContainData(second)) {
-      return Status::OK();
+      // If next buffer contains some data or is not eligible for prefetching,
+      // return.
+      if (!is_eligible_for_prefetching || NumBuffersAllocated() > 1) {
+        return Status::OK();
+      }
+    } else {
+      // Partial data in first buffer. Clear it to return continous data in one
+      // buffer.
+      FreeAllBuffers();
     }
-  } else {
-    // Partial data in curr_.
-    bufs_[curr_].ClearBuffer();
   }
-  bufs_[second].ClearBuffer();
 
   std::string msg;
 
@@ -984,73 +889,95 @@ Status FilePrefetchBuffer::PrefetchAsync(const IOOptions& opts,
   size_t alignment = reader->file()->GetRequiredBufferAlignment();
   size_t readahead_size = is_eligible_for_prefetching ? readahead_size_ / 2 : 0;
   size_t offset_to_read = static_cast<size_t>(offset);
-  uint64_t start_offset1 = offset, end_offset1 = 0, start_offset2 = 0,
-           chunk_len1 = 0;
-  size_t read_len1 = 0, read_len2 = 0;
+  uint64_t start_offset1 = offset, end_offset1 = 0, chunk_len1 = 0;
+  size_t read_len1 = 0;
 
-  // - If curr_ is empty.
-  //   - Call async read for full data +  readahead_size on curr_.
-  //   - Call async read for readahead_size on second if eligible.
-  // - If curr_ is filled.
-  //   - readahead_size on second.
+  AllocateBufferIfEmpty();
+  BufferInfo* buf = GetFirstBuffer();
+
+  // - If first buffer is empty.
+  //   - Call async read for full data + readahead_size on first buffer.
+  //   - Call async read for readahead_size on all remaining buffers if
+  //     eligible.
+  // - If first buffer contains data,
+  //   - Call async read for readahead_size on all remaining buffers if
+  //     eligible.
+
   // Calculate length and offsets for reading.
-  if (!DoesBufferContainData(curr_)) {
+  if (!DoesBufferContainData(buf)) {
     uint64_t roundup_len1;
-    // Prefetch full data + readahead_size in curr_.
+    // Prefetch full data + readahead_size in the first buffer.
     if (is_eligible_for_prefetching || reader->use_direct_io()) {
-      ReadAheadSizeTuning(/*read_curr_block=*/true, /*refit_tail=*/false,
-                          /*prev_buf_end_offset=*/start_offset1, curr_,
-                          alignment, n, readahead_size, start_offset1,
-                          end_offset1, read_len1, chunk_len1);
+      ReadAheadSizeTuning(buf, /*read_curr_block=*/true, /*refit_tail=*/false,
+                          /*prev_buf_end_offset=*/start_offset1, alignment, n,
+                          readahead_size, start_offset1, end_offset1, read_len1,
+                          chunk_len1);
     } else {
       // No alignment or extra prefetching.
       start_offset1 = offset_to_read;
       end_offset1 = offset_to_read + n;
       roundup_len1 = end_offset1 - start_offset1;
-      CalculateOffsetAndLen(alignment, start_offset1, roundup_len1, curr_,
-                            false, chunk_len1);
+      CalculateOffsetAndLen(buf, alignment, start_offset1, roundup_len1, false,
+                            chunk_len1);
       assert(chunk_len1 == 0);
       assert(roundup_len1 >= chunk_len1);
       read_len1 = static_cast<size_t>(roundup_len1);
-      bufs_[curr_].offset_ = start_offset1;
+      buf->offset_ = start_offset1;
+    }
+
+    if (read_len1 > 0) {
+      s = ReadAsync(buf, opts, reader, read_len1, start_offset1);
+      if (!s.ok()) {
+        DestroyAndClearIOHandle(buf);
+        FreeLastBuffer();
+        return s;
+      }
+      explicit_prefetch_submitted_ = true;
+      prev_len_ = 0;
     }
   }
 
   if (is_eligible_for_prefetching) {
-    start_offset2 = bufs_[curr_].initial_end_offset_;
-    // Second buffer might be out of bound if first buffer already prefetched
-    // that data.
-
-      uint64_t end_offset2 = start_offset2, chunk_len2 = 0;
-      ReadAheadSizeTuning(/*read_curr_block=*/false, /*refit_tail=*/false,
-                          /*prev_buf_end_offset=*/end_offset1, second,
-                          alignment,
-                          /*length=*/0, readahead_size, start_offset2,
-                          end_offset2, read_len2, chunk_len2);
-  }
-
-  if (read_len1) {
-    s = ReadAsync(opts, reader, read_len1, start_offset1, curr_);
+    s = PrefetchRemBuffers(opts, reader, end_offset1, alignment,
+                           readahead_size);
     if (!s.ok()) {
-      DestroyAndClearIOHandle(curr_);
-      bufs_[curr_].ClearBuffer();
-      return s;
-    }
-    explicit_prefetch_submitted_ = true;
-    prev_len_ = 0;
-  }
-
-  if (read_len2) {
-    TEST_SYNC_POINT("FilePrefetchBuffer::PrefetchAsync:ExtraPrefetching");
-    s = ReadAsync(opts, reader, read_len2, start_offset2, second);
-    if (!s.ok()) {
-      DestroyAndClearIOHandle(second);
-      bufs_[second].ClearBuffer();
       return s;
     }
     readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);
   }
   return (data_found ? Status::OK() : Status::TryAgain());
+}
+
+Status FilePrefetchBuffer::PrefetchRemBuffers(
+    const IOOptions& opts, RandomAccessFileReader* reader, uint64_t end_offset1,
+    size_t alignment, size_t readahead_size) {
+  Status s;
+  while (NumBuffersAllocated() < num_buffers_) {
+    BufferInfo* prev_buf = GetLastBuffer();
+    uint64_t start_offset2 = prev_buf->initial_end_offset_;
+
+    AllocateBuffer();
+    BufferInfo* new_buf = GetLastBuffer();
+
+    uint64_t end_offset2 = start_offset2, chunk_len2 = 0;
+    size_t read_len2 = 0;
+    ReadAheadSizeTuning(
+        new_buf, /*read_curr_block=*/false, /*refit_tail=*/false,
+        /*prev_buf_end_offset=*/end_offset1, alignment, /*length=*/0,
+        readahead_size, start_offset2, end_offset2, read_len2, chunk_len2);
+
+    if (read_len2 > 0) {
+      TEST_SYNC_POINT("FilePrefetchBuffer::PrefetchAsync:ExtraPrefetching");
+      s = ReadAsync(new_buf, opts, reader, read_len2, start_offset2);
+      if (!s.ok()) {
+        DestroyAndClearIOHandle(new_buf);
+        FreeLastBuffer();
+        return s;
+      }
+    }
+    end_offset1 = end_offset2;
+  }
+  return s;
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <deque>
 #include <sstream>
 #include <string>
 
@@ -30,6 +31,31 @@ namespace ROCKSDB_NAMESPACE {
 
 struct IOOptions;
 class RandomAccessFileReader;
+
+struct ReadaheadParams {
+  ReadaheadParams() {}
+
+  // The initial readahead size.
+  size_t initial_readahead_size = 0;
+
+  // The maximum readahead size.
+  // If max_readahead_size > readahead_size, then readahead size will be doubled
+  // on every IO until max_readahead_size is hit. Typically this is set as a
+  // multiple of initial_readahead_size. initial_readahead_size should be
+  // greater than equal to initial_readahead_size.
+  size_t max_readahead_size = 0;
+
+  // If true, Readahead is enabled implicitly by rocksdb
+  // after doing sequential scans for num_file_reads_for_auto_readahead.
+  bool implicit_auto_readahead = false;
+
+  uint64_t num_file_reads = 0;
+  uint64_t num_file_reads_for_auto_readahead = 0;
+
+  // Number of buffers to maintain that contains prefetched data. If num_buffers
+  // > 1 then buffers will be filled asynchronously whenever they get emptied.
+  size_t num_buffers = 1;
+};
 
 struct BufferInfo {
   void ClearBuffer() {
@@ -55,8 +81,9 @@ struct BufferInfo {
 
   IOHandleDeleter del_fn_ = nullptr;
 
-  // pos represents the index of this buffer in vector of BufferInfo.
-  uint32_t pos_ = 0;
+  // pos represents the address of this buffer in queue of BufferInfo. It's
+  // required during async callback to know which buffer to filled.
+  BufferInfo* pos_;
 
   // initial_end_offset is used to keep track of the end offset of the buffer
   // that was originally called. It's helpful in case of autotuning of readahead
@@ -77,68 +104,85 @@ enum class FilePrefetchBufferUsage {
   kUnknown,
 };
 
+// Implementation:
+// FilePrefetchBuffer maintains a dequeu of free buffers (free_bufs_) of size
+// num_buffers_ and bufs_ which contains the prefetched data. Whenever a buffer
+// is consumed or is outdated (w.r.t. to requested offset), that buffer is
+// cleared and returned to free_bufs_.
+//
+// If a buffer is available in free_bufs_, it's moved to bufs_ and is sent for
+// prefetching. num_buffers_ defines how many buffers are maintained that
+// contains prefetched data.
+// If num_buffers_ == 1, it's a sequential read flow. Read API will be called on
+// that one buffer whenever the data is requested and is not in the buffer.
+// If num_buffers_ > 1, then the data is prefetched asynchronosuly in the
+// buffers whenever the data is consumed from the buffers and that buffer is
+// freed.
+// If num_buffers > 1, then requested data can be overlapping between 2 buffers.
+// To return the continuous buffer, overlap_bufs_ is used. The requested data is
+// copied from 2 buffers to the overlap_bufs_ and overlap_bufs_ is returned to
+// the caller.
+
 // FilePrefetchBuffer is a smart buffer to store and read data from a file.
 class FilePrefetchBuffer {
  public:
   // Constructor.
   //
   // All arguments are optional.
-  // readahead_size     : the initial readahead size.
-  // max_readahead_size : the maximum readahead size.
-  //   If max_readahead_size > readahead_size, the readahead size will be
-  //   doubled on every IO until max_readahead_size is hit.
-  //   Typically this is set as a multiple of readahead_size.
-  //   max_readahead_size should be greater than equal to readahead_size.
-  // enable : controls whether reading from the buffer is enabled.
-  //   If false, TryReadFromCache() always return false, and we only take stats
-  //   for the minimum offset if track_min_offset = true. See below NOTE about
-  //   mmap reads.
+  // ReadaheadParams  : Parameters to control the readahead behavior.
+  // enable           : controls whether reading from the buffer is enabled.
+  //                    If false, TryReadFromCache() always return false, and we
+  //                    only take stats for the minimum offset if
+  //                    track_min_offset = true.
+  //                    See below NOTE about mmap reads.
   // track_min_offset : Track the minimum offset ever read and collect stats on
-  //   it. Used for adaptable readahead of the file footer/metadata.
-  // implicit_auto_readahead : Readahead is enabled implicitly by rocksdb after
-  //   doing sequential scans for two times.
+  //                    it. Used for adaptable readahead of the file
+  //                    footer/metadata.
   //
-  // Automatic readhead is enabled for a file if readahead_size
-  // and max_readahead_size are passed in.
   // A user can construct a FilePrefetchBuffer without any arguments, but use
   // `Prefetch` to load data into the buffer.
   // NOTE: FilePrefetchBuffer is incompatible with prefetching from
   // RandomAccessFileReaders using mmap reads, so it is common to use
   // `!use_mmap_reads` for the `enable` parameter.
   FilePrefetchBuffer(
-      size_t readahead_size = 0, size_t max_readahead_size = 0,
-      bool enable = true, bool track_min_offset = false,
-      bool implicit_auto_readahead = false, uint64_t num_file_reads = 0,
-      uint64_t num_file_reads_for_auto_readahead = 0, FileSystem* fs = nullptr,
+      const ReadaheadParams& readahead_params = {}, bool enable = true,
+      bool track_min_offset = false, FileSystem* fs = nullptr,
       SystemClock* clock = nullptr, Statistics* stats = nullptr,
       const std::function<void(bool, uint64_t&, uint64_t&)>& cb = nullptr,
       FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown)
-      : curr_(0),
-        readahead_size_(readahead_size),
-        initial_auto_readahead_size_(readahead_size),
-        max_readahead_size_(max_readahead_size),
+      : readahead_size_(readahead_params.initial_readahead_size),
+        initial_auto_readahead_size_(readahead_params.initial_readahead_size),
+        max_readahead_size_(readahead_params.max_readahead_size),
         min_offset_read_(std::numeric_limits<size_t>::max()),
         enable_(enable),
         track_min_offset_(track_min_offset),
-        implicit_auto_readahead_(implicit_auto_readahead),
+        implicit_auto_readahead_(readahead_params.implicit_auto_readahead),
         prev_offset_(0),
         prev_len_(0),
-        num_file_reads_for_auto_readahead_(num_file_reads_for_auto_readahead),
-        num_file_reads_(num_file_reads),
+        num_file_reads_for_auto_readahead_(
+            readahead_params.num_file_reads_for_auto_readahead),
+        num_file_reads_(readahead_params.num_file_reads),
         explicit_prefetch_submitted_(false),
         fs_(fs),
         clock_(clock),
         stats_(stats),
         usage_(usage),
-        readaheadsize_cb_(cb) {
+        readaheadsize_cb_(cb),
+        num_buffers_(readahead_params.num_buffers) {
     assert((num_file_reads_ >= num_file_reads_for_auto_readahead_ + 1) ||
            (num_file_reads_ == 0));
-    // If ReadOptions.async_io is enabled, data is asynchronously filled in
-    // second buffer while curr_ is being consumed. If data is overlapping in
-    // two buffers, data is copied to third buffer to return continuous buffer.
-    bufs_.resize(3);
-    for (uint32_t i = 0; i < 2; i++) {
-      bufs_[i].pos_ = i;
+
+    // If num_buffers_ > 1, data is asynchronously filled in the
+    // queue. As result, data can be overlapping in two buffers. It copies the
+    // data to overlap_bufs_ in order to to return continuous buffer.
+    if (num_buffers_ > 1) {
+      overlap_bufs_.emplace_back(new BufferInfo());
+    }
+
+    free_bufs_.resize(num_buffers_);
+    for (uint32_t i = 0; i < num_buffers_; i++) {
+      free_bufs_[i] = new BufferInfo();
+      free_bufs_[i]->pos_ = free_bufs_[i];
     }
   }
 
@@ -146,10 +190,9 @@ class FilePrefetchBuffer {
     // Abort any pending async read request before destroying the class object.
     if (fs_ != nullptr) {
       std::vector<void*> handles;
-      for (uint32_t i = 0; i < 2; i++) {
-        if (bufs_[i].async_read_in_progress_ &&
-            bufs_[i].io_handle_ != nullptr) {
-          handles.emplace_back(bufs_[i].io_handle_);
+      for (auto& buf : bufs_) {
+        if (buf->async_read_in_progress_ && buf->io_handle_ != nullptr) {
+          handles.emplace_back(buf->io_handle_);
         }
       }
       if (!handles.empty()) {
@@ -157,60 +200,64 @@ class FilePrefetchBuffer {
         Status s = fs_->AbortIO(handles);
         assert(s.ok());
       }
-    }
 
-    // Prefetch buffer bytes discarded.
-    uint64_t bytes_discarded = 0;
-    // Iterated over 2 buffers.
-    for (int i = 0; i < 2; i++) {
-      int first = i;
-      int second = i ^ 1;
-
-      if (DoesBufferContainData(first)) {
-        // If last block was read completely from first and some bytes in
-        // first buffer are still unconsumed.
-        if (prev_offset_ >= bufs_[first].offset_ &&
-            prev_offset_ + prev_len_ <
-                bufs_[first].offset_ + bufs_[first].buffer_.CurrentSize()) {
-          bytes_discarded += bufs_[first].buffer_.CurrentSize() -
-                             (prev_offset_ + prev_len_ - bufs_[first].offset_);
-        }
-        // If data was in second buffer and some/whole block bytes were read
-        // from second buffer.
-        else if (prev_offset_ < bufs_[first].offset_ &&
-                 !DoesBufferContainData(second)) {
-          // If last block read was completely from different buffer, this
-          // buffer is unconsumed.
-          if (prev_offset_ + prev_len_ <= bufs_[first].offset_) {
-            bytes_discarded += bufs_[first].buffer_.CurrentSize();
-          }
-          // If last block read overlaps with this buffer and some data is
-          // still unconsumed and previous buffer (second) is not cleared.
-          else if (prev_offset_ + prev_len_ > bufs_[first].offset_ &&
-                   bufs_[first].offset_ + bufs_[first].buffer_.CurrentSize() ==
-                       bufs_[second].offset_) {
-            bytes_discarded += bufs_[first].buffer_.CurrentSize() -
-                               (/*bytes read from this buffer=*/prev_len_ -
-                                (bufs_[first].offset_ - prev_offset_));
-          }
+      for (auto& buf : bufs_) {
+        if (buf->io_handle_ != nullptr) {
+          DestroyAndClearIOHandle(buf);
+          buf->async_read_in_progress_ = false;
+          buf->ClearBuffer();
         }
       }
     }
 
-    for (uint32_t i = 0; i < 2; i++) {
-      // Release io_handle.
-      DestroyAndClearIOHandle(i);
+    // Prefetch buffer bytes discarded.
+    uint64_t bytes_discarded = 0;
+    // Iterated over buffers.
+    for (auto& buf : bufs_) {
+      if (DoesBufferContainData(buf)) {
+        // If last read was from this block and some bytes are still unconsumed.
+        if (prev_offset_ >= buf->offset_ &&
+            prev_offset_ + prev_len_ <
+                buf->offset_ + buf->buffer_.CurrentSize()) {
+          bytes_discarded += buf->buffer_.CurrentSize() -
+                             (prev_offset_ + prev_len_ - buf->offset_);
+        }
+        // If last read was from previous blocks and this block is unconsumed.
+        else if (prev_offset_ < buf->offset_ &&
+                 prev_offset_ + prev_len_ <= buf->offset_) {
+          bytes_discarded += buf->buffer_.CurrentSize();
+        }
+      }
     }
+
     RecordInHistogram(stats_, PREFETCHED_BYTES_DISCARDED, bytes_discarded);
+
+    for (auto& buf : bufs_) {
+      delete buf;
+      buf = nullptr;
+    }
+
+    for (auto& buf : free_bufs_) {
+      delete buf;
+      buf = nullptr;
+    }
+
+    for (auto& buf : overlap_bufs_) {
+      delete buf;
+      buf = nullptr;
+    }
   }
 
   bool Enabled() const { return enable_; }
 
-  // Load data into the buffer from a file.
+  // Called externally by user to only load data into the buffer from a file
+  // with num_buffers_ should be set to default(1).
+  //
   // opts                  : the IO options to use.
   // reader                : the file reader.
   // offset                : the file offset to start reading from.
   // n                     : the number of bytes to read.
+  //
   Status Prefetch(const IOOptions& opts, RandomAccessFileReader* reader,
                   uint64_t offset, size_t n);
 
@@ -244,15 +291,11 @@ class FilePrefetchBuffer {
                         uint64_t offset, size_t n, Slice* result, Status* s,
                         bool for_compaction = false);
 
-  bool TryReadFromCacheAsync(const IOOptions& opts,
-                             RandomAccessFileReader* reader, uint64_t offset,
-                             size_t n, Slice* result, Status* status);
-
   // The minimum `offset` ever passed to TryReadFromCache(). This will nly be
   // tracked if track_min_offset = true.
   size_t min_offset_read() const { return min_offset_read_; }
 
-  size_t GetPrefetchOffset() const { return bufs_[curr_].offset_; }
+  size_t GetPrefetchOffset() const { return bufs_.front()->offset_; }
 
   // Called in case of implicit auto prefetching.
   void UpdateReadPattern(const uint64_t& offset, const size_t& len,
@@ -272,6 +315,10 @@ class FilePrefetchBuffer {
 
   void DecreaseReadAheadIfEligible(uint64_t offset, size_t size,
                                    size_t value = DEFAULT_DECREMENT) {
+    if (bufs_.empty()) {
+      return;
+    }
+
     // Decrease the readahead_size if
     // - its enabled internally by RocksDB (implicit_auto_readahead_) and,
     // - readahead_size is greater than 0 and,
@@ -281,11 +328,12 @@ class FilePrefetchBuffer {
     //   - block is sequential with the previous read and,
     //   - num_file_reads_ + 1 (including this read) >
     //   num_file_reads_for_auto_readahead_
-    size_t curr_size = bufs_[curr_].async_read_in_progress_
-                           ? bufs_[curr_].async_req_len_
-                           : bufs_[curr_].buffer_.CurrentSize();
+
+    size_t curr_size = bufs_.front()->async_read_in_progress_
+                           ? bufs_.front()->async_req_len_
+                           : bufs_.front()->buffer_.CurrentSize();
     if (implicit_auto_readahead_ && readahead_size_ > 0) {
-      if ((offset + size > bufs_[curr_].offset_ + curr_size) &&
+      if ((offset + size > bufs_.front()->offset_ + curr_size) &&
           IsBlockSequential(offset) &&
           (num_file_reads_ + 1 > num_file_reads_for_auto_readahead_)) {
         readahead_size_ =
@@ -300,43 +348,41 @@ class FilePrefetchBuffer {
 
   void TEST_GetBufferOffsetandSize(uint32_t index, uint64_t& offset,
                                    size_t& len) {
-    offset = bufs_[index].offset_;
-    len = bufs_[index].buffer_.CurrentSize();
+    offset = bufs_[index]->offset_;
+    len = bufs_[index]->buffer_.CurrentSize();
   }
 
  private:
   // Calculates roundoff offset and length to be prefetched based on alignment
   // and data present in buffer_. It also allocates new buffer or refit tail if
   // required.
-  void CalculateOffsetAndLen(size_t alignment, uint64_t offset,
-                             size_t roundup_len, uint32_t index,
-                             bool refit_tail, uint64_t& chunk_len);
+  void CalculateOffsetAndLen(BufferInfo* buf, size_t alignment, uint64_t offset,
+                             size_t roundup_len, bool refit_tail,
+                             uint64_t& chunk_len);
 
-  void AbortIOIfNeeded(uint64_t offset);
+  void AbortOutdatedIO(uint64_t offset);
 
   void AbortAllIOs();
 
-  void UpdateBuffersIfNeeded(uint64_t offset, size_t len);
+  void ClearOutdatedData(uint64_t offset, size_t len);
 
-  // It calls Poll API if any there is any pending asynchronous request. It then
-  // checks if data is in any buffer. It clears the outdated data and swaps the
-  // buffers if required.
-  void PollAndUpdateBuffersIfNeeded(uint64_t offset, size_t len);
+  // It calls Poll API to check for any pending asynchronous request.
+  void PollIfNeeded(uint64_t offset, size_t len);
 
-  Status PrefetchAsyncInternal(const IOOptions& opts,
-                               RandomAccessFileReader* reader, uint64_t offset,
-                               size_t length, size_t readahead_size,
-                               bool& copy_to_third_buffer);
+  Status PrefetchInternal(const IOOptions& opts, RandomAccessFileReader* reader,
+                          uint64_t offset, size_t length, size_t readahead_size,
+                          bool& copy_to_third_buffer);
 
-  Status Read(const IOOptions& opts, RandomAccessFileReader* reader,
-              uint64_t read_len, uint64_t chunk_len, uint64_t start_offset,
-              uint32_t index);
+  Status Read(BufferInfo* buf, const IOOptions& opts,
+              RandomAccessFileReader* reader, uint64_t read_len,
+              uint64_t chunk_len, uint64_t start_offset);
 
-  Status ReadAsync(const IOOptions& opts, RandomAccessFileReader* reader,
-                   uint64_t read_len, uint64_t start_offset, uint32_t index);
+  Status ReadAsync(BufferInfo* buf, const IOOptions& opts,
+                   RandomAccessFileReader* reader, uint64_t read_len,
+                   uint64_t start_offset);
 
-  // Copy the data from src to third buffer.
-  void CopyDataToBuffer(uint32_t src, uint64_t& offset, size_t& length);
+  // Copy the data from src to overlap_bufs_.
+  void CopyDataToBuffer(BufferInfo* src, uint64_t& offset, size_t& length);
 
   bool IsBlockSequential(const size_t& offset) {
     return (prev_len_ == 0 || (prev_offset_ + prev_len_ == offset));
@@ -372,64 +418,24 @@ class FilePrefetchBuffer {
     return true;
   }
 
-  // Helper functions.
-  bool IsDataBlockInBuffer(uint64_t offset, size_t length, uint32_t index) {
-    return (offset >= bufs_[index].offset_ &&
-            offset + length <=
-                bufs_[index].offset_ + bufs_[index].buffer_.CurrentSize());
-  }
-  bool IsOffsetInBuffer(uint64_t offset, uint32_t index) {
-    return (offset >= bufs_[index].offset_ &&
-            offset < bufs_[index].offset_ + bufs_[index].buffer_.CurrentSize());
-  }
-  bool DoesBufferContainData(uint32_t index) {
-    return bufs_[index].buffer_.CurrentSize() > 0;
-  }
-  bool IsBufferOutdated(uint64_t offset, uint32_t index) {
-    return (
-        !bufs_[index].async_read_in_progress_ && DoesBufferContainData(index) &&
-        offset >= bufs_[index].offset_ + bufs_[index].buffer_.CurrentSize());
-  }
-  bool IsBufferOutdatedWithAsyncProgress(uint64_t offset, uint32_t index) {
-    return (bufs_[index].async_read_in_progress_ &&
-            bufs_[index].io_handle_ != nullptr &&
-            offset >= bufs_[index].offset_ + bufs_[index].async_req_len_);
-  }
-  bool IsOffsetInBufferWithAsyncProgress(uint64_t offset, uint32_t index) {
-    return (bufs_[index].async_read_in_progress_ &&
-            offset >= bufs_[index].offset_ &&
-            offset < bufs_[index].offset_ + bufs_[index].async_req_len_);
-  }
-
-  bool IsSecondBuffEligibleForPrefetching() {
-    uint32_t second = curr_ ^ 1;
-    if (bufs_[second].async_read_in_progress_) {
+  bool IsEligibleForFurtherPrefetching() {
+    if (free_bufs_.empty()) {
       return false;
     }
-    assert(!bufs_[curr_].async_read_in_progress_);
-
-    if (DoesBufferContainData(curr_) && DoesBufferContainData(second) &&
-        (bufs_[curr_].offset_ + bufs_[curr_].buffer_.CurrentSize() ==
-         bufs_[second].offset_)) {
-      return false;
-    }
-
     // Readahead size can be 0 because of trimming.
     if (readahead_size_ == 0) {
       return false;
     }
-
-    bufs_[second].ClearBuffer();
     return true;
   }
 
-  void DestroyAndClearIOHandle(uint32_t index) {
-    if (bufs_[index].io_handle_ != nullptr && bufs_[index].del_fn_ != nullptr) {
-      bufs_[index].del_fn_(bufs_[index].io_handle_);
-      bufs_[index].io_handle_ = nullptr;
-      bufs_[index].del_fn_ = nullptr;
+  void DestroyAndClearIOHandle(BufferInfo* buf) {
+    if (buf->io_handle_ != nullptr && buf->del_fn_ != nullptr) {
+      buf->del_fn_(buf->io_handle_);
+      buf->io_handle_ = nullptr;
+      buf->del_fn_ = nullptr;
     }
-    bufs_[index].async_read_in_progress_ = false;
+    buf->async_read_in_progress_ = false;
   }
 
   Status HandleOverlappingData(const IOOptions& opts,
@@ -444,13 +450,8 @@ class FilePrefetchBuffer {
                                  Status* s,
                                  bool for_compaction = false);
 
-  bool TryReadFromCacheAsyncUntracked(const IOOptions& opts,
-                                      RandomAccessFileReader* reader,
-                                      uint64_t offset, size_t n, Slice* result,
-                                      Status* status);
-
-  void ReadAheadSizeTuning(bool read_curr_block, bool refit_tail,
-                           uint64_t prev_buf_end_offset, uint32_t index,
+  void ReadAheadSizeTuning(BufferInfo* buf, bool read_curr_block,
+                           bool refit_tail, uint64_t prev_buf_end_offset,
                            size_t alignment, size_t length,
                            size_t readahead_size, uint64_t& offset,
                            uint64_t& end_offset, size_t& read_len,
@@ -472,10 +473,104 @@ class FilePrefetchBuffer {
     }
   }
 
-  std::vector<BufferInfo> bufs_;
-  // curr_ represents the index for bufs_ indicating which buffer is being
-  // consumed currently.
-  uint32_t curr_;
+  Status PrefetchRemBuffers(const IOOptions& opts,
+                            RandomAccessFileReader* reader,
+                            uint64_t end_offset1, size_t alignment,
+                            size_t readahead_size);
+
+  // *** BEGIN Helper APIs related to data in Buffers ***
+  bool IsDataBlockInBuffer(BufferInfo* buf, uint64_t offset, size_t length) {
+    return (offset >= buf->offset_ &&
+            offset + length <= buf->offset_ + buf->buffer_.CurrentSize());
+  }
+  bool IsOffsetInBuffer(BufferInfo* buf, uint64_t offset) {
+    return (offset >= buf->offset_ &&
+            offset < buf->offset_ + buf->buffer_.CurrentSize());
+  }
+  bool DoesBufferContainData(BufferInfo* buf) {
+    return buf->buffer_.CurrentSize() > 0;
+  }
+  bool IsBufferOutdated(BufferInfo* buf, uint64_t offset) {
+    return (!buf->async_read_in_progress_ && DoesBufferContainData(buf) &&
+            offset >= buf->offset_ + buf->buffer_.CurrentSize());
+  }
+  bool IsBufferOutdatedWithAsyncProgress(BufferInfo* buf, uint64_t offset) {
+    return (buf->async_read_in_progress_ && buf->io_handle_ != nullptr &&
+            offset >= buf->offset_ + buf->async_req_len_);
+  }
+  bool IsOffsetInBufferWithAsyncProgress(BufferInfo* buf, uint64_t offset) {
+    return (buf->async_read_in_progress_ && offset >= buf->offset_ &&
+            offset < buf->offset_ + buf->async_req_len_);
+  }
+  // *** END Helper APIs related to data in Buffers ***
+
+  // *** BEGIN APIs related to allocating and freeing buffers ***
+  bool IsBufferQueueEmpty() { return bufs_.empty(); }
+
+  BufferInfo* GetFirstBuffer() { return bufs_.front(); }
+
+  BufferInfo* GetLastBuffer() { return bufs_.back(); }
+
+  size_t NumBuffersAllocated() { return bufs_.size(); }
+
+  void AllocateBuffer() {
+    assert(!free_bufs_.empty());
+    BufferInfo* buf = free_bufs_.front();
+    free_bufs_.pop_front();
+    bufs_.emplace_back(buf);
+  }
+
+  void AllocateBufferIfEmpty() {
+    if (bufs_.empty()) {
+      AllocateBuffer();
+    }
+  }
+
+  void FreeFrontBuffer() {
+    BufferInfo* buf = bufs_.front();
+    buf->buffer_.Clear();
+    bufs_.pop_front();
+    free_bufs_.emplace_back(buf);
+  }
+
+  void FreeLastBuffer() {
+    BufferInfo* buf = bufs_.back();
+    buf->buffer_.Clear();
+    bufs_.pop_back();
+    free_bufs_.emplace_back(buf);
+  }
+
+  void FreeAllBuffers() {
+    for (auto& buf : bufs_) {
+      buf->ClearBuffer();
+      bufs_.pop_front();
+      free_bufs_.emplace_back(buf);
+    }
+  }
+
+  void FreeEmptyBuffers() {
+    if (bufs_.empty()) {
+      return;
+    }
+
+    std::deque<BufferInfo*> tmp_buf;
+    while (!bufs_.empty()) {
+      BufferInfo* buf = bufs_.front();
+      bufs_.pop_front();
+      if (buf->async_read_in_progress_ || DoesBufferContainData(buf)) {
+        tmp_buf.emplace_back(buf);
+      } else {
+        free_bufs_.emplace_back(buf);
+      }
+    }
+    bufs_ = tmp_buf;
+  }
+
+  // *** END APIs related to allocating and freeing buffers ***
+
+  std::deque<BufferInfo*> bufs_;
+  std::deque<BufferInfo*> free_bufs_;
+  std::deque<BufferInfo*> overlap_bufs_;
 
   size_t readahead_size_;
   size_t initial_auto_readahead_size_;
@@ -503,7 +598,7 @@ class FilePrefetchBuffer {
   uint64_t num_file_reads_;
 
   // If explicit_prefetch_submitted_ is set then it indicates RocksDB called
-  // PrefetchAsync to submit request. It needs to call TryReadFromCacheAsync to
+  // PrefetchAsync to submit request. It needs to call TryReadFromCache to
   // poll the submitted request without checking if data is sequential and
   // num_file_reads_.
   bool explicit_prefetch_submitted_;
@@ -515,5 +610,9 @@ class FilePrefetchBuffer {
   FilePrefetchBufferUsage usage_;
 
   std::function<void(bool, uint64_t&, uint64_t&)> readaheadsize_cb_;
+
+  // num_buffers_ is the number of buffers maintained by FilePrefetchBuffer to
+  // prefetch the data at a time.
+  size_t num_buffers_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -384,7 +384,8 @@ void BlockBasedTableIterator::InitDataBlock() {
       block_prefetcher_.PrefetchIfNeeded(
           rep, data_block_handle, read_options_.readahead_size,
           is_for_compaction,
-          /*no_sequential_checking=*/false, read_options_, readaheadsize_cb);
+          /*no_sequential_checking=*/false, read_options_, readaheadsize_cb,
+          read_options_.async_io);
 
       Status s;
       table_->NewDataBlockIterator<DataBlockIter>(
@@ -444,7 +445,7 @@ void BlockBasedTableIterator::AsyncInitDataBlock(bool is_first_pass) {
       block_prefetcher_.PrefetchIfNeeded(
           rep, data_block_handle, read_options_.readahead_size,
           is_for_compaction, /*no_sequential_checking=*/read_options_.async_io,
-          read_options_, readaheadsize_cb);
+          read_options_, readaheadsize_cb, read_options_.async_io);
 
       Status s;
       table_->NewDataBlockIterator<DataBlockIter>(

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -713,7 +713,6 @@ void BlockBasedTableIterator::InitializeStartAndEndOffsets(
       // It can be due to reading error in second buffer in FilePrefetchBuffer.
       // BlockHandles already added to the queue but there was error in fetching
       // those data blocks. So in this call they need to be read again.
-      assert(block_handles_.front().is_cache_hit_ == false);
       found_first_miss_block = true;
       // Initialize prev_handles_size to 0 as all those handles need to be read
       // again.
@@ -856,7 +855,8 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
     auto it_end =
         block_handles_.rbegin() + (block_handles_.size() - prev_handles_size);
 
-    while (it != it_end && (*it).is_cache_hit_) {
+    while (it != it_end && (*it).is_cache_hit_ &&
+           start_updated_offset != (*it).handle_.offset()) {
       it++;
     }
     end_updated_offset = (*it).handle_.offset() + footer + (*it).handle_.size();

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -707,12 +707,10 @@ struct BlockBasedTable::Rep {
   }
 
   void CreateFilePrefetchBufferIfNotExists(
-          const ReadaheadParams& readahead_params,
-          std::unique_ptr<FilePrefetchBuffer>* fpb,
-          const std::function<void(bool, uint64_t&, uint64_t&)>&
-              readaheadsize_cb,
-          FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown)
-          const {
+      const ReadaheadParams& readahead_params,
+      std::unique_ptr<FilePrefetchBuffer>* fpb,
+      const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb,
+      FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown) const {
     if (!(*fpb)) {
       CreateFilePrefetchBuffer(readahead_params, fpb, readaheadsize_cb, usage);
     }

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -696,32 +696,25 @@ struct BlockBasedTable::Rep {
     return file ? TableFileNameToNumber(file->file_name()) : UINT64_MAX;
   }
   void CreateFilePrefetchBuffer(
-      size_t readahead_size, size_t max_readahead_size,
-      std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
-      uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
-
+      const ReadaheadParams& readahead_params,
+      std::unique_ptr<FilePrefetchBuffer>* fpb,
       const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb,
       FilePrefetchBufferUsage usage) const {
     fpb->reset(new FilePrefetchBuffer(
-        readahead_size, max_readahead_size,
-        !ioptions.allow_mmap_reads /* enable */, false /* track_min_offset */,
-        implicit_auto_readahead, num_file_reads,
-        num_file_reads_for_auto_readahead, ioptions.fs.get(), ioptions.clock,
+        readahead_params, !ioptions.allow_mmap_reads /* enable */,
+        false /* track_min_offset */, ioptions.fs.get(), ioptions.clock,
         ioptions.stats, readaheadsize_cb, usage));
   }
 
   void CreateFilePrefetchBufferIfNotExists(
-      size_t readahead_size, size_t max_readahead_size,
-      std::unique_ptr<FilePrefetchBuffer>* fpb, bool implicit_auto_readahead,
-      uint64_t num_file_reads, uint64_t num_file_reads_for_auto_readahead,
-
-      const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb,
-      FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown) const {
+          const ReadaheadParams& readahead_params,
+          std::unique_ptr<FilePrefetchBuffer>* fpb,
+          const std::function<void(bool, uint64_t&, uint64_t&)>&
+              readaheadsize_cb,
+          FilePrefetchBufferUsage usage = FilePrefetchBufferUsage::kUnknown)
+          const {
     if (!(*fpb)) {
-      CreateFilePrefetchBuffer(readahead_size, max_readahead_size, fpb,
-                               implicit_auto_readahead, num_file_reads,
-                               num_file_reads_for_auto_readahead,
-                               readaheadsize_cb, usage);
+      CreateFilePrefetchBuffer(readahead_params, fpb, readaheadsize_cb, usage);
     }
   }
 

--- a/table/block_based/block_prefetcher.h
+++ b/table/block_based/block_prefetcher.h
@@ -22,7 +22,8 @@ class BlockPrefetcher {
       const BlockBasedTable::Rep* rep, const BlockHandle& handle,
       size_t readahead_size, bool is_for_compaction,
       const bool no_sequential_checking, const ReadOptions& read_options,
-      const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb);
+      const std::function<void(bool, uint64_t&, uint64_t&)>& readaheadsize_cb,
+      bool is_async_io_prefetch);
   FilePrefetchBuffer* prefetch_buffer() { return prefetch_buffer_.get(); }
 
   void UpdateReadPattern(const uint64_t& offset, const size_t& len) {

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -495,11 +495,9 @@ Status PartitionedFilterBlockReader::CacheDependencies(
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
   if (tail_prefetch_buffer == nullptr || !tail_prefetch_buffer->Enabled() ||
       tail_prefetch_buffer->GetPrefetchOffset() > prefetch_off) {
-    rep->CreateFilePrefetchBuffer(
-        0, 0, &prefetch_buffer, false /* Implicit autoreadahead */,
-        0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/,
-        /*readaheadsize_cb*/ nullptr,
-        /*usage=*/FilePrefetchBufferUsage::kUnknown);
+    rep->CreateFilePrefetchBuffer(ReadaheadParams(), &prefetch_buffer,
+                                  /*readaheadsize_cb*/ nullptr,
+                                  /*usage=*/FilePrefetchBufferUsage::kUnknown);
 
     IOOptions opts;
     s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_based/partitioned_index_iterator.cc
+++ b/table/block_based/partitioned_index_iterator.cc
@@ -92,7 +92,7 @@ void PartitionedIndexIterator::InitPartitionedIndexBlock() {
     block_prefetcher_.PrefetchIfNeeded(
         rep, partitioned_index_handle, read_options_.readahead_size,
         is_for_compaction, /*no_sequential_checking=*/false, read_options_,
-        /*readaheadsize_cb=*/nullptr);
+        /*readaheadsize_cb=*/nullptr, /*is_async_io_prefetch=*/false);
     Status s;
     table_->NewDataBlockIterator<IndexBlockIter>(
         read_options_, partitioned_index_handle, &block_iter_,

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -167,11 +167,9 @@ Status PartitionIndexReader::CacheDependencies(
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
   if (tail_prefetch_buffer == nullptr || !tail_prefetch_buffer->Enabled() ||
       tail_prefetch_buffer->GetPrefetchOffset() > prefetch_off) {
-    rep->CreateFilePrefetchBuffer(
-        0, 0, &prefetch_buffer, false /*Implicit auto readahead*/,
-        0 /*num_reads_*/, 0 /*num_file_reads_for_auto_readahead*/,
-        /*readaheadsize_cb*/ nullptr,
-        /*usage=*/FilePrefetchBufferUsage::kUnknown);
+    rep->CreateFilePrefetchBuffer(ReadaheadParams(), &prefetch_buffer,
+                                  /*readaheadsize_cb*/ nullptr,
+                                  /*usage=*/FilePrefetchBufferUsage::kUnknown);
     IOOptions opts;
     {
       Status s = rep->file->PrepareIOOptions(ro, opts);

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -76,16 +76,9 @@ inline bool BlockFetcher::TryGetFromPrefetchBuffer() {
     IOOptions opts;
     IOStatus io_s = file_->PrepareIOOptions(read_options_, opts);
     if (io_s.ok()) {
-      bool read_from_prefetch_buffer = false;
-      if (read_options_.async_io && !for_compaction_) {
-        read_from_prefetch_buffer = prefetch_buffer_->TryReadFromCacheAsync(
-            opts, file_, handle_.offset(), block_size_with_trailer_, &slice_,
-            &io_s);
-      } else {
-        read_from_prefetch_buffer = prefetch_buffer_->TryReadFromCache(
-            opts, file_, handle_.offset(), block_size_with_trailer_, &slice_,
-            &io_s, for_compaction_);
-      }
+      bool read_from_prefetch_buffer = prefetch_buffer_->TryReadFromCache(
+          opts, file_, handle_.offset(), block_size_with_trailer_, &slice_,
+          &io_s, for_compaction_);
       if (read_from_prefetch_buffer) {
         ProcessTrailerIfPresent();
         if (!io_status_.ok()) {

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -103,7 +103,8 @@ Status SstFileDumper::GetTableReader(const std::string& file_path) {
 
   file_.reset(new RandomAccessFileReader(std::move(file), file_path));
 
-  FilePrefetchBuffer prefetch_buffer(ReadaheadParams(), !fopts.use_mmap_reads /* enable */,
+  FilePrefetchBuffer prefetch_buffer(ReadaheadParams(),
+                                     !fopts.use_mmap_reads /* enable */,
                                      false /* track_min_offset */);
   if (s.ok()) {
     const uint64_t kSstDumpTailPrefetchSize = 512 * 1024;

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -103,9 +103,8 @@ Status SstFileDumper::GetTableReader(const std::string& file_path) {
 
   file_.reset(new RandomAccessFileReader(std::move(file), file_path));
 
-  FilePrefetchBuffer prefetch_buffer(
-      0 /* readahead_size */, 0 /* max_readahead_size */,
-      !fopts.use_mmap_reads /* enable */, false /* track_min_offset */);
+  FilePrefetchBuffer prefetch_buffer(ReadaheadParams(), !fopts.use_mmap_reads /* enable */,
+                                     false /* track_min_offset */);
   if (s.ok()) {
     const uint64_t kSstDumpTailPrefetchSize = 512 * 1024;
     uint64_t prefetch_size = (file_size > kSstDumpTailPrefetchSize)

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -3222,8 +3222,6 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupSeqScans) {
   Slice* ub_ptr = &ub;
   read_options.iterate_upper_bound = ub_ptr;
   read_options.readahead_size = 16384;
-  uint64_t buffer_offset;
-  size_t buffer_len;
 
   // Test various functionalities -
   // 5 blocks prefetched - Current + 4 additional (readahead_size).
@@ -3255,13 +3253,14 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupSeqScans) {
       FilePrefetchBuffer* prefetch_buffer =
           (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
               ->prefetch_buffer();
-      prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                   buffer_len);
+      std::vector<std::pair<uint64_t, size_t>> buffer_info(1);
+      prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
+
       bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first, block_handle);
       // It won't prefetch the data of cache hit.
       // One block data.
-      ASSERT_EQ(buffer_len, 4096);
-      ASSERT_EQ(buffer_offset, block_handle.offset());
+      ASSERT_EQ(buffer_info[0].second, 4096);
+      ASSERT_EQ(buffer_info[0].first, block_handle.offset());
 
       ASSERT_EQ(options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED),
                 1);
@@ -3292,14 +3291,14 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupSeqScans) {
       FilePrefetchBuffer* prefetch_buffer =
           (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
               ->prefetch_buffer();
-      prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                   buffer_len);
+      std::vector<std::pair<uint64_t, size_t>> buffer_info(1);
+      prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
       bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first, block_handle);
 
       // It won't prefetch the data of cache hit.
       // 3 blocks data.
-      ASSERT_EQ(buffer_len, 12288);
-      ASSERT_EQ(buffer_offset, block_handle.offset());
+      ASSERT_EQ(buffer_info[0].second, 12288);
+      ASSERT_EQ(buffer_info[0].first, block_handle.offset());
 
       for (; kv_iter != kvmap.end() && iter->Valid(); kv_iter++) {
         ASSERT_EQ(iter->key(), kv_iter->first);
@@ -3313,11 +3312,10 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupSeqScans) {
       }
 
       // Second Prefetch.
-      prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                   buffer_len);
+      prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
       bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first, block_handle);
-      ASSERT_EQ(buffer_offset, 106496);
-      ASSERT_EQ(buffer_offset, block_handle.offset());
+      ASSERT_EQ(buffer_info[0].second, 20480);
+      ASSERT_EQ(buffer_info[0].first, block_handle.offset());
 
       ASSERT_EQ(options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED),
                 1);
@@ -3366,8 +3364,6 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
   read_options.iterate_upper_bound = ub_ptr;
   read_options.readahead_size = 16384;
   read_options.async_io = true;
-  uint64_t buffer_offset;
-  size_t buffer_len;
 
   // Test Various functionalities -
   // 3 blocks prefetched - Current + 2 additional (readahead_size/2).
@@ -3403,14 +3399,13 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
       FilePrefetchBuffer* prefetch_buffer =
           (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
               ->prefetch_buffer();
-      prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                   buffer_len);
+      std::vector<std::pair<uint64_t, size_t>> buffer_info(2);
+      prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
+
       bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first, block_handle);
-      ASSERT_EQ(buffer_len, 4096);
-      ASSERT_EQ(buffer_offset, block_handle.offset());
-      prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
-                                                   buffer_len);
-      ASSERT_EQ(buffer_len, 0);
+      ASSERT_EQ(buffer_info[0].first, block_handle.offset());
+      ASSERT_EQ(buffer_info[0].second, 4096);
+      ASSERT_EQ(buffer_info[1].second, 0);
 
       ASSERT_EQ(options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED),
                 2);
@@ -3443,23 +3438,21 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
       FilePrefetchBuffer* prefetch_buffer =
           (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
               ->prefetch_buffer();
+      std::vector<std::pair<uint64_t, size_t>> buffer_info(2);
+      prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
       {
         // 1st Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                     buffer_len);
         bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
                                      block_handle);
-        ASSERT_EQ(buffer_len, 8192);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_info[0].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[0].second, 8192);
 
         // 2nd Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
-                                                     buffer_len);
         InternalKey ikey_tmp("00000360", 0, kTypeValue);
         bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
                                      block_handle);
-        ASSERT_EQ(buffer_len, 8192);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].second, 8192);
 
         ASSERT_EQ(options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED),
                   1);
@@ -3496,23 +3489,23 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
       FilePrefetchBuffer* prefetch_buffer =
           (reinterpret_cast<BlockBasedTableIterator*>(iter.get()))
               ->prefetch_buffer();
+
       {
+        std::vector<std::pair<uint64_t, size_t>> buffer_info(2);
+        prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
+
         // 1st Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                     buffer_len);
         bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
                                      block_handle);
-        ASSERT_EQ(buffer_len, 8192);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_info[0].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[0].second, 8192);
 
         // 2nd Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
-                                                     buffer_len);
         InternalKey ikey_tmp("00000540", 0, kTypeValue);
         bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
                                      block_handle);
-        ASSERT_EQ(buffer_len, 8192);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].second, 8192);
 
         ASSERT_EQ(options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED),
                   1);
@@ -3532,23 +3525,21 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
       }
 
       {
+        std::vector<std::pair<uint64_t, size_t>> buffer_info(2);
+        prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
+
         // 1st Buffer Verification.
-        // curr buffer - 1.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                     buffer_len);
         bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
                                      block_handle);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
-        ASSERT_EQ(buffer_len, 8192);
+        ASSERT_EQ(buffer_info[0].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[0].second, 8192);
 
         // 2nd Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
-                                                     buffer_len);
         InternalKey ikey_tmp("00000585", 0, kTypeValue);
         bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
                                      block_handle);
-        ASSERT_EQ(buffer_len, 4096);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].second, 4096);
 
         ASSERT_EQ(options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED),
                   1);
@@ -3568,23 +3559,21 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
       }
 
       {
+        std::vector<std::pair<uint64_t, size_t>> buffer_info(2);
+        prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
+
         // 1st Buffer Verification.
-        // curr buffer - 0.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                     buffer_len);
         bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
                                      block_handle);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
-        ASSERT_EQ(buffer_len, 4096);
+        ASSERT_EQ(buffer_info[0].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[0].second, 4096);
 
         // 2nd Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
-                                                     buffer_len);
         InternalKey ikey_tmp("00000615", 0, kTypeValue);
         bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
                                      block_handle);
-        ASSERT_EQ(buffer_len, 4096);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].second, 4096);
 
         ASSERT_EQ(options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED),
                   1);
@@ -3604,23 +3593,21 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
       }
 
       {
+        std::vector<std::pair<uint64_t, size_t>> buffer_info(2);
+        prefetch_buffer->TEST_GetBufferOffsetandSize(buffer_info);
+
         // 1st Buffer Verification.
-        // curr_ - 1.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
-                                                     buffer_len);
-        ASSERT_EQ(buffer_len, 4096);
         bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
                                      block_handle);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_info[0].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[0].second, 4096);
 
         // 2nd Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
-                                                     buffer_len);
         InternalKey ikey_tmp("00000630", 0, kTypeValue);
         bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
                                      block_handle);
-        ASSERT_EQ(buffer_len, 8192);
-        ASSERT_EQ(buffer_offset, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].first, block_handle.offset());
+        ASSERT_EQ(buffer_info[1].second, 8192);
 
         ASSERT_EQ(options.statistics->getAndResetTickerCount(READAHEAD_TRIMMED),
                   0);

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -3534,7 +3534,7 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
       {
         // 1st Buffer Verification.
         // curr buffer - 1.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
+        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
                                                      buffer_len);
         bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
                                      block_handle);
@@ -3542,7 +3542,7 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
         ASSERT_EQ(buffer_len, 8192);
 
         // 2nd Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
                                                      buffer_len);
         InternalKey ikey_tmp("00000585", 0, kTypeValue);
         bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
@@ -3606,7 +3606,7 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
       {
         // 1st Buffer Verification.
         // curr_ - 1.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
+        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
                                                      buffer_len);
         ASSERT_EQ(buffer_len, 4096);
         bbt->TEST_GetDataBlockHandle(read_options, kv_iter->first,
@@ -3614,7 +3614,7 @@ TEST_P(BlockBasedTableTest, BlockCacheLookupAsyncScansSeek) {
         ASSERT_EQ(buffer_offset, block_handle.offset());
 
         // 2nd Buffer Verification.
-        prefetch_buffer->TEST_GetBufferOffsetandSize(0, buffer_offset,
+        prefetch_buffer->TEST_GetBufferOffsetandSize(1, buffer_offset,
                                                      buffer_len);
         InternalKey ikey_tmp("00000630", 0, kTypeValue);
         bbt->TEST_GetDataBlockHandle(read_options, ikey_tmp.Encode().ToString(),
@@ -5889,8 +5889,8 @@ TEST_F(BBTTailPrefetchTest, TestTailPrefetchStats) {
 
 TEST_F(BBTTailPrefetchTest, FilePrefetchBufferMinOffset) {
   TailPrefetchStats tpstats;
-  FilePrefetchBuffer buffer(0 /* readahead_size */, 0 /* max_readahead_size */,
-                            false /* enable */, true /* track_min_offset */);
+  FilePrefetchBuffer buffer(ReadaheadParams(), false /* enable */,
+                            true /* track_min_offset */);
   IOOptions opts;
   buffer.TryReadFromCache(opts, nullptr /* reader */, 500 /* offset */,
                           10 /* n */, nullptr /* result */,


### PR DESCRIPTION
Summary - Refactor FilePrefetchBuffer code 
- Implementation:
FilePrefetchBuffer maintains a deque of free buffers (free_bufs_) of size num_buffers_ and buffers (bufs_) which contains the prefetched data. Whenever a buffer is consumed or is outdated (w.r.t. to requested offset), that buffer is cleared and returned to free_bufs_.

 If a buffer is available in free_bufs_, it's moved to bufs_ and is sent for prefetching. num_buffers_ defines how many buffers are maintained that contains prefetched data.
If num_buffers_ == 1, it's a sequential read flow. Read API will be called on that one buffer whenever the data is requested and is not in the buffer.
If num_buffers_ > 1, then the data is prefetched asynchronosuly in the buffers whenever the data is consumed from the buffers and that buffer is freed.
If num_buffers > 1, then requested data can be overlapping between 2 buffers. To return the continuous buffer overlap_bufs_ is used. The requested data is copied from 2 buffers to the overlap_bufs_ and overlap_bufs_ is returned to
the caller.

- Merged Sync and Async code flow into one in FilePrefetchBuffer.

Test Plan - 
- Crash test passed
- Unit tests
- Pending - Benchmarks

