### PR TITLE
[Remote Compaction] Add PerKeyPlacement support

### DIFF
--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -431,7 +431,8 @@ struct CompactionServiceOutputFile {
   bool marked_for_compaction;
   UniqueId64x2 unique_id{};
   TableProperties table_properties;
-  bool is_penultimate_level_output;
+  // TODO: clean up the rest of the "penultimate" naming in the codebase
+  bool is_proximal_level_output;  // == is_penultimate_level_output
   Temperature file_temperature;
 
   CompactionServiceOutputFile() = default;
@@ -442,8 +443,8 @@ struct CompactionServiceOutputFile {
       uint64_t _epoch_number, const std::string& _file_checksum,
       const std::string& _file_checksum_func_name, uint64_t _paranoid_hash,
       bool _marked_for_compaction, UniqueId64x2 _unique_id,
-      const TableProperties& _table_properties,
-      bool _is_penultimate_level_output, Temperature _file_temperature)
+      const TableProperties& _table_properties, bool _is_proximal_level_output,
+      Temperature _file_temperature)
       : file_name(name),
         smallest_seqno(smallest),
         largest_seqno(largest),
@@ -458,7 +459,7 @@ struct CompactionServiceOutputFile {
         marked_for_compaction(_marked_for_compaction),
         unique_id(std::move(_unique_id)),
         table_properties(_table_properties),
-        is_penultimate_level_output(_is_penultimate_level_output),
+        is_proximal_level_output(_is_proximal_level_output),
         file_temperature(_file_temperature) {}
 };
 

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -431,6 +431,8 @@ struct CompactionServiceOutputFile {
   bool marked_for_compaction;
   UniqueId64x2 unique_id{};
   TableProperties table_properties;
+  bool is_penultimate_level_output;
+  Temperature file_temperature;
 
   CompactionServiceOutputFile() = default;
   CompactionServiceOutputFile(
@@ -440,7 +442,8 @@ struct CompactionServiceOutputFile {
       uint64_t _epoch_number, const std::string& _file_checksum,
       const std::string& _file_checksum_func_name, uint64_t _paranoid_hash,
       bool _marked_for_compaction, UniqueId64x2 _unique_id,
-      const TableProperties& _table_properties)
+      const TableProperties& _table_properties,
+      bool _is_penultimate_level_output, Temperature _file_temperature)
       : file_name(name),
         smallest_seqno(smallest),
         largest_seqno(largest),
@@ -454,7 +457,9 @@ struct CompactionServiceOutputFile {
         paranoid_hash(_paranoid_hash),
         marked_for_compaction(_marked_for_compaction),
         unique_id(std::move(_unique_id)),
-        table_properties(_table_properties) {}
+        table_properties(_table_properties),
+        is_penultimate_level_output(_is_penultimate_level_output),
+        file_temperature(_file_temperature) {}
 };
 
 // CompactionServiceResult contains the compaction result from a different db

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -1683,7 +1683,7 @@ TEST_F(CompactionJobTest, ResultSerialization) {
         file_checksum_func_name /* file_checksum_func_name */,
         rnd64.Uniform(UINT64_MAX) /* paranoid_hash */,
         rnd.OneIn(2) /* marked_for_compaction */, id /* unique_id */, tp,
-        false /* is_penultimate_level_output */, Temperature::kHot);
+        false /* is_proximal_level_output */, Temperature::kHot);
   }
   result.output_level = rnd.Uniform(10);
   result.output_path = rnd.RandomString(rnd.Uniform(kStrMaxLen));

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -1682,7 +1682,8 @@ TEST_F(CompactionJobTest, ResultSerialization) {
         file_checksum /* file_checksum */,
         file_checksum_func_name /* file_checksum_func_name */,
         rnd64.Uniform(UINT64_MAX) /* paranoid_hash */,
-        rnd.OneIn(2) /* marked_for_compaction */, id /* unique_id */, tp);
+        rnd.OneIn(2) /* marked_for_compaction */, id /* unique_id */, tp,
+        false /* is_penultimate_level_output */, Temperature::kHot);
   }
   result.output_level = rnd.Uniform(10);
   result.output_path = rnd.RandomString(rnd.Uniform(kStrMaxLen));
@@ -1736,6 +1737,8 @@ TEST_F(CompactionJobTest, ResultSerialization) {
     ASSERT_EQ(deserialized_tmp.output_files[0].file_checksum, file_checksum);
     ASSERT_EQ(deserialized_tmp.output_files[0].file_checksum_func_name,
               file_checksum_func_name);
+    ASSERT_EQ(deserialized_tmp.output_files[0].file_temperature,
+              Temperature::kHot);
   }
 
   // Test unknown field

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -30,13 +30,16 @@ class CompactionOutputs {
   // compaction output file
   struct Output {
     Output(FileMetaData&& _meta, const InternalKeyComparator& _icmp,
-           bool _enable_hash, bool _finished, uint64_t precalculated_hash)
+           bool _enable_hash, bool _finished, uint64_t precalculated_hash,
+           bool _is_penultimate_level)
         : meta(std::move(_meta)),
           validator(_icmp, _enable_hash, precalculated_hash),
-          finished(_finished) {}
+          finished(_finished),
+          is_penultimate_level(_is_penultimate_level) {}
     FileMetaData meta;
     OutputValidator validator;
     bool finished;
+    bool is_penultimate_level;
     std::shared_ptr<const TableProperties> table_properties;
   };
 
@@ -52,7 +55,7 @@ class CompactionOutputs {
                  bool enable_hash, bool finished = false,
                  uint64_t precalculated_hash = 0) {
     outputs_.emplace_back(std::move(meta), icmp, enable_hash, finished,
-                          precalculated_hash);
+                          precalculated_hash, is_penultimate_level_);
   }
 
   // Set new table builder for the current output

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -1211,6 +1211,7 @@ TEST_F(CompactionServiceTest, PrecludeLastLevel) {
   auto my_cs = GetCompactionService();
   CompactionServiceResult result;
   my_cs->GetResult(&result);
+  ASSERT_OK(result.status);
   ASSERT_GT(result.stats.cpu_micros, 0);
   ASSERT_GT(result.stats.elapsed_micros, 0);
   ASSERT_EQ(result.stats.num_output_records, kNumTrigger * kNumKeys);

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -1188,32 +1188,22 @@ TEST_F(CompactionServiceTest, PrecludeLastLevel) {
 
   for (int i = 0; i < kNumTrigger; i++) {
     for (int j = 0; j < kNumKeys; j++) {
-      // FIXME: need to assign outputs to levels to allow overlapping ranges:
-      // ASSERT_OK(Put(Key(j * kNumTrigger + i), "v" + std::to_string(i)));
-      // instead of this (too easy):
-      ASSERT_OK(Put(Key(i * kNumKeys + j), "v" + std::to_string(i)));
+      ASSERT_OK(Put(Key(j * kNumTrigger + i), "v" + std::to_string(i)));
     }
     ASSERT_OK(Flush());
   }
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
   // Data split between penultimate (kUnknown) and last (kCold) levels
-  // FIXME: need to assign outputs to levels to get this:
-  // ASSERT_EQ("0,0,0,0,0,1,1", FilesPerLevel());
-  // ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
-  // ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
-  // instead of this (WRONG but currently expected):
-  ASSERT_EQ("0,0,0,0,0,0,2", FilesPerLevel());
-  // Check manifest temperatures
+  ASSERT_EQ("0,0,0,0,0,1,1", FilesPerLevel());
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
-  ASSERT_EQ(GetSstSizeHelper(Temperature::kCold), 0);
+  ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
+
   // TODO: Check FileSystem temperatures with FileTemperatureTestFS
 
   for (int i = 0; i < kNumTrigger; i++) {
     for (int j = 0; j < kNumKeys; j++) {
-      // FIXME
-      // ASSERT_EQ(Get(Key(j * kNumTrigger + i)), "v" + std::to_string(i));
-      ASSERT_EQ(Get(Key(i * kNumKeys + j)), "v" + std::to_string(i));
+      ASSERT_EQ(Get(Key(j * kNumTrigger + i)), "v" + std::to_string(i));
     }
   }
 }

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -1206,6 +1206,15 @@ TEST_F(CompactionServiceTest, PrecludeLastLevel) {
       ASSERT_EQ(Get(Key(j * kNumTrigger + i)), "v" + std::to_string(i));
     }
   }
+
+  // Verify Output Stats
+  auto my_cs = GetCompactionService();
+  CompactionServiceResult result;
+  my_cs->GetResult(&result);
+  ASSERT_GT(result.stats.cpu_micros, 0);
+  ASSERT_GT(result.stats.elapsed_micros, 0);
+  ASSERT_EQ(result.stats.num_output_records, kNumTrigger * kNumKeys);
+  ASSERT_EQ(result.stats.num_output_files, 2);
 }
 
 TEST_F(CompactionServiceTest, ConcurrentCompaction) {

--- a/db/compaction/subcompaction_state.h
+++ b/db/compaction/subcompaction_state.h
@@ -81,6 +81,21 @@ class SubcompactionState {
   // it returns both the last level outputs and penultimate level outputs.
   OutputIterator GetOutputs() const;
 
+  // Get penultimate outputs (applicable to per_key_placement compaction only)
+  OutputIterator GetPenultimateLevelOutputs() const {
+    assert(compaction);
+    assert(compaction->SupportsPerKeyPlacement());
+    return OutputIterator({}, penultimate_level_outputs_.outputs_);
+  }
+
+  // Get last level outputs only (applicable to per_key_placement compaction
+  // only)
+  OutputIterator GetLastLevelOutputs() const {
+    assert(compaction);
+    assert(compaction->SupportsPerKeyPlacement());
+    return OutputIterator({}, compaction_outputs_.outputs_);
+  }
+
   // Assign range dels aggregator. The various tombstones will potentially
   // be filtered to different outputs.
   void AssignRangeDelAggregator(
@@ -167,6 +182,15 @@ class SubcompactionState {
   CompactionOutputs& Current() const {
     assert(current_outputs_);
     return *current_outputs_;
+  }
+
+  CompactionOutputs* GetOutputs(bool is_penultimate_level) {
+    assert(compaction);
+    if (is_penultimate_level) {
+      assert(compaction->SupportsPerKeyPlacement());
+      return &penultimate_level_outputs_;
+    }
+    return &compaction_outputs_;
   }
 
   CompactionRangeDelAggregator* RangeDelAgg() const {

--- a/db/compaction/subcompaction_state.h
+++ b/db/compaction/subcompaction_state.h
@@ -81,21 +81,6 @@ class SubcompactionState {
   // it returns both the last level outputs and penultimate level outputs.
   OutputIterator GetOutputs() const;
 
-  // Get penultimate outputs (applicable to per_key_placement compaction only)
-  OutputIterator GetPenultimateLevelOutputs() const {
-    assert(compaction);
-    assert(compaction->SupportsPerKeyPlacement());
-    return OutputIterator({}, penultimate_level_outputs_.outputs_);
-  }
-
-  // Get last level outputs only (applicable to per_key_placement compaction
-  // only)
-  OutputIterator GetLastLevelOutputs() const {
-    assert(compaction);
-    assert(compaction->SupportsPerKeyPlacement());
-    return OutputIterator({}, compaction_outputs_.outputs_);
-  }
-
   // Assign range dels aggregator. The various tombstones will potentially
   // be filtered to different outputs.
   void AssignRangeDelAggregator(
@@ -184,7 +169,7 @@ class SubcompactionState {
     return *current_outputs_;
   }
 
-  CompactionOutputs* GetOutputs(bool is_penultimate_level) {
+  CompactionOutputs* Outputs(bool is_penultimate_level) {
     assert(compaction);
     if (is_penultimate_level) {
       assert(compaction->SupportsPerKeyPlacement());

--- a/unreleased_history/new_features/per_key_placement_remote_compaction.md
+++ b/unreleased_history/new_features/per_key_placement_remote_compaction.md
@@ -1,0 +1,1 @@
+Added per-key-placement feature in Remote Compaction


### PR DESCRIPTION
# Summary

This PR adds support for PerKeyPlacement in Remote Compaction.

The `seqno_to_time_mapping` is already available from the table properties of the input files. `preserve_internal_time_seconds` and `preclude_last_level_data_seconds` are directly read from the OPTIONS file upon db open in the remote worker. The necessary changes include:

- Add `is_penultimate_level_output` and `file_temperature` to the `CompactionServiceOutputFile`
- When building the output for the remote compaction, get the outputs for penultimate level and last level separately, serialize them with the two additional information added in this PR.
- When deserializing the result from the primary, SubcompactionState's `GetOutputs()` now takes `is_penultimate_level`. This allows us to determine which level to place the output file.
- Include stats from `compaction_stats.penultimate_level_stats` in the remote compaction result

# To Follow up
- Stats to be fixed. Stats are not being populated correctly for PerKeyPlacement even for non-remote compactions.
- Clean up / Reconcile the "penultimate" naming by replacing with "proximal"

# Test Plan

Updated the unit test

```
./compaction_service_test
```