### PR TITLE
Force a primary flush before secondary verification when WAL is disabled or manual_wal_flush is set

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -170,14 +170,17 @@ class NonBatchedOpsStressTest : public StressTest {
                 shared->Get(static_cast<int>(cf), i));
           }
 
-          Status s = db_->Flush(FlushOptions(), column_families_[cf]);
-          if (!s.ok()) {
-            VerificationAbort(
-                shared,
-                "Failed to flush primary before secondary verification");
+          if (FLAGS_disable_wal) {
+            Status flush_status =
+                db_->Flush(FlushOptions(), column_families_[cf]);
+            if (!flush_status.ok()) {
+              VerificationAbort(
+                  shared,
+                  "Failed to flush primary before secondary verification");
+            }
           }
 
-          s = secondary_db_->TryCatchUpWithPrimary();
+          Status s = secondary_db_->TryCatchUpWithPrimary();
           if (!s.ok()) {
             VerificationAbort(shared,
                               "Secondary failed to catch up to the primary");

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -170,7 +170,14 @@ class NonBatchedOpsStressTest : public StressTest {
                 shared->Get(static_cast<int>(cf), i));
           }
 
-          Status s = secondary_db_->TryCatchUpWithPrimary();
+          Status s = db_->Flush(FlushOptions(), column_families_[cf]);
+          if (!s.ok()) {
+            VerificationAbort(
+                shared,
+                "Failed to flush primary before secondary verification");
+          }
+
+          s = secondary_db_->TryCatchUpWithPrimary();
           if (!s.ok()) {
             VerificationAbort(shared,
                               "Secondary failed to catch up to the primary");


### PR DESCRIPTION
# Summary

#13281 added support for verifying secondaries in the crash tests. We are trying to check that the values returned by the secondary in `Get` requests fall within an expected range of values. We do reads from the shared expected state before and after we read from the secondary. This confirms that the value returned by the secondary is from some time range `t_1` to `t_2`.

There are some _rare_ verification failures where `VerifyValueRange` fails with `Unexpected value found outside of the value base range`. 

It is possible there is a bug in the secondary database code, but if the tests themselves are the issue, I have some ideas on what the root cause could be. The secondary can read the WAL, MANIFEST, and SST files, but in certain scenarios some of these pieces may not be present.

Changes made:
1. I noticed that the failures had `manual_wal_flush_one_in=1000`, which means that `options.manual_wal_flush` is set to `true`. With this setting, RocksDB has its own internal buffers that need to be manually flushed for the WAL to be persisted.
2. Although the test failures I looked at did not disable the WAL, I realized that, when the WAL is disabled, we should flush the primary's memtables, since the secondary needs to be able to find SST files to fully catch up.
3. Injected faults further complicate matters, so I have a check to skip secondary verification whenever the WAL or memtable flushes fail due to fault injection.

# Test Plan

Locally:
```
python3 tools/db_crashtest.py --simple blackbox --test_secondary=1
python3 tools/db_crashtest.py --simple whitebox --test_secondary=1
python3 tools/db_crashtest.py --simple blackbox --test_secondary=1 --disable_wal=1
python3 tools/db_crashtest.py --simple blackbox --test_secondary=1 --disable_wal=0 --manual_wal_flush_one_in=1000
```

I will monitor the recurring crash tests after this gets merged.
