### PR TITLE
Disable inplace_update_support in OptimisticTxnDB

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -500,6 +500,8 @@ optimistic_txn_params = {
     "occ_lock_bucket_count": lambda: random.choice([10, 100, 500]),
     # PutEntity in transactions is not yet implemented
     "use_put_entity_one_in": 0,
+    # Should not be used with OptimisticTransactionDB which uses snapshot.
+    "inplace_update_support": 0,
 }
 
 best_efforts_recovery_params = {


### PR DESCRIPTION
# Summary

Adding OptimisticTransactionDB like #12586 

# Test Plan

```
python3 tools/db_crashtest.py whitebox --optimistic_txn
```
```
Running db_stress with pid=773197: ./db_stress  ...
--inplace_update_support=0  ...
--use_optimistic_txn=1 ...
...
```