### PR TITLE
Enable all Java test via CMake

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -895,7 +895,7 @@ foreach (CLAZZ ${JAVA_TEST_RUNNING_CLASSES})
   else()
     add_test(
       NAME jtest_${CLAZZ}
-      COMMAND ${Java_JAVA_EXECUTABLE} ${JVMARGS} -ea -Xcheck:jni -Djava.library.path=${PROJECT_BINARY_DIR}/java -classpath ${JAVA_RUN_TESTCLASSPATH}:${ROCKSDBJNI_CLASSES_TEST_JAR_FILE} org.rocksdb.test.RocksJunitRunner ${CLAZZ}
+            COMMAND ${Java_JAVA_EXECUTABLE} ${JVMARGS} -ea -Xcheck:jni -Djava.library.path=${PROJECT_BINARY_DIR}/java -classpath ${JAVA_RUN_TESTCLASSPATH}:${ROCKSDBJNI_CLASSES_TEST_JAR_FILE}:${CMAKE_CURRENT_BINARY_DIR}/${ROCKSDB_JAR} org.rocksdb.test.RocksJunitRunner ${CLAZZ}
     )
   endif()
 endforeach(CLAZZ)

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -16,12 +16,13 @@ set(CMAKE_JAVA_COMPILE_FLAGS -source 8)
 set(JNI_NATIVE_SOURCES
         rocksjni/backup_engine_options.cc
         rocksjni/backupenginejni.cc
+        rocksjni/cache.cc
         rocksjni/cassandra_compactionfilterjni.cc
         rocksjni/cassandra_value_operator.cc
         rocksjni/checkpoint.cc
         rocksjni/clock_cache.cc
-        rocksjni/cache.cc
         rocksjni/columnfamilyhandle.cc
+        rocksjni/compact_range_options.cc
         rocksjni/compaction_filter.cc
         rocksjni/compaction_filter_factory.cc
         rocksjni/compaction_filter_factory_jnicallback.cc
@@ -30,7 +31,6 @@ set(JNI_NATIVE_SOURCES
         rocksjni/compaction_options.cc
         rocksjni/compaction_options_fifo.cc
         rocksjni/compaction_options_universal.cc
-        rocksjni/compact_range_options.cc
         rocksjni/comparator.cc
         rocksjni/comparatorjnicallback.cc
         rocksjni/compression_options.cc
@@ -42,11 +42,12 @@ set(JNI_NATIVE_SOURCES
         rocksjni/event_listener_jnicallback.cc
         rocksjni/export_import_files_metadatajni.cc
         rocksjni/filter.cc
-        rocksjni/import_column_family_options.cc
         rocksjni/hyper_clock_cache.cc
+        rocksjni/import_column_family_options.cc
         rocksjni/ingest_external_file_options.cc
         rocksjni/iterator.cc
         rocksjni/jni_multiget_helpers.cc
+        rocksjni/jni_perf_context.cc
         rocksjni/jnicallback.cc
         rocksjni/loggerjnicallback.cc
         rocksjni/lru_cache.cc
@@ -59,7 +60,6 @@ set(JNI_NATIVE_SOURCES
         rocksjni/options.cc
         rocksjni/options_util.cc
         rocksjni/persistent_cache.cc
-        rocksjni/jni_perf_context.cc
         rocksjni/ratelimiterjni.cc
         rocksjni/remove_emptyvalue_compactionfilterjni.cc
         rocksjni/restorejni.cc
@@ -69,9 +69,9 @@ set(JNI_NATIVE_SOURCES
         rocksjni/slice.cc
         rocksjni/snapshot.cc
         rocksjni/sst_file_manager.cc
-        rocksjni/sst_file_writerjni.cc
-        rocksjni/sst_file_readerjni.cc
         rocksjni/sst_file_reader_iterator.cc
+        rocksjni/sst_file_readerjni.cc
+        rocksjni/sst_file_writerjni.cc
         rocksjni/sst_partitioner.cc
         rocksjni/statistics.cc
         rocksjni/statisticsjni.cc
@@ -95,10 +95,10 @@ set(JNI_NATIVE_SOURCES
         rocksjni/wal_filter.cc
         rocksjni/wal_filter_jnicallback.cc
         rocksjni/write_batch.cc
-        rocksjni/writebatchhandlerjnicallback.cc
         rocksjni/write_batch_test.cc
         rocksjni/write_batch_with_index.cc
         rocksjni/write_buffer_manager.cc
+        rocksjni/writebatchhandlerjnicallback.cc
 )
 
 set(JAVA_MAIN_CLASSES
@@ -120,8 +120,8 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
   src/main/java/org/rocksdb/AdvancedMutableColumnFamilyOptionsInterface.java
   src/main/java/org/rocksdb/BackgroundErrorReason.java
-  src/main/java/org/rocksdb/BackupEngineOptions.java
   src/main/java/org/rocksdb/BackupEngine.java
+  src/main/java/org/rocksdb/BackupEngineOptions.java
   src/main/java/org/rocksdb/BackupInfo.java
   src/main/java/org/rocksdb/BlockBasedTableConfig.java
   src/main/java/org/rocksdb/BloomFilter.java
@@ -136,8 +136,9 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/ColumnFamilyDescriptor.java
   src/main/java/org/rocksdb/ColumnFamilyHandle.java
   src/main/java/org/rocksdb/ColumnFamilyMetaData.java
-  src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
   src/main/java/org/rocksdb/ColumnFamilyOptions.java
+  src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+  src/main/java/org/rocksdb/CompactRangeOptions.java
   src/main/java/org/rocksdb/CompactionJobInfo.java
   src/main/java/org/rocksdb/CompactionJobStats.java
   src/main/java/org/rocksdb/CompactionOptions.java
@@ -145,17 +146,18 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/CompactionOptionsUniversal.java
   src/main/java/org/rocksdb/CompactionPriority.java
   src/main/java/org/rocksdb/CompactionReason.java
-  src/main/java/org/rocksdb/CompactRangeOptions.java
   src/main/java/org/rocksdb/CompactionStopStyle.java
   src/main/java/org/rocksdb/CompactionStyle.java
   src/main/java/org/rocksdb/ComparatorOptions.java
   src/main/java/org/rocksdb/ComparatorType.java
   src/main/java/org/rocksdb/CompressionOptions.java
   src/main/java/org/rocksdb/CompressionType.java
+  src/main/java/org/rocksdb/ConcurrentTaskLimiter.java
+  src/main/java/org/rocksdb/ConcurrentTaskLimiterImpl.java
   src/main/java/org/rocksdb/ConfigOptions.java
-  src/main/java/org/rocksdb/DataBlockIndexType.java
-  src/main/java/org/rocksdb/DBOptionsInterface.java
   src/main/java/org/rocksdb/DBOptions.java
+  src/main/java/org/rocksdb/DBOptionsInterface.java
+  src/main/java/org/rocksdb/DataBlockIndexType.java
   src/main/java/org/rocksdb/DbPath.java
   src/main/java/org/rocksdb/DirectSlice.java
   src/main/java/org/rocksdb/EncodingType.java
@@ -165,38 +167,36 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/Experimental.java
   src/main/java/org/rocksdb/ExportImportFilesMetaData.java
   src/main/java/org/rocksdb/ExternalFileIngestionInfo.java
+  src/main/java/org/rocksdb/FileOperationInfo.java
   src/main/java/org/rocksdb/Filter.java
   src/main/java/org/rocksdb/FilterPolicyType.java
-  src/main/java/org/rocksdb/FileOperationInfo.java
   src/main/java/org/rocksdb/FlushJobInfo.java
-  src/main/java/org/rocksdb/FlushReason.java
   src/main/java/org/rocksdb/FlushOptions.java
+  src/main/java/org/rocksdb/FlushReason.java
   src/main/java/org/rocksdb/GetStatus.java
   src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
   src/main/java/org/rocksdb/HashSkipListMemTableConfig.java
   src/main/java/org/rocksdb/HistogramData.java
   src/main/java/org/rocksdb/HistogramType.java
   src/main/java/org/rocksdb/Holder.java
-  src/main/java/org/rocksdb/ImportColumnFamilyOptions.java
   src/main/java/org/rocksdb/HyperClockCache.java
+  src/main/java/org/rocksdb/ImportColumnFamilyOptions.java
   src/main/java/org/rocksdb/IndexShorteningMode.java
   src/main/java/org/rocksdb/IndexType.java
   src/main/java/org/rocksdb/InfoLogLevel.java
   src/main/java/org/rocksdb/IngestExternalFileOptions.java
-  src/main/java/org/rocksdb/LevelMetaData.java
-  src/main/java/org/rocksdb/ConcurrentTaskLimiter.java
-  src/main/java/org/rocksdb/ConcurrentTaskLimiterImpl.java
   src/main/java/org/rocksdb/KeyMayExist.java
+  src/main/java/org/rocksdb/LRUCache.java
+  src/main/java/org/rocksdb/LevelMetaData.java
   src/main/java/org/rocksdb/LiveFileMetaData.java
   src/main/java/org/rocksdb/LogFile.java
   src/main/java/org/rocksdb/Logger.java
   src/main/java/org/rocksdb/LoggerInterface.java
   src/main/java/org/rocksdb/LoggerType.java
-  src/main/java/org/rocksdb/LRUCache.java
-  src/main/java/org/rocksdb/MemoryUsageType.java
-  src/main/java/org/rocksdb/MemoryUtil.java
   src/main/java/org/rocksdb/MemTableConfig.java
   src/main/java/org/rocksdb/MemTableInfo.java
+  src/main/java/org/rocksdb/MemoryUsageType.java
+  src/main/java/org/rocksdb/MemoryUtil.java
   src/main/java/org/rocksdb/MergeOperator.java
   src/main/java/org/rocksdb/MutableColumnFamilyOptions.java
   src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
@@ -210,12 +210,12 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/OperationType.java
   src/main/java/org/rocksdb/OptimisticTransactionDB.java
   src/main/java/org/rocksdb/OptimisticTransactionOptions.java
-  src/main/java/org/rocksdb/Options.java
   src/main/java/org/rocksdb/OptionString.java
+  src/main/java/org/rocksdb/Options.java
   src/main/java/org/rocksdb/OptionsUtil.java
-  src/main/java/org/rocksdb/PersistentCache.java
   src/main/java/org/rocksdb/PerfContext.java
   src/main/java/org/rocksdb/PerfLevel.java
+  src/main/java/org/rocksdb/PersistentCache.java
   src/main/java/org/rocksdb/PlainTableConfig.java
   src/main/java/org/rocksdb/PrepopulateBlobCache.java
   src/main/java/org/rocksdb/Priority.java
@@ -228,11 +228,11 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/RestoreOptions.java
   src/main/java/org/rocksdb/ReusedSynchronisationType.java
   src/main/java/org/rocksdb/RocksCallbackObject.java
-  src/main/java/org/rocksdb/RocksDBException.java
   src/main/java/org/rocksdb/RocksDB.java
+  src/main/java/org/rocksdb/RocksDBException.java
   src/main/java/org/rocksdb/RocksEnv.java
-  src/main/java/org/rocksdb/RocksIteratorInterface.java
   src/main/java/org/rocksdb/RocksIterator.java
+  src/main/java/org/rocksdb/RocksIteratorInterface.java
   src/main/java/org/rocksdb/RocksMemEnv.java
   src/main/java/org/rocksdb/RocksMutableObject.java
   src/main/java/org/rocksdb/RocksObject.java
@@ -249,9 +249,9 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/SstPartitionerFactory.java
   src/main/java/org/rocksdb/SstPartitionerFixedPrefixFactory.java
   src/main/java/org/rocksdb/StateType.java
-  src/main/java/org/rocksdb/StatisticsCollectorCallback.java
-  src/main/java/org/rocksdb/StatisticsCollector.java
   src/main/java/org/rocksdb/Statistics.java
+  src/main/java/org/rocksdb/StatisticsCollector.java
+  src/main/java/org/rocksdb/StatisticsCollectorCallback.java
   src/main/java/org/rocksdb/StatsCollectorInput.java
   src/main/java/org/rocksdb/StatsLevel.java
   src/main/java/org/rocksdb/Status.java
@@ -261,35 +261,36 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/TableFileCreationReason.java
   src/main/java/org/rocksdb/TableFileDeletionInfo.java
   src/main/java/org/rocksdb/TableFilter.java
+  src/main/java/org/rocksdb/TableFormatConfig.java
   src/main/java/org/rocksdb/TableProperties.java
   src/main/java/org/rocksdb/TablePropertiesCollectorFactory.java
-  src/main/java/org/rocksdb/TableFormatConfig.java
-  src/main/java/org/rocksdb/ThreadType.java
   src/main/java/org/rocksdb/ThreadStatus.java
+  src/main/java/org/rocksdb/ThreadType.java
   src/main/java/org/rocksdb/TickerType.java
   src/main/java/org/rocksdb/TimedEnv.java
   src/main/java/org/rocksdb/TraceOptions.java
   src/main/java/org/rocksdb/TraceWriter.java
-  src/main/java/org/rocksdb/TransactionalDB.java
-  src/main/java/org/rocksdb/TransactionalOptions.java
+  src/main/java/org/rocksdb/Transaction.java
   src/main/java/org/rocksdb/TransactionDB.java
   src/main/java/org/rocksdb/TransactionDBOptions.java
-  src/main/java/org/rocksdb/Transaction.java
   src/main/java/org/rocksdb/TransactionLogIterator.java
   src/main/java/org/rocksdb/TransactionOptions.java
+  src/main/java/org/rocksdb/TransactionalDB.java
+  src/main/java/org/rocksdb/TransactionalOptions.java
   src/main/java/org/rocksdb/TtlDB.java
   src/main/java/org/rocksdb/TxnDBWritePolicy.java
+  src/main/java/org/rocksdb/UInt64AddOperator.java
   src/main/java/org/rocksdb/VectorMemTableConfig.java
+  src/main/java/org/rocksdb/WALRecoveryMode.java
+  src/main/java/org/rocksdb/WBWIRocksIterator.java
   src/main/java/org/rocksdb/WalFileType.java
   src/main/java/org/rocksdb/WalFilter.java
   src/main/java/org/rocksdb/WalProcessingOption.java
-  src/main/java/org/rocksdb/WALRecoveryMode.java
-  src/main/java/org/rocksdb/WBWIRocksIterator.java
   src/main/java/org/rocksdb/WriteBatch.java
   src/main/java/org/rocksdb/WriteBatchInterface.java
   src/main/java/org/rocksdb/WriteBatchWithIndex.java
-  src/main/java/org/rocksdb/WriteOptions.java
   src/main/java/org/rocksdb/WriteBufferManager.java
+  src/main/java/org/rocksdb/WriteOptions.java
   src/main/java/org/rocksdb/WriteStallCondition.java
   src/main/java/org/rocksdb/WriteStallInfo.java
   src/main/java/org/rocksdb/util/BufferUtil.java
@@ -299,241 +300,240 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/util/IntComparator.java
   src/main/java/org/rocksdb/util/ReverseBytewiseComparator.java
   src/main/java/org/rocksdb/util/SizeUnit.java
-  src/main/java/org/rocksdb/UInt64AddOperator.java
+  src/main/java/org/rocksdb/util/StdErrLogger.java
   src/test/java/org/rocksdb/NativeComparatorWrapperTest.java
   src/test/java/org/rocksdb/RocksDBExceptionTest.java
-  src/test/java/org/rocksdb/test/TestableEventListener.java
-  src/test/java/org/rocksdb/WriteBatchTest.java
   src/test/java/org/rocksdb/RocksNativeLibraryResource.java
+  src/test/java/org/rocksdb/WriteBatchTest.java
+  src/test/java/org/rocksdb/test/TestableEventListener.java
   src/test/java/org/rocksdb/util/CapturingWriteBatchHandler.java
-  src/main/java/org/rocksdb/util/StdErrLogger.java
   src/test/java/org/rocksdb/util/WriteBatchGetter.java
 )
 
 set(JAVA_TEST_CLASSES
-  src/test/java/org/rocksdb/ConcurrentTaskLimiterTest.java
-  src/test/java/org/rocksdb/EventListenerTest.java
-  src/test/java/org/rocksdb/CompactionOptionsTest.java
-  src/test/java/org/rocksdb/PlatformRandomHelper.java
-  src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
-  src/test/java/org/rocksdb/ImportColumnFamilyTest.java
-  src/test/java/org/rocksdb/KeyExistsTest.java
-  src/test/java/org/rocksdb/MergeCFVariantsTest.java
-  src/test/java/org/rocksdb/MergeVariantsTest.java
-  src/test/java/org/rocksdb/PerfContextTest.java
-  src/test/java/org/rocksdb/PerfLevelTest.java
-  src/test/java/org/rocksdb/PutCFVariantsTest.java
-  src/test/java/org/rocksdb/PutVariantsTest.java
-  src/test/java/org/rocksdb/MutableDBOptionsTest.java
-  src/test/java/org/rocksdb/WriteOptionsTest.java
-  src/test/java/org/rocksdb/SstPartitionerTest.java
-  src/test/java/org/rocksdb/RocksMemEnvTest.java
-  src/test/java/org/rocksdb/CompactionOptionsUniversalTest.java
-  src/test/java/org/rocksdb/ClockCacheTest.java
-  src/test/java/org/rocksdb/BytewiseComparatorRegressionTest.java
-  src/test/java/org/rocksdb/SnapshotTest.java
-  src/test/java/org/rocksdb/CompactionJobStatsTest.java
-  src/test/java/org/rocksdb/MemTableTest.java
-  src/test/java/org/rocksdb/CompactionFilterFactoryTest.java
-  src/test/java/org/rocksdb/DefaultEnvTest.java
-  src/test/java/org/rocksdb/DBOptionsTest.java
-  src/test/java/org/rocksdb/RocksIteratorTest.java
-  src/test/java/org/rocksdb/SliceTest.java
-  src/test/java/org/rocksdb/MultiGetTest.java
-  src/test/java/org/rocksdb/ComparatorOptionsTest.java
-  src/test/java/org/rocksdb/NativeLibraryLoaderTest.java
-  src/test/java/org/rocksdb/StatisticsTest.java
-  src/test/java/org/rocksdb/WALRecoveryModeTest.java
-  src/test/java/org/rocksdb/TransactionLogIteratorTest.java
-  src/test/java/org/rocksdb/ReadOptionsTest.java
-  src/test/java/org/rocksdb/SecondaryDBTest.java
-  src/test/java/org/rocksdb/KeyMayExistTest.java
-  src/test/java/org/rocksdb/BlobOptionsTest.java
-  src/test/java/org/rocksdb/InfoLogLevelTest.java
-  src/test/java/org/rocksdb/CompactionPriorityTest.java
-  src/test/java/org/rocksdb/FlushOptionsTest.java
-  src/test/java/org/rocksdb/VerifyChecksumsTest.java
-  src/test/java/org/rocksdb/MultiColumnRegressionTest.java
-  src/test/java/org/rocksdb/FlushTest.java
-  src/test/java/org/rocksdb/HyperClockCacheTest.java
-  src/test/java/org/rocksdb/PutMultiplePartsTest.java
-  src/test/java/org/rocksdb/StatisticsCollectorTest.java
-  src/test/java/org/rocksdb/LRUCacheTest.java
-  src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
-  src/test/java/org/rocksdb/TransactionTest.java
-  src/test/java/org/rocksdb/CompactionOptionsFIFOTest.java
-  src/test/java/org/rocksdb/BackupEngineOptionsTest.java
-  src/test/java/org/rocksdb/CheckPointTest.java
-  src/test/java/org/rocksdb/PlainTableConfigTest.java
-  src/test/java/org/rocksdb/TransactionDBOptionsTest.java
-  src/test/java/org/rocksdb/ReadOnlyTest.java
-  src/test/java/org/rocksdb/EnvOptionsTest.java
-  src/test/java/org/rocksdb/test/RemoveEmptyValueCompactionFilterFactory.java
-  src/test/java/org/rocksdb/test/RemoveEmptyValueCompactionFilterFactory.java
-  src/test/java/org/rocksdb/test/TestableEventListener.java
-  src/test/java/org/rocksdb/test/RemoveEmptyValueCompactionFilterFactory.java
-  src/test/java/org/rocksdb/test/TestableEventListener.java
-  src/test/java/org/rocksdb/test/RocksJunitRunner.java
-  src/test/java/org/rocksdb/LoggerTest.java
-  src/test/java/org/rocksdb/FilterTest.java
-  src/test/java/org/rocksdb/ByteBufferUnsupportedOperationTest.java
-  src/test/java/org/rocksdb/util/IntComparatorTest.java
-  src/test/java/org/rocksdb/util/JNIComparatorTest.java
-  src/test/java/org/rocksdb/util/ByteBufferAllocator.java
-  src/test/java/org/rocksdb/util/SizeUnitTest.java
-  src/test/java/org/rocksdb/util/BytewiseComparatorTest.java
-  src/test/java/org/rocksdb/util/EnvironmentTest.java
-  src/test/java/org/rocksdb/util/BytewiseComparatorIntTest.java
-  src/test/java/org/rocksdb/util/DirectByteBufferAllocator.java
-  src/test/java/org/rocksdb/util/HeapByteBufferAllocator.java
-  src/test/java/org/rocksdb/util/TestUtil.java
-  src/test/java/org/rocksdb/util/ReverseBytewiseComparatorIntTest.java
-  src/test/java/org/rocksdb/Types.java
-  src/test/java/org/rocksdb/MixedOptionsTest.java
-  src/test/java/org/rocksdb/CompactRangeOptionsTest.java
-  src/test/java/org/rocksdb/SstFileWriterTest.java
-  src/test/java/org/rocksdb/WalFilterTest.java
   src/test/java/org/rocksdb/AbstractTransactionTest.java
-  src/test/java/org/rocksdb/MergeTest.java
-  src/test/java/org/rocksdb/OptionsTest.java
-  src/test/java/org/rocksdb/WriteBatchThreadedTest.java
-  src/test/java/org/rocksdb/MultiGetManyKeysTest.java
-  src/test/java/org/rocksdb/TimedEnvTest.java
-  src/test/java/org/rocksdb/CompactionStopStyleTest.java
-  src/test/java/org/rocksdb/CompactionJobInfoTest.java
+  src/test/java/org/rocksdb/BackupEngineOptionsTest.java
+  src/test/java/org/rocksdb/BackupEngineTest.java
+  src/test/java/org/rocksdb/BlobOptionsTest.java
   src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
   src/test/java/org/rocksdb/BuiltinComparatorTest.java
-  src/test/java/org/rocksdb/RateLimiterTest.java
-  src/test/java/org/rocksdb/TransactionOptionsTest.java
-  src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
-  src/test/java/org/rocksdb/WriteBatchHandlerTest.java
-  src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
-  src/test/java/org/rocksdb/OptionsUtilTest.java
-  src/test/java/org/rocksdb/OptimisticTransactionTest.java
-  src/test/java/org/rocksdb/MutableColumnFamilyOptionsTest.java
-  src/test/java/org/rocksdb/CompressionOptionsTest.java
+  src/test/java/org/rocksdb/ByteBufferUnsupportedOperationTest.java
+  src/test/java/org/rocksdb/BytewiseComparatorRegressionTest.java
+  src/test/java/org/rocksdb/CheckPointTest.java
+  src/test/java/org/rocksdb/ClockCacheTest.java
+  src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
   src/test/java/org/rocksdb/ColumnFamilyTest.java
-  src/test/java/org/rocksdb/SstFileReaderTest.java
-  src/test/java/org/rocksdb/TransactionDBTest.java
-  src/test/java/org/rocksdb/RocksDBTest.java
-  src/test/java/org/rocksdb/MutableOptionsGetSetTest.java
-  src/test/java/org/rocksdb/OptimisticTransactionOptionsTest.java
-  src/test/java/org/rocksdb/SstFileManagerTest.java
-  src/test/java/org/rocksdb/BackupEngineTest.java
-  src/test/java/org/rocksdb/DirectSliceTest.java
-  src/test/java/org/rocksdb/StatsCallbackMock.java
+  src/test/java/org/rocksdb/CompactRangeOptionsTest.java
+  src/test/java/org/rocksdb/CompactionFilterFactoryTest.java
+  src/test/java/org/rocksdb/CompactionJobInfoTest.java
+  src/test/java/org/rocksdb/CompactionJobStatsTest.java
+  src/test/java/org/rocksdb/CompactionOptionsFIFOTest.java
+  src/test/java/org/rocksdb/CompactionOptionsTest.java
+  src/test/java/org/rocksdb/CompactionOptionsUniversalTest.java
+  src/test/java/org/rocksdb/CompactionPriorityTest.java
+  src/test/java/org/rocksdb/CompactionStopStyleTest.java
+  src/test/java/org/rocksdb/ComparatorOptionsTest.java
+  src/test/java/org/rocksdb/CompressionOptionsTest.java
   src/test/java/org/rocksdb/CompressionTypesTest.java
+  src/test/java/org/rocksdb/ConcurrentTaskLimiterTest.java
+  src/test/java/org/rocksdb/DBOptionsTest.java
+  src/test/java/org/rocksdb/DefaultEnvTest.java
+  src/test/java/org/rocksdb/DirectSliceTest.java
+  src/test/java/org/rocksdb/EnvOptionsTest.java
+  src/test/java/org/rocksdb/EventListenerTest.java
+  src/test/java/org/rocksdb/FilterTest.java
+  src/test/java/org/rocksdb/FlushOptionsTest.java
+  src/test/java/org/rocksdb/FlushTest.java
+  src/test/java/org/rocksdb/HyperClockCacheTest.java
+  src/test/java/org/rocksdb/ImportColumnFamilyTest.java
+  src/test/java/org/rocksdb/InfoLogLevelTest.java
+  src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
+  src/test/java/org/rocksdb/KeyExistsTest.java
+  src/test/java/org/rocksdb/KeyMayExistTest.java
+  src/test/java/org/rocksdb/LRUCacheTest.java
+  src/test/java/org/rocksdb/LoggerTest.java
+  src/test/java/org/rocksdb/MemTableTest.java
   src/test/java/org/rocksdb/MemoryUtilTest.java
+  src/test/java/org/rocksdb/MergeCFVariantsTest.java
+  src/test/java/org/rocksdb/MergeTest.java
+  src/test/java/org/rocksdb/MergeVariantsTest.java
+  src/test/java/org/rocksdb/MixedOptionsTest.java
+  src/test/java/org/rocksdb/MultiColumnRegressionTest.java
+  src/test/java/org/rocksdb/MultiGetManyKeysTest.java
+  src/test/java/org/rocksdb/MultiGetTest.java
+  src/test/java/org/rocksdb/MutableColumnFamilyOptionsTest.java
+  src/test/java/org/rocksdb/MutableDBOptionsTest.java
+  src/test/java/org/rocksdb/MutableOptionsGetSetTest.java
+  src/test/java/org/rocksdb/NativeLibraryLoaderTest.java
+  src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
+  src/test/java/org/rocksdb/OptimisticTransactionOptionsTest.java
+  src/test/java/org/rocksdb/OptimisticTransactionTest.java
+  src/test/java/org/rocksdb/OptionsTest.java
+  src/test/java/org/rocksdb/OptionsUtilTest.java
+  src/test/java/org/rocksdb/PerfContextTest.java
+  src/test/java/org/rocksdb/PerfLevelTest.java
+  src/test/java/org/rocksdb/PlainTableConfigTest.java
+  src/test/java/org/rocksdb/PlatformRandomHelper.java
+  src/test/java/org/rocksdb/PutCFVariantsTest.java
+  src/test/java/org/rocksdb/PutMultiplePartsTest.java
+  src/test/java/org/rocksdb/PutVariantsTest.java
+  src/test/java/org/rocksdb/RateLimiterTest.java
+  src/test/java/org/rocksdb/ReadOnlyTest.java
+  src/test/java/org/rocksdb/ReadOptionsTest.java
+  src/test/java/org/rocksdb/RocksDBTest.java
+  src/test/java/org/rocksdb/RocksIteratorTest.java
+  src/test/java/org/rocksdb/RocksMemEnvTest.java
+  src/test/java/org/rocksdb/SecondaryDBTest.java
+  src/test/java/org/rocksdb/SliceTest.java
+  src/test/java/org/rocksdb/SnapshotTest.java
+  src/test/java/org/rocksdb/SstFileManagerTest.java
+  src/test/java/org/rocksdb/SstFileReaderTest.java
+  src/test/java/org/rocksdb/SstFileWriterTest.java
+  src/test/java/org/rocksdb/SstPartitionerTest.java
+  src/test/java/org/rocksdb/StatisticsCollectorTest.java
+  src/test/java/org/rocksdb/StatisticsTest.java
+  src/test/java/org/rocksdb/StatsCallbackMock.java
   src/test/java/org/rocksdb/TableFilterTest.java
+  src/test/java/org/rocksdb/TimedEnvTest.java
+  src/test/java/org/rocksdb/TransactionDBOptionsTest.java
+  src/test/java/org/rocksdb/TransactionDBTest.java
+  src/test/java/org/rocksdb/TransactionLogIteratorTest.java
+  src/test/java/org/rocksdb/TransactionOptionsTest.java
+  src/test/java/org/rocksdb/TransactionTest.java
   src/test/java/org/rocksdb/TtlDBTest.java
+  src/test/java/org/rocksdb/Types.java
+  src/test/java/org/rocksdb/VerifyChecksumsTest.java
+  src/test/java/org/rocksdb/WALRecoveryModeTest.java
+  src/test/java/org/rocksdb/WalFilterTest.java
+  src/test/java/org/rocksdb/WriteBatchHandlerTest.java
+  src/test/java/org/rocksdb/WriteBatchThreadedTest.java
+  src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
+  src/test/java/org/rocksdb/WriteOptionsTest.java
+  src/test/java/org/rocksdb/test/RemoveEmptyValueCompactionFilterFactory.java
+  src/test/java/org/rocksdb/test/RemoveEmptyValueCompactionFilterFactory.java
+  src/test/java/org/rocksdb/test/RemoveEmptyValueCompactionFilterFactory.java
+  src/test/java/org/rocksdb/test/RocksJunitRunner.java
+  src/test/java/org/rocksdb/test/TestableEventListener.java
+  src/test/java/org/rocksdb/test/TestableEventListener.java
+  src/test/java/org/rocksdb/util/ByteBufferAllocator.java
+  src/test/java/org/rocksdb/util/BytewiseComparatorIntTest.java
+  src/test/java/org/rocksdb/util/BytewiseComparatorTest.java
+  src/test/java/org/rocksdb/util/DirectByteBufferAllocator.java
+  src/test/java/org/rocksdb/util/EnvironmentTest.java
+  src/test/java/org/rocksdb/util/HeapByteBufferAllocator.java
+  src/test/java/org/rocksdb/util/IntComparatorTest.java
+  src/test/java/org/rocksdb/util/JNIComparatorTest.java
+  src/test/java/org/rocksdb/util/ReverseBytewiseComparatorIntTest.java
+  src/test/java/org/rocksdb/util/SizeUnitTest.java
   src/test/java/org/rocksdb/util/StdErrLoggerTest.java
+  src/test/java/org/rocksdb/util/TestUtil.java
 )
 
 set(JAVA_TEST_RUNNING_CLASSES
-  org.rocksdb.ConcurrentTaskLimiterTest
-  org.rocksdb.EventListenerTest
-  org.rocksdb.CompactionOptionsTest
-  org.rocksdb.IngestExternalFileOptionsTest
-  org.rocksdb.ImportColumnFamilyTest
-  org.rocksdb.MutableDBOptionsTest
-  org.rocksdb.WriteOptionsTest
-  org.rocksdb.SstPartitionerTest
-  org.rocksdb.RocksMemEnvTest
-  org.rocksdb.CompactionOptionsUniversalTest
-  org.rocksdb.ClockCacheTest
-  org.rocksdb.BytewiseComparatorRegressionTest
-  org.rocksdb.SnapshotTest
-  org.rocksdb.CompactionJobStatsTest
-  org.rocksdb.MemTableTest
-  org.rocksdb.CompactionFilterFactoryTest
-  org.rocksdb.DefaultEnvTest
-  org.rocksdb.DBOptionsTest
-  org.rocksdb.WriteBatchTest
-  org.rocksdb.RocksIteratorTest
-  org.rocksdb.SliceTest
-  org.rocksdb.MultiGetTest
-  org.rocksdb.ComparatorOptionsTest
-  org.rocksdb.NativeLibraryLoaderTest
-  org.rocksdb.StatisticsTest
-  org.rocksdb.WALRecoveryModeTest
-  org.rocksdb.TransactionLogIteratorTest
-  org.rocksdb.ReadOptionsTest
-  org.rocksdb.SecondaryDBTest
-  org.rocksdb.KeyMayExistTest
-  org.rocksdb.KeyExistsTest
-  org.rocksdb.MergeCFVariantsTest
-  org.rocksdb.MergeVariantsTest
-  org.rocksdb.NativeComparatorWrapperTest
-  org.rocksdb.PerfContextTest
-  org.rocksdb.PerfLevelTest
-  org.rocksdb.PutCFVariantsTest
-  org.rocksdb.PutVariantsTest
-  org.rocksdb.RocksDBExceptionTest
-  org.rocksdb.BlobOptionsTest
-  org.rocksdb.InfoLogLevelTest
-  org.rocksdb.CompactionPriorityTest
-  org.rocksdb.FlushOptionsTest
-  org.rocksdb.VerifyChecksumsTest
-  org.rocksdb.MultiColumnRegressionTest
-  org.rocksdb.FlushTest
-  org.rocksdb.HyperClockCacheTest
-  org.rocksdb.PutMultiplePartsTest
-  org.rocksdb.StatisticsCollectorTest
-  org.rocksdb.LRUCacheTest
-  org.rocksdb.ColumnFamilyOptionsTest
-  org.rocksdb.TransactionTest
-  org.rocksdb.CompactionOptionsFIFOTest
   org.rocksdb.BackupEngineOptionsTest
-  org.rocksdb.CheckPointTest
-  org.rocksdb.PlainTableConfigTest
-  org.rocksdb.TransactionDBOptionsTest
-  org.rocksdb.ReadOnlyTest
-  org.rocksdb.EnvOptionsTest
-  org.rocksdb.LoggerTest
-  org.rocksdb.FilterTest
-  org.rocksdb.ByteBufferUnsupportedOperationTest
-  org.rocksdb.util.IntComparatorTest
-  org.rocksdb.util.JNIComparatorTest
-  org.rocksdb.util.SizeUnitTest
-  org.rocksdb.util.BytewiseComparatorTest
-  org.rocksdb.util.EnvironmentTest
-  org.rocksdb.util.BytewiseComparatorIntTest
-  org.rocksdb.util.ReverseBytewiseComparatorIntTest
-  org.rocksdb.MixedOptionsTest
-  org.rocksdb.CompactRangeOptionsTest
-  org.rocksdb.SstFileWriterTest
-  org.rocksdb.WalFilterTest
-  org.rocksdb.MergeTest
-  org.rocksdb.OptionsTest
-  org.rocksdb.WriteBatchThreadedTest
-  org.rocksdb.MultiGetManyKeysTest
-  org.rocksdb.TimedEnvTest
-  org.rocksdb.CompactionStopStyleTest
-  org.rocksdb.CompactionJobInfoTest
+  org.rocksdb.BackupEngineTest
+  org.rocksdb.BlobOptionsTest
   org.rocksdb.BlockBasedTableConfigTest
   org.rocksdb.BuiltinComparatorTest
-  org.rocksdb.RateLimiterTest
-  org.rocksdb.TransactionOptionsTest
-  org.rocksdb.WriteBatchWithIndexTest
-  org.rocksdb.WriteBatchHandlerTest
-  org.rocksdb.OptimisticTransactionDBTest
-  org.rocksdb.OptionsUtilTest
-  org.rocksdb.OptimisticTransactionTest
-  org.rocksdb.MutableColumnFamilyOptionsTest
-  org.rocksdb.CompressionOptionsTest
+  org.rocksdb.ByteBufferUnsupportedOperationTest
+  org.rocksdb.BytewiseComparatorRegressionTest
+  org.rocksdb.CheckPointTest
+  org.rocksdb.ClockCacheTest
+  org.rocksdb.ColumnFamilyOptionsTest
   org.rocksdb.ColumnFamilyTest
-  org.rocksdb.SstFileReaderTest
-  org.rocksdb.TransactionDBTest
-  org.rocksdb.RocksDBTest
-  org.rocksdb.MutableOptionsGetSetTest
-  org.rocksdb.OptimisticTransactionOptionsTest
-  org.rocksdb.SstFileManagerTest
-  org.rocksdb.BackupEngineTest
-  org.rocksdb.DirectSliceTest
+  org.rocksdb.CompactRangeOptionsTest
+  org.rocksdb.CompactionFilterFactoryTest
+  org.rocksdb.CompactionJobInfoTest
+  org.rocksdb.CompactionJobStatsTest
+  org.rocksdb.CompactionOptionsFIFOTest
+  org.rocksdb.CompactionOptionsTest
+  org.rocksdb.CompactionOptionsUniversalTest
+  org.rocksdb.CompactionPriorityTest
+  org.rocksdb.CompactionStopStyleTest
+  org.rocksdb.ComparatorOptionsTest
+  org.rocksdb.CompressionOptionsTest
   org.rocksdb.CompressionTypesTest
+  org.rocksdb.ConcurrentTaskLimiterTest
+  org.rocksdb.DBOptionsTest
+  org.rocksdb.DefaultEnvTest
+  org.rocksdb.DirectSliceTest
+  org.rocksdb.EnvOptionsTest
+  org.rocksdb.EventListenerTest
+  org.rocksdb.FilterTest
+  org.rocksdb.FlushOptionsTest
+  org.rocksdb.FlushTest
+  org.rocksdb.HyperClockCacheTest
+  org.rocksdb.ImportColumnFamilyTest
+  org.rocksdb.InfoLogLevelTest
+  org.rocksdb.IngestExternalFileOptionsTest
+  org.rocksdb.KeyExistsTest
+  org.rocksdb.KeyMayExistTest
+  org.rocksdb.LRUCacheTest
+  org.rocksdb.LoggerTest
+  org.rocksdb.MemTableTest
   org.rocksdb.MemoryUtilTest
+  org.rocksdb.MergeCFVariantsTest
+  org.rocksdb.MergeTest
+  org.rocksdb.MergeVariantsTest
+  org.rocksdb.MixedOptionsTest
+  org.rocksdb.MultiColumnRegressionTest
+  org.rocksdb.MultiGetManyKeysTest
+  org.rocksdb.MultiGetTest
+  org.rocksdb.MutableColumnFamilyOptionsTest
+  org.rocksdb.MutableDBOptionsTest
+  org.rocksdb.MutableOptionsGetSetTest
+  org.rocksdb.NativeComparatorWrapperTest
+  org.rocksdb.NativeLibraryLoaderTest
+  org.rocksdb.OptimisticTransactionDBTest
+  org.rocksdb.OptimisticTransactionOptionsTest
+  org.rocksdb.OptimisticTransactionTest
+  org.rocksdb.OptionsTest
+  org.rocksdb.OptionsUtilTest
+  org.rocksdb.PerfContextTest
+  org.rocksdb.PerfLevelTest
+  org.rocksdb.PlainTableConfigTest
+  org.rocksdb.PutCFVariantsTest
+  org.rocksdb.PutMultiplePartsTest
+  org.rocksdb.PutVariantsTest
+  org.rocksdb.RateLimiterTest
+  org.rocksdb.ReadOnlyTest
+  org.rocksdb.ReadOptionsTest
+  org.rocksdb.RocksDBExceptionTest
+  org.rocksdb.RocksDBTest
+  org.rocksdb.RocksIteratorTest
+  org.rocksdb.RocksMemEnvTest
+  org.rocksdb.SecondaryDBTest
+  org.rocksdb.SliceTest
+  org.rocksdb.SnapshotTest
+  org.rocksdb.SstFileManagerTest
+  org.rocksdb.SstFileReaderTest
+  org.rocksdb.SstFileWriterTest
+  org.rocksdb.SstPartitionerTest
+  org.rocksdb.StatisticsCollectorTest
+  org.rocksdb.StatisticsTest
   org.rocksdb.TableFilterTest
+  org.rocksdb.TimedEnvTest
+  org.rocksdb.TransactionDBOptionsTest
+  org.rocksdb.TransactionDBTest
+  org.rocksdb.TransactionLogIteratorTest
+  org.rocksdb.TransactionOptionsTest
+  org.rocksdb.TransactionTest
   org.rocksdb.TtlDBTest
+  org.rocksdb.VerifyChecksumsTest
+  org.rocksdb.WALRecoveryModeTest
+  org.rocksdb.WalFilterTest
+  org.rocksdb.WriteBatchHandlerTest
+  org.rocksdb.WriteBatchTest
+  org.rocksdb.WriteBatchThreadedTest
+  org.rocksdb.WriteBatchWithIndexTest
+  org.rocksdb.WriteOptionsTest
+  org.rocksdb.util.BytewiseComparatorIntTest
+  org.rocksdb.util.BytewiseComparatorTest
+  org.rocksdb.util.EnvironmentTest
+  org.rocksdb.util.IntComparatorTest
+  org.rocksdb.util.JNIComparatorTest
+  org.rocksdb.util.ReverseBytewiseComparatorIntTest
+  org.rocksdb.util.SizeUnitTest
   org.rocksdb.util.StdErrLoggerTest
 )
 

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -105,6 +105,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/AbstractCompactionFilter.java
   src/main/java/org/rocksdb/AbstractCompactionFilterFactory.java
   src/main/java/org/rocksdb/AbstractComparator.java
+  src/main/java/org/rocksdb/AbstractComparatorJniBridge.java
   src/main/java/org/rocksdb/AbstractEventListener.java
   src/main/java/org/rocksdb/AbstractImmutableNativeReference.java
   src/main/java/org/rocksdb/AbstractMutableOptions.java
@@ -315,6 +316,14 @@ set(JAVA_TEST_CLASSES
   src/test/java/org/rocksdb/CompactionOptionsTest.java
   src/test/java/org/rocksdb/PlatformRandomHelper.java
   src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
+  src/test/java/org/rocksdb/ImportColumnFamilyTest.java
+  src/test/java/org/rocksdb/KeyExistsTest.java
+  src/test/java/org/rocksdb/MergeCFVariantsTest.java
+  src/test/java/org/rocksdb/MergeVariantsTest.java
+  src/test/java/org/rocksdb/PerfContextTest.java
+  src/test/java/org/rocksdb/PerfLevelTest.java
+  src/test/java/org/rocksdb/PutCFVariantsTest.java
+  src/test/java/org/rocksdb/PutVariantsTest.java
   src/test/java/org/rocksdb/MutableDBOptionsTest.java
   src/test/java/org/rocksdb/WriteOptionsTest.java
   src/test/java/org/rocksdb/SstPartitionerTest.java
@@ -425,31 +434,41 @@ set(JAVA_TEST_RUNNING_CLASSES
   org.rocksdb.EventListenerTest
   org.rocksdb.CompactionOptionsTest
   org.rocksdb.IngestExternalFileOptionsTest
+  org.rocksdb.ImportColumnFamilyTest
   org.rocksdb.MutableDBOptionsTest
   org.rocksdb.WriteOptionsTest
   org.rocksdb.SstPartitionerTest
   org.rocksdb.RocksMemEnvTest
   org.rocksdb.CompactionOptionsUniversalTest
   org.rocksdb.ClockCacheTest
-  # org.rocksdb.BytewiseComparatorRegressionTest
+  org.rocksdb.BytewiseComparatorRegressionTest
   org.rocksdb.SnapshotTest
   org.rocksdb.CompactionJobStatsTest
   org.rocksdb.MemTableTest
   org.rocksdb.CompactionFilterFactoryTest
-  # org.rocksdb.DefaultEnvTest
+  org.rocksdb.DefaultEnvTest
   org.rocksdb.DBOptionsTest
   org.rocksdb.WriteBatchTest
   org.rocksdb.RocksIteratorTest
   org.rocksdb.SliceTest
   org.rocksdb.MultiGetTest
   org.rocksdb.ComparatorOptionsTest
-  # org.rocksdb.NativeLibraryLoaderTest
+  org.rocksdb.NativeLibraryLoaderTest
   org.rocksdb.StatisticsTest
   org.rocksdb.WALRecoveryModeTest
   org.rocksdb.TransactionLogIteratorTest
   org.rocksdb.ReadOptionsTest
   org.rocksdb.SecondaryDBTest
   org.rocksdb.KeyMayExistTest
+  org.rocksdb.KeyExistsTest
+  org.rocksdb.MergeCFVariantsTest
+  org.rocksdb.MergeVariantsTest
+  org.rocksdb.NativeComparatorWrapperTest
+  org.rocksdb.PerfContextTest
+  org.rocksdb.PerfLevelTest
+  org.rocksdb.PutCFVariantsTest
+  org.rocksdb.PutVariantsTest
+  org.rocksdb.RocksDBExceptionTest
   org.rocksdb.BlobOptionsTest
   org.rocksdb.InfoLogLevelTest
   org.rocksdb.CompactionPriorityTest
@@ -467,24 +486,23 @@ set(JAVA_TEST_RUNNING_CLASSES
   org.rocksdb.BackupEngineOptionsTest
   org.rocksdb.CheckPointTest
   org.rocksdb.PlainTableConfigTest
-  # org.rocksdb.TransactionDBOptionsTest
+  org.rocksdb.TransactionDBOptionsTest
   org.rocksdb.ReadOnlyTest
   org.rocksdb.EnvOptionsTest
   org.rocksdb.LoggerTest
   org.rocksdb.FilterTest
-  # org.rocksdb.ByteBufferUnsupportedOperationTest
-  # org.rocksdb.util.IntComparatorTest
-  # org.rocksdb.util.JNIComparatorTest
+  org.rocksdb.ByteBufferUnsupportedOperationTest
+  org.rocksdb.util.IntComparatorTest
+  org.rocksdb.util.JNIComparatorTest
   org.rocksdb.util.SizeUnitTest
-  # org.rocksdb.util.BytewiseComparatorTest
+  org.rocksdb.util.BytewiseComparatorTest
   org.rocksdb.util.EnvironmentTest
-  # org.rocksdb.util.BytewiseComparatorIntTest
-  # org.rocksdb.util.ReverseBytewiseComparatorIntTest
+  org.rocksdb.util.BytewiseComparatorIntTest
+  org.rocksdb.util.ReverseBytewiseComparatorIntTest
   org.rocksdb.MixedOptionsTest
   org.rocksdb.CompactRangeOptionsTest
-  # org.rocksdb.SstFileWriterTest
+  org.rocksdb.SstFileWriterTest
   org.rocksdb.WalFilterTest
-  # org.rocksdb.AbstractTransactionTest
   org.rocksdb.MergeTest
   org.rocksdb.OptionsTest
   org.rocksdb.WriteBatchThreadedTest
@@ -495,7 +513,7 @@ set(JAVA_TEST_RUNNING_CLASSES
   org.rocksdb.BlockBasedTableConfigTest
   org.rocksdb.BuiltinComparatorTest
   org.rocksdb.RateLimiterTest
-  # org.rocksdb.TransactionOptionsTest
+  org.rocksdb.TransactionOptionsTest
   org.rocksdb.WriteBatchWithIndexTest
   org.rocksdb.WriteBatchHandlerTest
   org.rocksdb.OptimisticTransactionDBTest
@@ -508,7 +526,7 @@ set(JAVA_TEST_RUNNING_CLASSES
   org.rocksdb.TransactionDBTest
   org.rocksdb.RocksDBTest
   org.rocksdb.MutableOptionsGetSetTest
-  # org.rocksdb.OptimisticTransactionOptionsTest
+  org.rocksdb.OptimisticTransactionOptionsTest
   org.rocksdb.SstFileManagerTest
   org.rocksdb.BackupEngineTest
   org.rocksdb.DirectSliceTest

--- a/java/src/test/java/org/rocksdb/DefaultEnvTest.java
+++ b/java/src/test/java/org/rocksdb/DefaultEnvTest.java
@@ -5,16 +5,15 @@
 
 package org.rocksdb;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class DefaultEnvTest {
 
@@ -91,7 +90,8 @@ public class DefaultEnvTest {
   public void threadList() throws RocksDBException {
     // We need to open DB first to get at least one thread in thread list.
     try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath())) {
-      db.put("test-key".getBytes(StandardCharsets.UTF_8), "test-value".getBytes(StandardCharsets.UTF_8));
+      db.put("test-key".getBytes(StandardCharsets.UTF_8),
+          "test-value".getBytes(StandardCharsets.UTF_8));
       try (final Env defaultEnv = RocksEnv.getDefault()) {
         final Collection<ThreadStatus> threadList = defaultEnv.getThreadList();
         assertThat(threadList.size()).isGreaterThan(0);

--- a/java/src/test/java/org/rocksdb/DefaultEnvTest.java
+++ b/java/src/test/java/org/rocksdb/DefaultEnvTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 
@@ -88,9 +89,13 @@ public class DefaultEnvTest {
 
   @Test
   public void threadList() throws RocksDBException {
-    try (final Env defaultEnv = RocksEnv.getDefault()) {
-      final Collection<ThreadStatus> threadList = defaultEnv.getThreadList();
-      assertThat(threadList.size()).isGreaterThan(0);
+    // We need to open DB first to get at least one thread in thread list.
+    try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath())) {
+      db.put("test-key".getBytes(StandardCharsets.UTF_8), "test-value".getBytes(StandardCharsets.UTF_8));
+      try (final Env defaultEnv = RocksEnv.getDefault()) {
+        final Collection<ThreadStatus> threadList = defaultEnv.getThreadList();
+        assertThat(threadList.size()).isGreaterThan(0);
+      }
     }
   }
 

--- a/java/src/test/java/org/rocksdb/OptimisticTransactionOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptimisticTransactionOptionsTest.java
@@ -5,6 +5,7 @@
 
 package org.rocksdb;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.rocksdb.util.BytewiseComparator;
 
@@ -16,6 +17,11 @@ public class OptimisticTransactionOptionsTest {
 
   private static final Random rand = PlatformRandomHelper.
       getPlatformSpecificRandomFactory();
+
+  @BeforeClass
+  public static void  beforeAll() {
+    RocksDB.loadLibrary();
+  }
 
   @Test
   public void setSnapshot() {

--- a/java/src/test/java/org/rocksdb/OptimisticTransactionOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptimisticTransactionOptionsTest.java
@@ -5,13 +5,12 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Random;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.rocksdb.util.BytewiseComparator;
-
-import java.util.Random;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptimisticTransactionOptionsTest {
 
@@ -19,7 +18,7 @@ public class OptimisticTransactionOptionsTest {
       getPlatformSpecificRandomFactory();
 
   @BeforeClass
-  public static void  beforeAll() {
+  public static void beforeAll() {
     RocksDB.loadLibrary();
   }
 

--- a/java/src/test/java/org/rocksdb/RocksDBExceptionTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBExceptionTest.java
@@ -5,18 +5,17 @@
 
 package org.rocksdb;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import org.rocksdb.Status.Code;
-import org.rocksdb.Status.SubCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-public class RocksDBExceptionTest {
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.rocksdb.Status.Code;
+import org.rocksdb.Status.SubCode;
 
+public class RocksDBExceptionTest {
   @BeforeClass
-  public static void  beforeAll() {
+  public static void beforeAll() {
     RocksDB.loadLibrary();
   }
 

--- a/java/src/test/java/org/rocksdb/RocksDBExceptionTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBExceptionTest.java
@@ -5,6 +5,7 @@
 
 package org.rocksdb;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.rocksdb.Status.Code;
@@ -13,6 +14,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public class RocksDBExceptionTest {
+
+  @BeforeClass
+  public static void  beforeAll() {
+    RocksDB.loadLibrary();
+  }
 
   @Test
   public void exception() {

--- a/java/src/test/java/org/rocksdb/TransactionDBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionDBOptionsTest.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Random;
@@ -12,6 +14,11 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TransactionDBOptionsTest {
+
+  @BeforeClass
+  public static void  beforeAll() {
+    RocksDB.loadLibrary();
+  }
 
   private static final Random rand = PlatformRandomHelper.
       getPlatformSpecificRandomFactory();

--- a/java/src/test/java/org/rocksdb/TransactionDBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionDBOptionsTest.java
@@ -5,18 +5,16 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Random;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Random;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class TransactionDBOptionsTest {
-
   @BeforeClass
-  public static void  beforeAll() {
+  public static void beforeAll() {
     RocksDB.loadLibrary();
   }
 

--- a/java/src/test/java/org/rocksdb/TransactionOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionOptionsTest.java
@@ -5,6 +5,7 @@
 
 package org.rocksdb;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Random;
@@ -13,6 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TransactionOptionsTest {
 
+  @BeforeClass
+  public static void  beforeAll() {
+    RocksDB.loadLibrary();
+  }
   private static final Random rand = PlatformRandomHelper.
       getPlatformSpecificRandomFactory();
 

--- a/java/src/test/java/org/rocksdb/TransactionOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionOptionsTest.java
@@ -5,17 +5,15 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Random;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Random;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class TransactionOptionsTest {
-
   @BeforeClass
-  public static void  beforeAll() {
+  public static void beforeAll() {
     RocksDB.loadLibrary();
   }
   private static final Random rand = PlatformRandomHelper.


### PR DESCRIPTION
This PR follows the work done in  #11756 and enable all Java test to be run via CMake/Ctest.