### PR TITLE
Disable AttributeGroup in multiops txn test

### DIFF
--- a/db_stress_tool/multi_ops_txns_stress.cc
+++ b/db_stress_tool/multi_ops_txns_stress.cc
@@ -432,6 +432,13 @@ Status MultiOpsTxnsStressTest::TestIterate(
   return s;
 }
 
+Status MultiOpsTxnsStressTest::TestIterateAttributeGroups(
+    ThreadState* /*thread*/, const ReadOptions& /*read_opts*/,
+    const std::vector<int>& /*rand_column_families*/,
+    const std::vector<int64_t>& /*rand_keys*/) {
+  return Status::NotSupported();
+}
+
 // Not intended for use.
 Status MultiOpsTxnsStressTest::TestPut(ThreadState* /*thread*/,
                                        WriteOptions& /*write_opts*/,

--- a/db_stress_tool/multi_ops_txns_stress.h
+++ b/db_stress_tool/multi_ops_txns_stress.h
@@ -228,6 +228,11 @@ class MultiOpsTxnsStressTest : public StressTest {
                      const std::vector<int>& rand_column_families,
                      const std::vector<int64_t>& rand_keys) override;
 
+  Status TestIterateAttributeGroups(
+      ThreadState* thread, const ReadOptions& read_opts,
+      const std::vector<int>& rand_column_families,
+      const std::vector<int64_t>& rand_keys) override;
+
   Status TestPut(ThreadState* thread, WriteOptions& write_opts,
                  const ReadOptions& read_opts, const std::vector<int>& cf_ids,
                  const std::vector<int64_t>& keys, char (&value)[100]) override;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -627,7 +627,7 @@ multiops_txn_default_params = {
     "inplace_update_support": 0,
     # TimedPut not supported in transaction
     "use_timed_put_one_in": 0,
-    # AttributeGroupIterator not yet supported
+    # AttributeGroup not yet supported
     "use_attribute_group": 0,
 }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -627,6 +627,8 @@ multiops_txn_default_params = {
     "inplace_update_support": 0,
     # TimedPut not supported in transaction
     "use_timed_put_one_in": 0,
+    # AttributeGroupIterator not yet supported
+    "use_attribute_group": 0,
 }
 
 multiops_wc_txn_params = {


### PR DESCRIPTION
# Summary

AttributeGroup is not yet supported in MultiOpsTxn Test. Disabling it for now.

# Test Plan

Disabling in the test