### PR TITLE
Propagate ReadOptions::readahead_size in PartitionedIndexReader

### DIFF
--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -2722,11 +2722,7 @@ TEST_P(PrefetchTest, SeekParallelizationTestWithPosix) {
     if (read_async_called) {
       ASSERT_GT(async_read_bytes.count, 0);
       ASSERT_GT(get_perf_context()->number_async_seek, 0);
-      if (std::get<1>(GetParam())) {
-        ASSERT_EQ(buff_prefetch_count, 1);
-      } else {
-        ASSERT_EQ(buff_prefetch_count, 2);
-      }
+      ASSERT_EQ(buff_prefetch_count, 2);
     } else {
       // Not all platforms support iouring. In that case, ReadAsync in posix
       // won't submit async requests.

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -78,11 +78,6 @@ InternalIteratorBase<IndexValue>* PartitionIndexReader::NewIterator(
             index_value_is_full(), false /* block_contents_pinned */,
             user_defined_timestamps_persisted()));
   } else {
-    ReadOptions ro{read_options};
-    // FIXME? Possible regression seen in prefetch_test if this field is
-    // propagated
-    ro.readahead_size = ReadOptions{}.readahead_size;
-
     // We don't return pinned data from index blocks, so no need
     // to set `block_contents_pinned`.
     std::unique_ptr<InternalIteratorBase<IndexValue>> index_iter(
@@ -94,7 +89,7 @@ InternalIteratorBase<IndexValue>* PartitionIndexReader::NewIterator(
             user_defined_timestamps_persisted()));
 
     it = new PartitionedIndexIterator(
-        table(), ro, *internal_comparator(), std::move(index_iter),
+        table(), read_options, *internal_comparator(), std::move(index_iter),
         lookup_context ? lookup_context->caller
                        : TableReaderCaller::kUncategorized);
   }


### PR DESCRIPTION
Summary: Not sure if this change is desirable given the unit test churn, but the unit test is not clear, in part because the meaning of readahead options is unclear (#12756).

Test Plan: existing tests (updated)