### PR TITLE
Fix flaky test shutdown race in seqno_time_test

### DIFF
--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -33,10 +33,11 @@ class SeqnoTimeTest : public DBTestBase {
   void SetUp() override {
     mock_clock_->InstallTimedWaitFixCallback();
     SyncPoint::GetInstance()->SetCallBack(
-        "DBImpl::StartPeriodicTaskScheduler:Init", [&](void* arg) {
+        "DBImpl::StartPeriodicTaskScheduler:Init",
+        [mock_clock = mock_clock_](void* arg) {
           auto periodic_task_scheduler_ptr =
               reinterpret_cast<PeriodicTaskScheduler*>(arg);
-          periodic_task_scheduler_ptr->TEST_OverrideTimer(mock_clock_.get());
+          periodic_task_scheduler_ptr->TEST_OverrideTimer(mock_clock.get());
         });
     mock_clock_->SetCurrentTime(kMockStartTime);
   }


### PR DESCRIPTION
Summary: Seen in build-macos-cmake:

```
Received signal 11 (Segmentation fault: 11)
	#1   rocksdb::MockSystemClock::InstallTimedWaitFixCallback()::$_0::operator()(void*) const (in seqno_time_test) (mock_time_env.cc:29)
	#2   decltype(std::declval<rocksdb::MockSystemClock::InstallTimedWaitFixCallback()::$_0&>()(std::declval<void*>())) std::__1::__invoke[abi:v15006]<rocksdb::MockSystemClock::InstallTimedWaitFixCallback()::$_0&, void*>(rocksdb::MockSystemClock::InstallTimedWait	ixCallback()::$_0&, void*&&) (in seqno_time_test) (invoke.h:394)
...
```

This is presumably because the std::function from the lambda only saves a copy of the SeqnoTimeTest* this pointer, which doesn't prevent it from being reclaimed on parallel shutdown. If we instead save a copy of the `std::shared_ptr<MockSystemClock>` in the std::function, this should prevent the crash. (Note that in `SyncPoint::Data::Process()` copies the std::function before releasing the mutex for calling the callback.)

Test Plan: watch CI