### PR TITLE
Temporary work around nullptr seqno_to_time_mapping in FlushJob

### DIFF
--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -1193,7 +1193,11 @@ void FlushJob::GetEffectiveCutoffUDTForPickedMemTables() {
 }
 
 void FlushJob::GetPrecludeLastLevelMinSeqno() {
-  if (mutable_cf_options_.preclude_last_level_data_seconds == 0) {
+  if (mutable_cf_options_.preclude_last_level_data_seconds == 0 ||
+      // FIXME: create FlushJob and build SuperVersions such that
+      // preclude_last_level_data_seconds > 0 implies
+      // seqno_to_time_mapping_ != nullptr
+      seqno_to_time_mapping_ == nullptr) {
     return;
   }
   int64_t current_time = 0;


### PR DESCRIPTION
Summary: To resolve a crash test failure in
`FlushJob::GetPrecludeLastLevelMinSeqno()`

To fix this properly, I will work on ensuring that (a) FlushJob is created with a consistent view on mutable options and seqno_to_time_mapping (from a single SuperVersion) and (b) SuperVersions always have a non-null seqno_to_time_mapping when a relevant option is set.

Test Plan: watch crash test