### PR TITLE
Use `std::optional` instead of `std::unique_ptr` to conditionally create a read lock.

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -13,6 +13,7 @@
 #include <array>
 #include <limits>
 #include <memory>
+#include <optional>
 
 #include "db/dbformat.h"
 #include "db/kv_checksum.h"
@@ -955,9 +956,9 @@ static bool SaveValue(void* arg, const char* entry) {
                                              s->key->user_key())) {
     // Correct user key
     TEST_SYNC_POINT_CALLBACK("Memtable::SaveValue:Found:entry", &entry);
-    std::unique_ptr<ReadLock> read_lock;
+    std::optional<ReadLock> read_lock;
     if (s->inplace_update_support) {
-      read_lock.reset(new ReadLock(s->mem->GetLock(s->key->user_key())));
+      read_lock.emplace(s->mem->GetLock(s->key->user_key()));
     }
 
     if (s->protection_bytes_per_key > 0) {


### PR DESCRIPTION
This change replaces the use of `std::unique_ptr` with `std::optional` for conditionally constructing a `ReadLock` object. The read lock object was recently introduced in PR #12624. This change makes the code more concise and clarifies that the lock is not meant to be transferred (as `std::unique_ptr` is movable). It also avoids a heap allocation.

There are no functional changes.