### PR TITLE
Add -Wsuggest-destructor-override check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -552,7 +552,8 @@ endif
 ifdef USE_CLANG
 	# Used by some teams in Facebook
 	WARNING_FLAGS += -Wshift-sign-overflow -Wambiguous-reversed-operator \
-	  -Wimplicit-fallthrough -Wreinterpret-base-class -Wundefined-reinterpret-cast
+	  -Wimplicit-fallthrough -Wreinterpret-base-class -Wundefined-reinterpret-cast \
+	  -Wsuggest-destructor-override
 endif
 
 ifeq ($(PLATFORM), OS_OPENBSD)

--- a/Makefile
+++ b/Makefile
@@ -552,8 +552,10 @@ endif
 ifdef USE_CLANG
 	# Used by some teams in Facebook
 	WARNING_FLAGS += -Wshift-sign-overflow -Wambiguous-reversed-operator \
-	  -Wimplicit-fallthrough -Wreinterpret-base-class -Wundefined-reinterpret-cast \
-	  -Wsuggest-destructor-override
+	  -Wimplicit-fallthrough -Wreinterpret-base-class -Wundefined-reinterpret-cast
+	ifeq ($(CC), clang-13)
+	  WARNING_FLAGS += -Wsuggest-destructor-override
+	endif
 endif
 
 ifeq ($(PLATFORM), OS_OPENBSD)

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -90,7 +90,7 @@ class CacheShardBase {
 class ShardedCacheBase : public Cache {
  public:
   explicit ShardedCacheBase(const ShardedCacheOptions& opts);
-  virtual ~ShardedCacheBase() = default;
+  virtual ~ShardedCacheBase() override = default;
 
   int GetNumShardBits() const;
   uint32_t GetNumShards() const;
@@ -143,7 +143,7 @@ class ShardedCache : public ShardedCacheBase {
             sizeof(CacheShard) * GetNumShards()))),
         destroy_shards_in_dtor_(false) {}
 
-  virtual ~ShardedCache() {
+  virtual ~ShardedCache() override {
     if (destroy_shards_in_dtor_) {
       ForEachShard([](CacheShard* cs) { cs->~CacheShard(); });
     }

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -168,7 +168,7 @@ class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
   ColumnFamilyHandleImpl(ColumnFamilyData* cfd, DBImpl* db,
                          InstrumentedMutex* mutex);
   // destroy without mutex
-  virtual ~ColumnFamilyHandleImpl();
+  virtual ~ColumnFamilyHandleImpl() override;
   virtual ColumnFamilyData* cfd() const { return cfd_; }
   virtual DBImpl* db() const { return db_; }
 

--- a/db/compaction/compaction_picker.h
+++ b/db/compaction/compaction_picker.h
@@ -255,7 +255,7 @@ class NullCompactionPicker : public CompactionPicker {
   NullCompactionPicker(const ImmutableOptions& ioptions,
                        const InternalKeyComparator* icmp)
       : CompactionPicker(ioptions, icmp) {}
-  virtual ~NullCompactionPicker() {}
+  virtual ~NullCompactionPicker() override {}
 
   // Always return "nullptr"
   Compaction* PickCompaction(

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -195,7 +195,7 @@ class DBImpl : public DB {
   DBImpl(const DBImpl&) = delete;
   void operator=(const DBImpl&) = delete;
 
-  virtual ~DBImpl();
+  virtual ~DBImpl() override;
 
   // ---- Implementations of the DB interface ----
 
@@ -1921,8 +1921,8 @@ class DBImpl : public DB {
     const InternalKey* begin = nullptr;  // nullptr means beginning of key range
     const InternalKey* end = nullptr;    // nullptr means end of key range
     InternalKey* manual_end = nullptr;   // how far we are compacting
-    InternalKey tmp_storage;      // Used to keep track of compaction progress
-    InternalKey tmp_storage1;     // Used to keep track of compaction progress
+    InternalKey tmp_storage;   // Used to keep track of compaction progress
+    InternalKey tmp_storage1;  // Used to keep track of compaction progress
 
     // When the user provides a canceled pointer in CompactRangeOptions, the
     // above varaibe is the reference of the user-provided

--- a/db/db_impl/db_impl_follower.h
+++ b/db/db_impl/db_impl_follower.h
@@ -19,7 +19,7 @@ class DBImplFollower : public DBImplSecondary {
  public:
   DBImplFollower(const DBOptions& db_options, std::unique_ptr<Env>&& env,
                  const std::string& dbname, std::string src_path);
-  ~DBImplFollower();
+  ~DBImplFollower() override;
 
   Status Close() override;
 

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 #include <vector>
 
@@ -21,7 +20,7 @@ class DBImplReadOnly : public DBImpl {
   DBImplReadOnly(const DBImplReadOnly&) = delete;
   void operator=(const DBImplReadOnly&) = delete;
 
-  virtual ~DBImplReadOnly();
+  virtual ~DBImplReadOnly() override;
 
   // Implementations of the DB interface
   using DBImpl::GetImpl;

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -282,7 +282,9 @@ class SpecialEnv : public EnvWrapper {
           : env_(env), base_(std::move(b)) {
         env_->num_open_wal_file_.fetch_add(1);
       }
-      virtual ~SpecialWalFile() { env_->num_open_wal_file_.fetch_add(-1); }
+      virtual ~SpecialWalFile() override {
+        env_->num_open_wal_file_.fetch_add(-1);
+      }
       Status Append(const Slice& data) override {
 #if !(defined NDEBUG) || !defined(OS_WIN)
         TEST_SYNC_POINT("SpecialEnv::SpecialWalFile::Append:1");
@@ -594,7 +596,7 @@ class SpecialEnv : public EnvWrapper {
       class NoopDirectory : public Directory {
        public:
         NoopDirectory() {}
-        ~NoopDirectory() {}
+        ~NoopDirectory() override {}
 
         Status Fsync() override { return Status::OK(); }
         Status Close() override { return Status::OK(); }
@@ -1098,7 +1100,7 @@ class DBTestBase : public testing::Test {
   // tests, but won't cover the exact fsync logic.
   DBTestBase(const std::string path, bool env_do_fsync);
 
-  ~DBTestBase();
+  ~DBTestBase() override;
 
   static std::string Key(int i) {
     char buf[100];

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -396,7 +396,7 @@ class InternalKeyComparator
   //    overhead, set `named` to false. In that case, `Name()` will return a
   //    generic name that is non-specific to the underlying comparator.
   explicit InternalKeyComparator(const Comparator* c) : user_comparator_(c) {}
-  virtual ~InternalKeyComparator() {}
+  virtual ~InternalKeyComparator() override {}
 
   int Compare(const Slice& a, const Slice& b) const override;
 

--- a/db/experimental.cc
+++ b/db/experimental.cc
@@ -37,7 +37,6 @@ Status PromoteL0(DB* db, ColumnFamilyHandle* column_family, int target_level) {
   return db->PromoteL0(column_family, target_level);
 }
 
-
 Status SuggestCompactRange(DB* db, const Slice* begin, const Slice* end) {
   return SuggestCompactRange(db, db->DefaultColumnFamily(), begin, end);
 }
@@ -517,7 +516,7 @@ class SstQueryFilterConfigImpl : public SstQueryFilterConfig {
       const KeySegmentsExtractor::KeyCategorySet& categories)
       : input_(input), categories_(categories) {}
 
-  virtual ~SstQueryFilterConfigImpl() = default;
+  virtual ~SstQueryFilterConfigImpl() override = default;
 
   virtual std::unique_ptr<SstQueryFilterBuilder> NewBuilder(
       bool sanity_checks) const = 0;

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -4,13 +4,12 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-#include "rocksdb/comparator.h"
-
 #include <queue>
 #include <string>
 #include <vector>
 
 #include "memory/arena.h"
+#include "rocksdb/comparator.h"
 #include "rocksdb/db.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"
@@ -55,7 +54,7 @@ class ForwardIterator : public InternalIterator {
   ForwardIterator(DBImpl* db, const ReadOptions& read_options,
                   ColumnFamilyData* cfd, SuperVersion* current_sv = nullptr,
                   bool allow_unprepared_value = false);
-  virtual ~ForwardIterator();
+  virtual ~ForwardIterator() override;
 
   void SeekForPrev(const Slice& /*target*/) override {
     status_ = Status::NotSupported("ForwardIterator::SeekForPrev()");

--- a/db/snapshot_checker.h
+++ b/db/snapshot_checker.h
@@ -26,7 +26,7 @@ class SnapshotChecker {
 
 class DisableGCSnapshotChecker : public SnapshotChecker {
  public:
-  virtual ~DisableGCSnapshotChecker() {}
+  virtual ~DisableGCSnapshotChecker() override {}
   SnapshotCheckerResult CheckInSnapshot(
       SequenceNumber /*sequence*/,
       SequenceNumber /*snapshot_sequence*/) const override {
@@ -46,7 +46,7 @@ class WritePreparedTxnDB;
 class WritePreparedSnapshotChecker : public SnapshotChecker {
  public:
   explicit WritePreparedSnapshotChecker(WritePreparedTxnDB* txn_db);
-  virtual ~WritePreparedSnapshotChecker() {}
+  virtual ~WritePreparedSnapshotChecker() override {}
 
   SnapshotCheckerResult CheckInSnapshot(
       SequenceNumber sequence, SequenceNumber snapshot_sequence) const override;

--- a/db/table_properties_collector.h
+++ b/db/table_properties_collector.h
@@ -66,7 +66,7 @@ class UserKeyTablePropertiesCollector : public InternalTblPropColl {
   explicit UserKeyTablePropertiesCollector(TablePropertiesCollector* collector)
       : collector_(collector) {}
 
-  virtual ~UserKeyTablePropertiesCollector() {}
+  virtual ~UserKeyTablePropertiesCollector() override {}
 
   Status InternalAdd(const Slice& key, const Slice& value,
                      uint64_t file_size) override;

--- a/db/write_controller.h
+++ b/db/write_controller.h
@@ -128,21 +128,21 @@ class StopWriteToken : public WriteControllerToken {
  public:
   explicit StopWriteToken(WriteController* controller)
       : WriteControllerToken(controller) {}
-  virtual ~StopWriteToken();
+  virtual ~StopWriteToken() override;
 };
 
 class DelayWriteToken : public WriteControllerToken {
  public:
   explicit DelayWriteToken(WriteController* controller)
       : WriteControllerToken(controller) {}
-  virtual ~DelayWriteToken();
+  virtual ~DelayWriteToken() override;
 };
 
 class CompactionPressureToken : public WriteControllerToken {
  public:
   explicit CompactionPressureToken(WriteController* controller)
       : WriteControllerToken(controller) {}
-  virtual ~CompactionPressureToken();
+  virtual ~CompactionPressureToken() override;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/env/env_encryption_ctr.h
+++ b/env/env_encryption_ctr.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include "rocksdb/env_encryption.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -24,8 +23,8 @@ class CTRCipherStream final : public BlockAccessCipherStream {
  public:
   CTRCipherStream(const std::shared_ptr<BlockCipher>& c, const char* iv,
                   uint64_t initialCounter)
-      : cipher_(c), iv_(iv, c->BlockSize()), initialCounter_(initialCounter){}
-  virtual ~CTRCipherStream(){}
+      : cipher_(c), iv_(iv, c->BlockSize()), initialCounter_(initialCounter) {}
+  virtual ~CTRCipherStream() override {}
 
   size_t BlockSize() override { return cipher_->BlockSize(); }
 
@@ -55,7 +54,7 @@ class CTREncryptionProvider : public EncryptionProvider {
  public:
   explicit CTREncryptionProvider(
       const std::shared_ptr<BlockCipher>& c = nullptr);
-  virtual ~CTREncryptionProvider() {}
+  virtual ~CTREncryptionProvider() override {}
 
   static const char* kClassName() { return "CTR"; }
   const char* Name() const override { return kClassName(); }
@@ -94,4 +93,3 @@ Status NewEncryptedFileSystemImpl(
     std::unique_ptr<FileSystem>* fs);
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/env/fs_on_demand.h
+++ b/env/fs_on_demand.h
@@ -100,7 +100,7 @@ class OnDemandSequentialFile : public FSSequentialFile {
         eof_(false),
         offset_(0) {}
 
-  virtual ~OnDemandSequentialFile() {}
+  virtual ~OnDemandSequentialFile() override {}
 
   IOStatus Read(size_t n, const IOOptions& options, Slice* result,
                 char* scratch, IODebugContext* dbg) override;

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -273,7 +273,7 @@ class PosixSequentialFile : public FSSequentialFile {
  public:
   PosixSequentialFile(const std::string& fname, FILE* file, int fd,
                       size_t logical_block_size, const EnvOptions& options);
-  virtual ~PosixSequentialFile();
+  virtual ~PosixSequentialFile() override;
 
   IOStatus Read(size_t n, const IOOptions& opts, Slice* result, char* scratch,
                 IODebugContext* dbg) override;
@@ -326,7 +326,7 @@ class PosixRandomAccessFile : public FSRandomAccessFile {
                         ThreadLocalPtr* thread_local_io_urings
 #endif
   );
-  virtual ~PosixRandomAccessFile();
+  virtual ~PosixRandomAccessFile() override;
 
   IOStatus Read(uint64_t offset, size_t n, const IOOptions& opts, Slice* result,
                 char* scratch, IODebugContext* dbg) const override;
@@ -375,7 +375,7 @@ class PosixWritableFile : public FSWritableFile {
   explicit PosixWritableFile(const std::string& fname, int fd,
                              size_t logical_block_size,
                              const EnvOptions& options);
-  virtual ~PosixWritableFile();
+  virtual ~PosixWritableFile() override;
 
   // Need to implement this so the file is truncated correctly
   // with direct I/O
@@ -431,7 +431,7 @@ class PosixMmapReadableFile : public FSRandomAccessFile {
  public:
   PosixMmapReadableFile(const int fd, const std::string& fname, void* base,
                         size_t length, const EnvOptions& options);
-  virtual ~PosixMmapReadableFile();
+  virtual ~PosixMmapReadableFile() override;
   IOStatus Read(uint64_t offset, size_t n, const IOOptions& opts, Slice* result,
                 char* scratch, IODebugContext* dbg) const override;
   void Hint(AccessPattern pattern) override;
@@ -470,7 +470,7 @@ class PosixMmapFile : public FSWritableFile {
  public:
   PosixMmapFile(const std::string& fname, int fd, size_t page_size,
                 const EnvOptions& options);
-  ~PosixMmapFile();
+  ~PosixMmapFile() override;
 
   // Means Close() will properly take care of truncate
   // and it does not need any additional information
@@ -501,7 +501,7 @@ class PosixRandomRWFile : public FSRandomRWFile {
  public:
   explicit PosixRandomRWFile(const std::string& fname, int fd,
                              const EnvOptions& options);
-  virtual ~PosixRandomRWFile();
+  virtual ~PosixRandomRWFile() override;
 
   IOStatus Write(uint64_t offset, const Slice& data, const IOOptions& opts,
                  IODebugContext* dbg) override;
@@ -522,13 +522,13 @@ class PosixRandomRWFile : public FSRandomRWFile {
 struct PosixMemoryMappedFileBuffer : public MemoryMappedFileBuffer {
   PosixMemoryMappedFileBuffer(void* _base, size_t _length)
       : MemoryMappedFileBuffer(_base, _length) {}
-  virtual ~PosixMemoryMappedFileBuffer();
+  virtual ~PosixMemoryMappedFileBuffer() override;
 };
 
 class PosixDirectory : public FSDirectory {
  public:
   explicit PosixDirectory(int fd, const std::string& directory_name);
-  ~PosixDirectory();
+  ~PosixDirectory() override;
   IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
 
   IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;

--- a/file/sst_file_manager_impl.h
+++ b/file/sst_file_manager_impl.h
@@ -34,7 +34,7 @@ class SstFileManagerImpl : public SstFileManager {
   SstFileManagerImpl(const SstFileManagerImpl& sfm) = delete;
   SstFileManagerImpl& operator=(const SstFileManagerImpl& sfm) = delete;
 
-  ~SstFileManagerImpl();
+  ~SstFileManagerImpl() override;
 
   // DB will call OnAddFile whenever a new sst/blob file is added.
   Status OnAddFile(const std::string& file_path);

--- a/include/rocksdb/advanced_cache.h
+++ b/include/rocksdb/advanced_cache.h
@@ -188,7 +188,7 @@ class Cache : public Customizable {
   Cache& operator=(const Cache&) = delete;
 
   // Destroys all remaining entries by calling the associated "deleter"
-  virtual ~Cache() {}
+  virtual ~Cache() override {}
 
   static const char* Type() { return "Cache"; }
 
@@ -209,7 +209,7 @@ class Cache : public Customizable {
 
  public:  // functions
   // The type of the Cache
-  virtual const char* Name() const = 0;
+  virtual const char* Name() const override = 0;
 
   // The Insert and Lookup APIs below are intended to allow cached objects
   // to be demoted/promoted between the primary block cache and a secondary
@@ -425,7 +425,7 @@ class Cache : public Customizable {
   // Prerequisite: no entry is referenced.
   virtual void EraseUnRefEntries() = 0;
 
-  virtual std::string GetPrintableOptions() const { return ""; }
+  virtual std::string GetPrintableOptions() const override { return ""; }
 
   // Check for any warnings or errors in the operation of the cache and
   // report them to the logger. This is intended only to be called

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -177,7 +177,7 @@ class CompactionFilter : public Customizable {
     static const int kUnknownStartLevel = -1;
   };
 
-  virtual ~CompactionFilter() {}
+  virtual ~CompactionFilter() override {}
   static const char* Type() { return "CompactionFilter"; }
   static Status CreateFromString(const ConfigOptions& config_options,
                                  const std::string& name,
@@ -348,7 +348,7 @@ class CompactionFilter : public Customizable {
 // including data loss, unreported corruption, deadlocks, and more.
 class CompactionFilterFactory : public Customizable {
  public:
-  virtual ~CompactionFilterFactory() {}
+  virtual ~CompactionFilterFactory() override {}
   static const char* Type() { return "CompactionFilterFactory"; }
   static Status CreateFromString(
       const ConfigOptions& config_options, const std::string& name,

--- a/include/rocksdb/env_encryption.h
+++ b/include/rocksdb/env_encryption.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 
 #include "rocksdb/customizable.h"
@@ -32,7 +31,7 @@ std::shared_ptr<FileSystem> NewEncryptedFS(
 // blocks). E.g. CTR (Counter operation mode) supports this requirement.
 class BlockAccessCipherStream {
  public:
-  virtual ~BlockAccessCipherStream(){}
+  virtual ~BlockAccessCipherStream() {}
 
   // BlockSize returns the size of each block supported by this cipher stream.
   virtual size_t BlockSize() = 0;
@@ -67,7 +66,7 @@ class BlockAccessCipherStream {
 // including data loss, unreported corruption, deadlocks, and more.
 class BlockCipher : public Customizable {
  public:
-  virtual ~BlockCipher() {}
+  virtual ~BlockCipher() override {}
 
   // Creates a new BlockCipher from the input config_options and value
   // The value describes the type of provider (and potentially optional
@@ -114,7 +113,7 @@ class BlockCipher : public Customizable {
 // including data loss, unreported corruption, deadlocks, and more.
 class EncryptionProvider : public Customizable {
  public:
-  virtual ~EncryptionProvider() {}
+  virtual ~EncryptionProvider() override {}
 
   // Creates a new EncryptionProvider from the input config_options and value.
   // The value describes the type of provider (and potentially optional
@@ -360,4 +359,3 @@ class EncryptedFileSystem : public FileSystemWrapper {
   }
 };
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -296,7 +296,7 @@ class FileSystem : public Customizable {
   // No copying allowed
   FileSystem(const FileSystem&) = delete;
 
-  virtual ~FileSystem();
+  virtual ~FileSystem() override;
 
   static const char* Type() { return "FileSystem"; }
   static const char* kDefaultName() { return "DefaultFileSystem"; }

--- a/include/rocksdb/filter_policy.h
+++ b/include/rocksdb/filter_policy.h
@@ -88,7 +88,7 @@ struct FilterBuildingContext {
 // GetBuilderWithContext.
 class FilterPolicy : public Customizable {
  public:
-  virtual ~FilterPolicy();
+  virtual ~FilterPolicy() override;
   static const char* Type() { return "FilterPolicy"; }
 
   // The name used for identifying whether a filter on disk is readable

--- a/include/rocksdb/flush_block_policy.h
+++ b/include/rocksdb/flush_block_policy.h
@@ -53,7 +53,7 @@ class FlushBlockPolicyFactory : public Customizable {
       const BlockBasedTableOptions& table_options,
       const BlockBuilder& data_block_builder) const = 0;
 
-  virtual ~FlushBlockPolicyFactory() {}
+  virtual ~FlushBlockPolicyFactory() override {}
 };
 
 class FlushBlockBySizePolicyFactory : public FlushBlockPolicyFactory {

--- a/include/rocksdb/merge_operator.h
+++ b/include/rocksdb/merge_operator.h
@@ -52,7 +52,7 @@ class Logger;
 // including data loss, unreported corruption, deadlocks, and more.
 class MergeOperator : public Customizable {
  public:
-  virtual ~MergeOperator() {}
+  virtual ~MergeOperator() override {}
   static const char* Type() { return "MergeOperator"; }
   static Status CreateFromString(const ConfigOptions& opts,
                                  const std::string& id,

--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -34,7 +34,7 @@ struct ConfigOptions;
 // including data loss, unreported corruption, deadlocks, and more.
 class SliceTransform : public Customizable {
  public:
-  virtual ~SliceTransform(){}
+  virtual ~SliceTransform() override {}
 
   // Return the name of this transformation.
   const char* Name() const override = 0;

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -647,7 +647,7 @@ class BackupEngineAppendOnlyBase {
 class BackupEngine : public BackupEngineReadOnlyBase,
                      public BackupEngineAppendOnlyBase {
  public:
-  virtual ~BackupEngine() {}
+  virtual ~BackupEngine() override {}
 
   // BackupEngineOptions have to be the same as the ones used in previous
   // BackupEngines for the same backup directory.
@@ -675,7 +675,7 @@ class BackupEngine : public BackupEngineReadOnlyBase,
 // BackupEngine comment for details. This class is not user-extensible.
 class BackupEngineReadOnly : public BackupEngineReadOnlyBase {
  public:
-  virtual ~BackupEngineReadOnly() {}
+  virtual ~BackupEngineReadOnly() override {}
 
   static IOStatus Open(const BackupEngineOptions& options, Env* db_env,
                        BackupEngineReadOnly** backup_engine_ptr);

--- a/include/rocksdb/utilities/env_mirror.h
+++ b/include/rocksdb/utilities/env_mirror.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-
 #include <algorithm>
 #include <iostream>
 #include <vector>
@@ -38,7 +37,7 @@ class EnvMirror : public EnvWrapper {
  public:
   EnvMirror(Env* a, Env* b, bool free_a = false, bool free_b = false)
       : EnvWrapper(a), a_(a), b_(b), free_a_(free_a), free_b_(free_b) {}
-  ~EnvMirror() {
+  ~EnvMirror() override {
     if (free_a_) delete a_;
     if (free_b_) delete b_;
   }
@@ -176,4 +175,3 @@ class EnvMirror : public EnvWrapper {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/include/rocksdb/wal_filter.h
+++ b/include/rocksdb/wal_filter.h
@@ -42,7 +42,7 @@ class WalFilter : public Customizable {
     kWalProcessingOptionMax = 4
   };
 
-  virtual ~WalFilter() {}
+  virtual ~WalFilter() override {}
 
   // Provide ColumnFamily->LogNumber map to filter
   // so that filter can determine whether a log number applies to a given

--- a/logging/auto_roll_logger.h
+++ b/logging/auto_roll_logger.h
@@ -67,7 +67,7 @@ class AutoRollLogger : public Logger {
     }
   }
 
-  virtual ~AutoRollLogger() {
+  virtual ~AutoRollLogger() override {
     if (logger_ && !closed_) {
       logger_->Close().PermitUncheckedError();
     }

--- a/logging/env_logger.h
+++ b/logging/env_logger.h
@@ -40,7 +40,7 @@ class EnvLogger : public Logger {
         last_flush_micros_(0),
         flush_pending_(false) {}
 
-  ~EnvLogger() {
+  ~EnvLogger() override {
     if (!closed_) {
       closed_ = true;
       CloseHelper().PermitUncheckedError();

--- a/memory/arena.h
+++ b/memory/arena.h
@@ -41,7 +41,7 @@ class Arena : public Allocator {
   // page TLB first. If allocation fails, will fall back to normal case.
   explicit Arena(size_t block_size = kMinBlockSize,
                  AllocTracker* tracker = nullptr, size_t huge_page_size = 0);
-  ~Arena();
+  ~Arena() override;
 
   char* Allocate(size_t bytes) override;
 

--- a/monitoring/histogram.h
+++ b/monitoring/histogram.h
@@ -88,7 +88,7 @@ struct HistogramStat {
 class Histogram {
  public:
   Histogram() {}
-  virtual ~Histogram(){}
+  virtual ~Histogram() {}
 
   virtual void Clear() = 0;
   virtual bool Empty() const = 0;
@@ -131,7 +131,7 @@ class HistogramImpl : public Histogram {
   double StandardDeviation() const override;
   void Data(HistogramData* const data) const override;
 
-  virtual ~HistogramImpl() {}
+  virtual ~HistogramImpl() override {}
 
   inline HistogramStat& TEST_GetStats() { return stats_; }
 

--- a/monitoring/histogram_windowing.h
+++ b/monitoring/histogram_windowing.h
@@ -23,7 +23,7 @@ class HistogramWindowingImpl : public Histogram {
   HistogramWindowingImpl(const HistogramWindowingImpl&) = delete;
   HistogramWindowingImpl& operator=(const HistogramWindowingImpl&) = delete;
 
-  ~HistogramWindowingImpl();
+  ~HistogramWindowingImpl() override;
 
   void Clear() override;
   bool Empty() const override;

--- a/monitoring/statistics_impl.h
+++ b/monitoring/statistics_impl.h
@@ -42,7 +42,7 @@ enum HistogramsInternal : uint32_t {
 class StatisticsImpl : public Statistics {
  public:
   StatisticsImpl(std::shared_ptr<Statistics> stats);
-  virtual ~StatisticsImpl();
+  virtual ~StatisticsImpl() override;
   const char* Name() const override { return kClassName(); }
   static const char* kClassName() { return "BasicStatistics"; }
 

--- a/table/adaptive/adaptive_table_factory.h
+++ b/table/adaptive/adaptive_table_factory.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 
 #include "rocksdb/options.h"
@@ -23,7 +22,7 @@ class TableBuilder;
 
 class AdaptiveTableFactory : public TableFactory {
  public:
-  ~AdaptiveTableFactory() {}
+  ~AdaptiveTableFactory() override {}
 
   explicit AdaptiveTableFactory(
       std::shared_ptr<TableFactory> table_factory_to_write,

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -50,7 +50,7 @@ class BlockBasedTableBuilder : public TableBuilder {
   BlockBasedTableBuilder& operator=(const BlockBasedTableBuilder&) = delete;
 
   // REQUIRES: Either Finish() or Abandon() has been called.
-  ~BlockBasedTableBuilder();
+  ~BlockBasedTableBuilder() override;
 
   // Add key,value to the table being constructed.
   // REQUIRES: Unless key has type kTypeRangeDeletion, key is after any

--- a/table/block_based/block_based_table_factory.h
+++ b/table/block_based/block_based_table_factory.h
@@ -52,7 +52,7 @@ class BlockBasedTableFactory : public TableFactory {
   explicit BlockBasedTableFactory(
       const BlockBasedTableOptions& table_options = BlockBasedTableOptions());
 
-  ~BlockBasedTableFactory() {}
+  ~BlockBasedTableFactory() override {}
 
   // Method to allow CheckedCast to work for this class
   static const char* kClassName() { return kBlockBasedTableName(); }

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -213,7 +213,7 @@ class BlockBasedTable : public TableReader {
 
   void MarkObsolete(uint32_t uncache_aggressiveness) override;
 
-  ~BlockBasedTable();
+  ~BlockBasedTable() override;
 
   bool TEST_FilterBlockInCache() const;
   bool TEST_IndexBlockInCache() const;

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -47,7 +47,7 @@ class FullFilterBlockBuilder : public FilterBlockBuilder {
 
   // bits_builder is created in filter_policy, it should be passed in here
   // directly. and be deleted here
-  ~FullFilterBlockBuilder() {}
+  ~FullFilterBlockBuilder() override {}
 
   void Add(const Slice& key_without_ts) override;
   void AddWithPrevKey(const Slice& key_without_ts,

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -35,7 +35,7 @@ class PartitionedFilterBlockBuilder : public FullFilterBlockBuilder {
       const bool persist_user_defined_timestamps,
       bool decouple_from_index_partitions);
 
-  virtual ~PartitionedFilterBlockBuilder();
+  virtual ~PartitionedFilterBlockBuilder() override;
 
   void Add(const Slice& key_without_ts) override;
   void AddWithPrevKey(const Slice& key_without_ts,

--- a/table/cuckoo/cuckoo_table_builder.h
+++ b/table/cuckoo/cuckoo_table_builder.h
@@ -37,7 +37,7 @@ class CuckooTableBuilder : public TableBuilder {
   void operator=(const CuckooTableBuilder&) = delete;
 
   // REQUIRES: Either Finish() or Abandon() has been called.
-  ~CuckooTableBuilder() {}
+  ~CuckooTableBuilder() override {}
 
   // Add key,value to the table being constructed.
   // REQUIRES: key is after any previously added key according to comparator.
@@ -133,4 +133,3 @@ class CuckooTableBuilder : public TableBuilder {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/table/cuckoo/cuckoo_table_factory.h
+++ b/table/cuckoo/cuckoo_table_factory.h
@@ -54,7 +54,7 @@ class CuckooTableFactory : public TableFactory {
  public:
   explicit CuckooTableFactory(
       const CuckooTableOptions& table_option = CuckooTableOptions());
-  ~CuckooTableFactory() {}
+  ~CuckooTableFactory() override {}
 
   // Method to allow CheckedCast to work for this class
   static const char* kClassName() { return kCuckooTableName(); }

--- a/table/cuckoo/cuckoo_table_reader.h
+++ b/table/cuckoo/cuckoo_table_reader.h
@@ -31,7 +31,7 @@ class CuckooTableReader : public TableReader {
                     uint64_t file_size, const Comparator* user_comparator,
                     uint64_t (*get_slice_hash)(const Slice&, uint32_t,
                                                uint64_t));
-  ~CuckooTableReader() {}
+  ~CuckooTableReader() override {}
 
   std::shared_ptr<const TableProperties> GetTableProperties() const override {
     return table_props_;

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -94,7 +94,7 @@ class MockTableBuilder : public TableBuilder {
   }
 
   // REQUIRES: Either Finish() or Abandon() has been called.
-  ~MockTableBuilder() = default;
+  ~MockTableBuilder() override = default;
 
   // Add key,value to the table being constructed.
   // REQUIRES: key is after any previously added key according to comparator.

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -135,7 +135,7 @@ class MockTableReader : public TableReader {
     return std::make_shared<const TableProperties>(tp_);
   }
 
-  ~MockTableReader() = default;
+  ~MockTableReader() override = default;
 
  private:
   const KVVector& table_;

--- a/table/plain/plain_table_builder.h
+++ b/table/plain/plain_table_builder.h
@@ -53,7 +53,7 @@ class PlainTableBuilder : public TableBuilder {
   void operator=(const PlainTableBuilder&) = delete;
 
   // REQUIRES: Either Finish() or Abandon() has been called.
-  ~PlainTableBuilder();
+  ~PlainTableBuilder() override;
 
   // Add key,value to the table being constructed.
   // REQUIRES: key is after any previously added key according to comparator.

--- a/table/plain/plain_table_factory.h
+++ b/table/plain/plain_table_factory.h
@@ -137,7 +137,7 @@ class TableBuilder;
 //
 class PlainTableFactory : public TableFactory {
  public:
-  ~PlainTableFactory() {}
+  ~PlainTableFactory() override {}
   // user_key_len is the length of the user key. If it is set to be
   // kPlainTableVariableLength, then it means variable length. Otherwise, all
   // the keys need to have the fix length of this value. bloom_bits_per_key is

--- a/table/plain/plain_table_reader.h
+++ b/table/plain/plain_table_reader.h
@@ -117,7 +117,7 @@ class PlainTableReader : public TableReader {
                    EncodingType encoding_type, uint64_t file_size,
                    const TableProperties* table_properties,
                    const SliceTransform* prefix_extractor);
-  virtual ~PlainTableReader();
+  virtual ~PlainTableReader() override;
 
  protected:
   // Check bloom filter to see whether it might contain this prefix.

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -84,7 +84,7 @@ class PlainInternalKeyComparator : public InternalKeyComparator {
   explicit PlainInternalKeyComparator(const Comparator* c)
       : InternalKeyComparator(c) {}
 
-  virtual ~PlainInternalKeyComparator() {}
+  virtual ~PlainInternalKeyComparator() override {}
 
   int Compare(const Slice& a, const Slice& b) const override {
     return user_comparator()->Compare(a, b);
@@ -310,7 +310,7 @@ class StringSource : public FSRandomAccessFile {
         mmap_(mmap),
         total_reads_(0) {}
 
-  virtual ~StringSource() {}
+  virtual ~StringSource() override {}
 
   uint64_t Size() const { return contents_.size(); }
 
@@ -744,7 +744,7 @@ class ChanglingMergeOperator : public MergeOperator {
  public:
   explicit ChanglingMergeOperator(const std::string& name)
       : name_(name + "MergeOperator") {}
-  ~ChanglingMergeOperator() {}
+  ~ChanglingMergeOperator() override {}
 
   void SetName(const std::string& name) { name_ = name; }
 
@@ -783,7 +783,7 @@ class ChanglingCompactionFilter : public CompactionFilter {
  public:
   explicit ChanglingCompactionFilter(const std::string& name)
       : name_(name + "CompactionFilter") {}
-  ~ChanglingCompactionFilter() {}
+  ~ChanglingCompactionFilter() override {}
 
   void SetName(const std::string& name) { name_ = name; }
 
@@ -819,7 +819,7 @@ class ChanglingCompactionFilterFactory : public CompactionFilterFactory {
  public:
   explicit ChanglingCompactionFilterFactory(const std::string& name)
       : name_(name + "CompactionFilterFactory") {}
-  ~ChanglingCompactionFilterFactory() {}
+  ~ChanglingCompactionFilterFactory() override {}
 
   void SetName(const std::string& name) { name_ = name; }
 

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -118,7 +118,7 @@ class BlockCacheTraceWriterImpl : public BlockCacheTraceWriter {
   BlockCacheTraceWriterImpl(SystemClock* clock,
                             const BlockCacheTraceWriterOptions& trace_options,
                             std::unique_ptr<TraceWriter>&& trace_writer);
-  ~BlockCacheTraceWriterImpl() = default;
+  ~BlockCacheTraceWriterImpl() override = default;
   // No copy and move.
   BlockCacheTraceWriterImpl(const BlockCacheTraceWriterImpl&) = delete;
   BlockCacheTraceWriterImpl& operator=(const BlockCacheTraceWriterImpl&) =
@@ -187,7 +187,7 @@ class BlockCacheHumanReadableTraceReader : public BlockCacheTraceReader {
  public:
   BlockCacheHumanReadableTraceReader(const std::string& trace_file_path);
 
-  ~BlockCacheHumanReadableTraceReader();
+  ~BlockCacheHumanReadableTraceReader() override;
 
   Status ReadHeader(BlockCacheTraceHeader* header);
 

--- a/util/concurrent_task_limiter_impl.h
+++ b/util/concurrent_task_limiter_impl.h
@@ -27,7 +27,7 @@ class ConcurrentTaskLimiterImpl : public ConcurrentTaskLimiter {
   ConcurrentTaskLimiterImpl& operator=(const ConcurrentTaskLimiterImpl&) =
       delete;
 
-  virtual ~ConcurrentTaskLimiterImpl();
+  virtual ~ConcurrentTaskLimiterImpl() override;
 
   const std::string& GetName() const override;
 

--- a/util/rate_limiter_impl.h
+++ b/util/rate_limiter_impl.h
@@ -31,7 +31,7 @@ class GenericRateLimiter : public RateLimiter {
                      const std::shared_ptr<SystemClock>& clock, bool auto_tuned,
                      int64_t single_burst_bytes);
 
-  virtual ~GenericRateLimiter();
+  virtual ~GenericRateLimiter() override;
 
   // This API allows user to dynamically change rate limiter's bytes per second.
   void SetBytesPerSecond(int64_t bytes_per_second) override;

--- a/util/threadpool_imp.h
+++ b/util/threadpool_imp.h
@@ -19,7 +19,7 @@ namespace ROCKSDB_NAMESPACE {
 class ThreadPoolImpl : public ThreadPool {
  public:
   ThreadPoolImpl();
-  ~ThreadPoolImpl();
+  ~ThreadPoolImpl() override;
 
   ThreadPoolImpl(ThreadPoolImpl&&) = delete;
   ThreadPoolImpl& operator=(ThreadPoolImpl&&) = delete;

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <atomic>
 #include <condition_variable>
 #include <limits>
@@ -166,7 +165,7 @@ class BlobDBImpl : public BlobDB {
       const LiveFilesStorageInfoOptions& opts,
       std::vector<LiveFileStorageInfo>* files) override;
 
-  ~BlobDBImpl();
+  ~BlobDBImpl() override;
 
   Status Open(std::vector<ColumnFamilyHandle*>* handles);
 

--- a/utilities/blob_db/blob_db_iterator.h
+++ b/utilities/blob_db/blob_db_iterator.h
@@ -29,7 +29,7 @@ class BlobDBIterator : public Iterator {
         clock_(clock),
         statistics_(statistics) {}
 
-  virtual ~BlobDBIterator() = default;
+  virtual ~BlobDBIterator() override = default;
 
   bool Valid() const override {
     if (!iter_->Valid()) {

--- a/utilities/cache_dump_load_impl.h
+++ b/utilities/cache_dump_load_impl.h
@@ -99,7 +99,7 @@ class CacheDumperImpl : public CacheDumper {
       : options_(dump_options), cache_(cache), writer_(std::move(writer)) {
     dumped_size_bytes_ = 0;
   }
-  ~CacheDumperImpl() { writer_.reset(); }
+  ~CacheDumperImpl() override { writer_.reset(); }
   Status SetDumpFilter(std::vector<DB*> db_list) override;
   IOStatus DumpCacheEntriesToWriter() override;
 
@@ -140,7 +140,7 @@ class CacheDumpedLoaderImpl : public CacheDumpedLoader {
       : options_(dump_options),
         secondary_cache_(secondary_cache),
         reader_(std::move(reader)) {}
-  ~CacheDumpedLoaderImpl() {}
+  ~CacheDumpedLoaderImpl() override {}
   IOStatus RestoreCacheEntriesToSecondaryCache() override;
 
  private:
@@ -162,7 +162,7 @@ class ToFileCacheDumpWriter : public CacheDumpWriter {
       std::unique_ptr<WritableFileWriter>&& file_writer)
       : file_writer_(std::move(file_writer)) {}
 
-  ~ToFileCacheDumpWriter() { Close().PermitUncheckedError(); }
+  ~ToFileCacheDumpWriter() override { Close().PermitUncheckedError(); }
 
   // Write the serialized metadata to the file
   IOStatus WriteMetadata(const Slice& metadata) override {
@@ -217,7 +217,7 @@ class FromFileCacheDumpReader : public CacheDumpReader {
         offset_(0),
         buffer_(new char[kDumpReaderBufferSize]) {}
 
-  ~FromFileCacheDumpReader() { delete[] buffer_; }
+  ~FromFileCacheDumpReader() override { delete[] buffer_; }
 
   IOStatus ReadMetadata(std::string* metadata) override {
     uint32_t metadata_len = 0;

--- a/utilities/counted_fs.cc
+++ b/utilities/counted_fs.cc
@@ -245,7 +245,7 @@ class CountedDirectory : public FSDirectoryWrapper {
     return rv;
   }
 
-  ~CountedDirectory() {
+  ~CountedDirectory() override {
     if (!closed_) {
       // TODO: fix DB+CF code to use explicit Close, not rely on destructor
       fs_->counters()->closes++;

--- a/utilities/fault_injection_env.h
+++ b/utilities/fault_injection_env.h
@@ -71,7 +71,7 @@ class TestWritableFile : public WritableFile {
   explicit TestWritableFile(const std::string& fname,
                             std::unique_ptr<WritableFile>&& f,
                             FaultInjectionTestEnv* env);
-  virtual ~TestWritableFile();
+  virtual ~TestWritableFile() override;
   Status Append(const Slice& data) override;
   Status Append(const Slice& data,
                 const DataVerificationInfo& /*verification_info*/) override {
@@ -107,7 +107,7 @@ class TestRandomRWFile : public RandomRWFile {
   explicit TestRandomRWFile(const std::string& fname,
                             std::unique_ptr<RandomRWFile>&& f,
                             FaultInjectionTestEnv* env);
-  virtual ~TestRandomRWFile();
+  virtual ~TestRandomRWFile() override;
   Status Write(uint64_t offset, const Slice& data) override;
   Status Read(uint64_t offset, size_t n, Slice* result,
               char* scratch) const override;
@@ -130,7 +130,7 @@ class TestDirectory : public Directory {
   explicit TestDirectory(FaultInjectionTestEnv* env, std::string dirname,
                          Directory* dir)
       : env_(env), dirname_(dirname), dir_(dir) {}
-  ~TestDirectory() {}
+  ~TestDirectory() override {}
 
   Status Fsync() override;
   Status Close() override;
@@ -145,7 +145,7 @@ class FaultInjectionTestEnv : public EnvWrapper {
  public:
   explicit FaultInjectionTestEnv(Env* base)
       : EnvWrapper(base), filesystem_active_(true) {}
-  virtual ~FaultInjectionTestEnv() { error_.PermitUncheckedError(); }
+  virtual ~FaultInjectionTestEnv() override { error_.PermitUncheckedError(); }
 
   static const char* kClassName() { return "FaultInjectionTestEnv"; }
   const char* Name() const override { return kClassName(); }

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -65,7 +65,7 @@ class TestFSWritableFile : public FSWritableFile {
                               const FileOptions& file_opts,
                               std::unique_ptr<FSWritableFile>&& f,
                               FaultInjectionTestFS* fs);
-  virtual ~TestFSWritableFile();
+  virtual ~TestFSWritableFile() override;
   IOStatus Append(const Slice& data, const IOOptions&,
                   IODebugContext*) override;
   IOStatus Append(const Slice& data, const IOOptions& options,
@@ -113,7 +113,7 @@ class TestFSRandomRWFile : public FSRandomRWFile {
   explicit TestFSRandomRWFile(const std::string& fname,
                               std::unique_ptr<FSRandomRWFile>&& f,
                               FaultInjectionTestFS* fs);
-  virtual ~TestFSRandomRWFile();
+  virtual ~TestFSRandomRWFile() override;
   IOStatus Write(uint64_t offset, const Slice& data, const IOOptions& options,
                  IODebugContext* dbg) override;
   IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,
@@ -185,7 +185,7 @@ class TestFSDirectory : public FSDirectory {
   explicit TestFSDirectory(FaultInjectionTestFS* fs, std::string dirname,
                            FSDirectory* dir)
       : fs_(fs), dirname_(std::move(dirname)), dir_(dir) {}
-  ~TestFSDirectory() {}
+  ~TestFSDirectory() override {}
 
   IOStatus Fsync(const IOOptions& options, IODebugContext* dbg) override;
 
@@ -589,8 +589,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   bool filesystem_writable_;  // Bypass FaultInjectionTestFS and go directly
                               // to underlying FS for writable files
   bool inject_unsynced_data_loss_;  // See InjectUnsyncedDataLoss()
-  bool read_unsynced_data_;   // See SetReadUnsyncedData()
-  bool allow_link_open_file_;  // See SetAllowLinkOpenFile()
+  bool read_unsynced_data_;         // See SetReadUnsyncedData()
+  bool allow_link_open_file_;       // See SetAllowLinkOpenFile()
   IOStatus fs_error_;
 
   enum ErrorType : int {

--- a/utilities/persistent_cache/block_cache_tier.h
+++ b/utilities/persistent_cache/block_cache_tier.h
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-
 #ifndef OS_WIN
 #include <unistd.h>
 #endif  // ! OS_WIN
@@ -50,7 +49,7 @@ class BlockCacheTier : public PersistentCacheTier {
          opt_.write_buffer_size, opt_.write_buffer_count());
   }
 
-  virtual ~BlockCacheTier() {
+  virtual ~BlockCacheTier() override {
     // Close is re-entrant so we can call close even if it is already closed
     Close().PermitUncheckedError();
     assert(!insert_th_.joinable());
@@ -151,4 +150,3 @@ class BlockCacheTier : public PersistentCacheTier {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/block_cache_tier_file.h
+++ b/utilities/persistent_cache/block_cache_tier_file.h
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-
 #include <list>
 #include <memory>
 #include <string>
@@ -97,7 +96,7 @@ class BlockCacheFile : public LRUElement<BlockCacheFile> {
         dir_(dir),
         cache_id_(cache_id) {}
 
-  virtual ~BlockCacheFile() {}
+  virtual ~BlockCacheFile() override {}
 
   // append key/value to file and return LBA locator to user
   virtual bool Append(const Slice& /*key*/, const Slice& /*val*/,
@@ -149,7 +148,7 @@ class RandomAccessCacheFile : public BlockCacheFile {
                                  const std::shared_ptr<Logger>& log)
       : BlockCacheFile(env, dir, cache_id), log_(log) {}
 
-  virtual ~RandomAccessCacheFile() {}
+  virtual ~RandomAccessCacheFile() override {}
 
   // open file for reading
   bool Open(const bool enable_direct_reads);
@@ -182,7 +181,7 @@ class WriteableCacheFile : public RandomAccessCacheFile {
         writer_(writer),
         max_size_(max_size) {}
 
-  virtual ~WriteableCacheFile();
+  virtual ~WriteableCacheFile() override;
 
   // create file on disk
   bool Create(const bool enable_direct_writes, const bool enable_direct_reads);
@@ -271,7 +270,7 @@ class ThreadedWriter : public Writer {
 
   explicit ThreadedWriter(PersistentCacheTier* const cache, const size_t qdepth,
                           const size_t io_size);
-  virtual ~ThreadedWriter() { assert(threads_.empty()); }
+  virtual ~ThreadedWriter() override { assert(threads_.empty()); }
 
   void Stop() override;
   void Write(WritableFile* const file, CacheWriteBuffer* buf,
@@ -288,4 +287,3 @@ class ThreadedWriter : public Writer {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/hash_table_evictable.h
+++ b/utilities/persistent_cache/hash_table_evictable.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <functional>
 
 #include "util/random.h"
@@ -33,7 +32,7 @@ class EvictableHashTable : private HashTable<T*, Hash, Equal> {
     assert(lru_lists_);
   }
 
-  virtual ~EvictableHashTable() { AssertEmptyLRU(); }
+  virtual ~EvictableHashTable() override { AssertEmptyLRU(); }
 
   //
   // Insert given record to hash table (and LRU list)
@@ -163,4 +162,3 @@ class EvictableHashTable : private HashTable<T*, Hash, Equal> {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/persistent_cache_tier.h
+++ b/utilities/persistent_cache/persistent_cache_tier.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <limits>
 #include <list>
 #include <map>
@@ -236,7 +235,7 @@ class PersistentCacheTier : public PersistentCache {
  public:
   using Tier = std::shared_ptr<PersistentCacheTier>;
 
-  virtual ~PersistentCacheTier() {}
+  virtual ~PersistentCacheTier() override {}
 
   // Open the persistent cache tier
   virtual Status Open();
@@ -297,7 +296,7 @@ class PersistentCacheTier : public PersistentCache {
 // ease and support PersistentCache methods for accessing data.
 class PersistentTieredCache : public PersistentCacheTier {
  public:
-  virtual ~PersistentTieredCache();
+  virtual ~PersistentTieredCache() override;
 
   Status Open() override;
   Status Close() override;
@@ -337,4 +336,3 @@ class PersistentTieredCache : public PersistentCacheTier {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/volatile_tier_impl.h
+++ b/utilities/persistent_cache/volatile_tier_impl.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <atomic>
 #include <limits>
 #include <sstream>
@@ -46,7 +45,7 @@ class VolatileCacheTier : public PersistentCacheTier {
       const size_t max_size = std::numeric_limits<size_t>::max())
       : is_compressed_(is_compressed), max_size_(max_size) {}
 
-  virtual ~VolatileCacheTier();
+  virtual ~VolatileCacheTier() override;
 
   // insert to cache
   Status Insert(const Slice& page_key, const char* data,
@@ -79,7 +78,7 @@ class VolatileCacheTier : public PersistentCacheTier {
     explicit CacheData(const std::string& _key, const std::string& _value = "")
         : key(_key), value(_value) {}
 
-    virtual ~CacheData() {}
+    virtual ~CacheData() override {}
 
     const std::string key;
     const std::string value;
@@ -136,4 +135,3 @@ class VolatileCacheTier : public PersistentCacheTier {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/trace/file_trace_reader_writer.h
+++ b/utilities/trace/file_trace_reader_writer.h
@@ -16,7 +16,7 @@ class WritableFileWriter;
 class FileTraceReader : public TraceReader {
  public:
   explicit FileTraceReader(std::unique_ptr<RandomAccessFileReader>&& reader);
-  ~FileTraceReader();
+  ~FileTraceReader() override;
 
   Status Read(std::string* data) override;
   Status Close() override;
@@ -35,7 +35,7 @@ class FileTraceReader : public TraceReader {
 class FileTraceWriter : public TraceWriter {
  public:
   explicit FileTraceWriter(std::unique_ptr<WritableFileWriter>&& file_writer);
-  ~FileTraceWriter();
+  ~FileTraceWriter() override;
 
   Status Write(const Slice& data) override;
   Status Close() override;

--- a/utilities/transactions/optimistic_transaction.h
+++ b/utilities/transactions/optimistic_transaction.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <stack>
 #include <string>
 #include <unordered_map>
@@ -34,7 +33,7 @@ class OptimisticTransaction : public TransactionBaseImpl {
   OptimisticTransaction(const OptimisticTransaction&) = delete;
   void operator=(const OptimisticTransaction&) = delete;
 
-  virtual ~OptimisticTransaction();
+  virtual ~OptimisticTransaction() override;
 
   void Reinitialize(OptimisticTransactionDB* txn_db,
                     const WriteOptions& write_options,
@@ -96,4 +95,3 @@ class OptimisticTransactionCallback : public WriteCallback {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/optimistic_transaction_db_impl.h
+++ b/utilities/transactions/optimistic_transaction_db_impl.h
@@ -60,7 +60,7 @@ class OptimisticTransactionDBImpl : public OptimisticTransactionDB {
     }
   }
 
-  ~OptimisticTransactionDBImpl() {
+  ~OptimisticTransactionDBImpl() override {
     // Prevent this stackable from destroying
     // base db
     if (!db_owner_) {

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -34,7 +34,7 @@ class PessimisticTransactionDB : public TransactionDB {
   explicit PessimisticTransactionDB(StackableDB* db,
                                     const TransactionDBOptions& txn_db_options);
 
-  virtual ~PessimisticTransactionDB();
+  virtual ~PessimisticTransactionDB() override;
 
   const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
 
@@ -274,7 +274,7 @@ class WriteCommittedTxnDB : public PessimisticTransactionDB {
                                const TransactionDBOptions& txn_db_options)
       : PessimisticTransactionDB(db, txn_db_options) {}
 
-  virtual ~WriteCommittedTxnDB() {}
+  virtual ~WriteCommittedTxnDB() override {}
 
   Transaction* BeginTransaction(const WriteOptions& write_options,
                                 const TransactionOptions& txn_options,

--- a/utilities/transactions/write_prepared_txn.h
+++ b/utilities/transactions/write_prepared_txn.h
@@ -44,7 +44,7 @@ class WritePreparedTxn : public PessimisticTransaction {
   WritePreparedTxn(const WritePreparedTxn&) = delete;
   void operator=(const WritePreparedTxn&) = delete;
 
-  virtual ~WritePreparedTxn() {}
+  virtual ~WritePreparedTxn() override {}
 
   // To make WAL commit markers visible, the snapshot will be based on the last
   // seq in the WAL that is also published, LastPublishedSequence, as opposed to

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -59,7 +59,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     Init(txn_db_options);
   }
 
-  virtual ~WritePreparedTxnDB();
+  virtual ~WritePreparedTxnDB() override;
 
   Status Initialize(const std::vector<size_t>& compaction_enabled_cf_indices,
                     const std::vector<ColumnFamilyHandle*>& handles) override;
@@ -851,7 +851,7 @@ class WritePreparedTxnReadCallback : public ReadCallback {
     (void)backed_by_snapshot_;  // to silence unused private field warning
   }
 
-  virtual ~WritePreparedTxnReadCallback() {
+  virtual ~WritePreparedTxnReadCallback() override {
     // If it is not backed by snapshot, the caller must check validity
     assert(valid_checked_ || backed_by_snapshot_ == kBackedByDBSnapshot);
   }

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <set>
 
 #include "utilities/transactions/write_prepared_txn.h"
@@ -69,7 +68,7 @@ class WriteUnpreparedTxnReadCallback : public ReadCallback {
     (void)backed_by_snapshot_;  // to silence unused private field warning
   }
 
-  virtual ~WriteUnpreparedTxnReadCallback() {
+  virtual ~WriteUnpreparedTxnReadCallback() override {
     // If it is not backed by snapshot, the caller must check validity
     assert(valid_checked_ || backed_by_snapshot_ == kBackedByDBSnapshot);
   }
@@ -114,7 +113,7 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
                      const WriteOptions& write_options,
                      const TransactionOptions& txn_options);
 
-  virtual ~WriteUnpreparedTxn();
+  virtual ~WriteUnpreparedTxn() override;
 
   using TransactionBaseImpl::Put;
   Status Put(ColumnFamilyHandle* column_family, const Slice& key,
@@ -272,7 +271,7 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
 
     SavePoint(const std::map<SequenceNumber, size_t>& seqs,
               ManagedSnapshot* snapshot)
-        : unprep_seqs_(seqs), snapshot_(snapshot){}
+        : unprep_seqs_(seqs), snapshot_(snapshot) {}
   };
 
   // We have 3 data structures holding savepoint information:

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -34,7 +34,7 @@ class DBWithTTLImpl : public DBWithTTL {
   static void RegisterTtlClasses();
   explicit DBWithTTLImpl(DB* db);
 
-  virtual ~DBWithTTLImpl();
+  virtual ~DBWithTTLImpl() override;
 
   Status Close() override;
 
@@ -109,7 +109,7 @@ class TtlIterator : public Iterator {
  public:
   explicit TtlIterator(Iterator* iter) : iter_(iter) { assert(iter_); }
 
-  ~TtlIterator() { delete iter_; }
+  ~TtlIterator() override { delete iter_; }
 
   bool Valid() const override { return iter_->Valid(); }
 


### PR DESCRIPTION
# Summary

This was suggested in https://github.com/facebook/rocksdb/pull/13212#issuecomment-2546384807. It should help reduce the discrepancy between our CI checks here and the CI checks that get run as part of releases to fbcode.

I am still not sure why the fbcode CI checked only complained about 2 instances of this missing `override` issue when there are clearly many, many more examples.

Note that with `clang-10`, this `-Wsuggest-destructor-override` option is not recognized, so I only add it for `clang-13` in the MAKEFILE. 

# Test Plan

These updated GitHub CI checks should pass, and we should no longer run into the same surprise at release time in the fbcode repo.