### PR TITLE
Fix flaky test ExternalSSTFileBasicTest.Basic

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5952,6 +5952,7 @@ Status DBImpl::IngestExternalFiles(
 
     num_running_ingest_file_ += static_cast<int>(num_cfs);
     TEST_SYNC_POINT("DBImpl::IngestExternalFile:AfterIncIngestFileCounter");
+    TEST_SYNC_POINT("DBImpl::IngestExternalFile:AfterIncIngestFileCounter:2");
 
     bool at_least_one_cf_need_flush = false;
     std::vector<bool> need_flush(num_cfs, false);

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -265,8 +265,8 @@ TEST_F(ExternalSSTFileBasicTest, Basic) {
   SyncPoint::GetInstance()->LoadDependency({
       {"DBImpl::IngestExternalFile:AfterIncIngestFileCounter",
        "ExternalSSTFileBasicTest.LiveWriteStart"},
-      {"ExternalSSTFileBasicTest.LiveWriteStart",
-       "DBImpl::IngestExternalFiles:InstallSVForFirstCF:0"},
+      {"WriteThread::JoinBatchGroup::AfterLinkOne",
+       "DBImpl::IngestExternalFile:AfterIncIngestFileCounter:2"},
   });
   SyncPoint::GetInstance()->EnableProcessing();
   PerfContext* write_thread_perf_context;

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -265,7 +265,7 @@ TEST_F(ExternalSSTFileBasicTest, Basic) {
   SyncPoint::GetInstance()->LoadDependency({
       {"DBImpl::IngestExternalFile:AfterIncIngestFileCounter",
        "ExternalSSTFileBasicTest.LiveWriteStart"},
-      {"WriteThread::JoinBatchGroup::AfterLinkOne",
+      {"WriteThread::JoinBatchGroup:Wait",
        "DBImpl::IngestExternalFile:AfterIncIngestFileCounter:2"},
   });
   SyncPoint::GetInstance()->EnableProcessing();

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -410,7 +410,6 @@ void WriteThread::JoinBatchGroup(Writer* w) {
     SetState(w, STATE_GROUP_LEADER);
   }
 
-  TEST_SYNC_POINT("WriteThread::JoinBatchGroup::AfterLinkOne");
   TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Wait", w);
   TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Wait2", w);
 

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -410,6 +410,7 @@ void WriteThread::JoinBatchGroup(Writer* w) {
     SetState(w, STATE_GROUP_LEADER);
   }
 
+  TEST_SYNC_POINT("WriteThread::JoinBatchGroup::AfterLinkOne");
   TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Wait", w);
   TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Wait2", w);
 


### PR DESCRIPTION
This test is flaky likely due to synchronization of the file ingestion thread and the live write thread with test sync points are not working as expected sometimes. Very occasionally, the live write thread can enter the write queue after file ingestion job already dequeued. Or it entered and waited for a very short period of time and quickly returned in the fast path: https://github.com/facebook/rocksdb/blob/833a2266a394fe5f140d2a22f406c82bb605c726/db/write_thread.cc#L83-L86

To fix the flakiness, I moved the test sync points to make sure the write thread is already linked into the write queue before the file ingestion writer get dequeued, so it definitely would need to wait some time in order to do its write.

Test plan:
I'm able to reproduce the flakiness with this command before the fix  with every two or three runs:
./gtest-parallel external_sst_file_basic_test --gtest_filter=ExternalSSTFileBasicTest.Basic --repeat=10000 --workers=100

After the fix, I have tried the command for 10 runs, and there is no failure detected.