### PR TITLE
Fix iterator errors for CFs with disallow_memtable_writes

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -244,9 +244,6 @@ ColumnFamilyOptions SanitizeCfOptions(const ImmutableDBOptions& db_options,
   if (result.disallow_memtable_writes) {
     // A simple memtable that enforces MarkReadOnly (unlike skip list)
     result.memtable_factory = std::make_shared<VectorRepFactory>();
-    // Memtable will be empty, so should be safe to silently ignore
-    // paranoid_memory_checks
-    result.paranoid_memory_checks = false;
   }
 
   if (result.num_levels < 1) {

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -244,6 +244,9 @@ ColumnFamilyOptions SanitizeCfOptions(const ImmutableDBOptions& db_options,
   if (result.disallow_memtable_writes) {
     // A simple memtable that enforces MarkReadOnly (unlike skip list)
     result.memtable_factory = std::make_shared<VectorRepFactory>();
+    // Memtable will be empty, so should be safe to silently ignore
+    // paranoid_memory_checks
+    result.paranoid_memory_checks = false;
   }
 
   if (result.num_levels < 1) {

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -5086,6 +5086,7 @@ TEST_F(DBBasicTest, DisallowMemtableWrite) {
   options_allow.create_if_missing = true;
   Options options_disallow = options_allow;
   options_disallow.disallow_memtable_writes = true;
+  options_disallow.paranoid_memory_checks = true;
 
   DestroyAndReopen(options_allow);
   // CFs allowing and disallowing memtable write
@@ -5125,6 +5126,11 @@ TEST_F(DBBasicTest, DisallowMemtableWrite) {
   EXPECT_EQ(Get(2, "b2"), "2");
   EXPECT_EQ(Get(3, "b3"), "NOT_FOUND");
 
+  std::unique_ptr<Iterator> iter(
+      dbfull()->NewIterator(ReadOptions(), handles_[3]));
+  iter->Seek("a3");
+  ASSERT_OK(iter->status());
+  iter.reset();
   // When the DB is re-opened with WAL entries for a CF that is newly setting
   // disallow_memtable_writes, we detect that and fail the open gracefully.
   ASSERT_EQ(TryReopenWithColumnFamilies(

--- a/unreleased_history/bug_fixes/disallow_memtable_writes_paranoid_checks.md
+++ b/unreleased_history/bug_fixes/disallow_memtable_writes_paranoid_checks.md
@@ -1,0 +1,1 @@
+Fix iterator operations returning NotImplemented status if disallow_memtable_writes CF option is set.

--- a/unreleased_history/bug_fixes/disallow_memtable_writes_paranoid_checks.md
+++ b/unreleased_history/bug_fixes/disallow_memtable_writes_paranoid_checks.md
@@ -1,1 +1,1 @@
-Fix iterator operations returning NotImplemented status if disallow_memtable_writes CF option is set.
+Fix iterator operations returning NotImplemented status if disallow_memtable_writes and paranoid_memory_checks CF options are both set.


### PR DESCRIPTION
Iterator seek returns "SeekAndValidate() not implemented" error if the disallow_memtable_writes CF option is set along with paranoid_memory_checks. This is because we sanitize the memtable_factory to VectorRepFactory if the disallow_memtable_options is set. The fix is to implement SeekAndValidate() in VectorRep that returns ok status if the memtable is immutable and empty.

Test plan:
Update unit test in db_basic_test.cc