### PR TITLE
Add Remote Compaction Installation Callback Function

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -108,6 +108,11 @@ class MyTestCompactionService : public CompactionService {
     }
   }
 
+  void OnInstallation(const std::string& /*scheduled_job_id*/,
+                      CompactionServiceJobStatus status) override {
+    final_updated_status_ = status;
+  }
+
   int GetCompactionNum() { return compaction_num_.load(); }
 
   CompactionServiceJobInfo GetCompactionInfoForStart() { return start_info_; }
@@ -136,6 +141,10 @@ class MyTestCompactionService : public CompactionService {
 
   void SetCanceled(bool canceled) { canceled_ = canceled; }
 
+  CompactionServiceJobStatus GetFinalCompactionServiceJobStatus() {
+    return final_updated_status_;
+  }
+
  private:
   InstrumentedMutex mutex_;
   std::atomic_int compaction_num_{0};
@@ -158,6 +167,8 @@ class MyTestCompactionService : public CompactionService {
   std::vector<std::shared_ptr<TablePropertiesCollectorFactory>>
       table_properties_collector_factories_;
   std::atomic_bool canceled_{false};
+  CompactionServiceJobStatus final_updated_status_ =
+      CompactionServiceJobStatus::kUseLocal;
 };
 
 class CompactionServiceTest : public DBTestBase {
@@ -255,6 +266,8 @@ TEST_F(CompactionServiceTest, BasicCompactions) {
 
   auto my_cs = GetCompactionService();
   ASSERT_GE(my_cs->GetCompactionNum(), 1);
+  ASSERT_EQ(CompactionServiceJobStatus::kSuccess,
+            my_cs->GetFinalCompactionServiceJobStatus());
 
   // make sure the compaction statistics is only recorded on the remote side
   ASSERT_GE(compactor_statistics->getTickerCount(COMPACT_WRITE_BYTES), 1);
@@ -437,6 +450,8 @@ TEST_F(CompactionServiceTest, InvalidResult) {
   Slice end(end_str);
   Status s = db_->CompactRange(CompactRangeOptions(), &start, &end);
   ASSERT_FALSE(s.ok());
+  ASSERT_EQ(CompactionServiceJobStatus::kFailure,
+            my_cs->GetFinalCompactionServiceJobStatus());
 }
 
 TEST_F(CompactionServiceTest, SubCompaction) {

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -142,7 +142,7 @@ class MyTestCompactionService : public CompactionService {
   void SetCanceled(bool canceled) { canceled_ = canceled; }
 
   CompactionServiceJobStatus GetFinalCompactionServiceJobStatus() {
-    return final_updated_status_;
+    return final_updated_status_.load();
   }
 
  private:
@@ -167,8 +167,8 @@ class MyTestCompactionService : public CompactionService {
   std::vector<std::shared_ptr<TablePropertiesCollectorFactory>>
       table_properties_collector_factories_;
   std::atomic_bool canceled_{false};
-  CompactionServiceJobStatus final_updated_status_ =
-      CompactionServiceJobStatus::kUseLocal;
+  std::atomic<CompactionServiceJobStatus> final_updated_status_{
+      CompactionServiceJobStatus::kUseLocal};
 };
 
 class CompactionServiceTest : public DBTestBase {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -512,6 +512,10 @@ class CompactionService : public Customizable {
     return CompactionServiceJobStatus::kUseLocal;
   }
 
+  // Optional callback function upon Installation.
+  virtual void OnInstallation(const std::string& /*scheduled_job_id*/,
+                              CompactionServiceJobStatus /*status*/) {}
+
   // Deprecated. Please implement Schedule() and Wait() API to handle remote
   // compaction
 

--- a/unreleased_history/public_api_changes/callback_fn_remote_compaction.md
+++ b/unreleased_history/public_api_changes/callback_fn_remote_compaction.md
@@ -1,0 +1,2 @@
+Adds optional installation callback function for remote compaction
+


### PR DESCRIPTION
# Summary

Add an optional callback function upon remote compaction temp output installation. This will be internally used for setting the final status in the Offload Infra.

# Test Plan

Unit Test added
```
./compaction_service_test
```

_Also internally tested by manually merging into internal code base_