### PR TITLE
Format compatibility test cover compressions, including mixed

### DIFF
--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -410,7 +410,7 @@ Status GetStringFromColumnFamilyOptions(std::string* opts_str,
 Status GetStringFromCompressionType(std::string* compression_str,
                                     CompressionType compression_type);
 
-std::vector<CompressionType> GetSupportedCompressions();
+const std::vector<CompressionType>& GetSupportedCompressions();
 
 Status GetBlockBasedTableOptionsFromString(
     const ConfigOptions& config_options,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -384,38 +384,49 @@ std::unordered_map<std::string, CompressionType>
         {"kZSTD", kZSTD},
         {"kDisableCompressionOption", kDisableCompressionOption}};
 
-std::vector<CompressionType> GetSupportedCompressions() {
-  // std::set internally to deduplicate potential name aliases
-  std::set<CompressionType> supported_compressions;
-  for (const auto& comp_to_name : OptionsHelper::compression_type_string_map) {
-    CompressionType t = comp_to_name.second;
-    if (t != kDisableCompressionOption && CompressionTypeSupported(t)) {
-      supported_compressions.insert(t);
+const std::vector<CompressionType>& GetSupportedCompressions() {
+  static std::vector<CompressionType> supported_compressions = []() {
+    // std::set internally to deduplicate potential name aliases
+    std::set<CompressionType> supported_compressions;
+    for (const auto& comp_to_name :
+         OptionsHelper::compression_type_string_map) {
+      CompressionType t = comp_to_name.second;
+      if (t != kDisableCompressionOption && CompressionTypeSupported(t)) {
+        supported_compressions.insert(t);
+      }
     }
-  }
-  return std::vector<CompressionType>(supported_compressions.begin(),
-                                      supported_compressions.end());
+    return std::vector<CompressionType>(supported_compressions.begin(),
+                                        supported_compressions.end());
+  }();
+  return supported_compressions;
 }
 
-std::vector<CompressionType> GetSupportedDictCompressions() {
-  std::set<CompressionType> dict_compression_types;
-  for (const auto& comp_to_name : OptionsHelper::compression_type_string_map) {
-    CompressionType t = comp_to_name.second;
-    if (t != kDisableCompressionOption && DictCompressionTypeSupported(t)) {
-      dict_compression_types.insert(t);
+const std::vector<CompressionType>& GetSupportedDictCompressions() {
+  static std::vector<CompressionType> supported_dict_compressions = []() {
+    std::set<CompressionType> dict_compression_types;
+    for (const auto& comp_to_name :
+         OptionsHelper::compression_type_string_map) {
+      CompressionType t = comp_to_name.second;
+      if (t != kDisableCompressionOption && DictCompressionTypeSupported(t)) {
+        dict_compression_types.insert(t);
+      }
     }
-  }
-  return std::vector<CompressionType>(dict_compression_types.begin(),
-                                      dict_compression_types.end());
+    return std::vector<CompressionType>(dict_compression_types.begin(),
+                                        dict_compression_types.end());
+  }();
+  return supported_dict_compressions;
 }
 
-std::vector<ChecksumType> GetSupportedChecksums() {
-  std::set<ChecksumType> checksum_types;
-  for (const auto& e : OptionsHelper::checksum_type_string_map) {
-    checksum_types.insert(e.second);
-  }
-  return std::vector<ChecksumType>(checksum_types.begin(),
-                                   checksum_types.end());
+const std::vector<ChecksumType>& GetSupportedChecksums() {
+  static std::vector<ChecksumType> supported_checksums = []() {
+    std::set<ChecksumType> checksum_types;
+    for (const auto& e : OptionsHelper::checksum_type_string_map) {
+      checksum_types.insert(e.second);
+    }
+    return std::vector<ChecksumType>(checksum_types.begin(),
+                                     checksum_types.end());
+  }();
+  return supported_checksums;
 }
 
 static bool ParseOptionHelper(void* opt_address, const OptionType& opt_type,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -387,32 +387,30 @@ std::unordered_map<std::string, CompressionType>
 const std::vector<CompressionType>& GetSupportedCompressions() {
   static std::vector<CompressionType> supported_compressions = []() {
     // std::set internally to deduplicate potential name aliases
-    std::set<CompressionType> supported_compressions;
+    std::set<CompressionType> comp_set;
     for (const auto& comp_to_name :
          OptionsHelper::compression_type_string_map) {
       CompressionType t = comp_to_name.second;
       if (t != kDisableCompressionOption && CompressionTypeSupported(t)) {
-        supported_compressions.insert(t);
+        comp_set.insert(t);
       }
     }
-    return std::vector<CompressionType>(supported_compressions.begin(),
-                                        supported_compressions.end());
+    return std::vector<CompressionType>(comp_set.begin(), comp_set.end());
   }();
   return supported_compressions;
 }
 
 const std::vector<CompressionType>& GetSupportedDictCompressions() {
   static std::vector<CompressionType> supported_dict_compressions = []() {
-    std::set<CompressionType> dict_compression_types;
+    std::set<CompressionType> comp_set;
     for (const auto& comp_to_name :
          OptionsHelper::compression_type_string_map) {
       CompressionType t = comp_to_name.second;
       if (t != kDisableCompressionOption && DictCompressionTypeSupported(t)) {
-        dict_compression_types.insert(t);
+        comp_set.insert(t);
       }
     }
-    return std::vector<CompressionType>(dict_compression_types.begin(),
-                                        dict_compression_types.end());
+    return std::vector<CompressionType>(comp_set.begin(), comp_set.end());
   }();
   return supported_dict_compressions;
 }

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -25,11 +25,11 @@ struct MutableDBOptions;
 struct MutableCFOptions;
 struct Options;
 
-std::vector<CompressionType> GetSupportedCompressions();
+const std::vector<CompressionType>& GetSupportedCompressions();
 
-std::vector<CompressionType> GetSupportedDictCompressions();
+const std::vector<CompressionType>& GetSupportedDictCompressions();
 
-std::vector<ChecksumType> GetSupportedChecksums();
+const std::vector<ChecksumType>& GetSupportedChecksums();
 
 inline bool IsSupportedChecksumType(ChecksumType type) {
   // Avoid annoying compiler warning-as-error (-Werror=type-limits)

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1254,7 +1254,7 @@ void BlockBasedTableBuilder::CompressAndVerifyBlock(
       // If zstd is in the mix, the compression_name table property needs to be
       // set to it, for proper handling of context and dictionaries.
       assert(!ZSTD_Supported() || r->compression_type == kZSTD);
-      auto compressions = GetSupportedCompressions();
+      const auto& compressions = GetSupportedCompressions();
       auto counter =
           g_hack_mixed_compression_in_block_based_table.FetchAddRelaxed(1);
       *type = compressions[counter % compressions.size()];

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -29,6 +29,7 @@
 #include "index_builder.h"
 #include "logging/logging.h"
 #include "memory/memory_allocator_impl.h"
+#include "options/options_helper.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/env.h"
@@ -1246,6 +1247,20 @@ void BlockBasedTableBuilder::CompressAndVerifyBlock(
         r->ioptions.clock,
         ShouldReportDetailedTime(r->ioptions.env, r->ioptions.stats));
 
+    *type = r->compression_type;
+#ifndef NDEBUG
+    if (r->compression_type != kNoCompression &&
+        g_hack_mixed_compression_in_block_based_table.LoadRelaxed() > 0U) {
+      // If zstd is in the mix, the compression_name table property needs to be
+      // set to it, for proper handling of context and dictionaries.
+      assert(!ZSTD_Supported() || r->compression_type == kZSTD);
+      auto compressions = GetSupportedCompressions();
+      auto counter =
+          g_hack_mixed_compression_in_block_based_table.FetchAddRelaxed(1);
+      *type = compressions[counter % compressions.size()];
+    }
+#endif  // !NDEBUG
+
     if (is_data_block) {
       r->compressible_input_data_bytes.fetch_add(uncompressed_block_data.size(),
                                                  std::memory_order_relaxed);
@@ -1258,7 +1273,7 @@ void BlockBasedTableBuilder::CompressAndVerifyBlock(
     }
     assert(compression_dict != nullptr);
     CompressionInfo compression_info(r->compression_opts, compression_ctx,
-                                     *compression_dict, r->compression_type,
+                                     *compression_dict, *type,
                                      r->sample_for_compression);
 
     std::string sampled_output_fast;
@@ -2185,4 +2200,8 @@ const std::string BlockBasedTable::kObsoleteFilterBlockPrefix = "filter.";
 const std::string BlockBasedTable::kFullFilterBlockPrefix = "fullfilter.";
 const std::string BlockBasedTable::kPartitionedFilterBlockPrefix =
     "partitionedfilter.";
+
+#ifndef NDEBUG
+RelaxedAtomic<uint64_t> g_hack_mixed_compression_in_block_based_table{0};
+#endif  // !NDEBUG
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -24,6 +24,7 @@
 #include "rocksdb/table.h"
 #include "table/meta_blocks.h"
 #include "table/table_builder.h"
+#include "util/atomic.h"
 #include "util/compression.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -204,5 +205,11 @@ Slice CompressBlock(const Slice& uncompressed_data, const CompressionInfo& info,
                     bool do_sample, std::string* compressed_output,
                     std::string* sampled_output_fast,
                     std::string* sampled_output_slow);
+
+#ifndef NDEBUG
+// 0 == disable the hack
+// > 0 => counter for rotating through compression types
+extern RelaxedAtomic<uint64_t> g_hack_mixed_compression_in_block_based_table;
+#endif
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -14,6 +14,9 @@
 #  SHORT_TEST=1 - Test only the oldest branch for each kind of test. This is
 #    a good choice for PR validation as it is relatively fast and will find
 #    most issues.
+#  LONG_TEST=1 - Test all branches known to build for this test, rather than
+#    the default of randomly sampling the branches that aren't the oldest in
+#    each set.
 #  USE_SSH=1 - Connect to GitHub with ssh instead of https
 
 if ! git diff-index --quiet HEAD; then
@@ -86,19 +89,26 @@ mkdir -p $bak_test_dir
 
 python_bin=$(which python3 || which python || echo python3)
 
-# Generate random files.
-for i in {1..6}
+if [ "$J" == "" ]; then
+  # make parallelism
+  J=32
+fi
+
+# Generate random files. We want enough files to cover a variety of compression
+# settings and low enough entropy in the files to make compression highly
+# likely, including for index blocks.
+for i in {1..8}
 do
   input_data[$i]=$input_data_path/data$i
   echo == Generating random input file ${input_data[$i]}
   $python_bin - <<EOF
 import random
 random.seed($i)
-symbols=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+symbols=['a', 'b', 'c', 'd', 'e', 'f', 'g']
 with open('${input_data[$i]}', 'w') as f:
   for i in range(1,1024):
     k = ""
-    for j in range(1, random.randint(1,32)):
+    for j in range(1, random.randint(1,80)):
       k=k + symbols[random.randint(0, len(symbols) - 1)]
     vb = ""
     for j in range(1, random.randint(0,128)):
@@ -148,7 +158,7 @@ declare -a bak_forward_refs=("${db_forward_no_options_refs[@]}" "${db_forward_wi
 # Branches (git refs) to check for DB backward compatibility (new version
 # reading data from old) (in addition to the "forward compatible" list)
 # NOTE: 2.7.fb.branch shows assertion violation in some configurations
-declare -a db_backward_only_refs=("2.2.fb.branch" "2.3.fb.branch" "2.4.fb.branch" "2.5.fb.branch" "2.6.fb.branch" "2.7.fb.branch" "2.8.1.fb" "3.0.fb.branch" "3.1.fb" "3.2.fb" "3.3.fb" "3.4.fb" "3.5.fb" "3.6.fb" "3.7.fb" "3.8.fb" "3.9.fb" "4.2.fb" "4.3.fb" "4.4.fb" "4.5.fb" "4.6.fb" "4.7.fb" "4.8.fb" "4.9.fb" "4.10.fb" "${bak_backward_only_refs[@]}")
+declare -a db_backward_only_refs=("2.2.fb.branch" "2.3.fb.branch" "2.4.fb.branch" "2.5.fb.branch" "2.6.fb.branch" "2.8.1.fb" "3.0.fb.branch" "3.1.fb" "3.2.fb" "3.3.fb" "3.4.fb" "3.5.fb" "3.6.fb" "3.7.fb" "3.8.fb" "3.9.fb" "4.2.fb" "4.3.fb" "4.4.fb" "4.5.fb" "4.6.fb" "4.7.fb" "4.8.fb" "4.9.fb" "4.10.fb" "${bak_backward_only_refs[@]}")
 
 if [ "$SHORT_TEST" ]; then
   # Use only the first (if exists) of each list
@@ -163,13 +173,27 @@ fi
 
 # De-duplicate & accumulate
 declare -a checkout_refs=()
-for checkout_ref in "${db_backward_only_refs[@]}" "${db_forward_no_options_refs[@]}" "${db_forward_with_options_refs[@]}" "${ext_backward_only_refs[@]}" "${ext_forward_refs[@]}" "${bak_backward_only_refs[@]}" "${bak_forward_refs[@]}"
+# Always include first release on each list
+for checkout_ref in "${db_backward_only_refs[0]}" "${db_forward_no_options_refs[0]}" "${db_forward_with_options_refs[0]}" "${ext_backward_only_refs[0]}" "${ext_forward_refs[0]}" "${bak_backward_only_refs[0]}" "${bak_forward_refs[0]}"
 do
   if [ ! -e $db_test_dir/$checkout_ref ]; then
     mkdir -p $db_test_dir/$checkout_ref
     checkout_refs+=($checkout_ref)
   fi
 done
+# Maybe include rest if not short test
+if [ "$SHORT_TEST" == "" ]; then
+  for checkout_ref in "${db_backward_only_refs[@]}" "${db_forward_no_options_refs[@]}" "${db_forward_with_options_refs[@]}" "${ext_backward_only_refs[@]}" "${ext_forward_refs[@]}" "${bak_backward_only_refs[@]}" "${bak_forward_refs[@]}"
+  do
+    if [ ! -e $db_test_dir/$checkout_ref ]; then
+      mkdir -p $db_test_dir/$checkout_ref
+      # Randomly sample remaining releases, unless long test
+      if [ "$LONG_TEST" ] || [ "$(($RANDOM % 3))" == "0" ]; then
+        checkout_refs+=($checkout_ref)
+      fi
+    fi
+  done
+fi
 
 generate_db()
 {
@@ -250,6 +274,10 @@ force_no_fbcode()
   # Not all branches recognize ROCKSDB_NO_FBCODE and we should not need
   # to patch old branches for changes to available FB compilers.
   sed -i -e 's|-d /mnt/gvfs/third-party|"$ROCKSDB_FORCE_FBCODE"|' build_tools/build_detect_platform
+  # Fix a build issue affecting at least 4.2.fb
+  if [ -e include/rocksdb/delete_scheduler.h ]; then
+    sed -i -e 's|pragma once|pragma once\n#include <memory>|' include/rocksdb/delete_scheduler.h
+  fi
 }
 
 # General structure from here:
@@ -270,7 +298,7 @@ echo "== Building $current_checkout_name debug"
 git checkout -B $tmp_branch $current_checkout_hash
 force_no_fbcode
 make clean
-DISABLE_WARNING_AS_ERROR=1 make ldb -j32
+DISABLE_WARNING_AS_ERROR=1 make ldb -j$J
 
 echo "== Using $current_checkout_name, generate DB with extern SST and ingest"
 current_ext_test_dir=$ext_test_dir"/current"
@@ -291,7 +319,7 @@ do
   git reset --hard $tmp_origin/$checkout_ref
   force_no_fbcode
   make clean
-  DISABLE_WARNING_AS_ERROR=1 make ldb -j32
+  DISABLE_WARNING_AS_ERROR=1 make ldb -j$J
 
   # We currently assume DB backward compatibility for every branch listed
   echo "== Use $checkout_ref to generate a DB ..."
@@ -349,7 +377,7 @@ echo "== Building $current_checkout_name debug (again, final)"
 git reset --hard $current_checkout_hash
 force_no_fbcode
 make clean
-DISABLE_WARNING_AS_ERROR=1 make ldb -j32
+DISABLE_WARNING_AS_ERROR=1 make ldb -j$J
 
 for checkout_ref in "${checkout_refs[@]}"
 do

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -39,6 +39,7 @@
 #include "rocksdb/utilities/options_util.h"
 #include "rocksdb/write_batch.h"
 #include "rocksdb/write_buffer_manager.h"
+#include "table/block_based/block_based_table_builder.h"
 #include "table/sst_file_dumper.h"
 #include "tools/ldb_cmd_impl.h"
 #include "util/cast_util.h"
@@ -805,26 +806,78 @@ bool LDBCommand::ParseCompressionTypeOption(
       value = kNoCompression;
       return true;
     } else if (comp == "snappy") {
-      value = kSnappyCompression;
-      return true;
+      if (!Snappy_Supported()) {
+        exec_state = LDBCommandExecuteResult::Failed(
+            "Snappy compression is not supported in this build.");
+      } else {
+        value = kSnappyCompression;
+        return true;
+      }
     } else if (comp == "zlib") {
-      value = kZlibCompression;
-      return true;
+      if (!Zlib_Supported()) {
+        exec_state = LDBCommandExecuteResult::Failed(
+            "zlib compression is not supported in this build.");
+      } else {
+        value = kZlibCompression;
+        return true;
+      }
     } else if (comp == "bzip2") {
-      value = kBZip2Compression;
-      return true;
+      if (!BZip2_Supported()) {
+        exec_state = LDBCommandExecuteResult::Failed(
+            "bzip2 compression is not supported in this build.");
+      } else {
+        value = kBZip2Compression;
+        return true;
+      }
     } else if (comp == "lz4") {
-      value = kLZ4Compression;
-      return true;
+      if (!LZ4_Supported()) {
+        exec_state = LDBCommandExecuteResult::Failed(
+            "lz4 compression is not supported in this build.");
+      } else {
+        value = kLZ4Compression;
+        return true;
+      }
     } else if (comp == "lz4hc") {
-      value = kLZ4HCCompression;
-      return true;
+      if (!LZ4_Supported()) {
+        exec_state = LDBCommandExecuteResult::Failed(
+            "lz4hc compression is not supported in this build.");
+      } else {
+        value = kLZ4HCCompression;
+        return true;
+      }
     } else if (comp == "xpress") {
-      value = kXpressCompression;
-      return true;
+      if (!XPRESS_Supported()) {
+        exec_state = LDBCommandExecuteResult::Failed(
+            "xpress compression is not supported in this build.");
+      } else {
+        value = kXpressCompression;
+        return true;
+      }
     } else if (comp == "zstd") {
-      value = kZSTD;
+      if (!ZSTD_Supported()) {
+        exec_state = LDBCommandExecuteResult::Failed(
+            "zstd compression is not supported in this build.");
+      } else {
+        value = kZSTD;
+        return true;
+      }
+#ifndef NDEBUG
+    } else if (comp == "mixed" && option == ARG_COMPRESSION_TYPE) {
+      if (GetSupportedCompressions().empty()) {
+        exec_state = LDBCommandExecuteResult::Failed(
+            "No compressions are supported in this build for \"mixed\".");
+        return false;
+      }
+      // A temporary hack to generate an SST file with a mix of compression
+      // types, as this has been *de facto* supported for a long time on the
+      // read side with no code to generate them on the write side. We can test
+      // that functionality, e.g. in check_format_compatible.sh, with this hack
+      g_hack_mixed_compression_in_block_based_table.StoreRelaxed(1);
+      // Need to list zstd in compression_name table property if it's
+      // potentially in the mix, for proper handling of context and dictionary.
+      value = ZSTD_Supported() ? kZSTD : GetSupportedCompressions()[0];
       return true;
+#endif  // !NDEBUG
     } else {
       // Unknown compression.
       exec_state = LDBCommandExecuteResult::Failed(

--- a/unreleased_history/behavior_changes/ldb_comp.md
+++ b/unreleased_history/behavior_changes/ldb_comp.md
@@ -1,0 +1,1 @@
+* `ldb` now returns an error if the specified `--compression_type` is not supported in the build.


### PR DESCRIPTION
Summary: The existing format compatibility test had limited coverage of compression options, particularly newer algorithms with and without dictionary compression. There are some subtleties that need to remain consistent, such as index blocks potentially being compressed but *not* using the file's dictionary if they are. This involves detecting (with a rough approximation) builds with the appropriate capabilities.

The other motivation for this change is testing some potentially useful reader-side functionality that has been in place for a long time but has not been exercised until now: mixing compressions in a single SST file. The block-based SST schema puts a compression marker on each block; arguably this is for distinguishing blocks compressed using the algorithm stored in compression_name table property from blocks left uncompressed, e.g. because they did not reach the threshold of useful compression ratio, but the marker can also distinguish compression algorithms / decompressors.

As we work toward customizable compression, it seems worth unlocking the capability to leverage the existing schema and SST reader-side support for mixing compression algorithms among the blocks of a file. Yes, a custom compression could implement its own dynamic algorithm chooser with its own tag on the compressed data (e.g. first byte), but that is slightly less storage efficient and doesn't support "vanilla" RocksDB builds reading files using a mix of built-in algorithms. As a hypothetical example, we might want to switch to lz4 on a machine that is under heavy CPU load and back to zstd when load is more normal. I dug up some data indicating ~30 seconds per output file in compaction, suggesting that file-level responsiveness might be too slow. This agility is perhaps more useful with disaggregated storage, where there is more flexibility in DB storage footprint and potentially more payoff in optimizing the *average* footprint.

In support of this direction, I have added a backdoor capability for debug builds of `ldb` to generate files with a mix of compression algorithms and incorporated this into the format compatibility test. All of the existing "forward compatible" versions (currently back to 8.6) are able to read the files generated with "mixed" compression. (NOTE: there's no easy way to patch a bunch of old versions to have them support generating mixed compression files, but going forward we can auto-detect builds with this "mixed" capability.) A subtle aspect of this support that is that for proper handling of decompression contexts and digested dictionaries, we need to set the `compression_name` table property to `zstd` if any blocks are zstd compressed. I'm expecting to add better info to SST files in follow-up, but this approach here gives us forward compatibility back to 8.6.

However, in the spirit of opening things up with what makes sense under the existing schema, we only support one compression dictionary per file. It will be used by any/all algorithms that support dictionary compression. This is not outrageous because it seems standard that a dictionary is *or can be* arbitrary data representative of what will be compressed. This means we would need a schema change to add dictionary compression support to an existing built-in compression algorithm (because otherwise old versions and new versions would disagree on whether the data dictionary is needed with that algorithm; this could take the form of a new built-in compression type, e.g. `kSnappyCompressionWithDict`; only snappy, bzip2, and windows-only xpress compression lack dictionary support currently). 

Looking ahead to supporting custom compression, exposing a sizeable set of CompressionTypes to the user for custom handling essentially guarantees a path for the user to put *versioning* on their compression even if they neglect that initially, and without resorting to managing a bunch of distinct named entities. (I'm envisioning perhaps 64 or 127 CompressionTypes open to customization, enough for ~weekly new releases with more than a year of horizon on recycling.)

More details:
* Reduce the running time (CI cost) of the default format compatibility test by randomly sampling versions that aren't the oldest in a category. AFAIK, pretty much all regressions can be caught with the even more stripped-down SHORT_TEST.
* Configurable make parallelism with J environment variable
* Generate data files in a way that makes them much more eligible for index compression, e.g. bigger keys with less entropy
* Generate enough data files 
* Remove 2.7.fb.branch from list because it shows an assertion violation when involving compression.
* Randomly choose a contiguous subset of the compression algorithms X {dictionary, no dictionary} configuration space when generating files, with a number of files > number of algorithms. This covers all the algorithms and both dictionary/no dictionary for each release (but not in all combinations).
* Have `ldb` fail if the specified compression type is not supported by the build.

Other future work needed:
* Blob files in format compatibility test, and support for mixed compression. NOTE: the blob file schema should naturally support mixing compression algorithms but the reader code does not because of an assertion that the block CompressionType (if not no compression) matches the whole file CompressionType. We might introduce a "various" CompressionType for this whole file marker in blob files.
* Do more to ensure certain features and code paths e.g. in the scripts are actually used in the compatibility test, so that they aren't accidentally neutralized.

Test Plan:
Manual runs with some temporary instrumentation, also a recent revision of this change included a GitHub Actions run of the updated format compatible test: https://github.com/facebook/rocksdb/actions/runs/13463551149/job/37624205915?pr=13414