### PR TITLE
Print iterator status in stress tests when PrepareValue() fails

### DIFF
--- a/db_stress_tool/batched_ops_stress.cc
+++ b/db_stress_tool/batched_ops_stress.cc
@@ -621,8 +621,9 @@ class BatchedOpsStressTest : public StressTest {
 
           if (!iters[i]->PrepareValue()) {
             fprintf(stderr,
-                    "prefix scan error: PrepareValue failed for key %s\n",
-                    prepare_value_key.c_str());
+                    "prefix scan error: PrepareValue failed for key %s: %s\n",
+                    prepare_value_key.c_str(),
+                    iters[i]->status().ToString().c_str());
             continue;
           }
         }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2010,9 +2010,9 @@ void StressTest::VerifyIterator(
             stderr,
             "Iterator failed to prepare value for key %s %s under specified "
             "iterator ReadOptions: %s (Empty string or missing field indicates "
-            "default option or value is used)\n",
+            "default option or value is used): %s\n",
             prepare_value_key.c_str(), op_logs.c_str(),
-            read_opt_oss.str().c_str());
+            read_opt_oss.str().c_str(), iter->status().ToString().c_str());
         *diverged = true;
       }
     }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -2308,9 +2308,10 @@ class NonBatchedOpsStressTest : public StressTest {
         if (!iter->PrepareValue()) {
           shared->SetVerificationFailure();
 
-          fprintf(stderr,
-                  "Verification failed for key %s: failed to prepare value\n",
-                  prepare_value_key.c_str());
+          fprintf(
+              stderr,
+              "Verification failed for key %s: failed to prepare value: %s\n",
+              prepare_value_key.c_str(), iter->status().ToString().c_str());
           fprintf(stderr, "Column family: %s, op_logs: %s\n",
                   cfh->GetName().c_str(), op_logs.c_str());
 


### PR DESCRIPTION
Summary: The patch changes the stress test code so it always logs the error status to aid debugging when a `PrepareValue` call fails.

Differential Revision: D65712502


