### PR TITLE
Prioritize marked file in level compaction

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3975,13 +3975,19 @@ void SortFileByOverlappingRatio(
                       // This makes the algorithm more deterministic, and also
                       // help the trivial move case to have more files to
                       // extend.
-                      if (file_to_order[f1.file->fd.GetNumber()] ==
-                          file_to_order[f2.file->fd.GetNumber()]) {
-                        return icmp.Compare(f1.file->smallest,
-                                            f2.file->smallest) < 0;
+                      if (f1.file->marked_for_compaction ==
+                          f2.file->marked_for_compaction) {
+                        if (file_to_order[f1.file->fd.GetNumber()] ==
+                            file_to_order[f2.file->fd.GetNumber()]) {
+                          return icmp.Compare(f1.file->smallest,
+                                              f2.file->smallest) < 0;
+                        }
+                        return file_to_order[f1.file->fd.GetNumber()] <
+                               file_to_order[f2.file->fd.GetNumber()];
+                      } else {
+                        return f1.file->marked_for_compaction >
+                               f2.file->marked_for_compaction;
                       }
-                      return file_to_order[f1.file->fd.GetNumber()] <
-                             file_to_order[f2.file->fd.GetNumber()];
                     });
 }
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -51,6 +51,8 @@ enum CompactionPri : char {
   // First compact files whose ratio between overlapping size in next level
   // and its size is the smallest. It in many cases can optimize write
   // amplification.
+  // Files marked for compaction will be prioritized over files that are not
+  // marked.
   kMinOverlappingRatio = 0x3,
   // Keeps a cursor(s) of the successor of the file (key range) was/were
   // compacted before, and always picks the next files (key range) in that

--- a/unreleased_history/behavior_changes/pri_file_marked_for_compaction
+++ b/unreleased_history/behavior_changes/pri_file_marked_for_compaction
@@ -1,0 +1,1 @@
+* For leveled compaction with default compaction pri (kMinOverlappingRatio), files marked for compaction will be prioritized over files not marked when picking a file from a level for compaction.


### PR DESCRIPTION
When ranking file by compaction priority in a level, prioritize files marked for compaction over files that are not marked. This only applies to default CompactPri kMinOverlappingRatio for now.

Test plan:
* New unit tests

