### PR TITLE
Fix TSAN-reported data race with uncache_aggressiveness

### DIFF
--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -191,7 +191,9 @@ class TableReader {
 
   // Tell the reader that the file should now be obsolete, e.g. as a hint
   // to delete relevant cache entries on destruction. (It might not be safe
-  // to "unpin" cache entries until destruction time.)
+  // to "unpin" cache entries until destruction time.) NOTE: must be thread
+  // safe because multiple table cache references might all mark this file as
+  // obsolete when they are released (the last of which destroys this reader).
   virtual void MarkObsolete(uint32_t /*uncache_aggressiveness*/) {
     // no-op as default
   }


### PR DESCRIPTION
Summary: Data race reported on
BlockBasedTableReader::Rep::uncache_aggressiveness because apparently a file can be marked obsolete through multiple table cache references in parallel. Using a relaxed atomic should resolve the race quite reasonably, especially considering this is a rare case and the racing writes should be storing the same value anyway.

Test Plan: watch for TSAN crash test results