### PR TITLE
Remove extra semi colon from internal_repo_rocksdb/repo/utilities/fault_injection_env.h

### DIFF
--- a/utilities/fault_injection_env.h
+++ b/utilities/fault_injection_env.h
@@ -95,7 +95,7 @@ class TestWritableFile : public WritableFile {
   }
   virtual bool use_direct_io() const override {
     return target_->use_direct_io();
-  };
+  }
   uint64_t GetFileSize() final { return target_->GetFileSize(); }
 
  private:
@@ -122,7 +122,7 @@ class TestRandomRWFile : public RandomRWFile {
   size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  bool use_direct_io() const override { return target_->use_direct_io(); };
+  bool use_direct_io() const override { return target_->use_direct_io(); }
 
  private:
   std::unique_ptr<RandomRWFile> target_;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: jaykorean

Differential Revision: D52968943


