### PR TITLE
Fix flaky test DBTest2.VariousFileTemperatures

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -6739,6 +6739,7 @@ TEST_F(DBTest2, VariousFileTemperatures) {
                 TCM({{options.default_write_temperature, 2}}));
 
       ASSERT_OK(db_->CompactRange({}, nullptr, nullptr));
+      ASSERT_OK(dbfull()->TEST_WaitForBackgroundWork());
 
       ASSERT_EQ(test_fs->CountCurrentSstFilesByTemp(),
                 TCM({{options.last_level_temperature, 1}}));


### PR DESCRIPTION
Summary: ... apparently due to potentially not purging obsolete files after CompactRange

Test Plan: reproduced failure with USE_CLANG=1 COERCE_CONTEXT_SWITCH=1, now fixed