### PR TITLE
More separation of txn_write_policy for crash tests

### DIFF
--- a/crash_test.mk
+++ b/crash_test.mk
@@ -11,18 +11,29 @@ CRASHTEST_MAKE=$(MAKE) -f crash_test.mk
 CRASHTEST_PY=$(PYTHON) -u tools/db_crashtest.py --stress_cmd=$(DB_STRESS_CMD) --cleanup_cmd='$(DB_CLEANUP_CMD)'
 
 .PHONY: crash_test crash_test_with_atomic_flush crash_test_with_txn \
+	crash_test_with_wc_txn crash_test_with_wp_txn crash_test_with_wup_txn \
 	crash_test_with_best_efforts_recovery crash_test_with_ts \
+	crash_test_with_multiops_wc_txn \
+	crash_test_with_multiops_wp_txn \
+	crash_test_with_multiops_wup_txn \
+	crash_test_with_optimistic_txn \
+	crash_test_with_tiered_storage \
 	blackbox_crash_test blackbox_crash_test_with_atomic_flush \
+	blackbox_crash_test_with_wc_txn blackbox_crash_test_with_wp_txn \
+	blackbox_crash_test_with_wup_txn \
 	blackbox_crash_test_with_txn blackbox_crash_test_with_ts \
 	blackbox_crash_test_with_best_efforts_recovery \
-	whitebox_crash_test whitebox_crash_test_with_atomic_flush \
-	whitebox_crash_test_with_txn whitebox_crash_test_with_ts \
 	blackbox_crash_test_with_multiops_wc_txn \
 	blackbox_crash_test_with_multiops_wp_txn \
-	crash_test_with_tiered_storage blackbox_crash_test_with_tiered_storage \
-	whitebox_crash_test_with_tiered_storage \
-	whitebox_crash_test_with_optimistic_txn \
+	blackbox_crash_test_with_multiops_wup_txn \
 	blackbox_crash_test_with_optimistic_txn \
+	blackbox_crash_test_with_tiered_storage \
+	whitebox_crash_test whitebox_crash_test_with_atomic_flush \
+	whitebox_crash_test_with_wc_txn whitebox_crash_test_with_wp_txn \
+	whitebox_crash_test_with_wup_txn \
+	whitebox_crash_test_with_txn whitebox_crash_test_with_ts \
+	whitebox_crash_test_with_optimistic_txn \
+	whitebox_crash_test_with_tiered_storage \
 
 crash_test: $(DB_STRESS_CMD)
 # Do not parallelize
@@ -34,10 +45,20 @@ crash_test_with_atomic_flush: $(DB_STRESS_CMD)
 	$(CRASHTEST_MAKE) whitebox_crash_test_with_atomic_flush
 	$(CRASHTEST_MAKE) blackbox_crash_test_with_atomic_flush
 
-crash_test_with_txn: $(DB_STRESS_CMD)
+crash_test_with_wc_txn: $(DB_STRESS_CMD)
 # Do not parallelize
-	$(CRASHTEST_MAKE) whitebox_crash_test_with_txn
-	$(CRASHTEST_MAKE) blackbox_crash_test_with_txn
+	$(CRASHTEST_MAKE) whitebox_crash_test_with_wc_txn
+	$(CRASHTEST_MAKE) blackbox_crash_test_with_wc_txn
+
+crash_test_with_wp_txn: $(DB_STRESS_CMD)
+# Do not parallelize
+	$(CRASHTEST_MAKE) whitebox_crash_test_with_wp_txn
+	$(CRASHTEST_MAKE) blackbox_crash_test_with_wp_txn
+
+crash_test_with_wup_txn: $(DB_STRESS_CMD)
+# Do not parallelize
+	$(CRASHTEST_MAKE) whitebox_crash_test_with_wup_txn
+	$(CRASHTEST_MAKE) blackbox_crash_test_with_wup_txn
 
 crash_test_with_optimistic_txn: $(DB_STRESS_CMD)
 # Do not parallelize
@@ -62,6 +83,9 @@ crash_test_with_multiops_wc_txn: $(DB_STRESS_CMD)
 crash_test_with_multiops_wp_txn: $(DB_STRESS_CMD)
 	$(CRASHTEST_MAKE) blackbox_crash_test_with_multiops_wp_txn
 
+crash_test_with_multiops_wup_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_MAKE) blackbox_crash_test_with_multiops_wup_txn
+
 blackbox_crash_test: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --simple blackbox $(CRASH_TEST_EXT_ARGS)
 	$(CRASHTEST_PY) blackbox $(CRASH_TEST_EXT_ARGS)
@@ -69,8 +93,14 @@ blackbox_crash_test: $(DB_STRESS_CMD)
 blackbox_crash_test_with_atomic_flush: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --cf_consistency blackbox $(CRASH_TEST_EXT_ARGS)
 
-blackbox_crash_test_with_txn: $(DB_STRESS_CMD)
-	$(CRASHTEST_PY) --txn blackbox $(CRASH_TEST_EXT_ARGS)
+blackbox_crash_test_with_wc_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_PY) --txn blackbox --txn_write_policy 0 $(CRASH_TEST_EXT_ARGS)
+
+blackbox_crash_test_with_wp_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_PY) --txn blackbox --txn_write_policy 1 $(CRASH_TEST_EXT_ARGS)
+
+blackbox_crash_test_with_wup_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_PY) --txn blackbox --txn_write_policy 2 $(CRASH_TEST_EXT_ARGS)
 
 blackbox_crash_test_with_best_efforts_recovery: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --test_best_efforts_recovery blackbox $(CRASH_TEST_EXT_ARGS)
@@ -79,10 +109,13 @@ blackbox_crash_test_with_ts: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --enable_ts blackbox $(CRASH_TEST_EXT_ARGS)
 
 blackbox_crash_test_with_multiops_wc_txn: $(DB_STRESS_CMD)
-	$(CRASHTEST_PY) --test_multiops_txn --write_policy write_committed blackbox $(CRASH_TEST_EXT_ARGS)
+	$(CRASHTEST_PY) --test_multiops_txn --txn_write_policy 0 blackbox $(CRASH_TEST_EXT_ARGS)
 
 blackbox_crash_test_with_multiops_wp_txn: $(DB_STRESS_CMD)
-	$(CRASHTEST_PY) --test_multiops_txn --write_policy write_prepared blackbox $(CRASH_TEST_EXT_ARGS)
+	$(CRASHTEST_PY) --test_multiops_txn --txn_write_policy 1 blackbox $(CRASH_TEST_EXT_ARGS)
+
+blackbox_crash_test_with_multiops_wup_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_PY) --test_multiops_txn --txn_write_policy 2 blackbox $(CRASH_TEST_EXT_ARGS)
 
 blackbox_crash_test_with_tiered_storage: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --test_tiered_storage blackbox $(CRASH_TEST_EXT_ARGS)
@@ -104,9 +137,17 @@ whitebox_crash_test_with_atomic_flush: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --cf_consistency whitebox  --random_kill_odd \
       $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
 
-whitebox_crash_test_with_txn: $(DB_STRESS_CMD)
-	$(CRASHTEST_PY) --txn whitebox --random_kill_odd \
-      $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
+whitebox_crash_test_with_wc_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_PY) --txn whitebox --txn_write_policy 0 \
+	  --random_kill_odd $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
+
+whitebox_crash_test_with_wp_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_PY) --txn whitebox --txn_write_policy 1 \
+      --random_kill_odd $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
+
+whitebox_crash_test_with_wup_txn: $(DB_STRESS_CMD)
+	$(CRASHTEST_PY) --txn whitebox --txn_write_policy 2 \
+      --random_kill_odd $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
 
 whitebox_crash_test_with_ts: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --enable_ts whitebox --random_kill_odd \
@@ -119,3 +160,8 @@ whitebox_crash_test_with_tiered_storage: $(DB_STRESS_CMD)
 whitebox_crash_test_with_optimistic_txn: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --optimistic_txn whitebox --random_kill_odd \
       $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
+
+# Old names DEPRECATED
+crash_test_with_txn: crash_test_with_wc_txn
+whitebox_crash_test_with_txn: whitebox_crash_test_with_wc_txn
+blackbox_crash_test_with_txn: blackbox_crash_test_with_wc_txn

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -24,9 +24,16 @@ class SecondaryIndex;
 class TransactionDBMutexFactory;
 
 enum TxnDBWritePolicy {
-  WRITE_COMMITTED = 0,  // write only the committed data
-  WRITE_PREPARED,       // write data after the prepare phase of 2pc
-  WRITE_UNPREPARED      // write data before the prepare phase of 2pc
+  // Write data at transaction commit time
+  WRITE_COMMITTED = 0,
+
+  // EXPERIMENTAL: The remaining write policies are not as mature, well
+  // validated, nor as compatible with other features as WRITE_COMMITTED.
+
+  // Write data after the prepare phase of 2pc
+  WRITE_PREPARED,
+  // Write data before the prepare phase of 2pc
+  WRITE_UNPREPARED
 };
 
 constexpr uint32_t kInitialMaxDeadlocks = 5;


### PR DESCRIPTION
Summary: We are seeing some occasional failures with WRITE_(UN)PREPARED crash test runs, and it's alarming when these are grouped in with WRITE_COMMITTED, which AFAIK is the only one considered mature and mission-critical at this point.

* Mark WRITE_(UN)PREPARED as EXPERIMENTAL in the public APIs
* Separate out the `_with_txn` crash test jobs by write policy, now `_with_wc_txn`, `_with_wp_txn` and `_with_wup_txn` so that the major functional and maturity differences are better grouped.
* Add `_with_multiops_wup_txn` which was apparently missing
* Clean up db_crashtest.py for better consistency
  * Get rid of awkard "write_policy" parameter that could conflict with authoritative "txn_write_policy" parameter.
  * Similarly, move some multiops logic from different parameter sets to finalize_and_sanitize logic.

Immediate internal follow-up:
* Migrate from `_with_txn` which are now deprecated aliases of `_with_wc_txn` to more jobs with the new variants. And likely also add new multiops job.

Test Plan: manual runs of modified jobs, at least long enough to spot check things like txn_write_policy