### PR TITLE
Add NewExternalTableFactoryAsUniquePtr API

### DIFF
--- a/include/rocksdb/external_table.h
+++ b/include/rocksdb/external_table.h
@@ -272,4 +272,8 @@ class ExternalTableFactory : public Customizable {
 std::shared_ptr<TableFactory> NewExternalTableFactory(
     std::shared_ptr<ExternalTableFactory> inner_factory);
 
+// A unique_ptr version of the above
+std::unique_ptr<TableFactory> NewExternalTableFactoryAsUniquePtr(
+    std::shared_ptr<ExternalTableFactory> inner_factory);
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -480,4 +480,11 @@ std::shared_ptr<TableFactory> NewExternalTableFactory(
   return res;
 }
 
+std::unique_ptr<TableFactory> NewExternalTableFactoryAsUniquePtr(
+    std::shared_ptr<ExternalTableFactory> inner_factory) {
+  std::unique_ptr<TableFactory> res;
+  res = std::make_unique<ExternalTableFactoryAdapter>(std::move(inner_factory));
+  return res;
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -7004,7 +7004,8 @@ TEST_F(ExternalTableTest, SstReaderTest) {
   std::shared_ptr<ExternalTableFactory> factory =
       std::make_shared<DummyExternalTableFactory>(
           /*support_property_block=*/false);
-  options.table_factory = NewExternalTableFactory(factory);
+  options.table_factory.reset(
+      NewExternalTableFactoryAsUniquePtr(factory).release());
 
   std::unique_ptr<SstFileWriter> writer;
   writer.reset(new SstFileWriter(EnvOptions(), options));

--- a/unreleased_history/public_api_changes/external_table_unique_ptr.md
+++ b/unreleased_history/public_api_changes/external_table_unique_ptr.md
@@ -1,0 +1,1 @@
+Add the NewExternalTableFactoryAsUniquePtr() API to return a std::unique_ptr


### PR DESCRIPTION
The Object registry requires object to be allocated as std::unique_ptr. Hence we provide a new API for external table plugins to allocate and return a unique_ptr ExternalTableFactory wrapper.