### PR TITLE
Fix ldbcmd cant use custom comparator

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -762,6 +762,10 @@ void LDBCommand::OverrideBaseCFOptions(ColumnFamilyOptions* cf_opts) {
     }
   }
 
+  if (options_.comparator != nullptr) {
+    cf_opts->comparator = options_.comparator;
+  }
+
   cf_opts->force_consistency_checks = force_consistency_checks_;
   if (use_table_options) {
     cf_opts->table_factory.reset(NewBlockBasedTableFactory(table_options));

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -14,6 +14,7 @@
 #include "file/filename.h"
 #include "port/stack_trace.h"
 #include "rocksdb/advanced_options.h"
+#include "rocksdb/comparator.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb/file_checksum.h"
@@ -1207,7 +1208,7 @@ TEST_F(LdbCmdTest, RenameDbAndLoadOptions) {
   ASSERT_OK(DestroyDB(new_dbname, opts));
 }
 
-class MyComparator : public rocksdb::Comparator {
+class MyComparator : public Comparator {
  public:
   int Compare(const rocksdb::Slice& a, const rocksdb::Slice& b) const override {
     return a.compare(b);
@@ -1220,11 +1221,12 @@ class MyComparator : public rocksdb::Comparator {
 
 TEST_F(LdbCmdTest, CustomComparator) {
   Env* env = TryLoadCustomOrDefaultEnv();
+  MyComparator my_comparator;
   Options opts;
   opts.env = env;
   opts.create_if_missing = true;
   opts.create_missing_column_families = true;
-  opts.comparator = new MyComparator;
+  opts.comparator = &my_comparator;
 
   std::string dbname = test::PerThreadDBPath(env, "ldb_cmd_test");
   DB* db = nullptr;

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -1247,7 +1247,7 @@ TEST_F(LdbCmdTest, CustomComparator) {
   char* argv[] = {arg1, const_cast<char*>(arg2.c_str()), arg3, arg4};
 
   ASSERT_EQ(0,
-            LDBCommandRunner::RunCommand(4, argv, opts, LDBOptions(), nullptr));}
+            LDBCommandRunner::RunCommand(4, argv, opts, LDBOptions(), nullptr));
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -1248,6 +1248,7 @@ TEST_F(LdbCmdTest, CustomComparator) {
 
   ASSERT_EQ(0,
             LDBCommandRunner::RunCommand(4, argv, opts, LDBOptions(), nullptr));
+  }
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -1250,7 +1250,7 @@ TEST_F(LdbCmdTest, CustomComparator) {
 
   ASSERT_EQ(0,
             LDBCommandRunner::RunCommand(4, argv, opts, LDBOptions(), nullptr));
-  }
+}
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -1213,7 +1213,8 @@ class MyComparator : public rocksdb::Comparator {
     return a.compare(b);
   }
   void FindShortSuccessor(std::string* /*key*/) const override {}
-  void FindShortestSeparator(std::string* /*start*/, const Slice& /*limit*/) const override {}
+  void FindShortestSeparator(std::string* /*start*/,
+                             const Slice& /*limit*/) const override {}
   const char* Name() const override { return "my_comparator"; }
 };
 
@@ -1245,8 +1246,8 @@ TEST_F(LdbCmdTest, CustomComparator) {
   char arg4[] = "k1";
   char* argv[] = {arg1, const_cast<char*>(arg2.c_str()), arg3, arg4};
 
-  ASSERT_EQ(0, LDBCommandRunner::RunCommand(4, argv, opts, LDBOptions(), nullptr));
-}
+  ASSERT_EQ(0,
+            LDBCommandRunner::RunCommand(4, argv, opts, LDBOptions(), nullptr));}
 
 }  // namespace ROCKSDB_NAMESPACE
 


### PR DESCRIPTION
According to this [Q&A](https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ#:~:text=Q%3A%20If%20I%20use%20non%2Ddefault%20comparators%20or%20merge%20operators%2C%20can%20I%20still%20use%20ldb%20tool%3F), user should be able to use LDB with passing a customized comparator into the option. 

In the process of opening DB in order to perform ldb commands, there is a exception saying comparator not match even if a option with customized comparator is provided. After initializing the column family to open DB, the `LDBCommand::OverrideBaseCFOptions` method does not update the comparator inside column family descriptor using the passed in options. This can cause a mismatch while doing version edit, and in function `ToggleUDT CompareComparator` it will failed and return a exception saying comparator not match.

Propose fix by updating the column family descriptor's option using the user passed in option. Also a test case is provided to illustrate the steps.