### PR TITLE
Add a factory function for FaissIVFIndex

### DIFF
--- a/include/rocksdb/utilities/secondary_index.h
+++ b/include/rocksdb/utilities/secondary_index.h
@@ -15,6 +15,7 @@
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
+#include "rocksdb/utilities/secondary_index_options.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -50,27 +51,6 @@ class ColumnFamilyHandle;
 // Note: the methods of SecondaryIndex implementations are expected to be
 // thread-safe with the exception of Set{Primary,Secondary}ColumnFamily (which
 // are not expected to be called after initialization).
-
-// Read options for secondary index iterators
-struct SecondaryIndexReadOptions {
-  // The maximum number of neighbors K to return when performing a
-  // K-nearest-neighbors vector similarity search. The number of neighbors
-  // returned can be smaller if there are not enough vectors in the inverted
-  // lists probed. Only applicable to FAISS IVF secondary indices, where it must
-  // be specified and positive. See also `SecondaryIndex::NewIterator` and
-  // `similarity_search_probes` below.
-  //
-  // Default: none
-  std::optional<size_t> similarity_search_neighbors;
-
-  // The number of inverted lists to probe when performing a K-nearest-neighbors
-  // vector similarity search. Only applicable to FAISS IVF secondary indices,
-  // where it must be specified and positive. See also
-  // `SecondaryIndex::NewIterator` and `similarity_search_neighbors` above.
-  //
-  // Default: none
-  std::optional<size_t> similarity_search_probes;
-};
 
 class SecondaryIndex {
  public:

--- a/include/rocksdb/utilities/secondary_index_faiss.h
+++ b/include/rocksdb/utilities/secondary_index_faiss.h
@@ -1,0 +1,32 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/utilities/secondary_index.h"
+
+namespace faiss {
+struct IndexIVF;
+}
+
+namespace ROCKSDB_NAMESPACE {
+
+// EXPERIMENTAL
+//
+// Creates a new FAISS inverted file based secondary index that indexes the
+// embedding in the specified primary column using the given pre-trained
+// faiss::IndexIVF object (which the secondary index takes ownership of).
+// The secondary index iterator returned by the index can be used to perform
+// K-nearest-neighbors queries (see also SecondaryIndex::NewIterator and
+// SecondaryIndexReadOptions).
+std::unique_ptr<SecondaryIndex> NewFaissIVFIndex(
+    std::unique_ptr<faiss::IndexIVF>&& index, std::string primary_column_name);
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/utilities/secondary_index_options.h
+++ b/include/rocksdb/utilities/secondary_index_options.h
@@ -1,0 +1,40 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <optional>
+
+#include "rocksdb/rocksdb_namespace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// EXPERIMENTAL
+//
+// Read options for secondary index iterators (see also
+// SecondaryIndex::NewIterator)
+
+struct SecondaryIndexReadOptions {
+  // The maximum number of neighbors K to return when performing a
+  // K-nearest-neighbors vector similarity search. The number of neighbors
+  // returned can be smaller if there are not enough vectors in the inverted
+  // lists probed. Only applicable to FAISS IVF secondary indices, where it must
+  // be specified and positive. See also SecondaryIndex::NewIterator and
+  // similarity_search_probes below.
+  //
+  // Default: none
+  std::optional<size_t> similarity_search_neighbors;
+
+  // The number of inverted lists to probe when performing a K-nearest-neighbors
+  // vector similarity search. Only applicable to FAISS IVF secondary indices,
+  // where it must be specified and positive. See also
+  // SecondaryIndex::NewIterator and similarity_search_neighbors above.
+  //
+  // Default: none
+  std::optional<size_t> similarity_search_probes;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/secondary_index/faiss_ivf_index.cc
+++ b/utilities/secondary_index/faiss_ivf_index.cc
@@ -457,4 +457,10 @@ std::unique_ptr<Iterator> FaissIVFIndex::NewIterator(
       *read_options.similarity_search_probes);
 }
 
+std::unique_ptr<SecondaryIndex> NewFaissIVFIndex(
+    std::unique_ptr<faiss::IndexIVF>&& index, std::string primary_column_name) {
+  return std::make_unique<FaissIVFIndex>(std::move(index),
+                                         std::move(primary_column_name));
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/secondary_index/faiss_ivf_index.h
+++ b/utilities/secondary_index/faiss_ivf_index.h
@@ -10,7 +10,7 @@
 #include <string>
 
 #include "faiss/IndexIVF.h"
-#include "rocksdb/utilities/secondary_index.h"
+#include "rocksdb/utilities/secondary_index_faiss.h"
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/utilities/secondary_index/faiss_ivf_index_test.cc
+++ b/utilities/secondary_index/faiss_ivf_index_test.cc
@@ -3,8 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-#include "utilities/secondary_index/faiss_ivf_index.h"
-
 #include <charconv>
 #include <memory>
 #include <string>
@@ -13,6 +11,7 @@
 #include "faiss/IndexFlat.h"
 #include "faiss/IndexIVFFlat.h"
 #include "faiss/utils/random.h"
+#include "rocksdb/utilities/secondary_index_faiss.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "test_util/testharness.h"
 #include "util/coding.h"
@@ -42,7 +41,7 @@ TEST(FaissIVFIndexTest, Basic) {
   TransactionDBOptions txn_db_options;
   const std::string primary_column_name = "embedding";
   txn_db_options.secondary_indices.emplace_back(
-      std::make_shared<FaissIVFIndex>(std::move(index), primary_column_name));
+      NewFaissIVFIndex(std::move(index), primary_column_name));
 
   TransactionDB* db = nullptr;
   ASSERT_OK(TransactionDB::Open(options, txn_db_options, db_name, &db));
@@ -319,8 +318,8 @@ TEST(FaissIVFIndexTest, Compare) {
   options.create_if_missing = true;
 
   TransactionDBOptions txn_db_options;
-  txn_db_options.secondary_indices.emplace_back(std::make_shared<FaissIVFIndex>(
-      std::move(index), kDefaultWideColumnName.ToString()));
+  txn_db_options.secondary_indices.emplace_back(
+      NewFaissIVFIndex(std::move(index), kDefaultWideColumnName.ToString()));
 
   TransactionDB* db = nullptr;
   ASSERT_OK(TransactionDB::Open(options, txn_db_options, db_name, &db));


### PR DESCRIPTION
Summary: The patch adds a public factory method `NewFaissIVFIndex` that can be used to create a FAISS inverted file based secondary index object. (Note that at the moment, FAISS secondary indices require using the Meta-internal BUCK build; this will be addressed in a follow-up patch.) As a small code organization improvement, the patch also moves `SecondaryIndexReadOptions` to its own header file.

Differential Revision: D68284544


