### PR TITLE
Remove build-linux-arm from circle_ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -880,9 +880,6 @@ jobs:
 
 workflows: # Only jobs that haven't been successfully migrated to GitHub Actions
   version: 2
-  jobs-linux-arm:
-    jobs:
-      - build-linux-arm
   benchmark-linux:
     triggers:
       - schedule:
@@ -893,13 +890,3 @@ workflows: # Only jobs that haven't been successfully migrated to GitHub Actions
                 - main
     jobs:
       - benchmark-linux
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 9 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - build-linux-arm-test-full


### PR DESCRIPTION
# Summary

`build-linux-arm` and `build-linux-arm-test-full` have been migrated to github actions in https://github.com/facebook/rocksdb/pull/12569.

Removing them from circle ci config.

Note: CircleCI has been turned off. We may nuke the config eventually.

# Test Plan

CI