### PR TITLE
[WIP]Allow commit with arbitrary timestamp if no record found for key

### DIFF
--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -496,7 +496,11 @@ Status WriteCommittedTxn::SetReadTimestampForValidation(TxnTimestamp ts) {
 }
 
 Status WriteCommittedTxn::SetCommitTimestamp(TxnTimestamp ts) {
-  if (read_timestamp_ < kMaxTxnTimestamp && ts <= read_timestamp_) {
+  // Only enforcing this if records may have been found for these keys in the db
+  // and allow the user to set arbitrary commit timestamp if definitely no
+  // records has been found.
+  if (keys_may_exist_in_db_ && read_timestamp_ < kMaxTxnTimestamp &&
+      ts <= read_timestamp_) {
     return Status::InvalidArgument(
         "Cannot commit at timestamp smaller than or equal to read timestamp");
   }
@@ -1203,9 +1207,19 @@ Status PessimisticTransaction::ValidateSnapshot(
     PutFixed64(&ts_buf, read_timestamp_);
   }
 
-  return TransactionUtil::CheckKeyForConflicts(
+  bool found_record_for_key = false;
+  Status s = TransactionUtil::CheckKeyForConflicts(
       db_impl_, cfh, key.ToString(), snap_seq, ts_sz == 0 ? nullptr : &ts_buf,
-      false /* cache_only */);
+      /*cache_only=*/false, &found_record_for_key, /*snap_checker=*/nullptr,
+      /*min_uncommitted=*/kMaxSequenceNumber);
+  // If a record is found or the checking is not successful due to other
+  // failures, it's considered the key may exist in the db.
+  if (!keys_may_exist_in_db_ &&
+      (found_record_for_key ||
+       !(s.ok() || s.IsNotFound() || s.IsMergeInProgress()))) {
+    keys_may_exist_in_db_ = true;
+  }
+  return s;
 }
 
 bool PessimisticTransaction::TryStealingLocks() {

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -165,6 +165,12 @@ class PessimisticTransaction : public TransactionBaseImpl {
   // performed any GetForUpdate. It is possible that the transaction has
   // performed blind writes or Get, though.
   TxnTimestamp read_timestamp_{kMaxTxnTimestamp};
+  // A boolean flag to mark if any of the keys read via `GetForUpdate` may
+  // already exist in the db. This is only false if none of the keys cannot be
+  // definitively found in the db. If any key may be found, either because it's
+  // found or the db query cannot proceed for some unexpected error, this will
+  // be true.
+  bool keys_may_exist_in_db_{false};
   TxnTimestamp commit_timestamp_{kMaxTxnTimestamp};
 
  private:

--- a/utilities/transactions/transaction_util.h
+++ b/utilities/transactions/transaction_util.h
@@ -41,7 +41,7 @@ class TransactionUtil {
   static Status CheckKeyForConflicts(
       DBImpl* db_impl, ColumnFamilyHandle* column_family,
       const std::string& key, SequenceNumber snap_seq,
-      const std::string* const ts, bool cache_only,
+      const std::string* const ts, bool cache_only, bool* found_record_for_key,
       ReadCallback* snap_checker = nullptr,
       SequenceNumber min_uncommitted = kMaxSequenceNumber);
 
@@ -75,7 +75,8 @@ class TransactionUtil {
   static Status CheckKey(DBImpl* db_impl, SuperVersion* sv,
                          SequenceNumber earliest_seq, SequenceNumber snap_seq,
                          const std::string& key, const std::string* const ts,
-                         bool cache_only, ReadCallback* snap_checker = nullptr,
+                         bool cache_only, bool* found_record_for_key,
+                         ReadCallback* snap_checker = nullptr,
                          SequenceNumber min_uncommitted = kMaxSequenceNumber);
 };
 

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -522,9 +522,19 @@ Status WritePreparedTxn::ValidateSnapshot(ColumnFamilyHandle* column_family,
   WritePreparedTxnReadCallback snap_checker(wpt_db_, snap_seq, min_uncommitted,
                                             kBackedByDBSnapshot);
   // TODO(yanqin): support user-defined timestamp
-  return TransactionUtil::CheckKeyForConflicts(
+  bool found_record_for_key = false;
+  Status s = TransactionUtil::CheckKeyForConflicts(
       db_impl_, cfh, key.ToString(), snap_seq, /*ts=*/nullptr,
-      false /* cache_only */, &snap_checker, min_uncommitted);
+      false /* cache_only */, &found_record_for_key, &snap_checker,
+      min_uncommitted);
+  // If a record is found or the checking is not successful due to other
+  // failures, it's considered the key may exist in the db.
+  if (!keys_may_exist_in_db_ &&
+      (found_record_for_key ||
+       !(s.ok() || s.IsNotFound() || s.IsMergeInProgress()))) {
+    keys_may_exist_in_db_ = true;
+  }
+  return s;
 }
 
 void WritePreparedTxn::SetSnapshot() {

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -1074,9 +1074,19 @@ Status WriteUnpreparedTxn::ValidateSnapshot(ColumnFamilyHandle* column_family,
   WriteUnpreparedTxnReadCallback snap_checker(
       wupt_db_, snap_seq, min_uncommitted, unprep_seqs_, kBackedByDBSnapshot);
   // TODO(yanqin): Support user-defined timestamp.
-  return TransactionUtil::CheckKeyForConflicts(
+  bool found_record_for_key = false;
+  Status s = TransactionUtil::CheckKeyForConflicts(
       db_impl_, cfh, key.ToString(), snap_seq, /*ts=*/nullptr,
-      false /* cache_only */, &snap_checker, min_uncommitted);
+      false /* cache_only */, &found_record_for_key, &snap_checker,
+      min_uncommitted);
+  // If a record is found or the checking is not successful due to other
+  // failures, it's considered the key may exist in the db.
+  if (!keys_may_exist_in_db_ &&
+      (found_record_for_key ||
+       !(s.ok() || s.IsNotFound() || s.IsMergeInProgress()))) {
+    keys_may_exist_in_db_ = true;
+  }
+  return s;
 }
 
 const std::map<SequenceNumber, size_t>&


### PR DESCRIPTION
As titled. When no records for keys can be found in the DB, this allows user to set arbitrary commit timestamp regardless of the read timestamp set for validation since this is a safe operation.

Test plan:
Added unit test.