### PR TITLE
Fix WRITE_STALL start_time

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1839,11 +1839,12 @@ Status DBImpl::DelayWrite(uint64_t num_bytes, WriteThread& write_thread,
       delay = 0;
     }
     TEST_SYNC_POINT("DBImpl::DelayWrite:Start");
+    start_time = immutable_db_options_.clock->NowMicros();
+
     if (delay > 0) {
       if (write_options.no_slowdown) {
         return Status::Incomplete("Write stall");
       }
-      start_time = immutable_db_options_.clock->NowMicros();
       TEST_SYNC_POINT("DBImpl::DelayWrite:Sleep");
 
       // Notify write_thread about the stall so it can setup a barrier and

--- a/unreleased_history/bug_fixes/fix_stall_counter.md
+++ b/unreleased_history/bug_fixes/fix_stall_counter.md
@@ -1,0 +1,1 @@
+Fix a WRITE_STALL counter that was reporting wrong value in few cases.


### PR DESCRIPTION
Summary: `Delayed` is set true in two cases. One is when `delay` is specified. Other one is in the `while` loop - https://github.com/facebook/rocksdb/blob/cd21e4e69d76ec4ec3b080c8cdae016ac2309cc5/db/db_impl/db_impl_write.cc#L1876 
However start_time is not initialized in second case, resulting in time_delayed = immutable_db_options_.clock->NowMicros() - 0(start_time); 

Test Plan: Existing CircleCI

Reviewers:

Subscribers:

Tasks:

Tags: