### PR TITLE
Avoid crashing on signal delivery

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1090,11 +1090,16 @@ class PosixFileSystem : public FileSystem {
       while (true) {
         // io_uring_wait_cqe.
         struct io_uring_cqe* cqe = nullptr;
-        ssize_t ret = io_uring_wait_cqe(iu, &cqe);
-        if (ret) {
-          // abort as it shouldn't be in indeterminate state and there is no
-          // good way currently to handle this error.
-          abort();
+        ssize_t ret;
+        while (true) {
+          ret = io_uring_wait_cqe(iu, &cqe);
+          if (ret == -EAGAIN || ret == -EINTR) {
+            continue;
+          }
+          if (ret < 0) {
+            return IOStatus::IOError("io_uring_wait_cqe failed: " + errno);
+          }
+          break;
         }
 
         // Step 3: Populate the request.


### PR DESCRIPTION
Hot fix for #13602 .

This is not an ideal solution, but it solves our immediate problem of crashes when profiling with coroutines enabled.

I would like to open a discussion about a proper solution to this problem.

Thank you.