### PR TITLE
Add GetLiveFilesStorageInfo to legacy BlobDB

### DIFF
--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -162,6 +162,9 @@ class BlobDBImpl : public BlobDB {
   Status GetLiveFiles(std::vector<std::string>&, uint64_t* manifest_file_size,
                       bool flush_memtable = true) override;
   void GetLiveFilesMetaData(std::vector<LiveFileMetaData>*) override;
+  Status GetLiveFilesStorageInfo(
+      const LiveFilesStorageInfoOptions& opts,
+      std::vector<LiveFileStorageInfo>* files) override;
 
   ~BlobDBImpl();
 

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -107,11 +107,6 @@ void BlobDBImpl::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
 Status BlobDBImpl::GetLiveFilesStorageInfo(
     const LiveFilesStorageInfoOptions& opts,
     std::vector<LiveFileStorageInfo>* files) {
-  if (!bdb_options_.path_relative) {
-    return Status::NotSupported(
-        "Not able to get relative blob file path from absolute blob_dir.");
-  }
-
   ReadLock rl(&mutex_);
   Status s = db_->GetLiveFilesStorageInfo(opts, files);
   if (s.ok()) {
@@ -119,7 +114,7 @@ Status BlobDBImpl::GetLiveFilesStorageInfo(
     for (const auto& [blob_number, blob_file] : blob_files_) {
       LiveFileStorageInfo file;
       file.size = blob_file->GetFileSize();
-      file.directory = bdb_options_.blob_dir;
+      file.directory = blob_dir_;
       file.relative_filename = BlobFileName(blob_number);
       file.file_type = kBlobFile;
       file.trim_to_size = true;

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -104,4 +104,28 @@ void BlobDBImpl::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
   }
 }
 
+Status BlobDBImpl::GetLiveFilesStorageInfo(
+    const LiveFilesStorageInfoOptions& opts,
+    std::vector<LiveFileStorageInfo>* files) {
+  if (!bdb_options_.path_relative) {
+    return Status::NotSupported(
+        "Not able to get relative blob file path from absolute blob_dir.");
+  }
+
+  ReadLock rl(&mutex_);
+  Status s = db_->GetLiveFilesStorageInfo(opts, files);
+  if (s.ok()) {
+    files->reserve(files->size() + blob_files_.size());
+    for (const auto& [blob_number, blob_file] : blob_files_) {
+      LiveFileStorageInfo file;
+      file.size = blob_file->GetFileSize();
+      file.directory = bdb_options_.blob_dir;
+      file.relative_filename = BlobFileName(blob_number);
+      file.file_type = kBlobFile;
+      files->push_back(std::move(file));
+    }
+  }
+  return s;
+}
+
 }  // namespace ROCKSDB_NAMESPACE::blob_db

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -122,6 +122,7 @@ Status BlobDBImpl::GetLiveFilesStorageInfo(
       file.directory = bdb_options_.blob_dir;
       file.relative_filename = BlobFileName(blob_number);
       file.file_type = kBlobFile;
+      file.trim_to_size = true;
       files->push_back(std::move(file));
     }
   }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1013,6 +1013,26 @@ TEST_F(BlobDBTest, GetLiveFilesMetaData) {
   ASSERT_EQ(5U, livefile.size());
   ASSERT_EQ(filename1, livefile[3]);
   ASSERT_EQ(filename2, livefile[4]);
+
+  std::vector<LiveFileStorageInfo> all_files, blob_files;
+  ASSERT_OK(blob_db_->GetLiveFilesStorageInfo(LiveFilesStorageInfoOptions(),
+                                              &all_files));
+  for (size_t i = 0; i < all_files.size(); i++) {
+    if (all_files[i].file_type == kBlobFile) {
+      blob_files.push_back(all_files[i]);
+    }
+  }
+
+  ASSERT_EQ(2U, blob_files.size());
+
+  ASSERT_EQ("000001.blob", blob_files[0].relative_filename);
+  ASSERT_EQ("blob_dir", blob_files[0].directory);
+  ASSERT_GT(blob_files[0].size, 0);
+
+  ASSERT_EQ("000002.blob", blob_files[1].relative_filename);
+  ASSERT_EQ("blob_dir", blob_files[1].directory);
+  ASSERT_GT(blob_files[1].size, 0);
+
   VerifyDB(data);
 }
 

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1024,6 +1024,7 @@ TEST_F(BlobDBTest, GetLiveFilesMetaData) {
   }
 
   ASSERT_EQ(2U, blob_files.size());
+  ASSERT_GT(all_files.size(), blob_files.size());
 
   ASSERT_EQ("000001.blob", blob_files[0].relative_filename);
   ASSERT_EQ("blob_dir", blob_files[0].directory);

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1027,11 +1027,11 @@ TEST_F(BlobDBTest, GetLiveFilesMetaData) {
   ASSERT_GT(all_files.size(), blob_files.size());
 
   ASSERT_EQ("000001.blob", blob_files[0].relative_filename);
-  ASSERT_EQ("blob_dir", blob_files[0].directory);
+  ASSERT_EQ(blob_db_impl()->TEST_blob_dir(), blob_files[0].directory);
   ASSERT_GT(blob_files[0].size, 0);
 
   ASSERT_EQ("000002.blob", blob_files[1].relative_filename);
-  ASSERT_EQ("blob_dir", blob_files[1].directory);
+  ASSERT_EQ(blob_db_impl()->TEST_blob_dir(), blob_files[1].directory);
   ASSERT_GT(blob_files[1].size, 0);
 
   VerifyDB(data);


### PR DESCRIPTION
It is an important function and should be correct on legacy BlobDB, even though using legacy BlobDB is not recommended