### PR TITLE
chore: refactor `WBWIMemTable::NewIterator` for better readability

### DIFF
--- a/memtable/wbwi_memtable.cc
+++ b/memtable/wbwi_memtable.cc
@@ -29,9 +29,8 @@ InternalIterator* WBWIMemTable::NewIterator(
   assert(assigned_seqno_.lower_bound != kMaxSequenceNumber);
   assert(arena);
   auto mem = arena->AllocateAligned(sizeof(WBWIMemTableIterator));
-  return new (mem) WBWIMemTableIterator(
-      std::unique_ptr<WBWIIterator>(wbwi_->NewIterator(cf_id_)),
-      assigned_seqno_, comparator_, for_flush);
+  auto iter = std::make_unique<WBWIIterator>(wbwi_->NewIterator(cf_id_));
+  return new (mem) WBWIMemTableIterator(std::move(iter), assigned_seqno_, comparator_, for_flush);
 }
 
 inline InternalIterator* WBWIMemTable::NewIterator() const {


### PR DESCRIPTION
I refactored the `WBWIMemTable::NewIterator` function to improve its clarity and memory management. Instead of creating a `unique_ptr` inline in the constructor, I used `std::make_unique` to create the iterator and passed it more clearly using `std::move`.

This change makes the code simpler, more readable, and ensures proper ownership transfer of the iterator.