### PR TITLE
Disallow manual prefix iteration in MultiCfIterators

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -358,7 +358,8 @@ class DBImpl : public DB {
                         ColumnFamilyHandle* column_family) override;
   Status NewIterators(const ReadOptions& _read_options,
                       const std::vector<ColumnFamilyHandle*>& column_families,
-                      std::vector<Iterator*>* iterators) override;
+                      std::vector<Iterator*>* iterators,
+                      bool disallow_manual_prefix_iteration) override;
 
   const Snapshot* GetSnapshot() override;
   void ReleaseSnapshot(const Snapshot* snapshot) override;

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -187,7 +187,7 @@ Iterator* DBImplReadOnly::NewIterator(const ReadOptions& _read_options,
 Status DBImplReadOnly::NewIterators(
     const ReadOptions& read_options,
     const std::vector<ColumnFamilyHandle*>& column_families,
-    std::vector<Iterator*>* iterators) {
+    std::vector<Iterator*>* iterators, bool disallow_manual_prefix_iteration) {
   if (read_options.timestamp) {
     for (auto* cf : column_families) {
       assert(cf);
@@ -220,21 +220,32 @@ Status DBImplReadOnly::NewIterators(
 
   autovector<std::tuple<ColumnFamilyData*, SuperVersion*>> cfd_to_sv;
 
+  const bool check_manual_prefix_iter = disallow_manual_prefix_iteration &&
+                                        !read_options.total_order_seek &&
+                                        !read_options.auto_prefix_mode;
+
   const bool check_read_ts =
       read_options.timestamp && read_options.timestamp->size() > 0;
+
   for (auto cfh : column_families) {
     auto* cfd = static_cast_with_check<ColumnFamilyHandleImpl>(cfh)->cfd();
     auto* sv = cfd->GetSuperVersion()->Ref();
     cfd_to_sv.emplace_back(cfd, sv);
-    if (check_read_ts) {
-      const Status s =
-          FailIfReadCollapsedHistory(cfd, sv, *(read_options.timestamp));
-      if (!s.ok()) {
-        for (auto prev_entry : cfd_to_sv) {
-          std::get<1>(prev_entry)->Unref();
-        }
-        return s;
+    Status s;
+    if (check_manual_prefix_iter &&
+        sv->mutable_cf_options.prefix_extractor != nullptr) {
+      s = Status::InvalidArgument(
+          "Manual prefix iteration is not allowed. Consider auto_prefix_mode "
+          "or set total_order_seek = true");
+    }
+    if (s.ok() && check_read_ts) {
+      s = FailIfReadCollapsedHistory(cfd, sv, *(read_options.timestamp));
+    }
+    if (!s.ok()) {
+      for (auto prev_entry : cfd_to_sv) {
+        std::get<1>(prev_entry)->Unref();
       }
+      return s;
     }
   }
   assert(cfd_to_sv.size() == column_families.size());

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -36,7 +36,8 @@ class DBImplReadOnly : public DBImpl {
 
   Status NewIterators(const ReadOptions& options,
                       const std::vector<ColumnFamilyHandle*>& column_families,
-                      std::vector<Iterator*>* iterators) override;
+                      std::vector<Iterator*>* iterators,
+                      bool disallow_manual_prefix_iteration) override;
 
   using DBImpl::Put;
   Status Put(const WriteOptions& /*options*/,

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -121,7 +121,8 @@ class DBImplSecondary : public DBImpl {
 
   Status NewIterators(const ReadOptions& _read_options,
                       const std::vector<ColumnFamilyHandle*>& column_families,
-                      std::vector<Iterator*>* iterators) override;
+                      std::vector<Iterator*>* iterators,
+                      bool disallow_manual_prefix_iteration) override;
 
   using DBImpl::Put;
   Status Put(const WriteOptions& /*options*/,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3196,7 +3196,8 @@ class ModelDB : public DB {
   }
   Status NewIterators(const ReadOptions& /*options*/,
                       const std::vector<ColumnFamilyHandle*>& /*column_family*/,
-                      std::vector<Iterator*>* /*iterators*/) override {
+                      std::vector<Iterator*>* /*iterators*/,
+                      bool /*disallow_manual_prefix_iteration*/) override {
     return Status::NotSupported("Not supported yet");
   }
 

--- a/db/multi_cf_iterator_test.cc
+++ b/db/multi_cf_iterator_test.cc
@@ -94,8 +94,8 @@ TEST_F(CoalescingIteratorTest, InvalidArguments) {
     ASSERT_NOK(iter->status());
     ASSERT_TRUE(iter->status().IsInvalidArgument());
     ASSERT_EQ(
-        "Invalid argument: Manual Prefix Iteration is not allowed in "
-        "MultiCfIterator",
+        "Invalid argument: Manual prefix iteration is not allowed. Consider "
+        "auto_prefix_mode or set total_order_seek = true",
         iter->status().ToString());
   }
 }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1427,7 +1427,7 @@ Status StressTest::TestIterate(ThreadState* thread,
 
   std::unique_ptr<Iterator> iter;
 
-  if (FLAGS_use_multi_cf_iterator) {
+  if (FLAGS_use_multi_cf_iterator && expect_total_order) {
     std::vector<ColumnFamilyHandle*> cfhs;
     cfhs.reserve(rand_column_families.size());
     for (auto cf_index : rand_column_families) {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1884,6 +1884,9 @@ class NonBatchedOpsStressTest : public StressTest {
       ro.total_order_seek = true;
     }
 
+    bool expect_total_order = ro.total_order_seek || ro.auto_prefix_mode ||
+                              options_.prefix_extractor.get() == nullptr;
+
     std::string read_ts_str;
     Slice read_ts;
     if (FLAGS_user_timestamp_size > 0) {
@@ -1915,7 +1918,7 @@ class NonBatchedOpsStressTest : public StressTest {
           shared->Get(rand_column_family, i + lb));
     }
     std::unique_ptr<Iterator> iter;
-    if (FLAGS_use_multi_cf_iterator) {
+    if (FLAGS_use_multi_cf_iterator && expect_total_order) {
       std::vector<ColumnFamilyHandle*> cfhs;
       cfhs.reserve(rand_column_families.size());
       for (auto cf_index : rand_column_families) {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1002,10 +1002,15 @@ class DB {
   // Returns iterators from a consistent database state across multiple
   // column families. Iterators are heap allocated and need to be deleted
   // before the db is deleted
+  //
+  // if disallow_manual_prefix_iteration is set, manual prefix iteration
+  // https://github.com/facebook/rocksdb/wiki/Prefix-Seek#manual-prefix-iterating
+  // is not allowed and Status::InvalidArgument() is returned
   virtual Status NewIterators(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_families,
-      std::vector<Iterator*>* iterators) = 0;
+      std::vector<Iterator*>* iterators,
+      bool disallow_manual_prefix_iteration = false) = 0;
 
   // EXPERIMENTAL
   // Return a cross-column-family iterator from a consistent database state.

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -267,8 +267,10 @@ class StackableDB : public DB {
 
   Status NewIterators(const ReadOptions& options,
                       const std::vector<ColumnFamilyHandle*>& column_families,
-                      std::vector<Iterator*>* iterators) override {
-    return db_->NewIterators(options, column_families, iterators);
+                      std::vector<Iterator*>* iterators,
+                      bool disallow_manual_prefix_iteration) override {
+    return db_->NewIterators(options, column_families, iterators,
+                             disallow_manual_prefix_iteration);
   }
 
   using DB::NewCoalescingIterator;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -154,7 +154,7 @@ default_params = {
     # use_put_entity_one_in has to be the same across invocations for verification to work, hence no lambda
     "use_put_entity_one_in": random.choice([0] * 7 + [1, 5, 10]),
     "use_attribute_group": lambda: random.randint(0, 1),
-    "use_multi_cf_iterator": 0, # TODO(jaykorean) - re-enable this after fixing the test
+    "use_multi_cf_iterator": lambda: random.randint(0, 1),
     # 999 -> use Bloom API
     "bloom_before_level": lambda: random.choice([random.randint(-1, 2), random.randint(-1, 10), 0x7fffffff - 1, 0x7fffffff]),
     "value_size_mult": 32,

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -118,7 +118,8 @@ class BlobDBImpl : public BlobDB {
   Status NewIterators(
       const ReadOptions& /*read_options*/,
       const std::vector<ColumnFamilyHandle*>& /*column_families*/,
-      std::vector<Iterator*>* /*iterators*/) override {
+      std::vector<Iterator*>* /*iterators*/,
+      bool /*disallow_manual_prefix_iteration*/) override {
     return Status::NotSupported("Not implemented");
   }
 

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -99,7 +99,8 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   using DB::NewIterators;
   Status NewIterators(const ReadOptions& _read_options,
                       const std::vector<ColumnFamilyHandle*>& column_families,
-                      std::vector<Iterator*>* iterators) override;
+                      std::vector<Iterator*>* iterators,
+                      bool disallow_manual_prefix_iteration) override;
 
   // Check whether the transaction that wrote the value with sequence number seq
   // is visible to the snapshot with sequence number snapshot_seq.


### PR DESCRIPTION
# Summary

As described in https://github.com/facebook/rocksdb/wiki/Prefix-Seek#manual-prefix-iterating, a DBIter can land on an unexpected key if it iterates outside of the iterator range. MultiCfIterator uses DBIters as child iterators, and the implementation assumes that these child iterators are at valid keys at all times.

After a recent change in #12706 , which added the MultiCfIterator to the stress test , we encountered a failure where the CoalescingIterator failed to switch direction when a child iterator was at a key that had previously been deleted. This issue was due to the undefined result from the manual prefix iteration of the child iterator.

This PR adds an optional param `bool disallow_manual_prefix_iteration = false` to the `DB::NewIterators()` API so that `Status::InvalidArgument()` can be returned when MultiCfIterator creation tries to get child iterators when total order seek is not guaranteed.

In case anyone is wondering why this has not been a problem in the regular DBIter stress test, `VerifyIterator()` skips checking when the iterator prefix seek is out of the range

https://github.com/facebook/rocksdb/blob/13c758f9869c2b086e9c1f7457c15db93349f258/db_stress_tool/db_stress_test_base.cc#L1700-L1702

# Test Plan

Unit Test added
```
./multi_cf_iterator_test
```

MultiCfIterator added back to the stress test
```
python3 tools/db_crashtest.py blackbox --simple --max_key=25000000 --write_buffer_size=4194304 --use_attribute_group=0 --use_put_entity_one_in=1 --use_multi_get=1 --use_multi_cf_iterator=1 --verify_iterator_with_expected_state_one_in=2
```