### PR TITLE
Mark wal_compression feature as production-ready

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1259,10 +1259,11 @@ struct DBOptions {
   // file.
   bool manual_wal_flush = false;
 
-  // This feature is WORK IN PROGRESS
   // If enabled WAL records will be compressed before they are written.
-  // Only zstd is supported. Compressed WAL records will be read in supported
-  // versions regardless of the wal_compression settings.
+  // Only zstd is supported (until streaming support is adapted for other
+  // compression types). Compressed WAL records will be read in supported
+  // versions (>= RocksDB 7.4.0 for zstd) regardless of the current
+  // wal_compression setting.
   CompressionType wal_compression = kNoCompression;
 
   // If true, RocksDB supports flushing multiple column families and committing

--- a/unreleased_history/new_features/wal_compression_production.md
+++ b/unreleased_history/new_features/wal_compression_production.md
@@ -1,0 +1,1 @@
+Mark wal\_compression feature as production-ready. Currently only compatible with ZSTD compression.


### PR DESCRIPTION
Summary: (as title)

Test Plan: in use at Meta for a large service, in crash test