### PR TITLE
Fix IteratorsConsistentView tests

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2643,6 +2643,7 @@ Status DBImpl::MultiCFSnapshot(const ReadOptions& read_options,
             break;
           }
         }
+        TEST_SYNC_POINT("DBImpl::MultiCFSnapshot::BeforeCheckingSnapshot");
         if (read_options.snapshot != nullptr || last_try) {
           // If user passed a snapshot, then we don't care if a memtable is
           // sealed or compaction happens because the snapshot would ensure

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -3566,17 +3566,18 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewImplicitSnapshot) {
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::BGWorkFlush:done",
-        "DBImpl::MultiCFSnapshot::AfterGetSeqNum1"}});
+        "DBImpl::MultiCFSnapshot::BeforeCheckingSnapshot"}});
 
   bool flushed = false;
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::MultiCFSnapshot::AfterRefSV", [&](void* /*arg*/) {
         if (!flushed) {
           for (int i = 0; i < 3; ++i) {
-            ASSERT_OK(Flush(i));
             ASSERT_OK(Put(i, "cf" + std::to_string(i) + "_key",
                           "cf" + std::to_string(i) + "_val_new"));
           }
+          // After SV is obtained for the first CF, flush for the second CF
+          ASSERT_OK(Flush(1));
           flushed = true;
         }
       });
@@ -3600,7 +3601,6 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewImplicitSnapshot) {
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVObsolete);
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVInUse);
   }
-
   for (auto* iter : iters) {
     delete iter;
   }
@@ -3608,6 +3608,7 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewImplicitSnapshot) {
 
 TEST_F(DBIteratorTest, IteratorsConsistentViewExplicitSnapshot) {
   Options options = GetDefaultOptions();
+  options.atomic_flush = true;
   CreateAndReopenWithCF({"cf_1", "cf_2"}, options);
 
   for (int i = 0; i < 3; ++i) {
@@ -3617,17 +3618,18 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewExplicitSnapshot) {
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::BGWorkFlush:done",
-        "DBImpl::MultiCFSnapshot::AfterGetSeqNum1"}});
+        "DBImpl::MultiCFSnapshot::BeforeCheckingSnapshot"}});
 
   bool flushed = false;
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::MultiCFSnapshot::AfterRefSV", [&](void* /*arg*/) {
         if (!flushed) {
           for (int i = 0; i < 3; ++i) {
-            ASSERT_OK(Flush(i));
             ASSERT_OK(Put(i, "cf" + std::to_string(i) + "_key",
                           "cf" + std::to_string(i) + "_val_new"));
           }
+          // After SV is obtained for the first CF, do the atomic flush()
+          ASSERT_OK(Flush());
           flushed = true;
         }
       });
@@ -3648,8 +3650,8 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewExplicitSnapshot) {
                                     std::to_string(i) + "_val");
   }
 
-  // Thread-local SV for cf_0 is obsolete (flush happened after the first SV
-  // Ref)
+  // Thread-local SV for cf_0 is obsolete (atomic flush happened after the first
+  // SV Ref)
   auto* cfd0 =
       static_cast_with_check<ColumnFamilyHandleImpl>(handles_[0])->cfd();
   ASSERT_EQ(cfd0->TEST_GetLocalSV()->Get(), SuperVersion::kSVObsolete);

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -3593,6 +3593,9 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewImplicitSnapshot) {
     ASSERT_EQ(IterStatus(iter), "cf" + std::to_string(i) + "_key->cf" +
                                     std::to_string(i) + "_val_new");
   }
+  for (auto* iter : iters) {
+    delete iter;
+  }
 
   // Thread-local SVs are no longer obsolete nor in use
   for (int i = 0; i < 3; ++i) {
@@ -3600,9 +3603,6 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewImplicitSnapshot) {
         static_cast_with_check<ColumnFamilyHandleImpl>(handles_[i])->cfd();
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVObsolete);
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVInUse);
-  }
-  for (auto* iter : iters) {
-    delete iter;
   }
 }
 
@@ -3649,6 +3649,10 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewExplicitSnapshot) {
     ASSERT_EQ(IterStatus(iter), "cf" + std::to_string(i) + "_key->cf" +
                                     std::to_string(i) + "_val");
   }
+  db_->ReleaseSnapshot(snapshot);
+  for (auto* iter : iters) {
+    delete iter;
+  }
 
   // Thread-local SV for cf_0 is obsolete (atomic flush happened after the first
   // SV Ref)
@@ -3663,11 +3667,6 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewExplicitSnapshot) {
         static_cast_with_check<ColumnFamilyHandleImpl>(handles_[i])->cfd();
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVObsolete);
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVInUse);
-  }
-
-  db_->ReleaseSnapshot(snapshot);
-  for (auto* iter : iters) {
-    delete iter;
   }
 }
 

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -3592,9 +3592,6 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewImplicitSnapshot) {
     ASSERT_EQ(IterStatus(iter), "cf" + std::to_string(i) + "_key->cf" +
                                     std::to_string(i) + "_val_new");
   }
-  for (auto* iter : iters) {
-    delete iter;
-  }
 
   // Thread-local SVs are no longer obsolete nor in use
   for (int i = 0; i < 3; ++i) {
@@ -3602,6 +3599,10 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewImplicitSnapshot) {
         static_cast_with_check<ColumnFamilyHandleImpl>(handles_[i])->cfd();
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVObsolete);
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVInUse);
+  }
+
+  for (auto* iter : iters) {
+    delete iter;
   }
 }
 
@@ -3647,11 +3648,6 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewExplicitSnapshot) {
                                     std::to_string(i) + "_val");
   }
 
-  db_->ReleaseSnapshot(snapshot);
-  for (auto* iter : iters) {
-    delete iter;
-  }
-
   // Thread-local SV for cf_0 is obsolete (flush happened after the first SV
   // Ref)
   auto* cfd0 =
@@ -3665,6 +3661,11 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewExplicitSnapshot) {
         static_cast_with_check<ColumnFamilyHandleImpl>(handles_[i])->cfd();
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVObsolete);
     ASSERT_NE(cfd->TEST_GetLocalSV()->Get(), SuperVersion::kSVInUse);
+  }
+
+  db_->ReleaseSnapshot(snapshot);
+  for (auto* iter : iters) {
+    delete iter;
   }
 }
 


### PR DESCRIPTION
# Summary

Fixing the failure in IteratorsConsistentViewExplicitSnapshot as shown in https://github.com/facebook/rocksdb/actions/runs/8825927545/job/24230854140?pr=12581

The failure was due to the timing of the `flush()` for the later Column Family in the loop. If the flush for the later CFs installs the new super version before getting the SV for the iterator, assertion succeeds, but if the order flips, SV will be obsolete and assertion can fail.

This PR simplifies the test in a way that we do only one `flush()` so that `SYNC_POINT` can guarantee the order of operations. For ImplicitSnapshot test, it now just triggers flush for the second CF after obtaining SV for the first CF. For the ExplicitSnapshot test, it now triggers atomic flush() for all CFs after obtaining SV for the first CF.

# Test Plan

```
./db_iterator_test --gtest_filter="*IteratorsConsistentView*" 
./multi_cf_iterator_test -- --gtest_filter="*ConsistentView*
```