### PR TITLE
Ingest files in separate batches if they overlap

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -1790,8 +1790,8 @@ TEST_F(ExternalSSTFileBasicTest, OverlappingFiles) {
     SstFileWriter sst_file_writer(EnvOptions(), options);
     std::string file1 = sst_files_dir_ + "file1.sst";
     ASSERT_OK(sst_file_writer.Open(file1));
-    ASSERT_OK(sst_file_writer.Put("a", "z"));
-    ASSERT_OK(sst_file_writer.Put("i", "m"));
+    ASSERT_OK(sst_file_writer.Put("a", "a1"));
+    ASSERT_OK(sst_file_writer.Put("i", "i1"));
     ExternalSstFileInfo file1_info;
     ASSERT_OK(sst_file_writer.Finish(&file1_info));
     files.push_back(std::move(file1));
@@ -1800,16 +1800,29 @@ TEST_F(ExternalSSTFileBasicTest, OverlappingFiles) {
     SstFileWriter sst_file_writer(EnvOptions(), options);
     std::string file2 = sst_files_dir_ + "file2.sst";
     ASSERT_OK(sst_file_writer.Open(file2));
-    ASSERT_OK(sst_file_writer.Put("i", "k"));
+    ASSERT_OK(sst_file_writer.Put("i", "i2"));
     ExternalSstFileInfo file2_info;
     ASSERT_OK(sst_file_writer.Finish(&file2_info));
     files.push_back(std::move(file2));
   }
 
+  {
+    SstFileWriter sst_file_writer(EnvOptions(), options);
+    std::string file3 = sst_files_dir_ + "file3.sst";
+    ASSERT_OK(sst_file_writer.Open(file3));
+    ASSERT_OK(sst_file_writer.Put("j", "j1"));
+    ASSERT_OK(sst_file_writer.Put("m", "m1"));
+    ExternalSstFileInfo file3_info;
+    ASSERT_OK(sst_file_writer.Finish(&file3_info));
+    files.push_back(std::move(file3));
+  }
+
   IngestExternalFileOptions ifo;
   ASSERT_OK(db_->IngestExternalFile(files, ifo));
-  ASSERT_EQ(Get("a"), "z");
-  ASSERT_EQ(Get("i"), "k");
+  ASSERT_EQ(Get("a"), "a1");
+  ASSERT_EQ(Get("i"), "i2");
+  ASSERT_EQ(Get("j"), "j1");
+  ASSERT_EQ(Get("m"), "m1");
 
   int total_keys = 0;
   Iterator* iter = db_->NewIterator(ReadOptions());
@@ -1817,10 +1830,93 @@ TEST_F(ExternalSSTFileBasicTest, OverlappingFiles) {
     ASSERT_OK(iter->status());
     total_keys++;
   }
+  ASSERT_OK(iter->status());
   delete iter;
-  ASSERT_EQ(total_keys, 2);
+  ASSERT_EQ(total_keys, 4);
 
-  ASSERT_EQ(2, NumTableFilesAtLevel(0));
+  ASSERT_EQ(1, NumTableFilesAtLevel(6));
+  ASSERT_EQ(2, NumTableFilesAtLevel(5));
+}
+
+TEST_F(ExternalSSTFileBasicTest, AtomicReplaceData) {
+  Options options = CurrentOptions();
+
+  std::vector<std::string> files;
+  {
+    // Writes first version of data in range partitioned files.
+    SstFileWriter sst_file_writer(EnvOptions(), options);
+    std::string file1 = sst_files_dir_ + "file1.sst";
+    ASSERT_OK(sst_file_writer.Open(file1));
+    ASSERT_OK(sst_file_writer.Put("a", "a1"));
+    ASSERT_OK(sst_file_writer.Put("b", "b1"));
+    ExternalSstFileInfo file1_info;
+    ASSERT_OK(sst_file_writer.Finish(&file1_info));
+    files.push_back(std::move(file1));
+
+    std::string file2 = sst_files_dir_ + "file2.sst";
+    ASSERT_OK(sst_file_writer.Open(file2));
+    ASSERT_OK(sst_file_writer.Put("x", "x1"));
+    ASSERT_OK(sst_file_writer.Put("y", "y1"));
+    ExternalSstFileInfo file2_info;
+    ASSERT_OK(sst_file_writer.Finish(&file2_info));
+    files.push_back(std::move(file2));
+  }
+
+  IngestExternalFileOptions ifo;
+  ASSERT_OK(db_->IngestExternalFile(files, ifo));
+  ASSERT_EQ(Get("a"), "a1");
+  ASSERT_EQ(Get("b"), "b1");
+  ASSERT_EQ(Get("x"), "x1");
+  ASSERT_EQ(Get("y"), "y1");
+  ASSERT_EQ(2, NumTableFilesAtLevel(6));
+
+  {
+    // Atomically delete old version of data with one range delete file.
+    // And a new batch of range partitioned files with new version of data.
+    files.clear();
+    SstFileWriter sst_file_writer(EnvOptions(), options);
+    std::string file2 = sst_files_dir_ + "file2.sst";
+    ASSERT_OK(sst_file_writer.Open(file2));
+    ASSERT_OK(sst_file_writer.DeleteRange("a", "z"));
+    ExternalSstFileInfo file2_info;
+    ASSERT_OK(sst_file_writer.Finish(&file2_info));
+    files.push_back(std::move(file2));
+
+    std::string file3 = sst_files_dir_ + "file3.sst";
+    ASSERT_OK(sst_file_writer.Open(file3));
+    ASSERT_OK(sst_file_writer.Put("a", "a2"));
+    ASSERT_OK(sst_file_writer.Put("b", "b2"));
+    ExternalSstFileInfo file3_info;
+    ASSERT_OK(sst_file_writer.Finish(&file3_info));
+    files.push_back(std::move(file3));
+
+    std::string file4 = sst_files_dir_ + "file4.sst";
+    ASSERT_OK(sst_file_writer.Open(file4));
+    ASSERT_OK(sst_file_writer.Put("x", "x2"));
+    ASSERT_OK(sst_file_writer.Put("y", "y2"));
+    ExternalSstFileInfo file4_info;
+    ASSERT_OK(sst_file_writer.Finish(&file4_info));
+    files.push_back(std::move(file4));
+  }
+
+  ASSERT_OK(db_->IngestExternalFile(files, ifo));
+  ASSERT_EQ(Get("a"), "a2");
+  ASSERT_EQ(Get("b"), "b2");
+  ASSERT_EQ(Get("x"), "x2");
+  ASSERT_EQ(Get("y"), "y2");
+
+  // Check old version of data, big range deletion, new version of data are
+  // on separate levels.
+  ASSERT_EQ(2, NumTableFilesAtLevel(4));
+  ASSERT_EQ(1, NumTableFilesAtLevel(5));
+  ASSERT_EQ(2, NumTableFilesAtLevel(6));
+
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
+  ASSERT_EQ(0, NumTableFilesAtLevel(4));
+  ASSERT_EQ(0, NumTableFilesAtLevel(5));
+  ASSERT_EQ(1, NumTableFilesAtLevel(6));
 }
 
 TEST_F(ExternalSSTFileBasicTest, IngestFileAfterDBPut) {

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -427,6 +427,10 @@ Status ExternalSstFileIngestionJob::Run() {
     if (!status.ok()) {
       return status;
     }
+
+    // When `files_overlap_` is true, we use a new sequence number for each file
+    // and there will be multiple batches. This tracks the starting point of
+    // sequence number for each batch.
     batch_start_last_seqno = batch_end_last_seqno;
     prev_batch_uppermost_level = batch_uppermost_level;
   }

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -67,7 +67,6 @@ Status ExternalSstFileIngestionJob::Prepare(
     files_to_ingest_.emplace_back(std::move(file_to_ingest));
   }
 
-  const Comparator* ucmp = cfd_->internal_comparator().user_comparator();
   auto num_files = files_to_ingest_.size();
   if (num_files == 0) {
     return Status::InvalidArgument("The list of files is empty");
@@ -78,16 +77,12 @@ Status ExternalSstFileIngestionJob::Prepare(
       sorted_files.push_back(&files_to_ingest_[i]);
     }
 
-    std::sort(
-        sorted_files.begin(), sorted_files.end(),
-        [&ucmp](const IngestedFileInfo* info1, const IngestedFileInfo* info2) {
-          return sstableKeyCompare(ucmp, info1->smallest_internal_key,
-                                   info2->smallest_internal_key) < 0;
-        });
+    std::sort(sorted_files.begin(), sorted_files.end(), file_range_checker_);
 
     for (size_t i = 0; i + 1 < num_files; i++) {
-      if (sstableKeyCompare(ucmp, sorted_files[i]->largest_internal_key,
-                            sorted_files[i + 1]->smallest_internal_key) >= 0) {
+      if (file_range_checker_.OverlapsWithPrev(sorted_files[i],
+                                               sorted_files[i + 1],
+                                               /* ranges_sorted= */ true)) {
         files_overlap_ = true;
         break;
       }
@@ -100,7 +95,7 @@ Status ExternalSstFileIngestionJob::Prepare(
         "behind mode.");
   }
 
-  if (ucmp->timestamp_size() > 0 && files_overlap_) {
+  if (ucmp_->timestamp_size() > 0 && files_overlap_) {
     return Status::NotSupported(
         "Files with overlapping ranges cannot be ingested to column "
         "family with user-defined timestamp enabled.");
@@ -336,7 +331,33 @@ Status ExternalSstFileIngestionJob::Prepare(
     }
   }
 
+  if (status.ok()) {
+    DivideInputFilesIntoBatches();
+  }
+
   return status;
+}
+
+void ExternalSstFileIngestionJob::DivideInputFilesIntoBatches() {
+  if (!files_overlap_) {
+    // No overlap, treat as one batch without the need of tracking overall batch
+    // range.
+    file_batches_to_ingest_.emplace_back(/* _track_batch_range= */ false);
+    for (auto& file : files_to_ingest_) {
+      file_batches_to_ingest_.back().AddFile(&file, file_range_checker_);
+    }
+    return;
+  }
+
+  file_batches_to_ingest_.emplace_back(/* _track_batch_range= */ true);
+  for (auto& file : files_to_ingest_) {
+    if (file_range_checker_.OverlapsWithPrev(&file_batches_to_ingest_.back(),
+                                             &file,
+                                             /* ranges_sorted= */ false)) {
+      file_batches_to_ingest_.emplace_back(/* _track_batch_range= */ true);
+    }
+    file_batches_to_ingest_.back().AddFile(&file, file_range_checker_);
+  }
 }
 
 Status ExternalSstFileIngestionJob::NeedsFlush(bool* flush_needed,
@@ -353,9 +374,7 @@ Status ExternalSstFileIngestionJob::NeedsFlush(bool* flush_needed,
     if (!ingestion_options_.allow_blocking_flush) {
       status = Status::InvalidArgument("External file requires flush");
     }
-    auto ucmp = cfd_->user_comparator();
-    assert(ucmp);
-    if (ucmp->timestamp_size() > 0) {
+    if (ucmp_->timestamp_size() > 0) {
       status = Status::InvalidArgument(
           "Column family enables user-defined timestamps, please make "
           "sure the key range (without timestamp) of external file does not "
@@ -393,18 +412,48 @@ Status ExternalSstFileIngestionJob::Run() {
   }
   // It is safe to use this instead of LastAllocatedSequence since we are
   // the only active writer, and hence they are equal
-  SequenceNumber last_seqno = versions_->LastSequence();
+  SequenceNumber batch_start_last_seqno = versions_->LastSequence();
   edit_.SetColumnFamily(cfd_->GetID());
   // The levels that the files will be ingested into
 
-  for (IngestedFileInfo& f : files_to_ingest_) {
+  std::optional<int> prev_batch_uppermost_level;
+  for (auto& batch : file_batches_to_ingest_) {
+    SequenceNumber batch_end_last_seqno = 0;
+    int batch_uppermost_level = 0;
+    status = AssignLevelsForOneBatch(
+        batch, super_version, force_global_seqno, batch_start_last_seqno,
+        &batch_end_last_seqno, &batch_uppermost_level,
+        prev_batch_uppermost_level);
+    if (!status.ok()) {
+      return status;
+    }
+    batch_start_last_seqno = batch_end_last_seqno;
+    prev_batch_uppermost_level = batch_uppermost_level;
+  }
+
+  CreateEquivalentFileIngestingCompactions();
+  return status;
+}
+
+Status ExternalSstFileIngestionJob::AssignLevelsForOneBatch(
+    FileBatchInfo& batch, SuperVersion* super_version, bool force_global_seqno,
+    SequenceNumber batch_start_last_seqno, SequenceNumber* batch_end_last_seqno,
+    int* batch_uppermost_level, std::optional<int> prev_batch_uppermost_level) {
+  Status status;
+  assert(batch_uppermost_level);
+  *batch_uppermost_level = std::numeric_limits<int>::max();
+  // Make a copy of batch_start_last_seqno as we will be updating it during file
+  // iterations.
+  SequenceNumber last_seqno = batch_start_last_seqno;
+  for (IngestedFileInfo* file : batch.files) {
+    assert(file);
     SequenceNumber assigned_seqno = 0;
     if (ingestion_options_.ingest_behind) {
-      status = CheckLevelForIngestedBehindFile(&f);
+      status = CheckLevelForIngestedBehindFile(file);
     } else {
       status = AssignLevelAndSeqnoForIngestedFile(
           super_version, force_global_seqno, cfd_->ioptions()->compaction_style,
-          last_seqno, &f, &assigned_seqno);
+          last_seqno, file, &assigned_seqno, prev_batch_uppermost_level);
     }
 
     // Modify the smallest/largest internal key to include the sequence number
@@ -413,26 +462,26 @@ Status ExternalSstFileIngestionJob::Run() {
     // exclusive endpoint.
     ParsedInternalKey smallest_parsed, largest_parsed;
     if (status.ok()) {
-      status = ParseInternalKey(*f.smallest_internal_key.rep(),
+      status = ParseInternalKey(*(file->smallest_internal_key.rep()),
                                 &smallest_parsed, false /* log_err_key */);
     }
     if (status.ok()) {
-      status = ParseInternalKey(*f.largest_internal_key.rep(), &largest_parsed,
-                                false /* log_err_key */);
+      status = ParseInternalKey(*(file->largest_internal_key.rep()),
+                                &largest_parsed, false /* log_err_key */);
     }
     if (!status.ok()) {
       return status;
     }
     if (smallest_parsed.sequence == 0 && assigned_seqno != 0) {
-      UpdateInternalKey(f.smallest_internal_key.rep(), assigned_seqno,
+      UpdateInternalKey(file->smallest_internal_key.rep(), assigned_seqno,
                         smallest_parsed.type);
     }
     if (largest_parsed.sequence == 0 && assigned_seqno != 0) {
-      UpdateInternalKey(f.largest_internal_key.rep(), assigned_seqno,
+      UpdateInternalKey(file->largest_internal_key.rep(), assigned_seqno,
                         largest_parsed.type);
     }
 
-    status = AssignGlobalSeqnoForIngestedFile(&f, assigned_seqno);
+    status = AssignGlobalSeqnoForIngestedFile(file, assigned_seqno);
     if (!status.ok()) {
       return status;
     }
@@ -444,7 +493,7 @@ Status ExternalSstFileIngestionJob::Run() {
       ++consumed_seqno_count_;
     }
 
-    status = GenerateChecksumForIngestedFile(&f);
+    status = GenerateChecksumForIngestedFile(file);
     if (!status.ok()) {
       return status;
     }
@@ -459,31 +508,36 @@ Status ExternalSstFileIngestionJob::Run() {
           static_cast<uint64_t>(temp_current_time);
     }
     uint64_t tail_size = 0;
-    bool contain_no_data_blocks = f.table_properties.num_entries > 0 &&
-                                  (f.table_properties.num_entries ==
-                                   f.table_properties.num_range_deletions);
-    if (f.table_properties.tail_start_offset > 0 || contain_no_data_blocks) {
-      uint64_t file_size = f.fd.GetFileSize();
-      assert(f.table_properties.tail_start_offset <= file_size);
-      tail_size = file_size - f.table_properties.tail_start_offset;
+    bool contain_no_data_blocks = file->table_properties.num_entries > 0 &&
+                                  (file->table_properties.num_entries ==
+                                   file->table_properties.num_range_deletions);
+    if (file->table_properties.tail_start_offset > 0 ||
+        contain_no_data_blocks) {
+      uint64_t file_size = file->fd.GetFileSize();
+      assert(file->table_properties.tail_start_offset <= file_size);
+      tail_size = file_size - file->table_properties.tail_start_offset;
     }
 
     FileMetaData f_metadata(
-        f.fd.GetNumber(), f.fd.GetPathId(), f.fd.GetFileSize(),
-        f.smallest_internal_key, f.largest_internal_key, f.assigned_seqno,
-        f.assigned_seqno, false, f.file_temperature, kInvalidBlobFileNumber,
-        oldest_ancester_time, current_time,
+        file->fd.GetNumber(), file->fd.GetPathId(), file->fd.GetFileSize(),
+        file->smallest_internal_key, file->largest_internal_key,
+        file->assigned_seqno, file->assigned_seqno, false,
+        file->file_temperature, kInvalidBlobFileNumber, oldest_ancester_time,
+        current_time,
         ingestion_options_.ingest_behind
             ? kReservedEpochNumberForFileIngestedBehind
             : cfd_->NewEpochNumber(),
-        f.file_checksum, f.file_checksum_func_name, f.unique_id, 0, tail_size,
-        f.user_defined_timestamps_persisted);
-    f_metadata.temperature = f.file_temperature;
-    edit_.AddFile(f.picked_level, f_metadata);
+        file->file_checksum, file->file_checksum_func_name, file->unique_id, 0,
+        tail_size, file->user_defined_timestamps_persisted);
+    f_metadata.temperature = file->file_temperature;
+    edit_.AddFile(file->picked_level, f_metadata);
+
+    *batch_end_last_seqno = std::max(*batch_end_last_seqno, assigned_seqno);
+    *batch_uppermost_level =
+        std::min(*batch_uppermost_level, file->picked_level);
   }
 
-  CreateEquivalentFileIngestingCompactions();
-  return status;
+  return Status::OK();
 }
 
 void ExternalSstFileIngestionJob::CreateEquivalentFileIngestingCompactions() {
@@ -787,9 +841,7 @@ Status ExternalSstFileIngestionJob::SanityCheckTableProperties(
   // `TableReader` is initialized with `user_defined_timestamps_persisted` flag
   // to be true. If its value changed to false after this sanity check, we
   // need to reset the `TableReader`.
-  auto ucmp = cfd_->user_comparator();
-  assert(ucmp);
-  if (ucmp->timestamp_size() > 0 &&
+  if (ucmp_->timestamp_size() > 0 &&
       !file_to_ingest->user_defined_timestamps_persisted) {
     s = ResetTableReader(external_file, new_file_number,
                          file_to_ingest->user_defined_timestamps_persisted, sv,
@@ -854,11 +906,6 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
       /*skip_filters=*/false, TableReaderCaller::kExternalSSTIngestion));
 
   // Get first (smallest) and last (largest) key from file.
-  file_to_ingest->smallest_internal_key =
-      InternalKey("", 0, ValueType::kTypeValue);
-  file_to_ingest->largest_internal_key =
-      InternalKey("", 0, ValueType::kTypeValue);
-  bool bounds_set = false;
   bool allow_data_in_errors = db_options_.allow_data_in_errors;
   iter->SeekToFirst();
   if (iter->Valid()) {
@@ -908,8 +955,6 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
       return Status::Corruption("External file has non zero sequence number");
     }
     file_to_ingest->largest_internal_key.SetFrom(key);
-
-    bounds_set = true;
   } else if (!iter->status().ok()) {
     return iter->status();
   }
@@ -946,7 +991,6 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
       table_reader->NewRangeTombstoneIterator(ro));
   // We may need to adjust these key bounds, depending on whether any range
   // deletion tombstones extend past them.
-  const Comparator* ucmp = cfd_->user_comparator();
   if (range_del_iter != nullptr) {
     for (range_del_iter->SeekToFirst(); range_del_iter->Valid();
          range_del_iter->Next()) {
@@ -962,24 +1006,13 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
             "number.");
       }
       RangeTombstone tombstone(key, range_del_iter->value());
-
-      InternalKey start_key = tombstone.SerializeKey();
-      if (!bounds_set ||
-          sstableKeyCompare(ucmp, start_key,
-                            file_to_ingest->smallest_internal_key) < 0) {
-        file_to_ingest->smallest_internal_key = start_key;
-      }
-      InternalKey end_key = tombstone.SerializeEndKey();
-      if (!bounds_set ||
-          sstableKeyCompare(ucmp, end_key,
-                            file_to_ingest->largest_internal_key) > 0) {
-        file_to_ingest->largest_internal_key = end_key;
-      }
-      bounds_set = true;
+      file_range_checker_.MaybeUpdateRange(tombstone.SerializeKey(),
+                                           tombstone.SerializeEndKey(),
+                                           file_to_ingest);
     }
   }
 
-  const size_t ts_sz = ucmp->timestamp_size();
+  const size_t ts_sz = ucmp_->timestamp_size();
   Slice smallest = file_to_ingest->smallest_internal_key.user_key();
   Slice largest = file_to_ingest->largest_internal_key.user_key();
   if (ts_sz > 0) {
@@ -1008,16 +1041,19 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
 Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
     SuperVersion* sv, bool force_global_seqno, CompactionStyle compaction_style,
     SequenceNumber last_seqno, IngestedFileInfo* file_to_ingest,
-    SequenceNumber* assigned_seqno) {
+    SequenceNumber* assigned_seqno,
+    std::optional<int> prev_batch_uppermost_level) {
   Status status;
   *assigned_seqno = 0;
-  auto ucmp = cfd_->user_comparator();
-  const size_t ts_sz = ucmp->timestamp_size();
+  const size_t ts_sz = ucmp_->timestamp_size();
+  assert(!prev_batch_uppermost_level.has_value() ||
+         prev_batch_uppermost_level.value() < cfd_->NumberLevels());
+  bool must_assign_to_l0 = prev_batch_uppermost_level.has_value() &&
+                           prev_batch_uppermost_level.value() == 0;
   if (force_global_seqno || files_overlap_ ||
-      compaction_style == kCompactionStyleFIFO) {
+      compaction_style == kCompactionStyleFIFO || must_assign_to_l0) {
     *assigned_seqno = last_seqno + 1;
-    // If files overlap, we have to ingest them at level 0.
-    if (files_overlap_ || compaction_style == kCompactionStyleFIFO) {
+    if (compaction_style == kCompactionStyleFIFO || must_assign_to_l0) {
       assert(ts_sz == 0);
       file_to_ingest->picked_level = 0;
       if (ingestion_options_.fail_if_not_bottommost_level &&
@@ -1037,8 +1073,12 @@ Status ExternalSstFileIngestionJob::AssignLevelAndSeqnoForIngestedFile(
   ro.total_order_seek = true;
   int target_level = 0;
   auto* vstorage = cfd_->current()->storage_info();
+  assert(!must_assign_to_l0);
+  int exclusive_end_level = prev_batch_uppermost_level.has_value()
+                                ? prev_batch_uppermost_level.value()
+                                : cfd_->NumberLevels();
 
-  for (int lvl = 0; lvl < cfd_->NumberLevels(); lvl++) {
+  for (int lvl = 0; lvl < exclusive_end_level; lvl++) {
     if (lvl > 0 && lvl < vstorage->base_level()) {
       continue;
     }

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -301,8 +301,7 @@ class ExternalSstFileIngestionJob {
   Status AssignLevelsForOneBatch(FileBatchInfo& batch,
                                  SuperVersion* super_version,
                                  bool force_global_seqno,
-                                 SequenceNumber batch_start_last_seqno,
-                                 SequenceNumber* batch_end_last_seqno,
+                                 SequenceNumber* last_seqno,
                                  int* batch_uppermost_level,
                                  std::optional<int> prev_batch_uppermost_level);
 

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -25,13 +25,74 @@ namespace ROCKSDB_NAMESPACE {
 class Directories;
 class SystemClock;
 
-struct IngestedFileInfo {
+struct KeyRangeInfo {
+  // Smallest internal key in an external file or for a batch of external files.
+  InternalKey smallest_internal_key;
+  // Largest internal key in an external file or for a batch of external files.
+  InternalKey largest_internal_key;
+
+  bool empty() const {
+    return smallest_internal_key.size() == 0 &&
+           largest_internal_key.size() == 0;
+  }
+};
+
+// Helper class to apply SST file key range checks to the external files.
+class ExternalFileRangeChecker {
+ public:
+  explicit ExternalFileRangeChecker(const Comparator* ucmp) : ucmp_(ucmp) {}
+
+  // Operator used for sorting ranges.
+  bool operator()(const KeyRangeInfo* prev_range,
+                  const KeyRangeInfo* range) const {
+    assert(prev_range);
+    assert(range);
+    return sstableKeyCompare(ucmp_, prev_range->smallest_internal_key,
+                             range->smallest_internal_key) < 0;
+  }
+
+  // Check whether `range` overlaps with `prev_range`. `ranges_sorted` can be
+  // set to true when the inputs are already sorted based on the sorting logic
+  // provided by this checker's operator(), which can help simplify the check.
+  bool OverlapsWithPrev(const KeyRangeInfo* prev_range,
+                        const KeyRangeInfo* range,
+                        bool ranges_sorted = false) const {
+    assert(prev_range);
+    assert(range);
+    if (prev_range->empty() || range->empty()) {
+      return false;
+    }
+    if (ranges_sorted) {
+      return sstableKeyCompare(ucmp_, prev_range->largest_internal_key,
+                               range->smallest_internal_key) >= 0;
+    }
+
+    return sstableKeyCompare(ucmp_, prev_range->largest_internal_key,
+                             range->smallest_internal_key) >= 0 &&
+           sstableKeyCompare(ucmp_, prev_range->smallest_internal_key,
+                             range->largest_internal_key) <= 0;
+  }
+
+  void MaybeUpdateRange(const InternalKey& start_key,
+                        const InternalKey& end_key, KeyRangeInfo* range) const {
+    assert(range);
+    if (range->smallest_internal_key.size() == 0 ||
+        sstableKeyCompare(ucmp_, start_key, range->smallest_internal_key) < 0) {
+      range->smallest_internal_key = start_key;
+    }
+    if (range->largest_internal_key.size() == 0 ||
+        sstableKeyCompare(ucmp_, end_key, range->largest_internal_key) > 0) {
+      range->largest_internal_key = end_key;
+    }
+  }
+
+ private:
+  const Comparator* ucmp_;
+};
+
+struct IngestedFileInfo : public KeyRangeInfo {
   // External file path
   std::string external_file_path;
-  // Smallest internal key in external file
-  InternalKey smallest_internal_key;
-  // Largest internal key in external file
-  InternalKey largest_internal_key;
   // NOTE: use below two fields for all `*Overlap*` types of checks instead of
   // smallest_internal_key.user_key() and largest_internal_key.user_key().
   // The smallest / largest user key contained in the file for key range checks.
@@ -94,6 +155,30 @@ struct IngestedFileInfo {
   bool user_defined_timestamps_persisted = true;
 };
 
+// A batch of files.
+struct FileBatchInfo : public KeyRangeInfo {
+  autovector<IngestedFileInfo*> files;
+  // When true, `smallest_internal_key` and `largest_internal_key` will be
+  // tracked and updated as new file get added via `AddFile`. When false, we
+  // bypass this tracking. This is used when the all input external files
+  // are already checked and not overlapping, and they just need to be added
+  // into one default batch.
+  bool track_batch_range;
+
+  void AddFile(IngestedFileInfo* file,
+               const ExternalFileRangeChecker& key_range_checker) {
+    assert(file);
+    files.push_back(file);
+    if (track_batch_range) {
+      key_range_checker.MaybeUpdateRange(file->smallest_internal_key,
+                                         file->largest_internal_key, this);
+    }
+  }
+
+  FileBatchInfo(bool _track_batch_range)
+      : track_batch_range(_track_batch_range) {}
+};
+
 class ExternalSstFileIngestionJob {
  public:
   ExternalSstFileIngestionJob(
@@ -108,6 +193,8 @@ class ExternalSstFileIngestionJob {
         fs_(db_options.fs, io_tracer),
         versions_(versions),
         cfd_(cfd),
+        ucmp_(cfd ? cfd->user_comparator() : nullptr),
+        file_range_checker_(ucmp_),
         db_options_(db_options),
         mutable_db_options_(mutable_db_options),
         env_options_(env_options),
@@ -119,6 +206,8 @@ class ExternalSstFileIngestionJob {
         consumed_seqno_count_(0),
         io_tracer_(io_tracer) {
     assert(directories != nullptr);
+    assert(cfd_);
+    assert(ucmp_);
   }
 
   ~ExternalSstFileIngestionJob() { UnregisterRange(); }
@@ -194,15 +283,39 @@ class ExternalSstFileIngestionJob {
                              IngestedFileInfo* file_to_ingest,
                              SuperVersion* sv);
 
+  // If the input files' key range overlaps themselves, this function divides
+  // them in the user specified order into multiple batches. Where the files
+  // within a batch do not overlap with each other, but key range could overlap
+  // between batches.
+  // If the input files' key range don't overlap themselves, they always just
+  // make one batch.
+  void DivideInputFilesIntoBatches();
+
+  // Assign level for the files in one batch. The files within one batch are not
+  // overlapping, and we assign level to each file one after another.
+  // If `prev_batch_uppermost_level` is specified, all files in this batch will
+  // be assigned to levels that are higher than `prev_batch_uppermost_level`.
+  // The uppermost level used by this batch of files is tracked too, so that it
+  // can be used by the next batch.
+  // REQUIRES: Mutex held
+  Status AssignLevelsForOneBatch(FileBatchInfo& batch,
+                                 SuperVersion* super_version,
+                                 bool force_global_seqno,
+                                 SequenceNumber batch_start_last_seqno,
+                                 SequenceNumber* batch_end_last_seqno,
+                                 int* batch_uppermost_level,
+                                 std::optional<int> prev_batch_uppermost_level);
+
   // Assign `file_to_ingest` the appropriate sequence number and the lowest
   // possible level that it can be ingested to according to compaction_style.
+  // If `prev_batch_uppermost_level` is specified, the file will only be
+  // assigned to levels tha are higher than `prev_batch_uppermost_level`.
   // REQUIRES: Mutex held
-  Status AssignLevelAndSeqnoForIngestedFile(SuperVersion* sv,
-                                            bool force_global_seqno,
-                                            CompactionStyle compaction_style,
-                                            SequenceNumber last_seqno,
-                                            IngestedFileInfo* file_to_ingest,
-                                            SequenceNumber* assigned_seqno);
+  Status AssignLevelAndSeqnoForIngestedFile(
+      SuperVersion* sv, bool force_global_seqno,
+      CompactionStyle compaction_style, SequenceNumber last_seqno,
+      IngestedFileInfo* file_to_ingest, SequenceNumber* assigned_seqno,
+      std::optional<int> prev_batch_uppermost_level);
 
   // File that we want to ingest behind always goes to the lowest level;
   // we just check that it fits in the level, that DB allows ingest_behind,
@@ -237,11 +350,14 @@ class ExternalSstFileIngestionJob {
   FileSystemPtr fs_;
   VersionSet* versions_;
   ColumnFamilyData* cfd_;
+  const Comparator* ucmp_;
+  ExternalFileRangeChecker file_range_checker_;
   const ImmutableDBOptions& db_options_;
   const MutableDBOptions& mutable_db_options_;
   const EnvOptions& env_options_;
   SnapshotList* db_snapshots_;
   autovector<IngestedFileInfo> files_to_ingest_;
+  std::vector<FileBatchInfo> file_batches_to_ingest_;
   const IngestExternalFileOptions& ingestion_options_;
   Directories* directories_;
   EventLogger* event_logger_;

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -175,7 +175,7 @@ struct FileBatchInfo : public KeyRangeInfo {
     }
   }
 
-  FileBatchInfo(bool _track_batch_range)
+  explicit FileBatchInfo(bool _track_batch_range)
       : track_batch_range(_track_batch_range) {}
 };
 

--- a/unreleased_history/behavior_changes/overlapping_files_ingestion.md
+++ b/unreleased_history/behavior_changes/overlapping_files_ingestion.md
@@ -1,0 +1,1 @@
+*Overlapping files level assignment are done in multiple batches, so that they can potentially be assigned to lower levels other than always land on L0.

--- a/unreleased_history/behavior_changes/overlapping_files_ingestion.md
+++ b/unreleased_history/behavior_changes/overlapping_files_ingestion.md
@@ -1,1 +1,1 @@
-*Overlapping files level assignment are done in multiple batches, so that they can potentially be assigned to lower levels other than always land on L0.
+*During file ingestion, overlapping files level assignment are done in multiple batches, so that they can potentially be assigned to lower levels other than always land on L0.


### PR DESCRIPTION
This PR assigns levels to files in separate batches if they overlap. This approach can potentially assign external files to lower levels. 

In the prepare stage, if the input files' key range overlaps themselves, we divide them up in the user specified order into multiple batches. Where the files in the same batch do not overlap with each other, but key range could overlap between batches. If the input files' key range don't overlap, they always just make one default batch.

During the level assignment stage, we assign levels to files one batch after another.  It's guaranteed that files within one batch are not overlapping, we assign level to each file one after another. If the previous batch's uppermost level is specified, all files in this batch will be assigned to levels that are higher than that level. The uppermost level used by this batch of files is also tracked, so that it can be used by the next batch.

Test plan:
Updated test and added new test
Manually stress tested
