### PR TITLE
Attempt fix rare failure in DBBlockCacheTypeTest.Uncache

### DIFF
--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -1345,11 +1345,14 @@ TEST_P(DBBlockCacheTypeTest, Uncache) {
     for (uint32_t ua : {0, 1, 2, 10000}) {
       SCOPED_TRACE("ua=" + std::to_string(ua));
 
+      BlockBasedTableOptions table_options;
       Options options = CurrentOptions();
       options.uncache_aggressiveness = ua;
       options.create_if_missing = true;
       options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
-      BlockBasedTableOptions table_options;
+      // Don't allow background operations to keep Versions referenced
+      options.stats_dump_period_sec = 0;
+      options.stats_persist_period_sec = 0;
 
       const size_t capacity = size_t{1} << 25;
       const int num_shard_bits = 0;  // 1 shard


### PR DESCRIPTION
Summary: I haven't been able to reproduce the failure, seen in https://github.com/facebook/rocksdb/actions/runs/9420830905/job/25953696902?pr=12734

```
[ RUN      ] DBBlockCacheTypeTestInstance/DBBlockCacheTypeTest.Uncache/2
db/db_block_cache_test.cc:1415: Failure
Expected equality of these values:
  cache->GetOccupancyCount()
    Which is: 37
  kBaselineCount + kNumDataBlocks + meta_blocks_per_file
    Which is: 15
Google Test trace:
db/db_block_cache_test.cc:1346: ua=10000
db/db_block_cache_test.cc:1344: partitioned=1
db/db_block_cache_test.cc:1418: Failure
...
```

But it's consistent with a SuperVersion reference sticking around beyond the CompactRange, as I can reproduce the result with a dangling Iterator. Like some other tests have had trouble with periodic stats popping up randomly, I suspect that could be the explanation in this case.

Test Plan: Watch for similar future failures