### PR TITLE
Expose a simple secondary index implementation

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -318,6 +318,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "utilities/persistent_cache/persistent_cache_tier.cc",
         "utilities/persistent_cache/volatile_tier_impl.cc",
         "utilities/secondary_index/secondary_index_iterator.cc",
+        "utilities/secondary_index/simple_secondary_index.cc",
         "utilities/simulator_cache/cache_simulator.cc",
         "utilities/simulator_cache/sim_cache.cc",
         "utilities/table_properties_collectors/compact_for_tiering_collector.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,6 +940,7 @@ set(SOURCES
         utilities/persistent_cache/persistent_cache_tier.cc
         utilities/persistent_cache/volatile_tier_impl.cc
         utilities/secondary_index/secondary_index_iterator.cc
+        utilities/secondary_index/simple_secondary_index.cc
         utilities/simulator_cache/cache_simulator.cc
         utilities/simulator_cache/sim_cache.cc
         utilities/table_properties_collectors/compact_for_tiering_collector.cc

--- a/include/rocksdb/utilities/secondary_index_simple.h
+++ b/include/rocksdb/utilities/secondary_index_simple.h
@@ -1,0 +1,57 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <string>
+
+#include "rocksdb/rocksdb_namespace.h"
+#include "rocksdb/utilities/secondary_index.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// EXPERIMENTAL
+//
+// A simple secondary index implementation that indexes the specified column
+// as-is.
+
+class SimpleSecondaryIndex : public SecondaryIndex {
+ public:
+  explicit SimpleSecondaryIndex(std::string primary_column_name);
+
+  void SetPrimaryColumnFamily(ColumnFamilyHandle* column_family) override;
+  void SetSecondaryColumnFamily(ColumnFamilyHandle* column_family) override;
+
+  ColumnFamilyHandle* GetPrimaryColumnFamily() const override;
+  ColumnFamilyHandle* GetSecondaryColumnFamily() const override;
+
+  Slice GetPrimaryColumnName() const override;
+
+  Status UpdatePrimaryColumnValue(
+      const Slice& primary_key, const Slice& primary_column_value,
+      std::optional<std::variant<Slice, std::string>>* updated_column_value)
+      const override;
+
+  Status GetSecondaryKeyPrefix(
+      const Slice& primary_key, const Slice& primary_column_value,
+      std::variant<Slice, std::string>* secondary_key_prefix) const override;
+
+  Status FinalizeSecondaryKeyPrefix(
+      std::variant<Slice, std::string>* secondary_key_prefix) const override;
+
+  Status GetSecondaryValue(const Slice& primary_key,
+                           const Slice& primary_column_value,
+                           const Slice& original_column_value,
+                           std::optional<std::variant<Slice, std::string>>*
+                               secondary_value) const override;
+
+ private:
+  std::string primary_column_name_;
+  ColumnFamilyHandle* primary_column_family_{};
+  ColumnFamilyHandle* secondary_column_family_{};
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/src.mk
+++ b/src.mk
@@ -305,6 +305,7 @@ LIB_SOURCES =                                                   \
   utilities/persistent_cache/persistent_cache_tier.cc           \
   utilities/persistent_cache/volatile_tier_impl.cc              \
   utilities/secondary_index/secondary_index_iterator.cc         \
+  utilities/secondary_index/simple_secondary_index.cc           \
   utilities/simulator_cache/cache_simulator.cc                  \
   utilities/simulator_cache/sim_cache.cc                        \
   utilities/table_properties_collectors/compact_for_tiering_collector.cc \

--- a/unreleased_history/new_features/simple_secondary_index.md
+++ b/unreleased_history/new_features/simple_secondary_index.md
@@ -1,0 +1,1 @@
+Experimental feature: added support for simple secondary indices that index the specified column as-is. See `SimpleSecondaryIndex` and `SecondaryIndex` for more details.

--- a/utilities/secondary_index/simple_secondary_index.cc
+++ b/utilities/secondary_index/simple_secondary_index.cc
@@ -1,0 +1,79 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <cassert>
+
+#include "rocksdb/utilities/secondary_index_simple.h"
+#include "util/coding.h"
+#include "utilities/secondary_index/secondary_index_helper.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+SimpleSecondaryIndex::SimpleSecondaryIndex(std::string primary_column_name)
+    : primary_column_name_(std::move(primary_column_name)) {}
+
+void SimpleSecondaryIndex::SetPrimaryColumnFamily(
+    ColumnFamilyHandle* column_family) {
+  assert(column_family);
+  primary_column_family_ = column_family;
+}
+
+void SimpleSecondaryIndex::SetSecondaryColumnFamily(
+    ColumnFamilyHandle* column_family) {
+  assert(column_family);
+  secondary_column_family_ = column_family;
+}
+
+ColumnFamilyHandle* SimpleSecondaryIndex::GetPrimaryColumnFamily() const {
+  return primary_column_family_;
+}
+
+ColumnFamilyHandle* SimpleSecondaryIndex::GetSecondaryColumnFamily() const {
+  return secondary_column_family_;
+}
+
+Slice SimpleSecondaryIndex::GetPrimaryColumnName() const {
+  return primary_column_name_;
+}
+
+Status SimpleSecondaryIndex::UpdatePrimaryColumnValue(
+    const Slice& /* primary_key */, const Slice& /* primary_column_value */,
+    std::optional<std::variant<Slice, std::string>>* /* updated_column_value */)
+    const {
+  return Status::OK();
+}
+
+Status SimpleSecondaryIndex::GetSecondaryKeyPrefix(
+    const Slice& /* primary_key */, const Slice& primary_column_value,
+    std::variant<Slice, std::string>* secondary_key_prefix) const {
+  assert(secondary_key_prefix);
+
+  *secondary_key_prefix = primary_column_value;
+
+  return Status::OK();
+}
+
+Status SimpleSecondaryIndex::FinalizeSecondaryKeyPrefix(
+    std::variant<Slice, std::string>* secondary_key_prefix) const {
+  assert(secondary_key_prefix);
+
+  std::string prefix;
+  PutLengthPrefixedSlice(&prefix,
+                         SecondaryIndexHelper::AsSlice(*secondary_key_prefix));
+
+  *secondary_key_prefix = std::move(prefix);
+
+  return Status::OK();
+}
+
+Status SimpleSecondaryIndex::GetSecondaryValue(
+    const Slice& /* primary_key */, const Slice& /* primary_column_value */,
+    const Slice& /* original_column_value */,
+    std::optional<std::variant<Slice, std::string>>* /* secondary_value */)
+    const {
+  return Status::OK();
+}
+
+}  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: We have a class called `DefaultSecondaryIndex` in `TransactionTest.SecondaryIndexPutDelete` that contains generally useful functionality. The patch generalizes it a bit to make the column name configurable, renames it to `SimpleSecondaryIndex`, and moves it to the public API so applications can use it.

Differential Revision: D69147890


