### PR TITLE
Improve atomicity of SetOptions, skip manifest write

### DIFF
--- a/db/column_family.h
+++ b/db/column_family.h
@@ -210,6 +210,7 @@ struct SuperVersion {
   ReadOnlyMemTable* mem;
   MemTableListVersion* imm;
   Version* current;
+  // TODO: do we really need this in addition to what's in current Version?
   MutableCFOptions mutable_cf_options;
   // Version number of the current SuperVersion
   uint64_t version_number;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1296,18 +1296,42 @@ Status DBImpl::SetOptions(
   {
     auto db_options = GetDBOptions();
     InstrumentedMutexLock l(&mutex_);
-    s = cfd->SetOptions(db_options, options_map);
-    if (s.ok()) {
-      new_options_copy = cfd->GetLatestMutableCFOptions();
-      // Append new version to recompute compaction score.
-      VersionEdit dummy_edit;
-      s = versions_->LogAndApply(cfd, read_options, write_options, &dummy_edit,
-                                 &mutex_, directories_.GetDbDir());
-      if (!versions_->io_status().ok()) {
-        assert(!s.ok());
-        error_handler_.SetBGError(versions_->io_status(),
-                                  BackgroundErrorReason::kManifestWrite);
+    // Manifest writers + Version appenders like flush and compaction use
+    // LogAndApply, which releases DB mutex to wait for other manifest writers
+    // and for the manifest write. We need to append a Version for the options
+    // to take full effect (e.g. compaction scores), but we don't want to
+    // interleave with other callers of LogAndApply, which could at least
+    // temporarily roll back option changes. Thus, we use a special call to
+    // LogAndApply that allows us to
+    //
+    // (a) Apply the options update when we know we are the exclusive version
+    // appender + (fake) manifest writer, and
+    //
+    // (b) Append a new Version without manifest write nor DB mutex release
+    //
+    // Thus aren't releasing the DB mutex again until the end of this block,
+    // after installing the new SuperVersion.
+    auto pre_cb = [&]() -> Status {
+      Status cb_s = cfd->SetOptions(db_options, options_map);
+      if (cb_s.ok()) {
+        new_options_copy = cfd->GetLatestMutableCFOptions();
       }
+      return cb_s;
+    };
+    VersionEdit dummy_edit;
+    dummy_edit.MemoryOnlyCFManipulation();
+    TEST_SYNC_POINT_CALLBACK("DBImpl::SetOptions:dummy_edit", &dummy_edit);
+    s = versions_->LogAndApply(
+        cfd, read_options, write_options, &dummy_edit, &mutex_,
+        directories_.GetDbDir(), false /*new_descriptor_log=*/,
+        nullptr /*new_opts*/, {} /*manifest_wcb*/, pre_cb);
+    if (!versions_->io_status().ok()) {
+      assert(!s.ok());
+      error_handler_.SetBGError(versions_->io_status(),
+                                BackgroundErrorReason::kManifestWrite);
+    }
+
+    if (s.ok()) {
       // Trigger possible flush/compactions. This has to be before we persist
       // options to file, otherwise there will be a deadlock with writer
       // thread.
@@ -1315,6 +1339,14 @@ Status DBImpl::SetOptions(
       persist_options_status =
           WriteOptionsFile(write_options, true /*db_mutex_already_held*/);
       bg_cv_.SignalAll();
+
+#if __cplusplus >= 202002L
+      assert(new_options_copy == cfd->GetLatestMutableCFOptions());
+      assert(cfd->GetLatestMutableCFOptions() ==
+             cfd->GetCurrentMutableCFOptions());
+      assert(cfd->GetCurrentMutableCFOptions() ==
+             cfd->current()->GetMutableCFOptions());
+#endif
     }
   }
   sv_context.Clean();

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1319,7 +1319,7 @@ Status DBImpl::SetOptions(
       return cb_s;
     };
     VersionEdit dummy_edit;
-    dummy_edit.MemoryOnlyCFManipulation();
+    dummy_edit.MarkNoManifestWriteDummy();
     TEST_SYNC_POINT_CALLBACK("DBImpl::SetOptions:dummy_edit", &dummy_edit);
     s = versions_->LogAndApply(
         cfd, read_options, write_options, &dummy_edit, &mutex_,

--- a/db/merge_test.cc
+++ b/db/merge_test.cc
@@ -377,6 +377,14 @@ void testCountersWithFlushAndCompaction(Counters& counters, DB* db) {
       {"testCountersWithFlushAndCompaction:AfterGet",
        "testCountersWithFlushAndCompaction::bg_flush_thread:2"},
   });
+  // This test relies on old behavior of SetOptions writing to the
+  // manifest. Here we restore that old behavior for reproducer purposes.
+  // (Brief attempts to use an alternative to SetOptions failed.)
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::SetOptions:dummy_edit", [&](void* arg) {
+        auto* dummy_edit = static_cast<VersionEdit*>(arg);
+        dummy_edit->Clear();
+      });
   SyncPoint::GetInstance()->EnableProcessing();
 
   port::Thread set_options_thread([&]() {

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -59,42 +59,11 @@ Status FileMetaData::UpdateBoundaries(const Slice& key, const Slice& value,
   return Status::OK();
 }
 
-void VersionEdit::Clear() {
-  max_level_ = 0;
-  db_id_.clear();
-  comparator_.clear();
-  log_number_ = 0;
-  prev_log_number_ = 0;
-  next_file_number_ = 0;
-  max_column_family_ = 0;
-  min_log_number_to_keep_ = 0;
-  last_sequence_ = 0;
-  has_db_id_ = false;
-  has_comparator_ = false;
-  has_log_number_ = false;
-  has_prev_log_number_ = false;
-  has_next_file_number_ = false;
-  has_max_column_family_ = false;
-  has_min_log_number_to_keep_ = false;
-  has_last_sequence_ = false;
-  compact_cursors_.clear();
-  deleted_files_.clear();
-  new_files_.clear();
-  blob_file_additions_.clear();
-  blob_file_garbages_.clear();
-  wal_additions_.clear();
-  wal_deletion_.Reset();
-  column_family_ = 0;
-  is_column_family_add_ = false;
-  is_column_family_drop_ = false;
-  column_family_name_.clear();
-  is_in_atomic_group_ = false;
-  remaining_entries_ = 0;
-  full_history_ts_low_.clear();
-}
+void VersionEdit::Clear() { *this = VersionEdit(); }
 
 bool VersionEdit::EncodeTo(std::string* dst,
                            std::optional<size_t> ts_sz) const {
+  assert(!IsNoManifestWriteDummy());
   if (has_db_id_) {
     PutVarint32(dst, kDbId);
     PutLengthPrefixedSlice(dst, db_id_);

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -85,8 +85,7 @@ void VersionEdit::Clear() {
   wal_additions_.clear();
   wal_deletion_.Reset();
   column_family_ = 0;
-  is_column_family_add_ = false;
-  is_column_family_drop_ = false;
+  cf_manip_ = ColumnFamilyManipulation::kNone;
   column_family_name_.clear();
   is_in_atomic_group_ = false;
   remaining_entries_ = 0;
@@ -292,13 +291,20 @@ bool VersionEdit::EncodeTo(std::string* dst,
     PutVarint32Varint32(dst, kColumnFamily, column_family_);
   }
 
-  if (is_column_family_add_) {
-    PutVarint32(dst, kColumnFamilyAdd);
-    PutLengthPrefixedSlice(dst, Slice(column_family_name_));
-  }
-
-  if (is_column_family_drop_) {
-    PutVarint32(dst, kColumnFamilyDrop);
+  switch (cf_manip_) {
+    case ColumnFamilyManipulation::kAdd:
+      PutVarint32(dst, kColumnFamilyAdd);
+      PutLengthPrefixedSlice(dst, Slice(column_family_name_));
+      break;
+    case ColumnFamilyManipulation::kDrop:
+      PutVarint32(dst, kColumnFamilyDrop);
+      break;
+    case ColumnFamilyManipulation::kMemoryOnly:
+      // Not to be serialized
+      assert(false);
+      break;
+    case ColumnFamilyManipulation::kNone:
+      break;
   }
 
   if (is_in_atomic_group_) {
@@ -755,7 +761,7 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
 
       case kColumnFamilyAdd:
         if (GetLengthPrefixedSlice(&input, &str)) {
-          is_column_family_add_ = true;
+          cf_manip_ = ColumnFamilyManipulation::kAdd;
           column_family_name_ = str.ToString();
         } else {
           if (!msg) {
@@ -765,7 +771,7 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         break;
 
       case kColumnFamilyDrop:
-        is_column_family_drop_ = true;
+        cf_manip_ = ColumnFamilyManipulation::kDrop;
         break;
 
       case kInAtomicGroup:
@@ -948,12 +954,19 @@ std::string VersionEdit::DebugString(bool hex_key) const {
 
   r.append("\n  ColumnFamily: ");
   AppendNumberTo(&r, column_family_);
-  if (is_column_family_add_) {
-    r.append("\n  ColumnFamilyAdd: ");
-    r.append(column_family_name_);
-  }
-  if (is_column_family_drop_) {
-    r.append("\n  ColumnFamilyDrop");
+  switch (cf_manip_) {
+    case ColumnFamilyManipulation::kAdd:
+      r.append("\n  ColumnFamilyAdd: ");
+      r.append(column_family_name_);
+      break;
+    case ColumnFamilyManipulation::kDrop:
+      r.append("\n  ColumnFamilyDrop");
+      break;
+    case ColumnFamilyManipulation::kMemoryOnly:
+      r.append("\n  MemoryOnly!");
+      break;
+    case ColumnFamilyManipulation::kNone:
+      break;
   }
   if (is_in_atomic_group_) {
     r.append("\n  AtomicGroup: ");
@@ -1099,11 +1112,18 @@ std::string VersionEdit::DebugJSON(int edit_num, bool hex_key) const {
 
   jw << "ColumnFamily" << column_family_;
 
-  if (is_column_family_add_) {
-    jw << "ColumnFamilyAdd" << column_family_name_;
-  }
-  if (is_column_family_drop_) {
-    jw << "ColumnFamilyDrop" << column_family_name_;
+  switch (cf_manip_) {
+    case ColumnFamilyManipulation::kAdd:
+      jw << "ColumnFamilyAdd" << column_family_name_;
+      break;
+    case ColumnFamilyManipulation::kDrop:
+      jw << "ColumnFamilyDrop" << column_family_name_;
+      break;
+    case ColumnFamilyManipulation::kMemoryOnly:
+      jw << "MemoryOnly" << column_family_name_;
+      break;
+    case ColumnFamilyManipulation::kNone:
+      break;
   }
   if (is_in_atomic_group_) {
     jw << "AtomicGroup" << remaining_entries_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5913,7 +5913,7 @@ Status VersionSet::LogAndApply(
     InstrumentedMutex* mu, FSDirectory* dir_contains_current_file,
     bool new_descriptor_log, const ColumnFamilyOptions* new_cf_options,
     const std::vector<std::function<void(const Status&)>>& manifest_wcbs,
-    const std::function<Status()> pre_cb) {
+    const std::function<Status()>& pre_cb) {
   mu->AssertHeld();
   int num_edits = 0;
   for (const auto& elist : edit_lists) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5424,8 +5424,11 @@ Status VersionSet::ProcessManifestWrites(
         // no grouping when skipping manifest write
         break;
       }
-      if ((*it)->edit_list.front()->IsColumnFamilyManipulation()) {
+      const auto* next = (*it)->edit_list.front();
+      if (next->IsColumnFamilyManipulation() ||
+          next->IsNoManifestWriteDummy()) {
         // no group commits for column family add or drop
+        // nor for dummy skipping manifest write
         break;
       }
     }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1217,7 +1217,7 @@ class VersionSet {
       bool new_descriptor_log = false,
       const ColumnFamilyOptions* column_family_options = nullptr,
       const std::function<void(const Status&)>& manifest_wcb = {},
-      const std::function<Status()> pre_cb = {}) {
+      const std::function<Status()>& pre_cb = {}) {
     autovector<ColumnFamilyData*> cfds;
     cfds.emplace_back(column_family_data);
     autovector<autovector<VersionEdit*>> edit_lists;
@@ -1237,7 +1237,7 @@ class VersionSet {
       FSDirectory* dir_contains_current_file, bool new_descriptor_log = false,
       const ColumnFamilyOptions* column_family_options = nullptr,
       const std::function<void(const Status&)>& manifest_wcb = {},
-      const std::function<Status()> pre_cb = {}) {
+      const std::function<Status()>& pre_cb = {}) {
     autovector<ColumnFamilyData*> cfds;
     cfds.emplace_back(column_family_data);
     autovector<autovector<VersionEdit*>> edit_lists;
@@ -1258,7 +1258,7 @@ class VersionSet {
       bool new_descriptor_log = false,
       const ColumnFamilyOptions* new_cf_options = nullptr,
       const std::vector<std::function<void(const Status&)>>& manifest_wcbs = {},
-      const std::function<Status()> pre_cb = {});
+      const std::function<Status()>& pre_cb = {});
 
   void WakeUpWaitingManifestWriters();
 
@@ -1786,7 +1786,7 @@ class ReactiveVersionSet : public VersionSet {
       InstrumentedMutex* /*mu*/, FSDirectory* /*dir_contains_current_file*/,
       bool /*new_descriptor_log*/, const ColumnFamilyOptions* /*new_cf_option*/,
       const std::vector<std::function<void(const Status&)>>& /*manifest_wcbs*/,
-      const std::function<Status()> /*pre_cb*/) override {
+      const std::function<Status()>& /*pre_cb*/) override {
     return Status::NotSupported("not supported in reactive mode");
   }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1216,7 +1216,8 @@ class VersionSet {
       InstrumentedMutex* mu, FSDirectory* dir_contains_current_file,
       bool new_descriptor_log = false,
       const ColumnFamilyOptions* column_family_options = nullptr,
-      const std::function<void(const Status&)>& manifest_wcb = {}) {
+      const std::function<void(const Status&)>& manifest_wcb = {},
+      const std::function<Status()> pre_cb = {}) {
     autovector<ColumnFamilyData*> cfds;
     cfds.emplace_back(column_family_data);
     autovector<autovector<VersionEdit*>> edit_lists;
@@ -1225,7 +1226,7 @@ class VersionSet {
     edit_lists.emplace_back(edit_list);
     return LogAndApply(cfds, read_options, write_options, edit_lists, mu,
                        dir_contains_current_file, new_descriptor_log,
-                       column_family_options, {manifest_wcb});
+                       column_family_options, {manifest_wcb}, pre_cb);
   }
   // The batch version. If edit_list.size() > 1, caller must ensure that
   // no edit in the list column family add or drop
@@ -1235,14 +1236,15 @@ class VersionSet {
       const autovector<VersionEdit*>& edit_list, InstrumentedMutex* mu,
       FSDirectory* dir_contains_current_file, bool new_descriptor_log = false,
       const ColumnFamilyOptions* column_family_options = nullptr,
-      const std::function<void(const Status&)>& manifest_wcb = {}) {
+      const std::function<void(const Status&)>& manifest_wcb = {},
+      const std::function<Status()> pre_cb = {}) {
     autovector<ColumnFamilyData*> cfds;
     cfds.emplace_back(column_family_data);
     autovector<autovector<VersionEdit*>> edit_lists;
     edit_lists.emplace_back(edit_list);
     return LogAndApply(cfds, read_options, write_options, edit_lists, mu,
                        dir_contains_current_file, new_descriptor_log,
-                       column_family_options, {manifest_wcb});
+                       column_family_options, {manifest_wcb}, pre_cb);
   }
 
   // The across-multi-cf batch version. If edit_lists contain more than
@@ -1255,8 +1257,8 @@ class VersionSet {
       InstrumentedMutex* mu, FSDirectory* dir_contains_current_file,
       bool new_descriptor_log = false,
       const ColumnFamilyOptions* new_cf_options = nullptr,
-      const std::vector<std::function<void(const Status&)>>& manifest_wcbs =
-          {});
+      const std::vector<std::function<void(const Status&)>>& manifest_wcbs = {},
+      const std::function<Status()> pre_cb = {});
 
   void WakeUpWaitingManifestWriters();
 
@@ -1783,8 +1785,8 @@ class ReactiveVersionSet : public VersionSet {
       const autovector<autovector<VersionEdit*>>& /*edit_lists*/,
       InstrumentedMutex* /*mu*/, FSDirectory* /*dir_contains_current_file*/,
       bool /*new_descriptor_log*/, const ColumnFamilyOptions* /*new_cf_option*/,
-      const std::vector<std::function<void(const Status&)>>& /*manifest_wcbs*/)
-      override {
+      const std::vector<std::function<void(const Status&)>>& /*manifest_wcbs*/,
+      const std::function<Status()> /*pre_cb*/) override {
     return Status::NotSupported("not supported in reactive mode");
   }
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -64,6 +64,9 @@ enum CompactionPri : char {
 struct FileTemperatureAge {
   Temperature temperature = Temperature::kUnknown;
   uint64_t age = 0;
+#if __cplusplus >= 202002L
+  bool operator==(const FileTemperatureAge& rhs) const = default;
+#endif
 };
 
 struct CompactionOptionsFIFO {
@@ -116,6 +119,10 @@ struct CompactionOptionsFIFO {
   CompactionOptionsFIFO(uint64_t _max_table_files_size, bool _allow_compaction)
       : max_table_files_size(_max_table_files_size),
         allow_compaction(_allow_compaction) {}
+
+#if __cplusplus >= 202002L
+  bool operator==(const CompactionOptionsFIFO& rhs) const = default;
+#endif
 };
 
 // The control option of how the cache tiers will be used. Currently rocksdb

--- a/include/rocksdb/compression_type.h
+++ b/include/rocksdb/compression_type.h
@@ -174,6 +174,10 @@ struct CompressionOptions {
   void SetMinRatio(double min_ratio) {
     max_compressed_bytes_per_kb = static_cast<int>(1024.0 / min_ratio + 0.5);
   }
+
+#if __cplusplus >= 202002L
+  bool operator==(const CompressionOptions& rhs) const = default;
+#endif
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/universal_compaction.h
+++ b/include/rocksdb/universal_compaction.h
@@ -122,6 +122,10 @@ class CompactionOptionsUniversal {
         stop_style(kCompactionStopStyleTotalSize),
         allow_trivial_move(false),
         incremental(false) {}
+
+#if __cplusplus >= 202002L
+  bool operator==(const CompactionOptionsUniversal& rhs) const = default;
+#endif
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -249,6 +249,10 @@ struct MutableCFOptions {
 
   void Dump(Logger* log) const;
 
+#if __cplusplus >= 202002L
+  bool operator==(const MutableCFOptions& rhs) const = default;
+#endif
+
   // Memtable related options
   size_t write_buffer_size;
   int max_write_buffer_number;


### PR DESCRIPTION
Summary: Motivated by code review issue in #13316, we don't want to release the DB mutex in SetOptions between updating the cfd latest options and installing the new Version and SuperVersion. SetOptions uses LogAndApply to install a new Version but this currently incurs an unnecessary manifest write. (This is not a big performance concern because SetOptions dumps a new OPTIONS file, which is much larger than the redundant manifest update.) Since we don't want IO while holding the DB mutex, we need to get rid of the manifest write, and that's what this change does. We introduce a kind of dummy VersionEdit that allows the existing code paths of LogAndApply to install a new Version (with the updated mutable options), recompute resulting compaction scores etc., but without the manifest write.

Part of the validation for this is new assertions in SetOptions verifying the consistency of the various copies of MutableCFOptions. (I'm not convinced we need it in SuperVersion in addition to Version, but that's not for here and now.) These checks depend on defaulted `operator==` so depend on C++20.

Test Plan: New unit test in addition to new assertions. SetOptions already tested heavily in crash test. Used
`ROCKSDB_CXX_STANDARD=c++20 make -j100 check` to ensure the new assertions are verified