### PR TITLE
Pass wrapped WritableFileWriter to ExternalTableBuilder

### DIFF
--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -311,8 +311,8 @@ class ExternalTableFactoryAdapter : public TableFactory {
         topts.read_options, topts.write_options,
         topts.moptions.prefix_extractor, topts.ioptions.user_comparator,
         topts.column_family_name, topts.reason);
-    std::unique_ptr<ExternalTableWritableFileWrapper> file_wrapper(
-        new ExternalTableWritableFileWrapper(file));
+    auto file_wrapper =
+        std::make_unique<ExternalTableWritableFileWrapper>(file);
     builder.reset(inner_->NewTableBuilder(ext_topts, file->file_name(),
                                           file_wrapper.get()));
     if (builder) {
@@ -326,12 +326,12 @@ class ExternalTableFactoryAdapter : public TableFactory {
 
  private:
   // An FSWritableFile subclass for wrapping a WritableFileWriter. The
-  // latter is private to RocksDB, so we wrp it here in order to pass it
+  // latter is private to RocksDB, so we wrap it here in order to pass it
   // to the ExternalTableBuilder. This is necessary for WritableFileWriter
   // to intercept Append so that it can calculate the file checksum.
   class ExternalTableWritableFileWrapper : public FSWritableFile {
    public:
-    ExternalTableWritableFileWrapper(WritableFileWriter* writer)
+    explicit ExternalTableWritableFileWrapper(WritableFileWriter* writer)
         : writer_(writer) {}
 
     using FSWritableFile::Append;

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -219,8 +219,9 @@ class ExternalTableReaderAdapter : public TableReader {
 class ExternalTableBuilderAdapter : public TableBuilder {
  public:
   explicit ExternalTableBuilderAdapter(
-      std::unique_ptr<ExternalTableBuilder>&& builder)
-      : builder_(std::move(builder)), num_entries_(0) {}
+      std::unique_ptr<ExternalTableBuilder>&& builder,
+      std::unique_ptr<FSWritableFile>&& file)
+      : builder_(std::move(builder)), file_(std::move(file)), num_entries_(0) {}
 
   void Add(const Slice& key, const Slice& value) override {
     ParsedInternalKey pkey;
@@ -269,6 +270,7 @@ class ExternalTableBuilderAdapter : public TableBuilder {
  private:
   Status status_;
   std::unique_ptr<ExternalTableBuilder> builder_;
+  std::unique_ptr<FSWritableFile> file_;
   uint64_t num_entries_;
 };
 
@@ -309,10 +311,13 @@ class ExternalTableFactoryAdapter : public TableFactory {
         topts.read_options, topts.write_options,
         topts.moptions.prefix_extractor, topts.ioptions.user_comparator,
         topts.column_family_name, topts.reason);
+    std::unique_ptr<ExternalTableWritableFileWrapper> file_wrapper(
+        new ExternalTableWritableFileWrapper(file));
     builder.reset(inner_->NewTableBuilder(ext_topts, file->file_name(),
-                                          file->writable_file()));
+                                          file_wrapper.get()));
     if (builder) {
-      return new ExternalTableBuilderAdapter(std::move(builder));
+      return new ExternalTableBuilderAdapter(std::move(builder),
+                                             std::move(file_wrapper));
     }
     return nullptr;
   }
@@ -320,6 +325,41 @@ class ExternalTableFactoryAdapter : public TableFactory {
   std::unique_ptr<TableFactory> Clone() const override { return nullptr; }
 
  private:
+  // An FSWritableFile subclass for wrapping a WritableFileWriter. The
+  // latter is private to RocksDB, so we wrp it here in order to pass it
+  // to the ExternalTableBuilder. This is necessary for WritableFileWriter
+  // to intercept Append so that it can calculate the file checksum.
+  class ExternalTableWritableFileWrapper : public FSWritableFile {
+   public:
+    ExternalTableWritableFileWrapper(WritableFileWriter* writer)
+        : writer_(writer) {}
+
+    IOStatus Append(const Slice& data, const IOOptions& options,
+                    IODebugContext* /*dbg*/) override {
+      return writer_->Append(options, data);
+    }
+
+    IOStatus Close(const IOOptions& options, IODebugContext* /*dbg*/) override {
+      return writer_->Close(options);
+    }
+
+    IOStatus Flush(const IOOptions& options, IODebugContext* /*dbg*/) override {
+      return writer_->Flush(options);
+    }
+
+    IOStatus Sync(const IOOptions& options, IODebugContext* /*dbg*/) override {
+      return writer_->Sync(options, /*use_fsync=*/false);
+    }
+
+    uint64_t GetFileSize(const IOOptions& options,
+                         IODebugContext* dbg) override {
+      return writer_->writable_file()->GetFileSize(options, dbg);
+    }
+
+   private:
+    WritableFileWriter* writer_;
+  };
+
   std::shared_ptr<ExternalTableFactory> inner_;
 };
 

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -334,6 +334,7 @@ class ExternalTableFactoryAdapter : public TableFactory {
     ExternalTableWritableFileWrapper(WritableFileWriter* writer)
         : writer_(writer) {}
 
+    using FSWritableFile::Append;
     IOStatus Append(const Slice& data, const IOOptions& options,
                     IODebugContext* /*dbg*/) override {
       return writer_->Append(options, data);

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6921,12 +6921,14 @@ TEST_F(ExternalTableTest, BasicTest) {
 }
 
 TEST_F(ExternalTableTest, SstReaderTest) {
+  if (encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-encrypted environment");
+    return;
+  }
   Options options = GetDefaultOptions();
   std::string dbname = test::PerThreadDBPath("external_table_test");
   std::string ingest_file = dbname + "test.immutabledb";
   dbname += "_db";
-  // This test doesn't work with some custom Envs, like EncryptedEnv
-  options.env = Env::Default();
 
   std::shared_ptr<ExternalTableFactory> factory =
       std::make_shared<DummyExternalTableFactory>();
@@ -6954,12 +6956,14 @@ TEST_F(ExternalTableTest, SstReaderTest) {
 }
 
 TEST_F(ExternalTableTest, ExternalFileChecksumTest) {
+  if (encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-encrypted environment");
+    return;
+  }
   Options options = GetDefaultOptions();
   std::string dbname = test::PerThreadDBPath("external_table_test");
   std::string ingest_file = dbname + "test.immutable";
   dbname += "_db";
-  // This test doesn't work with some custom Envs, like EncryptedEnv
-  options.env = Env::Default();
   ASSERT_OK(DestroyDB(dbname, options));
 
   std::shared_ptr<ExternalTableFactory> factory =
@@ -6987,12 +6991,14 @@ TEST_F(ExternalTableTest, ExternalFileChecksumTest) {
 }
 
 TEST_F(ExternalTableTest, DBIterTest) {
+  if (encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-encrypted environment");
+    return;
+  }
   Options options = GetDefaultOptions();
   std::string dbname = test::PerThreadDBPath("external_table_test");
   std::string ingest_file = dbname + "test.immutable";
   dbname += "_db";
-  // This test doesn't work with some custom Envs, like EncryptedEnv
-  options.env = Env::Default();
   ASSERT_OK(DestroyDB(dbname, options));
 
   std::shared_ptr<ExternalTableFactory> factory =
@@ -7041,12 +7047,14 @@ TEST_F(ExternalTableTest, DBIterTest) {
 }
 
 TEST_F(ExternalTableTest, DBMultiScanTest) {
+  if (encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-encrypted environment");
+    return;
+  }
   Options options = GetDefaultOptions();
   std::string dbname = test::PerThreadDBPath("external_table_test");
   std::string ingest_file = dbname + "test.immutable";
   dbname += "_db";
-  // This test doesn't work with some custom Envs, like EncryptedEnv
-  options.env = Env::Default();
   ASSERT_OK(DestroyDB(dbname, options));
 
   std::shared_ptr<ExternalTableFactory> factory =

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6525,10 +6525,10 @@ TEST_F(CacheUsageOptionsOverridesTest, SanitizeAndValidateOptions) {
   Destroy(options);
 }
 
-class ExternalTableReaderTest : public DBTestBase {
+class ExternalTableTest : public DBTestBase {
  public:
-  ExternalTableReaderTest()
-      : DBTestBase("external_table_reader_test", /*env_do_fsync=*/false) {}
+  ExternalTableTest()
+      : DBTestBase("external_table_test", /*env_do_fsync=*/false) {}
 
  protected:
   class DummyExternalTableFile {
@@ -6872,7 +6872,7 @@ class ExternalTableReaderTest : public DBTestBase {
   };
 };
 
-TEST_F(ExternalTableReaderTest, BasicTest) {
+TEST_F(ExternalTableTest, BasicTest) {
   std::shared_ptr<ExternalTableFactory> factory =
       std::make_shared<DummyExternalTableFactory>();
 
@@ -6920,9 +6920,9 @@ TEST_F(ExternalTableReaderTest, BasicTest) {
   ASSERT_EQ(statuses[1], Status::NotFound());
 }
 
-TEST_F(ExternalTableReaderTest, SstReaderTest) {
+TEST_F(ExternalTableTest, SstReaderTest) {
   Options options = GetDefaultOptions();
-  std::string dbname = test::PerThreadDBPath("external_table_reader_test");
+  std::string dbname = test::PerThreadDBPath("external_table_test");
   std::string ingest_file = dbname + "test.immutabledb";
   dbname += "_db";
   // This test doesn't work with some custom Envs, like EncryptedEnv
@@ -6953,9 +6953,42 @@ TEST_F(ExternalTableReaderTest, SstReaderTest) {
   ASSERT_TRUE(iter->status().ok());
 }
 
-TEST_F(ExternalTableReaderTest, DBIterTest) {
+TEST_F(ExternalTableTest, ExternalFileChecksumTest) {
   Options options = GetDefaultOptions();
-  std::string dbname = test::PerThreadDBPath("external_table_reader_test");
+  std::string dbname = test::PerThreadDBPath("external_table_test");
+  std::string ingest_file = dbname + "test.immutable";
+  dbname += "_db";
+  // This test doesn't work with some custom Envs, like EncryptedEnv
+  options.env = Env::Default();
+  ASSERT_OK(DestroyDB(dbname, options));
+
+  std::shared_ptr<ExternalTableFactory> factory =
+      std::make_shared<DummyExternalTableFactory>();
+  options.table_factory = NewExternalTableFactory(factory);
+
+  // Create a file
+  options.file_checksum_gen_factory = GetFileChecksumGenCrc32cFactory();
+  std::unique_ptr<SstFileWriter> writer;
+  writer.reset(new SstFileWriter(EnvOptions(), options));
+  ASSERT_OK(writer->Open(ingest_file));
+  ASSERT_OK(writer->Put("foo", "bar"));
+  ASSERT_OK(writer->Put("foo2", "bar2"));
+  ExternalSstFileInfo info;
+  ASSERT_OK(writer->Finish(&info));
+  writer.reset();
+
+  FileChecksumGenContext cksum_ctx;
+  FileChecksumGenCrc32c cksum_gen(cksum_ctx);
+  std::string file_data;
+  ASSERT_OK(ReadFileToString(options.env, ingest_file, &file_data));
+  cksum_gen.Update(file_data.data(), file_data.size());
+  cksum_gen.Finalize();
+  ASSERT_EQ(info.file_checksum, cksum_gen.GetChecksum());
+}
+
+TEST_F(ExternalTableTest, DBIterTest) {
+  Options options = GetDefaultOptions();
+  std::string dbname = test::PerThreadDBPath("external_table_test");
   std::string ingest_file = dbname + "test.immutable";
   dbname += "_db";
   // This test doesn't work with some custom Envs, like EncryptedEnv
@@ -7007,9 +7040,9 @@ TEST_F(ExternalTableReaderTest, DBIterTest) {
   ASSERT_OK(db->Close());
 }
 
-TEST_F(ExternalTableReaderTest, DBMultiScanTest) {
+TEST_F(ExternalTableTest, DBMultiScanTest) {
   Options options = GetDefaultOptions();
-  std::string dbname = test::PerThreadDBPath("external_table_reader_test");
+  std::string dbname = test::PerThreadDBPath("external_table_test");
   std::string ingest_file = dbname + "test.immutable";
   dbname += "_db";
   // This test doesn't work with some custom Envs, like EncryptedEnv

--- a/unreleased_history/bug_fixes/external_table_checksum.md
+++ b/unreleased_history/bug_fixes/external_table_checksum.md
@@ -1,0 +1,1 @@
+Pass wrapped WritableFileWriter pointer to ExternalTableBuilder so that the file checksum can be correctly calculated and returned by SstFileWriter for external table files.


### PR DESCRIPTION
This PR fixes a bug where the file checksum for an external table file was not being calculated by SstFileWriter. The checksum is calculated in WritableFileWriter, so we need to pass that the the external table builder rather than the FSWritableFile pointer directly. However, WritableFileWriter is private to RocksDB, so wrap it in an FSWritableFile and pass it.

Test plan:
Add a new test in table_test.cc