### PR TITLE
change default `CompactionOptions::compression` while deprecating it

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1935,20 +1935,29 @@ Status CreateLoggerFromOptions(const std::string& dbname,
 
 // CompactionOptions are used in CompactFiles() call.
 struct CompactionOptions {
+  // DEPRECATED: this option is unsafe because it allows the user to set any
+  // `CompressionType` while always using `CompressionOptions` from the
+  // `ColumnFamilyOptions`. As a result the `CompressionType` and
+  // `CompressionOptions` can easily be inconsistent.
+  //
   // Compaction output compression type
-  // Default: snappy
+  //
+  // Default: `kDisableCompressionOption`
+  //
   // If set to `kDisableCompressionOption`, RocksDB will choose compression type
-  // according to the `ColumnFamilyOptions`, taking into account the output
-  // level if `compression_per_level` is specified.
+  // according to the `ColumnFamilyOptions`. RocksDB takes into account the
+  // output level in case the `ColumnFamilyOptions` has level-specific settings.
   CompressionType compression;
+
   // Compaction will create files of size `output_file_size_limit`.
   // Default: MAX, which means that compaction will create a single file
   uint64_t output_file_size_limit;
+
   // If > 0, it will replace the option in the DBOptions for this compaction.
   uint32_t max_subcompactions;
 
   CompactionOptions()
-      : compression(kSnappyCompression),
+      : compression(kDisableCompressionOption),
         output_file_size_limit(std::numeric_limits<uint64_t>::max()),
         max_subcompactions(0) {}
 };

--- a/java/src/test/java/org/rocksdb/CompactionOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompactionOptionsTest.java
@@ -20,7 +20,7 @@ public class CompactionOptionsTest {
   public void compression() {
     try (final CompactionOptions compactionOptions = new CompactionOptions()) {
       assertThat(compactionOptions.compression())
-          .isEqualTo(CompressionType.NO_COMPRESSION);
+          .isEqualTo(CompressionType.DISABLE_COMPRESSION_OPTION);
       compactionOptions.setCompression(CompressionType.SNAPPY_COMPRESSION);
       assertThat(compactionOptions.compression()).isEqualTo(CompressionType.SNAPPY_COMPRESSION);
     }

--- a/java/src/test/java/org/rocksdb/CompactionOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompactionOptionsTest.java
@@ -22,8 +22,7 @@ public class CompactionOptionsTest {
       assertThat(compactionOptions.compression())
           .isEqualTo(CompressionType.NO_COMPRESSION);
       compactionOptions.setCompression(CompressionType.SNAPPY_COMPRESSION);
-      assertThat(compactionOptions.compression())
-          .isEqualTo(CompressionType.SNAPPY_COMPRESSION);
+      assertThat(compactionOptions.compression()).isEqualTo(CompressionType.SNAPPY_COMPRESSION);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/CompactionOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompactionOptionsTest.java
@@ -20,10 +20,10 @@ public class CompactionOptionsTest {
   public void compression() {
     try (final CompactionOptions compactionOptions = new CompactionOptions()) {
       assertThat(compactionOptions.compression())
-          .isEqualTo(CompressionType.SNAPPY_COMPRESSION);
-      compactionOptions.setCompression(CompressionType.NO_COMPRESSION);
-      assertThat(compactionOptions.compression())
           .isEqualTo(CompressionType.NO_COMPRESSION);
+      compactionOptions.setCompression(CompressionType.SNAPPY_COMPRESSION);
+      assertThat(compactionOptions.compression())
+          .isEqualTo(CompressionType.SNAPPY_COMPRESSION);
     }
   }
 

--- a/unreleased_history/behavior_changes/default_compaction_options_compression.md
+++ b/unreleased_history/behavior_changes/default_compaction_options_compression.md
@@ -1,0 +1,1 @@
+* Changed the default value of `CompactionOptions::compression` to `kDisableCompressionOption`, which means the compression type is determined by the `ColumnFamilyOptions`.

--- a/unreleased_history/public_api_changes/deprecate_compaction_options_compression.md
+++ b/unreleased_history/public_api_changes/deprecate_compaction_options_compression.md
@@ -1,0 +1,1 @@
+* Deprecated `CompactionOptions::compression` since `CompactionOptions`'s API for configuring compression was incomplete, unsafe, and likely unnecessary


### PR DESCRIPTION
I had a TODO to complete `CompactionOptions`'s compression API but never did it: https://github.com/facebook/rocksdb/blob/d610e14f9386bab7f1fa85cf34dcb5b465152699/db/compaction/compaction_picker.cc#L371-L373

Without solving that TODO, the API remains incomplete and unsafe. Now, however, I don't think it's worthwhile to complete it. I think we should instead delete the API entirely. This PR deprecates it in preparation for deletion in a future major release. The `ColumnFamilyOptions` settings for compression should be good enough for `CompactFiles()` since they are apparently good enough for every other compaction, including `CompactRange()`.

In the meantime, I also changed the default `CompressionType`. Having callers of `CompactFiles()` use Snappy compression by default does not make sense when the default could be to simply use the same compression type that is used for every other compaction. As a bonus, this change makes the default `CompressionType` consistent with the `CompressionOptions` that will be used.