### PR TITLE
Tidy up and share (between processes) temporary copies of JNI shared library loaded from JAR

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -503,6 +503,7 @@ set(JAVA_TEST_RUNNING_CLASSES
   org.rocksdb.RocksIteratorTest
   org.rocksdb.RocksMemEnvTest
   org.rocksdb.SecondaryDBTest
+  org.rocksdb.SharedTempFileLoaderTest
   org.rocksdb.SliceTest
   org.rocksdb.SnapshotTest
   org.rocksdb.SstFileManagerTest

--- a/java/Makefile
+++ b/java/Makefile
@@ -184,6 +184,7 @@ JAVA_TESTS = \
 	org.rocksdb.RocksMemEnvTest\
 	org.rocksdb.util.SizeUnitTest\
 	org.rocksdb.SecondaryDBTest\
+	org.rocksdb.SharedTempFileLoaderTest\
 	org.rocksdb.SliceTest\
 	org.rocksdb.SnapshotTest\
 	org.rocksdb.SstFileManagerTest\

--- a/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
+++ b/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
@@ -1,11 +1,13 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 package org.rocksdb;
 
-import java.io.*;
-import java.nio.file.Path;
-
 import org.rocksdb.util.Environment;
 import org.rocksdb.util.SharedTempFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Path;
 
 /**
  * This class is used to load the RocksDB shared library from within the jar.
@@ -121,18 +123,31 @@ public class NativeLibraryLoader {
     return is;
   }
 
+  private String libraryResourcePath() {
+    URL resource = getClass().getClassLoader().getResource(jniLibraryFileName);
+    if (resource == null) {
+      resource = getClass().getClassLoader().getResource(fallbackJniLibraryFileName);
+    }
+    if (resource == null) {
+      throw new RuntimeException(jniLibraryFileName + " was not found inside JAR.");
+    }
+    return resource.getFile();
+  }
+
   @SuppressWarnings({"PMD.UseProperClassLoader", "PMD.UseTryWithResources"})
   Path loadLibraryFromJarToTemp(final String tmpDir) throws IOException {
 
-    String[] split = jniLibraryFileName.split("\\.");
     String prefix = "librocksdbjni";
     String suffix = "jnilib";
-    if (split.length == 2) {
-      prefix = split[0];
-      suffix = split[1];
+    if (jniLibraryFileName != null) {
+      String[] split = jniLibraryFileName.split("\\.");
+      if (split.length == 2) {
+        prefix = split[0];
+        suffix = split[1];
+      }
     }
-    SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir,prefix, suffix);
-    SharedTempFile sharedTemp = instance.searchOrCreate();
+    SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir,prefix, libraryResourcePath(), suffix);
+    SharedTempFile sharedTemp = instance.create();
     SharedTempFile.Lock lock = sharedTemp.lock(this::libraryFromJar);
     Runtime.getRuntime().addShutdownHook(new Thread(lock::close));
     return sharedTemp.getContent();

--- a/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
+++ b/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
@@ -137,8 +137,8 @@ public class NativeLibraryLoader {
   @SuppressWarnings({"PMD.UseProperClassLoader", "PMD.UseTryWithResources"})
   Path loadLibraryFromJarToTemp(final String tmpDir) throws IOException {
 
-    String prefix = "librocksdbjni";
-    String suffix = "jnilib";
+    String prefix = tempFilePrefix;
+    String suffix = tempFileSuffix;
     if (jniLibraryFileName != null) {
       String[] split = jniLibraryFileName.split("\\.");
       if (split.length == 2) {

--- a/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
+++ b/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
@@ -142,6 +142,7 @@ public class NativeLibraryLoader {
     try (InputStream is = getClass().getClassLoader().getResourceAsStream(jniLibraryFileName)) {
       if (is != null) {
         final File temp = createTemp(tmpDir, jniLibraryFileName);
+        System.err.println("Temporary JNI lib copy: " + temp.toPath());
         Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
         return temp;
       }

--- a/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
+++ b/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
@@ -2,10 +2,10 @@
 package org.rocksdb;
 
 import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.Path;
 
 import org.rocksdb.util.Environment;
+import org.rocksdb.util.SharedTempFile;
 
 /**
  * This class is used to load the RocksDB shared library from within the jar.
@@ -104,64 +104,38 @@ public class NativeLibraryLoader {
   void loadLibraryFromJar(final String tmpDir)
       throws IOException {
     if (!initialized) {
-      System.load(loadLibraryFromJarToTemp(tmpDir).getAbsolutePath());
+      System.load(loadLibraryFromJarToTemp(tmpDir).toString());
       initialized = true;
     }
   }
 
-  private File createTemp(final String tmpDir, final String libraryFileName) throws IOException {
-    // create a temporary file to copy the library to
-    final File temp;
-    if (tmpDir == null || tmpDir.isEmpty()) {
-      temp = File.createTempFile(tempFilePrefix, tempFileSuffix);
-    } else {
-      final File parentDir = new File(tmpDir);
-      if (!parentDir.exists()) {
-        throw new RuntimeException(
-            "Directory: " + parentDir.getAbsolutePath() + " does not exist!");
-      }
-      temp = new File(parentDir, libraryFileName);
-      if (temp.exists() && !temp.delete()) {
-        throw new RuntimeException(
-            "File: " + temp.getAbsolutePath() + " already exists and cannot be removed.");
-      }
-      if (!temp.createNewFile()) {
-        throw new RuntimeException("File: " + temp.getAbsolutePath() + " could not be created.");
-      }
+  private InputStream libraryFromJar() {
+
+    InputStream is = getClass().getClassLoader().getResourceAsStream(jniLibraryFileName);
+    if (is == null) {
+      is = getClass().getClassLoader().getResourceAsStream(fallbackJniLibraryFileName);
     }
-    if (temp.exists()) {
-      temp.deleteOnExit();
-      return temp;
-    } else {
-      throw new RuntimeException("File " + temp.getAbsolutePath() + " does not exist.");
+    if (is == null) {
+      throw new RuntimeException(jniLibraryFileName + " was not found inside JAR.");
     }
+    return is;
   }
 
   @SuppressWarnings({"PMD.UseProperClassLoader", "PMD.UseTryWithResources"})
-  File loadLibraryFromJarToTemp(final String tmpDir) throws IOException {
-    try (InputStream is = getClass().getClassLoader().getResourceAsStream(jniLibraryFileName)) {
-      if (is != null) {
-        final File temp = createTemp(tmpDir, jniLibraryFileName);
-        System.err.println("Temporary JNI lib copy: " + temp.toPath());
-        Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        return temp;
-      }
-    }
+  Path loadLibraryFromJarToTemp(final String tmpDir) throws IOException {
 
-    if (fallbackJniLibraryFileName == null) {
-      throw new RuntimeException(fallbackJniLibraryFileName + " was not found inside JAR.");
+    String[] split = jniLibraryFileName.split("\\.");
+    String prefix = "librocksdbjni";
+    String suffix = "jnilib";
+    if (split.length == 2) {
+      prefix = split[0];
+      suffix = split[1];
     }
-
-    try (InputStream is =
-             getClass().getClassLoader().getResourceAsStream(fallbackJniLibraryFileName)) {
-      if (is != null) {
-        final File temp = createTemp(tmpDir, fallbackJniLibraryFileName);
-        Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        return temp;
-      }
-    }
-
-    throw new RuntimeException(jniLibraryFileName + " was not found inside JAR.");
+    SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir,prefix, suffix);
+    SharedTempFile sharedTemp = instance.searchOrCreate();
+    SharedTempFile.Lock lock = sharedTemp.lock(this::libraryFromJar);
+    Runtime.getRuntime().addShutdownHook(new Thread(lock::close));
+    return sharedTemp.getContent();
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
+++ b/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
@@ -136,7 +136,6 @@ public class NativeLibraryLoader {
 
   @SuppressWarnings({"PMD.UseProperClassLoader", "PMD.UseTryWithResources"})
   Path loadLibraryFromJarToTemp(final String tmpDir) throws IOException {
-
     String prefix = tempFilePrefix;
     String suffix = tempFileSuffix;
     if (jniLibraryFileName != null) {

--- a/java/src/main/java/org/rocksdb/util/SharedTempFile.java
+++ b/java/src/main/java/org/rocksdb/util/SharedTempFile.java
@@ -81,6 +81,15 @@ public class SharedTempFile {
             return new SharedTempFile(this, Files.createTempDirectory(prefix)).ensureCreated();
         }
 
+        public SharedTempFile searchOrCreate() throws IOException {
+            final List<SharedTempFile> existing = search();
+            if (existing.isEmpty()) {
+                return create();
+            } else {
+                return existing.get(0);
+            }
+        }
+
         public Instance(final String prefix, final String suffix) {
             this.prefix = prefix;
             this.suffix = suffix;

--- a/java/src/main/java/org/rocksdb/util/SharedTempFile.java
+++ b/java/src/main/java/org/rocksdb/util/SharedTempFile.java
@@ -1,0 +1,188 @@
+package org.rocksdb.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+
+/**
+ * A mechanism for sharing a single instance of a temporary file
+ * The file persists (and uses storage space) only as long as the longest lived of its users.
+ * <p>
+ *     Shared temp files are used so that only a single temporary instance of the RocksJNI shared library
+ *     is created when it is loaded from within the RocksJNI jar.
+ *     This prevents the infinite destruction of storage (it has been observed)
+ *     when each VM which creates its own copy, and is later killed by a signal instead of terminating cleanly.
+ *     In the shared temp file model, the jnilib will persist, but will be re-used by other VMs.
+ * </p>
+ */
+public class SharedTempFile {
+
+    private final static String INSTANCE_LOCK = "instance-lock";
+    private final static String DIR_LOCK = "dir-lock";
+
+    private final Instance instance;
+
+    private final Path directory;
+    private final Path directoryLock;
+    private final Path content;
+    private Path instanceLock;
+
+    private SharedTempFile(final Instance instance, final Path directory) {
+        this.instance = instance;
+        this.directory = directory;
+        this.directoryLock = directory.resolve(instance.prefix + "." + DIR_LOCK);
+        this.content = directory.resolve(instance.prefix + "." + instance.suffix);
+    }
+
+    /**
+     * Handler for a shared temp file of a particular prefix and suffix
+     */
+    public static class Instance {
+
+        private final String prefix;
+        private final String suffix;
+
+        /**
+         * Look for existing shared temp files
+         * @return a list of these files.
+         */
+        public List<SharedTempFile> search() throws IOException {
+            Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
+            List<SharedTempFile> existing = new ArrayList<>();
+            try (Stream<Path> children = Files.walk(tmpDir, 1)) {
+                children.forEach(path -> {
+                    if (path.getFileName().toString().startsWith(prefix) && Files.isDirectory(path)) {
+                        existing.add(new SharedTempFile(this, path));
+                    }
+                });
+            }
+            existing.sort(Comparator.comparing(o -> o.directory));
+            if (!existing.isEmpty()) {
+                existing.get(0).ensureCreated();
+            }
+            return existing;
+        }
+
+        /**
+         * Create the shared temp file
+         * Ensure that the contained lock file is also created
+         *
+         * @return the new shared temp file object
+         */
+        public SharedTempFile create() throws IOException {
+
+            return new SharedTempFile(this, Files.createTempDirectory(prefix)).ensureCreated();
+        }
+
+        public Instance(final String prefix, final String suffix) {
+            this.prefix = prefix;
+            this.suffix = suffix;
+        }
+    }
+
+    public class Lock implements AutoCloseable {
+
+        @Override
+        public void close() {
+            unlock();
+        }
+    }
+
+    private SharedTempFile ensureCreated() throws IOException {
+        Path dirLock = directory.resolve(instance.prefix + "." + DIR_LOCK);
+        try {
+            Files.createFile(dirLock);
+        } catch (FileAlreadyExistsException e) {
+            //Fine. Just needs to be created once.
+        }
+
+        return this;
+    }
+
+
+    /**
+     * Lock the content as in use by the current SharedTempFile instance,
+     * and create the content if it does not already exist as a file in the expected directory.
+     *
+     * @param contentCreator return a stream from which the content can be read if it is to be created
+     * @throws IOException if a file system error occurs
+     *
+     * @return an autocloseable lock
+     */
+    public Lock lock(Callable<InputStream> contentCreator) throws IOException {
+
+        try (FileChannel fc = FileChannel.open(directoryLock, StandardOpenOption.WRITE)) {
+            try (FileLock ignored = fc.lock()) {
+                if (!Files.exists(content)) {
+                    Files.createFile(content);
+                    try {
+                        InputStream is = contentCreator.call();
+                        Files.copy(is, content, StandardCopyOption.REPLACE_EXISTING);
+                    } catch (Exception e) {
+                        throw new RuntimeException("Unable to create content for SharedTempFile " + instance.prefix, e);
+                    }
+                }
+                instanceLock = Files.createTempFile(directory, instance.prefix, INSTANCE_LOCK);
+            }
+        }
+
+        return new Lock();
+    }
+
+    /**
+     * Unlock the content, as it is no longer in use by the current SharedTempFile instance.
+     * If this is the last user of the content (no other instance lock) delete it all.
+     */
+    private void unlock() {
+        try (FileChannel fc = FileChannel.open(directoryLock, StandardOpenOption.WRITE)) {
+            try (FileLock ignored = fc.lock()) {
+                Files.delete(instanceLock);
+                // prefixNNN.lock - one instance lock for every VM currently locking the content file
+                List<Path> lockFiles = new ArrayList<>();
+                try (Stream<Path> children = Files.walk(directory, 1)) {
+                    children.forEach(path -> {
+                        Path fileName = path.getFileName();
+                        if (fileName.toString().startsWith(instance.prefix) && fileName.endsWith(INSTANCE_LOCK)) {
+                            lockFiles.add(fileName);
+                        }
+                    });
+                }
+                if (lockFiles.isEmpty()) {
+                    // No VMs are locking this SharedTempFile, so we can delete it
+                    if (!Files.exists(content)) {
+                        throw new RuntimeException("SharedTempFile " + instance.prefix + " contents not found for deletion");
+                    }
+                    Files.delete(content);
+
+                    // At this point we have removed the content, but it is difficult to remove the dir
+                    // What happens to the contained lock file when the dir is renamed ?
+                    // This is presumably implementation dependent (e.g. advisory locking or not)
+                    // SO ? We just leave it hanging around, because:
+                    // 1. It's in a temporary so in theory it should just get deleted eventually
+                    // 2. It doesn't take up much space,  which was the point of the exercise.
+                    // 3. It may/will get used again anyway when found by `search()`
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("SharedTempFile " + instance.prefix + " could not be locked", e);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("SharedTempFile " + instance.prefix + " could not be opened", e);
+        }
+    }
+
+    public Path getContent() {
+        return content;
+    }
+
+    @Override public String toString() {
+        return "[" + getClass().getSimpleName() + "]{" + directory + "}";
+    }
+
+}

--- a/java/src/main/java/org/rocksdb/util/SharedTempFile.java
+++ b/java/src/main/java/org/rocksdb/util/SharedTempFile.java
@@ -149,16 +149,15 @@ public class SharedTempFile {
                 try (Stream<Path> children = Files.walk(directory, 1)) {
                     children.forEach(path -> {
                         Path fileName = path.getFileName();
-                        System.err.println(fileName);
                         String name = fileName.toString();
                         if (name.startsWith(instance.prefix) && name.endsWith("." + INSTANCE_LOCK)) {
                             lockFiles.add(fileName);
                         }
                     });
                 }
-                System.err.println("SharedTempFile " + lockFiles.size() + " lock files");
                 if (lockFiles.isEmpty()) {
                     // No VMs are locking this SharedTempFile, so we can delete it
+                    System.err.println("SharedTempFile last lock file - delete content");
                     if (!Files.exists(content)) {
                         throw new RuntimeException("SharedTempFile " + instance.prefix + " contents not found for deletion");
                     }

--- a/java/src/test/java/org/rocksdb/LeakedSharedObjectTest.java
+++ b/java/src/test/java/org/rocksdb/LeakedSharedObjectTest.java
@@ -105,6 +105,7 @@ public class LeakedSharedObjectTest {
         List<Process> processes = new ArrayList<>();
         List<BufferedReader> readers = new ArrayList<>();
         List<List<String>> lines = new ArrayList<>();
+        List<Integer> exitCodes = new ArrayList<>();
 
         for (int i = 0; i < DB_COUNT; i++) {
 
@@ -144,18 +145,25 @@ public class LeakedSharedObjectTest {
         for (int i = 0; i < DB_COUNT; i++) {
             try {
                 processes.get(i).waitFor();
-                lines.get(i).add("Exit value " + processes.get(i).exitValue());
+                int exitCode = processes.get(i).exitValue();
+                lines.get(i).add("Exit value " + exitCode);
+                exitCodes.add(exitCode);
             } catch (InterruptedException ie) {
                 throw new RuntimeException("Process interrupted");
             }
         }
 
-        for (List<String> linei : lines) {
-            for (String line : linei) {
-                System.err.println(line);
+        boolean ok = true;
+        for (int i = 0; i < DB_COUNT; i++) {
+            if (exitCodes.get(i) != 0) {
+                ok = false;
+                System.err.println("Process " + i + " failed: " + exitCodes.get(i));
+                for (String line : lines.get(i)) {
+                    System.err.println(line);
+                }
             }
         }
-
+        assertThat(ok).as("all subprocesses return success").isTrue();
     }
 
 }

--- a/java/src/test/java/org/rocksdb/LeakedSharedObjectTest.java
+++ b/java/src/test/java/org/rocksdb/LeakedSharedObjectTest.java
@@ -1,0 +1,144 @@
+package org.rocksdb;
+
+import org.junit.Test;
+import org.rocksdb.util.SharedTempFile;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LeakedSharedObjectTest {
+
+    final static Random random = new Random();
+
+    static InputStream mockContent() throws IOException {
+
+        ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+        InputStream is = classloader.getResourceAsStream("shared-temp-file.txt");
+        return new BufferedInputStream(is);
+    }
+
+    static BufferedReader mockContentReader() {
+
+        ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+        InputStream is = classloader.getResourceAsStream("shared-temp-file.txt");
+        return new BufferedReader(new InputStreamReader(is));
+    }
+
+    static void compare(BufferedReader expected, BufferedReader actual) throws IOException {
+        int lines = 0;
+        String expectedLine = expected.readLine();
+        String actualLine = actual.readLine();
+        while (expectedLine != null) {
+            lines++;
+            assertThat(actualLine).isEqualTo(expectedLine);
+            expectedLine = expected.readLine();
+            actualLine = actual.readLine();
+        }
+        assertThat(actualLine).isNull();
+    }
+
+    @Test
+    public void sharedTempFresh() throws IOException {
+        String prefix = "rocksdbjnitest__" + random.nextLong() + "__";
+        SharedTempFile.Instance instance = new SharedTempFile.Instance(prefix, "jnilib");
+        assertThat(instance.search()).isEmpty();
+        SharedTempFile sharedTemp = instance.create();
+        System.err.println(sharedTemp);
+        Path content;
+        try (SharedTempFile.Lock ignored = sharedTemp.lock(LeakedSharedObjectTest::mockContent)) {
+            content = sharedTemp.getContent();
+            assertThat(Files.exists(content)).isTrue();
+            try (BufferedReader shared = new BufferedReader(new InputStreamReader(Files.newInputStream(content))); BufferedReader resource = mockContentReader()) {
+                compare(resource, shared);
+            }
+        }
+        assertThat(Files.exists(content)).isFalse();
+    }
+
+    @Test
+    public void sharedTempExists() throws IOException {
+
+        String prefix = "rocksdbjnitest__" + random.nextLong() + "__";
+        SharedTempFile.Instance instance = new SharedTempFile.Instance(prefix, "jnilib");
+        assertThat(instance.search()).isEmpty();
+        SharedTempFile sharedTemp = instance.create();
+        System.err.println("Created: " + sharedTemp);
+        List<SharedTempFile> existing = instance.search();
+        assertThat(existing).isNotEmpty();
+        sharedTemp = existing.get(0);
+        Path content;
+        try (SharedTempFile.Lock ignored = sharedTemp.lock(LeakedSharedObjectTest::mockContent)) {
+            content = sharedTemp.getContent();
+            assertThat(Files.exists(content)).isTrue();
+            try (BufferedReader shared = new BufferedReader(new InputStreamReader(Files.newInputStream(content))); BufferedReader resource = mockContentReader()) {
+                compare(resource, shared);
+            }
+        }
+        assertThat(Files.exists(content)).isFalse();
+    }
+
+
+    @Test
+    public void openJar() {
+        RocksDB.loadLibrary();
+    }
+
+    @Test
+    public void openManySharedTemp() throws IOException {
+        openMany("org.rocksdb.SharedTempFileMockMain");
+    }
+
+    @Test
+    public void openManyRocksDB() throws IOException {
+        openMany("org.rocksdb.SharedTempFileRocksDBMain");
+    }
+
+    public void openMany(final String mainClass) throws IOException {
+
+        final int DB_COUNT = 50;
+        List<Process> processes = new ArrayList<>();
+        List<BufferedReader> readers = new ArrayList<>();
+
+        for (int i = 0; i < DB_COUNT; i++) {
+
+            Process process = Runtime.getRuntime()
+                .exec("java -cp target/classes:target/test-classes:target/* " + mainClass);
+            processes.add(process);
+            BufferedReader err = new BufferedReader( new InputStreamReader(process.getErrorStream()));
+            readers.add(err);
+        }
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        int i = 0;
+        for (BufferedReader reader : readers) {
+            i++;
+            String line = reader.readLine();
+            System.err.println(i + ":" + line);
+        }
+
+        for (Process process : processes) {
+            process.destroyForcibly();
+        }
+
+        for (Process process : processes) {
+            try {
+                process.waitFor();
+                System.err.println("Exit value " + process.exitValue());
+            } catch (InterruptedException ie) {
+                throw new RuntimeException("Process interrupted");
+            }
+        }
+    }
+
+}

--- a/java/src/test/java/org/rocksdb/LeakedSharedObjectTest.java
+++ b/java/src/test/java/org/rocksdb/LeakedSharedObjectTest.java
@@ -44,10 +44,12 @@ public class LeakedSharedObjectTest {
         assertThat(actualLine).isNull();
     }
 
+    private final String tmpDir = System.getProperty("java.io.tmpdir");
+
     @Test
     public void sharedTempFresh() throws IOException {
         String prefix = "rocksdbjnitest__" + random.nextLong() + "__";
-        SharedTempFile.Instance instance = new SharedTempFile.Instance(prefix, "jnilib");
+        SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir, prefix, "jnilib");
         assertThat(instance.search()).isEmpty();
         SharedTempFile sharedTemp = instance.create();
         System.err.println(sharedTemp);
@@ -66,7 +68,7 @@ public class LeakedSharedObjectTest {
     public void sharedTempExists() throws IOException {
 
         String prefix = "rocksdbjnitest__" + random.nextLong() + "__";
-        SharedTempFile.Instance instance = new SharedTempFile.Instance(prefix, "jnilib");
+        SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir, prefix, "jnilib");
         assertThat(instance.search()).isEmpty();
         SharedTempFile sharedTemp = instance.create();
         System.err.println("Created: " + sharedTemp);

--- a/java/src/test/java/org/rocksdb/SharedTempFileLoaderTest.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileLoaderTest.java
@@ -12,7 +12,7 @@ import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LeakedSharedObjectTest {
+public class SharedTempFileLoaderTest {
 
     private final static int SIGKILL_CODE = 128 + 9;
     private final static int SIGTERM_CODE = 128 + 15;
@@ -54,7 +54,7 @@ public class LeakedSharedObjectTest {
         SharedTempFile sharedTemp = instance.create();
         System.err.println(sharedTemp);
         Path content;
-        try (SharedTempFile.Lock ignored = sharedTemp.lock(LeakedSharedObjectTest::mockContent)) {
+        try (SharedTempFile.Lock ignored = sharedTemp.lock(SharedTempFileLoaderTest::mockContent)) {
             content = sharedTemp.getContent();
             assertThat(Files.exists(content)).isTrue();
             try (BufferedReader shared = new BufferedReader(new InputStreamReader(Files.newInputStream(content))); BufferedReader resource = mockContentReader()) {
@@ -76,7 +76,7 @@ public class LeakedSharedObjectTest {
         assertThat(existing).isNotEmpty();
         sharedTemp = existing.get(0);
         Path content;
-        try (SharedTempFile.Lock ignored = sharedTemp.lock(LeakedSharedObjectTest::mockContent)) {
+        try (SharedTempFile.Lock ignored = sharedTemp.lock(SharedTempFileLoaderTest::mockContent)) {
             content = sharedTemp.getContent();
             assertThat(Files.exists(content)).isTrue();
             try (BufferedReader shared = new BufferedReader(new InputStreamReader(Files.newInputStream(content))); BufferedReader resource = mockContentReader()) {

--- a/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
@@ -23,14 +23,8 @@ public class SharedTempFileMockMain {
         Thread.sleep(random.nextInt(1000));
 
         SharedTempFile.Instance instance = new SharedTempFile.Instance("rocksdbmock", "jnilib");
-        final List<SharedTempFile> existing = instance.search();
-        SharedTempFile sharedTemp;
-        if (existing.isEmpty()) {
-            sharedTemp = instance.create();
-        } else {
-            sharedTemp = existing.get(0);
-        }
-        System.err.println(sharedTemp + " created");
+        SharedTempFile sharedTemp = instance.searchOrCreate();
+        System.err.println(sharedTemp + " created/found");
         Path content;
         try (SharedTempFile.Lock ignored = sharedTemp.lock(LeakedSharedObjectTest::mockContent)) {
             content = sharedTemp.getContent();

--- a/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
@@ -15,17 +15,12 @@ import static org.rocksdb.LeakedSharedObjectTest.compare;
 
 public class SharedTempFileMockMain {
 
-
     public static void main(final String[] args) throws IOException, InterruptedException {
 
         // uncouple precise start time from other processes
         // otherwise they all create their own temp
         final Random random = new Random();
-        try {
-            Thread.sleep(random.nextInt(1000));
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        Thread.sleep(random.nextInt(1000));
 
         SharedTempFile.Instance instance = new SharedTempFile.Instance("rocksdbmock", "jnilib");
         final List<SharedTempFile> existing = instance.search();
@@ -43,6 +38,7 @@ public class SharedTempFileMockMain {
             try (BufferedReader shared = new BufferedReader(new InputStreamReader(Files.newInputStream(content))); BufferedReader resource = LeakedSharedObjectTest.mockContentReader()) {
                 compare(resource, shared);
             }
+            Thread.sleep(random.nextInt(1000));
         }
         System.err.println(sharedTemp + " finished");
 

--- a/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
@@ -1,0 +1,50 @@
+package org.rocksdb;
+
+import org.rocksdb.util.SharedTempFile;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rocksdb.LeakedSharedObjectTest.compare;
+
+public class SharedTempFileMockMain {
+
+
+    public static void main(final String[] args) throws IOException, InterruptedException {
+
+        final Random random = new Random();
+        try {
+            Thread.sleep(random.nextInt(100));
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        SharedTempFile.Instance instance = new SharedTempFile.Instance("rocksdbmock", "jnilib");
+        final List<SharedTempFile> existing = instance.search();
+        SharedTempFile sharedTemp;
+        if (existing.isEmpty()) {
+            sharedTemp = instance.create();
+        } else {
+            sharedTemp = existing.get(0);
+        }
+        System.err.println(sharedTemp);
+        Path content;
+        try (SharedTempFile.Lock ignored = sharedTemp.lock(LeakedSharedObjectTest::mockContent)) {
+            content = sharedTemp.getContent();
+            assertThat(Files.exists(content)).isTrue();
+            try (BufferedReader shared = new BufferedReader(new InputStreamReader(Files.newInputStream(content))); BufferedReader resource = LeakedSharedObjectTest.mockContentReader()) {
+                compare(resource, shared);
+            }
+        }
+        assertThat(Files.exists(content)).isFalse();
+
+        Thread.sleep(2000);
+    }
+
+}

--- a/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
@@ -29,8 +29,8 @@ public class SharedTempFileMockMain {
             tmpDir = argMap.get("tmpdir");
         }
 
-        SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir, "rocksdbmock", "jnilib");
-        SharedTempFile sharedTemp = instance.searchOrCreate();
+        SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir, "rocksdbmock", "789","jnilib");
+        SharedTempFile sharedTemp = instance.create();
         System.err.println(sharedTemp + " created/found");
         Path content;
         try (SharedTempFile.Lock ignored = sharedTemp.lock(SharedTempFileLoaderTest::mockContent)) {

--- a/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.rocksdb.LeakedSharedObjectTest.compare;
+import static org.rocksdb.SharedTempFileLoaderTest.compare;
 
 public class SharedTempFileMockMain {
 
@@ -27,10 +27,10 @@ public class SharedTempFileMockMain {
         SharedTempFile sharedTemp = instance.searchOrCreate();
         System.err.println(sharedTemp + " created/found");
         Path content;
-        try (SharedTempFile.Lock ignored = sharedTemp.lock(LeakedSharedObjectTest::mockContent)) {
+        try (SharedTempFile.Lock ignored = sharedTemp.lock(SharedTempFileLoaderTest::mockContent)) {
             content = sharedTemp.getContent();
             assertThat(Files.exists(content)).isTrue();
-            try (BufferedReader shared = new BufferedReader(new InputStreamReader(Files.newInputStream(content))); BufferedReader resource = LeakedSharedObjectTest.mockContentReader()) {
+            try (BufferedReader shared = new BufferedReader(new InputStreamReader(Files.newInputStream(content))); BufferedReader resource = SharedTempFileLoaderTest.mockContentReader()) {
                 compare(resource, shared);
             }
             Thread.sleep(random.nextInt(1000));

--- a/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
@@ -18,9 +18,11 @@ public class SharedTempFileMockMain {
 
     public static void main(final String[] args) throws IOException, InterruptedException {
 
+        // uncouple precise start time from other processes
+        // otherwise they all create their own temp
         final Random random = new Random();
         try {
-            Thread.sleep(random.nextInt(100));
+            Thread.sleep(random.nextInt(1000));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -33,7 +35,7 @@ public class SharedTempFileMockMain {
         } else {
             sharedTemp = existing.get(0);
         }
-        System.err.println(sharedTemp);
+        System.err.println(sharedTemp + " created");
         Path content;
         try (SharedTempFile.Lock ignored = sharedTemp.lock(LeakedSharedObjectTest::mockContent)) {
             content = sharedTemp.getContent();
@@ -42,7 +44,7 @@ public class SharedTempFileMockMain {
                 compare(resource, shared);
             }
         }
-        assertThat(Files.exists(content)).isFalse();
+        System.err.println(sharedTemp + " finished");
 
         Thread.sleep(2000);
     }

--- a/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
@@ -1,5 +1,6 @@
 package org.rocksdb;
 
+import org.rocksdb.util.ArgUtil;
 import org.rocksdb.util.SharedTempFile;
 
 import java.io.BufferedReader;
@@ -7,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +24,10 @@ public class SharedTempFileMockMain {
         Thread.sleep(random.nextInt(1000));
 
         String tmpDir = System.getProperty("java.io.tmpdir");
+        Map<String,String> argMap = ArgUtil.parseArgs(args);
+        if (argMap.containsKey("tmpdir")) {
+            tmpDir = argMap.get("tmpdir");
+        }
 
         SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir, "rocksdbmock", "jnilib");
         SharedTempFile sharedTemp = instance.searchOrCreate();

--- a/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileMockMain.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,7 +21,9 @@ public class SharedTempFileMockMain {
         final Random random = new Random();
         Thread.sleep(random.nextInt(1000));
 
-        SharedTempFile.Instance instance = new SharedTempFile.Instance("rocksdbmock", "jnilib");
+        String tmpDir = System.getProperty("java.io.tmpdir");
+
+        SharedTempFile.Instance instance = new SharedTempFile.Instance(tmpDir, "rocksdbmock", "jnilib");
         SharedTempFile sharedTemp = instance.searchOrCreate();
         System.err.println(sharedTemp + " created/found");
         Path content;

--- a/java/src/test/java/org/rocksdb/SharedTempFileRocksDBMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileRocksDBMain.java
@@ -1,18 +1,53 @@
 package org.rocksdb;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
 
 public class SharedTempFileRocksDBMain {
-    public static void main(final String[] args) throws IOException, RocksDBException, InterruptedException {
+    public static void main(final String[] args) throws InterruptedException {
 
-        RocksDB.loadLibrary();
-
-        String tmpdir = Files.createTempDirectory("tmpRocksDBTestDir").toFile().getAbsolutePath();
-        try (final RocksDB db = RocksDB.open(tmpdir)) {
-            db.put("key".getBytes(), "value".getBytes());
+        boolean waitKill = false;
+        for (String arg : args) {
+            if ("--waitkill".equals(arg)) waitKill = true;
         }
-        Thread.sleep(10000);
+
+        try {
+            RocksDB.loadLibrary();
+
+            Path tmpDir = Files.createTempDirectory("tmpRocksDBTestDir");
+            try (final RocksDB db = RocksDB.open(tmpDir.toFile().getAbsolutePath())) {
+                db.put("key".getBytes(), "value".getBytes());
+                if (!Arrays.equals("value".getBytes(), db.get("key".getBytes()))) {
+                    System.err.println("Get: key != value");
+                    System.exit(2);
+                }
+            } finally {
+                purgeDirectory(tmpDir.toFile());
+                Files.delete(tmpDir);
+            }
+        } catch (Exception e) {
+            System.err.println("Exit with exception: " + e);
+            e.printStackTrace(System.err);
+            System.exit(1);
+        }
+
+        if (waitKill) {
+            Thread.sleep(5 * 60 * 1000);
+        }
+
+        System.exit(0);
+    }
+
+    static void purgeDirectory(File dir) {
+        for (File file: dir.listFiles()) {
+            if (file.isDirectory())
+                purgeDirectory(file);
+            file.delete();
+        }
     }
 
 }

--- a/java/src/test/java/org/rocksdb/SharedTempFileRocksDBMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileRocksDBMain.java
@@ -1,0 +1,18 @@
+package org.rocksdb;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class SharedTempFileRocksDBMain {
+    public static void main(final String[] args) throws IOException, RocksDBException, InterruptedException {
+
+        RocksDB.loadLibrary();
+
+        String tmpdir = Files.createTempDirectory("tmpRocksDBTestDir").toFile().getAbsolutePath();
+        try (final RocksDB db = RocksDB.open(tmpdir)) {
+            db.put("key".getBytes(), "value".getBytes());
+        }
+        Thread.sleep(10000);
+    }
+
+}

--- a/java/src/test/java/org/rocksdb/SharedTempFileRocksDBMain.java
+++ b/java/src/test/java/org/rocksdb/SharedTempFileRocksDBMain.java
@@ -1,33 +1,41 @@
 package org.rocksdb;
 
+import org.rocksdb.util.ArgUtil;
+
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Map;
 
 public class SharedTempFileRocksDBMain {
     public static void main(final String[] args) throws InterruptedException {
 
         boolean waitKill = false;
-        for (String arg : args) {
-            if ("--waitkill".equals(arg)) waitKill = true;
+        Map<String, String> argMap = ArgUtil.parseArgs(args);
+        if (argMap.containsKey("waitkill")) {
+            waitKill = Boolean.parseBoolean(argMap.get("waitkill"));
+        }
+
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        if (argMap.containsKey("tmpdir")) {
+            tmpDir = argMap.get("tmpdir");
         }
 
         try {
             RocksDB.loadLibrary();
 
-            Path tmpDir = Files.createTempDirectory("tmpRocksDBTestDir");
-            try (final RocksDB db = RocksDB.open(tmpDir.toFile().getAbsolutePath())) {
+            Path dbDir = Files.createTempDirectory(Paths.get(tmpDir), "rocksdbdir");
+            try (final RocksDB db = RocksDB.open(dbDir.toFile().getAbsolutePath())) {
                 db.put("key".getBytes(), "value".getBytes());
                 if (!Arrays.equals("value".getBytes(), db.get("key".getBytes()))) {
                     System.err.println("Get: key != value");
                     System.exit(2);
                 }
             } finally {
-                purgeDirectory(tmpDir.toFile());
-                Files.delete(tmpDir);
+                purgeDirectory(dbDir.toFile());
+                Files.delete(dbDir);
             }
         } catch (Exception e) {
             System.err.println("Exit with exception: " + e);

--- a/java/src/test/java/org/rocksdb/util/ArgUtil.java
+++ b/java/src/test/java/org/rocksdb/util/ArgUtil.java
@@ -1,0 +1,21 @@
+package org.rocksdb.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ArgUtil {
+
+    public static Map<String, String> parseArgs(String[] args) {
+        final Map<String, String> map = new HashMap<>();
+        for (String arg : args) {
+            String[] split = arg.trim().split("=");
+            if (split.length == 2 && split[0].startsWith("-")) {
+                String key = split[0].replaceFirst("-[-]","").toLowerCase();
+                if (!key.isEmpty()) {
+                    map.put(key, split[1]);
+                }
+            }
+        }
+        return map;
+    }
+}

--- a/java/src/test/resources/shared-temp-file.txt
+++ b/java/src/test/resources/shared-temp-file.txt
@@ -1,0 +1,9 @@
+We came across the west sea
+We didn't have much idea of the
+Kind of climate waiting
+We used our hands for guidance
+Like the children of a preacher
+Like a dry tree seeking water
+Or a daughter
+Nice 'n' sleazy
+Nice 'n' sleazy does it


### PR DESCRIPTION
This fixes https://github.com/facebook/rocksdb/issues/13185

`NativeLibraryLoader.java` (part of RokcsJava) goes through a number of stages to find an instance of the rocksdb native library to run against. As a backstop, it extracts a copy of the library from the rocksdb jni jar (the build bundles the library into the jar). The library is stored in the temporary directory, and the Java process is requested to `deleteOnExit()` the temporary file. This deletion doesn't work when the Java process is killed (-9) and as a result, many copies of the (large) library file can build up.

This PR adds a mechanism to find/create a temporary library in a known subdirectory of the temporary directory; the name is based on the name requested by the client, plus some digestification to distinguish between files with version names. The Java file locking mechanism is used to lock a blessed lock file in the subdirectory, and a separate 0-length lock file is created for each process which is using the library. The last process to stop using the library deletes the temporary library, but NOT the directory and the blessed lock file.

In this model, the result of not running shutdown handlers will be to leave 1 instance of each version of the library in place; however, it will be discovered by future processes so that the system will not collect multiple unpacked copies of the same version.