### PR TITLE
Add comment clarifying proper use of fs_scratch

### DIFF
--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -113,15 +113,18 @@ class AlignedBuffer {
     alignment_ = alignment;
   }
 
-  // Points the buffer to new_buf (taking ownership) without allocating extra
-  // memory or performing any data copies. This method is called when we want to
-  // reuse the buffer provided by the file system
+  // Points the buffer to the result without allocating extra
+  // memory or performing any data copies. Takes ownership of the
+  // FSAllocationPtr. This method is called when we want to reuse the buffer
+  // provided by the file system
   void SetBuffer(Slice& result, FSAllocationPtr new_buf) {
     alignment_ = 1;
     capacity_ = result.size();
     cursize_ = result.size();
     buf_ = std::move(new_buf);
     assert(buf_.get() != nullptr);
+    // Note: bufstart_ must point to result.data() and not new_buf, which can
+    // point to any arbitrary object
     bufstart_ = const_cast<char*>(result.data());
   }
 


### PR DESCRIPTION
# Summary

https://github.com/facebook/rocksdb/pull/13182 seems to have resolved the `heap-use-after-free` / `heap-buffer-overflow` issues, but not for the reasons we had in mind.

I believe I have figured out the root cause after doing more thinking / reading into the warm storage code.

**`fs_scratch` cannot be assumed to point to the start of the data buffer. It must be treated as a pointer to any arbitrary object / data structure. As such, we must rely only on result.data().**

I think that part of the reason for the bug was that the comment for `fs_scratch` was 

> fs_scratch is a data buffer allocated and provided by underlying FileSystem

which is _extremely misleading_.

To avoid confusion in the future, I have updated the comments related to `FsReadRequest` with some of my learnings and included `WARNING`s in all caps to hopefully steer future engineers aware from the same issue.

In another PR, I will update some of our mock file system test classes that support `FSSupportedOps::kFSBuffer`. The test class implementation also contributed to my confusion, since `fs_scratch` did point to the start of the valid data in those implementations. This cannot and should not be assumed to be true in general, and we should try to guard against potential future bugs by updating those mock implementations.

# Test Plan

These are just comments.