### PR TITLE
Verify compaction output record count

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -930,7 +930,6 @@ Status CompactionJob::Run() {
           job_context_->job_id, msg.c_str());
       status = Status::Corruption(msg);
     }
-    assert(expected == total_output_num);
   }
 
   RecordCompactionIOStats();

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -839,7 +839,6 @@ Status CompactionJob::Run() {
   TEST_SYNC_POINT("CompactionJob::ReleaseSubcompactionResources:0");
   TEST_SYNC_POINT("CompactionJob::ReleaseSubcompactionResources:1");
 
-  TablePropertiesCollection tp;
   for (const auto& state : compact_->sub_compact_states) {
     for (const auto& output : state.GetOutputs()) {
       auto fn =
@@ -900,6 +899,38 @@ Status CompactionJob::Run() {
         }
       }
     }
+  }
+
+  // Verify number of output records
+  if (status.ok() && db_options_.compaction_verify_record_count) {
+    uint64_t total_output_num = 0;
+    for (const auto& state : compact_->sub_compact_states) {
+      for (const auto& output : state.GetOutputs()) {
+        total_output_num += output.table_properties->num_entries -
+                            output.table_properties->num_range_deletions;
+      }
+    }
+
+    uint64_t expected = internal_stats_.output_level_stats.num_output_records;
+    if (internal_stats_.has_proximal_level_output) {
+      expected += internal_stats_.proximal_level_stats.num_output_records;
+    }
+    if (expected != total_output_num) {
+      char scratch[2345];
+      compact_->compaction->Summary(scratch, sizeof(scratch));
+      std::string msg =
+          "Number of keys in compaction output SST files does not match "
+          "number of keys added. Expected " +
+          std::to_string(expected) + " but there are " +
+          std::to_string(total_output_num) +
+          " in output SST files. Compaction summary: " + scratch;
+      ROCKS_LOG_WARN(
+          db_options_.info_log, "[%s] [JOB %d] Compaction with status: %s",
+          compact_->compaction->column_family_data()->GetName().c_str(),
+          job_context_->job_id, msg.c_str());
+      status = Status::Corruption(msg);
+    }
+    assert(expected == total_output_num);
   }
 
   RecordCompactionIOStats();

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -232,6 +232,11 @@ class CompactionJobTestBase : public testing::Test {
     // set default for the tests
     mutable_cf_options_.target_file_size_base = 1024 * 1024;
     mutable_cf_options_.max_compaction_bytes = 10 * 1024 * 1024;
+
+    // Turn off compaction_verify_record_count MockTables
+    if (table_type == TableTypeForTest::kMockTable) {
+      db_options_.compaction_verify_record_count = false;
+    }
   }
 
   void SetUp() override {

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -851,6 +851,9 @@ TEST_F(CorruptionTest, ParanoidFileChecksOnCompact) {
   options.env = env_.get();
   options.paranoid_file_checks = true;
   options.create_if_missing = true;
+  // Bypass record count verification so that the test reaches
+  // paranoid file check later in the process
+  options.compaction_verify_record_count = false;
   Status s;
   for (const auto& mode : corruption_modes) {
     delete db_;
@@ -863,7 +866,6 @@ TEST_F(CorruptionTest, ParanoidFileChecksOnCompact) {
     ASSERT_OK(DB::Open(options, dbname_, &db_));
     assert(db_ != nullptr);  // suppress false clang-analyze report
     Build(100, 2);
-    // ASSERT_OK(db_->Flush(FlushOptions()));
     DBImpl* dbi = static_cast_with_check<DBImpl>(db_);
     ASSERT_OK(dbi->TEST_FlushMemTable());
     mock->SetCorruptionMode(mode);

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -851,8 +851,8 @@ TEST_F(CorruptionTest, ParanoidFileChecksOnCompact) {
   options.env = env_.get();
   options.paranoid_file_checks = true;
   options.create_if_missing = true;
-  // Bypass record count verification so that the test reaches
-  // paranoid file check later in the process
+  // Skip verifying record count against TableProperties for
+  // MockTables
   options.compaction_verify_record_count = false;
   Status s;
   for (const auto& mode : corruption_modes) {

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5455,6 +5455,7 @@ TEST_F(DBTest, DynamicLevelCompressionPerLevel2) {
   options.max_bytes_for_level_multiplier = 8;
   options.max_background_compactions = 1;
   options.num_levels = 5;
+  options.compaction_verify_record_count = false;
   std::shared_ptr<mock::MockTableFactory> mtf(new mock::MockTableFactory);
   options.table_factory = mtf;
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1018,6 +1018,11 @@ void BlockBasedTableBuilder::Add(const Slice& ikey, const Slice& value) {
     if (r->props.num_entries > r->props.num_range_deletions) {
       assert(r->internal_comparator.Compare(ikey, Slice(r->last_ikey)) > 0);
     }
+    bool skip = false;
+    TEST_SYNC_POINT_CALLBACK("BlockBasedTableBuilder::Add::skip", (void*)&skip);
+    if (skip) {
+      return;
+    }
 #endif  // !NDEBUG
 
     auto should_flush = r->flush_block_policy->Update(ikey, value);

--- a/table/plain/plain_table_builder.cc
+++ b/table/plain/plain_table_builder.cc
@@ -151,6 +151,14 @@ void PlainTableBuilder::Add(const Slice& key, const Slice& value) {
     return;
   }
 
+#ifndef NDEBUG
+  bool skip = false;
+  TEST_SYNC_POINT_CALLBACK("PlainTableBuilder::Add::skip", (void*)&skip);
+  if (skip) {
+    return;
+  }
+#endif  // !NDEBUG
+
   // Store key hash
   if (store_index_in_file_) {
     if (moptions_.prefix_extractor == nullptr) {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -2558,6 +2558,9 @@ TEST_P(TransactionTest, FlushTest2) {
       case 0:
         break;
       case 1:
+        // Skip verifying record count against TableProperties for
+        // MockTables
+        options.compaction_verify_record_count = false;
         options.table_factory.reset(new mock::MockTableFactory());
         break;
       case 2: {


### PR DESCRIPTION
# Summary

Continuing @cbi42 's work in 602cc0f9a4be89020fb870dba2816f11dd515d16.

In this PR, we are adding record count verification for each compaction by comparing number of entries summed from Table Properties with the number of output records from the compaction stats.

If the count does not match, `Status::Corruption(msg)` is returned with detailed message including the actual number (from table property) and the expected number (from compaction stats)

# Test Plan

New UT added
```
./db_compaction_test -- --gtest_filter="*Verify*"
```

The check had to be disabled for some of the existing tests using MockTable/MockTableFactory, because TableProperties aren't populated properly for the MockTables.
