### PR TITLE
include cstdint from blog_file_meta.h

### DIFF
--- a/db/blob/blob_file_meta.h
+++ b/db/blob/blob_file_meta.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <unordered_set>
+#include <cstdint>
 
 #include "rocksdb/rocksdb_namespace.h"
 


### PR DESCRIPTION
There are compilation errors on gcc 15.
This PR tries to solve it.

```
/usr/bin/c++ -DBZIP2 -DLZ4 -DNUMA -DOS_LINUX -DROCKSDB_AUXV_GETAUXVAL_PRESENT -DROCKSDB_FALLOCATE_PRESENT -DROCKSDB_IOURING_PRESENT -DROCKSDB_LIB_IO_POSIX -DROCKSDB_MALLOC_USABLE_SIZE -DROCKSDB_NO_DYNAMIC_EXTENSION -DROCKSDB_PLATFORM_POSIX -DROCKSDB_PTHREAD_ADAPTIVE_MUTEX -DROCKSDB_RANGESYNC_PRESENT -DROCKSDB_SCHED_GETCPU_PRESENT -DSNAPPY -DTBB -DTBB_USE_DEBUG -DZLIB -DZSTD -I/home/toge/src/github-vcpkg/buildtrees/rocksdb/src/v10.1.3-3b1b28199a.clean -I/home/toge/src/github-vcpkg/buildtrees/rocksdb/src/v10.1.3-3b1b28199a.clean/include -isystem /home/toge/src/github-vcpkg/installed/x64-linux/include -isystem /home/toge/src/github-vcpkg/installed/x64-linux/debug/lib/pkgconfig/../../../include -fPIC -W -Wextra -Wall -pthread -Wsign-compare -Wshadow -Wno-unused-parameter -Wno-unused-variable -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-strict-aliasing -Wno-invalid-offsetof -fno-builtin-memcmp -g -DROCKSDB_USE_RTTI -std=gnu++17 -MD -MT CMakeFiles/rocksdb.dir/db/blob/blob_file_meta.cc.o -MF CMakeFiles/rocksdb.dir/db/blob/blob_file_meta.cc.o.d -o CMakeFiles/rocksdb.dir/db/blob/blob_file_meta.cc.o -c db/blob/blob_file_meta.cc
In file included from db/blob/blob_file_meta.cc:6:
/home/toge/src/github-vcpkg/buildtrees/rocksdb/src/v10.1.3-3b1b28199a.clean/db/blob/blob_file_meta.h:28:7: error: ‘uint64_t’ has not been declared
   28 |       uint64_t blob_file_number, uint64_t total_blob_count,
      |       ^~~~~~~~
db/blob/blob_file_meta.h:15:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   14 | #include "rocksdb/rocksdb_namespace.h"
  +++ |+#include <cstdint>
   15 | 
```

