### PR TITLE
Fix kBlockCacheTier read with table cache miss

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -489,9 +489,8 @@ Status TableCache::Get(
       s = t->Get(options, k, get_context, prefix_extractor.get(), skip_filters);
       get_context->SetReplayLog(nullptr);
     } else if (options.read_tier == kBlockCacheTier && s.IsIncomplete()) {
-      // Couldn't find Table in cache but treat as kFound if no_io set
+      // Couldn't find table in cache and couldn't open it because of no_io.
       get_context->MarkKeyMayExist();
-      s = Status::OK();
       done = true;
     }
   }

--- a/unreleased_history/bug_fixes/blockcachetier_tablecachemiss.md
+++ b/unreleased_history/bug_fixes/blockcachetier_tablecachemiss.md
@@ -1,0 +1,1 @@
+* Fixed `kBlockCacheTier` reads to return `Status::Incomplete` on table cache miss rather than incorrectly returning an empty value.


### PR DESCRIPTION
Thanks @ltamasi for pointing out this bug.

We were incorrectly overwriting `Status::Incomplete` with `Status::OK` after a table cache miss failed to open the file due to the read being memory-only (`kBlockCacheTier`). The fix is to simply stop overwriting the status.