### PR TITLE
Disable file deletion before `GetLiveFilesStorageInfo()` in stress test

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1513,9 +1513,18 @@ Status StressTest::VerifyGetLiveFilesMetaData() const {
 
 // Test the return status of GetLiveFilesStorageInfo()
 Status StressTest::VerifyGetLiveFilesStorageInfo() const {
+  Status status = db_->DisableFileDeletions();
+  if (!status.ok()) {
+    return status;
+  }
+
   std::vector<LiveFileStorageInfo> live_file_storage_info;
-  return db_->GetLiveFilesStorageInfo(LiveFilesStorageInfoOptions(),
-                                      &live_file_storage_info);
+  status = db_->GetLiveFilesStorageInfo(LiveFilesStorageInfoOptions(),
+                                        &live_file_storage_info);
+  if (!status.ok()) {
+    return status;
+  }
+  return db_->EnableFileDeletions();
 }
 
 // Test GetAllColumnFamilyMetaData()


### PR DESCRIPTION
**Context/Summary:** 
According to below API, we need to disable/enable file deletion when testing `GetLiveFilesStorageInfo()` in crash test.
```
...
If creating a live copy, use DisableFileDeletions() before and EnableFileDeletions() after to prevent deletions.
...
  virtual Status GetLiveFilesStorageInfo(
...
```

Otherwise we can run into failures like
```
Verification failed: VerifyGetLiveFilesStorageInfo failed: IO error: No such file or directory: while stat a file for size: /dev/shm/rocksdb_test/rocksdb_crashtest_blackbox/027550.log: No such file or directory
```

**Test:**
CI
