### PR TITLE
Standardize on clang-format version 18

### DIFF
--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -31,7 +31,7 @@ jobs:
   # ======================== Fast Initial Checks ====================== #
   check-format-and-targets:
     if: ${{ github.repository_owner == 'facebook' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4.1.0
       with:

--- a/cache/cache.cc
+++ b/cache/cache.cc
@@ -118,7 +118,6 @@ Status SecondaryCache::CreateFromString(
       sec_cache = NewCompressedSecondaryCache(sec_cache_opts);
     }
 
-
     if (status.ok()) {
       result->swap(sec_cache);
     }

--- a/cache/cache_bench_tool.cc
+++ b/cache/cache_bench_tool.cc
@@ -191,8 +191,7 @@ namespace {
 class SharedState {
  public:
   explicit SharedState(CacheBench* cache_bench)
-      : cv_(&mu_),
-        cache_bench_(cache_bench) {}
+      : cv_(&mu_), cache_bench_(cache_bench) {}
 
   ~SharedState() = default;
 

--- a/cache/compressed_secondary_cache_test.cc
+++ b/cache/compressed_secondary_cache_test.cc
@@ -845,7 +845,6 @@ TEST_P(CompressedSecondaryCacheTestWithCompressionParam,
   BasicTestHelper(sec_cache, sec_cache_is_compressed_);
 }
 
-
 TEST_P(CompressedSecondaryCacheTestWithCompressionParam, FailsTest) {
   FailsTest(sec_cache_is_compressed_);
 }

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -93,9 +93,8 @@ void LRUHandleTable::Resize() {
 
   uint32_t old_length = uint32_t{1} << length_bits_;
   int new_length_bits = length_bits_ + 1;
-  std::unique_ptr<LRUHandle* []> new_list {
-    new LRUHandle* [size_t{1} << new_length_bits] {}
-  };
+  std::unique_ptr<LRUHandle*[]> new_list{
+      new LRUHandle* [size_t{1} << new_length_bits] {}};
   [[maybe_unused]] uint32_t count = 0;
   for (uint32_t i = 0; i < old_length; i++) {
     LRUHandle* h = list_[i];

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -546,7 +546,7 @@ TYPED_TEST(ClockCacheTest, Limits) {
     // verify usage tracking on detached entries.)
     {
       size_t n = kCapacity * 5 + 1;
-      std::unique_ptr<HandleImpl* []> ha { new HandleImpl* [n] {} };
+      std::unique_ptr<HandleImpl*[]> ha{new HandleImpl* [n] {}};
       Status s;
       for (size_t i = 0; i < n && s.ok(); ++i) {
         hkey[1] = i;
@@ -713,7 +713,7 @@ TYPED_TEST(ClockCacheTest, ClockEvictionEffortCapTest) {
       // evictable entries are present beyond the cache capacity, despite
       // being evictable.
       constexpr size_t kCount = kCapacity - 1;
-      std::unique_ptr<HandleImpl* []> ha { new HandleImpl* [kCount] {} };
+      std::unique_ptr<HandleImpl*[]> ha{new HandleImpl* [kCount] {}};
       for (size_t i = 0; i < 2 * kCount; ++i) {
         UniqueId64x2 hkey = this->CheapHash(i);
         ASSERT_OK(shard.Insert(

--- a/cache/secondary_cache.cc
+++ b/cache/secondary_cache.cc
@@ -7,6 +7,4 @@
 
 #include "cache/cache_entry_roles.h"
 
-namespace ROCKSDB_NAMESPACE {
-
-}  // namespace ROCKSDB_NAMESPACE
+namespace ROCKSDB_NAMESPACE {}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_source.cc
+++ b/db/blob/blob_source.cc
@@ -82,8 +82,8 @@ Status BlobSource::PutBlobIntoCache(
   assert(cached_blob->IsEmpty());
 
   TypedHandle* cache_handle = nullptr;
-  const Status s = InsertEntryIntoCache(cache_key, blob->get(),
-                                        &cache_handle, Cache::Priority::BOTTOM);
+  const Status s = InsertEntryIntoCache(cache_key, blob->get(), &cache_handle,
+                                        Cache::Priority::BOTTOM);
   if (s.ok()) {
     blob->release();
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -231,7 +231,7 @@ struct rocksdb_livefiles_t {
 };
 struct rocksdb_column_family_handle_t {
   ColumnFamilyHandle* rep;
-  bool immortal;  /* only true for default cf */
+  bool immortal; /* only true for default cf */
 };
 struct rocksdb_column_family_metadata_t {
   ColumnFamilyMetaData rep;

--- a/db/compact_files_test.cc
+++ b/db/compact_files_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include <mutex>
 #include <string>
 #include <thread>

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -460,7 +460,6 @@ class Compaction {
   void MarkFilesBeingCompacted(bool being_compacted) const;
 
  private:
-
   Status InitInputTableProperties();
 
   // get the smallest and largest key present in files to be compacted

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -959,8 +959,7 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options,
   UpdateCompactionJobStats(stats);
 
   auto stream = event_logger_->LogToBuffer(log_buffer_, 8192);
-  stream << "job" << job_id_ << "event"
-         << "compaction_finished"
+  stream << "job" << job_id_ << "event" << "compaction_finished"
          << "compaction_time_micros" << stats.micros
          << "compaction_time_cpu_micros" << stats.cpu_micros << "output_level"
          << compact_->compaction->output_level() << "num_output_files"
@@ -1050,12 +1049,10 @@ void CompactionJob::NotifyOnSubcompactionBegin(
     listener->OnSubcompactionBegin(info);
   }
   info.status.PermitUncheckedError();
-
 }
 
 void CompactionJob::NotifyOnSubcompactionCompleted(
     SubcompactionState* sub_compact) {
-
   if (db_options_.listeners.empty()) {
     return;
   }
@@ -2135,8 +2132,7 @@ void CompactionJob::LogCompaction() {
                    cfd->GetName().c_str(), scratch);
     // build event logger report
     auto stream = event_logger_->Log();
-    stream << "job" << job_id_ << "event"
-           << "compaction_started"
+    stream << "job" << job_id_ << "event" << "compaction_started"
            << "compaction_reason"
            << GetCompactionReasonString(compaction->compaction_reason());
     for (size_t i = 0; i < compaction->num_input_levels(); ++i) {

--- a/db/compaction/compaction_job_stats_test.cc
+++ b/db/compaction/compaction_job_stats_test.cc
@@ -959,7 +959,6 @@ int main(int argc, char** argv) {
   return RUN_ALL_TESTS();
 }
 
-
 #else
 
 int main(int /*argc*/, char** /*argv*/) { return 0; }

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "db/compaction/compaction_job.h"
 
 #include <algorithm>
@@ -1900,8 +1899,8 @@ TEST_F(CompactionJobTest, CutToSkipGrandparentFile) {
   const std::vector<int> input_levels = {0, 1};
   auto lvl0_files = cfd_->current()->storage_info()->LevelFiles(0);
   auto lvl1_files = cfd_->current()->storage_info()->LevelFiles(1);
-    RunCompaction({lvl0_files, lvl1_files}, input_levels,
-                  {expected_file1, expected_file2});
+  RunCompaction({lvl0_files, lvl1_files}, input_levels,
+                {expected_file1, expected_file2});
 }
 
 TEST_F(CompactionJobTest, CutToAlignGrandparentBoundary) {
@@ -1975,8 +1974,8 @@ TEST_F(CompactionJobTest, CutToAlignGrandparentBoundary) {
   const std::vector<int> input_levels = {0, 1};
   auto lvl0_files = cfd_->current()->storage_info()->LevelFiles(0);
   auto lvl1_files = cfd_->current()->storage_info()->LevelFiles(1);
-    RunCompaction({lvl0_files, lvl1_files}, input_levels,
-                  {expected_file1, expected_file2});
+  RunCompaction({lvl0_files, lvl1_files}, input_levels,
+                {expected_file1, expected_file2});
 }
 
 TEST_F(CompactionJobTest, CutToAlignGrandparentBoundarySameKey) {
@@ -2037,8 +2036,8 @@ TEST_F(CompactionJobTest, CutToAlignGrandparentBoundarySameKey) {
   for (int i = 80; i <= 100; i++) {
     snapshots.emplace_back(i);
   }
-    RunCompaction({lvl0_files, lvl1_files}, input_levels,
-                  {expected_file1, expected_file2}, snapshots);
+  RunCompaction({lvl0_files, lvl1_files}, input_levels,
+                {expected_file1, expected_file2}, snapshots);
 }
 
 TEST_F(CompactionJobTest, CutForMaxCompactionBytesSameKey) {

--- a/db/convenience.cc
+++ b/db/convenience.cc
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 
-
 #include "rocksdb/convenience.h"
 
 #include "db/convenience_impl.h"

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -7,8 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "rocksdb/options.h"
-
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -25,6 +23,7 @@
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
+#include "rocksdb/options.h"
 #include "rocksdb/table.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "rocksdb/write_batch.h"

--- a/db/cuckoo_table_db_test.cc
+++ b/db/cuckoo_table_db_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "db/db_impl/db_impl.h"
 #include "db/db_test_util.h"
 #include "rocksdb/db.h"
@@ -349,4 +348,3 @@ int main(int argc, char** argv) {
     return 0;
   }
 }
-

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -878,7 +878,6 @@ TEST_F(DBBasicTest, Snapshot) {
   } while (ChangeOptions());
 }
 
-
 class DBBasicMultiConfigs : public DBBasicTest,
                             public ::testing::WithParamInterface<int> {
  public:
@@ -2604,8 +2603,7 @@ class DBMultiGetAsyncIOTest : public DBBasicTest,
     // Warm up the block cache so we don't need to use the IO uring
     Iterator* iter = dbfull()->NewIterator(ReadOptions());
     for (iter->SeekToFirst(); iter->Valid() && iter->status().ok();
-         iter->Next())
-      ;
+         iter->Next());
     EXPECT_OK(iter->status());
     delete iter;
 #endif  // ROCKSDB_IOURING_PRESENT

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -305,7 +305,6 @@ class ReadOnlyCacheWrapper : public CacheWrapper {
 }  // anonymous namespace
 #endif  // SNAPPY
 
-
 // Make sure that when options.block_cache is set, after a new table is
 // created its index/filter blocks are added to block cache.
 TEST_F(DBBlockCacheTest, IndexAndFilterBlocksOfNewTableAddedToCache) {
@@ -1758,8 +1757,8 @@ class CacheKeyTest : public testing::Test {
     tp_.db_id = std::to_string(db_id_);
     tp_.orig_file_number = file_number;
     bool is_stable;
-    std::string cur_session_id;       // ignored
-    uint64_t cur_file_number = 42;    // ignored
+    std::string cur_session_id;     // ignored
+    uint64_t cur_file_number = 42;  // ignored
     OffsetableCacheKey rv;
     BlockBasedTable::SetupBaseCacheKey(&tp_, cur_session_id, cur_file_number,
                                        &rv, &is_stable);

--- a/db/db_dynamic_level_test.cc
+++ b/db/db_dynamic_level_test.cc
@@ -491,7 +491,6 @@ TEST_F(DBTestDynamicLevel, DISABLED_MigrateToDynamicLevelMaxBytesBase) {
 }
 }  // namespace ROCKSDB_NAMESPACE
 
-
 int main(int argc, char** argv) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
   ::testing::InitGoogleTest(&argc, argv);

--- a/db/db_encryption_test.cc
+++ b/db/db_encryption_test.cc
@@ -3,12 +3,13 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 //
+#include <iostream>
+#include <string>
+
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"
 #include "test_util/sync_point.h"
-#include <iostream>
-#include <string>
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -24,7 +25,6 @@ class DBEncryptionTest : public DBTestBase {
     }
   }
 };
-
 
 TEST_F(DBEncryptionTest, CheckEncrypted) {
   ASSERT_OK(Put("foo567", "v1.fetdq"));
@@ -115,7 +115,6 @@ TEST_F(DBEncryptionTest, ReadEmptyFile) {
 
   ASSERT_TRUE(data.empty());
 }
-
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 
-
 #include <algorithm>
 #include <cstdint>
 #include <memory>

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1921,8 +1921,8 @@ class DBImpl : public DB {
     const InternalKey* begin = nullptr;  // nullptr means beginning of key range
     const InternalKey* end = nullptr;    // nullptr means end of key range
     InternalKey* manual_end = nullptr;   // how far we are compacting
-    InternalKey tmp_storage;      // Used to keep track of compaction progress
-    InternalKey tmp_storage1;     // Used to keep track of compaction progress
+    InternalKey tmp_storage;   // Used to keep track of compaction progress
+    InternalKey tmp_storage1;  // Used to keep track of compaction progress
 
     // When the user provides a canceled pointer in CompactRangeOptions, the
     // above varaibe is the reference of the user-provided

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3866,8 +3866,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
                                                              moved_bytes);
     {
       event_logger_.LogToBuffer(log_buffer)
-          << "job" << job_context->job_id << "event"
-          << "trivial_move"
+          << "job" << job_context->job_id << "event" << "trivial_move"
           << "destination_level" << c->output_level() << "files" << moved_files
           << "total_files_size" << moved_bytes;
     }

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1158,8 +1158,7 @@ void DBImpl::SetupLogFilesRecovery(
   {
     auto stream = event_logger_.Log();
     stream << "job" << *job_id;
-    stream << "event"
-           << "recovery_started";
+    stream << "event" << "recovery_started";
     stream << "wal_files";
     stream.StartArray();
     for (auto wal_number : wal_numbers) {

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -16,7 +16,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-
 DBImplReadOnly::DBImplReadOnly(const DBOptions& db_options,
                                const std::string& dbname)
     : DBImpl(db_options, dbname, /*seq_per_batch*/ false,
@@ -371,6 +370,5 @@ Status DBImplReadOnly::OpenForReadOnlyWithoutCheck(
   }
   return s;
 }
-
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 #include <vector>
 

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -1057,5 +1057,4 @@ Status DB::OpenAndCompact(
                         output, override_options);
 }
 
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/db_impl/db_impl_secondary.h
+++ b/db/db_impl/db_impl_secondary.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 #include <vector>
 

--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -332,7 +332,6 @@ TEST_F(DBTestXactLogIterator, TransactionLogIteratorBlobs) {
 }
 }  // namespace ROCKSDB_NAMESPACE
 
-
 int main(int argc, char** argv) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
   ::testing::InitGoogleTest(&argc, argv);

--- a/db/db_merge_operand_test.cc
+++ b/db/db_merge_operand_test.cc
@@ -5,11 +5,11 @@
 
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
+#include "rocksdb/merge_operator.h"
 #include "rocksdb/perf_context.h"
 #include "rocksdb/utilities/debug.h"
 #include "table/block_based/block_builder.h"
 #include "test_util/sync_point.h"
-#include "rocksdb/merge_operator.h"
 #include "utilities/fault_injection_env.h"
 #include "utilities/merge_operators.h"
 #include "utilities/merge_operators/sortlist.h"

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1451,7 +1451,6 @@ TEST_F(DBOptionsTest, ChangeCompression) {
   SyncPoint::GetInstance()->DisableProcessing();
 }
 
-
 TEST_F(DBOptionsTest, BottommostCompressionOptsWithFallbackType) {
   // Verify the bottommost compression options still take effect even when the
   // bottommost compression type is left at its default value. Verify for both

--- a/db/db_rate_limiter_test.cc
+++ b/db/db_rate_limiter_test.cc
@@ -226,7 +226,6 @@ TEST_P(DBRateLimiterOnReadTest, Iterator) {
   ASSERT_EQ(expected, options_.rate_limiter->GetTotalRequests(Env::IO_USER));
 }
 
-
 TEST_P(DBRateLimiterOnReadTest, VerifyChecksum) {
   if (use_direct_io_ && !IsDirectIOSupported()) {
     return;
@@ -270,7 +269,6 @@ TEST_P(DBRateLimiterOnReadTest, VerifyFileChecksums) {
   int expected = kNumFiles;
   ASSERT_EQ(expected, options_.rate_limiter->GetTotalRequests(Env::IO_USER));
 }
-
 
 class DBRateLimiterOnWriteTest : public DBTestBase {
  public:

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -1991,7 +1991,6 @@ TEST_F(DBSSTTest, DBWithSFMForBlobFilesAtomicFlush) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
-
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/db_statistics_test.cc
+++ b/db/db_statistics_test.cc
@@ -198,7 +198,6 @@ TEST_F(DBStatisticsTest, ExcludeTickers) {
   ASSERT_GT(options.statistics->getTickerCount(BYTES_READ), 0);
 }
 
-
 TEST_F(DBStatisticsTest, VerifyChecksumReadStat) {
   Options options = CurrentOptions();
   options.file_checksum_gen_factory = GetFileChecksumGenCrc32cFactory();

--- a/db/db_table_properties_test.cc
+++ b/db/db_table_properties_test.cc
@@ -25,7 +25,6 @@
 #include "util/atomic.h"
 #include "util/random.h"
 
-
 namespace ROCKSDB_NAMESPACE {
 
 // A helper function that ensures the table properties returned in
@@ -743,7 +742,6 @@ INSTANTIATE_TEST_CASE_P(DBTablePropertiesTest, DBTablePropertiesTest,
                                           "kCompactionStyleUniversal"));
 
 }  // namespace ROCKSDB_NAMESPACE
-
 
 int main(int argc, char** argv) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();

--- a/db/db_tailing_iter_test.cc
+++ b/db/db_tailing_iter_test.cc
@@ -703,7 +703,6 @@ TEST_P(DBTestTailingIterator, SeekToFirstWithUpperBoundBug) {
 
 }  // namespace ROCKSDB_NAMESPACE
 
-
 int main(int argc, char** argv) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
   ::testing::InitGoogleTest(&argc, argv);

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1161,7 +1161,6 @@ class DelayFilterFactory : public CompactionFilterFactory {
 };
 }  // anonymous namespace
 
-
 static std::string CompressibleString(Random* rnd, int len) {
   std::string r;
   test::CompressibleString(rnd, 0.8, len, &r);
@@ -4378,7 +4377,6 @@ TEST_F(DBTest, ConcurrentMemtableNotSupported) {
   ASSERT_NOK(db_->CreateColumnFamily(cf_options, "name", &handle));
 }
 
-
 TEST_F(DBTest, SanitizeNumThreads) {
   for (int attempt = 0; attempt < 2; attempt++) {
     const size_t kTotalTasks = 8;
@@ -5787,7 +5785,6 @@ TEST_F(DBTest, FileCreationRandomFailure) {
     ASSERT_EQ(v, values[k]);
   }
 }
-
 
 TEST_F(DBTest, DynamicMiscOptions) {
   // Test max_sequential_skip_in_iterations
@@ -7230,7 +7227,6 @@ TEST_F(DBTest, ReusePinnableSlice) {
             1);
 }
 
-
 TEST_F(DBTest, DeletingOldWalAfterDrop) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"Test:AllowFlushes", "DBImpl::BGWorkFlush"},
@@ -7354,7 +7350,6 @@ TEST_F(DBTest, LargeBlockSizeTest) {
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
   ASSERT_NOK(TryReopenWithColumnFamilies({"default", "pikachu"}, options));
 }
-
 
 TEST_F(DBTest, CreationTimeOfOldestFile) {
   const int kNumKeysPerFile = 32;

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -135,7 +135,6 @@ TEST_F(DBTest2, PartitionedIndexUserToInternalKey) {
   }
 }
 
-
 class PrefixFullBloomWithReverseComparator
     : public DBTestBase,
       public ::testing::WithParamInterface<bool> {
@@ -1977,7 +1976,6 @@ TEST_F(DBTest2, CompactionStall) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
 
-
 TEST_F(DBTest2, FirstSnapshotTest) {
   Options options;
   options.write_buffer_size = 100000;  // Small write buffer
@@ -3600,7 +3598,6 @@ TEST_F(DBTest2, OptimizeForSmallDB) {
   value.Reset();
 }
 
-
 TEST_F(DBTest2, IterRaceFlush1) {
   ASSERT_OK(Put("foo", "v1"));
 
@@ -4104,7 +4101,6 @@ TEST_F(DBTest2, ReadCallbackTest) {
   }
 }
 
-
 TEST_F(DBTest2, LiveFilesOmitObsoleteFiles) {
   // Regression test for race condition where an obsolete file is returned to
   // user as a "live file" but then deleted, all while file deletions are
@@ -4432,7 +4428,7 @@ TEST_F(DBTest2, TraceAndReplay) {
       db2->NewDefaultReplayer(handles, std::move(trace_reader), &replayer));
 
   TraceExecutionResultHandler res_handler;
-  std::function<void(Status, std::unique_ptr<TraceRecordResult> &&)> res_cb =
+  std::function<void(Status, std::unique_ptr<TraceRecordResult>&&)> res_cb =
       [&res_handler](Status exec_s, std::unique_ptr<TraceRecordResult>&& res) {
         ASSERT_TRUE(exec_s.ok() || exec_s.IsNotSupported());
         if (res != nullptr) {
@@ -5163,7 +5159,6 @@ TEST_F(DBTest2, TraceWithFilter) {
   // 4 WRITE + HEADER + FOOTER = 6
   ASSERT_EQ(count, 6);
 }
-
 
 TEST_F(DBTest2, PinnableSliceAndMmapReads) {
   Options options = CurrentOptions();
@@ -7692,7 +7687,6 @@ TEST_F(DBTest2, RecoverEpochNumber) {
                   : 2);
   }
 }
-
 
 TEST_F(DBTest2, RenameDirectory) {
   Options options = CurrentOptions();

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -122,7 +122,6 @@ DBTestBase::~DBTestBase() {
 }
 
 bool DBTestBase::ShouldSkipOptions(int option_config, int skip_mask) {
-
   if ((skip_mask & kSkipUniversalCompaction) &&
       (option_config == kUniversalCompaction ||
        option_config == kUniversalCompactionMultiLevel ||
@@ -1208,7 +1207,6 @@ std::string DBTestBase::FilesPerLevel(int cf) {
   return result;
 }
 
-
 std::vector<uint64_t> DBTestBase::GetBlobFileNumbers() {
   VersionSet* const versions = dbfull()->GetVersionSet();
   assert(versions);
@@ -1667,7 +1665,7 @@ void DBTestBase::VerifyDBFromMap(
     data_iter = true_data.begin();
     for (iter->SeekToFirst(); iter->Valid(); iter->Next(), ++data_iter) {
       ASSERT_EQ(iter->key().ToString(), data_iter->first);
-        ASSERT_EQ(iter->value().ToString(), data_iter->second);
+      ASSERT_EQ(iter->value().ToString(), data_iter->second);
       iter_cnt++;
       total_reads++;
     }
@@ -1683,7 +1681,7 @@ void DBTestBase::VerifyDBFromMap(
     auto data_rev = true_data.rbegin();
     for (iter->SeekToLast(); iter->Valid(); iter->Prev(), data_rev++) {
       ASSERT_EQ(iter->key().ToString(), data_rev->first);
-        ASSERT_EQ(iter->value().ToString(), data_rev->second);
+      ASSERT_EQ(iter->value().ToString(), data_rev->second);
       iter_cnt++;
       total_reads++;
     }
@@ -1764,7 +1762,6 @@ void DBTestBase::VerifyDBInternal(
   ASSERT_FALSE(iter->Valid());
   iter->~InternalIterator();
 }
-
 
 uint64_t DBTestBase::GetNumberOfSstFilesForColumnFamily(
     DB* db, std::string column_family_name) {

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -2369,7 +2369,6 @@ TEST_F(DBTestUniversalCompaction2, PeriodicCompactionOffpeak) {
 
 }  // namespace ROCKSDB_NAMESPACE
 
-
 int main(int argc, char** argv) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
   ::testing::InitGoogleTest(&argc, argv);

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -2124,7 +2124,6 @@ TEST_F(DBWALTest, FixSyncWalOnObseletedWalWithNewManifestCausingMissingWAL) {
         wal_synced = true;
       });
 
-
   SyncPoint::GetInstance()->EnableProcessing();
 
   ASSERT_OK(Flush());
@@ -2699,12 +2698,12 @@ TEST_F(DBWALTest, ReadOnlyRecoveryNoTruncate) {
   // create DB and close with file truncate disabled
   std::atomic_bool enable_truncate{false};
 
-  SyncPoint::GetInstance()->SetCallBack(
-      "PosixWritableFile::Close", [&](void* arg) {
-        if (!enable_truncate) {
-          *(static_cast<size_t*>(arg)) = 0;
-        }
-      });
+  SyncPoint::GetInstance()->SetCallBack("PosixWritableFile::Close",
+                                        [&](void* arg) {
+                                          if (!enable_truncate) {
+                                            *(static_cast<size_t*>(arg)) = 0;
+                                          }
+                                        });
   SyncPoint::GetInstance()->EnableProcessing();
 
   DestroyAndReopen(options);
@@ -2792,7 +2791,6 @@ TEST_F(DBWALTest, WalInManifestButNotInSortedWals) {
   wals_go_missing = false;
   Close();
 }
-
 
 TEST_F(DBWALTest, WalTermTest) {
   Options options = CurrentOptions();

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -3257,7 +3257,6 @@ TEST_F(DBBasicTestWithTimestamp, MultiGetNoReturnTs) {
   Close();
 }
 
-
 INSTANTIATE_TEST_CASE_P(
     Timestamp, DBBasicTestWithTimestampCompressionSettings,
     ::testing::Combine(

--- a/db/db_write_buffer_manager_test.cc
+++ b/db/db_write_buffer_manager_test.cc
@@ -780,7 +780,6 @@ TEST_P(DBWriteBufferManagerTest, MixedSlowDownOptionsMultipleDB) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }
 
-
 // Tests a `WriteBufferManager` constructed with `allow_stall == false` does not
 // thrash memtable switching when full and a CF receives multiple writes.
 // Instead, we expect to switch a CF's memtable for flush only when that CF does

--- a/db/event_helpers.cc
+++ b/db/event_helpers.cc
@@ -81,9 +81,8 @@ void EventHelpers::LogAndNotifyTableFileCreationFinished(
     JSONWriter jwriter;
     AppendCurrentTime(&jwriter);
     jwriter << "cf_name" << cf_name << "job" << job_id << "event"
-            << "table_file_creation"
-            << "file_number" << fd.GetNumber() << "file_size"
-            << fd.GetFileSize() << "file_checksum"
+            << "table_file_creation" << "file_number" << fd.GetNumber()
+            << "file_size" << fd.GetFileSize() << "file_checksum"
             << Slice(file_checksum).ToString(true) << "file_checksum_func_name"
             << file_checksum_func_name << "smallest_seqno" << fd.smallest_seqno
             << "largest_seqno" << fd.largest_seqno;
@@ -199,8 +198,7 @@ void EventHelpers::LogAndNotifyTableFileDeletion(
   JSONWriter jwriter;
   AppendCurrentTime(&jwriter);
 
-  jwriter << "job" << job_id << "event"
-          << "table_file_deletion"
+  jwriter << "job" << job_id << "event" << "table_file_deletion"
           << "file_number" << file_number;
   if (!status.ok()) {
     jwriter << "status" << status.ToString();
@@ -280,11 +278,11 @@ void EventHelpers::LogAndNotifyBlobFileCreationFinished(
     JSONWriter jwriter;
     AppendCurrentTime(&jwriter);
     jwriter << "cf_name" << cf_name << "job" << job_id << "event"
-            << "blob_file_creation"
-            << "file_number" << file_number << "total_blob_count"
-            << total_blob_count << "total_blob_bytes" << total_blob_bytes
-            << "file_checksum" << file_checksum << "file_checksum_func_name"
-            << file_checksum_func_name << "status" << s.ToString();
+            << "blob_file_creation" << "file_number" << file_number
+            << "total_blob_count" << total_blob_count << "total_blob_bytes"
+            << total_blob_bytes << "file_checksum" << file_checksum
+            << "file_checksum_func_name" << file_checksum_func_name << "status"
+            << s.ToString();
 
     jwriter.EndObject();
     event_logger->Log(jwriter);
@@ -311,8 +309,7 @@ void EventHelpers::LogAndNotifyBlobFileDeletion(
     JSONWriter jwriter;
     AppendCurrentTime(&jwriter);
 
-    jwriter << "job" << job_id << "event"
-            << "blob_file_deletion"
+    jwriter << "job" << job_id << "event" << "blob_file_deletion"
             << "file_number" << file_number;
     if (!status.ok()) {
       jwriter << "status" << status.ToString();

--- a/db/experimental.cc
+++ b/db/experimental.cc
@@ -37,7 +37,6 @@ Status PromoteL0(DB* db, ColumnFamilyHandle* column_family, int target_level) {
   return db->PromoteL0(column_family, target_level);
 }
 
-
 Status SuggestCompactRange(DB* db, const Slice* begin, const Slice* end) {
   return SuggestCompactRange(db, db->DefaultColumnFamily(), begin, end);
 }

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -2878,7 +2878,6 @@ INSTANTIATE_TEST_CASE_P(ExternalSSTFileBasicTest, ExternalSSTFileBasicTest,
                                         std::make_tuple(false, true),
                                         std::make_tuple(false, false)));
 
-
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -631,8 +631,7 @@ void ExternalSstFileIngestionJob::UpdateStats() {
   uint64_t total_time = clock_->NowMicros() - job_start_time_;
 
   EventLoggerStream stream = event_logger_->Log();
-  stream << "event"
-         << "ingest_finished";
+  stream << "event" << "ingest_finished";
   stream << "files_ingested";
   stream.StartArray();
 

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -345,8 +345,7 @@ Status FlushJob::Run(LogsWithPrepTracker* prep_tracker, FileMetaData* file_meta,
 
   // When measure_io_stats_ is true, the default 512 bytes is not enough.
   auto stream = event_logger_->LogToBuffer(log_buffer_, 1024);
-  stream << "job" << job_context_->job_id << "event"
-         << "flush_finished";
+  stream << "job" << job_context_->job_id << "event" << "flush_finished";
   stream << "output_compression"
          << CompressionTypeToString(output_compression_);
   stream << "lsm_state";
@@ -933,9 +932,8 @@ Status FlushJob::WriteLevel0Table() {
     //  hitting limit memtable_max_range_deletions, flush_reason_ is still
     //  "Write Buffer Full", should make update flush_reason_ accordingly.
     event_logger_->Log() << "job" << job_context_->job_id << "event"
-                         << "flush_started"
-                         << "num_memtables" << mems_.size() << "num_entries"
-                         << total_num_entries << "num_deletes"
+                         << "flush_started" << "num_memtables" << mems_.size()
+                         << "num_entries" << total_num_entries << "num_deletes"
                          << total_num_deletes << "total_data_size"
                          << total_data_size << "memory_usage"
                          << total_memory_usage << "num_range_deletes"

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -4,13 +4,12 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-#include "rocksdb/comparator.h"
-
 #include <queue>
 #include <string>
 #include <vector>
 
 #include "memory/arena.h"
+#include "rocksdb/comparator.h"
 #include "rocksdb/db.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -4,8 +4,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-#include "db/version_builder.h"
-
 #include "db/import_column_family_job.h"
 
 #include <algorithm>
@@ -13,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "db/version_builder.h"
 #include "db/version_edit.h"
 #include "file/file_util.h"
 #include "file/random_access_file_reader.h"

--- a/db/import_column_family_test.cc
+++ b/db/import_column_family_test.cc
@@ -4,7 +4,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include <functional>
 
 #include "db/db_test_util.h"
@@ -1057,4 +1056,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -33,7 +33,6 @@
 #include "util/string_util.h"
 #include "utilities/merge_operators.h"
 
-
 namespace ROCKSDB_NAMESPACE {
 
 class EventListenerTest : public DBTestBase {
@@ -1590,7 +1589,6 @@ TEST_F(EventListenerTest, BlobDBFileTest) {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-
 
 int main(int argc, char** argv) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -43,7 +43,7 @@ Reader::Reader(std::shared_ptr<Logger> info_log,
       compression_type_record_read_(false),
       uncompress_(nullptr),
       hash_state_(nullptr),
-      uncompress_hash_state_(nullptr){}
+      uncompress_hash_state_(nullptr) {}
 
 Reader::~Reader() {
   delete[] backing_store_;

--- a/db/malloc_stats.h
+++ b/db/malloc_stats.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-
 #include <string>
 
 #include "rocksdb/rocksdb_namespace.h"
@@ -19,4 +18,3 @@ namespace ROCKSDB_NAMESPACE {
 void DumpMallocStats(std::string*);
 
 }
-

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -618,8 +618,8 @@ class TimestampStrippingIterator : public InternalIterator {
       const SliceTransform* cf_prefix_extractor, size_t ts_sz)
       : arena_mode_(arena != nullptr), kind_(kind), ts_sz_(ts_sz) {
     assert(ts_sz_ != 0);
-    void* mem = arena ? arena->AllocateAligned(sizeof(MemTableIterator)) :
-                      operator new(sizeof(MemTableIterator));
+    void* mem = arena ? arena->AllocateAligned(sizeof(MemTableIterator))
+                      : operator new(sizeof(MemTableIterator));
     iter_ = new (mem)
         MemTableIterator(kind, memtable, read_options, seqno_to_time_mapping,
                          arena, cf_prefix_extractor);

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -312,4 +312,3 @@ int main(int argc, char** argv) {
   RegisterCustomObjects(argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-
 #include "util/timer.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-
 #include <algorithm>
 #include <set>
 

--- a/db/prefix_test.cc
+++ b/db/prefix_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #ifndef GFLAGS
 #include <cstdio>
 int main() {

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -59,8 +59,6 @@
 //   Store per-table metadata (smallest, largest, largest-seq#, ...)
 //   in the table's meta section to speed up ScanTable.
 
-#include "db/version_builder.h"
-
 #include <cinttypes>
 
 #include "db/builder.h"
@@ -70,6 +68,7 @@
 #include "db/log_writer.h"
 #include "db/memtable.h"
 #include "db/table_cache.h"
+#include "db/version_builder.h"
 #include "db/version_edit.h"
 #include "db/write_batch_internal.h"
 #include "file/filename.h"

--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -608,4 +608,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -612,12 +612,12 @@ TEST_P(SeqnoTimeTablePropTest, MultiCFs) {
   ASSERT_GE(seqs.size(), 99);
   ASSERT_LE(seqs.size(), 101);
 
-    for (int i = 0; i < 200; i++) {
-      ASSERT_OK(Put(0, Key(i), "value"));
-      dbfull()->TEST_WaitForPeriodicTaskRun(
-          [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(100)); });
-    }
-    ASSERT_OK(Flush(0));
+  for (int i = 0; i < 200; i++) {
+    ASSERT_OK(Put(0, Key(i), "value"));
+    dbfull()->TEST_WaitForPeriodicTaskRun(
+        [&] { mock_clock_->MockSleepForSeconds(static_cast<int>(100)); });
+  }
+  ASSERT_OK(Flush(0));
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
   tables_props.clear();
   ASSERT_OK(dbfull()->GetPropertiesOfAllTables(handles_[0], &tables_props));
@@ -1642,7 +1642,6 @@ TEST(PackValueAndWriteTimeTest, Basic) {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-
 
 int main(int argc, char** argv) {
   ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -53,13 +53,11 @@ static Slice GetSliceForFileNumber(const uint64_t* file_number) {
                sizeof(*file_number));
 }
 
-
 void AppendVarint64(IterKey* key, uint64_t v) {
   char buf[10];
   auto ptr = EncodeVarint64(buf, v);
   key->TrimAppend(key->Size(), buf, ptr - buf);
 }
-
 
 }  // anonymous namespace
 

--- a/db/transaction_log_impl.cc
+++ b/db/transaction_log_impl.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "db/transaction_log_impl.h"
 
 #include <cinttypes>
@@ -232,8 +231,7 @@ bool TransactionLogIteratorImpl::IsBatchExpected(
   SequenceNumber batchSeq = WriteBatchInternal::Sequence(batch);
   if (batchSeq != expected_seq) {
     std::ostringstream oss;
-    oss << "Discontinuity in log records. "
-        << "Got seq=" << batchSeq << ", "
+    oss << "Discontinuity in log records. " << "Got seq=" << batchSeq << ", "
         << "Expected seq=" << expected_seq << ", "
         << "Last flushed seq=" << versions_->LastSequence() << ". "
         << "Log iterator will reseek the correct batch.";

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3987,26 +3987,25 @@ void SortFileByOverlappingRatio(
                            ? VersionStorageInfo::kNumberFilesToSort
                            : temp->size();
 
-  std::partial_sort(temp->begin(), temp->begin() + num_to_sort, temp->end(),
-                    [&](const Fsize& f1, const Fsize& f2) -> bool {
-                      // If score is the same, pick file with smaller keys.
-                      // This makes the algorithm more deterministic, and also
-                      // help the trivial move case to have more files to
-                      // extend.
-                      if (f1.file->marked_for_compaction ==
-                          f2.file->marked_for_compaction) {
-                        if (file_to_order[f1.file->fd.GetNumber()] ==
-                            file_to_order[f2.file->fd.GetNumber()]) {
-                          return icmp.Compare(f1.file->smallest,
-                                              f2.file->smallest) < 0;
-                        }
-                        return file_to_order[f1.file->fd.GetNumber()] <
-                               file_to_order[f2.file->fd.GetNumber()];
-                      } else {
-                        return f1.file->marked_for_compaction >
-                               f2.file->marked_for_compaction;
-                      }
-                    });
+  std::partial_sort(
+      temp->begin(), temp->begin() + num_to_sort, temp->end(),
+      [&](const Fsize& f1, const Fsize& f2) -> bool {
+        // If score is the same, pick file with smaller keys.
+        // This makes the algorithm more deterministic, and also
+        // help the trivial move case to have more files to
+        // extend.
+        if (f1.file->marked_for_compaction == f2.file->marked_for_compaction) {
+          if (file_to_order[f1.file->fd.GetNumber()] ==
+              file_to_order[f2.file->fd.GetNumber()]) {
+            return icmp.Compare(f1.file->smallest, f2.file->smallest) < 0;
+          }
+          return file_to_order[f1.file->fd.GetNumber()] <
+                 file_to_order[f2.file->fd.GetNumber()];
+        } else {
+          return f1.file->marked_for_compaction >
+                 f2.file->marked_for_compaction;
+        }
+      });
 }
 
 void SortFileByRoundRobin(const InternalKeyComparator& icmp,

--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -34,7 +34,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-
 Status WalManager::DeleteFile(const std::string& fname, uint64_t number) {
   auto s = env_->DeleteFile(wal_dir_ + "/" + fname);
   if (s.ok()) {

--- a/db/wal_manager.h
+++ b/db/wal_manager.h
@@ -29,7 +29,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-
 // WAL manager provides the abstraction for reading the WAL files as a single
 // unit. Internally, it opens and reads the files using Reader or Writer
 // abstraction.

--- a/db/wal_manager_test.cc
+++ b/db/wal_manager_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "db/wal_manager.h"
 
 #include <map>

--- a/db/wide/wide_columns.cc
+++ b/db/wide/wide_columns.cc
@@ -4,6 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include "rocksdb/wide_columns.h"
+
 #include "db/wide/wide_column_serialization.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -492,4 +492,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/env/env.cc
+++ b/env/env.cc
@@ -611,6 +611,7 @@ class LegacyFileSystemWrapper : public FileSystem {
     // would be part of the Env.  As such, do not serialize it here.
     return "";
   }
+
  private:
   Env* target_;
 };

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/env_encryption.h"
 
 #include <algorithm>
@@ -1187,6 +1186,5 @@ Status EncryptionProvider::CreateFromString(
   RegisterEncryptionBuiltins();
   return LoadSharedObject<EncryptionProvider>(config_options, value, result);
 }
-
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/env/env_encryption_ctr.h
+++ b/env/env_encryption_ctr.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include "rocksdb/env_encryption.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -24,8 +23,8 @@ class CTRCipherStream final : public BlockAccessCipherStream {
  public:
   CTRCipherStream(const std::shared_ptr<BlockCipher>& c, const char* iv,
                   uint64_t initialCounter)
-      : cipher_(c), iv_(iv, c->BlockSize()), initialCounter_(initialCounter){}
-  virtual ~CTRCipherStream(){}
+      : cipher_(c), iv_(iv, c->BlockSize()), initialCounter_(initialCounter) {}
+  virtual ~CTRCipherStream() {}
 
   size_t BlockSize() override { return cipher_->BlockSize(); }
 
@@ -94,4 +93,3 @@ Status NewEncryptedFileSystemImpl(
     std::unique_ptr<FileSystem>* fs);
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -2938,7 +2938,6 @@ TEST_F(CreateEnvTest, CreateEncryptedFileSystem) {
   ASSERT_TRUE(fs->AreEquivalent(config_options_, copy.get(), &mismatch));
 }
 
-
 namespace {
 
 constexpr size_t kThreads = 8;

--- a/env/fs_readonly.h
+++ b/env/fs_readonly.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include "rocksdb/file_system.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -102,4 +101,3 @@ class ReadOnlyFileSystem : public FileSystemWrapper {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/env/fs_remap.cc
+++ b/env/fs_remap.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "env/fs_remap.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -349,4 +348,3 @@ IOStatus RemapFileSystem::GetAbsolutePath(const std::string& db_path,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/env/fs_remap.h
+++ b/env/fs_remap.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <utility>
 
 #include "rocksdb/file_system.h"
@@ -139,4 +138,3 @@ class RemapFileSystem : public FileSystemWrapper {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -1054,5 +1054,4 @@ Status MockEnv::CorruptBuffer(const std::string& fname) {
 // This is to maintain the behavior before swithcing from InMemoryEnv to MockEnv
 Env* NewMemEnv(Env* base_env) { return MockEnv::Create(base_env); }
 
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/examples/c_simple_example.c
+++ b/examples/c_simple_example.c
@@ -3,10 +3,10 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
 #include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "rocksdb/c.h"
 

--- a/examples/optimistic_transaction_example.cc
+++ b/examples/optimistic_transaction_example.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/db.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
@@ -187,4 +186,3 @@ int main() {
   DestroyDB(kDBPath, options);
   return 0;
 }
-

--- a/examples/transaction_example.cc
+++ b/examples/transaction_example.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/db.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
@@ -193,4 +192,3 @@ int main() {
   ROCKSDB_NAMESPACE::DestroyDB(kDBPath, options);
   return 0;
 }
-

--- a/file/delete_scheduler.cc
+++ b/file/delete_scheduler.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "file/delete_scheduler.h"
 
 #include <cinttypes>
@@ -510,4 +509,3 @@ void DeleteScheduler::MaybeCreateBackgroundThread() {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/file/delete_scheduler.h
+++ b/file/delete_scheduler.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <map>
 #include <optional>
 #include <queue>
@@ -197,4 +196,3 @@ class DeleteScheduler {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/file/delete_scheduler_test.cc
+++ b/file/delete_scheduler_test.cc
@@ -18,7 +18,6 @@
 #include "test_util/testharness.h"
 #include "util/string_util.h"
 
-
 namespace ROCKSDB_NAMESPACE {
 
 class DeleteSchedulerTest : public testing::Test {
@@ -864,4 +863,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -76,7 +76,6 @@ class RandomAccessFileReader {
     io_status.PermitUncheckedError();
   }
 
-
   bool ShouldNotifyListeners() const { return !listeners_.empty(); }
 
   FSRandomAccessFilePtr file_;

--- a/file/sst_file_manager_impl.cc
+++ b/file/sst_file_manager_impl.cc
@@ -531,5 +531,4 @@ SstFileManager* NewSstFileManager(Env* env, std::shared_ptr<FileSystem> fs,
   return res;
 }
 
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -435,7 +435,7 @@ extern ROCKSDB_LIBRARY_API void rocksdb_drop_column_family(
     rocksdb_t* db, rocksdb_column_family_handle_t* handle, char** errptr);
 
 extern ROCKSDB_LIBRARY_API rocksdb_column_family_handle_t*
-    rocksdb_get_default_column_family_handle(rocksdb_t* db);
+rocksdb_get_default_column_family_handle(rocksdb_t* db);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_column_family_handle_destroy(
     rocksdb_column_family_handle_t*);

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -109,7 +109,6 @@ struct ConfigOptions {
   }
 };
 
-
 // The following set of functions provide a way to construct RocksDB Options
 // from a string or a string-to-string map.  Here is the general rule of
 // setting option values from strings by type.  Some RocksDB types are also

--- a/include/rocksdb/env_encryption.h
+++ b/include/rocksdb/env_encryption.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 
 #include "rocksdb/customizable.h"
@@ -32,7 +31,7 @@ std::shared_ptr<FileSystem> NewEncryptedFS(
 // blocks). E.g. CTR (Counter operation mode) supports this requirement.
 class BlockAccessCipherStream {
  public:
-  virtual ~BlockAccessCipherStream(){}
+  virtual ~BlockAccessCipherStream() {}
 
   // BlockSize returns the size of each block supported by this cipher stream.
   virtual size_t BlockSize() = 0;
@@ -360,4 +359,3 @@ class EncryptedFileSystem : public FileSystemWrapper {
   }
 };
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/include/rocksdb/ldb_tool.h
+++ b/include/rocksdb/ldb_tool.h
@@ -39,4 +39,3 @@ class LDBTool {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -211,7 +211,6 @@ struct WriteStallInfo {
   } condition;
 };
 
-
 struct FileDeletionInfo {
   FileDeletionInfo() = default;
 
@@ -864,6 +863,5 @@ class EventListener : public Customizable {
 
   ~EventListener() override {}
 };
-
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -34,7 +34,7 @@ struct ConfigOptions;
 // including data loss, unreported corruption, deadlocks, and more.
 class SliceTransform : public Customizable {
  public:
-  virtual ~SliceTransform(){}
+  virtual ~SliceTransform() {}
 
   // Return the name of this transformation.
   const char* Name() const override = 0;

--- a/include/rocksdb/sst_dump_tool.h
+++ b/include/rocksdb/sst_dump_tool.h
@@ -14,4 +14,3 @@ class SSTDumpTool {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <memory>
 #include <string>
 

--- a/include/rocksdb/utilities/debug.h
+++ b/include/rocksdb/utilities/debug.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include "rocksdb/db.h"
 #include "rocksdb/types.h"
 
@@ -43,4 +42,3 @@ Status GetAllKeyVersions(DB* db, ColumnFamilyHandle* cfh, Slice begin_key,
                          std::vector<KeyVersion>* key_versions);
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/include/rocksdb/utilities/env_mirror.h
+++ b/include/rocksdb/utilities/env_mirror.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-
 #include <algorithm>
 #include <iostream>
 #include <vector>
@@ -176,4 +175,3 @@ class EnvMirror : public EnvWrapper {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/include/rocksdb/utilities/memory_util.h
+++ b/include/rocksdb/utilities/memory_util.h
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #pragma once
 
 #include <map>

--- a/include/rocksdb/utilities/object_registry.h
+++ b/include/rocksdb/utilities/object_registry.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <functional>
 #include <map>
 #include <memory>
@@ -163,7 +162,7 @@ class ObjectLibrary {
     size_t slength_;  // The minimum required length to match the separators
     std::vector<std::pair<std::string, Quantifier>>
         separators_;  // What to match
-  };                  // End class Entry
+  };  // End class Entry
 
  private:
   // An Entry containing a FactoryFunc for creating new Objects

--- a/include/rocksdb/utilities/options_util.h
+++ b/include/rocksdb/utilities/options_util.h
@@ -6,7 +6,6 @@
 // This file contains utility functions for RocksDB Options.
 #pragma once
 
-
 #include <string>
 #include <vector>
 

--- a/include/rocksdb/utilities/transaction_db_mutex.h
+++ b/include/rocksdb/utilities/transaction_db_mutex.h
@@ -86,4 +86,3 @@ class TransactionDBMutexFactory {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/logging/auto_roll_logger_test.cc
+++ b/logging/auto_roll_logger_test.cc
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 
-
 #include "logging/auto_roll_logger.h"
 
 #include <sys/stat.h>
@@ -728,4 +727,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/logging/event_logger_test.cc
+++ b/logging/event_logger_test.cc
@@ -28,8 +28,7 @@ class StringLogger : public Logger {
 TEST_F(EventLoggerTest, SimpleTest) {
   StringLogger logger;
   EventLogger event_logger(&logger);
-  event_logger.Log() << "id" << 5 << "event"
-                     << "just_testing";
+  event_logger.Log() << "id" << 5 << "event" << "just_testing";
   std::string output(logger.buffer());
   ASSERT_TRUE(output.find("\"event\": \"just_testing\"") != std::string::npos);
   ASSERT_TRUE(output.find("\"id\": 5") != std::string::npos);

--- a/memory/memory_allocator_test.cc
+++ b/memory/memory_allocator_test.cc
@@ -226,7 +226,6 @@ INSTANTIATE_TEST_CASE_P(
                                       JemallocNodumpAllocator::IsSupported())));
 #endif  // ROCKSDB_JEMALLOC
 
-
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/memtable/hash_linklist_rep.cc
+++ b/memtable/hash_linklist_rep.cc
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 
-
 #include <algorithm>
 #include <atomic>
 

--- a/memtable/memtablerep_bench.cc
+++ b/memtable/memtablerep_bench.cc
@@ -352,7 +352,9 @@ class SeqReadBenchmarkThread : public BenchmarkThread {
 
   void operator()() override {
     for (unsigned int i = 0; i < num_ops_; ++i) {
-      { ReadOneSeq(); }
+      {
+        ReadOneSeq();
+      }
     }
   }
 };

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -366,13 +366,11 @@ class SkipListRep : public MemTableRep {
     if (lookahead_ > 0) {
       void* mem =
           arena ? arena->AllocateAligned(sizeof(SkipListRep::LookaheadIterator))
-                :
-                operator new(sizeof(SkipListRep::LookaheadIterator));
+                : operator new(sizeof(SkipListRep::LookaheadIterator));
       return new (mem) SkipListRep::LookaheadIterator(*this);
     } else {
       void* mem = arena ? arena->AllocateAligned(sizeof(SkipListRep::Iterator))
-                        :
-                        operator new(sizeof(SkipListRep::Iterator));
+                        : operator new(sizeof(SkipListRep::Iterator));
       return new (mem) SkipListRep::Iterator(&skip_list_);
     }
   }

--- a/monitoring/histogram.h
+++ b/monitoring/histogram.h
@@ -88,7 +88,7 @@ struct HistogramStat {
 class Histogram {
  public:
   Histogram() {}
-  virtual ~Histogram(){}
+  virtual ~Histogram() {}
 
   virtual void Clear() = 0;
   virtual bool Empty() const = 0;

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -257,10 +257,10 @@ void PerfContext::Reset() {
 #endif
 }
 
-void PerfContextByLevel::Reset() {
+void PerfContextByLevel::Reset(){
 #ifndef NPERF_CONTEXT
 #define EMIT_FIELDS(x) x = 0;
-  DEF_PERF_CONTEXT_LEVEL_METRICS(EMIT_FIELDS)
+    DEF_PERF_CONTEXT_LEVEL_METRICS(EMIT_FIELDS)
 #undef EMIT_FIELDS
 #endif
 }

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -1043,9 +1043,9 @@ uint64_t MultiplyCheckOverflow(uint64_t op1, double op2) {
 // when level_compaction_dynamic_level_bytes is true and leveled compaction
 // is used, the base level is not always L1, so precomupted max_file_size can
 // no longer be used. Recompute file_size_for_level from base level.
-uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options,
-    int level, CompactionStyle compaction_style, int base_level,
-    bool level_compaction_dynamic_level_bytes) {
+uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options, int level,
+                             CompactionStyle compaction_style, int base_level,
+                             bool level_compaction_dynamic_level_bytes) {
   if (!level_compaction_dynamic_level_bytes || level < base_level ||
       compaction_style != kCompactionStyleLevel) {
     assert(level >= 0);

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -341,9 +341,10 @@ struct MutableCFOptions {
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2);
 
 // Get the max file size in a given level.
-uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options,
-    int level, CompactionStyle compaction_style, int base_level = 1,
-    bool level_compaction_dynamic_level_bytes = false);
+uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options, int level,
+                             CompactionStyle compaction_style,
+                             int base_level = 1,
+                             bool level_compaction_dynamic_level_bytes = false);
 
 // Get the max size of an L0 file for which we will pin its meta-blocks when
 // `pin_l0_filter_and_index_blocks_in_cache` is set.

--- a/options/configurable.cc
+++ b/options/configurable.cc
@@ -246,7 +246,6 @@ Status Configurable::ParseOption(const ConfigOptions& config_options,
   }
 }
 
-
 Status ConfigurableHelper::ConfigureOptions(
     const ConfigOptions& config_options, Configurable& configurable,
     const std::unordered_map<std::string, std::string>& opts_map,
@@ -329,7 +328,7 @@ Status ConfigurableHelper::ConfigureSomeOptions(
         }
       }
     }  // End for all remaining options
-  }    // End while found one or options remain
+  }  // End while found one or options remain
 
   // Now that we have been through the list, remove any unsupported
   for (const auto& u : unsupported) {

--- a/options/configurable_test.h
+++ b/options/configurable_test.h
@@ -51,8 +51,7 @@ static std::unordered_map<std::string, OptionTypeInfo> simple_option_info = {
 
 static std::unordered_map<std::string, OptionTypeInfo> enum_option_info = {
     {"enum",
-     OptionTypeInfo::Enum(offsetof(struct TestOptions, e), &test_enum_map)}
-};
+     OptionTypeInfo::Enum(offsetof(struct TestOptions, e), &test_enum_map)}};
 
 static std::unordered_map<std::string, OptionTypeInfo> unique_option_info = {
     {"unique",

--- a/options/customizable.cc
+++ b/options/customizable.cc
@@ -67,7 +67,6 @@ std::string Customizable::SerializeOptions(const ConfigOptions& config_options,
   return result;
 }
 
-
 bool Customizable::AreEquivalent(const ConfigOptions& config_options,
                                  const Configurable* other,
                                  std::string* mismatch) const {

--- a/options/customizable_test.cc
+++ b/options/customizable_test.cc
@@ -78,9 +78,7 @@ class TestCustomizable : public Customizable {
  public:
   TestCustomizable(const std::string& name) : name_(name) {}
   // Method to allow CheckedCast to work for this class
-  static const char* kClassName() {
-    return "TestCustomizable";
-  }
+  static const char* kClassName() { return "TestCustomizable"; }
 
   const char* Name() const override { return name_.c_str(); }
   static const char* Type() { return "test.custom"; }
@@ -611,10 +609,9 @@ TEST_F(CustomizableTest, PrepareOptionsTest) {
 
 namespace {
 static std::unordered_map<std::string, OptionTypeInfo> inner_option_info = {
-    {"inner",
-     OptionTypeInfo::AsCustomSharedPtr<TestCustomizable>(
-         0, OptionVerificationType::kNormal, OptionTypeFlags::kStringNameOnly)}
-};
+    {"inner", OptionTypeInfo::AsCustomSharedPtr<TestCustomizable>(
+                  0, OptionVerificationType::kNormal,
+                  OptionTypeFlags::kStringNameOnly)}};
 
 struct InnerOptions {
   static const char* kName() { return "InnerOptions"; }
@@ -939,7 +936,6 @@ TEST_F(CustomizableTest, NoNameTest) {
   ASSERT_EQ(copts->cu, nullptr);
 }
 
-
 TEST_F(CustomizableTest, IgnoreUnknownObjects) {
   ConfigOptions ignore = config_options_;
   std::shared_ptr<TestCustomizable> shared;
@@ -1223,7 +1219,6 @@ TEST_F(CustomizableTest, CreateManagedObjects) {
   ASSERT_EQ(mc1, obj);
 }
 
-
 namespace {
 class TestSecondaryCache : public SecondaryCache {
  public:
@@ -1346,8 +1341,6 @@ class DummyFileSystem : public FileSystemWrapper {
   static const char* kClassName() { return "DummyFileSystem"; }
   const char* Name() const override { return kClassName(); }
 };
-
-
 
 class MockTablePropertiesCollectorFactory
     : public TablePropertiesCollectorFactory {

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -950,8 +950,7 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    "            Options.background_close_inactive_wals: %d",
                    background_close_inactive_wals);
   ROCKS_LOG_HEADER(log, "            Options.atomic_flush: %d", atomic_flush);
-  ROCKS_LOG_HEADER(log,
-                   "            Options.avoid_unnecessary_blocking_io: %d",
+  ROCKS_LOG_HEADER(log, "            Options.avoid_unnecessary_blocking_io: %d",
                    avoid_unnecessary_blocking_io);
   ROCKS_LOG_HEADER(log, "            Options.prefix_seek_opt_in_only: %d",
                    prefix_seek_opt_in_only);
@@ -1096,14 +1095,13 @@ void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "                     Options.wal_bytes_per_sync: %" PRIu64,
                    wal_bytes_per_sync);
-  ROCKS_LOG_HEADER(log,
-                   "                  Options.strict_bytes_per_sync: %d",
+  ROCKS_LOG_HEADER(log, "                  Options.strict_bytes_per_sync: %d",
                    strict_bytes_per_sync);
   ROCKS_LOG_HEADER(log,
                    "      Options.compaction_readahead_size: %" ROCKSDB_PRIszt,
                    compaction_readahead_size);
   ROCKS_LOG_HEADER(log, "                 Options.max_background_flushes: %d",
-                          max_background_flushes);
+                   max_background_flushes);
   ROCKS_LOG_HEADER(log, "Options.daily_offpeak_time_utc: %s",
                    daily_offpeak_time_utc.c_str());
 }

--- a/options/options.cc
+++ b/options/options.cc
@@ -133,8 +133,8 @@ DBOptions::DBOptions(const Options& options)
     : DBOptions(*static_cast<const DBOptions*>(&options)) {}
 
 void DBOptions::Dump(Logger* log) const {
-    ImmutableDBOptions(*this).Dump(log);
-    MutableDBOptions(*this).Dump(log);
+  ImmutableDBOptions(*this).Dump(log);
+  MutableDBOptions(*this).Dump(log);
 }  // DBOptions::Dump
 
 void ColumnFamilyOptions::Dump(Logger* log) const {
@@ -171,304 +171,286 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
           log, "       Options.compression[%d]: %s", i,
           CompressionTypeToString(compression_per_level[i]).c_str());
     }
-    } else {
-      ROCKS_LOG_HEADER(log, "         Options.compression: %s",
-                       CompressionTypeToString(compression).c_str());
-    }
-    ROCKS_LOG_HEADER(
-        log, "                 Options.bottommost_compression: %s",
-        bottommost_compression == kDisableCompressionOption
-            ? "Disabled"
-            : CompressionTypeToString(bottommost_compression).c_str());
-    ROCKS_LOG_HEADER(
-        log, "      Options.prefix_extractor: %s",
-        prefix_extractor == nullptr ? "nullptr" : prefix_extractor->Name());
-    ROCKS_LOG_HEADER(log,
-                     "  Options.memtable_insert_with_hint_prefix_extractor: %s",
-                     memtable_insert_with_hint_prefix_extractor == nullptr
-                         ? "nullptr"
-                         : memtable_insert_with_hint_prefix_extractor->Name());
-    ROCKS_LOG_HEADER(log, "            Options.num_levels: %d", num_levels);
-    ROCKS_LOG_HEADER(log, "       Options.min_write_buffer_number_to_merge: %d",
-                     min_write_buffer_number_to_merge);
-    ROCKS_LOG_HEADER(log, "    Options.max_write_buffer_number_to_maintain: %d",
-                     max_write_buffer_number_to_maintain);
-    ROCKS_LOG_HEADER(log,
-                     "    Options.max_write_buffer_size_to_maintain: %" PRIu64,
-                     max_write_buffer_size_to_maintain);
-    ROCKS_LOG_HEADER(
-        log, "           Options.bottommost_compression_opts.window_bits: %d",
-        bottommost_compression_opts.window_bits);
-    ROCKS_LOG_HEADER(
-        log, "                 Options.bottommost_compression_opts.level: %d",
-        bottommost_compression_opts.level);
-    ROCKS_LOG_HEADER(
-        log, "              Options.bottommost_compression_opts.strategy: %d",
-        bottommost_compression_opts.strategy);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.max_dict_bytes: "
-        "%" PRIu32,
-        bottommost_compression_opts.max_dict_bytes);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.zstd_max_train_bytes: "
-        "%" PRIu32,
-        bottommost_compression_opts.zstd_max_train_bytes);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.parallel_threads: "
-        "%" PRIu32,
-        bottommost_compression_opts.parallel_threads);
-    ROCKS_LOG_HEADER(
-        log, "                 Options.bottommost_compression_opts.enabled: %s",
-        bottommost_compression_opts.enabled ? "true" : "false");
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.max_dict_buffer_bytes: "
-        "%" PRIu64,
-        bottommost_compression_opts.max_dict_buffer_bytes);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.bottommost_compression_opts.use_zstd_dict_trainer: %s",
-        bottommost_compression_opts.use_zstd_dict_trainer ? "true" : "false");
-    ROCKS_LOG_HEADER(log, "           Options.compression_opts.window_bits: %d",
-                     compression_opts.window_bits);
-    ROCKS_LOG_HEADER(log, "                 Options.compression_opts.level: %d",
-                     compression_opts.level);
-    ROCKS_LOG_HEADER(log, "              Options.compression_opts.strategy: %d",
-                     compression_opts.strategy);
-    ROCKS_LOG_HEADER(
-        log,
-        "        Options.compression_opts.max_dict_bytes: %" PRIu32,
-        compression_opts.max_dict_bytes);
-    ROCKS_LOG_HEADER(log,
-                     "        Options.compression_opts.zstd_max_train_bytes: "
-                     "%" PRIu32,
-                     compression_opts.zstd_max_train_bytes);
-    ROCKS_LOG_HEADER(
-        log, "        Options.compression_opts.use_zstd_dict_trainer: %s",
-        compression_opts.use_zstd_dict_trainer ? "true" : "false");
-    ROCKS_LOG_HEADER(log,
-                     "        Options.compression_opts.parallel_threads: "
-                     "%" PRIu32,
-                     compression_opts.parallel_threads);
-    ROCKS_LOG_HEADER(log,
-                     "                 Options.compression_opts.enabled: %s",
-                     compression_opts.enabled ? "true" : "false");
-    ROCKS_LOG_HEADER(log,
-                     "        Options.compression_opts.max_dict_buffer_bytes: "
-                     "%" PRIu64,
-                     compression_opts.max_dict_buffer_bytes);
-    ROCKS_LOG_HEADER(log, "     Options.level0_file_num_compaction_trigger: %d",
-                     level0_file_num_compaction_trigger);
-    ROCKS_LOG_HEADER(log, "         Options.level0_slowdown_writes_trigger: %d",
-                     level0_slowdown_writes_trigger);
-    ROCKS_LOG_HEADER(log, "             Options.level0_stop_writes_trigger: %d",
-                     level0_stop_writes_trigger);
-    ROCKS_LOG_HEADER(
-        log, "                  Options.target_file_size_base: %" PRIu64,
-        target_file_size_base);
-    ROCKS_LOG_HEADER(log, "            Options.target_file_size_multiplier: %d",
-                     target_file_size_multiplier);
-    ROCKS_LOG_HEADER(
-        log, "               Options.max_bytes_for_level_base: %" PRIu64,
-        max_bytes_for_level_base);
-    ROCKS_LOG_HEADER(log, "Options.level_compaction_dynamic_level_bytes: %d",
-                     level_compaction_dynamic_level_bytes);
-    ROCKS_LOG_HEADER(log, "         Options.max_bytes_for_level_multiplier: %f",
-                     max_bytes_for_level_multiplier);
-    for (size_t i = 0; i < max_bytes_for_level_multiplier_additional.size();
-         i++) {
-      ROCKS_LOG_HEADER(
-          log, "Options.max_bytes_for_level_multiplier_addtl[%" ROCKSDB_PRIszt
-               "]: %d",
-          i, max_bytes_for_level_multiplier_additional[i]);
-    }
-    ROCKS_LOG_HEADER(
-        log, "      Options.max_sequential_skip_in_iterations: %" PRIu64,
-        max_sequential_skip_in_iterations);
-    ROCKS_LOG_HEADER(
-        log, "                   Options.max_compaction_bytes: %" PRIu64,
-        max_compaction_bytes);
+  } else {
+    ROCKS_LOG_HEADER(log, "         Options.compression: %s",
+                     CompressionTypeToString(compression).c_str());
+  }
+  ROCKS_LOG_HEADER(
+      log, "                 Options.bottommost_compression: %s",
+      bottommost_compression == kDisableCompressionOption
+          ? "Disabled"
+          : CompressionTypeToString(bottommost_compression).c_str());
+  ROCKS_LOG_HEADER(
+      log, "      Options.prefix_extractor: %s",
+      prefix_extractor == nullptr ? "nullptr" : prefix_extractor->Name());
+  ROCKS_LOG_HEADER(log,
+                   "  Options.memtable_insert_with_hint_prefix_extractor: %s",
+                   memtable_insert_with_hint_prefix_extractor == nullptr
+                       ? "nullptr"
+                       : memtable_insert_with_hint_prefix_extractor->Name());
+  ROCKS_LOG_HEADER(log, "            Options.num_levels: %d", num_levels);
+  ROCKS_LOG_HEADER(log, "       Options.min_write_buffer_number_to_merge: %d",
+                   min_write_buffer_number_to_merge);
+  ROCKS_LOG_HEADER(log, "    Options.max_write_buffer_number_to_maintain: %d",
+                   max_write_buffer_number_to_maintain);
+  ROCKS_LOG_HEADER(log,
+                   "    Options.max_write_buffer_size_to_maintain: %" PRIu64,
+                   max_write_buffer_size_to_maintain);
+  ROCKS_LOG_HEADER(
+      log, "           Options.bottommost_compression_opts.window_bits: %d",
+      bottommost_compression_opts.window_bits);
+  ROCKS_LOG_HEADER(
+      log, "                 Options.bottommost_compression_opts.level: %d",
+      bottommost_compression_opts.level);
+  ROCKS_LOG_HEADER(
+      log, "              Options.bottommost_compression_opts.strategy: %d",
+      bottommost_compression_opts.strategy);
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.max_dict_bytes: "
+      "%" PRIu32,
+      bottommost_compression_opts.max_dict_bytes);
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.zstd_max_train_bytes: "
+      "%" PRIu32,
+      bottommost_compression_opts.zstd_max_train_bytes);
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.parallel_threads: "
+      "%" PRIu32,
+      bottommost_compression_opts.parallel_threads);
+  ROCKS_LOG_HEADER(
+      log, "                 Options.bottommost_compression_opts.enabled: %s",
+      bottommost_compression_opts.enabled ? "true" : "false");
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.max_dict_buffer_bytes: "
+      "%" PRIu64,
+      bottommost_compression_opts.max_dict_buffer_bytes);
+  ROCKS_LOG_HEADER(
+      log,
+      "        Options.bottommost_compression_opts.use_zstd_dict_trainer: %s",
+      bottommost_compression_opts.use_zstd_dict_trainer ? "true" : "false");
+  ROCKS_LOG_HEADER(log, "           Options.compression_opts.window_bits: %d",
+                   compression_opts.window_bits);
+  ROCKS_LOG_HEADER(log, "                 Options.compression_opts.level: %d",
+                   compression_opts.level);
+  ROCKS_LOG_HEADER(log, "              Options.compression_opts.strategy: %d",
+                   compression_opts.strategy);
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.max_dict_bytes: %" PRIu32,
+                   compression_opts.max_dict_bytes);
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.zstd_max_train_bytes: "
+                   "%" PRIu32,
+                   compression_opts.zstd_max_train_bytes);
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.use_zstd_dict_trainer: %s",
+                   compression_opts.use_zstd_dict_trainer ? "true" : "false");
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.parallel_threads: "
+                   "%" PRIu32,
+                   compression_opts.parallel_threads);
+  ROCKS_LOG_HEADER(log, "                 Options.compression_opts.enabled: %s",
+                   compression_opts.enabled ? "true" : "false");
+  ROCKS_LOG_HEADER(log,
+                   "        Options.compression_opts.max_dict_buffer_bytes: "
+                   "%" PRIu64,
+                   compression_opts.max_dict_buffer_bytes);
+  ROCKS_LOG_HEADER(log, "     Options.level0_file_num_compaction_trigger: %d",
+                   level0_file_num_compaction_trigger);
+  ROCKS_LOG_HEADER(log, "         Options.level0_slowdown_writes_trigger: %d",
+                   level0_slowdown_writes_trigger);
+  ROCKS_LOG_HEADER(log, "             Options.level0_stop_writes_trigger: %d",
+                   level0_stop_writes_trigger);
+  ROCKS_LOG_HEADER(log,
+                   "                  Options.target_file_size_base: %" PRIu64,
+                   target_file_size_base);
+  ROCKS_LOG_HEADER(log, "            Options.target_file_size_multiplier: %d",
+                   target_file_size_multiplier);
+  ROCKS_LOG_HEADER(log,
+                   "               Options.max_bytes_for_level_base: %" PRIu64,
+                   max_bytes_for_level_base);
+  ROCKS_LOG_HEADER(log, "Options.level_compaction_dynamic_level_bytes: %d",
+                   level_compaction_dynamic_level_bytes);
+  ROCKS_LOG_HEADER(log, "         Options.max_bytes_for_level_multiplier: %f",
+                   max_bytes_for_level_multiplier);
+  for (size_t i = 0; i < max_bytes_for_level_multiplier_additional.size();
+       i++) {
     ROCKS_LOG_HEADER(
         log,
-        "                       Options.arena_block_size: %" ROCKSDB_PRIszt,
-        arena_block_size);
-    ROCKS_LOG_HEADER(log,
-                     "  Options.soft_pending_compaction_bytes_limit: %" PRIu64,
-                     soft_pending_compaction_bytes_limit);
-    ROCKS_LOG_HEADER(log,
-                     "  Options.hard_pending_compaction_bytes_limit: %" PRIu64,
-                     hard_pending_compaction_bytes_limit);
-    ROCKS_LOG_HEADER(log, "               Options.disable_auto_compactions: %d",
-                     disable_auto_compactions);
+        "Options.max_bytes_for_level_multiplier_addtl[%" ROCKSDB_PRIszt "]: %d",
+        i, max_bytes_for_level_multiplier_additional[i]);
+  }
+  ROCKS_LOG_HEADER(log,
+                   "      Options.max_sequential_skip_in_iterations: %" PRIu64,
+                   max_sequential_skip_in_iterations);
+  ROCKS_LOG_HEADER(log,
+                   "                   Options.max_compaction_bytes: %" PRIu64,
+                   max_compaction_bytes);
+  ROCKS_LOG_HEADER(
+      log, "                       Options.arena_block_size: %" ROCKSDB_PRIszt,
+      arena_block_size);
+  ROCKS_LOG_HEADER(log,
+                   "  Options.soft_pending_compaction_bytes_limit: %" PRIu64,
+                   soft_pending_compaction_bytes_limit);
+  ROCKS_LOG_HEADER(log,
+                   "  Options.hard_pending_compaction_bytes_limit: %" PRIu64,
+                   hard_pending_compaction_bytes_limit);
+  ROCKS_LOG_HEADER(log, "               Options.disable_auto_compactions: %d",
+                   disable_auto_compactions);
 
-    const auto& it_compaction_style =
-        compaction_style_to_string.find(compaction_style);
-    std::string str_compaction_style;
-    if (it_compaction_style == compaction_style_to_string.end()) {
-      assert(false);
-      str_compaction_style = "unknown_" + std::to_string(compaction_style);
-    } else {
-      str_compaction_style = it_compaction_style->second;
-    }
-    ROCKS_LOG_HEADER(log,
-                     "                       Options.compaction_style: %s",
-                     str_compaction_style.c_str());
+  const auto& it_compaction_style =
+      compaction_style_to_string.find(compaction_style);
+  std::string str_compaction_style;
+  if (it_compaction_style == compaction_style_to_string.end()) {
+    assert(false);
+    str_compaction_style = "unknown_" + std::to_string(compaction_style);
+  } else {
+    str_compaction_style = it_compaction_style->second;
+  }
+  ROCKS_LOG_HEADER(log, "                       Options.compaction_style: %s",
+                   str_compaction_style.c_str());
 
-    const auto& it_compaction_pri =
-        compaction_pri_to_string.find(compaction_pri);
-    std::string str_compaction_pri;
-    if (it_compaction_pri == compaction_pri_to_string.end()) {
-      assert(false);
-      str_compaction_pri = "unknown_" + std::to_string(compaction_pri);
-    } else {
-      str_compaction_pri = it_compaction_pri->second;
-    }
-    ROCKS_LOG_HEADER(log,
-                     "                         Options.compaction_pri: %s",
-                     str_compaction_pri.c_str());
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.size_ratio: %u",
-                     compaction_options_universal.size_ratio);
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.min_merge_width: %u",
-                     compaction_options_universal.min_merge_width);
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.max_merge_width: %u",
-                     compaction_options_universal.max_merge_width);
-    ROCKS_LOG_HEADER(
-        log,
-        "Options.compaction_options_universal."
-        "max_size_amplification_percent: %u",
-        compaction_options_universal.max_size_amplification_percent);
-    ROCKS_LOG_HEADER(
-        log,
-        "Options.compaction_options_universal.compression_size_percent: %d",
-        compaction_options_universal.compression_size_percent);
-    const auto& it_compaction_stop_style = compaction_stop_style_to_string.find(
-        compaction_options_universal.stop_style);
-    std::string str_compaction_stop_style;
-    if (it_compaction_stop_style == compaction_stop_style_to_string.end()) {
-      assert(false);
-      str_compaction_stop_style =
-          "unknown_" + std::to_string(compaction_options_universal.stop_style);
-    } else {
-      str_compaction_stop_style = it_compaction_stop_style->second;
-    }
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.stop_style: %s",
-                     str_compaction_stop_style.c_str());
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_universal.max_read_amp: %d",
-                     compaction_options_universal.max_read_amp);
-    ROCKS_LOG_HEADER(
-        log, "Options.compaction_options_fifo.max_table_files_size: %" PRIu64,
-        compaction_options_fifo.max_table_files_size);
-    ROCKS_LOG_HEADER(log,
-                     "Options.compaction_options_fifo.allow_compaction: %d",
-                     compaction_options_fifo.allow_compaction);
-    std::ostringstream collector_info;
-    for (const auto& collector_factory : table_properties_collector_factories) {
-      collector_info << collector_factory->ToString() << ';';
-    }
-    ROCKS_LOG_HEADER(
-        log, "                  Options.table_properties_collectors: %s",
-        collector_info.str().c_str());
-    ROCKS_LOG_HEADER(log,
-                     "                  Options.inplace_update_support: %d",
-                     inplace_update_support);
-    ROCKS_LOG_HEADER(
-        log,
-        "                Options.inplace_update_num_locks: %" ROCKSDB_PRIszt,
-        inplace_update_num_locks);
-    // TODO: easier config for bloom (maybe based on avg key/value size)
-    ROCKS_LOG_HEADER(
-        log, "              Options.memtable_prefix_bloom_size_ratio: %f",
-        memtable_prefix_bloom_size_ratio);
-    ROCKS_LOG_HEADER(log,
-                     "              Options.memtable_whole_key_filtering: %d",
-                     memtable_whole_key_filtering);
+  const auto& it_compaction_pri = compaction_pri_to_string.find(compaction_pri);
+  std::string str_compaction_pri;
+  if (it_compaction_pri == compaction_pri_to_string.end()) {
+    assert(false);
+    str_compaction_pri = "unknown_" + std::to_string(compaction_pri);
+  } else {
+    str_compaction_pri = it_compaction_pri->second;
+  }
+  ROCKS_LOG_HEADER(log, "                         Options.compaction_pri: %s",
+                   str_compaction_pri.c_str());
+  ROCKS_LOG_HEADER(log, "Options.compaction_options_universal.size_ratio: %u",
+                   compaction_options_universal.size_ratio);
+  ROCKS_LOG_HEADER(log,
+                   "Options.compaction_options_universal.min_merge_width: %u",
+                   compaction_options_universal.min_merge_width);
+  ROCKS_LOG_HEADER(log,
+                   "Options.compaction_options_universal.max_merge_width: %u",
+                   compaction_options_universal.max_merge_width);
+  ROCKS_LOG_HEADER(log,
+                   "Options.compaction_options_universal."
+                   "max_size_amplification_percent: %u",
+                   compaction_options_universal.max_size_amplification_percent);
+  ROCKS_LOG_HEADER(
+      log, "Options.compaction_options_universal.compression_size_percent: %d",
+      compaction_options_universal.compression_size_percent);
+  const auto& it_compaction_stop_style = compaction_stop_style_to_string.find(
+      compaction_options_universal.stop_style);
+  std::string str_compaction_stop_style;
+  if (it_compaction_stop_style == compaction_stop_style_to_string.end()) {
+    assert(false);
+    str_compaction_stop_style =
+        "unknown_" + std::to_string(compaction_options_universal.stop_style);
+  } else {
+    str_compaction_stop_style = it_compaction_stop_style->second;
+  }
+  ROCKS_LOG_HEADER(log, "Options.compaction_options_universal.stop_style: %s",
+                   str_compaction_stop_style.c_str());
+  ROCKS_LOG_HEADER(log, "Options.compaction_options_universal.max_read_amp: %d",
+                   compaction_options_universal.max_read_amp);
+  ROCKS_LOG_HEADER(
+      log, "Options.compaction_options_fifo.max_table_files_size: %" PRIu64,
+      compaction_options_fifo.max_table_files_size);
+  ROCKS_LOG_HEADER(log, "Options.compaction_options_fifo.allow_compaction: %d",
+                   compaction_options_fifo.allow_compaction);
+  std::ostringstream collector_info;
+  for (const auto& collector_factory : table_properties_collector_factories) {
+    collector_info << collector_factory->ToString() << ';';
+  }
+  ROCKS_LOG_HEADER(log,
+                   "                  Options.table_properties_collectors: %s",
+                   collector_info.str().c_str());
+  ROCKS_LOG_HEADER(log, "                  Options.inplace_update_support: %d",
+                   inplace_update_support);
+  ROCKS_LOG_HEADER(
+      log, "                Options.inplace_update_num_locks: %" ROCKSDB_PRIszt,
+      inplace_update_num_locks);
+  // TODO: easier config for bloom (maybe based on avg key/value size)
+  ROCKS_LOG_HEADER(log,
+                   "              Options.memtable_prefix_bloom_size_ratio: %f",
+                   memtable_prefix_bloom_size_ratio);
+  ROCKS_LOG_HEADER(log,
+                   "              Options.memtable_whole_key_filtering: %d",
+                   memtable_whole_key_filtering);
 
-    ROCKS_LOG_HEADER(log, "  Options.memtable_huge_page_size: %" ROCKSDB_PRIszt,
-                     memtable_huge_page_size);
-    ROCKS_LOG_HEADER(log,
-                     "                          Options.bloom_locality: %d",
-                     bloom_locality);
+  ROCKS_LOG_HEADER(log, "  Options.memtable_huge_page_size: %" ROCKSDB_PRIszt,
+                   memtable_huge_page_size);
+  ROCKS_LOG_HEADER(log, "                          Options.bloom_locality: %d",
+                   bloom_locality);
 
-    ROCKS_LOG_HEADER(
-        log,
-        "                   Options.max_successive_merges: %" ROCKSDB_PRIszt,
-        max_successive_merges);
+  ROCKS_LOG_HEADER(
+      log, "                   Options.max_successive_merges: %" ROCKSDB_PRIszt,
+      max_successive_merges);
+  ROCKS_LOG_HEADER(log, "            Options.strict_max_successive_merges: %d",
+                   strict_max_successive_merges);
+  ROCKS_LOG_HEADER(log, "               Options.optimize_filters_for_hits: %d",
+                   optimize_filters_for_hits);
+  ROCKS_LOG_HEADER(log, "               Options.paranoid_file_checks: %d",
+                   paranoid_file_checks);
+  ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
+                   force_consistency_checks);
+  ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
+                   report_bg_io_stats);
+  ROCKS_LOG_HEADER(log, "                              Options.ttl: %" PRIu64,
+                   ttl);
+  ROCKS_LOG_HEADER(log,
+                   "         Options.periodic_compaction_seconds: %" PRIu64,
+                   periodic_compaction_seconds);
+  const auto& it_temp = temperature_to_string.find(default_temperature);
+  std::string str_default_temperature;
+  if (it_temp == temperature_to_string.end()) {
+    assert(false);
+    str_default_temperature = "unknown_temperature";
+  } else {
+    str_default_temperature = it_temp->second;
+  }
+  ROCKS_LOG_HEADER(log,
+                   "                       Options.default_temperature: %s",
+                   str_default_temperature.c_str());
+  ROCKS_LOG_HEADER(log, " Options.preclude_last_level_data_seconds: %" PRIu64,
+                   preclude_last_level_data_seconds);
+  ROCKS_LOG_HEADER(log, "   Options.preserve_internal_time_seconds: %" PRIu64,
+                   preserve_internal_time_seconds);
+  ROCKS_LOG_HEADER(log, "                      Options.enable_blob_files: %s",
+                   enable_blob_files ? "true" : "false");
+  ROCKS_LOG_HEADER(log,
+                   "                          Options.min_blob_size: %" PRIu64,
+                   min_blob_size);
+  ROCKS_LOG_HEADER(log,
+                   "                         Options.blob_file_size: %" PRIu64,
+                   blob_file_size);
+  ROCKS_LOG_HEADER(log, "                  Options.blob_compression_type: %s",
+                   CompressionTypeToString(blob_compression_type).c_str());
+  ROCKS_LOG_HEADER(log, "         Options.enable_blob_garbage_collection: %s",
+                   enable_blob_garbage_collection ? "true" : "false");
+  ROCKS_LOG_HEADER(log, "     Options.blob_garbage_collection_age_cutoff: %f",
+                   blob_garbage_collection_age_cutoff);
+  ROCKS_LOG_HEADER(log, "Options.blob_garbage_collection_force_threshold: %f",
+                   blob_garbage_collection_force_threshold);
+  ROCKS_LOG_HEADER(log,
+                   "         Options.blob_compaction_readahead_size: %" PRIu64,
+                   blob_compaction_readahead_size);
+  ROCKS_LOG_HEADER(log, "               Options.blob_file_starting_level: %d",
+                   blob_file_starting_level);
+  if (blob_cache) {
+    ROCKS_LOG_HEADER(log, "                          Options.blob_cache: %s",
+                     blob_cache->Name());
+    ROCKS_LOG_HEADER(log, "                          blob_cache options: %s",
+                     blob_cache->GetPrintableOptions().c_str());
     ROCKS_LOG_HEADER(log,
-                     "            Options.strict_max_successive_merges: %d",
-                     strict_max_successive_merges);
-    ROCKS_LOG_HEADER(log,
-                     "               Options.optimize_filters_for_hits: %d",
-                     optimize_filters_for_hits);
-    ROCKS_LOG_HEADER(log, "               Options.paranoid_file_checks: %d",
-                     paranoid_file_checks);
-    ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
-                     force_consistency_checks);
-    ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
-                     report_bg_io_stats);
-    ROCKS_LOG_HEADER(log, "                              Options.ttl: %" PRIu64,
-                     ttl);
-    ROCKS_LOG_HEADER(log,
-                     "         Options.periodic_compaction_seconds: %" PRIu64,
-                     periodic_compaction_seconds);
-    const auto& it_temp = temperature_to_string.find(default_temperature);
-    std::string str_default_temperature;
-    if (it_temp == temperature_to_string.end()) {
-      assert(false);
-      str_default_temperature = "unknown_temperature";
-    } else {
-      str_default_temperature = it_temp->second;
-    }
-    ROCKS_LOG_HEADER(log,
-                     "                       Options.default_temperature: %s",
-                     str_default_temperature.c_str());
-    ROCKS_LOG_HEADER(log, " Options.preclude_last_level_data_seconds: %" PRIu64,
-                     preclude_last_level_data_seconds);
-    ROCKS_LOG_HEADER(log, "   Options.preserve_internal_time_seconds: %" PRIu64,
-                     preserve_internal_time_seconds);
-    ROCKS_LOG_HEADER(log, "                      Options.enable_blob_files: %s",
-                     enable_blob_files ? "true" : "false");
-    ROCKS_LOG_HEADER(
-        log, "                          Options.min_blob_size: %" PRIu64,
-        min_blob_size);
-    ROCKS_LOG_HEADER(
-        log, "                         Options.blob_file_size: %" PRIu64,
-        blob_file_size);
-    ROCKS_LOG_HEADER(log, "                  Options.blob_compression_type: %s",
-                     CompressionTypeToString(blob_compression_type).c_str());
-    ROCKS_LOG_HEADER(log, "         Options.enable_blob_garbage_collection: %s",
-                     enable_blob_garbage_collection ? "true" : "false");
-    ROCKS_LOG_HEADER(log, "     Options.blob_garbage_collection_age_cutoff: %f",
-                     blob_garbage_collection_age_cutoff);
-    ROCKS_LOG_HEADER(log, "Options.blob_garbage_collection_force_threshold: %f",
-                     blob_garbage_collection_force_threshold);
-    ROCKS_LOG_HEADER(
-        log, "         Options.blob_compaction_readahead_size: %" PRIu64,
-        blob_compaction_readahead_size);
-    ROCKS_LOG_HEADER(log, "               Options.blob_file_starting_level: %d",
-                     blob_file_starting_level);
-    if (blob_cache) {
-      ROCKS_LOG_HEADER(log, "                          Options.blob_cache: %s",
-                       blob_cache->Name());
-      ROCKS_LOG_HEADER(log, "                          blob_cache options: %s",
-                       blob_cache->GetPrintableOptions().c_str());
-      ROCKS_LOG_HEADER(
-          log, "                          blob_cache prepopulated: %s",
-          prepopulate_blob_cache == PrepopulateBlobCache::kFlushOnly
-              ? "flush only"
-              : "disabled");
-    }
-    ROCKS_LOG_HEADER(log, "        Options.experimental_mempurge_threshold: %f",
-                     experimental_mempurge_threshold);
-    ROCKS_LOG_HEADER(log, "           Options.memtable_max_range_deletions: %d",
-                     memtable_max_range_deletions);
+                     "                          blob_cache prepopulated: %s",
+                     prepopulate_blob_cache == PrepopulateBlobCache::kFlushOnly
+                         ? "flush only"
+                         : "disabled");
+  }
+  ROCKS_LOG_HEADER(log, "        Options.experimental_mempurge_threshold: %f",
+                   experimental_mempurge_threshold);
+  ROCKS_LOG_HEADER(log, "           Options.memtable_max_range_deletions: %d",
+                   memtable_max_range_deletions);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {
@@ -484,13 +466,11 @@ void Options::DumpCFOptions(Logger* log) const {
 // The goal of this method is to create a configuration that
 // allows an application to write all files into L0 and
 // then do a single compaction to output all files into L1.
-Options*
-Options::PrepareForBulkLoad()
-{
+Options* Options::PrepareForBulkLoad() {
   // never slowdown ingest.
-  level0_file_num_compaction_trigger = (1<<30);
-  level0_slowdown_writes_trigger = (1<<30);
-  level0_stop_writes_trigger = (1<<30);
+  level0_file_num_compaction_trigger = (1 << 30);
+  level0_slowdown_writes_trigger = (1 << 30);
+  level0_stop_writes_trigger = (1 << 30);
   soft_pending_compaction_bytes_limit = 0;
   hard_pending_compaction_bytes_limit = 0;
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -30,9 +30,7 @@
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
-ConfigOptions::ConfigOptions()
-    : registry(ObjectRegistry::NewInstance())
-{
+ConfigOptions::ConfigOptions() : registry(ObjectRegistry::NewInstance()) {
   env = Env::Default();
 }
 
@@ -512,13 +510,11 @@ bool SerializeSingleOptionHelper(const void* opt_address,
     case OptionType::kInt32T:
       *value = std::to_string(*(static_cast<const int32_t*>(opt_address)));
       break;
-    case OptionType::kInt64T:
-      {
-        int64_t v;
-        GetUnaligned(static_cast<const int64_t*>(opt_address), &v);
-        *value = std::to_string(v);
-      }
-      break;
+    case OptionType::kInt64T: {
+      int64_t v;
+      GetUnaligned(static_cast<const int64_t*>(opt_address), &v);
+      *value = std::to_string(v);
+    } break;
     case OptionType::kUInt:
       *value = std::to_string(*(static_cast<const unsigned int*>(opt_address)));
       break;
@@ -528,20 +524,16 @@ bool SerializeSingleOptionHelper(const void* opt_address,
     case OptionType::kUInt32T:
       *value = std::to_string(*(static_cast<const uint32_t*>(opt_address)));
       break;
-    case OptionType::kUInt64T:
-      {
-        uint64_t v;
-        GetUnaligned(static_cast<const uint64_t*>(opt_address), &v);
-        *value = std::to_string(v);
-      }
-      break;
-    case OptionType::kSizeT:
-      {
-        size_t v;
-        GetUnaligned(static_cast<const size_t*>(opt_address), &v);
-        *value = std::to_string(v);
-      }
-      break;
+    case OptionType::kUInt64T: {
+      uint64_t v;
+      GetUnaligned(static_cast<const uint64_t*>(opt_address), &v);
+      *value = std::to_string(v);
+    } break;
+    case OptionType::kSizeT: {
+      size_t v;
+      GetUnaligned(static_cast<const size_t*>(opt_address), &v);
+      *value = std::to_string(v);
+    } break;
     case OptionType::kDouble:
       *value = std::to_string(*(static_cast<const double*>(opt_address)));
       break;
@@ -606,7 +598,6 @@ Status ConfigureFromMap(
   return s;
 }
 
-
 Status StringToMap(const std::string& opts_str,
                    std::unordered_map<std::string, std::string>* opts_map) {
   assert(opts_map);
@@ -650,7 +641,6 @@ Status StringToMap(const std::string& opts_str,
   return Status::OK();
 }
 
-
 Status GetStringFromDBOptions(std::string* opt_string,
                               const DBOptions& db_options,
                               const std::string& delimiter) {
@@ -667,7 +657,6 @@ Status GetStringFromDBOptions(const ConfigOptions& config_options,
   auto config = DBOptionsAsConfigurable(db_options);
   return config->GetOptionString(config_options, opt_string);
 }
-
 
 Status GetStringFromColumnFamilyOptions(std::string* opt_string,
                                         const ColumnFamilyOptions& cf_options,

--- a/options/options_parser.cc
+++ b/options/options_parser.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "options/options_parser.h"
 
 #include <cmath>
@@ -385,9 +384,8 @@ Status RocksDBOptionsParser::CheckSection(const OptionSection section,
   } else if (section == kOptionSectionTableOptions) {
     if (GetCFOptions(section_arg) == nullptr) {
       return InvalidArgument(
-          line_num, std::string(
-                        "Does not find a matched column family name in "
-                        "TableOptions section.  Column Family Name:") +
+          line_num, std::string("Does not find a matched column family name in "
+                                "TableOptions section.  Column Family Name:") +
                         section_arg);
     }
   } else if (section == kOptionSectionVersion) {

--- a/options/options_parser.h
+++ b/options/options_parser.h
@@ -147,5 +147,4 @@ class RocksDBOptionsParser {
   int opt_file_version[3];
 };
 
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -625,7 +625,8 @@ TEST_F(OptionsTest, GetColumnFamilyOptionsFromStringTest) {
       "memtable=skip_list:10;arena_block_size=1024",
       &new_cf_opt));
   ASSERT_TRUE(new_cf_opt.memtable_factory != nullptr);
-  ASSERT_EQ(std::string(new_cf_opt.memtable_factory->Name()), "SkipListFactory");
+  ASSERT_EQ(std::string(new_cf_opt.memtable_factory->Name()),
+            "SkipListFactory");
   ASSERT_TRUE(new_cf_opt.memtable_factory->IsInstanceOf("SkipListFactory"));
 
   // blob cache
@@ -951,7 +952,6 @@ TEST_F(OptionsTest, OldInterfaceTest) {
       RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
 }
 
-
 TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
   BlockBasedTableOptions table_opt;
   BlockBasedTableOptions new_opt;
@@ -980,7 +980,7 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
   ASSERT_EQ(new_opt.index_type, BlockBasedTableOptions::kHashSearch);
   ASSERT_EQ(new_opt.checksum, ChecksumType::kxxHash);
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(new_opt.block_size, 1024UL);
   ASSERT_EQ(new_opt.block_size_deviation, 8);
   ASSERT_EQ(new_opt.block_restart_interval, 4);
@@ -1114,13 +1114,14 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
       "strict_capacity_limit=true;high_pri_pool_ratio=0.5;}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
             4);
   ASSERT_EQ(new_opt.block_cache->HasStrictCapacityLimit(), true);
-  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(
-                new_opt.block_cache)->GetHighPriPoolRatio(), 0.5);
+  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(new_opt.block_cache)
+                ->GetHighPriPoolRatio(),
+            0.5);
 
   // Set only block cache capacity. Check other values are
   // reset to default values.
@@ -1130,7 +1131,7 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
       "block_cache_compressed={capacity=2M}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 2*1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 2 * 1024UL * 1024UL);
   // Default values
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
@@ -1152,8 +1153,9 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
                 ->GetNumShardBits(),
             5);
   ASSERT_EQ(new_opt.block_cache->HasStrictCapacityLimit(), false);
-  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(
-                new_opt.block_cache)->GetHighPriPoolRatio(), 0.5);
+  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(new_opt.block_cache)
+                ->GetHighPriPoolRatio(),
+            0.5);
 
   // Set couple of block cache options.
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
@@ -1164,7 +1166,7 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
       "strict_capacity_limit=true;}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
             4);
@@ -1192,7 +1194,6 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
   ASSERT_TRUE(
       new_opt.filter_policy->IsInstanceOf(RibbonFilterPolicy::kNickName()));
 }
-
 
 TEST_F(OptionsTest, GetPlainTableOptionsFromString) {
   PlainTableOptions table_opt;
@@ -1245,14 +1246,14 @@ TEST_F(OptionsTest, GetMemTableRepFactoryFromString) {
                                              &new_mem_factory));
 
   ASSERT_OK(GetMemTableRepFactoryFromString("prefix_hash", &new_mem_factory));
-  ASSERT_OK(GetMemTableRepFactoryFromString("prefix_hash:1000",
-                                            &new_mem_factory));
+  ASSERT_OK(
+      GetMemTableRepFactoryFromString("prefix_hash:1000", &new_mem_factory));
   ASSERT_STREQ(new_mem_factory->Name(), "HashSkipListRepFactory");
   ASSERT_NOK(GetMemTableRepFactoryFromString("prefix_hash:1000:invalid_opt",
                                              &new_mem_factory));
 
-  ASSERT_OK(GetMemTableRepFactoryFromString("hash_linkedlist",
-                                            &new_mem_factory));
+  ASSERT_OK(
+      GetMemTableRepFactoryFromString("hash_linkedlist", &new_mem_factory));
   ASSERT_OK(GetMemTableRepFactoryFromString("hash_linkedlist:1000",
                                             &new_mem_factory));
   ASSERT_EQ(std::string(new_mem_factory->Name()), "HashLinkListRepFactory");
@@ -1846,10 +1847,8 @@ TEST_F(OptionsTest, MutableCFOptions) {
   ASSERT_EQ(pto, cf_opts.table_factory->GetOptions<PlainTableOptions>());
 }
 
-
-Status StringToMap(
-    const std::string& opts_str,
-    std::unordered_map<std::string, std::string>* opts_map);
+Status StringToMap(const std::string& opts_str,
+                   std::unordered_map<std::string, std::string>* opts_map);
 
 TEST_F(OptionsTest, StringToMapTest) {
   std::unordered_map<std::string, std::string> opts_map;
@@ -1907,17 +1906,17 @@ TEST_F(OptionsTest, StringToMapTest) {
   ASSERT_EQ(opts_map["k3"], "v3");
   // Multi-level nested options
   opts_map.clear();
-  ASSERT_OK(StringToMap("k1=v1;k2={nk1=nv1;nk2={nnk1=nnk2}};"
-                        "k3={nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}};k4=v4",
-                        &opts_map));
+  ASSERT_OK(
+      StringToMap("k1=v1;k2={nk1=nv1;nk2={nnk1=nnk2}};"
+                  "k3={nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}};k4=v4",
+                  &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
   ASSERT_EQ(opts_map["k2"], "nk1=nv1;nk2={nnk1=nnk2}");
   ASSERT_EQ(opts_map["k3"], "nk1={nnk1={nnnk1=nnnv1;nnnk2;nnnv2}}");
   ASSERT_EQ(opts_map["k4"], "v4");
   // Garbage inside curly braces
   opts_map.clear();
-  ASSERT_OK(StringToMap("k1=v1;k2={dfad=};k3={=};k4=v4",
-                        &opts_map));
+  ASSERT_OK(StringToMap("k1=v1;k2={dfad=};k3={=};k4=v4", &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
   ASSERT_EQ(opts_map["k2"], "dfad=");
   ASSERT_EQ(opts_map["k3"], "=");
@@ -1933,9 +1932,10 @@ TEST_F(OptionsTest, StringToMapTest) {
   ASSERT_EQ(opts_map["k2"], "{{{}}}{}{}");
   // With random spaces
   opts_map.clear();
-  ASSERT_OK(StringToMap("  k1 =  v1 ; k2= {nk1=nv1; nk2={nnk1=nnk2}}  ; "
-                        "k3={  {   } }; k4= v4  ",
-                        &opts_map));
+  ASSERT_OK(
+      StringToMap("  k1 =  v1 ; k2= {nk1=nv1; nk2={nnk1=nnk2}}  ; "
+                  "k3={  {   } }; k4= v4  ",
+                  &opts_map));
   ASSERT_EQ(opts_map["k1"], "v1");
   ASSERT_EQ(opts_map["k2"], "nk1=nv1; nk2={nnk1=nnk2}");
   ASSERT_EQ(opts_map["k3"], "{   }");
@@ -1983,8 +1983,8 @@ TEST_F(OptionsTest, StringToMapRandomTest) {
       for (int attempt = 0; attempt < 10; attempt++) {
         std::string str = base;
         // Replace random position to space
-        size_t pos = static_cast<size_t>(
-            rnd.Uniform(static_cast<int>(base.size())));
+        size_t pos =
+            static_cast<size_t>(rnd.Uniform(static_cast<int>(base.size())));
         str[pos] = ' ';
         Status s = StringToMap(str, &opts_map);
         ASSERT_TRUE(s.ok() || s.IsInvalidArgument());
@@ -2001,8 +2001,8 @@ TEST_F(OptionsTest, StringToMapRandomTest) {
     std::string str;
     for (int attempt = 0; attempt < len; attempt++) {
       // Add a random character
-      size_t pos = static_cast<size_t>(
-          rnd.Uniform(static_cast<int>(chars.size())));
+      size_t pos =
+          static_cast<size_t>(rnd.Uniform(static_cast<int>(chars.size())));
       str.append(1, chars[pos]);
     }
     Status s = StringToMap(str, &opts_map);
@@ -2603,7 +2603,8 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   exact.sanity_level = ConfigOptions::kSanityLevelExactMatch;
   loose.sanity_level = ConfigOptions::kSanityLevelLooselyCompatible;
 
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   cf_options_map["write_buffer_size"] = "1";
   ASSERT_OK(GetColumnFamilyOptionsFromMap(cf_config_options, base_cf_opt,
@@ -2612,7 +2613,8 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   cf_options_map["unknown_option"] = "1";
   ASSERT_NOK(GetColumnFamilyOptionsFromMap(cf_config_options, base_cf_opt,
                                            cf_options_map, &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   cf_config_options.input_strings_escaped = false;
   cf_config_options.ignore_unknown_options = true;
@@ -2621,7 +2623,8 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(
       loose, base_cf_opt, new_cf_opt, nullptr /* new_opt_map */));
   ASSERT_NOK(RocksDBOptionsParser::VerifyCFOptions(
-      exact /* default for VerifyCFOptions */, base_cf_opt, new_cf_opt, nullptr));
+      exact /* default for VerifyCFOptions */, base_cf_opt, new_cf_opt,
+      nullptr));
 
   DBOptions base_db_opt;
   DBOptions new_db_opt;
@@ -2674,21 +2677,26 @@ TEST_F(OptionsOldApiTest, GetOptionsFromMapTest) {
   db_options_map["max_open_files"] = "hello";
   ASSERT_NOK(GetDBOptionsFromMap(db_config_options, base_db_opt, db_options_map,
                                  &new_db_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
 
   // unknow options should fail parsing without ignore_unknown_options = true
   db_options_map["unknown_db_option"] = "1";
   ASSERT_NOK(GetDBOptionsFromMap(db_config_options, base_db_opt, db_options_map,
                                  &new_db_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
 
   db_config_options.input_strings_escaped = false;
   db_config_options.ignore_unknown_options = true;
   ASSERT_OK(GetDBOptionsFromMap(db_config_options, base_db_opt, db_options_map,
                                 &new_db_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
-  ASSERT_NOK(RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
+  ASSERT_NOK(
+      RocksDBOptionsParser::VerifyDBOptions(exact, base_db_opt, new_db_opt));
 }
 
 TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
@@ -2729,7 +2737,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "write_buffer_size=13;max_write_buffer_number_=14;", &new_cf_opt));
   ConfigOptions exact;
   exact.sanity_level = ConfigOptions::kSanityLevelExactMatch;
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Comparator from object registry
   std::string kCompName = "reverse_comp";
@@ -2756,18 +2765,21 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
       "write_buffer_size=13;max_write_buffer_number;", &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Error Paring value
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
       "write_buffer_size=13;max_write_buffer_number=;", &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Missing option name
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt, "write_buffer_size=13; =100;", &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   const uint64_t kilo = 1024UL;
   const uint64_t mega = 1024 * kilo;
@@ -2833,7 +2845,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "block_based_table_factory={{{block_size=4;};"
       "arena_block_size=1024",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Unexpected chars after closing curly brace
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
@@ -2842,7 +2855,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "block_based_table_factory={block_size=4;}};"
       "arena_block_size=1024",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
@@ -2850,14 +2864,16 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "block_based_table_factory={block_size=4;}xdfa;"
       "arena_block_size=1024",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
       "write_buffer_size=10;max_write_buffer_number=16;"
       "block_based_table_factory={block_size=4;}xdfa",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Invalid block based table option
   ASSERT_NOK(GetColumnFamilyOptionsFromString(
@@ -2865,7 +2881,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
       "write_buffer_size=10;max_write_buffer_number=16;"
       "block_based_table_factory={xx_block_size=4;}",
       &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   ASSERT_OK(GetColumnFamilyOptionsFromString(config_options, base_cf_opt,
                                              "optimize_filters_for_hits=true",
@@ -2877,7 +2894,8 @@ TEST_F(OptionsOldApiTest, GetColumnFamilyOptionsFromStringTest) {
   ASSERT_NOK(GetColumnFamilyOptionsFromString(config_options, base_cf_opt,
                                               "optimize_filters_for_hits=junk",
                                               &new_cf_opt));
-  ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
+  ASSERT_OK(
+      RocksDBOptionsParser::VerifyCFOptions(exact, base_cf_opt, new_cf_opt));
 
   // Nested plain table options
   // Empty
@@ -3034,7 +3052,7 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
   ASSERT_EQ(new_opt.checksum, ChecksumType::kxxHash);
   ASSERT_TRUE(new_opt.no_block_cache);
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(new_opt.block_size, 1024UL);
   ASSERT_EQ(new_opt.block_size_deviation, 8);
   ASSERT_EQ(new_opt.block_restart_interval, 4);
@@ -3099,13 +3117,14 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
       "strict_capacity_limit=true;high_pri_pool_ratio=0.5;}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
             4);
   ASSERT_EQ(new_opt.block_cache->HasStrictCapacityLimit(), true);
-  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(
-                new_opt.block_cache)->GetHighPriPoolRatio(), 0.5);
+  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(new_opt.block_cache)
+                ->GetHighPriPoolRatio(),
+            0.5);
 
   // Set only block cache capacity. Check other values are
   // reset to default values.
@@ -3115,7 +3134,7 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
       "block_cache_compressed={capacity=2M}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 2*1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 2 * 1024UL * 1024UL);
   // Default values
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
@@ -3137,8 +3156,9 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
                 ->GetNumShardBits(),
             5);
   ASSERT_EQ(new_opt.block_cache->HasStrictCapacityLimit(), false);
-  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(
-                new_opt.block_cache)->GetHighPriPoolRatio(), 0.5);
+  ASSERT_EQ(std::dynamic_pointer_cast<LRUCache>(new_opt.block_cache)
+                ->GetHighPriPoolRatio(),
+            0.5);
 
   // Set couple of block cache options.
   ASSERT_OK(GetBlockBasedTableOptionsFromString(
@@ -3149,7 +3169,7 @@ TEST_F(OptionsOldApiTest, GetBlockBasedTableOptionsFromString) {
       "strict_capacity_limit=true;}",
       &new_opt));
   ASSERT_TRUE(new_opt.block_cache != nullptr);
-  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL*1024UL);
+  ASSERT_EQ(new_opt.block_cache->GetCapacity(), 1024UL * 1024UL);
   ASSERT_EQ(std::dynamic_pointer_cast<ShardedCacheBase>(new_opt.block_cache)
                 ->GetNumShardBits(),
             4);
@@ -3631,13 +3651,19 @@ TEST_F(OptionsParserTest, ParseVersion) {
   RocksDBOptionsParser parser;
 
   const std::vector<std::string> invalid_versions = {
-      "a.b.c", "3.2.2b", "3.-12", "3. 1",  // only digits and dots are allowed
+      "a.b.c",
+      "3.2.2b",
+      "3.-12",
+      "3. 1",  // only digits and dots are allowed
       "1.2.3.4",
       "1.2.3"  // can only contains at most one dot.
       "0",     // options_file_version must be at least one
       "3..2",
-      ".", ".1.2",             // must have at least one digit before each dot
-      "1.2.", "1.", "2.34."};  // must have at least one digit after each dot
+      ".",
+      ".1.2",  // must have at least one digit before each dot
+      "1.2.",
+      "1.",
+      "2.34."};  // must have at least one digit after each dot
   for (const auto& iv : invalid_versions) {
     snprintf(buffer, kLength - 1, file_template.c_str(), iv.c_str());
 
@@ -3796,7 +3822,10 @@ TEST_F(OptionsParserTest, Readahead) {
 TEST_F(OptionsParserTest, DumpAndParse) {
   DBOptions base_db_opt;
   std::vector<ColumnFamilyOptions> base_cf_opts;
-  std::vector<std::string> cf_names = {"default", "cf1", "cf2", "cf3",
+  std::vector<std::string> cf_names = {"default",
+                                       "cf1",
+                                       "cf2",
+                                       "cf3",
                                        "c:f:4:4:4"
                                        "p\\i\\k\\a\\chu\\\\\\",
                                        "###rocksdb#1-testcf#2###"};

--- a/port/lang.h
+++ b/port/lang.h
@@ -72,7 +72,8 @@ constexpr bool kMustFreeHeapAllocations = false;
 // Compile-time CPU feature testing compatibility
 //
 // A way to be extra sure these defines have been included.
-#define ASSERT_FEATURE_COMPAT_HEADER() static_assert(true, "Semicolon required") /* empty */
+#define ASSERT_FEATURE_COMPAT_HEADER() \
+  static_assert(true, "Semicolon required") /* empty */
 
 // MSVC doesn't support the same defines that gcc and clang provide
 // but does some like __AVX__. Here we can infer some features from others.

--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -34,8 +34,8 @@ void* SaveStack(int* /*num_frames*/, int /*first_frames_to_skip*/) {
 #include <cstring>
 
 #ifdef OS_OPENBSD
-#include <sys/wait.h>
 #include <sys/sysctl.h>
+#include <sys/wait.h>
 #endif  // OS_OPENBSD
 #ifdef OS_FREEBSD
 #include <sys/sysctl.h>
@@ -60,7 +60,8 @@ namespace ROCKSDB_NAMESPACE::port {
 
 namespace {
 
-#if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_GNU_KFREEBSD)
+#if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || \
+    defined(OS_GNU_KFREEBSD)
 const char* GetExecutableName() {
   static char name[1024];
 
@@ -296,7 +297,7 @@ void PrintStack(int first_frames_to_skip) {
   const int kMaxFrames = 100;
   void* frames[kMaxFrames];
 
-  int num_frames = (int) backtrace(frames, kMaxFrames);
+  int num_frames = (int)backtrace(frames, kMaxFrames);
   PrintStack(&frames[first_frames_to_skip], num_frames - first_frames_to_skip);
 }
 
@@ -309,7 +310,7 @@ void* SaveStack(int* num_frames, int first_frames_to_skip) {
   const int kMaxFrames = 100;
   void* frames[kMaxFrames];
 
-  int count = (int) backtrace(frames, kMaxFrames);
+  int count = (int)backtrace(frames, kMaxFrames);
   *num_frames = count - first_frames_to_skip;
   void* callstack = malloc(sizeof(void*) * *num_frames);
   memcpy(callstack, &frames[first_frames_to_skip], sizeof(void*) * *num_frames);

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -90,8 +90,9 @@ WinClock::WinClock()
 
   HMODULE module = GetModuleHandle("kernel32.dll");
   if (module != NULL) {
-    GetSystemTimePreciseAsFileTime_ = (FnGetSystemTimePreciseAsFileTime)(
-        void*)GetProcAddress(module, "GetSystemTimePreciseAsFileTime");
+    GetSystemTimePreciseAsFileTime_ =
+        (FnGetSystemTimePreciseAsFileTime)(void*)GetProcAddress(
+            module, "GetSystemTimePreciseAsFileTime");
   }
 }
 

--- a/table/adaptive/adaptive_table_factory.h
+++ b/table/adaptive/adaptive_table_factory.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 
 #include "rocksdb/options.h"

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1566,7 +1566,6 @@ IOStatus BlockBasedTableBuilder::io_status() const {
 Status BlockBasedTableBuilder::InsertBlockInCacheHelper(
     const Slice& block_contents, const BlockHandle* handle,
     BlockType block_type) {
-
   Cache* block_cache = rep_->table_options.block_cache.get();
   Status s;
   auto helper =

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -164,7 +164,6 @@ size_t TailPrefetchStats::GetSuggestedPrefetchSize() {
   return std::min(kMaxPrefetchSize, max_qualified_size);
 }
 
-
 const std::string kOptNameMetadataCacheOpts = "metadata_cache_options";
 
 static std::unordered_map<std::string, PinningTier>
@@ -479,8 +478,8 @@ namespace {
 // Different cache kinds use the same keys for physically different values, so
 // they must not share an underlying key space with each other.
 Status CheckCacheOptionCompatibility(const BlockBasedTableOptions& bbto) {
-  int cache_count = (bbto.block_cache != nullptr) +
-                    (bbto.persistent_cache != nullptr);
+  int cache_count =
+      (bbto.block_cache != nullptr) + (bbto.persistent_cache != nullptr);
   if (cache_count <= 1) {
     // Nothing to share / overlap
     return Status::OK();

--- a/table/block_based/filter_block.h
+++ b/table/block_based/filter_block.h
@@ -64,7 +64,7 @@ class FilterBlockBuilder {
   virtual void AddWithPrevKey(const Slice& key_without_ts,
                               const Slice& /*prev_key_without_ts*/) = 0;
 
-  virtual bool IsEmpty() const = 0;      // Empty == none added
+  virtual bool IsEmpty() const = 0;  // Empty == none added
   // For reporting stats on how many entries the builder considered unique
   virtual size_t EstimateEntriesAdded() = 0;
 

--- a/table/block_fetcher_test.cc
+++ b/table/block_fetcher_test.cc
@@ -530,7 +530,6 @@ TEST_F(BlockFetcherTest, FetchAndUncompressCompressedDataBlock) {
                      expected_stats_by_mode);
 }
 
-
 }  // namespace
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/table/cuckoo/cuckoo_table_builder.h
+++ b/table/cuckoo/cuckoo_table_builder.h
@@ -133,4 +133,3 @@ class CuckooTableBuilder : public TableBuilder {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/table/cuckoo/cuckoo_table_builder_test.cc
+++ b/table/cuckoo/cuckoo_table_builder_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "table/cuckoo/cuckoo_table_builder.h"
 
 #include <map>

--- a/table/cuckoo/cuckoo_table_reader_test.cc
+++ b/table/cuckoo/cuckoo_table_reader_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #ifndef GFLAGS
 #include <cstdio>
 int main() {

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -219,8 +219,7 @@ class MultiGetContext {
         while (++index_ < range_->end_ &&
                (Mask{1} << index_) &
                    (range_->ctx_->value_mask_ | range_->skip_mask_ |
-                    range_->invalid_mask_))
-          ;
+                    range_->invalid_mask_));
         return *this;
       }
 

--- a/table/plain/plain_table_index.cc
+++ b/table/plain/plain_table_index.cc
@@ -208,4 +208,3 @@ Slice PlainTableIndexBuilder::FillIndexes(
 const std::string PlainTableIndexBuilder::kPlainTableIndexBlock =
     "PlainTableIndexBlock";
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/table/plain/plain_table_index.h
+++ b/table/plain/plain_table_index.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 #include <vector>
 
@@ -243,4 +242,3 @@ class PlainTableIndexBuilder {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/table/plain/plain_table_key_coding.h
+++ b/table/plain/plain_table_key_coding.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <array>
 
 #include "rocksdb/slice.h"
@@ -196,4 +195,3 @@ class PlainTableKeyDecoder {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/table/plain/plain_table_reader.cc
+++ b/table/plain/plain_table_reader.cc
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-
 #include "table/plain/plain_table_reader.h"
 
 #include <string>

--- a/table/sst_file_dumper.h
+++ b/table/sst_file_dumper.h
@@ -101,4 +101,3 @@ class SstFileDumper {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/sst_file_reader.h"
 
 #include "db/arena_wrapped_db_iter.h"

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/sst_file_reader.h"
 
 #include <cinttypes>
@@ -777,4 +776,3 @@ int main(int argc, char** argv) {
   RegisterCustomObjects(argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -25,7 +25,6 @@ const std::string ExternalSstFilePropertyNames::kVersion =
 const std::string ExternalSstFilePropertyNames::kGlobalSeqno =
     "rocksdb.external_sst_file.global_seqno";
 
-
 const size_t kFadviseTrigger = 1024 * 1024;  // 1MB
 
 struct SstFileWriter::Rep {

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -235,7 +235,7 @@ class TableBuilder {
   // enforced state (ready to encode to string).
   virtual void SetSeqnoTimeTableProperties(
       const SeqnoToTimeMapping& /*relevant_mapping*/,
-      uint64_t /*oldest_ancestor_time*/){}
+      uint64_t /*oldest_ancestor_time*/) {}
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -765,7 +765,6 @@ int RegisterTestObjects(ObjectLibrary& library, const std::string& arg) {
   return static_cast<int>(library.GetFactoryCount(&num_types));
 }
 
-
 void RegisterTestLibrary(const std::string& arg) {
   static bool registered = false;
   if (!registered) {

--- a/test_util/transaction_test_util.cc
+++ b/test_util/transaction_test_util.cc
@@ -397,4 +397,3 @@ Status RandomTransactionInserter::Verify(DB* db, uint16_t num_sets,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/test_util/transaction_test_util.h
+++ b/test_util/transaction_test_util.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include "port/port.h"
 #include "rocksdb/options.h"
 #include "rocksdb/utilities/optimistic_transaction_db.h"
@@ -144,4 +143,3 @@ class RandomTransactionInserter {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1075,7 +1075,6 @@ DEFINE_string(
 static enum ROCKSDB_NAMESPACE::CompressionType
     FLAGS_blob_db_compression_type_e = ROCKSDB_NAMESPACE::kSnappyCompression;
 
-
 // Integrated BlobDB options
 DEFINE_bool(
     enable_blob_files,
@@ -1146,7 +1145,6 @@ DEFINE_int32(prepopulate_blob_cache, 0,
              "[Integrated BlobDB] Pre-populate hot/warm blobs in blob cache. 0 "
              "to disable and 1 to insert during flush.");
 
-
 // Secondary DB instance Options
 DEFINE_bool(use_secondary_db, false,
             "Open a RocksDB secondary instance. A primary instance can be "
@@ -1171,7 +1169,6 @@ DEFINE_bool(report_bg_io_stats, false,
 
 DEFINE_bool(use_stderr_info_logger, false,
             "Write info logs to stderr instead of to LOG file. ");
-
 
 DEFINE_string(trace_file, "", "Trace workload to a file. ");
 
@@ -2001,11 +1998,7 @@ struct DBWithColumnFamilies {
   std::vector<int> cfh_idx_to_prob;  // ith index holds probability of operating
                                      // on cfh[i].
 
-  DBWithColumnFamilies()
-      : db(nullptr)
-        ,
-        opt_txn_db(nullptr)
-  {
+  DBWithColumnFamilies() : db(nullptr), opt_txn_db(nullptr) {
     cfh.clear();
     num_created = 0;
     num_hot = 0;
@@ -2017,8 +2010,7 @@ struct DBWithColumnFamilies {
         opt_txn_db(other.opt_txn_db),
         num_created(other.num_created.load()),
         num_hot(other.num_hot),
-        cfh_idx_to_prob(other.cfh_idx_to_prob) {
-  }
+        cfh_idx_to_prob(other.cfh_idx_to_prob) {}
 
   void DeleteDBs() {
     std::for_each(cfh.begin(), cfh.end(),
@@ -8543,7 +8535,6 @@ class Benchmark {
     }
   }
 
-
   void Replay(ThreadState* thread) {
     if (db_.db != nullptr) {
       Replay(thread, &db_);
@@ -8631,7 +8622,6 @@ class Benchmark {
     assert(s.ok());
     delete backup_engine;
   }
-
 };
 
 int db_bench_tool(int argc, char** argv) {

--- a/tools/db_repl_stress.cc
+++ b/tools/db_repl_stress.cc
@@ -129,4 +129,3 @@ int main(int argc, const char** argv) {
 }
 
 #endif  // GFLAGS
-

--- a/tools/dump/db_dump_tool.cc
+++ b/tools/dump/db_dump_tool.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/db_dump_tool.h"
 
 #include <cinttypes>

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -4794,7 +4794,7 @@ void DBLiveFilesMetadataDumperCommand::DoCommand() {
               NormalizePath(sst_metadata.db_path + "/" + sst_metadata.name);
           all_files.emplace_back(filename, level, cf);
         }  // End of for-loop over sst files
-      }    // End of for-loop over levels
+      }  // End of for-loop over levels
 
       const auto& blob_files = column_metadata.blob_files;
       for (const auto& blob_metadata : blob_files) {
@@ -4808,7 +4808,7 @@ void DBLiveFilesMetadataDumperCommand::DoCommand() {
         // Level for blob files is encoded as -1
         all_files.emplace_back(filename, -1, cf);
       }  // End of for-loop over blob files
-    }    // End of for-loop over column metadata
+    }  // End of for-loop over column metadata
 
     // Sort by filename (i.e. first entry in tuple)
     std::sort(all_files.begin(), all_files.end());
@@ -4847,7 +4847,7 @@ void DBLiveFilesMetadataDumperCommand::DoCommand() {
               NormalizePath(sst_metadata.db_path + "/" + sst_metadata.name);
           std::cout << filename << std::endl;
         }  // End of for-loop over sst files
-      }    // End of for-loop over levels
+      }  // End of for-loop over levels
 
       std::cout << "Live Blob Files:" << std::endl;
       const auto& blob_files = column_metadata.blob_files;
@@ -4861,8 +4861,8 @@ void DBLiveFilesMetadataDumperCommand::DoCommand() {
             blob_metadata.blob_file_path + "/" + blob_metadata.blob_file_name);
         std::cout << filename << std::endl;
       }  // End of for-loop over blob files
-    }    // End of for-loop over column metadata
-  }      // End of else ("not sort_by_filename")
+    }  // End of for-loop over column metadata
+  }  // End of else ("not sort_by_filename")
   std::cout << "------------------------------" << std::endl;
 }
 

--- a/tools/reduce_levels_test.cc
+++ b/tools/reduce_levels_test.cc
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 
-
 #include "db/db_impl/db_impl.h"
 #include "db/version_set.h"
 #include "rocksdb/db.h"
@@ -210,4 +209,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/tools/simulated_hybrid_file_system.cc
+++ b/tools/simulated_hybrid_file_system.cc
@@ -3,14 +3,14 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-#include "util/stop_watch.h"
+#include "tools/simulated_hybrid_file_system.h"
 
 #include <algorithm>
 #include <sstream>
 #include <string>
 
 #include "rocksdb/rate_limiter.h"
-#include "tools/simulated_hybrid_file_system.h"
+#include "util/stop_watch.h"
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/tools/simulated_hybrid_file_system.h
+++ b/tools/simulated_hybrid_file_system.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <utility>
 
 #include "rocksdb/file_system.h"
@@ -121,4 +120,3 @@ class SimulatedWritableFile : public FSWritableFileWrapper {
   void SimulateIOWait(int64_t num_requests) const;
 };
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -585,4 +585,3 @@ int SSTDumpTool::Run(int argc, char const* const* argv, Options options) {
   }
 }
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 
-
 #ifdef GFLAGS
 #ifdef NUMA
 #include <numa.h>

--- a/tools/trace_analyzer_tool.h
+++ b/tools/trace_analyzer_tool.h
@@ -326,4 +326,3 @@ class TraceAnalyzer : private TraceRecord::Handler,
 int trace_analyzer_tool(int argc, char** argv);
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -588,11 +588,9 @@ bool Tracer::IsTraceFileOverMax() {
 
 Status Tracer::WriteHeader() {
   std::ostringstream s;
-  s << kTraceMagic << "\t"
-    << "Trace Version: " << kTraceFileMajorVersion << "."
-    << kTraceFileMinorVersion << "\t"
-    << "RocksDB Version: " << kMajorVersion << "." << kMinorVersion << "\t"
-    << "Format: Timestamp OpType Payload\n";
+  s << kTraceMagic << "\t" << "Trace Version: " << kTraceFileMajorVersion << "."
+    << kTraceFileMinorVersion << "\t" << "RocksDB Version: " << kMajorVersion
+    << "." << kMinorVersion << "\t" << "Format: Timestamp OpType Payload\n";
   std::string header(s.str());
 
   Trace trace;

--- a/util/autovector.h
+++ b/util/autovector.h
@@ -61,7 +61,7 @@ class autovector {
     using iterator_category = std::random_access_iterator_tag;
 
     iterator_impl(TAutoVector* vect, size_t index)
-        : vect_(vect), index_(index){}
+        : vect_(vect), index_(index) {}
     iterator_impl(const iterator_impl&) = default;
     ~iterator_impl() {}
     iterator_impl& operator=(const iterator_impl&) = default;

--- a/util/autovector_test.cc
+++ b/util/autovector_test.cc
@@ -248,8 +248,8 @@ size_t BenchmarkSequenceAccess(std::string name, size_t ops, size_t elem_size) {
   }
   auto elapsed = env->NowNanos() - start_time;
   cout << "performed " << ops << " sequence access against " << name << "\n\t"
-       << "size: " << elem_size << "\n\t"
-       << "total time elapsed: " << elapsed << " (ns)" << endl;
+       << "size: " << elem_size << "\n\t" << "total time elapsed: " << elapsed
+       << " (ns)" << endl;
   // HACK avoid compiler's optimization to ignore total
   return total;
 }

--- a/util/compaction_job_stats_impl.cc
+++ b/util/compaction_job_stats_impl.cc
@@ -7,7 +7,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-
 void CompactionJobStats::Reset() {
   elapsed_micros = 0;
   cpu_micros = 0;
@@ -99,6 +98,5 @@ void CompactionJobStats::Add(const CompactionJobStats& stats) {
 
   is_remote_compaction |= stats.is_remote_compaction;
 }
-
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/compression.h
+++ b/util/compression.h
@@ -1424,10 +1424,10 @@ inline bool ZSTD_Compress(const CompressionInfo& info, const char* input,
                                      info.dict().GetRawDict().size(), level);
   }
 #endif                          // ZSTD_ADVANCED
-#else   // up to v0.4.x
+#else                           // up to v0.4.x
   outlen = ZSTD_compress(&(*output)[output_header_len], compressBound, input,
                          length, level);
-#endif  // ZSTD_VERSION_NUMBER >= 500
+#endif                          // ZSTD_VERSION_NUMBER >= 500
   if (outlen == 0) {
     return false;
   }

--- a/util/crc32c_arm64.cc
+++ b/util/crc32c_arm64.cc
@@ -37,15 +37,15 @@
   crc0 = crc32c_u64(crc0, *(buf64 + (ITR)));
 
 /* unfolding to compute 24 * 7 = 168 bytes parallelly */
-#define CRC32C7X24BYTES(ITR)   \
-  do {                         \
-    CRC32C24BYTES((ITR)*7 + 0) \
-    CRC32C24BYTES((ITR)*7 + 1) \
-    CRC32C24BYTES((ITR)*7 + 2) \
-    CRC32C24BYTES((ITR)*7 + 3) \
-    CRC32C24BYTES((ITR)*7 + 4) \
-    CRC32C24BYTES((ITR)*7 + 5) \
-    CRC32C24BYTES((ITR)*7 + 6) \
+#define CRC32C7X24BYTES(ITR)     \
+  do {                           \
+    CRC32C24BYTES((ITR) * 7 + 0) \
+    CRC32C24BYTES((ITR) * 7 + 1) \
+    CRC32C24BYTES((ITR) * 7 + 2) \
+    CRC32C24BYTES((ITR) * 7 + 3) \
+    CRC32C24BYTES((ITR) * 7 + 4) \
+    CRC32C24BYTES((ITR) * 7 + 5) \
+    CRC32C24BYTES((ITR) * 7 + 6) \
   } while (0)
 #endif
 

--- a/util/crc32c_ppc.c
+++ b/util/crc32c_ppc.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <strings.h>
+
 #include "util/crc32c_ppc_constants.h"
 
 #define VMX_ALIGN 16

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -205,9 +205,7 @@ TEST_F(WritableFileWriterTest, IncrementalBuffer) {
     env_options.writable_file_max_buffer_size =
         (attempt < kNumAttempts / 2) ? 512 * 1024 : 700 * 1024;
     std::string actual;
-    std::unique_ptr<FakeWF> wf(new FakeWF(&actual,
-                                          attempt % 2 == 1,
-                                          no_flush));
+    std::unique_ptr<FakeWF> wf(new FakeWF(&actual, attempt % 2 == 1, no_flush));
     std::unique_ptr<WritableFileWriter> writer(new WritableFileWriter(
         std::move(wf), "" /* don't care */, env_options));
 

--- a/util/ppc-opcode.h
+++ b/util/ppc-opcode.h
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#define __PPC_RA(a) (((a)&0x1f) << 16)
-#define __PPC_RB(b) (((b)&0x1f) << 11)
-#define __PPC_XA(a) ((((a)&0x1f) << 16) | (((a)&0x20) >> 3))
-#define __PPC_XB(b) ((((b)&0x1f) << 11) | (((b)&0x20) >> 4))
-#define __PPC_XS(s) ((((s)&0x1f) << 21) | (((s)&0x20) >> 5))
+#define __PPC_RA(a) (((a) & 0x1f) << 16)
+#define __PPC_RB(b) (((b) & 0x1f) << 11)
+#define __PPC_XA(a) ((((a) & 0x1f) << 16) | (((a) & 0x20) >> 3))
+#define __PPC_XB(b) ((((b) & 0x1f) << 11) | (((b) & 0x20) >> 4))
+#define __PPC_XS(s) ((((s) & 0x1f) << 21) | (((s) & 0x20) >> 5))
 #define __PPC_XT(s) __PPC_XS(s)
 #define VSX_XX3(t, a, b) (__PPC_XT(t) | __PPC_XA(a) | __PPC_XB(b))
 #define VSX_XX1(s, a, b) (__PPC_XS(s) | __PPC_RA(a) | __PPC_RB(b))

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -296,7 +296,6 @@ bool StartsWith(const std::string& string, const std::string& pattern) {
   return string.compare(0, pattern.size(), pattern) == 0;
 }
 
-
 bool ParseBoolean(const std::string& type, const std::string& value) {
   if (value == "true" || value == "1") {
     return true;
@@ -333,7 +332,6 @@ int32_t ParseInt32(const std::string& value) {
     throw std::out_of_range(value);
   }
 }
-
 
 uint64_t ParseUint64(const std::string& value) {
   size_t endchar;

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-
 #include <algorithm>
 #include <atomic>
 #include <cinttypes>

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/blob_db/blob_compaction_filter.h"
 
 #include <cinttypes>

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <functional>
 #include <limits>
 #include <string>

--- a/utilities/blob_db/blob_db_gc_stats.h
+++ b/utilities/blob_db/blob_db_gc_stats.h
@@ -9,7 +9,6 @@
 
 #include "rocksdb/rocksdb_namespace.h"
 
-
 namespace ROCKSDB_NAMESPACE {
 
 namespace blob_db {

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <atomic>
 #include <condition_variable>
 #include <limits>

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "file/filename.h"
 #include "logging/logging.h"
 #include "util/cast_util.h"

--- a/utilities/blob_db/blob_db_listener.h
+++ b/utilities/blob_db/blob_db_listener.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <atomic>
 
 #include "rocksdb/listener.h"

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/blob_db/blob_db.h"
 
 #include <algorithm>

--- a/utilities/blob_db/blob_dump_tool.h
+++ b/utilities/blob_db/blob_dump_tool.h
@@ -53,4 +53,3 @@ class BlobDumpTool {
 
 }  // namespace blob_db
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/cache_dump_load.cc
+++ b/utilities/cache_dump_load.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/cache_dump_load.h"
 
 #include "file/writable_file_writer.h"

--- a/utilities/cache_dump_load_impl.cc
+++ b/utilities/cache_dump_load_impl.cc
@@ -230,8 +230,8 @@ IOStatus CacheDumperImpl::WriteHeader() {
   std::ostringstream s;
   s << kTraceMagic << "\t"
     << "Cache dump format version: " << kCacheDumpMajorVersion << "."
-    << kCacheDumpMinorVersion << "\t"
-    << "RocksDB Version: " << kMajorVersion << "." << kMinorVersion << "\t"
+    << kCacheDumpMinorVersion << "\t" << "RocksDB Version: " << kMajorVersion
+    << "." << kMinorVersion << "\t"
     << "Format: dump_unit_metadata <sequence_number, dump_unit_checksum, "
        "dump_unit_size>, dump_unit <timestamp, key, block_type, "
        "block_size, block_data, block_checksum> cache_value\n";

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 #include "utilities/checkpoint/checkpoint_impl.h"
 
 #include <algorithm>

--- a/utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc
+++ b/utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/compaction_filters/remove_emptyvalue_compactionfilter.h"
 
 #include <string>

--- a/utilities/compaction_filters/remove_emptyvalue_compactionfilter.h
+++ b/utilities/compaction_filters/remove_emptyvalue_compactionfilter.h
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #pragma once
 
 #include <string>

--- a/utilities/debug.cc
+++ b/utilities/debug.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/debug.h"
 
 #include "db/db_impl/db_impl.h"
@@ -131,4 +130,3 @@ Status GetAllKeyVersions(DB* db, ColumnFamilyHandle* cfh, Slice begin_key,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/env_mirror.cc
+++ b/utilities/env_mirror.cc
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-
 #include "rocksdb/utilities/env_mirror.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/utilities/env_mirror_test.cc
+++ b/utilities/env_mirror_test.cc
@@ -4,7 +4,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/env_mirror.h"
 
 #include "env/mock_env.h"
@@ -213,4 +212,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/utilities/env_timed.cc
+++ b/utilities/env_timed.cc
@@ -177,5 +177,4 @@ Env* NewTimedEnv(Env* base_env) {
   return new CompositeEnvWrapper(base_env, timed_fs);
 }
 
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/env_timed_test.cc
+++ b/utilities/env_timed_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/env.h"
 #include "rocksdb/perf_context.h"
 #include "test_util/testharness.h"
@@ -31,4 +30,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -578,7 +578,7 @@ void FaultInjectionTestFS::ReadUnsynced(const std::string& fname,
                                         uint64_t offset, size_t n,
                                         Slice* result, char* scratch,
                                         int64_t* pos_at_last_sync) {
-  *result = Slice(scratch, 0);  // default empty result
+  *result = Slice(scratch, 0);      // default empty result
   assert(*pos_at_last_sync == -1);  // default "unknown"
 
   MutexLock l(&mutex_);

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -589,8 +589,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   bool filesystem_writable_;  // Bypass FaultInjectionTestFS and go directly
                               // to underlying FS for writable files
   bool inject_unsynced_data_loss_;  // See InjectUnsyncedDataLoss()
-  bool read_unsynced_data_;   // See SetReadUnsyncedData()
-  bool allow_link_open_file_;  // See SetAllowLinkOpenFile()
+  bool read_unsynced_data_;         // See SetReadUnsyncedData()
+  bool allow_link_open_file_;       // See SetAllowLinkOpenFile()
   IOStatus fs_error_;
 
   enum ErrorType : int {

--- a/utilities/memory/memory_test.cc
+++ b/utilities/memory/memory_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "db/db_impl/db_impl.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/table.h"

--- a/utilities/memory/memory_util.cc
+++ b/utilities/memory/memory_util.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/memory_util.h"
 
 #include "db/db_impl/db_impl.h"

--- a/utilities/memory_allocators.h
+++ b/utilities/memory_allocators.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <atomic>
+
 #include "rocksdb/memory_allocator.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/utilities/object_registry_test.cc
+++ b/utilities/object_registry_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/object_registry.h"
 
 #include "rocksdb/convenience.h"
@@ -859,4 +858,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/utilities/options/options_util.cc
+++ b/utilities/options/options_util.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/options_util.h"
 
 #include "file/filename.h"

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "rocksdb/utilities/options_util.h"
 
 #include <cctype>

--- a/utilities/persistent_cache/block_cache_tier.cc
+++ b/utilities/persistent_cache/block_cache_tier.cc
@@ -417,4 +417,3 @@ Status NewPersistentCache(Env* const env, const std::string& path,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/block_cache_tier.h
+++ b/utilities/persistent_cache/block_cache_tier.h
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-
 #ifndef OS_WIN
 #include <unistd.h>
 #endif  // ! OS_WIN
@@ -151,4 +150,3 @@ class BlockCacheTier : public PersistentCacheTier {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/block_cache_tier_file.h
+++ b/utilities/persistent_cache/block_cache_tier_file.h
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-
 #include <list>
 #include <memory>
 #include <string>
@@ -288,4 +287,3 @@ class ThreadedWriter : public Writer {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/block_cache_tier_metadata.cc
+++ b/utilities/persistent_cache/block_cache_tier_metadata.cc
@@ -81,4 +81,3 @@ void BlockCacheTierMetadata::RemoveAllKeys(BlockCacheFile* f) {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/block_cache_tier_metadata.h
+++ b/utilities/persistent_cache/block_cache_tier_metadata.h
@@ -4,7 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -119,4 +118,3 @@ class BlockCacheTierMetadata {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/hash_table.h
+++ b/utilities/persistent_cache/hash_table.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <assert.h>
 
 #include <list>
@@ -234,4 +233,3 @@ class HashTable {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/hash_table_evictable.h
+++ b/utilities/persistent_cache/hash_table_evictable.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <functional>
 
 #include "util/random.h"
@@ -163,4 +162,3 @@ class EvictableHashTable : private HashTable<T*, Hash, Equal> {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/lrulist.h
+++ b/utilities/persistent_cache/lrulist.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <atomic>
 
 #include "util/mutexlock.h"
@@ -169,4 +168,3 @@ class LRUList {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/persistent_cache_test.h
+++ b/utilities/persistent_cache/persistent_cache_test.h
@@ -8,7 +8,6 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #pragma once
 
-
 #include <functional>
 #include <limits>
 #include <list>
@@ -281,4 +280,3 @@ class PersistentCacheDBTest : public DBTestBase {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/persistent_cache_tier.cc
+++ b/utilities/persistent_cache/persistent_cache_tier.cc
@@ -162,4 +162,3 @@ bool PersistentTieredCache::IsCompressed() {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/persistent_cache_tier.h
+++ b/utilities/persistent_cache/persistent_cache_tier.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <limits>
 #include <list>
 #include <map>
@@ -337,4 +336,3 @@ class PersistentTieredCache : public PersistentCacheTier {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/volatile_tier_impl.cc
+++ b/utilities/persistent_cache/volatile_tier_impl.cc
@@ -135,4 +135,3 @@ bool VolatileCacheTier::Evict() {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/persistent_cache/volatile_tier_impl.h
+++ b/utilities/persistent_cache/volatile_tier_impl.h
@@ -5,7 +5,6 @@
 //
 #pragma once
 
-
 #include <atomic>
 #include <limits>
 #include <sstream>
@@ -136,4 +135,3 @@ class VolatileCacheTier : public PersistentCacheTier {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/trace/replayer_impl.cc
+++ b/utilities/trace/replayer_impl.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/trace/replayer_impl.h"
 
 #include <cmath>

--- a/utilities/transactions/lock/lock_manager.cc
+++ b/utilities/transactions/lock/lock_manager.cc
@@ -3,7 +3,6 @@
 // COPYING file in the root directory) and Apache 2.0 License
 // (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/lock/lock_manager.h"
 
 #include "utilities/transactions/lock/point/point_lock_manager.h"
@@ -24,4 +23,3 @@ std::shared_ptr<LockManager> NewLockManager(PessimisticTransactionDB* db,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/lock/lock_manager.h
+++ b/utilities/transactions/lock/lock_manager.h
@@ -77,4 +77,3 @@ std::shared_ptr<LockManager> NewLockManager(PessimisticTransactionDB* db,
                                             const TransactionDBOptions& opt);
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/lock/point/point_lock_manager.cc
+++ b/utilities/transactions/lock/point/point_lock_manager.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/lock/point/point_lock_manager.h"
 
 #include <algorithm>

--- a/utilities/transactions/lock/point/point_lock_manager_test.cc
+++ b/utilities/transactions/lock/point/point_lock_manager_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/lock/point/point_lock_manager_test.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -167,4 +166,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/utilities/transactions/lock/point/point_lock_tracker.cc
+++ b/utilities/transactions/lock/point/point_lock_tracker.cc
@@ -3,7 +3,6 @@
 // COPYING file in the root directory) and Apache 2.0 License
 // (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/lock/point/point_lock_tracker.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -252,4 +251,3 @@ LockTracker::KeyIterator* PointLockTracker::GetKeyIterator(
 void PointLockTracker::Clear() { tracked_keys_.clear(); }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/lock/range/range_locking_test.cc
+++ b/utilities/transactions/lock/range/range_locking_test.cc
@@ -445,4 +445,3 @@ int main(int /*argc*/, char** /*argv*/) {
 }
 
 #endif  // OS_WIN
-

--- a/utilities/transactions/lock/range/range_tree/lib/db.h
+++ b/utilities/transactions/lock/range/range_tree/lib/db.h
@@ -53,7 +53,7 @@ typedef struct __toku_engine_status_row {
     char datebuf[26];
     struct partitioned_counter *parcount;
   } value;
-} * TOKU_ENGINE_STATUS_ROW, TOKU_ENGINE_STATUS_ROW_S;
+} *TOKU_ENGINE_STATUS_ROW, TOKU_ENGINE_STATUS_ROW_S;
 
 #define DB_BUFFER_SMALL -30999
 #define DB_LOCK_DEADLOCK -30995

--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
@@ -156,7 +156,7 @@ static inline tokutime_t toku_time_now(void) {
   return cycles;
 #elif defined(__loongarch64)
   unsigned long result;
-  asm volatile ("rdtime.d\t%0,$r0" : "=r" (result));
+  asm volatile("rdtime.d\t%0,$r0" : "=r"(result));
   return result;
 #else
 #error No timer implementation for this platform

--- a/utilities/transactions/lock/range/range_tree/lib/util/dbt.cc
+++ b/utilities/transactions/lock/range/range_tree/lib/util/dbt.cc
@@ -65,7 +65,8 @@ DBT *toku_init_dbt(DBT *dbt) {
 }
 
 DBT toku_empty_dbt(void) {
-  static const DBT empty_dbt = {.data = nullptr, .size = 0, .ulen = 0, .flags = 0};
+  static const DBT empty_dbt = {
+      .data = nullptr, .size = 0, .ulen = 0, .flags = 0};
   return empty_dbt;
 }
 

--- a/utilities/transactions/optimistic_transaction.cc
+++ b/utilities/transactions/optimistic_transaction.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/optimistic_transaction.h"
 
 #include <cstdint>

--- a/utilities/transactions/optimistic_transaction.h
+++ b/utilities/transactions/optimistic_transaction.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <stack>
 #include <string>
 #include <unordered_map>
@@ -96,4 +95,3 @@ class OptimisticTransactionCallback : public WriteCallback {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/optimistic_transaction_db_impl.cc
+++ b/utilities/transactions/optimistic_transaction_db_impl.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/optimistic_transaction_db_impl.h"
 
 #include <string>

--- a/utilities/transactions/snapshot_checker.cc
+++ b/utilities/transactions/snapshot_checker.cc
@@ -5,16 +5,14 @@
 
 #include "db/snapshot_checker.h"
 
-
 #include "port/lang.h"
 #include "utilities/transactions/write_prepared_txn_db.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-
 WritePreparedSnapshotChecker::WritePreparedSnapshotChecker(
     WritePreparedTxnDB* txn_db)
-    : txn_db_(txn_db){}
+    : txn_db_(txn_db) {}
 
 SnapshotCheckerResult WritePreparedSnapshotChecker::CheckInSnapshot(
     SequenceNumber sequence, SequenceNumber snapshot_sequence) const {
@@ -28,7 +26,6 @@ SnapshotCheckerResult WritePreparedSnapshotChecker::CheckInSnapshot(
   return in_snapshot ? SnapshotCheckerResult::kInSnapshot
                      : SnapshotCheckerResult::kNotInSnapshot;
 }
-
 
 DisableGCSnapshotChecker* DisableGCSnapshotChecker::Instance() {
   STATIC_AVOID_DESTRUCTION(DisableGCSnapshotChecker, instance);

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -248,8 +248,7 @@ class TransactionBaseImpl : public Transaction {
 
   WriteBatchWithIndex* GetWriteBatch() override;
 
-  void SetLockTimeout(int64_t /*timeout*/) override { /* Do nothing */
-  }
+  void SetLockTimeout(int64_t /*timeout*/) override { /* Do nothing */ }
 
   const Snapshot* GetSnapshot() const override {
     // will return nullptr when there is no snapshot

--- a/utilities/transactions/transaction_db_mutex_impl.cc
+++ b/utilities/transactions/transaction_db_mutex_impl.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/transaction_db_mutex_impl.h"
 
 #include <chrono>
@@ -130,4 +129,3 @@ Status TransactionDBCondVarImpl::WaitFor(
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/transaction_db_mutex_impl.h
+++ b/utilities/transactions/transaction_db_mutex_impl.h
@@ -21,4 +21,3 @@ class TransactionDBMutexFactoryImpl : public TransactionDBMutexFactory {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -6291,8 +6291,8 @@ TEST_P(TransactionTest, DuplicateKeys) {
         }
         delete cf_handle;
       }  // with_commit_batch
-    }    // do_rollback
-  }      // do_prepare
+    }  // do_rollback
+  }  // do_prepare
 
   if (!options.unordered_write) {
     // Also test with max_successive_merges > 0. max_successive_merges will not

--- a/utilities/transactions/transaction_util.cc
+++ b/utilities/transactions/transaction_util.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/transaction_util.h"
 
 #include <cinttypes>
@@ -204,4 +203,3 @@ Status TransactionUtil::CheckKeysForConflicts(DBImpl* db_impl,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/transaction_util.h
+++ b/utilities/transactions/transaction_util.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <string>
 #include <unordered_map>
 
@@ -83,4 +82,3 @@ class TransactionUtil {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include <algorithm>
 #include <atomic>
 #include <cinttypes>
@@ -3596,7 +3595,7 @@ TEST_P(WritePreparedTransactionTest, NonAtomicCommitOfDelayedPrepared) {
       ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
       ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
     }  // for split_before_mutex
-  }    // for split_read
+  }  // for split_read
 }
 
 // When max evicted seq advances a prepared seq, it involves two updates: i)

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/write_prepared_txn_db.h"
 
 #include <algorithm>

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/transaction_test.h"
 #include "utilities/transactions/write_unprepared_txn.h"
 #include "utilities/transactions/write_unprepared_txn_db.h"
@@ -729,4 +728,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/write_unprepared_txn.h"
 
 #include "db/db_impl/db_impl.h"

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <set>
 
 #include "utilities/transactions/write_prepared_txn.h"
@@ -272,7 +271,7 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
 
     SavePoint(const std::map<SequenceNumber, size_t>& seqs,
               ManagedSnapshot* snapshot)
-        : unprep_seqs_(seqs), snapshot_(snapshot){}
+        : unprep_seqs_(seqs), snapshot_(snapshot) {}
   };
 
   // We have 3 data structures holding savepoint information:

--- a/utilities/transactions/write_unprepared_txn_db.cc
+++ b/utilities/transactions/write_unprepared_txn_db.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-
 #include "utilities/transactions/write_unprepared_txn_db.h"
 
 #include "db/arena_wrapped_db_iter.h"

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-
 #include <map>
 #include <memory>
 
@@ -931,4 +930,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -154,12 +154,12 @@ struct WriteBatchIndexEntry {
   bool has_single_del;     // whether single del was issued for this key
   bool has_overwritten_single_del;  // whether a single del for this key was
                                     // overwritten by another key
-  size_t key_offset;       // offset of the key in write batch's string buffer.
-  size_t key_size;         // size of the key. kFlagMinInCf indicates
-                           // that this is a dummy look up entry for
-                           // SeekToFirst() to the beginning of the column
-                           // family. We use the flag here to save a boolean
-                           // in the struct.
+  size_t key_offset;  // offset of the key in write batch's string buffer.
+  size_t key_size;    // size of the key. kFlagMinInCf indicates
+                      // that this is a dummy look up entry for
+                      // SeekToFirst() to the beginning of the column
+                      // family. We use the flag here to save a boolean
+                      // in the struct.
 
   const Slice* search_key;  // if not null, instead of reading keys from
                             // write batch, use it to compare. This is used

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -2476,8 +2476,8 @@ TEST_P(WriteBatchWithIndexTest, MultiGetTest2) {
         default:
           assert(false);
       }  // end switch
-    }    // End for each key
-  }      // end for passes
+    }  // End for each key
+  }  // end for passes
 }
 
 // This test has merges, but the merge does not play into the final result


### PR DESCRIPTION
Summary: ... which is the default for CentOS 9 and Ubuntu 24, the latter of which is now available in GitHub Actions. Relevant CI job updated.

Re-formatted all cc|c|h files except in third-party/, using

```
clang-format -i `git ls-files | grep -E '[.](cc|c|h)$' | grep -v third-party/`
```

Test Plan: CI