### PR TITLE
Fix flaky test asserting concurrent write thread's waiting time

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -297,8 +297,6 @@ TEST_F(ExternalSSTFileBasicTest, Basic) {
   }
 
   write_thread.join();
-  ASSERT_GT(perf_context.file_ingestion_blocking_live_writes_nanos,
-            write_thread_perf_context->write_thread_wait_nanos);
   SyncPoint::GetInstance()->DisableProcessing();
 
   // Re-ingest the file just to check the perf context not enabled at and below


### PR DESCRIPTION
This test assertion was added in #13219. It checks the concurrent write thread's wait time is not longer than the file ingestion thread's write blocking time since the former entered the write thread after the blocking already started in the test. This test runs into flakiness like this: 
```db/external_sst_file_basic_test.cc:300: Failure
Expected: (perf_context.file_ingestion_blocking_live_writes_nanos) > (write_thread_perf_context->write_thread_wait_nanos), actual: 166210 vs 279681
```
 In reality the write thread is yielding starting with a 1 micro period and then every 100 micros: https://github.com/facebook/rocksdb/blob/54b614de5bd3e26d332b85557d44bde86b2a2e87/db/write_thread.cc#L68-L70

So this 113 micros errors is within this margin
This fix the test with just removing this assertion. The other assertion `ASSERT_GT(write_thread_perf_context->write_thread_wait_nanos, 0)` should be sufficient for the test's purpose.