### PR TITLE
port: only override `__PCLMUL__` on MSVC

### DIFF
--- a/port/lang.h
+++ b/port/lang.h
@@ -76,7 +76,7 @@ constexpr bool kMustFreeHeapAllocations = false;
 
 // MSVC doesn't support the same defines that gcc and clang provide
 // but does some like __AVX__. Here we can infer some features from others.
-#ifdef __AVX__
+#ifdef __AVX__ && (_MSC_VER)
 #define __SSE4_2__ 1
 #define __PCLMUL__ 1
 #endif  // __AVX__


### PR DESCRIPTION
Hello!

We ran into issues when compiling RocksDB to `x86-64-v3` and other targets which have `avx` but not `pclmul`. I believe the code is doing something different from what the comment is saying. This overrides `__PCLMUL__` for all compilers, not just MSVC, which caused us to bring in intrinsics that weren't supported by the target.

Is there a better way of solving this?