### PR TITLE
fd leak with io_uring

### DIFF
--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -265,6 +265,7 @@ const unsigned int kIoUringDepth = 256;
 
 inline void DeleteIOUring(void* p) {
   struct io_uring* iu = static_cast<struct io_uring*>(p);
+  io_uring_queue_exit(iu);
   delete iu;
 }
 


### PR DESCRIPTION
On thread exit the memory was release, but not calling the exit function for a io_uring context leaks file descriptors. Compare the implementation of `CreateIOUring` and `DeleteIOUring` with the manual [here](https://man.archlinux.org/man/io_uring_queue_exit.3.en):

> On success, the resources held by ring should be released via a corresponding call to [io_uring_queue_exit(3)](https://man.archlinux.org/man/io_uring_queue_exit.3.en).