### PR TITLE
Allow kPointInTimeRecovery to recover until corrupted write batch

### DIFF
--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -244,8 +244,9 @@ class WriteBatchInternal {
 
   // Update per-key value protection information on this write batch.
   // If checksum is provided, the batch content is verfied against the checksum.
-  static Status UpdateProtectionInfo(WriteBatch* wb, size_t bytes_per_key,
-                                     uint64_t* checksum = nullptr);
+  static Status UpdateProtectionInfo(WriteBatch* wb, size_t bytes_per_key);
+
+  static Status VerifyChecksum(WriteBatch* wb, uint64_t expected_checksum);
 };
 
 // LocalSavePoint is similar to a scope guard


### PR DESCRIPTION
Summary: instead of failing DB open, when we see a corrupted write batch, we should follow the convention to report corruption and decide on what to do based on wal recovery mode.

Test plan: added a new unit test.