### PR TITLE
Add API `GetOptionsFromMap` to convert Options from map

### DIFF
--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -304,6 +304,16 @@ Status GetDBOptionsFromMap(
     const std::unordered_map<std::string, std::string>& opts_map,
     DBOptions* new_options);
 
+// Take a ConfigOptions `config_options` and a Options "base_options" as the
+// default option in addition to a map "opts_map" of option name to option value
+// to construct the new Options "new_options".
+//
+// Options are a superset of DBOptions and ColumnFamilyOptions.
+Status GetOptionsFromMap(
+    const ConfigOptions& config_options, const Options& base_options,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    Options* new_options);
+
 // Take a ConfigOptions `config_options` and a BlockBasedTableOptions
 // "table_options" as the default option in addition to a map "opts_map" of
 // option name to option value to construct the new BlockBasedTableOptions

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -759,36 +759,20 @@ Status GetDBOptionsFromString(const ConfigOptions& config_options,
                              new_options);
 }
 
-Status GetOptionsFromString(const Options& base_options,
-                            const std::string& opts_str, Options* new_options) {
-  ConfigOptions config_options(base_options);
-  config_options.input_strings_escaped = false;
-  config_options.ignore_unknown_options = false;
-
-  return GetOptionsFromString(config_options, base_options, opts_str,
-                              new_options);
-}
-
-Status GetOptionsFromString(const ConfigOptions& config_options,
-                            const Options& base_options,
-                            const std::string& opts_str, Options* new_options) {
-  ColumnFamilyOptions new_cf_options;
-  std::unordered_map<std::string, std::string> unused_opts;
-  std::unordered_map<std::string, std::string> opts_map;
-
+Status GetOptionsFromMap(
+    const ConfigOptions& config_options, const Options& base_options,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    Options* new_options) {
   assert(new_options);
   *new_options = base_options;
-  Status s = StringToMap(opts_str, &opts_map);
-  if (!s.ok()) {
-    return s;
-  }
   auto config = DBOptionsAsConfigurable(base_options);
-  s = config->ConfigureFromMap(config_options, opts_map, &unused_opts);
-
+  std::unordered_map<std::string, std::string> unused_opts;
+  Status s = config->ConfigureFromMap(config_options, opts_map, &unused_opts);
   if (s.ok()) {
     DBOptions* new_db_options =
         config->GetOptions<DBOptions>(OptionsHelper::kDBOptionsName);
     if (!unused_opts.empty()) {
+      ColumnFamilyOptions new_cf_options;
       s = GetColumnFamilyOptionsFromMap(config_options, base_options,
                                         unused_opts, &new_cf_options);
       if (s.ok()) {
@@ -804,6 +788,28 @@ Status GetOptionsFromString(const ConfigOptions& config_options,
   } else {
     return Status::InvalidArgument(s.getState());
   }
+}
+
+Status GetOptionsFromString(const Options& base_options,
+                            const std::string& opts_str, Options* new_options) {
+  ConfigOptions config_options(base_options);
+  config_options.input_strings_escaped = false;
+  config_options.ignore_unknown_options = false;
+
+  return GetOptionsFromString(config_options, base_options, opts_str,
+                              new_options);
+}
+
+Status GetOptionsFromString(const ConfigOptions& config_options,
+                            const Options& base_options,
+                            const std::string& opts_str, Options* new_options) {
+  std::unordered_map<std::string, std::string> opts_map;
+  Status s = StringToMap(opts_str, &opts_map);
+  if (!s.ok()) {
+    *new_options = base_options;
+    return s;
+  }
+  return GetOptionsFromMap(config_options, base_options, opts_map, new_options);
 }
 
 std::unordered_map<std::string, EncodingType>

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -376,6 +376,11 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_OK(
       RocksDBOptionsParser::VerifyDBOptions(loose, base_db_opt, new_db_opt));
 
+  db_options_map["max_open_files"] = "32";
+  s = GetDBOptionsFromMap(exact, base_db_opt, db_options_map, &new_db_opt);
+  ASSERT_OK(s);
+  ASSERT_FALSE(s.IsInvalidArgument());
+
   // unknow options should fail parsing without ignore_unknown_options = true
   db_options_map["unknown_db_option"] = "1";
   s = GetDBOptionsFromMap(exact, base_db_opt, db_options_map, &new_db_opt);


### PR DESCRIPTION
We can convert both `DBOptions` and `ColumnFamilyOptions` from string or map, but `Options` can only be converted from string using `GetOptionsFromString`. This PR introduces a new API `GetOptionsFromMap`, to convert `Options` from a map.