### PR TITLE
Fix GetMergeOperands in ReadOnlyDB and SecondaryDB

### DIFF
--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -32,7 +32,8 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
                                const Slice& key,
                                GetImplOptions& get_impl_options) {
   assert(get_impl_options.value != nullptr ||
-         get_impl_options.columns != nullptr);
+         get_impl_options.columns != nullptr ||
+         get_impl_options.merge_operands != nullptr);
   assert(get_impl_options.column_family);
 
   Status s;
@@ -86,7 +87,11 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
       return s;
     }
   }
+  // Prepare to store a list of merge operations if merge occurs.
   MergeContext merge_context;
+  // TODO - Large Result Optimization for Read Only DB
+  // (https://github.com/facebook/rocksdb/pull/10458)
+
   SequenceNumber max_covering_tombstone_seq = 0;
   LookupKey lkey(key, snapshot, read_options.timestamp);
   PERF_TIMER_STOP(get_snapshot_time);
@@ -98,9 +103,6 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
           get_impl_options.columns, ts, &s, &merge_context,
           &max_covering_tombstone_seq, read_options,
           false /* immutable_memtable */, &read_cb)) {
-    if (get_impl_options.value) {
-      get_impl_options.value->PinSelf();
-    }
     RecordTick(stats_, MEMTABLE_HIT);
   } else {
     PERF_TIMER_GUARD(get_from_output_files_time);
@@ -118,9 +120,18 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
     RecordTick(stats_, NUMBER_KEYS_READ);
     size_t size = 0;
     if (get_impl_options.value) {
+      get_impl_options.value->PinSelf();
       size = get_impl_options.value->size();
     } else if (get_impl_options.columns) {
       size = get_impl_options.columns->serialized_size();
+    } else if (get_impl_options.merge_operands) {
+      *get_impl_options.number_of_operands =
+          static_cast<int>(merge_context.GetNumOperands());
+      for (const Slice& sl : merge_context.GetOperands()) {
+        size += sl.size();
+        get_impl_options.merge_operands->PinSelf(sl);
+        get_impl_options.merge_operands++;
+      }
     }
     RecordTick(stats_, BYTES_READ, size);
     RecordInHistogram(stats_, BYTES_PER_READ, size);

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -103,6 +103,9 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
           get_impl_options.columns, ts, &s, &merge_context,
           &max_covering_tombstone_seq, read_options,
           false /* immutable_memtable */, &read_cb)) {
+    if (get_impl_options.value) {
+      get_impl_options.value->PinSelf();
+    }
     RecordTick(stats_, MEMTABLE_HIT);
   } else {
     PERF_TIMER_GUARD(get_from_output_files_time);
@@ -120,7 +123,6 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
     RecordTick(stats_, NUMBER_KEYS_READ);
     size_t size = 0;
     if (get_impl_options.value) {
-      get_impl_options.value->PinSelf();
       size = get_impl_options.value->size();
     } else if (get_impl_options.columns) {
       size = get_impl_options.columns->serialized_size();

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -414,6 +414,9 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
           &max_covering_tombstone_seq, read_options,
           false /* immutable_memtable */, &read_cb)) {
     done = true;
+    if (get_impl_options.value) {
+      get_impl_options.value->PinSelf();
+    }
     RecordTick(stats_, MEMTABLE_HIT);
   } else if ((s.ok() || s.IsMergeInProgress()) &&
              super_version->imm->Get(
@@ -423,6 +426,9 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
                  get_impl_options.columns, ts, &s, &merge_context,
                  &max_covering_tombstone_seq, read_options, &read_cb)) {
     done = true;
+    if (get_impl_options.value) {
+      get_impl_options.value->PinSelf();
+    }
     RecordTick(stats_, MEMTABLE_HIT);
   }
   if (!done && !s.ok() && !s.IsMergeInProgress()) {
@@ -446,7 +452,6 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
     RecordTick(stats_, NUMBER_KEYS_READ);
     size_t size = 0;
     if (get_impl_options.value) {
-      get_impl_options.value->PinSelf();
       size = get_impl_options.value->size();
     } else if (get_impl_options.columns) {
       size = get_impl_options.columns->serialized_size();

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -14,7 +14,6 @@
 #include "rocksdb/utilities/transaction_db.h"
 #include "test_util/sync_point.h"
 #include "test_util/testutil.h"
-#include "utilities/fault_injection_env.h"
 #include "utilities/merge_operators/string_append/stringappend2.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -355,7 +354,6 @@ TEST_F(DBSecondaryTest, GetMergeOperands) {
 
   auto cfh = db_secondary_->DefaultColumnFamily();
 
-  // s.IsMergeInProgress()
   const Status s = db_secondary_->GetMergeOperands(
       ReadOptions(), cfh, "k1", values.data(), &merge_operands_info,
       &number_of_operands);

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -15,9 +15,9 @@
 #include "test_util/sync_point.h"
 #include "test_util/testutil.h"
 #include "utilities/fault_injection_env.h"
+#include "utilities/merge_operators/string_append/stringappend2.h"
 
 namespace ROCKSDB_NAMESPACE {
-
 class DBSecondaryTestBase : public DBBasicTestWithTimestampBase {
  public:
   explicit DBSecondaryTestBase(const std::string& dbname)
@@ -329,6 +329,44 @@ TEST_F(DBSecondaryTest, InternalCompactionMultiLevels) {
   // if files is missing.
   //  ASSERT_OK(db_secondary_full()->TEST_CompactWithoutInstallation(OpenAndCompactOptions(),
   //  cfh, input1, &result));
+}
+
+TEST_F(DBSecondaryTest, GetMergeOperands) {
+  Options options;
+  options.merge_operator = MergeOperators::CreateStringAppendOperator();
+  options.env = env_;
+  Reopen(options);
+
+  ASSERT_OK(Merge("k1", "v1"));
+  ASSERT_OK(Merge("k1", "v2"));
+  ASSERT_OK(Merge("k1", "v3"));
+  ASSERT_OK(Merge("k1", "v4"));
+
+  options.max_open_files = -1;
+  OpenSecondary(options);
+
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+
+  int num_records = 4;
+  int number_of_operands = 0;
+  std::vector<PinnableSlice> values(num_records);
+  GetMergeOperandsOptions merge_operands_info;
+  merge_operands_info.expected_max_number_of_operands = num_records;
+
+  auto cfh = db_secondary_->DefaultColumnFamily();
+
+  // s.IsMergeInProgress()
+  const Status s = db_secondary_->GetMergeOperands(
+      ReadOptions(), cfh, "k1", values.data(), &merge_operands_info,
+      &number_of_operands);
+  ASSERT_NOK(s);
+  ASSERT_TRUE(s.IsMergeInProgress());
+
+  ASSERT_EQ(number_of_operands, 4);
+  ASSERT_EQ(values[0].ToString(), "v1");
+  ASSERT_EQ(values[1].ToString(), "v2");
+  ASSERT_EQ(values[2].ToString(), "v3");
+  ASSERT_EQ(values[3].ToString(), "v4");
 }
 
 TEST_F(DBSecondaryTest, InternalCompactionCompactedFiles) {

--- a/unreleased_history/bug_fixes/get_merge_operand_fix.md
+++ b/unreleased_history/bug_fixes/get_merge_operand_fix.md
@@ -1,0 +1,1 @@
+Fixed GetMergeOperands() API in ReadOnlyDB and SecondaryDB


### PR DESCRIPTION
# Summary

Fixing the GetMergeOperands() in ReadOnlyDB and SecondaryDB as reported in #13243. Refactor in #11799 introduced this regression.

Follow ups to come
- Large Result Optimization (done in #10458 ) for ReadOnlyDB and SecondaryDB
- Stress Test / Crash Test coverage
- Consider removing some duplicate logic between ReadOnlyDB's GetImpl() and SecondaryDB's `GetImpl()`. The only difference is between acquiring/referencing Superversion.


# Test Plan

`DBMergeOperandTest` and `DBSecondaryTest` updated

```
./db_merge_operand_test --gtest_filter="*GetMergeOperandsBasic*"
```
```
./db_secondary_test -- --gtest_filter="*GetMergeOperands*"
```