### PR TITLE
Add [set]DailyOffpeakTimeUTC option to Java API

### DIFF
--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -2304,6 +2304,35 @@ jlong Java_org_rocksdb_Options_bgerrorResumeRetryInterval(JNIEnv*, jclass,
 
 /*
  * Class:     org_rocksdb_Options
+ * Method:    setDailyOffpeakTimeUTC
+ * Signature: (JLjava/lang/String;)V
+ */
+void Java_org_rocksdb_Options_setDailyOffpeakTimeUTC(JNIEnv* env, jclass,
+                                                     jlong jhandle,
+                                                     jstring jtimeutc) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  const jsize jtimesz = env->GetStringUTFLength(jtimeutc);
+  const char* timeutc = env->GetStringUTFChars(jtimeutc, nullptr);
+  if (env->ExceptionCheck()) {
+    return;
+  }
+  opt->daily_offpeak_time_utc = std::string(timeutc, jtimesz);
+  env->ReleaseStringUTFChars(jtimeutc, timeutc);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    dailyOffpeakTimeUTC
+ * Signature: (J)Ljava/lang/String;
+ */
+jstring Java_org_rocksdb_Options_dailyOffpeakTimeUTC(JNIEnv* env, jclass,
+                                                     jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return env->NewStringUTF(opt->daily_offpeak_time_utc.c_str());
+}
+
+/*
+ * Class:     org_rocksdb_Options
  * Method:    setAvoidFlushDuringShutdown
  * Signature: (JZ)V
  */
@@ -7876,6 +7905,35 @@ jlong Java_org_rocksdb_DBOptions_bgerrorResumeRetryInterval(JNIEnv*, jclass,
                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->bgerror_resume_retry_interval);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setDailyOffpeakTimeUTC
+ * Signature: (JLjava/lang/String;)V
+ */
+void Java_org_rocksdb_DBOptions_setDailyOffpeakTimeUTC(JNIEnv* env, jclass,
+                                                       jlong jhandle,
+                                                       jstring jtimeutc) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  const jsize jtimesz = env->GetStringUTFLength(jtimeutc);
+  const char* timeutc = env->GetStringUTFChars(jtimeutc, nullptr);
+  if (env->ExceptionCheck()) {
+    return;
+  }
+  opt->daily_offpeak_time_utc = std::string(timeutc, jtimesz);
+  env->ReleaseStringUTFChars(jtimeutc, timeutc);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    dailyOffpeakTimeUTC
+ * Signature: (J)Ljava/lang/String;
+ */
+jstring Java_org_rocksdb_DBOptions_dailyOffpeakTimeUTC(JNIEnv* env, jclass,
+                                                       jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return env->NewStringUTF(opt->daily_offpeak_time_utc.c_str());
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -2311,13 +2311,13 @@ void Java_org_rocksdb_Options_setDailyOffpeakTimeUTC(JNIEnv* env, jclass,
                                                      jlong jhandle,
                                                      jstring jtimeutc) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
-  const jsize jtimesz = env->GetStringUTFLength(jtimeutc);
-  const char* timeutc = env->GetStringUTFChars(jtimeutc, nullptr);
-  if (env->ExceptionCheck()) {
+  jboolean has_exception;
+  auto timeutc =
+      ROCKSDB_NAMESPACE::JniUtil::copyStdString(env, jtimeutc, &has_exception);
+  if (has_exception == JNI_TRUE) {
     return;
   }
-  opt->daily_offpeak_time_utc = std::string(timeutc, jtimesz);
-  env->ReleaseStringUTFChars(jtimeutc, timeutc);
+  opt->daily_offpeak_time_utc = timeutc;
 }
 
 /*

--- a/java/src/main/java/org/rocksdb/AbstractMutableOptions.java
+++ b/java/src/main/java/org/rocksdb/AbstractMutableOptions.java
@@ -196,6 +196,22 @@ public class AbstractMutableOptions {
       return value.asIntArray();
     }
 
+    protected U setString(final K key, final String value) {
+      if (key.getValueType() != MutableOptionKey.ValueType.STRING) {
+        throw new IllegalArgumentException(key + " does not accept a string value");
+      }
+      options.put(key, MutableOptionValue.fromString(value));
+      return self();
+    }
+
+    protected String getString(final K key) {
+      final MutableOptionValue<?> value = options.get(key);
+      if (value == null) {
+        throw new NoSuchElementException(key.name() + HAS_NOT_BEEN_SET);
+      }
+      return value.asString();
+    }
+
     protected <N extends Enum<N>> U setEnum(
         final K key, final N value) {
       if(key.getValueType() != MutableOptionKey.ValueType.ENUM) {
@@ -316,7 +332,8 @@ public class AbstractMutableOptions {
       }
 
       // Check that simple values are the single item in the array
-      if (key.getValueType() != MutableOptionKey.ValueType.INT_ARRAY) {
+      if (key.getValueType() != MutableOptionKey.ValueType.INT_ARRAY
+          && key.getValueType() != MutableOptionKey.ValueType.STRING) {
         {
           if (option.value.list.size() != 1) {
             throw new IllegalArgumentException(
@@ -361,6 +378,8 @@ public class AbstractMutableOptions {
           } else {
             throw new IllegalArgumentException("Unknown enum type: " + key.name());
           }
+        case STRING:
+          return setString(key, option.value.toString());
 
         default:
           throw new IllegalStateException(key + " has unknown value type: " + key.getValueType());

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -760,6 +760,19 @@ public class DBOptions extends RocksObject
   }
 
   @Override
+  public DBOptions setDailyOffpeakTimeUTC(String offpeakTimeUTC) {
+    assert (isOwningHandle());
+    setDailyOffpeakTimeUTC(nativeHandle_, offpeakTimeUTC);
+    return this;
+  }
+
+  @Override
+  public String dailyOffpeakTimeUTC() {
+    assert (isOwningHandle());
+    return dailyOffpeakTimeUTC(nativeHandle_);
+  }
+
+  @Override
   public DBOptions setRandomAccessMaxBufferSize(final long randomAccessMaxBufferSize) {
     assert(isOwningHandle());
     setRandomAccessMaxBufferSize(nativeHandle_, randomAccessMaxBufferSize);
@@ -1348,6 +1361,9 @@ public class DBOptions extends RocksObject
   private static native void setCompactionReadaheadSize(
       final long handle, final long compactionReadaheadSize);
   private static native long compactionReadaheadSize(final long handle);
+  private static native void setDailyOffpeakTimeUTC(
+      final long handle, final String dailyOffpeakTimeUTC);
+  private static native String dailyOffpeakTimeUTC(final long handle);
   private static native void setRandomAccessMaxBufferSize(
       final long handle, final long randomAccessMaxBufferSize);
   private static native long randomAccessMaxBufferSize(final long handle);

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1744,4 +1744,47 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    * @return the instance of the current object.
    */
   long bgerrorResumeRetryInterval();
+
+  /**
+   * Implementing off-peak duration awareness in RocksDB. In this context,
+   * "off-peak time" signifies periods characterized by significantly less read
+   * and write activity compared to other times. By leveraging this knowledge,
+   * we can prevent low-priority tasks, such as TTL-based compactions, from
+   * competing with read and write operations during peak hours. Essentially, we
+   * preprocess these tasks during the preceding off-peak period, just before
+   * the next peak cycle begins. For example, if the TTL is configured for 25
+   * days, we may compact the files during the off-peak hours of the 24th day.
+   *
+   * Time of the day in UTC, start_time-end_time inclusive.
+   * Format - HH:mm-HH:mm (00:00-23:59)
+   * If the start time > end time, it will be considered that the time period
+   * spans to the next day (e.g., 23:30-04:00). To make an entire day off-peak,
+   * use "0:00-23:59". To make an entire day have no offpeak period, leave
+   * this field blank. Default: Empty string (no offpeak).
+   *
+   * @param offpeakTimeUTC String value from which to parse offpeak time range
+   */
+  T setDailyOffpeakTimeUTC(final String offpeakTimeUTC);
+
+  /**
+   *
+   * Implementing off-peak duration awareness in RocksDB. In this context,
+   * "off-peak time" signifies periods characterized by significantly less read
+   * and write activity compared to other times. By leveraging this knowledge,
+   * we can prevent low-priority tasks, such as TTL-based compactions, from
+   * competing with read and write operations during peak hours. Essentially, we
+   * preprocess these tasks during the preceding off-peak period, just before
+   * the next peak cycle begins. For example, if the TTL is configured for 25
+   * days, we may compact the files during the off-peak hours of the 24th day.
+   *
+   * Time of the day in UTC, start_time-end_time inclusive.
+   * Format - HH:mm-HH:mm (00:00-23:59)
+   * If the start time > end time, it will be considered that the time period
+   * spans to the next day (e.g., 23:30-04:00). To make an entire day off-peak,
+   * use "0:00-23:59". To make an entire day have no offpeak period, leave
+   * this field blank. Default: Empty string (no offpeak).
+   *
+   * @return String value of current offpeak time range, "" if none is set.
+   */
+  public String dailyOffpeakTimeUTC();
 }

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1757,7 +1757,7 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    *
    * Time of the day in UTC, start_time-end_time inclusive.
    * Format - HH:mm-HH:mm (00:00-23:59)
-   * If the start time > end time, it will be considered that the time period
+   * If the start time exceeds the end time, it will be considered that the time period
    * spans to the next day (e.g., 23:30-04:00). To make an entire day off-peak,
    * use "0:00-23:59". To make an entire day have no offpeak period, leave
    * this field blank. Default: Empty string (no offpeak).
@@ -1779,7 +1779,7 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    *
    * Time of the day in UTC, start_time-end_time inclusive.
    * Format - HH:mm-HH:mm (00:00-23:59)
-   * If the start time > end time, it will be considered that the time period
+   * If the start time exceeds the end time, it will be considered that the time period
    * spans to the next day (e.g., 23:30-04:00). To make an entire day off-peak,
    * use "0:00-23:59". To make an entire day have no offpeak period, leave
    * this field blank. Default: Empty string (no offpeak).

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1786,5 +1786,5 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    *
    * @return String value of current offpeak time range, "" if none is set.
    */
-  public String dailyOffpeakTimeUTC();
+  String dailyOffpeakTimeUTC();
 }

--- a/java/src/main/java/org/rocksdb/MutableDBOptions.java
+++ b/java/src/main/java/org/rocksdb/MutableDBOptions.java
@@ -76,7 +76,9 @@ public class MutableDBOptions extends AbstractMutableOptions {
     bytes_per_sync(ValueType.LONG),
     wal_bytes_per_sync(ValueType.LONG),
     strict_bytes_per_sync(ValueType.BOOLEAN),
-    compaction_readahead_size(ValueType.LONG);
+    compaction_readahead_size(ValueType.LONG),
+
+    daily_offpeak_time_utc(ValueType.STRING);
 
     private final ValueType valueType;
     DBOption(final ValueType valueType) {
@@ -287,6 +289,16 @@ public class MutableDBOptions extends AbstractMutableOptions {
     @Override
     public long compactionReadaheadSize() {
       return getLong(DBOption.compaction_readahead_size);
+    }
+
+    @Override
+    public MutableDBOptionsBuilder setDailyOffpeakTimeUTC(final String offpeakTimeUTC) {
+      return setString(DBOption.daily_offpeak_time_utc, offpeakTimeUTC);
+    }
+
+    @Override
+    public String dailyOffpeakTimeUTC() {
+      return getString(DBOption.daily_offpeak_time_utc);
     }
   }
 }

--- a/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
@@ -1,6 +1,8 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 package org.rocksdb;
 
+import java.time.LocalTime;
+
 public interface MutableDBOptionsInterface<T extends MutableDBOptionsInterface<T>> {
   /**
    * Specifies the maximum number of concurrent background jobs (both flushes
@@ -437,4 +439,47 @@ public interface MutableDBOptionsInterface<T extends MutableDBOptionsInterface<T
    * @return The compaction read-ahead size
    */
   long compactionReadaheadSize();
+
+  /**
+   * Implementing off-peak duration awareness in RocksDB. In this context,
+   * "off-peak time" signifies periods characterized by significantly less read
+   * and write activity compared to other times. By leveraging this knowledge,
+   * we can prevent low-priority tasks, such as TTL-based compactions, from
+   * competing with read and write operations during peak hours. Essentially, we
+   * preprocess these tasks during the preceding off-peak period, just before
+   * the next peak cycle begins. For example, if the TTL is configured for 25
+   * days, we may compact the files during the off-peak hours of the 24th day.
+   *
+   * Time of the day in UTC, start_time-end_time inclusive.
+   * Format - HH:mm-HH:mm (00:00-23:59)
+   * If the start time > end time, it will be considered that the time period
+   * spans to the next day (e.g., 23:30-04:00). To make an entire day off-peak,
+   * use "0:00-23:59". To make an entire day have no offpeak period, leave
+   * this field blank. Default: Empty string (no offpeak).
+   *
+   * @param offpeakTimeUTC String value from which to parse offpeak time range
+   */
+  T setDailyOffpeakTimeUTC(final String offpeakTimeUTC);
+
+  /**
+   *
+   * Implementing off-peak duration awareness in RocksDB. In this context,
+   * "off-peak time" signifies periods characterized by significantly less read
+   * and write activity compared to other times. By leveraging this knowledge,
+   * we can prevent low-priority tasks, such as TTL-based compactions, from
+   * competing with read and write operations during peak hours. Essentially, we
+   * preprocess these tasks during the preceding off-peak period, just before
+   * the next peak cycle begins. For example, if the TTL is configured for 25
+   * days, we may compact the files during the off-peak hours of the 24th day.
+   *
+   * Time of the day in UTC, start_time-end_time inclusive.
+   * Format - HH:mm-HH:mm (00:00-23:59)
+   * If the start time > end time, it will be considered that the time period
+   * spans to the next day (e.g., 23:30-04:00). To make an entire day off-peak,
+   * use "0:00-23:59". To make an entire day have no offpeak period, leave
+   * this field blank. Default: Empty string (no offpeak).
+   *
+   * @return String value of current offpeak time range, "" if none is set.
+   */
+  String dailyOffpeakTimeUTC();
 }

--- a/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
@@ -452,7 +452,7 @@ public interface MutableDBOptionsInterface<T extends MutableDBOptionsInterface<T
    *
    * Time of the day in UTC, start_time-end_time inclusive.
    * Format - HH:mm-HH:mm (00:00-23:59)
-   * If the start time > end time, it will be considered that the time period
+   * If the start time exceeds the end time, it will be considered that the time period
    * spans to the next day (e.g., 23:30-04:00). To make an entire day off-peak,
    * use "0:00-23:59". To make an entire day have no offpeak period, leave
    * this field blank. Default: Empty string (no offpeak).
@@ -474,7 +474,7 @@ public interface MutableDBOptionsInterface<T extends MutableDBOptionsInterface<T
    *
    * Time of the day in UTC, start_time-end_time inclusive.
    * Format - HH:mm-HH:mm (00:00-23:59)
-   * If the start time > end time, it will be considered that the time period
+   * If the start time exceeds the end time, it will be considered that the time period
    * spans to the next day (e.g., 23:30-04:00). To make an entire day off-peak,
    * use "0:00-23:59". To make an entire day have no offpeak period, leave
    * this field blank. Default: Empty string (no offpeak).

--- a/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
@@ -1,8 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 package org.rocksdb;
 
-import java.time.LocalTime;
-
 public interface MutableDBOptionsInterface<T extends MutableDBOptionsInterface<T>> {
   /**
    * Specifies the maximum number of concurrent background jobs (both flushes

--- a/java/src/main/java/org/rocksdb/MutableOptionKey.java
+++ b/java/src/main/java/org/rocksdb/MutableOptionKey.java
@@ -8,7 +8,9 @@ public interface MutableOptionKey {
     INT,
     BOOLEAN,
     INT_ARRAY,
-    ENUM
+    ENUM,
+    STRING,
+
   }
 
   String name();

--- a/java/src/main/java/org/rocksdb/OptionString.java
+++ b/java/src/main/java/org/rocksdb/OptionString.java
@@ -19,6 +19,8 @@ public class OptionString {
   private static final char wrappedValueEnd = '}';
   private static final char arrayValueSeparator = ':';
 
+  private static final char escapeChar = '\\';
+
   static class Value {
     final List<String> list;
     final List<Entry> complex;
@@ -177,6 +179,9 @@ public class OptionString {
       final List<String> list = new ArrayList<>(1);
       while (true) {
         list.add(parseSimpleValue());
+        if (isChar(escapeChar)) {
+          next();
+        }
         if (!isChar(arrayValueSeparator))
           break;
 

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -848,6 +848,19 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options setDailyOffpeakTimeUTC(String offpeakTimeUTC) {
+    assert (isOwningHandle());
+    setDailyOffpeakTimeUTC(nativeHandle_, offpeakTimeUTC);
+    return this;
+  }
+
+  @Override
+  public String dailyOffpeakTimeUTC() {
+    assert (isOwningHandle());
+    return dailyOffpeakTimeUTC(nativeHandle_);
+  }
+
+  @Override
   public Options setRandomAccessMaxBufferSize(final long randomAccessMaxBufferSize) {
     assert(isOwningHandle());
     setRandomAccessMaxBufferSize(nativeHandle_, randomAccessMaxBufferSize);
@@ -2256,6 +2269,8 @@ public class Options extends RocksObject
   private static native void setCompactionReadaheadSize(
       final long handle, final long compactionReadaheadSize);
   private static native long compactionReadaheadSize(final long handle);
+  private static native void setDailyOffpeakTimeUTC(final long handle, final String offpeakTimeUTC);
+  private static native String dailyOffpeakTimeUTC(final long handle);
   private static native void setRandomAccessMaxBufferSize(
       final long handle, final long randomAccessMaxBufferSize);
   private static native long randomAccessMaxBufferSize(final long handle);

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -1454,6 +1454,16 @@ public class OptionsTest {
   }
 
   @Test
+  public void dailyOffpeakTimeUTC() {
+    try (final Options options = new Options()) {
+      assertThat(options.dailyOffpeakTimeUTC()).isEqualTo("");
+      final String offPeak = "03:45-20:15";
+      assertThat(options.setDailyOffpeakTimeUTC(offPeak)).isEqualTo(options);
+      assertThat(options.dailyOffpeakTimeUTC()).isEqualTo(offPeak);
+    }
+  }
+
+  @Test
   public void eventListeners() {
     final AtomicBoolean wasCalled1 = new AtomicBoolean();
     final AtomicBoolean wasCalled2 = new AtomicBoolean();


### PR DESCRIPTION
Reflect RocksDB DailyOffpeakTimeUTC  option in Java API. As is standard for options, there are a number of different places where this option needs to be added: it is an option, a DB option, and it is mutable (can be changed while running).

The new option is a string value. This requires an extension to the internal MutableDBOptions parse code, which received the entire options string from C++ and parses it on the Java side.