### PR TITLE
Fix false negative in TieredSecondaryCache nvm cache lookup

### DIFF
--- a/cache/tiered_secondary_cache.cc
+++ b/cache/tiered_secondary_cache.cc
@@ -109,8 +109,7 @@ void TieredSecondaryCache::WaitAll(
   }
   nvm_sec_cache_->WaitAll(nvm_handles);
   for (auto handle : my_handles) {
-    auto nvm_handle = handle->inner_handle();
-    assert(nvm_handle->IsReady());
+    assert(handle->inner_handle()->IsReady());
     handle->Complete();
   }
 }

--- a/cache/tiered_secondary_cache.cc
+++ b/cache/tiered_secondary_cache.cc
@@ -109,10 +109,9 @@ void TieredSecondaryCache::WaitAll(
   }
   nvm_sec_cache_->WaitAll(nvm_handles);
   for (auto handle : my_handles) {
-    assert(handle->IsReady());
     auto nvm_handle = handle->inner_handle();
-    handle->SetSize(nvm_handle->Size());
-    handle->SetValue(nvm_handle->Value());
+    assert(nvm_handle->IsReady());
+    handle->Complete();
   }
 }
 

--- a/cache/tiered_secondary_cache_test.cc
+++ b/cache/tiered_secondary_cache_test.cc
@@ -212,7 +212,7 @@ class DBTieredSecondaryCacheTest : public DBTestBase {
 
   void ClearPrimaryCache() {
     ASSERT_EQ(UpdateTieredCache(cache_, -1, 1.0), Status::OK());
-    ASSERT_EQ(UpdateTieredCache(cache_, compressed_secondary_ratio_),
+    ASSERT_EQ(UpdateTieredCache(cache_, -1, compressed_secondary_ratio_),
               Status::OK());
   }
 

--- a/cache/tiered_secondary_cache_test.cc
+++ b/cache/tiered_secondary_cache_test.cc
@@ -696,7 +696,7 @@ TEST_F(DBTieredSecondaryCacheTest, ReadyBeforeWaitAllTest) {
   }
   ASSERT_EQ(nvm_sec_cache()->num_insert_saved(), 8u);
   ASSERT_EQ(nvm_sec_cache()->num_misses(), 8u);
-  ASSERT_EQ(nvm_sec_cache()->num_hits(), 6u);
+  ASSERT_EQ(nvm_sec_cache()->num_hits(), 4u);
   ASSERT_EQ(options.statistics->getTickerCount(BLOCK_CACHE_MISS), 8u);
 
   Destroy(options);

--- a/cache/tiered_secondary_cache_test.cc
+++ b/cache/tiered_secondary_cache_test.cc
@@ -15,10 +15,11 @@ namespace ROCKSDB_NAMESPACE {
 
 class TestSecondaryCache : public SecondaryCache {
  public:
-  explicit TestSecondaryCache(size_t capacity)
+  explicit TestSecondaryCache(size_t capacity, bool ready_before_wait)
       : cache_(NewLRUCache(capacity, 0, false, 0.5 /* high_pri_pool_ratio */,
                            nullptr, kDefaultToAdaptiveMutex,
                            kDontChargeCacheMetadata)),
+        ready_before_wait_(ready_before_wait),
         num_insert_saved_(0),
         num_hits_(0),
         num_misses_(0) {}
@@ -88,7 +89,8 @@ class TestSecondaryCache : public SecondaryCache {
                             /*alloc*/ nullptr, &value, &charge);
       if (s.ok()) {
         secondary_handle.reset(new TestSecondaryCacheResultHandle(
-            cache_.get(), handle, value, charge, /*ready=*/wait));
+            cache_.get(), handle, value, charge,
+            /*ready=*/wait || ready_before_wait_));
         kept_in_sec_cache = true;
       } else {
         cache_.Release(handle);
@@ -168,6 +170,7 @@ class TestSecondaryCache : public SecondaryCache {
       BasicTypedSharedCacheInterface<char[], CacheEntryRole::kMisc>;
   using TypedHandle = SharedCache::TypedHandle;
   SharedCache cache_;
+  bool ready_before_wait_;
   uint32_t num_insert_saved_;
   uint32_t num_hits_;
   uint32_t num_misses_;
@@ -179,11 +182,10 @@ class DBTieredSecondaryCacheTest : public DBTestBase {
   DBTieredSecondaryCacheTest()
       : DBTestBase("db_tiered_secondary_cache_test", /*env_do_fsync=*/true) {}
 
-  std::shared_ptr<Cache> NewCache(size_t pri_capacity,
-                                  size_t compressed_capacity,
-                                  size_t nvm_capacity,
-                                  TieredAdmissionPolicy adm_policy =
-                                      TieredAdmissionPolicy::kAdmPolicyAuto) {
+  std::shared_ptr<Cache> NewCache(
+      size_t pri_capacity, size_t compressed_capacity, size_t nvm_capacity,
+      TieredAdmissionPolicy adm_policy = TieredAdmissionPolicy::kAdmPolicyAuto,
+      bool ready_before_wait = false) {
     LRUCacheOptions lru_opts;
     TieredCacheOptions opts;
     lru_opts.capacity = 0;
@@ -194,10 +196,11 @@ class DBTieredSecondaryCacheTest : public DBTestBase {
     opts.comp_cache_opts.capacity = 0;
     opts.comp_cache_opts.num_shard_bits = 0;
     opts.total_capacity = pri_capacity + compressed_capacity;
-    opts.compressed_secondary_ratio =
+    opts.compressed_secondary_ratio = compressed_secondary_ratio_ =
         (double)compressed_capacity / opts.total_capacity;
     if (nvm_capacity > 0) {
-      nvm_sec_cache_.reset(new TestSecondaryCache(nvm_capacity));
+      nvm_sec_cache_.reset(
+          new TestSecondaryCache(nvm_capacity, ready_before_wait));
       opts.nvm_sec_cache = nvm_sec_cache_;
     }
     opts.adm_policy = adm_policy;
@@ -205,6 +208,12 @@ class DBTieredSecondaryCacheTest : public DBTestBase {
     assert(cache_ != nullptr);
 
     return cache_;
+  }
+
+  void ClearPrimaryCache() {
+    ASSERT_EQ(UpdateTieredCache(cache_, -1, 1.0), Status::OK());
+    ASSERT_EQ(UpdateTieredCache(cache_, compressed_secondary_ratio_),
+              Status::OK());
   }
 
   TestSecondaryCache* nvm_sec_cache() { return nvm_sec_cache_.get(); }
@@ -218,6 +227,7 @@ class DBTieredSecondaryCacheTest : public DBTestBase {
  private:
   std::shared_ptr<Cache> cache_;
   std::shared_ptr<TestSecondaryCache> nvm_sec_cache_;
+  double compressed_secondary_ratio_;
 };
 
 // In this test, the block size is set to 4096. Each value is 1007 bytes, so
@@ -578,6 +588,116 @@ TEST_F(DBTieredSecondaryCacheTest, WaitAllTest) {
   ASSERT_EQ(nvm_sec_cache()->num_insert_saved(), 10u);
   ASSERT_EQ(nvm_sec_cache()->num_misses(), 10u);
   ASSERT_EQ(nvm_sec_cache()->num_hits(), 4u);
+
+  Destroy(options);
+}
+
+TEST_F(DBTieredSecondaryCacheTest, ReadyBeforeWaitAllTest) {
+  if (!LZ4_Supported()) {
+    ROCKSDB_GTEST_SKIP("This test requires LZ4 support.");
+    return;
+  }
+
+  BlockBasedTableOptions table_options;
+  table_options.block_cache = NewCache(250 * 1024, 20 * 1024, 256 * 1024,
+                                       TieredAdmissionPolicy::kAdmPolicyAuto,
+                                       /*ready_before_wait=*/true);
+  table_options.block_size = 4 * 1024;
+  table_options.cache_index_and_filter_blocks = false;
+  Options options = GetDefaultOptions();
+  options.create_if_missing = true;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  options.statistics = CreateDBStatistics();
+
+  options.paranoid_file_checks = false;
+  DestroyAndReopen(options);
+  Random rnd(301);
+  const int N = 256;
+  for (int i = 0; i < N; i++) {
+    std::string p_v;
+    test::CompressibleString(&rnd, 0.5, 1007, &p_v);
+    ASSERT_OK(Put(Key(i), p_v));
+  }
+
+  ASSERT_OK(Flush());
+
+  std::vector<std::string> keys;
+  std::vector<std::string> values;
+
+  keys.push_back(Key(0));
+  keys.push_back(Key(4));
+  keys.push_back(Key(8));
+  values = MultiGet(keys, /*snapshot=*/nullptr, /*async=*/true);
+  ASSERT_EQ(values.size(), keys.size());
+  for (auto value : values) {
+    ASSERT_EQ(1007, value.size());
+  }
+  ASSERT_EQ(nvm_sec_cache()->num_insert_saved(), 3u);
+  ASSERT_EQ(nvm_sec_cache()->num_misses(), 3u);
+  ASSERT_EQ(nvm_sec_cache()->num_hits(), 0u);
+  ASSERT_EQ(options.statistics->getTickerCount(BLOCK_CACHE_MISS), 3u);
+
+  keys.clear();
+  values.clear();
+  keys.push_back(Key(12));
+  keys.push_back(Key(16));
+  keys.push_back(Key(20));
+  values = MultiGet(keys, /*snapshot=*/nullptr, /*async=*/true);
+  ASSERT_EQ(values.size(), keys.size());
+  for (auto value : values) {
+    ASSERT_EQ(1007, value.size());
+  }
+  ASSERT_EQ(nvm_sec_cache()->num_insert_saved(), 6u);
+  ASSERT_EQ(nvm_sec_cache()->num_misses(), 6u);
+  ASSERT_EQ(nvm_sec_cache()->num_hits(), 0u);
+  ASSERT_EQ(options.statistics->getTickerCount(BLOCK_CACHE_MISS), 6u);
+
+  keys.clear();
+  values.clear();
+  keys.push_back(Key(0));
+  keys.push_back(Key(4));
+  keys.push_back(Key(8));
+  values = MultiGet(keys, /*snapshot=*/nullptr, /*async=*/true);
+  ASSERT_EQ(values.size(), keys.size());
+  for (auto value : values) {
+    ASSERT_EQ(1007, value.size());
+  }
+  ASSERT_EQ(nvm_sec_cache()->num_insert_saved(), 6u);
+  ASSERT_EQ(nvm_sec_cache()->num_misses(), 6u);
+  ASSERT_EQ(nvm_sec_cache()->num_hits(), 3u);
+  ASSERT_EQ(options.statistics->getTickerCount(BLOCK_CACHE_MISS), 6u);
+
+  ClearPrimaryCache();
+
+  keys.clear();
+  values.clear();
+  keys.push_back(Key(0));
+  keys.push_back(Key(32));
+  keys.push_back(Key(36));
+  values = MultiGet(keys, /*snapshot=*/nullptr, /*async=*/true);
+  ASSERT_EQ(values.size(), keys.size());
+  for (auto value : values) {
+    ASSERT_EQ(1007, value.size());
+  }
+  ASSERT_EQ(nvm_sec_cache()->num_insert_saved(), 8u);
+  ASSERT_EQ(nvm_sec_cache()->num_misses(), 8u);
+  ASSERT_EQ(nvm_sec_cache()->num_hits(), 4u);
+  ASSERT_EQ(options.statistics->getTickerCount(BLOCK_CACHE_MISS), 8u);
+
+  keys.clear();
+  values.clear();
+  keys.push_back(Key(0));
+  keys.push_back(Key(32));
+  keys.push_back(Key(36));
+  values = MultiGet(keys, /*snapshot=*/nullptr, /*async=*/true);
+  ASSERT_EQ(values.size(), keys.size());
+  for (auto value : values) {
+    ASSERT_EQ(1007, value.size());
+  }
+  ASSERT_EQ(nvm_sec_cache()->num_insert_saved(), 8u);
+  ASSERT_EQ(nvm_sec_cache()->num_misses(), 8u);
+  ASSERT_EQ(nvm_sec_cache()->num_hits(), 6u);
+  ASSERT_EQ(options.statistics->getTickerCount(BLOCK_CACHE_MISS), 8u);
 
   Destroy(options);
 }

--- a/unreleased_history/bug_fixes/tiered_cache_low_latency_false_negative.md
+++ b/unreleased_history/bug_fixes/tiered_cache_low_latency_false_negative.md
@@ -1,0 +1,1 @@
+A lookup by MultiGet in a TieredCache that goes to the local flash cache and finishes with very low latency, i.e before the subsequent call to WaitAll, is ignored, resulting in a false negative and a memory leak.


### PR DESCRIPTION
There is a bug in the `TieredSecondaryCache` that can result in a false negative. This can happen when a MultiGet does a cache lookup that gets a hit in the `TieredSecondaryCache` local nvm cache tier, and the result is available before MultiGet calls `WaitAll` (i.e the nvm cache `SecondaryCacheResultHandle` `IsReady` returns true).

Test plan:
Add a new unit test in tiered_secondary_cache_test