### PR TITLE
Add debug printfs in secondary cache adapter destructor

### DIFF
--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -126,8 +126,8 @@ CacheWithSecondaryAdapter::~CacheWithSecondaryAdapter() {
     if (pri_cache_res_mismatch) {
       fprintf(stderr,
               "~CacheWithSecondaryAdapter: Primary cache reservation: "
-              "%lu, Secondary cache capacity: %lu, "
-              "Secondary cache reserved: %lu\n",
+              "%zu, Secondary cache capacity: %zu, "
+              "Secondary cache reserved: %zu\n",
               pri_cache_res_->GetTotalMemoryUsed(), sec_capacity,
               sec_reserved_);
       assert(pri_cache_res_mismatch);

--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -121,7 +121,17 @@ CacheWithSecondaryAdapter::~CacheWithSecondaryAdapter() {
     assert(s.ok());
     assert(placeholder_usage_ == 0);
     assert(reserved_usage_ == 0);
-    assert(pri_cache_res_->GetTotalMemoryUsed() == sec_capacity);
+    bool pri_cache_res_mismatch =
+        pri_cache_res_->GetTotalMemoryUsed() == sec_capacity;
+    if (pri_cache_res_mismatch) {
+      fprintf(stderr,
+              "~CacheWithSecondaryAdapter: Primary cache reservation: "
+              "%lu, Secondary cache capacity: %lu, "
+              "Secondary cache reserved: %lu\n",
+              pri_cache_res_->GetTotalMemoryUsed(), sec_capacity,
+              sec_reserved_);
+      assert(pri_cache_res_mismatch);
+    }
   }
 #endif  // NDEBUG
 }

--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -122,7 +122,7 @@ CacheWithSecondaryAdapter::~CacheWithSecondaryAdapter() {
     assert(placeholder_usage_ == 0);
     assert(reserved_usage_ == 0);
     bool pri_cache_res_mismatch =
-        pri_cache_res_->GetTotalMemoryUsed() == sec_capacity;
+        pri_cache_res_->GetTotalMemoryUsed() != sec_capacity;
     if (pri_cache_res_mismatch) {
       fprintf(stderr,
               "~CacheWithSecondaryAdapter: Primary cache reservation: "


### PR DESCRIPTION
Add debug printfs to troubleshoot an intermittent crash test assertion failure.