### PR TITLE
BlobDB is not compatible with secondary instances

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1073,6 +1073,7 @@ def gen_cmd_params(args):
     if (
         not args.test_best_efforts_recovery
         and not args.test_tiered_storage
+        and params.get("test_secondary", 0) == 0
         and random.choice([0] * 9 + [1]) == 1
     ):
         params.update(blob_params)


### PR DESCRIPTION
# Summary

There was a failed TSAN crash test run that involved BlobDB and secondary instances. @ltamasi said that BlobDB is not compatible with secondary instances, so I have updated the crash test script accordingly.

# Test Plan

I confirmed there were no blob-related parameters after running

```
python3 tools/db_crashtest.py --simple blackbox --test_secondary=1
```