### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/db/internal_stats.h

### DIFF
--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -432,7 +432,7 @@ class InternalStats {
     explicit CompactionStatsFull() : stats(), penultimate_level_stats() {}
 
     explicit CompactionStatsFull(CompactionReason reason, int c)
-        : stats(reason, c), penultimate_level_stats(reason, c){};
+        : stats(reason, c), penultimate_level_stats(reason, c){}
 
     uint64_t TotalBytesWritten() const {
       uint64_t bytes_written = stats.bytes_written + stats.bytes_written_blob;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52969116


