### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/include/rocksdb/slice_transform.h

### DIFF
--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -34,7 +34,7 @@ struct ConfigOptions;
 // including data loss, unreported corruption, deadlocks, and more.
 class SliceTransform : public Customizable {
  public:
-  virtual ~SliceTransform(){};
+  virtual ~SliceTransform(){}
 
   // Return the name of this transformation.
   virtual const char* Name() const override = 0;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52969065


