### PR TITLE
Fix uninitialized use in WBWIMemTable::Get

### DIFF
--- a/memtable/wbwi_memtable.cc
+++ b/memtable/wbwi_memtable.cc
@@ -61,6 +61,7 @@ bool WBWIMemTable::Get(const LookupKey& key, std::string* value,
   assert(!wbwi_->GetWriteBatch()->HasDeleteRange());
   assert(merge_context);
 
+  *out_seq = kMaxSequenceNumber;
   [[maybe_unused]] SequenceNumber read_seq =
       GetInternalKeySeqno(key.internal_key());
   // This is memtable is a single write batch, no snapshot can be taken within


### PR DESCRIPTION
Summary: Based on passing address of uninit variable in ReadOnlyMemTable::Get() in memtable.h. The contract and other implementations suggest it is a pure out parameter that is always overwritten, so we initialize it in the function before checking its value in a loop

Test Plan: watch build-linux-valgrind in CI