### PR TITLE
Remove LogReaderContainer's status

### DIFF
--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -17,18 +17,15 @@ namespace ROCKSDB_NAMESPACE {
 // A wrapper class to hold log reader, log reporter, log status.
 class LogReaderContainer {
  public:
-  LogReaderContainer()
-      : reader_(nullptr), reporter_(nullptr), status_(nullptr) {}
+  LogReaderContainer() : reader_(nullptr), reporter_(nullptr) {}
   LogReaderContainer(Env* env, std::shared_ptr<Logger> info_log,
                      std::string fname,
                      std::unique_ptr<SequentialFileReader>&& file_reader,
                      uint64_t log_number) {
     LogReporter* reporter = new LogReporter();
-    status_ = new Status();
     reporter->env = env;
     reporter->info_log = info_log.get();
     reporter->fname = std::move(fname);
-    reporter->status = status_;
     reporter_ = reporter;
     // We intentially make log::Reader do checksumming even if
     // paranoid_checks==false so that corruptions cause entire commits
@@ -40,11 +37,9 @@ class LogReaderContainer {
   }
   log::FragmentBufferedReader* reader_;
   log::Reader::Reporter* reporter_;
-  Status* status_;
   ~LogReaderContainer() {
     delete reader_;
     delete reporter_;
-    delete status_;
   }
 
  private:


### PR DESCRIPTION
# Summary

LogReader is there to replay WAL to recover log files for Secondary DB. `LogReaderContainer` is a wrapper class that contains buffer reader, reporter and the status.

While investigating not-checked-status failure in https://github.com/facebook/rocksdb/actions/runs/8334988399/job/22809612148, I found that `status_` in `LogReaderContainer` is never set or being checked properly. Just removing it in this PR.

# Test Plan

existing tests