### PR TITLE
Fix and test for leaks of open SST files

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -726,13 +726,19 @@ uint64_t TableCache::ApproximateSize(
   return result;
 }
 
-void TableCache::ReleaseObsolete(Cache* cache, Cache::Handle* h,
+void TableCache::ReleaseObsolete(Cache* cache, uint64_t file_number,
+                                 Cache::Handle* h,
                                  uint32_t uncache_aggressiveness) {
   CacheInterface typed_cache(cache);
   TypedHandle* table_handle = reinterpret_cast<TypedHandle*>(h);
-  TableReader* table_reader = typed_cache.Value(table_handle);
-  table_reader->MarkObsolete(uncache_aggressiveness);
-  typed_cache.ReleaseAndEraseIfLastRef(table_handle);
+  if (table_handle == nullptr) {
+    table_handle = typed_cache.Lookup(GetSliceForFileNumber(&file_number));
+  }
+  if (table_handle != nullptr) {
+    TableReader* table_reader = typed_cache.Value(table_handle);
+    table_reader->MarkObsolete(uncache_aggressiveness);
+    typed_cache.ReleaseAndEraseIfLastRef(table_handle);
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -159,12 +159,14 @@ class TableCache {
                          bool skip_range_deletions = false, int level = -1,
                          TypedHandle* table_handle = nullptr);
 
-  // Evict any entry for the specified file number
+  // Evict any entry for the specified file number. ReleaseObsolete() is
+  // preferred for cleaning up from obsolete files.
   static void Evict(Cache* cache, uint64_t file_number);
 
   // Handles releasing, erasing, etc. of what should be the last reference
-  // to an obsolete file.
-  static void ReleaseObsolete(Cache* cache, Cache::Handle* handle,
+  // to an obsolete file. `handle` may be nullptr if no prior handle is known.
+  static void ReleaseObsolete(Cache* cache, uint64_t file_number,
+                              Cache::Handle* handle,
                               uint32_t uncache_aggressiveness);
 
   // Return handle to an existing cache entry if there is one

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5204,18 +5204,16 @@ VersionSet::~VersionSet() {
   column_family_set_.reset();
 
   for (auto& file : obsolete_files_) {
-    if (file.metadata->table_reader_handle) {
-      // NOTE: DB is shutting down, so file is probably not obsolete, just
-      // no longer referenced by Versions in memory.
-      // For more context, see comment on "table_cache_->EraseUnRefEntries()"
-      // in DBImpl::CloseHelper().
-      // Using uncache_aggressiveness=0 overrides any previous marking to
-      // attempt to uncache the file's blocks (which after cleaning up
-      // column families could cause use-after-free)
-      TableCache::ReleaseObsolete(table_cache_,
-                                  file.metadata->table_reader_handle,
-                                  /*uncache_aggressiveness=*/0);
-    }
+    // NOTE: DB is shutting down, so file is probably not obsolete, just
+    // no longer referenced by Versions in memory.
+    // For more context, see comment on "table_cache_->EraseUnRefEntries()"
+    // in DBImpl::CloseHelper().
+    // Using uncache_aggressiveness=0 overrides any previous marking to
+    // attempt to uncache the file's blocks (which after cleaning up
+    // column families could cause use-after-free)
+    TableCache::ReleaseObsolete(table_cache_, file.metadata->fd.GetNumber(),
+                                file.metadata->table_reader_handle,
+                                /*uncache_aggressiveness=*/0);
     file.DeleteMetadata();
   }
   obsolete_files_.clear();

--- a/unreleased_history/bug_fixes/open_sst_file_leaks.md
+++ b/unreleased_history/bug_fixes/open_sst_file_leaks.md
@@ -1,0 +1,1 @@
+* Fix leaks of some open SST files (until `DB::Close()`) that are written but never become live due to various failures. (We now have a check for such leaks with no outstanding issues.)


### PR DESCRIPTION
Summary: Follow-up to #13106 which revealed that some SST file readers (in addition to blob files) were being essentially leaked in TableCache (until DB::Close() time). Patched sources of leaks:
* Flush that is not committed (builder.cc)
* Various obsolete SST files picked up by directory scan but not caught by SubcompactionState::Cleanup() cleaning up from some failed compactions. Dozens of unit tests fail without the "backstop" TableCache::Evict() call in PurgeObsoleteFiles().

We also needed to adjust the check for leaks as follows:
* Ok if DB::Open never finished (see comment)
* Ok if deletions are disabled (see comment)
* Allow "quarantined" files to be in table_cache because (presumably) they might become live again.
* Get live files from all live Versions.

Suggested follow-up:
* Potentially delete more obsolete files sooner with a FIXME in db_impl_files.cc. This could potentially be high value because it seems to gate deletion of any/all newer obsolete files on all older compactions finishing.
* Try to catch obsolete files in more places using the VersionSet::obsolete_files_ pipeline rather than relying on them being picked up with directory scan, or deleting them outside of normal mechanisms.

Test Plan: updated check used in most all unit tests in ASAN build