### PR TITLE
Unify compaction prefetching logic

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -772,7 +772,7 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     const IOOptions& opts, RandomAccessFileReader* reader, uint64_t offset,
     size_t n, Slice* result, Status* status, bool for_compaction) {
   // We disallow async IO for compaction reads since they are performed in
-  // the background anyways and are less latency sensitive compareed to
+  // the background anyways and are less latency sensitive compared to
   // user-initiated reads
   (void)for_compaction;
   assert(!for_compaction || num_buffers_ == 1);
@@ -854,7 +854,8 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     } else {
       return false;
     }
-  } else {
+  } else if (!for_compaction) {
+    // These stats are meant to track prefetch effectiveness for user reads only
     UpdateStats(/*found_in_buffer=*/true, n);
   }
 

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -771,6 +771,12 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
 bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     const IOOptions& opts, RandomAccessFileReader* reader, uint64_t offset,
     size_t n, Slice* result, Status* status, bool for_compaction) {
+  // We disallow async IO for compaction reads since they are performed in
+  // the background anyways and are less latency sensitive compareed to
+  // user-initiated reads
+  (void)for_compaction;
+  assert(!for_compaction || num_buffers_ == 1);
+
   if (track_min_offset_ && offset < min_offset_read_) {
     min_offset_read_ = static_cast<size_t>(offset);
   }
@@ -819,39 +825,22 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
       assert(reader != nullptr);
       assert(max_readahead_size_ >= readahead_size_);
 
-      // We disallow async IO for compaction reads since their
-      // latencies are not user-visible
-      if (for_compaction) {
-        assert(num_buffers_ == 1);
-        // The readahead size for compaction reads is different and the
-        // historical reason is not clear at the moment. TODO: revisit whether
-        // we want to just use the "regular" logic and readahead by the full
-        // readahize_size_.
-        uint64_t trimmed_readahead_size = 0;
-        if (n < readahead_size_) {
-          trimmed_readahead_size = readahead_size_ - n;
+      if (implicit_auto_readahead_) {
+        if (!IsEligibleForPrefetch(offset, n)) {
+          // Ignore status as Prefetch is not called.
+          s.PermitUncheckedError();
+          return false;
         }
-        s = PrefetchInternal(opts, reader, offset, n, trimmed_readahead_size,
-                             copy_to_overlap_buffer);
-      } else {
-        if (implicit_auto_readahead_) {
-          if (!IsEligibleForPrefetch(offset, n)) {
-            // Ignore status as Prefetch is not called.
-            s.PermitUncheckedError();
-            return false;
-          }
-        }
-
-        // Prefetch n + readahead_size_/2 synchronously as remaining
-        // readahead_size_/2 will be prefetched asynchronously if num_buffers_
-        // > 1.
-        s = PrefetchInternal(
-            opts, reader, offset, n,
-            (num_buffers_ > 1 ? readahead_size_ / 2 : readahead_size_),
-            copy_to_overlap_buffer);
-        explicit_prefetch_submitted_ = false;
       }
 
+      // Prefetch n + readahead_size_/2 synchronously as remaining
+      // readahead_size_/2 will be prefetched asynchronously if num_buffers_
+      // > 1.
+      s = PrefetchInternal(
+          opts, reader, offset, n,
+          (num_buffers_ > 1 ? readahead_size_ / 2 : readahead_size_),
+          copy_to_overlap_buffer);
+      explicit_prefetch_submitted_ = false;
       if (!s.ok()) {
         if (status) {
           *status = s;
@@ -865,7 +854,7 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     } else {
       return false;
     }
-  } else if (!for_compaction) {
+  } else {
     UpdateStats(/*found_in_buffer=*/true, n);
   }
 

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -821,7 +821,8 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
       assert(max_readahead_size_ >= readahead_size_);
 
       if (for_compaction) {
-        s = Prefetch(opts, reader, offset, std::max(n, readahead_size_));
+        s = PrefetchInternal(opts, reader, offset, std::max(n, readahead_size_),
+                             0, copy_to_overlap_buffer);
       } else {
         if (implicit_auto_readahead_) {
           if (!IsEligibleForPrefetch(offset, n)) {

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -865,6 +865,7 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
   }
   assert(buf->offset_ <= offset);
   uint64_t offset_in_buffer = offset - buf->offset_;
+  assert(n <= buf->CurrentSize() - offset_in_buffer);
   *result = Slice(buf->buffer_.BufferStart() + offset_in_buffer, n);
   if (prefetched) {
     readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -865,7 +865,7 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     buf = overlap_buf_;
   }
   if (offset < buf->offset_) {
-    fprintf(stderr,
+    fprintf(stdout,
             "Requested offset %" PRIu64 " is less than buffer offset %" PRIu64
             ". UseFSBuffer(reader)=%d\n",
             offset, buf->offset_, UseFSBuffer(reader));
@@ -873,14 +873,6 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     return false;
   }
   uint64_t offset_in_buffer = offset - buf->offset_;
-  if (buf->CurrentSize() - offset_in_buffer < n) {
-    fprintf(stderr,
-            "Insufficient room in buffer. Only have %" PRIu64
-            " but need %lu. UseFSBuffer(reader)=%d\n",
-            buf->CurrentSize() - offset_in_buffer, n, UseFSBuffer(reader));
-    assert(false);
-    return false;
-  }
   *result = Slice(buf->buffer_.BufferStart() + offset_in_buffer, n);
   if (prefetched) {
     readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -11,7 +11,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cinttypes>
 
 #include "file/random_access_file_reader.h"
 #include "monitoring/histogram.h"
@@ -824,6 +823,10 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
       // latencies are not user-visible
       if (for_compaction) {
         assert(num_buffers_ == 1);
+        // The readahead size for compaction reads is different and the
+        // historical reason is not clear at the moment. TODO: revisit whether
+        // we want to just use the "regular" logic and readahead by the full
+        // readahize_size_.
         uint64_t trimmed_readahead_size = 0;
         if (n < readahead_size_) {
           trimmed_readahead_size = readahead_size_ - n;

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -865,6 +865,7 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
     buf = overlap_buf_;
   }
   assert(buf->offset_ <= offset);
+  assert(buf->IsDataBlockInBuffer(offset, n));
   uint64_t offset_in_buffer = offset - buf->offset_;
   *result = Slice(buf->buffer_.BufferStart() + offset_in_buffer, n);
   if (prefetched) {

--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -864,14 +864,7 @@ bool FilePrefetchBuffer::TryReadFromCacheUntracked(
   if (copy_to_overlap_buffer) {
     buf = overlap_buf_;
   }
-  if (offset < buf->offset_) {
-    fprintf(stdout,
-            "Requested offset %" PRIu64 " is less than buffer offset %" PRIu64
-            ". UseFSBuffer(reader)=%d\n",
-            offset, buf->offset_, UseFSBuffer(reader));
-    assert(false);
-    return false;
-  }
+  assert(buf->offset_ <= offset);
   uint64_t offset_in_buffer = offset - buf->offset_;
   *result = Slice(buf->buffer_.BufferStart() + offset_in_buffer, n);
   if (prefetched) {

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -3539,9 +3539,11 @@ TEST_P(FSBufferPrefetchTest, FSBufferPrefetchStatsInternals) {
   ASSERT_TRUE(fpb.TryReadFromCache(IOOptions(), r.get(), 8192 /* offset */,
                                    8192 /* n */, &result, &s, for_compaction));
   ASSERT_EQ(s, Status::OK());
-  ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_HITS), 0);
-  ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_BYTES_USEFUL),
-            4096);  // 8192-12288
+  if (!for_compaction) {
+    ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_HITS), 0);
+    ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_BYTES_USEFUL),
+              4096);  // 8192-12288
+  }
 
   ASSERT_EQ(strncmp(result.data(), content.substr(8192, 8192).c_str(), 8192),
             0);
@@ -3577,9 +3579,11 @@ TEST_P(FSBufferPrefetchTest, FSBufferPrefetchStatsInternals) {
                                    4096 /* n */, &result, &s, for_compaction));
   ASSERT_EQ(s, Status::OK());
 
-  ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_HITS), 1);
-  ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_BYTES_USEFUL),
-            4096);  // 12288-16384
+  if (!for_compaction) {
+    ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_HITS), 1);
+    ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_BYTES_USEFUL),
+              4096);  // 12288-16384
+  }
 
   ASSERT_EQ(strncmp(result.data(), content.substr(12288, 4096).c_str(), 4096),
             0);
@@ -3611,10 +3615,12 @@ TEST_P(FSBufferPrefetchTest, FSBufferPrefetchStatsInternals) {
                                    10000 /* n */, &result, &s, for_compaction));
   ASSERT_EQ(s, Status::OK());
 
-  ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_HITS), 0);
-  ASSERT_EQ(
-      stats->getAndResetTickerCount(PREFETCH_BYTES_USEFUL),
-      /* 24576(end offset of the buffer) - 16000(requested offset) =*/8576);
+  if (!for_compaction) {
+    ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_HITS), 0);
+    ASSERT_EQ(
+        stats->getAndResetTickerCount(PREFETCH_BYTES_USEFUL),
+        /* 24576(end offset of the buffer) - 16000(requested offset) =*/8576);
+  }
 
   ASSERT_EQ(strncmp(result.data(), content.substr(16000, 10000).c_str(), 10000),
             0);


### PR DESCRIPTION
# Summary

In https://github.com/facebook/rocksdb/pull/13177, I discussed an unsigned integer overflow issue that affects compaction reads inside `FilePrefetchBuffer` when we attempt to enable the file system buffer reuse optimization. In that PR, I disabled the optimization whenever `for_compaction` was `true` to eliminate the source of the bug.

**This PR safely re-enables the optimization when `for_compaction` is `true`.** We need to properly set the overlap buffer through `PrefetchInternal` rather than simply calling `Prefetch`. `Prefetch` assumes `num_buffers_` is 1 (i.e. async IO is disabled), so historically it did not have any overlap buffer logic. What ends up happening (with the old bug) is that, when we try to reuse the file system provided buffer, inside the `Prefetch` method, we read the remaining missing data. However, since we do not do any `RefitTail` method when `use_fs_buffer` is true, normally we would rely on copying the partial relevant data into an overlap buffer. That overlap buffer logic was missing, so the final main buffer ends up storing data from an offset that is greater than the requested offset, and we effectively end up "throwing away" part of the requested data.

**This PR also unifies the prefetching logic for compaction and non-compaction reads:**
- The same readahead size is used. Previously, we read only `std::max(n, readahead_size_)` bytes for compaction reads, rather than `n + readahead_size_` bytes
- The stats for `PREFETCH_HITS` and `PREFETCH_BYTES_USEFUL` are tracked for both. Previously, they were only tracked for non-compaction reads.

These two small changes should help reduce some of the cognitive load required to understand the codebase. The test suite also became easier to maintain. We could not come up with good reasons why the logic for the readahead size and stats should be different for compaction reads.

# Test Plan

I removed the temporary test case from #13200 and incorporated the same test cases into my updated parameterized test case, which tests the valid combinations between `use_async_prefetch` and `for_compaction`.

I went further and added a randomized test case that will simply try to hit `assert`ion failures and catch any missing areas in the logic.

I also added a test case for compaction reads _without_ the file system buffer reuse optimization. I am thinking that it may be valuable to make a future PR that unifies a lot of these prefetch tests and parametrizes as much of them as possible. This way we can avoid writing duplicate tests and just look over different parameters for async IO, direct IO, file system buffer reuse, and `for_compaction`.