### PR TITLE
Fix database open with column family.

### DIFF
--- a/java/src/test/java/org/rocksdb/TtlDBTest.java
+++ b/java/src/test/java/org/rocksdb/TtlDBTest.java
@@ -5,19 +5,20 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class TtlDBTest {
+  private static final int BATCH_ITERATION = 16;
 
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
@@ -107,6 +108,79 @@ public class TtlDBTest {
       TimeUnit.SECONDS.sleep(2);
       ttlDB.compactRange(columnFamilyHandle);
       assertThat(ttlDB.get(columnFamilyHandle, "key".getBytes())).isNull();
+    }
+  }
+
+  @Test
+  public void writeBatchWithFlush() throws RocksDBException {
+    try (final Options dbOptions = new Options()) {
+      dbOptions.setCreateIfMissing(true);
+      dbOptions.setCreateMissingColumnFamilies(true);
+
+      try (final RocksDB db =
+               TtlDB.open(dbOptions, dbFolder.getRoot().getAbsolutePath(), 100, false)) {
+        try (WriteBatch wb = new WriteBatch()) {
+          for (int i = 0; i < BATCH_ITERATION; i++) {
+            wb.put(("key" + i).getBytes(StandardCharsets.UTF_8),
+                ("value" + i).getBytes(StandardCharsets.UTF_8));
+          }
+          try (WriteOptions writeOptions = new WriteOptions()) {
+            db.write(writeOptions, wb);
+          }
+          try (FlushOptions fOptions = new FlushOptions()) {
+            db.flush(fOptions);
+          }
+        }
+        for (int i = 0; i < BATCH_ITERATION; i++) {
+          assertThat(db.get(("key" + i).getBytes(StandardCharsets.UTF_8)))
+              .isEqualTo(("value" + i).getBytes(StandardCharsets.UTF_8));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void writeBatchWithFlushAndColumnFamily() throws RocksDBException {
+    try (final DBOptions dbOptions = new DBOptions()) {
+      System.out.println("Test start");
+      dbOptions.setCreateIfMissing(true);
+      dbOptions.setCreateMissingColumnFamilies(true);
+
+      final List<ColumnFamilyDescriptor> cfNames =
+          Arrays.asList(new ColumnFamilyDescriptor("new_cf".getBytes()),
+              new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+      final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+
+      final List<Integer> ttlValues = Arrays.asList(0, 1);
+
+      try (final RocksDB db = TtlDB.open(dbOptions, dbFolder.getRoot().getAbsolutePath(), cfNames,
+               columnFamilyHandleList, ttlValues, false)) {
+        try {
+          assertThat(columnFamilyHandleList.get(1).isDefaultColumnFamily()).isTrue();
+
+          try (WriteBatch wb = new WriteBatch()) {
+            for (int i = 0; i < BATCH_ITERATION; i++) {
+              wb.put(("key" + i).getBytes(StandardCharsets.UTF_8),
+                  ("value" + i).getBytes(StandardCharsets.UTF_8));
+            }
+            try (WriteOptions writeOptions = new WriteOptions()) {
+              db.write(writeOptions, wb);
+            }
+            try (FlushOptions fOptions = new FlushOptions()) {
+              // Test both flush options, db.flush(fOptions) slush only default CF
+              db.flush(fOptions);
+              db.flush(fOptions, columnFamilyHandleList);
+            }
+          }
+          for (int i = 0; i < BATCH_ITERATION; i++) {
+            assertThat(db.get(("key" + i).getBytes(StandardCharsets.UTF_8)))
+                .isEqualTo(("value" + i).getBytes(StandardCharsets.UTF_8));
+          }
+        } finally {
+          // All CF handles must be closed before we close DB.
+          columnFamilyHandleList.stream().forEach(ColumnFamilyHandle::close);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
When is RocksDB is opened with Column Family descriptors, the default column family must be set properly. If it was not, then the flush operation will fail.