### PR TITLE
Temporarily disable file ingestion and LockWAL combination

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -674,6 +674,10 @@ TEST_F(ExternalSSTFileBasicTest, NoCopy) {
   ASSERT_EQ(file3_info.smallest_key, Key(110));
   ASSERT_EQ(file3_info.largest_key, Key(124));
 
+  ASSERT_OK(dbfull()->LockWAL());
+  // TODO(FIXME): should not allow file ingestion.
+  // With below line, ingestion will block, without it, ingestion can go
+  // through. ASSERT_OK(dbfull()->Put(WriteOptions(), "vo", "vo"));
   s = DeprecatedAddFile({file1}, true /* move file */);
   ASSERT_OK(s) << s.ToString();
   ASSERT_EQ(Status::NotFound(), env_->FileExists(file1));

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -858,6 +858,9 @@ def finalize_and_sanitize(src_params):
     elif (dest_params.get("use_put_entity_one_in") > 1 and
         dest_params.get("use_timed_put_one_in") == 1):
         dest_params["use_timed_put_one_in"] = 3
+    # TODO: renable this when file ingestion is failed during wal lock.
+    if dest_params.get("lock_wal_one_in") != 0:
+        dest_params["ingest_external_file_one_in"] = 0
     return dest_params
 
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -858,11 +858,13 @@ def finalize_and_sanitize(src_params):
     elif (dest_params.get("use_put_entity_one_in") > 1 and
         dest_params.get("use_timed_put_one_in") == 1):
         dest_params["use_timed_put_one_in"] = 3
-    # TODO: renable this when file ingestion is failed during wal lock.
-    if dest_params.get("lock_wal_one_in") != 0:
-        dest_params["ingest_external_file_one_in"] = 0
+    # TODO: re-enable this combination.
+    if dest_params.get("lock_wal_one_in") != 0 and dest_params["ingest_external_file_one_in"] != 0:
+        if random.choice([0, 1]) == 0:
+            dest_params["ingest_external_file_one_in"] = 0
+        else:
+            dest_params["lock_wal_one_in"] = 0
     return dest_params
-
 
 def gen_cmd_params(args):
     params = {}


### PR DESCRIPTION
As titled. A proper fix should probably be failing file ingestion if the DB is in a lock wal state as it promises to "Freezes the logical state of the DB".