### PR TITLE
Scope down workflow permissions

### DIFF
--- a/.github/workflows/benchmark-linux.yml
+++ b/.github/workflows/benchmark-linux.yml
@@ -1,14 +1,13 @@
 name: facebook/rocksdb/benchmark-linux
+on: workflow_dispatch
 permissions: {}
-on:
-  schedule:
   # FIXME: Disabled temporarily
+  # schedule:
   # - cron: 7 */2 * * *  # At minute 7 past every 2nd hour
-
 jobs:
   benchmark-linux:
     if: ${{ github.repository_owner == 'facebook' }}
-    runs-on: self-hosted
+    runs-on: ubuntu-latest # FIXME: change this back to self-hosted when ready
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: "./.github/actions/build-for-benchmarks"

--- a/.github/workflows/benchmark-linux.yml
+++ b/.github/workflows/benchmark-linux.yml
@@ -1,8 +1,9 @@
 name: facebook/rocksdb/benchmark-linux
-# FIXME: Disabled temporarily
-# on:
-#   schedule:
-#   - cron: 7 */2 * * *  # At minute 7 past every 2nd hour
+permissions: {}
+on:
+  schedule:
+  # FIXME: Disabled temporarily
+  # - cron: 7 */2 * * *  # At minute 7 past every 2nd hour
 
 jobs:
   benchmark-linux:

--- a/.github/workflows/nightly-candidate.yml
+++ b/.github/workflows/nightly-candidate.yml
@@ -1,5 +1,6 @@
 name: facebook/rocksdb/nightly
 on: workflow_dispatch
+permissions: {}
 jobs:
   # These jobs would be in nightly but are failing or otherwise broken for
   # some reason.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ on:
   schedule:
   - cron: 0 9 * * *
   workflow_dispatch:
+permissions: {}
 jobs:
   build-format-compatible:
     if: ${{ github.repository_owner == 'facebook' }}

--- a/.github/workflows/pr-jobs-candidate.yml
+++ b/.github/workflows/pr-jobs-candidate.yml
@@ -1,5 +1,6 @@
 name: facebook/rocksdb/pr-jobs-candidate
 on: workflow_dispatch
+permissions: {}
 jobs:
   # These jobs would be in pr-jobs but are failing or otherwise broken for
   # some reason.

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -1,5 +1,6 @@
 name: facebook/rocksdb/pr-jobs
 on: [push, pull_request]
+permissions: {}
 jobs:
   # NOTE: multiple workflows would be recommended, but the current GHA UI in
   # PRs doesn't make it clear when there's an overall error with a workflow,


### PR DESCRIPTION
# Summary

Followed instruction per https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes

It turns out that we did not need any of these except `Metadata: read`.

Before
```
GITHUB_TOKEN Permissions
  Actions: write
  Attestations: write
  Checks: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Packages: write
  Pages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write
```

After
```
GITHUB_TOKEN Permissions
  Metadata: read
```

# Test Plan

GitHub Actions triggered by this PR