### PR TITLE
MultiGet support in SstReader

### DIFF
--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -30,6 +30,11 @@ class SstFileReader {
   // If "snapshot" is nullptr, the iterator returns only the latest keys.
   Iterator* NewIterator(const ReadOptions& options);
 
+  // MultiGet to fetch a set of keys from the SST
+  std::vector<Status> MultiGet(const ReadOptions& options,
+                               const std::vector<Slice>& keys,
+                               std::vector<std::string>* values);
+
   // Returns a new iterator over the table contents as a raw table iterator,
   // a.k.a a `TableIterator`that iterates all point data entries in the table
   // including logically invisible entries like delete entries.

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -80,6 +80,82 @@ Status SstFileReader::Open(const std::string& file_path) {
   return s;
 }
 
+std::vector<Status> SstFileReader::MultiGet(const ReadOptions& roptions,
+                                            const std::vector<Slice>& keys,
+                                            std::vector<std::string>* values) {
+  const auto num_keys = keys.size();
+  std::vector<Status> statuses(num_keys, Status::IOError());
+  std::vector<PinnableSlice> pin_values(num_keys);
+
+  auto r = rep_.get();
+  const Comparator* user_comparator =
+      r->ioptions.internal_comparator.user_comparator();
+
+  autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE> key_context;
+  autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
+  autovector<GetContext, MultiGetContext::MAX_BATCH_SIZE> get_ctx;
+  sorted_keys.resize(num_keys);
+  for (size_t i = 0; i < num_keys; ++i) {
+    PinnableSlice* val = &pin_values[i];
+    val->Reset();
+    key_context.emplace_back(nullptr, keys[i], val, nullptr,
+                             nullptr /* timestamp */, &statuses[i]);
+    get_ctx.emplace_back(user_comparator, nullptr, nullptr, nullptr,
+                         GetContext::kNotFound, *key_context[i].key, val,
+                         nullptr, nullptr, nullptr, nullptr, true,
+                         &key_context[i].max_covering_tombstone_seq, nullptr);
+    key_context[i].get_context = &get_ctx[i];
+  }
+  for (size_t i = 0; i < num_keys; ++i) {
+    sorted_keys[i] = &key_context[i];
+  }
+
+  struct CompareKeyContext {
+    explicit CompareKeyContext(const Comparator* comp) : comparator(comp) {}
+    inline bool operator()(const KeyContext* lhs, const KeyContext* rhs) const {
+      return comparator->CompareWithoutTimestamp(*(lhs->key), false,
+                                                 *(rhs->key), false) < 0;
+    }
+    const Comparator* comparator;
+  };
+
+  std::sort(sorted_keys.begin(), sorted_keys.end(),
+            CompareKeyContext(user_comparator));
+  const auto sequence = roptions.snapshot != nullptr
+                            ? roptions.snapshot->GetSequenceNumber()
+                            : kMaxSequenceNumber;
+  MultiGetContext ctx(&sorted_keys, 0, num_keys, sequence, roptions,
+                      r->ioptions.fs.get(), nullptr);
+  MultiGetRange range = ctx.GetMultiGetRange();
+  r->table_reader->MultiGet(roptions, &range,
+                            r->moptions.prefix_extractor.get(),
+                            false /* skip filters */);
+
+  values->resize(num_keys);
+  for (size_t i = 0; i < num_keys; ++i) {
+    if (statuses[i].ok()) {
+      switch (get_ctx[i].State()) {
+        case GetContext::kFound:
+          (*values)[i].assign(pin_values[i].data(), pin_values[i].size());
+          break;
+        case GetContext::kNotFound:
+        case GetContext::kDeleted:
+          statuses[i] = Status::NotFound();
+          break;
+        case GetContext::kMerge:
+          statuses[i] = Status::MergeInProgress();
+          break;
+        case GetContext::kCorrupt:
+        case GetContext::kUnexpectedBlobIndex:
+        case GetContext::kMergeOperatorFailed:
+          statuses[i] = Status::Corruption();
+          break;
+      };
+    }
+  }
+  return statuses;
+}
+
 Iterator* SstFileReader::NewIterator(const ReadOptions& roptions) {
   assert(roptions.io_activity == Env::IOActivity::kUnknown);
   auto r = rep_.get();

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -768,6 +768,83 @@ TEST_F(SstFileReaderTableIteratorTest, UserDefinedTimestampsEnabled) {
   Close();
 }
 
+class SstFileReaderTableMultiGetTest : public DBTestBase {
+ public:
+  SstFileReaderTableMultiGetTest()
+      : DBTestBase("sst_file_reader_table_multi_get_test",
+                   /*env_do_fsync=*/false) {}
+
+  void VerifyTableEntry(Iterator* iter, const std::string& user_key,
+                        ValueType value_type,
+                        std::optional<std::string> expected_value,
+                        bool backward_iteration = false) {
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_TRUE(iter->status().ok());
+    ParsedInternalKey pikey;
+    ASSERT_OK(ParseInternalKey(iter->key(), &pikey, /*log_err_key=*/false));
+    ASSERT_EQ(pikey.user_key, user_key);
+    ASSERT_EQ(pikey.type, value_type);
+    if (expected_value.has_value()) {
+      ASSERT_EQ(iter->value(), expected_value.value());
+    }
+    if (!backward_iteration) {
+      iter->Next();
+    } else {
+      iter->Prev();
+    }
+  }
+};
+
+TEST_F(SstFileReaderTableMultiGetTest, Basic) {
+  Options options = CurrentOptions();
+  const Comparator* ucmp = BytewiseComparator();
+  options.comparator = ucmp;
+  options.disable_auto_compactions = true;
+
+  DestroyAndReopen(options);
+
+  ASSERT_OK(Put("foo", "val1"));
+  const Snapshot* snapshot1 = dbfull()->GetSnapshot();
+  ASSERT_OK(Delete("foo"));
+  ASSERT_OK(Delete("bar"));
+  const Snapshot* snapshot2 = dbfull()->GetSnapshot();
+  ASSERT_OK(Put("bar", "val2"));
+  ASSERT_OK(Put("baz", "val3"));
+
+  ASSERT_OK(Flush());
+
+  std::vector<LiveFileMetaData> files;
+  dbfull()->GetLiveFilesMetaData(&files);
+  ASSERT_TRUE(files.size() == 1);
+  ASSERT_TRUE(files[0].level == 0);
+  std::string file_name = files[0].directory + "/" + files[0].relative_filename;
+
+  SstFileReader reader(options);
+  ASSERT_OK(reader.Open(file_name));
+  ASSERT_OK(reader.VerifyChecksum());
+
+  std::vector<Slice> keys;
+  std::vector<std::string> values;
+
+  keys.emplace_back("fo1");
+  keys.emplace_back("foo");
+  keys.emplace_back("baz");
+  keys.emplace_back("bar");
+  auto statuses = reader.MultiGet(ReadOptions(), keys, &values);
+  ASSERT_TRUE(statuses[0].IsNotFound())
+      << "Failed: status=" << statuses[0].ToString() << " val=" << values[0];
+  ASSERT_TRUE(statuses[1].IsNotFound())
+      << "Failed: status=" << statuses[0].ToString() << " val=" << values[1];
+  ASSERT_TRUE(statuses[2].ok());
+  ASSERT_TRUE(statuses[3].ok());
+  ASSERT_EQ("val3", values[2]);
+  ASSERT_EQ("val2", values[3]);
+
+  dbfull()->ReleaseSnapshot(snapshot1);
+  dbfull()->ReleaseSnapshot(snapshot2);
+  Close();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
Add MultiGet support in SstReader. Today we only have iteration support and this change
also adds MultiGet support to SstFileReader if some application wants to use it.

Differential Revision: D69514499


