### PR TITLE
Fix `max_read_amp` value in crash test

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1532,12 +1532,14 @@ Status ColumnFamilyData::ValidateOptions(
   if (cf_options.compaction_style == kCompactionStyleUniversal) {
     int max_read_amp = cf_options.compaction_options_universal.max_read_amp;
     if (max_read_amp < -1) {
-      return Status::NotSupported("max_read_amp should be at least -1.");
+      return Status::NotSupported(
+          "CompactionOptionsUniversal::max_read_amp should be at least -1.");
     } else if (0 < max_read_amp &&
                max_read_amp < cf_options.level0_file_num_compaction_trigger) {
       return Status::NotSupported(
-          "max_read_amp limits the number of sorted runs but is smaller than "
-          "the compaction trigger level0_file_num_compaction_trigger.");
+          "CompactionOptionsUniversal::max_read_amp limits the number of sorted"
+          " runs but is smaller than the compaction trigger "
+          "level0_file_num_compaction_trigger.");
     }
   }
   return s;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -312,7 +312,7 @@ default_params = {
     "check_multiget_consistency": lambda: random.choice([0, 0, 0, 1]),
     "check_multiget_entity_consistency": lambda: random.choice([0, 0, 0, 1]),
     "use_timed_put_one_in": lambda: random.choice([0] * 7 + [1, 5, 10]),
-    "universal_max_read_amp": lambda : random.choice([-1] * 3 + [0, 3, 10]),
+    "universal_max_read_amp": lambda : random.choice([-1] * 3 + [0, 4, 10]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR


### PR DESCRIPTION
It should be no less than `level0_file_num_compaction_trigger`(which defaults to 4) when set to a positive value. Otherwise DB open will fail.

Test plan: crash test not failing DB open due to this option value.