### PR TITLE
Expose OccValidationPolicy to the Java API

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3115,6 +3115,10 @@ void StressTest::Open(SharedState* shared, bool reopen) {
         } else {
           options_.two_write_queues = FLAGS_two_write_queues;
         }
+        if (FLAGS_use_optimistic_txn) {
+          assert(optimistic_txn_db_->GetValidatePolicy() ==
+                 static_cast<OccValidationPolicy>(FLAGS_occ_validation_policy));
+        }
         txn_db_options.wp_snapshot_cache_bits =
             static_cast<size_t>(FLAGS_wp_snapshot_cache_bits);
         txn_db_options.wp_commit_cache_bits =

--- a/include/rocksdb/utilities/optimistic_transaction_db.h
+++ b/include/rocksdb/utilities/optimistic_transaction_db.h
@@ -118,6 +118,9 @@ class OptimisticTransactionDB : public StackableDB {
           OptimisticTransactionOptions(),
       Transaction* old_txn = nullptr) = 0;
 
+  // Get the OCC Validation Policy specified for this instance.
+  virtual OccValidationPolicy GetValidatePolicy() const = 0;
+
   OptimisticTransactionDB(const OptimisticTransactionDB&) = delete;
   void operator=(const OptimisticTransactionDB&) = delete;
 

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -56,6 +56,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/merge_operator.cc
         rocksjni/native_comparator_wrapper_test.cc
         rocksjni/optimistic_transaction_db.cc
+        rocksjni/optimistic_transaction_db_options.cc
         rocksjni/optimistic_transaction_options.cc
         rocksjni/options.cc
         rocksjni/options_util.cc
@@ -206,9 +207,11 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/MutableOptionValue.java
   src/main/java/org/rocksdb/NativeComparatorWrapper.java
   src/main/java/org/rocksdb/NativeLibraryLoader.java
+  src/main/java/org/rocksdb/OccValidationPolicy.java
   src/main/java/org/rocksdb/OperationStage.java
   src/main/java/org/rocksdb/OperationType.java
   src/main/java/org/rocksdb/OptimisticTransactionDB.java
+  src/main/java/org/rocksdb/OptimisticTransactionDBOptions.java
   src/main/java/org/rocksdb/OptimisticTransactionOptions.java
   src/main/java/org/rocksdb/OptionString.java
   src/main/java/org/rocksdb/Options.java
@@ -366,6 +369,7 @@ set(JAVA_TEST_CLASSES
   src/test/java/org/rocksdb/MutableOptionsGetSetTest.java
   src/test/java/org/rocksdb/NativeLibraryLoaderTest.java
   src/test/java/org/rocksdb/OptimisticTransactionDBTest.java
+  src/test/java/org/rocksdb/OptimisticTransactionOptionsDBTest.java
   src/test/java/org/rocksdb/OptimisticTransactionOptionsTest.java
   src/test/java/org/rocksdb/OptimisticTransactionTest.java
   src/test/java/org/rocksdb/OptionsTest.java
@@ -485,6 +489,7 @@ set(JAVA_TEST_RUNNING_CLASSES
   org.rocksdb.NativeComparatorWrapperTest
   org.rocksdb.NativeLibraryLoaderTest
   org.rocksdb.OptimisticTransactionDBTest
+  org.rocksdb.OptimisticTransactionOptionsDBTest
   org.rocksdb.OptimisticTransactionOptionsTest
   org.rocksdb.OptimisticTransactionTest
   org.rocksdb.OptionsTest

--- a/java/Makefile
+++ b/java/Makefile
@@ -165,6 +165,7 @@ JAVA_TESTS = \
 	org.rocksdb.NativeLibraryLoaderTest\
 	org.rocksdb.OptimisticTransactionTest\
 	org.rocksdb.OptimisticTransactionDBTest\
+	org.rocksdb.OptimisticTransactionOptionsDBTest\
 	org.rocksdb.OptimisticTransactionOptionsTest\
 	org.rocksdb.OptionsUtilTest\
 	org.rocksdb.OptionsTest\

--- a/java/rocksjni/optimistic_transaction_db_options.cc
+++ b/java/rocksjni/optimistic_transaction_db_options.cc
@@ -1,0 +1,93 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the "bridge" between Java and C++
+// for ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions.
+
+#include <jni.h>
+
+#include "include/org_rocksdb_OptimisticTransactionOptions.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/utilities/optimistic_transaction_db.h"
+#include "rocksjni/cplusplus_to_java_convert.h"
+#include "rocksjni/portal.h"
+
+/*
+ * Class:     org_rocksdb_OptimisticTransactionDBOptions
+ * Method:    newOptimisticTransactionDBOptions
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_OptimisticTransactionDBOptions_newOptimisticTransactionDBOptions(
+    JNIEnv* /*env*/, jclass /*jcls*/) {
+  ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions* opts =
+      new ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions();
+  return GET_CPLUSPLUS_POINTER(opts);
+}
+
+/*
+ * Class:     org_rocksdb_OptimisticTransactionDBOptions
+ * Method:    setOccValidationPolicy
+ * Signature: (JB)V
+ */
+void Java_org_rocksdb_OptimisticTransactionDBOptions_setOccValidationPolicy(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jbyte policy) {
+  auto* opts =
+      reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions*>(
+          jhandle);
+  opts->validate_policy =
+      ROCKSDB_NAMESPACE::OccValidationPolicyJni::toCppOccValidationPolicy(
+          policy);
+}
+
+/*
+ * Class:     org_rocksdb_OptimisticTransactionDBOptions
+ * Method:    getOccValidationPolicy
+ * Signature: (J)B
+ */
+jbyte Java_org_rocksdb_OptimisticTransactionDBOptions_getOccValidationPolicy(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
+  auto* opts =
+      reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions*>(
+          jhandle);
+  return ROCKSDB_NAMESPACE::OccValidationPolicyJni::toJavaOccValidationPolicy(
+      opts->validate_policy);
+}
+
+/*
+ * Class:     org_rocksdb_OptimisticTransactionDBOptions
+ * Method:    setOccValidationPolicy
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_OptimisticTransactionDBOptions_setOccLockBuckets(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle, jlong occ_lock_buckets) {
+  auto* opts =
+      reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions*>(
+          jhandle);
+  opts->occ_lock_buckets = static_cast<uint32_t>(occ_lock_buckets);
+}
+
+/*
+ * Class:     org_rocksdb_OptimisticTransactionDBOptions
+ * Method:    getOccValidationPolicy
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_OptimisticTransactionDBOptions_getOccLockBuckets(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
+  auto* opts =
+      reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions*>(
+          jhandle);
+  return static_cast<long>(opts->occ_lock_buckets);
+}
+
+/*
+ * Class:     org_rocksdb_OptimisticTransactionDBOptions
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_OptimisticTransactionDBOptions_disposeInternalJni(
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
+  delete reinterpret_cast<ROCKSDB_NAMESPACE::OptimisticTransactionDBOptions*>(
+      jhandle);
+}

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -33,6 +33,7 @@
 #include "rocksdb/table.h"
 #include "rocksdb/utilities/backup_engine.h"
 #include "rocksdb/utilities/memory_util.h"
+#include "rocksdb/utilities/optimistic_transaction_db.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
 #include "rocksjni/compaction_filter_factory_jnicallback.h"
@@ -6356,6 +6357,31 @@ class TransactionDBJni : public JavaClass {
     }
 
     return jdeadlock_info;
+  }
+};
+// The portal class for org.rocksdb.OccValidationPolicy.
+class OccValidationPolicyJni {
+ public:
+  static jbyte toJavaOccValidationPolicy(
+      const ROCKSDB_NAMESPACE::OccValidationPolicy policy) {
+    switch (policy) {
+      case ROCKSDB_NAMESPACE::OccValidationPolicy::kValidateSerial:
+        return 0x0;
+      case ROCKSDB_NAMESPACE::OccValidationPolicy::kValidateParallel:
+      default:
+        return 0x1;
+    }
+  }
+
+  static ROCKSDB_NAMESPACE::OccValidationPolicy toCppOccValidationPolicy(
+      const jbyte policy) {
+    switch (policy) {
+      case 0x0:
+        return ROCKSDB_NAMESPACE::OccValidationPolicy::kValidateSerial;
+      case 0x1:
+      default:
+        return ROCKSDB_NAMESPACE::OccValidationPolicy::kValidateParallel;
+    }
   }
 };
 

--- a/java/src/main/java/org/rocksdb/OccValidationPolicy.java
+++ b/java/src/main/java/org/rocksdb/OccValidationPolicy.java
@@ -1,0 +1,65 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Defines the policy for optimistic concurrency control validation.
+ * This enum specifies the manner in which the validation occurs
+ * during the commit stage.
+ */
+public enum OccValidationPolicy {
+  /**
+   * Validate serially at commit stage, AFTER entering the write-group.
+   * This method processes isolation validation in a single-threaded manner
+   * within the write-group, potentially suffering from high mutex contention
+   * as discussed in the following issue:
+   * <a href="https://github.com/facebook/rocksdb/issues/4402">GitHub 4402</a>
+   */
+  VALIDATE_SERIAL((byte) 0),
+
+  /**
+   * Validate parallelly before the commit stage, BEFORE entering the write-group.
+   * This approach aims to reduce mutex contention by having each
+   * transaction acquire locks for its write-set records in a well-defined
+   * order prior to entering the write-group.
+   */
+  VALIDATE_PARALLEL((byte) 1);
+
+  private final byte _value;
+
+  /**
+   * Constructor for the OccValidationPolicy enum.
+   * @param _value the byte representation that corresponds to
+   *               one of the above enums.
+   */
+  OccValidationPolicy(final byte _value) {
+    this._value = _value;
+  }
+
+  /**
+   * Retrieves the byte representation associated with this validation policy.
+   * @return the byte representation of the validation policy.
+   */
+  public byte getValue() {
+    return _value;
+  }
+
+  /**
+   * Given a byte representation of a value, convert it to {@link OccValidationPolicy}.
+   *
+   * @param policy the byte representation of the policy.
+   * @return the matching OccValidationPolicy.
+   * @throws IllegalArgumentException if no matching policy is found.
+   */
+  public static OccValidationPolicy getOccValidationPolicy(final byte policy) {
+    for (OccValidationPolicy value : OccValidationPolicy.values()) {
+      if (value.getValue() == policy) {
+        return value;
+      }
+    }
+    throw new IllegalArgumentException("Unknown OccValidationPolicy constant : " + policy);
+  }
+}

--- a/java/src/main/java/org/rocksdb/OptimisticTransactionDBOptions.java
+++ b/java/src/main/java/org/rocksdb/OptimisticTransactionDBOptions.java
@@ -1,0 +1,89 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Used to control the Optimistic Concurrency Control (OCC) aspect of a database.
+ * It will be used during the creation of a
+ * {@link org.rocksdb.OptimisticTransactionDB} (i.e., OptimisticTransactionDB.open()).
+ * <p>
+ * As a descendent of {@link AbstractNativeReference}, this class is {@link AutoCloseable}
+ * and will be automatically released if opened in the preamble of a try with resources block.
+ */
+public class OptimisticTransactionDBOptions extends RocksObject {
+  public OptimisticTransactionDBOptions() {
+    super(newOptimisticTransactionOptions());
+  }
+
+  /**
+   * Set OccValidationPolicy for this instance.
+   * See {@link OccValidationPolicy}.
+   *
+   * @param policy The type of OCC Validation Policy
+   *
+   * @return this OptimisticTransactionOptions instance
+   */
+  public OptimisticTransactionDBOptions setOccValidationPolicy(final OccValidationPolicy policy) {
+    assert (isOwningHandle());
+    setOccValidationPolicy(nativeHandle_, policy.getValue());
+    return this;
+  }
+
+  /**
+   * Get OccValidationPolicy for this instance.
+   * See {@link OccValidationPolicy}.
+   *
+   * @return The type of OCC Validation Policy used.
+   */
+  public OccValidationPolicy occValidationPolicy() {
+    assert (isOwningHandle());
+    return OccValidationPolicy.getOccValidationPolicy(occValidationPolicy(getNativeHandle()));
+  }
+
+  /**
+   * Number of striped/bucketed mutex locks for validating transactions.
+   * Used on only if validate_policy == {@link OccValidationPolicy}::VALIDATE_PARALLEL
+   * and shared_lock_buckets (below) is empty. Larger number potentially
+   * reduces contention but uses more memory.
+   *
+   * @param occLongBuckets Number of striped/bucketed mutex locks.
+   *
+   * @return this OptimisticTransactionOptions instance
+   */
+  public OptimisticTransactionDBOptions setOccLockBuckets(final long occLongBuckets) {
+    assert (isOwningHandle());
+    setOccLockBuckets(nativeHandle_, occLongBuckets);
+    return this;
+  }
+
+  /**
+   * Get the number of striped/bucketed mutex locks for validating transactions.
+   * Used on only if validate_policy == {@link OccValidationPolicy}::VALIDATE_PARALLEL
+   * and shared_lock_buckets (below) is empty. Larger number potentially
+   * reduces contention but uses more memory.
+   **
+   * @return Number of striped/bucketed mutex locks.
+   */
+  public long getOccLockBuckets() {
+    assert (isOwningHandle());
+    return getOccLockBuckets(nativeHandle_);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected final void disposeInternal(final long handle) {
+    disposeInternalJni(handle);
+  }
+
+  private static native long newOptimisticTransactionOptions();
+  private static native void setOccValidationPolicy(final long handle, final byte policy);
+  private static native byte occValidationPolicy(final long handle);
+  private static native void setOccLockBuckets(final long handle, final long occLongBuckets);
+  private static native byte getOccLockBuckets(final long handle);
+  private static native void disposeInternalJni(final long handle);
+}

--- a/java/src/test/java/org/rocksdb/OptimisticTransactionOptionsDBTest.java
+++ b/java/src/test/java/org/rocksdb/OptimisticTransactionOptionsDBTest.java
@@ -1,0 +1,41 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Random;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OptimisticTransactionOptionsDBTest {
+  private static final Random rand = PlatformRandomHelper.getPlatformSpecificRandomFactory();
+
+  @BeforeClass
+  public static void beforeAll() {
+    RocksDB.loadLibrary();
+  }
+
+  @Test
+  public void lockBucketCount() {
+    try (final OptimisticTransactionDBOptions options = new OptimisticTransactionDBOptions()) {
+      final long lockBucketCount = rand.nextInt(Integer.MAX_VALUE) + 1;
+      options.setOccLockBuckets(lockBucketCount);
+      assertThat(options.getOccLockBuckets()).isEqualTo(lockBucketCount);
+    }
+  }
+
+  @Test
+  public void setOccValidationPolicy() {
+    try (final OptimisticTransactionDBOptions options = new OptimisticTransactionDBOptions()) {
+      options.setOccValidationPolicy(OccValidationPolicy.VALIDATE_SERIAL);
+      assertThat(options.occValidationPolicy()).isEqualTo(OccValidationPolicy.VALIDATE_SERIAL);
+
+      options.setOccValidationPolicy(OccValidationPolicy.VALIDATE_PARALLEL);
+      assertThat(options.occValidationPolicy()).isEqualTo(OccValidationPolicy.VALIDATE_PARALLEL);
+    }
+  }
+}

--- a/src.mk
+++ b/src.mk
@@ -687,6 +687,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/merge_operator.cc                             \
   java/rocksjni/native_comparator_wrapper_test.cc             \
   java/rocksjni/optimistic_transaction_db.cc                  \
+  java/rocksjni/optimistic_transaction_db_options.cc          \
   java/rocksjni/optimistic_transaction_options.cc             \
   java/rocksjni/options.cc                                    \
   java/rocksjni/options_util.cc                               \

--- a/utilities/transactions/optimistic_transaction_db_impl.h
+++ b/utilities/transactions/optimistic_transaction_db_impl.h
@@ -88,7 +88,9 @@ class OptimisticTransactionDBImpl : public OptimisticTransactionDB {
     return OptimisticTransactionDB::Write(write_opts, batch);
   }
 
-  OccValidationPolicy GetValidatePolicy() const { return validate_policy_; }
+  OccValidationPolicy GetValidatePolicy() const override {
+    return validate_policy_;
+  }
 
   port::Mutex& GetLockBucket(const Slice& key, uint64_t seed) {
     return bucketed_locks_->GetLockBucket(key, seed);


### PR DESCRIPTION
Allow users of RocksDB JNI to specify the OCC Validation Policy when using OptimisticTransactionOptionsDB.