### PR TITLE
Implement the DB::GetPropertiesOfTablesForLevels API

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4424,9 +4424,9 @@ Status DBImpl::GetPropertiesOfTablesInRange(ColumnFamilyHandle* column_family,
   return s;
 }
 
-Status DBImpl::GetPropertiesOfTablesForLevels(
+Status DBImpl::GetPropertiesOfTablesByLevel(
     ColumnFamilyHandle* column_family,
-    std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props) {
+    std::vector<std::unique_ptr<TablePropertiesCollection>>* props_by_level) {
   auto cfh = static_cast_with_check<ColumnFamilyHandleImpl>(column_family);
   auto cfd = cfh->cfd();
 
@@ -4437,7 +4437,7 @@ Status DBImpl::GetPropertiesOfTablesForLevels(
   mutex_.Unlock();
 
   const ReadOptions read_options;
-  auto s = version->GetPropertiesOfTablesForLevels(read_options, levels_props);
+  auto s = version->GetPropertiesOfTablesByLevel(read_options, props_by_level);
 
   // Decrement the ref count
   mutex_.Lock();

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4424,6 +4424,29 @@ Status DBImpl::GetPropertiesOfTablesInRange(ColumnFamilyHandle* column_family,
   return s;
 }
 
+Status DBImpl::GetPropertiesOfTablesForLevels(
+    ColumnFamilyHandle* column_family,
+    std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props) {
+  auto cfh = static_cast_with_check<ColumnFamilyHandleImpl>(column_family);
+  auto cfd = cfh->cfd();
+
+  // Increment the ref count
+  mutex_.Lock();
+  auto version = cfd->current();
+  version->Ref();
+  mutex_.Unlock();
+
+  const ReadOptions read_options;
+  auto s = version->GetPropertiesOfTablesForLevels(read_options, levels_props);
+
+  // Decrement the ref count
+  mutex_.Lock();
+  version->Unref();
+  mutex_.Unlock();
+
+  return s;
+}
+
 const std::string& DBImpl::GetName() const { return dbname_; }
 
 Env* DBImpl::GetEnv() const { return env_; }

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -651,9 +651,9 @@ class DBImpl : public DB {
       ColumnFamilyHandle* column_family, const Range* range, std::size_t n,
       TablePropertiesCollection* props) override;
 
-  Status GetPropertiesOfTablesForLevels(
+  Status GetPropertiesOfTablesByLevel(
       ColumnFamilyHandle* column_family,
-      std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props)
+      std::vector<std::unique_ptr<TablePropertiesCollection>>* props_by_level)
       override;
 
   // ---- End of implementations of the DB interface ----

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -651,6 +651,11 @@ class DBImpl : public DB {
       ColumnFamilyHandle* column_family, const Range* range, std::size_t n,
       TablePropertiesCollection* props) override;
 
+  Status GetPropertiesOfTablesForLevels(
+      ColumnFamilyHandle* column_family,
+      std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props)
+      override;
+
   // ---- End of implementations of the DB interface ----
   SystemClock* GetSystemClock() const;
 

--- a/db/db_table_properties_test.cc
+++ b/db/db_table_properties_test.cc
@@ -229,7 +229,7 @@ TEST_F(DBTablePropertiesTest, CreateOnDeletionCollectorFactory) {
   ASSERT_EQ(0.5, del_factory->GetDeletionRatio());
 }
 
-TEST_F(DBTablePropertiesTest, GetPropertiesOfTablesForLevelsTest) {
+TEST_F(DBTablePropertiesTest, GetPropertiesOfTablesByLevelTest) {
   Random rnd(202);
   Options options;
   options.level_compaction_dynamic_level_bytes = false;
@@ -268,8 +268,8 @@ TEST_F(DBTablePropertiesTest, GetPropertiesOfTablesForLevelsTest) {
   ColumnFamilyMetaData cf_meta;
   db_->GetColumnFamilyMetaData(&cf_meta);
   std::vector<std::unique_ptr<TablePropertiesCollection>> levels_props;
-  ASSERT_OK(db_->GetPropertiesOfTablesForLevels(db_->DefaultColumnFamily(),
-                                                &levels_props));
+  ASSERT_OK(db_->GetPropertiesOfTablesByLevel(db_->DefaultColumnFamily(),
+                                              &levels_props));
   for (int i = 0; i < 8; i++) {
     const std::unique_ptr<TablePropertiesCollection>& level_props =
         levels_props[i];

--- a/db/db_table_properties_test.cc
+++ b/db/db_table_properties_test.cc
@@ -229,6 +229,56 @@ TEST_F(DBTablePropertiesTest, CreateOnDeletionCollectorFactory) {
   ASSERT_EQ(0.5, del_factory->GetDeletionRatio());
 }
 
+TEST_F(DBTablePropertiesTest, GetPropertiesOfTablesForLevelsTest) {
+  Random rnd(202);
+  Options options;
+  options.level_compaction_dynamic_level_bytes = false;
+  options.create_if_missing = true;
+  options.write_buffer_size = 4096;
+  options.max_write_buffer_number = 2;
+  options.level0_file_num_compaction_trigger = 2;
+  options.level0_slowdown_writes_trigger = 2;
+  options.level0_stop_writes_trigger = 2;
+  options.target_file_size_base = 2048;
+  options.max_bytes_for_level_base = 40960;
+  options.max_bytes_for_level_multiplier = 4;
+  options.hard_pending_compaction_bytes_limit = 16 * 1024;
+  options.num_levels = 8;
+  options.env = env_;
+
+  DestroyAndReopen(options);
+
+  // build a decent LSM
+  for (int i = 0; i < 10000; i++) {
+    EXPECT_OK(Put(test::RandomKey(&rnd, 5), rnd.RandomString(102)));
+  }
+  ASSERT_OK(Flush());
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  if (NumTableFilesAtLevel(0) == 0) {
+    EXPECT_OK(Put(test::RandomKey(&rnd, 5), rnd.RandomString(102)));
+    ASSERT_OK(Flush());
+  }
+
+  ASSERT_OK(db_->PauseBackgroundWork());
+
+  // Ensure that we have at least L0, L1 and L2
+  ASSERT_GT(NumTableFilesAtLevel(0), 0);
+  ASSERT_GT(NumTableFilesAtLevel(1), 0);
+  ASSERT_GT(NumTableFilesAtLevel(2), 0);
+  ColumnFamilyMetaData cf_meta;
+  db_->GetColumnFamilyMetaData(&cf_meta);
+  std::vector<std::unique_ptr<TablePropertiesCollection>> levels_props;
+  ASSERT_OK(db_->GetPropertiesOfTablesForLevels(db_->DefaultColumnFamily(),
+                                                &levels_props));
+  for (int i = 0; i < 8; i++) {
+    const std::unique_ptr<TablePropertiesCollection>& level_props =
+        levels_props[i];
+    ASSERT_EQ(level_props->size(), cf_meta.levels[i].files.size());
+  }
+
+  Close();
+}
+
 // Test params:
 // 1) whether to enable user-defined timestamps
 class DBTablePropertiesInRangeTest : public DBTestBase,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3182,11 +3182,11 @@ class ModelDB : public DB {
     return Status();
   }
 
-  using DB::GetPropertiesOfTablesForLevels;
-  Status GetPropertiesOfTablesForLevels(
+  using DB::GetPropertiesOfTablesByLevel;
+  Status GetPropertiesOfTablesByLevel(
       ColumnFamilyHandle* /* column_family */,
       std::vector<
-          std::unique_ptr<TablePropertiesCollection>>* /* levels_props */)
+          std::unique_ptr<TablePropertiesCollection>>* /* props_by_level */)
       override {
     return Status();
   }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3182,6 +3182,15 @@ class ModelDB : public DB {
     return Status();
   }
 
+  using DB::GetPropertiesOfTablesForLevels;
+  Status GetPropertiesOfTablesForLevels(
+      ColumnFamilyHandle* /* column_family */,
+      std::vector<
+          std::unique_ptr<TablePropertiesCollection>>* /* levels_props */)
+      override {
+    return Status();
+  }
+
   using DB::KeyMayExist;
   bool KeyMayExist(const ReadOptions& /*options*/,
                    ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1753,16 +1753,16 @@ Status Version::GetPropertiesOfTablesInRange(
   return Status::OK();
 }
 
-Status Version::GetPropertiesOfTablesForLevels(
+Status Version::GetPropertiesOfTablesByLevel(
     const ReadOptions& read_options,
-    std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props)
+    std::vector<std::unique_ptr<TablePropertiesCollection>>* props_by_level)
     const {
   Status s;
 
-  levels_props->reserve(storage_info_.num_levels_);
+  props_by_level->reserve(storage_info_.num_levels_);
   for (int level = 0; level < storage_info_.num_levels_; level++) {
-    levels_props->push_back(std::make_unique<TablePropertiesCollection>());
-    s = GetPropertiesOfAllTables(read_options, levels_props->back().get(),
+    props_by_level->push_back(std::make_unique<TablePropertiesCollection>());
+    s = GetPropertiesOfAllTables(read_options, props_by_level->back().get(),
                                  level);
     if (!s.ok()) {
       return s;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1627,8 +1627,8 @@ Status Version::GetTableProperties(const ReadOptions& read_options,
   return s;
 }
 
-Status Version::GetPropertiesOfAllTables(const ReadOptions& read_options,
-                                         TablePropertiesCollection* props) {
+Status Version::GetPropertiesOfAllTables(
+    const ReadOptions& read_options, TablePropertiesCollection* props) const {
   Status s;
   for (int level = 0; level < storage_info_.num_levels_; level++) {
     s = GetPropertiesOfAllTables(read_options, props, level);
@@ -1699,7 +1699,7 @@ Status Version::TablesRangeTombstoneSummary(int max_entries_to_print,
 
 Status Version::GetPropertiesOfAllTables(const ReadOptions& read_options,
                                          TablePropertiesCollection* props,
-                                         int level) {
+                                         int level) const {
   for (const auto& file_meta : storage_info_.files_[level]) {
     auto fname =
         TableFileName(cfd_->ioptions().cf_paths, file_meta->fd.GetNumber(),
@@ -1750,6 +1750,24 @@ Status Version::GetPropertiesOfTablesInRange(
     }
   }
 
+  return Status::OK();
+}
+
+Status Version::GetPropertiesOfTablesForLevels(
+    const ReadOptions& read_options,
+    std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props)
+    const {
+  Status s;
+
+  levels_props->reserve(storage_info_.num_levels_);
+  for (int level = 0; level < storage_info_.num_levels_; level++) {
+    levels_props->push_back(std::make_unique<TablePropertiesCollection>());
+    s = GetPropertiesOfAllTables(read_options, levels_props->back().get(),
+                                 level);
+    if (!s.ok()) {
+      return s;
+    }
+  }
   return Status::OK();
 }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -994,17 +994,21 @@ class Version {
                             const FileMetaData* file_meta,
                             const std::string* fname = nullptr) const;
 
-  // REQUIRES: lock is held
   // On success, *props will be populated with all SSTables' table properties.
   // The keys of `props` are the sst file name, the values of `props` are the
   // tables' properties, represented as std::shared_ptr.
   Status GetPropertiesOfAllTables(const ReadOptions& read_options,
-                                  TablePropertiesCollection* props);
+                                  TablePropertiesCollection* props) const;
   Status GetPropertiesOfAllTables(const ReadOptions& read_options,
-                                  TablePropertiesCollection* props, int level);
+                                  TablePropertiesCollection* props,
+                                  int level) const;
   Status GetPropertiesOfTablesInRange(const ReadOptions& read_options,
                                       const autovector<UserKeyRange>& ranges,
                                       TablePropertiesCollection* props) const;
+  Status GetPropertiesOfTablesForLevels(
+      const ReadOptions& read_options,
+      std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props)
+      const;
 
   // Print summary of range delete tombstones in SST files into out_str,
   // with maximum max_entries_to_print entries printed out.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1005,9 +1005,9 @@ class Version {
   Status GetPropertiesOfTablesInRange(const ReadOptions& read_options,
                                       const autovector<UserKeyRange>& ranges,
                                       TablePropertiesCollection* props) const;
-  Status GetPropertiesOfTablesForLevels(
+  Status GetPropertiesOfTablesByLevel(
       const ReadOptions& read_options,
-      std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props)
+      std::vector<std::unique_ptr<TablePropertiesCollection>>* props_by_level)
       const;
 
   // Print summary of range delete tombstones in SST files into out_str,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -2103,11 +2103,11 @@ class DB {
       ColumnFamilyHandle* column_family, const Range* range, std::size_t n,
       TablePropertiesCollection* props) = 0;
 
-  // Get the table properties of files per level.
-  virtual Status GetPropertiesOfTablesForLevels(
+  // Get the table properties of files by level.
+  virtual Status GetPropertiesOfTablesByLevel(
       ColumnFamilyHandle* column_family,
       std::vector<std::unique_ptr<TablePropertiesCollection>>*
-          levels_props) = 0;
+          props_by_level) = 0;
 
   virtual Status SuggestCompactRange(ColumnFamilyHandle* /*column_family*/,
                                      const Slice* /*begin*/,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -2105,12 +2105,9 @@ class DB {
 
   // Get the table properties of files per level.
   virtual Status GetPropertiesOfTablesForLevels(
-      ColumnFamilyHandle* /* column_family */,
-      std::vector<
-          std::unique_ptr<TablePropertiesCollection>>* /* levels_props */) {
-    return Status::NotSupported(
-        "GetPropertiesOfTablesForLevels() is not implemented.");
-  }
+      ColumnFamilyHandle* column_family,
+      std::vector<std::unique_ptr<TablePropertiesCollection>>*
+          levels_props) = 0;
 
   virtual Status SuggestCompactRange(ColumnFamilyHandle* /*column_family*/,
                                      const Slice* /*begin*/,

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -554,12 +554,12 @@ class StackableDB : public DB {
     return db_->GetPropertiesOfTablesInRange(column_family, range, n, props);
   }
 
-  using DB::GetPropertiesOfTablesForLevels;
-  Status GetPropertiesOfTablesForLevels(
+  using DB::GetPropertiesOfTablesByLevel;
+  Status GetPropertiesOfTablesByLevel(
       ColumnFamilyHandle* column_family,
-      std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props)
+      std::vector<std::unique_ptr<TablePropertiesCollection>>* props_by_level)
       override {
-    return db_->GetPropertiesOfTablesForLevels(column_family, levels_props);
+    return db_->GetPropertiesOfTablesByLevel(column_family, props_by_level);
   }
 
   Status GetUpdatesSince(

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -554,6 +554,14 @@ class StackableDB : public DB {
     return db_->GetPropertiesOfTablesInRange(column_family, range, n, props);
   }
 
+  using DB::GetPropertiesOfTablesForLevels;
+  Status GetPropertiesOfTablesForLevels(
+      ColumnFamilyHandle* column_family,
+      std::vector<std::unique_ptr<TablePropertiesCollection>>* levels_props)
+      override {
+    return db_->GetPropertiesOfTablesForLevels(column_family, levels_props);
+  }
+
   Status GetUpdatesSince(
       SequenceNumber seq_number, std::unique_ptr<TransactionLogIterator>* iter,
       const TransactionLogIterator::ReadOptions& read_options) override {

--- a/unreleased_history/new_features/table_properties_for_levels.md
+++ b/unreleased_history/new_features/table_properties_for_levels.md
@@ -1,0 +1,1 @@
+Implemented API DB::GetPropertiesOfTablesForLevels that retrieves table properties for files in each LSM tree level

--- a/unreleased_history/new_features/table_properties_for_levels.md
+++ b/unreleased_history/new_features/table_properties_for_levels.md
@@ -1,1 +1,1 @@
-Implemented API DB::GetPropertiesOfTablesForLevels that retrieves table properties for files in each LSM tree level
+Implemented API DB::GetPropertiesOfTablesByLevel that retrieves table properties for files in each LSM tree level


### PR DESCRIPTION
As titled. This API returns the table properties of files per level. It can be handy for use cases that needed file's leveling info while retrieving TableProperties. We will use this API to later aggregate per level data write time info.

Test plan:
Added unit tests