### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/util/ribbon_impl.h

### DIFF
--- a/util/ribbon_impl.h
+++ b/util/ribbon_impl.h
@@ -168,11 +168,11 @@ class StandardHasher {
 
   inline Hash GetHash(const Key& key) const {
     return TypesAndSettings::HashFn(key, raw_seed_);
-  };
+  }
   // For when AddInput == pair<Key, ResultRow> (kIsFilter == false)
   inline Hash GetHash(const std::pair<Key, ResultRow>& bi) const {
     return GetHash(bi.first);
-  };
+  }
   inline Index GetStart(Hash h, Index num_starts) const {
     // This is "critical path" code because it's required before memory
     // lookup.


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52969093


