### PR TITLE
Support GetFileSize API in FSRandomAccessFile

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1056,6 +1056,11 @@ IOStatus PosixMmapReadableFile::InvalidateCache(size_t offset, size_t length) {
 #endif
 }
 
+IOStatus PosixMmapReadableFile::GetFileSize(uint64_t* result) {
+  *result = length_;
+  return IOStatus::OK();
+}
+
 /*
  * PosixMmapFile
  *

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -437,6 +437,7 @@ class PosixMmapReadableFile : public FSRandomAccessFile {
                 char* scratch, IODebugContext* dbg) const override;
   void Hint(AccessPattern pattern) override;
   IOStatus InvalidateCache(size_t offset, size_t length) override;
+  virtual IOStatus GetFileSize(uint64_t* result) override;
 };
 
 class PosixMmapFile : public FSWritableFile {

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -909,6 +909,13 @@ class FSRandomAccessFile {
     return IOStatus::NotSupported("Prefetch");
   }
 
+  // Get the file size. The default implementation is not supported, as some of
+  // the file systems are not defined in this repo. Sub classes which use this
+  // function are suppose to override it.
+  virtual IOStatus GetFileSize(uint64_t* /*result*/) {
+    return IOStatus::NotSupported("GetFileSize");
+  }
+
   // Read a bunch of blocks as described by reqs. The blocks can
   // optionally be read in parallel. This is a synchronous call, i.e it
   // should return after all reads have completed. The reads will be


### PR DESCRIPTION
Summary:

This change is used to address this issue
https://github.com/facebook/rocksdb/issues/13619
It supports GetFileSize API in FSRandomAccessFile. This allows ReadFooterFromFile to quickly get the file size for file size validation.

Test Plan:
make check

Reviewers:
Peter Dillinger

Subscribers:

Tasks:

Tags: