### PR TITLE
Improve internal lossless_cast to work on pointers

### DIFF
--- a/util/coding.h
+++ b/util/coding.h
@@ -21,6 +21,7 @@
 
 #include "port/port.h"
 #include "rocksdb/slice.h"
+#include "util/cast_util.h"
 #include "util/coding_lean.h"
 
 // Some processors does not allow unaligned access to memory
@@ -105,7 +106,7 @@ const char* GetVarint32PtrFallback(const char* p, const char* limit,
 inline const char* GetVarint32Ptr(const char* p, const char* limit,
                                   uint32_t* value) {
   if (p < limit) {
-    uint32_t result = *(reinterpret_cast<const unsigned char*>(p));
+    uint32_t result = *(lossless_cast<const unsigned char*>(p));
     if ((result & 128) == 0) {
       *value = result;
       return p + 1;
@@ -172,13 +173,13 @@ inline void PutVarint32Varint32Varint32(std::string* dst, uint32_t v1,
 
 inline char* EncodeVarint64(char* dst, uint64_t v) {
   static const unsigned int B = 128;
-  unsigned char* ptr = reinterpret_cast<unsigned char*>(dst);
+  unsigned char* ptr = lossless_cast<unsigned char*>(dst);
   while (v >= B) {
     *(ptr++) = (v & (B - 1)) | B;
     v >>= 7;
   }
   *(ptr++) = static_cast<unsigned char>(v);
-  return reinterpret_cast<char*>(ptr);
+  return lossless_cast<char*>(ptr);
 }
 
 inline void PutVarint64(std::string* dst, uint64_t v) {


### PR DESCRIPTION
Summary: I was going to use this in some code I was working on but ended up not needing it. But it's useful nonetheless and I'm using it in a few places to replace reinterpret_cast.

Test Plan: existing tests, manually see compilation fail when pointed-to types are not same size integral types