### PR TITLE
Fix HISTORY.md file for 9.6 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,20 +1,15 @@
 # Rocksdb Change Log
 > NOTE: Entries for next release do not go here. Follow instructions in `unreleased_history/README.txt`
 
-## 9.7.0 (08/19/2024)
-### New Features
-* Introduce a new mutable CF option `paranoid_memory_checks`. It enables additional validation on data integrity during reads/scanning. Currently, skip list based memtable will validate key ordering during look up and scans.
-
-### Public API Changes
-* Adds optional installation callback function for remote compaction
-
-## 9.6.0 (08/16/2024)
+## 9.6.0 (08/19/2024)
 ### New Features
 * *Best efforts recovery supports recovering to incomplete Version with a clean seqno cut that presents a valid point in time view from the user's perspective, if versioning history doesn't include atomic flush.
 * New option `BlockBasedTableOptions::decouple_partitioned_filters` should improve efficiency in serving read queries because filter and index partitions can consistently target the configured `metadata_block_size`. This option is currently opt-in.
+* Introduce a new mutable CF option `paranoid_memory_checks`. It enables additional validation on data integrity during reads/scanning. Currently, skip list based memtable will validate key ordering during look up and scans.
 
 ### Public API Changes
 * Add ticker stats to count file read retries due to checksum mismatch
+* Adds optional installation callback function for remote compaction
 
 ### Behavior Changes
 * There may be less intra-L0 compaction triggered by total L0 size being too small. We now use compensated file size (tombstones are assigned some value size) when calculating L0 size and reduce the threshold for L0 size limit. This is to avoid accumulating too much data/tombstones in L0.


### PR DESCRIPTION
# Summary 

Mistakenly double-updated the HISTORY.md file by running `unreleased_history/release.sh` after the first commit in  #12945. Manually fixing the file to reflect the correct content

# Test Plan

N/A. History file change.