### PR TITLE
Add enable_remote_compaction option to DB Stress

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -422,6 +422,7 @@ DECLARE_bool(allow_unprepared_value);
 DECLARE_string(file_temperature_age_thresholds);
 DECLARE_uint32(commit_bypass_memtable_one_in);
 DECLARE_bool(track_and_verify_wals);
+DECLARE_bool(enable_remote_compaction);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_compaction_service.h
+++ b/db_stress_tool/db_stress_compaction_service.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "include/rocksdb/options.h"
+#include "rocksdb/options.h"
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/db_stress_tool/db_stress_compaction_service.h
+++ b/db_stress_tool/db_stress_compaction_service.h
@@ -1,0 +1,39 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include "include/rocksdb/options.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Service to simulate Remote Compaction in Stress Test
+class DbStressCompactionService : public CompactionService {
+ public:
+  explicit DbStressCompactionService() {}
+
+  static const char* kClassName() { return "DbStressCompactionService"; }
+
+  const char* Name() const override { return kClassName(); }
+
+  CompactionServiceScheduleResponse Schedule(
+      const CompactionServiceJobInfo& /*info*/,
+      const std::string& /*compaction_service_input*/) override {
+    CompactionServiceScheduleResponse response(
+        "Implement Me", CompactionServiceJobStatus::kUseLocal);
+    return response;
+  }
+
+  CompactionServiceJobStatus Wait(const std::string& /*scheduled_job_id*/,
+                                  std::string* /*result*/) override {
+    // TODO - Implement
+    return CompactionServiceJobStatus::kUseLocal;
+  }
+
+  // TODO - Implement
+  void CancelAwaitingJobs() override {}
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -851,6 +851,9 @@ DEFINE_bool(track_and_verify_wals,
             ROCKSDB_NAMESPACE::Options().track_and_verify_wals,
             "See Options::track_and_verify_wals");
 
+DEFINE_bool(enable_remote_compaction, false,
+            "Enable (simulated) Remote Compaction");
+
 static bool ValidateInt32Percent(const char* flagname, int32_t value) {
   if (value < 0 || value > 100) {
     fprintf(stderr, "Invalid value for --%s: %d, 0<= pct <=100 \n", flagname,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -19,6 +19,7 @@
 #ifdef GFLAGS
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_compaction_filter.h"
+#include "db_stress_tool/db_stress_compaction_service.h"
 #include "db_stress_tool/db_stress_driver.h"
 #include "db_stress_tool/db_stress_filters.h"
 #include "db_stress_tool/db_stress_table_properties_collector.h"
@@ -4297,6 +4298,11 @@ void InitializeOptionsFromFlags(
       static_cast<CacheTier>(FLAGS_lowest_used_cache_tier);
   options.inplace_update_support = FLAGS_inplace_update_support;
   options.uncache_aggressiveness = FLAGS_uncache_aggressiveness;
+
+  // Remote Compaction
+  if (FLAGS_enable_remote_compaction) {
+    options.compaction_service = std::make_shared<DbStressCompactionService>();
+  }
 }
 
 void InitializeOptionsGeneral(

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1808,6 +1808,9 @@ DEFINE_bool(track_and_verify_wals_in_manifest, false,
 
 DEFINE_bool(track_and_verify_wals, false, "See Options.track_and_verify_wals");
 
+DEFINE_bool(enable_remote_compaction, false,
+            "Enable (simulated) Remote Compaction");
+
 namespace ROCKSDB_NAMESPACE {
 namespace {
 static Status CreateMemTableRepFactory(

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1808,9 +1808,6 @@ DEFINE_bool(track_and_verify_wals_in_manifest, false,
 
 DEFINE_bool(track_and_verify_wals, false, "See Options.track_and_verify_wals");
 
-DEFINE_bool(enable_remote_compaction, false,
-            "Enable (simulated) Remote Compaction");
-
 namespace ROCKSDB_NAMESPACE {
 namespace {
 static Status CreateMemTableRepFactory(

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1032,9 +1032,6 @@ def finalize_and_sanitize(src_params):
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
     if dest_params.get("test_secondary") == 1:
         dest_params["continuous_verification_interval"] = 0
-    if dest_params.get("enable_remote_compaction", 0) == 1:
-        # TODO(jaykorean): Enable Merge Operator in Remote Compaction
-        dest_params["use_merge"] = 0
     return dest_params
 
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -344,6 +344,7 @@ default_params = {
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
     "track_and_verify_wals": lambda: random.choice([0, 1]),
+    "enable_remote_compaction": lambda: random.choice([0, 1]), 
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR
@@ -1031,6 +1032,9 @@ def finalize_and_sanitize(src_params):
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
     if dest_params.get("test_secondary") == 1:
         dest_params["continuous_verification_interval"] = 0
+    if dest_params.get("enable_remote_compaction", 0) == 1:
+        # TODO(jaykorean): Enable Merge Operator in Remote Compaction
+        dest_params["use_merge"] = 0
     return dest_params
 
 


### PR DESCRIPTION
# Summary

First step to add (simulated) Remote Compaction in Stress Test. More PRs to come. Just first PR to add the FLAG to enable it. `DbStressCompactionService` will return `kUseLocal` for all compactions.

# Test Plan
```
python3 -u tools/db_crashtest.py whitebox --enable_remote_compaction=1
```
```
python3 -u tools/db_crashtest.py blackbox --enable_remote_compaction=1
```