### PR TITLE
Fix DB failed to resume after "no space left on device" error

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -418,6 +418,8 @@ Status DBImpl::ResumeImpl(DBRecoverContext context) {
   }
 
   if (s.ok()) {
+    //DB has resumed，force writable file to be continue writable.
+    logs_.back().writer->file()->reset_seen_error();
     // This will notify and unblock threads waiting for error recovery to
     // finish. Those previouly waiting threads can now proceed, which may
     // include closing the db.

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -290,7 +290,9 @@ class SpecialEnv : public EnvWrapper {
         Status s;
         if (env_->log_write_error_.load(std::memory_order_acquire)) {
           s = Status::IOError("simulated writer error");
-        } else {
+        } else if (env_->no_space_.load(std::memory_order_acquire)) {
+          return Status::NoSpace("No space left on device");
+        }else {
           int slowdown =
               env_->log_write_slowdown_.load(std::memory_order_acquire);
           if (slowdown > 0) {


### PR DESCRIPTION
Fix [11643](https://github.com/facebook/rocksdb/issues/11643)

Summary:
The cause of this issue is that after recovery from "no space" problem, the seen_error flag in the WritableFileWriter was not reset. 
IMO that the seen_error flag is used to prevent frequent write retries when an error is present.
A similar situation can be referenced in SyncWalImpl, where error_recovery_in_prog is true it also been reset. 
Therefore, it is acceptable to reset it in ResumeImpl.
Considering that a successful resume is required and it needs to be done before 'OnErrorRecoveryCompleted', the changes are as follow.

Test Plan:
Added a test case 'NoSpaceOnWriteWalAndRecovery' in 'db_io_failure_test.cc' to test the "no space" error and recovery when writing WAL.
Modified 'db_test_util.h' to simulate the "no space" error when appending WAL.