### PR TITLE
Potential fix for heap use-after-free issue

### DIFF
--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -521,8 +521,7 @@ class FilePrefetchBuffer {
     if (!s.ok()) {
       return s;
     }
-    buf->buffer_.SetBuffer(read_req.result.size(),
-                           std::move(read_req.fs_scratch));
+    buf->buffer_.SetBuffer(read_req.result, std::move(read_req.fs_scratch));
     buf->offset_ = offset;
     buf->initial_end_offset_ = offset + read_req.result.size();
     result = read_req.result;
@@ -552,8 +551,7 @@ class FilePrefetchBuffer {
   bool TryReadFromCacheUntracked(const IOOptions& opts,
                                  RandomAccessFileReader* reader,
                                  uint64_t offset, size_t n, Slice* result,
-                                 Status* s,
-                                 bool for_compaction = false);
+                                 Status* s, bool for_compaction = false);
 
   void ReadAheadSizeTuning(BufferInfo* buf, bool read_curr_block,
                            bool refit_tail, bool use_fs_buffer,

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -116,12 +116,13 @@ class AlignedBuffer {
   // Points the buffer to new_buf (taking ownership) without allocating extra
   // memory or performing any data copies. This method is called when we want to
   // reuse the buffer provided by the file system
-  void SetBuffer(size_t size, FSAllocationPtr&& new_buf) {
+  void SetBuffer(size_t size, FSAllocationPtr new_buf) {
     alignment_ = 1;
     capacity_ = size;
     cursize_ = size;
-    bufstart_ = reinterpret_cast<char*>(new_buf.get());
     buf_ = std::move(new_buf);
+    assert(buf_.get() != nullptr);
+    bufstart_ = reinterpret_cast<char*>(buf_.get());
   }
 
   // Allocates a new buffer and sets the start position to the first aligned

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -116,13 +116,13 @@ class AlignedBuffer {
   // Points the buffer to new_buf (taking ownership) without allocating extra
   // memory or performing any data copies. This method is called when we want to
   // reuse the buffer provided by the file system
-  void SetBuffer(size_t size, FSAllocationPtr new_buf) {
+  void SetBuffer(Slice& result, FSAllocationPtr new_buf) {
     alignment_ = 1;
-    capacity_ = size;
-    cursize_ = size;
+    capacity_ = result.size();
+    cursize_ = result.size();
     buf_ = std::move(new_buf);
     assert(buf_.get() != nullptr);
-    bufstart_ = reinterpret_cast<char*>(buf_.get());
+    bufstart_ = const_cast<char*>(result.data());
   }
 
   // Allocates a new buffer and sets the start position to the first aligned


### PR DESCRIPTION
# Summary

This PR is an attempt to address #13118. The warm storage crash tests show use-after-free errors. They do not occur in every single crash test run, but with enough attempts, they are repeatable.

Theory 1:
I am wondering if the `fs_buffer` is being prematurely freed before we take ownership of it. In `SetBuffer`, I was passing in `FSAllocationPtr&& new_buf` rather than `FSAllocationPtr new_buf`. When I pass the parameter as `FSAllocationPtr&& new_buf`, only after the `buf_ = std::move(new_buf);` line is run is ownership transferred from the original `FSAllocationPtr`. But before that I had a line `bufstart_ = reinterpret_cast<char*>(buf_.get());`. So I am hypothesizing that it is possible, under certain race conditions, that between the first `buf_.get()` and the `buf_ = std::move(new_buf);`, the `fs_buffer` was altered, leaving `bufstart_` pointing to some freed memory area.

Theory 2 (from @anand1976):
Perhaps we need to set the `bufstart_` based on the `Slice` rather than the `FSAllocationPtr`. This would be more consistent with what we do here https://github.com/facebook/rocksdb/blob/main/table/block_fetcher.cc#L275.

# Test Plan

The existing unit tests and CI ensures I am not making anything worse, but I will want to wait and see if the daily crash tests runs still have the same `heap-use-after-free` errors with this change. Alternatively, if we fail the `assert` I just added, then I can make a follow-up PR to return `false` from `TryReadFromCache` whenever we get handed back a `nullptr`.