### PR TITLE
Call delete on secondary_db_ wherever it is done on db_

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -119,6 +119,7 @@ void StressTest::CleanUp() {
   }
   secondary_cfhs_.clear();
   delete secondary_db_;
+  secondary_db_ = nullptr;
 }
 
 std::shared_ptr<Cache> StressTest::NewCache(size_t capacity,
@@ -742,6 +743,8 @@ void StressTest::PreloadDbAndReopenAsReadOnly(int64_t number_of_keys,
     db_ = nullptr;
     txn_db_ = nullptr;
     optimistic_txn_db_ = nullptr;
+    delete secondary_db_;
+    secondary_db_ = nullptr;
 
     db_preload_finished_.store(true);
     auto now = clock_->NowMicros();
@@ -3584,6 +3587,8 @@ void StressTest::Open(SharedState* shared, bool reopen) {
               column_families_.clear();
               delete db_;
               db_ = nullptr;
+              delete secondary_db_;
+              secondary_db_ = nullptr;
             }
           }
           if (!s.ok()) {
@@ -3790,6 +3795,8 @@ void StressTest::Reopen(ThreadState* thread) {
   db_ = nullptr;
   txn_db_ = nullptr;
   optimistic_txn_db_ = nullptr;
+  delete secondary_db_;
+  secondary_db_ = nullptr;
 
   num_times_reopened_++;
   auto now = clock_->NowMicros();


### PR DESCRIPTION
# Summary

#13281 added support to the crash tests for secondary DB verification.

I looked at our recurring crash tests to see what impact #13281 had. The actual secondary verification looks okay to me (no `assert` failures), but I noticed memory leaks were detected.

The problematic areas were tracked down to the call to `DB::OpenAsSecondary` from `rocksdb::StressTest::Open`.

# Test Plan

Monitor recurring crash tests. It is likely hard to reproduce the ASAN failures locally if they are rare enough.

```
make -j100 db_stress COMPILE_WITH_ASAN=1
python3 tools/db_crashtest.py --simple blackbox --test_secondary=1
```
