### PR TITLE
Small CPU optimization to experimental range filters

### DIFF
--- a/db/experimental.cc
+++ b/db/experimental.cc
@@ -711,7 +711,7 @@ class SstQueryFilterConfigsManagerImpl : public SstQueryFilterConfigsManager {
                       uint64_t /*file_size*/) override {
       // FIXME later: `key` might contain user timestamp. That should be
       // exposed properly in a future update to TablePropertiesCollector
-      KeySegmentsExtractor::Result extracted;
+      extracted.Reset();
       if (extractor) {
         extractor->Extract(key, KeySegmentsExtractor::kFullUserKey, &extracted);
         if (UNLIKELY(extracted.category >=
@@ -750,7 +750,7 @@ class SstQueryFilterConfigsManagerImpl : public SstQueryFilterConfigsManager {
         }
       }
       prev_key.assign(key.data(), key.size());
-      prev_extracted = std::move(extracted);
+      std::swap(prev_extracted, extracted);
       first_key = false;
       return Status::OK();
     }
@@ -859,6 +859,7 @@ class SstQueryFilterConfigsManagerImpl : public SstQueryFilterConfigsManager {
     std::vector<std::shared_ptr<SstQueryFilterBuilder>> builders;
     bool first_key = true;
     std::string prev_key;
+    KeySegmentsExtractor::Result extracted;
     KeySegmentsExtractor::Result prev_extracted;
     KeySegmentsExtractor::KeyCategorySet categories_seen;
   };

--- a/include/rocksdb/experimental.h
+++ b/include/rocksdb/experimental.h
@@ -238,6 +238,11 @@ class KeySegmentsExtractor {
     // determined by segment 0 in some way, often the first byte.) The enum
     // scalar values do not need to be related to key order.
     KeyCategory category = kDefaultCategory;
+
+    void Reset() {
+      segment_ends.clear();
+      category = kDefaultCategory;
+    }
   };
 
   virtual ~KeySegmentsExtractor() {}


### PR DESCRIPTION
Summary: By reusing an object that owns a vector. The vector allocation/sizing was substantial in a CPU profile.

Test Plan: existing tests