### PR TITLE
WIP: EnforceReadOpts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -851,6 +851,7 @@ set(SOURCES
         table/sst_file_writer.cc
         table/table_factory.cc
         table/table_properties.cc
+        table/table_reader.cc
         table/two_level_iterator.cc
         table/unique_id.cc
         test_util/sync_point.cc

--- a/TARGETS
+++ b/TARGETS
@@ -229,6 +229,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "table/sst_file_writer.cc",
         "table/table_factory.cc",
         "table/table_properties.cc",
+        "table/table_reader.cc",
         "table/two_level_iterator.cc",
         "table/unique_id.cc",
         "test_util/sync_point.cc",

--- a/src.mk
+++ b/src.mk
@@ -221,6 +221,7 @@ LIB_SOURCES =                                                   \
   table/sst_file_writer.cc                                      \
   table/table_factory.cc                                        \
   table/table_properties.cc                                     \
+  table/table_reader.cc                                         \
   table/two_level_iterator.cc                                   \
   table/unique_id.cc                                            \
   test_util/sync_point.cc                                       \

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -37,6 +37,7 @@ void BlockPrefetcher::PrefetchIfNeeded(
       if (!s.ok()) {
         return;
       }
+      EnforceReadOpts::UsedIO();
       s = rep->file->Prefetch(opts, offset, len + compaction_readahead_size_);
       if (s.ok()) {
         readahead_limit_ = offset + len + compaction_readahead_size_;

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -249,6 +249,7 @@ void BlockFetcher::ReadBlock(bool retry) {
   read_req.status.PermitUncheckedError();
   // Actual file read
   if (io_status_.ok()) {
+    EnforceReadOpts::UsedIO();
     if (file_->use_direct_io()) {
       PERF_TIMER_GUARD(block_read_time);
       PERF_CPU_TIMER_GUARD(
@@ -410,6 +411,7 @@ IOStatus BlockFetcher::ReadAsyncBlockContents() {
       if (!io_s.ok()) {
         return io_s;
       }
+      EnforceReadOpts::UsedIO();
       io_s = status_to_io_status(prefetch_buffer_->PrefetchAsync(
           opts, file_, handle_.offset(), block_size_with_trailer_, &slice_));
       if (io_s.IsTryAgain()) {

--- a/table/table_reader.cc
+++ b/table/table_reader.cc
@@ -1,0 +1,35 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "table/table_reader.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+#ifndef NDEBUG
+namespace {
+// Thread local flags to connect different instances and calls to
+// EnforceReadOpts within a thread.
+thread_local bool tl_enforce_block_cache_tier = false;
+}  // namespace
+
+EnforceReadOpts::EnforceReadOpts(const ReadOptions& read_opts) {
+  saved_enforce_block_cache_tier = tl_enforce_block_cache_tier;
+  if (read_opts.read_tier == ReadTier::kBlockCacheTier) {
+    tl_enforce_block_cache_tier = true;
+  } else {
+    // We should not be entertaining a full read in a context only allowing
+    // memory-only reads.
+    assert(tl_enforce_block_cache_tier == false);
+  }
+}
+
+EnforceReadOpts::~EnforceReadOpts() {
+  tl_enforce_block_cache_tier = saved_enforce_block_cache_tier;
+}
+
+void EnforceReadOpts::UsedIO() { assert(!tl_enforce_block_cache_tier); }
+#endif
+
+}  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: Follow-up from #12757. New infrastructure to DEBUG builds to catch certain ReadOptions being ignored in a context where they should be in effect. This currently only applies to checking that no IO happens when read_tier == kBlockCacheTier. The check is in effect for unit tests and for stress/crash tests.

Specifically, an `EnforceReadOpts` object on the stack establishes a thread-local context under which we assert no IOs are performed if the provided ReadOptions said it should be forbidden.

Test Plan: Reports failure before production code fix in #12757