### PR TITLE
Ensures PendingExpectedValue either Commit or Rollback

### DIFF
--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -80,7 +80,7 @@ std::vector<PendingExpectedValue> ExpectedState::PrepareDeleteRange(
     if (prepared) {
       pending_expected_values.push_back(pending_expected_value);
     } else {
-      pending_expected_value.Rollback();
+      pending_expected_value.PermitUnclosedPendingState();
     }
   }
   return pending_expected_values;

--- a/db_stress_tool/expected_state.cc
+++ b/db_stress_tool/expected_state.cc
@@ -79,6 +79,8 @@ std::vector<PendingExpectedValue> ExpectedState::PrepareDeleteRange(
         PrepareDelete(cf, key, &prepared);
     if (prepared) {
       pending_expected_values.push_back(pending_expected_value);
+    } else {
+      pending_expected_value.Rollback();
     }
   }
   return pending_expected_values;


### PR DESCRIPTION
This PR adds automatic checks in the `PendingExpectedValue` class to make sure it's either committed or rolled back before being destructed. 