### PR TITLE
Deflake test DBPropertiesTest.AggregatedTableProperties

### DIFF
--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -377,9 +377,8 @@ TEST_F(DBPropertiesTest, AggregatedTableProperties) {
         NewBloomFilterPolicy(kBloomBitsPerKey, false));
     table_options.block_size = 1024;
     options.table_factory.reset(NewBlockBasedTableFactory(table_options));
-    // FIXME: why does this test seem to fall down when compactions kick in?
-    // (Some VerifySimilar failure)
-    options.disable_auto_compactions = 1;
+    // The checks assume kTableCount number of files
+    options.disable_auto_compactions = true;
 
     DestroyAndReopen(options);
 
@@ -570,7 +569,7 @@ TEST_F(DBPropertiesTest, AggregatedTablePropertiesAtLevel) {
   options.target_file_size_base = 8192;
   options.max_bytes_for_level_base = 10000;
   options.max_bytes_for_level_multiplier = 2;
-  // This ensures there no compaction happening when we call GetProperty().
+  // The checks assume kTableCount number of files
   options.disable_auto_compactions = true;
   options.merge_operator.reset(new TestPutOperator());
 

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -377,6 +377,9 @@ TEST_F(DBPropertiesTest, AggregatedTableProperties) {
         NewBloomFilterPolicy(kBloomBitsPerKey, false));
     table_options.block_size = 1024;
     options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+    // FIXME: why does this test seem to fall down when compactions kick in?
+    // (Some VerifySimilar failure)
+    options.disable_auto_compactions = 1;
 
     DestroyAndReopen(options);
 


### PR DESCRIPTION
Summary: This test was failing sporadically for me, like

```
db/db_properties_test.cc:247: Failure
Expected: (static_cast<double>(dbl_a - dbl_b) / (dbl_a + dbl_b)) <
(bias), actual: 0.113964 vs 0.1
```

I tried waiting for compaction in the test, but that made it fail consistently. Based on inspection of the test and the related test AggregatedTablePropertiesAtLevel already using `disable_auto_compactions = true`, I'm applying that to this test.

Test Plan:
Parallel runs of the unit test, before and after