### PR TITLE
Introduce a SecondaryIndexHelper class

### DIFF
--- a/utilities/secondary_index/secondary_index_helper.h
+++ b/utilities/secondary_index/secondary_index_helper.h
@@ -1,0 +1,33 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <string>
+#include <variant>
+
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
+#include "util/overload.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class SecondaryIndexHelper {
+ public:
+  static Slice AsSlice(const std::variant<Slice, std::string>& var) {
+    return std::visit([](const auto& value) -> Slice { return value; }, var);
+  }
+
+  static std::string AsString(const std::variant<Slice, std::string>& var) {
+    return std::visit(
+        overload{
+            [](const Slice& value) -> std::string { return value.ToString(); },
+            [](const std::string& value) -> std::string { return value; }},
+        var);
+  }
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/secondary_index/secondary_index_iterator.h
+++ b/utilities/secondary_index/secondary_index_iterator.h
@@ -12,7 +12,7 @@
 #include "rocksdb/iterator.h"
 #include "rocksdb/status.h"
 #include "rocksdb/utilities/secondary_index.h"
-#include "util/overload.h"
+#include "utilities/secondary_index/secondary_index_helper.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -54,11 +54,7 @@ class SecondaryIndexIterator : public Iterator {
       return;
     }
 
-    prefix_ = std::visit(
-        overload{
-            [](const Slice& value) -> std::string { return value.ToString(); },
-            [](const std::string& value) -> std::string { return value; }},
-        prefix);
+    prefix_ = SecondaryIndexHelper::AsString(prefix);
 
     // FIXME: this works for BytewiseComparator but not for all comparators in
     // general


### PR DESCRIPTION
Summary: The patch moves the `AsSlice` and `AsString` methods to a new `SecondaryIndexHelper` class to facilitate reuse and eliminate some code duplication.

Differential Revision: D68342378


