### PR TITLE
Fixed `MultiGet()` error handling to not skip blob dereference

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2777,7 +2777,7 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
     }
   }
 
-  if (s.ok() && !blob_ctxs.empty()) {
+  if (!blob_ctxs.empty()) {
     MultiGetBlob(read_options, keys_with_blobs_range, blob_ctxs);
   }
 

--- a/unreleased_history/bug_fixes/multiget_partial_error_blob_dereference.md
+++ b/unreleased_history/bug_fixes/multiget_partial_error_blob_dereference.md
@@ -1,0 +1,1 @@
+* Fixed a bug in `MultiGet()` and `MultiGetEntity()` together with blob files (`ColumnFamilyOptions::enable_blob_files == true`). An error looking up one of the keys could cause the results to be wrong for other keys for which the statuses were `Status::OK`.


### PR DESCRIPTION
See comment at top of the test case and release note.