### PR TITLE
Add LDB command and option for follower instances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,7 @@ set(SOURCES
         db/db_impl/db_impl_write.cc
         db/db_impl/db_impl_compaction_flush.cc
         db/db_impl/db_impl_files.cc
+        db/db_impl/db_impl_follower.cc
         db/db_impl/db_impl_open.cc
         db/db_impl/db_impl_debug.cc
         db/db_impl/db_impl_experimental.cc
@@ -748,6 +749,7 @@ set(SOURCES
         env/env_encryption.cc
         env/file_system.cc
         env/file_system_tracer.cc
+        env/fs_on_demand.cc
         env/fs_remap.cc
         env/mock_env.cc
         env/unique_id_gen.cc
@@ -1037,10 +1039,8 @@ endif()
 
 else()
   list(APPEND SOURCES
-    db/db_impl/db_impl_follower.cc
     port/port_posix.cc
     env/env_posix.cc
-    env/fs_on_demand.cc
     env/fs_posix.cc
     env/io_posix.cc)
 endif()

--- a/db/db_impl/db_impl_follower.cc
+++ b/db/db_impl/db_impl_follower.cc
@@ -5,6 +5,7 @@
 
 #include "db/db_impl/db_impl_follower.h"
 
+#include <algorithm>
 #include <cinttypes>
 
 #include "db/arena_wrapped_db_iter.h"

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -84,6 +84,10 @@ class LDBCommand {
 
   static LDBCommand* SelectCommand(const ParsedParams& parsed_parms);
 
+  static void ParseSingleParam(const std::string& param,
+                               ParsedParams& parsed_params,
+                               std::vector<std::string>& cmd_tokens);
+
   static LDBCommand* InitFromCmdLineArgs(
       const std::vector<std::string>& args, const Options& options,
       const LDBOptions& ldb_options,

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -35,6 +35,7 @@ class LDBCommand {
   static const std::string ARG_DB;
   static const std::string ARG_PATH;
   static const std::string ARG_SECONDARY_PATH;
+  static const std::string ARG_LEADER_PATH;
   static const std::string ARG_HEX;
   static const std::string ARG_KEY_HEX;
   static const std::string ARG_VALUE_HEX;
@@ -156,6 +157,7 @@ class LDBCommand {
   // with this secondary path. When running against a database opened by
   // another process, ldb wll leave the source directory completely intact.
   std::string secondary_path_;
+  std::string leader_path_;
   std::string column_family_name_;
   DB* db_;
   DBWithTTL* db_ttl_;

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -3995,7 +3995,7 @@ void DBQuerierCommand::DoCommand() {
         iter->Next();
       }
       if (iter->status().ok()) {
-        fprintf(stdout, "%lu\n", count);
+        fprintf(stdout, "%" PRIu64 "\n", count);
       } else {
         oss << "scan from " << start_key << " to " << end_key
             << "failed: " << iter->status().ToString();

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -3894,7 +3894,6 @@ void DBQuerierCommand::DoCommand() {
     // Parse line into std::vector<std::string>
     std::vector<std::string> tokens;
     ParsedParams parsed_params;
-    std::map<std::string, std::string> option_map;
     size_t pos = 0;
     while (true) {
       size_t pos2 = line.find(' ', pos);
@@ -3922,7 +3921,8 @@ void DBQuerierCommand::DoCommand() {
               "put <key> <value>\n"
               "delete <key>\n"
               "count [--from=<start_key>] [--to=<end_key>]\n");
-    } else if (cmd == DELETE_CMD && tokens.size() == 2) {
+    } else if (cmd == DELETE_CMD && tokens.size() == 2 &&
+               parsed_params.option_map.empty()) {
       key = (is_key_hex_ ? HexToString(tokens[1]) : tokens[1]);
       s = db_->Delete(write_options, GetCfHandle(), Slice(key));
       if (s.ok()) {
@@ -3930,7 +3930,8 @@ void DBQuerierCommand::DoCommand() {
       } else {
         oss << "delete " << key << " failed: " << s.ToString();
       }
-    } else if (cmd == PUT_CMD && tokens.size() == 3) {
+    } else if (cmd == PUT_CMD && tokens.size() == 3 &&
+               parsed_params.option_map.empty()) {
       key = (is_key_hex_ ? HexToString(tokens[1]) : tokens[1]);
       value = (is_value_hex_ ? HexToString(tokens[2]) : tokens[2]);
       s = db_->Put(write_options, GetCfHandle(), Slice(key), Slice(value));
@@ -3940,7 +3941,8 @@ void DBQuerierCommand::DoCommand() {
       } else {
         oss << "put " << key << "=>" << value << " failed: " << s.ToString();
       }
-    } else if (cmd == GET_CMD && tokens.size() == 2) {
+    } else if (cmd == GET_CMD && tokens.size() == 2 &&
+               parsed_params.option_map.empty()) {
       key = (is_key_hex_ ? HexToString(tokens[1]) : tokens[1]);
       s = db_->Get(read_options, GetCfHandle(), Slice(key), &value);
       if (s.ok()) {
@@ -3960,7 +3962,7 @@ void DBQuerierCommand::DoCommand() {
       std::string start_key;
       std::string end_key;
       bool bad_option = false;
-      for (auto& option : option_map) {
+      for (auto& option : parsed_params.option_map) {
         if (option.first == "from") {
           start_key =
               (is_key_hex_ ? HexToString(option.second) : option.second);

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -620,6 +620,7 @@ class DBQuerierCommand : public LDBCommand {
   static const char* GET_CMD;
   static const char* PUT_CMD;
   static const char* DELETE_CMD;
+  static const char* COUNT_CMD;
 };
 
 class CheckConsistencyCommand : public LDBCommand {

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -28,6 +28,9 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
   ret.append("  --" + LDBCommand::ARG_SECONDARY_PATH +
              "=<secondary_path> to open DB as secondary instance. Operations "
              "not supported in secondary instance will fail.\n\n");
+  ret.append("  --" + LDBCommand::ARG_LEADER_PATH +
+             "=<leader_path> to open DB as a follower instance. Operations "
+             "not supported in follower instance will fail.\n\n");
   ret.append(
       "The following optional parameters control if keys/values are "
       "input/output as hex or as plain strings:\n");

--- a/unreleased_history/new_features/ldb_count_command.md
+++ b/unreleased_history/new_features/ldb_count_command.md
@@ -1,0 +1,1 @@
+Added a new "count" command to the ldb repl shell. By default, it prints a count of keys in the database from start to end. The options --from=<key> and/or --to=<key> can be specified to limit the range.


### PR DESCRIPTION
Add the `--leader_path` option to specify the directory path of the leader for a follower RocksDB instance. This PR also adds a `count` command to the repl shell. While not specific to followers, it is useful for testing purposes.