### PR TITLE
Fix a bug where `OnErrorRecoveryBegin()` is not called before auto-recovery

### DIFF
--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -289,7 +289,8 @@ class DbStressListener : public EventListener {
     }
   }
 
-  void OnErrorRecoveryCompleted(Status /* old_bg_error */) override {
+  void OnErrorRecoveryEnd(
+      const BackgroundErrorRecoveryInfo& /*info*/) override {
     RandomSleep();
     if (FLAGS_error_recovery_with_no_fault_injection && fault_fs_guard) {
       fault_fs_guard->EnableThreadLocalErrorInjection(

--- a/unreleased_history/bug_fixes/event_listener_not_called.md
+++ b/unreleased_history/bug_fixes/event_listener_not_called.md
@@ -1,0 +1,1 @@
+Fixed a bug where `OnErrorRecoveryBegin()` is not called before auto recovery starts.


### PR DESCRIPTION
**Context/Summary:**
`*auto_recovery` needs to be set true in order for `OnErrorRecoveryBegin()` to be called before auto-recovery
https://github.com/facebook/rocksdb/blob/3db030d7ee1b887ce818ec6f6a8d10949f9e9a22/db/event_helpers.cc#L64-L66
Currently it's set false for auto-recovery. This PR fixes it.


**Test plan:**
- Manual observation that it is called
- Existing UT
