### PR TITLE
fix gcc warning about dangling-reference in backup_engine_test

### DIFF
--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -4406,9 +4406,9 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
   delete db;
   db = nullptr;
 
-  for (auto be_pair :
-       {std::make_pair(backup_engine_.get(), alt_backup_engine),
-        std::make_pair(alt_backup_engine, backup_engine_.get())}) {
+  auto backup_engine = backup_engine_.get();
+  for (auto be_pair : {std::make_pair(backup_engine, alt_backup_engine),
+                       std::make_pair(alt_backup_engine, backup_engine)}) {
     ASSERT_OK(DestroyDB(dbname_, options_));
     RestoreOptions ro;
     // Fails without alternate dir
@@ -4430,9 +4430,9 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
   CloseBackupEngine();
   OpenBackupEngine();
 
-  for (auto be_pair :
-       {std::make_pair(backup_engine_.get(), alt_backup_engine),
-        std::make_pair(alt_backup_engine, backup_engine_.get())}) {
+  backup_engine = backup_engine_.get();
+  for (auto be_pair : {std::make_pair(backup_engine, alt_backup_engine),
+                       std::make_pair(alt_backup_engine, backup_engine)}) {
     ASSERT_OK(DestroyDB(dbname_, options_));
     RestoreOptions ro;
     ro.alternate_dirs.push_front(be_pair.second);
@@ -4459,9 +4459,9 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
   AssertBackupInfoConsistency(/*allow excluded*/ true);
 
   // Excluded file(s) deleted, unable to restore
-  for (auto be_pair :
-       {std::make_pair(backup_engine_.get(), alt_backup_engine),
-        std::make_pair(alt_backup_engine, backup_engine_.get())}) {
+  backup_engine = backup_engine_.get();
+  for (auto be_pair : {std::make_pair(backup_engine, alt_backup_engine),
+                       std::make_pair(alt_backup_engine, backup_engine)}) {
     RestoreOptions ro;
     ro.alternate_dirs.push_front(be_pair.second);
     ASSERT_TRUE(be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro)
@@ -4475,9 +4475,9 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
   AssertBackupInfoConsistency(/*allow excluded*/ true);
 
   // Excluded file(s) deleted, unable to restore
-  for (auto be_pair :
-       {std::make_pair(backup_engine_.get(), alt_backup_engine),
-        std::make_pair(alt_backup_engine, backup_engine_.get())}) {
+  backup_engine = backup_engine_.get();
+  for (auto be_pair : {std::make_pair(backup_engine, alt_backup_engine),
+                       std::make_pair(alt_backup_engine, backup_engine)}) {
     RestoreOptions ro;
     ro.alternate_dirs.push_front(be_pair.second);
     ASSERT_TRUE(be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro)


### PR DESCRIPTION
gcc 14.1 reports some warnings about dangling-reference occured in backup_engine_test.
```c++
/data/rocksdb/utilities/backup/backup_engine_test.cc: In member function 'virtual void rocksdb::{anonymous}::BackupEngineTest_ExcludeFiles_Test::TestBody()':
/data/rocksdb/utilities/backup/backup_engine_test.cc:4411:64: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
 4411 |         std::make_pair(alt_backup_engine, backup_engine_.get())}) {
      |                                                                ^
/data/rocksdb/utilities/backup/backup_engine_test.cc:4410:23: note: the temporary was destroyed at the end of the full expression 'std::make_pair<rocksdb::BackupEngine*, rocksdb::BackupEngine*&>(((rocksdb::{anonymous}::BackupEngineTest_ExcludeFiles_Test*)this)->rocksdb::{anonymous}::BackupEngineTest_ExcludeFiles_Test::rocksdb::{anonymous}::BackupEngineTest.rocksdb::{anonymous}::BackupEngineTest::backup_engine_.std::unique_ptr<rocksdb::BackupEngine>::get(), alt_backup_engine)'
 4410 |        {std::make_pair(backup_engine_.get(), alt_backup_engine),
      |         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/rocksdb/utilities/backup/backup_engine_test.cc:4411:64: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
 4411 |         std::make_pair(alt_backup_engine, backup_engine_.get())}) {
      |                                                                ^
/data/rocksdb/utilities/backup/backup_engine_test.cc:4411:23: note: the temporary was destroyed at the end of the full expression 'std::make_pair<rocksdb::BackupEngine*&, rocksdb::BackupEngine*>(alt_backup_engine, ((rocksdb::{anonymous}::BackupEngineTest_ExcludeFiles_Test*)this)->rocksdb::{anonymous}::BackupEngineTest_ExcludeFiles_Test::rocksdb::{anonymous}::BackupEngineTest.rocksdb::{anonymous}::BackupEngineTest::backup_engine_.std::unique_ptr<rocksdb::BackupEngine>::get())'
 4411 |         std::make_pair(alt_backup_engine, backup_engine_.get())}) {
      |         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
It seems to be related to this update in gcc:
https://gcc.gnu.org/gcc-14/changes.html#:~:text=%2DWdangling%2Dreference%20false%20positives%20have%20been%20reduced.%20The%20warning%20does%20not%20warn%20about%20std%3A%3Aspan%2Dlike%20classes%3B%20there%20is%20also%20a%20new%20attribute%20gnu%3A%3Ano_dangling%20to%20suppress%20the%20warning.%20See%20the%20manual%20for%20more%20info.
