### PR TITLE
Fix data race in WalManager

### DIFF
--- a/db/wal_manager.h
+++ b/db/wal_manager.h
@@ -25,6 +25,7 @@
 #include "rocksdb/status.h"
 #include "rocksdb/transaction_log.h"
 #include "rocksdb/types.h"
+#include "util/atomic.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -118,7 +119,7 @@ class WalManager {
   port::Mutex read_first_record_cache_mutex_;
 
   // last time when PurgeObsoleteWALFiles ran.
-  uint64_t purge_wal_files_last_run_;
+  RelaxedAtomic<uint64_t> purge_wal_files_last_run_;
 
   bool seq_per_batch_;
 

--- a/unreleased_history/bug_fixes/data_race_in_wal_manager.md
+++ b/unreleased_history/bug_fixes/data_race_in_wal_manager.md
@@ -1,0 +1,1 @@
+* Fixed a data race in WalManager that may affect how frequent PurgeObsoleteWALFiles() runs.


### PR DESCRIPTION
Crash tests were failing due to data race in accessing `purge_wal_files_last_run_`. This PR changes it to atomic.

Test plan: 
- existing UT
- not able to repro with `python3 tools/db_crashtest.py whitebox --simple --max_key=25000000 --WAL_ttl_seconds=1` and TSAN yet, will monitor internal crash tests