### PR TITLE
Java API - Fix handling of CF handles in DB subclasses

### DIFF
--- a/java/src/main/java/org/rocksdb/OptimisticTransactionDB.java
+++ b/java/src/main/java/org/rocksdb/OptimisticTransactionDB.java
@@ -44,6 +44,8 @@ public class OptimisticTransactionDB extends RocksDB
     // in RocksDB can prevent Java to GC during the life-time of
     // the currently-created RocksDB.
     otdb.storeOptionsInstance(options);
+    
+    otdb.storeDefaultColumnFamilyHandle(otdb.makeDefaultColumnFamilyHandle());
 
     return otdb;
   }

--- a/java/src/main/java/org/rocksdb/OptimisticTransactionDB.java
+++ b/java/src/main/java/org/rocksdb/OptimisticTransactionDB.java
@@ -5,6 +5,7 @@
 
 package org.rocksdb;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -44,7 +45,7 @@ public class OptimisticTransactionDB extends RocksDB
     // in RocksDB can prevent Java to GC during the life-time of
     // the currently-created RocksDB.
     otdb.storeOptionsInstance(options);
-    
+
     otdb.storeDefaultColumnFamilyHandle(otdb.makeDefaultColumnFamilyHandle());
 
     return otdb;
@@ -69,7 +70,7 @@ public class OptimisticTransactionDB extends RocksDB
       final List<ColumnFamilyDescriptor> columnFamilyDescriptors,
       final List<ColumnFamilyHandle> columnFamilyHandles)
       throws RocksDBException {
-
+    int defaultColumnFamilyIndex = -1;
     final byte[][] cfNames = new byte[columnFamilyDescriptors.size()][];
     final long[] cfOptionHandles = new long[columnFamilyDescriptors.size()];
     for (int i = 0; i < columnFamilyDescriptors.size(); i++) {
@@ -77,6 +78,13 @@ public class OptimisticTransactionDB extends RocksDB
           .get(i);
       cfNames[i] = cfDescriptor.getName();
       cfOptionHandles[i] = cfDescriptor.getOptions().nativeHandle_;
+      if (Arrays.equals(cfDescriptor.getName(), RocksDB.DEFAULT_COLUMN_FAMILY)) {
+        defaultColumnFamilyIndex = i;
+      }
+    }
+    if (defaultColumnFamilyIndex < 0) {
+      throw new IllegalArgumentException(
+          "You must provide the default column family in your columnFamilyDescriptors");
     }
 
     final long[] handles = open(dbOptions.nativeHandle_, path, cfNames,
@@ -88,11 +96,13 @@ public class OptimisticTransactionDB extends RocksDB
     // in RocksDB can prevent Java to GC during the life-time of
     // the currently-created RocksDB.
     otdb.storeOptionsInstance(dbOptions);
-    otdb.storeDefaultColumnFamilyHandle(otdb.makeDefaultColumnFamilyHandle());
 
     for (int i = 1; i < handles.length; i++) {
       columnFamilyHandles.add(new ColumnFamilyHandle(otdb, handles[i]));
     }
+
+    otdb.ownedColumnFamilyHandles.addAll(columnFamilyHandles);
+    otdb.storeDefaultColumnFamilyHandle(columnFamilyHandles.get(defaultColumnFamilyIndex));
 
     return otdb;
   }
@@ -135,6 +145,12 @@ public class OptimisticTransactionDB extends RocksDB
   @SuppressWarnings("PMD.EmptyCatchBlock")
   @Override
   public void close() {
+    for (final ColumnFamilyHandle columnFamilyHandle : // NOPMD - CloseResource
+        ownedColumnFamilyHandles) {
+      columnFamilyHandle.close();
+    }
+    ownedColumnFamilyHandles.clear();
+
     if (owningHandle_.compareAndSet(true, false)) {
       try {
         closeDatabase(nativeHandle_);

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -304,9 +304,7 @@ public class RocksDB extends RocksObject {
    */
   public static RocksDB open(final DBOptions options, final String path,
       final List<ColumnFamilyDescriptor> columnFamilyDescriptors,
-      final List<ColumnFamilyHandle> columnFamilyHandles)
-      throws RocksDBException {
-
+      final List<ColumnFamilyHandle> columnFamilyHandles) throws RocksDBException {
     final byte[][] cfNames = new byte[columnFamilyDescriptors.size()][];
     final long[] cfOptionHandles = new long[columnFamilyDescriptors.size()];
     int defaultColumnFamilyIndex = -1;
@@ -320,7 +318,7 @@ public class RocksDB extends RocksObject {
       }
     }
     if (defaultColumnFamilyIndex < 0) {
-      new IllegalArgumentException(
+      throw new IllegalArgumentException(
           "You must provide the default column family in your columnFamilyDescriptors");
     }
 

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -500,11 +500,19 @@ public class RocksDB extends RocksObject {
 
     final byte[][] cfNames = new byte[columnFamilyDescriptors.size()][];
     final long[] cfOptionHandles = new long[columnFamilyDescriptors.size()];
+    int defaultColumnFamilyIndex = -1;
     for (int i = 0; i < columnFamilyDescriptors.size(); i++) {
       final ColumnFamilyDescriptor cfDescriptor = columnFamilyDescriptors
           .get(i);
       cfNames[i] = cfDescriptor.getName();
       cfOptionHandles[i] = cfDescriptor.getOptions().nativeHandle_;
+      if (Arrays.equals(cfDescriptor.getName(), RocksDB.DEFAULT_COLUMN_FAMILY)) {
+        defaultColumnFamilyIndex = i;
+      }
+    }
+    if (defaultColumnFamilyIndex < 0) {
+      throw new IllegalArgumentException(
+          "You must provide the default column family in your columnFamilyDescriptors");
     }
 
     final long[] handles =
@@ -519,7 +527,7 @@ public class RocksDB extends RocksObject {
     }
 
     db.ownedColumnFamilyHandles.addAll(columnFamilyHandles);
-    db.storeDefaultColumnFamilyHandle(db.makeDefaultColumnFamilyHandle());
+    db.storeDefaultColumnFamilyHandle(columnFamilyHandles.get(defaultColumnFamilyIndex));
 
     return db;
   }

--- a/java/src/main/java/org/rocksdb/TtlDB.java
+++ b/java/src/main/java/org/rocksdb/TtlDB.java
@@ -133,7 +133,7 @@ public class TtlDB extends RocksDB {
       }
     }
     if (defaultColumnFamilyIndex < 0) {
-      new IllegalArgumentException(
+      throw new IllegalArgumentException(
           "You must provide the default column family in your columnFamilyDescriptors");
     }
 
@@ -195,6 +195,12 @@ public class TtlDB extends RocksDB {
   @SuppressWarnings("PMD.EmptyCatchBlock")
   @Override
   public void close() {
+    for (final ColumnFamilyHandle columnFamilyHandle : // NOPMD - CloseResource
+        ownedColumnFamilyHandles) {
+      columnFamilyHandle.close();
+    }
+    ownedColumnFamilyHandles.clear();
+
     if (owningHandle_.compareAndSet(true, false)) {
       try {
         closeDatabase(nativeHandle_);

--- a/java/src/test/java/org/rocksdb/ColumnFamilyTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyTest.java
@@ -148,6 +148,166 @@ public class ColumnFamilyTest {
   }
 
   @Test
+  public void defaultColumnFamilySynonyms() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("dfkey_syn_1".getBytes(), "dfvalue_syn_1".getBytes());
+    }
+
+    final List<ColumnFamilyDescriptor> cfNames =
+        Arrays.asList(new ColumnFamilyDescriptor("new_cf1".getBytes()),
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY),
+            new ColumnFamilyDescriptor("new_cf2".getBytes()));
+    final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+
+    try (final DBOptions options =
+             new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final RocksDB db = RocksDB.open(
+             options, dbFolder.getRoot().getAbsolutePath(), cfNames, columnFamilyHandleList)) {
+      assertThat(columnFamilyHandleList.size()).isEqualTo(3);
+      assertThat(db.get(columnFamilyHandleList.get(1), "dfkey_syn_1".getBytes()))
+          .isEqualTo("dfvalue_syn_1".getBytes());
+      db.put(columnFamilyHandleList.get(1), "dfkey_syn_2".getBytes(), "dfvalue_syn_2".getBytes());
+    }
+
+    final List<ColumnFamilyDescriptor> cfNames2 =
+        Arrays.asList(new ColumnFamilyDescriptor("new_cf1".getBytes()),
+            new ColumnFamilyDescriptor("new_cf2".getBytes()),
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+    final List<ColumnFamilyHandle> columnFamilyHandleList2 = new ArrayList<>();
+
+    try (final RocksDB db = RocksDB.open(new DBOptions(), dbFolder.getRoot().getAbsolutePath(),
+             cfNames2, columnFamilyHandleList2)) {
+      assertThat(db.get("dfkey_syn_2".getBytes())).isEqualTo("dfvalue_syn_2".getBytes());
+    }
+  }
+
+  @Test
+  public void defaultColumnFamilySynonymsOTDB() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true);
+         final OptimisticTransactionDB db =
+             OptimisticTransactionDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("dfkey_syn_1".getBytes(), "dfvalue_syn_1".getBytes());
+    }
+
+    final List<ColumnFamilyDescriptor> cfNames =
+        Arrays.asList(new ColumnFamilyDescriptor("new_cf1".getBytes()),
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY),
+            new ColumnFamilyDescriptor("new_cf2".getBytes()));
+    final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+
+    try (final DBOptions options =
+             new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final OptimisticTransactionDB db = OptimisticTransactionDB.open(
+             options, dbFolder.getRoot().getAbsolutePath(), cfNames, columnFamilyHandleList)) {
+      assertThat(columnFamilyHandleList.size()).isEqualTo(3);
+      assertThat(db.get(columnFamilyHandleList.get(1), "dfkey_syn_1".getBytes()))
+          .isEqualTo("dfvalue_syn_1".getBytes());
+      db.put(columnFamilyHandleList.get(1), "dfkey_syn_2".getBytes(), "dfvalue_syn_2".getBytes());
+    }
+
+    final List<ColumnFamilyDescriptor> cfNames2 =
+        Arrays.asList(new ColumnFamilyDescriptor("new_cf1".getBytes()),
+            new ColumnFamilyDescriptor("new_cf2".getBytes()),
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+    final List<ColumnFamilyHandle> columnFamilyHandleList2 = new ArrayList<>();
+
+    try (final OptimisticTransactionDB db = OptimisticTransactionDB.open(new DBOptions(),
+             dbFolder.getRoot().getAbsolutePath(), cfNames2, columnFamilyHandleList2)) {
+      assertThat(db.get("dfkey_syn_2".getBytes())).isEqualTo("dfvalue_syn_2".getBytes());
+    }
+  }
+
+  @Test
+  public void defaultColumnFamilySynonymsTDB() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true);
+         final TransactionDBOptions transactionDBOptions = new TransactionDBOptions();
+         final TransactionDB db = TransactionDB.open(
+             options, transactionDBOptions, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("dfkey_syn_1".getBytes(), "dfvalue_syn_1".getBytes());
+    }
+
+    final List<ColumnFamilyDescriptor> cfNames =
+        Arrays.asList(new ColumnFamilyDescriptor("new_cf1".getBytes()),
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY),
+            new ColumnFamilyDescriptor("new_cf2".getBytes()));
+    final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+
+    try (final DBOptions options =
+             new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final TransactionDBOptions transactionDBOptions = new TransactionDBOptions();
+         final TransactionDB db = TransactionDB.open(options, transactionDBOptions,
+             dbFolder.getRoot().getAbsolutePath(), cfNames, columnFamilyHandleList)) {
+      assertThat(columnFamilyHandleList.size()).isEqualTo(3);
+      assertThat(db.get(columnFamilyHandleList.get(1), "dfkey_syn_1".getBytes()))
+          .isEqualTo("dfvalue_syn_1".getBytes());
+      db.put(columnFamilyHandleList.get(1), "dfkey_syn_2".getBytes(), "dfvalue_syn_2".getBytes());
+    }
+
+    final List<ColumnFamilyDescriptor> cfNames2 =
+        Arrays.asList(new ColumnFamilyDescriptor("new_cf1".getBytes()),
+            new ColumnFamilyDescriptor("new_cf2".getBytes()),
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+    final List<ColumnFamilyHandle> columnFamilyHandleList2 = new ArrayList<>();
+
+    try (final TransactionDBOptions transactionDBOptions = new TransactionDBOptions();
+         final TransactionDB db = TransactionDB.open(new DBOptions(), transactionDBOptions,
+             dbFolder.getRoot().getAbsolutePath(), cfNames2, columnFamilyHandleList2)) {
+      assertThat(db.get("dfkey_syn_2".getBytes())).isEqualTo("dfvalue_syn_2".getBytes());
+    }
+  }
+
+  @Test
+  public void defaultColumnFamilySynonymsTTLDB() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true);
+         final TtlDB db = TtlDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("dfkey_syn_1".getBytes(), "dfvalue_syn_1".getBytes());
+    }
+
+    final List<ColumnFamilyDescriptor> cfNames =
+        Arrays.asList(new ColumnFamilyDescriptor("new_cf1".getBytes()),
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY),
+            new ColumnFamilyDescriptor("new_cf2".getBytes()));
+    final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+
+    try (final DBOptions options =
+             new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final TtlDB db = TtlDB.open(options, dbFolder.getRoot().getAbsolutePath(), cfNames,
+             columnFamilyHandleList, Arrays.asList(10, 10, 10), false)) {
+      assertThat(columnFamilyHandleList.size()).isEqualTo(3);
+      assertThat(db.get(columnFamilyHandleList.get(1), "dfkey_syn_1".getBytes()))
+          .isEqualTo("dfvalue_syn_1".getBytes());
+      db.put(columnFamilyHandleList.get(1), "dfkey_syn_2".getBytes(), "dfvalue_syn_2".getBytes());
+    }
+
+    final List<ColumnFamilyDescriptor> cfNames2 =
+        Arrays.asList(new ColumnFamilyDescriptor("new_cf1".getBytes()),
+            new ColumnFamilyDescriptor("new_cf2".getBytes()),
+            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+    final List<ColumnFamilyHandle> columnFamilyHandleList2 = new ArrayList<>();
+
+    try (final TtlDB db = TtlDB.open(new DBOptions(), dbFolder.getRoot().getAbsolutePath(),
+             cfNames2, columnFamilyHandleList2, Arrays.asList(10, 10, 10), false)) {
+      assertThat(db.get("dfkey_syn_2".getBytes())).isEqualTo("dfvalue_syn_2".getBytes());
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void open_columnFamilies_no_default() throws RocksDBException {
+    try (final DBOptions dbOptions =
+             new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final ColumnFamilyOptions myCfOpts = new ColumnFamilyOptions()) {
+      final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
+          Collections.singletonList(new ColumnFamilyDescriptor("myCf".getBytes(), myCfOpts));
+
+      final List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
+
+      RocksDB.open(dbOptions, dbFolder.getRoot().getAbsolutePath(), columnFamilyDescriptors,
+          columnFamilyHandles);
+    }
+  }
+
+  @Test
   public void getWithOutValueAndCf() throws RocksDBException {
     final List<ColumnFamilyDescriptor> cfDescriptors =
         Collections.singletonList(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));

--- a/java/src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
+++ b/java/src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
@@ -147,7 +147,8 @@ public class OptimisticTransactionDBTest {
   @Test
   public void otdbSimpleIterator() throws RocksDBException {
     try (final Options options = new Options().setCreateIfMissing(true).setMaxCompactionBytes(0);
-         final OptimisticTransactionDB otdb = OptimisticTransactionDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+         final OptimisticTransactionDB otdb =
+             OptimisticTransactionDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
       otdb.put("keyI".getBytes(), "valueI".getBytes());
       try (final RocksIterator iterator = otdb.newIterator()) {
         iterator.seekToFirst();

--- a/java/src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
+++ b/java/src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
@@ -128,4 +128,20 @@ public class OptimisticTransactionDBTest {
       assertThat(db.isOwningHandle()).isFalse();
     }
   }
+
+  @Test
+  public void otdbSimpleIterator() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true).setMaxCompactionBytes(0);
+         final OptimisticTransactionDB otdb = OptimisticTransactionDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      otdb.put("keyI".getBytes(), "valueI".getBytes());
+      try (final RocksIterator iterator = otdb.newIterator()) {
+        iterator.seekToFirst();
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("keyI".getBytes());
+        assertThat(iterator.value()).isEqualTo("valueI".getBytes());
+        iterator.next();
+        assertThat(iterator.isValid()).isFalse();
+      }
+    }
+  }
 }

--- a/java/src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
+++ b/java/src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
@@ -5,15 +5,15 @@
 
 package org.rocksdb;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class OptimisticTransactionDBTest {
 
@@ -53,6 +53,21 @@ public class OptimisticTransactionDBTest {
           }
         }
       }
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void open_columnFamilies_no_default() throws RocksDBException {
+    try (final DBOptions dbOptions =
+             new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final ColumnFamilyOptions myCfOpts = new ColumnFamilyOptions()) {
+      final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
+          Collections.singletonList(new ColumnFamilyDescriptor("myCf".getBytes(), myCfOpts));
+
+      final List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
+
+      OptimisticTransactionDB.open(dbOptions, dbFolder.getRoot().getAbsolutePath(),
+          columnFamilyDescriptors, columnFamilyHandles);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/TransactionDBTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionDBTest.java
@@ -196,7 +196,8 @@ public class TransactionDBTest {
   public void tdbSimpleIterator() throws RocksDBException {
     try (final Options options = new Options().setCreateIfMissing(true).setMaxCompactionBytes(0);
          final TransactionDBOptions txnDbOptions = new TransactionDBOptions();
-         final TransactionDB tdb = TransactionDB.open(options, txnDbOptions, dbFolder.getRoot().getAbsolutePath())) {
+         final TransactionDB tdb =
+             TransactionDB.open(options, txnDbOptions, dbFolder.getRoot().getAbsolutePath())) {
       tdb.put("keyI".getBytes(), "valueI".getBytes());
       try (final RocksIterator iterator = tdb.newIterator()) {
         iterator.seekToFirst();
@@ -208,5 +209,4 @@ public class TransactionDBTest {
       }
     }
   }
-
 }

--- a/java/src/test/java/org/rocksdb/TransactionDBTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionDBTest.java
@@ -31,10 +31,9 @@ public class TransactionDBTest {
 
   @Test
   public void open_columnFamilies() throws RocksDBException {
-    try(final DBOptions dbOptions = new DBOptions().setCreateIfMissing(true)
-          .setCreateMissingColumnFamilies(true);
-        final ColumnFamilyOptions myCfOpts = new ColumnFamilyOptions()) {
-
+    try (final DBOptions dbOptions =
+             new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final ColumnFamilyOptions myCfOpts = new ColumnFamilyOptions()) {
       final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
           Arrays.asList(
               new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY),
@@ -53,6 +52,24 @@ public class TransactionDBTest {
             handle.close();
           }
         }
+      }
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void open_columnFamilies_no_default() throws RocksDBException {
+    try (final DBOptions dbOptions =
+             new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+         final ColumnFamilyOptions myCfOpts = new ColumnFamilyOptions()) {
+      final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
+          Collections.singletonList(new ColumnFamilyDescriptor("myCf".getBytes(), myCfOpts));
+
+      final List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
+
+      try (
+          final TransactionDBOptions txnDbOptions = new TransactionDBOptions();
+          final TransactionDB ignored = TransactionDB.open(dbOptions, txnDbOptions,
+              dbFolder.getRoot().getAbsolutePath(), columnFamilyDescriptors, columnFamilyHandles)) {
       }
     }
   }

--- a/java/src/test/java/org/rocksdb/TransactionDBTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionDBTest.java
@@ -174,4 +174,22 @@ public class TransactionDBTest {
       tdb.setDeadlockInfoBufferSize(123);
     }
   }
+
+  @Test
+  public void tdbSimpleIterator() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true).setMaxCompactionBytes(0);
+         final TransactionDBOptions txnDbOptions = new TransactionDBOptions();
+         final TransactionDB tdb = TransactionDB.open(options, txnDbOptions, dbFolder.getRoot().getAbsolutePath())) {
+      tdb.put("keyI".getBytes(), "valueI".getBytes());
+      try (final RocksIterator iterator = tdb.newIterator()) {
+        iterator.seekToFirst();
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("keyI".getBytes());
+        assertThat(iterator.value()).isEqualTo("valueI".getBytes());
+        iterator.next();
+        assertThat(iterator.isValid()).isFalse();
+      }
+    }
+  }
+
 }

--- a/java/src/test/java/org/rocksdb/TtlDBTest.java
+++ b/java/src/test/java/org/rocksdb/TtlDBTest.java
@@ -52,6 +52,22 @@ public class TtlDBTest {
   }
 
   @Test
+  public void ttlDBSimpleIterator() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true).setMaxCompactionBytes(0);
+         final TtlDB ttlDB = TtlDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      ttlDB.put("keyI".getBytes(), "valueI".getBytes());
+      try (final RocksIterator iterator = ttlDB.newIterator()) {
+        iterator.seekToFirst();
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("keyI".getBytes());
+        assertThat(iterator.value()).isEqualTo("valueI".getBytes());
+        iterator.next();
+        assertThat(iterator.isValid()).isFalse();
+      }
+    }
+  }
+
+  @Test
   public void ttlDbOpenWithColumnFamilies() throws RocksDBException,
       InterruptedException {
     final List<ColumnFamilyDescriptor> cfNames = Arrays.asList(


### PR DESCRIPTION
The most general `open()` method for each of RocksDB, TtlDB, OptimisticTransactionDB and TransactionDB should
- ensure the default CF is supplied in the list of descriptors
- cache the default CF handle
- store open CF handles for automatic close on DB close
The `close()` method in each of these DB subclasses should `close()` all the owned CF handles.

I can’t find a cleaner way to build some generalised open/close that does this for all DB subclasses, so it exists as cut and paste with variations in the 4 different DB subclasses.

Added some slightly paranoid testing that CF handles explicitly referred to as default in a list of CF handles in the general open methods, and the simple open that doesn’t supply a CF, end up reading and writing to the same CF. Prompted by the fact that this code is a bit opaque; the first returned handle is the DB.

As part of this, fix the bug where the Java side of `OptimisticsTransactionDB` was not setting up default column family; this was visible when setting up an iterator; add a test to validate that the iterator is OK. A single Java reference to the default column family was not being created in the OptimisticsTransactionDB RocksDB subclass; it should be created in all subclasses. The same problem had previously been fixed for TtlDB.