### PR TITLE
Add io_buffer_size to BackupEngineOptions

### DIFF
--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -77,6 +77,13 @@ struct BackupEngineOptions {
   // Default: true
   bool backup_log_files;
 
+  // Size of the buffer used for reading files.
+  // Enables optimally configuring the IO size based on the storage backend.
+  // If specified, takes precendence over the rate limiter burst size (if
+  // specified) as well as kDefaultCopyFileBufferSize.
+  // Default: 0
+  uint64_t io_buffer_size;
+
   // Max bytes that can be transferred in a second during backup.
   // If 0, go as fast as you can
   // This limit only applies to writes. To also limit reads,
@@ -228,8 +235,9 @@ struct BackupEngineOptions {
       const std::string& _backup_dir, Env* _backup_env = nullptr,
       bool _share_table_files = true, Logger* _info_log = nullptr,
       bool _sync = true, bool _destroy_old_data = false,
-      bool _backup_log_files = true, uint64_t _backup_rate_limit = 0,
-      uint64_t _restore_rate_limit = 0, int _max_background_operations = 1,
+      bool _backup_log_files = true, uint64_t _io_buffer_size = 0,
+      uint64_t _backup_rate_limit = 0, uint64_t _restore_rate_limit = 0,
+      int _max_background_operations = 1,
       uint64_t _callback_trigger_interval_size = 4 * 1024 * 1024,
       int _max_valid_backups_to_open = INT_MAX,
       ShareFilesNaming _share_files_with_checksum_naming =
@@ -241,6 +249,7 @@ struct BackupEngineOptions {
         sync(_sync),
         destroy_old_data(_destroy_old_data),
         backup_log_files(_backup_log_files),
+        io_buffer_size(_io_buffer_size),
         backup_rate_limit(_backup_rate_limit),
         restore_rate_limit(_restore_rate_limit),
         share_files_with_checksum(true),

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -81,6 +81,8 @@ struct BackupEngineOptions {
   // Enables optimally configuring the IO size based on the storage backend.
   // If specified, takes precendence over the rate limiter burst size (if
   // specified) as well as kDefaultCopyFileBufferSize.
+  // If 0, the rate limiter burst size (if specified) or
+  // kDefaultCopyFileBufferSize will be used.
   // Default: 0
   uint64_t io_buffer_size;
 

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -77,7 +77,7 @@ struct BackupEngineOptions {
   // Default: true
   bool backup_log_files;
 
-  // Size of the buffer used for reading files.
+  // Size of the buffer in bytes used for reading files.
   // Enables optimally configuring the IO size based on the storage backend.
   // If specified, takes precendence over the rate limiter burst size (if
   // specified) as well as kDefaultCopyFileBufferSize.

--- a/unreleased_history/public_api_changes/backup_engine_options_io_buffer_size.md
+++ b/unreleased_history/public_api_changes/backup_engine_options_io_buffer_size.md
@@ -1,0 +1,1 @@
+Add `io_buffer_size` to BackupEngineOptions to enable optimal configuration of IO size

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -581,6 +581,8 @@ class BackupEngineImpl {
                             uint64_t* bytes_toward_next_callback,
                             uint64_t* size, std::string* checksum_hex);
 
+  uint64_t CalculateIOBufferSize(RateLimiter* rate_limiter) const;
+
   IOStatus ReadFileAndComputeChecksum(const std::string& src,
                                       const std::shared_ptr<FileSystem>& src_fs,
                                       const EnvOptions& src_env_options,
@@ -2212,9 +2214,7 @@ IOStatus BackupEngineImpl::CopyOrCreateFile(
     return io_s;
   }
 
-  size_t buf_size =
-      rate_limiter ? static_cast<size_t>(rate_limiter->GetSingleBurstBytes())
-                   : kDefaultCopyFileBufferSize;
+  size_t buf_size = CalculateIOBufferSize(rate_limiter);
 
   // TODO: pass in Histograms if the destination file is sst or blob
   std::unique_ptr<WritableFileWriter> dest_writer(
@@ -2305,6 +2305,16 @@ IOStatus BackupEngineImpl::CopyOrCreateFile(
     io_s = dest_writer->Close(opts);
   }
   return io_s;
+}
+
+uint64_t BackupEngineImpl::CalculateIOBufferSize(
+    RateLimiter* rate_limiter) const {
+  if (options_.io_buffer_size > 0) {
+    return options_.io_buffer_size;
+  }
+  return rate_limiter != nullptr
+             ? static_cast<size_t>(rate_limiter->GetSingleBurstBytes())
+             : kDefaultCopyFileBufferSize;
 }
 
 // fname will always start with "/"
@@ -2588,7 +2598,7 @@ IOStatus BackupEngineImpl::ReadFileAndComputeChecksum(
     return io_s;
   }
 
-  size_t buf_size = kDefaultCopyFileBufferSize;
+  size_t buf_size = CalculateIOBufferSize(nullptr);
   std::unique_ptr<char[]> buf(new char[buf_size]);
   Slice data;
 

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -2215,6 +2215,8 @@ IOStatus BackupEngineImpl::CopyOrCreateFile(
   }
 
   size_t buf_size = CalculateIOBufferSize(rate_limiter);
+  TEST_SYNC_POINT_CALLBACK(
+      "BackupEngineImpl::CopyOrCreateFile:CalculateIOBufferSize", &buf_size);
 
   // TODO: pass in Histograms if the destination file is sst or blob
   std::unique_ptr<WritableFileWriter> dest_writer(
@@ -2599,6 +2601,7 @@ IOStatus BackupEngineImpl::ReadFileAndComputeChecksum(
   }
 
   size_t buf_size = CalculateIOBufferSize(nullptr);
+
   std::unique_ptr<char[]> buf(new char[buf_size]);
   Slice data;
 

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -2600,7 +2600,7 @@ IOStatus BackupEngineImpl::ReadFileAndComputeChecksum(
     return io_s;
   }
 
-  size_t buf_size = CalculateIOBufferSize(nullptr);
+  size_t buf_size = CalculateIOBufferSize(rate_limiter);
   std::unique_ptr<char[]> buf(new char[buf_size]);
   Slice data;
 

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -2601,7 +2601,6 @@ IOStatus BackupEngineImpl::ReadFileAndComputeChecksum(
   }
 
   size_t buf_size = CalculateIOBufferSize(nullptr);
-
   std::unique_ptr<char[]> buf(new char[buf_size]);
   Slice data;
 

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -4516,7 +4516,7 @@ TEST_F(BackupEngineTest, IOBufferSize) {
   ASSERT_TRUE(io_buffer_size_calculated);
   CloseDBAndBackupEngine();
 
-  // Override the default buffer size with 64 MB through BackupEngineOptions
+  // Override the default buffer size to 64 MB through BackupEngineOptions
   expected_buffer_size = 64 * 1024 * 1024;
   engine_options_->io_buffer_size = expected_buffer_size;
   io_buffer_size_calculated = false;

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -4525,16 +4525,17 @@ TEST_F(BackupEngineTest, IOBufferSize) {
   ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), false));
   ASSERT_TRUE(io_buffer_size_calculated);
   CloseDBAndBackupEngine();
-  engine_options_->io_buffer_size = 0;
 
   // Without io_buffer_size specified, the rate limiter burst bytes value will
   // be used (16 MB in this example)
-  expected_buffer_size = 16 * 1024 * 1024;
+  engine_options_->io_buffer_size = 0;
+  size_t single_burst_bytes = 16 * 1024 * 1024;
+  expected_buffer_size = single_burst_bytes;
   std::shared_ptr<RateLimiter> backup_rate_limiter(NewGenericRateLimiter(
       5 * 1024 * 1024 /* rate_bytes_per_sec */,
       100 * 1000 /* refill_period_us */, 10 /* fairness */,
       RateLimiter::Mode::kWritesOnly /* mode */, false /* auto_tuned */,
-      expected_buffer_size /* single_burst_bytes */));
+      single_burst_bytes /* single_burst_bytes */));
   engine_options_->backup_rate_limiter = backup_rate_limiter;
   io_buffer_size_calculated = false;
   OpenDBAndBackupEngine(true /* destroy_old_data */);

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -4496,7 +4496,7 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
 
 TEST_F(BackupEngineTest, IOBufferSize) {
   size_t expected_buffer_size = 5 * 1024 * 1024;
-  bool io_buffer_size_calculated = false;
+  std::atomic<bool> io_buffer_size_calculated{false};
   SyncPoint::GetInstance()->SetCallBack(
       "BackupEngineImpl::CopyOrCreateFile:CalculateIOBufferSize",
       [&](void* data) {

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -4494,6 +4494,59 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
   delete alt_backup_engine;
 }
 
+TEST_F(BackupEngineTest, IOBufferSize) {
+  size_t expected_buffer_size = 5 * 1024 * 1024;
+  bool io_buffer_size_calculated = false;
+  SyncPoint::GetInstance()->SetCallBack(
+      "BackupEngineImpl::CopyOrCreateFile:CalculateIOBufferSize",
+      [&](void* data) {
+        if (data != nullptr) {
+          EXPECT_EQ(expected_buffer_size, *static_cast<uint64_t*>(data));
+        }
+        io_buffer_size_calculated = true;
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  const int keys_iteration = 5000;
+  Random rnd(6);
+  // With no overrides, fall back to the default buffer size of 5 MB
+  OpenDBAndBackupEngine(true /* destroy_old_data */);
+  FillDB(db_.get(), 0, keys_iteration);
+  ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), false));
+  ASSERT_TRUE(io_buffer_size_calculated);
+  CloseDBAndBackupEngine();
+
+  // Override the default buffer size with 64 MB through BackupEngineOptions
+  expected_buffer_size = 64 * 1024 * 1024;
+  engine_options_->io_buffer_size = expected_buffer_size;
+  io_buffer_size_calculated = false;
+  OpenDBAndBackupEngine(true /* destroy_old_data */);
+  FillDB(db_.get(), 0, keys_iteration);
+  ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), false));
+  ASSERT_TRUE(io_buffer_size_calculated);
+  CloseDBAndBackupEngine();
+  engine_options_->io_buffer_size = 0;
+
+  // Without io_buffer_size specified, the rate limiter burst bytes value will
+  // be used (16 MB in this example)
+  expected_buffer_size = 16 * 1024 * 1024;
+  std::shared_ptr<RateLimiter> backup_rate_limiter(NewGenericRateLimiter(
+      5 * 1024 * 1024 /* rate_bytes_per_sec */,
+      100 * 1000 /* refill_period_us */, 10 /* fairness */,
+      RateLimiter::Mode::kWritesOnly /* mode */, false /* auto_tuned */,
+      expected_buffer_size /* single_burst_bytes */));
+  engine_options_->backup_rate_limiter = backup_rate_limiter;
+  io_buffer_size_calculated = false;
+  OpenDBAndBackupEngine(true /* destroy_old_data */);
+  FillDB(db_.get(), 0, keys_iteration);
+  ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), false));
+  ASSERT_TRUE(io_buffer_size_calculated);
+  CloseDBAndBackupEngine();
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
 }  // namespace
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
# Summary

The RocksDB backup engine code currently derives the IO buffer size based on the following criteria:

1. If specified, use the rate limiter burst size
2. Otherwise, use the default size (5 MiB)

We want to be able to explicitly choose the IO size based on the storage backend. We want the new criteria to be:

1. If specified, use the size in `BackupEngineOptions`
2. If specified, use the rate limiter burst size
3. Otherwise, use the default size (5 MiB)

This PR adds a new option called `io_buffer_size` to `BackupEngineOptions` and updates the logic used to set the buffer size.

# Test Plan

I added a separate unit test and verified that we can either use the `io_buffer_size`, rate limiter burst size, or the default size.

I decided to use a `TEST_SYNC_POINT_CALLBACK`. I considered the alternative of updating the `Read` implementation of `DummySequentialFile` / `CheckIOOptsSequentialFile` to check the value of `n`. However, that would have considerably complicated the whole test code, and we also do not need to be checking for this in every single test case. I think the `TEST_SYNC_POINT_CALLBACK` turned out to be quite elegant.