### PR TITLE
Fix WriteBatch atomicity and WAL recovery for some failures

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2361,7 +2361,7 @@ class DBImpl : public DB {
   void WALIOStatusCheck(const IOStatus& status);
 
   // Used by WriteImpl to update bg_error_ in case of memtable insert error.
-  void MemTableInsertStatusCheck(const Status& memtable_insert_status);
+  void HandleMemTableInsertFailure(const Status& nonok_memtable_insert_status);
 
   Status CompactFilesImpl(const CompactionOptions& compact_options,
                           ColumnFamilyData* cfd, Version* version,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1781,6 +1781,13 @@ class DBImpl : public DB {
       if (writer->file()) {
         // TODO: plumb Env::IOActivity, Env::IOPriority
         s = writer->WriteBuffer(WriteOptions());
+        if (attempt_truncate_size < SIZE_MAX &&
+            attempt_truncate_size < writer->file()->GetFileSize()) {
+          Status s2 = writer->file()->writable_file()->Truncate(
+              attempt_truncate_size, IOOptions{}, nullptr);
+          // This is just a best effort attempt
+          s2.PermitUncheckedError();
+        }
       }
       delete writer;
       writer = nullptr;
@@ -1813,6 +1820,11 @@ class DBImpl : public DB {
       getting_synced = false;
     }
 
+    void SetAttemptTruncateSize(uint64_t size) {
+      assert(attempt_truncate_size == SIZE_MAX);
+      attempt_truncate_size = size;
+    }
+
     uint64_t number;
     // Visual Studio doesn't support deque's member to be noncopyable because
     // of a std::unique_ptr as a member.
@@ -1825,6 +1837,10 @@ class DBImpl : public DB {
     // to be persisted even if appends happen during sync so it can be used for
     // tracking the synced size in MANIFEST.
     uint64_t pre_sync_size = 0;
+    // When < SIZE_MAX, attempt to truncate the WAL to this size on close,
+    // because a bad entry was written to it beyond that point and it likely
+    // won't be recoverable with the bad entry.
+    uint64_t attempt_truncate_size = SIZE_MAX;
   };
 
   struct LogContext {
@@ -1834,6 +1850,7 @@ class DBImpl : public DB {
     bool need_log_dir_sync = false;
     log::Writer* writer = nullptr;
     LogFileNumberSize* log_file_number_size = nullptr;
+    uint64_t prev_size = SIZE_MAX;
   };
 
   // PurgeFileInfo is a structure to hold information of files to be deleted in

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -1341,9 +1341,8 @@ INSTANTIATE_TEST_CASE_P(PlainTableDBTest, PlainTableDBTest, ::testing::Bool());
 TEST_P(PlainTableDBTest, DeleteRangeNotSupported) {
   // XXX: After attempting DeleteRange with PlainTable, Writes will permanently
   // fail. Even if re-opening the DB, if WAL is used, the WAL is not recoverable
-  // (without manual intervention). Furthermore, a partial write batch can
-  // be exposed to readers, breaking WriteBatch atomicity.
-  for (bool use_write_batch : {/*false, */ true}) {
+  // (without manual intervention).
+  for (bool use_write_batch : {false, true}) {
     DestroyAndReopen();
 
     ASSERT_OK(Put("a0001111", "1"));
@@ -1362,12 +1361,7 @@ TEST_P(PlainTableDBTest, DeleteRangeNotSupported) {
     ASSERT_EQ(Get("a0001111"), "1");
     ASSERT_EQ(Get("b0001111"), "2");
     ASSERT_EQ(Get("c0001111"), "3");
-    if (use_write_batch) {
-      // XXX: broken WriteBatch atomicity
-      ASSERT_EQ(Get("d0001111"), "4");
-    } else {
-      ASSERT_EQ(Get("d0001111"), "NOT_FOUND");
-    }
+    ASSERT_EQ(Get("d0001111"), "NOT_FOUND");
     ASSERT_EQ(Get("e0001111"), "NOT_FOUND");
 
     ASSERT_EQ(Put("e0001111", "5").code(), Status::Code::kNotSupported);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -616,7 +616,7 @@ class DB {
                        const Slice& /*key*/, const Slice& /*ts*/,
                        const Slice& /*value*/);
 
-  // Apply the specified updates to the database.
+  // Apply the specified updates atomically to the database.
   // If `updates` contains no update, WAL will still be synced if
   // options.sync=true.
   // Returns OK on success, non-OK on failure.


### PR DESCRIPTION
Summary: Essentially fix #13429 by
* Avoiding publishing to readers a partial write batch written to memtable. Also clarify in DB::Write that WriteBatch is applied atomically, and improve some logging.
* When we know we have written a bad write batch to WAL due to memtable insert failure, make a good effort to roll it back to make the DB recoverable. (Not compatible with all options.)

Fixes #13429

Follow-up items:
* More rigorously test and fix the code paths and option combinations where these features could be useful.
* Allow default CF with disallow_memtable_writes (with caveat that violation stops writes on your open DB)

Test Plan: Updated existing test, manually verified the DB went into a "stopped" state at least in this example.