### PR TITLE
Support atomic_flush for ingesting WBWI

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1570,8 +1570,7 @@ class DBImpl : public DB {
                    size_t batch_cnt = 0,
                    PreReleaseCallback* pre_release_callback = nullptr,
                    PostMemTableCallback* post_memtable_callback = nullptr,
-                   std::shared_ptr<WriteBatchWithIndex> wbwi = nullptr,
-                   uint64_t min_prep_log = 0);
+                   std::shared_ptr<WriteBatchWithIndex> wbwi = nullptr);
 
   Status PipelinedWriteImpl(const WriteOptions& options, WriteBatch* updates,
                             WriteCallback* callback = nullptr,

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -192,7 +192,7 @@ Status DBImpl::WriteWithCallback(const WriteOptions& write_options,
 
 Status DBImpl::IngestWBWI(std::shared_ptr<WriteBatchWithIndex> wbwi,
                           const WBWIMemTable::SeqnoRange& assigned_seqno,
-                          uint64_t prep_log,
+                          uint64_t min_prep_log,
                           SequenceNumber last_seqno_after_ingest,
                           bool memtable_updated, bool ignore_missing_cf) {
   // Keys in new memtable have seqno > last_seqno_after_ingest >= keys in wbwi.
@@ -238,7 +238,7 @@ Status DBImpl::IngestWBWI(std::shared_ptr<WriteBatchWithIndex> wbwi,
     wbwi_memtable->AssignSequenceNumbers(assigned_seqno);
     // This is needed to keep the WAL that contains Prepare alive until
     // committed data in this memtable is persisted.
-    wbwi_memtable->SetMinPrepLog(prep_log);
+    wbwi_memtable->SetMinPrepLog(min_prep_log);
     memtables.push_back(wbwi_memtable);
     cfd->Ref();
     cfds.push_back(cfd);
@@ -879,7 +879,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
         assert(ub <= versions_->LastAllocatedSequence());
       }
       status = IngestWBWI(wbwi, {/*lower_bound=*/lb, /*upper_bound=*/ub},
-                          /*prep_log=*/log_ref, last_sequence,
+                          /*min_prep_log=*/log_ref, last_sequence,
                           /*memtable_updated=*/memtable_update_count > 0,
                           write_options.ignore_missing_column_families);
     }

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -244,6 +244,24 @@ Status DBImpl::IngestWBWI(std::shared_ptr<WriteBatchWithIndex> wbwi,
     cfds.push_back(cfd);
   }
 
+  autovector<ColumnFamilyData*> cfds_for_atomic_flush;
+  if (immutable_db_options_.atomic_flush) {
+    SelectColumnFamiliesForAtomicFlush(&cfds_for_atomic_flush);
+    for (auto cfd : cfds_for_atomic_flush) {
+      bool found = false;
+      for (auto existing_cfd : cfds) {
+        if (existing_cfd == cfd) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        cfd->Ref();
+        cfds.push_back(cfd);
+      }
+    }
+  }
+
   // Stop writes to the DB by entering both write threads
   WriteThread::Writer nonmem_w;
   if (two_write_queues_) {
@@ -253,15 +271,16 @@ Status DBImpl::IngestWBWI(std::shared_ptr<WriteBatchWithIndex> wbwi,
 
   // Switch memtable and add WBWIMemTables
   Status s;
-  for (size_t i = 0; i < memtables.size(); ++i) {
-    assert(!immutable_db_options_.atomic_flush);
-    // NOTE: to support atomic flush, need to call
-    // SelectColumnFamiliesForAtomicFlush()
+  for (size_t i = 0; i < cfds.size(); ++i) {
     WriteContext write_context;
     // TODO: not switch on empty memtable, may need to update metadata
     //   like NextLogNumber(), earliest_seqno and memtable id.
-    s = SwitchMemtable(cfds[i], &write_context, memtables[i],
-                       last_seqno_after_ingest);
+    if (i < memtables.size()) {
+      s = SwitchMemtable(cfds[i], &write_context, memtables[i],
+                         last_seqno_after_ingest);
+    } else {
+      s = SwitchMemtable(cfds[i], &write_context);
+    }
     if (!s.ok()) {
       // SwitchMemtable() can only fail if a new WAL is to be created, this
       // should only happen for the first call to SwitchMemtable(). log will
@@ -301,9 +320,18 @@ Status DBImpl::IngestWBWI(std::shared_ptr<WriteBatchWithIndex> wbwi,
         continue;
       }
       cfd->imm()->FlushRequested();
+      if (!immutable_db_options_.atomic_flush) {
+        FlushRequest flush_req;
+        // TODO: a new flush reason for ingesting memtable
+        GenerateFlushRequest({cfd}, FlushReason::kExternalFileIngestion,
+                             &flush_req);
+        EnqueuePendingFlush(flush_req);
+      }
+    }
+    if (immutable_db_options_.atomic_flush) {
+      AssignAtomicFlushSeq(cfds);
       FlushRequest flush_req;
-      // TODO: a new flush reason for ingesting memtable
-      GenerateFlushRequest({cfd}, FlushReason::kExternalFileIngestion,
+      GenerateFlushRequest(cfds, FlushReason::kExternalFileIngestion,
                            &flush_req);
       EnqueuePendingFlush(flush_req);
     }
@@ -319,8 +347,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
                          uint64_t* seq_used, size_t batch_cnt,
                          PreReleaseCallback* pre_release_callback,
                          PostMemTableCallback* post_memtable_callback,
-                         std::shared_ptr<WriteBatchWithIndex> wbwi,
-                         uint64_t prep_log) {
+                         std::shared_ptr<WriteBatchWithIndex> wbwi) {
   assert(!seq_per_batch_ || batch_cnt != 0);
   assert(my_batch == nullptr || my_batch->Count() == 0 ||
          write_options.protection_bytes_per_key == 0 ||
@@ -410,7 +437,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
         "DeleteRange is not compatible with row cache.");
   }
   if (wbwi) {
-    assert(prep_log > 0);
+    assert(log_ref > 0);
     // Used only in WriteCommittedTxn::CommitInternal() with no `callback`.
     assert(!callback);
     if (immutable_db_options_.unordered_write) {
@@ -420,10 +447,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
     if (immutable_db_options_.enable_pipelined_write) {
       return Status::NotSupported(
           "Ingesting WriteBatch does not support pipelined_write");
-    }
-    if (immutable_db_options_.atomic_flush) {
-      return Status::NotSupported(
-          "Ingesting WriteBatch does not support atomic_flush");
     }
   }
   // Otherwise IsLatestPersistentState optimization does not make sense
@@ -856,7 +879,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
         assert(ub <= versions_->LastAllocatedSequence());
       }
       status = IngestWBWI(wbwi, {/*lower_bound=*/lb, /*upper_bound=*/ub},
-                          prep_log, last_sequence,
+                          /*prep_log=*/log_ref, last_sequence,
                           /*memtable_updated=*/memtable_update_count > 0,
                           write_options.ignore_missing_column_families);
     }
@@ -1918,7 +1941,10 @@ void DBImpl::AssignAtomicFlushSeq(const autovector<ColumnFamilyData*>& cfds) {
   assert(immutable_db_options_.atomic_flush);
   auto seq = versions_->LastSequence();
   for (auto cfd : cfds) {
-    cfd->imm()->AssignAtomicFlushSeq(seq);
+    // cfd can be nullptr, see ScheduleFlushes()
+    if (cfd) {
+      cfd->imm()->AssignAtomicFlushSeq(seq);
+    }
   }
 }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1029,7 +1029,6 @@ def finalize_and_sanitize(src_params):
     ):
         dest_params["enable_blob_files"] = 0
         dest_params["allow_setting_blob_options_dynamically"] = 0
-        dest_params["atomic_flush"] = 0
         dest_params["allow_concurrent_memtable_write"] = 0
         dest_params["use_put_entity_one_in"] = 0
         dest_params["use_get_entity"] = 0

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -920,8 +920,8 @@ Status WriteCommittedTxn::CommitInternal() {
         /*wal_used*/ nullptr, /*log_ref*/ log_number_,
         /*disable_memtable*/ false, &seq_used,
         /*batch_cnt=*/0, /*pre_release_callback=*/nullptr, post_mem_cb,
-        /*wbwi=*/std::make_shared<WriteBatchWithIndex>(std::move(write_batch_)),
-        /*min_prep_log=*/log_number_);
+        /*wbwi=*/
+        std::make_shared<WriteBatchWithIndex>(std::move(write_batch_)));
     // Reset write_batch_ since it's accessed in transaction clean up and
     // might be used for transaction reuse.
     write_batch_ = WriteBatchWithIndex(cmp_, 0, true, 0,

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -8924,13 +8924,15 @@ class CommitBypassMemtableTest : public DBTestBase,
   TransactionDBOptions txn_db_opts;
 
   void SetUpTransactionDB(
-      uint32_t threshold = std::numeric_limits<uint32_t>::max()) {
+      uint32_t threshold = std::numeric_limits<uint32_t>::max(),
+      bool atomic_flush = false) {
     options = CurrentOptions();
     options.create_if_missing = true;
     options.allow_2pc = true;
     options.two_write_queues = GetParam();
     // Avoid write stall
     options.max_write_buffer_number = 8;
+    options.atomic_flush = atomic_flush;
     // Destroy the DB to recreate as a TransactionDB.
     Close();
     Destroy(options, true);
@@ -9450,6 +9452,37 @@ TEST_P(CommitBypassMemtableTest, ThresholdTxnDBOption) {
     ASSERT_OK(txn_cf->Commit());
     ASSERT_EQ(commit_bypass_memtable, num_ops > threshold);
     delete txn_cf;
+  }
+}
+
+TEST_P(CommitBypassMemtableTest, AtomicFlushTest) {
+  const uint32_t threshold = 10;
+  SetUpTransactionDB(/*threshold=*/threshold, /*atomic_flush=*/true);
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  std::vector<std::string> cfs = {"cf0", "cf1", "cf2"};
+  CreateColumnFamilies(cfs, options);
+
+  // Seed data in CF1 and 2 as atomic flush picks CFs with non-empty memtable
+  ASSERT_OK(db_->Put({}, handles_[1], "key1", "val1"));
+  ASSERT_OK(db_->Put({}, handles_[2], "key2", "val2"));
+
+  // Write to cf 1, should see 2 and 3 flushed too
+  auto txn = txn_db->BeginTransaction({}, {}, nullptr);
+  for (uint32_t i = 0; i <= threshold; ++i) {
+    ASSERT_OK(txn->Put(handles_[0], "key" + std::to_string(i),
+                       "cf0" + std::to_string(i)));
+  }
+  txn->SetName("cf0");
+  ASSERT_OK(txn->Prepare());
+  ASSERT_OK(txn->Commit());
+  delete txn;
+
+  ASSERT_OK(db_->WaitForCompact({}));
+  for (size_t i = 0; i < 3; ++i) {
+    auto cfh = static_cast<ColumnFamilyHandleImpl*>(handles_[i]);
+    ASSERT_EQ(0, cfh->cfd()->imm()->NumNotFlushed());
+    ASSERT_TRUE(cfh->cfd()->mem()->IsEmpty());
   }
 }
 

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -9467,7 +9467,7 @@ TEST_P(CommitBypassMemtableTest, AtomicFlushTest) {
   ASSERT_OK(db_->Put({}, handles_[1], "key1", "val1"));
   ASSERT_OK(db_->Put({}, handles_[2], "key2", "val2"));
 
-  // Write to cf 1, should see 2 and 3 flushed too
+  // Write to cf 0, should see cf1 and cf2 flushed too
   auto txn = txn_db->BeginTransaction({}, {}, nullptr);
   for (uint32_t i = 0; i <= threshold; ++i) {
     ASSERT_OK(txn->Put(handles_[0], "key" + std::to_string(i),

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -9473,7 +9473,7 @@ TEST_P(CommitBypassMemtableTest, AtomicFlushTest) {
     ASSERT_OK(txn->Put(handles_[0], "key" + std::to_string(i),
                        "cf0" + std::to_string(i)));
   }
-  txn->SetName("cf0");
+  ASSERT_OK(txn->SetName("cf0"));
   ASSERT_OK(txn->Prepare());
   ASSERT_OK(txn->Commit());
   delete txn;


### PR DESCRIPTION
Summary: add support for atomic_flush when using WBWI ingestion [feature](https://github.com/facebook/rocksdb/blob/29c6610617ddc1b486f12b99c16e7c9851e80430/include/rocksdb/utilities/transaction_db.h#L387). Transaction DB usually uses WAL so atomic_flush is not as helpful. This is to prepare for a follow up PR that enables ingesting WBWI without using transaction DB.

This PR also removes a redundant parameter `prep_log` for the WBWI ingestion feature.

Test plan:
- unti test added
- stress test will be added as we add support to ingest WBWI without using transaction DB.