### PR TITLE
Fix external table ingestion workflow

### DIFF
--- a/include/rocksdb/external_table.h
+++ b/include/rocksdb/external_table.h
@@ -125,6 +125,17 @@ class ExternalTableReader {
                         std::vector<std::string>* values,
                         std::vector<Status>* statuses) = 0;
 
+  // Allocate and return the contents of the properties block. If the builder
+  // supports PutPropertiesBlock(), then this must be supported. The
+  // properties block should be written to the table file as is (no
+  // compression or mutation of any kind), and its offset in the file
+  // should be returned in file_offset.
+  virtual Status GetPropertiesBlock(std::unique_ptr<char[]>* /*property_block*/,
+                                    uint64_t* /*size*/,
+                                    uint64_t* /*file_offset*/) {
+    return Status::NotSupported();
+  }
+
   // Return TableProperties for the file. At a minimum, the following
   // properties need to be returned -
   // comparator_name
@@ -178,6 +189,11 @@ class ExternalTableBuilder {
   // Return the size of the table file. Will be called at the end, after
   // Finish().
   virtual uint64_t FileSize() const = 0;
+
+  // Write the raw properties block as is in the table file
+  virtual Status PutPropertiesBlock(const Slice& /*property_block*/) {
+    return Status::NotSupported();
+  }
 
   //  As mentioned in earlier comments, the following table properties must be
   //  returned at a minimum -

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -5,8 +5,11 @@
 
 #include "rocksdb/external_table.h"
 
+#include "logging/logging.h"
 #include "rocksdb/table.h"
+#include "table/block_based/block.h"
 #include "table/internal_iterator.h"
+#include "table/meta_blocks.h"
 #include "table/table_builder.h"
 #include "table/table_reader.h"
 
@@ -156,8 +159,9 @@ class ExternalTableIteratorAdapter : public InternalIterator {
 class ExternalTableReaderAdapter : public TableReader {
  public:
   explicit ExternalTableReaderAdapter(
+      const ImmutableOptions& ioptions,
       std::unique_ptr<ExternalTableReader>&& reader)
-      : reader_(std::move(reader)) {}
+      : ioptions_(ioptions), reader_(std::move(reader)) {}
 
   ~ExternalTableReaderAdapter() override {}
 
@@ -193,9 +197,34 @@ class ExternalTableReaderAdapter : public TableReader {
   void SetupForCompaction() override {}
 
   std::shared_ptr<const TableProperties> GetTableProperties() const override {
-    std::shared_ptr<TableProperties> props =
-        std::make_shared<TableProperties>(*reader_->GetTableProperties());
-    props->key_largest_seqno = 0;
+    std::shared_ptr<TableProperties> props;
+    std::unique_ptr<char[]> property_block;
+    uint64_t property_block_size = 0;
+    uint64_t property_block_offset = 0;
+    Status s;
+    // Get the raw properties block from the external table reader. We don't
+    // support writing the global sequence number, but we still get and return
+    // the correct global seqno offset in the file to prevent accidental
+    // corruption.
+    s = reader_->GetPropertiesBlock(&property_block, &property_block_size,
+                                    &property_block_offset);
+    if (s.ok()) {
+      std::unique_ptr<TableProperties> table_properties =
+          std::make_unique<TableProperties>();
+      BlockContents block_contents(std::move(property_block),
+                                   property_block_size);
+      Block block(std::move(block_contents));
+      s = ParsePropertiesBlock(ioptions_, property_block_offset, block,
+                               table_properties);
+      if (s.ok()) {
+        props.reset(table_properties.release());
+      }
+    } else {
+      // Fallback to getting a minimal table properties structure from the
+      // external table reader
+      props = std::make_shared<TableProperties>(*reader_->GetTableProperties());
+      props->key_largest_seqno = 0;
+    }
     return props;
   }
 
@@ -213,15 +242,54 @@ class ExternalTableReaderAdapter : public TableReader {
   }
 
  private:
+  const ImmutableOptions& ioptions_;
   std::unique_ptr<ExternalTableReader> reader_;
 };
 
 class ExternalTableBuilderAdapter : public TableBuilder {
  public:
   explicit ExternalTableBuilderAdapter(
+      const TableBuilderOptions& topts,
       std::unique_ptr<ExternalTableBuilder>&& builder,
       std::unique_ptr<FSWritableFile>&& file)
-      : builder_(std::move(builder)), file_(std::move(file)), num_entries_(0) {}
+      : builder_(std::move(builder)),
+        file_(std::move(file)),
+        ioptions_(topts.ioptions) {
+    properties_.num_data_blocks = 1;
+    properties_.index_size = 0;
+    properties_.filter_size = 0;
+    properties_.format_version = 0;
+    properties_.key_largest_seqno = 0;
+    properties_.column_family_id = topts.column_family_id;
+    properties_.column_family_name = topts.column_family_name;
+    properties_.db_id = topts.db_id;
+    properties_.db_session_id = topts.db_session_id;
+    properties_.db_host_id = topts.ioptions.db_host_id;
+    if (!ReifyDbHostIdProperty(topts.ioptions.env, &properties_.db_host_id)
+             .ok()) {
+      ROCKS_LOG_INFO(topts.ioptions.logger,
+                     "db_host_id property will not be set");
+    }
+    properties_.orig_file_number = topts.cur_file_num;
+    properties_.comparator_name = topts.ioptions.user_comparator != nullptr
+                                      ? topts.ioptions.user_comparator->Name()
+                                      : "nullptr";
+    properties_.prefix_extractor_name =
+        topts.moptions.prefix_extractor != nullptr
+            ? topts.moptions.prefix_extractor->AsString()
+            : "nullptr";
+
+    for (auto& factory : *topts.internal_tbl_prop_coll_factories) {
+      assert(factory);
+      std::unique_ptr<InternalTblPropColl> collector{
+          factory->CreateInternalTblPropColl(topts.column_family_id,
+                                             topts.level_at_creation,
+                                             topts.ioptions.num_levels)};
+      if (collector) {
+        table_properties_collectors_.emplace_back(std::move(collector));
+      }
+    }
+  }
 
   void Add(const Slice& key, const Slice& value) override {
     ParsedInternalKey pkey;
@@ -232,7 +300,12 @@ class ExternalTableBuilderAdapter : public TableBuilder {
             "Value type " + std::to_string(pkey.type) + "not supported");
       } else {
         builder_->Add(pkey.user_key, value);
-        num_entries_++;
+        properties_.num_entries++;
+        properties_.raw_key_size += key.size();
+        properties_.raw_value_size += value.size();
+        NotifyCollectTableCollectorsOnAdd(key, value, /*offset=*/0,
+                                          table_properties_collectors_,
+                                          ioptions_.logger);
       }
     }
   }
@@ -247,13 +320,37 @@ class ExternalTableBuilderAdapter : public TableBuilder {
 
   IOStatus io_status() const override { return status_to_io_status(status()); }
 
-  Status Finish() override { return builder_->Finish(); }
+  Status Finish() override {
+    // Approximate the data size
+    properties_.data_size =
+        properties_.raw_key_size + properties_.raw_value_size;
+
+    PropertyBlockBuilder property_block_builder;
+    property_block_builder.AddTableProperty(properties_);
+    UserCollectedProperties more_user_collected_properties;
+    NotifyCollectTableCollectorsOnFinish(
+        table_properties_collectors_, ioptions_.logger, &property_block_builder,
+        more_user_collected_properties, properties_.readable_properties);
+    properties_.user_collected_properties.insert(
+        more_user_collected_properties.begin(),
+        more_user_collected_properties.end());
+
+    Slice prop_block = property_block_builder.Finish();
+    Status s = builder_->PutPropertiesBlock(prop_block);
+    if (s.ok() || s.IsNotSupported()) {
+      // If the builder doesn't support writing the properties block,
+      // we still call Finish() and let the external builder handle it.
+      s = builder_->Finish();
+    }
+
+    return s;
+  }
 
   void Abandon() override { builder_->Abandon(); }
 
   uint64_t FileSize() const override { return builder_->FileSize(); }
 
-  uint64_t NumEntries() const override { return num_entries_; }
+  uint64_t NumEntries() const override { return properties_.num_entries; }
 
   TableProperties GetTableProperties() const override {
     return builder_->GetTableProperties();
@@ -271,7 +368,10 @@ class ExternalTableBuilderAdapter : public TableBuilder {
   Status status_;
   std::unique_ptr<ExternalTableBuilder> builder_;
   std::unique_ptr<FSWritableFile> file_;
-  uint64_t num_entries_;
+  const ImmutableOptions& ioptions_;
+  TableProperties properties_;
+  std::vector<std::unique_ptr<InternalTblPropColl>>
+      table_properties_collectors_;
 };
 
 class ExternalTableFactoryAdapter : public TableFactory {
@@ -288,6 +388,10 @@ class ExternalTableFactoryAdapter : public TableFactory {
       std::unique_ptr<RandomAccessFileReader>&& file, uint64_t /* file_size */,
       std::unique_ptr<TableReader>* table_reader,
       bool /* prefetch_index_and_filter_in_cache */) const override {
+    if (topts.largest_seqno > 0) {
+      return Status::NotSupported(
+          "Ingesting file with sequence number larger than 0");
+    }
     std::unique_ptr<ExternalTableReader> reader;
     FileOptions fopts(topts.env_options);
     ExternalTableOptions ext_topts(topts.prefix_extractor,
@@ -298,7 +402,8 @@ class ExternalTableFactoryAdapter : public TableFactory {
     if (!status.ok()) {
       return status;
     }
-    table_reader->reset(new ExternalTableReaderAdapter(std::move(reader)));
+    table_reader->reset(
+        new ExternalTableReaderAdapter(topts.ioptions, std::move(reader)));
     file.reset();
     return Status::OK();
   }
@@ -316,7 +421,7 @@ class ExternalTableFactoryAdapter : public TableFactory {
     builder.reset(inner_->NewTableBuilder(ext_topts, file->file_name(),
                                           file_wrapper.get()));
     if (builder) {
-      return new ExternalTableBuilderAdapter(std::move(builder),
+      return new ExternalTableBuilderAdapter(topts, std::move(builder),
                                              std::move(file_wrapper));
     }
     return nullptr;

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -388,7 +388,9 @@ class ExternalTableFactoryAdapter : public TableFactory {
       std::unique_ptr<RandomAccessFileReader>&& file, uint64_t /* file_size */,
       std::unique_ptr<TableReader>* table_reader,
       bool /* prefetch_index_and_filter_in_cache */) const override {
-    if (topts.largest_seqno > 0) {
+    // SstFileReader specifies largest_seqno as kMaxSequenceNumber to denote
+    // that its unknown
+    if (topts.largest_seqno > 0 && topts.largest_seqno != kMaxSequenceNumber) {
       return Status::NotSupported(
           "Ingesting file with sequence number larger than 0");
     }

--- a/table/meta_blocks.h
+++ b/table/meta_blocks.h
@@ -22,6 +22,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+class Block;
 class BlockBuilder;
 class BlockHandle;
 class Env;
@@ -109,6 +110,10 @@ bool NotifyCollectTableCollectorsOnFinish(
     Logger* info_log, PropertyBlockBuilder* builder,
     UserCollectedProperties& user_collected_properties,
     UserCollectedProperties& readable_properties);
+
+Status ParsePropertiesBlock(
+    const ImmutableOptions& ioptions, uint64_t offset, Block& block,
+    std::unique_ptr<TableProperties>& new_table_properties);
 
 // Read table properties from a file using known BlockHandle.
 // @returns a status to indicate if the operation succeeded. On success,

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6834,8 +6834,8 @@ class ExternalTableTest : public DBTestBase {
       }
     }
 
-    Status GetPropertiesBlock(std::unique_ptr<char[]>* block, size_t* size,
-                              size_t* file_offset) override {
+    Status GetPropertiesBlock(std::unique_ptr<char[]>* block, uint64_t* size,
+                              uint64_t* file_offset) override {
       if (!support_property_block_) {
         return Status::NotSupported();
       }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6541,6 +6541,13 @@ class ExternalTableTest : public DBTestBase {
 
     Status Serialize(
         const std::vector<std::pair<std::string, std::string>>& kv_vec) {
+      // First append the property block if one exists
+      uint32_t prop_block_size = static_cast<uint32_t>(prop_block_.length());
+      buf_.append(static_cast<char*>(static_cast<void*>(&prop_block_size)),
+                  sizeof(prop_block_size));
+      if (!prop_block_.empty()) {
+        buf_.append(prop_block_);
+      }
       for (auto& kv : kv_vec) {
         SerializeOne(kv.first, kv.second);
         props_.raw_key_size += kv.first.length();
@@ -6561,6 +6568,12 @@ class ExternalTableTest : public DBTestBase {
         return s;
       }
 
+      uint32_t prop_block_size = 0;
+      buf_.copy(static_cast<char*>(static_cast<void*>(&prop_block_size)),
+                sizeof(prop_block_size));
+      buf_.erase(0, sizeof(prop_block_size));
+      prop_block_.assign(buf_.substr(0, prop_block_size));
+      buf_.erase(0, prop_block_size);
       while (buf_.length() > 0) {
         std::pair<std::string, std::string> kv;
         s = DeserializeOne(kv);
@@ -6575,6 +6588,24 @@ class ExternalTableTest : public DBTestBase {
       }
       props_.num_entries = kv_map.size();
       return s;
+    }
+
+    Status PutPropertiesBlock(const Slice& prop_block) {
+      prop_block_.assign(prop_block.data(), prop_block.size());
+      return Status::OK();
+    }
+
+    Status GetPropertiesBlock(std::unique_ptr<char[]>* block, uint64_t* size,
+                              uint64_t* file_offset) {
+      if (!prop_block_.empty()) {
+        *block = std::make_unique<char[]>(prop_block_.length());
+        memcpy(block->get(), prop_block_.data(), prop_block_.length());
+        *size = prop_block_.length();
+        *file_offset = sizeof(uint32_t);
+      } else {
+        *size = 0;
+      }
+      return Status::OK();
     }
 
     TableProperties GetTableProperties() const { return props_; }
@@ -6619,6 +6650,7 @@ class ExternalTableTest : public DBTestBase {
     std::string buf_;
     TableProperties props_;
     uint64_t file_size_;
+    std::string prop_block_;
   };
 
   class DummyExternalTableIterator : public ExternalTableIterator {
@@ -6764,8 +6796,10 @@ class ExternalTableTest : public DBTestBase {
 
   class DummyExternalTableReader : public ExternalTableReader {
    public:
-    explicit DummyExternalTableReader(const std::string& file_path)
-        : file_(file_path, /*file=*/nullptr) {
+    explicit DummyExternalTableReader(const std::string& file_path,
+                                      bool support_property_block)
+        : file_(file_path, /*file=*/nullptr),
+          support_property_block_(support_property_block) {
       Status s = file_.Deserialize(kv_map_);
       EXPECT_OK(s);
     }
@@ -6800,6 +6834,14 @@ class ExternalTableTest : public DBTestBase {
       }
     }
 
+    Status GetPropertiesBlock(std::unique_ptr<char[]>* block, size_t* size,
+                              size_t* file_offset) override {
+      if (!support_property_block_) {
+        return Status::NotSupported();
+      }
+      return file_.GetPropertiesBlock(block, size, file_offset);
+    }
+
     std::shared_ptr<const TableProperties> GetTableProperties() const override {
       std::shared_ptr<TableProperties> props =
           std::make_shared<TableProperties>();
@@ -6813,13 +6855,16 @@ class ExternalTableTest : public DBTestBase {
    private:
     std::map<std::string, std::string> kv_map_;
     DummyExternalTableFile file_;
+    bool support_property_block_;
   };
 
   class DummyExternalTableBuilder : public ExternalTableBuilder {
    public:
     explicit DummyExternalTableBuilder(const std::string& file_path,
-                                       FSWritableFile* file)
-        : file_(file_path, file) {}
+                                       FSWritableFile* file,
+                                       bool support_property_block)
+        : file_(file_path, file),
+          support_property_block_(support_property_block) {}
 
     void Add(const Slice& key, const Slice& value) override {
       if (!kv_vec_.empty()) {
@@ -6837,6 +6882,13 @@ class ExternalTableTest : public DBTestBase {
 
     uint64_t FileSize() const override { return file_.FileSize(); }
 
+    Status PutPropertiesBlock(const Slice& block) override {
+      if (!support_property_block_) {
+        return Status::NotSupported();
+      }
+      return file_.PutPropertiesBlock(block);
+    }
+
     TableProperties GetTableProperties() const override {
       return file_.GetTableProperties();
     }
@@ -6847,10 +6899,13 @@ class ExternalTableTest : public DBTestBase {
     std::vector<std::pair<std::string, std::string>> kv_vec_;
     DummyExternalTableFile file_;
     Status status_;
+    bool support_property_block_;
   };
 
   class DummyExternalTableFactory : public ExternalTableFactory {
    public:
+    explicit DummyExternalTableFactory(bool support_property_block)
+        : support_property_block_(support_property_block) {}
     const char* Name() const override { return "DummyExternalTableFactory"; }
 
     Status NewTableReader(
@@ -6860,21 +6915,27 @@ class ExternalTableTest : public DBTestBase {
       // Sanity check some options
       EXPECT_EQ(topts.file_options.handoff_checksum_type,
                 ChecksumType::kCRC32c);
-      table_reader->reset(new DummyExternalTableReader(file_path));
+      table_reader->reset(
+          new DummyExternalTableReader(file_path, support_property_block_));
       return Status::OK();
     }
 
     ExternalTableBuilder* NewTableBuilder(
         const ExternalTableBuilderOptions& /*opts*/,
         const std::string& file_path, FSWritableFile* file) const override {
-      return new DummyExternalTableBuilder(file_path, file);
+      return new DummyExternalTableBuilder(file_path, file,
+                                           support_property_block_);
     }
+
+   private:
+    bool support_property_block_;
   };
 };
 
 TEST_F(ExternalTableTest, BasicTest) {
   std::shared_ptr<ExternalTableFactory> factory =
-      std::make_shared<DummyExternalTableFactory>();
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/false);
 
   std::string file_path = test::PerThreadDBPath("external_table");
   {
@@ -6931,7 +6992,8 @@ TEST_F(ExternalTableTest, SstReaderTest) {
   dbname += "_db";
 
   std::shared_ptr<ExternalTableFactory> factory =
-      std::make_shared<DummyExternalTableFactory>();
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/false);
   options.table_factory = NewExternalTableFactory(factory);
 
   std::unique_ptr<SstFileWriter> writer;
@@ -6967,7 +7029,8 @@ TEST_F(ExternalTableTest, ExternalFileChecksumTest) {
   ASSERT_OK(DestroyDB(dbname, options));
 
   std::shared_ptr<ExternalTableFactory> factory =
-      std::make_shared<DummyExternalTableFactory>();
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/true);
   options.table_factory = NewExternalTableFactory(factory);
 
   // Create a file
@@ -7002,7 +7065,8 @@ TEST_F(ExternalTableTest, DBIterTest) {
   ASSERT_OK(DestroyDB(dbname, options));
 
   std::shared_ptr<ExternalTableFactory> factory =
-      std::make_shared<DummyExternalTableFactory>();
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/true);
   options.table_factory = NewExternalTableFactory(factory);
 
   // Create a file
@@ -7058,7 +7122,8 @@ TEST_F(ExternalTableTest, DBMultiScanTest) {
   ASSERT_OK(DestroyDB(dbname, options));
 
   std::shared_ptr<ExternalTableFactory> factory =
-      std::make_shared<DummyExternalTableFactory>();
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/true);
   options.table_factory = NewExternalTableFactory(factory);
 
   // Create a file
@@ -7198,6 +7263,111 @@ TEST_F(ExternalTableTest, DBMultiScanTest) {
   iter.reset();
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  ASSERT_OK(db->DestroyColumnFamilyHandle(cfh));
+  ASSERT_OK(db->Close());
+}
+
+TEST_F(ExternalTableTest, IngestionTest) {
+  if (encrypted_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires non-encrypted environment");
+    return;
+  }
+  Options options = GetDefaultOptions();
+  std::string dbname = test::PerThreadDBPath("external_table_test");
+  std::string ingest_file = dbname + "test.immutable";
+  dbname += "_db";
+  ASSERT_OK(DestroyDB(dbname, options));
+
+  std::shared_ptr<ExternalTableFactory> factory =
+      std::make_shared<DummyExternalTableFactory>(
+          /*support_property_block=*/true);
+  options.table_factory = NewExternalTableFactory(factory);
+
+  // Create a file
+  std::unique_ptr<SstFileWriter> writer;
+  writer.reset(new SstFileWriter(EnvOptions(), options));
+  ASSERT_OK(writer->Open(ingest_file));
+  ASSERT_OK(writer->Put("foo", "bar"));
+  ASSERT_OK(writer->Put("foo2", "bar2"));
+  ASSERT_OK(writer->Finish());
+  writer.reset();
+
+  std::unique_ptr<DB> db;
+  options.create_if_missing = true;
+  Status s = DB::Open(options, dbname, &db);
+  ASSERT_OK(s);
+  ASSERT_TRUE(db != nullptr);
+  ColumnFamilyHandle* cfh = nullptr;
+  ASSERT_OK(db->CreateColumnFamily(options, "new_cf", &cfh));
+
+  IngestExternalFileOptions ifo;
+  ifo.allow_db_generated_files = false;
+  ifo.fill_cache = false;
+  s = db->IngestExternalFile(cfh, {ingest_file}, ifo);
+  ASSERT_OK(s);
+
+  std::unique_ptr<Iterator> iter(db->NewIterator({}, cfh));
+  ASSERT_NE(iter, nullptr);
+  iter->Seek("foo");
+  ASSERT_TRUE(iter->Valid() && iter->status().ok());
+  ASSERT_EQ(iter->value(), "bar");
+  iter->Next();
+  ASSERT_TRUE(iter->Valid() && iter->status().ok());
+  ASSERT_EQ(iter->key(), "foo2");
+  ASSERT_EQ(iter->value(), "bar2");
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_OK(iter->status());
+  iter.reset();
+
+  // Create an overlapping file to ingest with atomic_replace_range option
+  ingest_file += "2";
+  writer.reset(new SstFileWriter(EnvOptions(), options));
+  ASSERT_OK(writer->Open(ingest_file));
+  ASSERT_OK(writer->Put("foo", "val"));
+  ASSERT_OK(writer->Put("foo2", "val2"));
+  ASSERT_OK(writer->Finish());
+  writer.reset();
+
+  ifo.snapshot_consistency = false;
+  s = db->IngestExternalFiles({{cfh,
+                                {ingest_file},
+                                ifo,
+                                {},
+                                {},
+                                Temperature::kUnknown,
+                                {{nullptr, nullptr}}}});
+  ASSERT_OK(s);
+
+  iter.reset(db->NewIterator({}, cfh));
+  ASSERT_NE(iter, nullptr);
+  iter->Seek("foo");
+  ASSERT_TRUE(iter->Valid() && iter->status().ok());
+  ASSERT_EQ(iter->value(), "val");
+  iter->Next();
+  ASSERT_TRUE(iter->Valid() && iter->status().ok());
+  ASSERT_EQ(iter->key(), "foo2");
+  ASSERT_EQ(iter->value(), "val2");
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+  ASSERT_OK(iter->status());
+  iter.reset();
+
+  // Create an overlapping file to ingest without atomic_replace_range option.
+  // This should fail as we don't support ingesting an external file with
+  // non-zero assigned sequence number.
+  ingest_file += "3";
+  writer.reset(new SstFileWriter(EnvOptions(), options));
+  ASSERT_OK(writer->Open(ingest_file));
+  ASSERT_OK(writer->Put("foo", "newval"));
+  ASSERT_OK(writer->Put("foo2", "newval2"));
+  ASSERT_OK(writer->Finish());
+  writer.reset();
+
+  s = db->IngestExternalFiles(
+      {{cfh, {ingest_file}, ifo, {}, {}, Temperature::kUnknown, {}}});
+  ASSERT_EQ(s, Status::NotSupported());
 
   ASSERT_OK(db->DestroyColumnFamilyHandle(cfh));
   ASSERT_OK(db->Close());


### PR DESCRIPTION
Remove the dependency on `allow_db_generated_files` option in `IngestExternalFile` to be set for ingesting external tables. The files are created by SstFileWriter, and we should be able to ingest them. We could make it work by having the external table implementation provide the version and global sequence number related properties, but its safer to have RocksDB generate the table properties block and store it as is in the file.

Test plan:
Add unit test to test basic ingestion and ingestion with atomic_replace_range