### PR TITLE
Allow SmallEnumSet on larger enum types

### DIFF
--- a/include/rocksdb/data_structure.h
+++ b/include/rocksdb/data_structure.h
@@ -7,9 +7,9 @@
 
 #include <assert.h>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
-#include <vector>
 
 #include "rocksdb/rocksdb_namespace.h"
 
@@ -17,24 +17,33 @@ namespace ROCKSDB_NAMESPACE {
 
 namespace detail {
 int CountTrailingZeroBitsForSmallEnumSet(uint64_t);
+int BitsSetToOneForSmallEnumSet(uint64_t);
 }  // namespace detail
 
-// Represents a set of values of some enum type with a small number of
-// possible enumerators. For now, it supports enums where no enumerator
-// exceeds 63 when converted to int.
+// Represents a set of values of some enum type with a small number of possible
+// enumerators. Assumes that any combination of enumerators with values 0
+// through MAX_ENUMERATOR (inclusive) might be part of the set. NOTE: would like
+// to use std::bitset, but it doesn't support constexpr (in C++17) operations
+// and doesn't support efficient iteration over sparse "set to true" entries.
 template <typename ENUM_TYPE, ENUM_TYPE MAX_ENUMERATOR>
 class SmallEnumSet {
  private:
-  using StateT = uint64_t;
-  static constexpr int kStateBits = sizeof(StateT) * 8;
-  static constexpr int kMaxMax = kStateBits - 1;
   static constexpr int kMaxValue = static_cast<int>(MAX_ENUMERATOR);
   static_assert(kMaxValue >= 0);
-  static_assert(kMaxValue <= kMaxMax);
+  static_assert(kMaxValue < 1024, "MAX_ENUMERATOR is suspiciously large");
+  using PieceT = uint64_t;
+  static constexpr int kPieceBits = 64;
+  static constexpr int kPieceMask = 63;
+  static constexpr int kPieceShift = 6;
+  static constexpr int kPieceCount = kMaxValue / kPieceBits + 1;
+  using StateT = std::array<PieceT, kPieceCount>;
+  static constexpr int kStateBits = kPieceBits * kPieceCount;
+  static_assert(kStateBits == sizeof(StateT) * 8);
+  static_assert(kMaxValue <= kStateBits - 1);
 
  public:
-  // construct / create
-  SmallEnumSet() : state_(0) {}
+  // construct / create empty set
+  SmallEnumSet() : state_{} {}
 
   template <class... TRest>
   /*implicit*/ constexpr SmallEnumSet(const ENUM_TYPE e, TRest... rest) {
@@ -44,8 +53,16 @@ class SmallEnumSet {
   // Return the set that includes all valid values, assuming the enum
   // is "dense" (includes all values converting to 0 through kMaxValue)
   static constexpr SmallEnumSet All() {
-    StateT tmp = StateT{1} << kMaxValue;
-    return SmallEnumSet(RawStateMarker(), tmp | (tmp - 1));
+    StateT tmp;
+    for (int i = 0; i < kPieceCount - 1; ++i) {
+      tmp[i] = ~PieceT{0};
+    }
+    if constexpr ((kMaxValue + 1) & kPieceMask) {
+      tmp[kPieceCount - 1] = (PieceT{1} << ((kMaxValue + 1) & kPieceMask)) - 1;
+    } else {
+      tmp[kPieceCount - 1] = ~PieceT{0};
+    }
+    return SmallEnumSet(RawStateMarker(), tmp);
   }
 
   // equality
@@ -60,11 +77,17 @@ class SmallEnumSet {
   bool Contains(const ENUM_TYPE e) const {
     int value = static_cast<int>(e);
     assert(value >= 0 && value <= kMaxValue);
-    StateT tmp = 1;
-    return state_ & (tmp << value);
+    return GetPiece(value) & (PieceT{1} << (value & kPieceMask));
   }
 
-  bool empty() const { return state_ == 0; }
+  bool empty() const {
+    for (int i = 0; i < kPieceCount; ++i) {
+      if (state_[i] != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   // iterator
   class const_iterator {
@@ -92,7 +115,7 @@ class SmallEnumSet {
       if (pos_ < kMaxValue) {
         pos_ = set_->SkipUnset(pos_ + 1);
       } else {
-        pos_ = kStateBits;
+        pos_ = kMaxValue + 1;
       }
       return *this;
     }
@@ -118,7 +141,15 @@ class SmallEnumSet {
 
   const_iterator begin() const { return const_iterator(this, SkipUnset(0)); }
 
-  const_iterator end() const { return const_iterator(this, kStateBits); }
+  const_iterator end() const { return const_iterator(this, kMaxValue + 1); }
+
+  size_t count() const {
+    size_t rv = 0;
+    for (int i = 0; i < kPieceCount; ++i) {
+      rv += static_cast<size_t>(detail::BitsSetToOneForSmallEnumSet(state_[i]));
+    }
+    return rv;
+  }
 
   // mutable ops
 
@@ -127,9 +158,10 @@ class SmallEnumSet {
   bool Add(const ENUM_TYPE e) {
     int value = static_cast<int>(e);
     assert(value >= 0 && value <= kMaxValue);
-    StateT old_state = state_;
-    state_ |= (StateT{1} << value);
-    return old_state != state_;
+    PieceT& piece_ref = RefPiece(value);
+    PieceT old_piece = piece_ref;
+    piece_ref |= (PieceT{1} << (value & kPieceMask));
+    return old_piece != piece_ref;
   }
 
   // Modifies the set (if needed) not to include the given value. Returns true
@@ -137,9 +169,10 @@ class SmallEnumSet {
   bool Remove(const ENUM_TYPE e) {
     int value = static_cast<int>(e);
     assert(value >= 0 && value <= kMaxValue);
-    StateT old_state = state_;
-    state_ &= ~(StateT{1} << value);
-    return old_state != state_;
+    PieceT& piece_ref = RefPiece(value);
+    PieceT old_piece = piece_ref;
+    piece_ref &= ~(PieceT{1} << (value & kPieceMask));
+    return old_piece != piece_ref;
   }
 
   // applicative ops
@@ -148,7 +181,9 @@ class SmallEnumSet {
   constexpr SmallEnumSet With(const ENUM_TYPE e) const {
     int value = static_cast<int>(e);
     assert(value >= 0 && value <= kMaxValue);
-    return SmallEnumSet(RawStateMarker(), state_ | (StateT{1} << value));
+    SmallEnumSet rv(*this);
+    rv.Add(e);
+    return rv;
   }
   template <class... TRest>
   constexpr SmallEnumSet With(const ENUM_TYPE e1, const ENUM_TYPE e2,
@@ -160,7 +195,9 @@ class SmallEnumSet {
   constexpr SmallEnumSet Without(const ENUM_TYPE e) const {
     int value = static_cast<int>(e);
     assert(value >= 0 && value <= kMaxValue);
-    return SmallEnumSet(RawStateMarker(), state_ & ~(StateT{1} << value));
+    SmallEnumSet rv(*this);
+    rv.Remove(e);
+    return rv;
   }
   template <class... TRest>
   constexpr SmallEnumSet Without(const ENUM_TYPE e1, const ENUM_TYPE e2,
@@ -170,15 +207,31 @@ class SmallEnumSet {
 
  private:
   int SkipUnset(int pos) const {
-    StateT tmp = state_ >> pos;
-    if (tmp == 0) {
-      return kStateBits;
-    } else {
-      return pos + detail::CountTrailingZeroBitsForSmallEnumSet(tmp);
+    while (pos <= kMaxValue) {
+      PieceT remainder = GetPiece(pos) >> (pos & kPieceMask);
+      if (remainder != 0) {
+        return pos + detail::CountTrailingZeroBitsForSmallEnumSet(remainder);
+      }
+      pos = (pos + kPieceBits) & ~kPieceMask;
     }
+    return kMaxValue + 1;
   }
   struct RawStateMarker {};
   explicit SmallEnumSet(RawStateMarker, StateT state) : state_(state) {}
+  PieceT GetPiece(int pos) const {
+    if constexpr (kPieceCount == 1) {
+      return state_[0];
+    } else {
+      return state_[pos >> kPieceShift];
+    }
+  }
+  PieceT& RefPiece(int pos) {
+    if constexpr (kPieceCount == 1) {
+      return state_[0];
+    } else {
+      return state_[pos >> kPieceShift];
+    }
+  }
 
   StateT state_;
 };

--- a/include/rocksdb/data_structure.h
+++ b/include/rocksdb/data_structure.h
@@ -57,7 +57,7 @@ class SmallEnumSet {
     for (int i = 0; i < kPieceCount - 1; ++i) {
       tmp[i] = ~PieceT{0};
     }
-    if constexpr ((kMaxValue + 1) & kPieceMask) {
+    if constexpr (((kMaxValue + 1) & kPieceMask) != 0) {
       tmp[kPieceCount - 1] = (PieceT{1} << ((kMaxValue + 1) & kPieceMask)) - 1;
     } else {
       tmp[kPieceCount - 1] = ~PieceT{0};

--- a/include/rocksdb/data_structure.h
+++ b/include/rocksdb/data_structure.h
@@ -179,8 +179,7 @@ class SmallEnumSet {
 
   // Return a new set based on this one with the additional value(s) inserted
   constexpr SmallEnumSet With(const ENUM_TYPE e) const {
-    int value = static_cast<int>(e);
-    assert(value >= 0 && value <= kMaxValue);
+    assert(static_cast<int>(e) >= 0 && static_cast<int>(e) <= kMaxValue);
     SmallEnumSet rv(*this);
     rv.Add(e);
     return rv;
@@ -193,8 +192,7 @@ class SmallEnumSet {
 
   // Return a new set based on this one excluding the given value(s)
   constexpr SmallEnumSet Without(const ENUM_TYPE e) const {
-    int value = static_cast<int>(e);
-    assert(value >= 0 && value <= kMaxValue);
+    assert(static_cast<int>(e) >= 0 && static_cast<int>(e) <= kMaxValue);
     SmallEnumSet rv(*this);
     rv.Remove(e);
     return rv;

--- a/util/data_structure.cc
+++ b/util/data_structure.cc
@@ -13,4 +13,6 @@ int CountTrailingZeroBitsForSmallEnumSet(uint64_t v) {
   return CountTrailingZeroBits(v);
 }
 
+int BitsSetToOneForSmallEnumSet(uint64_t v) { return BitsSetToOne(v); }
+
 }  // namespace ROCKSDB_NAMESPACE::detail


### PR DESCRIPTION
Summary: ... to support SmallEnumSet over CompressionType with allowed custom compression types using most of the available byte. This is accomplished using an std::array<uint64_t> in place of just uint64_t. Also adds an std::bitset-like count() operation.

Test Plan: unit tests included