### PR TITLE
version_set.cc: Remove unused num_empty_non_l0_level (clang warning)

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2850,13 +2850,9 @@ void VersionStorageInfo::SetFinalized() {
     assert(MaxBytesForLevel(level) >= max_bytes_prev_level);
     max_bytes_prev_level = MaxBytesForLevel(level);
   }
-  int num_empty_non_l0_level = 0;
   for (int level = 0; level < num_levels(); level++) {
     assert(LevelFiles(level).size() == 0 ||
            LevelFiles(level).size() == LevelFilesBrief(level).num_files);
-    if (level > 0 && NumLevelBytes(level) > 0) {
-      num_empty_non_l0_level++;
-    }
     if (LevelFiles(level).size() > 0) {
       assert(level < num_non_empty_levels());
     }


### PR DESCRIPTION
This variable appears to be unused. It was added in commit db03739340 back in 2015, and it was unused then. I am guessing there may have originally been some assert() statements that used this variable that were removed?

Fixes the following warning on Mac OS X 14.4.1 with Apple clang 15:
```
db/version_set.cc:2853:7: error: variable 'num_empty_non_l0_level' set but not used [-Werror,-Wunused-but-set-variable]
```