### PR TITLE
Do not change compaction style for tiered_storage crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1109,13 +1109,13 @@ def whitebox_crash_main(args, unknown_args):
             }
             # Single level universal has a lot of special logic. Ensure we cover
             # it sometimes.
-            if random.randint(0, 1) == 1:
+            if not args.test_tiered_storage and random.randint(0, 1) == 1:
                 additional_opts.update(
                     {
                         "num_levels": 1,
                     }
                 )
-        elif check_mode == 2:
+        elif check_mode == 2 and not args.test_tiered_storage:
             # normal run with FIFO compaction mode
             # ops_per_thread is divided by 5 because FIFO compaction
             # style is quite a bit slower on reads with lot of files


### PR DESCRIPTION
Summary: tiered_storage crash tests are intended to run with universal compaction only: https://github.com/facebook/rocksdb/blob/e2ef349f56f99ae83d2ded1de23ff0684c66e1bb/tools/db_crashtest.py#L562 Update the test script to not change compaction style for tiered_storage crash tests.

Test plan: `python3 tools/db_crashtest.py whitebox --test_tiered_storage  --ops_per_thread=10 --max_key=100000 --duration=300 --reopen=1`