### PR TITLE
Print additional information when flaky test DBTestWithParam.ThreadStatusSingleCompaction fails

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4670,6 +4670,13 @@ void VerifyOperationCount(Env* env, ThreadStatus::OperationType op_type,
       op_count++;
     }
   }
+  if (op_count != expected_count) {
+    for (const auto& thread : thread_list) {
+      fprintf(stderr, "thread id: %" PRIu64 ", thread status: %s\n",
+              thread.thread_id,
+              thread.GetOperationName(thread.operation_type).c_str());
+    }
+  }
   ASSERT_EQ(op_count, expected_count);
 }
 }  // anonymous namespace


### PR DESCRIPTION
The test is [flaky](https://github.com/facebook/rocksdb/actions/runs/7616272304/job/20742657041?pr=12257&fbclid=IwAR1vNI1rSRVKnOsXs0WCPklqTkBXxlwS1GMJgWWe7D8dtAvh6e6wxk067FY) but I could not reproduce the test failure. Add some debug print to make the next failure more helpful


Test plan:
```
check print works when test fails:
[ RUN      ] DBTestWithParam/DBTestWithParam.ThreadStatusSingleCompaction/0
thread id: 6134067200, thread status:
thread id: 6133493760, thread status: Compaction
db/db_test.cc:4680: Failure
Expected equality of these values:
  op_count
    Which is: 1
  expected_count
    Which is: 0
```