### PR TITLE
Fix non-ASCII character

### DIFF
--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -506,10 +506,10 @@ IOStatus TestFSRandomAccessFile::ReadAsync(
     s = target_->ReadAsync(req, opts, cb, cb_arg, io_handle, del_fn, nullptr);
     // TODO (low priority): fs_->ReadUnsyncedData()
   } else {
-    // If there’s no injected error, then cb will be called asynchronously when
-    // target_ actually finishes the read. But if there’s an injected error, it
+    // If there's no injected error, then cb will be called asynchronously when
+    // target_ actually finishes the read. But if there's an injected error, it
     // needs to immediately call cb(res, cb_arg) s since target_->ReadAsync()
-    // isn’t invoked at all.
+    // isn't invoked at all.
     res.status = res_status;
     cb(res, cb_arg);
   }


### PR DESCRIPTION
Met the following error while compiling the project.

```
build_tools/check-sources.sh
utilities/fault_injection_fs.cc:509:    // If there<E2><80><99>s no injected error, then cb will be called asynchronously when
utilities/fault_injection_fs.cc:510:    // target_ actually finishes the read. But if there<E2><80><99>s an injected error, it
utilities/fault_injection_fs.cc:512:    // isn<E2><80><99>t invoked at all.
^^^^ Use only ASCII characters in source files
make[1]: *** [Makefile:1291: check-sources] Error 1
make[1]: Leaving directory '/home/janus/Github/symious/rocksdb'
make: *** [Makefile:1084: check] Error 2
```