### PR TITLE
Refresh() is not supported by vector memtable which may lead to an error in db_stress

### DIFF
--- a/db/arena_wrapped_db_iter.cc
+++ b/db/arena_wrapped_db_iter.cc
@@ -168,7 +168,10 @@ ArenaWrappedDBIter* NewArenaWrappedDbIterator(
   ArenaWrappedDBIter* iter = new ArenaWrappedDBIter();
   iter->Init(env, read_options, ioptions, mutable_cf_options, version, sequence,
              max_sequential_skip_in_iterations, version_number, read_callback,
-             db_impl, cfd, expose_blob_index, allow_refresh);
+             db_impl, cfd, expose_blob_index,
+             !ioptions.memtable_factory->IsRefreshIterSupported()
+                 ? false
+                 : allow_refresh);
   if (db_impl != nullptr && cfd != nullptr && allow_refresh) {
     iter->StoreRefreshInfo(db_impl, cfd, read_callback, expose_blob_index);
   }

--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -76,6 +76,7 @@ class ArenaWrappedDBIter : public Iterator {
   Status status() const override { return db_iter_->status(); }
   Slice timestamp() const override { return db_iter_->timestamp(); }
   bool IsBlob() const { return db_iter_->IsBlob(); }
+  bool IsAllowRefresh() override { return allow_refresh_; }
 
   Status GetProperty(std::string prop_name, std::string* prop) override;
 

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -3550,6 +3550,29 @@ TEST_F(DBIteratorTest, ErrorWhenReadFile) {
   iter->Reset();
 }
 
+TEST_F(DBIteratorTest, VectorRefreshStatus) {
+  Options options = CurrentOptions();
+  options.allow_concurrent_memtable_write = false;
+  options.memtable_factory.reset(new VectorRepFactory());
+  DestroyAndReopen(options);
+  Iterator* iter = db_->NewIterator(ReadOptions());
+  Status s = iter->Refresh();
+  ASSERT_TRUE(s.IsNotSupported());
+  ASSERT_FALSE(iter->IsAllowRefresh());
+  delete iter;
+}
+
+TEST_F(DBIteratorTest, SkipListRefreshStatus) {
+  Options options = CurrentOptions();
+  options.memtable_factory.reset(new SkipListFactory());
+  DestroyAndReopen(options);
+  Iterator* iter = db_->NewIterator(ReadOptions());
+  Status s = iter->Refresh();
+  ASSERT_OK(s);
+  ASSERT_TRUE(iter->IsAllowRefresh());
+  delete iter;
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1868,9 +1868,8 @@ class NonBatchedOpsStressTest : public StressTest {
       op_logs += "P";
     }
 
-    // Write-prepared and Write-unprepared do not support Refresh() yet.
-    if (!(FLAGS_use_txn && FLAGS_txn_write_policy != 0) &&
-        thread->rand.OneIn(2)) {
+    // Check if Refresh() supported.
+    if (thread->rand.OneIn(2) && iter->IsAllowRefresh()) {
       pre_read_expected_values.clear();
       post_read_expected_values.clear();
       // Refresh after forward/backward scan to allow higher chance of SV

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -122,7 +122,10 @@ class Iterator : public Cleanable {
   virtual Status Refresh(const class Snapshot*) {
     return Status::NotSupported("Refresh() is not supported");
   }
-
+  
+  // Check if iterator supports Refrsh()
+  virtual bool IsAllowRefresh() { return true; }
+  
   // Property "rocksdb.iterator.is-key-pinned":
   //   If returning "1", this means that the Slice returned by key() is valid
   //   as long as the iterator is not deleted.

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -325,6 +325,9 @@ class MemTableRepFactory : public Customizable {
   // false when if the <key,seq> already exists.
   // Default: false
   virtual bool CanHandleDuplicatedKey() const { return false; }
+
+  // Return true if the memtable support Refresh()
+  virtual bool IsRefreshIterSupported() const { return true; }
 };
 
 // This uses a skip list to store keys. It is the default.
@@ -378,6 +381,7 @@ class VectorRepFactory : public MemTableRepFactory {
   static const char* kNickName() { return "vector"; }
   const char* Name() const override { return kClassName(); }
   const char* NickName() const override { return kNickName(); }
+  bool IsRefreshIterSupported() const override { return false; }
 
   // Methods for MemTableRepFactory class overrides
   using MemTableRepFactory::CreateMemTableRep;


### PR DESCRIPTION
How to reproduce:

./db_stress --clear_column_family_one_in=0 --column_families=1  --destroy_db_initially=1 --key_len_percent_dist=100 --kill_random_test=0 --max_key=102400 --max_key_len=1  --verify_iterator_with_expected_state_one_in=1 --iterpercent=13 --readpercent=20 --writepercent=67 --delpercent=0 --delrangepercent=0 --prefixpercent=0   -column_families=1 -memtablerep=vector

error is: 

Verification failed. Expected state has key 0000000000008CD1, iterator is at key 0000000000008C97
Column family: default, op_logs: S 0000000000008CCC N SFP 0000000000008CD5 PRefresh  S 0000000000008CD1 P
2024/01/24-17:10:03  Starting verification        
Stress Test : 1194.578 micros/op 26618 ops/sec
            : Wrote 0.08 MB (0.28 MB/sec) (67% of 8147 ops)
            : Wrote 5496 times
            : Deleted 0 times
            : Single deleted 0 times
            : 1606 read and 50 found the key
            : Prefix scanned 0 times
            : Iterator size sum is 0
            : Iterated 1044 times
            : Deleted 0 key-ranges
            : Range deletions covered 0 keys
            : Got errors 1 times
            : 0 CompactFiles() succeed
            : 0 CompactFiles() did not succeed
Verification failed :(


After the fix there is no error
