### PR TITLE
Fix leak or crash on failure in automatic atomic flush

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1564,7 +1564,7 @@ Status DBImpl::WriteRecoverableState() {
       cached_recoverable_state_.Clear();
       cached_recoverable_state_empty_ = true;
     } else {
-      assert(false);
+      // FIXME: !ok status is untested
     }
     return status;
   }

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1563,6 +1563,8 @@ Status DBImpl::WriteRecoverableState() {
     if (status.ok()) {
       cached_recoverable_state_.Clear();
       cached_recoverable_state_empty_ = true;
+    } else {
+      assert(false);
     }
     return status;
   }
@@ -2060,15 +2062,14 @@ Status DBImpl::ScheduleFlushes(WriteContext* context) {
     nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
   }
 
+  TEST_SYNC_POINT_CALLBACK("DBImpl::ScheduleFlushes:PreSwitchMemtable",
+                           nullptr);
   for (auto& cfd : cfds) {
-    if (!cfd->mem()->IsEmpty()) {
+    if (status.ok() && !cfd->mem()->IsEmpty()) {
       status = SwitchMemtable(cfd, context);
     }
     if (cfd->UnrefAndTryDelete()) {
       cfd = nullptr;
-    }
-    if (!status.ok()) {
-      break;
     }
   }
 

--- a/unreleased_history/bug_fixes/cfd_leak.md
+++ b/unreleased_history/bug_fixes/cfd_leak.md
@@ -1,0 +1,1 @@
+Fixed a possible memory leak or crash on a failure (such as I/O error) in automatic atomic flush of multiple column families.


### PR DESCRIPTION
Summary: Through code inspection in debugging an apparent leak of ColumnFamilyData in the crash test, I found a case where too few UnrefAndTryDelete() could be called on a cfd. This fixes that case, which would fail like this in the new unit test:

```
db_flush_test: db/column_family.cc:1648:
rocksdb::ColumnFamilySet::~ColumnFamilySet(): Assertion `last_ref' failed.
```

Test Plan: unit test added