### PR TITLE
Turn Transaction into a pure interface class

### DIFF
--- a/unreleased_history/public_api_changes/transaction_interface.md
+++ b/unreleased_history/public_api_changes/transaction_interface.md
@@ -1,0 +1,1 @@
+The `Transaction` class is now an abstract interface class with no data members, and the methods `Transaction::{SetLogNumber, GetLogNumber, GetName, GetState, SetState, GetId, SetId, GetLastLogNumber}` are now accordingly pure virtuals implemented further down in the class hierarchy.

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -74,7 +74,6 @@ TransactionBaseImpl::TransactionBaseImpl(
                          0 /* default_cf_ts_sz */),
       indexing_enabled_(true) {
   assert(dynamic_cast<DBImpl*>(db_) != nullptr);
-  log_number_ = 0;
   if (dbimpl_->allow_2pc()) {
     InitWriteBatch();
   }

--- a/utilities/transactions/write_prepared_txn.h
+++ b/utilities/transactions/write_prepared_txn.h
@@ -84,7 +84,7 @@ class WritePreparedTxn : public PessimisticTransaction {
   void Initialize(const TransactionOptions& txn_options) override;
   // Override the protected SetId to make it visible to the friend class
   // WritePreparedTxnDB
-  inline void SetId(uint64_t id) override { Transaction::SetId(id); }
+  void SetId(uint64_t id) override { TransactionBaseImpl::SetId(id); }
 
  private:
   friend class WritePreparedTransactionTest_BasicRecoveryTest_Test;


### PR DESCRIPTION
Summary: As groundwork for further work, the patch changes `Transaction` to be an abstract interface class with no data members by moving the current members `log_number_`, `name_`, `txn_state_`, and `id_` (as well as the implementations of the methods accessing them) to `TransactionBaseImpl`. Note that this involves some minor API changes : `SetLogNumber`, `GetLogNumber`, `GetName`, `SetId`, and `GetLastLogNumber` are now pure virtual in `Transaction` instead of non-pure virtual, and `GetState`, `SetState`, and `GetId` are pure virtual instead of non-virtual. The patch also removes an unused protected `Transaction` constructor.

Differential Revision: D66386696


