### PR TITLE
[Remote Compaction] Fix CompactionStats when max_sub_compaction > 1

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -862,20 +862,16 @@ Status CompactionJob::Run() {
   bool ok = BuildStatsFromInputTableProperties(&num_input_range_del);
   // (Sub)compactions returned ok, do sanity check on the number of input
   // keys.
-  if (status.ok() && ok && job_stats_->has_num_input_records) {
-    status = VerifyInputRecordCount(num_input_range_del);
-    if (!status.ok()) {
-      ROCKS_LOG_WARN(
-          db_options_.info_log, "[%s] [JOB %d] Compaction with status: %s",
-          compact_->compaction->column_family_data()->GetName().c_str(),
-          job_context_->job_id, status.ToString().c_str());
+  if (status.ok() && ok) {
+    if (job_stats_->has_num_input_records) {
+      status = VerifyInputRecordCount(num_input_range_del);
+      if (!status.ok()) {
+        ROCKS_LOG_WARN(
+            db_options_.info_log, "[%s] [JOB %d] Compaction with status: %s",
+            compact_->compaction->column_family_data()->GetName().c_str(),
+            job_context_->job_id, status.ToString().c_str());
+      }
     }
-  }
-
-  // job_stats_ may not have accurate input records if
-  // compaction_iterator's must_count_input_entries is false. If that's the
-  // case, copy the stats from internal_stats_
-  if (job_stats_->has_num_input_records == false) {
     UpdateCompactionJobInputStats(internal_stats_, num_input_range_del);
   }
   UpdateCompactionJobOutputStats(internal_stats_);

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -858,47 +858,20 @@ Status CompactionJob::Run() {
   // Finish up all bookkeeping to unify the subcompaction results.
   compact_->AggregateCompactionStats(internal_stats_, *job_stats_);
 
-  // For remote compactions, internal_stats_.output_level_stats were part of the
-  // compaction_result already. No need to re-update it.
-  if (job_stats_->is_remote_compaction == false) {
-    uint64_t num_input_range_del = 0;
-    bool ok = UpdateOutputLevelCompactionStats(&num_input_range_del);
-    // (Sub)compactions returned ok, do sanity check on the number of input
-    // keys.
-    if (status.ok() && ok && job_stats_->has_num_input_records) {
-      size_t ts_sz = compact_->compaction->column_family_data()
-                         ->user_comparator()
-                         ->timestamp_size();
-      // When trim_ts_ is non-empty, CompactionIterator takes
-      // HistoryTrimmingIterator as input iterator and sees a trimmed view of
-      // input keys. So the number of keys it processed is not suitable for
-      // verification here.
-      // TODO: support verification when trim_ts_ is non-empty.
-      if (!(ts_sz > 0 && !trim_ts_.empty())) {
-        assert(internal_stats_.output_level_stats.num_input_records > 0);
-        // TODO: verify the number of range deletion entries.
-        uint64_t expected =
-            internal_stats_.output_level_stats.num_input_records -
-            num_input_range_del;
-        uint64_t actual = job_stats_->num_input_records;
-        if (expected != actual) {
-          char scratch[2345];
-          compact_->compaction->Summary(scratch, sizeof(scratch));
-          std::string msg =
-              "Compaction number of input keys does not match "
-              "number of keys processed. Expected " +
-              std::to_string(expected) + " but processed " +
-              std::to_string(actual) + ". Compaction summary: " + scratch;
-          ROCKS_LOG_WARN(
-              db_options_.info_log, "[%s] [JOB %d] Compaction with status: %s",
-              compact_->compaction->column_family_data()->GetName().c_str(),
-              job_context_->job_id, msg.c_str());
-          if (db_options_.compaction_verify_record_count) {
-            status = Status::Corruption(msg);
-          }
-        }
-      }
+  uint64_t num_input_range_del = 0;
+  bool ok = BuildStatsFromInputTableProperties(&num_input_range_del);
+  // (Sub)compactions returned ok, do sanity check on the number of input
+  // keys.
+  if (status.ok() && ok && job_stats_->has_num_input_records) {
+    status = VerifyInputRecordCount(num_input_range_del);
+    if (!status.ok()) {
+      ROCKS_LOG_WARN(
+          db_options_.info_log, "[%s] [JOB %d] Compaction with status: %s",
+          compact_->compaction->column_family_data()->GetName().c_str(),
+          job_context_->job_id, status.ToString().c_str());
     }
+    UpdateCompactionJobInputStats(internal_stats_, num_input_range_del);
+    UpdateCompactionJobOutputStats(internal_stats_);
   }
 
   // Verify number of output records
@@ -1042,7 +1015,6 @@ Status CompactionJob::Install(bool* compaction_released) {
                      internal_stats_.proximal_level_stats.num_output_records);
   }
 
-  UpdateCompactionJobStats(internal_stats_);
   TEST_SYNC_POINT_CALLBACK(
       "CompactionJob::Install:AfterUpdateCompactionJobStats", job_stats_);
 
@@ -2125,7 +2097,7 @@ void CopyPrefix(const Slice& src, size_t prefix_length, std::string* dst) {
 }
 }  // namespace
 
-bool CompactionJob::UpdateOutputLevelCompactionStats(
+bool CompactionJob::BuildStatsFromInputTableProperties(
     uint64_t* num_input_range_del) {
   assert(compact_);
 
@@ -2199,6 +2171,7 @@ bool CompactionJob::UpdateOutputLevelCompactionStats(
     }
   }
 
+  // TODO - find a better place to set these two
   assert(job_stats_);
   internal_stats_.output_level_stats.bytes_read_blob =
       job_stats_->total_blob_bytes_read;
@@ -2208,18 +2181,16 @@ bool CompactionJob::UpdateOutputLevelCompactionStats(
   return !has_error;
 }
 
-void CompactionJob::UpdateCompactionJobStats(
-    const InternalStats::CompactionStatsFull& internal_stats) const {
+void CompactionJob::UpdateCompactionJobInputStats(
+    const InternalStats::CompactionStatsFull& internal_stats,
+    uint64_t num_input_range_del) const {
   assert(job_stats_);
-  job_stats_->elapsed_micros = internal_stats.output_level_stats.micros;
-  job_stats_->cpu_micros = internal_stats.output_level_stats.cpu_micros;
-
   // input information
   job_stats_->total_input_bytes =
       internal_stats.output_level_stats.bytes_read_non_output_levels +
       internal_stats.output_level_stats.bytes_read_output_level;
   job_stats_->num_input_records =
-      internal_stats.output_level_stats.num_input_records;
+      internal_stats.output_level_stats.num_input_records - num_input_range_del;
   job_stats_->num_input_files =
       internal_stats.output_level_stats.num_input_files_in_non_output_levels +
       internal_stats.output_level_stats.num_input_files_in_output_level;
@@ -2237,19 +2208,6 @@ void CompactionJob::UpdateCompactionJobStats(
       internal_stats.output_level_stats.bytes_skipped_non_output_levels +
       internal_stats.output_level_stats.bytes_skipped_output_level;
 
-  // output information
-  job_stats_->total_output_bytes =
-      internal_stats.output_level_stats.bytes_written;
-  job_stats_->total_output_bytes_blob =
-      internal_stats.output_level_stats.bytes_written_blob;
-  job_stats_->num_output_records =
-      internal_stats.output_level_stats.num_output_records;
-  job_stats_->num_output_files =
-      internal_stats.output_level_stats.num_output_files;
-  job_stats_->num_output_files_blob =
-      internal_stats.output_level_stats.num_output_files_blob;
-
-  // If proximal level output exists
   if (internal_stats.has_proximal_level_output) {
     job_stats_->total_input_bytes +=
         internal_stats.proximal_level_stats.bytes_read_non_output_levels +
@@ -2273,7 +2231,28 @@ void CompactionJob::UpdateCompactionJobStats(
     job_stats_->total_skipped_input_bytes +=
         internal_stats.proximal_level_stats.bytes_skipped_non_output_levels +
         internal_stats.proximal_level_stats.bytes_skipped_output_level;
+  }
+}
 
+void CompactionJob::UpdateCompactionJobOutputStats(
+    const InternalStats::CompactionStatsFull& internal_stats) const {
+  assert(job_stats_);
+  job_stats_->elapsed_micros = internal_stats.output_level_stats.micros;
+  job_stats_->cpu_micros = internal_stats.output_level_stats.cpu_micros;
+
+  // output information
+  job_stats_->total_output_bytes =
+      internal_stats.output_level_stats.bytes_written;
+  job_stats_->total_output_bytes_blob =
+      internal_stats.output_level_stats.bytes_written_blob;
+  job_stats_->num_output_records =
+      internal_stats.output_level_stats.num_output_records;
+  job_stats_->num_output_files =
+      internal_stats.output_level_stats.num_output_files;
+  job_stats_->num_output_files_blob =
+      internal_stats.output_level_stats.num_output_files_blob;
+
+  if (internal_stats.has_proximal_level_output) {
     job_stats_->total_output_bytes +=
         internal_stats.proximal_level_stats.bytes_written;
     job_stats_->total_output_bytes_blob +=
@@ -2364,6 +2343,38 @@ Env::IOPriority CompactionJob::GetRateLimiterPriority() {
   }
 
   return Env::IO_LOW;
+}
+
+Status CompactionJob::VerifyInputRecordCount(
+    uint64_t num_input_range_del) const {
+  size_t ts_sz = compact_->compaction->column_family_data()
+                     ->user_comparator()
+                     ->timestamp_size();
+  // When trim_ts_ is non-empty, CompactionIterator takes
+  // HistoryTrimmingIterator as input iterator and sees a trimmed view of
+  // input keys. So the number of keys it processed is not suitable for
+  // verification here.
+  // TODO: support verification when trim_ts_ is non-empty.
+  if (!(ts_sz > 0 && !trim_ts_.empty())) {
+    assert(internal_stats_.output_level_stats.num_input_records > 0);
+    // TODO: verify the number of range deletion entries.
+    uint64_t expected = internal_stats_.output_level_stats.num_input_records -
+                        num_input_range_del;
+    uint64_t actual = job_stats_->num_input_records;
+    if (expected != actual) {
+      char scratch[2345];
+      compact_->compaction->Summary(scratch, sizeof(scratch));
+      std::string msg =
+          "Compaction number of input keys does not match "
+          "number of keys processed. Expected " +
+          std::to_string(expected) + " but processed " +
+          std::to_string(actual) + ". Compaction summary: " + scratch;
+      if (db_options_.compaction_verify_record_count) {
+        return Status::Corruption(msg);
+      }
+    }
+  }
+  return Status::OK();
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -196,24 +196,9 @@ class CompactionJob {
   IOStatus io_status() const { return io_status_; }
 
  protected:
-  // Update the following stats in internal_stats_.output_level_stats
-  // - num_input_files_in_non_output_levels
-  // - num_input_files_in_output_level
-  // - bytes_read_non_output_levels
-  // - bytes_read_output_level
-  // - num_input_records
-  // - bytes_read_blob
-  // - num_dropped_records
-  //
-  // @param num_input_range_del if non-null, will be set to the number of range
-  // deletion entries in this compaction input.
-  //
-  // Returns true iff internal_stats_.output_level_stats.num_input_records and
-  // num_input_range_del are calculated successfully.
-  bool UpdateOutputLevelCompactionStats(
-      uint64_t* num_input_range_del = nullptr);
-  void UpdateCompactionJobStats(
+  void UpdateCompactionJobOutputStats(
       const InternalStats::CompactionStatsFull& internal_stats) const;
+
   void LogCompaction();
   virtual void RecordCompactionIOStats();
   void CleanupCompaction();
@@ -239,6 +224,32 @@ class CompactionJob {
 
  private:
   friend class CompactionJobTestBase;
+
+  // Collect the following stats from Input Table Properties
+  // - num_input_files_in_non_output_levels
+  // - num_input_files_in_output_level
+  // - bytes_read_non_output_levels
+  // - bytes_read_output_level
+  // - num_input_records
+  // - bytes_read_blob
+  // - num_dropped_records
+  // and set them in internal_stats_.output_level_stats
+  //
+  // @param num_input_range_del if non-null, will be set to the number of range
+  // deletion entries in this compaction input.
+  //
+  // Returns true iff internal_stats_.output_level_stats.num_input_records and
+  // num_input_range_del are calculated successfully.
+  //
+  // This should be called only once for compactions (not per subcompaction)
+  bool BuildStatsFromInputTableProperties(
+      uint64_t* num_input_range_del = nullptr);
+
+  void UpdateCompactionJobInputStats(
+      const InternalStats::CompactionStatsFull& internal_stats,
+      uint64_t num_input_range_del) const;
+
+  Status VerifyInputRecordCount(uint64_t num_input_range_del) const;
 
   // Generates a histogram representing potential divisions of key ranges from
   // the input. It adds the starting and/or ending keys of certain input files

--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -394,29 +394,16 @@ Status CompactionServiceCompactionJob::Run() {
   // For remote compaction, there's only one subcompaction.
   compact_->AggregateCompactionStats(internal_stats_, *job_stats_);
 
-  // 2. Update the following stats in internal_stats_.output_level_stats
-  // - num_input_files_in_non_output_levels
-  // - num_input_files_in_output_level
-  // - bytes_read_non_output_levels
-  // - bytes_read_output_level
-  // - num_input_records
-  // - bytes_read_blob
-  // - num_dropped_records
-  uint64_t num_input_range_del = 0;
-  const bool ok = UpdateOutputLevelCompactionStats(&num_input_range_del);
-  if (status.ok() && ok && job_stats_->has_num_input_records) {
-    // TODO(jaykorean) - verify record count
-    assert(job_stats_->num_input_records > 0);
-  }
-
-  // 3. Update job-level stats with the aggregated internal_stats_
-  UpdateCompactionJobStats(internal_stats_);
+  // 2. Update job-level output stats with the aggregated internal_stats_
+  // Please note that input stats will be updated by primary host when all
+  // subcompactions are finished
+  UpdateCompactionJobOutputStats(internal_stats_);
   // and set fields that are not propagated as part of the update
   compaction_result_->stats.is_manual_compaction = c->is_manual_compaction();
   compaction_result_->stats.is_full_compaction = c->is_full_compaction();
   compaction_result_->stats.is_remote_compaction = true;
 
-  // 4. Update IO Stats that are not part of the the update above
+  // 3. Update IO Stats that are not part of the the update above
   // (bytes_read, bytes_written)
   RecordCompactionIOStats();
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -448,7 +448,7 @@ class InternalStats {
   };
 
   // Compaction internal stats, for per_key_placement compaction, it includes 2
-  // levels stats: the last level and the proximal level.
+  // output level stats: the last level and the proximal level.
   struct CompactionStatsFull {
     // the stats for the target primary output level
     CompactionStats output_level_stats;


### PR DESCRIPTION
# Summary

## Issue

Thanks to PRs #13455 and #13464 , we were able to find another issue with compaction stats.

When there are multiple sub-compactions and they are processed remotely, some compaction stats are not collected correctly.

Here's an example of how `num_input_records` can be double-counted during a compaction with multiple sub-compactions executed remotely. Please note that this problem is not limited to `num_input_records`.

Input File: 1 SST file with 100 keys.

- Key 1~50 are in one sub compaction
- Key 51~100 in another sub compaction

`UpdateOutputLevelCompactionStats()` currently retrieves the total number of entries from the input files and sets `num_input_records` in the internal_stats to 100. In `CompactionJob::Run()`, this method is called once after all sub-compactions have finished. However, during remote compaction, `UpdateOutputLevelCompactionStats()` is called for each offloaded sub-compaction on the remote side and then aggregated on the primary host. The internal_stats for the first sub-compaction will have 100 `num_input_records`, and the second sub-compaction will have another 100 `num_input_records`. We end up having 200 `num_input_records` in the aggregated internal_stats.

There was another issue that `num_input_record` was not properly excluding `num_input_range_del` in `UpdateCompactionJobStats()`. `job_stats_->num_input_record` originally has correct value set by compaction iterator, but then later overwritten in `UpdateCompactionJobStats()`. `UpdateCompactionJobStats()` was called during `CompactionJob::Install()`, so not caught by `VerifyInputRecordCount()`.

## Refactor and other changes before the fixes
* Renamed `UpdateOutputLevelCompactionStats()` to `BuildStatsFromInputTableProperties()` to make the function more descriptive. `BuildStatsFromInputTableProperties()` builds input stats by scanning through entries from TableProperties in the Input Files and it's at the top compaction level, not at the sub-compaction level. (It also updates a couple of non-input stats, `bytes_read_blob` and `num_dropped_records`, but will be refactored in a later PR.)
* `UpdateCompactionJobStats()` was moved from `CompactionJob::Install()` to `CompactionJob::Run()` and separated into `UpdateCompactionJobInputStats()` and `UpdateCompactionJobOutputStats()`.

## Fixes
* Remote Compaction no longer updates the subcompaction-job-level input stats from InputTableProperties to avoid double-counted stats in case of multiple sub-compactions. Subcompaction-job-level input stats are aggregated to the compaction-job-level input stats in the primary host after all sub-compactions are finished.
* Remote Compaction now only calls `UpdateCompactionJobOutputStats()` to update the job-level output stats by copying from internal stats.
* `UpdateCompactionJobInputStats()` now takes `num_input_range_del` and properly subtracts it from the input record count. `VerifyInputRecordCount()` expected `job_stats.num_input_records` to be equal to `internal_stats_.output_level_stats.num_input_records - num_input_range_del`. However, when updating the job-level stats, we were taking the entire `internal_stats_.output_level_stats.num_input_records` after verification.


# Test Plan
Local Compaction
```
./db_compaction_test -- --gtest_filter="*DBCompactionTest.VerifyRecordCount*"
```
Remote Compaction
```
./compaction_service_test --gtest_filter="*CompactionServiceTest.VerifyInputRecordCount*"
```