### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/utilities/transactions/write_unprepared_txn.h

### DIFF
--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -281,7 +281,7 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
 
     SavePoint(const std::map<SequenceNumber, size_t>& seqs,
               ManagedSnapshot* snapshot)
-        : unprep_seqs_(seqs), snapshot_(snapshot){};
+        : unprep_seqs_(seqs), snapshot_(snapshot){}
   };
 
   // We have 3 data structures holding savepoint information:


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52969166


