### PR TITLE
Add support in CompactForTieringCollectorFactory to collect data write time

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <deque>
 #include <vector>
+#include <iostream>
 
 #include "db/blob/blob_file_builder.h"
 #include "db/compaction/compaction_iterator.h"
@@ -85,6 +86,7 @@ Status BuildTable(
   const size_t kReportFlushIOStatsEvery = 1048576;
   OutputValidator output_validator(tboptions.internal_comparator,
                                    /*enable_hash=*/paranoid_file_checks);
+  std::cout << "yuzhangyu_debug, start to create file: " << meta->fd.GetNumber() << std::endl;
   Status s;
   meta->fd.file_size = 0;
   iter->SeekToFirst();

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -12,7 +12,6 @@
 #include <algorithm>
 #include <deque>
 #include <vector>
-#include <iostream>
 
 #include "db/blob/blob_file_builder.h"
 #include "db/compaction/compaction_iterator.h"
@@ -86,7 +85,6 @@ Status BuildTable(
   const size_t kReportFlushIOStatsEvery = 1048576;
   OutputValidator output_validator(tboptions.internal_comparator,
                                    /*enable_hash=*/paranoid_file_checks);
-  std::cout << "yuzhangyu_debug, start to create file: " << meta->fd.GetNumber() << std::endl;
   Status s;
   meta->fd.file_size = 0;
   iter->SeekToFirst();

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -209,6 +209,7 @@ Status BuildTable(
         true /* must_count_input_entries */,
         /*compaction=*/nullptr, compaction_filter.get(),
         /*shutting_down=*/nullptr, db_options.info_log, full_history_ts_low);
+    builder->SetSeqnoTimeForTrackingWriteTime(seqno_to_time_mapping);
 
     SequenceNumber smallest_preferred_seqno = kMaxSequenceNumber;
     std::string key_after_flush_buf;

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2078,7 +2078,7 @@ Status CompactionJob::OpenCompactionOutputFile(SubcompactionState* sub_compact,
       sub_compact->compaction->max_output_file_size(), file_number,
       proximal_after_seqno_ /*last_level_inclusive_max_seqno_threshold*/);
 
-  outputs.NewBuilder(tboptions);
+  outputs.NewBuilder(tboptions, &seqno_to_time_mapping_);
 
   LogFlush(db_options_.info_log);
   return s;

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -14,8 +14,11 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-void CompactionOutputs::NewBuilder(const TableBuilderOptions& tboptions) {
+void CompactionOutputs::NewBuilder(
+    const TableBuilderOptions& tboptions,
+    UnownedPtr<const SeqnoToTimeMapping> seqno_to_time_mapping) {
   builder_.reset(NewTableBuilder(tboptions, file_writer_.get()));
+  builder_->SetSeqnoTimeForTrackingWriteTime(seqno_to_time_mapping);
 }
 
 Status CompactionOutputs::Finish(

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -59,7 +59,8 @@ class CompactionOutputs {
   }
 
   // Set new table builder for the current output
-  void NewBuilder(const TableBuilderOptions& tboptions);
+  void NewBuilder(const TableBuilderOptions& tboptions,
+                  UnownedPtr<const SeqnoToTimeMapping> seqno_to_time_mapping);
 
   // Assign a new WritableFileWriter to the current output
   void AssignFileWriter(WritableFileWriter* writer) {

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -2198,7 +2198,7 @@ TEST_P(TimedPutPrecludeLastLevelTest, AutoTriggerCompaction) {
   std::string id = CompactForTieringCollectorFactory::kClassName();
   ASSERT_OK(TablePropertiesCollectorFactory::CreateFromString(
       config_options,
-      "compaction_trigger_ratio=0.4;track_data_write_time=false;id=" + id,
+      "compaction_trigger_ratio=0.4;track_data_write_time=true;id=" + id,
       &factory));
   auto collector_factory =
       factory->CheckedCast<CompactForTieringCollectorFactory>();

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -2197,7 +2197,9 @@ TEST_P(TimedPutPrecludeLastLevelTest, AutoTriggerCompaction) {
   std::shared_ptr<TablePropertiesCollectorFactory> factory;
   std::string id = CompactForTieringCollectorFactory::kClassName();
   ASSERT_OK(TablePropertiesCollectorFactory::CreateFromString(
-      config_options, "compaction_trigger_ratio=0.4; id=" + id, &factory));
+      config_options,
+      "compaction_trigger_ratio=0.4;track_data_write_time=false;id=" + id,
+      &factory));
   auto collector_factory =
       factory->CheckedCast<CompactForTieringCollectorFactory>();
   options.table_properties_collector_factories.push_back(factory);

--- a/db/compaction/tiered_compaction_test.cc
+++ b/db/compaction/tiered_compaction_test.cc
@@ -2208,7 +2208,7 @@ TEST_P(TimedPutPrecludeLastLevelTest, AutoTriggerCompaction) {
   wo.protection_bytes_per_key = ProtectionBytesPerKey();
 
   auto check_write_time_for_regular_put_file =
-      [](const std::shared_ptr<const TableProperties>& table_properties) {
+      [&](const std::shared_ptr<const TableProperties>& table_properties) {
         std::unique_ptr<DataCollectionUnixWriteTimeInfo> file_write_time_info;
         ASSERT_OK(GetDataCollectionUnixWriteTimeInfoForFile(
             table_properties, &file_write_time_info));
@@ -2224,7 +2224,7 @@ TEST_P(TimedPutPrecludeLastLevelTest, AutoTriggerCompaction) {
         ASSERT_EQ(file_write_time_info->num_entries_write_time_untracked, 0);
       };
   auto check_write_time_for_timed_put_file =
-      [](const std::shared_ptr<const TableProperties>& table_properties) {
+      [&](const std::shared_ptr<const TableProperties>& table_properties) {
         std::unique_ptr<DataCollectionUnixWriteTimeInfo> file_write_time_info;
         ASSERT_OK(GetDataCollectionUnixWriteTimeInfoForFile(
             table_properties, &file_write_time_info));

--- a/db/table_properties_collector.cc
+++ b/db/table_properties_collector.cc
@@ -39,8 +39,9 @@ Status UserKeyTablePropertiesCollector::InternalAdd(const Slice& key,
     return s;
   }
 
-  return collector_->AddUserKey(ikey.user_key, value, GetEntryType(ikey.type),
-                                ikey.sequence, unix_write_time, file_size);
+  return collector_->AddUserKeyWithWriteTime(
+      ikey.user_key, value, GetEntryType(ikey.type), ikey.sequence,
+      unix_write_time, file_size);
 }
 
 void UserKeyTablePropertiesCollector::BlockAdd(

--- a/db/table_properties_collector.cc
+++ b/db/table_properties_collector.cc
@@ -31,6 +31,7 @@ uint64_t GetUint64Property(const UserCollectedProperties& props,
 
 Status UserKeyTablePropertiesCollector::InternalAdd(const Slice& key,
                                                     const Slice& value,
+                                                    uint64_t unix_write_time,
                                                     uint64_t file_size) {
   ParsedInternalKey ikey;
   Status s = ParseInternalKey(key, &ikey, false /* log_err_key */);  // TODO
@@ -39,7 +40,7 @@ Status UserKeyTablePropertiesCollector::InternalAdd(const Slice& key,
   }
 
   return collector_->AddUserKey(ikey.user_key, value, GetEntryType(ikey.type),
-                                ikey.sequence, file_size);
+                                ikey.sequence, unix_write_time, file_size);
 }
 
 void UserKeyTablePropertiesCollector::BlockAdd(

--- a/db/table_properties_collector.h
+++ b/db/table_properties_collector.h
@@ -27,7 +27,7 @@ class InternalTblPropColl {
   // @params key    the user key that is inserted into the table.
   // @params value  the value that is inserted into the table.
   virtual Status InternalAdd(const Slice& key, const Slice& value,
-                             uint64_t file_size, uint64_t unix_write_time) = 0;
+                             uint64_t unix_write_time, uint64_t file_size) = 0;
 
   virtual void BlockAdd(uint64_t block_uncomp_bytes,
                         uint64_t block_compressed_bytes_fast,

--- a/db/table_properties_collector_test.cc
+++ b/db/table_properties_collector_test.cc
@@ -171,6 +171,7 @@ class RegularKeysStartWithAInternal : public InternalTblPropColl {
   }
 
   Status InternalAdd(const Slice& user_key, const Slice& /*value*/,
+                     uint64_t /*unix_write_time*/,
                      uint64_t /*file_size*/) override {
     // simply asssume all user keys are not empty.
     if (user_key.data()[0] == 'A') {

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -120,15 +121,18 @@ class TablePropertiesCollector {
     return Add(key, value);
   }
 
-  // Overloaded AddUserKey() API for collector that needs access to the data's
-  // original unix write time.
+  // AddUserKeyWithWriteTime() API will be called when a key/value pair is
+  // inserted into the table if the collector has enabled write time tracking
+  // and write time is available.
+  // Check WriteTimeTrackingEnabled API to enable write time tracking.
   // @param unix_write_time   the original time when this entry was written to
   //                          the DB. This info is available if DB has enabled
   //                          internal time tracking for the period when this
   //                          entry was written.
-  virtual Status AddUserKey(const Slice& key, const Slice& value,
-                            EntryType type, SequenceNumber seq,
-                            uint64_t /*unix_write_time*/, uint64_t file_size) {
+  virtual Status AddUserKeyWithWriteTime(const Slice& key, const Slice& value,
+                                         EntryType type, SequenceNumber seq,
+                                         uint64_t /*unix_write_time*/,
+                                         uint64_t file_size) {
     return AddUserKey(key, value, type, seq, file_size);
   }
 

--- a/include/rocksdb/utilities/table_properties_collectors.h
+++ b/include/rocksdb/utilities/table_properties_collectors.h
@@ -184,6 +184,17 @@ struct DataCollectionUnixWriteTimeInfo {
         num_entries_write_time_aggregated(_num_entries_write_time_aggregated),
         num_entries_write_time_untracked(_num_entries_write_time_untracked) {}
 
+  bool operator==(const DataCollectionUnixWriteTimeInfo& other) const {
+    return min_write_time == other.min_write_time &&
+           max_write_time == other.max_write_time &&
+           average_write_time == other.average_write_time &&
+           num_entries_infinitely_old == other.num_entries_infinitely_old &&
+           num_entries_write_time_aggregated ==
+               other.num_entries_write_time_aggregated &&
+           num_entries_write_time_untracked ==
+               other.num_entries_write_time_untracked;
+  }
+
   // Returns true if the data collection for which this
   // `DataCollectionUnixWriteTimeInfo` is for is empty.
   bool DataCollectionIsEmpty() const {

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -2200,7 +2200,7 @@ const char* BlockBasedTableBuilder::GetFileChecksumFuncName() const {
   }
 }
 void BlockBasedTableBuilder::SetSeqnoTimeForTrackingWriteTime(
-    UnownedPtr<const rocksdb::SeqnoToTimeMapping> seqno_to_time_mapping) {
+    UnownedPtr<const SeqnoToTimeMapping> seqno_to_time_mapping) {
   assert(!rep_->seqno_to_time_for_tracking);
   rep_->seqno_to_time_for_tracking = seqno_to_time_mapping;
 }

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -221,8 +221,8 @@ class BlockBasedTableBuilder::BlockBasedTablePropertiesCollector
         decoupled_partitioned_filters_(decoupled_partitioned_filters) {}
 
   Status InternalAdd(const Slice& /*key*/, const Slice& /*value*/,
-                     uint64_t /*file_size*/,
-                     uint64_t /*unix_write_time*/) override {
+                     uint64_t /*unix_write_time*/,
+                     uint64_t /*file_size*/) override {
     // Intentionally left blank. Have no interest in collecting stats for
     // individual key/value pairs.
     return Status::OK();

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -107,6 +107,9 @@ class BlockBasedTableBuilder : public TableBuilder {
   // Get file checksum function name
   const char* GetFileChecksumFuncName() const override;
 
+  void SetSeqnoTimeForTrackingWriteTime(
+      UnownedPtr<const SeqnoToTimeMapping> seqno_to_time_mapping) override;
+
   void SetSeqnoTimeTableProperties(const SeqnoToTimeMapping& relevant_mapping,
                                    uint64_t oldest_ancestor_time) override;
 
@@ -198,6 +201,9 @@ class BlockBasedTableBuilder : public TableBuilder {
 
   // Stop BGWorkCompression and BGWorkWriteMaybeCompressedBlock threads
   void StopParallelCompression();
+
+  uint64_t GetDataUnixWriteTime(SequenceNumber seq, ValueType value_type,
+                                const Slice& value);
 };
 
 Slice CompressBlock(const Slice& uncompressed_data, const CompressionInfo& info,

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -193,12 +193,13 @@ void LogPropertiesCollectionError(Logger* info_log, const std::string& method,
 }
 
 bool NotifyCollectTableCollectorsOnAdd(
-    const Slice& key, const Slice& value, uint64_t file_size,
+    const Slice& key, const Slice& value, uint64_t unix_write_time,
+    uint64_t file_size,
     const std::vector<std::unique_ptr<InternalTblPropColl>>& collectors,
     Logger* info_log) {
   bool all_succeeded = true;
   for (auto& collector : collectors) {
-    Status s = collector->InternalAdd(key, value, file_size);
+    Status s = collector->InternalAdd(key, value, unix_write_time, file_size);
     all_succeeded = all_succeeded && s.ok();
     if (!s.ok()) {
       LogPropertiesCollectionError(info_log, "Add" /* method */,

--- a/table/meta_blocks.h
+++ b/table/meta_blocks.h
@@ -91,7 +91,8 @@ void LogPropertiesCollectionError(Logger* info_log, const std::string& method,
 // NotifyCollectTableCollectorsOnAdd() triggers the `Add` event for all
 // property collectors.
 bool NotifyCollectTableCollectorsOnAdd(
-    const Slice& key, const Slice& value, uint64_t file_size,
+    const Slice& key, const Slice& value, uint64_t unix_write_time,
+    uint64_t file_size,
     const std::vector<std::unique_ptr<InternalTblPropColl>>& collectors,
     Logger* info_log);
 

--- a/table/plain/plain_table_builder.cc
+++ b/table/plain/plain_table_builder.cc
@@ -18,6 +18,7 @@
 #include "rocksdb/filter_policy.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table.h"
+#include "rocksdb/table_properties.h"
 #include "table/block_based/block_builder.h"
 #include "table/format.h"
 #include "table/meta_blocks.h"
@@ -211,7 +212,8 @@ void PlainTableBuilder::Add(const Slice& key, const Slice& value) {
 
   // notify property collectors
   NotifyCollectTableCollectorsOnAdd(
-      key, value, offset_, table_properties_collectors_, ioptions_.logger);
+      key, value, TablePropertiesCollector::kUnknownUnixWriteTime, offset_,
+      table_properties_collectors_, ioptions_.logger);
   status_ = io_status_;
 }
 
@@ -347,6 +349,13 @@ const char* PlainTableBuilder::GetFileChecksumFuncName() const {
     return kUnknownFileChecksumFuncName;
   }
 }
+
+void PlainTableBuilder::SetSeqnoTimeForTrackingWriteTime(
+    UnownedPtr<const SeqnoToTimeMapping> seqno_to_time) {
+  // TODO: plain table doesn't track write time per data entry yet.
+  TableBuilder::SetSeqnoTimeForTrackingWriteTime(seqno_to_time);
+}
+
 void PlainTableBuilder::SetSeqnoTimeTableProperties(
     const SeqnoToTimeMapping& relevant_mapping, uint64_t uint_64) {
   // TODO: storing seqno to time mapping is not yet support for plain table.

--- a/table/plain/plain_table_builder.h
+++ b/table/plain/plain_table_builder.h
@@ -95,6 +95,9 @@ class PlainTableBuilder : public TableBuilder {
   // Get file checksum function name
   const char* GetFileChecksumFuncName() const override;
 
+  void SetSeqnoTimeForTrackingWriteTime(
+      UnownedPtr<const SeqnoToTimeMapping> seqno_to_time) override;
+
   void SetSeqnoTimeTableProperties(const SeqnoToTimeMapping& relevant_mapping,
                                    uint64_t uint_64) override;
 

--- a/table/sst_file_writer_collectors.h
+++ b/table/sst_file_writer_collectors.h
@@ -30,6 +30,7 @@ class SstFileWriterPropertiesCollector : public InternalTblPropColl {
       : version_(version), global_seqno_(global_seqno) {}
 
   Status InternalAdd(const Slice& /*key*/, const Slice& /*value*/,
+                     uint64_t /*unix_write_time*/,
                      uint64_t /*file_size*/) override {
     // Intentionally left blank. Have no interest in collecting stats for
     // individual key/value pairs.

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -24,6 +24,7 @@
 #include "rocksdb/table_properties.h"
 #include "table/unique_id_impl.h"
 #include "trace_replay/block_cache_tracer.h"
+#include "util/cast_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -230,6 +231,12 @@ class TableBuilder {
 
   // Return file checksum function name
   virtual const char* GetFileChecksumFuncName() const = 0;
+
+  // Set the sequence number to time mapping for use in tracking data's unix
+  // write time during table building. It should be set before table building
+  // starts.
+  virtual void SetSeqnoTimeForTrackingWriteTime(
+      UnownedPtr<const SeqnoToTimeMapping> /*seqno_to_time_mapping*/) {}
 
   // Set the sequence number to time mapping. `relevant_mapping` must be in
   // enforced state (ready to encode to string).

--- a/unreleased_history/new_features/compact_for_tiering_collects_data_write_time.md
+++ b/unreleased_history/new_features/compact_for_tiering_collects_data_write_time.md
@@ -1,0 +1,1 @@
+CompactForTieringCollectorFactory supports collecting and aggregating data write time when it's available.

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.cc
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.cc
@@ -46,14 +46,11 @@ CompactForTieringCollector::CompactForTieringCollector(
   // How do we calculate data write time? We need the seqno to time mapping
   // thing. How would we have access to the seqno to time mapping in the user
   // property collector?
-  (void)track_data_write_time_;
 }
 
-Status CompactForTieringCollector::AddUserKey(const Slice& /*key*/,
-                                              const Slice& value,
-                                              EntryType type,
-                                              SequenceNumber seq,
-                                              uint64_t /*file_size*/) {
+Status CompactForTieringCollector::AddUserKey(
+    const Slice& /*key*/, const Slice& value, EntryType type,
+    SequenceNumber seq, uint64_t /*unix_write_time*/, uint64_t /*file_size*/) {
   SequenceNumber seq_for_check = seq;
   if (type == kEntryTimedPut) {
     seq_for_check = ParsePackedValueForSeqno(value);
@@ -93,6 +90,10 @@ UserCollectedProperties CompactForTieringCollector::GetReadableProperties()
 
 bool CompactForTieringCollector::NeedCompact() const {
   return need_compaction_;
+}
+
+bool CompactForTieringCollector::WriteTimeTrackingEnabled() const {
+  return track_data_write_time_;
 }
 
 void CompactForTieringCollector::Reset() {

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.h
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.h
@@ -47,7 +47,8 @@ class CompactForTieringCollector : public TablePropertiesCollector {
  private:
   void Reset();
 
-  void TrackEligibleEntries(const Slice& value, EntryType type, SequenceNumber seq);
+  void TrackEligibleEntries(const Slice& value, EntryType type,
+                            SequenceNumber seq);
 
   void TrackWriteTimeMetric(uint64_t unix_write_time);
 
@@ -60,18 +61,16 @@ class CompactForTieringCollector : public TablePropertiesCollector {
   double compaction_trigger_ratio_;
   bool track_eligible_entries_{false};
   bool mark_need_compaction_for_eligible_entries_{false};
+  bool track_data_write_time_{false};
   size_t last_level_eligible_entries_counter_ = 0;
   size_t total_entries_counter_ = 0;
   bool finish_called_ = false;
   bool need_compaction_ = false;
-  bool track_data_write_time_ = false;
   uint64_t write_time_aggregated_entries_ = 0;
   uint64_t write_time_untracked_entries_ = 0;
   uint64_t write_time_infinitely_old_entries_ = 0;
-  uint64_t min_data_write_time_ =
-      TablePropertiesCollector::kUnknownUnixWriteTime;
-  uint64_t max_data_write_time_ =
-      TablePropertiesCollector::kInfinitelyOldUnixWriteTime;
-  std::optional<uint64_t> average_data_write_time_ = std::nullopt;
+  uint64_t min_data_write_time_ = std::numeric_limits<uint64_t>::max();
+  uint64_t max_data_write_time_ = 0;
+  std::optional<double> average_data_write_time_ = std::nullopt;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.h
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.h
@@ -26,7 +26,8 @@ class CompactForTieringCollector : public TablePropertiesCollector {
       double compaction_trigger_ratio, bool collect_data_age_stats);
 
   Status AddUserKey(const Slice& key, const Slice& value, EntryType type,
-                    SequenceNumber seq, uint64_t file_size) override;
+                    SequenceNumber seq, uint64_t unix_write_time,
+                    uint64_t file_size) override;
 
   Status Finish(UserCollectedProperties* properties) override;
 
@@ -35,6 +36,8 @@ class CompactForTieringCollector : public TablePropertiesCollector {
   const char* Name() const override { return "CompactForTieringCollector"; }
 
   bool NeedCompact() const override;
+
+  bool WriteTimeTrackingEnabled() const override;
 
  private:
   void Reset();

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.h
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.h
@@ -45,6 +45,6 @@ class CompactForTieringCollector : public TablePropertiesCollector {
   size_t total_entries_counter_ = 0;
   bool finish_called_ = false;
   bool need_compaction_ = false;
-  bool collect_data_age_stats_ = false;
+  bool track_data_write_time_ = false;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/table_properties_collectors/compact_for_tiering_collector.h
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector.h
@@ -25,6 +25,10 @@ class CompactForTieringCollector : public TablePropertiesCollector {
   static const std::string kNumWriteTimeAggregatedEntriesPropertyName;
   static const std::string kNumWriteTimeUntrackedEntriesPropertyName;
 
+  static Status GetDataCollectionUnixWriteTimeInfoFromUserProperties(
+      const UserCollectedProperties& user_props,
+      std::unique_ptr<DataCollectionUnixWriteTimeInfo>* file_info);
+
   CompactForTieringCollector(
       SequenceNumber last_level_inclusive_max_seqno_threshold,
       double compaction_trigger_ratio, bool collect_data_age_stats);

--- a/utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
@@ -89,7 +89,8 @@ TEST(CompactForTieringCollector, CollectorEnabled) {
       std::unique_ptr<TablePropertiesCollector> collector(
           factory->CreateTablePropertiesCollector(context));
       for (size_t i = 0; i < kTotalEntries; i++) {
-        ASSERT_OK(collector->AddUserKey("hello", "rocksdb", kEntryPut, i, 0));
+        ASSERT_OK(collector->AddUserKeyWithWriteTime("hello", "rocksdb",
+                                                     kEntryPut, i, 0, 0));
         ASSERT_FALSE(collector->NeedCompact());
       }
       UserCollectedProperties user_properties;
@@ -120,7 +121,8 @@ TEST(CompactForTieringCollector, TimedPutEntries) {
   for (size_t i = 0; i < kTotalEntries; i++) {
     std::string value;
     PackValueAndSeqno("rocksdb", i, &value);
-    ASSERT_OK(collector->AddUserKey("hello", value, kEntryTimedPut, 0, 0));
+    ASSERT_OK(collector->AddUserKeyWithWriteTime("hello", value, kEntryTimedPut,
+                                                 0, 0, 0));
     ASSERT_FALSE(collector->NeedCompact());
   }
   UserCollectedProperties user_properties;

--- a/utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
@@ -22,70 +22,124 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-TEST(CompactForTieringCollector, NotEnabled) {
+class CompactForTieringCollectorTest
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<bool> {
+ public:
+  void CheckFileWriteTimePropertyWithOnlyInfinitelyOldEntries(
+      bool track_write_time, UserCollectedProperties& user_properties,
+      size_t infinitely_old_entries) {
+    ASSERT_EQ(
+        user_properties
+            [CompactForTieringCollector::kNumInfinitelyOldEntriesPropertyName],
+        track_write_time ? std::to_string(infinitely_old_entries) : "");
+    ASSERT_EQ(user_properties[CompactForTieringCollector::
+                                  kNumWriteTimeUntrackedEntriesPropertyName],
+              track_write_time ? std::to_string(0) : "");
+    ASSERT_EQ(user_properties[CompactForTieringCollector::
+                                  kNumWriteTimeAggregatedEntriesPropertyName],
+              track_write_time ? std::to_string(0) : "");
+    ASSERT_EQ(
+        user_properties
+            [CompactForTieringCollector::kMinDataUnixWriteTimePropertyName],
+        track_write_time
+            ? std::to_string(TablePropertiesCollector::kUnknownUnixWriteTime)
+            : "");
+    ASSERT_EQ(
+        user_properties
+            [CompactForTieringCollector::kMaxDataUnixWriteTimePropertyName],
+        track_write_time
+            ? std::to_string(TablePropertiesCollector::kUnknownUnixWriteTime)
+            : "");
+    ASSERT_EQ(
+        user_properties
+            [CompactForTieringCollector::kAverageDataUnixWriteTimePropertyName],
+        track_write_time
+            ? std::to_string(TablePropertiesCollector::kUnknownUnixWriteTime)
+            : "");
+  }
+};
+
+TEST_P(CompactForTieringCollectorTest, CompactionTriggeringNotEnabled) {
   TablePropertiesCollectorFactory::Context context;
   context.column_family_id = 1;
   context.level_at_creation = 1;
   context.num_levels = 6;
   context.last_level_inclusive_max_seqno_threshold = 50;
+  bool track_write_time = GetParam();
 
   // Set compaction trigger ratio to 0 to disable it. No collector created.
-  auto factory = NewCompactForTieringCollectorFactory(0, false);
+  auto factory = NewCompactForTieringCollectorFactory(0, track_write_time);
   std::unique_ptr<TablePropertiesCollector> collector(
       factory->CreateTablePropertiesCollector(context));
-  ASSERT_EQ(nullptr, collector);
+  if (!track_write_time) {
+    ASSERT_EQ(nullptr, collector);
+  } else {
+    ASSERT_NE(nullptr, collector);
+  }
 }
 
-TEST(CompactForTieringCollector, TieringDisabled) {
+TEST_P(CompactForTieringCollectorTest, TieringDisabled) {
   TablePropertiesCollectorFactory::Context context;
   context.column_family_id = 1;
   context.level_at_creation = 1;
   context.num_levels = 6;
   context.last_level_inclusive_max_seqno_threshold = kMaxSequenceNumber;
+  bool track_write_time = GetParam();
 
   // Tiering is disabled on the column family. No collector created.
   {
     for (double compaction_trigger_ratio : {0.0, 0.1, 1.0, 1.5}) {
-      auto factory =
-          NewCompactForTieringCollectorFactory(compaction_trigger_ratio, false);
+      auto factory = NewCompactForTieringCollectorFactory(
+          compaction_trigger_ratio, track_write_time);
       std::unique_ptr<TablePropertiesCollector> collector(
           factory->CreateTablePropertiesCollector(context));
-      ASSERT_EQ(nullptr, collector);
+      if (!track_write_time) {
+        ASSERT_EQ(nullptr, collector);
+      } else {
+        ASSERT_NE(nullptr, collector);
+      }
     }
   }
 }
 
-TEST(CompactForTieringCollector, LastLevelFile) {
+TEST_P(CompactForTieringCollectorTest, LastLevelFile) {
   TablePropertiesCollectorFactory::Context context;
   context.column_family_id = 1;
   context.level_at_creation = 5;
   context.num_levels = 6;
   context.last_level_inclusive_max_seqno_threshold = 50;
+  bool track_write_time = GetParam();
 
   // No collector created for a file that is already on the last level.
   {
     for (double compaction_trigger_ratio : {0.0, 0.1, 1.0, 1.5}) {
-      auto factory =
-          NewCompactForTieringCollectorFactory(compaction_trigger_ratio, false);
+      auto factory = NewCompactForTieringCollectorFactory(
+          compaction_trigger_ratio, track_write_time);
       std::unique_ptr<TablePropertiesCollector> collector(
           factory->CreateTablePropertiesCollector(context));
-      ASSERT_EQ(nullptr, collector);
+      if (!track_write_time) {
+        ASSERT_EQ(nullptr, collector);
+      } else {
+        ASSERT_NE(nullptr, collector);
+      }
     }
   }
 }
 
-TEST(CompactForTieringCollector, CollectorEnabled) {
+TEST_P(CompactForTieringCollectorTest, CollectorEnabled) {
   TablePropertiesCollectorFactory::Context context;
   context.column_family_id = 1;
   context.level_at_creation = 1;
   context.num_levels = 6;
   context.last_level_inclusive_max_seqno_threshold = 50;
   const size_t kTotalEntries = 100;
+  bool track_write_time = GetParam();
 
   {
     for (double compaction_trigger_ratio : {0.1, 0.33333333, 0.5, 1.0, 1.5}) {
-      auto factory =
-          NewCompactForTieringCollectorFactory(compaction_trigger_ratio, false);
+      auto factory = NewCompactForTieringCollectorFactory(
+          compaction_trigger_ratio, track_write_time);
       std::unique_ptr<TablePropertiesCollector> collector(
           factory->CreateTablePropertiesCollector(context));
       for (size_t i = 0; i < kTotalEntries; i++) {
@@ -103,19 +157,23 @@ TEST(CompactForTieringCollector, CollectorEnabled) {
       } else {
         ASSERT_TRUE(collector->NeedCompact());
       }
+
+      CheckFileWriteTimePropertyWithOnlyInfinitelyOldEntries(
+          track_write_time, user_properties, kTotalEntries);
     }
   }
 }
 
-TEST(CompactForTieringCollector, TimedPutEntries) {
+TEST_P(CompactForTieringCollectorTest, TimedPutEntries) {
   TablePropertiesCollectorFactory::Context context;
   context.column_family_id = 1;
   context.level_at_creation = 1;
   context.num_levels = 6;
   context.last_level_inclusive_max_seqno_threshold = 50;
   const size_t kTotalEntries = 100;
+  bool track_write_time = GetParam();
 
-  auto factory = NewCompactForTieringCollectorFactory(0.1, false);
+  auto factory = NewCompactForTieringCollectorFactory(0.1, track_write_time);
   std::unique_ptr<TablePropertiesCollector> collector(
       factory->CreateTablePropertiesCollector(context));
   for (size_t i = 0; i < kTotalEntries; i++) {
@@ -131,6 +189,52 @@ TEST(CompactForTieringCollector, TimedPutEntries) {
                                 kNumEligibleLastLevelEntriesPropertyName],
             std::to_string(50));
   ASSERT_TRUE(collector->NeedCompact());
+
+  CheckFileWriteTimePropertyWithOnlyInfinitelyOldEntries(
+      track_write_time, user_properties, kTotalEntries);
+}
+
+INSTANTIATE_TEST_CASE_P(CompactForTieringCollectorTest,
+                        CompactForTieringCollectorTest, ::testing::Bool());
+
+TEST(CompactForTieringCollector, AggregateTimeTest) {
+  TablePropertiesCollectorFactory::Context context;
+  context.column_family_id = 1;
+  context.level_at_creation = 1;
+  context.num_levels = 6;
+  context.last_level_inclusive_max_seqno_threshold = 50;
+  const size_t kTotalEntries = 100;
+
+  auto factory = NewCompactForTieringCollectorFactory(0, true);
+  std::unique_ptr<TablePropertiesCollector> collector(
+      factory->CreateTablePropertiesCollector(context));
+  for (size_t i = 0; i < kTotalEntries; i++) {
+    ASSERT_OK(collector->AddUserKeyWithWriteTime(
+        "hello", "value", kEntryPut, 0,
+        /*unix_write_time*/ static_cast<uint64_t>(i), 0));
+  }
+  UserCollectedProperties user_properties;
+  ASSERT_OK(collector->Finish(&user_properties));
+  ASSERT_EQ(
+      user_properties
+          [CompactForTieringCollector::kNumInfinitelyOldEntriesPropertyName],
+      std::to_string(1));
+  ASSERT_EQ(user_properties[CompactForTieringCollector::
+                                kNumWriteTimeUntrackedEntriesPropertyName],
+            std::to_string(0));
+  ASSERT_EQ(user_properties[CompactForTieringCollector::
+                                kNumWriteTimeAggregatedEntriesPropertyName],
+            std::to_string(99));
+  ASSERT_EQ(user_properties
+                [CompactForTieringCollector::kMinDataUnixWriteTimePropertyName],
+            std::to_string(1));
+  ASSERT_EQ(user_properties
+                [CompactForTieringCollector::kMaxDataUnixWriteTimePropertyName],
+            std::to_string(99));
+  ASSERT_EQ(
+      user_properties
+          [CompactForTieringCollector::kAverageDataUnixWriteTimePropertyName],
+      std::to_string(50));
 }
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
+++ b/utilities/table_properties_collectors/compact_for_tiering_collector_test.cc
@@ -30,7 +30,7 @@ TEST(CompactForTieringCollector, NotEnabled) {
   context.last_level_inclusive_max_seqno_threshold = 50;
 
   // Set compaction trigger ratio to 0 to disable it. No collector created.
-  auto factory = NewCompactForTieringCollectorFactory(0);
+  auto factory = NewCompactForTieringCollectorFactory(0, false);
   std::unique_ptr<TablePropertiesCollector> collector(
       factory->CreateTablePropertiesCollector(context));
   ASSERT_EQ(nullptr, collector);
@@ -47,7 +47,7 @@ TEST(CompactForTieringCollector, TieringDisabled) {
   {
     for (double compaction_trigger_ratio : {0.0, 0.1, 1.0, 1.5}) {
       auto factory =
-          NewCompactForTieringCollectorFactory(compaction_trigger_ratio);
+          NewCompactForTieringCollectorFactory(compaction_trigger_ratio, false);
       std::unique_ptr<TablePropertiesCollector> collector(
           factory->CreateTablePropertiesCollector(context));
       ASSERT_EQ(nullptr, collector);
@@ -66,7 +66,7 @@ TEST(CompactForTieringCollector, LastLevelFile) {
   {
     for (double compaction_trigger_ratio : {0.0, 0.1, 1.0, 1.5}) {
       auto factory =
-          NewCompactForTieringCollectorFactory(compaction_trigger_ratio);
+          NewCompactForTieringCollectorFactory(compaction_trigger_ratio, false);
       std::unique_ptr<TablePropertiesCollector> collector(
           factory->CreateTablePropertiesCollector(context));
       ASSERT_EQ(nullptr, collector);
@@ -85,7 +85,7 @@ TEST(CompactForTieringCollector, CollectorEnabled) {
   {
     for (double compaction_trigger_ratio : {0.1, 0.33333333, 0.5, 1.0, 1.5}) {
       auto factory =
-          NewCompactForTieringCollectorFactory(compaction_trigger_ratio);
+          NewCompactForTieringCollectorFactory(compaction_trigger_ratio, false);
       std::unique_ptr<TablePropertiesCollector> collector(
           factory->CreateTablePropertiesCollector(context));
       for (size_t i = 0; i < kTotalEntries; i++) {
@@ -114,7 +114,7 @@ TEST(CompactForTieringCollector, TimedPutEntries) {
   context.last_level_inclusive_max_seqno_threshold = 50;
   const size_t kTotalEntries = 100;
 
-  auto factory = NewCompactForTieringCollectorFactory(0.1);
+  auto factory = NewCompactForTieringCollectorFactory(0.1, false);
   std::unique_ptr<TablePropertiesCollector> collector(
       factory->CreateTablePropertiesCollector(context));
   for (size_t i = 0; i < kTotalEntries; i++) {

--- a/utilities/table_properties_collectors/compact_on_deletion_collector.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector.cc
@@ -30,11 +30,6 @@ CompactOnDeletionCollector::CompactOnDeletionCollector(
   memset(num_deletions_in_buckets_, 0, sizeof(size_t) * kNumBuckets);
 }
 
-// AddUserKey() will be called when a new key/value pair is inserted into the
-// table.
-// @params key    the user key that is inserted into the table.
-// @params value  the value that is inserted into the table.
-// @params file_size  file size up to now
 Status CompactOnDeletionCollector::AddUserKey(const Slice& /*key*/,
                                               const Slice& /*value*/,
                                               EntryType type,

--- a/utilities/table_properties_collectors/compact_on_deletion_collector.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector.cc
@@ -211,7 +211,7 @@ static int RegisterTablePropertiesCollectorFactories(
         // By default, create a `CompactForTieringCollectorFactory` that is
         // disabled. Users will need to call corresponding setters to enable
         // the factory.
-        guard->reset(new CompactForTieringCollectorFactory(0));
+        guard->reset(new CompactForTieringCollectorFactory(0, false));
         return guard->get();
       });
   return 1;

--- a/utilities/table_properties_collectors/compact_on_deletion_collector.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector.cc
@@ -30,6 +30,11 @@ CompactOnDeletionCollector::CompactOnDeletionCollector(
   memset(num_deletions_in_buckets_, 0, sizeof(size_t) * kNumBuckets);
 }
 
+// AddUserKey() will be called when a new key/value pair is inserted into the
+// table.
+// @params key    the user key that is inserted into the table.
+// @params value  the value that is inserted into the table.
+// @params file_size  file size up to now
 Status CompactOnDeletionCollector::AddUserKey(const Slice& /*key*/,
                                               const Slice& /*value*/,
                                               EntryType type,


### PR DESCRIPTION
This PR adds support in `CompactForTieringCollectorFactory` and `CompactForTieringCollector` to collect and aggregate data write time metric.

In order to do this, an internal API `TableBuilder::SetSeqnoTimeForTrackingWriteTime` is added to be called before table building starts, so that write time tracking per data entry is available while table is being built.

Two public API `TablePropertiesCollector::AddUserKeyWithWriteTime(...)` and `TablePropertiesCollector::WriteTimeTrackingEnabled(...)` are added to enable table builder passing per data entry write time to table property collectors.

This PR also include implementation for the util method `GetDataCollectionUnixWriteTimeInfoForFile` to create a `DataCollectionUnixWriteTimeInfo` from table properties.

A follow up is needed to aggregate `DataCollectionUnixWriteTimeInfo`, such as across all the files on a level. 

Test plan:
Added unit tests