### PR TITLE
[Remote Compaction] Add MergeOperator UnitTest for Remote Compaction

### DIFF
--- a/db/compaction/compaction_service_test.cc
+++ b/db/compaction/compaction_service_test.cc
@@ -1230,7 +1230,8 @@ TEST_F(CompactionServiceTest, MergeOperator) {
   GenerateTestData();
   ASSERT_OK(dbfull()->TEST_WaitForCompact());
   for (int i = 0; i < 200; i++) {
-    db_->Merge(WriteOptions(), Key(i), "merge_op_append_" + std::to_string(i));
+    ASSERT_OK(db_->Merge(WriteOptions(), Key(i),
+                         "merge_op_append_" + std::to_string(i)));
   }
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   // verify result


### PR DESCRIPTION
# Summary
As title. Simple Unit Test to check MergeOperator in Remote Compaction flow.

# Test Plan
```
./compaction_service_test --gtest_filter="*CompactionServiceTest.MergeOperator*"
```