### PR TITLE
Add more missing options in crash test

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -20,7 +20,6 @@
 // NOTE that if FLAGS_test_batches_snapshots is set, the test will have
 // different behavior. See comment of the flag for details.
 
-#include "rocksdb/advanced_options.h"
 #ifdef GFLAGS
 #pragma once
 #include <fcntl.h>
@@ -47,6 +46,7 @@
 #include "monitoring/histogram.h"
 #include "options/options_helper.h"
 #include "port/port.h"
+#include "rocksdb/advanced_options.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/env.h"
 #include "rocksdb/slice.h"
@@ -260,9 +260,9 @@ DECLARE_int32(continuous_verification_interval);
 DECLARE_int32(get_property_one_in);
 DECLARE_string(file_checksum_impl);
 DECLARE_bool(verification_only);
-DECLARE_uint32(last_level_temperature);
-DECLARE_uint32(default_write_temperature);
-DECLARE_uint32(default_temperature);
+DECLARE_string(last_level_temperature);
+DECLARE_string(default_write_temperature);
+DECLARE_string(default_temperature);
 
 // Options for transaction dbs.
 // Use TransactionDB (a.k.a. Pessimistic Transaction DB)
@@ -495,6 +495,28 @@ inline std::string ChecksumTypeToString(ROCKSDB_NAMESPACE::ChecksumType ctype) {
               name_and_enum_val) { return name_and_enum_val.second == ctype; });
   assert(iter != ROCKSDB_NAMESPACE::checksum_type_string_map.end());
   return iter->first;
+}
+
+inline enum ROCKSDB_NAMESPACE::Temperature StringToTemperature(
+    const char* ctype) {
+  assert(ctype);
+  auto iter = std::find_if(
+      ROCKSDB_NAMESPACE::temperature_to_string.begin(),
+      ROCKSDB_NAMESPACE::temperature_to_string.end(),
+      [&](const std::pair<ROCKSDB_NAMESPACE::Temperature, std::string>&
+              temp_and_string_val) {
+        return ctype == temp_and_string_val.second;
+      });
+  assert(iter != ROCKSDB_NAMESPACE::temperature_to_string.end());
+  return iter->first;
+}
+
+inline std::string TemperatureToString(
+    ROCKSDB_NAMESPACE::Temperature temperature) {
+  auto iter =
+      ROCKSDB_NAMESPACE::OptionsHelper::temperature_to_string.find(temperature);
+  assert(iter != ROCKSDB_NAMESPACE::OptionsHelper::temperature_to_string.end());
+  return iter->second;
 }
 
 inline std::vector<std::string> SplitString(std::string src) {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -20,6 +20,7 @@
 // NOTE that if FLAGS_test_batches_snapshots is set, the test will have
 // different behavior. See comment of the flag for details.
 
+#include "rocksdb/advanced_options.h"
 #ifdef GFLAGS
 #pragma once
 #include <fcntl.h>
@@ -259,6 +260,9 @@ DECLARE_int32(continuous_verification_interval);
 DECLARE_int32(get_property_one_in);
 DECLARE_string(file_checksum_impl);
 DECLARE_bool(verification_only);
+DECLARE_uint32(last_level_temperature);
+DECLARE_uint32(default_write_temperature);
+DECLARE_uint32(default_temperature);
 
 // Options for transaction dbs.
 // Use TransactionDB (a.k.a. Pessimistic Transaction DB)
@@ -340,7 +344,6 @@ DECLARE_uint32(memtable_max_range_deletions);
 DECLARE_uint32(bottommost_file_compaction_delay);
 
 // Tiered storage
-DECLARE_bool(enable_tiered_storage);  // set last_level_temperature
 DECLARE_int64(preclude_last_level_data_seconds);
 DECLARE_int64(preserve_internal_time_seconds);
 
@@ -392,6 +395,13 @@ DECLARE_double(low_pri_pool_ratio);
 DECLARE_uint64(soft_pending_compaction_bytes_limit);
 DECLARE_uint64(hard_pending_compaction_bytes_limit);
 DECLARE_uint64(max_sequential_skip_in_iterations);
+DECLARE_bool(enable_sst_partitioner_factory);
+DECLARE_bool(enable_do_not_compress_roles);
+DECLARE_bool(block_align);
+DECLARE_uint32(lowest_used_cache_tier);
+DECLARE_bool(enable_custom_split_merge);
+DECLARE_uint32(adm_policy);
+DECLARE_bool(enable_memtable_insert_with_hint_prefix_extractor);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1331,20 +1331,20 @@ DEFINE_uint32(
     static_cast<uint32_t>(ROCKSDB_NAMESPACE::TieredCacheOptions().adm_policy),
     "TieredCacheOptions.adm_policy");
 
-DEFINE_uint32(
-    last_level_temperature,
-    static_cast<uint32_t>(ROCKSDB_NAMESPACE::Options().last_level_temperature),
-    "Options.last_level_temperature");
+DEFINE_string(last_level_temperature,
+              ROCKSDB_NAMESPACE::TemperatureToString(
+                  ROCKSDB_NAMESPACE::Options().last_level_temperature),
+              "Options.last_level_temperature");
 
-DEFINE_uint32(default_write_temperature,
-              static_cast<uint32_t>(
+DEFINE_string(default_write_temperature,
+              ROCKSDB_NAMESPACE::TemperatureToString(
                   ROCKSDB_NAMESPACE::Options().default_write_temperature),
               "Options.default_write_temperature");
 
-DEFINE_uint32(
-    default_temperature,
-    static_cast<uint32_t>(ROCKSDB_NAMESPACE::Options().default_temperature),
-    "Options.default_temperature");
+DEFINE_string(default_temperature,
+              ROCKSDB_NAMESPACE::TemperatureToString(
+                  ROCKSDB_NAMESPACE::Options().default_temperature),
+              "Options.default_temperature");
 
 DEFINE_bool(enable_memtable_insert_with_hint_prefix_extractor,
             ROCKSDB_NAMESPACE::Options()

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -516,8 +516,6 @@ DEFINE_int32(prepopulate_blob_cache, 0,
              "[Integrated BlobDB] Pre-populate hot/warm blobs in blob cache. 0 "
              "to disable and 1 to insert during flush.");
 
-DEFINE_bool(enable_tiered_storage, false, "Set last_level_temperature");
-
 DEFINE_int64(preclude_last_level_data_seconds, 0,
              "Preclude data from the last level. Used with tiered storage "
              "feature to preclude new data from comacting to the last level.");
@@ -1304,4 +1302,54 @@ DEFINE_uint64(soft_pending_compaction_bytes_limit,
 DEFINE_uint64(hard_pending_compaction_bytes_limit,
               ROCKSDB_NAMESPACE::Options().hard_pending_compaction_bytes_limit,
               "Options.hard_pending_compaction_bytes_limit");
+
+DEFINE_bool(enable_sst_partitioner_factory, false,
+            "If true, set Options.sst_partitioner_factory to "
+            "SstPartitionerFixedPrefixFactory with prefix length equal to 1");
+
+DEFINE_bool(
+    enable_do_not_compress_roles, false,
+    "If true, set CompressedSecondaryCacheOptions.do_not_compress_roles to "
+    "include all cache roles");
+
+DEFINE_bool(block_align,
+            ROCKSDB_NAMESPACE::BlockBasedTableOptions().block_align,
+            "BlockBasedTableOptions.block_align");
+
+DEFINE_uint32(
+    lowest_used_cache_tier,
+    static_cast<uint32_t>(ROCKSDB_NAMESPACE::Options().lowest_used_cache_tier),
+    "Options.lowest_used_cache_tier");
+
+DEFINE_bool(enable_custom_split_merge,
+            ROCKSDB_NAMESPACE::CompressedSecondaryCacheOptions()
+                .enable_custom_split_merge,
+            "CompressedSecondaryCacheOptions.enable_custom_split_merge");
+
+DEFINE_uint32(
+    adm_policy,
+    static_cast<uint32_t>(ROCKSDB_NAMESPACE::TieredCacheOptions().adm_policy),
+    "TieredCacheOptions.adm_policy");
+
+DEFINE_uint32(
+    last_level_temperature,
+    static_cast<uint32_t>(ROCKSDB_NAMESPACE::Options().last_level_temperature),
+    "Options.last_level_temperature");
+
+DEFINE_uint32(default_write_temperature,
+              static_cast<uint32_t>(
+                  ROCKSDB_NAMESPACE::Options().default_write_temperature),
+              "Options.default_write_temperature");
+
+DEFINE_uint32(
+    default_temperature,
+    static_cast<uint32_t>(ROCKSDB_NAMESPACE::Options().default_temperature),
+    "Options.default_temperature");
+
+DEFINE_bool(enable_memtable_insert_with_hint_prefix_extractor,
+            ROCKSDB_NAMESPACE::Options()
+                    .memtable_insert_with_hint_prefix_extractor != nullptr,
+            "If true and FLAGS_prefix_size > 0, set "
+            "Options.memtable_insert_with_hint_prefix_extractor to "
+            "be Options.prefix_extractor");
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -190,6 +190,14 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
       tiered_opts.compressed_secondary_ratio = 0.5;
       tiered_opts.adm_policy =
           static_cast<TieredAdmissionPolicy>(FLAGS_adm_policy);
+      if (tiered_opts.adm_policy ==
+          TieredAdmissionPolicy::kAdmPolicyThreeQueue) {
+        std::shared_ptr<SecondaryCache> nvm_sec_cache;
+        CompressedSecondaryCacheOptions nvm_sec_cache_opts;
+        nvm_sec_cache_opts.capacity = cache_size;
+        tiered_opts.nvm_sec_cache =
+            NewCompressedSecondaryCache(nvm_sec_cache_opts);
+      }
       block_cache = NewTieredCache(tiered_opts);
     } else {
       opts.secondary_cache = std::move(secondary_cache);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -12,6 +12,7 @@
 #include <thread>
 
 #include "rocksdb/options.h"
+#include "rocksdb/slice_transform.h"
 #include "util/compression.h"
 #ifdef GFLAGS
 #include "db_stress_tool/db_stress_common.h"
@@ -142,6 +143,10 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
     CompressedSecondaryCacheOptions opts;
     opts.capacity = FLAGS_compressed_secondary_cache_size;
     opts.compress_format_version = FLAGS_compress_format_version;
+    if (FLAGS_enable_do_not_compress_roles) {
+      opts.do_not_compress_roles = {CacheEntryRoleSet::All()};
+    }
+    opts.enable_custom_split_merge = FLAGS_enable_custom_split_merge;
     secondary_cache = NewCompressedSecondaryCache(opts);
     if (secondary_cache == nullptr) {
       fprintf(stderr, "Failed to allocate compressed secondary cache\n");
@@ -183,6 +188,8 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
       tiered_opts.cache_type = PrimaryCacheType::kCacheTypeHCC;
       tiered_opts.total_capacity = cache_size;
       tiered_opts.compressed_secondary_ratio = 0.5;
+      tiered_opts.adm_policy =
+          static_cast<TieredAdmissionPolicy>(FLAGS_adm_policy);
       block_cache = NewTieredCache(tiered_opts);
     } else {
       opts.secondary_cache = std::move(secondary_cache);
@@ -203,6 +210,8 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
       tiered_opts.cache_type = PrimaryCacheType::kCacheTypeLRU;
       tiered_opts.total_capacity = cache_size;
       tiered_opts.compressed_secondary_ratio = 0.5;
+      tiered_opts.adm_policy =
+          static_cast<TieredAdmissionPolicy>(FLAGS_adm_policy);
       block_cache = NewTieredCache(tiered_opts);
     } else {
       opts.secondary_cache = std::move(secondary_cache);
@@ -1718,6 +1727,7 @@ Status StressTest::TestBackupRestore(
         FLAGS_backup_max_size * 1000000 /* rate_bytes_per_sec */,
         1 /* refill_period_us */));
   }
+  backup_opts.current_temperatures_override_manifest = thread->rand.OneIn(2);
   std::ostringstream backup_opt_oss;
   backup_opt_oss << "share_table_files: " << backup_opts.share_table_files
                  << ", share_files_with_checksum: "
@@ -1730,7 +1740,9 @@ Status StressTest::TestBackupRestore(
                  << ", backup_rate_limiter: "
                  << backup_opts.backup_rate_limiter.get()
                  << ", restore_rate_limiter: "
-                 << backup_opts.restore_rate_limiter.get();
+                 << backup_opts.restore_rate_limiter.get()
+                 << ", current_temperatures_override_manifest: "
+                 << backup_opts.current_temperatures_override_manifest;
 
   std::ostringstream create_backup_opt_oss;
   std::ostringstream restore_opts_oss;
@@ -3415,6 +3427,7 @@ void InitializeOptionsFromFlags(
   block_based_options.index_shortening =
       static_cast<BlockBasedTableOptions::IndexShorteningMode>(
           FLAGS_index_shortening);
+  block_based_options.block_align = FLAGS_block_align;
   options.table_factory.reset(NewBlockBasedTableFactory(block_based_options));
   options.db_write_buffer_size = FLAGS_db_write_buffer_size;
   options.write_buffer_size = FLAGS_write_buffer_size;
@@ -3447,6 +3460,10 @@ void InitializeOptionsFromFlags(
   options.num_levels = FLAGS_num_levels;
   if (FLAGS_prefix_size >= 0) {
     options.prefix_extractor.reset(NewFixedPrefixTransform(FLAGS_prefix_size));
+    if (FLAGS_enable_memtable_insert_with_hint_prefix_extractor) {
+      options.memtable_insert_with_hint_prefix_extractor =
+          options.prefix_extractor;
+    }
   }
   options.max_open_files = FLAGS_open_files;
   options.statistics = dbstats;
@@ -3573,9 +3590,13 @@ void InitializeOptionsFromFlags(
   options.wal_compression =
       StringToCompressionType(FLAGS_wal_compression.c_str());
 
-  if (FLAGS_enable_tiered_storage) {
-    options.last_level_temperature = Temperature::kCold;
-  }
+  options.last_level_temperature =
+      static_cast<Temperature>(FLAGS_last_level_temperature);
+  options.default_write_temperature =
+      static_cast<Temperature>(FLAGS_default_write_temperature);
+  options.default_temperature =
+      static_cast<Temperature>(FLAGS_default_temperature);
+
   options.preclude_last_level_data_seconds =
       FLAGS_preclude_last_level_data_seconds;
   options.preserve_internal_time_seconds = FLAGS_preserve_internal_time_seconds;
@@ -3652,6 +3673,12 @@ void InitializeOptionsFromFlags(
       FLAGS_hard_pending_compaction_bytes_limit;
   options.max_sequential_skip_in_iterations =
       FLAGS_max_sequential_skip_in_iterations;
+  if (FLAGS_enable_sst_partitioner_factory) {
+    options.sst_partitioner_factory = std::shared_ptr<SstPartitionerFactory>(
+        NewSstPartitionerFixedPrefixFactory(1));
+  }
+  options.lowest_used_cache_tier =
+      static_cast<CacheTier>(FLAGS_lowest_used_cache_tier);
 }
 
 void InitializeOptionsGeneral(

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3599,11 +3599,11 @@ void InitializeOptionsFromFlags(
       StringToCompressionType(FLAGS_wal_compression.c_str());
 
   options.last_level_temperature =
-      static_cast<Temperature>(FLAGS_last_level_temperature);
+      StringToTemperature(FLAGS_last_level_temperature.c_str());
   options.default_write_temperature =
-      static_cast<Temperature>(FLAGS_default_write_temperature);
+      StringToTemperature(FLAGS_default_write_temperature.c_str());
   options.default_temperature =
-      static_cast<Temperature>(FLAGS_default_temperature);
+      StringToTemperature(FLAGS_default_temperature.c_str());
 
   options.preclude_last_level_data_seconds =
       FLAGS_preclude_last_level_data_seconds;

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -37,6 +37,7 @@ static std::unordered_map<std::string, WALRecoveryMode>
 
 static std::unordered_map<std::string, CacheTier> cache_tier_string_map = {
     {"kVolatileTier", CacheTier::kVolatileTier},
+    {"kVolatileCompressedTier", CacheTier::kVolatileCompressedTier},
     {"kNonVolatileBlockTier", CacheTier::kNonVolatileBlockTier}};
 
 static std::unordered_map<std::string, InfoLogLevel> info_log_level_string_map =

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -274,9 +274,9 @@ default_params = {
     "lowest_used_cache_tier": lambda: random.choice([0, 1, 2]),
     "enable_custom_split_merge": lambda: random.choice([0, 1]),
     "adm_policy": lambda: random.choice([0, 1, 2, 3]),
-    "last_level_temperature": lambda: random.choice([0, 4, 8, 12]),
-    "default_write_temperature": lambda: random.choice([0, 4, 8, 12]),
-    "default_temperature": lambda: random.choice([0, 4, 8, 12]),
+    "last_level_temperature": lambda: random.choice(["kUnknown", "kHot", "kWarm", "kCold"]),
+    "default_write_temperature": lambda: random.choice(["kUnknown", "kHot", "kWarm", "kCold"]),
+    "default_temperature": lambda: random.choice(["kUnknown", "kHot", "kWarm", "kCold"]),
     # TODO(hx235): enable `enable_memtable_insert_with_hint_prefix_extractor`
     # after fixing the surfaced issue with delete range
     "enable_memtable_insert_with_hint_prefix_extractor": 0,
@@ -529,8 +529,8 @@ tiered_params = {
     # tiered storage doesn't support blob db yet
     "enable_blob_files": 0,
     "use_blob_db": 0,
-    # Temperature::kCold
-    "last_level_temperature": 12,
+    "default_write_temperature": lambda: random.choice(["kUnknown", "kHot", "kWarm"]),
+    "last_level_temperature": "kCold",
 }
 
 multiops_txn_default_params = {
@@ -788,6 +788,7 @@ def finalize_and_sanitize(src_params):
         # disableWAL and recycle_log_file_num options are not mutually
         # compatible at the moment
         dest_params["recycle_log_file_num"] = 0
+    # Enabling block_align with compression is not supported
     if dest_params.get("block_align") == 1:
         dest_params["compression_type"] = "none"
     return dest_params

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -273,8 +273,7 @@ default_params = {
     "block_align": 0,
     "lowest_used_cache_tier": lambda: random.choice([0, 1, 2]),
     "enable_custom_split_merge": lambda: random.choice([0, 1]),
-    # TODO(hx235): enable other `adm_policy` after fixing the surfaced segfault issue with compressed secondary cache
-    "adm_policy": lambda: random.choice([0]),
+    "adm_policy": lambda: random.choice([0, 1, 2, 3]),
     "last_level_temperature": lambda: random.choice([0, 4, 8, 12]),
     "default_write_temperature": lambda: random.choice([0, 4, 8, 12]),
     "default_temperature": lambda: random.choice([0, 4, 8, 12]),

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -177,8 +177,8 @@ default_params = {
         [16, 64, 1024 * 1024, 16 * 1024 * 1024]
     ),
     "level_compaction_dynamic_level_bytes": lambda: random.randint(0, 1),
-    "verify_checksum_one_in": lambda: random.choice([100000, 1000000]),
-    "verify_file_checksums_one_in": lambda: random.choice([100000, 1000000]),
+    "verify_checksum_one_in": lambda: random.choice([1000, 1000000]),
+    "verify_file_checksums_one_in": lambda: random.choice([1000, 1000000]),
     "verify_db_one_in": lambda: random.choice([10000, 100000]),
     "continuous_verification_interval": 0,
     "max_key_len": 3,
@@ -267,6 +267,20 @@ default_params = {
     "low_pri_pool_ratio": lambda: random.choice([0, 0.5]),
     "soft_pending_compaction_bytes_limit" : lambda: random.choice([1024 * 1024] + [64 * 1073741824] * 4),
     "hard_pending_compaction_bytes_limit" : lambda: random.choice([2 * 1024 * 1024] + [256 * 1073741824] * 4),
+    "enable_sst_partitioner_factory": lambda: random.choice([0, 1]),
+    "enable_do_not_compress_roles": lambda: random.choice([0, 1]),
+    # TODO(hx235): enable `block_align` after fixing the surfaced corruption issue
+    "block_align": 0,
+    "lowest_used_cache_tier": lambda: random.choice([0, 1, 2]),
+    "enable_custom_split_merge": lambda: random.choice([0, 1]),
+    # TODO(hx235): enable other `adm_policy` after fixing the surfaced segfault issue with compressed secondary cache
+    "adm_policy": lambda: random.choice([0]),
+    "last_level_temperature": lambda: random.choice([0, 4, 8, 12]),
+    "default_write_temperature": lambda: random.choice([0, 4, 8, 12]),
+    "default_temperature": lambda: random.choice([0, 4, 8, 12]),
+    # TODO(hx235): enable `enable_memtable_insert_with_hint_prefix_extractor`
+    # after fixing the surfaced issue with delete range
+    "enable_memtable_insert_with_hint_prefix_extractor": 0,
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR
@@ -508,7 +522,6 @@ ts_params = {
 }
 
 tiered_params = {
-    "enable_tiered_storage": 1,
     # Set tiered compaction hot data time as: 1 minute, 1 hour, 10 hour
     "preclude_last_level_data_seconds": lambda: random.choice([60, 3600, 36000]),
     # only test universal compaction for now, level has known issue of
@@ -517,6 +530,8 @@ tiered_params = {
     # tiered storage doesn't support blob db yet
     "enable_blob_files": 0,
     "use_blob_db": 0,
+    # Temperature::kCold
+    "last_level_temperature": 12,
 }
 
 multiops_txn_default_params = {
@@ -774,6 +789,8 @@ def finalize_and_sanitize(src_params):
         # disableWAL and recycle_log_file_num options are not mutually
         # compatible at the moment
         dest_params["recycle_log_file_num"] = 0
+    if dest_params.get("block_align") == 1:
+        dest_params["compression_type"] = "none"
     return dest_params
 
 


### PR DESCRIPTION
**Context/Summary:**
This is to improve our crash test coverage.

Bonus change:
- Added the missing Options string mapping for `CacheTier::kVolatileCompressedTier`
- Deprecated crash test options `enable_tiered_storage` mainly for setting `last_level_temperature` which is now covered in crash test by itself
- Intensified `verify_checksum_one_in\verify_file_checksums_one_in` as I found out these together with new coverage surface more issues

**Test plan:**
CI to look out for trivial failures


