### PR TITLE
Enhance ldb_cmd_tool to enable user pass in customized cfds

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -981,7 +981,7 @@ void LDBCommand::PrepareOptions() {
 
   if (column_families_.empty()) {
     // column_families not set. Either set it from MANIFEST or OPTIONS file.
-    if(column_families_from_options.empty()) {
+    if (column_families_from_options.empty()) {
       // Reads the MANIFEST to figure out what column families exist. In this
       // case, the option overrides from the CLI argument/specific subcommand
       // apply to all column families.
@@ -1002,15 +1002,15 @@ void LDBCommand::PrepareOptions() {
     }
   }
 
-  if (! column_families_from_options.empty()) {
+  if (!column_families_from_options.empty()) {
     // We got column families from the OPTIONS file. In this case, the option
     // overrides from the CLI argument/specific subcommand only apply to the
     // column family specified by `--column_family_name`.
-    auto column_families_iter = std::find_if(
-        column_families_.begin(), column_families_.end(),
-        [this](const ColumnFamilyDescriptor& cf_desc) {
-          return cf_desc.name == column_family_name_;
-        });
+    auto column_families_iter =
+        std::find_if(column_families_.begin(), column_families_.end(),
+                     [this](const ColumnFamilyDescriptor& cf_desc) {
+                       return cf_desc.name == column_family_name_;
+                     });
     if (column_families_iter == column_families_.end()) {
       exec_state_ = LDBCommandExecuteResult::Failed(
           "Non-existing column family " + column_family_name_);

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -1232,7 +1232,8 @@ TEST_F(LdbCmdTest, CustomComparator) {
   std::string dbname = test::PerThreadDBPath(env, "ldb_cmd_test");
   DB* db = nullptr;
 
-  std::vector<ColumnFamilyDescriptor> cfds = {{kDefaultColumnFamilyName, opts}};
+  std::vector<ColumnFamilyDescriptor> cfds = {
+      {kDefaultColumnFamilyName, opts}, {"cf1", opts}, {"cf2", opts}};
   std::vector<ColumnFamilyHandle*> handles;
   ASSERT_OK(DestroyDB(dbname, opts));
   ASSERT_OK(DB::Open(opts, dbname, cfds, &handles, &db));
@@ -1250,7 +1251,7 @@ TEST_F(LdbCmdTest, CustomComparator) {
   char* argv[] = {arg1, const_cast<char*>(arg2.c_str()), arg3, arg4};
 
   ASSERT_EQ(0,
-            LDBCommandRunner::RunCommand(4, argv, opts, LDBOptions(), nullptr));
+            LDBCommandRunner::RunCommand(4, argv, opts, LDBOptions(), &cfds));
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
# Summary
The current implementation of the ldb_cmd tool involves commenting out the user-passed column_family_descriptors, resulting in the tool consistently constructing its column_family_descriptors from the pre-existing OPTIONS file.

The proposed fix prioritizes user-passed column family descriptors, ensuring they take precedence over those specified in the OPTIONS file. This modification enhances the tool's adaptability and responsiveness to user configurations.