### PR TITLE
Fix ArenaTest.UnmappedAllocation in some cases

### DIFF
--- a/memory/arena_test.cc
+++ b/memory/arena_test.cc
@@ -267,7 +267,10 @@ TEST_F(ArenaTest, UnmappedAllocation) {
   // Verify that it's possible to get unmapped pages in large allocations,
   // for memory efficiency and to ensure we don't accidentally waste time &
   // space initializing the memory.
-  constexpr size_t kBlockSize = 2U << 20;
+  //
+  // This block size value is smaller than the smallest x86 huge page size,
+  // so should not be fulfilled by a transparent huge page mapping.
+  constexpr size_t kBlockSize = 1U << 20;
   Arena arena(kBlockSize);
 
   // The allocator might give us back recycled memory for a while, but

--- a/memory/arena_test.cc
+++ b/memory/arena_test.cc
@@ -12,6 +12,7 @@
 #ifndef OS_WIN
 #include <sys/resource.h>
 #endif
+#include "port/jemalloc_helper.h"
 #include "port/port.h"
 #include "test_util/testharness.h"
 #include "util/random.h"
@@ -267,7 +268,18 @@ TEST_F(ArenaTest, UnmappedAllocation) {
   // Verify that it's possible to get unmapped pages in large allocations,
   // for memory efficiency and to ensure we don't accidentally waste time &
   // space initializing the memory.
-  //
+
+#ifdef ROCKSDB_JEMALLOC
+  // With Jemalloc config.fill, the pages are written to before we get them
+  uint8_t fill = 0;
+  size_t fill_sz = sizeof(fill);
+  mallctl("config.fill", &fill, &fill_sz, nullptr, 0);
+  if (fill) {
+    ROCKSDB_GTEST_BYPASS("Test skipped because of config.fill==true");
+    return;
+  }
+#endif  // ROCKSDB_JEMALLOC
+
   // This block size value is smaller than the smallest x86 huge page size,
   // so should not be fulfilled by a transparent huge page mapping.
   constexpr size_t kBlockSize = 1U << 20;


### PR DESCRIPTION
Summary:
Fix compatibility with transparent huge pages by allocating in increments (1MiB) smaller than the
typical smallest huge page size of 2MiB.

Also, bypass the test when jemalloc config.fill is used, which means the allocator is explicitly
configured to write to memory before we get it, which is not what this test expects.

Fixes #12351

Test Plan:
```
sudo bash -c 'echo "always" > /sys/kernel/mm/transparent_hugepage/enabled'
```
And see unit test fails before this change, passes after this change

Also tested internal buck build with dbg mode (previously failing).