### PR TITLE
Parallelize backup verification

### DIFF
--- a/unreleased_history/behavior_changes/parallelize_backup_verification.md
+++ b/unreleased_history/behavior_changes/parallelize_backup_verification.md
@@ -1,0 +1,1 @@
+`VerifyBackup` in `verify_with_checksum`=`true` mode will now evaluate checksums in parallel. As a result, unlike in case of original implementation, the API won't bail out on a very first corruption / mismatch and instead will iterate over all the backup files logging success / _degree_of_failure_ for each.


### PR DESCRIPTION
### Summary
Today, backup verification is serial, which could pose a challenge in rare, high urgency recovery scenarios where we want to timely assess whether candidate backup is not corrupted and eligible for the restore. The _timely_ part will become increasingly more important in case of disaggregated storage.

### Semantics
Given the very simple thread pool implementation in `backup_engine` today, we do not really have a control over initialized threads and consequently do not have an option to unschedule / cancel in-progress tasks. As a result, `VerifyBackup` won't bail out on a very first mismatch (as it was the case for serial implementation) and instead will iterate over all the files logging success / degree_of_failure for each. We _could_, in theory, not `.wait()` on remaining `std::future<WorkItem>`s (upon previously detected failure) and therefore decrease the observed API latency, but that _could_ cause more confusion down the road as verification threads would still be occupied with inflight/scheduled work and would not be reclaimed by the pool for a while. It's a tradeoff where we choose a solution with clear and intuitive semantics.

### Test plan
Kudos to @pdillinger who pointed out that we should already have appropriate fuzzing for `max_background_operations` and `verify_checksum`=`true` parameters in scope of `::VerifyBackup` calls in existing backup restore stress test collateral.

[1]

https://github.com/facebook/rocksdb/blob/15a55329dd874d9184b0add91101181db4dc40d5/db_stress_tool/db_stress_test_base.cc#L2219.
