### PR TITLE
-g enabled only for DEBUG_LEVEL>=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,15 @@ else
 	CXXFLAGS += -DROCKSDB_USE_RTTI
 endif
 else
+ifeq ($(PLATFORM), OS_AIX)
+# no debug info
+else ifneq ($(PLATFORM), IOS)
+CFLAGS += -g
+CXXFLAGS += -g
+else
+# no debug info for IOS, that will make our library big
+OPT += -DNDEBUG
+endif
 ifneq ($(USE_RTTI), 0)
 	CXXFLAGS += -DROCKSDB_USE_RTTI
 else
@@ -305,16 +314,6 @@ missing_make_config_paths := $(shell				\
 
 $(foreach path, $(missing_make_config_paths), \
 	$(warning Warning: $(path) does not exist))
-
-ifeq ($(PLATFORM), OS_AIX)
-# no debug info
-else ifneq ($(PLATFORM), IOS)
-CFLAGS += -g
-CXXFLAGS += -g
-else
-# no debug info for IOS, that will make our library big
-OPT += -DNDEBUG
-endif
 
 ifeq ($(PLATFORM), OS_AIX)
 ARFLAGS = -X64 rs


### PR DESCRIPTION
When I build a project via `make` with DEBUG_LEVEL=0, debug symbols are added to the shared library and object files, and because of this it takes up 30 times more disk space for *librocksdb.so* (422MB vs 13,8MB). I suggest using the **-g** flag only for DEBUG_LEVEL>=1.