### PR TITLE
Update the main branch for the 9.3 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,27 @@
 # Rocksdb Change Log
 > NOTE: Entries for next release do not go here. Follow instructions in `unreleased_history/README.txt`
 
+## 9.3.0 (05/17/2024)
+### New Features
+* Optimistic transactions and pessimistic transactions with the WriteCommitted policy now support the `GetEntity` API.
+* Added new `Iterator` property, "rocksdb.iterator.is-value-pinned", for checking whether the `Slice` returned by `Iterator::value()` can be used until the `Iterator` is destroyed.
+* Optimistic transactions and WriteCommitted pessimistic transactions now support the `MultiGetEntity` API.
+* Optimistic transactions and pessimistic transactions with the WriteCommitted policy now support the `PutEntity` API. Support for read APIs and other write policies (WritePrepared, WriteUnprepared) will be added later.
+
+### Public API Changes
+* Exposed block based metadata cache options via C API
+* Exposed compaction pri via c api.
+* Add a kAdmPolicyAllowAll option to TieredAdmissionPolicy that admits all blocks evicted from the primary block cache into the compressed secondary cache.
+
+### Behavior Changes
+* CompactRange() with change_level=true on a CF with FIFO compaction will return Status::NotSupported().
+* External file ingestion with FIFO compaction will always ingest to L0.
+
+### Bug Fixes
+* Fixed a bug for databases using `DBOptions::allow_2pc == true` (all `TransactionDB`s except `OptimisticTransactionDB`) that have exactly one column family. Due to a missing WAL sync, attempting to open the DB could have returned a `Status::Corruption` with a message like "SST file is ahead of WALs".
+* Fix a bug in CreateColumnFamilyWithImport() where if multiple CFs are imported, we were not resetting files' epoch number and L0 files can have overlapping key range but the same epoch number.
+* Fixed race conditions when `ColumnFamilyOptions::inplace_update_support == true` between user overwrites and reads on the same key.
+
 ## 9.2.0 (05/01/2024)
 ### New Features
 * Added two options `deadline` and `max_size_bytes` for CacheDumper to exit early

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,10 @@
 * Fixed a bug for databases using `DBOptions::allow_2pc == true` (all `TransactionDB`s except `OptimisticTransactionDB`) that have exactly one column family. Due to a missing WAL sync, attempting to open the DB could have returned a `Status::Corruption` with a message like "SST file is ahead of WALs".
 * Fix a bug in CreateColumnFamilyWithImport() where if multiple CFs are imported, we were not resetting files' epoch number and L0 files can have overlapping key range but the same epoch number.
 * Fixed race conditions when `ColumnFamilyOptions::inplace_update_support == true` between user overwrites and reads on the same key.
+* Fix a bug where `CompactFiles()` can compact files of range conflict with other ongoing compactions' when `preclude_last_level_data_seconds > 0` is used
+* Fixed a false positive `Status::Corruption` reported when reopening a DB that used `DBOptions::recycle_log_file_num > 0` and `DBOptions::wal_compression != kNoCompression`.
+* While WAL is locked with LockWAL(), some operations like Flush() and IngestExternalFile() are now blocked as they should have been.
+* Fixed a bug causing stale memory access when using the TieredSecondaryCache with an NVM secondary cache, and a file system that supports return an FS allocated buffer for MultiRead (FSSupportedOps::kFSBuffer is set).
 
 ## 9.2.0 (05/01/2024)
 ### New Features

--- a/include/rocksdb/version.h
+++ b/include/rocksdb/version.h
@@ -12,7 +12,7 @@
 // NOTE: in 'main' development branch, this should be the *next*
 // minor or major version number planned for release.
 #define ROCKSDB_MAJOR 9
-#define ROCKSDB_MINOR 3
+#define ROCKSDB_MINOR 4
 #define ROCKSDB_PATCH 0
 
 // Do not use these. We made the mistake of declaring macros starting with

--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -125,7 +125,7 @@ EOF
 
 # To check for DB forward compatibility with loading options (old version
 # reading data from new), as well as backward compatibility
-declare -a db_forward_with_options_refs=("8.6.fb" "8.7.fb" "8.8.fb" "8.9.fb" "8.10.fb" "8.11.fb" "9.0.fb" "9.1.fb" "9.2.fb")
+declare -a db_forward_with_options_refs=("8.6.fb" "8.7.fb" "8.8.fb" "8.9.fb" "8.10.fb" "8.11.fb" "9.0.fb" "9.1.fb" "9.2.fb" "9.3.fb")
 # To check for DB forward compatibility without loading options (in addition
 # to the "with loading options" set), as well as backward compatibility
 declare -a db_forward_no_options_refs=() # N/A at the moment

--- a/unreleased_history/behavior_changes/fifo-compact-range.md
+++ b/unreleased_history/behavior_changes/fifo-compact-range.md
@@ -1,1 +1,0 @@
-* CompactRange() with change_level=true on a CF with FIFO compaction will return Status::NotSupported(). 

--- a/unreleased_history/behavior_changes/fifo-ingestion.md
+++ b/unreleased_history/behavior_changes/fifo-ingestion.md
@@ -1,1 +1,0 @@
-* External file ingestion with FIFO compaction will always ingest to L0.

--- a/unreleased_history/bug_fixes/2pc_wal_sync.md
+++ b/unreleased_history/bug_fixes/2pc_wal_sync.md
@@ -1,1 +1,0 @@
-* Fixed a bug for databases using `DBOptions::allow_2pc == true` (all `TransactionDB`s except `OptimisticTransactionDB`) that have exactly one column family. Due to a missing WAL sync, attempting to open the DB could have returned a `Status::Corruption` with a message like "SST file is ahead of WALs".

--- a/unreleased_history/bug_fixes/compact_files.md
+++ b/unreleased_history/bug_fixes/compact_files.md
@@ -1,1 +1,0 @@
-Fix a bug where `CompactFiles()` can compact files of range conflict with other ongoing compactions' when `preclude_last_level_data_seconds > 0` is used

--- a/unreleased_history/bug_fixes/fix-import-epoch.md
+++ b/unreleased_history/bug_fixes/fix-import-epoch.md
@@ -1,1 +1,0 @@
-* Fix a bug in CreateColumnFamilyWithImport() where if multiple CFs are imported, we were not resetting files' epoch number and L0 files can have overlapping key range but the same epoch number.

--- a/unreleased_history/bug_fixes/fix_compressed_wal_recycling.md
+++ b/unreleased_history/bug_fixes/fix_compressed_wal_recycling.md
@@ -1,1 +1,0 @@
-* Fixed a false positive `Status::Corruption` reported when reopening a DB that used `DBOptions::recycle_log_file_num > 0` and `DBOptions::wal_compression != kNoCompression`.

--- a/unreleased_history/bug_fixes/inplace_update_race.md
+++ b/unreleased_history/bug_fixes/inplace_update_race.md
@@ -1,1 +1,0 @@
-* Fixed race conditions when `ColumnFamilyOptions::inplace_update_support == true` between user overwrites and reads on the same key.

--- a/unreleased_history/bug_fixes/lock_wal.md
+++ b/unreleased_history/bug_fixes/lock_wal.md
@@ -1,1 +1,0 @@
-* While WAL is locked with LockWAL(), some operations like Flush() and IngestExternalFile() are now blocked as they should have been.

--- a/unreleased_history/bug_fixes/tiered_cache_fs_buffer.md
+++ b/unreleased_history/bug_fixes/tiered_cache_fs_buffer.md
@@ -1,1 +1,0 @@
-Fixed a bug causing stale memory access when using the TieredSecondaryCache with an NVM secondary cache, and a file system that supports return an FS allocated buffer for MultiRead (FSSupportedOps::kFSBuffer is set).

--- a/unreleased_history/new_features/get_entity_txn.md
+++ b/unreleased_history/new_features/get_entity_txn.md
@@ -1,1 +1,0 @@
-Optimistic transactions and pessimistic transactions with the WriteCommitted policy now support the `GetEntity` API.

--- a/unreleased_history/new_features/iterator_property_value_pinned.md
+++ b/unreleased_history/new_features/iterator_property_value_pinned.md
@@ -1,1 +1,0 @@
-* Added new `Iterator` property, "rocksdb.iterator.is-value-pinned", for checking whether the `Slice` returned by `Iterator::value()` can be used until the `Iterator` is destroyed.

--- a/unreleased_history/new_features/multi_get_entity_txn.md
+++ b/unreleased_history/new_features/multi_get_entity_txn.md
@@ -1,1 +1,0 @@
-Optimistic transactions and WriteCommitted pessimistic transactions now support the `MultiGetEntity` API.

--- a/unreleased_history/new_features/put_entity_txn.md
+++ b/unreleased_history/new_features/put_entity_txn.md
@@ -1,1 +1,0 @@
-Optimistic transactions and pessimistic transactions with the WriteCommitted policy now support the `PutEntity` API. Support for read APIs and other write policies (WritePrepared, WriteUnprepared) will be added later.

--- a/unreleased_history/public_api_changes/expose_block_based_metadata_cache_options_via_c_api.md
+++ b/unreleased_history/public_api_changes/expose_block_based_metadata_cache_options_via_c_api.md
@@ -1,1 +1,0 @@
-Exposed block based metadata cache options via C API

--- a/unreleased_history/public_api_changes/expose_compaction_pri_via_c_api.md
+++ b/unreleased_history/public_api_changes/expose_compaction_pri_via_c_api.md
@@ -1,1 +1,0 @@
-Exposed compaction pri via c api.

--- a/unreleased_history/public_api_changes/sec_cache_allow_all.md
+++ b/unreleased_history/public_api_changes/sec_cache_allow_all.md
@@ -1,1 +1,0 @@
-Add a kAdmPolicyAllowAll option to TieredAdmissionPolicy that admits all blocks evicted from the primary block cache into the compressed secondary cache.


### PR DESCRIPTION
Cut the 9.3.fb branch as of 5/17 11:59pm. Also, cherry-picked all bug fixes that have happened since then. Removed their files from unreleased_history/ since those fixes will appear in 9.3.0, so there seems no use repeating them in any later release.

Release branch: https://github.com/facebook/rocksdb/tree/9.3.fb
Tests: https://github.com/facebook/rocksdb/actions/runs/9342097111