### PR TITLE
Initial implementation of ExternalTableBuilder

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -214,7 +214,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "table/cuckoo/cuckoo_table_builder.cc",
         "table/cuckoo/cuckoo_table_factory.cc",
         "table/cuckoo/cuckoo_table_reader.cc",
-        "table/external_table_reader.cc",
+        "table/external_table.cc",
         "table/format.cc",
         "table/get_context.cc",
         "table/iterator.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -835,7 +835,7 @@ set(SOURCES
         table/cuckoo/cuckoo_table_builder.cc
         table/cuckoo/cuckoo_table_factory.cc
         table/cuckoo/cuckoo_table_reader.cc
-        table/external_table_reader.cc
+        table/external_table.cc
         table/format.cc
         table/get_context.cc
         table/iterator.cc

--- a/include/rocksdb/external_table.h
+++ b/include/rocksdb/external_table.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "rocksdb/customizable.h"
+#include "rocksdb/file_checksum.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
@@ -18,22 +19,21 @@ class ExternalTableFactory;
 // The interface defined in this file is subject to change at any time without
 // warning!!
 
-// This file defines an interface for plugging in an external table reader
+// This file defines an interface for plugging in an external table
 // into RocksDB. The external table reader will be used instead of the
 // BlockBasedTable to load and query sst files. As of now, creating the
-// external table files using RocksDB is not supported, but will be added in
-// the near future. The external table files can be created outside and
-// RocksDB and ingested into a RocksDB instance using the IngestExternalFIle()
-// API.
+// the near future. The external table files can be created using an
+// SstFileWriter. Eventually external tables will be allowed to be ingested
+// into a RocksDB instance using the IngestExternalFIle() API.
 //
-// Initial support is for loading and querying the files using an
-// SstFileReader. We will add support for ingestion of an external table
-// into a limited RocksDB instance that only supports ingestion and not live
-// writes in the near future. It'll be followed by support for replacing the
-// column family by ingesting a new set of files. In all cases, the external
-// table files will only be allowed in the bottommost level.
+// Initial support is for writing and querying the files using an
+// SstFileWriter and SstFileReader. We will add support for ingestion of an
+// external table into a limited RocksDB instance that only supports ingestion
+// and not live writes in the near future. It'll be followed by support for
+// replacing the column family by ingesting a new set of files. In all cases,
+// the external table files will only be allowed in the bottommost level.
 //
-// The external table reader can support one or both of the following layouts -
+// The external table can support one or both of the following layouts -
 // 1. Total order seek - All the keys in the files are in sorted order, and a
 //    user can seek to the first, last, or any key in between and iterate
 //    forwards or backwards till the end of the range. To support this mode,
@@ -54,8 +54,8 @@ class ExternalTableFactory;
 //    true to seek to the first non-empty prefix (as determined by the key
 //    order) if the seek prefix is empty.
 //
-// Many of the options in ReadOptions may not be relevant to the external
-// table implementation.
+// Many of the options in ReadOptions and WriteOptions may not be relevant to
+// the external table implementation.
 // TODO: Specify which options are relevant
 
 class ExternalTableReader {
@@ -94,6 +94,62 @@ class ExternalTableReader {
   }
 };
 
+// A table builder interface that can be used by SstFileWriter to allow
+// RocksDB users to write external table files. The sequence of operations
+// to write an external table is as follows -
+// 1. Add() is called one or more times to write all key-values to the table.
+//    Its called in increasing key order, as determined by the comparator.
+//    The input key is a user key, i.e sequence number and value type are
+//    stripped out.
+// 2. After every Add() operation, status() is called to check the current
+//    status.
+// 3. After the last key is added, Finish() is called to do whatever is
+//    necessary to ensure the data is persisted in the table file.
+// 4. If there is a failure midway for some reason, Abandon() is called
+//    instead of Finish().
+// 5. At the end, FileSize(), GetTableProperties(), and status() are called to
+//    get the final size of the file, the table properties, and the final
+//    status. GetFileChecksum() and GetFileChecksumFuncName() may also be
+//    called to get checksum information about the whole file, but their
+//    implementation is optional.
+class ExternalTableBuilder {
+ public:
+  virtual ~ExternalTableBuilder() {}
+
+  // Write a single KV to the table file. This is guaranteed to be called
+  // in key order, and the write may be buffered and flushed at a later time.
+  virtual void Add(const Slice& key, const Slice& value) = 0;
+
+  // Return the current Status. This could return non-ok, for example, if
+  // Add() fails for some reason.
+  virtual Status status() const = 0;
+
+  // Flush and close the table file
+  virtual Status Finish() = 0;
+
+  // Delete the partial file and release any allocated resources. Either this
+  // Finish() will be called, but not both.
+  virtual void Abandon() = 0;
+
+  // Return the size of the table file. Will be called at the end, after
+  // Finish().
+  virtual uint64_t FileSize() const = 0;
+
+  //  As mentioned in earlier comments, the following table properties must be
+  //  returned at a minimum -
+  //  comparator_name
+  //  num_entries
+  //  raw_key_size
+  //  raw_value_size
+  virtual TableProperties GetTableProperties() const = 0;
+
+  virtual std::string GetFileChecksum() const { return kUnknownFileChecksum; }
+
+  virtual const char* GetFileChecksumFuncName() const {
+    return kUnknownFileChecksumFuncName;
+  }
+};
+
 struct ExternalTableOptions {
   const std::shared_ptr<const SliceTransform>& prefix_extractor;
   const Comparator* comparator;
@@ -102,6 +158,29 @@ struct ExternalTableOptions {
       const std::shared_ptr<const SliceTransform>& _prefix_extractor,
       const Comparator* _comparator)
       : prefix_extractor(_prefix_extractor), comparator(_comparator) {}
+};
+
+struct ExternalTableBuilderOptions {
+  const ReadOptions& read_options;
+  const WriteOptions& write_options;
+  const std::shared_ptr<const SliceTransform>& prefix_extractor;
+  const Comparator* comparator;
+  const std::string& column_family_name;
+  const std::string db_id;
+  const std::string db_session_id;
+  const TableFileCreationReason reason;
+
+  ExternalTableBuilderOptions(
+      const ReadOptions& _read_options, const WriteOptions& _write_options,
+      const std::shared_ptr<const SliceTransform>& _prefix_extractor,
+      const Comparator* _comparator, const std::string& _column_family_name,
+      const TableFileCreationReason _reason)
+      : read_options(_read_options),
+        write_options(_write_options),
+        prefix_extractor(_prefix_extractor),
+        comparator(_comparator),
+        column_family_name(_column_family_name),
+        reason(_reason) {}
 };
 
 class ExternalTableFactory : public Customizable {
@@ -113,7 +192,11 @@ class ExternalTableFactory : public Customizable {
   virtual Status NewTableReader(
       const ReadOptions& read_options, const std::string& file_path,
       const ExternalTableOptions& table_options,
-      std::unique_ptr<ExternalTableReader>* table_reader) = 0;
+      std::unique_ptr<ExternalTableReader>* table_reader) const = 0;
+
+  virtual ExternalTableBuilder* NewTableBuilder(
+      const ExternalTableBuilderOptions& builder_options,
+      const std::string& file_path) const = 0;
 };
 
 // Allocate a TableFactory that wraps around an ExternalTableFactory. Use this

--- a/include/rocksdb/external_table.h
+++ b/include/rocksdb/external_table.h
@@ -21,10 +21,10 @@ class ExternalTableFactory;
 
 // This file defines an interface for plugging in an external table
 // into RocksDB. The external table reader will be used instead of the
-// BlockBasedTable to load and query sst files. As of now, creating the
-// the near future. The external table files can be created using an
-// SstFileWriter. Eventually external tables will be allowed to be ingested
-// into a RocksDB instance using the IngestExternalFIle() API.
+// BlockBasedTable to load and query sst files.
+// The external table files can be created using an SstFileWriter. Eventually
+// external tables will be allowed to be ingested into a RocksDB instance
+// using the IngestExternalFIle() API.
 //
 // Initial support is for writing and querying the files using an
 // SstFileWriter and SstFileReader. We will add support for ingestion of an
@@ -128,7 +128,7 @@ class ExternalTableBuilder {
   virtual Status Finish() = 0;
 
   // Delete the partial file and release any allocated resources. Either this
-  // Finish() will be called, but not both.
+  // or Finish() will be called, but not both.
   virtual void Abandon() = 0;
 
   // Return the size of the table file. Will be called at the end, after

--- a/src.mk
+++ b/src.mk
@@ -205,7 +205,7 @@ LIB_SOURCES =                                                   \
   table/cuckoo/cuckoo_table_builder.cc                          \
   table/cuckoo/cuckoo_table_factory.cc                          \
   table/cuckoo/cuckoo_table_reader.cc                           \
-  table/external_table_reader.cc				\
+  table/external_table.cc					\
   table/format.cc                                               \
   table/get_context.cc                                          \
   table/iterator.cc                                             \

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -3,7 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
-#include "rocksdb/external_table_reader.h"
+#include "rocksdb/external_table.h"
 
 #include "rocksdb/table.h"
 #include "table/internal_iterator.h"
@@ -110,7 +110,7 @@ class ExternalTableIterator : public InternalIterator {
 class ExternalTableReaderAdapter : public TableReader {
  public:
   explicit ExternalTableReaderAdapter(
-      std::unique_ptr<ExternalTableReader> reader)
+      std::unique_ptr<ExternalTableReader>&& reader)
       : reader_(std::move(reader)) {}
 
   ~ExternalTableReaderAdapter() override {}
@@ -170,6 +170,62 @@ class ExternalTableReaderAdapter : public TableReader {
   std::unique_ptr<ExternalTableReader> reader_;
 };
 
+class ExternalTableBuilderAdapter : public TableBuilder {
+ public:
+  explicit ExternalTableBuilderAdapter(
+      std::unique_ptr<ExternalTableBuilder>&& builder)
+      : builder_(std::move(builder)), num_entries_(0) {}
+
+  void Add(const Slice& key, const Slice& value) override {
+    ParsedInternalKey pkey;
+    status_ = ParseInternalKey(key, &pkey, /*log_err_key=*/false);
+    if (status_.ok()) {
+      if (pkey.type != ValueType::kTypeValue) {
+        status_ = Status::NotSupported(
+            "Value type " + std::to_string(pkey.type) + "not supported");
+      } else {
+        builder_->Add(pkey.user_key, value);
+        num_entries_++;
+      }
+    }
+  }
+
+  Status status() const override {
+    if (status_.ok()) {
+      return builder_->status();
+    } else {
+      return status_;
+    }
+  }
+
+  IOStatus io_status() const override { return status_to_io_status(status()); }
+
+  Status Finish() override { return builder_->Finish(); }
+
+  void Abandon() override { builder_->Abandon(); }
+
+  uint64_t FileSize() const override { return builder_->FileSize(); }
+
+  uint64_t NumEntries() const override { return num_entries_; }
+
+  TableProperties GetTableProperties() const override {
+    return builder_->GetTableProperties();
+  }
+
+  std::string GetFileChecksum() const override {
+    return builder_->GetFileChecksum();
+  }
+
+  const char* GetFileChecksumFuncName() const override {
+    return builder_->GetFileChecksumFuncName();
+  }
+
+ private:
+  Status status_;
+  std::unique_ptr<ExternalTableBuilder> builder_;
+  uint64_t num_entries_;
+};
+
 class ExternalTableFactoryAdapter : public TableFactory {
  public:
   explicit ExternalTableFactoryAdapter(
@@ -197,8 +253,18 @@ class ExternalTableFactoryAdapter : public TableFactory {
     return Status::OK();
   }
 
-  TableBuilder* NewTableBuilder(const TableBuilderOptions&,
-                                WritableFileWriter*) const override {
+  using TableFactory::NewTableBuilder;
+  TableBuilder* NewTableBuilder(const TableBuilderOptions& topts,
+                                WritableFileWriter* file) const override {
+    std::unique_ptr<ExternalTableBuilder> builder;
+    ExternalTableBuilderOptions ext_topts(
+        topts.read_options, topts.write_options,
+        topts.moptions.prefix_extractor, topts.ioptions.user_comparator,
+        topts.column_family_name, topts.reason);
+    builder.reset(inner_->NewTableBuilder(ext_topts, file->file_name()));
+    if (builder) {
+      return new ExternalTableBuilderAdapter(std::move(builder));
+    }
     return nullptr;
   }
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -36,7 +36,7 @@
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
-#include "rocksdb/external_table_reader.h"
+#include "rocksdb/external_table.h"
 #include "rocksdb/file_checksum.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/filter_policy.h"
@@ -6531,28 +6531,112 @@ class ExternalTableReaderTest : public DBTestBase {
       : DBTestBase("external_table_reader_test", /*env_do_fsync=*/false) {}
 
  protected:
+  class DummyExternalTableFile {
+   public:
+    explicit DummyExternalTableFile(const std::string& file_path)
+        : file_path_(file_path), file_size_(0) {
+      props_.comparator_name = BytewiseComparator()->Name();
+    }
+
+    Status Serialize(
+        const std::vector<std::pair<std::string, std::string>>& kv_vec) {
+      for (auto& kv : kv_vec) {
+        SerializeOne(kv.first, kv.second);
+        props_.raw_key_size += kv.first.length();
+        props_.raw_value_size += kv.second.length();
+      }
+      props_.num_entries = kv_vec.size();
+      file_size_ = buf_.length();
+      return WriteStringToFile(Env::Default(), buf_, file_path_);
+    }
+
+    Status Deserialize(std::map<std::string, std::string>& kv_map) {
+      Status s = ReadFileToString(Env::Default(), file_path_, &buf_);
+      if (!s.ok()) {
+        return s;
+      }
+
+      while (buf_.length() > 0) {
+        std::pair<std::string, std::string> kv;
+        s = DeserializeOne(kv);
+        if (!s.ok()) {
+          break;
+        }
+        size_t key_size = kv.first.length();
+        size_t value_size = kv.second.length();
+        kv_map.emplace(std::move(kv));
+        props_.raw_key_size += key_size;
+        props_.raw_value_size += value_size;
+      }
+      props_.num_entries = kv_map.size();
+      return s;
+    }
+
+    TableProperties GetTableProperties() const { return props_; }
+
+    uint64_t FileSize() const { return file_size_; }
+
+   private:
+    struct ItemHeader {
+      uint32_t key_size;
+      uint32_t value_size;
+    };
+
+    void SerializeOne(const Slice& key, const Slice& value) {
+      ItemHeader hdr;
+      hdr.key_size = static_cast<uint32_t>(key.size());
+      hdr.value_size = static_cast<uint32_t>(value.size());
+      buf_.append(static_cast<char*>(static_cast<void*>(&hdr)), sizeof(hdr));
+      buf_.append(key.data(), key.size());
+      buf_.append(value.data(), value.size());
+    }
+
+    Status DeserializeOne(std::pair<std::string, std::string>& kv) {
+      ItemHeader hdr;
+      size_t copied =
+          buf_.copy(static_cast<char*>(static_cast<void*>(&hdr)), sizeof(hdr));
+      if (copied < sizeof(hdr)) {
+        return Status::Corruption();
+      }
+      buf_.erase(0, sizeof(hdr));
+      if (buf_.length() < hdr.key_size + hdr.value_size) {
+        return Status::Corruption();
+      }
+      kv.first.assign(std::string_view(buf_.data(), hdr.key_size));
+      buf_.erase(0, hdr.key_size);
+      kv.second.assign(std::string_view(buf_.data(), hdr.value_size));
+      buf_.erase(0, hdr.value_size);
+      return Status::OK();
+    }
+
+    std::string file_path_;
+    std::string buf_;
+    TableProperties props_;
+    uint64_t file_size_;
+  };
+
   class DummyExternalTableIterator : public Iterator {
    public:
-    explicit DummyExternalTableIterator(bool empty) : empty_(empty) {}
+    explicit DummyExternalTableIterator(
+        const ReadOptions& ro, const std::map<std::string, std::string>& kv_map)
+        : weight_(ro.weight), kv_map_(kv_map), valid_(false) {}
 
-    bool Valid() const override { return empty_ ? !empty_ : valid_; }
+    bool Valid() const override { return valid_; }
 
     void SeekToFirst() override {
-      valid_ = true;
+      iter_ = kv_map_.begin();
+      valid_ = iter_ != kv_map_.end();
       status_ = Status::OK();
     }
 
     void SeekToLast() override {
-      valid_ = true;
-      status_ = Status::OK();
+      valid_ = false;
+      status_ = Status::NotSupported();
     }
 
     void Seek(const Slice& target) override {
-      if (target.compare(key_str) <= 0) {
-        valid_ = true;
-      } else {
-        valid_ = false;
-      }
+      iter_ = kv_map_.find(target.ToString());
+      valid_ = iter_ != kv_map_.end();
       status_ = Status::OK();
     }
 
@@ -6562,7 +6646,9 @@ class ExternalTableReaderTest : public DBTestBase {
     }
 
     void Next() override {
-      valid_ = false;
+      iter_++;
+      weight_--;
+      valid_ = iter_ != kv_map_.end() && weight_ > 0;
       // status_ is still ok. valid_ indicates end of scan
     }
 
@@ -6573,7 +6659,7 @@ class ExternalTableReaderTest : public DBTestBase {
 
     Slice key() const override {
       // If valid_ is false or status_ is non-ok, behavior is indeterminate
-      return Slice(key_str);
+      return Slice(iter_->first);
     }
 
     Status status() const override {
@@ -6583,31 +6669,36 @@ class ExternalTableReaderTest : public DBTestBase {
 
     Slice value() const override {
       // If valid_ is false or status_ is non-ok, behavior is indeterminate
-      return Slice(value_str);
+      return Slice(iter_->second);
     }
 
    private:
-    static const std::string key_str;
-    static const std::string value_str;
-
+    uint64_t weight_;
+    std::map<std::string, std::string> kv_map_;
     bool valid_ = false;
-    bool empty_;
     Status status_ = Status::OK();
+    std::map<std::string, std::string>::iterator iter_;
   };
 
   class DummyExternalTableReader : public ExternalTableReader {
    public:
+    explicit DummyExternalTableReader(const std::string& file_path)
+        : file_(file_path) {
+      Status s = file_.Deserialize(kv_map_);
+      EXPECT_OK(s);
+    }
+
     Iterator* NewIterator(const ReadOptions& read_options,
                           const SliceTransform* /*prefix_extractor*/) override {
-      return new DummyExternalTableIterator((read_options.weight == 0) ? true
-                                                                       : false);
+      return new DummyExternalTableIterator(read_options, kv_map_);
     }
 
     Status Get(const ReadOptions& /*read_options*/, const Slice& key,
                const SliceTransform* /*prefix_extractor*/,
                std::string* value) override {
-      if (!key.compare("foo")) {
-        value->assign("bar");
+      auto iter = kv_map_.find(key.ToString());
+      if (iter != kv_map_.end()) {
+        value->assign(iter->second);
         return Status::OK();
       }
       return Status::NotFound();
@@ -6635,6 +6726,43 @@ class ExternalTableReaderTest : public DBTestBase {
       props->raw_value_size = 3;
       return props;
     }
+
+   private:
+    std::map<std::string, std::string> kv_map_;
+    DummyExternalTableFile file_;
+  };
+
+  class DummyExternalTableBuilder : public ExternalTableBuilder {
+   public:
+    explicit DummyExternalTableBuilder(const std::string& file_path)
+        : file_(file_path) {}
+
+    void Add(const Slice& key, const Slice& value) override {
+      if (!kv_vec_.empty()) {
+        ASSERT_LT(BytewiseComparator()->Compare(kv_vec_.back().first, key), 0);
+      }
+      kv_vec_.emplace_back(key.ToString(), value.ToString());
+    }
+
+    Status Finish() override {
+      status_ = file_.Serialize(kv_vec_);
+      return status_;
+    }
+
+    void Abandon() override { kv_vec_.clear(); }
+
+    uint64_t FileSize() const override { return file_.FileSize(); }
+
+    TableProperties GetTableProperties() const override {
+      return file_.GetTableProperties();
+    }
+
+    Status status() const override { return status_; }
+
+   private:
+    std::vector<std::pair<std::string, std::string>> kv_vec_;
+    DummyExternalTableFile file_;
+    Status status_;
   };
 
   class DummyExternalTableFactory : public ExternalTableFactory {
@@ -6642,28 +6770,42 @@ class ExternalTableReaderTest : public DBTestBase {
     const char* Name() const override { return "DummyExternalTableFactory"; }
 
     Status NewTableReader(
-        const ReadOptions& /*read_options*/, const std::string& /*file_path*/,
+        const ReadOptions& /*read_options*/, const std::string& file_path,
         const ExternalTableOptions& /*topts*/,
-        std::unique_ptr<ExternalTableReader>* table_reader) override {
-      table_reader->reset(new DummyExternalTableReader());
+        std::unique_ptr<ExternalTableReader>* table_reader) const override {
+      table_reader->reset(new DummyExternalTableReader(file_path));
       return Status::OK();
+    }
+
+    ExternalTableBuilder* NewTableBuilder(
+        const ExternalTableBuilderOptions& /*opts*/,
+        const std::string& file_path) const override {
+      return new DummyExternalTableBuilder(file_path);
     }
   };
 };
-
-const std::string ExternalTableReaderTest::DummyExternalTableIterator::key_str =
-    "foo";
-const std::string
-    ExternalTableReaderTest::DummyExternalTableIterator::value_str = "bar";
 
 TEST_F(ExternalTableReaderTest, BasicTest) {
   std::shared_ptr<ExternalTableFactory> factory =
       std::make_shared<DummyExternalTableFactory>();
 
+  std::string file_path = test::PerThreadDBPath("external_table");
+  {
+    std::unique_ptr<ExternalTableBuilder> builder;
+    builder.reset(factory->NewTableBuilder(
+        ExternalTableBuilderOptions(ReadOptions(), WriteOptions(),
+                                    std::shared_ptr<const SliceTransform>(),
+                                    BytewiseComparator(), "default",
+                                    TableFileCreationReason::kMisc),
+        file_path));
+    builder->Add("foo", "bar");
+    ASSERT_OK(builder->Finish());
+  }
+
   std::unique_ptr<ExternalTableReader> reader;
   std::shared_ptr<SliceTransform> prefix_extractor;
   ASSERT_OK(factory->NewTableReader(
-      {}, "", ExternalTableOptions(prefix_extractor, nullptr), &reader));
+      {}, file_path, ExternalTableOptions(prefix_extractor, nullptr), &reader));
 
   ReadOptions ro;
   ro.weight = 1;
@@ -6699,9 +6841,12 @@ TEST_F(ExternalTableReaderTest, SstReaderTest) {
       std::make_shared<DummyExternalTableFactory>();
   options.table_factory = NewExternalTableFactory(factory);
 
-  // Create a file
-  ASSERT_OK(WriteStringToFile(options.env, "Hello World", ingest_file,
-                              /*should_sync=*/true));
+  std::unique_ptr<SstFileWriter> writer;
+  writer.reset(new SstFileWriter(EnvOptions(), options));
+  ASSERT_OK(writer->Open(ingest_file));
+  ASSERT_OK(writer->Put("foo", "bar"));
+  ASSERT_OK(writer->Finish());
+  writer.reset();
 
   std::unique_ptr<SstFileReader> reader(new SstFileReader(options));
   ASSERT_OK(reader->Open(ingest_file));

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6836,6 +6836,8 @@ TEST_F(ExternalTableReaderTest, SstReaderTest) {
   std::string dbname = test::PerThreadDBPath("external_table_reader_test");
   std::string ingest_file = dbname + "test.immutabledb";
   dbname += "_db";
+  // This test doesn't work with some custom Envs, like EncryptedEnv
+  options.env = Env::Default();
 
   std::shared_ptr<ExternalTableFactory> factory =
       std::make_shared<DummyExternalTableFactory>();


### PR DESCRIPTION
This PR adds the ability to use an ExternalTableBuilder through the SstFileWriter to create external tables. This is a counterpart to #13401 , which adds the ExternalTableReader. The support for external tables is confined to ingestion only DBs, with external table files ingested into the bottommost level only. #13431 enforces ingestion only DBs by adding a disallow_memtable_writes column family option.

Test plan:
New unit tests in table_test.cc