### PR TITLE
Fix Compaction Stats for Remote Compaction and Tiered Storage

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -147,7 +147,7 @@ CompactionJob::CompactionJob(
     BlobFileCompletionCallback* blob_callback, int* bg_compaction_scheduled,
     int* bg_bottom_compaction_scheduled)
     : compact_(new CompactionState(compaction)),
-      compaction_stats_(compaction->compaction_reason(), 1),
+      internal_stats_(compaction->compaction_reason(), 1),
       db_options_(db_options),
       mutable_db_options_copy_(mutable_db_options),
       log_buffer_(log_buffer),
@@ -155,7 +155,7 @@ CompactionJob::CompactionJob(
       stats_(stats),
       bottommost_level_(false),
       write_hint_(Env::WLTH_NOT_SET),
-      compaction_job_stats_(compaction_job_stats),
+      job_stats_(compaction_job_stats),
       job_id_(job_id),
       dbname_(dbname),
       db_id_(db_id),
@@ -191,7 +191,7 @@ CompactionJob::CompactionJob(
       extra_num_subcompaction_threads_reserved_(0),
       bg_compaction_scheduled_(bg_compaction_scheduled),
       bg_bottom_compaction_scheduled_(bg_bottom_compaction_scheduled) {
-  assert(compaction_job_stats_ != nullptr);
+  assert(job_stats_ != nullptr);
   assert(log_buffer_ != nullptr);
 
   const auto* cfd = compact_->compaction->column_family_data();
@@ -240,9 +240,8 @@ void CompactionJob::ReportStartedCompaction(Compaction* compaction) {
   // to ensure GetThreadList() can always show them all together.
   ThreadStatusUtil::SetThreadOperation(ThreadStatus::OP_COMPACTION);
 
-  compaction_job_stats_->is_manual_compaction =
-      compaction->is_manual_compaction();
-  compaction_job_stats_->is_full_compaction = compaction->is_full_compaction();
+  job_stats_->is_manual_compaction = compaction->is_manual_compaction();
+  job_stats_->is_full_compaction = compaction->is_full_compaction();
 }
 
 void CompactionJob::Prepare(
@@ -695,17 +694,17 @@ Status CompactionJob::Run() {
     thread.join();
   }
 
-  compaction_stats_.SetMicros(db_options_.clock->NowMicros() - start_micros);
+  internal_stats_.SetMicros(db_options_.clock->NowMicros() - start_micros);
 
   for (auto& state : compact_->sub_compact_states) {
-    compaction_stats_.AddCpuMicros(state.compaction_job_stats.cpu_micros);
+    internal_stats_.AddCpuMicros(state.compaction_job_stats.cpu_micros);
     state.RemoveLastEmptyOutput();
   }
 
   RecordTimeToHistogram(stats_, COMPACTION_TIME,
-                        compaction_stats_.stats.micros);
+                        internal_stats_.output_level_stats.micros);
   RecordTimeToHistogram(stats_, COMPACTION_CPU_TIME,
-                        compaction_stats_.stats.cpu_micros);
+                        internal_stats_.output_level_stats.cpu_micros);
 
   TEST_SYNC_POINT("CompactionJob::Run:BeforeVerify");
 
@@ -855,46 +854,54 @@ Status CompactionJob::Run() {
   // compaction_service is set. We now know whether each sub_compaction was
   // done remotely or not. Reset is_remote_compaction back to false and allow
   // AggregateCompactionStats() to set the right value.
-  compaction_job_stats_->is_remote_compaction = false;
+  job_stats_->is_remote_compaction = false;
 
   // Finish up all bookkeeping to unify the subcompaction results.
-  compact_->AggregateCompactionStats(compaction_stats_, *compaction_job_stats_);
-  uint64_t num_input_range_del = 0;
-  bool ok = UpdateCompactionStats(&num_input_range_del);
-  // (Sub)compactions returned ok, do sanity check on the number of input keys.
-  if (status.ok() && ok && compaction_job_stats_->has_num_input_records) {
-    size_t ts_sz = compact_->compaction->column_family_data()
-                       ->user_comparator()
-                       ->timestamp_size();
-    // When trim_ts_ is non-empty, CompactionIterator takes
-    // HistoryTrimmingIterator as input iterator and sees a trimmed view of
-    // input keys. So the number of keys it processed is not suitable for
-    // verification here.
-    // TODO: support verification when trim_ts_ is non-empty.
-    if (!(ts_sz > 0 && !trim_ts_.empty())) {
-      assert(compaction_stats_.stats.num_input_records > 0);
-      // TODO: verify the number of range deletion entries.
-      uint64_t expected =
-          compaction_stats_.stats.num_input_records - num_input_range_del;
-      uint64_t actual = compaction_job_stats_->num_input_records;
-      if (expected != actual) {
-        char scratch[2345];
-        compact_->compaction->Summary(scratch, sizeof(scratch));
-        std::string msg =
-            "Compaction number of input keys does not match "
-            "number of keys processed. Expected " +
-            std::to_string(expected) + " but processed " +
-            std::to_string(actual) + ". Compaction summary: " + scratch;
-        ROCKS_LOG_WARN(
-            db_options_.info_log, "[%s] [JOB %d] Compaction with status: %s",
-            compact_->compaction->column_family_data()->GetName().c_str(),
-            job_context_->job_id, msg.c_str());
-        if (db_options_.compaction_verify_record_count) {
-          status = Status::Corruption(msg);
+  compact_->AggregateCompactionStats(internal_stats_, *job_stats_);
+
+  // For remote compactions, internal_stats_.output_level_stats were part of the
+  // compaction_result already. No need to re-update it.
+  if (job_stats_->is_remote_compaction == false) {
+    uint64_t num_input_range_del = 0;
+    bool ok = UpdateOutputLevelCompactionStats(&num_input_range_del);
+    // (Sub)compactions returned ok, do sanity check on the number of input
+    // keys.
+    if (status.ok() && ok && job_stats_->has_num_input_records) {
+      size_t ts_sz = compact_->compaction->column_family_data()
+                         ->user_comparator()
+                         ->timestamp_size();
+      // When trim_ts_ is non-empty, CompactionIterator takes
+      // HistoryTrimmingIterator as input iterator and sees a trimmed view of
+      // input keys. So the number of keys it processed is not suitable for
+      // verification here.
+      // TODO: support verification when trim_ts_ is non-empty.
+      if (!(ts_sz > 0 && !trim_ts_.empty())) {
+        assert(internal_stats_.output_level_stats.num_input_records > 0);
+        // TODO: verify the number of range deletion entries.
+        uint64_t expected =
+            internal_stats_.output_level_stats.num_input_records -
+            num_input_range_del;
+        uint64_t actual = job_stats_->num_input_records;
+        if (expected != actual) {
+          char scratch[2345];
+          compact_->compaction->Summary(scratch, sizeof(scratch));
+          std::string msg =
+              "Compaction number of input keys does not match "
+              "number of keys processed. Expected " +
+              std::to_string(expected) + " but processed " +
+              std::to_string(actual) + ". Compaction summary: " + scratch;
+          ROCKS_LOG_WARN(
+              db_options_.info_log, "[%s] [JOB %d] Compaction with status: %s",
+              compact_->compaction->column_family_data()->GetName().c_str(),
+              job_context_->job_id, msg.c_str());
+          if (db_options_.compaction_verify_record_count) {
+            status = Status::Corruption(msg);
+          }
         }
       }
     }
   }
+
   RecordCompactionIOStats();
   LogFlush(db_options_.info_log);
   TEST_SYNC_POINT("CompactionJob::Run():End");
@@ -916,7 +923,7 @@ Status CompactionJob::Install(bool* compaction_released) {
 
   int output_level = compact_->compaction->output_level();
   cfd->internal_stats()->AddCompactionStats(output_level, thread_pri_,
-                                            compaction_stats_);
+                                            internal_stats_);
 
   if (status.ok()) {
     status = InstallCompactionResults(compaction_released);
@@ -927,7 +934,7 @@ Status CompactionJob::Install(bool* compaction_released) {
 
   VersionStorageInfo::LevelSummaryStorage tmp;
   auto vstorage = cfd->current()->storage_info();
-  const auto& stats = compaction_stats_.stats;
+  const auto& stats = internal_stats_.output_level_stats;
 
   double read_write_amp = 0.0;
   double write_amp = 0.0;
@@ -993,19 +1000,21 @@ Status CompactionJob::Install(bool* compaction_released) {
         blob_files.back()->GetBlobFileNumber());
   }
 
-  if (compaction_stats_.has_proximal_level_output) {
+  if (internal_stats_.has_proximal_level_output) {
     ROCKS_LOG_BUFFER(log_buffer_,
                      "[%s] has Proximal Level output: %" PRIu64
                      ", level %d, number of files: %" PRIu64
                      ", number of records: %" PRIu64,
                      column_family_name.c_str(),
-                     compaction_stats_.proximal_level_stats.bytes_written,
+                     internal_stats_.proximal_level_stats.bytes_written,
                      compact_->compaction->GetProximalLevel(),
-                     compaction_stats_.proximal_level_stats.num_output_files,
-                     compaction_stats_.proximal_level_stats.num_output_records);
+                     internal_stats_.proximal_level_stats.num_output_files,
+                     internal_stats_.proximal_level_stats.num_output_records);
   }
 
-  UpdateCompactionJobStats(stats);
+  UpdateCompactionJobStats(internal_stats_);
+  TEST_SYNC_POINT_CALLBACK(
+      "CompactionJob::Install:AfterUpdateCompactionJobStats", job_stats_);
 
   auto stream = event_logger_->LogToBuffer(log_buffer_, 8192);
   stream << "job" << job_id_ << "event" << "compaction_finished"
@@ -1027,17 +1036,16 @@ Status CompactionJob::Install(bool* compaction_released) {
          << CompressionTypeToString(compact_->compaction->output_compression());
 
   stream << "num_single_delete_mismatches"
-         << compaction_job_stats_->num_single_del_mismatch;
+         << job_stats_->num_single_del_mismatch;
   stream << "num_single_delete_fallthrough"
-         << compaction_job_stats_->num_single_del_fallthru;
+         << job_stats_->num_single_del_fallthru;
 
   if (measure_io_stats_) {
-    stream << "file_write_nanos" << compaction_job_stats_->file_write_nanos;
-    stream << "file_range_sync_nanos"
-           << compaction_job_stats_->file_range_sync_nanos;
-    stream << "file_fsync_nanos" << compaction_job_stats_->file_fsync_nanos;
+    stream << "file_write_nanos" << job_stats_->file_write_nanos;
+    stream << "file_range_sync_nanos" << job_stats_->file_range_sync_nanos;
+    stream << "file_fsync_nanos" << job_stats_->file_fsync_nanos;
     stream << "file_prepare_write_nanos"
-           << compaction_job_stats_->file_prepare_write_nanos;
+           << job_stats_->file_prepare_write_nanos;
   }
 
   stream << "lsm_state";
@@ -1055,9 +1063,9 @@ Status CompactionJob::Install(bool* compaction_released) {
     stream << "blob_file_tail" << blob_files.back()->GetBlobFileNumber();
   }
 
-  if (compaction_stats_.has_proximal_level_output) {
+  if (internal_stats_.has_proximal_level_output) {
     InternalStats::CompactionStats& pl_stats =
-        compaction_stats_.proximal_level_stats;
+        internal_stats_.proximal_level_stats;
     stream << "proximal_level_num_output_files" << pl_stats.num_output_files;
     stream << "proximal_level_bytes_written" << pl_stats.bytes_written;
     stream << "proximal_level_num_output_records"
@@ -1812,22 +1820,22 @@ Status CompactionJob::InstallCompactionResults(bool* compaction_released) {
 
   {
     Compaction::InputLevelSummaryBuffer inputs_summary;
-    if (compaction_stats_.has_proximal_level_output) {
+    if (internal_stats_.has_proximal_level_output) {
       ROCKS_LOG_BUFFER(
           log_buffer_,
           "[%s] [JOB %d] Compacted %s => output_to_proximal_level: %" PRIu64
           " bytes + last: %" PRIu64 " bytes. Total: %" PRIu64 " bytes",
           compaction->column_family_data()->GetName().c_str(), job_id_,
           compaction->InputLevelSummary(&inputs_summary),
-          compaction_stats_.proximal_level_stats.bytes_written,
-          compaction_stats_.stats.bytes_written,
-          compaction_stats_.TotalBytesWritten());
+          internal_stats_.proximal_level_stats.bytes_written,
+          internal_stats_.output_level_stats.bytes_written,
+          internal_stats_.TotalBytesWritten());
     } else {
       ROCKS_LOG_BUFFER(log_buffer_,
                        "[%s] [JOB %d] Compacted %s => %" PRIu64 " bytes",
                        compaction->column_family_data()->GetName().c_str(),
                        job_id_, compaction->InputLevelSummary(&inputs_summary),
-                       compaction_stats_.TotalBytesWritten());
+                       internal_stats_.TotalBytesWritten());
     }
   }
 
@@ -2087,12 +2095,13 @@ void CopyPrefix(const Slice& src, size_t prefix_length, std::string* dst) {
 }
 }  // namespace
 
-bool CompactionJob::UpdateCompactionStats(uint64_t* num_input_range_del) {
+bool CompactionJob::UpdateOutputLevelCompactionStats(
+    uint64_t* num_input_range_del) {
   assert(compact_);
 
   Compaction* compaction = compact_->compaction;
-  compaction_stats_.stats.num_input_files_in_non_output_levels = 0;
-  compaction_stats_.stats.num_input_files_in_output_level = 0;
+  internal_stats_.output_level_stats.num_input_files_in_non_output_levels = 0;
+  internal_stats_.output_level_stats.num_input_files_in_output_level = 0;
 
   bool has_error = false;
   const ReadOptions read_options(Env::IOActivity::kCompaction);
@@ -2104,13 +2113,14 @@ bool CompactionJob::UpdateCompactionStats(uint64_t* num_input_range_del) {
     size_t num_input_files = flevel->num_files;
     uint64_t* bytes_read;
     if (compaction->level(input_level) != compaction->output_level()) {
-      compaction_stats_.stats.num_input_files_in_non_output_levels +=
+      internal_stats_.output_level_stats.num_input_files_in_non_output_levels +=
           static_cast<int>(num_input_files);
-      bytes_read = &compaction_stats_.stats.bytes_read_non_output_levels;
+      bytes_read =
+          &internal_stats_.output_level_stats.bytes_read_non_output_levels;
     } else {
-      compaction_stats_.stats.num_input_files_in_output_level +=
+      internal_stats_.output_level_stats.num_input_files_in_output_level +=
           static_cast<int>(num_input_files);
-      bytes_read = &compaction_stats_.stats.bytes_read_output_level;
+      bytes_read = &internal_stats_.output_level_stats.bytes_read_output_level;
     }
     for (size_t i = 0; i < num_input_files; ++i) {
       const FileMetaData* file_meta = flevel->files[i].file_metadata;
@@ -2130,7 +2140,8 @@ bool CompactionJob::UpdateCompactionStats(uint64_t* num_input_range_del) {
           has_error = true;
         }
       }
-      compaction_stats_.stats.num_input_records += file_input_entries;
+      internal_stats_.output_level_stats.num_input_records +=
+          file_input_entries;
       if (num_input_range_del) {
         *num_input_range_del += file_num_range_del;
       }
@@ -2141,62 +2152,116 @@ bool CompactionJob::UpdateCompactionStats(uint64_t* num_input_range_del) {
     size_t num_filtered_input_files = filtered_flevel.size();
     uint64_t* bytes_skipped;
     if (compaction->level(input_level) != compaction->output_level()) {
-      compaction_stats_.stats.num_filtered_input_files_in_non_output_levels +=
+      internal_stats_.output_level_stats
+          .num_filtered_input_files_in_non_output_levels +=
           static_cast<int>(num_filtered_input_files);
-      bytes_skipped = &compaction_stats_.stats.bytes_skipped_non_output_levels;
+      bytes_skipped =
+          &internal_stats_.output_level_stats.bytes_skipped_non_output_levels;
     } else {
-      compaction_stats_.stats.num_filtered_input_files_in_output_level +=
+      internal_stats_.output_level_stats
+          .num_filtered_input_files_in_output_level +=
           static_cast<int>(num_filtered_input_files);
-      bytes_skipped = &compaction_stats_.stats.bytes_skipped_output_level;
+      bytes_skipped =
+          &internal_stats_.output_level_stats.bytes_skipped_output_level;
     }
     for (const FileMetaData* filtered_file_meta : filtered_flevel) {
       *bytes_skipped += filtered_file_meta->fd.GetFileSize();
     }
   }
 
-  assert(compaction_job_stats_);
-  compaction_stats_.stats.bytes_read_blob =
-      compaction_job_stats_->total_blob_bytes_read;
+  assert(job_stats_);
+  internal_stats_.output_level_stats.bytes_read_blob =
+      job_stats_->total_blob_bytes_read;
 
-  compaction_stats_.stats.num_dropped_records =
-      compaction_stats_.DroppedRecords();
+  internal_stats_.output_level_stats.num_dropped_records =
+      internal_stats_.DroppedRecords();
   return !has_error;
 }
 
 void CompactionJob::UpdateCompactionJobStats(
-    const InternalStats::CompactionStats& stats) const {
-  compaction_job_stats_->elapsed_micros = stats.micros;
+    const InternalStats::CompactionStatsFull& internal_stats) const {
+  assert(job_stats_);
+  job_stats_->elapsed_micros = internal_stats.output_level_stats.micros;
+  job_stats_->cpu_micros = internal_stats.output_level_stats.cpu_micros;
 
   // input information
-  compaction_job_stats_->total_input_bytes =
-      stats.bytes_read_non_output_levels + stats.bytes_read_output_level;
-  compaction_job_stats_->num_input_records = stats.num_input_records;
-  compaction_job_stats_->num_input_files =
-      stats.num_input_files_in_non_output_levels +
-      stats.num_input_files_in_output_level;
-  compaction_job_stats_->num_input_files_at_output_level =
-      stats.num_input_files_in_output_level;
-  compaction_job_stats_->num_filtered_input_files =
-      stats.num_filtered_input_files_in_non_output_levels +
-      stats.num_filtered_input_files_in_output_level;
-  compaction_job_stats_->num_filtered_input_files_at_output_level =
-      stats.num_filtered_input_files_in_output_level;
-  compaction_job_stats_->total_skipped_input_bytes =
-      stats.bytes_skipped_non_output_levels + stats.bytes_skipped_output_level;
+  job_stats_->total_input_bytes =
+      internal_stats.output_level_stats.bytes_read_non_output_levels +
+      internal_stats.output_level_stats.bytes_read_output_level;
+  job_stats_->num_input_records =
+      internal_stats.output_level_stats.num_input_records;
+  job_stats_->num_input_files =
+      internal_stats.output_level_stats.num_input_files_in_non_output_levels +
+      internal_stats.output_level_stats.num_input_files_in_output_level;
+  job_stats_->num_input_files_at_output_level =
+      internal_stats.output_level_stats.num_input_files_in_output_level;
+  job_stats_->num_filtered_input_files =
+      internal_stats.output_level_stats
+          .num_filtered_input_files_in_non_output_levels +
+      internal_stats.output_level_stats
+          .num_filtered_input_files_in_output_level;
+  job_stats_->num_filtered_input_files_at_output_level =
+      internal_stats.output_level_stats
+          .num_filtered_input_files_in_output_level;
+  job_stats_->total_skipped_input_bytes =
+      internal_stats.output_level_stats.bytes_skipped_non_output_levels +
+      internal_stats.output_level_stats.bytes_skipped_output_level;
 
   // output information
-  compaction_job_stats_->total_output_bytes = stats.bytes_written;
-  compaction_job_stats_->total_output_bytes_blob = stats.bytes_written_blob;
-  compaction_job_stats_->num_output_records = stats.num_output_records;
-  compaction_job_stats_->num_output_files = stats.num_output_files;
-  compaction_job_stats_->num_output_files_blob = stats.num_output_files_blob;
+  job_stats_->total_output_bytes =
+      internal_stats.output_level_stats.bytes_written;
+  job_stats_->total_output_bytes_blob =
+      internal_stats.output_level_stats.bytes_written_blob;
+  job_stats_->num_output_records =
+      internal_stats.output_level_stats.num_output_records;
+  job_stats_->num_output_files =
+      internal_stats.output_level_stats.num_output_files;
+  job_stats_->num_output_files_blob =
+      internal_stats.output_level_stats.num_output_files_blob;
 
-  if (stats.num_output_files > 0) {
+  // If proximal level output exists
+  if (internal_stats.has_proximal_level_output) {
+    job_stats_->total_input_bytes +=
+        internal_stats.proximal_level_stats.bytes_read_non_output_levels +
+        internal_stats.proximal_level_stats.bytes_read_output_level;
+    job_stats_->num_input_records +=
+        internal_stats.proximal_level_stats.num_input_records;
+    job_stats_->num_input_files +=
+        internal_stats.proximal_level_stats
+            .num_input_files_in_non_output_levels +
+        internal_stats.proximal_level_stats.num_input_files_in_output_level;
+    job_stats_->num_input_files_at_output_level +=
+        internal_stats.proximal_level_stats.num_input_files_in_output_level;
+    job_stats_->num_filtered_input_files +=
+        internal_stats.proximal_level_stats
+            .num_filtered_input_files_in_non_output_levels +
+        internal_stats.proximal_level_stats
+            .num_filtered_input_files_in_output_level;
+    job_stats_->num_filtered_input_files_at_output_level +=
+        internal_stats.proximal_level_stats
+            .num_filtered_input_files_in_output_level;
+    job_stats_->total_skipped_input_bytes +=
+        internal_stats.proximal_level_stats.bytes_skipped_non_output_levels +
+        internal_stats.proximal_level_stats.bytes_skipped_output_level;
+
+    job_stats_->total_output_bytes +=
+        internal_stats.proximal_level_stats.bytes_written;
+    job_stats_->total_output_bytes_blob +=
+        internal_stats.proximal_level_stats.bytes_written_blob;
+    job_stats_->num_output_records +=
+        internal_stats.proximal_level_stats.num_output_records;
+    job_stats_->num_output_files +=
+        internal_stats.proximal_level_stats.num_output_files;
+    job_stats_->num_output_files_blob +=
+        internal_stats.proximal_level_stats.num_output_files_blob;
+  }
+
+  if (job_stats_->num_output_files > 0) {
     CopyPrefix(compact_->SmallestUserKey(),
                CompactionJobStats::kMaxPrefixLength,
-               &compaction_job_stats_->smallest_output_key_prefix);
+               &job_stats_->smallest_output_key_prefix);
     CopyPrefix(compact_->LargestUserKey(), CompactionJobStats::kMaxPrefixLength,
-               &compaction_job_stats_->largest_output_key_prefix);
+               &job_stats_->largest_output_key_prefix);
   }
 }
 

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -479,7 +479,7 @@ struct CompactionServiceResult {
 
   // Job-level Compaction Stats.
   //
-  // NOTE: Job level stats cannot be rebuilt from scatch by simply aggregating
+  // NOTE: Job level stats cannot be rebuilt from scratch by simply aggregating
   // per-level stats due to some fields populated directly during compaction
   // (e.g. RecordDroppedKeys()). This is why we need both job-level stats and
   // per-level in the serialized result. If rebuilding job-level stats from

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -67,7 +67,7 @@ class SubcompactionState;
 // if needed.
 //
 // CompactionJob has 2 main stats:
-// 1. CompactionJobStats compaction_job_stats_
+// 1. CompactionJobStats job_stats_
 //    CompactionJobStats is a public data structure which is part of Compaction
 //    event listener that rocksdb share the job stats with the user.
 //    Internally it's an aggregation of all the compaction_job_stats from each
@@ -81,7 +81,7 @@ class SubcompactionState;
 // +------------------------+     |
 // | CompactionJob          |     |          +------------------------+
 // |                        |     |          | SubcompactionState     |
-// |   compaction_job_stats +-----+          |                        |
+// |   job_stats            +-----+          |                        |
 // |                        |     +--------->|   compaction_job_stats |
 // |                        |     |          |                        |
 // +------------------------+     |          +------------------------+
@@ -123,7 +123,7 @@ class SubcompactionState;
 // |                                |    +--------->|   stats_             |  |
 // |   compaction_stats_            |    |    |   | +----------------------+  |
 // |    +-------------------------+ |    |    |   |                           |
-// |    |stats (normal)           |------|----+   +---------------------------+
+// |    |output_level_stats       |------|----+   +---------------------------+
 // |    +-------------------------+ |    |    |
 // |                                |    |    |
 // |    +-------------------------+ |    |    |   +---------------------------+
@@ -199,7 +199,7 @@ class CompactionJob {
   IOStatus io_status() const { return io_status_; }
 
  protected:
-  // Update the following stats in compaction_stats_.stats
+  // Update the following stats in internal_stats_.output_level_stats
   // - num_input_files_in_non_output_levels
   // - num_input_files_in_output_level
   // - bytes_read_non_output_levels
@@ -211,11 +211,12 @@ class CompactionJob {
   // @param num_input_range_del if non-null, will be set to the number of range
   // deletion entries in this compaction input.
   //
-  // Returns true iff compaction_stats_.stats.num_input_records and
+  // Returns true iff internal_stats_.output_level_stats.num_input_records and
   // num_input_range_del are calculated successfully.
-  bool UpdateCompactionStats(uint64_t* num_input_range_del = nullptr);
-  virtual void UpdateCompactionJobStats(
-      const InternalStats::CompactionStats& stats) const;
+  bool UpdateOutputLevelCompactionStats(
+      uint64_t* num_input_range_del = nullptr);
+  void UpdateCompactionJobStats(
+      const InternalStats::CompactionStatsFull& internal_stats) const;
   void LogCompaction();
   virtual void RecordCompactionIOStats();
   void CleanupCompaction();
@@ -224,7 +225,7 @@ class CompactionJob {
   void ProcessKeyValueCompaction(SubcompactionState* sub_compact);
 
   CompactionState* compact_;
-  InternalStats::CompactionStatsFull compaction_stats_;
+  InternalStats::CompactionStatsFull internal_stats_;
   const ImmutableDBOptions& db_options_;
   const MutableDBOptions mutable_db_options_copy_;
   LogBuffer* log_buffer_;
@@ -237,7 +238,7 @@ class CompactionJob {
 
   IOStatus io_status_;
 
-  CompactionJobStats* compaction_job_stats_;
+  CompactionJobStats* job_stats_;
 
  private:
   friend class CompactionJobTestBase;
@@ -475,7 +476,13 @@ struct CompactionServiceResult {
 
   uint64_t bytes_read = 0;
   uint64_t bytes_written = 0;
+
+  // Job-level Compaction Stats
   CompactionJobStats stats;
+
+  // Per-level Compaction Stats
+  // for both output_level_stats and proximal_level_stats
+  InternalStats::CompactionStatsFull internal_stats;
 
   // serialization interface to read and write the object
   static Status Read(const std::string& data_str, CompactionServiceResult* obj);
@@ -521,9 +528,6 @@ class CompactionServiceCompactionJob : private CompactionJob {
 
  protected:
   void RecordCompactionIOStats() override;
-
-  void UpdateCompactionJobStats(
-      const InternalStats::CompactionStats& stats) const override;
 
  private:
   // Get table file name in output_path

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -98,16 +98,13 @@ class SubcompactionState;
 //                                +--------->+                        |
 //                                           +------------------------+
 //
-// 2. CompactionStatsFull compaction_stats_
+// 2. CompactionStatsFull internal_stats_
 //    `CompactionStatsFull` is an internal stats about the compaction, which
 //    is eventually sent to `ColumnFamilyData::internal_stats_` and used for
 //    logging and public metrics.
 //    Internally, it's an aggregation of stats_ from each `SubcompactionState`.
-//    It has 2 parts, normal stats about the main compaction information and
-//    the proximal level output stats.
-//    `SubcompactionState` maintains the CompactionOutputs for ordinary level
-//    output and the proximal level output if exists, the per_level stats is
-//    stored with the outputs.
+//    It has 2 parts, ordinary output level stats and the proximal level output
+//    stats.
 //                                                +---------------------------+
 //                                                | SubcompactionState        |
 //                                                |                           |
@@ -121,7 +118,7 @@ class SubcompactionState;
 // +--------------------------------+         |   | | CompactionOutputs    |  |
 // | CompactionJob                  |         |   | | (proximal_level)     |  |
 // |                                |    +--------->|   stats_             |  |
-// |   compaction_stats_            |    |    |   | +----------------------+  |
+// |   internal_stats_              |    |    |   | +----------------------+  |
 // |    +-------------------------+ |    |    |   |                           |
 // |    |output_level_stats       |------|----+   +---------------------------+
 // |    +-------------------------+ |    |    |

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -477,11 +477,18 @@ struct CompactionServiceResult {
   uint64_t bytes_read = 0;
   uint64_t bytes_written = 0;
 
-  // Job-level Compaction Stats
+  // Job-level Compaction Stats.
+  //
+  // NOTE: Job level stats cannot be rebuilt from scatch by simply aggregating
+  // per-level stats due to some fields populated directly during compaction
+  // (e.g. RecordDroppedKeys()). This is why we need both job-level stats and
+  // per-level in the serialized result. If rebuilding job-level stats from
+  // per-level stats become possible in the future, consider deprecating this
+  // field.
   CompactionJobStats stats;
 
-  // Per-level Compaction Stats
-  // for both output_level_stats and proximal_level_stats
+  // Per-level Compaction Stats for both output_level_stats and
+  // proximal_level_stats
   InternalStats::CompactionStatsFull internal_stats;
 
   // serialization interface to read and write the object

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -54,7 +54,7 @@ Status CompactionOutputs::Finish(
   }
   current_output().finished = true;
   stats_.bytes_written += current_bytes;
-  stats_.num_output_files = outputs_.size();
+  stats_.num_output_files = static_cast<int>(outputs_.size());
 
   return s;
 }

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -66,11 +66,6 @@ class CompactionOutputs {
     file_writer_.reset(writer);
   }
 
-  // TODO: Remove it when remote compaction support tiered compaction
-  void AddBytesWritten(uint64_t bytes) { stats_.bytes_written += bytes; }
-  void SetNumOutputRecords(uint64_t num) { stats_.num_output_records = num; }
-  void SetNumOutputFiles(uint64_t num) { stats_.num_output_files = num; }
-
   // TODO: Move the BlobDB builder into CompactionOutputs
   const std::vector<BlobFileAddition>& GetBlobFileAdditions() const {
     if (is_proximal_level_) {

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -98,7 +98,8 @@ class CompactionOutputs {
 
   void UpdateBlobStats() {
     assert(!is_proximal_level_);
-    stats_.num_output_files_blob = blob_file_additions_.size();
+    stats_.num_output_files_blob =
+        static_cast<int>(blob_file_additions_.size());
     for (const auto& blob : blob_file_additions_) {
       stats_.bytes_written_blob += blob.GetTotalBlobBytes();
     }
@@ -302,8 +303,8 @@ class CompactionOutputs {
   std::vector<BlobFileAddition> blob_file_additions_;
   std::unique_ptr<BlobGarbageMeter> blob_garbage_meter_;
 
-  // Basic compaction output stats for this level's outputs
-  InternalStats::CompactionOutputsStats stats_;
+  // Per level's output stat
+  InternalStats::CompactionStats stats_;
 
   // indicate if this CompactionOutputs obj for proximal_level, should always
   // be false if per_key_placement feature is not enabled.

--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -839,6 +839,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct InternalStats::CompactionStats, count),
           OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"counts", OptionTypeInfo::Array<
+                       int, static_cast<int>(CompactionReason::kNumOfReasons)>(
+                       offsetof(struct InternalStats::CompactionStats, counts),
+                       OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+                       {0, OptionType::kInt})},
 };
 
 static std::unordered_map<std::string, OptionTypeInfo>

--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -384,12 +384,12 @@ Status CompactionServiceCompactionJob::Run() {
 
   // Build Compaction Job Stats
 
-  // 1. Aggregate for all subcompactions
-  // per-level stats: sub_compact.proximal_level_outputs_.stats and
-  //                  sub_compact.compaction_outputs_.stats into
-  //                  internal_stats_.output_level_stats and
-  //                  internal_stats_.proximal_level_stats
-  // job-level stats: sub_compact.job_level_stats_ into compact.job_level_stats_
+  // 1. Aggregate internal stats and job stats for all subcompactions
+  // internal stats: sub_compact.proximal_level_outputs_.stats and
+  //                 sub_compact.compaction_outputs_.stats into
+  //                 internal_stats_.output_level_stats and
+  //                 internal_stats_.proximal_level_stats
+  // job-level stats: sub_compact.compaction_job_stats into compact.job_stats_
   //
   // For remote compaction, there's only one subcompaction.
   compact_->AggregateCompactionStats(internal_stats_, *job_stats_);
@@ -409,14 +409,14 @@ Status CompactionServiceCompactionJob::Run() {
     assert(job_stats_->num_input_records > 0);
   }
 
-  // 3. Aggregate per-level stats into job-level stats and
-  // set fields that are not propagated as part of the aggregation
+  // 3. Update job-level stats with the aggregated internal_stats_
   UpdateCompactionJobStats(internal_stats_);
+  // and set fields that are not propagated as part of the update
   compaction_result_->stats.is_manual_compaction = c->is_manual_compaction();
   compaction_result_->stats.is_full_compaction = c->is_full_compaction();
   compaction_result_->stats.is_remote_compaction = true;
 
-  // 4. Update IO Stats that are not part of the aggregations above
+  // 4. Update IO Stats that are not part of the the update above
   // (bytes_read, bytes_written)
   RecordCompactionIOStats();
 

--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -249,12 +249,18 @@ CompactionJob::ProcessKeyValueCompactionWithCompactionService(
                                   false, true, file.paranoid_hash);
     compaction_outputs->UpdateTableProperties(file.table_properties);
   }
+
+  // Set job stats
   sub_compact->compaction_job_stats = compaction_result.stats;
-  sub_compact->Current().SetNumOutputRecords(
-      compaction_result.stats.num_output_records);
-  sub_compact->Current().SetNumOutputFiles(
-      compaction_result.stats.num_output_files);
-  sub_compact->Current().AddBytesWritten(compaction_result.bytes_written);
+
+  // Set per-level stats
+  internal_stats_.output_level_stats =
+      compaction_result.internal_stats.output_level_stats;
+  internal_stats_.proximal_level_stats =
+      compaction_result.internal_stats.proximal_level_stats;
+  internal_stats_.has_proximal_level_output =
+      compaction_result.internal_stats.has_proximal_level_output;
+
   RecordTick(stats_, REMOTE_COMPACT_READ_BYTES, compaction_result.bytes_read);
   RecordTick(stats_, REMOTE_COMPACT_WRITE_BYTES,
              compaction_result.bytes_written);
@@ -272,16 +278,6 @@ void CompactionServiceCompactionJob::RecordCompactionIOStats() {
   compaction_result_->bytes_read += IOSTATS(bytes_read);
   compaction_result_->bytes_written += IOSTATS(bytes_written);
   CompactionJob::RecordCompactionIOStats();
-}
-
-void CompactionServiceCompactionJob::UpdateCompactionJobStats(
-    const InternalStats::CompactionStats& stats) const {
-  // output information only in remote compaction
-  compaction_job_stats_->total_output_bytes += stats.bytes_written;
-  compaction_job_stats_->total_output_bytes_blob += stats.bytes_written_blob;
-  compaction_job_stats_->num_output_records += stats.num_output_records;
-  compaction_job_stats_->num_output_files += stats.num_output_files;
-  compaction_job_stats_->num_output_files_blob += stats.num_output_files_blob;
 }
 
 CompactionServiceCompactionJob::CompactionServiceCompactionJob(
@@ -345,15 +341,14 @@ Status CompactionServiceCompactionJob::Run() {
 
   ProcessKeyValueCompaction(sub_compact);
 
-  compaction_job_stats_->elapsed_micros =
-      db_options_.clock->NowMicros() - start_micros;
-  compaction_job_stats_->cpu_micros =
-      sub_compact->compaction_job_stats.cpu_micros;
+  uint64_t elapsed_micros = db_options_.clock->NowMicros() - start_micros;
+  internal_stats_.SetMicros(elapsed_micros);
+  internal_stats_.AddCpuMicros(elapsed_micros);
 
   RecordTimeToHistogram(stats_, COMPACTION_TIME,
-                        compaction_job_stats_->elapsed_micros);
+                        internal_stats_.output_level_stats.micros);
   RecordTimeToHistogram(stats_, COMPACTION_CPU_TIME,
-                        compaction_job_stats_->cpu_micros);
+                        internal_stats_.output_level_stats.cpu_micros);
 
   Status status = sub_compact->status;
   IOStatus io_s = sub_compact->io_status;
@@ -383,28 +378,31 @@ Status CompactionServiceCompactionJob::Run() {
 
   // Build Compaction Job Stats
 
-  // 1. Aggregate CompactionOutputStats into Internal Compaction Stats
-  // (compaction_stats_) and aggregate Compaction Job Stats
-  // (compaction_job_stats_) from the sub compactions
-  compact_->AggregateCompactionStats(compaction_stats_, *compaction_job_stats_);
+  // 1. Aggregate CompactionOutputStats for subcompaction.
+  // (For remote compaction, there's only one subcompaction)
+  compact_->AggregateCompactionStats(internal_stats_, *job_stats_);
 
-  // 2. Update the Output information in the Compaction Job Stats with
-  // aggregated Internal Compaction Stats.
-  UpdateCompactionJobStats(compaction_stats_.stats);
-  if (compaction_stats_.has_proximal_level_output) {
-    UpdateCompactionJobStats(compaction_stats_.proximal_level_stats);
-  }
+  // 2. Update internal_stats_.output_level_stats
+  uint64_t num_input_range_del = 0;
+  UpdateOutputLevelCompactionStats(&num_input_range_del);
 
-  // 3. Set fields that are not propagated as part of aggregations above
+  // 3. Aggregate per-level stats into job-level stats and
+  // Set fields that are not propagated as part of the aggregation
+  // Please note that this step is done again on the primary side.
+  // Continuing to populate this for backward compatibility.
+  // Consider deprecating this from the compaction_result since this can be
+  // rebuilt from per-level stats on the primary side
+  UpdateCompactionJobStats(internal_stats_);
   compaction_result_->stats.is_manual_compaction = c->is_manual_compaction();
   compaction_result_->stats.is_full_compaction = c->is_full_compaction();
   compaction_result_->stats.is_remote_compaction = true;
 
-  // 4. Update IO Stats that are not part of the aggregations above (bytes_read,
-  // bytes_written)
+  // 4. Update IO Stats that are not part of the aggregations above
+  // (bytes_read, bytes_written)
   RecordCompactionIOStats();
 
   // Build Output
+  compaction_result_->internal_stats = internal_stats_;
   compaction_result_->output_level = compact_->compaction->output_level();
   compaction_result_->output_path = output_path_;
   if (status.ok()) {
@@ -724,6 +722,120 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
 };
 
+static std::unordered_map<std::string, OptionTypeInfo>
+    compaction_stats_type_info = {
+        {"micros",
+         {offsetof(struct InternalStats::CompactionStats, micros),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"cpu_micros",
+         {offsetof(struct InternalStats::CompactionStats, cpu_micros),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"bytes_read_non_output_levels",
+         {offsetof(struct InternalStats::CompactionStats,
+                   bytes_read_non_output_levels),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"bytes_read_output_level",
+         {offsetof(struct InternalStats::CompactionStats,
+                   bytes_read_output_level),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"bytes_skipped_non_output_levels",
+         {offsetof(struct InternalStats::CompactionStats,
+                   bytes_skipped_non_output_levels),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"bytes_skipped_output_level",
+         {offsetof(struct InternalStats::CompactionStats,
+                   bytes_skipped_output_level),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"bytes_read_blob",
+         {offsetof(struct InternalStats::CompactionStats, bytes_read_blob),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"bytes_written",
+         {offsetof(struct InternalStats::CompactionStats, bytes_written),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"bytes_written_blob",
+         {offsetof(struct InternalStats::CompactionStats, bytes_written_blob),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"bytes_moved",
+         {offsetof(struct InternalStats::CompactionStats, bytes_moved),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_input_files_in_non_output_levels",
+         {offsetof(struct InternalStats::CompactionStats,
+                   num_input_files_in_non_output_levels),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_input_files_in_output_level",
+         {offsetof(struct InternalStats::CompactionStats,
+                   num_input_files_in_output_level),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_filtered_input_files_in_non_output_levels",
+         {offsetof(struct InternalStats::CompactionStats,
+                   num_filtered_input_files_in_non_output_levels),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_filtered_input_files_in_output_level",
+         {offsetof(struct InternalStats::CompactionStats,
+                   num_filtered_input_files_in_output_level),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_output_files",
+         {offsetof(struct InternalStats::CompactionStats, num_output_files),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_output_files_blob",
+         {offsetof(struct InternalStats::CompactionStats,
+                   num_output_files_blob),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_input_records",
+         {offsetof(struct InternalStats::CompactionStats, num_input_records),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_dropped_records",
+         {offsetof(struct InternalStats::CompactionStats, num_dropped_records),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_output_records",
+         {offsetof(struct InternalStats::CompactionStats, num_output_records),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"count",
+         {offsetof(struct InternalStats::CompactionStats, count),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+};
+
+static std::unordered_map<std::string, OptionTypeInfo>
+    compaction_internal_stats_type_info = {
+        {"output_level_stats",
+         OptionTypeInfo::Struct(
+             "output_level_stats", &compaction_stats_type_info,
+             offsetof(struct InternalStats::CompactionStatsFull,
+                      output_level_stats),
+             OptionVerificationType::kNormal, OptionTypeFlags::kNone)},
+        {"has_proximal_level_output",
+         {offsetof(struct InternalStats::CompactionStatsFull,
+                   has_proximal_level_output),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"proximal_level_stats",
+         OptionTypeInfo::Struct(
+             "proximal_level_stats", &compaction_stats_type_info,
+             offsetof(struct InternalStats::CompactionStatsFull,
+                      proximal_level_stats),
+             OptionVerificationType::kNormal, OptionTypeFlags::kNone)},
+};
+
 namespace {
 // this is a helper struct to serialize and deserialize class Status, because
 // Status's members are not public.
@@ -830,6 +942,11 @@ static std::unordered_map<std::string, OptionTypeInfo> cs_result_type_info = {
                   "stats", &compaction_job_stats_type_info,
                   offsetof(struct CompactionServiceResult, stats),
                   OptionVerificationType::kNormal, OptionTypeFlags::kNone)},
+    {"internal_stats",
+     OptionTypeInfo::Struct(
+         "internal_stats", &compaction_internal_stats_type_info,
+         offsetof(struct CompactionServiceResult, internal_stats),
+         OptionVerificationType::kNormal, OptionTypeFlags::kNone)},
 };
 
 Status CompactionServiceInput::Read(const std::string& data_str,

--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -405,19 +405,12 @@ Status CompactionServiceCompactionJob::Run() {
   uint64_t num_input_range_del = 0;
   const bool ok = UpdateOutputLevelCompactionStats(&num_input_range_del);
   if (status.ok() && ok && job_stats_->has_num_input_records) {
-    // Consider verify record count optionally here
-    // This verification will be done on the primary side later before
-    // installation anyway, but in case we want to fail early
+    // TODO(jaykorean) - verify record count
     assert(job_stats_->num_input_records > 0);
   }
 
   // 3. Aggregate per-level stats into job-level stats and
   // set fields that are not propagated as part of the aggregation
-  //
-  // Please note that this step is done again on the primary side.
-  // Continuing to populate this for backward compatibility.
-  // Consider deprecating this from the compaction_result since this can be
-  // rebuilt from per-level stats on the primary side
   UpdateCompactionJobStats(internal_stats_);
   compaction_result_->stats.is_manual_compaction = c->is_manual_compaction();
   compaction_result_->stats.is_full_compaction = c->is_full_compaction();

--- a/db/compaction/compaction_state.cc
+++ b/db/compaction/compaction_state.cc
@@ -37,10 +37,10 @@ Slice CompactionState::LargestUserKey() {
 
 void CompactionState::AggregateCompactionStats(
     InternalStats::CompactionStatsFull& internal_stats,
-    CompactionJobStats& job_level_stats) {
+    CompactionJobStats& job_stats) {
   for (const auto& sc : sub_compact_states) {
     sc.AggregateCompactionOutputStats(internal_stats);
-    job_level_stats.Add(sc.compaction_job_stats);
+    job_stats.Add(sc.compaction_job_stats);
   }
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction_state.cc
+++ b/db/compaction/compaction_state.cc
@@ -36,11 +36,11 @@ Slice CompactionState::LargestUserKey() {
 }
 
 void CompactionState::AggregateCompactionStats(
-    InternalStats::CompactionStatsFull& compaction_stats,
-    CompactionJobStats& compaction_job_stats) {
+    InternalStats::CompactionStatsFull& internal_stats,
+    CompactionJobStats& job_level_stats) {
   for (const auto& sc : sub_compact_states) {
-    sc.AggregateCompactionOutputStats(compaction_stats);
-    compaction_job_stats.Add(sc.compaction_job_stats);
+    sc.AggregateCompactionOutputStats(internal_stats);
+    job_level_stats.Add(sc.compaction_job_stats);
   }
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction_state.h
+++ b/db/compaction/compaction_state.h
@@ -29,8 +29,8 @@ class CompactionState {
   Status status;
 
   void AggregateCompactionStats(
-      InternalStats::CompactionStatsFull& compaction_stats,
-      CompactionJobStats& compaction_job_stats);
+      InternalStats::CompactionStatsFull& internal_stats,
+      CompactionJobStats& job_level_stats);
 
   explicit CompactionState(Compaction* c) : compaction(c) {}
 

--- a/db/compaction/compaction_state.h
+++ b/db/compaction/compaction_state.h
@@ -30,7 +30,7 @@ class CompactionState {
 
   void AggregateCompactionStats(
       InternalStats::CompactionStatsFull& internal_stats,
-      CompactionJobStats& job_level_stats);
+      CompactionJobStats& job_stats);
 
   explicit CompactionState(Compaction* c) : compaction(c) {}
 

--- a/db/compaction/subcompaction_state.cc
+++ b/db/compaction/subcompaction_state.cc
@@ -14,7 +14,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 void SubcompactionState::AggregateCompactionOutputStats(
-    InternalStats::CompactionStatsFull& compaction_stats) const {
+    InternalStats::CompactionStatsFull& internal_stats) const {
   // Outputs should be closed. By extension, any files created just for
   // range deletes have already been written also.
   assert(compaction_outputs_.HasBuilder() == false);
@@ -26,10 +26,10 @@ void SubcompactionState::AggregateCompactionOutputStats(
   // assert(proximal_level_outputs_.stats_.num_output_files ==
   //        proximal_level_outputs_.outputs_.size());
 
-  compaction_stats.stats.Add(compaction_outputs_.stats_);
+  internal_stats.output_level_stats.Add(compaction_outputs_.stats_);
   if (proximal_level_outputs_.HasOutput()) {
-    compaction_stats.has_proximal_level_output = true;
-    compaction_stats.proximal_level_stats.Add(proximal_level_outputs_.stats_);
+    internal_stats.has_proximal_level_output = true;
+    internal_stats.proximal_level_stats.Add(proximal_level_outputs_.stats_);
   }
 }
 

--- a/db/compaction/subcompaction_state.h
+++ b/db/compaction/subcompaction_state.h
@@ -177,6 +177,16 @@ class SubcompactionState {
     return &compaction_outputs_;
   }
 
+  // Per-level stats for the output
+  InternalStats::CompactionStats* OutputStats(bool is_proximal_level) {
+    assert(compaction);
+    if (is_proximal_level) {
+      assert(compaction->SupportsPerKeyPlacement());
+      return &proximal_level_outputs_.stats_;
+    }
+    return &compaction_outputs_.stats_;
+  }
+
   CompactionRangeDelAggregator* RangeDelAgg() const {
     return range_del_agg_.get();
   }

--- a/db/compaction/subcompaction_state.h
+++ b/db/compaction/subcompaction_state.h
@@ -161,7 +161,7 @@ class SubcompactionState {
   void Cleanup(Cache* cache);
 
   void AggregateCompactionOutputStats(
-      InternalStats::CompactionStatsFull& compaction_stats) const;
+      InternalStats::CompactionStatsFull& internal_stats) const;
 
   CompactionOutputs& Current() const {
     assert(current_outputs_);

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -130,7 +130,7 @@ class TieredCompactionTest : public DBTestBase {
     ASSERT_EQ(stats.micros > 0, expect_stats.micros > 0);
     ASSERT_EQ(stats.cpu_micros > 0, expect_stats.cpu_micros > 0);
 
-    // FIXME: Changes to exact comparison
+    // FIXME: Change to exact value comparison
     ASSERT_EQ(stats.bytes_read_non_output_levels > 0,
               expect_stats.bytes_read_non_output_levels > 0);
     ASSERT_EQ(stats.bytes_read_output_level > 0,
@@ -140,7 +140,6 @@ class TieredCompactionTest : public DBTestBase {
     ASSERT_EQ(stats.bytes_read_blob > 0, expect_stats.bytes_read_blob > 0);
     ASSERT_EQ(stats.bytes_written > 0, expect_stats.bytes_written > 0);
 
-    // Exact Comparison
     ASSERT_EQ(stats.bytes_moved, expect_stats.bytes_moved);
     ASSERT_EQ(stats.num_input_files_in_non_output_levels,
               expect_stats.num_input_files_in_non_output_levels);
@@ -202,8 +201,8 @@ TEST_F(TieredCompactionTest, SequenceBasedTieredStorageUniversal) {
   InternalStats::CompactionStats expect_pl_stats;
 
   // Put keys in the following way to create overlaps
-  // First file from 0 ~ 100
-  // Second file from 10 ~ 110
+  // First file from 0 ~ 99
+  // Second file from 10 ~ 109
   // ...
   size_t bytes_per_file = 1952;
   int total_input_key_count = kNumTrigger * kNumKeys;
@@ -388,7 +387,7 @@ TEST_F(TieredCompactionTest, SequenceBasedTieredStorageUniversal) {
   ASSERT_GT(GetSstSizeHelper(Temperature::kUnknown), 0);
   ASSERT_GT(GetSstSizeHelper(Temperature::kCold), 0);
 
-  // Previous output + one delete rangei
+  // Previous output + one delete range
   total_input_key_count = total_output_key_count + 1;
   moved_to_last_level_key_count = 20;
 
@@ -1049,8 +1048,8 @@ TEST_F(TieredCompactionTest, SequenceBasedTieredStorageLevel) {
   InternalStats::CompactionStats expect_pl_stats;
 
   // Put keys in the following way to create overlaps
-  // First file from 0 ~ 100
-  // Second file from 10 ~ 110
+  // First file from 0 ~ 99
+  // Second file from 10 ~ 109
   // ...
   size_t bytes_per_file = 1952;
   int total_input_key_count = kNumTrigger * kNumKeys;

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -64,7 +64,7 @@ class TieredCompactionTest : public DBTestBase {
 
   InternalStats::CompactionStats kBasicCompStats;
   InternalStats::CompactionStats kBasicPerKeyPlacementCompStats;
-  InternalStats::CompactionOutputsStats kBasicPerLevelStats;
+  InternalStats::CompactionStats kBasicPerLevelStats;
   InternalStats::CompactionStats kBasicFlushStats;
 
   std::atomic_bool enable_per_key_placement = true;

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -153,23 +153,6 @@ class InternalStats {
 
   InternalStats(int num_levels, SystemClock* clock, ColumnFamilyData* cfd);
 
-  // Per level compaction stats
-  struct CompactionOutputsStats {
-    uint64_t num_output_records = 0;
-    uint64_t bytes_written = 0;
-    uint64_t bytes_written_blob = 0;
-    uint64_t num_output_files = 0;
-    uint64_t num_output_files_blob = 0;
-
-    void Add(const CompactionOutputsStats& stats) {
-      this->num_output_records += stats.num_output_records;
-      this->bytes_written += stats.bytes_written;
-      this->bytes_written_blob += stats.bytes_written_blob;
-      this->num_output_files += stats.num_output_files;
-      this->num_output_files_blob += stats.num_output_files_blob;
-    }
-  };
-
   // Per level compaction stats.  comp_stats_[level] stores the stats for
   // compactions that produced data for the specified "level".
   struct CompactionStats {
@@ -418,15 +401,6 @@ class InternalStats {
       for (int i = 0; i < num_of_reasons; i++) {
         counts[i] += c.counts[i];
       }
-    }
-
-    void Add(const CompactionOutputsStats& stats) {
-      this->num_output_files += static_cast<int>(stats.num_output_files);
-      this->num_output_records += stats.num_output_records;
-      this->bytes_written += stats.bytes_written;
-      this->bytes_written_blob += stats.bytes_written_blob;
-      this->num_output_files_blob +=
-          static_cast<int>(stats.num_output_files_blob);
     }
 
     void Subtract(const CompactionStats& c) {

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -473,23 +473,25 @@ class InternalStats {
     }
   };
 
-  // Compaction stats, for per_key_placement compaction, it includes 2 levels
-  // stats: the last level and the proximal level.
+  // Compaction internal stats, for per_key_placement compaction, it includes 2
+  // levels stats: the last level and the proximal level.
   struct CompactionStatsFull {
     // the stats for the target primary output level
-    CompactionStats stats;
+    CompactionStats output_level_stats;
 
     // stats for proximal level output if exist
     bool has_proximal_level_output = false;
     CompactionStats proximal_level_stats;
 
-    explicit CompactionStatsFull() : stats(), proximal_level_stats() {}
+    explicit CompactionStatsFull()
+        : output_level_stats(), proximal_level_stats() {}
 
     explicit CompactionStatsFull(CompactionReason reason, int c)
-        : stats(reason, c), proximal_level_stats(reason, c) {}
+        : output_level_stats(reason, c), proximal_level_stats(reason, c) {}
 
     uint64_t TotalBytesWritten() const {
-      uint64_t bytes_written = stats.bytes_written + stats.bytes_written_blob;
+      uint64_t bytes_written = output_level_stats.bytes_written +
+                               output_level_stats.bytes_written_blob;
       if (has_proximal_level_output) {
         bytes_written += proximal_level_stats.bytes_written +
                          proximal_level_stats.bytes_written_blob;
@@ -498,23 +500,23 @@ class InternalStats {
     }
 
     uint64_t DroppedRecords() {
-      uint64_t output_records = stats.num_output_records;
+      uint64_t output_records = output_level_stats.num_output_records;
       if (has_proximal_level_output) {
         output_records += proximal_level_stats.num_output_records;
       }
-      if (stats.num_input_records > output_records) {
-        return stats.num_input_records - output_records;
+      if (output_level_stats.num_input_records > output_records) {
+        return output_level_stats.num_input_records - output_records;
       }
       return 0;
     }
 
     void SetMicros(uint64_t val) {
-      stats.micros = val;
+      output_level_stats.micros = val;
       proximal_level_stats.micros = val;
     }
 
     void AddCpuMicros(uint64_t val) {
-      stats.cpu_micros += val;
+      output_level_stats.cpu_micros += val;
       proximal_level_stats.cpu_micros += val;
     }
   };
@@ -587,7 +589,7 @@ class InternalStats {
 
   void AddCompactionStats(int level, Env::Priority thread_pri,
                           const CompactionStatsFull& comp_stats_full) {
-    AddCompactionStats(level, thread_pri, comp_stats_full.stats);
+    AddCompactionStats(level, thread_pri, comp_stats_full.output_level_stats);
     if (comp_stats_full.has_proximal_level_output) {
       per_key_placement_comp_stats_.Add(comp_stats_full.proximal_level_stats);
     }

--- a/unreleased_history/bug_fixes/stats_fix_for_tiered_storage.md
+++ b/unreleased_history/bug_fixes/stats_fix_for_tiered_storage.md
@@ -1,0 +1,1 @@
+Fixed stats for Tiered Storage with preclude_last_level feature


### PR DESCRIPTION
# Summary

## Background

Compaction statistics are collected at various levels across different classes and structs.

* `InternalStats::CompactionStats`: Per-level Compaction Stats within a job (can be at subcompaction level which later get aggregated to the compaction level)
* `InternalStats::CompactionStatsFull`: Contains two per-level compaction stats - `output_level_stats` for primary output level stats and `proximal_level_stats` for proximal level stats. Proximal level statistics are only relevant when using Tiered Storage with the per-key placement feature enabled.
* `InternalStats::CompactionOutputsStats`: Simplified version of `InternalStats::CompactionStats`. Only has a subset of fields from `InternalStats::CompactionStats`
* `CompactionJobStats`: Job-level Compaction Stats. (can be at subcompaction level which later get aggregated to the compaction level)

Please note that some fields in Job-level stats are not in Per-level stats and they don't map 1-to-1 today.

## Issues

* In non-remote compactions, proximal level compaction statistics were not being aggregated into job-level statistics. Job level statistics were missing stats for proximal level for tiered storage compactions with per-key-replacement feature enabled.
* During remote compactions, proximal level compaction statistics were pre-aggregated into job-level statistics on the remote side. However, per-level compaction statistics were not part of the serialized compaction result, so that primary host lost that information and weren't able to populate `per_key_placement_comp_stats_` and `internal_stats_.proximal_level_stats` properly during the installation.
* `TieredCompactionTest` was only checking if (expected stats > 0 && actual stats > 0) instead actual value comparison

## Fixes

* Renamed `compaction_stats_` to `internal_stats_` for `InternalStats::CompactionStatsFull` in `CompactionJob` for better readability
* Removed the usage of `InternalStats::CompactionOutputsStats` and consolidated them to `InternalStats::CompactionStats`.
* Remote Compactions now include the internal stats in the serialized `CompactionServiceResult`. `output_level_stats` and `proximal_level_stats` get later propagated in sub_compact output stats accordingly.
* `CompactionJob::UpdateCompactionJobStats()` now takes `CompactionStatsFull` and aggregates the `proximal_level_stats` as well
* `TieredCompactionTest` is now doing the actual value comparisons for input/output file counts and record counts. Follow up is needed to do the same for the bytes read / written.

# Test Plan

Unit Tests updated to verify stats

```
./compaction_service_test
```
```
./tiered_compaction_test
```