### PR TITLE
Tag FaultInjectionIOType::kRead for FaultInjectionTestFS new read file & fix unreleased snapshot

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2868,6 +2868,7 @@ void StressTest::TestAcquireSnapshot(ThreadState* thread,
   // verify that the results are the same.
   Status status_at = db_->Get(ropt, column_family, key, &value_at);
   if (!status_at.ok() && IsErrorInjectedAndRetryable(status_at)) {
+    db_->ReleaseSnapshot(snapshot);
     return;
   }
   std::vector<bool>* key_vec = nullptr;

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -846,8 +846,8 @@ IOStatus FaultInjectionTestFS::NewRandomAccessFile(
   if (!IsFilesystemActive()) {
     return GetError();
   }
-  IOStatus io_s = MaybeInjectThreadLocalError(
-      FaultInjectionIOType::kMetadataWrite, file_opts.io_options);
+  IOStatus io_s = MaybeInjectThreadLocalError(FaultInjectionIOType::kRead,
+                                              file_opts.io_options);
   if (!io_s.ok()) {
     return io_s;
   }
@@ -866,8 +866,8 @@ IOStatus FaultInjectionTestFS::NewSequentialFile(
   if (!IsFilesystemActive()) {
     return GetError();
   }
-  IOStatus io_s = MaybeInjectThreadLocalError(
-      FaultInjectionIOType::kMetadataWrite, file_opts.io_options);
+  IOStatus io_s = MaybeInjectThreadLocalError(FaultInjectionIOType::kRead,
+                                              file_opts.io_options);
   if (!io_s.ok()) {
     return io_s;
   }


### PR DESCRIPTION
**Context/Summary:** It makes more sense to mark error injection during creation as read file as "kread" so we don't get confusing msg like below 
```
stderr:
 error : Get() returns IO error: injected metadata write error for key: 000000000000004F000000000000012B00000000000000EF.
Verification failed :(
```

Also an early return here https://github.com/facebook/rocksdb/blob/e0ddbee76fdc55b1e9f449b6e430b76291268786/db_stress_tool/db_stress_test_base.cc#L2871 can lead to unreleased snapshot upon DB restart `Non-ok close status: Operation aborted: Cannot close DB with unreleased snapshot`. This PR fixed it too.


**Test:** CI