### PR TITLE
Enable attribute group APIs in the transaction stress tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -530,8 +530,6 @@ txn_params = {
     "inplace_update_support": 0,
     # TimedPut is not supported in transaction
     "use_timed_put_one_in": 0,
-    # AttributeGroup not yet supported
-    "use_attribute_group": 0,
 }
 
 # For optimistic transaction db
@@ -545,8 +543,6 @@ optimistic_txn_params = {
     "inplace_update_support": 0,
     # TimedPut is not supported in transaction
     "use_timed_put_one_in": 0,
-    # AttributeGroup not yet supported
-    "use_attribute_group": 0,
 }
 
 best_efforts_recovery_params = {


### PR DESCRIPTION
Summary: Even though `Transaction` does not currently support the attribute group variants of `PutEntity` / `GetEntity` / `MultiGetEntity`, we can still test the corresponding APIs of the underlying `TransactionDB` or `OptimisticTransactionDB` instance. Note: the multi-operation transaction stress test will be handled separately.

Differential Revision: D65780384


