### PR TITLE
Hide private symbols in shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1167,6 +1167,16 @@ if(ROCKSDB_BUILD_SHARED)
                           VERSION ${rocksdb_VERSION}
                           SOVERSION ${rocksdb_VERSION_MAJOR}
                           OUTPUT_NAME "rocksdb${ARTIFACT_SUFFIX}")
+    
+    if(HIDE_PRIVATE_SYMBOLS AND CMAKE_BUILD_TYPE STREQUAL "Release")  # Do not export private symbols in output shared library
+      message("HIDING symbols")
+      set_target_properties(${ROCKSDB_SHARED_LIB} PROPERTIES                           
+                          CXX_VISIBILITY_PRESET hidden
+                          VISIBILITY_INLINES_HIDDEN ON
+      )
+      target_compile_definitions(${ROCKSDB_SHARED_LIB} PUBLIC HIDE_PRIVATE_SYMBOLS)    
+    endif()
+
   endif()
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,11 @@ endif
 ifeq ($(DEBUG_LEVEL),0)
 OPT += -DNDEBUG
 
+#Only in non debug mode
+ifeq ($(HIDE_PRIVATE_SYMBOLS), 1)
+	CXXFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden -DHIDE_PRIVATE_SYMBOLS
+endif
+
 ifneq ($(USE_RTTI), 1)
 	CXXFLAGS += -fno-rtti
 else

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -55,9 +55,14 @@
 #define ROCKSDB_LIBRARY_API
 #endif
 #else
+
+#ifdef HIDE_PRIVATE_SYMBOLS
+#define ROCKSDB_LIBRARY_API __attribute__((visibility("default")))
+#else
 #define ROCKSDB_LIBRARY_API
 #endif
 
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Add new build flag `HIDE_PRIVATE_SYMBOLS` to allow compile shared library without exported private symbols.

Work only in Release mode.

Fix #12929