### PR TITLE
Add a public factory method for SecondaryIndexIterator

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -317,6 +317,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "utilities/persistent_cache/block_cache_tier_metadata.cc",
         "utilities/persistent_cache/persistent_cache_tier.cc",
         "utilities/persistent_cache/volatile_tier_impl.cc",
+        "utilities/secondary_index/secondary_index_iterator.cc",
         "utilities/simulator_cache/cache_simulator.cc",
         "utilities/simulator_cache/sim_cache.cc",
         "utilities/table_properties_collectors/compact_for_tiering_collector.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -939,6 +939,7 @@ set(SOURCES
         utilities/persistent_cache/block_cache_tier_metadata.cc
         utilities/persistent_cache/persistent_cache_tier.cc
         utilities/persistent_cache/volatile_tier_impl.cc
+        utilities/secondary_index/secondary_index_iterator.cc
         utilities/simulator_cache/cache_simulator.cc
         utilities/simulator_cache/sim_cache.cc
         utilities/table_properties_collectors/compact_for_tiering_collector.cc

--- a/include/rocksdb/utilities/secondary_index.h
+++ b/include/rocksdb/utilities/secondary_index.h
@@ -138,4 +138,12 @@ class SecondaryIndex {
       std::unique_ptr<Iterator>&& underlying_it) const = 0;
 };
 
+// Create a simple secondary index iterator that can be used to query an index,
+// i.e. find the primary keys for a given search target. Can be used as-is or as
+// a building block for more complex iterators. The returned iterator supports
+// Seek/Next/Prev but not SeekToFirst/SeekToLast/SeekForPrev, and exposes
+// primary keys. See also SecondaryIndex::NewIterator above.
+std::unique_ptr<Iterator> NewSecondaryIndexIterator(
+    const SecondaryIndex* index, std::unique_ptr<Iterator>&& underlying_it);
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/src.mk
+++ b/src.mk
@@ -304,6 +304,7 @@ LIB_SOURCES =                                                   \
   utilities/persistent_cache/block_cache_tier_metadata.cc       \
   utilities/persistent_cache/persistent_cache_tier.cc           \
   utilities/persistent_cache/volatile_tier_impl.cc              \
+  utilities/secondary_index/secondary_index_iterator.cc         \
   utilities/simulator_cache/cache_simulator.cc                  \
   utilities/simulator_cache/sim_cache.cc                        \
   utilities/table_properties_collectors/compact_for_tiering_collector.cc \

--- a/utilities/secondary_index/faiss_ivf_index.cc
+++ b/utilities/secondary_index/faiss_ivf_index.cc
@@ -457,8 +457,7 @@ std::unique_ptr<Iterator> FaissIVFIndex::NewIterator(
   }
 
   return std::make_unique<KNNIterator>(
-      index_.get(),
-      std::make_unique<SecondaryIndexIterator>(this, std::move(underlying_it)),
+      index_.get(), NewSecondaryIndexIterator(this, std::move(underlying_it)),
       *read_options.similarity_search_neighbors,
       *read_options.similarity_search_probes);
 }

--- a/utilities/secondary_index/secondary_index_iterator.cc
+++ b/utilities/secondary_index/secondary_index_iterator.cc
@@ -1,0 +1,21 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "utilities/secondary_index/secondary_index_iterator.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+std::unique_ptr<Iterator> NewSecondaryIndexIterator(
+    const SecondaryIndex* index, std::unique_ptr<Iterator>&& underlying_it) {
+  if (!underlying_it) {
+    return std::unique_ptr<Iterator>(NewErrorIterator(
+        Status::InvalidArgument("Underlying iterator must be provided")));
+  }
+
+  return std::make_unique<SecondaryIndexIterator>(index,
+                                                  std::move(underlying_it));
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -8080,8 +8080,7 @@ TEST_P(TransactionTest, SecondaryIndexPutDelete) {
     std::unique_ptr<Iterator> NewIterator(
         const SecondaryIndexReadOptions& /* read_options */,
         std::unique_ptr<Iterator>&& underlying_it) const override {
-      return std::make_unique<SecondaryIndexIterator>(this,
-                                                      std::move(underlying_it));
+      return NewSecondaryIndexIterator(this, std::move(underlying_it));
     }
 
    private:
@@ -8456,8 +8455,7 @@ TEST_P(TransactionTest, SecondaryIndexPutEntity) {
     std::unique_ptr<Iterator> NewIterator(
         const SecondaryIndexReadOptions& /* read_options */,
         std::unique_ptr<Iterator>&& underlying_it) const override {
-      return std::make_unique<SecondaryIndexIterator>(this,
-                                                      std::move(underlying_it));
+      return NewSecondaryIndexIterator(this, std::move(underlying_it));
     }
 
    private:
@@ -8830,8 +8828,7 @@ TEST_P(TransactionTest, SecondaryIndexOnKey) {
     std::unique_ptr<Iterator> NewIterator(
         const SecondaryIndexReadOptions& /* read_options */,
         std::unique_ptr<Iterator>&& underlying_it) const override {
-      return std::make_unique<SecondaryIndexIterator>(this,
-                                                      std::move(underlying_it));
+      return NewSecondaryIndexIterator(this, std::move(underlying_it));
     }
 
    private:


### PR DESCRIPTION
Summary: The patch adds a public API method `NewSecondaryIndexIterator` that can be leveraged by users providing their own `SecondaryIndex` implementations.

Differential Revision: D68569198


