### PR TITLE
Add initial support to stress test persist_user_defined_timestamps

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -313,6 +313,7 @@ DECLARE_uint32(memtable_protection_bytes_per_key);
 DECLARE_uint32(block_protection_bytes_per_key);
 
 DECLARE_uint64(user_timestamp_size);
+DECLARE_bool(persist_user_defined_timestamps);
 DECLARE_string(secondary_cache_uri);
 DECLARE_int32(secondary_cache_fault_one_in);
 

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1026,8 +1026,8 @@ DEFINE_uint64(user_timestamp_size, 0,
               "8-byte is supported");
 
 DEFINE_bool(persist_user_defined_timestamps, true,
-            "Flag to indicate whether user-defined timestamps will be stripped"
-            "during Flush");
+            "Flag to indicate whether user-defined timestamps will be persisted"
+            " during Flush");
 
 DEFINE_int32(open_metadata_write_fault_one_in, 0,
              "On non-zero, enables fault injection on file metadata write "

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1025,6 +1025,10 @@ DEFINE_uint64(user_timestamp_size, 0,
               "Number of bytes for a user-defined timestamp. Currently, only "
               "8-byte is supported");
 
+DEFINE_bool(persist_user_defined_timestamps, true,
+            "Flag to indicate whether user-defined timestamps will be stripped"
+            "during Flush");
+
 DEFINE_int32(open_metadata_write_fault_one_in, 0,
              "On non-zero, enables fault injection on file metadata write "
              "during DB reopen.");

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -454,22 +454,12 @@ blob_params = {
     "prepopulate_blob_cache": lambda: random.randint(0, 1),
 }
 
-# To ensure value for flag `persist_user_defined_timestamps` are consistent
-# through multiple stress test runs.
-class PersistUserDefinedTimestampsInitializer:
-    _initialized = False
-    _persist_udt = 0
-    def __call__(self):
-        if not PersistUserDefinedTimestampsInitializer._initialized:
-            PersistUserDefinedTimestampsInitializer._persist_udt = random.choice([0, 1, 1])
-            PersistUserDefinedTimestampsInitializer._initialized = True
-        return PersistUserDefinedTimestampsInitializer._persist_udt
-
 ts_params = {
     "test_cf_consistency": 0,
     "test_batches_snapshots": 0,
     "user_timestamp_size": 8,
-    "persist_user_defined_timestamps": PersistUserDefinedTimestampsInitializer(),
+    # Below flag is randomly picked once and kept consistent in following runs.
+    "persist_user_defined_timestamps": random.choice([0, 1, 1]),
     "use_merge": 0,
     "use_full_merge_v1": 0,
     "use_txn": 0,
@@ -562,7 +552,6 @@ multiops_wp_txn_params = {
     "clear_wp_commit_cache_one_in": 10,
     "create_timestamped_snapshot_one_in": 0,
 }
-
 
 def finalize_and_sanitize(src_params):
     dest_params = {k: v() if callable(v) else v for (k, v) in src_params.items()}


### PR DESCRIPTION
This PR adds initial stress testing for the user-defined timestamps in memtable only feature. Each flavor of the `*_ts` crash test get a 1 in 3 chance to run with timestamps not persisted, this setting is initialized once and kept consistent across the following re-runs. 

This initial stress test included these things besides disabling incompatible feature combinations to make the test run more stably: 
1) It currently only run test methods that validates db state with expected state. Not the ones that validate db state by comparing result from one API to another API. Such as `TestMultiGet` (compared with `Get`), similarly `TestMultiGetEntity`, `TestIterate` (compare src iterator to a control iterator). Due to timestamps being removed, results from one API to another API is not directly comparable as it is now. More test logic to handle that need to be added, will do that in a follow up.

2) Even when comparing db state to expected state, sometimes the db can receive `InvalidArgument` too due to timestamps getting flushed and removed. Added some logic to handle that.

3) When timestamps are not persisted, we don't try to read with older timestamp. Since that's making it easier to get `InvalidArgument`. And this capability is not yet needed by our customer so it's disabled for now.

Test plan:
running multiple flavor of this test on continuous run for sometime before checkin