### PR TITLE
Add opaque options in ReadOptions for external tables

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1985,6 +1985,12 @@ struct ReadOptions {
   // reader implementation.
   uint64_t weight = 0;
 
+  // A map of name,value pairs that can be passed by the user to an
+  // external table reader. This is completely opaque to RocksDB and is
+  // ignored by the natively supported table readers like block based and plain
+  // table. This is only useful for Iterator.
+  std::unordered_map<std::string, std::string> property_bag;
+
   // *** END options for RocksDB internal use only ***
 
   ReadOptions() {}

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1989,7 +1989,7 @@ struct ReadOptions {
   // external table reader. This is completely opaque to RocksDB and is
   // ignored by the natively supported table readers like block based and plain
   // table. This is only useful for Iterator.
-  std::unordered_map<std::string, std::string> property_bag;
+  std::optional<std::unordered_map<std::string, std::string>> property_bag;
 
   // *** END options for RocksDB internal use only ***
 

--- a/unreleased_history/public_api_changes/read_options_property_bag.md
+++ b/unreleased_history/public_api_changes/read_options_property_bag.md
@@ -1,0 +1,1 @@
+Add an unordered map of name/value pairs, ReadOptions::property_bag, to pass opaque options through to an external table when creating an Iterator.


### PR DESCRIPTION
Add an unordered_map of name/value pairs in ReadOptions::property_bag, similar to IOOptions::property_bag. It allows users to pass through some custom options to an external table.