### PR TITLE
Fix blob files not reclaimed after deleting all SSTs

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1073,6 +1073,12 @@ class VersionBuilder::Rep {
     const uint64_t oldest_blob_file_with_linked_ssts =
         GetMinOldestBlobFileNumber();
 
+    // If there are no blob files with linked SSTs, meaning that there are no
+    // valid blob files
+    if (oldest_blob_file_with_linked_ssts == kInvalidBlobFileNumber) {
+      return;
+    }
+
     auto process_base =
         [vstorage](const std::shared_ptr<BlobFileMetaData>& base_meta) {
           assert(base_meta);


### PR DESCRIPTION
Fix issue #12208.

After all the SSTs have been deleted, all the blob files will become unreferenced. 
These files should be considered obsolete and thus, should not be saved to the vstorage.