### PR TITLE
Use secondary_cfhs in secondary_db_->Get 

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -221,8 +221,7 @@ class NonBatchedOpsStressTest : public StressTest {
             const std::string key = Key(i);
             std::string from_db;
 
-            s = secondary_db_->Get(options, column_families_[cf], key,
-                                   &from_db);
+            s = secondary_db_->Get(options, secondary_cfhs_[cf], key, &from_db);
 
             assert(!pre_read_expected_values.empty() &&
                    static_cast<size_t>(i - start) <


### PR DESCRIPTION
# Summary

This bug was spotted by @cbi42 and should be the root cause for the crash test data races during secondary DB verification (from #13281) 🤞 .

# Test Plan

Monitor recurring crash tests.