### PR TITLE
Remove WritableFile(FSWritableFile)::GetFileSize default implementation

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -1002,7 +1002,7 @@ class WritableFile {
   /*
    * Get the size of valid data in the file.
    */
-  virtual uint64_t GetFileSize() { return 0; }
+  virtual uint64_t GetFileSize() = 0;
 
   /*
    * Get and set the default pre-allocation block size for writes to

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1144,9 +1144,7 @@ class FSWritableFile {
    * Get the size of valid data in the file.
    */
   virtual uint64_t GetFileSize(const IOOptions& /*options*/,
-                               IODebugContext* /*dbg*/) {
-    return 0;
-  }
+                               IODebugContext* /*dbg*/) = 0;
 
   /*
    * Get and set the default pre-allocation block size for writes to

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -189,6 +189,11 @@ class StringSink : public FSWritableFile {
     }
   }
 
+  uint64_t GetFileSize(const IOOptions& /*options*/,
+                       IODebugContext* /*dbg*/) override {
+    return contents_.size();
+  }
+
  private:
   Slice* reader_contents_;
   size_t last_flush_;
@@ -283,6 +288,11 @@ class OverwritingStringSink : public FSWritableFile {
   void Drop(size_t bytes) {
     contents_.resize(contents_.size() - bytes);
     if (last_flush_ > contents_.size()) last_flush_ = contents_.size();
+  }
+
+  uint64_t GetFileSize(const IOOptions& /*options*/,
+                       IODebugContext* /*dbg*/) override {
+    return contents_.size();
   }
 
  private:
@@ -561,6 +571,14 @@ class StringFS : public FileSystemWrapper {
                     IODebugContext* /*dbg*/) override {
       contents_->append(slice.data(), slice.size());
       return IOStatus::OK();
+    }
+
+    uint64_t GetFileSize(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) override {
+      if (contents_ != nullptr) {
+        return contents_->size();
+      }
+      return 0;
     }
 
    private:

--- a/unreleased_history/public_api_changes/remove_default_get_file_size.md
+++ b/unreleased_history/public_api_changes/remove_default_get_file_size.md
@@ -1,0 +1,1 @@
+*Remove the default `WritableFile::GetFileSize` implementation that returns 0 and make it pure virtual, so that subclasses are enforced to explicitly provide an implementation.

--- a/unreleased_history/public_api_changes/remove_default_get_file_size.md
+++ b/unreleased_history/public_api_changes/remove_default_get_file_size.md
@@ -1,1 +1,1 @@
-*Remove the default `WritableFile::GetFileSize` implementation that returns 0 and make it pure virtual, so that subclasses are enforced to explicitly provide an implementation.
+*Remove the default `WritableFile::GetFileSize` and `FSWritableFile::GetFileSize` implementation that returns 0 and make it pure virtual, so that subclasses are enforced to explicitly provide an implementation.

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -463,6 +463,11 @@ TEST_F(WritableFileWriterTest, AppendStatusReturn) {
     void Setuse_direct_io(bool val) { use_direct_io_ = val; }
     void SetIOError(bool val) { io_error_ = val; }
 
+    uint64_t GetFileSize(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) override {
+      return 0;
+    }
+
    protected:
     bool use_direct_io_;
     bool io_error_;
@@ -860,6 +865,11 @@ TEST_F(DBWritableFileWriterTest, IOErrorNotification) {
     void CheckCounters(int file_append_errors, int file_flush_errors) {
       ASSERT_EQ(file_append_errors, file_append_errors_);
       ASSERT_EQ(file_flush_errors_, file_flush_errors);
+    }
+
+    uint64_t GetFileSize(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) override {
+      return 0;
     }
 
    protected:

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -96,6 +96,11 @@ class TestFSWritableFile : public FSWritableFile {
     return target_->use_direct_io();
   }
 
+  virtual uint64_t GetFileSize(const IOOptions& options,
+                               IODebugContext* dbg) override {
+    return target_->GetFileSize(options, dbg);
+  }
+
  private:
   FSFileState state_;  // Need protection by mutex_
   FileOptions file_opts_;


### PR DESCRIPTION
As titled. This changes public API behavior, and subclasses of `WritableFile` and `FSWritableFile` need to explicitly provide an implementation for the `GetFileSize` method after this change.