### PR TITLE
Fix same user collected property being re-added in stress tests

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4262,6 +4262,7 @@ void InitializeOptionsGeneral(
     options.disable_auto_compactions = true;
   }
 
+  options.table_properties_collector_factories.clear();
   options.table_properties_collector_factories.emplace_back(
       std::make_shared<DbStressTablePropertiesCollectorFactory>());
 


### PR DESCRIPTION
As titled. The `emplace_back` below will add the same collector factory again during Reopen. 