### PR TITLE
Add CompactForTieringCollector to support automatically trigger compaction for tiering use case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -939,6 +939,7 @@ set(SOURCES
         utilities/persistent_cache/volatile_tier_impl.cc
         utilities/simulator_cache/cache_simulator.cc
         utilities/simulator_cache/sim_cache.cc
+        utilities/table_properties_collectors/compact_for_tiering_collector.cc
         utilities/table_properties_collectors/compact_on_deletion_collector.cc
         utilities/trace/file_trace_reader_writer.cc
         utilities/trace/replayer_impl.cc
@@ -1481,6 +1482,7 @@ if(WITH_TESTS)
         utilities/persistent_cache/persistent_cache_test.cc
         utilities/simulator_cache/cache_simulator_test.cc
         utilities/simulator_cache/sim_cache_test.cc
+        utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
         utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
         utilities/transactions/optimistic_transaction_test.cc
         utilities/transactions/transaction_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1631,6 +1631,9 @@ compaction_job_stats_test: $(OBJ_DIR)/db/compaction/compaction_job_stats_test.o 
 compaction_service_test: $(OBJ_DIR)/db/compaction/compaction_service_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+compact_for_tiering_collector_test: $(OBJ_DIR)/utilities/table_properties_collectors/compact_for_tiering_collector_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 compact_on_deletion_collector_test: $(OBJ_DIR)/utilities/table_properties_collectors/compact_on_deletion_collector_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/TARGETS
+++ b/TARGETS
@@ -317,6 +317,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "utilities/persistent_cache/volatile_tier_impl.cc",
         "utilities/simulator_cache/cache_simulator.cc",
         "utilities/simulator_cache/sim_cache.cc",
+        "utilities/table_properties_collectors/compact_for_tiering_collector.cc",
         "utilities/table_properties_collectors/compact_on_deletion_collector.cc",
         "utilities/trace/file_trace_reader_writer.cc",
         "utilities/trace/replayer_impl.cc",
@@ -4622,6 +4623,12 @@ cpp_unittest_wrapper(name="column_family_test",
 
 cpp_unittest_wrapper(name="compact_files_test",
             srcs=["db/compact_files_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
+cpp_unittest_wrapper(name="compact_for_tiering_collector_test",
+            srcs=["utilities/table_properties_collectors/compact_for_tiering_collector_test.cc"],
             deps=[":rocksdb_test_lib"],
             extra_compiler_flags=[])
 

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -64,7 +64,7 @@ Status BuildTable(
     std::vector<std::unique_ptr<FragmentedRangeTombstoneIterator>>
         range_del_iters,
     FileMetaData* meta, std::vector<BlobFileAddition>* blob_file_additions,
-    std::vector<SequenceNumber> snapshots,
+    std::vector<SequenceNumber> snapshots, SequenceNumber earliest_snapshot,
     SequenceNumber earliest_write_conflict_snapshot,
     SequenceNumber job_snapshot, SnapshotChecker* snapshot_checker,
     bool paranoid_file_checks, InternalStats* internal_stats,
@@ -195,7 +195,7 @@ Status BuildTable(
 
     const std::atomic<bool> kManualCompactionCanceledFalse{false};
     CompactionIterator c_iter(
-        iter, ucmp, &merge, kMaxSequenceNumber, &snapshots,
+        iter, ucmp, &merge, kMaxSequenceNumber, &snapshots, earliest_snapshot,
         earliest_write_conflict_snapshot, job_snapshot, snapshot_checker, env,
         ShouldReportDetailedTime(env, ioptions.stats),
         true /* internal key corruption is not ok */, range_del_agg.get(),

--- a/db/builder.h
+++ b/db/builder.h
@@ -57,7 +57,7 @@ Status BuildTable(
     std::vector<std::unique_ptr<FragmentedRangeTombstoneIterator>>
         range_del_iters,
     FileMetaData* meta, std::vector<BlobFileAddition>* blob_file_additions,
-    std::vector<SequenceNumber> snapshots,
+    std::vector<SequenceNumber> snapshots, SequenceNumber earliest_snapshot,
     SequenceNumber earliest_write_conflict_snapshot,
     SequenceNumber job_snapshot, SnapshotChecker* snapshot_checker,
     bool paranoid_file_checks, InternalStats* internal_stats,

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -25,6 +25,7 @@ namespace ROCKSDB_NAMESPACE {
 CompactionIterator::CompactionIterator(
     InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
     SequenceNumber last_sequence, std::vector<SequenceNumber>* snapshots,
+    SequenceNumber earliest_snapshot,
     SequenceNumber earliest_write_conflict_snapshot,
     SequenceNumber job_snapshot, const SnapshotChecker* snapshot_checker,
     Env* env, bool report_detailed_time, bool expect_valid_internal_key,
@@ -40,7 +41,7 @@ CompactionIterator::CompactionIterator(
     const SequenceNumber preserve_time_min_seqno,
     const SequenceNumber preclude_last_level_min_seqno)
     : CompactionIterator(
-          input, cmp, merge_helper, last_sequence, snapshots,
+          input, cmp, merge_helper, last_sequence, snapshots, earliest_snapshot,
           earliest_write_conflict_snapshot, job_snapshot, snapshot_checker, env,
           report_detailed_time, expect_valid_internal_key, range_del_agg,
           blob_file_builder, allow_data_in_errors, enforce_single_del_contracts,
@@ -54,6 +55,7 @@ CompactionIterator::CompactionIterator(
 CompactionIterator::CompactionIterator(
     InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
     SequenceNumber /*last_sequence*/, std::vector<SequenceNumber>* snapshots,
+    SequenceNumber earliest_snapshot,
     SequenceNumber earliest_write_conflict_snapshot,
     SequenceNumber job_snapshot, const SnapshotChecker* snapshot_checker,
     Env* env, bool report_detailed_time, bool expect_valid_internal_key,
@@ -91,9 +93,7 @@ CompactionIterator::CompactionIterator(
       // snapshots_ cannot be nullptr, but we will assert later in the body of
       // the constructor.
       visible_at_tip_(snapshots_ ? snapshots_->empty() : false),
-      earliest_snapshot_(!snapshots_ || snapshots_->empty()
-                             ? kMaxSequenceNumber
-                             : snapshots_->at(0)),
+      earliest_snapshot_(earliest_snapshot),
       info_log_(info_log),
       allow_data_in_errors_(allow_data_in_errors),
       enforce_single_del_contracts_(enforce_single_del_contracts),

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -203,6 +203,7 @@ class CompactionIterator {
   CompactionIterator(
       InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
       SequenceNumber last_sequence, std::vector<SequenceNumber>* snapshots,
+      SequenceNumber earliest_snapshot,
       SequenceNumber earliest_write_conflict_snapshot,
       SequenceNumber job_snapshot, const SnapshotChecker* snapshot_checker,
       Env* env, bool report_detailed_time, bool expect_valid_internal_key,
@@ -222,6 +223,7 @@ class CompactionIterator {
   CompactionIterator(
       InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
       SequenceNumber last_sequence, std::vector<SequenceNumber>* snapshots,
+      SequenceNumber earliest_snapshot,
       SequenceNumber earliest_write_conflict_snapshot,
       SequenceNumber job_snapshot, const SnapshotChecker* snapshot_checker,
       Env* env, bool report_detailed_time, bool expect_valid_internal_key,

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -296,6 +296,7 @@ class CompactionIteratorTest : public testing::TestWithParam<bool> {
     iter_->SeekToFirst();
     c_iter_.reset(new CompactionIterator(
         iter_.get(), cmp_, merge_helper_.get(), last_sequence, &snapshots_,
+        snapshots_.empty() ? kMaxSequenceNumber : snapshots_.at(0),
         earliest_write_conflict_snapshot, kMaxSequenceNumber,
         snapshot_checker_.get(), Env::Default(),
         false /* report_detailed_time */, false, range_del_agg_.get(),

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -314,6 +314,8 @@ class CompactionJob {
   // deleted because that version is not visible in any snapshot.
   std::vector<SequenceNumber> existing_snapshots_;
 
+  SequenceNumber earliest_snapshot_;
+
   // This is the earliest snapshot that could be used for write-conflict
   // checking by a transaction.  For any user-key newer than this snapshot, we
   // should make sure not to remove evidence that a write occurred.

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -1753,8 +1753,7 @@ TEST_P(TimedPutPrecludeLastLevelTest, AutoTriggerCompaction) {
   std::shared_ptr<TablePropertiesCollectorFactory> factory;
   std::string id = CompactForTieringCollectorFactory::kClassName();
   ASSERT_OK(TablePropertiesCollectorFactory::CreateFromString(
-      config_options, "compaction_triggers=0:50; enabled=true; id=" + id,
-      &factory));
+      config_options, "compaction_trigger_ratio=0.4; id=" + id, &factory));
   auto collector_factory =
       factory->CheckedCast<CompactForTieringCollectorFactory>();
   options.table_properties_collector_factories.push_back(factory);
@@ -1791,7 +1790,7 @@ TEST_P(TimedPutPrecludeLastLevelTest, AutoTriggerCompaction) {
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
 
-  collector_factory->SetCompactionTrigger(0, 51);
+  collector_factory->SetCompactionTriggerRatio(1.1);
   for (int i = kNumKeys / 2; i < kNumKeys * 3 / 4; i++) {
     ASSERT_OK(TimedPut(0, Key(i), rnd.RandomString(100), 50, wo));
   }
@@ -1800,8 +1799,7 @@ TEST_P(TimedPutPrecludeLastLevelTest, AutoTriggerCompaction) {
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
   ASSERT_EQ("2,0,0,0,0,0,1", FilesPerLevel());
 
-  collector_factory->SetCompactionTrigger(0, 50);
-  collector_factory->SetEnabled(false);
+  collector_factory->SetCompactionTriggerRatio(0);
   for (int i = kNumKeys * 3 / 4; i < kNumKeys; i++) {
     ASSERT_OK(TimedPut(0, Key(i), rnd.RandomString(100), 50, wo));
   }

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -13,6 +13,7 @@
 #include "rocksdb/iostats_context.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/utilities/debug.h"
+#include "rocksdb/utilities/table_properties_collectors.h"
 #include "test_util/mock_time_env.h"
 #include "utilities/merge_operators.h"
 
@@ -1731,6 +1732,84 @@ TEST_P(TimedPutPrecludeLastLevelTest, PreserveTimedPutOnPenultimateLevel) {
   ASSERT_EQ("0,0,0,0,0,0,1", FilesPerLevel());
   ASSERT_EQ(GetSstSizeHelper(Temperature::kHot), 0);
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
+  Close();
+}
+
+TEST_P(TimedPutPrecludeLastLevelTest, AutoTriggerCompaction) {
+  const int kNumTrigger = 10;
+  const int kNumLevels = 7;
+  const int kNumKeys = 200;
+
+  Options options = CurrentOptions();
+  options.compaction_style = kCompactionStyleUniversal;
+  options.preclude_last_level_data_seconds = 60;
+  options.preserve_internal_time_seconds = 0;
+  options.env = mock_env_.get();
+  options.level0_file_num_compaction_trigger = kNumTrigger;
+  options.num_levels = kNumLevels;
+  options.last_level_temperature = Temperature::kCold;
+  ConfigOptions config_options;
+  config_options.ignore_unsupported_options = false;
+  std::shared_ptr<TablePropertiesCollectorFactory> factory;
+  std::string id = CompactForTieringCollectorFactory::kClassName();
+  ASSERT_OK(TablePropertiesCollectorFactory::CreateFromString(
+      config_options, "compaction_triggers=0:50; enabled=true; id=" + id,
+      &factory));
+  auto collector_factory =
+      factory->CheckedCast<CompactForTieringCollectorFactory>();
+  options.table_properties_collector_factories.push_back(factory);
+  DestroyAndReopen(options);
+  WriteOptions wo;
+  wo.protection_bytes_per_key = GetParam();
+
+  Random rnd(301);
+
+  dbfull()->TEST_WaitForPeriodicTaskRun([&] {
+    mock_clock_->MockSleepForSeconds(static_cast<int>(rnd.Uniform(10) + 1));
+  });
+
+  for (int i = 0; i < kNumKeys / 4; i++) {
+    ASSERT_OK(Put(Key(i), rnd.RandomString(100), wo));
+    dbfull()->TEST_WaitForPeriodicTaskRun([&] {
+      mock_clock_->MockSleepForSeconds(static_cast<int>(rnd.Uniform(2)));
+    });
+  }
+  // Create one file with regular Put.
+  ASSERT_OK(Flush());
+
+  // Create one file with TimedPut.
+  // These data are eligible to be put on the last level once written to db
+  // and compaction will fast track them to the last level.
+  for (int i = kNumKeys / 4; i < kNumKeys / 2; i++) {
+    ASSERT_OK(TimedPut(0, Key(i), rnd.RandomString(100), 50, wo));
+  }
+  ASSERT_OK(Flush());
+
+  // TimedPut file moved to the last level via auto triggered compaction.
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_EQ("1,0,0,0,0,0,1", FilesPerLevel());
+  ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
+  ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
+
+  collector_factory->SetCompactionTrigger(0, 51);
+  for (int i = kNumKeys / 2; i < kNumKeys * 3 / 4; i++) {
+    ASSERT_OK(TimedPut(0, Key(i), rnd.RandomString(100), 50, wo));
+  }
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_EQ("2,0,0,0,0,0,1", FilesPerLevel());
+
+  collector_factory->SetCompactionTrigger(0, 50);
+  collector_factory->SetEnabled(false);
+  for (int i = kNumKeys * 3 / 4; i < kNumKeys; i++) {
+    ASSERT_OK(TimedPut(0, Key(i), rnd.RandomString(100), 50, wo));
+  }
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_EQ("3,0,0,0,0,0,1", FilesPerLevel());
+
   Close();
 }
 

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1670,6 +1670,8 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
       SequenceNumber earliest_write_conflict_snapshot;
       std::vector<SequenceNumber> snapshot_seqs =
           snapshots_.GetAll(&earliest_write_conflict_snapshot);
+      SequenceNumber earliest_snapshot =
+          (snapshot_seqs.empty() ? kMaxSequenceNumber : snapshot_seqs.at(0));
       auto snapshot_checker = snapshot_checker_.get();
       if (use_custom_gc_ && snapshot_checker == nullptr) {
         snapshot_checker = DisableGCSnapshotChecker::Instance();
@@ -1689,6 +1691,7 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
       IOStatus io_s;
       const ReadOptions read_option(Env::IOActivity::kDBOpen);
       const WriteOptions write_option(Env::IO_HIGH, Env::IOActivity::kDBOpen);
+
       TableBuilderOptions tboptions(
           *cfd->ioptions(), mutable_cf_options, read_option, write_option,
           cfd->internal_comparator(), cfd->internal_tbl_prop_coll_factories(),
@@ -1697,21 +1700,22 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
           0 /* level */, false /* is_bottommost */,
           TableFileCreationReason::kRecovery, 0 /* oldest_key_time */,
           0 /* file_creation_time */, db_id_, db_session_id_,
-          0 /* target_file_size */, meta.fd.GetNumber());
+          0 /* target_file_size */, meta.fd.GetNumber(), kMaxSequenceNumber);
       Version* version = cfd->current();
       version->Ref();
       uint64_t num_input_entries = 0;
-      s = BuildTable(
-          dbname_, versions_.get(), immutable_db_options_, tboptions,
-          file_options_for_compaction_, cfd->table_cache(), iter.get(),
-          std::move(range_del_iters), &meta, &blob_file_additions,
-          snapshot_seqs, earliest_write_conflict_snapshot, kMaxSequenceNumber,
-          snapshot_checker, paranoid_file_checks, cfd->internal_stats(), &io_s,
-          io_tracer_, BlobFileCreationReason::kRecovery,
-          nullptr /* seqno_to_time_mapping */, &event_logger_, job_id,
-          nullptr /* table_properties */, write_hint,
-          nullptr /*full_history_ts_low*/, &blob_callback_, version,
-          &num_input_entries);
+      s = BuildTable(dbname_, versions_.get(), immutable_db_options_, tboptions,
+                     file_options_for_compaction_, cfd->table_cache(),
+                     iter.get(), std::move(range_del_iters), &meta,
+                     &blob_file_additions, snapshot_seqs, earliest_snapshot,
+                     earliest_write_conflict_snapshot, kMaxSequenceNumber,
+                     snapshot_checker, paranoid_file_checks,
+                     cfd->internal_stats(), &io_s, io_tracer_,
+                     BlobFileCreationReason::kRecovery,
+                     nullptr /* seqno_to_time_mapping */, &event_logger_,
+                     job_id, nullptr /* table_properties */, write_hint,
+                     nullptr /*full_history_ts_low*/, &blob_callback_, version,
+                     &num_input_entries);
       version->Unref();
       LogFlush(immutable_db_options_.info_log);
       ROCKS_LOG_DEBUG(immutable_db_options_.info_log,

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -480,9 +480,10 @@ class Repairer {
           dbname_, /* versions */ nullptr, immutable_db_options_, tboptions,
           file_options_, table_cache_.get(), iter.get(),
           std::move(range_del_iters), &meta, nullptr /* blob_file_additions */,
-          {}, kMaxSequenceNumber, kMaxSequenceNumber, snapshot_checker,
-          false /* paranoid_file_checks*/, nullptr /* internal_stats */, &io_s,
-          nullptr /*IOTracer*/, BlobFileCreationReason::kRecovery,
+          {}, kMaxSequenceNumber, kMaxSequenceNumber, kMaxSequenceNumber,
+          snapshot_checker, false /* paranoid_file_checks*/,
+          nullptr /* internal_stats */, &io_s, nullptr /*IOTracer*/,
+          BlobFileCreationReason::kRecovery,
           nullptr /* seqno_to_time_mapping */, nullptr /* event_logger */,
           0 /* job_id */, nullptr /* table_properties */, write_hint);
       ROCKS_LOG_INFO(db_options_.info_log,

--- a/db/seqno_to_time_mapping.h
+++ b/db/seqno_to_time_mapping.h
@@ -213,6 +213,15 @@ class SeqnoToTimeMapping {
   // must be in enforced state as a precondition.
   SequenceNumber GetProximalSeqnoBeforeTime(uint64_t time) const;
 
+  // Given current time, the configured `preserve_internal_time_seconds`, and
+  // `preclude_last_level_data_seconds`, find the relevant cutoff sequence
+  // numbers for tiering.
+  void GetCurrentTieringCutoffSeqnos(
+      uint64_t current_time, uint64_t preserve_internal_time_seconds,
+      uint64_t preclude_last_level_data_seconds,
+      SequenceNumber* preserve_time_min_seqno,
+      SequenceNumber* preclude_last_level_min_seqno) const;
+
   // Encode to a binary string by appending to `dest`.
   // Because this is a const operation depending on sortedness, the structure
   // must be in enforced state as a precondition.

--- a/db/table_properties_collector.h
+++ b/db/table_properties_collector.h
@@ -44,7 +44,9 @@ class InternalTblPropCollFactory {
   virtual ~InternalTblPropCollFactory() {}
   // has to be thread-safe
   virtual InternalTblPropColl* CreateInternalTblPropColl(
-      uint32_t column_family_id, int level_at_creation) = 0;
+      uint32_t column_family_id, int level_at_creation, int num_levels,
+      SequenceNumber last_level_inclusive_max_seqno_threshold =
+          kMaxSequenceNumber) = 0;
 
   // The name of the properties collector can be used for debugging purpose.
   virtual const char* Name() const = 0;
@@ -92,10 +94,15 @@ class UserKeyTablePropertiesCollectorFactory
       std::shared_ptr<TablePropertiesCollectorFactory> user_collector_factory)
       : user_collector_factory_(user_collector_factory) {}
   InternalTblPropColl* CreateInternalTblPropColl(
-      uint32_t column_family_id, int level_at_creation) override {
+      uint32_t column_family_id, int level_at_creation, int num_levels,
+      SequenceNumber last_level_inclusive_max_seqno_threshold =
+          kMaxSequenceNumber) override {
     TablePropertiesCollectorFactory::Context context;
     context.column_family_id = column_family_id;
     context.level_at_creation = level_at_creation;
+    context.num_levels = num_levels;
+    context.last_level_inclusive_max_seqno_threshold =
+        last_level_inclusive_max_seqno_threshold;
     TablePropertiesCollector* collector =
         user_collector_factory_->CreateTablePropertiesCollector(context);
     if (collector) {

--- a/db/table_properties_collector_test.cc
+++ b/db/table_properties_collector_test.cc
@@ -209,7 +209,9 @@ class RegularKeysStartWithAFactory : public InternalTblPropCollFactory,
     }
   }
   InternalTblPropColl* CreateInternalTblPropColl(
-      uint32_t /*column_family_id*/, int /* level_at_creation */) override {
+      uint32_t /*column_family_id*/, int /* level_at_creation */,
+      int /* num_levels */,
+      SequenceNumber /* last_level_inclusive_max_seqno_threshold */) override {
     return new RegularKeysStartWithAInternal();
   }
   const char* Name() const override { return "RegularKeysStartWithA"; }

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -166,6 +166,16 @@ class TablePropertiesCollectorFactory : public Customizable {
     static const uint32_t kUnknownColumnFamily;
     static const int kUnknownLevelAtCreation = -1;
     static const int kUnknownNumLevels = -1;
+
+    Context() {}
+
+    Context(uint32_t _column_family_id, int _level_at_creation, int _num_levels,
+            SequenceNumber _last_level_inclusive_max_seqno_threshold)
+        : column_family_id(_column_family_id),
+          level_at_creation(_level_at_creation),
+          num_levels(_num_levels),
+          last_level_inclusive_max_seqno_threshold(
+              _last_level_inclusive_max_seqno_threshold) {}
   };
 
   ~TablePropertiesCollectorFactory() override {}

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -157,8 +157,15 @@ class TablePropertiesCollectorFactory : public Customizable {
     // The level at creating the SST file (i.e, table), of which the
     // properties are being collected.
     int level_at_creation = kUnknownLevelAtCreation;
+    int num_levels = kUnknownNumLevels;
+    // In the tiering case, data with seqnos smaller than or equal to this
+    // cutoff sequence number will be considered by a compaction job as eligible
+    // to be placed on the last level. When this is the maximum sequence number,
+    // it indicates tiering is disabled.
+    SequenceNumber last_level_inclusive_max_seqno_threshold;
     static const uint32_t kUnknownColumnFamily;
     static const int kUnknownLevelAtCreation = -1;
+    static const int kUnknownNumLevels = -1;
   };
 
   ~TablePropertiesCollectorFactory() override {}

--- a/include/rocksdb/utilities/table_properties_collectors.h
+++ b/include/rocksdb/utilities/table_properties_collectors.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "rocksdb/table_properties.h"
+#include "util/mutexlock.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -84,4 +85,99 @@ std::shared_ptr<CompactOnDeletionCollectorFactory>
 NewCompactOnDeletionCollectorFactory(size_t sliding_window_size,
                                      size_t deletion_trigger,
                                      double deletion_ratio = 0);
+
+// A factory of a table property collector that marks a SST file as
+// need-compaction when for the tiering use case, it observes, at least "D" data
+// entries that are already eligible to be placed on the last level but are not
+// yet on the last level. "D" is the compaction trigger threshold set via the
+// initial construction or later via `SetCompactionTrigger` API.
+// When tiering is disabled for a column family, no observation is made, the SST
+// file won't be marked as need-compaction either.
+class CompactForTieringCollectorFactory
+    : public TablePropertiesCollectorFactory {
+ public:
+  // @param enabled. Whether to enable the collectors to observe and mark files
+  // as need compaction.
+  // @param compaction_triggers. Mapping from column family id to compaction
+  // trigger. Not set it for a column family, or set the compaction trigger to 0
+  // effectively will only collect stats and write a user property in sst file
+  // Set it to something other than 0 will also mark the file as need compaction
+  // if the number of observed eligible entries is equal to or higher than the
+  // trigger.
+  // No observation will be made if a column family that does not enable
+  // tiering, regardless of the configured compaction trigger.
+  CompactForTieringCollectorFactory(
+      const std::map<uint32_t, size_t>& compaction_triggers, bool enabled);
+
+  ~CompactForTieringCollectorFactory() {}
+
+  TablePropertiesCollector* CreateTablePropertiesCollector(
+      TablePropertiesCollectorFactory::Context context) override;
+
+  // Update the value of existing compaction triggers or add compaction triggers
+  // for new column families.
+  void SetCompactionTriggers(
+      const std::map<uint32_t, size_t>& compaction_triggers) {
+    WriteLock _(&rwlock_);
+    for (const auto& [cf_id, compaction_trigger] : compaction_triggers) {
+      auto iter = compaction_triggers_.find(cf_id);
+      if (iter == compaction_triggers_.end()) {
+        compaction_triggers_.emplace(cf_id, compaction_trigger);
+      } else {
+        iter->second = compaction_trigger;
+      }
+    }
+  }
+
+  // Update the value of existing compaction trigger or add one for a new
+  // column family.
+  void SetCompactionTrigger(uint32_t cf_id, size_t compaction_trigger) {
+    WriteLock _(&rwlock_);
+    auto iter = compaction_triggers_.find(cf_id);
+    if (iter == compaction_triggers_.end()) {
+      compaction_triggers_.emplace(cf_id, compaction_trigger);
+    } else {
+      iter->second = compaction_trigger;
+    }
+  }
+
+  const std::map<uint32_t, size_t>& GetCompactionTriggers() const {
+    ReadLock _(&rwlock_);
+    return compaction_triggers_;
+  }
+
+  size_t GetCompactionTrigger(uint32_t cf_id) const {
+    ReadLock _(&rwlock_);
+    auto iter = compaction_triggers_.find(cf_id);
+    if (iter == compaction_triggers_.end()) {
+      return 0;
+    }
+    return iter->second;
+  }
+
+  // To support dynamically enable / disable all the collectors.
+  void SetEnabled(bool enabled) {
+    WriteLock _(&rwlock_);
+    enabled_ = enabled;
+  }
+
+  bool GetEnabled() const {
+    ReadLock _(&rwlock_);
+    return enabled_;
+  }
+
+  static const char* kClassName() { return "CompactForTieringCollector"; }
+  const char* Name() const override { return kClassName(); }
+
+  std::string ToString() const override;
+
+ private:
+  mutable port::RWMutex rwlock_;  // synchronization mutex
+  std::map<uint32_t, size_t> compaction_triggers_;
+  bool enabled_;
+};
+
+std::shared_ptr<CompactForTieringCollectorFactory>
+NewCompactForTieringCollectorFactory(
+    const std::map<uint32_t, size_t>& compaction_triggers, bool enabled);
 }  // namespace ROCKSDB_NAMESPACE

--- a/src.mk
+++ b/src.mk
@@ -304,6 +304,7 @@ LIB_SOURCES =                                                   \
   utilities/persistent_cache/volatile_tier_impl.cc              \
   utilities/simulator_cache/cache_simulator.cc                  \
   utilities/simulator_cache/sim_cache.cc                        \
+  utilities/table_properties_collectors/compact_for_tiering_collector.cc \
   utilities/table_properties_collectors/compact_on_deletion_collector.cc \
   utilities/trace/file_trace_reader_writer.cc                   \
   utilities/trace/replayer_impl.cc                              \
@@ -628,6 +629,7 @@ TEST_MAIN_SOURCES =                                                     \
   utilities/persistent_cache/persistent_cache_test.cc                   \
   utilities/simulator_cache/cache_simulator_test.cc                     \
   utilities/simulator_cache/sim_cache_test.cc                           \
+  utilities/table_properties_collectors/compact_for_tiering_collector_test.cc \
   utilities/table_properties_collectors/compact_on_deletion_collector_test.cc  \
   utilities/transactions/optimistic_transaction_test.cc                 \
   utilities/transactions/lock/range/range_locking_test.cc               \

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -582,8 +582,10 @@ struct BlockBasedTableBuilder::Rep {
       assert(factory);
 
       std::unique_ptr<InternalTblPropColl> collector{
-          factory->CreateInternalTblPropColl(tbo.column_family_id,
-                                             tbo.level_at_creation)};
+          factory->CreateInternalTblPropColl(
+              tbo.column_family_id, tbo.level_at_creation,
+              tbo.ioptions.num_levels,
+              tbo.last_level_inclusive_max_seqno_threshold)};
       if (collector) {
         table_properties_collectors.emplace_back(std::move(collector));
       }

--- a/table/plain/plain_table_builder.cc
+++ b/table/plain/plain_table_builder.cc
@@ -119,8 +119,8 @@ PlainTableBuilder::PlainTableBuilder(
     assert(factory);
 
     std::unique_ptr<InternalTblPropColl> collector{
-        factory->CreateInternalTblPropColl(column_family_id,
-                                           level_at_creation)};
+        factory->CreateInternalTblPropColl(column_family_id, level_at_creation,
+                                           ioptions.num_levels)};
     if (collector) {
       table_properties_collectors_.emplace_back(std::move(collector));
     }

--- a/table/sst_file_writer_collectors.h
+++ b/table/sst_file_writer_collectors.h
@@ -79,7 +79,9 @@ class SstFileWriterPropertiesCollectorFactory
       : version_(version), global_seqno_(global_seqno) {}
 
   InternalTblPropColl* CreateInternalTblPropColl(
-      uint32_t /*column_family_id*/, int /* level_at_creation */) override {
+      uint32_t /*column_family_id*/, int /* level_at_creation */,
+      int /* num_levels */,
+      SequenceNumber /* last_level_inclusive_max_seqno_threshold */) override {
     return new SstFileWriterPropertiesCollector(version_, global_seqno_);
   }
 

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -99,7 +99,7 @@ struct TableReaderOptions {
   bool user_defined_timestamps_persisted;
 };
 
-struct TableBuilderOptions {
+struct TableBuilderOptions : public TablePropertiesCollectorFactory::Context {
   TableBuilderOptions(
       const ImmutableOptions& _ioptions, const MutableCFOptions& _moptions,
       const ReadOptions& _read_options, const WriteOptions& _write_options,
@@ -116,7 +116,10 @@ struct TableBuilderOptions {
       const uint64_t _target_file_size = 0, const uint64_t _cur_file_num = 0,
       const SequenceNumber _last_level_inclusive_max_seqno_threshold =
           kMaxSequenceNumber)
-      : ioptions(_ioptions),
+      : TablePropertiesCollectorFactory::Context(
+            _column_family_id, _level, _ioptions.num_levels,
+            _last_level_inclusive_max_seqno_threshold),
+        ioptions(_ioptions),
         moptions(_moptions),
         read_options(_read_options),
         write_options(_write_options),
@@ -124,19 +127,15 @@ struct TableBuilderOptions {
         internal_tbl_prop_coll_factories(_internal_tbl_prop_coll_factories),
         compression_type(_compression_type),
         compression_opts(_compression_opts),
-        column_family_id(_column_family_id),
         column_family_name(_column_family_name),
         oldest_key_time(_oldest_key_time),
         target_file_size(_target_file_size),
         file_creation_time(_file_creation_time),
         db_id(_db_id),
         db_session_id(_db_session_id),
-        level_at_creation(_level),
         is_bottommost(_is_bottommost),
         reason(_reason),
-        cur_file_num(_cur_file_num),
-        last_level_inclusive_max_seqno_threshold(
-            _last_level_inclusive_max_seqno_threshold) {}
+        cur_file_num(_cur_file_num) {}
 
   const ImmutableOptions& ioptions;
   const MutableCFOptions& moptions;
@@ -146,7 +145,6 @@ struct TableBuilderOptions {
   const InternalTblPropCollFactories* internal_tbl_prop_coll_factories;
   const CompressionType compression_type;
   const CompressionOptions& compression_opts;
-  const uint32_t column_family_id;
   const std::string& column_family_name;
   const int64_t oldest_key_time;
   const uint64_t target_file_size;
@@ -154,7 +152,6 @@ struct TableBuilderOptions {
   const std::string db_id;
   const std::string db_session_id;
   // BEGIN for FilterBuildingContext
-  const int level_at_creation;
   const bool is_bottommost;
   const TableFileCreationReason reason;
   // END for FilterBuildingContext
@@ -164,12 +161,6 @@ struct TableBuilderOptions {
   // in the table options of the ioptions.table_factory
   bool skip_filters = false;
   const uint64_t cur_file_num;
-
-  // When tiering is enabled, this is the current maximum seqno threshold below
-  // which data is considered old enough to be placed on the last level. The
-  // default value with maximum sequence number indicate tiering is disabled.
-  const SequenceNumber last_level_inclusive_max_seqno_threshold =
-      kMaxSequenceNumber;
 };
 
 // TableBuilder provides the interface used to build a Table

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -113,7 +113,9 @@ struct TableBuilderOptions {
       const int64_t _oldest_key_time = 0,
       const uint64_t _file_creation_time = 0, const std::string& _db_id = "",
       const std::string& _db_session_id = "",
-      const uint64_t _target_file_size = 0, const uint64_t _cur_file_num = 0)
+      const uint64_t _target_file_size = 0, const uint64_t _cur_file_num = 0,
+      const SequenceNumber _last_level_inclusive_max_seqno_threshold =
+          kMaxSequenceNumber)
       : ioptions(_ioptions),
         moptions(_moptions),
         read_options(_read_options),
@@ -132,7 +134,9 @@ struct TableBuilderOptions {
         level_at_creation(_level),
         is_bottommost(_is_bottommost),
         reason(_reason),
-        cur_file_num(_cur_file_num) {}
+        cur_file_num(_cur_file_num),
+        last_level_inclusive_max_seqno_threshold(
+            _last_level_inclusive_max_seqno_threshold) {}
 
   const ImmutableOptions& ioptions;
   const MutableCFOptions& moptions;
@@ -160,6 +164,12 @@ struct TableBuilderOptions {
   // in the table options of the ioptions.table_factory
   bool skip_filters = false;
   const uint64_t cur_file_num;
+
+  // When tiering is enabled, this is the current maximum seqno threshold below
+  // which data is considered old enough to be placed on the last level. The
+  // default value with maximum sequence number indicate tiering is disabled.
+  const SequenceNumber last_level_inclusive_max_seqno_threshold =
+      kMaxSequenceNumber;
 };
 
 // TableBuilder provides the interface used to build a Table

--- a/unreleased_history/new_features/auto_trigger_compaction_for_tiering.md
+++ b/unreleased_history/new_features/auto_trigger_compaction_for_tiering.md
@@ -1,0 +1,1 @@
+Added a `CompactForTieringCollectorFactory` to auto trigger compaction for tiering use case.

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -450,44 +450,6 @@ bool SerializeIntVector(const std::vector<int>& vec, std::string* value) {
   return true;
 }
 
-std::map<uint32_t, size_t> ParseUint32MapToSizeT(const std::string& value) {
-  std::map<uint32_t, size_t> result;
-  size_t start = 0;
-
-  auto parse_add_entry = [&](const std::string& str) {
-    size_t end = str.find(":", 0);
-    result.emplace(ParseUint32(str.substr(0, end)),
-                   ParseSizeT(str.substr(end + 1)));
-  };
-
-  while (start < value.size()) {
-    size_t end = value.find(",", start);
-    if (end == std::string::npos) {
-      parse_add_entry(value.substr(start));
-      break;
-    } else {
-      parse_add_entry(value.substr(start, end - start));
-      start = end + 1;
-    }
-  }
-  return result;
-}
-
-bool SerializeUint32MapToSizeT(const std::map<uint32_t, size_t>& mapping,
-                               std::string* value) {
-  size_t i = 0;
-  for (auto iter = mapping.begin(); iter != mapping.end(); iter++) {
-    if (i > 0) {
-      *value += ",";
-    }
-    *value += std::to_string(iter->first);
-    *value += ":";
-    *value += std::to_string(iter->second);
-    i += 1;
-  }
-  return true;
-}
-
 int ParseTimeStringToSeconds(const std::string& value) {
   int hours, minutes;
   char colon;

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -450,6 +450,44 @@ bool SerializeIntVector(const std::vector<int>& vec, std::string* value) {
   return true;
 }
 
+std::map<uint32_t, size_t> ParseUint32MapToSizeT(const std::string& value) {
+  std::map<uint32_t, size_t> result;
+  size_t start = 0;
+
+  auto parse_add_entry = [&](const std::string& str) {
+    size_t end = str.find(":", 0);
+    result.emplace(ParseUint32(str.substr(0, end)),
+                   ParseSizeT(str.substr(end + 1)));
+  };
+
+  while (start < value.size()) {
+    size_t end = value.find(",", start);
+    if (end == std::string::npos) {
+      parse_add_entry(value.substr(start));
+      break;
+    } else {
+      parse_add_entry(value.substr(start, end - start));
+      start = end + 1;
+    }
+  }
+  return result;
+}
+
+bool SerializeUint32MapToSizeT(const std::map<uint32_t, size_t>& mapping,
+                               std::string* value) {
+  size_t i = 0;
+  for (auto iter = mapping.begin(); iter != mapping.end(); iter++) {
+    if (i > 0) {
+      *value += ",";
+    }
+    *value += std::to_string(iter->first);
+    *value += ":";
+    *value += std::to_string(iter->second);
+    i += 1;
+  }
+  return true;
+}
+
 int ParseTimeStringToSeconds(const std::string& value) {
   int hours, minutes;
   char colon;

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -165,6 +166,11 @@ size_t ParseSizeT(const std::string& value);
 std::vector<int> ParseVectorInt(const std::string& value);
 
 bool SerializeIntVector(const std::vector<int>& vec, std::string* value);
+
+std::map<uint32_t, size_t> ParseUint32MapToSizeT(const std::string& value);
+
+bool SerializeUint32MapToSizeT(const std::map<uint32_t, size_t>& mapping,
+                               std::string* value);
 
 // Expects HH:mm format for the input value
 // Returns -1 if invalid input. Otherwise returns seconds since midnight

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -166,11 +165,6 @@ size_t ParseSizeT(const std::string& value);
 std::vector<int> ParseVectorInt(const std::string& value);
 
 bool SerializeIntVector(const std::vector<int>& vec, std::string* value);
-
-std::map<uint32_t, size_t> ParseUint32MapToSizeT(const std::string& value);
-
-bool SerializeUint32MapToSizeT(const std::map<uint32_t, size_t>& mapping,
-                               std::string* value);
 
 // Expects HH:mm format for the input value
 // Returns -1 if invalid input. Otherwise returns seconds since midnight

--- a/util/string_util_test.cc
+++ b/util/string_util_test.cc
@@ -27,6 +27,16 @@ TEST(StringUtilTest, NumberToHumanString) {
   ASSERT_EQ("-10G", NumberToHumanString(-10000000000));
 }
 
+TEST(StringUtilTest, Uint32MapToSizeT) {
+  std::map<uint32_t, size_t> mappings = {{1, 2}, {3, 4}, {5, 6}};
+
+  std::string serialization;
+  SerializeUint32MapToSizeT(mappings, &serialization);
+  ASSERT_EQ("1:2,3:4,5:6", serialization);
+  std::map<uint32_t, size_t> parsed = ParseUint32MapToSizeT(serialization);
+  ASSERT_EQ(mappings, parsed);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/util/string_util_test.cc
+++ b/util/string_util_test.cc
@@ -27,16 +27,6 @@ TEST(StringUtilTest, NumberToHumanString) {
   ASSERT_EQ("-10G", NumberToHumanString(-10000000000));
 }
 
-TEST(StringUtilTest, Uint32MapToSizeT) {
-  std::map<uint32_t, size_t> mappings = {{1, 2}, {3, 4}, {5, 6}};
-
-  std::string serialization;
-  SerializeUint32MapToSizeT(mappings, &serialization);
-  ASSERT_EQ("1:2,3:4,5:6", serialization);
-  std::map<uint32_t, size_t> parsed = ParseUint32MapToSizeT(serialization);
-  ASSERT_EQ(mappings, parsed);
-}
-
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.cc
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.cc
@@ -1,0 +1,177 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "utilities/table_properties_collectors/compact_for_tiering_collector.h"
+
+#include <sstream>
+
+#include "db/seqno_to_time_mapping.h"
+#include "rocksdb/status.h"
+#include "rocksdb/types.h"
+#include "rocksdb/utilities/customizable_util.h"
+#include "rocksdb/utilities/object_registry.h"
+#include "rocksdb/utilities/options_type.h"
+#include "rocksdb/utilities/table_properties_collectors.h"
+#include "util/string_util.h"
+
+namespace ROCKSDB_NAMESPACE {
+const std::string
+    CompactForTieringCollector::kNumEligibleLastLevelEntriesPropertyName =
+        "rocksdb.eligible.last.level.entries";
+
+CompactForTieringCollector::CompactForTieringCollector(
+    int level_at_creation, int num_levels,
+    SequenceNumber last_level_inclusive_max_seqno_threshold,
+    size_t compaction_trigger, bool enabled)
+    : level_at_creation_(level_at_creation),
+      num_levels_(num_levels),
+      last_level_inclusive_max_seqno_threshold_(
+          last_level_inclusive_max_seqno_threshold),
+      compaction_trigger_(compaction_trigger),
+      enabled_(enabled) {}
+
+Status CompactForTieringCollector::AddUserKey(const Slice& /*key*/,
+                                              const Slice& value,
+                                              EntryType type,
+                                              SequenceNumber seq,
+                                              uint64_t /*file_size*/) {
+  if (!enabled_ || level_at_creation_ == num_levels_ - 1 ||
+      last_level_inclusive_max_seqno_threshold_ == kMaxSequenceNumber) {
+    return Status::OK();
+  }
+  SequenceNumber seq_for_check = seq;
+  if (type == kEntryTimedPut) {
+    seq_for_check = ParsePackedValueForSeqno(value);
+  }
+  if (seq_for_check < last_level_inclusive_max_seqno_threshold_) {
+    last_level_eligible_entries_counter_++;
+  }
+  return Status::OK();
+}
+
+Status CompactForTieringCollector::Finish(UserCollectedProperties* properties) {
+  assert(!finish_called_);
+  if (compaction_trigger_ != 0 &&
+      last_level_eligible_entries_counter_ >= compaction_trigger_) {
+    need_compaction_ = true;
+  }
+  finish_called_ = true;
+  if (last_level_eligible_entries_counter_ > 0) {
+    *properties = UserCollectedProperties{
+        {kNumEligibleLastLevelEntriesPropertyName,
+         std::to_string(last_level_eligible_entries_counter_)},
+    };
+  }
+  return Status::OK();
+}
+
+UserCollectedProperties CompactForTieringCollector::GetReadableProperties()
+    const {
+  return UserCollectedProperties{
+      {kNumEligibleLastLevelEntriesPropertyName,
+       std::to_string(last_level_eligible_entries_counter_)},
+  };
+}
+
+bool CompactForTieringCollector::NeedCompact() const {
+  return need_compaction_;
+}
+
+void CompactForTieringCollector::Reset() {
+  last_level_eligible_entries_counter_ = 0;
+  finish_called_ = false;
+  need_compaction_ = false;
+}
+
+TablePropertiesCollector*
+CompactForTieringCollectorFactory::CreateTablePropertiesCollector(
+    TablePropertiesCollectorFactory::Context context) {
+  uint64_t compaction_trigger = GetCompactionTrigger(context.column_family_id);
+  return new CompactForTieringCollector(
+      context.level_at_creation, context.num_levels,
+      context.last_level_inclusive_max_seqno_threshold, compaction_trigger,
+      enabled_);
+}
+
+static std::unordered_map<std::string, OptionTypeInfo>
+    on_compact_for_tiering_type_info = {
+        {"compaction_triggers",
+         {0, OptionType::kUnknown, OptionVerificationType::kNormal,
+          OptionTypeFlags::kCompareNever | OptionTypeFlags::kMutable,
+          [](const ConfigOptions&, const std::string&, const std::string& value,
+             void* addr) {
+            auto* factory =
+                static_cast<CompactForTieringCollectorFactory*>(addr);
+            factory->SetCompactionTriggers(ParseUint32MapToSizeT(value));
+            return Status::OK();
+          },
+          [](const ConfigOptions&, const std::string&, const void* addr,
+             std::string* value) {
+            const auto* factory =
+                static_cast<const CompactForTieringCollectorFactory*>(addr);
+            SerializeUint32MapToSizeT(
+                const_cast<CompactForTieringCollectorFactory*>(factory)
+                    ->GetCompactionTriggers(),
+                value);
+            return Status::OK();
+          },
+          nullptr}},
+        {"enabled",
+         {0, OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kCompareNever | OptionTypeFlags::kMutable,
+          [](const ConfigOptions&, const std::string&, const std::string& value,
+             void* addr) {
+            auto* factory =
+                static_cast<CompactForTieringCollectorFactory*>(addr);
+            factory->SetEnabled(ParseBoolean("", value));
+            return Status::OK();
+          },
+          [](const ConfigOptions&, const std::string&, const void* addr,
+             std::string* value) {
+            const auto* factory =
+                static_cast<const CompactForTieringCollectorFactory*>(addr);
+            *value = std::to_string(
+                const_cast<CompactForTieringCollectorFactory*>(factory)
+                    ->GetEnabled());
+            return Status::OK();
+          },
+          nullptr}},
+
+};
+
+CompactForTieringCollectorFactory::CompactForTieringCollectorFactory(
+    const std::map<uint32_t, size_t>& compaction_triggers, bool enabled)
+    : compaction_triggers_(compaction_triggers), enabled_(enabled) {
+  RegisterOptions("", this, &on_compact_for_tiering_type_info);
+}
+
+std::string CompactForTieringCollectorFactory::ToString() const {
+  std::ostringstream cfg;
+  cfg << Name() << ", compaction triggers: {";
+  bool first_entry = true;
+  for (const auto& [cf_id, compaction_trigger] : compaction_triggers_) {
+    if (first_entry) {
+      first_entry = false;
+    } else {
+      cfg << ", ";
+    }
+    cfg << "(column family id: " << cf_id
+        << ", compaction trigger: " << compaction_trigger << ")";
+  }
+  cfg << "}, enabled: " << (enabled_ ? "true" : "false") << std::endl;
+  return cfg.str();
+}
+
+std::shared_ptr<CompactForTieringCollectorFactory>
+NewCompactForTieringCollectorFactory(
+    const std::map<uint32_t, size_t>& compaction_triggers, bool enabled) {
+  return std::make_shared<CompactForTieringCollectorFactory>(
+      compaction_triggers, enabled);
+  return std::shared_ptr<CompactForTieringCollectorFactory>(
+      new CompactForTieringCollectorFactory(compaction_triggers, enabled));
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.cc
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.cc
@@ -23,25 +23,19 @@ const std::string
         "rocksdb.eligible.last.level.entries";
 
 CompactForTieringCollector::CompactForTieringCollector(
-    int level_at_creation, int num_levels,
     SequenceNumber last_level_inclusive_max_seqno_threshold,
-    size_t compaction_trigger, bool enabled)
-    : level_at_creation_(level_at_creation),
-      num_levels_(num_levels),
-      last_level_inclusive_max_seqno_threshold_(
+    double compaction_trigger_ratio)
+    : last_level_inclusive_max_seqno_threshold_(
           last_level_inclusive_max_seqno_threshold),
-      compaction_trigger_(compaction_trigger),
-      enabled_(enabled) {}
+      compaction_trigger_ratio_(compaction_trigger_ratio) {
+  assert(last_level_inclusive_max_seqno_threshold_ != kMaxSequenceNumber);
+}
 
 Status CompactForTieringCollector::AddUserKey(const Slice& /*key*/,
                                               const Slice& value,
                                               EntryType type,
                                               SequenceNumber seq,
                                               uint64_t /*file_size*/) {
-  if (!enabled_ || level_at_creation_ == num_levels_ - 1 ||
-      last_level_inclusive_max_seqno_threshold_ == kMaxSequenceNumber) {
-    return Status::OK();
-  }
   SequenceNumber seq_for_check = seq;
   if (type == kEntryTimedPut) {
     seq_for_check = ParsePackedValueForSeqno(value);
@@ -49,22 +43,25 @@ Status CompactForTieringCollector::AddUserKey(const Slice& /*key*/,
   if (seq_for_check < last_level_inclusive_max_seqno_threshold_) {
     last_level_eligible_entries_counter_++;
   }
+  total_entries_counter_ += 1;
   return Status::OK();
 }
 
 Status CompactForTieringCollector::Finish(UserCollectedProperties* properties) {
   assert(!finish_called_);
-  if (compaction_trigger_ != 0 &&
-      last_level_eligible_entries_counter_ >= compaction_trigger_) {
+  assert(compaction_trigger_ratio_ > 0);
+  if (last_level_eligible_entries_counter_ >=
+      compaction_trigger_ratio_ * total_entries_counter_) {
+    assert(compaction_trigger_ratio_ <= 1);
     need_compaction_ = true;
   }
-  finish_called_ = true;
   if (last_level_eligible_entries_counter_ > 0) {
     *properties = UserCollectedProperties{
         {kNumEligibleLastLevelEntriesPropertyName,
          std::to_string(last_level_eligible_entries_counter_)},
     };
   }
+  finish_called_ = true;
   return Status::OK();
 }
 
@@ -82,6 +79,7 @@ bool CompactForTieringCollector::NeedCompact() const {
 
 void CompactForTieringCollector::Reset() {
   last_level_eligible_entries_counter_ = 0;
+  total_entries_counter_ = 0;
   finish_called_ = false;
   need_compaction_ = false;
 }
@@ -89,53 +87,34 @@ void CompactForTieringCollector::Reset() {
 TablePropertiesCollector*
 CompactForTieringCollectorFactory::CreateTablePropertiesCollector(
     TablePropertiesCollectorFactory::Context context) {
-  uint64_t compaction_trigger = GetCompactionTrigger(context.column_family_id);
+  double compaction_trigger_ratio = GetCompactionTriggerRatio();
+  if (compaction_trigger_ratio <= 0 ||
+      context.level_at_creation == context.num_levels - 1 ||
+      context.last_level_inclusive_max_seqno_threshold == kMaxSequenceNumber) {
+    return nullptr;
+  }
   return new CompactForTieringCollector(
-      context.level_at_creation, context.num_levels,
-      context.last_level_inclusive_max_seqno_threshold, compaction_trigger,
-      enabled_);
+      context.last_level_inclusive_max_seqno_threshold,
+      compaction_trigger_ratio);
 }
 
 static std::unordered_map<std::string, OptionTypeInfo>
     on_compact_for_tiering_type_info = {
-        {"compaction_triggers",
+        {"compaction_trigger_ratio",
          {0, OptionType::kUnknown, OptionVerificationType::kNormal,
           OptionTypeFlags::kCompareNever | OptionTypeFlags::kMutable,
           [](const ConfigOptions&, const std::string&, const std::string& value,
              void* addr) {
             auto* factory =
                 static_cast<CompactForTieringCollectorFactory*>(addr);
-            factory->SetCompactionTriggers(ParseUint32MapToSizeT(value));
+            factory->SetCompactionTriggerRatio(ParseDouble(value));
             return Status::OK();
           },
           [](const ConfigOptions&, const std::string&, const void* addr,
              std::string* value) {
             const auto* factory =
                 static_cast<const CompactForTieringCollectorFactory*>(addr);
-            SerializeUint32MapToSizeT(
-                const_cast<CompactForTieringCollectorFactory*>(factory)
-                    ->GetCompactionTriggers(),
-                value);
-            return Status::OK();
-          },
-          nullptr}},
-        {"enabled",
-         {0, OptionType::kBoolean, OptionVerificationType::kNormal,
-          OptionTypeFlags::kCompareNever | OptionTypeFlags::kMutable,
-          [](const ConfigOptions&, const std::string&, const std::string& value,
-             void* addr) {
-            auto* factory =
-                static_cast<CompactForTieringCollectorFactory*>(addr);
-            factory->SetEnabled(ParseBoolean("", value));
-            return Status::OK();
-          },
-          [](const ConfigOptions&, const std::string&, const void* addr,
-             std::string* value) {
-            const auto* factory =
-                static_cast<const CompactForTieringCollectorFactory*>(addr);
-            *value = std::to_string(
-                const_cast<CompactForTieringCollectorFactory*>(factory)
-                    ->GetEnabled());
+            *value = std::to_string(factory->GetCompactionTriggerRatio());
             return Status::OK();
           },
           nullptr}},
@@ -143,35 +122,25 @@ static std::unordered_map<std::string, OptionTypeInfo>
 };
 
 CompactForTieringCollectorFactory::CompactForTieringCollectorFactory(
-    const std::map<uint32_t, size_t>& compaction_triggers, bool enabled)
-    : compaction_triggers_(compaction_triggers), enabled_(enabled) {
+    double compaction_trigger_ratio)
+    : compaction_trigger_ratio_(compaction_trigger_ratio) {
   RegisterOptions("", this, &on_compact_for_tiering_type_info);
 }
 
 std::string CompactForTieringCollectorFactory::ToString() const {
   std::ostringstream cfg;
-  cfg << Name() << ", compaction triggers: {";
-  bool first_entry = true;
-  for (const auto& [cf_id, compaction_trigger] : compaction_triggers_) {
-    if (first_entry) {
-      first_entry = false;
-    } else {
-      cfg << ", ";
-    }
-    cfg << "(column family id: " << cf_id
-        << ", compaction trigger: " << compaction_trigger << ")";
-  }
-  cfg << "}, enabled: " << (enabled_ ? "true" : "false") << std::endl;
+  cfg << Name()
+      << ", compaction trigger ratio:" << compaction_trigger_ratio_.load()
+      << std::endl;
   return cfg.str();
 }
 
 std::shared_ptr<CompactForTieringCollectorFactory>
-NewCompactForTieringCollectorFactory(
-    const std::map<uint32_t, size_t>& compaction_triggers, bool enabled) {
+NewCompactForTieringCollectorFactory(double compaction_trigger_ratio) {
   return std::make_shared<CompactForTieringCollectorFactory>(
-      compaction_triggers, enabled);
+      compaction_trigger_ratio);
   return std::shared_ptr<CompactForTieringCollectorFactory>(
-      new CompactForTieringCollectorFactory(compaction_triggers, enabled));
+      new CompactForTieringCollectorFactory(compaction_trigger_ratio));
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.h
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.h
@@ -11,17 +11,15 @@
 namespace ROCKSDB_NAMESPACE {
 
 // A user property collector that marks a SST file as need-compaction when for
-// the tiering use case, it observes, at least "compaction_trigger"  number of
-// data entries that are already eligible to be placed on the last level but are
-// not yet on the last level.
+// the tiering use case. See documentation for
+// `CompactForTieringCollectorFactory`.
 class CompactForTieringCollector : public TablePropertiesCollector {
  public:
   static const std::string kNumEligibleLastLevelEntriesPropertyName;
 
   CompactForTieringCollector(
-      int level_at_creation, int num_levels,
       SequenceNumber last_level_inclusive_max_seqno_threshold_,
-      size_t compaction_trigger, bool enabled);
+      double compaction_trigger_ratio);
 
   Status AddUserKey(const Slice& key, const Slice& value, EntryType type,
                     SequenceNumber seq, uint64_t file_size) override;
@@ -37,13 +35,11 @@ class CompactForTieringCollector : public TablePropertiesCollector {
  private:
   void Reset();
 
-  int level_at_creation_;
-  int num_levels_;
   SequenceNumber last_level_inclusive_max_seqno_threshold_;
-  size_t compaction_trigger_;
+  double compaction_trigger_ratio_;
   size_t last_level_eligible_entries_counter_ = 0;
+  size_t total_entries_counter_ = 0;
   bool finish_called_ = false;
   bool need_compaction_ = false;
-  bool enabled_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.h
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.h
@@ -1,0 +1,49 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include "rocksdb/utilities/table_properties_collectors.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// A user property collector that marks a SST file as need-compaction when for
+// the tiering use case, it observes, at least "compaction_trigger"  number of
+// data entries that are already eligible to be placed on the last level but are
+// not yet on the last level.
+class CompactForTieringCollector : public TablePropertiesCollector {
+ public:
+  static const std::string kNumEligibleLastLevelEntriesPropertyName;
+
+  CompactForTieringCollector(
+      int level_at_creation, int num_levels,
+      SequenceNumber last_level_inclusive_max_seqno_threshold_,
+      size_t compaction_trigger, bool enabled);
+
+  Status AddUserKey(const Slice& key, const Slice& value, EntryType type,
+                    SequenceNumber seq, uint64_t file_size) override;
+
+  Status Finish(UserCollectedProperties* properties) override;
+
+  UserCollectedProperties GetReadableProperties() const override;
+
+  const char* Name() const override { return "CompactForTieringCollector"; }
+
+  bool NeedCompact() const override;
+
+ private:
+  void Reset();
+
+  int level_at_creation_;
+  int num_levels_;
+  SequenceNumber last_level_inclusive_max_seqno_threshold_;
+  size_t compaction_trigger_;
+  size_t last_level_eligible_entries_counter_ = 0;
+  bool finish_called_ = false;
+  bool need_compaction_ = false;
+  bool enabled_;
+};
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
@@ -1,0 +1,228 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "utilities/table_properties_collectors/compact_for_tiering_collector.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <vector>
+
+#include "db/seqno_to_time_mapping.h"
+#include "port/stack_trace.h"
+#include "rocksdb/table.h"
+#include "rocksdb/table_properties.h"
+#include "rocksdb/utilities/table_properties_collectors.h"
+#include "test_util/testharness.h"
+#include "util/random.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+TEST(CompactForTieringCollector, NotEnabled) {
+  TablePropertiesCollectorFactory::Context context;
+  context.column_family_id = 1;
+  context.level_at_creation = 1;
+  context.num_levels = 6;
+  context.last_level_inclusive_max_seqno_threshold = 50;
+  const size_t kTotalEntries = 100;
+
+  // When not enabled, collectors are no op.
+  {
+    for (size_t compaction_trigger : {0, 50, 100}) {
+      auto factory = NewCompactForTieringCollectorFactory(
+          {{1, compaction_trigger}}, /*enabled=*/false);
+      std::unique_ptr<TablePropertiesCollector> collector(
+          factory->CreateTablePropertiesCollector(context));
+      for (size_t i = 0; i < kTotalEntries; i++) {
+        ASSERT_OK(collector->AddUserKey("hello", "rocksdb", kEntryPut, i, 0));
+        ASSERT_FALSE(collector->NeedCompact());
+      }
+      UserCollectedProperties user_properties;
+      ASSERT_OK(collector->Finish(&user_properties));
+      ASSERT_EQ(
+          user_properties.find(CompactForTieringCollector::
+                                   kNumEligibleLastLevelEntriesPropertyName),
+          user_properties.end());
+      ASSERT_FALSE(collector->NeedCompact());
+    }
+  }
+}
+
+TEST(CompactForTieringCollector, TieringDisabled) {
+  TablePropertiesCollectorFactory::Context context;
+  context.column_family_id = 1;
+  context.level_at_creation = 1;
+  context.num_levels = 6;
+  context.last_level_inclusive_max_seqno_threshold = kMaxSequenceNumber;
+  const size_t kTotalEntries = 100;
+
+  // Tiering is disabled on the column family. No stats related to tiering is
+  // collected, nor will the file be marked for need compaction regardless of
+  // the configured compaction trigger (likely mistakenly).
+  {
+    for (size_t compaction_trigger : {0, 50, 100}) {
+      auto factory = NewCompactForTieringCollectorFactory(
+          {{1, compaction_trigger}}, /*enabled=*/true);
+      std::unique_ptr<TablePropertiesCollector> collector(
+          factory->CreateTablePropertiesCollector(context));
+      for (size_t i = 0; i < kTotalEntries; i++) {
+        ASSERT_OK(collector->AddUserKey("hello", "rocksdb", kEntryPut, i, 0));
+        ASSERT_FALSE(collector->NeedCompact());
+      }
+      UserCollectedProperties user_properties;
+      ASSERT_OK(collector->Finish(&user_properties));
+      ASSERT_EQ(
+          user_properties.find(CompactForTieringCollector::
+                                   kNumEligibleLastLevelEntriesPropertyName),
+          user_properties.end());
+      ASSERT_FALSE(collector->NeedCompact());
+    }
+  }
+}
+
+TEST(CompactForTieringCollector, LastLevelFile) {
+  TablePropertiesCollectorFactory::Context context;
+  context.column_family_id = 1;
+  context.level_at_creation = 5;
+  context.num_levels = 6;
+  context.last_level_inclusive_max_seqno_threshold = 50;
+  const size_t kTotalEntries = 100;
+
+  // No stats are collected for a file that is already on the last level, nor
+  // will the file be marked as need compaction.
+  {
+    for (size_t compaction_trigger : {0, 50, 100}) {
+      auto factory = NewCompactForTieringCollectorFactory(
+          {{1, compaction_trigger}}, /*enabled=*/true);
+      std::unique_ptr<TablePropertiesCollector> collector(
+          factory->CreateTablePropertiesCollector(context));
+      for (size_t i = 0; i < kTotalEntries; i++) {
+        ASSERT_OK(collector->AddUserKey("hello", "rocksdb", kEntryPut, 0, 0));
+        ASSERT_FALSE(collector->NeedCompact());
+      }
+      UserCollectedProperties user_properties;
+      ASSERT_OK(collector->Finish(&user_properties));
+      ASSERT_EQ(
+          user_properties.find(CompactForTieringCollector::
+                                   kNumEligibleLastLevelEntriesPropertyName),
+          user_properties.end());
+      ASSERT_FALSE(collector->NeedCompact());
+    }
+  }
+}
+
+TEST(CompactForTieringCollector, CompactionTriggerNotSet) {
+  TablePropertiesCollectorFactory::Context context;
+  context.column_family_id = 1;
+  context.level_at_creation = 1;
+  context.num_levels = 6;
+  context.last_level_inclusive_max_seqno_threshold = 50;
+  const size_t kTotalEntries = 100;
+
+  // No compaction trigger explicitly set for this column family.
+  auto factory =
+      NewCompactForTieringCollectorFactory({{2, 15}}, /*enabled=*/true);
+  {
+    std::unique_ptr<TablePropertiesCollector> collector(
+        factory->CreateTablePropertiesCollector(context));
+    for (size_t i = 0; i < kTotalEntries; i++) {
+      ASSERT_OK(collector->AddUserKey("hello", "rocksdb", kEntryPut, i, 0));
+      ASSERT_FALSE(collector->NeedCompact());
+    }
+    // User property written to sst file, file not marked for compaction.
+    UserCollectedProperties user_properties;
+    ASSERT_OK(collector->Finish(&user_properties));
+    ASSERT_EQ(std::to_string(50),
+              user_properties[CompactForTieringCollector::
+                                  kNumEligibleLastLevelEntriesPropertyName]);
+    ASSERT_FALSE(collector->NeedCompact());
+  }
+
+  // Compaction trigger explicitly set to 0.
+  factory->SetCompactionTrigger(1, 0);
+  {
+    std::unique_ptr<TablePropertiesCollector> collector(
+        factory->CreateTablePropertiesCollector(context));
+    for (size_t i = 0; i < kTotalEntries; i++) {
+      ASSERT_OK(collector->AddUserKey("hello", "rocksdb", kEntryPut, i, 0));
+      ASSERT_FALSE(collector->NeedCompact());
+    }
+
+    // User property written to sst file, file not marked for compaction.
+    UserCollectedProperties user_properties;
+    ASSERT_OK(collector->Finish(&user_properties));
+    ASSERT_EQ(std::to_string(50),
+              user_properties[CompactForTieringCollector::
+                                  kNumEligibleLastLevelEntriesPropertyName]);
+    ASSERT_FALSE(collector->NeedCompact());
+  }
+}
+
+TEST(CompactForTieringCollector, MarkForCompaction) {
+  TablePropertiesCollectorFactory::Context context;
+  context.column_family_id = 1;
+  context.level_at_creation = 1;
+  context.num_levels = 6;
+  context.last_level_inclusive_max_seqno_threshold = 50;
+  const size_t kTotalEntries = 100;
+
+  {
+    for (size_t compaction_trigger : {0, 1, 50, 100}) {
+      auto factory = NewCompactForTieringCollectorFactory(
+          {{1, compaction_trigger}}, /*enabled=*/true);
+      std::unique_ptr<TablePropertiesCollector> collector(
+          factory->CreateTablePropertiesCollector(context));
+      for (size_t i = 0; i < kTotalEntries; i++) {
+        ASSERT_OK(collector->AddUserKey("hello", "rocksdb", kEntryPut, i, 0));
+        ASSERT_FALSE(collector->NeedCompact());
+      }
+      UserCollectedProperties user_properties;
+      ASSERT_OK(collector->Finish(&user_properties));
+      ASSERT_EQ(user_properties[CompactForTieringCollector::
+                                    kNumEligibleLastLevelEntriesPropertyName],
+                std::to_string(50));
+      if (compaction_trigger == 0 || compaction_trigger > 50) {
+        ASSERT_FALSE(collector->NeedCompact());
+      } else {
+        ASSERT_TRUE(collector->NeedCompact());
+      }
+    }
+  }
+}
+
+TEST(CompactForTieringCollector, TimedPutEntries) {
+  TablePropertiesCollectorFactory::Context context;
+  context.column_family_id = 1;
+  context.level_at_creation = 1;
+  context.num_levels = 6;
+  context.last_level_inclusive_max_seqno_threshold = 50;
+  const size_t kTotalEntries = 100;
+
+  auto factory =
+      NewCompactForTieringCollectorFactory({{1, 50}}, /*enabled=*/true);
+  std::unique_ptr<TablePropertiesCollector> collector(
+      factory->CreateTablePropertiesCollector(context));
+  for (size_t i = 0; i < kTotalEntries; i++) {
+    std::string value;
+    PackValueAndSeqno("rocksdb", i, &value);
+    ASSERT_OK(collector->AddUserKey("hello", value, kEntryTimedPut, 0, 0));
+    ASSERT_FALSE(collector->NeedCompact());
+  }
+  UserCollectedProperties user_properties;
+  ASSERT_OK(collector->Finish(&user_properties));
+  ASSERT_EQ(user_properties[CompactForTieringCollector::
+                                kNumEligibleLastLevelEntriesPropertyName],
+            std::to_string(50));
+  ASSERT_TRUE(collector->NeedCompact());
+}
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/utilities/table_properties_collectors/compact_on_deletion_collector.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector.cc
@@ -211,10 +211,7 @@ static int RegisterTablePropertiesCollectorFactories(
         // By default, create a `CompactForTieringCollectorFactory` that is
         // disabled. Users will need to call corresponding setters to enable
         // the factory.
-        std::map<uint32_t, size_t> compaction_triggers;
-        bool dark_mode = true;
-        guard->reset(new CompactForTieringCollectorFactory(compaction_triggers,
-                                                           dark_mode));
+        guard->reset(new CompactForTieringCollectorFactory(0));
         return guard->get();
       });
   return 1;

--- a/utilities/table_properties_collectors/compact_on_deletion_collector.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector.cc
@@ -188,6 +188,7 @@ NewCompactOnDeletionCollectorFactory(size_t sliding_window_size,
       new CompactOnDeletionCollectorFactory(sliding_window_size,
                                             deletion_trigger, deletion_ratio));
 }
+
 namespace {
 static int RegisterTablePropertiesCollectorFactories(
     ObjectLibrary& library, const std::string& /*arg*/) {
@@ -200,6 +201,20 @@ static int RegisterTablePropertiesCollectorFactories(
         // Users will need to provide configuration parameters or call the
         // corresponding Setter to enable the factory.
         guard->reset(new CompactOnDeletionCollectorFactory(0, 0, 0));
+        return guard->get();
+      });
+  library.AddFactory<TablePropertiesCollectorFactory>(
+      CompactForTieringCollectorFactory::kClassName(),
+      [](const std::string& /*uri*/,
+         std::unique_ptr<TablePropertiesCollectorFactory>* guard,
+         std::string* /* errmsg */) {
+        // By default, create a `CompactForTieringCollectorFactory` that is
+        // disabled. Users will need to call corresponding setters to enable
+        // the factory.
+        std::map<uint32_t, size_t> compaction_triggers;
+        bool dark_mode = true;
+        guard->reset(new CompactForTieringCollectorFactory(compaction_triggers,
+                                                           dark_mode));
         return guard->get();
       });
   return 1;

--- a/utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <vector>
 
+#include "db/dbformat.h"
 #include "port/stack_trace.h"
 #include "rocksdb/table.h"
 #include "rocksdb/table_properties.h"
@@ -27,6 +28,7 @@ TEST(CompactOnDeletionCollector, DeletionRatio) {
   TablePropertiesCollectorFactory::Context context;
   context.column_family_id =
       TablePropertiesCollectorFactory::Context::kUnknownColumnFamily;
+  context.last_level_inclusive_max_seqno_threshold = kMaxSequenceNumber;
   const size_t kTotalEntries = 100;
 
   {
@@ -86,6 +88,7 @@ TEST(CompactOnDeletionCollector, SlidingWindow) {
   TablePropertiesCollectorFactory::Context context;
   context.column_family_id =
       TablePropertiesCollectorFactory::Context::kUnknownColumnFamily;
+  context.last_level_inclusive_max_seqno_threshold = kMaxSequenceNumber;
 
   std::vector<int> window_sizes;
   std::vector<int> deletion_triggers;


### PR DESCRIPTION
This PR adds user property collector factory `CompactForTieringCollectorFactory` to support observe SST file and mark it as need compaction for fast tracking data to the proper tier.

A triggering ratio `compaction_trigger_ratio_` can be configured to achieve the following:
1) Setting the ratio to be equal to or smaller than 0 disables this collector
2) Setting the ratio to be within (0, 1] will write the number of observed eligible entries into a user property and marks a file as need-compaction when aforementioned condition is met.
3) Setting the ratio to be higher than 1 can be used to just writes the user table property, and not mark any file as need compaction.
 For a column family that does not enable tiering feature, even if an effective configuration is provided, this collector is still disabled. For a file that is already on the last level, this collector is also disabled.

Test Plan:
Added unit tests