### PR TITLE
Add padding before timestamp size record if it doesn't fit into a WAL block.

### DIFF
--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -789,7 +789,7 @@ TEST_P(LogTest, TimestampSizeRecordPadding) {
   UnorderedMap<uint32_t, size_t> ts_sz = {
       {2, sizeof(uint64_t)},
   };
-  writer_->MaybeAddUserDefinedTimestampSizeRecord(WriteOptions(), ts_sz);
+  ASSERT_OK(writer_->MaybeAddUserDefinedTimestampSizeRecord(WriteOptions(), ts_sz));
   ASSERT_LT(writer_->TEST_block_offset(), kBlockSize);
 
   const auto second_str = BigString("bar", 1000);

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -774,6 +774,31 @@ TEST_P(LogTest, RecycleWithTimestampSize) {
   ASSERT_EQ("EOF", Read());
 }
 
+// Validates that `MaybeAddUserDefinedTimestampSizeRecord`` adds padding to the
+// tail of a block and switches to a new block, if there's not enough space for
+// the record.
+TEST_P(LogTest, TimestampSizeRecordPadding) {
+  bool recyclable_log = (std::get<0>(GetParam()) != 0);
+  const size_t header_size =
+      recyclable_log ? kRecyclableHeaderSize : kHeaderSize;
+  const size_t data_len = kBlockSize - 2 * header_size;
+
+  const auto first_str = BigString("foo", data_len);
+  Write(first_str);
+
+  UnorderedMap<uint32_t, size_t> ts_sz = {
+      {2, sizeof(uint64_t)},
+  };
+  writer_->MaybeAddUserDefinedTimestampSizeRecord(WriteOptions(), ts_sz);
+  ASSERT_LT(writer_->TEST_block_offset(), kBlockSize);
+
+  const auto second_str = BigString("bar", 1000);
+  Write(second_str);
+
+  ASSERT_EQ(first_str, Read());
+  CheckRecordAndTimestampSize(second_str, ts_sz);
+}
+
 // Do NOT enable compression for this instantiation.
 INSTANTIATE_TEST_CASE_P(
     Log, LogTest,

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -789,7 +789,8 @@ TEST_P(LogTest, TimestampSizeRecordPadding) {
   UnorderedMap<uint32_t, size_t> ts_sz = {
       {2, sizeof(uint64_t)},
   };
-  ASSERT_OK(writer_->MaybeAddUserDefinedTimestampSizeRecord(WriteOptions(), ts_sz));
+  ASSERT_OK(
+      writer_->MaybeAddUserDefinedTimestampSizeRecord(WriteOptions(), ts_sz));
   ASSERT_LT(writer_->TEST_block_offset(), kBlockSize);
 
   const auto second_str = BigString("bar", 1000);

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -109,11 +109,14 @@ class Writer {
 
   bool BufferIsEmpty();
 
+  size_t TEST_block_offset() const { return block_offset_; }
+
  private:
   std::unique_ptr<WritableFileWriter> dest_;
   size_t block_offset_;  // Current offset in block
   uint64_t log_number_;
   bool recycle_log_files_;
+  int header_size_;
 
   // crc32c values for all supported record types.  These are
   // pre-computed to reduce the overhead of computing the crc of the


### PR DESCRIPTION
If timestamp size record doesn't fit into a block, without padding `Writer::EmitPhysicalRecord` fails on assert (either `assert(block_offset_ + kHeaderSize + n <= kBlockSize);` or `assert(block_offset_ + kRecyclableHeaderSize + n <= kBlockSize)`, depending on whether recycling log files is enabled)  in debug build. In release, current block grows beyond 32K, `block_offset_` gets reset on next `AddRecord` and all the subsequent blocks are no longer aligned by block size.