### PR TITLE
AttributeGroup APIs in stress test - PutEntity and GetEntity

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -316,7 +316,7 @@ class BatchedOpsStressTest : public StressTest {
         attribute_group_results[i].emplace_back(cfh);
         s = db_->GetEntity(read_opts_copy, key, &attribute_group_results[i]);
         if (s.ok()) {
-          s = attribute_group_results[i].front().status();
+          s = attribute_group_results[i].back().status();
         }
       } else {
         s = db_->GetEntity(read_opts_copy, cfh, key, &column_results[i]);

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -54,7 +54,11 @@ class BatchedOpsStressTest : public StressTest {
       const std::string v = value_body + num;
       if (FLAGS_use_put_entity_one_in > 0 &&
           (value_base % FLAGS_use_put_entity_one_in) == 0) {
-        status = batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
+        if (FLAGS_use_attribute_group) {
+          status = batch.PutEntity(k, GenerateAttributeGroups({cfh}, value_base, v));
+        } else {
+          status = batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
+        }
       } else if (FLAGS_use_timed_put_one_in > 0 &&
                  ((value_base + kLargePrimeForCommonFactorSkew) %
                   FLAGS_use_timed_put_one_in) == 0) {

--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -55,7 +55,8 @@ class BatchedOpsStressTest : public StressTest {
       if (FLAGS_use_put_entity_one_in > 0 &&
           (value_base % FLAGS_use_put_entity_one_in) == 0) {
         if (FLAGS_use_attribute_group) {
-          status = batch.PutEntity(k, GenerateAttributeGroups({cfh}, value_base, v));
+          status =
+              batch.PutEntity(k, GenerateAttributeGroups({cfh}, value_base, v));
         } else {
           status = batch.PutEntity(cfh, k, GenerateWideColumns(value_base, v));
         }
@@ -304,12 +305,22 @@ class BatchedOpsStressTest : public StressTest {
 
     constexpr size_t num_keys = 10;
 
-    std::array<PinnableWideColumns, num_keys> results;
+    std::array<PinnableWideColumns, num_keys> column_results;
+    std::array<PinnableAttributeGroups, num_keys> attribute_group_results;
 
     for (size_t i = 0; i < num_keys; ++i) {
       const std::string key = std::to_string(i) + key_suffix;
 
-      const Status s = db_->GetEntity(read_opts_copy, cfh, key, &results[i]);
+      Status s;
+      if (FLAGS_use_attribute_group) {
+        attribute_group_results[i].emplace_back(cfh);
+        s = db_->GetEntity(read_opts_copy, key, &attribute_group_results[i]);
+        if (s.ok()) {
+          s = attribute_group_results[i].front().status();
+        }
+      } else {
+        s = db_->GetEntity(read_opts_copy, cfh, key, &column_results[i]);
+      }
 
       if (!s.ok() && !s.IsNotFound()) {
         fprintf(stderr, "GetEntity error: %s\n", s.ToString().c_str());
@@ -321,14 +332,21 @@ class BatchedOpsStressTest : public StressTest {
       }
     }
 
-    for (size_t i = 0; i < num_keys; ++i) {
-      const WideColumns& columns = results[i].columns();
+    const WideColumns& columns_to_compare =
+        FLAGS_use_attribute_group ? attribute_group_results[0].front().columns()
+                                  : column_results[0].columns();
 
-      if (!CompareColumns(results[0].columns(), columns)) {
+    for (size_t i = 1; i < num_keys; ++i) {
+      const WideColumns& columns =
+          FLAGS_use_attribute_group
+              ? attribute_group_results[i].front().columns()
+              : column_results[i].columns();
+
+      if (!CompareColumns(columns_to_compare, columns)) {
         fprintf(stderr,
                 "GetEntity error: inconsistent entities for key %s: %s, %s\n",
                 StringToHex(key_suffix).c_str(),
-                WideColumnsToHex(results[0].columns()).c_str(),
+                WideColumnsToHex(columns_to_compare).c_str(),
                 WideColumnsToHex(columns).c_str());
       }
 

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -355,7 +355,13 @@ class CfConsistencyStressTest : public StressTest {
             }
 
             for (auto& attribute_group : result) {
-              const bool found = attribute_group.status().ok();
+              s = attribute_group.status();
+              if (!s.ok() && !s.IsNotFound()) {
+                break;
+              }
+
+              const bool found = s.ok();
+
               if (!cmp_found && found) {
                 fprintf(
                     stderr,
@@ -394,7 +400,6 @@ class CfConsistencyStressTest : public StressTest {
                 break;
               }
             }
-
           } else {
             for (size_t i = 1; i < rand_column_families.size(); ++i) {
               assert(rand_column_families[i] >= 0);

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -321,6 +321,16 @@ uint32_t GetValueBase(Slice s) {
   return res;
 }
 
+AttributeGroups GenerateAttributeGroups(
+    const std::vector<ColumnFamilyHandle*>& cfhs, uint32_t value_base,
+    const Slice& slice) {
+  AttributeGroups attribute_groups;
+  for (auto cfh : cfhs) {
+    attribute_groups.emplace_back(cfh, GenerateWideColumns(value_base, slice));
+  }
+  return attribute_groups;
+}
+
 WideColumns GenerateWideColumns(uint32_t value_base, const Slice& slice) {
   WideColumns columns;
 

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -325,7 +325,7 @@ AttributeGroups GenerateAttributeGroups(
     const std::vector<ColumnFamilyHandle*>& cfhs, uint32_t value_base,
     const Slice& slice) {
   AttributeGroups attribute_groups;
-  for (auto cfh : cfhs) {
+  for (auto* cfh : cfhs) {
     attribute_groups.emplace_back(cfh, GenerateWideColumns(value_base, slice));
   }
   return attribute_groups;

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -324,9 +324,10 @@ uint32_t GetValueBase(Slice s) {
 AttributeGroups GenerateAttributeGroups(
     const std::vector<ColumnFamilyHandle*>& cfhs, uint32_t value_base,
     const Slice& slice) {
+  WideColumns columns = GenerateWideColumns(value_base, slice);
   AttributeGroups attribute_groups;
   for (auto* cfh : cfhs) {
-    attribute_groups.emplace_back(cfh, GenerateWideColumns(value_base, slice));
+    attribute_groups.emplace_back(cfh, columns);
   }
   return attribute_groups;
 }

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -250,6 +250,7 @@ DECLARE_string(memtablerep);
 DECLARE_int32(prefix_size);
 DECLARE_bool(use_merge);
 DECLARE_uint32(use_put_entity_one_in);
+DECLARE_bool(use_attribute_group);
 DECLARE_bool(use_full_merge_v1);
 DECLARE_int32(sync_wal_one_in);
 DECLARE_bool(avoid_unnecessary_blocking_io);
@@ -757,6 +758,10 @@ WideColumns GenerateExpectedWideColumns(uint32_t value_base,
                                         const Slice& slice);
 bool VerifyWideColumns(const Slice& value, const WideColumns& columns);
 bool VerifyWideColumns(const WideColumns& columns);
+
+AttributeGroups GenerateAttributeGroups(
+    const std::vector<ColumnFamilyHandle*>& cfhs, uint32_t value_base,
+    const Slice& slice);
 
 StressTest* CreateCfConsistencyStressTest();
 StressTest* CreateBatchedOpsStressTest();

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -940,6 +940,9 @@ DEFINE_uint32(use_put_entity_one_in, 0,
               "If greater than zero, PutEntity will be used once per every N "
               "write ops on average.");
 
+DEFINE_bool(use_attribute_group, false,
+            "If set, use the attribute_group API to put/get entities");
+
 DEFINE_bool(use_full_merge_v1, false,
             "On true, use a merge operator that implement the deprecated "
             "version of FullMerge");

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1302,8 +1302,13 @@ class NonBatchedOpsStressTest : public StressTest {
 
     if (FLAGS_use_put_entity_one_in > 0 &&
         (value_base % FLAGS_use_put_entity_one_in) == 0) {
-      s = db_->PutEntity(write_opts, cfh, k,
-                         GenerateWideColumns(value_base, v));
+      if (FLAGS_use_attribute_group) {
+        s = db_->PutEntity(write_opts, k,
+                           GenerateAttributeGroups({cfh}, value_base, v));
+      } else {
+        s = db_->PutEntity(write_opts, cfh, k,
+                           GenerateWideColumns(value_base, v));
+      }
     } else if (FLAGS_use_timed_put_one_in > 0 &&
                ((value_base + kLargePrimeForCommonFactorSkew) %
                 FLAGS_use_timed_put_one_in) == 0) {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -935,7 +935,7 @@ class NonBatchedOpsStressTest : public StressTest {
       attribute_groups_from_db.emplace_back(cfh);
       s = db_->GetEntity(read_opts_copy, key, &attribute_groups_from_db);
       if (s.ok()) {
-        s = attribute_groups_from_db.front().status();
+        s = attribute_groups_from_db.back().status();
       }
     } else {
       s = db_->GetEntity(read_opts_copy, cfh, key, &columns_from_db);
@@ -963,9 +963,12 @@ class NonBatchedOpsStressTest : public StressTest {
       thread->stats.AddGets(1, 1);
 
       if (!FLAGS_skip_verifydb && !read_older_ts) {
+        if (FLAGS_use_attribute_group) {
+          assert(!attribute_groups_from_db.empty());
+        }
         const WideColumns& columns =
             FLAGS_use_attribute_group
-                ? attribute_groups_from_db.front().columns()
+                ? attribute_groups_from_db.back().columns()
                 : columns_from_db.columns();
         ExpectedValue expected =
             shared->Get(rand_column_families[0], rand_keys[0]);

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -916,7 +916,8 @@ class NonBatchedOpsStressTest : public StressTest {
 
     const std::string key = Key(rand_keys[0]);
 
-    PinnableWideColumns from_db;
+    PinnableWideColumns columns_from_db;
+    PinnableAttributeGroups attribute_groups_from_db;
 
     ReadOptions read_opts_copy = read_opts;
     std::string read_ts_str;
@@ -929,7 +930,16 @@ class NonBatchedOpsStressTest : public StressTest {
     bool read_older_ts = MaybeUseOlderTimestampForPointLookup(
         thread, read_ts_str, read_ts_slice, read_opts_copy);
 
-    const Status s = db_->GetEntity(read_opts_copy, cfh, key, &from_db);
+    Status s;
+    if (FLAGS_use_attribute_group) {
+      attribute_groups_from_db.emplace_back(cfh);
+      s = db_->GetEntity(read_opts_copy, key, &attribute_groups_from_db);
+      if (s.ok()) {
+        s = attribute_groups_from_db.front().status();
+      }
+    } else {
+      s = db_->GetEntity(read_opts_copy, cfh, key, &columns_from_db);
+    }
 
     int error_count = 0;
 
@@ -953,7 +963,10 @@ class NonBatchedOpsStressTest : public StressTest {
       thread->stats.AddGets(1, 1);
 
       if (!FLAGS_skip_verifydb && !read_older_ts) {
-        const WideColumns& columns = from_db.columns();
+        const WideColumns& columns =
+            FLAGS_use_attribute_group
+                ? attribute_groups_from_db.front().columns()
+                : columns_from_db.columns();
         ExpectedValue expected =
             shared->Get(rand_column_families[0], rand_keys[0]);
         if (!VerifyWideColumns(columns)) {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -147,6 +147,7 @@ default_params = {
     "use_merge": lambda: random.randint(0, 1),
     # use_put_entity_one_in has to be the same across invocations for verification to work, hence no lambda
     "use_put_entity_one_in": random.choice([0] * 7 + [1, 5, 10]),
+    "use_attribute_group": lambda: random.randint(0, 1),
     # 999 -> use Bloom API
     "bloom_before_level": lambda: random.choice([random.randint(-1, 2), random.randint(-1, 10), 0x7fffffff - 1, 0x7fffffff]),
     "value_size_mult": 32,


### PR DESCRIPTION
# Summary

Adding AttributeGroup APIs in stress test. This contains the following changes only. More PRs to follow.

- Introduce `use_attribute_group` flag
- AttributeGroup `PutEntity()` and `GetEntity()` are now used per `use_attribute_group` flag in BatchOps, NonBatchOps and CfConsistency tests

In the next PRs I plan to add
- AttributeGroup `MultiGetEntity()` in Stress Test
- AttributeGroupIterator in Stress Test (along with CoalescingIterator)

# Test Plan

NonBatchOps
```
python3 tools/db_crashtest.py blackbox --simple --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=1 --use_put_entity_one_in=1
```

BatchOps
```
python3 tools/db_crashtest.py blackbox --test_batches_snapshots=1 --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=1 --use_put_entity_one_in=1
```

CfConsistency Test
```
python3 tools/db_crashtest.py blackbox --cf_consistency --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=1 --use_put_entity_one_in=1
```