### PR TITLE
Skip secondary verification on injected read error

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -223,6 +223,14 @@ class NonBatchedOpsStressTest : public StressTest {
 
             s = secondary_db_->Get(options, secondary_cfhs_[cf], key, &from_db);
 
+            if (!s.ok() && IsErrorInjectedAndRetryable(s)) {
+              fprintf(
+                  stdout,
+                  "Skipping secondary verification for key because error was "
+                  "injected into read\n");
+              continue;
+            }
+
             assert(!pre_read_expected_values.empty() &&
                    static_cast<size_t>(i - start) <
                        pre_read_expected_values.size());
@@ -231,7 +239,6 @@ class NonBatchedOpsStressTest : public StressTest {
                              pre_read_expected_values[i - start]);
           }
         }
-
       } else if (method == VerificationMethod::kGetEntity) {
         for (int64_t i = start; i < end; ++i) {
           if (thread->shared->HasVerificationFailedYet()) {
@@ -2966,11 +2973,7 @@ class NonBatchedOpsStressTest : public StressTest {
                           Slice(expected_value_data, expected_value_data_size));
         return false;
       }
-    } else if (IsErrorInjectedAndRetryable(s) {
-      fprintf(stdout,
-              "Skipping secondary verification because error was "
-              "injected into read\n");
-      } else {
+    } else {
       VerificationAbort(
           shared,
           msg_prefix + ": Non-OK status" + read_u64ts.str() + s.ToString(), cf,

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -2966,10 +2966,14 @@ class NonBatchedOpsStressTest : public StressTest {
                           Slice(expected_value_data, expected_value_data_size));
         return false;
       }
-    } else {
+    } else if (IsErrorInjectedAndRetryable(s) {
+      fprintf(stdout,
+              "Skipping secondary verification because error was "
+              "injected into read\n");
+      } else {
       VerificationAbort(
           shared,
-          msg_prefix + "Non-OK status" + read_u64ts.str() + s.ToString(), cf,
+          msg_prefix + ": Non-OK status" + read_u64ts.str() + s.ToString(), cf,
           key, "", Slice(expected_value_data, expected_value_data_size));
       return false;
     }


### PR DESCRIPTION
# Summary

#13281 added secondary database verification to the crash tests.

I am seeing failures in the crash test that trace back to these two code sections:

1. https://github.com/facebook/rocksdb/blob/main/db_stress_tool/no_batched_ops_stress.cc#L2969-L2975
```cpp
VerificationAbort(
          shared,
          msg_prefix + "Non-OK status" + read_u64ts.str() + s.ToString(), cf,
          key, "", Slice(expected_value_data, expected_value_data_size));
```
2. https://github.com/facebook/rocksdb/blob/main/table/block_fetcher.cc#L327-L331
```cpp
      io_status_ = IOStatus::Corruption(
          "truncated block read from " + file_->file_name() + " offset " +
          std::to_string(handle_.offset()) + ", expected " +
          std::to_string(block_size_with_trailer_) + " bytes, got " +
          std::to_string(slice_.size()));
```

The error messages look like
```
Secondary get verificationNon-OK statusCorruption: truncated block read from /dev/shm/rocksdb_test/rocksdb_crashtest_blackbox/011887.sst offset 11780096, expected 16274 bytes, got 0
```

As you can see, the issue is not that the values of the secondary DB differ from what we expect. Rather, the `get` request itself is returning a non-OK status. I looked at the test configurations for the failed test runs, and I saw that both of them enabled fault injections (e.g. `read_fault_one_in`).


# Test Plan

Before merging: `python3 tools/db_crashtest.py --simple blackbox --test_secondary=1`
After merging: monitor for crash test failures 