### PR TITLE
Fix stack trace trimming with LLDB

### DIFF
--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -256,9 +256,9 @@ void PrintStack(int first_frames_to_skip) {
         if (lldb_stack_trace) {
           fprintf(stderr, "Invoking LLDB for stack trace...\n");
 
-          // Skip top ~8 frames here in PrintStack
+          // Skip top ~4 frames here in PrintStack
           auto bt_in_lldb =
-              "script -l python -- for f in lldb.thread.frames[8:]: print(f)";
+              "script -l python -- for f in lldb.thread.frames[4:]: print(f)";
           execlp(/*cmd in PATH*/ "lldb", /*arg0*/ "lldb", "-p", attach_pid_str,
                  "-b", "-Q", "-o", GetLldbScriptSelectThread(attach_tid), "-o",
                  bt_in_lldb, (char*)nullptr);


### PR DESCRIPTION
Summary: I must have chosen trimming before frame 8 based on assertion failures, but that trims too many frame for a general segfault. So this changes to start printing at frame 4, as in this example where I've seeded a null deref:

```
Received signal 11 (Segmentation fault)
Invoking LLDB for stack trace...
Process 873208 stopped
* thread #1, name = 'db_stress', stop reason = signal SIGSTOP
    frame #0: 0x00007fb1fe8f1033 libc.so.6`__GI___wait4(pid=873478, stat_loc=0x00007fb1fb114030, options=0, usage=0x0000000000000000) at wait4.c:30:10
  thread #2, name = 'rocksdb:low', stop reason = signal SIGSTOP
    frame #0: 0x00007fb1fe8972a1 libc.so.6`__GI___futex_abstimed_wait_cancelable64 at futex-internal.c:57:12
Executable module set to "/data/users/peterd/rocksdb/db_stress".
Architecture set to: x86_64-unknown-linux-gnu.
True
frame #4: 0x00007fb1fe844540 libc.so.6`__restore_rt at libc_sigaction.c:13
frame #5: 0x0000000000608514 db_stress`rocksdb::StressTest::InitDb(rocksdb::SharedState*) at db_stress_test_base.cc:345:18
frame #6: 0x0000000000585d62 db_stress`rocksdb::RunStressTestImpl(rocksdb::SharedState*) at db_stress_driver.cc:84:17
frame #7: 0x000000000058dd69 db_stress`rocksdb::RunStressTest(shared=0x00006120000001c0) at db_stress_driver.cc:266:34
frame #8: 0x0000000000453b34 db_stress`rocksdb::db_stress_tool(int, char**) at db_stress_tool.cc:370:20
...
```

Test Plan: manual (see above)

Reviewers:

Subscribers:

Tasks:

Tags: