### PR TITLE
Disable auto_refresh_iterator_with_snapshot temporarily in stress test 

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -347,7 +347,9 @@ default_params = {
     # it has with write fault injection and TXN
     "track_and_verify_wals": 0,
     "enable_remote_compaction": lambda: random.choice([0, 1]),
-    "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
+    # TODO: enable `auto_refresh_iterator_with_snapshot` again after 
+    # fixing issues with prefix scan and injected read errors  
+    "auto_refresh_iterator_with_snapshot": 0,
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR


### PR DESCRIPTION
Context/Summary: recent crash test failures seem to find issues with recently added auto_refresh_iterator_with_snapshot and prefix/scan, injected read. For now, let's disable the auto_refresh_iterator_with_snapshot.

Test: monitor CI