### PR TITLE
Temp disable in crash test: secondary instance + seqno-time tracking

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1030,6 +1030,9 @@ def finalize_and_sanitize(src_params):
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
     if dest_params.get("test_secondary") == 1:
         dest_params["continuous_verification_interval"] = 0
+        # FIXME: temporarily broken combination
+        dest_params["preserve_internal_time_seconds"] = 0
+        dest_params["preclude_last_level_data_seconds"] = 0
     return dest_params
 
 


### PR DESCRIPTION
Summary: PR #13316 broke some crash test cases in DBImplSecondary, from combining test_secondary=1 and preserve_internal_time_seconds>0. Disabling that while investigating the fix.

Test Plan: manual blackbox_crash_test runs with forced test_secondary=1