### PR TITLE
Fix truncating last character in the StderrLogger

### DIFF
--- a/util/stderr_logger.cc
+++ b/util/stderr_logger.cc
@@ -38,12 +38,12 @@ void StderrLogger::Logv(const char* format, va_list ap) {
 
   va_list ap_copy;
   va_copy(ap_copy, ap);
-  const size_t log_suffix_len = vsnprintf(nullptr, 0, format, ap_copy);
+  const size_t log_suffix_len = vsnprintf(nullptr, 0, format, ap_copy) + 1;
   va_end(ap_copy);
 
   // Allocate space for the context, log_prefix, and log itself
   // Extra byte for null termination
-  size_t buf_len = ctx_len + log_prefix_len + log_suffix_len + 1;
+  size_t buf_len = ctx_len + log_prefix_len + log_suffix_len;
   std::unique_ptr<char[]> buf(new char[buf_len]);
 
   // If the logger was created without a prefix, the prefix is a nullptr
@@ -55,8 +55,7 @@ void StderrLogger::Logv(const char* format, va_list ap) {
                t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min,
                t.tm_sec, static_cast<int>(now_tv.tv_usec),
                static_cast<long long unsigned int>(thread_id), prefix);
-  written += vsnprintf(buf.get() + written, log_suffix_len, format, ap);
-  buf[written] = '\0';
+  vsnprintf(buf.get() + written, log_suffix_len, format, ap);
 
   fprintf(stderr, "%s%c", buf.get(), '\n');
 }


### PR DESCRIPTION
This PR fixes a bug in the StderrLogger that truncated the last character in the logline. The problem was that we provided an incorrect max size parameter into the vsnprintf function. The size didn't take into account the null byte that the function automatically adds.

Before fix
```
** File Read Latency Histogram By Level [default] **
2024/05/04-18:50:24.209304 4788 [/db_impl/db_impl.cc:498] Shutdown: canceling all background wor
2024/05/04-18:50:24.209598 4788 [/db_impl/db_impl.cc:692] Shutdown complet
```

After fix
```
** File Read Latency Histogram By Level [default] **

2024/05/04-18:51:19.814584 4d4d [/db_impl/db_impl.cc:498] Shutdown: canceling all background work
2024/05/04-18:51:19.815528 4d4d [/db_impl/db_impl.cc:692] Shutdown complete
```

Test plan: tested on examples/simple_example.cc with StderrLogger
Fixes: #12576