### PR TITLE
Only run secondary db verification for blackbox crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -485,12 +485,12 @@ simple_default_params = {
     "write_buffer_size": 32 * 1024 * 1024,
     "level_compaction_dynamic_level_bytes": lambda: random.randint(0, 1),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
-    "test_secondary": lambda: random.choice([0, 1]),
 }
 
 blackbox_simple_default_params = {
     "open_files": -1,
     "set_options_one_in": 0,
+    "test_secondary": lambda: random.choice([0, 1]),
 }
 
 whitebox_simple_default_params = {}


### PR DESCRIPTION
# Summary

This is a continuation of #13338, which aims to address crash test failures caused by #13281.

I looked through the test failures again, and they all are for the whitebox tests. 

I am pretty sure this is because the whitebox tests have 20 for `reopen` whereas the blackbox tests have 0 inside `whitebox_default_params` and `blackbox_default_params`.

The error logs for the ASAN and TSAN failures  point to the `ReOpen` method, so I think that if we just avoid this code path, we can avoid the failures. 

I do not think that the whitebox tests give us additional information _for the sole purpose of secondary DB verification_ compared to the blackbox tests. Thus, I think it is likely better to just enable secondary DB verification on blackbox tests only. We still will want to monitor for data verification failures and see no verification failures for an extended period of time.

# Test Plan

Monitor recurring crash test runs.

I confirmed the simple blackbox test can give 1 for `test_secondary`.
```
python3 tools/db_crashtest.py --simple blackbox 
```

whereas `test_secondary` is not even specified in
```
python3 tools/db_crashtest.py --simple whitebox 
```