### PR TITLE
Fix a case of ignored corruption in creating backups

### DIFF
--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -92,13 +92,14 @@ Status SstFileDumper::GetTableReader(const std::string& file_path) {
   fopts.temperature = file_temp_;
   Status s = fs->NewRandomAccessFile(file_path, fopts, &file, nullptr);
   if (s.ok()) {
+    // check empty file
+    // if true, skip further processing of this file
     s = fs->GetFileSize(file_path, IOOptions(), &file_size, nullptr);
-  }
-
-  // check empty file
-  // if true, skip further processing of this file
-  if (file_size == 0) {
-    return Status::Aborted(file_path, "Empty file");
+    if (s.ok()) {
+      if (file_size == 0) {
+        return Status::Aborted(file_path, "Empty file");
+      }
+    }
   }
 
   file_.reset(new RandomAccessFileReader(std::move(file), file_path));

--- a/unreleased_history/bug_fixes/backup_verify_gap.md
+++ b/unreleased_history/bug_fixes/backup_verify_gap.md
@@ -1,0 +1,1 @@
+Fixed some cases in which DB file corruption was detected but ignored on creating a backup with BackupEngine.


### PR DESCRIPTION
Summary: We often need to read the table properties of an SST file when taking a backup. However, we currently do not check checksums for this step, and even with that enabled, we ignore failures. This change ensures we fail creating a backup if corruption is detected in that step of reading table properties.

To get this working properly (with existing unit tests), we also add some temperature handling logic like already exists in
BackupEngineImpl::ReadFileAndComputeChecksum and elsewhere in BackupEngine. Also, SstFileDumper needed a fix to its error handling logic.

This is also intended to help diagnose some mysterious failures (apparent corruptions) seen in taking backups in the crash test.

Test Plan: unit test added that corrupts table properties, along with existing tests