### PR TITLE
optimize file size statistics in benchmark script

### DIFF
--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -460,10 +460,12 @@ function start_stats {
   pspid=$!
 
   while :; do
-    b_gb=$( ls -l $DB_DIR 2> /dev/null | grep blob | awk '{ c += 1; b += $5 } END { printf "%.1f", b / (1024*1024*1024) }' )
-    s_gb=$( ls -l $DB_DIR 2> /dev/null | grep sst | awk '{ c += 1; b += $5 } END { printf "%.1f", b / (1024*1024*1024) }' )
-    l_gb=$( ls -l $WAL_DIR 2> /dev/null | grep log | awk '{ c += 1; b += $5 } END { printf "%.1f", b / (1024*1024*1024) }' )
-    a_gb=$( ls -l $DB_DIR 2> /dev/null | awk '{ c += 1; b += $5 } END { printf "%.1f", b / (1024*1024*1024) }' )
+    eval $( ls -l $DB_DIR 2> /dev/null | awk '
+      BEGIN { gb = 1024*1024*1024 }
+      /blob/{ bb += $5 } /sst/{ sb += $5 } { ab += $5 }
+      END { printf "b_gb=%.1f s_gb=%.1f a_gb=%.1f", bb / gb, sb / gb, ab / gb }
+    ')
+    l_gb=$( ls -l $WAL_DIR 2> /dev/null | awk '/log/{ b += $5 } END { printf "%.1f", b / (1024*1024*1024) }' )
     ts=$( date +%H%M%S )
     echo -e "${a_gb}\t${s_gb}\t${l_gb}\t${b_gb}\t${ts}"
     sleep 10


### PR DESCRIPTION
Execute `ls` once when counting the file size of the `DB_DIR` and remove unused file number counter variable `c` . The test information as follow :

```Shell
# benchmark command

NUM_KEYS=30000000 CACHE_SIZE=6442450944 DB_DIR=/mnt/rocksdb_test WAL_DIR=/mnt/rocksdb_test ../tools/benchmark.sh fillseq_disable_wal

# before modification

cat /tmp/benchmark_fillseq.wal_disabled.v400.log.stats.sizes
0.0	0.0	0.0	0.0	195250
1.1	1.1	0.0	0.0	195300
2.5	2.5	0.0	0.0	195310
3.8	3.7	0.0	0.0	195320
5.1	5.1	0.0	0.0	195330
max sizes (GB): 5.1 all, 5.1 sst, 0.0 log, 0.0 blob

# after modification

cat /tmp/benchmark_fillseq.wal_disabled.v400.log.stats.sizes
0.0	0.0	0.0	0.0	194839
1.2	1.2	0.0	0.0	194849
2.6	2.6	0.0	0.0	194859
4.0	4.0	0.0	0.0	194909
5.4	5.4	0.0	0.0	194919
max sizes (GB): 5.4 all, 5.4 sst, 0.0 log, 0.0 blob
```