### PR TITLE
Update default value for large txn options

### DIFF
--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -373,7 +373,7 @@ struct TransactionOptions {
   // - If only bypass memtable write for transactions with >= n operations,
   //  set commit_bypass_memtable to false,
   //  large_txn_commit_optimize_threshold to n, and
-  //  large_txn_commit_optimize_byte_threshold to max.
+  //  large_txn_commit_optimize_byte_threshold to 0.
   //  Similarly for only optimize when a transaction's write batch size is >= n.
   // - If bypass memtable write for transactions with >= n operations or >= x
   // bytes,

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -254,7 +254,7 @@ struct TransactionDBOptions {
   // for more details.
   std::vector<std::shared_ptr<SecondaryIndex>> secondary_indices;
 
-  // Deprecated, this option may be removed in the future.
+  // Deprecated, this option has no effect and may be removed in the future.
   // Use TransactionOptions::large_txn_commit_optimize_threshold instead.
   //
   // This option is only valid for write committed. If the number of updates in
@@ -410,15 +410,17 @@ struct TransactionOptions {
   // When the number of updates in a transaction is at least this threshold,
   // we will enable optimizations for commiting a large transaction. See
   // comment for `commit_bypass_memtable` for more optimization detail.
-  uint32_t large_txn_commit_optimize_threshold =
-      std::numeric_limits<uint32_t>::max();
+  //
+  // Default: 0 (disabled).
+  uint32_t large_txn_commit_optimize_threshold = 0;
 
   // EXPERIMENTAL, SUBJECT TO CHANGE
   // When the size of a transaction's write batch is at least this threshold,
   // we will enable optimizations for commiting a large transaction. See
   // comment for `commit_bypass_memtable` for more optimization detail.
-  uint64_t large_txn_commit_optimize_byte_threshold =
-      std::numeric_limits<uint64_t>::max();
+  //
+  // Default: 0 (disabled).
+  uint64_t large_txn_commit_optimize_byte_threshold = 0;
 };
 
 // The per-write optimizations that do not involve transactions. TransactionDB

--- a/unreleased_history/behavior_changes/large-txn-default-val.md
+++ b/unreleased_history/behavior_changes/large-txn-default-val.md
@@ -1,1 +1,1 @@
-* `TransactionOptions::large_txn_commit_optimize_threshold` now has default value 0 for disabled. `TransactionDBOptions::txn_commit_bypass_memtable_threshold` has no effect on transactions.
+* `TransactionOptions::large_txn_commit_optimize_threshold` now has default value 0 for disabled. `TransactionDBOptions::txn_commit_bypass_memtable_threshold` now has no effect on transactions.

--- a/unreleased_history/behavior_changes/large-txn-default-val.md
+++ b/unreleased_history/behavior_changes/large-txn-default-val.md
@@ -1,0 +1,1 @@
+* `TransactionOptions::large_txn_commit_optimize_threshold` now has default value 0 for disabled. `TransactionDBOptions::txn_commit_bypass_memtable_threshold` has no effect on transactions.

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -107,13 +107,9 @@ void PessimisticTransaction::Initialize(const TransactionOptions& txn_options) {
   if (txn_options.commit_bypass_memtable) {
     // No need to optimize for empty transction
     commit_bypass_memtable_threshold_ = 1;
-  } else if (txn_options.large_txn_commit_optimize_threshold !=
-             std::numeric_limits<uint32_t>::max()) {
-    commit_bypass_memtable_threshold_ =
-        txn_options.large_txn_commit_optimize_threshold;
   } else {
     commit_bypass_memtable_threshold_ =
-        db_options.txn_commit_bypass_memtable_threshold;
+        txn_options.large_txn_commit_optimize_threshold;
   }
 
   commit_bypass_memtable_byte_threshold_ =
@@ -900,10 +896,16 @@ Status WriteCommittedTxn::CommitInternal() {
   uint32_t wb_count = wb->Count();
   RecordInHistogram(db_impl_->immutable_db_options_.stats,
                     NUM_OP_PER_TRANSACTION, wb_count);
-  bool bypass_memtable =
-      !needs_ts &&
-      (wb_count >= commit_bypass_memtable_threshold_ ||
-       wb->GetDataSize() >= commit_bypass_memtable_byte_threshold_);
+  bool bypass_memtable = false;
+  if (!needs_ts) {
+    if (commit_bypass_memtable_threshold_ &&
+        wb_count >= commit_bypass_memtable_threshold_) {
+      bypass_memtable = true;
+    } else if (commit_bypass_memtable_byte_threshold_ &&
+               wb->GetDataSize() >= commit_bypass_memtable_byte_threshold_) {
+      bypass_memtable = true;
+    }
+  }
   if (!bypass_memtable) {
     // insert prepared batch into Memtable only skipping WAL.
     // Memtable will ignore BeginPrepare/EndPrepare markers

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -854,10 +854,8 @@ Status WriteCommittedTxn::CommitInternal() {
   if (!needs_ts) {
     s = WriteBatchInternal::MarkCommit(working_batch, name_);
   } else {
-    assert(commit_bypass_memtable_threshold_ ==
-           std::numeric_limits<uint32_t>::max());
-    assert(commit_bypass_memtable_byte_threshold_ ==
-           std::numeric_limits<uint64_t>::max());
+    assert(!commit_bypass_memtable_threshold_);
+    assert(!commit_bypass_memtable_byte_threshold_);
     assert(commit_timestamp_ != kMaxTxnTimestamp);
     char commit_ts_buf[sizeof(kMaxTxnTimestamp)];
     EncodeFixed64(commit_ts_buf, commit_timestamp_);


### PR DESCRIPTION
Summary: to make it easier to use 0 for disabled. And deprecate the use of txn db option `txn_commit_bypass_memtable_threshold`. 

Test plan: updated unit tests.