### PR TITLE
include cstdint to trace_record.h

### DIFF
--- a/include/rocksdb/trace_record.h
+++ b/include/rocksdb/trace_record.h
@@ -8,7 +8,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-
+#include <cstdint>
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"


### PR DESCRIPTION
There are compilation errors on gcc 15 in fedora 42 while compiling ceph.

This is similar to PR #13573.