### PR TITLE
Templatize MultiCfIteratorImpl to avoid std::function's overhead

### DIFF
--- a/db/coalescing_iterator.h
+++ b/db/coalescing_iterator.h
@@ -15,11 +15,8 @@ class CoalescingIterator : public Iterator {
   CoalescingIterator(const Comparator* comparator,
                      const std::vector<ColumnFamilyHandle*>& column_families,
                      const std::vector<Iterator*>& child_iterators)
-      : impl_(
-            comparator, column_families, child_iterators, [this]() { Reset(); },
-            [this](const autovector<MultiCfIteratorInfo>& items) {
-              Coalesce(items);
-            }) {}
+      : impl_(comparator, column_families, child_iterators, ResetFunc(this),
+              PopulateFunc(this)) {}
   ~CoalescingIterator() override {}
 
   // No copy allowed
@@ -51,7 +48,33 @@ class CoalescingIterator : public Iterator {
   }
 
  private:
-  MultiCfIteratorImpl impl_;
+  class ResetFunc {
+   public:
+    explicit ResetFunc(CoalescingIterator* iter) : iter_(iter) {}
+
+    void operator()() const {
+      assert(iter_);
+      iter_->Reset();
+    }
+
+   private:
+    CoalescingIterator* iter_;
+  };
+
+  class PopulateFunc {
+   public:
+    explicit PopulateFunc(CoalescingIterator* iter) : iter_(iter) {}
+
+    void operator()(const autovector<MultiCfIteratorInfo>& items) const {
+      assert(iter_);
+      iter_->Coalesce(items);
+    }
+
+   private:
+    CoalescingIterator* iter_;
+  };
+
+  MultiCfIteratorImpl<ResetFunc, PopulateFunc> impl_;
   Slice value_;
   WideColumns wide_columns_;
 

--- a/db/multi_cf_iterator_impl.h
+++ b/db/multi_cf_iterator_impl.h
@@ -21,14 +21,13 @@ struct MultiCfIteratorInfo {
   int order;
 };
 
+template <typename ResetFunc, typename PopulateFunc>
 class MultiCfIteratorImpl {
  public:
-  MultiCfIteratorImpl(
-      const Comparator* comparator,
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      const std::vector<Iterator*>& child_iterators,
-      std::function<void()> reset_func,
-      std::function<void(const autovector<MultiCfIteratorInfo>&)> populate_func)
+  MultiCfIteratorImpl(const Comparator* comparator,
+                      const std::vector<ColumnFamilyHandle*>& column_families,
+                      const std::vector<Iterator*>& child_iterators,
+                      ResetFunc reset_func, PopulateFunc populate_func)
       : comparator_(comparator),
         heap_(MultiCfMinHeap(
             MultiCfHeapItemComparator<std::greater<int>>(comparator_))),
@@ -136,8 +135,8 @@ class MultiCfIteratorImpl {
 
   MultiCfIterHeap heap_;
 
-  std::function<void()> reset_func_;
-  std::function<void(autovector<MultiCfIteratorInfo>)> populate_func_;
+  ResetFunc reset_func_;
+  PopulateFunc populate_func_;
 
   Iterator* current() const {
     if (std::holds_alternative<MultiCfMaxHeap>(heap_)) {
@@ -163,11 +162,11 @@ class MultiCfIteratorImpl {
   }
 
   void InitMinHeap() {
-    heap_.emplace<MultiCfMinHeap>(
+    heap_.template emplace<MultiCfMinHeap>(
         MultiCfHeapItemComparator<std::greater<int>>(comparator_));
   }
   void InitMaxHeap() {
-    heap_.emplace<MultiCfMaxHeap>(
+    heap_.template emplace<MultiCfMaxHeap>(
         MultiCfHeapItemComparator<std::less<int>>(comparator_));
   }
 


### PR DESCRIPTION
Summary: Currently, `MultiCfIteratorImpl` uses `std::function`s for `reset_func_` and `populate_func_`, which uses type erasure and has a performance overhead. The patch turns `MultiCfIteratorImpl` into a template that takes the two function object types as template parameters, and changes `AttributeGroupIteratorImpl` and `CoalescingIterator` so they pass in function objects of named types (as opposed to lambdas).

Differential Revision: D63802598


