### PR TITLE
Improve crash test script to not rely on std::errors for failures.

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -837,16 +837,15 @@ def execute_cmd(cmd, timeout=None):
     return hit_timeout, child.returncode, outs.decode("utf-8"), errs.decode("utf-8")
 
 
-def print_if_stderr_has_errors(stderr, print_stderr=True):
-    if print_stderr:
-        for line in stderr.split("\n"):
-            if line != "" and not line.startswith("WARNING"):
-                print("stderr has error message:")
-                print("***" + line + "***")
+def print_if_stderr_has_errors(stderr):
+    for line in stderr.split("\n"):
+        if line != "" and not line.startswith("WARNING"):
+            print("stderr has error message:")
+            print("***" + line + "***")
 
     stderrdata = stderr.lower()
     errorcount = stderrdata.count("error") - stderrdata.count("got errors 0 times")
-    print("For debugging - #times std::error occurred in output is " + str(errorcount) + "\n")
+    print("#times error occurred in output is " + str(errorcount) + "\n")
 
 
 def cleanup_after_success(dbname):
@@ -1074,8 +1073,6 @@ def whitebox_crash_main(args, unknown_args):
             print("TEST FAILED. See kill option and exit code above!!!\n")
             sys.exit(1)
 
-        #stderr already printed above
-        print_if_stderr_has_errors(stderrdata, False)
 
         # First half of the duration, keep doing kill test. For the next half,
         # try different modes.

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -837,7 +837,7 @@ def execute_cmd(cmd, timeout=None):
     return hit_timeout, child.returncode, outs.decode("utf-8"), errs.decode("utf-8")
 
 
-def exit_if_stderr_has_errors(stderr, print_stderr=True):
+def print_if_stderr_has_errors(stderr, print_stderr=True):
     if print_stderr:
         for line in stderr.split("\n"):
             if line != "" and not line.startswith("WARNING"):
@@ -846,14 +846,8 @@ def exit_if_stderr_has_errors(stderr, print_stderr=True):
 
     stderrdata = stderr.lower()
     errorcount = stderrdata.count("error") - stderrdata.count("got errors 0 times")
-    print("#times error occurred in output is " + str(errorcount) + "\n")
+    print("For debugging - #times std::error occurred in output is " + str(errorcount) + "\n")
 
-    if errorcount > 0:
-        print("TEST FAILED. Output has 'error'!!!\n")
-        sys.exit(2)
-    if stderrdata.find("fail") >= 0:
-        print("TEST FAILED. Output has 'fail'!!!\n")
-        sys.exit(2)
 
 def cleanup_after_success(dbname):
     shutil.rmtree(dbname, True)
@@ -896,7 +890,7 @@ def blackbox_crash_main(args, unknown_args):
             print(errs)
             sys.exit(2)
 
-        exit_if_stderr_has_errors(errs);
+        print_if_stderr_has_errors(errs);
 
         time.sleep(1)  # time to stabilize before the next run
 
@@ -916,7 +910,7 @@ def blackbox_crash_main(args, unknown_args):
     # Print stats of the final run
     print("stdout:", outs)
 
-    exit_if_stderr_has_errors(errs)
+    print_if_stderr_has_errors(errs)
 
     # we need to clean up after ourselves -- only do this on test success
     cleanup_after_success(dbname)
@@ -1081,7 +1075,7 @@ def whitebox_crash_main(args, unknown_args):
             sys.exit(1)
 
         #stderr already printed above
-        exit_if_stderr_has_errors(stderrdata, False)
+        print_if_stderr_has_errors(stderrdata, False)
 
         # First half of the duration, keep doing kill test. For the next half,
         # try different modes.


### PR DESCRIPTION
Summary: Right now crash_test relies on std::errors too to check for only errors/failures along with verification. However, that's not a reliable solution and many internal services logs benign errors/warnings in which case our test script fails.

Test Plan: Keep std::errors but printout instead of failing and will monitor crash tests internally to see if there is any scenario which solely relies on std::error, in which case stress tests can be improve.

Reviewers:

Subscribers:

Tasks:

Tags: