### PR TITLE
Make flush create its own reference of MemTableListVersion

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2202,6 +2202,9 @@ class DBImpl : public DB {
     std::unordered_map<ColumnFamilyData*, uint64_t>
         cfd_to_max_mem_id_to_persist;
 
+    // TODO(yuzhangyu): Add a field to track the base atomic replacement
+    // counter when flush is initially requested.
+
 #ifndef NDEBUG
     int reschedule_count = 1;
 #endif /* !NDEBUG */


### PR DESCRIPTION
This extra ref is redundant now but we need it for when data replacement can happen. This PR also changes the contract for cancelling a FlushJob and adds some TODOs for the flush code path for implementing atomic replacement.

FlushJob's cancellation is for properly releasing the resources it is holding. In this PR one more resource namely the `MemTableListVersion` is added into FlushJob, so I want to make sure it's properly handled. Currently, the caller of FlushJob's public APIs use a side by side boolean to track the need for cancellation on their side. That is a contract that cannot be enforced. For example, flush_job_test.cc is not doing that at all.  Besides, this is also a complicated contract. There is setting that boolean to true / false in some conditions, checking it in combination with returned Status etc. That makes the contract error prone. There is also no enforcement that resources are guaranteed to be cleaned up.

In this PR, we added a required output variable `need_cleanup` to FlushJob's public APIs. The contract is: the user always need to call `FlushJob::Cleanup` as long as that boolean is set to true. Although this is yet one more output argument, `FlushJob::Run` already have a few other boolean output arguments of the same pattern so it's not too much extra cognitive burden.  FlushJob maintains its own internal state about resource management, and a few extra guards are added in debug mode.

Test plan:
Existing tests