### PR TITLE
Print file number when TEST_VerifyNoObsoleteFilesCached fails

### DIFF
--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -6,8 +6,8 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
-
 #ifndef NDEBUG
+#include <iostream>
 
 #include "db/blob/blob_file_cache.h"
 #include "db/column_family.h"
@@ -379,7 +379,11 @@ void DBImpl::TEST_VerifyNoObsoleteFilesCached(
     uint64_t file_number;
     GetUnaligned(reinterpret_cast<const uint64_t*>(key.data()), &file_number);
     // Assert file is in live/quarantined set
-    assert(live_and_quar_files.find(file_number) != live_and_quar_files.end());
+    if (live_and_quar_files.find(file_number) == live_and_quar_files.end()) {
+      std::cerr << "File " << file_number << " is not live nor quarantined"
+                << std::endl;
+      assert(false);
+    }
   };
   table_cache_->ApplyToAllEntries(fn, {});
 }


### PR DESCRIPTION
**Context/Summary:**

https://github.com/facebook/rocksdb/pull/13117 added check for obsolete SST files that are not cleaned up timely. It caused a infrequent stress test failure  `assertion="live_and_quar_files.find(file_number) != live_and_quar_files.end()"` that I haven't repro-ed yet. 

This PR prints the file number so we can find out what happens to that file through info logs when encountering the same failure. 

**Test:**
Manually fail the assertion and observe the stderr printing
```
[ RUN      ] DBBasicTest.UniqueSession
File 12 is not live nor quarantined
db_basic_test: db/db_impl/db_impl_debug.cc:384: rocksdb::DBImpl::TEST_VerifyNoObsoleteFilesCached(bool) const::<lambda(const rocksdb::Slice&, rocksdb::Cache::ObjectPtr, size_t, const rocksdb::Cache::CacheItemHelper*)>: Assertion `false' failed. 
```