### PR TITLE
Native support for incremental restore

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -627,7 +627,7 @@ class Env : public Customizable {
       const EnvOptions& env_options,
       const ImmutableDBOptions& immutable_ops) const;
 
-  // OptimizeForCompactionTableWrite will create a new EnvOptions object that
+  // OptimizeForCompactionTableRead will create a new EnvOptions object that
   // is a copy of the EnvOptions in the parameters, but is optimized for reading
   // table files.
   virtual EnvOptions OptimizeForCompactionTableRead(

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -366,8 +366,15 @@ struct RestoreOptions {
     // Instructs restore engine to consider existing destination file and its'
     // backup counterpart file as 'equal' IF the `db_session_id` (indicative of
     // db instance runtime that created this SST file) parsed out from the
-    // backup file name AND its respective size MATCH the corresponding values
+    // backup file name AND its respective size match the corresponding values
     // in the existing destination file metadata block.
+    //
+    // EXCLUDED FILES COMPATIBILITY:
+    // =============================
+    // In case when excluded backup file name cannot be found under the default
+    // (or alternative) backup directories, restore engine will try to
+    // opportunistically find existing destination file with `db_session_id`
+    // and size matching those parsed from excluded backup relative file name.
     //
     // WARNING:
     // ========

--- a/include/rocksdb/utilities/backup_engine.h
+++ b/include/rocksdb/utilities/backup_engine.h
@@ -126,8 +126,8 @@ struct BackupEngineOptions {
   // Default: true
   bool share_files_with_checksum;
 
-  // Up to this many background threads will copy files for CreateNewBackup()
-  // and RestoreDBFromBackup()
+  // Up to this many background threads will be used to copy files & compute
+  // checksums for CreateNewBackup() and RestoreDBFromBackup().
   // Default: 1
   int max_background_operations;
 
@@ -348,6 +348,46 @@ struct CreateBackupOptions {
   CpuPriority background_thread_cpu_priority = CpuPriority::kNormal;
 };
 
+// Enum reflecting tiered approach to incremental restores.
+// Options `kKeepLatestDbSessionIdFiles`, `kVerifyChecksum` are intended
+// to be used separately and NOT to be combined with one another.
+enum RestoreMode : uint32_t {
+  // Instructs restore engine to consider existing destination file and its'
+  // backup counterpart as 'equal' IF the db session id AND size values read
+  // from the backup file footer match the corresponding values in existing
+  // destination file metadata block.
+  //
+  // NOTE:
+  // =====
+  //
+  // Only applicable to backup files that preserve the notion of 'session'
+  // in the footer. Good approximation to tell if that's the case is to verify
+  // that backup files do follow the `kUseDbSessionId` naming scheme, ex:
+  //
+  //  <file_number>_s<db_session_id>[_<file_size>].sst
+  //
+  // RISK WARNING:
+  // =============
+  //
+  // Determination is made solely based on the backup & db file footer metadata.
+  // Technically speaking, it is possible that backup or db file with the very
+  // same db session id and size hold different data (think file corruption,
+  // blocks filled with zeros [trash], etc.). If you need stronger guarantees
+  // with no 'session' constraints, use `kVerifyChecksum` restore mode instead.
+  kKeepLatestDbSessionIdFiles = 1U,
+
+  // When opted-in, restore engine will scan the db file, evaluate the checksum
+  // and compare it against the checksum hardened in the backup file metadata.
+  // If checksums match, existing file will be retained as-is. Otherwise, it
+  // will be deleted and replaced it with its' restored backup counterpart.
+  // If backup file doesn't have a checksum hardened in the metadata,
+  // we'll schedule an async task to compute it.
+  kVerifyChecksum = 2U,
+
+  // Zero trust. Purge all the destination files and restore all the files.
+  kPurgeAllFiles = 0xffffU,
+};
+
 struct RestoreOptions {
   // If true, restore won't overwrite the existing log files in wal_dir. It will
   // also move all log files from archive directory to wal_dir. Use this option
@@ -361,8 +401,12 @@ struct RestoreOptions {
   // directories known to contain the required files.
   std::forward_list<BackupEngineReadOnlyBase*> alternate_dirs;
 
-  explicit RestoreOptions(bool _keep_log_files = false)
-      : keep_log_files(_keep_log_files) {}
+  // Specifies the level of incremental restore. 'kPurgeAllFiles' by default.
+  RestoreMode mode;
+
+  explicit RestoreOptions(bool _keep_log_files = false,
+                          RestoreMode _mode = RestoreMode::kPurgeAllFiles)
+      : keep_log_files(_keep_log_files), mode(_mode) {}
 };
 
 using BackupID = uint32_t;

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -2835,8 +2835,7 @@ void BackupEngineImpl::InferDBFilesToRetainInRestore(
     }
 
     // We only care to optimize restore for large files - like SSTs and blobs.
-    // Blobs are only supported in kVerifyChecksum mode as we do not record
-    // `db_session_id` for blobs.
+    // Blobs are only supported in kVerifyChecksum.
     if (type == kTableFile ||
         (type == kBlobFile && mode == RestoreOptions::Mode::kVerifyChecksum)) {
       file_num_to_engine_infos[number] = engine_and_file_info;
@@ -2915,8 +2914,7 @@ void BackupEngineImpl::InferDBFilesToRetainInRestore(
       if (!found) {
         const auto& uo_sst_bfn = unowned_backups.find(shared_file_name);
         if (uo_sst_bfn != unowned_backups.end()) {
-          // Db file # has been already associated with the excluded backup.
-          // Remove it from the temporary map of files to be processed.
+          // Db file has been successfully associated with the excluded backup.
           unowned_backups.erase(shared_file_name);
           found = true;
         }

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -3054,7 +3054,6 @@ void BackupEngineImpl::InferDBFilesToRetainInRestore(
         continue;
       }
 
-      auto backup_checksum_hex = it->second;
       if (it->second != result.checksum_hex) {
         Log(options_.info_log,
             "Checksum mismatch between backup file and existing file '%s'.",

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -563,7 +563,7 @@ class BackupEngineImpl {
     return file_copy;
   }
 
-  // Path valid format: */**/<file_number>_s<db_session_id>[_<file_size>].<ext>.
+  // Valid path format: */**/<file_number>_s<db_session_id>[_<file_size>].<ext>.
   // Path might be preceeded with any # of '/' and directories.
   //
   // Function will return true in following cases:
@@ -2056,9 +2056,6 @@ IOStatus BackupEngineImpl::RestoreDBFromBackup(
         uint64_t number;
         FileType type;
         if (ParseFileName(filename, &number, &type) && type == kTableFile) {
-          // ParseDbSessionIdAndSizeFromFile(filename, &db_session_id, &size) {
-          // unowned_sst_backups.emplace(number,
-          // std::make_pair(std::move(db_session_id), size));
           unowned_sst_backups.emplace(number, ef.relative_file);
           continue;
         }
@@ -3069,8 +3066,7 @@ IOStatus BackupEngineImpl::InferDBFilesToRetainInRestore(
       if (parsed_size_bytes != 0 && (parsed_size_bytes != size_bytes)) {
         Log(options_.info_log,
             "Mismatch between on-disk backup file size: %" PRIu64
-            " "
-            "and parsed backup file size: %" PRIu64 " for file: '%s",
+            " and parsed backup file size: %" PRIu64 " for file: '%s",
             size_bytes, parsed_size_bytes, backup_file_info->filename.c_str());
         continue;
       }

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -809,6 +809,9 @@ class BackupEngineImpl {
           file_path(_file_path),
           file_number(_file_number) {}
 
+    ComputeChecksumWorkItem(const ComputeChecksumWorkItem&) = delete;
+    ComputeChecksumWorkItem& operator=(const ComputeChecksumWorkItem&) = delete;
+
     ComputeChecksumWorkItem(ComputeChecksumWorkItem&& o) noexcept {
       *this = std::move(o);
     }
@@ -819,6 +822,8 @@ class BackupEngineImpl {
       file_number = o.file_number;
       return *this;
     }
+
+    ~ComputeChecksumWorkItem() = default;
   };
 
   struct RestoreAfterCopyOrCreateWorkItem {

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -1151,12 +1151,6 @@ TEST_F(BackupEngineTest, IncrementalRestore) {
       }
     }
 
-    // Files filled with data have lower #s.
-    // It's handy to know which files are non-empty and
-    // therefore easier to corrupt for the sake of testing.
-    std::sort(all_sst_files.begin(), all_sst_files.end());
-    std::sort(all_blob_files.begin(), all_blob_files.end());
-
     std::string one_sst_file = all_sst_files[0];
 
     // 2. Verify expected behavior with exclude files feature.
@@ -1265,7 +1259,7 @@ TEST_F(BackupEngineTest, IncrementalRestore) {
     // (by overriding bytes beyond the footer) to corrupt a file in a more
     // harmful way...
     std::string sst_file_to_be_corrupted = all_sst_files[0];
-    ASSERT_OK(db_file_manager_->CorruptFileMiddle(sst_file_to_be_corrupted));
+    ASSERT_OK(db_file_manager_->CorruptFileStart(sst_file_to_be_corrupted));
 
     OpenBackupEngine();
 

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -4556,6 +4556,7 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
     // Include files only in given bucket, based on modulus and remainder
     constexpr int modulus = 4;
     int remainder = 0;
+
     cbo.exclude_files_callback = [&remainder](
                                      MaybeExcludeBackupFile* files_begin,
                                      MaybeExcludeBackupFile* files_end) {
@@ -4646,8 +4647,13 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
                          std::make_pair(alt_backup_engine, backup_engine)}) {
       RestoreOptions ro(false /* _keep_log_files */, restore_mode);
       ro.alternate_dirs.push_front(be_pair.second);
-      ASSERT_TRUE(be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro)
-                      .IsInvalidArgument());
+      IOStatus io_st =
+          be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro);
+      if (restore_mode == RestoreOptions::Mode::kKeepLatestDbSessionIdFiles) {
+        ASSERT_OK(io_st);
+      } else {
+        ASSERT_TRUE(io_st.IsInvalidArgument());
+      }
     }
 
     // Close & Re-open (no crash, etc.)
@@ -4662,8 +4668,13 @@ TEST_F(BackupEngineTest, ExcludeFiles) {
                          std::make_pair(alt_backup_engine, backup_engine)}) {
       RestoreOptions ro(false /* _keep_log_files */, restore_mode);
       ro.alternate_dirs.push_front(be_pair.second);
-      ASSERT_TRUE(be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro)
-                      .IsInvalidArgument());
+      IOStatus io_st =
+          be_pair.first->RestoreDBFromLatestBackup(dbname_, dbname_, ro);
+      if (restore_mode == RestoreOptions::Mode::kKeepLatestDbSessionIdFiles) {
+        ASSERT_OK(io_st);
+      } else {
+        ASSERT_TRUE(io_st.IsInvalidArgument());
+      }
     }
 
     // Ensure files are not leaked after removing everything.

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -1116,7 +1116,8 @@ TEST_F(BackupEngineTest, IncrementalRestore) {
       dbname_ + "/MANIFEST-000005", dbname_ + "/OPTIONS-000007",
       dbname_ + "/CURRENT.tmp",     dbname_ + "/000011.log"};
 
-  for (const auto& mode : {kKeepLatestDbSessionIdFiles, kVerifyChecksum}) {
+  for (const auto& mode : {RestoreOptions::Mode::kKeepLatestDbSessionIdFiles,
+                           RestoreOptions::Mode::kVerifyChecksum}) {
     OpenDBAndBackupEngine(true /* destroy_old_data */, false /* dummy */,
                           kShareWithChecksum);
 
@@ -1173,7 +1174,7 @@ TEST_F(BackupEngineTest, IncrementalRestore) {
     std::vector<std::string> should_have_written = always_copyable_files;
     should_have_written.emplace_back(dbname_ + "/000012.sst");
     should_have_written.emplace_back(dbname_ + "/000010.blob");
-    if (mode == kKeepLatestDbSessionIdFiles) {
+    if (mode == RestoreOptions::Mode::kKeepLatestDbSessionIdFiles) {
       // We only support incremental restore for blobs in kVerifyChecksum mode.
       should_have_written.emplace_back(dbname_ + "/000013.blob");
     }
@@ -1205,12 +1206,12 @@ TEST_F(BackupEngineTest, IncrementalRestore) {
 
     should_have_written = always_copyable_files;
     should_have_written.emplace_back(dbname_ + "/000010.blob");
-    if (mode == kVerifyChecksum) {
+    if (mode == RestoreOptions::Mode::kVerifyChecksum) {
       // Restore running in kVerifyChecksum mode would have caught the mismatch
       // between crc32c and db file contents. Such file would have been deleted
       // and restored from the backup.
       should_have_written.emplace_back(dbname_ + "/000012.sst");
-    } else if (mode == kKeepLatestDbSessionIdFiles) {
+    } else if (mode == RestoreOptions::Mode::kKeepLatestDbSessionIdFiles) {
       // This mode is more prone to subtle db file corruptions as we do not run
       // any CPU intensive computations (like checksum) and the match between
       // existing db file and its' relevant backup counterpart is determined
@@ -1230,10 +1231,10 @@ TEST_F(BackupEngineTest, IncrementalRestore) {
     Status s = db_->VerifyChecksum();
 
     // Check DB contents.
-    if (mode == kVerifyChecksum) {
+    if (mode == RestoreOptions::Mode::kVerifyChecksum) {
       EXPECT_OK(s);
       AssertExists(db_.get(), 0, keys_iteration * 2);
-    } else if (mode == kKeepLatestDbSessionIdFiles) {
+    } else if (mode == RestoreOptions::Mode::kKeepLatestDbSessionIdFiles) {
       ASSERT_TRUE(s.IsCorruption());
     }
 

--- a/utilities/backup/backup_engine_test.cc
+++ b/utilities/backup/backup_engine_test.cc
@@ -1309,11 +1309,11 @@ TEST_F(BackupEngineTest, IncrementalRestore) {
     Status s = db_->VerifyChecksum();
 
     // Check DB contents.
-    if (mode == RestoreOptions::Mode::kVerifyChecksum) {
+    if (mode == RestoreOptions::Mode::kKeepLatestDbSessionIdFiles) {
+      ASSERT_TRUE(s.IsCorruption());
+    } else {
       EXPECT_OK(s);
       AssertExists(db_.get(), 0, keys_iteration * 2);
-    } else if (mode == RestoreOptions::Mode::kKeepLatestDbSessionIdFiles) {
-      ASSERT_TRUE(s.IsCorruption());
     }
 
     db_.reset();  // Close DB.


### PR DESCRIPTION
### Summary

With this change we are adding native library support for incremental restores. When designing the solution we decided to follow 'tiered' approach where users can pick one of the three predefined, and for now, mutually exclusive restore modes (`kKeepLatestDbSessionIdFiles`, `kVerifyChecksum` and `kPurgeAllFiles` [default]) - trading write IO / CPU for the degree of certainty that the existing destination db files match selected backup files contents. New mode option is exposed via existing `RestoreOptions` configuration, which by this time has been already well-baked into our APIs. Restore engine will consume this configuration and infer which of the existing destination db files are 'in policy' to be retained during restore.

### Motivation

This work is motivated by internal customer who is running write-heavy, 1M+ QPS service and is using RocksDB restore functionality to scale up their fleet. Given already high QPS on their end, additional write IO from restores as-is today is contributing to prolonged spikes which lead the service to hit BLOB storage write quotas, which finally results in slowing down the pace of their scaling. See [T206217267](https://www.internalfb.com/intern/tasks/?t=206217267) for more.

### Impact
Enable faster service scaling by reducing write IO footprint on BLOB storage (coming from restore) to the absolute minimum.

### Key technical nuances

1. According to prior investigations, the risk of collisions on [file #, db session id, file size] metadata triplets is low enough to the point that we can confidently use it to uniquely describe the file and its' *perceived* contents, which is the rationale behind the `kKeepLatestDbSessionIdFiles` mode. To find more about the risks / tradeoffs for using this mode, please check the related comment in `backup_engine.cc`. This mode is only supported for SSTs where we persist the `db_session_id` information in the metadata footer.
2. `kVerifyChecksum` mode requires a full blob / SST file scan (assuming backup file has its' `checksum_hex` metadata set appropriately, if not additional file scan for backup file). While it saves us on write IOs (if checksums match), it's still fairly complex and _potentially_ CPU intensive operation.
3. We're extending the `WorkItemType` enum introduced in https://github.com/facebook/rocksdb/pull/13228 to accommodate a new simple request to `ComputeChecksum`, which will enable us to run 2) in parallel. This will become increasingly more important as we're moving towards disaggregated storage and holding up the sequence of checksum evaluations on a single lagging remote file scan would not be acceptable.
4. Note that it's necessary to compute the checksum on the restored file if corresponding backup file and existing destination db file checksums didn't match.

### Test plan  ✅ 

1. Manual testing using debugger: ✅ 
2. Automated tests:
* `./backup_engine_test --gtest_filter=*IncrementalRestore*` covering the following scenarios: ✅
  * Full clean restore
  * Integration with `exclude files` feature (with proper writes counting)
  * User workflow simulation: happy path with mix of added new files and deleted original backup files,
  * Existing db files corruptions and the difference in handling between `kVerifyChecksum` and `kKeepLatestDbSessionIdFiles` modes.
* `./backup_engine_test --gtest_filter=*ExcludedFiles*`  ✅ 
  * Integrate existing test collateral with newly introduced restore modes
