### PR TITLE
Update sequence number assignment method in `WBWIMemTable`

### DIFF
--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -77,6 +77,8 @@ class WBWIIterator {
 
   virtual void Prev() = 0;
 
+  virtual Status status() const = 0;
+
   // The returned WriteEntry is only valid until the next mutation of
   // WriteBatchWithIndex.
   virtual WriteEntry Entry() const = 0;
@@ -85,7 +87,9 @@ class WBWIIterator {
   // and it was overwritten by another update.
   virtual bool HasOverWrittenSingleDel() const { return false; }
 
-  virtual Status status() const = 0;
+  // Returns n where the current entry is the n-th update to the current key.
+  // Only valid if WBWI is created with overwrite_key = true.
+  virtual uint32_t GetUpdateCount() const { return 0; }
 };
 
 // A WriteBatchWithIndex with a binary searchable index built for all the keys

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -88,6 +88,7 @@ class WBWIIterator {
   virtual bool HasOverWrittenSingleDel() const { return false; }
 
   // Returns n where the current entry is the n-th update to the current key.
+  // The update count starts from 1.
   // Only valid if WBWI is created with overwrite_key = true.
   virtual uint32_t GetUpdateCount() const { return 0; }
 };

--- a/memtable/wbwi_memtable.cc
+++ b/memtable/wbwi_memtable.cc
@@ -62,6 +62,10 @@ bool WBWIMemTable::Get(const LookupKey& key, std::string* value,
 
   [[maybe_unused]] SequenceNumber read_seq =
       GetInternalKeySeqno(key.internal_key());
+  // This is memtable is a single write batch, no snapshot can be taken within
+  // assigned seqnos for this memtable.
+  assert(read_seq >= assigned_seqno_.upper_bound ||
+         read_seq < assigned_seqno_.lower_bound);
   std::unique_ptr<InternalIterator> iter{NewIterator()};
   iter->Seek(key.internal_key());
   const Slice lookup_user_key = key.user_key();

--- a/memtable/wbwi_memtable.h
+++ b/memtable/wbwi_memtable.h
@@ -13,12 +13,21 @@ namespace ROCKSDB_NAMESPACE {
 // a transaction (which is based on WBWI) into the DB as an immutable memtable.
 //
 // REQUIRE overwrite_key to be true for the WBWI
-// Since the keys in WBWI do not have sequence number, the memtable needs to be
+// Since the keys in WBWI do not have sequence number, this class is responsible
+// for assigning sequence numbers to the keys. This memtable needs to be
 // assigned a range of sequence numbers through AssignSequenceNumbers(seqno)
 // before being available for reads.
-// With overwrite_key = true, WBWI keeps track of the most recent update for
-// each key, and each such key will be assigned seqno.upper_bound during reads.
-// One exception is during flush, consider the following scenario:
+//
+// The sequence number assignment uses the update count for each key
+// tracked in WBWI (see WBWIIterator::GetUpdateCount()). For each key, the
+// sequence number assigned is seqno.lower_bound + update_count - 1. So more
+// recent updates will have higher sequence number.
+//
+// WBWI with overwrite mode keeps track of the most recent update for each key,
+// so this memtable contains one update per key usually. However, there is a
+// special case where this memtable needs to emit an extra SingleDelete even
+// when the SD is overwritten by another update.
+// Consider the following scenario:
 // - WBWI has SD(k) then PUT(k, v1)
 // - DB has PUT(k, v2) in L1
 // - flush WBWI adds PUT(k, v1) into L0
@@ -26,8 +35,7 @@ namespace ROCKSDB_NAMESPACE {
 // - flush live memtable and compact it with L0 will drop SD(k) and PUT(k, v1)
 // - the PUT(k, v2) in L1 incorrectly becomes visible
 // So during flush, iterator from this memtable will need emit overwritten
-// single deletion. These single deletion entries will be
-// assigned seqno.upper_bound - 1.
+// single deletion. This SD will be assigned seqno.lower_bound.
 class WBWIMemTable final : public ReadOnlyMemTable {
  public:
   struct SeqnoRange {
@@ -258,51 +266,40 @@ class WBWIMemTableIterator final : public InternalIterator {
   }
 
   void Seek(const Slice& target) override {
+    // `emit_overwritten_single_del_` is only used for flush, which does
+    // sequential forward scan from the beginning.
+    assert(!emit_overwritten_single_del_);
     Slice target_user_key = ExtractUserKey(target);
+    // Moves to first update >= target_user_key
     it_->Seek(target_user_key);
-    if (it_->Valid()) {
-      // compare seqno
-      SequenceNumber seqno = GetInternalKeySeqno(target);
-      assert(!emit_overwritten_single_del_);
-      // For now all keys are assigned seqno_ub_, this may change after merge
-      // is supported.
-      assert(seqno <= assigned_seqno_.lower_bound ||
-             seqno >= assigned_seqno_.upper_bound);
-      if (seqno < assigned_seqno_.upper_bound &&
-          comparator_->Compare(it_->Entry().key, target_user_key) == 0) {
-        it_->Next();
-        // TODO: cannot assume distinct keys once Merge is supported
-        if (it_->Valid()) {
-          assert(comparator_->Compare(it_->Entry().key, target_user_key) > 0);
-        }
-      }
+    SequenceNumber target_seqno = GetInternalKeySeqno(target);
+    // Move to the first entry with seqno <= target_seqno for the same
+    // user key or a different user key.
+    while (it_->Valid() &&
+           comparator_->Compare(it_->Entry().key, target_user_key) == 0 &&
+           target_seqno < CurrentKeySeqno()) {
+      it_->Next();
     }
     UpdateKey();
   }
 
   void SeekForPrev(const Slice& target) override {
+    assert(!emit_overwritten_single_del_);
     Slice target_user_key = ExtractUserKey(target);
+    // Moves to last update <= target_user_key
     it_->SeekForPrev(target_user_key);
-    if (it_->Valid()) {
-      SequenceNumber seqno = GetInternalKeySeqno(target);
-      assert(seqno <= assigned_seqno_.lower_bound ||
-             seqno >= assigned_seqno_.upper_bound);
-      if (seqno > assigned_seqno_.upper_bound &&
-          comparator_->Compare(it_->Entry().key, target_user_key) == 0) {
-        it_->Prev();
-        if (it_->Valid()) {
-          // TODO: cannot assume distinct keys once Merge is supported
-          assert(comparator_->Compare(it_->Entry().key, target_user_key) < 0);
-        }
-      }
+    SequenceNumber target_seqno = GetInternalKeySeqno(target);
+    // Move to the first entry with seqno >= target_seqno for the same
+    // user key or a different user key.
+    while (it_->Valid() &&
+           comparator_->Compare(it_->Entry().key, target_user_key) == 0 &&
+           CurrentKeySeqno() < target_seqno) {
+      it_->Prev();
     }
     UpdateKey();
   }
 
   void Next() override {
-    // Only need to emit single deletion during flush. Since Flush does
-    // sequential forward scan, we only need to emit single deletion in Next(),
-    // and do not need to consider iterator direction change.
     assert(Valid());
     if (emit_overwritten_single_del_) {
       if (it_->HasOverWrittenSingleDel() && !at_overwritten_single_del_) {
@@ -329,6 +326,7 @@ class WBWIMemTableIterator final : public InternalIterator {
   }
 
   void Prev() override {
+    assert(!emit_overwritten_single_del_);
     assert(Valid());
     it_->Prev();
     UpdateKey();
@@ -341,7 +339,6 @@ class WBWIMemTableIterator final : public InternalIterator {
 
   Slice value() const override {
     assert(Valid());
-    // TODO: it_->Entry() is not trivial, cache it
     return it_->Entry().value;
   }
 
@@ -355,6 +352,16 @@ class WBWIMemTableIterator final : public InternalIterator {
  private:
   static const std::unordered_map<WriteType, ValueType> WriteTypeToValueTypeMap;
 
+  SequenceNumber CurrentKeySeqno() {
+    assert(it_->Valid());
+    assert(it_->GetUpdateCount() >= 1);
+    auto seq = assigned_seqno_.lower_bound + it_->GetUpdateCount() - 1;
+    assert(seq <= assigned_seqno_.upper_bound);
+    return seq;
+  }
+
+  // If it_ is valid, udate key_ to an internal key containing it_ current
+  // key, CurrentKeySeqno() and a type corresponding to it_ current entry type.
   void UpdateKey() {
     valid_ = it_->Valid();
     if (!Valid()) {
@@ -370,16 +377,16 @@ class WBWIMemTableIterator final : public InternalIterator {
                               std::to_string(it_->Entry().type));
       return;
     }
-    key_buf_.SetInternalKey(it_->Entry().key, assigned_seqno_.upper_bound,
-                            t->second);
+    key_buf_.SetInternalKey(it_->Entry().key, CurrentKeySeqno(), t->second);
     key_ = key_buf_.GetInternalKey();
   }
 
   void UpdateSingleDeleteKey() {
     assert(it_->Valid());
     assert(Valid());
-    assert(assigned_seqno_.lower_bound < assigned_seqno_.upper_bound);
-    key_buf_.SetInternalKey(it_->Entry().key, assigned_seqno_.upper_bound - 1,
+    // The key that overwrites this SingleDelete will be assigned at least
+    // seqno lower_bound + 1 (see CurrentKeySeqno()).
+    key_buf_.SetInternalKey(it_->Entry().key, assigned_seqno_.lower_bound,
                             kTypeSingleDeletion);
     key_ = key_buf_.GetInternalKey();
     at_overwritten_single_del_ = true;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -110,9 +110,10 @@ class BaseDeltaIterator : public Iterator {
 
 // Key used by skip list, as the binary searchable index of WriteBatchWithIndex.
 struct WriteBatchIndexEntry {
-  WriteBatchIndexEntry(size_t o, uint32_t c, size_t ko, size_t ksz)
+  WriteBatchIndexEntry(size_t o, uint32_t c, size_t ko, size_t ksz, uint32_t uc)
       : offset(o),
         column_family(c),
+        update_count(uc),
         has_single_del(false),
         has_overwritten_single_del(false),
         key_offset(ko),
@@ -133,6 +134,7 @@ struct WriteBatchIndexEntry {
       // Keys are ordered by descending offset.
       : offset(is_forward_direction ? std::numeric_limits<size_t>::max() : 0),
         column_family(_column_family),
+        update_count(1),
         has_single_del(false),
         has_overwritten_single_del(false),
         key_offset(0),
@@ -161,6 +163,9 @@ struct WriteBatchIndexEntry {
   // SeekForPrev() will see all the keys with the same key.
   size_t offset;
   uint32_t column_family;  // column family of the entry.
+  // The following three fields are only maintained when the WBWI is created
+  // with overwrite_key = true.
+  uint32_t update_count;   // number of updates for this key up to this entry.
   bool has_single_del;     // whether single del was issued for this key
   bool has_overwritten_single_del;  // whether a single del for this key was
                                     // overwritten by another key
@@ -346,6 +351,11 @@ class WBWIIteratorImpl final : public WBWIIterator {
   bool HasOverWrittenSingleDel() const override {
     assert(Valid());
     return skip_list_iter_.key()->has_overwritten_single_del;
+  }
+
+  uint32_t GetUpdateCount() const override {
+    assert(Valid());
+    return skip_list_iter_.key()->update_count;
   }
 
   Status status() const override {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -165,7 +165,8 @@ struct WriteBatchIndexEntry {
   uint32_t column_family;  // column family of the entry.
   // The following three fields are only maintained when the WBWI is created
   // with overwrite_key = true.
-  uint32_t update_count;   // number of updates for this key up to this entry.
+  uint32_t update_count;   // The number of updates (1-based) for this key up to
+                           // this entry.
   bool has_single_del;     // whether single del was issued for this key
   bool has_overwritten_single_del;  // whether a single del for this key was
                                     // overwritten by another key


### PR DESCRIPTION
Summary: This is a preparation for supporting merge in `WBWIMemTable`. This PR updates the sequence number assignment method so that it allows efficient and simple assignment when there are multiple entries with the same user key. This can happen when the WBWI contains Merge operations. This assignment relies on tracking the number of updates issued for each key in each WBWI entry (`WriteBatchIndexEntry::update_count`). Some refactoring is done in WBWI to remove `last_entry_offset` as part of the WBWI state which I find it harder to use correctly. 

Test plan: updated unit tests to check that update count is tracked correctly and WBWIMemTable is assigning sequence number as expected.