### PR TITLE
MultipleIteratorsConsistentViewTest to verify current behavior

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3844,6 +3844,8 @@ Status DBImpl::NewIterators(
     auto cfh = static_cast_with_check<ColumnFamilyHandleImpl>(cf);
     auto cfd = cfh->cfd();
     SuperVersion* sv = cfd->GetReferencedSuperVersion(this);
+    TEST_SYNC_POINT("DBImpl::NewIterators::AfterRefSV:0");
+    TEST_SYNC_POINT("DBImpl::NewIterators::AfterRefSV:1");
     cfh_to_sv.emplace_back(cfh, sv);
     if (check_read_ts) {
       const Status s =


### PR DESCRIPTION
# Summary

As described in #12561, the `NewIterators()` API does not currently guarantee a consistent view across CFs. This PR includes a unit test to verify the existing behavior. A subsequent PR will address the API fix and modify the test to verify the expected behavior after the fix.

# Test Plan

```
./db_iterator_test --gtest_filter="*MultipleIteratorsConsistentViewTest*"
```