### PR TITLE
Turn the default Timer in PeriodicTaskScheduler into a leaky Meyers singleton

### DIFF
--- a/db/periodic_task_scheduler.cc
+++ b/db/periodic_task_scheduler.cc
@@ -94,7 +94,7 @@ Status PeriodicTaskScheduler::Unregister(PeriodicTaskType task_type) {
 }
 
 Timer* PeriodicTaskScheduler::Default() {
-  static Timer timer(SystemClock::Default().get());
+  STATIC_AVOID_DESTRUCTION(Timer, timer)(SystemClock::Default().get());
   return &timer;
 }
 
@@ -108,4 +108,3 @@ void PeriodicTaskScheduler::TEST_OverrideTimer(SystemClock* clock) {
 #endif  // NDEBUG
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/unreleased_history/bug_fixes/avoid_destroying_timer.md
+++ b/unreleased_history/bug_fixes/avoid_destroying_timer.md
@@ -1,0 +1,1 @@
+Avoid destroying the periodic task scheduler's default timer in order to prevent static destruction order issues.


### PR DESCRIPTION
Summary: The patch turns the `Timer` Meyers singleton in `PeriodicTaskScheduler::Default()` into one of the leaky variety in order to prevent static destruction order issues.

Differential Revision: D51963950


