### PR TITLE
Reduce cases of impacted performance from bug fix

### DIFF
--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -20,7 +20,8 @@ namespace ROCKSDB_NAMESPACE {
 FullFilterBlockBuilder::FullFilterBlockBuilder(
     const SliceTransform* _prefix_extractor, bool whole_key_filtering,
     FilterBitsBuilder* filter_bits_builder)
-    : prefix_extractor_(_prefix_extractor),
+    : need_last_prefix_(whole_key_filtering && _prefix_extractor != nullptr),
+      prefix_extractor_(_prefix_extractor),
       whole_key_filtering_(whole_key_filtering),
       last_whole_key_recorded_(false),
       last_prefix_recorded_(false),
@@ -38,7 +39,7 @@ void FullFilterBlockBuilder::Add(const Slice& key_without_ts) {
   const bool add_prefix =
       prefix_extractor_ && prefix_extractor_->InDomain(key_without_ts);
 
-  if (!last_prefix_recorded_ && last_key_in_domain_) {
+  if (need_last_prefix_ && !last_prefix_recorded_ && last_key_in_domain_) {
     // We can reach here when a new filter partition starts in partitioned
     // filter. The last prefix in the previous partition should be added if
     // necessary regardless of key_without_ts, to support prefix SeekForPrev.
@@ -82,12 +83,13 @@ inline void FullFilterBlockBuilder::AddKey(const Slice& key) {
 void FullFilterBlockBuilder::AddPrefix(const Slice& key) {
   assert(prefix_extractor_ && prefix_extractor_->InDomain(key));
   Slice prefix = prefix_extractor_->Transform(key);
-  if (true /*WART*/ || whole_key_filtering_) {
+  if (need_last_prefix_) {
     // WART/FIXME: Because last_prefix_str_ is needed above to make
-    // SeekForPrev work, we are currently using this inefficient code always.
-    // Hopefully this can be optimized with some refactoring up the call chain
-    // to BlockBasedTableBuilder. Even in PartitionedFilterBlockBuilder, we
-    // don't currently have access to the previous key/prefix by the time we
+    // SeekForPrev work with partitioned + prefix filters, we are currently
+    // use this inefficient code in that case (in addition to prefix+whole
+    // key). Hopefully this can be optimized with some refactoring up the call
+    // chain to BlockBasedTableBuilder. Even in PartitionedFilterBlockBuilder,
+    // we don't currently have access to the previous key/prefix by the time we
     // know we are starting a new partition.
 
     // if both whole_key and prefix are added to bloom then we will have whole

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -69,6 +69,7 @@ class FullFilterBlockBuilder : public FilterBlockBuilder {
   void AddPrefix(const Slice& key);
   const SliceTransform* prefix_extractor() { return prefix_extractor_; }
   const std::string& last_prefix_str() const { return last_prefix_str_; }
+  bool need_last_prefix_;
 
  private:
   // important: all of these might point to invalid addresses

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -45,6 +45,9 @@ PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
       p_index_builder_(p_index_builder),
       keys_added_to_partition_(0),
       total_added_in_built_(0) {
+  // See FullFilterBlockBuilder::AddPrefix
+  need_last_prefix_ = prefix_extractor() != nullptr;
+  // Compute keys_per_partition_
   keys_per_partition_ = static_cast<uint32_t>(
       filter_bits_builder_->ApproximateNumEntries(partition_size));
   if (keys_per_partition_ < 1) {


### PR DESCRIPTION
Summary: #12872 was a bit too gross of a fix, because we still don't need to track previous prefix in FullFilterBlockBuilder for many non-partitioned use cases. This basically narrows the fix (and potentail CPU regression) to partitioned+prefix filter cases, which are the cases that needed to be fixed.

A better efficiency fix would still be nice but not as high of a priority.

Test Plan: existing tests (just added in #12872)