### PR TITLE
Fix DB open failure caused by duplicate VersionEdit records in MANIFEST

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -32,6 +32,7 @@
 #include "db/version_edit.h"
 #include "db/version_edit_handler.h"
 #include "db/version_set.h"
+#include "logging/logging.h"
 #include "port/port.h"
 #include "table/table_reader.h"
 #include "util/string_util.h"
@@ -853,6 +854,19 @@ class VersionBuilder::Rep {
     if (level != current_level) {
       if (level >= num_levels_) {
         has_invalid_levels_ = true;
+      }
+
+      if (current_level ==
+              VersionStorageInfo::FileLocation::Invalid().GetLevel() &&
+          ioptions_->allow_deleting_missing_file_during_recovery) {
+        if (version_set_) {
+          ROCKS_LOG_WARN(
+              version_set_->db_options()->info_log,
+              "table file #%" PRIu64
+              " on level %d not found when applying file deletion, ignored",
+              file_number, level);
+        }
+        return Status::OK();
       }
 
       std::ostringstream oss;

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1146,6 +1146,18 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through the SetOptions() API.
   uint32_t memtable_avg_op_scan_flush_trigger = 0;
 
+  // Allows duplicate file deletions when applying VersionEdit records during
+  // DB::Open. If a VersionEdit attempts to delete a file that no longer exists,
+  // recovery will ignore it instead of failing.
+  //
+  // This option is intended for compatibility with MANIFEST files generated
+  // by older RocksDB versions, where bugs in FIFO compaction could lead to
+  // duplicate VersionEdit entries.
+  // See https://github.com/facebook/rocksdb/issues/13624 for details.
+  //
+  // Default: false
+  bool allow_deleting_missing_file_during_recovery = false;
+
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -752,6 +752,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableCFOptions, force_consistency_checks),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"allow_deleting_missing_file_during_recovery",
+         {offsetof(struct ImmutableCFOptions,
+                   allow_deleting_missing_file_during_recovery),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         {"disallow_memtable_writes",
          {offsetof(struct ImmutableCFOptions, disallow_memtable_writes),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -1014,6 +1019,8 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       num_levels(cf_options.num_levels),
       optimize_filters_for_hits(cf_options.optimize_filters_for_hits),
       force_consistency_checks(cf_options.force_consistency_checks),
+      allow_deleting_missing_file_during_recovery(
+          cf_options.allow_deleting_missing_file_during_recovery),
       disallow_memtable_writes(cf_options.disallow_memtable_writes),
       default_temperature(cf_options.default_temperature),
       memtable_insert_with_hint_prefix_extractor(

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -66,6 +66,8 @@ struct ImmutableCFOptions {
 
   bool force_consistency_checks;
 
+  bool allow_deleting_missing_file_during_recovery;
+
   bool disallow_memtable_writes;
 
   Temperature default_temperature;

--- a/options/options.cc
+++ b/options/options.cc
@@ -114,7 +114,9 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       persist_user_defined_timestamps(options.persist_user_defined_timestamps),
       memtable_op_scan_flush_trigger(options.memtable_op_scan_flush_trigger),
       memtable_avg_op_scan_flush_trigger(
-          options.memtable_avg_op_scan_flush_trigger) {
+          options.memtable_avg_op_scan_flush_trigger),
+      allow_deleting_missing_file_during_recovery(
+          options.allow_deleting_missing_file_during_recovery) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
       static_cast<unsigned int>(num_levels)) {
@@ -399,6 +401,10 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                    paranoid_file_checks);
   ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
                    force_consistency_checks);
+  ROCKS_LOG_HEADER(
+      log,
+      "               Options.allow_deleting_missing_file_during_recovery: %d",
+      allow_deleting_missing_file_during_recovery);
   ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
                    report_bg_io_stats);
   ROCKS_LOG_HEADER(log, "               Options.disallow_memtable_writes: %d",

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -328,6 +328,8 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
   cf_opts->num_levels = ioptions.num_levels;
   cf_opts->optimize_filters_for_hits = ioptions.optimize_filters_for_hits;
   cf_opts->force_consistency_checks = ioptions.force_consistency_checks;
+  cf_opts->allow_deleting_missing_file_during_recovery =
+      ioptions.allow_deleting_missing_file_during_recovery;
   cf_opts->disallow_memtable_writes = ioptions.disallow_memtable_writes;
   cf_opts->memtable_insert_with_hint_prefix_extractor =
       ioptions.memtable_insert_with_hint_prefix_extractor;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -633,6 +633,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "check_flush_compaction_key_order=false;"
       "paranoid_file_checks=true;"
       "force_consistency_checks=true;"
+      "allow_deleting_missing_file_in_recovery=false;"
       "inplace_update_num_locks=7429;"
       "experimental_mempurge_threshold=0.0001;"
       "optimize_filters_for_hits=false;"


### PR DESCRIPTION
As described in #13624 , this PR fixes a DB open failure caused by duplicate `VersionEdit` records in the MANIFEST. The issue stems from a bug in FIFO compaction in older versions of RocksDB that could write multiple identical `VersionEdit` records to the MANIFEST, leading to `DB::Open()` failures in newer versions.

This patch introduces an option to allow duplicated deletion during recovery, enabling affected DBs to be opened successfully. 

close #13624