### PR TITLE
Disable `track_and_verify_wals=1` with write fault injection only when pessimistic txn in stress test 

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1018,9 +1018,13 @@ def finalize_and_sanitize(src_params):
         dest_params["use_full_merge_v1"] = 0
         dest_params["enable_pipelined_write"] = 0
         dest_params["use_attribute_group"] = 0
-    # TODO(hx235): Enable below fault injections again after resolving the apparent WAL hole
-    # that the mishandling of these faults create and is detected by `track_and_verify_wals=0`
-    if dest_params.get("track_and_verify_wals", 0) == 1:
+    # TODO(hx235): Re-enable write fault injections with pessimistic 
+    # transactions after resolving the WAL hole caused by how corrupted 
+    # WAL is handled under 2PC upon WAL write error recovery. 
+    if (
+        dest_params.get("track_and_verify_wals", 0) == 1 
+        and dest_params.get("use_optimistic_txn") == 0
+    ):
         dest_params["metadata_write_fault_one_in"] = 0
         dest_params["write_fault_one_in"] = 0
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest


### PR DESCRIPTION
**Context/Summary:**

https://github.com/facebook/rocksdb/pull/13263 temporally disabled `track_and_verify_wals=1` with write fault injection in all cases to mitigate a WAL hole surfaced by `track_and_verify_wals=1` not fully debugged at that time. Fully debugging shows the WAL hole only happens under pessimistic TXN  when two-phase-commit (2pc) was used. 

The bug essentially is about 2pc won't be able to discard the corrupted WAL as it would in non-2pc case as part of the WAL write error recovery. So the corrupted WAL will still present in the next DB open and caught by `track_and_verify_wals=1`.

This fix is going to take a while. So for now, let's reduce the scope of disabling the testing. 


**Test:**
Monitor stress test for WAL recovery error/corruption

