### PR TITLE
Detect compaction pressure at lower debt ratios

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -870,7 +870,7 @@ uint64_t GetPendingCompactionBytesForCompactionSpeedup(
     const VersionStorageInfo* vstorage) {
   // Compaction debt relatively large compared to the stable (bottommost) data
   // size indicates compaction fell behind.
-  const uint64_t kBottommostSizeMultiplier = 8;
+  const uint64_t kBottommostSizeDivisor = 8;
   // Meaningful progress toward the slowdown trigger is another good indication.
   const uint64_t kSlowdownTriggerDivisor = 4;
 
@@ -890,8 +890,7 @@ uint64_t GetPendingCompactionBytesForCompactionSpeedup(
     return slowdown_threshold;
   }
 
-  uint64_t size_threshold =
-      MultiplyCheckOverflow(bottommost_files_size, kBottommostSizeMultiplier);
+  uint64_t size_threshold = bottommost_files_size / kBottommostSizeDivisor;
   return std::min(size_threshold, slowdown_threshold);
 }
 }  // anonymous namespace

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -3860,6 +3860,17 @@ TEST_F(DBTest2, LowPriWrite) {
         int64_t* rate_bytes_per_sec = static_cast<int64_t*>(arg);
         ASSERT_EQ(1024 * 1024, *rate_bytes_per_sec);
       });
+
+  // Make a trivial L5 for L0 to compact into. L6 will be large so debt ratio
+  // will not cause compaction pressure.
+  Random rnd(301);
+  ASSERT_OK(Put("", rnd.RandomString(102400)));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(6);
+  ASSERT_OK(Put("", ""));
+  ASSERT_OK(Flush());
+  MoveFilesToLevel(5);
+
   // Block compaction
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency({
       {"DBTest.LowPriWrite:0", "DBImpl::BGWorkCompaction"},

--- a/unreleased_history/behavior_changes/more_debt_based_speedup.md
+++ b/unreleased_history/behavior_changes/more_debt_based_speedup.md
@@ -1,0 +1,1 @@
+Reduced the compaction debt ratio trigger for scheduling parallel compactions


### PR DESCRIPTION
This PR significantly reduces the compaction pressure threshold introduced in #12130 by a factor of 64x. The original number was too high to trigger in scenarios where compaction parallelism was needed.