### PR TITLE
Record largest seqno in table properties and verify in file ingestion

### DIFF
--- a/db/event_helpers.cc
+++ b/db/event_helpers.cc
@@ -124,6 +124,7 @@ void EventHelpers::LogAndNotifyTableFileCreationFinished(
               << "comparator" << table_properties.comparator_name
               << "user_defined_timestamps_persisted"
               << table_properties.user_defined_timestamps_persisted
+              << "key_largest_seqno" << table_properties.key_largest_seqno
               << "merge_operator" << table_properties.merge_operator_name
               << "prefix_extractor_name"
               << table_properties.prefix_extractor_name << "property_collectors"

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -3776,6 +3776,7 @@ TEST_P(IngestDBGeneratedFileTest, FailureCase) {
                                  live_meta[0].relative_filename);
     // Ingesting a file whose boundary key has non-zero seqno.
     Status s = db_->IngestExternalFile(to_ingest_files, ingest_opts);
+    // This error msg is from checking seqno of boundary keys.
     ASSERT_TRUE(
         s.ToString().find("External file has non zero sequence number") !=
         std::string::npos);
@@ -3822,10 +3823,9 @@ TEST_P(IngestDBGeneratedFileTest, FailureCase) {
           live_meta[0].directory + "/" + live_meta[0].relative_filename;
       s = db_->IngestExternalFile(to_ingest_files, ingest_opts);
       ASSERT_NOK(s);
-      ASSERT_TRUE(
-          s.ToString().find(
-              "External file has a key with non zero sequence number") !=
-          std::string::npos);
+      // This error msg is from checking largest seqno in table property.
+      ASSERT_TRUE(s.ToString().find("non zero largest sequence number") !=
+                  std::string::npos);
       db_->ReleaseSnapshot(snapshot);
     }
 

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -296,8 +296,8 @@ struct TableProperties {
 
   // The largest sequence number of keys in this file.
   // UINT64_MAX means unknown.
-  // Only written to properties block if known (should be unknown unless
-  // the table is empty).
+  // Only written to properties block if known (should be known unless the
+  // table is empty).
   uint64_t key_largest_seqno = UINT64_MAX;
 
   // DB identity

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -296,6 +296,8 @@ struct TableProperties {
 
   // The largest sequence number of keys in this file.
   // UINT64_MAX means unknown.
+  // Only written to properties block if known (should be unknown unless
+  // the table is empty).
   uint64_t key_largest_seqno = UINT64_MAX;
 
   // DB identity

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -74,6 +74,7 @@ struct TablePropertiesNames {
   static const std::string kSequenceNumberTimeMapping;
   static const std::string kTailStartOffset;
   static const std::string kUserDefinedTimestampsPersisted;
+  static const std::string kKeyLargestSeqno;
 };
 
 // `TablePropertiesCollector` provides the mechanism for users to collect
@@ -134,6 +135,7 @@ class TablePropertiesCollector {
 
   // Return the human-readable properties, where the key is property name and
   // the value is the human-readable form of value.
+  // Returned properties are used for logging.
   // It will only be called after Finish() has been called by RocksDB internal.
   virtual UserCollectedProperties GetReadableProperties() const = 0;
 
@@ -291,6 +293,10 @@ struct TableProperties {
   // when the file is created. Default to be true, only when this flag is false,
   // it's explicitly written to meta properties block.
   uint64_t user_defined_timestamps_persisted = 1;
+
+  // The largest sequence number of keys in this file.
+  // UINT64_MAX means unknown.
+  uint64_t key_largest_seqno = UINT64_MAX;
 
   // DB identity
   // db_id is an identifier generated the first time the DB is created

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -627,6 +627,9 @@ struct BlockBasedTableBuilder::Rep {
     if (!ReifyDbHostIdProperty(ioptions.env, &props.db_host_id).ok()) {
       ROCKS_LOG_INFO(ioptions.logger, "db_host_id property will not be set");
     }
+    // Default is UINT64_MAX for unknown. Setting it to 0 here
+    // to allow updating it by taking max in BlockBasedTableBuilder::Add().
+    props.key_largest_seqno = 0;
 
     if (FormatVersionUsesContextChecksum(table_options.format_version)) {
       // Must be non-zero and semi- or quasi-random
@@ -1014,7 +1017,10 @@ void BlockBasedTableBuilder::Add(const Slice& ikey, const Slice& value) {
   if (!ok()) {
     return;
   }
-  ValueType value_type = ExtractValueType(ikey);
+  ValueType value_type;
+  SequenceNumber seq;
+  UnPackSequenceAndType(ExtractInternalKeyFooter(ikey), &seq, &value_type);
+  r->props.key_largest_seqno = std::max(r->props.key_largest_seqno, seq);
   if (IsValueType(value_type)) {
 #ifndef NDEBUG
     if (r->props.num_entries > r->props.num_range_deletions) {

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1787,6 +1787,7 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
     rep_->props.user_defined_timestamps_persisted =
         rep_->persist_user_defined_timestamps;
 
+    assert(IsEmpty() || rep_->props.key_largest_seqno != UINT64_MAX);
     // Add basic properties
     property_block_builder.AddTableProperty(rep_->props);
 

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -82,7 +82,7 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
                            const_cast<TableProperties*>(&props));
 
   Add(TablePropertiesNames::kOriginalFileNumber, props.orig_file_number);
-  Add(TablePropertiesNames::kRawKeySize, props.raw_key_size);  // follow this
+  Add(TablePropertiesNames::kRawKeySize, props.raw_key_size);
   Add(TablePropertiesNames::kRawValueSize, props.raw_value_size);
   Add(TablePropertiesNames::kDataSize, props.data_size);
   Add(TablePropertiesNames::kIndexSize, props.index_size);
@@ -93,7 +93,7 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
   Add(TablePropertiesNames::kIndexKeyIsUserKey, props.index_key_is_user_key);
   Add(TablePropertiesNames::kIndexValueIsDeltaEncoded,
       props.index_value_is_delta_encoded);
-  Add(TablePropertiesNames::kNumEntries, props.num_entries);  // follow this
+  Add(TablePropertiesNames::kNumEntries, props.num_entries);
   Add(TablePropertiesNames::kNumFilterEntries, props.num_filter_entries);
   Add(TablePropertiesNames::kDeletedKeys, props.num_deletions);
   Add(TablePropertiesNames::kMergeOperands, props.num_merge_operands);

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -82,7 +82,7 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
                            const_cast<TableProperties*>(&props));
 
   Add(TablePropertiesNames::kOriginalFileNumber, props.orig_file_number);
-  Add(TablePropertiesNames::kRawKeySize, props.raw_key_size);
+  Add(TablePropertiesNames::kRawKeySize, props.raw_key_size);  // follow this
   Add(TablePropertiesNames::kRawValueSize, props.raw_value_size);
   Add(TablePropertiesNames::kDataSize, props.data_size);
   Add(TablePropertiesNames::kIndexSize, props.index_size);
@@ -93,7 +93,7 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
   Add(TablePropertiesNames::kIndexKeyIsUserKey, props.index_key_is_user_key);
   Add(TablePropertiesNames::kIndexValueIsDeltaEncoded,
       props.index_value_is_delta_encoded);
-  Add(TablePropertiesNames::kNumEntries, props.num_entries);
+  Add(TablePropertiesNames::kNumEntries, props.num_entries);  // follow this
   Add(TablePropertiesNames::kNumFilterEntries, props.num_filter_entries);
   Add(TablePropertiesNames::kDeletedKeys, props.num_deletions);
   Add(TablePropertiesNames::kMergeOperands, props.num_merge_operands);
@@ -163,6 +163,8 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
     Add(TablePropertiesNames::kSequenceNumberTimeMapping,
         props.seqno_to_time_mapping);
   }
+  assert(props.key_largest_seqno != UINT64_MAX);
+  Add(TablePropertiesNames::kKeyLargestSeqno, props.key_largest_seqno);
 }
 
 Slice PropertyBlockBuilder::Finish() {
@@ -336,6 +338,8 @@ Status ReadTablePropertiesHelper(
        &new_table_properties->tail_start_offset},
       {TablePropertiesNames::kUserDefinedTimestampsPersisted,
        &new_table_properties->user_defined_timestamps_persisted},
+      {TablePropertiesNames::kKeyLargestSeqno,
+       &new_table_properties->key_largest_seqno},
   };
 
   std::string last_key;

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -163,8 +163,9 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
     Add(TablePropertiesNames::kSequenceNumberTimeMapping,
         props.seqno_to_time_mapping);
   }
-  assert(props.key_largest_seqno != UINT64_MAX);
-  Add(TablePropertiesNames::kKeyLargestSeqno, props.key_largest_seqno);
+  if (props.key_largest_seqno != UINT64_MAX) {
+    Add(TablePropertiesNames::kKeyLargestSeqno, props.key_largest_seqno);
+  }
 }
 
 Slice PropertyBlockBuilder::Finish() {

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -113,6 +113,8 @@ std::string TableProperties::ToString(const std::string& prop_delim,
                  user_defined_timestamps_persisted ? std::string("true")
                                                    : std::string("false"),
                  prop_delim, kv_delim);
+  AppendProperty(result, "largest sequence number in file", key_largest_seqno,
+                 prop_delim, kv_delim);
 
   AppendProperty(
       result, "merge operator name",
@@ -311,6 +313,8 @@ const std::string TablePropertiesNames::kTailStartOffset =
     "rocksdb.tail.start.offset";
 const std::string TablePropertiesNames::kUserDefinedTimestampsPersisted =
     "rocksdb.user.defined.timestamps.persisted";
+const std::string TablePropertiesNames::kKeyLargestSeqno =
+    "rocksdb.key.largest.seqno";
 
 #ifndef NDEBUG
 // WARNING: TEST_SetRandomTableProperties assumes the following layout of

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4726,7 +4726,7 @@ static void DoCompressionTest(CompressionType comp) {
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k02"), 0, 0));
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k03"), 2000, 3550));
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k04"), 2000, 3550));
-  ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"), 4000, 7075));
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"), 4000, 7100));
   c.ResetTableReader();
 }
 

--- a/unreleased_history/new_features/tp_largest_seqno.md
+++ b/unreleased_history/new_features/tp_largest_seqno.md
@@ -1,0 +1,1 @@
+* Add a new table property "rocksdb.key.largest.seqno" which records the largest sequence number of all keys in file. It is verified to be zero during SST file ingestion.


### PR DESCRIPTION
Summary: this helps to avoid scanning input files when ingesting db generated files: https://github.com/facebook/rocksdb/blob/ecb844babda9e669ff00a5d1ee51eda7430c9bc0/db/external_sst_file_ingestion_job.cc#L917-L935

Test plan:
* `IngestDBGeneratedFileTest.FailureCase` is updated to verify that this table property is verified during ingestion
* existing unit tests for other ingestion use cases.