### PR TITLE
Fix stress test DB verification methods

### DIFF
--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -831,13 +831,15 @@ DEFINE_uint64(snapshot_hold_ops, 0,
 DEFINE_bool(long_running_snapshots, false,
             "If set, hold on some some snapshots for much longer time.");
 
+// The following three options affect both regular read operations during the
+// test and initial/final database verification through VerifyDB.
 DEFINE_bool(use_multiget, false,
-            "If set, use the batched MultiGet API for reads");
+            "If set, use the batched MultiGet API for reads.");
 
-DEFINE_bool(use_get_entity, false, "If set, use the GetEntity API for reads");
+DEFINE_bool(use_get_entity, false, "If set, use the GetEntity API for reads.");
 
 DEFINE_bool(use_multi_get_entity, false,
-            "If set, use the MultiGetEntity API for reads");
+            "If set, use the MultiGetEntity API for reads.");
 
 DEFINE_int32(test_ingest_standalone_range_deletion_one_in, 0,
              "If non-zero, file ingestion flow will test standalone range "

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -72,9 +72,20 @@ class NonBatchedOpsStressTest : public StressTest {
       constexpr int num_methods =
           static_cast<int>(VerificationMethod::kNumberOfMethods);
 
-      const VerificationMethod method =
+      VerificationMethod method =
           static_cast<VerificationMethod>(thread->rand.Uniform(
               (FLAGS_user_timestamp_size > 0) ? num_methods - 1 : num_methods));
+
+      if (method == VerificationMethod::kGetEntity && !FLAGS_use_get_entity) {
+        method = VerificationMethod::kGet;
+      }
+      if (method == VerificationMethod::kMultiGetEntity &&
+          !FLAGS_use_multi_get_entity) {
+        method = VerificationMethod::kMultiGet;
+      }
+      if (method == VerificationMethod::kMultiGet && !FLAGS_use_multiget) {
+        method = VerificationMethod::kGet;
+      }
 
       if (method == VerificationMethod::kIterator) {
         std::unique_ptr<ManagedSnapshot> snapshot = nullptr;


### PR DESCRIPTION
Summary: update VerifyDB() to respect user specified flags when choosing verification method.

Test plan: existing CI.