### PR TITLE
Support disallow_memtable_writes for default CF

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1170,6 +1170,7 @@ class DBImpl : public DB {
   Status TEST_GetBGError();
 
   bool TEST_IsRecoveryInProgress();
+  bool TEST_IsStopped() { return error_handler_.IsDBStopped(); }
 
   // Return the maximum overlapping data (in bytes) at next level for any
   // file at a level >= 1.

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -224,12 +224,6 @@ Status DBImpl::ValidateOptions(
     if (!s.ok()) {
       return s;
     }
-    if (cfd.name == kDefaultColumnFamilyName) {
-      if (cfd.options.disallow_memtable_writes) {
-        return Status::InvalidArgument(
-            "Default column family cannot use disallow_memtable_writes=true");
-      }
-    }
   }
   s = ValidateOptions(db_options);
   return s;

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -2970,6 +2970,21 @@ TEST_F(ExternalSSTFileBasicTest, FailIfNotBottommostLevelAndDisallowMemtable) {
         ASSERT_EQ(Get(1, "g"), "8");
       }
     }
+
+    {
+      // Also test default CF with disallow_memtable_writes
+      ASSERT_EQ(disallow_memtable, options.disallow_memtable_writes);
+      DestroyAndReopen(options);
+      ASSERT_OK(db_->IngestExternalFile({file_path}, {}));
+      ASSERT_EQ(Get("f"), "6");
+      if (disallow_memtable) {
+        EXPECT_EQ(Put("f", "7").code(), Status::Code::kInvalidArgument);
+        EXPECT_EQ(Get("f"), "6");
+      } else {
+        EXPECT_OK(Put("f", "7"));
+        EXPECT_EQ(Get("f"), "7");
+      }
+    }
   }
 }
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -721,13 +721,14 @@ struct AdvancedColumnFamilyOptions {
 
   // Setting this option to true disallows ordinary writes to the column family
   // and it can only be populated through import and ingestion. It is intended
-  // to protect "ingestion only" column families. This option is not currently
-  // supported on the default column family because of error handling challenges
-  // analogous to https://github.com/facebook/rocksdb/issues/13429
+  // to protect "ingestion only" column families.
   //
   // This option is not mutable with SetOptions(). It can be changed between
   // DB::Open() calls, but open will fail if recovering WAL writes to a CF with
   // this option set.
+  //
+  // WART: in some cases, attempting to write to the default CF with this option
+  // set will stop all writes to the DB until re-opened.
   bool disallow_memtable_writes = false;
 
   // This option has different meanings for different compaction styles:

--- a/unreleased_history/new_features/disallow_memtable_writes.md
+++ b/unreleased_history/new_features/disallow_memtable_writes.md
@@ -1,0 +1,1 @@
+* CF option `disallow_memtable_writes` can be set to `true` for column families intended as "ingestion only," to protect them from ordinary writes through the memtable.


### PR DESCRIPTION
Summary: in follow-up to #13489 and #13431

Because this feature is relatively simple and of the "protecting users from themselves" variety, I think we can call it production-ready. Release note added (none last time).

Test Plan: unit tests updated