### PR TITLE
[Auto refresh iterator] Fix dbstress run - attempt 1

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1969,9 +1969,14 @@ void StressTest::VerifyIterator(
                        ? ro.iterate_lower_bound->ToString(true).c_str()
                        : "")
                << ", allow_unprepared_value: " << ro.allow_unprepared_value
-               << ", auto_refresh_iterator_with_snapshot"
-               << ro.auto_refresh_iterator_with_snapshot << ", snapshot: "
-               << ((ro.snapshot == nullptr) ? "nullptr" : "non-nullptr");
+               << ", auto_refresh_iterator_with_snapshot: "
+               << ro.auto_refresh_iterator_with_snapshot
+               << ", snapshot: " << (ro.snapshot ? "non-nullptr" : "nullptr")
+               << ", timestamp: "
+               << (ro.timestamp ? ro.timestamp->ToString(true).c_str() : "")
+               << ", iter_start_ts: "
+               << (ro.iter_start_ts ? ro.iter_start_ts->ToString(true).c_str()
+                                    : "");
 
   if (iter->Valid() && !cmp_iter->Valid()) {
     if (pe != nullptr) {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -550,6 +550,9 @@ class NonBatchedOpsStressTest : public StressTest {
           for (int i = 0; i < 5 && iter->Valid(); ++i, iter->Prev()) {
           }
         }
+        if (read_opts.auto_refresh_iterator_with_snapshot) {
+          read_opts.snapshot = nullptr;
+        }
       }
     }
   }
@@ -1586,7 +1589,7 @@ class NonBatchedOpsStressTest : public StressTest {
     Slice ub_slice;
     ReadOptions ro_copy = read_opts;
 
-    // There is a narrow window in iterator auto run refresh where injected read
+    // There is a narrow window in iterator auto refresh run where injected read
     // errors are simply untraceable, ex. failure to delete file as a part of
     // superversion cleanup callback invoked by the DBIter destructor.
     bool ignore_injected_read_error_in_iter =

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -29,13 +29,6 @@ class NonBatchedOpsStressTest : public StressTest {
     // This `ReadOptions` is for validation purposes. Ignore
     // `FLAGS_rate_limit_user_ops` to avoid slowing any validation.
     ReadOptions options(FLAGS_verify_checksum, true);
-    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
-    if (FLAGS_auto_refresh_iterator_with_snapshot) {
-      snapshot = std::make_unique<ManagedSnapshot>(db_);
-      options.snapshot = snapshot->snapshot();
-      options.auto_refresh_iterator_with_snapshot = true;
-    }
-
     std::string ts_str;
     Slice ts;
     if (FLAGS_user_timestamp_size > 0) {
@@ -54,6 +47,10 @@ class NonBatchedOpsStressTest : public StressTest {
 
     if (thread->tid == shared->GetNumThreads() - 1) {
       end = max_key;
+    }
+
+    if (FLAGS_auto_refresh_iterator_with_snapshot) {
+      options.auto_refresh_iterator_with_snapshot = true;
     }
 
     for (size_t cf = 0; cf < column_families_.size(); ++cf) {
@@ -80,6 +77,12 @@ class NonBatchedOpsStressTest : public StressTest {
               (FLAGS_user_timestamp_size > 0) ? num_methods - 1 : num_methods));
 
       if (method == VerificationMethod::kIterator) {
+        std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+        if (options.auto_refresh_iterator_with_snapshot) {
+          snapshot = std::make_unique<ManagedSnapshot>(db_);
+          options.snapshot = snapshot->snapshot();
+        }
+
         std::unique_ptr<Iterator> iter(
             db_->NewIterator(options, column_families_[cf]));
 
@@ -140,6 +143,10 @@ class NonBatchedOpsStressTest : public StressTest {
             PrintKeyValue(static_cast<int>(cf), static_cast<uint32_t>(i),
                           from_db.data(), from_db.size());
           }
+        }
+
+        if (options.auto_refresh_iterator_with_snapshot) {
+          options.snapshot = nullptr;
         }
       } else if (method == VerificationMethod::kGet) {
         for (int64_t i = start; i < end; ++i) {
@@ -509,6 +516,10 @@ class NonBatchedOpsStressTest : public StressTest {
         s.PermitUncheckedError();
       } else {
         // Use range scan
+        if (read_opts.auto_refresh_iterator_with_snapshot) {
+          snapshot = std::make_unique<ManagedSnapshot>(db_);
+          read_opts.snapshot = snapshot->snapshot();
+        }
         std::unique_ptr<Iterator> iter(
             secondary_db_->NewIterator(read_opts, handle));
         uint32_t rnd = (thread->rand.Next()) % 4;
@@ -1575,12 +1586,11 @@ class NonBatchedOpsStressTest : public StressTest {
     Slice ub_slice;
     ReadOptions ro_copy = read_opts;
 
-    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
-    if (ro_copy.auto_refresh_iterator_with_snapshot) {
-      snapshot = std::make_unique<ManagedSnapshot>(db_);
-      ro_copy.snapshot = snapshot->snapshot();
-      ro_copy.auto_refresh_iterator_with_snapshot = true;
-    }
+    // There is a narrow window in iterator auto run refresh where injected read
+    // errors are simply untraceable, ex. failure to delete file as a part of
+    // superversion cleanup callback invoked by the DBIter destructor.
+    bool ignore_injected_read_error_in_iter =
+        ro_copy.auto_refresh_iterator_with_snapshot;
 
     // Randomly test with `iterate_upper_bound` and `prefix_same_as_start`
     //
@@ -1611,6 +1621,12 @@ class NonBatchedOpsStressTest : public StressTest {
       SharedState::ignore_read_error = false;
     }
 
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (ro_copy.snapshot == nullptr &&
+        ro_copy.auto_refresh_iterator_with_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db_);
+      ro_copy.snapshot = snapshot->snapshot();
+    }
     std::unique_ptr<Iterator> iter(db_->NewIterator(ro_copy, cfh));
 
     uint64_t count = 0;
@@ -1668,7 +1684,8 @@ class NonBatchedOpsStressTest : public StressTest {
               FaultInjectionIOType::kRead),
           fault_fs_guard->GetAndResetInjectedThreadLocalErrorCount(
               FaultInjectionIOType::kMetadataRead));
-      if (!SharedState::ignore_read_error && injected_error_count > 0 &&
+      if (!ignore_injected_read_error_in_iter &&
+          !SharedState::ignore_read_error && injected_error_count > 0 &&
           s.ok()) {
         // Grab mutex so multiple thread don't try to print the
         // stack trace at the same time
@@ -2361,12 +2378,6 @@ class NonBatchedOpsStressTest : public StressTest {
     }
 
     ReadOptions ro(read_opts);
-    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
-    if (ro.auto_refresh_iterator_with_snapshot) {
-      snapshot = std::make_unique<ManagedSnapshot>(db_);
-      ro.snapshot = snapshot->snapshot();
-      ro.auto_refresh_iterator_with_snapshot = true;
-    }
 
     if (FLAGS_prefix_size > 0) {
       ro.total_order_seek = true;
@@ -2409,6 +2420,16 @@ class NonBatchedOpsStressTest : public StressTest {
       pre_read_expected_values.push_back(
           shared->Get(rand_column_family, i + lb));
     }
+
+    // Snapshot initialization timing plays a crucial role here.
+    // We want the iterator to reflect the state of the DB between
+    // reading `pre_read_expected_values` and `post_read_expected_values`.
+    std::unique_ptr<ManagedSnapshot> snapshot = nullptr;
+    if (ro.auto_refresh_iterator_with_snapshot) {
+      snapshot = std::make_unique<ManagedSnapshot>(db_);
+      ro.snapshot = snapshot->snapshot();
+    }
+
     std::unique_ptr<Iterator> iter;
     if (FLAGS_use_multi_cf_iterator) {
       std::vector<ColumnFamilyHandle*> cfhs;
@@ -2651,7 +2672,11 @@ class NonBatchedOpsStressTest : public StressTest {
         pre_read_expected_values.push_back(
             shared->Get(rand_column_family, i + lb));
       }
-      Status rs = iter->Refresh();
+      if (ro.auto_refresh_iterator_with_snapshot) {
+        snapshot = std::make_unique<ManagedSnapshot>(db_);
+        ro.snapshot = snapshot->snapshot();
+      }
+      Status rs = iter->Refresh(ro.snapshot);
       if (!rs.ok() && IsErrorInjectedAndRetryable(rs)) {
         return rs;
       }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -347,8 +347,7 @@ default_params = {
     # it has with write fault injection and TXN
     "track_and_verify_wals": 0,
     "enable_remote_compaction": lambda: random.choice([0, 1]),
-    # TODO(mszeszko): Temporarily setting to 1 to get more signal in testing phase.
-    "auto_refresh_iterator_with_snapshot": 1,
+    "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -343,13 +343,12 @@ default_params = {
     "universal_max_read_amp": lambda: random.choice([-1] * 3 + [0, 4, 10]),
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
-    # TODO(hx235): enable `track_and_verify_wals` again after resolving the issues 
+    # TODO(hx235): enable `track_and_verify_wals` again after resolving the issues
     # it has with write fault injection and TXN
     "track_and_verify_wals": 0,
     "enable_remote_compaction": lambda: random.choice([0, 1]),
-    # TODO: enable `auto_refresh_iterator_with_snapshot` again after 
-    # fixing issues with prefix scan and injected read errors  
-    "auto_refresh_iterator_with_snapshot": 0,
+    # TODO(mszeszko): Temporarily setting to 1 to get more signal in testing phase.
+    "auto_refresh_iterator_with_snapshot": 1,
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR
@@ -846,9 +845,9 @@ def finalize_and_sanitize(src_params):
     if dest_params.get("atomic_flush", 0) == 1:
         # disable pipelined write when atomic flush is used.
         dest_params["enable_pipelined_write"] = 0
-    # Truncating SST files in primary DB is incompatible 
-    # with secondary DB since the latter can't read the shared 
-    # and truncated SST file correctly 
+    # Truncating SST files in primary DB is incompatible
+    # with secondary DB since the latter can't read the shared
+    # and truncated SST file correctly
     if (
         dest_params.get("sst_file_manager_bytes_per_sec", 0) == 0
         or dest_params.get("test_secondary") == 1


### PR DESCRIPTION
This PR attempts to fix the **dbstress failures** post https://github.com/facebook/rocksdb/pull/13354. There are at least 2 high level categories of errors: 1) likely caused by wide-scope snapshot initialization ([issue found by Peter](https://github.com/facebook/rocksdb/pull/13354#discussion_r1960177118)), 2) lack of proper error propagation. Wrt 2), part of the problem is a real miss (we should condition auto refresh on `status().ok()` after calling to `Next` / `Prev`), but another part - [failure in propagating dbstress-injected read error](https://github.com/facebook/rocksdb/pull/13354#discussion_r1960913871) in file deletion is expected and should not be asserted on in dbstress.

### Test plan
Confirmed there are no more errors after running sandcastle crashtest for each of the failing flavors:

```hcl
https://www.internalfb.com/sandcastle/workflow/252201579138859344
https://www.internalfb.com/sandcastle/workflow/3233584532458171962
https://www.internalfb.com/sandcastle/workflow/1283525893806766134
https://www.internalfb.com/sandcastle/workflow/2796735368603351293
https://www.internalfb.com/sandcastle/workflow/3792030886252148966
https://www.internalfb.com/sandcastle/workflow/67553994428973733
https://www.internalfb.com/sandcastle/workflow/3886606478427208295
https://www.internalfb.com/sandcastle/workflow/1684346260642682928
https://www.internalfb.com/sandcastle/workflow/4197354852715406516
https://www.internalfb.com/sandcastle/workflow/535928355663233170
https://www.internalfb.com/sandcastle/workflow/3409224917925569737
```