### PR TITLE
Fix the handling of PrepareValue failures due to fault injection

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1748,6 +1748,15 @@ Status StressTest::TestIterateImpl(ThreadState* thread,
       op_logs += "S " + key.ToString(true) + " ";
     }
 
+    if (iter->Valid() && ro.allow_unprepared_value) {
+      op_logs += "*";
+
+      if (!iter->PrepareValue()) {
+        assert(!iter->Valid());
+        assert(!iter->status().ok());
+      }
+    }
+
     if (!iter->status().ok() && IsErrorInjectedAndRetryable(iter->status())) {
       return iter->status();
     } else if (!cmp_iter->status().ok() &&
@@ -1778,6 +1787,15 @@ Status StressTest::TestIterateImpl(ThreadState* thread,
       }
 
       last_op = kLastOpNextOrPrev;
+
+      if (iter->Valid() && ro.allow_unprepared_value) {
+        op_logs += "*";
+
+        if (!iter->PrepareValue()) {
+          assert(!iter->Valid());
+          assert(!iter->status().ok());
+        }
+      }
 
       if (!iter->status().ok() && IsErrorInjectedAndRetryable(iter->status())) {
         return iter->status();
@@ -2000,27 +2018,8 @@ void StressTest::VerifyIterator(
   }
 
   if (!*diverged && iter->Valid()) {
-    if (ro.allow_unprepared_value) {
-      // Save key in case PrepareValue fails and invalidates the iterator
-      const std::string prepare_value_key =
-          iter->key().ToString(/* hex */ true);
-
-      if (!iter->PrepareValue()) {
-        fprintf(
-            stderr,
-            "Iterator failed to prepare value for key %s %s under specified "
-            "iterator ReadOptions: %s (Empty string or missing field indicates "
-            "default option or value is used): %s\n",
-            prepare_value_key.c_str(), op_logs.c_str(),
-            read_opt_oss.str().c_str(), iter->status().ToString().c_str());
-        *diverged = true;
-      }
-    }
-
-    if (!*diverged && iter->Valid()) {
-      if (!verify_func(iter)) {
-        *diverged = true;
-      }
+    if (!verify_func(iter)) {
+      *diverged = true;
     }
   }
 


### PR DESCRIPTION
Summary: The earlier stress test code did not consider that `PrepareValue()` could fail because of read fault injection, leading to false positives. The patch shuffles the `PrepareValue()` calls around a bit in `TestIterate` / `TestIterateAgainstExpected` in order to prevent this by leveraging the existing code paths that intercept injected faults.

Differential Revision: D65731543


