### PR TITLE
Fix SystemClock not passed from environment to PERF_CPU_TIMER_GUARD.

### DIFF
--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -258,8 +258,9 @@ IOStatus BlockFetcher::ReadBlockContents() {
     if (io_status_.ok()) {
       if (file_->use_direct_io()) {
         PERF_TIMER_GUARD(block_read_time);
-        PERF_CPU_TIMER_GUARD(block_read_cpu_time,
-          ioptions_.env? ioptions_.env->GetSystemClock().get() : nullptr);
+        PERF_CPU_TIMER_GUARD(
+            block_read_cpu_time,
+            ioptions_.env ? ioptions_.env->GetSystemClock().get() : nullptr);
         io_status_ =
             file_->Read(opts, handle_.offset(), block_size_with_trailer_,
                         &slice_, nullptr, &direct_io_buf_);
@@ -268,8 +269,9 @@ IOStatus BlockFetcher::ReadBlockContents() {
       } else {
         PrepareBufferForBlockFromFile();
         PERF_TIMER_GUARD(block_read_time);
-        PERF_CPU_TIMER_GUARD(block_read_cpu_time,
-          ioptions_.env? ioptions_.env->GetSystemClock().get() : nullptr);
+        PERF_CPU_TIMER_GUARD(
+            block_read_cpu_time,
+            ioptions_.env ? ioptions_.env->GetSystemClock().get() : nullptr);
         io_status_ =
             file_->Read(opts, handle_.offset(), block_size_with_trailer_,
                         &slice_, used_buf_, nullptr);

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -258,7 +258,8 @@ IOStatus BlockFetcher::ReadBlockContents() {
     if (io_status_.ok()) {
       if (file_->use_direct_io()) {
         PERF_TIMER_GUARD(block_read_time);
-        PERF_CPU_TIMER_GUARD(block_read_cpu_time, nullptr);
+        PERF_CPU_TIMER_GUARD(block_read_cpu_time,
+          ioptions_.env? ioptions_.env->GetSystemClock().get() : nullptr);
         io_status_ =
             file_->Read(opts, handle_.offset(), block_size_with_trailer_,
                         &slice_, nullptr, &direct_io_buf_);
@@ -267,7 +268,8 @@ IOStatus BlockFetcher::ReadBlockContents() {
       } else {
         PrepareBufferForBlockFromFile();
         PERF_TIMER_GUARD(block_read_time);
-        PERF_CPU_TIMER_GUARD(block_read_cpu_time, nullptr);
+        PERF_CPU_TIMER_GUARD(block_read_cpu_time,
+          ioptions_.env? ioptions_.env->GetSystemClock().get() : nullptr);
         io_status_ =
             file_->Read(opts, handle_.offset(), block_size_with_trailer_,
                         &slice_, used_buf_, nullptr);


### PR DESCRIPTION
Summary:
The hardcoded nullptr argument for SystemClock to PERF_CPU_TIMER_GUARD ignored any SystemClock instance provided by the env; this was probably an oversight.

In practice, the defaulting SystemClock could lead to excessive `clock_gettime(CLOCK_THREAD_CPUTIME_ID)` syscalls if `report_bg_io_stats=true` which cannot be mitigated by the embedder.