### PR TITLE
Implement secondary cache admission policy to allow all evicted blocks

### DIFF
--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -523,6 +523,11 @@ enum TieredAdmissionPolicy {
   // compressed secondary, and a compressed local flash (non-volatile) cache.
   // Each tier is managed as an independent queue.
   kAdmPolicyThreeQueue,
+  // Allow all blocks evicted from the primary block cache into the secondary
+  // cache. This may increase CPU overhead due to more blocks being admitted
+  // and compressed, but may increase the compressed secondary cache hit rate
+  // for some workloads
+  kAdmPolicyAllowAll,
   kAdmPolicyMax,
 };
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1299,6 +1299,8 @@ static enum ROCKSDB_NAMESPACE::TieredAdmissionPolicy StringToAdmissionPolicy(
     return ROCKSDB_NAMESPACE::kAdmPolicyAllowCacheHits;
   } else if (!strcasecmp(policy, "three_queue")) {
     return ROCKSDB_NAMESPACE::kAdmPolicyThreeQueue;
+  } else if (!strcasecmp(policy, "allow_all")) {
+    return ROCKSDB_NAMESPACE::kAdmPolicyAllowAll;
   } else {
     fprintf(stderr, "Cannot parse admission policy %s\n", policy);
     exit(1);

--- a/unreleased_history/public_api_changes/sec_cache_allow_all.md
+++ b/unreleased_history/public_api_changes/sec_cache_allow_all.md
@@ -1,0 +1,1 @@
+Add a kAdmPolicyAllowAll option to TieredAdmissionPolicy that admits all blocks evicted from the primary block cache into the compressed secondary cache.


### PR DESCRIPTION
Add a secondary cache admission policy to admit all blocks evicted from the block cache.