### PR TITLE
Pass block_type and caller by reference in static bool methods

### DIFF
--- a/trace_replay/block_cache_tracer.cc
+++ b/trace_replay/block_cache_tracer.cc
@@ -42,17 +42,17 @@ const uint64_t BlockCacheTraceRecord::kReservedGetId = 0;
 const uint64_t BlockCacheTraceHelper::kReservedGetId = 0;
 
 bool BlockCacheTraceHelper::IsGetOrMultiGetOnDataBlock(
-    TraceType block_type, TableReaderCaller caller) {
+    const TraceType& block_type, const TableReaderCaller& caller) {
   return (block_type == TraceType::kBlockTraceDataBlock) &&
          IsGetOrMultiGet(caller);
 }
 
-bool BlockCacheTraceHelper::IsGetOrMultiGet(TableReaderCaller caller) {
+bool BlockCacheTraceHelper::IsGetOrMultiGet(const TableReaderCaller& caller) {
   return caller == TableReaderCaller::kUserGet ||
          caller == TableReaderCaller::kUserMultiGet;
 }
 
-bool BlockCacheTraceHelper::IsUserAccess(TableReaderCaller caller) {
+bool BlockCacheTraceHelper::IsUserAccess(const TableReaderCaller& caller) {
   return caller == TableReaderCaller::kUserGet ||
          caller == TableReaderCaller::kUserMultiGet ||
          caller == TableReaderCaller::kUserIterator ||

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -27,10 +27,10 @@ struct BlockCacheTraceRecord;
 
 class BlockCacheTraceHelper {
  public:
-  static bool IsGetOrMultiGetOnDataBlock(TraceType block_type,
-                                         TableReaderCaller caller);
-  static bool IsGetOrMultiGet(TableReaderCaller caller);
-  static bool IsUserAccess(TableReaderCaller caller);
+  static bool IsGetOrMultiGetOnDataBlock(const TraceType& block_type,
+                                         const TableReaderCaller& caller);
+  static bool IsGetOrMultiGet(const TableReaderCaller& caller);
+  static bool IsUserAccess(const TableReaderCaller& caller);
   // Row key is a concatenation of the access's fd_number and the referenced
   // user key.
   static std::string ComputeRowKey(const BlockCacheTraceRecord& access);


### PR DESCRIPTION
We don't want to create a useless copy if we aren't modifying the params in any way. Passing the params by const reference will ensure this.