### PR TITLE
Explicitly mark destructors with override

### DIFF
--- a/include/rocksdb/utilities/table_properties_collectors.h
+++ b/include/rocksdb/utilities/table_properties_collectors.h
@@ -33,7 +33,7 @@ class CompactOnDeletionCollectorFactory
                                     size_t deletion_trigger,
                                     double deletion_ratio);
 
-  ~CompactOnDeletionCollectorFactory() {}
+  ~CompactOnDeletionCollectorFactory() override {}
 
   TablePropertiesCollector* CreateTablePropertiesCollector(
       TablePropertiesCollectorFactory::Context context) override;
@@ -108,7 +108,7 @@ class CompactForTieringCollectorFactory
   // for what entry is eligible.
   CompactForTieringCollectorFactory(double compaction_trigger_ratio);
 
-  ~CompactForTieringCollectorFactory() {}
+  ~CompactForTieringCollectorFactory() override {}
 
   TablePropertiesCollector* CreateTablePropertiesCollector(
       TablePropertiesCollectorFactory::Context context) override;


### PR DESCRIPTION
# Summary

I saw these compiler warnings while preparing for the 9.10 release:

```cpp
'~CompactOnDeletionCollectorFactory' overrides a destructor but is not marked 'override' [-Werror,-Wsuggest-destructor-override]

'~CompactForTieringCollectorFactory' overrides a destructor but is not marked 'override' [-Werror,-Wsuggest-destructor-override]
```

This code is from a while ago so I assume that this CI check has been failing for quite some time. We should still clean this up to avoid confusion in the future.

# Test Plan

Existing CI checks should pass, and we should not see this CI check failure the next time we try to make a release/patch.