### PR TITLE
Remove missing checksum types from stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -56,7 +56,7 @@ default_params = {
     if random.randint(0, 1) == 0
     else random.choice(["none", "snappy", "zlib", "lz4", "lz4hc", "xpress", "zstd"]),
     "checksum_type": lambda: random.choice(
-        ["kCRC32c", "kxxHash", "kxxHash64", "kXXH3"]
+        ["kCRC32c", "kxxHash"]
     ),
     "compression_max_dict_bytes": lambda: 16384 * random.randint(0, 1),
     "compression_zstd_max_train_bytes": lambda: 65536 * random.randint(0, 1),


### PR DESCRIPTION
# Summary

Not all checksum types are supported by `CalculateTypedChecksum()` in `FaultInjectionFs` and some checksums may not be returned. https://github.com/facebook/rocksdb/blame/3d4e78937af634165a131bf36d8c19bb3cf51840/utilities/fault_injection_fs.cc?fbclid=IwAR24LsuvGm53lazvC-MPTg1otgkDBkcxBc0E6ddJl5-4q_jyXKlWSl6Rgus#L65-L77.

However, we included them in our stress test
https://github.com/facebook/rocksdb/blame/3d4e78937af634165a131bf36d8c19bb3cf51840/tools/db_crashtest.py?fbclid=IwAR2Trc69dMiMBj_Ifqi2-kmrWQWP6YwVazGa9S96DugOtS90TpOWADunLV8#L58-L59.

Thanks @jowlyzhang for finding the cause of the failure. 

# Test Plan

WIP