### PR TITLE
Implement `PerfContex#toString` for the Java API

### DIFF
--- a/java/rocksjni/jni_perf_context.cc
+++ b/java/rocksjni/jni_perf_context.cc
@@ -6,6 +6,7 @@
 #include <jni.h>
 
 #include "include/org_rocksdb_PerfContext.h"
+#include "portal.h"
 #include "rocksdb/db.h"
 #include "rocksdb/perf_context.h"
 
@@ -1240,6 +1241,8 @@ jstring Java_org_rocksdb_PerfContext_toString(JNIEnv* env, jobject,
                                               jboolean exclude_zero_counters) {
   ROCKSDB_NAMESPACE::PerfContext* perf_context =
       reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
-  return env->NewStringUTF(
-      perf_context->ToString(exclude_zero_counters).c_str());
+
+  auto result = perf_context->ToString(exclude_zero_counters);
+
+  return ROCKSDB_NAMESPACE::JniUtil::toJavaString(env, &result, false);
 }

--- a/java/rocksjni/jni_perf_context.cc
+++ b/java/rocksjni/jni_perf_context.cc
@@ -1234,3 +1234,12 @@ jlong Java_org_rocksdb_PerfContext_getNumberAsyncSeek(JNIEnv*, jobject,
       reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
   return perf_context->number_async_seek;
 }
+
+jstring Java_org_rocksdb_PerfContext_toString(JNIEnv* env, jobject,
+                                              jlong jpc_handle,
+                                              jboolean exclude_zero_counters) {
+  ROCKSDB_NAMESPACE::PerfContext* perf_context =
+      reinterpret_cast<ROCKSDB_NAMESPACE::PerfContext*>(jpc_handle);
+  return env->NewStringUTF(
+      perf_context->ToString(exclude_zero_counters).c_str());
+}

--- a/java/src/main/java/org/rocksdb/PerfContext.java
+++ b/java/src/main/java/org/rocksdb/PerfContext.java
@@ -651,6 +651,10 @@ public class PerfContext extends RocksObject {
     return getNumberAsyncSeek(nativeHandle_);
   }
 
+  public String toString(final boolean excludeZeroCounters) {
+    return toString(nativeHandle_, excludeZeroCounters);
+  }
+
   @Override
   protected void disposeInternal(long handle) {
     // Nothing to do. Perf context is valid for all the time of application is running.
@@ -758,4 +762,6 @@ public class PerfContext extends RocksObject {
   private native long getEncryptDataNanos(long nativeHandle_);
   private native long getDecryptDataNanos(long nativeHandle_);
   private native long getNumberAsyncSeek(long nativeHandle_);
+
+  private native String toString(long nativeHandle_, final boolean excludeZeroCounters);
 }

--- a/java/src/main/java/org/rocksdb/PerfContext.java
+++ b/java/src/main/java/org/rocksdb/PerfContext.java
@@ -651,6 +651,11 @@ public class PerfContext extends RocksObject {
     return getNumberAsyncSeek(nativeHandle_);
   }
 
+  @Override
+  public String toString() {
+    return toString(true);
+  }
+
   public String toString(final boolean excludeZeroCounters) {
     return toString(nativeHandle_, excludeZeroCounters);
   }
@@ -763,5 +768,5 @@ public class PerfContext extends RocksObject {
   private native long getDecryptDataNanos(long nativeHandle_);
   private native long getNumberAsyncSeek(long nativeHandle_);
 
-  private native String toString(long nativeHandle_, final boolean excludeZeroCounters);
+  private native String toString(final long nativeHandle, final boolean excludeZeroCounters);
 }

--- a/java/src/test/java/org/rocksdb/PerfContextTest.java
+++ b/java/src/test/java/org/rocksdb/PerfContextTest.java
@@ -111,6 +111,17 @@ public class PerfContextTest {
     db.get("key".getBytes());
     PerfContext ctx = db.getPerfContext();
     assertThat(ctx).isNotNull();
-    assertThat(ctx.toString(true)).isNotEmpty();
+    assertThat(ctx.toString(false)).isNotEmpty();
+  }
+
+  @Test
+  public void testDefaultToString() throws RocksDBException {
+    db.setPerfLevel(PerfLevel.ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX);
+    db.put("key".getBytes(), "value".getBytes());
+    db.compactRange();
+    db.get("key".getBytes());
+    PerfContext ctx = db.getPerfContext();
+    assertThat(ctx).isNotNull();
+    assertThat(ctx.toString()).isNotEmpty();
   }
 }

--- a/java/src/test/java/org/rocksdb/PerfContextTest.java
+++ b/java/src/test/java/org/rocksdb/PerfContextTest.java
@@ -102,4 +102,15 @@ public class PerfContextTest {
     assertThat(ctx).isNotNull();
     assertThat(ctx.getPostProcessTime()).isGreaterThan(0);
   }
+
+  @Test
+  public void testToString() throws RocksDBException {
+    db.setPerfLevel(PerfLevel.ENABLE_TIME_AND_CPU_TIME_EXCEPT_FOR_MUTEX);
+    db.put("key".getBytes(), "value".getBytes());
+    db.compactRange();
+    db.get("key".getBytes());
+    PerfContext ctx = db.getPerfContext();
+    assertThat(ctx).isNotNull();
+    assertThat(ctx.toString(true)).isNotEmpty();
+  }
 }


### PR DESCRIPTION
I've implemented `PerfContext#toString` for the Java API.
See: https://groups.google.com/g/rocksdb/c/qbY_gNhbyAg