### PR TITLE
Remove deprecated option `level_compaction_dynamic_file_size`

### DIFF
--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -350,11 +350,9 @@ Compaction::Compaction(
 
   // for the non-bottommost levels, it tries to build files match the target
   // file size, but not guaranteed. It could be 2x the size of the target size.
-  max_output_file_size_ =
-      bottommost_level_ || grandparents_.empty() ||
-              !_immutable_options.level_compaction_dynamic_file_size
-          ? target_output_file_size_
-          : 2 * target_output_file_size_;
+  max_output_file_size_ = bottommost_level_ || grandparents_.empty()
+                              ? target_output_file_size_
+                              : 2 * target_output_file_size_;
 
 #ifndef NDEBUG
   for (size_t i = 1; i < inputs_.size(); ++i) {

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -1752,23 +1752,9 @@ TEST_F(CompactionJobTest, ResultSerialization) {
   }
 }
 
-class CompactionJobDynamicFileSizeTest
-    : public CompactionJobTestBase,
-      public ::testing::WithParamInterface<bool> {
- public:
-  CompactionJobDynamicFileSizeTest()
-      : CompactionJobTestBase(
-            test::PerThreadDBPath("compaction_job_dynamic_file_size_test"),
-            BytewiseComparator(), [](uint64_t /*ts*/) { return ""; },
-            /*test_io_priority=*/false, TableTypeForTest::kMockTable) {}
-};
-
-TEST_P(CompactionJobDynamicFileSizeTest, CutForMaxCompactionBytes) {
+TEST_F(CompactionJobTest, CutForMaxCompactionBytes) {
   // dynamic_file_size option should have no impact on cutting for max
   // compaction bytes.
-  bool enable_dyanmic_file_size = GetParam();
-  cf_options_.level_compaction_dynamic_file_size = enable_dyanmic_file_size;
-
   NewDB();
   mutable_cf_options_.target_file_size_base = 80;
   mutable_cf_options_.max_compaction_bytes = 21;
@@ -1842,10 +1828,7 @@ TEST_P(CompactionJobDynamicFileSizeTest, CutForMaxCompactionBytes) {
                 {expected_file1, expected_file2});
 }
 
-TEST_P(CompactionJobDynamicFileSizeTest, CutToSkipGrandparentFile) {
-  bool enable_dyanmic_file_size = GetParam();
-  cf_options_.level_compaction_dynamic_file_size = enable_dyanmic_file_size;
-
+TEST_F(CompactionJobTest, CutToSkipGrandparentFile) {
   NewDB();
   // Make sure the grandparent level file size (10) qualifies skipping.
   // Currently, it has to be > 1/8 of target file size.
@@ -1880,28 +1863,15 @@ TEST_P(CompactionJobDynamicFileSizeTest, CutToSkipGrandparentFile) {
       mock::MakeMockFile({{KeyStr("x", 4U, kTypeValue), "val"},
                           {KeyStr("z", 6U, kTypeValue), "val3"}});
 
-  auto expected_file_disable_dynamic_file_size =
-      mock::MakeMockFile({{KeyStr("a", 5U, kTypeValue), "val2"},
-                          {KeyStr("c", 3U, kTypeValue), "val"},
-                          {KeyStr("x", 4U, kTypeValue), "val"},
-                          {KeyStr("z", 6U, kTypeValue), "val3"}});
-
   SetLastSequence(6U);
   const std::vector<int> input_levels = {0, 1};
   auto lvl0_files = cfd_->current()->storage_info()->LevelFiles(0);
   auto lvl1_files = cfd_->current()->storage_info()->LevelFiles(1);
-  if (enable_dyanmic_file_size) {
     RunCompaction({lvl0_files, lvl1_files}, input_levels,
                   {expected_file1, expected_file2});
-  } else {
-    RunCompaction({lvl0_files, lvl1_files}, input_levels,
-                  {expected_file_disable_dynamic_file_size});
-  }
 }
 
-TEST_P(CompactionJobDynamicFileSizeTest, CutToAlignGrandparentBoundary) {
-  bool enable_dyanmic_file_size = GetParam();
-  cf_options_.level_compaction_dynamic_file_size = enable_dyanmic_file_size;
+TEST_F(CompactionJobTest, CutToAlignGrandparentBoundary) {
   NewDB();
 
   // MockTable has 1 byte per entry by default and each file is 10 bytes.
@@ -1968,40 +1938,15 @@ TEST_P(CompactionJobDynamicFileSizeTest, CutToAlignGrandparentBoundary) {
   }
   expected_file2.emplace_back(KeyStr("s", 4U, kTypeValue), "val");
 
-  mock::KVVector expected_file_disable_dynamic_file_size1;
-  for (char i = 0; i < 10; i++) {
-    expected_file_disable_dynamic_file_size1.emplace_back(
-        KeyStr(std::string(1, ch + i), i + 10, kTypeValue),
-        "val" + std::to_string(i));
-  }
-
-  mock::KVVector expected_file_disable_dynamic_file_size2;
-  for (char i = 10; i < 12; i++) {
-    expected_file_disable_dynamic_file_size2.emplace_back(
-        KeyStr(std::string(1, ch + i), i + 10, kTypeValue),
-        "val" + std::to_string(i));
-  }
-
-  expected_file_disable_dynamic_file_size2.emplace_back(
-      KeyStr("s", 4U, kTypeValue), "val");
-
   SetLastSequence(22U);
   const std::vector<int> input_levels = {0, 1};
   auto lvl0_files = cfd_->current()->storage_info()->LevelFiles(0);
   auto lvl1_files = cfd_->current()->storage_info()->LevelFiles(1);
-  if (enable_dyanmic_file_size) {
     RunCompaction({lvl0_files, lvl1_files}, input_levels,
                   {expected_file1, expected_file2});
-  } else {
-    RunCompaction({lvl0_files, lvl1_files}, input_levels,
-                  {expected_file_disable_dynamic_file_size1,
-                   expected_file_disable_dynamic_file_size2});
-  }
 }
 
-TEST_P(CompactionJobDynamicFileSizeTest, CutToAlignGrandparentBoundarySameKey) {
-  bool enable_dyanmic_file_size = GetParam();
-  cf_options_.level_compaction_dynamic_file_size = enable_dyanmic_file_size;
+TEST_F(CompactionJobTest, CutToAlignGrandparentBoundarySameKey) {
   NewDB();
 
   // MockTable has 1 byte per entry by default and each file is 10 bytes.
@@ -2038,13 +1983,9 @@ TEST_P(CompactionJobDynamicFileSizeTest, CutToAlignGrandparentBoundarySameKey) {
   AddMockFile(file5, 2);
 
   mock::KVVector expected_file1;
-  mock::KVVector expected_file_disable_dynamic_file_size;
-
   for (int i = 0; i < 8; i++) {
     expected_file1.emplace_back(KeyStr("a", 100 - i, kTypeValue),
                                 "val" + std::to_string(100 - i));
-    expected_file_disable_dynamic_file_size.emplace_back(
-        KeyStr("a", 100 - i, kTypeValue), "val" + std::to_string(100 - i));
   }
 
   // make sure `b` is cut in a separated file (so internally it's not using
@@ -2052,9 +1993,6 @@ TEST_P(CompactionJobDynamicFileSizeTest, CutToAlignGrandparentBoundarySameKey) {
   // than "b:85" on L2.)
   auto expected_file2 =
       mock::MakeMockFile({{KeyStr("b", 90U, kTypeValue), "valb"}});
-
-  expected_file_disable_dynamic_file_size.emplace_back(
-      KeyStr("b", 90U, kTypeValue), "valb");
 
   SetLastSequence(122U);
   const std::vector<int> input_levels = {0, 1};
@@ -2066,20 +2004,13 @@ TEST_P(CompactionJobDynamicFileSizeTest, CutToAlignGrandparentBoundarySameKey) {
   for (int i = 80; i <= 100; i++) {
     snapshots.emplace_back(i);
   }
-  if (enable_dyanmic_file_size) {
     RunCompaction({lvl0_files, lvl1_files}, input_levels,
                   {expected_file1, expected_file2}, snapshots);
-  } else {
-    RunCompaction({lvl0_files, lvl1_files}, input_levels,
-                  {expected_file_disable_dynamic_file_size}, snapshots);
-  }
 }
 
-TEST_P(CompactionJobDynamicFileSizeTest, CutForMaxCompactionBytesSameKey) {
+TEST_F(CompactionJobTest, CutForMaxCompactionBytesSameKey) {
   // dynamic_file_size option should have no impact on cutting for max
   // compaction bytes.
-  bool enable_dyanmic_file_size = GetParam();
-  cf_options_.level_compaction_dynamic_file_size = enable_dyanmic_file_size;
 
   NewDB();
   mutable_cf_options_.target_file_size_base = 80;
@@ -2135,9 +2066,6 @@ TEST_P(CompactionJobDynamicFileSizeTest, CutForMaxCompactionBytesSameKey) {
   RunCompaction({lvl0_files, lvl1_files}, input_levels,
                 {expected_file1, expected_file2, expected_file3}, snapshots);
 }
-
-INSTANTIATE_TEST_CASE_P(CompactionJobDynamicFileSizeTest,
-                        CompactionJobDynamicFileSizeTest, testing::Bool());
 
 class CompactionJobTimestampTest : public CompactionJobTestBase {
  public:

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -320,7 +320,6 @@ bool CompactionOutputs::ShouldStopBefore(const CompactionIterator& c_iter) {
         being_grandparent_gap_ ? 2 : 3;
     if (compaction_->immutable_options()->compaction_style ==
             kCompactionStyleLevel &&
-        compaction_->immutable_options()->level_compaction_dynamic_file_size &&
         num_grandparent_boundaries_crossed >=
             num_skippable_boundaries_crossed &&
         grandparent_overlapped_bytes_ - previous_overlapped_bytes >
@@ -342,7 +341,6 @@ bool CompactionOutputs::ShouldStopBefore(const CompactionIterator& c_iter) {
     // improvement.
     if (compaction_->immutable_options()->compaction_style ==
             kCompactionStyleLevel &&
-        compaction_->immutable_options()->level_compaction_dynamic_file_size &&
         current_output_file_size_ >=
             ((compaction_->target_output_file_size() + 99) / 100) *
                 (50 + std::min(grandparent_boundary_switched_num_ * 5,

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -4720,7 +4720,6 @@ TEST_F(DBCompactionTest, LevelTtlCompactionOutputCuttingIteractingWithOther) {
   options.env = env_;
   options.target_file_size_base = 4 << 10;
   options.disable_auto_compactions = true;
-  options.level_compaction_dynamic_file_size = false;
 
   DestroyAndReopen(options);
   Random rnd(301);

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -547,17 +547,6 @@ struct AdvancedColumnFamilyOptions {
   // Default: true
   bool level_compaction_dynamic_level_bytes = true;
 
-  // DEPRECATED: This option might be removed in a future release.
-  //
-  // Allows RocksDB to generate files that are not exactly the target_file_size
-  // only for the non-bottommost files. Which can reduce the write-amplification
-  // from compaction. The file size could be from 0 to 2x target_file_size.
-  // Once enabled, non-bottommost compaction will try to cut the files align
-  // with the next level file boundaries (grandparent level).
-  //
-  // Default: true
-  bool level_compaction_dynamic_file_size = true;
-
   // Default: 10.
   //
   // Dynamically changeable through SetOptions() API

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -594,9 +594,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"level_compaction_dynamic_file_size",
-         {offsetof(struct ImmutableCFOptions,
-                   level_compaction_dynamic_file_size),
-          OptionType::kBoolean, OptionVerificationType::kNormal,
+         {0, OptionType::kBoolean, OptionVerificationType::kDeprecated,
           OptionTypeFlags::kNone}},
         {"optimize_filters_for_hits",
          {offsetof(struct ImmutableCFOptions, optimize_filters_for_hits),
@@ -944,8 +942,6 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       bloom_locality(cf_options.bloom_locality),
       level_compaction_dynamic_level_bytes(
           cf_options.level_compaction_dynamic_level_bytes),
-      level_compaction_dynamic_file_size(
-          cf_options.level_compaction_dynamic_file_size),
       num_levels(cf_options.num_levels),
       optimize_filters_for_hits(cf_options.optimize_filters_for_hits),
       force_consistency_checks(cf_options.force_consistency_checks),

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -64,8 +64,6 @@ struct ImmutableCFOptions {
 
   bool level_compaction_dynamic_level_bytes;
 
-  bool level_compaction_dynamic_file_size;
-
   int num_levels;
 
   bool optimize_filters_for_hits;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -302,8 +302,6 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
   cf_opts->bloom_locality = ioptions.bloom_locality;
   cf_opts->level_compaction_dynamic_level_bytes =
       ioptions.level_compaction_dynamic_level_bytes;
-  cf_opts->level_compaction_dynamic_file_size =
-      ioptions.level_compaction_dynamic_file_size;
   cf_opts->num_levels = ioptions.num_levels;
   cf_opts->optimize_filters_for_hits = ioptions.optimize_filters_for_hits;
   cf_opts->force_consistency_checks = ioptions.force_consistency_checks;

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -2451,7 +2451,6 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.target_file_size_multiplier, 13);
   ASSERT_EQ(new_cf_opt.max_bytes_for_level_base, 14U);
   ASSERT_EQ(new_cf_opt.level_compaction_dynamic_level_bytes, true);
-  ASSERT_EQ(new_cf_opt.level_compaction_dynamic_file_size, true);
   ASSERT_EQ(new_cf_opt.max_bytes_for_level_multiplier, 15.0);
   ASSERT_EQ(new_cf_opt.max_bytes_for_level_multiplier_additional.size(), 3U);
   ASSERT_EQ(new_cf_opt.max_bytes_for_level_multiplier_additional[0], 16);

--- a/unreleased_history/public_api_changes/remove_dynamic_level_size.md
+++ b/unreleased_history/public_api_changes/remove_dynamic_level_size.md
@@ -1,0 +1,1 @@
+Removed deprecated option `ColumnFamilyOptions::level_compaction_dynamic_file_size`


### PR DESCRIPTION
The option is introduced in #10655 to allow reverting to old behavior. The option is enabled by default and there has not been a need to disable it. Remove it for 9.0 release. Also fixed and improved a few unit tests that depended on setting this option to false.

Test plan: existing tests. 