### PR TITLE
Properly disable MultiCFIterator in WritePrepared/UnPreparedTxnDBs

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -523,8 +523,11 @@ txn_params = {
     "inplace_update_support": 0,
     # TimedPut is not supported in transaction
     "use_timed_put_one_in": 0,
+    # MultiCfIterator not yet supported
+    "use_multi_cf_iterator": 0,
     # AttributeGroup not yet supported
     "use_attribute_group": 0,
+
 }
 
 # For optimistic transaction db
@@ -538,6 +541,8 @@ optimistic_txn_params = {
     "inplace_update_support": 0,
     # TimedPut is not supported in transaction
     "use_timed_put_one_in": 0,
+    # MultiCfIterator not yet supported
+    "use_multi_cf_iterator": 0,
     # AttributeGroup not yet supported
     "use_attribute_group": 0,
 }
@@ -658,6 +663,8 @@ multiops_txn_default_params = {
     "inplace_update_support": 0,
     # TimedPut not supported in transaction
     "use_timed_put_one_in": 0,
+    # MultiCfIterator not yet supported
+    "use_multi_cf_iterator": 0,
     # AttributeGroup not yet supported
     "use_attribute_group": 0,
 }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -523,11 +523,8 @@ txn_params = {
     "inplace_update_support": 0,
     # TimedPut is not supported in transaction
     "use_timed_put_one_in": 0,
-    # MultiCfIterator not yet supported
-    "use_multi_cf_iterator": 0,
     # AttributeGroup not yet supported
     "use_attribute_group": 0,
-
 }
 
 # For optimistic transaction db
@@ -541,8 +538,6 @@ optimistic_txn_params = {
     "inplace_update_support": 0,
     # TimedPut is not supported in transaction
     "use_timed_put_one_in": 0,
-    # MultiCfIterator not yet supported
-    "use_multi_cf_iterator": 0,
     # AttributeGroup not yet supported
     "use_attribute_group": 0,
 }
@@ -663,8 +658,6 @@ multiops_txn_default_params = {
     "inplace_update_support": 0,
     # TimedPut not supported in transaction
     "use_timed_put_one_in": 0,
-    # MultiCfIterator not yet supported
-    "use_multi_cf_iterator": 0,
     # AttributeGroup not yet supported
     "use_attribute_group": 0,
 }
@@ -851,6 +844,8 @@ def finalize_and_sanitize(src_params):
         # Wide-column pessimistic transaction APIs are initially supported for
         # WriteCommitted only
         dest_params["use_put_entity_one_in"] = 0
+        # MultiCfIterator is currently only compatible with write committed policy
+        dest_params["use_multi_cf_iterator"] = 0        
     # TODO(hx235): enable test_multi_ops_txns with fault injection after stabilizing the CI
     if dest_params.get("test_multi_ops_txns") == 1:
         dest_params["write_fault_one_in"] = 0

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "db/attribute_group_iterator_impl.h"
 #include "db/db_iter.h"
 #include "db/pre_release_callback.h"
 #include "db/read_callback.h"
@@ -100,6 +101,22 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   Status NewIterators(const ReadOptions& _read_options,
                       const std::vector<ColumnFamilyHandle*>& column_families,
                       std::vector<Iterator*>* iterators) override;
+
+  using DB::NewCoalescingIterator;
+  std::unique_ptr<Iterator> NewCoalescingIterator(
+      const ReadOptions& /*options*/,
+      const std::vector<ColumnFamilyHandle*>& /*column_families*/) override {
+    return std::unique_ptr<Iterator>(
+        NewErrorIterator(Status::NotSupported("Not supported yet")));
+  }
+
+  using DB::NewAttributeGroupIterator;
+  std::unique_ptr<AttributeGroupIterator> NewAttributeGroupIterator(
+      const ReadOptions& /*options*/,
+      const std::vector<ColumnFamilyHandle*>& /*column_families*/) override {
+    return NewAttributeGroupErrorIterator(
+        Status::NotSupported("Not supported yet"));
+  }
 
   // Check whether the transaction that wrote the value with sequence number seq
   // is visible to the snapshot with sequence number snapshot_seq.


### PR DESCRIPTION
# Summary

MultiCfIterators (`CoalescingIterator` and `AttributeGroupIterator`) are not yet compatible with write-prepared/write-unprepared transactions, yet (write-committed is fine). This fix includes the following.

- Properly return `ErrorIterator` if the user attempts to use the `CoalescingIterator` or `AttributeGroupIterator` in WritePreparedTxnDB (and WriteUnpreparedTxnDB)
- Set `use_multi_cf_iterator = 0` if `use_txn=1` and `txn_write_policy != 0 (WRITE_COMMITTED)` in stress test.

# Test Plan

Works
```
./db_stress ... --use_txn=1 --txn_write_policy=0 --use_multi_cf_iterator=1
```

Fails
```
./db_stress ... --use_txn=1 --txn_write_policy=1 --use_multi_cf_iterator=1
```
