### PR TITLE
Generalize and move the wide-column Find method to facilitate reuse

### DIFF
--- a/db/wide/wide_column_serialization.cc
+++ b/db/wide/wide_column_serialization.cc
@@ -129,21 +129,6 @@ Status WideColumnSerialization::Deserialize(Slice& input,
   return Status::OK();
 }
 
-WideColumns::const_iterator WideColumnSerialization::Find(
-    const WideColumns& columns, const Slice& column_name) {
-  const auto it =
-      std::lower_bound(columns.cbegin(), columns.cend(), column_name,
-                       [](const WideColumn& lhs, const Slice& rhs) {
-                         return lhs.name().compare(rhs) < 0;
-                       });
-
-  if (it == columns.cend() || it->name() != column_name) {
-    return columns.cend();
-  }
-
-  return it;
-}
-
 Status WideColumnSerialization::GetValueOfDefaultColumn(Slice& input,
                                                         Slice& value) {
   WideColumns columns;

--- a/db/wide/wide_column_serialization.h
+++ b/db/wide/wide_column_serialization.h
@@ -47,8 +47,6 @@ class WideColumnSerialization {
 
   static Status Deserialize(Slice& input, WideColumns& columns);
 
-  static WideColumns::const_iterator Find(const WideColumns& columns,
-                                          const Slice& column_name);
   static Status GetValueOfDefaultColumn(Slice& input, Slice& value);
 
   static constexpr uint32_t kCurrentVersion = 1;

--- a/db/wide/wide_column_serialization_test.cc
+++ b/db/wide/wide_column_serialization_test.cc
@@ -5,6 +5,7 @@
 
 #include "db/wide/wide_column_serialization.h"
 
+#include "db/wide/wide_columns_helper.h"
 #include "test_util/testharness.h"
 #include "util/coding.h"
 
@@ -99,27 +100,28 @@ TEST(WideColumnSerializationTest, SerializeDeserialize) {
   ASSERT_EQ(columns, deserialized_columns);
 
   {
-    const auto it = WideColumnSerialization::Find(deserialized_columns, "foo");
+    const auto it = WideColumnsHelper::Find(deserialized_columns.cbegin(),
+                                            deserialized_columns.cend(), "foo");
     ASSERT_NE(it, deserialized_columns.cend());
     ASSERT_EQ(*it, deserialized_columns.front());
   }
 
   {
-    const auto it =
-        WideColumnSerialization::Find(deserialized_columns, "hello");
+    const auto it = WideColumnsHelper::Find(
+        deserialized_columns.cbegin(), deserialized_columns.cend(), "hello");
     ASSERT_NE(it, deserialized_columns.cend());
     ASSERT_EQ(*it, deserialized_columns.back());
   }
 
   {
-    const auto it =
-        WideColumnSerialization::Find(deserialized_columns, "fubar");
+    const auto it = WideColumnsHelper::Find(
+        deserialized_columns.cbegin(), deserialized_columns.cend(), "fubar");
     ASSERT_EQ(it, deserialized_columns.cend());
   }
 
   {
-    const auto it =
-        WideColumnSerialization::Find(deserialized_columns, "snafu");
+    const auto it = WideColumnsHelper::Find(
+        deserialized_columns.cbegin(), deserialized_columns.cend(), "snafu");
     ASSERT_EQ(it, deserialized_columns.cend());
   }
 }

--- a/db/wide/wide_columns_helper.cc
+++ b/db/wide/wide_columns_helper.cc
@@ -5,7 +5,6 @@
 
 #include "db/wide/wide_columns_helper.h"
 
-#include <algorithm>
 #include <ios>
 
 #include "db/wide/wide_column_serialization.h"
@@ -40,13 +39,6 @@ Status WideColumnsHelper::DumpSliceAsWideColumns(const Slice& value,
     DumpWideColumns(columns, os, hex);
   }
   return s;
-}
-
-void WideColumnsHelper::SortColumns(WideColumns& columns) {
-  std::sort(columns.begin(), columns.end(),
-            [](const WideColumn& lhs, const WideColumn& rhs) {
-              return lhs.name().compare(rhs.name()) < 0;
-            });
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: The patch moves `WideColumnSerialization::Find` to `WideColumnsHelper` to facilitate reuse in non-serialization-related contexts. It also generalizes the method to take a range of iterators, and templatizes it on the iterator type to enable using it with both `const` and non-`const` iterators. Finally, it adds an assertion to ensure the method is called with a properly sorted range, which is a precondition for binary search.

Differential Revision: D66602558


