### PR TITLE
Temporary revert #12386 to unblock MyRocks build

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -72,9 +72,6 @@
 #include "options/cf_options.h"
 #include "options/options_helper.h"
 #include "options/options_parser.h"
-#ifdef ROCKSDB_JEMALLOC
-#include "port/jemalloc_helper.h"
-#endif
 #include "port/port.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/compaction_filter.h"
@@ -152,12 +149,6 @@ void DumpSupportInfo(Logger* logger) {
                    crc32c::IsFastCrc32Supported().c_str());
 
   ROCKS_LOG_HEADER(logger, "DMutex implementation: %s", DMutex::kName());
-
-  bool jemalloc_supported = false;
-#ifdef ROCKSDB_JEMALLOC
-  jemalloc_supported = HasJemalloc();
-#endif
-  ROCKS_LOG_HEADER(logger, "Jemalloc supported: %d", jemalloc_supported);
 }
 }  // namespace
 


### PR DESCRIPTION
MyRocks reports build failure with this change #12386, we haven't figured out how to fix it yet. So we are temporarily reverting it to unblock them.

This reverts commit 3104e55f298c9af087a0d07b99627aa476db6e27.