### PR TITLE
Add an API to check if an SST file is generated by SstFileWriter

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -707,6 +707,7 @@ Status ExternalSstFileIngestionJob::SanityCheckTableProperties(
   // Get table version
   auto version_iter = uprops.find(ExternalSstFilePropertyNames::kVersion);
   if (version_iter == uprops.end()) {
+    assert(!SstFileWriter::CreatedBySstFileWriter(*props));
     if (!ingestion_options_.allow_db_generated_files) {
       return Status::Corruption("External file version not found");
     } else {
@@ -715,6 +716,7 @@ Status ExternalSstFileIngestionJob::SanityCheckTableProperties(
       file_to_ingest->version = 0;
     }
   } else {
+    assert(SstFileWriter::CreatedBySstFileWriter(*props));
     file_to_ingest->version = DecodeFixed32(version_iter->second.c_str());
   }
 

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -195,6 +195,9 @@ class SstFileWriter {
   // Return the current file size.
   uint64_t FileSize();
 
+  // Check if a file with input table property is created by SstFileWriter.
+  static bool CreatedBySstFileWriter(const TableProperties&);
+
  private:
   void InvalidatePageCache(bool closing);
   struct Rep;

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -533,4 +533,9 @@ Status SstFileWriter::Finish(ExternalSstFileInfo* file_info) {
 
 uint64_t SstFileWriter::FileSize() { return rep_->file_info.file_size; }
 
+bool SstFileWriter::CreatedBySstFileWriter(const TableProperties& tp) {
+  const auto& uprops = tp.user_collected_properties;
+  return uprops.find(ExternalSstFilePropertyNames::kVersion) != uprops.end();
+}
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: Some users want to check if a file in their DB was created by SstFileWriter and ingested into the DB. Files created by SstFileWriter records additional table properties https://github.com/facebook/rocksdb/blob/cbebbad7d9353173bb0e2580da2eef71c5c18199/table/sst_file_writer_collectors.h#L17-L21. These are not exposed so I'm adding an API to SstFileWriter to check for them.


Test plan: added some assertions.