### PR TITLE
get block_based_table_builder.cc to compile on c++23

### DIFF
--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -190,6 +190,300 @@ struct BlockBasedTableBuilder::WorkingAreaPair {
   Decompressor::ManagedWorkingArea verify;
 };
 
+struct BlockBasedTableBuilder::ParallelCompressionRep {
+  // TODO: consider replacing with autovector or similar
+  // Keys is a wrapper of vector of strings avoiding
+  // releasing string memories during vector clear()
+  // in order to save memory allocation overhead
+  class Keys {
+   public:
+    Keys() : keys_(kKeysInitSize), size_(0) {}
+    void PushBack(const Slice& key) {
+      if (size_ == keys_.size()) {
+        keys_.emplace_back(key.data(), key.size());
+      } else {
+        keys_[size_].assign(key.data(), key.size());
+      }
+      size_++;
+    }
+    void SwapAssign(std::vector<std::string>& keys) {
+      size_ = keys.size();
+      std::swap(keys_, keys);
+    }
+    void Clear() { size_ = 0; }
+    size_t Size() { return size_; }
+    std::string& Back() { return keys_[size_ - 1]; }
+    std::string& operator[](size_t idx) {
+      assert(idx < size_);
+      return keys_[idx];
+    }
+
+   private:
+    static constexpr size_t kKeysInitSize = 32;
+    std::vector<std::string> keys_;
+    size_t size_;
+  };
+  Keys curr_block_keys;
+
+  struct BlockRep;
+
+  // Use BlockRepSlot to keep block order in write thread.
+  // slot_ will pass references to BlockRep
+  class BlockRepSlot {
+   public:
+    BlockRepSlot() : slot_(1) {}
+    template <typename T>
+    void Fill(T&& rep) {
+      slot_.push(std::forward<T>(rep));
+    }
+    void Take(BlockRep*& rep) { slot_.pop(rep); }
+
+   private:
+    // slot_ will pass references to BlockRep in block_rep_buf,
+    // and those references are always valid before the destruction of
+    // block_rep_buf.
+    WorkQueue<BlockRep*> slot_;
+  };
+
+  // BlockRep instances are fetched from and recycled to
+  // block_rep_pool during parallel compression.
+  struct ALIGN_AS(CACHE_LINE_SIZE) BlockRep {
+    // Uncompressed block contents
+    std::string uncompressed;
+    std::string compressed;
+    CompressionType compression_type = kNoCompression;
+    // For efficiency, the std::string is repeatedly overwritten without
+    // checking for "has no value". Only at the end of its life will it be
+    // assigned "no value". Thus, it needs to start with a value.
+    std::optional<std::string> first_key_in_next_block = std::string{};
+    Keys keys;
+    BlockRepSlot slot;
+    Status status;
+  };
+
+  // Use a vector of BlockRep as a buffer for a determined number
+  // of BlockRep structures. All data referenced by pointers in
+  // BlockRep will be freed when this vector is destructed.
+  using BlockRepBuffer = std::vector<BlockRep>;
+  BlockRepBuffer block_rep_buf;
+  // Use a thread-safe queue for concurrent access from block
+  // building thread and writer thread.
+  using BlockRepPool = WorkQueue<BlockRep*>;
+  BlockRepPool block_rep_pool;
+
+  // Compression queue will pass references to BlockRep in block_rep_buf,
+  // and those references are always valid before the destruction of
+  // block_rep_buf.
+  using CompressQueue = WorkQueue<BlockRep*>;
+  CompressQueue compress_queue;
+  std::vector<port::Thread> compress_thread_pool;
+
+  // Write queue will pass references to BlockRep::slot in block_rep_buf,
+  // and those references are always valid before the corresponding
+  // BlockRep::slot is destructed, which is before the destruction of
+  // block_rep_buf.
+  using WriteQueue = WorkQueue<BlockRepSlot*>;
+  WriteQueue write_queue;
+  std::unique_ptr<port::Thread> write_thread;
+
+  // Estimate output file size when parallel compression is enabled. This is
+  // necessary because compression & flush are no longer synchronized,
+  // and BlockBasedTableBuilder::FileSize() is no longer accurate.
+  // memory_order_relaxed suffices because accurate statistics is not required.
+  class FileSizeEstimator {
+   public:
+    explicit FileSizeEstimator()
+        : uncomp_bytes_compressed(0),
+          uncomp_bytes_curr_block(0),
+          uncomp_bytes_curr_block_set(false),
+          uncomp_bytes_inflight(0),
+          blocks_inflight(0),
+          curr_compression_ratio(0),
+          estimated_file_size(0) {}
+
+    // Estimate file size when a block is about to be emitted to
+    // compression thread
+    void EmitBlock(uint64_t uncomp_block_size, uint64_t curr_file_size) {
+      uint64_t new_uncomp_bytes_inflight =
+          uncomp_bytes_inflight.fetch_add(uncomp_block_size,
+                                          std::memory_order_relaxed) +
+          uncomp_block_size;
+
+      uint64_t new_blocks_inflight =
+          blocks_inflight.fetch_add(1, std::memory_order_relaxed) + 1;
+
+      estimated_file_size.store(
+          curr_file_size +
+              static_cast<uint64_t>(
+                  static_cast<double>(new_uncomp_bytes_inflight) *
+                  curr_compression_ratio.load(std::memory_order_relaxed)) +
+              new_blocks_inflight * kBlockTrailerSize,
+          std::memory_order_relaxed);
+    }
+
+    // Estimate file size when a block is already reaped from
+    // compression thread
+    void ReapBlock(uint64_t compressed_block_size, uint64_t curr_file_size) {
+      assert(uncomp_bytes_curr_block_set);
+
+      uint64_t new_uncomp_bytes_compressed =
+          uncomp_bytes_compressed + uncomp_bytes_curr_block;
+      assert(new_uncomp_bytes_compressed > 0);
+
+      curr_compression_ratio.store(
+          (curr_compression_ratio.load(std::memory_order_relaxed) *
+               uncomp_bytes_compressed +
+           compressed_block_size) /
+              static_cast<double>(new_uncomp_bytes_compressed),
+          std::memory_order_relaxed);
+      uncomp_bytes_compressed = new_uncomp_bytes_compressed;
+
+      uint64_t new_uncomp_bytes_inflight =
+          uncomp_bytes_inflight.fetch_sub(uncomp_bytes_curr_block,
+                                          std::memory_order_relaxed) -
+          uncomp_bytes_curr_block;
+
+      uint64_t new_blocks_inflight =
+          blocks_inflight.fetch_sub(1, std::memory_order_relaxed) - 1;
+
+      estimated_file_size.store(
+          curr_file_size +
+              static_cast<uint64_t>(
+                  static_cast<double>(new_uncomp_bytes_inflight) *
+                  curr_compression_ratio.load(std::memory_order_relaxed)) +
+              new_blocks_inflight * kBlockTrailerSize,
+          std::memory_order_relaxed);
+
+      uncomp_bytes_curr_block_set = false;
+    }
+
+    void SetEstimatedFileSize(uint64_t size) {
+      estimated_file_size.store(size, std::memory_order_relaxed);
+    }
+
+    uint64_t GetEstimatedFileSize() {
+      return estimated_file_size.load(std::memory_order_relaxed);
+    }
+
+    void SetCurrBlockUncompSize(uint64_t size) {
+      uncomp_bytes_curr_block = size;
+      uncomp_bytes_curr_block_set = true;
+    }
+
+   private:
+    // Input bytes compressed so far.
+    uint64_t uncomp_bytes_compressed;
+    // Size of current block being appended.
+    uint64_t uncomp_bytes_curr_block;
+    // Whether uncomp_bytes_curr_block has been set for next
+    // ReapBlock call.
+    bool uncomp_bytes_curr_block_set;
+    // Input bytes under compression and not appended yet.
+    std::atomic<uint64_t> uncomp_bytes_inflight;
+    // Number of blocks under compression and not appended yet.
+    std::atomic<uint64_t> blocks_inflight;
+    // Current compression ratio, maintained by BGWorkWriteMaybeCompressedBlock.
+    std::atomic<double> curr_compression_ratio;
+    // Estimated SST file size.
+    std::atomic<uint64_t> estimated_file_size;
+  };
+  FileSizeEstimator file_size_estimator;
+
+  // Facilities used for waiting first block completion. Need to Wait for
+  // the completion of first block compression and flush to get a non-zero
+  // compression ratio.
+  std::atomic<bool> first_block_processed;
+  std::condition_variable first_block_cond;
+  std::mutex first_block_mutex;
+
+  explicit ParallelCompressionRep(uint32_t parallel_threads)
+      : block_rep_buf(parallel_threads),
+        block_rep_pool(parallel_threads),
+        compress_queue(parallel_threads),
+        write_queue(parallel_threads),
+        first_block_processed(false) {
+    for (uint32_t i = 0; i < parallel_threads; i++) {
+      // Prime the queue of available BlockReps
+      block_rep_pool.push(&block_rep_buf[i]);
+    }
+  }
+
+  ~ParallelCompressionRep() { block_rep_pool.finish(); }
+
+  // Make a block prepared to be emitted to compression thread
+  // Used in non-buffered mode
+  BlockRep* PrepareBlock(const Slice* first_key_in_next_block,
+                         BlockBuilder* data_block) {
+    BlockRep* block_rep = PrepareBlockInternal(first_key_in_next_block);
+    assert(block_rep != nullptr);
+    data_block->SwapAndReset(block_rep->uncompressed);
+    std::swap(block_rep->keys, curr_block_keys);
+    curr_block_keys.Clear();
+    return block_rep;
+  }
+
+  // Used in EnterUnbuffered
+  BlockRep* PrepareBlock(const Slice* first_key_in_next_block,
+                         std::string* data_block,
+                         std::vector<std::string>* keys) {
+    BlockRep* block_rep = PrepareBlockInternal(first_key_in_next_block);
+    assert(block_rep != nullptr);
+    std::swap(block_rep->uncompressed, *data_block);
+    block_rep->keys.SwapAssign(*keys);
+    return block_rep;
+  }
+
+  // Emit a block to compression thread
+  void EmitBlock(BlockRep* block_rep) {
+    assert(block_rep != nullptr);
+    assert(block_rep->status.ok());
+    if (!write_queue.push(&block_rep->slot)) {
+      return;
+    }
+    if (!compress_queue.push(block_rep)) {
+      return;
+    }
+
+    if (!first_block_processed.load(std::memory_order_relaxed)) {
+      std::unique_lock<std::mutex> lock(first_block_mutex);
+      first_block_cond.wait(lock, [this] {
+        return first_block_processed.load(std::memory_order_relaxed);
+      });
+    }
+  }
+
+  // Reap a block from compression thread
+  void ReapBlock(BlockRep* block_rep) {
+    assert(block_rep != nullptr);
+    block_rep->compressed.clear();
+    block_rep_pool.push(block_rep);
+
+    if (!first_block_processed.load(std::memory_order_relaxed)) {
+      std::lock_guard<std::mutex> lock(first_block_mutex);
+      first_block_processed.store(true, std::memory_order_relaxed);
+      first_block_cond.notify_one();
+    }
+  }
+
+ private:
+  BlockRep* PrepareBlockInternal(const Slice* first_key_in_next_block) {
+    BlockRep* block_rep = nullptr;
+    block_rep_pool.pop(block_rep);
+    assert(block_rep != nullptr);
+
+    block_rep->compression_type = kNoCompression;
+
+    if (first_key_in_next_block == nullptr) {
+      block_rep->first_key_in_next_block = {};
+    } else {
+      block_rep->first_key_in_next_block->assign(
+          first_key_in_next_block->data(), first_key_in_next_block->size());
+    }
+
+    return block_rep;
+  }
+};
+
 struct BlockBasedTableBuilder::Rep {
   const ImmutableOptions ioptions;
   // BEGIN from MutableCFOptions
@@ -669,300 +963,6 @@ struct BlockBasedTableBuilder::Rep {
   std::mutex io_status_mutex;
   std::atomic<bool> io_status_ok;
   IOStatus io_status;
-};
-
-struct BlockBasedTableBuilder::ParallelCompressionRep {
-  // TODO: consider replacing with autovector or similar
-  // Keys is a wrapper of vector of strings avoiding
-  // releasing string memories during vector clear()
-  // in order to save memory allocation overhead
-  class Keys {
-   public:
-    Keys() : keys_(kKeysInitSize), size_(0) {}
-    void PushBack(const Slice& key) {
-      if (size_ == keys_.size()) {
-        keys_.emplace_back(key.data(), key.size());
-      } else {
-        keys_[size_].assign(key.data(), key.size());
-      }
-      size_++;
-    }
-    void SwapAssign(std::vector<std::string>& keys) {
-      size_ = keys.size();
-      std::swap(keys_, keys);
-    }
-    void Clear() { size_ = 0; }
-    size_t Size() { return size_; }
-    std::string& Back() { return keys_[size_ - 1]; }
-    std::string& operator[](size_t idx) {
-      assert(idx < size_);
-      return keys_[idx];
-    }
-
-   private:
-    static constexpr size_t kKeysInitSize = 32;
-    std::vector<std::string> keys_;
-    size_t size_;
-  };
-  Keys curr_block_keys;
-
-  struct BlockRep;
-
-  // Use BlockRepSlot to keep block order in write thread.
-  // slot_ will pass references to BlockRep
-  class BlockRepSlot {
-   public:
-    BlockRepSlot() : slot_(1) {}
-    template <typename T>
-    void Fill(T&& rep) {
-      slot_.push(std::forward<T>(rep));
-    }
-    void Take(BlockRep*& rep) { slot_.pop(rep); }
-
-   private:
-    // slot_ will pass references to BlockRep in block_rep_buf,
-    // and those references are always valid before the destruction of
-    // block_rep_buf.
-    WorkQueue<BlockRep*> slot_;
-  };
-
-  // BlockRep instances are fetched from and recycled to
-  // block_rep_pool during parallel compression.
-  struct ALIGN_AS(CACHE_LINE_SIZE) BlockRep {
-    // Uncompressed block contents
-    std::string uncompressed;
-    std::string compressed;
-    CompressionType compression_type = kNoCompression;
-    // For efficiency, the std::string is repeatedly overwritten without
-    // checking for "has no value". Only at the end of its life will it be
-    // assigned "no value". Thus, it needs to start with a value.
-    std::optional<std::string> first_key_in_next_block = std::string{};
-    Keys keys;
-    BlockRepSlot slot;
-    Status status;
-  };
-
-  // Use a vector of BlockRep as a buffer for a determined number
-  // of BlockRep structures. All data referenced by pointers in
-  // BlockRep will be freed when this vector is destructed.
-  using BlockRepBuffer = std::vector<BlockRep>;
-  BlockRepBuffer block_rep_buf;
-  // Use a thread-safe queue for concurrent access from block
-  // building thread and writer thread.
-  using BlockRepPool = WorkQueue<BlockRep*>;
-  BlockRepPool block_rep_pool;
-
-  // Compression queue will pass references to BlockRep in block_rep_buf,
-  // and those references are always valid before the destruction of
-  // block_rep_buf.
-  using CompressQueue = WorkQueue<BlockRep*>;
-  CompressQueue compress_queue;
-  std::vector<port::Thread> compress_thread_pool;
-
-  // Write queue will pass references to BlockRep::slot in block_rep_buf,
-  // and those references are always valid before the corresponding
-  // BlockRep::slot is destructed, which is before the destruction of
-  // block_rep_buf.
-  using WriteQueue = WorkQueue<BlockRepSlot*>;
-  WriteQueue write_queue;
-  std::unique_ptr<port::Thread> write_thread;
-
-  // Estimate output file size when parallel compression is enabled. This is
-  // necessary because compression & flush are no longer synchronized,
-  // and BlockBasedTableBuilder::FileSize() is no longer accurate.
-  // memory_order_relaxed suffices because accurate statistics is not required.
-  class FileSizeEstimator {
-   public:
-    explicit FileSizeEstimator()
-        : uncomp_bytes_compressed(0),
-          uncomp_bytes_curr_block(0),
-          uncomp_bytes_curr_block_set(false),
-          uncomp_bytes_inflight(0),
-          blocks_inflight(0),
-          curr_compression_ratio(0),
-          estimated_file_size(0) {}
-
-    // Estimate file size when a block is about to be emitted to
-    // compression thread
-    void EmitBlock(uint64_t uncomp_block_size, uint64_t curr_file_size) {
-      uint64_t new_uncomp_bytes_inflight =
-          uncomp_bytes_inflight.fetch_add(uncomp_block_size,
-                                          std::memory_order_relaxed) +
-          uncomp_block_size;
-
-      uint64_t new_blocks_inflight =
-          blocks_inflight.fetch_add(1, std::memory_order_relaxed) + 1;
-
-      estimated_file_size.store(
-          curr_file_size +
-              static_cast<uint64_t>(
-                  static_cast<double>(new_uncomp_bytes_inflight) *
-                  curr_compression_ratio.load(std::memory_order_relaxed)) +
-              new_blocks_inflight * kBlockTrailerSize,
-          std::memory_order_relaxed);
-    }
-
-    // Estimate file size when a block is already reaped from
-    // compression thread
-    void ReapBlock(uint64_t compressed_block_size, uint64_t curr_file_size) {
-      assert(uncomp_bytes_curr_block_set);
-
-      uint64_t new_uncomp_bytes_compressed =
-          uncomp_bytes_compressed + uncomp_bytes_curr_block;
-      assert(new_uncomp_bytes_compressed > 0);
-
-      curr_compression_ratio.store(
-          (curr_compression_ratio.load(std::memory_order_relaxed) *
-               uncomp_bytes_compressed +
-           compressed_block_size) /
-              static_cast<double>(new_uncomp_bytes_compressed),
-          std::memory_order_relaxed);
-      uncomp_bytes_compressed = new_uncomp_bytes_compressed;
-
-      uint64_t new_uncomp_bytes_inflight =
-          uncomp_bytes_inflight.fetch_sub(uncomp_bytes_curr_block,
-                                          std::memory_order_relaxed) -
-          uncomp_bytes_curr_block;
-
-      uint64_t new_blocks_inflight =
-          blocks_inflight.fetch_sub(1, std::memory_order_relaxed) - 1;
-
-      estimated_file_size.store(
-          curr_file_size +
-              static_cast<uint64_t>(
-                  static_cast<double>(new_uncomp_bytes_inflight) *
-                  curr_compression_ratio.load(std::memory_order_relaxed)) +
-              new_blocks_inflight * kBlockTrailerSize,
-          std::memory_order_relaxed);
-
-      uncomp_bytes_curr_block_set = false;
-    }
-
-    void SetEstimatedFileSize(uint64_t size) {
-      estimated_file_size.store(size, std::memory_order_relaxed);
-    }
-
-    uint64_t GetEstimatedFileSize() {
-      return estimated_file_size.load(std::memory_order_relaxed);
-    }
-
-    void SetCurrBlockUncompSize(uint64_t size) {
-      uncomp_bytes_curr_block = size;
-      uncomp_bytes_curr_block_set = true;
-    }
-
-   private:
-    // Input bytes compressed so far.
-    uint64_t uncomp_bytes_compressed;
-    // Size of current block being appended.
-    uint64_t uncomp_bytes_curr_block;
-    // Whether uncomp_bytes_curr_block has been set for next
-    // ReapBlock call.
-    bool uncomp_bytes_curr_block_set;
-    // Input bytes under compression and not appended yet.
-    std::atomic<uint64_t> uncomp_bytes_inflight;
-    // Number of blocks under compression and not appended yet.
-    std::atomic<uint64_t> blocks_inflight;
-    // Current compression ratio, maintained by BGWorkWriteMaybeCompressedBlock.
-    std::atomic<double> curr_compression_ratio;
-    // Estimated SST file size.
-    std::atomic<uint64_t> estimated_file_size;
-  };
-  FileSizeEstimator file_size_estimator;
-
-  // Facilities used for waiting first block completion. Need to Wait for
-  // the completion of first block compression and flush to get a non-zero
-  // compression ratio.
-  std::atomic<bool> first_block_processed;
-  std::condition_variable first_block_cond;
-  std::mutex first_block_mutex;
-
-  explicit ParallelCompressionRep(uint32_t parallel_threads)
-      : block_rep_buf(parallel_threads),
-        block_rep_pool(parallel_threads),
-        compress_queue(parallel_threads),
-        write_queue(parallel_threads),
-        first_block_processed(false) {
-    for (uint32_t i = 0; i < parallel_threads; i++) {
-      // Prime the queue of available BlockReps
-      block_rep_pool.push(&block_rep_buf[i]);
-    }
-  }
-
-  ~ParallelCompressionRep() { block_rep_pool.finish(); }
-
-  // Make a block prepared to be emitted to compression thread
-  // Used in non-buffered mode
-  BlockRep* PrepareBlock(const Slice* first_key_in_next_block,
-                         BlockBuilder* data_block) {
-    BlockRep* block_rep = PrepareBlockInternal(first_key_in_next_block);
-    assert(block_rep != nullptr);
-    data_block->SwapAndReset(block_rep->uncompressed);
-    std::swap(block_rep->keys, curr_block_keys);
-    curr_block_keys.Clear();
-    return block_rep;
-  }
-
-  // Used in EnterUnbuffered
-  BlockRep* PrepareBlock(const Slice* first_key_in_next_block,
-                         std::string* data_block,
-                         std::vector<std::string>* keys) {
-    BlockRep* block_rep = PrepareBlockInternal(first_key_in_next_block);
-    assert(block_rep != nullptr);
-    std::swap(block_rep->uncompressed, *data_block);
-    block_rep->keys.SwapAssign(*keys);
-    return block_rep;
-  }
-
-  // Emit a block to compression thread
-  void EmitBlock(BlockRep* block_rep) {
-    assert(block_rep != nullptr);
-    assert(block_rep->status.ok());
-    if (!write_queue.push(&block_rep->slot)) {
-      return;
-    }
-    if (!compress_queue.push(block_rep)) {
-      return;
-    }
-
-    if (!first_block_processed.load(std::memory_order_relaxed)) {
-      std::unique_lock<std::mutex> lock(first_block_mutex);
-      first_block_cond.wait(lock, [this] {
-        return first_block_processed.load(std::memory_order_relaxed);
-      });
-    }
-  }
-
-  // Reap a block from compression thread
-  void ReapBlock(BlockRep* block_rep) {
-    assert(block_rep != nullptr);
-    block_rep->compressed.clear();
-    block_rep_pool.push(block_rep);
-
-    if (!first_block_processed.load(std::memory_order_relaxed)) {
-      std::lock_guard<std::mutex> lock(first_block_mutex);
-      first_block_processed.store(true, std::memory_order_relaxed);
-      first_block_cond.notify_one();
-    }
-  }
-
- private:
-  BlockRep* PrepareBlockInternal(const Slice* first_key_in_next_block) {
-    BlockRep* block_rep = nullptr;
-    block_rep_pool.pop(block_rep);
-    assert(block_rep != nullptr);
-
-    block_rep->compression_type = kNoCompression;
-
-    if (first_key_in_next_block == nullptr) {
-      block_rep->first_key_in_next_block = {};
-    } else {
-      block_rep->first_key_in_next_block->assign(
-          first_key_in_next_block->data(), first_key_in_next_block->size());
-    }
-
-    return block_rep;
-  }
 };
 
 BlockBasedTableBuilder::BlockBasedTableBuilder(

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -403,259 +403,7 @@ struct BlockBasedTableBuilder::Rep {
   }
 
   Rep(const BlockBasedTableOptions& table_opt, const TableBuilderOptions& tbo,
-      WritableFileWriter* f)
-      : ioptions(tbo.ioptions),
-        prefix_extractor(tbo.moptions.prefix_extractor),
-        write_options(tbo.write_options),
-        table_options(table_opt),
-        internal_comparator(tbo.internal_comparator),
-        ts_sz(tbo.internal_comparator.user_comparator()->timestamp_size()),
-        persist_user_defined_timestamps(
-            tbo.ioptions.persist_user_defined_timestamps),
-        file(f),
-        offset(0),
-        alignment(table_options.block_align
-                      ? std::min(static_cast<size_t>(table_options.block_size),
-                                 kDefaultPageSize)
-                      : 0),
-        data_block(table_options.block_restart_interval,
-                   table_options.use_delta_encoding,
-                   false /* use_value_delta_encoding */,
-                   tbo.internal_comparator.user_comparator()
-                           ->CanKeysWithDifferentByteContentsBeEqual()
-                       ? BlockBasedTableOptions::kDataBlockBinarySearch
-                       : table_options.data_block_index_type,
-                   table_options.data_block_hash_table_util_ratio, ts_sz,
-                   persist_user_defined_timestamps),
-        range_del_block(
-            1 /* block_restart_interval */, true /* use_delta_encoding */,
-            false /* use_value_delta_encoding */,
-            BlockBasedTableOptions::kDataBlockBinarySearch /* index_type */,
-            0.75 /* data_block_hash_table_util_ratio */, ts_sz,
-            persist_user_defined_timestamps),
-        internal_prefix_transform(prefix_extractor.get()),
-        sample_for_compression(tbo.moptions.sample_for_compression),
-        compressible_input_data_bytes(0),
-        uncompressible_input_data_bytes(0),
-        sampled_input_data_bytes(0),
-        sampled_output_slow_data_bytes(0),
-        sampled_output_fast_data_bytes(0),
-        compression_parallel_threads(tbo.compression_opts.parallel_threads),
-        max_compressed_bytes_per_kb(
-            tbo.compression_opts.max_compressed_bytes_per_kb),
-        data_block_working_areas(compression_parallel_threads),
-        use_delta_encoding_for_index_values(table_opt.format_version >= 4 &&
-                                            !table_opt.block_align),
-        reason(tbo.reason),
-        flush_block_policy(
-            table_options.flush_block_policy_factory->NewFlushBlockPolicy(
-                table_options, data_block)),
-        create_context(&table_options, &ioptions, ioptions.stats,
-                       /*decompressor=*/nullptr,
-                       tbo.moptions.block_protection_bytes_per_key,
-                       tbo.internal_comparator.user_comparator(),
-                       !use_delta_encoding_for_index_values,
-                       table_opt.index_type ==
-                           BlockBasedTableOptions::kBinarySearchWithFirstKey),
-        tail_size(0),
-        status_ok(true),
-        io_status_ok(true) {
-    FilterBuildingContext filter_context(table_options);
-
-    filter_context.info_log = ioptions.logger;
-    filter_context.column_family_name = tbo.column_family_name;
-    filter_context.reason = reason;
-
-    // Only populate other fields if known to be in LSM rather than
-    // generating external SST file
-    if (reason != TableFileCreationReason::kMisc) {
-      filter_context.compaction_style = ioptions.compaction_style;
-      filter_context.num_levels = ioptions.num_levels;
-      filter_context.level_at_creation = tbo.level_at_creation;
-      filter_context.is_bottommost = tbo.is_bottommost;
-      assert(filter_context.level_at_creation < filter_context.num_levels);
-    }
-
-    // TODO: get CompressionManager from options and sort out properties
-    auto mgr = tbo.moptions.compression_manager;
-    if (mgr == nullptr) {
-      mgr = GetBuiltinCompressionManager(
-          GetCompressFormatForVersion(table_opt.format_version));
-    }
-    props.compression_name = CompressionTypeToString(tbo.compression_type);
-    props.compression_options =
-        CompressionOptionsToString(tbo.compression_opts);
-
-    // Sanitize to only allowing compression when it saves space.
-    max_compressed_bytes_per_kb =
-        std::min(int{1023}, tbo.compression_opts.max_compressed_bytes_per_kb);
-
-    basic_compressor = mgr->GetCompressorForSST(
-        filter_context, tbo.compression_opts, tbo.compression_type);
-    if (basic_compressor) {
-      if (table_options.enable_index_compression) {
-        basic_working_area.compress = basic_compressor->ObtainWorkingArea();
-      }
-      max_dict_sample_bytes = basic_compressor->GetMaxSampleSizeIfWantDict(
-          CacheEntryRole::kDataBlock);
-      if (max_dict_sample_bytes > 0) {
-        state = State::kBuffered;
-        if (tbo.target_file_size == 0) {
-          buffer_limit = tbo.compression_opts.max_dict_buffer_bytes;
-        } else if (tbo.compression_opts.max_dict_buffer_bytes == 0) {
-          buffer_limit = tbo.target_file_size;
-        } else {
-          buffer_limit = std::min(tbo.target_file_size,
-                                  tbo.compression_opts.max_dict_buffer_bytes);
-        }
-      } else {
-        // No distinct data block compressor using dictionary
-        data_block_compressor = basic_compressor.get();
-        for (uint32_t i = 0; i < compression_parallel_threads; i++) {
-          data_block_working_areas[i].compress =
-              data_block_compressor->ObtainWorkingArea();
-        }
-      }
-      basic_decompressor =
-          mgr->GetDecompressorOptimizeFor(tbo.compression_type);
-      create_context.decompressor = basic_decompressor.get();
-
-      if (table_options.verify_compression) {
-        verify_decompressor = basic_decompressor.get();
-        if (table_options.enable_index_compression) {
-          basic_working_area.verify =
-              verify_decompressor->ObtainWorkingArea(tbo.compression_type);
-        }
-        if (state == State::kUnbuffered) {
-          for (uint32_t i = 0; i < compression_parallel_threads; i++) {
-            data_block_working_areas[i].verify =
-                verify_decompressor->ObtainWorkingArea(tbo.compression_type);
-          }
-          data_block_verify_decompressor = verify_decompressor.get();
-        }
-      }
-    }
-
-    switch (table_options.prepopulate_block_cache) {
-      case BlockBasedTableOptions::PrepopulateBlockCache::kFlushOnly:
-        warm_cache = (reason == TableFileCreationReason::kFlush);
-        break;
-      case BlockBasedTableOptions::PrepopulateBlockCache::kDisable:
-        warm_cache = false;
-        break;
-      default:
-        // missing case
-        assert(false);
-        warm_cache = false;
-    }
-
-    const auto compress_dict_build_buffer_charged =
-        table_options.cache_usage_options.options_overrides
-            .at(CacheEntryRole::kCompressionDictionaryBuildingBuffer)
-            .charged;
-    if (table_options.block_cache &&
-        (compress_dict_build_buffer_charged ==
-             CacheEntryRoleOptions::Decision::kEnabled ||
-         compress_dict_build_buffer_charged ==
-             CacheEntryRoleOptions::Decision::kFallback)) {
-      compression_dict_buffer_cache_res_mgr =
-          std::make_shared<CacheReservationManagerImpl<
-              CacheEntryRole::kCompressionDictionaryBuildingBuffer>>(
-              table_options.block_cache);
-    } else {
-      compression_dict_buffer_cache_res_mgr = nullptr;
-    }
-
-    if (table_options.index_type ==
-        BlockBasedTableOptions::kTwoLevelIndexSearch) {
-      p_index_builder_ = PartitionedIndexBuilder::CreateIndexBuilder(
-          &internal_comparator, use_delta_encoding_for_index_values,
-          table_options, ts_sz, persist_user_defined_timestamps);
-      index_builder.reset(p_index_builder_);
-    } else {
-      index_builder.reset(IndexBuilder::CreateIndexBuilder(
-          table_options.index_type, &internal_comparator,
-          &this->internal_prefix_transform, use_delta_encoding_for_index_values,
-          table_options, ts_sz, persist_user_defined_timestamps));
-    }
-    if (ioptions.optimize_filters_for_hits && tbo.is_bottommost) {
-      // Apply optimize_filters_for_hits setting here when applicable by
-      // skipping filter generation
-      filter_builder.reset();
-    } else if (tbo.skip_filters) {
-      // For SstFileWriter skip_filters
-      filter_builder.reset();
-    } else if (!table_options.filter_policy) {
-      // Null filter_policy -> no filter
-      filter_builder.reset();
-    } else {
-      filter_builder.reset(CreateFilterBlockBuilder(
-          ioptions, tbo.moptions, filter_context,
-          use_delta_encoding_for_index_values, p_index_builder_, ts_sz,
-          persist_user_defined_timestamps));
-    }
-
-    assert(tbo.internal_tbl_prop_coll_factories);
-    for (auto& factory : *tbo.internal_tbl_prop_coll_factories) {
-      assert(factory);
-
-      std::unique_ptr<InternalTblPropColl> collector{
-          factory->CreateInternalTblPropColl(
-              tbo.column_family_id, tbo.level_at_creation,
-              tbo.ioptions.num_levels,
-              tbo.last_level_inclusive_max_seqno_threshold)};
-      if (collector) {
-        table_properties_collectors.emplace_back(std::move(collector));
-      }
-    }
-    table_properties_collectors.emplace_back(
-        new BlockBasedTablePropertiesCollector(
-            table_options.index_type, table_options.whole_key_filtering,
-            prefix_extractor != nullptr,
-            table_options.decouple_partitioned_filters));
-    if (ts_sz > 0 && persist_user_defined_timestamps) {
-      table_properties_collectors.emplace_back(
-          new TimestampTablePropertiesCollector(
-              tbo.internal_comparator.user_comparator()));
-    }
-
-    // These are only needed for populating table properties
-    props.column_family_id = tbo.column_family_id;
-    props.column_family_name = tbo.column_family_name;
-    props.oldest_key_time = tbo.oldest_key_time;
-    props.newest_key_time = tbo.newest_key_time;
-    props.file_creation_time = tbo.file_creation_time;
-    props.orig_file_number = tbo.cur_file_num;
-    props.db_id = tbo.db_id;
-    props.db_session_id = tbo.db_session_id;
-    props.db_host_id = ioptions.db_host_id;
-    props.format_version = table_options.format_version;
-    if (!ReifyDbHostIdProperty(ioptions.env, &props.db_host_id).ok()) {
-      ROCKS_LOG_INFO(ioptions.logger, "db_host_id property will not be set");
-    }
-    // Default is UINT64_MAX for unknown. Setting it to 0 here
-    // to allow updating it by taking max in BlockBasedTableBuilder::Add().
-    props.key_largest_seqno = 0;
-
-    if (FormatVersionUsesContextChecksum(table_options.format_version)) {
-      // Must be non-zero and semi- or quasi-random
-      // TODO: ideally guaranteed different for related files (e.g. use file
-      // number and db_session, for benefit of SstFileWriter)
-      do {
-        base_context_checksum = Random::GetTLSInstance()->Next();
-      } while (UNLIKELY(base_context_checksum == 0));
-    } else {
-      base_context_checksum = 0;
-    }
-
-    if (alignment > 0 && basic_compressor) {
-      // With better sanitization in `CompactionPicker::CompactFiles()`, we
-      // would not need to handle this case here and could change it to an
-      // assertion instead.
-      SetStatus(Status::InvalidArgument(
-          "Enable block_align, but compression enabled"));
-    }
-  }
+      WritableFileWriter* f);
 
   Rep(const Rep&) = delete;
   Rep& operator=(const Rep&) = delete;
@@ -964,6 +712,260 @@ struct BlockBasedTableBuilder::ParallelCompressionRep {
     return block_rep;
   }
 };
+
+BlockBasedTableBuilder::Rep::Rep(const BlockBasedTableOptions& table_opt,
+                                 const TableBuilderOptions& tbo,
+                                 WritableFileWriter* f)
+    : ioptions(tbo.ioptions),
+      prefix_extractor(tbo.moptions.prefix_extractor),
+      write_options(tbo.write_options),
+      table_options(table_opt),
+      internal_comparator(tbo.internal_comparator),
+      ts_sz(tbo.internal_comparator.user_comparator()->timestamp_size()),
+      persist_user_defined_timestamps(
+          tbo.ioptions.persist_user_defined_timestamps),
+      file(f),
+      offset(0),
+      alignment(table_options.block_align
+                    ? std::min(static_cast<size_t>(table_options.block_size),
+                               kDefaultPageSize)
+                    : 0),
+      data_block(table_options.block_restart_interval,
+                 table_options.use_delta_encoding,
+                 false /* use_value_delta_encoding */,
+                 tbo.internal_comparator.user_comparator()
+                         ->CanKeysWithDifferentByteContentsBeEqual()
+                     ? BlockBasedTableOptions::kDataBlockBinarySearch
+                     : table_options.data_block_index_type,
+                 table_options.data_block_hash_table_util_ratio, ts_sz,
+                 persist_user_defined_timestamps),
+      range_del_block(
+          1 /* block_restart_interval */, true /* use_delta_encoding */,
+          false /* use_value_delta_encoding */,
+          BlockBasedTableOptions::kDataBlockBinarySearch /* index_type */,
+          0.75 /* data_block_hash_table_util_ratio */, ts_sz,
+          persist_user_defined_timestamps),
+      internal_prefix_transform(prefix_extractor.get()),
+      sample_for_compression(tbo.moptions.sample_for_compression),
+      compressible_input_data_bytes(0),
+      uncompressible_input_data_bytes(0),
+      sampled_input_data_bytes(0),
+      sampled_output_slow_data_bytes(0),
+      sampled_output_fast_data_bytes(0),
+      compression_parallel_threads(tbo.compression_opts.parallel_threads),
+      max_compressed_bytes_per_kb(
+          tbo.compression_opts.max_compressed_bytes_per_kb),
+      data_block_working_areas(compression_parallel_threads),
+      use_delta_encoding_for_index_values(table_opt.format_version >= 4 &&
+                                          !table_opt.block_align),
+      reason(tbo.reason),
+      flush_block_policy(
+          table_options.flush_block_policy_factory->NewFlushBlockPolicy(
+              table_options, data_block)),
+      create_context(&table_options, &ioptions, ioptions.stats,
+                     /*decompressor=*/nullptr,
+                     tbo.moptions.block_protection_bytes_per_key,
+                     tbo.internal_comparator.user_comparator(),
+                     !use_delta_encoding_for_index_values,
+                     table_opt.index_type ==
+                         BlockBasedTableOptions::kBinarySearchWithFirstKey),
+      tail_size(0),
+      status_ok(true),
+      io_status_ok(true) {
+  FilterBuildingContext filter_context(table_options);
+
+  filter_context.info_log = ioptions.logger;
+  filter_context.column_family_name = tbo.column_family_name;
+  filter_context.reason = reason;
+
+  // Only populate other fields if known to be in LSM rather than
+  // generating external SST file
+  if (reason != TableFileCreationReason::kMisc) {
+    filter_context.compaction_style = ioptions.compaction_style;
+    filter_context.num_levels = ioptions.num_levels;
+    filter_context.level_at_creation = tbo.level_at_creation;
+    filter_context.is_bottommost = tbo.is_bottommost;
+    assert(filter_context.level_at_creation < filter_context.num_levels);
+  }
+
+  // TODO: get CompressionManager from options and sort out properties
+  auto mgr = tbo.moptions.compression_manager;
+  if (mgr == nullptr) {
+    mgr = GetBuiltinCompressionManager(
+        GetCompressFormatForVersion(table_opt.format_version));
+  }
+  props.compression_name = CompressionTypeToString(tbo.compression_type);
+  props.compression_options = CompressionOptionsToString(tbo.compression_opts);
+
+  // Sanitize to only allowing compression when it saves space.
+  max_compressed_bytes_per_kb =
+      std::min(int{1023}, tbo.compression_opts.max_compressed_bytes_per_kb);
+
+  basic_compressor = mgr->GetCompressorForSST(
+      filter_context, tbo.compression_opts, tbo.compression_type);
+  if (basic_compressor) {
+    if (table_options.enable_index_compression) {
+      basic_working_area.compress = basic_compressor->ObtainWorkingArea();
+    }
+    max_dict_sample_bytes = basic_compressor->GetMaxSampleSizeIfWantDict(
+        CacheEntryRole::kDataBlock);
+    if (max_dict_sample_bytes > 0) {
+      state = State::kBuffered;
+      if (tbo.target_file_size == 0) {
+        buffer_limit = tbo.compression_opts.max_dict_buffer_bytes;
+      } else if (tbo.compression_opts.max_dict_buffer_bytes == 0) {
+        buffer_limit = tbo.target_file_size;
+      } else {
+        buffer_limit = std::min(tbo.target_file_size,
+                                tbo.compression_opts.max_dict_buffer_bytes);
+      }
+    } else {
+      // No distinct data block compressor using dictionary
+      data_block_compressor = basic_compressor.get();
+      for (uint32_t i = 0; i < compression_parallel_threads; i++) {
+        data_block_working_areas[i].compress =
+            data_block_compressor->ObtainWorkingArea();
+      }
+    }
+    basic_decompressor = mgr->GetDecompressorOptimizeFor(tbo.compression_type);
+    create_context.decompressor = basic_decompressor.get();
+
+    if (table_options.verify_compression) {
+      verify_decompressor = basic_decompressor.get();
+      if (table_options.enable_index_compression) {
+        basic_working_area.verify =
+            verify_decompressor->ObtainWorkingArea(tbo.compression_type);
+      }
+      if (state == State::kUnbuffered) {
+        for (uint32_t i = 0; i < compression_parallel_threads; i++) {
+          data_block_working_areas[i].verify =
+              verify_decompressor->ObtainWorkingArea(tbo.compression_type);
+        }
+        data_block_verify_decompressor = verify_decompressor.get();
+      }
+    }
+  }
+
+  switch (table_options.prepopulate_block_cache) {
+    case BlockBasedTableOptions::PrepopulateBlockCache::kFlushOnly:
+      warm_cache = (reason == TableFileCreationReason::kFlush);
+      break;
+    case BlockBasedTableOptions::PrepopulateBlockCache::kDisable:
+      warm_cache = false;
+      break;
+    default:
+      // missing case
+      assert(false);
+      warm_cache = false;
+  }
+
+  const auto compress_dict_build_buffer_charged =
+      table_options.cache_usage_options.options_overrides
+          .at(CacheEntryRole::kCompressionDictionaryBuildingBuffer)
+          .charged;
+  if (table_options.block_cache &&
+      (compress_dict_build_buffer_charged ==
+           CacheEntryRoleOptions::Decision::kEnabled ||
+       compress_dict_build_buffer_charged ==
+           CacheEntryRoleOptions::Decision::kFallback)) {
+    compression_dict_buffer_cache_res_mgr =
+        std::make_shared<CacheReservationManagerImpl<
+            CacheEntryRole::kCompressionDictionaryBuildingBuffer>>(
+            table_options.block_cache);
+  } else {
+    compression_dict_buffer_cache_res_mgr = nullptr;
+  }
+
+  if (table_options.index_type ==
+      BlockBasedTableOptions::kTwoLevelIndexSearch) {
+    p_index_builder_ = PartitionedIndexBuilder::CreateIndexBuilder(
+        &internal_comparator, use_delta_encoding_for_index_values,
+        table_options, ts_sz, persist_user_defined_timestamps);
+    index_builder.reset(p_index_builder_);
+  } else {
+    index_builder.reset(IndexBuilder::CreateIndexBuilder(
+        table_options.index_type, &internal_comparator,
+        &this->internal_prefix_transform, use_delta_encoding_for_index_values,
+        table_options, ts_sz, persist_user_defined_timestamps));
+  }
+  if (ioptions.optimize_filters_for_hits && tbo.is_bottommost) {
+    // Apply optimize_filters_for_hits setting here when applicable by
+    // skipping filter generation
+    filter_builder.reset();
+  } else if (tbo.skip_filters) {
+    // For SstFileWriter skip_filters
+    filter_builder.reset();
+  } else if (!table_options.filter_policy) {
+    // Null filter_policy -> no filter
+    filter_builder.reset();
+  } else {
+    filter_builder.reset(CreateFilterBlockBuilder(
+        ioptions, tbo.moptions, filter_context,
+        use_delta_encoding_for_index_values, p_index_builder_, ts_sz,
+        persist_user_defined_timestamps));
+  }
+
+  assert(tbo.internal_tbl_prop_coll_factories);
+  for (auto& factory : *tbo.internal_tbl_prop_coll_factories) {
+    assert(factory);
+
+    std::unique_ptr<InternalTblPropColl> collector{
+        factory->CreateInternalTblPropColl(
+            tbo.column_family_id, tbo.level_at_creation,
+            tbo.ioptions.num_levels,
+            tbo.last_level_inclusive_max_seqno_threshold)};
+    if (collector) {
+      table_properties_collectors.emplace_back(std::move(collector));
+    }
+  }
+  table_properties_collectors.emplace_back(
+      new BlockBasedTablePropertiesCollector(
+          table_options.index_type, table_options.whole_key_filtering,
+          prefix_extractor != nullptr,
+          table_options.decouple_partitioned_filters));
+  if (ts_sz > 0 && persist_user_defined_timestamps) {
+    table_properties_collectors.emplace_back(
+        new TimestampTablePropertiesCollector(
+            tbo.internal_comparator.user_comparator()));
+  }
+
+  // These are only needed for populating table properties
+  props.column_family_id = tbo.column_family_id;
+  props.column_family_name = tbo.column_family_name;
+  props.oldest_key_time = tbo.oldest_key_time;
+  props.newest_key_time = tbo.newest_key_time;
+  props.file_creation_time = tbo.file_creation_time;
+  props.orig_file_number = tbo.cur_file_num;
+  props.db_id = tbo.db_id;
+  props.db_session_id = tbo.db_session_id;
+  props.db_host_id = ioptions.db_host_id;
+  props.format_version = table_options.format_version;
+  if (!ReifyDbHostIdProperty(ioptions.env, &props.db_host_id).ok()) {
+    ROCKS_LOG_INFO(ioptions.logger, "db_host_id property will not be set");
+  }
+  // Default is UINT64_MAX for unknown. Setting it to 0 here
+  // to allow updating it by taking max in BlockBasedTableBuilder::Add().
+  props.key_largest_seqno = 0;
+
+  if (FormatVersionUsesContextChecksum(table_options.format_version)) {
+    // Must be non-zero and semi- or quasi-random
+    // TODO: ideally guaranteed different for related files (e.g. use file
+    // number and db_session, for benefit of SstFileWriter)
+    do {
+      base_context_checksum = Random::GetTLSInstance()->Next();
+    } while (UNLIKELY(base_context_checksum == 0));
+  } else {
+    base_context_checksum = 0;
+  }
+
+  if (alignment > 0 && basic_compressor) {
+    // With better sanitization in `CompactionPicker::CompactFiles()`, we
+    // would not need to handle this case here and could change it to an
+    // assertion instead.
+    SetStatus(
+        Status::InvalidArgument("Enable block_align, but compression enabled"));
+  }
+}
 
 BlockBasedTableBuilder::BlockBasedTableBuilder(
     const BlockBasedTableOptions& table_options, const TableBuilderOptions& tbo,


### PR DESCRIPTION
Get table/block_based/block_based_table_builder.cc to compile on c++23 on clang, by re-ordering BlockBasedTableBuilder::Rep and BlockBasedTableBuilder::ParallelCompressionRep definitions. 

Clang `--std=c++23` changed behavior of unique_ptr<> with incomplete types. Now, constructor/destructures involving types with unique_ptr fields, must have access to the complete type; and thus must be defined after all its dependencies: See [godbolt link for behavior](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGe1wAyeAyYAHI%2BAEaYxBIAbKQADqgKhE4MHt6%2BekkpjgJBIeEsUTFc8XaYDmlCBEzEBBk%2Bfly2mPZ5DDV1BAVhkdFxtrX1jVktCsM9wX3FA2UAlLaoXsTI7BzmAMzByN5YANQmm25sLCQAnkfYJhoAgje3u0wKCvsAkgxoLAn0BJhHVjuDyeL32t0OAHZAbcAPQw/YI24QCboEAgLwMPAARy8mAA%2BgkCMQjm4Pl8fpg/ld9kx5gCHojkQRUejMTj8YTiccyahvr9/ptsDT5iAaXimSyzgA3TAQWnzSFWCEAEQZ%2BxRaIx2NxBKJJJ5fMpAqFTDx9KBKvN9zuINeBopf0VJktm2hDzh%2BwxXzYgn2RH25LomH2wQD1msZk2%2BzlDHQ%2B2ImGlwYICGDwVo0zjaAYE2IXgcJH2WBomI6dLuHtuaKRGtZ2o5eu5n15DuNwv2otNErRSbl8wVzqVqqBd2CBH2LCYwQgA6haoRCYIKwY%2Bw0Vudyo4i1onAArLw/BwtKRUJw3OHLOrlqtg1seKQCJot4sANYgMy7/ScSQHp8nzi8AoIAaA%2BT6LHAsBIJgqiVF4RBkBQcrEMACjKIYbRCAgqAAO6HvegYGB0aEhLQmE4Yex4EQMTxGFwAAcXAgVRxChKw6y8MxADycFkbhf7QZUtzIUBHC8AJyA1Pgh68PwggiGI7BSDIgiKCo6hHjoegGEYKAXjYGYREBkCLKghJpCJAC0FkokcyqmJYEabLwqAysQxB4FgRkzqQeaCHgbAACqoJ4XmLAo15rHoKLBMRGFYXx3C8NhxBMAknA8Nue6/hp/4cNgMHIHBhaqHRsQWbEkgBtpwD7PRAB0XB1Ro0bng5likPsuCEIWd7zLwj4af2pBvh%2BX4cD%2BpAUc5AG2MBoGDaQEGICA4lFQhlB1ChsWkfFeEcS2dBMER6E7eRf7MSg1X0YxpDMaxbAzVxPG7fxBVCShM3iZJwQzbJwiiOISl/apah/roZj6IYxh6foeCGfAJlmQIlnWcytn2VYlhmMeLnRO5nkIz5GKOIFwW0KFSwrJF4zMjFJ28XtpDJal6VbmN%2B6TX%2Bp55QVa37CVZUVVVUO1XRDVNS1MOdfg8GHJGXB9fNWhDSNkh1QAnJrWva9r8Q7uN2U4zNQEgQNyuLTAy2rfB5AbcJ20M6zt0HYRaQOy9OUXcAXC7i0d1sY9LvRNxwge8e4nvSJYkFd90nKf9CkSNIwNKKDOW6JskM6Rj1iw/DxknkjOacFZNmbHZemRs5rn45gFO%2BSTmBBSFhPhVTilDFJ7tnYlTMpWliWZRwHNTbl%2BWwbLAvlZVwDIMgtW7g1kttTY0vdcQcubAr/Vga%2B76fvrE2j9zgFzWbz5jWYhvTaJSsX65KTOJIQA%3D%3D%3D).

Interestingly, `gcc --std=c++23` accepts the code as-is.

Fixes https://github.com/facebook/rocksdb/issues/13574