### PR TITLE
Simplify RoundRobinSubcompactionsAgainstResources.SubcompactionsUsingResources test

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -839,8 +839,7 @@ Status CompactionJob::Run() {
   }
 
   ReleaseSubcompactionResources();
-  TEST_SYNC_POINT("CompactionJob::ReleaseSubcompactionResources:0");
-  TEST_SYNC_POINT("CompactionJob::ReleaseSubcompactionResources:1");
+  TEST_SYNC_POINT("CompactionJob::ReleaseSubcompactionResources");
 
   for (const auto& state : compact_->sub_compact_states) {
     for (const auto& output : state.GetOutputs()) {


### PR DESCRIPTION
**Context/Summary:**
`RoundRobinSubcompactionsAgainstResources.SubcompactionsUsingResources` has been flaky and difficult to de-flake. One of the reasons is the complicated usage of sync points and unnecessarily strict verification. 
- The sync points don't seem necessary to verify the number reserved threads for sub-compactions so are removed.
- The full reservation after compaction to verify extra reserved threads were release is indirect and hard to get right. So it's replaced with simpler sync-point callback check. 
    - Since we already have tests (see https://github.com/facebook/rocksdb/blob/7d80ea45442e84c25669db61cb7376ba0cd10ba5/env/env_test.cc#L841) for testing pure functionality of reserve/release does reserve/release the threads, verifying the relevant code paths are called should be enough to verify extra reserved threads were released after compaction


**Test plan:**
Monitor future flakiness
