### PR TITLE
Use same logic to assign level for non-overlapping files in universal compaction

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -2045,7 +2045,7 @@ TEST_F(ExternalSSTFileBasicTest, FailIfNotBottommostLevel) {
     ifo.fail_if_not_bottommost_level = true;
     ifo.snapshot_consistency = true;
     const Status s = db_->IngestExternalFile({file_path}, ifo);
-    ASSERT_TRUE(s.IsTryAgain());
+    ASSERT_TRUE(s.ok());
   }
 
   // Test level compaction

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -1065,8 +1065,6 @@ Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
         overlap_with_db = true;
         break;
       }
-    } else if (compaction_style == kCompactionStyleUniversal) {
-      continue;
     }
 
     // We don't overlap with any keys in this level, but we still need to check

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1941,9 +1941,9 @@ TEST_P(ExternalSSTFileTest, IngestFileWithGlobalSeqnoAssignedUniversal) {
       options, file_data, -1, true, write_global_seqno,
       verify_checksums_before_ingest, false, false, &true_data));
 
-  // This file overlap with files in L4, we will ingest it into the last
-  // non-overlapping and non-empty level, in this case, it's L0.
-  ASSERT_EQ("3,0,0,0,3", FilesPerLevel());
+  // This file overlap with files in L4, we will ingest it into the closest
+  // non-overlapping level, in this case, it's L3.
+  ASSERT_EQ("2,0,0,1,3", FilesPerLevel());
 
   size_t kcnt = 0;
   VerifyDBFromMap(true_data, &kcnt, false);

--- a/unreleased_history/behavior_changes/universal_level_assgiment.md
+++ b/unreleased_history/behavior_changes/universal_level_assgiment.md
@@ -1,0 +1,1 @@
+*Assigning levels for external files are done in the same way for universal compaction and leveled compaction.

--- a/unreleased_history/behavior_changes/universal_level_assgiment.md
+++ b/unreleased_history/behavior_changes/universal_level_assgiment.md
@@ -1,1 +1,1 @@
-*Assigning levels for external files are done in the same way for universal compaction and leveled compaction.
+*Assigning levels for external files are done in the same way for universal compaction and leveled compaction. The old behavior tends to assign files to L0 while the new behavior will assign the files to the lowest level possible.


### PR DESCRIPTION
When the input files are not overlapping, a.k.a `files_overlap_=false`, it's best to assign them to non L0 levels so that they are not one sorted run each.  This can be done regardless of compaction style being leveled or universal without any side effects. 

Just my guessing, this special handling may be there because universal compaction used to have an invariant that sequence number on higher levels should not be smaller than sequence number in lower levels. File ingestion used to try to keep up to that promise by doing "sequence number stealing" from the to be assigned level. However, that invariant is no longer true after deletion triggered compaction is added for universal compaction, and we also removed the sequence stealing logic from file ingestion. 

Test plan:
Updated existing tests