### PR TITLE
Add support for linux-riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2060,7 +2060,7 @@ JAVA_INCLUDE = -I$(JAVA_HOME)/include/ -I$(JAVA_HOME)/include/linux
 ifeq ($(PLATFORM), OS_SOLARIS)
 	ARCH := $(shell isainfo -b)
 else ifeq ($(PLATFORM), OS_OPENBSD)
-	ifneq (,$(filter amd64 ppc64 ppc64le s390x arm64 aarch64 sparc64 loongarch64, $(MACHINE)))
+	ifneq (,$(filter amd64 ppc64 ppc64le s390x arm64 aarch64 riscv64 sparc64 loongarch64, $(MACHINE)))
 		ARCH := 64
 	else
 		ARCH := 32
@@ -2081,7 +2081,7 @@ ifneq ($(origin JNI_LIBC), undefined)
 endif
 
 ifeq (,$(ROCKSDBJNILIB))
-ifneq (,$(filter ppc% s390x arm64 aarch64 sparc64 loongarch64, $(MACHINE)))
+ifneq (,$(filter ppc% s390x arm64 aarch64 riscv64 sparc64 loongarch64, $(MACHINE)))
 	ROCKSDBJNILIB = librocksdbjni-linux-$(MACHINE)$(JNI_LIBC_POSTFIX).so
 else
 	ROCKSDBJNILIB = librocksdbjni-linux$(ARCH)$(JNI_LIBC_POSTFIX).so
@@ -2345,6 +2345,10 @@ rocksdbjavastaticdockerarm64v8:
 rocksdbjavastaticdockers390x:
 	mkdir -p java/target
 	docker run --rm --name rocksdb_linux_s390x-be --attach stdin --attach stdout --attach stderr --volume $(HOME)/.m2:/root/.m2:ro --volume `pwd`:/rocksdb-host:ro --volume /rocksdb-local-build --volume `pwd`/java/target:/rocksdb-java-target --env DEBUG_LEVEL=$(DEBUG_LEVEL) evolvedbinary/rocksjava:ubuntu18_s390x-be /rocksdb-host/java/crossbuild/docker-build-linux-centos.sh
+
+rocksdbjavastaticdockerriscv64:
+	mkdir -p java/target
+	docker run --rm --name rocksdb_linux_riscv64-be --attach stdin --attach stdout --attach stderr --volume $(HOME)/.m2:/root/.m2:ro --volume `pwd`:/rocksdb-host:ro --volume /rocksdb-local-build --volume `pwd`/java/target:/rocksdb-java-target --env DEBUG_LEVEL=$(DEBUG_LEVEL) evolvedbinary/rocksjava:ubuntu20_riscv64-be /rocksdb-host/java/crossbuild/docker-build-linux-centos.sh
 
 rocksdbjavastaticdockerx86musl:
 	mkdir -p java/target

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -647,8 +647,10 @@ if [ "$PORTABLE" == "" ] || [ "$PORTABLE" == 0 ]; then
     fi
     COMMON_FLAGS="$COMMON_FLAGS"
   elif test -n "`echo $TARGET_ARCHITECTURE | grep ^riscv64`"; then
-    RISC_ISA=$(cat /proc/cpuinfo | grep isa | head -1 | cut --delimiter=: -f 2 | cut -b 2-)
-    COMMON_FLAGS="$COMMON_FLAGS -march=${RISC_ISA}"
+    RISC_ISA=$(cat /proc/cpuinfo | grep -E '^isa\s*:' | head -1 | cut --delimiter=: -f 2 | cut -b 2-)
+    if [ -n "${RISCV_ISA}" ]; then
+      COMMON_FLAGS="$COMMON_FLAGS -march=${RISC_ISA}"
+    fi
   elif [ "$TARGET_OS" == "IOS" ]; then
     COMMON_FLAGS="$COMMON_FLAGS"
   else
@@ -660,8 +662,7 @@ else
     if test -n "`echo $TARGET_ARCHITECTURE | grep ^s390x`"; then
       COMMON_FLAGS="$COMMON_FLAGS -march=z196 "
     elif test -n "`echo $TARGET_ARCHITECTURE | grep ^riscv64`"; then
-      RISC_ISA=$(cat /proc/cpuinfo | grep isa | head -1 | cut --delimiter=: -f 2 | cut -b 2-)
-      COMMON_FLAGS="$COMMON_FLAGS -march=${RISC_ISA}"
+      COMMON_FLAGS="$COMMON_FLAGS -march=rv64gc"
     elif test "$USE_SSE"; then
       # USE_SSE is DEPRECATED
       # This is a rough approximation of the old USE_SSE behavior

--- a/java/src/main/java/org/rocksdb/util/Environment.java
+++ b/java/src/main/java/org/rocksdb/util/Environment.java
@@ -36,6 +36,10 @@ public class Environment {
     return ARCH.contains("s390x");
   }
 
+  public static boolean isRISCV() {
+    return ARCH.contains("riscv64");
+  }
+
   public static boolean isWindows() {
     return (OS.contains("win"));
   }
@@ -180,7 +184,7 @@ public class Environment {
   public static String getJniLibraryName(final String name) {
     if (isUnix()) {
       final String arch = is64Bit() ? "64" : "32";
-      if (isPowerPC() || isAarch64()) {
+      if (isPowerPC() || isAarch64() || isRISCV()) {
         return String.format("%sjni-linux-%s%s", name, ARCH, getLibcPostfix());
       } else if (isS390x()) {
         return String.format("%sjni-linux-%s", name, ARCH);

--- a/java/src/main/java/org/rocksdb/util/Environment.java
+++ b/java/src/main/java/org/rocksdb/util/Environment.java
@@ -36,7 +36,7 @@ public class Environment {
     return ARCH.contains("s390x");
   }
 
-  public static boolean isRISCV() {
+  public static boolean isRiscv64() {
     return ARCH.contains("riscv64");
   }
 
@@ -184,7 +184,7 @@ public class Environment {
   public static String getJniLibraryName(final String name) {
     if (isUnix()) {
       final String arch = is64Bit() ? "64" : "32";
-      if (isPowerPC() || isAarch64() || isRISCV()) {
+      if (isPowerPC() || isAarch64() || isRiscv64()) {
         return String.format("%sjni-linux-%s%s", name, ARCH, getLibcPostfix());
       } else if (isS390x()) {
         return String.format("%sjni-linux-%s", name, ARCH);


### PR DESCRIPTION
Following https://github.com/evolvedbinary/docker-rocksjava/pull/2, we can now build rocksdb on riscv64.

I've verified this works as expected with `make rocksdbjavastaticdockerriscv64`.

Also fixes https://github.com/facebook/rocksdb/issues/10500 https://github.com/facebook/rocksdb/issues/11994