### PR TITLE
Support asyncio for windows

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -357,7 +357,7 @@ Options DBTestBase::GetOptions(
       "NewRandomAccessFile:O_DIRECT");
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearCallBack(
       "NewWritableFile:O_DIRECT");
-#else if defined(OS_WIN)
+#elif defined(OS_WIN)
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearCallBack(
       "NewRandomAccessFile:FILE_FLAG_NO_BUFFERING");
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearCallBack(

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -357,6 +357,11 @@ Options DBTestBase::GetOptions(
       "NewRandomAccessFile:O_DIRECT");
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearCallBack(
       "NewWritableFile:O_DIRECT");
+#else if defined(OS_WIN)
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearCallBack(
+      "NewRandomAccessFile:FILE_FLAG_NO_BUFFERING");
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearCallBack(
+      "NewWritableFile:FILE_FLAG_NO_BUFFERING");
 #endif
   // kMustFreeHeapAllocations -> indicates ASAN build
   if (kMustFreeHeapAllocations && !options_override.full_block_cache) {

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1411,6 +1411,7 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
   for (uint32_t attempt = 0; attempt < 20; attempt++) {
     // Random Read
     Random rnd(301 + attempt);
+#ifndef OS_WIN  // Windows currently does not read remaining data.
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
         "UpdateResults::io_uring_result", [&](void* arg) {
           if (attempt > 0) {
@@ -1424,6 +1425,7 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
             }
           }
         });
+#endif
 
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
     std::unique_ptr<RandomAccessFile> file;
@@ -1481,6 +1483,7 @@ TEST_F(EnvPosixTest, MultiReadNonAlignedLargeNum) {
     // too long, we can modify the io uring depth with SyncPoint here.
     const int num_reads = rnd.Uniform(512) + 1;
 
+#ifndef OS_WIN  // Windows currently does not read remaining data.
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
         "UpdateResults::io_uring_result", [&](void* arg) {
           if (attempt > 5) {
@@ -1497,6 +1500,7 @@ TEST_F(EnvPosixTest, MultiReadNonAlignedLargeNum) {
             }
           }
         });
+#endif
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
     // Generate (offset, len) pairs

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -1961,6 +1961,7 @@ TEST_P(PrefetchTest, AvoidBlockCacheLookupTwice) {
   Close();
 }
 
+#ifndef OS_WIN
 TEST_P(PrefetchTest, DBIterAsyncIONoIOUring) {
   if (mem_env_ || encrypted_env_) {
     ROCKSDB_GTEST_SKIP("Test requires non-mem or non-encrypted environment");
@@ -2061,6 +2062,7 @@ TEST_P(PrefetchTest, DBIterAsyncIONoIOUring) {
 
   enable_io_uring = true;
 }
+#endif
 
 class PrefetchTest1 : public DBTestBase,
                       public ::testing::WithParamInterface<bool> {

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -36,6 +36,7 @@
 #include "rocksdb/env.h"
 #include "rocksdb/slice.h"
 #include "strsafe.h"
+#include "test_util/sync_point.h"
 #include "util/string_util.h"
 
 // Undefine the functions  windows might use (again)...
@@ -245,6 +246,8 @@ IOStatus WinFileSystem::NewSequentialFile(
 
   if (options.use_direct_reads && !options.use_mmap_reads) {
     fileFlags |= FILE_FLAG_NO_BUFFERING;
+    TEST_SYNC_POINT_CALLBACK("NewSequentialFile:FILE_FLAG_NO_BUFFERING",
+                             &fileFlags);
   }
 
   {
@@ -278,8 +281,17 @@ IOStatus WinFileSystem::NewRandomAccessFile(
 
   if (options.use_direct_reads && !options.use_mmap_reads) {
     fileFlags |= FILE_FLAG_NO_BUFFERING;
+    TEST_SYNC_POINT_CALLBACK("NewRandomAccessFile:FILE_FLAG_NO_BUFFERING",
+                             &fileFlags);
   } else {
     fileFlags |= FILE_FLAG_RANDOM_ACCESS;
+  }
+
+  // Open in async mode which makes Windows allow more parallelism even
+  // if we need to do sync I/O on top of it. This is directly related to
+  // PositionedReadInternal() implementation
+  if (!options.use_mmap_reads) {
+    fileFlags |= FILE_FLAG_OVERLAPPED;
   }
 
   /// Shared access is necessary for corruption test to pass
@@ -350,7 +362,8 @@ IOStatus WinFileSystem::NewRandomAccessFile(
       fileGuard.release();
     }
   } else {
-    result->reset(new WinRandomAccessFile(fname, hFile, page_size_, options));
+    result->reset(
+        new WinRandomAccessFileAsyncIo(fname, hFile, page_size_, options));
     fileGuard.release();
   }
   return s;
@@ -370,6 +383,8 @@ IOStatus WinFileSystem::OpenWritableFile(
 
   if (local_options.use_direct_writes && !local_options.use_mmap_writes) {
     fileFlags = FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH;
+    TEST_SYNC_POINT_CALLBACK("NewWritableFile:FILE_FLAG_NO_BUFFERING",
+                             &fileFlags);
   }
 
   // Desired access. We are want to write only here but if we want to memory
@@ -469,6 +484,8 @@ IOStatus WinFileSystem::NewRandomRWFile(const std::string& fname,
 
   if (options.use_direct_reads && options.use_direct_writes) {
     file_flags |= FILE_FLAG_NO_BUFFERING;
+    TEST_SYNC_POINT_CALLBACK("NewRandomRWFile:FILE_FLAG_NO_BUFFERING",
+                             &file_flags);
   }
 
   /// Shared access is necessary for corruption test to pass
@@ -1168,6 +1185,88 @@ FileOptions WinFileSystem::OptimizeForManifestRead(
   optimized.use_mmap_writes = false;
   optimized.use_direct_reads = false;
   return optimized;
+}
+
+void WinFileSystem::SupportedOps(int64_t& supported_ops) {
+  supported_ops = 0;
+  supported_ops |= (1 << FSSupportedOps::kAsyncIO);
+}
+
+IOStatus WinFileSystem::Poll(std::vector<void*>& io_handles,
+                             size_t /*min_completions*/) {
+  for (size_t i = 0; i < io_handles.size(); i++) {
+    auto win_handle = static_cast<Win_IOHandle*>(io_handles[i]);
+
+    if (win_handle->is_finished) {
+      continue;
+    }
+
+    FSReadRequest req;
+    req.scratch = win_handle->scratch;
+    req.offset = win_handle->offset;
+    req.len = win_handle->len;
+    DWORD bytes_read = 0;
+    if (FALSE != GetOverlappedResult(win_handle->file_data->GetFileHandle(),
+                                     &win_handle->overlapped, &bytes_read,
+                                     TRUE)) {
+      TEST_SYNC_POINT_CALLBACK(
+          "UpdateResults::io_uring_result",
+          &bytes_read);  // For testing compatibility with io_uring only
+      req.result = Slice(req.scratch, bytes_read);
+      req.status = IOStatus::OK();
+    } else {
+      auto err = GetLastError();
+      if (ERROR_HANDLE_EOF != err) {
+        req.result = Slice(req.scratch, 0);
+        req.status = IOErrorFromWindowsError(
+            "GetOverlappedResult failed: " + win_handle->file_data->GetName(),
+            err);
+      } else {  // EOF
+        req.result = Slice(req.scratch, 0);
+        req.status = IOStatus::OK();
+      }
+    }
+
+    if (win_handle->overlapped.hEvent != NULL) {
+      CloseHandle(win_handle->overlapped.hEvent);
+      win_handle->overlapped.hEvent = NULL;
+    }
+
+    win_handle->is_finished = true;
+    win_handle->cb(req, win_handle->cb_arg);
+  }
+  return IOStatus::OK();
+}
+
+IOStatus WinFileSystem::AbortIO(std::vector<void*>& io_handles) {
+  for (size_t i = 0; i < io_handles.size(); i++) {
+    auto win_handle = static_cast<Win_IOHandle*>(io_handles[i]);
+    if (win_handle->is_finished) {
+      continue;
+    }
+
+    if (FALSE == CancelIoEx(win_handle->file_data->GetFileHandle(),
+                            &win_handle->overlapped)) {
+      auto err = GetLastError();
+      // If this CancelIoEx cannot find a request to cancel, GetLastError
+      // returns ERROR_NOT_FOUND
+      if (err != ERROR_NOT_FOUND) {
+        return IOErrorFromWindowsError(
+            "CancelIoEx failed: " + win_handle->file_data->GetName(), err);
+      }
+    }
+
+    if (win_handle->overlapped.hEvent != NULL) {
+      CloseHandle(win_handle->overlapped.hEvent);
+      win_handle->overlapped.hEvent = NULL;
+    }
+
+    win_handle->is_finished = true;
+    FSReadRequest req;
+    req.status = IOStatus::Aborted();
+    win_handle->cb(req, win_handle->cb_arg);
+  }
+  return IOStatus::OK();
 }
 
 // Returns true iff the named directory exists and is a directory.

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -1239,6 +1239,10 @@ IOStatus WinFileSystem::Poll(std::vector<void*>& io_handles,
 }
 
 IOStatus WinFileSystem::AbortIO(std::vector<void*>& io_handles) {
+  // On error, returns early without firing callbacks for remaining handles.
+  // Matches the Posix io_uring AbortIO behavior; real errors here indicate a
+  // broken FS state where the caller will have larger problems than a hung
+  // prefetch.
   for (size_t i = 0; i < io_handles.size(); i++) {
     auto win_handle = static_cast<Win_IOHandle*>(io_handles[i]);
     if (win_handle->is_finished) {

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -227,7 +227,10 @@ class WinFileSystem : public FileSystem {
       const FileOptions& file_options) const override;
   FileOptions OptimizeForManifestWrite(
       const FileOptions& file_options) const override;
-  void SupportedOps(int64_t& supported_ops) override { supported_ops = 0; }
+  virtual void SupportedOps(int64_t& supported_ops) override;
+  virtual IOStatus Poll(std::vector<void*>& io_handles,
+                        size_t min_completions) override;
+  virtual IOStatus AbortIO(std::vector<void*>& io_handles) override;
 
  protected:
   static uint64_t FileTimeToUnixTime(const FILETIME& ftTime);

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -35,6 +35,37 @@ inline bool IsPowerOfTwo(const size_t alignment) {
 inline bool IsAligned(size_t alignment, const void* ptr) {
   return ((uintptr_t(ptr)) & (alignment - 1)) == 0;
 }
+
+// Owns a per-thread auto-reset event used by preadAsyncIo() so synchronous
+// reads on FILE_FLAG_OVERLAPPED handles do not pay a CreateEvent/CloseHandle
+// kernel round-trip on every call. Safe because preadAsyncIo() blocks until
+// the IO completes before returning, so a thread can have at most one
+// outstanding IO using this event at any time.
+class ThreadLocalSyncReadEvent {
+ public:
+  ThreadLocalSyncReadEvent() : handle_(NULL) {}
+  ~ThreadLocalSyncReadEvent() {
+    if (handle_ != NULL) {
+      CloseHandle(handle_);
+    }
+  }
+
+  ThreadLocalSyncReadEvent(const ThreadLocalSyncReadEvent&) = delete;
+  ThreadLocalSyncReadEvent& operator=(const ThreadLocalSyncReadEvent&) = delete;
+
+  // Returns NULL on failure; caller should fall back to per-call CreateEvent.
+  HANDLE Get() {
+    if (handle_ == NULL) {
+      // Auto-reset event: WaitForSingleObject / GetOverlappedResult clears
+      // the signaled state automatically, so no ResetEvent() between reuses.
+      handle_ = RX_CreateEvent(NULL, FALSE, FALSE, NULL);
+    }
+    return handle_;
+  }
+
+ private:
+  HANDLE handle_;
+};
 }  // namespace
 
 std::string GetWindowsErrSz(DWORD err) {
@@ -154,7 +185,12 @@ IOStatus preadAsyncIo(const WinFileData* file_data, char* src, size_t num_bytes,
 
   overlapped.Offset = offsetUnion.LowPart;
   overlapped.OffsetHigh = offsetUnion.HighPart;
-  overlapped.hEvent = RX_CreateEvent(NULL, TRUE, FALSE, NULL);
+  // Reuse a per-thread auto-reset event to avoid a CreateEvent/CloseHandle
+  // kernel round-trip on every synchronous read. This path always waits for
+  // the IO to complete before returning, so the event is never in use by
+  // more than one in-flight IO on the same thread.
+  static thread_local ThreadLocalSyncReadEvent tls_event;
+  overlapped.hEvent = tls_event.Get();
 
   if (NULL == overlapped.hEvent) {
     auto lastError = GetLastError();
@@ -189,8 +225,6 @@ IOStatus preadAsyncIo(const WinFileData* file_data, char* src, size_t num_bytes,
   } else {
     bytes_read = bytesRead;
   }
-
-  CloseHandle(overlapped.hEvent);
 
   return s;
 }

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -1095,7 +1095,7 @@ WinRandomAccessFileAsyncIo::WinRandomAccessFileAsyncIo(
     const FileOptions& options)
     : WinRandomAccessFile(fname, hFile, alignment, options) {}
 
-Win_IOHandle::Win_IOHandle(std::function<void(const FSReadRequest&, void*)> _cb,
+Win_IOHandle::Win_IOHandle(std::function<void(FSReadRequest&, void*)> _cb,
                            void* _cb_arg, uint64_t _offset, size_t _len,
                            char* _scratch, WinFileData* _file_data)
     : cb(_cb),

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -1020,7 +1020,7 @@ IOStatus WinRandomAccessFileAsyncIo::MultiRead(FSReadRequest* reqs,
 
 IOStatus WinRandomAccessFileAsyncIo::ReadAsync(
     FSReadRequest& req, const IOOptions& /*opts*/,
-    std::function<void(const FSReadRequest&, void*)> cb, void* cb_arg,
+    std::function<void(FSReadRequest&, void*)> cb, void* cb_arg,
     void** io_handle, IOHandleDeleter* del_fn, IODebugContext* /*dbg*/) {
   // Check buffer alignment
   if (file_base_->use_direct_io()) {

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -15,6 +15,7 @@
 #include "monitoring/iostats_context_imp.h"
 #include "test_util/sync_point.h"
 #include "util/aligned_buffer.h"
+#include "util/autovector.h"
 #include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -132,6 +133,64 @@ IOStatus pread(const WinFileData* file_data, char* src, size_t num_bytes,
   } else {
     bytes_read = bytesRead;
   }
+
+  return s;
+}
+
+IOStatus preadAsyncIo(const WinFileData* file_data, char* src, size_t num_bytes,
+                      uint64_t offset, size_t& bytes_read) {
+  IOStatus s;
+  bytes_read = 0;
+
+  if (num_bytes > std::numeric_limits<DWORD>::max()) {
+    return IOStatus::InvalidArgument(
+        "num_bytes is too large for a single ReadFile: " +
+        file_data->GetName());
+  }
+
+  OVERLAPPED overlapped = {0};
+  ULARGE_INTEGER offsetUnion;
+  offsetUnion.QuadPart = offset;
+
+  overlapped.Offset = offsetUnion.LowPart;
+  overlapped.OffsetHigh = offsetUnion.HighPart;
+  overlapped.hEvent = RX_CreateEvent(NULL, TRUE, FALSE, NULL);
+
+  if (NULL == overlapped.hEvent) {
+    auto lastError = GetLastError();
+    return IOErrorFromWindowsError(
+        "CreateEvent for async read failed: " + file_data->GetName(),
+        lastError);
+  }
+
+  DWORD bytesRead = 0;
+
+  if (FALSE == ReadFile(file_data->GetFileHandle(), src,
+                        static_cast<DWORD>(num_bytes), &bytesRead,
+                        &overlapped)) {
+    DWORD lastError = GetLastError();
+    if (ERROR_IO_PENDING == lastError) {
+      if (FALSE != GetOverlappedResult(file_data->GetFileHandle(), &overlapped,
+                                       &bytesRead, TRUE)) {
+        bytes_read = bytesRead;
+      } else {
+        lastError = GetLastError();
+        if (lastError != ERROR_HANDLE_EOF) {
+          s = IOErrorFromWindowsError(
+              "GetOverlappedResult failed: " + file_data->GetName(), lastError);
+        }
+      }
+    } else {
+      if (lastError != ERROR_HANDLE_EOF) {
+        s = IOErrorFromWindowsError("ReadFile failed: " + file_data->GetName(),
+                                    lastError);
+      }
+    }
+  } else {
+    bytes_read = bytesRead;
+  }
+
+  CloseHandle(overlapped.hEvent);
 
   return s;
 }
@@ -701,6 +760,7 @@ inline IOStatus WinRandomAccessImpl::ReadImpl(uint64_t offset, size_t n,
   // Check buffer alignment
   if (file_base_->use_direct_io()) {
     assert(file_base_->IsSectorAligned(static_cast<size_t>(offset)));
+    assert(file_base_->IsSectorAligned(n));
     assert(IsAligned(alignment_, scratch));
   }
 
@@ -723,8 +783,6 @@ WinRandomAccessFile::WinRandomAccessFile(const std::string& fname, HANDLE hFile,
                                          const FileOptions& options)
     : WinFileData(fname, hFile, options.use_direct_reads),
       WinRandomAccessImpl(this, alignment, options) {}
-
-WinRandomAccessFile::~WinRandomAccessFile() {}
 
 IOStatus WinRandomAccessFile::Read(uint64_t offset, size_t n,
                                    const IOOptions& /*options*/, Slice* result,
@@ -752,6 +810,309 @@ IOStatus WinRandomAccessFile::GetFileSize(uint64_t* size) {
     return IOStatus::OK();
   } else {
     return IOStatus::IOError("Failed to get file size", filename_);
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// WinRandomAccessFileAsyncIo
+template <typename T>
+using AutoVector =
+    autovector<T, WinRandomAccessFileAsyncIo::kMaxConcurrentRequests>;
+IOStatus WinRandomAccessFileAsyncIo::PositionedReadInternal(
+    char* src, size_t numBytes, uint64_t offset, size_t& bytes_read) const {
+  return preadAsyncIo(file_base_, src, numBytes, offset, bytes_read);
+}
+
+inline void UpdateOverlapped(uint64_t offset, OVERLAPPED& overlapped) {
+  overlapped.Offset = static_cast<DWORD>(offset & 0xFFFFFFFF);
+  overlapped.OffsetHigh = static_cast<DWORD>(offset >> 32);
+};
+
+struct WrappedReadRequest {
+  FSReadRequest* req;
+  OVERLAPPED overlapped;
+  size_t finished_len;
+  DWORD error_code;
+
+  explicit WrappedReadRequest(FSReadRequest* r, uint64_t offset)
+      : req(r), finished_len(0), error_code(ERROR_SUCCESS) {
+    memset(&overlapped, 0, sizeof(overlapped));
+    UpdateOverlapped(offset, overlapped);
+  }
+
+  ~WrappedReadRequest() { CloseEvent(); }
+
+  IOStatus CreateEventIfNeeded() {
+    if (overlapped.hEvent == NULL) {
+      overlapped.hEvent = RX_CreateEvent(NULL, TRUE, FALSE, NULL);
+      if (overlapped.hEvent == NULL) {
+        return IOErrorFromWindowsError("CreateEvent failed", GetLastError());
+      }
+    }
+    return IOStatus::OK();
+  }
+
+  void CloseEvent() {
+    if (overlapped.hEvent != NULL) {
+      CloseHandle(overlapped.hEvent);
+      overlapped.hEvent = NULL;
+    }
+  }
+};
+
+inline IOStatus ProcessReadBatch(AutoVector<WrappedReadRequest>& req_wraps,
+                                 size_t start_idx, size_t batch_size,
+                                 WinFileData* file_data,
+                                 bool& stop_processing) {
+  IOStatus s = IOStatus::OK();
+  bool submitted_new_reqs = false;
+  DWORD bytes_read = 0;
+  stop_processing = false;
+
+  for (size_t i = 0; i < batch_size; i++) {
+    WrappedReadRequest* req_wrap = &req_wraps[start_idx + i];
+    FSReadRequest* req = req_wrap->req;
+
+    if (req->len > std::numeric_limits<DWORD>::max()) {
+      // To bypass regular error handling later
+      req_wrap->error_code = WinRandomAccessFileAsyncIo::kErrorCustomized;
+      req->result = Slice(req->scratch, 0);
+      req->status = IOStatus::InvalidArgument(
+          "FSReadRequest::len is too large for a single read: " +
+          file_data->GetName());
+      s = req->status;
+      continue;
+    }
+
+    // EOF presented as ERROR_HANDLE_EOF
+    if (req_wrap->finished_len == req->len ||
+        req_wrap->error_code != ERROR_SUCCESS) {
+      continue;
+    }
+
+    s = req_wrap->CreateEventIfNeeded();
+    if (!s.ok()) {
+      req_wrap->error_code = WinRandomAccessFileAsyncIo::kErrorCustomized;
+      req->result = Slice(req->scratch, 0);
+      req->status = s;
+      continue;
+    }
+
+    if (!submitted_new_reqs) {
+      submitted_new_reqs = true;
+    }
+
+    assert(req->len > req_wrap->finished_len);
+    UpdateOverlapped(req->offset + req_wrap->finished_len,
+                     req_wrap->overlapped);
+
+    if (FALSE == ReadFile(file_data->GetFileHandle(),
+                          req->scratch + req_wrap->finished_len,
+                          static_cast<DWORD>(req->len - req_wrap->finished_len),
+                          &bytes_read, &req_wrap->overlapped)) {
+      DWORD last_error = GetLastError();
+      req_wrap->error_code = last_error;
+      // Too many outstanding asynchronous I/O requests
+      if (last_error == ERROR_NOT_ENOUGH_MEMORY) {
+        CancelIoEx(file_data->GetFileHandle(), &req_wrap->overlapped);
+        stop_processing = true;
+        return IOErrorFromWindowsError(
+            "ReadFile failed: " + file_data->GetName(), last_error);
+      }
+    } else {
+      req_wrap->finished_len += bytes_read;
+      req_wrap->error_code = ERROR_SUCCESS;
+    }
+  }
+
+  if (!submitted_new_reqs) {
+    return s;
+  }
+
+  for (size_t i = 0; i < batch_size; i++) {
+    auto req_wrap = &req_wraps[start_idx + i];
+    auto req = req_wrap->req;
+    DWORD err = req_wrap->error_code;
+
+    if (ERROR_SUCCESS != err) {
+      if (ERROR_IO_PENDING == err) {
+        bytes_read = 0;
+        if (FALSE != GetOverlappedResult(file_data->GetFileHandle(),
+                                         &req_wrap->overlapped, &bytes_read,
+                                         TRUE)) {
+          TEST_SYNC_POINT_CALLBACK(
+              "UpdateResults::io_uring_result",
+              &bytes_read);  // For testing compatibility with io_uring only
+          req_wrap->finished_len += bytes_read;
+          req_wrap->error_code = ERROR_SUCCESS;
+          req->result = Slice(req->scratch, req_wrap->finished_len);
+          req->status = IOStatus::OK();
+        } else {
+          err = GetLastError();
+          req_wrap->error_code = err;
+          if (ERROR_HANDLE_EOF != err) {
+            req->result = Slice(req->scratch, 0);
+            req->status = IOErrorFromWindowsError(
+                "GetOverlappedResult failed: " + file_data->GetName(), err);
+          } else {  // EOF
+            req->result = Slice(req->scratch, 0);
+            req->status = IOStatus::OK();
+          }
+        }
+      } else if (ERROR_HANDLE_EOF == err) {  // EOF
+        req->result = Slice(req->scratch, 0);
+        req->status = IOStatus::OK();
+      } else if (WinRandomAccessFileAsyncIo::kErrorCustomized != err) {
+        req->result = Slice(req->scratch, 0);
+        req->status = IOErrorFromWindowsError(
+            "ReadFile failed: " + file_data->GetName(), err);
+      }
+    } else {
+      req->result = Slice(req->scratch, req_wrap->finished_len);
+      req->status = IOStatus::OK();
+    }
+
+    req_wrap->CloseEvent();
+  }
+
+  return s;
+}
+
+IOStatus WinRandomAccessFileAsyncIo::MultiRead(FSReadRequest* reqs,
+                                               size_t num_reqs,
+                                               const IOOptions& /*options*/,
+                                               IODebugContext* /*dbg*/) {
+  // Check buffer alignment
+  if (file_base_->use_direct_io()) {
+    for (size_t i = 0; i < num_reqs; i++) {
+      assert(file_base_->IsSectorAligned(static_cast<size_t>(reqs[i].offset)));
+      assert(file_base_->IsSectorAligned(reqs[i].len));
+      assert(IsAligned(GetAlignment(), reqs[i].scratch));
+    }
+  }
+
+  AutoVector<WrappedReadRequest> req_wraps;
+  IOStatus ios = IOStatus::OK();
+
+  for (size_t i = 0; i < num_reqs; i++) {
+    req_wraps.emplace_back(&reqs[i], reqs[i].offset);
+  }
+
+  // Process requests in batches
+  size_t current_idx = 0;
+  while (num_reqs > current_idx) {
+    size_t batch_size = num_reqs - current_idx;
+    batch_size = std::min(kMaxConcurrentRequests, batch_size);
+    size_t end_idx = batch_size + current_idx;
+
+    bool stop_processing = false;
+    ios = ProcessReadBatch(req_wraps, current_idx, batch_size, file_base_,
+                           stop_processing);
+    if (!ios.ok() && stop_processing) {
+      return ios;
+    }
+
+    current_idx = end_idx;
+  }
+
+  return ios;
+}
+
+IOStatus WinRandomAccessFileAsyncIo::ReadAsync(
+    FSReadRequest& req, const IOOptions& /*opts*/,
+    std::function<void(const FSReadRequest&, void*)> cb, void* cb_arg,
+    void** io_handle, IOHandleDeleter* del_fn, IODebugContext* /*dbg*/) {
+  // Check buffer alignment
+  if (file_base_->use_direct_io()) {
+    assert(file_base_->IsSectorAligned(static_cast<size_t>(req.offset)));
+    assert(file_base_->IsSectorAligned(req.len));
+    assert(IsAligned(alignment_, req.scratch));
+  }
+
+  if (req.len > std::numeric_limits<DWORD>::max()) {
+    return IOStatus::InvalidArgument(
+        "FSReadRequest::len is too large for a single ReadFile: " +
+        file_base_->GetName());
+  }
+
+  IOHandleDeleter deletefn = [](void* args) -> void {
+    delete (static_cast<Win_IOHandle*>(args));
+    args = nullptr;
+  };
+
+  Win_IOHandle* win_handle = new Win_IOHandle(cb, cb_arg, req.offset, req.len,
+                                              req.scratch, file_base_);
+
+  win_handle->overlapped.hEvent = RX_CreateEvent(NULL, TRUE, FALSE, NULL);
+  if (win_handle->overlapped.hEvent == NULL) {
+    return IOErrorFromWindowsError("CreateEvent failed", GetLastError());
+  }
+
+  *io_handle = static_cast<void*>(win_handle);
+  *del_fn = deletefn;
+
+  IOStatus ios = IOStatus::OK();
+  DWORD bytes_read = 0;
+  bool close_handle = true;
+  if (FALSE == ReadFile(file_base_->GetFileHandle(), req.scratch,
+                        static_cast<DWORD>(req.len), &bytes_read,
+                        &win_handle->overlapped)) {
+    DWORD last_error = GetLastError();
+    // Too many outstanding asynchronous I/O requests
+    if (last_error == ERROR_NOT_ENOUGH_MEMORY) {
+      CancelIoEx(file_base_->GetFileHandle(), &win_handle->overlapped);
+      ios = IOErrorFromWindowsError("ReadFile failed: " + file_base_->GetName(),
+                                    last_error);
+    } else if (last_error == ERROR_HANDLE_EOF) {
+      win_handle->is_finished = true;
+      req.result = Slice(req.scratch, 0);
+      req.status = IOStatus::OK();
+      cb(req, cb_arg);
+    } else if (last_error != ERROR_IO_PENDING) {
+      ios = IOErrorFromWindowsError("ReadFile failed: " + file_base_->GetName(),
+                                    last_error);
+    } else {
+      close_handle = false;
+    }
+
+  } else {
+    win_handle->is_finished = true;
+    req.result = Slice(req.scratch, bytes_read);
+    req.status = IOStatus::OK();
+    cb(req, cb_arg);
+  }
+
+  if (close_handle && win_handle->overlapped.hEvent != NULL) {
+    CloseHandle(win_handle->overlapped.hEvent);
+    win_handle->overlapped.hEvent = NULL;
+  }
+
+  return ios;
+}
+
+WinRandomAccessFileAsyncIo::WinRandomAccessFileAsyncIo(
+    const std::string& fname, HANDLE hFile, size_t alignment,
+    const FileOptions& options)
+    : WinRandomAccessFile(fname, hFile, alignment, options) {}
+
+Win_IOHandle::Win_IOHandle(std::function<void(const FSReadRequest&, void*)> _cb,
+                           void* _cb_arg, uint64_t _offset, size_t _len,
+                           char* _scratch, WinFileData* _file_data)
+    : cb(_cb),
+      cb_arg(_cb_arg),
+      offset(_offset),
+      len(_len),
+      scratch(_scratch),
+      is_finished(false),
+      file_data(_file_data) {
+  memset(&overlapped, 0, sizeof(overlapped));
+  UpdateOverlapped(_offset, overlapped);
+}
+
+Win_IOHandle::~Win_IOHandle() {
+  if (overlapped.hEvent != NULL) {
+    CloseHandle(overlapped.hEvent);
+    overlapped.hEvent = NULL;
   }
 }
 

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -1035,6 +1035,11 @@ IOStatus WinRandomAccessFileAsyncIo::ReadAsync(
         file_base_->GetName());
   }
 
+  HANDLE h_event = RX_CreateEvent(NULL, TRUE, FALSE, NULL);
+  if (h_event == NULL) {
+    return IOErrorFromWindowsError("CreateEvent failed", GetLastError());
+  }
+
   IOHandleDeleter deletefn = [](void* args) -> void {
     delete (static_cast<Win_IOHandle*>(args));
     args = nullptr;
@@ -1042,28 +1047,18 @@ IOStatus WinRandomAccessFileAsyncIo::ReadAsync(
 
   Win_IOHandle* win_handle = new Win_IOHandle(cb, cb_arg, req.offset, req.len,
                                               req.scratch, file_base_);
-
-  win_handle->overlapped.hEvent = RX_CreateEvent(NULL, TRUE, FALSE, NULL);
-  if (win_handle->overlapped.hEvent == NULL) {
-    return IOErrorFromWindowsError("CreateEvent failed", GetLastError());
-  }
+  win_handle->overlapped.hEvent = h_event;
 
   *io_handle = static_cast<void*>(win_handle);
   *del_fn = deletefn;
 
   IOStatus ios = IOStatus::OK();
   DWORD bytes_read = 0;
-  bool close_handle = true;
   if (FALSE == ReadFile(file_base_->GetFileHandle(), req.scratch,
                         static_cast<DWORD>(req.len), &bytes_read,
                         &win_handle->overlapped)) {
     DWORD last_error = GetLastError();
-    // Too many outstanding asynchronous I/O requests
-    if (last_error == ERROR_NOT_ENOUGH_MEMORY) {
-      CancelIoEx(file_base_->GetFileHandle(), &win_handle->overlapped);
-      ios = IOErrorFromWindowsError("ReadFile failed: " + file_base_->GetName(),
-                                    last_error);
-    } else if (last_error == ERROR_HANDLE_EOF) {
+    if (last_error == ERROR_HANDLE_EOF) {
       win_handle->is_finished = true;
       req.result = Slice(req.scratch, 0);
       req.status = IOStatus::OK();
@@ -1071,10 +1066,8 @@ IOStatus WinRandomAccessFileAsyncIo::ReadAsync(
     } else if (last_error != ERROR_IO_PENDING) {
       ios = IOErrorFromWindowsError("ReadFile failed: " + file_base_->GetName(),
                                     last_error);
-    } else {
-      close_handle = false;
     }
-
+    // else last_error is ERROR_IO_PENDING
   } else {
     win_handle->is_finished = true;
     req.result = Slice(req.scratch, bytes_read);
@@ -1082,7 +1075,7 @@ IOStatus WinRandomAccessFileAsyncIo::ReadAsync(
     cb(req, cb_arg);
   }
 
-  if (close_handle && win_handle->overlapped.hEvent != NULL) {
+  if (win_handle->is_finished && win_handle->overlapped.hEvent != NULL) {
     CloseHandle(win_handle->overlapped.hEvent);
     win_handle->overlapped.hEvent = NULL;
   }

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -532,6 +532,7 @@ class WinFileLock : public FileLock {
   HANDLE hFile_;
 };
 
+// This class auto closes overlapped.hEvent during destruction if it is not NULL
 struct Win_IOHandle {
   std::function<void(FSReadRequest&, void*)> cb;
   void* cb_arg;

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -533,7 +533,7 @@ class WinFileLock : public FileLock {
 };
 
 struct Win_IOHandle {
-  std::function<void(const FSReadRequest&, void*)> cb;
+  std::function<void(FSReadRequest&, void*)> cb;
   void* cb_arg;
   uint64_t offset;
   size_t len;
@@ -542,8 +542,8 @@ struct Win_IOHandle {
   bool is_finished;
   WinFileData* file_data;
 
-  Win_IOHandle(std::function<void(const FSReadRequest&, void*)> _cb,
-               void* _cb_arg, uint64_t _offset, size_t _len, char* _scratch,
+  Win_IOHandle(std::function<void(FSReadRequest&, void*)> _cb, void* _cb_arg,
+               uint64_t _offset, size_t _len, char* _scratch,
                WinFileData* _file_data);
   ~Win_IOHandle();
 };

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -44,6 +44,7 @@ inline IOStatus IOError(const std::string& context, int err_number) {
              : IOStatus::IOError(context, errnoStr(err_number).c_str());
 }
 
+struct Win_IOHandle;
 class WinFileData;
 
 IOStatus pwrite(const WinFileData* file_data, const Slice& data,
@@ -252,7 +253,7 @@ class WinRandomAccessImpl {
   size_t alignment_;
 
   // Override for behavior change when creating a custom env
-  virtual IOStatus PositionedReadInternal(char* src, size_t numBytes,
+  virtual IOStatus PositionedReadInternal(char* src, size_t num_bytes,
                                           uint64_t offset,
                                           size_t& bytes_read) const;
 
@@ -281,7 +282,7 @@ class WinRandomAccessFile
   WinRandomAccessFile(const std::string& fname, HANDLE hFile, size_t alignment,
                       const FileOptions& options);
 
-  ~WinRandomAccessFile();
+  virtual ~WinRandomAccessFile() = default;
 
   IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,
                 Slice* result, char* scratch,
@@ -296,6 +297,31 @@ class WinRandomAccessFile
   size_t GetRequiredBufferAlignment() const override;
 
   IOStatus GetFileSize(uint64_t* file_size) override;
+};
+
+// hFile opened with FILE_FLAG_OVERLAPPED
+class WinRandomAccessFileAsyncIo : public WinRandomAccessFile {
+ public:
+  static constexpr size_t kMaxConcurrentRequests = 32;
+  static constexpr DWORD kErrorCustomized = (DWORD)-1;
+
+  WinRandomAccessFileAsyncIo(const std::string& fname, HANDLE hFile,
+                             size_t alignment, const FileOptions& options);
+
+  virtual ~WinRandomAccessFileAsyncIo() = default;
+
+  virtual IOStatus PositionedReadInternal(char* src, size_t num_bytes,
+                                          uint64_t offset,
+                                          size_t& bytes_read) const override;
+
+  virtual IOStatus MultiRead(FSReadRequest* reqs, size_t num_reqs,
+                             const IOOptions& options,
+                             IODebugContext* dbg) override;
+  // EXPERIMENTAL
+  virtual IOStatus ReadAsync(
+      FSReadRequest& req, const IOOptions& opts,
+      std::function<void(const FSReadRequest&, void*)> cb, void* cb_arg,
+      void** io_handle, IOHandleDeleter* del_fn, IODebugContext* dbg) override;
 };
 
 // This is a sequential write class. It has been mimicked (as others) after
@@ -504,5 +530,22 @@ class WinFileLock : public FileLock {
  private:
   HANDLE hFile_;
 };
+
+struct Win_IOHandle {
+  std::function<void(const FSReadRequest&, void*)> cb;
+  void* cb_arg;
+  uint64_t offset;
+  size_t len;
+  char* scratch;
+  OVERLAPPED overlapped;
+  bool is_finished;
+  WinFileData* file_data;
+
+  Win_IOHandle(std::function<void(const FSReadRequest&, void*)> _cb,
+               void* _cb_arg, uint64_t _offset, size_t _len, char* _scratch,
+               WinFileData* _file_data);
+  ~Win_IOHandle();
+};
+
 }  // namespace port
 }  // namespace ROCKSDB_NAMESPACE

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -318,10 +318,11 @@ class WinRandomAccessFileAsyncIo : public WinRandomAccessFile {
                              const IOOptions& options,
                              IODebugContext* dbg) override;
   // EXPERIMENTAL
-  virtual IOStatus ReadAsync(
-      FSReadRequest& req, const IOOptions& opts,
-      std::function<void(const FSReadRequest&, void*)> cb, void* cb_arg,
-      void** io_handle, IOHandleDeleter* del_fn, IODebugContext* dbg) override;
+  virtual IOStatus ReadAsync(FSReadRequest& req, const IOOptions& opts,
+                             std::function<void(FSReadRequest&, void*)> cb,
+                             void* cb_arg, void** io_handle,
+                             IOHandleDeleter* del_fn,
+                             IODebugContext* dbg) override;
 };
 
 // This is a sequential write class. It has been mimicked (as others) after

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -343,6 +343,7 @@ bool GenerateRfcUuid(std::string* output);
 #define RX_GetCurrentDirectory GetCurrentDirectoryW
 #define RX_GetDiskFreeSpaceEx GetDiskFreeSpaceExW
 #define RX_PathIsDirectory PathIsDirectoryW
+#define RX_CreateEvent CreateEventW
 
 #else
 
@@ -369,6 +370,7 @@ bool GenerateRfcUuid(std::string* output);
 #define RX_GetCurrentDirectory GetCurrentDirectoryA
 #define RX_GetDiskFreeSpaceEx GetDiskFreeSpaceExA
 #define RX_PathIsDirectory PathIsDirectoryA
+#define RX_CreateEvent CreateEventA
 
 #endif
 

--- a/test_util/sync_point.cc
+++ b/test_util/sync_point.cc
@@ -77,6 +77,28 @@ void SetupSyncPointsToMockDirectIO() {
         *val &= ~O_DIRECT;
       });
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+#elif !defined(NDEBUG) && defined(OS_WIN)
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "NewWritableFile:FILE_FLAG_NO_BUFFERING", [&](void* arg) {
+        DWORD* val = static_cast<DWORD*>(arg);
+        *val &= ~FILE_FLAG_NO_BUFFERING;
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "NewRandomAccessFile:FILE_FLAG_NO_BUFFERING", [&](void* arg) {
+        DWORD* val = static_cast<DWORD*>(arg);
+        *val &= ~FILE_FLAG_NO_BUFFERING;
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "NewSequentialFile:FILE_FLAG_NO_BUFFERING", [&](void* arg) {
+        DWORD* val = static_cast<DWORD*>(arg);
+        *val &= ~FILE_FLAG_NO_BUFFERING;
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "NewRandomRWFile:FILE_FLAG_NO_BUFFERING", [&](void* arg) {
+        DWORD* val = static_cast<DWORD*>(arg);
+        *val &= ~FILE_FLAG_NO_BUFFERING;
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 #endif
 }
 


### PR DESCRIPTION
Implemented interfaces to support asynchronous I/O on Windows and updated the corresponding unit tests accordingly. Our benchmark tests revealed the following performance improvements:

- Setup1: Sequentially filled data ( -key_size=32 -value_size=512 --num=1800000 ) then compacted to one single SST file. Randomly read from that file.

![image](https://github.com/user-attachments/assets/8400a99b-b9c3-465e-bfc5-2ef80854b346)
![image](https://github.com/user-attachments/assets/6ca30a05-2561-43ae-9313-41c39b0d33b3)
![image](https://github.com/user-attachments/assets/091cc0a9-3f29-479b-9e75-9e0f845bc4e5)

- Setup2: 
Data ingestion:
.\db_bench_je  --benchmarks=fillseqdeterministic,levelstats,memstats --statistics --threads={thread_count} --compression_type=None --db=K:\manyleveldb -key_size=32 -value_size=512 --num=18000000 --num_levels=5 --report_file=fillseqmany.csv --disable_wal=true --seed=1714024597051096 --stats_dump_period_sec=30 --optimize_filters_for_hits=true  --disable_auto_compactions=true
Then random seek from that db.
  
![10f3d1f6-7729-4ca2-a849-9288819d6eb0](https://github.com/user-attachments/assets/6d87f85c-25fb-4319-86be-87c98123ffe3)
![688dec94-78fe-4878-a105-6e1df207708c](https://github.com/user-attachments/assets/35c63f02-3250-4e55-8514-b8b626f1e1ca)
![2f89318b-8b70-475d-90a0-b09ea2fc89fc](https://github.com/user-attachments/assets/c3ba6d28-ae90-4ac9-b570-4b660360b699)

We didn't test integration with folly.

