### PR TITLE
Add PutEntity support for optimistic and WritePrepared pessimistic transactions

### DIFF
--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -165,7 +165,7 @@ class Transaction {
   virtual void SetSnapshot() = 0;
 
   // Similar to SetSnapshot(), but will not change the current snapshot
-  // until Put/Merge/Delete/GetForUpdate/MultigetForUpdate is called.
+  // until Put/PutEntity/Merge/Delete/GetForUpdate/MultigetForUpdate is called.
   // By calling this function, the transaction will essentially call
   // SetSnapshot() for you right before performing the next write/GetForUpdate.
   //
@@ -268,10 +268,10 @@ class Transaction {
   // points.
   virtual void SetSavePoint() = 0;
 
-  // Undo all operations in this transaction (Put, Merge, Delete, PutLogData)
-  // since the most recent call to SetSavePoint() and removes the most recent
-  // SetSavePoint().
-  // If there is no previous call to SetSavePoint(), returns Status::NotFound()
+  // Undo all operations in this transaction (Put, PutEntity, Merge, Delete,
+  // PutLogData) since the most recent call to SetSavePoint() and removes the
+  // most recent SetSavePoint(). If there is no previous call to SetSavePoint(),
+  // returns Status::NotFound()
   virtual Status RollbackToSavePoint() = 0;
 
   // Pop the most recent save point.
@@ -461,9 +461,9 @@ class Transaction {
   virtual Iterator* GetIterator(const ReadOptions& read_options,
                                 ColumnFamilyHandle* column_family) = 0;
 
-  // Put, Merge, Delete, and SingleDelete behave similarly to the corresponding
-  // functions in WriteBatch, but will also do conflict checking on the
-  // keys being written.
+  // Put, PutEntity, Merge, Delete, and SingleDelete behave similarly to the
+  // corresponding functions in WriteBatch, but will also do conflict checking
+  // on the keys being written.
   //
   // assume_tracked=true expects the key be already tracked. More
   // specifically, it means the the key was previous tracked in the same
@@ -488,6 +488,10 @@ class Transaction {
                      const SliceParts& value,
                      const bool assume_tracked = false) = 0;
   virtual Status Put(const SliceParts& key, const SliceParts& value) = 0;
+
+  virtual Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
+                           const WideColumns& columns,
+                           bool assume_tracked = false) = 0;
 
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
                        const Slice& value,
@@ -528,6 +532,10 @@ class Transaction {
   virtual Status PutUntracked(const SliceParts& key,
                               const SliceParts& value) = 0;
 
+  virtual Status PutEntityUntracked(ColumnFamilyHandle* column_family,
+                                    const Slice& key,
+                                    const WideColumns& columns) = 0;
+
   virtual Status MergeUntracked(ColumnFamilyHandle* column_family,
                                 const Slice& key, const Slice& value) = 0;
   virtual Status MergeUntracked(const Slice& key, const Slice& value) = 0;
@@ -556,18 +564,18 @@ class Transaction {
   // Similar to WriteBatch::PutLogData
   virtual void PutLogData(const Slice& blob) = 0;
 
-  // By default, all Put/Merge/Delete operations will be indexed in the
-  // transaction so that Get/GetForUpdate/GetIterator can search for these
+  // By default, all Put/PutEntity/Merge/Delete operations will be indexed in
+  // the transaction so that Get/GetForUpdate/GetIterator can search for these
   // keys.
   //
   // If the caller does not want to fetch the keys about to be written,
   // they may want to avoid indexing as a performance optimization.
   // Calling DisableIndexing() will turn off indexing for all future
-  // Put/Merge/Delete operations until EnableIndexing() is called.
+  // Put/PutEntity/Merge/Delete operations until EnableIndexing() is called.
   //
-  // If a key is Put/Merge/Deleted after DisableIndexing is called and then
-  // is fetched via Get/GetForUpdate/GetIterator, the result of the fetch is
-  // undefined.
+  // If a key is written (using Put/PutEntity/Merge/Delete) after
+  // DisableIndexing is called and then is fetched via
+  // Get/GetForUpdate/GetIterator, the result of the fetch is undefined.
   virtual void DisableIndexing() = 0;
   virtual void EnableIndexing() = 0;
 
@@ -578,9 +586,10 @@ class Transaction {
   // number of keys that need to be checked for conflicts at commit time.
   virtual uint64_t GetNumKeys() const = 0;
 
-  // Returns the number of Puts/Deletes/Merges that have been applied to this
-  // transaction so far.
+  // Returns the number of Put/PutEntity/Delete/Merge operations that have been
+  // applied to this transaction so far.
   virtual uint64_t GetNumPuts() const = 0;
+  virtual uint64_t GetNumPutEntities() const = 0;
   virtual uint64_t GetNumDeletes() const = 0;
   virtual uint64_t GetNumMerges() const = 0;
 

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -130,7 +130,7 @@ class WriteBatchWithIndex : public WriteBatchBase {
           "Cannot call this method without attribute groups");
     }
     return Status::NotSupported(
-        "PutEntity not supported by WriteBatchWithIndex");
+        "PutEntity with AttributeGroups not supported by WriteBatchWithIndex");
   }
 
   using WriteBatchBase::Merge;

--- a/unreleased_history/new_features/put_entity_txn.md
+++ b/unreleased_history/new_features/put_entity_txn.md
@@ -1,0 +1,1 @@
+Optimistic transactions and pessimistic transactions with the WriteCommitted policy now support the `PutEntity` API. Support for read APIs and other write policies (WritePrepared, WriteUnprepared) will be added later.

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -3,10 +3,10 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/pessimistic_transaction_db.h"
 
 #include <cinttypes>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -512,15 +512,15 @@ Transaction* PessimisticTransactionDB::BeginInternalTransaction(
   return txn;
 }
 
-// All user Put, Merge, Delete, and Write requests must be intercepted to make
-// sure that they lock all keys that they are writing to avoid causing conflicts
-// with any concurrent transactions. The easiest way to do this is to wrap all
-// write operations in a transaction.
+// All user Put, PutEntity, Merge, Delete, and Write requests must be
+// intercepted to make sure that they lock all keys that they are writing to
+// avoid causing conflicts with any concurrent transactions. The easiest way to
+// do this is to wrap all write operations in a transaction.
 //
-// Put(), Merge(), and Delete() only lock a single key per call.  Write() will
-// sort its keys before locking them.  This guarantees that TransactionDB write
-// methods cannot deadlock with each other (but still could deadlock with a
-// Transaction).
+// Put(), PutEntity(), Merge(), and Delete() only lock a single key per call.
+// Write() will sort its keys before locking them.  This guarantees that
+// TransactionDB write methods cannot deadlock with each other (but still could
+// deadlock with a Transaction).
 Status PessimisticTransactionDB::Put(const WriteOptions& options,
                                      ColumnFamilyHandle* column_family,
                                      const Slice& key, const Slice& val) {
@@ -543,6 +543,42 @@ Status PessimisticTransactionDB::Put(const WriteOptions& options,
   delete txn;
 
   return s;
+}
+
+Status PessimisticTransactionDB::PutEntity(const WriteOptions& options,
+                                           ColumnFamilyHandle* column_family,
+                                           const Slice& key,
+                                           const WideColumns& columns) {
+  {
+    const Status s = FailIfCfEnablesTs(this, column_family);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  {
+    std::unique_ptr<Transaction> txn(BeginInternalTransaction(options));
+    txn->DisableIndexing();
+
+    // Since the client didn't create a transaction, they don't care about
+    // conflict checking for this write.  So we just need to do
+    // PutEntityUntracked().
+    {
+      const Status s = txn->PutEntityUntracked(column_family, key, columns);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+
+    {
+      const Status s = txn->Commit();
+      if (!s.ok()) {
+        return s;
+      }
+    }
+  }
+
+  return Status::OK();
 }
 
 Status PessimisticTransactionDB::Delete(const WriteOptions& wopts,

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -50,6 +50,20 @@ class PessimisticTransactionDB : public TransactionDB {
   Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
              const Slice& key, const Slice& val) override;
 
+  Status PutEntity(const WriteOptions& options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   const WideColumns& columns) override;
+  Status PutEntity(const WriteOptions& /* options */, const Slice& /* key */,
+                   const AttributeGroups& attribute_groups) override {
+    if (attribute_groups.empty()) {
+      return Status::InvalidArgument(
+          "Cannot call this method without attribute groups");
+    }
+    return Status::NotSupported(
+        "PutEntity with AttributeGroups not supported by "
+        "PessimisticTransactionDB");
+  }
+
   using StackableDB::Delete;
   Status Delete(const WriteOptions& wopts, ColumnFamilyHandle* column_family,
                 const Slice& key) override;

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <stack>
 #include <string>
 #include <vector>
@@ -37,10 +36,11 @@ class TransactionBaseImpl : public Transaction {
 
   void Reinitialize(DB* db, const WriteOptions& write_options);
 
-  // Called before executing Put, Merge, Delete, and GetForUpdate.  If TryLock
-  // returns non-OK, the Put/Merge/Delete/GetForUpdate will be failed.
-  // do_validate will be false if called from PutUntracked, DeleteUntracked,
-  // MergeUntracked, or GetForUpdate(do_validate=false)
+  // Called before executing Put, PutEntity, Merge, Delete, and GetForUpdate. If
+  // TryLock returns non-OK, the Put/PutEntity/Merge/Delete/GetForUpdate will be
+  // failed. do_validate will be false if called from PutUntracked,
+  // PutEntityUntracked, DeleteUntracked, MergeUntracked, or
+  // GetForUpdate(do_validate=false)
   virtual Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                          bool read_only, bool exclusive,
                          const bool do_validate = true,
@@ -145,6 +145,15 @@ class TransactionBaseImpl : public Transaction {
     return Put(nullptr, key, value);
   }
 
+  Status PutEntity(ColumnFamilyHandle* column_family, const Slice& key,
+                   const WideColumns& columns,
+                   bool assume_tracked = false) override {
+    const bool do_validate = !assume_tracked;
+
+    return PutEntityImpl(column_family, key, columns, do_validate,
+                         assume_tracked);
+  }
+
   Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
                const Slice& value, const bool assume_tracked = false) override;
   Status Merge(const Slice& key, const Slice& value) override {
@@ -179,6 +188,15 @@ class TransactionBaseImpl : public Transaction {
                       const SliceParts& value) override;
   Status PutUntracked(const SliceParts& key, const SliceParts& value) override {
     return PutUntracked(nullptr, key, value);
+  }
+
+  Status PutEntityUntracked(ColumnFamilyHandle* column_family, const Slice& key,
+                            const WideColumns& columns) override {
+    constexpr bool do_validate = false;
+    constexpr bool assume_tracked = false;
+
+    return PutEntityImpl(column_family, key, columns, do_validate,
+                         assume_tracked);
   }
 
   Status MergeUntracked(ColumnFamilyHandle* column_family, const Slice& key,
@@ -240,6 +258,8 @@ class TransactionBaseImpl : public Transaction {
 
   uint64_t GetNumPuts() const override;
 
+  uint64_t GetNumPutEntities() const override;
+
   uint64_t GetNumDeletes() const override;
 
   uint64_t GetNumMerges() const override;
@@ -275,6 +295,10 @@ class TransactionBaseImpl : public Transaction {
 
   Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* column_family,
                  const Slice& key, PinnableSlice* value) override;
+
+  Status PutEntityImpl(ColumnFamilyHandle* column_family, const Slice& key,
+                       const WideColumns& columns, bool do_validate,
+                       bool assume_tracked);
 
   // Add a key to the list of tracked keys.
   //
@@ -320,6 +344,7 @@ class TransactionBaseImpl : public Transaction {
 
   // Count of various operations pending in this transaction
   uint64_t num_puts_ = 0;
+  uint64_t num_put_entities_ = 0;
   uint64_t num_deletes_ = 0;
   uint64_t num_merges_ = 0;
 
@@ -328,6 +353,7 @@ class TransactionBaseImpl : public Transaction {
     bool snapshot_needed_ = false;
     std::shared_ptr<TransactionNotifier> snapshot_notifier_;
     uint64_t num_puts_ = 0;
+    uint64_t num_put_entities_ = 0;
     uint64_t num_deletes_ = 0;
     uint64_t num_merges_ = 0;
 
@@ -336,12 +362,14 @@ class TransactionBaseImpl : public Transaction {
 
     SavePoint(std::shared_ptr<const Snapshot> snapshot, bool snapshot_needed,
               std::shared_ptr<TransactionNotifier> snapshot_notifier,
-              uint64_t num_puts, uint64_t num_deletes, uint64_t num_merges,
+              uint64_t num_puts, uint64_t num_put_entities,
+              uint64_t num_deletes, uint64_t num_merges,
               const LockTrackerFactory& lock_tracker_factory)
         : snapshot_(snapshot),
           snapshot_needed_(snapshot_needed),
           snapshot_notifier_(snapshot_notifier),
           num_puts_(num_puts),
+          num_put_entities_(num_put_entities),
           num_deletes_(num_deletes),
           num_merges_(num_merges),
           new_locks_(lock_tracker_factory.Create()) {}
@@ -373,10 +401,10 @@ class TransactionBaseImpl : public Transaction {
   // prepare phase is not skipped.
   WriteBatch commit_time_batch_;
 
-  // If true, future Put/Merge/Deletes will be indexed in the
-  // WriteBatchWithIndex.
-  // If false, future Put/Merge/Deletes will be inserted directly into the
-  // underlying WriteBatch and not indexed in the WriteBatchWithIndex.
+  // If true, future Put/PutEntity/Merge/Delete operations will be indexed in
+  // the WriteBatchWithIndex. If false, future Put/PutEntity/Merge/Delete
+  // operations will be inserted directly into the underlying WriteBatch and not
+  // indexed in the WriteBatchWithIndex.
   bool indexing_enabled_;
 
   // SetSnapshotOnNextOperation() has been called and the snapshot has not yet


### PR DESCRIPTION
Summary: The patch extends optimistic transactions and WriteCommitted pessimistic transactions with support for the `PutEntity` API. Similarly to the other APIs, `PutEntity` is available via both the `Transaction` and `TransactionDB` interfaces, where using the latter executes the write in a single-operation transaction as usual. Support for read APIs and other write policies (WritePrepared, WriteUnprepared) will be added in separate PRs.

Differential Revision: D56911242


