### PR TITLE
Add option for manual flush/compaction to ignore unexpired UDT

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -538,6 +538,7 @@ ColumnFamilyData::ColumnFamilyData(
       refs_(0),
       initialized_(false),
       dropped_(false),
+      manual_flush_asks_to_ignore_udt_(false),
       internal_comparator_(cf_options.comparator),
       initial_cf_options_(SanitizeOptions(db_options, cf_options)),
       ioptions_(db_options, initial_cf_options_),

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -329,6 +329,16 @@ class ColumnFamilyData {
   void SetDropped();
   bool IsDropped() const { return dropped_.load(std::memory_order_relaxed); }
 
+  void SetManualFlushAsksToIgnoreUDT() {
+    manual_flush_asks_to_ignore_udt_ = true;
+  }
+  bool GetManualFlushAsksToIgnoreUDT() const {
+    return manual_flush_asks_to_ignore_udt_;
+  }
+  void ClearManualFlushAsksToIgnoreUDT() {
+    manual_flush_asks_to_ignore_udt_ = false;
+  }
+
   // thread-safe
   int NumberLevels() const { return ioptions_.num_levels; }
 
@@ -591,6 +601,10 @@ class ColumnFamilyData {
   std::atomic<int> refs_;  // outstanding references to ColumnFamilyData
   std::atomic<bool> initialized_;
   std::atomic<bool> dropped_;  // true if client dropped it
+
+  // This is accessed while holding db mutex.
+  // True if a manual flush requesting to ignore unexpired UDT is in progress.
+  bool manual_flush_asks_to_ignore_udt_;
 
   const InternalKeyComparator internal_comparator_;
   InternalTblPropCollFactories internal_tbl_prop_coll_factories_;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1926,7 +1926,13 @@ struct FlushOptions {
   // is performed by someone else (foreground call or background thread).
   // Default: false
   bool allow_write_stall;
-  FlushOptions() : wait(true), allow_write_stall(false) {}
+  // If true, will not try to retain user-defined timestamps by rescheduling
+  // flush. This option only applies for when user-defined timestamps is enabled
+  // and `persist_user_defined_timestamps` is set to false.
+  // Default: false
+  bool ignore_unexpired_udt;
+  FlushOptions()
+      : wait(true), allow_write_stall(false), ignore_unexpired_udt(false) {}
 };
 
 // Create a Logger from provided DBOptions
@@ -2021,6 +2027,12 @@ struct CompactRangeOptions {
   // Set user-defined timestamp low bound, the data with older timestamp than
   // low bound maybe GCed by compaction. Default: nullptr
   const Slice* full_history_ts_low = nullptr;
+  // If true, will not try to retain user-defined timestamps by rescheduling
+  // flush. This option only applies for when user-defined timestamps is enabled
+  // and `persist_user_defined_timestamps` is set to false. Also see
+  // FlushOptions.ignore_unexpired_udt
+  // Default: false
+  bool ignore_unexpired_udt_for_flush = false;
 
   // Allows cancellation of an in-progress manual compaction.
   //

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1926,13 +1926,13 @@ struct FlushOptions {
   // is performed by someone else (foreground call or background thread).
   // Default: false
   bool allow_write_stall;
-  // If true, will not try to retain user-defined timestamps by rescheduling
+  // If false, will not try to retain user-defined timestamps by rescheduling
   // flush. This option only applies for when user-defined timestamps is enabled
   // and `persist_user_defined_timestamps` is set to false.
-  // Default: false
-  bool ignore_unexpired_udt;
+  // Default: true
+  bool strict_udt_retention;
   FlushOptions()
-      : wait(true), allow_write_stall(false), ignore_unexpired_udt(false) {}
+      : wait(true), allow_write_stall(false), strict_udt_retention(true) {}
 };
 
 // Create a Logger from provided DBOptions
@@ -2027,12 +2027,12 @@ struct CompactRangeOptions {
   // Set user-defined timestamp low bound, the data with older timestamp than
   // low bound maybe GCed by compaction. Default: nullptr
   const Slice* full_history_ts_low = nullptr;
-  // If true, will not try to retain user-defined timestamps by rescheduling
+  // If false, will not try to retain user-defined timestamps by rescheduling
   // flush. This option only applies for when user-defined timestamps is enabled
   // and `persist_user_defined_timestamps` is set to false. Also see
-  // FlushOptions.ignore_unexpired_udt
-  // Default: false
-  bool ignore_unexpired_udt_for_flush = false;
+  // FlushOptions.strict_udt_retention
+  // Default: true
+  bool strict_udt_retention = true;
 
   // Allows cancellation of an in-progress manual compaction.
   //


### PR DESCRIPTION
Add options in `FlushOptions` and `CompactRangeOptions` to ignore unexpired user-defined timestamps for user initiated flush. 

For user-defined timestamps in Memtable only feature (a.k.a when `Options.persist_user_defined_timestamps` is false), flush has the side effect that UDTs are also removed. A `FlushRequest` is recheduled when it applies to try to retain user-defined timestamps that are not expired in a best effort. The expiration is determined w.r.t the cutoff timestamp `full_history_ts_low` that users can set via the `IncreaseFullHistoryTsLow` API.

The current behavior of manual flush and manual compaction is that it won't return until the memtables only contain expired UDT and flush proceeds to finish. This was intended to make the user more conscience of aforementioned side effect of flush. And users can explicitly increase the cutoff timestamp before calling manual flush /compaction to indicate they are aware of this. However, these steps are inconvenient since user also need to block their writes before calling `IncreaseFullHisotoryTsLow` and unblock after manual flush / compaction finishes. This is to avoid another write with higher UDT gets added after increasing cutoff timestamp, making the memtable containing unexpired UDT again.

In order to avoid this inconvenience, we added `strict_udt_retention` options in `FlushOptions` and `CompactRangeOptions` for users to achieve similar effect without the need to block writes on their side.

Test Plan:
Existing tests
./column_family_test --gtest_filter=ColumnFamilyRetainUDTTest, NotAllKeysExpiredUserAsksToIgnore