### PR TITLE
Clean up obsolete code in BlockBasedTable::PrefetchIndexAndFilterBlocks

### DIFF
--- a/table/block_based/filter_policy.cc
+++ b/table/block_based/filter_policy.cc
@@ -1410,10 +1410,6 @@ bool BuiltinFilterPolicy::IsInstanceOf(const std::string& name) const {
 
 static const char* kBuiltinFilterMetadataName = "rocksdb.BuiltinBloomFilter";
 
-const char* BuiltinFilterPolicy::kCompatibilityName() {
-  return kBuiltinFilterMetadataName;
-}
-
 const char* BuiltinFilterPolicy::CompatibilityName() const {
   return kBuiltinFilterMetadataName;
 }

--- a/table/block_based/filter_policy_internal.h
+++ b/table/block_based/filter_policy_internal.h
@@ -149,7 +149,6 @@ class BuiltinFilterPolicy : public FilterPolicy {
   bool IsInstanceOf(const std::string& id) const override;
   // All variants of BuiltinFilterPolicy can read each others filters.
   const char* CompatibilityName() const override;
-  static const char* kCompatibilityName();
 
  public:  // new
   // An internal function for the implementation of

--- a/unreleased_history/bug_fixes/cleanup_obsolete_code_in_prefetch_index.md
+++ b/unreleased_history/bug_fixes/cleanup_obsolete_code_in_prefetch_index.md
@@ -1,0 +1,1 @@
+Clean up obsolete fix in `BlockBasedTable::PrefetchIndexAndFilterBlocks` isolated to early 7.0.x releases.

--- a/unreleased_history/bug_fixes/cleanup_obsolete_code_in_prefetch_index.md
+++ b/unreleased_history/bug_fixes/cleanup_obsolete_code_in_prefetch_index.md
@@ -1,1 +1,0 @@
-Clean up obsolete fix in `BlockBasedTable::PrefetchIndexAndFilterBlocks` isolated to early 7.0.x releases.


### PR DESCRIPTION
### Summary:

As advertised and recommended by original authors comment, we're removing the now-outdated special handling logic for bloom filters perf regression (timing ~release 7.0.X). I decided to keep the `CompatibilityName` as-is since 1) it's publicly exposed API and 2) it's generally useful to have a dedicated name used for identifying whether a filter on disk is readable by the FilterPolicy.

### Test Plan

'Dead code' / tech debt. As a smoke test, I manually run a similar benchmark to the one in https://github.com/facebook/rocksdb/pull/9736, with ./db_bench built pre and post change.

**Generate DB:**

```hcl
./db_bench -db=/dev/shm/rocksdb.9.11 -bloom_bits=10 -cache_index_and_filter_blocks=1 -benchmarks=fillrandom -num=10000000 -compaction_style=2 -fifo_compaction_max_table_files_size_mb=10000 -fifo_compaction_allow_compaction=0
```

**Before removing the 'if' block:**

```hcl
./db_bench -db=/dev/shm/rocksdb.9.11 -use_existing_db -readonly -bloom_bits=10 -benchmarks=readrandom -num=10000000 -compaction_style=2 -fifo_compaction_max_table_files_size_mb=10000 -fifo_compaction_allow_compaction=0 -duration=10 2>&1 | grep micros/op

readrandom   :      17.216 micros/op 58085 ops/sec 10.002 seconds 580999 operations;    4.1 MB/s (367256 of 580999 found)
```

**After removing the 'if' block:**

```hcl
./db_bench -db=/dev/shm/rocksdb.9.11 -use_existing_db -readonly -bloom_bits=10 -benchmarks=readrandom -num=10000000 -compaction_style=2 -fifo_compaction_max_table_files_size_mb=10000 -fifo_compaction_allow_compaction=0 -duration=10 2>&1 | grep micros/op

readrandom   :      16.776 micros/op 59607 ops/sec 10.015 seconds 596999 operations;    4.2 MB/s (377846 of 596999 found)
```