### PR TITLE
Fix race condition for accessing file size in TestFSWritableFile 

### DIFF
--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -98,6 +98,7 @@ class TestFSWritableFile : public FSWritableFile {
 
   virtual uint64_t GetFileSize(const IOOptions& options,
                                IODebugContext* dbg) override {
+    MutexLock l(&mutex_);
     return target_->GetFileSize(options, dbg);
   }
 


### PR DESCRIPTION
Fix a race condition reported by thread sanitizer for accessing an underlying file's size from `TestFSWritableFile`.

Test plan:
COMPILE_WITH_TSAN=1 make -j10 transaction_test
./transaction_test --gtest_filter="DBAsBaseDB/TransactionTest.UnlockWALStallCleared/4" --gtest_repeat=100