### PR TITLE
Fix static initialization error on opening an instance.

### DIFF
--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -1289,20 +1289,21 @@ TEST_F(DBBlobBasicTest, Properties) {
   // Number of blob files
   uint64_t num_blob_files = 0;
   ASSERT_TRUE(
-      db_->GetIntProperty(DB::Properties::kNumBlobFiles, &num_blob_files));
+      db_->GetIntProperty(DB::Properties::GetNumBlobFiles(), &num_blob_files));
   ASSERT_EQ(num_blob_files, 2);
 
   // Total size of live blob files
   uint64_t live_blob_file_size = 0;
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kLiveBlobFileSize,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetLiveBlobFileSize(),
                                   &live_blob_file_size));
   ASSERT_EQ(live_blob_file_size, total_expected_size);
 
   // Total amount of garbage in live blob files
   {
     uint64_t live_blob_file_garbage_size = 0;
-    ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kLiveBlobFileGarbageSize,
-                                    &live_blob_file_garbage_size));
+    ASSERT_TRUE(
+        db_->GetIntProperty(DB::Properties::GetLiveBlobFileGarbageSize(),
+                            &live_blob_file_garbage_size));
     ASSERT_EQ(live_blob_file_garbage_size, 0);
   }
 
@@ -1310,7 +1311,7 @@ TEST_F(DBBlobBasicTest, Properties) {
   // Note: this should be the same as above since we only have one
   // version at this point.
   uint64_t total_blob_file_size = 0;
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kTotalBlobFileSize,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetTotalBlobFileSize(),
                                   &total_blob_file_size));
   ASSERT_EQ(total_blob_file_size, total_expected_size);
 
@@ -1332,7 +1333,7 @@ TEST_F(DBBlobBasicTest, Properties) {
 
   // Blob file stats
   std::string blob_stats;
-  ASSERT_TRUE(db_->GetProperty(DB::Properties::kBlobStats, &blob_stats));
+  ASSERT_TRUE(db_->GetProperty(DB::Properties::GetBlobStats(), &blob_stats));
 
   std::ostringstream oss;
   oss << "Number of blob files: 2\nTotal size of blob files: "
@@ -1345,8 +1346,9 @@ TEST_F(DBBlobBasicTest, Properties) {
   // Total amount of garbage in live blob files
   {
     uint64_t live_blob_file_garbage_size = 0;
-    ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kLiveBlobFileGarbageSize,
-                                    &live_blob_file_garbage_size));
+    ASSERT_TRUE(
+        db_->GetIntProperty(DB::Properties::GetLiveBlobFileGarbageSize(),
+                            &live_blob_file_garbage_size));
     ASSERT_EQ(live_blob_file_garbage_size, expected_garbage_size);
   }
 }
@@ -1398,7 +1400,7 @@ TEST_F(DBBlobBasicTest, PropertiesMultiVersion) {
   // file. (The second blob file is thus shared by the two versions but should
   // be counted only once.)
   uint64_t total_blob_file_size = 0;
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kTotalBlobFileSize,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetTotalBlobFileSize(),
                                   &total_blob_file_size));
   ASSERT_EQ(total_blob_file_size,
             3 * (BlobLogHeader::kSize +

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -562,7 +562,8 @@ TEST_P(ColumnFamilyTest, CreateCFRaceWithGetAggProperty) {
 
   TEST_SYNC_POINT("ColumnFamilyTest.CreateCFRaceWithGetAggProperty:1");
   uint64_t pv;
-  db_->GetAggregatedIntProperty(DB::Properties::kEstimateTableReadersMem, &pv);
+  db_->GetAggregatedIntProperty(DB::Properties::GetEstimateTableReadersMem(),
+                                &pv);
   TEST_SYNC_POINT("ColumnFamilyTest.CreateCFRaceWithGetAggProperty:2");
 
   thread.join();

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -947,8 +947,7 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options,
   UpdateCompactionJobStats(stats);
 
   auto stream = event_logger_->LogToBuffer(log_buffer_, 8192);
-  stream << "job" << job_id_ << "event"
-         << "compaction_finished"
+  stream << "job" << job_id_ << "event" << "compaction_finished"
          << "compaction_time_micros" << stats.micros
          << "compaction_time_cpu_micros" << stats.cpu_micros << "output_level"
          << compact_->compaction->output_level() << "num_output_files"
@@ -1038,12 +1037,10 @@ void CompactionJob::NotifyOnSubcompactionBegin(
     listener->OnSubcompactionBegin(info);
   }
   info.status.PermitUncheckedError();
-
 }
 
 void CompactionJob::NotifyOnSubcompactionCompleted(
     SubcompactionState* sub_compact) {
-
   if (db_options_.listeners.empty()) {
     return;
   }
@@ -1648,13 +1645,14 @@ Status CompactionJob::FinishCompactionOutputFile(
   if (s.ok() && (current_entries > 0 || tp.num_range_deletions > 0)) {
     // Output to event logger and fire events.
     outputs.UpdateTableProperties();
-    ROCKS_LOG_INFO(db_options_.info_log,
-                   "[%s] [JOB %d] Generated table #%" PRIu64 ": %" PRIu64
-                   " keys, %" PRIu64 " bytes%s, temperature: %s",
-                   cfd->GetName().c_str(), job_id_, output_number,
-                   current_entries, meta->fd.file_size,
-                   meta->marked_for_compaction ? " (need compaction)" : "",
-                   temperature_to_string[meta->temperature].c_str());
+    ROCKS_LOG_INFO(
+        db_options_.info_log,
+        "[%s] [JOB %d] Generated table #%" PRIu64 ": %" PRIu64 " keys, %" PRIu64
+        " bytes%s, temperature: %s",
+        cfd->GetName().c_str(), job_id_, output_number, current_entries,
+        meta->fd.file_size,
+        meta->marked_for_compaction ? " (need compaction)" : "",
+        OptionsHelper::GetTemperatureToString()[meta->temperature].c_str());
   }
   std::string fname;
   FileDescriptor output_fd;
@@ -2091,8 +2089,7 @@ void CompactionJob::LogCompaction() {
                    cfd->GetName().c_str(), scratch);
     // build event logger report
     auto stream = event_logger_->Log();
-    stream << "job" << job_id_ << "event"
-           << "compaction_started"
+    stream << "job" << job_id_ << "event" << "compaction_started"
            << "compaction_reason"
            << GetCompactionReasonString(compaction->compaction_reason());
     for (size_t i = 0; i < compaction->num_input_levels(); ++i) {

--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -406,7 +406,7 @@ Compaction* FIFOCompactionPicker::PickTemperatureChangeCompaction(
             "[%s] FIFO compaction: picking file %" PRIu64
             " with next file's oldest time %" PRIu64 " for temperature %s.",
             cf_name.c_str(), cur_file->fd.GetNumber(), oldest_ancestor_time,
-            temperature_to_string[cur_target_temp].c_str());
+            OptionsHelper::GetTemperatureToString()[cur_target_temp].c_str());
       }
       if (compaction_size > mutable_cf_options.max_compaction_bytes) {
         break;

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -137,8 +137,8 @@ class DBBlockCacheTest : public DBTestBase {
     // Verify in cache entry role stats
     std::array<size_t, kNumCacheEntryRoles> cache_entry_role_counts;
     std::map<std::string, std::string> values;
-    EXPECT_TRUE(db_->GetMapProperty(DB::Properties::kFastBlockCacheEntryStats,
-                                    &values));
+    EXPECT_TRUE(db_->GetMapProperty(
+        DB::Properties::GetFastBlockCacheEntryStats(), &values));
     for (size_t i = 0; i < kNumCacheEntryRoles; ++i) {
       auto role = static_cast<CacheEntryRole>(i);
       cache_entry_role_counts[i] =
@@ -304,7 +304,6 @@ class ReadOnlyCacheWrapper : public CacheWrapper {
 
 }  // anonymous namespace
 #endif  // SNAPPY
-
 
 // Make sure that when options.block_cache is set, after a new table is
 // created its index/filter blocks are added to block cache.
@@ -994,8 +993,8 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
 
       // Also check the GetProperty interface
       std::map<std::string, std::string> values;
-      ASSERT_TRUE(
-          db_->GetMapProperty(DB::Properties::kBlockCacheEntryStats, &values));
+      ASSERT_TRUE(db_->GetMapProperty(DB::Properties::GetBlockCacheEntryStats(),
+                                      &values));
 
       for (size_t i = 0; i < kNumCacheEntryRoles; ++i) {
         auto role = static_cast<CacheEntryRole>(i);
@@ -1019,8 +1018,8 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
         // Not enough for a "background" miss but enough for a "foreground" miss
         env_->MockSleepForSeconds(45);
 
-        ASSERT_TRUE(db_->GetMapProperty(DB::Properties::kBlockCacheEntryStats,
-                                        &values));
+        ASSERT_TRUE(db_->GetMapProperty(
+            DB::Properties::GetBlockCacheEntryStats(), &values));
         EXPECT_EQ(
             std::to_string(
                 expected[static_cast<size_t>(CacheEntryRole::kWriteBuffer)]),
@@ -1078,33 +1077,33 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
       ASSERT_EQ(scan_count, 1);
 
       env_->MockSleepForSeconds(60);
-      ASSERT_TRUE(db_->GetMapProperty(DB::Properties::kFastBlockCacheEntryStats,
-                                      &values));
+      ASSERT_TRUE(db_->GetMapProperty(
+          DB::Properties::GetFastBlockCacheEntryStats(), &values));
       ASSERT_EQ(scan_count, 1);
-      ASSERT_TRUE(
-          db_->GetMapProperty(DB::Properties::kBlockCacheEntryStats, &values));
+      ASSERT_TRUE(db_->GetMapProperty(DB::Properties::GetBlockCacheEntryStats(),
+                                      &values));
       ASSERT_EQ(scan_count, 2);
 
       env_->MockSleepForSeconds(10000);
-      ASSERT_TRUE(db_->GetMapProperty(DB::Properties::kFastBlockCacheEntryStats,
-                                      &values));
+      ASSERT_TRUE(db_->GetMapProperty(
+          DB::Properties::GetFastBlockCacheEntryStats(), &values));
       ASSERT_EQ(scan_count, 3);
 
       env_->MockSleepForSeconds(60);
       std::string value_str;
-      ASSERT_TRUE(db_->GetProperty(DB::Properties::kFastBlockCacheEntryStats,
-                                   &value_str));
+      ASSERT_TRUE(db_->GetProperty(
+          DB::Properties::GetFastBlockCacheEntryStats(), &value_str));
       ASSERT_EQ(scan_count, 3);
-      ASSERT_TRUE(
-          db_->GetProperty(DB::Properties::kBlockCacheEntryStats, &value_str));
+      ASSERT_TRUE(db_->GetProperty(DB::Properties::GetBlockCacheEntryStats(),
+                                   &value_str));
       ASSERT_EQ(scan_count, 4);
 
       env_->MockSleepForSeconds(10000);
-      ASSERT_TRUE(db_->GetProperty(DB::Properties::kFastBlockCacheEntryStats,
-                                   &value_str));
+      ASSERT_TRUE(db_->GetProperty(
+          DB::Properties::GetFastBlockCacheEntryStats(), &value_str));
       ASSERT_EQ(scan_count, 5);
 
-      ASSERT_TRUE(db_->GetProperty(DB::Properties::kCFStats, &value_str));
+      ASSERT_TRUE(db_->GetProperty(DB::Properties::GetCFStats(), &value_str));
       // To match historical speed, querying this property no longer triggers
       // a scan, even if results are old. But periodic dump stats should keep
       // things reasonably updated.
@@ -1723,8 +1722,8 @@ class CacheKeyTest : public testing::Test {
     tp_.db_id = std::to_string(db_id_);
     tp_.orig_file_number = file_number;
     bool is_stable;
-    std::string cur_session_id;       // ignored
-    uint64_t cur_file_number = 42;    // ignored
+    std::string cur_session_id;     // ignored
+    uint64_t cur_file_number = 42;  // ignored
     OffsetableCacheKey rv;
     BlockBasedTable::SetupBaseCacheKey(&tp_, cur_session_id, cur_file_number,
                                        &rv, &is_stable);

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -593,7 +593,7 @@ TEST_P(DBBloomFilterTestWithParam, BloomFilter) {
     // Sanity check some table properties
     std::map<std::string, std::string> props;
     ASSERT_TRUE(db_->GetMapProperty(
-        handles_[1], DB::Properties::kAggregatedTableProperties, &props));
+        handles_[1], DB::Properties::GetAggregatedTableProperties(), &props));
     uint64_t nkeys = N + N / 100;
     uint64_t filter_size = ParseUint64(props["filter_size"]);
     EXPECT_LE(filter_size,
@@ -674,7 +674,7 @@ TEST_P(DBBloomFilterTestWithParam, SkipFilterOnEssentiallyZeroBpk) {
     GetFn();
   };
   std::map<std::string, std::string> props;
-  const auto& kAggTableProps = DB::Properties::kAggregatedTableProperties;
+  const auto& kAggTableProps = DB::Properties::GetAggregatedTableProperties();
 
   Options options = CurrentOptions();
   options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
@@ -1658,7 +1658,7 @@ class TestingContextCustomFilterPolicy
     test_report_ += context.column_family_name;
     test_report_ += ",s=";
     test_report_ +=
-        OptionsHelper::compaction_style_to_string[context.compaction_style];
+        OptionsHelper::GetCompactionStyleToString()[context.compaction_style];
     test_report_ += ",n=";
     test_report_ += std::to_string(context.num_levels);
     test_report_ += ",l=";

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -5784,7 +5784,7 @@ TEST_F(DBCompactionTest, CompactRangeSkipFlushAfterDelay) {
   // If CompactRange's flush was skipped, the final Put above will still be
   // in the active memtable.
   std::string num_keys_in_memtable;
-  ASSERT_TRUE(db_->GetProperty(DB::Properties::kNumEntriesActiveMemTable,
+  ASSERT_TRUE(db_->GetProperty(DB::Properties::GetNumEntriesActiveMemTable(),
                                &num_keys_in_memtable));
   ASSERT_EQ(std::to_string(1), num_keys_in_memtable);
 
@@ -5828,11 +5828,11 @@ TEST_F(DBCompactionTest, CompactRangeFlushOverlappingMemtable) {
       ASSERT_OK(db_->CompactRange(compact_range_opts, begin_ptr, end_ptr));
 
       uint64_t get_prop_tmp, num_memtable_entries = 0;
-      ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumEntriesImmMemTables,
-                                      &get_prop_tmp));
+      ASSERT_TRUE(db_->GetIntProperty(
+          DB::Properties::GetNumEntriesImmMemTables(), &get_prop_tmp));
       num_memtable_entries += get_prop_tmp;
-      ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumEntriesActiveMemTable,
-                                      &get_prop_tmp));
+      ASSERT_TRUE(db_->GetIntProperty(
+          DB::Properties::GetNumEntriesActiveMemTable(), &get_prop_tmp));
       num_memtable_entries += get_prop_tmp;
       if (begin_ptr == nullptr || end_ptr == nullptr ||
           (i <= 4 && j >= 1 && (begin != "c" || end != "c"))) {
@@ -6750,7 +6750,8 @@ TEST_F(DBCompactionTest, PartialManualCompaction) {
   MoveFilesToLevel(2);
 
   std::string prop;
-  EXPECT_TRUE(dbfull()->GetProperty(DB::Properties::kLiveSstFilesSize, &prop));
+  EXPECT_TRUE(
+      dbfull()->GetProperty(DB::Properties::GetLiveSstFilesSize(), &prop));
   uint64_t max_compaction_bytes = atoi(prop.c_str()) / 2;
   ASSERT_OK(dbfull()->SetOptions(
       {{"max_compaction_bytes", std::to_string(max_compaction_bytes)}}));

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 
-
 #include <algorithm>
 #include <cstdint>
 #include <memory>
@@ -343,7 +342,7 @@ Status DBImpl::GetLiveFilesStorageInfo(
     results.emplace_back();
     LiveFileStorageInfo& info = results.back();
 
-    info.relative_filename = kCurrentFileName;
+    info.relative_filename = GetCurrentFileName();
     info.directory = GetName();
     info.file_type = kCurrentFile;
     // CURRENT could be replaced so we have to record the contents as needed.

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -1951,8 +1951,8 @@ TEST_F(DBFlushTest, ManualFlushFailsInReadOnlyMode) {
   // We ingested the error to env, so the returned status is not OK.
   ASSERT_NOK(dbfull()->TEST_WaitForFlushMemTable());
   uint64_t num_bg_errors;
-  ASSERT_TRUE(
-      db_->GetIntProperty(DB::Properties::kBackgroundErrors, &num_bg_errors));
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetBackgroundErrors(),
+                                  &num_bg_errors));
   ASSERT_GT(num_bg_errors, 0);
 
   // In the bug scenario, triggering another flush would cause the second flush

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -142,7 +142,7 @@ CompressionType GetCompressionFlush(
 namespace {
 void DumpSupportInfo(Logger* logger) {
   ROCKS_LOG_HEADER(logger, "Compression algorithms supported:");
-  for (auto& compression : OptionsHelper::compression_type_string_map) {
+  for (auto& compression : OptionsHelper::GetCompressionTypeStringMap()) {
     if (compression.second != kNoCompression &&
         compression.second != kDisableCompressionOption) {
       ROCKS_LOG_HEADER(logger, "\t%s supported: %d", compression.first.c_str(),
@@ -1158,14 +1158,14 @@ void DBImpl::DumpStats() {
       }
     }
 
-    const std::string* property = &DB::Properties::kDBStats;
+    const std::string* property = &DB::Properties::GetDBStats();
     const DBPropertyInfo* property_info = GetPropertyInfo(*property);
     assert(property_info != nullptr);
     assert(!property_info->need_out_of_mutex);
     default_cf_internal_stats_->GetStringProperty(*property_info, *property,
                                                   &stats);
 
-    property = &InternalStats::kPeriodicCFStats;
+    property = &InternalStats::GetPeriodicCFStats();
     property_info = GetPropertyInfo(*property);
     assert(property_info != nullptr);
     assert(!property_info->need_out_of_mutex);

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -580,10 +580,11 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
         //
         // TODO(yhchiang): carefully modify the third condition to safely
         //                 remove the temp options files.
-        keep = (sst_live_set.find(number) != sst_live_set.end()) ||
-               (blob_live_set.find(number) != blob_live_set.end()) ||
-               (number == state.pending_manifest_file_number) ||
-               (to_delete.find(kOptionsFileNamePrefix) != std::string::npos);
+        keep =
+            (sst_live_set.find(number) != sst_live_set.end()) ||
+            (blob_live_set.find(number) != blob_live_set.end()) ||
+            (number == state.pending_manifest_file_number) ||
+            (to_delete.find(GetOptionsFileNamePrefix()) != std::string::npos);
         break;
       case kInfoLogFile:
         keep = true;

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -3492,7 +3492,7 @@ TEST_F(DBRangeDelTest, NonBottommostCompactionDropRangetombstone) {
   ASSERT_OK(Flush());
   // nothing is dropped during flush
   std::string property;
-  db_->GetProperty(DB::Properties::kAggregatedTableProperties, &property);
+  db_->GetProperty(DB::Properties::GetAggregatedTableProperties(), &property);
   TableProperties output_tp;
   ParseTablePropertiesString(property, &output_tp);
   ASSERT_EQ(output_tp.num_range_deletions, 2);
@@ -3502,7 +3502,7 @@ TEST_F(DBRangeDelTest, NonBottommostCompactionDropRangetombstone) {
   ASSERT_OK(Flush());
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
   ASSERT_EQ(NumTableFilesAtLevel(1), 1);
-  db_->GetProperty(DB::Properties::kAggregatedTableProperties, &property);
+  db_->GetProperty(DB::Properties::GetAggregatedTableProperties(), &property);
   ParseTablePropertiesString(property, &output_tp);
   ASSERT_EQ(output_tp.num_range_deletions, 1);
 
@@ -3517,7 +3517,7 @@ TEST_F(DBRangeDelTest, NonBottommostCompactionDropRangetombstone) {
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
   // All compacted to L6
   ASSERT_EQ("0,0,0,0,0,0,1", FilesPerLevel(0));
-  db_->GetProperty(DB::Properties::kAggregatedTableProperties, &property);
+  db_->GetProperty(DB::Properties::GetAggregatedTableProperties(), &property);
   ParseTablePropertiesString(property, &output_tp);
   ASSERT_EQ(output_tp.num_range_deletions, 1);
   db_->ReleaseSnapshot(snapshot);

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1161,7 +1161,6 @@ class DelayFilterFactory : public CompactionFilterFactory {
 };
 }  // anonymous namespace
 
-
 static std::string CompressibleString(Random* rnd, int len) {
   std::string r;
   test::CompressibleString(rnd, 0.8, len, &r);
@@ -4368,7 +4367,6 @@ TEST_F(DBTest, ConcurrentMemtableNotSupported) {
   ASSERT_NOK(db_->CreateColumnFamily(cf_options, "name", &handle));
 }
 
-
 TEST_F(DBTest, SanitizeNumThreads) {
   for (int attempt = 0; attempt < 2; attempt++) {
     const size_t kTotalTasks = 8;
@@ -4804,7 +4802,7 @@ TEST_F(DBTest, ThreadStatusFlush) {
   ASSERT_TRUE(VerifyOperationCount(env_, ThreadStatus::OP_FLUSH, 0));
 
   uint64_t num_running_flushes = 0;
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningFlushes,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumRunningFlushes(),
                                   &num_running_flushes));
   ASSERT_EQ(num_running_flushes, 0);
 
@@ -4815,7 +4813,7 @@ TEST_F(DBTest, ThreadStatusFlush) {
   // running when we perform VerifyOperationCount().
   TEST_SYNC_POINT("DBTest::ThreadStatusFlush:1");
   ASSERT_TRUE(VerifyOperationCount(env_, ThreadStatus::OP_FLUSH, 1));
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningFlushes,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumRunningFlushes(),
                                   &num_running_flushes));
   ASSERT_EQ(num_running_flushes, 1);
   // This second sync point is to ensure the flush job will not
@@ -4860,7 +4858,7 @@ TEST_P(DBTestWithParam, ThreadStatusSingleCompaction) {
     // This makes sure a compaction won't be scheduled until
     // we have done with the above Put Phase.
     uint64_t num_running_compactions = 0;
-    ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningCompactions,
+    ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumRunningCompactions(),
                                     &num_running_compactions));
     ASSERT_EQ(num_running_compactions, 0);
     TEST_SYNC_POINT("DBTest::ThreadStatusSingleCompaction:0");
@@ -4875,8 +4873,9 @@ TEST_P(DBTestWithParam, ThreadStatusSingleCompaction) {
       // This test is flaky and fails here.
       bool match = VerifyOperationCount(env_, ThreadStatus::OP_COMPACTION, 1);
       if (!match) {
-        ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningCompactions,
-                                        &num_running_compactions));
+        ASSERT_TRUE(
+            db_->GetIntProperty(DB::Properties::GetNumRunningCompactions(),
+                                &num_running_compactions));
         fprintf(stderr, "running compaction: %" PRIu64 " lsm state: %s\n",
                 num_running_compactions, FilesPerLevel().c_str());
       }
@@ -4885,7 +4884,7 @@ TEST_P(DBTestWithParam, ThreadStatusSingleCompaction) {
       // If thread tracking is not enabled, compaction count should be 0.
       ASSERT_TRUE(VerifyOperationCount(env_, ThreadStatus::OP_COMPACTION, 0));
     }
-    ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumRunningCompactions,
+    ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumRunningCompactions(),
                                     &num_running_compactions));
     ASSERT_EQ(num_running_compactions, 1);
     // TODO(yhchiang): adding assert to verify each compaction stage.
@@ -5755,7 +5754,6 @@ TEST_F(DBTest, FileCreationRandomFailure) {
     ASSERT_EQ(v, values[k]);
   }
 }
-
 
 TEST_F(DBTest, DynamicMiscOptions) {
   // Test max_sequential_skip_in_iterations
@@ -7198,7 +7196,6 @@ TEST_F(DBTest, ReusePinnableSlice) {
             1);
 }
 
-
 TEST_F(DBTest, DeletingOldWalAfterDrop) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"Test:AllowFlushes", "DBImpl::BGWorkFlush"},
@@ -7322,7 +7319,6 @@ TEST_F(DBTest, LargeBlockSizeTest) {
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
   ASSERT_NOK(TryReopenWithColumnFamilies({"default", "pikachu"}, options));
 }
-
 
 TEST_F(DBTest, CreationTimeOfOldestFile) {
   const int kNumKeysPerFile = 32;

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -144,7 +144,6 @@ TEST_F(DBTest2, PartitionedIndexUserToInternalKey) {
   }
 }
 
-
 class PrefixFullBloomWithReverseComparator
     : public DBTestBase,
       public ::testing::WithParamInterface<bool> {
@@ -1986,7 +1985,6 @@ TEST_F(DBTest2, CompactionStall) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
 
-
 TEST_F(DBTest2, FirstSnapshotTest) {
   Options options;
   options.write_buffer_size = 100000;  // Small write buffer
@@ -2872,7 +2870,7 @@ TEST_F(DBTest2, AutomaticCompactionOverlapManualCompaction) {
                      std::map<std::string, std::string> props) {
     auto prop_str =
         "compaction." + level_str + "." +
-        InternalStats::compaction_level_stats.at(type).property_name.c_str();
+        InternalStats::GetCompactionLevelStats().at(type).property_name.c_str();
     auto prop_item = props.find(prop_str);
     return prop_item == props.end() ? 0 : std::stod(prop_item->second);
   };
@@ -3610,7 +3608,6 @@ TEST_F(DBTest2, OptimizeForSmallDB) {
   value.Reset();
 }
 
-
 TEST_F(DBTest2, IterRaceFlush1) {
   ASSERT_OK(Put("foo", "v1"));
 
@@ -4114,7 +4111,6 @@ TEST_F(DBTest2, ReadCallbackTest) {
   }
 }
 
-
 TEST_F(DBTest2, LiveFilesOmitObsoleteFiles) {
   // Regression test for race condition where an obsolete file is returned to
   // user as a "live file" but then deleted, all while file deletions are
@@ -4442,7 +4438,7 @@ TEST_F(DBTest2, TraceAndReplay) {
       db2->NewDefaultReplayer(handles, std::move(trace_reader), &replayer));
 
   TraceExecutionResultHandler res_handler;
-  std::function<void(Status, std::unique_ptr<TraceRecordResult> &&)> res_cb =
+  std::function<void(Status, std::unique_ptr<TraceRecordResult>&&)> res_cb =
       [&res_handler](Status exec_s, std::unique_ptr<TraceRecordResult>&& res) {
         ASSERT_TRUE(exec_s.ok() || exec_s.IsNotSupported());
         if (res != nullptr) {
@@ -5173,7 +5169,6 @@ TEST_F(DBTest2, TraceWithFilter) {
   // 4 WRITE + HEADER + FOOTER = 6
   ASSERT_EQ(count, 6);
 }
-
 
 TEST_F(DBTest2, PinnableSliceAndMmapReads) {
   Options options = CurrentOptions();
@@ -6726,7 +6721,7 @@ TEST_F(DBTest2, LastLevelTemperature) {
   ASSERT_EQ(size, 0);
   std::string prop;
   ASSERT_TRUE(dbfull()->GetProperty(
-      DB::Properties::kLiveSstFilesSizeAtTemperature + std::to_string(22),
+      DB::Properties::GetLiveSstFilesSizeAtTemperature() + std::to_string(22),
       &prop));
   ASSERT_EQ(std::atoi(prop.c_str()), 0);
 
@@ -6865,7 +6860,7 @@ TEST_F(DBTest2, LastLevelTemperatureUniversal) {
   ASSERT_EQ(size, 0);
   std::string prop;
   ASSERT_TRUE(dbfull()->GetProperty(
-      DB::Properties::kLiveSstFilesSizeAtTemperature + std::to_string(22),
+      DB::Properties::GetLiveSstFilesSizeAtTemperature() + std::to_string(22),
       &prop));
   ASSERT_EQ(std::atoi(prop.c_str()), 0);
 
@@ -7459,7 +7454,6 @@ TEST_F(DBTest2, RecoverEpochNumber) {
                   : 2);
   }
 }
-
 
 TEST_F(DBTest2, RenameDirectory) {
   Options options = CurrentOptions();

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -122,7 +122,6 @@ DBTestBase::~DBTestBase() {
 }
 
 bool DBTestBase::ShouldSkipOptions(int option_config, int skip_mask) {
-
   if ((skip_mask & kSkipUniversalCompaction) &&
       (option_config == kUniversalCompaction ||
        option_config == kUniversalCompactionMultiLevel ||
@@ -1191,7 +1190,6 @@ std::string DBTestBase::FilesPerLevel(int cf) {
   return result;
 }
 
-
 std::vector<uint64_t> DBTestBase::GetBlobFileNumbers() {
   VersionSet* const versions = dbfull()->GetVersionSet();
   assert(versions);
@@ -1702,7 +1700,6 @@ void DBTestBase::VerifyDBInternal(
   iter->~InternalIterator();
 }
 
-
 uint64_t DBTestBase::GetNumberOfSstFilesForColumnFamily(
     DB* db, std::string column_family_name) {
   std::vector<LiveFileMetaData> metadata;
@@ -1717,7 +1714,7 @@ uint64_t DBTestBase::GetNumberOfSstFilesForColumnFamily(
 uint64_t DBTestBase::GetSstSizeHelper(Temperature temperature) {
   std::string prop;
   EXPECT_TRUE(dbfull()->GetProperty(
-      DB::Properties::kLiveSstFilesSizeAtTemperature +
+      DB::Properties::GetLiveSstFilesSizeAtTemperature() +
           std::to_string(static_cast<uint8_t>(temperature)),
       &prop));
   return static_cast<uint64_t>(std::atoi(prop.c_str()));

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -731,9 +731,10 @@ class FileTemperatureTestFS : public FileSystemWrapper {
             result->reset();
             return IOStatus::PathNotFound(
                 "Read requested temperature " +
-                temperature_to_string[opts.temperature] +
+                OptionsHelper::GetTemperatureToString()[opts.temperature] +
                 " but stored with temperature " +
-                temperature_to_string[e->second] + " for " + fname);
+                OptionsHelper::GetTemperatureToString()[e->second] + " for " +
+                fname);
           }
         }
         *result = WrapWithTemperature<FSSequentialFileOwnerWrapper>(
@@ -764,9 +765,10 @@ class FileTemperatureTestFS : public FileSystemWrapper {
             result->reset();
             return IOStatus::PathNotFound(
                 "Read requested temperature " +
-                temperature_to_string[opts.temperature] +
+                OptionsHelper::GetTemperatureToString()[opts.temperature] +
                 " but stored with temperature " +
-                temperature_to_string[e->second] + " for " + fname);
+                OptionsHelper::GetTemperatureToString()[e->second] + " for " +
+                fname);
           }
         }
         *result = WrapWithTemperature<FSRandomAccessFileOwnerWrapper>(

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -2017,7 +2017,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestWithTemperature) {
     // reasonable and not an error.
     std::string prop;
     ASSERT_TRUE(dbfull()->GetProperty(
-        DB::Properties::kLiveSstFilesSizeAtTemperature + std::to_string(22),
+        DB::Properties::GetLiveSstFilesSizeAtTemperature() + std::to_string(22),
         &prop));
     ASSERT_EQ(std::atoi(prop.c_str()), 0);
 #undef VERIFY_SST_COUNT
@@ -2222,7 +2222,6 @@ INSTANTIATE_TEST_CASE_P(ExternalSSTFileBasicTest, ExternalSSTFileBasicTest,
                                         std::make_tuple(true, false),
                                         std::make_tuple(false, true),
                                         std::make_tuple(false, false)));
-
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1962,7 +1962,7 @@ TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoMemtableFlush) {
     ASSERT_OK(Put(Key(k), "memtable"));
     true_data[Key(k)] = "memtable";
   }
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumEntriesActiveMemTable,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumEntriesActiveMemTable(),
                                   &entries_in_memtable));
   ASSERT_GE(entries_in_memtable, 1);
 
@@ -1972,7 +1972,7 @@ TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoMemtableFlush) {
   ASSERT_OK(GenerateAndAddExternalFile(
       options, {90, 100, 110}, -1, true, write_global_seqno,
       verify_checksums_before_ingest, false, false, &true_data));
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumEntriesActiveMemTable,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumEntriesActiveMemTable(),
                                   &entries_in_memtable));
   ASSERT_GE(entries_in_memtable, 1);
 
@@ -1980,7 +1980,7 @@ TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoMemtableFlush) {
   ASSERT_OK(GenerateAndAddExternalFile(
       options, {19, 20, 21}, -1, true, write_global_seqno,
       verify_checksums_before_ingest, false, false, &true_data));
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumEntriesActiveMemTable,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumEntriesActiveMemTable(),
                                   &entries_in_memtable));
   ASSERT_EQ(entries_in_memtable, 0);
 
@@ -1988,7 +1988,7 @@ TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoMemtableFlush) {
     ASSERT_OK(Put(Key(k), "memtable"));
     true_data[Key(k)] = "memtable";
   }
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumEntriesActiveMemTable,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumEntriesActiveMemTable(),
                                   &entries_in_memtable));
   ASSERT_GE(entries_in_memtable, 1);
 
@@ -1996,7 +1996,7 @@ TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoMemtableFlush) {
   ASSERT_OK(GenerateAndAddExternalFile(
       options, {202, 203, 204}, -1, true, write_global_seqno,
       verify_checksums_before_ingest, false, false, &true_data));
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumEntriesActiveMemTable,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumEntriesActiveMemTable(),
                                   &entries_in_memtable));
   ASSERT_GE(entries_in_memtable, 1);
 
@@ -2004,7 +2004,7 @@ TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoMemtableFlush) {
   ASSERT_OK(GenerateAndAddExternalFile(
       options, {206, 207}, -1, true, write_global_seqno,
       verify_checksums_before_ingest, false, false, &true_data));
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kNumEntriesActiveMemTable,
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::GetNumEntriesActiveMemTable(),
                                   &entries_in_memtable));
   ASSERT_EQ(entries_in_memtable, 0);
 

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -16,6 +16,7 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -34,55 +35,63 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-const std::map<LevelStatType, LevelStat> InternalStats::compaction_level_stats =
-    {
-        {LevelStatType::NUM_FILES, LevelStat{"NumFiles", "Files"}},
-        {LevelStatType::COMPACTED_FILES,
-         LevelStat{"CompactedFiles", "CompactedFiles"}},
-        {LevelStatType::SIZE_BYTES, LevelStat{"SizeBytes", "Size"}},
-        {LevelStatType::SCORE, LevelStat{"Score", "Score"}},
-        {LevelStatType::READ_GB, LevelStat{"ReadGB", "Read(GB)"}},
-        {LevelStatType::RN_GB, LevelStat{"RnGB", "Rn(GB)"}},
-        {LevelStatType::RNP1_GB, LevelStat{"Rnp1GB", "Rnp1(GB)"}},
-        {LevelStatType::WRITE_GB, LevelStat{"WriteGB", "Write(GB)"}},
-        {LevelStatType::W_NEW_GB, LevelStat{"WnewGB", "Wnew(GB)"}},
-        {LevelStatType::MOVED_GB, LevelStat{"MovedGB", "Moved(GB)"}},
-        {LevelStatType::WRITE_AMP, LevelStat{"WriteAmp", "W-Amp"}},
-        {LevelStatType::READ_MBPS, LevelStat{"ReadMBps", "Rd(MB/s)"}},
-        {LevelStatType::WRITE_MBPS, LevelStat{"WriteMBps", "Wr(MB/s)"}},
-        {LevelStatType::COMP_SEC, LevelStat{"CompSec", "Comp(sec)"}},
-        {LevelStatType::COMP_CPU_SEC,
-         LevelStat{"CompMergeCPU", "CompMergeCPU(sec)"}},
-        {LevelStatType::COMP_COUNT, LevelStat{"CompCount", "Comp(cnt)"}},
-        {LevelStatType::AVG_SEC, LevelStat{"AvgSec", "Avg(sec)"}},
-        {LevelStatType::KEY_IN, LevelStat{"KeyIn", "KeyIn"}},
-        {LevelStatType::KEY_DROP, LevelStat{"KeyDrop", "KeyDrop"}},
-        {LevelStatType::R_BLOB_GB, LevelStat{"RblobGB", "Rblob(GB)"}},
-        {LevelStatType::W_BLOB_GB, LevelStat{"WblobGB", "Wblob(GB)"}},
-};
+const std::map<LevelStatType, LevelStat>&
+InternalStats::GetCompactionLevelStats() {
+  static const std::map<LevelStatType, LevelStat> compaction_level_stats = {
+      {LevelStatType::NUM_FILES, LevelStat{"NumFiles", "Files"}},
+      {LevelStatType::COMPACTED_FILES,
+       LevelStat{"CompactedFiles", "CompactedFiles"}},
+      {LevelStatType::SIZE_BYTES, LevelStat{"SizeBytes", "Size"}},
+      {LevelStatType::SCORE, LevelStat{"Score", "Score"}},
+      {LevelStatType::READ_GB, LevelStat{"ReadGB", "Read(GB)"}},
+      {LevelStatType::RN_GB, LevelStat{"RnGB", "Rn(GB)"}},
+      {LevelStatType::RNP1_GB, LevelStat{"Rnp1GB", "Rnp1(GB)"}},
+      {LevelStatType::WRITE_GB, LevelStat{"WriteGB", "Write(GB)"}},
+      {LevelStatType::W_NEW_GB, LevelStat{"WnewGB", "Wnew(GB)"}},
+      {LevelStatType::MOVED_GB, LevelStat{"MovedGB", "Moved(GB)"}},
+      {LevelStatType::WRITE_AMP, LevelStat{"WriteAmp", "W-Amp"}},
+      {LevelStatType::READ_MBPS, LevelStat{"ReadMBps", "Rd(MB/s)"}},
+      {LevelStatType::WRITE_MBPS, LevelStat{"WriteMBps", "Wr(MB/s)"}},
+      {LevelStatType::COMP_SEC, LevelStat{"CompSec", "Comp(sec)"}},
+      {LevelStatType::COMP_CPU_SEC,
+       LevelStat{"CompMergeCPU", "CompMergeCPU(sec)"}},
+      {LevelStatType::COMP_COUNT, LevelStat{"CompCount", "Comp(cnt)"}},
+      {LevelStatType::AVG_SEC, LevelStat{"AvgSec", "Avg(sec)"}},
+      {LevelStatType::KEY_IN, LevelStat{"KeyIn", "KeyIn"}},
+      {LevelStatType::KEY_DROP, LevelStat{"KeyDrop", "KeyDrop"}},
+      {LevelStatType::R_BLOB_GB, LevelStat{"RblobGB", "Rblob(GB)"}},
+      {LevelStatType::W_BLOB_GB, LevelStat{"WblobGB", "Wblob(GB)"}},
+  };
+  return compaction_level_stats;
+}
 
-const std::map<InternalStats::InternalDBStatsType, DBStatInfo>
-    InternalStats::db_stats_type_to_info = {
-        {InternalStats::kIntStatsWalFileBytes,
-         DBStatInfo{"db.wal_bytes_written"}},
-        {InternalStats::kIntStatsWalFileSynced, DBStatInfo{"db.wal_syncs"}},
-        {InternalStats::kIntStatsBytesWritten,
-         DBStatInfo{"db.user_bytes_written"}},
-        {InternalStats::kIntStatsNumKeysWritten,
-         DBStatInfo{"db.user_keys_written"}},
-        {InternalStats::kIntStatsWriteDoneByOther,
-         DBStatInfo{"db.user_writes_by_other"}},
-        {InternalStats::kIntStatsWriteDoneBySelf,
-         DBStatInfo{"db.user_writes_by_self"}},
-        {InternalStats::kIntStatsWriteWithWal,
-         DBStatInfo{"db.user_writes_with_wal"}},
-        {InternalStats::kIntStatsWriteStallMicros,
-         DBStatInfo{"db.user_write_stall_micros"}},
-        {InternalStats::kIntStatsWriteBufferManagerLimitStopsCounts,
-         DBStatInfo{WriteStallStatsMapKeys::CauseConditionCount(
-             WriteStallCause::kWriteBufferManagerLimit,
-             WriteStallCondition::kStopped)}},
-};
+const std::map<InternalStats::InternalDBStatsType, DBStatInfo>&
+InternalStats::GetDBStatsTypeToInfo() {
+  static const std::map<InternalStats::InternalDBStatsType, DBStatInfo>
+      db_stats_type_to_info = {
+          {InternalStats::kIntStatsWalFileBytes,
+           DBStatInfo{"db.wal_bytes_written"}},
+          {InternalStats::kIntStatsWalFileSynced, DBStatInfo{"db.wal_syncs"}},
+          {InternalStats::kIntStatsBytesWritten,
+           DBStatInfo{"db.user_bytes_written"}},
+          {InternalStats::kIntStatsNumKeysWritten,
+           DBStatInfo{"db.user_keys_written"}},
+          {InternalStats::kIntStatsWriteDoneByOther,
+           DBStatInfo{"db.user_writes_by_other"}},
+          {InternalStats::kIntStatsWriteDoneBySelf,
+           DBStatInfo{"db.user_writes_by_self"}},
+          {InternalStats::kIntStatsWriteWithWal,
+           DBStatInfo{"db.user_writes_with_wal"}},
+          {InternalStats::kIntStatsWriteStallMicros,
+           DBStatInfo{"db.user_write_stall_micros"}},
+          {InternalStats::kIntStatsWriteBufferManagerLimitStopsCounts,
+           DBStatInfo{WriteStallStatsMapKeys::CauseConditionCount(
+               WriteStallCause::kWriteBufferManagerLimit,
+               WriteStallCondition::kStopped)}},
+
+      };
+  return db_stats_type_to_info;
+}
 
 namespace {
 const double kMB = 1048576.0;
@@ -95,7 +104,7 @@ void PrintLevelStatsHeader(char* buf, size_t len, const std::string& cf_name,
       snprintf(buf, len, "\n** Compaction Stats [%s] **\n", cf_name.c_str());
   written_size = std::min(written_size, static_cast<int>(len));
   auto hdr = [](LevelStatType t) {
-    return InternalStats::compaction_level_stats.at(t).header_name.c_str();
+    return InternalStats::GetCompactionLevelStats().at(t).header_name.c_str();
   };
   int line_size = snprintf(
       buf + written_size, len - written_size,
@@ -237,394 +246,603 @@ std::pair<Slice, Slice> GetPropertyNameAndArg(const Slice& property) {
 }
 }  // anonymous namespace
 
-static const std::string rocksdb_prefix = "rocksdb.";
+static constexpr std::string_view rocksdb_prefix = "rocksdb.";
 
-static const std::string num_files_at_level_prefix = "num-files-at-level";
-static const std::string compression_ratio_at_level_prefix =
+static constexpr std::string_view num_files_at_level_prefix =
+    "num-files-at-level";
+static constexpr std::string_view compression_ratio_at_level_prefix =
     "compression-ratio-at-level";
-static const std::string allstats = "stats";
-static const std::string sstables = "sstables";
-static const std::string cfstats = "cfstats";
-static const std::string cfstats_no_file_histogram =
+static constexpr std::string_view allstats = "stats";
+static constexpr std::string_view sstables = "sstables";
+static constexpr std::string_view cfstats = "cfstats";
+static constexpr std::string_view cfstats_no_file_histogram =
     "cfstats-no-file-histogram";
-static const std::string cf_file_histogram = "cf-file-histogram";
-static const std::string cf_write_stall_stats = "cf-write-stall-stats";
-static const std::string dbstats = "dbstats";
-static const std::string db_write_stall_stats = "db-write-stall-stats";
-static const std::string levelstats = "levelstats";
-static const std::string block_cache_entry_stats = "block-cache-entry-stats";
-static const std::string fast_block_cache_entry_stats =
+static constexpr std::string_view cf_file_histogram = "cf-file-histogram";
+static constexpr std::string_view cf_write_stall_stats = "cf-write-stall-stats";
+static constexpr std::string_view dbstats = "dbstats";
+static constexpr std::string_view db_write_stall_stats = "db-write-stall-stats";
+static constexpr std::string_view levelstats = "levelstats";
+static constexpr std::string_view block_cache_entry_stats =
+    "block-cache-entry-stats";
+static constexpr std::string_view fast_block_cache_entry_stats =
     "fast-block-cache-entry-stats";
-static const std::string num_immutable_mem_table = "num-immutable-mem-table";
-static const std::string num_immutable_mem_table_flushed =
+static constexpr std::string_view num_immutable_mem_table =
+    "num-immutable-mem-table";
+static constexpr std::string_view num_immutable_mem_table_flushed =
     "num-immutable-mem-table-flushed";
-static const std::string mem_table_flush_pending = "mem-table-flush-pending";
-static const std::string compaction_pending = "compaction-pending";
-static const std::string background_errors = "background-errors";
-static const std::string cur_size_active_mem_table =
+static constexpr std::string_view mem_table_flush_pending =
+    "mem-table-flush-pending";
+static constexpr std::string_view compaction_pending = "compaction-pending";
+static constexpr std::string_view background_errors = "background-errors";
+static constexpr std::string_view cur_size_active_mem_table =
     "cur-size-active-mem-table";
-static const std::string cur_size_all_mem_tables = "cur-size-all-mem-tables";
-static const std::string size_all_mem_tables = "size-all-mem-tables";
-static const std::string num_entries_active_mem_table =
+static constexpr std::string_view cur_size_all_mem_tables =
+    "cur-size-all-mem-tables";
+static constexpr std::string_view size_all_mem_tables = "size-all-mem-tables";
+static constexpr std::string_view num_entries_active_mem_table =
     "num-entries-active-mem-table";
-static const std::string num_entries_imm_mem_tables =
+static constexpr std::string_view num_entries_imm_mem_tables =
     "num-entries-imm-mem-tables";
-static const std::string num_deletes_active_mem_table =
+static constexpr std::string_view num_deletes_active_mem_table =
     "num-deletes-active-mem-table";
-static const std::string num_deletes_imm_mem_tables =
+static constexpr std::string_view num_deletes_imm_mem_tables =
     "num-deletes-imm-mem-tables";
-static const std::string estimate_num_keys = "estimate-num-keys";
-static const std::string estimate_table_readers_mem =
+static constexpr std::string_view estimate_num_keys = "estimate-num-keys";
+static constexpr std::string_view estimate_table_readers_mem =
     "estimate-table-readers-mem";
-static const std::string is_file_deletions_enabled =
+static constexpr std::string_view is_file_deletions_enabled =
     "is-file-deletions-enabled";
-static const std::string num_snapshots = "num-snapshots";
-static const std::string oldest_snapshot_time = "oldest-snapshot-time";
-static const std::string oldest_snapshot_sequence = "oldest-snapshot-sequence";
-static const std::string num_live_versions = "num-live-versions";
-static const std::string current_version_number =
+static constexpr std::string_view num_snapshots = "num-snapshots";
+static constexpr std::string_view oldest_snapshot_time = "oldest-snapshot-time";
+static constexpr std::string_view oldest_snapshot_sequence =
+    "oldest-snapshot-sequence";
+static constexpr std::string_view num_live_versions = "num-live-versions";
+static constexpr std::string_view current_version_number =
     "current-super-version-number";
-static const std::string estimate_live_data_size = "estimate-live-data-size";
-static const std::string min_log_number_to_keep_str = "min-log-number-to-keep";
-static const std::string min_obsolete_sst_number_to_keep_str =
+static constexpr std::string_view estimate_live_data_size =
+    "estimate-live-data-size";
+static constexpr std::string_view min_log_number_to_keep_str =
+    "min-log-number-to-keep";
+static constexpr std::string_view min_obsolete_sst_number_to_keep_str =
     "min-obsolete-sst-number-to-keep";
-static const std::string base_level_str = "base-level";
-static const std::string total_sst_files_size = "total-sst-files-size";
-static const std::string live_sst_files_size = "live-sst-files-size";
-static const std::string obsolete_sst_files_size = "obsolete-sst-files-size";
-static const std::string live_sst_files_size_at_temperature =
+static constexpr std::string_view base_level_str = "base-level";
+static constexpr std::string_view total_sst_files_size = "total-sst-files-size";
+static constexpr std::string_view live_sst_files_size = "live-sst-files-size";
+static constexpr std::string_view obsolete_sst_files_size =
+    "obsolete-sst-files-size";
+static constexpr std::string_view live_sst_files_size_at_temperature =
     "live-sst-files-size-at-temperature";
-static const std::string estimate_pending_comp_bytes =
+static constexpr std::string_view estimate_pending_comp_bytes =
     "estimate-pending-compaction-bytes";
-static const std::string aggregated_table_properties =
+static constexpr std::string_view aggregated_table_properties =
     "aggregated-table-properties";
-static const std::string aggregated_table_properties_at_level =
-    aggregated_table_properties + "-at-level";
-static const std::string num_running_compactions = "num-running-compactions";
-static const std::string num_running_flushes = "num-running-flushes";
-static const std::string actual_delayed_write_rate =
+static constexpr std::string_view at_level = "-at-level";
+static constexpr std::string_view num_running_compactions =
+    "num-running-compactions";
+static constexpr std::string_view num_running_flushes = "num-running-flushes";
+static constexpr std::string_view actual_delayed_write_rate =
     "actual-delayed-write-rate";
-static const std::string is_write_stopped = "is-write-stopped";
-static const std::string estimate_oldest_key_time = "estimate-oldest-key-time";
-static const std::string block_cache_capacity = "block-cache-capacity";
-static const std::string block_cache_usage = "block-cache-usage";
-static const std::string block_cache_pinned_usage = "block-cache-pinned-usage";
-static const std::string options_statistics = "options-statistics";
-static const std::string num_blob_files = "num-blob-files";
-static const std::string blob_stats = "blob-stats";
-static const std::string total_blob_file_size = "total-blob-file-size";
-static const std::string live_blob_file_size = "live-blob-file-size";
-static const std::string live_blob_file_garbage_size =
+static constexpr std::string_view is_write_stopped = "is-write-stopped";
+static constexpr std::string_view estimate_oldest_key_time =
+    "estimate-oldest-key-time";
+static constexpr std::string_view block_cache_capacity = "block-cache-capacity";
+static constexpr std::string_view block_cache_usage = "block-cache-usage";
+static constexpr std::string_view block_cache_pinned_usage =
+    "block-cache-pinned-usage";
+static constexpr std::string_view options_statistics = "options-statistics";
+static constexpr std::string_view num_blob_files = "num-blob-files";
+static constexpr std::string_view blob_stats = "blob-stats";
+static constexpr std::string_view total_blob_file_size = "total-blob-file-size";
+static constexpr std::string_view live_blob_file_size = "live-blob-file-size";
+static constexpr std::string_view live_blob_file_garbage_size =
     "live-blob-file-garbage-size";
-static const std::string blob_cache_capacity = "blob-cache-capacity";
-static const std::string blob_cache_usage = "blob-cache-usage";
-static const std::string blob_cache_pinned_usage = "blob-cache-pinned-usage";
+static constexpr std::string_view blob_cache_capacity = "blob-cache-capacity";
+static constexpr std::string_view blob_cache_usage = "blob-cache-usage";
+static constexpr std::string_view blob_cache_pinned_usage =
+    "blob-cache-pinned-usage";
 
-const std::string DB::Properties::kNumFilesAtLevelPrefix =
-    rocksdb_prefix + num_files_at_level_prefix;
-const std::string DB::Properties::kCompressionRatioAtLevelPrefix =
-    rocksdb_prefix + compression_ratio_at_level_prefix;
-const std::string DB::Properties::kStats = rocksdb_prefix + allstats;
-const std::string DB::Properties::kSSTables = rocksdb_prefix + sstables;
-const std::string DB::Properties::kCFStats = rocksdb_prefix + cfstats;
-const std::string DB::Properties::kCFStatsNoFileHistogram =
-    rocksdb_prefix + cfstats_no_file_histogram;
-const std::string DB::Properties::kCFFileHistogram =
-    rocksdb_prefix + cf_file_histogram;
-const std::string DB::Properties::kCFWriteStallStats =
-    rocksdb_prefix + cf_write_stall_stats;
-const std::string DB::Properties::kDBWriteStallStats =
-    rocksdb_prefix + db_write_stall_stats;
-const std::string DB::Properties::kDBStats = rocksdb_prefix + dbstats;
-const std::string DB::Properties::kLevelStats = rocksdb_prefix + levelstats;
-const std::string DB::Properties::kBlockCacheEntryStats =
-    rocksdb_prefix + block_cache_entry_stats;
-const std::string DB::Properties::kFastBlockCacheEntryStats =
-    rocksdb_prefix + fast_block_cache_entry_stats;
-const std::string DB::Properties::kNumImmutableMemTable =
-    rocksdb_prefix + num_immutable_mem_table;
-const std::string DB::Properties::kNumImmutableMemTableFlushed =
-    rocksdb_prefix + num_immutable_mem_table_flushed;
-const std::string DB::Properties::kMemTableFlushPending =
-    rocksdb_prefix + mem_table_flush_pending;
-const std::string DB::Properties::kCompactionPending =
-    rocksdb_prefix + compaction_pending;
-const std::string DB::Properties::kNumRunningCompactions =
-    rocksdb_prefix + num_running_compactions;
-const std::string DB::Properties::kNumRunningFlushes =
-    rocksdb_prefix + num_running_flushes;
-const std::string DB::Properties::kBackgroundErrors =
-    rocksdb_prefix + background_errors;
-const std::string DB::Properties::kCurSizeActiveMemTable =
-    rocksdb_prefix + cur_size_active_mem_table;
-const std::string DB::Properties::kCurSizeAllMemTables =
-    rocksdb_prefix + cur_size_all_mem_tables;
-const std::string DB::Properties::kSizeAllMemTables =
-    rocksdb_prefix + size_all_mem_tables;
-const std::string DB::Properties::kNumEntriesActiveMemTable =
-    rocksdb_prefix + num_entries_active_mem_table;
-const std::string DB::Properties::kNumEntriesImmMemTables =
-    rocksdb_prefix + num_entries_imm_mem_tables;
-const std::string DB::Properties::kNumDeletesActiveMemTable =
-    rocksdb_prefix + num_deletes_active_mem_table;
-const std::string DB::Properties::kNumDeletesImmMemTables =
-    rocksdb_prefix + num_deletes_imm_mem_tables;
-const std::string DB::Properties::kEstimateNumKeys =
-    rocksdb_prefix + estimate_num_keys;
-const std::string DB::Properties::kEstimateTableReadersMem =
-    rocksdb_prefix + estimate_table_readers_mem;
-const std::string DB::Properties::kIsFileDeletionsEnabled =
-    rocksdb_prefix + is_file_deletions_enabled;
-const std::string DB::Properties::kNumSnapshots =
-    rocksdb_prefix + num_snapshots;
-const std::string DB::Properties::kOldestSnapshotTime =
-    rocksdb_prefix + oldest_snapshot_time;
-const std::string DB::Properties::kOldestSnapshotSequence =
-    rocksdb_prefix + oldest_snapshot_sequence;
-const std::string DB::Properties::kNumLiveVersions =
-    rocksdb_prefix + num_live_versions;
-const std::string DB::Properties::kCurrentSuperVersionNumber =
-    rocksdb_prefix + current_version_number;
-const std::string DB::Properties::kEstimateLiveDataSize =
-    rocksdb_prefix + estimate_live_data_size;
-const std::string DB::Properties::kMinLogNumberToKeep =
-    rocksdb_prefix + min_log_number_to_keep_str;
-const std::string DB::Properties::kMinObsoleteSstNumberToKeep =
-    rocksdb_prefix + min_obsolete_sst_number_to_keep_str;
-const std::string DB::Properties::kTotalSstFilesSize =
-    rocksdb_prefix + total_sst_files_size;
-const std::string DB::Properties::kLiveSstFilesSize =
-    rocksdb_prefix + live_sst_files_size;
-const std::string DB::Properties::kObsoleteSstFilesSize =
-    rocksdb_prefix + obsolete_sst_files_size;
-const std::string DB::Properties::kBaseLevel = rocksdb_prefix + base_level_str;
-const std::string DB::Properties::kEstimatePendingCompactionBytes =
-    rocksdb_prefix + estimate_pending_comp_bytes;
-const std::string DB::Properties::kAggregatedTableProperties =
-    rocksdb_prefix + aggregated_table_properties;
-const std::string DB::Properties::kAggregatedTablePropertiesAtLevel =
-    rocksdb_prefix + aggregated_table_properties_at_level;
-const std::string DB::Properties::kActualDelayedWriteRate =
-    rocksdb_prefix + actual_delayed_write_rate;
-const std::string DB::Properties::kIsWriteStopped =
-    rocksdb_prefix + is_write_stopped;
-const std::string DB::Properties::kEstimateOldestKeyTime =
-    rocksdb_prefix + estimate_oldest_key_time;
-const std::string DB::Properties::kBlockCacheCapacity =
-    rocksdb_prefix + block_cache_capacity;
-const std::string DB::Properties::kBlockCacheUsage =
-    rocksdb_prefix + block_cache_usage;
-const std::string DB::Properties::kBlockCachePinnedUsage =
-    rocksdb_prefix + block_cache_pinned_usage;
-const std::string DB::Properties::kOptionsStatistics =
-    rocksdb_prefix + options_statistics;
-const std::string DB::Properties::kLiveSstFilesSizeAtTemperature =
-    rocksdb_prefix + live_sst_files_size_at_temperature;
-const std::string DB::Properties::kNumBlobFiles =
-    rocksdb_prefix + num_blob_files;
-const std::string DB::Properties::kBlobStats = rocksdb_prefix + blob_stats;
-const std::string DB::Properties::kTotalBlobFileSize =
-    rocksdb_prefix + total_blob_file_size;
-const std::string DB::Properties::kLiveBlobFileSize =
-    rocksdb_prefix + live_blob_file_size;
-const std::string DB::Properties::kLiveBlobFileGarbageSize =
-    rocksdb_prefix + live_blob_file_garbage_size;
-const std::string DB::Properties::kBlobCacheCapacity =
-    rocksdb_prefix + blob_cache_capacity;
-const std::string DB::Properties::kBlobCacheUsage =
-    rocksdb_prefix + blob_cache_usage;
-const std::string DB::Properties::kBlobCachePinnedUsage =
-    rocksdb_prefix + blob_cache_pinned_usage;
+const std::string& DB::Properties::GetNumFilesAtLevelPrefix() {
+  static const std::string kNumFilesAtLevelPrefix =
+      std::string(rocksdb_prefix) + std::string(num_files_at_level_prefix);
+  return kNumFilesAtLevelPrefix;
+}
+const std::string& DB::Properties::GetCompressionRatioAtLevelPrefix() {
+  static const std::string kCompressionRatioAtLevelPrefix =
+      std::string(rocksdb_prefix) +
+      std::string(compression_ratio_at_level_prefix);
+  return kCompressionRatioAtLevelPrefix;
+}
+const std::string& DB::Properties::GetStats() {
+  static const std::string kStats =
+      std::string(rocksdb_prefix) + std::string(allstats);
+  return kStats;
+}
+const std::string& DB::Properties::GetSSTables() {
+  static const std::string kSSTables =
+      std::string(rocksdb_prefix) + std::string(sstables);
+  return kSSTables;
+}
+const std::string& DB::Properties::GetCFStats() {
+  static const std::string kCFStats =
+      std::string(rocksdb_prefix) + std::string(cfstats);
+  return kCFStats;
+}
+const std::string& DB::Properties::GetCFStatsNoFileHistogram() {
+  static const std::string kCFStatsNoFileHistogram =
+      std::string(rocksdb_prefix) + std::string(cfstats_no_file_histogram);
+  return kCFStatsNoFileHistogram;
+}
+const std::string& DB::Properties::GetCFFileHistogram() {
+  static const std::string kCFFileHistogram =
+      std::string(rocksdb_prefix) + std::string(cf_file_histogram);
+  return kCFFileHistogram;
+}
+const std::string& DB::Properties::GetCFWriteStallStats() {
+  static const std::string kCFWriteStallStats =
+      std::string(rocksdb_prefix) + std::string(cf_write_stall_stats);
+  return kCFWriteStallStats;
+}
+const std::string& DB::Properties::GetDBWriteStallStats() {
+  static const std::string kDBWriteStallStats =
+      std::string(rocksdb_prefix) + std::string(db_write_stall_stats);
+  return kDBWriteStallStats;
+}
+const std::string& DB::Properties::GetDBStats() {
+  static const std::string kDBStats =
+      std::string(rocksdb_prefix) + std::string(dbstats);
+  return kDBStats;
+}
+const std::string& DB::Properties::GetLevelStats() {
+  static const std::string kLevelStats =
+      std::string(rocksdb_prefix) + std::string(levelstats);
+  return kLevelStats;
+}
+const std::string& DB::Properties::GetBlockCacheEntryStats() {
+  static const std::string kBlockCacheEntryStats =
+      std::string(rocksdb_prefix) + std::string(block_cache_entry_stats);
+  return kBlockCacheEntryStats;
+}
+const std::string& DB::Properties::GetFastBlockCacheEntryStats() {
+  static const std::string kFastBlockCacheEntryStats =
+      std::string(rocksdb_prefix) + std::string(fast_block_cache_entry_stats);
+  return kFastBlockCacheEntryStats;
+}
+const std::string& DB::Properties::GetNumImmutableMemTable() {
+  static const std::string kNumImmutableMemTable =
+      std::string(rocksdb_prefix) + std::string(num_immutable_mem_table);
+  return kNumImmutableMemTable;
+}
+const std::string& DB::Properties::GetNumImmutableMemTableFlushed() {
+  static const std::string kNumImmutableMemTableFlushed =
+      std::string(rocksdb_prefix) +
+      std::string(num_immutable_mem_table_flushed);
+  return kNumImmutableMemTableFlushed;
+}
+const std::string& DB::Properties::GetMemTableFlushPending() {
+  static const std::string kMemTableFlushPending =
+      std::string(rocksdb_prefix) + std::string(mem_table_flush_pending);
+  return kMemTableFlushPending;
+}
+const std::string& DB::Properties::GetCompactionPending() {
+  static const std::string kCompactionPending =
+      std::string(rocksdb_prefix) + std::string(compaction_pending);
+  return kCompactionPending;
+}
+const std::string& DB::Properties::GetNumRunningCompactions() {
+  static const std::string kNumRunningCompactions =
+      std::string(rocksdb_prefix) + std::string(num_running_compactions);
+  return kNumRunningCompactions;
+}
+const std::string& DB::Properties::GetNumRunningFlushes() {
+  static const std::string kNumRunningFlushes =
+      std::string(rocksdb_prefix) + std::string(num_running_flushes);
+  return kNumRunningFlushes;
+}
+const std::string& DB::Properties::GetBackgroundErrors() {
+  static const std::string kBackgroundErrors =
+      std::string(rocksdb_prefix) + std::string(background_errors);
+  return kBackgroundErrors;
+}
+const std::string& DB::Properties::GetCurSizeActiveMemTable() {
+  static const std::string kCurSizeActiveMemTable =
+      std::string(rocksdb_prefix) + std::string(cur_size_active_mem_table);
+  return kCurSizeActiveMemTable;
+}
+const std::string& DB::Properties::GetCurSizeAllMemTables() {
+  static const std::string kCurSizeAllMemTables =
+      std::string(rocksdb_prefix) + std::string(cur_size_all_mem_tables);
+  return kCurSizeAllMemTables;
+}
+const std::string& DB::Properties::GetSizeAllMemTables() {
+  static const std::string kSizeAllMemTables =
+      std::string(rocksdb_prefix) + std::string(size_all_mem_tables);
+  return kSizeAllMemTables;
+}
+const std::string& DB::Properties::GetNumEntriesActiveMemTable() {
+  static const std::string kNumEntriesActiveMemTable =
+      std::string(rocksdb_prefix) + std::string(num_entries_active_mem_table);
+  return kNumEntriesActiveMemTable;
+}
+const std::string& DB::Properties::GetNumEntriesImmMemTables() {
+  static const std::string kNumEntriesImmMemTables =
+      std::string(rocksdb_prefix) + std::string(num_entries_imm_mem_tables);
+  return kNumEntriesImmMemTables;
+}
+const std::string& DB::Properties::GetNumDeletesActiveMemTable() {
+  static const std::string kNumDeletesActiveMemTable =
+      std::string(rocksdb_prefix) + std::string(num_deletes_active_mem_table);
+  return kNumDeletesActiveMemTable;
+}
+const std::string& DB::Properties::GetNumDeletesImmMemTables() {
+  static const std::string kNumDeletesImmMemTables =
+      std::string(rocksdb_prefix) + std::string(num_deletes_imm_mem_tables);
+  return kNumDeletesImmMemTables;
+}
+const std::string& DB::Properties::GetEstimateNumKeys() {
+  static const std::string kEstimateNumKeys =
+      std::string(rocksdb_prefix) + std::string(estimate_num_keys);
+  return kEstimateNumKeys;
+}
+const std::string& DB::Properties::GetEstimateTableReadersMem() {
+  static const std::string kEstimateTableReadersMem =
+      std::string(rocksdb_prefix) + std::string(estimate_table_readers_mem);
+  return kEstimateTableReadersMem;
+}
+const std::string& DB::Properties::GetIsFileDeletionsEnabled() {
+  static const std::string kIsFileDeletionsEnabled =
+      std::string(rocksdb_prefix) + std::string(is_file_deletions_enabled);
+  return kIsFileDeletionsEnabled;
+}
+const std::string& DB::Properties::GetNumSnapshots() {
+  static const std::string kNumSnapshots =
+      std::string(rocksdb_prefix) + std::string(num_snapshots);
+  return kNumSnapshots;
+}
+const std::string& DB::Properties::GetOldestSnapshotTime() {
+  static const std::string kOldestSnapshotTime =
+      std::string(rocksdb_prefix) + std::string(oldest_snapshot_time);
+  return kOldestSnapshotTime;
+}
+const std::string& DB::Properties::GetOldestSnapshotSequence() {
+  static const std::string kOldestSnapshotSequence =
+      std::string(rocksdb_prefix) + std::string(oldest_snapshot_sequence);
+  return kOldestSnapshotSequence;
+}
+const std::string& DB::Properties::GetNumLiveVersions() {
+  static const std::string kNumLiveVersions =
+      std::string(rocksdb_prefix) + std::string(num_live_versions);
+  return kNumLiveVersions;
+}
+const std::string& DB::Properties::GetCurrentSuperVersionNumber() {
+  static const std::string kCurrentSuperVersionNumber =
+      std::string(rocksdb_prefix) + std::string(current_version_number);
+  return kCurrentSuperVersionNumber;
+}
+const std::string& DB::Properties::GetEstimateLiveDataSize() {
+  static const std::string kEstimateLiveDataSize =
+      std::string(rocksdb_prefix) + std::string(estimate_live_data_size);
+  return kEstimateLiveDataSize;
+}
+const std::string& DB::Properties::GetMinLogNumberToKeep() {
+  static const std::string kMinLogNumberToKeep =
+      std::string(rocksdb_prefix) + std::string(min_log_number_to_keep_str);
+  return kMinLogNumberToKeep;
+}
+const std::string& DB::Properties::GetMinObsoleteSstNumberToKeep() {
+  static const std::string kMinObsoleteSstNumberToKeep =
+      std::string(rocksdb_prefix) +
+      std::string(min_obsolete_sst_number_to_keep_str);
+  return kMinObsoleteSstNumberToKeep;
+}
+const std::string& DB::Properties::GetTotalSstFilesSize() {
+  static const std::string kTotalSstFilesSize =
+      std::string(rocksdb_prefix) + std::string(total_sst_files_size);
+  return kTotalSstFilesSize;
+}
+const std::string& DB::Properties::GetLiveSstFilesSize() {
+  static const std::string kLiveSstFilesSize =
+      std::string(rocksdb_prefix) + std::string(live_sst_files_size);
+  return kLiveSstFilesSize;
+}
+const std::string& DB::Properties::GetObsoleteSstFilesSize() {
+  static const std::string kObsoleteSstFilesSize =
+      std::string(rocksdb_prefix) + std::string(obsolete_sst_files_size);
+  return kObsoleteSstFilesSize;
+}
+const std::string& DB::Properties::GetBaseLevel() {
+  static const std::string kBaseLevel =
+      std::string(rocksdb_prefix) + std::string(base_level_str);
+  return kBaseLevel;
+}
+const std::string& DB::Properties::GetEstimatePendingCompactionBytes() {
+  static const std::string kEstimatePendingCompactionBytes =
+      std::string(rocksdb_prefix) + std::string(estimate_pending_comp_bytes);
+  return kEstimatePendingCompactionBytes;
+}
+const std::string& DB::Properties::GetAggregatedTableProperties() {
+  static const std::string kAggregatedTableProperties =
+      std::string(rocksdb_prefix) + std::string(aggregated_table_properties);
+  return kAggregatedTableProperties;
+}
+const std::string& DB::Properties::GetAggregatedTablePropertiesAtLevel() {
+  static const std::string kAggregatedTablePropertiesAtLevel =
+      std::string(rocksdb_prefix) + std::string(aggregated_table_properties) +
+      std::string(at_level);
+  return kAggregatedTablePropertiesAtLevel;
+}
+const std::string& DB::Properties::GetActualDelayedWriteRate() {
+  static const std::string kActualDelayedWriteRate =
+      std::string(rocksdb_prefix) + std::string(actual_delayed_write_rate);
+  return kActualDelayedWriteRate;
+}
+const std::string& DB::Properties::GetIsWriteStopped() {
+  static const std::string kIsWriteStopped =
+      std::string(rocksdb_prefix) + std::string(is_write_stopped);
+  return kIsWriteStopped;
+}
+const std::string& DB::Properties::GetEstimateOldestKeyTime() {
+  static const std::string kEstimateOldestKeyTime =
+      std::string(rocksdb_prefix) + std::string(estimate_oldest_key_time);
+  return kEstimateOldestKeyTime;
+}
+const std::string& DB::Properties::GetBlockCacheCapacity() {
+  static const std::string kBlockCacheCapacity =
+      std::string(rocksdb_prefix) + std::string(block_cache_capacity);
+  return kBlockCacheCapacity;
+}
+const std::string& DB::Properties::GetBlockCacheUsage() {
+  static const std::string kBlockCacheUsage =
+      std::string(rocksdb_prefix) + std::string(block_cache_usage);
+  return kBlockCacheUsage;
+}
+const std::string& DB::Properties::GetBlockCachePinnedUsage() {
+  static const std::string kBlockCachePinnedUsage =
+      std::string(rocksdb_prefix) + std::string(block_cache_pinned_usage);
+  return kBlockCachePinnedUsage;
+}
+const std::string& DB::Properties::GetOptionsStatistics() {
+  static const std::string kOptionsStatistics =
+      std::string(rocksdb_prefix) + std::string(options_statistics);
+  return kOptionsStatistics;
+}
+const std::string& DB::Properties::GetLiveSstFilesSizeAtTemperature() {
+  static const std::string kLiveSstFilesSizeAtTemperature =
+      std::string(rocksdb_prefix) +
+      std::string(live_sst_files_size_at_temperature);
+  return kLiveSstFilesSizeAtTemperature;
+}
+const std::string& DB::Properties::GetNumBlobFiles() {
+  static const std::string kNumBlobFiles =
+      std::string(rocksdb_prefix) + std::string(num_blob_files);
+  return kNumBlobFiles;
+}
+const std::string& DB::Properties::GetBlobStats() {
+  static const std::string kBlobStats =
+      std::string(rocksdb_prefix) + std::string(blob_stats);
+  return kBlobStats;
+}
+const std::string& DB::Properties::GetTotalBlobFileSize() {
+  static const std::string kTotalBlobFileSize =
+      std::string(rocksdb_prefix) + std::string(total_blob_file_size);
+  return kTotalBlobFileSize;
+}
+const std::string& DB::Properties::GetLiveBlobFileSize() {
+  static const std::string kLiveBlobFileSize =
+      std::string(rocksdb_prefix) + std::string(live_blob_file_size);
+  return kLiveBlobFileSize;
+}
+const std::string& DB::Properties::GetLiveBlobFileGarbageSize() {
+  static const std::string kLiveBlobFileGarbageSize =
+      std::string(rocksdb_prefix) + std::string(live_blob_file_garbage_size);
+  return kLiveBlobFileGarbageSize;
+}
+const std::string& DB::Properties::GetBlobCacheCapacity() {
+  static const std::string kBlobCacheCapacity =
+      std::string(rocksdb_prefix) + std::string(blob_cache_capacity);
+  return kBlobCacheCapacity;
+}
+const std::string& DB::Properties::GetBlobCacheUsage() {
+  static const std::string kBlobCacheUsage =
+      std::string(rocksdb_prefix) + std::string(blob_cache_usage);
+  return kBlobCacheUsage;
+}
+const std::string& DB::Properties::GetBlobCachePinnedUsage() {
+  static const std::string kBlobCachePinnedUsage =
+      std::string(rocksdb_prefix) + std::string(blob_cache_pinned_usage);
+  return kBlobCachePinnedUsage;
+}
 
-const std::string InternalStats::kPeriodicCFStats =
-    DB::Properties::kCFStats + ".periodic";
-const int InternalStats::kMaxNoChangePeriodSinceDump = 8;
+const std::string& InternalStats::GetPeriodicCFStats() {
+  static const std::string kPeriodicCFStats =
+      DB::Properties::GetCFStats() + ".periodic";
+  return kPeriodicCFStats;
+}
 
-const UnorderedMap<std::string, DBPropertyInfo>
-    InternalStats::ppt_name_to_info = {
-        {DB::Properties::kNumFilesAtLevelPrefix,
-         {false, &InternalStats::HandleNumFilesAtLevel, nullptr, nullptr,
-          nullptr}},
-        {DB::Properties::kCompressionRatioAtLevelPrefix,
-         {false, &InternalStats::HandleCompressionRatioAtLevelPrefix, nullptr,
-          nullptr, nullptr}},
-        {DB::Properties::kLevelStats,
-         {false, &InternalStats::HandleLevelStats, nullptr, nullptr, nullptr}},
-        {DB::Properties::kStats,
-         {false, &InternalStats::HandleStats, nullptr, nullptr, nullptr}},
-        {DB::Properties::kCFStats,
-         {false, &InternalStats::HandleCFStats, nullptr,
-          &InternalStats::HandleCFMapStats, nullptr}},
-        {InternalStats::kPeriodicCFStats,
-         {false, &InternalStats::HandleCFStatsPeriodic, nullptr, nullptr,
-          nullptr}},
-        {DB::Properties::kCFStatsNoFileHistogram,
-         {false, &InternalStats::HandleCFStatsNoFileHistogram, nullptr, nullptr,
-          nullptr}},
-        {DB::Properties::kCFFileHistogram,
-         {false, &InternalStats::HandleCFFileHistogram, nullptr, nullptr,
-          nullptr}},
-        {DB::Properties::kCFWriteStallStats,
-         {false, &InternalStats::HandleCFWriteStallStats, nullptr,
-          &InternalStats::HandleCFWriteStallStatsMap, nullptr}},
-        {DB::Properties::kDBStats,
-         {false, &InternalStats::HandleDBStats, nullptr,
-          &InternalStats::HandleDBMapStats, nullptr}},
-        {DB::Properties::kDBWriteStallStats,
-         {false, &InternalStats::HandleDBWriteStallStats, nullptr,
-          &InternalStats::HandleDBWriteStallStatsMap, nullptr}},
-        {DB::Properties::kBlockCacheEntryStats,
-         {true, &InternalStats::HandleBlockCacheEntryStats, nullptr,
-          &InternalStats::HandleBlockCacheEntryStatsMap, nullptr}},
-        {DB::Properties::kFastBlockCacheEntryStats,
-         {true, &InternalStats::HandleFastBlockCacheEntryStats, nullptr,
-          &InternalStats::HandleFastBlockCacheEntryStatsMap, nullptr}},
-        {DB::Properties::kSSTables,
-         {false, &InternalStats::HandleSsTables, nullptr, nullptr, nullptr}},
-        {DB::Properties::kAggregatedTableProperties,
-         {false, &InternalStats::HandleAggregatedTableProperties, nullptr,
-          &InternalStats::HandleAggregatedTablePropertiesMap, nullptr}},
-        {DB::Properties::kAggregatedTablePropertiesAtLevel,
-         {false, &InternalStats::HandleAggregatedTablePropertiesAtLevel,
-          nullptr, &InternalStats::HandleAggregatedTablePropertiesAtLevelMap,
-          nullptr}},
-        {DB::Properties::kNumImmutableMemTable,
-         {false, nullptr, &InternalStats::HandleNumImmutableMemTable, nullptr,
-          nullptr}},
-        {DB::Properties::kNumImmutableMemTableFlushed,
-         {false, nullptr, &InternalStats::HandleNumImmutableMemTableFlushed,
-          nullptr, nullptr}},
-        {DB::Properties::kMemTableFlushPending,
-         {false, nullptr, &InternalStats::HandleMemTableFlushPending, nullptr,
-          nullptr}},
-        {DB::Properties::kCompactionPending,
-         {false, nullptr, &InternalStats::HandleCompactionPending, nullptr,
-          nullptr}},
-        {DB::Properties::kBackgroundErrors,
-         {false, nullptr, &InternalStats::HandleBackgroundErrors, nullptr,
-          nullptr}},
-        {DB::Properties::kCurSizeActiveMemTable,
-         {false, nullptr, &InternalStats::HandleCurSizeActiveMemTable, nullptr,
-          nullptr}},
-        {DB::Properties::kCurSizeAllMemTables,
-         {false, nullptr, &InternalStats::HandleCurSizeAllMemTables, nullptr,
-          nullptr}},
-        {DB::Properties::kSizeAllMemTables,
-         {false, nullptr, &InternalStats::HandleSizeAllMemTables, nullptr,
-          nullptr}},
-        {DB::Properties::kNumEntriesActiveMemTable,
-         {false, nullptr, &InternalStats::HandleNumEntriesActiveMemTable,
-          nullptr, nullptr}},
-        {DB::Properties::kNumEntriesImmMemTables,
-         {false, nullptr, &InternalStats::HandleNumEntriesImmMemTables, nullptr,
-          nullptr}},
-        {DB::Properties::kNumDeletesActiveMemTable,
-         {false, nullptr, &InternalStats::HandleNumDeletesActiveMemTable,
-          nullptr, nullptr}},
-        {DB::Properties::kNumDeletesImmMemTables,
-         {false, nullptr, &InternalStats::HandleNumDeletesImmMemTables, nullptr,
-          nullptr}},
-        {DB::Properties::kEstimateNumKeys,
-         {false, nullptr, &InternalStats::HandleEstimateNumKeys, nullptr,
-          nullptr}},
-        {DB::Properties::kEstimateTableReadersMem,
-         {true, nullptr, &InternalStats::HandleEstimateTableReadersMem, nullptr,
-          nullptr}},
-        {DB::Properties::kIsFileDeletionsEnabled,
-         {false, nullptr, &InternalStats::HandleIsFileDeletionsEnabled, nullptr,
-          nullptr}},
-        {DB::Properties::kNumSnapshots,
-         {false, nullptr, &InternalStats::HandleNumSnapshots, nullptr,
-          nullptr}},
-        {DB::Properties::kOldestSnapshotTime,
-         {false, nullptr, &InternalStats::HandleOldestSnapshotTime, nullptr,
-          nullptr}},
-        {DB::Properties::kOldestSnapshotSequence,
-         {false, nullptr, &InternalStats::HandleOldestSnapshotSequence, nullptr,
-          nullptr}},
-        {DB::Properties::kNumLiveVersions,
-         {false, nullptr, &InternalStats::HandleNumLiveVersions, nullptr,
-          nullptr}},
-        {DB::Properties::kCurrentSuperVersionNumber,
-         {false, nullptr, &InternalStats::HandleCurrentSuperVersionNumber,
-          nullptr, nullptr}},
-        {DB::Properties::kEstimateLiveDataSize,
-         {true, nullptr, &InternalStats::HandleEstimateLiveDataSize, nullptr,
-          nullptr}},
-        {DB::Properties::kMinLogNumberToKeep,
-         {false, nullptr, &InternalStats::HandleMinLogNumberToKeep, nullptr,
-          nullptr}},
-        {DB::Properties::kMinObsoleteSstNumberToKeep,
-         {false, nullptr, &InternalStats::HandleMinObsoleteSstNumberToKeep,
-          nullptr, nullptr}},
-        {DB::Properties::kBaseLevel,
-         {false, nullptr, &InternalStats::HandleBaseLevel, nullptr, nullptr}},
-        {DB::Properties::kTotalSstFilesSize,
-         {false, nullptr, &InternalStats::HandleTotalSstFilesSize, nullptr,
-          nullptr}},
-        {DB::Properties::kLiveSstFilesSize,
-         {false, nullptr, &InternalStats::HandleLiveSstFilesSize, nullptr,
-          nullptr}},
-        {DB::Properties::kLiveSstFilesSizeAtTemperature,
-         {false, &InternalStats::HandleLiveSstFilesSizeAtTemperature, nullptr,
-          nullptr, nullptr}},
-        {DB::Properties::kObsoleteSstFilesSize,
-         {false, nullptr, &InternalStats::HandleObsoleteSstFilesSize, nullptr,
-          nullptr}},
-        {DB::Properties::kEstimatePendingCompactionBytes,
-         {false, nullptr, &InternalStats::HandleEstimatePendingCompactionBytes,
-          nullptr, nullptr}},
-        {DB::Properties::kNumRunningFlushes,
-         {false, nullptr, &InternalStats::HandleNumRunningFlushes, nullptr,
-          nullptr}},
-        {DB::Properties::kNumRunningCompactions,
-         {false, nullptr, &InternalStats::HandleNumRunningCompactions, nullptr,
-          nullptr}},
-        {DB::Properties::kActualDelayedWriteRate,
-         {false, nullptr, &InternalStats::HandleActualDelayedWriteRate, nullptr,
-          nullptr}},
-        {DB::Properties::kIsWriteStopped,
-         {false, nullptr, &InternalStats::HandleIsWriteStopped, nullptr,
-          nullptr}},
-        {DB::Properties::kEstimateOldestKeyTime,
-         {false, nullptr, &InternalStats::HandleEstimateOldestKeyTime, nullptr,
-          nullptr}},
-        {DB::Properties::kBlockCacheCapacity,
-         {false, nullptr, &InternalStats::HandleBlockCacheCapacity, nullptr,
-          nullptr}},
-        {DB::Properties::kBlockCacheUsage,
-         {false, nullptr, &InternalStats::HandleBlockCacheUsage, nullptr,
-          nullptr}},
-        {DB::Properties::kBlockCachePinnedUsage,
-         {false, nullptr, &InternalStats::HandleBlockCachePinnedUsage, nullptr,
-          nullptr}},
-        {DB::Properties::kOptionsStatistics,
-         {true, nullptr, nullptr, nullptr,
-          &DBImpl::GetPropertyHandleOptionsStatistics}},
-        {DB::Properties::kNumBlobFiles,
-         {false, nullptr, &InternalStats::HandleNumBlobFiles, nullptr,
-          nullptr}},
-        {DB::Properties::kBlobStats,
-         {false, &InternalStats::HandleBlobStats, nullptr, nullptr, nullptr}},
-        {DB::Properties::kTotalBlobFileSize,
-         {false, nullptr, &InternalStats::HandleTotalBlobFileSize, nullptr,
-          nullptr}},
-        {DB::Properties::kLiveBlobFileSize,
-         {false, nullptr, &InternalStats::HandleLiveBlobFileSize, nullptr,
-          nullptr}},
-        {DB::Properties::kLiveBlobFileGarbageSize,
-         {false, nullptr, &InternalStats::HandleLiveBlobFileGarbageSize,
-          nullptr, nullptr}},
-        {DB::Properties::kBlobCacheCapacity,
-         {false, nullptr, &InternalStats::HandleBlobCacheCapacity, nullptr,
-          nullptr}},
-        {DB::Properties::kBlobCacheUsage,
-         {false, nullptr, &InternalStats::HandleBlobCacheUsage, nullptr,
-          nullptr}},
-        {DB::Properties::kBlobCachePinnedUsage,
-         {false, nullptr, &InternalStats::HandleBlobCachePinnedUsage, nullptr,
-          nullptr}},
-};
+const UnorderedMap<std::string, DBPropertyInfo>&
+InternalStats::GetPptNameToInfo() {
+  static const UnorderedMap<std::string, DBPropertyInfo> ppt_name_to_info = {
+      {DB::Properties::GetNumFilesAtLevelPrefix(),
+       {false, &InternalStats::HandleNumFilesAtLevel, nullptr, nullptr,
+        nullptr}},
+      {DB::Properties::GetCompressionRatioAtLevelPrefix(),
+       {false, &InternalStats::HandleCompressionRatioAtLevelPrefix, nullptr,
+        nullptr, nullptr}},
+      {DB::Properties::GetLevelStats(),
+       {false, &InternalStats::HandleLevelStats, nullptr, nullptr, nullptr}},
+      {DB::Properties::GetStats(),
+       {false, &InternalStats::HandleStats, nullptr, nullptr, nullptr}},
+      {DB::Properties::GetCFStats(),
+       {false, &InternalStats::HandleCFStats, nullptr,
+        &InternalStats::HandleCFMapStats, nullptr}},
+      {InternalStats::GetPeriodicCFStats(),
+       {false, &InternalStats::HandleCFStatsPeriodic, nullptr, nullptr,
+        nullptr}},
+      {DB::Properties::GetCFStatsNoFileHistogram(),
+       {false, &InternalStats::HandleCFStatsNoFileHistogram, nullptr, nullptr,
+        nullptr}},
+      {DB::Properties::GetCFFileHistogram(),
+       {false, &InternalStats::HandleCFFileHistogram, nullptr, nullptr,
+        nullptr}},
+      {DB::Properties::GetCFWriteStallStats(),
+       {false, &InternalStats::HandleCFWriteStallStats, nullptr,
+        &InternalStats::HandleCFWriteStallStatsMap, nullptr}},
+      {DB::Properties::GetDBStats(),
+       {false, &InternalStats::HandleDBStats, nullptr,
+        &InternalStats::HandleDBMapStats, nullptr}},
+      {DB::Properties::GetDBWriteStallStats(),
+       {false, &InternalStats::HandleDBWriteStallStats, nullptr,
+        &InternalStats::HandleDBWriteStallStatsMap, nullptr}},
+      {DB::Properties::GetBlockCacheEntryStats(),
+       {true, &InternalStats::HandleBlockCacheEntryStats, nullptr,
+        &InternalStats::HandleBlockCacheEntryStatsMap, nullptr}},
+      {DB::Properties::GetFastBlockCacheEntryStats(),
+       {true, &InternalStats::HandleFastBlockCacheEntryStats, nullptr,
+        &InternalStats::HandleFastBlockCacheEntryStatsMap, nullptr}},
+      {DB::Properties::GetSSTables(),
+       {false, &InternalStats::HandleSsTables, nullptr, nullptr, nullptr}},
+      {DB::Properties::GetAggregatedTableProperties(),
+       {false, &InternalStats::HandleAggregatedTableProperties, nullptr,
+        &InternalStats::HandleAggregatedTablePropertiesMap, nullptr}},
+      {DB::Properties::GetAggregatedTablePropertiesAtLevel(),
+       {false, &InternalStats::HandleAggregatedTablePropertiesAtLevel, nullptr,
+        &InternalStats::HandleAggregatedTablePropertiesAtLevelMap, nullptr}},
+      {DB::Properties::GetNumImmutableMemTable(),
+       {false, nullptr, &InternalStats::HandleNumImmutableMemTable, nullptr,
+        nullptr}},
+      {DB::Properties::GetNumImmutableMemTableFlushed(),
+       {false, nullptr, &InternalStats::HandleNumImmutableMemTableFlushed,
+        nullptr, nullptr}},
+      {DB::Properties::GetMemTableFlushPending(),
+       {false, nullptr, &InternalStats::HandleMemTableFlushPending, nullptr,
+        nullptr}},
+      {DB::Properties::GetCompactionPending(),
+       {false, nullptr, &InternalStats::HandleCompactionPending, nullptr,
+        nullptr}},
+      {DB::Properties::GetBackgroundErrors(),
+       {false, nullptr, &InternalStats::HandleBackgroundErrors, nullptr,
+        nullptr}},
+      {DB::Properties::GetCurSizeActiveMemTable(),
+       {false, nullptr, &InternalStats::HandleCurSizeActiveMemTable, nullptr,
+        nullptr}},
+      {DB::Properties::GetCurSizeAllMemTables(),
+       {false, nullptr, &InternalStats::HandleCurSizeAllMemTables, nullptr,
+        nullptr}},
+      {DB::Properties::GetSizeAllMemTables(),
+       {false, nullptr, &InternalStats::HandleSizeAllMemTables, nullptr,
+        nullptr}},
+      {DB::Properties::GetNumEntriesActiveMemTable(),
+       {false, nullptr, &InternalStats::HandleNumEntriesActiveMemTable, nullptr,
+        nullptr}},
+      {DB::Properties::GetNumEntriesImmMemTables(),
+       {false, nullptr, &InternalStats::HandleNumEntriesImmMemTables, nullptr,
+        nullptr}},
+      {DB::Properties::GetNumDeletesActiveMemTable(),
+       {false, nullptr, &InternalStats::HandleNumDeletesActiveMemTable, nullptr,
+        nullptr}},
+      {DB::Properties::GetNumDeletesImmMemTables(),
+       {false, nullptr, &InternalStats::HandleNumDeletesImmMemTables, nullptr,
+        nullptr}},
+      {DB::Properties::GetEstimateNumKeys(),
+       {false, nullptr, &InternalStats::HandleEstimateNumKeys, nullptr,
+        nullptr}},
+      {DB::Properties::GetEstimateTableReadersMem(),
+       {true, nullptr, &InternalStats::HandleEstimateTableReadersMem, nullptr,
+        nullptr}},
+      {DB::Properties::GetIsFileDeletionsEnabled(),
+       {false, nullptr, &InternalStats::HandleIsFileDeletionsEnabled, nullptr,
+        nullptr}},
+      {DB::Properties::GetNumSnapshots(),
+       {false, nullptr, &InternalStats::HandleNumSnapshots, nullptr, nullptr}},
+      {DB::Properties::GetOldestSnapshotTime(),
+       {false, nullptr, &InternalStats::HandleOldestSnapshotTime, nullptr,
+        nullptr}},
+      {DB::Properties::GetOldestSnapshotSequence(),
+       {false, nullptr, &InternalStats::HandleOldestSnapshotSequence, nullptr,
+        nullptr}},
+      {DB::Properties::GetNumLiveVersions(),
+       {false, nullptr, &InternalStats::HandleNumLiveVersions, nullptr,
+        nullptr}},
+      {DB::Properties::GetCurrentSuperVersionNumber(),
+       {false, nullptr, &InternalStats::HandleCurrentSuperVersionNumber,
+        nullptr, nullptr}},
+      {DB::Properties::GetEstimateLiveDataSize(),
+       {true, nullptr, &InternalStats::HandleEstimateLiveDataSize, nullptr,
+        nullptr}},
+      {DB::Properties::GetMinLogNumberToKeep(),
+       {false, nullptr, &InternalStats::HandleMinLogNumberToKeep, nullptr,
+        nullptr}},
+      {DB::Properties::GetMinObsoleteSstNumberToKeep(),
+       {false, nullptr, &InternalStats::HandleMinObsoleteSstNumberToKeep,
+        nullptr, nullptr}},
+      {DB::Properties::GetBaseLevel(),
+       {false, nullptr, &InternalStats::HandleBaseLevel, nullptr, nullptr}},
+      {DB::Properties::GetTotalSstFilesSize(),
+       {false, nullptr, &InternalStats::HandleTotalSstFilesSize, nullptr,
+        nullptr}},
+      {DB::Properties::GetLiveSstFilesSize(),
+       {false, nullptr, &InternalStats::HandleLiveSstFilesSize, nullptr,
+        nullptr}},
+      {DB::Properties::GetLiveSstFilesSizeAtTemperature(),
+       {false, &InternalStats::HandleLiveSstFilesSizeAtTemperature, nullptr,
+        nullptr, nullptr}},
+      {DB::Properties::GetObsoleteSstFilesSize(),
+       {false, nullptr, &InternalStats::HandleObsoleteSstFilesSize, nullptr,
+        nullptr}},
+      {DB::Properties::GetEstimatePendingCompactionBytes(),
+       {false, nullptr, &InternalStats::HandleEstimatePendingCompactionBytes,
+        nullptr, nullptr}},
+      {DB::Properties::GetNumRunningFlushes(),
+       {false, nullptr, &InternalStats::HandleNumRunningFlushes, nullptr,
+        nullptr}},
+      {DB::Properties::GetNumRunningCompactions(),
+       {false, nullptr, &InternalStats::HandleNumRunningCompactions, nullptr,
+        nullptr}},
+      {DB::Properties::GetActualDelayedWriteRate(),
+       {false, nullptr, &InternalStats::HandleActualDelayedWriteRate, nullptr,
+        nullptr}},
+      {DB::Properties::GetIsWriteStopped(),
+       {false, nullptr, &InternalStats::HandleIsWriteStopped, nullptr,
+        nullptr}},
+      {DB::Properties::GetEstimateOldestKeyTime(),
+       {false, nullptr, &InternalStats::HandleEstimateOldestKeyTime, nullptr,
+        nullptr}},
+      {DB::Properties::GetBlockCacheCapacity(),
+       {false, nullptr, &InternalStats::HandleBlockCacheCapacity, nullptr,
+        nullptr}},
+      {DB::Properties::GetBlockCacheUsage(),
+       {false, nullptr, &InternalStats::HandleBlockCacheUsage, nullptr,
+        nullptr}},
+      {DB::Properties::GetBlockCachePinnedUsage(),
+       {false, nullptr, &InternalStats::HandleBlockCachePinnedUsage, nullptr,
+        nullptr}},
+      {DB::Properties::GetOptionsStatistics(),
+       {true, nullptr, nullptr, nullptr,
+        &DBImpl::GetPropertyHandleOptionsStatistics}},
+      {DB::Properties::GetNumBlobFiles(),
+       {false, nullptr, &InternalStats::HandleNumBlobFiles, nullptr, nullptr}},
+      {DB::Properties::GetBlobStats(),
+       {false, &InternalStats::HandleBlobStats, nullptr, nullptr, nullptr}},
+      {DB::Properties::GetTotalBlobFileSize(),
+       {false, nullptr, &InternalStats::HandleTotalBlobFileSize, nullptr,
+        nullptr}},
+      {DB::Properties::GetLiveBlobFileSize(),
+       {false, nullptr, &InternalStats::HandleLiveBlobFileSize, nullptr,
+        nullptr}},
+      {DB::Properties::GetLiveBlobFileGarbageSize(),
+       {false, nullptr, &InternalStats::HandleLiveBlobFileGarbageSize, nullptr,
+        nullptr}},
+      {DB::Properties::GetBlobCacheCapacity(),
+       {false, nullptr, &InternalStats::HandleBlobCacheCapacity, nullptr,
+        nullptr}},
+      {DB::Properties::GetBlobCacheUsage(),
+       {false, nullptr, &InternalStats::HandleBlobCacheUsage, nullptr,
+        nullptr}},
+      {DB::Properties::GetBlobCachePinnedUsage(),
+       {false, nullptr, &InternalStats::HandleBlobCachePinnedUsage, nullptr,
+        nullptr}},
+  };
+  return ppt_name_to_info;
+}
 
 InternalStats::InternalStats(int num_levels, SystemClock* clock,
                              ColumnFamilyData* cfd)
@@ -959,8 +1177,8 @@ bool InternalStats::HandleBlobCachePinnedUsage(uint64_t* value, DBImpl* /*db*/,
 
 const DBPropertyInfo* GetPropertyInfo(const Slice& property) {
   std::string ppt_name = GetPropertyNameAndArg(property).first.ToString();
-  auto ppt_info_iter = InternalStats::ppt_name_to_info.find(ppt_name);
-  if (ppt_info_iter == InternalStats::ppt_name_to_info.end()) {
+  auto ppt_info_iter = InternalStats::GetPptNameToInfo().find(ppt_name);
+  if (ppt_info_iter == InternalStats::GetPptNameToInfo().end()) {
     return nullptr;
   }
   return &ppt_info_iter->second;
@@ -1534,7 +1752,7 @@ void InternalStats::DumpDBMapStats(
     std::map<std::string, std::string>* db_stats) {
   for (int i = 0; i < static_cast<int>(kIntStatsNumMax); ++i) {
     InternalDBStatsType type = static_cast<InternalDBStatsType>(i);
-    (*db_stats)[db_stats_type_to_info.at(type).property_name] =
+    (*db_stats)[GetDBStatsTypeToInfo().at(type).property_name] =
         std::to_string(GetDBStats(type));
   }
   double seconds_up = (clock_->NowMicros() - started_at_) / kMicrosInSec;
@@ -1735,7 +1953,7 @@ void InternalStats::DumpCFMapStats(
       auto stat_type = stat_ent.first;
       auto key_str =
           "compaction." + level_str + "." +
-          InternalStats::compaction_level_stats.at(stat_type).property_name;
+          InternalStats::GetCompactionLevelStats().at(stat_type).property_name;
       (*cf_stats)[key_str] = std::to_string(stat_ent.second);
     }
   }
@@ -2186,9 +2404,9 @@ class BlockCachePropertyAggregator : public IntPropertyAggregator {
 
 std::unique_ptr<IntPropertyAggregator> CreateIntPropertyAggregator(
     const Slice& property) {
-  if (property == DB::Properties::kBlockCacheCapacity ||
-      property == DB::Properties::kBlockCacheUsage ||
-      property == DB::Properties::kBlockCachePinnedUsage) {
+  if (property == DB::Properties::GetBlockCacheCapacity() ||
+      property == DB::Properties::GetBlockCacheUsage() ||
+      property == DB::Properties::GetBlockCachePinnedUsage()) {
     return std::make_unique<BlockCachePropertyAggregator>();
   } else {
     return std::make_unique<SumPropertyAggregator>();

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -101,7 +101,7 @@ struct DBStatInfo {
 
 class InternalStats {
  public:
-  static const std::map<LevelStatType, LevelStat> compaction_level_stats;
+  static const std::map<LevelStatType, LevelStat>& GetCompactionLevelStats();
 
   enum InternalCFStatsType {
     MEMTABLE_LIMIT_DELAYS,
@@ -149,7 +149,8 @@ class InternalStats {
     kIntStatsNumMax,
   };
 
-  static const std::map<InternalDBStatsType, DBStatInfo> db_stats_type_to_info;
+  static const std::map<InternalDBStatsType, DBStatInfo>&
+  GetDBStatsTypeToInfo();
 
   InternalStats(int num_levels, SystemClock* clock, ColumnFamilyData* cfd);
 
@@ -609,9 +610,9 @@ class InternalStats {
 
   // Store a mapping from the user-facing DB::Properties string to our
   // DBPropertyInfo struct used internally for retrieving properties.
-  static const UnorderedMap<std::string, DBPropertyInfo> ppt_name_to_info;
+  static const UnorderedMap<std::string, DBPropertyInfo>& GetPptNameToInfo();
 
-  static const std::string kPeriodicCFStats;
+  static const std::string& GetPeriodicCFStats();
 
  private:
   void DumpDBMapStats(std::map<std::string, std::string>* db_stats);
@@ -665,7 +666,7 @@ class InternalStats {
   // a periodic dump.
   int no_cf_change_period_since_dump_ = 0;
   uint64_t last_histogram_num = std::numeric_limits<uint64_t>::max();
-  static const int kMaxNoChangePeriodSinceDump;
+  static constexpr int kMaxNoChangePeriodSinceDump = 8;
 
   // Used to compute per-interval statistics
   struct CFStatsSnapshot {

--- a/db/options_file_test.cc
+++ b/db/options_file_test.cc
@@ -92,7 +92,7 @@ TEST_F(OptionsFileTest, OptionsFileName) {
   const uint64_t kTempOptionsFileNum = 54352;
   auto temp_options_file_name = TempOptionsFileName("", kTempOptionsFileNum);
   ASSERT_TRUE(ParseFileName(temp_options_file_name, &number, &type, nullptr));
-  ASSERT_NE(temp_options_file_name.find(kTempFileNameSuffix),
+  ASSERT_NE(temp_options_file_name.find(GetTempFileNameSuffix()),
             std::string::npos);
   ASSERT_EQ(type, kTempFile);
   ASSERT_EQ(number, kTempOptionsFileNum);

--- a/db/periodic_task_scheduler.cc
+++ b/db/periodic_task_scheduler.cc
@@ -21,23 +21,31 @@ namespace ROCKSDB_NAMESPACE {
 // infrequently.
 static port::Mutex timer_mutex;
 
-static const std::map<PeriodicTaskType, uint64_t> kDefaultPeriodSeconds = {
-    {PeriodicTaskType::kDumpStats, kInvalidPeriodSec},
-    {PeriodicTaskType::kPersistStats, kInvalidPeriodSec},
-    {PeriodicTaskType::kFlushInfoLog, 10},
-    {PeriodicTaskType::kRecordSeqnoTime, kInvalidPeriodSec},
-};
+static const std::map<PeriodicTaskType, uint64_t>& GetDefaultPeriodSeconds() {
+  static const std::map<PeriodicTaskType, uint64_t> kDefaultPeriodSeconds = {
+      {PeriodicTaskType::kDumpStats, kInvalidPeriodSec},
+      {PeriodicTaskType::kPersistStats, kInvalidPeriodSec},
+      {PeriodicTaskType::kFlushInfoLog, 10},
+      {PeriodicTaskType::kRecordSeqnoTime, kInvalidPeriodSec},
+  };
+  return kDefaultPeriodSeconds;
+}
 
-static const std::map<PeriodicTaskType, std::string> kPeriodicTaskTypeNames = {
-    {PeriodicTaskType::kDumpStats, "dump_st"},
-    {PeriodicTaskType::kPersistStats, "pst_st"},
-    {PeriodicTaskType::kFlushInfoLog, "flush_info_log"},
-    {PeriodicTaskType::kRecordSeqnoTime, "record_seq_time"},
-};
+static const std::map<PeriodicTaskType, std::string>&
+GetPeriodicTaskTypeNames() {
+  static const std::map<PeriodicTaskType, std::string> kPeriodicTaskTypeNames =
+      {
+          {PeriodicTaskType::kDumpStats, "dump_st"},
+          {PeriodicTaskType::kPersistStats, "pst_st"},
+          {PeriodicTaskType::kFlushInfoLog, "flush_info_log"},
+          {PeriodicTaskType::kRecordSeqnoTime, "record_seq_time"},
+      };
+  return kPeriodicTaskTypeNames;
+}
 
 Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
                                        const PeriodicTaskFunc& fn) {
-  return Register(task_type, fn, kDefaultPeriodSeconds.at(task_type));
+  return Register(task_type, fn, GetDefaultPeriodSeconds().at(task_type));
 }
 
 Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
@@ -63,7 +71,7 @@ Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,
   timer_->Start();
   // put task type name as prefix, for easy debug
   std::string unique_id =
-      kPeriodicTaskTypeNames.at(task_type) + std::to_string(id_++);
+      GetPeriodicTaskTypeNames().at(task_type) + std::to_string(id_++);
 
   bool succeeded = timer_->Add(
       fn, unique_id,

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-
 #include "util/timer.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -495,8 +495,9 @@ inline enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
 inline enum ROCKSDB_NAMESPACE::ChecksumType StringToChecksumType(
     const char* ctype) {
   assert(ctype);
-  auto iter = ROCKSDB_NAMESPACE::checksum_type_string_map.find(ctype);
-  if (iter != ROCKSDB_NAMESPACE::checksum_type_string_map.end()) {
+  auto iter =
+      ROCKSDB_NAMESPACE::OptionsHelper::GetChecksumTypeStringMap().find(ctype);
+  if (iter != ROCKSDB_NAMESPACE::OptionsHelper::GetChecksumTypeStringMap(.end()) {
     return iter->second;
   }
   fprintf(stderr, "Cannot parse checksum type '%s'\n", ctype);
@@ -505,11 +506,12 @@ inline enum ROCKSDB_NAMESPACE::ChecksumType StringToChecksumType(
 
 inline std::string ChecksumTypeToString(ROCKSDB_NAMESPACE::ChecksumType ctype) {
   auto iter = std::find_if(
-      ROCKSDB_NAMESPACE::checksum_type_string_map.begin(),
-      ROCKSDB_NAMESPACE::checksum_type_string_map.end(),
+      ROCKSDB_NAMESPACE::OptionsHelper::GetChecksumTypeStringMap(.begin(),
+      ROCKSDB_NAMESPACE::OptionsHelper::GetChecksumTypeStringMap(.end(),
       [&](const std::pair<std::string, ROCKSDB_NAMESPACE::ChecksumType>&
-              name_and_enum_val) { return name_and_enum_val.second == ctype; });
-  assert(iter != ROCKSDB_NAMESPACE::checksum_type_string_map.end());
+              name_and_enum_val) {
+    return name_and_enum_val.second == ctype; });
+  assert(iter != ROCKSDB_NAMESPACE::OptionsHelper::GetChecksumTypeStringMap(.end());
   return iter->first;
 }
 
@@ -517,21 +519,23 @@ inline enum ROCKSDB_NAMESPACE::Temperature StringToTemperature(
     const char* ctype) {
   assert(ctype);
   auto iter = std::find_if(
-      ROCKSDB_NAMESPACE::temperature_to_string.begin(),
-      ROCKSDB_NAMESPACE::temperature_to_string.end(),
+      ROCKSDB_NAMESPACE::OptionsHelper::GetTemperatureToString().begin(),
+      ROCKSDB_NAMESPACE::OptionsHelper::GetTemperatureToString().end(),
       [&](const std::pair<ROCKSDB_NAMESPACE::Temperature, std::string>&
               temp_and_string_val) {
         return ctype == temp_and_string_val.second;
       });
-  assert(iter != ROCKSDB_NAMESPACE::temperature_to_string.end());
+  assert(iter !=
+         ROCKSDB_NAMESPACE::OptionsHelper::GetTemperatureToString().end());
   return iter->first;
 }
 
 inline std::string TemperatureToString(
     ROCKSDB_NAMESPACE::Temperature temperature) {
-  auto iter =
-      ROCKSDB_NAMESPACE::OptionsHelper::temperature_to_string.find(temperature);
-  assert(iter != ROCKSDB_NAMESPACE::OptionsHelper::temperature_to_string.end());
+  auto iter = ROCKSDB_NAMESPACE::OptionsHelper::GetTemperatureToString().find(
+      temperature);
+  assert(iter !=
+         ROCKSDB_NAMESPACE::OptionsHelper::GetTemperatureToString().end());
   return iter->second;
 }
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2596,24 +2596,24 @@ Status StressTest::TestCheckpoint(ThreadState* thread,
 
 void StressTest::TestGetProperty(ThreadState* thread) const {
   std::unordered_set<std::string> levelPropertyNames = {
-      DB::Properties::kAggregatedTablePropertiesAtLevel,
-      DB::Properties::kCompressionRatioAtLevelPrefix,
-      DB::Properties::kNumFilesAtLevelPrefix,
+      DB::Properties::GetAggregatedTablePropertiesAtLevel(),
+      DB::Properties::GetCompressionRatioAtLevelPrefix(),
+      DB::Properties::GetNumFilesAtLevelPrefix(),
   };
   std::unordered_set<std::string> unknownPropertyNames = {
-      DB::Properties::kEstimateOldestKeyTime,
-      DB::Properties::kOptionsStatistics,
+      DB::Properties::GetEstimateOldestKeyTime(),
+      DB::Properties::GetOptionsStatistics(),
       DB::Properties::
-          kLiveSstFilesSizeAtTemperature,  // similar to levelPropertyNames, it
-                                           // requires a number suffix
+          GetLiveSstFilesSizeAtTemperature(),  // similar to levelPropertyNames,
+                                               // it requires a number suffix
   };
   unknownPropertyNames.insert(levelPropertyNames.begin(),
                               levelPropertyNames.end());
 
   std::unordered_set<std::string> blobCachePropertyNames = {
-      DB::Properties::kBlobCacheCapacity,
-      DB::Properties::kBlobCacheUsage,
-      DB::Properties::kBlobCachePinnedUsage,
+      DB::Properties::GetBlobCacheCapacity(),
+      DB::Properties::GetBlobCacheUsage(),
+      DB::Properties::GetBlobCachePinnedUsage(),
   };
   if (db_->GetOptions().blob_cache == nullptr) {
     unknownPropertyNames.insert(blobCachePropertyNames.begin(),
@@ -2621,7 +2621,7 @@ void StressTest::TestGetProperty(ThreadState* thread) const {
   }
 
   std::string prop;
-  for (const auto& ppt_name_and_info : InternalStats::ppt_name_to_info) {
+  for (const auto& ppt_name_and_info : InternalStats::GetPptNameToInfo()) {
     bool res = db_->GetProperty(ppt_name_and_info.first, &prop);
     if (unknownPropertyNames.find(ppt_name_and_info.first) ==
         unknownPropertyNames.end()) {

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -23,14 +23,40 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-const std::string kCurrentFileName = "CURRENT";
-const std::string kOptionsFileNamePrefix = "OPTIONS-";
-const std::string kTempFileNameSuffix = "dbtmp";
+const std::string& GetCurrentFileName() {
+  static const std::string kCurrentFileName = "CURRENT";
+  return kCurrentFileName;
+}
 
-static const std::string kRocksDbTFileExt = "sst";
-static const std::string kLevelDbTFileExt = "ldb";
-static const std::string kRocksDBBlobFileExt = "blob";
-static const std::string kArchivalDirName = "archive";
+const std::string& GetOptionsFileNamePrefix() {
+  static const std::string kOptionsFileNamePrefix = "OPTIONS-";
+  return kOptionsFileNamePrefix;
+}
+
+const std::string& GetTempFileNameSuffix() {
+  static const std::string kTempFileNameSuffix = "dbtmp";
+  return kTempFileNameSuffix;
+}
+
+static const std::string& GetRocksDbFileExt() {
+  static const std::string kRocksDbTFileExt = "sst";
+  return kRocksDbTFileExt;
+}
+
+static const std::string& GetLevelDbFileExt() {
+  static const std::string kLevelDbTFileExt = "ldb";
+  return kLevelDbTFileExt;
+}
+
+static const std::string& GetRocksDBBlobFileExt() {
+  static const std::string kRocksDBBlobFileExt = "blob";
+  return kRocksDBBlobFileExt;
+}
+
+static const std::string& GetArchivalDirName() {
+  static const std::string kArchivalDirName = "archive";
+  return kArchivalDirName;
+}
 
 // Given a path, flatten the path name by replacing all chars not in
 // {[0-9,a-z,A-Z,-,_,.]} with _. And append '_LOG\0' at the end.
@@ -86,44 +112,44 @@ std::string LogFileName(uint64_t number) {
 
 std::string BlobFileName(uint64_t number) {
   assert(number > 0);
-  return MakeFileName(number, kRocksDBBlobFileExt.c_str());
+  return MakeFileName(number, GetRocksDBBlobFileExt().c_str());
 }
 
 std::string BlobFileName(const std::string& blobdirname, uint64_t number) {
   assert(number > 0);
-  return MakeFileName(blobdirname, number, kRocksDBBlobFileExt.c_str());
+  return MakeFileName(blobdirname, number, GetRocksDBBlobFileExt().c_str());
 }
 
 std::string BlobFileName(const std::string& dbname, const std::string& blob_dir,
                          uint64_t number) {
   assert(number > 0);
   return MakeFileName(dbname + "/" + blob_dir, number,
-                      kRocksDBBlobFileExt.c_str());
+                      GetRocksDBBlobFileExt().c_str());
 }
 
 std::string ArchivalDirectory(const std::string& dir) {
-  return dir + "/" + kArchivalDirName;
+  return dir + "/" + GetArchivalDirName();
 }
 std::string ArchivedLogFileName(const std::string& name, uint64_t number) {
   assert(number > 0);
-  return MakeFileName(name + "/" + kArchivalDirName, number, "log");
+  return MakeFileName(name + "/" + GetArchivalDirName(), number, "log");
 }
 
 std::string MakeTableFileName(const std::string& path, uint64_t number) {
-  return MakeFileName(path, number, kRocksDbTFileExt.c_str());
+  return MakeFileName(path, number, GetRocksDbFileExt().c_str());
 }
 
 std::string MakeTableFileName(uint64_t number) {
-  return MakeFileName(number, kRocksDbTFileExt.c_str());
+  return MakeFileName(number, GetRocksDbFileExt().c_str());
 }
 
 std::string Rocks2LevelTableFileName(const std::string& fullname) {
-  assert(fullname.size() > kRocksDbTFileExt.size() + 1);
-  if (fullname.size() <= kRocksDbTFileExt.size() + 1) {
+  assert(fullname.size() > GetRocksDbFileExt().size() + 1);
+  if (fullname.size() <= GetRocksDbFileExt().size() + 1) {
     return "";
   }
-  return fullname.substr(0, fullname.size() - kRocksDbTFileExt.size()) +
-         kLevelDbTFileExt;
+  return fullname.substr(0, fullname.size() - GetRocksDbFileExt().size()) +
+         GetLevelDbFileExt();
 }
 
 uint64_t TableFileNameToNumber(const std::string& name) {
@@ -175,13 +201,13 @@ std::string DescriptorFileName(const std::string& dbname, uint64_t number) {
 }
 
 std::string CurrentFileName(const std::string& dbname) {
-  return dbname + "/" + kCurrentFileName;
+  return dbname + "/" + GetCurrentFileName();
 }
 
 std::string LockFileName(const std::string& dbname) { return dbname + "/LOCK"; }
 
 std::string TempFileName(const std::string& dbname, uint64_t number) {
-  return MakeFileName(dbname, number, kTempFileNameSuffix.c_str());
+  return MakeFileName(dbname, number, GetTempFileNameSuffix().c_str());
 }
 
 InfoLogPrefix::InfoLogPrefix(bool has_log_dir,
@@ -227,7 +253,7 @@ std::string OldInfoLogFileName(const std::string& dbname, uint64_t ts,
 std::string OptionsFileName(uint64_t file_num) {
   char buffer[256];
   snprintf(buffer, sizeof(buffer), "%s%06" PRIu64,
-           kOptionsFileNamePrefix.c_str(), file_num);
+           GetOptionsFileNamePrefix().c_str(), file_num);
   return buffer;
 }
 std::string OptionsFileName(const std::string& dbname, uint64_t file_num) {
@@ -237,8 +263,8 @@ std::string OptionsFileName(const std::string& dbname, uint64_t file_num) {
 std::string TempOptionsFileName(const std::string& dbname, uint64_t file_num) {
   char buffer[256];
   snprintf(buffer, sizeof(buffer), "%s%06" PRIu64 ".%s",
-           kOptionsFileNamePrefix.c_str(), file_num,
-           kTempFileNameSuffix.c_str());
+           GetOptionsFileNamePrefix().c_str(), file_num,
+           GetTempFileNameSuffix().c_str());
   return dbname + "/" + buffer;
 }
 
@@ -324,12 +350,12 @@ bool ParseFileName(const std::string& fname, uint64_t* number,
     }
     *type = kMetaDatabase;
     *number = num;
-  } else if (rest.starts_with(kOptionsFileNamePrefix)) {
+  } else if (rest.starts_with(GetOptionsFileNamePrefix())) {
     uint64_t ts_suffix;
     bool is_temp_file = false;
-    rest.remove_prefix(kOptionsFileNamePrefix.size());
+    rest.remove_prefix(GetOptionsFileNamePrefix().size());
     const std::string kTempFileNameSuffixWithDot =
-        std::string(".") + kTempFileNameSuffix;
+        std::string(".") + GetTempFileNameSuffix();
     if (rest.ends_with(kTempFileNameSuffixWithDot)) {
       rest.remove_suffix(kTempFileNameSuffixWithDot.size());
       is_temp_file = true;
@@ -343,11 +369,11 @@ bool ParseFileName(const std::string& fname, uint64_t* number,
     // Avoid strtoull() to keep filename format independent of the
     // current locale
     bool archive_dir_found = false;
-    if (rest.starts_with(kArchivalDirName)) {
-      if (rest.size() <= kArchivalDirName.size()) {
+    if (rest.starts_with(GetArchivalDirName())) {
+      if (rest.size() <= GetArchivalDirName().size()) {
         return false;
       }
-      rest.remove_prefix(kArchivalDirName.size() +
+      rest.remove_prefix(GetArchivalDirName().size() +
                          1);  // Add 1 to remove / also
       if (log_type) {
         *log_type = kArchivedLogFile;
@@ -371,12 +397,12 @@ bool ParseFileName(const std::string& fname, uint64_t* number,
       }
     } else if (archive_dir_found) {
       return false;  // Archive dir can contain only log files
-    } else if (suffix == Slice(kRocksDbTFileExt) ||
-               suffix == Slice(kLevelDbTFileExt)) {
+    } else if (suffix == Slice(GetRocksDbFileExt()) ||
+               suffix == Slice(GetLevelDbFileExt())) {
       *type = kTableFile;
-    } else if (suffix == Slice(kRocksDBBlobFileExt)) {
+    } else if (suffix == Slice(GetRocksDBBlobFileExt())) {
       *type = kBlobFile;
-    } else if (suffix == Slice(kTempFileNameSuffix)) {
+    } else if (suffix == Slice(GetTempFileNameSuffix())) {
       *type = kTempFile;
     } else {
       return false;

--- a/file/filename.h
+++ b/file/filename.h
@@ -76,7 +76,7 @@ std::string TableFileName(const std::vector<DbPath>& db_paths, uint64_t number,
                           uint32_t path_id);
 
 // Sufficient buffer size for FormatFileNumber.
-const size_t kFormatFileNumberBufSize = 38;
+constexpr size_t kFormatFileNumberBufSize = 38;
 
 void FormatFileNumber(uint64_t number, uint32_t path_id, char* out_buf,
                       size_t out_buf_size);
@@ -88,7 +88,7 @@ std::string DescriptorFileName(const std::string& dbname, uint64_t number);
 
 std::string DescriptorFileName(uint64_t number);
 
-extern const std::string kCurrentFileName;  // = "CURRENT"
+const std::string& GetCurrentFileName();  // = "CURRENT"
 
 // Return the name of the current file.  This file contains the name
 // of the current manifest file.  The result will be prefixed with
@@ -123,8 +123,8 @@ std::string OldInfoLogFileName(const std::string& dbname, uint64_t ts,
                                const std::string& db_path = "",
                                const std::string& log_dir = "");
 
-extern const std::string kOptionsFileNamePrefix;  // = "OPTIONS-"
-extern const std::string kTempFileNameSuffix;     // = "dbtmp"
+const std::string& GetOptionsFileNamePrefix();  // = "OPTIONS-"
+const std::string& GetTempFileNameSuffix();     // = "dbtmp"
 
 // Return a options file name given the "dbname" and file number.
 // Format:  OPTIONS-[number].dbtmp

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1055,187 +1055,187 @@ class DB {
     //  "rocksdb.num-files-at-level<N>" - returns string containing the number
     //      of files at level <N>, where <N> is an ASCII representation of a
     //      level number (e.g., "0").
-    static const std::string kNumFilesAtLevelPrefix;
+    static const std::string& GetNumFilesAtLevelPrefix();
 
     //  "rocksdb.compression-ratio-at-level<N>" - returns string containing the
     //      compression ratio of data at level <N>, where <N> is an ASCII
     //      representation of a level number (e.g., "0"). Here, compression
     //      ratio is defined as uncompressed data size / compressed file size.
     //      Returns "-1.0" if no open files at level <N>.
-    static const std::string kCompressionRatioAtLevelPrefix;
+    static const std::string& GetCompressionRatioAtLevelPrefix();
 
     //  "rocksdb.stats" - returns a multi-line string containing the data
     //      described by kCFStats followed by the data described by kDBStats.
-    static const std::string kStats;
+    static const std::string& GetStats();
 
     //  "rocksdb.sstables" - returns a multi-line string summarizing current
     //      SST files.
-    static const std::string kSSTables;
+    static const std::string& GetSSTables();
 
     //  "rocksdb.cfstats" - Raw data from "rocksdb.cfstats-no-file-histogram"
     //      and "rocksdb.cf-file-histogram" as a "map" property.
-    static const std::string kCFStats;
+    static const std::string& GetCFStats();
 
     //  "rocksdb.cfstats-no-file-histogram" - returns a multi-line string with
     //      general column family stats per-level over db's lifetime ("L<n>"),
     //      aggregated over db's lifetime ("Sum"), and aggregated over the
     //      interval since the last retrieval ("Int").
-    static const std::string kCFStatsNoFileHistogram;
+    static const std::string& GetCFStatsNoFileHistogram();
 
     //  "rocksdb.cf-file-histogram" - print out how many file reads to every
     //      level, as well as the histogram of latency of single requests.
-    static const std::string kCFFileHistogram;
+    static const std::string& GetCFFileHistogram();
 
     // "rocksdb.cf-write-stall-stats" - returns a multi-line string or
     //      map with statistics on CF-scope write stalls for a given CF
     // See`WriteStallStatsMapKeys` for structured representation of keys
     // available in the map form.
-    static const std::string kCFWriteStallStats;
+    static const std::string& GetCFWriteStallStats();
 
     // "rocksdb.db-write-stall-stats" - returns a multi-line string or
     //      map with statistics on DB-scope write stalls
     // See`WriteStallStatsMapKeys` for structured representation of keys
     // available in the map form.
-    static const std::string kDBWriteStallStats;
+    static const std::string& GetDBWriteStallStats();
 
     //  "rocksdb.dbstats" - As a string property, returns a multi-line string
     //      with general database stats, both cumulative (over the db's
     //      lifetime) and interval (since the last retrieval of kDBStats).
     //      As a map property, returns cumulative stats only and does not
     //      update the baseline for the interval stats.
-    static const std::string kDBStats;
+    static const std::string& GetDBStats();
 
     //  "rocksdb.levelstats" - returns multi-line string containing the number
     //      of files per level and total size of each level (MB).
-    static const std::string kLevelStats;
+    static const std::string& GetLevelStats();
 
     //  "rocksdb.block-cache-entry-stats" - returns a multi-line string or
     //      map with statistics on block cache usage. See
     //      `BlockCacheEntryStatsMapKeys` for structured representation of keys
     //      available in the map form.
-    static const std::string kBlockCacheEntryStats;
+    static const std::string& GetBlockCacheEntryStats();
 
     //  "rocksdb.fast-block-cache-entry-stats" - same as above, but returns
     //      stale values more frequently to reduce overhead and latency.
-    static const std::string kFastBlockCacheEntryStats;
+    static const std::string& GetFastBlockCacheEntryStats();
 
     //  "rocksdb.num-immutable-mem-table" - returns number of immutable
     //      memtables that have not yet been flushed.
-    static const std::string kNumImmutableMemTable;
+    static const std::string& GetNumImmutableMemTable();
 
     //  "rocksdb.num-immutable-mem-table-flushed" - returns number of immutable
     //      memtables that have already been flushed.
-    static const std::string kNumImmutableMemTableFlushed;
+    static const std::string& GetNumImmutableMemTableFlushed();
 
     //  "rocksdb.mem-table-flush-pending" - returns 1 if a memtable flush is
     //      pending; otherwise, returns 0.
-    static const std::string kMemTableFlushPending;
+    static const std::string& GetMemTableFlushPending();
 
     //  "rocksdb.num-running-flushes" - returns the number of currently running
     //      flushes.
-    static const std::string kNumRunningFlushes;
+    static const std::string& GetNumRunningFlushes();
 
     //  "rocksdb.compaction-pending" - returns 1 if at least one compaction is
     //      pending; otherwise, returns 0.
-    static const std::string kCompactionPending;
+    static const std::string& GetCompactionPending();
 
     //  "rocksdb.num-running-compactions" - returns the number of currently
     //      running compactions.
-    static const std::string kNumRunningCompactions;
+    static const std::string& GetNumRunningCompactions();
 
     //  "rocksdb.background-errors" - returns accumulated number of background
     //      errors.
-    static const std::string kBackgroundErrors;
+    static const std::string& GetBackgroundErrors();
 
     //  "rocksdb.cur-size-active-mem-table" - returns approximate size of active
     //      memtable (bytes).
-    static const std::string kCurSizeActiveMemTable;
+    static const std::string& GetCurSizeActiveMemTable();
 
     //  "rocksdb.cur-size-all-mem-tables" - returns approximate size of active
     //      and unflushed immutable memtables (bytes).
-    static const std::string kCurSizeAllMemTables;
+    static const std::string& GetCurSizeAllMemTables();
 
     //  "rocksdb.size-all-mem-tables" - returns approximate size of active,
     //      unflushed immutable, and pinned immutable memtables (bytes).
-    static const std::string kSizeAllMemTables;
+    static const std::string& GetSizeAllMemTables();
 
     //  "rocksdb.num-entries-active-mem-table" - returns total number of entries
     //      in the active memtable.
-    static const std::string kNumEntriesActiveMemTable;
+    static const std::string& GetNumEntriesActiveMemTable();
 
     //  "rocksdb.num-entries-imm-mem-tables" - returns total number of entries
     //      in the unflushed immutable memtables.
-    static const std::string kNumEntriesImmMemTables;
+    static const std::string& GetNumEntriesImmMemTables();
 
     //  "rocksdb.num-deletes-active-mem-table" - returns total number of delete
     //      entries in the active memtable.
-    static const std::string kNumDeletesActiveMemTable;
+    static const std::string& GetNumDeletesActiveMemTable();
 
     //  "rocksdb.num-deletes-imm-mem-tables" - returns total number of delete
     //      entries in the unflushed immutable memtables.
-    static const std::string kNumDeletesImmMemTables;
+    static const std::string& GetNumDeletesImmMemTables();
 
     //  "rocksdb.estimate-num-keys" - returns estimated number of total keys in
     //      the active and unflushed immutable memtables and storage.
-    static const std::string kEstimateNumKeys;
+    static const std::string& GetEstimateNumKeys();
 
     //  "rocksdb.estimate-table-readers-mem" - returns estimated memory used for
     //      reading SST tables, excluding memory used in block cache (e.g.,
     //      filter and index blocks).
-    static const std::string kEstimateTableReadersMem;
+    static const std::string& GetEstimateTableReadersMem();
 
     //  "rocksdb.is-file-deletions-enabled" - returns 0 if deletion of obsolete
     //      files is enabled; otherwise, returns a non-zero number.
     //  This name may be misleading because true(non-zero) means disable,
     //  but we keep the name for backward compatibility.
-    static const std::string kIsFileDeletionsEnabled;
+    static const std::string& GetIsFileDeletionsEnabled();
 
     //  "rocksdb.num-snapshots" - returns number of unreleased snapshots of the
     //      database.
-    static const std::string kNumSnapshots;
+    static const std::string& GetNumSnapshots();
 
     //  "rocksdb.oldest-snapshot-time" - returns number representing unix
     //      timestamp of oldest unreleased snapshot.
-    static const std::string kOldestSnapshotTime;
+    static const std::string& GetOldestSnapshotTime();
 
     //  "rocksdb.oldest-snapshot-sequence" - returns number representing
     //      sequence number of oldest unreleased snapshot.
-    static const std::string kOldestSnapshotSequence;
+    static const std::string& GetOldestSnapshotSequence();
 
     //  "rocksdb.num-live-versions" - returns number of live versions. `Version`
     //      is an internal data structure. See version_set.h for details. More
     //      live versions often mean more SST files are held from being deleted,
     //      by iterators or unfinished compactions.
-    static const std::string kNumLiveVersions;
+    static const std::string& GetNumLiveVersions();
 
     //  "rocksdb.current-super-version-number" - returns number of current LSM
     //  version. It is a uint64_t integer number, incremented after there is
     //  any change to the LSM tree. The number is not preserved after restarting
     //  the DB. After DB restart, it will start from 0 again.
-    static const std::string kCurrentSuperVersionNumber;
+    static const std::string& GetCurrentSuperVersionNumber();
 
     //  "rocksdb.estimate-live-data-size" - returns an estimate of the amount of
     //      live data in bytes. For BlobDB, it also includes the exact value of
     //      live bytes in the blob files of the version.
-    static const std::string kEstimateLiveDataSize;
+    static const std::string& GetEstimateLiveDataSize();
 
     //  "rocksdb.min-log-number-to-keep" - return the minimum log number of the
     //      log files that should be kept.
-    static const std::string kMinLogNumberToKeep;
+    static const std::string& GetMinLogNumberToKeep();
 
     //  "rocksdb.min-obsolete-sst-number-to-keep" - return the minimum file
     //      number for an obsolete SST to be kept. The max value of `uint64_t`
     //      will be returned if all obsolete files can be deleted.
-    static const std::string kMinObsoleteSstNumberToKeep;
+    static const std::string& GetMinObsoleteSstNumberToKeep();
 
     //  "rocksdb.total-sst-files-size" - returns total size (bytes) of all SST
     //      files belonging to any of the CF's versions.
     //  WARNING: may slow down online queries if there are too many files.
-    static const std::string kTotalSstFilesSize;
+    static const std::string& GetTotalSstFilesSize();
 
     //  "rocksdb.live-sst-files-size" - returns total size (bytes) of all SST
     //      files belong to the CF's current version.
-    static const std::string kLiveSstFilesSize;
+    static const std::string& GetLiveSstFilesSize();
 
     //  "rocksdb.obsolete-sst-files-size" - returns total size (bytes) of all
     //      SST files that became obsolete but have not yet been deleted or
@@ -1244,92 +1244,92 @@ class DB {
     //
     //      N.B. Unlike the other "*SstFilesSize" properties, this property
     //      includes SST files that originated in any of the DB's CFs.
-    static const std::string kObsoleteSstFilesSize;
+    static const std::string& GetObsoleteSstFilesSize();
 
     // "rocksdb.live_sst_files_size_at_temperature" - returns total size (bytes)
     //      of SST files at all certain file temperature
-    static const std::string kLiveSstFilesSizeAtTemperature;
+    static const std::string& GetLiveSstFilesSizeAtTemperature();
 
     //  "rocksdb.base-level" - returns number of level to which L0 data will be
     //      compacted.
-    static const std::string kBaseLevel;
+    static const std::string& GetBaseLevel();
 
     //  "rocksdb.estimate-pending-compaction-bytes" - returns estimated total
     //      number of bytes compaction needs to rewrite to get all levels down
     //      to under target size. Not valid for other compactions than level-
     //      based.
-    static const std::string kEstimatePendingCompactionBytes;
+    static const std::string& GetEstimatePendingCompactionBytes();
 
     //  "rocksdb.aggregated-table-properties" - returns a string or map
     //      representation of the aggregated table properties of the target
     //      column family. Only properties that make sense for aggregation
     //      are included.
-    static const std::string kAggregatedTableProperties;
+    static const std::string& GetAggregatedTableProperties();
 
     //  "rocksdb.aggregated-table-properties-at-level<N>", same as the previous
     //      one but only returns the aggregated table properties of the
     //      specified level "N" at the target column family.
-    static const std::string kAggregatedTablePropertiesAtLevel;
+    static const std::string& GetAggregatedTablePropertiesAtLevel();
 
     //  "rocksdb.actual-delayed-write-rate" - returns the current actual delayed
     //      write rate. 0 means no delay.
-    static const std::string kActualDelayedWriteRate;
+    static const std::string& GetActualDelayedWriteRate();
 
     //  "rocksdb.is-write-stopped" - Return 1 if write has been stopped.
-    static const std::string kIsWriteStopped;
+    static const std::string& GetIsWriteStopped();
 
     //  "rocksdb.estimate-oldest-key-time" - returns an estimation of
     //      oldest key timestamp in the DB. Currently only available for
     //      FIFO compaction with
     //      compaction_options_fifo.allow_compaction = false.
-    static const std::string kEstimateOldestKeyTime;
+    static const std::string& GetEstimateOldestKeyTime();
 
     //  "rocksdb.block-cache-capacity" - returns block cache capacity.
-    static const std::string kBlockCacheCapacity;
+    static const std::string& GetBlockCacheCapacity();
 
     //  "rocksdb.block-cache-usage" - returns the memory size for the entries
     //      residing in block cache.
-    static const std::string kBlockCacheUsage;
+    static const std::string& GetBlockCacheUsage();
 
     // "rocksdb.block-cache-pinned-usage" - returns the memory size for the
     //      entries being pinned.
-    static const std::string kBlockCachePinnedUsage;
+    static const std::string& GetBlockCachePinnedUsage();
 
     // "rocksdb.options-statistics" - returns multi-line string
     //      of options.statistics
-    static const std::string kOptionsStatistics;
+    static const std::string& GetOptionsStatistics();
 
     // "rocksdb.num-blob-files" - returns number of blob files in the current
     //      version.
-    static const std::string kNumBlobFiles;
+    static const std::string& GetNumBlobFiles();
 
     // "rocksdb.blob-stats" - return the total number and size of all blob
     //      files, and total amount of garbage (bytes) in the blob files in
     //      the current version.
-    static const std::string kBlobStats;
+    static const std::string& GetBlobStats();
 
     // "rocksdb.total-blob-file-size" - returns the total size of all blob
     //      files over all versions.
-    static const std::string kTotalBlobFileSize;
+    static const std::string& GetTotalBlobFileSize();
 
     // "rocksdb.live-blob-file-size" - returns the total size of all blob
     //      files in the current version.
-    static const std::string kLiveBlobFileSize;
+    static const std::string& GetLiveBlobFileSize();
 
     // "rocksdb.live-blob-file-garbage-size" - returns the total amount of
     // garbage in the blob files in the current version.
-    static const std::string kLiveBlobFileGarbageSize;
+    static const std::string& GetLiveBlobFileGarbageSize();
 
     //  "rocksdb.blob-cache-capacity" - returns blob cache capacity.
-    static const std::string kBlobCacheCapacity;
+    static const std::string& GetBlobCacheCapacity();
 
     //  "rocksdb.blob-cache-usage" - returns the memory size for the entries
     //      residing in blob cache.
-    static const std::string kBlobCacheUsage;
+    static const std::string& GetBlobCacheUsage();
 
     // "rocksdb.blob-cache-pinned-usage" - returns the memory size for the
     //      entries being pinned in blob cache.
-    static const std::string kBlobCachePinnedUsage;
+    static const std::string& GetBlobCachePinnedUsage();
   };
 
   // DB implementations export properties about their state via this method.

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -497,7 +497,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
         {"prepopulate_blob_cache",
          OptionTypeInfo::Enum<PrepopulateBlobCache>(
              offsetof(struct MutableCFOptions, prepopulate_blob_cache),
-             &prepopulate_blob_cache_string_map, OptionTypeFlags::kMutable)},
+             &OptionsHelper::GetPrepopulateBlobCacheStringMap(),
+             OptionTypeFlags::kMutable)},
         {"sample_for_compression",
          {offsetof(struct MutableCFOptions, sample_for_compression),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
@@ -828,8 +829,6 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kCompareLoose}},
 };
 
-const std::string OptionsHelper::kCFOptionsName = "ColumnFamilyOptions";
-
 class ConfigurableMutableCFOptions : public Configurable {
  public:
   explicit ConfigurableMutableCFOptions(const MutableCFOptions& mcf) {
@@ -867,7 +866,7 @@ class ConfigurableCFOptions : public ConfigurableMutableCFOptions {
   }
 
   const void* GetOptionsPtr(const std::string& name) const override {
-    if (name == OptionsHelper::kCFOptionsName) {
+    if (name == OptionsHelper::GetCFOptionsName()) {
       return &cf_options_;
     } else {
       return ConfigurableMutableCFOptions::GetOptionsPtr(name);
@@ -1007,9 +1006,9 @@ uint64_t MultiplyCheckOverflow(uint64_t op1, double op2) {
 // when level_compaction_dynamic_level_bytes is true and leveled compaction
 // is used, the base level is not always L1, so precomupted max_file_size can
 // no longer be used. Recompute file_size_for_level from base level.
-uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options,
-    int level, CompactionStyle compaction_style, int base_level,
-    bool level_compaction_dynamic_level_bytes) {
+uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options, int level,
+                             CompactionStyle compaction_style, int base_level,
+                             bool level_compaction_dynamic_level_bytes) {
   if (!level_compaction_dynamic_level_bytes || level < base_level ||
       compaction_style != kCompactionStyleLevel) {
     assert(level >= 0);

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -578,8 +578,6 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
 };
 
-const std::string OptionsHelper::kDBOptionsName = "DBOptions";
-
 class MutableDBConfigurable : public Configurable {
  public:
   explicit MutableDBConfigurable(
@@ -665,7 +663,7 @@ class DBOptionsConfigurable : public MutableDBConfigurable {
   }
 
   const void* GetOptionsPtr(const std::string& name) const override {
-    if (name == OptionsHelper::kDBOptionsName) {
+    if (name == OptionsHelper::GetDBOptionsName()) {
       return &db_options_;
     } else {
       return MutableDBConfigurable::GetOptionsPtr(name);
@@ -930,8 +928,7 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    "            Options.background_close_inactive_wals: %d",
                    background_close_inactive_wals);
   ROCKS_LOG_HEADER(log, "            Options.atomic_flush: %d", atomic_flush);
-  ROCKS_LOG_HEADER(log,
-                   "            Options.avoid_unnecessary_blocking_io: %d",
+  ROCKS_LOG_HEADER(log, "            Options.avoid_unnecessary_blocking_io: %d",
                    avoid_unnecessary_blocking_io);
   ROCKS_LOG_HEADER(log, "                Options.persist_stats_to_disk: %u",
                    persist_stats_to_disk);
@@ -1068,14 +1065,13 @@ void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "                     Options.wal_bytes_per_sync: %" PRIu64,
                    wal_bytes_per_sync);
-  ROCKS_LOG_HEADER(log,
-                   "                  Options.strict_bytes_per_sync: %d",
+  ROCKS_LOG_HEADER(log, "                  Options.strict_bytes_per_sync: %d",
                    strict_bytes_per_sync);
   ROCKS_LOG_HEADER(log,
                    "      Options.compaction_readahead_size: %" ROCKSDB_PRIszt,
                    compaction_readahead_size);
   ROCKS_LOG_HEADER(log, "                 Options.max_background_flushes: %d",
-                          max_background_flushes);
+                   max_background_flushes);
   ROCKS_LOG_HEADER(log, "Options.daily_offpeak_time_utc: %s",
                    daily_offpeak_time_utc.c_str());
 }

--- a/options/options.cc
+++ b/options/options.cc
@@ -133,8 +133,8 @@ DBOptions::DBOptions(const Options& options)
     : DBOptions(*static_cast<const DBOptions*>(&options)) {}
 
 void DBOptions::Dump(Logger* log) const {
-    ImmutableDBOptions(*this).Dump(log);
-    MutableDBOptions(*this).Dump(log);
+  ImmutableDBOptions(*this).Dump(log);
+  MutableDBOptions(*this).Dump(log);
 }  // DBOptions::Dump
 
 void ColumnFamilyOptions::Dump(Logger* log) const {
@@ -171,304 +171,291 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
           log, "       Options.compression[%d]: %s", i,
           CompressionTypeToString(compression_per_level[i]).c_str());
     }
-    } else {
-      ROCKS_LOG_HEADER(log, "         Options.compression: %s",
-                       CompressionTypeToString(compression).c_str());
-    }
-    ROCKS_LOG_HEADER(
-        log, "                 Options.bottommost_compression: %s",
-        bottommost_compression == kDisableCompressionOption
-            ? "Disabled"
-            : CompressionTypeToString(bottommost_compression).c_str());
-    ROCKS_LOG_HEADER(
-        log, "      Options.prefix_extractor: %s",
-        prefix_extractor == nullptr ? "nullptr" : prefix_extractor->Name());
-    ROCKS_LOG_HEADER(log,
-                     "  Options.memtable_insert_with_hint_prefix_extractor: %s",
-                     memtable_insert_with_hint_prefix_extractor == nullptr
-                         ? "nullptr"
-                         : memtable_insert_with_hint_prefix_extractor->Name());
-    ROCKS_LOG_HEADER(log, "            Options.num_levels: %d", num_levels);
-    ROCKS_LOG_HEADER(log, "       Options.min_write_buffer_number_to_merge: %d",
-                     min_write_buffer_number_to_merge);
-    ROCKS_LOG_HEADER(log, "    Options.max_write_buffer_number_to_maintain: %d",
-                     max_write_buffer_number_to_maintain);
-    ROCKS_LOG_HEADER(log,
-                     "    Options.max_write_buffer_size_to_maintain: %" PRIu64,
-                     max_write_buffer_size_to_maintain);
-    ROCKS_LOG_HEADER(
-        log, "           Options.bottommost_compression_opts.window_bits: %d",
-        bottommost_compression_opts.window_bits);
-    ROCKS_LOG_HEADER(
-        log, "                 Options.bottommost_compression_opts.level: %d",
-        bottommost_compression_opts.level);
-    ROCKS_LOG_HEADER(
-        log, "              Options.bottommost_compression_opts.strategy: %d",
-        bottommost_compression_opts.strategy);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.max_dict_bytes: "
-        "%" PRIu32,
-        bottommost_compression_opts.max_dict_bytes);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.zstd_max_train_bytes: "
-        "%" PRIu32,
-        bottommost_compression_opts.zstd_max_train_bytes);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.parallel_threads: "
-        "%" PRIu32,
-        bottommost_compression_opts.parallel_threads);
-    ROCKS_LOG_HEADER(
-        log, "                 Options.bottommost_compression_opts.enabled: %s",
-        bottommost_compression_opts.enabled ? "true" : "false");
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.max_dict_buffer_bytes: "
-        "%" PRIu64,
-        bottommost_compression_opts.max_dict_buffer_bytes);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.use_zstd_dict_trainer: %s",
-        bottommost_compression_opts.use_zstd_dict_trainer ? "true" : "false");
-    ROCKS_LOG_HEADER(log, "           Options.compression_opts.window_bits: %d",
-                     compression_opts.window_bits);
-    ROCKS_LOG_HEADER(log, "                 Options.compression_opts.level: %d",
-                     compression_opts.level);
-    ROCKS_LOG_HEADER(log, "              Options.compression_opts.strategy: %d",
-                     compression_opts.strategy);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.compression_opts.max_dict_bytes: %" PRIu32,
-        compression_opts.max_dict_bytes);
-    ROCKS_LOG_HEADER(log,
-                     "        Options.compression_opts.zstd_max_train_bytes: "
-                     "%" PRIu32,
-                     compression_opts.zstd_max_train_bytes);
-    ROCKS_LOG_HEADER(
-        log, "        Options.compression_opts.use_zstd_dict_trainer: %s",
-        compression_opts.use_zstd_dict_trainer ? "true" : "false");
-    ROCKS_LOG_HEADER(log,
-                     "        Options.compression_opts.parallel_threads: "
-                     "%" PRIu32,
-                     compression_opts.parallel_threads);
-    ROCKS_LOG_HEADER(log,
-                     "                 Options.compression_opts.enabled: %s",
-                     compression_opts.enabled ? "true" : "false");
-    ROCKS_LOG_HEADER(log,
-                     "        Options.compression_opts.max_dict_buffer_bytes: "
-                     "%" PRIu64,
-                     compression_opts.max_dict_buffer_bytes);
-    ROCKS_LOG_HEADER(log, "     Options.level0_file_num_compaction_trigger: %d",
-                     level0_file_num_compaction_trigger);
-    ROCKS_LOG_HEADER(log, "         Options.level0_slowdown_writes_trigger: %d",
-                     level0_slowdown_writes_trigger);
-    ROCKS_LOG_HEADER(log, "             Options.level0_stop_writes_trigger: %d",
-                     level0_stop_writes_trigger);
-    ROCKS_LOG_HEADER(
-        log, "                  Options.target_file_size_base: %" PRIu64,
-        target_file_size_base);
-    ROCKS_LOG_HEADER(log, "            Options.target_file_size_multiplier: %d",
-                     target_file_size_multiplier);
-    ROCKS_LOG_HEADER(
-        log, "               Options.max_bytes_for_level_base: %" PRIu64,
-        max_bytes_for_level_base);
-    ROCKS_LOG_HEADER(log, "Options.level_compaction_dynamic_level_bytes: %d",
-                     level_compaction_dynamic_level_bytes);
-    ROCKS_LOG_HEADER(log, "         Options.max_bytes_for_level_multiplier: %f",
-                     max_bytes_for_level_multiplier);
-    for (size_t i = 0; i < max_bytes_for_level_multiplier_additional.size();
-         i++) {
-      ROCKS_LOG_HEADER(
-          log, "Options.max_bytes_for_level_multiplier_addtl[%" ROCKSDB_PRIszt
-               "]: %d",
-          i, max_bytes_for_level_multiplier_additional[i]);
-    }
-    ROCKS_LOG_HEADER(
-        log, "      Options.max_sequential_skip_in_iterations: %" PRIu64,
-        max_sequential_skip_in_iterations);
-    ROCKS_LOG_HEADER(
-        log, "                   Options.max_compaction_bytes: %" PRIu64,
-        max_compaction_bytes);
+  } else {
+    ROCKS_LOG_HEADER(log, "         Options.compression: %s",
+                     CompressionTypeToString(compression).c_str());
+  }
+  ROCKS_LOG_HEADER(
+      log, "                 Options.bottommost_compression: %s",
+      bottommost_compression == kDisableCompressionOption
+          ? "Disabled"
+          : CompressionTypeToString(bottommost_compression).c_str());
+  ROCKS_LOG_HEADER(
+      log, "      Options.prefix_extractor: %s",
+      prefix_extractor == nullptr ? "nullptr" : prefix_extractor->Name());
+  ROCKS_LOG_HEADER(log,
+                   "  Options.memtable_insert_with_hint_prefix_extractor: %s",
+                   memtable_insert_with_hint_prefix_extractor == nullptr
+                       ? "nullptr"
+                       : memtable_insert_with_hint_prefix_extractor->Name());
+  ROCKS_LOG_HEADER(log, "            Options.num_levels: %d", num_levels);
+  ROCKS_LOG_HEADER(log, "       Options.min_write_buffer_number_to_merge: %d",
+                   min_write_buffer_number_to_merge);
+  ROCKS_LOG_HEADER(log, "    Options.max_write_buffer_number_to_maintain: %d",
+                   max_write_buffer_number_to_maintain);
+  ROCKS_LOG_HEADER(log,
+                   "    Options.max_write_buffer_size_to_maintain: %" PRIu64,
+                   max_write_buffer_size_to_maintain);
+  ROCKS_LOG_HEADER(
+      log, "           Options.bottommost_compression_opts.window_bits: %d",
+      bottommost_compression_opts.window_bits);
+  ROCKS_LOG_HEADER(
+      log, "                 Options.bottommost_compression_opts.level: %d",
+      bottommost_compression_opts.level);
+  ROCKS_LOG_HEADER(
+      log, "              Options.bottommost_compression_opts.strategy: %d",
+      bottommost_compression_opts.strategy);
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.max_dict_bytes: "
+      "%" PRIu32,
+      bottommost_compression_opts.max_dict_bytes);
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.zstd_max_train_bytes: "
+      "%" PRIu32,
+      bottommost_compression_opts.zstd_max_train_bytes);
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.parallel_threads: "
+      "%" PRIu32,
+      bottommost_compression_opts.parallel_threads);
+  ROCKS_LOG_HEADER(
+      log, "                 Options.bottommost_compression_opts.enabled: %s",
+      bottommost_compression_opts.enabled ? "true" : "false");
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.max_dict_buffer_bytes: "
+      "%" PRIu64,
+      bottommost_compression_opts.max_dict_buffer_bytes);
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.use_zstd_dict_trainer: %s",
+      bottommost_compression_opts.use_zstd_dict_trainer ? "true" : "false");
+  ROCKS_LOG_HEADER(log, "           Options.compression_opts.window_bits: %d",
+                   compression_opts.window_bits);
+  ROCKS_LOG_HEADER(log, "                 Options.compression_opts.level: %d",
+                   compression_opts.level);
+  ROCKS_LOG_HEADER(log, "              Options.compression_opts.strategy: %d",
+                   compression_opts.strategy);
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.max_dict_bytes: %" PRIu32,
+                   compression_opts.max_dict_bytes);
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.zstd_max_train_bytes: "
+                   "%" PRIu32,
+                   compression_opts.zstd_max_train_bytes);
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.use_zstd_dict_trainer: %s",
+                   compression_opts.use_zstd_dict_trainer ? "true" : "false");
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.parallel_threads: "
+                   "%" PRIu32,
+                   compression_opts.parallel_threads);
+  ROCKS_LOG_HEADER(log, "                 Options.compression_opts.enabled: %s",
+                   compression_opts.enabled ? "true" : "false");
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.max_dict_buffer_bytes: "
+                   "%" PRIu64,
+                   compression_opts.max_dict_buffer_bytes);
+  ROCKS_LOG_HEADER(log, "     Options.level0_file_num_compaction_trigger: %d",
+                   level0_file_num_compaction_trigger);
+  ROCKS_LOG_HEADER(log, "         Options.level0_slowdown_writes_trigger: %d",
+                   level0_slowdown_writes_trigger);
+  ROCKS_LOG_HEADER(log, "             Options.level0_stop_writes_trigger: %d",
+                   level0_stop_writes_trigger);
+  ROCKS_LOG_HEADER(log,
+                   "                  Options.target_file_size_base: %" PRIu64,
+                   target_file_size_base);
+  ROCKS_LOG_HEADER(log, "            Options.target_file_size_multiplier: %d",
+                   target_file_size_multiplier);
+  ROCKS_LOG_HEADER(log,
+                   "               Options.max_bytes_for_level_base: %" PRIu64,
+                   max_bytes_for_level_base);
+  ROCKS_LOG_HEADER(log, "Options.level_compaction_dynamic_level_bytes: %d",
+                   level_compaction_dynamic_level_bytes);
+  ROCKS_LOG_HEADER(log, "         Options.max_bytes_for_level_multiplier: %f",
+                   max_bytes_for_level_multiplier);
+  for (size_t i = 0; i < max_bytes_for_level_multiplier_additional.size();
+       i++) {
     ROCKS_LOG_HEADER(
         log,
-        "                       Options.arena_block_size: %" ROCKSDB_PRIszt,
-        arena_block_size);
-    ROCKS_LOG_HEADER(log,
-                     "  Options.soft_pending_compaction_bytes_limit: %" PRIu64,
-                     soft_pending_compaction_bytes_limit);
-    ROCKS_LOG_HEADER(log,
-                     "  Options.hard_pending_compaction_bytes_limit: %" PRIu64,
-                     hard_pending_compaction_bytes_limit);
-    ROCKS_LOG_HEADER(log, "               Options.disable_auto_compactions: %d",
-                     disable_auto_compactions);
+        "Options.max_bytes_for_level_multiplier_addtl[%" ROCKSDB_PRIszt "]: %d",
+        i, max_bytes_for_level_multiplier_additional[i]);
+  }
+  ROCKS_LOG_HEADER(log,
+                   "      Options.max_sequential_skip_in_iterations: %" PRIu64,
+                   max_sequential_skip_in_iterations);
+  ROCKS_LOG_HEADER(log,
+                   "                   Options.max_compaction_bytes: %" PRIu64,
+                   max_compaction_bytes);
+  ROCKS_LOG_HEADER(
+      log, "                       Options.arena_block_size: %" ROCKSDB_PRIszt,
+      arena_block_size);
+  ROCKS_LOG_HEADER(log,
+                   "  Options.soft_pending_compaction_bytes_limit: %" PRIu64,
+                   soft_pending_compaction_bytes_limit);
+  ROCKS_LOG_HEADER(log,
+                   "  Options.hard_pending_compaction_bytes_limit: %" PRIu64,
+                   hard_pending_compaction_bytes_limit);
+  ROCKS_LOG_HEADER(log, "               Options.disable_auto_compactions: %d",
+                   disable_auto_compactions);
 
-    const auto& it_compaction_style =
-        compaction_style_to_string.find(compaction_style);
-    std::string str_compaction_style;
-    if (it_compaction_style == compaction_style_to_string.end()) {
-      assert(false);
-      str_compaction_style = "unknown_" + std::to_string(compaction_style);
-    } else {
-      str_compaction_style = it_compaction_style->second;
-    }
-    ROCKS_LOG_HEADER(log,
-                     "                       Options.compaction_style: %s",
-                     str_compaction_style.c_str());
+  const auto& it_compaction_style =
+      OptionsHelper::GetCompactionStyleToString().find(compaction_style);
+  std::string str_compaction_style;
+  if (it_compaction_style ==
+      OptionsHelper::GetCompactionStyleToString().end()) {
+    assert(false);
+    str_compaction_style = "unknown_" + std::to_string(compaction_style);
+  } else {
+    str_compaction_style = it_compaction_style->second;
+  }
+  ROCKS_LOG_HEADER(log, "                       Options.compaction_style: %s",
+                   str_compaction_style.c_str());
 
-    const auto& it_compaction_pri =
-        compaction_pri_to_string.find(compaction_pri);
-    std::string str_compaction_pri;
-    if (it_compaction_pri == compaction_pri_to_string.end()) {
-      assert(false);
-      str_compaction_pri = "unknown_" + std::to_string(compaction_pri);
-    } else {
-      str_compaction_pri = it_compaction_pri->second;
-    }
-    ROCKS_LOG_HEADER(log,
-                     "                         Options.compaction_pri: %s",
-                     str_compaction_pri.c_str());
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.size_ratio: %u",
-                     compaction_options_universal.size_ratio);
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.min_merge_width: %u",
-                     compaction_options_universal.min_merge_width);
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.max_merge_width: %u",
-                     compaction_options_universal.max_merge_width);
-    ROCKS_LOG_HEADER(
-        log,
-        "Options.compaction_options_universal."
-        "max_size_amplification_percent: %u",
-        compaction_options_universal.max_size_amplification_percent);
-    ROCKS_LOG_HEADER(
-        log,
-        "Options.compaction_options_universal.compression_size_percent: %d",
-        compaction_options_universal.compression_size_percent);
-    const auto& it_compaction_stop_style = compaction_stop_style_to_string.find(
-        compaction_options_universal.stop_style);
-    std::string str_compaction_stop_style;
-    if (it_compaction_stop_style == compaction_stop_style_to_string.end()) {
-      assert(false);
-      str_compaction_stop_style =
-          "unknown_" + std::to_string(compaction_options_universal.stop_style);
-    } else {
-      str_compaction_stop_style = it_compaction_stop_style->second;
-    }
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.stop_style: %s",
-                     str_compaction_stop_style.c_str());
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.max_read_amp: %d",
-                     compaction_options_universal.max_read_amp);
-    ROCKS_LOG_HEADER(
-        log, "Options.compaction_options_fifo.max_table_files_size: %" PRIu64,
-        compaction_options_fifo.max_table_files_size);
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_fifo.allow_compaction: %d",
-                     compaction_options_fifo.allow_compaction);
-    std::ostringstream collector_info;
-    for (const auto& collector_factory : table_properties_collector_factories) {
-      collector_info << collector_factory->ToString() << ';';
-    }
-    ROCKS_LOG_HEADER(
-        log, "                  Options.table_properties_collectors: %s",
-        collector_info.str().c_str());
-    ROCKS_LOG_HEADER(log,
-                     "                  Options.inplace_update_support: %d",
-                     inplace_update_support);
-    ROCKS_LOG_HEADER(
-        log,
-        "                Options.inplace_update_num_locks: %" ROCKSDB_PRIszt,
-        inplace_update_num_locks);
-    // TODO: easier config for bloom (maybe based on avg key/value size)
-    ROCKS_LOG_HEADER(
-        log, "              Options.memtable_prefix_bloom_size_ratio: %f",
-        memtable_prefix_bloom_size_ratio);
-    ROCKS_LOG_HEADER(log,
-                     "              Options.memtable_whole_key_filtering: %d",
-                     memtable_whole_key_filtering);
+  const auto& it_compaction_pri =
+      OptionsHelper::GetCompactionPriToString().find(compaction_pri);
+  std::string str_compaction_pri;
+  if (it_compaction_pri == OptionsHelper::GetCompactionPriToString().end()) {
+    assert(false);
+    str_compaction_pri = "unknown_" + std::to_string(compaction_pri);
+  } else {
+    str_compaction_pri = it_compaction_pri->second;
+  }
+  ROCKS_LOG_HEADER(log, "                         Options.compaction_pri: %s",
+                   str_compaction_pri.c_str());
+  ROCKS_LOG_HEADER(log, "Options.compaction_options_universal.size_ratio: %u",
+                   compaction_options_universal.size_ratio);
+  ROCKS_LOG_HEADER(log,
+                   "Options.compaction_options_universal.min_merge_width: %u",
+                   compaction_options_universal.min_merge_width);
+  ROCKS_LOG_HEADER(log,
+                   "Options.compaction_options_universal.max_merge_width: %u",
+                   compaction_options_universal.max_merge_width);
+  ROCKS_LOG_HEADER(log,
+                   "Options.compaction_options_universal."
+                   "max_size_amplification_percent: %u",
+                   compaction_options_universal.max_size_amplification_percent);
+  ROCKS_LOG_HEADER(
+      log, "Options.compaction_options_universal.compression_size_percent: %d",
+      compaction_options_universal.compression_size_percent);
+  const auto& it_compaction_stop_style =
+      OptionsHelper::GetCompactionStopStyleToString().find(
+          compaction_options_universal.stop_style);
+  std::string str_compaction_stop_style;
+  if (it_compaction_stop_style ==
+      OptionsHelper::GetCompactionStopStyleToString().end()) {
+    assert(false);
+    str_compaction_stop_style =
+        "unknown_" + std::to_string(compaction_options_universal.stop_style);
+  } else {
+    str_compaction_stop_style = it_compaction_stop_style->second;
+  }
+  ROCKS_LOG_HEADER(log, "Options.compaction_options_universal.stop_style: %s",
+                   str_compaction_stop_style.c_str());
+  ROCKS_LOG_HEADER(log, "Options.compaction_options_universal.max_read_amp: %d",
+                   compaction_options_universal.max_read_amp);
+  ROCKS_LOG_HEADER(
+      log, "Options.compaction_options_fifo.max_table_files_size: %" PRIu64,
+      compaction_options_fifo.max_table_files_size);
+  ROCKS_LOG_HEADER(log, "Options.compaction_options_fifo.allow_compaction: %d",
+                   compaction_options_fifo.allow_compaction);
+  std::ostringstream collector_info;
+  for (const auto& collector_factory : table_properties_collector_factories) {
+    collector_info << collector_factory->ToString() << ';';
+  }
+  ROCKS_LOG_HEADER(log,
+                   "                  Options.table_properties_collectors: %s",
+                   collector_info.str().c_str());
+  ROCKS_LOG_HEADER(log, "                  Options.inplace_update_support: %d",
+                   inplace_update_support);
+  ROCKS_LOG_HEADER(
+      log, "                Options.inplace_update_num_locks: %" ROCKSDB_PRIszt,
+      inplace_update_num_locks);
+  // TODO: easier config for bloom (maybe based on avg key/value size)
+  ROCKS_LOG_HEADER(log,
+                   "              Options.memtable_prefix_bloom_size_ratio: %f",
+                   memtable_prefix_bloom_size_ratio);
+  ROCKS_LOG_HEADER(log,
+                   "              Options.memtable_whole_key_filtering: %d",
+                   memtable_whole_key_filtering);
 
-    ROCKS_LOG_HEADER(log, "  Options.memtable_huge_page_size: %" ROCKSDB_PRIszt,
-                     memtable_huge_page_size);
-    ROCKS_LOG_HEADER(log,
-                     "                          Options.bloom_locality: %d",
-                     bloom_locality);
+  ROCKS_LOG_HEADER(log, "  Options.memtable_huge_page_size: %" ROCKSDB_PRIszt,
+                   memtable_huge_page_size);
+  ROCKS_LOG_HEADER(log, "                          Options.bloom_locality: %d",
+                   bloom_locality);
 
-    ROCKS_LOG_HEADER(
-        log,
-        "                   Options.max_successive_merges: %" ROCKSDB_PRIszt,
-        max_successive_merges);
+  ROCKS_LOG_HEADER(
+      log, "                   Options.max_successive_merges: %" ROCKSDB_PRIszt,
+      max_successive_merges);
+  ROCKS_LOG_HEADER(log, "            Options.strict_max_successive_merges: %d",
+                   strict_max_successive_merges);
+  ROCKS_LOG_HEADER(log, "               Options.optimize_filters_for_hits: %d",
+                   optimize_filters_for_hits);
+  ROCKS_LOG_HEADER(log, "               Options.paranoid_file_checks: %d",
+                   paranoid_file_checks);
+  ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
+                   force_consistency_checks);
+  ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
+                   report_bg_io_stats);
+  ROCKS_LOG_HEADER(log, "                              Options.ttl: %" PRIu64,
+                   ttl);
+  ROCKS_LOG_HEADER(log,
+                   "         Options.periodic_compaction_seconds: %" PRIu64,
+                   periodic_compaction_seconds);
+  const auto& it_temp =
+      OptionsHelper::GetTemperatureToString().find(default_temperature);
+  std::string str_default_temperature;
+  if (it_temp == OptionsHelper::GetTemperatureToString().end()) {
+    assert(false);
+    str_default_temperature = "unknown_temperature";
+  } else {
+    str_default_temperature = it_temp->second;
+  }
+  ROCKS_LOG_HEADER(log,
+                   "                       Options.default_temperature: %s",
+                   str_default_temperature.c_str());
+  ROCKS_LOG_HEADER(log, " Options.preclude_last_level_data_seconds: %" PRIu64,
+                   preclude_last_level_data_seconds);
+  ROCKS_LOG_HEADER(log, "   Options.preserve_internal_time_seconds: %" PRIu64,
+                   preserve_internal_time_seconds);
+  ROCKS_LOG_HEADER(log, "                      Options.enable_blob_files: %s",
+                   enable_blob_files ? "true" : "false");
+  ROCKS_LOG_HEADER(log,
+                   "                          Options.min_blob_size: %" PRIu64,
+                   min_blob_size);
+  ROCKS_LOG_HEADER(log,
+                   "                         Options.blob_file_size: %" PRIu64,
+                   blob_file_size);
+  ROCKS_LOG_HEADER(log, "                  Options.blob_compression_type: %s",
+                   CompressionTypeToString(blob_compression_type).c_str());
+  ROCKS_LOG_HEADER(log, "         Options.enable_blob_garbage_collection: %s",
+                   enable_blob_garbage_collection ? "true" : "false");
+  ROCKS_LOG_HEADER(log, "     Options.blob_garbage_collection_age_cutoff: %f",
+                   blob_garbage_collection_age_cutoff);
+  ROCKS_LOG_HEADER(log, "Options.blob_garbage_collection_force_threshold: %f",
+                   blob_garbage_collection_force_threshold);
+  ROCKS_LOG_HEADER(log,
+                   "         Options.blob_compaction_readahead_size: %" PRIu64,
+                   blob_compaction_readahead_size);
+  ROCKS_LOG_HEADER(log, "               Options.blob_file_starting_level: %d",
+                   blob_file_starting_level);
+  if (blob_cache) {
+    ROCKS_LOG_HEADER(log, "                          Options.blob_cache: %s",
+                     blob_cache->Name());
+    ROCKS_LOG_HEADER(log, "                          blob_cache options: %s",
+                     blob_cache->GetPrintableOptions().c_str());
     ROCKS_LOG_HEADER(log,
-                     "            Options.strict_max_successive_merges: %d",
-                     strict_max_successive_merges);
-    ROCKS_LOG_HEADER(log,
-                     "               Options.optimize_filters_for_hits: %d",
-                     optimize_filters_for_hits);
-    ROCKS_LOG_HEADER(log, "               Options.paranoid_file_checks: %d",
-                     paranoid_file_checks);
-    ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
-                     force_consistency_checks);
-    ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
-                     report_bg_io_stats);
-    ROCKS_LOG_HEADER(log, "                              Options.ttl: %" PRIu64,
-                     ttl);
-    ROCKS_LOG_HEADER(log,
-                     "         Options.periodic_compaction_seconds: %" PRIu64,
-                     periodic_compaction_seconds);
-    const auto& it_temp = temperature_to_string.find(default_temperature);
-    std::string str_default_temperature;
-    if (it_temp == temperature_to_string.end()) {
-      assert(false);
-      str_default_temperature = "unknown_temperature";
-    } else {
-      str_default_temperature = it_temp->second;
-    }
-    ROCKS_LOG_HEADER(log,
-                     "                       Options.default_temperature: %s",
-                     str_default_temperature.c_str());
-    ROCKS_LOG_HEADER(log, " Options.preclude_last_level_data_seconds: %" PRIu64,
-                     preclude_last_level_data_seconds);
-    ROCKS_LOG_HEADER(log, "   Options.preserve_internal_time_seconds: %" PRIu64,
-                     preserve_internal_time_seconds);
-    ROCKS_LOG_HEADER(log, "                      Options.enable_blob_files: %s",
-                     enable_blob_files ? "true" : "false");
-    ROCKS_LOG_HEADER(
-        log, "                          Options.min_blob_size: %" PRIu64,
-        min_blob_size);
-    ROCKS_LOG_HEADER(
-        log, "                         Options.blob_file_size: %" PRIu64,
-        blob_file_size);
-    ROCKS_LOG_HEADER(log, "                  Options.blob_compression_type: %s",
-                     CompressionTypeToString(blob_compression_type).c_str());
-    ROCKS_LOG_HEADER(log, "         Options.enable_blob_garbage_collection: %s",
-                     enable_blob_garbage_collection ? "true" : "false");
-    ROCKS_LOG_HEADER(log, "     Options.blob_garbage_collection_age_cutoff: %f",
-                     blob_garbage_collection_age_cutoff);
-    ROCKS_LOG_HEADER(log, "Options.blob_garbage_collection_force_threshold: %f",
-                     blob_garbage_collection_force_threshold);
-    ROCKS_LOG_HEADER(
-        log, "         Options.blob_compaction_readahead_size: %" PRIu64,
-        blob_compaction_readahead_size);
-    ROCKS_LOG_HEADER(log, "               Options.blob_file_starting_level: %d",
-                     blob_file_starting_level);
-    if (blob_cache) {
-      ROCKS_LOG_HEADER(log, "                          Options.blob_cache: %s",
-                       blob_cache->Name());
-      ROCKS_LOG_HEADER(log, "                          blob_cache options: %s",
-                       blob_cache->GetPrintableOptions().c_str());
-      ROCKS_LOG_HEADER(
-          log, "                          blob_cache prepopulated: %s",
-          prepopulate_blob_cache == PrepopulateBlobCache::kFlushOnly
-              ? "flush only"
-              : "disabled");
-    }
-    ROCKS_LOG_HEADER(log, "        Options.experimental_mempurge_threshold: %f",
-                     experimental_mempurge_threshold);
-    ROCKS_LOG_HEADER(log, "           Options.memtable_max_range_deletions: %d",
-                     memtable_max_range_deletions);
+                     "                          blob_cache prepopulated: %s",
+                     prepopulate_blob_cache == PrepopulateBlobCache::kFlushOnly
+                         ? "flush only"
+                         : "disabled");
+  }
+  ROCKS_LOG_HEADER(log, "        Options.experimental_mempurge_threshold: %f",
+                   experimental_mempurge_threshold);
+  ROCKS_LOG_HEADER(log, "           Options.memtable_max_range_deletions: %d",
+                   memtable_max_range_deletions);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {
@@ -484,13 +471,11 @@ void Options::DumpCFOptions(Logger* log) const {
 // The goal of this method is to create a configuration that
 // allows an application to write all files into L0 and
 // then do a single compaction to output all files into L1.
-Options*
-Options::PrepareForBulkLoad()
-{
+Options* Options::PrepareForBulkLoad() {
   // never slowdown ingest.
-  level0_file_num_compaction_trigger = (1<<30);
-  level0_slowdown_writes_trigger = (1<<30);
-  level0_stop_writes_trigger = (1<<30);
+  level0_file_num_compaction_trigger = (1 << 30);
+  level0_slowdown_writes_trigger = (1 << 30);
+  level0_stop_writes_trigger = (1 << 30);
   soft_pending_compaction_bytes_limit = 0;
   hard_pending_compaction_bytes_limit = 0;
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -30,9 +30,7 @@
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
-ConfigOptions::ConfigOptions()
-    : registry(ObjectRegistry::NewInstance())
-{
+ConfigOptions::ConfigOptions() : registry(ObjectRegistry::NewInstance()) {
   env = Env::Default();
 }
 
@@ -320,56 +318,91 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
   // TODO(yhchiang): find some way to handle the following derived options
   // * max_file_size
 }
+const std::string& OptionsHelper::GetCFOptionsName() {
+  static const std::string kCFOptionsName = "ColumnFamilyOptions";
+  return kCFOptionsName;
+}
+const std::string& OptionsHelper::GetDBOptionsName() {
+  static const std::string kDBOptionsName = "DBOptions";
+  return kDBOptionsName;
+}
+std::map<CompactionStyle, std::string>&
+OptionsHelper::GetCompactionStyleToString() {
+  static std::map<CompactionStyle, std::string> compaction_style_to_string = {
+      {kCompactionStyleLevel, "kCompactionStyleLevel"},
+      {kCompactionStyleUniversal, "kCompactionStyleUniversal"},
+      {kCompactionStyleFIFO, "kCompactionStyleFIFO"},
+      {kCompactionStyleNone, "kCompactionStyleNone"}};
 
-std::map<CompactionStyle, std::string>
-    OptionsHelper::compaction_style_to_string = {
-        {kCompactionStyleLevel, "kCompactionStyleLevel"},
-        {kCompactionStyleUniversal, "kCompactionStyleUniversal"},
-        {kCompactionStyleFIFO, "kCompactionStyleFIFO"},
-        {kCompactionStyleNone, "kCompactionStyleNone"}};
+  return compaction_style_to_string;
+}
 
-std::map<CompactionPri, std::string> OptionsHelper::compaction_pri_to_string = {
-    {kByCompensatedSize, "kByCompensatedSize"},
-    {kOldestLargestSeqFirst, "kOldestLargestSeqFirst"},
-    {kOldestSmallestSeqFirst, "kOldestSmallestSeqFirst"},
-    {kMinOverlappingRatio, "kMinOverlappingRatio"},
-    {kRoundRobin, "kRoundRobin"}};
+std::map<CompactionPri, std::string>&
+OptionsHelper::GetCompactionPriToString() {
+  static std::map<CompactionPri, std::string> compaction_pri_to_string = {
+      {kByCompensatedSize, "kByCompensatedSize"},
+      {kOldestLargestSeqFirst, "kOldestLargestSeqFirst"},
+      {kOldestSmallestSeqFirst, "kOldestSmallestSeqFirst"},
+      {kMinOverlappingRatio, "kMinOverlappingRatio"},
+      {kRoundRobin, "kRoundRobin"}};
 
-std::map<CompactionStopStyle, std::string>
-    OptionsHelper::compaction_stop_style_to_string = {
-        {kCompactionStopStyleSimilarSize, "kCompactionStopStyleSimilarSize"},
-        {kCompactionStopStyleTotalSize, "kCompactionStopStyleTotalSize"}};
+  return compaction_pri_to_string;
+}
 
-std::map<Temperature, std::string> OptionsHelper::temperature_to_string = {
-    {Temperature::kUnknown, "kUnknown"},
-    {Temperature::kHot, "kHot"},
-    {Temperature::kWarm, "kWarm"},
-    {Temperature::kCold, "kCold"}};
+std::map<CompactionStopStyle, std::string>&
+OptionsHelper::GetCompactionStopStyleToString() {
+  static std::map<CompactionStopStyle, std::string>
+      compaction_stop_style_to_string = {
+          {kCompactionStopStyleSimilarSize, "kCompactionStopStyleSimilarSize"},
+          {kCompactionStopStyleTotalSize, "kCompactionStopStyleTotalSize"}};
 
-std::unordered_map<std::string, ChecksumType>
-    OptionsHelper::checksum_type_string_map = {{"kNoChecksum", kNoChecksum},
-                                               {"kCRC32c", kCRC32c},
-                                               {"kxxHash", kxxHash},
-                                               {"kxxHash64", kxxHash64},
-                                               {"kXXH3", kXXH3}};
+  return compaction_stop_style_to_string;
+}
+std::map<Temperature, std::string>& OptionsHelper::GetTemperatureToString() {
+  static std::map<Temperature, std::string> temperature_to_string = {
+      {Temperature::kUnknown, "kUnknown"},
+      {Temperature::kHot, "kHot"},
+      {Temperature::kWarm, "kWarm"},
+      {Temperature::kCold, "kCold"}};
 
-std::unordered_map<std::string, CompressionType>
-    OptionsHelper::compression_type_string_map = {
-        {"kNoCompression", kNoCompression},
-        {"kSnappyCompression", kSnappyCompression},
-        {"kZlibCompression", kZlibCompression},
-        {"kBZip2Compression", kBZip2Compression},
-        {"kLZ4Compression", kLZ4Compression},
-        {"kLZ4HCCompression", kLZ4HCCompression},
-        {"kXpressCompression", kXpressCompression},
-        {"kZSTD", kZSTD},
-        {"kZSTDNotFinalCompression", kZSTDNotFinalCompression},
-        {"kDisableCompressionOption", kDisableCompressionOption}};
+  return temperature_to_string;
+}
+
+std::unordered_map<std::string, ChecksumType>&
+OptionsHelper::GetChecksumTypeStringMap() {
+  static std::unordered_map<std::string, ChecksumType>
+      checksum_type_string_map = {{"kNoChecksum", kNoChecksum},
+                                  {"kCRC32c", kCRC32c},
+                                  {"kxxHash", kxxHash},
+                                  {"kxxHash64", kxxHash64},
+                                  {"kXXH3", kXXH3}};
+
+  return checksum_type_string_map;
+}
+
+std::unordered_map<std::string, CompressionType>&
+OptionsHelper::GetCompressionTypeStringMap() {
+  static std::unordered_map<std::string, CompressionType>
+      compression_type_string_map = {
+          {"kNoCompression", kNoCompression},
+          {"kSnappyCompression", kSnappyCompression},
+          {"kZlibCompression", kZlibCompression},
+          {"kBZip2Compression", kBZip2Compression},
+          {"kLZ4Compression", kLZ4Compression},
+          {"kLZ4HCCompression", kLZ4HCCompression},
+          {"kXpressCompression", kXpressCompression},
+          {"kZSTD", kZSTD},
+          {"kZSTDNotFinalCompression", kZSTDNotFinalCompression},
+          {"kDisableCompressionOption", kDisableCompressionOption}};
+
+  return compression_type_string_map;
+}
 
 std::vector<CompressionType> GetSupportedCompressions() {
   // std::set internally to deduplicate potential name aliases
   std::set<CompressionType> supported_compressions;
-  for (const auto& comp_to_name : OptionsHelper::compression_type_string_map) {
+  for (const auto& comp_to_name :
+       OptionsHelper::GetCompressionTypeStringMap()) {
     CompressionType t = comp_to_name.second;
     if (t != kDisableCompressionOption && CompressionTypeSupported(t)) {
       supported_compressions.insert(t);
@@ -381,7 +414,8 @@ std::vector<CompressionType> GetSupportedCompressions() {
 
 std::vector<CompressionType> GetSupportedDictCompressions() {
   std::set<CompressionType> dict_compression_types;
-  for (const auto& comp_to_name : OptionsHelper::compression_type_string_map) {
+  for (const auto& comp_to_name :
+       OptionsHelper::GetCompressionTypeStringMap()) {
     CompressionType t = comp_to_name.second;
     if (t != kDisableCompressionOption && DictCompressionTypeSupported(t)) {
       dict_compression_types.insert(t);
@@ -393,7 +427,7 @@ std::vector<CompressionType> GetSupportedDictCompressions() {
 
 std::vector<ChecksumType> GetSupportedChecksums() {
   std::set<ChecksumType> checksum_types;
-  for (const auto& e : OptionsHelper::checksum_type_string_map) {
+  for (const auto& e : OptionsHelper::GetChecksumTypeStringMap()) {
     checksum_types.insert(e.second);
   }
   return std::vector<ChecksumType>(checksum_types.begin(),
@@ -442,24 +476,27 @@ static bool ParseOptionHelper(void* opt_address, const OptionType& opt_type,
       break;
     case OptionType::kCompactionStyle:
       return ParseEnum<CompactionStyle>(
-          compaction_style_string_map, value,
+          OptionsHelper::GetCompactionStyleStringMap(), value,
           static_cast<CompactionStyle*>(opt_address));
     case OptionType::kCompactionPri:
-      return ParseEnum<CompactionPri>(compaction_pri_string_map, value,
-                                      static_cast<CompactionPri*>(opt_address));
+      return ParseEnum<CompactionPri>(
+          OptionsHelper::GetCompactionPriStringMap(), value,
+          static_cast<CompactionPri*>(opt_address));
     case OptionType::kCompressionType:
       return ParseEnum<CompressionType>(
-          compression_type_string_map, value,
+          OptionsHelper::GetCompressionTypeStringMap(), value,
           static_cast<CompressionType*>(opt_address));
     case OptionType::kChecksumType:
-      return ParseEnum<ChecksumType>(checksum_type_string_map, value,
+      return ParseEnum<ChecksumType>(OptionsHelper::GetChecksumTypeStringMap(),
+                                     value,
                                      static_cast<ChecksumType*>(opt_address));
     case OptionType::kEncodingType:
-      return ParseEnum<EncodingType>(encoding_type_string_map, value,
+      return ParseEnum<EncodingType>(OptionsHelper::GetEncodingTypeStringMap(),
+                                     value,
                                      static_cast<EncodingType*>(opt_address));
     case OptionType::kCompactionStopStyle:
       return ParseEnum<CompactionStopStyle>(
-          compaction_stop_style_string_map, value,
+          OptionsHelper::GetCompactionStopStyleStringMap(), value,
           static_cast<CompactionStopStyle*>(opt_address));
     case OptionType::kEncodedString: {
       std::string* output_addr = static_cast<std::string*>(opt_address);
@@ -467,7 +504,8 @@ static bool ParseOptionHelper(void* opt_address, const OptionType& opt_type,
       break;
     }
     case OptionType::kTemperature: {
-      return ParseEnum<Temperature>(temperature_string_map, value,
+      return ParseEnum<Temperature>(OptionsHelper::GetTemperatureStringMap(),
+                                    value,
                                     static_cast<Temperature*>(opt_address));
     }
     default:
@@ -490,13 +528,11 @@ bool SerializeSingleOptionHelper(const void* opt_address,
     case OptionType::kInt32T:
       *value = std::to_string(*(static_cast<const int32_t*>(opt_address)));
       break;
-    case OptionType::kInt64T:
-      {
-        int64_t v;
-        GetUnaligned(static_cast<const int64_t*>(opt_address), &v);
-        *value = std::to_string(v);
-      }
-      break;
+    case OptionType::kInt64T: {
+      int64_t v;
+      GetUnaligned(static_cast<const int64_t*>(opt_address), &v);
+      *value = std::to_string(v);
+    } break;
     case OptionType::kUInt:
       *value = std::to_string(*(static_cast<const unsigned int*>(opt_address)));
       break;
@@ -506,20 +542,16 @@ bool SerializeSingleOptionHelper(const void* opt_address,
     case OptionType::kUInt32T:
       *value = std::to_string(*(static_cast<const uint32_t*>(opt_address)));
       break;
-    case OptionType::kUInt64T:
-      {
-        uint64_t v;
-        GetUnaligned(static_cast<const uint64_t*>(opt_address), &v);
-        *value = std::to_string(v);
-      }
-      break;
-    case OptionType::kSizeT:
-      {
-        size_t v;
-        GetUnaligned(static_cast<const size_t*>(opt_address), &v);
-        *value = std::to_string(v);
-      }
-      break;
+    case OptionType::kUInt64T: {
+      uint64_t v;
+      GetUnaligned(static_cast<const uint64_t*>(opt_address), &v);
+      *value = std::to_string(v);
+    } break;
+    case OptionType::kSizeT: {
+      size_t v;
+      GetUnaligned(static_cast<const size_t*>(opt_address), &v);
+      *value = std::to_string(v);
+    } break;
     case OptionType::kDouble:
       *value = std::to_string(*(static_cast<const double*>(opt_address)));
       break;
@@ -533,28 +565,28 @@ bool SerializeSingleOptionHelper(const void* opt_address,
       break;
     case OptionType::kCompactionStyle:
       return SerializeEnum<CompactionStyle>(
-          compaction_style_string_map,
+          OptionsHelper::GetCompactionStyleStringMap(),
           *(static_cast<const CompactionStyle*>(opt_address)), value);
     case OptionType::kCompactionPri:
       return SerializeEnum<CompactionPri>(
-          compaction_pri_string_map,
+          OptionsHelper::GetCompactionPriStringMap(),
           *(static_cast<const CompactionPri*>(opt_address)), value);
     case OptionType::kCompressionType:
       return SerializeEnum<CompressionType>(
-          compression_type_string_map,
+          OptionsHelper::GetCompressionTypeStringMap(),
           *(static_cast<const CompressionType*>(opt_address)), value);
       break;
     case OptionType::kChecksumType:
       return SerializeEnum<ChecksumType>(
-          checksum_type_string_map,
+          OptionsHelper::GetChecksumTypeStringMap(),
           *static_cast<const ChecksumType*>(opt_address), value);
     case OptionType::kEncodingType:
       return SerializeEnum<EncodingType>(
-          encoding_type_string_map,
+          OptionsHelper::GetEncodingTypeStringMap(),
           *static_cast<const EncodingType*>(opt_address), value);
     case OptionType::kCompactionStopStyle:
       return SerializeEnum<CompactionStopStyle>(
-          compaction_stop_style_string_map,
+          OptionsHelper::GetCompactionStopStyleStringMap(),
           *static_cast<const CompactionStopStyle*>(opt_address), value);
     case OptionType::kEncodedString: {
       const auto* ptr = static_cast<const std::string*>(opt_address);
@@ -563,8 +595,8 @@ bool SerializeSingleOptionHelper(const void* opt_address,
     }
     case OptionType::kTemperature: {
       return SerializeEnum<Temperature>(
-          temperature_string_map, *static_cast<const Temperature*>(opt_address),
-          value);
+          OptionsHelper::GetTemperatureStringMap(),
+          *static_cast<const Temperature*>(opt_address), value);
     }
     default:
       return false;
@@ -583,7 +615,6 @@ Status ConfigureFromMap(
   }
   return s;
 }
-
 
 Status StringToMap(const std::string& opts_str,
                    std::unordered_map<std::string, std::string>* opts_map) {
@@ -628,7 +659,6 @@ Status StringToMap(const std::string& opts_str,
   return Status::OK();
 }
 
-
 Status GetStringFromDBOptions(std::string* opt_string,
                               const DBOptions& db_options,
                               const std::string& delimiter) {
@@ -645,7 +675,6 @@ Status GetStringFromDBOptions(const ConfigOptions& config_options,
   auto config = DBOptionsAsConfigurable(db_options);
   return config->GetOptionString(config_options, opt_string);
 }
-
 
 Status GetStringFromColumnFamilyOptions(std::string* opt_string,
                                         const ColumnFamilyOptions& cf_options,
@@ -665,8 +694,9 @@ Status GetStringFromColumnFamilyOptions(const ConfigOptions& config_options,
 
 Status GetStringFromCompressionType(std::string* compression_str,
                                     CompressionType compression_type) {
-  bool ok = SerializeEnum<CompressionType>(compression_type_string_map,
-                                           compression_type, compression_str);
+  bool ok = SerializeEnum<CompressionType>(
+      OptionsHelper::GetCompressionTypeStringMap(), compression_type,
+      compression_str);
   if (ok) {
     return Status::OK();
   } else {
@@ -685,7 +715,7 @@ Status GetColumnFamilyOptionsFromMap(
 
   const auto config = CFOptionsAsConfigurable(base_options);
   Status s = ConfigureFromMap<ColumnFamilyOptions>(
-      config_options, opts_map, OptionsHelper::kCFOptionsName, config.get(),
+      config_options, opts_map, OptionsHelper::GetCFOptionsName(), config.get(),
       new_options);
   // Translate any errors (NotFound, NotSupported, to InvalidArgument
   if (s.ok() || s.IsInvalidArgument()) {
@@ -717,7 +747,7 @@ Status GetDBOptionsFromMap(
   *new_options = base_options;
   auto config = DBOptionsAsConfigurable(base_options);
   Status s = ConfigureFromMap<DBOptions>(config_options, opts_map,
-                                         OptionsHelper::kDBOptionsName,
+                                         OptionsHelper::GetDBOptionsName(),
                                          config.get(), new_options);
   // Translate any errors (NotFound, NotSupported, to InvalidArgument
   if (s.ok() || s.IsInvalidArgument()) {
@@ -769,7 +799,7 @@ Status GetOptionsFromString(const ConfigOptions& config_options,
 
   if (s.ok()) {
     DBOptions* new_db_options =
-        config->GetOptions<DBOptions>(OptionsHelper::kDBOptionsName);
+        config->GetOptions<DBOptions>(OptionsHelper::GetDBOptionsName());
     if (!unused_opts.empty()) {
       s = GetColumnFamilyOptionsFromMap(config_options, base_options,
                                         unused_opts, &new_cf_options);
@@ -788,41 +818,69 @@ Status GetOptionsFromString(const ConfigOptions& config_options,
   }
 }
 
-std::unordered_map<std::string, EncodingType>
-    OptionsHelper::encoding_type_string_map = {{"kPlain", kPlain},
-                                               {"kPrefix", kPrefix}};
+std::unordered_map<std::string, EncodingType>&
+OptionsHelper::GetEncodingTypeStringMap() {
+  static std::unordered_map<std::string, EncodingType>
+      encoding_type_string_map = {{"kPlain", kPlain}, {"kPrefix", kPrefix}};
 
-std::unordered_map<std::string, CompactionStyle>
-    OptionsHelper::compaction_style_string_map = {
-        {"kCompactionStyleLevel", kCompactionStyleLevel},
-        {"kCompactionStyleUniversal", kCompactionStyleUniversal},
-        {"kCompactionStyleFIFO", kCompactionStyleFIFO},
-        {"kCompactionStyleNone", kCompactionStyleNone}};
+  return encoding_type_string_map;
+}
 
-std::unordered_map<std::string, CompactionPri>
-    OptionsHelper::compaction_pri_string_map = {
-        {"kByCompensatedSize", kByCompensatedSize},
-        {"kOldestLargestSeqFirst", kOldestLargestSeqFirst},
-        {"kOldestSmallestSeqFirst", kOldestSmallestSeqFirst},
-        {"kMinOverlappingRatio", kMinOverlappingRatio},
-        {"kRoundRobin", kRoundRobin}};
+std::unordered_map<std::string, CompactionStyle>&
+OptionsHelper::GetCompactionStyleStringMap() {
+  static std::unordered_map<std::string, CompactionStyle>
+      compaction_style_string_map = {
+          {"kCompactionStyleLevel", kCompactionStyleLevel},
+          {"kCompactionStyleUniversal", kCompactionStyleUniversal},
+          {"kCompactionStyleFIFO", kCompactionStyleFIFO},
+          {"kCompactionStyleNone", kCompactionStyleNone}};
 
-std::unordered_map<std::string, CompactionStopStyle>
-    OptionsHelper::compaction_stop_style_string_map = {
-        {"kCompactionStopStyleSimilarSize", kCompactionStopStyleSimilarSize},
-        {"kCompactionStopStyleTotalSize", kCompactionStopStyleTotalSize}};
+  return compaction_style_string_map;
+}
 
-std::unordered_map<std::string, Temperature>
-    OptionsHelper::temperature_string_map = {
-        {"kUnknown", Temperature::kUnknown},
-        {"kHot", Temperature::kHot},
-        {"kWarm", Temperature::kWarm},
-        {"kCold", Temperature::kCold}};
+std::unordered_map<std::string, CompactionPri>&
+OptionsHelper::GetCompactionPriStringMap() {
+  static std::unordered_map<std::string, CompactionPri>
+      compaction_pri_string_map = {
+          {"kByCompensatedSize", kByCompensatedSize},
+          {"kOldestLargestSeqFirst", kOldestLargestSeqFirst},
+          {"kOldestSmallestSeqFirst", kOldestSmallestSeqFirst},
+          {"kMinOverlappingRatio", kMinOverlappingRatio},
+          {"kRoundRobin", kRoundRobin}};
 
-std::unordered_map<std::string, PrepopulateBlobCache>
-    OptionsHelper::prepopulate_blob_cache_string_map = {
-        {"kDisable", PrepopulateBlobCache::kDisable},
-        {"kFlushOnly", PrepopulateBlobCache::kFlushOnly}};
+  return compaction_pri_string_map;
+}
+
+std::unordered_map<std::string, CompactionStopStyle>&
+OptionsHelper::GetCompactionStopStyleStringMap() {
+  static std::unordered_map<std::string, CompactionStopStyle>
+      compaction_stop_style_string_map = {
+          {"kCompactionStopStyleSimilarSize", kCompactionStopStyleSimilarSize},
+          {"kCompactionStopStyleTotalSize", kCompactionStopStyleTotalSize}};
+
+  return compaction_stop_style_string_map;
+}
+
+std::unordered_map<std::string, Temperature>&
+OptionsHelper::GetTemperatureStringMap() {
+  static std::unordered_map<std::string, Temperature> temperature_string_map = {
+      {"kUnknown", Temperature::kUnknown},
+      {"kHot", Temperature::kHot},
+      {"kWarm", Temperature::kWarm},
+      {"kCold", Temperature::kCold}};
+
+  return temperature_string_map;
+}
+
+std::unordered_map<std::string, PrepopulateBlobCache>&
+OptionsHelper::GetPrepopulateBlobCacheStringMap() {
+  static std::unordered_map<std::string, PrepopulateBlobCache>
+      prepopulate_blob_cache_string_map = {
+          {"kDisable", PrepopulateBlobCache::kDisable},
+          {"kFlushOnly", PrepopulateBlobCache::kFlushOnly}};
+
+  return prepopulate_blob_cache_string_map;
+}
 
 Status OptionTypeInfo::NextToken(const std::string& opts, char delimiter,
                                  size_t pos, size_t* end, std::string* token) {

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -70,9 +70,7 @@ Status StringToMap(const std::string& opts_str,
 
 struct OptionsHelper {
   static const std::string& GetCFOptionsName(); /*= "ColumnFamilyOptions"*/
-  ;
   static const std::string& GetDBOptionsName(); /*= "DBOptions" */
-  ;
   static std::map<CompactionStyle, std::string>& GetCompactionStyleToString();
   static std::map<CompactionPri, std::string>& GetCompactionPriToString();
   static std::map<CompactionStopStyle, std::string>&

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -69,47 +69,31 @@ Status StringToMap(const std::string& opts_str,
                    std::unordered_map<std::string, std::string>* opts_map);
 
 struct OptionsHelper {
-  static const std::string kCFOptionsName /*= "ColumnFamilyOptions"*/;
-  static const std::string kDBOptionsName /*= "DBOptions" */;
-  static std::map<CompactionStyle, std::string> compaction_style_to_string;
-  static std::map<CompactionPri, std::string> compaction_pri_to_string;
-  static std::map<CompactionStopStyle, std::string>
-      compaction_stop_style_to_string;
-  static std::map<Temperature, std::string> temperature_to_string;
-  static std::unordered_map<std::string, ChecksumType> checksum_type_string_map;
-  static std::unordered_map<std::string, CompressionType>
-      compression_type_string_map;
-  static std::unordered_map<std::string, PrepopulateBlobCache>
-      prepopulate_blob_cache_string_map;
-  static std::unordered_map<std::string, CompactionStopStyle>
-      compaction_stop_style_string_map;
-  static std::unordered_map<std::string, EncodingType> encoding_type_string_map;
-  static std::unordered_map<std::string, CompactionStyle>
-      compaction_style_string_map;
-  static std::unordered_map<std::string, CompactionPri>
-      compaction_pri_string_map;
-  static std::unordered_map<std::string, Temperature> temperature_string_map;
+  static const std::string& GetCFOptionsName(); /*= "ColumnFamilyOptions"*/
+  ;
+  static const std::string& GetDBOptionsName(); /*= "DBOptions" */
+  ;
+  static std::map<CompactionStyle, std::string>& GetCompactionStyleToString();
+  static std::map<CompactionPri, std::string>& GetCompactionPriToString();
+  static std::map<CompactionStopStyle, std::string>&
+  GetCompactionStopStyleToString();
+  static std::map<Temperature, std::string>& GetTemperatureToString();
+  static std::unordered_map<std::string, ChecksumType>&
+  GetChecksumTypeStringMap();
+  static std::unordered_map<std::string, CompressionType>&
+  GetCompressionTypeStringMap();
+  static std::unordered_map<std::string, PrepopulateBlobCache>&
+  GetPrepopulateBlobCacheStringMap();
+  static std::unordered_map<std::string, CompactionStopStyle>&
+  GetCompactionStopStyleStringMap();
+  static std::unordered_map<std::string, EncodingType>&
+  GetEncodingTypeStringMap();
+  static std::unordered_map<std::string, CompactionStyle>&
+  GetCompactionStyleStringMap();
+  static std::unordered_map<std::string, CompactionPri>&
+  GetCompactionPriStringMap();
+  static std::unordered_map<std::string, Temperature>&
+  GetTemperatureStringMap();
 };
-
-// Some aliasing
-static auto& compaction_style_to_string =
-    OptionsHelper::compaction_style_to_string;
-static auto& compaction_pri_to_string = OptionsHelper::compaction_pri_to_string;
-static auto& compaction_stop_style_to_string =
-    OptionsHelper::compaction_stop_style_to_string;
-static auto& temperature_to_string = OptionsHelper::temperature_to_string;
-static auto& checksum_type_string_map = OptionsHelper::checksum_type_string_map;
-static auto& compaction_stop_style_string_map =
-    OptionsHelper::compaction_stop_style_string_map;
-static auto& compression_type_string_map =
-    OptionsHelper::compression_type_string_map;
-static auto& encoding_type_string_map = OptionsHelper::encoding_type_string_map;
-static auto& compaction_style_string_map =
-    OptionsHelper::compaction_style_string_map;
-static auto& compaction_pri_string_map =
-    OptionsHelper::compaction_pri_string_map;
-static auto& temperature_string_map = OptionsHelper::temperature_string_map;
-static auto& prepopulate_blob_cache_string_map =
-    OptionsHelper::prepopulate_blob_cache_string_map;
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/options_parser.h
+++ b/options/options_parser.h
@@ -29,8 +29,7 @@ enum OptionSection : char {
   kOptionSectionUnknown
 };
 
-static const std::string opt_section_titles[] = {
-    "Version", "DBOptions", "CFOptions", "TableOptions/", "Unknown"};
+const std::array<std::string, 5>& GetOptSectionTitles();
 
 Status PersistRocksDBOptions(const WriteOptions& write_options,
                              const DBOptions& db_opt,
@@ -146,6 +145,5 @@ class RocksDBOptionsParser {
   int db_version[3];
   int opt_file_version[3];
 };
-
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -622,7 +622,8 @@ TEST_F(OptionsTest, GetColumnFamilyOptionsFromStringTest) {
       "memtable=skip_list:10;arena_block_size=1024",
       &new_cf_opt));
   ASSERT_TRUE(new_cf_opt.memtable_factory != nullptr);
-  ASSERT_EQ(std::string(new_cf_opt.memtable_factory->Name()), "SkipListFactory");
+  ASSERT_EQ(std::string(new_cf_opt.memtable_factory->Name()),
+            "SkipListFactory");
   ASSERT_TRUE(new_cf_opt.memtable_factory->IsInstanceOf("SkipListFactory"));
 
   // blob cache
@@ -933,7 +934,6 @@ TEST_F(OptionsTest, OldInterfaceTest) {
       RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
 }
 
-
 TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
   BlockBasedTableOptions table_opt;
   BlockBasedTableOptions new_opt;
@@ -962,7 +962,7 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
   ASSERT_EQ(new_opt.index_type, BlockBasedTableOptions::kHashSearch);
   ASSERT_EQ(new_opt.checksum, ChecksumType::kxxHash);
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(new_opt.block_size, 1024UL);
   ASSERT_EQ(new_opt.block_size_deviation, 8);
   ASSERT_EQ(new_opt.block_restart_interval, 4);
@@ -1096,13 +1096,14 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
       "strict_capacity_limit=true;high_pri_pool_ratio=0.5;}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
             4);
   ASSERT_EQ(new_opt.block_cache->HasStrictCapacityLimit(), true);
-  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(
-                new_opt.block_cache)->GetHighPriPoolRatio(), 0.5);
+  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(new_opt.block_cache)
+                ->GetHighPriPoolRatio(),
+            0.5);
 
   // Set only block cache capacity. Check other values are
   // reset to default values.
@@ -1112,7 +1113,7 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
       "block_cache_compressed={capacity=2M}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 2*1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 2 * 1024UL * 1024UL);
   // Default values
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
@@ -1134,8 +1135,9 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
                 ->GetNumShardBits(),
             5);
   ASSERT_EQ(new_opt.block_cache->HasStrictCapacityLimit(), false);
-  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(
-                new_opt.block_cache)->GetHighPriPoolRatio(), 0.5);
+  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(new_opt.block_cache)
+                ->GetHighPriPoolRatio(),
+            0.5);
 
   // Set couple of block cache options.
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
@@ -1146,7 +1148,7 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
       "strict_capacity_limit=true;}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
             4);
@@ -1174,7 +1176,6 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
   ASSERT_TRUE(
       new_opt.filter_policy->IsInstanceOf(RibbonFilterPolicy::kNickName()));
 }
-
 
 TEST_F(OptionsTest, GetPlainTableOptionsFromString) {
   PlainTableOptions table_opt;
@@ -1227,14 +1228,14 @@ TEST_F(OptionsTest, GetMemTableRepFactoryFromString) {
                                              &new_mem_factory));
 
   ASSERT_OK(GetMemTableRepFactoryFromString("prefix_hash", &new_mem_factory));
-  ASSERT_OK(GetMemTableRepFactoryFromString("prefix_hash:1000",
-                                            &new_mem_factory));
+  ASSERT_OK(
+      GetMemTableRepFactoryFromString("prefix_hash:1000", &new_mem_factory));
   ASSERT_STREQ(new_mem_factory->Name(), "HashSkipListRepFactory");
   ASSERT_NOK(GetMemTableRepFactoryFromString("prefix_hash:1000:invalid_opt",
                                              &new_mem_factory));
 
-  ASSERT_OK(GetMemTableRepFactoryFromString("hash_linkedlist",
-                                            &new_mem_factory));
+  ASSERT_OK(
+      GetMemTableRepFactoryFromString("hash_linkedlist", &new_mem_factory));
   ASSERT_OK(GetMemTableRepFactoryFromString("hash_linkedlist:1000",
                                             &new_mem_factory));
   ASSERT_EQ(std::string(new_mem_factory->Name()), "HashLinkListRepFactory");
@@ -1760,10 +1761,8 @@ TEST_F(OptionsTest, MutableCFOptions) {
   ASSERT_EQ(bbto->block_size, 32768);
 }
 
-
-Status StringToMap(
-    const std::string& opts_str,
-    std::unordered_map<std::string, std::string>* opts_map);
+Status StringToMap(const std::string& opts_str,
+                   std::unordered_map<std::string, std::string>* opts_map);
 
 TEST_F(OptionsTest, StringToMapTest) {
   std::unordered_map<std::string, std::string> opts_map;
@@ -1821,17 +1820,17 @@ TEST_F(OptionsTest, StringToMapTest) {
   ASSERT_EQ(opts_map["k3"], "v3");
   // Multi-level nested options
   opts_map.clear();
-  ASSERT_OK(StringToMap("k1=v1;k2={nk1=nv1;nk2={nnk1=nnk2}};"
-                        "k3={nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}};k4=v4",
-                        &opts_map));
+  ASSERT_OK(
+      StringToMap("k1=v1;k2={nk1=nv1;nk2={nnk1=nnk2}};"
+                  "k3={nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}};k4=v4",
+                  &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
   ASSERT_EQ(opts_map["k2"], "nk1=nv1;nk2={nnk1=nnk2}");
   ASSERT_EQ(opts_map["k3"], "nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}");
   ASSERT_EQ(opts_map["k4"], "v4");
   // Garbage inside curly braces
   opts_map.clear();
-  ASSERT_OK(StringToMap("k1=v1;k2={dfad=};k3={=};k4=v4",
-                        &opts_map));
+  ASSERT_OK(StringToMap("k1=v1;k2={dfad=};k3={=};k4=v4", &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
   ASSERT_EQ(opts_map["k2"], "dfad=");
   ASSERT_EQ(opts_map["k3"], "=");
@@ -1847,9 +1846,10 @@ TEST_F(OptionsTest, StringToMapTest) {
   ASSERT_EQ(opts_map["k2"], "{{{}}}{}{}");
   // With random spaces
   opts_map.clear();
-  ASSERT_OK(StringToMap("  k1 =  v1 ; k2= {nk1=nv1; nk2={nnk1=nnk2}}  ; "
-                        "k3={  {   } }; k4= v4  ",
-                        &opts_map));
+  ASSERT_OK(
+      StringToMap("  k1 =  v1 ; k2= {nk1=nv1; nk2={nnk1=nnk2}}  ; "
+                  "k3={  {   } }; k4= v4  ",
+                  &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
   ASSERT_EQ(opts_map["k2"], "nk1=nv1; nk2={nnk1=nnk2}");
   ASSERT_EQ(opts_map["k3"], "{   }");
@@ -1897,8 +1897,8 @@ TEST_F(OptionsTest, StringToMapRandomTest) {
       for (int attempt = 0; attempt < 10; attempt++) {
         std::string str = base;
         // Replace random position to space
-        size_t pos = static_cast<size_t>(
-            rnd.Uniform(static_cast<int>(base.size())));
+        size_t pos =
+            static_cast<size_t>(rnd.Uniform(static_cast<int>(base.size())));
         str[pos] = ' ';
         Status s = StringToMap(str, &opts_map);
         ASSERT_TRUE(s.ok() || s.IsInvalidArgument());
@@ -1915,8 +1915,8 @@ TEST_F(OptionsTest, StringToMapRandomTest) {
     std::string str;
     for (int attempt = 0; attempt < len; attempt++) {
       // Add a random character
-      size_t pos = static_cast<size_t>(
-          rnd.Uniform(static_cast<int>(chars.size())));
+      size_t pos =
+          static_cast<size_t>(rnd.Uniform(static_cast<int>(chars.size())));
       str.append(1, chars[pos]);
     }
     Status s = StringToMap(str, &opts_map);
@@ -2517,7 +2517,8 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   exact.sanity_level = ConfigOptions::kSanityLevelExactMatch;
   loose.sanity_level = ConfigOptions::kSanityLevelLooselyCompatible;
 
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   cf_options_map["write_buffer_size"] = "1";
   ASSERT_OK(GetColumnFamilyOptionsFromMap(cf_config_options, base_cf_opt,
@@ -2526,7 +2527,8 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   cf_options_map["unknown_option"] = "1";
   ASSERT_NOK(GetColumnFamilyOptionsFromMap(cf_config_options, base_cf_opt,
                                            cf_options_map, &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   cf_config_options.input_strings_escaped = false;
   cf_config_options.ignore_unknown_options = true;
@@ -2535,7 +2537,8 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(
       loose, base_cf_opt, new_cf_opt, nullptr /* new_opt_map */));
   ASSERT_NOK(RocksDBOptionsParser::VerifyCFOptions(
-      exact /* default for VerifyCFOptions */, base_cf_opt, new_cf_opt, nullptr));
+      exact /* default for VerifyCFOptions */, base_cf_opt, new_cf_opt,
+      nullptr));
 
   DBOptions base_db_opt;
   DBOptions new_db_opt;
@@ -2588,21 +2591,26 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   db_options_map["max_open_files"] = "hello";
   ASSERT_NOK(GetDBOptionsFromMap(db_config_options, base_db_opt, db_options_map,
                                  &new_db_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
 
   // unknow options should fail parsing without ignore_unknown_options = true
   db_options_map["unknown_db_option"] = "1";
   ASSERT_NOK(GetDBOptionsFromMap(db_config_options, base_db_opt, db_options_map,
                                  &new_db_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
 
   db_config_options.input_strings_escaped = false;
   db_config_options.ignore_unknown_options = true;
   ASSERT_OK(GetDBOptionsFromMap(db_config_options, base_db_opt, db_options_map,
                                 &new_db_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
-  ASSERT_NOK(RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
+  ASSERT_NOK(
+      RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
 }
 
 TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
@@ -2643,7 +2651,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "write_buffer_size=13;max_write_buffer_number_=14;", &new_cf_opt));
   ConfigOptions exact;
   exact.sanity_level = ConfigOptions::kSanityLevelExactMatch;
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Comparator from object registry
   std::string kCompName = "reverse_comp";
@@ -2670,18 +2679,21 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
       "write_buffer_size=13;max_write_buffer_number;", &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Error Paring value
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
       "write_buffer_size=13;max_write_buffer_number=;", &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Missing option name
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt, "write_buffer_size=13; =100;", &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   const uint64_t kilo = 1024UL;
   const uint64_t mega = 1024 * kilo;
@@ -2747,7 +2759,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "block_based_table_factory={{{block_size=4;};"
       "arena_block_size=1024",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Unexpected chars after closing curly brace
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
@@ -2756,7 +2769,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "block_based_table_factory={block_size=4;}};"
       "arena_block_size=1024",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
@@ -2764,14 +2778,16 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "block_based_table_factory={block_size=4;}xdfa;"
       "arena_block_size=1024",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
       "write_buffer_size=10;max_write_buffer_number=16;"
       "block_based_table_factory={block_size=4;}xdfa",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Invalid block based table option
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
@@ -2779,7 +2795,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "write_buffer_size=10;max_write_buffer_number=16;"
       "block_based_table_factory={xx_block_size=4;}",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   ASSERT_OK(GetColumnFamilyOptionsFromString(config_options, base_cf_opt,
                                              "optimize_filters_for_hits=true",
@@ -2791,7 +2808,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
   ASSERT_NOK(GetColumnFamilyOptionsFromString(config_options, base_cf_opt,
                                               "optimize_filters_for_hits=junk",
                                               &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Nested plain table options
   // Empty
@@ -2948,7 +2966,7 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
   ASSERT_EQ(new_opt.checksum, ChecksumType::kxxHash);
   ASSERT_TRUE(new_opt.no_block_cache);
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(new_opt.block_size, 1024UL);
   ASSERT_EQ(new_opt.block_size_deviation, 8);
   ASSERT_EQ(new_opt.block_restart_interval, 4);
@@ -3013,13 +3031,14 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
       "strict_capacity_limit=true;high_pri_pool_ratio=0.5;}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
             4);
   ASSERT_EQ(new_opt.block_cache->HasStrictCapacityLimit(), true);
-  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(
-                new_opt.block_cache)->GetHighPriPoolRatio(), 0.5);
+  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(new_opt.block_cache)
+                ->GetHighPriPoolRatio(),
+            0.5);
 
   // Set only block cache capacity. Check other values are
   // reset to default values.
@@ -3029,7 +3048,7 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
       "block_cache_compressed={capacity=2M}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 2*1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 2 * 1024UL * 1024UL);
   // Default values
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
@@ -3051,8 +3070,9 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
                 ->GetNumShardBits(),
             5);
   ASSERT_EQ(new_opt.block_cache->HasStrictCapacityLimit(), false);
-  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(
-                new_opt.block_cache)->GetHighPriPoolRatio(), 0.5);
+  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(new_opt.block_cache)
+                ->GetHighPriPoolRatio(),
+            0.5);
 
   // Set couple of block cache options.
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
@@ -3063,7 +3083,7 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
       "strict_capacity_limit=true;}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
             4);
@@ -3552,13 +3572,19 @@ TEST_F(OptionsParserTest, ParseVersion) {
   RocksDBOptionsParser parser;
 
   const std::vector<std::string> invalid_versions = {
-      "a.b.c", "3.2.2b", "3.-12", "3. 1",  // only digits and dots are allowed
+      "a.b.c",
+      "3.2.2b",
+      "3.-12",
+      "3. 1",  // only digits and dots are allowed
       "1.2.3.4",
       "1.2.3"  // can only contains at most one dot.
       "0",     // options_file_version must be at least one
       "3..2",
-      ".", ".1.2",             // must have at least one digit before each dot
-      "1.2.", "1.", "2.34."};  // must have at least one digit after each dot
+      ".",
+      ".1.2",  // must have at least one digit before each dot
+      "1.2.",
+      "1.",
+      "2.34."};  // must have at least one digit after each dot
   for (const auto& iv : invalid_versions) {
     snprintf(buffer, kLength - 1, file_template.c_str(), iv.c_str());
 
@@ -3717,7 +3743,10 @@ TEST_F(OptionsParserTest, Readahead) {
 TEST_F(OptionsParserTest, DumpAndParse) {
   DBOptions base_db_opt;
   std::vector<ColumnFamilyOptions> base_cf_opts;
-  std::vector<std::string> cf_names = {"default", "cf1", "cf2", "cf3",
+  std::vector<std::string> cf_names = {"default",
+                                       "cf1",
+                                       "cf2",
+                                       "cf3",
                                        "c:f:4:4:4"
                                        "p\\i\\k\\a\\chu\\\\\\",
                                        "###rocksdb#1-testcf#2###"};
@@ -4648,42 +4677,42 @@ TEST_F(OptionTypeInfoTest, TestCustomEnum) {
 
 TEST_F(OptionTypeInfoTest, TestBuiltinEnum) {
   ConfigOptions config_options;
-  for (const auto& iter : OptionsHelper::compaction_style_string_map) {
+  for (const auto& iter : OptionsHelper::GetCompactionStyleStringMap()) {
     CompactionStyle e1, e2;
     TestParseAndCompareOption(config_options,
                               OptionTypeInfo(0, OptionType::kCompactionStyle),
                               "CompactionStyle", iter.first, &e1, &e2);
     ASSERT_EQ(e1, iter.second);
   }
-  for (const auto& iter : OptionsHelper::compaction_pri_string_map) {
+  for (const auto& iter : OptionsHelper::GetCompactionPriStringMap()) {
     CompactionPri e1, e2;
     TestParseAndCompareOption(config_options,
                               OptionTypeInfo(0, OptionType::kCompactionPri),
                               "CompactionPri", iter.first, &e1, &e2);
     ASSERT_EQ(e1, iter.second);
   }
-  for (const auto& iter : OptionsHelper::compression_type_string_map) {
+  for (const auto& iter : OptionsHelper::GetCompressionTypeStringMap()) {
     CompressionType e1, e2;
     TestParseAndCompareOption(config_options,
                               OptionTypeInfo(0, OptionType::kCompressionType),
                               "CompressionType", iter.first, &e1, &e2);
     ASSERT_EQ(e1, iter.second);
   }
-  for (const auto& iter : OptionsHelper::compaction_stop_style_string_map) {
+  for (const auto& iter : OptionsHelper::GetCompactionStopStyleStringMap()) {
     CompactionStopStyle e1, e2;
     TestParseAndCompareOption(
         config_options, OptionTypeInfo(0, OptionType::kCompactionStopStyle),
         "CompactionStopStyle", iter.first, &e1, &e2);
     ASSERT_EQ(e1, iter.second);
   }
-  for (const auto& iter : OptionsHelper::checksum_type_string_map) {
+  for (const auto& iter : OptionsHelper::GetChecksumTypeStringMap()) {
     ChecksumType e1, e2;
     TestParseAndCompareOption(config_options,
                               OptionTypeInfo(0, OptionType::kChecksumType),
                               "CheckSumType", iter.first, &e1, &e2);
     ASSERT_EQ(e1, iter.second);
   }
-  for (const auto& iter : OptionsHelper::encoding_type_string_map) {
+  for (const auto& iter : OptionsHelper::GetEncodingTypeStringMap()) {
     EncodingType e1, e2;
     TestParseAndCompareOption(config_options,
                               OptionTypeInfo(0, OptionType::kEncodingType),

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -164,7 +164,6 @@ size_t TailPrefetchStats::GetSuggestedPrefetchSize() {
   return std::min(kMaxPrefetchSize, max_qualified_size);
 }
 
-
 const std::string kOptNameMetadataCacheOpts = "metadata_cache_options";
 
 static std::unordered_map<std::string, PinningTier>
@@ -495,8 +494,8 @@ namespace {
 // Different cache kinds use the same keys for physically different values, so
 // they must not share an underlying key space with each other.
 Status CheckCacheOptionCompatibility(const BlockBasedTableOptions& bbto) {
-  int cache_count = (bbto.block_cache != nullptr) +
-                    (bbto.persistent_cache != nullptr);
+  int cache_count =
+      (bbto.block_cache != nullptr) + (bbto.persistent_cache != nullptr);
   if (cache_count <= 1) {
     // Nothing to share / overlap
     return Status::OK();
@@ -724,7 +723,7 @@ Status BlockBasedTableFactory::ValidateOptions(
     }
   }
   std::string garbage;
-  if (!SerializeEnum<ChecksumType>(checksum_type_string_map,
+  if (!SerializeEnum<ChecksumType>(OptionsHelper::GetChecksumTypeStringMap(),
                                    table_options_.checksum, &garbage)) {
     return Status::InvalidArgument(
         "Unrecognized ChecksumType for checksum: " +

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -1128,9 +1128,8 @@ static inline Function Choose_Extend() {
 #endif
 }
 
-static Function ChosenExtend = Choose_Extend();
 uint32_t Extend(uint32_t crc, const char* buf, size_t size) {
-  return ChosenExtend(crc, buf, size);
+  return Choose_Extend()(crc, buf, size);
 }
 
 // The code for crc32c combine, copied with permission from folly

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-
 #include <algorithm>
 #include <atomic>
 #include <cinttypes>
@@ -3106,8 +3105,8 @@ IOStatus BackupEngineImpl::BackupMeta::LoadFromFile(
       } else if (field_name == kFileSizeFieldName) {
         expected_size = std::strtoull(field_data.c_str(), nullptr, /*base*/ 10);
       } else if (field_name == kTemperatureFieldName) {
-        auto iter = temperature_string_map.find(field_data);
-        if (iter != temperature_string_map.end()) {
+        auto iter = OptionsHelper::GetTemperatureStringMap().find(field_data);
+        if (iter != OptionsHelper::GetTemperatureStringMap().end()) {
           temp = iter->second;
         } else {
           // Could report corruption, but in case of new temperatures added
@@ -3279,7 +3278,7 @@ IOStatus BackupEngineImpl::BackupMeta::StoreToFile(
     }
     if (schema_version >= 2 && file->temp != Temperature::kUnknown) {
       buf << " " << kTemperatureFieldName << " "
-          << temperature_to_string[file->temp];
+          << OptionsHelper::GetTemperatureToString()[file->temp];
     }
     if (schema_test_options && schema_test_options->file_sizes) {
       buf << " " << kFileSizeFieldName << " " << std::to_string(file->size);

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1267,7 +1267,8 @@ void BlobDBImpl::GetCompactionContext(BlobCompactionContext* context,
 
 void BlobDBImpl::UpdateLiveSSTSize(const WriteOptions& write_options) {
   uint64_t live_sst_size = 0;
-  bool ok = GetIntProperty(DB::Properties::kLiveSstFilesSize, &live_sst_size);
+  bool ok =
+      GetIntProperty(DB::Properties::GetLiveSstFilesSize(), &live_sst_size);
   if (ok) {
     live_sst_size_.store(live_sst_size);
     ROCKS_LOG_INFO(db_options_.info_log,

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/blob_db/blob_db.h"
 
 #include <algorithm>
@@ -1223,7 +1222,7 @@ TEST_F(BlobDBTest, FIFOEviction_NoEnoughBlobFilesToEvict) {
   ASSERT_OK(blob_db_->Flush(FlushOptions()));
 
   uint64_t live_sst_size = 0;
-  ASSERT_TRUE(blob_db_->GetIntProperty(DB::Properties::kTotalSstFilesSize,
+  ASSERT_TRUE(blob_db_->GetIntProperty(DB::Properties::GetTotalSstFilesSize(),
                                        &live_sst_size));
   ASSERT_TRUE(live_sst_size > 0);
 

--- a/utilities/memory/memory_util.cc
+++ b/utilities/memory/memory_util.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/memory_util.h"
 
 #include "db/db_impl/db_impl.h"
@@ -19,11 +18,11 @@ Status MemoryUtil::GetApproximateMemoryUsageByType(
   // MemTable
   for (auto* db : dbs) {
     uint64_t usage = 0;
-    if (db->GetAggregatedIntProperty(DB::Properties::kSizeAllMemTables,
+    if (db->GetAggregatedIntProperty(DB::Properties::GetSizeAllMemTables(),
                                      &usage)) {
       (*usage_by_type)[MemoryUtil::kMemTableTotal] += usage;
     }
-    if (db->GetAggregatedIntProperty(DB::Properties::kCurSizeAllMemTables,
+    if (db->GetAggregatedIntProperty(DB::Properties::GetCurSizeAllMemTables(),
                                      &usage)) {
       (*usage_by_type)[MemoryUtil::kMemTableUnFlushed] += usage;
     }
@@ -32,8 +31,8 @@ Status MemoryUtil::GetApproximateMemoryUsageByType(
   // Table Readers
   for (auto* db : dbs) {
     uint64_t usage = 0;
-    if (db->GetAggregatedIntProperty(DB::Properties::kEstimateTableReadersMem,
-                                     &usage)) {
+    if (db->GetAggregatedIntProperty(
+            DB::Properties::GetEstimateTableReadersMem(), &usage)) {
       (*usage_by_type)[MemoryUtil::kTableReadersTotal] += usage;
     }
   }

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -453,8 +453,8 @@ TEST_P(OptimisticTransactionTest, CheckKeySkipOldMemtable) {
       ASSERT_OK(db_impl->TEST_SwitchMemtable());
     }
     uint64_t num_imm_mems;
-    ASSERT_TRUE(txn_db->GetIntProperty(DB::Properties::kNumImmutableMemTable,
-                                       &num_imm_mems));
+    ASSERT_TRUE(txn_db->GetIntProperty(
+        DB::Properties::GetNumImmutableMemTable(), &num_imm_mems));
     if (attempt == kAttemptHistoryMemtable) {
       ASSERT_EQ(0, num_imm_mems);
     } else {

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include <algorithm>
 #include <atomic>
 #include <cinttypes>
@@ -841,7 +840,7 @@ TEST_P(WritePreparedTransactionTest, CheckKeySkipOldMemtable) {
       ASSERT_OK(db_impl->TEST_SwitchMemtable());
     }
     uint64_t num_imm_mems;
-    ASSERT_TRUE(db->GetIntProperty(DB::Properties::kNumImmutableMemTable,
+    ASSERT_TRUE(db->GetIntProperty(DB::Properties::GetNumImmutableMemTable(),
                                    &num_imm_mems));
     if (attempt == kAttemptHistoryMemtable) {
       ASSERT_EQ(0, num_imm_mems);
@@ -3596,7 +3595,7 @@ TEST_P(WritePreparedTransactionTest, NonAtomicCommitOfDelayedPrepared) {
       ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
       ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
     }  // for split_before_mutex
-  }    // for split_read
+  }  // for split_read
 }
 
 // When max evicted seq advances a prepared seq, it involves two updates: i)


### PR DESCRIPTION
When opening a rocksdb instance in a static object the static members or global variables that don't have "constexpr" aren't guaranteed to be initialized before said object.

Implemented constexpr when possible and wrapped around static members with Getter methods. 