### PR TITLE
Verify values in secondary database against expected state

### DIFF
--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -1040,8 +1040,8 @@ class CfConsistencyStressTest : public StressTest {
     assert(thread);
     Status status;
 
-    DB* db_ptr = cmp_db_ ? cmp_db_ : db_;
-    const auto& cfhs = cmp_db_ ? cmp_cfhs_ : column_families_;
+    DB* db_ptr = secondary_db_ ? secondary_db_ : db_;
+    const auto& cfhs = secondary_db_ ? secondary_cfhs_ : column_families_;
 
     // Take a snapshot to preserve the state of primary db.
     ManagedSnapshot snapshot_guard(db_);
@@ -1049,8 +1049,8 @@ class CfConsistencyStressTest : public StressTest {
     SharedState* shared = thread->shared;
     assert(shared);
 
-    if (cmp_db_) {
-      status = cmp_db_->TryCatchUpWithPrimary();
+    if (secondary_db_) {
+      status = secondary_db_->TryCatchUpWithPrimary();
       if (!status.ok()) {
         fprintf(stderr, "TryCatchUpWithPrimary: %s\n",
                 status.ToString().c_str());
@@ -1083,7 +1083,7 @@ class CfConsistencyStressTest : public StressTest {
     // `FLAGS_rate_limit_user_ops` to avoid slowing any validation.
     ReadOptions ropts(FLAGS_verify_checksum, true);
     ropts.total_order_seek = true;
-    if (nullptr == cmp_db_) {
+    if (nullptr == secondary_db_) {
       ropts.snapshot = snapshot_guard.snapshot();
     }
     uint32_t crc = 0;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -69,7 +69,7 @@ StressTest::StressTest()
       new_column_family_name_(1),
       num_times_reopened_(0),
       db_preload_finished_(false),
-      cmp_db_(nullptr),
+      secondary_db_(nullptr),
       is_db_stopped_(false) {
   if (FLAGS_destroy_db_initially) {
     std::vector<std::string> files;
@@ -114,11 +114,11 @@ void StressTest::CleanUp() {
   delete db_;
   db_ = nullptr;
 
-  for (auto* cf : cmp_cfhs_) {
+  for (auto* cf : secondary_cfhs_) {
     delete cf;
   }
-  cmp_cfhs_.clear();
-  delete cmp_db_;
+  secondary_cfhs_.clear();
+  delete secondary_db_;
 }
 
 std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
@@ -3696,9 +3696,10 @@ void StressTest::Open(SharedState* shared, bool reopen) {
       tmp_opts.env = db_stress_env;
       const std::string& secondary_path = FLAGS_secondaries_base;
       s = DB::OpenAsSecondary(tmp_opts, FLAGS_db, secondary_path,
-                              cf_descriptors, &cmp_cfhs_, &cmp_db_);
+                              cf_descriptors, &secondary_cfhs_, &secondary_db_);
       assert(s.ok());
-      assert(cmp_cfhs_.size() == static_cast<size_t>(FLAGS_column_families));
+      assert(secondary_cfhs_.size() ==
+             static_cast<size_t>(FLAGS_column_families));
     }
   } else {
     DBWithTTL* db_with_ttl;

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -412,9 +412,8 @@ class StressTest {
   std::atomic<bool> db_preload_finished_;
   std::shared_ptr<SstQueryFilterConfigsManager::Factory> sqfc_factory_;
 
-  // Fields used for continuous verification from another thread
-  DB* cmp_db_;
-  std::vector<ColumnFamilyHandle*> cmp_cfhs_;
+  DB* secondary_db_;
+  std::vector<ColumnFamilyHandle*> secondary_cfhs_;
   bool is_db_stopped_;
 };
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -398,7 +398,7 @@ class NonBatchedOpsStressTest : public StressTest {
                     << pre_read_expected_value.GetValueBase() << " to"
                     << post_read_expected_value.GetFinalValueBase()
                     << std::endl;
-          thread->shared->SetVerificationFailure();
+          shared->SetVerificationFailure();
           break;
         }
       } else if (s.IsNotFound()) {
@@ -409,7 +409,7 @@ class NonBatchedOpsStressTest : public StressTest {
               << ", key=" << key.ToString(true)
               << ". Get() returned NotFound when the key should have existed."
               << std::endl;
-          thread->shared->SetVerificationFailure();
+          shared->SetVerificationFailure();
           break;
         }
       }
@@ -449,8 +449,9 @@ class NonBatchedOpsStressTest : public StressTest {
             FLAGS_user_timestamp_size > 0 ? &key_ts : nullptr);
         s.PermitUncheckedError();
       } else if (!FLAGS_inplace_update_support) {
-        // The combination of inplace_update_support=true and backward iteration
-        // is not allowed
+        // I think this portion of the verification failed because the
+        // combination of inplace_update_support=true and backward iteration is
+        // not allowed.
 
         // Use range scan
         std::unique_ptr<Iterator> iter(
@@ -492,7 +493,7 @@ class NonBatchedOpsStressTest : public StressTest {
         if (!s.ok()) {
           std::string checksum_err_msg =
               "Failed to compute checksum for secondary cf " +
-              std::to_string(cf) + ". Status " + s.ToString();
+              std::to_string(cf) + ". Status: " + s.ToString();
           VerificationAbort(shared, checksum_err_msg);
           assert(false);
         }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -376,14 +376,13 @@ class NonBatchedOpsStressTest : public StressTest {
   }
 
   void ContinuouslyVerifyDb(ThreadState* thread) const override {
-    // Currently this method gets called even when
-    // FLAGS_continuous_verification_interval == 0 as long as
-    // FLAGS_verify_db_one_in > 0. Previously, this was not causing a problem in
-    // the crash tests since test_secondary was always equal to 0, and thus we
-    // returned early from this method. When test_secondary is set and we have a
-    // secondary_db_, the crash test fails during this iterator scan. The stack
-    // trace mentions BlobReader/BlobSource but it may not necessarily be
-    // related to BlobDB
+    // For automated crash tests, we only want to run this continous
+    // verification when continuous_verification_interval > 0 and there is
+    // a secondary db. This continous verification currently fails when there is
+    // a secondary db during the iterator scan. The stack trace mentions
+    // BlobReader/BlobSource but it may not necessarily be related to BlobDB.
+    // Regardless, we only want to run this function if we are experimenting and
+    // explicitly setting continuous_verification_interval.
     if (!secondary_db_ || !FLAGS_continuous_verification_interval) {
       return;
     }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -373,7 +373,15 @@ class NonBatchedOpsStressTest : public StressTest {
   }
 
   void ContinuouslyVerifyDb(ThreadState* thread) const override {
-    if (!secondary_db_) {
+    // Currently this method gets calleds even when
+    // FLAGS_continuous_verification_interval == 0 as long as
+    // FLAGS_verify_db_one_in > 0. Previously, this was not causing a problem in
+    // the crash tests since test_secondary was always equal to 0, and thus we
+    // returned early from this method. When test_secondary is set and we have a
+    // secondary_db_, the crash test fails during this iterator scan. The stack
+    // trace mentions BlobReader/BlobSource but it may not necessarily be
+    // related to BlobDB
+    if (!secondary_db_ || !FLAGS_continuous_verification_interval) {
       return;
     }
     assert(secondary_db_);

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -187,6 +187,9 @@ class NonBatchedOpsStressTest : public StressTest {
             s = secondary_db_->Get(options, column_families_[cf], key,
                                    &from_db);
 
+            assert(!pre_read_expected_values.empty() &&
+                   static_cast<size_t>(i - start) <
+                       pre_read_expected_values.size());
             VerifyValueRange(static_cast<int>(cf), i, options, shared, from_db,
                              /* msg_prefix */ "Secondary get verification", s,
                              pre_read_expected_values[i - start]);
@@ -373,7 +376,7 @@ class NonBatchedOpsStressTest : public StressTest {
   }
 
   void ContinuouslyVerifyDb(ThreadState* thread) const override {
-    // Currently this method gets calleds even when
+    // Currently this method gets called even when
     // FLAGS_continuous_verification_interval == 0 as long as
     // FLAGS_verify_db_one_in > 0. Previously, this was not causing a problem in
     // the crash tests since test_secondary was always equal to 0, and thus we

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -486,7 +486,6 @@ simple_default_params = {
     "level_compaction_dynamic_level_bytes": lambda: random.randint(0, 1),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
     "test_secondary": lambda: random.choice([0, 1]),
-    "continuous_verification_interval": lambda: random.choice([0, 1000]),
 }
 
 blackbox_simple_default_params = {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -485,6 +485,8 @@ simple_default_params = {
     "write_buffer_size": 32 * 1024 * 1024,
     "level_compaction_dynamic_level_bytes": lambda: random.randint(0, 1),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
+    "test_secondary": lambda: random.choice([0, 1]),
+    "continuous_verification_interval": lambda: random.choice([0, 1000]),
 }
 
 blackbox_simple_default_params = {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1023,6 +1023,9 @@ def finalize_and_sanitize(src_params):
     if dest_params.get("track_and_verify_wals", 0) == 1:
         dest_params["metadata_write_fault_one_in"] = 0
         dest_params["write_fault_one_in"] = 0
+    # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
+    if dest_params.get("test_secondary") == 1:
+        dest_params["continuous_verification_interval"] = 0
     return dest_params
 
 


### PR DESCRIPTION
# Summary

TLDR: This PR enables secondary DB verification inside the "simple" crash tests (`NonBatchedOpsStressTest`). Essentially, we want to be able to verify that the secondary is a valid "prefix" of the primary. This PR allows us to do this by piggybacking on the existing verification of the primary through `Get()` requests.

I originally proposed replaying the trace file to recreate the `ExpectedState` as of a specific sequence number. This could be used to run verifications against the secondary database. I did some experimenting in #13266 and got a "mostly working" implementation of this approach. I could sometimes get through entire key space verifications but eventually one of the keys would fail verification. I have not figured out the root cause yet, but I assume that something caused the sequence number to trace record alignment to break.

The approach in this PR is considerably simpler. We can just check that the secondary database's value is in the correct "range," which we already have functionality for checking that. Compared to the approach in #13266, this approach is _much, much simpler_ since we do not have to go through the whole headache of replaying the trace and creating an entire new `ExpectedState`. (Look at #13266 to see how much of a mess that creates.) I think this approach is better than my original approach in almost most aspects: it's faster, uses less space, and has less room for implementation errors.

Other nice aspects of this approach:
1. We don't need to block the primary. (Another approach you could imagine would be to block writes to the primary, have the secondary catch up, do the whole verification, and then re-enable writes to the primary.)
2. We don't need to block the secondary or do any special coordination (locks, sync points, etc). (If we insist on one "golden" expected value to be read from the secondary, then we need to make sure that another thread does not call `TryCatchUpWithPrimary` while we are trying to perform a `Get()`)
3. More "realistic" usage of the secondary. For instance, writes to the primary and secondary would continue on in production while we try to read from the secondary.

The main drawback of course is that we verify against a range of expected values, rather than one particular expected value. However, I think this is acceptable and "good enough" especially with all of other the aforementioned benefits.

Historical context: There is some very old code that attempted to verify secondaries, but is not enabled. This code has not been touched or executed in an extremely long time, and the crash tests started failing when I tried enabling it, most likely because the code is not compatible with certain other crash test options. This code is for the "continuous verification" and involves long iterator scans over the secondary database. Some of the code involved the cross CF consistency test type. I don't think the old checks are what we really want for our purposes of verifying the secondary functionality. Since I don't think we will get much value out of this old "continuous verification" code, I integrated my secondary verification with the "regular" database verification. This also makes the rollout simpler on my end, since I can control whether my secondary verifications are enabled through one `test_secondary` configuration. To make sure the old code does not execute for our recurring crash test runs, I had to enforce that `continuous_verification_interval` is 0 whenever `test_secondary` is set.

Monitoring: I will want to monitor the Sandcastle "simple" runs for failures where `test_secondary` is set. All of my error messages are prefixed with "Secondary" so it should be easy to tell if this PR causes any crash test issues.

Future work:
1. Extend this to followers. I think the same verification method should work, so most of the code from this PR should be reusable
2. Add additional checks to make sure the sequence number of the follower/secondary is actually increasing. For instance, if the primary's sequence number has advanced, and in that period the secondary has not (even after calling `TryCatchUpWithPrimary`), then we know there is a problem
3. Potentially checking things other than `Get()` for the secondary (i.e. iterators). I think the focus here should be testing replication-specific logic, and since we will already have separate unit tests, we do not need to repeat all of tests against both the primary and the secondary.

# Test Plan

The primary crash test commands I ran were:
```
python3 tools/db_crashtest.py --simple blackbox --test_secondary=1
python3 tools/db_crashtest.py --simple whitebox --test_secondary=1
```

As a sanity check, I added an `assert(false)` right after my secondary verification code to make sure that my code was actually being run.