### PR TITLE
FaultInjectionTestFS follow-up and clean-up

### DIFF
--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -41,17 +41,15 @@ enum class FaultInjectionIOType {
 
 struct FSFileState {
   std::string filename_;
-  int64_t pos_at_last_append_;
-  int64_t pos_at_last_sync_;
+  uint64_t pos_at_last_append_ = 0;
+  uint64_t pos_at_last_sync_ = 0;
   std::string buffer_;
 
-  explicit FSFileState(const std::string& filename)
-      : filename_(filename), pos_at_last_append_(-1), pos_at_last_sync_(-1) {}
-
-  FSFileState() : pos_at_last_append_(-1), pos_at_last_sync_(-1) {}
+  explicit FSFileState(const std::string& filename = {})
+      : filename_(filename) {}
 
   bool IsFullySynced() const {
-    return pos_at_last_append_ <= 0 || pos_at_last_append_ == pos_at_last_sync_;
+    return pos_at_last_append_ == pos_at_last_sync_;
   }
 
   IOStatus DropUnsyncedData();


### PR DESCRIPTION
Summary: In follow-up to #12852:
* Use std::copy in place of copy_n for potentially overlapping buffer
* Get rid of troublesome -1 idiom from `pos_at_last_append_` and `pos_at_last_sync_`
* Small improvements to test FaultInjectionFSTest.ReadUnsyncedData

Test Plan: CI, crash test, etc.