### PR TITLE
Add support to bulk load external files for UDT in memtable only feature

### DIFF
--- a/db/c_test.c
+++ b/db/c_test.c
@@ -883,9 +883,8 @@ int main(int argc, char** argv) {
   StartPhase("addfile");
   {
     rocksdb_envoptions_t* env_opt = rocksdb_envoptions_create();
-    rocksdb_options_t* io_options = rocksdb_options_create();
     rocksdb_sstfilewriter_t* writer =
-        rocksdb_sstfilewriter_create(env_opt, io_options);
+        rocksdb_sstfilewriter_create(env_opt, options);
 
     remove(sstfilename);
     rocksdb_sstfilewriter_open(writer, sstfilename, &err);
@@ -944,7 +943,6 @@ int main(int argc, char** argv) {
 
     rocksdb_ingestexternalfileoptions_destroy(ing_opt);
     rocksdb_sstfilewriter_destroy(writer);
-    rocksdb_options_destroy(io_options);
     rocksdb_envoptions_destroy(env_opt);
 
     // Delete all keys we just ingested

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "db/external_sst_file_ingestion_job.h"
 
 #include <algorithm>
@@ -24,6 +23,7 @@
 #include "table/unique_id_impl.h"
 #include "test_util/sync_point.h"
 #include "util/stop_watch.h"
+#include "util/udt_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -465,8 +465,7 @@ Status ExternalSstFileIngestionJob::Run() {
             ? kReservedEpochNumberForFileIngestedBehind
             : cfd_->NewEpochNumber(),
         f.file_checksum, f.file_checksum_func_name, f.unique_id, 0, tail_size,
-        static_cast<bool>(
-            f.table_properties.user_defined_timestamps_persisted));
+        f.user_defined_timestamps_persisted);
     f_metadata.temperature = f.file_temperature;
     edit_.AddFile(f.picked_level, f_metadata);
   }
@@ -644,38 +643,20 @@ void ExternalSstFileIngestionJob::DeleteInternalFiles() {
   }
 }
 
-Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
+Status ExternalSstFileIngestionJob::ResetTableReader(
     const std::string& external_file, uint64_t new_file_number,
-    IngestedFileInfo* file_to_ingest, SuperVersion* sv) {
-  file_to_ingest->external_file_path = external_file;
-
-  // Get external file size
-  Status status = fs_->GetFileSize(external_file, IOOptions(),
-                                   &file_to_ingest->file_size, nullptr);
-  if (!status.ok()) {
-    return status;
-  }
-
-  // Assign FD with number
-  file_to_ingest->fd =
-      FileDescriptor(new_file_number, 0, file_to_ingest->file_size);
-
-  // Create TableReader for external file
-  std::unique_ptr<TableReader> table_reader;
+    SuperVersion* sv, IngestedFileInfo* file_to_ingest,
+    std::unique_ptr<TableReader>* table_reader) {
   std::unique_ptr<FSRandomAccessFile> sst_file;
-  std::unique_ptr<RandomAccessFileReader> sst_file_reader;
-
-  status =
+  Status status =
       fs_->NewRandomAccessFile(external_file, env_options_, &sst_file, nullptr);
   if (!status.ok()) {
     return status;
   }
-  sst_file_reader.reset(new RandomAccessFileReader(
-      std::move(sst_file), external_file, nullptr /*Env*/, io_tracer_));
-
-  // TODO(yuzhangyu): User-defined timestamps doesn't support external sst file
-  //  ingestion. Pass in the correct `user_defined_timestamps_persisted` flag
-  //  for creating `TableReaderOptions` when the support is there.
+  std::unique_ptr<RandomAccessFileReader> sst_file_reader(
+      new RandomAccessFileReader(std::move(sst_file), external_file,
+                                 nullptr /*Env*/, io_tracer_));
+  table_reader->reset();
   status = cfd_->ioptions()->table_factory->NewTableReader(
       TableReaderOptions(
           *cfd_->ioptions(), sv->mutable_cf_options.prefix_extractor,
@@ -685,28 +666,20 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
           /*force_direct_prefetch*/ false, /*level*/ -1,
           /*block_cache_tracer*/ nullptr,
           /*max_file_size_for_l0_meta_pin*/ 0, versions_->DbSessionId(),
-          /*cur_file_num*/ new_file_number),
-      std::move(sst_file_reader), file_to_ingest->file_size, &table_reader);
-  if (!status.ok()) {
-    return status;
-  }
+          /*cur_file_num*/ new_file_number,
+          /* unique_id */ {}, /* largest_seqno */ 0,
+          /* tail_size */ 0, file_to_ingest->user_defined_timestamps_persisted),
+      std::move(sst_file_reader), file_to_ingest->file_size, table_reader);
+  return status;
+}
 
-  if (ingestion_options_.verify_checksums_before_ingest) {
-    // If customized readahead size is needed, we can pass a user option
-    // all the way to here. Right now we just rely on the default readahead
-    // to keep things simple.
-    // TODO: plumb Env::IOActivity, Env::IOPriority
-    ReadOptions ro;
-    ro.readahead_size = ingestion_options_.verify_checksums_readahead_size;
-    status = table_reader->VerifyChecksum(
-        ro, TableReaderCaller::kExternalSSTIngestion);
-    if (!status.ok()) {
-      return status;
-    }
-  }
-
+Status ExternalSstFileIngestionJob::SanityCheckTableProperties(
+    const std::string& external_file, uint64_t new_file_number,
+    SuperVersion* sv, IngestedFileInfo* file_to_ingest,
+    std::unique_ptr<TableReader>* table_reader) {
   // Get the external file properties
-  auto props = table_reader->GetTableProperties();
+  auto props = table_reader->get()->GetTableProperties();
+  assert(props.get());
   const auto& uprops = props->user_collected_properties;
 
   // Get table version
@@ -744,9 +717,95 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
   } else {
     return Status::InvalidArgument("External file version is not supported");
   }
+
+  file_to_ingest->cf_id = static_cast<uint32_t>(props->column_family_id);
+  // This assignment works fine even though `table_reader` may later be reset,
+  // since that will not affect how table properties are parsed, and this
+  // assignment is making a copy.
+  file_to_ingest->table_properties = *props;
+
   // Get number of entries in table
   file_to_ingest->num_entries = props->num_entries;
   file_to_ingest->num_range_deletions = props->num_range_deletions;
+
+  // Validate table properties related to comparator name and user defined
+  // timestamps persisted flag.
+  const bool orig_udt_persisted =
+      file_to_ingest->user_defined_timestamps_persisted;
+  file_to_ingest->user_defined_timestamps_persisted =
+      static_cast<bool>(props->user_defined_timestamps_persisted);
+  bool mark_sst_file_has_no_udt = false;
+  Status s = ValidateUserDefinedTimestampsOptions(
+      cfd_->user_comparator(), props->comparator_name,
+      cfd_->ioptions()->persist_user_defined_timestamps,
+      file_to_ingest->user_defined_timestamps_persisted,
+      &mark_sst_file_has_no_udt);
+  if (s.ok() && mark_sst_file_has_no_udt) {
+    // A column family that enables user-defined timestamps in Memtable only
+    // feature can also ingest external files created by a setting that disables
+    // user-defined timestamps. In that case, we need to re-mark the
+    // user_defined_timestamps_persisted flag for the file.
+    file_to_ingest->user_defined_timestamps_persisted = false;
+  } else if (!s.ok()) {
+    return s;
+  }
+
+  // This flag is passed to `TableReader` and affects how table is parsed and
+  // read when UDTs are enabled, if its value changes, we should recreate the
+  // `TableReader`.
+  auto ucmp = cfd_->user_comparator();
+  assert(ucmp);
+  if (ucmp->timestamp_size() > 0 &&
+      orig_udt_persisted != file_to_ingest->user_defined_timestamps_persisted) {
+    s = ResetTableReader(external_file, new_file_number, sv, file_to_ingest,
+                         table_reader);
+  }
+  return s;
+}
+
+Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
+    const std::string& external_file, uint64_t new_file_number,
+    IngestedFileInfo* file_to_ingest, SuperVersion* sv) {
+  file_to_ingest->external_file_path = external_file;
+
+  // Get external file size
+  Status status = fs_->GetFileSize(external_file, IOOptions(),
+                                   &file_to_ingest->file_size, nullptr);
+  if (!status.ok()) {
+    return status;
+  }
+
+  // Assign FD with number
+  file_to_ingest->fd =
+      FileDescriptor(new_file_number, 0, file_to_ingest->file_size);
+
+  // Create TableReader for external file
+  std::unique_ptr<TableReader> table_reader;
+  status = ResetTableReader(external_file, new_file_number, sv, file_to_ingest,
+                            &table_reader);
+  if (!status.ok()) {
+    return status;
+  }
+
+  status = SanityCheckTableProperties(external_file, new_file_number, sv,
+                                      file_to_ingest, &table_reader);
+  if (!status.ok()) {
+    return status;
+  }
+
+  if (ingestion_options_.verify_checksums_before_ingest) {
+    // If customized readahead size is needed, we can pass a user option
+    // all the way to here. Right now we just rely on the default readahead
+    // to keep things simple.
+    // TODO: plumb Env::IOActivity, Env::IOPriority
+    ReadOptions ro;
+    ro.readahead_size = ingestion_options_.verify_checksums_readahead_size;
+    status = table_reader->VerifyChecksum(
+        ro, TableReaderCaller::kExternalSSTIngestion);
+    if (!status.ok()) {
+      return status;
+    }
+  }
 
   ParsedInternalKey key;
   // TODO: plumb Env::IOActivity, Env::IOPriority
@@ -820,7 +879,7 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
       table_reader->NewRangeTombstoneIterator(ro));
   // We may need to adjust these key bounds, depending on whether any range
   // deletion tombstones extend past them.
-  const Comparator* ucmp = cfd_->internal_comparator().user_comparator();
+  const Comparator* ucmp = cfd_->user_comparator();
   if (range_del_iter != nullptr) {
     for (range_del_iter->SeekToFirst(); range_del_iter->Valid();
          range_del_iter->Next()) {
@@ -848,13 +907,11 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
     }
   }
 
-  file_to_ingest->cf_id = static_cast<uint32_t>(props->column_family_id);
-
-  file_to_ingest->table_properties = *props;
-
-  auto s = GetSstInternalUniqueId(props->db_id, props->db_session_id,
-                                  props->orig_file_number,
-                                  &(file_to_ingest->unique_id));
+  auto s =
+      GetSstInternalUniqueId(file_to_ingest->table_properties.db_id,
+                             file_to_ingest->table_properties.db_session_id,
+                             file_to_ingest->table_properties.orig_file_number,
+                             &(file_to_ingest->unique_id));
   if (!s.ok()) {
     ROCKS_LOG_WARN(db_options_.info_log,
                    "Failed to get SST unique id for file %s",

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -73,6 +73,14 @@ struct IngestedFileInfo {
   Temperature file_temperature = Temperature::kUnknown;
   // Unique id of the file to be ingested
   UniqueId64x2 unique_id{};
+  // Whether the external file should be treated as if it has user-defined
+  // timestamps or not. If this flag is false, and the column family enables
+  // UDT feature, the file will have min-timestamp artificially padded to its
+  // user keys when it's read. Since it will affect how `TableReader` reads a
+  // table file, it's defaulted to optimize for the majority of the case where
+  // the user key's format in the external file matches the column family's
+  // setting.
+  bool user_defined_timestamps_persisted = true;
 };
 
 class ExternalSstFileIngestionJob {
@@ -151,6 +159,20 @@ class ExternalSstFileIngestionJob {
   int ConsumedSequenceNumbersCount() const { return consumed_seqno_count_; }
 
  private:
+  Status ResetTableReader(const std::string& external_file,
+                          uint64_t new_file_number, SuperVersion* sv,
+                          IngestedFileInfo* file_to_ingest,
+                          std::unique_ptr<TableReader>* table_reader);
+
+  // Read the external file's table properties to do various sanity checks.
+  // In some cases when sanity check passes, `table_reader` could be reset with
+  // different options. For example: when external file does not contain
+  // timestamps while column family enables UDT in Memtables only feature.
+  Status SanityCheckTableProperties(const std::string& external_file,
+                                    uint64_t new_file_number, SuperVersion* sv,
+                                    IngestedFileInfo* file_to_ingest,
+                                    std::unique_ptr<TableReader>* table_reader);
+
   // Open the external file and populate `file_to_ingest` with all the
   // external information we need to ingest this file.
   Status GetIngestedFileInfo(const std::string& external_file,

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -160,8 +160,9 @@ class ExternalSstFileIngestionJob {
 
  private:
   Status ResetTableReader(const std::string& external_file,
-                          uint64_t new_file_number, SuperVersion* sv,
-                          IngestedFileInfo* file_to_ingest,
+                          uint64_t new_file_number,
+                          bool user_defined_timestamps_persisted,
+                          SuperVersion* sv, IngestedFileInfo* file_to_ingest,
                           std::unique_ptr<TableReader>* table_reader);
 
   // Read the external file's table properties to do various sanity checks and

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -164,7 +164,9 @@ class ExternalSstFileIngestionJob {
                           IngestedFileInfo* file_to_ingest,
                           std::unique_ptr<TableReader>* table_reader);
 
-  // Read the external file's table properties to do various sanity checks.
+  // Read the external file's table properties to do various sanity checks and
+  // populates certain fields in `IngestedFileInfo` according to some table
+  // properties.
   // In some cases when sanity check passes, `table_reader` could be reset with
   // different options. For example: when external file does not contain
   // timestamps while column family enables UDT in Memtables only feature.

--- a/unreleased_history/new_features/new_ingest_files_behavior.md
+++ b/unreleased_history/new_features/new_ingest_files_behavior.md
@@ -1,2 +1,2 @@
-*Add sanity checks for ingesting external files that currently checks if the user comparator used to create the file is compatible with the column family's user comparator.
+*Add sanity checks for ingesting external files that currently checks if the user key comparator used to create the file is compatible with the column family's user key comparator.
 *Support ingesting external files for column family that has user-defined timestamps in memtable only enabled.

--- a/unreleased_history/new_features/new_ingest_files_behavior.md
+++ b/unreleased_history/new_features/new_ingest_files_behavior.md
@@ -1,0 +1,2 @@
+*Add sanity checks for ingesting external files that currently checks if the user comparator used to create the file is compatible with the column family's user comparator.
+*Support ingesting external files for column family that has user-defined timestamps in memtable only enabled.


### PR DESCRIPTION
This PR expands on the capabilities added in #12343. It adds sanity checks for external file's comparator name and user-defined timestamps related flag. With this, it now supports ingesting files to a column family that enables user-defined timestamps in Memtable only feature.

Two fields in the table properties are used for aformentioned check: 1) the comparator name, it records what comparator is used to create this external sst file, 2) the flag `user_defined_timestamps_persisted`.  We compare these two fields with the column family's settings. The details are in util function `ValidateUserDefinedTimestampsOptions`. 

To optimize for the majority of the cases where sanity check should pass and the table properties read should not affect how `TableReader` is constructed, instead of read the table properties block separately and use it for sanity check before creating a `TableReader`. We continue using the current flow to first create a `TableReader`, use it for reading table properties and do sanity checks, and reset the`TableReader` for the case where the column family enables UDTs in memtable only feature, and the external file does not contain user-defined timestamps.

This PR also groups other table properties related sanity check in function `GetIngestedFileInfo` into the newly added `SanityCheckTableProperties` function.


Test plan:
added unit test
existing unit test
