### PR TITLE
fix compile warning

### DIFF
--- a/monitoring/thread_status_util.cc
+++ b/monitoring/thread_status_util.cc
@@ -190,7 +190,7 @@ void ThreadStatusUtil::SetThreadState(ThreadStatus::StateType /*state*/) {}
 void ThreadStatusUtil::NewColumnFamilyInfo(const DB* /*db*/,
                                            const ColumnFamilyData* /*cfd*/,
                                            const std::string& /*cf_name*/,
-                                           const Env* env) {}
+                                           const Env* /*env*/) {}
 
 void ThreadStatusUtil::EraseColumnFamilyInfo(const ColumnFamilyData* /*cfd*/) {}
 


### PR DESCRIPTION
Fix compile warning
```
monitoring/thread_status_util.cc: In static member function ‘static void rocksdb::ThreadStatusUtil::NewColumnFamilyInfo(const rocksdb::DB*, const rocksdb::ColumnFamilyData*, const std::string&, const rocksdb::Env*)’: monitoring/thread_status_util.cc:193:55: warning: unused parameter ‘env’ [-Wunused-parameter]
  193 |                                            const Env* env) {}
      |                                            ~~~~~~~~~~~^~~
```