### PR TITLE
Upgrade Maven to 3.9.10

### DIFF
--- a/.github/actions/install-maven/action.yml
+++ b/.github/actions/install-maven/action.yml
@@ -4,8 +4,8 @@ runs:
   steps:
   - name: Install Maven
     run: |
-      wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz
-      tar zxf apache-maven-3.9.6-bin.tar.gz
-      echo "export M2_HOME=$(pwd)/apache-maven-3.9.6" >> $GITHUB_ENV
-      echo "$(pwd)/apache-maven-3.9.6/bin" >> $GITHUB_PATH
+      wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz
+      tar zxf apache-maven-3.9.10-bin.tar.gz
+      echo "export M2_HOME=$(pwd)/apache-maven-3.9.10" >> $GITHUB_ENV
+      echo "$(pwd)/apache-maven-3.9.10/bin" >> $GITHUB_PATH
     shell: bash


### PR DESCRIPTION
# Summary

https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz is no longer available. Because of that, CI for JAVA has been broken. 

https://github.com/facebook/rocksdb/actions/runs/15596243797/job/43927189803?pr=13683

Instead of finding a new place to download from, taking this opportunity to upgrade to 3.9.10.

# Test Plan

CI