### PR TITLE
MultiCfIterator - Tests for lower/upper bounds

### DIFF
--- a/db/multi_cf_iterator_impl.h
+++ b/db/multi_cf_iterator_impl.h
@@ -139,8 +139,6 @@ class MultiCfIteratorImpl {
   std::function<void()> reset_func_;
   std::function<void(autovector<MultiCfIteratorInfo>)> populate_func_;
 
-  // TODO: Lower and Upper bounds
-
   Iterator* current() const {
     if (std::holds_alternative<MultiCfMaxHeap>(heap_)) {
       auto& max_heap = std::get<MultiCfMaxHeap>(heap_);


### PR DESCRIPTION
# Summary

Thanks to how we are using `DBIter` as child iterators in MultiCfIterators (both `CoalescingIterator` and `AttributeGroupIterator`), we got the lower/upper bound feature for free. This PR simply adds unit test coverage to ensure that the lower/upper bounds are working as expected in the MultiCfIterators.

# Test Plan

UnitTest Added
```
./multi_cf_iterator_test
```