### PR TITLE
Sanity check the keys parameter in MultiGetEntityFromBatchAndDB

### DIFF
--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -1005,6 +1005,8 @@ void WriteBatchWithIndex::MultiGetEntityFromBatchAndDB(
     DB* db, const ReadOptions& read_options, ColumnFamilyHandle* column_family,
     size_t num_keys, const Slice* keys, PinnableWideColumns* results,
     Status* statuses, bool sorted_input) {
+  assert(statuses);
+
   if (!db) {
     for (size_t i = 0; i < num_keys; ++i) {
       statuses[i] = Status::InvalidArgument(
@@ -1029,12 +1031,18 @@ void WriteBatchWithIndex::MultiGetEntityFromBatchAndDB(
     return;
   }
 
+  if (!keys) {
+    for (size_t i = 0; i < num_keys; ++i) {
+      statuses[i] = Status::InvalidArgument(
+          "Cannot call MultiGetEntityFromBatchAndDB without keys");
+    }
+  }
+
   if (!results) {
     for (size_t i = 0; i < num_keys; ++i) {
       statuses[i] = Status::InvalidArgument(
           "Cannot call MultiGetEntityFromBatchAndDB without "
-          "PinnableWideColumns "
-          "objects");
+          "PinnableWideColumns objects");
     }
   }
 


### PR DESCRIPTION
Summary: Similarly to how `db`, `column_family`, and `results` are handled, bail out early from `WriteBatchWithIndex::MultiGetEntityFromBatchAndDB` if `keys` is `nullptr`. Note that these checks are best effort in the sense that with the current method signature, the callee has no way of reporting an error if `statuses` is `nullptr` or catching other types of invalid pointers (e.g. when `keys` and/or `results` is non-`nullptr` but do not point to a contiguous range of `num_keys` objects). We can improve this (and many similar RocksDB APIs) using `std::span` in a major release once we move to C++20.

Differential Revision: D56318179


