### PR TITLE
Initialize `FaultInjectionTestFS::checksum_handoff_func_type_` to `kCRC32c`

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -262,7 +262,7 @@ default_params = {
     "use_adaptive_mutex_lru": lambda: random.choice([0, 1]),
     "compress_format_version": lambda: random.choice([1, 2]),
     "manifest_preallocation_size": lambda: random.choice([0, 5 * 1024]),
-    "enable_checksum_handoff": 0,
+    "enable_checksum_handoff": lambda: random.choice([0, 1]),
     "max_total_wal_size": lambda: random.choice([0] * 4 + [64 * 1024 * 1024]),
     "high_pri_pool_ratio": lambda: random.choice([0, 0.5]),
     "low_pri_pool_ratio": lambda: random.choice([0, 0.5]),

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -210,6 +210,7 @@ class FaultInjectionTestFS : public FileSystemWrapper {
         metadata_write_error_one_in_(0),
         read_error_one_in_(0),
         ingest_data_corruption_before_write_(false),
+        checksum_handoff_func_type_(kCRC32c),
         fail_get_file_unique_id_(false) {}
   virtual ~FaultInjectionTestFS() { error_.PermitUncheckedError(); }
 
@@ -368,12 +369,12 @@ class FaultInjectionTestFS : public FileSystemWrapper {
 
   void SetChecksumHandoffFuncType(const ChecksumType& func_type) {
     MutexLock l(&mutex_);
-    checksum_handoff_func_tpye_ = func_type;
+    checksum_handoff_func_type_ = func_type;
   }
 
   const ChecksumType& GetChecksumHandoffFuncType() {
     MutexLock l(&mutex_);
-    return checksum_handoff_func_tpye_;
+    return checksum_handoff_func_type_;
   }
 
   void SetFailGetUniqueId(bool flag) {
@@ -581,7 +582,7 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   // File types where direct writable is skipped.
   std::set<FileType> direct_writable_types_;
   bool ingest_data_corruption_before_write_;
-  ChecksumType checksum_handoff_func_tpye_;
+  ChecksumType checksum_handoff_func_type_;
   bool fail_get_file_unique_id_;
 
   // Extract number of type from file name. Return false if failing to fine


### PR DESCRIPTION
Previously it was uninitialized. Setting `checksum_handoff_file_types` will cause `kCRC32c` checksums to be passed down in the `DataVerificationInfo`, so it makes sense for `kCRC32c` to be the default.

Test Plan:

ran `db_stress` in a way that failed before. Building with ASAN was needed to ensure the uninitialized bytes are nonzero according to `malloc_fill_byte` (default 0xbe)

```
$ COMPILE_WITH_ASAN=1 make -j28 db_stress
...
$ ./db_stress -sync_fault_injection=1 -enable_checksum_handoff=true
```