### PR TITLE
Return injected error when injecting empty result and corrupted bytes read error

### DIFF
--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -1412,6 +1412,7 @@ IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalReadError(
       msg << "empty result";
       ctx->message = msg.str();
       ret_fault_injected = true;
+      ret = IOStatus::IOError(ctx->message);
     } else if (!direct_io && Random::GetTLSInstance()->OneIn(7) &&
                scratch != nullptr && result->data() == scratch) {
       assert(result);
@@ -1430,6 +1431,7 @@ IOStatus FaultInjectionTestFS::MaybeInjectThreadLocalReadError(
       msg << "corrupt last byte";
       ctx->message = msg.str();
       ret_fault_injected = true;
+      ret = IOStatus::IOError(ctx->message);
     } else {
       msg << "error result multiget single";
       ctx->message = msg.str();


### PR DESCRIPTION
**Context/Summary:**

@archang19 found the place in code where no injected error status is returned on effectively injected error (empty result or corrupted bytes). I can't find a good argument for doing so since in these cases where such empty result and corrupted result is not expected, the file system should return error (< 0). Our fault injection framework should align with that to simulate fault returned by file system. Though there can be rate bugs or unexpected behavior in the FS as mentioned in https://github.com/facebook/rocksdb/pull/13369#issuecomment-2635020045, we should limit the testing on those to simplify the crash test.


**Test:**
Monitor stress test 