### PR TITLE
Remove 'virtual' when implied by 'override'

### DIFF
--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -259,7 +259,7 @@ class ShardedCache : public ShardedCacheBase {
     } while (remaining_work);
   }
 
-  virtual void EraseUnRefEntries() override {
+  void EraseUnRefEntries() override {
     ForEachShard([](CacheShard* cs) { cs->EraseUnRefEntries(); });
   }
 

--- a/cache/tiered_secondary_cache.h
+++ b/cache/tiered_secondary_cache.h
@@ -42,27 +42,25 @@ class TieredSecondaryCache : public SecondaryCacheWrapper {
 
   // This is a no-op as we currently don't allow demotion (i.e
   // insertion by the upper layer) of evicted blocks.
-  virtual Status Insert(const Slice& /*key*/, Cache::ObjectPtr /*obj*/,
-                        const Cache::CacheItemHelper* /*helper*/,
-                        bool /*force_insert*/) override {
+  Status Insert(const Slice& /*key*/, Cache::ObjectPtr /*obj*/,
+                const Cache::CacheItemHelper* /*helper*/,
+                bool /*force_insert*/) override {
     return Status::OK();
   }
 
   // Warm up the nvm tier directly
-  virtual Status InsertSaved(
-      const Slice& key, const Slice& saved,
-      CompressionType type = CompressionType::kNoCompression,
-      CacheTier source = CacheTier::kVolatileTier) override {
+  Status InsertSaved(const Slice& key, const Slice& saved,
+                     CompressionType type = CompressionType::kNoCompression,
+                     CacheTier source = CacheTier::kVolatileTier) override {
     return nvm_sec_cache_->InsertSaved(key, saved, type, source);
   }
 
-  virtual std::unique_ptr<SecondaryCacheResultHandle> Lookup(
+  std::unique_ptr<SecondaryCacheResultHandle> Lookup(
       const Slice& key, const Cache::CacheItemHelper* helper,
       Cache::CreateContext* create_context, bool wait, bool advise_erase,
       Statistics* stats, bool& kept_in_sec_cache) override;
 
-  virtual void WaitAll(
-      std::vector<SecondaryCacheResultHandle*> handles) override;
+  void WaitAll(std::vector<SecondaryCacheResultHandle*> handles) override;
 
  private:
   struct CreateContext : public Cache::CreateContext {

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -169,10 +169,10 @@ class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
   virtual ~ColumnFamilyHandleImpl();
   virtual ColumnFamilyData* cfd() const { return cfd_; }
 
-  virtual uint32_t GetID() const override;
-  virtual const std::string& GetName() const override;
-  virtual Status GetDescriptor(ColumnFamilyDescriptor* desc) override;
-  virtual const Comparator* GetComparator() const override;
+  uint32_t GetID() const override;
+  const std::string& GetName() const override;
+  Status GetDescriptor(ColumnFamilyDescriptor* desc) override;
+  const Comparator* GetComparator() const override;
 
  private:
   ColumnFamilyData* cfd_;
@@ -193,7 +193,7 @@ class ColumnFamilyHandleInternal : public ColumnFamilyHandleImpl {
         internal_cfd_(nullptr) {}
 
   void SetCFD(ColumnFamilyData* _cfd) { internal_cfd_ = _cfd; }
-  virtual ColumnFamilyData* cfd() const override { return internal_cfd_; }
+  ColumnFamilyData* cfd() const override { return internal_cfd_; }
 
  private:
   ColumnFamilyData* internal_cfd_;
@@ -853,17 +853,17 @@ class ColumnFamilyMemTablesImpl : public ColumnFamilyMemTables {
   // REQUIRES: Seek() called first
   // REQUIRES: use this function of DBImpl::column_family_memtables_ should be
   //           under a DB mutex OR from a write thread
-  virtual MemTable* GetMemTable() const override;
+  MemTable* GetMemTable() const override;
 
   // Returns column family handle for the selected column family
   // REQUIRES: use this function of DBImpl::column_family_memtables_ should be
   //           under a DB mutex OR from a write thread
-  virtual ColumnFamilyHandle* GetColumnFamilyHandle() override;
+  ColumnFamilyHandle* GetColumnFamilyHandle() override;
 
   // Cannot be called while another thread is calling Seek().
   // REQUIRES: use this function of DBImpl::column_family_memtables_ should be
   //           under a DB mutex OR from a write thread
-  virtual ColumnFamilyData* current() override { return current_; }
+  ColumnFamilyData* current() override { return current_; }
 
  private:
   ColumnFamilySet* column_family_set_;

--- a/db/compaction/compaction_picker.h
+++ b/db/compaction/compaction_picker.h
@@ -277,8 +277,7 @@ class NullCompactionPicker : public CompactionPicker {
   }
 
   // Always returns false.
-  virtual bool NeedsCompaction(
-      const VersionStorageInfo* /*vstorage*/) const override {
+  bool NeedsCompaction(const VersionStorageInfo* /*vstorage*/) const override {
     return false;
   }
 };

--- a/db/compaction/compaction_picker_fifo.h
+++ b/db/compaction/compaction_picker_fifo.h
@@ -18,26 +18,27 @@ class FIFOCompactionPicker : public CompactionPicker {
                        const InternalKeyComparator* icmp)
       : CompactionPicker(ioptions, icmp) {}
 
-  virtual Compaction* PickCompaction(const std::string& cf_name,
-                                     const MutableCFOptions& mutable_cf_options,
-                                     const MutableDBOptions& mutable_db_options,
-                                     VersionStorageInfo* version,
-                                     LogBuffer* log_buffer) override;
+  Compaction* PickCompaction(const std::string& cf_name,
+                             const MutableCFOptions& mutable_cf_options,
+                             const MutableDBOptions& mutable_db_options,
+                             VersionStorageInfo* version,
+                             LogBuffer* log_buffer) override;
 
-  virtual Compaction* CompactRange(
-      const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
-      const MutableDBOptions& mutable_db_options, VersionStorageInfo* vstorage,
-      int input_level, int output_level,
-      const CompactRangeOptions& compact_range_options,
-      const InternalKey* begin, const InternalKey* end,
-      InternalKey** compaction_end, bool* manual_conflict,
-      uint64_t max_file_num_to_ignore, const std::string& trim_ts) override;
+  Compaction* CompactRange(const std::string& cf_name,
+                           const MutableCFOptions& mutable_cf_options,
+                           const MutableDBOptions& mutable_db_options,
+                           VersionStorageInfo* vstorage, int input_level,
+                           int output_level,
+                           const CompactRangeOptions& compact_range_options,
+                           const InternalKey* begin, const InternalKey* end,
+                           InternalKey** compaction_end, bool* manual_conflict,
+                           uint64_t max_file_num_to_ignore,
+                           const std::string& trim_ts) override;
 
   // The maximum allowed output level.  Always returns 0.
-  virtual int MaxOutputLevel() const override { return 0; }
+  int MaxOutputLevel() const override { return 0; }
 
-  virtual bool NeedsCompaction(
-      const VersionStorageInfo* vstorage) const override;
+  bool NeedsCompaction(const VersionStorageInfo* vstorage) const override;
 
  private:
   Compaction* PickTTLCompaction(const std::string& cf_name,

--- a/db/compaction/compaction_picker_level.h
+++ b/db/compaction/compaction_picker_level.h
@@ -20,14 +20,13 @@ class LevelCompactionPicker : public CompactionPicker {
   LevelCompactionPicker(const ImmutableOptions& ioptions,
                         const InternalKeyComparator* icmp)
       : CompactionPicker(ioptions, icmp) {}
-  virtual Compaction* PickCompaction(const std::string& cf_name,
-                                     const MutableCFOptions& mutable_cf_options,
-                                     const MutableDBOptions& mutable_db_options,
-                                     VersionStorageInfo* vstorage,
-                                     LogBuffer* log_buffer) override;
+  Compaction* PickCompaction(const std::string& cf_name,
+                             const MutableCFOptions& mutable_cf_options,
+                             const MutableDBOptions& mutable_db_options,
+                             VersionStorageInfo* vstorage,
+                             LogBuffer* log_buffer) override;
 
-  virtual bool NeedsCompaction(
-      const VersionStorageInfo* vstorage) const override;
+  bool NeedsCompaction(const VersionStorageInfo* vstorage) const override;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction_picker_universal.h
+++ b/db/compaction/compaction_picker_universal.h
@@ -17,14 +17,13 @@ class UniversalCompactionPicker : public CompactionPicker {
   UniversalCompactionPicker(const ImmutableOptions& ioptions,
                             const InternalKeyComparator* icmp)
       : CompactionPicker(ioptions, icmp) {}
-  virtual Compaction* PickCompaction(const std::string& cf_name,
-                                     const MutableCFOptions& mutable_cf_options,
-                                     const MutableDBOptions& mutable_db_options,
-                                     VersionStorageInfo* vstorage,
-                                     LogBuffer* log_buffer) override;
-  virtual int MaxOutputLevel() const override { return NumberLevels() - 1; }
+  Compaction* PickCompaction(const std::string& cf_name,
+                             const MutableCFOptions& mutable_cf_options,
+                             const MutableDBOptions& mutable_db_options,
+                             VersionStorageInfo* vstorage,
+                             LogBuffer* log_buffer) override;
+  int MaxOutputLevel() const override { return NumberLevels() - 1; }
 
-  virtual bool NeedsCompaction(
-      const VersionStorageInfo* vstorage) const override;
+  bool NeedsCompaction(const VersionStorageInfo* vstorage) const override;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -53,10 +53,9 @@ class ErrorFS : public FileSystemWrapper {
         num_writable_file_errors_(0) {}
   const char* Name() const override { return "ErrorEnv"; }
 
-  virtual IOStatus NewWritableFile(const std::string& fname,
-                                   const FileOptions& opts,
-                                   std::unique_ptr<FSWritableFile>* result,
-                                   IODebugContext* dbg) override {
+  IOStatus NewWritableFile(const std::string& fname, const FileOptions& opts,
+                           std::unique_ptr<FSWritableFile>* result,
+                           IODebugContext* dbg) override {
     result->reset();
     if (writable_file_error_) {
       ++num_writable_file_errors_;

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -3658,11 +3658,9 @@ class DBBasicTestMultiGet : public DBTestBase {
    public:
     MyFlushBlockPolicyFactory() {}
 
-    virtual const char* Name() const override {
-      return "MyFlushBlockPolicyFactory";
-    }
+    const char* Name() const override { return "MyFlushBlockPolicyFactory"; }
 
-    virtual FlushBlockPolicy* NewFlushBlockPolicy(
+    FlushBlockPolicy* NewFlushBlockPolicy(
         const BlockBasedTableOptions& /*table_options*/,
         const BlockBuilder& data_block_builder) const override {
       return new MyFlushBlockPolicy(data_block_builder);

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -1373,7 +1373,7 @@ class StableCacheKeyTestFS : public FaultInjectionTestFS {
     SetFailGetUniqueId(true);
   }
 
-  virtual ~StableCacheKeyTestFS() override {}
+  ~StableCacheKeyTestFS() override {}
 
   IOStatus LinkFile(const std::string&, const std::string&, const IOOptions&,
                     IODebugContext*) override {

--- a/db/db_impl/compacted_db_impl.h
+++ b/db/db_impl/compacted_db_impl.h
@@ -26,9 +26,8 @@ class CompactedDBImpl : public DBImpl {
 
   // Implementations of the DB interface
   using DB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override;
+  Status Get(const ReadOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, PinnableSlice* value) override;
 
   Status Get(const ReadOptions& _read_options,
              ColumnFamilyHandle* column_family, const Slice& key,
@@ -38,10 +37,10 @@ class CompactedDBImpl : public DBImpl {
   // Note that CompactedDBImpl::MultiGet is not the optimized version of
   // MultiGet to use.
   // TODO: optimize CompactedDBImpl::MultiGet, see DBImpl::MultiGet for details.
-  virtual std::vector<Status> MultiGet(
-      const ReadOptions& options, const std::vector<ColumnFamilyHandle*>&,
-      const std::vector<Slice>& keys,
-      std::vector<std::string>* values) override;
+  std::vector<Status> MultiGet(const ReadOptions& options,
+                               const std::vector<ColumnFamilyHandle*>&,
+                               const std::vector<Slice>& keys,
+                               std::vector<std::string>* values) override;
 
   std::vector<Status> MultiGet(const ReadOptions& _read_options,
                                const std::vector<ColumnFamilyHandle*>&,
@@ -50,9 +49,9 @@ class CompactedDBImpl : public DBImpl {
                                std::vector<std::string>* timestamps) override;
 
   using DBImpl::Put;
-  virtual Status Put(const WriteOptions& /*options*/,
-                     ColumnFamilyHandle* /*column_family*/,
-                     const Slice& /*key*/, const Slice& /*value*/) override {
+  Status Put(const WriteOptions& /*options*/,
+             ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,
+             const Slice& /*value*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
 
@@ -65,54 +64,53 @@ class CompactedDBImpl : public DBImpl {
   }
 
   using DBImpl::Merge;
-  virtual Status Merge(const WriteOptions& /*options*/,
-                       ColumnFamilyHandle* /*column_family*/,
-                       const Slice& /*key*/, const Slice& /*value*/) override {
+  Status Merge(const WriteOptions& /*options*/,
+               ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,
+               const Slice& /*value*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
 
   using DBImpl::Delete;
-  virtual Status Delete(const WriteOptions& /*options*/,
-                        ColumnFamilyHandle* /*column_family*/,
-                        const Slice& /*key*/) override {
+  Status Delete(const WriteOptions& /*options*/,
+                ColumnFamilyHandle* /*column_family*/,
+                const Slice& /*key*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
-  virtual Status Write(const WriteOptions& /*options*/,
-                       WriteBatch* /*updates*/) override {
+  Status Write(const WriteOptions& /*options*/,
+               WriteBatch* /*updates*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
   using DBImpl::CompactRange;
-  virtual Status CompactRange(const CompactRangeOptions& /*options*/,
-                              ColumnFamilyHandle* /*column_family*/,
-                              const Slice* /*begin*/,
-                              const Slice* /*end*/) override {
+  Status CompactRange(const CompactRangeOptions& /*options*/,
+                      ColumnFamilyHandle* /*column_family*/,
+                      const Slice* /*begin*/, const Slice* /*end*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
 
-  virtual Status DisableFileDeletions() override {
+  Status DisableFileDeletions() override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
-  virtual Status EnableFileDeletions(bool /*force*/) override {
+  Status EnableFileDeletions(bool /*force*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
-  virtual Status GetLiveFiles(std::vector<std::string>& ret,
-                              uint64_t* manifest_file_size,
-                              bool /*flush_memtable*/) override {
+  Status GetLiveFiles(std::vector<std::string>& ret,
+                      uint64_t* manifest_file_size,
+                      bool /*flush_memtable*/) override {
     return DBImpl::GetLiveFiles(ret, manifest_file_size,
                                 false /* flush_memtable */);
   }
   using DBImpl::Flush;
-  virtual Status Flush(const FlushOptions& /*options*/,
-                       ColumnFamilyHandle* /*column_family*/) override {
+  Status Flush(const FlushOptions& /*options*/,
+               ColumnFamilyHandle* /*column_family*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
 
-  virtual Status SyncWAL() override {
+  Status SyncWAL() override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
 
   using DB::IngestExternalFile;
-  virtual Status IngestExternalFile(
+  Status IngestExternalFile(
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*external_files*/,
       const IngestExternalFileOptions& /*ingestion_options*/) override {
@@ -120,7 +118,7 @@ class CompactedDBImpl : public DBImpl {
   }
 
   using DB::CreateColumnFamilyWithImport;
-  virtual Status CreateColumnFamilyWithImport(
+  Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
@@ -130,9 +128,9 @@ class CompactedDBImpl : public DBImpl {
   }
 
   using DB::ClipColumnFamily;
-  virtual Status ClipColumnFamily(ColumnFamilyHandle* /*column_family*/,
-                                  const Slice& /*begin*/,
-                                  const Slice& /*end*/) override {
+  Status ClipColumnFamily(ColumnFamilyHandle* /*column_family*/,
+                          const Slice& /*begin*/,
+                          const Slice& /*end*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -229,16 +229,14 @@ class DBImpl : public DB {
                      const Slice& end_key, const Slice& ts) override;
 
   using DB::Write;
-  virtual Status Write(const WriteOptions& options,
-                       WriteBatch* updates) override;
+  Status Write(const WriteOptions& options, WriteBatch* updates) override;
 
   using DB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override;
-  virtual Status Get(const ReadOptions& _read_options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value, std::string* timestamp) override;
+  Status Get(const ReadOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, PinnableSlice* value) override;
+  Status Get(const ReadOptions& _read_options,
+             ColumnFamilyHandle* column_family, const Slice& key,
+             PinnableSlice* value, std::string* timestamp) override;
 
   using DB::GetEntity;
   Status GetEntity(const ReadOptions& options,
@@ -263,12 +261,12 @@ class DBImpl : public DB {
   }
 
   using DB::MultiGet;
-  virtual std::vector<Status> MultiGet(
+  std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
       std::vector<std::string>* values) override;
-  virtual std::vector<Status> MultiGet(
+  std::vector<Status> MultiGet(
       const ReadOptions& _read_options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys, std::vector<std::string>* values,
@@ -319,9 +317,9 @@ class DBImpl : public DB {
                       const Slice* keys,
                       PinnableAttributeGroups* results) override;
 
-  virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
-                                    const std::string& column_family,
-                                    ColumnFamilyHandle** handle) override {
+  Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
+                            const std::string& column_family,
+                            ColumnFamilyHandle** handle) override {
     // TODO: plumb Env::IOActivity, Env::IOPriority
     return CreateColumnFamily(ReadOptions(), WriteOptions(), cf_options,
                               column_family, handle);
@@ -331,7 +329,7 @@ class DBImpl : public DB {
                                     const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,
                                     ColumnFamilyHandle** handle);
-  virtual Status CreateColumnFamilies(
+  Status CreateColumnFamilies(
       const ColumnFamilyOptions& cf_options,
       const std::vector<std::string>& column_family_names,
       std::vector<ColumnFamilyHandle*>* handles) override {
@@ -345,7 +343,7 @@ class DBImpl : public DB {
       const std::vector<std::string>& column_family_names,
       std::vector<ColumnFamilyHandle*>* handles);
 
-  virtual Status CreateColumnFamilies(
+  Status CreateColumnFamilies(
       const std::vector<ColumnFamilyDescriptor>& column_families,
       std::vector<ColumnFamilyHandle*>* handles) override {
     // TODO: plumb Env::IOActivity, Env::IOPriority
@@ -356,8 +354,8 @@ class DBImpl : public DB {
       const ReadOptions& read_options, const WriteOptions& write_options,
       const std::vector<ColumnFamilyDescriptor>& column_families,
       std::vector<ColumnFamilyHandle*>* handles);
-  virtual Status DropColumnFamily(ColumnFamilyHandle* column_family) override;
-  virtual Status DropColumnFamilies(
+  Status DropColumnFamily(ColumnFamilyHandle* column_family) override;
+  Status DropColumnFamilies(
       const std::vector<ColumnFamilyHandle*>& column_families) override;
 
   // Returns false if key doesn't exist in the database and true if it may.
@@ -365,21 +363,20 @@ class DBImpl : public DB {
   // memory. On return, if value was found, then value_found will be set to true
   // , otherwise false.
   using DB::KeyMayExist;
-  virtual bool KeyMayExist(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           std::string* value, std::string* timestamp,
-                           bool* value_found = nullptr) override;
+  bool KeyMayExist(const ReadOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   std::string* value, std::string* timestamp,
+                   bool* value_found = nullptr) override;
 
   using DB::NewIterator;
-  virtual Iterator* NewIterator(const ReadOptions& _read_options,
-                                ColumnFamilyHandle* column_family) override;
-  virtual Status NewIterators(
-      const ReadOptions& _read_options,
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      std::vector<Iterator*>* iterators) override;
+  Iterator* NewIterator(const ReadOptions& _read_options,
+                        ColumnFamilyHandle* column_family) override;
+  Status NewIterators(const ReadOptions& _read_options,
+                      const std::vector<ColumnFamilyHandle*>& column_families,
+                      std::vector<Iterator*>* iterators) override;
 
-  virtual const Snapshot* GetSnapshot() override;
-  virtual void ReleaseSnapshot(const Snapshot* snapshot) override;
+  const Snapshot* GetSnapshot() override;
+  void ReleaseSnapshot(const Snapshot* snapshot) override;
   // Create a timestamped snapshot. This snapshot can be shared by multiple
   // readers. If any of them uses it for write conflict checking, then
   // is_write_conflict_boundary is true. For simplicity, set it to true by
@@ -394,35 +391,33 @@ class DBImpl : public DB {
                                      timestamped_snapshots) const;
 
   using DB::GetProperty;
-  virtual bool GetProperty(ColumnFamilyHandle* column_family,
-                           const Slice& property, std::string* value) override;
+  bool GetProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                   std::string* value) override;
   using DB::GetMapProperty;
-  virtual bool GetMapProperty(
-      ColumnFamilyHandle* column_family, const Slice& property,
-      std::map<std::string, std::string>* value) override;
+  bool GetMapProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                      std::map<std::string, std::string>* value) override;
   using DB::GetIntProperty;
-  virtual bool GetIntProperty(ColumnFamilyHandle* column_family,
-                              const Slice& property, uint64_t* value) override;
+  bool GetIntProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                      uint64_t* value) override;
   using DB::GetAggregatedIntProperty;
-  virtual bool GetAggregatedIntProperty(const Slice& property,
-                                        uint64_t* aggregated_value) override;
+  bool GetAggregatedIntProperty(const Slice& property,
+                                uint64_t* aggregated_value) override;
   using DB::GetApproximateSizes;
-  virtual Status GetApproximateSizes(const SizeApproximationOptions& options,
-                                     ColumnFamilyHandle* column_family,
-                                     const Range* range, int n,
-                                     uint64_t* sizes) override;
+  Status GetApproximateSizes(const SizeApproximationOptions& options,
+                             ColumnFamilyHandle* column_family,
+                             const Range* range, int n,
+                             uint64_t* sizes) override;
   using DB::GetApproximateMemTableStats;
-  virtual void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
-                                           const Range& range,
-                                           uint64_t* const count,
-                                           uint64_t* const size) override;
+  void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
+                                   const Range& range, uint64_t* const count,
+                                   uint64_t* const size) override;
   using DB::CompactRange;
-  virtual Status CompactRange(const CompactRangeOptions& options,
-                              ColumnFamilyHandle* column_family,
-                              const Slice* begin, const Slice* end) override;
+  Status CompactRange(const CompactRangeOptions& options,
+                      ColumnFamilyHandle* column_family, const Slice* begin,
+                      const Slice* end) override;
 
   using DB::CompactFiles;
-  virtual Status CompactFiles(
+  Status CompactFiles(
       const CompactionOptions& compact_options,
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names, const int output_level,
@@ -430,55 +425,54 @@ class DBImpl : public DB {
       std::vector<std::string>* const output_file_names = nullptr,
       CompactionJobInfo* compaction_job_info = nullptr) override;
 
-  virtual Status PauseBackgroundWork() override;
-  virtual Status ContinueBackgroundWork() override;
+  Status PauseBackgroundWork() override;
+  Status ContinueBackgroundWork() override;
 
-  virtual Status EnableAutoCompaction(
+  Status EnableAutoCompaction(
       const std::vector<ColumnFamilyHandle*>& column_family_handles) override;
 
-  virtual void EnableManualCompaction() override;
-  virtual void DisableManualCompaction() override;
+  void EnableManualCompaction() override;
+  void DisableManualCompaction() override;
 
   using DB::SetOptions;
   Status SetOptions(
       ColumnFamilyHandle* column_family,
       const std::unordered_map<std::string, std::string>& options_map) override;
 
-  virtual Status SetDBOptions(
+  Status SetDBOptions(
       const std::unordered_map<std::string, std::string>& options_map) override;
 
   using DB::NumberLevels;
-  virtual int NumberLevels(ColumnFamilyHandle* column_family) override;
+  int NumberLevels(ColumnFamilyHandle* column_family) override;
   using DB::MaxMemCompactionLevel;
-  virtual int MaxMemCompactionLevel(ColumnFamilyHandle* column_family) override;
+  int MaxMemCompactionLevel(ColumnFamilyHandle* column_family) override;
   using DB::Level0StopWriteTrigger;
-  virtual int Level0StopWriteTrigger(
-      ColumnFamilyHandle* column_family) override;
-  virtual const std::string& GetName() const override;
-  virtual Env* GetEnv() const override;
-  virtual FileSystem* GetFileSystem() const override;
+  int Level0StopWriteTrigger(ColumnFamilyHandle* column_family) override;
+  const std::string& GetName() const override;
+  Env* GetEnv() const override;
+  FileSystem* GetFileSystem() const override;
   using DB::GetOptions;
-  virtual Options GetOptions(ColumnFamilyHandle* column_family) const override;
+  Options GetOptions(ColumnFamilyHandle* column_family) const override;
   using DB::GetDBOptions;
-  virtual DBOptions GetDBOptions() const override;
+  DBOptions GetDBOptions() const override;
   using DB::Flush;
-  virtual Status Flush(const FlushOptions& options,
-                       ColumnFamilyHandle* column_family) override;
-  virtual Status Flush(
+  Status Flush(const FlushOptions& options,
+               ColumnFamilyHandle* column_family) override;
+  Status Flush(
       const FlushOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_families) override;
-  virtual Status FlushWAL(bool sync) override {
+  Status FlushWAL(bool sync) override {
     // TODO: plumb Env::IOActivity, Env::IOPriority
     return FlushWAL(WriteOptions(), sync);
   }
 
   virtual Status FlushWAL(const WriteOptions& write_options, bool sync);
   bool WALBufferIsEmpty();
-  virtual Status SyncWAL() override;
-  virtual Status LockWAL() override;
-  virtual Status UnlockWAL() override;
+  Status SyncWAL() override;
+  Status LockWAL() override;
+  Status UnlockWAL() override;
 
-  virtual SequenceNumber GetLatestSequenceNumber() const override;
+  SequenceNumber GetLatestSequenceNumber() const override;
 
   // IncreaseFullHistoryTsLow(ColumnFamilyHandle*, std::string) will acquire
   // and release db_mutex
@@ -490,21 +484,21 @@ class DBImpl : public DB {
   Status GetFullHistoryTsLow(ColumnFamilyHandle* column_family,
                              std::string* ts_low) override;
 
-  virtual Status GetDbIdentity(std::string& identity) const override;
+  Status GetDbIdentity(std::string& identity) const override;
 
   virtual Status GetDbIdentityFromIdentityFile(std::string* identity) const;
 
-  virtual Status GetDbSessionId(std::string& session_id) const override;
+  Status GetDbSessionId(std::string& session_id) const override;
 
   ColumnFamilyHandle* DefaultColumnFamily() const override;
 
   ColumnFamilyHandle* PersistentStatsColumnFamily() const;
 
-  virtual Status Close() override;
+  Status Close() override;
 
-  virtual Status DisableFileDeletions() override;
+  Status DisableFileDeletions() override;
 
-  virtual Status EnableFileDeletions(bool force) override;
+  Status EnableFileDeletions(bool force) override;
 
   virtual bool IsFileDeletionsEnabled() const;
 
@@ -513,40 +507,35 @@ class DBImpl : public DB {
       std::unique_ptr<StatsHistoryIterator>* stats_iterator) override;
 
   using DB::ResetStats;
-  virtual Status ResetStats() override;
+  Status ResetStats() override;
   // All the returned filenames start with "/"
-  virtual Status GetLiveFiles(std::vector<std::string>&,
-                              uint64_t* manifest_file_size,
-                              bool flush_memtable = true) override;
-  virtual Status GetSortedWalFiles(VectorLogPtr& files) override;
-  virtual Status GetCurrentWalFile(
-      std::unique_ptr<LogFile>* current_log_file) override;
-  virtual Status GetCreationTimeOfOldestFile(
-      uint64_t* creation_time) override;
+  Status GetLiveFiles(std::vector<std::string>&, uint64_t* manifest_file_size,
+                      bool flush_memtable = true) override;
+  Status GetSortedWalFiles(VectorLogPtr& files) override;
+  Status GetCurrentWalFile(std::unique_ptr<LogFile>* current_log_file) override;
+  Status GetCreationTimeOfOldestFile(uint64_t* creation_time) override;
 
-  virtual Status GetUpdatesSince(
+  Status GetUpdatesSince(
       SequenceNumber seq_number, std::unique_ptr<TransactionLogIterator>* iter,
       const TransactionLogIterator::ReadOptions& read_options =
           TransactionLogIterator::ReadOptions()) override;
-  virtual Status DeleteFile(std::string name) override;
+  Status DeleteFile(std::string name) override;
   Status DeleteFilesInRanges(ColumnFamilyHandle* column_family,
                              const RangePtr* ranges, size_t n,
                              bool include_end = true);
 
-  virtual void GetLiveFilesMetaData(
-      std::vector<LiveFileMetaData>* metadata) override;
+  void GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) override;
 
-  virtual Status GetLiveFilesChecksumInfo(
-      FileChecksumList* checksum_list) override;
+  Status GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) override;
 
-  virtual Status GetLiveFilesStorageInfo(
+  Status GetLiveFilesStorageInfo(
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) override;
 
   // Obtains the meta data of the specified column family of the DB.
   // TODO(yhchiang): output parameter is placed in the end in this codebase.
-  virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
-                                       ColumnFamilyMetaData* metadata) override;
+  void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
+                               ColumnFamilyMetaData* metadata) override;
 
   void GetAllColumnFamilyMetaData(
       std::vector<ColumnFamilyMetaData>* metadata) override;
@@ -558,32 +547,32 @@ class DBImpl : public DB {
                    int target_level) override;
 
   using DB::IngestExternalFile;
-  virtual Status IngestExternalFile(
+  Status IngestExternalFile(
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& external_files,
       const IngestExternalFileOptions& ingestion_options) override;
 
   using DB::IngestExternalFiles;
-  virtual Status IngestExternalFiles(
+  Status IngestExternalFiles(
       const std::vector<IngestExternalFileArg>& args) override;
 
   using DB::CreateColumnFamilyWithImport;
-  virtual Status CreateColumnFamilyWithImport(
+  Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
       const std::vector<const ExportImportFilesMetaData*>& metadatas,
       ColumnFamilyHandle** handle) override;
 
   using DB::ClipColumnFamily;
-  virtual Status ClipColumnFamily(ColumnFamilyHandle* column_family,
-                                  const Slice& begin_key,
-                                  const Slice& end_key) override;
+  Status ClipColumnFamily(ColumnFamilyHandle* column_family,
+                          const Slice& begin_key,
+                          const Slice& end_key) override;
 
   using DB::VerifyFileChecksums;
   Status VerifyFileChecksums(const ReadOptions& read_options) override;
 
   using DB::VerifyChecksum;
-  virtual Status VerifyChecksum(const ReadOptions& /*read_options*/) override;
+  Status VerifyChecksum(const ReadOptions& /*read_options*/) override;
   // Verify the checksums of files in db. Currently only tables are checked.
   //
   // read_options: controls file I/O behavior, e.g. read ahead size while
@@ -604,18 +593,16 @@ class DBImpl : public DB {
                                 const ReadOptions& read_options);
 
   using DB::StartTrace;
-  virtual Status StartTrace(
-      const TraceOptions& options,
-      std::unique_ptr<TraceWriter>&& trace_writer) override;
+  Status StartTrace(const TraceOptions& options,
+                    std::unique_ptr<TraceWriter>&& trace_writer) override;
 
   using DB::EndTrace;
-  virtual Status EndTrace() override;
+  Status EndTrace() override;
 
   using DB::NewDefaultReplayer;
-  virtual Status NewDefaultReplayer(
-      const std::vector<ColumnFamilyHandle*>& handles,
-      std::unique_ptr<TraceReader>&& reader,
-      std::unique_ptr<Replayer>* replayer) override;
+  Status NewDefaultReplayer(const std::vector<ColumnFamilyHandle*>& handles,
+                            std::unique_ptr<TraceReader>&& reader,
+                            std::unique_ptr<Replayer>* replayer) override;
 
   using DB::StartBlockCacheTrace;
   Status StartBlockCacheTrace(
@@ -637,13 +624,11 @@ class DBImpl : public DB {
   Status EndIOTrace() override;
 
   using DB::GetPropertiesOfAllTables;
-  virtual Status GetPropertiesOfAllTables(
-      ColumnFamilyHandle* column_family,
-      TablePropertiesCollection* props) override;
-  virtual Status GetPropertiesOfTablesInRange(
+  Status GetPropertiesOfAllTables(ColumnFamilyHandle* column_family,
+                                  TablePropertiesCollection* props) override;
+  Status GetPropertiesOfTablesInRange(
       ColumnFamilyHandle* column_family, const Range* range, std::size_t n,
       TablePropertiesCollection* props) override;
-
 
   // ---- End of implementations of the DB interface ----
   SystemClock* GetSystemClock() const;

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -31,18 +31,17 @@ class DBImplReadOnly : public DBImpl {
   // TODO: Implement ReadOnly MultiGet?
 
   using DBImpl::NewIterator;
-  virtual Iterator* NewIterator(const ReadOptions& _read_options,
-                                ColumnFamilyHandle* column_family) override;
+  Iterator* NewIterator(const ReadOptions& _read_options,
+                        ColumnFamilyHandle* column_family) override;
 
-  virtual Status NewIterators(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      std::vector<Iterator*>* iterators) override;
+  Status NewIterators(const ReadOptions& options,
+                      const std::vector<ColumnFamilyHandle*>& column_families,
+                      std::vector<Iterator*>* iterators) override;
 
   using DBImpl::Put;
-  virtual Status Put(const WriteOptions& /*options*/,
-                     ColumnFamilyHandle* /*column_family*/,
-                     const Slice& /*key*/, const Slice& /*value*/) override {
+  Status Put(const WriteOptions& /*options*/,
+             ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,
+             const Slice& /*value*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
@@ -59,37 +58,36 @@ class DBImplReadOnly : public DBImpl {
   }
 
   using DBImpl::Merge;
-  virtual Status Merge(const WriteOptions& /*options*/,
-                       ColumnFamilyHandle* /*column_family*/,
-                       const Slice& /*key*/, const Slice& /*value*/) override {
+  Status Merge(const WriteOptions& /*options*/,
+               ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,
+               const Slice& /*value*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
   using DBImpl::Delete;
-  virtual Status Delete(const WriteOptions& /*options*/,
-                        ColumnFamilyHandle* /*column_family*/,
-                        const Slice& /*key*/) override {
+  Status Delete(const WriteOptions& /*options*/,
+                ColumnFamilyHandle* /*column_family*/,
+                const Slice& /*key*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
   using DBImpl::SingleDelete;
-  virtual Status SingleDelete(const WriteOptions& /*options*/,
-                              ColumnFamilyHandle* /*column_family*/,
-                              const Slice& /*key*/) override {
+  Status SingleDelete(const WriteOptions& /*options*/,
+                      ColumnFamilyHandle* /*column_family*/,
+                      const Slice& /*key*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
-  virtual Status Write(const WriteOptions& /*options*/,
-                       WriteBatch* /*updates*/) override {
+  Status Write(const WriteOptions& /*options*/,
+               WriteBatch* /*updates*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
   using DBImpl::CompactRange;
-  virtual Status CompactRange(const CompactRangeOptions& /*options*/,
-                              ColumnFamilyHandle* /*column_family*/,
-                              const Slice* /*begin*/,
-                              const Slice* /*end*/) override {
+  Status CompactRange(const CompactRangeOptions& /*options*/,
+                      ColumnFamilyHandle* /*column_family*/,
+                      const Slice* /*begin*/, const Slice* /*end*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
   using DBImpl::CompactFiles;
-  virtual Status CompactFiles(
+  Status CompactFiles(
       const CompactionOptions& /*compact_options*/,
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*input_file_names*/,
@@ -99,33 +97,33 @@ class DBImplReadOnly : public DBImpl {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
-  virtual Status DisableFileDeletions() override {
+  Status DisableFileDeletions() override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
-  virtual Status EnableFileDeletions(bool /*force*/) override {
+  Status EnableFileDeletions(bool /*force*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
-  virtual Status GetLiveFiles(std::vector<std::string>& ret,
-                              uint64_t* manifest_file_size,
-                              bool /*flush_memtable*/) override {
+  Status GetLiveFiles(std::vector<std::string>& ret,
+                      uint64_t* manifest_file_size,
+                      bool /*flush_memtable*/) override {
     return DBImpl::GetLiveFiles(ret, manifest_file_size,
                                 false /* flush_memtable */);
   }
 
   using DBImpl::Flush;
-  virtual Status Flush(const FlushOptions& /*options*/,
-                       ColumnFamilyHandle* /*column_family*/) override {
+  Status Flush(const FlushOptions& /*options*/,
+               ColumnFamilyHandle* /*column_family*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
   using DBImpl::SyncWAL;
-  virtual Status SyncWAL() override {
+  Status SyncWAL() override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
   using DB::IngestExternalFile;
-  virtual Status IngestExternalFile(
+  Status IngestExternalFile(
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*external_files*/,
       const IngestExternalFileOptions& /*ingestion_options*/) override {
@@ -133,7 +131,7 @@ class DBImplReadOnly : public DBImpl {
   }
 
   using DB::CreateColumnFamilyWithImport;
-  virtual Status CreateColumnFamilyWithImport(
+  Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
@@ -142,7 +140,7 @@ class DBImplReadOnly : public DBImpl {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
-  virtual Status CreateColumnFamilyWithImport(
+  Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
@@ -152,9 +150,9 @@ class DBImplReadOnly : public DBImpl {
   }
 
   using DB::ClipColumnFamily;
-  virtual Status ClipColumnFamily(ColumnFamilyHandle* /*column_family*/,
-                                  const Slice& /*begin*/,
-                                  const Slice& /*end*/) override {
+  Status ClipColumnFamily(ColumnFamilyHandle* /*column_family*/,
+                          const Slice& /*begin*/,
+                          const Slice& /*end*/) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3103,11 +3103,11 @@ class ModelDB : public DB {
   }
 
   using DB::GetMergeOperands;
-  virtual Status GetMergeOperands(
-      const ReadOptions& /*options*/, ColumnFamilyHandle* /*column_family*/,
-      const Slice& key, PinnableSlice* /*slice*/,
-      GetMergeOperandsOptions* /*merge_operands_options*/,
-      int* /*number_of_operands*/) override {
+  Status GetMergeOperands(const ReadOptions& /*options*/,
+                          ColumnFamilyHandle* /*column_family*/,
+                          const Slice& key, PinnableSlice* /*slice*/,
+                          GetMergeOperandsOptions* /*merge_operands_options*/,
+                          int* /*number_of_operands*/) override {
     return Status::NotSupported(key);
   }
 
@@ -3137,7 +3137,7 @@ class ModelDB : public DB {
   }
 
   using DB::CreateColumnFamilyWithImport;
-  virtual Status CreateColumnFamilyWithImport(
+  Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& /*options*/,
       const std::string& /*column_family_name*/,
       const ImportColumnFamilyOptions& /*import_options*/,
@@ -3152,9 +3152,9 @@ class ModelDB : public DB {
   }
 
   using DB::ClipColumnFamily;
-  virtual Status ClipColumnFamily(ColumnFamilyHandle* /*column_family*/,
-                                  const Slice& /*begin*/,
-                                  const Slice& /*end*/) override {
+  Status ClipColumnFamily(ColumnFamilyHandle* /*column_family*/,
+                          const Slice& /*begin*/,
+                          const Slice& /*end*/) override {
     return Status::NotSupported("Not implemented.");
   }
 
@@ -3308,7 +3308,7 @@ class ModelDB : public DB {
 
   void DisableManualCompaction() override {}
 
-  virtual Status WaitForCompact(
+  Status WaitForCompact(
       const WaitForCompactOptions& /* wait_for_compact_options */) override {
     return Status::OK();
   }
@@ -3381,8 +3381,7 @@ class ModelDB : public DB {
     return Status::OK();
   }
 
-  virtual Status GetCreationTimeOfOldestFile(
-      uint64_t* /*creation_time*/) override {
+  Status GetCreationTimeOfOldestFile(uint64_t* /*creation_time*/) override {
     return Status::NotSupported();
   }
 

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -4242,7 +4242,7 @@ class TraceExecutionResultHandler : public TraceRecordResult::Handler {
   TraceExecutionResultHandler() = default;
   ~TraceExecutionResultHandler() override = default;
 
-  virtual Status Handle(const StatusOnlyTraceExecutionResult& result) override {
+  Status Handle(const StatusOnlyTraceExecutionResult& result) override {
     if (result.GetStartTimestamp() > result.GetEndTimestamp()) {
       return Status::InvalidArgument("Invalid timestamps.");
     }
@@ -4260,8 +4260,7 @@ class TraceExecutionResultHandler : public TraceRecordResult::Handler {
     return Status::OK();
   }
 
-  virtual Status Handle(
-      const SingleValueTraceExecutionResult& result) override {
+  Status Handle(const SingleValueTraceExecutionResult& result) override {
     if (result.GetStartTimestamp() > result.GetEndTimestamp()) {
       return Status::InvalidArgument("Invalid timestamps.");
     }
@@ -4279,8 +4278,7 @@ class TraceExecutionResultHandler : public TraceRecordResult::Handler {
     return Status::OK();
   }
 
-  virtual Status Handle(
-      const MultiValuesTraceExecutionResult& result) override {
+  Status Handle(const MultiValuesTraceExecutionResult& result) override {
     if (result.GetStartTimestamp() > result.GetEndTimestamp()) {
       return Status::InvalidArgument("Invalid timestamps.");
     }
@@ -4300,7 +4298,7 @@ class TraceExecutionResultHandler : public TraceRecordResult::Handler {
     return Status::OK();
   }
 
-  virtual Status Handle(const IteratorTraceExecutionResult& result) override {
+  Status Handle(const IteratorTraceExecutionResult& result) override {
     if (result.GetStartTimestamp() > result.GetEndTimestamp()) {
       return Status::InvalidArgument("Invalid timestamps.");
     }

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -843,19 +843,19 @@ class InternalKeySliceTransform : public SliceTransform {
   explicit InternalKeySliceTransform(const SliceTransform* transform)
       : transform_(transform) {}
 
-  virtual const char* Name() const override { return transform_->Name(); }
+  const char* Name() const override { return transform_->Name(); }
 
-  virtual Slice Transform(const Slice& src) const override {
+  Slice Transform(const Slice& src) const override {
     auto user_key = ExtractUserKey(src);
     return transform_->Transform(user_key);
   }
 
-  virtual bool InDomain(const Slice& src) const override {
+  bool InDomain(const Slice& src) const override {
     auto user_key = ExtractUserKey(src);
     return transform_->InDomain(user_key);
   }
 
-  virtual bool InRange(const Slice& dst) const override {
+  bool InRange(const Slice& dst) const override {
     auto user_key = ExtractUserKey(dst);
     return transform_->InRange(user_key);
   }

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -70,19 +70,18 @@ class ForwardIterator : public InternalIterator {
     valid_ = false;
   }
 
-  virtual bool Valid() const override;
+  bool Valid() const override;
   void SeekToFirst() override;
-  virtual void Seek(const Slice& target) override;
-  virtual void Next() override;
-  virtual Slice key() const override;
-  virtual Slice value() const override;
-  virtual Status status() const override;
-  virtual bool PrepareValue() override;
-  virtual Status GetProperty(std::string prop_name, std::string* prop) override;
-  virtual void SetPinnedItersMgr(
-      PinnedIteratorsManager* pinned_iters_mgr) override;
-  virtual bool IsKeyPinned() const override;
-  virtual bool IsValuePinned() const override;
+  void Seek(const Slice& target) override;
+  void Next() override;
+  Slice key() const override;
+  Slice value() const override;
+  Status status() const override;
+  bool PrepareValue() override;
+  Status GetProperty(std::string prop_name, std::string* prop) override;
+  void SetPinnedItersMgr(PinnedIteratorsManager* pinned_iters_mgr) override;
+  bool IsKeyPinned() const override;
+  bool IsValuePinned() const override;
 
   bool TEST_CheckDeletedIters(int* deleted_iters, int* num_iters);
 

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -90,10 +90,10 @@ class MemTable {
   struct KeyComparator : public MemTableRep::KeyComparator {
     const InternalKeyComparator comparator;
     explicit KeyComparator(const InternalKeyComparator& c) : comparator(c) {}
-    virtual int operator()(const char* prefix_len_key1,
-                           const char* prefix_len_key2) const override;
-    virtual int operator()(const char* prefix_len_key,
-                           const DecodedType& key) const override;
+    int operator()(const char* prefix_len_key1,
+                   const char* prefix_len_key2) const override;
+    int operator()(const char* prefix_len_key,
+                   const DecodedType& key) const override;
   };
 
   // MemTables are reference counted.  The initial reference count

--- a/db/snapshot_checker.h
+++ b/db/snapshot_checker.h
@@ -27,7 +27,7 @@ class SnapshotChecker {
 class DisableGCSnapshotChecker : public SnapshotChecker {
  public:
   virtual ~DisableGCSnapshotChecker() {}
-  virtual SnapshotCheckerResult CheckInSnapshot(
+  SnapshotCheckerResult CheckInSnapshot(
       SequenceNumber /*sequence*/,
       SequenceNumber /*snapshot_sequence*/) const override {
     // By returning kNotInSnapshot, we prevent all the values from being GCed
@@ -48,7 +48,7 @@ class WritePreparedSnapshotChecker : public SnapshotChecker {
   explicit WritePreparedSnapshotChecker(WritePreparedTxnDB* txn_db);
   virtual ~WritePreparedSnapshotChecker() {}
 
-  virtual SnapshotCheckerResult CheckInSnapshot(
+  SnapshotCheckerResult CheckInSnapshot(
       SequenceNumber sequence, SequenceNumber snapshot_sequence) const override;
 
  private:

--- a/db/table_properties_collector.h
+++ b/db/table_properties_collector.h
@@ -66,22 +66,20 @@ class UserKeyTablePropertiesCollector : public IntTblPropCollector {
 
   virtual ~UserKeyTablePropertiesCollector() {}
 
-  virtual Status InternalAdd(const Slice& key, const Slice& value,
-                             uint64_t file_size) override;
+  Status InternalAdd(const Slice& key, const Slice& value,
+                     uint64_t file_size) override;
 
-  virtual void BlockAdd(uint64_t block_uncomp_bytes,
-                        uint64_t block_compressed_bytes_fast,
-                        uint64_t block_compressed_bytes_slow) override;
+  void BlockAdd(uint64_t block_uncomp_bytes,
+                uint64_t block_compressed_bytes_fast,
+                uint64_t block_compressed_bytes_slow) override;
 
-  virtual Status Finish(UserCollectedProperties* properties) override;
+  Status Finish(UserCollectedProperties* properties) override;
 
-  virtual const char* Name() const override { return collector_->Name(); }
+  const char* Name() const override { return collector_->Name(); }
 
   UserCollectedProperties GetReadableProperties() const override;
 
-  virtual bool NeedCompact() const override {
-    return collector_->NeedCompact();
-  }
+  bool NeedCompact() const override { return collector_->NeedCompact(); }
 
  protected:
   std::unique_ptr<TablePropertiesCollector> collector_;
@@ -93,7 +91,7 @@ class UserKeyTablePropertiesCollectorFactory
   explicit UserKeyTablePropertiesCollectorFactory(
       std::shared_ptr<TablePropertiesCollectorFactory> user_collector_factory)
       : user_collector_factory_(user_collector_factory) {}
-  virtual IntTblPropCollector* CreateIntTblPropCollector(
+  IntTblPropCollector* CreateIntTblPropCollector(
       uint32_t column_family_id, int level_at_creation) override {
     TablePropertiesCollectorFactory::Context context;
     context.column_family_id = column_family_id;
@@ -107,9 +105,7 @@ class UserKeyTablePropertiesCollectorFactory
     }
   }
 
-  virtual const char* Name() const override {
-    return user_collector_factory_->Name();
-  }
+  const char* Name() const override { return user_collector_factory_->Name(); }
 
  private:
   std::shared_ptr<TablePropertiesCollectorFactory> user_collector_factory_;

--- a/db/transaction_log_impl.h
+++ b/db/transaction_log_impl.h
@@ -63,13 +63,13 @@ class TransactionLogIteratorImpl : public TransactionLogIterator {
       std::unique_ptr<VectorLogPtr> files, VersionSet const* const versions,
       const bool seq_per_batch, const std::shared_ptr<IOTracer>& io_tracer);
 
-  virtual bool Valid() override;
+  bool Valid() override;
 
-  virtual void Next() override;
+  void Next() override;
 
-  virtual Status status() override;
+  Status status() override;
 
-  virtual BatchResult GetBatch() override;
+  BatchResult GetBatch() override;
 
  private:
   const std::string& dir_;
@@ -98,7 +98,7 @@ class TransactionLogIteratorImpl : public TransactionLogIterator {
   struct LogReporter : public log::Reader::Reporter {
     Env* env;
     Logger* info_log;
-    virtual void Corruption(size_t bytes, const Status& s) override {
+    void Corruption(size_t bytes, const Status& s) override {
       ROCKS_LOG_ERROR(info_log, "dropping %" ROCKSDB_PRIszt " bytes; %s", bytes,
                       s.ToString().c_str());
     }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1571,7 +1571,7 @@ class VersionSet {
 
   struct LogReporter : public log::Reader::Reporter {
     Status* status;
-    virtual void Corruption(size_t /*bytes*/, const Status& s) override {
+    void Corruption(size_t /*bytes*/, const Status& s) override {
       if (status->ok()) {
         *status = s;
       }

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -400,7 +400,7 @@ class MyXXH64Checksum : public FileChecksumGenerator {
     XXH64_reset(state_, 0);
   }
 
-  virtual ~MyXXH64Checksum() override { XXH64_freeState(state_); }
+  ~MyXXH64Checksum() override { XXH64_freeState(state_); }
 
   void Update(const char* data, size_t n) override {
     XXH64_update(state_, data, n);

--- a/db_stress_tool/db_stress_env_wrapper.h
+++ b/db_stress_tool/db_stress_env_wrapper.h
@@ -135,8 +135,8 @@ class DbStressWritableFileWrapper : public FSWritableFileOwnerWrapper {
                                       dbg);
   }
 
-  virtual IOStatus Truncate(uint64_t size, const IOOptions& options,
-                            IODebugContext* dbg) override {
+  IOStatus Truncate(uint64_t size, const IOOptions& options,
+                    IODebugContext* dbg) override {
 #ifndef NDEBUG
     const ThreadStatus::OperationType thread_op =
         ThreadStatusUtil::GetThreadOperation();
@@ -148,8 +148,7 @@ class DbStressWritableFileWrapper : public FSWritableFileOwnerWrapper {
     return target()->Truncate(size, options, dbg);
   }
 
-  virtual IOStatus Close(const IOOptions& options,
-                         IODebugContext* dbg) override {
+  IOStatus Close(const IOOptions& options, IODebugContext* dbg) override {
 #ifndef NDEBUG
     const ThreadStatus::OperationType thread_op =
         ThreadStatusUtil::GetThreadOperation();
@@ -161,8 +160,7 @@ class DbStressWritableFileWrapper : public FSWritableFileOwnerWrapper {
     return target()->Close(options, dbg);
   }
 
-  virtual IOStatus Flush(const IOOptions& options,
-                         IODebugContext* dbg) override {
+  IOStatus Flush(const IOOptions& options, IODebugContext* dbg) override {
 #ifndef NDEBUG
     const ThreadStatus::OperationType thread_op =
         ThreadStatusUtil::GetThreadOperation();
@@ -174,8 +172,7 @@ class DbStressWritableFileWrapper : public FSWritableFileOwnerWrapper {
     return target()->Flush(options, dbg);
   }
 
-  virtual IOStatus Sync(const IOOptions& options,
-                        IODebugContext* dbg) override {
+  IOStatus Sync(const IOOptions& options, IODebugContext* dbg) override {
 #ifndef NDEBUG
     const ThreadStatus::OperationType thread_op =
         ThreadStatusUtil::GetThreadOperation();
@@ -187,8 +184,7 @@ class DbStressWritableFileWrapper : public FSWritableFileOwnerWrapper {
     return target()->Sync(options, dbg);
   }
 
-  virtual IOStatus Fsync(const IOOptions& options,
-                         IODebugContext* dbg) override {
+  IOStatus Fsync(const IOOptions& options, IODebugContext* dbg) override {
 #ifndef NDEBUG
     const ThreadStatus::OperationType thread_op =
         ThreadStatusUtil::GetThreadOperation();
@@ -201,9 +197,8 @@ class DbStressWritableFileWrapper : public FSWritableFileOwnerWrapper {
   }
 
 #ifdef ROCKSDB_FALLOCATE_PRESENT
-  virtual IOStatus Allocate(uint64_t offset, uint64_t len,
-                            const IOOptions& options,
-                            IODebugContext* dbg) override {
+  IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& options,
+                    IODebugContext* dbg) override {
 #ifndef NDEBUG
     const ThreadStatus::OperationType thread_op =
         ThreadStatusUtil::GetThreadOperation();
@@ -216,9 +211,8 @@ class DbStressWritableFileWrapper : public FSWritableFileOwnerWrapper {
   }
 #endif
 
-  virtual IOStatus RangeSync(uint64_t offset, uint64_t nbytes,
-                             const IOOptions& options,
-                             IODebugContext* dbg) override {
+  IOStatus RangeSync(uint64_t offset, uint64_t nbytes, const IOOptions& options,
+                     IODebugContext* dbg) override {
 #ifndef NDEBUG
     const ThreadStatus::OperationType thread_op =
         ThreadStatusUtil::GetThreadOperation();

--- a/db_stress_tool/db_stress_table_properties_collector.h
+++ b/db_stress_tool/db_stress_table_properties_collector.h
@@ -23,25 +23,25 @@ class DbStressTablePropertiesCollector : public TablePropertiesCollector {
       : need_compact_(Random::GetTLSInstance()->OneInOpt(
             FLAGS_mark_for_compaction_one_file_in)) {}
 
-  virtual Status AddUserKey(const Slice& /* key */, const Slice& /* value */,
-                            EntryType /*type*/, SequenceNumber /*seq*/,
-                            uint64_t /*file_size*/) override {
+  Status AddUserKey(const Slice& /* key */, const Slice& /* value */,
+                    EntryType /*type*/, SequenceNumber /*seq*/,
+                    uint64_t /*file_size*/) override {
     return Status::OK();
   }
 
-  virtual Status Finish(UserCollectedProperties* /* properties */) override {
+  Status Finish(UserCollectedProperties* /* properties */) override {
     return Status::OK();
   }
 
-  virtual UserCollectedProperties GetReadableProperties() const override {
+  UserCollectedProperties GetReadableProperties() const override {
     return UserCollectedProperties{};
   }
 
-  virtual const char* Name() const override {
+  const char* Name() const override {
     return "DbStressTablePropertiesCollector";
   }
 
-  virtual bool NeedCompact() const override { return need_compact_; }
+  bool NeedCompact() const override { return need_compact_; }
 
  private:
   const bool need_compact_;
@@ -52,12 +52,12 @@ class DbStressTablePropertiesCollector : public TablePropertiesCollector {
 class DbStressTablePropertiesCollectorFactory
     : public TablePropertiesCollectorFactory {
  public:
-  virtual TablePropertiesCollector* CreateTablePropertiesCollector(
+  TablePropertiesCollector* CreateTablePropertiesCollector(
       TablePropertiesCollectorFactory::Context /* context */) override {
     return new DbStressTablePropertiesCollector();
   }
 
-  virtual const char* Name() const override {
+  const char* Name() const override {
     return "DbStressTablePropertiesCollectorFactory";
   }
 };

--- a/env/emulated_clock.h
+++ b/env/emulated_clock.h
@@ -34,7 +34,7 @@ class EmulatedSystemClock : public SystemClockWrapper {
   static const char* kClassName() { return "TimeEmulatedSystemClock"; }
   const char* Name() const override { return kClassName(); }
 
-  virtual void SleepForMicroseconds(int micros) override {
+  void SleepForMicroseconds(int micros) override {
     sleep_counter_++;
     if (no_slowdown_ || time_elapse_only_sleep_) {
       addon_microseconds_.fetch_add(micros);
@@ -70,7 +70,7 @@ class EmulatedSystemClock : public SystemClockWrapper {
 
   int GetSleepCounter() const { return sleep_counter_.load(); }
 
-  virtual Status GetCurrentTime(int64_t* unix_time) override {
+  Status GetCurrentTime(int64_t* unix_time) override {
     Status s;
     if (time_elapse_only_sleep_) {
       *unix_time = maybe_starting_time_;
@@ -84,22 +84,22 @@ class EmulatedSystemClock : public SystemClockWrapper {
     return s;
   }
 
-  virtual uint64_t CPUNanos() override {
+  uint64_t CPUNanos() override {
     cpu_counter_++;
     return SystemClockWrapper::CPUNanos();
   }
 
-  virtual uint64_t CPUMicros() override {
+  uint64_t CPUMicros() override {
     cpu_counter_++;
     return SystemClockWrapper::CPUMicros();
   }
 
-  virtual uint64_t NowNanos() override {
+  uint64_t NowNanos() override {
     return (time_elapse_only_sleep_ ? 0 : SystemClockWrapper::NowNanos()) +
            addon_microseconds_.load() * 1000;
   }
 
-  virtual uint64_t NowMicros() override {
+  uint64_t NowMicros() override {
     return (time_elapse_only_sleep_ ? 0 : SystemClockWrapper::NowMicros()) +
            addon_microseconds_.load();
   }

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -116,7 +116,7 @@ class PosixFileLock : public FileLock {
     filename.clear();
   }
 
-  virtual ~PosixFileLock() override {
+  ~PosixFileLock() override {
     // Check for destruction without UnlockFile
     assert(fd_ == -1);
   }
@@ -1004,8 +1004,8 @@ class PosixFileSystem : public FileSystem {
   // equal to atleast min_completions.
   // 2. Currently in case of direct_io, Read API is called because of which call
   // to Poll API fails as it expects IOHandle to be populated.
-  virtual IOStatus Poll(std::vector<void*>& io_handles,
-                        size_t /*min_completions*/) override {
+  IOStatus Poll(std::vector<void*>& io_handles,
+                size_t /*min_completions*/) override {
 #if defined(ROCKSDB_IOURING_PRESENT)
     // io_uring_queue_init.
     struct io_uring* iu = nullptr;
@@ -1077,7 +1077,7 @@ class PosixFileSystem : public FileSystem {
 #endif
   }
 
-  virtual IOStatus AbortIO(std::vector<void*>& io_handles) override {
+  IOStatus AbortIO(std::vector<void*>& io_handles) override {
 #if defined(ROCKSDB_IOURING_PRESENT)
     // io_uring_queue_init.
     struct io_uring* iu = nullptr;

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -246,15 +246,15 @@ class PosixSequentialFile : public FSSequentialFile {
                       size_t logical_block_size, const EnvOptions& options);
   virtual ~PosixSequentialFile();
 
-  virtual IOStatus Read(size_t n, const IOOptions& opts, Slice* result,
-                        char* scratch, IODebugContext* dbg) override;
-  virtual IOStatus PositionedRead(uint64_t offset, size_t n,
-                                  const IOOptions& opts, Slice* result,
-                                  char* scratch, IODebugContext* dbg) override;
-  virtual IOStatus Skip(uint64_t n) override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
-  virtual bool use_direct_io() const override { return use_direct_io_; }
-  virtual size_t GetRequiredBufferAlignment() const override {
+  IOStatus Read(size_t n, const IOOptions& opts, Slice* result, char* scratch,
+                IODebugContext* dbg) override;
+  IOStatus PositionedRead(uint64_t offset, size_t n, const IOOptions& opts,
+                          Slice* result, char* scratch,
+                          IODebugContext* dbg) override;
+  IOStatus Skip(uint64_t n) override;
+  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  bool use_direct_io() const override { return use_direct_io_; }
+  size_t GetRequiredBufferAlignment() const override {
     return logical_sector_size_;
   }
 };
@@ -299,31 +299,29 @@ class PosixRandomAccessFile : public FSRandomAccessFile {
   );
   virtual ~PosixRandomAccessFile();
 
-  virtual IOStatus Read(uint64_t offset, size_t n, const IOOptions& opts,
-                        Slice* result, char* scratch,
-                        IODebugContext* dbg) const override;
+  IOStatus Read(uint64_t offset, size_t n, const IOOptions& opts, Slice* result,
+                char* scratch, IODebugContext* dbg) const override;
 
-  virtual IOStatus MultiRead(FSReadRequest* reqs, size_t num_reqs,
-                             const IOOptions& options,
-                             IODebugContext* dbg) override;
+  IOStatus MultiRead(FSReadRequest* reqs, size_t num_reqs,
+                     const IOOptions& options, IODebugContext* dbg) override;
 
-  virtual IOStatus Prefetch(uint64_t offset, size_t n, const IOOptions& opts,
-                            IODebugContext* dbg) override;
+  IOStatus Prefetch(uint64_t offset, size_t n, const IOOptions& opts,
+                    IODebugContext* dbg) override;
 
 #if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_AIX)
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
+  size_t GetUniqueId(char* id, size_t max_size) const override;
 #endif
-  virtual void Hint(AccessPattern pattern) override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
-  virtual bool use_direct_io() const override { return use_direct_io_; }
-  virtual size_t GetRequiredBufferAlignment() const override {
+  void Hint(AccessPattern pattern) override;
+  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  bool use_direct_io() const override { return use_direct_io_; }
+  size_t GetRequiredBufferAlignment() const override {
     return logical_sector_size_;
   }
   // EXPERIMENTAL
-  virtual IOStatus ReadAsync(
-      FSReadRequest& req, const IOOptions& opts,
-      std::function<void(const FSReadRequest&, void*)> cb, void* cb_arg,
-      void** io_handle, IOHandleDeleter* del_fn, IODebugContext* dbg) override;
+  IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
+                     std::function<void(const FSReadRequest&, void*)> cb,
+                     void* cb_arg, void** io_handle, IOHandleDeleter* del_fn,
+                     IODebugContext* dbg) override;
 };
 
 class PosixWritableFile : public FSWritableFile {
@@ -351,47 +349,44 @@ class PosixWritableFile : public FSWritableFile {
 
   // Need to implement this so the file is truncated correctly
   // with direct I/O
-  virtual IOStatus Truncate(uint64_t size, const IOOptions& opts,
-                            IODebugContext* dbg) override;
-  virtual IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Append(const Slice& data, const IOOptions& opts,
-                          IODebugContext* dbg) override;
-  virtual IOStatus Append(const Slice& data, const IOOptions& opts,
-                          const DataVerificationInfo& /* verification_info */,
-                          IODebugContext* dbg) override {
+  IOStatus Truncate(uint64_t size, const IOOptions& opts,
+                    IODebugContext* dbg) override;
+  IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Append(const Slice& data, const IOOptions& opts,
+                  IODebugContext* dbg) override;
+  IOStatus Append(const Slice& data, const IOOptions& opts,
+                  const DataVerificationInfo& /* verification_info */,
+                  IODebugContext* dbg) override {
     return Append(data, opts, dbg);
   }
-  virtual IOStatus PositionedAppend(const Slice& data, uint64_t offset,
-                                    const IOOptions& opts,
-                                    IODebugContext* dbg) override;
-  virtual IOStatus PositionedAppend(
-      const Slice& data, uint64_t offset, const IOOptions& opts,
-      const DataVerificationInfo& /* verification_info */,
-      IODebugContext* dbg) override {
+  IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                            const IOOptions& opts,
+                            IODebugContext* dbg) override;
+  IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                            const IOOptions& opts,
+                            const DataVerificationInfo& /* verification_info */,
+                            IODebugContext* dbg) override {
     return PositionedAppend(data, offset, opts, dbg);
   }
-  virtual IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual bool IsSyncThreadSafe() const override;
-  virtual bool use_direct_io() const override { return use_direct_io_; }
-  virtual void SetWriteLifeTimeHint(Env::WriteLifeTimeHint hint) override;
-  virtual uint64_t GetFileSize(const IOOptions& opts,
-                               IODebugContext* dbg) override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
-  virtual size_t GetRequiredBufferAlignment() const override {
+  IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
+  bool IsSyncThreadSafe() const override;
+  bool use_direct_io() const override { return use_direct_io_; }
+  void SetWriteLifeTimeHint(Env::WriteLifeTimeHint hint) override;
+  uint64_t GetFileSize(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus InvalidateCache(size_t offset, size_t length) override;
+  size_t GetRequiredBufferAlignment() const override {
     return logical_sector_size_;
   }
 #ifdef ROCKSDB_FALLOCATE_PRESENT
-  virtual IOStatus Allocate(uint64_t offset, uint64_t len,
-                            const IOOptions& opts,
-                            IODebugContext* dbg) override;
+  IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& opts,
+                    IODebugContext* dbg) override;
 #endif
-  virtual IOStatus RangeSync(uint64_t offset, uint64_t nbytes,
-                             const IOOptions& opts,
-                             IODebugContext* dbg) override;
+  IOStatus RangeSync(uint64_t offset, uint64_t nbytes, const IOOptions& opts,
+                     IODebugContext* dbg) override;
 #ifdef OS_LINUX
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
+  size_t GetUniqueId(char* id, size_t max_size) const override;
 #endif
 };
 
@@ -449,28 +444,26 @@ class PosixMmapFile : public FSWritableFile {
 
   // Means Close() will properly take care of truncate
   // and it does not need any additional information
-  virtual IOStatus Truncate(uint64_t /*size*/, const IOOptions& /*opts*/,
-                            IODebugContext* /*dbg*/) override {
+  IOStatus Truncate(uint64_t /*size*/, const IOOptions& /*opts*/,
+                    IODebugContext* /*dbg*/) override {
     return IOStatus::OK();
   }
-  virtual IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Append(const Slice& data, const IOOptions& opts,
-                          IODebugContext* dbg) override;
-  virtual IOStatus Append(const Slice& data, const IOOptions& opts,
-                          const DataVerificationInfo& /* verification_info */,
-                          IODebugContext* dbg) override {
+  IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Append(const Slice& data, const IOOptions& opts,
+                  IODebugContext* dbg) override;
+  IOStatus Append(const Slice& data, const IOOptions& opts,
+                  const DataVerificationInfo& /* verification_info */,
+                  IODebugContext* dbg) override {
     return Append(data, opts, dbg);
   }
-  virtual IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual uint64_t GetFileSize(const IOOptions& opts,
-                               IODebugContext* dbg) override;
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
+  uint64_t GetFileSize(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus InvalidateCache(size_t offset, size_t length) override;
 #ifdef ROCKSDB_FALLOCATE_PRESENT
-  virtual IOStatus Allocate(uint64_t offset, uint64_t len,
-                            const IOOptions& opts,
-                            IODebugContext* dbg) override;
+  IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& opts,
+                    IODebugContext* dbg) override;
 #endif
 };
 
@@ -480,17 +473,16 @@ class PosixRandomRWFile : public FSRandomRWFile {
                              const EnvOptions& options);
   virtual ~PosixRandomRWFile();
 
-  virtual IOStatus Write(uint64_t offset, const Slice& data,
-                         const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Write(uint64_t offset, const Slice& data, const IOOptions& opts,
+                 IODebugContext* dbg) override;
 
-  virtual IOStatus Read(uint64_t offset, size_t n, const IOOptions& opts,
-                        Slice* result, char* scratch,
-                        IODebugContext* dbg) const override;
+  IOStatus Read(uint64_t offset, size_t n, const IOOptions& opts, Slice* result,
+                char* scratch, IODebugContext* dbg) const override;
 
-  virtual IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
-  virtual IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
 
  private:
   const std::string filename_;
@@ -507,11 +499,11 @@ class PosixDirectory : public FSDirectory {
  public:
   explicit PosixDirectory(int fd, const std::string& directory_name);
   ~PosixDirectory();
-  virtual IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
 
-  virtual IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
 
-  virtual IOStatus FsyncWithDirOptions(
+  IOStatus FsyncWithDirOptions(
       const IOOptions&, IODebugContext*,
       const DirFsyncOptions& dir_fsync_options) override;
 

--- a/examples/compaction_filter_example.cc
+++ b/examples/compaction_filter_example.cc
@@ -10,8 +10,8 @@
 
 class MyMerge : public ROCKSDB_NAMESPACE::MergeOperator {
  public:
-  virtual bool FullMergeV2(const MergeOperationInput& merge_in,
-                           MergeOperationOutput* merge_out) const override {
+  bool FullMergeV2(const MergeOperationInput& merge_in,
+                   MergeOperationOutput* merge_out) const override {
     merge_out->new_value.clear();
     if (merge_in.existing_value != nullptr) {
       merge_out->new_value.assign(merge_in.existing_value->data(),

--- a/file/sst_file_manager_impl.h
+++ b/file/sst_file_manager_impl.h
@@ -88,16 +88,16 @@ class SstFileManagerImpl : public SstFileManager {
   std::unordered_map<std::string, uint64_t> GetTrackedFiles() override;
 
   // Return delete rate limit in bytes per second.
-  virtual int64_t GetDeleteRateBytesPerSecond() override;
+  int64_t GetDeleteRateBytesPerSecond() override;
 
   // Update the delete rate limit in bytes per second.
-  virtual void SetDeleteRateBytesPerSecond(int64_t delete_rate) override;
+  void SetDeleteRateBytesPerSecond(int64_t delete_rate) override;
 
   // Return trash/DB size ratio where new files will be deleted immediately
-  virtual double GetMaxTrashDBRatio() override;
+  double GetMaxTrashDBRatio() override;
 
   // Update trash/DB size ratio where new files will be deleted immediately
-  virtual void SetMaxTrashDBRatio(double ratio) override;
+  void SetMaxTrashDBRatio(double ratio) override;
 
   // Return the total size of trash files
   uint64_t GetTotalTrashSize() override;

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -368,7 +368,7 @@ class CompactionFilterFactory : public Customizable {
       const CompactionFilter::Context& context) = 0;
 
   // Returns a name that identifies this `CompactionFilter` factory.
-  virtual const char* Name() const override = 0;
+  const char* Name() const override = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1593,16 +1593,16 @@ class FileSystemWrapper : public FileSystem {
   std::string SerializeOptions(const ConfigOptions& config_options,
                                const std::string& header) const override;
 
-  virtual IOStatus Poll(std::vector<void*>& io_handles,
-                        size_t min_completions) override {
+  IOStatus Poll(std::vector<void*>& io_handles,
+                size_t min_completions) override {
     return target_->Poll(io_handles, min_completions);
   }
 
-  virtual IOStatus AbortIO(std::vector<void*>& io_handles) override {
+  IOStatus AbortIO(std::vector<void*>& io_handles) override {
     return target_->AbortIO(io_handles);
   }
 
-  virtual void SupportedOps(int64_t& supported_ops) override {
+  void SupportedOps(int64_t& supported_ops) override {
     return target_->SupportedOps(supported_ops);
   }
 

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -341,15 +341,15 @@ class SkipListFactory : public MemTableRepFactory {
   // Methods for Configurable/Customizable class overrides
   static const char* kClassName() { return "SkipListFactory"; }
   static const char* kNickName() { return "skip_list"; }
-  virtual const char* Name() const override { return kClassName(); }
-  virtual const char* NickName() const override { return kNickName(); }
+  const char* Name() const override { return kClassName(); }
+  const char* NickName() const override { return kNickName(); }
   std::string GetId() const override;
 
   // Methods for MemTableRepFactory class overrides
   using MemTableRepFactory::CreateMemTableRep;
-  virtual MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator&,
-                                         Allocator*, const SliceTransform*,
-                                         Logger* logger) override;
+  MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator&, Allocator*,
+                                 const SliceTransform*,
+                                 Logger* logger) override;
 
   bool IsInsertConcurrentlySupported() const override { return true; }
 
@@ -381,9 +381,9 @@ class VectorRepFactory : public MemTableRepFactory {
 
   // Methods for MemTableRepFactory class overrides
   using MemTableRepFactory::CreateMemTableRep;
-  virtual MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator&,
-                                         Allocator*, const SliceTransform*,
-                                         Logger* logger) override;
+  MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator&, Allocator*,
+                                 const SliceTransform*,
+                                 Logger* logger) override;
 };
 
 // This class contains a fixed array of buckets, each

--- a/include/rocksdb/merge_operator.h
+++ b/include/rocksdb/merge_operator.h
@@ -278,7 +278,7 @@ class MergeOperator : public Customizable {
   // TODO: the name is currently not stored persistently and thus
   //       no checking is enforced. Client is responsible for providing
   //       consistent MergeOperator between DB opens.
-  virtual const char* Name() const override = 0;
+  const char* Name() const override = 0;
 
   // Determines whether the PartialMerge can be called with just a single
   // merge operand.

--- a/include/rocksdb/secondary_cache.h
+++ b/include/rocksdb/secondary_cache.h
@@ -160,20 +160,19 @@ class SecondaryCacheWrapper : public SecondaryCache {
   explicit SecondaryCacheWrapper(std::shared_ptr<SecondaryCache> target)
       : target_(std::move(target)) {}
 
-  virtual Status Insert(const Slice& key, Cache::ObjectPtr obj,
-                        const Cache::CacheItemHelper* helper,
-                        bool force_insert) override {
+  Status Insert(const Slice& key, Cache::ObjectPtr obj,
+                const Cache::CacheItemHelper* helper,
+                bool force_insert) override {
     return target()->Insert(key, obj, helper, force_insert);
   }
 
-  virtual Status InsertSaved(
-      const Slice& key, const Slice& saved,
-      CompressionType type = CompressionType::kNoCompression,
-      CacheTier source = CacheTier::kVolatileTier) override {
+  Status InsertSaved(const Slice& key, const Slice& saved,
+                     CompressionType type = CompressionType::kNoCompression,
+                     CacheTier source = CacheTier::kVolatileTier) override {
     return target()->InsertSaved(key, saved, type, source);
   }
 
-  virtual std::unique_ptr<SecondaryCacheResultHandle> Lookup(
+  std::unique_ptr<SecondaryCacheResultHandle> Lookup(
       const Slice& key, const Cache::CacheItemHelper* helper,
       Cache::CreateContext* create_context, bool wait, bool advise_erase,
       Statistics* stats, bool& kept_in_sec_cache) override {
@@ -181,30 +180,29 @@ class SecondaryCacheWrapper : public SecondaryCache {
                             stats, kept_in_sec_cache);
   }
 
-  virtual bool SupportForceErase() const override {
+  bool SupportForceErase() const override {
     return target()->SupportForceErase();
   }
 
-  virtual void Erase(const Slice& key) override { target()->Erase(key); }
+  void Erase(const Slice& key) override { target()->Erase(key); }
 
-  virtual void WaitAll(
-      std::vector<SecondaryCacheResultHandle*> handles) override {
+  void WaitAll(std::vector<SecondaryCacheResultHandle*> handles) override {
     target()->WaitAll(handles);
   }
 
-  virtual Status SetCapacity(size_t capacity) override {
+  Status SetCapacity(size_t capacity) override {
     return target()->SetCapacity(capacity);
   }
 
-  virtual Status GetCapacity(size_t& capacity) override {
+  Status GetCapacity(size_t& capacity) override {
     return target()->GetCapacity(capacity);
   }
 
-  virtual Status Deflate(size_t decrease) override {
+  Status Deflate(size_t decrease) override {
     return target()->Deflate(decrease);
   }
 
-  virtual Status Inflate(size_t increase) override {
+  Status Inflate(size_t increase) override {
     return target()->Inflate(increase);
   }
 

--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -37,7 +37,7 @@ class SliceTransform : public Customizable {
   virtual ~SliceTransform(){}
 
   // Return the name of this transformation.
-  virtual const char* Name() const override = 0;
+  const char* Name() const override = 0;
   static const char* Type() { return "SliceTransform"; }
 
   // Creates and configures a new SliceTransform from the input options and id.

--- a/include/rocksdb/sst_partitioner.h
+++ b/include/rocksdb/sst_partitioner.h
@@ -104,7 +104,7 @@ class SstPartitionerFixedPrefix : public SstPartitioner {
  public:
   explicit SstPartitionerFixedPrefix(size_t len) : len_(len) {}
 
-  virtual ~SstPartitionerFixedPrefix() override {}
+  ~SstPartitionerFixedPrefix() override {}
 
   const char* Name() const override { return "SstPartitionerFixedPrefix"; }
 

--- a/include/rocksdb/system_clock.h
+++ b/include/rocksdb/system_clock.h
@@ -36,7 +36,7 @@ class SystemClock : public Customizable {
                                  const std::string& value,
                                  std::shared_ptr<SystemClock>* result);
   // The name of this system clock
-  virtual const char* Name() const override = 0;
+  const char* Name() const override = 0;
 
   // The name/nickname for the Default SystemClock.  This name can be used
   // to determine if the clock is the default one.
@@ -100,12 +100,12 @@ class SystemClockWrapper : public SystemClock {
 
   uint64_t CPUNanos() override { return target_->CPUNanos(); }
 
-  virtual void SleepForMicroseconds(int micros) override {
+  void SleepForMicroseconds(int micros) override {
     return target_->SleepForMicroseconds(micros);
   }
 
-  virtual bool TimedWait(port::CondVar* cv,
-                         std::chrono::microseconds deadline) override {
+  bool TimedWait(port::CondVar* cv,
+                 std::chrono::microseconds deadline) override {
     return target_->TimedWait(cv, deadline);
   }
 

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -837,7 +837,7 @@ class RandomAccessFileReader;
 // A base class for table factories.
 class TableFactory : public Customizable {
  public:
-  virtual ~TableFactory() override {}
+  ~TableFactory() override {}
 
   static const char* kBlockCacheOpts() { return "BlockCache"; }
   static const char* kBlockBasedTableName() { return "BlockBasedTable"; }

--- a/include/rocksdb/trace_record.h
+++ b/include/rocksdb/trace_record.h
@@ -104,7 +104,7 @@ class WriteQueryTraceRecord : public QueryTraceRecord {
 
   WriteQueryTraceRecord(const std::string& write_batch_rep, uint64_t timestamp);
 
-  virtual ~WriteQueryTraceRecord() override;
+  ~WriteQueryTraceRecord() override;
 
   TraceType GetTraceType() const override { return kTraceWrite; }
 
@@ -127,7 +127,7 @@ class GetQueryTraceRecord : public QueryTraceRecord {
   GetQueryTraceRecord(uint32_t column_family_id, const std::string& key,
                       uint64_t timestamp);
 
-  virtual ~GetQueryTraceRecord() override;
+  ~GetQueryTraceRecord() override;
 
   TraceType GetTraceType() const override { return kTraceGet; }
 
@@ -156,7 +156,7 @@ class IteratorQueryTraceRecord : public QueryTraceRecord {
   IteratorQueryTraceRecord(const std::string& lower_bound,
                            const std::string& upper_bound, uint64_t timestamp);
 
-  virtual ~IteratorQueryTraceRecord() override;
+  ~IteratorQueryTraceRecord() override;
 
   // Get the iterator's lower/upper bound. They may be used in ReadOptions to
   // create an Iterator instance.
@@ -193,7 +193,7 @@ class IteratorSeekQueryTraceRecord : public IteratorQueryTraceRecord {
                                const std::string& upper_bound,
                                uint64_t timestamp);
 
-  virtual ~IteratorSeekQueryTraceRecord() override;
+  ~IteratorSeekQueryTraceRecord() override;
 
   // Trace type matches the seek type.
   TraceType GetTraceType() const override;
@@ -227,7 +227,7 @@ class MultiGetQueryTraceRecord : public QueryTraceRecord {
                            const std::vector<std::string>& keys,
                            uint64_t timestamp);
 
-  virtual ~MultiGetQueryTraceRecord() override;
+  ~MultiGetQueryTraceRecord() override;
 
   TraceType GetTraceType() const override { return kTraceMultiGet; }
 

--- a/include/rocksdb/trace_record_result.h
+++ b/include/rocksdb/trace_record_result.h
@@ -86,12 +86,12 @@ class StatusOnlyTraceExecutionResult : public TraceExecutionResult {
   StatusOnlyTraceExecutionResult(Status status, uint64_t start_timestamp,
                                  uint64_t end_timestamp, TraceType trace_type);
 
-  virtual ~StatusOnlyTraceExecutionResult() override = default;
+  ~StatusOnlyTraceExecutionResult() override = default;
 
   // Return value of DB::Write(), etc.
   virtual const Status& GetStatus() const;
 
-  virtual Status Accept(Handler* handler) override;
+  Status Accept(Handler* handler) override;
 
  private:
   Status status_;
@@ -109,7 +109,7 @@ class SingleValueTraceExecutionResult : public TraceExecutionResult {
                                   uint64_t start_timestamp,
                                   uint64_t end_timestamp, TraceType trace_type);
 
-  virtual ~SingleValueTraceExecutionResult() override;
+  ~SingleValueTraceExecutionResult() override;
 
   // Return status of DB::Get().
   virtual const Status& GetStatus() const;
@@ -117,7 +117,7 @@ class SingleValueTraceExecutionResult : public TraceExecutionResult {
   // Value for the searched key.
   virtual const std::string& GetValue() const;
 
-  virtual Status Accept(Handler* handler) override;
+  Status Accept(Handler* handler) override;
 
  private:
   Status status_;
@@ -133,7 +133,7 @@ class MultiValuesTraceExecutionResult : public TraceExecutionResult {
                                   uint64_t start_timestamp,
                                   uint64_t end_timestamp, TraceType trace_type);
 
-  virtual ~MultiValuesTraceExecutionResult() override;
+  ~MultiValuesTraceExecutionResult() override;
 
   // Returned Status(es) of DB::MultiGet().
   virtual const std::vector<Status>& GetMultiStatus() const;
@@ -141,7 +141,7 @@ class MultiValuesTraceExecutionResult : public TraceExecutionResult {
   // Returned values for the searched keys.
   virtual const std::vector<std::string>& GetValues() const;
 
-  virtual Status Accept(Handler* handler) override;
+  Status Accept(Handler* handler) override;
 
  private:
   std::vector<Status> multi_status_;
@@ -161,7 +161,7 @@ class IteratorTraceExecutionResult : public TraceExecutionResult {
                                uint64_t start_timestamp, uint64_t end_timestamp,
                                TraceType trace_type);
 
-  virtual ~IteratorTraceExecutionResult() override;
+  ~IteratorTraceExecutionResult() override;
 
   // Return if the Iterator is valid.
   virtual bool GetValid() const;
@@ -175,7 +175,7 @@ class IteratorTraceExecutionResult : public TraceExecutionResult {
   // Value of the current iterating entry, empty if GetValid() is false.
   virtual Slice GetValue() const;
 
-  virtual Status Accept(Handler* handler) override;
+  Status Accept(Handler* handler) override;
 
  private:
   bool valid_;

--- a/include/rocksdb/utilities/env_mirror.h
+++ b/include/rocksdb/utilities/env_mirror.h
@@ -55,8 +55,8 @@ class EnvMirror : public EnvWrapper {
                            const std::string& old_fname,
                            std::unique_ptr<WritableFile>* r,
                            const EnvOptions& options) override;
-  virtual Status NewDirectory(const std::string& name,
-                              std::unique_ptr<Directory>* result) override {
+  Status NewDirectory(const std::string& name,
+                      std::unique_ptr<Directory>* result) override {
     std::unique_ptr<Directory> br;
     Status as = a_->NewDirectory(name, result);
     Status bs = b_->NewDirectory(name, &br);

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -36,49 +36,47 @@ class StackableDB : public DB {
     db_ = nullptr;
   }
 
-  virtual Status Close() override { return db_->Close(); }
+  Status Close() override { return db_->Close(); }
 
   virtual DB* GetBaseDB() { return db_; }
 
-  virtual DB* GetRootDB() override { return db_->GetRootDB(); }
+  DB* GetRootDB() override { return db_->GetRootDB(); }
 
-  virtual Status CreateColumnFamily(const ColumnFamilyOptions& options,
-                                    const std::string& column_family_name,
-                                    ColumnFamilyHandle** handle) override {
+  Status CreateColumnFamily(const ColumnFamilyOptions& options,
+                            const std::string& column_family_name,
+                            ColumnFamilyHandle** handle) override {
     return db_->CreateColumnFamily(options, column_family_name, handle);
   }
 
-  virtual Status CreateColumnFamilies(
+  Status CreateColumnFamilies(
       const ColumnFamilyOptions& options,
       const std::vector<std::string>& column_family_names,
       std::vector<ColumnFamilyHandle*>* handles) override {
     return db_->CreateColumnFamilies(options, column_family_names, handles);
   }
 
-  virtual Status CreateColumnFamilies(
+  Status CreateColumnFamilies(
       const std::vector<ColumnFamilyDescriptor>& column_families,
       std::vector<ColumnFamilyHandle*>* handles) override {
     return db_->CreateColumnFamilies(column_families, handles);
   }
 
-  virtual Status DropColumnFamily(ColumnFamilyHandle* column_family) override {
+  Status DropColumnFamily(ColumnFamilyHandle* column_family) override {
     return db_->DropColumnFamily(column_family);
   }
 
-  virtual Status DropColumnFamilies(
+  Status DropColumnFamilies(
       const std::vector<ColumnFamilyHandle*>& column_families) override {
     return db_->DropColumnFamilies(column_families);
   }
 
-  virtual Status DestroyColumnFamilyHandle(
-      ColumnFamilyHandle* column_family) override {
+  Status DestroyColumnFamilyHandle(ColumnFamilyHandle* column_family) override {
     return db_->DestroyColumnFamilyHandle(column_family);
   }
 
   using DB::Put;
-  virtual Status Put(const WriteOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& val) override {
+  Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, const Slice& val) override {
     return db_->Put(options, column_family, key, val);
   }
   Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
@@ -98,9 +96,8 @@ class StackableDB : public DB {
   }
 
   using DB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override {
+  Status Get(const ReadOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, PinnableSlice* value) override {
     return db_->Get(options, column_family, key, value);
   }
 
@@ -112,18 +109,18 @@ class StackableDB : public DB {
   }
 
   using DB::GetMergeOperands;
-  virtual Status GetMergeOperands(
-      const ReadOptions& options, ColumnFamilyHandle* column_family,
-      const Slice& key, PinnableSlice* slice,
-      GetMergeOperandsOptions* get_merge_operands_options,
-      int* number_of_operands) override {
+  Status GetMergeOperands(const ReadOptions& options,
+                          ColumnFamilyHandle* column_family, const Slice& key,
+                          PinnableSlice* slice,
+                          GetMergeOperandsOptions* get_merge_operands_options,
+                          int* number_of_operands) override {
     return db_->GetMergeOperands(options, column_family, key, slice,
                                  get_merge_operands_options,
                                  number_of_operands);
   }
 
   using DB::MultiGet;
-  virtual std::vector<Status> MultiGet(
+  std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
@@ -131,11 +128,9 @@ class StackableDB : public DB {
     return db_->MultiGet(options, column_family, keys, values);
   }
 
-  virtual void MultiGet(const ReadOptions& options,
-                        ColumnFamilyHandle* column_family,
-                        const size_t num_keys, const Slice* keys,
-                        PinnableSlice* values, Status* statuses,
-                        const bool sorted_input = false) override {
+  void MultiGet(const ReadOptions& options, ColumnFamilyHandle* column_family,
+                const size_t num_keys, const Slice* keys, PinnableSlice* values,
+                Status* statuses, const bool sorted_input = false) override {
     return db_->MultiGet(options, column_family, num_keys, keys, values,
                          statuses, sorted_input);
   }
@@ -159,21 +154,20 @@ class StackableDB : public DB {
   }
 
   using DB::IngestExternalFile;
-  virtual Status IngestExternalFile(
-      ColumnFamilyHandle* column_family,
-      const std::vector<std::string>& external_files,
-      const IngestExternalFileOptions& options) override {
+  Status IngestExternalFile(ColumnFamilyHandle* column_family,
+                            const std::vector<std::string>& external_files,
+                            const IngestExternalFileOptions& options) override {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
   using DB::IngestExternalFiles;
-  virtual Status IngestExternalFiles(
+  Status IngestExternalFiles(
       const std::vector<IngestExternalFileArg>& args) override {
     return db_->IngestExternalFiles(args);
   }
 
   using DB::CreateColumnFamilyWithImport;
-  virtual Status CreateColumnFamilyWithImport(
+  Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
       const ExportImportFilesMetaData& metadata,
@@ -182,7 +176,7 @@ class StackableDB : public DB {
                                              import_options, metadata, handle);
   }
 
-  virtual Status CreateColumnFamilyWithImport(
+  Status CreateColumnFamilyWithImport(
       const ColumnFamilyOptions& options, const std::string& column_family_name,
       const ImportColumnFamilyOptions& import_options,
       const std::vector<const ExportImportFilesMetaData*>& metadatas,
@@ -192,9 +186,9 @@ class StackableDB : public DB {
   }
 
   using DB::ClipColumnFamily;
-  virtual Status ClipColumnFamily(ColumnFamilyHandle* column_family,
-                                  const Slice& begin_key,
-                                  const Slice& end_key) override {
+  Status ClipColumnFamily(ColumnFamilyHandle* column_family,
+                          const Slice& begin_key,
+                          const Slice& end_key) override {
     return db_->ClipColumnFamily(column_family, begin_key, end_key);
   }
 
@@ -203,24 +197,22 @@ class StackableDB : public DB {
     return db_->VerifyFileChecksums(read_opts);
   }
 
-  virtual Status VerifyChecksum() override { return db_->VerifyChecksum(); }
+  Status VerifyChecksum() override { return db_->VerifyChecksum(); }
 
-  virtual Status VerifyChecksum(const ReadOptions& options) override {
+  Status VerifyChecksum(const ReadOptions& options) override {
     return db_->VerifyChecksum(options);
   }
 
   using DB::KeyMayExist;
-  virtual bool KeyMayExist(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           std::string* value,
-                           bool* value_found = nullptr) override {
+  bool KeyMayExist(const ReadOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   std::string* value, bool* value_found = nullptr) override {
     return db_->KeyMayExist(options, column_family, key, value, value_found);
   }
 
   using DB::Delete;
-  virtual Status Delete(const WriteOptions& wopts,
-                        ColumnFamilyHandle* column_family,
-                        const Slice& key) override {
+  Status Delete(const WriteOptions& wopts, ColumnFamilyHandle* column_family,
+                const Slice& key) override {
     return db_->Delete(wopts, column_family, key);
   }
   Status Delete(const WriteOptions& wopts, ColumnFamilyHandle* column_family,
@@ -229,9 +221,9 @@ class StackableDB : public DB {
   }
 
   using DB::SingleDelete;
-  virtual Status SingleDelete(const WriteOptions& wopts,
-                              ColumnFamilyHandle* column_family,
-                              const Slice& key) override {
+  Status SingleDelete(const WriteOptions& wopts,
+                      ColumnFamilyHandle* column_family,
+                      const Slice& key) override {
     return db_->SingleDelete(wopts, column_family, key);
   }
   Status SingleDelete(const WriteOptions& wopts,
@@ -248,9 +240,8 @@ class StackableDB : public DB {
   }
 
   using DB::Merge;
-  virtual Status Merge(const WriteOptions& options,
-                       ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value) override {
+  Status Merge(const WriteOptions& options, ColumnFamilyHandle* column_family,
+               const Slice& key, const Slice& value) override {
     return db_->Merge(options, column_family, key, value);
   }
   Status Merge(const WriteOptions& options, ColumnFamilyHandle* column_family,
@@ -258,78 +249,74 @@ class StackableDB : public DB {
     return db_->Merge(options, column_family, key, ts, value);
   }
 
-  virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override {
+  Status Write(const WriteOptions& opts, WriteBatch* updates) override {
     return db_->Write(opts, updates);
   }
 
   using DB::NewIterator;
-  virtual Iterator* NewIterator(const ReadOptions& opts,
-                                ColumnFamilyHandle* column_family) override {
+  Iterator* NewIterator(const ReadOptions& opts,
+                        ColumnFamilyHandle* column_family) override {
     return db_->NewIterator(opts, column_family);
   }
 
-  virtual Status NewIterators(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      std::vector<Iterator*>* iterators) override {
+  Status NewIterators(const ReadOptions& options,
+                      const std::vector<ColumnFamilyHandle*>& column_families,
+                      std::vector<Iterator*>* iterators) override {
     return db_->NewIterators(options, column_families, iterators);
   }
 
-  virtual const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
+  const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
 
-  virtual void ReleaseSnapshot(const Snapshot* snapshot) override {
+  void ReleaseSnapshot(const Snapshot* snapshot) override {
     return db_->ReleaseSnapshot(snapshot);
   }
 
   using DB::GetMapProperty;
   using DB::GetProperty;
-  virtual bool GetProperty(ColumnFamilyHandle* column_family,
-                           const Slice& property, std::string* value) override {
+  bool GetProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                   std::string* value) override {
     return db_->GetProperty(column_family, property, value);
   }
-  virtual bool GetMapProperty(
-      ColumnFamilyHandle* column_family, const Slice& property,
-      std::map<std::string, std::string>* value) override {
+  bool GetMapProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                      std::map<std::string, std::string>* value) override {
     return db_->GetMapProperty(column_family, property, value);
   }
 
   using DB::GetIntProperty;
-  virtual bool GetIntProperty(ColumnFamilyHandle* column_family,
-                              const Slice& property, uint64_t* value) override {
+  bool GetIntProperty(ColumnFamilyHandle* column_family, const Slice& property,
+                      uint64_t* value) override {
     return db_->GetIntProperty(column_family, property, value);
   }
 
   using DB::GetAggregatedIntProperty;
-  virtual bool GetAggregatedIntProperty(const Slice& property,
-                                        uint64_t* value) override {
+  bool GetAggregatedIntProperty(const Slice& property,
+                                uint64_t* value) override {
     return db_->GetAggregatedIntProperty(property, value);
   }
 
   using DB::GetApproximateSizes;
-  virtual Status GetApproximateSizes(const SizeApproximationOptions& options,
-                                     ColumnFamilyHandle* column_family,
-                                     const Range* r, int n,
-                                     uint64_t* sizes) override {
+  Status GetApproximateSizes(const SizeApproximationOptions& options,
+                             ColumnFamilyHandle* column_family, const Range* r,
+                             int n, uint64_t* sizes) override {
     return db_->GetApproximateSizes(options, column_family, r, n, sizes);
   }
 
   using DB::GetApproximateMemTableStats;
-  virtual void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
-                                           const Range& range,
-                                           uint64_t* const count,
-                                           uint64_t* const size) override {
+  void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
+                                   const Range& range, uint64_t* const count,
+                                   uint64_t* const size) override {
     return db_->GetApproximateMemTableStats(column_family, range, count, size);
   }
 
   using DB::CompactRange;
-  virtual Status CompactRange(const CompactRangeOptions& options,
-                              ColumnFamilyHandle* column_family,
-                              const Slice* begin, const Slice* end) override {
+  Status CompactRange(const CompactRangeOptions& options,
+                      ColumnFamilyHandle* column_family, const Slice* begin,
+                      const Slice* end) override {
     return db_->CompactRange(options, column_family, begin, end);
   }
 
   using DB::CompactFiles;
-  virtual Status CompactFiles(
+  Status CompactFiles(
       const CompactionOptions& compact_options,
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names, const int output_level,
@@ -341,111 +328,98 @@ class StackableDB : public DB {
                              compaction_job_info);
   }
 
-  virtual Status PauseBackgroundWork() override {
-    return db_->PauseBackgroundWork();
-  }
-  virtual Status ContinueBackgroundWork() override {
+  Status PauseBackgroundWork() override { return db_->PauseBackgroundWork(); }
+  Status ContinueBackgroundWork() override {
     return db_->ContinueBackgroundWork();
   }
 
-  virtual Status EnableAutoCompaction(
+  Status EnableAutoCompaction(
       const std::vector<ColumnFamilyHandle*>& column_family_handles) override {
     return db_->EnableAutoCompaction(column_family_handles);
   }
 
-  virtual void EnableManualCompaction() override {
+  void EnableManualCompaction() override {
     return db_->EnableManualCompaction();
   }
-  virtual void DisableManualCompaction() override {
+  void DisableManualCompaction() override {
     return db_->DisableManualCompaction();
   }
 
-  virtual Status WaitForCompact(
+  Status WaitForCompact(
       const WaitForCompactOptions& wait_for_compact_options) override {
     return db_->WaitForCompact(wait_for_compact_options);
   }
 
   using DB::NumberLevels;
-  virtual int NumberLevels(ColumnFamilyHandle* column_family) override {
+  int NumberLevels(ColumnFamilyHandle* column_family) override {
     return db_->NumberLevels(column_family);
   }
 
   using DB::MaxMemCompactionLevel;
-  virtual int MaxMemCompactionLevel(
-      ColumnFamilyHandle* column_family) override {
+  int MaxMemCompactionLevel(ColumnFamilyHandle* column_family) override {
     return db_->MaxMemCompactionLevel(column_family);
   }
 
   using DB::Level0StopWriteTrigger;
-  virtual int Level0StopWriteTrigger(
-      ColumnFamilyHandle* column_family) override {
+  int Level0StopWriteTrigger(ColumnFamilyHandle* column_family) override {
     return db_->Level0StopWriteTrigger(column_family);
   }
 
-  virtual const std::string& GetName() const override { return db_->GetName(); }
+  const std::string& GetName() const override { return db_->GetName(); }
 
-  virtual Env* GetEnv() const override { return db_->GetEnv(); }
+  Env* GetEnv() const override { return db_->GetEnv(); }
 
-  virtual FileSystem* GetFileSystem() const override {
-    return db_->GetFileSystem();
-  }
+  FileSystem* GetFileSystem() const override { return db_->GetFileSystem(); }
 
   using DB::GetOptions;
-  virtual Options GetOptions(ColumnFamilyHandle* column_family) const override {
+  Options GetOptions(ColumnFamilyHandle* column_family) const override {
     return db_->GetOptions(column_family);
   }
 
   using DB::GetDBOptions;
-  virtual DBOptions GetDBOptions() const override {
-    return db_->GetDBOptions();
-  }
+  DBOptions GetDBOptions() const override { return db_->GetDBOptions(); }
 
   using DB::Flush;
-  virtual Status Flush(const FlushOptions& fopts,
-                       ColumnFamilyHandle* column_family) override {
+  Status Flush(const FlushOptions& fopts,
+               ColumnFamilyHandle* column_family) override {
     return db_->Flush(fopts, column_family);
   }
-  virtual Status Flush(
+  Status Flush(
       const FlushOptions& fopts,
       const std::vector<ColumnFamilyHandle*>& column_families) override {
     return db_->Flush(fopts, column_families);
   }
 
-  virtual Status SyncWAL() override { return db_->SyncWAL(); }
+  Status SyncWAL() override { return db_->SyncWAL(); }
 
-  virtual Status FlushWAL(bool sync) override { return db_->FlushWAL(sync); }
+  Status FlushWAL(bool sync) override { return db_->FlushWAL(sync); }
 
-  virtual Status LockWAL() override { return db_->LockWAL(); }
+  Status LockWAL() override { return db_->LockWAL(); }
 
-  virtual Status UnlockWAL() override { return db_->UnlockWAL(); }
+  Status UnlockWAL() override { return db_->UnlockWAL(); }
 
+  Status DisableFileDeletions() override { return db_->DisableFileDeletions(); }
 
-  virtual Status DisableFileDeletions() override {
-    return db_->DisableFileDeletions();
-  }
-
-  virtual Status EnableFileDeletions(bool force) override {
+  Status EnableFileDeletions(bool force) override {
     return db_->EnableFileDeletions(force);
   }
 
-  virtual void GetLiveFilesMetaData(
-      std::vector<LiveFileMetaData>* metadata) override {
+  void GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) override {
     db_->GetLiveFilesMetaData(metadata);
   }
 
-  virtual Status GetLiveFilesChecksumInfo(
-      FileChecksumList* checksum_list) override {
+  Status GetLiveFilesChecksumInfo(FileChecksumList* checksum_list) override {
     return db_->GetLiveFilesChecksumInfo(checksum_list);
   }
 
-  virtual Status GetLiveFilesStorageInfo(
+  Status GetLiveFilesStorageInfo(
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) override {
     return db_->GetLiveFilesStorageInfo(opts, files);
   }
 
-  virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
-                                       ColumnFamilyMetaData* cf_meta) override {
+  void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
+                               ColumnFamilyMetaData* cf_meta) override {
     db_->GetColumnFamilyMetaData(column_family, cf_meta);
   }
 
@@ -490,13 +464,12 @@ class StackableDB : public DB {
     return db_->NewDefaultReplayer(handles, std::move(reader), replayer);
   }
 
-
-  virtual Status GetLiveFiles(std::vector<std::string>& vec, uint64_t* mfs,
-                              bool flush_memtable = true) override {
+  Status GetLiveFiles(std::vector<std::string>& vec, uint64_t* mfs,
+                      bool flush_memtable = true) override {
     return db_->GetLiveFiles(vec, mfs, flush_memtable);
   }
 
-  virtual SequenceNumber GetLatestSequenceNumber() const override {
+  SequenceNumber GetLatestSequenceNumber() const override {
     return db_->GetLatestSequenceNumber();
   }
 
@@ -510,16 +483,16 @@ class StackableDB : public DB {
     return db_->GetFullHistoryTsLow(column_family, ts_low);
   }
 
-  virtual Status GetSortedWalFiles(VectorLogPtr& files) override {
+  Status GetSortedWalFiles(VectorLogPtr& files) override {
     return db_->GetSortedWalFiles(files);
   }
 
-  virtual Status GetCurrentWalFile(
+  Status GetCurrentWalFile(
       std::unique_ptr<LogFile>* current_log_file) override {
     return db_->GetCurrentWalFile(current_log_file);
   }
 
-  virtual Status GetCreationTimeOfOldestFile(uint64_t* creation_time) override {
+  Status GetCreationTimeOfOldestFile(uint64_t* creation_time) override {
     return db_->GetCreationTimeOfOldestFile(creation_time);
   }
 
@@ -530,66 +503,61 @@ class StackableDB : public DB {
   // do not plan to maintain it, the contract will likely remain underspecified
   // until its removal. Any user is encouraged to read the implementation
   // carefully and migrate away from it when possible.
-  virtual Status DeleteFile(std::string name) override {
-    return db_->DeleteFile(name);
-  }
+  Status DeleteFile(std::string name) override { return db_->DeleteFile(name); }
 
-  virtual Status GetDbIdentity(std::string& identity) const override {
+  Status GetDbIdentity(std::string& identity) const override {
     return db_->GetDbIdentity(identity);
   }
 
-  virtual Status GetDbSessionId(std::string& session_id) const override {
+  Status GetDbSessionId(std::string& session_id) const override {
     return db_->GetDbSessionId(session_id);
   }
 
   using DB::SetOptions;
-  virtual Status SetOptions(ColumnFamilyHandle* column_family_handle,
-                            const std::unordered_map<std::string, std::string>&
-                                new_options) override {
+  Status SetOptions(ColumnFamilyHandle* column_family_handle,
+                    const std::unordered_map<std::string, std::string>&
+                        new_options) override {
     return db_->SetOptions(column_family_handle, new_options);
   }
 
-  virtual Status SetDBOptions(
-      const std::unordered_map<std::string, std::string>& new_options)
-      override {
+  Status SetDBOptions(const std::unordered_map<std::string, std::string>&
+                          new_options) override {
     return db_->SetDBOptions(new_options);
   }
 
   using DB::ResetStats;
-  virtual Status ResetStats() override { return db_->ResetStats(); }
+  Status ResetStats() override { return db_->ResetStats(); }
 
   using DB::GetPropertiesOfAllTables;
-  virtual Status GetPropertiesOfAllTables(
-      ColumnFamilyHandle* column_family,
-      TablePropertiesCollection* props) override {
+  Status GetPropertiesOfAllTables(ColumnFamilyHandle* column_family,
+                                  TablePropertiesCollection* props) override {
     return db_->GetPropertiesOfAllTables(column_family, props);
   }
 
   using DB::GetPropertiesOfTablesInRange;
-  virtual Status GetPropertiesOfTablesInRange(
+  Status GetPropertiesOfTablesInRange(
       ColumnFamilyHandle* column_family, const Range* range, std::size_t n,
       TablePropertiesCollection* props) override {
     return db_->GetPropertiesOfTablesInRange(column_family, range, n, props);
   }
 
-  virtual Status GetUpdatesSince(
+  Status GetUpdatesSince(
       SequenceNumber seq_number, std::unique_ptr<TransactionLogIterator>* iter,
       const TransactionLogIterator::ReadOptions& read_options) override {
     return db_->GetUpdatesSince(seq_number, iter, read_options);
   }
 
-  virtual Status SuggestCompactRange(ColumnFamilyHandle* column_family,
-                                     const Slice* begin,
-                                     const Slice* end) override {
+  Status SuggestCompactRange(ColumnFamilyHandle* column_family,
+                             const Slice* begin, const Slice* end) override {
     return db_->SuggestCompactRange(column_family, begin, end);
   }
 
-  virtual Status PromoteL0(ColumnFamilyHandle* column_family,
-                           int target_level) override {
+  Status PromoteL0(ColumnFamilyHandle* column_family,
+                   int target_level) override {
     return db_->PromoteL0(column_family, target_level);
   }
 
-  virtual ColumnFamilyHandle* DefaultColumnFamily() const override {
+  ColumnFamilyHandle* DefaultColumnFamily() const override {
     return db_->DefaultColumnFamily();
   }
 
@@ -597,7 +565,7 @@ class StackableDB : public DB {
     return db_->TryCatchUpWithPrimary();
   }
 
-  virtual Status Resume() override { return db_->Resume(); }
+  Status Resume() override { return db_->Resume(); }
 
  protected:
   DB* db_;

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -390,8 +390,8 @@ class TransactionDB : public StackableDB {
   // WRITE_PREPARED or WRITE_UNPREPARED , `skip_duplicate_key_check` must
   // additionally be set.
   using StackableDB::DeleteRange;
-  virtual Status DeleteRange(const WriteOptions&, ColumnFamilyHandle*,
-                             const Slice&, const Slice&) override {
+  Status DeleteRange(const WriteOptions&, ColumnFamilyHandle*, const Slice&,
+                     const Slice&) override {
     return Status::NotSupported();
   }
   // Open a TransactionDB similar to DB::Open().

--- a/include/rocksdb/wal_filter.h
+++ b/include/rocksdb/wal_filter.h
@@ -105,7 +105,7 @@ class WalFilter : public Customizable {
 
   // Returns a name that identifies this WAL filter.
   // The name will be printed to LOG file on start up for diagnosis.
-  virtual const char* Name() const override = 0;
+  const char* Name() const override = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/java/rocksjni/statisticsjni.h
+++ b/java/rocksjni/statisticsjni.h
@@ -23,7 +23,7 @@ class StatisticsJni : public StatisticsImpl {
   StatisticsJni(std::shared_ptr<Statistics> stats);
   StatisticsJni(std::shared_ptr<Statistics> stats,
                 const std::set<uint32_t> ignore_histograms);
-  virtual bool HistEnabledForType(uint32_t type) const override;
+  bool HistEnabledForType(uint32_t type) const override;
 
  private:
   const std::set<uint32_t> m_ignore_histograms;

--- a/logging/auto_roll_logger.h
+++ b/logging/auto_roll_logger.h
@@ -36,7 +36,7 @@ class AutoRollLogger : public Logger {
 
   // Write a header entry to the log. All header information will be written
   // again every time the log rolls over.
-  virtual void LogHeader(const char* format, va_list ap) override;
+  void LogHeader(const char* format, va_list ap) override;
 
   // check if the logger has encountered any problem.
   Status GetStatus() { return status_; }
@@ -106,7 +106,7 @@ class AutoRollLogger : public Logger {
 
  protected:
   // Implementation of Close()
-  virtual Status CloseImpl() override {
+  Status CloseImpl() override {
     if (logger_) {
       return logger_->Close();
     } else {

--- a/memtable/hash_linklist_rep.cc
+++ b/memtable/hash_linklist_rep.cc
@@ -887,14 +887,15 @@ class HashLinkListRepFactory : public MemTableRepFactory {
   }
 
   using MemTableRepFactory::CreateMemTableRep;
-  virtual MemTableRep* CreateMemTableRep(
-      const MemTableRep::KeyComparator& compare, Allocator* allocator,
-      const SliceTransform* transform, Logger* logger) override;
+  MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator& compare,
+                                 Allocator* allocator,
+                                 const SliceTransform* transform,
+                                 Logger* logger) override;
 
   static const char* kClassName() { return "HashLinkListRepFactory"; }
   static const char* kNickName() { return "hash_linkedlist"; }
-  virtual const char* Name() const override { return kClassName(); }
-  virtual const char* NickName() const override { return kNickName(); }
+  const char* Name() const override { return kClassName(); }
+  const char* NickName() const override { return kNickName(); }
 
  private:
   HashLinkListRepOptions options_;

--- a/memtable/hash_skiplist_rep.cc
+++ b/memtable/hash_skiplist_rep.cc
@@ -357,15 +357,16 @@ class HashSkipListRepFactory : public MemTableRepFactory {
   }
 
   using MemTableRepFactory::CreateMemTableRep;
-  virtual MemTableRep* CreateMemTableRep(
-      const MemTableRep::KeyComparator& compare, Allocator* allocator,
-      const SliceTransform* transform, Logger* logger) override;
+  MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator& compare,
+                                 Allocator* allocator,
+                                 const SliceTransform* transform,
+                                 Logger* logger) override;
 
   static const char* kClassName() { return "HashSkipListRepFactory"; }
   static const char* kNickName() { return "prefix_hash"; }
 
-  virtual const char* Name() const override { return kClassName(); }
-  virtual const char* NickName() const override { return kNickName(); }
+  const char* Name() const override { return kClassName(); }
+  const char* NickName() const override { return kNickName(); }
 
  private:
   HashSkipListRepOptions options_;

--- a/monitoring/histogram.h
+++ b/monitoring/histogram.h
@@ -114,22 +114,22 @@ class HistogramImpl : public Histogram {
   HistogramImpl(const HistogramImpl&) = delete;
   HistogramImpl& operator=(const HistogramImpl&) = delete;
 
-  virtual void Clear() override;
-  virtual bool Empty() const override;
-  virtual void Add(uint64_t value) override;
-  virtual void Merge(const Histogram& other) override;
+  void Clear() override;
+  bool Empty() const override;
+  void Add(uint64_t value) override;
+  void Merge(const Histogram& other) override;
   void Merge(const HistogramImpl& other);
 
-  virtual std::string ToString() const override;
-  virtual const char* Name() const override { return "HistogramImpl"; }
-  virtual uint64_t min() const override { return stats_.min(); }
-  virtual uint64_t max() const override { return stats_.max(); }
-  virtual uint64_t num() const override { return stats_.num(); }
-  virtual double Median() const override;
-  virtual double Percentile(double p) const override;
-  virtual double Average() const override;
-  virtual double StandardDeviation() const override;
-  virtual void Data(HistogramData* const data) const override;
+  std::string ToString() const override;
+  const char* Name() const override { return "HistogramImpl"; }
+  uint64_t min() const override { return stats_.min(); }
+  uint64_t max() const override { return stats_.max(); }
+  uint64_t num() const override { return stats_.num(); }
+  double Median() const override;
+  double Percentile(double p) const override;
+  double Average() const override;
+  double StandardDeviation() const override;
+  void Data(HistogramData* const data) const override;
 
   virtual ~HistogramImpl() {}
 

--- a/monitoring/histogram_windowing.h
+++ b/monitoring/histogram_windowing.h
@@ -25,22 +25,22 @@ class HistogramWindowingImpl : public Histogram {
 
   ~HistogramWindowingImpl();
 
-  virtual void Clear() override;
-  virtual bool Empty() const override;
-  virtual void Add(uint64_t value) override;
-  virtual void Merge(const Histogram& other) override;
+  void Clear() override;
+  bool Empty() const override;
+  void Add(uint64_t value) override;
+  void Merge(const Histogram& other) override;
   void Merge(const HistogramWindowingImpl& other);
 
-  virtual std::string ToString() const override;
-  virtual const char* Name() const override { return "HistogramWindowingImpl"; }
-  virtual uint64_t min() const override { return stats_.min(); }
-  virtual uint64_t max() const override { return stats_.max(); }
-  virtual uint64_t num() const override { return stats_.num(); }
-  virtual double Median() const override;
-  virtual double Percentile(double p) const override;
-  virtual double Average() const override;
-  virtual double StandardDeviation() const override;
-  virtual void Data(HistogramData* const data) const override;
+  std::string ToString() const override;
+  const char* Name() const override { return "HistogramWindowingImpl"; }
+  uint64_t min() const override { return stats_.min(); }
+  uint64_t max() const override { return stats_.max(); }
+  uint64_t num() const override { return stats_.num(); }
+  double Median() const override;
+  double Percentile(double p) const override;
+  double Average() const override;
+  double StandardDeviation() const override;
+  void Data(HistogramData* const data) const override;
 
 #ifndef NDEBUG
   void TEST_UpdateClock(const std::shared_ptr<SystemClock>& clock) {

--- a/monitoring/statistics_impl.h
+++ b/monitoring/statistics_impl.h
@@ -46,14 +46,14 @@ class StatisticsImpl : public Statistics {
   const char* Name() const override { return kClassName(); }
   static const char* kClassName() { return "BasicStatistics"; }
 
-  virtual uint64_t getTickerCount(uint32_t ticker_type) const override;
-  virtual void histogramData(uint32_t histogram_type,
-                             HistogramData* const data) const override;
+  uint64_t getTickerCount(uint32_t ticker_type) const override;
+  void histogramData(uint32_t histogram_type,
+                     HistogramData* const data) const override;
   std::string getHistogramString(uint32_t histogram_type) const override;
 
-  virtual void setTickerCount(uint32_t ticker_type, uint64_t count) override;
-  virtual uint64_t getAndResetTickerCount(uint32_t ticker_type) override;
-  virtual void recordTick(uint32_t ticker_type, uint64_t count) override;
+  void setTickerCount(uint32_t ticker_type, uint64_t count) override;
+  uint64_t getAndResetTickerCount(uint32_t ticker_type) override;
+  void recordTick(uint32_t ticker_type, uint64_t count) override;
   // The function is implemented for now for backward compatibility reason.
   // In case a user explictly calls it, for example, they may have a wrapped
   // Statistics object, passing the call to recordTick() into here, nothing
@@ -61,13 +61,12 @@ class StatisticsImpl : public Statistics {
   void measureTime(uint32_t histogramType, uint64_t time) override {
     recordInHistogram(histogramType, time);
   }
-  virtual void recordInHistogram(uint32_t histogram_type,
-                                 uint64_t value) override;
+  void recordInHistogram(uint32_t histogram_type, uint64_t value) override;
 
-  virtual Status Reset() override;
-  virtual std::string ToString() const override;
-  virtual bool getTickerMap(std::map<std::string, uint64_t>*) const override;
-  virtual bool HistEnabledForType(uint32_t type) const override;
+  Status Reset() override;
+  std::string ToString() const override;
+  bool getTickerMap(std::map<std::string, uint64_t>*) const override;
+  bool HistEnabledForType(uint32_t type) const override;
 
   const Customizable* Inner() const override { return stats_.get(); }
 

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -855,7 +855,7 @@ class ConfigurableCFOptions : public ConfigurableMutableCFOptions {
     return s;
   }
 
-  virtual const void* GetOptionsPtr(const std::string& name) const override {
+  const void* GetOptionsPtr(const std::string& name) const override {
     if (name == OptionsHelper::kCFOptionsName) {
       return &cf_options_;
     } else {

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -125,9 +125,7 @@ class WinSequentialFile : protected WinFileData, public FSSequentialFile {
 
   IOStatus InvalidateCache(size_t offset, size_t length) override;
 
-  virtual bool use_direct_io() const override {
-    return WinFileData::use_direct_io();
-  }
+  bool use_direct_io() const override { return WinFileData::use_direct_io(); }
 };
 
 // mmap() based random-access
@@ -151,9 +149,9 @@ class WinMmapReadableFile : private WinFileData, public FSRandomAccessFile {
                 Slice* result, char* scratch,
                 IODebugContext* dbg) const override;
 
-  virtual IOStatus InvalidateCache(size_t offset, size_t length) override;
+  IOStatus InvalidateCache(size_t offset, size_t length) override;
 
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
+  size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 // We preallocate and use memcpy to append new
@@ -243,7 +241,7 @@ class WinMmapFile : private WinFileData, public FSWritableFile {
   IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& options,
                     IODebugContext* dbg) override;
 
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
+  size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomAccessImpl {
@@ -287,15 +285,13 @@ class WinRandomAccessFile
                 Slice* result, char* scratch,
                 IODebugContext* dbg) const override;
 
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
+  size_t GetUniqueId(char* id, size_t max_size) const override;
 
-  virtual bool use_direct_io() const override {
-    return WinFileData::use_direct_io();
-  }
+  bool use_direct_io() const override { return WinFileData::use_direct_io(); }
 
   IOStatus InvalidateCache(size_t offset, size_t length) override;
 
-  virtual size_t GetRequiredBufferAlignment() const override;
+  size_t GetRequiredBufferAlignment() const override;
 };
 
 // This is a sequential write class. It has been mimicked (as others) after
@@ -399,20 +395,20 @@ class WinWritableFile : private WinFileData,
 
   IOStatus Fsync(const IOOptions& options, IODebugContext* dbg) override;
 
-  virtual bool IsSyncThreadSafe() const override;
+  bool IsSyncThreadSafe() const override;
 
   // Indicates if the class makes use of direct I/O
   // Use PositionedAppend
-  virtual bool use_direct_io() const override;
+  bool use_direct_io() const override;
 
-  virtual size_t GetRequiredBufferAlignment() const override;
+  size_t GetRequiredBufferAlignment() const override;
 
   uint64_t GetFileSize(const IOOptions& options, IODebugContext* dbg) override;
 
   IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& options,
                     IODebugContext* dbg) override;
 
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
+  size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomRWFile : private WinFileData,
@@ -427,11 +423,11 @@ class WinRandomRWFile : private WinFileData,
 
   // Indicates if the class makes use of direct I/O
   // If false you must pass aligned buffer to Write()
-  virtual bool use_direct_io() const override;
+  bool use_direct_io() const override;
 
   // Use the returned alignment value to allocate aligned
   // buffer for Write() when use_direct_io() returns true
-  virtual size_t GetRequiredBufferAlignment() const override;
+  size_t GetRequiredBufferAlignment() const override;
 
   // Write bytes in `data` at  offset `offset`, Returns Status::OK() on success.
   // Pass aligned buffer when use_direct_io() returns true.

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -340,7 +340,7 @@ class BlockIter : public InternalIteratorBase<TValue> {
     return current_ < restarts_;
   }
 
-  virtual void SeekToFirst() override final {
+  void SeekToFirst() override final {
 #ifndef NDEBUG
     if (TEST_Corrupt_Callback("BlockIter::SeekToFirst")) return;
 #endif
@@ -348,33 +348,33 @@ class BlockIter : public InternalIteratorBase<TValue> {
     UpdateKey();
   }
 
-  virtual void SeekToLast() override final {
+  void SeekToLast() override final {
     SeekToLastImpl();
     UpdateKey();
   }
 
-  virtual void Seek(const Slice& target) override final {
+  void Seek(const Slice& target) override final {
     SeekImpl(target);
     UpdateKey();
   }
 
-  virtual void SeekForPrev(const Slice& target) override final {
+  void SeekForPrev(const Slice& target) override final {
     SeekForPrevImpl(target);
     UpdateKey();
   }
 
-  virtual void Next() override final {
+  void Next() override final {
     NextImpl();
     UpdateKey();
   }
 
-  virtual bool NextAndGetResult(IterateResult* result) override final {
+  bool NextAndGetResult(IterateResult* result) override final {
     // This does not need to call `UpdateKey()` as the parent class only has
     // access to the `UpdateKey()`-invoking functions.
     return InternalIteratorBase<TValue>::NextAndGetResult(result);
   }
 
-  virtual void Prev() override final {
+  void Prev() override final {
     PrevImpl();
     UpdateKey();
   }

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -225,9 +225,9 @@ class BlockBasedTableBuilder::BlockBasedTablePropertiesCollector
     return Status::OK();
   }
 
-  virtual void BlockAdd(uint64_t /* block_uncomp_bytes */,
-                        uint64_t /* block_compressed_bytes_fast */,
-                        uint64_t /* block_compressed_bytes_slow */) override {
+  void BlockAdd(uint64_t /* block_uncomp_bytes */,
+                uint64_t /* block_compressed_bytes_fast */,
+                uint64_t /* block_compressed_bytes_slow */) override {
     // Intentionally left blank. No interest in collecting stats for
     // blocks.
   }

--- a/table/block_based/filter_policy.cc
+++ b/table/block_based/filter_policy.cc
@@ -74,7 +74,7 @@ class XXPH3FilterBitsBuilder : public BuiltinFilterBitsBuilder {
 
   ~XXPH3FilterBitsBuilder() override = default;
 
-  virtual void AddKey(const Slice& key) override {
+  void AddKey(const Slice& key) override {
     uint64_t hash = GetSliceHash64(key);
     // Especially with prefixes, it is common to have repetition,
     // though only adjacent repetition, which we want to immediately
@@ -100,11 +100,11 @@ class XXPH3FilterBitsBuilder : public BuiltinFilterBitsBuilder {
     }
   }
 
-  virtual size_t EstimateEntriesAdded() override {
+  size_t EstimateEntriesAdded() override {
     return hash_entries_info_.entries.size();
   }
 
-  virtual Status MaybePostVerify(const Slice& filter_content) override;
+  Status MaybePostVerify(const Slice& filter_content) override;
 
  protected:
   static constexpr uint32_t kMetadataLen = 5;
@@ -325,12 +325,11 @@ class FastLocalBloomBitsBuilder : public XXPH3FilterBitsBuilder {
 
   using FilterBitsBuilder::Finish;
 
-  virtual Slice Finish(std::unique_ptr<const char[]>* buf) override {
+  Slice Finish(std::unique_ptr<const char[]>* buf) override {
     return Finish(buf, nullptr);
   }
 
-  virtual Slice Finish(std::unique_ptr<const char[]>* buf,
-                       Status* status) override {
+  Slice Finish(std::unique_ptr<const char[]>* buf, Status* status) override {
     size_t num_entries = hash_entries_info_.entries.size();
     size_t len_with_metadata = CalculateSpace(num_entries);
 
@@ -536,7 +535,7 @@ class FastLocalBloomBitsReader : public BuiltinFilterBitsReader {
                                                     data_ + byte_offset);
   }
 
-  virtual void MayMatch(int num_keys, Slice** keys, bool* may_match) override {
+  void MayMatch(int num_keys, Slice** keys, bool* may_match) override {
     std::array<uint32_t, MultiGetContext::MAX_BATCH_SIZE> hashes;
     std::array<uint32_t, MultiGetContext::MAX_BATCH_SIZE> byte_offsets;
     for (int i = 0; i < num_keys; ++i) {
@@ -610,12 +609,11 @@ class Standard128RibbonBitsBuilder : public XXPH3FilterBitsBuilder {
 
   using FilterBitsBuilder::Finish;
 
-  virtual Slice Finish(std::unique_ptr<const char[]>* buf) override {
+  Slice Finish(std::unique_ptr<const char[]>* buf) override {
     return Finish(buf, nullptr);
   }
 
-  virtual Slice Finish(std::unique_ptr<const char[]>* buf,
-                       Status* status) override {
+  Slice Finish(std::unique_ptr<const char[]>* buf, Status* status) override {
     if (hash_entries_info_.entries.size() > kMaxRibbonEntries) {
       ROCKS_LOG_WARN(
           info_log_, "Too many keys for Ribbon filter: %llu",
@@ -974,7 +972,7 @@ class Standard128RibbonBitsReader : public BuiltinFilterBitsReader {
     return soln_.FilterQuery(h, hasher_);
   }
 
-  virtual void MayMatch(int num_keys, Slice** keys, bool* may_match) override {
+  void MayMatch(int num_keys, Slice** keys, bool* may_match) override {
     struct SavedData {
       uint64_t seeded_hash;
       uint32_t segment_num;
@@ -1020,9 +1018,7 @@ class LegacyBloomBitsBuilder : public BuiltinFilterBitsBuilder {
 
   void AddKey(const Slice& key) override;
 
-  virtual size_t EstimateEntriesAdded() override {
-    return hash_entries_.size();
-  }
+  size_t EstimateEntriesAdded() override { return hash_entries_.size(); }
 
   using FilterBitsBuilder::Finish;
 
@@ -1236,7 +1232,7 @@ class LegacyBloomBitsReader : public BuiltinFilterBitsReader {
         hash, num_probes_, data_ + byte_offset, log2_cache_line_size_);
   }
 
-  virtual void MayMatch(int num_keys, Slice** keys, bool* may_match) override {
+  void MayMatch(int num_keys, Slice** keys, bool* may_match) override {
     std::array<uint32_t, MultiGetContext::MAX_BATCH_SIZE> hashes;
     std::array<uint32_t, MultiGetContext::MAX_BATCH_SIZE> byte_offsets;
     for (int i = 0; i < num_keys; ++i) {

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -49,19 +49,16 @@ class FullFilterBlockBuilder : public FilterBlockBuilder {
   // directly. and be deleted here
   ~FullFilterBlockBuilder() {}
 
-  virtual void Add(const Slice& key_without_ts) override;
-  virtual bool IsEmpty() const override { return !any_added_; }
-  virtual size_t EstimateEntriesAdded() override;
-  virtual Slice Finish(
-      const BlockHandle& tmp, Status* status,
-      std::unique_ptr<const char[]>* filter_data = nullptr) override;
+  void Add(const Slice& key_without_ts) override;
+  bool IsEmpty() const override { return !any_added_; }
+  size_t EstimateEntriesAdded() override;
+  Slice Finish(const BlockHandle& tmp, Status* status,
+               std::unique_ptr<const char[]>* filter_data = nullptr) override;
   using FilterBlockBuilder::Finish;
 
-  virtual void ResetFilterBitsBuilder() override {
-    filter_bits_builder_.reset();
-  }
+  void ResetFilterBitsBuilder() override { filter_bits_builder_.reset(); }
 
-  virtual Status MaybePostVerifyFilter(const Slice& filter_content) override {
+  Status MaybePostVerifyFilter(const Slice& filter_content) override {
     return filter_bits_builder_->MaybePostVerify(filter_content);
   }
 

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -40,11 +40,10 @@ class PartitionedFilterBlockBuilder : public FullFilterBlockBuilder {
   void Add(const Slice& key) override;
   size_t EstimateEntriesAdded() override;
 
-  virtual Slice Finish(
-      const BlockHandle& last_partition_block_handle, Status* status,
-      std::unique_ptr<const char[]>* filter_data = nullptr) override;
+  Slice Finish(const BlockHandle& last_partition_block_handle, Status* status,
+               std::unique_ptr<const char[]>* filter_data = nullptr) override;
 
-  virtual void ResetFilterBitsBuilder() override {
+  void ResetFilterBitsBuilder() override {
     // Previously constructed partitioned filters by
     // this to-be-reset FiterBitsBuilder can also be
     // cleared
@@ -56,8 +55,7 @@ class PartitionedFilterBlockBuilder : public FullFilterBlockBuilder {
   // as part of PartitionFilterBlockBuilder::Finish
   // to avoid implementation complexity of doing it elsewhere.
   // Therefore we are skipping it in here.
-  virtual Status MaybePostVerifyFilter(
-      const Slice& /* filter_content */) override {
+  Status MaybePostVerifyFilter(const Slice& /* filter_content */) override {
     return Status::OK();
   }
 

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -67,9 +67,7 @@ class MockTableFactory : public TableFactory {
   Status CreateMockTable(Env* env, const std::string& fname,
                          KVVector file_contents);
 
-  virtual std::string GetPrintableOptions() const override {
-    return std::string();
-  }
+  std::string GetPrintableOptions() const override { return std::string(); }
 
   void SetCorruptionMode(MockCorruptionMode mode) { corrupt_mode_ = mode; }
 

--- a/table/plain/plain_table_reader.h
+++ b/table/plain/plain_table_reader.h
@@ -106,7 +106,7 @@ class PlainTableReader : public TableReader {
     return table_properties_;
   }
 
-  virtual size_t ApproximateMemoryUsage() const override {
+  size_t ApproximateMemoryUsage() const override {
     return arena_.MemoryAllocatedBytes();
   }
 

--- a/table/sst_file_writer_collectors.h
+++ b/table/sst_file_writer_collectors.h
@@ -29,22 +29,22 @@ class SstFileWriterPropertiesCollector : public IntTblPropCollector {
                                             SequenceNumber global_seqno)
       : version_(version), global_seqno_(global_seqno) {}
 
-  virtual Status InternalAdd(const Slice& /*key*/, const Slice& /*value*/,
-                             uint64_t /*file_size*/) override {
+  Status InternalAdd(const Slice& /*key*/, const Slice& /*value*/,
+                     uint64_t /*file_size*/) override {
     // Intentionally left blank. Have no interest in collecting stats for
     // individual key/value pairs.
     return Status::OK();
   }
 
-  virtual void BlockAdd(uint64_t /* block_uncomp_bytes */,
-                        uint64_t /* block_compressed_bytes_fast */,
-                        uint64_t /* block_compressed_bytes_slow */) override {
+  void BlockAdd(uint64_t /* block_uncomp_bytes */,
+                uint64_t /* block_compressed_bytes_fast */,
+                uint64_t /* block_compressed_bytes_slow */) override {
     // Intentionally left blank. No interest in collecting stats for
     // blocks.
     return;
   }
 
-  virtual Status Finish(UserCollectedProperties* properties) override {
+  Status Finish(UserCollectedProperties* properties) override {
     // File version
     std::string version_val;
     PutFixed32(&version_val, static_cast<uint32_t>(version_));
@@ -58,11 +58,11 @@ class SstFileWriterPropertiesCollector : public IntTblPropCollector {
     return Status::OK();
   }
 
-  virtual const char* Name() const override {
+  const char* Name() const override {
     return "SstFileWriterPropertiesCollector";
   }
 
-  virtual UserCollectedProperties GetReadableProperties() const override {
+  UserCollectedProperties GetReadableProperties() const override {
     return {{ExternalSstFilePropertyNames::kVersion, std::to_string(version_)}};
   }
 
@@ -78,12 +78,12 @@ class SstFileWriterPropertiesCollectorFactory
                                                    SequenceNumber global_seqno)
       : version_(version), global_seqno_(global_seqno) {}
 
-  virtual IntTblPropCollector* CreateIntTblPropCollector(
+  IntTblPropCollector* CreateIntTblPropCollector(
       uint32_t /*column_family_id*/, int /* level_at_creation */) override {
     return new SstFileWriterPropertiesCollector(version_, global_seqno_);
   }
 
-  virtual const char* Name() const override {
+  const char* Name() const override {
     return "SstFileWriterPropertiesCollector";
   }
 

--- a/test_util/mock_time_env.h
+++ b/test_util/mock_time_env.h
@@ -26,7 +26,7 @@ class MockSystemClock : public SystemClockWrapper {
 
   static const char* kClassName() { return "MockSystemClock"; }
   const char* Name() const override { return kClassName(); }
-  virtual Status GetCurrentTime(int64_t* time_sec) override {
+  Status GetCurrentTime(int64_t* time_sec) override {
     assert(time_sec != nullptr);
     *time_sec = static_cast<int64_t>(current_time_us_ / kMicrosInSecond);
     return Status::OK();
@@ -34,9 +34,9 @@ class MockSystemClock : public SystemClockWrapper {
 
   virtual uint64_t NowSeconds() { return current_time_us_ / kMicrosInSecond; }
 
-  virtual uint64_t NowMicros() override { return current_time_us_; }
+  uint64_t NowMicros() override { return current_time_us_; }
 
-  virtual uint64_t NowNanos() override {
+  uint64_t NowNanos() override {
     assert(current_time_us_ <= std::numeric_limits<uint64_t>::max() / 1000);
     return current_time_us_ * 1000;
   }
@@ -69,8 +69,8 @@ class MockSystemClock : public SystemClockWrapper {
     current_time_us_.fetch_add(micros);
   }
 
-  virtual bool TimedWait(port::CondVar* cv,
-                         std::chrono::microseconds deadline) override {
+  bool TimedWait(port::CondVar* cv,
+                 std::chrono::microseconds deadline) override {
     uint64_t now_micros = NowMicros();
     uint64_t deadline_micros = static_cast<uint64_t>(deadline.count());
     uint64_t delay_micros;

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -591,13 +591,13 @@ class SpecialMemTableRep : public MemTableRep {
         num_entries_flush_(num_entries_flush),
         num_entries_(0) {}
 
-  virtual KeyHandle Allocate(const size_t len, char** buf) override {
+  KeyHandle Allocate(const size_t len, char** buf) override {
     return memtable_->Allocate(len, buf);
   }
 
   // Insert key into the list.
   // REQUIRES: nothing that compares equal to key is currently in the list.
-  virtual void Insert(KeyHandle handle) override {
+  void Insert(KeyHandle handle) override {
     num_entries_++;
     memtable_->Insert(handle);
   }
@@ -608,19 +608,18 @@ class SpecialMemTableRep : public MemTableRep {
   }
 
   // Returns true iff an entry that compares equal to key is in the list.
-  virtual bool Contains(const char* key) const override {
+  bool Contains(const char* key) const override {
     return memtable_->Contains(key);
   }
 
-  virtual size_t ApproximateMemoryUsage() override {
+  size_t ApproximateMemoryUsage() override {
     // Return a high memory usage when number of entries exceeds the threshold
     // to trigger a flush.
     return (num_entries_ < num_entries_flush_) ? 0 : 1024 * 1024 * 1024;
   }
 
-  virtual void Get(const LookupKey& k, void* callback_args,
-                   bool (*callback_func)(void* arg,
-                                         const char* entry)) override {
+  void Get(const LookupKey& k, void* callback_args,
+           bool (*callback_func)(void* arg, const char* entry)) override {
     memtable_->Get(k, callback_args, callback_func);
   }
 
@@ -629,11 +628,11 @@ class SpecialMemTableRep : public MemTableRep {
     return memtable_->ApproximateNumEntries(start_ikey, end_ikey);
   }
 
-  virtual MemTableRep::Iterator* GetIterator(Arena* arena = nullptr) override {
+  MemTableRep::Iterator* GetIterator(Arena* arena = nullptr) override {
     return memtable_->GetIterator(arena);
   }
 
-  virtual ~SpecialMemTableRep() override = default;
+  ~SpecialMemTableRep() override = default;
 
  private:
   std::unique_ptr<MemTableRep> memtable_;
@@ -665,16 +664,17 @@ class SpecialSkipListFactory : public MemTableRepFactory {
       : num_entries_flush_(num_entries_flush) {}
 
   using MemTableRepFactory::CreateMemTableRep;
-  virtual MemTableRep* CreateMemTableRep(
-      const MemTableRep::KeyComparator& compare, Allocator* allocator,
-      const SliceTransform* transform, Logger* /*logger*/) override {
+  MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator& compare,
+                                 Allocator* allocator,
+                                 const SliceTransform* transform,
+                                 Logger* /*logger*/) override {
     return new SpecialMemTableRep(
         allocator,
         factory_.CreateMemTableRep(compare, allocator, transform, nullptr),
         num_entries_flush_);
   }
   static const char* kClassName() { return "SpecialSkipListFactory"; }
-  virtual const char* Name() const override { return kClassName(); }
+  const char* Name() const override { return kClassName(); }
   std::string GetId() const override {
     std::string id = Name();
     if (num_entries_flush_ > 0) {

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -86,7 +86,7 @@ class PlainInternalKeyComparator : public InternalKeyComparator {
 
   virtual ~PlainInternalKeyComparator() {}
 
-  virtual int Compare(const Slice& a, const Slice& b) const override {
+  int Compare(const Slice& a, const Slice& b) const override {
     return user_comparator()->Compare(a, b);
   }
 };
@@ -102,9 +102,9 @@ class SimpleSuffixReverseComparator : public Comparator {
  public:
   SimpleSuffixReverseComparator() {}
   static const char* kClassName() { return "SimpleSuffixReverseComparator"; }
-  virtual const char* Name() const override { return kClassName(); }
+  const char* Name() const override { return kClassName(); }
 
-  virtual int Compare(const Slice& a, const Slice& b) const override {
+  int Compare(const Slice& a, const Slice& b) const override {
     Slice prefix_a = Slice(a.data(), 8);
     Slice prefix_b = Slice(b.data(), 8);
     int prefix_comp = prefix_a.compare(prefix_b);
@@ -116,10 +116,10 @@ class SimpleSuffixReverseComparator : public Comparator {
       return -(suffix_a.compare(suffix_b));
     }
   }
-  virtual void FindShortestSeparator(std::string* /*start*/,
-                                     const Slice& /*limit*/) const override {}
+  void FindShortestSeparator(std::string* /*start*/,
+                             const Slice& /*limit*/) const override {}
 
-  virtual void FindShortSuccessor(std::string* /*key*/) const override {}
+  void FindShortSuccessor(std::string* /*key*/) const override {}
 };
 
 // Returns a user key comparator that can be used for comparing two uint64_t
@@ -369,8 +369,8 @@ class StringSource : public FSRandomAccessFile {
 class NullLogger : public Logger {
  public:
   using Logger::Logv;
-  virtual void Logv(const char* /*format*/, va_list /*ap*/) override {}
-  virtual size_t GetLogFileSize() const override { return 0; }
+  void Logv(const char* /*format*/, va_list /*ap*/) override {}
+  size_t GetLogFileSize() const override { return 0; }
 };
 
 // Corrupts key by changing the type
@@ -748,14 +748,14 @@ class ChanglingMergeOperator : public MergeOperator {
 
   void SetName(const std::string& name) { name_ = name; }
 
-  virtual bool FullMergeV2(const MergeOperationInput& /*merge_in*/,
-                           MergeOperationOutput* /*merge_out*/) const override {
+  bool FullMergeV2(const MergeOperationInput& /*merge_in*/,
+                   MergeOperationOutput* /*merge_out*/) const override {
     return false;
   }
-  virtual bool PartialMergeMulti(const Slice& /*key*/,
-                                 const std::deque<Slice>& /*operand_list*/,
-                                 std::string* /*new_value*/,
-                                 Logger* /*logger*/) const override {
+  bool PartialMergeMulti(const Slice& /*key*/,
+                         const std::deque<Slice>& /*operand_list*/,
+                         std::string* /*new_value*/,
+                         Logger* /*logger*/) const override {
     return false;
   }
   static const char* kClassName() { return "ChanglingMergeOperator"; }
@@ -769,7 +769,7 @@ class ChanglingMergeOperator : public MergeOperator {
     }
   }
 
-  virtual const char* Name() const override { return name_.c_str(); }
+  const char* Name() const override { return name_.c_str(); }
 
  protected:
   std::string name_;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1853,8 +1853,8 @@ class FixedDistribution : public BaseDistribution {
       : BaseDistribution(size, size), size_(size) {}
 
  private:
-  virtual unsigned int Get() override { return size_; }
-  virtual bool NeedTruncate() override { return false; }
+  unsigned int Get() override { return size_; }
+  bool NeedTruncate() override { return false; }
   unsigned int size_;
 };
 
@@ -1870,7 +1870,7 @@ class NormalDistribution : public BaseDistribution,
         gen_(rd_()) {}
 
  private:
-  virtual unsigned int Get() override {
+  unsigned int Get() override {
     return static_cast<unsigned int>((*this)(gen_));
   }
   std::random_device rd_;
@@ -1886,8 +1886,8 @@ class UniformDistribution : public BaseDistribution,
         gen_(rd_()) {}
 
  private:
-  virtual unsigned int Get() override { return (*this)(gen_); }
-  virtual bool NeedTruncate() override { return false; }
+  unsigned int Get() override { return (*this)(gen_); }
+  bool NeedTruncate() override { return false; }
   std::random_device rd_;
   std::mt19937 gen_;
 };

--- a/tools/db_sanity_test.cc
+++ b/tools/db_sanity_test.cc
@@ -88,12 +88,12 @@ class SanityTest {
 class SanityTestBasic : public SanityTest {
  public:
   explicit SanityTestBasic(const std::string& path) : SanityTest(path) {}
-  virtual Options GetOptions() const override {
+  Options GetOptions() const override {
     Options options;
     options.create_if_missing = true;
     return options;
   }
-  virtual std::string Name() const override { return "Basic"; }
+  std::string Name() const override { return "Basic"; }
 };
 
 class SanityTestSpecialComparator : public SanityTest {
@@ -103,23 +103,20 @@ class SanityTestSpecialComparator : public SanityTest {
     options_.comparator = new NewComparator();
   }
   ~SanityTestSpecialComparator() { delete options_.comparator; }
-  virtual Options GetOptions() const override { return options_; }
-  virtual std::string Name() const override { return "SpecialComparator"; }
+  Options GetOptions() const override { return options_; }
+  std::string Name() const override { return "SpecialComparator"; }
 
  private:
   class NewComparator : public Comparator {
    public:
-    virtual const char* Name() const override {
-      return "rocksdb.NewComparator";
-    }
-    virtual int Compare(const Slice& a, const Slice& b) const override {
+    const char* Name() const override { return "rocksdb.NewComparator"; }
+    int Compare(const Slice& a, const Slice& b) const override {
       return BytewiseComparator()->Compare(a, b);
     }
-    virtual void FindShortestSeparator(std::string* s,
-                                       const Slice& l) const override {
+    void FindShortestSeparator(std::string* s, const Slice& l) const override {
       BytewiseComparator()->FindShortestSeparator(s, l);
     }
-    virtual void FindShortSuccessor(std::string* key) const override {
+    void FindShortSuccessor(std::string* key) const override {
       BytewiseComparator()->FindShortSuccessor(key);
     }
   };
@@ -132,8 +129,8 @@ class SanityTestZlibCompression : public SanityTest {
       : SanityTest(path) {
     options_.compression = kZlibCompression;
   }
-  virtual Options GetOptions() const override { return options_; }
-  virtual std::string Name() const override { return "ZlibCompression"; }
+  Options GetOptions() const override { return options_; }
+  std::string Name() const override { return "ZlibCompression"; }
 
  private:
   Options options_;
@@ -150,10 +147,8 @@ class SanityTestZlibCompressionVersion2 : public SanityTest {
 #endif
     options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
   }
-  virtual Options GetOptions() const override { return options_; }
-  virtual std::string Name() const override {
-    return "ZlibCompressionVersion2";
-  }
+  Options GetOptions() const override { return options_; }
+  std::string Name() const override { return "ZlibCompressionVersion2"; }
 
  private:
   Options options_;
@@ -165,8 +160,8 @@ class SanityTestLZ4Compression : public SanityTest {
       : SanityTest(path) {
     options_.compression = kLZ4Compression;
   }
-  virtual Options GetOptions() const override { return options_; }
-  virtual std::string Name() const override { return "LZ4Compression"; }
+  Options GetOptions() const override { return options_; }
+  std::string Name() const override { return "LZ4Compression"; }
 
  private:
   Options options_;
@@ -178,8 +173,8 @@ class SanityTestLZ4HCCompression : public SanityTest {
       : SanityTest(path) {
     options_.compression = kLZ4HCCompression;
   }
-  virtual Options GetOptions() const override { return options_; }
-  virtual std::string Name() const override { return "LZ4HCCompression"; }
+  Options GetOptions() const override { return options_; }
+  std::string Name() const override { return "LZ4HCCompression"; }
 
  private:
   Options options_;
@@ -191,8 +186,8 @@ class SanityTestZSTDCompression : public SanityTest {
       : SanityTest(path) {
     options_.compression = kZSTD;
   }
-  virtual Options GetOptions() const override { return options_; }
-  virtual std::string Name() const override { return "ZSTDCompression"; }
+  Options GetOptions() const override { return options_; }
+  std::string Name() const override { return "ZSTDCompression"; }
 
  private:
   Options options_;
@@ -207,8 +202,8 @@ class SanityTestPlainTableFactory : public SanityTest {
     options_.allow_mmap_reads = true;
   }
   ~SanityTestPlainTableFactory() {}
-  virtual Options GetOptions() const override { return options_; }
-  virtual std::string Name() const override { return "PlainTable"; }
+  Options GetOptions() const override { return options_; }
+  std::string Name() const override { return "PlainTable"; }
 
  private:
   Options options_;
@@ -222,8 +217,8 @@ class SanityTestBloomFilter : public SanityTest {
     options_.table_factory.reset(NewBlockBasedTableFactory(table_options));
   }
   ~SanityTestBloomFilter() {}
-  virtual Options GetOptions() const override { return options_; }
-  virtual std::string Name() const override { return "BloomFilter"; }
+  Options GetOptions() const override { return options_; }
+  std::string Name() const override { return "BloomFilter"; }
 
  private:
   Options options_;

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -208,9 +208,9 @@ class UpdateManifestCommand : public LDBCommand {
                         const std::vector<std::string>& flags);
 
   static void Help(std::string& ret);
-  virtual void DoCommand() override;
+  void DoCommand() override;
 
-  virtual bool NoDBOpen() override { return true; }
+  bool NoDBOpen() override { return true; }
 
  private:
   bool verbose_;

--- a/trace_replay/trace_record_handler.h
+++ b/trace_replay/trace_record_handler.h
@@ -22,16 +22,16 @@ class TraceExecutionHandler : public TraceRecord::Handler {
  public:
   TraceExecutionHandler(DB* db,
                         const std::vector<ColumnFamilyHandle*>& handles);
-  virtual ~TraceExecutionHandler() override;
+  ~TraceExecutionHandler() override;
 
-  virtual Status Handle(const WriteQueryTraceRecord& record,
-                        std::unique_ptr<TraceRecordResult>* result) override;
-  virtual Status Handle(const GetQueryTraceRecord& record,
-                        std::unique_ptr<TraceRecordResult>* result) override;
-  virtual Status Handle(const IteratorSeekQueryTraceRecord& record,
-                        std::unique_ptr<TraceRecordResult>* result) override;
-  virtual Status Handle(const MultiGetQueryTraceRecord& record,
-                        std::unique_ptr<TraceRecordResult>* result) override;
+  Status Handle(const WriteQueryTraceRecord& record,
+                std::unique_ptr<TraceRecordResult>* result) override;
+  Status Handle(const GetQueryTraceRecord& record,
+                std::unique_ptr<TraceRecordResult>* result) override;
+  Status Handle(const IteratorSeekQueryTraceRecord& record,
+                std::unique_ptr<TraceRecordResult>* result) override;
+  Status Handle(const MultiGetQueryTraceRecord& record,
+                std::unique_ptr<TraceRecordResult>* result) override;
 
  private:
   DB* db_;

--- a/util/concurrent_task_limiter_impl.h
+++ b/util/concurrent_task_limiter_impl.h
@@ -29,13 +29,13 @@ class ConcurrentTaskLimiterImpl : public ConcurrentTaskLimiter {
 
   virtual ~ConcurrentTaskLimiterImpl();
 
-  virtual const std::string& GetName() const override;
+  const std::string& GetName() const override;
 
-  virtual void SetMaxOutstandingTask(int32_t limit) override;
+  void SetMaxOutstandingTask(int32_t limit) override;
 
-  virtual void ResetMaxOutstandingTask() override;
+  void ResetMaxOutstandingTask() override;
 
-  virtual int32_t GetOutstandingTask() const override;
+  int32_t GetOutstandingTask() const override;
 
   // Request token for adding a new task.
   // If force == true, it requests a token bypassing throttle.

--- a/util/file_checksum_helper.cc
+++ b/util/file_checksum_helper.cc
@@ -118,7 +118,7 @@ Status GetFileChecksumsFromManifest(Env* src_env, const std::string& abs_path,
 
   struct LogReporter : public log::Reader::Reporter {
     Status* status_ptr;
-    virtual void Corruption(size_t /*bytes*/, const Status& st) override {
+    void Corruption(size_t /*bytes*/, const Status& st) override {
       if (status_ptr->ok()) {
         *status_ptr = st;
       }

--- a/util/rate_limiter_impl.h
+++ b/util/rate_limiter_impl.h
@@ -34,23 +34,23 @@ class GenericRateLimiter : public RateLimiter {
   virtual ~GenericRateLimiter();
 
   // This API allows user to dynamically change rate limiter's bytes per second.
-  virtual void SetBytesPerSecond(int64_t bytes_per_second) override;
+  void SetBytesPerSecond(int64_t bytes_per_second) override;
 
-  virtual Status SetSingleBurstBytes(int64_t single_burst_bytes) override;
+  Status SetSingleBurstBytes(int64_t single_burst_bytes) override;
 
   // Request for token to write bytes. If this request can not be satisfied,
   // the call is blocked. Caller is responsible to make sure
   // bytes <= GetSingleBurstBytes() and bytes >= 0. Negative bytes
   // passed in will be rounded up to 0.
   using RateLimiter::Request;
-  virtual void Request(const int64_t bytes, const Env::IOPriority pri,
-                       Statistics* stats) override;
+  void Request(const int64_t bytes, const Env::IOPriority pri,
+               Statistics* stats) override;
 
-  virtual int64_t GetSingleBurstBytes() const override {
+  int64_t GetSingleBurstBytes() const override {
     return refill_bytes_per_period_.load(std::memory_order_relaxed);
   }
 
-  virtual int64_t GetTotalBytesThrough(
+  int64_t GetTotalBytesThrough(
       const Env::IOPriority pri = Env::IO_TOTAL) const override {
     MutexLock g(&request_mutex_);
     if (pri == Env::IO_TOTAL) {
@@ -63,7 +63,7 @@ class GenericRateLimiter : public RateLimiter {
     return total_bytes_through_[pri];
   }
 
-  virtual int64_t GetTotalRequests(
+  int64_t GetTotalRequests(
       const Env::IOPriority pri = Env::IO_TOTAL) const override {
     MutexLock g(&request_mutex_);
     if (pri == Env::IO_TOTAL) {
@@ -76,7 +76,7 @@ class GenericRateLimiter : public RateLimiter {
     return total_requests_[pri];
   }
 
-  virtual Status GetTotalPendingRequests(
+  Status GetTotalPendingRequests(
       int64_t* total_pending_requests,
       const Env::IOPriority pri = Env::IO_TOTAL) const override {
     assert(total_pending_requests != nullptr);
@@ -93,7 +93,7 @@ class GenericRateLimiter : public RateLimiter {
     return Status::OK();
   }
 
-  virtual int64_t GetBytesPerSecond() const override {
+  int64_t GetBytesPerSecond() const override {
     return rate_bytes_per_sec_.load(std::memory_order_relaxed);
   }
 

--- a/util/stderr_logger.h
+++ b/util/stderr_logger.h
@@ -29,7 +29,7 @@ class StderrLogger : public Logger {
   // a subset of them.
   using Logger::Logv;
 
-  virtual void Logv(const char* format, va_list ap) override;
+  void Logv(const char* format, va_list ap) override;
 
  private:
   // This prefix will be appended after the time/thread info of every log

--- a/util/threadpool_imp.h
+++ b/util/threadpool_imp.h
@@ -101,7 +101,7 @@ class ThreadPoolImpl : public ThreadPool {
   struct Impl;
 
  private:
-  // Current public virtual interface does not provide usable
+  // Current public interface does not provide usable
   // functionality and thus can not be used internally to
   // facade different implementations.
   //

--- a/util/vector_iterator.h
+++ b/util/vector_iterator.h
@@ -33,14 +33,14 @@ class VectorIterator : public InternalIterator {
     }
   }
 
-  virtual bool Valid() const override {
+  bool Valid() const override {
     return !indices_.empty() && current_ < indices_.size();
   }
 
-  virtual void SeekToFirst() override { current_ = 0; }
-  virtual void SeekToLast() override { current_ = indices_.size() - 1; }
+  void SeekToFirst() override { current_ = 0; }
+  void SeekToLast() override { current_ = indices_.size() - 1; }
 
-  virtual void Seek(const Slice& target) override {
+  void Seek(const Slice& target) override {
     if (indexed_cmp_.cmp != nullptr) {
       current_ = std::lower_bound(indices_.begin(), indices_.end(), target,
                                   indexed_cmp_) -
@@ -52,7 +52,7 @@ class VectorIterator : public InternalIterator {
     }
   }
 
-  virtual void SeekForPrev(const Slice& target) override {
+  void SeekForPrev(const Slice& target) override {
     if (indexed_cmp_.cmp != nullptr) {
       current_ = std::upper_bound(indices_.begin(), indices_.end(), target,
                                   indexed_cmp_) -
@@ -69,20 +69,16 @@ class VectorIterator : public InternalIterator {
     }
   }
 
-  virtual void Next() override { current_++; }
-  virtual void Prev() override { current_--; }
+  void Next() override { current_++; }
+  void Prev() override { current_--; }
 
-  virtual Slice key() const override {
-    return Slice(keys_[indices_[current_]]);
-  }
-  virtual Slice value() const override {
-    return Slice(values_[indices_[current_]]);
-  }
+  Slice key() const override { return Slice(keys_[indices_[current_]]); }
+  Slice value() const override { return Slice(values_[indices_[current_]]); }
 
-  virtual Status status() const override { return Status::OK(); }
+  Status status() const override { return Status::OK(); }
 
-  virtual bool IsKeyPinned() const override { return true; }
-  virtual bool IsValuePinned() const override { return true; }
+  bool IsKeyPinned() const override { return true; }
+  bool IsValuePinned() const override { return true; }
 
  protected:
   std::vector<std::string> keys_;

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -88,11 +88,10 @@ struct BlobDBOptions {
 class BlobDB : public StackableDB {
  public:
   using ROCKSDB_NAMESPACE::StackableDB::Put;
-  virtual Status Put(const WriteOptions& options, const Slice& key,
-                     const Slice& value) override = 0;
-  virtual Status Put(const WriteOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value) override {
+  Status Put(const WriteOptions& options, const Slice& key,
+             const Slice& value) override = 0;
+  Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, const Slice& value) override {
     if (column_family->GetID() != DefaultColumnFamily()->GetID()) {
       return Status::NotSupported(
           "Blob DB doesn't support non-default column family.");
@@ -101,9 +100,8 @@ class BlobDB : public StackableDB {
   }
 
   using ROCKSDB_NAMESPACE::StackableDB::Delete;
-  virtual Status Delete(const WriteOptions& options,
-                        ColumnFamilyHandle* column_family,
-                        const Slice& key) override {
+  Status Delete(const WriteOptions& options, ColumnFamilyHandle* column_family,
+                const Slice& key) override {
     if (column_family->GetID() != DefaultColumnFamily()->GetID()) {
       return Status::NotSupported(
           "Blob DB doesn't support non-default column family.");
@@ -139,9 +137,8 @@ class BlobDB : public StackableDB {
   }
 
   using ROCKSDB_NAMESPACE::StackableDB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override = 0;
+  Status Get(const ReadOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, PinnableSlice* value) override = 0;
 
   // Get value and expiration.
   virtual Status Get(const ReadOptions& options,
@@ -153,10 +150,10 @@ class BlobDB : public StackableDB {
   }
 
   using ROCKSDB_NAMESPACE::StackableDB::MultiGet;
-  virtual std::vector<Status> MultiGet(
-      const ReadOptions& options, const std::vector<Slice>& keys,
-      std::vector<std::string>* values) override = 0;
-  virtual std::vector<Status> MultiGet(
+  std::vector<Status> MultiGet(const ReadOptions& options,
+                               const std::vector<Slice>& keys,
+                               std::vector<std::string>* values) override = 0;
+  std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_families,
       const std::vector<Slice>& keys,
@@ -171,11 +168,11 @@ class BlobDB : public StackableDB {
     }
     return MultiGet(options, keys, values);
   }
-  virtual void MultiGet(const ReadOptions& /*options*/,
-                        ColumnFamilyHandle* /*column_family*/,
-                        const size_t num_keys, const Slice* /*keys*/,
-                        PinnableSlice* /*values*/, Status* statuses,
-                        const bool /*sorted_input*/ = false) override {
+  void MultiGet(const ReadOptions& /*options*/,
+                ColumnFamilyHandle* /*column_family*/, const size_t num_keys,
+                const Slice* /*keys*/, PinnableSlice* /*values*/,
+                Status* statuses,
+                const bool /*sorted_input*/ = false) override {
     for (size_t i = 0; i < num_keys; ++i) {
       statuses[i] =
           Status::NotSupported("Blob DB doesn't support batched MultiGet");
@@ -183,26 +180,25 @@ class BlobDB : public StackableDB {
   }
 
   using ROCKSDB_NAMESPACE::StackableDB::SingleDelete;
-  virtual Status SingleDelete(const WriteOptions& /*wopts*/,
-                              ColumnFamilyHandle* /*column_family*/,
-                              const Slice& /*key*/) override {
+  Status SingleDelete(const WriteOptions& /*wopts*/,
+                      ColumnFamilyHandle* /*column_family*/,
+                      const Slice& /*key*/) override {
     return Status::NotSupported("Not supported operation in blob db.");
   }
 
   using ROCKSDB_NAMESPACE::StackableDB::Merge;
-  virtual Status Merge(const WriteOptions& /*options*/,
-                       ColumnFamilyHandle* /*column_family*/,
-                       const Slice& /*key*/, const Slice& /*value*/) override {
+  Status Merge(const WriteOptions& /*options*/,
+               ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,
+               const Slice& /*value*/) override {
     return Status::NotSupported("Not supported operation in blob db.");
   }
 
-  virtual Status Write(const WriteOptions& opts,
-                       WriteBatch* updates) override = 0;
+  Status Write(const WriteOptions& opts, WriteBatch* updates) override = 0;
 
   using ROCKSDB_NAMESPACE::StackableDB::NewIterator;
-  virtual Iterator* NewIterator(const ReadOptions& options) override = 0;
-  virtual Iterator* NewIterator(const ReadOptions& options,
-                                ColumnFamilyHandle* column_family) override {
+  Iterator* NewIterator(const ReadOptions& options) override = 0;
+  Iterator* NewIterator(const ReadOptions& options,
+                        ColumnFamilyHandle* column_family) override {
     if (column_family->GetID() != DefaultColumnFamily()->GetID()) {
       // Blob DB doesn't support non-default column family.
       return nullptr;
@@ -233,7 +229,7 @@ class BlobDB : public StackableDB {
   }
 
   using ROCKSDB_NAMESPACE::StackableDB::Close;
-  virtual Status Close() override = 0;
+  Status Close() override = 0;
 
   // Opening blob db.
   static Status Open(const Options& options, const BlobDBOptions& bdb_options,

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -112,10 +112,10 @@ class BlobDBImpl : public BlobDB {
              PinnableSlice* value, uint64_t* expiration) override;
 
   using BlobDB::NewIterator;
-  virtual Iterator* NewIterator(const ReadOptions& read_options) override;
+  Iterator* NewIterator(const ReadOptions& read_options) override;
 
   using BlobDB::NewIterators;
-  virtual Status NewIterators(
+  Status NewIterators(
       const ReadOptions& /*read_options*/,
       const std::vector<ColumnFamilyHandle*>& /*column_families*/,
       std::vector<Iterator*>* /*iterators*/) override {
@@ -123,14 +123,14 @@ class BlobDBImpl : public BlobDB {
   }
 
   using BlobDB::MultiGet;
-  virtual std::vector<Status> MultiGet(
-      const ReadOptions& _read_options, const std::vector<Slice>& keys,
-      std::vector<std::string>* values) override;
+  std::vector<Status> MultiGet(const ReadOptions& _read_options,
+                               const std::vector<Slice>& keys,
+                               std::vector<std::string>* values) override;
 
   using BlobDB::Write;
-  virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override;
+  Status Write(const WriteOptions& opts, WriteBatch* updates) override;
 
-  virtual Status Close() override;
+  Status Close() override;
 
   using BlobDB::PutWithTTL;
   Status PutWithTTL(const WriteOptions& options, const Slice& key,
@@ -154,14 +154,13 @@ class BlobDBImpl : public BlobDB {
              const DBOptions& db_options,
              const ColumnFamilyOptions& cf_options);
 
-  virtual Status DisableFileDeletions() override;
+  Status DisableFileDeletions() override;
 
-  virtual Status EnableFileDeletions(bool force) override;
+  Status EnableFileDeletions(bool force) override;
 
-  virtual Status GetLiveFiles(std::vector<std::string>&,
-                              uint64_t* manifest_file_size,
-                              bool flush_memtable = true) override;
-  virtual void GetLiveFilesMetaData(std::vector<LiveFileMetaData>*) override;
+  Status GetLiveFiles(std::vector<std::string>&, uint64_t* manifest_file_size,
+                      bool flush_memtable = true) override;
+  void GetLiveFilesMetaData(std::vector<LiveFileMetaData>*) override;
 
   ~BlobDBImpl();
 

--- a/utilities/cache_dump_load_impl.h
+++ b/utilities/cache_dump_load_impl.h
@@ -158,7 +158,7 @@ class ToFileCacheDumpWriter : public CacheDumpWriter {
   ~ToFileCacheDumpWriter() { Close().PermitUncheckedError(); }
 
   // Write the serialized metadata to the file
-  virtual IOStatus WriteMetadata(const Slice& metadata) override {
+  IOStatus WriteMetadata(const Slice& metadata) override {
     assert(file_writer_ != nullptr);
     std::string prefix;
     PutFixed32(&prefix, static_cast<uint32_t>(metadata.size()));
@@ -172,7 +172,7 @@ class ToFileCacheDumpWriter : public CacheDumpWriter {
   }
 
   // Write the serialized data to the file
-  virtual IOStatus WritePacket(const Slice& data) override {
+  IOStatus WritePacket(const Slice& data) override {
     assert(file_writer_ != nullptr);
     std::string prefix;
     PutFixed32(&prefix, static_cast<uint32_t>(data.size()));
@@ -186,7 +186,7 @@ class ToFileCacheDumpWriter : public CacheDumpWriter {
   }
 
   // Reset the writer
-  virtual IOStatus Close() override {
+  IOStatus Close() override {
     file_writer_.reset();
     return IOStatus::OK();
   }
@@ -208,7 +208,7 @@ class FromFileCacheDumpReader : public CacheDumpReader {
 
   ~FromFileCacheDumpReader() { delete[] buffer_; }
 
-  virtual IOStatus ReadMetadata(std::string* metadata) override {
+  IOStatus ReadMetadata(std::string* metadata) override {
     uint32_t metadata_len = 0;
     IOStatus io_s = ReadSizePrefix(&metadata_len);
     if (!io_s.ok()) {
@@ -217,7 +217,7 @@ class FromFileCacheDumpReader : public CacheDumpReader {
     return Read(metadata_len, metadata);
   }
 
-  virtual IOStatus ReadPacket(std::string* data) override {
+  IOStatus ReadPacket(std::string* data) override {
     uint32_t data_len = 0;
     IOStatus io_s = ReadSizePrefix(&data_len);
     if (!io_s.ok()) {

--- a/utilities/cassandra/cassandra_compaction_filter.h
+++ b/utilities/cassandra/cassandra_compaction_filter.h
@@ -31,9 +31,9 @@ class CassandraCompactionFilter : public CompactionFilter {
   static const char* kClassName() { return "CassandraCompactionFilter"; }
   const char* Name() const override { return kClassName(); }
 
-  virtual Decision FilterV2(int level, const Slice& key, ValueType value_type,
-                            const Slice& existing_value, std::string* new_value,
-                            std::string* skip_until) const override;
+  Decision FilterV2(int level, const Slice& key, ValueType value_type,
+                    const Slice& existing_value, std::string* new_value,
+                    std::string* skip_until) const override;
 
  private:
   CassandraOptions options_;

--- a/utilities/cassandra/format.h
+++ b/utilities/cassandra/format.h
@@ -94,9 +94,9 @@ class Column : public ColumnBase {
   Column(int8_t mask, int8_t index, int64_t timestamp, int32_t value_size,
          const char* value);
 
-  virtual int64_t Timestamp() const override;
-  virtual std::size_t Size() const override;
-  virtual void Serialize(std::string* dest) const override;
+  int64_t Timestamp() const override;
+  std::size_t Size() const override;
+  void Serialize(std::string* dest) const override;
   static std::shared_ptr<Column> Deserialize(const char* src,
                                              std::size_t offset);
 
@@ -111,9 +111,9 @@ class Tombstone : public ColumnBase {
   Tombstone(int8_t mask, int8_t index, int32_t local_deletion_time,
             int64_t marked_for_delete_at);
 
-  virtual int64_t Timestamp() const override;
-  virtual std::size_t Size() const override;
-  virtual void Serialize(std::string* dest) const override;
+  int64_t Timestamp() const override;
+  std::size_t Size() const override;
+  void Serialize(std::string* dest) const override;
   bool Collectable(int32_t gc_grace_period) const;
   static std::shared_ptr<Tombstone> Deserialize(const char* src,
                                                 std::size_t offset);
@@ -128,8 +128,8 @@ class ExpiringColumn : public Column {
   ExpiringColumn(int8_t mask, int8_t index, int64_t timestamp,
                  int32_t value_size, const char* value, int32_t ttl);
 
-  virtual std::size_t Size() const override;
-  virtual void Serialize(std::string* dest) const override;
+  std::size_t Size() const override;
+  void Serialize(std::string* dest) const override;
   bool Expired() const;
   std::shared_ptr<Tombstone> ToTombstone() const;
 

--- a/utilities/cassandra/merge_operator.h
+++ b/utilities/cassandra/merge_operator.h
@@ -19,20 +19,19 @@ class CassandraValueMergeOperator : public MergeOperator {
   explicit CassandraValueMergeOperator(int32_t gc_grace_period_in_seconds,
                                        size_t operands_limit = 0);
 
-  virtual bool FullMergeV2(const MergeOperationInput& merge_in,
-                           MergeOperationOutput* merge_out) const override;
+  bool FullMergeV2(const MergeOperationInput& merge_in,
+                   MergeOperationOutput* merge_out) const override;
 
-  virtual bool PartialMergeMulti(const Slice& key,
-                                 const std::deque<Slice>& operand_list,
-                                 std::string* new_value,
-                                 Logger* logger) const override;
+  bool PartialMergeMulti(const Slice& key,
+                         const std::deque<Slice>& operand_list,
+                         std::string* new_value, Logger* logger) const override;
 
   const char* Name() const override { return kClassName(); }
   static const char* kClassName() { return "CassandraValueMergeOperator"; }
 
-  virtual bool AllowSingleOperand() const override { return true; }
+  bool AllowSingleOperand() const override { return true; }
 
-  virtual bool ShouldMerge(const std::vector<Slice>& operands) const override {
+  bool ShouldMerge(const std::vector<Slice>& operands) const override {
     return options_.operands_limit > 0 &&
            operands.size() >= options_.operands_limit;
   }

--- a/utilities/fault_injection_env.h
+++ b/utilities/fault_injection_env.h
@@ -72,30 +72,25 @@ class TestWritableFile : public WritableFile {
                             std::unique_ptr<WritableFile>&& f,
                             FaultInjectionTestEnv* env);
   virtual ~TestWritableFile();
-  virtual Status Append(const Slice& data) override;
-  virtual Status Append(
-      const Slice& data,
-      const DataVerificationInfo& /*verification_info*/) override {
+  Status Append(const Slice& data) override;
+  Status Append(const Slice& data,
+                const DataVerificationInfo& /*verification_info*/) override {
     return Append(data);
   }
-  virtual Status Truncate(uint64_t size) override {
-    return target_->Truncate(size);
-  }
-  virtual Status Close() override;
-  virtual Status Flush() override;
-  virtual Status Sync() override;
-  virtual bool IsSyncThreadSafe() const override { return true; }
-  virtual Status PositionedAppend(const Slice& data, uint64_t offset) override {
+  Status Truncate(uint64_t size) override { return target_->Truncate(size); }
+  Status Close() override;
+  Status Flush() override;
+  Status Sync() override;
+  bool IsSyncThreadSafe() const override { return true; }
+  Status PositionedAppend(const Slice& data, uint64_t offset) override {
     return target_->PositionedAppend(data, offset);
   }
-  virtual Status PositionedAppend(
+  Status PositionedAppend(
       const Slice& data, uint64_t offset,
       const DataVerificationInfo& /*verification_info*/) override {
     return PositionedAppend(data, offset);
   }
-  virtual bool use_direct_io() const override {
-    return target_->use_direct_io();
-  };
+  bool use_direct_io() const override { return target_->use_direct_io(); };
   uint64_t GetFileSize() final { return target_->GetFileSize(); }
 
  private:
@@ -137,8 +132,8 @@ class TestDirectory : public Directory {
       : env_(env), dirname_(dirname), dir_(dir) {}
   ~TestDirectory() {}
 
-  virtual Status Fsync() override;
-  virtual Status Close() override;
+  Status Fsync() override;
+  Status Close() override;
 
  private:
   FaultInjectionTestEnv* env_;
@@ -174,17 +169,15 @@ class FaultInjectionTestEnv : public EnvWrapper {
                              std::unique_ptr<RandomAccessFile>* result,
                              const EnvOptions& soptions) override;
 
-  virtual Status DeleteFile(const std::string& f) override;
+  Status DeleteFile(const std::string& f) override;
 
-  virtual Status RenameFile(const std::string& s,
-                            const std::string& t) override;
+  Status RenameFile(const std::string& s, const std::string& t) override;
 
-  virtual Status LinkFile(const std::string& s, const std::string& t) override;
+  Status LinkFile(const std::string& s, const std::string& t) override;
 
 // Undef to eliminate clash on Windows
 #undef GetFreeSpace
-  virtual Status GetFreeSpace(const std::string& path,
-                              uint64_t* disk_free) override {
+  Status GetFreeSpace(const std::string& path, uint64_t* disk_free) override {
     if (!IsFilesystemActive() &&
         error_.subcode() == IOStatus::SubCode::kNoSpace) {
       *disk_free = 0;

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -63,41 +63,36 @@ class TestFSWritableFile : public FSWritableFile {
                               std::unique_ptr<FSWritableFile>&& f,
                               FaultInjectionTestFS* fs);
   virtual ~TestFSWritableFile();
-  virtual IOStatus Append(const Slice& data, const IOOptions&,
-                          IODebugContext*) override;
-  virtual IOStatus Append(const Slice& data, const IOOptions& options,
-                          const DataVerificationInfo& verification_info,
-                          IODebugContext* dbg) override;
-  virtual IOStatus Truncate(uint64_t size, const IOOptions& options,
-                            IODebugContext* dbg) override {
+  IOStatus Append(const Slice& data, const IOOptions&,
+                  IODebugContext*) override;
+  IOStatus Append(const Slice& data, const IOOptions& options,
+                  const DataVerificationInfo& verification_info,
+                  IODebugContext* dbg) override;
+  IOStatus Truncate(uint64_t size, const IOOptions& options,
+                    IODebugContext* dbg) override {
     return target_->Truncate(size, options, dbg);
   }
-  virtual IOStatus Close(const IOOptions& options,
-                         IODebugContext* dbg) override;
-  virtual IOStatus Flush(const IOOptions&, IODebugContext*) override;
-  virtual IOStatus Sync(const IOOptions& options, IODebugContext* dbg) override;
-  virtual IOStatus RangeSync(uint64_t /*offset*/, uint64_t /*nbytes*/,
-                             const IOOptions& options,
-                             IODebugContext* dbg) override;
-  virtual bool IsSyncThreadSafe() const override { return true; }
-  virtual IOStatus PositionedAppend(const Slice& data, uint64_t offset,
-                                    const IOOptions& options,
-                                    IODebugContext* dbg) override {
+  IOStatus Close(const IOOptions& options, IODebugContext* dbg) override;
+  IOStatus Flush(const IOOptions&, IODebugContext*) override;
+  IOStatus Sync(const IOOptions& options, IODebugContext* dbg) override;
+  IOStatus RangeSync(uint64_t /*offset*/, uint64_t /*nbytes*/,
+                     const IOOptions& options, IODebugContext* dbg) override;
+  bool IsSyncThreadSafe() const override { return true; }
+  IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                            const IOOptions& options,
+                            IODebugContext* dbg) override {
     return target_->PositionedAppend(data, offset, options, dbg);
   }
   IOStatus PositionedAppend(const Slice& data, uint64_t offset,
                             const IOOptions& options,
                             const DataVerificationInfo& verification_info,
                             IODebugContext* dbg) override;
-  virtual size_t GetRequiredBufferAlignment() const override {
+  size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();
   }
-  virtual bool use_direct_io() const override {
-    return target_->use_direct_io();
-  }
+  bool use_direct_io() const override { return target_->use_direct_io(); }
 
-  virtual uint64_t GetFileSize(const IOOptions& options,
-                               IODebugContext* dbg) override {
+  uint64_t GetFileSize(const IOOptions& options, IODebugContext* dbg) override {
     MutexLock l(&mutex_);
     return target_->GetFileSize(options, dbg);
   }
@@ -187,13 +182,11 @@ class TestFSDirectory : public FSDirectory {
       : fs_(fs), dirname_(dirname), dir_(dir) {}
   ~TestFSDirectory() {}
 
-  virtual IOStatus Fsync(const IOOptions& options,
-                         IODebugContext* dbg) override;
+  IOStatus Fsync(const IOOptions& options, IODebugContext* dbg) override;
 
-  virtual IOStatus Close(const IOOptions& options,
-                         IODebugContext* dbg) override;
+  IOStatus Close(const IOOptions& options, IODebugContext* dbg) override;
 
-  virtual IOStatus FsyncWithDirOptions(
+  IOStatus FsyncWithDirOptions(
       const IOOptions& options, IODebugContext* dbg,
       const DirFsyncOptions& dir_fsync_options) override;
 
@@ -250,22 +243,19 @@ class FaultInjectionTestFS : public FileSystemWrapper {
                              std::unique_ptr<FSSequentialFile>* r,
                              IODebugContext* dbg) override;
 
-  virtual IOStatus DeleteFile(const std::string& f, const IOOptions& options,
-                              IODebugContext* dbg) override;
+  IOStatus DeleteFile(const std::string& f, const IOOptions& options,
+                      IODebugContext* dbg) override;
 
-  virtual IOStatus RenameFile(const std::string& s, const std::string& t,
-                              const IOOptions& options,
-                              IODebugContext* dbg) override;
+  IOStatus RenameFile(const std::string& s, const std::string& t,
+                      const IOOptions& options, IODebugContext* dbg) override;
 
-  virtual IOStatus LinkFile(const std::string& src, const std::string& target,
-                            const IOOptions& options,
-                            IODebugContext* dbg) override;
+  IOStatus LinkFile(const std::string& src, const std::string& target,
+                    const IOOptions& options, IODebugContext* dbg) override;
 
 // Undef to eliminate clash on Windows
 #undef GetFreeSpace
-  virtual IOStatus GetFreeSpace(const std::string& path,
-                                const IOOptions& options, uint64_t* disk_free,
-                                IODebugContext* dbg) override {
+  IOStatus GetFreeSpace(const std::string& path, const IOOptions& options,
+                        uint64_t* disk_free, IODebugContext* dbg) override {
     IOStatus io_s;
     if (!IsFilesystemActive() &&
         error_.subcode() == IOStatus::SubCode::kNoSpace) {
@@ -276,10 +266,10 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     return io_s;
   }
 
-  virtual IOStatus Poll(std::vector<void*>& io_handles,
-                        size_t min_completions) override;
+  IOStatus Poll(std::vector<void*>& io_handles,
+                size_t min_completions) override;
 
-  virtual IOStatus AbortIO(std::vector<void*>& io_handles) override;
+  IOStatus AbortIO(std::vector<void*>& io_handles) override;
 
   void WritableFileClosed(const FSFileState& state);
 

--- a/utilities/fault_injection_secondary_cache.h
+++ b/utilities/fault_injection_secondary_cache.h
@@ -27,7 +27,7 @@ class FaultInjectionSecondaryCache : public SecondaryCache {
     }
   }
 
-  virtual ~FaultInjectionSecondaryCache() override {}
+  ~FaultInjectionSecondaryCache() override {}
 
   const char* Name() const override { return "FaultInjectionSecondaryCache"; }
 

--- a/utilities/merge_operators/bytesxor.h
+++ b/utilities/merge_operators/bytesxor.h
@@ -23,9 +23,8 @@ class BytesXOROperator : public AssociativeMergeOperator {
  public:
   // XORs the two array of bytes one byte at a time and stores the result
   // in new_value. len is the number of xored bytes, and the length of new_value
-  virtual bool Merge(const Slice& key, const Slice* existing_value,
-                     const Slice& value, std::string* new_value,
-                     Logger* logger) const override;
+  bool Merge(const Slice& key, const Slice* existing_value, const Slice& value,
+             std::string* new_value, Logger* logger) const override;
 
   static const char* kClassName() { return "BytesXOR"; }
   static const char* kNickName() { return "bytesxor"; }

--- a/utilities/merge_operators/string_append/stringappend.h
+++ b/utilities/merge_operators/string_append/stringappend.h
@@ -17,14 +17,13 @@ class StringAppendOperator : public AssociativeMergeOperator {
   explicit StringAppendOperator(char delim_char);
   explicit StringAppendOperator(const std::string& delim);
 
-  virtual bool Merge(const Slice& key, const Slice* existing_value,
-                     const Slice& value, std::string* new_value,
-                     Logger* logger) const override;
+  bool Merge(const Slice& key, const Slice* existing_value, const Slice& value,
+             std::string* new_value, Logger* logger) const override;
 
   static const char* kClassName() { return "StringAppendOperator"; }
   static const char* kNickName() { return "stringappend"; }
-  virtual const char* Name() const override { return kClassName(); }
-  virtual const char* NickName() const override { return kNickName(); }
+  const char* Name() const override { return kClassName(); }
+  const char* NickName() const override { return kNickName(); }
 
  private:
   std::string delim_;  // The delimiter is inserted between elements

--- a/utilities/merge_operators/string_append/stringappend2.h
+++ b/utilities/merge_operators/string_append/stringappend2.h
@@ -26,13 +26,12 @@ class StringAppendTESTOperator : public MergeOperator {
   explicit StringAppendTESTOperator(char delim_char);
   explicit StringAppendTESTOperator(const std::string& delim);
 
-  virtual bool FullMergeV2(const MergeOperationInput& merge_in,
-                           MergeOperationOutput* merge_out) const override;
+  bool FullMergeV2(const MergeOperationInput& merge_in,
+                   MergeOperationOutput* merge_out) const override;
 
-  virtual bool PartialMergeMulti(const Slice& key,
-                                 const std::deque<Slice>& operand_list,
-                                 std::string* new_value,
-                                 Logger* logger) const override;
+  bool PartialMergeMulti(const Slice& key,
+                         const std::deque<Slice>& operand_list,
+                         std::string* new_value, Logger* logger) const override;
 
   static const char* kClassName() { return "StringAppendTESTOperator"; }
   static const char* kNickName() { return "stringappendtest"; }

--- a/utilities/persistent_cache/persistent_cache_tier.h
+++ b/utilities/persistent_cache/persistent_cache_tier.h
@@ -253,22 +253,22 @@ class PersistentCacheTier : public PersistentCache {
   // Print stats to string recursively
   virtual std::string PrintStats();
 
-  virtual PersistentCache::StatsType Stats() override;
+  PersistentCache::StatsType Stats() override;
 
   // Insert to page cache
-  virtual Status Insert(const Slice& page_key, const char* data,
-                        const size_t size) override = 0;
+  Status Insert(const Slice& page_key, const char* data,
+                const size_t size) override = 0;
 
   // Lookup page cache by page identifier
-  virtual Status Lookup(const Slice& page_key, std::unique_ptr<char[]>* data,
-                        size_t* size) override = 0;
+  Status Lookup(const Slice& page_key, std::unique_ptr<char[]>* data,
+                size_t* size) override = 0;
 
   // Does it store compressed data ?
-  virtual bool IsCompressed() override = 0;
+  bool IsCompressed() override = 0;
 
-  virtual std::string GetPrintableOptions() const override = 0;
+  std::string GetPrintableOptions() const override = 0;
 
-  virtual uint64_t NewId() override;
+  uint64_t NewId() override;
 
   // Return a reference to next tier
   virtual Tier& next_tier() { return next_tier_; }

--- a/utilities/table_properties_collectors/compact_on_deletion_collector.h
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector.h
@@ -18,29 +18,26 @@ class CompactOnDeletionCollector : public TablePropertiesCollector {
   // @params key    the user key that is inserted into the table.
   // @params value  the value that is inserted into the table.
   // @params file_size  file size up to now
-  virtual Status AddUserKey(const Slice& key, const Slice& value,
-                            EntryType type, SequenceNumber seq,
-                            uint64_t file_size) override;
+  Status AddUserKey(const Slice& key, const Slice& value, EntryType type,
+                    SequenceNumber seq, uint64_t file_size) override;
 
   // Finish() will be called when a table has already been built and is ready
   // for writing the properties block.
   // @params properties  User will add their collected statistics to
   // `properties`.
-  virtual Status Finish(UserCollectedProperties* /*properties*/) override;
+  Status Finish(UserCollectedProperties* /*properties*/) override;
 
   // Return the human-readable properties, where the key is property name and
   // the value is the human-readable form of value.
-  virtual UserCollectedProperties GetReadableProperties() const override {
+  UserCollectedProperties GetReadableProperties() const override {
     return UserCollectedProperties();
   }
 
   // The name of the properties collector can be used for debugging purpose.
-  virtual const char* Name() const override {
-    return "CompactOnDeletionCollector";
-  }
+  const char* Name() const override { return "CompactOnDeletionCollector"; }
 
   // EXPERIMENTAL Return whether the output file should be further compacted
-  virtual bool NeedCompact() const override { return need_compaction_; }
+  bool NeedCompact() const override { return need_compaction_; }
 
   static const int kNumBuckets = 128;
 

--- a/utilities/trace/file_trace_reader_writer.h
+++ b/utilities/trace/file_trace_reader_writer.h
@@ -18,9 +18,9 @@ class FileTraceReader : public TraceReader {
   explicit FileTraceReader(std::unique_ptr<RandomAccessFileReader>&& reader);
   ~FileTraceReader();
 
-  virtual Status Read(std::string* data) override;
-  virtual Status Close() override;
-  virtual Status Reset() override;
+  Status Read(std::string* data) override;
+  Status Close() override;
+  Status Reset() override;
 
  private:
   std::unique_ptr<RandomAccessFileReader> file_reader_;
@@ -37,9 +37,9 @@ class FileTraceWriter : public TraceWriter {
   explicit FileTraceWriter(std::unique_ptr<WritableFileWriter>&& file_writer);
   ~FileTraceWriter();
 
-  virtual Status Write(const Slice& data) override;
-  virtual Status Close() override;
-  virtual uint64_t GetFileSize() override;
+  Status Write(const Slice& data) override;
+  Status Close() override;
+  uint64_t GetFileSize() override;
 
  private:
   std::unique_ptr<WritableFileWriter> file_writer_;

--- a/utilities/transactions/lock/point/point_lock_tracker.h
+++ b/utilities/transactions/lock/point/point_lock_tracker.h
@@ -65,7 +65,7 @@ class PointLockTracker : public LockTracker {
 
   void Clear() override;
 
-  virtual LockTracker* GetTrackedLocksSinceSavePoint(
+  LockTracker* GetTrackedLocksSinceSavePoint(
       const LockTracker& save_point_tracker) const override;
 
   PointLockStatus GetPointLockStatus(ColumnFamilyId column_family_id,

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_tracker.h
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_tracker.h
@@ -94,7 +94,7 @@ class RangeTreeLockTracker : public LockTracker {
   void Clear() override;
 
   // "If this method is not supported, returns nullptr."
-  virtual LockTracker* GetTrackedLocksSinceSavePoint(
+  LockTracker* GetTrackedLocksSinceSavePoint(
       const LockTracker&) const override {
     return nullptr;
   }

--- a/utilities/transactions/optimistic_transaction_db_impl.h
+++ b/utilities/transactions/optimistic_transaction_db_impl.h
@@ -74,15 +74,14 @@ class OptimisticTransactionDBImpl : public OptimisticTransactionDB {
 
   // Transactional `DeleteRange()` is not yet supported.
   using StackableDB::DeleteRange;
-  virtual Status DeleteRange(const WriteOptions&, ColumnFamilyHandle*,
-                             const Slice&, const Slice&) override {
+  Status DeleteRange(const WriteOptions&, ColumnFamilyHandle*, const Slice&,
+                     const Slice&) override {
     return Status::NotSupported();
   }
 
   // Range deletions also must not be snuck into `WriteBatch`es as they are
   // incompatible with `OptimisticTransactionDB`.
-  virtual Status Write(const WriteOptions& write_opts,
-                       WriteBatch* batch) override {
+  Status Write(const WriteOptions& write_opts, WriteBatch* batch) override {
     if (batch->HasDeleteRange()) {
       return Status::NotSupported();
     }

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -547,9 +547,8 @@ Status WriteCommittedTxn::PrepareInternal() {
         : db_(db), two_write_queues_(two_write_queues) {
       (void)two_write_queues_;  // to silence unused private field warning
     }
-    virtual Status Callback(SequenceNumber, bool is_mem_disabled,
-                            uint64_t log_number, size_t /*index*/,
-                            size_t /*total*/) override {
+    Status Callback(SequenceNumber, bool is_mem_disabled, uint64_t log_number,
+                    size_t /*index*/, size_t /*total*/) override {
 #ifdef NDEBUG
       (void)is_mem_disabled;
 #endif

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -115,13 +115,12 @@ class PessimisticTransaction : public TransactionBaseImpl {
 
   int64_t GetDeadlockDetectDepth() const { return deadlock_detect_depth_; }
 
-  virtual Status GetRangeLock(ColumnFamilyHandle* column_family,
-                              const Endpoint& start_key,
-                              const Endpoint& end_key) override;
+  Status GetRangeLock(ColumnFamilyHandle* column_family,
+                      const Endpoint& start_key,
+                      const Endpoint& end_key) override;
 
-  virtual Status CollapseKey(
-      const ReadOptions& options, const Slice& key,
-      ColumnFamilyHandle* column_family = nullptr) override;
+  Status CollapseKey(const ReadOptions& options, const Slice& key,
+                     ColumnFamilyHandle* column_family = nullptr) override;
 
  protected:
   // Refer to

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -36,7 +36,7 @@ class PessimisticTransactionDB : public TransactionDB {
 
   virtual ~PessimisticTransactionDB();
 
-  virtual const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
+  const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
 
   virtual Status Initialize(
       const std::vector<size_t>& compaction_enabled_cf_indices,
@@ -47,27 +47,24 @@ class PessimisticTransactionDB : public TransactionDB {
                                 Transaction* old_txn) override = 0;
 
   using StackableDB::Put;
-  virtual Status Put(const WriteOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& val) override;
+  Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, const Slice& val) override;
 
   using StackableDB::Delete;
-  virtual Status Delete(const WriteOptions& wopts,
-                        ColumnFamilyHandle* column_family,
-                        const Slice& key) override;
+  Status Delete(const WriteOptions& wopts, ColumnFamilyHandle* column_family,
+                const Slice& key) override;
 
   using StackableDB::SingleDelete;
-  virtual Status SingleDelete(const WriteOptions& wopts,
-                              ColumnFamilyHandle* column_family,
-                              const Slice& key) override;
+  Status SingleDelete(const WriteOptions& wopts,
+                      ColumnFamilyHandle* column_family,
+                      const Slice& key) override;
 
   using StackableDB::Merge;
-  virtual Status Merge(const WriteOptions& options,
-                       ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value) override;
+  Status Merge(const WriteOptions& options, ColumnFamilyHandle* column_family,
+               const Slice& key, const Slice& value) override;
 
   using TransactionDB::Write;
-  virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override;
+  Status Write(const WriteOptions& opts, WriteBatch* updates) override;
   inline Status WriteWithConcurrencyControl(const WriteOptions& opts,
                                             WriteBatch* updates) {
     Status s;
@@ -96,9 +93,9 @@ class PessimisticTransactionDB : public TransactionDB {
   }
 
   using StackableDB::CreateColumnFamily;
-  virtual Status CreateColumnFamily(const ColumnFamilyOptions& options,
-                                    const std::string& column_family_name,
-                                    ColumnFamilyHandle** handle) override;
+  Status CreateColumnFamily(const ColumnFamilyOptions& options,
+                            const std::string& column_family_name,
+                            ColumnFamilyHandle** handle) override;
 
   Status CreateColumnFamilies(
       const ColumnFamilyOptions& options,
@@ -110,7 +107,7 @@ class PessimisticTransactionDB : public TransactionDB {
       std::vector<ColumnFamilyHandle*>* handles) override;
 
   using StackableDB::DropColumnFamily;
-  virtual Status DropColumnFamily(ColumnFamilyHandle* column_family) override;
+  Status DropColumnFamily(ColumnFamilyHandle* column_family) override;
 
   Status DropColumnFamilies(
       const std::vector<ColumnFamilyHandle*>& column_families) override;
@@ -254,10 +251,10 @@ class WriteCommittedTxnDB : public PessimisticTransactionDB {
   // Optimized version of ::Write that makes use of skip_concurrency_control
   // hint
   using TransactionDB::Write;
-  virtual Status Write(const WriteOptions& opts,
-                       const TransactionDBWriteOptimizations& optimizations,
-                       WriteBatch* updates) override;
-  virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override;
+  Status Write(const WriteOptions& opts,
+               const TransactionDBWriteOptimizations& optimizations,
+               WriteBatch* updates) override;
+  Status Write(const WriteOptions& opts, WriteBatch* updates) override;
 };
 
 inline Status PessimisticTransactionDB::FailIfBatchHasTs(

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -201,7 +201,7 @@ class TransactionBaseImpl : public Transaction {
 
   WriteBatchWithIndex* GetWriteBatch() override;
 
-  virtual void SetLockTimeout(int64_t /*timeout*/) override { /* Do nothing */
+  void SetLockTimeout(int64_t /*timeout*/) override { /* Do nothing */
   }
 
   const Snapshot* GetSnapshot() const override {
@@ -213,7 +213,7 @@ class TransactionBaseImpl : public Transaction {
     return snapshot_;
   }
 
-  virtual void SetSnapshot() override;
+  void SetSnapshot() override;
   void SetSnapshotOnNextOperation(
       std::shared_ptr<TransactionNotifier> notifier = nullptr) override;
 
@@ -256,7 +256,7 @@ class TransactionBaseImpl : public Transaction {
 
   // iterates over the given batch and makes the appropriate inserts.
   // used for rebuilding prepared transactions after recovery.
-  virtual Status RebuildFromWriteBatch(WriteBatch* src_batch) override;
+  Status RebuildFromWriteBatch(WriteBatch* src_batch) override;
 
   WriteBatch* GetCommitTimeWriteBatch() override;
 
@@ -266,9 +266,8 @@ class TransactionBaseImpl : public Transaction {
   Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* column_family,
                  const Slice& key, std::string* value) override;
 
-  virtual Status GetImpl(const ReadOptions& options,
-                         ColumnFamilyHandle* column_family, const Slice& key,
-                         PinnableSlice* value) override;
+  Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* column_family,
+                 const Slice& key, PinnableSlice* value) override;
 
   // Add a key to the list of tracked keys.
   //

--- a/utilities/transactions/write_prepared_txn.h
+++ b/utilities/transactions/write_prepared_txn.h
@@ -51,16 +51,15 @@ class WritePreparedTxn : public PessimisticTransaction {
   // seq in the WAL that is also published, LastPublishedSequence, as opposed to
   // the last seq in the memtable.
   using Transaction::Get;
-  virtual Status Get(const ReadOptions& _read_options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override;
+  Status Get(const ReadOptions& _read_options,
+             ColumnFamilyHandle* column_family, const Slice& key,
+             PinnableSlice* value) override;
 
   using Transaction::MultiGet;
-  virtual void MultiGet(const ReadOptions& _read_options,
-                        ColumnFamilyHandle* column_family,
-                        const size_t num_keys, const Slice* keys,
-                        PinnableSlice* values, Status* statuses,
-                        const bool sorted_input = false) override;
+  void MultiGet(const ReadOptions& _read_options,
+                ColumnFamilyHandle* column_family, const size_t num_keys,
+                const Slice* keys, PinnableSlice* values, Status* statuses,
+                const bool sorted_input = false) override;
 
   // Note: The behavior is undefined in presence of interleaved writes to the
   // same transaction.
@@ -68,11 +67,11 @@ class WritePreparedTxn : public PessimisticTransaction {
   // based on the last seq in the WAL that is also published,
   // LastPublishedSequence, as opposed to the last seq in the memtable.
   using Transaction::GetIterator;
-  virtual Iterator* GetIterator(const ReadOptions& options) override;
-  virtual Iterator* GetIterator(const ReadOptions& options,
-                                ColumnFamilyHandle* column_family) override;
+  Iterator* GetIterator(const ReadOptions& options) override;
+  Iterator* GetIterator(const ReadOptions& options,
+                        ColumnFamilyHandle* column_family) override;
 
-  virtual void SetSnapshot() override;
+  void SetSnapshot() override;
 
  protected:
   void Initialize(const TransactionOptions& txn_options) override;
@@ -106,11 +105,10 @@ class WritePreparedTxn : public PessimisticTransaction {
 
   Status RollbackInternal() override;
 
-  virtual Status ValidateSnapshot(ColumnFamilyHandle* column_family,
-                                  const Slice& key,
-                                  SequenceNumber* tracked_at_seq) override;
+  Status ValidateSnapshot(ColumnFamilyHandle* column_family, const Slice& key,
+                          SequenceNumber* tracked_at_seq) override;
 
-  virtual Status RebuildFromWriteBatch(WriteBatch* src_batch) override;
+  Status RebuildFromWriteBatch(WriteBatch* src_batch) override;
 
   WritePreparedTxnDB* wpt_db_;
   // Number of sub-batches in prepare

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -60,9 +60,8 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
 
   virtual ~WritePreparedTxnDB();
 
-  virtual Status Initialize(
-      const std::vector<size_t>& compaction_enabled_cf_indices,
-      const std::vector<ColumnFamilyHandle*>& handles) override;
+  Status Initialize(const std::vector<size_t>& compaction_enabled_cf_indices,
+                    const std::vector<ColumnFamilyHandle*>& handles) override;
 
   Transaction* BeginTransaction(const WriteOptions& write_options,
                                 const TransactionOptions& txn_options,
@@ -83,26 +82,25 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
                        size_t batch_cnt, WritePreparedTxn* txn);
 
   using DB::Get;
-  virtual Status Get(const ReadOptions& _read_options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override;
+  Status Get(const ReadOptions& _read_options,
+             ColumnFamilyHandle* column_family, const Slice& key,
+             PinnableSlice* value) override;
 
   using DB::MultiGet;
-  virtual std::vector<Status> MultiGet(
+  std::vector<Status> MultiGet(
       const ReadOptions& _read_options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
       std::vector<std::string>* values) override;
 
   using DB::NewIterator;
-  virtual Iterator* NewIterator(const ReadOptions& _read_options,
-                                ColumnFamilyHandle* column_family) override;
+  Iterator* NewIterator(const ReadOptions& _read_options,
+                        ColumnFamilyHandle* column_family) override;
 
   using DB::NewIterators;
-  virtual Status NewIterators(
-      const ReadOptions& _read_options,
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      std::vector<Iterator*>* iterators) override;
+  Status NewIterators(const ReadOptions& _read_options,
+                      const std::vector<ColumnFamilyHandle*>& column_families,
+                      std::vector<Iterator*>* iterators) override;
 
   // Check whether the transaction that wrote the value with sequence number seq
   // is visible to the snapshot with sequence number snapshot_seq.
@@ -440,12 +438,11 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       const std::vector<ColumnFamilyHandle*>& handles) override;
   void UpdateCFComparatorMap(ColumnFamilyHandle* handle) override;
 
-  virtual const Snapshot* GetSnapshot() override;
+  const Snapshot* GetSnapshot() override;
   SnapshotImpl* GetSnapshotInternal(bool for_ww_conflict_check);
 
  protected:
-  virtual Status VerifyCFOptions(
-      const ColumnFamilyOptions& cf_options) override;
+  Status VerifyCFOptions(const ColumnFamilyOptions& cf_options) override;
   // Assign the min and max sequence numbers for reading from the db. A seq >
   // max is not valid, and a seq < min is valid, and a min <= seq < max requires
   // further checking. Normally max is defined by the snapshot and min is by
@@ -845,7 +842,7 @@ class WritePreparedTxnReadCallback : public ReadCallback {
 
   // Will be called to see if the seq number visible; if not it moves on to
   // the next seq number.
-  inline virtual bool IsVisibleFullCheck(SequenceNumber seq) override {
+  inline bool IsVisibleFullCheck(SequenceNumber seq) override {
     auto snapshot = max_visible_seq_;
     bool snap_released = false;
     auto ret =
@@ -882,10 +879,9 @@ class AddPreparedCallback : public PreReleaseCallback {
         first_prepare_batch_(first_prepare_batch) {
     (void)two_write_queues_;  // to silence unused private field warning
   }
-  virtual Status Callback(SequenceNumber prepare_seq,
-                          bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t log_number, size_t index,
-                          size_t total) override {
+  Status Callback(SequenceNumber prepare_seq,
+                  bool is_mem_disabled __attribute__((__unused__)),
+                  uint64_t log_number, size_t index, size_t total) override {
     assert(index < total);
     // To reduce the cost of lock acquisition competing with the concurrent
     // prepare requests, lock on the first callback and unlock on the last.
@@ -946,10 +942,9 @@ class WritePreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {
     assert((aux_batch_cnt_ > 0) != (aux_seq == kMaxSequenceNumber));  // xor
   }
 
-  virtual Status Callback(SequenceNumber commit_seq,
-                          bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t, size_t /*index*/,
-                          size_t /*total*/) override {
+  Status Callback(SequenceNumber commit_seq,
+                  bool is_mem_disabled __attribute__((__unused__)), uint64_t,
+                  size_t /*index*/, size_t /*total*/) override {
     // Always commit from the 2nd queue
     assert(!db_impl_->immutable_db_options().two_write_queues ||
            is_mem_disabled);

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -74,7 +74,7 @@ class WriteUnpreparedTxnReadCallback : public ReadCallback {
     assert(valid_checked_ || backed_by_snapshot_ == kBackedByDBSnapshot);
   }
 
-  virtual bool IsVisibleFullCheck(SequenceNumber seq) override;
+  bool IsVisibleFullCheck(SequenceNumber seq) override;
 
   inline bool valid() {
     valid_checked_ = true;
@@ -117,32 +117,27 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   virtual ~WriteUnpreparedTxn();
 
   using TransactionBaseImpl::Put;
-  virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value,
-                     const bool assume_tracked = false) override;
-  virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
-                     const SliceParts& value,
-                     const bool assume_tracked = false) override;
+  Status Put(ColumnFamilyHandle* column_family, const Slice& key,
+             const Slice& value, const bool assume_tracked = false) override;
+  Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
+             const SliceParts& value,
+             const bool assume_tracked = false) override;
 
   using TransactionBaseImpl::Merge;
-  virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value,
-                       const bool assume_tracked = false) override;
+  Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
+               const Slice& value, const bool assume_tracked = false) override;
 
   using TransactionBaseImpl::Delete;
-  virtual Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
-                        const bool assume_tracked = false) override;
-  virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const SliceParts& key,
-                        const bool assume_tracked = false) override;
+  Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
+                const bool assume_tracked = false) override;
+  Status Delete(ColumnFamilyHandle* column_family, const SliceParts& key,
+                const bool assume_tracked = false) override;
 
   using TransactionBaseImpl::SingleDelete;
-  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const Slice& key,
-                              const bool assume_tracked = false) override;
-  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const SliceParts& key,
-                              const bool assume_tracked = false) override;
+  Status SingleDelete(ColumnFamilyHandle* column_family, const Slice& key,
+                      const bool assume_tracked = false) override;
+  Status SingleDelete(ColumnFamilyHandle* column_family, const SliceParts& key,
+                      const bool assume_tracked = false) override;
 
   // In WriteUnprepared, untracked writes will break snapshot validation logic.
   // Snapshot validation will only check the largest sequence number of a key to
@@ -153,11 +148,9 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   // validate all values larger than snap_seq. Otherwise, we should return
   // Status::NotSupported for untracked writes.
 
-  virtual Status RebuildFromWriteBatch(WriteBatch*) override;
+  Status RebuildFromWriteBatch(WriteBatch*) override;
 
-  virtual uint64_t GetLastLogNumber() const override {
-    return last_log_number_;
-  }
+  uint64_t GetLastLogNumber() const override { return last_log_number_; }
 
   void RemoveActiveIterator(Iterator* iter) {
     active_iterators_.erase(
@@ -184,25 +177,23 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   // Get and GetIterator needs to be overridden so that a ReadCallback to
   // handle read-your-own-write is used.
   using Transaction::Get;
-  virtual Status Get(const ReadOptions& _read_options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override;
+  Status Get(const ReadOptions& _read_options,
+             ColumnFamilyHandle* column_family, const Slice& key,
+             PinnableSlice* value) override;
 
   using Transaction::MultiGet;
-  virtual void MultiGet(const ReadOptions& _read_options,
-                        ColumnFamilyHandle* column_family,
-                        const size_t num_keys, const Slice* keys,
-                        PinnableSlice* values, Status* statuses,
-                        const bool sorted_input = false) override;
+  void MultiGet(const ReadOptions& _read_options,
+                ColumnFamilyHandle* column_family, const size_t num_keys,
+                const Slice* keys, PinnableSlice* values, Status* statuses,
+                const bool sorted_input = false) override;
 
   using Transaction::GetIterator;
-  virtual Iterator* GetIterator(const ReadOptions& options) override;
-  virtual Iterator* GetIterator(const ReadOptions& options,
-                                ColumnFamilyHandle* column_family) override;
+  Iterator* GetIterator(const ReadOptions& options) override;
+  Iterator* GetIterator(const ReadOptions& options,
+                        ColumnFamilyHandle* column_family) override;
 
-  virtual Status ValidateSnapshot(ColumnFamilyHandle* column_family,
-                                  const Slice& key,
-                                  SequenceNumber* tracked_at_seq) override;
+  Status ValidateSnapshot(ColumnFamilyHandle* column_family, const Slice& key,
+                          SequenceNumber* tracked_at_seq) override;
 
  private:
   friend class WriteUnpreparedTransactionTest_ReadYourOwnWrite_Test;

--- a/utilities/transactions/write_unprepared_txn_db.h
+++ b/utilities/transactions/write_unprepared_txn_db.h
@@ -54,10 +54,9 @@ class WriteUnpreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {
     assert(unprep_seqs.size() > 0);
   }
 
-  virtual Status Callback(SequenceNumber commit_seq,
-                          bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t, size_t /*index*/,
-                          size_t /*total*/) override {
+  Status Callback(SequenceNumber commit_seq,
+                  bool is_mem_disabled __attribute__((__unused__)), uint64_t,
+                  size_t /*index*/, size_t /*total*/) override {
     const uint64_t last_commit_seq = LIKELY(data_batch_cnt_ <= 1)
                                          ? commit_seq
                                          : commit_seq + data_batch_cnt_ - 1;

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -36,7 +36,7 @@ class DBWithTTLImpl : public DBWithTTL {
 
   virtual ~DBWithTTLImpl();
 
-  virtual Status Close() override;
+  Status Close() override;
 
   Status CreateColumnFamilyWithTtl(const ColumnFamilyOptions& options,
                                    const std::string& column_family_name,
@@ -48,40 +48,36 @@ class DBWithTTLImpl : public DBWithTTL {
                             ColumnFamilyHandle** handle) override;
 
   using StackableDB::Put;
-  virtual Status Put(const WriteOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& val) override;
+  Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, const Slice& val) override;
 
   using StackableDB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override;
+  Status Get(const ReadOptions& options, ColumnFamilyHandle* column_family,
+             const Slice& key, PinnableSlice* value) override;
 
   using StackableDB::MultiGet;
-  virtual std::vector<Status> MultiGet(
+  std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
       std::vector<std::string>* values) override;
 
   using StackableDB::KeyMayExist;
-  virtual bool KeyMayExist(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           std::string* value,
-                           bool* value_found = nullptr) override;
+  bool KeyMayExist(const ReadOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   std::string* value, bool* value_found = nullptr) override;
 
   using StackableDB::Merge;
-  virtual Status Merge(const WriteOptions& options,
-                       ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value) override;
+  Status Merge(const WriteOptions& options, ColumnFamilyHandle* column_family,
+               const Slice& key, const Slice& value) override;
 
-  virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override;
+  Status Write(const WriteOptions& opts, WriteBatch* updates) override;
 
   using StackableDB::NewIterator;
-  virtual Iterator* NewIterator(const ReadOptions& _read_options,
-                                ColumnFamilyHandle* column_family) override;
+  Iterator* NewIterator(const ReadOptions& _read_options,
+                        ColumnFamilyHandle* column_family) override;
 
-  virtual DB* GetBaseDB() override { return db_; }
+  DB* GetBaseDB() override { return db_; }
 
   static bool IsStale(const Slice& value, int32_t ttl, SystemClock* clock);
 
@@ -157,8 +153,8 @@ class TtlCompactionFilter : public LayeredCompactionFilterBase {
                       std::unique_ptr<const CompactionFilter>
                           _user_comp_filter_from_factory = nullptr);
 
-  virtual bool Filter(int level, const Slice& key, const Slice& old_val,
-                      std::string* new_val, bool* value_changed) const override;
+  bool Filter(int level, const Slice& key, const Slice& old_val,
+              std::string* new_val, bool* value_changed) const override;
 
   const char* Name() const override { return kClassName(); }
   static const char* kClassName() { return "TtlCompactionFilter"; }


### PR DESCRIPTION
Summary: ... to follow modern C++ style / idioms.

Used this hack:
```
for FILE in `cat my_list_of_files`; do perl -pi -e 'BEGIN{undef $/;} s/ virtual( [^;{]* override)/$1/smg' $FILE; done
```

Test Plan: existing tests, CI