### PR TITLE
Populate Missing Compaction Input Statistics

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -235,6 +235,16 @@ void CompactionJob::ReportStartedCompaction(Compaction* compaction) {
 
   job_stats_->is_manual_compaction = compaction->is_manual_compaction();
   job_stats_->is_full_compaction = compaction->is_full_compaction();
+  // populate compaction stats num_input_files and total_num_of_bytes
+  size_t num_input_files = 0;
+  for (int input_level = 0;
+       input_level < static_cast<int>(compaction->num_input_levels());
+       ++input_level) {
+    const LevelFilesBrief* flevel = compaction->input_levels(input_level);
+    num_input_files += flevel->num_files;
+  }
+  job_stats_->CompactionJobStats::num_input_files = num_input_files;
+  job_stats_->total_input_bytes = compaction->CalculateTotalInputSize();
 }
 
 void CompactionJob::Prepare(

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -217,10 +217,9 @@ void CompactionJob::ReportStartedCompaction(Compaction* compaction) {
       ThreadStatus::COMPACTION_PROP_FLAGS,
       compaction->is_manual_compaction() +
           (compaction->deletion_compaction() << 1));
-
+  auto total_input_bytes = compaction->CalculateTotalInputSize();
   ThreadStatusUtil::SetThreadOperationProperty(
-      ThreadStatus::COMPACTION_TOTAL_INPUT_BYTES,
-      compaction->CalculateTotalInputSize());
+      ThreadStatus::COMPACTION_TOTAL_INPUT_BYTES, total_input_bytes);
 
   IOSTATS_RESET(bytes_written);
   IOSTATS_RESET(bytes_read);
@@ -244,7 +243,7 @@ void CompactionJob::ReportStartedCompaction(Compaction* compaction) {
     num_input_files += flevel->num_files;
   }
   job_stats_->CompactionJobStats::num_input_files = num_input_files;
-  job_stats_->total_input_bytes = compaction->CalculateTotalInputSize();
+  job_stats_->total_input_bytes = total_input_bytes;
 }
 
 void CompactionJob::Prepare(

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -43,7 +43,6 @@ void VerifyInitializationOfCompactionJobStats(
   ASSERT_EQ(compaction_job_stats.elapsed_micros, 0U);
 
   ASSERT_EQ(compaction_job_stats.num_input_records, 0U);
-  ASSERT_EQ(compaction_job_stats.num_input_files, 0U);
   ASSERT_EQ(compaction_job_stats.num_input_files_at_output_level, 0U);
 
   ASSERT_EQ(compaction_job_stats.num_output_records, 0U);
@@ -52,7 +51,6 @@ void VerifyInitializationOfCompactionJobStats(
   ASSERT_TRUE(compaction_job_stats.is_manual_compaction);
   ASSERT_FALSE(compaction_job_stats.is_remote_compaction);
 
-  ASSERT_EQ(compaction_job_stats.total_input_bytes, 0U);
   ASSERT_EQ(compaction_job_stats.total_output_bytes, 0U);
 
   ASSERT_EQ(compaction_job_stats.total_input_raw_key_bytes, 0U);

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -545,8 +545,8 @@ class TestNumInputFilesTotalInputBytesPouplatedInListener
     num_input_files = ci.stats.num_input_files;
     total_num_of_bytes = ci.stats.total_input_bytes;
   }
-  size_t num_input_files;
-  size_t total_num_of_bytes;
+  size_t num_input_files = 0;
+  size_t total_num_of_bytes = 0;
   std::mutex mutex_;
 };
 

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -537,17 +537,20 @@ TEST_F(EventListenerTest, DisableBGCompaction) {
   ASSERT_GE(listener->slowdown_count, kSlowdownTrigger * 9);
 }
 
-class TestNumInputFilesPouplatedInListener : public EventListener {
+class TestNumInputFilesTotalInputBytesPouplatedInListener
+    : public EventListener {
  public:
   void OnCompactionCompleted(DB* /*db*/, const CompactionJobInfo& ci) override {
     std::lock_guard<std::mutex> lock(mutex_);
     num_input_files = ci.stats.num_input_files;
+    total_num_of_bytes = ci.stats.total_input_bytes;
   }
   size_t num_input_files;
+  size_t total_num_of_bytes;
   std::mutex mutex_;
 };
 
-TEST_F(EventListenerTest, NumInputFiles) {
+TEST_F(EventListenerTest, NumInputFilesTotalBytesPopulated) {
   Options options;
   options.level_compaction_dynamic_level_bytes = false;
   options.env = CurrentOptions().env;
@@ -555,8 +558,8 @@ TEST_F(EventListenerTest, NumInputFiles) {
   options.memtable_factory.reset(test::NewSpecialSkipListFactory(
       DBTestBase::kNumKeysByGenerateNewRandomFile));
 
-  TestNumInputFilesPouplatedInListener* listener =
-      new TestNumInputFilesPouplatedInListener();
+  TestNumInputFilesTotalInputBytesPouplatedInListener* listener =
+      new TestNumInputFilesTotalInputBytesPouplatedInListener();
   options.listeners.emplace_back(listener);
 
   options.level0_file_num_compaction_trigger = 4;
@@ -565,47 +568,13 @@ TEST_F(EventListenerTest, NumInputFiles) {
   DestroyAndReopen(options);
   Random rnd(301);
   ASSERT_EQ(listener->num_input_files, 0);
-  // Write 4 files in L0
-  for (int i = 0; i < 4; i++) {
-    GenerateNewRandomFile(&rnd);
-  }
-  ASSERT_OK(dbfull()->TEST_WaitForCompact());
-  ASSERT_EQ(listener->num_input_files, 4);
-}
-
-class TestTotalInputBytesPouplatedInListener : public EventListener {
- public:
-  void OnCompactionCompleted(DB* /*db*/, const CompactionJobInfo& ci) override {
-    std::lock_guard<std::mutex> lock(mutex_);
-    total_num_of_bytes = ci.stats.total_input_bytes;
-  }
-  size_t total_num_of_bytes;
-  std::mutex mutex_;
-};
-
-TEST_F(EventListenerTest, TotalInputBytes) {
-  Options options;
-  options.level_compaction_dynamic_level_bytes = false;
-  options.env = CurrentOptions().env;
-  options.create_if_missing = true;
-  options.memtable_factory.reset(test::NewSpecialSkipListFactory(
-      DBTestBase::kNumKeysByGenerateNewRandomFile));
-
-  TestTotalInputBytesPouplatedInListener* listener =
-      new TestTotalInputBytesPouplatedInListener();
-  options.listeners.emplace_back(listener);
-
-  options.level0_file_num_compaction_trigger = 4;
-  options.compaction_style = kCompactionStyleLevel;
-
-  DestroyAndReopen(options);
-  Random rnd(301);
   ASSERT_EQ(listener->total_num_of_bytes, 0);
   // Write 4 files in L0
   for (int i = 0; i < 4; i++) {
     GenerateNewRandomFile(&rnd);
   }
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_EQ(listener->num_input_files, 4);
   ASSERT_NE(listener->total_num_of_bytes, 0);
 }
 


### PR DESCRIPTION
**Summary**
This pull request aims to populate num_input_files and total_input_bytes in the CompactionJobStats object, which is accessible through EventListener::OnCompactionBegin(DB*, const CompactionJobInfo&). This change will enable RocksDB users to access accurate compaction input information.

**Context/Goals**
Provide accurate compaction input statistics to RocksDB users
Populate num_input_files and total_input_bytes in CompactionJobStats
Ensure correct population of these fields before EventListener::OnCompactionBegin() is called

**Test Plan**
Added test code to capture num_input_file and total_num_bytes when EventHandler is triggered
Asserted that these values are populated correctly

