### PR TITLE
MultiCfIterator Implementations

### DIFF
--- a/db/multi_cf_iterator.cc
+++ b/db/multi_cf_iterator.cc
@@ -10,20 +10,10 @@
 namespace ROCKSDB_NAMESPACE {
 
 void MultiCfIterator::SeekToFirst() {
-  Reset();
-  int i = 0;
-  for (auto& cfh_iter_pair : cfh_iter_pairs_) {
-    auto& cfh = cfh_iter_pair.first;
-    auto& iter = cfh_iter_pair.second;
-    iter->SeekToFirst();
-    if (iter->Valid()) {
-      assert(iter->status().ok());
-      min_heap_.push(MultiCfIteratorInfo{iter.get(), cfh, i});
-    } else {
-      considerStatus(iter->status());
-    }
-    ++i;
-  }
+  SeekCommon([](Iterator* iter) { iter->SeekToFirst(); });
+}
+void MultiCfIterator::Seek(const Slice& target) {
+  SeekCommon([&target](Iterator* iter) { iter->Seek(target); });
 }
 
 void MultiCfIterator::Next() {

--- a/db/multi_cf_iterator_test.cc
+++ b/db/multi_cf_iterator_test.cc
@@ -14,6 +14,7 @@ class MultiCfIteratorTest : public DBTestBase {
   MultiCfIteratorTest()
       : DBTestBase("multi_cf_iterator_test", /*env_do_fsync=*/true) {}
 
+  // Verify Iteration of MultiCfIterator by SeekToFirst() + Next()
   void verifyMultiCfIterator(
       const std::vector<ColumnFamilyHandle*>& cfhs,
       const std::vector<Slice>& expected_keys,
@@ -100,6 +101,20 @@ TEST_F(MultiCfIteratorTest, SimpleValues) {
     // Iteration order and the return values should be the same since keys are
     // unique per CF
     verifyMultiCfIterator(cfhs_order_3_1_0_2, expected_keys, expected_values);
+
+    // Verify Seek()
+    std::unique_ptr<Iterator> iter =
+        db_->NewMultiCfIterator(ReadOptions(), cfhs_order_0_1_2_3);
+    iter->Seek("");
+    ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_0_val");
+    iter->Seek("key_1");
+    ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_0_val");
+    iter->Seek("key_2");
+    ASSERT_EQ(IterStatus(iter.get()), "key_2->key_2_cf_1_val");
+    iter->Next();
+    ASSERT_EQ(IterStatus(iter.get()), "key_3->key_3_cf_2_val");
+    iter->Seek("key_x");
+    ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
   }
   {
     // Case 2: Same key in multiple CFs
@@ -129,6 +144,71 @@ TEST_F(MultiCfIteratorTest, SimpleValues) {
         handles_[3], handles_[2], handles_[0], handles_[1]};
     expected_values = {"key_1_cf_3_val", "key_2_cf_2_val", "key_3_cf_3_val"};
     verifyMultiCfIterator(cfhs_order_3_2_0_1, expected_keys, expected_values);
+
+    // Verify Seek()
+    std::unique_ptr<Iterator> iter =
+        db_->NewMultiCfIterator(ReadOptions(), cfhs_order_3_2_0_1);
+    iter->Seek("");
+    ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_3_val");
+    iter->Seek("key_1");
+    ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_3_val");
+    iter->Seek("key_2");
+    ASSERT_EQ(IterStatus(iter.get()), "key_2->key_2_cf_2_val");
+    iter->Next();
+    ASSERT_EQ(IterStatus(iter.get()), "key_3->key_3_cf_3_val");
+    iter->Seek("key_x");
+    ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
+  }
+}
+
+TEST_F(MultiCfIteratorTest, EmptyCfs) {
+  Options options = GetDefaultOptions();
+
+  {
+    // Case 1: No keys in any of the CFs
+    CreateAndReopenWithCF({"cf_1", "cf_2", "cf_3"}, options);
+    std::unique_ptr<Iterator> iter =
+        db_->NewMultiCfIterator(ReadOptions(), handles_);
+    iter->SeekToFirst();
+    ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
+    iter->SeekToLast();
+    ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
+    iter->Seek("foo");
+    ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
+    iter->SeekForPrev("foo");
+    ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
+
+    ASSERT_OK(iter->status());
+  }
+  {
+    // Case 2: keys in only one of the CF. Rest CFs are empty.
+    ASSERT_OK(Put(1, "key_1", "key_1_cf_1_val"));
+    std::unique_ptr<Iterator> iter =
+        db_->NewMultiCfIterator(ReadOptions(), handles_);
+    iter->SeekToFirst();
+    ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_1_val");
+    iter->Next();
+    ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
+    iter->SeekToFirst();
+    ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_1_val");
+    // iter->Prev();
+    // ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
+  }
+  {
+    // Case 3: same keys in all of the CFs except one (cf_2).
+    ASSERT_OK(Put(0, "key_1", "key_1_cf_0_val"));
+    ASSERT_OK(Put(3, "key_1", "key_1_cf_3_val"));
+    // handles_ are in the order of 0->1->2->3. We should expect value from cf_0
+    std::unique_ptr<Iterator> iter =
+        db_->NewMultiCfIterator(ReadOptions(), handles_);
+    iter->SeekToFirst();
+    ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_0_val");
+    iter->Next();
+    ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
+    iter->SeekToFirst();
+    ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_0_val");
+    // iter->Prev();
+    // ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
   }
 }
 

--- a/db/multi_cf_iterator_test.cc
+++ b/db/multi_cf_iterator_test.cc
@@ -234,7 +234,7 @@ TEST_F(MultiCfIteratorTest, EmptyCfs) {
     ASSERT_OK(iter->status());
   }
   {
-    // Case 2: keys in only one of the CF. Rest CFs are empty.
+    // Case 2: A single key exists in only one of the CF. Rest CFs are empty.
     ASSERT_OK(Put(1, "key_1", "key_1_cf_1_val"));
     std::unique_ptr<Iterator> iter =
         db_->NewMultiCfIterator(ReadOptions(), handles_);
@@ -242,13 +242,13 @@ TEST_F(MultiCfIteratorTest, EmptyCfs) {
     ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_1_val");
     iter->Next();
     ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
-    iter->SeekToFirst();
+    iter->SeekToLast();
     ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_1_val");
     iter->Prev();
     ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
   }
   {
-    // Case 3: same keys in all of the CFs except one (cf_2).
+    // Case 3: same key exists in all of the CFs except one (cf_2)
     ASSERT_OK(Put(0, "key_1", "key_1_cf_0_val"));
     ASSERT_OK(Put(3, "key_1", "key_1_cf_3_val"));
     // handles_ are in the order of 0->1->2->3. We should expect value from cf_0
@@ -258,7 +258,7 @@ TEST_F(MultiCfIteratorTest, EmptyCfs) {
     ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_0_val");
     iter->Next();
     ASSERT_EQ(IterStatus(iter.get()), "(invalid)");
-    iter->SeekToFirst();
+    iter->SeekToLast();
     ASSERT_EQ(IterStatus(iter.get()), "key_1->key_1_cf_0_val");
     iter->Prev();
     ASSERT_EQ(IterStatus(iter.get()), "(invalid)");


### PR DESCRIPTION
# Summary

This PR continues #12153 by implementing the missing `Iterator` APIs - `Seek()`, `SeekForPrev()`, `SeekToLast()`, and `Prev`. A MaxHeap Implementation has been added to handle the reverse direction.

The current implementation does not include upper/lower bounds yet. These will be added in subsequent PRs. The API is still marked as under construction and will be lifted after being added to the stress test.

Please note that changing the iterator direction in the middle of iteration is expensive, as it requires seeking the element in each iterator again in the opposite direction and rebuilding the heap along the way. The first `Next()` after `SeekForPrev()` requires changing the direction under the current implementation. We may optimize this in later PRs.

# Test Plan
The `multi_cf_iterator_test` has been extended to cover the API implementations.