### PR TITLE
Fix value of `inplace_update_support` across stress test runs

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -687,6 +687,11 @@ def finalize_and_sanitize(src_params):
         if dest_params["prefix_size"] < 0:
             dest_params["prefix_size"] = 1
 
+    # BER disables WAL and tests unsynced data loss which
+    # does not work with inplace_update_support.
+    if dest_params.get("best_efforts_recovery") == 1:
+        dest_params["inplace_update_support"] = 0
+
     # Multi-key operations are not currently compatible with transactions or
     # timestamp.
     if (
@@ -701,6 +706,22 @@ def finalize_and_sanitize(src_params):
     ):
         dest_params["delpercent"] += dest_params["delrangepercent"]
         dest_params["delrangepercent"] = 0
+    # Since the value of inplace_update_support needs to be fixed across runs,
+    # we disable other incompatible options here instead of disabling
+    # inplace_update_support based on other option values, which may change
+    # across runs.
+    if dest_params["inplace_update_support"] == 1:
+       dest_params["delpercent"] += dest_params["delrangepercent"]
+       dest_params["delrangepercent"] = 0
+       dest_params["readpercent"] += dest_params["prefixpercent"]
+       dest_params["prefixpercent"] = 0
+       dest_params["allow_concurrent_memtable_write"] = 0
+       # inplace_update_support does not update sequence number. Our stress test recovery
+       # logic for unsynced data loss relies on max sequence number stored
+       # in MANIFEST, so they don't work together.
+       dest_params["disable_wal"] = 0
+       dest_params["sync_fault_injection"] = 0
+       dest_params["manual_wal_flush_one_in"] = 0
     if (
         dest_params.get("disable_wal") == 1
         or dest_params.get("sync_fault_injection") == 1
@@ -723,16 +744,9 @@ def finalize_and_sanitize(src_params):
         # with potential data loss in mind like start of each `./db_stress` run.
         # Therefore it always expects no data loss.
         dest_params["reopen"] = 0
-        # inplace_update_support can cause memtable update to swallow newer
-        # sequence numbers. Our trace-and-replay logic replies on accurate
-        # tracking of the latest sequence number so they don't work together.
-        dest_params["inplace_update_support"] = 0
-    if dest_params["inplace_update_support"] == 1:
-       dest_params["delpercent"] += dest_params["delrangepercent"]
-       dest_params["delrangepercent"] = 0
-       dest_params["readpercent"] += dest_params["prefixpercent"]
-       dest_params["prefixpercent"] = 0
     # Only under WritePrepared txns, unordered_write would provide the same guarnatees as vanilla rocksdb
+    # unordered_write is only enabled with --txn, and txn_params disables inplace_update_support, so
+    # setting allow_concurrent_memtable_write=1 won't conflcit with inplace_update_support.
     if dest_params.get("unordered_write", 0) == 1:
         dest_params["txn_write_policy"] = 1
         dest_params["allow_concurrent_memtable_write"] = 1
@@ -836,7 +850,6 @@ def finalize_and_sanitize(src_params):
           dest_params["disable_wal"] = 0
     if dest_params.get("allow_concurrent_memtable_write", 1) == 1:
         dest_params["memtablerep"] = "skip_list"
-        dest_params["inplace_update_support"] = 0
     if (dest_params.get("enable_compaction_filter", 0) == 1
         or dest_params.get("inplace_update_support", 0) == 1):
         # Compaction filter, inplace update support are incompatible with snapshots. Need to avoid taking


### PR DESCRIPTION
Summary: the value of `inplace_update_support` option need to be fixed across runs of db_stress on the same DB (#12577). My recent fix (#12673) regressed this behavior. Also fix some existing places where this does not hold.


Test plan: monitor crash tests related to `inplace_update_support`.