### PR TITLE
Fix overflow of data_size in WritableFileWriter::WriteBufferedWithChecksum

### DIFF
--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -687,7 +687,7 @@ IOStatus WritableFileWriter::WriteBufferedWithChecksum(const IOOptions& opts,
   if (rate_limiter_ != nullptr && rate_limiter_priority_used != Env::IO_TOTAL) {
     while (data_size > 0) {
       size_t tmp_size;
-      tmp_size = rate_limiter_->RequestToken(data_size, buf_.Alignment(),
+      tmp_size = rate_limiter_->RequestToken(data_size, 0,
                                              rate_limiter_priority_used, stats_,
                                              RateLimiter::OpType::kWrite);
       data_size -= tmp_size;


### PR DESCRIPTION
In the function WritableFileWriter::WriteBufferedWithChecksum, since the alignment parameter passed to RequestToken defaults to 4096, when data_size is less than 4096, subtracting a larger value from data_size (which is of type unsigned long) will cause an underflow. This results in an infinite loop. Since WriteBuffered does not require alignment, it is sufficient to pass alignment == 0.

issue:#13640