### PR TITLE
Remove testing PromoteL0() in stress test

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -209,7 +209,6 @@ DECLARE_int32(ingest_external_file_one_in);
 DECLARE_int32(ingest_external_file_width);
 DECLARE_int32(compact_files_one_in);
 DECLARE_int32(compact_range_one_in);
-DECLARE_int32(promote_l0_one_in);
 DECLARE_int32(mark_for_compaction_one_file_in);
 DECLARE_int32(flush_one_in);
 DECLARE_int32(key_may_exist_one_in);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -756,10 +756,6 @@ DEFINE_int32(compact_range_one_in, 0,
              "If non-zero, then CompactRange() will be called once for every N "
              "operations on average.  0 indicates CompactRange() is disabled.");
 
-DEFINE_int32(promote_l0_one_in, 0,
-             "If non-zero, then PromoteL0() will be called once for every N "
-             "operations on average.  0 indicates PromoteL0() is disabled.");
-
 DEFINE_int32(mark_for_compaction_one_file_in, 0,
              "A `TablePropertiesCollectorFactory` will be registered, which "
              "creates a `TablePropertiesCollector` with `NeedCompact()` "

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -140,9 +140,6 @@ class StressTest {
                                 const Slice& start_key,
                                 ColumnFamilyHandle* column_family);
 
-  virtual void TestPromoteL0(ThreadState* thread,
-                             ColumnFamilyHandle* column_family);
-
   // Calculate a hash value for all keys in range [start_key, end_key]
   // at a certain snapshot.
   uint32_t GetRangeHash(ThreadState* thread, const Snapshot* snapshot,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -67,9 +67,6 @@ default_params = {
     "clear_column_family_one_in": 0,
     "compact_files_one_in":  lambda: random.choice([1000, 1000000]),
     "compact_range_one_in":  lambda: random.choice([1000, 1000000]),
-    # Disabled because of various likely related failures with
-    # "Cannot delete table file #N from level 0 since it is on level X"
-    "promote_l0_one_in": 0,
     "compaction_pri": random.randint(0, 4),
     "key_may_exist_one_in":  lambda: random.choice([100, 100000]),
     "data_block_index_type": lambda: random.choice([0, 1]),


### PR DESCRIPTION
Context/Summary: this function is very likely to be deprecated in the future

Test: CI