### PR TITLE
Speedup based on pending compaction bytes relative to data size

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -866,8 +866,8 @@ int GetL0FileCountForCompactionSpeedup(int level0_file_num_compaction_trigger,
 }
 
 uint64_t GetPendingCompactionBytesForCompactionSpeedup(
-    uint64_t soft_pending_compaction_bytes_limit) {
-  return soft_pending_compaction_bytes_limit / 4;
+    const MutableCFOptions& mutable_cf_options) {
+  return mutable_cf_options.soft_pending_compaction_bytes_limit / 4;
 }
 }  // anonymous namespace
 
@@ -1036,7 +1036,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
             name_.c_str(), vstorage->l0_delay_trigger_count());
       } else if (vstorage->estimated_compaction_needed_bytes() >=
                  GetPendingCompactionBytesForCompactionSpeedup(
-                     mutable_cf_options.soft_pending_compaction_bytes_limit)) {
+                     mutable_cf_options)) {
         // Increase compaction threads if bytes needed for compaction exceeds
         // 1/4 of threshold for slowing down.
         // If soft pending compaction byte limit is not set, always speed up

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -879,8 +879,8 @@ uint64_t GetPendingCompactionBytesForCompactionSpeedup(
     bottommost_files_size += level_and_file.second->fd.GetFileSize();
   }
 
-  // Soft limit might be zero but that means compaction speedup should always
-  // happen, so no special treatment is needed.
+  // Slowdown trigger might be zero but that means compaction speedup should
+  // always happen (undocumented/historical), so no special treatment is needed.
   uint64_t slowdown_threshold =
       mutable_cf_options.soft_pending_compaction_bytes_limit /
       kSlowdownTriggerDivisor;

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -866,8 +866,33 @@ int GetL0FileCountForCompactionSpeedup(int level0_file_num_compaction_trigger,
 }
 
 uint64_t GetPendingCompactionBytesForCompactionSpeedup(
-    const MutableCFOptions& mutable_cf_options) {
-  return mutable_cf_options.soft_pending_compaction_bytes_limit / 4;
+    const MutableCFOptions& mutable_cf_options,
+    const VersionStorageInfo* vstorage) {
+  // Compaction debt relatively large compared to the stable (bottommost) data
+  // size indicates compaction fell behind.
+  const uint64_t kBottommostSizeMultiplier = 8;
+  // Meaningful progress toward the slowdown trigger is another good indication.
+  const uint64_t kSlowdownTriggerDivisor = 4;
+
+  uint64_t bottommost_files_size = 0;
+  for (const auto& level_and_file : vstorage->BottommostFiles()) {
+    bottommost_files_size += level_and_file.second->fd.GetFileSize();
+  }
+
+  // Soft limit might be zero but that means compaction speedup should always
+  // happen, so no special treatment is needed.
+  uint64_t slowdown_threshold =
+      mutable_cf_options.soft_pending_compaction_bytes_limit /
+      kSlowdownTriggerDivisor;
+
+  // Size of zero, however, should not be used to decide to speedup compaction.
+  if (bottommost_files_size == 0) {
+    return slowdown_threshold;
+  }
+
+  uint64_t size_threshold =
+      MultiplyCheckOverflow(bottommost_files_size, kBottommostSizeMultiplier);
+  return std::min(size_threshold, slowdown_threshold);
 }
 }  // anonymous namespace
 
@@ -1034,23 +1059,22 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
             "[%s] Increasing compaction threads because we have %d level-0 "
             "files ",
             name_.c_str(), vstorage->l0_delay_trigger_count());
-      } else if (vstorage->estimated_compaction_needed_bytes() >=
-                 GetPendingCompactionBytesForCompactionSpeedup(
-                     mutable_cf_options)) {
-        // Increase compaction threads if bytes needed for compaction exceeds
-        // 1/4 of threshold for slowing down.
+      } else if (mutable_cf_options.soft_pending_compaction_bytes_limit == 0) {
         // If soft pending compaction byte limit is not set, always speed up
         // compaction.
         write_controller_token_ =
             write_controller->GetCompactionPressureToken();
-        if (mutable_cf_options.soft_pending_compaction_bytes_limit > 0) {
-          ROCKS_LOG_INFO(
-              ioptions_.logger,
-              "[%s] Increasing compaction threads because of estimated pending "
-              "compaction "
-              "bytes %" PRIu64,
-              name_.c_str(), vstorage->estimated_compaction_needed_bytes());
-        }
+      } else if (vstorage->estimated_compaction_needed_bytes() >=
+                 GetPendingCompactionBytesForCompactionSpeedup(
+                     mutable_cf_options, vstorage)) {
+        write_controller_token_ =
+            write_controller->GetCompactionPressureToken();
+        ROCKS_LOG_INFO(
+            ioptions_.logger,
+            "[%s] Increasing compaction threads because of estimated pending "
+            "compaction "
+            "bytes %" PRIu64,
+            name_.c_str(), vstorage->estimated_compaction_needed_bytes());
       } else {
         write_controller_token_.reset();
       }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3067,9 +3067,7 @@ void VersionStorageInfo::PrepareForVersionAppend(
   GenerateFileIndexer();
   GenerateLevelFilesBrief();
   GenerateLevel0NonOverlapping();
-  if (!immutable_options.allow_ingest_behind) {
-    GenerateBottommostFiles();
-  }
+  GenerateBottommostFiles();
   GenerateFileLocationIndex();
 }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -490,6 +490,13 @@ class VersionStorageInfo {
     files_marked_for_periodic_compaction_.emplace_back(level, f);
   }
 
+  // REQUIRES: PrepareForVersionAppend has been called
+  const autovector<std::pair<int, FileMetaData*>>&
+  BottommostFiles() const {
+    assert(finalized_);
+    return bottommost_files_;
+  }
+
   // REQUIRES: ComputeCompactionScore has been called
   // REQUIRES: DB mutex held during access
   const autovector<std::pair<int, FileMetaData*>>&

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -491,8 +491,7 @@ class VersionStorageInfo {
   }
 
   // REQUIRES: PrepareForVersionAppend has been called
-  const autovector<std::pair<int, FileMetaData*>>&
-  BottommostFiles() const {
+  const autovector<std::pair<int, FileMetaData*>>& BottommostFiles() const {
     assert(finalized_);
     return bottommost_files_;
   }

--- a/unreleased_history/behavior_changes/debt_based_speedup.md
+++ b/unreleased_history/behavior_changes/debt_based_speedup.md
@@ -1,0 +1,1 @@
+Compactions can be scheduled in parallel in an additional scenario: high compaction debt relative to the data size


### PR DESCRIPTION
RocksDB self throttles per-DB compaction parallelism until it detects compaction pressure. The pressure detection based on pending compaction bytes was only comparing against the slowdown trigger (`soft_pending_compaction_bytes_limit`). Online services tend to set that extremely high to avoid stalling at all costs. Perhaps they should have set it to zero, but we never documented that zero disables stalling so I have been telling everyone to increase it for years.

This PR adds pressure detection based on pending compaction bytes relative to the size of bottommost data. The size of bottommost data should be fairly stable and proportional to the logical data size