### PR TITLE
Add MultiGetEntityFromBatchAndDB to WriteBatchWithIndex

### DIFF
--- a/unreleased_history/new_features/multi_get_entity_from_batch_and_db.md
+++ b/unreleased_history/new_features/multi_get_entity_from_batch_and_db.md
@@ -1,0 +1,1 @@
+Added a new API `MultiGetEntityFromBatchAndDB` to `WriteBatchWithIndex` that can be used for batched wide-column point lookups with read-your-own-writes consistency. Similarly to `MultiGetFromBatchAndDB`, the API can combine data from the write batch with data from the underlying database if needed. See the API comments for more details.

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -2631,7 +2631,23 @@ TEST_P(WriteBatchWithIndexTest, WideColumnsBatchOnly) {
     ASSERT_EQ(columns.columns(), expected[i]);
   }
 
-  // TODO: add tests for MultiGetEntityFromBatchAndDB once it is implemented
+  // MultiGetEntityFromBatchAndDB
+  {
+    std::array<PinnableWideColumns, num_keys> results;
+    std::array<Status, num_keys> statuses;
+    constexpr bool sorted_input = false;
+
+    batch_->MultiGetEntityFromBatchAndDB(
+        db_, read_opts_, db_->DefaultColumnFamily(), num_keys, keys.data(),
+        results.data(), statuses.data(), sorted_input);
+
+    ASSERT_TRUE(statuses[0].IsNotFound());
+
+    for (size_t i = 1; i < num_keys; ++i) {
+      ASSERT_OK(statuses[i]);
+      ASSERT_EQ(results[i].columns(), expected[i]);
+    }
+  }
 
   // Iterator
   std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(
@@ -2766,7 +2782,23 @@ TEST_P(WriteBatchWithIndexTest, WideColumnsBatchAndDB) {
                     .IsNotFound());
   }
 
-  // TODO: add tests for MultiGetEntityFromBatchAndDB once it is implemented
+  // MultiGetEntityFromBatchAndDB
+  {
+    std::array<PinnableWideColumns, num_keys> results;
+    std::array<Status, num_keys> statuses;
+    constexpr bool sorted_input = false;
+
+    batch_->MultiGetEntityFromBatchAndDB(
+        db_, read_opts_, db_->DefaultColumnFamily(), num_keys, keys.data(),
+        results.data(), statuses.data(), sorted_input);
+
+    for (size_t i = 0; i < num_keys - 1; ++i) {
+      ASSERT_OK(statuses[i]);
+      ASSERT_EQ(results[i].columns(), expected[i]);
+    }
+
+    ASSERT_TRUE(statuses[num_keys - 1].IsNotFound());
+  }
 
   // Iterator
   std::unique_ptr<Iterator> iter(batch_->NewIteratorWithBase(


### PR DESCRIPTION
Summary: As a follow-up to https://github.com/facebook/rocksdb/pull/12533, this PR extends `WriteBatchWithIndex` with a `MultiGetEntityFromBatchAndDB` API that enables users to perform batched wide-column point lookups with read-your-own-writes consistency. This API transparently combines data from the indexed write batch and the underlying database as needed and presents the results in the form of a wide-column entity.

Differential Revision: D56153145


