### PR TITLE
Enable Continuous Benchmarking of RocksDB

### DIFF
--- a/.github/workflows/benchmark-linux.yml
+++ b/.github/workflows/benchmark-linux.yml
@@ -1,7 +1,7 @@
 name: facebook/rocksdb/benchmark-linux
 on:
   schedule:
-  - cron: 5 17 * * *  # Every day 5:17 UTC, 22:00 PST
+  - cron: 7 */2 * * *  # At minute 7 past every 2nd hour
 
 jobs:
   benchmark-linux:

--- a/.github/workflows/benchmark-linux.yml
+++ b/.github/workflows/benchmark-linux.yml
@@ -1,13 +1,12 @@
 name: facebook/rocksdb/benchmark-linux
-on: workflow_dispatch
+on: [push, pull_request] #To test self-hosted runner
+  #schedule:
+  #- cron: 5 17 * * *  # Every day 5:17 morning UTC, 22:00 PST
+  #workflow_dispatch:
 jobs:
-  # FIXME: when this job is fixed, it should be given a cron schedule like
-  # schedule:
-  # - cron: 0 * * * *
-  # workflow_dispatch:
   benchmark-linux:
     if: ${{ github.repository_owner == 'facebook' }}
-    runs-on: ubuntu-latest
+    runs-on: benchmark-linux
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/build-for-benchmarks"

--- a/.github/workflows/benchmark-linux.yml
+++ b/.github/workflows/benchmark-linux.yml
@@ -6,7 +6,7 @@ on: [push, pull_request] #To test self-hosted runner
 jobs:
   benchmark-linux:
     if: ${{ github.repository_owner == 'facebook' }}
-    runs-on: benchmark-linux
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/build-for-benchmarks"

--- a/.github/workflows/benchmark-linux.yml
+++ b/.github/workflows/benchmark-linux.yml
@@ -1,8 +1,8 @@
 name: facebook/rocksdb/benchmark-linux
-on: [push, pull_request] #To test self-hosted runner
-  #schedule:
-  #- cron: 5 17 * * *  # Every day 5:17 morning UTC, 22:00 PST
-  #workflow_dispatch:
+on:
+  schedule:
+  - cron: 5 17 * * *  # Every day 5:17 UTC, 22:00 PST
+
 jobs:
   benchmark-linux:
     if: ${{ github.repository_owner == 'facebook' }}

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -1,5 +1,5 @@
 name: facebook/rocksdb/pr-jobs
-on: [push, pull_request]
+on:
 jobs:
   # NOTE: multiple workflows would be recommended, but the current GHA UI in
   # PRs doesn't make it clear when there's an overall error with a workflow,

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -1,5 +1,5 @@
 name: facebook/rocksdb/pr-jobs
-on:
+on: [push, pull_request]
 jobs:
   # NOTE: multiple workflows would be recommended, but the current GHA UI in
   # PRs doesn't make it clear when there's an overall error with a workflow,


### PR DESCRIPTION
This pull request transitions the benchmarking process from CircleCI to GitHub Actions. The benchmarking jobs will now be executed on a self-hosted runner. Unlike the previous CircleCI configuration, where jobs were queued due to the long execution time (nearly 60 minutes per job), the new setup schedules the benchmarking tasks to run every two hours.

Closes #12615