### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/utilities/env_mirror.cc

### DIFF
--- a/utilities/env_mirror.cc
+++ b/utilities/env_mirror.cc
@@ -59,7 +59,7 @@ class SequentialFileMirror : public SequentialFile {
     Status bs = b_->InvalidateCache(offset, length);
     assert(as == bs);
     return as;
-  };
+  }
 };
 
 class RandomAccessFileMirror : public RandomAccessFile {


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52969070


