### PR TITLE
Reapply fix for https://github.com/facebook/rocksdb/issues/13166

### DIFF
--- a/memtable/wbwi_memtable.h
+++ b/memtable/wbwi_memtable.h
@@ -367,7 +367,7 @@ class WBWIMemTableIterator final : public InternalIterator {
       key_.clear();
       valid_ = false;
       s_ = Status::Corruption("Unexpected write_batch_with_index entry type " +
-                              std::to_string(t->second));
+                              std::to_string(it_->Entry().type));
       return;
     }
     key_buf_.SetInternalKey(it_->Entry().key, assigned_seqno_.upper_bound,


### PR DESCRIPTION
There was a fix in https://github.com/facebook/rocksdb/pull/13171 for issue https://github.com/facebook/rocksdb/issues/13166 but it was overwritten by commit https://github.com/facebook/rocksdb/commit/d5345a8ff72c05c3d014fb18bed030d60d1d8e4d. This PR is to reapply the fix.

Fixes https://github.com/facebook/rocksdb/issues/13264 to have Rocks compile under Ubuntu again