### PR TITLE
Expose column family export and import methods publicly

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1107,8 +1107,19 @@ rocksdb_column_family_handle_t* rocksdb_create_column_family_with_import(
   return c_handle;
 }
 
-rocksdb_export_import_files_metadata_t*
-rocksdb_checkpoint_export_column_family(rocksdb_t* db,
+rocksdb_column_family_handle_t* rocksdb_create_column_family_with_ttl(
+    rocksdb_t* db, const rocksdb_options_t* column_family_options,
+    const char* column_family_name, int ttl, char** errptr) {
+  ROCKSDB_NAMESPACE::DBWithTTL* db_with_ttl =
+      static_cast<ROCKSDB_NAMESPACE::DBWithTTL*>(db->rep);
+  rocksdb_column_family_handle_t* handle = new rocksdb_column_family_handle_t;
+  SaveError(errptr, db_with_ttl->CreateColumnFamilyWithTtl(
+                        ColumnFamilyOptions(column_family_options->rep),
+                        std::string(column_family_name), &(handle->rep), ttl));
+  return handle;
+}
+
+rocksdb_export_import_files_metadata_t* rocksdb_checkpoint_export_column_family(rocksdb_t* db,
                                         rocksdb_checkpoint_t* checkpoint,
                                         rocksdb_column_family_handle_t* handle,
                                         const char* export_dir, char** errptr) {

--- a/db/c.cc
+++ b/db/c.cc
@@ -1107,19 +1107,8 @@ rocksdb_column_family_handle_t* rocksdb_create_column_family_with_import(
   return c_handle;
 }
 
-rocksdb_column_family_handle_t* rocksdb_create_column_family_with_ttl(
-    rocksdb_t* db, const rocksdb_options_t* column_family_options,
-    const char* column_family_name, int ttl, char** errptr) {
-  ROCKSDB_NAMESPACE::DBWithTTL* db_with_ttl =
-      static_cast<ROCKSDB_NAMESPACE::DBWithTTL*>(db->rep);
-  rocksdb_column_family_handle_t* handle = new rocksdb_column_family_handle_t;
-  SaveError(errptr, db_with_ttl->CreateColumnFamilyWithTtl(
-                        ColumnFamilyOptions(column_family_options->rep),
-                        std::string(column_family_name), &(handle->rep), ttl));
-  return handle;
-}
-
-rocksdb_export_import_files_metadata_t* rocksdb_checkpoint_export_column_family(rocksdb_t* db,
+rocksdb_export_import_files_metadata_t*
+rocksdb_checkpoint_export_column_family(rocksdb_t* db,
                                         rocksdb_checkpoint_t* checkpoint,
                                         rocksdb_column_family_handle_t* handle,
                                         const char* export_dir, char** errptr) {
@@ -1182,6 +1171,18 @@ rocksdb_column_family_handle_t** rocksdb_create_column_families(
 void rocksdb_create_column_families_destroy(
     rocksdb_column_family_handle_t** list) {
   free(list);
+}
+
+rocksdb_column_family_handle_t* rocksdb_create_column_family_with_ttl(
+    rocksdb_t* db, const rocksdb_options_t* column_family_options,
+    const char* column_family_name, int ttl, char** errptr) {
+  ROCKSDB_NAMESPACE::DBWithTTL* db_with_ttl =
+      static_cast<ROCKSDB_NAMESPACE::DBWithTTL*>(db->rep);
+  rocksdb_column_family_handle_t* handle = new rocksdb_column_family_handle_t;
+  SaveError(errptr, db_with_ttl->CreateColumnFamilyWithTtl(
+                        ColumnFamilyOptions(column_family_options->rep),
+                        std::string(column_family_name), &(handle->rep), ttl));
+  return handle;
 }
 
 void rocksdb_drop_column_family(rocksdb_t* db,

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -271,7 +271,7 @@ void CheckMetaData(rocksdb_column_family_metadata_t* cf_meta,
 
   size_t cf_size = rocksdb_column_family_metadata_get_size(cf_meta);
   assert(cf_size > 0);
-  size_t cf_file_count = rocksdb_column_family_metadata_get_size(cf_meta);
+  size_t cf_file_count = rocksdb_column_family_metadata_get_file_count(cf_meta);
   assert(cf_file_count > 0);
 
   uint64_t total_level_size = 0;
@@ -1477,6 +1477,7 @@ int main(int argc, char** argv) {
     db = rocksdb_open(db_options, dbname, &err);
     rocksdb_column_family_handle_t* cfh;
     cfh = rocksdb_create_column_family(db, db_options, "cf1", &err);
+
     rocksdb_column_family_handle_destroy(cfh);
     CheckNoError(err);
     rocksdb_close(db);
@@ -1723,6 +1724,133 @@ int main(int argc, char** argv) {
       LoadAndCheckLatestOptions(dbname, env, false, cache, NULL, 1,
                                 expected_cf_names, NULL);
     }
+
+    rocksdb_options_set_create_if_missing(db_options, 1);
+    db = rocksdb_open(db_options, dbname, &err);
+    rocksdb_column_family_handle_t* cfh1 = rocksdb_create_column_family(db, db_options, "cf1", &err);
+
+    /* put some data */
+    rocksdb_put_cf(db, woptions, cfh1, "foo", 3, "hello", 5, &err);
+    CheckNoError(err);
+
+    /* create checkpoint for export and export column family */
+    rocksdb_checkpoint_t* checkpoint =
+        rocksdb_checkpoint_object_create(db, &err);
+    CheckNoError(err);
+    rocksdb_checkpoint_create(checkpoint, dbcheckpointname, 0, &err);
+    CheckNoError(err);
+
+    char exportPath[200];
+    snprintf(exportPath, sizeof(exportPath), "%s/rocksdb_c_test-%d/exportdir",
+             GetTempDir(), ((int)geteuid()));
+    rocksdb_export_import_files_metadata_t* metadata =
+        rocksdb_checkpoint_export_column_family(db, checkpoint, cfh1, exportPath,
+                                                &err);
+    CheckNoError(err);
+
+    rocksdb_drop_column_family(db, cfh1, &err);
+    CheckNoError(err);
+
+    /* check metadata */
+    char* dbComparatorName = NULL;
+    size_t dbComparatorNameSize = 0;
+    rocksdb_livefiles_t* plf = NULL;
+    size_t lfSize = 0;
+    char* columnFamilyNamePtr = NULL;
+    size_t columnFamilyNameSize = 0;
+    int level = 0;
+    uint64_t smallestSeqNo = 0;
+    uint64_t largestSeqNo = 0;
+    char* smallestKeyPtr = NULL;
+    size_t smallestKeySize = 0;
+    char* largestKeyPtr = NULL;
+    size_t largestKeySize = 0;
+    uint64_t numReadsSampled = 0;
+    bool beingCompacted = false;
+    uint64_t numEntries = 0;
+    uint64_t numDeletions = 0;
+    uint64_t oldestBlobFileNumber = 0;
+    uint64_t oldestAncesterTime = 0;
+    uint64_t fileCreationTime = 0;
+    uint64_t epochNumber = 0;
+    char* smallestInternalKeyPtr = NULL;
+    size_t smallestInternalKeySize = 0;
+    char* largestInternalKeyPtr = NULL;
+    size_t largestInternalKeySize = 0;
+    char* fileNamePtr = NULL;
+    size_t fileNameSize = 0;
+    char* databasePathPtr = NULL;
+    size_t databasePathSize = 0;
+    char* relativeFilenamePtr = NULL;
+    size_t relativeFilenameSize = 0;
+    char* directoryNamePtr = NULL;
+    size_t directoryNameSize = 0;
+    uint64_t fileNumber = 0;
+    uint64_t fileType = 0;
+    size_t size = 0;
+    uint64_t temperature = 0;
+    char* fileChecksumPtr = NULL;
+    size_t fileChecksumSize = 0;
+    char* fileChecksumFuncNamePtr = NULL;
+    size_t fileChecksumFuncNameSize = 0;
+
+    rocksdb_export_import_files_metadata_properties(
+        db, metadata, &dbComparatorName, &dbComparatorNameSize, &plf, &lfSize);
+    for (int idx = 0; idx < (int)lfSize; idx++) {
+      rocksdb_livefiles_get_livefile_properties(
+          db, plf, idx, &columnFamilyNamePtr, &columnFamilyNameSize, &level,
+          &smallestSeqNo, &largestSeqNo, &smallestKeyPtr, &smallestKeySize,
+          &largestKeyPtr, &largestKeySize, &numReadsSampled, &beingCompacted,
+          &numEntries, &numDeletions, &oldestBlobFileNumber,
+          &oldestAncesterTime, &fileCreationTime, &epochNumber,
+          &smallestInternalKeyPtr, &smallestInternalKeySize,
+          &largestInternalKeyPtr, &largestInternalKeySize, &fileNamePtr,
+          &fileNameSize, &databasePathPtr, &databasePathSize,
+          &relativeFilenamePtr, &relativeFilenameSize, &directoryNamePtr,
+          &directoryNameSize, &fileNumber, &fileType, &size, &temperature,
+          &fileChecksumPtr, &fileChecksumSize, &fileChecksumFuncNamePtr,
+          &fileChecksumFuncNameSize);
+    }
+
+    int index = 0;
+    rocksdb_export_import_files_metadata_t* metadata2;
+    rocksdb_create_export_import_files_metadata(db, 
+        dbComparatorName, dbComparatorNameSize, &metadata2);
+    for (int idx2 = 0; idx2 < (int)lfSize; idx2++) {
+      rocksdb_export_import_files_metadata_add_livefile(db, metadata2,
+                    columnFamilyNamePtr, columnFamilyNameSize, level,
+                    smallestSeqNo, largestSeqNo, smallestKeyPtr, smallestKeySize,
+                    largestKeyPtr, largestKeySize, numReadsSampled, beingCompacted,
+                    numEntries, numDeletions, oldestBlobFileNumber,
+                    oldestAncesterTime, fileCreationTime, epochNumber,
+                    smallestInternalKeyPtr, smallestInternalKeySize,
+                    largestInternalKeyPtr, largestInternalKeySize,
+                    fileNamePtr, fileNameSize, databasePathPtr, databasePathSize,
+                    relativeFilenamePtr, relativeFilenameSize, directoryNamePtr,
+                    directoryNameSize, fileNumber, fileType, size, temperature,
+                    fileChecksumPtr, fileChecksumSize,
+                    fileChecksumFuncNamePtr, fileChecksumFuncNameSize, index);
+    }
+
+    rocksdb_import_column_family_options_t* importCFOptions =
+        rocksdb_import_column_family_options_create();
+    rocksdb_import_column_family_options_set_move_files(importCFOptions, true);
+    cfh1 = rocksdb_create_column_family_with_import(
+        db, db_options, "cf1", importCFOptions, metadata, &err);
+    CheckNoError(err);
+
+    /* put some more data */
+    rocksdb_put_cf(db, woptions, cfh1, "foo2", 4, "hello2", 6, &err);
+    CheckNoError(err);
+
+    /* validate data puts */ 
+    CheckGetCF(db, roptions, cfh1, "foo", "hello");
+    CheckGetCF(db, roptions, cfh1, "foo2", "hello2");
+
+    rocksdb_column_family_handle_destroy(cfh1);
+    CheckNoError(err);
+    rocksdb_close(db);
+
     rocksdb_destroy_db(options, dbname, &err);
     rocksdb_options_destroy(db_options);
     rocksdb_options_destroy(cf_options_1);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -113,8 +113,11 @@ typedef struct rocksdb_universal_compaction_options_t
     rocksdb_universal_compaction_options_t;
 typedef struct rocksdb_livefiles_t rocksdb_livefiles_t;
 typedef struct rocksdb_column_family_handle_t rocksdb_column_family_handle_t;
+typedef struct rocksdb_import_column_family_options_t rocksdb_import_column_family_options_t;
 typedef struct rocksdb_column_family_metadata_t
     rocksdb_column_family_metadata_t;
+typedef struct rocksdb_export_import_files_metadata_t
+    rocksdb_export_import_files_metadata_t;
 typedef struct rocksdb_level_metadata_t rocksdb_level_metadata_t;
 typedef struct rocksdb_sst_file_metadata_t rocksdb_sst_file_metadata_t;
 typedef struct rocksdb_envoptions_t rocksdb_envoptions_t;
@@ -415,6 +418,82 @@ extern ROCKSDB_LIBRARY_API rocksdb_column_family_handle_t*
 rocksdb_create_column_family(rocksdb_t* db,
                              const rocksdb_options_t* column_family_options,
                              const char* column_family_name, char** errptr);
+
+extern ROCKSDB_LIBRARY_API rocksdb_column_family_handle_t*
+rocksdb_create_column_family_with_import(
+    rocksdb_t* db, const rocksdb_options_t* column_family_options,
+    const char* column_family_name,
+    const rocksdb_import_column_family_options_t* import_column_family_options,
+    const rocksdb_export_import_files_metadata_t* metadatas, char** errptr);
+
+extern ROCKSDB_LIBRARY_API rocksdb_export_import_files_metadata_t*
+rocksdb_checkpoint_export_column_family(rocksdb_t* db,
+                                        rocksdb_checkpoint_t* checkpoint,
+                                        rocksdb_column_family_handle_t* handle,
+                                        const char* export_dir, char** errptr);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_create_export_import_files_metadata(
+    rocksdb_t* db, const char* dbComparatorName, size_t dbComparatorNameLen,
+    rocksdb_export_import_files_metadata_t** eifm);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_export_import_files_metadata_add_livefile(
+    rocksdb_t* db, rocksdb_export_import_files_metadata_t* eifm,
+    const char* columnFamilyName, size_t columnFamilyNameSize, int level,
+    uint64_t smallestSeqNo, uint64_t largestSeqNo, const char* smallestKey,
+    size_t smallestKeySize, const char* largestKey, size_t largestKeySize,
+    uint64_t numReadsSampled, bool beingCompacted, uint64_t numEntries,
+    uint64_t numDeletions, uint64_t oldestBlobFileNumber,
+    uint64_t oldestAncesterTime, uint64_t fileCreationTime,
+    uint64_t epochNumber, const char* smallestInternalKey,
+    size_t smallestInternalKeySize, const char* largestInternalKey,
+    size_t largestInternalKeySize, const char* fileName, size_t fileNameSize,
+    const char* databasePath, size_t databasePathSize,
+    const char* relativeFilename, size_t relativeFilenameSize,
+    const char* directoryName, size_t directoryNameSize, uint64_t fileNumber,
+    uint64_t fileType, uint64_t size, uint64_t temperature,
+    const char* fileChecksum, size_t fileChecksumSize,
+    const char* fileChecksumFuncName, size_t fileChecksumFuncNameSize,
+    int index);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_export_import_files_metadata_properties(
+    rocksdb_t* db,
+    const rocksdb_export_import_files_metadata_t* eifm,
+    const char** dbComparatorNamePtr, size_t* dbComparatorNameSize,
+    rocksdb_livefiles_t** lfPtr, size_t* lfSize);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_get_livefile_properties(
+    rocksdb_t* db, const rocksdb_livefiles_t* lf, int index,
+    const char** columnFamilyName, size_t* columnFamilyNameSize, int* level, 
+    uint64_t* smallestSeqNo, uint64_t* largestSeqNo, 
+    const char** smallestKey, size_t* smallestKeySize, 
+    const char** largestKey, size_t* largestKeySize, 
+    uint64_t* numReadsSampled, bool* beingCompacted, 
+    uint64_t* numEntries, uint64_t* numDeletions, 
+    uint64_t* oldestBlobFileNumber, uint64_t* oldestAncesterTime, 
+    uint64_t* fileCreationTime, uint64_t* epochNumber, 
+    const char** smallestInternalKey, size_t* smallestInternalKeySize, 
+    const char** largestInternalKey, size_t* largestInternalKeySize, 
+    const char** fileName, size_t* fileNameSize,
+    const char** databasePath, size_t* databasePathSize,
+    const char** relativeFilename, size_t* relativeFilenameSize,
+    const char** directoryName, size_t* directoryNameSize, uint64_t* fileNumber,
+    uint64_t* fileType, size_t* size, uint64_t* temperature,
+    const char** fileChecksum, size_t* fileChecksumSize,
+    const char** fileChecksumFuncName, size_t* fileChecksumFuncNameSize);
+
+extern ROCKSDB_LIBRARY_API rocksdb_import_column_family_options_t*
+rocksdb_import_column_family_options_create();
+
+extern ROCKSDB_LIBRARY_API void rocksdb_import_column_family_options_destroy(
+    rocksdb_import_column_family_options_t* opt);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_import_column_family_options_set_move_files(
+    rocksdb_import_column_family_options_t* opt, unsigned char v);
+
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_import_column_family_options_get_move_files(
+    rocksdb_import_column_family_options_t* opt);
 
 extern ROCKSDB_LIBRARY_API rocksdb_column_family_handle_t**
 rocksdb_create_column_families(rocksdb_t* db,

--- a/include/rocksdb/metadata.h
+++ b/include/rocksdb/metadata.h
@@ -250,9 +250,16 @@ struct ColumnFamilyMetaData {
 };
 
 // Metadata returned as output from ExportColumnFamily() and used as input to
-// CreateColumnFamiliesWithImport().
+// CreateColumnFamilyWithImport().
 struct ExportImportFilesMetaData {
   std::string db_comparator_name;       // Used to safety check at import.
   std::vector<LiveFileMetaData> files;  // Vector of file metadata.
+
+  // Create ColumnFamilyOptions with default values for all fields
+  ExportImportFilesMetaData()
+      : db_comparator_name(BytewiseComparator()->Name()) {}
+  // Create ColumnFamilyOptions from Options
+  explicit ExportImportFilesMetaData(const ExportImportFilesMetaData& metadata)
+      : db_comparator_name(metadata.db_comparator_name), files(metadata.files) {}
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2174,6 +2174,11 @@ struct TraceOptions {
 struct ImportColumnFamilyOptions {
   // Can be set to true to move the files instead of copying them.
   bool move_files = false;
+
+  // Create ColumnFamilyOptions with default values for all fields
+  ImportColumnFamilyOptions();
+  // Create ColumnFamilyOptions from Options
+  explicit ImportColumnFamilyOptions(const bool moveFiles);
 };
 
 // Options used with DB::GetApproximateSizes()

--- a/options/options.cc
+++ b/options/options.cc
@@ -128,6 +128,10 @@ ColumnFamilyOptions::ColumnFamilyOptions()
 ColumnFamilyOptions::ColumnFamilyOptions(const Options& options)
     : ColumnFamilyOptions(*static_cast<const ColumnFamilyOptions*>(&options)) {}
 
+ImportColumnFamilyOptions::ImportColumnFamilyOptions() = default;
+ImportColumnFamilyOptions::ImportColumnFamilyOptions(const bool moveFiles) 
+    : move_files(moveFiles == true ? true : false) {}
+
 DBOptions::DBOptions() = default;
 DBOptions::DBOptions(const Options& options)
     : DBOptions(*static_cast<const DBOptions*>(&options)) {}


### PR DESCRIPTION
Expose ExportColumnFamily() and CreateColumnFamilyWithImport() methods in the public C-style API.  For proper usage, by any external calling application, this will require additional support functions (especially to facilitate marshalling of LiveFileMetadata structure and the ImportColumnFamilyOptions classes/structs via properties and objects from native to C# applications and back) to be implemented and exposed in the RocksDB public API.

Additional detail in [post for Feature Request](https://groups.google.com/g/rocksdb/c/V8kLGjpwxHk/m/to62jkAHAQAJ).