### PR TITLE
c.h: Add set_track_and_verify_wals_in_manifest to C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3969,6 +3969,16 @@ void rocksdb_options_set_write_dbid_to_manifest(
   opt->rep.write_dbid_to_manifest = write_dbid_to_manifest;
 }
 
+unsigned char rocksdb_options_get_track_and_verify_wals_in_manifest(
+    rocksdb_options_t* opt) {
+  return opt->rep.track_and_verify_wals_in_manifest;
+}
+
+void rocksdb_options_set_track_and_verify_wals_in_manifest(
+    rocksdb_options_t* opt, unsigned char track_and_verify_wals_in_manifest) {
+  opt->rep.track_and_verify_wals_in_manifest = track_and_verify_wals_in_manifest;
+}
+
 void rocksdb_options_set_max_successive_merges(rocksdb_options_t* opt,
                                                size_t v) {
   opt->rep.max_successive_merges = v;

--- a/db/c.cc
+++ b/db/c.cc
@@ -3976,7 +3976,8 @@ unsigned char rocksdb_options_get_track_and_verify_wals_in_manifest(
 
 void rocksdb_options_set_track_and_verify_wals_in_manifest(
     rocksdb_options_t* opt, unsigned char track_and_verify_wals_in_manifest) {
-  opt->rep.track_and_verify_wals_in_manifest = track_and_verify_wals_in_manifest;
+  opt->rep.track_and_verify_wals_in_manifest =
+      track_and_verify_wals_in_manifest;
 }
 
 void rocksdb_options_set_max_successive_merges(rocksdb_options_t* opt,

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -2234,9 +2234,11 @@ int main(int argc, char** argv) {
     CheckCondition(rocksdb_statistics_level_all ==
                    rocksdb_options_get_statistics_level(o));
 
-    CheckCondition(0 == rocksdb_options_get_track_and_verify_wals_in_manifest(o));
+    CheckCondition(0 ==
+                   rocksdb_options_get_track_and_verify_wals_in_manifest(o));
     rocksdb_options_set_track_and_verify_wals_in_manifest(o, 42);
-    CheckCondition(1 == rocksdb_options_get_track_and_verify_wals_in_manifest(o));
+    CheckCondition(1 ==
+                   rocksdb_options_get_track_and_verify_wals_in_manifest(o));
 
     /* Blob Options */
     rocksdb_options_set_enable_blob_files(o, 1);

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -2234,6 +2234,10 @@ int main(int argc, char** argv) {
     CheckCondition(rocksdb_statistics_level_all ==
                    rocksdb_options_get_statistics_level(o));
 
+    CheckCondition(0 == rocksdb_options_get_track_and_verify_wals_in_manifest(o));
+    rocksdb_options_set_track_and_verify_wals_in_manifest(o, 42);
+    CheckCondition(1 == rocksdb_options_get_track_and_verify_wals_in_manifest(o));
+
     /* Blob Options */
     rocksdb_options_set_enable_blob_files(o, 1);
     CheckCondition(1 == rocksdb_options_get_enable_blob_files(o));

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1620,6 +1620,11 @@ rocksdb_options_get_write_dbid_to_manifest(rocksdb_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_write_dbid_to_manifest(
     rocksdb_options_t*, unsigned char);
 
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_options_get_track_and_verify_wals_in_manifest(rocksdb_options_t*);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_track_and_verify_wals_in_manifest(
+    rocksdb_options_t*, unsigned char);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_min_level_to_compress(
     rocksdb_options_t* opt, int level);
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1622,8 +1622,9 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_write_dbid_to_manifest(
 
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_options_get_track_and_verify_wals_in_manifest(rocksdb_options_t*);
-extern ROCKSDB_LIBRARY_API void rocksdb_options_set_track_and_verify_wals_in_manifest(
-    rocksdb_options_t*, unsigned char);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_track_and_verify_wals_in_manifest(rocksdb_options_t*,
+                                                      unsigned char);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_min_level_to_compress(
     rocksdb_options_t* opt, int level);


### PR DESCRIPTION
This option is recommended to be set for production use:

    We recommend to set track_and_verify_wals_in_manifest to true
    for production

https://github.com/facebook/rocksdb/wiki/Track-WAL-in-MANIFEST

This adds this setting to the C API, so it can be used by other languages.