### PR TITLE
Decouple `RateLimiter` burst size and refill period

### DIFF
--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -40,8 +40,9 @@ class RateLimiter {
   // REQUIRED: bytes_per_second > 0
   virtual void SetBytesPerSecond(int64_t bytes_per_second) = 0;
 
-  // This API allows user to dynamically change the max bytes can be granted at
-  // once. Zero is a special value meaning the number of bytes per refill.
+  // This API allows user to dynamically change the max bytes can be granted in
+  // a single call to `Request()`. Zero is a special value meaning the number of
+  // bytes per refill.
   //
   // REQUIRED: single_burst_bytes >= 0. Otherwise `Status::InvalidArgument` will
   // be returned.
@@ -93,7 +94,7 @@ class RateLimiter {
                               Env::IOPriority io_priority, Statistics* stats,
                               RateLimiter::OpType op_type);
 
-  // Max bytes can be granted in a single burst
+  // Max bytes can be granted in a single call to `Request()`.
   virtual int64_t GetSingleBurstBytes() const = 0;
 
   // Total bytes that go through rate limiter

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -40,10 +40,10 @@ class RateLimiter {
   // REQUIRED: bytes_per_second > 0
   virtual void SetBytesPerSecond(int64_t bytes_per_second) = 0;
 
-  // This API allows user to dynamically change the max bytes can be granted in
-  // a single refill period (i.e, burst)
+  // This API allows user to dynamically change the max bytes can be granted at
+  // once. Zero is a special value meaning the number of bytes per refill.
   //
-  // REQUIRED: single_burst_bytes > 0. Otherwise `Status::InvalidArgument` will
+  // REQUIRED: single_burst_bytes >= 0. Otherwise `Status::InvalidArgument` will
   // be returned.
   virtual Status SetSingleBurstBytes(int64_t /* single_burst_bytes */) {
     return Status::NotSupported();
@@ -143,11 +143,11 @@ class RateLimiter {
 // time. It controls the total write rate of compaction and flush in bytes per
 // second. Currently, RocksDB does not enforce rate limit for anything other
 // than flush and compaction, e.g. write to WAL.
-// @refill_period_us: this controls how often tokens are refilled. For example,
-// when rate_bytes_per_sec is set to 10MB/s and refill_period_us is set to
-// 100ms, then 1MB is refilled every 100ms internally. Larger value can lead to
-// burstier writes while smaller value introduces more CPU overhead.
-// The default should work for most cases.
+// @refill_period_us: This controls how often tokens are refilled. For example,
+//                    when `rate_bytes_per_sec` is set to 10MB/s and
+//                    `refill_period_us` is set to 100ms, then 1MB is refilled
+//                    every 100ms internally. Larger values can lead to sporadic
+//                    delays while smaller values introduce more CPU overhead.
 // @fairness: RateLimiter accepts high-pri requests and low-pri requests.
 // A low-pri request is usually blocked in favor of hi-pri request. Currently,
 // RocksDB assigns low-pri to request from compaction and high-pri to request
@@ -159,10 +159,14 @@ class RateLimiter {
 // @auto_tuned: Enables dynamic adjustment of rate limit within the range
 //              `[rate_bytes_per_sec / 20, rate_bytes_per_sec]`, according to
 //              the recent demand for background I/O.
+// @single_burst_bytes: The maximum number of bytes that can be granted in a
+//                      single call to `Request()`. Zero is a special value
+//                      meaning the number of bytes per refill.
 RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us = 100 * 1000,
     int32_t fairness = 10,
     RateLimiter::Mode mode = RateLimiter::Mode::kWritesOnly,
-    bool auto_tuned = false);
+    bool auto_tuned = false,
+    int64_t single_burst_bytes = 0);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -166,7 +166,6 @@ RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us = 100 * 1000,
     int32_t fairness = 10,
     RateLimiter::Mode mode = RateLimiter::Mode::kWritesOnly,
-    bool auto_tuned = false,
-    int64_t single_burst_bytes = 0);
+    bool auto_tuned = false, int64_t single_burst_bytes = 0);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1471,6 +1471,9 @@ DEFINE_bool(rate_limiter_auto_tuned, false,
             "Enable dynamic adjustment of rate limit according to demand for "
             "background I/O");
 
+DEFINE_int64(rate_limiter_single_burst_bytes, 0,
+             "Set single burst bytes on background I/O rate limiter.");
+
 DEFINE_bool(sine_write_rate, false, "Use a sine wave write_rate_limit");
 
 DEFINE_uint64(
@@ -4783,7 +4786,8 @@ class Benchmark {
             // Get()/MultiGet()
             FLAGS_rate_limit_bg_reads ? RateLimiter::Mode::kReadsOnly
                                       : RateLimiter::Mode::kWritesOnly,
-            FLAGS_rate_limiter_auto_tuned));
+            FLAGS_rate_limiter_auto_tuned,
+            FLAGS_rate_limiter_single_burst_bytes));
       }
     }
 

--- a/unreleased_history/behavior_changes/generic_rate_limiter_burst.md
+++ b/unreleased_history/behavior_changes/generic_rate_limiter_burst.md
@@ -1,0 +1,1 @@
+* `RateLimiter`s created by `NewGenericRateLimiter()` no longer modify the refill period when `SetSingleBurstBytes()` is called.

--- a/unreleased_history/public_api_changes/rate_limiter_burst.md
+++ b/unreleased_history/public_api_changes/rate_limiter_burst.md
@@ -1,0 +1,1 @@
+* `RateLimiter`'s API no longer requires the burst size to be the refill size. Users of `NewGenericRateLimiter()` can now provide burst size in `single_burst_bytes`. Implementors of `RateLimiter::SetSingleBurstBytes()` need to adapt their implementations to match the changed API doc.

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -46,13 +46,14 @@ struct GenericRateLimiter::Req {
 GenericRateLimiter::GenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us, int32_t fairness,
     RateLimiter::Mode mode, const std::shared_ptr<SystemClock>& clock,
-    bool auto_tuned)
+    bool auto_tuned, int64_t single_burst_bytes)
     : RateLimiter(mode),
       refill_period_us_(refill_period_us),
       rate_bytes_per_sec_(auto_tuned ? rate_bytes_per_sec / 2
                                      : rate_bytes_per_sec),
       refill_bytes_per_period_(
           CalculateRefillBytesPerPeriodLocked(rate_bytes_per_sec_)),
+      raw_single_burst_bytes_(single_burst_bytes),
       clock_(clock),
       stop_(false),
       exit_cv_(&request_mutex_),
@@ -108,25 +109,19 @@ void GenericRateLimiter::SetBytesPerSecondLocked(int64_t bytes_per_second) {
 }
 
 Status GenericRateLimiter::SetSingleBurstBytes(int64_t single_burst_bytes) {
-  if (single_burst_bytes <= 0) {
+  if (single_burst_bytes < 0) {
     return Status::InvalidArgument(
-        "`single_burst_bytes` must be greater than 0");
+        "`single_burst_bytes` must be greater than or equal to 0");
   }
 
   MutexLock g(&request_mutex_);
-  SetSingleBurstBytesLocked(single_burst_bytes);
+  raw_single_burst_bytes_.store(single_burst_bytes, std::memory_order_relaxed);
   return Status::OK();
-}
-
-void GenericRateLimiter::SetSingleBurstBytesLocked(int64_t single_burst_bytes) {
-  refill_bytes_per_period_.store(single_burst_bytes, std::memory_order_relaxed);
-  refill_period_us_.store(CalculateRefillPeriodUsLocked(single_burst_bytes),
-                          std::memory_order_relaxed);
 }
 
 void GenericRateLimiter::Request(int64_t bytes, const Env::IOPriority pri,
                                  Statistics* stats) {
-  assert(bytes <= refill_bytes_per_period_.load(std::memory_order_relaxed));
+  assert(bytes <= GetSingleBurstBytes());
   bytes = std::max(static_cast<int64_t>(0), bytes);
   TEST_SYNC_POINT("GenericRateLimiter::Request");
   TEST_SYNC_POINT_CALLBACK("GenericRateLimiter::Request:1",
@@ -297,10 +292,13 @@ void GenericRateLimiter::RefillBytesAndGrantRequestsLocked() {
     while (!queue->empty()) {
       auto* next_req = queue->front();
       if (available_bytes_ < next_req->request_bytes) {
-        // Grant partial request_bytes to avoid starvation of requests
-        // that become asking for more bytes than available_bytes_
-        // due to dynamically reduced rate limiter's bytes_per_second that
-        // leads to reduced refill_bytes_per_period hence available_bytes_
+        // Grant partial request_bytes even if request is for more than
+        // `available_bytes_`, which can happen in a few situations:
+        //
+        // - The available bytes were partially consumed by other request(s)
+        // - The rate was dynamically reduced while requests were already
+        //   enqueued
+        // - The burst size was explicitly set to be larger than the refill size
         next_req->request_bytes -= available_bytes_;
         available_bytes_ = 0;
         break;
@@ -326,20 +324,6 @@ int64_t GenericRateLimiter::CalculateRefillBytesPerPeriodLocked(
     return std::numeric_limits<int64_t>::max() / kMicrosecondsPerSecond;
   } else {
     return rate_bytes_per_sec * refill_period_us / kMicrosecondsPerSecond;
-  }
-}
-
-int64_t GenericRateLimiter::CalculateRefillPeriodUsLocked(
-    int64_t single_burst_bytes) {
-  int64_t rate_bytes_per_sec =
-      rate_bytes_per_sec_.load(std::memory_order_relaxed);
-  if (std::numeric_limits<int64_t>::max() / single_burst_bytes <
-      kMicrosecondsPerSecond) {
-    // Avoid unexpected result in the overflow case. The result now is still
-    // inaccurate but is a number that is large enough.
-    return std::numeric_limits<int64_t>::max() / rate_bytes_per_sec;
-  } else {
-    return single_burst_bytes * kMicrosecondsPerSecond / rate_bytes_per_sec;
   }
 }
 
@@ -398,14 +382,13 @@ RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us /* = 100 * 1000 */,
     int32_t fairness /* = 10 */,
     RateLimiter::Mode mode /* = RateLimiter::Mode::kWritesOnly */,
-    bool auto_tuned /* = false */,
-    int64_t /* single_burst_bytes */ /* = 0 */) {
+    bool auto_tuned /* = false */, int64_t single_burst_bytes /* = 0 */) {
   assert(rate_bytes_per_sec > 0);
   assert(refill_period_us > 0);
   assert(fairness > 0);
-  std::unique_ptr<RateLimiter> limiter(
-      new GenericRateLimiter(rate_bytes_per_sec, refill_period_us, fairness,
-                             mode, SystemClock::Default(), auto_tuned));
+  std::unique_ptr<RateLimiter> limiter(new GenericRateLimiter(
+      rate_bytes_per_sec, refill_period_us, fairness, mode,
+      SystemClock::Default(), auto_tuned, single_burst_bytes));
   return limiter.release();
 }
 

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -398,7 +398,8 @@ RateLimiter* NewGenericRateLimiter(
     int64_t rate_bytes_per_sec, int64_t refill_period_us /* = 100 * 1000 */,
     int32_t fairness /* = 10 */,
     RateLimiter::Mode mode /* = RateLimiter::Mode::kWritesOnly */,
-    bool auto_tuned /* = false */) {
+    bool auto_tuned /* = false */,
+    int64_t /* single_burst_bytes */ /* = 0 */) {
   assert(rate_bytes_per_sec > 0);
   assert(refill_period_us > 0);
   assert(fairness > 0);

--- a/util/rate_limiter_impl.h
+++ b/util/rate_limiter_impl.h
@@ -28,8 +28,8 @@ class GenericRateLimiter : public RateLimiter {
  public:
   GenericRateLimiter(int64_t refill_bytes, int64_t refill_period_us,
                      int32_t fairness, RateLimiter::Mode mode,
-                     const std::shared_ptr<SystemClock>& clock,
-                     bool auto_tuned);
+                     const std::shared_ptr<SystemClock>& clock, bool auto_tuned,
+                     int64_t single_burst_bytes);
 
   virtual ~GenericRateLimiter();
 
@@ -47,7 +47,12 @@ class GenericRateLimiter : public RateLimiter {
                Statistics* stats) override;
 
   int64_t GetSingleBurstBytes() const override {
-    return refill_bytes_per_period_.load(std::memory_order_relaxed);
+    int64_t raw_single_burst_bytes =
+        raw_single_burst_bytes_.load(std::memory_order_relaxed);
+    if (raw_single_burst_bytes == 0) {
+      return refill_bytes_per_period_.load(std::memory_order_relaxed);
+    }
+    return raw_single_burst_bytes;
   }
 
   int64_t GetTotalBytesThrough(
@@ -108,10 +113,8 @@ class GenericRateLimiter : public RateLimiter {
   void RefillBytesAndGrantRequestsLocked();
   std::vector<Env::IOPriority> GeneratePriorityIterationOrderLocked();
   int64_t CalculateRefillBytesPerPeriodLocked(int64_t rate_bytes_per_sec);
-  int64_t CalculateRefillPeriodUsLocked(int64_t single_burst_bytes);
   Status TuneLocked();
   void SetBytesPerSecondLocked(int64_t bytes_per_second);
-  void SetSingleBurstBytesLocked(int64_t single_burst_bytes);
 
   uint64_t NowMicrosMonotonicLocked() {
     return clock_->NowNanos() / std::milli::den;
@@ -124,6 +127,8 @@ class GenericRateLimiter : public RateLimiter {
 
   std::atomic<int64_t> rate_bytes_per_sec_;
   std::atomic<int64_t> refill_bytes_per_period_;
+  // This value is validated but unsanitized (may be zero).
+  std::atomic<int64_t> raw_single_burst_bytes_;
   std::shared_ptr<SystemClock> clock_;
 
   bool stop_;

--- a/util/rate_limiter_impl.h
+++ b/util/rate_limiter_impl.h
@@ -123,7 +123,7 @@ class GenericRateLimiter : public RateLimiter {
   // This mutex guard all internal states
   mutable port::Mutex request_mutex_;
 
-  std::atomic<int64_t> refill_period_us_;
+  const int64_t refill_period_us_;
 
   std::atomic<int64_t> rate_bytes_per_sec_;
   std::atomic<int64_t> refill_bytes_per_period_;

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -2734,12 +2734,14 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimiting) {
         std::make_shared<GenericRateLimiter>(
             limit.first, 100 * 1000 /* refill_period_us */, 10 /* fairness */,
             RateLimiter::Mode::kWritesOnly /* mode */,
-            special_env->GetSystemClock(), false /* auto_tuned */);
+            special_env->GetSystemClock(), false /* auto_tuned */,
+            0 /* single_burst_bytes */);
     std::shared_ptr<RateLimiter> restore_rate_limiter =
         std::make_shared<GenericRateLimiter>(
             limit.second, 100 * 1000 /* refill_period_us */, 10 /* fairness */,
             RateLimiter::Mode::kWritesOnly /* mode */,
-            special_env->GetSystemClock(), false /* auto_tuned */);
+            special_env->GetSystemClock(), false /* auto_tuned */,
+            0 /* single_burst_bytes */);
     engine_options_->backup_rate_limiter = backup_rate_limiter;
     engine_options_->restore_rate_limiter = restore_rate_limiter;
   } else {
@@ -2807,7 +2809,8 @@ TEST_P(BackupEngineRateLimitingTestWithParam, RateLimitingVerifyBackup) {
         std::make_shared<GenericRateLimiter>(
             backup_rate_limiter_limit, 100 * 1000 /* refill_period_us */,
             10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */,
-            special_env->GetSystemClock(), false /* auto_tuned */);
+            special_env->GetSystemClock(), false /* auto_tuned */,
+            0 /* single_burst_bytes */);
     engine_options_->backup_rate_limiter = backup_rate_limiter;
   } else {
     engine_options_->backup_rate_limit = backup_rate_limiter_limit;
@@ -3003,7 +3006,8 @@ TEST_P(BackupEngineRateLimitingTestWithParam2,
       std::make_shared<GenericRateLimiter>(
           backup_rate_limiter_limit, 1000 * 1000 /* refill_period_us */,
           10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */,
-          special_env.GetSystemClock(), false /* auto_tuned */));
+          special_env.GetSystemClock(), false /* auto_tuned */,
+          0 /* single_burst_bytes */));
 
   engine_options_->backup_rate_limiter = backup_rate_limiter;
 
@@ -3012,7 +3016,8 @@ TEST_P(BackupEngineRateLimitingTestWithParam2,
       std::make_shared<GenericRateLimiter>(
           restore_rate_limiter_limit, 1000 * 1000 /* refill_period_us */,
           10 /* fairness */, RateLimiter::Mode::kAllIo /* mode */,
-          special_env.GetSystemClock(), false /* auto_tuned */));
+          special_env.GetSystemClock(), false /* auto_tuned */,
+          0 /* single_burst_bytes */));
 
   engine_options_->restore_rate_limiter = restore_rate_limiter;
 


### PR DESCRIPTION
When the rate limiter does not have any waiting requests, the first request to arrive may consume all of the available bandwidth, despite potentially having lower priority than requests that arrive later in the same refill interval. Then, those higher priority requests must wait for a refill. So even in scenarios in which we have an overall bandwidth surplus, the highest priority requests can be sporadically delayed up to a whole refill period.

Alone, this isn't necessarily problematic as the refill period is configurable via `refill_period_us` and can be tuned down as needed until the max sporadic delay is tolerable. However, tuning down `refill_period_us` had a side effect of reducing burst size. Some users require a certain burst size to issue optimal I/O sizes to the underlying storage system.

To satisfy those users, this PR decouples the refill period from the burst size. That way, the max sporadic delay can be limited without impacting I/O sizes issued to the underlying storage system.

Test Plan:

The goal is to show we can now limit the max sporadic delay without impacting compaction's I/O size.

The benchmark runs compaction with a large I/O size, while user reads simultaneously run at a low rate that does not consume all of the available bandwidth. The max sporadic delay is measured using the P100 of rocksdb.file.read.get.micros. I just used strace to verify the compaction reads follow `rate_limiter_single_burst_bytes`

Setup: `./db_bench -benchmarks=fillrandom,flush -write_buffer_size=67108864 -disable_auto_compactions=true -value_size=256 -num=1048576`

Benchmark: `./db_bench -benchmarks=readrandom -use_existing_db=true -num=1048576 -duration=10 -benchmark_read_rate_limit=4096 -rate_limiter_bytes_per_sec=67108864 -rate_limiter_refill_period_us=$refill_micros -rate_limiter_single_burst_bytes=16777216 -rate_limit_bg_reads=true -rate_limit_user_ops=true -statistics=true -cache_size=0 -stats_level=5 -compaction_readahead_size=16777216 -use_direct_reads=true`

Results:

refill_micros | rocksdb.file.read.get.micros (P100)
-- | --
10000 | 10802
100000 | 100240
1000000 | 922061

For verifying compaction read sizes: `strace -fye pread64 ./db_bench -benchmarks=compact -use_existing_db=true -rate_limiter_bytes_per_sec=67108864 -rate_limiter_refill_period_us=$refill_micros -rate_limiter_single_burst_bytes=16777216 -rate_limit_bg_reads=true -compaction_readahead_size=16777216 -use_direct_reads=true`
