### PR TITLE
Skip some unnecessary block iterations in point look up when SST files have no timestamps

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2321,6 +2321,12 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
 
     size_t ts_sz =
         rep_->internal_comparator.user_comparator()->timestamp_size();
+    Slice point_lookup_optimize_key = key;
+    std::string key_buffer;
+    if (ts_sz > 0 && !rep_->user_defined_timestamps_persisted) {
+      ReplaceInternalKeyWithMinTimestamp(&key_buffer, key, ts_sz);
+      point_lookup_optimize_key = key_buffer;
+    }
     bool matched = false;  // if such user key matched a key in SST
     bool done = false;
     for (iiter->Seek(key); iiter->Valid() && !done; iiter->Next()) {
@@ -2363,15 +2369,18 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
         s = biter.status();
         break;
       }
-
-      bool may_exist = biter.SeekForGet(key);
-      // If user-specified timestamp is supported, we cannot end the search
-      // just because hash index lookup indicates the key+ts does not exist.
-      if (!may_exist && ts_sz == 0) {
+      bool may_exist = biter.SeekForGet(point_lookup_optimize_key);
+      if (!may_exist &&
+          (ts_sz == 0 || !rep_->user_defined_timestamps_persisted)) {
         // HashSeek cannot find the key this block and the the iter is not
         // the end of the block, i.e. cannot be in the following blocks
         // either. In this case, the seek_key cannot be found, so we break
         // from the top level for-loop.
+        // When SST files don't have timestamps, we use min timestamp in the
+        // point_lookup_optimize_key. In that case when may_exist returns false.
+        // It means we don't have exact match of point_lookup_optimize_key and
+        // block's largest user key is already bigger. Which is also sufficient
+        // for us to end the search.
         done = true;
       } else {
         // Call the *saver function on each entry/block until it returns false


### PR DESCRIPTION
The end search early capability provided by `DataBlockIter::SeekForGet(target)` could be used for user defined timestamps in Memtable only feature. It returns false if there is no exact user key match found for the target in the data block and the biggest user key in the data block is already bigger than target's user key.  

When user-defined timestamps is enabled and SST files have timestamps, we cannot end search early just because of this. For example, if we are looking for `foo + ts: 2345`, `SeekForGet` will return false if the block has `foo + ts:2322`, which is a useful entry we want to iterate. But for user defined timestamps in MemTable only feature, the only timestamps that can exist in SST files are min timestamp. If `DataBlockIter::SeekForGet("foo" + ts:0)` returns false, we can end the search early too.

Test plan:
Existing tests