### PR TITLE
Enable building JAR with support for parallel IO

### DIFF
--- a/java/rocksjni/env.cc
+++ b/java/rocksjni/env.cc
@@ -19,6 +19,11 @@
 #include "portal.h"
 #include "rocksjni/cplusplus_to_java_convert.h"
 
+// This will be read only if RocksDB was built with ROCKSDB_IOURING_PRESENT=1
+extern "C" bool RocksDbIOUringEnable() {
+  return true;
+}
+
 /*
  * Class:     org_rocksdb_Env
  * Method:    getDefaultEnvInternal

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -51,6 +51,11 @@
 #undef DELETE
 #endif
 
+// Undefine macro from snappy
+#ifdef LOG
+#undef LOG
+#endif
+
 namespace ROCKSDB_NAMESPACE {
 
 class JavaClass {


### PR DESCRIPTION
This change set intends to introduce the minimal set of modifications required to enable building the Java bindings with coroutine and `io_uring` support simply by running
```
ROCKSDB_USE_IO_URING=1 USE_COROUTINES=1 make rocksdbjavastatic
```

To achieve this without a breaking change, Folly and it's dependencies are linked in statically. The drawback of this is a slight increase in the library size.

The purpose of this change is to allow users of the Java bindings to benefit from the capability of the `MultiGet` implementation to issue IO requests for multiple data blocks in parallel. We would like for this feature to be part of a release, and so we need
1. confirmation that this is desirable or at least admissible, and
2. either cooperation from the party making the JAR release (it's not part of the public CI in this repo) to set `ROCKSDB_USE_IO_URING=1` and `USE_COROUTINES=1`, or agree to make building the JAR with coroutine support the default behavior.

In case building and publishing the artifact with coroutine support by default is undesirable for some reason would it be possible to perhaps (temporarily) release two versions of the artifact - with and without coroutine support, or find some other solution? We want to use this feature in our Java project, and we would like to avoid building and publishing our own artifacts for this reason.

Another question related to this PR I would like to ask is about the purpose of the `RocksDbIOUringEnable()`. I see that the changelog says:

> Add an interface RocksDbIOUringEnable() that, if defined by the user, will allow them to enable/disable the use of IO uring by RocksDB.

I assume that although `read_options.async_io` already performs the same role, there are situations where there is a need to disable `io_uring` where `read_options` are not available. Since the choice to use `io_uring` or not is already exposed to the user via `read_options.async_io`, is it safe for the wrappers implementation of `RocksDbIOUringEnable()` to just always return `true`, or does it have to e.g. do some check whether `io_uring` is available on the OS (just once to avoid incurring latency), or is it expected to do something else?