### PR TITLE
Fix the output of `ldb dump_wal` for PutEntity records

### DIFF
--- a/db/wide/wide_columns_helper.cc
+++ b/db/wide/wide_columns_helper.cc
@@ -6,6 +6,7 @@
 #include "db/wide/wide_columns_helper.h"
 
 #include <algorithm>
+#include <ios>
 
 #include "db/wide/wide_column_serialization.h"
 
@@ -15,6 +16,9 @@ void WideColumnsHelper::DumpWideColumns(const WideColumns& columns,
   if (columns.empty()) {
     return;
   }
+
+  const std::ios_base::fmtflags orig_flags = os.flags();
+
   if (hex) {
     os << std::hex;
   }
@@ -23,6 +27,8 @@ void WideColumnsHelper::DumpWideColumns(const WideColumns& columns,
   for (++it; it != columns.end(); ++it) {
     os << ' ' << *it;
   }
+
+  os.flags(orig_flags);
 }
 
 Status WideColumnsHelper::DumpSliceAsWideColumns(const Slice& value,

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2666,11 +2666,19 @@ class InMemoryHandler : public WriteBatch::Handler {
 
   Status PutEntityCF(uint32_t cf, const Slice& key,
                      const Slice& value) override {
-    row_ << "PUT_ENTITY(" << cf << ") : ";
-    std::string k = LDBCommand::StringToHex(key.ToString());
+    row_ << "PUT_ENTITY(" << cf
+         << ") : " << LDBCommand::StringToHex(key.ToString());
+
     if (print_values_) {
-      return WideColumnsHelper::DumpSliceAsWideColumns(value, row_, true);
+      row_ << " : ";
+      const Status s =
+          WideColumnsHelper::DumpSliceAsWideColumns(value, row_, true);
+      if (!s.ok()) {
+        return s;
+      }
     }
+
+    row_ << ' ';
     return Status::OK();
   }
 


### PR DESCRIPTION
Summary:
The patch contains two fixes related to printing `PutEntity` records with `ldb dump_wal`:
1) It adds the key to the printout (it was missing earlier).
2) It restores the formatting flags of the output stream after dumping the wide-column structure so that any `hex` flag that might have been set does not affect subsequent printing of e.g. sequence numbers.

Differential Revision: D57591295


