### PR TITLE
Fix scan-build path

### DIFF
--- a/build_tools/fbcode_config.sh
+++ b/build_tools/fbcode_config.sh
@@ -113,7 +113,7 @@ CLANG_LIB="$CLANG_BASE/lib"
 CLANG_SRC="$CLANG_BASE/../../src"
 
 CLANG_ANALYZER="$CLANG_BIN/clang++"
-CLANG_SCAN_BUILD="$CLANG_SRC/llvm/tools/clang/tools/scan-build/bin/scan-build"
+CLANG_SCAN_BUILD="$CLANG_BIN/scan-build
 
 if [ -z "$USE_CLANG" ]; then
   # gcc

--- a/build_tools/fbcode_config_platform010.sh
+++ b/build_tools/fbcode_config_platform010.sh
@@ -110,7 +110,7 @@ CLANG_LIB="$CLANG_BASE/lib"
 CLANG_SRC="$CLANG_BASE/../../src"
 
 CLANG_ANALYZER="$CLANG_BIN/clang++"
-CLANG_SCAN_BUILD="$CLANG_SRC/llvm/clang/tools/scan-build/bin/scan-build"
+CLANG_SCAN_BUILD="$CLANG_BIN/scan-build"
 
 if [ -z "$USE_CLANG" ]; then
   # gcc


### PR DESCRIPTION
# Summary

As title

# Test Plan
```
make -j64 release
```

**Before the fix**
```
$DEBUG_LEVEL is 0, $LIB_MODE is static
Makefile:306: Warning: /mnt/gvfs/third-party2/llvm-fb/1f6edd1ff15c99c861afc8f3cd69054cd974dd64/15/platform010/72a2ff8/../../src/llvm/clang/tools/scan-build/bin/scan-build does not exist
...
```

**After the fix**
```
$DEBUG_LEVEL is 0, $LIB_MODE is static
...
```