### PR TITLE
Add dynamic disabling of compressed cache to db_stress

### DIFF
--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -210,9 +210,6 @@ void CompressedCacheSetCapacityThread(void* v) {
             (double)thread->rand.Uniform(
                 FLAGS_compressed_secondary_cache_ratio * 100) /
             100;
-        if (new_comp_cache_ratio == 0.0) {
-          new_comp_cache_ratio = 0.05;
-        }
         fprintf(stderr, "New comp cache ratio = %f\n", new_comp_cache_ratio);
 
         s = UpdateTieredCache(block_cache, /*capacity*/ -1,


### PR DESCRIPTION
We now support re-enabling the compressed portion of the `TieredCache` after dynamically disabling it. Add it to db_stress for testing purposes.