### PR TITLE
Remove early return when scanning files for temperature change compaction

### DIFF
--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -370,8 +370,11 @@ Compaction* FIFOCompactionPicker::PickTemperatureChangeCompaction(
         return nullptr;
       }
       uint64_t est_newest_key_time = cur_file->TryGetNewestKeyTime(prev_file);
-      if (est_newest_key_time == kUnknownNewestKeyTime ||
-          est_newest_key_time > create_time_threshold) {
+      // Newer file could have newest_key_time populated
+      if (est_newest_key_time == kUnknownNewestKeyTime) {
+        continue;
+      }
+      if (est_newest_key_time > create_time_threshold) {
         break;
       }
       Temperature cur_target_temp = ages[0].temperature;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3397,8 +3397,11 @@ bool ShouldChangeFileTemperature(const ImmutableOptions& ioptions,
       FileMetaData* prev_file = index < 2 ? nullptr : files[index - 2];
       if (!cur_file->being_compacted) {
         uint64_t est_newest_key_time = cur_file->TryGetNewestKeyTime(prev_file);
-        if (est_newest_key_time == kUnknownNewestKeyTime ||
-            est_newest_key_time > create_time_threshold) {
+        // Newer file could have newest_key_time populated
+        if (est_newest_key_time == kUnknownNewestKeyTime) {
+          continue;
+        }
+        if (est_newest_key_time > create_time_threshold) {
           return false;
         }
         target_temp = ages[0].temperature;


### PR DESCRIPTION
### Summary

This is a small follow-up to https://github.com/facebook/rocksdb/pull/13083.

When we check the `newest_key_time` of files for temperature change compaction, we currently return early if we ever find a file with an unknown `est_newest_key_time`.

However, it is possible for a younger file to have a populated value for `newest_key_time`, since this is a new table property. 

### Test Plan

The existing unit tests are sufficient.