### PR TITLE
remove unused IOOptions::property_bag

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -104,14 +104,6 @@ struct IOOptions {
   // Type of data being read/written
   IOType type;
 
-  // EXPERIMENTAL
-  // An option map that's opaque to RocksDB. It can be used to implement a
-  // custom contract between a FileSystem user and the provider. This is only
-  // useful in cases where a RocksDB user directly uses the FileSystem or file
-  // object for their own purposes, and wants to pass extra options to APIs
-  // such as NewRandomAccessFile and NewWritableFile.
-  std::unordered_map<std::string, std::string> property_bag;
-
   // Force directory fsync, some file systems like btrfs may skip directory
   // fsync, set this to force the fsync
   bool force_dir_fsync;


### PR DESCRIPTION
`IOOptions::property_bag` is an std::unordered_map, although it is constructed empty,
 in many cases, it incurs considerable overhead compared to a small `pread`.

Now it is not used anywhere, so delete it.