### PR TITLE
Allow TablePropertiesCollectorFactory to return null collector

### DIFF
--- a/db/db_table_properties_test.cc
+++ b/db/db_table_properties_test.cc
@@ -22,6 +22,7 @@
 #include "table/table_properties_internal.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
+#include "util/atomic.h"
 #include "util/random.h"
 
 
@@ -414,6 +415,71 @@ TEST_F(DBTablePropertiesTest, GetDbIdentifiersProperty) {
     ASSERT_OK(db_->GetDbSessionId(sid));
     ASSERT_EQ(id, fname_to_props.begin()->second->db_id);
     ASSERT_EQ(sid, fname_to_props.begin()->second->db_session_id);
+  }
+}
+
+TEST_F(DBTablePropertiesTest, FactoryReturnsNull) {
+  struct JunkTablePropertiesCollector : public TablePropertiesCollector {
+    const char* Name() const override { return "JunkTablePropertiesCollector"; }
+    Status Finish(UserCollectedProperties* properties) override {
+      properties->insert({"Junk", "Junk"});
+      return Status::OK();
+    }
+    UserCollectedProperties GetReadableProperties() const override {
+      return {};
+    }
+  };
+
+  // Alternates between putting a "Junk" property and using `nullptr` to
+  // opt out.
+  static RelaxedAtomic<int> count{0};
+  struct SometimesTablePropertiesCollectorFactory
+      : public TablePropertiesCollectorFactory {
+    const char* Name() const override {
+      return "SometimesTablePropertiesCollectorFactory";
+    }
+    TablePropertiesCollector* CreateTablePropertiesCollector(
+        TablePropertiesCollectorFactory::Context /*context*/) override {
+      if (count.FetchAddRelaxed(1) & 1) {
+        return nullptr;
+      } else {
+        return new JunkTablePropertiesCollector();
+      }
+    }
+  };
+
+  Options options = CurrentOptions();
+  options.table_properties_collector_factories.emplace_back(
+      std::make_shared<SometimesTablePropertiesCollectorFactory>());
+  // For plain table
+  options.prefix_extractor.reset(NewFixedPrefixTransform(4));
+  for (std::shared_ptr<TableFactory> tf :
+       {options.table_factory,
+        std::shared_ptr<TableFactory>(NewPlainTableFactory({}))}) {
+    SCOPED_TRACE("Table factory = " + std::string(tf->Name()));
+    options.table_factory = tf;
+
+    DestroyAndReopen(options);
+
+    ASSERT_OK(Put("key0", "value1"));
+    ASSERT_OK(Flush());
+    ASSERT_OK(Put("key0", "value2"));
+    ASSERT_OK(Flush());
+
+    TablePropertiesCollection props;
+    ASSERT_OK(db_->GetPropertiesOfAllTables(&props));
+    int no_junk_count = 0;
+    int junk_count = 0;
+    for (const auto& item : props) {
+      if (item.second->user_collected_properties.find("Junk") !=
+          item.second->user_collected_properties.end()) {
+        junk_count++;
+      } else {
+        no_junk_count++;
+      }
+    }
+    EXPECT_EQ(1, no_junk_count);
+    EXPECT_EQ(1, junk_count);
   }
 }
 

--- a/db/table_properties_collector.h
+++ b/db/table_properties_collector.h
@@ -98,8 +98,13 @@ class UserKeyTablePropertiesCollectorFactory
     TablePropertiesCollectorFactory::Context context;
     context.column_family_id = column_family_id;
     context.level_at_creation = level_at_creation;
-    return new UserKeyTablePropertiesCollector(
-        user_collector_factory_->CreateTablePropertiesCollector(context));
+    TablePropertiesCollector* collector =
+        user_collector_factory_->CreateTablePropertiesCollector(context);
+    if (collector) {
+      return new UserKeyTablePropertiesCollector(collector);
+    } else {
+      return nullptr;
+    }
   }
 
   virtual const char* Name() const override {

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -140,8 +140,7 @@ class TablePropertiesCollector {
   virtual bool NeedCompact() const { return false; }
 };
 
-// Constructs TablePropertiesCollector. Internals create a new
-// TablePropertiesCollector for each new table
+// Constructs TablePropertiesCollector instances for each table file creation.
 //
 // Exceptions MUST NOT propagate out of overridden functions into RocksDB,
 // because RocksDB is not exception-safe. This could cause undefined behavior
@@ -163,7 +162,12 @@ class TablePropertiesCollectorFactory : public Customizable {
       const ConfigOptions& options, const std::string& value,
       std::shared_ptr<TablePropertiesCollectorFactory>* result);
 
-  // has to be thread-safe
+  // To collect properties of a table with the given context, returns
+  // a new object inheriting from TablePropertiesCollector. The caller
+  // is responsible for deleting the object returned. Alternatively,
+  // nullptr may be returned to decline collecting properties for the
+  // file (and reduce callback overheads).
+  // MUST be thread-safe.
   virtual TablePropertiesCollector* CreateTablePropertiesCollector(
       TablePropertiesCollectorFactory::Context context) = 0;
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -577,9 +577,12 @@ struct BlockBasedTableBuilder::Rep {
     for (auto& factory : *tbo.int_tbl_prop_collector_factories) {
       assert(factory);
 
-      table_properties_collectors.emplace_back(
+      std::unique_ptr<IntTblPropCollector> collector{
           factory->CreateIntTblPropCollector(tbo.column_family_id,
-                                             tbo.level_at_creation));
+                                             tbo.level_at_creation)};
+      if (collector) {
+        table_properties_collectors.emplace_back(std::move(collector));
+      }
     }
     table_properties_collectors.emplace_back(
         new BlockBasedTablePropertiesCollector(

--- a/table/plain/plain_table_builder.cc
+++ b/table/plain/plain_table_builder.cc
@@ -118,9 +118,12 @@ PlainTableBuilder::PlainTableBuilder(
   for (auto& factory : *int_tbl_prop_collector_factories) {
     assert(factory);
 
-    table_properties_collectors_.emplace_back(
+    std::unique_ptr<IntTblPropCollector> collector{
         factory->CreateIntTblPropCollector(column_family_id,
-                                           level_at_creation));
+                                           level_at_creation)};
+    if (collector) {
+      table_properties_collectors_.emplace_back(std::move(collector));
+    }
   }
 }
 

--- a/unreleased_history/public_api_changes/null_collector.md
+++ b/unreleased_history/public_api_changes/null_collector.md
@@ -1,0 +1,1 @@
+Custom implementations of `TablePropertiesCollectorFactory` may now return a `nullptr` collector to decline processing a file, reducing callback overheads in such cases.


### PR DESCRIPTION
Summary: As part of building another feature, I wanted this:
* Custom implementations of `TablePropertiesCollectorFactory` may now return a `nullptr` collector to decline processing a file, reducing callback overheads in such cases.
* Polished, clarified some related API comments.

Test Plan: unit test added