### PR TITLE
Remove flaky test for file ingestion wait time metric

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -260,55 +260,6 @@ TEST_F(ExternalSSTFileBasicTest, Basic) {
   s = sst_file_writer.DeleteRange(Key(100), Key(200));
   ASSERT_NOK(s) << s.ToString();
 
-  DestroyAndReopen(options);
-
-  SyncPoint::GetInstance()->LoadDependency({
-      {"DBImpl::IngestExternalFile:AfterIncIngestFileCounter",
-       "ExternalSSTFileBasicTest.LiveWriteStart"},
-      {"WriteThread::JoinBatchGroup:Wait",
-       "DBImpl::IngestExternalFile:AfterIncIngestFileCounter:2"},
-  });
-  SyncPoint::GetInstance()->EnableProcessing();
-  PerfContext* write_thread_perf_context;
-  std::thread write_thread([&] {
-    TEST_SYNC_POINT("ExternalSSTFileBasicTest.LiveWriteStart");
-    SetPerfLevel(kEnableWait);
-    write_thread_perf_context = get_perf_context();
-    write_thread_perf_context->Reset();
-    ASSERT_OK(db_->Put(WriteOptions(), "bar", "v2"));
-    ASSERT_GT(write_thread_perf_context->write_thread_wait_nanos, 0);
-    // Test sync points were used to make sure this live write enter write
-    // thread after the file ingestion entered write thread. So by the time this
-    // live write finishes, the latest seqno is 1 means file ingestion used
-    // seqno 0.
-    ASSERT_EQ(db_->GetLatestSequenceNumber(), 1U);
-  });
-
-  // Add file using file path
-  SetPerfLevel(kEnableTimeExceptForMutex);
-  PerfContext* perf_ctx = get_perf_context();
-  perf_ctx->Reset();
-  s = DeprecatedAddFile({file1});
-  ASSERT_GT(perf_context.file_ingestion_nanos, 0);
-  ASSERT_GT(perf_context.file_ingestion_blocking_live_writes_nanos, 0);
-  ASSERT_OK(s) << s.ToString();
-  for (int k = 0; k < 100; k++) {
-    ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
-  }
-
-  write_thread.join();
-  SyncPoint::GetInstance()->DisableProcessing();
-
-  // Re-ingest the file just to check the perf context not enabled at and below
-  // kEnableWait.
-  SetPerfLevel(kEnableWait);
-  perf_ctx->Reset();
-  IngestExternalFileOptions opts;
-  opts.allow_global_seqno = true;
-  opts.allow_blocking_flush = true;
-  ASSERT_OK(db_->IngestExternalFile({file1}, opts));
-  ASSERT_EQ(perf_context.file_ingestion_nanos, 0);
-  ASSERT_EQ(perf_context.file_ingestion_blocking_live_writes_nanos, 0);
   DestroyAndRecreateExternalSSTFilesDir();
 }
 


### PR DESCRIPTION
As titled. This test is mostly verifying the tickers: file_ingestion_blocking_live_writes_nanos is accounting the time file ingestion blocks live writes.

It starts ticking after file ingestion enter write thread: https://github.com/facebook/rocksdb/blob/35e1c6c402532bbdca851c067296dfced1826954/db/db_impl/db_impl.cc#L5962-L5965 and stops after file ingestion exit write thread: https://github.com/facebook/rocksdb/blob/35e1c6c402532bbdca851c067296dfced1826954/db/db_impl/db_impl.cc#L6125-L6126 Since live writes and file ingestion all queue up in the main write thread, this is in theory the longest a live write thread could be blocked. 

The test coordinates a file ingestion thread and a live write thread to get the live write's own accounting of how long it has been blocked, recorded by ticker: write_thread_wait_nanos. And verify it with file ingestion thread's file_ingestion_blocking_live_writes_nanos side by side. But due to write_thread_wait_nanos's implementation and its granularity, if the wait is too short, it can be accounted to 0. For example, in below loop, the wait could finish before the first 7 nano seconds pause.
https://github.com/facebook/rocksdb/blob/35e1c6c402532bbdca851c067296dfced1826954/db/write_thread.cc#L68-L82

To avoid this flakiness and the low risk of ticker not doing the right thing, I just removed this test.

Test plan:
This is removing a test