### PR TITLE
Add inplace_update_support to crash/stress test

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -402,6 +402,9 @@ DECLARE_uint32(lowest_used_cache_tier);
 DECLARE_bool(enable_custom_split_merge);
 DECLARE_uint32(adm_policy);
 DECLARE_bool(enable_memtable_insert_with_hint_prefix_extractor);
+DECLARE_bool(check_multiget_consistency);
+DECLARE_bool(check_multiget_entity_consistency);
+DECLARE_bool(inplace_update_support);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1345,4 +1345,16 @@ DEFINE_bool(enable_memtable_insert_with_hint_prefix_extractor,
             "If true and FLAGS_prefix_size > 0, set "
             "Options.memtable_insert_with_hint_prefix_extractor to "
             "be Options.prefix_extractor");
+
+DEFINE_bool(check_multiget_consistency, true,
+            "If true, check consistency of MultiGet result by comparing it "
+            "with Get's under a snapshot");
+
+DEFINE_bool(check_multiget_entity_consistency, true,
+            "If true, check consistency of MultiGetEntity result by comparing "
+            "it GetEntity's under a snapshot");
+
+DEFINE_bool(inplace_update_support,
+            ROCKSDB_NAMESPACE::Options().inplace_update_support,
+            "Options.inplace_update_support");
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3693,6 +3693,7 @@ void InitializeOptionsFromFlags(
   }
   options.lowest_used_cache_tier =
       static_cast<CacheTier>(FLAGS_lowest_used_cache_tier);
+  options.inplace_update_support = FLAGS_inplace_update_support;
 }
 
 void InitializeOptionsGeneral(

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -249,14 +249,17 @@ int db_stress_tool(int argc, char** argv) {
       exit(1);
     }
   }
-  if (FLAGS_enable_compaction_filter &&
+  if ((FLAGS_enable_compaction_filter || FLAGS_inplace_update_support) &&
       (FLAGS_acquire_snapshot_one_in > 0 || FLAGS_compact_range_one_in > 0 ||
        FLAGS_iterpercent > 0 || FLAGS_test_batches_snapshots ||
-       FLAGS_test_cf_consistency)) {
+       FLAGS_test_cf_consistency || FLAGS_check_multiget_consistency ||
+       FLAGS_check_multiget_entity_consistency)) {
     fprintf(
         stderr,
         "Error: acquire_snapshot_one_in, compact_range_one_in, iterpercent, "
-        "test_batches_snapshots  must all be 0 when using compaction filter\n");
+        "test_batches_snapshots, test_cf_consistency, "
+        "check_multiget_consistency, check_multiget_entity_consistency must "
+        "all be 0 when using compaction filter or inplace update support\n");
     exit(1);
   }
   if (FLAGS_test_multi_ops_txns) {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -580,13 +580,8 @@ class NonBatchedOpsStressTest : public StressTest {
     int column_family = rand_column_families[0];
     ColumnFamilyHandle* cfh = column_families_[column_family];
     int error_count = 0;
-    // Do a consistency check between Get and MultiGet. Don't do it too
-    // often as it will slow db_stress down
-    //
-    // CompactionFilter can make snapshot non-repeatable by removing keys
-    // protected by snapshot
-    bool do_consistency_check =
-        !FLAGS_enable_compaction_filter && thread->rand.OneIn(4);
+
+    bool do_consistency_check = FLAGS_check_multiget_consistency;
 
     ReadOptions readoptionscopy = read_opts;
 
@@ -1075,10 +1070,8 @@ class NonBatchedOpsStressTest : public StressTest {
       fault_fs_guard->DisableErrorInjection();
     }
 
-    // CompactionFilter can make snapshot non-repeatable by removing keys
-    // protected by snapshot
-    const bool check_get_entity = !FLAGS_enable_compaction_filter &&
-                                  !error_count && thread->rand.OneIn(4);
+    const bool check_get_entity =
+        !error_count && FLAGS_check_multiget_entity_consistency;
 
     for (size_t i = 0; i < num_keys; ++i) {
       const Status& s = statuses[i];


### PR DESCRIPTION
**Context/Summary:**
`inplace_update_support=true` is not tested in crash/stress test. Since it's not compatible with snapshots like compaction_filter, we need to sanitize its value in presence of snapshots-related options. A minor refactoring is added to centralize such sanitization in db_crashtest.py - see `check_multiget_consistency` and `check_multiget_entity_consistency`



**Test:**
Locally run blackbox simple crash test with inplace_update_support=1 (confirmed by command line) for a while