### PR TITLE
[Remote Compaction] Arbitrary string map in CompactionServiceOptionsOverride

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -94,17 +94,11 @@ class MyTestCompactionService : public CompactionService {
           table_properties_collector_factories_;
     }
 
-    // Some options to override
-    Status s = StringToMap("compaction_readahead_size=8388608;",
-                           &options_override.options_map);
-    if (!s.ok()) {
-      return CompactionServiceJobStatus::kFailure;
-    }
-
     OpenAndCompactOptions options;
     options.canceled = &canceled_;
 
-    s = DB::OpenAndCompact(options, db_path_, db_path_ + "/" + scheduled_job_id,
+    Status s =
+        DB::OpenAndCompact(options, db_path_, db_path_ + "/" + scheduled_job_id,
                            compaction_input, result, options_override);
     {
       InstrumentedMutexLock l(&mutex_);

--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -94,11 +94,17 @@ class MyTestCompactionService : public CompactionService {
           table_properties_collector_factories_;
     }
 
+    // Some options to override
+    Status s = StringToMap("compaction_readahead_size=8388608;",
+                           &options_override.options_map);
+    if (!s.ok()) {
+      return CompactionServiceJobStatus::kFailure;
+    }
+
     OpenAndCompactOptions options;
     options.canceled = &canceled_;
 
-    Status s =
-        DB::OpenAndCompact(options, db_path_, db_path_ + "/" + scheduled_job_id,
+    s = DB::OpenAndCompact(options, db_path_, db_path_ + "/" + scheduled_job_id,
                            compaction_input, result, options_override);
     {
       InstrumentedMutexLock l(&mutex_);

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -1031,8 +1031,8 @@ Status DB::OpenAndCompact(
   // default CF)
   std::vector<ColumnFamilyDescriptor> column_families;
   for (auto& cf : all_column_families) {
-    ColumnFamilyOptions cf_options;
     if (cf.name == compaction_input.cf_name) {
+      ColumnFamilyOptions cf_options;
       cf.options.comparator = override_options.comparator;
       cf.options.merge_operator = override_options.merge_operator;
       cf.options.compaction_filter = override_options.compaction_filter;

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -1071,7 +1071,6 @@ Status DB::OpenAndCompact(
 
   TEST_SYNC_POINT_CALLBACK(
       "DBImplSecondary::OpenAndCompact::AfterOpenAsSecondary:0", db);
-  TEST_SYNC_POINT("DBImplSecondary::OpenAndCompact::AfterOpenAsSecondary:1");
 
   // 6. Find the handle of the Column Family that this will compact
   ColumnFamilyHandle* cfh = nullptr;

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -547,6 +547,7 @@ TEST_F(DBSecondaryTest, OptionsOverrideTest) {
   std::string compaction_result_binary;
 
   CompactionServiceOptionsOverride override_options;
+  override_options.env = env_;
   override_options.table_factory.reset(
       NewBlockBasedTableFactory(BlockBasedTableOptions()));
 

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -557,9 +557,6 @@ TEST_F(DBSecondaryTest, OptionsOverrideTest) {
                   "some_invalid_option=ignore_me;",
                   &override_options.options_map));
 
-  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
-      {{"DBSecondaryTest::OptionsVerified",
-        "DBImplSecondary::OpenAndCompact::AfterOpenAsSecondary:1"}});
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "DBImplSecondary::OpenAndCompact::AfterOpenAsSecondary:0",
       [&](void* arg) {
@@ -569,8 +566,6 @@ TEST_F(DBSecondaryTest, OptionsOverrideTest) {
         ASSERT_EQ(secondary_db_options.compaction_readahead_size, 8388608);
         // CFOption
         ASSERT_EQ(secondary_db_options.blob_compaction_readahead_size, 4194304);
-
-        TEST_SYNC_POINT("DBSecondaryTest::OptionsVerified");
       });
   SyncPoint::GetInstance()->EnableProcessing();
 

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -508,6 +508,78 @@ TEST_F(DBSecondaryTest, OpenAsSecondary) {
   verify_db_func("new_foo_value", "new_bar_value");
 }
 
+TEST_F(DBSecondaryTest, OptionsOverrideTest) {
+  Options options;
+  options.env = env_;
+  options.preserve_internal_time_seconds = 300;
+  options.compaction_readahead_size = 200;
+  options.blob_compaction_readahead_size = 100;
+  Reopen(options);
+
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_OK(Put("foo", "foo_value" + std::to_string(i)));
+    ASSERT_OK(Put("bar", "bar_value" + std::to_string(i)));
+    ASSERT_OK(Flush());
+  }
+
+  CompactionServiceInput input;
+
+  ColumnFamilyMetaData meta;
+  db_->GetColumnFamilyMetaData(&meta);
+  for (auto& file : meta.levels[0].files) {
+    ASSERT_EQ(0, meta.levels[0].level);
+    input.input_files.push_back(file.name);
+  }
+  ASSERT_EQ(input.input_files.size(), 3);
+
+  input.output_level = 1;
+  input.options_file_number = dbfull()->GetVersionSet()->options_file_number();
+  input.cf_name = kDefaultColumnFamilyName;
+  ASSERT_OK(db_->GetDbIdentity(input.db_id));
+
+  ASSERT_EQ(db_->GetOptions().compaction_readahead_size, 200);
+  ASSERT_EQ(db_->GetOptions().blob_compaction_readahead_size, 100);
+
+  Close();
+
+  std::string compaction_input_binary;
+  ASSERT_OK(input.Write(&compaction_input_binary));
+  std::string compaction_result_binary;
+
+  CompactionServiceOptionsOverride override_options;
+  override_options.table_factory.reset(
+      NewBlockBasedTableFactory(BlockBasedTableOptions()));
+
+  ASSERT_OK(
+      StringToMap("compaction_readahead_size=8388608;"
+                  "blob_compaction_readahead_size=4194304;"
+                  "some_invalid_option=ignore_me;",
+                  &override_options.options_map));
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
+      {{"DBSecondaryTest::OptionsVerified",
+        "DBImplSecondary::OpenAndCompact::AfterOpenAsSecondary:1"}});
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "DBImplSecondary::OpenAndCompact::AfterOpenAsSecondary:0",
+      [&](void* arg) {
+        auto secondary_db = static_cast<DB*>(arg);
+        auto secondary_db_options = secondary_db->GetOptions();
+        // DBOption
+        ASSERT_EQ(secondary_db_options.compaction_readahead_size, 8388608);
+        // CFOption
+        ASSERT_EQ(secondary_db_options.blob_compaction_readahead_size, 4194304);
+
+        TEST_SYNC_POINT("DBSecondaryTest::OptionsVerified");
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(DB::OpenAndCompact(OpenAndCompactOptions(), dbname_,
+                               secondary_path_, compaction_input_binary,
+                               &compaction_result_binary, override_options));
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
 namespace {
 class TraceFileEnv : public EnvWrapper {
  public:

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2522,6 +2522,9 @@ struct CompactionServiceOptionsOverride {
   // collector.
   std::vector<std::shared_ptr<TablePropertiesCollectorFactory>>
       table_properties_collector_factories;
+
+  // All other options to override. Unknown options will be ignored.
+  std::unordered_map<std::string, std::string> options_map;
 };
 
 struct OpenAndCompactOptions {

--- a/unreleased_history/public_api_changes/options_map_in_compaction_service_options_override.md
+++ b/unreleased_history/public_api_changes/options_map_in_compaction_service_options_override.md
@@ -1,0 +1,1 @@
+Added arbitrary string map for additional options to be overriden for remote compactions


### PR DESCRIPTION
# Summary

Adding an arbitrary options map so that any additional overridable options can be added without RocksDB change. Unknown options will be ignored

# Test Plan

Unit Test added
```
./db_secondary_test -- --gtest_filter="*OptionsOverrideTest*"
```