### PR TITLE
Fix crash test where DB diverge from expected state

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -2085,6 +2085,11 @@ class NonBatchedOpsStressTest : public StressTest {
     }
     const ExpectedValue expected_value = shared->Get(cf, key);
 
+    // When expected state has pending writes/deletes. We use db state as source
+    // of truth to sync it with expected state during VerifyDB (after initDB,
+    // before any DB operation). These keys should be exempt from compaction
+    // filter because compaction filter use expected state as source of truth to
+    // operate on the DB.
     if (expected_value.PendingWrite() || expected_value.PendingDelete()) {
       if (s.ok()) {
         // Value exists in db, update state to reflect that


### PR DESCRIPTION
As titled, we saw some crash test failures where DB state diverged from expected state. There are some common symptoms of these crash test failures: 1) the key does not exist in DB, 2) `enable_compaction_filter=1` is toggled on for some test runs.  This could be a test infra bug caused by below scenario:

1) In the compaction filter, we use expected state as source of truth, and could be dropping entries that expected state says does not exist.

2) During `VerifyDB`, there is a procedure to sync expected state with DB's state, there,  DB state is used as source of truth.  This happens when a value has pending writes or pending delete.

Logically we cannot have both happening at the same time, one of the state, either DB's state or the expected state should act as source of truth exclusively during time of ambiguity. So in this PR, we disable handling of a key in compaction filter if expected state for it is not finalized yet.

A concrete example of how this could result in the error could be a chain of events like this:
1) First DB Open:
Put("1", "key") => writes to expected state and db
Delete("1") => mark a pending delete in expected state, db is killed, delete not written to db.

2) DB reopen:
  step 1) A compaction filter is created for all files running in the background, checking for key "1" in expected state, it says it doesn't exists according to this logic:
https://github.com/facebook/rocksdb/blob/b4e9f5a400545d2cf2434cf75013bf5d490f4fff/db_stress_tool/expected_value.h#L40
And make a decision to drop it.

   step 2) During `VerifyDB`, expected state is updated to say the key exists because a read from DB has it:
https://github.com/facebook/rocksdb/blob/b4e9f5a400545d2cf2434cf75013bf5d490f4fff/db_stress_tool/no_batched_ops_stress.cc#L2088

    After the compaction in step 1) finishes, it will install a new SuperVersion where the key "1" doesn't exist anymore, while 
    expected state has it. 

3) During next DB open, this discrepancy will be reported.

Test Plan:
