### PR TITLE
Remove unnecessary, confusing 'extern'

### DIFF
--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -118,7 +118,7 @@ class ArenaWrappedDBIter : public Iterator {
 // Generate the arena wrapped iterator class.
 // `db_impl` and `cfd` are used for reneweal. If left null, renewal will not
 // be supported.
-extern ArenaWrappedDBIter* NewArenaWrappedDbIterator(
+ArenaWrappedDBIter* NewArenaWrappedDbIterator(
     Env* env, const ReadOptions& read_options, const ImmutableOptions& ioptions,
     const MutableCFOptions& mutable_cf_options, const Version* version,
     const SequenceNumber& sequence, uint64_t max_sequential_skip_in_iterations,

--- a/db/builder.h
+++ b/db/builder.h
@@ -50,7 +50,7 @@ TableBuilder* NewTableBuilder(const TableBuilderOptions& tboptions,
 //
 // @param column_family_name Name of the column family that is also identified
 //    by column_family_id, or empty string if unknown.
-extern Status BuildTable(
+Status BuildTable(
     const std::string& dbname, VersionSet* versions,
     const ImmutableDBOptions& db_options, const TableBuilderOptions& tboptions,
     const FileOptions& file_options, TableCache* table_cache,

--- a/db/c.cc
+++ b/db/c.cc
@@ -3144,7 +3144,7 @@ void rocksdb_options_set_enable_blob_files(rocksdb_options_t* opt,
                                            unsigned char val) {
   opt->rep.enable_blob_files = val;
 }
-extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_enable_blob_files(
+ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_enable_blob_files(
     rocksdb_options_t* opt) {
   return opt->rep.enable_blob_files;
 }
@@ -4636,7 +4636,7 @@ void rocksdb_readoptions_set_io_timeout(rocksdb_readoptions_t* opt,
   opt->rep.io_timeout = std::chrono::microseconds(microseconds);
 }
 
-extern ROCKSDB_LIBRARY_API uint64_t
+ROCKSDB_LIBRARY_API uint64_t
 rocksdb_readoptions_get_io_timeout(rocksdb_readoptions_t* opt) {
   return opt->rep.io_timeout.count();
 }
@@ -5469,9 +5469,7 @@ uint64_t rocksdb_livefiles_deletions(const rocksdb_livefiles_t* lf, int index) {
   return lf->rep[index].num_deletions;
 }
 
-extern void rocksdb_livefiles_destroy(const rocksdb_livefiles_t* lf) {
-  delete lf;
-}
+void rocksdb_livefiles_destroy(const rocksdb_livefiles_t* lf) { delete lf; }
 
 void rocksdb_get_options_from_string(const rocksdb_options_t* base_options,
                                      const char* opts_str,

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -251,20 +251,19 @@ struct SuperVersion {
   autovector<MemTable*> to_delete;
 };
 
-extern Status CheckCompressionSupported(const ColumnFamilyOptions& cf_options);
+Status CheckCompressionSupported(const ColumnFamilyOptions& cf_options);
 
-extern Status CheckConcurrentWritesSupported(
-    const ColumnFamilyOptions& cf_options);
+Status CheckConcurrentWritesSupported(const ColumnFamilyOptions& cf_options);
 
-extern Status CheckCFPathsSupported(const DBOptions& db_options,
-                                    const ColumnFamilyOptions& cf_options);
+Status CheckCFPathsSupported(const DBOptions& db_options,
+                             const ColumnFamilyOptions& cf_options);
 
-extern ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
-                                           const ColumnFamilyOptions& src);
+ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
+                                    const ColumnFamilyOptions& src);
 // Wrap user defined table properties collector factories `from cf_options`
 // into internal ones in int_tbl_prop_collector_factories. Add a system internal
 // one too.
-extern void GetIntTblPropCollectorFactory(
+void GetIntTblPropCollectorFactory(
     const ImmutableCFOptions& ioptions,
     IntTblPropCollectorFactories* int_tbl_prop_collector_factories);
 
@@ -872,12 +871,11 @@ class ColumnFamilyMemTablesImpl : public ColumnFamilyMemTables {
   ColumnFamilyHandleInternal handle_;
 };
 
-extern uint32_t GetColumnFamilyID(ColumnFamilyHandle* column_family);
+uint32_t GetColumnFamilyID(ColumnFamilyHandle* column_family);
 
-extern const Comparator* GetColumnFamilyUserComparator(
+const Comparator* GetColumnFamilyUserComparator(
     ColumnFamilyHandle* column_family);
 
-extern const ImmutableOptions& GetImmutableOptions(
-    ColumnFamilyHandle* column_family);
+const ImmutableOptions& GetImmutableOptions(ColumnFamilyHandle* column_family);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -595,6 +595,6 @@ struct PerKeyPlacementContext {
 #endif /* !NDEBUG */
 
 // Return sum of sizes of all files in `files`.
-extern uint64_t TotalFileSize(const std::vector<FileMetaData*>& files);
+uint64_t TotalFileSize(const std::vector<FileMetaData*>& files);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/db_impl/compacted_db_impl.cc
+++ b/db/db_impl/compacted_db_impl.cc
@@ -13,10 +13,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-extern void MarkKeyMayExist(void* arg);
-extern bool SaveValue(void* arg, const ParsedInternalKey& parsed_key,
-                      const Slice& v, bool hit_and_return);
-
 CompactedDBImpl::CompactedDBImpl(const DBOptions& options,
                                  const std::string& dbname)
     : DBImpl(options, dbname, /*seq_per_batch*/ false, +/*batch_per_txn*/ true,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2855,17 +2855,16 @@ class GetWithTimestampReadCallback : public ReadCallback {
   }
 };
 
-extern Options SanitizeOptions(const std::string& db, const Options& src,
-                               bool read_only = false,
-                               Status* logger_creation_s = nullptr);
+Options SanitizeOptions(const std::string& db, const Options& src,
+                        bool read_only = false,
+                        Status* logger_creation_s = nullptr);
 
-extern DBOptions SanitizeOptions(const std::string& db, const DBOptions& src,
-                                 bool read_only = false,
-                                 Status* logger_creation_s = nullptr);
+DBOptions SanitizeOptions(const std::string& db, const DBOptions& src,
+                          bool read_only = false,
+                          Status* logger_creation_s = nullptr);
 
-extern CompressionType GetCompressionFlush(
-    const ImmutableCFOptions& ioptions,
-    const MutableCFOptions& mutable_cf_options);
+CompressionType GetCompressionFlush(const ImmutableCFOptions& ioptions,
+                                    const MutableCFOptions& mutable_cf_options);
 
 // Return the earliest log file to keep after the memtable flush is
 // finalized.
@@ -2873,13 +2872,13 @@ extern CompressionType GetCompressionFlush(
 // `memtables_to_flush`) will be flushed and thus will not depend on any WAL
 // file.
 // The function is only applicable to 2pc mode.
-extern uint64_t PrecomputeMinLogNumberToKeep2PC(
+uint64_t PrecomputeMinLogNumberToKeep2PC(
     VersionSet* vset, const ColumnFamilyData& cfd_to_flush,
     const autovector<VersionEdit*>& edit_list,
     const autovector<MemTable*>& memtables_to_flush,
     LogsWithPrepTracker* prep_tracker);
 // For atomic flush.
-extern uint64_t PrecomputeMinLogNumberToKeep2PC(
+uint64_t PrecomputeMinLogNumberToKeep2PC(
     VersionSet* vset, const autovector<ColumnFamilyData*>& cfds_to_flush,
     const autovector<autovector<VersionEdit*>>& edit_lists,
     const autovector<const autovector<MemTable*>*>& memtables_to_flush,
@@ -2887,21 +2886,21 @@ extern uint64_t PrecomputeMinLogNumberToKeep2PC(
 
 // In non-2PC mode, WALs with log number < the returned number can be
 // deleted after the cfd_to_flush column family is flushed successfully.
-extern uint64_t PrecomputeMinLogNumberToKeepNon2PC(
+uint64_t PrecomputeMinLogNumberToKeepNon2PC(
     VersionSet* vset, const ColumnFamilyData& cfd_to_flush,
     const autovector<VersionEdit*>& edit_list);
 // For atomic flush.
-extern uint64_t PrecomputeMinLogNumberToKeepNon2PC(
+uint64_t PrecomputeMinLogNumberToKeepNon2PC(
     VersionSet* vset, const autovector<ColumnFamilyData*>& cfds_to_flush,
     const autovector<autovector<VersionEdit*>>& edit_lists);
 
 // `cfd_to_flush` is the column family whose memtable will be flushed and thus
 // will not depend on any WAL file. nullptr means no memtable is being flushed.
 // The function is only applicable to 2pc mode.
-extern uint64_t FindMinPrepLogReferencedByMemTable(
+uint64_t FindMinPrepLogReferencedByMemTable(
     VersionSet* vset, const autovector<MemTable*>& memtables_to_flush);
 // For atomic flush.
-extern uint64_t FindMinPrepLogReferencedByMemTable(
+uint64_t FindMinPrepLogReferencedByMemTable(
     VersionSet* vset,
     const autovector<const autovector<MemTable*>*>& memtables_to_flush);
 

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -428,13 +428,15 @@ class DBIter final : public Iterator {
 // Return a new iterator that converts internal keys (yielded by
 // "*internal_iter") that were live at the specified `sequence` number
 // into appropriate user keys.
-extern Iterator* NewDBIterator(
-    Env* env, const ReadOptions& read_options, const ImmutableOptions& ioptions,
-    const MutableCFOptions& mutable_cf_options,
-    const Comparator* user_key_comparator, InternalIterator* internal_iter,
-    const Version* version, const SequenceNumber& sequence,
-    uint64_t max_sequential_skip_in_iterations, ReadCallback* read_callback,
-    DBImpl* db_impl = nullptr, ColumnFamilyData* cfd = nullptr,
-    bool expose_blob_index = false);
+Iterator* NewDBIterator(Env* env, const ReadOptions& read_options,
+                        const ImmutableOptions& ioptions,
+                        const MutableCFOptions& mutable_cf_options,
+                        const Comparator* user_key_comparator,
+                        InternalIterator* internal_iter, const Version* version,
+                        const SequenceNumber& sequence,
+                        uint64_t max_sequential_skip_in_iterations,
+                        ReadCallback* read_callback, DBImpl* db_impl = nullptr,
+                        ColumnFamilyData* cfd = nullptr,
+                        bool expose_blob_index = false);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -58,7 +58,7 @@ struct DBPropertyInfo {
   bool (DBImpl::*handle_string_dbimpl)(std::string* value);
 };
 
-extern const DBPropertyInfo* GetPropertyInfo(const Slice& property);
+const DBPropertyInfo* GetPropertyInfo(const Slice& property);
 
 #undef SCORE
 enum class LevelStatType {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -699,6 +699,6 @@ class MemTable {
   void MaybeUpdateNewestUDT(const Slice& user_key);
 };
 
-extern const char* EncodeKey(std::string* scratch, const Slice& target);
+const char* EncodeKey(std::string* scratch, const Slice& target);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -498,7 +498,7 @@ class MemTableList {
 // installs flush results for external immutable memtable lists other than the
 // cfds' own immutable memtable lists, e.g. MemTableLIstTest. In this case,
 // imm_lists parameter is not nullptr.
-extern Status InstallMemtableAtomicFlushResults(
+Status InstallMemtableAtomicFlushResults(
     const autovector<MemTableList*>* imm_lists,
     const autovector<ColumnFamilyData*>& cfds,
     const autovector<const MutableCFOptions*>& mutable_cf_options_list,

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -252,8 +252,6 @@ TEST_P(PlainTableDBTest, Empty) {
   ASSERT_EQ("NOT_FOUND", Get("0000000000000foo"));
 }
 
-extern const uint64_t kPlainTableMagicNumber;
-
 class TestPlainTableReader : public PlainTableReader {
  public:
   TestPlainTableReader(
@@ -307,7 +305,6 @@ class TestPlainTableReader : public PlainTableReader {
   bool* expect_bloom_not_match_;
 };
 
-extern const uint64_t kPlainTableMagicNumber;
 class TestPlainTableFactory : public PlainTableFactory {
  public:
   explicit TestPlainTableFactory(bool* expect_bloom_not_match,

--- a/db/table_properties_collector_test.cc
+++ b/db/table_properties_collector_test.cc
@@ -242,8 +242,6 @@ class FlushBlockEveryThreePolicyFactory : public FlushBlockPolicyFactory {
   }
 };
 
-extern const uint64_t kBlockBasedTableMagicNumber;
-extern const uint64_t kPlainTableMagicNumber;
 namespace {
 void TestCustomizedTablePropertiesCollector(
     bool backward_mode, uint64_t magic_number, bool test_int_tbl_prop_collector,

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -113,7 +113,7 @@ constexpr uint64_t kUnknownEpochNumber = 0;
 // will be dedicated to files ingested behind.
 constexpr uint64_t kReservedEpochNumberForFileIngestedBehind = 1;
 
-extern uint64_t PackFileNumberAndPathId(uint64_t number, uint64_t path_id);
+uint64_t PackFileNumberAndPathId(uint64_t number, uint64_t path_id);
 
 // A copyable structure contains information needed to read data from an SST
 // file. It can contain a pointer to a table reader opened for the file, or

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -98,8 +98,8 @@ using VersionEditParams = VersionEdit;
 // Return file_level.num_files if there is no such file.
 // REQUIRES: "file_level.files" contains a sorted list of
 // non-overlapping files.
-extern int FindFile(const InternalKeyComparator& icmp,
-                    const LevelFilesBrief& file_level, const Slice& key);
+int FindFile(const InternalKeyComparator& icmp,
+             const LevelFilesBrief& file_level, const Slice& key);
 
 // Returns true iff some file in "files" overlaps the user key range
 // [*smallest,*largest].
@@ -107,18 +107,18 @@ extern int FindFile(const InternalKeyComparator& icmp,
 // largest==nullptr represents a key largest than all keys in the DB.
 // REQUIRES: If disjoint_sorted_files, file_level.files[]
 // contains disjoint ranges in sorted order.
-extern bool SomeFileOverlapsRange(const InternalKeyComparator& icmp,
-                                  bool disjoint_sorted_files,
-                                  const LevelFilesBrief& file_level,
-                                  const Slice* smallest_user_key,
-                                  const Slice* largest_user_key);
+bool SomeFileOverlapsRange(const InternalKeyComparator& icmp,
+                           bool disjoint_sorted_files,
+                           const LevelFilesBrief& file_level,
+                           const Slice* smallest_user_key,
+                           const Slice* largest_user_key);
 
 // Generate LevelFilesBrief from vector<FdWithKeyRange*>
 // Would copy smallest_key and largest_key data to sequential memory
 // arena: Arena used to allocate the memory
-extern void DoGenerateLevelFilesBrief(LevelFilesBrief* file_level,
-                                      const std::vector<FileMetaData*>& files,
-                                      Arena* arena);
+void DoGenerateLevelFilesBrief(LevelFilesBrief* file_level,
+                               const std::vector<FileMetaData*>& files,
+                               Arena* arena);
 enum EpochNumberRequirement {
   kMightMissing,
   kMustPresent,

--- a/db/write_stall_stats.h
+++ b/db/write_stall_stats.h
@@ -11,11 +11,11 @@
 #include "rocksdb/types.h"
 
 namespace ROCKSDB_NAMESPACE {
-extern const std::string& InvalidWriteStallHyphenString();
+const std::string& InvalidWriteStallHyphenString();
 
-extern const std::string& WriteStallCauseToHyphenString(WriteStallCause cause);
+const std::string& WriteStallCauseToHyphenString(WriteStallCause cause);
 
-extern const std::string& WriteStallConditionToHyphenString(
+const std::string& WriteStallConditionToHyphenString(
     WriteStallCondition condition);
 
 // REQUIRES:
@@ -23,7 +23,7 @@ extern const std::string& WriteStallConditionToHyphenString(
 //
 // REQUIRES:
 // `condition` != `WriteStallCondition::kNormal`
-extern InternalStats::InternalCFStatsType InternalCFStat(
+InternalStats::InternalCFStatsType InternalCFStat(
     WriteStallCause cause, WriteStallCondition condition);
 
 // REQUIRES:
@@ -31,11 +31,11 @@ extern InternalStats::InternalCFStatsType InternalCFStat(
 //
 // REQUIRES:
 // `condition` != `WriteStallCondition::kNormal`
-extern InternalStats::InternalDBStatsType InternalDBStat(
+InternalStats::InternalDBStatsType InternalDBStat(
     WriteStallCause cause, WriteStallCondition condition);
 
-extern bool isCFScopeWriteStallCause(WriteStallCause cause);
-extern bool isDBScopeWriteStallCause(WriteStallCause cause);
+bool isCFScopeWriteStallCause(WriteStallCause cause);
+bool isDBScopeWriteStallCause(WriteStallCause cause);
 
 constexpr uint32_t kNumCFScopeWriteStallCauses =
     static_cast<uint32_t>(WriteStallCause::kCFScopeWriteStallCauseEnumMax) -

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -489,7 +489,7 @@ inline bool GetNextPrefix(const ROCKSDB_NAMESPACE::Slice& src, std::string* v) {
 #endif
 
 // Append `val` to `*key` in fixed-width big-endian format
-extern inline void AppendIntToString(uint64_t val, std::string* key) {
+inline void AppendIntToString(uint64_t val, std::string* key) {
   // PutFixed64 uses little endian
   PutFixed64(key, val);
   // Reverse to get big endian
@@ -518,7 +518,7 @@ extern KeyGenContext key_gen_ctx;
 // - {0}...{x-1}
 // {(x-1),0}..{(x-1),(y-1)},{(x-1),(y-1),0}..{(x-1),(y-1),(z-1)} and so on.
 // Additionally, a trailer of 0-7 bytes could be appended.
-extern inline std::string Key(int64_t val) {
+inline std::string Key(int64_t val) {
   uint64_t window = key_gen_ctx.window;
   size_t levels = key_gen_ctx.weights.size();
   std::string key;
@@ -556,7 +556,7 @@ extern inline std::string Key(int64_t val) {
 }
 
 // Given a string key, map it to an index into the expected values buffer
-extern inline bool GetIntVal(std::string big_endian_key, uint64_t* key_p) {
+inline bool GetIntVal(std::string big_endian_key, uint64_t* key_p) {
   size_t size_key = big_endian_key.size();
   std::vector<uint64_t> prefixes;
 
@@ -611,8 +611,8 @@ inline bool GetFirstIntValInPrefix(std::string big_endian_prefix,
   return GetIntVal(std::move(big_endian_prefix), key_p);
 }
 
-extern inline uint64_t GetPrefixKeyCount(const std::string& prefix,
-                                         const std::string& ub) {
+inline uint64_t GetPrefixKeyCount(const std::string& prefix,
+                                  const std::string& ub) {
   uint64_t start = 0;
   uint64_t end = 0;
 
@@ -624,7 +624,7 @@ extern inline uint64_t GetPrefixKeyCount(const std::string& prefix,
   return end - start;
 }
 
-extern inline std::string StringToHex(const std::string& str) {
+inline std::string StringToHex(const std::string& str) {
   std::string result = "0x";
   result.append(Slice(str).ToString(true));
   return result;
@@ -643,49 +643,49 @@ inline std::string WideColumnsToHex(const WideColumns& columns) {
 }
 
 // Unified output format for double parameters
-extern inline std::string FormatDoubleParam(double param) {
+inline std::string FormatDoubleParam(double param) {
   return std::to_string(param);
 }
 
 // Make sure that double parameter is a value we can reproduce by
 // re-inputting the value printed.
-extern inline void SanitizeDoubleParam(double* param) {
+inline void SanitizeDoubleParam(double* param) {
   *param = std::atof(FormatDoubleParam(*param).c_str());
 }
 
-extern void PoolSizeChangeThread(void* v);
+void PoolSizeChangeThread(void* v);
 
-extern void DbVerificationThread(void* v);
+void DbVerificationThread(void* v);
 
-extern void CompressedCacheSetCapacityThread(void* v);
+void CompressedCacheSetCapacityThread(void* v);
 
-extern void TimestampedSnapshotsThread(void* v);
+void TimestampedSnapshotsThread(void* v);
 
-extern void PrintKeyValue(int cf, uint64_t key, const char* value, size_t sz);
+void PrintKeyValue(int cf, uint64_t key, const char* value, size_t sz);
 
-extern int64_t GenerateOneKey(ThreadState* thread, uint64_t iteration);
+int64_t GenerateOneKey(ThreadState* thread, uint64_t iteration);
 
-extern std::vector<int64_t> GenerateNKeys(ThreadState* thread, int num_keys,
-                                          uint64_t iteration);
+std::vector<int64_t> GenerateNKeys(ThreadState* thread, int num_keys,
+                                   uint64_t iteration);
 
-extern size_t GenerateValue(uint32_t rand, char* v, size_t max_sz);
-extern uint32_t GetValueBase(Slice s);
+size_t GenerateValue(uint32_t rand, char* v, size_t max_sz);
+uint32_t GetValueBase(Slice s);
 
-extern WideColumns GenerateWideColumns(uint32_t value_base, const Slice& slice);
-extern WideColumns GenerateExpectedWideColumns(uint32_t value_base,
-                                               const Slice& slice);
-extern bool VerifyWideColumns(const Slice& value, const WideColumns& columns);
-extern bool VerifyWideColumns(const WideColumns& columns);
+WideColumns GenerateWideColumns(uint32_t value_base, const Slice& slice);
+WideColumns GenerateExpectedWideColumns(uint32_t value_base,
+                                        const Slice& slice);
+bool VerifyWideColumns(const Slice& value, const WideColumns& columns);
+bool VerifyWideColumns(const WideColumns& columns);
 
-extern StressTest* CreateCfConsistencyStressTest();
-extern StressTest* CreateBatchedOpsStressTest();
-extern StressTest* CreateNonBatchedOpsStressTest();
-extern StressTest* CreateMultiOpsTxnsStressTest();
-extern void CheckAndSetOptionsForMultiOpsTxnStressTest();
-extern void InitializeHotKeyGenerator(double alpha);
-extern int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);
+StressTest* CreateCfConsistencyStressTest();
+StressTest* CreateBatchedOpsStressTest();
+StressTest* CreateNonBatchedOpsStressTest();
+StressTest* CreateMultiOpsTxnsStressTest();
+void CheckAndSetOptionsForMultiOpsTxnStressTest();
+void InitializeHotKeyGenerator(double alpha);
+int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);
 
-extern std::string GetNowNanos();
+std::string GetNowNanos();
 
 std::shared_ptr<FileChecksumGenFactory> GetFileChecksumImpl(
     const std::string& name);

--- a/db_stress_tool/db_stress_driver.h
+++ b/db_stress_tool/db_stress_driver.h
@@ -12,7 +12,7 @@
 #pragma once
 #include "db_stress_tool/db_stress_test_base.h"
 namespace ROCKSDB_NAMESPACE {
-extern void ThreadBody(void* /*thread_state*/);
-extern bool RunStressTest(SharedState*);
+void ThreadBody(void* /*thread_state*/);
+bool RunStressTest(SharedState*);
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -291,13 +291,13 @@ class StressTest {
 };
 
 // Load options from OPTIONS file and populate `options`.
-extern bool InitializeOptionsFromFile(Options& options);
+bool InitializeOptionsFromFile(Options& options);
 
 // Initialize `options` using command line arguments.
 // When this function is called, `cache`, `block_cache_compressed`,
 // `filter_policy` have all been initialized. Therefore, we just pass them as
 // input arguments.
-extern void InitializeOptionsFromFlags(
+void InitializeOptionsFromFlags(
     const std::shared_ptr<Cache>& cache,
     const std::shared_ptr<const FilterPolicy>& filter_policy, Options& options);
 
@@ -322,7 +322,7 @@ extern void InitializeOptionsFromFlags(
 //
 // InitializeOptionsGeneral() must not overwrite fields of `options` loaded
 // from OPTIONS file.
-extern void InitializeOptionsGeneral(
+void InitializeOptionsGeneral(
     const std::shared_ptr<Cache>& cache,
     const std::shared_ptr<const FilterPolicy>& filter_policy, Options& options);
 
@@ -330,7 +330,7 @@ extern void InitializeOptionsGeneral(
 // user-defined timestamp which requires `-user_timestamp_size=8`.
 // This function also checks for known (currently) incompatible features with
 // user-defined timestamp.
-extern void CheckAndSetOptionsForUserTimestamp(Options& options);
+void CheckAndSetOptionsForUserTimestamp(Options& options);
 
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/file/file_util.h
+++ b/file/file_util.h
@@ -20,16 +20,15 @@
 namespace ROCKSDB_NAMESPACE {
 // use_fsync maps to options.use_fsync, which determines the way that
 // the file is synced after copying.
-extern IOStatus CopyFile(FileSystem* fs, const std::string& source,
-                         std::unique_ptr<WritableFileWriter>& dest_writer,
-                         uint64_t size, bool use_fsync,
-                         const std::shared_ptr<IOTracer>& io_tracer,
-                         const Temperature temperature);
-extern IOStatus CopyFile(FileSystem* fs, const std::string& source,
-                         const std::string& destination, uint64_t size,
-                         bool use_fsync,
-                         const std::shared_ptr<IOTracer>& io_tracer,
-                         const Temperature temperature);
+IOStatus CopyFile(FileSystem* fs, const std::string& source,
+                  std::unique_ptr<WritableFileWriter>& dest_writer,
+                  uint64_t size, bool use_fsync,
+                  const std::shared_ptr<IOTracer>& io_tracer,
+                  const Temperature temperature);
+IOStatus CopyFile(FileSystem* fs, const std::string& source,
+                  const std::string& destination, uint64_t size, bool use_fsync,
+                  const std::shared_ptr<IOTracer>& io_tracer,
+                  const Temperature temperature);
 inline IOStatus CopyFile(const std::shared_ptr<FileSystem>& fs,
                          const std::string& source,
                          const std::string& destination, uint64_t size,
@@ -39,8 +38,8 @@ inline IOStatus CopyFile(const std::shared_ptr<FileSystem>& fs,
   return CopyFile(fs.get(), source, destination, size, use_fsync, io_tracer,
                   temperature);
 }
-extern IOStatus CreateFile(FileSystem* fs, const std::string& destination,
-                           const std::string& contents, bool use_fsync);
+IOStatus CreateFile(FileSystem* fs, const std::string& destination,
+                    const std::string& contents, bool use_fsync);
 
 inline IOStatus CreateFile(const std::shared_ptr<FileSystem>& fs,
                            const std::string& destination,
@@ -48,13 +47,12 @@ inline IOStatus CreateFile(const std::shared_ptr<FileSystem>& fs,
   return CreateFile(fs.get(), destination, contents, use_fsync);
 }
 
-extern Status DeleteDBFile(const ImmutableDBOptions* db_options,
-                           const std::string& fname,
-                           const std::string& path_to_sync, const bool force_bg,
-                           const bool force_fg);
+Status DeleteDBFile(const ImmutableDBOptions* db_options,
+                    const std::string& fname, const std::string& path_to_sync,
+                    const bool force_bg, const bool force_fg);
 
 // TODO(hx235): pass the whole DBOptions intead of its individual fields
-extern IOStatus GenerateOneFileChecksum(
+IOStatus GenerateOneFileChecksum(
     FileSystem* fs, const std::string& file_path,
     FileChecksumGenFactory* checksum_factory,
     const std::string& requested_checksum_func_name, std::string* file_checksum,

--- a/file/filename.h
+++ b/file/filename.h
@@ -40,69 +40,68 @@ constexpr char kFilePathSeparator = '/';
 // Return the name of the log file with the specified number
 // in the db named by "dbname".  The result will be prefixed with
 // "dbname".
-extern std::string LogFileName(const std::string& dbname, uint64_t number);
+std::string LogFileName(const std::string& dbname, uint64_t number);
 
-extern std::string LogFileName(uint64_t number);
+std::string LogFileName(uint64_t number);
 
-extern std::string BlobFileName(uint64_t number);
+std::string BlobFileName(uint64_t number);
 
-extern std::string BlobFileName(const std::string& bdirname, uint64_t number);
+std::string BlobFileName(const std::string& bdirname, uint64_t number);
 
-extern std::string BlobFileName(const std::string& dbname,
-                                const std::string& blob_dir, uint64_t number);
+std::string BlobFileName(const std::string& dbname, const std::string& blob_dir,
+                         uint64_t number);
 
-extern std::string ArchivalDirectory(const std::string& dbname);
+std::string ArchivalDirectory(const std::string& dbname);
 
 //  Return the name of the archived log file with the specified number
 //  in the db named by "dbname". The result will be prefixed with "dbname".
-extern std::string ArchivedLogFileName(const std::string& dbname, uint64_t num);
+std::string ArchivedLogFileName(const std::string& dbname, uint64_t num);
 
-extern std::string MakeTableFileName(const std::string& name, uint64_t number);
+std::string MakeTableFileName(const std::string& name, uint64_t number);
 
-extern std::string MakeTableFileName(uint64_t number);
+std::string MakeTableFileName(uint64_t number);
 
 // Return the name of sstable with LevelDB suffix
 // created from RocksDB sstable suffixed name
-extern std::string Rocks2LevelTableFileName(const std::string& fullname);
+std::string Rocks2LevelTableFileName(const std::string& fullname);
 
 // the reverse function of MakeTableFileName
 // TODO(yhchiang): could merge this function with ParseFileName()
-extern uint64_t TableFileNameToNumber(const std::string& name);
+uint64_t TableFileNameToNumber(const std::string& name);
 
 // Return the name of the sstable with the specified number
 // in the db named by "dbname".  The result will be prefixed with
 // "dbname".
-extern std::string TableFileName(const std::vector<DbPath>& db_paths,
-                                 uint64_t number, uint32_t path_id);
+std::string TableFileName(const std::vector<DbPath>& db_paths, uint64_t number,
+                          uint32_t path_id);
 
 // Sufficient buffer size for FormatFileNumber.
 const size_t kFormatFileNumberBufSize = 38;
 
-extern void FormatFileNumber(uint64_t number, uint32_t path_id, char* out_buf,
-                             size_t out_buf_size);
+void FormatFileNumber(uint64_t number, uint32_t path_id, char* out_buf,
+                      size_t out_buf_size);
 
 // Return the name of the descriptor file for the db named by
 // "dbname" and the specified incarnation number.  The result will be
 // prefixed with "dbname".
-extern std::string DescriptorFileName(const std::string& dbname,
-                                      uint64_t number);
+std::string DescriptorFileName(const std::string& dbname, uint64_t number);
 
-extern std::string DescriptorFileName(uint64_t number);
+std::string DescriptorFileName(uint64_t number);
 
 extern const std::string kCurrentFileName;  // = "CURRENT"
 
 // Return the name of the current file.  This file contains the name
 // of the current manifest file.  The result will be prefixed with
 // "dbname".
-extern std::string CurrentFileName(const std::string& dbname);
+std::string CurrentFileName(const std::string& dbname);
 
 // Return the name of the lock file for the db named by
 // "dbname".  The result will be prefixed with "dbname".
-extern std::string LockFileName(const std::string& dbname);
+std::string LockFileName(const std::string& dbname);
 
 // Return the name of a temporary file owned by the db named "dbname".
 // The result will be prefixed with "dbname".
-extern std::string TempFileName(const std::string& dbname, uint64_t number);
+std::string TempFileName(const std::string& dbname, uint64_t number);
 
 // A helper structure for prefix of info log names.
 struct InfoLogPrefix {
@@ -115,77 +114,73 @@ struct InfoLogPrefix {
 };
 
 // Return the name of the info log file for "dbname".
-extern std::string InfoLogFileName(const std::string& dbname,
-                                   const std::string& db_path = "",
-                                   const std::string& log_dir = "");
+std::string InfoLogFileName(const std::string& dbname,
+                            const std::string& db_path = "",
+                            const std::string& log_dir = "");
 
 // Return the name of the old info log file for "dbname".
-extern std::string OldInfoLogFileName(const std::string& dbname, uint64_t ts,
-                                      const std::string& db_path = "",
-                                      const std::string& log_dir = "");
+std::string OldInfoLogFileName(const std::string& dbname, uint64_t ts,
+                               const std::string& db_path = "",
+                               const std::string& log_dir = "");
 
 extern const std::string kOptionsFileNamePrefix;  // = "OPTIONS-"
 extern const std::string kTempFileNameSuffix;     // = "dbtmp"
 
 // Return a options file name given the "dbname" and file number.
 // Format:  OPTIONS-[number].dbtmp
-extern std::string OptionsFileName(const std::string& dbname,
-                                   uint64_t file_num);
-extern std::string OptionsFileName(uint64_t file_num);
+std::string OptionsFileName(const std::string& dbname, uint64_t file_num);
+std::string OptionsFileName(uint64_t file_num);
 
 // Return a temp options file name given the "dbname" and file number.
 // Format:  OPTIONS-[number]
-extern std::string TempOptionsFileName(const std::string& dbname,
-                                       uint64_t file_num);
+std::string TempOptionsFileName(const std::string& dbname, uint64_t file_num);
 
 // Return the name to use for a metadatabase. The result will be prefixed with
 // "dbname".
-extern std::string MetaDatabaseName(const std::string& dbname, uint64_t number);
+std::string MetaDatabaseName(const std::string& dbname, uint64_t number);
 
 // Return the name of the Identity file which stores a unique number for the db
 // that will get regenerated if the db loses all its data and is recreated fresh
 // either from a backup-image or empty
-extern std::string IdentityFileName(const std::string& dbname);
+std::string IdentityFileName(const std::string& dbname);
 
 // If filename is a rocksdb file, store the type of the file in *type.
 // The number encoded in the filename is stored in *number.  If the
 // filename was successfully parsed, returns true.  Else return false.
 // info_log_name_prefix is the path of info logs.
-extern bool ParseFileName(const std::string& filename, uint64_t* number,
-                          const Slice& info_log_name_prefix, FileType* type,
-                          WalFileType* log_type = nullptr);
+bool ParseFileName(const std::string& filename, uint64_t* number,
+                   const Slice& info_log_name_prefix, FileType* type,
+                   WalFileType* log_type = nullptr);
 // Same as previous function, but skip info log files.
-extern bool ParseFileName(const std::string& filename, uint64_t* number,
-                          FileType* type, WalFileType* log_type = nullptr);
+bool ParseFileName(const std::string& filename, uint64_t* number,
+                   FileType* type, WalFileType* log_type = nullptr);
 
 // Make the CURRENT file point to the descriptor file with the
 // specified number. On its success and when dir_contains_current_file is not
 // nullptr, the function will fsync the directory containing the CURRENT file
 // when
-extern IOStatus SetCurrentFile(const WriteOptions& write_options,
-                               FileSystem* fs, const std::string& dbname,
-                               uint64_t descriptor_number,
-                               FSDirectory* dir_contains_current_file);
+IOStatus SetCurrentFile(const WriteOptions& write_options, FileSystem* fs,
+                        const std::string& dbname, uint64_t descriptor_number,
+                        FSDirectory* dir_contains_current_file);
 
 // Make the IDENTITY file for the db
-extern Status SetIdentityFile(const WriteOptions& write_options, Env* env,
-                              const std::string& dbname,
-                              const std::string& db_id = {});
+Status SetIdentityFile(const WriteOptions& write_options, Env* env,
+                       const std::string& dbname,
+                       const std::string& db_id = {});
 
 // Sync manifest file `file`.
-extern IOStatus SyncManifest(const ImmutableDBOptions* db_options,
-                             const WriteOptions& write_options,
-                             WritableFileWriter* file);
+IOStatus SyncManifest(const ImmutableDBOptions* db_options,
+                      const WriteOptions& write_options,
+                      WritableFileWriter* file);
 
 // Return list of file names of info logs in `file_names`.
 // The list only contains file name. The parent directory name is stored
 // in `parent_dir`.
 // `db_log_dir` should be the one as in options.db_log_dir
-extern Status GetInfoLogFiles(const std::shared_ptr<FileSystem>& fs,
-                              const std::string& db_log_dir,
-                              const std::string& dbname,
-                              std::string* parent_dir,
-                              std::vector<std::string>* file_names);
+Status GetInfoLogFiles(const std::shared_ptr<FileSystem>& fs,
+                       const std::string& db_log_dir, const std::string& dbname,
+                       std::string* parent_dir,
+                       std::vector<std::string>* file_names);
 
-extern std::string NormalizePath(const std::string& path);
+std::string NormalizePath(const std::string& path);
 }  // namespace ROCKSDB_NAMESPACE

--- a/file/read_write_util.h
+++ b/file/read_write_util.h
@@ -21,9 +21,9 @@ namespace ROCKSDB_NAMESPACE {
 // fname   : the file name.
 // result  : output arg. A WritableFile based on `fname` returned.
 // options : the Env Options.
-extern IOStatus NewWritableFile(FileSystem* fs, const std::string& fname,
-                                std::unique_ptr<FSWritableFile>* result,
-                                const FileOptions& options);
+IOStatus NewWritableFile(FileSystem* fs, const std::string& fname,
+                         std::unique_ptr<FSWritableFile>* result,
+                         const FileOptions& options);
 
 #ifndef NDEBUG
 bool IsFileSectorAligned(const size_t off, size_t sector_size);

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -497,7 +497,7 @@ struct HyperClockCacheOptions : public ShardedCacheOptions {
 // has been removed. The new HyperClockCache requires an additional
 // configuration parameter that is not provided by this API. This function
 // simply returns a new LRUCache for functional compatibility.
-extern std::shared_ptr<Cache> NewClockCache(
+std::shared_ptr<Cache> NewClockCache(
     size_t capacity, int num_shard_bits = -1,
     bool strict_capacity_limit = false,
     CacheMetadataChargePolicy metadata_charge_policy =
@@ -556,8 +556,7 @@ struct TieredCacheOptions {
   std::shared_ptr<SecondaryCache> nvm_sec_cache;
 };
 
-extern std::shared_ptr<Cache> NewTieredCache(
-    const TieredCacheOptions& cache_opts);
+std::shared_ptr<Cache> NewTieredCache(const TieredCacheOptions& cache_opts);
 
 // EXPERIMENTAL
 // Dynamically update some of the parameters of a TieredCache. The input
@@ -568,7 +567,7 @@ extern std::shared_ptr<Cache> NewTieredCache(
 // 2. Once the compressed secondary cache is disabled by setting the
 //    compressed_secondary_ratio to 0.0, it cannot be dynamically re-enabled
 //    again
-extern Status UpdateTieredCache(
+Status UpdateTieredCache(
     const std::shared_ptr<Cache>& cache, int64_t total_capacity = -1,
     double compressed_secondary_ratio = std::numeric_limits<double>::max(),
     TieredAdmissionPolicy adm_policy = TieredAdmissionPolicy::kAdmPolicyMax);

--- a/include/rocksdb/concurrent_task_limiter.h
+++ b/include/rocksdb/concurrent_task_limiter.h
@@ -45,7 +45,7 @@ class ConcurrentTaskLimiter {
 // @param limit: max concurrent tasks.
 //        limit = 0 means no new task allowed.
 //        limit < 0 means no limitation.
-extern ConcurrentTaskLimiter* NewConcurrentTaskLimiter(const std::string& name,
-                                                       int32_t limit);
+ConcurrentTaskLimiter* NewConcurrentTaskLimiter(const std::string& name,
+                                                int32_t limit);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -1302,63 +1302,60 @@ class DynamicLibrary {
   virtual Status LoadSymbol(const std::string& sym_name, void** func) = 0;
 };
 
-extern void LogFlush(const std::shared_ptr<Logger>& info_log);
+void LogFlush(const std::shared_ptr<Logger>& info_log);
 
-extern void Log(const InfoLogLevel log_level,
-                const std::shared_ptr<Logger>& info_log, const char* format,
-                ...) ROCKSDB_PRINTF_FORMAT_ATTR(3, 4);
+void Log(const InfoLogLevel log_level, const std::shared_ptr<Logger>& info_log,
+         const char* format, ...) ROCKSDB_PRINTF_FORMAT_ATTR(3, 4);
 
 // a set of log functions with different log levels.
-extern void Header(const std::shared_ptr<Logger>& info_log, const char* format,
-                   ...) ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Debug(const std::shared_ptr<Logger>& info_log, const char* format,
-                  ...) ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Info(const std::shared_ptr<Logger>& info_log, const char* format,
-                 ...) ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Warn(const std::shared_ptr<Logger>& info_log, const char* format,
-                 ...) ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Error(const std::shared_ptr<Logger>& info_log, const char* format,
-                  ...) ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Fatal(const std::shared_ptr<Logger>& info_log, const char* format,
-                  ...) ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
+void Header(const std::shared_ptr<Logger>& info_log, const char* format, ...)
+    ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
+void Debug(const std::shared_ptr<Logger>& info_log, const char* format, ...)
+    ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
+void Info(const std::shared_ptr<Logger>& info_log, const char* format, ...)
+    ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
+void Warn(const std::shared_ptr<Logger>& info_log, const char* format, ...)
+    ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
+void Error(const std::shared_ptr<Logger>& info_log, const char* format, ...)
+    ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
+void Fatal(const std::shared_ptr<Logger>& info_log, const char* format, ...)
+    ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
 
 // Log the specified data to *info_log if info_log is non-nullptr.
 // The default info log level is InfoLogLevel::INFO_LEVEL.
-extern void Log(const std::shared_ptr<Logger>& info_log, const char* format,
-                ...) ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
+void Log(const std::shared_ptr<Logger>& info_log, const char* format, ...)
+    ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
 
-extern void LogFlush(Logger* info_log);
+void LogFlush(Logger* info_log);
 
-extern void Log(const InfoLogLevel log_level, Logger* info_log,
-                const char* format, ...) ROCKSDB_PRINTF_FORMAT_ATTR(3, 4);
+void Log(const InfoLogLevel log_level, Logger* info_log, const char* format,
+         ...) ROCKSDB_PRINTF_FORMAT_ATTR(3, 4);
 
 // The default info log level is InfoLogLevel::INFO_LEVEL.
-extern void Log(Logger* info_log, const char* format, ...)
+void Log(Logger* info_log, const char* format, ...)
     ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
 
 // a set of log functions with different log levels.
-extern void Header(Logger* info_log, const char* format, ...)
+void Header(Logger* info_log, const char* format, ...)
     ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Debug(Logger* info_log, const char* format, ...)
+void Debug(Logger* info_log, const char* format, ...)
     ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Info(Logger* info_log, const char* format, ...)
+void Info(Logger* info_log, const char* format, ...)
     ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Warn(Logger* info_log, const char* format, ...)
+void Warn(Logger* info_log, const char* format, ...)
     ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Error(Logger* info_log, const char* format, ...)
+void Error(Logger* info_log, const char* format, ...)
     ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
-extern void Fatal(Logger* info_log, const char* format, ...)
+void Fatal(Logger* info_log, const char* format, ...)
     ROCKSDB_PRINTF_FORMAT_ATTR(2, 3);
 
 // A utility routine: write "data" to the named file.
-extern Status WriteStringToFile(Env* env, const Slice& data,
-                                const std::string& fname,
-                                bool should_sync = false,
-                                const IOOptions* io_options = nullptr);
+Status WriteStringToFile(Env* env, const Slice& data, const std::string& fname,
+                         bool should_sync = false,
+                         const IOOptions* io_options = nullptr);
 
 // A utility routine: read contents of named file into *data
-extern Status ReadFileToString(Env* env, const std::string& fname,
-                               std::string* data);
+Status ReadFileToString(Env* env, const std::string& fname, std::string* data);
 
 // Below are helpers for wrapping most of the classes in this file.
 // They forward all calls to another instance of the class.

--- a/include/rocksdb/file_checksum.h
+++ b/include/rocksdb/file_checksum.h
@@ -131,7 +131,7 @@ class FileChecksumList {
 };
 
 // Create a new file checksum list.
-extern FileChecksumList* NewFileChecksumList();
+FileChecksumList* NewFileChecksumList();
 
 // Return a shared_ptr of the builtin Crc32c based file checksum generator
 // factory object, which can be shared to create the Crc32c based checksum

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1916,13 +1916,12 @@ class FSDirectoryWrapper : public FSDirectory {
 };
 
 // A utility routine: write "data" to the named file.
-extern IOStatus WriteStringToFile(FileSystem* fs, const Slice& data,
-                                  const std::string& fname,
-                                  bool should_sync = false,
-                                  const IOOptions& io_options = IOOptions());
+IOStatus WriteStringToFile(FileSystem* fs, const Slice& data,
+                           const std::string& fname, bool should_sync = false,
+                           const IOOptions& io_options = IOOptions());
 
 // A utility routine: read contents of named file into *data
-extern IOStatus ReadFileToString(FileSystem* fs, const std::string& fname,
-                                 std::string* data);
+IOStatus ReadFileToString(FileSystem* fs, const std::string& fname,
+                          std::string* data);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -155,9 +155,9 @@ class Iterator : public Cleanable {
 };
 
 // Return an empty iterator (yields nothing).
-extern Iterator* NewEmptyIterator();
+Iterator* NewEmptyIterator();
 
 // Return an empty iterator with the specified status.
-extern Iterator* NewErrorIterator(const Status& status);
+Iterator* NewErrorIterator(const Status& status);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/memory_allocator.h
+++ b/include/rocksdb/memory_allocator.h
@@ -80,7 +80,7 @@ struct JemallocAllocatorOptions {
 // (thread-local cache) is enabled to cache unused allocations for future use.
 // The tcache normally incurs 0.5M extra memory usage per-thread. The usage
 // can be reduced by limiting allocation sizes to cache.
-extern Status NewJemallocNodumpAllocator(
+Status NewJemallocNodumpAllocator(
     const JemallocAllocatorOptions& options,
     std::shared_ptr<MemoryAllocator>* memory_allocator);
 

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -56,7 +56,7 @@ struct DBOptions;
 
 using KeyHandle = void*;
 
-extern Slice GetLengthPrefixedSlice(const char* data);
+Slice GetLengthPrefixedSlice(const char* data);
 
 class MemTableRep {
  public:
@@ -392,7 +392,7 @@ class VectorRepFactory : public MemTableRepFactory {
 // skiplist_height: the max height of the skiplist
 // skiplist_branching_factor: probabilistic size ratio between adjacent
 //                            link lists in the skiplist
-extern MemTableRepFactory* NewHashSkipListRepFactory(
+MemTableRepFactory* NewHashSkipListRepFactory(
     size_t bucket_count = 1000000, int32_t skiplist_height = 4,
     int32_t skiplist_branching_factor = 4);
 
@@ -412,7 +412,7 @@ extern MemTableRepFactory* NewHashSkipListRepFactory(
 //                                 entries when flushing.
 // @threshold_use_skiplist: a bucket switches to skip list if number of
 //                          entries exceed this parameter.
-extern MemTableRepFactory* NewHashLinkListRepFactory(
+MemTableRepFactory* NewHashLinkListRepFactory(
     size_t bucket_count = 50000, size_t huge_page_tlb_size = 0,
     int bucket_entries_logging_threshold = 4096,
     bool if_log_bucket_dist_when_flash = true,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1877,9 +1877,9 @@ struct FlushOptions {
 };
 
 // Create a Logger from provided DBOptions
-extern Status CreateLoggerFromOptions(const std::string& dbname,
-                                      const DBOptions& options,
-                                      std::shared_ptr<Logger>* logger);
+Status CreateLoggerFromOptions(const std::string& dbname,
+                               const DBOptions& options,
+                               std::shared_ptr<Logger>* logger);
 
 // CompactionOptions are used in CompactFiles() call.
 struct CompactionOptions {

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -159,7 +159,7 @@ class RateLimiter {
 // @auto_tuned: Enables dynamic adjustment of rate limit within the range
 //              `[rate_bytes_per_sec / 20, rate_bytes_per_sec]`, according to
 //              the recent demand for background I/O.
-extern RateLimiter* NewGenericRateLimiter(
+RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us = 100 * 1000,
     int32_t fairness = 10,
     RateLimiter::Mode mode = RateLimiter::Mode::kWritesOnly,

--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -123,13 +123,13 @@ class SliceTransform : public Customizable {
 
 // The prefix is the first `prefix_len` bytes of the key, and keys shorter
 // then `prefix_len` are not InDomain.
-extern const SliceTransform* NewFixedPrefixTransform(size_t prefix_len);
+const SliceTransform* NewFixedPrefixTransform(size_t prefix_len);
 
 // The prefix is the first min(length(key),`cap_len`) bytes of the key, and
 // all keys are InDomain.
-extern const SliceTransform* NewCappedPrefixTransform(size_t cap_len);
+const SliceTransform* NewCappedPrefixTransform(size_t cap_len);
 
 // Prefix is equal to key. All keys are InDomain.
-extern const SliceTransform* NewNoopTransform();
+const SliceTransform* NewNoopTransform();
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/sst_file_manager.h
+++ b/include/rocksdb/sst_file_manager.h
@@ -117,17 +117,19 @@ class SstFileManager {
 //    `rate_bytes_per_sec` will be appreciated. NOTE that with this option,
 //    files already renamed as a trash may be partial, so users should not
 //    directly recover them without checking.
-extern SstFileManager* NewSstFileManager(
-    Env* env, std::shared_ptr<FileSystem> fs,
-    std::shared_ptr<Logger> info_log = nullptr,
-    const std::string& trash_dir = "", int64_t rate_bytes_per_sec = 0,
-    bool delete_existing_trash = true, Status* status = nullptr,
-    double max_trash_db_ratio = 0.25,
-    uint64_t bytes_max_delete_chunk = 64 * 1024 * 1024);
+SstFileManager* NewSstFileManager(Env* env, std::shared_ptr<FileSystem> fs,
+                                  std::shared_ptr<Logger> info_log = nullptr,
+                                  const std::string& trash_dir = "",
+                                  int64_t rate_bytes_per_sec = 0,
+                                  bool delete_existing_trash = true,
+                                  Status* status = nullptr,
+                                  double max_trash_db_ratio = 0.25,
+                                  uint64_t bytes_max_delete_chunk = 64 * 1024 *
+                                                                    1024);
 
 // Same as above, but takes a pointer to a legacy Env object, instead of
 // Env and FileSystem objects
-extern SstFileManager* NewSstFileManager(
+SstFileManager* NewSstFileManager(
     Env* env, std::shared_ptr<Logger> info_log = nullptr,
     std::string trash_dir = "", int64_t rate_bytes_per_sec = 0,
     bool delete_existing_trash = true, Status* status = nullptr,

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -136,7 +136,7 @@ class SstPartitionerFixedPrefixFactory : public SstPartitionerFactory {
   size_t len_;
 };
 
-extern std::shared_ptr<SstPartitionerFactory>
-NewSstPartitionerFixedPrefixFactory(size_t prefix_len);
+std::shared_ptr<SstPartitionerFactory> NewSstPartitionerFixedPrefixFactory(
+    size_t prefix_len);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -674,9 +674,8 @@ struct BlockBasedTablePropertyNames {
 };
 
 // Create default block based table factory.
-extern TableFactory* NewBlockBasedTableFactory(
+TableFactory* NewBlockBasedTableFactory(
     const BlockBasedTableOptions& table_options = BlockBasedTableOptions());
-
 
 enum EncodingType : char {
   // Always write full keys without any special encoding.
@@ -763,7 +762,7 @@ struct PlainTableOptions {
 // the hash bucket found, a binary search is executed for hash conflicts.
 // Finally, a linear search is used.
 
-extern TableFactory* NewPlainTableFactory(
+TableFactory* NewPlainTableFactory(
     const PlainTableOptions& options = PlainTableOptions());
 
 struct CuckooTablePropertyNames {
@@ -830,9 +829,8 @@ struct CuckooTableOptions {
 };
 
 // Cuckoo Table Factory for SST table format using Cache Friendly Cuckoo Hashing
-extern TableFactory* NewCuckooTableFactory(
+TableFactory* NewCuckooTableFactory(
     const CuckooTableOptions& table_options = CuckooTableOptions());
-
 
 class RandomAccessFileReader;
 
@@ -923,11 +921,10 @@ class TableFactory : public Customizable {
 // @plain_table_factory: plain table factory to use. If NULL, use a default one.
 // @cuckoo_table_factory: cuckoo table factory to use. If NULL, use a default
 // one.
-extern TableFactory* NewAdaptiveTableFactory(
+TableFactory* NewAdaptiveTableFactory(
     std::shared_ptr<TableFactory> table_factory_to_write = nullptr,
     std::shared_ptr<TableFactory> block_based_table_factory = nullptr,
     std::shared_ptr<TableFactory> plain_table_factory = nullptr,
     std::shared_ptr<TableFactory> cuckoo_table_factory = nullptr);
-
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -349,8 +349,8 @@ struct TableProperties {
 // DEPRECATED: these properties now belong as TableProperties members. Please
 // use TableProperties::num_deletions and TableProperties::num_merge_operands,
 // respectively.
-extern uint64_t GetDeletedKeys(const UserCollectedProperties& props);
-extern uint64_t GetMergeOperands(const UserCollectedProperties& props,
-                                 bool* property_present);
+uint64_t GetDeletedKeys(const UserCollectedProperties& props);
+uint64_t GetMergeOperands(const UserCollectedProperties& props,
+                          bool* property_present);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/threadpool.h
+++ b/include/rocksdb/threadpool.h
@@ -62,6 +62,6 @@ class ThreadPool {
 
 // NewThreadPool() is a function that could be used to create a ThreadPool
 // with `num_threads` background threads.
-extern ThreadPool* NewThreadPool(int num_threads);
+ThreadPool* NewThreadPool(int num_threads);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/utilities/sim_cache.h
+++ b/include/rocksdb/utilities/sim_cache.h
@@ -34,13 +34,12 @@ class SimCache;
 // BlockBasedTableOptions.block_size = 4096 by default but is configurable,
 // Therefore, generally the actual memory overhead of SimCache is Less than
 // sim_capacity * 2%
-extern std::shared_ptr<SimCache> NewSimCache(std::shared_ptr<Cache> cache,
-                                             size_t sim_capacity,
-                                             int num_shard_bits);
+std::shared_ptr<SimCache> NewSimCache(std::shared_ptr<Cache> cache,
+                                      size_t sim_capacity, int num_shard_bits);
 
-extern std::shared_ptr<SimCache> NewSimCache(std::shared_ptr<Cache> sim_cache,
-                                             std::shared_ptr<Cache> cache,
-                                             int num_shard_bits);
+std::shared_ptr<SimCache> NewSimCache(std::shared_ptr<Cache> sim_cache,
+                                      std::shared_ptr<Cache> cache,
+                                      int num_shard_bits);
 
 // An abstract base class (public interface) to the SimCache implementation
 class SimCache : public CacheWrapper {

--- a/include/rocksdb/utilities/table_properties_collectors.h
+++ b/include/rocksdb/utilities/table_properties_collectors.h
@@ -80,9 +80,8 @@ class CompactOnDeletionCollectorFactory
 //     the specified number for "D" will not be changed.
 // @param deletion_ratio, if <= 0 or > 1, disable triggering compaction
 //     based on deletion ratio. Disabled by default.
-extern std::shared_ptr<CompactOnDeletionCollectorFactory>
+std::shared_ptr<CompactOnDeletionCollectorFactory>
 NewCompactOnDeletionCollectorFactory(size_t sliding_window_size,
                                      size_t deletion_trigger,
                                      double deletion_ratio = 0);
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/logging/log_buffer.h
+++ b/logging/log_buffer.h
@@ -49,9 +49,9 @@ class LogBuffer {
 // Add log to the LogBuffer for a delayed info logging. It can be used when
 // we want to add some logs inside a mutex.
 // max_log_size indicates maximize log size, including some metadata.
-extern void LogToBuffer(LogBuffer* log_buffer, size_t max_log_size,
-                        const char* format, ...);
+void LogToBuffer(LogBuffer* log_buffer, size_t max_log_size, const char* format,
+                 ...);
 // Same as previous function, but with default max log size.
-extern void LogToBuffer(LogBuffer* log_buffer, const char* format, ...);
+void LogToBuffer(LogBuffer* log_buffer, const char* format, ...);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/monitoring/file_read_sample.h
+++ b/monitoring/file_read_sample.h
@@ -9,8 +9,8 @@
 
 namespace ROCKSDB_NAMESPACE {
 static const uint32_t kFileReadSampleRate = 1024;
-extern bool should_sample_file_read();
-extern void sample_file_read_inc(FileMetaData*);
+bool should_sample_file_read();
+void sample_file_read_inc(FileMetaData*);
 
 inline bool should_sample_file_read() {
   return (Random::GetTLSInstance()->Next() % kFileReadSampleRate == 307);

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -65,9 +65,8 @@ std::unique_ptr<Configurable> CFOptionsAsConfigurable(
     const ColumnFamilyOptions& opts,
     const std::unordered_map<std::string, std::string>* opt_map = nullptr);
 
-extern Status StringToMap(
-    const std::string& opts_str,
-    std::unordered_map<std::string, std::string>* opts_map);
+Status StringToMap(const std::string& opts_str,
+                   std::unordered_map<std::string, std::string>* opts_map);
 
 struct OptionsHelper {
   static const std::string kCFOptionsName /*= "ColumnFamilyOptions"*/;

--- a/port/port_example.h
+++ b/port/port_example.h
@@ -72,20 +72,20 @@ class CondVar {
 //      port::InitOnce(&init_control, &Initializer);
 using OnceType = intptr_t;
 #define LEVELDB_ONCE_INIT 0
-extern void InitOnce(port::OnceType*, void (*initializer)());
+void InitOnce(port::OnceType*, void (*initializer)());
 
 // ------------------ Compression -------------------
 
 // Store the snappy compression of "input[0,input_length-1]" in *output.
 // Returns false if snappy is not supported by this port.
-extern bool Snappy_Compress(const char* input, size_t input_length,
-                            std::string* output);
+bool Snappy_Compress(const char* input, size_t input_length,
+                     std::string* output);
 
 // If input[0,input_length-1] looks like a valid snappy compressed
 // buffer, store the size of the uncompressed data in *result and
 // return true.  Else return false.
-extern bool Snappy_GetUncompressedLength(const char* input, size_t length,
-                                         size_t* result);
+bool Snappy_GetUncompressedLength(const char* input, size_t length,
+                                  size_t* result);
 
 // Attempt to snappy uncompress input[0,input_length-1] into *output.
 // Returns true if successful, false if the input is invalid lightweight
@@ -94,8 +94,8 @@ extern bool Snappy_GetUncompressedLength(const char* input, size_t length,
 // REQUIRES: at least the first "n" bytes of output[] must be writable
 // where "n" is the result of a successful call to
 // Snappy_GetUncompressedLength.
-extern bool Snappy_Uncompress(const char* input_data, size_t input_length,
-                              char* output);
+bool Snappy_Uncompress(const char* input_data, size_t input_length,
+                       char* output);
 
 }  // namespace port
 }  // namespace ROCKSDB_NAMESPACE

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -41,9 +41,9 @@ namespace ROCKSDB_NAMESPACE {
 // build environment then this happens automatically; otherwise it's up to the
 // consumer to define the identifier.
 #ifdef ROCKSDB_DEFAULT_TO_ADAPTIVE_MUTEX
-extern const bool kDefaultToAdaptiveMutex = true;
+const bool kDefaultToAdaptiveMutex = true;
 #else
-extern const bool kDefaultToAdaptiveMutex = false;
+const bool kDefaultToAdaptiveMutex = false;
 #endif
 
 namespace port {

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -179,11 +179,11 @@ static inline void AsmVolatilePause() {
 }
 
 // Returns -1 if not available on this platform
-extern int PhysicalCoreID();
+int PhysicalCoreID();
 
 using OnceType = pthread_once_t;
 #define LEVELDB_ONCE_INIT PTHREAD_ONCE_INIT
-extern void InitOnce(OnceType* once, void (*initializer)());
+void InitOnce(OnceType* once, void (*initializer)());
 
 #ifndef CACHE_LINE_SIZE
 // To test behavior with non-native cache line size, e.g. for
@@ -211,9 +211,9 @@ extern void InitOnce(OnceType* once, void (*initializer)());
 static_assert((CACHE_LINE_SIZE & (CACHE_LINE_SIZE - 1)) == 0,
               "Cache line size must be a power of 2 number of bytes");
 
-extern void* cacheline_aligned_alloc(size_t size);
+void* cacheline_aligned_alloc(size_t size);
 
-extern void cacheline_aligned_free(void* memblock);
+void cacheline_aligned_free(void* memblock);
 
 #if defined(__aarch64__)
 //  __builtin_prefetch(..., 1) turns into a prefetch into prfm pldl3keep. On
@@ -226,15 +226,15 @@ extern void cacheline_aligned_free(void* memblock);
 #define PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)
 #endif
 
-extern void Crash(const std::string& srcfile, int srcline);
+void Crash(const std::string& srcfile, int srcline);
 
-extern int GetMaxOpenFiles();
+int GetMaxOpenFiles();
 
 extern const size_t kPageSize;
 
 using ThreadId = pid_t;
 
-extern void SetCpuPriority(ThreadId id, CpuPriority priority);
+void SetCpuPriority(ThreadId id, CpuPriority priority);
 
 int64_t GetProcessID();
 

--- a/port/win/port_win.cc
+++ b/port/win/port_win.cc
@@ -36,7 +36,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-extern const bool kDefaultToAdaptiveMutex = false;
+const bool kDefaultToAdaptiveMutex = false;
 
 namespace port {
 

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -213,7 +213,7 @@ struct OnceType {
 };
 
 #define LEVELDB_ONCE_INIT port::OnceType::Init()
-extern void InitOnce(OnceType* once, void (*initializer)());
+void InitOnce(OnceType* once, void (*initializer)());
 
 #ifndef CACHE_LINE_SIZE
 #define CACHE_LINE_SIZE 64U
@@ -253,7 +253,7 @@ static inline void AsmVolatilePause() {
   // it would be nice to get "wfe" on ARM here
 }
 
-extern int PhysicalCoreID();
+int PhysicalCoreID();
 
 // For Thread Local Storage abstraction
 using pthread_key_t = DWORD;
@@ -303,13 +303,13 @@ inline void* pthread_getspecific(pthread_key_t key) {
 int truncate(const char* path, int64_t length);
 int Truncate(std::string path, int64_t length);
 void Crash(const std::string& srcfile, int srcline);
-extern int GetMaxOpenFiles();
+int GetMaxOpenFiles();
 std::string utf16_to_utf8(const std::wstring& utf16);
 std::wstring utf8_to_utf16(const std::string& utf8);
 
 using ThreadId = int;
 
-extern void SetCpuPriority(ThreadId id, CpuPriority priority);
+void SetCpuPriority(ThreadId id, CpuPriority priority);
 
 int64_t GetProcessID();
 

--- a/table/adaptive/adaptive_table_factory.cc
+++ b/table/adaptive/adaptive_table_factory.cc
@@ -34,12 +34,6 @@ AdaptiveTableFactory::AdaptiveTableFactory(
   }
 }
 
-extern const uint64_t kPlainTableMagicNumber;
-extern const uint64_t kLegacyPlainTableMagicNumber;
-extern const uint64_t kBlockBasedTableMagicNumber;
-extern const uint64_t kLegacyBlockBasedTableMagicNumber;
-extern const uint64_t kCuckooTableMagicNumber;
-
 Status AdaptiveTableFactory::NewTableReader(
     const ReadOptions& ro, const TableReaderOptions& table_reader_options,
     std::unique_ptr<RandomAccessFileReader>&& file, uint64_t file_size,
@@ -112,7 +106,7 @@ std::string AdaptiveTableFactory::GetPrintableOptions() const {
   return ret;
 }
 
-extern TableFactory* NewAdaptiveTableFactory(
+TableFactory* NewAdaptiveTableFactory(
     std::shared_ptr<TableFactory> table_factory_to_write,
     std::shared_ptr<TableFactory> block_based_table_factory,
     std::shared_ptr<TableFactory> plain_table_factory,

--- a/table/block_based/reader_common.h
+++ b/table/block_based/reader_common.h
@@ -15,7 +15,7 @@ namespace ROCKSDB_NAMESPACE {
 class Footer;
 
 // Release the cached entry and decrement its ref count.
-extern void ForceReleaseCachedEntry(void* arg, void* h);
+void ForceReleaseCachedEntry(void* arg, void* h);
 
 inline MemoryAllocator* GetMemoryAllocator(
     const BlockBasedTableOptions& table_options) {
@@ -30,8 +30,7 @@ inline MemoryAllocator* GetMemoryAllocator(
 //
 // Returns Status::OK() on checksum match, or Status::Corruption() on checksum
 // mismatch.
-extern Status VerifyBlockChecksum(const Footer& footer, const char* data,
-                                  size_t block_size,
-                                  const std::string& file_name,
-                                  uint64_t offset);
+Status VerifyBlockChecksum(const Footer& footer, const char* data,
+                           size_t block_size, const std::string& file_name,
+                           uint64_t offset);
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/cuckoo/cuckoo_table_builder.cc
+++ b/table/cuckoo/cuckoo_table_builder.cc
@@ -44,7 +44,7 @@ const std::string CuckooTablePropertyNames::kUserKeyLength =
     "rocksdb.cuckoo.hash.userkeylength";
 
 // Obtained by running echo rocksdb.table.cuckoo | sha1sum
-extern const uint64_t kCuckooTableMagicNumber = 0x926789d0c5f17873ull;
+const uint64_t kCuckooTableMagicNumber = 0x926789d0c5f17873ull;
 
 CuckooTableBuilder::CuckooTableBuilder(
     WritableFileWriter* file, double max_hash_table_ratio,

--- a/table/format.cc
+++ b/table/format.cc
@@ -38,11 +38,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-extern const uint64_t kLegacyBlockBasedTableMagicNumber;
-extern const uint64_t kBlockBasedTableMagicNumber;
-
-extern const uint64_t kLegacyPlainTableMagicNumber;
-extern const uint64_t kPlainTableMagicNumber;
 const char* kHostnameForDbHostId = "__hostname__";
 
 bool ShouldReportDetailedTime(Env* env, Statistics* stats) {

--- a/table/format.h
+++ b/table/format.h
@@ -34,6 +34,14 @@ bool ShouldReportDetailedTime(Env* env, Statistics* stats);
 // the length of the magic number in bytes.
 constexpr uint32_t kMagicNumberLengthByte = 8;
 
+extern const uint64_t kLegacyBlockBasedTableMagicNumber;
+extern const uint64_t kBlockBasedTableMagicNumber;
+
+extern const uint64_t kLegacyPlainTableMagicNumber;
+extern const uint64_t kPlainTableMagicNumber;
+
+extern const uint64_t kCuckooTableMagicNumber;
+
 // BlockHandle is a pointer to the extent of a file that stores a data
 // block or a meta block.
 class BlockHandle {

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -220,16 +220,15 @@ using InternalIterator = InternalIteratorBase<Slice>;
 
 // Return an empty iterator (yields nothing).
 template <class TValue = Slice>
-extern InternalIteratorBase<TValue>* NewEmptyInternalIterator();
+InternalIteratorBase<TValue>* NewEmptyInternalIterator();
 
 // Return an empty iterator with the specified status.
 template <class TValue = Slice>
-extern InternalIteratorBase<TValue>* NewErrorInternalIterator(
-    const Status& status);
+InternalIteratorBase<TValue>* NewErrorInternalIterator(const Status& status);
 
 // Return an empty iterator with the specified status, allocated arena.
 template <class TValue = Slice>
-extern InternalIteratorBase<TValue>* NewErrorInternalIterator(
-    const Status& status, Arena* arena);
+InternalIteratorBase<TValue>* NewErrorInternalIterator(const Status& status,
+                                                       Arena* arena);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -214,6 +214,6 @@ using IteratorWrapper = IteratorWrapperBase<Slice>;
 class Arena;
 // Return an empty iterator (yields nothing) allocated from arena.
 template <class TValue = Slice>
-extern InternalIteratorBase<TValue>* NewEmptyInternalIterator(Arena* arena);
+InternalIteratorBase<TValue>* NewEmptyInternalIterator(Arena* arena);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/merging_iterator.h
+++ b/table/merging_iterator.h
@@ -32,9 +32,10 @@ using InternalIterator = InternalIteratorBase<Slice>;
 // key is present in K child iterators, it will be yielded K times.
 //
 // REQUIRES: n >= 0
-extern InternalIterator* NewMergingIterator(
-    const InternalKeyComparator* comparator, InternalIterator** children, int n,
-    Arena* arena = nullptr, bool prefix_seek_mode = false);
+InternalIterator* NewMergingIterator(const InternalKeyComparator* comparator,
+                                     InternalIterator** children, int n,
+                                     Arena* arena = nullptr,
+                                     bool prefix_seek_mode = false);
 
 // The iterator returned by NewMergingIterator() and
 // MergeIteratorBuilder::Finish(). MergingIterator handles the merging of data

--- a/table/plain/plain_table_builder.cc
+++ b/table/plain/plain_table_builder.cc
@@ -52,8 +52,8 @@ IOStatus WriteBlock(const Slice& block_contents, WritableFileWriter* file,
 // kPlainTableMagicNumber was picked by running
 //    echo rocksdb.table.plain | sha1sum
 // and taking the leading 64 bits.
-extern const uint64_t kPlainTableMagicNumber = 0x8242229663bf9564ull;
-extern const uint64_t kLegacyPlainTableMagicNumber = 0x4f3418eb7a8f13b8ull;
+const uint64_t kPlainTableMagicNumber = 0x8242229663bf9564ull;
+const uint64_t kLegacyPlainTableMagicNumber = 0x4f3418eb7a8f13b8ull;
 
 PlainTableBuilder::PlainTableBuilder(
     const ImmutableOptions& ioptions, const MutableCFOptions& moptions,

--- a/table/plain/plain_table_factory.cc
+++ b/table/plain/plain_table_factory.cc
@@ -279,7 +279,7 @@ Status GetPlainTableOptionsFromMap(
   return s;
 }
 
-extern TableFactory* NewPlainTableFactory(const PlainTableOptions& options) {
+TableFactory* NewPlainTableFactory(const PlainTableOptions& options) {
   return new PlainTableFactory(options);
 }
 

--- a/table/plain/plain_table_reader.cc
+++ b/table/plain/plain_table_reader.cc
@@ -87,7 +87,6 @@ class PlainTableIterator : public InternalIterator {
   Status status_;
 };
 
-extern const uint64_t kPlainTableMagicNumber;
 PlainTableReader::PlainTableReader(
     const ImmutableOptions& ioptions,
     std::unique_ptr<RandomAccessFileReader>&& file,

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -68,12 +68,6 @@ SstFileDumper::SstFileDumper(const Options& options,
   init_result_ = GetTableReader(file_name_);
 }
 
-extern const uint64_t kBlockBasedTableMagicNumber;
-extern const uint64_t kLegacyBlockBasedTableMagicNumber;
-extern const uint64_t kPlainTableMagicNumber;
-extern const uint64_t kLegacyPlainTableMagicNumber;
-extern const uint64_t kCuckooTableMagicNumber;
-
 const char* testFileName = "test_file_name";
 
 Status SstFileDumper::GetTableReader(const std::string& file_path) {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -79,11 +79,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-extern const uint64_t kLegacyBlockBasedTableMagicNumber;
-extern const uint64_t kLegacyPlainTableMagicNumber;
-extern const uint64_t kBlockBasedTableMagicNumber;
-extern const uint64_t kPlainTableMagicNumber;
-
 namespace {
 
 const std::string kDummyValue(10000, 'o');

--- a/table/two_level_iterator.h
+++ b/table/two_level_iterator.h
@@ -36,7 +36,7 @@ struct TwoLevelIteratorState {
 // Uses a supplied function to convert an index_iter value into
 // an iterator over the contents of the corresponding block.
 // Note: this function expects first_level_iter was not created using the arena
-extern InternalIteratorBase<IndexValue>* NewTwoLevelIterator(
+InternalIteratorBase<IndexValue>* NewTwoLevelIterator(
     TwoLevelIteratorState* state,
     InternalIteratorBase<IndexValue>* first_level_iter);
 

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -91,8 +91,8 @@ bool ShouldPersistUDT(const UserDefinedTimestampTestMode& test_mode) {
   return test_mode != UserDefinedTimestampTestMode::kStripUserDefinedTimestamp;
 }
 
-extern Slice CompressibleString(Random* rnd, double compressed_fraction,
-                                int len, std::string* dst) {
+Slice CompressibleString(Random* rnd, double compressed_fraction, int len,
+                         std::string* dst) {
   int raw = static_cast<int>(len * compressed_fraction);
   if (raw < 1) {
     raw = 1;

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -49,8 +49,8 @@ extern const std::set<uint32_t> kFooterFormatVersionsToTest;
 // Return a random key with the specified length that may contain interesting
 // characters (e.g. \x00, \xff, etc.).
 enum RandomKeyType : char { RANDOM, LARGEST, SMALLEST, MIDDLE };
-extern std::string RandomKey(Random* rnd, int len,
-                             RandomKeyType type = RandomKeyType::RANDOM);
+std::string RandomKey(Random* rnd, int len,
+                      RandomKeyType type = RandomKeyType::RANDOM);
 
 enum class UserDefinedTimestampTestMode {
   // Test does not enable user-defined timestamp feature.
@@ -62,17 +62,17 @@ enum class UserDefinedTimestampTestMode {
   kStripUserDefinedTimestamp,
 };
 
-extern const std::vector<UserDefinedTimestampTestMode>& GetUDTTestModes();
+const std::vector<UserDefinedTimestampTestMode>& GetUDTTestModes();
 
-extern bool IsUDTEnabled(const UserDefinedTimestampTestMode& test_mode);
+bool IsUDTEnabled(const UserDefinedTimestampTestMode& test_mode);
 
-extern bool ShouldPersistUDT(const UserDefinedTimestampTestMode& test_mode);
+bool ShouldPersistUDT(const UserDefinedTimestampTestMode& test_mode);
 
 // Store in *dst a string of length "len" that will compress to
 // "N*compressed_fraction" bytes and return a Slice that references
 // the generated data.
-extern Slice CompressibleString(Random* rnd, double compressed_fraction,
-                                int len, std::string* dst);
+Slice CompressibleString(Random* rnd, double compressed_fraction, int len,
+                         std::string* dst);
 
 #ifndef NDEBUG
 // An internal comparator that just forward comparing results from the
@@ -127,13 +127,13 @@ class SimpleSuffixReverseComparator : public Comparator {
 // at once. Assumes same endian-ness is used though the database's lifetime.
 // Symantics of comparison would differ from Bytewise comparator in little
 // endian machines.
-extern const Comparator* Uint64Comparator();
+const Comparator* Uint64Comparator();
 
 // A wrapper api for getting the ComparatorWithU64Ts<BytewiseComparator>
-extern const Comparator* BytewiseComparatorWithU64TsWrapper();
+const Comparator* BytewiseComparatorWithU64TsWrapper();
 
 // A wrapper api for getting the ComparatorWithU64Ts<ReverseBytewiseComparator>
-extern const Comparator* ReverseBytewiseComparatorWithU64TsWrapper();
+const Comparator* ReverseBytewiseComparatorWithU64TsWrapper();
 
 class StringSink : public FSWritableFile {
  public:
@@ -364,15 +364,14 @@ class NullLogger : public Logger {
 };
 
 // Corrupts key by changing the type
-extern void CorruptKeyType(InternalKey* ikey);
+void CorruptKeyType(InternalKey* ikey);
 
-extern std::string KeyStr(const std::string& user_key,
-                          const SequenceNumber& seq, const ValueType& t,
-                          bool corrupt = false);
+std::string KeyStr(const std::string& user_key, const SequenceNumber& seq,
+                   const ValueType& t, bool corrupt = false);
 
-extern std::string KeyStr(uint64_t ts, const std::string& user_key,
-                          const SequenceNumber& seq, const ValueType& t,
-                          bool corrupt = false);
+std::string KeyStr(uint64_t ts, const std::string& user_key,
+                   const SequenceNumber& seq, const ValueType& t,
+                   bool corrupt = false);
 
 class SleepingBackgroundTask {
  public:
@@ -831,7 +830,7 @@ class ChanglingCompactionFilterFactory : public CompactionFilterFactory {
 
 // The factory for the hacky skip list mem table that triggers flush after
 // number of entries exceeds a threshold.
-extern MemTableRepFactory* NewSpecialSkipListFactory(int num_entries_per_flush);
+MemTableRepFactory* NewSpecialSkipListFactory(int num_entries_per_flush);
 
 CompressionType RandomCompressionType(Random* rnd);
 

--- a/util/coding.h
+++ b/util/coding.h
@@ -34,40 +34,38 @@ namespace ROCKSDB_NAMESPACE {
 const uint32_t kMaxVarint64Length = 10;
 
 // Standard Put... routines append to a string
-extern void PutFixed16(std::string* dst, uint16_t value);
-extern void PutFixed32(std::string* dst, uint32_t value);
-extern void PutFixed64(std::string* dst, uint64_t value);
-extern void PutVarint32(std::string* dst, uint32_t value);
-extern void PutVarint32Varint32(std::string* dst, uint32_t value1,
-                                uint32_t value2);
-extern void PutVarint32Varint32Varint32(std::string* dst, uint32_t value1,
-                                        uint32_t value2, uint32_t value3);
-extern void PutVarint64(std::string* dst, uint64_t value);
-extern void PutVarint64Varint64(std::string* dst, uint64_t value1,
-                                uint64_t value2);
-extern void PutVarint32Varint64(std::string* dst, uint32_t value1,
-                                uint64_t value2);
-extern void PutVarint32Varint32Varint64(std::string* dst, uint32_t value1,
-                                        uint32_t value2, uint64_t value3);
-extern void PutLengthPrefixedSlice(std::string* dst, const Slice& value);
-extern void PutLengthPrefixedSliceParts(std::string* dst,
-                                        const SliceParts& slice_parts);
-extern void PutLengthPrefixedSlicePartsWithPadding(
-    std::string* dst, const SliceParts& slice_parts, size_t pad_sz);
+void PutFixed16(std::string* dst, uint16_t value);
+void PutFixed32(std::string* dst, uint32_t value);
+void PutFixed64(std::string* dst, uint64_t value);
+void PutVarint32(std::string* dst, uint32_t value);
+void PutVarint32Varint32(std::string* dst, uint32_t value1, uint32_t value2);
+void PutVarint32Varint32Varint32(std::string* dst, uint32_t value1,
+                                 uint32_t value2, uint32_t value3);
+void PutVarint64(std::string* dst, uint64_t value);
+void PutVarint64Varint64(std::string* dst, uint64_t value1, uint64_t value2);
+void PutVarint32Varint64(std::string* dst, uint32_t value1, uint64_t value2);
+void PutVarint32Varint32Varint64(std::string* dst, uint32_t value1,
+                                 uint32_t value2, uint64_t value3);
+void PutLengthPrefixedSlice(std::string* dst, const Slice& value);
+void PutLengthPrefixedSliceParts(std::string* dst,
+                                 const SliceParts& slice_parts);
+void PutLengthPrefixedSlicePartsWithPadding(std::string* dst,
+                                            const SliceParts& slice_parts,
+                                            size_t pad_sz);
 
 // Standard Get... routines parse a value from the beginning of a Slice
 // and advance the slice past the parsed value.
-extern bool GetFixed64(Slice* input, uint64_t* value);
-extern bool GetFixed32(Slice* input, uint32_t* value);
-extern bool GetFixed16(Slice* input, uint16_t* value);
-extern bool GetVarint32(Slice* input, uint32_t* value);
-extern bool GetVarint64(Slice* input, uint64_t* value);
-extern bool GetVarsignedint64(Slice* input, int64_t* value);
-extern bool GetLengthPrefixedSlice(Slice* input, Slice* result);
+bool GetFixed64(Slice* input, uint64_t* value);
+bool GetFixed32(Slice* input, uint32_t* value);
+bool GetFixed16(Slice* input, uint16_t* value);
+bool GetVarint32(Slice* input, uint32_t* value);
+bool GetVarint64(Slice* input, uint64_t* value);
+bool GetVarsignedint64(Slice* input, int64_t* value);
+bool GetLengthPrefixedSlice(Slice* input, Slice* result);
 // This function assumes data is well-formed.
-extern Slice GetLengthPrefixedSlice(const char* data);
+Slice GetLengthPrefixedSlice(const char* data);
 
-extern Slice GetSliceUntil(Slice* slice, char delimiter);
+Slice GetSliceUntil(Slice* slice, char delimiter);
 
 // Borrowed from
 // https://github.com/facebook/fbthrift/blob/449a5f77f9f9bae72c9eb5e78093247eef185c04/thrift/lib/cpp/util/VarintUtils-inl.h#L202-L208
@@ -82,10 +80,8 @@ inline int64_t zigzagToI64(uint64_t n) {
 // in *v and return a pointer just past the parsed value, or return
 // nullptr on error.  These routines only look at bytes in the range
 // [p..limit-1]
-extern const char* GetVarint32Ptr(const char* p, const char* limit,
-                                  uint32_t* v);
-extern const char* GetVarint64Ptr(const char* p, const char* limit,
-                                  uint64_t* v);
+const char* GetVarint32Ptr(const char* p, const char* limit, uint32_t* v);
+const char* GetVarint64Ptr(const char* p, const char* limit, uint64_t* v);
 inline const char* GetVarsignedint64Ptr(const char* p, const char* limit,
                                         int64_t* value) {
   uint64_t u = 0;
@@ -95,17 +91,17 @@ inline const char* GetVarsignedint64Ptr(const char* p, const char* limit,
 }
 
 // Returns the length of the varint32 or varint64 encoding of "v"
-extern int VarintLength(uint64_t v);
+int VarintLength(uint64_t v);
 
 // Lower-level versions of Put... that write directly into a character buffer
 // and return a pointer just past the last byte written.
 // REQUIRES: dst has enough space for the value being written
-extern char* EncodeVarint32(char* dst, uint32_t value);
-extern char* EncodeVarint64(char* dst, uint64_t value);
+char* EncodeVarint32(char* dst, uint32_t value);
+char* EncodeVarint64(char* dst, uint64_t value);
 
 // Internal routine for use by fallback path of GetVarint32Ptr
-extern const char* GetVarint32PtrFallback(const char* p, const char* limit,
-                                          uint32_t* value);
+const char* GetVarint32PtrFallback(const char* p, const char* limit,
+                                   uint32_t* value);
 inline const char* GetVarint32Ptr(const char* p, const char* limit,
                                   uint32_t* value) {
   if (p < limit) {

--- a/util/crc32c.h
+++ b/util/crc32c.h
@@ -18,18 +18,18 @@
 namespace ROCKSDB_NAMESPACE {
 namespace crc32c {
 
-extern std::string IsFastCrc32Supported();
+std::string IsFastCrc32Supported();
 
 // Return the crc32c of concat(A, data[0,n-1]) where init_crc is the
 // crc32c of some string A.  Extend() is often used to maintain the
 // crc32c of a stream of data.
-extern uint32_t Extend(uint32_t init_crc, const char* data, size_t n);
+uint32_t Extend(uint32_t init_crc, const char* data, size_t n);
 
 // Takes two unmasked crc32c values, and the length of the string from
 // which `crc2` was computed, and computes a crc32c value for the
 // concatenation of the original two input strings. Running time is
 // ~ log(crc2len).
-extern uint32_t Crc32cCombine(uint32_t crc1, uint32_t crc2, size_t crc2len);
+uint32_t Crc32cCombine(uint32_t crc1, uint32_t crc2, size_t crc2len);
 
 // Return the crc32c of data[0,n-1]
 inline uint32_t Value(const char* data, size_t n) { return Extend(0, data, n); }

--- a/util/crc32c_arm64.h
+++ b/util/crc32c_arm64.h
@@ -36,10 +36,9 @@
   PREF4X64L1(buffer, (PREF_OFFSET), 8) \
   PREF4X64L1(buffer, (PREF_OFFSET), 12)
 
-extern uint32_t crc32c_arm64(uint32_t crc, unsigned char const *data,
-                             size_t len);
-extern uint32_t crc32c_runtime_check(void);
-extern bool crc32c_pmull_runtime_check(void);
+uint32_t crc32c_arm64(uint32_t crc, unsigned char const *data, size_t len);
+uint32_t crc32c_runtime_check(void);
+bool crc32c_pmull_runtime_check(void);
 
 #ifdef __ARM_FEATURE_CRYPTO
 #define HAVE_ARM64_CRYPTO

--- a/util/crc32c_ppc.h
+++ b/util/crc32c_ppc.h
@@ -14,8 +14,7 @@
 extern "C" {
 #endif
 
-extern uint32_t crc32c_ppc(uint32_t crc, unsigned char const *buffer,
-                           size_t len);
+uint32_t crc32c_ppc(uint32_t crc, unsigned char const *buffer, size_t len);
 
 #ifdef __cplusplus
 }

--- a/util/hash.h
+++ b/util/hash.h
@@ -31,10 +31,10 @@ namespace ROCKSDB_NAMESPACE {
 // Hash(), especially for inputs > 24 bytes.
 // KNOWN FLAW: incrementing seed by 1 might not give sufficiently independent
 // results from previous seed. Recommend incrementing by a large odd number.
-extern uint64_t Hash64(const char* data, size_t n, uint64_t seed);
+uint64_t Hash64(const char* data, size_t n, uint64_t seed);
 
 // Specific optimization without seed (same as seed = 0)
-extern uint64_t Hash64(const char* data, size_t n);
+uint64_t Hash64(const char* data, size_t n);
 
 // Non-persistent hash. Must only used for in-memory data structures.
 // The hash results are thus subject to change between releases,
@@ -87,7 +87,7 @@ void BijectiveUnhash2x64(uint64_t in_high64, uint64_t in_low64, uint64_t seed,
 // TODO: consider rename to Hash32
 // KNOWN FLAW: incrementing seed by 1 might not give sufficiently independent
 // results from previous seed. Recommend pseudorandom or hashed seeds.
-extern uint32_t Hash(const char* data, size_t n, uint32_t seed);
+uint32_t Hash(const char* data, size_t n, uint32_t seed);
 
 // TODO: consider rename to LegacyBloomHash32
 inline uint32_t BloomHash(const Slice& key) {
@@ -111,7 +111,7 @@ inline uint64_t GetSliceNPHash64(const Slice& s, uint64_t seed) {
 
 // Similar to `GetSliceNPHash64()` with `seed`, but input comes from
 // concatenation of `Slice`s in `data`.
-extern uint64_t GetSlicePartsNPHash64(const SliceParts& data, uint64_t seed);
+uint64_t GetSlicePartsNPHash64(const SliceParts& data, uint64_t seed);
 
 inline size_t GetSliceRangedNPHash(const Slice& s, size_t range) {
   return FastRange64(NPHash64(s.data(), s.size()), range);

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -18,14 +18,14 @@ namespace ROCKSDB_NAMESPACE {
 
 class Slice;
 
-extern std::vector<std::string> StringSplit(const std::string& arg, char delim);
+std::vector<std::string> StringSplit(const std::string& arg, char delim);
 
 // Append a human-readable printout of "num" to *str
-extern void AppendNumberTo(std::string* str, uint64_t num);
+void AppendNumberTo(std::string* str, uint64_t num);
 
 // Append a human-readable printout of "value" to *str.
 // Escapes any non-printable characters found in "value".
-extern void AppendEscapedStringTo(std::string* str, const Slice& value);
+void AppendEscapedStringTo(std::string* str, const Slice& value);
 
 // Put n digits from v in base kBase to (*buf)[0] to (*buf)[n-1] and
 // advance *buf to the position after what was written.
@@ -73,15 +73,15 @@ inline bool ParseBaseChars(const char** buf, size_t n, uint64_t* v) {
 // for num >= 10.000, prints "xxK"
 // for num >= 10.000.000, prints "xxM"
 // for num >= 10.000.000.000, prints "xxG"
-extern std::string NumberToHumanString(int64_t num);
+std::string NumberToHumanString(int64_t num);
 
 // Return a human-readable version of bytes
 // ex: 1048576 -> 1.00 GB
-extern std::string BytesToHumanString(uint64_t bytes);
+std::string BytesToHumanString(uint64_t bytes);
 
 // Return a human-readable version of unix time
 // ex: 1562116015 -> "Tue Jul  2 18:06:55 2019"
-extern std::string TimeToHumanString(int unixtime);
+std::string TimeToHumanString(int unixtime);
 
 // Append a human-readable time in micros.
 int AppendHumanMicros(uint64_t micros, char* output, int len,
@@ -92,13 +92,13 @@ int AppendHumanBytes(uint64_t bytes, char* output, int len);
 
 // Return a human-readable version of "value".
 // Escapes any non-printable characters found in "value".
-extern std::string EscapeString(const Slice& value);
+std::string EscapeString(const Slice& value);
 
 // Parse a human-readable number from "*in" into *value.  On success,
 // advances "*in" past the consumed number and sets "*val" to the
 // numeric value.  Otherwise, returns false and leaves *in in an
 // unspecified state.
-extern bool ConsumeDecimalNumber(Slice* in, uint64_t* val);
+bool ConsumeDecimalNumber(Slice* in, uint64_t* val);
 
 // Returns true if the input char "c" is considered as a special character
 // that will be escaped when EscapeOptionString() is called.
@@ -180,6 +180,6 @@ extern const std::string kNullptrString;
 
 // errnoStr() function returns a string that describes the error code passed in
 // the argument err
-extern std::string errnoStr(int err);
+std::string errnoStr(int err);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/agg_merge/agg_merge_impl.h
+++ b/utilities/agg_merge/agg_merge_impl.h
@@ -44,6 +44,6 @@ class AggMergeOperator : public MergeOperator {
   static Accumulator& GetTLSAccumulator();
 };
 
-extern std::string EncodeAggFuncAndPayloadNoCheck(const Slice& function_name,
-                                                  const Slice& value);
+std::string EncodeAggFuncAndPayloadNoCheck(const Slice& function_name,
+                                           const Slice& value);
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary:
In C++, `extern` is redundant in a number of cases:
* "Global" function declarations and definitions
* "Global" variable definitions when already declared `extern`

For consistency and simplicity, I've removed these in code that *we own*. In a couple of cases, I removed obsolete declarations, and for MagicNumber constants, I have consolidated the declarations into a header file (format.h)
as standard best practice would prescribe.

Test Plan: no functional changes, CI