### PR TITLE
Add an option to dump wal seqno gaps

### DIFF
--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -379,6 +379,7 @@ class WALDumperCommand : public LDBCommand {
   bool print_header_;
   std::string wal_file_;
   bool print_values_;
+  bool only_print_seqno_gaps_;
   bool is_write_committed_;  // default will be set to true
   bool no_db_open_ = true;
 
@@ -386,6 +387,7 @@ class WALDumperCommand : public LDBCommand {
   static const std::string ARG_WRITE_COMMITTED;
   static const std::string ARG_PRINT_HEADER;
   static const std::string ARG_PRINT_VALUE;
+  static const std::string ARG_ONLY_PRINT_SEQNO_GAPS;
 };
 
 class GetCommand : public LDBCommand {

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -562,7 +562,7 @@ class LDBTestCase(unittest.TestCase):
             0
             == run_err_null(
                 "./ldb dump_wal --db=%s --walfile=%s --header"
-                % (origDbPath, os.path.join(origDbPath, "LOG"))
+                % (origDbPath, origDbPath)
             )
         )
         self.assertRunOK("scan", "x1 ==> y1\nx2 ==> y2\nx3 ==> y3\nx4 ==> y4")


### PR DESCRIPTION
Add an option `--only_print_seqno_gaps` for wal dump to help with debugging. This option will check the continuity of sequence numbers in WAL logs, assuming `seq_per_batch` is false. `--walfile` option now also takes a directory, and it will check all WAL logs in the directory in chronological order. 

When a gap is found, we can further check if it's related to operations like external file ingestion.

Test plan:
Manually tested
