### PR TITLE
Disable track_and_verify_wals  + write fault injection less

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1018,9 +1018,13 @@ def finalize_and_sanitize(src_params):
         dest_params["use_full_merge_v1"] = 0
         dest_params["enable_pipelined_write"] = 0
         dest_params["use_attribute_group"] = 0
-    # TODO(hx235): Enable below fault injections again after resolving the apparent WAL hole
-    # that the mishandling of these faults create and is detected by `track_and_verify_wals=0`
-    if dest_params.get("track_and_verify_wals", 0) == 1:
+    # TODO(hx235): Re-enable write fault injections with non write-committed policies
+    # after resolving the WAL hole caused by how corrupted WAL is handled under 2PC 
+    # upon WAL write error recovery. 
+    if (
+        dest_params.get("track_and_verify_wals", 0) == 1 
+        and dest_params.get("txn_write_policy") != 0
+    ):
         dest_params["metadata_write_fault_one_in"] = 0
         dest_params["write_fault_one_in"] = 0
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest


### PR DESCRIPTION
Reduce the scope of disabling track_and_verify_wals  + write fault injection since the wal hole is subjected to only 2pc. More info coming