### PR TITLE
rocksdb/db.h: GetDbIdentity comment: ID comes from MANIFEST

### DIFF
--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -2108,15 +2108,15 @@ class DB {
 
   virtual Status VerifyChecksum() { return VerifyChecksum(ReadOptions()); }
 
-  // Returns the unique ID which is read from IDENTITY file during the opening
-  // of database by setting in the identity variable
-  // Returns Status::OK if identity could be set properly
+  // Copies the database's unique ID into identity. The ID is read from the
+  // MANIFEST file when opening the database. See the write_dbid_to_manifest
+  // option for details. Returns Status::OK if identity was set.
   virtual Status GetDbIdentity(std::string& identity) const = 0;
 
   // Return a unique identifier for each DB object that is opened
   // This DB session ID should be unique among all open DB instances on all
   // hosts, and should be unique among re-openings of the same or other DBs.
-  // (Two open DBs have the same identity from other function GetDbIdentity when
+  // (Two open DBs have the same identity from GetDbIdentity when
   // one is physically copied from the other.)
   virtual Status GetDbSessionId(std::string& session_id) const = 0;
 


### PR DESCRIPTION
Commit 98c33cb8e3 changed the default for the write_dbid_to_manifest option, so this ID now comes from MANIFEST and not IDENTITY. Update the comment to reflect that.

Remove 2 unneeded words from the comment on GetDbSessionId since it refers to this function.