### PR TITLE
Remove unused variable: `number_of_files_to_sort_`

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4085,7 +4085,7 @@ void VersionStorageInfo::UpdateFilesByCompactionPri(
       temp[i].file = files[i];
     }
 
-    // sort the top number_of_files_to_sort_ based on file size
+    // sort the top kNumberFilesToSort based on file size
     size_t num = VersionStorageInfo::kNumberFilesToSort;
     if (num > temp.size()) {
       num = temp.size();

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -703,13 +703,6 @@ class VersionStorageInfo {
   // file that is not yet compacted
   std::vector<int> next_file_to_compact_by_size_;
 
-  // Only the first few entries of files_by_compaction_pri_ are sorted.
-  // There is no need to sort all the files because it is likely
-  // that on a running system, we need to look at only the first
-  // few largest files because a new version is created every few
-  // seconds/minutes (because of concurrent compactions).
-  static const size_t number_of_files_to_sort_ = 50;
-
   // This vector contains list of files marked for compaction and also not
   // currently being compacted. It is protected by DB mutex. It is calculated in
   // ComputeCompactionScore(). Used by Leveled and Universal Compaction.


### PR DESCRIPTION
This variable is not used, the one actually being used is `kNumberFilesToSort`.
https://github.com/facebook/rocksdb/blob/02b4197544f758bdf84d80fe9319238611848c48/db/version_set.h#L544-L549

