### PR TITLE
Remove extra semi colon from hbt/src/tagstack/tests/SlicerTest.cpp

### DIFF
--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -484,7 +484,7 @@ void VersionEdit::EncodeFileBoundaries(std::string* dst,
   StripTimestampFromInternalKey(&largest_buf, meta.largest.Encode(), ts_sz);
   PutLengthPrefixedSlice(dst, smallest_buf);
   PutLengthPrefixedSlice(dst, largest_buf);
-};
+}
 
 Status VersionEdit::DecodeFrom(const Slice& src) {
   Clear();


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: rahku

Differential Revision: D55087324


