### PR TITLE
Properly propagate the result io_status handle upstream

### DIFF
--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -1343,11 +1343,11 @@ IOStatus BackupEngineImpl::Initialize() {
                   work_item.dst_path.c_str(), checksum_function_info.c_str());
             }
           }
-          work_item.result.set_value(std::move(result));
         } else {
           result.io_status = IOStatus::InvalidArgument(
               "Unknown work item type: " + std::to_string(work_item.type));
         }
+        work_item.result.set_value(std::move(result));
       }
     });
   }


### PR DESCRIPTION
Followup to https://github.com/facebook/rocksdb/pull/13228. This fix is not a critical one in a sense that `else`-branch is only supposed to act as a guard just in case when new work item type is being introduced, scheduled but not handled. However, we're in control of the work item types and currently we only support a single one (which has appropriate handling logic to it).