### PR TITLE
Rename max_file_num_to_ignore to min_file_num_to_ignore (#13692)

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1305,12 +1305,12 @@ Compaction* ColumnFamilyData::CompactRange(
     int output_level, const CompactRangeOptions& compact_range_options,
     const InternalKey* begin, const InternalKey* end,
     InternalKey** compaction_end, bool* conflict,
-    uint64_t max_file_num_to_ignore, const std::string& trim_ts) {
+    uint64_t min_file_num_to_ignore, const std::string& trim_ts) {
   auto* result = compaction_picker_->CompactRange(
       GetName(), mutable_cf_options, mutable_db_options,
       current_->storage_info(), input_level, output_level,
       compact_range_options, begin, end, compaction_end, conflict,
-      max_file_num_to_ignore, trim_ts);
+      min_file_num_to_ignore, trim_ts);
   if (result != nullptr) {
     result->FinalizeInputInfo(current_);
   }

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -456,7 +456,7 @@ class ColumnFamilyData {
                            const CompactRangeOptions& compact_range_options,
                            const InternalKey* begin, const InternalKey* end,
                            InternalKey** compaction_end, bool* manual_conflict,
-                           uint64_t max_file_num_to_ignore,
+                           uint64_t min_file_num_to_ignore,
                            const std::string& trim_ts);
 
   CompactionPicker* compaction_picker() { return compaction_picker_.get(); }

--- a/db/compaction/compaction_picker.h
+++ b/db/compaction/compaction_picker.h
@@ -82,7 +82,7 @@ class CompactionPicker {
       const CompactRangeOptions& compact_range_options,
       const InternalKey* begin, const InternalKey* end,
       InternalKey** compaction_end, bool* manual_conflict,
-      uint64_t max_file_num_to_ignore, const std::string& trim_ts);
+      uint64_t min_file_num_to_ignore, const std::string& trim_ts);
 
   // The maximum allowed output level.  Default value is NumberLevels() - 1.
   virtual int MaxOutputLevel() const { return NumberLevels() - 1; }
@@ -288,7 +288,7 @@ class NullCompactionPicker : public CompactionPicker {
                            const InternalKey* /*end*/,
                            InternalKey** /*compaction_end*/,
                            bool* /*manual_conflict*/,
-                           uint64_t /*max_file_num_to_ignore*/,
+                           uint64_t /*min_file_num_to_ignore*/,
                            const std::string& /*trim_ts*/) override {
     return nullptr;
   }

--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -453,7 +453,7 @@ Compaction* FIFOCompactionPicker::CompactRange(
     const CompactRangeOptions& /*compact_range_options*/,
     const InternalKey* /*begin*/, const InternalKey* /*end*/,
     InternalKey** compaction_end, bool* /*manual_conflict*/,
-    uint64_t /*max_file_num_to_ignore*/, const std::string& /*trim_ts*/) {
+    uint64_t /*min_file_num_to_ignore*/, const std::string& /*trim_ts*/) {
 #ifdef NDEBUG
   (void)input_level;
   (void)output_level;

--- a/db/compaction/compaction_picker_fifo.h
+++ b/db/compaction/compaction_picker_fifo.h
@@ -34,7 +34,7 @@ class FIFOCompactionPicker : public CompactionPicker {
                            const CompactRangeOptions& compact_range_options,
                            const InternalKey* begin, const InternalKey* end,
                            InternalKey** compaction_end, bool* manual_conflict,
-                           uint64_t max_file_num_to_ignore,
+                           uint64_t min_file_num_to_ignore,
                            const std::string& trim_ts) override;
 
   // The maximum allowed output level.  Always returns 0.

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -808,8 +808,8 @@ class DBImpl : public DB {
   // match to our in-memory records
   virtual Status CheckConsistency();
 
-  // max_file_num_to_ignore allows bottom level compaction to filter out newly
-  // compacted SST files. Setting max_file_num_to_ignore to kMaxUint64 will
+  // min_file_num_to_ignore allows bottom level compaction to filter out newly
+  // compacted SST files. Setting min_file_num_to_ignore to kMaxUint64 will
   // disable the filtering
   // If `final_output_level` is not nullptr, it is set to manual compaction's
   // output level if returned status is OK, and it may or may not be set to
@@ -819,7 +819,7 @@ class DBImpl : public DB {
                              const CompactRangeOptions& compact_range_options,
                              const Slice* begin, const Slice* end,
                              bool exclusive, bool disallow_trivial_move,
-                             uint64_t max_file_num_to_ignore,
+                             uint64_t min_file_num_to_ignore,
                              const std::string& trim_ts,
                              int* final_output_level = nullptr);
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1218,7 +1218,7 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
         s = RunManualCompaction(
             cfd, first_overlapped_level, first_overlapped_level, options, begin,
             end, exclusive, true /* disallow_trivial_move */,
-            std::numeric_limits<uint64_t>::max() /* max_file_num_to_ignore */,
+            std::numeric_limits<uint64_t>::max() /* min_file_num_to_ignore */,
             trim_ts);
         final_output_level = first_overlapped_level;
       } else {
@@ -1260,12 +1260,12 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
               level == 0) {
             output_level = ColumnFamilyData::kCompactToBaseLevel;
           }
-          // Use max value for `max_file_num_to_ignore` to always compact
+          // Use max value for `min_file_num_to_ignore` to always compact
           // files down.
           s = RunManualCompaction(
               cfd, level, output_level, options, begin, end, exclusive,
               !trim_ts.empty() /* disallow_trivial_move */,
-              std::numeric_limits<uint64_t>::max() /* max_file_num_to_ignore */,
+              std::numeric_limits<uint64_t>::max() /* min_file_num_to_ignore */,
               trim_ts,
               output_level == ColumnFamilyData::kCompactToBaseLevel
                   ? &base_level
@@ -1294,13 +1294,13 @@ Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,
                   BottommostLevelCompaction::kForceOptimized ||
               options.bottommost_level_compaction ==
                   BottommostLevelCompaction::kForce) {
-            // Use `next_file_number` as `max_file_num_to_ignore` to avoid
+            // Use `next_file_number` as `min_file_num_to_ignore` to avoid
             // rewriting newly compacted files when it is kForceOptimized
             // or kIfHaveCompactionFilter with compaction filter set.
             s = RunManualCompaction(
                 cfd, final_output_level, final_output_level, options, begin,
                 end, exclusive, true /* disallow_trivial_move */,
-                next_file_number /* max_file_num_to_ignore */, trim_ts);
+                next_file_number /* min_file_num_to_ignore */, trim_ts);
           }
         }
       }
@@ -2006,7 +2006,7 @@ Status DBImpl::RunManualCompaction(
     ColumnFamilyData* cfd, int input_level, int output_level,
     const CompactRangeOptions& compact_range_options, const Slice* begin,
     const Slice* end, bool exclusive, bool disallow_trivial_move,
-    uint64_t max_file_num_to_ignore, const std::string& trim_ts,
+    uint64_t min_file_num_to_ignore, const std::string& trim_ts,
     int* final_output_level) {
   assert(input_level == ColumnFamilyData::kCompactAllLevels ||
          input_level >= 0);
@@ -2118,7 +2118,7 @@ Status DBImpl::RunManualCompaction(
                manual.cfd->GetLatestMutableCFOptions(), mutable_db_options_,
                manual.input_level, manual.output_level, compact_range_options,
                manual.begin, manual.end, &manual.manual_end, &manual_conflict,
-               max_file_num_to_ignore, trim_ts)) == nullptr &&
+               min_file_num_to_ignore, trim_ts)) == nullptr &&
           manual_conflict))) {
       if (!manual.done) {
         bg_cv_.Wait();

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -111,7 +111,7 @@ Status DBImpl::TEST_CompactRange(int level, const Slice* begin,
   return RunManualCompaction(
       cfd, level, output_level, CompactRangeOptions(), begin, end, true,
       disallow_trivial_move,
-      std::numeric_limits<uint64_t>::max() /*max_file_num_to_ignore*/,
+      std::numeric_limits<uint64_t>::max() /*min_file_num_to_ignore*/,
       "" /*trim_ts*/);
 }
 


### PR DESCRIPTION
## Summary
Rename max_file_num_to_ignore for compaction parameters to min_file_num_to_ignore. For reasoning see #13692 

## Verification
### Unit Test
```
```