### PR TITLE
Test PromoteL0() with no concurrent PromoteL0() in stress test

### DIFF
--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -150,6 +150,8 @@ class SharedState {
 
   port::CondVar* GetCondVar() { return &cv_; }
 
+  port::Mutex* GetTestPromoteL0Mutex() { return &test_promote_l0_mu_; }
+
   StressTest* GetStressTest() const { return stress_test_; }
 
   int64_t GetMaxKey() const { return max_key_; }
@@ -384,6 +386,7 @@ class SharedState {
 
   port::Mutex mu_;
   port::CondVar cv_;
+  port::Mutex test_promote_l0_mu_;
   const uint32_t seed_;
   const int64_t max_key_;
   const uint32_t log2_keys_per_lock_;


### PR DESCRIPTION
**Context/Summary:**

If any file on L0 that PromoteL0() called on were moved or deleted concurrently by another PromoteL0(), it will result and propagate to users the corruption `Corruption: VersionBuilder: Cannot delete table file #13 from level 0 since it is on level 3` to users. Such corruption will fail any subsequent writes. While it's debatable whether we should let such failure in PromoteL0() fail any subsequent writes, the easiest fix for now is to test PromoteL0() without any concurrent PromoteL0().


**Test:** 
CI that failed before this fix and pass after with equally frequent PromoteL0()