### PR TITLE
Use 'INFO' level for 'tail prefetch size is calculated based on'

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -858,11 +858,11 @@ Status BlockBasedTable::PrefetchTail(
       // properties, at which point we don't yet know the index type.
       tail_prefetch_size = prefetch_all || preload_all ? 512 * 1024 : 4 * 1024;
 
-      ROCKS_LOG_WARN(logger,
+      ROCKS_LOG_INFO(logger,
                      "Tail prefetch size %zu is calculated based on heuristics",
                      tail_prefetch_size);
     } else {
-      ROCKS_LOG_WARN(
+      ROCKS_LOG_INFO(
           logger,
           "Tail prefetch size %zu is calculated based on TailPrefetchStats",
           tail_prefetch_size);


### PR DESCRIPTION
These log messages make quite a lot of spam on each DB open.
Since these messages do not indicate any problem and just indicate that SST file was created by a pre-9.0.0 RocksDB, I think it log level can be lowered to `INFO`

Fixes #12664 