### PR TITLE
Introduce minimum compaction debt requirement for parallel compaction

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -901,7 +901,11 @@ uint64_t GetPendingCompactionBytesForCompactionSpeedup(
     return slowdown_threshold;
   }
 
-  uint64_t size_threshold = bottommost_files_size / kBottommostSizeDivisor;
+  // Prevent a small CF from triggering parallel compactions for other CFs.
+  // Require compaction debt to be more than a full L0 to Lbase compaction.
+  const uint64_t kMinDebtSize = 2 * mutable_cf_options.max_bytes_for_level_base;
+  uint64_t size_threshold =
+      std::max(bottommost_files_size / kBottommostSizeDivisor, kMinDebtSize);
   return std::min(size_threshold, slowdown_threshold);
 }
 

--- a/db/import_column_family_test.cc
+++ b/db/import_column_family_test.cc
@@ -951,6 +951,8 @@ TEST_F(ImportColumnFamilyTest, AssignEpochNumberToMultipleCF) {
   Options options = CurrentOptions();
   options.level_compaction_dynamic_level_bytes = true;
   options.max_background_jobs = 8;
+  // Always allow parallel compaction
+  options.soft_pending_compaction_bytes_limit = 10;
   env_->SetBackgroundThreads(2, Env::LOW);
   env_->SetBackgroundThreads(0, Env::BOTTOM);
   CreateAndReopenWithCF({"CF1", "CF2"}, options);

--- a/unreleased_history/behavior_changes/parallel-compaction.md
+++ b/unreleased_history/behavior_changes/parallel-compaction.md
@@ -1,0 +1,1 @@
+* Fix an issue in level compaction where a small CF with small compaction debt can cause the DB to allow parallel compactions. (#13054) 


### PR DESCRIPTION
Summary: a small CF can trigger parallel compaction that applies to the entire DB. This is because the bottommost file size of a small CF can be too small compared to l0 files when a l0->lbase compaction happens. We prevent this by requiring some minimum on the compaction debt.


Test plan: updated unit test.