### PR TITLE
Add EntryType for TimedPut

### DIFF
--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -47,6 +47,8 @@ EntryType GetEntryType(ValueType value_type) {
       return kEntryBlobIndex;
     case kTypeWideColumnEntity:
       return kEntryWideColumnEntity;
+    case kTypeValuePreferredSeqno:
+      return kEntryTimedPut;
     default:
       return kEntryOther;
   }

--- a/include/rocksdb/types.h
+++ b/include/rocksdb/types.h
@@ -67,6 +67,7 @@ enum EntryType {
   kEntryBlobIndex,
   kEntryDeleteWithTimestamp,
   kEntryWideColumnEntity,
+  kEntryTimedPut,  // That hasn't yet converted to a standard Put entry
   kEntryOther,
 };
 


### PR DESCRIPTION
Summary: Represent internal kTypeValuePreferredSeqno in the public API as kEntryTimedPut (because it is created by TimedPut, until the entry can be safely converted to a regular value entry in compaction)

Test Plan: for follow-up work actually using it. But putting this in place in the public API gives us more flexibility in rolling out that follow-up work (e.g. as a user extension or patch if needed).