### PR TITLE
`GetAggregatedIntProperty` accumulates property once per block cache

### DIFF
--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -2135,10 +2135,12 @@ void InternalStats::DumpCFFileHistogram(std::string* value) {
   value->append(oss.str());
 }
 
+namespace {
+
 class SumPropertyAggregator : public IntPropertyAggregator {
  public:
   SumPropertyAggregator() : aggregated_value_(0) {}
-  virtual ~SumPropertyAggregator() = default;
+  virtual ~SumPropertyAggregator() override = default;
 
   void Add(ColumnFamilyData* cfd, uint64_t value) override {
     (void)cfd;
@@ -2156,7 +2158,7 @@ class SumPropertyAggregator : public IntPropertyAggregator {
 class BlockCachePropertyAggregator : public IntPropertyAggregator {
  public:
   BlockCachePropertyAggregator() = default;
-  virtual ~BlockCachePropertyAggregator() = default;
+  virtual ~BlockCachePropertyAggregator() override = default;
 
   void Add(ColumnFamilyData* cfd, uint64_t value) override {
     auto* table_factory = cfd->ioptions()->table_factory.get();
@@ -2179,6 +2181,8 @@ class BlockCachePropertyAggregator : public IntPropertyAggregator {
  private:
   std::unordered_map<Cache*, uint64_t> block_cache_properties_;
 };
+
+}  // anonymous namespace
 
 std::unique_ptr<IntPropertyAggregator> CreateIntPropertyAggregator(
     const Slice& property) {

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -16,6 +16,7 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -32,7 +33,6 @@
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
-
 
 const std::map<LevelStatType, LevelStat> InternalStats::compaction_level_stats =
     {
@@ -2135,5 +2135,58 @@ void InternalStats::DumpCFFileHistogram(std::string* value) {
   value->append(oss.str());
 }
 
+class SumPropertyAggregator : public IntPropertyAggregator {
+ public:
+  SumPropertyAggregator() : aggregated_value_(0) {}
+  virtual ~SumPropertyAggregator() = default;
+
+  void Add(ColumnFamilyData* cfd, uint64_t value) override {
+    (void)cfd;
+    aggregated_value_ += value;
+  }
+
+  uint64_t Aggregate() const override { return aggregated_value_; }
+
+ private:
+  uint64_t aggregated_value_;
+};
+
+// A block cache may be shared by multiple column families.
+// BlockCachePropertyAggregator ensures that the same cache is only added once.
+class BlockCachePropertyAggregator : public IntPropertyAggregator {
+ public:
+  BlockCachePropertyAggregator() = default;
+  virtual ~BlockCachePropertyAggregator() = default;
+
+  void Add(ColumnFamilyData* cfd, uint64_t value) override {
+    auto* table_factory = cfd->ioptions()->table_factory.get();
+    assert(table_factory != nullptr);
+    Cache* cache =
+        table_factory->GetOptions<Cache>(TableFactory::kBlockCacheOpts());
+    if (cache != nullptr) {
+      block_cache_properties_.emplace(cache, value);
+    }
+  }
+
+  uint64_t Aggregate() const override {
+    return std::accumulate(
+        block_cache_properties_.cbegin(), block_cache_properties_.cend(), 0,
+        [](uint64_t sum, const auto& p) { return sum + p.second; });
+  }
+
+ private:
+  std::unordered_map<Cache*, uint64_t> block_cache_properties_;
+};
+
+std::unique_ptr<IntPropertyAggregator> CreateIntPropertyAggregator(
+    const Slice& property) {
+  if (property == DB::Properties::kBlockCacheCapacity ||
+      property == DB::Properties::kBlockCacheUsage ||
+      property == DB::Properties::kBlockCachePinnedUsage) {
+    return std::make_unique<BlockCachePropertyAggregator>();
+  } else {
+    return std::make_unique<SumPropertyAggregator>();
+  }
+}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -2169,9 +2169,11 @@ class BlockCachePropertyAggregator : public IntPropertyAggregator {
   }
 
   uint64_t Aggregate() const override {
-    return std::accumulate(
-        block_cache_properties_.cbegin(), block_cache_properties_.cend(), 0,
-        [](uint64_t sum, const auto& p) { return sum + p.second; });
+    uint64_t sum = 0;
+    for (const auto& p : block_cache_properties_) {
+      sum += p.second;
+    }
+    return sum;
   }
 
  private:

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -432,7 +432,7 @@ class InternalStats {
     explicit CompactionStatsFull() : stats(), penultimate_level_stats() {}
 
     explicit CompactionStatsFull(CompactionReason reason, int c)
-        : stats(reason, c), penultimate_level_stats(reason, c){}
+        : stats(reason, c), penultimate_level_stats(reason, c) {}
 
     uint64_t TotalBytesWritten() const {
       uint64_t bytes_written = stats.bytes_written + stats.bytes_written_blob;
@@ -873,5 +873,24 @@ class InternalStats {
   uint64_t started_at_;
 };
 
+// IntPropertyAggregator aggregates an integer property across all column
+// families.
+class IntPropertyAggregator {
+ public:
+  IntPropertyAggregator() {}
+  virtual ~IntPropertyAggregator() {}
+
+  IntPropertyAggregator(const IntPropertyAggregator&) = delete;
+  void operator=(const IntPropertyAggregator&) = delete;
+
+  // Add a column family's property value to the aggregator.
+  virtual void Add(ColumnFamilyData* cfd, uint64_t value) = 0;
+
+  // Get the aggregated value.
+  virtual uint64_t Aggregate() const = 0;
+};
+
+std::unique_ptr<IntPropertyAggregator> CreateIntPropertyAggregator(
+    const Slice& property);
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Fix issue https://github.com/facebook/rocksdb/issues/12687.

A block cache may be shared by multiple column families. Therefore, when getting the aggregated property of the block cache, we need to deduplicate by instances of the block cache, meaning the same instance should only be counted once.