### PR TITLE
Make `db_map_fuzzer` more robust

### DIFF
--- a/fuzz/db_map_fuzzer.cc
+++ b/fuzz/db_map_fuzzer.cc
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <unistd.h>
 
 #include "proto/gen/db_operation.pb.h"
 #include "rocksdb/db.h"
@@ -41,7 +42,7 @@ DEFINE_PROTO_FUZZER(DBOperations& input) {
     return;
   }
 
-  const std::string kDbPath = "/tmp/db_map_fuzzer_test";
+  const std::string kDbPath = "/tmp/db_map_fuzzer_test_" + std::to_string(getpid());
   auto fs = ROCKSDB_NAMESPACE::FileSystem::Default();
   if (fs->FileExists(kDbPath, ROCKSDB_NAMESPACE::IOOptions(), /*dbg=*/nullptr)
           .ok()) {


### PR DESCRIPTION
While testing a new fuzzer on the OSS-Fuzz harness `db_map_fuzzer` I got a huge number of crashes. It turns out that the fuzzer detected a timeout and preempted its child process before it could remove the database. All subsequent attempts at running the harness failed, because the database was already existing.

This PR creates a database name unique per process to continue fuzzing after finding an initial crash.

Additionally, it could be beneficial to return gracefully if the database already exists to avoid having false positive crash reports.