### PR TITLE
Remove deprecated remote compaction apis

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -531,25 +531,6 @@ class CompactionService : public Customizable {
   virtual void OnInstallation(const std::string& /*scheduled_job_id*/,
                               CompactionServiceJobStatus /*status*/) {}
 
-  // Deprecated. Please implement Schedule() and Wait() API to handle remote
-  // compaction
-
-  // Start the remote compaction with `compaction_service_input`, which can be
-  // passed to `DB::OpenAndCompact()` on the remote side. `info` provides the
-  // information the user might want to know, which includes `job_id`.
-  virtual CompactionServiceJobStatus StartV2(
-      const CompactionServiceJobInfo& /*info*/,
-      const std::string& /*compaction_service_input*/) {
-    return CompactionServiceJobStatus::kUseLocal;
-  }
-
-  // Wait for remote compaction to finish.
-  virtual CompactionServiceJobStatus WaitForCompleteV2(
-      const CompactionServiceJobInfo& /*info*/,
-      std::string* /*compaction_service_result*/) {
-    return CompactionServiceJobStatus::kUseLocal;
-  }
-
   ~CompactionService() override = default;
 };
 

--- a/unreleased_history/public_api_changes/old_remote_compaction_api_removal.md
+++ b/unreleased_history/public_api_changes/old_remote_compaction_api_removal.md
@@ -1,0 +1,1 @@
+Deprecated Remote Compaction APIs (StartV2, WaitForCompleteV2) are completely removed from the codebase


### PR DESCRIPTION
# Summary

`StartV2()` and `WaitForCompleteV2()` were deprecated and replaced by`Schedule()` and `Wait()` in 9.1.0. This PR removes them from the codebase completely.

# Test Plan

CI