### PR TITLE
Avoid regenerating OPTIONS if no value to update

### DIFF
--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -1274,4 +1274,14 @@ std::vector<std::string> TEST_GetImmutableInMutableCFOptions() {
   return result;
 }
 #endif  // !NDEBUG
+
+bool MutableCFOptionsAreEqual(const MutableCFOptions& this_options,
+                              const MutableCFOptions& that_options) {
+  ConfigOptions config_options;
+  std::string mismatch;
+  return OptionTypeInfo::StructsAreEqual(
+      config_options, "MutableCFOptions", &cf_mutable_options_type_info,
+      "MutableCFOptions", &this_options, &that_options, &mismatch);
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -362,4 +362,7 @@ Status GetMutableOptionsFromStrings(
 std::vector<std::string> TEST_GetImmutableInMutableCFOptions();
 #endif
 
+bool MutableCFOptionsAreEqual(const MutableCFOptions& this_options,
+                              const MutableCFOptions& that_options);
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
# Summary

Similar to PR #8518 , skip updating the options when there's no real value to update.

# Test Plan

./options_test --gtest_filter="*AvoidUpdatingOptions*"