### PR TITLE
Fix the compactRange with wrong cf handle when ClipColumnFamily

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -6280,7 +6280,7 @@ Status DBImpl::ClipColumnFamily(ColumnFamilyHandle* column_family,
     // last level to compact to and that range tombstones are not dropped
     // during non-bottommost compactions, calling CompactRange() on these two
     // ranges may not clear all range tombstones.
-    status = CompactRange(compact_options, nullptr, nullptr);
+    status = CompactRange(compact_options, column_family, nullptr, nullptr);
   }
   return status;
 }


### PR DESCRIPTION
- **Context**:

In ClipColumnFamily, the DeleteRange API will be used to delete data, and then CompactRange will be called for physical deletion. But now However, the ColumnFamilyHandle is not passed , so by default only the DefaultColumnFamily will be CompactRanged. Therefore, it may cause that the data in some sst files of CompactionRange cannot be physically deleted.

- **In this change**

Pass the ColumnFamilyHandle when call CompactRange