### PR TITLE
Fix unexpected keyword argument 'print_as_stderr' in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -909,7 +909,7 @@ def blackbox_crash_main(args, unknown_args):
     print("stdout:", outs)
 
     # Print stderr of the final run
-    exit_if_stderr_has_errors(errs, print_as_stderr=args.print_stderr_separately)
+    exit_if_stderr_has_errors(errs, args.print_stderr_separately)
 
     # we need to clean up after ourselves -- only do this on test success
     cleanup_after_success(dbname)


### PR DESCRIPTION
Fix crash test failure like https://github.com/facebook/rocksdb/actions/runs/7821514511/job/21338625372#step:5:530

Test plan: CI

With --print_stderr_separately
```
python3 tools/db_crashtest.py blackbox --simple --max_key=25000000 --write_buffer_size=4194304 --print_stderr_separately 2> /tmp/error.log
...
DB path: [/tmp/rocksdb_crashtest_blackboxadjlpsxa]
(Re-)verified 0 unique IDs
2024/02/07-15:03:29  Initializing worker threads
Crash-recovery verification passed :)
2024/02/07-15:03:33  Starting database operations
2024/02/07-15:03:33  Starting verification
New cache capacity = 19461571

cat /tmp/error.log
stderr has error message:

simulated error
...


python3 tools/db_crashtest.py whitebox --simple --max_key=25000000 --write_buffer_size=4194304 --print_stderr_separately 2> /tmp/error.log
...
DB path: [/tmp/rocksdb_crashtest_whiteboxvhwwg7aw]
(Re-)verified 0 unique IDs
2024/02/07-15:01:54  Initializing worker threads
Crash-recovery verification passed :)
2024/02/07-15:01:59  Starting database operations
2024/02/07-15:01:59  Starting verification
New cache capacity = 4865393

cat /tmp/error.log
stderr has error message:

simulated error
...
```

Without --print_stderr_separately, error.log is empty:

```
python3 tools/db_crashtest.py whitebox --simple --max_key=25000000 --write_buffer_size=4194304 2> /tmp/error.log
...
DB path: [/tmp/rocksdb_crashtest_whitebox7d4d_5h2]
(Re-)verified 0 unique IDs
2024/02/07-15:07:58  Initializing worker threads
Crash-recovery verification passed :)
2024/02/07-15:08:02  Starting database operations
2024/02/07-15:08:02  Starting verification
New cache capacity = 4865393

stderr has error message:
simulated error
simulated error
simulated error
simulated error
simulated errorNo writes or ops?
Verification failed :(

cat /tmp/error.log


python3 tools/db_crashtest.py blackbox --simple --max_key=25000000 --write_buffer_size=4194304 2> /tmp/error.log
...DB path: [/tmp/rocksdb_crashtest_blackbox_krti3my]
(Re-)verified 0 unique IDs
2024/02/07-15:10:24  Initializing worker threads
Crash-recovery verification passed :)
2024/02/07-15:10:29  Starting database operations
2024/02/07-15:10:29  Starting verification

stderr has error message:
simulated error
simulated error
simulated error
simulated error
simulated error
No writes or ops?
Verification failed :(

cat /tmp/error.log

```