### PR TITLE
Fix data race in AutoRollLogger

### DIFF
--- a/logging/auto_roll_logger.cc
+++ b/logging/auto_roll_logger.cc
@@ -192,14 +192,13 @@ void AutoRollLogger::LogInternal(const char* format, ...) {
 }
 
 void AutoRollLogger::Logv(const char* format, va_list ap) {
-  assert(GetStatus().ok());
-  if (!logger_) {
-    return;
-  }
-
   std::shared_ptr<Logger> logger;
   {
     MutexLock l(&mutex_);
+    assert(GetStatus().ok());
+    if (!logger_) {
+      return;
+    }
     if ((kLogFileTimeToRoll > 0 && LogExpired()) ||
         (kMaxLogFileSize > 0 && logger_->GetLogFileSize() >= kMaxLogFileSize)) {
       RollLogFile();
@@ -240,10 +239,6 @@ void AutoRollLogger::WriteHeaderInfo() {
 }
 
 void AutoRollLogger::LogHeader(const char* format, va_list args) {
-  if (!logger_) {
-    return;
-  }
-
   // header message are to be retained in memory. Since we cannot make any
   // assumptions about the data contained in va_list, we will retain them as
   // strings
@@ -253,6 +248,9 @@ void AutoRollLogger::LogHeader(const char* format, va_list args) {
   va_end(tmp);
 
   MutexLock l(&mutex_);
+  if (!logger_) {
+    return;
+  }
   headers_.push_back(data);
 
   // Log the original message to the current log

--- a/logging/auto_roll_logger.h
+++ b/logging/auto_roll_logger.h
@@ -42,13 +42,12 @@ class AutoRollLogger : public Logger {
   Status GetStatus() { return status_; }
 
   size_t GetLogFileSize() const override {
-    if (!logger_) {
-      return 0;
-    }
-
     std::shared_ptr<Logger> logger;
     {
       MutexLock l(&mutex_);
+      if (!logger_) {
+        return 0;
+      }
       // pin down the current logger_ instance before releasing the mutex.
       logger = logger_;
     }


### PR DESCRIPTION
`logger_` can be destructed in `ResetLogger()` so we should access them under `mutex_`. Similarly `status_` can be updated only under `mutex_` or in constructor. 

Test plan: I tried running tsan crash test with log_file_time_to_roll = 2, but not able to repro yet. Will monitor internal crash tests.