### PR TITLE
disable_wal and reopen are incompatible

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -813,6 +813,7 @@ def finalize_and_sanitize(src_params):
         dest_params["atomic_flush"] = 1
         dest_params["sync"] = 0
         dest_params["write_fault_one_in"] = 0
+        dest_params["reopen"] = 0
     if dest_params.get("open_files", 1) != -1:
         # Compaction TTL and periodic compactions are only compatible
         # with open_files = -1
@@ -1018,11 +1019,11 @@ def finalize_and_sanitize(src_params):
         dest_params["use_full_merge_v1"] = 0
         dest_params["enable_pipelined_write"] = 0
         dest_params["use_attribute_group"] = 0
-    # TODO(hx235): Re-enable write fault injections with pessimistic 
-    # transactions after resolving the WAL hole caused by how corrupted 
-    # WAL is handled under 2PC upon WAL write error recovery. 
+    # TODO(hx235): Re-enable write fault injections with pessimistic
+    # transactions after resolving the WAL hole caused by how corrupted
+    # WAL is handled under 2PC upon WAL write error recovery.
     if (
-        dest_params.get("track_and_verify_wals", 0) == 1 
+        dest_params.get("track_and_verify_wals", 0) == 1
         and dest_params.get("use_optimistic_txn") == 0
     ):
         dest_params["metadata_write_fault_one_in"] = 0


### PR DESCRIPTION
# Summary

We want to disable WAL for RoWS stress tests (@anand1976 made a config change to explicitly do this), but it turns out that is not compatible with `reopen` > 0.

I found this error in the logs:
```
Error: Db cannot reopen safely with disable_wal set!
```

# Test Plan

We should not get this error message in the RoWS stress tests.