### PR TITLE
Add entry for #12803: fix race between event listener and error handler

### DIFF
--- a/unreleased_history/bug_fixes/event_listener_race_with_error_handler.md
+++ b/unreleased_history/bug_fixes/event_listener_race_with_error_handler.md
@@ -1,0 +1,1 @@
+Fixed a bug where event listener reads ErrorHandler's `bg_error_` member without holding db mutex(#12803).


### PR DESCRIPTION
As titled.