### PR TITLE
Update test implementations for MultiRead with fs_scratch reuse

### DIFF
--- a/db/db_io_failure_test.cc
+++ b/db/db_io_failure_test.cc
@@ -97,12 +97,20 @@ class CorruptionFS : public FileSystemWrapper {
         for (size_t i = 0; i < num_reqs; ++i) {
           FSReadRequest& req = reqs[i];
           if (fs_.fs_buffer_) {
-            FSAllocationPtr buffer(new char[req.len], [](void* ptr) {
-              delete[] static_cast<char*>(ptr);
-            });
-            req.fs_scratch = std::move(buffer);
+            // See https://github.com/facebook/rocksdb/pull/13195 for why we
+            // want to set up our test implementation for FSAllocationPtr this
+            // way.
+            char* internalData = new char[req.len];
             req.status = Read(req.offset, req.len, options, &req.result,
-                              static_cast<char*>(req.fs_scratch.get()), dbg);
+                              internalData, dbg);
+
+            Slice* internalSlice = new Slice(internalData, req.len);
+            FSAllocationPtr internalPtr(internalSlice, [](void* ptr) {
+              delete[] static_cast<const char*>(
+                  static_cast<Slice*>(ptr)->data_);
+              delete static_cast<Slice*>(ptr);
+            });
+            req.fs_scratch = std::move(internalPtr);
           } else {
             req.status = Read(req.offset, req.len, options, &req.result,
                               req.scratch, dbg);


### PR DESCRIPTION
# Summary

This is a follow up to #13189. As mentioned in the description in the previous PR, to guard against similar bugs in the future, we should update our test implementations to reflect the real-world assumptions that we can make about `fs_scratch` when we issue reads with the filesystem buffer reuse optimization. The current test implementations reinforce the misconception that `fs_scratch` points to the same place as `result.data()` (i.e. to the start of the valid data buffer for the read result). `fs_scratch` can point to any arbitrary data structure, but for our purposes, I think we achieve what we want if we just have it point to a `Slice` which wraps the underlying result buffer inside one of its class variables.

# Test Plan

Existing unit tests test the same functionality but in an improved way with this change.