### PR TITLE
Provide support for FSBuffer for point lookups

### DIFF
--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -420,7 +420,8 @@ IOStatus RandomAccessFileReader::MultiRead(const IOOptions& opts,
           remaining_bytes -= request_bytes;
         }
       }
-      io_s = file_->MultiRead(fs_reqs, num_fs_reqs, opts, nullptr);
+      io_s = file_->MultiRead(fs_reqs, num_fs_reqs, opts,
+                              /*IODebugContext*=*/nullptr);
       RecordInHistogram(stats_, MULTIGET_IO_BATCH_SIZE, num_fs_reqs);
     }
 

--- a/table/block_based/block_based_table_reader_sync_and_async.h
+++ b/table/block_based/block_based_table_reader_sync_and_async.h
@@ -192,10 +192,7 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::RetrieveMultipleBlocks)
 
     BlockContents serialized_block;
     if (s.ok()) {
-      if (use_fs_scratch) {
-        serialized_block =
-            BlockContents(Slice(req.result.data() + req_offset, handle.size()));
-      } else if (!use_shared_buffer) {
+      if (!use_fs_scratch && !use_shared_buffer) {
         // We allocated a buffer for this block. Give ownership of it to
         // BlockContents so it can free the memory
         assert(req.result.data() == req.scratch);
@@ -206,7 +203,8 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::RetrieveMultipleBlocks)
       } else {
         // We used the scratch buffer or direct io buffer
         // which are shared by the blocks.
-        // serialized_block does not have the ownership.
+        // In case of use_fs_scratch, underlying file system provided buffer is
+        // used. serialized_block does not have the ownership.
         serialized_block =
             BlockContents(Slice(req.result.data() + req_offset, handle.size()));
       }

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -191,16 +191,21 @@ inline void BlockFetcher::CopyBufferToCompressedBuf() {
 #endif
 }
 
-// Entering this method means the block is not compressed or do not need to be
-// uncompressed. The block can be in one of the following buffers:
+// Before - Entering this method means the block is uncompressed or do not need
+// to be uncompressed.
+//
+// The block can be in one of the following buffers:
 // 1. prefetch buffer if prefetch is enabled and the block is prefetched before
 // 2. stack_buf_ if block size is smaller than the stack_buf_ size and block
 //    is not compressed
 // 3. heap_buf_ if the block is not compressed
 // 4. compressed_buf_ if the block is compressed
-// 5. direct_io_buf_ if direct IO is enabled
-// After this method, if the block is compressed, it should be in
-// compressed_buf_, otherwise should be in heap_buf_.
+// 5. direct_io_buf_ if direct IO is enabled or
+// 6. underlying file_system scratch is used (FSReadRequest.fs_scratch).
+//
+// After - After this method, if the block is compressed, it should be in
+// compressed_buf_ and heap_buf_ points to compressed_buf_, otherwise should be
+// in heap_buf_.
 inline void BlockFetcher::GetBlockContents() {
   if (slice_.data() != used_buf_) {
     // the slice content is not the buffer provided
@@ -217,7 +222,7 @@ inline void BlockFetcher::GetBlockContents() {
       } else {
         heap_buf_ = std::move(compressed_buf_);
       }
-    } else if (direct_io_buf_.get() != nullptr) {
+    } else if (direct_io_buf_.get() != nullptr || use_fs_scratch_) {
       if (compression_type_ == kNoCompression) {
         CopyBufferToHeapBuf();
       } else {
@@ -233,6 +238,7 @@ inline void BlockFetcher::GetBlockContents() {
 }
 
 IOStatus BlockFetcher::ReadBlockContents() {
+  std::vector<FSReadRequest> read_reqs;
   if (TryGetUncompressBlockFromPersistentCache()) {
     compression_type_ = kNoCompression;
 #ifndef NDEBUG
@@ -256,18 +262,40 @@ IOStatus BlockFetcher::ReadBlockContents() {
             ioptions_.env ? ioptions_.env->GetSystemClock().get() : nullptr);
         io_status_ =
             file_->Read(opts, handle_.offset(), block_size_with_trailer_,
-                        &slice_, nullptr, &direct_io_buf_);
+                        &slice_, /*scratch=*/nullptr, &direct_io_buf_);
         PERF_COUNTER_ADD(block_read_count, 1);
         used_buf_ = const_cast<char*>(slice_.data());
-      } else {
-        PrepareBufferForBlockFromFile();
+      } else if (use_fs_scratch_) {
+        FSReadRequest read_req;
         PERF_TIMER_GUARD(block_read_time);
         PERF_CPU_TIMER_GUARD(
             block_read_cpu_time,
             ioptions_.env ? ioptions_.env->GetSystemClock().get() : nullptr);
-        io_status_ =
-            file_->Read(opts, handle_.offset(), block_size_with_trailer_,
-                        &slice_, used_buf_, nullptr);
+        read_req.offset = handle_.offset();
+        read_req.len = block_size_with_trailer_;
+        read_req.scratch = nullptr;
+        read_reqs.emplace_back(std::move(read_req));
+
+        io_status_ = file_->MultiRead(
+            opts, read_reqs.data(), read_reqs.size(),
+            (file_->use_direct_io() ? (&direct_io_buf_) : nullptr));
+
+        PERF_COUNTER_ADD(block_read_count, 1);
+
+        slice_ = Slice(read_reqs[0].result.data(), read_reqs[0].result.size());
+        used_buf_ = const_cast<char*>(slice_.data());
+      } else {
+        // It allocates/assign used_buf_
+        PrepareBufferForBlockFromFile();
+
+        PERF_TIMER_GUARD(block_read_time);
+        PERF_CPU_TIMER_GUARD(
+            block_read_cpu_time,
+            ioptions_.env ? ioptions_.env->GetSystemClock().get() : nullptr);
+
+        io_status_ = file_->Read(
+            opts, handle_.offset(), /*size*/ block_size_with_trailer_,
+            /*result*/ &slice_, /*scratch*/ used_buf_, /*aligned_buf=*/nullptr);
         PERF_COUNTER_ADD(block_read_count, 1);
 #ifndef NDEBUG
         if (slice_.data() == &stack_buf_[0]) {
@@ -303,10 +331,17 @@ IOStatus BlockFetcher::ReadBlockContents() {
 
     PERF_COUNTER_ADD(block_read_byte, block_size_with_trailer_);
     if (!io_status_.ok()) {
+      ReleaseFileSystemProvidedBuffer(read_reqs);
       return io_status_;
     }
 
+    if (!read_reqs.empty() && !read_reqs[0].status.ok()) {
+      ReleaseFileSystemProvidedBuffer(read_reqs);
+      return read_reqs[0].status;
+    }
+
     if (slice_.size() != block_size_with_trailer_) {
+      ReleaseFileSystemProvidedBuffer(read_reqs);
       return IOStatus::Corruption(
           "truncated block read from " + file_->file_name() + " offset " +
           std::to_string(handle_.offset()) + ", expected " +
@@ -318,6 +353,7 @@ IOStatus BlockFetcher::ReadBlockContents() {
     if (io_status_.ok()) {
       InsertCompressedBlockToPersistentCacheIfNeeded();
     } else {
+      ReleaseFileSystemProvidedBuffer(read_reqs);
       return io_status_;
     }
   }
@@ -341,6 +377,7 @@ IOStatus BlockFetcher::ReadBlockContents() {
   }
 
   InsertUncompressedBlockToPersistentCacheIfNeeded();
+  ReleaseFileSystemProvidedBuffer(read_reqs);
 
   return io_status_;
 }

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -148,14 +148,12 @@ class BlockFetcher {
   void InsertUncompressedBlockToPersistentCacheIfNeeded();
   void ProcessTrailerIfPresent();
 
-  void ReleaseFileSystemProvidedBuffer(std::vector<FSReadRequest>& read_reqs) {
+  void ReleaseFileSystemProvidedBuffer(FSReadRequest* read_req) {
     if (use_fs_scratch_) {
       // Free the scratch buffer allocated by FileSystem.
-      for (FSReadRequest& req : read_reqs) {
-        if (req.fs_scratch != nullptr) {
-          req.fs_scratch.reset();
-          req.fs_scratch = nullptr;
-        }
+      if (read_req->fs_scratch != nullptr) {
+        read_req->fs_scratch.reset();
+        read_req->fs_scratch = nullptr;
       }
     }
   }

--- a/unreleased_history/new_features/fsbuffer.md
+++ b/unreleased_history/new_features/fsbuffer.md
@@ -1,0 +1,1 @@
+Provide support for FSBuffer for point lookups. Also added support for scans and compactions that don't go through prefetching.

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -457,8 +457,8 @@ IOStatus TestFSRandomAccessFile::MultiRead(FSReadRequest* reqs, size_t num_reqs,
     }
     bool this_injected_error;
     reqs[i].status = fs_->InjectThreadSpecificReadError(
-        FaultInjectionTestFS::ErrorOperation::kMultiReadSingleReq,
-        &(reqs[i].result), use_direct_io(), reqs[i].scratch,
+        FaultInjectionTestFS::ErrorOperation::kRead, &(reqs[i].result),
+        use_direct_io(), reqs[i].scratch,
         /*need_count_increase=*/true,
         /*fault_injected=*/&this_injected_error);
     injected_error |= this_injected_error;


### PR DESCRIPTION
Summary: Provide support for FSBuffer for point lookups

It also add support for compaction and scan reads that goes through BlockFetcher when readahead/prefetching is not enabled.

Some of the compaction/Scan reads goes through FilePrefetchBuffer and some through BlockFetcher. This PR add support to use underlying file system scratch buffer for reads that go through BlockFetcher as for FilePrefetch reads, design is complicated to support this feature.

Design - In order to use underlying FileSystem provided scratch for Reads, it uses MultiRead with 1 request instead of Read API which required API change.

Test Plan: Stress test using underlying file system  scratch buffer internally.

Reviewers:

Subscribers:

Tasks:

Tags: