### PR TITLE
Fix wrong padded bytes being used to generate file checksum

### DIFF
--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -205,17 +205,24 @@ IOStatus WritableFileWriter::Pad(const IOOptions& opts,
   assert(pad_bytes < kDefaultPageSize);
   size_t left = pad_bytes;
   size_t cap = buf_.Capacity() - buf_.CurrentSize();
-  const size_t pad_start = buf_.CurrentSize();
 
   // Assume pad_bytes is small compared to buf_ capacity. So we always
   // use buf_ rather than write directly to file in certain cases like
   // Append() does.
-  size_t actual_pad_bytes = 0;
   while (left) {
     size_t append_bytes = std::min(cap, left);
     buf_.PadWith(append_bytes, 0);
     left -= append_bytes;
-    actual_pad_bytes += append_bytes;
+
+    Slice data(buf_.BufferStart() + buf_.CurrentSize() - append_bytes,
+               append_bytes);
+    UpdateFileChecksum(data);
+    if (perform_data_verification_) {
+      buffered_data_crc32c_checksum_ = crc32c::Extend(
+          buffered_data_crc32c_checksum_,
+          buf_.BufferStart() + buf_.CurrentSize() - append_bytes, append_bytes);
+    }
+
     if (left > 0) {
       IOStatus s = Flush(io_options);
       if (!s.ok()) {
@@ -229,13 +236,6 @@ IOStatus WritableFileWriter::Pad(const IOOptions& opts,
   uint64_t cur_size = filesize_.load(std::memory_order_acquire);
   filesize_.store(cur_size + pad_bytes, std::memory_order_release);
 
-  Slice data(buf_.BufferStart() + pad_start, actual_pad_bytes);
-  UpdateFileChecksum(data);
-  if (perform_data_verification_) {
-    buffered_data_crc32c_checksum_ =
-        crc32c::Extend(buffered_data_crc32c_checksum_,
-                       buf_.BufferStart() + pad_start, actual_pad_bytes);
-  }
   return IOStatus::OK();
 }
 

--- a/unreleased_history/bug_fixes/pad_bug.md
+++ b/unreleased_history/bug_fixes/pad_bug.md
@@ -1,0 +1,1 @@
+Fixed a bug where wrong padded bytes are used to generate file checksum and `DataVerificationInfo::checksum` upon file creation


### PR DESCRIPTION
**Context/Summary:**

https://github.com/facebook/rocksdb/pull/12542 introduced a bug where wrong padded bytes used to generate file checksum if flush happens during padding. This PR fixed it along with an existing same bug for `perform_data_verification_=true`. 


**Test plan:**
- New UT that failed before this fix (`db->VerifyFileChecksums: ...Corruption:  ...file checksum mismatch`) and passes after
- Benchmark
```
TEST_TMPDIR=/dev/shm  ./db_bench --benchmarks=fillseq[-X300] --num=100000 --block_align=1 --compression_type=none
```
Pre-PR:
fillseq [AVG    300 runs] : 421334 (± 4126) ops/sec;   46.6 (± 0.5) MB/sec
Post-PR: (no regression observed but a slight improvement)
fillseq [AVG    300 runs] : 425768 (± 4309) ops/sec;   47.1 (± 0.5) MB/sec


