### PR TITLE
Skip VerifyOutputRecordCount() if internal_stats_ is empty for remote compactions

### DIFF
--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -250,6 +250,7 @@ class CompactionJob {
       uint64_t num_input_range_del) const;
 
   Status VerifyInputRecordCount(uint64_t num_input_range_del) const;
+  Status VerifyOutputRecordCount() const;
 
   // Generates a histogram representing potential divisions of key ranges from
   // the input. It adds the starting and/or ending keys of certain input files


### PR DESCRIPTION
# Summary
With PR #13455 , we start to verify the output record count by comparing internal compaction stats against table properties read from compaction outputs. However, for the remote compactions, this internal compaction stats were missing in previous releases and recently added in PR #13464. Unless remote worker gets the change before the primary host, `VerifyOutputRecordCount()` will fail for all remote compactions. If `internal_stats_.output_level_stats.num_output_records` is 0 and `job_stats->is_remote_compaction` is true, assume that the remote worker does not have the fix yet and allow the difference temporarily.

# Test Plan

Existing tests are passing
```
./compaction_service_test  
```

Verified manually in Meta Internal Infra