### PR TITLE
IsEmpty() checks were missing before some SwitchMemtable() invocations

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2141,7 +2141,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
 
   if (cfd->mem()->IsEmpty()) {
     return Status::OK();
-  } 
+  }
   // Recoverable state is persisted in WAL. After memtable switch, WAL might
   // be deleted, so we write the state to memtable to be persisted as well.
   Status s = WriteRecoverableState();

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2139,7 +2139,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   MemTable* new_mem = nullptr;
   IOStatus io_s;
 
-  if(cfd->mem()->IsEmpty()) {
+  if (cfd->mem()->IsEmpty()) {
     return Status::OK();
   } 
   // Recoverable state is persisted in WAL. After memtable switch, WAL might

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2139,6 +2139,9 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   MemTable* new_mem = nullptr;
   IOStatus io_s;
 
+  if(cfd->mem()->IsEmpty()) {
+    return Status::OK();
+  } 
   // Recoverable state is persisted in WAL. After memtable switch, WAL might
   // be deleted, so we write the state to memtable to be persisted as well.
   Status s = WriteRecoverableState();


### PR DESCRIPTION
Fixes #12179 

There was one instance where the IsEmpty() check was missing: https://github.com/facebook/rocksdb/blob/21d5a8f54f06e01ca49d4e6bae89bb42ba78dfdd/db/db_impl/db_impl_write.cc#L1706

Having one check inside SwitchMemTable() will ensure there won't be misses in the future. 