### PR TITLE
fix compaction_picker_test asan heap use after free

### DIFF
--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -16,7 +16,6 @@
 #include "table/unique_id_impl.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
-#include "util/defer.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -215,7 +214,10 @@ class CompactionPickerTest : public CompactionPickerTestBase {
   explicit CompactionPickerTest()
       : CompactionPickerTestBase(BytewiseComparator()) {}
 
-  ~CompactionPickerTest() override = default;
+  ~CompactionPickerTest() override {
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+    SyncPoint::GetInstance()->DisableProcessing();
+  }
 };
 
 class CompactionPickerU64TsTest : public CompactionPickerTestBase {
@@ -3186,10 +3188,6 @@ TEST_F(CompactionPickerTest, UniversalMarkedCompactionStartOutputOverlap) {
         size_t* index = static_cast<size_t*>(arg);
         *index = random_index;
       });
-  Defer defer([]() {
-    SyncPoint::GetInstance()->ClearCallBack(
-        "CompactionPicker::PickFilesMarkedForCompaction");
-  });
   SyncPoint::GetInstance()->EnableProcessing();
   while (!input_level_overlap || !output_level_overlap) {
     // Ensure that the L0 file gets picked first
@@ -3707,10 +3705,6 @@ TEST_P(PerKeyPlacementCompactionPickerTest, OverlapWithNormalCompaction) {
         auto supports_per_key_placement = static_cast<bool*>(arg);
         *supports_per_key_placement = enable_per_key_placement_;
       });
-  Defer defer([]() {
-    SyncPoint::GetInstance()->ClearCallBack(
-        "Compaction::SupportsPerKeyPlacement:Enabled");
-  });
   SyncPoint::GetInstance()->EnableProcessing();
 
   int num_levels = ioptions_.num_levels;
@@ -3754,10 +3748,6 @@ TEST_P(PerKeyPlacementCompactionPickerTest, NormalCompactionOverlap) {
         auto supports_per_key_placement = static_cast<bool*>(arg);
         *supports_per_key_placement = enable_per_key_placement_;
       });
-  Defer defer([]() {
-    SyncPoint::GetInstance()->ClearCallBack(
-        "Compaction::SupportsPerKeyPlacement:Enabled");
-  });
   SyncPoint::GetInstance()->EnableProcessing();
 
   int num_levels = ioptions_.num_levels;
@@ -3802,10 +3792,6 @@ TEST_P(PerKeyPlacementCompactionPickerTest,
         auto supports_per_key_placement = static_cast<bool*>(arg);
         *supports_per_key_placement = enable_per_key_placement_;
       });
-  Defer defer([]() {
-    SyncPoint::GetInstance()->ClearCallBack(
-        "Compaction::SupportsPerKeyPlacement:Enabled");
-  });
   SyncPoint::GetInstance()->EnableProcessing();
 
   int num_levels = ioptions_.num_levels;
@@ -3850,10 +3836,6 @@ TEST_P(PerKeyPlacementCompactionPickerTest, NormalCompactionOverlapUniversal) {
         auto supports_per_key_placement = static_cast<bool*>(arg);
         *supports_per_key_placement = enable_per_key_placement_;
       });
-  Defer defer([]() {
-    SyncPoint::GetInstance()->ClearCallBack(
-        "Compaction::SupportsPerKeyPlacement:Enabled");
-  });
   SyncPoint::GetInstance()->EnableProcessing();
 
   int num_levels = ioptions_.num_levels;

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -16,6 +16,7 @@
 #include "table/unique_id_impl.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
+#include "util/defer.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -3185,6 +3186,10 @@ TEST_F(CompactionPickerTest, UniversalMarkedCompactionStartOutputOverlap) {
         size_t* index = static_cast<size_t*>(arg);
         *index = random_index;
       });
+  Defer defer([]() {
+    SyncPoint::GetInstance()->ClearCallBack(
+        "CompactionPicker::PickFilesMarkedForCompaction");
+  });
   SyncPoint::GetInstance()->EnableProcessing();
   while (!input_level_overlap || !output_level_overlap) {
     // Ensure that the L0 file gets picked first
@@ -3702,6 +3707,10 @@ TEST_P(PerKeyPlacementCompactionPickerTest, OverlapWithNormalCompaction) {
         auto supports_per_key_placement = static_cast<bool*>(arg);
         *supports_per_key_placement = enable_per_key_placement_;
       });
+  Defer defer([]() {
+    SyncPoint::GetInstance()->ClearCallBack(
+        "Compaction::SupportsPerKeyPlacement:Enabled");
+  });
   SyncPoint::GetInstance()->EnableProcessing();
 
   int num_levels = ioptions_.num_levels;
@@ -3745,6 +3754,10 @@ TEST_P(PerKeyPlacementCompactionPickerTest, NormalCompactionOverlap) {
         auto supports_per_key_placement = static_cast<bool*>(arg);
         *supports_per_key_placement = enable_per_key_placement_;
       });
+  Defer defer([]() {
+    SyncPoint::GetInstance()->ClearCallBack(
+        "Compaction::SupportsPerKeyPlacement:Enabled");
+  });
   SyncPoint::GetInstance()->EnableProcessing();
 
   int num_levels = ioptions_.num_levels;
@@ -3789,6 +3802,10 @@ TEST_P(PerKeyPlacementCompactionPickerTest,
         auto supports_per_key_placement = static_cast<bool*>(arg);
         *supports_per_key_placement = enable_per_key_placement_;
       });
+  Defer defer([]() {
+    SyncPoint::GetInstance()->ClearCallBack(
+        "Compaction::SupportsPerKeyPlacement:Enabled");
+  });
   SyncPoint::GetInstance()->EnableProcessing();
 
   int num_levels = ioptions_.num_levels;
@@ -3833,6 +3850,10 @@ TEST_P(PerKeyPlacementCompactionPickerTest, NormalCompactionOverlapUniversal) {
         auto supports_per_key_placement = static_cast<bool*>(arg);
         *supports_per_key_placement = enable_per_key_placement_;
       });
+  Defer defer([]() {
+    SyncPoint::GetInstance()->ClearCallBack(
+        "Compaction::SupportsPerKeyPlacement:Enabled");
+  });
   SyncPoint::GetInstance()->EnableProcessing();
 
   int num_levels = ioptions_.num_levels;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3290fe18-aca2-4691-b072-fbbc96a15fb1)

this testcase set syncpoint function which reference this test case heap variable "enable_per_key_placement_" and this sync point function will be triggered by another testcase, so asan will report asan heap use after free error