### PR TITLE
Fix "assertion failed - iter != ROCKSDB_NAMESPACE::OptionsHelper::temperature_to_string.end()"

### DIFF
--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1331,20 +1331,13 @@ DEFINE_uint32(
     static_cast<uint32_t>(ROCKSDB_NAMESPACE::TieredCacheOptions().adm_policy),
     "TieredCacheOptions.adm_policy");
 
-DEFINE_string(last_level_temperature,
-              ROCKSDB_NAMESPACE::TemperatureToString(
-                  ROCKSDB_NAMESPACE::Options().last_level_temperature),
+DEFINE_string(last_level_temperature, "kUnknown",
               "Options.last_level_temperature");
 
-DEFINE_string(default_write_temperature,
-              ROCKSDB_NAMESPACE::TemperatureToString(
-                  ROCKSDB_NAMESPACE::Options().default_write_temperature),
+DEFINE_string(default_write_temperature, "kUnknown",
               "Options.default_write_temperature");
 
-DEFINE_string(default_temperature,
-              ROCKSDB_NAMESPACE::TemperatureToString(
-                  ROCKSDB_NAMESPACE::Options().default_temperature),
-              "Options.default_temperature");
+DEFINE_string(default_temperature, "kUnknown", "Options.default_temperature");
 
 DEFINE_bool(enable_memtable_insert_with_hint_prefix_extractor,
             ROCKSDB_NAMESPACE::Options()


### PR DESCRIPTION
Context/Summary: for unknown reason, calling a db stress common function in db stress flag file for temperature-related flags will cause some weird behavior in some compilation/build. 
```
assertion failed - iter != ROCKSDB_NAMESPACE::OptionsHelper::temperature_to_string.end()
```
For now, we decide not to call such function by hard-coding their default stress test values.

Test:
- Run a rehearsal stress test with this fix and weird behavior is gone.