### PR TITLE
Don't fail crash test if cleanup cmd fails after successful test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1156,8 +1156,7 @@ def cleanup_after_success(dbname):
         print("Running DB cleanup command - %s\n" % cleanup_cmd)
         ret = os.system(cleanup_cmd)
         if ret != 0:
-            print("TEST FAILED. DB cleanup returned error %d\n" % ret)
-            sys.exit(1)
+            print("WARNING: DB cleanup returned error %d\n" % ret)
 
 
 # This script runs and kills db_stress multiple times. It checks consistency


### PR DESCRIPTION
The warm storage crash test sometimes fails due to the cleanup command failing if the db_stress exited successfully and we already cleaned up. This results in false alarms. Don't treat a cleanup command failure as crash test failure.