### PR TITLE
Add MultiGetEntity AttributeGroup API to stress test

### DIFF
--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -545,6 +545,26 @@ class CfConsistencyStressTest : public StressTest {
             has_error = true;
             break;
           }
+
+          assert(cmp_s.ok() || cmp_s.IsNotFound());
+
+          if (s.IsNotFound()) {
+            if (cmp_s.ok()) {
+              fprintf(stderr,
+                      "MultiGetEntity (AttributeGroup) returns different "
+                      "results for key %s: CF %s "
+                      "returns entity %s, CF %s returns not found\n",
+                      key_slices[i].ToString(true).c_str(),
+                      column_family_names_[0].c_str(),
+                      WideColumnsToHex(cmp_columns).c_str(),
+                      column_family_names_[j].c_str());
+              is_consistent = false;
+              break;
+            }
+
+            continue;
+          }
+
           assert(s.ok());
           if (cmp_s.IsNotFound()) {
             fprintf(stderr,
@@ -561,8 +581,8 @@ class CfConsistencyStressTest : public StressTest {
 
           if (columns != cmp_columns) {
             fprintf(stderr,
-                    "MultiGetEntity  (AttributeGroup) returns different "
-                    "results for key %s: CF %s "
+                    "MultiGetEntity (AttributeGroup) returns different results "
+                    "for key %s: CF %s "
                     "returns entity %s, CF %s returns entity %s\n",
                     key_slices[i].ToString(true).c_str(),
                     column_family_names_[0].c_str(),
@@ -575,7 +595,7 @@ class CfConsistencyStressTest : public StressTest {
 
           if (!VerifyWideColumns(columns)) {
             fprintf(stderr,
-                    "MultiGetEntity  (AttributeGroup) error: inconsistent "
+                    "MultiGetEntity (AttributeGroup) error: inconsistent "
                     "columns for key %s, "
                     "entity %s\n",
                     key_slices[i].ToString(true).c_str(),

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -511,12 +511,14 @@ class CfConsistencyStressTest : public StressTest {
 
       std::vector<PinnableAttributeGroups> results;
       std::vector<Slice> key_slices;
+      std::vector<std::string> key_strs;
       results.reserve(num_keys);
       key_slices.reserve(num_keys);
+      key_strs.reserve(num_keys);
 
       for (size_t i = 0; i < num_keys; ++i) {
-        const std::string key = Key(rand_keys[i]);
-        key_slices.emplace_back(key);
+        key_strs.emplace_back(Key(rand_keys[i]));
+        key_slices.emplace_back(key_strs.back());
         PinnableAttributeGroups attribute_groups;
         for (auto* cfh : cfhs) {
           attribute_groups.emplace_back(cfh);

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -506,94 +506,197 @@ class CfConsistencyStressTest : public StressTest {
 
     const size_t num_keys = rand_keys.size();
 
-    for (size_t i = 0; i < num_keys; ++i) {
-      const std::string key = Key(rand_keys[i]);
+    if (FLAGS_use_attribute_group) {
+      // AttributeGroup MultiGetEntity verification
 
-      std::vector<Slice> key_slices(num_cfs, key);
-      std::vector<PinnableWideColumns> results(num_cfs);
-      std::vector<Status> statuses(num_cfs);
+      std::vector<PinnableAttributeGroups> results;
+      std::vector<Slice> key_slices;
+      results.reserve(num_keys);
+      key_slices.reserve(num_keys);
 
-      db_->MultiGetEntity(read_opts_copy, num_cfs, cfhs.data(),
-                          key_slices.data(), results.data(), statuses.data());
+      for (size_t i = 0; i < num_keys; ++i) {
+        const std::string key = Key(rand_keys[i]);
+        key_slices.emplace_back(key);
+        PinnableAttributeGroups attribute_groups;
+        for (auto* cfh : cfhs) {
+          attribute_groups.emplace_back(cfh);
+        }
+        results.emplace_back(std::move(attribute_groups));
+      }
+      db_->MultiGetEntity(read_opts_copy, num_keys, key_slices.data(),
+                          results.data());
 
       bool is_consistent = true;
 
-      for (size_t j = 0; j < num_cfs; ++j) {
-        const Status& s = statuses[j];
-        const Status& cmp_s = statuses[0];
-        const WideColumns& columns = results[j].columns();
-        const WideColumns& cmp_columns = results[0].columns();
+      for (size_t i = 0; i < num_keys; ++i) {
+        const auto& result = results[i];
+        const Status& cmp_s = result[0].status();
+        const WideColumns& cmp_columns = result[0].columns();
 
-        if (!s.ok() && !s.IsNotFound()) {
-          fprintf(stderr, "TestMultiGetEntity error: %s\n",
-                  s.ToString().c_str());
-          thread->stats.AddErrors(1);
-          break;
-        }
+        bool has_error = false;
 
-        assert(cmp_s.ok() || cmp_s.IsNotFound());
-
-        if (s.IsNotFound()) {
-          if (cmp_s.ok()) {
-            fprintf(
-                stderr,
-                "MultiGetEntity returns different results for key %s: CF %s "
-                "returns entity %s, CF %s returns not found\n",
-                StringToHex(key).c_str(), column_family_names_[0].c_str(),
-                WideColumnsToHex(cmp_columns).c_str(),
-                column_family_names_[j].c_str());
+        for (size_t j = 0; j < num_cfs; ++j) {
+          const Status& s = result[j].status();
+          const WideColumns& columns = result[j].columns();
+          if (!s.ok() && !s.IsNotFound()) {
+            fprintf(stderr, "TestMultiGetEntity (AttributeGroup) error: %s\n",
+                    s.ToString().c_str());
+            thread->stats.AddErrors(1);
+            has_error = true;
+            break;
+          }
+          assert(s.ok());
+          if (cmp_s.IsNotFound()) {
+            fprintf(stderr,
+                    "MultiGetEntity (AttributeGroup) returns different results "
+                    "for key %s: CF %s "
+                    "returns not found, CF %s returns entity %s\n",
+                    key_slices[i].ToString(true).c_str(),
+                    column_family_names_[0].c_str(),
+                    column_family_names_[j].c_str(),
+                    WideColumnsToHex(columns).c_str());
             is_consistent = false;
             break;
           }
 
-          continue;
-        }
+          if (columns != cmp_columns) {
+            fprintf(stderr,
+                    "MultiGetEntity  (AttributeGroup) returns different "
+                    "results for key %s: CF %s "
+                    "returns entity %s, CF %s returns entity %s\n",
+                    key_slices[i].ToString(true).c_str(),
+                    column_family_names_[0].c_str(),
+                    WideColumnsToHex(cmp_columns).c_str(),
+                    column_family_names_[j].c_str(),
+                    WideColumnsToHex(columns).c_str());
+            is_consistent = false;
+            break;
+          }
 
-        assert(s.ok());
-        if (cmp_s.IsNotFound()) {
-          fprintf(stderr,
-                  "MultiGetEntity returns different results for key %s: CF %s "
-                  "returns not found, CF %s returns entity %s\n",
-                  StringToHex(key).c_str(), column_family_names_[0].c_str(),
-                  column_family_names_[j].c_str(),
-                  WideColumnsToHex(columns).c_str());
-          is_consistent = false;
-          break;
+          if (!VerifyWideColumns(columns)) {
+            fprintf(stderr,
+                    "MultiGetEntity  (AttributeGroup) error: inconsistent "
+                    "columns for key %s, "
+                    "entity %s\n",
+                    key_slices[i].ToString(true).c_str(),
+                    WideColumnsToHex(columns).c_str());
+            is_consistent = false;
+            break;
+          }
         }
-
-        if (columns != cmp_columns) {
-          fprintf(stderr,
-                  "MultiGetEntity returns different results for key %s: CF %s "
-                  "returns entity %s, CF %s returns entity %s\n",
-                  StringToHex(key).c_str(), column_family_names_[0].c_str(),
-                  WideColumnsToHex(cmp_columns).c_str(),
-                  column_family_names_[j].c_str(),
-                  WideColumnsToHex(columns).c_str());
-          is_consistent = false;
+        if (has_error) {
           break;
-        }
-
-        if (!VerifyWideColumns(columns)) {
+        } else if (!is_consistent) {
           fprintf(stderr,
-                  "MultiGetEntity error: inconsistent columns for key %s, "
-                  "entity %s\n",
-                  StringToHex(key).c_str(), WideColumnsToHex(columns).c_str());
-          is_consistent = false;
+                  "TestMultiGetEntity (AttributeGroup) error: results are not "
+                  "consistent\n");
+          thread->stats.AddErrors(1);
+          // Fail fast to preserve the DB state.
+          thread->shared->SetVerificationFailure();
           break;
+        } else if (cmp_s.ok()) {
+          thread->stats.AddGets(1, 1);
+        } else if (cmp_s.IsNotFound()) {
+          thread->stats.AddGets(1, 0);
         }
       }
 
-      if (!is_consistent) {
-        fprintf(stderr,
-                "TestMultiGetEntity error: results are not consistent\n");
-        thread->stats.AddErrors(1);
-        // Fail fast to preserve the DB state.
-        thread->shared->SetVerificationFailure();
-        break;
-      } else if (statuses[0].ok()) {
-        thread->stats.AddGets(1, 1);
-      } else if (statuses[0].IsNotFound()) {
-        thread->stats.AddGets(1, 0);
+    } else {
+      // Non-AttributeGroup MultiGetEntity verification
+
+      for (size_t i = 0; i < num_keys; ++i) {
+        const std::string key = Key(rand_keys[i]);
+
+        std::vector<Slice> key_slices(num_cfs, key);
+        std::vector<PinnableWideColumns> results(num_cfs);
+        std::vector<Status> statuses(num_cfs);
+
+        db_->MultiGetEntity(read_opts_copy, num_cfs, cfhs.data(),
+                            key_slices.data(), results.data(), statuses.data());
+
+        bool is_consistent = true;
+
+        const Status& cmp_s = statuses[0];
+        const WideColumns& cmp_columns = results[0].columns();
+
+        for (size_t j = 0; j < num_cfs; ++j) {
+          const Status& s = statuses[j];
+          const WideColumns& columns = results[j].columns();
+
+          if (!s.ok() && !s.IsNotFound()) {
+            fprintf(stderr, "TestMultiGetEntity error: %s\n",
+                    s.ToString().c_str());
+            thread->stats.AddErrors(1);
+            break;
+          }
+
+          assert(cmp_s.ok() || cmp_s.IsNotFound());
+
+          if (s.IsNotFound()) {
+            if (cmp_s.ok()) {
+              fprintf(
+                  stderr,
+                  "MultiGetEntity returns different results for key %s: CF %s "
+                  "returns entity %s, CF %s returns not found\n",
+                  StringToHex(key).c_str(), column_family_names_[0].c_str(),
+                  WideColumnsToHex(cmp_columns).c_str(),
+                  column_family_names_[j].c_str());
+              is_consistent = false;
+              break;
+            }
+
+            continue;
+          }
+
+          assert(s.ok());
+          if (cmp_s.IsNotFound()) {
+            fprintf(
+                stderr,
+                "MultiGetEntity returns different results for key %s: CF %s "
+                "returns not found, CF %s returns entity %s\n",
+                StringToHex(key).c_str(), column_family_names_[0].c_str(),
+                column_family_names_[j].c_str(),
+                WideColumnsToHex(columns).c_str());
+            is_consistent = false;
+            break;
+          }
+
+          if (columns != cmp_columns) {
+            fprintf(
+                stderr,
+                "MultiGetEntity returns different results for key %s: CF %s "
+                "returns entity %s, CF %s returns entity %s\n",
+                StringToHex(key).c_str(), column_family_names_[0].c_str(),
+                WideColumnsToHex(cmp_columns).c_str(),
+                column_family_names_[j].c_str(),
+                WideColumnsToHex(columns).c_str());
+            is_consistent = false;
+            break;
+          }
+
+          if (!VerifyWideColumns(columns)) {
+            fprintf(stderr,
+                    "MultiGetEntity error: inconsistent columns for key %s, "
+                    "entity %s\n",
+                    StringToHex(key).c_str(),
+                    WideColumnsToHex(columns).c_str());
+            is_consistent = false;
+            break;
+          }
+        }
+
+        if (!is_consistent) {
+          fprintf(stderr,
+                  "TestMultiGetEntity error: results are not consistent\n");
+          thread->stats.AddErrors(1);
+          // Fail fast to preserve the DB state.
+          thread->shared->SetVerificationFailure();
+          break;
+        } else if (statuses[0].ok()) {
+          thread->stats.AddGets(1, 1);
+        } else if (statuses[0].IsNotFound()) {
+          thread->stats.AddGets(1, 0);
+        }
       }
     }
   }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1077,130 +1077,257 @@ class NonBatchedOpsStressTest : public StressTest {
     std::vector<std::string> keys(num_keys);
     std::vector<Slice> key_slices(num_keys);
 
-    for (size_t i = 0; i < num_keys; ++i) {
-      keys[i] = Key(rand_keys[i]);
-      key_slices[i] = keys[i];
-    }
-
-    std::vector<PinnableWideColumns> results(num_keys);
-    std::vector<Status> statuses(num_keys);
-
     if (fault_fs_guard) {
       fault_fs_guard->EnableErrorInjection();
       SharedState::ignore_read_error = false;
     }
 
-    db_->MultiGetEntity(read_opts_copy, cfh, num_keys, key_slices.data(),
-                        results.data(), statuses.data());
+    for (size_t i = 0; i < num_keys; ++i) {
+      keys[i] = Key(rand_keys[i]);
+      key_slices[i] = keys[i];
+    }
 
     int error_count = 0;
 
-    if (fault_fs_guard) {
-      error_count = fault_fs_guard->GetAndResetErrorCount();
-
-      if (error_count && !SharedState::ignore_read_error) {
-        int stat_nok = 0;
-        for (const auto& s : statuses) {
-          if (!s.ok() && !s.IsNotFound()) {
-            stat_nok++;
-          }
-        }
-
-        if (stat_nok < error_count) {
-          // Grab mutex so multiple threads don't try to print the
-          // stack trace at the same time
-          assert(thread->shared);
-          MutexLock l(thread->shared->GetMutex());
-
-          fprintf(stderr, "Didn't get expected error from MultiGetEntity\n");
-          fprintf(stderr, "num_keys %zu Expected %d errors, seen %d\n",
-                  num_keys, error_count, stat_nok);
-          fprintf(stderr, "Call stack that injected the fault\n");
-          fault_fs_guard->PrintFaultBacktrace();
-          std::terminate();
+    auto handle_result = [&](ThreadState* _thread, const Status& s,
+                             bool is_consistent, int err_count) {
+      if (!is_consistent) {
+        fprintf(stderr,
+                "TestMultiGetEntity%s error: results are not consistent\n",
+                FLAGS_use_attribute_group ? "(AttributeGroup)" : "");
+        _thread->stats.AddErrors(1);
+        // Fail fast to preserve the DB state
+        _thread->shared->SetVerificationFailure();
+      } else if (s.ok()) {
+        _thread->stats.AddGets(1, 1);
+      } else if (s.IsNotFound()) {
+        _thread->stats.AddGets(1, 0);
+      } else {
+        if (err_count == 0) {
+          fprintf(stderr, "MultiGetEntity%s error: %s\n",
+                  FLAGS_use_attribute_group ? "(AttributeGroup)" : "",
+                  s.ToString().c_str());
+          _thread->stats.AddErrors(1);
+        } else {
+          _thread->stats.AddVerifiedErrors(1);
         }
       }
+    };
 
-      fault_fs_guard->DisableErrorInjection();
-    }
+    if (FLAGS_use_attribute_group) {
+      // AttributeGroup MultiGetEntity verification
 
-    const bool check_get_entity =
-        !error_count && FLAGS_check_multiget_entity_consistency;
+      std::vector<PinnableAttributeGroups> results;
+      results.reserve(num_keys);
+      for (size_t i = 0; i < num_keys; ++i) {
+        PinnableAttributeGroups attribute_groups;
+        attribute_groups.emplace_back(cfh);
+        results.emplace_back(std::move(attribute_groups));
+      }
+      db_->MultiGetEntity(read_opts_copy, num_keys, key_slices.data(),
+                          results.data());
 
-    for (size_t i = 0; i < num_keys; ++i) {
-      const Status& s = statuses[i];
+      if (fault_fs_guard) {
+        error_count = fault_fs_guard->GetAndResetErrorCount();
 
-      bool is_consistent = true;
-
-      if (s.ok() && !VerifyWideColumns(results[i].columns())) {
-        fprintf(
-            stderr,
-            "error : inconsistent columns returned by MultiGetEntity for key "
-            "%s: %s\n",
-            StringToHex(keys[i]).c_str(),
-            WideColumnsToHex(results[i].columns()).c_str());
-        is_consistent = false;
-      } else if (check_get_entity && (s.ok() || s.IsNotFound())) {
-        PinnableWideColumns cmp_result;
-        ThreadStatusUtil::SetThreadOperation(
-            ThreadStatus::OperationType::OP_GETENTITY);
-        const Status cmp_s =
-            db_->GetEntity(read_opts_copy, cfh, key_slices[i], &cmp_result);
-
-        if (!cmp_s.ok() && !cmp_s.IsNotFound()) {
-          fprintf(stderr, "GetEntity error: %s\n", cmp_s.ToString().c_str());
-          is_consistent = false;
-        } else if (cmp_s.IsNotFound()) {
-          if (s.ok()) {
-            fprintf(stderr,
-                    "Inconsistent results for key %s: MultiGetEntity returned "
-                    "ok, GetEntity returned not found\n",
-                    StringToHex(keys[i]).c_str());
-            is_consistent = false;
+        if (error_count && !SharedState::ignore_read_error) {
+          int stat_nok = 0;
+          for (size_t i = 0; i < num_keys; ++i) {
+            const Status& s = results[i][0].status();
+            if (!s.ok() && !s.IsNotFound()) {
+              stat_nok++;
+            }
           }
-        } else {
-          assert(cmp_s.ok());
 
-          if (s.IsNotFound()) {
+          if (stat_nok < error_count) {
+            // Grab mutex so multiple threads don't try to print the
+            // stack trace at the same time
+            assert(thread->shared);
+            MutexLock l(thread->shared->GetMutex());
+
             fprintf(stderr,
-                    "Inconsistent results for key %s: MultiGetEntity returned "
-                    "not found, GetEntity returned ok\n",
-                    StringToHex(keys[i]).c_str());
-            is_consistent = false;
-          } else {
-            assert(s.ok());
+                    "Didn't get expected error from MultiGetEntity "
+                    "(AttributeGroup)\n");
+            fprintf(stderr, "num_keys %zu Expected %d errors, seen %d\n",
+                    num_keys, error_count, stat_nok);
+            fprintf(stderr, "Call stack that injected the fault\n");
+            fault_fs_guard->PrintFaultBacktrace();
+            std::terminate();
+          }
+        }
+        fault_fs_guard->DisableErrorInjection();
+      }
 
-            if (results[i] != cmp_result) {
-              fprintf(
-                  stderr,
-                  "Inconsistent results for key %s: MultiGetEntity returned "
-                  "%s, GetEntity returned %s\n",
+      // Compare against non-attribute-group GetEntity result
+      const bool check_get_entity =
+          !error_count && FLAGS_check_multiget_entity_consistency;
+
+      for (size_t i = 0; i < num_keys; ++i) {
+        assert(results[i].size() == 1);
+        const Status& s = results[i][0].status();
+
+        bool is_consistent = true;
+
+        if (s.ok() && !VerifyWideColumns(results[i][0].columns())) {
+          fprintf(stderr,
+                  "error : inconsistent columns returned by MultiGetEntity "
+                  "(AttributeGroup) for key "
+                  "%s: %s\n",
                   StringToHex(keys[i]).c_str(),
-                  WideColumnsToHex(results[i].columns()).c_str(),
-                  WideColumnsToHex(cmp_result.columns()).c_str());
+                  WideColumnsToHex(results[i][0].columns()).c_str());
+          is_consistent = false;
+        } else if (check_get_entity && (s.ok() || s.IsNotFound())) {
+          PinnableWideColumns cmp_result;
+          ThreadStatusUtil::SetThreadOperation(
+              ThreadStatus::OperationType::OP_GETENTITY);
+          const Status cmp_s =
+              db_->GetEntity(read_opts_copy, cfh, key_slices[i], &cmp_result);
+
+          if (!cmp_s.ok() && !cmp_s.IsNotFound()) {
+            fprintf(stderr, "GetEntity error: %s\n", cmp_s.ToString().c_str());
+            is_consistent = false;
+          } else if (cmp_s.IsNotFound()) {
+            if (s.ok()) {
+              fprintf(stderr,
+                      "Inconsistent results for key %s: MultiGetEntity "
+                      "(AttributeGroup) returned "
+                      "ok, GetEntity returned not found\n",
+                      StringToHex(keys[i]).c_str());
               is_consistent = false;
+            }
+          } else {
+            assert(cmp_s.ok());
+
+            if (s.IsNotFound()) {
+              fprintf(stderr,
+                      "Inconsistent results for key %s: MultiGetEntity "
+                      "(AttributeGroup) returned "
+                      "not found, GetEntity returned ok\n",
+                      StringToHex(keys[i]).c_str());
+              is_consistent = false;
+            } else {
+              assert(s.ok());
+
+              if (results[i][0].columns() != cmp_result.columns()) {
+                fprintf(stderr,
+                        "Inconsistent results for key %s: MultiGetEntity "
+                        "(AttributeGroup) returned "
+                        "%s, GetEntity returned %s\n",
+                        StringToHex(keys[i]).c_str(),
+                        WideColumnsToHex(results[i][0].columns()).c_str(),
+                        WideColumnsToHex(cmp_result.columns()).c_str());
+                is_consistent = false;
+              }
             }
           }
         }
+        handle_result(thread, s, is_consistent, error_count);
+        if (!is_consistent) {
+          break;
+        }
+      }
+    } else {
+      // Non-AttributeGroup MultiGetEntity verification
+
+      std::vector<PinnableWideColumns> results(num_keys);
+      std::vector<Status> statuses(num_keys);
+
+      db_->MultiGetEntity(read_opts_copy, cfh, num_keys, key_slices.data(),
+                          results.data(), statuses.data());
+
+      if (fault_fs_guard) {
+        error_count = fault_fs_guard->GetAndResetErrorCount();
+
+        if (error_count && !SharedState::ignore_read_error) {
+          int stat_nok = 0;
+          for (const auto& s : statuses) {
+            if (!s.ok() && !s.IsNotFound()) {
+              stat_nok++;
+            }
+          }
+
+          if (stat_nok < error_count) {
+            // Grab mutex so multiple threads don't try to print the
+            // stack trace at the same time
+            assert(thread->shared);
+            MutexLock l(thread->shared->GetMutex());
+
+            fprintf(stderr, "Didn't get expected error from MultiGetEntity\n");
+            fprintf(stderr, "num_keys %zu Expected %d errors, seen %d\n",
+                    num_keys, error_count, stat_nok);
+            fprintf(stderr, "Call stack that injected the fault\n");
+            fault_fs_guard->PrintFaultBacktrace();
+            std::terminate();
+          }
+        }
+
+        fault_fs_guard->DisableErrorInjection();
       }
 
-      if (!is_consistent) {
-        fprintf(stderr,
-                "TestMultiGetEntity error: results are not consistent\n");
-        thread->stats.AddErrors(1);
-        // Fail fast to preserve the DB state
-        thread->shared->SetVerificationFailure();
-        break;
-      } else if (s.ok()) {
-        thread->stats.AddGets(1, 1);
-      } else if (s.IsNotFound()) {
-        thread->stats.AddGets(1, 0);
-      } else {
-        if (error_count == 0) {
-          fprintf(stderr, "MultiGetEntity error: %s\n", s.ToString().c_str());
-          thread->stats.AddErrors(1);
-        } else {
-          thread->stats.AddVerifiedErrors(1);
+      const bool check_get_entity =
+          !error_count && FLAGS_check_multiget_entity_consistency;
+
+      for (size_t i = 0; i < num_keys; ++i) {
+        const Status& s = statuses[i];
+
+        bool is_consistent = true;
+
+        if (s.ok() && !VerifyWideColumns(results[i].columns())) {
+          fprintf(
+              stderr,
+              "error : inconsistent columns returned by MultiGetEntity for key "
+              "%s: %s\n",
+              StringToHex(keys[i]).c_str(),
+              WideColumnsToHex(results[i].columns()).c_str());
+          is_consistent = false;
+        } else if (check_get_entity && (s.ok() || s.IsNotFound())) {
+          PinnableWideColumns cmp_result;
+          ThreadStatusUtil::SetThreadOperation(
+              ThreadStatus::OperationType::OP_GETENTITY);
+          const Status cmp_s =
+              db_->GetEntity(read_opts_copy, cfh, key_slices[i], &cmp_result);
+
+          if (!cmp_s.ok() && !cmp_s.IsNotFound()) {
+            fprintf(stderr, "GetEntity error: %s\n", cmp_s.ToString().c_str());
+            is_consistent = false;
+          } else if (cmp_s.IsNotFound()) {
+            if (s.ok()) {
+              fprintf(
+                  stderr,
+                  "Inconsistent results for key %s: MultiGetEntity returned "
+                  "ok, GetEntity returned not found\n",
+                  StringToHex(keys[i]).c_str());
+              is_consistent = false;
+            }
+          } else {
+            assert(cmp_s.ok());
+
+            if (s.IsNotFound()) {
+              fprintf(
+                  stderr,
+                  "Inconsistent results for key %s: MultiGetEntity returned "
+                  "not found, GetEntity returned ok\n",
+                  StringToHex(keys[i]).c_str());
+              is_consistent = false;
+            } else {
+              assert(s.ok());
+
+              if (results[i] != cmp_result) {
+                fprintf(
+                    stderr,
+                    "Inconsistent results for key %s: MultiGetEntity returned "
+                    "%s, GetEntity returned %s\n",
+                    StringToHex(keys[i]).c_str(),
+                    WideColumnsToHex(results[i].columns()).c_str(),
+                    WideColumnsToHex(cmp_result.columns()).c_str());
+                is_consistent = false;
+              }
+            }
+          }
+        }
+        handle_result(thread, s, is_consistent, error_count);
+        if (!is_consistent) {
+          break;
         }
       }
     }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1089,8 +1089,8 @@ class NonBatchedOpsStressTest : public StressTest {
 
     int error_count = 0;
 
-    auto handle_result = [&](ThreadState* _thread, const Status& s,
-                             bool is_consistent, int err_count) {
+    auto handle_result = [](ThreadState* _thread, const Status& s,
+                            bool is_consistent, int err_count) {
       if (!is_consistent) {
         fprintf(stderr,
                 "TestMultiGetEntity%s error: results are not consistent\n",


### PR DESCRIPTION
# Summary

Continuing from https://github.com/facebook/rocksdb/pull/12605, adding AttributeGroup `MultiGetEntity` API to stress tests.

# Test Plan

**AttributeGroup Tests**

NonBatchOps
```
python3 tools/db_crashtest.py blackbox --simple --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=1 --use_put_entity_one_in=1 --use_multi_get=1
```

BatchOps
```
python3 tools/db_crashtest.py blackbox  --test_batches_snapshots=1 --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=1 --use_put_entity_one_in=1 --use_multi_get=1
```

CfConsistency Test
```
python3 tools/db_crashtest.py blackbox --cf_consistency --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=1 --use_put_entity_one_in=1 --use_multi_get=1
```


**Non-AttributeGroup Tests**

NonBatchOps
```
python3 tools/db_crashtest.py blackbox --simple --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=0 --use_put_entity_one_in=1 --use_multi_get=1
```

BatchOps
```
python3 tools/db_crashtest.py blackbox  --test_batches_snapshots=1 --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=0 --use_put_entity_one_in=1 --use_multi_get=1
```

CfConsistency Test
```
python3 tools/db_crashtest.py blackbox --cf_consistency --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=0 --use_put_entity_one_in=1 --use_multi_get=1
```
