### PR TITLE
Simplify Make/Parallel jobs parallelism arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CFLAGS += ${EXTRA_CFLAGS}
 CXXFLAGS += ${EXTRA_CXXFLAGS}
 LDFLAGS += $(EXTRA_LDFLAGS)
 MACHINE ?= $(shell uname -m)
+NPROC ?= $(shell nproc)
 ARFLAGS = ${EXTRA_ARFLAGS} rs
 STRIPFLAGS = -S -x
 
@@ -971,11 +972,13 @@ prioritize_long_running_tests =						\
     | sed 's/^[.0-9]* //'
 
 # "make check" uses
-# Run with "make J=1 check" to disable parallelism in "make check".
-# Run with "make J=200% check" to run two parallel jobs per core.
-# The default is to run one job per core (J=100%).
-# See "man parallel" for its "-j ..." option.
-J ?= 100%
+# Run with "make J=1 check" to disable parallelism in "make check" or (Docker) container builds.
+# Run with "make J=$((`nproc`*2)) check" to run two parallel jobs per core.
+# The default is to run one job per core, but leave one core free for the OS, i.e.: J=$((`nproc`-1)).
+# This is used both to inform GNU `parrallel` of the number of parallel jobs to execute,
+# and also as the number of jobs for Make when executed in (Docker) containers
+# See "man parallel" and "man make" for their "-j ..." option syntax.
+J ?= $(shell expr $(NPROC) - 1)
 
 # Use this regexp to select the subset of tests whose names match.
 tests-regexp = .

--- a/java/crossbuild/docker-build-linux.sh
+++ b/java/crossbuild/docker-build-linux.sh
@@ -36,7 +36,7 @@ if hash scl 2>/dev/null; then
   fi
 else
   make clean-not-downloaded
-  PORTABLE=1 make -j$J rocksdbjavastatic
+  PORTABLE=1 J=$J make -j$J rocksdbjavastatic
 fi
 
 cp java/target/librocksdbjni-linux*.so java/target/rocksdbjni-*-linux*.jar java/target/rocksdbjni-*-linux*.jar.sha1 /rocksdb-java-target


### PR DESCRIPTION
Fixes the build so that the `J` env var is compatible with both GNU parallel and also Make (when used in Docker containers).