### PR TITLE
Mark destructors as overridden

### DIFF
--- a/include/rocksdb/utilities/optimistic_transaction_db.h
+++ b/include/rocksdb/utilities/optimistic_transaction_db.h
@@ -102,7 +102,7 @@ class OptimisticTransactionDB : public StackableDB {
                      std::vector<ColumnFamilyHandle*>* handles,
                      OptimisticTransactionDB** dbptr);
 
-  virtual ~OptimisticTransactionDB() {}
+  ~OptimisticTransactionDB() override {}
 
   // Starts a new Transaction.
   //

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -27,7 +27,7 @@ class StackableDB : public DB {
   explicit StackableDB(std::shared_ptr<DB> db)
       : db_(db.get()), shared_db_ptr_(db) {}
 
-  ~StackableDB() {
+  ~StackableDB() override {
     if (shared_db_ptr_ == nullptr) {
       delete db_;
     } else {

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -135,7 +135,7 @@ class RangeLockManagerHandle : public LockManagerHandle {
   virtual std::vector<RangeDeadlockPath> GetRangeDeadlockInfoBuffer() = 0;
   virtual void SetRangeDeadlockInfoBufferSize(uint32_t target_size) = 0;
 
-  virtual ~RangeLockManagerHandle() {}
+  ~RangeLockManagerHandle() override {}
 };
 
 // A factory function to create a Range Lock Manager. The created object should
@@ -503,4 +503,3 @@ class TransactionDB : public StackableDB {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -246,7 +246,7 @@ class BlobDB : public StackableDB {
 
   virtual Status SyncBlobFiles(const WriteOptions& write_options) = 0;
 
-  virtual ~BlobDB() {}
+  ~BlobDB() override {}
 
  protected:
   explicit BlobDB();


### PR DESCRIPTION
Summary: We are trying to use rocksdb inside Hedwig. This is causing some builds to fail D53033764. Hence fixing -Wsuggest-destructor-override warning.

Differential Revision: D53328538


