### PR TITLE
Disable blobDB and UDT in memtable only combination in stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -714,6 +714,7 @@ def finalize_and_sanitize(src_params):
         dest_params["delpercent"] += dest_params["delrangepercent"]
         dest_params["delrangepercent"] = 0
         dest_params["enable_blob_files"] = 0
+        dest_params["allow_setting_blob_options_dynamically"] = 0
         dest_params["atomic_flush"] = 0
         dest_params["allow_concurrent_memtable_write"] = 0
         dest_params["block_protection_bytes_per_key"] = 0


### PR DESCRIPTION
This feature combination is not fully working yet. Disable them so the stress tests have less noise. 