### PR TITLE
Fix file deletions in DestroyDB not rate limited

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1226,6 +1226,8 @@ class DBImpl : public DB {
     return logs_.back().number;
   }
 
+  void TEST_DeleteObsoleteFiles();
+
   const std::unordered_set<uint64_t>& TEST_GetFilesGrabbedForPurge() const {
     return files_grabbed_for_purge_;
   }

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -314,6 +314,11 @@ const autovector<uint64_t>& DBImpl::TEST_GetFilesToQuarantine() const {
   return error_handler_.GetFilesToQuarantine();
 }
 
+void DBImpl::TEST_DeleteObsoleteFiles() {
+  InstrumentedMutexLock l(&mutex_);
+  DeleteObsoleteFiles();
+}
+
 size_t DBImpl::TEST_EstimateInMemoryStatsHistorySize() const {
   InstrumentedMutexLock l(&const_cast<DBImpl*>(this)->stats_history_mutex_);
   return EstimateInMemoryStatsHistorySize();

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -1525,6 +1525,12 @@ TEST_F(DBSSTTest, OpenDBWithInfiniteMaxOpenFilesSubjectToMemoryLimit) {
         options.max_file_opening_threads = 5;
       }
 
+      // FIXME(yuzhangyu): the test is using Env::Default() instead of
+      // DBTestBase::env_, this breaks the purpose of testing with encrypted env
+      // when `ENCRYPTED_ENV` is enabled. All the DB files are created as
+      // unencrypted files, later DestroyDB during test destruction uses
+      // encryption env and assumed these files are encrypted ones. The file
+      // size assumption it has will fail.
       DestroyAndReopen(options);
 
       // Create 5 Files in L0 (then move then to L2)

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -98,14 +98,6 @@ DBTestBase::DBTestBase(const std::string path, bool env_do_fsync)
   EXPECT_OK(DestroyDB(dbname_, options));
   db_ = nullptr;
   Reopen(options);
-  // FIXME(yuzhangyu):
-  // Tests could DestroyAndReopen with an Options that doesn't necessarily
-  // use `env_`. However, the DestroyDB in below test destructor will always use
-  // `env_`. Now that `DestroyDB` introduced a path to check file's size, when
-  // a EncryptedFileSystemImpl is used, it checks that file size is always
-  // bigger than prefix length which can is not necessarily true because the DB
-  // could be created with a regular Env, and destroyed as an encrypted env. A
-  // proper fix is to enforce all tests use encrypted env when it's configured.
   Random::GetTLSInstance()->Reset(0xdeadbeef);
 }
 
@@ -124,14 +116,6 @@ DBTestBase::~DBTestBase() {
   if (getenv("KEEP_DB")) {
     printf("DB is still at %s\n", dbname_.c_str());
   } else {
-    // FIXME(yuzhangyu):
-    // The assumptions EncryptedFileSystem::GetFileSize has cannot always be met
-    // the way some tests are currently written. We disable slow deletion with
-    // this trick to bypass all the `FileSystem::GetFileSize` calls inside of
-    // DestroyDB.
-    if (getenv("ENCRYPTED_ENV") && options.sst_file_manager) {
-      options.sst_file_manager->SetDeleteRateBytesPerSecond(0);
-    }
     EXPECT_OK(DestroyDB(dbname_, options));
   }
   delete env_;

--- a/file/delete_scheduler.cc
+++ b/file/delete_scheduler.cc
@@ -31,6 +31,7 @@ DeleteScheduler::DeleteScheduler(SystemClock* clock, FileSystem* fs,
       total_trash_size_(0),
       rate_bytes_per_sec_(rate_bytes_per_sec),
       pending_files_(0),
+      next_trash_bucket_(0),
       bytes_max_delete_chunk_(bytes_max_delete_chunk),
       closing_(false),
       cv_(&mu_),
@@ -59,20 +60,15 @@ DeleteScheduler::~DeleteScheduler() {
 
 Status DeleteScheduler::DeleteFile(const std::string& file_path,
                                    const std::string& dir_to_sync,
-                                   const bool force_bg, uint64_t file_size) {
+                                   const bool force_bg) {
   uint64_t total_size = sst_file_manager_->GetTotalSize();
   if (rate_bytes_per_sec_.load() <= 0 ||
       (!force_bg &&
-       total_trash_size_.load() > total_size * max_trash_db_ratio_.load()) ||
-      file_size == 0) {
+       total_trash_size_.load() > total_size * max_trash_db_ratio_.load())) {
     // Rate limiting is disabled or trash size makes up more than
     // max_trash_db_ratio_ (default 25%) of the total DB size
-    TEST_SYNC_POINT("DeleteScheduler::DeleteFile");
-    TEST_SYNC_POINT_CALLBACK("DeleteScheduler::DeleteFile::cb",
-                             const_cast<std::string*>(&file_path));
-    Status s = fs_->DeleteFile(file_path, IOOptions(), nullptr);
+    Status s = DeleteFileImmediately(file_path, /*accounted=*/true);
     if (s.ok()) {
-      s = sst_file_manager_->OnDeleteFile(file_path);
       ROCKS_LOG_INFO(info_log_,
                      "Deleted file %s immediately, rate_bytes_per_sec %" PRIi64
                      ", total_trash_size %" PRIu64 ", total_size %" PRIi64
@@ -80,15 +76,57 @@ Status DeleteScheduler::DeleteFile(const std::string& file_path,
                      file_path.c_str(), rate_bytes_per_sec_.load(),
                      total_trash_size_.load(), total_size,
                      max_trash_db_ratio_.load());
-      InstrumentedMutexLock l(&mu_);
-      RecordTick(stats_.get(), FILES_DELETED_IMMEDIATELY);
     }
     return s;
   }
+  return AddFileToDeletionQueue(file_path, dir_to_sync, /*bucket=*/std::nullopt,
+                                /*accounted=*/true);
+}
 
+Status DeleteScheduler::DeleteUnaccountedFile(const std::string& file_path,
+                                              const std::string& dir_to_sync,
+                                              const bool force_bg,
+                                              std::optional<int32_t> bucket) {
+  uint64_t num_hard_links = 1;
+  fs_->NumFileLinks(file_path, IOOptions(), &num_hard_links, nullptr)
+      .PermitUncheckedError();
+
+  // We can tolerate rare races where we might immediately delete both links
+  // to a file.
+  if (rate_bytes_per_sec_.load() <= 0 || (!force_bg && num_hard_links > 1)) {
+    Status s = DeleteFileImmediately(file_path, /*accounted=*/false);
+    if (s.ok()) {
+      ROCKS_LOG_INFO(info_log_,
+                     "Deleted file %s immediately, rate_bytes_per_sec %" PRIi64,
+                     file_path.c_str(), rate_bytes_per_sec_.load());
+    }
+    return s;
+  }
+  return AddFileToDeletionQueue(file_path, dir_to_sync, bucket,
+                                /*accounted=*/false);
+}
+
+Status DeleteScheduler::DeleteFileImmediately(const std::string& file_path,
+                                              bool accounted) {
+  TEST_SYNC_POINT("DeleteScheduler::DeleteFile");
+  TEST_SYNC_POINT_CALLBACK("DeleteScheduler::DeleteFile::cb",
+                           const_cast<std::string*>(&file_path));
+  Status s = fs_->DeleteFile(file_path, IOOptions(), nullptr);
+  if (s.ok()) {
+    s = OnDeleteFile(file_path, accounted);
+    InstrumentedMutexLock l(&mu_);
+    RecordTick(stats_.get(), FILES_DELETED_IMMEDIATELY);
+  }
+  return s;
+}
+
+Status DeleteScheduler::AddFileToDeletionQueue(const std::string& file_path,
+                                               const std::string& dir_to_sync,
+                                               std::optional<int32_t> bucket,
+                                               bool accounted) {
   // Move file to trash
   std::string trash_file;
-  Status s = MarkAsTrash(file_path, &trash_file);
+  Status s = MarkAsTrash(file_path, accounted, &trash_file);
   ROCKS_LOG_INFO(info_log_, "Mark file: %s as trash -- %s", trash_file.c_str(),
                  s.ToString().c_str());
 
@@ -97,7 +135,7 @@ Status DeleteScheduler::DeleteFile(const std::string& file_path,
                     file_path.c_str(), s.ToString().c_str());
     s = fs_->DeleteFile(file_path, IOOptions(), nullptr);
     if (s.ok()) {
-      s = sst_file_manager_->OnDeleteFile(file_path);
+      s = OnDeleteFile(file_path, accounted);
       ROCKS_LOG_INFO(info_log_, "Deleted file %s immediately",
                      trash_file.c_str());
       InstrumentedMutexLock l(&mu_);
@@ -107,11 +145,13 @@ Status DeleteScheduler::DeleteFile(const std::string& file_path,
   }
 
   // Update the total trash size
-  uint64_t trash_file_size = 0;
-  IOStatus io_s =
-      fs_->GetFileSize(trash_file, IOOptions(), &trash_file_size, nullptr);
-  if (io_s.ok()) {
-    total_trash_size_.fetch_add(trash_file_size);
+  if (accounted) {
+    uint64_t trash_file_size = 0;
+    IOStatus io_s =
+        fs_->GetFileSize(trash_file, IOOptions(), &trash_file_size, nullptr);
+    if (io_s.ok()) {
+      total_trash_size_.fetch_add(trash_file_size);
+    }
   }
   //**TODO: What should we do if we failed to
   // get the file size?
@@ -120,8 +160,15 @@ Status DeleteScheduler::DeleteFile(const std::string& file_path,
   {
     InstrumentedMutexLock l(&mu_);
     RecordTick(stats_.get(), FILES_MARKED_TRASH);
-    queue_.emplace(trash_file, dir_to_sync);
+    queue_.emplace(trash_file, dir_to_sync, accounted, bucket);
     pending_files_++;
+    if (bucket.has_value()) {
+      auto iter = pending_files_in_buckets_.find(bucket.value());
+      assert(iter != pending_files_in_buckets_.end());
+      if (iter != pending_files_in_buckets_.end()) {
+        iter->second++;
+      }
+    }
     if (pending_files_ == 1) {
       cv_.SignalAll();
     }
@@ -180,7 +227,7 @@ Status DeleteScheduler::CleanupDirectory(Env* env, SstFileManagerImpl* sfm,
 }
 
 Status DeleteScheduler::MarkAsTrash(const std::string& file_path,
-                                    std::string* trash_file) {
+                                    bool accounted, std::string* trash_file) {
   // Sanity check of the path
   size_t idx = file_path.rfind('/');
   if (idx == std::string::npos || idx == file_path.size() - 1) {
@@ -214,7 +261,7 @@ Status DeleteScheduler::MarkAsTrash(const std::string& file_path,
     }
     cnt++;
   }
-  if (s.ok()) {
+  if (s.ok() && accounted) {
     s = sst_file_manager_->OnMoveFile(file_path, *trash_file);
   }
   return s;
@@ -238,6 +285,8 @@ void DeleteScheduler::BackgroundEmptyTrash() {
     uint64_t total_deleted_bytes = 0;
     int64_t current_delete_rate = rate_bytes_per_sec_.load();
     while (!queue_.empty() && !closing_) {
+      // Satisfy static analysis.
+      std::optional<int32_t> bucket = std::nullopt;
       if (current_delete_rate != rate_bytes_per_sec_.load()) {
         // User changed the delete rate
         current_delete_rate = rate_bytes_per_sec_.load();
@@ -250,14 +299,15 @@ void DeleteScheduler::BackgroundEmptyTrash() {
       // Get new file to delete
       const FileAndDir& fad = queue_.front();
       std::string path_in_trash = fad.fname;
+      bucket = fad.bucket;
 
       // We don't need to hold the lock while deleting the file
       mu_.Unlock();
       uint64_t deleted_bytes = 0;
       bool is_complete = true;
       // Delete file from trash and update total_penlty value
-      Status s =
-          DeleteTrashFile(path_in_trash, fad.dir, &deleted_bytes, &is_complete);
+      Status s = DeleteTrashFile(path_in_trash, fad.dir, fad.accounted,
+                                 &deleted_bytes, &is_complete);
       total_deleted_bytes += deleted_bytes;
       mu_.Lock();
       if (is_complete) {
@@ -291,12 +341,20 @@ void DeleteScheduler::BackgroundEmptyTrash() {
       TEST_SYNC_POINT_CALLBACK("DeleteScheduler::BackgroundEmptyTrash:Wait",
                                &total_penalty);
 
+      int32_t pending_files_in_bucket = std::numeric_limits<int32_t>::max();
       if (is_complete) {
         pending_files_--;
+        if (bucket.has_value()) {
+          auto iter = pending_files_in_buckets_.find(bucket.value());
+          assert(iter != pending_files_in_buckets_.end());
+          if (iter != pending_files_in_buckets_.end()) {
+            pending_files_in_bucket = iter->second--;
+          }
+        }
       }
-      if (pending_files_ == 0) {
-        // Unblock WaitForEmptyTrash since there are no more files waiting
-        // to be deleted
+      if (pending_files_ == 0 || pending_files_in_bucket == 0) {
+        // Unblock WaitForEmptyTrash or WaitForEmptyTrashBucket since there are
+        // no more files waiting to be deleted
         cv_.SignalAll();
       }
     }
@@ -305,7 +363,7 @@ void DeleteScheduler::BackgroundEmptyTrash() {
 
 Status DeleteScheduler::DeleteTrashFile(const std::string& path_in_trash,
                                         const std::string& dir_to_sync,
-                                        uint64_t* deleted_bytes,
+                                        bool accounted, uint64_t* deleted_bytes,
                                         bool* is_complete) {
   uint64_t file_size;
   Status s = fs_->GetFileSize(path_in_trash, IOOptions(), &file_size, nullptr);
@@ -379,7 +437,7 @@ Status DeleteScheduler::DeleteTrashFile(const std::string& path_in_trash,
       }
       if (s.ok()) {
         *deleted_bytes = file_size;
-        s = sst_file_manager_->OnDeleteFile(path_in_trash);
+        s = OnDeleteFile(path_in_trash, accounted);
       }
     }
   }
@@ -389,10 +447,22 @@ Status DeleteScheduler::DeleteTrashFile(const std::string& path_in_trash,
                     path_in_trash.c_str(), s.ToString().c_str());
     *deleted_bytes = 0;
   } else {
-    total_trash_size_.fetch_sub(*deleted_bytes);
+    if (accounted) {
+      total_trash_size_.fetch_sub(*deleted_bytes);
+    }
   }
 
   return s;
+}
+
+Status DeleteScheduler::OnDeleteFile(const std::string& file_path,
+                                     bool accounted) {
+  if (accounted) {
+    return sst_file_manager_->OnDeleteFile(file_path);
+  }
+  TEST_SYNC_POINT_CALLBACK("DeleteScheduler::OnDeleteFile",
+                           const_cast<std::string*>(&file_path));
+  return Status::OK();
 }
 
 void DeleteScheduler::WaitForEmptyTrash() {
@@ -400,6 +470,30 @@ void DeleteScheduler::WaitForEmptyTrash() {
   while (pending_files_ > 0 && !closing_) {
     cv_.Wait();
   }
+}
+
+std::optional<int32_t> DeleteScheduler::NewTrashBucket() {
+  if (rate_bytes_per_sec_.load() <= 0) {
+    return std::nullopt;
+  }
+  InstrumentedMutexLock l(&mu_);
+  int32_t bucket_number = next_trash_bucket_++;
+  pending_files_in_buckets_.emplace(bucket_number, 0);
+  return bucket_number;
+}
+
+void DeleteScheduler::WaitForEmptyTrashBucket(int32_t bucket) {
+  InstrumentedMutexLock l(&mu_);
+  if (bucket >= next_trash_bucket_) {
+    return;
+  }
+  auto iter = pending_files_in_buckets_.find(bucket);
+  while (iter != pending_files_in_buckets_.end() && iter->second > 0 &&
+         !closing_) {
+    cv_.Wait();
+    iter = pending_files_in_buckets_.find(bucket);
+  }
+  pending_files_in_buckets_.erase(bucket);
 }
 
 void DeleteScheduler::MaybeCreateBackgroundThread() {

--- a/file/delete_scheduler.cc
+++ b/file/delete_scheduler.cc
@@ -299,6 +299,8 @@ void DeleteScheduler::BackgroundEmptyTrash() {
       // Get new file to delete
       const FileAndDir& fad = queue_.front();
       std::string path_in_trash = fad.fname;
+      std::string dir_to_sync = fad.dir;
+      bool accounted = fad.accounted;
       bucket = fad.bucket;
 
       // We don't need to hold the lock while deleting the file
@@ -306,7 +308,7 @@ void DeleteScheduler::BackgroundEmptyTrash() {
       uint64_t deleted_bytes = 0;
       bool is_complete = true;
       // Delete file from trash and update total_penlty value
-      Status s = DeleteTrashFile(path_in_trash, fad.dir, fad.accounted,
+      Status s = DeleteTrashFile(path_in_trash, dir_to_sync, accounted,
                                  &deleted_bytes, &is_complete);
       total_deleted_bytes += deleted_bytes;
       mu_.Lock();

--- a/file/delete_scheduler.h
+++ b/file/delete_scheduler.h
@@ -50,9 +50,11 @@ class DeleteScheduler {
 
   // Mark file as trash directory and schedule its deletion. If force_bg is
   // set, it forces the file to always be deleted in the background thread,
-  // except when rate limiting is disabled
+  // except when rate limiting is disabled.
+  // If a file's size is known and 0, it will always be immediately deleted.
   Status DeleteFile(const std::string& fname, const std::string& dir_to_sync,
-                    const bool force_bg = false);
+                    const bool force_bg = false,
+                    uint64_t file_size = std::numeric_limits<uint64_t>::max());
 
   // Wait for all files being deleteing in the background to finish or for
   // destructor to be called.

--- a/file/delete_scheduler_test.cc
+++ b/file/delete_scheduler_test.cc
@@ -819,7 +819,6 @@ TEST_F(DeleteSchedulerTest, ConcurrentlyDeleteUnaccountedFilesInBuckets) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
 
-#ifdef OS_LINUX
 TEST_F(DeleteSchedulerTest,
        ImmediatelyDeleteUnaccountedFilesWithRemainingLinks) {
   int bg_delete_file = 0;
@@ -857,7 +856,6 @@ TEST_F(DeleteSchedulerTest,
   ASSERT_EQ(2, stats_->getAndResetTickerCount(FILES_DELETED_IMMEDIATELY));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 }
-#endif
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/file/delete_scheduler_test.cc
+++ b/file/delete_scheduler_test.cc
@@ -78,7 +78,7 @@ class DeleteSchedulerTest : public testing::Test {
   }
 
   std::string NewDummyFile(const std::string& file_name, uint64_t size = 1024,
-                           size_t dummy_files_dirs_idx = 0) {
+                           size_t dummy_files_dirs_idx = 0, bool track = true) {
     std::string file_path =
         dummy_files_dirs_[dummy_files_dirs_idx] + "/" + file_name;
     std::unique_ptr<WritableFile> f;
@@ -86,7 +86,9 @@ class DeleteSchedulerTest : public testing::Test {
     std::string data(size, 'A');
     EXPECT_OK(f->Append(data));
     EXPECT_OK(f->Close());
-    EXPECT_OK(sst_file_mgr_->OnAddFile(file_path));
+    if (track) {
+      EXPECT_OK(sst_file_mgr_->OnAddFile(file_path));
+    }
     return file_path;
   }
 
@@ -352,6 +354,8 @@ TEST_F(DeleteSchedulerTest, DisableRateLimiting) {
   ASSERT_EQ(0, stats_->getAndResetTickerCount(FILES_DELETED_FROM_TRASH_QUEUE));
   ASSERT_EQ(num_files,
             stats_->getAndResetTickerCount(FILES_DELETED_IMMEDIATELY));
+
+  ASSERT_FALSE(delete_scheduler_->NewTrashBucket().has_value());
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
@@ -717,6 +721,143 @@ TEST_F(DeleteSchedulerTest, IsTrashCheck) {
   ASSERT_FALSE(DeleteScheduler::IsTrashFile(".ttrash"));
   ASSERT_FALSE(DeleteScheduler::IsTrashFile("abc.trashx"));
 }
+
+TEST_F(DeleteSchedulerTest, DeleteAccountedAndUnaccountedFiles) {
+  rate_bytes_per_sec_ = 1024 * 1024;  // 1 MB / s
+  NewDeleteScheduler();
+
+  // Create 100 files, every file is 1 KB
+  int num_files = 100;        // 100 files
+  uint64_t file_size = 1024;  // 1 KB as a file size
+  std::vector<std::string> generated_files;
+  for (int i = 0; i < num_files; i++) {
+    std::string file_name = "file" + std::to_string(i) + ".data";
+    generated_files.push_back(NewDummyFile(file_name, file_size,
+                                           /*dummy_files_dirs_idx*/ 0,
+                                           /*track=*/false));
+  }
+
+  for (int i = 0; i < num_files; i++) {
+    if (i % 2) {
+      ASSERT_OK(sst_file_mgr_->OnAddFile(generated_files[i], file_size));
+      ASSERT_OK(delete_scheduler_->DeleteFile(generated_files[i], ""));
+    } else {
+      ASSERT_OK(
+          delete_scheduler_->DeleteUnaccountedFile(generated_files[i], ""));
+    }
+  }
+
+  delete_scheduler_->WaitForEmptyTrash();
+  ASSERT_EQ(0, delete_scheduler_->GetTotalTrashSize());
+  ASSERT_EQ(0, sst_file_mgr_->GetTotalSize());
+}
+
+TEST_F(DeleteSchedulerTest, ConcurrentlyDeleteUnaccountedFilesInBuckets) {
+  int bg_delete_file = 0;
+  int fg_delete_file = 0;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DeleteScheduler::DeleteTrashFile:DeleteFile",
+      [&](void* /*arg*/) { bg_delete_file++; });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DeleteScheduler::DeleteFile", [&](void* /*arg*/) { fg_delete_file++; });
+  rate_bytes_per_sec_ = 1024 * 1024;  // 1 MB / s
+  NewDeleteScheduler();
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+  // Create 1000 files, every file is 1 KB
+  int num_files = 1000;
+  uint64_t file_size = 1024;  // 1 KB as a file size
+  std::vector<std::string> generated_files;
+  for (int i = 0; i < num_files; i++) {
+    std::string file_name = "file" + std::to_string(i) + ".data";
+    generated_files.push_back(NewDummyFile(file_name, file_size,
+                                           /*dummy_files_dirs_idx*/ 0,
+                                           /*track=*/false));
+  }
+  // Concurrently delete files in different buckets and check all the buckets
+  // are empty.
+  int thread_cnt = 10;
+  int files_per_thread = 100;
+  std::atomic<int> thread_num(0);
+  std::vector<port::Thread> threads;
+  std::function<void()> delete_thread = [&]() {
+    std::optional<int32_t> bucket = delete_scheduler_->NewTrashBucket();
+    ASSERT_TRUE(bucket.has_value());
+    int idx = thread_num.fetch_add(1);
+    int range_start = idx * files_per_thread;
+    int range_end = range_start + files_per_thread;
+    for (int j = range_start; j < range_end; j++) {
+      ASSERT_OK(delete_scheduler_->DeleteUnaccountedFile(
+          generated_files[j], "", /*false_bg=*/false, bucket));
+    }
+    delete_scheduler_->WaitForEmptyTrashBucket(bucket.value());
+  };
+
+  for (int i = 0; i < thread_cnt; i++) {
+    threads.emplace_back(delete_thread);
+  }
+
+  for (size_t i = 0; i < threads.size(); i++) {
+    threads[i].join();
+  }
+
+  ASSERT_EQ(0, delete_scheduler_->GetTotalTrashSize());
+  ASSERT_EQ(0, stats_->getAndResetTickerCount(FILES_DELETED_IMMEDIATELY));
+  ASSERT_EQ(1000, stats_->getAndResetTickerCount(FILES_MARKED_TRASH));
+  ASSERT_EQ(0, fg_delete_file);
+  ASSERT_EQ(1000, bg_delete_file);
+
+  // OK to re check an already empty bucket
+  delete_scheduler_->WaitForEmptyTrashBucket(9);
+  // Invalid bucket return too.
+  delete_scheduler_->WaitForEmptyTrashBucket(100);
+  std::optional<int32_t> next_bucket = delete_scheduler_->NewTrashBucket();
+  ASSERT_TRUE(next_bucket.has_value());
+  ASSERT_EQ(10, next_bucket.value());
+  delete_scheduler_->WaitForEmptyTrashBucket(10);
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+}
+
+#ifdef OS_LINUX
+TEST_F(DeleteSchedulerTest,
+       ImmediatelyDeleteUnaccountedFilesWithRemainingLinks) {
+  int bg_delete_file = 0;
+  int fg_delete_file = 0;
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DeleteScheduler::DeleteTrashFile:DeleteFile",
+      [&](void* /*arg*/) { bg_delete_file++; });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DeleteScheduler::DeleteFile", [&](void* /*arg*/) { fg_delete_file++; });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  rate_bytes_per_sec_ = 1024 * 1024;  // 1 MB / sec
+  NewDeleteScheduler();
+
+  std::string file1 = NewDummyFile("data_1", 500 * 1024,
+                                   /*dummy_files_dirs_idx*/ 0, /*track=*/false);
+  std::string file2 = NewDummyFile("data_2", 100 * 1024,
+                                   /*dummy_files_dirs_idx*/ 0, /*track=*/false);
+
+  ASSERT_OK(env_->LinkFile(file1, dummy_files_dirs_[0] + "/data_1b"));
+  ASSERT_OK(env_->LinkFile(file2, dummy_files_dirs_[0] + "/data_2b"));
+
+  // Should delete in 4 batch if there is no hardlink
+  ASSERT_OK(
+      delete_scheduler_->DeleteUnaccountedFile(file1, "", /*force_bg=*/false));
+  ASSERT_OK(
+      delete_scheduler_->DeleteUnaccountedFile(file2, "", /*force_bg=*/false));
+
+  delete_scheduler_->WaitForEmptyTrash();
+
+  ASSERT_EQ(0, delete_scheduler_->GetTotalTrashSize());
+  ASSERT_EQ(0, bg_delete_file);
+  ASSERT_EQ(2, fg_delete_file);
+  ASSERT_EQ(0, stats_->getAndResetTickerCount(FILES_MARKED_TRASH));
+  ASSERT_EQ(2, stats_->getAndResetTickerCount(FILES_DELETED_IMMEDIATELY));
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+}
+#endif
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/file/file_util.cc
+++ b/file/file_util.cc
@@ -129,7 +129,9 @@ Status TrackAndDeleteDBFile(const ImmutableDBOptions* db_options,
   uint64_t file_size = std::numeric_limits<uint64_t>::max();
   SstFileManagerImpl* sfm =
       static_cast<SstFileManagerImpl*>(db_options->sst_file_manager.get());
-  if (sfm) {
+  // TODO(yuzhangyu): remove the check for GetDeleteRateBytesPerSecond after
+  // fixing usage of EncryptedFileSystem in tests.
+  if (sfm && sfm->GetDeleteRateBytesPerSecond() > 0) {
     Status s = sfm->OnAddFileForDestroyDB(fname, &file_size);
     if (!s.ok()) {
       return s;

--- a/file/file_util.h
+++ b/file/file_util.h
@@ -46,25 +46,6 @@ inline IOStatus CreateFile(const std::shared_ptr<FileSystem>& fs,
   return CreateFile(fs.get(), destination, contents, use_fsync);
 }
 
-// Slow deletion works when DB's total size and backlogged trash size are
-// properly tracked. DestroyDB attempts to delete each file as it enumerate
-// a DB directory. In order for slow deletion to work, if SstFileManager is
-// available, we first track each file in SstFileManager before passing it to
-// DeleteScheduler to delete. For DestroyDB purpose, we also treat a file that
-// will have remaining hard links as if its file size is zero, so that we can
-// special-case it to not be slow deleted. This is an optimization for
-// checkpoint cleanup via DestroyDB, where the majority of the files will still
-// have remaining hard links after its deletion.
-// While during a regular DB session, each file that eventually get passed to
-// DeleteScheduler should have already been tracked in SstFileManager when it
-// was initially created, or as a preexisting file discovered and tracked during
-// DB::Open. So those cases should continue to call the `DeleteDBFile` API for
-// deletion.
-Status TrackAndDeleteDBFile(const ImmutableDBOptions* db_options,
-                            const std::string& fname,
-                            const std::string& path_to_sync,
-                            const bool force_bg, const bool force_fg);
-
 // Delete a DB file, if this file is a SST file or Blob file and SstFileManager
 // is used, it should have already been tracked by SstFileManager via its
 // `OnFileAdd` API before passing to this API to be deleted, to ensure
@@ -72,8 +53,17 @@ Status TrackAndDeleteDBFile(const ImmutableDBOptions* db_options,
 // properly.
 Status DeleteDBFile(const ImmutableDBOptions* db_options,
                     const std::string& fname, const std::string& path_to_sync,
-                    const bool force_bg, const bool force_fg,
-                    uint64_t file_size = std::numeric_limits<uint64_t>::max());
+                    const bool force_bg, const bool force_fg);
+
+// Delete an unaccounted DB file that is not tracked by SstFileManager and will
+// not be tracked by its DeleteScheduler when getting deleted.
+// If a legitimate bucket is provided and this file is scheduled for slow
+// deletion, it will be assigned to the specified trash bucket.
+Status DeleteUnaccountedDBFile(const ImmutableDBOptions* db_options,
+                               const std::string& fname,
+                               const std::string& dir_to_sync,
+                               const bool force_bg, const bool force_fg,
+                               std::optional<int32_t> bucket);
 
 // TODO(hx235): pass the whole DBOptions intead of its individual fields
 IOStatus GenerateOneFileChecksum(

--- a/file/sst_file_manager_impl.cc
+++ b/file/sst_file_manager_impl.cc
@@ -80,6 +80,23 @@ Status SstFileManagerImpl::OnAddFile(const std::string& file_path,
   return Status::OK();
 }
 
+Status SstFileManagerImpl::OnAddFileForDestroyDB(const std::string& file_path,
+                                                 uint64_t* file_size) {
+  uint64_t num_hard_links = 1;
+  Status s =
+      fs_->NumFileLinks(file_path, IOOptions(), &num_hard_links, nullptr);
+  if (s.ok() && num_hard_links > 1) {
+    *file_size = 0;
+  } else {
+    s = fs_->GetFileSize(file_path, IOOptions(), file_size, nullptr);
+  }
+  if (s.ok()) {
+    MutexLock l(&mu_);
+    OnAddFileImpl(file_path, *file_size);
+  }
+  return s;
+}
+
 Status SstFileManagerImpl::OnDeleteFile(const std::string& file_path) {
   {
     MutexLock l(&mu_);
@@ -415,10 +432,12 @@ bool SstFileManagerImpl::CancelErrorRecovery(ErrorHandler* handler) {
 
 Status SstFileManagerImpl::ScheduleFileDeletion(const std::string& file_path,
                                                 const std::string& path_to_sync,
-                                                const bool force_bg) {
+                                                const bool force_bg,
+                                                uint64_t file_size) {
   TEST_SYNC_POINT_CALLBACK("SstFileManagerImpl::ScheduleFileDeletion",
                            const_cast<std::string*>(&file_path));
-  return delete_scheduler_.DeleteFile(file_path, path_to_sync, force_bg);
+  return delete_scheduler_.DeleteFile(file_path, path_to_sync, force_bg,
+                                      file_size);
 }
 
 void SstFileManagerImpl::WaitForEmptyTrash() {

--- a/file/sst_file_manager_impl.cc
+++ b/file/sst_file_manager_impl.cc
@@ -88,13 +88,7 @@ Status SstFileManagerImpl::OnAddFileForDestroyDB(const std::string& file_path,
   if (s.ok() && num_hard_links > 1) {
     *file_size = 0;
   } else {
-    // Some FileSystem::GetFileSystem doesn't like a file_size initialized as
-    // std::numeric_limits<uint64_t>::max() to be passed.
-    uint64_t file_size_from_fs;
-    s = fs_->GetFileSize(file_path, IOOptions(), &file_size_from_fs, nullptr);
-    if (s.ok()) {
-      *file_size = file_size_from_fs;
-    }
+    s = fs_->GetFileSize(file_path, IOOptions(), file_size, nullptr);
   }
   if (s.ok()) {
     MutexLock l(&mu_);

--- a/file/sst_file_manager_impl.cc
+++ b/file/sst_file_manager_impl.cc
@@ -88,7 +88,13 @@ Status SstFileManagerImpl::OnAddFileForDestroyDB(const std::string& file_path,
   if (s.ok() && num_hard_links > 1) {
     *file_size = 0;
   } else {
-    s = fs_->GetFileSize(file_path, IOOptions(), file_size, nullptr);
+    // Some FileSystem::GetFileSystem doesn't like a file_size initialized as
+    // std::numeric_limits<uint64_t>::max() to be passed.
+    uint64_t file_size_from_fs;
+    s = fs_->GetFileSize(file_path, IOOptions(), &file_size_from_fs, nullptr);
+    if (s.ok()) {
+      *file_size = file_size_from_fs;
+    }
   }
   if (s.ok()) {
     MutexLock l(&mu_);

--- a/file/sst_file_manager_impl.h
+++ b/file/sst_file_manager_impl.h
@@ -43,6 +43,13 @@ class SstFileManagerImpl : public SstFileManager {
   // queried from the filesystem. This is an optimization.
   Status OnAddFile(const std::string& file_path, uint64_t file_size);
 
+  // For the purpose of DestroyDB, if the file system supports getting a file's
+  // number of hard links, then a file with more than 1 hard links is treated
+  // as having a file size of 0. This API also returns the file size to the
+  // caller.
+  Status OnAddFileForDestroyDB(const std::string& file_path,
+                               uint64_t* file_size);
+
   // DB will call OnDeleteFile whenever a sst/blob file is deleted.
   Status OnDeleteFile(const std::string& file_path);
 
@@ -120,10 +127,12 @@ class SstFileManagerImpl : public SstFileManager {
 
   // Mark file as trash and schedule it's deletion. If force_bg is set, it
   // forces the file to be deleting in the background regardless of DB size,
-  // except when rate limited delete is disabled
-  virtual Status ScheduleFileDeletion(const std::string& file_path,
-                                      const std::string& dir_to_sync,
-                                      const bool force_bg = false);
+  // except when rate limited delete is disabled.
+  // When a file's size is known and 0, it will be deleted immediately.
+  virtual Status ScheduleFileDeletion(
+      const std::string& file_path, const std::string& dir_to_sync,
+      const bool force_bg = false,
+      uint64_t file_size = std::numeric_limits<uint64_t>::max());
 
   // Wait for all files being deleteing in the background to finish or for
   // destructor to be called.

--- a/file/sst_file_manager_impl.h
+++ b/file/sst_file_manager_impl.h
@@ -129,7 +129,9 @@ class SstFileManagerImpl : public SstFileManager {
   // deletion is disabled. A file with more than 1 hard links will be deleted
   // immediately unless force_bg is set. In other cases, files will be scheduled
   // for slow deletion, and assigned to the specified bucket if a legitimate one
-  // is provided.
+  // is provided. A legitimate bucket is one that is created with the
+  // `NewTrashBucket` API, and for which `WaitForEmptyTrashBucket` hasn't been
+  // called yet.
   virtual Status ScheduleUnaccountedFileDeletion(
       const std::string& file_path, const std::string& dir_to_sync,
       const bool force_bg = false,
@@ -141,12 +143,13 @@ class SstFileManagerImpl : public SstFileManager {
 
   // Creates a new trash bucket. A legitimate bucket is only created and
   // returned when slow deletion is enabled.
-  // For each bucket that is created, the user should also call
-  // `WaitForEmptyTrashBucket` to make sure trash are cleared.
+  // For each bucket that is created and used, the user should also call
+  // `WaitForEmptyTrashBucket` after scheduling file deletions to make sure all
+  // the trash files are cleared.
   std::optional<int32_t> NewTrashBucket();
 
   // Wait for all the files in the specified bucket to be deleted in the
-  // background.
+  // background or for destructor to be called.
   virtual void WaitForEmptyTrashBucket(int32_t bucket);
 
   DeleteScheduler* delete_scheduler() { return &delete_scheduler_; }

--- a/unreleased_history/bug_fixes/destroy_db_supports_slow_deletion.md
+++ b/unreleased_history/bug_fixes/destroy_db_supports_slow_deletion.md
@@ -1,0 +1,1 @@
+*Make DestroyDB supports slow deletion when it's configured in `SstFileManager`. The slow deletion is subject to the configured `rate_bytes_per_sec`, but not subject to the `max_trash_db_ratio`.

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -760,7 +760,7 @@ TEST_F(BlobDBTest, SstFileManager) {
   // run the same test for Get(), MultiGet() and Iterator each.
   std::shared_ptr<SstFileManager> sst_file_manager(
       NewSstFileManager(mock_env_.get()));
-  sst_file_manager->SetDeleteRateBytesPerSecond(1);
+  sst_file_manager->SetDeleteRateBytesPerSecond(1024 * 1024);
   SstFileManagerImpl *sfm =
       static_cast<SstFileManagerImpl *>(sst_file_manager.get());
 
@@ -818,7 +818,7 @@ TEST_F(BlobDBTest, SstFileManagerRestart) {
   // run the same test for Get(), MultiGet() and Iterator each.
   std::shared_ptr<SstFileManager> sst_file_manager(
       NewSstFileManager(mock_env_.get()));
-  sst_file_manager->SetDeleteRateBytesPerSecond(1);
+  sst_file_manager->SetDeleteRateBytesPerSecond(1024 * 1024);
   SstFileManagerImpl *sfm =
       static_cast<SstFileManagerImpl *>(sst_file_manager.get());
 

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -1111,7 +1111,6 @@ TEST_P(CheckpointDestroyTest, DisableEnableSlowDeletion) {
         }
       });
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
-  ASSERT_OK(s);
   ASSERT_OK(DestroyDB(snapshot_name_, options));
   if (slow_deletion) {
     ASSERT_EQ(fg_delete_sst, 1);


### PR DESCRIPTION
Make `DestroyDB` slowly delete files if it's configured and enabled via `SstFileManager`.

It's currently not available mainly because of DeleteScheduler's logic related to tracked total_size_ and total_trash_size_. These accounting and logic should not be applied to `DestroyDB`. This PR adds a `DeleteUnaccountedDBFile` util for this purpose which deletes files without accounting it.  This util also supports assigning a file to a specified trash bucket so that user can later wait for a specific trash bucket to be empty. For `DestroyDB`, files with more than 1 hard links will be deleted immediately. 

Test Plan:
Added unit tests, existing tests.