### PR TITLE
Clean up/refactor (Partitioned)FilterBlockBuilder

### DIFF
--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1578,9 +1578,10 @@ void BlockBasedTableBuilder::WriteFilterBlock(
       // See FilterBlockBuilder::Finish() for more on the difference in
       // transferred filter data payload among different FilterBlockBuilder
       // subtypes.
-      std::unique_ptr<const char[]> filter_data;
-      Slice filter_content =
-          rep_->filter_builder->Finish(filter_block_handle, &s, &filter_data);
+      std::unique_ptr<const char[]> filter_owner;
+      Slice filter_content;
+      s = rep_->filter_builder->Finish(filter_block_handle, &filter_content,
+                                       &filter_owner);
 
       assert(s.ok() || s.IsIncomplete() || s.IsCorruption());
       if (s.IsCorruption()) {

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -112,19 +112,19 @@ void FullFilterBlockBuilder::Reset() {
   last_prefix_recorded_ = false;
 }
 
-Slice FullFilterBlockBuilder::Finish(
-    const BlockHandle& /*tmp*/, Status* status,
-    std::unique_ptr<const char[]>* filter_data) {
+Status FullFilterBlockBuilder::Finish(
+    const BlockHandle& /*last_partition_block_handle*/, Slice* filter,
+    std::unique_ptr<const char[]>* filter_owner) {
   Reset();
-  // In this impl we ignore BlockHandle
-  *status = Status::OK();
+  Status s = Status::OK();
   if (any_added_) {
     any_added_ = false;
-    Slice filter_content = filter_bits_builder_->Finish(
-        filter_data ? filter_data : &filter_data_, status);
-    return filter_content;
+    *filter = filter_bits_builder_->Finish(
+        filter_owner ? filter_owner : &filter_data_, &s);
+  } else {
+    *filter = Slice{};
   }
-  return Slice();
+  return s;
 }
 
 FullFilterBlockReader::FullFilterBlockReader(

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -52,8 +52,8 @@ class FullFilterBlockBuilder : public FilterBlockBuilder {
   void Add(const Slice& key_without_ts) override;
   bool IsEmpty() const override { return !any_added_; }
   size_t EstimateEntriesAdded() override;
-  Slice Finish(const BlockHandle& tmp, Status* status,
-               std::unique_ptr<const char[]>* filter_data = nullptr) override;
+  Status Finish(const BlockHandle& last_partition_block_handle, Slice* filter,
+                std::unique_ptr<const char[]>* filter_owner = nullptr) override;
   using FilterBlockBuilder::Finish;
 
   void ResetFilterBitsBuilder() override { filter_bits_builder_.reset(); }

--- a/table/block_based/full_filter_block_test.cc
+++ b/table/block_based/full_filter_block_test.cc
@@ -104,7 +104,7 @@ class PluginFullFilterBlockTest : public mock::MockBlockBasedTableTester,
 
 TEST_F(PluginFullFilterBlockTest, PluginEmptyBuilder) {
   FullFilterBlockBuilder builder(nullptr, true, GetBuilder());
-  Slice slice = builder.Finish();
+  Slice slice = builder.TEST_Finish();
   ASSERT_EQ("", EscapeString(slice));
 
   CachableEntry<ParsedFullFilterBlock> block(
@@ -127,7 +127,7 @@ TEST_F(PluginFullFilterBlockTest, PluginSingleChunk) {
   builder.Add("box");
   builder.Add("box");
   builder.Add("hello");
-  Slice slice = builder.Finish();
+  Slice slice = builder.TEST_Finish();
 
   CachableEntry<ParsedFullFilterBlock> block(
       new ParsedFullFilterBlock(table_options_.filter_policy.get(),
@@ -174,7 +174,7 @@ class FullFilterBlockTest : public mock::MockBlockBasedTableTester,
 
 TEST_F(FullFilterBlockTest, EmptyBuilder) {
   FullFilterBlockBuilder builder(nullptr, true, GetBuilder());
-  Slice slice = builder.Finish();
+  Slice slice = builder.TEST_Finish();
   ASSERT_EQ("", EscapeString(slice));
 
   CachableEntry<ParsedFullFilterBlock> block(
@@ -274,8 +274,8 @@ TEST_F(FullFilterBlockTest, SingleChunk) {
   // "box" only counts once
   ASSERT_EQ(4, builder.EstimateEntriesAdded());
   ASSERT_FALSE(builder.IsEmpty());
-  Status s;
-  Slice slice = builder.Finish(BlockHandle(), &s);
+  Slice slice;
+  Status s = builder.Finish(BlockHandle(), &slice);
   ASSERT_OK(s);
 
   CachableEntry<ParsedFullFilterBlock> block(

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -30,6 +30,7 @@ PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
     const bool persist_user_defined_timestamps)
     : FullFilterBlockBuilder(_prefix_extractor, whole_key_filtering,
                              filter_bits_builder),
+      p_index_builder_(p_index_builder),
       index_on_filter_block_builder_(
           index_block_restart_interval, true /*use_delta_encoding*/,
           use_value_delta_encoding,
@@ -41,10 +42,7 @@ PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
           use_value_delta_encoding,
           BlockBasedTableOptions::kDataBlockBinarySearch /* index_type */,
           0.75 /* data_block_hash_table_util_ratio */, ts_sz,
-          persist_user_defined_timestamps, true /* is_user_key */),
-      p_index_builder_(p_index_builder),
-      keys_added_to_partition_(0),
-      total_added_in_built_(0) {
+          persist_user_defined_timestamps, true /* is_user_key */) {
   // See FullFilterBlockBuilder::AddPrefix
   need_last_prefix_ = prefix_extractor() != nullptr;
   // Compute keys_per_partition_
@@ -108,19 +106,17 @@ void PartitionedFilterBlockBuilder::MaybeCutAFilterBlock(
   if (filter_construction_status.ok()) {
     filter_construction_status = filter_bits_builder_->MaybePostVerify(filter);
   }
-  filters.push_back(
+  filters_.push_back(
       {p_index_builder_->GetPartitionKey(), std::move(filter_data), filter});
-  if (!filter_construction_status.ok() &&
-      partitioned_filters_construction_status_.ok()) {
-    partitioned_filters_construction_status_ = filter_construction_status;
-  }
+  partitioned_filters_construction_status_.UpdateIfOk(
+      filter_construction_status);
   keys_added_to_partition_ = 0;
   Reset();
 }
 
-void PartitionedFilterBlockBuilder::Add(const Slice& key) {
-  MaybeCutAFilterBlock(&key);
-  FullFilterBlockBuilder::Add(key);
+void PartitionedFilterBlockBuilder::Add(const Slice& key_without_ts) {
+  MaybeCutAFilterBlock(&key_without_ts);
+  FullFilterBlockBuilder::Add(key_without_ts);
 }
 
 void PartitionedFilterBlockBuilder::AddKey(const Slice& key) {
@@ -132,10 +128,14 @@ size_t PartitionedFilterBlockBuilder::EstimateEntriesAdded() {
   return total_added_in_built_ + filter_bits_builder_->EstimateEntriesAdded();
 }
 
-Slice PartitionedFilterBlockBuilder::Finish(
-    const BlockHandle& last_partition_block_handle, Status* status,
-    std::unique_ptr<const char[]>* filter_data) {
-  if (finishing_filters == true) {
+Status PartitionedFilterBlockBuilder::Finish(
+    const BlockHandle& last_partition_block_handle, Slice* filter,
+    std::unique_ptr<const char[]>* filter_owner) {
+  if (finishing_front_filter_) {
+    assert(!filters_.empty());
+    auto& e = filters_.front();
+
+    assert(last_partition_block_handle != BlockHandle{});
     // Record the handle of the last written filter block in the index
     std::string handle_encoding;
     last_partition_block_handle.EncodeTo(&handle_encoding);
@@ -145,54 +145,53 @@ Slice PartitionedFilterBlockBuilder::Finish(
         last_partition_block_handle.size() - last_encoded_handle_.size());
     last_encoded_handle_ = last_partition_block_handle;
     const Slice handle_delta_encoding_slice(handle_delta_encoding);
-    index_on_filter_block_builder_.Add(last_filter_entry_key, handle_encoding,
+
+    index_on_filter_block_builder_.Add(e.ikey, handle_encoding,
                                        &handle_delta_encoding_slice);
     if (!p_index_builder_->seperator_is_key_plus_seq()) {
       index_on_filter_block_builder_without_seq_.Add(
-          ExtractUserKey(last_filter_entry_key), handle_encoding,
+          ExtractUserKey(e.ikey), handle_encoding,
           &handle_delta_encoding_slice);
     }
+
+    filters_.pop_front();
   } else {
+    assert(last_partition_block_handle == BlockHandle{});
     MaybeCutAFilterBlock(nullptr);
   }
 
-  if (!partitioned_filters_construction_status_.ok()) {
-    *status = partitioned_filters_construction_status_;
-    return Slice();
-  }
+  Status s = partitioned_filters_construction_status_;
+  assert(!s.IsIncomplete());
 
-  // If there is no filter partition left, then return the index on filter
-  // partitions
-  if (UNLIKELY(filters.empty())) {
-    *status = Status::OK();
-    last_filter_data.reset();
-    if (finishing_filters) {
-      // Simplest to just add them all at the end
-      total_added_in_built_ = 0;
-      if (p_index_builder_->seperator_is_key_plus_seq()) {
-        return index_on_filter_block_builder_.Finish();
+  if (s.ok()) {
+    // If there is no filter partition left, then return the index on filter
+    // partitions
+    if (UNLIKELY(filters_.empty())) {
+      if (!index_on_filter_block_builder_.empty()) {
+        // Simplest to just add them all at the end
+        if (p_index_builder_->seperator_is_key_plus_seq()) {
+          *filter = index_on_filter_block_builder_.Finish();
+        } else {
+          *filter = index_on_filter_block_builder_without_seq_.Finish();
+        }
       } else {
-        return index_on_filter_block_builder_without_seq_.Finish();
+        // This is the rare case where no key was added to the filter
+        *filter = Slice{};
       }
     } else {
-      // This is the rare case where no key was added to the filter
-      return Slice();
-    }
-  } else {
-    // Return the next filter partition in line and set Incomplete() status to
-    // indicate we expect more calls to Finish
-    *status = Status::Incomplete();
-    finishing_filters = true;
+      // Return the next filter partition in line and set Incomplete() status to
+      // indicate we expect more calls to Finish
+      s = Status::Incomplete();
+      finishing_front_filter_ = true;
 
-    last_filter_entry_key = filters.front().key;
-    Slice filter = filters.front().filter;
-    last_filter_data = std::move(filters.front().filter_data);
-    if (filter_data != nullptr) {
-      *filter_data = std::move(last_filter_data);
+      auto& e = filters_.front();
+      if (filter_owner != nullptr) {
+        *filter_owner = std::move(e.filter_owner);
+      }
+      *filter = e.filter;
     }
-    filters.pop_front();
-    return filter;
   }
+  return s;
 }
 
 PartitionedFilterBlockReader::PartitionedFilterBlockReader(

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -170,7 +170,7 @@ class PartitionedFilterBlockTest
     Slice slice;
     std::unique_ptr<const char[]> filter_data;
     do {
-      slice = builder->Finish(bh, &status, &filter_data);
+      status = builder->Finish(bh, &slice, &filter_data);
       bh = Write(slice);
     } while (status.IsIncomplete());
 


### PR DESCRIPTION
Summary: This is ahead of some related changes/enhancements. Refactorings here:
* Restructure some state of PartitionedFilterBlockBuilder to reduce redundancy in state tracking, improve clarity.
* Changed some function signatures to better match standard practice (return Status)
* Improve comments, arrange related fields
* Discourage/prevent production use of Finish without status (now TEST_Finish)

Test Plan: existing tests