### PR TITLE
Intensify "xxx_one_in"'s default value in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -31,10 +31,10 @@ import time
 
 
 default_params = {
-    "acquire_snapshot_one_in": 10000,
+    "acquire_snapshot_one_in": lambda: random.choice([100, 10000]),
     "backup_max_size": 100 * 1024 * 1024,
     # Consider larger number when backups considered more stable
-    "backup_one_in": 100000,
+    "backup_one_in": lambda: random.choice([1000, 100000]),
     "batch_protection_bytes_per_key": lambda: random.choice([0, 8]),
     "memtable_protection_bytes_per_key": lambda: random.choice([0, 1, 2, 4, 8]),
     "block_protection_bytes_per_key": lambda: random.choice([0, 1, 2, 4, 8]),
@@ -48,7 +48,7 @@ default_params = {
     "charge_filter_construction": lambda: random.choice([0, 1]),
     "charge_table_reader": lambda: random.choice([0, 1]),
     "charge_file_metadata": lambda: random.choice([0, 1]),
-    "checkpoint_one_in": 1000000,
+    "checkpoint_one_in":  lambda: random.choice([10000, 1000000]),
     "compression_type": lambda: random.choice(
         ["none", "snappy", "zlib", "lz4", "lz4hc", "xpress", "zstd"]
     ),
@@ -67,8 +67,8 @@ default_params = {
     "compression_use_zstd_dict_trainer": lambda: random.randint(0, 1),
     "compression_checksum": lambda: random.randint(0, 1),
     "clear_column_family_one_in": 0,
-    "compact_files_one_in": 1000000,
-    "compact_range_one_in": 1000000,
+    "compact_files_one_in":  lambda: random.choice([1000, 1000000]),
+    "compact_range_one_in":  lambda: random.choice([1000, 1000000]),
     "compaction_pri": random.randint(0, 4),
     "data_block_index_type": lambda: random.choice([0, 1]),
     "delpercent": 4,
@@ -78,19 +78,19 @@ default_params = {
     "enable_compaction_filter": lambda: random.choice([0, 0, 0, 1]),
     "expected_values_dir": lambda: setup_expected_values_dir(),
     "fail_if_options_file_error": lambda: random.randint(0, 1),
-    "flush_one_in": 1000000,
-    "manual_wal_flush_one_in": lambda: random.choice([0, 0, 1000, 1000000]),
+    "flush_one_in": lambda: random.choice([1000, 1000000]),
+    "manual_wal_flush_one_in": lambda: random.choice([0, 1000]),
     "file_checksum_impl": lambda: random.choice(["none", "crc32c", "xxh64", "big"]),
-    "get_live_files_one_in": 1000000,
+    "get_live_files_one_in": lambda: random.choice([10000, 1000000]),
     # Note: the following two are intentionally disabled as the corresponding
     # APIs are not guaranteed to succeed.
     "get_sorted_wal_files_one_in": 0,
     "get_current_wal_file_one_in": 0,
     # Temporarily disable hash index
     "index_type": lambda: random.choice([0, 0, 0, 2, 2, 3]),
-    "ingest_external_file_one_in": 1000000,
+    "ingest_external_file_one_in": lambda: random.choice([1000, 1000000]),
     "iterpercent": 10,
-    "lock_wal_one_in": 1000000,
+    "lock_wal_one_in": lambda: random.choice([10000, 1000000]),
     "mark_for_compaction_one_file_in": lambda: 10 * random.randint(0, 1),
     "max_background_compactions": 20,
     "max_bytes_for_level_base": 10485760,
@@ -105,7 +105,7 @@ default_params = {
     "optimize_filters_for_memory": lambda: random.randint(0, 1),
     "partition_filters": lambda: random.randint(0, 1),
     "partition_pinning": lambda: random.randint(0, 3),
-    "pause_background_one_in": 1000000,
+    "pause_background_one_in": lambda: random.choice([10000, 1000000]),
     "prefix_size": lambda: random.choice([-1, 1, 5, 7, 8]),
     "prefixpercent": 5,
     "progress_reports": 0,
@@ -175,9 +175,9 @@ default_params = {
         [16, 64, 1024 * 1024, 16 * 1024 * 1024]
     ),
     "level_compaction_dynamic_level_bytes": lambda: random.randint(0, 1),
-    "verify_checksum_one_in": 1000000,
-    "verify_file_checksums_one_in": 1000000,
-    "verify_db_one_in": 100000,
+    "verify_checksum_one_in": lambda: random.choice([100000, 1000000]),
+    "verify_file_checksums_one_in": lambda: random.choice([100000, 1000000]),
+    "verify_db_one_in": lambda: random.choice([10000, 100000]),
     "continuous_verification_interval": 0,
     "max_key_len": 3,
     "key_len_percent_dist": "1,30,69",
@@ -187,7 +187,7 @@ default_params = {
     "open_write_fault_one_in": lambda: random.choice([0, 0, 16]),
     "open_read_fault_one_in": lambda: random.choice([0, 0, 32]),
     "sync_fault_injection": lambda: random.randint(0, 1),
-    "get_property_one_in": 1000000,
+    "get_property_one_in":  lambda: random.choice([100000, 1000000]),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
     "max_write_buffer_size_to_maintain": lambda: random.choice(
         [0, 1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024, 8 * 1024 * 1024]


### PR DESCRIPTION
**Context/Summary:**
My experimental stress runs with more frequent "xxx_one_in" surfaced a couple interesting bugs/issues with RocksDB or crash test framework in the past. We now consider changing the default value so they are run more frequently in production testing environment.

Increase frequency by 2 orders of magnitude for most parameters, except for error-prone features e.g, manual compaction and file ingestion (increased by 3 orders) and expensive features e.g, checksum verification (increased by 1 order)

**Test:**
Monitor CI to see if it did surface more interesting bugs/issues. If not, we may consider intensify even more.