### PR TITLE
Correct CMake Javadoc and source jar builds

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -794,12 +794,17 @@ if(NOT MINGW)
   )
 endif()
 
-set(ROCKSDB_JAVADOC_JAR rocksdb-${CMAKE_PROJECT_VERSION}-javadoc.jar)
-add_custom_target(rocksdbjava_javadocs_jar ALL
-        COMMAND ${Java_JAVADOC_EXECUTABLE} -d ${CMAKE_CURRENT_BINARY_DIR}/javadoc -sourcepath ${PROJECT_SOURCE_DIR}/java/src/main/java/ -subpackages org
-        COMMAND ${Java_JAR_EXECUTABLE} cvf ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_JAVADOC_JAR} -C ${CMAKE_CURRENT_BINARY_DIR}/javadoc .
-        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_JAVADOC_JAR}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+# Javadoc Jar
+create_javadoc(rocksdb
+        PACKAGES org.rocksdb org.rocksdb.util
+        SOURCEPATH "${PROJECT_SOURCE_DIR}/java/src/main/java"
+        WINDOWTITLE "RocksDB Java API JavaDoc"
+        AUTHOR FALSE
+        USE FALSE
+        VERSION TRUE
+)
+add_jar(rocksdb-${CMAKE_PROJECT_VERSION}-javadoc
+        SOURCES ${CMAKE_CURRENT_BINARY_DIR}/javadoc/rocksdb/org
 )
 
 set(ROCKSDB_SOURCES_JAR rocksdb-${CMAKE_PROJECT_VERSION}-sources.jar)

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -797,14 +797,14 @@ endif()
 set(ROCKSDB_JAVADOC_JAR rocksdb-${CMAKE_PROJECT_VERSION}-javadoc.jar)
 add_custom_target(rocksdbjava_javadocs_jar ALL
         COMMAND ${Java_JAVADOC_EXECUTABLE} -d ${CMAKE_CURRENT_BINARY_DIR}/javadoc -sourcepath ${PROJECT_SOURCE_DIR}/java/src/main/java/ -subpackages org
-        COMMAND ${Java_JAR_EXECUTABLE} -v -c -f ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_JAVADOC_JAR} -C ${CMAKE_CURRENT_BINARY_DIR}/javadoc .
+        COMMAND ${Java_JAR_EXECUTABLE} cvf ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_JAVADOC_JAR} -C ${CMAKE_CURRENT_BINARY_DIR}/javadoc .
         BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_JAVADOC_JAR}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set(ROCKSDB_SOURCES_JAR rocksdb-${CMAKE_PROJECT_VERSION}-sources.jar)
 add_custom_target(rocksdbjava_sources_jar
-        ${Java_JAR_EXECUTABLE} -v -c -f ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR} -C ${PROJECT_SOURCE_DIR}/java/src/main/java/ .
+        ${Java_JAR_EXECUTABLE} cvf ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR} -C ${PROJECT_SOURCE_DIR}/java/src/main/java/ .
         BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -795,7 +795,7 @@ if(NOT MINGW)
 endif()
 
 # Javadoc Jar
-set(ROCKSDB_JAVADOC_JAR rocksdb-${CMAKE_PROJECT_VERSION}-javadoc.jar)
+set(ROCKSDB_JAVADOC_JAR rocksdbjni-${CMAKE_PROJECT_VERSION}-javadoc.jar)
 create_javadoc(rocksdb
         PACKAGES org.rocksdb org.rocksdb.util
         SOURCEPATH "${PROJECT_SOURCE_DIR}/java/src/main/java"
@@ -811,7 +811,7 @@ add_custom_target(rocksdb_javadocs_jar ALL
 )
 
 # Sources Jar
-set(ROCKSDB_SOURCES_JAR rocksdb-${CMAKE_PROJECT_VERSION}-sources.jar)
+set(ROCKSDB_SOURCES_JAR rocksdbjni-${CMAKE_PROJECT_VERSION}-sources.jar)
 add_custom_target(rocksdb_sources_jar ALL
         ${Java_JAR_EXECUTABLE} cvf ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR} -C ${PROJECT_SOURCE_DIR}/java/src/main/java/ .
         BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR}

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -795,6 +795,7 @@ if(NOT MINGW)
 endif()
 
 # Javadoc Jar
+set(ROCKSDB_JAVADOC_JAR rocksdb-${CMAKE_PROJECT_VERSION}-javadoc.jar)
 create_javadoc(rocksdb
         PACKAGES org.rocksdb org.rocksdb.util
         SOURCEPATH "${PROJECT_SOURCE_DIR}/java/src/main/java"
@@ -803,13 +804,18 @@ create_javadoc(rocksdb
         USE FALSE
         VERSION TRUE
 )
-add_jar(rocksdb-${CMAKE_PROJECT_VERSION}-javadoc
-        SOURCES ${CMAKE_CURRENT_BINARY_DIR}/javadoc/rocksdb/org
+add_custom_target(rocksdb_javadocs_jar ALL
+  COMMAND ${Java_JAR_EXECUTABLE} cvf ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_JAVADOC_JAR} -C ${CMAKE_CURRENT_BINARY_DIR}/javadoc/rocksdb .
+  BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_JAVADOC_JAR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 # Sources Jar
-add_jar(rocksdb-${CMAKE_PROJECT_VERSION}-sources
-        SOURCES ${PROJECT_SOURCE_DIR}/java/src/main/java/org
+set(ROCKSDB_SOURCES_JAR rocksdb-${CMAKE_PROJECT_VERSION}-sources.jar)
+add_custom_target(rocksdb_sources_jar ALL
+        ${Java_JAR_EXECUTABLE} cvf ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR} -C ${PROJECT_SOURCE_DIR}/java/src/main/java/ .
+        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set(bitness 32)

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -807,12 +807,10 @@ add_jar(rocksdb-${CMAKE_PROJECT_VERSION}-javadoc
         SOURCES ${CMAKE_CURRENT_BINARY_DIR}/javadoc/rocksdb/org
 )
 
-set(ROCKSDB_SOURCES_JAR rocksdb-${CMAKE_PROJECT_VERSION}-sources.jar)
-add_custom_target(rocksdbjava_sources_jar
-        ${Java_JAR_EXECUTABLE} cvf ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR} -C ${PROJECT_SOURCE_DIR}/java/src/main/java/ .
-        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_SOURCES_JAR}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        )
+# Sources Jar
+add_jar(rocksdb-${CMAKE_PROJECT_VERSION}-sources
+        SOURCES ${PROJECT_SOURCE_DIR}/java/src/main/java/org
+)
 
 set(bitness 32)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
Fix some issues introduced in https://github.com/facebook/rocksdb/pull/12199 (CC @rhubner)
1. Previous `jar -v -c -f` was not valid command syntax.
2. Javadoc and source Jar files were prefixed `rocksdb-`, now corrected to `rocksdbjni-`

@pdillinger This needs to be merged to `main` and also `8.11.fb` (to fix the Windows build for the RocksJava release of 8.11.2) please.