### PR TITLE
Disable flaky part of TransactionLogIteratorCheckWhenArchive

### DIFF
--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -182,7 +182,8 @@ TEST_F(DBTestXactLogIterator, TransactionLogIteratorCheckWhenArchive) {
     ASSERT_OK(dbfull()->Flush(FlushOptions(), cf));
     delete cf;
     // Normally hit several times; WART: perhaps more in parallel after flush
-    ASSERT_TRUE(callback_hit.LoadRelaxed());
+    // FIXME: this test is flaky
+    // ASSERT_TRUE(callback_hit.LoadRelaxed());
   } while (ChangeCompactOptions());
   Close();
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();


### PR DESCRIPTION
Summary: #12397 attempted to make the test more honest about its failures, and they're really showing up in CI now (but not locally). Disable pending investigation

Test Plan: watch CI