### PR TITLE
Fix a corruption bug in `CreateColumnFamilyWithImport()`

### DIFF
--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -229,7 +229,9 @@ Status ImportColumnFamilyJob::Run() {
       s = dummy_version_builder.SaveTo(&dummy_vstorage);
     }
     if (s.ok()) {
-      dummy_vstorage.RecoverEpochNumbers(cfd_, /*reset=*/i == 0);
+      // force resetting epoch number for each file
+      dummy_vstorage.RecoverEpochNumbers(cfd_, /*restart_epoch=*/i == 0,
+                                         /*force=*/true);
       edit_.SetColumnFamily(cfd_->GetID());
 
       for (int level = 0; level < dummy_vstorage.num_levels(); level++) {

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -175,22 +175,29 @@ Status ImportColumnFamilyJob::Run() {
         static_cast<uint64_t>(temp_current_time);
   }
 
-  // Recover files' epoch number using dummy VersionStorageInfo
-  VersionBuilder dummy_version_builder(
-      cfd_->current()->version_set()->file_options(), cfd_->ioptions(),
-      cfd_->table_cache(), cfd_->current()->storage_info(),
-      cfd_->current()->version_set(),
-      cfd_->GetFileMetadataCacheReservationManager());
-  VersionStorageInfo dummy_vstorage(
-      &cfd_->internal_comparator(), cfd_->user_comparator(),
-      cfd_->NumberLevels(), cfd_->ioptions()->compaction_style,
-      nullptr /* src_vstorage */, cfd_->ioptions()->force_consistency_checks,
-      EpochNumberRequirement::kMightMissing, cfd_->ioptions()->clock,
-      cfd_->GetLatestMutableCFOptions()->bottommost_file_compaction_delay,
-      cfd_->current()->version_set()->offpeak_time_option());
   Status s;
-
+  // When importing multiple CFs, we should not reuse epoch number from ingested
+  // files. Since these epoch numbers were assigned by different CFs, there may
+  // be different files from different CFs with the same epoch number. With a
+  // subsequent intra-L0 compaction we may end up with files with overlapping
+  // key range but the same epoch number. Here we will create a dummy
+  // VersionStorageInfo per CF being imported. Each CF's files will be assigned
+  // increasing epoch numbers to avoid duplicated epoch number. This is done by
+  // only resetting epoch number of the new CF in the first call to
+  // RecoverEpochNumbers() below.
   for (size_t i = 0; s.ok() && i < files_to_import_.size(); ++i) {
+    VersionBuilder dummy_version_builder(
+        cfd_->current()->version_set()->file_options(), cfd_->ioptions(),
+        cfd_->table_cache(), cfd_->current()->storage_info(),
+        cfd_->current()->version_set(),
+        cfd_->GetFileMetadataCacheReservationManager());
+    VersionStorageInfo dummy_vstorage(
+        &cfd_->internal_comparator(), cfd_->user_comparator(),
+        cfd_->NumberLevels(), cfd_->ioptions()->compaction_style,
+        nullptr /* src_vstorage */, cfd_->ioptions()->force_consistency_checks,
+        EpochNumberRequirement::kMightMissing, cfd_->ioptions()->clock,
+        cfd_->GetLatestMutableCFOptions()->bottommost_file_compaction_delay,
+        cfd_->current()->version_set()->offpeak_time_option());
     for (size_t j = 0; s.ok() && j < files_to_import_[i].size(); ++j) {
       const auto& f = files_to_import_[i][j];
       const auto& file_metadata = *metadatas_[i][j];
@@ -218,42 +225,37 @@ Status ImportColumnFamilyJob::Run() {
               f.table_properties.user_defined_timestamps_persisted));
       s = dummy_version_builder.Apply(&dummy_version_edit);
     }
-  }
+    if (s.ok()) {
+      s = dummy_version_builder.SaveTo(&dummy_vstorage);
+    }
+    if (s.ok()) {
+      dummy_vstorage.RecoverEpochNumbers(cfd_, /*reset=*/i == 0);
+      edit_.SetColumnFamily(cfd_->GetID());
 
-  if (s.ok()) {
-    s = dummy_version_builder.SaveTo(&dummy_vstorage);
-  }
-  if (s.ok()) {
-    dummy_vstorage.RecoverEpochNumbers(cfd_);
-  }
-
-  // Record changes from this CF import in VersionEdit, including files with
-  // recovered epoch numbers
-  if (s.ok()) {
-    edit_.SetColumnFamily(cfd_->GetID());
-
+      for (int level = 0; level < dummy_vstorage.num_levels(); level++) {
+        for (FileMetaData* file_meta : dummy_vstorage.LevelFiles(level)) {
+          edit_.AddFile(level, *file_meta);
+          // If incoming sequence number is higher, update local sequence
+          // number.
+          if (file_meta->fd.largest_seqno > versions_->LastSequence()) {
+            versions_->SetLastAllocatedSequence(file_meta->fd.largest_seqno);
+            versions_->SetLastPublishedSequence(file_meta->fd.largest_seqno);
+            versions_->SetLastSequence(file_meta->fd.largest_seqno);
+          }
+        }
+      }
+    }
+    // Release resources occupied by the dummy VersionStorageInfo
     for (int level = 0; level < dummy_vstorage.num_levels(); level++) {
       for (FileMetaData* file_meta : dummy_vstorage.LevelFiles(level)) {
-        edit_.AddFile(level, *file_meta);
-        // If incoming sequence number is higher, update local sequence number.
-        if (file_meta->fd.largest_seqno > versions_->LastSequence()) {
-          versions_->SetLastAllocatedSequence(file_meta->fd.largest_seqno);
-          versions_->SetLastPublishedSequence(file_meta->fd.largest_seqno);
-          versions_->SetLastSequence(file_meta->fd.largest_seqno);
+        file_meta->refs--;
+        if (file_meta->refs <= 0) {
+          delete file_meta;
         }
       }
     }
   }
 
-  // Release resources occupied by the dummy VersionStorageInfo
-  for (int level = 0; level < dummy_vstorage.num_levels(); level++) {
-    for (FileMetaData* file_meta : dummy_vstorage.LevelFiles(level)) {
-      file_meta->refs--;
-      if (file_meta->refs <= 0) {
-        delete file_meta;
-      }
-    }
-  }
   return s;
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4617,25 +4617,27 @@ uint64_t VersionStorageInfo::GetMaxEpochNumberOfFiles() const {
   return max_epoch_number;
 }
 
-void VersionStorageInfo::RecoverEpochNumbers(ColumnFamilyData* cfd) {
-  cfd->ResetNextEpochNumber();
+void VersionStorageInfo::RecoverEpochNumbers(ColumnFamilyData* cfd,
+                                             bool reset) {
+  if (reset) {
+    cfd->ResetNextEpochNumber();
 
-  bool reserve_epoch_num_for_file_ingested_behind =
-      cfd->ioptions()->allow_ingest_behind;
-  if (reserve_epoch_num_for_file_ingested_behind) {
-    uint64_t reserved_epoch_number = cfd->NewEpochNumber();
-    assert(reserved_epoch_number == kReservedEpochNumberForFileIngestedBehind);
-    ROCKS_LOG_INFO(cfd->ioptions()->info_log.get(),
-                   "[%s]CF has reserved epoch number %" PRIu64
-                   " for files ingested "
-                   "behind since `Options::allow_ingest_behind` is true",
-                   cfd->GetName().c_str(), reserved_epoch_number);
+    bool reserve_epoch_num_for_file_ingested_behind =
+        cfd->ioptions()->allow_ingest_behind;
+    if (reserve_epoch_num_for_file_ingested_behind) {
+      uint64_t reserved_epoch_number = cfd->NewEpochNumber();
+      assert(reserved_epoch_number ==
+             kReservedEpochNumberForFileIngestedBehind);
+      ROCKS_LOG_INFO(cfd->ioptions()->info_log.get(),
+                     "[%s]CF has reserved epoch number %" PRIu64
+                     " for files ingested "
+                     "behind since `Options::allow_ingest_behind` is true",
+                     cfd->GetName().c_str(), reserved_epoch_number);
+    }
   }
 
-  if (HasMissingEpochNumber()) {
-    assert(epoch_number_requirement_ == EpochNumberRequirement::kMightMissing);
-    assert(num_levels_ >= 1);
-
+  bool missing_epoch_number = HasMissingEpochNumber();
+  if (missing_epoch_number || !reset) {
     for (int level = num_levels_ - 1; level >= 1; --level) {
       auto& files_at_level = files_[level];
       if (files_at_level.empty()) {
@@ -4646,17 +4648,19 @@ void VersionStorageInfo::RecoverEpochNumbers(ColumnFamilyData* cfd) {
         f->epoch_number = next_epoch_number;
       }
     }
-
     for (auto file_meta_iter = files_[0].rbegin();
          file_meta_iter != files_[0].rend(); file_meta_iter++) {
       FileMetaData* f = *file_meta_iter;
       f->epoch_number = cfd->NewEpochNumber();
     }
-
-    ROCKS_LOG_WARN(cfd->ioptions()->info_log.get(),
-                   "[%s]CF's epoch numbers are inferred based on seqno",
-                   cfd->GetName().c_str());
-    epoch_number_requirement_ = EpochNumberRequirement::kMustPresent;
+    if (missing_epoch_number) {
+      assert(epoch_number_requirement_ ==
+             EpochNumberRequirement::kMightMissing);
+      ROCKS_LOG_WARN(cfd->ioptions()->info_log.get(),
+                     "[%s]CF's epoch numbers are inferred based on seqno",
+                     cfd->GetName().c_str());
+      epoch_number_requirement_ = EpochNumberRequirement::kMustPresent;
+    }
   } else {
     assert(epoch_number_requirement_ == EpochNumberRequirement::kMustPresent);
     cfd->SetNextEpochNumber(

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4618,8 +4618,8 @@ uint64_t VersionStorageInfo::GetMaxEpochNumberOfFiles() const {
 }
 
 void VersionStorageInfo::RecoverEpochNumbers(ColumnFamilyData* cfd,
-                                             bool reset) {
-  if (reset) {
+                                             bool restart_epoch, bool force) {
+  if (restart_epoch) {
     cfd->ResetNextEpochNumber();
 
     bool reserve_epoch_num_for_file_ingested_behind =
@@ -4637,7 +4637,7 @@ void VersionStorageInfo::RecoverEpochNumbers(ColumnFamilyData* cfd,
   }
 
   bool missing_epoch_number = HasMissingEpochNumber();
-  if (missing_epoch_number || !reset) {
+  if (missing_epoch_number || force) {
     for (int level = num_levels_ - 1; level >= 1; --level) {
       auto& files_at_level = files_[level];
       if (files_at_level.empty()) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -342,14 +342,14 @@ class VersionStorageInfo {
     epoch_number_requirement_ = epoch_number_requirement;
   }
   // Ensure all files have epoch number set.
+  // If there is a file missing epoch number, all files' epoch number will be
+  // reset according to CF's epoch number. Otherwise, the CF will be updated
+  // with the max epoch number of the files.
   //
-  // This CF's epoch number will be reset to start from 0 if
-  // `reset` flag is true.
-  //
-  // If there is a file missing epoch number or `reset` is false,
-  // all files' epoch number will be set according to CF's epoch number.
-  // Otherwise, the CF will be updated with the max epoch number of the files.
-  void RecoverEpochNumbers(ColumnFamilyData* cfd, bool reset = true);
+  // @param restart_epoch This CF's epoch number will be reset to start from 0.
+  // @param force Force resetting all files' epoch number.
+  void RecoverEpochNumbers(ColumnFamilyData* cfd, bool restart_epoch = true,
+                           bool force = false);
 
   class FileLocation {
    public:

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -341,7 +341,15 @@ class VersionStorageInfo {
       EpochNumberRequirement epoch_number_requirement) {
     epoch_number_requirement_ = epoch_number_requirement;
   }
-  void RecoverEpochNumbers(ColumnFamilyData* cfd);
+  // Ensure all files have epoch number set.
+  //
+  // This CF's epoch number will be reset to start from 0 if
+  // `reset` flag is true.
+  //
+  // If there is a file missing epoch number or `reset` is false,
+  // all files' epoch number will be set according to CF's epoch number.
+  // Otherwise, the CF will be updated with the max epoch number of the files.
+  void RecoverEpochNumbers(ColumnFamilyData* cfd, bool reset = true);
 
   class FileLocation {
    public:

--- a/unreleased_history/bug_fixes/fix-import-epoch.md
+++ b/unreleased_history/bug_fixes/fix-import-epoch.md
@@ -1,0 +1,1 @@
+* Fix a bug in CreateColumnFamilyWithImport() where if multiple CFs are imported, we were not resetting files' epoch number and L0 files can have overlapping key range but the same epoch number.


### PR DESCRIPTION
Summary: when importing files from multiple CFs into a new CF, we were reusing the epoch numbers assigned by the original CFs. This means L0 files in the new CF can have the same epoch number (assigned originally by different CFs). While CreateColumnFamilyWithImport() requires each original CF to have disjoint key range, after an intra-l0 compaction, we still can end up with L0 files with the same epoch number but overlapping key range. This PR attempt to fix this by reassigning epoch numbers when importing multiple CFs.

Test plan: a new repro unit test. Before this PR, it fails with 
```
[ RUN      ] ImportColumnFamilyTest.AssignEpochNumberToMultipleCF
db/import_column_family_test.cc:1048: Failure
db_->WaitForCompact(o)
Corruption: force_consistency_checks(DEBUG): VersionBuilder: L0 files of same epoch number but overlapping range #44 , smallest key: '6B6579303030303030' seq:511, type:1 , largest key: '6B6579303031303239' seq:510, type:1 , epoch number: 3 vs. file #36 , smallest key: '6B6579303030313030' seq:401, type:1 , largest key: '6B6579303030313939' seq:500, type:1 , epoch number: 3
```