### PR TITLE
Fix an infinite-loop bug in transaction locking

### DIFF
--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -316,6 +316,8 @@ class Status {
     return Status(kInvalidArgument, kTxnNotPrepared, msg, msg2);
   }
 
+  static Status LockLimit() { return Status(kAborted, kLockLimit); }
+
   // Returns true iff the status indicates success.
   bool ok() const {
     MarkChecked();

--- a/unreleased_history/bug_fixes/lock-limit-timeout.md
+++ b/unreleased_history/bug_fixes/lock-limit-timeout.md
@@ -1,0 +1,1 @@
+* Fix an infinite-loop bug in transaction locking. This can happen if a transaction reaches lock limit and its time out expires before it attempts to wait for it.

--- a/utilities/transactions/lock/point/point_lock_manager.cc
+++ b/utilities/transactions/lock/point/point_lock_manager.cc
@@ -277,13 +277,13 @@ Status PointLockManager::AcquireWithTimeout(
   autovector<TransactionID> wait_ids;
   result = AcquireLocked(lock_map, stripe, key, env, lock_info,
                          &expire_time_hint, &wait_ids);
-
   if (!result.ok() && timeout != 0) {
     PERF_TIMER_GUARD(key_lock_wait_time);
     PERF_COUNTER_ADD(key_lock_wait_count, 1);
     // If we weren't able to acquire the lock, we will keep retrying as long
     // as the timeout allows.
     bool timed_out = false;
+    bool cv_wait_fail = false;
     do {
       // Decide how long to wait
       int64_t cv_end_time = -1;
@@ -294,8 +294,7 @@ Status PointLockManager::AcquireWithTimeout(
       } else if (end_time > 0) {
         cv_end_time = end_time;
       }
-
-      assert(result.IsBusy() || wait_ids.size() != 0);
+      assert(result.IsLockLimit() == wait_ids.empty());
 
       // We are dependent on a transaction to finish, so perform deadlock
       // detection.
@@ -315,7 +314,12 @@ Status PointLockManager::AcquireWithTimeout(
       if (cv_end_time < 0) {
         // Wait indefinitely
         result = stripe->stripe_cv->Wait(stripe->stripe_mutex);
+        cv_wait_fail = !result.ok();
       } else {
+        // FIXME: in this case, cv_end_time could be `expire_time_hint` from the
+        // current lock holder, a time out does not mean we reached the current
+        // transaction's timeout, and we should continue to retry locking
+        // instead of exiting this while loop below.
         uint64_t now = env->NowMicros();
         if (static_cast<uint64_t>(cv_end_time) > now) {
           // This may be invoked multiple times since we divide
@@ -323,6 +327,10 @@ Status PointLockManager::AcquireWithTimeout(
           (void)ROCKSDB_THREAD_YIELD_CHECK_ABORT();
           result = stripe->stripe_cv->WaitFor(stripe->stripe_mutex,
                                               cv_end_time - now);
+          cv_wait_fail = !result.ok() && !result.IsTimedOut();
+        } else {
+          // now >= cv_end_time, we already timed out
+          result = Status::TimedOut(Status::SubCode::kLockTimeout);
         }
       }
 
@@ -332,6 +340,9 @@ Status PointLockManager::AcquireWithTimeout(
           DecrementWaiters(txn, wait_ids);
         }
       }
+      if (cv_wait_fail) {
+        break;
+      }
 
       if (result.IsTimedOut()) {
         timed_out = true;
@@ -339,12 +350,10 @@ Status PointLockManager::AcquireWithTimeout(
         // acquire lock below (it is possible the lock expired and we
         // were never signaled).
       }
-
-      if (result.ok() || result.IsTimedOut()) {
-        wait_ids.clear();
-        result = AcquireLocked(lock_map, stripe, key, env, lock_info,
-                               &expire_time_hint, &wait_ids);
-      }
+      assert(result.ok() || result.IsTimedOut());
+      wait_ids.clear();
+      result = AcquireLocked(lock_map, stripe, key, env, lock_info,
+                             &expire_time_hint, &wait_ids);
     } while (!result.ok() && !timed_out);
   }
 
@@ -477,8 +486,8 @@ bool PointLockManager::IncrementWaiters(
 // Returns Status::TimeOut if the lock cannot be acquired due to it being
 // held by other transactions, `txn_ids` will be populated with the id of
 // transactions that hold the lock, excluding lock_info.txn_ids[0].
-// Returns Status::Busy if the lock cannot be acquired due to reaching
-// per CF limit on the number of locks.
+// Returns Status::Aborted(kLockLiimt) if the lock cannot be acquired due to
+// reaching per CF limit on the number of locks.
 //
 // REQUIRED:  Stripe mutex must be held. txn_ids must be empty.
 Status PointLockManager::AcquireLocked(LockMap* lock_map, LockMapStripe* stripe,
@@ -538,7 +547,7 @@ Status PointLockManager::AcquireLocked(LockMap* lock_map, LockMapStripe* stripe,
     // Check lock limit
     if (max_num_locks_ > 0 &&
         lock_map->lock_cnt.load(std::memory_order_acquire) >= max_num_locks_) {
-      result = Status::Busy(Status::SubCode::kLockLimit);
+      result = Status::LockLimit();
     } else {
       // acquire lock
       stripe->keys.emplace(key, txn_lock_info);

--- a/utilities/transactions/lock/point/point_lock_manager.cc
+++ b/utilities/transactions/lock/point/point_lock_manager.cc
@@ -486,7 +486,7 @@ bool PointLockManager::IncrementWaiters(
 // Returns Status::TimeOut if the lock cannot be acquired due to it being
 // held by other transactions, `txn_ids` will be populated with the id of
 // transactions that hold the lock, excluding lock_info.txn_ids[0].
-// Returns Status::Aborted(kLockLiimt) if the lock cannot be acquired due to
+// Returns Status::Aborted(kLockLimit) if the lock cannot be acquired due to
 // reaching per CF limit on the number of locks.
 //
 // REQUIRED:  Stripe mutex must be held. txn_ids must be empty.

--- a/utilities/transactions/lock/point/point_lock_manager.h
+++ b/utilities/transactions/lock/point/point_lock_manager.h
@@ -209,6 +209,8 @@ class PointLockManager : public LockManager {
   void UnLockKey(PessimisticTransaction* txn, const std::string& key,
                  LockMapStripe* stripe, LockMap* lock_map, Env* env);
 
+  // Returns true if a deadlock is detected.
+  // Will DecrementWaiters() if a deadlock is detected.
   bool IncrementWaiters(const PessimisticTransaction* txn,
                         const autovector<TransactionID>& wait_ids,
                         const std::string& key, const uint32_t& cf_id,

--- a/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
+++ b/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc
@@ -130,7 +130,7 @@ Status RangeTreeLockManager::TryLock(PessimisticTransaction* txn,
     case DB_LOCK_NOTGRANTED:
       return Status::TimedOut(Status::SubCode::kLockTimeout);
     case TOKUDB_OUT_OF_LOCKS:
-      return Status::Busy(Status::SubCode::kLockLimit);
+      return Status::LockLimit();
     case DB_LOCK_DEADLOCK: {
       std::reverse(di_path.begin(), di_path.end());
       dlock_buffer_.AddNewPath(
@@ -139,7 +139,7 @@ Status RangeTreeLockManager::TryLock(PessimisticTransaction* txn,
     }
     default:
       assert(0);
-      return Status::Busy(Status::SubCode::kLockLimit);
+      return Status::LockLimit();
   }
 
   return Status::OK();

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -3995,7 +3995,7 @@ TEST_P(TransactionTest, LockLimitWithTimeoutHangTest) {
   TransactionOptions txn_options;
 
   txn_db_options.max_num_locks = 3;
-  txn_db_options.transaction_lock_timeout = 1000;  // 10ms
+  txn_db_options.transaction_lock_timeout = 10;  // 10ms
   ASSERT_OK(ReOpen());
 
   Transaction* txn = db->BeginTransaction(write_options, txn_options);
@@ -4011,8 +4011,8 @@ TEST_P(TransactionTest, LockLimitWithTimeoutHangTest) {
 
   SyncPoint::GetInstance()->SetCallBack(
       "PointLockManager::AcquireWithTimeout:WaitingTxn", [&](void*) {
-        // Release all locks and txn2 can proceed
-        // Sleep for 2ms, so timeout is already passed before waiting.
+        // Sleep for 2ms, so timeout is already passed for txn2 before waiting.
+        // txn2 should fail instead of waiting forever.
         env->SleepForMicroseconds(2 * 1000);
       });
   SyncPoint::GetInstance()->EnableProcessing();

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -3912,16 +3912,16 @@ TEST_P(TransactionTest, LockLimitTest) {
 
   // lock limit reached
   s = txn->Put("W", "w");
-  ASSERT_TRUE(s.IsBusy());
+  ASSERT_TRUE(s.IsLockLimit());
 
   // re-locking same key shouldn't put us over the limit
   s = txn->Put("X", "xx");
   ASSERT_OK(s);
 
   s = txn->GetForUpdate(read_options, "W", &value);
-  ASSERT_TRUE(s.IsBusy());
+  ASSERT_TRUE(s.IsLockLimit());
   s = txn->GetForUpdate(read_options, "V", &value);
-  ASSERT_TRUE(s.IsBusy());
+  ASSERT_TRUE(s.IsLockLimit());
 
   // re-locking same key shouldn't put us over the limit
   s = txn->GetForUpdate(read_options, "Y", &value);
@@ -3940,7 +3940,7 @@ TEST_P(TransactionTest, LockLimitTest) {
 
   // lock limit reached
   s = txn2->Put("M", "m");
-  ASSERT_TRUE(s.IsBusy());
+  ASSERT_TRUE(s.IsLockLimit());
 
   s = txn->Commit();
   ASSERT_OK(s);
@@ -3967,7 +3967,7 @@ TEST_P(TransactionTest, LockLimitTest) {
 
   // lock limit reached
   s = txn2->Delete("Y");
-  ASSERT_TRUE(s.IsBusy());
+  ASSERT_TRUE(s.IsLockLimit());
 
   s = txn2->Commit();
   ASSERT_OK(s);
@@ -3982,6 +3982,44 @@ TEST_P(TransactionTest, LockLimitTest) {
 
   s = db->Get(read_options, "X", &value);
   ASSERT_TRUE(s.IsNotFound());
+
+  delete txn;
+  delete txn2;
+}
+
+TEST_P(TransactionTest, LockLimitWithTimeoutHangTest) {
+  // Tests a bug where transaction can infinite-loop during lock acquiry.
+  // This happens when lock limit is reached and user specifies a positive
+  // timeout which is reached before the transaction start waiting for it.
+  WriteOptions write_options;
+  TransactionOptions txn_options;
+
+  txn_db_options.max_num_locks = 3;
+  txn_db_options.transaction_lock_timeout = 1000;  // 10ms
+  ASSERT_OK(ReOpen());
+
+  Transaction* txn = db->BeginTransaction(write_options, txn_options);
+  ASSERT_TRUE(txn);
+
+  ASSERT_OK(txn->Put("X", "x"));
+  ASSERT_OK(txn->Put("Y", "y"));
+  ASSERT_OK(txn->Put("Z", "z"));
+
+  TransactionOptions txn2_options;
+  txn2_options.lock_timeout = 1;  // 1ms short timeout
+  Transaction* txn2 = db->BeginTransaction(write_options, txn2_options);
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "PointLockManager::AcquireWithTimeout:WaitingTxn", [&](void*) {
+        // Release all locks and txn2 can proceed
+        // Sleep for 2ms, so timeout is already passed before waiting.
+        env->SleepForMicroseconds(2 * 1000);
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // This lock attempt should fail and return
+  ASSERT_TRUE(txn2->Put("W", "w").IsLockLimit());
+  SyncPoint::GetInstance()->DisableProcessing();
 
   delete txn;
   delete txn2;


### PR DESCRIPTION
Summary: when a transaction reaches lock limit and times out before it attempts to wait for it (https://github.com/facebook/rocksdb/blob/9d1a071194de8093bbf3f8f57ffd176278359bf0/utilities/transactions/lock/point/point_lock_manager.cc#L320), it can busy-loop forever even though its timeout is expired. This PR fixes this bug by setting a timeout status when its timeout is reached. 

This PR also updates the `LockLimit` status from `Busy` to `Aborted`, this matches the check in `Status::IsLockLimit()` and matches the customer usage (https://github.com/facebook/mysql-5.6/blob/c6e4b9f3f93dce206370105fe73ee337ece0c5e7/storage/rocksdb/ha_rocksdb.cc#L10745-L10746).

Test plan: added a unit test that would infinite-loop before this fix.