### PR TITLE
Fix ExternalTableOptions initialization

### DIFF
--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -287,9 +287,10 @@ class ExternalTableFactoryAdapter : public TableFactory {
       std::unique_ptr<TableReader>* table_reader,
       bool /* prefetch_index_and_filter_in_cache */) const override {
     std::unique_ptr<ExternalTableReader> reader;
-    ExternalTableOptions ext_topts(
-        topts.prefix_extractor, topts.ioptions.user_comparator,
-        topts.ioptions.fs, FileOptions(topts.env_options));
+    FileOptions fopts(topts.env_options);
+    ExternalTableOptions ext_topts(topts.prefix_extractor,
+                                   topts.ioptions.user_comparator,
+                                   topts.ioptions.fs, fopts);
     auto status =
         inner_->NewTableReader(ro, file->file_name(), ext_topts, &reader);
     if (!status.ok()) {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6855,8 +6855,11 @@ class ExternalTableReaderTest : public DBTestBase {
 
     Status NewTableReader(
         const ReadOptions& /*read_options*/, const std::string& file_path,
-        const ExternalTableOptions& /*topts*/,
+        const ExternalTableOptions& topts,
         std::unique_ptr<ExternalTableReader>* table_reader) const override {
+      // Sanity check some options
+      EXPECT_EQ(topts.file_options.handoff_checksum_type,
+                ChecksumType::kCRC32c);
       table_reader->reset(new DummyExternalTableReader(file_path));
       return Status::OK();
     }


### PR DESCRIPTION
Fix the initialization of the `file_options` member in `ExternalTableOptions`.