### PR TITLE
Update pinned folly version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2472,7 +2472,7 @@ checkout_folly:
 	fi
 	@# Pin to a particular version for public CI, so that PR authors don't
 	@# need to worry about folly breaking our integration. Update periodically
-	cd third-party/folly && git reset --hard beacd86d63cd71c904632262e6c36f60874d78ba
+	cd third-party/folly && git reset --hard 48f8d8840a64aea1bb8a2a1b0696f6ddf28c9bea
 	@# A hack to remove boost dependency.
 	@# NOTE: this hack is only needed if building using USE_FOLLY_LITE
 	perl -pi -e 's/^(#include <boost)/\/\/$$1/' third-party/folly/folly/functional/Invoke.h


### PR DESCRIPTION
Summary: The version we've been using no longer builds in CI (broken dependency download link)

Test Plan: CI