### PR TITLE
Disable some files from Windows compilation for 9.2

### DIFF
--- a/db/db_impl/db_impl_follower.cc
+++ b/db/db_impl/db_impl_follower.cc
@@ -3,6 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#if !defined(OS_WIN)
 #include "db/db_impl/db_impl_follower.h"
 
 #include <cinttypes>
@@ -308,3 +309,4 @@ Status DB::OpenAsFollower(
 }
 
 }  // namespace ROCKSDB_NAMESPACE
+#endif

--- a/db/db_impl/db_impl_follower.h
+++ b/db/db_impl/db_impl_follower.h
@@ -4,6 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #pragma once
+#if !defined(OS_WIN)
 
 #include <string>
 #include <vector>
@@ -51,3 +52,4 @@ class DBImplFollower : public DBImplSecondary {
   port::CondVar cv_;
 };
 }  // namespace ROCKSDB_NAMESPACE
+#endif

--- a/env/fs_on_demand.cc
+++ b/env/fs_on_demand.cc
@@ -3,6 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#if !defined(OS_WIN)
 #include "env/fs_on_demand.h"
 
 #include <algorithm>
@@ -329,3 +330,4 @@ std::shared_ptr<FileSystem> NewOnDemandFileSystem(
   return std::make_shared<OnDemandFileSystem>(fs, src_path, dest_path);
 }
 }  // namespace ROCKSDB_NAMESPACE
+#endif

--- a/env/fs_on_demand.h
+++ b/env/fs_on_demand.h
@@ -4,6 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #pragma once
+#if !defined(OS_WIN)
 #include <string>
 
 #include "rocksdb/file_system.h"
@@ -137,3 +138,4 @@ std::shared_ptr<FileSystem> NewOnDemandFileSystem(
     std::string local_path);
 
 }  // namespace ROCKSDB_NAMESPACE
+#endif


### PR DESCRIPTION
Disable the RocksDB follower code for Windows to prevent errors like -
`
fbcode\rocksdb\src\env\fs_on_demand.cc:184:10: error: no member named 'for_each' in namespace 'std'
    std::for_each(rchildren.begin(), rchildren.end(), [&](std::string& name) {
    ~~~~~^
`