### PR TITLE
Remove `bottommost_temperature`

### DIFF
--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -1473,7 +1473,7 @@ TEST_F(CompactionJobTest, OldestBlobFileNumber) {
 }
 
 TEST_F(CompactionJobTest, VerifyPenultimateLevelOutput) {
-  cf_options_.bottommost_temperature = Temperature::kCold;
+  cf_options_.last_level_temperature = Temperature::kCold;
   SyncPoint::GetInstance()->SetCallBack(
       "Compaction::SupportsPerKeyPlacement:Enabled", [&](void* arg) {
         auto supports_per_key_placement = static_cast<bool*>(arg);

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -17,9 +17,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-
-class TieredCompactionTest : public DBTestBase,
-                             public testing::WithParamInterface<bool> {
+class TieredCompactionTest : public DBTestBase {
  public:
   TieredCompactionTest()
       : DBTestBase("tiered_compaction_test", /*env_do_fsync=*/true),
@@ -123,14 +121,8 @@ class TieredCompactionTest : public DBTestBase,
     pl_stats.Clear();
   }
 
-  // bottommost_temperature is renaming to last_level_temperature, set either
-  // of them should have the same effect.
   void SetColdTemperature(Options& options) {
-    if (GetParam()) {
-      options.bottommost_temperature = Temperature::kCold;
-    } else {
-      options.last_level_temperature = Temperature::kCold;
-    }
+    options.last_level_temperature = Temperature::kCold;
   }
 
  private:
@@ -172,7 +164,7 @@ class TieredCompactionTest : public DBTestBase,
   }
 };
 
-TEST_P(TieredCompactionTest, SequenceBasedTieredStorageUniversal) {
+TEST_F(TieredCompactionTest, SequenceBasedTieredStorageUniversal) {
   const int kNumTrigger = 4;
   const int kNumLevels = 7;
   const int kNumKeys = 100;
@@ -334,7 +326,7 @@ TEST_P(TieredCompactionTest, SequenceBasedTieredStorageUniversal) {
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
 }
 
-TEST_P(TieredCompactionTest, RangeBasedTieredStorageUniversal) {
+TEST_F(TieredCompactionTest, RangeBasedTieredStorageUniversal) {
   const int kNumTrigger = 4;
   const int kNumLevels = 7;
   const int kNumKeys = 100;
@@ -508,7 +500,7 @@ TEST_P(TieredCompactionTest, RangeBasedTieredStorageUniversal) {
       1);
 }
 
-TEST_P(TieredCompactionTest, LevelColdRangeDelete) {
+TEST_F(TieredCompactionTest, LevelColdRangeDelete) {
   const int kNumTrigger = 4;
   const int kNumLevels = 7;
   const int kNumKeys = 100;
@@ -614,7 +606,7 @@ class SingleKeySstPartitionerFactory : public SstPartitionerFactory {
   }
 };
 
-TEST_P(TieredCompactionTest, LevelOutofBoundaryRangeDelete) {
+TEST_F(TieredCompactionTest, LevelOutofBoundaryRangeDelete) {
   const int kNumTrigger = 4;
   const int kNumLevels = 3;
   const int kNumKeys = 10;
@@ -743,7 +735,7 @@ TEST_P(TieredCompactionTest, LevelOutofBoundaryRangeDelete) {
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
 }
 
-TEST_P(TieredCompactionTest, UniversalRangeDelete) {
+TEST_F(TieredCompactionTest, UniversalRangeDelete) {
   const int kNumTrigger = 4;
   const int kNumLevels = 7;
   const int kNumKeys = 10;
@@ -875,7 +867,7 @@ TEST_P(TieredCompactionTest, UniversalRangeDelete) {
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
 }
 
-TEST_P(TieredCompactionTest, SequenceBasedTieredStorageLevel) {
+TEST_F(TieredCompactionTest, SequenceBasedTieredStorageLevel) {
   const int kNumTrigger = 4;
   const int kNumLevels = 7;
   const int kNumKeys = 100;
@@ -1099,7 +1091,7 @@ TEST_P(TieredCompactionTest, SequenceBasedTieredStorageLevel) {
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
 }
 
-TEST_P(TieredCompactionTest, RangeBasedTieredStorageLevel) {
+TEST_F(TieredCompactionTest, RangeBasedTieredStorageLevel) {
   const int kNumTrigger = 4;
   const int kNumLevels = 7;
   const int kNumKeys = 100;
@@ -1240,10 +1232,7 @@ TEST_P(TieredCompactionTest, RangeBasedTieredStorageLevel) {
   db_->ReleaseSnapshot(temp_snap);
 }
 
-INSTANTIATE_TEST_CASE_P(TieredCompactionTest, TieredCompactionTest,
-                        testing::Bool());
-
-TEST_P(TieredCompactionTest, CheckInternalKeyRange) {
+TEST_F(TieredCompactionTest, CheckInternalKeyRange) {
   // When compacting keys from the last level to penultimate level,
   // output to penultimate level should be within internal key range
   // of input files from penultimate level.

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -6604,7 +6604,7 @@ TEST_F(DBTest2, LastLevelTemperature) {
   auto* listener = new TestListener();
 
   Options options = CurrentOptions();
-  options.bottommost_temperature = Temperature::kWarm;
+  options.last_level_temperature = Temperature::kWarm;
   options.level0_file_num_compaction_trigger = 2;
   options.level_compaction_dynamic_level_bytes = true;
   options.num_levels = kNumLevels;
@@ -6816,8 +6816,8 @@ TEST_F(DBTest2, LastLevelTemperatureUniversal) {
   size = GetSstSizeHelper(Temperature::kWarm);
   ASSERT_EQ(size, 0);
 
-  // Update bottommost temperature
-  options.bottommost_temperature = Temperature::kWarm;
+  // Update last level temperature
+  options.last_level_temperature = Temperature::kWarm;
   Reopen(options);
   db_->GetColumnFamilyMetaData(&metadata);
   // Should not impact existing ones
@@ -6869,10 +6869,10 @@ TEST_F(DBTest2, LastLevelTemperatureUniversal) {
       &prop));
   ASSERT_EQ(std::atoi(prop.c_str()), 0);
 
-  // Update bottommost temperature dynamically with SetOptions
+  // Update last level temperature dynamically with SetOptions
   auto s = db_->SetOptions({{"last_level_temperature", "kCold"}});
   ASSERT_OK(s);
-  ASSERT_EQ(db_->GetOptions().bottommost_temperature, Temperature::kCold);
+  ASSERT_EQ(db_->GetOptions().last_level_temperature, Temperature::kCold);
   db_->GetColumnFamilyMetaData(&metadata);
   // Should not impact the existing files
   ASSERT_EQ(Temperature::kWarm,
@@ -6898,14 +6898,14 @@ TEST_F(DBTest2, LastLevelTemperatureUniversal) {
   ASSERT_GT(size, 0);
 
   // kLastTemperature is an invalid temperature
-  options.bottommost_temperature = Temperature::kLastTemperature;
+  options.last_level_temperature = Temperature::kLastTemperature;
   s = TryReopen(options);
   ASSERT_TRUE(s.IsIOError());
 }
 
 TEST_F(DBTest2, LastLevelStatistics) {
   Options options = CurrentOptions();
-  options.bottommost_temperature = Temperature::kWarm;
+  options.last_level_temperature = Temperature::kWarm;
   options.default_temperature = Temperature::kHot;
   options.level0_file_num_compaction_trigger = 2;
   options.level_compaction_dynamic_level_bytes = true;
@@ -7002,7 +7002,7 @@ TEST_F(DBTest2, CheckpointFileTemperature) {
   auto test_fs = std::make_shared<NoLinkTestFS>(env_->GetFileSystem());
   std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, test_fs));
   Options options = CurrentOptions();
-  options.bottommost_temperature = Temperature::kWarm;
+  options.last_level_temperature = Temperature::kWarm;
   // set dynamic_level to true so the compaction would compact the data to the
   // last level directly which will have the last_level_temperature
   options.level_compaction_dynamic_level_bytes = true;
@@ -7061,7 +7061,7 @@ TEST_F(DBTest2, FileTemperatureManifestFixup) {
   auto test_fs = std::make_shared<FileTemperatureTestFS>(env_->GetFileSystem());
   std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, test_fs));
   Options options = CurrentOptions();
-  options.bottommost_temperature = Temperature::kWarm;
+  options.last_level_temperature = Temperature::kWarm;
   // set dynamic_level to true so the compaction would compact the data to the
   // last level directly which will have the last_level_temperature
   options.level_compaction_dynamic_level_bytes = true;

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -1863,7 +1863,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileAfterDBPut) {
 TEST_F(ExternalSSTFileBasicTest, IngestWithTemperature) {
   Options options = CurrentOptions();
   const ImmutableCFOptions ioptions(options);
-  options.bottommost_temperature = Temperature::kWarm;
+  options.last_level_temperature = Temperature::kWarm;
   SstFileWriter sst_file_writer(EnvOptions(), options);
   options.level0_file_num_compaction_trigger = 2;
   Reopen(options);

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -79,7 +79,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
   options.compaction_style = kCompactionStyleUniversal;
   options.preclude_last_level_data_seconds = 10000;
   options.env = mock_env_.get();
-  options.bottommost_temperature = Temperature::kCold;
+  options.last_level_temperature = Temperature::kCold;
   options.num_levels = kNumLevels;
   DestroyAndReopen(options);
 
@@ -181,7 +181,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicLevel) {
   Options options = CurrentOptions();
   options.preclude_last_level_data_seconds = 10000;
   options.env = mock_env_.get();
-  options.bottommost_temperature = Temperature::kCold;
+  options.last_level_temperature = Temperature::kCold;
   options.num_levels = kNumLevels;
   options.level_compaction_dynamic_level_bytes = true;
   // TODO(zjay): for level compaction, auto-compaction may stuck in deadloop, if

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3445,7 +3445,7 @@ void InitializeOptionsFromFlags(
       StringToCompressionType(FLAGS_wal_compression.c_str());
 
   if (FLAGS_enable_tiered_storage) {
-    options.bottommost_temperature = Temperature::kCold;
+    options.last_level_temperature = Temperature::kCold;
   }
   options.preclude_last_level_data_seconds =
       FLAGS_preclude_last_level_data_seconds;

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -808,14 +808,7 @@ struct AdvancedColumnFamilyOptions {
   // temperature to FileSystem used. Should be no-op for default FileSystem
   // and users need to plug in their own FileSystem to take advantage of it.
   //
-  // Note: the feature is changed from `bottommost_temperature` to
-  //  `last_level_temperature` which now only apply for the last level files.
-  //  The option name `bottommost_temperature` is kept only for migration, the
-  //  behavior is the same as `last_level_temperature`. Please stop using
-  //  `bottommost_temperature` and will be removed in next release.
-  //
   // Dynamically changeable through the SetOptions() API
-  Temperature bottommost_temperature = Temperature::kUnknown;
   Temperature last_level_temperature = Temperature::kUnknown;
 
   // EXPERIMENTAL

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -163,10 +163,7 @@ struct MutableCFOptions {
         bottommost_compression(options.bottommost_compression),
         compression_opts(options.compression_opts),
         bottommost_compression_opts(options.bottommost_compression_opts),
-        last_level_temperature(options.last_level_temperature ==
-                                       Temperature::kUnknown
-                                   ? options.bottommost_temperature
-                                   : options.last_level_temperature),
+        last_level_temperature(options.last_level_temperature),
         memtable_protection_bytes_per_key(
             options.memtable_protection_bytes_per_key),
         block_protection_bytes_per_key(options.block_protection_bytes_per_key),

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -272,7 +272,6 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->sample_for_compression = moptions.sample_for_compression;
   cf_opts->compression_per_level = moptions.compression_per_level;
   cf_opts->last_level_temperature = moptions.last_level_temperature;
-  cf_opts->bottommost_temperature = moptions.last_level_temperature;
   cf_opts->memtable_max_range_deletions = moptions.memtable_max_range_deletions;
 }
 

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -287,7 +287,6 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.blob_file_starting_level, 1);
   ASSERT_EQ(new_cf_opt.prepopulate_blob_cache, PrepopulateBlobCache::kDisable);
   ASSERT_EQ(new_cf_opt.last_level_temperature, Temperature::kWarm);
-  ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.default_temperature, Temperature::kHot);
   ASSERT_EQ(new_cf_opt.persist_user_defined_timestamps, true);
   ASSERT_EQ(new_cf_opt.memtable_max_range_deletions, 0);
@@ -2503,7 +2502,6 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.blob_file_starting_level, 1);
   ASSERT_EQ(new_cf_opt.prepopulate_blob_cache, PrepopulateBlobCache::kDisable);
   ASSERT_EQ(new_cf_opt.last_level_temperature, Temperature::kWarm);
-  ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.default_temperature, Temperature::kHot);
   ASSERT_EQ(new_cf_opt.persist_user_defined_timestamps, true);
   ASSERT_EQ(new_cf_opt.memtable_max_range_deletions, 0);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4570,7 +4570,7 @@ class Benchmark {
         FLAGS_level0_slowdown_writes_trigger;
     options.compression = FLAGS_compression_type_e;
     if (FLAGS_simulate_hybrid_fs_file != "") {
-      options.bottommost_temperature = Temperature::kWarm;
+      options.last_level_temperature = Temperature::kWarm;
     }
     options.preclude_last_level_data_seconds =
         FLAGS_preclude_last_level_data_seconds;

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -1071,7 +1071,7 @@ TEST_F(LdbCmdTest, FileTemperatureUpdateManifest) {
   auto test_fs = std::make_shared<FileTemperatureTestFS>(FileSystem::Default());
   std::unique_ptr<Env> env(new CompositeEnvWrapper(Env::Default(), test_fs));
   Options opts;
-  opts.bottommost_temperature = Temperature::kWarm;
+  opts.last_level_temperature = Temperature::kWarm;
   opts.level0_file_num_compaction_trigger = 10;
   opts.create_if_missing = true;
   opts.env = env.get();

--- a/unreleased_history/public_api_changes/bottommost_temperature.md
+++ b/unreleased_history/public_api_changes/bottommost_temperature.md
@@ -1,0 +1,1 @@
+Remove deprecated option `bottommost_temperature`, already replaced by `last_level_temperature`

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -4184,7 +4184,7 @@ TEST_F(BackupEngineTest, FileTemperatures) {
   SetEnvsFromFileSystems();
 
   // Use temperatures
-  options_.bottommost_temperature = Temperature::kWarm;
+  options_.last_level_temperature = Temperature::kWarm;
   options_.level0_file_num_compaction_trigger = 2;
   // set dynamic_level to true so the compaction would compact the data to the
   // last level directly which will have the last_level_temperature


### PR DESCRIPTION
Summary: deprecated option already replaced by `last_level_temperature`. (Keeping recognition of the option in old options files.)

Test Plan: tests updated