### PR TITLE
Some of this code did not compile at all on G++

### DIFF
--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -2066,6 +2066,19 @@ static int XXH_isLittleEndian(void)
 #  define XXH_HAS_BUILTIN(x) 0
 #endif
 
+namespace std{
+[[noreturn]] inline void unreachable()
+{
+    // Uses compiler specific extensions if possible.
+    // Even if no extension is used, undefined behavior is still raised by
+    // an empty function body and the noreturn attribute.
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC
+    __assume(false);
+#else // GCC, Clang
+    __builtin_unreachable();
+#endif
+}
+}
 
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ > 201710L)
 /* C23 and future versions have standard "unreachable()" */

--- a/utilities/transactions/optimistic_transaction_db_impl.cc
+++ b/utilities/transactions/optimistic_transaction_db_impl.cc
@@ -102,7 +102,7 @@ Status OptimisticTransactionDB::Open(
 void OptimisticTransactionDBImpl::ReinitializeTransaction(
     Transaction* txn, const WriteOptions& write_options,
     const OptimisticTransactionOptions& txn_options) {
-  assert(dynamic_cast<OptimisticTransaction*>(txn) != nullptr);
+//  assert(dynamic_cast<OptimisticTransaction*>(txn) != nullptr);
   auto txn_impl = static_cast<OptimisticTransaction*>(txn);
 
   txn_impl->Reinitialize(this, write_options, txn_options);

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -73,7 +73,7 @@ TransactionBaseImpl::TransactionBaseImpl(
                          write_options.protection_bytes_per_key,
                          0 /* default_cf_ts_sz */),
       indexing_enabled_(true) {
-  assert(dynamic_cast<DBImpl*>(db_) != nullptr);
+//  assert(dynamic_cast<DBImpl*>(db_) != nullptr);
   log_number_ = 0;
   if (dbimpl_->allow_2pc()) {
     InitWriteBatch();
@@ -897,7 +897,7 @@ Status TransactionBaseImpl::RebuildFromWriteBatch(WriteBatch* src_batch) {
     DBImpl* db_;
     IndexedWriteBatchBuilder(Transaction* txn, DBImpl* db)
         : txn_(txn), db_(db) {
-      assert(dynamic_cast<TransactionBaseImpl*>(txn_) != nullptr);
+//      assert(dynamic_cast<TransactionBaseImpl*>(txn_) != nullptr);
     }
 
     Status PutCF(uint32_t cf, const Slice& key, const Slice& val) override {


### PR DESCRIPTION
Some issues met while compiling on G++:
 * unreachable was not defined, not even in utility, thus even including this before [this](https://github.com/facebook/rocksdb/compare/main...LogDS:rocksdb:main?expand=1#diff-0d4398f04849a257749982d9dc2139f160f8849db279844a873db5f4faa119a9R2089) line did not help. I had to include the explicit definition of it.
 * When the compiler is on no rtti mode, dynamic casts are not allowed.