### PR TITLE
Add more detail to some statuses

### DIFF
--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -403,7 +403,7 @@ jobs:
     - uses: "./.github/actions/pre-steps"
     - run: ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=static OPT="-DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make V=1 -j24 check
     - uses: "./.github/actions/post-steps"
-  # ========================= MacOS with Tests ======================== #
+  # ========================= MacOS build only ======================== #
   build-macos:
     if: ${{ github.repository_owner == 'facebook' }}
     runs-on: macos-13
@@ -417,9 +417,10 @@ jobs:
     - uses: "./.github/actions/increase-max-open-files-on-macos"
     - uses: "./.github/actions/install-gflags-on-macos"
     - uses: "./.github/actions/pre-steps-macos"
-    - name: Run all tests
+    - name: Build
       run: ulimit -S -n `ulimit -H -n` && make V=1 J=16 -j16 all
     - uses: "./.github/actions/post-steps"
+  # ========================= MacOS with Tests ======================== #
   build-macos-cmake:
     if: ${{ github.repository_owner == 'facebook' }}
     runs-on: macos-13

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -309,7 +309,7 @@ Status DBImpl::Resume() {
 
   if (error_handler_.IsRecoveryInProgress()) {
     // Don't allow a mix of manual and automatic recovery
-    return Status::Busy();
+    return Status::Busy("Recovery in progress");
   }
 
   mutex_.Unlock();

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1695,7 +1695,7 @@ Status DBImpl::PauseBackgroundWork() {
 Status DBImpl::ContinueBackgroundWork() {
   InstrumentedMutexLock guard_lock(&mutex_);
   if (bg_work_paused_ == 0) {
-    return Status::InvalidArgument();
+    return Status::InvalidArgument("Background work already unpaused");
   }
   assert(bg_work_paused_ > 0);
   assert(bg_compaction_paused_ > 0);

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -576,7 +576,7 @@ Status ErrorHandler::RecoverFromBGError(bool is_manual) {
     // If its a manual recovery and there's a background recovery in progress
     // return busy status
     if (recovery_in_prog_) {
-      return Status::Busy();
+      return Status::Busy("Recovery already in progress");
     }
     recovery_in_prog_ = true;
 

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -387,7 +387,7 @@ Status ExternalSstFileIngestionJob::Run() {
     return status;
   }
   if (need_flush) {
-    return Status::TryAgain();
+    return Status::TryAgain("need_flush");
   }
   assert(status.ok() && need_flush == false);
 #endif

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -648,7 +648,7 @@ Status ForwardIterator::GetProperty(std::string prop_name, std::string* prop) {
     *prop = std::to_string(sv_->version_number);
     return Status::OK();
   }
-  return Status::InvalidArgument();
+  return Status::InvalidArgument("Unrecognized property: " + prop_name);
 }
 
 void ForwardIterator::SetPinnedItersMgr(

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -122,7 +122,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     } else if (block_iter_points_to_real_block_) {
       return block_iter_.status();
     } else if (async_read_in_progress_) {
-      return Status::TryAgain();
+      return Status::TryAgain("Async read in progress");
     } else {
       return Status::OK();
     }


### PR DESCRIPTION
Summary: and also fix comment/label on some MacOS CI jobs. Motivated by a crash test failure missing a definitive indicator of the genesis of the status:

```
file ingestion error: Operation failed. Try again.:
```

Test Plan: just cosmetic changes. These statuses should not arise frequently enough to be a performance issue (copying messages).