### PR TITLE
Try to align WritableFileWriter buffered writes

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -271,6 +271,80 @@ TEST_F(ExternalSSTFileBasicTest, Basic) {
   DestroyAndRecreateExternalSSTFilesDir();
 }
 
+TEST_F(ExternalSSTFileBasicTest,AlignedBufferedWrite) {
+  class AlignedWriteFS : public FileSystemWrapper {
+   public:
+
+    explicit AlignedWriteFS(const std::shared_ptr<FileSystem>& _target)
+        : FileSystemWrapper(_target) {}
+    ~AlignedWriteFS() override {}
+    const char* Name() const override { return "AlignedWriteFS"; }
+
+    IOStatus NewWritableFile(const std::string& fname, const FileOptions& opts,
+                             std::unique_ptr<FSWritableFile>* result,
+                             IODebugContext* dbg) override {
+      class AlignedWritableFile : public FSWritableFileOwnerWrapper {
+       public:
+        AlignedWritableFile(std::unique_ptr<FSWritableFile>& file)
+          : FSWritableFileOwnerWrapper(std::move(file)),
+            last_write_(false) {}
+
+        IOStatus Append(const Slice& data, const IOOptions& options,
+                        IODebugContext* dbg) override {
+          EXPECT_FALSE(last_write_);
+          if ((data.size() & (data.size() - 1)) != 0) {
+            last_write_ = true;
+          }
+          return target()->Append(data, options, dbg);
+        }
+
+       private:
+        bool last_write_;
+      };
+
+      std::unique_ptr<FSWritableFile> file;
+      IOStatus s = target()->NewWritableFile(fname, opts, &file, dbg);
+      if (s.ok()) {
+        result->reset(new AlignedWritableFile(file));
+      }
+      return s;
+    }
+  };
+
+  Options options = CurrentOptions();
+  std::shared_ptr<AlignedWriteFS> aligned_fs =
+    std::make_shared<AlignedWriteFS>(env_->GetFileSystem());
+  std::unique_ptr<Env> wrap_env(
+      new CompositeEnvWrapper(options.env, aligned_fs));
+  options.env = wrap_env.get();
+
+  EnvOptions env_options;
+  env_options.writable_file_max_buffer_size = 64 * 1024 * 1024;
+
+  SstFileWriter sst_file_writer(env_options, options);
+
+  // Current file size should be 0 after sst_file_writer init and before open a
+  // file.
+  ASSERT_EQ(sst_file_writer.FileSize(), 0);
+
+  // file1.sst (0 => 99)
+  std::string file1 = sst_files_dir_ + "file1.sst";
+  ASSERT_OK(sst_file_writer.Open(file1));
+  Random r(301);
+  for (int k = 0; k < 16 * 1024; k++) {
+    uint32_t num = 4096 + r.Uniform(8192);
+    std::string random_string = r.RandomString(num);
+    ASSERT_OK(sst_file_writer.Put(Key(k), random_string));
+  }
+  Status s = sst_file_writer.Finish();
+  ASSERT_OK(s) << s.ToString();
+
+  // Current file size should be non-zero after success write.
+  ASSERT_GT(sst_file_writer.FileSize(), 0);
+
+  DestroyAndRecreateExternalSSTFilesDir();
+}
+
 class ChecksumVerifyHelper {
  private:
   Options options_;

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -271,10 +271,9 @@ TEST_F(ExternalSSTFileBasicTest, Basic) {
   DestroyAndRecreateExternalSSTFilesDir();
 }
 
-TEST_F(ExternalSSTFileBasicTest,AlignedBufferedWrite) {
+TEST_F(ExternalSSTFileBasicTest, AlignedBufferedWrite) {
   class AlignedWriteFS : public FileSystemWrapper {
    public:
-
     explicit AlignedWriteFS(const std::shared_ptr<FileSystem>& _target)
         : FileSystemWrapper(_target) {}
     ~AlignedWriteFS() override {}
@@ -286,8 +285,7 @@ TEST_F(ExternalSSTFileBasicTest,AlignedBufferedWrite) {
       class AlignedWritableFile : public FSWritableFileOwnerWrapper {
        public:
         AlignedWritableFile(std::unique_ptr<FSWritableFile>& file)
-          : FSWritableFileOwnerWrapper(std::move(file)),
-            last_write_(false) {}
+            : FSWritableFileOwnerWrapper(std::move(file)), last_write_(false) {}
 
         using FSWritableFileOwnerWrapper::Append;
         IOStatus Append(const Slice& data, const IOOptions& options,
@@ -314,7 +312,7 @@ TEST_F(ExternalSSTFileBasicTest,AlignedBufferedWrite) {
 
   Options options = CurrentOptions();
   std::shared_ptr<AlignedWriteFS> aligned_fs =
-    std::make_shared<AlignedWriteFS>(env_->GetFileSystem());
+      std::make_shared<AlignedWriteFS>(env_->GetFileSystem());
   std::unique_ptr<Env> wrap_env(
       new CompositeEnvWrapper(options.env, aligned_fs));
   options.env = wrap_env.get();

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -289,6 +289,7 @@ TEST_F(ExternalSSTFileBasicTest,AlignedBufferedWrite) {
           : FSWritableFileOwnerWrapper(std::move(file)),
             last_write_(false) {}
 
+        using FSWritableFileOwnerWrapper::Append;
         IOStatus Append(const Slice& data, const IOOptions& options,
                         IODebugContext* dbg) override {
           EXPECT_FALSE(last_write_);

--- a/unreleased_history/performance_improvements/writable_file_writer_align.md
+++ b/unreleased_history/performance_improvements/writable_file_writer_align.md
@@ -1,0 +1,1 @@
+In buffered IO mode, try to align writes on power of 2 if checksum handoff is not enabled for the file type being written.

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -233,8 +233,7 @@ TEST_F(WritableFileWriterTest, IncrementalBuffer) {
 TEST_F(WritableFileWriterTest, AlignedBufferedWrites) {
   class FakeWF : public FSWritableFile {
    public:
-    explicit FakeWF(std::string* _file_data)
-        : file_data_(_file_data) {}
+    explicit FakeWF(std::string* _file_data) : file_data_(_file_data) {}
     ~FakeWF() override = default;
 
     using FSWritableFile::Append;
@@ -302,12 +301,13 @@ TEST_F(WritableFileWriterTest, AlignedBufferedWrites) {
   env_options.writable_file_max_buffer_size = 64 * 1024 * 1024;
   std::string actual;
   std::unique_ptr<FakeWF> wf(new FakeWF(&actual));
-  std::unique_ptr<WritableFileWriter> writer(new WritableFileWriter(
-      std::move(wf), "" /* don't care */, env_options));
+  std::unique_ptr<WritableFileWriter> writer(
+      new WritableFileWriter(std::move(wf), "" /* don't care */, env_options));
 
   std::string target;
   uint32_t left =
-    static_cast<uint32_t>(2 * env_options.writable_file_max_buffer_size);;
+      static_cast<uint32_t>(2 * env_options.writable_file_max_buffer_size);
+  ;
   while (left > 0) {
     uint32_t num = 4096 + r.Uniform(8192);
     num = std::min<uint32_t>(num, left);

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -230,6 +230,98 @@ TEST_F(WritableFileWriterTest, IncrementalBuffer) {
   }
 }
 
+TEST_F(WritableFileWriterTest, AlignedBufferedWrites) {
+  class FakeWF : public FSWritableFile {
+   public:
+    explicit FakeWF(std::string* _file_data)
+        : file_data_(_file_data) {}
+    ~FakeWF() override = default;
+
+    using FSWritableFile::Append;
+    IOStatus Append(const Slice& data, const IOOptions& /*options*/,
+                    IODebugContext* /*dbg*/) override {
+      EXPECT_EQ(data.size() & (data.size() - 1), 0);
+      file_data_->append(data.data(), data.size());
+      size_ += data.size();
+      return IOStatus::OK();
+    }
+    using FSWritableFile::PositionedAppend;
+    IOStatus PositionedAppend(const Slice& data, uint64_t pos,
+                              const IOOptions& /*options*/,
+                              IODebugContext* /*dbg*/) override {
+      EXPECT_TRUE(pos % 512 == 0);
+      EXPECT_TRUE(data.size() % 512 == 0);
+      file_data_->resize(pos);
+      file_data_->append(data.data(), data.size());
+      size_ += data.size();
+      return IOStatus::OK();
+    }
+
+    IOStatus Truncate(uint64_t size, const IOOptions& /*options*/,
+                      IODebugContext* /*dbg*/) override {
+      file_data_->resize(size);
+      return IOStatus::OK();
+    }
+    IOStatus Close(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Flush(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Sync(const IOOptions& /*options*/,
+                  IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    IOStatus Fsync(const IOOptions& /*options*/,
+                   IODebugContext* /*dbg*/) override {
+      return IOStatus::OK();
+    }
+    void SetIOPriority(Env::IOPriority /*pri*/) override {}
+    uint64_t GetFileSize(const IOOptions& /*options*/,
+                         IODebugContext* /*dbg*/) override {
+      return size_;
+    }
+    void GetPreallocationStatus(size_t* /*block_size*/,
+                                size_t* /*last_allocated_block*/) override {}
+    size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const override {
+      return 0;
+    }
+    IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+      return IOStatus::OK();
+    }
+    bool use_direct_io() const override { return false; }
+
+    std::string* file_data_;
+    size_t size_ = 0;
+  };
+
+  Random r(301);
+  EnvOptions env_options;
+  env_options.writable_file_max_buffer_size = 64 * 1024 * 1024;
+  std::string actual;
+  std::unique_ptr<FakeWF> wf(new FakeWF(&actual));
+  std::unique_ptr<WritableFileWriter> writer(new WritableFileWriter(
+      std::move(wf), "" /* don't care */, env_options));
+
+  std::string target;
+  uint32_t left =
+    static_cast<uint32_t>(2 * env_options.writable_file_max_buffer_size);;
+  while (left > 0) {
+    uint32_t num = 4096 + r.Uniform(8192);
+    num = std::min<uint32_t>(num, left);
+    std::string random_string = r.RandomString(num);
+    ASSERT_OK(writer->Append(IOOptions(), Slice(random_string.c_str(), num)));
+    target.append(random_string.c_str(), num);
+    left -= num;
+  }
+  ASSERT_OK(writer->Flush(IOOptions()));
+  ASSERT_OK(writer->Close(IOOptions()));
+  ASSERT_EQ(target.size(), actual.size());
+  ASSERT_EQ(target, actual);
+}
+
 TEST_F(WritableFileWriterTest, BufferWithZeroCapacityDirectIO) {
   EnvOptions env_opts;
   env_opts.use_direct_writes = true;


### PR DESCRIPTION
In buffered IO mode, without checksum calculation for buffered data enabled, try to align writes to the file system on a power of two. This can improve performance, especially on a distributed file system like Warm Storage that does erasure coding and benefits from full stripe writes. We do this by filling up the writable buffer, with a partial append if necessary, before flushing. When checksum calculation for buffered data is enabled, we don't do this since its preferable to not split the data, especially if the caller provides the checksum. We don't guarantee alignment if the caller manually flushes before finishing the file.

Tests:
Add unit tests in file_reader_writer_test and external_sst_file_basic_test.