### PR TITLE
Fix issue that cause false alarm corruption report

### DIFF
--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -1280,6 +1280,20 @@ void CompactionIterator::DecideOutputLevel() {
   }
 #endif  // NDEBUG
 
+  // saved_seq_for_penul_check_ is populated in `NextFromInput` when the
+  // entry's sequence number is non zero and validity context for output this
+  // entry is kSwapPreferredSeqno for use in `DecideOutputLevel`. It should be
+  // cleared out here unconditionally.
+  SequenceNumber seq_for_range_check =
+      (saved_seq_for_penul_check_.has_value() &&
+       saved_seq_for_penul_check_.value() != kMaxSequenceNumber)
+          ? saved_seq_for_penul_check_.value()
+          : ikey_.sequence;
+  saved_seq_for_penul_check_ = std::nullopt;
+  ParsedInternalKey ikey_for_range_check = ikey_;
+  if (seq_for_range_check != ikey_.sequence) {
+    ikey_for_range_check.sequence = seq_for_range_check;
+  }
   if (output_to_penultimate_level_) {
     // If it's decided to output to the penultimate level, but unsafe to do so,
     // still output to the last level. For example, moving the data from a lower
@@ -1287,16 +1301,6 @@ void CompactionIterator::DecideOutputLevel() {
     // considered unsafe, because the key may conflict with higher-level SSTs
     // not from this compaction.
     // TODO: add statistic for declined output_to_penultimate_level
-    SequenceNumber seq_for_range_check =
-        (saved_seq_for_penul_check_.has_value() &&
-         saved_seq_for_penul_check_.value() != kMaxSequenceNumber)
-            ? saved_seq_for_penul_check_.value()
-            : ikey_.sequence;
-    ParsedInternalKey ikey_for_range_check = ikey_;
-    if (seq_for_range_check != ikey_.sequence) {
-      ikey_for_range_check.sequence = seq_for_range_check;
-      saved_seq_for_penul_check_ = std::nullopt;
-    }
     bool safe_to_penultimate_level =
         compaction_->WithinPenultimateLevelOutputRange(ikey_for_range_check);
     if (!safe_to_penultimate_level) {
@@ -1310,7 +1314,7 @@ void CompactionIterator::DecideOutputLevel() {
       // snapshot is released before enabling `last_level_temperature` feature
       // We will migrate the feature to `last_level_temperature` and maybe make
       // it not dynamically changeable.
-      if (ikey_.sequence > earliest_snapshot_) {
+      if (seq_for_range_check > earliest_snapshot_) {
         status_ = Status::Corruption(
             "Unsafe to store Seq later than snapshot in the last level if "
             "per_key_placement is enabled");

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -1283,7 +1283,8 @@ void CompactionIterator::DecideOutputLevel() {
   // saved_seq_for_penul_check_ is populated in `NextFromInput` when the
   // entry's sequence number is non zero and validity context for output this
   // entry is kSwapPreferredSeqno for use in `DecideOutputLevel`. It should be
-  // cleared out here unconditionally.
+  // cleared out here unconditionally. Otherwise, it may end up getting consumed
+  // incorrectly by a different entry.
   SequenceNumber seq_for_range_check =
       (saved_seq_for_penul_check_.has_value() &&
        saved_seq_for_penul_check_.value() != kMaxSequenceNumber)


### PR DESCRIPTION
The state of `saved_seq_for_penul_check_` is not correctly maintained with the current flow. It's supposed to store the original sequence number for a `kTypeValuePreferredSeqno` entry for use in the `DecideOutputLevel` function. However, it's not always properly cleared.


Test Plan:
Added unit test that would fail before the fix
./tiered_compaction_test --gtest_filter="*InterleavedTimedPutAndPut*"