### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/util/murmurhash.cc

### DIFF
--- a/util/murmurhash.cc
+++ b/util/murmurhash.cc
@@ -64,7 +64,7 @@ uint64_t MurmurHash64A ( const void * key, int len, unsigned int seed )
     case 2: h ^= ((uint64_t)data2[1]) << 8;  FALLTHROUGH_INTENDED;
     case 1: h ^= ((uint64_t)data2[0]);
         h *= m;
-    };
+    }
 
     h ^= h >> r;
     h *= m;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52965944


