### PR TITLE
[Remote Compaction]set ignore_unknown_options when parsing options

### DIFF
--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -994,6 +994,7 @@ Status DB::OpenAndCompact(
   DBOptions db_options;
   ConfigOptions config_options;
   config_options.env = override_options.env;
+  config_options.ignore_unknown_options = true;
   std::vector<ColumnFamilyDescriptor> all_column_families;
 
   TEST_SYNC_POINT_CALLBACK(


### PR DESCRIPTION
# Summary

In case the primary host has a new option added which isn't available in the remote worker yet, the remote compaction currently fails. In most cases, these new options are not relevant to the remote compaction and the worker should be able to move on by ignoring it.

# Test Plan

Verified internally in Meta Infra.