### PR TITLE
[Testing] Enable reading un-synced data in db stress test

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -997,12 +997,7 @@ void StressTest::OperateDb(ThreadState* thread) {
                         " to %" PRIu64 "\n",
                         old_wal->LogNumber(), new_wal->LogNumber());
               }
-              // FIXME: FaultInjectionTestFS does not report file sizes that
-              // reflect what has been flushed. Either that needs to be fixed
-              // or GetSortedWals/GetLiveWalFile need to stop relying on
-              // asking the FS for sizes.
-              if (!fault_fs_guard &&
-                  old_wal->SizeFileBytes() != new_wal->SizeFileBytes()) {
+              if (old_wal->SizeFileBytes() != new_wal->SizeFileBytes()) {
                 fprintf(stderr,
                         "Failed: WAL %" PRIu64
                         " size changed during LockWAL(): %" PRIu64
@@ -1890,16 +1885,6 @@ Status StressTest::TestBackupRestore(
   Status s = BackupEngine::Open(db_stress_env, backup_opts, &backup_engine);
   if (!s.ok()) {
     from = "BackupEngine::Open";
-  }
-  // FIXME: this is only needed as long as db_stress uses
-  // SetReadUnsyncedData(false), because it will only be able to
-  // copy the synced portion of the WAL. For correctness validation, that
-  // needs to include updates to the locked key.
-  if (s.ok()) {
-    s = db_->SyncWAL();
-    if (!s.ok()) {
-      from = "SyncWAL";
-    }
   }
 
   if (s.ok()) {

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -93,10 +93,6 @@ int db_stress_tool(int argc, char** argv) {
     // This will be overwritten in StressTest::Open() for open fault injection
     // and in RunStressTestImpl() for proper write fault injection setup.
     fault_fs_guard->SetFilesystemDirectWritable(true);
-    // FIXME: For some reason(s), db_stress currently relies on the WRONG
-    // semantic of reading only synced data from files currently open for
-    // write.
-    fault_fs_guard->SetReadUnsyncedData(false);
     fault_env_guard =
         std::make_shared<CompositeEnvWrapper>(raw_env, fault_fs_guard);
     raw_env = fault_env_guard.get();

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -803,7 +803,7 @@ IOStatus FaultInjectionTestFS::GetFileSize(const std::string& f,
     // Need to report flushed size, not synced size
     MutexLock l(&mutex_);
     auto it = db_file_state_.find(f);
-    if (it != db_file_state_.end()) {
+    if (it != db_file_state_.end() && it->second.pos_ > 0) {
       *file_size = it->second.pos_;
     }
   }


### PR DESCRIPTION
**Context/Summary:** this is to actually turn on reading un-synced data in stress test that was developed in  https://github.com/facebook/rocksdb/pull/12729. Stacked on top of https://github.com/facebook/rocksdb/pull/12752 and fixed two FIXME to unblock enabling.

**Test:** 
- Run `python3 tools/db_crashtest.py --simple blackbox --lock_wal_one_in=10 --backup_one_in=10 --sync_fault_injection=0 --use_direct_io_for_flush_and_compaction=0` for 1 hour
- Monitor stress test CI