### PR TITLE
Miscellaneous improvement to info printing

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -151,6 +151,29 @@ Status DBImpl::GetSortedWalFiles(VectorLogPtr& files) {
     }
   }
 
+  if (s.ok()) {
+    size_t wal_size = files.size();
+    ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                   "Number of log files %" ROCKSDB_PRIszt " (%" ROCKSDB_PRIszt
+                   " required by manifest)",
+                   wal_size, required_by_manifest.size());
+#ifndef NDEBUG
+    std::ostringstream wal_names;
+    for (const auto& wal : files) {
+      wal_names << wal->PathName() << " ";
+    }
+
+    std::ostringstream wal_required_by_manifest_names;
+    for (const auto& wal : required_by_manifest) {
+      wal_required_by_manifest_names << wal << ".log ";
+    }
+
+    ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                   "Log files : %s .Log files required by manifest: %s.",
+                   wal_names.str().c_str(),
+                   wal_required_by_manifest_names.str().c_str());
+#endif  // NDEBUG
+  }
   return s;
 }
 
@@ -371,10 +394,6 @@ Status DBImpl::GetLiveFilesStorageInfo(
   }
 
   size_t wal_size = live_wal_files.size();
-
-  ROCKS_LOG_INFO(immutable_db_options_.info_log,
-                 "Number of log files %" ROCKSDB_PRIszt, live_wal_files.size());
-
   // Link WAL files. Copy exact size of last one because it is the only one
   // that has changes after the last flush.
   auto wal_dir = immutable_db_options_.GetWalDir();

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -232,7 +232,9 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
             // produce a hole in the recovered data. Report an error here, which
             // higher layers can choose to ignore when it's provable there is no
             // hole.
-            ReportCorruption(scratch->size(), "error reading trailing data");
+            ReportCorruption(
+                scratch->size(),
+                "error reading trailing data due to encountering EOF");
           }
           // This can be caused by the writer dying immediately after
           //  writing a physical record but before completing the next; don't
@@ -252,7 +254,9 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
               // produce a hole in the recovered data. Report an error here,
               // which higher layers can choose to ignore when it's provable
               // there is no hole.
-              ReportCorruption(scratch->size(), "error reading trailing data");
+              ReportCorruption(
+                  scratch->size(),
+                  "error reading trailing data due to encountering old record");
             }
             // This can be caused by the writer dying immediately after
             //  writing a physical record but before completing the next; don't


### PR DESCRIPTION
**Context/Summary:**
Debugging crash test makes me realize there are a few places can use some improvement of logging more info

**Test:**
Manual testing
Debug build
```
2024/04/04-16:12:12.289791 1636007 [/db_filesnapshot.cc:156] Number of log files 2 (0 required by manifest)
...
2024/04/04-16:12:12.289814 1636007 [/db_filesnapshot.cc:171] Log files : /000004.log /000008.log  .Log files required by manifest: .
```
Non-debug build
```
2024/04/04-16:19:23.222168 1685043 [/db_filesnapshot.cc:156] Number of log files 1 (0 required by manifest)
```
CI