### PR TITLE
Re-enable ingest_external_file with mmap_read in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -568,11 +568,6 @@ def finalize_and_sanitize(src_params):
     if dest_params["mmap_read"] == 1:
         dest_params["use_direct_io_for_flush_and_compaction"] = 0
         dest_params["use_direct_reads"] = 0
-        if dest_params["file_checksum_impl"] != "none":
-            # TODO(T109283569): there is a bug in `GenerateOneFileChecksum()`,
-            # used by `IngestExternalFile()`, causing it to fail with mmap
-            # reads. Remove this once it is fixed.
-            dest_params["ingest_external_file_one_in"] = 0
     if (
         dest_params["use_direct_io_for_flush_and_compaction"] == 1
         or dest_params["use_direct_reads"] == 1


### PR DESCRIPTION
Summary: I suspect the issue called out in #9357 was fixed in #11328

Test Plan: `make blackbox_crash_test` for hours