### PR TITLE
Auto refresh iterator with snapshot

### DIFF
--- a/db/arena_wrapped_db_iter.cc
+++ b/db/arena_wrapped_db_iter.cc
@@ -127,6 +127,8 @@ void ArenaWrappedDBIter::MaybeAutoRefresh(std::function<void()> op,
         }
       }
 
+      // It's perfectly fine to unref the corresponding superversion
+      // as we rely on pinning behavior of snapshot for consistency.
       DoRefresh(read_options_.snapshot, cur_sv_number);
 
       if (is_seek) {
@@ -139,7 +141,6 @@ void ArenaWrappedDBIter::MaybeAutoRefresh(std::function<void()> op,
           db_iter_->SeekForPrev(key);
         }
       }
-
       return;
     }
   }

--- a/db/arena_wrapped_db_iter.cc
+++ b/db/arena_wrapped_db_iter.cc
@@ -114,7 +114,7 @@ void ArenaWrappedDBIter::MaybeAutoRefresh(bool is_seek,
       //                            ---- T3: Seek(T)
       //
       bool valid = false;
-      std::string key = "";
+      std::string key;
       if (!is_seek && db_iter_->Valid()) {
         // The key() Slice is valid until the iterator state changes.
         // Given that refresh is heavy-weight operation it itself,

--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -65,12 +65,21 @@ class ArenaWrappedDBIter : public Iterator {
   void SeekToLast() override { db_iter_->SeekToLast(); }
   // 'target' does not contain timestamp, even if user timestamp feature is
   // enabled.
-  void Seek(const Slice& target) override { db_iter_->Seek(target); }
+  void Seek(const Slice& target) override {
+    db_iter_->Seek(target);
+    MaybeAutoRefresh();
+  }
   void SeekForPrev(const Slice& target) override {
     db_iter_->SeekForPrev(target);
   }
-  void Next() override { db_iter_->Next(); }
-  void Prev() override { db_iter_->Prev(); }
+  void Next() override {
+    db_iter_->Next();
+    MaybeAutoRefresh();
+  }
+  void Prev() override {
+    db_iter_->Prev();
+    MaybeAutoRefresh();
+  }
   Slice key() const override { return db_iter_->key(); }
   Slice value() const override { return db_iter_->value(); }
   const WideColumns& columns() const override { return db_iter_->columns(); }
@@ -103,6 +112,9 @@ class ArenaWrappedDBIter : public Iterator {
   }
 
  private:
+  void DoRefresh(const Snapshot* snapshot, uint64_t sv_number);
+  void MaybeAutoRefresh();
+
   DBIter* db_iter_ = nullptr;
   Arena arena_;
   uint64_t sv_number_;

--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -66,21 +66,25 @@ class ArenaWrappedDBIter : public Iterator {
   // 'target' does not contain timestamp, even if user timestamp feature is
   // enabled.
   void Seek(const Slice& target) override {
-    MaybeAutoRefresh([&] { db_iter_->Seek(target); }, true /* is_seek */,
-                     DBIter::kForward);
+    MaybeAutoRefresh(true /* is_seek */, DBIter::kForward);
+    db_iter_->Seek(target);
   }
+
   void SeekForPrev(const Slice& target) override {
-    MaybeAutoRefresh([&] { db_iter_->SeekForPrev(target); }, true /* is_seek */,
-                     DBIter::kReverse);
+    MaybeAutoRefresh(true /* is_seek */, DBIter::kReverse);
+    db_iter_->SeekForPrev(target);
   }
+
   void Next() override {
-    MaybeAutoRefresh([&] { db_iter_->Next(); }, false /* is_seek */,
-                     DBIter::kForward);
+    db_iter_->Next();
+    MaybeAutoRefresh(false /* is_seek */, DBIter::kForward);
   }
+
   void Prev() override {
-    MaybeAutoRefresh([&] { db_iter_->Prev(); }, false /* is_seek */,
-                     DBIter::kReverse);
+    db_iter_->Prev();
+    MaybeAutoRefresh(false /* is_seek */, DBIter::kReverse);
   }
+
   Slice key() const override { return db_iter_->key(); }
   Slice value() const override { return db_iter_->value(); }
   const WideColumns& columns() const override { return db_iter_->columns(); }
@@ -114,8 +118,7 @@ class ArenaWrappedDBIter : public Iterator {
 
  private:
   void DoRefresh(const Snapshot* snapshot, uint64_t sv_number);
-  void MaybeAutoRefresh(std::function<void()> op, bool is_seek,
-                        DBIter::Direction direction);
+  void MaybeAutoRefresh(bool is_seek, DBIter::Direction direction);
 
   DBIter* db_iter_ = nullptr;
   Arena arena_;

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -484,6 +484,9 @@ class ColumnFamilyData {
   uint64_t GetSuperVersionNumber() const {
     return super_version_number_.load();
   }
+  uint64_t GetSuperVersionNumberRelaxed() const {
+    return super_version_number_.load(std::memory_order_relaxed);
+  }
   // will return a pointer to SuperVersion* if previous SuperVersion
   // if its reference count is zero and needs deletion or nullptr if not
   // As argument takes a pointer to allocated SuperVersion to enable

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -2544,6 +2544,124 @@ TEST_P(DBIteratorTest, RefreshWithSnapshot) {
   ASSERT_OK(db_->Close());
 }
 
+TEST_P(DBIteratorTest, AutoRefreshIterator) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = true;
+  for (const bool auto_refresh_enabled : {false, true}) {
+    for (const bool use_snapshot : {false, true}) {
+      DestroyAndReopen(options);
+      // Multi dimensional iterator:
+      //
+      // L0 (level iterator): [key000000]
+      // L1 (table iterator): [key000001]
+      // Memtable           : [key000000, key000999]
+      for (int i = 0; i < 1002; i++) {
+        ASSERT_OK(Put(Key(i % 1000), "val" + std::to_string(i)));
+        if (i <= 1) {
+          ASSERT_OK(Flush());
+        }
+        if (i == 0) {
+          MoveFilesToLevel(1);
+        }
+      }
+
+      ReadOptions read_options;
+      read_options.snapshot = use_snapshot ? db_->GetSnapshot() : nullptr;
+      read_options.auto_refresh_iterator_enabled = auto_refresh_enabled;
+      Iterator* iter = NewIterator(read_options);
+
+      // This update should NOT be visible from the iterator.
+      ASSERT_OK(Put(Key(5), "new val"));
+
+      ASSERT_EQ(1, NumTableFilesAtLevel(1));
+      ASSERT_EQ(1, NumTableFilesAtLevel(0));
+
+      uint64_t all_memtables_size_before_refresh;
+      uint64_t all_memtables_size_after_refresh;
+
+      std::string prop_value;
+      ASSERT_OK(iter->GetProperty("rocksdb.iterator.super-version-number",
+                                  &prop_value));
+      int superversion_number = std::stoi(prop_value);
+
+      std::vector<LiveFileMetaData> old_files;
+      db_->GetLiveFilesMetaData(&old_files);
+
+      int it_num = 0;
+      int trigger_compact_on_it = 678;
+      std::unordered_map<std::string, std::string> kvs;
+      for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        ASSERT_OK(iter->status());
+        it_num++;
+
+        if (it_num == trigger_compact_on_it) {
+          // Bump the superversion by manually scheduling flush + compaction.
+          ASSERT_OK(Flush());
+          ASSERT_OK(
+              dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+          ASSERT_OK(dbfull()->TEST_WaitForBackgroundWork());
+
+          // Flush and compaction background tasks are completed by now.
+          std::vector<LiveFileMetaData> new_files;
+          db_->GetLiveFilesMetaData(&new_files);
+
+          // We expect a single, new SST file.
+          ASSERT_EQ(new_files.size(), 1);
+          for (const auto& old_file : old_files) {
+            ASSERT_TRUE(old_file.file_number != new_files[0].file_number);
+          }
+
+          // For accuracy, capture the memtables size right before consecutive
+          // iterator call to Next() will update its' stale superversion ref.
+          dbfull()->GetIntProperty("rocksdb.size-all-mem-tables",
+                                   &all_memtables_size_before_refresh);
+        }
+
+        if (it_num == trigger_compact_on_it + 1) {
+          dbfull()->GetIntProperty("rocksdb.size-all-mem-tables",
+                                   &all_memtables_size_after_refresh);
+          ASSERT_OK(iter->GetProperty("rocksdb.iterator.super-version-number",
+                                      &prop_value));
+          uint64_t new_superversion_number = std::stoi(prop_value);
+          if (!auto_refresh_enabled) {
+            ASSERT_EQ(superversion_number, new_superversion_number);
+            ASSERT_EQ(all_memtables_size_after_refresh,
+                      all_memtables_size_before_refresh);
+          } else {
+            // Iterator is expected to detect its' superversion staleness.
+            ASSERT_LT(superversion_number, new_superversion_number);
+            // ... and since our iterator was the only reference to that very
+            // superversion, we expect most of the active memory to be returned
+            // upon automatical iterator refresh.
+            ASSERT_GT(all_memtables_size_before_refresh,
+                      all_memtables_size_after_refresh);
+          }
+        }
+
+        kvs[iter->key().ToString()] = iter->value().ToString();
+      }
+      ASSERT_OK(iter->status());
+
+      // Data validation.
+      ASSERT_EQ(kvs.size(), 1000);
+      for (int i = 0; i < 1000; i++) {
+        auto kv = kvs.find(Key(i));
+        ASSERT_TRUE(kv != kvs.end());
+        int val = i;
+        if (i <= 1) {
+          val += 1000;
+        }
+        ASSERT_EQ(kv->second, "val" + std::to_string(val));
+      }
+
+      delete iter;
+      if (use_snapshot) {
+        db_->ReleaseSnapshot(read_options.snapshot);
+      }
+    }
+  }
+}
+
 TEST_P(DBIteratorTest, CreationFailure) {
   SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::NewInternalIterator:StatusCallback", [](void* arg) {

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -2545,115 +2545,139 @@ TEST_P(DBIteratorTest, RefreshWithSnapshot) {
 }
 
 TEST_P(DBIteratorTest, AutoRefreshIterator) {
+  constexpr int kNumKeys = 1000;
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
-  for (const bool auto_refresh_enabled : {false, true}) {
-    for (const bool explicit_snapshot : {false, true}) {
-      DestroyAndReopen(options);
-      // Multi dimensional iterator:
-      //
-      // L0 (level iterator): [key000000]
-      // L1 (table iterator): [key000001]
-      // Memtable           : [key000000, key000999]
-      for (int i = 0; i < 1002; i++) {
-        ASSERT_OK(Put(Key(i % 1000), "val" + std::to_string(i)));
-        if (i <= 1) {
-          ASSERT_OK(Flush());
-        }
-        if (i == 0) {
-          MoveFilesToLevel(1);
-        }
-      }
-
-      ReadOptions read_options;
-      std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
-      if (explicit_snapshot) {
-        snapshot = std::make_unique<ManagedSnapshot>(db_);
-      }
-      read_options.snapshot =
-          explicit_snapshot ? snapshot->snapshot() : nullptr;
-      read_options.auto_refresh_iterator_enabled = auto_refresh_enabled;
-      std::unique_ptr<Iterator> iter(NewIterator(read_options));
-
-      // This update should NOT be visible from the iterator.
-      ASSERT_OK(Put(Key(5), "new val"));
-
-      ASSERT_EQ(1, NumTableFilesAtLevel(1));
-      ASSERT_EQ(1, NumTableFilesAtLevel(0));
-
-      uint64_t all_memtables_size_before_refresh;
-      uint64_t all_memtables_size_after_refresh;
-
-      std::string prop_value;
-      ASSERT_OK(iter->GetProperty("rocksdb.iterator.super-version-number",
-                                  &prop_value));
-      int superversion_number = std::stoi(prop_value);
-
-      std::vector<LiveFileMetaData> old_files;
-      db_->GetLiveFilesMetaData(&old_files);
-
-      int it_num = 0;
-      int trigger_compact_on_it = 678;
-      std::unordered_map<std::string, std::string> kvs;
-      for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-        ASSERT_OK(iter->status());
-        it_num++;
-        if (it_num == trigger_compact_on_it) {
-          // Bump the superversion by manually scheduling flush + compaction.
-          ASSERT_OK(Flush());
-          ASSERT_OK(
-              dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr));
-          ASSERT_OK(dbfull()->TEST_WaitForBackgroundWork());
-
-          // For accuracy, capture the memtables size right before consecutive
-          // iterator call to Next() will update its' stale superversion ref.
-          dbfull()->GetIntProperty("rocksdb.size-all-mem-tables",
-                                   &all_memtables_size_before_refresh);
+  for (const DBIter::Direction direction :
+       {DBIter::kForward, DBIter::kReverse}) {
+    for (const bool auto_refresh_enabled : {false, true}) {
+      for (const bool explicit_snapshot : {false, true}) {
+        DestroyAndReopen(options);
+        // Multi dimensional iterator:
+        //
+        // L0 (level iterator): [key000000]
+        // L1 (table iterator): [key000001]
+        // Memtable           : [key000000, key000999]
+        for (int i = 0; i < kNumKeys + 2; i++) {
+          ASSERT_OK(Put(Key(i % kNumKeys), "val" + std::to_string(i)));
+          if (i <= 1) {
+            ASSERT_OK(Flush());
+          }
+          if (i == 0) {
+            MoveFilesToLevel(1);
+          }
         }
 
-        if (it_num == trigger_compact_on_it + 1) {
-          dbfull()->GetIntProperty("rocksdb.size-all-mem-tables",
-                                   &all_memtables_size_after_refresh);
-          ASSERT_OK(iter->GetProperty("rocksdb.iterator.super-version-number",
-                                      &prop_value));
-          uint64_t new_superversion_number = std::stoi(prop_value);
-          Status expected_status_for_preexisting_files;
-          if (!auto_refresh_enabled) {
-            ASSERT_EQ(superversion_number, new_superversion_number);
-            ASSERT_EQ(all_memtables_size_after_refresh,
-                      all_memtables_size_before_refresh);
-            expected_status_for_preexisting_files = Status::OK();
+        ReadOptions read_options;
+        std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+        if (explicit_snapshot) {
+          snapshot = std::make_unique<ManagedSnapshot>(db_);
+        }
+        read_options.snapshot =
+            explicit_snapshot ? snapshot->snapshot() : nullptr;
+        read_options.auto_refresh_iterator_with_snapshot = auto_refresh_enabled;
+        std::unique_ptr<Iterator> iter(NewIterator(read_options));
+
+        int trigger_compact_on_it = kNumKeys / 2;
+
+        // This update should NOT be visible from the iterator.
+        ASSERT_OK(Put(Key(trigger_compact_on_it + 1), "new val"));
+
+        ASSERT_EQ(1, NumTableFilesAtLevel(1));
+        ASSERT_EQ(1, NumTableFilesAtLevel(0));
+
+        uint64_t all_memtables_size_before_refresh;
+        uint64_t all_memtables_size_after_refresh;
+
+        std::string prop_value;
+        ASSERT_OK(iter->GetProperty("rocksdb.iterator.super-version-number",
+                                    &prop_value));
+        int superversion_number = std::stoi(prop_value);
+
+        std::vector<LiveFileMetaData> old_files;
+        db_->GetLiveFilesMetaData(&old_files);
+
+        int expected_next_key_int;
+        if (direction == DBIter::kForward) {
+          expected_next_key_int = 0;
+          iter->SeekToFirst();
+        } else {  // DBIter::kReverse
+          expected_next_key_int = kNumKeys - 1;
+          iter->SeekToLast();
+        }
+
+        int it_num = 0;
+        std::unordered_map<std::string, std::string> kvs;
+        while (iter->Valid()) {
+          ASSERT_OK(iter->status());
+          it_num++;
+          if (it_num == trigger_compact_on_it) {
+            // Bump the superversion by manually scheduling flush + compaction.
+            ASSERT_OK(Flush());
+            ASSERT_OK(dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+                                             nullptr));
+            ASSERT_OK(dbfull()->TEST_WaitForBackgroundWork());
+
+            // For accuracy, capture the memtables size right before consecutive
+            // iterator call to Next() will update its' stale superversion ref.
+            dbfull()->GetIntProperty("rocksdb.size-all-mem-tables",
+                                     &all_memtables_size_before_refresh);
+          }
+
+          if (it_num == trigger_compact_on_it + 1) {
+            dbfull()->GetIntProperty("rocksdb.size-all-mem-tables",
+                                     &all_memtables_size_after_refresh);
+            ASSERT_OK(iter->GetProperty("rocksdb.iterator.super-version-number",
+                                        &prop_value));
+            uint64_t new_superversion_number = std::stoi(prop_value);
+            Status expected_status_for_preexisting_files;
+            if (auto_refresh_enabled && explicit_snapshot) {
+              // Iterator is expected to detect its' superversion staleness.
+              ASSERT_LT(superversion_number, new_superversion_number);
+              // ... and since our iterator was the only reference to that very
+              // superversion, we expect most of the active memory to be
+              // returned upon automatical iterator refresh.
+              ASSERT_GT(all_memtables_size_before_refresh,
+                        all_memtables_size_after_refresh);
+              expected_status_for_preexisting_files = Status::NotFound();
+            } else {
+              ASSERT_EQ(superversion_number, new_superversion_number);
+              ASSERT_EQ(all_memtables_size_after_refresh,
+                        all_memtables_size_before_refresh);
+              expected_status_for_preexisting_files = Status::OK();
+            }
+
+            for (const auto& file : old_files) {
+              ASSERT_EQ(env_->FileExists(file.db_path + "/" + file.name),
+                        expected_status_for_preexisting_files);
+            }
+          }
+
+          // Ensure we're visiting the keys in desired order and at most once!
+          ASSERT_EQ(IdFromKey(iter->key().ToString()), expected_next_key_int);
+          kvs[iter->key().ToString()] = iter->value().ToString();
+
+          if (direction == DBIter::kForward) {
+            iter->Next();
+            expected_next_key_int++;
           } else {
-            // Iterator is expected to detect its' superversion staleness.
-            ASSERT_LT(superversion_number, new_superversion_number);
-            // ... and since our iterator was the only reference to that very
-            // superversion, we expect most of the active memory to be returned
-            // upon automatical iterator refresh.
-            ASSERT_GT(all_memtables_size_before_refresh,
-                      all_memtables_size_after_refresh);
-            expected_status_for_preexisting_files = Status::NotFound();
-          }
-
-          for (const auto& file : old_files) {
-            ASSERT_EQ(env_->FileExists(file.db_path + "/" + file.name),
-                      expected_status_for_preexisting_files);
+            iter->Prev();
+            expected_next_key_int--;
           }
         }
+        ASSERT_OK(iter->status());
 
-        kvs[iter->key().ToString()] = iter->value().ToString();
-      }
-      ASSERT_OK(iter->status());
-
-      // Data validation.
-      ASSERT_EQ(kvs.size(), 1000);
-      for (int i = 0; i < 1000; i++) {
-        auto kv = kvs.find(Key(i));
-        ASSERT_TRUE(kv != kvs.end());
-        int val = i;
-        if (i <= 1) {
-          val += 1000;
+        // Data validation.
+        ASSERT_EQ(kvs.size(), kNumKeys);
+        for (int i = 0; i < kNumKeys; i++) {
+          auto kv = kvs.find(Key(i));
+          ASSERT_TRUE(kv != kvs.end());
+          int val = i;
+          if (i <= 1) {
+            val += kNumKeys;
+          }
+          ASSERT_EQ(kv->second, "val" + std::to_string(val));
         }
-        ASSERT_EQ(kv->second, "val" + std::to_string(val));
       }
     }
   }

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -1106,6 +1106,7 @@ class DBTestBase : public testing::Test {
     return std::string(buf);
   }
 
+  // Expects valid key created by Key().
   static int IdFromKey(const std::string& key) {
     return std::stoi(key.substr(3));
   }

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -776,6 +776,11 @@ class CfConsistencyStressTest : public StressTest {
     Slice ub_slice;
 
     ReadOptions ro_copy = readoptions;
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (ro_copy.auto_refresh_iterator_with_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db_);
+      ro_copy.snapshot = snapshot->snapshot();
+    }
 
     // Get the next prefix first and then see if we want to set upper bound.
     // We'll use the next prefix in an assertion later on
@@ -858,6 +863,8 @@ class CfConsistencyStressTest : public StressTest {
 
     ManagedSnapshot snapshot_guard(db_);
     options.snapshot = snapshot_guard.snapshot();
+    options.auto_refresh_iterator_with_snapshot =
+        FLAGS_auto_refresh_iterator_with_snapshot;
 
     const size_t num = column_families_.size();
 
@@ -1083,8 +1090,9 @@ class CfConsistencyStressTest : public StressTest {
     // `FLAGS_rate_limit_user_ops` to avoid slowing any validation.
     ReadOptions ropts(FLAGS_verify_checksum, true);
     ropts.total_order_seek = true;
-    if (nullptr == secondary_db_) {
+    if (nullptr == secondary_db_ || FLAGS_auto_refresh_iterator_with_snapshot) {
       ropts.snapshot = snapshot_guard.snapshot();
+      ropts.auto_refresh_iterator_with_snapshot = true;
     }
     uint32_t crc = 0;
     {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -423,6 +423,7 @@ DECLARE_string(file_temperature_age_thresholds);
 DECLARE_uint32(commit_bypass_memtable_one_in);
 DECLARE_bool(track_and_verify_wals);
 DECLARE_bool(enable_remote_compaction);
+DECLARE_bool(auto_refresh_iterator_with_snapshot);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1479,4 +1479,10 @@ DEFINE_bool(paranoid_memory_checks,
 DEFINE_uint32(commit_bypass_memtable_one_in, 0,
               "If greater than zero, transaction option will set "
               "commit_bypass_memtable to per every N transactions on average.");
+
+DEFINE_bool(
+    auto_refresh_iterator_with_snapshot,
+    ROCKSDB_NAMESPACE::ReadOptions().auto_refresh_iterator_with_snapshot,
+    "ReadOptions.auto_refresh_iterator_with_snapshot");
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -520,6 +520,8 @@ Status StressTest::AssertSame(DB* db, ColumnFamilyHandle* cf,
   // `FLAGS_rate_limit_user_ops` to avoid slowing any validation.
   ReadOptions ropt;
   ropt.snapshot = snap_state.snapshot;
+  ropt.auto_refresh_iterator_with_snapshot =
+      FLAGS_auto_refresh_iterator_with_snapshot;
   Slice ts;
   if (!snap_state.timestamp.empty()) {
     ts = snap_state.timestamp;
@@ -954,6 +956,8 @@ void StressTest::OperateDb(ThreadState* thread) {
   read_opts.fill_cache = FLAGS_fill_cache;
   read_opts.optimize_multiget_for_io = FLAGS_optimize_multiget_for_io;
   read_opts.allow_unprepared_value = FLAGS_allow_unprepared_value;
+  read_opts.auto_refresh_iterator_with_snapshot =
+      FLAGS_auto_refresh_iterator_with_snapshot;
 
   WriteOptions write_opts;
   if (FLAGS_rate_limit_auto_wal_flush) {
@@ -1734,6 +1738,8 @@ Status StressTest::TestIterateImpl(ThreadState* thread,
     cmp_ro.timestamp = ro.timestamp;
     cmp_ro.iter_start_ts = ro.iter_start_ts;
     cmp_ro.snapshot = snapshot_guard.snapshot();
+    cmp_ro.auto_refresh_iterator_with_snapshot =
+        ro.auto_refresh_iterator_with_snapshot;
     cmp_ro.total_order_seek = true;
 
     ColumnFamilyHandle* const cmp_cfh =
@@ -1962,7 +1968,10 @@ void StressTest::VerifyIterator(
                << (ro.iterate_lower_bound
                        ? ro.iterate_lower_bound->ToString(true).c_str()
                        : "")
-               << ", allow_unprepared_value: " << ro.allow_unprepared_value;
+               << ", allow_unprepared_value: " << ro.allow_unprepared_value
+               << ", auto_refresh_iterator_with_snapshot"
+               << ro.auto_refresh_iterator_with_snapshot << ", snapshot: "
+               << ((ro.snapshot == nullptr) ? "nullptr" : "well-defined");
 
   if (iter->Valid() && !cmp_iter->Valid()) {
     if (pe != nullptr) {
@@ -2918,6 +2927,8 @@ void StressTest::TestAcquireSnapshot(ThreadState* thread,
       ww_snapshot ? db_impl->GetSnapshotForWriteConflictBoundary()
                   : db_->GetSnapshot();
   ropt.snapshot = snapshot;
+  ropt.auto_refresh_iterator_with_snapshot =
+      FLAGS_auto_refresh_iterator_with_snapshot;
 
   // Ideally, we want snapshot taking and timestamp generation to be atomic
   // here, so that the snapshot corresponds to the timestamp. However, it is
@@ -3127,6 +3138,8 @@ uint32_t StressTest::GetRangeHash(ThreadState* thread, const Snapshot* snapshot,
   ReadOptions ro;
   ro.snapshot = snapshot;
   ro.total_order_seek = true;
+  ro.auto_refresh_iterator_with_snapshot =
+      FLAGS_auto_refresh_iterator_with_snapshot;
   std::string ts_str;
   Slice ts;
   if (FLAGS_user_timestamp_size > 0) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1971,7 +1971,7 @@ void StressTest::VerifyIterator(
                << ", allow_unprepared_value: " << ro.allow_unprepared_value
                << ", auto_refresh_iterator_with_snapshot"
                << ro.auto_refresh_iterator_with_snapshot << ", snapshot: "
-               << ((ro.snapshot == nullptr) ? "nullptr" : "well-defined");
+               << ((ro.snapshot == nullptr) ? "nullptr" : "non-nullptr");
 
   if (iter->Valid() && !cmp_iter->Valid()) {
     if (pe != nullptr) {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -29,6 +29,13 @@ class NonBatchedOpsStressTest : public StressTest {
     // This `ReadOptions` is for validation purposes. Ignore
     // `FLAGS_rate_limit_user_ops` to avoid slowing any validation.
     ReadOptions options(FLAGS_verify_checksum, true);
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (FLAGS_auto_refresh_iterator_with_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db_);
+      options.snapshot = snapshot->snapshot();
+      options.auto_refresh_iterator_with_snapshot = true;
+    }
+
     std::string ts_str;
     Slice ts;
     if (FLAGS_user_timestamp_size > 0) {
@@ -467,6 +474,13 @@ class NonBatchedOpsStressTest : public StressTest {
       ts_str = GetNowNanos();
       ts = ts_str;
       read_opts.timestamp = &ts;
+    }
+
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (FLAGS_auto_refresh_iterator_with_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db_);
+      read_opts.snapshot = snapshot->snapshot();
+      read_opts.auto_refresh_iterator_with_snapshot = true;
     }
 
     static Random64 rand64(shared->GetSeed());
@@ -1561,6 +1575,13 @@ class NonBatchedOpsStressTest : public StressTest {
     Slice ub_slice;
     ReadOptions ro_copy = read_opts;
 
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (ro_copy.auto_refresh_iterator_with_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db_);
+      ro_copy.snapshot = snapshot->snapshot();
+      ro_copy.auto_refresh_iterator_with_snapshot = true;
+    }
+
     // Randomly test with `iterate_upper_bound` and `prefix_same_as_start`
     //
     // Get the next prefix first and then see if we want to set it to be the
@@ -2340,6 +2361,13 @@ class NonBatchedOpsStressTest : public StressTest {
     }
 
     ReadOptions ro(read_opts);
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (ro.auto_refresh_iterator_with_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db_);
+      ro.snapshot = snapshot->snapshot();
+      ro.auto_refresh_iterator_with_snapshot = true;
+    }
+
     if (FLAGS_prefix_size > 0) {
       ro.total_order_seek = true;
     }

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1946,6 +1946,20 @@ struct ReadOptions {
   // Default: false
   bool allow_unprepared_value = false;
 
+  // EXPERIMENTAL
+  //
+  // When enabled, the iterator will opportunistically check whether its current
+  // superversion number matches most recent CF counterpart during Seek(),
+  // Next() and Prev() calls. If not, it will refresh itself to the latest CF
+  // superversion preserving the very same snapshot it's been assigned to for
+  // consistency. This allows the iterator to adapt to updates such as new
+  // memtables, compactions and flushes.
+  //
+  // Note: This option requires iterator to have allow_refresh_ set to `true`.
+  //
+  // Default: false
+  bool auto_refresh_iterator_enabled = false;
+
   // *** END options only relevant to iterators or scans ***
 
   // *** BEGIN options for RocksDB internal use only ***

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1948,14 +1948,14 @@ struct ReadOptions {
 
   // EXPERIMENTAL
   //
-  // When enabled, the iterator will opportunistically check whether its current
-  // superversion number matches most recent CF counterpart during Seek(),
-  // Next() and Prev() calls. If not, it will refresh itself to the latest CF
-  // superversion preserving the very same snapshot it's been assigned to for
-  // consistency. This allows the iterator to adapt to updates such as new
-  // memtables, compactions and flushes.
+  // Long-running iterators are holding onto memory and storage resources long
+  // after they are obsolete. This setting (when enabled) will fix that problem
+  // as long as iterators periodically make some progress. The feature is
+  // engineered so that the performance impact should be negligible. We expect
+  // the default value to be true some time in the future.
   //
-  // Note: This option requires iterator to have allow_refresh_ set to `true`.
+  // Note: Does not have effect on TransactionDB with WRITE_PREPARED or
+  //       WRITE_UNPREPARED policies.
   //
   // Default: false
   bool auto_refresh_iterator_enabled = false;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1956,9 +1956,14 @@ struct ReadOptions {
   // negligible. We expect the default value to be true some time in the future.
   //
   // NOTE 1: Does not have effect on TransactionDB with WRITE_PREPARED or
-  //         WRITE_UNPREPARED policies.
+  //         WRITE_UNPREPARED policies (currently incompatible).
   //
-  // NOTE 2: Not recommended if your application is reading UDT timestamps.
+  // NOTE 2: True is not recommended if using user-defined timestamp with
+  //         persist_user_defined_timestamps=false and non-nullptr
+  //         ReadOptions::timestamp or ReadOptions::iter_start_ts, because
+  //         auto-refreshing iterator will not prevent user timestamp
+  //         information from being dropped during iteration. Auto-refresh might
+  //         be disabled for this combination in the future.
   //
   // Default: false
   bool auto_refresh_iterator_with_snapshot = false;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1950,15 +1950,18 @@ struct ReadOptions {
   //
   // Long-running iterators are holding onto memory and storage resources long
   // after they are obsolete. This setting (when enabled) will fix that problem
-  // as long as iterators periodically make some progress. The feature is
-  // engineered so that the performance impact should be negligible. We expect
-  // the default value to be true some time in the future.
+  // for as long as iterator periodically makes some progress and its supplied
+  // `read_options` was configured with explicit (non-nullptr) `snapshot` value.
+  // The feature is engineered so that the performance impact should be
+  // negligible. We expect the default value to be true some time in the future.
   //
-  // Note: Does not have effect on TransactionDB with WRITE_PREPARED or
-  //       WRITE_UNPREPARED policies.
+  // NOTE 1: Does not have effect on TransactionDB with WRITE_PREPARED or
+  //         WRITE_UNPREPARED policies.
+  //
+  // NOTE 2: Not recommended if your application is using UDT-IN-MEM!
   //
   // Default: false
-  bool auto_refresh_iterator_enabled = false;
+  bool auto_refresh_iterator_with_snapshot = false;
 
   // *** END options only relevant to iterators or scans ***
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1951,14 +1951,14 @@ struct ReadOptions {
   // Long-running iterators are holding onto memory and storage resources long
   // after they are obsolete. This setting (when enabled) will fix that problem
   // for as long as iterator periodically makes some progress and its supplied
-  // `read_options` was configured with explicit (non-nullptr) `snapshot` value.
+  // `read_options` was configured with non-nullptr `snapshot` value.
   // The feature is engineered so that the performance impact should be
   // negligible. We expect the default value to be true some time in the future.
   //
   // NOTE 1: Does not have effect on TransactionDB with WRITE_PREPARED or
   //         WRITE_UNPREPARED policies.
   //
-  // NOTE 2: Not recommended if your application is using UDT-IN-MEM!
+  // NOTE 2: Not recommended if your application is reading UDT timestamps.
   //
   // Default: false
   bool auto_refresh_iterator_with_snapshot = false;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1281,8 +1281,17 @@ DEFINE_bool(
     auto_readahead_size, false,
     "When set true, RocksDB does auto tuning of readahead size during Scans");
 
+DEFINE_bool(
+    auto_refresh_iterator_with_snapshot, false,
+    "When set to true, RocksDB iterator will automatically refresh itself "
+    "upon detecting stale superversion - preserving its' original snapshot");
+
 DEFINE_bool(paranoid_memory_checks, false,
             "Sets CF option paranoid_memory_checks");
+
+DEFINE_bool(explicit_snapshot, false,
+            "When set to true iterators will be initialized with explicit "
+            "snapshot");
 
 static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
     const char* ctype) {
@@ -3490,6 +3499,8 @@ class Benchmark {
       read_options_.async_io = FLAGS_async_io;
       read_options_.optimize_multiget_for_io = FLAGS_optimize_multiget_for_io;
       read_options_.auto_readahead_size = FLAGS_auto_readahead_size;
+      read_options_.auto_refresh_iterator_with_snapshot =
+          FLAGS_auto_refresh_iterator_with_snapshot;
 
       void (Benchmark::*method)(ThreadState*) = nullptr;
       void (Benchmark::*post_process_method)() = nullptr;
@@ -5897,6 +5908,13 @@ class Benchmark {
     options.adaptive_readahead = FLAGS_adaptive_readahead;
     options.async_io = FLAGS_async_io;
     options.auto_readahead_size = FLAGS_auto_readahead_size;
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (FLAGS_explicit_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db);
+      options.snapshot = snapshot->snapshot();
+    } else {
+      options.snapshot = nullptr;
+    }
 
     Iterator* iter = db->NewIterator(options);
     int64_t i = 0;
@@ -6857,6 +6875,14 @@ class Benchmark {
       int64_t seek_pos = thread->rand.Next() % FLAGS_num;
       GenerateKeyFromIntForSeek(static_cast<uint64_t>(seek_pos), FLAGS_num,
                                 &key);
+      std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+      if (FLAGS_explicit_snapshot) {
+        snapshot = std::make_unique<ManagedSnapshot>(db_.db);
+        options.snapshot = snapshot->snapshot();
+      } else {
+        options.snapshot = nullptr;
+      }
+
       if (FLAGS_max_scan_distance != 0) {
         if (FLAGS_reverse_iterator) {
           GenerateKeyFromInt(
@@ -7181,6 +7207,13 @@ class Benchmark {
       ts_guard.reset(new char[user_timestamp_size_]);
       ts = mock_app_clock_->GetTimestampForRead(thread->rand, ts_guard.get());
       read_options.timestamp = &ts;
+    }
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (FLAGS_explicit_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db_.db);
+      read_options.snapshot = snapshot->snapshot();
+    } else {
+      read_options.snapshot = nullptr;
     }
     Iterator* iter = db_.db->NewIterator(read_options);
 
@@ -7797,6 +7830,13 @@ class Benchmark {
       ts = mock_app_clock_->GetTimestampForRead(thread->rand, ts_guard.get());
       read_opts.timestamp = &ts;
     }
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (FLAGS_explicit_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db);
+      read_opts.snapshot = snapshot->snapshot();
+    } else {
+      read_opts.snapshot = nullptr;
+    }
     std::unique_ptr<Iterator> iter(db->NewIterator(read_opts));
 
     std::unique_ptr<const char[]> key_guard;
@@ -8143,6 +8183,7 @@ class Benchmark {
     std::unique_ptr<const char[]> key_guard;
     Slice key = AllocateKey(&key_guard);
 
+    ReadOptions read_opts = read_options_;
     char value_buffer[256];
     while (true) {
       {
@@ -8152,9 +8193,17 @@ class Benchmark {
           break;
         }
       }
+
+      std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
       if (!FLAGS_use_tailing_iterator) {
         delete iter;
-        iter = db_.db->NewIterator(read_options_);
+        if (FLAGS_explicit_snapshot) {
+          snapshot = std::make_unique<ManagedSnapshot>(db_.db);
+          read_opts.snapshot = snapshot->snapshot();
+        } else {
+          read_opts.snapshot = nullptr;
+        }
+        iter = db_.db->NewIterator(read_opts);
       }
       // Pick a Iterator to use
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -345,6 +345,7 @@ default_params = {
     "allow_unprepared_value": lambda: random.choice([0, 1]),
     "track_and_verify_wals": lambda: random.choice([0, 1]),
     "enable_remote_compaction": lambda: random.choice([0, 1]),
+    "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR

--- a/unreleased_history/new_features/auto_refresh_iterator.md
+++ b/unreleased_history/new_features/auto_refresh_iterator.md
@@ -1,0 +1,1 @@
+Introduced new `auto_refresh_iterator_enabled` opt-in knob in `ReadOptions` that (when enabled) will instruct the iterator to automatically refresh itself to the latest superversion simultaneously preserving its' original snapshot for consistency.

--- a/unreleased_history/new_features/auto_refresh_iterator.md
+++ b/unreleased_history/new_features/auto_refresh_iterator.md
@@ -1,1 +1,1 @@
-Introduced new `auto_refresh_iterator_enabled` opt-in knob in `ReadOptions` that (when enabled) will instruct the iterator to automatically refresh itself to the latest superversion simultaneously preserving its' original snapshot for consistency.
+Introduced new `auto_refresh_iterator_enabled` opt-in knob in `ReadOptions` that (when enabled) will release obsolete memory and storage resources for as long as the iterator is periodically making progress.

--- a/unreleased_history/new_features/auto_refresh_iterator.md
+++ b/unreleased_history/new_features/auto_refresh_iterator.md
@@ -1,1 +1,1 @@
-Introduced new `auto_refresh_iterator_enabled` opt-in knob in `ReadOptions` that (when enabled) will release obsolete memory and storage resources for as long as the iterator is periodically making progress.
+Introduced new `auto_refresh_iterator_with_snapshot` opt-in knob that (when enabled) will periodically release obsolete memory and storage resources for as long as the iterator is making progress and its supplied `read_options.snapshot` was initialized with well-defined (non-nullptr) value.

--- a/unreleased_history/new_features/auto_refresh_iterator.md
+++ b/unreleased_history/new_features/auto_refresh_iterator.md
@@ -1,1 +1,1 @@
-Introduced new `auto_refresh_iterator_with_snapshot` opt-in knob that (when enabled) will periodically release obsolete memory and storage resources for as long as the iterator is making progress and its supplied `read_options.snapshot` was initialized with well-defined (non-nullptr) value.
+Introduced new `auto_refresh_iterator_with_snapshot` opt-in knob that (when enabled) will periodically release obsolete memory and storage resources for as long as the iterator is making progress and its supplied `read_options.snapshot` was initialized with non-nullptr value.


### PR DESCRIPTION
# Problem
Once opened, iterator will preserve its' respective RocksDB snapshot for read consistency. Unless explicitly `Refresh'ed`, the iterator will hold on to the `Init`-time assigned `SuperVersion` throughout its lifetime. As time goes by, this might result in artificially long holdup of the obsolete memtables (_potentially_ referenced by that superversion alone) consequently limiting the supply of the reclaimable memory on the DB instance. This behavior proved to be especially problematic in case of _logical_ backups (outside of RocksDB `BackupEngine`) when scanning billions of rows artificially pinning the memtables for hours.

# Solution
Building on top of the `Refresh(const Snapshot* snapshot)` API introduced in https://github.com/facebook/rocksdb/pull/10594, we're adding a new `ReadOptions` opt-in knob that (when enabled) will instruct the iterator to automatically refresh itself to the latest superversion - all that while retaining the originally assigned, explicit snapshot (supplied in `read_options.snapshot` at the time of iterator creation) for consistency. To ensure minimal performance overhead we're leveraging relaxed atomic for superversion freshness lookups.

# Test plan

**Correctness:** New test to demonstrate the auto refresh behavior in contrast to legacy iterator: `./db_iterator_test --gtest_filter=*AutoRefreshIterator*`.

**Stress testing:** We're adding command line parameter controlling the feature and hooking it up to as many iterator use cases in `db_stress` as we reasonably can with random feature on/off configuration in db_crashtest.py.

# Benchmarking

The goal of this benchmark is to validate that throughput did not regress substantially. Benchmark was run on optimized build, 3-5 times for each respective category or till convergence. In addition, we configured aggressive threshold of 1 second for new `Superversion` creation. Experiments have been run 'in parallel' (at the same time) on separate db instances within a single host to evenly spread the potential adverse impact of noisy neighbor activities. Host specs [1].

**TLDR;** Baseline & new solution are practically indistinguishable from performance standpoint. Difference (positive or negative) in throughput relative to the baseline, if any, is no more than 1-2%.

**Snapshot initialization approach:**

This feature is only effective on iterators with well-defined `snapshot` passed via `ReadOptions` config. We modified the existing `db_bench` program to reflect that constraint. However, it quickly turned out that the actual `Snapshot*` initialization is quite expensive. Especially in case of 'tiny scans' (100 rows) contributing as much as 25-35 microseconds, which is ~20-30% of the average per/op latency unintentionally masking _potentially_ adverse performance impact of this change. As a result, we ended up creating a single, explicit 'global' `Snapshot*` for all the future scans _before_ running multiple experiments en masse. This is also a valuable data point for us to keep in mind in case of any future discussions about taking implicit snapshots - now we know what the lower bound cost could be.

## "DB in memory" benchmark

**DB Setup**

1. Allow a single memtable to grow large enough (~572MB) to fit in all the rows. Upon shutdown all the rows will be flushed to the WAL file (inspected `000004.log` file is 541MB in size).

```
./db_bench -db=/tmp/testdb_in_mem -benchmarks="fillseq" -key_size=32 -value_size=512 -num=1000000 -write_buffer_size=600000000  max_write_buffer_number=2 -compression_type=none
```

2. As a part of recovery in subsequent DB open, WAL will be processed to one or more SST files during the recovery. We're selecting a large block cache (`cache_size` parameter in `db_bench` script) suitable for holding the entire DB to test the “hot path” CPU overhead.

```
./db_bench -use_existing_db=true -db=/tmp/testdb_in_mem -statistics=false -cache_index_and_filter_blocks=true -benchmarks=seekrandom -preserve_internal_time_seconds=1 max_write_buffer_number=2 -explicit_snapshot=1 -use_direct_reads=1 -async_io=1 -num=? -seek_nexts=? -cache_size=? -write_buffer_size=? -auto_refresh_iterator_with_snapshot={0|1}
```

  | seek_nexts=100; num=2,000,000 | seek_nexts = 20,000; num=50000  | seek_nexts = 400,000; num=2000 
-- | -- | -- | --
baseline | 36362 (± 300) ops/sec, 928.8 (± 23) MB/s, 99.11% block cache hit  | 52.5 (± 0.5) ops/sec, 1402.05 (± 11.85) MB/s, 99.99% block cache hit | 156.2 (± 6.3) ms / op, 1330.45 (± 54) MB/s, 99.95% block cache hit
auto refresh |  35775.5 (± 537) ops/sec, 926.65 (± 13.75) MB/s, 99.11% block cache hit |  53.5 (± 0.5) ops/sec, 1367.9 (± 9.5) MB/s, 99.99% block cache hit |  162 (± 4.14) ms / op, 1281.35 (± 32.75) MB/s, 99.95% block cache hit 

_-cache_size=5000000000 -write_buffer_size=3200000000 -max_write_buffer_number=2_

  | seek_nexts=3,500,000; num=100 
-- | -- 
baseline | 1447.5 (± 34.5) ms / op, 1255.1 (± 30) MB/s, 98.98% block cache hit 
auto refresh | 1473.5 (± 26.5) ms / op, 1232.6 (± 22.2) MB/s, 98.98% block cache hit 

_-cache_size=17680000000 -write_buffer_size=14500000000 -max_write_buffer_number=2_

  | seek_nexts=17,500,000; num=10 
-- | --
baseline | 9.11 (± 0.185) s/op, 997 (± 20) MB/s 
auto refresh | 9.22 (± 0.1) s/op, 984 (± 11.4) MB/s 

[1]

### Specs

  | Property | Value
-- | -- 
RocksDB | version 10.0.0
Date | Mon Feb  3 23:21:03 2025
CPU | 32 * Intel Xeon Processor (Skylake)
CPUCache | 16384 KB
Keys | 16 bytes each (+ 0 bytes user-defined timestamp)
Values | 100 bytes each (50 bytes after compression)
Prefix | 0 bytes
RawSize | 5.5 MB (estimated)
FileSize | 3.1 MB (estimated)
Compression | Snappy
Compression sampling rate | 0
Memtablerep | SkipListFactory
Perf Level | 1