### PR TITLE
Revamp stress test for LockWAL(), tweak contract

### DIFF
--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1676,15 +1676,13 @@ class DB {
   // sync is done.
   virtual Status SyncWAL() = 0;
 
-  // Freezes the logical state of the DB (by stopping writes), and if WAL is
-  // enabled, ensures that state has been flushed to DB files (as in
-  // FlushWAL()). This can be used for taking a Checkpoint at a known DB
-  // state, though the user must use options to insure no DB flush is invoked
-  // in this frozen state. Other operations allowed on a "read only" DB should
-  // work while frozen. Each LockWAL() call that returns OK must eventually be
-  // followed by a corresponding call to UnlockWAL(). Where supported, non-OK
-  // status is generally only possible with some kind of corruption or I/O
-  // error.
+  // Blocks writes to the WAL (and some other writes not requiring the WAL)
+  // and ensures the current WAL state has been flushed (as in FlushWAL()).
+  // Some changes to the DB logical (and physical) state may still progress,
+  // such as file ingestion and compaction. Each LockWAL() call that returns
+  // OK must eventually be followed by a corresponding call to UnlockWAL().
+  // Where supported, non-OK status is generally only possible with some kind
+  // of corruption or I/O error.
   virtual Status LockWAL() {
     return Status::NotSupported("LockWAL not implemented");
   }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -864,12 +864,6 @@ def finalize_and_sanitize(src_params):
     elif (dest_params.get("use_put_entity_one_in") > 1 and
         dest_params.get("use_timed_put_one_in") == 1):
         dest_params["use_timed_put_one_in"] = 3
-    # TODO: re-enable this combination.
-    if dest_params.get("lock_wal_one_in") != 0 and dest_params["ingest_external_file_one_in"] != 0:
-        if random.choice([0, 1]) == 0:
-            dest_params["ingest_external_file_one_in"] = 0
-        else:
-            dest_params["lock_wal_one_in"] = 0
     return dest_params
 
 def gen_cmd_params(args):

--- a/unreleased_history/public_api_changes/lock_wal.md
+++ b/unreleased_history/public_api_changes/lock_wal.md
@@ -1,0 +1,1 @@
+Changed the contract of LockWAL() without changing the behavior. Some logical state changes like file ingestion are not blocked by LockWAL().


### PR DESCRIPTION
Summary: Upon discovering that LockWAL() does not block file ingestion, I looked into whether its behavior should be expanded to block that or whether it should block as little as reasonably possible to freeze the WAL state.

Although the idea of freezing more things that resemble writes was broadly attractive, I found in digging through the code that that would likely expose us to more risks of freezing too much, leading to deadlock. Stopped writes is a good, mature mechanism to reasonably over-approximate what is needed to freeze the WAL state.

LockWAL might not even be a useful feature. The MySQL team suspects that FlushWAL would be sufficient for their needs, because writes should already be blocked on their side, but we aren't yet sure we can deprecate the LockWAL feature.

So the best course of action now, in this commit and IMHO, is to
* Change how we validate LockWAL() in db_stress, checking for changes to GetCurrentWalFile state instead of change to latest sequence number.
* Change the contract for LockWAL() to better reflect what we now understand it actually does, which is closer to the original intended functionality.

This does not change any LockWAL functionality (and I think we should avoid changing the implementation in the same minor release if we're changing the contract in a minor release).

Follow-up to https://github.com/facebook/rocksdb/pull/12642

Test Plan:
The modifications to how we validate LockWAL() in the stress test mean we can re-enable file ingestion in combination with LockWAL(); HOWEVER, the new validation is bypassed when FaultInjectionTestFS is used because of at least two issues, which are detailed in a FIXME comment in db_stress_test_base.cc where the validation code lives.

I've run blackbox_crash_test for quite a while with certain relevant amplifications to ensure it remains stable.