### PR TITLE
Fix missing include

### DIFF
--- a/db/blob/blob_file_meta.h
+++ b/db/blob/blob_file_meta.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cassert>
 #include <cstdint>
 #include <iosfwd>


### PR DESCRIPTION
`uint64_t` is used at line 30, but `<cstdint>` was not included.

Fails the build with GCC 15 on Arm when building like so:

```
  ROCKSDB_DISABLE_NUMA=1 \
  ROCKSDB_DISABLE_ZLIB=1 \
  ROCKSDB_DISABLE_BZIP=1 \
  ROCKSDB_DISABLE_GFLAGS=1 \
  CFLAGS="-isystem $(pwd)/../../include -g0 -DSNAPPY -DZSTD -Wno-unknown-warning-option -Wno-uninitialized -Wno-array-bounds -Wno-stringop-overread -fPIC" \
  make -j $NJOBS \
    LITE=1 \
    V=1 \
    static_lib
  make install-static DESTDIR="$PREFIX"/ PREFIX= LIBDIR=lib
```