### PR TITLE
Enable large txn optimization by transaction write batch size

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -849,8 +849,14 @@ Status StressTest::NewTxn(WriteOptions& write_opts, ThreadState* thread,
       assert(FLAGS_user_timestamp_size == 0);
       if (thread->rand.OneIn(2)) {
         txn_options.commit_bypass_memtable = true;
-      } else {
+      }
+      if (thread->rand.OneIn(2)) {
         txn_options.large_txn_commit_optimize_threshold = 1;
+      }
+      if (thread->rand.OneIn(2) ||
+          (!txn_options.commit_bypass_memtable &&
+           txn_options.large_txn_commit_optimize_threshold != 1)) {
+        txn_options.large_txn_commit_optimize_byte_threshold = 1;
       }
       if (commit_bypass_memtable) {
         *commit_bypass_memtable = txn_options.commit_bypass_memtable;

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -396,6 +396,9 @@ struct TransactionOptions {
   // comment for `commit_bypass_memtable` for more optimization detail.
   uint32_t large_txn_commit_optimize_threshold =
       std::numeric_limits<uint32_t>::max();
+
+  uint64_t large_txn_commit_optimize_byte_threshold =
+      std::numeric_limits<uint64_t>::max();
 };
 
 // The per-write optimizations that do not involve transactions. TransactionDB

--- a/unreleased_history/new_features/large-txn-byte-threshold.md
+++ b/unreleased_history/new_features/large-txn-byte-threshold.md
@@ -1,0 +1,1 @@
+* Add new experimental `TransactionOptions::large_txn_commit_optimize_byte_threshold` to enable optimizations for large transaction commit by transaction batch data size.

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -166,10 +166,11 @@ class PessimisticTransaction : public TransactionBaseImpl {
   // Refer to
   // TransactionOptions::skip_prepare
   bool skip_prepare_ = false;
-  // Refer to
-  // TransactionOptions::commit_bypass_memtable
+  // Refer to TransactionOptions::commit_bypass_memtable
   uint32_t commit_bypass_memtable_threshold_ =
       std::numeric_limits<uint32_t>::max();
+  uint64_t commit_bypass_memtable_byte_threshold_ =
+      std::numeric_limits<uint64_t>::max();
 
  private:
   friend class TransactionTest_ValidateSnapshotTest_Test;


### PR DESCRIPTION
Summary: Larger key/values can cause memtable write to take longer time. Add new option `TransactionOptions::large_txn_commit_optimize_byte_threshold` that enables the optimization by transaction write batch size.


Test plan: 
- new unit test
- added option to stress test and ran stress test for some time: `python3 ./tools/db_crashtest.py --txn blackbox  --txn_write_policy=0 --commit_bypass_memtable_one_in=50 --test_batches_snapshots=0`