### PR TITLE
Fix GetMergeOperands() in ReadOnly and SecondaryDB

### DIFF
--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -102,7 +102,8 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
           get_impl_options.value ? get_impl_options.value->GetSelf() : nullptr,
           get_impl_options.columns, ts, &s, &merge_context,
           &max_covering_tombstone_seq, read_options,
-          false /* immutable_memtable */, &read_cb)) {
+          false /* immutable_memtable */, &read_cb,
+          /*is_blob_index=*/nullptr, /*do_merge=*/get_impl_options.get_value)) {
     if (get_impl_options.value) {
       get_impl_options.value->PinSelf();
     }
@@ -116,7 +117,7 @@ Status DBImplReadOnly::GetImpl(const ReadOptions& read_options,
         /*value_found*/ nullptr,
         /*key_exists*/ nullptr, /*seq*/ nullptr, &read_cb,
         /*is_blob*/ nullptr,
-        /*do_merge*/ true);
+        /*do_merge=*/get_impl_options.get_value);
     RecordTick(stats_, MEMTABLE_MISS);
   }
   {

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -407,31 +407,56 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
   bool done = false;
 
   // Look up starts here
-  if (super_version->mem->Get(
-          lkey,
-          get_impl_options.value ? get_impl_options.value->GetSelf() : nullptr,
-          get_impl_options.columns, ts, &s, &merge_context,
-          &max_covering_tombstone_seq, read_options,
-          false /* immutable_memtable */, &read_cb)) {
-    done = true;
-    if (get_impl_options.value) {
-      get_impl_options.value->PinSelf();
+  if (get_impl_options.get_value) {
+    if (super_version->mem->Get(
+            lkey,
+            get_impl_options.value ? get_impl_options.value->GetSelf()
+                                   : nullptr,
+            get_impl_options.columns, ts, &s, &merge_context,
+            &max_covering_tombstone_seq, read_options,
+            false /* immutable_memtable */, &read_cb,
+            /*is_blob_index=*/nullptr,
+            /*do_merge=*/get_impl_options.get_value)) {
+      done = true;
+      if (get_impl_options.value) {
+        get_impl_options.value->PinSelf();
+      }
+      RecordTick(stats_, MEMTABLE_HIT);
+    } else if ((s.ok() || s.IsMergeInProgress()) &&
+               super_version->imm->Get(
+                   lkey,
+                   get_impl_options.value ? get_impl_options.value->GetSelf()
+                                          : nullptr,
+                   get_impl_options.columns, ts, &s, &merge_context,
+                   &max_covering_tombstone_seq, read_options, &read_cb)) {
+      done = true;
+      if (get_impl_options.value) {
+        get_impl_options.value->PinSelf();
+      }
+      RecordTick(stats_, MEMTABLE_HIT);
     }
-    RecordTick(stats_, MEMTABLE_HIT);
-  } else if ((s.ok() || s.IsMergeInProgress()) &&
-             super_version->imm->Get(
-                 lkey,
-                 get_impl_options.value ? get_impl_options.value->GetSelf()
-                                        : nullptr,
-                 get_impl_options.columns, ts, &s, &merge_context,
-                 &max_covering_tombstone_seq, read_options, &read_cb)) {
-    done = true;
-    if (get_impl_options.value) {
-      get_impl_options.value->PinSelf();
+  } else {
+    // GetMergeOperands
+    if (super_version->mem->Get(
+            lkey,
+            get_impl_options.value ? get_impl_options.value->GetSelf()
+                                   : nullptr,
+            get_impl_options.columns, ts, &s, &merge_context,
+            &max_covering_tombstone_seq, read_options,
+            false /* immutable_memtable */, &read_cb,
+            /*is_blob_index=*/nullptr, /*do_merge=*/false)) {
+      done = true;
+      RecordTick(stats_, MEMTABLE_HIT);
+    } else if ((s.ok() || s.IsMergeInProgress()) &&
+               super_version->imm->GetMergeOperands(lkey, &s, &merge_context,
+                                                    &max_covering_tombstone_seq,
+                                                    read_options)) {
+      done = true;
+      RecordTick(stats_, MEMTABLE_HIT);
     }
-    RecordTick(stats_, MEMTABLE_HIT);
   }
-  if (!done && !s.ok() && !s.IsMergeInProgress()) {
+  if (!s.ok() && !s.IsMergeInProgress() && !s.IsNotFound()) {
+    assert(done);
     ReturnAndCleanupSuperVersion(cfd, super_version);
     return s;
   }

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -415,8 +415,7 @@ Status DBImplSecondary::GetImpl(const ReadOptions& read_options,
             get_impl_options.columns, ts, &s, &merge_context,
             &max_covering_tombstone_seq, read_options,
             false /* immutable_memtable */, &read_cb,
-            /*is_blob_index=*/nullptr,
-            /*do_merge=*/get_impl_options.get_value)) {
+            /*is_blob_index=*/nullptr, /*do_merge=*/true)) {
       done = true;
       if (get_impl_options.value) {
         get_impl_options.value->PinSelf();

--- a/db/db_merge_operand_test.cc
+++ b/db/db_merge_operand_test.cc
@@ -266,6 +266,7 @@ TEST_F(DBMergeOperandTest, GetMergeOperandsBasic) {
   ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
                                   "k3.2", values.data(), &merge_operands_info,
                                   &number_of_operands));
+  ASSERT_EQ(number_of_operands, 2);
   ASSERT_EQ(values[0], "cd");
   ASSERT_EQ(values[1], "de");
 
@@ -283,6 +284,7 @@ TEST_F(DBMergeOperandTest, GetMergeOperandsBasic) {
   ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
                                   "k4", values.data(), &merge_operands_info,
                                   &number_of_operands));
+  ASSERT_EQ(number_of_operands, 4);
   ASSERT_EQ(values[0], "ba");
   ASSERT_EQ(values[1], "cb");
   ASSERT_EQ(values[2], "dc");
@@ -318,9 +320,10 @@ TEST_F(DBMergeOperandTest, GetMergeOperandsBasic) {
   ASSERT_OK(db_->GetMergeOperands(ReadOptions(), db_->DefaultColumnFamily(),
                                   "k6", readonly_values.data(),
                                   &merge_operands_info, &number_of_operands));
-  ASSERT_EQ(number_of_operands, limit);
-  ASSERT_EQ(readonly_values[0], "call");
-  ASSERT_EQ(readonly_values[1], "saul");
+  ASSERT_EQ(number_of_operands, 3);
+  ASSERT_EQ(readonly_values[0], "better");
+  ASSERT_EQ(readonly_values[1], "call");
+  ASSERT_EQ(readonly_values[2], "saul");
 }
 
 TEST_F(DBMergeOperandTest, BlobDBGetMergeOperandsBasic) {


### PR DESCRIPTION
Summary: Noticed that the `do_merge` parameter is not properly set while working on memtable code.

Test plan: updated unit test for the read-only db case.