### PR TITLE
Set manual_wal_flush_one_in to 0 when disable_wal is 1

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -815,6 +815,10 @@ def finalize_and_sanitize(src_params):
         dest_params["sync"] = 0
         dest_params["write_fault_one_in"] = 0
         dest_params["reopen"] = 0
+        dest_params["manual_wal_flush_one_in"] = 0
+        # disableWAL and recycle_log_file_num options are not mutually
+        # compatible at the moment
+        dest_params["recycle_log_file_num"] = 0
     if dest_params.get("open_files", 1) != -1:
         # Compaction TTL and periodic compactions are only compatible
         # with open_files = -1
@@ -970,11 +974,6 @@ def finalize_and_sanitize(src_params):
             # we have a fix that allows auto recovery.
             dest_params["exclude_wal_from_write_fault_injection"] = 1
             dest_params["metadata_write_fault_one_in"] = 0
-    if dest_params.get("disable_wal") == 1:
-        # disableWAL and recycle_log_file_num options are not mutually
-        # compatible at the moment
-        dest_params["recycle_log_file_num"] = 0
-        dest_params["manual_wal_flush_one_in"] = 0
     # Enabling block_align with compression is not supported
     if dest_params.get("block_align") == 1:
         dest_params["compression_type"] = "none"

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -344,7 +344,7 @@ default_params = {
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
     "track_and_verify_wals": lambda: random.choice([0, 1]),
-    "enable_remote_compaction": lambda: random.choice([0, 1]), 
+    "enable_remote_compaction": lambda: random.choice([0, 1]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR
@@ -974,6 +974,7 @@ def finalize_and_sanitize(src_params):
         # disableWAL and recycle_log_file_num options are not mutually
         # compatible at the moment
         dest_params["recycle_log_file_num"] = 0
+        dest_params["manual_wal_flush_one_in"] = 0
     # Enabling block_align with compression is not supported
     if dest_params.get("block_align") == 1:
         dest_params["compression_type"] = "none"


### PR DESCRIPTION
# Summary

I found a failed crash test with this error message:

```
Verification failed: Failed to flush primary's WAL before secondary verification
```

`manual_wal_flush_one_in` does not make sense / is not applicable when we are disabling the WAL.

# Test Plan

Monitor future crash test runs