### PR TITLE
Best efforts recovery recover seqno prefix

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -3407,6 +3407,46 @@ class TableFileListener : public EventListener {
   InstrumentedMutex mutex_;
   std::unordered_map<std::string, std::vector<std::string>> cf_to_paths_;
 };
+
+class FlushTableFileListener : public EventListener {
+ public:
+  void OnTableFileCreated(const TableFileCreationInfo& info) override {
+    InstrumentedMutexLock lock(&mutex_);
+    if (info.reason != TableFileCreationReason::kFlush) {
+      return;
+    }
+    cf_to_flushed_files_[info.cf_name].push_back(info.file_path);
+  }
+  std::vector<std::string>& GetFlushedFiles(const std::string& cf_name) {
+    InstrumentedMutexLock lock(&mutex_);
+    return cf_to_flushed_files_[cf_name];
+  }
+
+ private:
+  InstrumentedMutex mutex_;
+  std::unordered_map<std::string, std::vector<std::string>>
+      cf_to_flushed_files_;
+};
+
+class FlushBlobFileListener : public EventListener {
+ public:
+  void OnBlobFileCreated(const BlobFileCreationInfo& info) override {
+    InstrumentedMutexLock lock(&mutex_);
+    if (info.reason != BlobFileCreationReason::kFlush) {
+      return;
+    }
+    cf_to_flushed_blobs_files_[info.cf_name].push_back(info.file_path);
+  }
+  std::vector<std::string>& GetFlushedBlobFiles(const std::string& cf_name) {
+    InstrumentedMutexLock lock(&mutex_);
+    return cf_to_flushed_blobs_files_[cf_name];
+  }
+
+ private:
+  InstrumentedMutex mutex_;
+  std::unordered_map<std::string, std::vector<std::string>>
+      cf_to_flushed_blobs_files_;
+};
 }  // anonymous namespace
 
 TEST_F(DBBasicTest, LastSstFileNotInManifest) {
@@ -3511,6 +3551,121 @@ TEST_F(DBBasicTest, RecoverWithMissingFiles) {
     ASSERT_OK(iter->status());
   }
 }
+
+// Param 0: whether to enable blob DB.
+// Param 1: when blob DB is enabled, whether to also delete the missing L0
+// file's associated blob file.
+class BestEffortsRecoverIncompleteVersionTest
+    : public DBTestBase,
+      public testing::WithParamInterface<std::tuple<bool, bool>> {
+ public:
+  BestEffortsRecoverIncompleteVersionTest()
+      : DBTestBase("best_efforts_recover_incomplete_version_test",
+                   /*env_do_fsync=*/false) {}
+};
+
+TEST_P(BestEffortsRecoverIncompleteVersionTest, Basic) {
+  Options options = CurrentOptions();
+  options.enable_blob_files = std::get<0>(GetParam());
+  bool delete_blob_file_too = std::get<1>(GetParam());
+  DestroyAndReopen(options);
+  FlushTableFileListener* flush_table_listener = new FlushTableFileListener();
+  FlushBlobFileListener* flush_blob_listener = new FlushBlobFileListener();
+  // Disable auto compaction to simplify SST file name tracking.
+  options.disable_auto_compactions = true;
+  options.listeners.emplace_back(flush_table_listener);
+  options.listeners.emplace_back(flush_blob_listener);
+  CreateAndReopenWithCF({"pikachu", "eevee"}, options);
+  std::vector<std::string> all_cf_names = {kDefaultColumnFamilyName, "pikachu",
+                                           "eevee"};
+  size_t num_cfs = handles_.size();
+  ASSERT_EQ(3, num_cfs);
+  std::string start = "a";
+  Slice start_slice = start;
+  std::string end = "d";
+  Slice end_slice = end;
+  for (size_t cf = 0; cf != num_cfs; ++cf) {
+    ASSERT_OK(Put(static_cast<int>(cf), "a", "a_value"));
+    ASSERT_OK(Flush(static_cast<int>(cf)));
+    // Compact file to L1 to avoid trivial file move in the next compaction
+    ASSERT_OK(db_->CompactRange(CompactRangeOptions(), handles_[cf],
+                                &start_slice, &end_slice));
+    ASSERT_OK(Put(static_cast<int>(cf), "a", "a_value_new"));
+    ASSERT_OK(Flush(static_cast<int>(cf)));
+    ASSERT_OK(Put(static_cast<int>(cf), "b", "b_value"));
+    ASSERT_OK(Flush(static_cast<int>(cf)));
+    ASSERT_OK(Put(static_cast<int>(cf), "f", "f_value"));
+    ASSERT_OK(Flush(static_cast<int>(cf)));
+    ASSERT_OK(db_->CompactRange(CompactRangeOptions(), handles_[cf],
+                                &start_slice, &end_slice));
+  }
+
+  dbfull()->TEST_DeleteObsoleteFiles();
+
+  // Delete the most recent L0 file which is before a compaction.
+  for (size_t i = 0; i < all_cf_names.size(); ++i) {
+    std::vector<std::string>& files =
+        flush_table_listener->GetFlushedFiles(all_cf_names[i]);
+    ASSERT_EQ(4, files.size());
+    ASSERT_OK(env_->DeleteFile(files[files.size() - 1]));
+    if (options.enable_blob_files) {
+      std::vector<std::string>& blob_files =
+          flush_blob_listener->GetFlushedBlobFiles(all_cf_names[i]);
+      ASSERT_EQ(4, blob_files.size());
+      if (delete_blob_file_too) {
+        ASSERT_OK(env_->DeleteFile(blob_files[files.size() - 1]));
+      }
+    }
+  }
+  options.best_efforts_recovery = true;
+  ReopenWithColumnFamilies(all_cf_names, options);
+
+  for (size_t i = 0; i < all_cf_names.size(); ++i) {
+    auto cfh = static_cast<ColumnFamilyHandleImpl*>(handles_[i]);
+    ColumnFamilyData* cfd = cfh->cfd();
+    VersionStorageInfo* vstorage = cfd->current()->storage_info();
+    // The L0 file flushed right before the last compaction is missing.
+    ASSERT_EQ(0, vstorage->LevelFiles(0).size());
+    // Only the output of the last compaction is available.
+    ASSERT_EQ(1, vstorage->LevelFiles(1).size());
+  }
+  // Verify data
+  ReadOptions read_opts;
+  read_opts.total_order_seek = true;
+  for (size_t i = 0; i < all_cf_names.size(); ++i) {
+    std::unique_ptr<Iterator> iter(db_->NewIterator(read_opts, handles_[i]));
+    iter->SeekToFirst();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->status());
+    ASSERT_EQ("a", iter->key());
+    ASSERT_EQ("a_value_new", iter->value());
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->status());
+    ASSERT_EQ("b", iter->key());
+    ASSERT_EQ("b_value", iter->value());
+    iter->Next();
+    ASSERT_FALSE(iter->Valid());
+    ASSERT_OK(iter->status());
+  }
+
+  // Write more data.
+  for (size_t cf = 0; cf < all_cf_names.size(); ++cf) {
+    ASSERT_OK(Put(static_cast<int>(cf), "g", "g_value"));
+    ASSERT_OK(Flush(static_cast<int>(cf)));
+    ASSERT_OK(db_->CompactRange(CompactRangeOptions(), handles_[cf], nullptr,
+                                nullptr));
+    std::string value;
+    ASSERT_OK(db_->Get(ReadOptions(), handles_[cf], "g", &value));
+    ASSERT_EQ("g_value", value);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(BestEffortsRecoverIncompleteVersionTest,
+                        BestEffortsRecoverIncompleteVersionTest,
+                        testing::Values(std::make_tuple(false, false),
+                                        std::make_tuple(true, false),
+                                        std::make_tuple(true, true)));
 
 TEST_F(DBBasicTest, BestEffortsRecoveryTryMultipleManifests) {
   Options options = CurrentOptions();

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1570,6 +1570,8 @@ class VersionBuilder::Rep {
         unaddressed_missing_files.erase(file_number);
       } else if (!unaddressed_missing_files.empty()) {
         return false;
+      } else {
+        break;
       }
     }
     return true;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -282,12 +282,45 @@ class VersionBuilder::Rep {
   ColumnFamilyData* cfd_;
   VersionEditHandler* version_edit_handler_;
   bool track_found_and_missing_files_;
+  // If false, only a complete Version with all files consisting it found is
+  // considered valid. If true, besides complete Version, if the Version is
+  // never edited in an atomic group, an incomplete Version with only a suffix
+  // of L0 files missing is also considered valid.
+  bool allow_incomplete_valid_version_;
 
-  // These are only tracked if `track_found_and_missing_files_` are enabled.
+  // These are only tracked if `track_found_and_missing_files_` is enabled.
+
+  // The SST files that are found (blob files not included yet).
   std::unordered_set<uint64_t> found_files_;
-  std::unordered_set<uint64_t> missing_files_;
+  // Missing SST files for L0
+  std::unordered_set<uint64_t> l0_missing_files_;
+  // Missing SST files for non L0 levels
+  std::unordered_set<uint64_t> non_l0_missing_files_;
+  // Intermediate SST files (blob files not included yet)
   std::vector<std::string> intermediate_files_;
+  // The highest file number for all the missing blob files, useful to check
+  // if a complete Version is available.
   uint64_t missing_blob_files_high_ = kInvalidBlobFileNumber;
+  // Missing blob files, useful to check if only the missing L0 files'
+  // associated blob files are missing.
+  std::unordered_set<uint64_t> missing_blob_files_;
+  // True if all files consisting the Version can be found. Or if
+  // `allow_incomplete_valid_version_` is true and the version history is not
+  // ever edited in an atomic group, this will be true if only a
+  // suffix of L0 SST files and their associated blob files are missing.
+  bool valid_version_available_;
+  // True if version is ever edited in an atomic group.
+  bool edited_in_atomic_group_;
+
+  // Flag to indicate if the Version is updated since last validity check. If no
+  // `Apply` call is made between a `Rep`'s construction and a
+  // `ValidVersionAvailable` check or between two `ValidVersionAvailable` calls.
+  // This flag will be true to indicate the cached validity value can be
+  // directly used without a recheck.
+  bool version_updated_since_last_check_;
+
+  // End of fields that are only tracked when `track_found_and_missing_files_`
+  // is enabled.
 
  public:
   Rep(const FileOptions& file_options, const ImmutableCFOptions* ioptions,
@@ -295,7 +328,7 @@ class VersionBuilder::Rep {
       VersionSet* version_set,
       std::shared_ptr<CacheReservationManager> file_metadata_cache_res_mgr,
       ColumnFamilyData* cfd, VersionEditHandler* version_edit_handler,
-      bool track_found_and_missing_files)
+      bool track_found_and_missing_files, bool allow_incomplete_valid_version)
       : file_options_(file_options),
         ioptions_(ioptions),
         table_cache_(table_cache),
@@ -311,13 +344,22 @@ class VersionBuilder::Rep {
         file_metadata_cache_res_mgr_(file_metadata_cache_res_mgr),
         cfd_(cfd),
         version_edit_handler_(version_edit_handler),
-        track_found_and_missing_files_(track_found_and_missing_files) {
+        track_found_and_missing_files_(track_found_and_missing_files),
+        allow_incomplete_valid_version_(allow_incomplete_valid_version) {
     assert(ioptions_);
 
     levels_ = new LevelState[num_levels_];
     if (track_found_and_missing_files_) {
       assert(cfd_);
       assert(version_edit_handler_);
+      // `track_found_and_missing_files_` mode used by VersionEditHandlerPIT
+      // assumes the initial base version is valid. For best efforts recovery,
+      // base will be empty. For manifest tailing usage like secondary instance,
+      // they do not allow incomplete version, so the base version in subsequent
+      // catch up attempts should be valid too.
+      valid_version_available_ = true;
+      edited_in_atomic_group_ = false;
+      version_updated_since_last_check_ = false;
     }
   }
 
@@ -340,10 +382,17 @@ class VersionBuilder::Rep {
         cfd_(other.cfd_),
         version_edit_handler_(other.version_edit_handler_),
         track_found_and_missing_files_(other.track_found_and_missing_files_),
+        allow_incomplete_valid_version_(other.allow_incomplete_valid_version_),
         found_files_(other.found_files_),
-        missing_files_(other.missing_files_),
+        l0_missing_files_(other.l0_missing_files_),
+        non_l0_missing_files_(other.non_l0_missing_files_),
         intermediate_files_(other.intermediate_files_),
-        missing_blob_files_high_(other.missing_blob_files_high_) {
+        missing_blob_files_high_(other.missing_blob_files_high_),
+        missing_blob_files_(other.missing_blob_files_),
+        valid_version_available_(other.valid_version_available_),
+        edited_in_atomic_group_(other.edited_in_atomic_group_),
+        version_updated_since_last_check_(
+            other.version_updated_since_last_check_) {
     assert(ioptions_);
     levels_ = new LevelState[num_levels_];
     for (int level = 0; level < num_levels_; level++) {
@@ -729,6 +778,7 @@ class VersionBuilder::Rep {
       if (s.IsPathNotFound() || s.IsNotFound() || s.IsCorruption()) {
         missing_blob_files_high_ =
             std::max(missing_blob_files_high_, blob_file_number);
+        missing_blob_files_.insert(blob_file_number);
         s = Status::OK();
       } else if (!s.ok()) {
         return s;
@@ -855,11 +905,13 @@ class VersionBuilder::Rep {
 
     if (track_found_and_missing_files_) {
       assert(version_edit_handler_);
-      auto fiter = missing_files_.find(file_number);
-      if (fiter != missing_files_.end()) {
-        missing_files_.erase(fiter);
+      if (l0_missing_files_.find(file_number) != l0_missing_files_.end()) {
+        l0_missing_files_.erase(file_number);
+      } else if (non_l0_missing_files_.find(file_number) !=
+                 non_l0_missing_files_.end()) {
+        non_l0_missing_files_.erase(file_number);
       } else {
-        fiter = found_files_.find(file_number);
+        auto fiter = found_files_.find(file_number);
         // Only mark new files added during this catchup attempt for deletion.
         // These files were never installed in VersionStorageInfo.
         // Already referenced files that are deleted by a VersionEdit will
@@ -954,7 +1006,11 @@ class VersionBuilder::Rep {
           MakeTableFileName(ioptions_->cf_paths[0].path, file_number);
       s = version_edit_handler_->VerifyFile(cfd_, fpath, level, meta);
       if (s.IsPathNotFound() || s.IsNotFound() || s.IsCorruption()) {
-        missing_files_.insert(file_number);
+        if (0 == level) {
+          l0_missing_files_.insert(file_number);
+        } else {
+          non_l0_missing_files_.insert(file_number);
+        }
         if (s.IsCorruption()) {
           found_files_.insert(file_number);
         }
@@ -987,6 +1043,7 @@ class VersionBuilder::Rep {
 
   // Apply all of the edits in *edit to the current state.
   Status Apply(const VersionEdit* edit) {
+    bool version_updated = false;
     {
       const Status s = CheckConsistency(base_vstorage_);
       if (!s.ok()) {
@@ -1004,6 +1061,7 @@ class VersionBuilder::Rep {
       if (!s.ok()) {
         return s;
       }
+      version_updated = true;
     }
 
     // Increase the amount of garbage for blob files affected by GC
@@ -1012,6 +1070,7 @@ class VersionBuilder::Rep {
       if (!s.ok()) {
         return s;
       }
+      version_updated = true;
     }
 
     // Delete table files
@@ -1023,6 +1082,7 @@ class VersionBuilder::Rep {
       if (!s.ok()) {
         return s;
       }
+      version_updated = true;
     }
 
     // Add new table files
@@ -1034,6 +1094,7 @@ class VersionBuilder::Rep {
       if (!s.ok()) {
         return s;
       }
+      version_updated = true;
     }
 
     // Populate compact cursors for round-robin compaction, leave
@@ -1044,6 +1105,13 @@ class VersionBuilder::Rep {
       const Status s = ApplyCompactCursors(level, smallest_uncompacted_key);
       if (!s.ok()) {
         return s;
+      }
+    }
+
+    if (track_found_and_missing_files_ && version_updated) {
+      version_updated_since_last_check_ = true;
+      if (!edited_in_atomic_group_ && edit->IsInAtomicGroup()) {
+        edited_in_atomic_group_ = true;
       }
     }
     return Status::OK();
@@ -1188,12 +1256,35 @@ class VersionBuilder::Rep {
         mutable_meta.GetGarbageBlobCount(), mutable_meta.GetGarbageBlobBytes());
   }
 
+  bool BlobFileOnlyLinkedToMissingL0Files(
+      const std::unordered_set<uint64_t>& linked_ssts) const {
+    return !linked_ssts.empty() &&
+           std::all_of(linked_ssts.begin(), linked_ssts.end(),
+                       [&](const uint64_t& element) {
+                         return l0_missing_files_.find(element) !=
+                                l0_missing_files_.end();
+                       });
+  }
+
   // Add the blob file specified by meta to *vstorage if it is determined to
   // contain valid data (blobs).
   template <typename Meta>
-  static void AddBlobFileIfNeeded(VersionStorageInfo* vstorage, Meta&& meta) {
+  void AddBlobFileIfNeeded(VersionStorageInfo* vstorage, Meta&& meta,
+                           uint64_t blob_file_number) const {
     assert(vstorage);
     assert(meta);
+
+    if (track_found_and_missing_files_) {
+      if (missing_blob_files_.find(blob_file_number) !=
+          missing_blob_files_.end()) {
+        return;
+      }
+      auto iter = mutable_blob_file_metas_.find(blob_file_number);
+      assert(iter != mutable_blob_file_metas_.end());
+      if (BlobFileOnlyLinkedToMissingL0Files(iter->second.GetLinkedSsts())) {
+        return;
+      }
+    }
 
     if (meta->GetLinkedSsts().empty() &&
         meta->GetGarbageBlobCount() >= meta->GetTotalBlobCount()) {
@@ -1207,6 +1298,7 @@ class VersionBuilder::Rep {
   // applied, and save the result into *vstorage.
   void SaveBlobFilesTo(VersionStorageInfo* vstorage) const {
     assert(vstorage);
+    assert(!track_found_and_missing_files_ || valid_version_available_);
 
     assert(base_vstorage_);
     vstorage->ReserveBlob(base_vstorage_->GetBlobFiles().size() +
@@ -1222,22 +1314,24 @@ class VersionBuilder::Rep {
     }
 
     auto process_base =
-        [vstorage](const std::shared_ptr<BlobFileMetaData>& base_meta) {
+        [this, vstorage](const std::shared_ptr<BlobFileMetaData>& base_meta) {
           assert(base_meta);
 
-          AddBlobFileIfNeeded(vstorage, base_meta);
+          AddBlobFileIfNeeded(vstorage, base_meta,
+                              base_meta->GetBlobFileNumber());
 
           return true;
         };
 
     auto process_mutable =
-        [vstorage](const MutableBlobFileMetaData& mutable_meta) {
-          AddBlobFileIfNeeded(vstorage, CreateBlobFileMetaData(mutable_meta));
+        [this, vstorage](const MutableBlobFileMetaData& mutable_meta) {
+          AddBlobFileIfNeeded(vstorage, CreateBlobFileMetaData(mutable_meta),
+                              mutable_meta.GetBlobFileNumber());
 
           return true;
         };
 
-    auto process_both = [vstorage](
+    auto process_both = [this, vstorage](
                             const std::shared_ptr<BlobFileMetaData>& base_meta,
                             const MutableBlobFileMetaData& mutable_meta) {
       assert(base_meta);
@@ -1250,12 +1344,14 @@ class VersionBuilder::Rep {
                mutable_meta.GetGarbageBlobBytes());
         assert(base_meta->GetLinkedSsts() == mutable_meta.GetLinkedSsts());
 
-        AddBlobFileIfNeeded(vstorage, base_meta);
+        AddBlobFileIfNeeded(vstorage, base_meta,
+                            base_meta->GetBlobFileNumber());
 
         return true;
       }
 
-      AddBlobFileIfNeeded(vstorage, CreateBlobFileMetaData(mutable_meta));
+      AddBlobFileIfNeeded(vstorage, CreateBlobFileMetaData(mutable_meta),
+                          mutable_meta.GetBlobFileNumber());
 
       return true;
     };
@@ -1267,6 +1363,10 @@ class VersionBuilder::Rep {
   void MaybeAddFile(VersionStorageInfo* vstorage, int level,
                     FileMetaData* f) const {
     const uint64_t file_number = f->fd.GetNumber();
+    if (track_found_and_missing_files_ && level == 0 &&
+        l0_missing_files_.find(file_number) != l0_missing_files_.end()) {
+      return;
+    }
 
     const auto& level_state = levels_[level];
 
@@ -1290,16 +1390,16 @@ class VersionBuilder::Rep {
     }
   }
 
-  bool ContainsCompletePIT() {
+  bool ContainsCompleteVersion() const {
     assert(track_found_and_missing_files_);
-    return missing_files_.empty() &&
+    return l0_missing_files_.empty() && non_l0_missing_files_.empty() &&
            (missing_blob_files_high_ == kInvalidBlobFileNumber ||
             missing_blob_files_high_ < GetMinOldestBlobFileNumber());
   }
 
   bool HasMissingFiles() const {
     assert(track_found_and_missing_files_);
-    return !missing_files_.empty() ||
+    return !l0_missing_files_.empty() || !non_l0_missing_files_.empty() ||
            missing_blob_files_high_ != kInvalidBlobFileNumber;
   }
 
@@ -1321,6 +1421,16 @@ class VersionBuilder::Rep {
     const auto& unordered_added_files = levels_[level].added_files;
     vstorage->Reserve(level, base_files.size() + unordered_added_files.size());
 
+    MergeUnorderdAddedFilesWithBase(
+        base_files, unordered_added_files, cmp,
+        [&](FileMetaData* file) { MaybeAddFile(vstorage, level, file); });
+  }
+
+  template <typename Cmp, typename AddFileFunc>
+  void MergeUnorderdAddedFilesWithBase(
+      const std::vector<FileMetaData*>& base_files,
+      const std::unordered_map<uint64_t, FileMetaData*>& unordered_added_files,
+      Cmp cmp, AddFileFunc add_file_func) const {
     // Sort added files for the level.
     std::vector<FileMetaData*> added_files;
     added_files.reserve(unordered_added_files.size());
@@ -1336,9 +1446,9 @@ class VersionBuilder::Rep {
     while (added_iter != added_end || base_iter != base_end) {
       if (base_iter == base_end ||
           (added_iter != added_end && cmp(*added_iter, *base_iter))) {
-        MaybeAddFile(vstorage, level, *added_iter++);
+        add_file_func(*added_iter++);
       } else {
-        MaybeAddFile(vstorage, level, *base_iter++);
+        add_file_func(*base_iter++);
       }
     }
   }
@@ -1397,8 +1507,108 @@ class VersionBuilder::Rep {
     }
   }
 
+  bool ValidVersionAvailable() {
+    assert(track_found_and_missing_files_);
+    if (version_updated_since_last_check_) {
+      valid_version_available_ = ContainsCompleteVersion();
+      if (!valid_version_available_ && !edited_in_atomic_group_ &&
+          allow_incomplete_valid_version_) {
+        valid_version_available_ = OnlyMissingL0Suffix();
+      }
+      version_updated_since_last_check_ = false;
+    }
+    return valid_version_available_;
+  }
+
+  bool OnlyMissingL0Suffix() const {
+    if (!non_l0_missing_files_.empty()) {
+      return false;
+    }
+    assert(!(l0_missing_files_.empty() && missing_blob_files_.empty()));
+
+    if (!l0_missing_files_.empty() && !MissingL0FilesAreL0Suffix()) {
+      return false;
+    }
+    if (!missing_blob_files_.empty() &&
+        !RemainingSstFilesNotMissingBlobFiles()) {
+      return false;
+    }
+    return true;
+  }
+
+  // Check missing L0 files are a suffix of expected sorted L0 files.
+  bool MissingL0FilesAreL0Suffix() const {
+    assert(non_l0_missing_files_.empty());
+    assert(!l0_missing_files_.empty());
+    std::vector<FileMetaData*> expected_sorted_l0_files;
+    const auto& base_files = base_vstorage_->LevelFiles(0);
+    const auto& unordered_added_files = levels_[0].added_files;
+    expected_sorted_l0_files.reserve(base_files.size() +
+                                     unordered_added_files.size());
+    EpochNumberRequirement epoch_number_requirement =
+        base_vstorage_->GetEpochNumberRequirement();
+
+    if (epoch_number_requirement == EpochNumberRequirement::kMightMissing) {
+      MergeUnorderdAddedFilesWithBase(
+          base_files, unordered_added_files, *level_zero_cmp_by_seqno_,
+          [&](FileMetaData* file) {
+            expected_sorted_l0_files.push_back(file);
+          });
+    } else {
+      MergeUnorderdAddedFilesWithBase(
+          base_files, unordered_added_files, *level_zero_cmp_by_epochno_,
+          [&](FileMetaData* file) {
+            expected_sorted_l0_files.push_back(file);
+          });
+    }
+    assert(expected_sorted_l0_files.size() >= l0_missing_files_.size());
+    std::unordered_set<uint64_t> unaddressed_missing_files = l0_missing_files_;
+    for (auto iter = expected_sorted_l0_files.begin();
+         iter != expected_sorted_l0_files.end(); iter++) {
+      uint64_t file_number = (*iter)->fd.GetNumber();
+      if (l0_missing_files_.find(file_number) != l0_missing_files_.end()) {
+        assert(unaddressed_missing_files.find(file_number) !=
+               unaddressed_missing_files.end());
+        unaddressed_missing_files.erase(file_number);
+      } else if (!unaddressed_missing_files.empty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Check for each of the missing blob file missing, it either is older than
+  // the minimum oldest blob file required by this Version or only linked to
+  // the missing L0 files.
+  bool RemainingSstFilesNotMissingBlobFiles() const {
+    assert(non_l0_missing_files_.empty());
+    assert(!missing_blob_files_.empty());
+    bool no_l0_files_missing = l0_missing_files_.empty();
+    uint64_t min_oldest_blob_file_num = GetMinOldestBlobFileNumber();
+    for (const auto& missing_blob_file : missing_blob_files_) {
+      if (missing_blob_file < min_oldest_blob_file_num) {
+        continue;
+      }
+      auto iter = mutable_blob_file_metas_.find(missing_blob_file);
+      assert(iter != mutable_blob_file_metas_.end());
+      auto linked_ssts = iter->second.GetLinkedSsts();
+      // TODO(yuzhangyu): In theory, if no L0 SST files ara missing, and only
+      // blob files exclusively linked to a L0 suffix are missing, we can
+      // recover to a valid point in time too. We don't recover that type of
+      // incomplete Version yet.
+      if (!linked_ssts.empty() && no_l0_files_missing) {
+        return false;
+      }
+      if (!BlobFileOnlyLinkedToMissingL0Files(linked_ssts)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   // Save the current state in *vstorage.
   Status SaveTo(VersionStorageInfo* vstorage) const {
+    assert(!track_found_and_missing_files_ || valid_version_available_);
     Status s;
 
 #ifndef NDEBUG
@@ -1431,6 +1641,7 @@ class VersionBuilder::Rep {
       size_t max_file_size_for_l0_meta_pin, const ReadOptions& read_options,
       uint8_t block_protection_bytes_per_key) {
     assert(table_cache_ != nullptr);
+    assert(!track_found_and_missing_files_ || valid_version_available_);
 
     size_t table_cache_capacity =
         table_cache_->get_cache().get()->GetCapacity();
@@ -1470,6 +1681,11 @@ class VersionBuilder::Rep {
     for (int level = 0; level < num_levels_; level++) {
       for (auto& file_meta_pair : levels_[level].added_files) {
         auto* file_meta = file_meta_pair.second;
+        uint64_t file_number = file_meta->fd.GetNumber();
+        if (track_found_and_missing_files_ && level == 0 &&
+            l0_missing_files_.find(file_number) != l0_missing_files_.end()) {
+          continue;
+        }
         // If the file has been opened before, just skip it.
         if (!file_meta->table_reader_handle) {
           files_meta.emplace_back(file_meta, level);
@@ -1536,10 +1752,11 @@ VersionBuilder::VersionBuilder(
     VersionSet* version_set,
     std::shared_ptr<CacheReservationManager> file_metadata_cache_res_mgr,
     ColumnFamilyData* cfd, VersionEditHandler* version_edit_handler,
-    bool track_found_and_missing_files)
+    bool track_found_and_missing_files, bool allow_incomplete_valid_version)
     : rep_(new Rep(file_options, ioptions, table_cache, base_vstorage,
                    version_set, file_metadata_cache_res_mgr, cfd,
-                   version_edit_handler, track_found_and_missing_files)) {}
+                   version_edit_handler, track_found_and_missing_files,
+                   allow_incomplete_valid_version)) {}
 
 VersionBuilder::~VersionBuilder() = default;
 
@@ -1573,8 +1790,8 @@ void VersionBuilder::CreateOrReplaceSavePoint() {
   rep_ = std::make_unique<Rep>(*savepoint_);
 }
 
-bool VersionBuilder::ContainsCompletePIT() const {
-  return rep_->ContainsCompletePIT();
+bool VersionBuilder::ValidVersionAvailable() {
+  return rep_->ValidVersionAvailable();
 }
 
 bool VersionBuilder::HasMissingFiles() const { return rep_->HasMissingFiles(); }
@@ -1586,7 +1803,7 @@ std::vector<std::string>& VersionBuilder::GetAndClearIntermediateFiles() {
 void VersionBuilder::ClearFoundFiles() { return rep_->ClearFoundFiles(); }
 
 Status VersionBuilder::SaveSavePointTo(VersionStorageInfo* vstorage) const {
-  if (!savepoint_) {
+  if (!savepoint_ || !savepoint_->ValidVersionAvailable()) {
     return Status::InvalidArgument();
   }
   return savepoint_->SaveTo(vstorage);
@@ -1598,7 +1815,7 @@ Status VersionBuilder::LoadSavePointTableHandlers(
     const std::shared_ptr<const SliceTransform>& prefix_extractor,
     size_t max_file_size_for_l0_meta_pin, const ReadOptions& read_options,
     uint8_t block_protection_bytes_per_key) {
-  if (!savepoint_) {
+  if (!savepoint_ || !savepoint_->ValidVersionAvailable()) {
     return Status::InvalidArgument();
   }
   return savepoint_->LoadTableHandlers(
@@ -1611,25 +1828,27 @@ void VersionBuilder::ClearSavePoint() { savepoint_.reset(nullptr); }
 
 BaseReferencedVersionBuilder::BaseReferencedVersionBuilder(
     ColumnFamilyData* cfd, VersionEditHandler* version_edit_handler,
-    bool track_found_and_missing_files)
+    bool track_found_and_missing_files, bool allow_incomplete_valid_version)
     : version_builder_(new VersionBuilder(
           cfd->current()->version_set()->file_options(), cfd->ioptions(),
           cfd->table_cache(), cfd->current()->storage_info(),
           cfd->current()->version_set(),
           cfd->GetFileMetadataCacheReservationManager(), cfd,
-          version_edit_handler, track_found_and_missing_files)),
+          version_edit_handler, track_found_and_missing_files,
+          allow_incomplete_valid_version)),
       version_(cfd->current()) {
   version_->Ref();
 }
 
 BaseReferencedVersionBuilder::BaseReferencedVersionBuilder(
     ColumnFamilyData* cfd, Version* v, VersionEditHandler* version_edit_handler,
-    bool track_found_and_missing_files)
+    bool track_found_and_missing_files, bool allow_incomplete_valid_version)
     : version_builder_(new VersionBuilder(
           cfd->current()->version_set()->file_options(), cfd->ioptions(),
           cfd->table_cache(), v->storage_info(), v->version_set(),
           cfd->GetFileMetadataCacheReservationManager(), cfd,
-          version_edit_handler, track_found_and_missing_files)),
+          version_edit_handler, track_found_and_missing_files,
+          allow_incomplete_valid_version)),
       version_(v) {
   assert(version_ != cfd->current());
 }

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -155,8 +155,8 @@ VersionEditHandler::VersionEditHandler(
     VersionSet* version_set, bool track_found_and_missing_files,
     bool no_error_if_files_missing, const std::shared_ptr<IOTracer>& io_tracer,
     const ReadOptions& read_options, bool skip_load_table_files,
-    EpochNumberRequirement epoch_number_requirement,
-    bool allow_incomplete_valid_version)
+    bool allow_incomplete_valid_version,
+    EpochNumberRequirement epoch_number_requirement)
     : VersionEditHandlerBase(read_options),
       read_only_(read_only),
       column_families_(std::move(column_families)),
@@ -166,8 +166,8 @@ VersionEditHandler::VersionEditHandler(
       io_tracer_(io_tracer),
       skip_load_table_files_(skip_load_table_files),
       initialized_(false),
-      epoch_number_requirement_(epoch_number_requirement),
-      allow_incomplete_valid_version_(allow_incomplete_valid_version) {
+      allow_incomplete_valid_version_(allow_incomplete_valid_version),
+      epoch_number_requirement_(epoch_number_requirement) {
   assert(version_set_ != nullptr);
 }
 
@@ -690,14 +690,13 @@ Status VersionEditHandler::MaybeHandleFileBoundariesForNewFiles(
 VersionEditHandlerPointInTime::VersionEditHandlerPointInTime(
     bool read_only, std::vector<ColumnFamilyDescriptor> column_families,
     VersionSet* version_set, const std::shared_ptr<IOTracer>& io_tracer,
-    const ReadOptions& read_options,
-    EpochNumberRequirement epoch_number_requirement,
-    bool allow_incomplete_valid_version)
+    const ReadOptions& read_options, bool allow_incomplete_valid_version,
+    EpochNumberRequirement epoch_number_requirement)
     : VersionEditHandler(read_only, column_families, version_set,
                          /*track_found_and_missing_files=*/true,
                          /*no_error_if_files_missing=*/true, io_tracer,
-                         read_options, epoch_number_requirement,
-                         allow_incomplete_valid_version) {}
+                         read_options, allow_incomplete_valid_version,
+                         epoch_number_requirement) {}
 
 VersionEditHandlerPointInTime::~VersionEditHandlerPointInTime() {
   for (const auto& cfid_and_version : atomic_update_versions_) {

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -121,12 +121,14 @@ class VersionEditHandler : public VersionEditHandlerBase {
       const std::shared_ptr<IOTracer>& io_tracer,
       const ReadOptions& read_options,
       EpochNumberRequirement epoch_number_requirement =
-          EpochNumberRequirement::kMustPresent)
+          EpochNumberRequirement::kMustPresent,
+      bool allow_incomplete_valid_version = false)
       : VersionEditHandler(read_only, column_families, version_set,
                            track_found_and_missing_files,
                            no_error_if_files_missing, io_tracer, read_options,
                            /*skip_load_table_files=*/false,
-                           epoch_number_requirement) {}
+                           epoch_number_requirement,
+                           allow_incomplete_valid_version) {}
 
   ~VersionEditHandler() override {}
 
@@ -160,7 +162,8 @@ class VersionEditHandler : public VersionEditHandlerBase {
       const std::shared_ptr<IOTracer>& io_tracer,
       const ReadOptions& read_options, bool skip_load_table_files,
       EpochNumberRequirement epoch_number_requirement =
-          EpochNumberRequirement::kMustPresent);
+          EpochNumberRequirement::kMustPresent,
+      bool allow_incomplete_valid_version = false);
 
   Status ApplyVersionEdit(VersionEdit& edit, ColumnFamilyData** cfd) override;
 
@@ -214,6 +217,11 @@ class VersionEditHandler : public VersionEditHandlerBase {
   bool initialized_;
   std::unique_ptr<std::unordered_map<uint32_t, std::string>> cf_to_cmp_names_;
   EpochNumberRequirement epoch_number_requirement_;
+  // If false, only a complete Version for which all files consisting it can be
+  // found is considered a valid Version. If true, besides complete Version, an
+  // incomplete Version with only a suffix of L0 files missing is also
+  // considered valid if the Version is never edited in an atomic group.
+  const bool allow_incomplete_valid_version_;
   std::unordered_set<uint32_t> cfds_to_mark_no_udt_;
 
  private:
@@ -245,7 +253,8 @@ class VersionEditHandlerPointInTime : public VersionEditHandler {
       VersionSet* version_set, const std::shared_ptr<IOTracer>& io_tracer,
       const ReadOptions& read_options,
       EpochNumberRequirement epoch_number_requirement =
-          EpochNumberRequirement::kMustPresent);
+          EpochNumberRequirement::kMustPresent,
+      bool allow_incomplete_valid_version = true);
   ~VersionEditHandlerPointInTime() override;
 
   bool HasMissingFiles() const;
@@ -311,7 +320,8 @@ class ManifestTailer : public VersionEditHandlerPointInTime {
                               EpochNumberRequirement::kMustPresent)
       : VersionEditHandlerPointInTime(/*read_only=*/false, column_families,
                                       version_set, io_tracer, read_options,
-                                      epoch_number_requirement),
+                                      epoch_number_requirement,
+                                      /*allow_incomplete_valid_version=*/false),
         mode_(Mode::kRecovery) {}
 
   Status VerifyFile(ColumnFamilyData* cfd, const std::string& fpath, int level,
@@ -359,7 +369,9 @@ class DumpManifestHandler : public VersionEditHandler {
             /*read_only=*/true, column_families, version_set,
             /*track_found_and_missing_files=*/false,
             /*no_error_if_files_missing=*/false, io_tracer, read_options,
-            /*skip_load_table_files=*/true),
+            /*skip_load_table_files=*/true,
+            /*epoch_number_requirement=*/EpochNumberRequirement::kMustPresent,
+            /*allow_incomplete_valid_version=*/false),
         verbose_(verbose),
         hex_(hex),
         json_(json),

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -119,16 +119,15 @@ class VersionEditHandler : public VersionEditHandlerBase {
       VersionSet* version_set, bool track_found_and_missing_files,
       bool no_error_if_files_missing,
       const std::shared_ptr<IOTracer>& io_tracer,
-      const ReadOptions& read_options,
+      const ReadOptions& read_options, bool allow_incomplete_valid_version,
       EpochNumberRequirement epoch_number_requirement =
-          EpochNumberRequirement::kMustPresent,
-      bool allow_incomplete_valid_version = false)
+          EpochNumberRequirement::kMustPresent)
       : VersionEditHandler(read_only, column_families, version_set,
                            track_found_and_missing_files,
                            no_error_if_files_missing, io_tracer, read_options,
                            /*skip_load_table_files=*/false,
-                           epoch_number_requirement,
-                           allow_incomplete_valid_version) {}
+                           allow_incomplete_valid_version,
+                           epoch_number_requirement) {}
 
   ~VersionEditHandler() override {}
 
@@ -161,9 +160,9 @@ class VersionEditHandler : public VersionEditHandlerBase {
       bool no_error_if_files_missing,
       const std::shared_ptr<IOTracer>& io_tracer,
       const ReadOptions& read_options, bool skip_load_table_files,
+      bool allow_incomplete_valid_version,
       EpochNumberRequirement epoch_number_requirement =
-          EpochNumberRequirement::kMustPresent,
-      bool allow_incomplete_valid_version = false);
+          EpochNumberRequirement::kMustPresent);
 
   Status ApplyVersionEdit(VersionEdit& edit, ColumnFamilyData** cfd) override;
 
@@ -216,12 +215,12 @@ class VersionEditHandler : public VersionEditHandlerBase {
   bool skip_load_table_files_;
   bool initialized_;
   std::unique_ptr<std::unordered_map<uint32_t, std::string>> cf_to_cmp_names_;
-  EpochNumberRequirement epoch_number_requirement_;
   // If false, only a complete Version for which all files consisting it can be
   // found is considered a valid Version. If true, besides complete Version, an
   // incomplete Version with only a suffix of L0 files missing is also
   // considered valid if the Version is never edited in an atomic group.
   const bool allow_incomplete_valid_version_;
+  EpochNumberRequirement epoch_number_requirement_;
   std::unordered_set<uint32_t> cfds_to_mark_no_udt_;
 
  private:
@@ -242,7 +241,9 @@ class VersionEditHandler : public VersionEditHandlerBase {
 
 // A class similar to its base class, i.e. VersionEditHandler.
 // VersionEditHandlerPointInTime restores the versions to the most recent point
-// in time such that at this point, the version does not have missing files.
+// in time such that at this point, the version does not have missing files. Or
+// if `allow_incomplete_valid_version` is true, only a suffix of L0 files (and
+// their associated blob files) are missing.
 //
 // Not thread-safe, external synchronization is necessary if an object of
 // VersionEditHandlerPointInTime is shared by multiple threads.
@@ -251,10 +252,9 @@ class VersionEditHandlerPointInTime : public VersionEditHandler {
   VersionEditHandlerPointInTime(
       bool read_only, std::vector<ColumnFamilyDescriptor> column_families,
       VersionSet* version_set, const std::shared_ptr<IOTracer>& io_tracer,
-      const ReadOptions& read_options,
+      const ReadOptions& read_options, bool allow_incomplete_valid_version,
       EpochNumberRequirement epoch_number_requirement =
-          EpochNumberRequirement::kMustPresent,
-      bool allow_incomplete_valid_version = true);
+          EpochNumberRequirement::kMustPresent);
   ~VersionEditHandlerPointInTime() override;
 
   bool HasMissingFiles() const;
@@ -320,8 +320,8 @@ class ManifestTailer : public VersionEditHandlerPointInTime {
                               EpochNumberRequirement::kMustPresent)
       : VersionEditHandlerPointInTime(/*read_only=*/false, column_families,
                                       version_set, io_tracer, read_options,
-                                      epoch_number_requirement,
-                                      /*allow_incomplete_valid_version=*/false),
+                                      /*allow_incomplete_valid_version=*/false,
+                                      epoch_number_requirement),
         mode_(Mode::kRecovery) {}
 
   Status VerifyFile(ColumnFamilyData* cfd, const std::string& fpath, int level,
@@ -370,8 +370,8 @@ class DumpManifestHandler : public VersionEditHandler {
             /*track_found_and_missing_files=*/false,
             /*no_error_if_files_missing=*/false, io_tracer, read_options,
             /*skip_load_table_files=*/true,
-            /*epoch_number_requirement=*/EpochNumberRequirement::kMustPresent,
-            /*allow_incomplete_valid_version=*/false),
+            /*allow_incomplete_valid_version=*/false,
+            /*epoch_number_requirement=*/EpochNumberRequirement::kMustPresent),
         verbose_(verbose),
         hex_(hex),
         json_(json),

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -6080,7 +6080,8 @@ Status VersionSet::Recover(
     VersionEditHandler handler(
         read_only, column_families, const_cast<VersionSet*>(this),
         /*track_found_and_missing_files=*/false, no_error_if_files_missing,
-        io_tracer_, read_options, EpochNumberRequirement::kMightMissing);
+        io_tracer_, read_options, /*allow_incomplete_valid_version=*/false,
+        EpochNumberRequirement::kMightMissing);
     handler.Iterate(reader, &log_read_status);
     s = handler.status();
     if (s.ok()) {
@@ -6256,7 +6257,8 @@ Status VersionSet::TryRecoverFromOneManifest(
                      /*checksum=*/true, /*log_num=*/0);
   VersionEditHandlerPointInTime handler_pit(
       read_only, column_families, const_cast<VersionSet*>(this), io_tracer_,
-      read_options, EpochNumberRequirement::kMightMissing);
+      read_options, /*allow_incomplete_valid_version=*/true,
+      EpochNumberRequirement::kMightMissing);
 
   handler_pit.Iterate(reader, &s);
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1434,7 +1434,17 @@ struct DBOptions {
   // For example, if an SST or blob file referenced by the MANIFEST is missing,
   // BER might be able to find a set of files corresponding to an old "point in
   // time" version of the column family, possibly from an older MANIFEST
-  // file. Some other kinds of DB files (e.g. CURRENT, LOCK, IDENTITY) are
+  // file.
+  // Besides complete "point in time" version, an incomplete version with
+  // only a suffix of L0 files missing can also be recovered to if the
+  // versioning history doesn't include an atomic flush.  From the users'
+  // perspective, missing a suffix of L0 files means missing the
+  // user's most recently written data. So the remaining available files still
+  // presents a valid point in time view, although for some previous time. It's
+  // not done for atomic flush because that guarantees a consistent view across
+  // column families. We cannot guarantee that if recovering an incomplete
+  // version.
+  // Some other kinds of DB files (e.g. CURRENT, LOCK, IDENTITY) are
   // either ignored or replaced with BER, or quietly fixed regardless of BER
   // setting. BER does require at least one valid MANIFEST to recover to a
   // non-trivial DB state, unlike `ldb repair`.

--- a/unreleased_history/new_features/best_efforts_recovery_seqno_prefix.md
+++ b/unreleased_history/new_features/best_efforts_recovery_seqno_prefix.md
@@ -1,0 +1,1 @@
+*Best efforts recovery supports recovering to incomplete Version with a clean seqno cut that presents a valid point in time view from the user's perspective, if versioning history doesn't include atomic flush.


### PR DESCRIPTION
This PR make best efforts recovery more permissive by allowing it to recover incomplete Version that presents a valid point in time view from the user's perspective. Currently, a Version is only valid and saved if all files consisting that Version can be found. With this change, if only a suffix of L0 files (and their associated blob files) are missing,  a valid Version is also available to be saved and recover to. Note that we don't do this if the column family was atomically flushed. Because atomic flush also need a consistent view across the column families, we cannot guarantee that if we are recovering to incomplete version.

Test plan:
Existing tests and added unit tests.