### PR TITLE
Add comment for memory usage in BeginTransaction() and WriteBatch::Clear()

### DIFF
--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -460,7 +460,10 @@ class TransactionDB : public StackableDB {
   //
   // If old_txn is not null, BeginTransaction will reuse this Transaction
   // handle instead of allocating a new one.  This is an optimization to avoid
-  // extra allocations when repeatedly creating transactions.
+  // extra allocations when repeatedly creating transactions. **Note that this
+  // may not free all the allocated memory by the previous transaction (see
+  // WriteBatch::Clear()). To ensure that all allocated memory is freed, users
+  // must destruct the transaction object.
   virtual Transaction* BeginTransaction(
       const WriteOptions& write_options,
       const TransactionOptions& txn_options = TransactionOptions(),

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -209,6 +209,8 @@ class WriteBatch : public WriteBatchBase {
 
   using WriteBatchBase::Clear;
   // Clear all updates buffered in this batch.
+  // Internally, it calls resize() on the string buffer. So allocated memory
+  // capacity may not be freed.
   void Clear() override;
 
   // Records the state of the batch for future calls to RollbackToSavePoint().


### PR DESCRIPTION
Summary: ... to note that memory may not be freed when reusing a transaction. This means reusing a large transaction can cause excessive memory usage and it may be better to destruct the transaction object in some cases.

Test plan: no code change.