### PR TITLE
Trigger memtable flush based on number of hidden entries scanned

### DIFF
--- a/db/arena_wrapped_db_iter.cc
+++ b/db/arena_wrapped_db_iter.cc
@@ -42,9 +42,9 @@ Status ArenaWrappedDBIter::GetProperty(std::string prop_name,
 void ArenaWrappedDBIter::Init(
     Env* env, const ReadOptions& read_options, const ImmutableOptions& ioptions,
     const MutableCFOptions& mutable_cf_options, const Version* version,
-    const SequenceNumber& sequence, uint64_t max_sequential_skip_in_iteration,
-    uint64_t version_number, ReadCallback* read_callback,
-    ColumnFamilyHandleImpl* cfh, bool expose_blob_index, bool allow_refresh) {
+    const SequenceNumber& sequence, uint64_t version_number,
+    ReadCallback* read_callback, ColumnFamilyHandleImpl* cfh,
+    bool expose_blob_index, bool allow_refresh, ReadOnlyMemTable* active_mem) {
   read_options_ = read_options;
   if (!CheckFSFeatureSupport(env->GetFileSystem().get(),
                              FSSupportedOps::kAsyncIO)) {
@@ -52,15 +52,14 @@ void ArenaWrappedDBIter::Init(
   }
   read_options_.total_order_seek |= ioptions.prefix_seek_opt_in_only;
 
-  auto mem = arena_.AllocateAligned(sizeof(DBIter));
-  db_iter_ = new (mem) DBIter(env, read_options_, ioptions, mutable_cf_options,
-                              ioptions.user_comparator,
-                              /* iter */ nullptr, version, sequence, true,
-                              max_sequential_skip_in_iteration, read_callback,
-                              cfh, expose_blob_index);
+  db_iter_ = DBIter::NewIter(env, read_options_, ioptions, mutable_cf_options,
+                             ioptions.user_comparator, /*iter=*/nullptr,
+                             version, sequence, read_callback, cfh,
+                             expose_blob_index, active_mem, &arena_);
 
   sv_number_ = version_number;
   allow_refresh_ = allow_refresh;
+  allow_mark_memtable_for_flush_ = active_mem;
   memtable_range_tombstone_iter_ = nullptr;
 }
 
@@ -166,9 +165,8 @@ void ArenaWrappedDBIter::DoRefresh(const Snapshot* snapshot,
     read_callback_->Refresh(read_seq);
   }
   Init(env, read_options_, cfd->ioptions(), sv->mutable_cf_options, sv->current,
-       read_seq, sv->mutable_cf_options.max_sequential_skip_in_iterations,
-       sv->version_number, read_callback_, cfh_, expose_blob_index_,
-       allow_refresh_);
+       read_seq, sv->version_number, read_callback_, cfh_, expose_blob_index_,
+       allow_refresh_, allow_mark_memtable_for_flush_ ? sv->mem : nullptr);
 
   InternalIterator* internal_iter = db_impl->NewInternalIterator(
       read_options_, cfd, sv, &arena_, read_seq,
@@ -253,20 +251,26 @@ Status ArenaWrappedDBIter::Refresh(const Snapshot* snapshot) {
 }
 
 ArenaWrappedDBIter* NewArenaWrappedDbIterator(
-    Env* env, const ReadOptions& read_options, const ImmutableOptions& ioptions,
-    const MutableCFOptions& mutable_cf_options, const Version* version,
-    const SequenceNumber& sequence, uint64_t max_sequential_skip_in_iterations,
-    uint64_t version_number, ReadCallback* read_callback,
-    ColumnFamilyHandleImpl* cfh, bool expose_blob_index, bool allow_refresh) {
-  ArenaWrappedDBIter* iter = new ArenaWrappedDBIter();
-  iter->Init(env, read_options, ioptions, mutable_cf_options, version, sequence,
-             max_sequential_skip_in_iterations, version_number, read_callback,
-             cfh, expose_blob_index, allow_refresh);
+    Env* env, const ReadOptions& read_options, ColumnFamilyHandleImpl* cfh,
+    SuperVersion* sv, const SequenceNumber& sequence,
+    ReadCallback* read_callback, DBImpl* db_impl, bool expose_blob_index,
+    bool allow_refresh, bool allow_mark_memtable_for_flush) {
+  ArenaWrappedDBIter* db_iter = new ArenaWrappedDBIter();
+  db_iter->Init(env, read_options, cfh->cfd()->ioptions(),
+                sv->mutable_cf_options, sv->current, sequence,
+                sv->version_number, read_callback, cfh, expose_blob_index,
+                allow_refresh,
+                allow_mark_memtable_for_flush ? sv->mem : nullptr);
   if (cfh != nullptr && allow_refresh) {
-    iter->StoreRefreshInfo(cfh, read_callback, expose_blob_index);
+    db_iter->StoreRefreshInfo(cfh, read_callback, expose_blob_index);
   }
 
-  return iter;
+  InternalIterator* internal_iter = db_impl->NewInternalIterator(
+      db_iter->GetReadOptions(), cfh->cfd(), sv, db_iter->GetArena(), sequence,
+      /*allow_unprepared_value=*/true, db_iter);
+  db_iter->SetIterUnderDBIter(internal_iter);
+
+  return db_iter;
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/arena_wrapped_db_iter.cc
+++ b/db/arena_wrapped_db_iter.cc
@@ -52,10 +52,10 @@ void ArenaWrappedDBIter::Init(
   }
   read_options_.total_order_seek |= ioptions.prefix_seek_opt_in_only;
 
-  db_iter_ = DBIter::NewIter(env, read_options_, ioptions, mutable_cf_options,
-                             ioptions.user_comparator, /*iter=*/nullptr,
-                             version, sequence, read_callback, cfh,
-                             expose_blob_index, active_mem, &arena_);
+  db_iter_ = DBIter::NewIter(
+      env, read_options_, ioptions, mutable_cf_options,
+      ioptions.user_comparator, /*internal_iter=*/nullptr, version, sequence,
+      read_callback, cfh, expose_blob_index, active_mem, &arena_);
 
   sv_number_ = version_number;
   allow_refresh_ = allow_refresh;

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -448,11 +448,11 @@ ColumnFamilyOptions SanitizeCfOptions(const ImmutableDBOptions& db_options,
     result.preclude_last_level_data_seconds = 0;
   }
 
-  if (read_only && result.tombstone_scan_flush_trigger != 0) {
+  if (read_only && result.memtable_op_scan_flush_trigger != 0) {
     ROCKS_LOG_WARN(db_options.info_log.get(),
-                   "option tombstone_scan_flush_trigger is sanitized to "
+                   "option memtable_op_scan_flush_trigger is sanitized to "
                    "0(disabled) for read only DB.");
-    result.tombstone_scan_flush_trigger = 0;
+    result.memtable_op_scan_flush_trigger = 0;
   }
 
   return result;

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -448,6 +448,13 @@ ColumnFamilyOptions SanitizeCfOptions(const ImmutableDBOptions& db_options,
     result.preclude_last_level_data_seconds = 0;
   }
 
+  if (read_only && result.memtable_tombstone_scan_limit != 0) {
+    ROCKS_LOG_WARN(db_options.info_log.get(),
+                   "option memtable_tombstone_scan_limit is sanitized to "
+                   "0(disabled) for read only DB.");
+    result.memtable_tombstone_scan_limit = 0;
+  }
+
   return result;
 }
 

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -448,11 +448,11 @@ ColumnFamilyOptions SanitizeCfOptions(const ImmutableDBOptions& db_options,
     result.preclude_last_level_data_seconds = 0;
   }
 
-  if (read_only && result.memtable_tombstone_scan_limit != 0) {
+  if (read_only && result.tombstone_scan_flush_trigger != 0) {
     ROCKS_LOG_WARN(db_options.info_log.get(),
-                   "option memtable_tombstone_scan_limit is sanitized to "
+                   "option tombstone_scan_flush_trigger is sanitized to "
                    "0(disabled) for read only DB.");
-    result.memtable_tombstone_scan_limit = 0;
+    result.tombstone_scan_flush_trigger = 0;
   }
 
   return result;

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -566,17 +566,10 @@ ArenaWrappedDBIter* DBImplSecondary::NewIteratorImpl(
   assert(snapshot == kMaxSequenceNumber);
   snapshot = versions_->LastSequence();
   assert(snapshot != kMaxSequenceNumber);
-  auto db_iter = NewArenaWrappedDbIterator(
-      env_, read_options, cfh->cfd()->ioptions(),
-      super_version->mutable_cf_options, super_version->current, snapshot,
-      super_version->mutable_cf_options.max_sequential_skip_in_iterations,
-      super_version->version_number, read_callback, cfh, expose_blob_index,
-      allow_refresh);
-  auto internal_iter = NewInternalIterator(
-      db_iter->GetReadOptions(), cfh->cfd(), super_version, db_iter->GetArena(),
-      snapshot, /* allow_unprepared_value */ true, db_iter);
-  db_iter->SetIterUnderDBIter(internal_iter);
-  return db_iter;
+  return NewArenaWrappedDbIterator(env_, read_options, cfh, super_version,
+                                   snapshot, read_callback, this,
+                                   expose_blob_index, allow_refresh,
+                                   /*allow_mark_memtable_for_flush=*/false);
 }
 
 Status DBImplSecondary::NewIterators(

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -9,7 +9,6 @@
 
 #include "db/db_iter.h"
 
-#include <iostream>
 #include <limits>
 #include <string>
 
@@ -42,9 +41,8 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
                const MutableCFOptions& mutable_cf_options,
                const Comparator* cmp, InternalIterator* iter,
                const Version* version, SequenceNumber s, bool arena_mode,
-               uint64_t max_sequential_skip_in_iterations,
                ReadCallback* read_callback, ColumnFamilyHandleImpl* cfh,
-               bool expose_blob_index)
+               bool expose_blob_index, ReadOnlyMemTable* active_mem)
     : prefix_extractor_(mutable_cf_options.prefix_extractor.get()),
       env_(_env),
       clock_(ioptions.clock),
@@ -58,11 +56,21 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       read_callback_(read_callback),
       sequence_(s),
       statistics_(ioptions.stats),
-      max_skip_(max_sequential_skip_in_iterations),
+      max_skip_(mutable_cf_options.max_sequential_skip_in_iterations),
       max_skippable_internal_keys_(read_options.max_skippable_internal_keys),
       num_internal_keys_skipped_(0),
       iterate_lower_bound_(read_options.iterate_lower_bound),
       iterate_upper_bound_(read_options.iterate_upper_bound),
+      cfh_(cfh),
+      timestamp_ub_(read_options.timestamp),
+      timestamp_lb_(read_options.iter_start_ts),
+      timestamp_size_(timestamp_ub_ ? timestamp_ub_->size() : 0),
+      active_mem_(active_mem),
+      memtable_seqno_lb_((active_mem_ && !active_mem_->IsEmpty())
+                             ? active_mem_->GetFirstSequenceNumber()
+                             : kMaxSequenceNumber),
+      memtable_tombstone_scan_limit_(
+          mutable_cf_options.memtable_tombstone_scan_limit),
       direction_(kForward),
       valid_(false),
       current_entry_is_merged_(false),
@@ -76,11 +84,7 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       expose_blob_index_(expose_blob_index),
       allow_unprepared_value_(read_options.allow_unprepared_value),
       is_blob_(false),
-      arena_mode_(arena_mode),
-      cfh_(cfh),
-      timestamp_ub_(read_options.timestamp),
-      timestamp_lb_(read_options.iter_start_ts),
-      timestamp_size_(timestamp_ub_ ? timestamp_ub_->size() : 0) {
+      arena_mode_(arena_mode) {
   RecordTick(statistics_, NO_ITERATOR_CREATED);
   if (pin_thru_lifetime_) {
     pinned_iters_mgr_.StartPinning();
@@ -369,6 +373,8 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
   // to one.
   bool reseek_done = false;
 
+  uint64_t num_mem_tombstone_scanned = 0;
+  bool mem_marked_for_flush = false;
   do {
     // Will update is_key_seqnum_zero_ as soon as we parsed the current key
     // but we need to save the previous value to be used in the loop.
@@ -446,6 +452,14 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
                                       !iter_.iter()->IsKeyPinned() /* copy */);
               skipping_saved_key = true;
               PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
+              if (memtable_tombstone_scan_limit_ && active_mem_ &&
+                  ikey_.sequence >= memtable_seqno_lb_ &&
+                  !mem_marked_for_flush &&
+                  ++num_mem_tombstone_scanned >=
+                      memtable_tombstone_scan_limit_) {
+                active_mem_->MarkForFlush();
+                mem_marked_for_flush = true;
+              }
             }
             break;
           case kTypeValue:
@@ -1790,21 +1804,4 @@ void DBIter::SeekToLast() {
         StripTimestampFromUserKey(saved_key_.GetUserKey(), timestamp_size_)));
   }
 }
-
-Iterator* NewDBIterator(Env* env, const ReadOptions& read_options,
-                        const ImmutableOptions& ioptions,
-                        const MutableCFOptions& mutable_cf_options,
-                        const Comparator* user_key_comparator,
-                        InternalIterator* internal_iter, const Version* version,
-                        const SequenceNumber& sequence,
-                        uint64_t max_sequential_skip_in_iterations,
-                        ReadCallback* read_callback,
-                        ColumnFamilyHandleImpl* cfh, bool expose_blob_index) {
-  DBIter* db_iter = new DBIter(
-      env, read_options, ioptions, mutable_cf_options, user_key_comparator,
-      internal_iter, version, sequence, false,
-      max_sequential_skip_in_iterations, read_callback, cfh, expose_blob_index);
-  return db_iter;
-}
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -69,8 +69,8 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       memtable_seqno_lb_((active_mem_ && !active_mem_->IsEmpty())
                              ? active_mem_->GetFirstSequenceNumber()
                              : kMaxSequenceNumber),
-      memtable_tombstone_scan_limit_(
-          mutable_cf_options.memtable_tombstone_scan_limit),
+      tombstone_scan_flush_trigger_(
+          mutable_cf_options.tombstone_scan_flush_trigger),
       direction_(kForward),
       valid_(false),
       current_entry_is_merged_(false),
@@ -452,11 +452,11 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
                                       !iter_.iter()->IsKeyPinned() /* copy */);
               skipping_saved_key = true;
               PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
-              if (memtable_tombstone_scan_limit_ && active_mem_ &&
+              if (tombstone_scan_flush_trigger_ && active_mem_ &&
                   ikey_.sequence >= memtable_seqno_lb_ &&
                   !mem_marked_for_flush &&
                   ++num_mem_tombstone_scanned >=
-                      memtable_tombstone_scan_limit_) {
+                      tombstone_scan_flush_trigger_) {
                 active_mem_->MarkForFlush();
                 mem_marked_for_flush = true;
               }

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -82,7 +82,7 @@ class DBIter final : public Iterator {
                user_key_comparator, internal_iter, version, sequence, arena,
                read_callback, cfh, expose_blob_index, active_mem);
     return db_iter;
-  };
+  }
 
   // The following is grossly complicated. TODO: clean it up
   // Which direction is the iterator currently moving?

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -57,6 +57,33 @@ class Version;
 // numbers, deletion markers, overwrites, etc.
 class DBIter final : public Iterator {
  public:
+  // Return a new DBIter that reads from `internal_iter` at the specified
+  // `sequence` number.
+  //
+  // @param active_mem Pointer to the active memtable that `internal_iter`
+  // is reading from. If not null, the memtable can be marked for flush
+  // according to option mutable_cf_options.memtable_tombstone_scan_limit.
+  // @param arena_mode If true, the DBIter will be allocated from the arena.
+  static DBIter* NewIter(Env* env, const ReadOptions& read_options,
+                         const ImmutableOptions& ioptions,
+                         const MutableCFOptions& mutable_cf_options,
+                         const Comparator* user_key_comparator,
+                         InternalIterator* internal_iter,
+                         const Version* version, const SequenceNumber& sequence,
+                         ReadCallback* read_callback,
+                         ColumnFamilyHandleImpl* cfh = nullptr,
+                         bool expose_blob_index = false,
+                         ReadOnlyMemTable* active_mem = nullptr,
+                         Arena* arena = nullptr) {
+    void* mem = arena ? arena->AllocateAligned(sizeof(DBIter))
+                      : operator new(sizeof(DBIter));
+    DBIter* db_iter = new (mem)
+        DBIter(env, read_options, ioptions, mutable_cf_options,
+               user_key_comparator, internal_iter, version, sequence, arena,
+               read_callback, cfh, expose_blob_index, active_mem);
+    return db_iter;
+  };
+
   // The following is grossly complicated. TODO: clean it up
   // Which direction is the iterator currently moving?
   // (1) When moving forward:
@@ -112,14 +139,6 @@ class DBIter final : public Iterator {
     // Map to Tickers::NUMBER_ITER_SKIP
     uint64_t skip_count_;
   };
-
-  DBIter(Env* _env, const ReadOptions& read_options,
-         const ImmutableOptions& ioptions,
-         const MutableCFOptions& mutable_cf_options, const Comparator* cmp,
-         InternalIterator* iter, const Version* version, SequenceNumber s,
-         bool arena_mode, uint64_t max_sequential_skip_in_iterations,
-         ReadCallback* read_callback, ColumnFamilyHandleImpl* cfh,
-         bool expose_blob_index);
 
   // No copying allowed
   DBIter(const DBIter&) = delete;
@@ -232,6 +251,14 @@ class DBIter final : public Iterator {
   }
 
  private:
+  DBIter(Env* _env, const ReadOptions& read_options,
+         const ImmutableOptions& ioptions,
+         const MutableCFOptions& mutable_cf_options, const Comparator* cmp,
+         InternalIterator* iter, const Version* version, SequenceNumber s,
+         bool arena_mode, ReadCallback* read_callback,
+         ColumnFamilyHandleImpl* cfh, bool expose_blob_index,
+         ReadOnlyMemTable* active_mem);
+
   class BlobReader {
    public:
     BlobReader(const Version* version, ReadTier read_tier,
@@ -436,6 +463,21 @@ class DBIter final : public Iterator {
   IterKey prefix_;
 
   Status status_;
+  Slice lazy_blob_index_;
+
+  // List of operands for merge operator.
+  MergeContext merge_context_;
+  LocalStatistics local_stats_;
+  PinnedIteratorsManager pinned_iters_mgr_;
+  ColumnFamilyHandleImpl* cfh_;
+  const Slice* const timestamp_ub_;
+  const Slice* const timestamp_lb_;
+  const size_t timestamp_size_;
+  std::string saved_timestamp_;
+  std::optional<std::vector<ScanOptions>> scan_opts_;
+  ReadOnlyMemTable* active_mem_;
+  SequenceNumber memtable_seqno_lb_;
+  uint32_t memtable_tombstone_scan_limit_;
   Direction direction_;
   bool valid_;
   bool current_entry_is_merged_;
@@ -454,30 +496,7 @@ class DBIter final : public Iterator {
   // the stacked BlobDB implementation is used, false otherwise.
   bool expose_blob_index_;
   bool allow_unprepared_value_;
-  Slice lazy_blob_index_;
   bool is_blob_;
   bool arena_mode_;
-  // List of operands for merge operator.
-  MergeContext merge_context_;
-  LocalStatistics local_stats_;
-  PinnedIteratorsManager pinned_iters_mgr_;
-  ColumnFamilyHandleImpl* cfh_;
-  const Slice* const timestamp_ub_;
-  const Slice* const timestamp_lb_;
-  const size_t timestamp_size_;
-  std::string saved_timestamp_;
-  std::optional<std::vector<ScanOptions>> scan_opts_;
 };
-
-// Return a new iterator that converts internal keys (yielded by
-// "*internal_iter") that were live at the specified `sequence` number
-// into appropriate user keys.
-Iterator* NewDBIterator(
-    Env* env, const ReadOptions& read_options, const ImmutableOptions& ioptions,
-    const MutableCFOptions& mutable_cf_options,
-    const Comparator* user_key_comparator, InternalIterator* internal_iter,
-    const Version* version, const SequenceNumber& sequence,
-    uint64_t max_sequential_skip_in_iterations, ReadCallback* read_callback,
-    ColumnFamilyHandleImpl* cfh = nullptr, bool expose_blob_index = false);
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -62,7 +62,7 @@ class DBIter final : public Iterator {
   //
   // @param active_mem Pointer to the active memtable that `internal_iter`
   // is reading from. If not null, the memtable can be marked for flush
-  // according to option mutable_cf_options.memtable_tombstone_scan_limit.
+  // according to option mutable_cf_options.tombstone_scan_flush_trigger.
   // @param arena_mode If true, the DBIter will be allocated from the arena.
   static DBIter* NewIter(Env* env, const ReadOptions& read_options,
                          const ImmutableOptions& ioptions,
@@ -477,7 +477,7 @@ class DBIter final : public Iterator {
   std::optional<std::vector<ScanOptions>> scan_opts_;
   ReadOnlyMemTable* active_mem_;
   SequenceNumber memtable_seqno_lb_;
-  uint32_t memtable_tombstone_scan_limit_;
+  uint32_t tombstone_scan_flush_trigger_;
   Direction direction_;
   bool valid_;
   bool current_entry_is_merged_;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -62,7 +62,7 @@ class DBIter final : public Iterator {
   //
   // @param active_mem Pointer to the active memtable that `internal_iter`
   // is reading from. If not null, the memtable can be marked for flush
-  // according to option mutable_cf_options.tombstone_scan_flush_trigger.
+  // according to option mutable_cf_options.memtable_op_scan_flush_trigger.
   // @param arena_mode If true, the DBIter will be allocated from the arena.
   static DBIter* NewIter(Env* env, const ReadOptions& read_options,
                          const ImmutableOptions& ioptions,
@@ -477,7 +477,7 @@ class DBIter final : public Iterator {
   std::optional<std::vector<ScanOptions>> scan_opts_;
   ReadOnlyMemTable* active_mem_;
   SequenceNumber memtable_seqno_lb_;
-  uint32_t tombstone_scan_flush_trigger_;
+  uint32_t memtable_op_scan_flush_trigger_;
   Direction direction_;
   bool valid_;
   bool current_entry_is_merged_;

--- a/db/db_iter_stress_test.cc
+++ b/db/db_iter_stress_test.cc
@@ -528,11 +528,10 @@ TEST_F(DBIteratorStressTest, StressTest) {
                   internal_iter->target_hidden_fraction =
                       target_hidden_fraction;
                   internal_iter->trace = trace;
-                  db_iter.reset(NewDBIterator(
+                  db_iter.reset(DBIter::NewIter(
                       env_, ropt, ImmutableOptions(options),
                       MutableCFOptions(options), BytewiseComparator(),
-                      internal_iter, nullptr /* version */, sequence,
-                      options.max_sequential_skip_in_iterations,
+                      internal_iter, /*version=*/nullptr, sequence,
                       nullptr /*read_callback*/));
                 }
 

--- a/db/db_iter_test.cc
+++ b/db/db_iter_test.cc
@@ -259,10 +259,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     internal_iter->Finish();
 
     ReadOptions ro;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -294,10 +293,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     internal_iter->Finish();
 
     ReadOptions ro;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -322,10 +320,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     ReadOptions ro;
     ro.iterate_upper_bound = &prefix;
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -356,10 +353,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     ReadOptions ro;
     ro.iterate_upper_bound = &prefix;
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -393,10 +389,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     ReadOptions ro;
     ro.iterate_upper_bound = &prefix;
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -425,10 +420,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     ReadOptions ro;
     ro.iterate_upper_bound = &prefix;
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 7 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     SetPerfLevel(kEnableCount);
@@ -465,10 +459,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     ReadOptions ro;
     ro.iterate_upper_bound = &prefix;
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 4 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -492,10 +485,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     ReadOptions ro;
     ro.iterate_upper_bound = &prefix;
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -517,10 +509,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     ReadOptions ro;
     ro.iterate_upper_bound = &prefix;
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -554,10 +545,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     ReadOptions ro;
     ro.iterate_upper_bound = &prefix;
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 7 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     SetPerfLevel(kEnableCount);
@@ -586,10 +576,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     internal_iter->Finish();
 
     ReadOptions ro;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToFirst();
@@ -631,10 +620,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     internal_iter->Finish();
 
     ReadOptions ro;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 2 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -664,10 +652,9 @@ TEST_F(DBIteratorTest, DBIteratorPrevNext) {
     internal_iter->Finish();
 
     ReadOptions ro;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -696,10 +683,9 @@ TEST_F(DBIteratorTest, DBIteratorEmpty) {
     TestIterator* internal_iter = new TestIterator(BytewiseComparator());
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 0 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(!db_iter->Valid());
@@ -710,10 +696,9 @@ TEST_F(DBIteratorTest, DBIteratorEmpty) {
     TestIterator* internal_iter = new TestIterator(BytewiseComparator());
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 0 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToFirst();
     ASSERT_TRUE(!db_iter->Valid());
@@ -735,11 +720,10 @@ TEST_F(DBIteratorTest, DBIteratorUseSkipCountSkips) {
   }
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      2 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      2 /* sequence */, nullptr /* read_callback */));
   db_iter->SeekToLast();
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "c");
@@ -782,10 +766,10 @@ TEST_F(DBIteratorTest, DBIteratorUseSkip) {
       internal_iter->Finish();
 
       options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
-      std::unique_ptr<Iterator> db_iter(NewDBIterator(
+      std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
           env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
           internal_iter, nullptr /* version */, i + 2 /* sequence */,
-          options.max_sequential_skip_in_iterations,
+
           nullptr /* read_callback */));
       db_iter->SeekToLast();
       ASSERT_TRUE(db_iter->Valid());
@@ -820,10 +804,10 @@ TEST_F(DBIteratorTest, DBIteratorUseSkip) {
       internal_iter->AddPut("c", "200");
       internal_iter->Finish();
 
-      std::unique_ptr<Iterator> db_iter(NewDBIterator(
+      std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
           env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
           internal_iter, nullptr /* version */, i + 2 /* sequence */,
-          options.max_sequential_skip_in_iterations,
+
           nullptr /* read_callback */));
       db_iter->SeekToLast();
       ASSERT_TRUE(db_iter->Valid());
@@ -851,10 +835,10 @@ TEST_F(DBIteratorTest, DBIteratorUseSkip) {
       internal_iter->AddPut("c", "200");
       internal_iter->Finish();
 
-      std::unique_ptr<Iterator> db_iter(NewDBIterator(
+      std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
           env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
           internal_iter, nullptr /* version */, 202 /* sequence */,
-          options.max_sequential_skip_in_iterations,
+
           nullptr /* read_callback */));
       db_iter->SeekToLast();
       ASSERT_TRUE(db_iter->Valid());
@@ -886,10 +870,10 @@ TEST_F(DBIteratorTest, DBIteratorUseSkip) {
       }
       internal_iter->AddPut("c", "200");
       internal_iter->Finish();
-      std::unique_ptr<Iterator> db_iter(NewDBIterator(
+      std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
           env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
           internal_iter, nullptr /* version */, i /* sequence */,
-          options.max_sequential_skip_in_iterations,
+
           nullptr /* read_callback */));
       db_iter->SeekToLast();
       ASSERT_TRUE(!db_iter->Valid());
@@ -906,10 +890,9 @@ TEST_F(DBIteratorTest, DBIteratorUseSkip) {
     }
     internal_iter->AddPut("c", "200");
     internal_iter->Finish();
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 200 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -944,10 +927,10 @@ TEST_F(DBIteratorTest, DBIteratorUseSkip) {
       }
       internal_iter->Finish();
 
-      std::unique_ptr<Iterator> db_iter(NewDBIterator(
+      std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
           env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
           internal_iter, nullptr /* version */, i + 2 /* sequence */,
-          options.max_sequential_skip_in_iterations,
+
           nullptr /* read_callback */));
       db_iter->SeekToLast();
       ASSERT_TRUE(db_iter->Valid());
@@ -981,10 +964,10 @@ TEST_F(DBIteratorTest, DBIteratorUseSkip) {
       }
       internal_iter->Finish();
 
-      std::unique_ptr<Iterator> db_iter(NewDBIterator(
+      std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
           env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
           internal_iter, nullptr /* version */, i + 2 /* sequence */,
-          options.max_sequential_skip_in_iterations,
+
           nullptr /* read_callback */));
       db_iter->SeekToLast();
       ASSERT_TRUE(db_iter->Valid());
@@ -1033,10 +1016,9 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
     internal_iter->Finish();
 
     ro.max_skippable_internal_keys = 0;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToFirst();
@@ -1081,10 +1063,9 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
     internal_iter->Finish();
 
     ro.max_skippable_internal_keys = 2;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToFirst();
@@ -1127,10 +1108,9 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
     internal_iter->Finish();
 
     ro.max_skippable_internal_keys = 2;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToFirst();
@@ -1167,10 +1147,9 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
     internal_iter->Finish();
 
     ro.max_skippable_internal_keys = 2;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToFirst();
@@ -1204,10 +1183,9 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
     internal_iter->Finish();
 
     ro.max_skippable_internal_keys = 2;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToLast();
@@ -1236,10 +1214,9 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
     internal_iter->Finish();
 
     ro.max_skippable_internal_keys = 2;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToFirst();
@@ -1275,10 +1252,9 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
     internal_iter->Finish();
 
     ro.max_skippable_internal_keys = 2;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
 
     db_iter->SeekToFirst();
@@ -1314,10 +1290,10 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
       internal_iter->Finish();
 
       ro.max_skippable_internal_keys = i;
-      std::unique_ptr<Iterator> db_iter(NewDBIterator(
+      std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
           env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
           internal_iter, nullptr /* version */, 2 * i + 1 /* sequence */,
-          options.max_sequential_skip_in_iterations,
+
           nullptr /* read_callback */));
 
       db_iter->SeekToFirst();
@@ -1369,10 +1345,9 @@ TEST_F(DBIteratorTest, DBIteratorSkipInternalKeys) {
 
       options.max_sequential_skip_in_iterations = 1000;
       ro.max_skippable_internal_keys = i;
-      std::unique_ptr<Iterator> db_iter(NewDBIterator(
-          env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
+      std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
+          env_, ro, ioptions, MutableCFOptions(options), BytewiseComparator(),
           internal_iter, nullptr /* version */, 2 * i + 1 /* sequence */,
-          options.max_sequential_skip_in_iterations,
           nullptr /* read_callback */));
 
       db_iter->SeekToFirst();
@@ -1412,11 +1387,11 @@ TEST_F(DBIteratorTest, DBIteratorTimedPutBasic) {
   internal_iter->AddTimedPut("d", "3", /*write_unix_time=*/0);
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  options.max_sequential_skip_in_iterations = 1;
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      7 /* sequence */, /*max_sequential_skip_in_iterations*/ 1,
-      nullptr /* read_callback */));
+      7 /* sequence */, nullptr /* read_callback */));
   db_iter->SeekToFirst();
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "a");
@@ -1463,11 +1438,10 @@ TEST_F(DBIteratorTest, DBIterator1) {
   internal_iter->AddMerge("b", "2");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      1 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      1 /* sequence */, nullptr /* read_callback */));
   db_iter->SeekToFirst();
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "a");
@@ -1493,11 +1467,10 @@ TEST_F(DBIteratorTest, DBIterator2) {
   internal_iter->AddMerge("b", "2");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      0 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      0 /* sequence */, nullptr /* read_callback */));
   db_iter->SeekToFirst();
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "a");
@@ -1519,11 +1492,10 @@ TEST_F(DBIteratorTest, DBIterator3) {
   internal_iter->AddMerge("b", "2");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      2 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      2 /* sequence */, nullptr /* read_callback */));
   db_iter->SeekToFirst();
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "a");
@@ -1545,11 +1517,10 @@ TEST_F(DBIteratorTest, DBIterator4) {
   internal_iter->AddMerge("b", "2");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      4 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      4 /* sequence */, nullptr /* read_callback */));
   db_iter->SeekToFirst();
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "a");
@@ -1580,10 +1551,9 @@ TEST_F(DBIteratorTest, DBIterator5) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 0 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1605,10 +1575,9 @@ TEST_F(DBIteratorTest, DBIterator5) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 1 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1630,10 +1599,9 @@ TEST_F(DBIteratorTest, DBIterator5) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 2 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1655,10 +1623,9 @@ TEST_F(DBIteratorTest, DBIterator5) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 3 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1680,10 +1647,9 @@ TEST_F(DBIteratorTest, DBIterator5) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 4 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1705,10 +1671,9 @@ TEST_F(DBIteratorTest, DBIterator5) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 5 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1730,10 +1695,9 @@ TEST_F(DBIteratorTest, DBIterator5) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 6 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1753,10 +1717,9 @@ TEST_F(DBIteratorTest, DBIterator5) {
     internal_iter->AddMerge("a", "merge_2");
     internal_iter->AddPut("b", "val_b");
     internal_iter->Finish();
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 10 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->Seek("b");
     ASSERT_TRUE(db_iter->Valid());
@@ -1785,10 +1748,9 @@ TEST_F(DBIteratorTest, DBIterator6) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 0 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1810,10 +1772,9 @@ TEST_F(DBIteratorTest, DBIterator6) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 1 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1835,10 +1796,9 @@ TEST_F(DBIteratorTest, DBIterator6) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 2 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1860,10 +1820,9 @@ TEST_F(DBIteratorTest, DBIterator6) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 3 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(!db_iter->Valid());
@@ -1881,10 +1840,9 @@ TEST_F(DBIteratorTest, DBIterator6) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 4 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1906,10 +1864,9 @@ TEST_F(DBIteratorTest, DBIterator6) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 5 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1931,10 +1888,9 @@ TEST_F(DBIteratorTest, DBIterator6) {
     internal_iter->AddMerge("a", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 6 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -1976,10 +1932,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 0 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2013,10 +1968,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 2 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2056,10 +2010,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 4 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2099,10 +2052,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 5 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2147,10 +2099,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 6 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2196,10 +2147,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 7 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2239,10 +2189,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 9 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2288,10 +2237,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 13 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2338,10 +2286,9 @@ TEST_F(DBIteratorTest, DBIterator7) {
     internal_iter->AddDeletion("c");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ioptions, mutable_cf_options, BytewiseComparator(),
         internal_iter, nullptr /* version */, 14 /* sequence */,
-        options.max_sequential_skip_in_iterations,
         nullptr /* read_callback */));
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2371,11 +2318,10 @@ TEST_F(DBIteratorTest, DBIterator8) {
   internal_iter->AddPut("b", "0");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      10 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      10 /* sequence */, nullptr /* read_callback */));
   db_iter->SeekToLast();
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "b");
@@ -2403,11 +2349,10 @@ TEST_F(DBIteratorTest, DBIterator9) {
     internal_iter->AddMerge("d", "merge_6");
     internal_iter->Finish();
 
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ImmutableOptions(options), MutableCFOptions(options),
         BytewiseComparator(), internal_iter, nullptr /* version */,
-        10 /* sequence */, options.max_sequential_skip_in_iterations,
-        nullptr /* read_callback */));
+        10 /* sequence */, nullptr /* read_callback */));
 
     db_iter->SeekToLast();
     ASSERT_TRUE(db_iter->Valid());
@@ -2471,11 +2416,10 @@ TEST_F(DBIteratorTest, DBIterator10) {
   internal_iter->AddPut("d", "4");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      10 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      10 /* sequence */, nullptr /* read_callback */));
 
   db_iter->Seek("c");
   ASSERT_TRUE(db_iter->Valid());
@@ -2512,7 +2456,7 @@ TEST_F(DBIteratorTest, SeekToLastOccurrenceSeq0) {
   internal_iter->AddPut("b", "2");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
       10 /* sequence */, 0 /* force seek */, nullptr /* read_callback */));
@@ -2542,11 +2486,10 @@ TEST_F(DBIteratorTest, DBIterator11) {
   internal_iter->AddMerge("b", "2");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      1 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      1 /* sequence */, nullptr /* read_callback */));
   db_iter->SeekToFirst();
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "a");
@@ -2571,7 +2514,7 @@ TEST_F(DBIteratorTest, DBIterator12) {
   internal_iter->AddSingleDeletion("b");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
       10 /* sequence */, 0 /* force seek */, nullptr /* read_callback */));
@@ -2610,11 +2553,11 @@ TEST_F(DBIteratorTest, DBIterator13) {
   internal_iter->AddPut(key, "8");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  options.max_sequential_skip_in_iterations = 3;
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      2 /* sequence */, 3 /* max_sequential_skip_in_iterations */,
-      nullptr /* read_callback */));
+      2 /* sequence */, nullptr /* read_callback */));
   db_iter->Seek("b");
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), key);
@@ -2640,11 +2583,11 @@ TEST_F(DBIteratorTest, DBIterator14) {
   internal_iter->AddPut("c", "9");
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  options.max_sequential_skip_in_iterations = 1;
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      4 /* sequence */, 1 /* max_sequential_skip_in_iterations */,
-      nullptr /* read_callback */));
+      4 /* sequence */, nullptr /* read_callback */));
   db_iter->Seek("b");
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_EQ(db_iter->key().ToString(), "b");
@@ -2680,11 +2623,11 @@ class DBIterWithMergeIterTest : public testing::Test {
     InternalIterator* merge_iter =
         NewMergingIterator(&icomp_, child_iters.data(), 2u);
 
-    db_iter_.reset(NewDBIterator(
+    options_.max_sequential_skip_in_iterations = 3;
+    db_iter_.reset(DBIter::NewIter(
         env_, ro_, ImmutableOptions(options_), MutableCFOptions(options_),
         BytewiseComparator(), merge_iter, nullptr /* version */,
-        8 /* read data earlier than seqId 8 */,
-        3 /* max iterators before reseek */, nullptr /* read_callback */));
+        8 /* read data earlier than seqId 8 */, nullptr /* read_callback */));
   }
 
   Env* env_;
@@ -3120,11 +3063,10 @@ TEST_F(DBIteratorTest, SeekPrefixTombstones) {
   internal_iter->Finish();
 
   ro.prefix_same_as_start = true;
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      10 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      10 /* sequence */, nullptr /* read_callback */));
 
   int skipped_keys = 0;
 
@@ -3157,11 +3099,10 @@ TEST_F(DBIteratorTest, SeekToFirstLowerBound) {
     Slice lower_bound(lower_bound_str);
     ro.iterate_lower_bound = &lower_bound;
     Options options;
-    std::unique_ptr<Iterator> db_iter(NewDBIterator(
+    std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
         env_, ro, ImmutableOptions(options), MutableCFOptions(options),
         BytewiseComparator(), internal_iter, nullptr /* version */,
-        10 /* sequence */, options.max_sequential_skip_in_iterations,
-        nullptr /* read_callback */));
+        10 /* sequence */, nullptr /* read_callback */));
 
     db_iter->SeekToFirst();
     if (i == kNumKeys + 1) {
@@ -3197,11 +3138,10 @@ TEST_F(DBIteratorTest, PrevLowerBound) {
   Slice lower_bound(lower_bound_str);
   ro.iterate_lower_bound = &lower_bound;
   Options options;
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      10 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      10 /* sequence */, nullptr /* read_callback */));
 
   db_iter->SeekToLast();
   for (int i = kNumKeys; i >= kLowerBound; --i) {
@@ -3226,11 +3166,10 @@ TEST_F(DBIteratorTest, SeekLessLowerBound) {
   Slice lower_bound(lower_bound_str);
   ro.iterate_lower_bound = &lower_bound;
   Options options;
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ro, ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      10 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      10 /* sequence */, nullptr /* read_callback */));
 
   auto before_lower_bound_str = std::to_string(kLowerBound - 1);
   Slice before_lower_bound(lower_bound_str);
@@ -3252,11 +3191,10 @@ TEST_F(DBIteratorTest, ReverseToForwardWithDisappearingKeys) {
   }
   internal_iter->Finish();
 
-  std::unique_ptr<Iterator> db_iter(NewDBIterator(
+  std::unique_ptr<Iterator> db_iter(DBIter::NewIter(
       env_, ReadOptions(), ImmutableOptions(options), MutableCFOptions(options),
       BytewiseComparator(), internal_iter, nullptr /* version */,
-      10 /* sequence */, options.max_sequential_skip_in_iterations,
-      nullptr /* read_callback */));
+      10 /* sequence */, nullptr /* read_callback */));
 
   db_iter->SeekForPrev("a");
   ASSERT_TRUE(db_iter->Valid());

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -3879,13 +3879,11 @@ TEST_P(DBIteratorTest, MemtableTombstoneScanLimitWithNext) {
   // is reached during a Next() operation, and not trigger a flush when
   // the limit is reached across multiple Next() operations.
   const int kNumDelete = 10;
-  for (int limit : {kNumDelete}) {
-    // , kNumDelete + 1}) {
+  for (int limit : {kNumDelete, kNumDelete + 1}) {
     Options options;
     options.create_if_missing = true;
     options.memtable_tombstone_scan_limit = limit;
     DestroyAndReopen(options);
-    TryReopen(options);
 
     ASSERT_OK(Put(Key(0), "val"));
     for (int i = 1; i <= kNumDelete; ++i) {

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -3825,7 +3825,7 @@ TEST_F(DBIteratorTest, IteratorsConsistentViewExplicitSnapshot) {
 }
 
 TEST_P(DBIteratorTest, MemtableTombstoneScanLimitWithSeek) {
-  // Tests that option memtable_tombstone_scan_limit works when the limit
+  // Tests that option tombstone_scan_flush_trigger works when the limit
   // is reached during a Seek() operation.
   const int kNumDelete = 10;
   Random* r = Random::GetTLSInstance();
@@ -3833,7 +3833,7 @@ TEST_P(DBIteratorTest, MemtableTombstoneScanLimitWithSeek) {
   for (int limit : {kNumDelete, kNumDelete + 1}) {
     Options options;
     options.create_if_missing = true;
-    options.memtable_tombstone_scan_limit = limit;
+    options.tombstone_scan_flush_trigger = limit;
     options.level_compaction_dynamic_level_bytes = true;
     DestroyAndReopen(options);
     // Base data that will be covered by the consecutive sequence of tombstones.
@@ -3886,7 +3886,7 @@ TEST_P(DBIteratorTest, MemtableTombstoneScanLimitWithSeek) {
 }
 
 TEST_P(DBIteratorTest, MemtableTombstoneScanLimitWithNext) {
-  // Tests that option memtable_tombstone_scan_limit works when the limit
+  // Tests that option tombstone_scan_flush_trigger works when the limit
   // is reached during a Next() operation, and not trigger a flush when
   // the limit is reached across multiple Next() operations.
   const int kNumDelete = 10;
@@ -3894,7 +3894,7 @@ TEST_P(DBIteratorTest, MemtableTombstoneScanLimitWithNext) {
   for (int limit : {kNumDelete, kNumDelete + 1}) {
     Options options;
     options.create_if_missing = true;
-    options.memtable_tombstone_scan_limit = limit;
+    options.tombstone_scan_flush_trigger = limit;
     options.level_compaction_dynamic_level_bytes = true;
     DestroyAndReopen(options);
     // Base data that will be covered by the consecutive sequence of tombstones.

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -901,9 +901,9 @@ Status FlushJob::WriteLevel0Table() {
     for (ReadOnlyMemTable* m : mems_) {
       ROCKS_LOG_INFO(db_options_.info_log,
                      "[%s] [JOB %d] Flushing memtable id %" PRIu64
-                     " with next log file: %" PRIu64 "\n",
+                     " with next log file: %" PRIu64 ", marked_for_flush: %d\n",
                      cfd_->GetName().c_str(), job_context_->job_id, m->GetID(),
-                     m->GetNextLogNumber());
+                     m->GetNextLogNumber(), m->IsMarkedForFlush());
       if (logical_strip_timestamp) {
         memtables.push_back(m->NewTimestampStrippingIterator(
             ro, /*seqno_to_time_mapping=*/nullptr, &arena,

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -175,6 +175,11 @@ size_t MemTable::ApproximateMemoryUsage() {
 }
 
 bool MemTable::ShouldFlushNow() {
+  if (marked_for_flush_.load(std::memory_order_relaxed)) {
+    // TODO: dedicated flush reason when marked for flush
+    return true;
+  }
+
   // This is set if memtable_max_range_deletions is > 0,
   // and that many range deletions are done
   if (memtable_max_range_deletions_ > 0 &&

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -175,7 +175,7 @@ size_t MemTable::ApproximateMemoryUsage() {
 }
 
 bool MemTable::ShouldFlushNow() {
-  if (marked_for_flush_.load(std::memory_order_relaxed)) {
+  if (IsMarkedForFlush()) {
     // TODO: dedicated flush reason when marked for flush
     return true;
   }

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -496,6 +496,14 @@ class ReadOnlyMemTable {
     return false;
   }
 
+  void MarkForFlush() {
+    marked_for_flush_.store(true, std::memory_order_relaxed);
+  }
+
+  bool IsMarkedForFlush() const {
+    return marked_for_flush_.load(std::memory_order_relaxed);
+  }
+
  protected:
   friend class MemTableList;
 
@@ -524,6 +532,8 @@ class ReadOnlyMemTable {
 
   // Flush job info of the current memtable.
   std::unique_ptr<FlushJobInfo> flush_job_info_;
+
+  std::atomic<bool> marked_for_flush_ = false;
 };
 
 class MemTable final : public ReadOnlyMemTable {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -30,6 +30,7 @@
 #include "rocksdb/db.h"
 #include "rocksdb/memtablerep.h"
 #include "table/multiget_context.h"
+#include "util/atomic.h"
 #include "util/cast_util.h"
 #include "util/dynamic_bloom.h"
 #include "util/hash.h"
@@ -496,13 +497,9 @@ class ReadOnlyMemTable {
     return false;
   }
 
-  void MarkForFlush() {
-    marked_for_flush_.store(true, std::memory_order_relaxed);
-  }
+  void MarkForFlush() { marked_for_flush_.StoreRelaxed(true); }
 
-  bool IsMarkedForFlush() const {
-    return marked_for_flush_.load(std::memory_order_relaxed);
-  }
+  bool IsMarkedForFlush() const { return marked_for_flush_.LoadRelaxed(); }
 
  protected:
   friend class MemTableList;
@@ -533,7 +530,7 @@ class ReadOnlyMemTable {
   // Flush job info of the current memtable.
   std::unique_ptr<FlushJobInfo> flush_job_info_;
 
-  std::atomic<bool> marked_for_flush_ = false;
+  RelaxedAtomic<bool> marked_for_flush_{false};
 };
 
 class MemTable final : public ReadOnlyMemTable {

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -422,6 +422,7 @@ DECLARE_uint32(commit_bypass_memtable_one_in);
 DECLARE_bool(track_and_verify_wals);
 DECLARE_bool(enable_remote_compaction);
 DECLARE_bool(auto_refresh_iterator_with_snapshot);
+DECLARE_uint32(memtable_tombstone_scan_limit);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -422,7 +422,7 @@ DECLARE_uint32(commit_bypass_memtable_one_in);
 DECLARE_bool(track_and_verify_wals);
 DECLARE_bool(enable_remote_compaction);
 DECLARE_bool(auto_refresh_iterator_with_snapshot);
-DECLARE_uint32(tombstone_scan_flush_trigger);
+DECLARE_uint32(memtable_op_scan_flush_trigger);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -422,7 +422,7 @@ DECLARE_uint32(commit_bypass_memtable_one_in);
 DECLARE_bool(track_and_verify_wals);
 DECLARE_bool(enable_remote_compaction);
 DECLARE_bool(auto_refresh_iterator_with_snapshot);
-DECLARE_uint32(memtable_tombstone_scan_limit);
+DECLARE_uint32(tombstone_scan_flush_trigger);
 
 constexpr long KB = 1024;
 constexpr int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1470,8 +1470,8 @@ DEFINE_bool(
     "ReadOptions.auto_refresh_iterator_with_snapshot");
 
 DEFINE_uint32(
-    tombstone_scan_flush_trigger,
-    ROCKSDB_NAMESPACE::ColumnFamilyOptions().tombstone_scan_flush_trigger,
-    "Sets CF option tombstone_scan_flush_trigger.");
+    memtable_op_scan_flush_trigger,
+    ROCKSDB_NAMESPACE::ColumnFamilyOptions().memtable_op_scan_flush_trigger,
+    "Sets CF option memtable_op_scan_flush_trigger.");
 
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1470,8 +1470,8 @@ DEFINE_bool(
     "ReadOptions.auto_refresh_iterator_with_snapshot");
 
 DEFINE_uint32(
-    memtable_tombstone_scan_limit,
-    ROCKSDB_NAMESPACE::ColumnFamilyOptions().memtable_tombstone_scan_limit,
-    "Sets CF option memtable_tombstone_scan_limit.");
+    tombstone_scan_flush_trigger,
+    ROCKSDB_NAMESPACE::ColumnFamilyOptions().tombstone_scan_flush_trigger,
+    "Sets CF option tombstone_scan_flush_trigger.");
 
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1469,4 +1469,9 @@ DEFINE_bool(
     ROCKSDB_NAMESPACE::ReadOptions().auto_refresh_iterator_with_snapshot,
     "ReadOptions.auto_refresh_iterator_with_snapshot");
 
+DEFINE_uint32(
+    memtable_tombstone_scan_limit,
+    ROCKSDB_NAMESPACE::ColumnFamilyOptions().memtable_tombstone_scan_limit,
+    "Sets CF option memtable_tombstone_scan_limit.");
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4317,7 +4317,7 @@ void InitializeOptionsFromFlags(
     options.compaction_service = std::make_shared<DbStressCompactionService>();
   }
 
-  options.memtable_tombstone_scan_limit = FLAGS_memtable_tombstone_scan_limit;
+  options.tombstone_scan_flush_trigger = FLAGS_tombstone_scan_flush_trigger;
 }
 
 void InitializeOptionsGeneral(

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4317,7 +4317,7 @@ void InitializeOptionsFromFlags(
     options.compaction_service = std::make_shared<DbStressCompactionService>();
   }
 
-  options.tombstone_scan_flush_trigger = FLAGS_tombstone_scan_flush_trigger;
+  options.memtable_op_scan_flush_trigger = FLAGS_memtable_op_scan_flush_trigger;
 }
 
 void InitializeOptionsGeneral(

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4316,6 +4316,8 @@ void InitializeOptionsFromFlags(
   if (FLAGS_enable_remote_compaction) {
     options.compaction_service = std::make_shared<DbStressCompactionService>();
   }
+
+  options.memtable_tombstone_scan_limit = FLAGS_memtable_tombstone_scan_limit;
 }
 
 void InitializeOptionsGeneral(

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1096,6 +1096,19 @@ struct AdvancedColumnFamilyOptions {
   // additional key comparison during memtable lookup.
   bool paranoid_memory_checks = false;
 
+  // When an iterator scans this number of tombstones from the active memtable
+  // for a single iterator operation, we will try to flush the memtable.
+  // Currently forward scan is supported (SeekToFirst(), Seek() and Next()).
+  // This helps to reduce the overhead of scanning through a large number of
+  // tombstones in memtable.
+  // Users should consider enable deletion-triggered-compaction (see
+  // CompactOnDeletionCollectorFactory) together with this option to compact
+  // away tombstones after the memtable is flushed.
+  //
+  // Default: 0 (disabled)
+  // Dynamically changeable through the SetOptions() API.
+  uint32_t memtable_tombstone_scan_limit = 0;
+
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1096,18 +1096,19 @@ struct AdvancedColumnFamilyOptions {
   // additional key comparison during memtable lookup.
   bool paranoid_memory_checks = false;
 
-  // When an iterator scans this number of tombstones from the active memtable
-  // for a single iterator operation, we will try to flush the memtable.
-  // Currently forward scan is supported (SeekToFirst(), Seek() and Next()).
-  // This helps to reduce the overhead of scanning through a large number of
-  // tombstones in memtable.
+  // When an iterator scans this number of invisible entries (tombstones or
+  // hidden puts) from the active memtable during a single iterator operation,
+  // we will attempt to flush the memtable. Currently only forward scans are
+  // supported (SeekToFirst(), Seek() and Next()).
+  // This option helps to reduce the overhead of scanning through a
+  // large number of entries in memtable.
   // Users should consider enable deletion-triggered-compaction (see
   // CompactOnDeletionCollectorFactory) together with this option to compact
   // away tombstones after the memtable is flushed.
   //
   // Default: 0 (disabled)
   // Dynamically changeable through the SetOptions() API.
-  uint32_t tombstone_scan_flush_trigger = 0;
+  uint32_t memtable_op_scan_flush_trigger = 0;
 
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1107,7 +1107,7 @@ struct AdvancedColumnFamilyOptions {
   //
   // Default: 0 (disabled)
   // Dynamically changeable through the SetOptions() API.
-  uint32_t memtable_tombstone_scan_limit = 0;
+  uint32_t tombstone_scan_flush_trigger = 0;
 
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -694,8 +694,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, memtable_max_range_deletions),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
-        {"tombstone_scan_flush_trigger",
-         {offsetof(struct MutableCFOptions, tombstone_scan_flush_trigger),
+        {"memtable_op_scan_flush_trigger",
+         {offsetof(struct MutableCFOptions, memtable_op_scan_flush_trigger),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
 };
@@ -1179,8 +1179,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  bottommost_file_compaction_delay);
   ROCKS_LOG_INFO(log, "                   uncache_aggressiveness: %" PRIu32,
                  uncache_aggressiveness);
-  ROCKS_LOG_INFO(log, "             tombstone_scan_flush_trigger: %" PRIu32,
-                 tombstone_scan_flush_trigger);
+  ROCKS_LOG_INFO(log, "             memtable_op_scan_flush_trigger: %" PRIu32,
+                 memtable_op_scan_flush_trigger);
 
   // Universal Compaction Options
   ROCKS_LOG_INFO(log, "compaction_options_universal.size_ratio : %d",

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -694,8 +694,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, memtable_max_range_deletions),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
-        {"memtable_tombstone_scan_limit",
-         {offsetof(struct MutableCFOptions, memtable_tombstone_scan_limit),
+        {"tombstone_scan_flush_trigger",
+         {offsetof(struct MutableCFOptions, tombstone_scan_flush_trigger),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
 };
@@ -1179,8 +1179,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  bottommost_file_compaction_delay);
   ROCKS_LOG_INFO(log, "                   uncache_aggressiveness: %" PRIu32,
                  uncache_aggressiveness);
-  ROCKS_LOG_INFO(log, "            memtable_tombstone_scan_limit: %" PRIu32,
-                 memtable_tombstone_scan_limit);
+  ROCKS_LOG_INFO(log, "             tombstone_scan_flush_trigger: %" PRIu32,
+                 tombstone_scan_flush_trigger);
 
   // Universal Compaction Options
   ROCKS_LOG_INFO(log, "compaction_options_universal.size_ratio : %d",

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -694,7 +694,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, memtable_max_range_deletions),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
-
+        {"memtable_tombstone_scan_limit",
+         {offsetof(struct MutableCFOptions, memtable_tombstone_scan_limit),
+          OptionType::kUInt32T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
 };
 
 static std::unordered_map<std::string, OptionTypeInfo>
@@ -1176,6 +1179,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  bottommost_file_compaction_delay);
   ROCKS_LOG_INFO(log, "                   uncache_aggressiveness: %" PRIu32,
                  uncache_aggressiveness);
+  ROCKS_LOG_INFO(log, "            memtable_tombstone_scan_limit: %" PRIu32,
+                 memtable_tombstone_scan_limit);
 
   // Universal Compaction Options
   ROCKS_LOG_INFO(log, "compaction_options_universal.size_ratio : %d",

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -230,7 +230,7 @@ struct MutableCFOptions {
         memtable_max_range_deletions(0),
         bottommost_file_compaction_delay(0),
         uncache_aggressiveness(0),
-        memtable_tombstone_scan_limit(UINT32_MAX) {}
+        memtable_tombstone_scan_limit(0) {}
 
   explicit MutableCFOptions(const Options& options);
 

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -174,7 +174,7 @@ struct MutableCFOptions {
         bottommost_file_compaction_delay(
             options.bottommost_file_compaction_delay),
         uncache_aggressiveness(options.uncache_aggressiveness),
-        tombstone_scan_flush_trigger(options.tombstone_scan_flush_trigger) {
+        memtable_op_scan_flush_trigger(options.memtable_op_scan_flush_trigger) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -230,7 +230,7 @@ struct MutableCFOptions {
         memtable_max_range_deletions(0),
         bottommost_file_compaction_delay(0),
         uncache_aggressiveness(0),
-        tombstone_scan_flush_trigger(0) {}
+        memtable_op_scan_flush_trigger(0) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -338,7 +338,7 @@ struct MutableCFOptions {
   uint32_t memtable_max_range_deletions;
   uint32_t bottommost_file_compaction_delay;
   uint32_t uncache_aggressiveness;
-  uint32_t tombstone_scan_flush_trigger;
+  uint32_t memtable_op_scan_flush_trigger;
 
   // Derived options
   // Per-level target file size.

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -174,7 +174,7 @@ struct MutableCFOptions {
         bottommost_file_compaction_delay(
             options.bottommost_file_compaction_delay),
         uncache_aggressiveness(options.uncache_aggressiveness),
-        memtable_tombstone_scan_limit(options.memtable_tombstone_scan_limit) {
+        tombstone_scan_flush_trigger(options.tombstone_scan_flush_trigger) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -230,7 +230,7 @@ struct MutableCFOptions {
         memtable_max_range_deletions(0),
         bottommost_file_compaction_delay(0),
         uncache_aggressiveness(0),
-        memtable_tombstone_scan_limit(0) {}
+        tombstone_scan_flush_trigger(0) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -338,7 +338,7 @@ struct MutableCFOptions {
   uint32_t memtable_max_range_deletions;
   uint32_t bottommost_file_compaction_delay;
   uint32_t uncache_aggressiveness;
-  uint32_t memtable_tombstone_scan_limit;
+  uint32_t tombstone_scan_flush_trigger;
 
   // Derived options
   // Per-level target file size.

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -173,7 +173,8 @@ struct MutableCFOptions {
         memtable_max_range_deletions(options.memtable_max_range_deletions),
         bottommost_file_compaction_delay(
             options.bottommost_file_compaction_delay),
-        uncache_aggressiveness(options.uncache_aggressiveness) {
+        uncache_aggressiveness(options.uncache_aggressiveness),
+        memtable_tombstone_scan_limit(options.memtable_tombstone_scan_limit) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -228,7 +229,8 @@ struct MutableCFOptions {
         sample_for_compression(0),
         memtable_max_range_deletions(0),
         bottommost_file_compaction_delay(0),
-        uncache_aggressiveness(0) {}
+        uncache_aggressiveness(0),
+        memtable_tombstone_scan_limit(UINT32_MAX) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -336,6 +338,7 @@ struct MutableCFOptions {
   uint32_t memtable_max_range_deletions;
   uint32_t bottommost_file_compaction_delay;
   uint32_t uncache_aggressiveness;
+  uint32_t memtable_tombstone_scan_limit;
 
   // Derived options
   // Per-level target file size.

--- a/options/options.cc
+++ b/options/options.cc
@@ -111,7 +111,8 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       blob_file_starting_level(options.blob_file_starting_level),
       blob_cache(options.blob_cache),
       prepopulate_blob_cache(options.prepopulate_blob_cache),
-      persist_user_defined_timestamps(options.persist_user_defined_timestamps) {
+      persist_user_defined_timestamps(options.persist_user_defined_timestamps),
+      memtable_tombstone_scan_limit(options.memtable_tombstone_scan_limit) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
       static_cast<unsigned int>(num_levels)) {
@@ -283,6 +284,9 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "      Options.max_sequential_skip_in_iterations: %" PRIu64,
                    max_sequential_skip_in_iterations);
+  ROCKS_LOG_HEADER(log,
+                   "          Options.memtable_tombstone_scan_limit: %" PRIu32,
+                   memtable_tombstone_scan_limit);
   ROCKS_LOG_HEADER(log,
                    "                   Options.max_compaction_bytes: %" PRIu64,
                    max_compaction_bytes);

--- a/options/options.cc
+++ b/options/options.cc
@@ -112,7 +112,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       blob_cache(options.blob_cache),
       prepopulate_blob_cache(options.prepopulate_blob_cache),
       persist_user_defined_timestamps(options.persist_user_defined_timestamps),
-      tombstone_scan_flush_trigger(options.tombstone_scan_flush_trigger) {
+      memtable_op_scan_flush_trigger(options.memtable_op_scan_flush_trigger) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
       static_cast<unsigned int>(num_levels)) {
@@ -284,9 +284,9 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "      Options.max_sequential_skip_in_iterations: %" PRIu64,
                    max_sequential_skip_in_iterations);
-  ROCKS_LOG_HEADER(log,
-                   "           Options.tombstone_scan_flush_trigger: %" PRIu32,
-                   tombstone_scan_flush_trigger);
+  ROCKS_LOG_HEADER(
+      log, "           Options.memtable_op_scan_flush_trigger: %" PRIu32,
+      memtable_op_scan_flush_trigger);
   ROCKS_LOG_HEADER(log,
                    "                   Options.max_compaction_bytes: %" PRIu64,
                    max_compaction_bytes);

--- a/options/options.cc
+++ b/options/options.cc
@@ -112,7 +112,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       blob_cache(options.blob_cache),
       prepopulate_blob_cache(options.prepopulate_blob_cache),
       persist_user_defined_timestamps(options.persist_user_defined_timestamps),
-      memtable_tombstone_scan_limit(options.memtable_tombstone_scan_limit) {
+      tombstone_scan_flush_trigger(options.tombstone_scan_flush_trigger) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
       static_cast<unsigned int>(num_levels)) {
@@ -285,8 +285,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                    "      Options.max_sequential_skip_in_iterations: %" PRIu64,
                    max_sequential_skip_in_iterations);
   ROCKS_LOG_HEADER(log,
-                   "          Options.memtable_tombstone_scan_limit: %" PRIu32,
-                   memtable_tombstone_scan_limit);
+                   "           Options.tombstone_scan_flush_trigger: %" PRIu32,
+                   tombstone_scan_flush_trigger);
   ROCKS_LOG_HEADER(log,
                    "                   Options.max_compaction_bytes: %" PRIu64,
                    max_compaction_bytes);

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -299,6 +299,8 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->default_write_temperature = moptions.default_write_temperature;
   cf_opts->memtable_max_range_deletions = moptions.memtable_max_range_deletions;
   cf_opts->uncache_aggressiveness = moptions.uncache_aggressiveness;
+  cf_opts->memtable_tombstone_scan_limit =
+      moptions.memtable_tombstone_scan_limit;
 }
 
 void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -299,7 +299,8 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->default_write_temperature = moptions.default_write_temperature;
   cf_opts->memtable_max_range_deletions = moptions.memtable_max_range_deletions;
   cf_opts->uncache_aggressiveness = moptions.uncache_aggressiveness;
-  cf_opts->tombstone_scan_flush_trigger = moptions.tombstone_scan_flush_trigger;
+  cf_opts->memtable_op_scan_flush_trigger =
+      moptions.memtable_op_scan_flush_trigger;
 }
 
 void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -299,8 +299,7 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->default_write_temperature = moptions.default_write_temperature;
   cf_opts->memtable_max_range_deletions = moptions.memtable_max_range_deletions;
   cf_opts->uncache_aggressiveness = moptions.uncache_aggressiveness;
-  cf_opts->memtable_tombstone_scan_limit =
-      moptions.memtable_tombstone_scan_limit;
+  cf_opts->tombstone_scan_flush_trigger = moptions.tombstone_scan_flush_trigger;
 }
 
 void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -675,7 +675,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "bottommost_file_compaction_delay=7200;"
       "uncache_aggressiveness=1234;"
       "paranoid_memory_checks=1;"
-      "tombstone_scan_flush_trigger=123;",
+      "memtable_op_scan_flush_trigger=123;",
       new_options));
 
   ASSERT_NE(new_options->blob_cache.get(), nullptr);

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -674,7 +674,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "memtable_max_range_deletions=999999;"
       "bottommost_file_compaction_delay=7200;"
       "uncache_aggressiveness=1234;"
-      "paranoid_memory_checks=1;",
+      "paranoid_memory_checks=1;"
+      "memtable_tombstone_scan_limit=123;",
       new_options));
 
   ASSERT_NE(new_options->blob_cache.get(), nullptr);

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -675,7 +675,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "bottommost_file_compaction_delay=7200;"
       "uncache_aggressiveness=1234;"
       "paranoid_memory_checks=1;"
-      "memtable_tombstone_scan_limit=123;",
+      "tombstone_scan_flush_trigger=123;",
       new_options));
 
   ASSERT_NE(new_options->blob_cache.get(), nullptr);

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -166,11 +166,11 @@ Iterator* SstFileReader::NewIterator(const ReadOptions& roptions) {
                       ? roptions.snapshot->GetSequenceNumber()
                       : kMaxSequenceNumber;
   ArenaWrappedDBIter* res = new ArenaWrappedDBIter();
-  res->Init(
-      r->options.env, roptions, r->ioptions, r->moptions, nullptr /* version */,
-      sequence, r->moptions.max_sequential_skip_in_iterations,
-      0 /* version_number */, nullptr /* read_callback */, nullptr /* cfh */,
-      true /* expose_blob_index */, false /* allow_refresh */);
+  res->Init(r->options.env, roptions, r->ioptions, r->moptions,
+            nullptr /* version */, sequence, 0 /* version_number */,
+            nullptr /* read_callback */, nullptr /* cfh */,
+            true /* expose_blob_index */, false /* allow_refresh */,
+            /*active_mem=*/nullptr);
   auto internal_iter = r->table_reader->NewIterator(
       res->GetReadOptions(), r->moptions.prefix_extractor.get(),
       res->GetArena(), false /* skip_filters */,

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1279,10 +1279,10 @@ DEFINE_bool(explicit_snapshot, false,
             "When set to true iterators will be initialized with explicit "
             "snapshot");
 
-DEFINE_uint32(
-    memtable_tombstone_scan_limit,
-    rocksdb::AdvancedColumnFamilyOptions().memtable_tombstone_scan_limit,
-    "Setting for CF option memtable_tombstone_scan_limit.");
+DEFINE_uint32(memtable_tombstone_scan_limit,
+              ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
+                  .memtable_tombstone_scan_limit,
+              "Setting for CF option memtable_tombstone_scan_limit.");
 
 static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
     const char* ctype) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1279,6 +1279,11 @@ DEFINE_bool(explicit_snapshot, false,
             "When set to true iterators will be initialized with explicit "
             "snapshot");
 
+DEFINE_uint32(
+    memtable_tombstone_scan_limit,
+    rocksdb::AdvancedColumnFamilyOptions().memtable_tombstone_scan_limit,
+    "Setting for CF option memtable_tombstone_scan_limit.");
+
 static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
     const char* ctype) {
   assert(ctype);
@@ -4747,6 +4752,7 @@ class Benchmark {
     options.block_protection_bytes_per_key =
         FLAGS_block_protection_bytes_per_key;
     options.paranoid_memory_checks = FLAGS_paranoid_memory_checks;
+    options.memtable_tombstone_scan_limit = FLAGS_memtable_tombstone_scan_limit;
   }
 
   void InitializeOptionsGeneral(Options* opts, ToolHooks& hooks) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1279,10 +1279,10 @@ DEFINE_bool(explicit_snapshot, false,
             "When set to true iterators will be initialized with explicit "
             "snapshot");
 
-DEFINE_uint32(tombstone_scan_flush_trigger,
+DEFINE_uint32(memtable_op_scan_flush_trigger,
               ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
-                  .tombstone_scan_flush_trigger,
-              "Setting for CF option tombstone_scan_flush_trigger.");
+                  .memtable_op_scan_flush_trigger,
+              "Setting for CF option memtable_op_scan_flush_trigger.");
 
 static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
     const char* ctype) {
@@ -4752,7 +4752,8 @@ class Benchmark {
     options.block_protection_bytes_per_key =
         FLAGS_block_protection_bytes_per_key;
     options.paranoid_memory_checks = FLAGS_paranoid_memory_checks;
-    options.tombstone_scan_flush_trigger = FLAGS_tombstone_scan_flush_trigger;
+    options.memtable_op_scan_flush_trigger =
+        FLAGS_memtable_op_scan_flush_trigger;
   }
 
   void InitializeOptionsGeneral(Options* opts, ToolHooks& hooks) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1279,10 +1279,10 @@ DEFINE_bool(explicit_snapshot, false,
             "When set to true iterators will be initialized with explicit "
             "snapshot");
 
-DEFINE_uint32(memtable_tombstone_scan_limit,
+DEFINE_uint32(tombstone_scan_flush_trigger,
               ROCKSDB_NAMESPACE::AdvancedColumnFamilyOptions()
-                  .memtable_tombstone_scan_limit,
-              "Setting for CF option memtable_tombstone_scan_limit.");
+                  .tombstone_scan_flush_trigger,
+              "Setting for CF option tombstone_scan_flush_trigger.");
 
 static enum ROCKSDB_NAMESPACE::CompressionType StringToCompressionType(
     const char* ctype) {
@@ -4752,7 +4752,7 @@ class Benchmark {
     options.block_protection_bytes_per_key =
         FLAGS_block_protection_bytes_per_key;
     options.paranoid_memory_checks = FLAGS_paranoid_memory_checks;
-    options.memtable_tombstone_scan_limit = FLAGS_memtable_tombstone_scan_limit;
+    options.tombstone_scan_flush_trigger = FLAGS_tombstone_scan_flush_trigger;
   }
 
   void InitializeOptionsGeneral(Options* opts, ToolHooks& hooks) {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -344,7 +344,7 @@ default_params = {
     "allow_unprepared_value": lambda: random.choice([0, 1]),
     "enable_remote_compaction": lambda: random.choice([0, 1]),
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
-    "tombstone_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
+    "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -344,6 +344,7 @@ default_params = {
     "allow_unprepared_value": lambda: random.choice([0, 1]),
     "enable_remote_compaction": lambda: random.choice([0, 1]),
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
+    "memtable_tombstone_scan_limit": lambda: random.choice([0, 10, 100, 1000]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -344,7 +344,7 @@ default_params = {
     "allow_unprepared_value": lambda: random.choice([0, 1]),
     "enable_remote_compaction": lambda: random.choice([0, 1]),
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
-    "memtable_tombstone_scan_limit": lambda: random.choice([0, 10, 100, 1000]),
+    "tombstone_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"
 # If TEST_TMPDIR_EXPECTED is not specified, default value will be TEST_TMPDIR

--- a/unreleased_history/new_features/tombstone_scan_flush_trigger.md
+++ b/unreleased_history/new_features/tombstone_scan_flush_trigger.md
@@ -1,0 +1,1 @@
+* Add a new CF option `tombstone_scan_flush_trigger` that triggers a flush of the memtable if an iterator's Seek()/Next() scans over a certain number of tombstones from the memtable.

--- a/unreleased_history/new_features/tombstone_scan_flush_trigger.md
+++ b/unreleased_history/new_features/tombstone_scan_flush_trigger.md
@@ -1,1 +1,1 @@
-* Add a new CF option `tombstone_scan_flush_trigger` that triggers a flush of the memtable if an iterator's Seek()/Next() scans over a certain number of tombstones from the memtable.
+* Add a new CF option `memtable_op_scan_flush_trigger` that triggers a flush of the memtable if an iterator's Seek()/Next() scans over a certain number of invisible entries from the memtable.


### PR DESCRIPTION
Summary: Introduce a mutable CF option `memtable_op_scan_flush_trigger`. When a DB iterator scans this number of hidden entries (tombstones, overwritten puts) from the active memtable in a Seek() or Next() operation, it marks the memtable to be eligible for flush. Subsequent write operations will schedule the marked memtable for flush.

The main change is small and is in db_iter.cc. Some refactoring is done to consolidate and simplify creation of `ArenaWrappedDBIter` and `DBIter`. 

Test plan:
- new unit tests added.
- added `memtable_op_scan_flush_trigger` in crash test
- benchmark: 
The following benchmark was done with a previous version of the PR where the option was `memtable_tombstone_scan_limit` and it concerns tombstone only. The results should still be applicable for the case when there's no overwritten puts.

Tests that when memtable has many tombstones, the option helps to improve scan performance:
```
TEST_TMPDIR=/dev/shm ./db_bench --benchmarks=seekrandomwhilewriting --expand_range_tombstones=true --writes_per_range_tombstone=1 --max_num_range_tombstones=10000000 --perf_level=2 --range_tombstone_width=100 --memtable_tombstone_scan_limit=


memtable_tombstone_scan_limit = 10000
seekrandomwhilewriting :      18.527 micros/op 53973 ops/sec 18.527 seconds 1000000 operations; (7348 of 1000000 found)
next_on_memtable_count = 122305248
grep "flush_started" /dev/shm/dbbench/LOG | wc
      8     200    2417

memtable_tombstone_scan_limit=200
seekrandomwhilewriting :       4.918 micros/op 203315 ops/sec 4.918 seconds 1000000 operations; (4510 of 1000000 found)
next_on_memtable_count = 1853167
grep "flush_started" /dev/shm/dbbench/LOG | wc
    184    4600   54121

When memtable_tombstone_scan_limit=200, more flush is trigged to drop tombstones sooner and improve scan performance.
```

Tests that the new option does not introduce noticeable regression:
```
TEST_TMPDIR=/dev/shm ./db_bench --benchmarks=seekrandomwhilewriting[-X5] --expand_range_tombstones=true --writes_per_range_tombstone=1 --max_num_range_tombstones=10000000 --perf_level=2 --range_tombstone_width=100 --seed=123

Main: 
seekrandomwhilewriting [AVG 5 runs] : 46049 (± 4512) ops/sec
PR: 
seekrandomwhilewriting [AVG 5 runs] : 46100 (± 4470) ops/sec

The results are noisy with this PR performing better and worse in different runs, with no noticeable regression. 
```
