### PR TITLE
Expose PerfContext::ToString in Java.

### DIFF
--- a/java/rocksjni/jni_perf_context.cc
+++ b/java/rocksjni/jni_perf_context.cc
@@ -6,8 +6,25 @@
 #include <jni.h>
 
 #include "include/org_rocksdb_PerfContext.h"
+#include "portal.h"
 #include "rocksdb/db.h"
 #include "rocksdb/perf_context.h"
+
+/*
+ * Class:     org_rocksdb_PerfContext
+ * Method:    toString
+ * Signature: (JZ)Ljava/lang/String;
+ */
+jstring Java_org_rocksdb_PerfContext_toString(JNIEnv* env, jobject,
+                                              jlong jpc_handle,
+                                              jboolean excludeZeroCounters) {
+  ROCKSDB_NAMESPACE::PerfContext* perf_context =
+      reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
+
+  auto result = perf_context->ToString(excludeZeroCounters);
+
+  return ROCKSDB_NAMESPACE::JniUtil::toJavaString(env, &result, false);
+}
 
 void Java_org_rocksdb_PerfContext_reset(JNIEnv*, jobject, jlong jpc_handle) {
   ROCKSDB_NAMESPACE::PerfContext* perf_context =

--- a/java/src/main/java/org/rocksdb/PerfContext.java
+++ b/java/src/main/java/org/rocksdb/PerfContext.java
@@ -651,6 +651,11 @@ public class PerfContext extends RocksObject {
     return getNumberAsyncSeek(nativeHandle_);
   }
 
+  public String toString(boolean excludeZeroCounters) {
+    return toString(nativeHandle_, excludeZeroCounters);
+  }
+  private native String toString(long nativeHandle, boolean excludeZeroCounters);
+
   @Override
   protected void disposeInternal(long handle) {
     // Nothing to do. Perf context is valid for all the time of application is running.

--- a/java/src/main/java/org/rocksdb/PerfContext.java
+++ b/java/src/main/java/org/rocksdb/PerfContext.java
@@ -654,6 +654,11 @@ public class PerfContext extends RocksObject {
   public String toString(boolean excludeZeroCounters) {
     return toString(nativeHandle_, excludeZeroCounters);
   }
+  @Override
+  public String toString() {
+    return toString(true);
+  }
+
   private native String toString(long nativeHandle, boolean excludeZeroCounters);
 
   @Override

--- a/java/src/main/java/org/rocksdb/PerfContext.java
+++ b/java/src/main/java/org/rocksdb/PerfContext.java
@@ -651,7 +651,7 @@ public class PerfContext extends RocksObject {
     return getNumberAsyncSeek(nativeHandle_);
   }
 
-  public String toString(boolean excludeZeroCounters) {
+  public String toString(final boolean excludeZeroCounters) {
     return toString(nativeHandle_, excludeZeroCounters);
   }
   @Override
@@ -659,7 +659,7 @@ public class PerfContext extends RocksObject {
     return toString(true);
   }
 
-  private native String toString(long nativeHandle, boolean excludeZeroCounters);
+  private native String toString(final long nativeHandle, final boolean excludeZeroCounters);
 
   @Override
   protected void disposeInternal(long handle) {

--- a/java/src/test/java/org/rocksdb/PerfContextTest.java
+++ b/java/src/test/java/org/rocksdb/PerfContextTest.java
@@ -104,7 +104,18 @@ public class PerfContextTest {
   }
 
   @Test
-  public void toStringTest() throws RocksDBException {
+  public void toStringDefault() throws RocksDBException {
+    db.setPerfLevel(PerfLevel.ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX);
+    db.put("key".getBytes(), "value".getBytes());
+    db.compactRange();
+    db.get("key".getBytes());
+    PerfContext ctx = db.getPerfContext();
+    String result = ctx.toString(false);
+    assertThat(result).isNotBlank();
+  }
+
+  @Test
+  public void toStringWithParameter() throws RocksDBException {
     db.setPerfLevel(PerfLevel.ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX);
     db.put("key".getBytes(), "value".getBytes());
     db.compactRange();

--- a/java/src/test/java/org/rocksdb/PerfContextTest.java
+++ b/java/src/test/java/org/rocksdb/PerfContextTest.java
@@ -102,4 +102,15 @@ public class PerfContextTest {
     assertThat(ctx).isNotNull();
     assertThat(ctx.getPostProcessTime()).isGreaterThan(0);
   }
+
+  @Test
+  public void toStringTest() throws RocksDBException {
+    db.setPerfLevel(PerfLevel.ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX);
+    db.put("key".getBytes(), "value".getBytes());
+    db.compactRange();
+    db.get("key".getBytes());
+    PerfContext ctx = db.getPerfContext();
+    String result = ctx.toString(false);
+    assertThat(result).isNotBlank();
+  }
 }


### PR DESCRIPTION
Overrode `public String toString()` to use `PerfContext::ToString()`