### PR TITLE
Add python binding to LANGUAGE-BINDINGS.md

### DIFF
--- a/LANGUAGE-BINDINGS.md
+++ b/LANGUAGE-BINDINGS.md
@@ -2,7 +2,8 @@ This is the list of all known third-party language bindings for RocksDB. If some
 
 * Java - https://github.com/facebook/rocksdb/tree/main/java
 * Python
-    * http://python-rocksdb.readthedocs.io/en/latest/
+    * https://github.com/rocksdict/RocksDict
+    * http://python-rocksdb.readthedocs.io/en/latest/ (unmaintained) 
     * http://pyrocksdb.readthedocs.org/en/latest/ (unmaintained)
 * Perl - https://metacpan.org/pod/RocksDB
 * Node.js - https://npmjs.org/package/rocksdb


### PR DESCRIPTION
The only actively maintained python binding is RocksDict