### PR TITLE
Bring back the ability to leverage the primary key in secondary indices

### DIFF
--- a/unreleased_history/public_api_changes/secondary_index_primary_key.md
+++ b/unreleased_history/public_api_changes/secondary_index_primary_key.md
@@ -1,0 +1,1 @@
+Added back the ability to leverage the primary key when building secondary index entries. This involved changes to the signatures of `SecondaryIndex::GetSecondary{KeyPrefix,Value}` as well as the addition of a new method `SecondaryIndex::FinalizeSecondaryKeyPrefix`. See the API comments for more details.

--- a/utilities/secondary_index/faiss_ivf_index.cc
+++ b/utilities/secondary_index/faiss_ivf_index.cc
@@ -390,7 +390,7 @@ Status FaissIVFIndex::UpdatePrimaryColumnValue(
 }
 
 Status FaissIVFIndex::GetSecondaryKeyPrefix(
-    const Slice& primary_column_value,
+    const Slice& /* primary_key */, const Slice& primary_column_value,
     std::variant<Slice, std::string>* secondary_key_prefix) const {
   assert(secondary_key_prefix);
 
@@ -404,8 +404,14 @@ Status FaissIVFIndex::GetSecondaryKeyPrefix(
   return Status::OK();
 }
 
+Status FaissIVFIndex::FinalizeSecondaryKeyPrefix(
+    std::variant<Slice, std::string>* /* secondary_key_prefix */) const {
+  return Status::OK();
+}
+
 Status FaissIVFIndex::GetSecondaryValue(
-    const Slice& primary_column_value, const Slice& original_column_value,
+    const Slice& /* primary_key */, const Slice& primary_column_value,
+    const Slice& original_column_value,
     std::optional<std::variant<Slice, std::string>>* secondary_value) const {
   assert(secondary_value);
 

--- a/utilities/secondary_index/faiss_ivf_index.h
+++ b/utilities/secondary_index/faiss_ivf_index.h
@@ -35,10 +35,14 @@ class FaissIVFIndex : public SecondaryIndex {
       const override;
 
   Status GetSecondaryKeyPrefix(
-      const Slice& primary_column_value,
+      const Slice& primary_key, const Slice& primary_column_value,
       std::variant<Slice, std::string>* secondary_key_prefix) const override;
 
-  Status GetSecondaryValue(const Slice& primary_column_value,
+  Status FinalizeSecondaryKeyPrefix(
+      std::variant<Slice, std::string>* secondary_key_prefix) const override;
+
+  Status GetSecondaryValue(const Slice& primary_key,
+                           const Slice& primary_column_value,
                            const Slice& original_column_value,
                            std::optional<std::variant<Slice, std::string>>*
                                secondary_value) const override;

--- a/utilities/secondary_index/secondary_index_iterator.h
+++ b/utilities/secondary_index/secondary_index_iterator.h
@@ -46,9 +46,9 @@ class SecondaryIndexIterator : public Iterator {
   void Seek(const Slice& target) override {
     status_ = Status::OK();
 
-    std::variant<Slice, std::string> prefix;
+    std::variant<Slice, std::string> prefix = target;
 
-    const Status s = index_->GetSecondaryKeyPrefix(target, &prefix);
+    const Status s = index_->FinalizeSecondaryKeyPrefix(&prefix);
     if (!s.ok()) {
       status_ = s;
       return;

--- a/utilities/secondary_index/secondary_index_mixin.h
+++ b/utilities/secondary_index/secondary_index_mixin.h
@@ -232,10 +232,20 @@ class SecondaryIndexMixin : public Txn {
 
     std::variant<Slice, std::string> secondary_key_prefix;
 
-    const Status s = secondary_index->GetSecondaryKeyPrefix(
-        existing_primary_column_value, &secondary_key_prefix);
-    if (!s.ok()) {
-      return s;
+    {
+      const Status s = secondary_index->GetSecondaryKeyPrefix(
+          primary_key, existing_primary_column_value, &secondary_key_prefix);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+
+    {
+      const Status s =
+          secondary_index->FinalizeSecondaryKeyPrefix(&secondary_key_prefix);
+      if (!s.ok()) {
+        return s;
+      }
     }
 
     const std::string secondary_key =
@@ -276,7 +286,15 @@ class SecondaryIndexMixin : public Txn {
 
     {
       const Status s = secondary_index->GetSecondaryKeyPrefix(
-          primary_column_value, &secondary_key_prefix);
+          primary_key, primary_column_value, &secondary_key_prefix);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+
+    {
+      const Status s =
+          secondary_index->FinalizeSecondaryKeyPrefix(&secondary_key_prefix);
       if (!s.ok()) {
         return s;
       }
@@ -286,7 +304,8 @@ class SecondaryIndexMixin : public Txn {
 
     {
       const Status s = secondary_index->GetSecondaryValue(
-          primary_column_value, previous_column_value, &secondary_value);
+          primary_key, primary_column_value, previous_column_value,
+          &secondary_value);
       if (!s.ok()) {
         return s;
       }


### PR DESCRIPTION
Summary: There are actually some use cases which would benefit from the ability to use the primary key when forming the secondary key prefix or value. One such use case, which is demonstrated using a unit test, is building a secondary index on non-initial part(s) of the primary key. The patch adds back this ability, which was was removed in https://github.com/facebook/rocksdb/pull/13207, with a twist: the earlier `GetSecondaryKeyPrefix` is essentially split into two parts, with `GetSecondaryKeyPrefix` now being responsible only for computing whatever the secondary index is built on (let's call this "index function result") and a new `FinalizeSecondaryKeyPrefix` method having the responsibility of dealing with serialization concerns like adding a length indicator for disambiguation. This also means a slight change for the `SecondaryIndexIterator` class: it now treats its `Seek` argument as an "index function result" and thus only calls the new `FinalizeSecondaryKeyPrefix` on it (but not `GetSecondaryKeyPrefix`).

Differential Revision: D68514201


