### PR TITLE
sst_dump: display metaindex_handle and the index_handle's offset and size in footer information

### DIFF
--- a/table/format.cc
+++ b/table/format.cc
@@ -466,19 +466,16 @@ std::string Footer::ToString() const {
   std::string result;
   result.reserve(1024);
 
-  bool legacy = IsLegacyFooterFormat(table_magic_number_);
-  if (legacy) {
-    result.append("metaindex handle: " + metaindex_handle_.ToString() + "\n  ");
-    result.append("index handle: " + index_handle_.ToString() + "\n  ");
-    result.append("table_magic_number: " + std::to_string(table_magic_number_) +
-                  "\n  ");
-  } else {
-    result.append("metaindex handle: " + metaindex_handle_.ToString() + "\n  ");
-    result.append("index handle: " + index_handle_.ToString() + "\n  ");
-    result.append("table_magic_number: " + std::to_string(table_magic_number_) +
-                  "\n  ");
-    result.append("format version: " + std::to_string(format_version_) +
-                  "\n  ");
+  result.append("metaindex handle: " + metaindex_handle_.ToString() +
+                " offset: " + std::to_string(metaindex_handle_.offset()) +
+                " size: " + std::to_string(metaindex_handle_.size()) + "\n  ");
+  result.append("index handle: " + index_handle_.ToString() +
+                " offset: " + std::to_string(index_handle_.offset()) +
+                " size: " + std::to_string(index_handle_.size()) + "\n  ");
+  result.append("table_magic_number: " + std::to_string(table_magic_number_) +
+                "\n  ");
+  if (!IsLegacyFooterFormat(table_magic_number_)) {
+    result.append("format version: " + std::to_string(format_version_) + "\n");
   }
   return result;
 }


### PR DESCRIPTION
Before applying this PR, the footer details:

```
Footer Details:
--------------------------------------
  metaindex handle: B0E499405C
  index handle: 8AC49940CD17
  table_magic_number: 9863518390377041911
  format version: 5
```

and after

```
Footer Details:
--------------------------------------
  metaindex handle: B0E499405C offset: 134640176 size: 92
  index handle: 8AC49940CD17 offset: 134636042 size: 3021
  table_magic_number: 9863518390377041911
  format version: 5
```
