### PR TITLE
Fix a data race in DBImpl::RenameTempFileToOptionsFile

### DIFF
--- a/unreleased_history/bug_fixes/fix_rename_temp_file_to_options_file_race.md
+++ b/unreleased_history/bug_fixes/fix_rename_temp_file_to_options_file_race.md
@@ -1,0 +1,1 @@
+Fixed a data race in `DBImpl::RenameTempFileToOptionsFile`.


### PR DESCRIPTION
Summary: `DBImpl::disable_delete_obsolete_files_` should only be accessed while holding the DB mutex to prevent data races. There's a piece of logic in `DBImpl::RenameTempFileToOptionsFile` where this synchronization was previously missing. The patch fixes this issue similarly to how it's handled in `DisableFileDeletions` and `EnableFileDeletions`, that is, by saving the counter value while holding the mutex and then performing the actual file deletion outside the critical section. Note: this PR only fixes the race itself; as a followup, we can also look into cleaning up and optimizing the file deletion logic (which is currently inefficient on multiple different levels).

Differential Revision: D53675153


