### PR TITLE
Make autovector call default constructor explicitly before move/copy

### DIFF
--- a/util/autovector.h
+++ b/util/autovector.h
@@ -371,6 +371,9 @@ autovector<T, kSize>& autovector<T, kSize>::assign(
 
   // copy array
   num_stack_items_ = other.num_stack_items_;
+  for (size_t i = 0; i < num_stack_items_; ++i) {
+    new ((void*)(&values_[i])) value_type();
+  }
   std::copy(other.values_, other.values_ + num_stack_items_, values_);
 
   return *this;
@@ -385,6 +388,7 @@ autovector<T, kSize>& autovector<T, kSize>::operator=(
   num_stack_items_ = n;
   other.num_stack_items_ = 0;
   for (size_t i = 0; i < n; ++i) {
+    new ((void*)(&values_[i])) value_type();
     values_[i] = std::move(other.values_[i]);
   }
   return *this;


### PR DESCRIPTION
Make `autovector` constructs the stack based element in place before move or copy another `autovector`'s stack based elements. This is already done in  the move/copy version of `autovector::push_back` when adding item to the stack based memory
https://github.com/facebook/rocksdb/blob/8e6e8957fbb90992d1ac0c9996c70998751bd621/util/autovector.h#L269-L285

The ` values_ = reinterpret_cast<pointer>(buf_);` statement is not sufficient to ensure the class's member variables are properly constructed. I'm able to reproduce this consistently in a unit test in this change: https://github.com/facebook/rocksdb/compare/main...jowlyzhang:fix_sv_install with unit test:
`./tiered_compaction_test --gtest_filter="\*FastTrack\*" 

With stack trace  showing the `std::string` copy destination is invalid, which indicates the object in the destination `autovector` is not constructed properly. 

Test plan:
Existing unit tests.