### PR TITLE
Verify flush output file record count + minor clean up

### DIFF
--- a/db/builder.h
+++ b/db/builder.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "db/internal_stats.h"
 #include "db/range_tombstone_fragmenter.h"
 #include "db/seqno_to_time_mapping.h"
 #include "db/table_properties_collector.h"
@@ -34,7 +35,6 @@ class SnapshotChecker;
 class TableCache;
 class TableBuilder;
 class WritableFileWriter;
-class InternalStats;
 class BlobFileCompletionCallback;
 
 // Convenience function for NewTableBuilder on the embedded table_factory.
@@ -49,6 +49,7 @@ TableBuilder* NewTableBuilder(const TableBuilderOptions& tboptions,
 //
 // @param column_family_name Name of the column family that is also identified
 //    by column_family_id, or empty string if unknown.
+// @param flush_stats treat flush as level 0 compaction in internal stats
 Status BuildTable(
     const std::string& dbname, VersionSet* versions,
     const ImmutableDBOptions& db_options, const TableBuilderOptions& tboptions,
@@ -69,8 +70,8 @@ Status BuildTable(
     Env::WriteLifeTimeHint write_hint = Env::WLTH_NOT_SET,
     const std::string* full_history_ts_low = nullptr,
     BlobFileCompletionCallback* blob_callback = nullptr,
-    Version* version = nullptr, uint64_t* num_input_entries = nullptr,
-    uint64_t* memtable_payload_bytes = nullptr,
-    uint64_t* memtable_garbage_bytes = nullptr);
+    Version* version = nullptr, uint64_t* memtable_payload_bytes = nullptr,
+    uint64_t* memtable_garbage_bytes = nullptr,
+    InternalStats::CompactionStats* flush_stats = nullptr);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -878,7 +878,14 @@ Status CompactionJob::Run() {
   UpdateCompactionJobOutputStats(internal_stats_);
 
   // Verify number of output records
-  if (status.ok() && db_options_.compaction_verify_record_count) {
+  // Only verify on table with format collects table properties
+  const auto& mutable_cf_options = compact_->compaction->mutable_cf_options();
+  if (status.ok() &&
+      (mutable_cf_options.table_factory->IsInstanceOf(
+           TableFactory::kBlockBasedTableName()) ||
+       mutable_cf_options.table_factory->IsInstanceOf(
+           TableFactory::kPlainTableName())) &&
+      db_options_.compaction_verify_record_count) {
     uint64_t total_output_num = 0;
     for (const auto& state : compact_->sub_compact_states) {
       for (const auto& output : state.GetOutputs()) {

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -232,11 +232,6 @@ class CompactionJobTestBase : public testing::Test {
     // set default for the tests
     mutable_cf_options_.target_file_size_base = 1024 * 1024;
     mutable_cf_options_.max_compaction_bytes = 10 * 1024 * 1024;
-
-    // Turn off compaction_verify_record_count MockTables
-    if (table_type == TableTypeForTest::kMockTable) {
-      db_options_.compaction_verify_record_count = false;
-    }
   }
 
   void SetUp() override {

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -225,6 +225,8 @@ TEST_F(TieredCompactionTest, SequenceBasedTieredStorageUniversal) {
     flush_stats.micros = 1;
     flush_stats.bytes_written = bytes_per_file;
     flush_stats.num_output_files = 1;
+    flush_stats.num_input_records = kNumKeys;
+    flush_stats.num_output_records = kNumKeys;
     expect_stats[0].Add(flush_stats);
   }
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
@@ -1080,6 +1082,8 @@ TEST_F(TieredCompactionTest, SequenceBasedTieredStorageLevel) {
     flush_stats.micros = 1;
     flush_stats.bytes_written = bytes_per_file;
     flush_stats.num_output_files = 1;
+    flush_stats.num_input_records = kNumKeys;
+    flush_stats.num_output_records = kNumKeys;
     expect_stats[0].Add(flush_stats);
   }
   ASSERT_OK(dbfull()->TEST_WaitForCompact());

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -851,9 +851,6 @@ TEST_F(CorruptionTest, ParanoidFileChecksOnCompact) {
   options.env = env_.get();
   options.paranoid_file_checks = true;
   options.create_if_missing = true;
-  // Skip verifying record count against TableProperties for
-  // MockTables
-  options.compaction_verify_record_count = false;
   Status s;
   for (const auto& mode : corruption_modes) {
     delete db_;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5463,7 +5463,6 @@ TEST_F(DBTest, DynamicLevelCompressionPerLevel2) {
   options.max_bytes_for_level_multiplier = 8;
   options.max_background_compactions = 1;
   options.num_levels = 5;
-  options.compaction_verify_record_count = false;
   std::shared_ptr<mock::MockTableFactory> mtf(new mock::MockTableFactory);
   options.table_factory = mtf;
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -697,7 +697,10 @@ class InternalStats {
   // a full cache, which would force a re-scan on the next GetStats.
   std::shared_ptr<CacheEntryStatsCollector<CacheEntryRoleStats>>
       cache_entry_stats_collector_;
-  // Per-ColumnFamily/level compaction stats
+
+  // Per-column family and level compaction statistics, including flush and file
+  // ingestion. These are treated as compactions to L0 or the level where the
+  // file was ingested.
   std::vector<CompactionStats> comp_stats_;
   std::vector<CompactionStats> comp_stats_by_pri_;
   CompactionStats per_key_placement_comp_stats_;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -605,7 +605,8 @@ struct DBOptions {
   // DEPRECATED: This option might be removed in a future release.
   //
   // If true, during memtable flush, RocksDB will validate total entries
-  // read in flush, and compare with counter inserted into it.
+  // read in flush, total entries written in the SST and compare them with
+  // counter of keys added.
   //
   // The option is here to turn the feature off in case this new validation
   // feature has a bug. The option may be removed in the future once the

--- a/utilities/backup/backup_engine.cc
+++ b/utilities/backup/backup_engine.cc
@@ -2825,7 +2825,7 @@ Status BackupEngineImpl::GetFileDbIdentities(Env* src_env,
     // Try to get table properties from the table reader of sst_reader
     if (!sst_reader.ReadTableProperties(&tp).ok()) {
       // FIXME (peterd): this logic is untested and seems obsolete.
-      // Try to use table properites from the initialization of sst_reader
+      // Try to use table properties from the initialization of sst_reader
       table_properties = sst_reader.GetInitTableProperties();
     } else {
       table_properties = tp.get();

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -2558,9 +2558,6 @@ TEST_P(TransactionTest, FlushTest2) {
       case 0:
         break;
       case 1:
-        // Skip verifying record count against TableProperties for
-        // MockTables
-        options.compaction_verify_record_count = false;
         options.table_factory.reset(new mock::MockTableFactory());
         break;
       case 2: {


### PR DESCRIPTION
**Context/Summary:**
Similar to https://github.com/facebook/rocksdb/commit/0a43d8a261b9c633c0a4e369b1ef33aa5ee32810, this is to verify flush output file contains the exact number of keys (represented by its `TableProperties::num_entries`) as added to table builder for block-based and plain table format. The implementation reuses a temporary compaction stats to record output record and existing input record (with some refactoring)

**Bonus:** 
following https://github.com/facebook/rocksdb/commit/0a43d8a261b9c633c0a4e369b1ef33aa5ee32810#r154313564, limit compaction output record count check within block based table and plain table format as well as removing extra test setting; fix some typo

**Test:**
New test  