### PR TITLE
Add TimedPut to stress test

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -769,7 +769,9 @@ Status DBTestBase::TimedPut(const Slice& k, const Slice& v,
 
 Status DBTestBase::TimedPut(int cf, const Slice& k, const Slice& v,
                             uint64_t write_unix_time, WriteOptions wo) {
-  WriteBatch wb;
+  WriteBatch wb(/*reserved_bytes=*/0, /*max_bytes=*/0,
+                wo.protection_bytes_per_key,
+                /*default_cf_ts_sz=*/0);
   ColumnFamilyHandle* cfh;
   if (cf != 0) {
     cfh = handles_[cf];

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -56,7 +56,8 @@ class BatchedOpsStressTest : public StressTest {
           (value_base % FLAGS_use_put_entity_one_in) == 0) {
         status = batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
       } else if (FLAGS_use_timed_put_one_in > 0 &&
-                 (value_base % FLAGS_use_timed_put_one_in) == 0) {
+                 ((value_base + kLargePrimeForCommonFactorSkew) %
+                  FLAGS_use_timed_put_one_in) == 0) {
         uint64_t write_unix_time = GetWriteUnixTime(thread);
         status = batch.TimedPut(cfh, k, v, write_unix_time);
       } else if (FLAGS_use_merge) {

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -42,6 +42,7 @@ class BatchedOpsStressTest : public StressTest {
     ColumnFamilyHandle* const cfh = column_families_[rand_column_families[0]];
     assert(cfh);
 
+    Status status;
     for (int i = 9; i >= 0; --i) {
       const std::string num = std::to_string(i);
 
@@ -51,28 +52,36 @@ class BatchedOpsStressTest : public StressTest {
       // batched, non-batched, CF consistency).
       const std::string k = num + key_body;
       const std::string v = value_body + num;
-
       if (FLAGS_use_put_entity_one_in > 0 &&
           (value_base % FLAGS_use_put_entity_one_in) == 0) {
-        batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
+        status = batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
+      } else if (FLAGS_use_timed_put_one_in > 0 &&
+                 (value_base % FLAGS_use_timed_put_one_in) == 0) {
+        uint64_t write_unix_time = GetWriteUnixTime(thread);
+        status = batch.TimedPut(cfh, k, v, write_unix_time);
       } else if (FLAGS_use_merge) {
-        batch.Merge(cfh, k, v);
+        status = batch.Merge(cfh, k, v);
       } else {
-        batch.Put(cfh, k, v);
+        status = batch.Put(cfh, k, v);
+      }
+      if (!status.ok()) {
+        break;
       }
     }
 
-    const Status s = db_->Write(write_opts, &batch);
+    if (status.ok()) {
+      status = db_->Write(write_opts, &batch);
+    }
 
-    if (!s.ok()) {
-      fprintf(stderr, "multiput error: %s\n", s.ToString().c_str());
+    if (!status.ok()) {
+      fprintf(stderr, "multiput error: %s\n", status.ToString().c_str());
       thread->stats.AddErrors(1);
     } else {
       // we did 10 writes each of size sz + 1
       thread->stats.AddBytesForWrites(10, (sz + 1) * 10);
     }
 
-    return s;
+    return status;
   }
 
   // Given a key K, this deletes ("0"+K), ("1"+K), ..., ("9"+K)

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -45,7 +45,8 @@ class CfConsistencyStressTest : public StressTest {
           (value_base % FLAGS_use_put_entity_one_in) == 0) {
         status = batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
       } else if (FLAGS_use_timed_put_one_in > 0 &&
-                 (value_base % FLAGS_use_timed_put_one_in) == 0) {
+                 ((value_base + kLargePrimeForCommonFactorSkew) %
+                  FLAGS_use_timed_put_one_in) == 0) {
         uint64_t write_unix_time = GetWriteUnixTime(thread);
         status = batch.TimedPut(cfh, k, v, write_unix_time);
       } else if (FLAGS_use_merge) {

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -36,31 +36,42 @@ class CfConsistencyStressTest : public StressTest {
 
     WriteBatch batch;
 
+    Status status;
     for (auto cf : rand_column_families) {
       ColumnFamilyHandle* const cfh = column_families_[cf];
       assert(cfh);
 
       if (FLAGS_use_put_entity_one_in > 0 &&
           (value_base % FLAGS_use_put_entity_one_in) == 0) {
-        batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
+        status = batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
+      } else if (FLAGS_use_timed_put_one_in > 0 &&
+                 (value_base % FLAGS_use_timed_put_one_in) == 0) {
+        uint64_t write_unix_time = GetWriteUnixTime(thread);
+        status = batch.TimedPut(cfh, k, v, write_unix_time);
       } else if (FLAGS_use_merge) {
-        batch.Merge(cfh, k, v);
+        status = batch.Merge(cfh, k, v);
       } else {
-        batch.Put(cfh, k, v);
+        status = batch.Put(cfh, k, v);
+      }
+      if (!status.ok()) {
+        break;
       }
     }
 
-    Status s = db_->Write(write_opts, &batch);
+    if (status.ok()) {
+      status = db_->Write(write_opts, &batch);
+    }
 
-    if (!s.ok()) {
-      fprintf(stderr, "multi put or merge error: %s\n", s.ToString().c_str());
+    if (!status.ok()) {
+      fprintf(stderr, "multi put or merge error: %s\n",
+              status.ToString().c_str());
       thread->stats.AddErrors(1);
     } else {
       auto num = static_cast<long>(rand_column_families.size());
       thread->stats.AddBytesForWrites(num, (sz + 1) * num);
     }
 
-    return s;
+    return status;
   }
 
   Status TestDelete(ThreadState* thread, WriteOptions& write_opts,

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -402,7 +402,11 @@ uint64_t GetWriteUnixTime(ThreadState* thread) {
   if (write_time_mode == 0 || !s.ok()) {
     return kFallbackTime;
   } else if (write_time_mode == 1) {
-    return static_cast<uint64_t>(write_time);
+    uint64_t delta = kPreserveSeconds > 0
+                         ? static_cast<uint64_t>(thread->rand.Uniform(
+                               static_cast<int>(kPreserveSeconds)))
+                         : 0;
+    return static_cast<uint64_t>(write_time) - delta;
   } else {
     return static_cast<uint64_t>(write_time) - kPreserveSeconds;
   }

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -391,6 +391,23 @@ std::string GetNowNanos() {
   return ret;
 }
 
+uint64_t GetWriteUnixTime(ThreadState* thread) {
+  static uint64_t kPreserveSeconds =
+      std::max(FLAGS_preserve_internal_time_seconds,
+               FLAGS_preclude_last_level_data_seconds);
+  static uint64_t kFallbackTime = std::numeric_limits<uint64_t>::max();
+  int64_t write_time = 0;
+  Status s = db_stress_env->GetCurrentTime(&write_time);
+  uint32_t write_time_mode = thread->rand.Uniform(3);
+  if (write_time_mode == 0 || !s.ok()) {
+    return kFallbackTime;
+  } else if (write_time_mode == 1) {
+    return static_cast<uint64_t>(write_time);
+  } else {
+    return static_cast<uint64_t>(write_time) - kPreserveSeconds;
+  }
+}
+
 namespace {
 
 class MyXXH64Checksum : public FileChecksumGenerator {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -351,6 +351,7 @@ DECLARE_uint32(bottommost_file_compaction_delay);
 // Tiered storage
 DECLARE_int64(preclude_last_level_data_seconds);
 DECLARE_int64(preserve_internal_time_seconds);
+DECLARE_uint32(use_timed_put_one_in);
 
 DECLARE_int32(verify_iterator_with_expected_state_one_in);
 DECLARE_bool(preserve_unverified_changes);
@@ -765,6 +766,8 @@ void InitializeHotKeyGenerator(double alpha);
 int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);
 
 std::string GetNowNanos();
+
+uint64_t GetWriteUnixTime(ThreadState* thread);
 
 std::shared_ptr<FileChecksumGenFactory> GetFileChecksumImpl(
     const std::string& name);

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -415,6 +415,7 @@ DECLARE_bool(inplace_update_support);
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;
 constexpr int kValueMaxLen = 100;
+constexpr uint32_t kLargePrimeForCommonFactorSkew = 1872439133;
 
 // wrapped posix environment
 extern ROCKSDB_NAMESPACE::Env* db_stress_env;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -534,6 +534,11 @@ DEFINE_int64(
     preserve_internal_time_seconds, 0,
     "Preserve internal time information which is attached to each SST.");
 
+DEFINE_uint32(use_timed_put_one_in, 0,
+              "If greater than zero, TimedPut is used per every N write ops on "
+              "on average. (N is an approximation, the actual average would be "
+              "higher when use_put_entity_one_in is also enabled)");
+
 static const bool FLAGS_subcompactions_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_subcompactions, &ValidateUint32Range);
 
@@ -934,7 +939,8 @@ DEFINE_bool(use_merge, false,
 
 DEFINE_uint32(use_put_entity_one_in, 0,
               "If greater than zero, PutEntity will be used once per every N "
-              "write ops on average.");
+              "write ops on average. (N is an approximation, the actual average"
+              "would be higher when use_timed_put_one_in is also enabled)");
 
 DEFINE_bool(use_full_merge_v1, false,
             "On true, use a merge operator that implement the deprecated "

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -536,8 +536,7 @@ DEFINE_int64(
 
 DEFINE_uint32(use_timed_put_one_in, 0,
               "If greater than zero, TimedPut is used per every N write ops on "
-              "on average. (N is an approximation, the actual average would be "
-              "higher when use_put_entity_one_in is also enabled)");
+              "on average.");
 
 static const bool FLAGS_subcompactions_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_subcompactions, &ValidateUint32Range);
@@ -939,8 +938,7 @@ DEFINE_bool(use_merge, false,
 
 DEFINE_uint32(use_put_entity_one_in, 0,
               "If greater than zero, PutEntity will be used once per every N "
-              "write ops on average. (N is an approximation, the actual average"
-              "would be higher when use_timed_put_one_in is also enabled)");
+              "write ops on average.");
 
 DEFINE_bool(use_full_merge_v1, false,
             "On true, use a merge operator that implement the deprecated "

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1304,6 +1304,14 @@ class NonBatchedOpsStressTest : public StressTest {
         (value_base % FLAGS_use_put_entity_one_in) == 0) {
       s = db_->PutEntity(write_opts, cfh, k,
                          GenerateWideColumns(value_base, v));
+    } else if (FLAGS_use_timed_put_one_in > 0 &&
+               (value_base % FLAGS_use_timed_put_one_in) == 0) {
+      WriteBatch wb;
+      uint64_t write_unix_time = GetWriteUnixTime(thread);
+      s = wb.TimedPut(cfh, k, v, write_unix_time);
+      if (s.ok()) {
+        s = db_->Write(write_opts, &wb);
+      }
     } else if (FLAGS_use_merge) {
       if (!FLAGS_use_txn) {
         if (FLAGS_user_timestamp_size == 0) {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1305,7 +1305,8 @@ class NonBatchedOpsStressTest : public StressTest {
       s = db_->PutEntity(write_opts, cfh, k,
                          GenerateWideColumns(value_base, v));
     } else if (FLAGS_use_timed_put_one_in > 0 &&
-               (value_base % FLAGS_use_timed_put_one_in) == 0) {
+               ((value_base + kLargePrimeForCommonFactorSkew) %
+                FLAGS_use_timed_put_one_in) == 0) {
       WriteBatch wb;
       uint64_t write_unix_time = GetWriteUnixTime(thread);
       s = wb.TimedPut(cfh, k, v, write_unix_time);


### PR DESCRIPTION
This also updates WriteBatch's protection info to include write time since there are several places in memtable that by default protects the whole value slice.
