### PR TITLE
Check for yields while waiting for lock in a loop

### DIFF
--- a/utilities/transactions/lock/point/point_lock_manager.cc
+++ b/utilities/transactions/lock/point/point_lock_manager.cc
@@ -320,7 +320,7 @@ Status PointLockManager::AcquireWithTimeout(
         if (static_cast<uint64_t>(cv_end_time) > now) {
           // This may be invoked multiple times since we divide
           // the time into smaller intervals.
-          (void) ROCKSDB_THREAD_YIELD_CHECK_ABORT();
+          (void)ROCKSDB_THREAD_YIELD_CHECK_ABORT();
           result = stripe->stripe_cv->WaitFor(stripe->stripe_mutex,
                                               cv_end_time - now);
         }

--- a/utilities/transactions/lock/point/point_lock_manager.cc
+++ b/utilities/transactions/lock/point/point_lock_manager.cc
@@ -318,6 +318,9 @@ Status PointLockManager::AcquireWithTimeout(
       } else {
         uint64_t now = env->NowMicros();
         if (static_cast<uint64_t>(cv_end_time) > now) {
+          // This may be invoked multiple times since we divide
+          // the time into smaller intervals.
+          (void) ROCKSDB_THREAD_YIELD_CHECK_ABORT();
           result = stripe->stripe_cv->WaitFor(stripe->stripe_mutex,
                                               cv_end_time - now);
         }


### PR DESCRIPTION
Acquiring a lock here can take a long time and cause a user mode scheduler to hold up, as it relies on explicit yielding. Hence, forcing a check here but ignoring any abort requests. Would rely on upstream to take action on aborts.