### PR TITLE
Initial version of an external table reader interface

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -214,6 +214,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "table/cuckoo/cuckoo_table_builder.cc",
         "table/cuckoo/cuckoo_table_factory.cc",
         "table/cuckoo/cuckoo_table_reader.cc",
+        "table/external_table_reader.cc",
         "table/format.cc",
         "table/get_context.cc",
         "table/iterator.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -835,6 +835,7 @@ set(SOURCES
         table/cuckoo/cuckoo_table_builder.cc
         table/cuckoo/cuckoo_table_factory.cc
         table/cuckoo/cuckoo_table_reader.cc
+        table/external_table_reader.cc
         table/format.cc
         table/get_context.cc
         table/iterator.cc

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -498,6 +498,8 @@ class InternalKey {
   // Intended only to be used together with ConvertFromUserKey().
   std::string* rep() { return &rep_; }
 
+  const std::string* const_rep() const { return &rep_; }
+
   // Assuming that *rep() contains a user key, this method makes internal key
   // out of it in-place. This saves a memcpy compared to Set()/SetFrom().
   void ConvertFromUserKey(SequenceNumber s, ValueType t) {

--- a/include/rocksdb/external_table_reader.h
+++ b/include/rocksdb/external_table_reader.h
@@ -1,0 +1,120 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include "rocksdb/customizable.h"
+#include "rocksdb/iterator.h"
+#include "rocksdb/options.h"
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class ExternalTableFactory;
+
+// EXPERIMENTAL
+// The interface defined in this file is subject to change at any time without
+// warning!!
+
+
+// This file defines an interface for plugging in an external table reader
+// into RocksDB. The external table reader will be used instead of the
+// BlockBasedTable to load and query sst files. As of now, creating the
+// external table files using RocksDB is not supported, but will be added in
+// the near future. The external table files can be created outside and
+// RocksDB and ingested into a RocksDB instance using the IngestExternalFIle()
+// API.
+//
+// Initial support is for loading and querying the files using an
+// SstFileReader. We will add support for ingestion of an external table
+// into a limited RocksDB instance that only supports ingestion and not live
+// writes in the near future. It'll be followed by support for replacing the
+// column family by ingesting a new set of files. In all cases, the external
+// table files will only be allowed in the bottommost level.
+//
+// The external table reader can support one or both of the following layouts -
+// 1. Total order seek - All the keys in the files are in sorted order, and a
+//    user can seek to the first, last, or any key in between and iterate
+//    forwards or backwards till the end of the range. To support this mode,
+//    the implementation needs to use the comparator passed in
+//    ExternalTableOptions to enforce the key ordering. The prefix_extractor
+//    in ExternalTableOptions and the ExternalTableReader interfaces can be
+//    ignored.
+// 2. Prefix seek - In this mode, the prefix_extractor is used to extract the
+//    prefix from a key. All the keys sharing the same prefix are ordered in
+//    ascending order according to the comparator. However, no specific
+//    ordering is required across prefixes. Users can scan keys by seeking
+//    to a specific key inside a prefix, and iterate forwards or backwards
+//    within the prefix. The prefix_same_as_start flag in ReadOptions will
+//    be true.
+// 3. Both - If supporting both of the above, a user can seek inside a prefix
+//    and iterate beyond the prefix. The prefix_same_as_start in ReadOptions
+//    will be false. Additionally, the total_order_seek flag can be set to
+//    true to seek to the first non-empty prefix (as determined by the key
+//    order) if the seek prefix is empty.
+//
+// Many of the options in ReadOptions may not be relevant to the external
+// table implementation.
+// TODO: Specify which options are relevant
+
+class ExternalTableReader {
+ public:
+  virtual ~ExternalTableReader() {}
+
+  // Return an Iterator that can be used to scan the table file.
+  // The read_options can optionally contain the upper bound
+  // key (exclusive) of the scan in iterate_upper_bound.
+  virtual Iterator* NewIterator(const ReadOptions& read_options,
+                                const SliceTransform* prefix_extractor) = 0;
+
+  // Point lookup the given key and return its value
+  virtual Status Get(const ReadOptions& read_options, const Slice& key,
+                     const SliceTransform* prefix_extractor,
+                     std::string* value) = 0;
+
+  // Point lookup the given vector of keys and return the values, as well
+  // as status of each individual lookup in statuses.
+  virtual void MultiGet(const ReadOptions& read_options,
+                        const std::vector<Slice>& keys,
+                        const SliceTransform* prefix_extractor,
+                        std::vector<std::string>* values,
+                        std::vector<Status>* statuses) = 0;
+
+  // Return TableProperties for the file. At a minimum, the following
+  // properties need to be returned -
+  // comparator_name
+  // num_entries
+  // raw_key_size
+  // raw_value_size
+  virtual std::shared_ptr<const TableProperties> GetTableProperties() const = 0;
+
+  virtual Status VerifyChecksum(const ReadOptions& /*ro*/) {
+    return Status::NotSupported("VerifyChecksum() not supported");
+  }
+};
+
+struct ExternalTableOptions {
+  const std::shared_ptr<const SliceTransform>& prefix_extractor;
+  const Comparator* comparator;
+};
+
+class ExternalTableFactory : public Customizable {
+ public:
+  ~ExternalTableFactory() override {}
+
+  const char* Name() const override { return "ExternalTableFactory"; }
+
+  virtual Status NewTableReader(
+      const ReadOptions& read_options, const std::string& file_path,
+      const ExternalTableOptions& table_options,
+      std::unique_ptr<ExternalTableReader>* table_reader) = 0;
+};
+
+// Allocate a TableFactory that wraps around an ExternalTableFactory. Use this
+// to allocate and set in ColumnFamilyOptions::table_factory.
+std::shared_ptr<TableFactory> NewExternalTableFactory(
+    std::shared_ptr<ExternalTableFactory> inner_factory);
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/external_table_reader.h
+++ b/include/rocksdb/external_table_reader.h
@@ -18,7 +18,6 @@ class ExternalTableFactory;
 // The interface defined in this file is subject to change at any time without
 // warning!!
 
-
 // This file defines an interface for plugging in an external table reader
 // into RocksDB. The external table reader will be used instead of the
 // BlockBasedTable to load and query sst files. As of now, creating the

--- a/include/rocksdb/external_table_reader.h
+++ b/include/rocksdb/external_table_reader.h
@@ -97,6 +97,11 @@ class ExternalTableReader {
 struct ExternalTableOptions {
   const std::shared_ptr<const SliceTransform>& prefix_extractor;
   const Comparator* comparator;
+
+  ExternalTableOptions(
+      const std::shared_ptr<const SliceTransform>& _prefix_extractor,
+      const Comparator* _comparator)
+      : prefix_extractor(_prefix_extractor), comparator(_comparator) {}
 };
 
 class ExternalTableFactory : public Customizable {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1955,12 +1955,12 @@ struct ReadOptions {
 
   // EXPERIMENTAL
   // An optional weight of values to be returned by a scan. Once the
-  // weight is exceeded the scan is terminated (i.e Next() invalidates the
-  // iterator). In the case of a DB with one of the built-in table formats,
-  // such as BlockBasedTable, the weight is simply the number of key-value
-  // pairs. In the case of an ExternalTableReader, the weight is passed
-  // through to the table reader and the interpretation is upto teh reader
-  // implementation.
+  // weight is reached or exceeded the scan is terminated (i.e Next()
+  // invalidates the iterator). In the case of a DB with one of the built-in
+  // table formats, such as BlockBasedTable, the weight is simply the number
+  // of key-value pairs. In the case of an ExternalTableReader, the weight is
+  // passed through to the table reader and the interpretation is upto the
+  // reader implementation.
   uint64_t weight = 0;
 
   // *** END options for RocksDB internal use only ***

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1953,6 +1953,16 @@ struct ReadOptions {
   // EXPERIMENTAL
   Env::IOActivity io_activity = Env::IOActivity::kUnknown;
 
+  // EXPERIMENTAL
+  // An optional weight of values to be returned by a scan. Once the
+  // weight is exceeded the scan is terminated (i.e Next() invalidates the
+  // iterator). In the case of a DB with one of the built-in table formats,
+  // such as BlockBasedTable, the weight is simply the number of key-value
+  // pairs. In the case of an ExternalTableReader, the weight is passed
+  // through to the table reader and the interpretation is upto teh reader
+  // implementation.
+  uint64_t weight = 0;
+
   // *** END options for RocksDB internal use only ***
 
   ReadOptions() {}

--- a/src.mk
+++ b/src.mk
@@ -205,6 +205,7 @@ LIB_SOURCES =                                                   \
   table/cuckoo/cuckoo_table_builder.cc                          \
   table/cuckoo/cuckoo_table_factory.cc                          \
   table/cuckoo/cuckoo_table_reader.cc                           \
+  table/external_table_reader.cc				\
   table/format.cc                                               \
   table/get_context.cc                                          \
   table/iterator.cc                                             \

--- a/table/external_table_reader.cc
+++ b/table/external_table_reader.cc
@@ -122,12 +122,16 @@ class ExternalTableReaderAdapter : public TableReader {
 
   InternalIterator* NewIterator(
       const ReadOptions& read_options, const SliceTransform* prefix_extractor,
-      Arena* /* arena */, bool /* skip_filters */,
-      TableReaderCaller /* caller */,
+      Arena* arena, bool /* skip_filters */, TableReaderCaller /* caller */,
       size_t /* compaction_readahead_size */ = 0,
       bool /* allow_unprepared_value */ = false) override {
     auto iterator = reader_->NewIterator(read_options, prefix_extractor);
-    return new ExternalTableIterator(iterator);
+    if (arena == nullptr) {
+      return new ExternalTableIterator(iterator);
+    } else {
+      auto* mem = arena->AllocateAligned(sizeof(ExternalTableIterator));
+      return new (mem) ExternalTableIterator(iterator);
+    }
   }
 
   uint64_t ApproximateOffsetOf(const ReadOptions&, const Slice&,

--- a/table/external_table_reader.cc
+++ b/table/external_table_reader.cc
@@ -174,6 +174,7 @@ class ExternalTableFactoryAdapter : public TableFactory {
 
   const char* Name() const override { return inner_->Name(); }
 
+  using TableFactory::NewTableReader;
   Status NewTableReader(
       const ReadOptions& ro, const TableReaderOptions& topts,
       std::unique_ptr<RandomAccessFileReader>&& file, uint64_t /* file_size */,
@@ -189,6 +190,7 @@ class ExternalTableFactoryAdapter : public TableFactory {
       return status;
     }
     table_reader->reset(new ExternalTableReaderAdapter(std::move(reader)));
+    file.reset();
     return Status::OK();
   }
 

--- a/table/external_table_reader.cc
+++ b/table/external_table_reader.cc
@@ -1,0 +1,215 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/external_table_reader.h"
+
+#include "rocksdb/table.h"
+#include "table/internal_iterator.h"
+#include "table/table_builder.h"
+#include "table/table_reader.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+namespace {
+
+class ExternalTableIterator : public InternalIterator {
+ public:
+  explicit ExternalTableIterator(Iterator* iterator) : iterator_(iterator) {}
+
+  // No copying allowed
+  ExternalTableIterator(const ExternalTableIterator&) = delete;
+  ExternalTableIterator& operator=(const ExternalTableIterator&) = delete;
+
+  ~ExternalTableIterator() override {}
+
+  bool Valid() const override { return iterator_ && iterator_->Valid(); }
+
+  void SeekToFirst() override {
+    status_ = Status::OK();
+    if (iterator_) {
+      iterator_->SeekToFirst();
+      UpdateKey();
+    }
+  }
+
+  void SeekToLast() override {
+    status_ = Status::OK();
+    if (iterator_) {
+      iterator_->SeekToLast();
+      UpdateKey();
+    }
+  }
+
+  void Seek(const Slice& target) override {
+    status_ = Status::OK();
+    if (iterator_) {
+      ParsedInternalKey pkey;
+      status_ = ParseInternalKey(target, &pkey, /*log_err_key=*/false);
+      if (status_.ok()) {
+        iterator_->Seek(pkey.user_key);
+        UpdateKey();
+      }
+    }
+  }
+
+  void SeekForPrev(const Slice& target) override {
+    status_ = Status::OK();
+    if (iterator_) {
+      ParsedInternalKey pkey;
+      status_ = ParseInternalKey(target, &pkey, /*log_err_key=*/false);
+      if (status_.ok()) {
+        iterator_->SeekForPrev(pkey.user_key);
+        UpdateKey();
+      }
+    }
+  }
+
+  void Next() override {
+    if (iterator_) {
+      iterator_->Next();
+      UpdateKey();
+    }
+  }
+
+  void Prev() override {
+    if (iterator_) {
+      iterator_->Prev();
+      UpdateKey();
+    }
+  }
+
+  Slice key() const override {
+    if (iterator_) {
+      return Slice(*key_.const_rep());
+    }
+    return Slice();
+  }
+
+  Slice value() const override {
+    if (iterator_) {
+      return iterator_->value();
+    }
+    return Slice();
+  }
+
+  Status status() const override {
+    return !status_.ok() ? status_
+                         : (iterator_ ? iterator_->status() : Status::OK());
+  }
+
+ private:
+  std::unique_ptr<Iterator> iterator_;
+  InternalKey key_;
+  Status status_;
+
+  void UpdateKey() { key_.Set(iterator_->key(), 0, ValueType::kTypeValue); }
+};
+
+class ExternalTableReaderAdapter : public TableReader {
+ public:
+  explicit ExternalTableReaderAdapter(
+      std::unique_ptr<ExternalTableReader> reader)
+      : reader_(std::move(reader)) {}
+
+  ~ExternalTableReaderAdapter() override {}
+
+  // No copying allowed
+  ExternalTableReaderAdapter(const ExternalTableReaderAdapter&) = delete;
+  ExternalTableReaderAdapter& operator=(const ExternalTableReaderAdapter&) =
+      delete;
+
+  InternalIterator* NewIterator(
+      const ReadOptions& read_options, const SliceTransform* prefix_extractor,
+      Arena* /* arena */, bool /* skip_filters */,
+      TableReaderCaller /* caller */,
+      size_t /* compaction_readahead_size */ = 0,
+      bool /* allow_unprepared_value */ = false) override {
+    auto iterator = reader_->NewIterator(read_options, prefix_extractor);
+    return new ExternalTableIterator(iterator);
+  }
+
+  uint64_t ApproximateOffsetOf(const ReadOptions&, const Slice&,
+                               TableReaderCaller) override {
+    return 0;
+  }
+
+  uint64_t ApproximateSize(const ReadOptions&, const Slice&, const Slice&,
+                           TableReaderCaller) override {
+    return 0;
+  }
+
+  void SetupForCompaction() override {}
+
+  std::shared_ptr<const TableProperties> GetTableProperties() const override {
+    std::shared_ptr<TableProperties> props =
+        std::make_shared<TableProperties>(*reader_->GetTableProperties());
+    props->key_largest_seqno = 0;
+    return props;
+  }
+
+  size_t ApproximateMemoryUsage() const override { return 0; }
+
+  Status Get(const ReadOptions&, const Slice&, GetContext*,
+             const SliceTransform*, bool = false) override {
+    return Status::NotSupported(
+        "Get() not supported on external file iterator");
+  }
+
+  virtual Status VerifyChecksum(const ReadOptions& /*ro*/,
+                                TableReaderCaller /*caller*/) override {
+    return Status::OK();
+  }
+
+ private:
+  std::unique_ptr<ExternalTableReader> reader_;
+};
+
+class ExternalTableFactoryAdapter : public TableFactory {
+ public:
+  explicit ExternalTableFactoryAdapter(
+      std::shared_ptr<ExternalTableFactory> inner)
+      : inner_(std::move(inner)) {}
+
+  const char* Name() const override { return inner_->Name(); }
+
+  Status NewTableReader(
+      const ReadOptions& ro, const TableReaderOptions& topts,
+      std::unique_ptr<RandomAccessFileReader>&& file, uint64_t /* file_size */,
+      std::unique_ptr<TableReader>* table_reader,
+      bool /* prefetch_index_and_filter_in_cache */) const override {
+    std::unique_ptr<ExternalTableReader> reader;
+    ExternalTableOptions ext_topts{
+        .prefix_extractor = topts.prefix_extractor,
+        .comparator = topts.ioptions.user_comparator};
+    auto status =
+        inner_->NewTableReader(ro, file->file_name(), ext_topts, &reader);
+    if (!status.ok()) {
+      return status;
+    }
+    table_reader->reset(new ExternalTableReaderAdapter(std::move(reader)));
+    return Status::OK();
+  }
+
+  TableBuilder* NewTableBuilder(const TableBuilderOptions&,
+                                WritableFileWriter*) const override {
+    return nullptr;
+  }
+
+  std::unique_ptr<TableFactory> Clone() const override { return nullptr; }
+
+ private:
+  std::shared_ptr<ExternalTableFactory> inner_;
+};
+
+}  // namespace
+
+std::shared_ptr<TableFactory> NewExternalTableFactory(
+    std::shared_ptr<ExternalTableFactory> inner_factory) {
+  std::shared_ptr<TableFactory> res;
+  res.reset(new ExternalTableFactoryAdapter(std::move(inner_factory)));
+  return res;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/table/external_table_reader.cc
+++ b/table/external_table_reader.cc
@@ -185,9 +185,8 @@ class ExternalTableFactoryAdapter : public TableFactory {
       std::unique_ptr<TableReader>* table_reader,
       bool /* prefetch_index_and_filter_in_cache */) const override {
     std::unique_ptr<ExternalTableReader> reader;
-    ExternalTableOptions ext_topts{
-        .prefix_extractor = topts.prefix_extractor,
-        .comparator = topts.ioptions.user_comparator};
+    ExternalTableOptions ext_topts(topts.prefix_extractor,
+                                   topts.ioptions.user_comparator);
     auto status =
         inner_->NewTableReader(ro, file->file_name(), ext_topts, &reader);
     if (!status.ok()) {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6662,8 +6662,7 @@ TEST_F(ExternalTableReaderTest, BasicTest) {
   std::unique_ptr<ExternalTableReader> reader;
   std::shared_ptr<SliceTransform> prefix_extractor;
   ASSERT_OK(factory->NewTableReader(
-      {}, "", {.prefix_extractor = prefix_extractor, .comparator = nullptr},
-      &reader));
+      {}, "", ExternalTableOptions(prefix_extractor, nullptr), &reader));
 
   ReadOptions ro;
   ro.weight = 1;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -36,6 +36,7 @@
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
+#include "rocksdb/external_table_reader.h"
 #include "rocksdb/file_checksum.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/filter_policy.h"
@@ -44,6 +45,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/perf_context.h"
 #include "rocksdb/slice_transform.h"
+#include "rocksdb/sst_file_reader.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/table_properties.h"
 #include "rocksdb/trace_record.h"
@@ -6522,6 +6524,199 @@ TEST_F(CacheUsageOptionsOverridesTest, SanitizeAndValidateOptions) {
               std::string::npos);
   Destroy(options);
 }
+
+class ExternalTableReaderTest : public DBTestBase {
+ public:
+  ExternalTableReaderTest()
+      : DBTestBase("external_table_reader_test", /*env_do_fsync=*/false) {}
+
+ protected:
+  class DummyExternalTableIterator : public Iterator {
+   public:
+    DummyExternalTableIterator(bool empty) : empty_(empty) {}
+
+    bool Valid() const override { return empty_ ? !empty_ : valid_; }
+
+    void SeekToFirst() override {
+      valid_ = true;
+      status_ = Status::OK();
+    }
+
+    void SeekToLast() override {
+      valid_ = true;
+      status_ = Status::OK();
+    }
+
+    void Seek(const Slice& target) override {
+      if (target.compare(key_str) <= 0) {
+        valid_ = true;
+      } else {
+        valid_ = false;
+      }
+      status_ = Status::OK();
+    }
+
+    void SeekForPrev(const Slice& /*target*/) override {
+      valid_ = false;
+      status_ = Status::NotSupported();
+    }
+
+    void Next() override {
+      valid_ = false;
+      // status_ is still ok. valid_ indicates end of scan
+    }
+
+    void Prev() override {
+      valid_ = false;
+      status_ = Status::NotSupported();
+    }
+
+    Slice key() const override {
+      // If valid_ is false or status_ is non-ok, behavior is indeterminate
+      return Slice(key_str);
+    }
+
+    Status status() const override {
+      // status_ gets overwritten by next Seek
+      return status_;
+    }
+
+    Slice value() const override {
+      // If valid_ is false or status_ is non-ok, behavior is indeterminate
+      return Slice(value_str);
+    }
+
+   private:
+    static const std::string key_str;
+    static const std::string value_str;
+
+    bool valid_ = false;
+    bool empty_;
+    Status status_ = Status::OK();
+  };
+
+  class DummyExternalTableReader : public ExternalTableReader {
+   public:
+    Iterator* NewIterator(const ReadOptions& read_options,
+                          const SliceTransform* /*prefix_extractor*/) {
+      return new DummyExternalTableIterator((read_options.weight == 0) ? true
+                                                                       : false);
+    }
+
+    Status Get(const ReadOptions& /*read_options*/, const Slice& key,
+               const SliceTransform* /*prefix_extractor*/, std::string* value) {
+      if (!key.compare("foo")) {
+        value->assign("bar");
+        return Status::OK();
+      }
+      return Status::NotFound();
+    }
+
+    void MultiGet(const ReadOptions& read_options,
+                  const std::vector<Slice>& keys,
+                  const SliceTransform* prefix_extractor,
+                  std::vector<std::string>* values,
+                  std::vector<Status>* statuses) {
+      values->resize(keys.size());
+      statuses->resize(keys.size());
+      for (size_t i = 0; i < keys.size(); ++i) {
+        statuses->at(i) =
+            Get(read_options, keys[i], prefix_extractor, &values->at(i));
+      }
+    }
+
+    std::shared_ptr<const TableProperties> GetTableProperties() const {
+      std::shared_ptr<TableProperties> props =
+          std::make_shared<TableProperties>();
+      props->comparator_name.assign(BytewiseComparator()->Name());
+      props->num_entries = 1;
+      props->raw_key_size = 3;
+      props->raw_value_size = 3;
+      return props;
+    }
+  };
+
+  class DummyExternalTableFactory : public ExternalTableFactory {
+   public:
+    const char* Name() const override { return "DummyExternalTableFactory"; }
+
+    Status NewTableReader(
+        const ReadOptions& /*read_options*/, const std::string& /*file_path*/,
+        const ExternalTableOptions& /*topts*/,
+        std::unique_ptr<ExternalTableReader>* table_reader) override {
+      table_reader->reset(new DummyExternalTableReader());
+      return Status::OK();
+    }
+  };
+};
+
+const std::string ExternalTableReaderTest::DummyExternalTableIterator::key_str =
+    "foo";
+const std::string
+    ExternalTableReaderTest::DummyExternalTableIterator::value_str = "bar";
+
+TEST_F(ExternalTableReaderTest, BasicTest) {
+  std::shared_ptr<ExternalTableFactory> factory(
+      new DummyExternalTableFactory());
+
+  std::unique_ptr<ExternalTableReader> reader;
+  std::shared_ptr<SliceTransform> prefix_extractor;
+  ASSERT_OK(factory->NewTableReader(
+      {}, "", {.prefix_extractor = prefix_extractor, .comparator = nullptr},
+      &reader));
+
+  ReadOptions ro;
+  ro.weight = 1;
+  std::unique_ptr<Iterator> iter(reader->NewIterator(ro, nullptr));
+  ASSERT_NE(iter, nullptr);
+  iter->Seek("foo");
+  ASSERT_TRUE(iter->Valid() && iter->status().ok());
+  ASSERT_EQ(iter->value(), "bar");
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+
+  std::string val;
+  ASSERT_OK(reader->Get({}, "foo", nullptr, &val));
+  ASSERT_EQ(val, "bar");
+
+  std::vector<std::string> vals;
+  std::vector<Status> statuses;
+  reader->MultiGet({}, {"foo", "bar"}, nullptr, &vals, &statuses);
+  ASSERT_EQ(vals.size(), 2);
+  ASSERT_EQ(statuses.size(), 2);
+  ASSERT_EQ(vals[0], "bar");
+  ASSERT_EQ(statuses[0], Status::OK());
+  ASSERT_EQ(statuses[1], Status::NotFound());
+}
+
+TEST_F(ExternalTableReaderTest, SstReaderTest) {
+  Options options = GetDefaultOptions();
+  std::string dbname = test::PerThreadDBPath("external_table_reader_test");
+  std::string ingest_file = dbname + "test.immutabledb";
+  dbname += "_db";
+
+  std::shared_ptr<ExternalTableFactory> factory(
+      new DummyExternalTableFactory());
+  options.table_factory = NewExternalTableFactory(factory);
+
+  // Create a file
+  ASSERT_OK(WriteStringToFile(options.env, "Hello World", ingest_file,
+                              /*should_sync=*/true));
+
+  std::unique_ptr<SstFileReader> reader(new SstFileReader(options));
+  ASSERT_OK(reader->Open(ingest_file));
+
+  ReadOptions ro;
+  ro.weight = 1;
+  std::unique_ptr<Iterator> iter(reader->NewIterator(ro));
+  ASSERT_NE(iter, nullptr);
+  iter->Seek("foo");
+  ASSERT_TRUE(iter->Valid() && iter->status().ok());
+  ASSERT_EQ(iter->value(), "bar");
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6715,6 +6715,7 @@ TEST_F(ExternalTableReaderTest, SstReaderTest) {
   ASSERT_EQ(iter->value(), "bar");
   iter->Next();
   ASSERT_FALSE(iter->Valid());
+  ASSERT_TRUE(iter->status().ok());
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/unreleased_history/new_features/external_table_reader.md
+++ b/unreleased_history/new_features/external_table_reader.md
@@ -1,0 +1,1 @@
+Added the ability to plug-in a custom table reader implementation. See include/rocksdb/external_table_reader.h for more details.


### PR DESCRIPTION
This PR introduces an interface to plug in an external table file reader into RocksDB. The external table reader may support custom file formats that might work better for a specific use case compared to RocksDB native formats. This initial version allows the external table file to be loaded and queried using an `SstFileReader`. In the near future, we will allow it to be used with a limited RocksDB instance that allows bulkload but not live writes.

The model of a DB using an external table reader is a read only database allowing bulkload and atomic replace in the bottommost level only. Live writes, if supported in the future, are expected to use block based table files in higher levels. Tombstones, merge operands, and non-zero sequence numbers are expected to be present only in non-bottommost levels. External table files are assumed to have only Puts, and all keys implicitly have sequence number 0.

TODO (in future PRs) -
1. Add support for external file ingestion, with safety mechanisms to prevent accidental writes
2. Add support for atomic column family replace
3. Allow custom table file extensions
4. Add a TableBuilder interface for use with `SstFileWriter` 