### PR TITLE
Flush WAL upon DB close

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -628,11 +628,11 @@ Status DBImpl::CloseHelper() {
   }
   if (!mutable_db_options_.avoid_sync_during_shutdown && !logs_.empty()) {
     mutex_.Unlock();
-    Status s = SyncWAL();
+    Status s = FlushWAL(true /* sync */);
     mutex_.Lock();
     if (!s.ok()) {
       ROCKS_LOG_WARN(immutable_db_options_.info_log,
-                     "Unable to sync WALs with error -- %s",
+                     "Unable to flush and sync WALs with error -- %s",
                      s.ToString().c_str());
       if (ret.ok()) {
         ret = s;

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -641,6 +641,7 @@ TEST_F(FaultInjectionFSTest, SyncWALDuringDBClose) {
       std::make_shared<FaultInjectionTestFS>(env_->GetFileSystem());
   std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, fault_fs));
   Options options = CurrentOptions();
+  options.manual_wal_flush = true;
   options.avoid_sync_during_shutdown = true;
   options.env = env.get();
   Reopen(options);

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1265,9 +1265,10 @@ struct DBOptions {
   // Dynamically changeable through SetDBOptions() API.
   bool avoid_flush_during_shutdown = false;
 
-  // By default RocksDB will not sync WAL on DB close even if there are
-  // unpersisted data (i.e. unsynced WAL data). This can speedup
-  // DB close. Unpersisted data WILL BE LOST.
+  // By default RocksDB will not flush (if `manual_wal_flush` = true) and sync
+  // WAL on DB close even if there are unpersisted data (i.e. unflushed or
+  // unsynced WAL data). This can speed up DB close. Unpersisted data WILL BE
+  // LOST.
   //
   // DEFAULT: true
   //

--- a/unreleased_history/behavior_changes/flush_wal_close.md
+++ b/unreleased_history/behavior_changes/flush_wal_close.md
@@ -1,0 +1,1 @@
+* When `manual_wal_flush=true`, `avoid_sync_during_shutdown=false` will flush WALs before syncing them


### PR DESCRIPTION
**Context/Summary:** https://github.com/facebook/rocksdb/pull/12556 `avoid_sync_during_shutdown=false` missed an edge case where `manual_wal_flush == true` so WAL sync will still miss unflushed WAL. This PR fixes it.


**Test plan:** modified UT to include this case `manual_wal_flush==true`