### PR TITLE
Downgrade warning for dynamic leveling with non-leveled compaction

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -358,7 +358,7 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
 
   if (result.level_compaction_dynamic_level_bytes) {
     if (result.compaction_style != kCompactionStyleLevel) {
-      ROCKS_LOG_WARN(db_options.info_log.get(),
+      ROCKS_LOG_INFO(db_options.info_log.get(),
                      "level_compaction_dynamic_level_bytes only makes sense"
                      "for level-based compaction");
       result.level_compaction_dynamic_level_bytes = false;


### PR DESCRIPTION
Now that `level_compaction_dynamic_level_bytes`'s default value is true, users who do not touch that setting and use non-leveled compaction will also see this log message. It can be info level rather than warning since, in the case mentioned, there is nothing the user needs to be warned about.