### PR TITLE
Reverse the order of updates to the same key in WriteBatchWithIndex

### DIFF
--- a/db/merge_context.h
+++ b/db/merge_context.h
@@ -140,7 +140,7 @@ class MergeContext {
     }
   }
 
-  // List of operands
+  // List of operands, the order of operands depends on operands_reversed_.
   mutable std::unique_ptr<std::vector<Slice>> operand_list_;
   // Copy of operands that are not pinned.
   std::unique_ptr<std::vector<std::unique_ptr<std::string>>> copied_operands_;

--- a/db/merge_context.h
+++ b/db/merge_context.h
@@ -144,6 +144,7 @@ class MergeContext {
   mutable std::unique_ptr<std::vector<Slice>> operand_list_;
   // Copy of operands that are not pinned.
   std::unique_ptr<std::vector<std::unique_ptr<std::string>>> copied_operands_;
+  // Reversed means the newest update is ordered first.
   mutable bool operands_reversed_ = true;
 };
 

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -856,15 +856,16 @@ TEST_F(WriteBatchTest, ColumnFamiliesBatchWithIndexTest) {
   iter->Seek("eightfoo");
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
-  ASSERT_EQ(WriteType::kPutRecord, iter->Entry().type);
+  // For the same key, most recent update is ordered first.
+  ASSERT_EQ(WriteType::kDeleteRecord, iter->Entry().type);
   ASSERT_EQ("eightfoo", iter->Entry().key.ToString());
-  ASSERT_EQ("bar8", iter->Entry().value.ToString());
 
   iter->Next();
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
-  ASSERT_EQ(WriteType::kDeleteRecord, iter->Entry().type);
+  ASSERT_EQ(WriteType::kPutRecord, iter->Entry().type);
   ASSERT_EQ("eightfoo", iter->Entry().key.ToString());
+  ASSERT_EQ("bar8", iter->Entry().value.ToString());
 
   iter->Next();
   ASSERT_OK(iter->status());
@@ -874,15 +875,15 @@ TEST_F(WriteBatchTest, ColumnFamiliesBatchWithIndexTest) {
   iter->Seek("twofoo");
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
-  ASSERT_EQ(WriteType::kPutRecord, iter->Entry().type);
+  ASSERT_EQ(WriteType::kSingleDeleteRecord, iter->Entry().type);
   ASSERT_EQ("twofoo", iter->Entry().key.ToString());
-  ASSERT_EQ("bar2", iter->Entry().value.ToString());
 
   iter->Next();
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
-  ASSERT_EQ(WriteType::kSingleDeleteRecord, iter->Entry().type);
+  ASSERT_EQ(WriteType::kPutRecord, iter->Entry().type);
   ASSERT_EQ("twofoo", iter->Entry().key.ToString());
+  ASSERT_EQ("bar2", iter->Entry().value.ToString());
 
   iter->Next();
   ASSERT_OK(iter->status());

--- a/unreleased_history/behavior_changes/wbwi-ordering.md
+++ b/unreleased_history/behavior_changes/wbwi-ordering.md
@@ -1,0 +1,1 @@
+* Reversed the order of updates to the same key in WriteBatchWithIndex. This means if there are multiple updates to the same key, the most recent update is ordered first. This affects the output of WBWIIterator. When WriteBatchWithIndex is created with `overwrite_key=true`, this affects the output only if Merge is used (#13387).

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -74,6 +74,8 @@ class BaseDeltaIterator : public Iterator {
 
  private:
   void AssertInvariants();
+  // Advance the current iterator to the next/prev key depending on forward_.
+  // If equal_keys_ is true, advance both base and delta iterators.
   void Advance();
   void AdvanceDelta();
   void AdvanceBase();
@@ -81,10 +83,17 @@ class BaseDeltaIterator : public Iterator {
   bool DeltaValid() const;
   void ResetValueAndColumns();
   void SetValueAndColumnsFromBase();
+  // Requires calling delta_iterator_->FindLatestUpdate() before this call.
+  // Will update value_ and column_ accordingly and assumes that delta iterator
+  // is visible.
   void SetValueAndColumnsFromDelta();
+  // Determine the current key and value for the iterator from base and delta
+  // iterators. Advance base or delta iters if needed.
   void UpdateCurrent();
 
   bool forward_;
+  // The non-current iterator, if valid, is at its first key that is ahead of
+  // the current iterator.
   bool current_at_base_;
   bool equal_keys_;
   bool allow_unprepared_value_;
@@ -119,9 +128,10 @@ struct WriteBatchIndexEntry {
   //                    _search_key should be null in this case.
   WriteBatchIndexEntry(const Slice* _search_key, uint32_t _column_family,
                        bool is_forward_direction, bool is_seek_to_first)
-      // For SeekForPrev(), we need to make the dummy entry larger than any
+      // For SeekForPrev(), we need to make the dummy entry no smaller than any
       // entry who has the same search key. Otherwise, we'll miss those entries.
-      : offset(is_forward_direction ? 0 : std::numeric_limits<size_t>::max()),
+      // Keys are ordered by descending offset.
+      : offset(is_forward_direction ? std::numeric_limits<size_t>::max() : 0),
         column_family(_column_family),
         has_single_del(false),
         has_overwritten_single_del(false),
@@ -141,19 +151,20 @@ struct WriteBatchIndexEntry {
     return key_size == kFlagMinInCf;
   }
 
-  // offset of an entry in write batch's string buffer. If this is a dummy
+  // The offset of an entry in write batch's string buffer. If this is a dummy
   // lookup key, in which case search_key != nullptr, offset is set to either
   // 0 or max, only for comparison purpose. Because when entries have the same
-  // key, the entry with larger offset is larger, offset = 0 will make a seek
-  // key small or equal than all the entries with the seek key, so that Seek()
-  // will find all the entries of the same key. Similarly, offset = MAX will
-  // make the entry just larger than all entries with the search key so
+  // key, the entry with larger offset is smaller, offset = MAX will make a seek
+  // key smaller than all the entries with the seek key, so that Seek()
+  // will find all the entries of the same key. Similarly, offset = 0 will
+  // make the entry larger than or equal to all entries with the seek key so
   // SeekForPrev() will see all the keys with the same key.
   size_t offset;
   uint32_t column_family;  // column family of the entry.
   bool has_single_del;     // whether single del was issued for this key
   bool has_overwritten_single_del;  // whether a single del for this key was
                                     // overwritten by another key
+  // The following two fields are used when search_key is null.
   size_t key_offset;  // offset of the key in write batch's string buffer.
   size_t key_size;    // size of the key. kFlagMinInCf indicates
                       // that this is a dummy look up entry for
@@ -354,16 +365,21 @@ class WBWIIteratorImpl final : public WBWIIterator {
   // Moves the iterator to first entry of the next key.
   void NextKey();
 
-  // Moves the iterator to the Update (Put, PutEntity or Delete) for the current
-  // key. If there is no Put/PutEntity/Delete, the Iterator will point to the
-  // first entry for this key.
-  // @return kFound if a Put/PutEntity was found for the key
-  // @return kDeleted if a delete was found for the key
-  // @return kMergeInProgress if only merges were found for the key
-  // @return kError if an unsupported operation was found for the key
-  // @return kNotFound if no operations were found for this key
+  // If the iterator's current entry equals to `key`, then
+  // - moves the iterator to the most recent update (Put, PutEntity or Delete)
+  // for `key`.
+  // - if there is no update (only Merge), the iterator will point to the last
+  // (oldest) Merge for `key`.
+  // - merge operands will be accumulated in merge_context.
+  // Else, the iterator will not move.
   //
+  // @return kFound if a Put/PutEntity was found for `key`.
+  // @return kDeleted if a Delete was found for `key`
+  // @return kMergeInProgress if only Merges were found for `key`
+  // @return kError if an unsupported operation was found for `key`
+  // @return kNotFound if no operations were found for `key`
   Result FindLatestUpdate(const Slice& key, MergeContext* merge_context);
+  // Find the latest update for iterator's current key.
   Result FindLatestUpdate(MergeContext* merge_context);
 
  protected:

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -695,18 +695,18 @@ TEST_P(WriteBatchWithIndexTest, TestValueAsSecondaryIndex) {
 
 TEST_P(WriteBatchWithIndexTest, WBWIIteratorImpl) {
   // Tests methods of WBWIIteratorImpl, with some overwrites and merges.
-  batch_->Merge("k0", "k0m0");
-  batch_->Put("k0", "k0p1");
+  ASSERT_OK(batch_->Merge("k0", "k0m0"));
+  ASSERT_OK(batch_->Put("k0", "k0p1"));
 
   // a merge and a non-merge
-  batch_->Merge("k1", "k1m0");
-  batch_->Merge("k1", "k1m1");
+  ASSERT_OK(batch_->Merge("k1", "k1m0"));
+  ASSERT_OK(batch_->Merge("k1", "k1m1"));
 
-  batch_->SingleDelete("k2");
+  ASSERT_OK(batch_->SingleDelete("k2"));
 
   // put then merge
-  batch_->Put("k3", "k3p0");
-  batch_->Merge("k3", "k3m1");
+  ASSERT_OK(batch_->Put("k3", "k3p0"));
+  ASSERT_OK(batch_->Merge("k3", "k3m1"));
 
   std::unique_ptr<WBWIIteratorImpl> iter(
       static_cast<WBWIIteratorImpl*>(batch_->NewIterator()));

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -415,7 +415,8 @@ class WriteBatchWithIndexTest : public WBWIBaseTest,
 };
 
 void TestValueAsSecondaryIndexHelper(std::vector<Entry> entries,
-                                     WriteBatchWithIndex* batch) {
+                                     WriteBatchWithIndex* batch,
+                                     bool overwrite) {
   // In this test, we insert <key, value> to column family `data`, and
   // <value, key> to column family `index`. Then iterator them in order
   // and seek them by key.
@@ -425,8 +426,25 @@ void TestValueAsSecondaryIndexHelper(std::vector<Entry> entries,
   // Sort entries by value
   std::map<std::string, std::vector<Entry*>> index_map;
   for (auto& e : entries) {
-    data_map[e.key].push_back(&e);
-    index_map[e.value].push_back(&e);
+    if (overwrite && e.type != kMergeRecord && data_map[e.key].size() > 0) {
+      data_map[e.key].back() = &e;
+    } else {
+      data_map[e.key].push_back(&e);
+    }
+
+    // index does not use Merge, so we overwrite the expected value
+    if (overwrite && index_map[e.value].size() > 0) {
+      index_map[e.value].back() = &e;
+    } else {
+      index_map[e.value].push_back(&e);
+    }
+  }
+  // Most recent update for the same key is ordered first.
+  for (auto& [_, v] : data_map) {
+    std::reverse(v.begin(), v.end());
+  }
+  for (auto& [_, v] : index_map) {
+    std::reverse(v.begin(), v.end());
   }
 
   ColumnFamilyHandleImplDummy data(6, BytewiseComparator());
@@ -554,6 +572,25 @@ void TestValueAsSecondaryIndexHelper(std::vector<Entry> entries,
         ASSERT_OK(iter->status());
       }
     }
+
+    // SeekForPrev
+    for (auto pair = data_map.begin(); pair != data_map.end(); ++pair) {
+      iter->SeekForPrev(pair->first);
+      ASSERT_OK(iter->status());
+      // SeekForPrev positions iter at the last entry <= target.
+      // So we iterate updates from oldest to most recent.
+      for (auto v = pair->second.rbegin(); v != pair->second.rend(); ++v) {
+        ASSERT_TRUE(iter->Valid());
+        auto write_entry = iter->Entry();
+        ASSERT_EQ(pair->first, write_entry.key.ToString());
+        ASSERT_EQ((*v)->type, write_entry.type);
+        if (write_entry.type != kDeleteRecord) {
+          ASSERT_EQ((*v)->value, write_entry.value.ToString());
+        }
+        iter->Prev();
+        ASSERT_OK(iter->status());
+      }
+    }
   }
 
   // Seek to every index
@@ -573,6 +610,24 @@ void TestValueAsSecondaryIndexHelper(std::vector<Entry> entries,
           ASSERT_EQ(v->key, write_entry.value.ToString());
         }
         iter->Next();
+        ASSERT_OK(iter->status());
+      }
+    }
+
+    // SeekForPrev
+    for (auto pair = index_map.begin(); pair != index_map.end(); ++pair) {
+      iter->SeekForPrev(pair->first);
+      ASSERT_OK(iter->status());
+      // SeekForPrev positions iter at the last entry <= target.
+      // So we iterate updates from oldest to most recent.
+      for (auto v = pair->second.rbegin(); v != pair->second.rend(); ++v) {
+        ASSERT_TRUE(iter->Valid());
+        auto write_entry = iter->Entry();
+        ASSERT_EQ(pair->first, write_entry.key.ToString());
+        if ((*v)->type != kDeleteRecord) {
+          ASSERT_EQ((*v)->key, write_entry.value.ToString());
+        }
+        iter->Prev();
         ASSERT_OK(iter->status());
       }
     }
@@ -610,7 +665,7 @@ void TestValueAsSecondaryIndexHelper(std::vector<Entry> entries,
   }
 }
 
-TEST_F(WBWIKeepTest, TestValueAsSecondaryIndex) {
+TEST_P(WriteBatchWithIndexTest, TestValueAsSecondaryIndex) {
   Entry entries[] = {
       {"aaa", "0005", kPutRecord},   {"b", "0002", kPutRecord},
       {"cdd", "0002", kMergeRecord}, {"aab", "00001", kPutRecord},
@@ -619,23 +674,138 @@ TEST_F(WBWIKeepTest, TestValueAsSecondaryIndex) {
   };
   std::vector<Entry> entries_list(entries, entries + 8);
 
-  batch_.reset(new WriteBatchWithIndex(nullptr, 20, false));
+  batch_.reset(new WriteBatchWithIndex(nullptr, 20, GetParam()));
 
-  TestValueAsSecondaryIndexHelper(entries_list, batch_.get());
+  TestValueAsSecondaryIndexHelper(entries_list, batch_.get(), GetParam());
 
   // Clear batch and re-run test with new values
   batch_->Clear();
 
   Entry new_entries[] = {
-      {"aaa", "0005", kPutRecord},   {"e", "0002", kPutRecord},
-      {"add", "0002", kMergeRecord}, {"aab", "00001", kPutRecord},
-      {"zz", "00005", kPutRecord},   {"add", "0002", kPutRecord},
-      {"aab", "0003", kPutRecord},   {"zz", "00005", kDeleteRecord},
+      {"aaa", "0005", kPutRecord}, {"e", "0002", kPutRecord},
+      {"add", "0002", kPutRecord}, {"aab", "00001", kPutRecord},
+      {"zz", "00005", kPutRecord}, {"add", "0002", kMergeRecord},
+      {"aab", "0003", kPutRecord}, {"zz", "00005", kDeleteRecord},
   };
 
   entries_list = std::vector<Entry>(new_entries, new_entries + 8);
 
-  TestValueAsSecondaryIndexHelper(entries_list, batch_.get());
+  TestValueAsSecondaryIndexHelper(entries_list, batch_.get(), GetParam());
+}
+
+TEST_P(WriteBatchWithIndexTest, WBWIIteratorImpl) {
+  // Tests methods of WBWIIteratorImpl, with some overwrites and merges.
+  batch_->Merge("k0", "k0m0");
+  batch_->Put("k0", "k0p1");
+
+  // a merge and a non-merge
+  batch_->Merge("k1", "k1m0");
+  batch_->Merge("k1", "k1m1");
+
+  batch_->SingleDelete("k2");
+
+  // put then merge
+  batch_->Put("k3", "k3p0");
+  batch_->Merge("k3", "k3m1");
+
+  std::unique_ptr<WBWIIteratorImpl> iter(
+      static_cast<WBWIIteratorImpl*>(batch_->NewIterator()));
+
+  auto verify_iter = [&iter](const std::string& k, const std::string& v,
+                             WriteType t, int line) {
+    SCOPED_TRACE("Called from line " + std::to_string(line));
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_OK(iter->status());
+    const auto entry = iter->Entry();
+    ASSERT_EQ(entry.key, k);
+    if (t != kDeleteRecord && t != kSingleDeleteRecord) {
+      ASSERT_EQ(entry.value, v);
+    }
+    ASSERT_EQ(entry.type, t);
+  };
+
+  // Should land on first key >= k0, recent update is ordered first
+  iter->Seek("k0");
+  verify_iter("k0", "k0p1", kPutRecord, __LINE__);
+  // Should land on the first update of the next key
+  iter->NextKey();
+  verify_iter("k1", "k1m1", kMergeRecord, __LINE__);
+  iter->NextKey();
+  verify_iter("k2", "", kSingleDeleteRecord, __LINE__);
+  iter->NextKey();
+  verify_iter("k3", "k3m1", kMergeRecord, __LINE__);
+  iter->PrevKey();
+  verify_iter("k2", "", kSingleDeleteRecord, __LINE__);
+
+  // Should land on last key <= k0, recent update is ordered first
+  iter->SeekForPrev("k3");
+  verify_iter("k3", "k3p0", kPutRecord, __LINE__);
+  iter->PrevKey();
+  verify_iter("k2", "", kSingleDeleteRecord, __LINE__);
+  iter->PrevKey();
+  verify_iter("k1", "k1m1", kMergeRecord, __LINE__);
+  iter->PrevKey();
+  verify_iter("k0", "k0p1", kPutRecord, __LINE__);
+  iter->NextKey();
+  verify_iter("k1", "k1m1", kMergeRecord, __LINE__);
+
+  // test FindLatestUpdate
+  iter->SeekToFirst();
+  verify_iter("k0", "k0p1", kPutRecord, __LINE__);
+  MergeContext merge_context;
+  // iterator is not at k1
+  ASSERT_EQ(iter->FindLatestUpdate("k1", &merge_context),
+            WBWIIteratorImpl::Result::kNotFound);
+  ASSERT_EQ(merge_context.GetNumOperands(), 0);
+  // iterator was not moved
+  verify_iter("k0", "k0p1", kPutRecord, __LINE__);
+
+  // k0's most recent update is a Put
+  ASSERT_EQ(iter->FindLatestUpdate("k0", &merge_context),
+            WBWIIteratorImpl::Result::kFound);
+  ASSERT_EQ(merge_context.GetNumOperands(), 0);
+  verify_iter("k0", "k0p1", kPutRecord, __LINE__);
+
+  iter->NextKey();
+  verify_iter("k1", "k1m1", kMergeRecord, __LINE__);
+  ASSERT_EQ(iter->FindLatestUpdate("k1", &merge_context),
+            WBWIIteratorImpl::Result::kMergeInProgress);
+  ASSERT_EQ(merge_context.GetNumOperands(), 2);
+  auto operands = merge_context.GetOperands();
+  // oldest merge is ordered first
+  ASSERT_EQ(operands[0], "k1m0");
+  ASSERT_EQ(operands[1], "k1m1");
+  // iterator moved to last merge
+  verify_iter("k1", "k1m0", kMergeRecord, __LINE__);
+  merge_context.Clear();
+
+  iter->Next();
+  verify_iter("k2", "", kSingleDeleteRecord, __LINE__);
+  ASSERT_EQ(iter->FindLatestUpdate("k2", &merge_context),
+            WBWIIteratorImpl::Result::kDeleted);
+  ASSERT_EQ(merge_context.GetNumOperands(), 0);
+  verify_iter("k2", "", kSingleDeleteRecord, __LINE__);
+
+  iter->Next();
+  verify_iter("k3", "k3m1", kMergeRecord, __LINE__);
+  // This will find latest updated of the current key
+  ASSERT_EQ(iter->FindLatestUpdate(&merge_context),
+            WBWIIteratorImpl::Result::kFound);
+  ASSERT_EQ(merge_context.GetNumOperands(), 1);
+  operands = merge_context.GetOperands();
+  ASSERT_EQ(operands[0], "k3m1");
+  // iterator moved to last merge
+  verify_iter("k3", "k3p0", kPutRecord, __LINE__);
+
+  // SeekToLast
+  iter->SeekToLast();
+  verify_iter("k3", "k3p0", kPutRecord, __LINE__);
+  // FindLatestUpdate() while we are at the older update of k3
+  ASSERT_EQ(iter->FindLatestUpdate(&merge_context),
+            WBWIIteratorImpl::Result::kFound);
+  ASSERT_EQ(merge_context.GetNumOperands(), 1);
+  operands = merge_context.GetOperands();
+  ASSERT_EQ(operands[0], "k3m1");
 }
 
 TEST_P(WriteBatchWithIndexTest, TestComparatorForCF) {
@@ -2599,7 +2769,7 @@ TEST_P(WriteBatchWithIndexTest, GetFromBatchAndDBAfterMerge) {
   ASSERT_EQ(value, "cc");
 }
 
-TEST_F(WBWIKeepTest, GetAfterPut) {
+TEST_P(WriteBatchWithIndexTest, GetAfterPut) {
   std::string value;
   ASSERT_OK(OpenDB());
   ColumnFamilyHandle* cf0 = db_->DefaultColumnFamily();
@@ -2691,7 +2861,7 @@ TEST_P(WriteBatchWithIndexTest, GetAfterMergeDelete) {
   ASSERT_EQ(value, "cc,dd");
 }
 
-TEST_F(WBWIOverwriteTest, TestBadMergeOperator) {
+TEST_P(WriteBatchWithIndexTest, TestBadMergeOperator) {
   class FailingMergeOperator : public MergeOperator {
    public:
     FailingMergeOperator() = default;
@@ -2837,15 +3007,16 @@ TEST_P(WriteBatchWithIndexTest, ColumnFamilyWithTimestamp) {
       std::string key;
       PutFixed32(&key, start);
       ASSERT_EQ(key, it->Entry().key);
-      if (!overwrite) {
-        ASSERT_EQ(WriteType::kPutRecord, it->Entry().type);
-        it->Next();
-        ASSERT_TRUE(it->Valid());
-      }
+      // For each key, most recent update (Del) is ordered first.
       if (0 == (start % 2)) {
         ASSERT_EQ(WriteType::kDeleteRecord, it->Entry().type);
       } else {
         ASSERT_EQ(WriteType::kSingleDeleteRecord, it->Entry().type);
+      }
+      if (!overwrite) {
+        it->Next();
+        ASSERT_TRUE(it->Valid());
+        ASSERT_EQ(WriteType::kPutRecord, it->Entry().type);
       }
     }
   }


### PR DESCRIPTION
Summary: as a preparation to support merge in [WBWIMemtable](https://github.com/facebook/rocksdb/blob/d48af213860054a7696e7ea2764f266c88a3263e/memtable/wbwi_memtable.h#L31), this PR updates how we [order updates to the same key](https://github.com/facebook/rocksdb/blob/d48af213860054a7696e7ea2764f266c88a3263e/utilities/write_batch_with_index/write_batch_with_index_internal.cc#L694-L697) in WriteBatchWithIndex. Specifically, the order is now reversed such that more recent update is ordered first. This will make iterating from WriteBatchWithIndex much easier since the key ordering in WBWI now matches internal key order where keys with larger sequence number are ordered first. The ordering is now explicitly documented above the declaration for `WriteBatchWithIndex` class.

Places that use `WBWIIteratorImpl` and assume key ordering are updated. The rest is test and comments update.
This will affect users who use WBWIIterator directly, the output of GetFromBatch, GetFromBatchAndDB or NewIteratorWithBase are not affected. Users are only affected if they may issue multiple updates to the same key. If WriteBatchWithIndex is created with `overwrite_key=true`, one the the updates needs to be Merge.

Test plan: we have some good coverage of WBWI, I updated some existing tests and added a test for `WBWIIteratorImpl`.