### PR TITLE
Detect WAL hole

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2071,23 +2071,26 @@ class DBImpl : public DB {
       bool read_only, int job_id, SequenceNumber* next_sequence,
       bool* stop_replay_for_corruption, bool* stop_replay_by_wal_filter,
       uint64_t* corrupted_wal_number, bool* corrupted_wal_found,
-      std::unordered_map<int, VersionEdit>* version_edits, bool* flushed);
+      std::unordered_map<int, VersionEdit>* version_edits, bool* flushed,
+      PredecessorWALInfo& predecessor_wal_info);
 
   void SetupLogFileProcessing(uint64_t wal_number);
 
-  Status InitializeLogReader(uint64_t wal_number, bool is_retry,
-                             std::string& fname, bool* const old_log_record,
-                             Status* const reporter_status,
-                             DBOpenLogReporter* reporter,
-                             std::unique_ptr<log::Reader>& reader);
+  Status InitializeLogReader(
+      uint64_t wal_number, bool is_retry, std::string& fname,
+
+      bool stop_replay_for_corruption, uint64_t min_wal_number,
+      const PredecessorWALInfo& predecessor_wal_info,
+      bool* const old_log_record, Status* const reporter_status,
+      DBOpenLogReporter* reporter, std::unique_ptr<log::Reader>& reader);
   Status ProcessLogRecord(
       Slice record, const std::unique_ptr<log::Reader>& reader,
       const UnorderedMap<uint32_t, size_t>& running_ts_sz, uint64_t wal_number,
       const std::string& fname, bool read_only, int job_id,
       std::function<void()> logFileDropped, DBOpenLogReporter* reporter,
-      uint64_t* record_checksum, SequenceNumber* next_sequence,
-      bool* stop_replay_for_corruption, Status* status,
-      bool* stop_replay_by_wal_filter,
+      uint64_t* record_checksum, SequenceNumber* last_seqno_observed,
+      SequenceNumber* next_sequence, bool* stop_replay_for_corruption,
+      Status* status, bool* stop_replay_by_wal_filter,
       std::unordered_map<int, VersionEdit>* version_edits, bool* flushed);
 
   Status InitializeWriteBatchForLogRecord(
@@ -2116,8 +2119,13 @@ class DBImpl : public DB {
       bool* stop_replay_for_corruption, uint64_t* corrupted_wal_number,
       bool* corrupted_wal_found);
 
-  void FinishLogFileProcessing(SequenceNumber const* const next_sequence,
-                               const Status& status);
+  Status UpdatePredecessorWALInfo(uint64_t wal_number,
+                                  const SequenceNumber last_seqno_observed,
+                                  const std::string& fname,
+                                  PredecessorWALInfo& predecessor_wal_info);
+
+  void FinishLogFileProcessing(const Status& status,
+                               const SequenceNumber* next_sequence);
 
   // Return `Status::Corruption()` when `stop_replay_for_corruption == true` and
   // exits inconsistency between SST and WAL data
@@ -2309,7 +2317,8 @@ class DBImpl : public DB {
                       const WriteOptions& write_options,
                       log::Writer* log_writer, uint64_t* log_used,
                       uint64_t* log_size,
-                      LogFileNumberSize& log_file_number_size);
+                      LogFileNumberSize& log_file_number_size,
+                      SequenceNumber sequence);
 
   IOStatus WriteToWAL(const WriteThread::WriteGroup& write_group,
                       log::Writer* log_writer, uint64_t* log_used,
@@ -2554,6 +2563,7 @@ class DBImpl : public DB {
 
   IOStatus CreateWAL(const WriteOptions& write_options, uint64_t log_file_num,
                      uint64_t recycle_log_number, size_t preallocate_block_size,
+                     const PredecessorWALInfo& predecessor_wal_info,
                      log::Writer** new_log);
 
   // Validate self-consistency of DB options

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -1179,4 +1179,64 @@ struct ParsedInternalKeyComparator {
   const InternalKeyComparator* cmp;
 };
 
+class PredecessorWALInfo {
+ public:
+  PredecessorWALInfo()
+      : log_number_(0),
+        size_bytes_(0),
+        last_seqno_recorded_(0),
+        initialized_(false) {}
+
+  explicit PredecessorWALInfo(uint64_t log_number, uint64_t size_bytes,
+                              SequenceNumber last_seqno_recorded)
+      : log_number_(log_number),
+        size_bytes_(size_bytes),
+        last_seqno_recorded_(last_seqno_recorded),
+        initialized_(true) {}
+
+  uint64_t GetLogNumber() const {
+    assert(initialized_);
+    return log_number_;
+  }
+
+  uint64_t GetSizeBytes() const {
+    assert(initialized_);
+    return size_bytes_;
+  }
+
+  SequenceNumber GetLastSeqnoRecorded() const {
+    assert(initialized_);
+    return last_seqno_recorded_;
+  }
+
+  bool IsInitialized() const { return initialized_; }
+
+  inline void EncodeTo(std::string* dst) const {
+    assert(dst != nullptr);
+    assert(initialized_);
+    PutFixed64(dst, log_number_);
+    PutFixed64(dst, size_bytes_);
+    PutFixed64(dst, last_seqno_recorded_);
+  }
+
+  inline Status DecodeFrom(Slice* src) {
+    if (!GetFixed64(src, &log_number_)) {
+      return Status::Corruption("Error decoding log number");
+    }
+    if (!GetFixed64(src, &size_bytes_)) {
+      return Status::Corruption("Error decoding size bytes");
+    }
+    if (!GetFixed64(src, &last_seqno_recorded_)) {
+      return Status::Corruption("Error decoding last seqno recorded");
+    }
+    initialized_ = true;
+    return Status::OK();
+  }
+
+ private:
+  uint64_t log_number_;
+  uint64_t size_bytes_;
+  SequenceNumber last_seqno_recorded_;
+  bool initialized_;
+};
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/log_format.h
+++ b/db/log_format.h
@@ -38,13 +38,18 @@ enum RecordType : uint8_t {
   // Compression Type
   kSetCompressionType = 9,
 
+  // For all the values >= 10, the 1 bit indicates whether it's recyclable
   // User-defined timestamp sizes
   kUserDefinedTimestampSizeType = 10,
   kRecyclableUserDefinedTimestampSizeType = 11,
+
+  // For WAL verification
+  kPredecessorWALInfoType = 130,
+  kRecyclePredecessorWALInfoType = 131,
 };
 // Unknown type of value with the 8-th bit set will be ignored
 constexpr uint8_t kRecordTypeSafeIgnoreMask = 1 << 7;
-constexpr uint8_t kMaxRecordType = kRecyclableUserDefinedTimestampSizeType;
+constexpr uint8_t kMaxRecordType = kRecyclePredecessorWALInfoType;
 
 constexpr unsigned int kBlockSize = 32768;
 

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -465,7 +465,7 @@ TEST_P(LogTest, TruncatedTrailingRecordIsNotIgnored) {
   Write("foo");
   ShrinkSize(4);  // Drop all payload as well as a header byte
   ASSERT_EQ("EOF", Read(WALRecoveryMode::kAbsoluteConsistency));
-  // Truncated last record is ignored, not treated as an error
+  // Truncated last record is not ignored, treated as an error
   ASSERT_GT(DroppedBytes(), 0U);
   ASSERT_EQ("OK", MatchError("Corruption: truncated header"));
 }

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "db/dbformat.h"
 #include "db/log_format.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/env.h"
@@ -76,18 +77,24 @@ class Writer {
   // Create a writer that will append data to "*dest".
   // "*dest" must be initially empty.
   // "*dest" must remain live while this Writer is in use.
+  // TODO(hx235): seperate WAL related parameters from general `Reader`
+  // parameters
   explicit Writer(std::unique_ptr<WritableFileWriter>&& dest,
                   uint64_t log_number, bool recycle_log_files,
                   bool manual_flush = false,
-                  CompressionType compressionType = kNoCompression);
+                  CompressionType compressionType = kNoCompression,
+                  bool track_and_verify_wals = false);
   // No copying allowed
   Writer(const Writer&) = delete;
   void operator=(const Writer&) = delete;
 
   ~Writer();
 
-  IOStatus AddRecord(const WriteOptions& write_options, const Slice& slice);
+  IOStatus AddRecord(const WriteOptions& write_options, const Slice& slice,
+                     const SequenceNumber& seqno = 0);
   IOStatus AddCompressionTypeRecord(const WriteOptions& write_options);
+  IOStatus MaybeAddPredecessorWALInfo(const WriteOptions& write_options,
+                                      const PredecessorWALInfo& info);
 
   // If there are column families in `cf_to_ts_sz` not included in
   // `recorded_cf_to_ts_sz_` and its user-defined timestamp size is non-zero,
@@ -116,6 +123,8 @@ class Writer {
 
   size_t TEST_block_offset() const { return block_offset_; }
 
+  SequenceNumber GetLastSeqnoRecorded() const { return last_seqno_recorded_; };
+
  private:
   std::unique_ptr<WritableFileWriter> dest_;
   size_t block_offset_;  // Current offset in block
@@ -131,6 +140,11 @@ class Writer {
   IOStatus EmitPhysicalRecord(const WriteOptions& write_options,
                               RecordType type, const char* ptr, size_t length);
 
+  IOStatus MaybeHandleSeenFileWriterError();
+
+  IOStatus MaybeSwitchToNewBlock(const WriteOptions& write_options,
+                                 const std::string& content_to_write);
+
   // If true, it does not flush after each write. Instead it relies on the upper
   // layer to manually does the flush by calling ::WriteBuffer()
   bool manual_flush_;
@@ -145,6 +159,11 @@ class Writer {
   // Since the user-defined timestamp size cannot be changed while the DB is
   // running, existing entry in this map cannot be updated.
   UnorderedMap<uint32_t, size_t> recorded_cf_to_ts_sz_;
+
+  // See `Options::track_and_verify_wals`
+  bool track_and_verify_wals_;
+
+  SequenceNumber last_seqno_recorded_;
 };
 
 }  // namespace log

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -421,6 +421,7 @@ DECLARE_int32(test_ingest_standalone_range_deletion_one_in);
 DECLARE_bool(allow_unprepared_value);
 DECLARE_string(file_temperature_age_thresholds);
 DECLARE_uint32(commit_bypass_memtable_one_in);
+DECLARE_bool(track_and_verify_wals);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -847,6 +847,10 @@ DEFINE_bool(allow_unprepared_value,
             ROCKSDB_NAMESPACE::ReadOptions().allow_unprepared_value,
             "Allow lazy loading of values for range scans");
 
+DEFINE_bool(track_and_verify_wals,
+            ROCKSDB_NAMESPACE::Options().track_and_verify_wals,
+            "See Options::track_and_verify_wals");
+
 static bool ValidateInt32Percent(const char* flagname, int32_t value) {
   if (value < 0 || value > 100) {
     fprintf(stderr, "Invalid value for --%s: %d, 0<= pct <=100 \n", flagname,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4127,6 +4127,7 @@ void InitializeOptionsFromFlags(
   options.level_compaction_dynamic_level_bytes =
       FLAGS_level_compaction_dynamic_level_bytes;
   options.track_and_verify_wals_in_manifest = true;
+  options.track_and_verify_wals = FLAGS_track_and_verify_wals;
   options.verify_sst_unique_id_in_manifest =
       FLAGS_verify_sst_unique_id_in_manifest;
   options.memtable_protection_bytes_per_key =

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -632,6 +632,26 @@ struct DBOptions {
   // Default: false
   bool track_and_verify_wals_in_manifest = false;
 
+  // EXPERIMENTAL
+  //
+  // If true, each new WAL will record various information about its predecessor
+  // WAL for verification on the predecessor WAL during WAL recovery.
+  //
+  // It verifies the following:
+  // 1. There exists at least some WAL in the DB
+  // - It's not compatible with `RepairDB()` since this option imposes a
+  // stricter requirement on WAL than the DB went through `RepariDB()` can
+  // normally meet
+  // 2. There exists no WAL hole where new WAL data presents while some old WAL
+  // data not yet obsolete is missing. The DB manifest indicates which WALs are
+  // obsolete.
+  //
+  // This is intended to be a better replacement to
+  // `track_and_verify_wals_in_manifest`.
+  //
+  // Default: false
+  bool track_and_verify_wals = false;
+
   // If true, verifies the SST unique id between MANIFEST and actual file
   // each time an SST file is opened. This check ensures an SST file is not
   // overwritten or misplaced. A corruption error will be reported if mismatch

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -230,6 +230,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    track_and_verify_wals_in_manifest),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"track_and_verify_wals",
+         {offsetof(struct ImmutableDBOptions, track_and_verify_wals),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         {"verify_sst_unique_id_in_manifest",
          {offsetof(struct ImmutableDBOptions, verify_sst_unique_id_in_manifest),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -716,6 +720,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       compaction_verify_record_count(options.compaction_verify_record_count),
       track_and_verify_wals_in_manifest(
           options.track_and_verify_wals_in_manifest),
+      track_and_verify_wals(options.track_and_verify_wals),
       verify_sst_unique_id_in_manifest(
           options.verify_sst_unique_id_in_manifest),
       env(options.env),
@@ -820,6 +825,10 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    "                              "
                    "Options.track_and_verify_wals_in_manifest: %d",
                    track_and_verify_wals_in_manifest);
+  ROCKS_LOG_HEADER(log,
+                   "                              "
+                   "Options.track_and_verify_wals: %d",
+                   track_and_verify_wals);
   ROCKS_LOG_HEADER(log, "       Options.verify_sst_unique_id_in_manifest: %d",
                    verify_sst_unique_id_in_manifest);
   ROCKS_LOG_HEADER(log, "                                    Options.env: %p",

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -27,6 +27,7 @@ struct ImmutableDBOptions {
   bool flush_verify_memtable_count;
   bool compaction_verify_record_count;
   bool track_and_verify_wals_in_manifest;
+  bool track_and_verify_wals;
   bool verify_sst_unique_id_in_manifest;
   Env* env;
   std::shared_ptr<RateLimiter> rate_limiter;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -71,6 +71,7 @@ void BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.compaction_verify_record_count;
   options.track_and_verify_wals_in_manifest =
       immutable_db_options.track_and_verify_wals_in_manifest;
+  options.track_and_verify_wals = immutable_db_options.track_and_verify_wals;
   options.verify_sst_unique_id_in_manifest =
       immutable_db_options.verify_sst_unique_id_in_manifest;
   options.env = immutable_db_options.env;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -406,6 +406,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "flush_verify_memtable_count=true;"
                              "compaction_verify_record_count=true;"
                              "track_and_verify_wals_in_manifest=true;"
+                             "track_and_verify_wals=true;"
                              "verify_sst_unique_id_in_manifest=true;"
                              "is_fd_close_on_exec=false;"
                              "bytes_per_sync=4295013613;"

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -146,6 +146,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"error_if_exists", "false"},
       {"paranoid_checks", "true"},
       {"track_and_verify_wals_in_manifest", "true"},
+      {"track_and_verify_wals", "true"},
       {"verify_sst_unique_id_in_manifest", "true"},
       {"max_open_files", "32"},
       {"max_total_wal_size", "33"},
@@ -329,6 +330,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.error_if_exists, false);
   ASSERT_EQ(new_db_opt.paranoid_checks, true);
   ASSERT_EQ(new_db_opt.track_and_verify_wals_in_manifest, true);
+  ASSERT_EQ(new_db_opt.track_and_verify_wals, true);
   ASSERT_EQ(new_db_opt.verify_sst_unique_id_in_manifest, true);
   ASSERT_EQ(new_db_opt.max_open_files, 32);
   ASSERT_EQ(new_db_opt.max_total_wal_size, static_cast<uint64_t>(33));
@@ -901,6 +903,7 @@ TEST_F(OptionsTest, OldInterfaceTest) {
       {"error_if_exists", "false"},
       {"paranoid_checks", "true"},
       {"track_and_verify_wals_in_manifest", "true"},
+      {"track_and_verify_wals", "true"},
       {"verify_sst_unique_id_in_manifest", "true"},
       {"max_open_files", "32"},
       {"daily_offpeak_time_utc", "06:30-23:30"},
@@ -916,6 +919,7 @@ TEST_F(OptionsTest, OldInterfaceTest) {
   ASSERT_EQ(new_db_opt.error_if_exists, false);
   ASSERT_EQ(new_db_opt.paranoid_checks, true);
   ASSERT_EQ(new_db_opt.track_and_verify_wals_in_manifest, true);
+  ASSERT_EQ(new_db_opt.track_and_verify_wals, true);
   ASSERT_EQ(new_db_opt.verify_sst_unique_id_in_manifest, true);
   ASSERT_EQ(new_db_opt.max_open_files, 32);
   db_options_map["unknown_option"] = "1";
@@ -2450,6 +2454,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
       {"error_if_exists", "false"},
       {"paranoid_checks", "true"},
       {"track_and_verify_wals_in_manifest", "true"},
+      {"track_and_verify_wals", "true"},
       {"verify_sst_unique_id_in_manifest", "true"},
       {"max_open_files", "32"},
       {"max_total_wal_size", "33"},
@@ -2638,6 +2643,7 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.error_if_exists, false);
   ASSERT_EQ(new_db_opt.paranoid_checks, true);
   ASSERT_EQ(new_db_opt.track_and_verify_wals_in_manifest, true);
+  ASSERT_EQ(new_db_opt.track_and_verify_wals, true);
   ASSERT_EQ(new_db_opt.max_open_files, 32);
   ASSERT_EQ(new_db_opt.max_total_wal_size, static_cast<uint64_t>(33));
   ASSERT_EQ(new_db_opt.use_fsync, true);

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -308,6 +308,7 @@ void RandomInitDBOptions(DBOptions* db_opt, Random* rnd) {
   db_opt->is_fd_close_on_exec = rnd->Uniform(2);
   db_opt->paranoid_checks = rnd->Uniform(2);
   db_opt->track_and_verify_wals_in_manifest = rnd->Uniform(2);
+  db_opt->track_and_verify_wals = rnd->Uniform(2);
   db_opt->verify_sst_unique_id_in_manifest = rnd->Uniform(2);
   db_opt->skip_stats_update_on_db_open = rnd->Uniform(2);
   db_opt->skip_checking_sst_file_sizes_on_db_open = rnd->Uniform(2);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1808,6 +1808,8 @@ DEFINE_bool(build_info, false,
 DEFINE_bool(track_and_verify_wals_in_manifest, false,
             "If true, enable WAL tracking in the MANIFEST");
 
+DEFINE_bool(track_and_verify_wals, false, "See Options.track_and_verify_wals");
+
 namespace ROCKSDB_NAMESPACE {
 namespace {
 static Status CreateMemTableRepFactory(
@@ -4721,6 +4723,7 @@ class Benchmark {
     options.allow_data_in_errors = FLAGS_allow_data_in_errors;
     options.track_and_verify_wals_in_manifest =
         FLAGS_track_and_verify_wals_in_manifest;
+    options.track_and_verify_wals = FLAGS_track_and_verify_wals;
 
     // Integrated BlobDB
     options.enable_blob_files = FLAGS_enable_blob_files;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -343,6 +343,7 @@ default_params = {
     "universal_max_read_amp": lambda: random.choice([-1] * 3 + [0, 4, 10]),
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
+    "track_and_verify_wals": lambda: random.choice([0, 1]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR

--- a/unreleased_history/new_features/track_and_verify_wals_api.md
+++ b/unreleased_history/new_features/track_and_verify_wals_api.md
@@ -1,0 +1,1 @@
+Provide a new option `track_and_verify_wals` to track and verify various information about WAL during WAL recovery. This is intended to be a better replacement to `track_and_verify_wals_in_manifest`.


### PR DESCRIPTION
**Context/Summary:**

This PR provides a new Options `track_and_verify_wals` to detect and handle WAL hole where new WAL data presents while some old WAL data is missing as well as db opened with no WAL. It's for https://github.com/facebook/rocksdb/issues/12488.

It's intended to be a future replacement to `track_and_verify_wals_in_manifest` for its simplicity, better handling of WAL hole in  `WALRecoveryMode::kPointInTimeRecovery` and potentials to cover more scenarios for `WALRecoveryMode::kTolerateCorruptedTailRecords/kAbsoluteConsistency`(in future PRs).

The verification is done in `LogReader::MaybeVerifyPredecessorWALInfo()` and tracking is done in `log::Writer::MaybeAddPredecessorWALInfo()`. This PR also groups common utilities in `log::Writer` into functions  `MaybeHandleSeenFileWriterError()`, `MaybeSwitchToNewBlock()` to avoid adding redundant code

**Test:**
- New UT
- Integrate into existing UT
- Intense rehearsal stress/crash test
- db bench
   - The only potential performance implication it has is to the write path since now we keep track of the last seqno recorded in the WAL in `log::Writer`. Below benchmark show no regression.
```
./db_bench --benchmarks=fillrandom[-X3] --num=2500000 --db=/dev/shm/db_bench_new --disable_auto_compactions=1 --threads=1 --enable_pipelined_write=0 --disable_wal=0 --track_and_verify_wals=1

Pre
fillrandom [AVG    3 runs] : 310517 (± 5641) ops/sec;   34.4 (± 0.6) MB/sec
fillrandom [MEDIAN 3 runs] : 308848 ops/sec;   34.2 MB/sec

Post
fillrandom [AVG    3 runs] : 311469 (± 4096) ops/sec;   34.5 (± 0.5) MB/sec
fillrandom [MEDIAN 3 runs] : 311961 ops/sec;   34.5 MB/sec
```

