### PR TITLE
Temporarily disable `wal_bytes_per_sync` in crash test

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1053,6 +1053,9 @@ struct DBOptions {
   uint64_t bytes_per_sync = 0;
 
   // Same as bytes_per_sync, but applies to WAL files
+  // This does not gaurantee the WALs are synced in the order of creation. New
+  // WAL can be synced while an older WAL doesn't. Therefore upon system crash,
+  // this hole in the WAL data can create partial data loss.
   //
   // Default: 0, turned off
   //

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -161,7 +161,9 @@ default_params = {
     # Sync mode might make test runs slower so running it in a smaller chance
     "sync": lambda: random.choice([1 if t == 0 else 0 for t in range(0, 20)]),
     "bytes_per_sync": lambda: random.choice([0, 262144]),
-    "wal_bytes_per_sync": lambda: random.choice([0, 524288]),
+    # TODO(hx235): Enable `wal_bytes_per_sync` after fixing the DB recovery such
+    # that it won't recover past the WAL data hole created by this option
+    "wal_bytes_per_sync": 0,
     "compaction_readahead_size": lambda: random.choice(
         [0, 0, 1024 * 1024]),
     "db_write_buffer_size": lambda: random.choice(


### PR DESCRIPTION
**Context/Summary:**

`wal_bytes_per_sync > 0` can sync newer WAL but not an older WAL by its nature. This creates a hole in synced WAL data. By our crash test, we recently discovered that our DB can recover past that hole. This resulted in crash-recovery-verification error. Before we fix that recovery behavior, we will temporarily disable `wal_bytes_per_sync` in crash test

Bonus: updated the API to make the nature of this option more explicitly documented

**Test:**
More stabilized crash test