### PR TITLE
Fix some compression-related assertion failures

### DIFF
--- a/util/compression.cc
+++ b/util/compression.cc
@@ -184,8 +184,9 @@ class BuiltinCompressorV2 : public Compressor {
       // Dictionary compression disabled
       return 0;
     } else {
-      return opts_.zstd_max_train_bytes > 0 ? opts_.zstd_max_train_bytes
-                                            : opts_.max_dict_bytes;
+      return type_ == kZSTD && opts_.zstd_max_train_bytes > 0
+                 ? opts_.zstd_max_train_bytes
+                 : opts_.max_dict_bytes;
     }
   }
 


### PR DESCRIPTION
Summary: showing up in the crash test after #13540
* For an assertion `dict_samples.sample_data.size() <= opts_.max_dict_bytes` we needed to ensure that `zstd_max_train_bytes` only takes effect with kZSTD compression.
* For an assertion with `r->table_options.verify_compression == (verify_decomp != nullptr)` we needed to ensure that `data_block_verify_decompressor` is set even when dictionary compression is attempted but not used.
* Noticed along the way: finish an optimization in `CompressAndVerifyBlock` that was incomplete.

Test Plan: Both failures were reproducible with hard-coding of some crash test params, and now not getting a failure.
```
--compression_type=zstd --compression_max_dict_bytes=16384 --compression_zstd_max_train_bytes=65536 --compression_max_dict_buffer_bytes=131071 --compression_use_zstd_dict_trainer=1
```
Write performance test like in #13540 shows essentially no change, maybe slightly faster (+0.4%) with verify_compression.