### PR TITLE
Make Cache a customizable class

### DIFF
--- a/cache/cache.cc
+++ b/cache/cache.cc
@@ -133,19 +133,23 @@ Status Cache::CreateFromString(const ConfigOptions& config_options,
                                std::shared_ptr<Cache>* result) {
   Status status;
   std::shared_ptr<Cache> cache;
-  if (value.find('=') == std::string::npos) {
-    cache = NewLRUCache(ParseSizeT(value));
-  } else {
-    LRUCacheOptions cache_opts;
-    status = OptionTypeInfo::ParseStruct(config_options, "",
-                                         &lru_cache_options_type_info, "",
-                                         value, &cache_opts);
-    if (status.ok()) {
-      cache = NewLRUCache(cache_opts);
+  if (value.find("://") == std::string::npos) {
+    if (value.find('=') == std::string::npos) {
+      cache = NewLRUCache(ParseSizeT(value));
+    } else {
+      LRUCacheOptions cache_opts;
+      status = OptionTypeInfo::ParseStruct(config_options, "",
+                                           &lru_cache_options_type_info, "",
+                                           value, &cache_opts);
+      if (status.ok()) {
+        cache = NewLRUCache(cache_opts);
+      }
     }
-  }
-  if (status.ok()) {
-    result->swap(cache);
+    if (status.ok()) {
+      result->swap(cache);
+    }
+  } else {
+    return LoadSharedObject<Cache>(config_options, value, result);
   }
   return status;
 }

--- a/cache/cache.cc
+++ b/cache/cache.cc
@@ -149,7 +149,7 @@ Status Cache::CreateFromString(const ConfigOptions& config_options,
       result->swap(cache);
     }
   } else {
-    return LoadSharedObject<Cache>(config_options, value, result);
+    status = LoadSharedObject<Cache>(config_options, value, result);
   }
   return status;
 }

--- a/include/rocksdb/advanced_cache.h
+++ b/include/rocksdb/advanced_cache.h
@@ -41,7 +41,7 @@ class Statistics;
 //
 // INTERNAL: See typed_cache.h for convenient wrappers on top of this API.
 // New virtual functions must also be added to CacheWrapper below.
-class Cache {
+class Cache : public Customizable {
  public:  // types hidden from API client
   // Opaque handle to an entry stored in the cache.
   struct Handle {};
@@ -189,6 +189,8 @@ class Cache {
 
   // Destroys all remaining entries by calling the associated "deleter"
   virtual ~Cache() {}
+
+  static const char* Type() { return "Cache"; }
 
   // Creates a new Cache based on the input value string and returns the result.
   // Currently, this method can be used to create LRUCaches only

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1753,6 +1753,7 @@ DEFINE_bool(read_with_latest_user_timestamp, true,
             "If true, always use the current latest timestamp for read. If "
             "false, choose a random timestamp from the past.");
 
+DEFINE_string(cache_uri, "", "Full URI for creating a custom cache object");
 DEFINE_string(secondary_cache_uri, "",
               "Full URI for creating a custom secondary cache object");
 static class std::shared_ptr<ROCKSDB_NAMESPACE::SecondaryCache> secondary_cache;
@@ -3138,7 +3139,15 @@ class Benchmark {
     }
 
     std::shared_ptr<Cache> block_cache;
-    if (FLAGS_cache_type == "clock_cache") {
+    if (!FLAGS_cache_uri.empty()) {
+      Status s = Cache::CreateFromString(ConfigOptions(), FLAGS_cache_uri,
+                                         &block_cache);
+      if (block_cache == nullptr) {
+        fprintf(stderr, "No  cache registered matching string: %s status=%s\n",
+                FLAGS_cache_uri.c_str(), s.ToString().c_str());
+        exit(1);
+      }
+    } else if (FLAGS_cache_type == "clock_cache") {
       fprintf(stderr, "Old clock cache implementation has been removed.\n");
       exit(1);
     } else if (EndsWith(FLAGS_cache_type, "hyper_clock_cache")) {

--- a/unreleased_history/new_features/customizable_cache.md
+++ b/unreleased_history/new_features/customizable_cache.md
@@ -1,0 +1,1 @@
+Make Cache a customizable class that can be instantiated by the object registry.


### PR DESCRIPTION
This PR allows a Cache object to be created using the object registry.