### PR TITLE
Follow ups for TimedPut and write time property

### DIFF
--- a/db/builder.h
+++ b/db/builder.h
@@ -64,7 +64,7 @@ Status BuildTable(
     bool paranoid_file_checks, InternalStats* internal_stats,
     IOStatus* io_status, const std::shared_ptr<IOTracer>& io_tracer,
     BlobFileCreationReason blob_creation_reason,
-    const SeqnoToTimeMapping& seqno_to_time_mapping,
+    UnownedPtr<const SeqnoToTimeMapping> seqno_to_time_mapping,
     EventLogger* event_logger = nullptr, int job_id = 0,
     TableProperties* table_properties = nullptr,
     Env::WriteLifeTimeHint write_hint = Env::WLTH_NOT_SET,

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -244,7 +244,7 @@ struct SuperVersion {
   // Share the ownership of the seqno to time mapping object referred to in this
   // SuperVersion. To be used by the new SuperVersion to be installed after this
   // one if seqno to time mapping does not change in between these two
-  // SuperVersions.
+  // SuperVersions. Or to share the ownership of the mapping with a FlushJob.
   std::shared_ptr<const SeqnoToTimeMapping> ShareSeqnoToTimeMapping() {
     return seqno_to_time_mapping;
   }

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -270,8 +270,8 @@ Status DBImpl::FlushMemTableToOutputFile(
       GetCompressionFlush(*cfd->ioptions(), mutable_cf_options), stats_,
       &event_logger_, mutable_cf_options.report_bg_io_stats,
       true /* sync_output_directory */, true /* write_manifest */, thread_pri,
-      io_tracer_, seqno_to_time_mapping_, db_id_, db_session_id_,
-      cfd->GetFullHistoryTsLow(), &blob_callback_);
+      io_tracer_, cfd->GetSuperVersion()->ShareSeqnoToTimeMapping(), db_id_,
+      db_session_id_, cfd->GetFullHistoryTsLow(), &blob_callback_);
   FileMetaData file_meta;
 
   Status s;
@@ -545,8 +545,9 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
         GetCompressionFlush(*cfd->ioptions(), mutable_cf_options), stats_,
         &event_logger_, mutable_cf_options.report_bg_io_stats,
         false /* sync_output_directory */, false /* write_manifest */,
-        thread_pri, io_tracer_, seqno_to_time_mapping_, db_id_, db_session_id_,
-        cfd->GetFullHistoryTsLow(), &blob_callback_));
+        thread_pri, io_tracer_,
+        cfd->GetSuperVersion()->ShareSeqnoToTimeMapping(), db_id_,
+        db_session_id_, cfd->GetFullHistoryTsLow(), &blob_callback_));
   }
 
   std::vector<FileMetaData> file_meta(num_cfs);

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1684,7 +1684,6 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
           TableFileCreationReason::kRecovery, 0 /* oldest_key_time */,
           0 /* file_creation_time */, db_id_, db_session_id_,
           0 /* target_file_size */, meta.fd.GetNumber());
-      SeqnoToTimeMapping empty_seqno_to_time_mapping;
       Version* version = cfd->current();
       version->Ref();
       uint64_t num_input_entries = 0;
@@ -1695,7 +1694,7 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
           snapshot_seqs, earliest_write_conflict_snapshot, kMaxSequenceNumber,
           snapshot_checker, paranoid_file_checks, cfd->internal_stats(), &io_s,
           io_tracer_, BlobFileCreationReason::kRecovery,
-          empty_seqno_to_time_mapping, &event_logger_, job_id,
+          nullptr /* seqno_to_time_mapping */, &event_logger_, job_id,
           nullptr /* table_properties */, write_hint,
           nullptr /*full_history_ts_low*/, &blob_callback_, version,
           &num_input_entries);

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -368,10 +368,10 @@ class DBIter final : public Iterator {
   // overhead of calling construction of the function if creating it each time.
   ParsedInternalKey ikey_;
 
-  // TODO(yuzhangyu): update this documentation for kTypeValuePreferredSeqno
-  // types.
   // The approximate write time for the entry. It is deduced from the entry's
-  // sequence number if the seqno to time mapping is available.
+  // sequence number if the seqno to time mapping is available. For a
+  // kTypeValuePreferredSeqno entry, this is the write time specified by the
+  // user.
   uint64_t saved_write_unix_time_;
   std::string saved_value_;
   Slice pinned_value_;

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -759,6 +759,11 @@ Status DBTestBase::Put(int cf, const Slice& k, const Slice& v,
   }
 }
 
+Status DBTestBase::TimedPut(const Slice& k, const Slice& v,
+                            uint64_t write_unix_time, WriteOptions wo) {
+  return TimedPut(0, k, v, write_unix_time, wo);
+}
+
 Status DBTestBase::TimedPut(int cf, const Slice& k, const Slice& v,
                             uint64_t write_unix_time, WriteOptions wo) {
   WriteBatch wb;

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -1176,6 +1176,9 @@ class DBTestBase : public testing::Test {
   Status Put(int cf, const Slice& k, const Slice& v,
              WriteOptions wo = WriteOptions());
 
+  Status TimedPut(const Slice& k, const Slice& v, uint64_t write_unix_time,
+                  WriteOptions wo = WriteOptions());
+
   Status TimedPut(int cf, const Slice& k, const Slice& v,
                   uint64_t write_unix_time, WriteOptions wo = WriteOptions());
 

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -374,13 +374,6 @@ inline ValueType ExtractValueType(const Slice& internal_key) {
   return static_cast<ValueType>(c);
 }
 
-// input [internal key]: <user_provided_key | ts | seqno + type>
-// output:                                        <seqno>
-inline SequenceNumber ExtractSequenceNumber(const Slice& internal_key) {
-  uint64_t num = ExtractInternalKeyFooter(internal_key);
-  return num >> 8;
-}
-
 // A comparator for internal keys that uses a specified comparator for
 // the user key portion and breaks ties by decreasing sequence number.
 class InternalKeyComparator

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -73,7 +73,7 @@ class FlushJob {
            EventLogger* event_logger, bool measure_io_stats,
            const bool sync_output_directory, const bool write_manifest,
            Env::Priority thread_pri, const std::shared_ptr<IOTracer>& io_tracer,
-           const SeqnoToTimeMapping& seq_time_mapping,
+           std::shared_ptr<const SeqnoToTimeMapping> seqno_to_time_mapping,
            const std::string& db_id = "", const std::string& db_session_id = "",
            std::string full_history_ts_low = "",
            BlobFileCompletionCallback* blob_callback = nullptr);
@@ -210,10 +210,14 @@ class FlushJob {
   const std::string full_history_ts_low_;
   BlobFileCompletionCallback* blob_callback_;
 
-  // reference to the seqno_to_time_mapping_ in db_impl.h, not safe to read
-  // without db mutex
-  const SeqnoToTimeMapping& db_impl_seqno_to_time_mapping_;
-  SeqnoToTimeMapping seqno_to_time_mapping_;
+  // Shared copy of DB's seqno to time mapping stored in SuperVersion. The
+  // ownership is shared with this FlushJob when it's created.
+  // FlushJob accesses and ref counts immutable MemTables directly via
+  // `MemTableListVersion` instead of ref `SuperVersion`, so we need to give
+  // the flush job shared ownership of the mapping.
+  // Note this is only installed when seqno to time recording feature is
+  // enables, so it could be nullptr.
+  std::shared_ptr<const SeqnoToTimeMapping> seqno_to_time_mapping_;
 
   // Keeps track of the newest user-defined timestamp for this flush job if
   // `persist_user_defined_timestamps` flag is false.

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -169,7 +169,7 @@ class FlushJobTestBase : public testing::Test {
   bool persist_udt_ = true;
   bool paranoid_file_checks_ = false;
 
-  SeqnoToTimeMapping empty_seqno_to_time_mapping_;
+  std::shared_ptr<SeqnoToTimeMapping> empty_seqno_to_time_mapping_;
 };
 
 class FlushJobTest : public FlushJobTestBase {
@@ -627,13 +627,14 @@ TEST_F(FlushJobTest, ReplaceTimedPutWriteTimeWithPreferredSeqno) {
   auto new_mem = cfd->ConstructNewMemtable(*cfd->GetLatestMutableCFOptions(),
                                            kMaxSequenceNumber);
   new_mem->Ref();
-  SeqnoToTimeMapping seqno_to_time_mapping;
+  std::shared_ptr<SeqnoToTimeMapping> seqno_to_time_mapping =
+      std::make_shared<SeqnoToTimeMapping>();
   // Seqno: 10,       11, ... 20,
   // Time:  ...  500      ...      600
   // GetProximalSeqnoBeforeTime(500) -> 10
   // GetProximalSeqnoBeforeTime(600) -> 20
-  seqno_to_time_mapping.Append(10, 500);
-  seqno_to_time_mapping.Append(20, 600);
+  seqno_to_time_mapping->Append(10, 500);
+  seqno_to_time_mapping->Append(20, 600);
 
   ASSERT_OK(new_mem->Add(SequenceNumber(15), kTypeValuePreferredSeqno, "bar",
                          ValueWithWriteTime("bval", 500),

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -484,7 +484,7 @@ class Repairer {
           {}, kMaxSequenceNumber, kMaxSequenceNumber, snapshot_checker,
           false /* paranoid_file_checks*/, nullptr /* internal_stats */, &io_s,
           nullptr /*IOTracer*/, BlobFileCreationReason::kRecovery,
-          empty_seqno_to_time_mapping, nullptr /* event_logger */,
+          nullptr /* seqno_to_time_mapping */, nullptr /* event_logger */,
           0 /* job_id */, nullptr /* table_properties */, write_hint);
       ROCKS_LOG_INFO(db_options_.info_log,
                      "Log #%" PRIu64 ": %d ops saved to Table #%" PRIu64 " %s",

--- a/db/seqno_to_time_mapping.h
+++ b/db/seqno_to_time_mapping.h
@@ -277,9 +277,15 @@ Slice PackValueAndWriteTime(const Slice& value, uint64_t unix_write_time,
 Slice PackValueAndSeqno(const Slice& value, SequenceNumber seqno,
                         std::string* buf);
 
+// Parse a packed value to get the write time.
+uint64_t ParsePackedValueForWriteTime(const Slice& value);
+
 // Parse a packed value to get the value and the write time. The unpacked value
 // Slice is backed up by the same memory backing up `value`.
 std::tuple<Slice, uint64_t> ParsePackedValueWithWriteTime(const Slice& value);
+
+// Parse a packed value to get the sequence number.
+SequenceNumber ParsePackedValueForSeqno(const Slice& value);
 
 // Parse a packed value to get the value and the sequence number. The unpacked
 // value Slice is backed up by the same memory backing up `value`.

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -871,6 +871,9 @@ Status WriteBatchInternal::TimedPut(WriteBatch* b, uint32_t column_family_id,
   if (value.size() > size_t{std::numeric_limits<uint32_t>::max()}) {
     return Status::InvalidArgument("value is too large");
   }
+  if (std::numeric_limits<uint64_t>::max() == write_unix_time) {
+    return WriteBatchInternal::Put(b, column_family_id, key, value);
+  }
   LocalSavePoint save(b);
 
   WriteBatchInternal::SetCount(b, WriteBatchInternal::Count(b) + 1);

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -406,12 +406,19 @@ TEST_F(WriteBatchTest, PutNotImplemented) {
 TEST_F(WriteBatchTest, TimedPutNotImplemented) {
   WriteBatch batch;
   ASSERT_OK(
-      batch.TimedPut(0, Slice("k1"), Slice("v1"), /*unix_write_time=*/30));
+      batch.TimedPut(0, Slice("k1"), Slice("v1"), /*write_unix_time=*/30));
   ASSERT_EQ(1u, batch.Count());
   ASSERT_EQ("TimedPut(k1, v1, 30)@0", PrintContents(&batch));
 
   WriteBatch::Handler handler;
   ASSERT_TRUE(batch.Iterate(&handler).IsInvalidArgument());
+
+  batch.Clear();
+  ASSERT_OK(
+      batch.TimedPut(0, Slice("k1"), Slice("v1"),
+                     /*write_unix_time=*/std::numeric_limits<uint64_t>::max()));
+  ASSERT_EQ(1u, batch.Count());
+  ASSERT_EQ("Put(k1, v1)@0", PrintContents(&batch));
 }
 
 TEST_F(WriteBatchTest, DeleteNotImplemented) {

--- a/unreleased_history/new_features/write_time_and_timed_put.md
+++ b/unreleased_history/new_features/write_time_and_timed_put.md
@@ -1,0 +1,1 @@
+*Implement API `Iterator::GetProperty("rocksdb.iterator.write-time")` to allow users to get data's approximate write unix time and write data with a specific write time via `WriteBatch::TimedPut` API.

--- a/unreleased_history/new_features/write_time_and_timed_put.md
+++ b/unreleased_history/new_features/write_time_and_timed_put.md
@@ -1,1 +1,1 @@
-*Implement API `Iterator::GetProperty("rocksdb.iterator.write-time")` to allow users to get data's approximate write unix time and write data with a specific write time via `WriteBatch::TimedPut` API.
+*Implement experimental features: API `Iterator::GetProperty("rocksdb.iterator.write-time")` to allow users to get data's approximate write unix time and write data with a specific write time via `WriteBatch::TimedPut` API.


### PR DESCRIPTION
This PR contains a few follow ups from #12419 and #12428 including:

1) Handle a special case for `WriteBatch::TimedPut`. When the user specified write time is `std::numeric_limits<uint64_t>::max()`, it's not treated as an error, but it instead creates and writes a regular `Put` entry. 

2) Update the `InternalIterator::write_unix_time` APIs to handle `kTypeValuePreferredSeqno` entries.

3) FlushJob is updated to use the seqno to time mapping copy in `SuperVersion`. FlushJob currently copy the DB's seqno to time mapping while holding db mutex and only copies the part of interest, a.k.a, the part that only goes back to the earliest sequence number of the to-be-flushed memtables. While updating FlushJob to use the mapping copy in `SuperVersion`, it's given access to the full mapping to help cover the need to convert `kTypeValuePreferredSeqno`'s write time to preferred seqno as much as possible.

Test plans:
Added unit tests