### PR TITLE
Clean up after long-running whitebox crashtest

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -855,7 +855,7 @@ def exit_if_stderr_has_errors(stderr, print_stderr=True):
         print("TEST FAILED. Output has 'fail'!!!\n")
         sys.exit(2)
 
-def cleanup_and_exit_if_failed(dbname):
+def cleanup_after_success(dbname):
     shutil.rmtree(dbname, True)
     if cleanup_cmd is not None:
         print("Running DB cleanup command - %s\n" % cleanup_cmd)
@@ -919,7 +919,7 @@ def blackbox_crash_main(args, unknown_args):
     exit_if_stderr_has_errors(errs)
 
     # we need to clean up after ourselves -- only do this on test success
-    cleanup_and_exit_if_failed(dbname)
+    cleanup_after_success(dbname)
 
 
 # This python script runs db_stress multiple times. Some runs with
@@ -1086,7 +1086,7 @@ def whitebox_crash_main(args, unknown_args):
         # First half of the duration, keep doing kill test. For the next half,
         # try different modes.
         if time.time() > half_time:
-            cleanup_and_exit_if_failed(dbname)
+            cleanup_after_success(dbname)
             try:
                 os.mkdir(dbname)
             except OSError:
@@ -1103,7 +1103,7 @@ def whitebox_crash_main(args, unknown_args):
     # If successfully finished or timed out (we currently treat timed out test as passing)
     # Clean up after ourselves
     if expected or hit_timeout:
-        cleanup_and_exit_if_failed(dbname)
+        cleanup_after_success(dbname)
 
 
 def main():

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -944,6 +944,8 @@ def whitebox_crash_main(args, unknown_args):
     kill_random_test = cmd_params["random_kill_odd"]
     kill_mode = 0
     prev_compaction_style = -1
+    expected = False
+    hit_timeout = False
     while time.time() < exit_time:
         if check_mode == 0:
             additional_opts = {
@@ -1063,8 +1065,6 @@ def whitebox_crash_main(args, unknown_args):
 
         if hit_timeout:
             print("Killing the run for running too long")
-            # We treat the long running test as passing today. Clean up after ourselves
-            cleanup_and_exit_if_failed(dbname)
             break
 
         expected = False
@@ -1098,6 +1098,12 @@ def whitebox_crash_main(args, unknown_args):
             check_mode = (check_mode + 1) % total_check_mode
 
         time.sleep(1)  # time to stabilize after a kill
+
+
+    # If successfully finished or timed out (we currently treat timed out test as passing)
+    # Clean up after ourselves
+    if expected or hit_timeout:
+        cleanup_and_exit_if_failed(dbname)
 
 
 def main():

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -944,7 +944,7 @@ def whitebox_crash_main(args, unknown_args):
     kill_random_test = cmd_params["random_kill_odd"]
     kill_mode = 0
     prev_compaction_style = -1
-    expected = False
+    succeeded = True
     hit_timeout = False
     while time.time() < exit_time:
         if check_mode == 0:
@@ -1067,16 +1067,16 @@ def whitebox_crash_main(args, unknown_args):
             print("Killing the run for running too long")
             break
 
-        expected = False
+        succeeded = False
         if additional_opts["kill_random_test"] is None and (retncode == 0):
             # we expect zero retncode if no kill option
-            expected = True
+            succeeded = True
         elif additional_opts["kill_random_test"] is not None and retncode <= 0:
             # When kill option is given, the test MIGHT kill itself.
             # If it does, negative retncode is expected. Otherwise 0.
-            expected = True
+            succeeded = True
 
-        if not expected:
+        if not succeeded:
             print("TEST FAILED. See kill option and exit code above!!!\n")
             sys.exit(1)
 
@@ -1102,7 +1102,7 @@ def whitebox_crash_main(args, unknown_args):
 
     # If successfully finished or timed out (we currently treat timed out test as passing)
     # Clean up after ourselves
-    if expected or hit_timeout:
+    if succeeded or hit_timeout:
         cleanup_after_success(dbname)
 
 


### PR DESCRIPTION
# Summary

Currently, we treat the long-running whitebox_crash_test as passing. However, we were not cleaning up after ourselves when we killed the running test for running too long, which often caused out-of-space errors in subsequent tests (e.g., blackbox_crash_test after whitebox_crash_test).

Unless we want to start treating these timeouts as failures and need the DB output for investigation now, we should properly clean up the tmp dir.

# Test Plan

```
$> make crash_test -j
```
