### PR TITLE
Make java Env class subclassable

### DIFF
--- a/java/src/main/java/org/rocksdb/Env.java
+++ b/java/src/main/java/org/rocksdb/Env.java
@@ -157,7 +157,7 @@ public abstract class Env extends RocksObject {
     return Arrays.asList(getThreadList(nativeHandle_));
   }
 
-  Env(final long nativeHandle) {
+  protected Env(final long nativeHandle) {
     super(nativeHandle);
   }
 


### PR DESCRIPTION
User requested the ability to do this
It simply requires that we make the constructor `protected`

Closes https://github.com/facebook/rocksdb/issues/13480