### PR TITLE
Refresh check_buck_targets.sh

### DIFF
--- a/buckifier/check_buck_targets.sh
+++ b/buckifier/check_buck_targets.sh
@@ -4,6 +4,7 @@
 if [[ ! -f "BUCK" ]]
 then
   echo "BUCK file is missing!"
+  echo "Please do not remove / rename BUCK file in your commit(s)."
   exit 1
 fi
 
@@ -23,8 +24,8 @@ ${PYTHON:-python3} buckifier/buckify_rocksdb.py
 
 if [[ ! -f "BUCK" ]]
 then
-  echo "buckifier/buckify_rocksdb.py was expected to (re)generate BUCK file."
-  echo "BUCK file is missing!"
+  echo "BUCK file went missing after running buckifier/buckify_rocksdb.py!"
+  echo "Please do not remove the BUCK file."
   exit 1
 fi
 

--- a/buckifier/check_buck_targets.sh
+++ b/buckifier/check_buck_targets.sh
@@ -3,30 +3,30 @@
 # If clang_format_diff.py command is not specfied, we assume we are able to
 # access directly without any path.
 
-TGT_DIFF=`git diff TARGETS | head -n 1`
+TGT_DIFF=`git diff BUCK | head -n 1`
 
 if [ ! -z "$TGT_DIFF" ]
 then
-  echo "TARGETS file has uncommitted changes. Skip this check."
+  echo "BUCK file has uncommitted changes. Skip this check."
   exit 0
 fi
 
-echo Backup original TARGETS file.
+echo Backup original BUCK file.
 
-cp TARGETS TARGETS.bkp
+cp BUCK BUCK.bkp
 
 ${PYTHON:-python3} buckifier/buckify_rocksdb.py
 
-TGT_DIFF=`git diff TARGETS | head -n 1`
+TGT_DIFF=`git diff BUCK | head -n 1`
 
 if [ -z "$TGT_DIFF" ]
 then
-  mv TARGETS.bkp TARGETS
+  mv BUCK.bkp BUCK
   exit 0
 else
-  echo "Please run '${PYTHON:-python3} buckifier/buckify_rocksdb.py' to update TARGETS file."
-  echo "Do not manually update TARGETS file."
+  echo "Please run '${PYTHON:-python3} buckifier/buckify_rocksdb.py' to update BUCK file."
+  echo "Do not manually update BUCK file."
   ${PYTHON:-python3} --version
-  mv TARGETS.bkp TARGETS
+  mv BUCK.bkp BUCK
   exit 1
 fi

--- a/buckifier/check_buck_targets.sh
+++ b/buckifier/check_buck_targets.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-# If clang_format_diff.py command is not specfied, we assume we are able to
-# access directly without any path.
 
 TGT_DIFF=`git diff BUCK | head -n 1`
 
@@ -16,6 +14,13 @@ echo Backup original BUCK file.
 cp BUCK BUCK.bkp
 
 ${PYTHON:-python3} buckifier/buckify_rocksdb.py
+
+if [[ ! -f "BUCK" ]]
+then
+  echo "buckifier/buckify_rocksdb.py was expected to (re)generate BUCK file."
+  echo "BUCK file is missing!"
+  exit 1
+fi
 
 TGT_DIFF=`git diff BUCK | head -n 1`
 

--- a/buckifier/check_buck_targets.sh
+++ b/buckifier/check_buck_targets.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
+if [[ ! -f "BUCK" ]]
+then
+  echo "BUCK file is missing!"
+  exit 1
+fi
+
 TGT_DIFF=`git diff BUCK | head -n 1`
 
 if [ ! -z "$TGT_DIFF" ]


### PR DESCRIPTION
### Summary:
This is a followup to #13190. We're patching the targets generating script to construct `BUCK` file instead of deprecated `TARGETS` file + adding safety checks to ensure that `BUCK` file does not go missing (either as a direct renaming / removal OR as a modification to buckfier's script(s)).

### Test plan:
1. Manually verify 'Compare buckify output' step produces expected results (vs previously soft-failed one [here](https://github.com/facebook/rocksdb/actions/runs/12202756083/job/34044173548?pr=13178)).
2. Manually test following scenarios (for both of which we expect the buckifier script to fail):
-> Simulate removing `BUCK` file via commit
-> Simulate buckifier script removing the `BUCK` file