### PR TITLE
fix linking without thread status support

### DIFF
--- a/monitoring/thread_status_util.cc
+++ b/monitoring/thread_status_util.cc
@@ -175,7 +175,13 @@ bool ThreadStatusUtil::MaybeInitThreadLocalUpdater(const Env* /*env*/) {
   return false;
 }
 
+void ThreadStatusUtil::SetEnableTracking(bool /*enable_tracking*/) {}
+
 void ThreadStatusUtil::SetColumnFamily(const ColumnFamilyData* /*cfd*/) {}
+
+ThreadStatus::OperationType ThreadStatusUtil::GetThreadOperation() {
+  return ThreadStatus::OperationType::OP_UNKNOWN;
+}
 
 void ThreadStatusUtil::SetThreadOperation(ThreadStatus::OperationType /*op*/) {}
 


### PR DESCRIPTION
When compiling with `-DNROCKSDB_THREAD_STATUS`, some functions in ThreadStatusUtil are declared but their definition is missing. Their definitions are only compiled when not defining `NROCKSDB_THREAD_STATUS`. This causes problems on linking, when the linker cannot find the definitions of

- ThreadStatusUtil::GetThreadOperation
- ThreadStatusUtil::SetEnableTracking

This PR fixes it by adding stubs for these functions in case `NROCKSDB_THREAD_STATUS` is defined.