### PR TITLE
Clean up RocksJava compilation warnings

### DIFF
--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1715,6 +1715,8 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    * this field blank. Default: Empty string (no offpeak).
    *
    * @param offpeakTimeUTC String value from which to parse offpeak time range
+   *
+   * @return the instance of the current object.
    */
   T setDailyOffpeakTimeUTC(final String offpeakTimeUTC);
 

--- a/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/MutableDBOptionsInterface.java
@@ -456,6 +456,7 @@ public interface MutableDBOptionsInterface<T extends MutableDBOptionsInterface<T
    * this field blank. Default: Empty string (no offpeak).
    *
    * @param offpeakTimeUTC String value from which to parse offpeak time range
+   * @return the reference to the current options.
    */
   T setDailyOffpeakTimeUTC(final String offpeakTimeUTC);
 

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -2128,7 +2128,7 @@ public class Options extends RocksObject
    * Set TablePropertiesCollectorFactory in underlying C++ object.
    * This method create its own copy of the list. Caller is responsible for
    * closing all the instances in the list.
-   * @param factories
+   * @param factories to set
    */
   public void setTablePropertiesCollectorFactory(List<TablePropertiesCollectorFactory> factories) {
     long[] factoryHandlers = new long[factories.size()];

--- a/java/src/main/java/org/rocksdb/PerfContext.java
+++ b/java/src/main/java/org/rocksdb/PerfContext.java
@@ -236,6 +236,8 @@ public class PerfContext extends RocksObject {
    *    hidden by the tombstones will be included here.
    * 4. symmetric cases for Prev() and SeekToLast()
    * internal_recent_skipped_count is not included in this counter.
+   *
+   * @return total number of internal keys skipped over during iteration
    */
   public long getInternalKeySkippedCount() {
     return getInternalKeySkippedCount(nativeHandle_);
@@ -248,6 +250,8 @@ public class PerfContext extends RocksObject {
    * SeekToFirst(), there may be one or more deleted keys before the next valid
    * key. Every deleted key is counted once. We don't recount here if there are
    * still older updates invalidated by the tombstones.
+   *
+   * @return Total number of deletes and single deletes skipped over during iteration
    */
   public long getInternalDeleteSkippedCount() {
     return getInternalDeleteSkippedCount(nativeHandle_);
@@ -256,6 +260,8 @@ public class PerfContext extends RocksObject {
   /**
    * How many times iterators skipped over internal keys that are more recent
    * than the snapshot that iterator is using.
+   *
+   * @return number of skipped recent internal keys
    */
   public long getInternalRecentSkippedCount() {
     return getInternalRecentSkippedCount(nativeHandle_);
@@ -264,6 +270,8 @@ public class PerfContext extends RocksObject {
   /**
    * How many merge operands were fed into the merge operator by iterators.
    * Note: base values are not included in the count.
+   *
+   * @return How many merge operands were fed into the merge operator by iterator
    */
   public long getInternalMergeCount() {
     return getInternalMergeCount(nativeHandle_);
@@ -272,6 +280,8 @@ public class PerfContext extends RocksObject {
   /**
    * How many merge operands were fed into the merge operator by point lookups.
    * Note: base values are not included in the count.
+   *
+   * @return How many merge operands were fed into the merge operator by point lookups
    */
   public long getInternalMergePointLookupCount() {
     return getInternalMergePointLookupCount(nativeHandle_);
@@ -281,6 +291,8 @@ public class PerfContext extends RocksObject {
    * Number of times we reseeked inside a merging iterator, specifically to skip
    * after or before a range of keys covered by a range deletion in a newer LSM
    * component.
+   *
+   * @return Number of times we reseeked inside a merging iterator
    */
   public long getInternalRangeDelReseekCount() {
     return getInternalRangeDelReseekCount(nativeHandle_);

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -798,6 +798,8 @@ public class RocksDB extends RocksObject {
    * The ColumnFamilyHandle is automatically disposed with DB disposal.
    *
    * @param columnFamilyDescriptor column family to be created.
+   * @param importColumnFamilyOptions options for the files being imported.
+   * @param metadata description of the column family
    * @return {@link org.rocksdb.ColumnFamilyHandle} instance.
    *
    * @throws RocksDBException thrown if error happens in underlying
@@ -3868,10 +3870,11 @@ public class RocksDB extends RocksObject {
 
   /**
    * Set performance level for rocksdb performance measurement.
-   * @param level
+   * @param level to set
    * @throws IllegalArgumentException for UNINITIALIZED and OUT_OF_BOUNDS values
    *    as they can't be used for settings.
    */
+  @SuppressWarnings("deprecation")
   public void setPerfLevel(final PerfLevel level) {
     if (level == PerfLevel.UNINITIALIZED) {
       throw new IllegalArgumentException("Unable to set UNINITIALIZED level");
@@ -3884,7 +3887,7 @@ public class RocksDB extends RocksObject {
 
   /**
    * Return current performance level measurement settings.
-   * @return
+   * @return current performance level measurement settings
    */
   public PerfLevel getPerfLevel() {
     byte level = getPerfLevelNative();
@@ -3893,7 +3896,7 @@ public class RocksDB extends RocksObject {
 
   /**
    * Return perf context bound to this thread.
-   * @return
+   * @return perf context bound to this thread
    */
   public PerfContext getPerfContext() {
     long native_handle = getPerfContextNative();

--- a/java/src/main/java/org/rocksdb/RocksIteratorInterface.java
+++ b/java/src/main/java/org/rocksdb/RocksIteratorInterface.java
@@ -133,6 +133,9 @@ public interface RocksIteratorInterface {
   /**
    * Similar to {@link #refresh()} but the iterator will be reading the latest DB state under the
    * given snapshot.
+   *
+   * @param snapshot to refresh from
+   * @throws RocksDBException if an error occurs during the refresh
    */
   void refresh(Snapshot snapshot) throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -185,6 +185,7 @@ public class Transaction extends RocksObject {
 
   /**
    * Prepare the current transaction for 2PC
+   * @throws RocksDBException if an error occurs when preparing the transaction
    */
   public void prepare() throws RocksDBException {
     //TODO(AR) consider a Java'ish version of this function, which returns an AutoCloseable (commit)

--- a/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
@@ -175,6 +175,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void getPut_cf() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
@@ -333,6 +334,7 @@ public abstract class AbstractTransactionTest {
     getPutByteBuffer_cf(ByteBuffer::allocate);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void multiGetPut_cf() throws RocksDBException {
     final byte[][] keys = new byte[][] {"key1".getBytes(UTF_8), "key2".getBytes(UTF_8)};
@@ -373,6 +375,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void multiGetPut() throws RocksDBException {
     final byte[][] keys = new byte[][] {"key1".getBytes(UTF_8), "key2".getBytes(UTF_8)};
@@ -589,6 +592,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void multiGetForUpdate_cf() throws RocksDBException {
     final byte[][] keys = new byte[][] {"key1".getBytes(UTF_8), "key2".getBytes(UTF_8)};
@@ -610,6 +614,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void multiGetForUpdate() throws RocksDBException {
     final byte[][] keys = new byte[][] {"key1".getBytes(UTF_8), "key2".getBytes(UTF_8)};
@@ -728,6 +733,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void merge_cf() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
@@ -795,6 +801,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void mergeDirectByteBuffer_cf() throws RocksDBException {
     final ByteBuffer k1 = ByteBuffer.allocateDirect(100).put("key1".getBytes(UTF_8));
@@ -817,6 +824,8 @@ public abstract class AbstractTransactionTest {
           .isEqualTo("value1**value2".getBytes());
     }
   }
+
+  @SuppressWarnings("deprecation")
   public void mergeIndirectByteBuffer_cf() throws RocksDBException {
     final ByteBuffer k1 = ByteBuffer.allocate(100).put("key1".getBytes(UTF_8));
     k1.flip();
@@ -837,6 +846,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void delete_cf() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
@@ -872,6 +882,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void delete_parts_cf() throws RocksDBException {
     final byte[][] keyParts = new byte[][] {"ke".getBytes(UTF_8), "y1".getBytes(UTF_8)};
@@ -915,6 +926,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void getPutUntracked_cf() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
@@ -1127,6 +1139,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void deleteUntracked_cf() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
@@ -1162,6 +1175,7 @@ public abstract class AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void deleteUntracked_parts_cf() throws RocksDBException {
     final byte[][] keyParts = new byte[][] {"ke".getBytes(UTF_8), "y1".getBytes(UTF_8)};

--- a/java/src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
+++ b/java/src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -211,15 +210,14 @@ public class BlockBasedTableConfigTest {
 
   @Test
   public void persistentCache() throws RocksDBException {
-    try (final DBOptions dbOptions = new DBOptions().
-        setInfoLogLevel(InfoLogLevel.INFO_LEVEL).
-        setCreateIfMissing(true);
-        final Logger logger = new Logger(dbOptions) {
-      @Override
-      protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
-        System.out.println(infoLogLevel.name() + ": " + logMsg);
-      }
-    }) {
+    try (final DBOptions dbOptions =
+             new DBOptions().setInfoLogLevel(InfoLogLevel.INFO_LEVEL).setCreateIfMissing(true);
+         final Logger logger = new Logger(dbOptions.infoLogLevel()) {
+           @Override
+           protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
+             System.out.println(infoLogLevel.name() + ": " + logMsg);
+           }
+         }) {
       try (final PersistentCache persistentCache =
                new PersistentCache(Env.getDefault(), dbFolder.getRoot().getPath(), 1024 * 1024 * 100, logger, false);
            final Options options = new Options().setTableFormatConfig(

--- a/java/src/test/java/org/rocksdb/ClockCacheTest.java
+++ b/java/src/test/java/org/rocksdb/ClockCacheTest.java
@@ -13,13 +13,14 @@ public class ClockCacheTest {
     RocksDB.loadLibrary();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void newClockCache() {
     final long capacity = 1000;
     final int numShardBits = 16;
     final boolean strictCapacityLimit = true;
     try (final Cache ignored = new ClockCache(capacity, numShardBits, strictCapacityLimit)) {
-      //no op
+      ; // no op
     }
   }
 }

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -64,16 +64,15 @@ public class DBOptionsTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void failDBOptionsFromPropsWithNullValue() {
-    try(final DBOptions opt = DBOptions.getDBOptionsFromProps(null)) {
-      //no-op
+    try (final DBOptions ignored = DBOptions.getDBOptionsFromProps(null)) {
+      ; // no-op
     }
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void failDBOptionsFromPropsWithEmptyProps() {
-    try(final DBOptions opt = DBOptions.getDBOptionsFromProps(
-        new Properties())) {
-      //no-op
+    try (final DBOptions ignored = DBOptions.getDBOptionsFromProps(new Properties())) {
+      ; // no-op
     }
   }
 
@@ -216,7 +215,7 @@ public class DBOptionsTest {
     }
   }
 
-  @SuppressWarnings("deprecated")
+  @SuppressWarnings({"deprecated", "deprecation"})
   @Test
   public void maxBackgroundCompactions() {
     try(final DBOptions opt = new DBOptions()) {
@@ -236,7 +235,7 @@ public class DBOptionsTest {
     }
   }
 
-  @SuppressWarnings("deprecated")
+  @SuppressWarnings("deprecation")
   @Test
   public void maxBackgroundFlushes() {
     try(final DBOptions opt = new DBOptions()) {
@@ -256,7 +255,7 @@ public class DBOptionsTest {
   }
 
   @Test
-  public void maxLogFileSize() throws RocksDBException {
+  public void maxLogFileSize() {
     try(final DBOptions opt = new DBOptions()) {
       final long longValue = rand.nextLong();
       opt.setMaxLogFileSize(longValue);
@@ -265,7 +264,7 @@ public class DBOptionsTest {
   }
 
   @Test
-  public void logFileTimeToRoll() throws RocksDBException {
+  public void logFileTimeToRoll() {
     try(final DBOptions opt = new DBOptions()) {
       final long longValue = rand.nextLong();
       opt.setLogFileTimeToRoll(longValue);
@@ -274,7 +273,7 @@ public class DBOptionsTest {
   }
 
   @Test
-  public void keepLogFileNum() throws RocksDBException {
+  public void keepLogFileNum() {
     try(final DBOptions opt = new DBOptions()) {
       final long longValue = rand.nextLong();
       opt.setKeepLogFileNum(longValue);
@@ -283,7 +282,7 @@ public class DBOptionsTest {
   }
 
   @Test
-  public void recycleLogFileNum() throws RocksDBException {
+  public void recycleLogFileNum() {
     try(final DBOptions opt = new DBOptions()) {
       final long longValue = rand.nextLong();
       opt.setRecycleLogFileNum(longValue);
@@ -328,7 +327,7 @@ public class DBOptionsTest {
   }
 
   @Test
-  public void manifestPreallocationSize() throws RocksDBException {
+  public void manifestPreallocationSize() {
     try(final DBOptions opt = new DBOptions()) {
       final long longValue = rand.nextLong();
       opt.setManifestPreallocationSize(longValue);
@@ -436,7 +435,7 @@ public class DBOptionsTest {
   }
 
   @Test
-  public void setWriteBufferManager() throws RocksDBException {
+  public void setWriteBufferManager() {
     try (final DBOptions opt = new DBOptions(); final Cache cache = new LRUCache(1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(2000L, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
@@ -445,7 +444,7 @@ public class DBOptionsTest {
   }
 
   @Test
-  public void setWriteBufferManagerWithZeroBufferSize() throws RocksDBException {
+  public void setWriteBufferManagerWithZeroBufferSize() {
     try (final DBOptions opt = new DBOptions(); final Cache cache = new LRUCache(1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(0L, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
@@ -607,6 +606,7 @@ public class DBOptionsTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void rowCache() {
     try (final DBOptions opt = new DBOptions()) {

--- a/java/src/test/java/org/rocksdb/EventListenerTest.java
+++ b/java/src/test/java/org/rocksdb/EventListenerTest.java
@@ -73,6 +73,7 @@ public class EventListenerTest {
     flushDb(onFlushBeginListener, wasCbCalled);
   }
 
+  @SuppressWarnings("deprecation")
   void deleteTableFile(final AbstractEventListener el, final AtomicBoolean wasCbCalled)
       throws RocksDBException {
     try (final Options opt =

--- a/java/src/test/java/org/rocksdb/ImportColumnFamilyTest.java
+++ b/java/src/test/java/org/rocksdb/ImportColumnFamilyTest.java
@@ -7,24 +7,15 @@
 package org.rocksdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.rocksdb.util.BytewiseComparator;
 
 public class ImportColumnFamilyTest {
-  private static final String SST_FILE_NAME = "test.sst";
-  private static final String DB_DIRECTORY_NAME = "test_db";
-
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
       new RocksNativeLibraryResource();
@@ -81,7 +72,7 @@ public class ImportColumnFamilyTest {
           ColumnFamilyDescriptor columnFamilyDescriptor =
               new ColumnFamilyDescriptor("new_cf".getBytes());
 
-          List<ExportImportFilesMetaData> importMetaDatas = new ArrayList();
+          List<ExportImportFilesMetaData> importMetaDatas = new ArrayList<>();
           importMetaDatas.add(default_cf_metadata1);
           importMetaDatas.add(default_cf_metadata2);
 

--- a/java/src/test/java/org/rocksdb/KeyExistsTest.java
+++ b/java/src/test/java/org/rocksdb/KeyExistsTest.java
@@ -6,13 +6,13 @@ package org.rocksdb;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.*;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 public class KeyExistsTest {
@@ -21,8 +21,6 @@ public class KeyExistsTest {
       new RocksNativeLibraryResource();
 
   @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
-
-  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   List<ColumnFamilyDescriptor> cfDescriptors;
   List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
@@ -109,15 +107,15 @@ public class KeyExistsTest {
   @Test
   public void keyExistsArrayIndexOutOfBoundsException() throws RocksDBException {
     db.put("key".getBytes(UTF_8), "value".getBytes(UTF_8));
-    exceptionRule.expect(IndexOutOfBoundsException.class);
-    db.keyExists(null, null, "key".getBytes(UTF_8), 0, 5);
+    assertThatThrownBy(() -> db.keyExists(null, null, "key".getBytes(UTF_8), 0, 5))
+        .isInstanceOf(IndexOutOfBoundsException.class);
   }
 
   @Test()
   public void keyExistsArrayIndexOutOfBoundsExceptionWrongOffset() throws RocksDBException {
     db.put("key".getBytes(UTF_8), "value".getBytes(UTF_8));
-    exceptionRule.expect(IndexOutOfBoundsException.class);
-    db.keyExists(null, null, "key".getBytes(UTF_8), 6, 2);
+    assertThatThrownBy(() -> db.keyExists(null, null, "key".getBytes(UTF_8), 6, 2))
+        .isInstanceOf(IndexOutOfBoundsException.class);
   }
 
   @Test

--- a/java/src/test/java/org/rocksdb/KeyMayExistTest.java
+++ b/java/src/test/java/org/rocksdb/KeyMayExistTest.java
@@ -6,6 +6,7 @@ package org.rocksdb;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -13,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.*;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 public class KeyMayExistTest {
@@ -23,8 +23,6 @@ public class KeyMayExistTest {
 
   @Rule
   public TemporaryFolder dbFolder = new TemporaryFolder();
-
-  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   List<ColumnFamilyDescriptor> cfDescriptors;
   List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
@@ -286,9 +284,10 @@ public class KeyMayExistTest {
     valueBuffer.get(valueGet);
     assertThat(valueGet).isEqualTo(Arrays.copyOfRange(value, 0, value.length - 1));
 
-    exceptionRule.expect(BufferUnderflowException.class);
-    valueGet = new byte[value.length];
-    valueBuffer.get(valueGet);
+    assertThatThrownBy(() -> {
+      byte[] valueGet2 = new byte[value.length];
+      valueBuffer.get(valueGet2);
+    }).isInstanceOf(BufferUnderflowException.class);
   }
 
   @Test
@@ -330,9 +329,10 @@ public class KeyMayExistTest {
       valueBuffer.get(valueGet);
       assertThat(valueGet).isEqualTo(Arrays.copyOfRange(value, 0, value.length - 1));
 
-      exceptionRule.expect(BufferUnderflowException.class);
-      valueGet = new byte[value.length];
-      valueBuffer.get(valueGet);
+      assertThatThrownBy(() -> {
+        byte[] valueGet2 = new byte[value.length];
+        valueBuffer.get(valueGet2);
+      }).isInstanceOf(BufferUnderflowException.class);
     }
   }
 
@@ -347,10 +347,10 @@ public class KeyMayExistTest {
     keyBuffer.put(key, 0, key.length);
     keyBuffer.flip();
 
-    exceptionRule.expect(AssertionError.class);
-    exceptionRule.expectMessage(
-        "value ByteBuffer parameter cannot be null. If you do not need the value, use a different version of the method");
-    final KeyMayExist keyMayExist = db.keyMayExist(keyBuffer, null);
+    assertThatThrownBy(() -> db.keyMayExist(keyBuffer, null))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("value ByteBuffer parameter cannot be null. If you do not need the "
+            + "value, use a different version of the method");
   }
 
   @Test
@@ -384,10 +384,11 @@ public class KeyMayExistTest {
     assertThat(db.keyMayExist(columnFamilyHandleList.get(0), keyBuffer)).isEqualTo(false);
     keyBuffer.flip();
 
-    exceptionRule.expect(AssertionError.class);
-    exceptionRule.expectMessage(
-        "value ByteBuffer parameter cannot be null. If you do not need the value, use a different version of the method");
-    final KeyMayExist keyMayExist = db.keyMayExist(columnFamilyHandleList.get(0), keyBuffer, null);
+    final ByteBuffer keyBuffer2 = keyBuffer;
+    assertThatThrownBy(() -> db.keyMayExist(columnFamilyHandleList.get(0), keyBuffer2, null))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("value ByteBuffer parameter cannot be null. If you do not need the "
+            + "value, use a different version of the method");
   }
 
   @Test
@@ -425,11 +426,12 @@ public class KeyMayExistTest {
       assertThat(db.keyMayExist(columnFamilyHandleList.get(0), readOptions, keyBuffer))
           .isEqualTo(false);
 
-      exceptionRule.expect(AssertionError.class);
-      exceptionRule.expectMessage(
-          "value ByteBuffer parameter cannot be null. If you do not need the value, use a different version of the method");
-      final KeyMayExist keyMayExist =
-          db.keyMayExist(columnFamilyHandleList.get(0), readOptions, keyBuffer, null);
+      final ByteBuffer keyBufferCopy = keyBuffer;
+      assertThatThrownBy(
+          () -> db.keyMayExist(columnFamilyHandleList.get(0), readOptions, keyBufferCopy, null))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("value ByteBuffer parameter cannot be null. If you do not need the "
+              + "value, use a different version of the method");
     }
   }
 
@@ -469,9 +471,9 @@ public class KeyMayExistTest {
     valueBuffer.get(valueGet);
     assertThat(valueGet).isEqualTo(Arrays.copyOfRange(value, 0, value.length - 1));
 
-    exceptionRule.expect(BufferUnderflowException.class);
-    valueGet = new byte[value.length];
-    valueBuffer.get(valueGet);
+    final byte[] valueGet2 = new byte[value.length];
+    assertThatThrownBy(() -> valueBuffer.get(valueGet2))
+        .isInstanceOf(BufferUnderflowException.class);
   }
 
   @Test
@@ -515,9 +517,9 @@ public class KeyMayExistTest {
       valueBuffer.get(valueGet);
       assertThat(valueGet).isEqualTo(Arrays.copyOfRange(value, 0, value.length - 1));
 
-      exceptionRule.expect(BufferUnderflowException.class);
-      valueGet = new byte[value.length];
-      valueBuffer.get(valueGet);
+      byte[] valueGet2 = new byte[value.length];
+      assertThatThrownBy(() -> valueBuffer.get(valueGet2))
+          .isInstanceOf(BufferUnderflowException.class);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/LoggerTest.java
+++ b/java/src/test/java/org/rocksdb/LoggerTest.java
@@ -23,10 +23,9 @@ public class LoggerTest {
   @Test
   public void customLogger() throws RocksDBException {
     final AtomicInteger logMessageCounter = new AtomicInteger();
-    try (final Options options = new Options().
-        setInfoLogLevel(InfoLogLevel.DEBUG_LEVEL).
-        setCreateIfMissing(true);
-         final Logger logger = new Logger(options) {
+    try (final Options options =
+             new Options().setInfoLogLevel(InfoLogLevel.DEBUG_LEVEL).setCreateIfMissing(true);
+         final Logger logger = new Logger(options.infoLogLevel()) {
            // Create new logger with max log level passed by options
            @Override
            protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
@@ -34,13 +33,11 @@ public class LoggerTest {
              assertThat(logMsg.length()).isGreaterThan(0);
              logMessageCounter.incrementAndGet();
            }
-         }
-    ) {
+         }) {
       // Set custom logger to options
       options.setLogger(logger);
 
-      try (final RocksDB db = RocksDB.open(options,
-          dbFolder.getRoot().getAbsolutePath())) {
+      try (final RocksDB ignored = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
         // there should be more than zero received log messages in
         // debug level.
         assertThat(logMessageCounter.get()).isGreaterThan(0);
@@ -51,11 +48,10 @@ public class LoggerTest {
   @Test
   public void warnLogger() throws RocksDBException {
     final AtomicInteger logMessageCounter = new AtomicInteger();
-    try (final Options options = new Options().
-        setInfoLogLevel(InfoLogLevel.WARN_LEVEL).
-        setCreateIfMissing(true);
+    try (final Options options =
+             new Options().setInfoLogLevel(InfoLogLevel.WARN_LEVEL).setCreateIfMissing(true);
 
-         final Logger logger = new Logger(options) {
+         final Logger logger = new Logger(options.infoLogLevel()) {
            // Create new logger with max log level passed by options
            @Override
            protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
@@ -63,14 +59,11 @@ public class LoggerTest {
              assertThat(logMsg.length()).isGreaterThan(0);
              logMessageCounter.incrementAndGet();
            }
-         }
-    ) {
-
+         }) {
       // Set custom logger to options
       options.setLogger(logger);
 
-      try (final RocksDB db = RocksDB.open(options,
-          dbFolder.getRoot().getAbsolutePath())) {
+      try (final RocksDB ignored = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
         // there should be zero messages
         // using warn level as log level.
         assertThat(logMessageCounter.get()).isEqualTo(0);
@@ -82,11 +75,10 @@ public class LoggerTest {
   @Test
   public void fatalLogger() throws RocksDBException {
     final AtomicInteger logMessageCounter = new AtomicInteger();
-    try (final Options options = new Options().
-        setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).
-        setCreateIfMissing(true);
+    try (final Options options =
+             new Options().setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).setCreateIfMissing(true);
 
-         final Logger logger = new Logger(options) {
+         final Logger logger = new Logger(options.infoLogLevel()) {
            // Create new logger with max log level passed by options
            @Override
            protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
@@ -94,14 +86,11 @@ public class LoggerTest {
              assertThat(logMsg.length()).isGreaterThan(0);
              logMessageCounter.incrementAndGet();
            }
-         }
-    ) {
-
+         }) {
       // Set custom logger to options
       options.setLogger(logger);
 
-      try (final RocksDB db = RocksDB.open(options,
-          dbFolder.getRoot().getAbsolutePath())) {
+      try (final RocksDB ignored = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
         // there should be zero messages
         // using fatal level as log level.
         assertThat(logMessageCounter.get()).isEqualTo(0);
@@ -112,10 +101,9 @@ public class LoggerTest {
   @Test
   public void dbOptionsLogger() throws RocksDBException {
     final AtomicInteger logMessageCounter = new AtomicInteger();
-    try (final DBOptions options = new DBOptions().
-        setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).
-        setCreateIfMissing(true);
-         final Logger logger = new Logger(options) {
+    try (final DBOptions options =
+             new DBOptions().setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).setCreateIfMissing(true);
+         final Logger logger = new Logger(options.infoLogLevel()) {
            // Create new logger with max log level passed by options
            @Override
            protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
@@ -123,8 +111,7 @@ public class LoggerTest {
              assertThat(logMsg.length()).isGreaterThan(0);
              logMessageCounter.incrementAndGet();
            }
-         }
-    ) {
+         }) {
       // Set custom logger to options
       options.setLogger(logger);
 
@@ -132,9 +119,8 @@ public class LoggerTest {
           Collections.singletonList(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
       final List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
 
-      try (final RocksDB db = RocksDB.open(options,
-          dbFolder.getRoot().getAbsolutePath(),
-          cfDescriptors, cfHandles)) {
+      try (final RocksDB ignored = RocksDB.open(
+               options, dbFolder.getRoot().getAbsolutePath(), cfDescriptors, cfHandles)) {
         try {
           // there should be zero messages
           // using fatal level as log level.
@@ -151,10 +137,9 @@ public class LoggerTest {
   @Test
   public void setWarnLogLevel() {
     final AtomicInteger logMessageCounter = new AtomicInteger();
-    try (final Options options = new Options().
-        setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).
-        setCreateIfMissing(true);
-         final Logger logger = new Logger(options) {
+    try (final Options options =
+             new Options().setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).setCreateIfMissing(true);
+         final Logger logger = new Logger(options.infoLogLevel()) {
            // Create new logger with max log level passed by options
            @Override
            protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
@@ -162,8 +147,7 @@ public class LoggerTest {
              assertThat(logMsg.length()).isGreaterThan(0);
              logMessageCounter.incrementAndGet();
            }
-         }
-    ) {
+         }) {
       assertThat(logger.infoLogLevel()).
           isEqualTo(InfoLogLevel.FATAL_LEVEL);
       logger.setInfoLogLevel(InfoLogLevel.WARN_LEVEL);
@@ -175,10 +159,9 @@ public class LoggerTest {
   @Test
   public void setInfoLogLevel() {
     final AtomicInteger logMessageCounter = new AtomicInteger();
-    try (final Options options = new Options().
-        setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).
-        setCreateIfMissing(true);
-         final Logger logger = new Logger(options) {
+    try (final Options options =
+             new Options().setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).setCreateIfMissing(true);
+         final Logger logger = new Logger(options.infoLogLevel()) {
            // Create new logger with max log level passed by options
            @Override
            protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
@@ -186,8 +169,7 @@ public class LoggerTest {
              assertThat(logMsg.length()).isGreaterThan(0);
              logMessageCounter.incrementAndGet();
            }
-         }
-    ) {
+         }) {
       assertThat(logger.infoLogLevel()).
           isEqualTo(InfoLogLevel.FATAL_LEVEL);
       logger.setInfoLogLevel(InfoLogLevel.DEBUG_LEVEL);
@@ -203,7 +185,7 @@ public class LoggerTest {
              new Options().setInfoLogLevel(InfoLogLevel.FATAL_LEVEL).setCreateIfMissing(true);
 
          // Create new logger with max log level passed by options
-         final Logger logger = new Logger(options) {
+         final Logger logger = new Logger(options.infoLogLevel()) {
            @Override
            protected void log(final InfoLogLevel infoLogLevel, final String logMsg) {
              assertThat(logMsg).isNotNull();
@@ -225,7 +207,9 @@ public class LoggerTest {
         logger.setInfoLogLevel(InfoLogLevel.DEBUG_LEVEL);
 
         db.put("key".getBytes(), "value".getBytes());
-        db.flush(new FlushOptions().setWaitForFlush(true));
+        try (FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+          db.flush(flushOptions);
+        }
 
         // messages shall be received due to previous actions.
         assertThat(logMessageCounter.get()).isNotEqualTo(0);
@@ -253,7 +237,7 @@ public class LoggerTest {
           Collections.singletonList(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
       final List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
 
-      try (final RocksDB db = RocksDB.open(
+      try (final RocksDB ignored = RocksDB.open(
                options, dbFolder.getRoot().getAbsolutePath(), cfDescriptors, cfHandles)) {
         try {
           // there should be zero messages

--- a/java/src/test/java/org/rocksdb/OptimisticTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/OptimisticTransactionTest.java
@@ -39,6 +39,7 @@ public class OptimisticTransactionTest extends AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void getForUpdate_cf_conflict() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);
@@ -158,6 +159,7 @@ public class OptimisticTransactionTest extends AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void multiGetAsListForUpdate_cf_conflict() throws RocksDBException {
     final byte[][] keys = new byte[][] {"key1".getBytes(UTF_8), "key2".getBytes(UTF_8)};
@@ -281,6 +283,7 @@ public class OptimisticTransactionTest extends AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void undoGetForUpdate_cf_conflict() throws RocksDBException {
     final byte[] k1 = "key1".getBytes(UTF_8);

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.*;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.rocksdb.test.RemoveEmptyValueCompactionFilterFactory;
@@ -45,7 +46,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void writeBufferSize() throws RocksDBException {
+  public void writeBufferSize() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setWriteBufferSize(longValue);
@@ -219,7 +220,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void arenaBlockSize() throws RocksDBException {
+  public void arenaBlockSize() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setArenaBlockSize(longValue);
@@ -255,7 +256,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void inplaceUpdateNumLocks() throws RocksDBException {
+  public void inplaceUpdateNumLocks() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setInplaceUpdateNumLocks(longValue);
@@ -309,7 +310,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void maxSuccessiveMerges() throws RocksDBException {
+  public void maxSuccessiveMerges() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setMaxSuccessiveMerges(longValue);
@@ -446,7 +447,7 @@ public class OptionsTest {
     }
   }
 
-  @SuppressWarnings("deprecated")
+  @SuppressWarnings("deprecation")
   @Test
   public void maxBackgroundCompactions() {
     try (final Options opt = new Options()) {
@@ -467,7 +468,7 @@ public class OptionsTest {
     }
   }
 
-  @SuppressWarnings("deprecated")
+  @SuppressWarnings("deprecation")
   @Test
   public void maxBackgroundFlushes() {
     try (final Options opt = new Options()) {
@@ -488,7 +489,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void maxLogFileSize() throws RocksDBException {
+  public void maxLogFileSize() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setMaxLogFileSize(longValue);
@@ -497,7 +498,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void logFileTimeToRoll() throws RocksDBException {
+  public void logFileTimeToRoll() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setLogFileTimeToRoll(longValue);
@@ -507,7 +508,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void keepLogFileNum() throws RocksDBException {
+  public void keepLogFileNum() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setKeepLogFileNum(longValue);
@@ -516,7 +517,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void recycleLogFileNum() throws RocksDBException {
+  public void recycleLogFileNum() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setRecycleLogFileNum(longValue);
@@ -563,7 +564,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void manifestPreallocationSize() throws RocksDBException {
+  public void manifestPreallocationSize() {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();
       opt.setManifestPreallocationSize(longValue);
@@ -672,7 +673,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void setWriteBufferManager() throws RocksDBException {
+  public void setWriteBufferManager() {
     try (final Options opt = new Options(); final Cache cache = new LRUCache(1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(2000L, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
@@ -681,7 +682,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void setWriteBufferManagerWithZeroBufferSize() throws RocksDBException {
+  public void setWriteBufferManagerWithZeroBufferSize() {
     try (final Options opt = new Options(); final Cache cache = new LRUCache(1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(0L, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
@@ -690,7 +691,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void setWriteBufferManagerWithAllowStall() throws RocksDBException {
+  public void setWriteBufferManagerWithAllowStall() {
     try (final Options opt = new Options(); final Cache cache = new LRUCache(1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(2000L, cache, true)) {
       opt.setWriteBufferManager(writeBufferManager);
@@ -853,6 +854,7 @@ public class OptionsTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void rowCache() {
     try (final Options opt = new Options()) {
@@ -1174,8 +1176,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void shouldTestMemTableFactoryName()
-      throws RocksDBException {
+  public void shouldTestMemTableFactoryName() {
     try (final Options options = new Options()) {
       options.setMemTableConfig(new VectorMemTableConfig());
       assertThat(options.memTableFactoryName()).
@@ -1492,14 +1493,18 @@ public class OptionsTest {
     try (final Options options = new Options()) {
       try (TablePropertiesCollectorFactory collectorFactory =
                TablePropertiesCollectorFactory.NewCompactOnDeletionCollectorFactory(10, 10, 1.0)) {
-        List<TablePropertiesCollectorFactory> factories = Arrays.asList(collectorFactory);
+        List<TablePropertiesCollectorFactory> factories =
+            Collections.singletonList(collectorFactory);
         options.setTablePropertiesCollectorFactory(factories);
       }
       List<TablePropertiesCollectorFactory> factories = options.tablePropertiesCollectorFactory();
       try {
         assertThat(factories).hasSize(1);
       } finally {
-        factories.stream().forEach(TablePropertiesCollectorFactory::close);
+        Optional.ofNullable(factories)
+            .map(Collection::stream)
+            .orElseGet(Stream::empty)
+            .forEach(TablePropertiesCollectorFactory::close);
       }
     }
   }

--- a/java/src/test/java/org/rocksdb/OptionsUtilTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsUtilTest.java
@@ -188,71 +188,73 @@ public class OptionsUtilTest {
                                 .setParanoidChecks(false)
                                 .setMaxOpenFiles(478)
                                 .setDelayedWriteRate(1234567L);
-    final ColumnFamilyOptions baseDefaultCFOpts = new ColumnFamilyOptions();
-    final byte[] secondCFName = "new_cf".getBytes();
-    final ColumnFamilyOptions baseSecondCFOpts =
-        new ColumnFamilyOptions()
-            .setWriteBufferSize(70 * 1024)
-            .setMaxWriteBufferNumber(7)
-            .setMaxBytesForLevelBase(53 * 1024 * 1024)
-            .setLevel0FileNumCompactionTrigger(3)
-            .setLevel0SlowdownWritesTrigger(51)
-            .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION);
+    try (final ColumnFamilyOptions baseDefaultCFOpts = new ColumnFamilyOptions()) {
+      final byte[] secondCFName = "new_cf".getBytes();
+      final ColumnFamilyOptions baseSecondCFOpts =
+          new ColumnFamilyOptions()
+              .setWriteBufferSize(70 * 1024)
+              .setMaxWriteBufferNumber(7)
+              .setMaxBytesForLevelBase(53 * 1024 * 1024)
+              .setLevel0FileNumCompactionTrigger(3)
+              .setLevel0SlowdownWritesTrigger(51)
+              .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION);
 
-    // Create a database with a new column family
-    try (final RocksDB db = RocksDB.open(options, dbPath)) {
-      assertThat(db).isNotNull();
+      // Create a database with a new column family
+      try (final RocksDB db = RocksDB.open(options, dbPath)) {
+        assertThat(db).isNotNull();
 
-      // create column family
-      try (final ColumnFamilyHandle columnFamilyHandle =
-               db.createColumnFamily(new ColumnFamilyDescriptor(secondCFName, baseSecondCFOpts))) {
-        assert(columnFamilyHandle != null);
+        // create column family
+        try (final ColumnFamilyHandle columnFamilyHandle = db.createColumnFamily(
+                 new ColumnFamilyDescriptor(secondCFName, baseSecondCFOpts))) {
+          assert (columnFamilyHandle != null);
+        }
       }
-    }
 
-    // Read the options back and verify
-    try (DBOptions dbOptions = new DBOptions()) {
-      final List<ColumnFamilyDescriptor> cfDescs = loaderUnderTest.loadOptions(dbPath, dbOptions);
+      // Read the options back and verify
+      try (DBOptions dbOptions = new DBOptions()) {
+        final List<ColumnFamilyDescriptor> cfDescs = loaderUnderTest.loadOptions(dbPath, dbOptions);
 
-      assertThat(dbOptions.createIfMissing()).isEqualTo(options.createIfMissing());
-      assertThat(dbOptions.paranoidChecks()).isEqualTo(options.paranoidChecks());
-      assertThat(dbOptions.maxOpenFiles()).isEqualTo(options.maxOpenFiles());
-      assertThat(dbOptions.delayedWriteRate()).isEqualTo(options.delayedWriteRate());
+        assertThat(dbOptions.createIfMissing()).isEqualTo(options.createIfMissing());
+        assertThat(dbOptions.paranoidChecks()).isEqualTo(options.paranoidChecks());
+        assertThat(dbOptions.maxOpenFiles()).isEqualTo(options.maxOpenFiles());
+        assertThat(dbOptions.delayedWriteRate()).isEqualTo(options.delayedWriteRate());
 
-      assertThat(cfDescs.size()).isEqualTo(2);
-      assertThat(cfDescs.get(0)).isNotNull();
-      assertThat(cfDescs.get(1)).isNotNull();
-      assertThat(cfDescs.get(0).getName()).isEqualTo(RocksDB.DEFAULT_COLUMN_FAMILY);
-      assertThat(cfDescs.get(1).getName()).isEqualTo(secondCFName);
+        assertThat(cfDescs.size()).isEqualTo(2);
+        assertThat(cfDescs.get(0)).isNotNull();
+        assertThat(cfDescs.get(1)).isNotNull();
+        assertThat(cfDescs.get(0).getName()).isEqualTo(RocksDB.DEFAULT_COLUMN_FAMILY);
+        assertThat(cfDescs.get(1).getName()).isEqualTo(secondCFName);
 
-      final ColumnFamilyOptions defaultCFOpts = cfDescs.get(0).getOptions();
-      assertThat(defaultCFOpts.writeBufferSize()).isEqualTo(baseDefaultCFOpts.writeBufferSize());
-      assertThat(defaultCFOpts.maxWriteBufferNumber())
-          .isEqualTo(baseDefaultCFOpts.maxWriteBufferNumber());
-      assertThat(defaultCFOpts.maxBytesForLevelBase())
-          .isEqualTo(baseDefaultCFOpts.maxBytesForLevelBase());
-      assertThat(defaultCFOpts.level0FileNumCompactionTrigger())
-          .isEqualTo(baseDefaultCFOpts.level0FileNumCompactionTrigger());
-      assertThat(defaultCFOpts.level0SlowdownWritesTrigger())
-          .isEqualTo(baseDefaultCFOpts.level0SlowdownWritesTrigger());
-      assertThat(defaultCFOpts.bottommostCompressionType())
-          .isEqualTo(baseDefaultCFOpts.bottommostCompressionType());
+        final ColumnFamilyOptions defaultCFOpts = cfDescs.get(0).getOptions();
+        assertThat(defaultCFOpts.writeBufferSize()).isEqualTo(baseDefaultCFOpts.writeBufferSize());
+        assertThat(defaultCFOpts.maxWriteBufferNumber())
+            .isEqualTo(baseDefaultCFOpts.maxWriteBufferNumber());
+        assertThat(defaultCFOpts.maxBytesForLevelBase())
+            .isEqualTo(baseDefaultCFOpts.maxBytesForLevelBase());
+        assertThat(defaultCFOpts.level0FileNumCompactionTrigger())
+            .isEqualTo(baseDefaultCFOpts.level0FileNumCompactionTrigger());
+        assertThat(defaultCFOpts.level0SlowdownWritesTrigger())
+            .isEqualTo(baseDefaultCFOpts.level0SlowdownWritesTrigger());
+        assertThat(defaultCFOpts.bottommostCompressionType())
+            .isEqualTo(baseDefaultCFOpts.bottommostCompressionType());
 
-      final ColumnFamilyOptions secondCFOpts = cfDescs.get(1).getOptions();
-      assertThat(secondCFOpts.writeBufferSize()).isEqualTo(baseSecondCFOpts.writeBufferSize());
-      assertThat(secondCFOpts.maxWriteBufferNumber())
-          .isEqualTo(baseSecondCFOpts.maxWriteBufferNumber());
-      assertThat(secondCFOpts.maxBytesForLevelBase())
-          .isEqualTo(baseSecondCFOpts.maxBytesForLevelBase());
-      assertThat(secondCFOpts.level0FileNumCompactionTrigger())
-          .isEqualTo(baseSecondCFOpts.level0FileNumCompactionTrigger());
-      assertThat(secondCFOpts.level0SlowdownWritesTrigger())
-          .isEqualTo(baseSecondCFOpts.level0SlowdownWritesTrigger());
-      assertThat(secondCFOpts.bottommostCompressionType())
-          .isEqualTo(baseSecondCFOpts.bottommostCompressionType());
+        final ColumnFamilyOptions secondCFOpts = cfDescs.get(1).getOptions();
+        assertThat(secondCFOpts.writeBufferSize()).isEqualTo(baseSecondCFOpts.writeBufferSize());
+        assertThat(secondCFOpts.maxWriteBufferNumber())
+            .isEqualTo(baseSecondCFOpts.maxWriteBufferNumber());
+        assertThat(secondCFOpts.maxBytesForLevelBase())
+            .isEqualTo(baseSecondCFOpts.maxBytesForLevelBase());
+        assertThat(secondCFOpts.level0FileNumCompactionTrigger())
+            .isEqualTo(baseSecondCFOpts.level0FileNumCompactionTrigger());
+        assertThat(secondCFOpts.level0SlowdownWritesTrigger())
+            .isEqualTo(baseSecondCFOpts.level0SlowdownWritesTrigger());
+        assertThat(secondCFOpts.bottommostCompressionType())
+            .isEqualTo(baseSecondCFOpts.bottommostCompressionType());
+      }
     }
   }
 
+  @SuppressWarnings("deprecation")
   private void verifyTableFormatOptions(final LoaderUnderTest loaderUnderTest)
       throws RocksDBException {
     final String dbPath = dbFolder.getRoot().getAbsolutePath();
@@ -261,78 +263,80 @@ public class OptionsUtilTest {
                                 .setParanoidChecks(false)
                                 .setMaxOpenFiles(478)
                                 .setDelayedWriteRate(1234567L);
-    final ColumnFamilyOptions defaultCFOptions = new ColumnFamilyOptions();
-    defaultCFOptions.setTableFormatConfig(new BlockBasedTableConfig());
-    final byte[] altCFName = "alt_cf".getBytes();
-    final ColumnFamilyOptions altCFOptions =
-        new ColumnFamilyOptions()
-            .setWriteBufferSize(70 * 1024)
-            .setMaxWriteBufferNumber(7)
-            .setMaxBytesForLevelBase(53 * 1024 * 1024)
-            .setLevel0FileNumCompactionTrigger(3)
-            .setLevel0SlowdownWritesTrigger(51)
-            .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION);
+    try (final ColumnFamilyOptions defaultCFOptions = new ColumnFamilyOptions()) {
+      defaultCFOptions.setTableFormatConfig(new BlockBasedTableConfig());
+      final byte[] altCFName = "alt_cf".getBytes();
+      try (final ColumnFamilyOptions altCFOptions =
+               new ColumnFamilyOptions()
+                   .setWriteBufferSize(70 * 1024)
+                   .setMaxWriteBufferNumber(7)
+                   .setMaxBytesForLevelBase(53 * 1024 * 1024)
+                   .setLevel0FileNumCompactionTrigger(3)
+                   .setLevel0SlowdownWritesTrigger(51)
+                   .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION)) {
+        final BlockBasedTableConfig altCFTableConfig = new BlockBasedTableConfig();
+        altCFTableConfig.setCacheIndexAndFilterBlocks(true);
+        altCFTableConfig.setCacheIndexAndFilterBlocksWithHighPriority(false);
+        altCFTableConfig.setPinL0FilterAndIndexBlocksInCache(true);
+        altCFTableConfig.setPinTopLevelIndexAndFilter(false);
+        altCFTableConfig.setIndexType(IndexType.kTwoLevelIndexSearch);
+        altCFTableConfig.setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash);
+        altCFTableConfig.setDataBlockHashTableUtilRatio(0.65);
+        altCFTableConfig.setChecksumType(ChecksumType.kxxHash64);
+        altCFTableConfig.setNoBlockCache(true);
+        altCFTableConfig.setBlockSize(35 * 1024);
+        altCFTableConfig.setBlockSizeDeviation(20);
+        altCFTableConfig.setBlockRestartInterval(12);
+        altCFTableConfig.setIndexBlockRestartInterval(6);
+        altCFTableConfig.setMetadataBlockSize(12 * 1024);
+        altCFTableConfig.setPartitionFilters(true);
+        altCFTableConfig.setOptimizeFiltersForMemory(false);
+        altCFTableConfig.setUseDeltaEncoding(false);
+        altCFTableConfig.setFilterPolicy(new BloomFilter(7.5));
+        altCFTableConfig.setWholeKeyFiltering(false);
+        altCFTableConfig.setVerifyCompression(true);
+        altCFTableConfig.setReadAmpBytesPerBit(2);
+        altCFTableConfig.setFormatVersion(8);
+        altCFTableConfig.setEnableIndexCompression(false);
+        altCFTableConfig.setBlockAlign(true);
+        altCFTableConfig.setIndexShortening(IndexShorteningMode.kShortenSeparatorsAndSuccessor);
+        altCFTableConfig.setBlockCacheSize(3 * 1024 * 1024);
+        // Note cache objects are not set here, as they are not read back when reading config.
 
-    final BlockBasedTableConfig altCFTableConfig = new BlockBasedTableConfig();
-    altCFTableConfig.setCacheIndexAndFilterBlocks(true);
-    altCFTableConfig.setCacheIndexAndFilterBlocksWithHighPriority(false);
-    altCFTableConfig.setPinL0FilterAndIndexBlocksInCache(true);
-    altCFTableConfig.setPinTopLevelIndexAndFilter(false);
-    altCFTableConfig.setIndexType(IndexType.kTwoLevelIndexSearch);
-    altCFTableConfig.setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash);
-    altCFTableConfig.setDataBlockHashTableUtilRatio(0.65);
-    altCFTableConfig.setChecksumType(ChecksumType.kxxHash64);
-    altCFTableConfig.setNoBlockCache(true);
-    altCFTableConfig.setBlockSize(35 * 1024);
-    altCFTableConfig.setBlockSizeDeviation(20);
-    altCFTableConfig.setBlockRestartInterval(12);
-    altCFTableConfig.setIndexBlockRestartInterval(6);
-    altCFTableConfig.setMetadataBlockSize(12 * 1024);
-    altCFTableConfig.setPartitionFilters(true);
-    altCFTableConfig.setOptimizeFiltersForMemory(false);
-    altCFTableConfig.setUseDeltaEncoding(false);
-    altCFTableConfig.setFilterPolicy(new BloomFilter(7.5));
-    altCFTableConfig.setWholeKeyFiltering(false);
-    altCFTableConfig.setVerifyCompression(true);
-    altCFTableConfig.setReadAmpBytesPerBit(2);
-    altCFTableConfig.setFormatVersion(8);
-    altCFTableConfig.setEnableIndexCompression(false);
-    altCFTableConfig.setBlockAlign(true);
-    altCFTableConfig.setIndexShortening(IndexShorteningMode.kShortenSeparatorsAndSuccessor);
-    altCFTableConfig.setBlockCacheSize(3 * 1024 * 1024);
-    // Note cache objects are not set here, as they are not read back when reading config.
+        altCFOptions.setTableFormatConfig(altCFTableConfig);
 
-    altCFOptions.setTableFormatConfig(altCFTableConfig);
+        // Create a database with a new column family
+        try (final RocksDB db = RocksDB.open(options, dbPath)) {
+          assertThat(db).isNotNull();
 
-    // Create a database with a new column family
-    try (final RocksDB db = RocksDB.open(options, dbPath)) {
-      assertThat(db).isNotNull();
+          // create column family
+          try (final ColumnFamilyHandle columnFamilyHandle =
+                   db.createColumnFamily(new ColumnFamilyDescriptor(altCFName, altCFOptions))) {
+            assert (columnFamilyHandle != null);
+          }
+        }
 
-      // create column family
-      try (final ColumnFamilyHandle columnFamilyHandle =
-               db.createColumnFamily(new ColumnFamilyDescriptor(altCFName, altCFOptions))) {
-        assert (columnFamilyHandle != null);
+        // Read the options back and verify
+        final DBOptions dbOptions = new DBOptions();
+        final List<ColumnFamilyDescriptor> cfDescs = loaderUnderTest.loadOptions(dbPath, dbOptions);
+
+        assertThat(dbOptions.createIfMissing()).isEqualTo(options.createIfMissing());
+        assertThat(dbOptions.paranoidChecks()).isEqualTo(options.paranoidChecks());
+        assertThat(dbOptions.maxOpenFiles()).isEqualTo(options.maxOpenFiles());
+        assertThat(dbOptions.delayedWriteRate()).isEqualTo(options.delayedWriteRate());
+
+        assertThat(cfDescs.size()).isEqualTo(2);
+        assertThat(cfDescs.get(0)).isNotNull();
+        assertThat(cfDescs.get(1)).isNotNull();
+        assertThat(cfDescs.get(0).getName()).isEqualTo(RocksDB.DEFAULT_COLUMN_FAMILY);
+        assertThat(cfDescs.get(1).getName()).isEqualTo(altCFName);
+
+        verifyBlockBasedTableConfig(
+            cfDescs.get(0).getOptions().tableFormatConfig(), new BlockBasedTableConfig());
+        verifyBlockBasedTableConfig(
+            cfDescs.get(1).getOptions().tableFormatConfig(), altCFTableConfig);
       }
     }
-
-    // Read the options back and verify
-    final DBOptions dbOptions = new DBOptions();
-    final List<ColumnFamilyDescriptor> cfDescs = loaderUnderTest.loadOptions(dbPath, dbOptions);
-
-    assertThat(dbOptions.createIfMissing()).isEqualTo(options.createIfMissing());
-    assertThat(dbOptions.paranoidChecks()).isEqualTo(options.paranoidChecks());
-    assertThat(dbOptions.maxOpenFiles()).isEqualTo(options.maxOpenFiles());
-    assertThat(dbOptions.delayedWriteRate()).isEqualTo(options.delayedWriteRate());
-
-    assertThat(cfDescs.size()).isEqualTo(2);
-    assertThat(cfDescs.get(0)).isNotNull();
-    assertThat(cfDescs.get(1)).isNotNull();
-    assertThat(cfDescs.get(0).getName()).isEqualTo(RocksDB.DEFAULT_COLUMN_FAMILY);
-    assertThat(cfDescs.get(1).getName()).isEqualTo(altCFName);
-
-    verifyBlockBasedTableConfig(
-        cfDescs.get(0).getOptions().tableFormatConfig(), new BlockBasedTableConfig());
-    verifyBlockBasedTableConfig(cfDescs.get(1).getOptions().tableFormatConfig(), altCFTableConfig);
   }
 
   private void verifyBlockBasedTableConfig(
@@ -369,6 +373,7 @@ public class OptionsUtilTest {
     if (expected.filterPolicy() == null) {
       assertThat(actual.filterPolicy()).isNull();
     } else {
+      // TODO (AP) this test is a no-op and the true test fails
       assertThat(expected.filterPolicy().equals(actual.filterPolicy()));
     }
   }

--- a/java/src/test/java/org/rocksdb/PerfLevelTest.java
+++ b/java/src/test/java/org/rocksdb/PerfLevelTest.java
@@ -45,6 +45,7 @@ public class PerfLevelTest {
     }
     db.close();
   }
+  @SuppressWarnings("deprecation")
   @Test
   public void testForInvalidValues() {
     assertThatThrownBy(() -> db.setPerfLevel(UNINITIALIZED))

--- a/java/src/test/java/org/rocksdb/ReadOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/ReadOptionsTest.java
@@ -5,24 +5,21 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Arrays;
 import java.util.Random;
-
+import java.util.function.Consumer;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReadOptionsTest {
 
   @ClassRule
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
       new RocksNativeLibraryResource();
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void altConstructor() {
@@ -98,7 +95,7 @@ public class ReadOptionsTest {
     }
   }
 
-  @SuppressWarnings("deprecated")
+  @SuppressWarnings("deprecation")
   @Test
   public void managed() {
     try (final ReadOptions opt = new ReadOptions()) {
@@ -265,98 +262,62 @@ public class ReadOptionsTest {
 
   @Test
   public void failSetVerifyChecksumUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.setVerifyChecksums(true);
-    }
+    failOperationWithClosedOptions(options -> options.setVerifyChecksums(true));
   }
 
   @Test
   public void failVerifyChecksumUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.verifyChecksums();
-    }
+    failOperationWithClosedOptions(ReadOptions::verifyChecksums);
   }
 
   @Test
   public void failSetFillCacheUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.setFillCache(true);
-    }
+    failOperationWithClosedOptions(options -> options.setFillCache(true));
   }
 
   @Test
   public void failFillCacheUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.fillCache();
-    }
+    failOperationWithClosedOptions(ReadOptions::fillCache);
   }
 
   @Test
   public void failSetTailingUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.setTailing(true);
-    }
+    failOperationWithClosedOptions(options -> options.setTailing(true));
   }
 
   @Test
   public void failTailingUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.tailing();
-    }
+    failOperationWithClosedOptions(ReadOptions::tailing);
   }
 
   @Test
   public void failSetSnapshotUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.setSnapshot(null);
-    }
+    failOperationWithClosedOptions(options -> options.setSnapshot(null));
   }
 
   @Test
   public void failSnapshotUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.snapshot();
-    }
+    failOperationWithClosedOptions(ReadOptions::snapshot);
   }
 
   @Test
   public void failSetIterateUpperBoundUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.setIterateUpperBound(null);
-    }
+    failOperationWithClosedOptions(options -> options.setIterateUpperBound(null));
   }
 
   @Test
   public void failIterateUpperBoundUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.iterateUpperBound();
-    }
+    failOperationWithClosedOptions(ReadOptions::iterateUpperBound);
   }
 
   @Test
   public void failSetIterateLowerBoundUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.setIterateLowerBound(null);
-    }
+    failOperationWithClosedOptions(options -> options.setIterateLowerBound(null));
   }
 
   @Test
   public void failIterateLowerBoundUninitialized() {
-    try (final ReadOptions readOptions =
-             setupUninitializedReadOptions(exception)) {
-      readOptions.iterateLowerBound();
-    }
+    failOperationWithClosedOptions(ReadOptions::iterateLowerBound);
   }
 
   private ReadOptions setupUninitializedReadOptions(final ExpectedException exception) {
@@ -364,6 +325,13 @@ public class ReadOptionsTest {
     readOptions.close();
     exception.expect(AssertionError.class);
     return readOptions;
+  }
+
+  private void failOperationWithClosedOptions(Consumer<ReadOptions> operation) {
+    try (final ReadOptions readOptions = new ReadOptions()) {
+      readOptions.close();
+      assertThatThrownBy(() -> operation.accept(readOptions)).isInstanceOf(AssertionError.class);
+    }
   }
 
   private Slice buildRandomSlice() {

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -4,16 +4,15 @@
 //  (found in the LICENSE.Apache file in the root directory).
 package org.rocksdb;
 
-import org.junit.*;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.fail;
 
 import java.nio.ByteBuffer;
 import java.util.*;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 
 public class RocksDBTest {
 
@@ -434,9 +433,6 @@ public class RocksDBTest {
     }
   }
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   @Test
   public void getOutOfArrayMaxSizeValue() throws RocksDBException {
     final int numberOfValueSplits = 10;
@@ -450,21 +446,21 @@ public class RocksDBTest {
     final byte[] valueSplit = new byte[splitSize];
     final byte[] key = "key".getBytes();
 
-    thrown.expect(RocksDBException.class);
-    thrown.expectMessage("Requested array size exceeds VM limit");
-
-    // merge (numberOfValueSplits + 1) valueSplit's to get value size exceeding Integer.MAX_VALUE
-    try (final StringAppendOperator stringAppendOperator = new StringAppendOperator();
-         final Options opt = new Options()
-                 .setCreateIfMissing(true)
-                 .setMergeOperator(stringAppendOperator);
-         final RocksDB db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath())) {
-      db.put(key, valueSplit);
-      for (int i = 0; i < numberOfValueSplits; i++) {
-        db.merge(key, valueSplit);
+    assertThatThrownBy(() -> {
+      // merge (numberOfValueSplits + 1) valueSplit's to get value size exceeding Integer.MAX_VALUE
+      try (final StringAppendOperator stringAppendOperator = new StringAppendOperator();
+           final Options opt =
+               new Options().setCreateIfMissing(true).setMergeOperator(stringAppendOperator);
+           final RocksDB db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath())) {
+        db.put(key, valueSplit);
+        for (int i = 0; i < numberOfValueSplits; i++) {
+          db.merge(key, valueSplit);
+        }
+        db.get(key);
       }
-      db.get(key);
-    }
+    })
+        .isInstanceOf(RocksDBException.class)
+        .hasMessageContaining("Requested array size exceeds VM limit");
   }
 
   @Test
@@ -1665,6 +1661,7 @@ public class RocksDBTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void deprecated_deleteFile() throws RocksDBException {
     try (final Options options = new Options().setCreateIfMissing(true)) {

--- a/java/src/test/java/org/rocksdb/TransactionTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionTest.java
@@ -198,6 +198,7 @@ public class TransactionTest extends AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void multiGetForUpdate_cf_conflict() throws RocksDBException {
     final byte[][] keys = new byte[][] {"key1".getBytes(UTF_8), "key2".getBytes(UTF_8)};
@@ -275,6 +276,7 @@ public class TransactionTest extends AbstractTransactionTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void multiGetForUpdate_conflict() throws RocksDBException {
     final byte[][] keys = new byte[][] {"key1".getBytes(UTF_8), "key2".getBytes(UTF_8)};


### PR DESCRIPTION
- Suppress deprecation in tests of deprecated methods
- Missing Javadoc elements - @param, @returns
- try with resources around AutoCloseable
- Deprecated unit test features (replace ExpectedException)