### PR TITLE
Support flush reasons above 12 in Java integration

### DIFF
--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -183,6 +183,8 @@ enum class FlushReason : int {
   kWalFull = 0xd,
   // SwitchMemtable will not be called for this flush reason.
   kCatchUpAfterErrorRecovery = 0xe,
+
+  // When adding flush reason, make sure to also add it to FlushReason in Java.
 };
 
 const char* GetFlushReasonString(FlushReason flush_reason);

--- a/java/src/main/java/org/rocksdb/FlushReason.java
+++ b/java/src/main/java/org/rocksdb/FlushReason.java
@@ -17,7 +17,10 @@ public enum FlushReason {
   DELETE_FILES((byte) 0x08),
   AUTO_COMPACTION((byte) 0x09),
   MANUAL_FLUSH((byte) 0x0a),
-  ERROR_RECOVERY((byte) 0xb);
+  ERROR_RECOVERY((byte) 0x0b),
+  ERROR_RECOVERY_RETRY_FLUSH((byte) 0x0c),
+  WAL_FULL((byte) 0x0d),
+  CATCH_UP_AFTER_ERROR_RECOVERY((byte) 0x0e);
 
   private final byte value;
 


### PR DESCRIPTION
Summary:

FlushReason enum in C++ has members up to 15, but in Java, the mirroring FlushReason only supports reason codes up to 12. This causes exceptions when adding a flush listener.