### PR TITLE
Add LogData `WriteBatch::Handler` implementation

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -2282,6 +2282,15 @@ class H : public WriteBatch::Handler {
   }
 };
 
+class HL : public WriteBatch::Handler {
+ public:
+  void* state_;
+  void (*log_data_)(void*, const char* d, size_t dlen);
+  void LogData(const Slice& data) override {
+    (*log_data_)(state_, data.data(), data.size());
+  }
+};
+
 class HCF : public WriteBatch::Handler {
  public:
   void* state_;
@@ -2317,6 +2326,16 @@ void rocksdb_writebatch_iterate(rocksdb_writebatch_t* b, void* state,
   handler.state_ = state;
   handler.put_ = put;
   handler.deleted_ = deleted;
+  b->rep.Iterate(&handler);
+}
+
+void rocksdb_writebatch_iterate_log(rocksdb_writebatch_t* b, void* state,
+                                    void (*log_data)(void*, const char* d,
+                                                     size_t dlen)
+) {
+  HL handler;
+  handler.state_ = state;
+  handler.log_data_ = log_data;
   b->rep.Iterate(&handler);
 }
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -860,6 +860,9 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate(
     rocksdb_writebatch_t*, void* state,
     void (*put)(void*, const char* k, size_t klen, const char* v, size_t vlen),
     void (*deleted)(void*, const char* k, size_t klen));
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate_log(
+    rocksdb_writebatch_t*, void* state,
+    void (*log_data)(void*, const char* d, size_t dlen));
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate_cf(
     rocksdb_writebatch_t*, void* state,
     void (*put_cf)(void*, uint32_t cfid, const char* k, size_t klen,


### PR DESCRIPTION
Currently, the API doesn't expose any implementation for fetching log data stored by `PutLogData`. The [wiki page on Replication Helpers](https://github.com/facebook/rocksdb/wiki/Replication-Helpers#function-for-streaming-updates-and-catching-up) suggests that updates can be fetched via the `GetUpdatesSince` API, but as far as I can tell, there's not any way to currently do that.

This PR is my attempt to implement that functionality at a very basic level. I have yet to write any tests, but I figured a second set of eyes would be helpful before I went too overboard in case I missed something obvious.

As this is my first contribution, I have filled out the CLA as well.

Thank you for your time!