### PR TITLE
Option to decouple index and filter partitions

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -366,6 +366,11 @@ Options DBTestBase::GetOptions(
     table_options.block_cache = NewLRUCache(/* too small */ 1);
   }
 
+  // Test anticipated new default as much as reasonably possible (and remove
+  // this code when obsolete)
+  assert(!table_options.decouple_partitioned_filters);
+  table_options.decouple_partitioned_filters = true;
+
   bool can_allow_mmap = IsMemoryMappedAccessSupported();
   switch (option_config) {
     case kHashSkipList:

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -213,8 +213,6 @@ TEST_P(DBTestUniversalCompaction, UniversalCompactionTrigger) {
   options.num_levels = num_levels_;
   options.write_buffer_size = 105 << 10;  // 105KB
   options.arena_block_size = 4 << 10;
-  // 32KB + some to accommodate apparent test sensitivity
-  options.target_file_size_base = 34 << 10;
   // trigger compaction if there are >= 4 files
   options.level0_file_num_compaction_trigger = 4;
   KeepFilterFactory* filter = new KeepFilterFactory(true);

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -213,7 +213,8 @@ TEST_P(DBTestUniversalCompaction, UniversalCompactionTrigger) {
   options.num_levels = num_levels_;
   options.write_buffer_size = 105 << 10;  // 105KB
   options.arena_block_size = 4 << 10;
-  options.target_file_size_base = 32 << 10;  // 32KB
+  // 32KB + some to accommodate apparent test sensitivity
+  options.target_file_size_base = 34 << 10;
   // trigger compaction if there are >= 4 files
   options.level0_file_num_compaction_trigger = 4;
   KeepFilterFactory* filter = new KeepFilterFactory(true);

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -330,17 +330,16 @@ inline Slice ExtractUserKey(const Slice& internal_key) {
 // output              : <user_provided_key>
 inline Slice ExtractUserKeyAndStripTimestamp(const Slice& internal_key,
                                              size_t ts_sz) {
-  Slice ret = internal_key;
-  ret.remove_suffix(kNumInternalBytes + ts_sz);
-  return ret;
+  assert(internal_key.size() >= kNumInternalBytes + ts_sz);
+  return Slice(internal_key.data(),
+               internal_key.size() - (kNumInternalBytes + ts_sz));
 }
 
 // input [user key]: <user_provided_key | ts>
 // output:           <user_provided_key>
 inline Slice StripTimestampFromUserKey(const Slice& user_key, size_t ts_sz) {
-  Slice ret = user_key;
-  ret.remove_suffix(ts_sz);
-  return ret;
+  assert(user_key.size() >= ts_sz);
+  return Slice(user_key.data(), user_key.size() - ts_sz);
 }
 
 // input [user key]: <user_provided_key | ts>

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -150,6 +150,7 @@ DECLARE_bool(charge_filter_construction);
 DECLARE_bool(charge_table_reader);
 DECLARE_bool(charge_file_metadata);
 DECLARE_bool(charge_blob_cache);
+DECLARE_bool(decouple_partitioned_filters);
 DECLARE_int32(top_level_index_pinning);
 DECLARE_int32(partition_pinning);
 DECLARE_int32(unpartitioned_pinning);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -380,6 +380,11 @@ DEFINE_bool(charge_blob_cache, false,
             "CacheEntryRoleOptions::charged of "
             "kBlobCache");
 
+DEFINE_bool(
+    decouple_partitioned_filters,
+    ROCKSDB_NAMESPACE::BlockBasedTableOptions().decouple_partitioned_filters,
+    "Decouple filter partitioning from index partitioning.");
+
 DEFINE_int32(
     top_level_index_pinning,
     static_cast<int32_t>(ROCKSDB_NAMESPACE::PinningTier::kFallback),

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3863,6 +3863,8 @@ void InitializeOptionsFromFlags(
     const std::shared_ptr<const FilterPolicy>& filter_policy,
     Options& options) {
   BlockBasedTableOptions block_based_options;
+  block_based_options.decouple_partitioned_filters =
+      FLAGS_decouple_partitioned_filters;
   block_based_options.block_cache = cache;
   block_based_options.cache_index_and_filter_blocks =
       FLAGS_cache_index_and_filter_blocks;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -188,6 +188,7 @@ TEST_F(OptionsSettableTest, BlockBasedTableOptionsAllFieldsSettable) {
       "block_size_deviation=8;block_restart_interval=4; "
       "metadata_block_size=1024;"
       "partition_filters=false;"
+      "decouple_partitioned_filters=true;"
       "optimize_filters_for_memory=true;"
       "use_delta_encoding=true;"
       "index_block_restart_interval=4;"

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -304,6 +304,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct BlockBasedTableOptions, partition_filters),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"decouple_partitioned_filters",
+         {offsetof(struct BlockBasedTableOptions, decouple_partitioned_filters),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         {"optimize_filters_for_memory",
          {offsetof(struct BlockBasedTableOptions, optimize_filters_for_memory),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -971,6 +975,8 @@ const std::string BlockBasedTablePropertyNames::kWholeKeyFiltering =
     "rocksdb.block.based.table.whole.key.filtering";
 const std::string BlockBasedTablePropertyNames::kPrefixFiltering =
     "rocksdb.block.based.table.prefix.filtering";
+const std::string BlockBasedTablePropertyNames::kDecoupledPartitionedFilters =
+    "rocksdb.block.based.table.decoupled.partitioned.filters";
 const std::string kHashIndexPrefixesBlock = "rocksdb.hashindex.prefixes";
 const std::string kHashIndexPrefixesMetadataBlock =
     "rocksdb.hashindex.metadata";

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -30,6 +30,11 @@ size_t FullFilterBlockBuilder::EstimateEntriesAdded() {
   return filter_bits_builder_->EstimateEntriesAdded();
 }
 
+void FullFilterBlockBuilder::AddWithPrevKey(
+    const Slice& key_without_ts, const Slice& /*prev_key_without_ts*/) {
+  FullFilterBlockBuilder::Add(key_without_ts);
+}
+
 void FullFilterBlockBuilder::Add(const Slice& key_without_ts) {
   if (prefix_extractor_ && prefix_extractor_->InDomain(key_without_ts)) {
     Slice prefix = prefix_extractor_->Transform(key_without_ts);

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -50,6 +50,9 @@ class FullFilterBlockBuilder : public FilterBlockBuilder {
   ~FullFilterBlockBuilder() {}
 
   void Add(const Slice& key_without_ts) override;
+  void AddWithPrevKey(const Slice& key_without_ts,
+                      const Slice& prev_key_without_ts) override;
+
   bool IsEmpty() const override {
     return filter_bits_builder_->EstimateEntriesAdded() == 0;
   }

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -27,10 +27,13 @@ PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
     const bool use_value_delta_encoding,
     PartitionedIndexBuilder* const p_index_builder,
     const uint32_t partition_size, size_t ts_sz,
-    const bool persist_user_defined_timestamps)
+    const bool persist_user_defined_timestamps,
+    bool decouple_from_index_partitions)
     : FullFilterBlockBuilder(_prefix_extractor, whole_key_filtering,
                              filter_bits_builder),
       p_index_builder_(p_index_builder),
+      ts_sz_(ts_sz),
+      decouple_from_index_partitions_(decouple_from_index_partitions),
       index_on_filter_block_builder_(
           index_block_restart_interval, true /*use_delta_encoding*/,
           use_value_delta_encoding,
@@ -73,18 +76,27 @@ PartitionedFilterBlockBuilder::~PartitionedFilterBlockBuilder() {
 }
 
 bool PartitionedFilterBlockBuilder::DecideCutAFilterBlock() {
-  // NOTE: Can't just use ==, because estimated might be incremented by more
-  // than one. +1 is for adding next_prefix below.
-  if (filter_bits_builder_->EstimateEntriesAdded() + 1 >= keys_per_partition_) {
-    // Currently only index builder is in charge of cutting a partition. We keep
-    // requesting until it is granted.
-    p_index_builder_->RequestPartitionCut();
+  // +1 to correct for adding next prefix in CutAFilterBlock
+  size_t added = filter_bits_builder_->EstimateEntriesAdded();
+  if (decouple_from_index_partitions_) {
+    // NOTE: Can't just use ==, because estimated might be incremented by more
+    // than one. +1 to correct for adding next prefix in CutAFilterBlock
+    return added + 1 >= keys_per_partition_;
+  } else {
+    // NOTE: Can't just use ==, because estimated might be incremented by more
+    // than one. +1 to correct for adding next prefix in CutAFilterBlock
+    if (added + 1 >= keys_per_partition_) {
+      // Currently only index builder is in charge of cutting a partition. We
+      // keep requesting until it is granted.
+      p_index_builder_->RequestPartitionCut();
+    }
+    return p_index_builder_->ShouldCutFilterBlock();
   }
-  return p_index_builder_->ShouldCutFilterBlock();
 }
 
 void PartitionedFilterBlockBuilder::CutAFilterBlock(const Slice* next_key,
-                                                    const Slice* next_prefix) {
+                                                    const Slice* next_prefix,
+                                                    const Slice& prev_key) {
   // When there is a next partition, add the prefix of the first key in the
   // next partition before closing this one out. This is needed to support
   // prefix Seek, because there could exist a key k where
@@ -115,51 +127,93 @@ void PartitionedFilterBlockBuilder::CutAFilterBlock(const Slice* next_key,
   if (filter_construction_status.ok()) {
     filter_construction_status = filter_bits_builder_->MaybePostVerify(filter);
   }
-  filters_.push_back(
-      {p_index_builder_->GetPartitionKey(), std::move(filter_data), filter});
+  std::string ikey;
+  if (decouple_from_index_partitions_) {
+    if (ts_sz_ > 0) {
+      AppendKeyWithMinTimestamp(&ikey, prev_key, ts_sz_);
+    } else {
+      ikey = prev_key.ToString();
+    }
+    AppendInternalKeyFooter(&ikey, /*seqno*/ 0, ValueType::kTypeDeletion);
+  } else {
+    ikey = p_index_builder_->GetPartitionKey();
+  }
+  filters_.push_back({std::move(ikey), std::move(filter_data), filter});
   partitioned_filters_construction_status_.UpdateIfOk(
       filter_construction_status);
 
   // If we are building another filter partition, the last prefix in the
   // previous partition should be added to support prefix SeekForPrev.
   // (Analogous to above fix for prefix Seek.)
-  if (next_key && last_key_in_domain_) {
+  if (next_key && prefix_extractor() &&
+      prefix_extractor()->InDomain(prev_key)) {
     // NOTE: At the beginning of building filter bits, we don't need a special
     // case for treating prefix as an "alt" entry.
     // See DBBloomFilterTest.FilterBitsBuilderDedup
-    filter_bits_builder_->AddKey(last_prefix_str_);
+    filter_bits_builder_->AddKey(prefix_extractor()->Transform(prev_key));
   }
 }
 
 void PartitionedFilterBlockBuilder::Add(const Slice& key_without_ts) {
+  assert(!DEBUG_add_with_prev_key_called_);
+  AddImpl(key_without_ts, prev_key_without_ts_);
+  prev_key_without_ts_.assign(key_without_ts.data(), key_without_ts.size());
+}
+
+void PartitionedFilterBlockBuilder::AddWithPrevKey(
+    const Slice& key_without_ts, const Slice& prev_key_without_ts) {
+#ifndef NDEBUG
+  if (!DEBUG_add_with_prev_key_called_) {
+    assert(prev_key_without_ts.compare(prev_key_without_ts_) == 0);
+    DEBUG_add_with_prev_key_called_ = true;
+  } else {
+    assert(prev_key_without_ts.compare(DEBUG_prev_key_without_ts_) == 0);
+  }
+  DEBUG_prev_key_without_ts_.assign(key_without_ts.data(),
+                                    key_without_ts.size());
+#endif
+  AddImpl(key_without_ts, prev_key_without_ts);
+}
+
+void PartitionedFilterBlockBuilder::AddImpl(const Slice& key_without_ts,
+                                            const Slice& prev_key_without_ts) {
   // When filter partitioning is coupled to index partitioning, we need to
   // check for cutting a block even if we aren't adding anything this time.
   bool cut = DecideCutAFilterBlock();
   if (prefix_extractor() && prefix_extractor()->InDomain(key_without_ts)) {
     Slice prefix = prefix_extractor()->Transform(key_without_ts);
     if (cut) {
-      CutAFilterBlock(&key_without_ts, &prefix);
+      CutAFilterBlock(&key_without_ts, &prefix, prev_key_without_ts);
     }
     if (whole_key_filtering()) {
       filter_bits_builder_->AddKeyAndAlt(key_without_ts, prefix);
     } else {
       filter_bits_builder_->AddKey(prefix);
     }
-    last_key_in_domain_ = true;
-    last_prefix_str_.assign(prefix.data(), prefix.size());
   } else {
     if (cut) {
-      CutAFilterBlock(&key_without_ts, nullptr);
+      CutAFilterBlock(&key_without_ts, nullptr /*no prefix*/,
+                      prev_key_without_ts);
     }
     if (whole_key_filtering()) {
       filter_bits_builder_->AddKey(key_without_ts);
     }
-    last_key_in_domain_ = false;
   }
 }
 
 size_t PartitionedFilterBlockBuilder::EstimateEntriesAdded() {
   return total_added_in_built_ + filter_bits_builder_->EstimateEntriesAdded();
+}
+
+void PartitionedFilterBlockBuilder::PrevKeyBeforeFinish(
+    const Slice& prev_key_without_ts) {
+  assert(prev_key_without_ts.compare(DEBUG_add_with_prev_key_called_
+                                         ? DEBUG_prev_key_without_ts_
+                                         : prev_key_without_ts_) == 0);
+  if (filter_bits_builder_->EstimateEntriesAdded() > 0) {
+    CutAFilterBlock(nullptr /*no next key*/, nullptr /*no next prefix*/,
+                    prev_key_without_ts);
+  }
 }
 
 Status PartitionedFilterBlockBuilder::Finish(
@@ -192,8 +246,11 @@ Status PartitionedFilterBlockBuilder::Finish(
   } else {
     assert(last_partition_block_handle == BlockHandle{});
     if (filter_bits_builder_->EstimateEntriesAdded() > 0) {
-      CutAFilterBlock(nullptr, nullptr);
+      // PrevKeyBeforeFinish was not called
+      assert(!DEBUG_add_with_prev_key_called_);
+      CutAFilterBlock(nullptr, nullptr, prev_key_without_ts_);
     }
+    // Nothing uncommitted
     assert(filter_bits_builder_->EstimateEntriesAdded() == 0);
   }
 

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -58,7 +58,7 @@ class MyPartitionedFilterBlockReader : public PartitionedFilterBlockReader {
 class PartitionedFilterBlockTest
     : public testing::Test,
       virtual public ::testing::WithParamInterface<
-          std::tuple<uint32_t, test::UserDefinedTimestampTestMode>> {
+          std::tuple<uint32_t, test::UserDefinedTimestampTestMode, bool>> {
  public:
   Options options_;
   ImmutableOptions ioptions_;
@@ -70,6 +70,7 @@ class PartitionedFilterBlockTest
   int bits_per_key_;
   size_t ts_sz_;
   bool user_defined_timestamps_persisted_;
+  bool decouple_partitioned_filters;
 
   PartitionedFilterBlockTest() : bits_per_key_(10) {
     auto udt_test_mode = std::get<1>(GetParam());
@@ -85,6 +86,8 @@ class PartitionedFilterBlockTest
         NewBloomFilterPolicy(bits_per_key_, false));
     table_options_.format_version = std::get<0>(GetParam());
     table_options_.index_block_restart_interval = 3;
+    table_options_.decouple_partitioned_filters = decouple_partitioned_filters =
+        std::get<2>(GetParam());
   }
 
   ~PartitionedFilterBlockTest() override = default;
@@ -160,8 +163,7 @@ class PartitionedFilterBlockTest
             FilterBuildingContext(table_options_)),
         table_options_.index_block_restart_interval, !kValueDeltaEncoded,
         p_index_builder, partition_size, ts_sz_,
-        user_defined_timestamps_persisted_,
-        true /*decouple_partitioned_filters TODO*/);
+        user_defined_timestamps_persisted_, decouple_partitioned_filters);
   }
 
   PartitionedFilterBlockReader* NewReader(
@@ -344,10 +346,10 @@ class PartitionedFilterBlockTest
 // Format versions potentially intersting to partitioning
 INSTANTIATE_TEST_CASE_P(
     FormatVersions, PartitionedFilterBlockTest,
-    testing::Combine(testing::ValuesIn(std::set<uint32_t>{
-                         2, 3, 4, 5, test::kDefaultFormatVersion,
-                         kLatestFormatVersion}),
-                     testing::ValuesIn(test::GetUDTTestModes())));
+    testing::Combine(
+        testing::ValuesIn(std::set<uint32_t>{
+            2, 3, 4, 5, test::kDefaultFormatVersion, kLatestFormatVersion}),
+        testing::ValuesIn(test::GetUDTTestModes()), testing::Bool()));
 
 TEST_P(PartitionedFilterBlockTest, EmptyBuilder) {
   std::unique_ptr<PartitionedIndexBuilder> pib(NewIndexBuilder());

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -160,7 +160,8 @@ class PartitionedFilterBlockTest
             FilterBuildingContext(table_options_)),
         table_options_.index_block_restart_interval, !kValueDeltaEncoded,
         p_index_builder, partition_size, ts_sz_,
-        user_defined_timestamps_persisted_);
+        user_defined_timestamps_persisted_,
+        true /*decouple_partitioned_filters TODO*/);
   }
 
   PartitionedFilterBlockReader* NewReader(

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -641,6 +641,11 @@ DEFINE_bool(use_cache_jemalloc_no_dump_allocator, false,
 DEFINE_bool(use_cache_memkind_kmem_allocator, false,
             "Use memkind kmem allocator for block/blob cache.");
 
+DEFINE_bool(
+    decouple_partitioned_filters,
+    ROCKSDB_NAMESPACE::BlockBasedTableOptions().decouple_partitioned_filters,
+    "Decouple filter partitioning from index partitioning.");
+
 DEFINE_bool(partition_index_and_filters, false,
             "Partition index and filter blocks.");
 
@@ -4362,6 +4367,8 @@ class Benchmark {
       } else {
         block_based_options.index_type = BlockBasedTableOptions::kBinarySearch;
       }
+      block_based_options.decouple_partitioned_filters =
+          FLAGS_decouple_partitioned_filters;
       if (FLAGS_partition_index_and_filters || FLAGS_partition_index) {
         if (FLAGS_index_with_first_key) {
           fprintf(stderr,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -75,6 +75,7 @@ default_params = {
     "compaction_pri": random.randint(0, 4),
     "key_may_exist_one_in": lambda: random.choice([100, 100000]),
     "data_block_index_type": lambda: random.choice([0, 1]),
+    "decouple_partitioned_filters": lambda: random.choice([0, 1, 1]),
     "delpercent": 4,
     "delrangepercent": 1,
     "destroy_db_initially": 0,

--- a/unreleased_history/new_features/decouple.md
+++ b/unreleased_history/new_features/decouple.md
@@ -1,0 +1,1 @@
+* New option `BlockBasedTableOptions::decouple_partitioned_filters` should improve efficiency in serving read queries because filter and index partitions can consistently target the configured `metadata_block_size`. This option is currently opt-in.


### PR DESCRIPTION
Summary: Partitioned metadata blocks were introduced back in 2017 to deal more gracefully with large DBs where RAM is relatively scarce and some data might be much colder than other data. The feature allows metadata blocks to compete for memory in the block cache against data blocks while alleviating tail latencies and thrash conditions that can arise with large metadata blocks (sometimes megabytes each) that can arise with large SST files. In general, the cost to partitioned metadata is more CPU in accesses (especially for filters where more binary search is needed before hashing can be used) and a bit more memory fragmentation and related overheads.

However the feature has always had a subtle limitation with a subtle effect on performance: index partitions and filter partitions must be cut at the same time, regardless of which wins the space race (hahaha) to metadata_block_size. Commonly filters will be a few times larger than indexes, so index partitions will be under-sized compared to filter (and data) blocks. While this does affect fragmentation and related overheads a bit, I suspect the bigger impact on performance is in the block cache. The coupling of the partition cuts would be defensible if the binary search done to find the filter block was used (on filter hit) to short-circuit binary search to an index partition, but that optimization has not been developed.

Consider two metadata blocks, an under-sized one and a normal-sized one, covering proportional sections of the key space with the same density of read queries. The under-sized one will be more prone to eviction from block cache because it is used less often. This is unfair because of its despite its proportionally smaller cost of keeping in block cache, and most of the cost of a miss to re-load it (random IO) is not proportional to the size (similar latency etc. up to ~32KB).

 ## This change

Adds a new table option decouple_partitioned_filters allows filter blocks and index blocks to be cut independently. To make this work, the partitioned filter block builder needs to know about the previous key, to generate an appropriate separator for the partition index. In most cases, BlockBasedTableBuilder already has easy access to the previous key to provide to the filter block builder.

This change includes refactoring to pass that previous key to the filter builder when available, with the filter building caching the previous key itself when unavailable, such as during compression dictionary training and some unit tests. Access to the previous key eliminates the need to track the previous prefix, which results in a small SST construction CPU win in prefix filtering cases, regardless of coupling, and possibly a small regression for some non-prefix cases, regardless of coupling, but still overall improvement especially with #12931.

Suggested follow-up:
* Update confusing use of "last key" to refer to "previous key"
* Expand unit test coverage with parallel compression and dictionary training
* Consider an option or enhancement to alleviate under-sized metadata blocks "at the end" of an SST file due to no coordination or awareness of when files are cut.

Test Plan: unit tests updated. Also did some unit test runs with "hard wired" usage of parallel compression and dictionary training code paths to ensure they were working. Also ran blackbox_crash_test for a while with the new feature.

 ## SST write performance (CPU)

Using the same testing setup as in #12931 but with -decouple_partitioned_filters=1 in the "after" configuration, which benchmarking shows makes almost no difference in terms of SST write CPU. "After" vs. "before" this PR
```
-partition_index_and_filters=0 -prefix_size=0 -whole_key_filtering=1
923691 vs. 924851 (-0.13%)
-partition_index_and_filters=0 -prefix_size=8 -whole_key_filtering=0
921398 vs. 922973 (-0.17%)
-partition_index_and_filters=0 -prefix_size=8 -whole_key_filtering=1
902259 vs. 908756 (-0.71%)
-partition_index_and_filters=1 -prefix_size=8 -whole_key_filtering=0
917932 vs. 916901 (+0.60%)
-partition_index_and_filters=1 -prefix_size=8 -whole_key_filtering=0
912755 vs. 907298 (+0.60%)
-partition_index_and_filters=1 -prefix_size=8 -whole_key_filtering=1
899754 vs. 892433 (+0.82%)
```
I think this is a pretty good trade, especially in attracting more movement toward partitioned configurations.

 ## Read performance

Let's see how decoupling affects read performance across various degrees of memory constraint. To simplify LSM structure, we're using FIFO compaction. Since decoupling will overall increase metadata block size, we control for this somewhat with an extra "before" configuration with larger metadata block size setting (8k instead of 4k). Basic setup:

```
(for CS in 0300 1200; do TEST_TMPDIR=/dev/shm/rocksdb1 ./db_bench -benchmarks=fillrandom,flush,readrandom,block_cache_entry_stats -num=5000000 -duration=30 -disable_wal=1 -write_buffer_size=30000000 -bloom_bits=10 -compaction_style=2 -fifo_compaction_max_table_files_size_mb=10000 -fifo_compaction_allow_compaction=0 -partition_index_and_filters=1 -statistics=1 -cache_size=${CS}000000 -metadata_block_size=4096 -decouple_partitioned_filters=1 2>&1 | tee results-$CS; done)
```

And read ops/s results:

```CSV
Cache size MB,After/decoupled/4k,Before/4k,Before/8k
3,15593,15158,12826
6,16295,16693,14134
10,20427,20813,18459
20,27035,26836,27384
30,33250,31810,33846
60,35518,32585,35329
100,36612,31805,35292
300,35780,31492,35481
1000,34145,31551,35411
1100,35219,31380,34302
1200,35060,31037,34322
```

If you graph this with log scale on the X axis (internal link: https://pxl.cl/5qKRc), you see that the decoupled/4k configuration is essentially the best of both the before/4k and before/8k configurations: handles really tight memory closer to the old 4k configuration and handles generous memory closer to the old 8k configuration.