### PR TITLE
Added 128B alignment to memory blocks in arena.cc

### DIFF
--- a/memory/arena.cc
+++ b/memory/arena.cc
@@ -143,9 +143,16 @@ char* Arena::AllocateAligned(size_t bytes, size_t huge_page_size,
 }
 
 char* Arena::AllocateNewBlock(size_t block_bytes) {
+#if _POSIX_C_SOURCE >= 200112L
+  char* block = NULL;
+  if (posix_memalign((void**)&block, 128, block_bytes) != 0) {
+    exit(1);
+  }
+#else
+  char* block = new char[block_bytes];
+#endif
   // NOTE: std::make_unique zero-initializes the block so is not appropriate
   // here
-  char* block = new char[block_bytes];
   blocks_.push_back(std::unique_ptr<char[]>(block));
 
   size_t allocated_size;


### PR DESCRIPTION
Aligning memory block allocations to a 128B boundary improves throughput for in-memory runs of `db_bench` using the InlineSkipList. The following is a possible set of parameters for `db_bench` with which I've observed a throughput increase of up to 5%:

`numactl -i 0 taskset -c 0-17,72-89 ./db_bench --use_existing_db=0 --benchmarks=filluniquerandom,readwhilewriting --key_size=128 --prefix_size=128 --value_size=1024 --use_plain_table=1 --memtablerep=skip_list --max_write_buffer_number=2 --write_buffer_size=49928994816 --disable_auto_compactions=true --num=10000000 --threads=35 --allow_concurrent_memtable_write=false --disable_wal=1 --sync=0`

(Note: varying the key/value sizes changes the level of improvement, but I have never observed the average throughput over 10 runs decrease when using aligned block allocations.)

For reference, I was running this on an Intel Xeon Gold 5220 CPU @ 2.20GHz with 187GB main memory.

I am still investigating the reason for the increased throughput with this change; there appears to be a small drop (1-2%) in L3 cache misses per operation using aligned allocations, but probably not enough to explain the magnitude of the throughput increase. I am curious to see if others also see improvements in throughput with this change.

The change was motivated by noticing a property of the memory layout when using the HashSkipList: in this case, key/value pairs are allocated contiguously within the memtable. When memory blocks are not aligned, this can result in a bunch of memtable entries crossing cache lines more often than necessary. By aligning memory blocks to 128B (and padding the length of memtable entries to the nearest multiple of the cache line size [here](https://github.com/facebook/rocksdb/blob/main/db/memtable.cc#L924)), you can get a modest (1-2%) throughput increase in runs of `db_bench` such as the one above (except using `hash_pref` instead of `skip_list`). Incidentally, aligning memory block allocations also seems to improve performance when using the InlineSkipList a little bit.