### PR TITLE
MemTableList::Add: `MarkImmutable()` before `current_->Add()`

### DIFF
--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -672,8 +672,8 @@ void MemTableList::Add(ReadOnlyMemTable* m,
   // and when moving to the immutable list we don't unref it,
   // we don't have to ref the memtable here. we just take over the
   // reference from the DBImpl.
-  current_->Add(m, to_delete);
   m->MarkImmutable();
+  current_->Add(m, to_delete);
   num_flush_not_started_++;
   if (num_flush_not_started_ == 1) {
     imm_flush_needed.store(true, std::memory_order_release);


### PR DESCRIPTION
The semantic of MemTableList::Add is add the immutable memtable, so current_->Add() should be called after MarkImmutable().

MemTable.MarkImmutable() calls MemTableRep.MarkReadOnly(), which may update memory usage which reported by ApproximateMemoryUsage, thus causing assert fail in MemTableListVersion::UnrefMemTable().

This issue was not reproduced is because rocksdb builtin MemTableRep does not update ApproximateMemoryUsage in MarkImmutable, but our custom MemTableRep does, yield the fails.