### PR TITLE
Temporarily disable multi_cf_iter in stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -153,7 +153,7 @@ default_params = {
     # use_put_entity_one_in has to be the same across invocations for verification to work, hence no lambda
     "use_put_entity_one_in": random.choice([0] * 7 + [1, 5, 10]),
     "use_attribute_group": lambda: random.randint(0, 1),
-    "use_multi_cf_iterator": lambda: random.randint(0, 1),
+    "use_multi_cf_iterator": 0, # TODO(jaykorean) - re-enable this after fixing the test
     # 999 -> use Bloom API
     "bloom_before_level": lambda: random.choice([random.randint(-1, 2), random.randint(-1, 10), 0x7fffffff - 1, 0x7fffffff]),
     "value_size_mult": 32,


### PR DESCRIPTION
# Summary

We plan to re-enable the test after fixing the test.

# Test Plan

N/A. Disabling the test