### PR TITLE
Handle a possible overflow

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1968,9 +1968,16 @@ uint64_t VersionStorageInfo::GetEstimatedActiveKeys() const {
   }
 
   if (current_num_samples_ < file_count) {
-    // casting to avoid overflowing
-    return static_cast<uint64_t>(
-        (est * static_cast<double>(file_count) / current_num_samples_));
+    assert(current_num_samples_ != 0);
+    assert(est != 0);
+    double multiplier = static_cast<double>(file_count) / current_num_samples_;
+    double maximum_multiplier =
+        static_cast<double>(std::numeric_limits<uint64_t>::max()) / est;
+    // If it can overflow, we return the maximum unsigned long.
+    if (multiplier >= maximum_multiplier) {
+      return std::numeric_limits<uint64_t>::max();
+    }
+    return static_cast<uint64_t>(est * multiplier);
   } else {
     return est;
   }


### PR DESCRIPTION
Stress test detects this variable could potentially overflow, so added some runtime handling to avoid it.

Test plan:
Existing tests