### PR TITLE
[Tiered Storage] Replace penultimate naming with proximal

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -109,16 +109,16 @@ const char* GetCompactionReasonString(CompactionReason compaction_reason) {
   }
 }
 
-const char* GetCompactionPenultimateOutputRangeTypeString(
-    Compaction::PenultimateOutputRangeType range_type) {
+const char* GetCompactionProximalOutputRangeTypeString(
+    Compaction::ProximalOutputRangeType range_type) {
   switch (range_type) {
-    case Compaction::PenultimateOutputRangeType::kNotSupported:
+    case Compaction::ProximalOutputRangeType::kNotSupported:
       return "NotSupported";
-    case Compaction::PenultimateOutputRangeType::kFullRange:
+    case Compaction::ProximalOutputRangeType::kFullRange:
       return "FullRange";
-    case Compaction::PenultimateOutputRangeType::kNonLastRange:
+    case Compaction::ProximalOutputRangeType::kNonLastRange:
       return "NonLastRange";
-    case Compaction::PenultimateOutputRangeType::kDisabled:
+    case Compaction::ProximalOutputRangeType::kDisabled:
       return "Disabled";
     default:
       assert(false);
@@ -378,8 +378,8 @@ void CompactionJob::Prepare(
   }
   // Now combine what we would like to preclude from last level with what we
   // can safely support without dangerously moving data back up the LSM tree,
-  // to get the final seqno threshold for penultimate vs. last. In particular,
-  // when the reserved output key range for the penultimate level does not
+  // to get the final seqno threshold for proximal vs. last. In particular,
+  // when the reserved output key range for the proximal level does not
   // include the entire last level input key range, we need to keep entries
   // already in the last level there. (Even allowing within-range entries to
   // move back up could cause problems with range tombstones. Perhaps it
@@ -388,8 +388,8 @@ void CompactionJob::Prepare(
   // tracking and complexity to CompactionIterator that is probably not
   // worthwhile overall. Correctness is also more clear when splitting by
   // seqno threshold.)
-  penultimate_after_seqno_ = std::max(preclude_last_level_min_seqno,
-                                      c->GetKeepInLastLevelThroughSeqno());
+  proximal_after_seqno_ = std::max(preclude_last_level_min_seqno,
+                                   c->GetKeepInLastLevelThroughSeqno());
 
   options_file_number_ = versions_->options_file_number();
 }
@@ -993,16 +993,16 @@ Status CompactionJob::Install(bool* compaction_released) {
         blob_files.back()->GetBlobFileNumber());
   }
 
-  if (compaction_stats_.has_penultimate_level_output) {
-    ROCKS_LOG_BUFFER(
-        log_buffer_,
-        "[%s] has Penultimate Level output: %" PRIu64
-        ", level %d, number of files: %" PRIu64 ", number of records: %" PRIu64,
-        column_family_name.c_str(),
-        compaction_stats_.penultimate_level_stats.bytes_written,
-        compact_->compaction->GetPenultimateLevel(),
-        compaction_stats_.penultimate_level_stats.num_output_files,
-        compaction_stats_.penultimate_level_stats.num_output_records);
+  if (compaction_stats_.has_proximal_level_output) {
+    ROCKS_LOG_BUFFER(log_buffer_,
+                     "[%s] has Proximal Level output: %" PRIu64
+                     ", level %d, number of files: %" PRIu64
+                     ", number of records: %" PRIu64,
+                     column_family_name.c_str(),
+                     compaction_stats_.proximal_level_stats.bytes_written,
+                     compact_->compaction->GetProximalLevel(),
+                     compaction_stats_.proximal_level_stats.num_output_files,
+                     compaction_stats_.proximal_level_stats.num_output_records);
   }
 
   UpdateCompactionJobStats(stats);
@@ -1055,16 +1055,16 @@ Status CompactionJob::Install(bool* compaction_released) {
     stream << "blob_file_tail" << blob_files.back()->GetBlobFileNumber();
   }
 
-  if (compaction_stats_.has_penultimate_level_output) {
+  if (compaction_stats_.has_proximal_level_output) {
     InternalStats::CompactionStats& pl_stats =
-        compaction_stats_.penultimate_level_stats;
-    stream << "penultimate_level_num_output_files" << pl_stats.num_output_files;
-    stream << "penultimate_level_bytes_written" << pl_stats.bytes_written;
-    stream << "penultimate_level_num_output_records"
+        compaction_stats_.proximal_level_stats;
+    stream << "proximal_level_num_output_files" << pl_stats.num_output_files;
+    stream << "proximal_level_bytes_written" << pl_stats.bytes_written;
+    stream << "proximal_level_num_output_records"
            << pl_stats.num_output_records;
-    stream << "penultimate_level_num_output_files_blob"
+    stream << "proximal_level_num_output_files_blob"
            << pl_stats.num_output_files_blob;
-    stream << "penultimate_level_bytes_written_blob"
+    stream << "proximal_level_bytes_written_blob"
            << pl_stats.bytes_written_blob;
   }
 
@@ -1312,7 +1312,7 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
 
   std::vector<std::string> blob_file_paths;
 
-  // TODO: BlobDB to support output_to_penultimate_level compaction, which needs
+  // TODO: BlobDB to support output_to_proximal_level compaction, which needs
   //  2 builders, so may need to move to `CompactionOutputs`
   std::unique_ptr<BlobFileBuilder> blob_file_builder(
       (mutable_cf_options.enable_blob_files &&
@@ -1397,30 +1397,30 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
     }
 
     const auto& ikey = c_iter->ikey();
-    bool use_penultimate_output = ikey.sequence > penultimate_after_seqno_;
+    bool use_proximal_output = ikey.sequence > proximal_after_seqno_;
 #ifndef NDEBUG
     if (sub_compact->compaction->SupportsPerKeyPlacement()) {
       // Could be overridden by unittest
       PerKeyPlacementContext context(sub_compact->compaction->output_level(),
                                      ikey.user_key, c_iter->value(),
-                                     ikey.sequence, use_penultimate_output);
+                                     ikey.sequence, use_proximal_output);
       TEST_SYNC_POINT_CALLBACK("CompactionIterator::PrepareOutput.context",
                                &context);
-      if (use_penultimate_output) {
-        // Verify that entries sent to the penultimate level are within the
+      if (use_proximal_output) {
+        // Verify that entries sent to the proximal level are within the
         // allowed range (because the input key range of the last level could
-        // be larger than the allowed output key range of the penultimate
+        // be larger than the allowed output key range of the proximal
         // level). This check uses user keys (ignores sequence numbers) because
         // compaction boundaries are a "clean cut" between user keys (see
         // CompactionPicker::ExpandInputsToCleanCut()), which is especially
         // important when preferred sequence numbers has been swapped in for
         // kTypeValuePreferredSeqno / TimedPut.
-        sub_compact->compaction->TEST_AssertWithinPenultimateLevelOutputRange(
+        sub_compact->compaction->TEST_AssertWithinProximalLevelOutputRange(
             c_iter->user_key());
       }
     } else {
-      assert(penultimate_after_seqno_ == kMaxSequenceNumber);
-      assert(!use_penultimate_output);
+      assert(proximal_after_seqno_ == kMaxSequenceNumber);
+      assert(!use_proximal_output);
     }
 #endif  // NDEBUG
 
@@ -1429,7 +1429,7 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
     // and `close_file_func`.
     // TODO: it would be better to have the compaction file open/close moved
     // into `CompactionOutputs` which has the output file information.
-    status = sub_compact->AddToOutput(*c_iter, use_penultimate_output,
+    status = sub_compact->AddToOutput(*c_iter, use_proximal_output,
                                       open_file_func, close_file_func);
     if (!status.ok()) {
       break;
@@ -1641,15 +1641,15 @@ Status CompactionJob::FinishCompactionOutputFile(
     std::pair<SequenceNumber, SequenceNumber> keep_seqno_range{
         0, kMaxSequenceNumber};
     if (sub_compact->compaction->SupportsPerKeyPlacement()) {
-      if (outputs.IsPenultimateLevel()) {
-        keep_seqno_range.first = penultimate_after_seqno_;
+      if (outputs.IsProximalLevel()) {
+        keep_seqno_range.first = proximal_after_seqno_;
       } else {
-        keep_seqno_range.second = penultimate_after_seqno_;
+        keep_seqno_range.second = proximal_after_seqno_;
       }
     }
     CompactionIterationStats range_del_out_stats;
     // NOTE1: Use `bottommost_level_ = true` for both bottommost and
-    // output_to_penultimate_level compaction here, as it's only used to decide
+    // output_to_proximal_level compaction here, as it's only used to decide
     // if range dels could be dropped. (Logically, we are taking a single sorted
     // run returned from CompactionIterator and physically splitting it between
     // two output levels.)
@@ -1812,14 +1812,14 @@ Status CompactionJob::InstallCompactionResults(bool* compaction_released) {
 
   {
     Compaction::InputLevelSummaryBuffer inputs_summary;
-    if (compaction_stats_.has_penultimate_level_output) {
+    if (compaction_stats_.has_proximal_level_output) {
       ROCKS_LOG_BUFFER(
           log_buffer_,
-          "[%s] [JOB %d] Compacted %s => output_to_penultimate_level: %" PRIu64
+          "[%s] [JOB %d] Compacted %s => output_to_proximal_level: %" PRIu64
           " bytes + last: %" PRIu64 " bytes. Total: %" PRIu64 " bytes",
           compaction->column_family_data()->GetName().c_str(), job_id_,
           compaction->InputLevelSummary(&inputs_summary),
-          compaction_stats_.penultimate_level_stats.bytes_written,
+          compaction_stats_.proximal_level_stats.bytes_written,
           compaction_stats_.stats.bytes_written,
           compaction_stats_.TotalBytesWritten());
     } else {
@@ -1946,8 +1946,7 @@ Status CompactionJob::OpenCompactionOutputFile(SubcompactionState* sub_compact,
   // Here last_level_temperature supersedes default_write_temperature, when
   // enabled and applicable
   if (last_level_temp != Temperature::kUnknown &&
-      sub_compact->compaction->is_last_level() &&
-      !outputs.IsPenultimateLevel()) {
+      sub_compact->compaction->is_last_level() && !outputs.IsProximalLevel()) {
     temperature = last_level_temp;
   }
   fo_copy.temperature = temperature;
@@ -2061,7 +2060,7 @@ Status CompactionJob::OpenCompactionOutputFile(SubcompactionState* sub_compact,
       bottommost_level_, TableFileCreationReason::kCompaction,
       0 /* oldest_key_time */, current_time, db_id_, db_session_id_,
       sub_compact->compaction->max_output_file_size(), file_number,
-      penultimate_after_seqno_ /*last_level_inclusive_max_seqno_threshold*/);
+      proximal_after_seqno_ /*last_level_inclusive_max_seqno_threshold*/);
 
   outputs.NewBuilder(tboptions);
 
@@ -2232,19 +2231,19 @@ void CompactionJob::LogCompaction() {
                    ? int64_t{-1}  // Use -1 for "none"
                    : static_cast<int64_t>(existing_snapshots_[0]));
     if (compaction->SupportsPerKeyPlacement()) {
-      stream << "prenultimate_after_seqno" << penultimate_after_seqno_;
+      stream << "prenultimate_after_seqno" << proximal_after_seqno_;
       stream << "preserve_seqno_after" << preserve_seqno_after_;
-      stream << "penultimate_output_level" << compaction->GetPenultimateLevel();
-      stream << "penultimate_output_range"
-             << GetCompactionPenultimateOutputRangeTypeString(
-                    compaction->GetPenultimateOutputRangeType());
+      stream << "proximal_output_level" << compaction->GetProximalLevel();
+      stream << "proximal_output_range"
+             << GetCompactionProximalOutputRangeTypeString(
+                    compaction->GetProximalOutputRangeType());
 
-      if (compaction->GetPenultimateOutputRangeType() ==
-          Compaction::PenultimateOutputRangeType::kDisabled) {
+      if (compaction->GetProximalOutputRangeType() ==
+          Compaction::ProximalOutputRangeType::kDisabled) {
         ROCKS_LOG_WARN(
             db_options_.info_log,
-            "[%s] [JOB %d] Penultimate level output is disabled, likely "
-            "because of the range conflict in the penultimate level",
+            "[%s] [JOB %d] Proximal level output is disabled, likely "
+            "because of the range conflict in the proximal level",
             cfd->GetName().c_str(), job_id_);
       }
     }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2231,7 +2231,7 @@ void CompactionJob::LogCompaction() {
                    ? int64_t{-1}  // Use -1 for "none"
                    : static_cast<int64_t>(existing_snapshots_[0]));
     if (compaction->SupportsPerKeyPlacement()) {
-      stream << "prenultimate_after_seqno" << proximal_after_seqno_;
+      stream << "proximal_after_seqno" << proximal_after_seqno_;
       stream << "preserve_seqno_after" << preserve_seqno_after_;
       stream << "proximal_output_level" << compaction->GetProximalLevel();
       stream << "proximal_output_range"

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -431,8 +431,7 @@ struct CompactionServiceOutputFile {
   bool marked_for_compaction;
   UniqueId64x2 unique_id{};
   TableProperties table_properties;
-  // TODO: clean up the rest of the "proximal" naming in the codebase
-  bool is_proximal_level_output;  // == is_proximal_level_output
+  bool is_proximal_level_output;
   Temperature file_temperature;
 
   CompactionServiceOutputFile() = default;

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -104,9 +104,9 @@ class SubcompactionState;
 //    logging and public metrics.
 //    Internally, it's an aggregation of stats_ from each `SubcompactionState`.
 //    It has 2 parts, normal stats about the main compaction information and
-//    the penultimate level output stats.
-//    `SubcompactionState` maintains the CompactionOutputs for normal output and
-//    the penultimate level output if exists, the per_level stats is
+//    the proximal level output stats.
+//    `SubcompactionState` maintains the CompactionOutputs for ordinary level
+//    output and the proximal level output if exists, the per_level stats is
 //    stored with the outputs.
 //                                                +---------------------------+
 //                                                | SubcompactionState        |
@@ -119,7 +119,7 @@ class SubcompactionState;
 //                                            |   |                           |
 //                                            |   | +----------------------+  |
 // +--------------------------------+         |   | | CompactionOutputs    |  |
-// | CompactionJob                  |         |   | | (penultimate_level)  |  |
+// | CompactionJob                  |         |   | | (proximal_level)     |  |
 // |                                |    +--------->|   stats_             |  |
 // |   compaction_stats_            |    |    |   | +----------------------+  |
 // |    +-------------------------+ |    |    |   |                           |
@@ -127,7 +127,7 @@ class SubcompactionState;
 // |    +-------------------------+ |    |    |
 // |                                |    |    |
 // |    +-------------------------+ |    |    |   +---------------------------+
-// |    |penultimate_level_stats  +------+    |   | SubcompactionState        |
+// |    |proximal_level_stats     |------+    |   | SubcompactionState        |
 // |    +-------------------------+ |    |    |   |                           |
 // |                                |    |    |   | +----------------------+  |
 // |                                |    |    |   | | CompactionOutputs    |  |
@@ -137,7 +137,7 @@ class SubcompactionState;
 //                                       |        |                           |
 //                                       |        | +----------------------+  |
 //                                       |        | | CompactionOutputs    |  |
-//                                       |        | | (penultimate_level)  |  |
+//                                       |        | | (proximal_level)     |  |
 //                                       +--------->|   stats_             |  |
 //                                                | +----------------------+  |
 //                                                |                           |
@@ -363,8 +363,8 @@ class CompactionJob {
 
   // Minimal sequence number to preclude the data from the last level. If the
   // key has bigger (newer) sequence number than this, it will be precluded from
-  // the last level (output to penultimate level).
-  SequenceNumber penultimate_after_seqno_ = kMaxSequenceNumber;
+  // the last level (output to proximal level).
+  SequenceNumber proximal_after_seqno_ = kMaxSequenceNumber;
 
   // Options File Number used for Remote Compaction
   // Setting this requires DBMutex.
@@ -431,8 +431,8 @@ struct CompactionServiceOutputFile {
   bool marked_for_compaction;
   UniqueId64x2 unique_id{};
   TableProperties table_properties;
-  // TODO: clean up the rest of the "penultimate" naming in the codebase
-  bool is_proximal_level_output;  // == is_penultimate_level_output
+  // TODO: clean up the rest of the "proximal" naming in the codebase
+  bool is_proximal_level_output;  // == is_proximal_level_output
   Temperature file_temperature;
 
   CompactionServiceOutputFile() = default;

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -1474,7 +1474,7 @@ TEST_F(CompactionJobTest, OldestBlobFileNumber) {
                 /* expected_oldest_blob_file_numbers */ {19});
 }
 
-TEST_F(CompactionJobTest, VerifyPenultimateLevelOutput) {
+TEST_F(CompactionJobTest, VerifyProximalLevelOutput) {
   cf_options_.last_level_temperature = Temperature::kCold;
   SyncPoint::GetInstance()->SetCallBack(
       "Compaction::SupportsPerKeyPlacement:Enabled", [&](void* arg) {
@@ -1487,8 +1487,7 @@ TEST_F(CompactionJobTest, VerifyPenultimateLevelOutput) {
   SyncPoint::GetInstance()->SetCallBack(
       "CompactionIterator::PrepareOutput.context", [&](void* arg) {
         auto context = static_cast<PerKeyPlacementContext*>(arg);
-        context->output_to_penultimate_level =
-            context->seq_num > latest_cold_seq;
+        context->output_to_proximal_level = context->seq_num > latest_cold_seq;
       });
   SyncPoint::GetInstance()->EnableProcessing();
 
@@ -1534,11 +1533,11 @@ TEST_F(CompactionJobTest, VerifyPenultimateLevelOutput) {
       /*verify_func=*/[&](Compaction& comp) {
         for (char c = 'a'; c <= 'z'; c++) {
           if (c == 'a') {
-            comp.TEST_AssertWithinPenultimateLevelOutputRange(
+            comp.TEST_AssertWithinProximalLevelOutputRange(
                 "a", true /*expect_failure*/);
           } else {
             std::string c_str{c};
-            comp.TEST_AssertWithinPenultimateLevelOutputRange(c_str);
+            comp.TEST_AssertWithinProximalLevelOutputRange(c_str);
           }
         }
       });

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -792,8 +792,8 @@ void CompactionOutputs::FillFilesToCutForTtl() {
 }
 
 CompactionOutputs::CompactionOutputs(const Compaction* compaction,
-                                     const bool is_penultimate_level)
-    : compaction_(compaction), is_penultimate_level_(is_penultimate_level) {
+                                     const bool is_proximal_level)
+    : compaction_(compaction), is_proximal_level_(is_proximal_level) {
   partitioner_ = compaction->output_level() == 0
                      ? nullptr
                      : compaction->CreateSstPartitioner();

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -31,31 +31,31 @@ class CompactionOutputs {
   struct Output {
     Output(FileMetaData&& _meta, const InternalKeyComparator& _icmp,
            bool _enable_hash, bool _finished, uint64_t precalculated_hash,
-           bool _is_penultimate_level)
+           bool _is_proximal_level)
         : meta(std::move(_meta)),
           validator(_icmp, _enable_hash, precalculated_hash),
           finished(_finished),
-          is_penultimate_level(_is_penultimate_level) {}
+          is_proximal_level(_is_proximal_level) {}
     FileMetaData meta;
     OutputValidator validator;
     bool finished;
-    bool is_penultimate_level;
+    bool is_proximal_level;
     std::shared_ptr<const TableProperties> table_properties;
   };
 
   CompactionOutputs() = delete;
 
   explicit CompactionOutputs(const Compaction* compaction,
-                             const bool is_penultimate_level);
+                             const bool is_proximal_level);
 
-  bool IsPenultimateLevel() const { return is_penultimate_level_; }
+  bool IsProximalLevel() const { return is_proximal_level_; }
 
   // Add generated output to the list
   void AddOutput(FileMetaData&& meta, const InternalKeyComparator& icmp,
                  bool enable_hash, bool finished = false,
                  uint64_t precalculated_hash = 0) {
     outputs_.emplace_back(std::move(meta), icmp, enable_hash, finished,
-                          precalculated_hash, is_penultimate_level_);
+                          precalculated_hash, is_proximal_level_);
   }
 
   // Set new table builder for the current output
@@ -73,27 +73,27 @@ class CompactionOutputs {
 
   // TODO: Move the BlobDB builder into CompactionOutputs
   const std::vector<BlobFileAddition>& GetBlobFileAdditions() const {
-    if (is_penultimate_level_) {
+    if (is_proximal_level_) {
       assert(blob_file_additions_.empty());
     }
     return blob_file_additions_;
   }
 
   std::vector<BlobFileAddition>* GetBlobFileAdditionsPtr() {
-    assert(!is_penultimate_level_);
+    assert(!is_proximal_level_);
     return &blob_file_additions_;
   }
 
   bool HasBlobFileAdditions() const { return !blob_file_additions_.empty(); }
 
   BlobGarbageMeter* CreateBlobGarbageMeter() {
-    assert(!is_penultimate_level_);
+    assert(!is_proximal_level_);
     blob_garbage_meter_ = std::make_unique<BlobGarbageMeter>();
     return blob_garbage_meter_.get();
   }
 
   BlobGarbageMeter* GetBlobGarbageMeter() const {
-    if (is_penultimate_level_) {
+    if (is_proximal_level_) {
       // blobdb doesn't support per_key_placement yet
       assert(blob_garbage_meter_ == nullptr);
       return nullptr;
@@ -102,7 +102,7 @@ class CompactionOutputs {
   }
 
   void UpdateBlobStats() {
-    assert(!is_penultimate_level_);
+    assert(!is_proximal_level_);
     stats_.num_output_files_blob = blob_file_additions_.size();
     for (const auto& blob : blob_file_additions_) {
       stats_.bytes_written_blob += blob.GetTotalBlobBytes();
@@ -310,9 +310,9 @@ class CompactionOutputs {
   // Basic compaction output stats for this level's outputs
   InternalStats::CompactionOutputsStats stats_;
 
-  // indicate if this CompactionOutputs obj for penultimate_level, should always
+  // indicate if this CompactionOutputs obj for proximal_level, should always
   // be false if per_key_placement feature is not enabled.
-  const bool is_penultimate_level_;
+  const bool is_proximal_level_;
 
   // partitioner information
   std::string last_key_for_partitioner_;
@@ -366,7 +366,7 @@ class CompactionOutputs {
   std::vector<size_t> level_ptrs_;
 };
 
-// helper struct to concatenate the last level and penultimate level outputs
+// helper struct to concatenate the last level and proximal level outputs
 // which could be replaced by std::ranges::join_view() in c++20
 struct OutputIterator {
  public:

--- a/db/compaction/compaction_picker.h
+++ b/db/compaction/compaction_picker.h
@@ -190,7 +190,7 @@ class CompactionPicker {
   // key range of a currently running compaction.
   bool FilesRangeOverlapWithCompaction(
       const std::vector<CompactionInputFiles>& inputs, int level,
-      int penultimate_level) const;
+      int proximal_level) const;
 
   bool SetupOtherInputs(const std::string& cf_name,
                         const MutableCFOptions& mutable_cf_options,

--- a/db/compaction/compaction_picker_level.cc
+++ b/db/compaction/compaction_picker_level.cc
@@ -414,9 +414,9 @@ void LevelCompactionBuilder::SetupOtherFilesWithRoundRobinExpansion() {
                                                     &tmp_start_level_inputs) ||
         compaction_picker_->FilesRangeOverlapWithCompaction(
             {tmp_start_level_inputs}, output_level_,
-            Compaction::EvaluatePenultimateLevel(vstorage_, mutable_cf_options_,
-                                                 ioptions_, start_level_,
-                                                 output_level_))) {
+            Compaction::EvaluateProximalLevel(vstorage_, mutable_cf_options_,
+                                              ioptions_, start_level_,
+                                              output_level_))) {
       // Constraint 1a
       tmp_start_level_inputs.clear();
       return;
@@ -490,9 +490,9 @@ bool LevelCompactionBuilder::SetupOtherInputsIfNeeded() {
     // We need to disallow this from happening.
     if (compaction_picker_->FilesRangeOverlapWithCompaction(
             compaction_inputs_, output_level_,
-            Compaction::EvaluatePenultimateLevel(vstorage_, mutable_cf_options_,
-                                                 ioptions_, start_level_,
-                                                 output_level_))) {
+            Compaction::EvaluateProximalLevel(vstorage_, mutable_cf_options_,
+                                              ioptions_, start_level_,
+                                              output_level_))) {
       // This compaction output could potentially conflict with the output
       // of a currently running compaction, we cannot run it.
       return false;
@@ -846,9 +846,9 @@ bool LevelCompactionBuilder::PickFileToCompact() {
                                                     &start_level_inputs_) ||
         compaction_picker_->FilesRangeOverlapWithCompaction(
             {start_level_inputs_}, output_level_,
-            Compaction::EvaluatePenultimateLevel(vstorage_, mutable_cf_options_,
-                                                 ioptions_, start_level_,
-                                                 output_level_))) {
+            Compaction::EvaluateProximalLevel(vstorage_, mutable_cf_options_,
+                                              ioptions_, start_level_,
+                                              output_level_))) {
       // A locked (pending compaction) input-level file was pulled in due to
       // user-key overlap.
       start_level_inputs_.clear();

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -288,7 +288,9 @@ class UniversalCompactionBuilder {
 // and the index of the file in that level
 
 struct InputFileInfo {
-  InputFileInfo() : f(nullptr), level(0), index(0) {}
+  InputFileInfo() : InputFileInfo(nullptr, 0, 0) {}
+  InputFileInfo(FileMetaData* file_meta, size_t l, size_t i)
+      : f(file_meta), level(l), index(i) {}
 
   FileMetaData* f;
   size_t level;
@@ -321,22 +323,14 @@ SmallestKeyHeap create_level_heap(Compaction* c, const Comparator* ucmp) {
   SmallestKeyHeap smallest_key_priority_q =
       SmallestKeyHeap(SmallestKeyHeapComparator(ucmp));
 
-  InputFileInfo input_file;
-
   for (size_t l = 0; l < c->num_input_levels(); l++) {
     if (c->num_input_files(l) != 0) {
       if (l == 0 && c->start_level() == 0) {
         for (size_t i = 0; i < c->num_input_files(0); i++) {
-          input_file.f = c->input(0, i);
-          input_file.level = 0;
-          input_file.index = i;
-          smallest_key_priority_q.push(std::move(input_file));
+          smallest_key_priority_q.emplace(c->input(0, i), 0, i);
         }
       } else {
-        input_file.f = c->input(l, 0);
-        input_file.level = l;
-        input_file.index = 0;
-        smallest_key_priority_q.push(std::move(input_file));
+        smallest_key_priority_q.emplace(c->input(l, 0), l, 0);
       }
     }
   }
@@ -374,7 +368,7 @@ bool UniversalCompactionBuilder::IsInputFilesNonOverlapping(Compaction* c) {
   auto comparator = icmp_->user_comparator();
   int first_iter = 1;
 
-  InputFileInfo prev, curr, next;
+  InputFileInfo prev, curr;
 
   SmallestKeyHeap smallest_key_priority_q =
       create_level_heap(c, icmp_->user_comparator());
@@ -397,17 +391,10 @@ bool UniversalCompactionBuilder::IsInputFilesNonOverlapping(Compaction* c) {
       prev = curr;
     }
 
-    next.f = nullptr;
-
     if (c->level(curr.level) != 0 &&
         curr.index < c->num_input_files(curr.level) - 1) {
-      next.f = c->input(curr.level, curr.index + 1);
-      next.level = curr.level;
-      next.index = curr.index + 1;
-    }
-
-    if (next.f) {
-      smallest_key_priority_q.push(std::move(next));
+      smallest_key_priority_q.emplace(c->input(curr.level, curr.index + 1),
+                                      curr.level, curr.index + 1);
     }
   }
   return true;

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -996,7 +996,7 @@ Compaction* UniversalCompactionBuilder::PickCompactionToReduceSortedRuns(
 
   if (output_level != 0 && picker_->FilesRangeOverlapWithCompaction(
                                inputs, output_level,
-                               Compaction::EvaluatePenultimateLevel(
+                               Compaction::EvaluateProximalLevel(
                                    vstorage_, mutable_cf_options_, ioptions_,
                                    start_level, output_level))) {
     return nullptr;
@@ -1345,7 +1345,7 @@ Compaction* UniversalCompactionBuilder::PickIncrementalForReduceSizeAmp(
   // intra L0 compactions outputs could have overlap
   if (output_level != 0 && picker_->FilesRangeOverlapWithCompaction(
                                inputs, output_level,
-                               Compaction::EvaluatePenultimateLevel(
+                               Compaction::EvaluateProximalLevel(
                                    vstorage_, mutable_cf_options_, ioptions_,
                                    start_level, output_level))) {
     return nullptr;
@@ -1486,9 +1486,9 @@ Compaction* UniversalCompactionBuilder::PickDeleteTriggeredCompaction() {
       }
       if (picker_->FilesRangeOverlapWithCompaction(
               inputs, output_level,
-              Compaction::EvaluatePenultimateLevel(
-                  vstorage_, mutable_cf_options_, ioptions_, start_level,
-                  output_level))) {
+              Compaction::EvaluateProximalLevel(vstorage_, mutable_cf_options_,
+                                                ioptions_, start_level,
+                                                output_level))) {
         return nullptr;
       }
 
@@ -1590,7 +1590,7 @@ Compaction* UniversalCompactionBuilder::PickCompactionWithSortedRunRange(
   // intra L0 compactions outputs could have overlap
   if (output_level != 0 && picker_->FilesRangeOverlapWithCompaction(
                                inputs, output_level,
-                               Compaction::EvaluatePenultimateLevel(
+                               Compaction::EvaluateProximalLevel(
                                    vstorage_, mutable_cf_options_, ioptions_,
                                    start_level, output_level))) {
     return nullptr;

--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -391,8 +391,8 @@ Status CompactionServiceCompactionJob::Run() {
   // 2. Update the Output information in the Compaction Job Stats with
   // aggregated Internal Compaction Stats.
   UpdateCompactionJobStats(compaction_stats_.stats);
-  if (compaction_stats_.has_penultimate_level_output) {
-    UpdateCompactionJobStats(compaction_stats_.penultimate_level_stats);
+  if (compaction_stats_.has_proximal_level_output) {
+    UpdateCompactionJobStats(compaction_stats_.proximal_level_stats);
   }
 
   // 3. Set fields that are not propagated as part of aggregations above
@@ -417,7 +417,7 @@ Status CompactionServiceCompactionJob::Run() {
           meta.file_creation_time, meta.epoch_number, meta.file_checksum,
           meta.file_checksum_func_name, output_file.validator.GetHash(),
           meta.marked_for_compaction, meta.unique_id,
-          *output_file.table_properties, output_file.is_penultimate_level,
+          *output_file.table_properties, output_file.is_proximal_level,
           meta.temperature);
     }
   }

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -1194,7 +1194,7 @@ TEST_F(CompactionServiceTest, PrecludeLastLevel) {
   }
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
-  // Data split between penultimate (kUnknown) and last (kCold) levels
+  // Data split between proximal (kUnknown) and last (kCold) levels
   ASSERT_EQ("0,0,0,0,0,1,1", FilesPerLevel());
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);

--- a/db/compaction/subcompaction_state.cc
+++ b/db/compaction/subcompaction_state.cc
@@ -18,29 +18,28 @@ void SubcompactionState::AggregateCompactionOutputStats(
   // Outputs should be closed. By extension, any files created just for
   // range deletes have already been written also.
   assert(compaction_outputs_.HasBuilder() == false);
-  assert(penultimate_level_outputs_.HasBuilder() == false);
+  assert(proximal_level_outputs_.HasBuilder() == false);
 
   // FIXME: These stats currently include abandonned output files
   // assert(compaction_outputs_.stats_.num_output_files ==
   //        compaction_outputs_.outputs_.size());
-  // assert(penultimate_level_outputs_.stats_.num_output_files ==
-  //        penultimate_level_outputs_.outputs_.size());
+  // assert(proximal_level_outputs_.stats_.num_output_files ==
+  //        proximal_level_outputs_.outputs_.size());
 
   compaction_stats.stats.Add(compaction_outputs_.stats_);
-  if (penultimate_level_outputs_.HasOutput()) {
-    compaction_stats.has_penultimate_level_output = true;
-    compaction_stats.penultimate_level_stats.Add(
-        penultimate_level_outputs_.stats_);
+  if (proximal_level_outputs_.HasOutput()) {
+    compaction_stats.has_proximal_level_output = true;
+    compaction_stats.proximal_level_stats.Add(proximal_level_outputs_.stats_);
   }
 }
 
 OutputIterator SubcompactionState::GetOutputs() const {
-  return OutputIterator(penultimate_level_outputs_.outputs_,
+  return OutputIterator(proximal_level_outputs_.outputs_,
                         compaction_outputs_.outputs_);
 }
 
 void SubcompactionState::Cleanup(Cache* cache) {
-  penultimate_level_outputs_.Cleanup();
+  proximal_level_outputs_.Cleanup();
   compaction_outputs_.Cleanup();
 
   if (!status.ok()) {
@@ -63,9 +62,9 @@ void SubcompactionState::Cleanup(Cache* cache) {
 }
 
 Slice SubcompactionState::SmallestUserKey() const {
-  if (penultimate_level_outputs_.HasOutput()) {
+  if (proximal_level_outputs_.HasOutput()) {
     Slice a = compaction_outputs_.SmallestUserKey();
-    Slice b = penultimate_level_outputs_.SmallestUserKey();
+    Slice b = proximal_level_outputs_.SmallestUserKey();
     if (a.empty()) {
       return b;
     }
@@ -85,9 +84,9 @@ Slice SubcompactionState::SmallestUserKey() const {
 }
 
 Slice SubcompactionState::LargestUserKey() const {
-  if (penultimate_level_outputs_.HasOutput()) {
+  if (proximal_level_outputs_.HasOutput()) {
     Slice a = compaction_outputs_.LargestUserKey();
-    Slice b = penultimate_level_outputs_.LargestUserKey();
+    Slice b = proximal_level_outputs_.LargestUserKey();
     if (a.empty()) {
       return b;
     }
@@ -107,12 +106,12 @@ Slice SubcompactionState::LargestUserKey() const {
 }
 
 Status SubcompactionState::AddToOutput(
-    const CompactionIterator& iter, bool use_penultimate_output,
+    const CompactionIterator& iter, bool use_proximal_output,
     const CompactionFileOpenFunc& open_file_func,
     const CompactionFileCloseFunc& close_file_func) {
   // update target output
-  current_outputs_ = use_penultimate_output ? &penultimate_level_outputs_
-                                            : &compaction_outputs_;
+  current_outputs_ =
+      use_proximal_output ? &proximal_level_outputs_ : &compaction_outputs_;
   return current_outputs_->AddToOutput(iter, open_file_func, close_file_func);
 }
 

--- a/db/compaction/subcompaction_state.h
+++ b/db/compaction/subcompaction_state.h
@@ -26,13 +26,13 @@ namespace ROCKSDB_NAMESPACE {
 // Maintains state and outputs for each sub-compaction
 // It contains 2 `CompactionOutputs`:
 //  1. one for the normal output files
-//  2. another for the penultimate level outputs
+//  2. another for the proximal level outputs
 // a `current` pointer maintains the current output group, when calling
 // `AddToOutput()`, it checks the output of the current compaction_iterator key
 // and point `current` to the target output group. By default, it just points to
 // normal compaction_outputs, if the compaction_iterator key should be placed on
-// the penultimate level, `current` is changed to point to
-// `penultimate_level_outputs`.
+// the proximal level, `current` is changed to point to
+// `proximal_level_outputs`.
 // The later operations uses `Current()` to get the target group.
 //
 // +----------+          +-----------------------------+      +---------+
@@ -43,7 +43,7 @@ namespace ROCKSDB_NAMESPACE {
 //       |                                                    |  ...    |
 //       |
 //       |               +-----------------------------+      +---------+
-//       +-------------> | penultimate_level_outputs   |----->| output  |
+//       +-------------> | proximal_level_outputs      |----->| output  |
 //                       +-----------------------------+      +---------+
 //                                                            |  ...    |
 
@@ -78,7 +78,7 @@ class SubcompactionState {
   Slice LargestUserKey() const;
 
   // Get all outputs from the subcompaction. For per_key_placement compaction,
-  // it returns both the last level outputs and penultimate level outputs.
+  // it returns both the last level outputs and proximal level outputs.
   OutputIterator GetOutputs() const;
 
   // Assign range dels aggregator. The various tombstones will potentially
@@ -92,7 +92,7 @@ class SubcompactionState {
 
   void RemoveLastEmptyOutput() {
     compaction_outputs_.RemoveLastEmptyOutput();
-    penultimate_level_outputs_.RemoveLastEmptyOutput();
+    proximal_level_outputs_.RemoveLastEmptyOutput();
   }
 
   void BuildSubcompactionJobInfo(
@@ -119,14 +119,14 @@ class SubcompactionState {
         start(_start),
         end(_end),
         sub_job_id(_sub_job_id),
-        compaction_outputs_(c, /*is_penultimate_level=*/false),
-        penultimate_level_outputs_(c, /*is_penultimate_level=*/true) {
+        compaction_outputs_(c, /*is_proximal_level=*/false),
+        proximal_level_outputs_(c, /*is_proximal_level=*/true) {
     assert(compaction != nullptr);
     // Set output split key (used for RoundRobin feature) only for normal
-    // compaction_outputs, output to penultimate_level feature doesn't support
+    // compaction_outputs, output to proximal_level feature doesn't support
     // RoundRobin feature (and may never going to be supported, because for
     // RoundRobin, the data time is mostly naturally sorted, no need to have
-    // per-key placement with output_to_penultimate_level).
+    // per-key placement with output_to_proximal_level).
     compaction_outputs_.SetOutputSlitKey(start, end);
   }
 
@@ -141,18 +141,17 @@ class SubcompactionState {
         compaction_job_stats(std::move(state.compaction_job_stats)),
         sub_job_id(state.sub_job_id),
         compaction_outputs_(std::move(state.compaction_outputs_)),
-        penultimate_level_outputs_(std::move(state.penultimate_level_outputs_)),
+        proximal_level_outputs_(std::move(state.proximal_level_outputs_)),
         range_del_agg_(std::move(state.range_del_agg_)) {
-    current_outputs_ =
-        state.current_outputs_ == &state.penultimate_level_outputs_
-            ? &penultimate_level_outputs_
-            : &compaction_outputs_;
+    current_outputs_ = state.current_outputs_ == &state.proximal_level_outputs_
+                           ? &proximal_level_outputs_
+                           : &compaction_outputs_;
   }
 
   // Add all the new files from this compaction to version_edit
   void AddOutputsEdit(VersionEdit* out_edit) const {
-    for (const auto& file : penultimate_level_outputs_.outputs_) {
-      out_edit->AddFile(compaction->GetPenultimateLevel(), file.meta);
+    for (const auto& file : proximal_level_outputs_.outputs_) {
+      out_edit->AddFile(compaction->GetProximalLevel(), file.meta);
     }
     for (const auto& file : compaction_outputs_.outputs_) {
       out_edit->AddFile(compaction->output_level(), file.meta);
@@ -169,11 +168,11 @@ class SubcompactionState {
     return *current_outputs_;
   }
 
-  CompactionOutputs* Outputs(bool is_penultimate_level) {
+  CompactionOutputs* Outputs(bool is_proximal_level) {
     assert(compaction);
-    if (is_penultimate_level) {
+    if (is_proximal_level) {
       assert(compaction->SupportsPerKeyPlacement());
-      return &penultimate_level_outputs_;
+      return &proximal_level_outputs_;
     }
     return &compaction_outputs_;
   }
@@ -188,12 +187,11 @@ class SubcompactionState {
   }
 
   // Add compaction_iterator key/value to the `Current` output group.
-  Status AddToOutput(const CompactionIterator& iter,
-                     bool use_penultimate_output,
+  Status AddToOutput(const CompactionIterator& iter, bool use_proximal_output,
                      const CompactionFileOpenFunc& open_file_func,
                      const CompactionFileCloseFunc& close_file_func);
 
-  // Close all compaction output files, both output_to_penultimate_level outputs
+  // Close all compaction output files, both output_to_proximal_level outputs
   // and normal outputs.
   Status CloseCompactionFiles(const Status& curr_status,
                               const CompactionFileOpenFunc& open_file_func,
@@ -204,11 +202,11 @@ class SubcompactionState {
     // CloseOutput() may open new compaction output files.
     Status s = curr_status;
     if (per_key) {
-      s = penultimate_level_outputs_.CloseOutput(
-          s, range_del_agg_.get(), open_file_func, close_file_func);
+      s = proximal_level_outputs_.CloseOutput(s, range_del_agg_.get(),
+                                              open_file_func, close_file_func);
     } else {
-      assert(penultimate_level_outputs_.HasBuilder() == false);
-      assert(penultimate_level_outputs_.HasOutput() == false);
+      assert(proximal_level_outputs_.HasBuilder() == false);
+      assert(proximal_level_outputs_.HasOutput() == false);
     }
     s = compaction_outputs_.CloseOutput(s, range_del_agg_.get(), open_file_func,
                                         close_file_func);
@@ -218,7 +216,7 @@ class SubcompactionState {
  private:
   // State kept for output being generated
   CompactionOutputs compaction_outputs_;
-  CompactionOutputs penultimate_level_outputs_;
+  CompactionOutputs proximal_level_outputs_;
   CompactionOutputs* current_outputs_ = &compaction_outputs_;
   std::unique_ptr<CompactionRangeDelAggregator> range_del_agg_;
 };

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -234,7 +234,7 @@ class FlushJob {
 
   // The current minimum seqno that compaction jobs will preclude the data from
   // the last level. Data with seqnos larger than this or larger than
-  // `earliest_snapshot_` will be output to the penultimate level had it gone
+  // `earliest_snapshot_` will be output to the proximal level had it gone
   // through a compaction to the last level.
   SequenceNumber preclude_last_level_min_seqno_ = kMaxSequenceNumber;
 };

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -474,33 +474,33 @@ class InternalStats {
   };
 
   // Compaction stats, for per_key_placement compaction, it includes 2 levels
-  // stats: the last level and the penultimate level.
+  // stats: the last level and the proximal level.
   struct CompactionStatsFull {
     // the stats for the target primary output level
     CompactionStats stats;
 
-    // stats for penultimate level output if exist
-    bool has_penultimate_level_output = false;
-    CompactionStats penultimate_level_stats;
+    // stats for proximal level output if exist
+    bool has_proximal_level_output = false;
+    CompactionStats proximal_level_stats;
 
-    explicit CompactionStatsFull() : stats(), penultimate_level_stats() {}
+    explicit CompactionStatsFull() : stats(), proximal_level_stats() {}
 
     explicit CompactionStatsFull(CompactionReason reason, int c)
-        : stats(reason, c), penultimate_level_stats(reason, c) {}
+        : stats(reason, c), proximal_level_stats(reason, c) {}
 
     uint64_t TotalBytesWritten() const {
       uint64_t bytes_written = stats.bytes_written + stats.bytes_written_blob;
-      if (has_penultimate_level_output) {
-        bytes_written += penultimate_level_stats.bytes_written +
-                         penultimate_level_stats.bytes_written_blob;
+      if (has_proximal_level_output) {
+        bytes_written += proximal_level_stats.bytes_written +
+                         proximal_level_stats.bytes_written_blob;
       }
       return bytes_written;
     }
 
     uint64_t DroppedRecords() {
       uint64_t output_records = stats.num_output_records;
-      if (has_penultimate_level_output) {
-        output_records += penultimate_level_stats.num_output_records;
+      if (has_proximal_level_output) {
+        output_records += proximal_level_stats.num_output_records;
       }
       if (stats.num_input_records > output_records) {
         return stats.num_input_records - output_records;
@@ -510,12 +510,12 @@ class InternalStats {
 
     void SetMicros(uint64_t val) {
       stats.micros = val;
-      penultimate_level_stats.micros = val;
+      proximal_level_stats.micros = val;
     }
 
     void AddCpuMicros(uint64_t val) {
       stats.cpu_micros += val;
-      penultimate_level_stats.cpu_micros += val;
+      proximal_level_stats.cpu_micros += val;
     }
   };
 
@@ -588,9 +588,8 @@ class InternalStats {
   void AddCompactionStats(int level, Env::Priority thread_pri,
                           const CompactionStatsFull& comp_stats_full) {
     AddCompactionStats(level, thread_pri, comp_stats_full.stats);
-    if (comp_stats_full.has_penultimate_level_output) {
-      per_key_placement_comp_stats_.Add(
-          comp_stats_full.penultimate_level_stats);
+    if (comp_stats_full.has_proximal_level_output) {
+      per_key_placement_comp_stats_.Add(comp_stats_full.proximal_level_stats);
     }
   }
 

--- a/db/seqno_time_test.cc
+++ b/db/seqno_time_test.cc
@@ -96,7 +96,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicUniversal) {
   }
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
-  // All data is hot, only output to penultimate level
+  // All data is hot, only output to proximal level
   ASSERT_EQ("0,0,0,0,0,1", FilesPerLevel());
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
   ASSERT_EQ(GetSstSizeHelper(Temperature::kCold), 0);
@@ -185,7 +185,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicLevel) {
   options.num_levels = kNumLevels;
   options.level_compaction_dynamic_level_bytes = true;
   // TODO(zjay): for level compaction, auto-compaction may stuck in deadloop, if
-  //  the penultimate level score > 1, but the hot is not cold enough to compact
+  //  the proximal level score > 1, but the hot is not cold enough to compact
   //  to last level, which will keep triggering compaction.
   options.disable_auto_compactions = true;
   DestroyAndReopen(options);
@@ -205,7 +205,7 @@ TEST_F(SeqnoTimeTest, TemperatureBasicLevel) {
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
 
-  // All data is hot, only output to penultimate level
+  // All data is hot, only output to proximal level
   ASSERT_EQ("0,0,0,0,0,1", FilesPerLevel());
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
   ASSERT_EQ(GetSstSizeHelper(Temperature::kCold), 0);
@@ -753,7 +753,7 @@ TEST_P(SeqnoTimeTablePropTest, SeqnoToTimeMappingUniversal) {
   CompactRangeOptions cro;
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
-  // make sure the data is all compacted to penultimate level if the feature is
+  // make sure the data is all compacted to proximal level if the feature is
   // on, otherwise, compacted to the last level.
   if (options.preclude_last_level_data_seconds > 0) {
     ASSERT_GT(NumTableFilesAtLevel(5), 0);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4761,7 +4761,7 @@ void VersionStorageInfo::CalculateBaseBytes(const ImmutableOptions& ioptions,
             cur_level_size <= base_bytes_min &&
             (options.preclude_last_level_data_seconds == 0 ||
              i < num_levels_ - 2)) {
-          // When per_key_placement is enabled, the penultimate level is
+          // When per_key_placement is enabled, the proximal level is
           // necessary.
           lowest_unnecessary_level_ = i;
         }

--- a/include/rocksdb/compaction_job_stats.h
+++ b/include/rocksdb/compaction_job_stats.h
@@ -118,6 +118,6 @@ struct CompactionJobStats {
   // number of single-deletes which meet something other than a put
   uint64_t num_single_del_mismatch = 0;
 
-  // TODO: Add output_to_penultimate_level output information
+  // TODO: Add output_to_proximal_level output information
 };
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
# Summary

With generalized age-based tiering (work-in-progress), the "warm tier" data will no longer necessarily be placed in the second-to-last level (also known as the "penultimate level").

Also, the cold tier may no longer necessarily be at the last level, so we need to rename options like `preclude_last_level_seconds` to `preclude_cold_tier_seconds`, but renaming options is trickier because it can be a breaking change for consuming applications. We will do this later as a follow up.

**Minor fix included**: Fixed one `use-after-move` in CompactionPicker

# Test Plan

CI