### PR TITLE
Renable kAdmPolicyThreeQueue in crash test

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -192,7 +192,6 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
           static_cast<TieredAdmissionPolicy>(FLAGS_adm_policy);
       if (tiered_opts.adm_policy ==
           TieredAdmissionPolicy::kAdmPolicyThreeQueue) {
-        std::shared_ptr<SecondaryCache> nvm_sec_cache;
         CompressedSecondaryCacheOptions nvm_sec_cache_opts;
         nvm_sec_cache_opts.capacity = cache_size;
         tiered_opts.nvm_sec_cache =
@@ -220,6 +219,13 @@ std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
       tiered_opts.compressed_secondary_ratio = 0.5;
       tiered_opts.adm_policy =
           static_cast<TieredAdmissionPolicy>(FLAGS_adm_policy);
+      if (tiered_opts.adm_policy ==
+          TieredAdmissionPolicy::kAdmPolicyThreeQueue) {
+        CompressedSecondaryCacheOptions nvm_sec_cache_opts;
+        nvm_sec_cache_opts.capacity = cache_size;
+        tiered_opts.nvm_sec_cache =
+            NewCompressedSecondaryCache(nvm_sec_cache_opts);
+      }
       block_cache = NewTieredCache(tiered_opts);
     } else {
       opts.secondary_cache = std::move(secondary_cache);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -273,9 +273,7 @@ default_params = {
     "block_align": 0,
     "lowest_used_cache_tier": lambda: random.choice([0, 1, 2]),
     "enable_custom_split_merge": lambda: random.choice([0, 1]),
-    # TODO(hx235): enable `kAdmPolicyThreeQueue` after fixing the surfaced segfault
-    # issue in CompressedCacheSetCapacityThread
-    "adm_policy": lambda: random.choice([0, 1, 2]),
+    "adm_policy": lambda: random.choice([0, 1, 2, 3]),
     "last_level_temperature": lambda: random.choice(["kUnknown", "kHot", "kWarm", "kCold"]),
     "default_write_temperature": lambda: random.choice(["kUnknown", "kHot", "kWarm", "kCold"]),
     "default_temperature": lambda: random.choice(["kUnknown", "kHot", "kWarm", "kCold"]),


### PR DESCRIPTION
Context/Summary: 

We need a `nvm_sec_cache` when `kAdmPolicyThreeQueue` is used otherwise a nullptr cache will be accessed causing us segfault in https://github.com/facebook/rocksdb/pull/12521

Test:
- Re-enabled `kAdmPolicyThreeQueue` and rehearsed stress test that failed before this fix and pass after