### PR TITLE
More accurate accounting of compressed cache memory

### DIFF
--- a/cache/compressed_secondary_cache.cc
+++ b/cache/compressed_secondary_cache.cc
@@ -81,6 +81,7 @@ std::unique_ptr<SecondaryCacheResultHandle> CompressedSecondaryCache::Lookup(
                               static_cast<uint32_t*>(&source_32));
     source = static_cast<CacheTier>(source_32);
     data_size = DecodeFixed64(data_ptr);
+    assert(handle_value_charge > data_size);
     data_ptr += sizeof(uint64_t);
     handle_value_charge = data_size;
   }

--- a/cache/compressed_secondary_cache.cc
+++ b/cache/compressed_secondary_cache.cc
@@ -79,7 +79,7 @@ std::unique_ptr<SecondaryCacheResultHandle> CompressedSecondaryCache::Lookup(
     data_ptr = GetVarint32Ptr(data_ptr, data_ptr + 1,
                               static_cast<uint32_t*>(&source_32));
     source = static_cast<CacheTier>(source_32);
-    uint64_t data_size;
+    uint64_t data_size = 0;
     data_ptr = GetVarint64Ptr(data_ptr, ptr->get() + handle_value_charge,
                               static_cast<uint64_t*>(&data_size));
     assert(handle_value_charge > data_size);

--- a/cache/compressed_secondary_cache.h
+++ b/cache/compressed_secondary_cache.h
@@ -139,6 +139,8 @@ class CompressedSecondaryCache : public SecondaryCache {
                         const Cache::CacheItemHelper* helper,
                         CompressionType type, CacheTier source);
 
+  size_t TEST_GetCharge(const Slice& key);
+
   // TODO: clean up to use cleaner interfaces in typed_cache.h
   const Cache::CacheItemHelper* GetHelper(bool enable_custom_split_merge) const;
   std::shared_ptr<Cache> cache_;

--- a/cache/compressed_secondary_cache_test.cc
+++ b/cache/compressed_secondary_cache_test.cc
@@ -39,6 +39,8 @@ class CompressedSecondaryCacheTestBase : public testing::Test,
  protected:
   void BasicTestHelper(std::shared_ptr<SecondaryCache> sec_cache,
                        bool sec_cache_is_compressed) {
+    CompressedSecondaryCache* comp_sec_cache =
+        static_cast<CompressedSecondaryCache*>(sec_cache.get());
     get_perf_context()->Reset();
     bool kept_in_sec_cache{true};
     // Lookup an non-existent key.
@@ -65,6 +67,8 @@ class CompressedSecondaryCacheTestBase : public testing::Test,
     // Insert and Lookup the item k1 for the second time and advise erasing it.
     ASSERT_OK(sec_cache->Insert(key1, &item1, GetHelper(), false));
     ASSERT_EQ(get_perf_context()->compressed_sec_cache_insert_real_count, 1);
+
+    ASSERT_GT(comp_sec_cache->TEST_GetCharge(key1), 1000);
 
     std::unique_ptr<SecondaryCacheResultHandle> handle1_2 =
         sec_cache->Lookup(key1, GetHelper(), this, true, /*advise_erase=*/true,

--- a/unreleased_history/bug_fixes/compressed_secondary_cache_account.md
+++ b/unreleased_history/bug_fixes/compressed_secondary_cache_account.md
@@ -1,1 +1,1 @@
-Fix under counting of allocated memory in the compressed secondary cache due to looking at actual block size rather than usable memory.
+Fix under counting of allocated memory in the compressed secondary cache due to looking at the compressed block size rather than the actual memory allocated, which could be larger due to internal fragmentation.

--- a/unreleased_history/bug_fixes/compressed_secondary_cache_account.md
+++ b/unreleased_history/bug_fixes/compressed_secondary_cache_account.md
@@ -1,0 +1,1 @@
+Fix under counting of allocated memory in the compressed secondary cache due to looking at actual block size rather than usable memory.


### PR DESCRIPTION
When an item is inserted into the compressed secondary cache, this PR calculates the charge using the malloc_usable_size of the allocated memory, as well as the unique pointer allocation.

Test plan:
New unit test