### PR TITLE
New PerfContext counters for block cache bytes read

### DIFF
--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -83,6 +83,11 @@ struct PerfContextBase {
   uint64_t filter_block_read_count;       // total number of filter block reads
   uint64_t compression_dict_block_read_count;  // total number of compression
                                                // dictionary block reads
+  // Cumulative size of blocks found in block cache
+  uint64_t block_cache_index_read_byte;
+  uint64_t block_cache_filter_read_byte;
+  uint64_t block_cache_compression_dict_read_byte;
+  uint64_t block_cache_read_byte;
 
   uint64_t secondary_cache_hit_count;  // total number of secondary cache hits
   // total number of real handles inserted into secondary cache

--- a/java/rocksjni/jni_perf_context.cc
+++ b/java/rocksjni/jni_perf_context.cc
@@ -172,8 +172,8 @@ jlong Java_org_rocksdb_PerfContext_getBlockReadCpuTime(JNIEnv*, jobject,
  * Method:    getBlockCacheIndexReadByte
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_PerfContext_getBlockCacheIndexReadByte(JNIEnv*, jobject,
-                                                    jlong jpc_handle) {
+jlong Java_org_rocksdb_PerfContext_getBlockCacheIndexReadByte(
+    JNIEnv*, jobject, jlong jpc_handle) {
   ROCKSDB_NAMESPACE::PerfContext* perf_context =
       reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
   return perf_context->block_cache_index_read_byte;
@@ -184,8 +184,8 @@ jlong Java_org_rocksdb_PerfContext_getBlockCacheIndexReadByte(JNIEnv*, jobject,
  * Method:    getBlockCacheFilterReadByte
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_PerfContext_getBlockCacheFilterReadByte(JNIEnv*, jobject,
-                                                    jlong jpc_handle) {
+jlong Java_org_rocksdb_PerfContext_getBlockCacheFilterReadByte(
+    JNIEnv*, jobject, jlong jpc_handle) {
   ROCKSDB_NAMESPACE::PerfContext* perf_context =
       reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
   return perf_context->block_cache_filter_read_byte;
@@ -209,7 +209,7 @@ jlong Java_org_rocksdb_PerfContext_getBlockCacheCompressionDictReadByte(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_PerfContext_getBlockCacheReadByte(JNIEnv*, jobject,
-                                                    jlong jpc_handle) {
+                                                         jlong jpc_handle) {
   ROCKSDB_NAMESPACE::PerfContext* perf_context =
       reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
   return perf_context->block_cache_read_byte;

--- a/java/rocksjni/jni_perf_context.cc
+++ b/java/rocksjni/jni_perf_context.cc
@@ -169,6 +169,54 @@ jlong Java_org_rocksdb_PerfContext_getBlockReadCpuTime(JNIEnv*, jobject,
 
 /*
  * Class:     org_rocksdb_PerfContext
+ * Method:    getBlockCacheIndexReadByte
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_PerfContext_getBlockCacheIndexReadByte(JNIEnv*, jobject,
+                                                    jlong jpc_handle) {
+  ROCKSDB_NAMESPACE::PerfContext* perf_context =
+      reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
+  return perf_context->block_cache_index_read_byte;
+}
+
+/*
+ * Class:     org_rocksdb_PerfContext
+ * Method:    getBlockCacheFilterReadByte
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_PerfContext_getBlockCacheFilterReadByte(JNIEnv*, jobject,
+                                                    jlong jpc_handle) {
+  ROCKSDB_NAMESPACE::PerfContext* perf_context =
+      reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
+  return perf_context->block_cache_filter_read_byte;
+}
+
+/*
+ * Class:     org_rocksdb_PerfContext
+ * Method:    getBlockCacheCompressionDictReadByte
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_PerfContext_getBlockCacheCompressionDictReadByte(
+    JNIEnv*, jobject, jlong jpc_handle) {
+  ROCKSDB_NAMESPACE::PerfContext* perf_context =
+      reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
+  return perf_context->block_cache_compression_dict_read_byte;
+}
+
+/*
+ * Class:     org_rocksdb_PerfContext
+ * Method:    getBlockCacheReadByte
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_PerfContext_getBlockCacheReadByte(JNIEnv*, jobject,
+                                                    jlong jpc_handle) {
+  ROCKSDB_NAMESPACE::PerfContext* perf_context =
+      reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
+  return perf_context->block_cache_read_byte;
+}
+
+/*
+ * Class:     org_rocksdb_PerfContext
  * Method:    getSecondaryCacheHitCount
  * Signature: (J)J
  */

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -62,6 +62,10 @@ struct PerfContextByLevelInt {
   defCmd(block_cache_filter_hit_count)             \
   defCmd(filter_block_read_count)                  \
   defCmd(compression_dict_block_read_count)        \
+  defCmd(block_cache_index_read_byte)              \
+  defCmd(block_cache_filter_read_byte)             \
+  defCmd(block_cache_compression_dict_read_byte)   \
+  defCmd(block_cache_read_byte)                    \
   defCmd(secondary_cache_hit_count)                \
   defCmd(compressed_sec_cache_insert_real_count)   \
   defCmd(compressed_sec_cache_insert_dummy_count)  \

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -217,6 +217,7 @@ void BlockBasedTable::UpdateCacheHitMetrics(BlockType block_type,
   Statistics* const statistics = rep_->ioptions.stats;
 
   PERF_COUNTER_ADD(block_cache_hit_count, 1);
+  PERF_COUNTER_ADD(block_cache_read_byte, usage);
   PERF_COUNTER_BY_LEVEL_ADD(block_cache_hit_count, 1,
                             static_cast<uint32_t>(rep_->level));
 
@@ -232,6 +233,7 @@ void BlockBasedTable::UpdateCacheHitMetrics(BlockType block_type,
     case BlockType::kFilter:
     case BlockType::kFilterPartitionIndex:
       PERF_COUNTER_ADD(block_cache_filter_hit_count, 1);
+      PERF_COUNTER_ADD(block_cache_filter_read_byte, usage);
 
       if (get_context) {
         ++get_context->get_context_stats_.num_cache_filter_hit;
@@ -242,6 +244,7 @@ void BlockBasedTable::UpdateCacheHitMetrics(BlockType block_type,
 
     case BlockType::kCompressionDictionary:
       // TODO: introduce perf counter for compression dictionary hit count
+      PERF_COUNTER_ADD(block_cache_compression_dict_read_byte, usage);
       if (get_context) {
         ++get_context->get_context_stats_.num_cache_compression_dict_hit;
       } else {
@@ -251,6 +254,7 @@ void BlockBasedTable::UpdateCacheHitMetrics(BlockType block_type,
 
     case BlockType::kIndex:
       PERF_COUNTER_ADD(block_cache_index_hit_count, 1);
+      PERF_COUNTER_ADD(block_cache_index_read_byte, usage);
 
       if (get_context) {
         ++get_context->get_context_stats_.num_cache_index_hit;

--- a/unreleased_history/public_api_changes/new_block_cache_perf_counters.md
+++ b/unreleased_history/public_api_changes/new_block_cache_perf_counters.md
@@ -1,0 +1,1 @@
+Added new PerfContext counters for block cache bytes read - block_cache_index_read_byte, block_cache_filter_read_byte, block_cache_compression_dict_read_byte, and block_cache_read_byte.


### PR DESCRIPTION
Add PerfContext counters for measuring the cumulative size of blocks found in the block cache.