### PR TITLE
Best-effort recovery support for atomic flush

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -281,12 +281,6 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
         "atomic_flush is incompatible with enable_pipelined_write");
   }
 
-  // TODO remove this restriction
-  if (db_options.atomic_flush && db_options.best_efforts_recovery) {
-    return Status::InvalidArgument(
-        "atomic_flush is currently incompatible with best-efforts recovery");
-  }
-
   if (db_options.use_direct_io_for_flush_and_compaction &&
       0 == db_options.writable_file_max_buffer_size) {
     return Status::InvalidArgument(

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -764,6 +764,10 @@ void VersionEditHandlerPointInTime::OnAtomicGroupReplayBegin() {
     // An old AtomicGroup is incomplete. Throw away the versions that failed to
     // complete it. They must not be used for completing the upcoming
     // AtomicGroup since they are too old.
+    for (auto& cfid_and_version : atomic_update_versions_) {
+      delete cfid_and_version.second;
+      cfid_and_version.second = nullptr;
+    }
   }
 
   in_atomic_group_ = true;

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -1050,8 +1050,7 @@ bool VersionEditHandlerPointInTime::AtomicUpdateVersionsContains(
   return atomic_update_versions_.find(cfid) != atomic_update_versions_.end();
 }
 
-void VersionEditHandlerPointInTime::AtomicUpdateVersionsDropCf(
-    uint32_t cfid) {
+void VersionEditHandlerPointInTime::AtomicUpdateVersionsDropCf(uint32_t cfid) {
   assert(!AtomicUpdateVersionsCompleted());
   auto atomic_update_versions_iter = atomic_update_versions_.find(cfid);
   assert(atomic_update_versions_iter != atomic_update_versions_.end());

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -763,13 +763,11 @@ Status VersionEditHandlerPointInTime::OnAtomicGroupReplayBegin() {
     }
   }
 
-  if (!atomic_update_versions_.empty()) {
-    // An old AtomicGroup is incomplete. Throw away the versions that failed to
-    // complete it. They must not be used for completing the upcoming
-    // AtomicGroup since they are too old.
-    for (auto& cfid_and_version : atomic_update_versions_) {
-      delete cfid_and_version.second;
-    }
+  // An old AtomicGroup is incomplete. Throw away the versions that failed to
+  // complete it. They must not be used for completing the upcoming
+  // AtomicGroup since they are too old.
+  for (auto& cfid_and_version : atomic_update_versions_) {
+    delete cfid_and_version.second;
   }
 
   in_atomic_group_ = true;

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -793,6 +793,9 @@ Status VersionEditHandlerPointInTime::OnAtomicGroupReplayEnd() {
 
   // The AtomicGroup must not have changed the column families. We don't support
   // CF adds or drops in an AtomicGroup.
+  if (builders_.size() != atomic_update_versions_.size()) {
+    return Status::Corruption("unexpected CF change in AtomicGroup");
+  }
   for (const auto& cfid_and_builder : builders_) {
     if (atomic_update_versions_.find(cfid_and_builder.first) ==
         atomic_update_versions_.end()) {
@@ -944,7 +947,7 @@ Status VersionEditHandlerPointInTime::MaybeCreateVersion(
 
   // Create version before apply edit. The version will represent the state
   // before applying the version edit.
-  // A new version will created if:
+  // A new version will be created if:
   // 1) no error has occurred so far, and
   // 2) log_number_, next_file_number_ and last_sequence_ are known, and
   // 3) not in an AtomicGroup

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -769,7 +769,6 @@ Status VersionEditHandlerPointInTime::OnAtomicGroupReplayBegin() {
     // AtomicGroup since they are too old.
     for (auto& cfid_and_version : atomic_update_versions_) {
       delete cfid_and_version.second;
-      cfid_and_version.second = nullptr;
     }
   }
 

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -740,6 +740,9 @@ VersionEditHandlerPointInTime::VersionEditHandlerPointInTime(
                          read_options, epoch_number_requirement) {}
 
 VersionEditHandlerPointInTime::~VersionEditHandlerPointInTime() {
+  for (const auto& cfid_and_version : atomic_update_versions_) {
+    delete cfid_and_version.second;
+  }
   for (const auto& elem : versions_) {
     delete elem.second;
   }

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -40,8 +40,8 @@ class VersionEditHandlerBase {
   virtual Status ApplyVersionEdit(VersionEdit& edit,
                                   ColumnFamilyData** cfd) = 0;
 
-  virtual void OnAtomicGroupReplayBegin() {}
-  virtual void OnAtomicGroupReplayEnd() {}
+  virtual Status OnAtomicGroupReplayBegin() { return Status::OK(); }
+  virtual Status OnAtomicGroupReplayEnd() { return Status::OK(); }
 
   virtual void CheckIterationResult(const log::Reader& /*reader*/,
                                     Status* /*s*/) {}
@@ -240,8 +240,8 @@ class VersionEditHandlerPointInTime : public VersionEditHandler {
   ~VersionEditHandlerPointInTime() override;
 
  protected:
-  void OnAtomicGroupReplayBegin() override;
-  void OnAtomicGroupReplayEnd() override;
+  Status OnAtomicGroupReplayBegin() override;
+  Status OnAtomicGroupReplayEnd() override;
   void CheckIterationResult(const log::Reader& reader, Status* s) override;
 
   ColumnFamilyData* DestroyCfAndCleanup(const VersionEdit& edit) override;

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -263,7 +263,21 @@ class VersionEditHandlerPointInTime : public VersionEditHandler {
   // updating `versions_` until all its entries are populated with valid
   // `Version`s.
   std::unordered_map<uint32_t, Version*> atomic_update_versions_;
+  size_t atomic_update_versions_missing_;
   bool in_atomic_group_ = false;
+
+ private:
+  bool AtomicUpdateVersionsCompleted();
+  bool AtomicUpdateVersionsContains(uint32_t cfid);
+
+  // This function is called for `Version*` updates for column families in an
+  // incomplete atomic update. It buffers `Version*` updates in
+  // `atomic_update_versions_`.
+  void AtomicUpdateVersionsPut(Version* version);
+
+  // This function is called upon completion of an atomic update. It applies
+  // `Version*` updates in `atomic_update_versions_` to `versions_`.
+  void AtomicUpdateVersionsApply();
 };
 
 class ManifestTailer : public VersionEditHandlerPointInTime {

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -269,6 +269,7 @@ class VersionEditHandlerPointInTime : public VersionEditHandler {
  private:
   bool AtomicUpdateVersionsCompleted();
   bool AtomicUpdateVersionsContains(uint32_t cfid);
+  void AtomicUpdateVersionsDropCf(uint32_t cfid);
 
   // This function is called for `Version*` updates for column families in an
   // incomplete atomic update. It buffers `Version*` updates in

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -2967,7 +2967,7 @@ TEST_F(AtomicGroupBestEffortRecoveryTest,
     edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
                                   cfid /* remaining_entries */);
   }
-  AddNewEditsToLog(edits_.size());
+  AddNewEditsToLog(kNumColumnFamilies);
 
   {
     bool has_missing_table_file;
@@ -3016,7 +3016,7 @@ TEST_F(AtomicGroupBestEffortRecoveryTest, HandleAtomicGroupUpdatesValidLater) {
     edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
                                   cfid /* remaining_entries */);
   }
-  AddNewEditsToLog(edits_.size());
+  AddNewEditsToLog(kNumColumnFamilies);
 
   {
     // Delete the file with the corrupted number.
@@ -3082,7 +3082,7 @@ TEST_F(AtomicGroupBestEffortRecoveryTest, HandleAtomicGroupUpdatesInvalid) {
     edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
                                   cfid /* remaining_entries */);
   }
-  AddNewEditsToLog(edits_.size());
+  AddNewEditsToLog(kNumColumnFamilies);
 
   {
     bool has_missing_table_file = false;
@@ -3132,7 +3132,7 @@ TEST_F(AtomicGroupBestEffortRecoveryTest,
     edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
                                   cfid /* remaining_entries */);
   }
-  AddNewEditsToLog(edits_.size());
+  AddNewEditsToLog(kNumColumnFamilies);
 
   {
     // Delete the file with the corrupted number. But bundle it in an
@@ -3204,7 +3204,7 @@ TEST_F(AtomicGroupBestEffortRecoveryTest,
   edits_.back().AddFile(0 /* level */, file_metas[0]);
   edits_.back().SetLastSequence(++last_seqno_);
   edits_.back().MarkAtomicGroup(0 /* remaining_entries */);
-  AddNewEditsToLog(edits_.size());
+  AddNewEditsToLog(kNumColumnFamilies);
 
   {
     bool has_missing_table_file = false;
@@ -3248,7 +3248,7 @@ TEST_F(AtomicGroupBestEffortRecoveryTest,
     edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
                                   cfid /* remaining_entries */);
   }
-  AddNewEditsToLog(edits_.size());
+  AddNewEditsToLog(kNumColumnFamilies);
 
   {
     // Delete the column family with the corrupted file number.
@@ -3303,7 +3303,7 @@ TEST_F(AtomicGroupBestEffortRecoveryTest,
     edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
                                   cfid /* remaining_entries */);
   }
-  AddNewEditsToLog(edits_.size());
+  AddNewEditsToLog(kNumColumnFamilies);
 
   {
     // Add a new CF. Have the new CF refer to a non-existent file for an extra

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -3182,6 +3182,55 @@ TEST_F(AtomicGroupBestEffortRecoveryTest,
        HandleAtomicGroupMadeWholeByDeletingCf) {
   // One AtomicGroup contains an update that becomes valid when its column
   // family is deleted, making it irrelevant.
+  std::vector<SstInfo> file_infos;
+  for (int cfid = 0; cfid < kNumColumnFamilies; cfid++) {
+    int file_number = 10 + cfid;
+    file_infos.emplace_back(file_number, column_families_[cfid].name,
+                            "" /* key */, 0 /* level */,
+                            file_number /* epoch_number */);
+  }
+
+  std::vector<FileMetaData> file_metas;
+  CreateDummyTableFiles(file_infos, &file_metas);
+
+  edits_.clear();
+  for (int cfid = 0; cfid < kNumColumnFamilies; cfid++) {
+    if (cfid == kNumColumnFamilies - 1) {
+      // Corrupt the number of the last file.
+      file_metas[cfid].fd.packed_number_and_path_id =
+          PackFileNumberAndPathId(20 /* number */, 0 /* path_id */);
+    }
+    edits_.emplace_back();
+    edits_.back().SetColumnFamily(cfid);
+    edits_.back().AddFile(0 /* level */, file_metas[cfid]);
+    edits_.back().SetLastSequence(++last_seqno_);
+    edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
+                                  cfid /* remaining_entries */);
+  }
+  AddNewEditsToLog(edits_.size());
+
+  {
+    // Delete the column family with the corrupted file number.
+    VersionEdit fixup_edit;
+    fixup_edit.DropColumnFamily();
+    fixup_edit.SetColumnFamily(kNumColumnFamilies - 1);
+    assert(log_writer_.get() != nullptr);
+    std::string record;
+    ASSERT_TRUE(fixup_edit.EncodeTo(&record, 0 /* ts_sz */));
+    ASSERT_OK(log_writer_->AddRecord(WriteOptions(), record));
+  }
+
+  {
+    bool has_missing_table_file = false;
+    ASSERT_OK(versions_->TryRecover(column_families_, false /* read_only */,
+                                    {DescriptorFileName(1 /* number */)},
+                                    nullptr /* db_id */,
+                                    &has_missing_table_file));
+  }
+  std::vector<uint64_t> all_table_files;
+  std::vector<uint64_t> all_blob_files;
+  versions_->AddLiveFiles(&all_table_files, &all_blob_files);
+  ASSERT_EQ(file_metas.size() - 1, all_table_files.size());
 }
 
 TEST_F(AtomicGroupBestEffortRecoveryTest,

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -2506,6 +2506,9 @@ class VersionSetAtomicGroupTest : public VersionSetTestBase,
   VersionSetAtomicGroupTest()
       : VersionSetTestBase("version_set_atomic_group_test") {}
 
+  explicit VersionSetAtomicGroupTest(const std::string& name)
+      : VersionSetTestBase(name) {}
+
   void SetUp() override {
     PrepareManifest(&column_families_, &last_seqno_, &log_writer_);
     SetupTestSyncPoints();
@@ -2870,6 +2873,51 @@ TEST_F(VersionSetAtomicGroupTest,
   mu.Unlock();
   EXPECT_EQ(edits_[1].DebugString(),
             edit_with_incorrect_group_size_.DebugString());
+}
+
+class AtomicGroupBestEffortRecoveryTest : public VersionSetAtomicGroupTest {
+ public:
+  AtomicGroupBestEffortRecoveryTest()
+      : VersionSetAtomicGroupTest("atomic_group_best_effort_recovery_test") {}
+};
+
+TEST_F(AtomicGroupBestEffortRecoveryTest,
+       HandleAtomicGroupUpdatesValidInitially) {
+  // One AtomicGroup contains updates that are valid at the outset.
+}
+
+TEST_F(AtomicGroupBestEffortRecoveryTest, HandleAtomicGroupUpdatesValidLater) {
+  // One AtomicGroup contains updates that become valid after applying further
+  // updates.
+}
+
+TEST_F(AtomicGroupBestEffortRecoveryTest, HandleAtomicGroupUpdatesInvalid) {
+  // One AtomicGroup contains updates that never become valid.
+}
+
+TEST_F(AtomicGroupBestEffortRecoveryTest,
+       HandleAtomicGroupUpdatesValidTooLate) {
+  // One AtomicGroup contains updates that become valid after the next
+  // AtomicGroup is reached, which is too late.
+}
+
+TEST_F(AtomicGroupBestEffortRecoveryTest,
+       HandleAtomicGroupUpdatesInDuplicateInvalid) {
+  // One AtomicGroup has multiple updates for the same CF. One of the earlier
+  // updates for this CF can lead to a valid state if applied. But the last
+  // update for this CF is invalid so the AtomicGroup must not be recovered.
+}
+
+TEST_F(AtomicGroupBestEffortRecoveryTest,
+       HandleAtomicGroupMadeWholeByDeletingCf) {
+  // One AtomicGroup contains an update that becomes valid when its column
+  // family is deleted, making it irrelevant.
+}
+
+TEST_F(AtomicGroupBestEffortRecoveryTest,
+       HandleAtomicGroupMadeWholeAfterNewCf) {
+  // One AtomicGroup contains updates that become valid after a new column
+  // family is added.
 }
 
 class VersionSetTestDropOneCF : public VersionSetTestBase,

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -1219,6 +1219,7 @@ class VersionSetTestBase {
   const static std::string kColumnFamilyName1;
   const static std::string kColumnFamilyName2;
   const static std::string kColumnFamilyName3;
+  const static int kNumColumnFamilies = 4;
   int num_initial_edits_;
 
   explicit VersionSetTestBase(const std::string& name)
@@ -1232,7 +1233,7 @@ class VersionSetTestBase {
         table_cache_(NewLRUCache(50000, 16)),
         write_buffer_manager_(db_options_.db_write_buffer_size),
         shutting_down_(false),
-        mock_table_factory_(std::make_shared<mock::MockTableFactory>()) {
+        table_factory_(std::make_shared<mock::MockTableFactory>()) {
     EXPECT_OK(test::CreateEnvFromSystem(ConfigOptions(), &env_, &env_guard_));
     if (env_ == Env::Default() && getenv("MEM_ENV")) {
       env_guard_.reset(NewMemEnv(Env::Default()));
@@ -1332,9 +1333,71 @@ class VersionSetTestBase {
     }
     ASSERT_OK(s);
 
-    cf_options_.table_factory = mock_table_factory_;
+    cf_options_.table_factory = table_factory_;
     for (const auto& cf_name : cf_names) {
       column_families->emplace_back(cf_name, cf_options_);
+    }
+  }
+
+  struct SstInfo {
+    uint64_t file_number;
+    std::string column_family;
+    std::string key;  // the only key
+    int level = 0;
+    uint64_t epoch_number;
+    SstInfo(uint64_t file_num, const std::string& cf_name,
+            const std::string& _key,
+            uint64_t _epoch_number = kUnknownEpochNumber)
+        : SstInfo(file_num, cf_name, _key, 0, _epoch_number) {}
+    SstInfo(uint64_t file_num, const std::string& cf_name,
+            const std::string& _key, int lvl,
+            uint64_t _epoch_number = kUnknownEpochNumber)
+        : file_number(file_num),
+          column_family(cf_name),
+          key(_key),
+          level(lvl),
+          epoch_number(_epoch_number) {}
+  };
+
+  // Create dummy sst, return their metadata. Note that only file name and size
+  // are used.
+  void CreateDummyTableFiles(const std::vector<SstInfo>& file_infos,
+                             std::vector<FileMetaData>* file_metas) {
+    assert(file_metas != nullptr);
+    for (const auto& info : file_infos) {
+      uint64_t file_num = info.file_number;
+      std::string fname = MakeTableFileName(dbname_, file_num);
+      std::unique_ptr<FSWritableFile> file;
+      Status s = fs_->NewWritableFile(fname, FileOptions(), &file, nullptr);
+      ASSERT_OK(s);
+      std::unique_ptr<WritableFileWriter> fwriter(new WritableFileWriter(
+          std::move(file), fname, FileOptions(), env_->GetSystemClock().get()));
+      InternalTblPropCollFactories internal_tbl_prop_coll_factories;
+
+      const ReadOptions read_options;
+      const WriteOptions write_options;
+      std::unique_ptr<TableBuilder> builder(table_factory_->NewTableBuilder(
+          TableBuilderOptions(
+              immutable_options_, mutable_cf_options_, read_options,
+              write_options, InternalKeyComparator(options_.comparator),
+              &internal_tbl_prop_coll_factories, kNoCompression,
+              CompressionOptions(),
+              TablePropertiesCollectorFactory::Context::kUnknownColumnFamily,
+              info.column_family, info.level),
+          fwriter.get()));
+      InternalKey ikey(info.key, 0, ValueType::kTypeValue);
+      builder->Add(ikey.Encode(), "value");
+      ASSERT_OK(builder->Finish());
+      ASSERT_OK(fwriter->Flush(IOOptions()));
+      uint64_t file_size = 0;
+      s = fs_->GetFileSize(fname, IOOptions(), &file_size, nullptr);
+      ASSERT_OK(s);
+      ASSERT_NE(0, file_size);
+      file_metas->emplace_back(
+          file_num, /*file_path_id=*/0, file_size, ikey, ikey, 0, 0, false,
+          Temperature::kUnknown, 0, 0, 0, info.epoch_number,
+          kUnknownFileChecksum, kUnknownFileChecksumFuncName, kNullUniqueId64x2,
+          0, 0, /* user_defined_timestamps_persisted */ true);
     }
   }
 
@@ -1469,7 +1532,7 @@ class VersionSetTestBase {
   std::shared_ptr<ReactiveVersionSet> reactive_versions_;
   InstrumentedMutex mutex_;
   std::atomic<bool> shutting_down_;
-  std::shared_ptr<mock::MockTableFactory> mock_table_factory_;
+  std::shared_ptr<TableFactory> table_factory_;
   std::vector<ColumnFamilyDescriptor> column_families_;
 };
 
@@ -2606,7 +2669,7 @@ class VersionSetAtomicGroupTest : public VersionSetTestBase,
   void AddNewEditsToLog(int num_edits) {
     for (int i = 0; i < num_edits; i++) {
       std::string record;
-      edits_[i].EncodeTo(&record);
+      edits_[i].EncodeTo(&record, 0 /* ts_sz */);
       ASSERT_OK(log_writer_->AddRecord(WriteOptions(), record));
     }
   }
@@ -2884,6 +2947,39 @@ class AtomicGroupBestEffortRecoveryTest : public VersionSetAtomicGroupTest {
 TEST_F(AtomicGroupBestEffortRecoveryTest,
        HandleAtomicGroupUpdatesValidInitially) {
   // One AtomicGroup contains updates that are valid at the outset.
+  std::vector<SstInfo> file_infos;
+  for (int cfid = 0; cfid < kNumColumnFamilies; cfid++) {
+    int file_number = 10 + cfid;
+    file_infos.emplace_back(file_number, column_families_[cfid].name,
+                            "" /* key */, 0 /* level */,
+                            file_number /* epoch_number */);
+  }
+
+  std::vector<FileMetaData> file_metas;
+  CreateDummyTableFiles(file_infos, &file_metas);
+
+  edits_.clear();
+  for (int cfid = 0; cfid < kNumColumnFamilies; cfid++) {
+    edits_.emplace_back();
+    edits_.back().SetColumnFamily(cfid);
+    edits_.back().AddFile(0 /* level */, file_metas[cfid]);
+    edits_.back().SetLastSequence(++last_seqno_);
+    edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
+                                  cfid /* remaining_entries */);
+  }
+  AddNewEditsToLog(edits_.size());
+
+  {
+    bool has_missing_table_file;
+    ASSERT_OK(versions_->TryRecover(column_families_, false /* read_only */,
+                                    {DescriptorFileName(1 /* number */)},
+                                    nullptr /* db_id */,
+                                    &has_missing_table_file));
+  }
+  std::vector<uint64_t> all_table_files;
+  std::vector<uint64_t> all_blob_files;
+  versions_->AddLiveFiles(&all_table_files, &all_blob_files);
+  ASSERT_EQ(file_metas.size(), all_table_files.size());
 }
 
 TEST_F(AtomicGroupBestEffortRecoveryTest, HandleAtomicGroupUpdatesValidLater) {
@@ -2893,6 +2989,44 @@ TEST_F(AtomicGroupBestEffortRecoveryTest, HandleAtomicGroupUpdatesValidLater) {
 
 TEST_F(AtomicGroupBestEffortRecoveryTest, HandleAtomicGroupUpdatesInvalid) {
   // One AtomicGroup contains updates that never become valid.
+  std::vector<SstInfo> file_infos;
+  for (int cfid = 0; cfid < kNumColumnFamilies; cfid++) {
+    int file_number = 10 + cfid;
+    file_infos.emplace_back(file_number, column_families_[cfid].name,
+                            "" /* key */, 0 /* level */,
+                            file_number /* epoch_number */);
+  }
+
+  std::vector<FileMetaData> file_metas;
+  CreateDummyTableFiles(file_infos, &file_metas);
+
+  edits_.clear();
+  for (int cfid = 0; cfid < kNumColumnFamilies; cfid++) {
+    if (cfid == kNumColumnFamilies - 1) {
+      // Corrupt the number of the last file.
+      file_metas[cfid].fd.packed_number_and_path_id =
+          PackFileNumberAndPathId(20 /* number */, 0 /* path_id */);
+    }
+    edits_.emplace_back();
+    edits_.back().SetColumnFamily(cfid);
+    edits_.back().AddFile(0 /* level */, file_metas[cfid]);
+    edits_.back().SetLastSequence(++last_seqno_);
+    edits_.back().MarkAtomicGroup(kNumColumnFamilies - 1 -
+                                  cfid /* remaining_entries */);
+  }
+  AddNewEditsToLog(edits_.size());
+
+  {
+    bool has_missing_table_file = false;
+    ASSERT_OK(versions_->TryRecover(column_families_, false /* read_only */,
+                                    {DescriptorFileName(1 /* number */)},
+                                    nullptr /* db_id */,
+                                    &has_missing_table_file));
+  }
+  std::vector<uint64_t> all_table_files;
+  std::vector<uint64_t> all_blob_files;
+  versions_->AddLiveFiles(&all_table_files, &all_blob_files);
+  ASSERT_TRUE(all_table_files.empty());
 }
 
 TEST_F(AtomicGroupBestEffortRecoveryTest,
@@ -3429,9 +3563,6 @@ class VersionSetTestMissingFiles : public VersionSetTestBase,
  public:
   VersionSetTestMissingFiles()
       : VersionSetTestBase("version_set_test_missing_files"),
-        block_based_table_options_(),
-        table_factory_(std::make_shared<BlockBasedTableFactory>(
-            block_based_table_options_)),
         internal_comparator_(
             std::make_shared<InternalKeyComparator>(options_.comparator)) {}
 
@@ -3505,68 +3636,6 @@ class VersionSetTestMissingFiles : public VersionSetTestBase,
     *last_seqno = seq + 1;
   }
 
-  struct SstInfo {
-    uint64_t file_number;
-    std::string column_family;
-    std::string key;  // the only key
-    int level = 0;
-    uint64_t epoch_number;
-    SstInfo(uint64_t file_num, const std::string& cf_name,
-            const std::string& _key,
-            uint64_t _epoch_number = kUnknownEpochNumber)
-        : SstInfo(file_num, cf_name, _key, 0, _epoch_number) {}
-    SstInfo(uint64_t file_num, const std::string& cf_name,
-            const std::string& _key, int lvl,
-            uint64_t _epoch_number = kUnknownEpochNumber)
-        : file_number(file_num),
-          column_family(cf_name),
-          key(_key),
-          level(lvl),
-          epoch_number(_epoch_number) {}
-  };
-
-  // Create dummy sst, return their metadata. Note that only file name and size
-  // are used.
-  void CreateDummyTableFiles(const std::vector<SstInfo>& file_infos,
-                             std::vector<FileMetaData>* file_metas) {
-    assert(file_metas != nullptr);
-    for (const auto& info : file_infos) {
-      uint64_t file_num = info.file_number;
-      std::string fname = MakeTableFileName(dbname_, file_num);
-      std::unique_ptr<FSWritableFile> file;
-      Status s = fs_->NewWritableFile(fname, FileOptions(), &file, nullptr);
-      ASSERT_OK(s);
-      std::unique_ptr<WritableFileWriter> fwriter(new WritableFileWriter(
-          std::move(file), fname, FileOptions(), env_->GetSystemClock().get()));
-      InternalTblPropCollFactories internal_tbl_prop_coll_factories;
-
-      const ReadOptions read_options;
-      const WriteOptions write_options;
-      std::unique_ptr<TableBuilder> builder(table_factory_->NewTableBuilder(
-          TableBuilderOptions(
-              immutable_options_, mutable_cf_options_, read_options,
-              write_options, *internal_comparator_,
-              &internal_tbl_prop_coll_factories, kNoCompression,
-              CompressionOptions(),
-              TablePropertiesCollectorFactory::Context::kUnknownColumnFamily,
-              info.column_family, info.level),
-          fwriter.get()));
-      InternalKey ikey(info.key, 0, ValueType::kTypeValue);
-      builder->Add(ikey.Encode(), "value");
-      ASSERT_OK(builder->Finish());
-      ASSERT_OK(fwriter->Flush(IOOptions()));
-      uint64_t file_size = 0;
-      s = fs_->GetFileSize(fname, IOOptions(), &file_size, nullptr);
-      ASSERT_OK(s);
-      ASSERT_NE(0, file_size);
-      file_metas->emplace_back(
-          file_num, /*file_path_id=*/0, file_size, ikey, ikey, 0, 0, false,
-          Temperature::kUnknown, 0, 0, 0, info.epoch_number,
-          kUnknownFileChecksum, kUnknownFileChecksumFuncName, kNullUniqueId64x2,
-          0, 0, /* user_defined_timestamps_persisted */ true);
-    }
-  }
-
   // This method updates last_sequence_.
   void WriteFileAdditionAndDeletionToManifest(
       uint32_t cf, const std::vector<std::pair<int, FileMetaData>>& added_files,
@@ -3590,8 +3659,6 @@ class VersionSetTestMissingFiles : public VersionSetTestBase,
     ASSERT_OK(s);
   }
 
-  BlockBasedTableOptions block_based_table_options_;
-  std::shared_ptr<TableFactory> table_factory_;
   std::shared_ptr<InternalKeyComparator> internal_comparator_;
   std::vector<ColumnFamilyDescriptor> column_families_;
   SequenceNumber last_seqno_;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1344,8 +1344,6 @@ struct DBOptions {
   // setting. BER does require at least one valid MANIFEST to recover to a
   // non-trivial DB state, unlike `ldb repair`.
   //
-  // Currently, best_efforts_recovery=true is not compatible with atomic flush.
-  //
   // Default: false
   bool best_efforts_recovery = false;
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1327,6 +1327,13 @@ struct DBOptions {
   // is like applying WALRecoveryMode::kPointInTimeRecovery to each column
   // family rather than just the WAL.
   //
+  // The behavior changes in the presence of "AtomicGroup"s in the MANIFEST,
+  // which is currently only the case when `atomic_flush == true`. In that
+  // case, all pre-existing CFs must recover the atomic group in order for
+  // that group to be applied in an all-or-nothing manner. This means that
+  // unused/inactive CF(s) with invalid filesystem state can block recovery of
+  // all other CFs at an atomic group.
+  //
   // Best-efforts recovery (BER) is specifically designed to recover a DB with
   // files that are missing or truncated to some smaller size, such as the
   // result of an incomplete DB "physical" (FileSystem) copy. BER can also

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -425,7 +425,6 @@ optimistic_txn_params = {
 
 best_efforts_recovery_params = {
     "best_efforts_recovery": 1,
-    "atomic_flush": 0,
     "disable_wal": 1,
     "column_families": 1,
     "skip_verifydb": 1,
@@ -668,7 +667,6 @@ def finalize_and_sanitize(src_params):
         dest_params["enable_pipelined_write"] = 0
     if dest_params.get("best_efforts_recovery") == 1:
         dest_params["disable_wal"] = 1
-        dest_params["atomic_flush"] = 0
         dest_params["enable_compaction_filter"] = 0
         dest_params["sync"] = 0
         dest_params["write_fault_one_in"] = 0

--- a/unreleased_history/public_api_changes/best_effort_atomic.md
+++ b/unreleased_history/public_api_changes/best_effort_atomic.md
@@ -1,0 +1,1 @@
+* Best-effort recovery (`best_efforts_recovery == true`) may now be used together with atomic flush (`atomic_flush == true`). The all-or-nothing recovery guarantee for atomically flushed data will be upheld.


### PR DESCRIPTION
This PR updates `VersionEditHandlerPointInTime` to recover all or none of the updates in an AtomicGroup. This makes best-effort recovery properly handle atomic flushes during recovery, so the features are now allowed to both be enabled at once.

The new logic requires that AtomicGroups do not contain column family additions or removals. AtomicGroups are currently written for atomic flush, which does not include such edits.

Column family additions or removals are recovered independently of AtomicGroups. The new logic needs to be aware of removal, though, so that a dropped CF does not prevent completion of an AtomicGroup recovery.

The new logic treats each AtomicGroup as if it contains updates for all existing column families, even though it is possible to create AtomicGroups that only affect a subset of column families. This simplifies the logic at the expense of recovering less data in certain edge case scenarios.

The usage of `MaybeCreateVersion()` is pretty tricky. The goal is to create a barrier at the start of an AtomicGroup such that all valid states up to that point will be applied to `versions_`. Here is a summary.

- `MaybeCreateVersion(..., false)` creates a `Version` on a negative edge trigger (transition from valid to invalid). It was  previously called when applying each update. Now, it is only called when applying non-AtomicGroup updates.
- `MaybeCreateVersion(..., true)` creates a `Version` on a positive level trigger (valid state). It was previously called only at the end of iteration. Now, it is additionally called before processing an AtomicGroup.