### PR TITLE
Fix zstd typo in cmake

### DIFF
--- a/cmake/modules/Findzstd.cmake
+++ b/cmake/modules/Findzstd.cmake
@@ -1,29 +1,29 @@
 # - Find zstd
 # Find the zstd compression library and includes
 #
-# zstd_INCLUDE_DIRS - where to find zstd.h, etc.
-# zstd_LIBRARIES - List of libraries when using zstd.
-# zstd_FOUND - True if zstd found.
+# ZSTD_INCLUDE_DIRS - where to find zstd.h, etc.
+# ZSTD_LIBRARIES - List of libraries when using zstd.
+# ZSTD_FOUND - True if zstd found.
 
-find_path(zstd_INCLUDE_DIRS
+find_path(ZSTD_INCLUDE_DIRS
   NAMES zstd.h
   HINTS ${zstd_ROOT_DIR}/include)
 
-find_library(zstd_LIBRARIES
+find_library(ZSTD_LIBRARIES
   NAMES zstd
   HINTS ${zstd_ROOT_DIR}/lib)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(zstd DEFAULT_MSG zstd_LIBRARIES ZSTD_INCLUDE_DIRS)
+find_package_handle_standard_args(zstd DEFAULT_MSG ZSTD_LIBRARIES ZSTD_INCLUDE_DIRS)
 
 mark_as_advanced(
-  zstd_LIBRARIES
-  zstd_INCLUDE_DIRS)
+  ZSTD_LIBRARIES
+  ZSTD_INCLUDE_DIRS)
 
-if(zstd_FOUND AND NOT (TARGET zstd::zstd))
+if(ZSTD_FOUND AND NOT (TARGET zstd::zstd))
   add_library (zstd::zstd UNKNOWN IMPORTED)
   set_target_properties(zstd::zstd
     PROPERTIES
-      IMPORTED_LOCATION ${zstd_LIBRARIES}
-      INTERFACE_INCLUDE_DIRECTORIES ${zstd_INCLUDE_DIRS})
+      IMPORTED_LOCATION ${ZSTD_LIBRARIES}
+      INTERFACE_INCLUDE_DIRECTORIES ${ZSTD_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
#12247 imported another typo in cmakelists.txt and findzstd.cmake.
cmake report ZSTD_INCLUDE_DIRS not found.
Actually it should be
https://github.com/facebook/rocksdb/blob/aacf60dda2a138f9d3826c25818a3bcf250859fd/cmake/modules/Findzstd.cmake#L8 
