### PR TITLE
Disable LockWAL() for multiops_wp_txn stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -552,6 +552,9 @@ multiops_wp_txn_params = {
     "use_only_the_last_commit_time_batch_for_recovery": 1,
     "clear_wp_commit_cache_one_in": 10,
     "create_timestamped_snapshot_one_in": 0,
+    # sequence number can be advanced in SwitchMemtable::WriteRecoverableState() for WP.
+    # disable it for now until we find another way to test LockWAL().
+    "lock_wal_one_in": 0,
 }
 
 def finalize_and_sanitize(src_params):


### PR DESCRIPTION
We test LockWAL() and UnlockWAL() by checking that latest sequence number is not changed: https://github.com/facebook/rocksdb/blob/1a1f9f166093e36541df0886505d9a87a4fbb887/db_stress_tool/db_stress_test_base.cc#L920-L937. With writeprepared transaction, sequence number can be advanced in SwitchMemtable::WriteRecoverableState() when writing recoverable state: https://github.com/facebook/rocksdb/blob/1a1f9f166093e36541df0886505d9a87a4fbb887/db/db_impl/db_impl_write.cc#L1560 

This PR disables LockWAL() tests for writeprepared transaction for now. We probably need to change how we test LockWAL() for writeprepared before re-enabling this test.
