### PR TITLE
Add a FS flag to detect and correct corruption

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -82,11 +82,12 @@ enum class IOType : uint8_t {
 // enum representing various operations supported by underlying FileSystem.
 // These need to be set in SupportedOps API for RocksDB to use them.
 enum FSSupportedOps {
-  kAsyncIO,        // Supports async reads
-  kFSBuffer,       // Supports handing off the file system allocated read buffer
-                   // to the caller of Read/MultiRead
-  kIntegrityRead,  // Supports a higher level of data inegrity. See the
-                   // integrity_read flag in IOOptions.
+  kAsyncIO,   // Supports async reads
+  kFSBuffer,  // Supports handing off the file system allocated read buffer
+              // to the caller of Read/MultiRead
+  kVerifyAndReconstructRead,  // Supports a higher level of data inegrity. See
+                              // the verify_and_reconstruct_read flag in
+                              // IOOptions.
 };
 
 // Per-request options that can be passed down to the FileSystem
@@ -134,9 +135,9 @@ struct IOOptions {
   // much higher overhead than a normal read.
   // This is a hint. At a minimum, the file system should implement this flag in
   // FSRandomAccessFile::Read and FSSequentialFile::Read
-  // NOTE: The file system must support kIntegrityRead in FSSupportedOps,
-  // otherwise this feature will not be used.
-  bool integrity_read;
+  // NOTE: The file system must support kVerifyAndReconstructRead in
+  // FSSupportedOps, otherwise this feature will not be used.
+  bool verify_and_reconstruct_read;
 
   // EXPERIMENTAL
   Env::IOActivity io_activity = Env::IOActivity::kUnknown;

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -85,7 +85,7 @@ enum FSSupportedOps {
   kAsyncIO,   // Supports async reads
   kFSBuffer,  // Supports handing off the file system allocated read buffer
               // to the caller of Read/MultiRead
-  kVerifyAndReconstructRead,  // Supports a higher level of data inegrity. See
+  kVerifyAndReconstructRead,  // Supports a higher level of data integrity. See
                               // the verify_and_reconstruct_read flag in
                               // IOOptions.
 };

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -81,7 +81,13 @@ enum class IOType : uint8_t {
 
 // enum representing various operations supported by underlying FileSystem.
 // These need to be set in SupportedOps API for RocksDB to use them.
-enum FSSupportedOps { kAsyncIO, kFSBuffer };
+enum FSSupportedOps {
+  kAsyncIO,        // Supports async reads
+  kFSBuffer,       // Supports handing off the file system allocated read buffer
+                   // to the caller of Read/MultiRead
+  kIntegrityRead,  // Supports a higher level of data inegrity. See the
+                   // integrity_read flag in IOOptions.
+};
 
 // Per-request options that can be passed down to the FileSystem
 // implementation. These are hints and are not necessarily guaranteed to be
@@ -119,6 +125,18 @@ struct IOOptions {
   // Can be used by underlying file systems to skip recursing through sub
   // directories and list only files in GetChildren API.
   bool do_not_recurse;
+
+  // Setting this flag indicates a corruption was detected by a previous read,
+  // so the caller wants to re-read the data with much stronger data integrity
+  // checking and correction, i.e requests the file system to reconstruct the
+  // data from redundant copies and verify checksums, if available, in order
+  // to have a better chance of success. It is expected that this will have a
+  // much higher overhead than a normal read.
+  // This is a hint. At a minimum, the file system should implement this flag in
+  // FSRandomAccessFile::Read and FSSequentialFile::Read
+  // NOTE: The file system must support kIntegrityRead in FSSupportedOps,
+  // otherwise this feature will not be used.
+  bool integrity_read;
 
   // EXPERIMENTAL
   Env::IOActivity io_activity = Env::IOActivity::kUnknown;


### PR DESCRIPTION
Add a flag in `IOOptions` to request the file system to make best efforts to detect data corruption and reconstruct the data if possible. This will be used by RocksDB to retry a read if the previous read returns corrupt data (checksum mismatch). Add a new op to `FSSupportedOps` that, if supported, will trigger this behavior in RocksDB.