### PR TITLE
Fix MultiGet dropping memtable kv checksum corruption

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2476,7 +2476,8 @@ Status DBImpl::GetImpl(const ReadOptions& read_options, const Slice& key,
         RecordTick(stats_, MEMTABLE_HIT);
       }
     }
-    if (!done && !s.ok() && !s.IsMergeInProgress()) {
+    if (!s.ok() && !s.IsMergeInProgress() && !s.IsNotFound()) {
+      assert(done);
       ReturnAndCleanupSuperVersion(cfd, sv);
       return s;
     }

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -933,6 +933,8 @@ static bool SaveValue(void* arg, const char* entry) {
   Saver* s = static_cast<Saver*>(arg);
   assert(s != nullptr);
   assert(!s->value || !s->columns);
+  assert(!*(s->found_final_value));
+  assert(s->status->ok() || s->status->IsMergeInProgress());
 
   MergeContext* merge_context = s->merge_context;
   SequenceNumber max_covering_tombstone_seq = s->max_covering_tombstone_seq;
@@ -966,6 +968,7 @@ static bool SaveValue(void* arg, const char* entry) {
       *(s->status) = MemTable::VerifyEntryChecksum(
           entry, s->protection_bytes_per_key, s->allow_data_in_errors);
       if (!s->status->ok()) {
+        *(s->found_final_value) = true;
         ROCKS_LOG_ERROR(s->logger, "In SaveValue: %s", s->status->getState());
         // Memtable entry corrupted
         return false;
@@ -1231,6 +1234,7 @@ static bool SaveValue(void* arg, const char* entry) {
                      ". ");
           msg.append("seq: " + std::to_string(seq) + ".");
         }
+        *(s->found_final_value) = true;
         *(s->status) = Status::Corruption(msg.c_str());
         return false;
       }
@@ -1310,7 +1314,7 @@ bool MemTable::Get(const LookupKey& key, std::string* value,
 
   // No change to value, since we have not yet found a Put/Delete
   // Propagate corruption error
-  if (!found_final_value && merge_in_progress && !s->IsCorruption()) {
+  if (!found_final_value && merge_in_progress && s->ok()) {
     *s = Status::MergeInProgress();
   }
   PERF_COUNTER_ADD(get_from_memtable_count, 1);
@@ -1348,6 +1352,7 @@ void MemTable::GetFromTable(const LookupKey& key,
   saver.allow_data_in_errors = moptions_.allow_data_in_errors;
   saver.protection_bytes_per_key = moptions_.protection_bytes_per_key;
   table_->Get(key, &saver, SaveValue);
+  assert(s->ok() || s->IsMergeInProgress() || *found_final_value);
   *seq = saver.seq;
 }
 
@@ -1420,11 +1425,16 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                  iter->timestamp, iter->s, &(iter->merge_context), &dummy_seq,
                  &found_final_value, &merge_in_progress);
 
-    if (!found_final_value && merge_in_progress) {
+    if (!found_final_value && merge_in_progress && iter->s->ok()) {
       *(iter->s) = Status::MergeInProgress();
     }
 
-    if (found_final_value) {
+    if (found_final_value ||
+        (!iter->s->ok() && !iter->s->IsMergeInProgress())) {
+      // `found_final_value` should be set if an error/corruption occurs.
+      // The check on iter->s is just there in case GetFromTable() did not
+      // set `found_final_value` properly.
+      assert(found_final_value);
       if (iter->value) {
         iter->value->PinSelf();
         range->AddValueSize(iter->value->size());

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -1314,8 +1314,12 @@ bool MemTable::Get(const LookupKey& key, std::string* value,
 
   // No change to value, since we have not yet found a Put/Delete
   // Propagate corruption error
-  if (!found_final_value && merge_in_progress && s->ok()) {
-    *s = Status::MergeInProgress();
+  if (!found_final_value && merge_in_progress) {
+    if (s->ok()) {
+      *s = Status::MergeInProgress();
+    } else {
+      assert(s->IsMergeInProgress());
+    }
   }
   PERF_COUNTER_ADD(get_from_memtable_count, 1);
   return found_final_value;
@@ -1425,8 +1429,12 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                  iter->timestamp, iter->s, &(iter->merge_context), &dummy_seq,
                  &found_final_value, &merge_in_progress);
 
-    if (!found_final_value && merge_in_progress && iter->s->ok()) {
-      *(iter->s) = Status::MergeInProgress();
+    if (!found_final_value && merge_in_progress) {
+      if (iter->s->ok()) {
+        *(iter->s) = Status::MergeInProgress();
+      } else {
+        assert(iter->s->IsMergeInProgress());
+      }
     }
 
     if (found_final_value ||

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -249,12 +249,14 @@ class MemTable {
   // If do_merge = true the default behavior which is Get value for key is
   // executed. Expected behavior is described right below.
   // If memtable contains a value for key, store it in *value and return true.
-  // If memtable contains a deletion for key, store a NotFound() error
-  // in *status and return true.
+  // If memtable contains a deletion for key, store NotFound() in *status and
+  // return true.
   // If memtable contains Merge operation as the most recent entry for a key,
   //   and the merge process does not stop (not reaching a value or delete),
   //   prepend the current merge operand to *operands.
   //   store MergeInProgress in s, and return false.
+  // If an unexpected error or corruption occurs, store Corruption() or other
+  // error in *status and return true.
   // Else, return false.
   // If any operation was found, its most recent sequence number
   // will be stored in *seq on success (regardless of whether true/false is

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -181,7 +181,8 @@ bool MemTableListVersion::GetFromList(
     }
 
     if (done) {
-      assert(*seq != kMaxSequenceNumber || s->IsNotFound());
+      assert(*seq != kMaxSequenceNumber ||
+             (!s->ok() && !s->IsMergeInProgress()));
       return true;
     }
     if (!s->ok() && !s->IsMergeInProgress() && !s->IsNotFound()) {

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -287,6 +287,7 @@ TEST_F(MemTableListTest, GetTest) {
 
   // Fetch the newly written keys
   merge_context.Clear();
+  s = Status::OK();
   found = mem->Get(LookupKey("key1", seq), &value, /*columns*/ nullptr,
                    /*timestamp*/ nullptr, &s, &merge_context,
                    &max_covering_tombstone_seq, ReadOptions(),
@@ -295,6 +296,7 @@ TEST_F(MemTableListTest, GetTest) {
   ASSERT_EQ(value, "value1");
 
   merge_context.Clear();
+  s = Status::OK();
   found = mem->Get(LookupKey("key1", 2), &value, /*columns*/ nullptr,
                    /*timestamp*/ nullptr, &s, &merge_context,
                    &max_covering_tombstone_seq, ReadOptions(),
@@ -303,6 +305,7 @@ TEST_F(MemTableListTest, GetTest) {
   ASSERT_TRUE(found && s.IsNotFound());
 
   merge_context.Clear();
+  s = Status::OK();
   found = mem->Get(LookupKey("key2", seq), &value, /*columns*/ nullptr,
                    /*timestamp*/ nullptr, &s, &merge_context,
                    &max_covering_tombstone_seq, ReadOptions(),
@@ -311,6 +314,7 @@ TEST_F(MemTableListTest, GetTest) {
   ASSERT_EQ(value, "value2.2");
 
   merge_context.Clear();
+  s = Status::OK();
   found = mem->Get(LookupKey("key3", seq), &value, /*columns*/ nullptr,
                    /*timestamp*/ nullptr, &s, &merge_context,
                    &max_covering_tombstone_seq, ReadOptions(),
@@ -350,6 +354,7 @@ TEST_F(MemTableListTest, GetTest) {
 
   // Fetch keys via MemTableList
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key1", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,
@@ -357,6 +362,7 @@ TEST_F(MemTableListTest, GetTest) {
   ASSERT_TRUE(found && s.IsNotFound());
 
   merge_context.Clear();
+  s = Status::OK();
   found = list.current()->Get(LookupKey("key1", saved_seq), &value,
                               /*columns=*/nullptr, /*timestamp=*/nullptr, &s,
                               &merge_context, &max_covering_tombstone_seq,
@@ -365,6 +371,7 @@ TEST_F(MemTableListTest, GetTest) {
   ASSERT_EQ("value1", value);
 
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key2", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,
@@ -373,12 +380,14 @@ TEST_F(MemTableListTest, GetTest) {
   ASSERT_EQ(value, "value2.3");
 
   merge_context.Clear();
+  s = Status::OK();
   found = list.current()->Get(LookupKey("key2", 1), &value, /*columns=*/nullptr,
                               /*timestamp=*/nullptr, &s, &merge_context,
                               &max_covering_tombstone_seq, ReadOptions());
   ASSERT_FALSE(found);
 
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key3", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,
@@ -438,6 +447,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
 
   // Fetch the newly written keys
   merge_context.Clear();
+  s = Status::OK();
   found = mem->Get(LookupKey("key1", seq), &value, /*columns*/ nullptr,
                    /*timestamp*/ nullptr, &s, &merge_context,
                    &max_covering_tombstone_seq, ReadOptions(),
@@ -446,6 +456,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   ASSERT_TRUE(found && s.IsNotFound());
 
   merge_context.Clear();
+  s = Status::OK();
   found = mem->Get(LookupKey("key2", seq), &value, /*columns*/ nullptr,
                    /*timestamp*/ nullptr, &s, &merge_context,
                    &max_covering_tombstone_seq, ReadOptions(),
@@ -462,6 +473,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
 
   // Fetch keys via MemTableList
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key1", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,
@@ -469,6 +481,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   ASSERT_TRUE(found && s.IsNotFound());
 
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key2", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,
@@ -508,6 +521,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
 
   // Verify keys are present in history
   merge_context.Clear();
+  s = Status::OK();
   found = list.current()->GetFromHistory(
       LookupKey("key1", seq), &value, /*columns=*/nullptr,
       /*timestamp=*/nullptr, &s, &merge_context, &max_covering_tombstone_seq,
@@ -515,6 +529,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   ASSERT_TRUE(found && s.IsNotFound());
 
   merge_context.Clear();
+  s = Status::OK();
   found = list.current()->GetFromHistory(
       LookupKey("key2", seq), &value, /*columns=*/nullptr,
       /*timestamp=*/nullptr, &s, &merge_context, &max_covering_tombstone_seq,
@@ -568,6 +583,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
 
   // Verify keys are no longer in MemTableList
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key1", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,
@@ -575,6 +591,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   ASSERT_FALSE(found);
 
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key2", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,
@@ -582,6 +599,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   ASSERT_FALSE(found);
 
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key3", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,
@@ -590,6 +608,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
 
   // Verify that the second memtable's keys are in the history
   merge_context.Clear();
+  s = Status::OK();
   found = list.current()->GetFromHistory(
       LookupKey("key1", seq), &value, /*columns=*/nullptr,
       /*timestamp=*/nullptr, &s, &merge_context, &max_covering_tombstone_seq,
@@ -597,6 +616,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   ASSERT_TRUE(found && s.IsNotFound());
 
   merge_context.Clear();
+  s = Status::OK();
   found = list.current()->GetFromHistory(
       LookupKey("key3", seq), &value, /*columns=*/nullptr,
       /*timestamp=*/nullptr, &s, &merge_context, &max_covering_tombstone_seq,
@@ -606,6 +626,7 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
 
   // Verify that key2 from the first memtable is no longer in the history
   merge_context.Clear();
+  s = Status::OK();
   found =
       list.current()->Get(LookupKey("key2", seq), &value, /*columns=*/nullptr,
                           /*timestamp=*/nullptr, &s, &merge_context,

--- a/unreleased_history/bug_fixes/multiget-kv-checksum.md
+++ b/unreleased_history/bug_fixes/multiget-kv-checksum.md
@@ -1,0 +1,1 @@
+* Fix a bug where per kv checksum corruption may be ignored in MultiGet().


### PR DESCRIPTION
Corruption status returned by `GetFromTable()` could be overwritten here: https://github.com/facebook/rocksdb/blob/b6c3495a7183f01901d3be01dc68f7e40a1a2e9b/db/version_set.cc#L2614

This PR fixes this issue by setting `*(s->found_final_value) = true;` in SaveValue. Also makes the handling of the return value of `GetFromTable()` more robust and added asserts in a couple places. 


Test plan: Updated an existing unit test to cover MultiGet. It fails the assertion here before this PR: https://github.com/facebook/rocksdb/blob/b6c3495a7183f01901d3be01dc68f7e40a1a2e9b/db/version_set.cc#L2601