### PR TITLE
[bugfix] compare key equality in blob file reader using user comparator instead of simply using equal sign

### DIFF
--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -64,7 +64,8 @@ class BlobFileReader {
  private:
   BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,
                  uint64_t file_size, CompressionType compression_type,
-                 SystemClock* clock, Statistics* statistics);
+                 SystemClock* clock, Statistics* statistics,
+                 const Comparator* user_comparator);
 
   static Status OpenFile(const ImmutableOptions& immutable_options,
                          const FileOptions& file_opts,
@@ -92,7 +93,7 @@ class BlobFileReader {
                              AlignedBuf* aligned_buf);
 
   static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
-                           uint64_t value_size);
+                           uint64_t value_size, const Comparator* user_comparator);
 
   static Status UncompressBlobIfNeeded(const Slice& value_slice,
                                        CompressionType compression_type,
@@ -106,6 +107,7 @@ class BlobFileReader {
   CompressionType compression_type_;
   SystemClock* clock_;
   Statistics* statistics_;
+  const Comparator* user_comparator_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
With custom comparator which only compare part of user_key,  record.key is always not equal to user_key 
 in BlobFileReader::VerifyBlob().
For example, user_key is always suffixed with ttl, and custom comparator without ttl like below would make record.key not equal to user_key.

    const size_t TTL_LEN_IN_BYTES = 8;
    class NoTTLComparator: public rocksdb::Comparator {
    public:
        static const char* kClassName() { return "NoTTLComparator";  }
        const char* Name() const override {return kClassName();}
        int Compare(const rocksdb::Slice& a, const rocksdb::Slice& b) const override {
              rocksdb::Slice a_no_ttl = rocksdb::Slice(a.data(), a.size()-TTL_LEN_IN_BYTES);
              rocksdb::Slice b_no_ttl = rocksdb::Slice(b.data(), b.size()-TTL_LEN_IN_BYTES);
              return rocksdb::BytewiseComparator()->Compare(a_no_ttl, b_no_ttl);
        }

        void FindShortestSeparator(std::string* start, const rocksdb::Slice& limit) const {};
        void FindShortSuccessor(std::string* key) const {};
    };