### PR TITLE
Add a couple of convenience methods for converting embeddings

### DIFF
--- a/include/rocksdb/utilities/secondary_index_faiss.h
+++ b/include/rocksdb/utilities/secondary_index_faiss.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/utilities/secondary_index.h"
 
 namespace faiss {
@@ -28,5 +29,25 @@ namespace ROCKSDB_NAMESPACE {
 // SecondaryIndexReadOptions).
 std::unique_ptr<SecondaryIndex> NewFaissIVFIndex(
     std::unique_ptr<faiss::IndexIVF>&& index, std::string primary_column_name);
+
+// Helper methods to convert embeddings from a span of floats to Slice or vice
+// versa
+
+// Convert the given span of floats of size dim to a Slice.
+// PRE: embedding points to a contiguous span of floats of size dim
+inline Slice ConvertFloatsToSlice(const float* embedding, size_t dim) {
+  return Slice(reinterpret_cast<const char*>(embedding), dim * sizeof(float));
+}
+
+// Convert the given Slice to a span of floats of size dim.
+// PRE: embedding.size() == dim * sizeof(float)
+// Returns nullptr if the precondition is violated.
+inline const float* ConvertSliceToFloats(const Slice& embedding, size_t dim) {
+  if (embedding.size() != dim * sizeof(float)) {
+    return nullptr;
+  }
+
+  return reinterpret_cast<const float*>(embedding.data());
+}
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: The patch adds two convenience methods `ConvertFloatsToSlice` and `ConvertSliceToFloats` that can be used to convert embeddings from a contiguous range of floats to a RocksDB `Slice` or vice versa. The methods are added to the public API so they can be utilized by applications as well.

Differential Revision: D68581494


