### PR TITLE
wal_read_status check in RecoverLogFiles

### DIFF
--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -327,6 +327,7 @@ Status DBImplSecondary::RecoverLogFiles(
       status = *wal_read_status;
     }
     if (!status.ok()) {
+      wal_read_status->PermitUncheckedError();
       return status;
     }
   }


### PR DESCRIPTION
# Summary

Fixing the not-checked status failure as in https://github.com/facebook/rocksdb/actions/runs/8334988399/job/22809612148. 

When the status is not ok() for any reason, we do not check the `wal_read_status` because it's not necessary. It's causing the test failure when running with `ASSERT_STATUS_CHECKED=1` 

# Test Plan

Existing tests