### PR TITLE
Lightweight verification of MANIFEST file after close on shutdown

### DIFF
--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -217,7 +217,7 @@ class CompactionJobTestBase : public testing::Test {
             /*block_cache_tracer=*/nullptr,
             /*io_tracer=*/nullptr, /*db_id=*/"", /*db_session_id=*/"",
             /*daily_offpeak_time_utc=*/"",
-            /*error_handler=*/nullptr)),
+            /*error_handler=*/nullptr, /*read_only=*/false)),
         shutting_down_(false),
         mock_table_factory_(new mock::MockTableFactory()),
         error_handler_(nullptr, db_options_, &mutex_),
@@ -547,7 +547,7 @@ class CompactionJobTestBase : public testing::Test {
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
         /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
-        /*error_handler=*/nullptr));
+        /*error_handler=*/nullptr, /*read_only=*/false));
     compaction_job_stats_.Reset();
     ASSERT_OK(SetIdentityFile(env_, dbname_));
 

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1543,7 +1543,7 @@ class RecoveryTestHelper {
         /*block_cache_tracer=*/nullptr,
         /*io_tracer=*/nullptr, /*db_id=*/"", /*db_session_id=*/"",
         options.daily_offpeak_time_utc,
-        /*error_handler=*/nullptr));
+        /*error_handler=*/nullptr, /*read_only=*/false));
 
     wal_manager.reset(
         new WalManager(db_options, file_options, /*io_tracer=*/nullptr));

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -132,7 +132,7 @@ class FlushJobTestBase : public testing::Test {
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
         /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
-        /*error_handler=*/nullptr));
+        /*error_handler=*/nullptr, /*read_only=*/false));
     EXPECT_OK(versions_->Recover(column_families, false));
   }
 

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -108,7 +108,7 @@ class MemTableListTest : public testing::Test {
                         &write_controller, /*block_cache_tracer=*/nullptr,
                         /*io_tracer=*/nullptr, /*db_id=*/"",
                         /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
-                        /*error_handler=*/nullptr);
+                        /*error_handler=*/nullptr, /*read_only=*/false);
     std::vector<ColumnFamilyDescriptor> cf_descs;
     cf_descs.emplace_back(kDefaultColumnFamilyName, ColumnFamilyOptions());
     cf_descs.emplace_back("one", ColumnFamilyOptions());
@@ -160,7 +160,7 @@ class MemTableListTest : public testing::Test {
                         &write_controller, /*block_cache_tracer=*/nullptr,
                         /*io_tracer=*/nullptr, /*db_id=*/"",
                         /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
-                        /*error_handler=*/nullptr);
+                        /*error_handler=*/nullptr, /*read_only=*/false);
     std::vector<ColumnFamilyDescriptor> cf_descs;
     cf_descs.emplace_back(kDefaultColumnFamilyName, ColumnFamilyOptions());
     cf_descs.emplace_back("one", ColumnFamilyOptions());

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -123,7 +123,7 @@ class Repairer {
               raw_table_cache_.get(), &wb_, &wc_,
               /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
               /*db_id=*/"", db_session_id_, db_options.daily_offpeak_time_utc,
-              /*error_handler=*/nullptr),
+              /*error_handler=*/nullptr, /*read_only=*/false),
         next_file_number_(1),
         db_lock_(nullptr),
         closed_(false) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5106,8 +5106,7 @@ VersionSet::VersionSet(
 
 Status VersionSet::Close(FSDirectory* db_dir, InstrumentedMutex* mu) {
   Status s;
-  if (closed_ || read_only_ || !manifest_file_number_ ||
-      !descriptor_log_) {
+  if (closed_ || read_only_ || !manifest_file_number_ || !descriptor_log_) {
     return s;
   }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5073,7 +5073,7 @@ VersionSet::VersionSet(
     BlockCacheTracer* const block_cache_tracer,
     const std::shared_ptr<IOTracer>& io_tracer, const std::string& db_id,
     const std::string& db_session_id, const std::string& daily_offpeak_time_utc,
-    ErrorHandler* const error_handler)
+    ErrorHandler* const error_handler, const bool read_only)
     : column_family_set_(new ColumnFamilySet(
           dbname, _db_options, storage_options, table_cache,
           write_buffer_manager, write_controller, block_cache_tracer, io_tracer,
@@ -5100,7 +5100,59 @@ VersionSet::VersionSet(
       io_tracer_(io_tracer),
       db_session_id_(db_session_id),
       offpeak_time_option_(OffpeakTimeOption(daily_offpeak_time_utc)),
-      error_handler_(error_handler) {}
+      error_handler_(error_handler),
+      read_only_(read_only),
+      closed_(false) {}
+
+Status VersionSet::Close(FSDirectory* db_dir, InstrumentedMutex* mu) {
+  Status s;
+  if (closed_ || read_only_ || !manifest_file_number_ ||
+      !descriptor_log_) {
+    return s;
+  }
+
+  std::string manifest_file_name =
+      DescriptorFileName(dbname_, manifest_file_number_);
+  uint64_t size = 0;
+  IOStatus io_s = descriptor_log_->Close();
+  descriptor_log_.reset();
+  TEST_SYNC_POINT("VersionSet::Close:AfterClose");
+  if (io_s.ok()) {
+    io_s = fs_->GetFileSize(manifest_file_name, IOOptions(), &size, nullptr);
+  }
+  if (!io_s.ok() || size != manifest_file_size_) {
+    if (io_s.ok()) {
+      // This means the size is not as expected. So we treat it as a
+      // corruption and set io_s appropriately
+      io_s = IOStatus::Corruption();
+    }
+    ColumnFamilyData* cfd = GetColumnFamilySet()->GetDefault();
+    const ImmutableOptions* ioptions = cfd->ioptions();
+    IOErrorInfo io_error_info(io_s, FileOperationType::kVerify,
+                              manifest_file_name, /*length=*/size,
+                              /*offset=*/0);
+
+    for (auto& listener : ioptions->listeners) {
+      listener->OnIOError(io_error_info);
+    }
+    io_s.PermitUncheckedError();
+    io_error_info.io_status.PermitUncheckedError();
+    ROCKS_LOG_ERROR(db_options_->info_log,
+                    "MANIFEST verification on Close, "
+                    "filename %s, expected size %" PRIu64
+                    " failed with status %s and "
+                    "actual size %" PRIu64 "\n",
+                    manifest_file_name.c_str(), manifest_file_size_,
+                    io_s.ToString().c_str(), size);
+    VersionEdit edit;
+    assert(cfd);
+    const MutableCFOptions& cf_opts = *cfd->GetLatestMutableCFOptions();
+    s = LogAndApply(cfd, cf_opts, ReadOptions(), &edit, mu, db_dir);
+  }
+
+  closed_ = true;
+  return s;
+}
 
 VersionSet::~VersionSet() {
   // we need to delete column_family_set_ because its destructor depends on
@@ -6244,7 +6296,7 @@ Status VersionSet::ReduceNumberOfLevels(const std::string& dbname,
                       nullptr /*BlockCacheTracer*/, nullptr /*IOTracer*/,
                       /*db_id*/ "",
                       /*db_session_id*/ "", options->daily_offpeak_time_utc,
-                      /*error_handler_*/ nullptr);
+                      /*error_handler_*/ nullptr, /*read_only=*/false);
   Status status;
 
   std::vector<ColumnFamilyDescriptor> dummy;
@@ -7286,7 +7338,7 @@ ReactiveVersionSet::ReactiveVersionSet(
                  write_buffer_manager, write_controller,
                  /*block_cache_tracer=*/nullptr, io_tracer, /*db_id*/ "",
                  /*db_session_id*/ "", /*daily_offpeak_time_utc*/ "",
-                 /*error_handler=*/nullptr) {}
+                 /*error_handler=*/nullptr, /*read_only=*/true) {}
 
 ReactiveVersionSet::~ReactiveVersionSet() = default;
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1160,12 +1160,14 @@ class VersionSet {
              const std::shared_ptr<IOTracer>& io_tracer,
              const std::string& db_id, const std::string& db_session_id,
              const std::string& daily_offpeak_time_utc,
-             ErrorHandler* const error_handler);
+             ErrorHandler* const error_handler, const bool read_only);
   // No copying allowed
   VersionSet(const VersionSet&) = delete;
   void operator=(const VersionSet&) = delete;
 
   virtual ~VersionSet();
+
+  virtual Status Close(FSDirectory* db_dir, InstrumentedMutex* mu);
 
   Status LogAndApplyToDefaultColumnFamily(
       const ReadOptions& read_options, VersionEdit* edit, InstrumentedMutex* mu,
@@ -1693,6 +1695,9 @@ class VersionSet {
   Status LogAndApplyHelper(ColumnFamilyData* cfd, VersionBuilder* b,
                            VersionEdit* edit, SequenceNumber* max_last_sequence,
                            InstrumentedMutex* mu);
+
+  const bool read_only_;
+  bool closed_;
 };
 
 // ReactiveVersionSet represents a collection of versions of the column
@@ -1709,6 +1714,10 @@ class ReactiveVersionSet : public VersionSet {
                      const std::shared_ptr<IOTracer>& io_tracer);
 
   ~ReactiveVersionSet() override;
+
+  Status Close(FSDirectory* /*db_dir*/, InstrumentedMutex* /*mu*/) override {
+    return Status::OK();
+  }
 
   Status ReadAndApply(
       InstrumentedMutex* mu,

--- a/db/version_util.h
+++ b/db/version_util.h
@@ -27,7 +27,8 @@ class OfflineManifestWriter {
                   /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                   /*db_id=*/"", /*db_session_id=*/"",
                   options.daily_offpeak_time_utc,
-                  /*error_handler=*/nullptr) {}
+                  /*error_handler=*/nullptr,
+                  /*read_only=*/false) {}
 
   Status Recover(const std::vector<ColumnFamilyDescriptor>& column_families) {
     return versions_.Recover(column_families, /*read_only*/ false,

--- a/db/wal_manager_test.cc
+++ b/db/wal_manager_test.cc
@@ -55,7 +55,7 @@ class WalManagerTest : public testing::Test {
         &write_buffer_manager_, &write_controller_,
         /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
         /*db_id=*/"", /*db_session_id=*/"", /*daily_offpeak_time_utc=*/"",
-        /*error_handler=*/nullptr));
+        /*error_handler=*/nullptr, /*read_only=*/false));
 
     wal_manager_.reset(
         new WalManager(db_options_, env_options_, nullptr /*IOTracer*/));

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -251,7 +251,8 @@ enum class FileOperationType {
   kRangeSync,
   kAppend,
   kPositionedAppend,
-  kOpen
+  kOpen,
+  kVerify
 };
 
 struct FileOperationInfo {

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1370,7 +1370,7 @@ void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                       /*db_id=*/"", /*db_session_id=*/"",
                       options.daily_offpeak_time_utc,
-                      /*error_handler=*/nullptr);
+                      /*error_handler=*/nullptr, /*read_only=*/true);
   Status s = versions.DumpManifest(options, file, verbose, hex, json, cf_descs);
   if (!s.ok()) {
     fprintf(stderr, "Error in processing file %s %s\n", file.c_str(),
@@ -1514,7 +1514,7 @@ Status GetLiveFilesChecksumInfoFromVersionSet(Options options,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                       /*db_id=*/"", /*db_session_id=*/"",
                       options.daily_offpeak_time_utc,
-                      /*error_handler=*/nullptr);
+                      /*error_handler=*/nullptr, /*read_only=*/true);
   std::vector<std::string> cf_name_list;
   s = versions.ListColumnFamilies(&cf_name_list, db_path,
                                   immutable_db_options.fs.get());
@@ -2348,7 +2348,7 @@ Status ReduceDBLevelsCommand::GetOldNumOfLevels(Options& opt, int* levels) {
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                       /*db_id=*/"", /*db_session_id=*/"",
                       opt.daily_offpeak_time_utc,
-                      /*error_handler=*/nullptr);
+                      /*error_handler=*/nullptr, /*read_only=*/true);
   std::vector<ColumnFamilyDescriptor> dummy;
   ColumnFamilyDescriptor dummy_descriptor(kDefaultColumnFamilyName,
                                           ColumnFamilyOptions(opt));

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -209,7 +209,8 @@ class FileChecksumTestHelper {
     ImmutableDBOptions immutable_db_options(options_);
     VersionSet versions(dbname_, &immutable_db_options, sopt, tc.get(), &wb,
                         &wc, nullptr, nullptr, "", "",
-                        options_.daily_offpeak_time_utc, nullptr);
+                        options_.daily_offpeak_time_utc, nullptr,
+                        /*read_only=*/false);
     std::vector<std::string> cf_name_list;
     Status s;
     s = versions.ListColumnFamilies(&cf_name_list, dbname_,


### PR DESCRIPTION
Do a size verification on the MANIFEST file during DB shutdown, after closing the file. If the verification fails, write a new MANIFEST file. In the future, we can do a more thorough verification if we want to.

Test plan:
Unit test, and some manual verification