### PR TITLE
Augment sst_dump tool to verify num_entries in table property

### DIFF
--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -460,7 +460,7 @@ Status SstFileDumper::SetOldTableOptions() {
   return Status::OK();
 }
 
-Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
+Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num_limit,
                                      bool has_from, const std::string& from_key,
                                      bool has_to, const std::string& to_key,
                                      bool use_from_as_prefix) {
@@ -494,7 +494,7 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
     Slice key = iter->key();
     Slice value = iter->value();
     ++i;
-    if (read_num > 0 && i > read_num) {
+    if (read_num_limit > 0 && i > read_num_limit) {
       break;
     }
 
@@ -556,14 +556,17 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
   Status ret = iter->status();
 
   bool verify_num_entries =
-      (read_num == 0 || read_num == std::numeric_limits<uint64_t>::max()) &&
+      (read_num_limit == 0 ||
+       read_num_limit == std::numeric_limits<uint64_t>::max()) &&
       !has_from && !has_to;
   if (verify_num_entries && ret.ok()) {
     // Compare the number of entries
     if (!table_properties_) {
       fprintf(stderr, "Table properties not available.");
     } else {
-      if (i != table_properties_->num_entries) {
+      // TODO: verify num_range_deletions
+      if (i != table_properties_->num_entries -
+                   table_properties_->num_range_deletions) {
         ret =
             Status::Corruption("Table property has num_entries = " +
                                std::to_string(table_properties_->num_entries) +

--- a/table/sst_file_dumper.h
+++ b/table/sst_file_dumper.h
@@ -23,6 +23,12 @@ class SstFileDumper {
                          const EnvOptions& soptions = EnvOptions(),
                          bool silent = false);
 
+  // read_num limits the total number of keys read. If read_num = 0, then
+  // there is no limit.
+  // If read_num = 0 or std::numeric_limits<uint64_t>::max(), has_from and
+  // has_to are false, then the number of keys read is compared with
+  // `num_entries` field in table properties. A Corruption status is returned if
+  // they do not match.
   Status ReadSequential(bool print_kv, uint64_t read_num, bool has_from,
                         const std::string& from_key, bool has_to,
                         const std::string& to_key,

--- a/table/sst_file_dumper.h
+++ b/table/sst_file_dumper.h
@@ -23,13 +23,12 @@ class SstFileDumper {
                          const EnvOptions& soptions = EnvOptions(),
                          bool silent = false);
 
-  // read_num limits the total number of keys read. If read_num = 0, then
-  // there is no limit.
-  // If read_num = 0 or std::numeric_limits<uint64_t>::max(), has_from and
-  // has_to are false, then the number of keys read is compared with
-  // `num_entries` field in table properties. A Corruption status is returned if
-  // they do not match.
-  Status ReadSequential(bool print_kv, uint64_t read_num, bool has_from,
+  // read_num_limit limits the total number of keys read. If read_num_limit = 0,
+  // then there is no limit. If read_num_limit = 0 or
+  // std::numeric_limits<uint64_t>::max(), has_from and has_to are false, then
+  // the number of keys read is compared with `num_entries` field in table
+  // properties. A Corruption status is returned if they do not match.
+  Status ReadSequential(bool print_kv, uint64_t read_num_limit, bool has_from,
                         const std::string& from_key, bool has_to,
                         const std::string& to_key,
                         bool use_from_as_prefix = false);

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -109,7 +109,7 @@ class SSTDumpToolTest : public testing::Test {
   }
 
   void createSST(const Options& opts, const std::string& file_name,
-                 uint32_t wide_column_one_in = 0) {
+                 uint32_t wide_column_one_in = 0, bool range_del = false) {
     Env* test_env = opts.env;
     FileOptions file_options(opts);
     ReadOptions read_options;
@@ -139,7 +139,7 @@ class SSTDumpToolTest : public testing::Test {
     uint32_t num_keys = kNumKey;
     const char* comparator_name = ikc.user_comparator()->Name();
     if (strcmp(comparator_name, ReverseBytewiseComparator()->Name()) == 0) {
-      for (int32_t i = num_keys; i >= 0; i--) {
+      for (int32_t i = num_keys; i > 0; i--) {
         if (wide_column_one_in == 0 || i % wide_column_one_in != 0) {
           tb->Add(MakeKey(i), MakeValue(i));
         } else {
@@ -154,7 +154,12 @@ class SSTDumpToolTest : public testing::Test {
         tb->Add(MakeKeyWithTimeStamp(i, 100 + i), MakeValue(i));
       }
     } else {
-      for (uint32_t i = 0; i < num_keys; i++) {
+      uint32_t i = 0;
+      if (range_del) {
+        tb->Add(MakeKey(i, kTypeRangeDeletion), MakeValue(i + 1));
+        i = 1;
+      }
+      for (; i < num_keys; i++) {
         if (wide_column_one_in == 0 || i % wide_column_one_in != 0) {
           tb->Add(MakeKey(i), MakeValue(i));
         } else {
@@ -526,9 +531,24 @@ TEST_F(SSTDumpToolTest, SstFileDumperVerifyNumRecords) {
   opts.env = env();
 
   EnvOptions env_opts;
+  std::string file_path = MakeFilePath("rocksdb_sst_test.sst");
   {
-    std::string file_path = MakeFilePath("rocksdb_sst_test.sst");
     createSST(opts, file_path, 10);
+    SstFileDumper dumper(opts, file_path, Temperature::kUnknown,
+                         1024 /*readahead_size*/, true /*verify_checksum*/,
+                         false /*output_hex*/, false /*decode_blob_index*/,
+                         env_opts, /*silent=*/true);
+    ASSERT_OK(dumper.getStatus());
+    ASSERT_OK(dumper.ReadSequential(
+        /*print_kv=*/false, /*read_num=*/std::numeric_limits<uint64_t>::max(),
+        /*has_from=*/false, /*from_key=*/"",
+        /*has_to=*/false, /*to_key=*/""));
+    cleanup(opts, file_path);
+  }
+
+  {
+    // Test with range del
+    createSST(opts, file_path, 10, /*range_del=*/true);
     SstFileDumper dumper(opts, file_path, Temperature::kUnknown,
                          1024 /*readahead_size*/, true /*verify_checksum*/,
                          false /*output_hex*/, false /*decode_blob_index*/,
@@ -548,7 +568,6 @@ TEST_F(SSTDumpToolTest, SstFileDumperVerifyNumRecords) {
           props->num_entries = kNumKey + 2;
         });
     SyncPoint::GetInstance()->EnableProcessing();
-    std::string file_path = MakeFilePath("rocksdb_sst_test2.sst");
     createSST(opts, file_path, 10);
     SstFileDumper dumper(opts, file_path, Temperature::kUnknown,
                          1024 /*readahead_size*/, true /*verify_checksum*/,
@@ -564,6 +583,23 @@ TEST_F(SSTDumpToolTest, SstFileDumperVerifyNumRecords) {
         std::strstr("Table property has num_entries = 1026 but scanning the "
                     "table returns 1024 records.",
                     s.getState()));
+
+    // Validation is not performed when read_num, has_from, has_to are set
+    ASSERT_OK(dumper.ReadSequential(
+        /*print_kv=*/false, /*read_num=*/10,
+        /*has_from=*/false, /*from_key=*/"",
+        /*has_to=*/false, /*to_key=*/""));
+
+    ASSERT_OK(dumper.ReadSequential(
+        /*print_kv=*/false, /*read_num=*/std::numeric_limits<uint64_t>::max(),
+        /*has_from=*/true, /*from_key=*/MakeKey(100),
+        /*has_to=*/false, /*to_key=*/""));
+
+    ASSERT_OK(dumper.ReadSequential(
+        /*print_kv=*/false, /*read_num=*/std::numeric_limits<uint64_t>::max(),
+        /*has_from=*/false, /*from_key=*/"",
+        /*has_to=*/true, /*to_key=*/MakeKey(100)));
+
     cleanup(opts, file_path);
   }
 }

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -540,7 +540,8 @@ TEST_F(SSTDumpToolTest, SstFileDumperVerifyNumRecords) {
                          env_opts, /*silent=*/true);
     ASSERT_OK(dumper.getStatus());
     ASSERT_OK(dumper.ReadSequential(
-        /*print_kv=*/false, /*read_num=*/std::numeric_limits<uint64_t>::max(),
+        /*print_kv=*/false,
+        /*read_num_limit=*/std::numeric_limits<uint64_t>::max(),
         /*has_from=*/false, /*from_key=*/"",
         /*has_to=*/false, /*to_key=*/""));
     cleanup(opts, file_path);
@@ -555,7 +556,8 @@ TEST_F(SSTDumpToolTest, SstFileDumperVerifyNumRecords) {
                          env_opts, /*silent=*/true);
     ASSERT_OK(dumper.getStatus());
     ASSERT_OK(dumper.ReadSequential(
-        /*print_kv=*/false, /*read_num=*/std::numeric_limits<uint64_t>::max(),
+        /*print_kv=*/false,
+        /*read_num_limit=*/std::numeric_limits<uint64_t>::max(),
         /*has_from=*/false, /*from_key=*/"",
         /*has_to=*/false, /*to_key=*/""));
     cleanup(opts, file_path);
@@ -575,7 +577,8 @@ TEST_F(SSTDumpToolTest, SstFileDumperVerifyNumRecords) {
                          env_opts, /*silent=*/true);
     ASSERT_OK(dumper.getStatus());
     Status s = dumper.ReadSequential(
-        /*print_kv=*/false, /*read_num=*/std::numeric_limits<uint64_t>::max(),
+        /*print_kv=*/false,
+        /*read_num_limit==*/std::numeric_limits<uint64_t>::max(),
         /*has_from=*/false, /*from_key=*/"",
         /*has_to=*/false, /*to_key=*/"");
     ASSERT_TRUE(s.IsCorruption());
@@ -586,17 +589,19 @@ TEST_F(SSTDumpToolTest, SstFileDumperVerifyNumRecords) {
 
     // Validation is not performed when read_num, has_from, has_to are set
     ASSERT_OK(dumper.ReadSequential(
-        /*print_kv=*/false, /*read_num=*/10,
+        /*print_kv=*/false, /*read_num_limit=*/10,
         /*has_from=*/false, /*from_key=*/"",
         /*has_to=*/false, /*to_key=*/""));
 
     ASSERT_OK(dumper.ReadSequential(
-        /*print_kv=*/false, /*read_num=*/std::numeric_limits<uint64_t>::max(),
+        /*print_kv=*/false,
+        /*read_num_limit=*/std::numeric_limits<uint64_t>::max(),
         /*has_from=*/true, /*from_key=*/MakeKey(100),
         /*has_to=*/false, /*to_key=*/""));
 
     ASSERT_OK(dumper.ReadSequential(
-        /*print_kv=*/false, /*read_num=*/std::numeric_limits<uint64_t>::max(),
+        /*print_kv=*/false,
+        /*read_num_limit=*/std::numeric_limits<uint64_t>::max(),
         /*has_from=*/false, /*from_key=*/"",
         /*has_to=*/true, /*to_key=*/MakeKey(100)));
 

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -55,6 +55,8 @@ void print_help(bool to_stderr) {
 
     --command=check|scan|raw|verify|identify
         check: Iterate over entries in files but don't print anything except if an error is encountered (default command)
+               When read_num, from and to are not set, it compares the number of keys read with num_entries in table
+               property and will report corruption if there is a mismatch.
         scan: Iterate over entries in files and print them to screen
         raw: Dump all the table contents to <file_name>_dump.txt
         verify: Iterate all the blocks in files verifying checksum to detect possible corruption but don't print anything except if a corruption is encountered


### PR DESCRIPTION
Summary: sst_dump --command=check can now compare number of keys in a file with num_entries in table property and reports corruption is there is a mismatch. 

Test plan: 
- new unit test for API `SstFileDumper::ReadSequential`
- ran sst_dump on a good and a bad file:
```
sst_dump --file=./32316112.sst
options.env is 0x7f68bfcb5000
Process ./32316112.sst
Sst file format: block-based
from [] to []

sst_dump --file=./32316115.sst
options.env is 0x7f6d0d2b5000
Process ./32316115.sst
Sst file format: block-based
from [] to []
./32316115.sst: Corruption: Table property has num_entries = 6050408 but scanning the table returns 6050406 records.
```