### PR TITLE
Add cost info field to IODebugContext

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 
+#include <any>
 #include <chrono>
 #include <cstdarg>
 #include <functional>
@@ -249,6 +250,9 @@ struct IODebugContext {
     kRequestID = 0,
   };
   uint64_t trace_data = 0;
+
+  // Arbitrary structure containing cost information about the IO request
+  std::any cost_info;
 
   IODebugContext() {}
 


### PR DESCRIPTION
This field will be used internally to feed Warm Storage cost information back through the Sally IO stack.