### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/utilities/transactions/lock/range/range_tree/lib/locktree/manager.cc

### DIFF
--- a/utilities/transactions/lock/range/range_tree/lib/locktree/manager.cc
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/manager.cc
@@ -260,7 +260,7 @@ void locktree_manager::run_escalation(void) {
     static void run(void *extra) {
       locktree_manager *mgr = (locktree_manager *)extra;
       mgr->escalate_all_locktrees();
-    };
+    }
   };
   m_escalator.run(this, escalation_fn::run, this);
 }


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52969073


