### PR TITLE
Disable `track_and_verify_wals` completely temporarily  

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -343,7 +343,9 @@ default_params = {
     "universal_max_read_amp": lambda: random.choice([-1] * 3 + [0, 4, 10]),
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
-    "track_and_verify_wals": lambda: random.choice([0, 1]),
+    # TODO(hx235): enable `track_and_verify_wals` again after resolving the issues 
+    # it has with write fault injection and TXN
+    "track_and_verify_wals": 0,
     "enable_remote_compaction": lambda: random.choice([0, 1]),
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
 }
@@ -1027,15 +1029,6 @@ def finalize_and_sanitize(src_params):
         dest_params["use_full_merge_v1"] = 0
         dest_params["enable_pipelined_write"] = 0
         dest_params["use_attribute_group"] = 0
-    # TODO(hx235): Re-enable write fault injections with pessimistic
-    # transactions after resolving the WAL hole caused by how corrupted
-    # WAL is handled under 2PC upon WAL write error recovery.
-    if (
-        dest_params.get("track_and_verify_wals", 0) == 1
-        and dest_params.get("use_optimistic_txn") == 0
-    ):
-        dest_params["metadata_write_fault_one_in"] = 0
-        dest_params["write_fault_one_in"] = 0
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
     if dest_params.get("test_secondary") == 1:
         dest_params["continuous_verification_interval"] = 0


### PR DESCRIPTION
**Context/Summary:**

https://github.com/facebook/rocksdb/pull/13263 and https://github.com/facebook/rocksdb/pull/13360 disabled `track_and_verify_wals` with some injection under TXN temporarily but recent stress tests has found more issues this feature surfaced even with the previous disabling. Disabling the feature **completely** now for stabilizing CI while debugging.


**Test:**
Monitor CI


