### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/env/env_encryption.cc

### DIFF
--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -117,7 +117,7 @@ IOStatus EncryptedRandomAccessFile::Prefetch(uint64_t offset, size_t n,
 
 size_t EncryptedRandomAccessFile::GetUniqueId(char* id, size_t max_size) const {
   return file_->GetUniqueId(id, max_size);
-};
+}
 
 void EncryptedRandomAccessFile::Hint(AccessPattern pattern) {
   file_->Hint(pattern);


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52969133


