### PR TITLE
Persist tail size of remote compaction output file to manifest

### DIFF
--- a/db/compaction/compaction_service_job.cc
+++ b/db/compaction/compaction_service_job.cc
@@ -240,7 +240,8 @@ CompactionJob::ProcessKeyValueCompactionWithCompactionService(
     meta.marked_for_compaction = file.marked_for_compaction;
     meta.unique_id = file.unique_id;
     meta.temperature = file.file_temperature;
-
+    meta.tail_size =
+        FileMetaData::CalculateTailSize(file_size, file.table_properties);
     auto cfd = compaction->column_family_data();
     CompactionOutputs* compaction_outputs =
         sub_compact->Outputs(file.is_proximal_level_output);

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -914,6 +914,7 @@ Status BlockBasedTable::PrefetchTail(
                      "TailPrefetchStats.",
                      file->file_name().c_str(), tail_prefetch_size);
     }
+    TEST_SYNC_POINT("BlockBasedTable::PrefetchTail::TaiSizeNotRecorded");
   }
   size_t prefetch_off;
   size_t prefetch_len;

--- a/unreleased_history/bug_fixes/remote_compact_populate.md
+++ b/unreleased_history/bug_fixes/remote_compact_populate.md
@@ -1,0 +1,1 @@
+Fix a bug where tail size of remote compaction output is not persisted in primary db's manifest


### PR DESCRIPTION
**Context/Summary:**

This is to fix a bug that tail size of remote compaction output SST file is not persisted to manifest in primary instance. This prevent us from using direct tail prefetch optimization each time opening this SST file.

**Test:**
Modify existing UT that failed before the fix