### PR TITLE
Fix c++ compilation errors on Linux using g++

### DIFF
--- a/cache/compressed_secondary_cache.cc
+++ b/cache/compressed_secondary_cache.cc
@@ -101,7 +101,7 @@ std::unique_ptr<SecondaryCacheResultHandle> CompressedSecondaryCache::Lookup(
 
       size_t uncompressed_size{0};
       CacheAllocationPtr uncompressed =
-          UncompressData(uncompression_info, (char*)data_ptr,
+          UncompressData(uncompression_info, data_ptr,
                          handle_value_charge, &uncompressed_size,
                          cache_options_.compress_format_version, allocator);
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -6054,7 +6054,7 @@ Status DBImpl::CreateColumnFamilyWithImport(
       return Status::InvalidArgument("Comparator name mismatch");
     }
     for (auto& file : metadatas[i]->files) {
-      metadata_files[i].push_back((LiveFileMetaData*)&file);
+      metadata_files[i].push_back(const_cast<LiveFileMetaData*>(&file));
     }
     total_file_num += metadatas[i]->files.size();
   }

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -41,7 +41,7 @@ IOStatus EncryptedSequentialFile::Read(size_t n, const IOOptions& options,
   {
     PERF_TIMER_GUARD(decrypt_data_nanos);
     io_s = status_to_io_status(
-        stream_->Decrypt(offset_, (char*)result->data(), result->size()));
+        stream_->Decrypt(offset_, const_cast<char*>(result->data()), result->size()));
   }
   if (io_s.ok()) {
     offset_ += result->size();  // We've already read data from disk, so update
@@ -86,7 +86,7 @@ IOStatus EncryptedSequentialFile::PositionedRead(uint64_t offset, size_t n,
   {
     PERF_TIMER_GUARD(decrypt_data_nanos);
     io_s = status_to_io_status(
-        stream_->Decrypt(offset, (char*)result->data(), result->size()));
+        stream_->Decrypt(offset, const_cast<char*>(result->data()), result->size()));
   }
   return io_s;
 }
@@ -104,7 +104,7 @@ IOStatus EncryptedRandomAccessFile::Read(uint64_t offset, size_t n,
   {
     PERF_TIMER_GUARD(decrypt_data_nanos);
     io_s = status_to_io_status(
-        stream_->Decrypt(offset, (char*)result->data(), result->size()));
+        stream_->Decrypt(offset, const_cast<char*>(result->data()), result->size()));
   }
   return io_s;
 }
@@ -308,7 +308,7 @@ IOStatus EncryptedRandomRWFile::Read(uint64_t offset, size_t n,
   {
     PERF_TIMER_GUARD(decrypt_data_nanos);
     status = status_to_io_status(
-        stream_->Decrypt(offset, (char*)result->data(), result->size()));
+        stream_->Decrypt(offset, const_cast<char*>(result->data()), result->size()));
   }
   return status;
 }
@@ -1100,7 +1100,7 @@ Status CTREncryptionProvider::CreateCipherStream(
   Status status;
   {
     PERF_TIMER_GUARD(decrypt_data_nanos);
-    status = cipherStream.Decrypt(0, (char*)prefix.data() + (2 * blockSize),
+    status = cipherStream.Decrypt(0, const_cast<char*>(prefix.data()) + (2 * blockSize),
                                   prefix.size() - (2 * blockSize));
   }
   if (!status.ok()) {

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -1327,7 +1327,7 @@ IndexBlockIter* Block::NewIndexIterator(
 size_t Block::ApproximateMemoryUsage() const {
   size_t usage = usable_size();
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE
-  usage += malloc_usable_size((void*)this);
+  usage += malloc_usable_size(static_cast<void*>(const_cast<Block*>((this))));
 #else
   usage += sizeof(*this);
 #endif  // ROCKSDB_MALLOC_USABLE_SIZE

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -108,7 +108,7 @@ class BlockReadAmpBitmap {
 
   size_t ApproximateMemoryUsage() const {
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE
-    return malloc_usable_size(static_cast<void*>(const_cast<rocksdb::BlockReadAmpBitmap*>(this)));
+    return malloc_usable_size(static_cast<void*>(const_cast<BlockReadAmpBitmap*>(this)));
 #endif  // ROCKSDB_MALLOC_USABLE_SIZE
     return sizeof(*this);
   }

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -108,7 +108,7 @@ class BlockReadAmpBitmap {
 
   size_t ApproximateMemoryUsage() const {
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE
-    return malloc_usable_size((void*)this);
+    return malloc_usable_size(static_cast<void*>(const_cast<rocksdb::BlockReadAmpBitmap*>(this)));
 #endif  // ROCKSDB_MALLOC_USABLE_SIZE
     return sizeof(*this);
   }
@@ -612,7 +612,7 @@ class BlockIter : public InternalIteratorBase<TValue> {
       key_pinned_ = false;
     }
     TEST_SYNC_POINT_CALLBACK("BlockIter::UpdateKey::value",
-                             (void*)value_.data());
+                             static_cast<void*>(const_cast<char*>(value_.data())));
     TEST_SYNC_POINT_CALLBACK("Block::VerifyChecksum::checksum_len",
                              &protection_bytes_per_key_);
     if (protection_bytes_per_key_ > 0) {

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -225,7 +225,7 @@ TableProperties::GetAggregatablePropertiesAsMap() const {
 std::size_t TableProperties::ApproximateMemoryUsage() const {
   std::size_t usage = 0;
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE
-  usage += malloc_usable_size((void*)this);
+  usage += malloc_usable_size(static_cast<void*>(const_cast<TableProperties*>(this)));
 #else
   usage += sizeof(*this);
 #endif  // ROCKSDB_MALLOC_USABLE_SIZE

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -269,7 +269,7 @@ class OverwritingStringSink : public FSWritableFile {
   IOStatus Flush(const IOOptions& /*opts*/, IODebugContext* /*dbg*/) override {
     if (last_flush_ < contents_.size()) {
       assert(reader_contents_->size() >= contents_.size());
-      memcpy((char*)reader_contents_->data() + last_flush_,
+      memcpy(const_cast<char*>(reader_contents_->data()) + last_flush_,
              contents_.data() + last_flush_, contents_.size() - last_flush_);
       last_flush_ = contents_.size();
     }

--- a/test_util/transaction_test_util.cc
+++ b/test_util/transaction_test_util.cc
@@ -357,7 +357,7 @@ Status RandomTransactionInserter::Verify(DB* db, uint16_t num_sets,
             "VerifyRead at %" PRIu64 " (%" PRIu64 "): %.*s value: %" PRIu64,
             roptions.snapshot ? roptions.snapshot->GetSequenceNumber() : 0ul,
             roptions.snapshot
-                ? ((SnapshotImpl*)roptions.snapshot)->min_uncommitted_
+                ? (static_cast<SnapshotImpl*>(const_cast<Snapshot*>(roptions.snapshot)))->min_uncommitted_
                 : 0ul,
             static_cast<int>(key.size()), key.data(), int_value);
         total += int_value;

--- a/util/stderr_logger.cc
+++ b/util/stderr_logger.cc
@@ -12,7 +12,7 @@
 namespace ROCKSDB_NAMESPACE {
 StderrLogger::~StderrLogger() {
   if (log_prefix != nullptr) {
-    free((void*)log_prefix);
+    free(static_cast<void*>(const_cast<char*>(log_prefix)));
   }
 }
 
@@ -33,7 +33,7 @@ void StderrLogger::Logv(const char* format, va_list ap) {
   // 44 bytes, but we allocate 50 to be safe.
   //
   //    ctx_len = 44         = ( 4+ 1+ 2+1+2+ 1+2+ 1+2+ 1+ 2+1+6+ 1+16+1)
-  const char* ctx_prefix_fmt = "%04d/%02d/%02d-%02d:%02d:%02d.%06d %llx %s";
+  const char* const ctx_prefix_fmt = "%04d/%02d/%02d-%02d:%02d:%02d.%06d %llx %s";
   size_t ctx_len = 50;
 
   va_list ap_copy;

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -162,7 +162,10 @@ std::string TimeToHumanString(int unixtime) {
   struct tm tInfo;
   struct tm* timeinfo = port::LocalTimeR(&rawtime, &tInfo);
   assert(timeinfo == &tInfo);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-y2k"
   strftime(time_buffer, 80, "%c", timeinfo);
+#pragma GCC diagnostic pop
   return std::string(time_buffer);
 }
 

--- a/utilities/cache_dump_load_impl.h
+++ b/utilities/cache_dump_load_impl.h
@@ -359,7 +359,7 @@ class CacheDumperHelper {
     if (!GetLengthPrefixedSlice(&encoded_slice, &block)) {
       return Status::Incomplete("Decode dumped unit string failed");
     }
-    dump_unit->value = (void*)block.data();
+    dump_unit->value = static_cast<void*>(const_cast<char*>(block.data()));
     assert(block.size() == dump_unit->value_len);
     return Status::OK();
   }

--- a/utilities/persistent_cache/block_cache_tier.cc
+++ b/utilities/persistent_cache/block_cache_tier.cc
@@ -322,7 +322,7 @@ Status BlockCacheTier::NewCacheFile() {
   lock_.AssertHeld();
 
   TEST_SYNC_POINT_CALLBACK("BlockCacheTier::NewCacheFile:DeleteDir",
-                           (void*)(GetCachePath().c_str()));
+                           static_cast<void*>(const_cast<char*>(GetCachePath().c_str())));
 
   std::unique_ptr<WriteableCacheFile> f(new WriteableCacheFile(
       opt_.env, &buffer_allocator_, &writer_, GetCachePath(), writer_cache_id_,

--- a/utilities/transactions/lock/range/range_tree/lib/util/dbt.cc
+++ b/utilities/transactions/lock/range/range_tree/lib/util/dbt.cc
@@ -88,7 +88,7 @@ void toku_destroy_dbt(DBT *dbt) {
 DBT *toku_fill_dbt(DBT *dbt, const void *k, size_t len) {
   toku_init_dbt(dbt);
   dbt->size = len;
-  dbt->data = (char *)k;
+  dbt->data = static_cast<char *>(const_cast<void *>(k));
   return dbt;
 }
 

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
@@ -198,7 +198,7 @@ void RangeTreeLockManager::UnLock(PessimisticTransaction* txn,
 
   // tracked_locks_->range_list may hold nullptr if the transaction has never
   // acquired any locks.
-  ((RangeTreeLockTracker*)range_tracker)->ReleaseLocks(this, txn, all_keys);
+  const_cast<RangeTreeLockTracker*>(range_tracker)->ReleaseLocks(this, txn, all_keys);
 }
 
 int RangeTreeLockManager::CompareDbtEndpoints(void* arg, const DBT* a_key,
@@ -373,7 +373,7 @@ void RangeTreeLockManager::AddColumnFamily(const ColumnFamilyHandle* cfh) {
   if (ltree_map_.find(column_family_id) == ltree_map_.end()) {
     DICTIONARY_ID dict_id = {.dictid = column_family_id};
     toku::comparator cmp;
-    cmp.create(CompareDbtEndpoints, (void*)cfh->GetComparator());
+    cmp.create(CompareDbtEndpoints, static_cast<void*>(const_cast<Comparator*>(cfh->GetComparator())));
     toku::locktree* ltree =
         ltm_.get_lt(dict_id, cmp,
                     /* on_create_extra*/ static_cast<void*>(this));


### PR DESCRIPTION
This PR fixes a number of compilation errors seen compiling on Linux (Ubuntu 22.04.4 LTS) using cmake 3.29 and g++ 11.4.0

Sampling of errors fixed are as follows:

```
rocksdb/table/block_based/block.cc:1330:31: error: cast from type ‘const rocksdb::Block*’ to type ‘void*’ casts away qualifiers [-Werror=cast-qual]
rocksdb/test_util/testutil.h:272:14: error: cast from type ‘const char*’ to type ‘char*’ casts away qualifiers [-Werror=cast-qual]
rocksdb/util/stderr_logger.cc:36:53: error: format not a string literal, argument types not checked [-Werror=format-nonlteral]
rocksdb/util/string_util.cc:165:29: error: ‘%c’ yields only last 2 digits of year in some locales [-Werror=format-y2k]
```

NOTES:
cache/compressed_secondary_cache.cc - UncompressedData already takes in a const char*, so no need to cast to (char *)

const_cast<T> is used to remove const qualifiers.
static_cast<T> is used to change types (largely from one pointer type to another).
reinterpret_cast<T>was used in places that static_cast<T> would not work.