### PR TITLE
Remove unused variables in env/env_posix.cc

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -86,9 +86,9 @@
 namespace ROCKSDB_NAMESPACE {
 #if defined(OS_WIN)
 static const std::string kSharedLibExt = ".dll";
-static const char kPathSeparator = ';';
+[[maybe_unused]] static const char kPathSeparator = ';';
 #else
-static const char kPathSeparator = ':';
+[[maybe_unused]] static const char kPathSeparator = ':';
 #if defined(OS_MACOSX)
 static const std::string kSharedLibExt = ".dylib";
 #else


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D52847993


