### PR TITLE
Control SST write lifetime hints based on compaction style

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -259,7 +259,8 @@ void CompactionJob::Prepare(
   assert(storage_info);
   assert(storage_info->NumLevelFiles(compact_->compaction->level()) > 0);
 
-  write_hint_ = storage_info->CalculateSSTWriteHint(c->output_level());
+  write_hint_ = storage_info->CalculateSSTWriteHint(
+      c->output_level(), db_options_.calculate_sst_write_lifetime_hint_bitmap);
   bottommost_level_ = c->bottommost_level();
 
   if (!known_single_subcompact.has_value() && c->ShouldFormSubcompactions()) {

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -260,7 +260,7 @@ void CompactionJob::Prepare(
   assert(storage_info->NumLevelFiles(compact_->compaction->level()) > 0);
 
   write_hint_ = storage_info->CalculateSSTWriteHint(
-      c->output_level(), db_options_.calculate_sst_write_lifetime_hint_bitmap);
+      c->output_level(), db_options_.calculate_sst_write_lifetime_hint_set);
   bottommost_level_ = c->bottommost_level();
 
   if (!known_single_subcompact.has_value() && c->ShouldFormSubcompactions()) {

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -2029,7 +2029,7 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
     {
       auto write_hint = cfd->current()->storage_info()->CalculateSSTWriteHint(
           /*level=*/0,
-          immutable_db_options_.calculate_sst_write_lifetime_hint_bitmap);
+          immutable_db_options_.calculate_sst_write_lifetime_hint_set);
       mutex_.Unlock();
 
       SequenceNumber earliest_write_conflict_snapshot;

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -2027,8 +2027,9 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
     meta.oldest_ancester_time = current_time;
     meta.epoch_number = cfd->NewEpochNumber();
     {
-      auto write_hint =
-          cfd->current()->storage_info()->CalculateSSTWriteHint(/*level=*/0);
+      auto write_hint = cfd->current()->storage_info()->CalculateSSTWriteHint(
+          /*level=*/0,
+          immutable_db_options_.calculate_sst_write_lifetime_hint_bitmap);
       mutex_.Unlock();
 
       SequenceNumber earliest_write_conflict_snapshot;

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -870,7 +870,8 @@ Status FlushJob::WriteLevel0Table() {
   std::vector<BlobFileAddition> blob_file_additions;
 
   {
-    auto write_hint = base_->storage_info()->CalculateSSTWriteHint(/*level=*/0);
+    auto write_hint = base_->storage_info()->CalculateSSTWriteHint(
+        /*level=*/0, db_options_.calculate_sst_write_lifetime_hint_bitmap);
     Env::IOPriority io_priority = GetRateLimiterPriority();
     db_mutex_->Unlock();
     if (log_buffer_) {

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -871,7 +871,7 @@ Status FlushJob::WriteLevel0Table() {
 
   {
     auto write_hint = base_->storage_info()->CalculateSSTWriteHint(
-        /*level=*/0, db_options_.calculate_sst_write_lifetime_hint_bitmap);
+        /*level=*/0, db_options_.calculate_sst_write_lifetime_hint_set);
     Env::IOPriority io_priority = GetRateLimiterPriority();
     db_mutex_->Unlock();
     if (log_buffer_) {

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -459,7 +459,7 @@ class Repairer {
       SnapshotChecker* snapshot_checker = DisableGCSnapshotChecker::Instance();
 
       auto write_hint = cfd->current()->storage_info()->CalculateSSTWriteHint(
-          /*level=*/0, db_options_.calculate_sst_write_lifetime_hint_bitmap);
+          /*level=*/0, db_options_.calculate_sst_write_lifetime_hint_set);
 
       std::vector<std::unique_ptr<FragmentedRangeTombstoneIterator>>
           range_del_iters;

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -458,8 +458,9 @@ class Repairer {
       meta.file_creation_time = current_time;
       SnapshotChecker* snapshot_checker = DisableGCSnapshotChecker::Instance();
 
-      auto write_hint =
-          cfd->current()->storage_info()->CalculateSSTWriteHint(/*level=*/0);
+      auto write_hint = cfd->current()->storage_info()->CalculateSSTWriteHint(
+          /*level=*/0, db_options_.calculate_sst_write_lifetime_hint_bitmap);
+
       std::vector<std::unique_ptr<FragmentedRangeTombstoneIterator>>
           range_del_iters;
       auto range_del_iter = mem->NewRangeTombstoneIterator(

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4903,8 +4903,14 @@ bool VersionStorageInfo::RangeMightExistAfterSortedRun(
 }
 
 Env::WriteLifeTimeHint VersionStorageInfo::CalculateSSTWriteHint(
-    int level) const {
-  if (compaction_style_ != kCompactionStyleLevel) {
+    int level, int compaction_style_bitmap) const {
+  if (compaction_style_ != kCompactionStyleLevel &&
+      compaction_style_ != kCompactionStyleUniversal) {
+    return Env::WLTH_NOT_SET;
+  }
+
+  // Conditionally support kCompactionStyleLevel and kCompactionStyleUniversal.
+  if ((compaction_style_bitmap & (1 << (int)compaction_style_)) == 0) {
     return Env::WLTH_NOT_SET;
   }
   if (level == 0) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4913,6 +4913,17 @@ Env::WriteLifeTimeHint VersionStorageInfo::CalculateSSTWriteHint(
   if ((compaction_style_bitmap & (1 << (int)compaction_style_)) == 0) {
     return Env::WLTH_NOT_SET;
   }
+
+  if (compaction_style_ == kCompactionStyleUniversal) {
+    if (level == 0) {
+      return Env::WLTH_SHORT;
+    }
+    if (level == 1) {
+      return Env::WLTH_MEDIUM;
+    }
+    return Env::WLTH_LONG;
+  }
+
   if (level == 0) {
     return Env::WLTH_MEDIUM;
   }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4903,14 +4903,14 @@ bool VersionStorageInfo::RangeMightExistAfterSortedRun(
 }
 
 Env::WriteLifeTimeHint VersionStorageInfo::CalculateSSTWriteHint(
-    int level, int compaction_style_bitmap) const {
+    int level, CompactionStyleSet compaction_style_set) const {
   if (compaction_style_ != kCompactionStyleLevel &&
       compaction_style_ != kCompactionStyleUniversal) {
     return Env::WLTH_NOT_SET;
   }
 
   // Conditionally support kCompactionStyleLevel and kCompactionStyleUniversal.
-  if ((compaction_style_bitmap & (1 << (int)compaction_style_)) == 0) {
+  if (!compaction_style_set.Contains(compaction_style_)) {
     return Env::WLTH_NOT_SET;
   }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -631,7 +631,7 @@ class VersionStorageInfo {
                                      int last_level, int last_l0_idx);
 
   Env::WriteLifeTimeHint CalculateSSTWriteHint(
-      int level, int compaction_style_bitmap) const;
+      int level, CompactionStyleSet compaction_style_set) const;
 
   const Comparator* user_comparator() const { return user_comparator_; }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -630,7 +630,8 @@ class VersionStorageInfo {
                                      const Slice& largest_user_key,
                                      int last_level, int last_l0_idx);
 
-  Env::WriteLifeTimeHint CalculateSSTWriteHint(int level) const;
+  Env::WriteLifeTimeHint CalculateSSTWriteHint(
+      int level, int compaction_style_bitmap) const;
 
   const Comparator* user_comparator() const { return user_comparator_; }
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -63,7 +63,7 @@ struct DbPath;
 
 using FileTypeSet = SmallEnumSet<FileType, FileType::kBlobFile>;
 using CompactionStyleSet =
-    SmallEnumSet<CompactionStyle, CompactionStyle::kCompactionStyleFIFO>;
+    SmallEnumSet<CompactionStyle, CompactionStyle::kCompactionStyleUniversal>;
 
 struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // The function recovers options to a previous version. Only 4.6 or later

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1620,6 +1620,30 @@ struct DBOptions {
   // `kUnknown`, this overrides any temperature set by OptimizeForLogWrite
   // functions.
   Temperature wal_write_temperature = Temperature::kUnknown;
+
+  // Bitmap indicative of which compaction styles SST write lifetime hint
+  // calculation is allowed on. Today, RocksDB provides native support for
+  // kCompactionStyleLevel and kCompactionStyleUniversal (experimental version).
+  // Other compaction styles, even when enabled in the bitmap, won't have any
+  // effect in the default PosixWritableFile file implementation.
+  //
+  // Bits in the map reflect the natural order of CompactionStyle enum members:
+  //
+  //  Bit 0: kCompactionStyleLevel
+  //  Bit 1: kCompactionStyleUniversal
+  //  Bit 2: kCompactionStyleFIFO
+  //
+  // The are numerous benefits coming from employing the hints including
+  // reduction in write amplification caused by OS file movement during
+  // garbage collection, reduction in wear-leveling (SSDs), etc. However,
+  // as currently implemented, SST write lifetime hints are calculated in a
+  // static way and solely based on the level, which might not be suitable for
+  // non-uniform workloads with dynamic / high-variance lifespan of data across
+  // the levels. In those cases (or when the performance is not satisfactory),
+  // it's recommended to disable the hints by setting the bitmap to 0.
+  //
+  // Default: 1 (kCompactionStyleLevel)
+  int calculate_sst_write_lifetime_hint_bitmap = 1 << kCompactionStyleLevel;
   // End EXPERIMENTAL
 };
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -63,7 +63,7 @@ struct DbPath;
 
 using FileTypeSet = SmallEnumSet<FileType, FileType::kBlobFile>;
 using CompactionStyleSet =
-    SmallEnumSet<CompactionStyle, CompactionStyle::kCompactionStyleFIFO>;
+    SmallEnumSet<CompactionStyle, CompactionStyle::kCompactionStyleNone>;
 
 struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // The function recovers options to a previous version. Only 4.6 or later

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -63,7 +63,7 @@ struct DbPath;
 
 using FileTypeSet = SmallEnumSet<FileType, FileType::kBlobFile>;
 using CompactionStyleSet =
-    SmallEnumSet<CompactionStyle, CompactionStyle::kCompactionStyleUniversal>;
+    SmallEnumSet<CompactionStyle, CompactionStyle::kCompactionStyleFIFO>;
 
 struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // The function recovers options to a previous version. Only 4.6 or later

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -141,6 +141,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
           std::shared_ptr<Statistics> statistics;
           std::vector<DbPath> db_paths;
           FileTypeSet checksum_handoff_file_types;
+          CompactionStyleSet calculate_sst_write_lifetime_hint_set;
          */
         {"advise_random_on_open",
          {offsetof(struct ImmutableDBOptions, advise_random_on_open),
@@ -595,11 +596,6 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableDBOptions, wal_write_temperature),
           OptionType::kTemperature, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
-        {"calculate_sst_write_lifetime_hint_bitmap",
-         {offsetof(struct ImmutableDBOptions,
-                   calculate_sst_write_lifetime_hint_bitmap),
-          OptionType::kInt, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone}},
 };
 
 const std::string OptionsHelper::kDBOptionsName = "DBOptions";
@@ -807,8 +803,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       follower_catchup_retry_wait_ms(options.follower_catchup_retry_wait_ms),
       metadata_write_temperature(options.metadata_write_temperature),
       wal_write_temperature(options.wal_write_temperature),
-      calculate_sst_write_lifetime_hint_bitmap(
-          options.calculate_sst_write_lifetime_hint_bitmap) {
+      calculate_sst_write_lifetime_hint_set(
+          options.calculate_sst_write_lifetime_hint_set) {
   fs = env->GetFileSystem();
   clock = env->GetSystemClock().get();
   logger = info_log.get();
@@ -994,10 +990,6 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    temperature_to_string[metadata_write_temperature].c_str());
   ROCKS_LOG_HEADER(log, "            Options.wal_write_temperature: %s",
                    temperature_to_string[wal_write_temperature].c_str());
-  ROCKS_LOG_HEADER(
-      log,
-      "                Options.calculate_sst_write_lifetime_hint_bitmap: %d",
-      calculate_sst_write_lifetime_hint_bitmap);
 }
 
 bool ImmutableDBOptions::IsWalDirSameAsDBPath() const {

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -595,6 +595,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableDBOptions, wal_write_temperature),
           OptionType::kTemperature, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"calculate_sst_write_lifetime_hint_bitmap",
+         {offsetof(struct ImmutableDBOptions,
+                   calculate_sst_write_lifetime_hint_bitmap),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
 };
 
 const std::string OptionsHelper::kDBOptionsName = "DBOptions";
@@ -801,7 +806,9 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       follower_catchup_retry_count(options.follower_catchup_retry_count),
       follower_catchup_retry_wait_ms(options.follower_catchup_retry_wait_ms),
       metadata_write_temperature(options.metadata_write_temperature),
-      wal_write_temperature(options.wal_write_temperature) {
+      wal_write_temperature(options.wal_write_temperature),
+      calculate_sst_write_lifetime_hint_bitmap(
+          options.calculate_sst_write_lifetime_hint_bitmap) {
   fs = env->GetFileSystem();
   clock = env->GetSystemClock().get();
   logger = info_log.get();
@@ -987,6 +994,10 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    temperature_to_string[metadata_write_temperature].c_str());
   ROCKS_LOG_HEADER(log, "            Options.wal_write_temperature: %s",
                    temperature_to_string[wal_write_temperature].c_str());
+  ROCKS_LOG_HEADER(
+      log,
+      "                Options.calculate_sst_write_lifetime_hint_bitmap: %d",
+      calculate_sst_write_lifetime_hint_bitmap);
 }
 
 bool ImmutableDBOptions::IsWalDirSameAsDBPath() const {

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -107,6 +107,7 @@ struct ImmutableDBOptions {
   uint64_t follower_catchup_retry_wait_ms;
   Temperature metadata_write_temperature;
   Temperature wal_write_temperature;
+  int calculate_sst_write_lifetime_hint_bitmap;
 
   // Beginning convenience/helper objects that are not part of the base
   // DBOptions

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -107,7 +107,7 @@ struct ImmutableDBOptions {
   uint64_t follower_catchup_retry_wait_ms;
   Temperature metadata_write_temperature;
   Temperature wal_write_temperature;
-  int calculate_sst_write_lifetime_hint_bitmap;
+  CompactionStyleSet calculate_sst_write_lifetime_hint_set;
 
   // Beginning convenience/helper objects that are not part of the base
   // DBOptions

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -199,8 +199,8 @@ void BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.metadata_write_temperature;
   options.wal_write_temperature = immutable_db_options.wal_write_temperature;
   options.compaction_service = immutable_db_options.compaction_service;
-  options.calculate_sst_write_lifetime_hint_bitmap =
-      immutable_db_options.calculate_sst_write_lifetime_hint_bitmap;
+  options.calculate_sst_write_lifetime_hint_set =
+      immutable_db_options.calculate_sst_write_lifetime_hint_set;
 }
 
 ColumnFamilyOptions BuildColumnFamilyOptions(

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -199,6 +199,8 @@ void BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.metadata_write_temperature;
   options.wal_write_temperature = immutable_db_options.wal_write_temperature;
   options.compaction_service = immutable_db_options.compaction_service;
+  options.calculate_sst_write_lifetime_hint_bitmap =
+      immutable_db_options.calculate_sst_write_lifetime_hint_bitmap;
 }
 
 ColumnFamilyOptions BuildColumnFamilyOptions(

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -472,7 +472,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "write_dbid_to_manifest=true;"
                              "write_identity_file=true;"
                              "prefix_seek_opt_in_only=true;"
-                             "calculate_sst_write_lifetime_hint_bitmap=1;",
+                             "calculate_sst_write_lifetime_hint_set=1;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -471,7 +471,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "background_close_inactive_wals=true;"
                              "write_dbid_to_manifest=true;"
                              "write_identity_file=true;"
-                             "prefix_seek_opt_in_only=true;",
+                             "prefix_seek_opt_in_only=true;"
+                             "calculate_sst_write_lifetime_hint_bitmap=1;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -342,6 +342,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       {offsetof(struct DBOptions, compaction_service),
        sizeof(std::shared_ptr<CompactionService>)},
       {offsetof(struct DBOptions, daily_offpeak_time_utc), sizeof(std::string)},
+      {offsetof(struct DBOptions, calculate_sst_write_lifetime_hint_set),
+       sizeof(CompactionStyleSet)},
   };
 
   char* options_ptr = new char[sizeof(DBOptions)];
@@ -471,8 +473,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "background_close_inactive_wals=true;"
                              "write_dbid_to_manifest=true;"
                              "write_identity_file=true;"
-                             "prefix_seek_opt_in_only=true;"
-                             "calculate_sst_write_lifetime_hint_set=1;",
+                             "prefix_seek_opt_in_only=true;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/unreleased_history/new_features/calculate_sst_write_lifetime_hint_set.md
+++ b/unreleased_history/new_features/calculate_sst_write_lifetime_hint_set.md
@@ -1,0 +1,1 @@
+Added a new `DBOptions.calculate_sst_write_lifetime_hint_set` setting that allows to customize which compaction styles SST write lifetime hint calculation is allowed on. Today RocksDB supports only two modes `kCompactionStyleLevel` and `kCompactionStyleUniversal`.


### PR DESCRIPTION
This PR is a followup to https://github.com/facebook/rocksdb/pull/13461. We're introducing an experimental option / killswitch to control SST write lifetime hint calculation based on the selected compaction style. By default (and mostly for backwards compatibility reasons), we'll calculate the SST hints only for level compactions. With this change users have an option to configure SST lifetime hint policy in their environments to enable the calculations in the universal compaction mode as well. It's important to underline that as currently implemented, SST write lifetime hints are calculated in a static way and solely based on the level, which might not be suitable for non-uniform workloads with dynamic / high-variance lifespan of data within the same level. In those cases (or when the performance is not satisfactory), it's recommended to disable the hints by setting the set to empty. Please see the comment in `options.h` for more.

**NOTE:** We deliberately decided to introduce a new option to ensure no impact to external users running their RocksDB instances on local flash with the default `PosixWritableFile` file implementation.