### PR TITLE
Demonstrate how we can receive chained results

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -803,6 +803,16 @@ class FSSequentialFile {
 
 using FSAllocationPtr = std::unique_ptr<void, std::function<void(void*)>>;
 
+struct PartialResult {
+  uint64_t offset;
+  Slice result;
+  FSAllocationPtr fs_scratch;
+};
+
+struct ResultChain {
+  std::vector<PartialResult> result_chain;
+};
+
 // A read IO request structure for use in MultiRead and asynchronous Read APIs.
 struct FSReadRequest {
   // Input parameter that represents the file offset in bytes.
@@ -863,6 +873,8 @@ struct FSReadRequest {
   // start to the real data. See https://github.com/facebook/rocksdb/pull/13189
   // for more context.
   FSAllocationPtr fs_scratch;
+
+  std::optional<ResultChain> result_chain;
 };
 
 // A file abstraction for randomly reading the contents of a file.


### PR DESCRIPTION
This is an exploratory PR meant to see how RocksDB could support receiving a chain of (noncontiguous) buffers. This would enable a true zero-copy of the result buffer from the file system.