### PR TITLE
Fix unhandled MANIFEST write errors

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5564,7 +5564,9 @@ Status VersionSet::ProcessManifestWrites(
         s = WriteCurrentStateToManifest(write_options, curr_state,
                                         wal_additions, descriptor_log_.get(),
                                         io_s);
-      } else {
+        assert(s == io_s);
+      }
+      if (!io_s.ok()) {
         manifest_io_status = io_s;
         s = io_s;
       }

--- a/unreleased_history/bug_fixes/handle_manifest_error.md
+++ b/unreleased_history/bug_fixes/handle_manifest_error.md
@@ -1,0 +1,1 @@
+Fixed a bug in handling MANIFEST write error that caused the latest valid MANIFEST file to get deleted, resulting in the DB being unopenable.


### PR DESCRIPTION
The failure of `WriteCurrentStateToManifest()` in `VersionSet::ProcessManifestWrites()` was not handled properly. If it failed, `manifest_io_status` was not updated, leading to `manifest_file_number_` being updated to the newly created manifest even though its bad. This would lead to the bad manifest immediately getting deleted, and also the good manifest (referenced by `CURRENT`) getting deleted by obsolete file deletion because of `manifest_file_number_` not referencing its number.
