### PR TITLE
Reset user-facing wide-column stuctures upon deserialization failures

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -231,6 +231,7 @@ bool DBIter::SetValueAndColumnsFromEntity(Slice slice) {
   if (!s.ok()) {
     status_ = s;
     valid_ = false;
+    wide_columns_.clear();
     return false;
   }
 

--- a/include/rocksdb/wide_columns.h
+++ b/include/rocksdb/wide_columns.h
@@ -144,6 +144,11 @@ class PinnableWideColumns {
   WideColumns columns_;
 };
 
+inline void PinnableWideColumns::Reset() {
+  value_.Reset();
+  columns_.clear();
+}
+
 inline void PinnableWideColumns::Move(PinnableWideColumns&& other) {
   assert(columns_.empty());
 
@@ -228,28 +233,47 @@ inline void PinnableWideColumns::SetPlainValue(std::string&& value) {
 
 inline Status PinnableWideColumns::SetWideColumnValue(const Slice& value) {
   CopyValue(value);
-  return CreateIndexForWideColumns();
+
+  const Status s = CreateIndexForWideColumns();
+  if (!s.ok()) {
+    Reset();
+  }
+
+  return s;
 }
 
 inline Status PinnableWideColumns::SetWideColumnValue(const Slice& value,
                                                       Cleanable* cleanable) {
   PinOrCopyValue(value, cleanable);
-  return CreateIndexForWideColumns();
+
+  const Status s = CreateIndexForWideColumns();
+  if (!s.ok()) {
+    Reset();
+  }
+
+  return s;
 }
 
 inline Status PinnableWideColumns::SetWideColumnValue(PinnableSlice&& value) {
   MoveValue(std::move(value));
-  return CreateIndexForWideColumns();
+
+  const Status s = CreateIndexForWideColumns();
+  if (!s.ok()) {
+    Reset();
+  }
+
+  return s;
 }
 
 inline Status PinnableWideColumns::SetWideColumnValue(std::string&& value) {
   MoveValue(std::move(value));
-  return CreateIndexForWideColumns();
-}
 
-inline void PinnableWideColumns::Reset() {
-  value_.Reset();
-  columns_.clear();
+  const Status s = CreateIndexForWideColumns();
+  if (!s.ok()) {
+    Reset();
+  }
+
+  return s;
 }
 
 inline PinnableWideColumns::PinnableWideColumns(PinnableWideColumns&& other) {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -281,6 +281,7 @@ void BaseDeltaIterator::SetValueAndColumnsFromDelta() {
 
       status_ = WideColumnSerialization::Deserialize(value_copy, columns_);
       if (!status_.ok()) {
+        columns_.clear();
         return;
       }
 
@@ -340,6 +341,7 @@ void BaseDeltaIterator::SetValueAndColumnsFromDelta() {
 
     status_ = WideColumnSerialization::Deserialize(entity, columns_);
     if (!status_.ok()) {
+      columns_.clear();
       return;
     }
 


### PR DESCRIPTION
Summary: The patch makes a small usability improvement by consistently resetting any user-facing wide-column structures (`DBIter::columns()`, `BaseDeltaIterator::columns()`, and any `PinnableWideColumns` objects) upon encountering any deserialization failures.

Differential Revision: D56312764


