### PR TITLE
New CF option to trigger flush based on average cost of scanning memtable

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -448,11 +448,20 @@ ColumnFamilyOptions SanitizeCfOptions(const ImmutableDBOptions& db_options,
     result.preclude_last_level_data_seconds = 0;
   }
 
-  if (read_only && result.memtable_op_scan_flush_trigger != 0) {
-    ROCKS_LOG_WARN(db_options.info_log.get(),
-                   "option memtable_op_scan_flush_trigger is sanitized to "
-                   "0(disabled) for read only DB.");
-    result.memtable_op_scan_flush_trigger = 0;
+  if (read_only) {
+    if (result.memtable_op_scan_flush_trigger) {
+      ROCKS_LOG_WARN(db_options.info_log.get(),
+                     "option memtable_op_scan_flush_trigger is sanitized to "
+                     "0(disabled) for read only DB.");
+      result.memtable_op_scan_flush_trigger = 0;
+    }
+    if (result.memtable_avg_op_scan_flush_trigger) {
+      ROCKS_LOG_WARN(
+          db_options.info_log.get(),
+          "option memtable_avg_op_scan_flush_trigger is sanitized to "
+          "0(disabled) for read only DB.");
+      result.memtable_avg_op_scan_flush_trigger = 0;
+    }
   }
 
   return result;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -66,11 +66,6 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       timestamp_lb_(read_options.iter_start_ts),
       timestamp_size_(timestamp_ub_ ? timestamp_ub_->size() : 0),
       active_mem_(active_mem),
-      memtable_seqno_lb_((active_mem_ && !active_mem_->IsEmpty())
-                             ? active_mem_->GetFirstSequenceNumber()
-                             : kMaxSequenceNumber),
-      memtable_op_scan_flush_trigger_(
-          mutable_cf_options.memtable_op_scan_flush_trigger),
       direction_(kForward),
       valid_(false),
       current_entry_is_merged_(false),
@@ -98,6 +93,25 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
   // prefix_seek_opt_in_only should force total_order_seek whereever the caller
   // is duplicating the original ReadOptions
   assert(!ioptions.prefix_seek_opt_in_only || read_options.total_order_seek);
+  if (active_mem_) {
+    // FIXME: GetEarliestSequenceNumber() may return a seqno that is one smaller
+    // than the smallest seqno in the memtable. This violates its comment and
+    // entries with that seqno may not be in the active memtable. Before it's
+    // fixed, we use GetFirstSequenceNumber() for more accurate result.
+    memtable_seqno_lb_ = active_mem_->IsEmpty()
+                             ? active_mem_->GetEarliestSequenceNumber()
+                             : active_mem_->GetFirstSequenceNumber();
+    memtable_op_scan_flush_trigger_ =
+        mutable_cf_options.memtable_op_scan_flush_trigger;
+    if (memtable_op_scan_flush_trigger_) {
+      // avg_op_scan_flush_trigger_ requires memtable_op_scan_flush_trigger_ > 0
+      avg_op_scan_flush_trigger_ =
+          mutable_cf_options.memtable_avg_op_scan_flush_trigger;
+    }
+  } else {
+    // memtable_op_scan_flush_trigger_ and avg_op_scan_flush_trigger_ are
+    // initialized to 0(disabled) as default.
+  }
 }
 
 Status DBIter::GetProperty(std::string prop_name, std::string* prop) {
@@ -159,6 +173,7 @@ void DBIter::Next() {
   local_stats_.skip_count_ += num_internal_keys_skipped_;
   local_stats_.skip_count_--;
   num_internal_keys_skipped_ = 0;
+  iter_step_since_seek_++;
   bool ok = true;
   if (direction_ == kReverse) {
     is_key_seqnum_zero_ = false;
@@ -373,8 +388,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
   // to one.
   bool reseek_done = false;
 
-  uint64_t mem_ops_scanned = 0;
-  bool marked_for_flush = false;
+  uint64_t mem_hidden_op_scanned = 0;
   do {
     // Will update is_key_seqnum_zero_ as soon as we parsed the current key
     // but we need to save the previous value to be used in the loop.
@@ -431,12 +445,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
           CompareKeyForSkip(ikey_.user_key, saved_key_.GetUserKey()) <= 0) {
         num_skipped++;  // skip this entry
         PERF_COUNTER_ADD(internal_key_skipped_count, 1);
-        if (memtable_op_scan_flush_trigger_ && active_mem_ &&
-            ikey_.sequence >= memtable_seqno_lb_ && !marked_for_flush &&
-            ++mem_ops_scanned >= memtable_op_scan_flush_trigger_) {
-          active_mem_->MarkForFlush();
-          marked_for_flush = true;
-        }
+        CheckCurKeyForFlushTrigger(mem_hidden_op_scanned);
       } else {
         assert(!skipping_saved_key ||
                CompareKeyForSkip(ikey_.user_key, saved_key_.GetUserKey()) > 0);
@@ -458,12 +467,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
                                       !iter_.iter()->IsKeyPinned() /* copy */);
               skipping_saved_key = true;
               PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
-              if (memtable_op_scan_flush_trigger_ && active_mem_ &&
-                  ikey_.sequence >= memtable_seqno_lb_ && !marked_for_flush &&
-                  ++mem_ops_scanned >= memtable_op_scan_flush_trigger_) {
-                active_mem_->MarkForFlush();
-                marked_for_flush = true;
-              }
+              CheckCurKeyForFlushTrigger(mem_hidden_op_scanned);
             }
             break;
           case kTypeValue:
@@ -1588,6 +1592,7 @@ void DBIter::Seek(const Slice& target) {
   ResetBlobData();
   ResetValueAndColumns();
   ResetInternalKeysSkippedCounter();
+  MarkMemtableForFlushIfNeeded();
 
   // Seek the inner iterator based on the target key.
   {
@@ -1664,6 +1669,7 @@ void DBIter::SeekForPrev(const Slice& target) {
   ResetBlobData();
   ResetValueAndColumns();
   ResetInternalKeysSkippedCounter();
+  MarkMemtableForFlushIfNeeded();
 
   // Seek the inner iterator based on the target key.
   {
@@ -1725,6 +1731,7 @@ void DBIter::SeekToFirst() {
   ResetBlobData();
   ResetValueAndColumns();
   ResetInternalKeysSkippedCounter();
+  MarkMemtableForFlushIfNeeded();
   ClearSavedValue();
   is_key_seqnum_zero_ = false;
 
@@ -1788,6 +1795,7 @@ void DBIter::SeekToLast() {
   ResetBlobData();
   ResetValueAndColumns();
   ResetInternalKeysSkippedCounter();
+  MarkMemtableForFlushIfNeeded();
   ClearSavedValue();
   is_key_seqnum_zero_ = false;
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -445,7 +445,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
           CompareKeyForSkip(ikey_.user_key, saved_key_.GetUserKey()) <= 0) {
         num_skipped++;  // skip this entry
         PERF_COUNTER_ADD(internal_key_skipped_count, 1);
-        CheckCurKeyForFlushTrigger(mem_hidden_op_scanned);
+        MarkMemtableForFlushForPerOpTrigger(mem_hidden_op_scanned);
       } else {
         assert(!skipping_saved_key ||
                CompareKeyForSkip(ikey_.user_key, saved_key_.GetUserKey()) > 0);
@@ -467,7 +467,7 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
                                       !iter_.iter()->IsKeyPinned() /* copy */);
               skipping_saved_key = true;
               PERF_COUNTER_ADD(internal_delete_skipped_count, 1);
-              CheckCurKeyForFlushTrigger(mem_hidden_op_scanned);
+              MarkMemtableForFlushForPerOpTrigger(mem_hidden_op_scanned);
             }
             break;
           case kTypeValue:
@@ -1592,7 +1592,7 @@ void DBIter::Seek(const Slice& target) {
   ResetBlobData();
   ResetValueAndColumns();
   ResetInternalKeysSkippedCounter();
-  MarkMemtableForFlushIfNeeded();
+  MarkMemtableForFlushForAvgTrigger();
 
   // Seek the inner iterator based on the target key.
   {
@@ -1669,7 +1669,7 @@ void DBIter::SeekForPrev(const Slice& target) {
   ResetBlobData();
   ResetValueAndColumns();
   ResetInternalKeysSkippedCounter();
-  MarkMemtableForFlushIfNeeded();
+  MarkMemtableForFlushForAvgTrigger();
 
   // Seek the inner iterator based on the target key.
   {
@@ -1731,7 +1731,7 @@ void DBIter::SeekToFirst() {
   ResetBlobData();
   ResetValueAndColumns();
   ResetInternalKeysSkippedCounter();
-  MarkMemtableForFlushIfNeeded();
+  MarkMemtableForFlushForAvgTrigger();
   ClearSavedValue();
   is_key_seqnum_zero_ = false;
 
@@ -1795,7 +1795,7 @@ void DBIter::SeekToLast() {
   ResetBlobData();
   ResetValueAndColumns();
   ResetInternalKeysSkippedCounter();
-  MarkMemtableForFlushIfNeeded();
+  MarkMemtableForFlushForAvgTrigger();
   ClearSavedValue();
   is_key_seqnum_zero_ = false;
 

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "db/db_impl/db_impl.h"
-#include "db/range_del_aggregator.h"
 #include "memory/arena.h"
 #include "options/cf_options.h"
 #include "rocksdb/db.h"
@@ -62,7 +61,8 @@ class DBIter final : public Iterator {
   //
   // @param active_mem Pointer to the active memtable that `internal_iter`
   // is reading from. If not null, the memtable can be marked for flush
-  // according to option mutable_cf_options.memtable_op_scan_flush_trigger.
+  // according to options mutable_cf_options.memtable_op_scan_flush_trigger
+  // and mutable_cf_options.memtable_avg_op_scan_flush_trigger.
   // @param arena_mode If true, the DBIter will be allocated from the arena.
   static DBIter* NewIter(Env* env, const ReadOptions& read_options,
                          const ImmutableOptions& ioptions,
@@ -145,6 +145,7 @@ class DBIter final : public Iterator {
   void operator=(const DBIter&) = delete;
 
   ~DBIter() override {
+    MarkMemtableForFlushIfNeeded();
     ThreadStatus::OperationType cur_op_type =
         ThreadStatusUtil::GetThreadOperation();
     ThreadStatusUtil::SetThreadOperation(
@@ -417,6 +418,36 @@ class DBIter final : public Iterator {
     return true;
   }
 
+  void MarkMemtableForFlushIfNeeded() {
+    if (avg_op_scan_flush_trigger_ &&
+        mem_hidden_op_since_seek_ >= memtable_op_scan_flush_trigger_ &&
+        mem_hidden_op_since_seek_ >=
+            static_cast<uint64_t>(iter_step_since_seek_) *
+                avg_op_scan_flush_trigger_) {
+      assert(memtable_op_scan_flush_trigger_ > 0);
+      active_mem_->MarkForFlush();
+      avg_op_scan_flush_trigger_ = 0;
+      memtable_op_scan_flush_trigger_ = 0;
+    }
+    iter_step_since_seek_ = 1;
+    mem_hidden_op_since_seek_ = 0;
+  }
+
+  void CheckCurKeyForFlushTrigger(uint64_t& mem_hidden_op_scanned) {
+    if (memtable_op_scan_flush_trigger_ &&
+        ikey_.sequence >= memtable_seqno_lb_) {
+      if (++mem_hidden_op_scanned >= memtable_op_scan_flush_trigger_) {
+        active_mem_->MarkForFlush();
+        // Turn off the flush trigger checks.
+        memtable_op_scan_flush_trigger_ = 0;
+        avg_op_scan_flush_trigger_ = 0;
+      }
+      if (avg_op_scan_flush_trigger_) {
+        ++mem_hidden_op_since_seek_;
+      }
+    }
+  }
+
   const SliceTransform* prefix_extractor_;
   Env* const env_;
   SystemClock* clock_;
@@ -476,8 +507,11 @@ class DBIter final : public Iterator {
   std::string saved_timestamp_;
   std::optional<std::vector<ScanOptions>> scan_opts_;
   ReadOnlyMemTable* const active_mem_;
-  const SequenceNumber memtable_seqno_lb_;
-  const uint32_t memtable_op_scan_flush_trigger_;
+  SequenceNumber memtable_seqno_lb_ = kMaxSequenceNumber;
+  uint32_t memtable_op_scan_flush_trigger_ = 0;
+  uint32_t avg_op_scan_flush_trigger_ = 0;
+  uint32_t iter_step_since_seek_ = 1;
+  uint32_t mem_hidden_op_since_seek_ = 0;
   Direction direction_;
   bool valid_;
   bool current_entry_is_merged_;

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -3890,6 +3890,7 @@ TEST_P(DBIteratorTest, MemtableOpsScanFlushTriggerWithSeek) {
             db_->GetIntProperty("rocksdb.num-deletes-active-mem-table", &val));
         ASSERT_EQ(0, val);
       } else {
+        ASSERT_EQ(0, NumTableFilesAtLevel(0));
         uint64_t val = 0;
         ASSERT_TRUE(
             db_->GetIntProperty("rocksdb.num-deletes-active-mem-table", &val));
@@ -3983,6 +3984,139 @@ TEST_P(DBIteratorTest, MemtableOpsScanFlushTriggerWithNext) {
       }
     }
   }
+}
+
+TEST_P(DBIteratorTest, AverageMemtableOpsScanFlushTrigger) {
+  // Tests option memtable_avg_op_scan_flush_trigger with
+  // long tombstone sequences.
+  Random* r = Random::GetTLSInstance();
+
+  const int kAvgTrigger = 10;
+  Options options;
+  options.create_if_missing = true;
+  options.memtable_op_scan_flush_trigger = 500;
+  options.memtable_avg_op_scan_flush_trigger = kAvgTrigger;
+  options.level_compaction_dynamic_level_bytes = true;
+  DestroyAndReopen(options);
+
+  const int kNumKeys = 1000;
+  // Base data that will be covered by a consecutive sequence of tombstones.
+  for (int i = 0; i < kNumKeys; ++i) {
+    ASSERT_OK(Put(Key(i), r->RandomString(50)));
+  }
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->CompactRange({}, nullptr, nullptr));
+  ASSERT_EQ(1, NumTableFilesAtLevel(6));
+
+  for (int i = 0; i < kNumKeys; ++i) {
+    // We issue slightly more deletions than kAvgTrigger between visible keys
+    // to ensure avg skipped entries exceed kAvgTrigger.
+    if (i % (kAvgTrigger + 2) != 0) {
+      ASSERT_OK(SingleDelete(Key(i)));
+    }
+  }
+
+  // Each operation, except the first Seek, is expected to see kAvgTrigger + 1
+  // tombstones (from the active memtable) before it finds the next visible key.
+  SetPerfLevel(PerfLevel::kEnableCount);
+  get_perf_context()->Reset();
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->Seek(Key(1));
+  ASSERT_EQ(get_perf_context()->next_on_memtable_count, kAvgTrigger + 1);
+  iter.reset();
+  // Should not flush since total entries skipped is below
+  // memtable_op_scan_flush_trigger
+  ASSERT_OK(Put(Key(0), "dummy write"));
+  ASSERT_OK(Put(Key(0), "dummy write"));
+  ASSERT_OK(db_->WaitForCompact({}));
+  ASSERT_EQ(0, NumTableFilesAtLevel(0));
+
+  get_perf_context()->Reset();
+  iter.reset(db_->NewIterator(ReadOptions()));
+  iter->Seek(Key(0));
+  ASSERT_EQ(iter->key(), Key(0));
+  iter->Next();
+  while (iter->Valid()) {
+    ASSERT_OK(iter->status());
+    ASSERT_GE(get_perf_context()->next_on_memtable_count, kAvgTrigger + 1);
+    get_perf_context()->Reset();
+    iter->Next();
+  }
+  // During iterator destruction we mark memtable for flush
+  iter.reset();
+
+  // Average hidden entries scanned from memtable per operation is 2.
+  ASSERT_OK(Put(Key(0), "dummy write"));
+  // Before a write, we schedule memtables for flush if requested.
+  ASSERT_OK(Put(Key(0), "dummy write"));
+  ASSERT_OK(db_->WaitForCompact({}));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+}
+
+TEST_P(DBIteratorTest, AverageMemtableOpsScanFlushTriggerByOverwrites) {
+  // Tests option memtable_avg_op_scan_flush_trigger with overwrites to keys.
+  Random* r = Random::GetTLSInstance();
+
+  const int kAvgTrigger = 25;
+  Options options;
+  options.create_if_missing = true;
+  options.memtable_op_scan_flush_trigger = 250;
+  options.memtable_avg_op_scan_flush_trigger = kAvgTrigger;
+  options.level_compaction_dynamic_level_bytes = true;
+  DestroyAndReopen(options);
+
+  const int kNumKeys = 100;
+  // Base data that will be covered by a consecutive sequence of tombstones.
+  for (int i = 0; i < kNumKeys; ++i) {
+    ASSERT_OK(Put(Key(i), r->RandomString(50)));
+  }
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->CompactRange({}, nullptr, nullptr));
+  ASSERT_EQ(1, NumTableFilesAtLevel(6));
+
+  // One visible key every 10 keys.
+  // Each non-visible user key has 3 non-visible entries in the active memtable.
+  for (int i = 0; i < kNumKeys; ++i) {
+    if (i % 10 != 0) {
+      ASSERT_OK(Put(Key(i), r->RandomString(50)));
+      ASSERT_OK(Put(Key(i), r->RandomString(50)));
+      ASSERT_OK(Delete(Key(i)));
+    }
+  }
+
+  SetPerfLevel(PerfLevel::kEnableCount);
+  get_perf_context()->Reset();
+  ReadOptions ro;
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ro));
+  iter->Seek(Key(1));
+  ASSERT_GT(get_perf_context()->next_on_memtable_count, kAvgTrigger);
+  // Re-seek to trigger check for flush trigger
+  iter->Seek(Key(1));
+  // Should not flush since total entries skipped is below
+  // memtable_op_scan_flush_trigger
+  ASSERT_OK(Put(Key(0), "dummy write"));
+  ASSERT_OK(Put(Key(0), "dummy write"));
+  ASSERT_OK(db_->WaitForCompact({}));
+  ASSERT_EQ(0, NumTableFilesAtLevel(0));
+  get_perf_context()->Reset();
+
+  int num_ops = 1;
+  iter->Seek(Key(1));
+  while (iter->Valid()) {
+    num_ops++;
+    iter->Next();
+  }
+  ASSERT_GT(get_perf_context()->next_on_memtable_count, num_ops * kAvgTrigger);
+
+  // Re-seek should check conditions for marking memtable for flush
+  iter->Seek(Key(80));
+
+  // Average hidden entries scanned from memtable per operation is 2.
+  ASSERT_OK(Put(Key(0), "dummy write"));
+  // Before a write, we schedule memtables for flush if requested.
+  ASSERT_OK(Put(Key(0), "dummy write"));
+  ASSERT_OK(db_->WaitForCompact({}));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
 }
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -424,6 +424,7 @@ DECLARE_bool(track_and_verify_wals);
 DECLARE_bool(enable_remote_compaction);
 DECLARE_bool(auto_refresh_iterator_with_snapshot);
 DECLARE_uint32(memtable_op_scan_flush_trigger);
+DECLARE_uint32(memtable_avg_op_scan_flush_trigger);
 DECLARE_uint32(ingest_wbwi_one_in);
 
 constexpr long KB = 1024;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1482,4 +1482,8 @@ DEFINE_uint32(
     ROCKSDB_NAMESPACE::ColumnFamilyOptions().memtable_op_scan_flush_trigger,
     "Sets CF option memtable_op_scan_flush_trigger.");
 
+DEFINE_uint32(
+    memtable_avg_op_scan_flush_trigger,
+    ROCKSDB_NAMESPACE::ColumnFamilyOptions().memtable_avg_op_scan_flush_trigger,
+    "Sets CF option memtable_avg_op_scan_flush_trigger.");
 #endif  // GFLAGS

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1127,6 +1127,25 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through the SetOptions() API.
   uint32_t memtable_op_scan_flush_trigger = 0;
 
+  // Similar to `memtable_op_scan_flush_trigger`, but this option applies to
+  // Next() calls between Seeks or until iterator destruction. If the average
+  // of the number of invisible entries scanned from the active memtable, the
+  // memtable will be marked for flush.
+  // Note that to avoid the case where the window between Seeks is too small,
+  // the option only takes effect if the total number of hidden entries scanned
+  // within a window is at least `memtable_op_scan_flush_trigger`. So this
+  // option is only effective when `memtable_op_scan_flush_trigger` is set.
+  //
+  // This option should be set to a lower value than
+  // `memtable_op_scan_flush_trigger`. It covers the case where an iterator
+  // scans through an expensive key range with many invisible entries from the
+  // active memtable, but the number of invisible entries per operation does not
+  // exceed `memtable_op_scan_flush_trigger`.
+  //
+  // Default: 0 (disabled)
+  // Dynamically changeable through the SetOptions() API.
+  uint32_t memtable_avg_op_scan_flush_trigger = 0;
+
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -707,6 +707,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, memtable_op_scan_flush_trigger),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"memtable_avg_op_scan_flush_trigger",
+         {offsetof(struct MutableCFOptions, memtable_avg_op_scan_flush_trigger),
+          OptionType::kUInt32T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
 };
 
 static std::unordered_map<std::string, OptionTypeInfo>
@@ -1190,6 +1194,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  uncache_aggressiveness);
   ROCKS_LOG_INFO(log, "             memtable_op_scan_flush_trigger: %" PRIu32,
                  memtable_op_scan_flush_trigger);
+  ROCKS_LOG_INFO(log, "         memtable_avg_op_scan_flush_trigger: %" PRIu32,
+                 memtable_avg_op_scan_flush_trigger);
 
   // Universal Compaction Options
   ROCKS_LOG_INFO(log, "compaction_options_universal.size_ratio : %d",

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -174,7 +174,9 @@ struct MutableCFOptions {
         bottommost_file_compaction_delay(
             options.bottommost_file_compaction_delay),
         uncache_aggressiveness(options.uncache_aggressiveness),
-        memtable_op_scan_flush_trigger(options.memtable_op_scan_flush_trigger) {
+        memtable_op_scan_flush_trigger(options.memtable_op_scan_flush_trigger),
+        memtable_avg_op_scan_flush_trigger(
+            options.memtable_avg_op_scan_flush_trigger) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -230,7 +232,8 @@ struct MutableCFOptions {
         memtable_max_range_deletions(0),
         bottommost_file_compaction_delay(0),
         uncache_aggressiveness(0),
-        memtable_op_scan_flush_trigger(0) {}
+        memtable_op_scan_flush_trigger(0),
+        memtable_avg_op_scan_flush_trigger(0) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -339,6 +342,7 @@ struct MutableCFOptions {
   uint32_t bottommost_file_compaction_delay;
   uint32_t uncache_aggressiveness;
   uint32_t memtable_op_scan_flush_trigger;
+  uint32_t memtable_avg_op_scan_flush_trigger;
 
   // Derived options
   // Per-level target file size.

--- a/options/options.cc
+++ b/options/options.cc
@@ -112,7 +112,9 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       blob_cache(options.blob_cache),
       prepopulate_blob_cache(options.prepopulate_blob_cache),
       persist_user_defined_timestamps(options.persist_user_defined_timestamps),
-      memtable_op_scan_flush_trigger(options.memtable_op_scan_flush_trigger) {
+      memtable_op_scan_flush_trigger(options.memtable_op_scan_flush_trigger),
+      memtable_avg_op_scan_flush_trigger(
+          options.memtable_avg_op_scan_flush_trigger) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
       static_cast<unsigned int>(num_levels)) {
@@ -284,9 +286,12 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "      Options.max_sequential_skip_in_iterations: %" PRIu64,
                    max_sequential_skip_in_iterations);
-  ROCKS_LOG_HEADER(
-      log, "           Options.memtable_op_scan_flush_trigger: %" PRIu32,
-      memtable_op_scan_flush_trigger);
+  ROCKS_LOG_HEADER(log,
+                   "         Options.memtable_op_scan_flush_trigger: %" PRIu32,
+                   memtable_op_scan_flush_trigger);
+  ROCKS_LOG_HEADER(log,
+                   "     Options.memtable_avg_op_scan_flush_trigger: %" PRIu32,
+                   memtable_avg_op_scan_flush_trigger);
   ROCKS_LOG_HEADER(log,
                    "                   Options.max_compaction_bytes: %" PRIu64,
                    max_compaction_bytes);

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -301,6 +301,8 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->uncache_aggressiveness = moptions.uncache_aggressiveness;
   cf_opts->memtable_op_scan_flush_trigger =
       moptions.memtable_op_scan_flush_trigger;
+  cf_opts->memtable_avg_op_scan_flush_trigger =
+      moptions.memtable_avg_op_scan_flush_trigger;
 }
 
 void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -675,7 +675,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "bottommost_file_compaction_delay=7200;"
       "uncache_aggressiveness=1234;"
       "paranoid_memory_checks=1;"
-      "memtable_op_scan_flush_trigger=123;",
+      "memtable_op_scan_flush_trigger=123;"
+      "memtable_avg_op_scan_flush_trigger=12;",
       new_options));
 
   ASSERT_NE(new_options->blob_cache.get(), nullptr);

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -345,6 +345,7 @@ default_params = {
     "enable_remote_compaction": lambda: random.choice([0, 1]),
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
     "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
+    "memtable_avg_op_scan_flush_trigger": lambda: random.choice([0, 2, 20, 200]),
     "ingest_wbwi_one_in": lambda: random.choice([0, 0, 100, 500]),
 }
 _TEST_DIR_ENV_VAR = "TEST_TMPDIR"

--- a/unreleased_history/new_features/avg-flush-trigger.md
+++ b/unreleased_history/new_features/avg-flush-trigger.md
@@ -1,0 +1,1 @@
+* Add a new CF option `memtable_avg_op_scan_flush_trigger` that supports triggering memtable flush when an iterator scans through an expensive range of keys, with the average number of skipped keys from the active memtable exceeding the threshold.


### PR DESCRIPTION
Summary: This PR introduces a new CF option, `memtable_avg_op_scan_flush_trigger`, to support triggering a memtable flush when an iterator skips too many invisible keys from the active memtable. This is a follow up to https://github.com/facebook/rocksdb/pull/13523#discussion_r2038261975, which introduced the option `memtable_op_scan_flush_trigger` for a single expensive iterator step. This PR focus on an expensive stretch of iterator steps, between Seeks and until iterator destruction. To avoid triggering a memtable flush for a stretch that is too small, this option only takes effect when the total number of entries skipped from the active memtable in a stretch of iterator steps exceeds `memtable_op_scan_flush_trigger`.


Test plan:
* New unit tests covering the new option
* Add the option to the crash test.

