### PR TITLE
Loosen a strong assertion in ExpectedValue::Exists()

### DIFF
--- a/db_stress_tool/expected_value.h
+++ b/db_stress_tool/expected_value.h
@@ -38,7 +38,7 @@ class ExpectedValue {
       : expected_value_(expected_value) {}
 
   bool Exists() const {
-    assert(!PendingWrite() && !PendingDelete());
+    assert(!PendingWrite());
     return !IsDeleted();
   }
 


### PR DESCRIPTION
**Context/Summary:** .... since it won't work in the PrepareDelete() path. The delete path can delete a key with a pending delete set previously. 


**Test:** CI