### PR TITLE
Update MultiGet to respect the strict_capacity_limit block cache option

### DIFF
--- a/table/block_based/block_based_table_reader_sync_and_async.h
+++ b/table/block_based/block_based_table_reader_sync_and_async.h
@@ -312,7 +312,6 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::RetrieveMultipleBlocks)
         // block cache is configured. In that case, fall
         // through and set up the block explicitly
         if (block_entry->GetValue() != nullptr) {
-          s.PermitUncheckedError();
           continue;
         }
       }

--- a/table/block_based/block_based_table_reader_sync_and_async.h
+++ b/table/block_based/block_based_table_reader_sync_and_async.h
@@ -303,6 +303,10 @@ DEFINE_SYNC_AND_ASYNC(void, BlockBasedTable::RetrieveMultipleBlocks)
             /*lookup_context=*/nullptr, &serialized_block,
             /*async_read=*/false, /*use_block_cache_for_lookup=*/true);
 
+        if (!s.ok()) {
+          statuses[idx_in_batch] = s;
+          continue;
+        }
         // block_entry value could be null if no block cache is present, i.e
         // BlockBasedTableOptions::no_block_cache is true and no compressed
         // block cache is configured. In that case, fall

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -745,7 +745,7 @@ class StrictCapacityLimitReaderTest : public BlockBasedTableReaderTest {
   }
 };
 
-TEST_P(StrictCapacityLimitReaderTest, StrictCapacityLimitGet) {
+TEST_P(StrictCapacityLimitReaderTest, Get) {
   // Test that we get error status when we exceed
   // the strict_capacity_limit
   Options options;

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -746,6 +746,8 @@ class StrictCapacityLimitReaderTest : public BlockBasedTableReaderTest {
 };
 
 TEST_P(StrictCapacityLimitReaderTest, StrictCapacityLimitGet) {
+  // Task T205994926: Test that we get error status when we exceed
+  // the strict_capacity_limit
   Options options;
   size_t ts_sz = options.comparator->timestamp_size();
   std::vector<std::pair<std::string, std::string>> kv =
@@ -753,7 +755,7 @@ TEST_P(StrictCapacityLimitReaderTest, StrictCapacityLimitGet) {
           2 /* num_block */, true /* mixed_with_human_readable_string_value */,
           ts_sz, false);
 
-  std::string table_name = "BlockBasedTableReaderGetTest_Get" +
+  std::string table_name = "StrictCapacityLimitReaderTest_Get" +
                            CompressionTypeToString(compression_type_);
 
   ImmutableOptions ioptions(options);
@@ -805,6 +807,8 @@ TEST_P(StrictCapacityLimitReaderTest, StrictCapacityLimitGet) {
 }
 
 TEST_P(StrictCapacityLimitReaderTest, MultiGet) {
+  // Task T205994926: Test that we get error status when we exceed
+  // the strict_capacity_limit
   Options options;
   ReadOptions read_opts;
   std::string dummy_ts(sizeof(uint64_t), '\0');
@@ -817,8 +821,8 @@ TEST_P(StrictCapacityLimitReaderTest, MultiGet) {
   size_t ts_sz = options.comparator->timestamp_size();
   std::vector<std::pair<std::string, std::string>> kv =
       BlockBasedTableReaderBaseTest::GenerateKVMap(
-          100 /* num_block */,
-          true /* mixed_with_human_readable_string_value */, ts_sz);
+          2 /* num_block */, true /* mixed_with_human_readable_string_value */,
+          ts_sz);
 
   // Prepare keys, values, and statuses for MultiGet.
   autovector<Slice, MultiGetContext::MAX_BATCH_SIZE> keys;
@@ -847,7 +851,7 @@ TEST_P(StrictCapacityLimitReaderTest, MultiGet) {
     }
   }
 
-  std::string table_name = "BlockBasedTableReaderTest_MultiGet" +
+  std::string table_name = "StrictCapacityLimitReaderTest_MultiGet" +
                            CompressionTypeToString(compression_type_);
 
   ImmutableOptions ioptions(options);
@@ -910,11 +914,6 @@ TEST_P(StrictCapacityLimitReaderTest, MultiGet) {
     }
   }
   ASSERT_TRUE(hit_memory_limit);
-  // Check that keys are in cache after MultiGet.
-  // for (size_t i = 0; i < keys.size(); i++) {
-  //   ASSERT_TRUE(table->TEST_KeyInCache(read_opts, keys[i]));
-  //   ASSERT_EQ(values[i].ToString(), *expected_values[i]);
-  // }
 }
 
 class BlockBasedTableReaderTestVerifyChecksum

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -746,7 +746,7 @@ class StrictCapacityLimitReaderTest : public BlockBasedTableReaderTest {
 };
 
 TEST_P(StrictCapacityLimitReaderTest, StrictCapacityLimitGet) {
-  // Task T205994926: Test that we get error status when we exceed
+  // Test that we get error status when we exceed
   // the strict_capacity_limit
   Options options;
   size_t ts_sz = options.comparator->timestamp_size();
@@ -807,7 +807,7 @@ TEST_P(StrictCapacityLimitReaderTest, StrictCapacityLimitGet) {
 }
 
 TEST_P(StrictCapacityLimitReaderTest, MultiGet) {
-  // Task T205994926: Test that we get error status when we exceed
+  // Test that we get error status when we exceed
   // the strict_capacity_limit
   Options options;
   ReadOptions read_opts;


### PR DESCRIPTION
### Summary

There is a `strict_capacity_limit` option which imposes a hard memory limit on the block cache. When the block cache is enabled, every read request is serviced from the block cache. If the required block is missing, it is first inserted into the cache. If `strict_capacity_limit` is `true` and the limit has been reached, the `Get` and `MultiGet` requests should fail. However, currently this is not happening for `MultiGet`.

I updated `MultiGet` to explicitly check the returned status of `MaybeReadBlockAndLoadToCache`, so the status does not get overwritten later.

Thank you @anand1976 for the problem explanation.

### Test Plan

Added unit test for both `Get` and `MultiGet` with a `strict_capacity_limit` set.

Before the change, half of my unit test cases failed https://github.com/facebook/rocksdb/actions/runs/11604597524/job/32313608085?pr=13104. After I added the check for the status returned by `MaybeReadBlockAndLoadToCache`, they all pass.

I also ran these tests manually (I had to run `make clean` before):

```
make -j64 block_based_table_reader_test COMPILE_WITH_ASAN=1 ASSERT_STATUS_CHECKED=1

 ./block_based_table_reader_test --gtest_filter="*StrictCapacityLimitReaderTest.Get*"
 ./block_based_table_reader_test --gtest_filter="*StrictCapacityLimitReaderTest.MultiGet*"

```