### PR TITLE
Allow for Customizable DB Open Hooks for DB Bench

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -407,6 +407,7 @@ cpp_library_wrapper(name="rocksdb_tools_lib", srcs=[
         "tools/block_cache_analyzer/block_cache_trace_analyzer.cc",
         "tools/db_bench_tool.cc",
         "tools/simulated_hybrid_file_system.cc",
+        "tools/tool_hooks.cc",
         "tools/trace_analyzer_tool.cc",
     ], deps=[":rocksdb_lib"], headers=[], link_whole=False, extra_test_libs=False)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1572,6 +1572,7 @@ if(WITH_BENCHMARK_TOOLS)
   add_executable(db_bench${ARTIFACT_SUFFIX}
     tools/simulated_hybrid_file_system.cc
     tools/db_bench.cc
+    tools/tool_hooks.cc
     tools/db_bench_tool.cc)
   target_link_libraries(db_bench${ARTIFACT_SUFFIX}
     ${ROCKSDB_LIB} ${THIRDPARTY_LIBS})

--- a/include/rocksdb/db_bench_tool.h
+++ b/include/rocksdb/db_bench_tool.h
@@ -5,7 +5,8 @@
 #pragma once
 
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/tool_hooks.h"
 
 namespace ROCKSDB_NAMESPACE {
-int db_bench_tool(int argc, char** argv);
+int db_bench_tool(int argc, char** argv, ToolHooks& hooks = defaultHooks);
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/tool_hooks.h
+++ b/include/rocksdb/tool_hooks.h
@@ -1,0 +1,124 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include "rocksdb/db.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+struct TransactionDBOptions;
+class TransactionDB;
+class OptimisticTransactionDB;
+
+namespace blob_db {
+struct BlobDBOptions;
+class BlobDB;
+}  // namespace blob_db
+
+/*
+ * ToolHooks is currently a WORK IN PROGRESS, API is subject to change.
+ * ToolHooks is a class that allows users to override the default behavior of
+ * the various OpenDB calls used by db_bench_tool.  This allows users to easily
+ * extend the functionality of db_bench_tool to support their own open
+ * implementations.
+ */
+class ToolHooks {
+ public:
+  ToolHooks() = default;
+  virtual ~ToolHooks() = default;
+  virtual Status Open(const Options& db_options, const std::string& name,
+                      DB** dbptr) = 0;
+  virtual Status Open(
+      const DBOptions& db_options, const std::string& name,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr) = 0;
+  virtual Status OpenForReadOnly(const Options& options,
+                                 const std::string& name, DB** dbptr,
+                                 bool error_if_wal_file_exists) = 0;
+  virtual Status OpenForReadOnly(
+      const Options& options, const std::string& name,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr) = 0;
+  virtual Status OpenTransactionDB(const Options& db_options,
+                                   const TransactionDBOptions& txn_db_options,
+                                   const std::string& dbname,
+                                   TransactionDB** dbptr) = 0;
+  virtual Status OpenTransactionDB(
+      const DBOptions& db_options, const TransactionDBOptions& txn_db_options,
+      const std::string& dbname,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles, TransactionDB** dbptr) = 0;
+  virtual Status OpenOptimisticTransactionDB(
+      const Options& options, const std::string& dbname,
+      OptimisticTransactionDB** dbptr) = 0;
+  virtual Status OpenOptimisticTransactionDB(
+      const DBOptions& db_options, const std::string& dbname,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles,
+      OptimisticTransactionDB** dbptr) = 0;
+  virtual Status OpenAsSecondary(const Options& options,
+                                 const std::string& name,
+                                 const std::string& secondary_path,
+                                 DB** dbptr) = 0;
+  virtual Status OpenAsFollower(const Options& options, const std::string& name,
+                                const std::string& leader_path,
+                                std::unique_ptr<DB>* dbptr) = 0;
+  virtual Status Open(const Options& options,
+                      const blob_db::BlobDBOptions& bdb_options,
+                      const std::string& dbname, blob_db::BlobDB** blob_db) = 0;
+};
+
+class DefaultHooks : public ToolHooks {
+ public:
+  DefaultHooks() = default;
+  ~DefaultHooks() override = default;
+  virtual Status Open(const Options& db_options, const std::string& name,
+                      DB** dbptr) override;
+  virtual Status Open(
+      const DBOptions& db_options, const std::string& name,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr) override;
+  virtual Status OpenForReadOnly(const Options& options,
+                                 const std::string& name, DB** dbptr,
+                                 bool error_if_wal_file_exists) override;
+  virtual Status OpenForReadOnly(
+      const Options& options, const std::string& name,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr) override;
+  virtual Status OpenTransactionDB(const Options& db_options,
+                                   const TransactionDBOptions& txn_db_options,
+                                   const std::string& dbname,
+                                   TransactionDB** dbptr) override;
+  virtual Status OpenTransactionDB(
+      const DBOptions& db_options, const TransactionDBOptions& txn_db_options,
+      const std::string& dbname,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles,
+      TransactionDB** dbptr) override;
+  virtual Status OpenOptimisticTransactionDB(
+      const Options& options, const std::string& dbname,
+      OptimisticTransactionDB** dbptr) override;
+  virtual Status OpenOptimisticTransactionDB(
+      const DBOptions& db_options, const std::string& dbname,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles,
+      OptimisticTransactionDB** dbptr) override;
+  virtual Status OpenAsSecondary(const Options& options,
+                                 const std::string& name,
+                                 const std::string& secondary_path,
+                                 DB** dbptr) override;
+  virtual Status OpenAsFollower(const Options& options, const std::string& name,
+                                const std::string& leader_path,
+                                std::unique_ptr<DB>* dbptr) override;
+  virtual Status Open(const Options& options,
+                      const blob_db::BlobDBOptions& bdb_options,
+                      const std::string& dbname,
+                      blob_db::BlobDB** blob_db) override;
+};
+
+extern DefaultHooks defaultHooks;
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/src.mk
+++ b/src.mk
@@ -111,7 +111,7 @@ LIB_SOURCES =                                                   \
   env/env_encryption.cc                                         \
   env/env_posix.cc                                              \
   env/file_system.cc                                            \
-  env/fs_on_demand.cc                                               \
+  env/fs_on_demand.cc                                           \
   env/fs_posix.cc                                               \
   env/fs_remap.cc                                               \
   env/file_system_tracer.cc                                     \
@@ -235,7 +235,7 @@ LIB_SOURCES =                                                   \
   trace_replay/trace_replay.cc                                  \
   trace_replay/block_cache_tracer.cc                            \
   trace_replay/io_tracer.cc                                     \
-  util/async_file_reader.cc					\
+  util/async_file_reader.cc					                            \
   util/build_version.cc                                         \
   util/cleanable.cc                                             \
   util/coding.cc                                                \
@@ -377,12 +377,13 @@ MOCK_LIB_SOURCES =                                              \
 
 BENCH_LIB_SOURCES =                                             \
   tools/db_bench_tool.cc                                        \
+  tools/tool_hooks.cc                                           \
   tools/simulated_hybrid_file_system.cc                         \
 
-CACHE_BENCH_LIB_SOURCES =					\
+CACHE_BENCH_LIB_SOURCES =					                              \
   cache/cache_bench_tool.cc                                     \
 
-STRESS_LIB_SOURCES =                                            \
+STRESS_LIB_SOURCES =                                           \
   db_stress_tool/batched_ops_stress.cc                         \
   db_stress_tool/cf_consistency_stress.cc                      \
   db_stress_tool/db_stress_common.cc                           \
@@ -407,7 +408,7 @@ TEST_LIB_SOURCES =                                              \
   test_util/secondary_cache_test_util.cc                        \
   test_util/testharness.cc                                      \
   test_util/testutil.cc                                         \
-  utilities/agg_merge/test_agg_merge.cc                                 \
+  utilities/agg_merge/test_agg_merge.cc                         \
   utilities/cassandra/test_utils.cc                             \
 
 FOLLY_SOURCES =                                                 \
@@ -444,14 +445,13 @@ BENCH_MAIN_SOURCES =                                                    \
   tools/db_bench.cc                                                     \
   util/filter_bench.cc                                                  \
   utilities/persistent_cache/persistent_cache_bench.cc                  \
-  #util/log_write_bench.cc                                               \
 
 TEST_MAIN_SOURCES =                                                     \
   cache/cache_test.cc                                                   \
   cache/cache_reservation_manager_test.cc                               \
   cache/compressed_secondary_cache_test.cc                              \
   cache/lru_cache_test.cc                                               \
-  cache/tiered_secondary_cache_test.cc					\
+  cache/tiered_secondary_cache_test.cc					                        \
   db/blob/blob_counting_iterator_test.cc                                \
   db/blob/blob_file_addition_test.cc                                    \
   db/blob/blob_file_builder_test.cc                                     \
@@ -485,7 +485,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/db_dynamic_level_test.cc                                           \
   db/db_encryption_test.cc                                              \
   db/db_flush_test.cc                                                   \
-  db/db_follower_test.cc						\
+  db/db_follower_test.cc						                                    \
   db/db_readonly_with_timestamp_test.cc                                 \
   db/db_with_timestamp_basic_test.cc                                    \
   db/import_column_family_test.cc                                       \
@@ -652,15 +652,15 @@ TEST_MAIN_SOURCES =                                                     \
   utilities/util_merge_operators_test.cc                                \
   utilities/write_batch_with_index/write_batch_with_index_test.cc       \
 
-TEST_MAIN_SOURCES_C = \
+TEST_MAIN_SOURCES_C =                                                   \
   db/c_test.c                                                           \
 
-WITH_FAISS_TEST_MAIN_SOURCES = \
+WITH_FAISS_TEST_MAIN_SOURCES =                                          \
   utilities/secondary_index/faiss_ivf_index_test.cc                     \
 
 MICROBENCH_SOURCES =                                          \
   microbench/ribbon_bench.cc                                  \
-  microbench/db_basic_bench.cc                                  \
+  microbench/db_basic_bench.cc                                \
 
 JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/backupenginejni.cc                            \

--- a/tools/tool_hooks.cc
+++ b/tools/tool_hooks.cc
@@ -1,0 +1,94 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/tool_hooks.h"
+
+#include "rocksdb/convenience.h"
+#include "rocksdb/db.h"
+#include "rocksdb/options.h"
+#include "rocksdb/utilities/optimistic_transaction_db.h"
+#include "rocksdb/utilities/options_type.h"
+#include "rocksdb/utilities/transaction_db.h"
+#include "utilities/blob_db/blob_db.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+Status DefaultHooks::Open(const Options& db_options, const std::string& name,
+                          DB** dbptr) {
+  return DB::Open(db_options, name, dbptr);
+};
+
+Status DefaultHooks::Open(
+    const DBOptions& db_options, const std::string& name,
+    const std::vector<ColumnFamilyDescriptor>& column_families,
+    std::vector<ColumnFamilyHandle*>* handles, DB** dbptr) {
+  return DB::Open(db_options, name, column_families, handles, dbptr);
+};
+
+Status DefaultHooks::OpenForReadOnly(const Options& options,
+                                     const std::string& name, DB** dbptr,
+                                     bool error_if_wal_file_exists = false) {
+  return DB::OpenForReadOnly(options, name, dbptr, error_if_wal_file_exists);
+};
+
+Status DefaultHooks::OpenForReadOnly(
+    const Options& options, const std::string& name,
+    const std::vector<ColumnFamilyDescriptor>& column_families,
+    std::vector<ColumnFamilyHandle*>* handles, DB** dbptr) {
+  return DB::OpenForReadOnly(options, name, column_families, handles, dbptr);
+};
+Status DefaultHooks::OpenTransactionDB(
+    const Options& db_options, const TransactionDBOptions& txn_db_options,
+    const std::string& dbname, TransactionDB** dbptr) {
+  return TransactionDB::Open(db_options, txn_db_options, dbname, dbptr);
+};
+
+Status DefaultHooks::OpenTransactionDB(
+    const DBOptions& db_options, const TransactionDBOptions& txn_db_options,
+    const std::string& dbname,
+    const std::vector<ColumnFamilyDescriptor>& column_families,
+    std::vector<ColumnFamilyHandle*>* handles, TransactionDB** dbptr) {
+  return TransactionDB::Open(db_options, txn_db_options, dbname,
+                             column_families, handles, dbptr);
+};
+
+Status DefaultHooks::OpenOptimisticTransactionDB(
+    const Options& options, const std::string& dbname,
+    OptimisticTransactionDB** dbptr) {
+  return OptimisticTransactionDB::Open(options, dbname, dbptr);
+};
+
+Status DefaultHooks::OpenOptimisticTransactionDB(
+    const DBOptions& db_options, const std::string& dbname,
+    const std::vector<ColumnFamilyDescriptor>& column_families,
+    std::vector<ColumnFamilyHandle*>* handles,
+    OptimisticTransactionDB** dbptr) {
+  return OptimisticTransactionDB::Open(db_options, dbname, column_families,
+                                       handles, dbptr);
+}
+
+Status DefaultHooks::OpenAsSecondary(const Options& options,
+                                     const std::string& name,
+                                     const std::string& secondary_path,
+                                     DB** dbptr) {
+  return DB::OpenAsSecondary(options, name, secondary_path, dbptr);
+}
+Status DefaultHooks::OpenAsFollower(const Options& options,
+                                    const std::string& name,
+                                    const std::string& leader_path,
+                                    std::unique_ptr<DB>* dbptr) {
+  return DB::OpenAsFollower(options, name, leader_path, dbptr);
+};
+
+Status DefaultHooks::Open(const Options& options,
+                          const blob_db::BlobDBOptions& bdb_options,
+                          const std::string& dbname,
+                          blob_db::BlobDB** blob_db) {
+  return blob_db::BlobDB::Open(options, bdb_options, dbname, blob_db);
+}
+
+DefaultHooks defaultHooks;
+
+}  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: This diff introduces ToolHooks, a class which allows for users to interpose their own set of logic for various functionality with db_bench_tool (i.e., various OpenDB implementations).

Differential Revision: D67868126


