### PR TITLE
Making AutoSkip Manager predictor safe thread by moving to its own working area

### DIFF
--- a/util/auto_skip_compressor.cc
+++ b/util/auto_skip_compressor.cc
@@ -45,9 +45,7 @@ AutoSkipCompressorWrapper::AutoSkipCompressorWrapper(
     const CompressionType type)
     : CompressorWrapper::CompressorWrapper(std::move(compressor)),
       opts_(opts),
-      type_(type),
-      predictor_(
-          std::make_shared<CompressionRejectionProbabilityPredictor>(10)) {
+      type_(type) {
   (void)type_;
   (void)opts_;
 }
@@ -64,7 +62,9 @@ Status AutoSkipCompressorWrapper::CompressBlock(
     return CompressBlockAndRecord(uncompressed_data, compressed_output,
                                   out_compression_type, wa);
   } else {
-    auto prediction = predictor_->Predict();
+    auto predictor_ptr =
+        static_cast<AutoSkipCompressionContext*>(wa->get())->predictor_;
+    auto prediction = predictor_ptr->Predict();
     if (prediction <= kProbabilityCutOff) {
       // decide to compress
       return CompressBlockAndRecord(uncompressed_data, compressed_output,
@@ -78,13 +78,24 @@ Status AutoSkipCompressorWrapper::CompressBlock(
   return Status::OK();
 }
 
+Compressor::ManagedWorkingArea AutoSkipCompressorWrapper::ObtainWorkingArea() {
+  return ManagedWorkingArea(
+      static_cast<WorkingArea*>(new AutoSkipCompressionContext(type_, opts_)),
+      this);
+}
+void AutoSkipCompressorWrapper::ReleaseWorkingArea(WorkingArea* wa) {
+  delete static_cast<AutoSkipCompressionContext*>(wa);
+}
+
 Status AutoSkipCompressorWrapper::CompressBlockAndRecord(
     Slice uncompressed_data, std::string* compressed_output,
     CompressionType* out_compression_type, ManagedWorkingArea* wa) {
   Status status = wrapped_->CompressBlock(uncompressed_data, compressed_output,
                                           out_compression_type, wa);
   // determine if it was rejected or compressed
-  predictor_->Record(uncompressed_data, compressed_output, opts_);
+  auto predictor_ptr =
+      static_cast<AutoSkipCompressionContext*>(wa->get())->predictor_;
+  predictor_ptr->Record(uncompressed_data, compressed_output, opts_);
   return status;
 }
 

--- a/util/auto_skip_compressor.h
+++ b/util/auto_skip_compressor.h
@@ -34,6 +34,20 @@ class CompressionRejectionProbabilityPredictor {
   size_t window_size_;
 };
 
+class AutoSkipCompressionContext : public CompressionContext {
+ public:
+  explicit AutoSkipCompressionContext(const CompressionType& type,
+                                      const CompressionOptions& options)
+      : CompressionContext::CompressionContext(type, options),
+        predictor_(
+            std::make_shared<CompressionRejectionProbabilityPredictor>(10)) {}
+  ~AutoSkipCompressionContext() {}
+  AutoSkipCompressionContext(const AutoSkipCompressionContext&) = delete;
+  AutoSkipCompressionContext& operator=(const AutoSkipCompressionContext&) =
+      delete;
+  std::shared_ptr<CompressionRejectionProbabilityPredictor> predictor_;
+};
+
 class AutoSkipCompressorWrapper : public CompressorWrapper {
  public:
   explicit AutoSkipCompressorWrapper(std::unique_ptr<Compressor> compressor,
@@ -43,6 +57,8 @@ class AutoSkipCompressorWrapper : public CompressorWrapper {
   Status CompressBlock(Slice uncompressed_data, std::string* compressed_output,
                        CompressionType* out_compression_type,
                        ManagedWorkingArea* wa) override;
+  ManagedWorkingArea ObtainWorkingArea() override;
+  void ReleaseWorkingArea(WorkingArea* wa) override;
 
  private:
   Status CompressBlockAndRecord(Slice uncompressed_data,
@@ -53,7 +69,6 @@ class AutoSkipCompressorWrapper : public CompressorWrapper {
   static constexpr int kProbabilityCutOff = 50;
   const CompressionOptions& opts_;
   const CompressionType type_;
-  std::shared_ptr<CompressionRejectionProbabilityPredictor> predictor_;
 };
 
 class AutoSkipCompressorManager : public CompressionManagerWrapper {


### PR DESCRIPTION
**Summary**:
Current implementation of AutoSkipCompressor is not thread safe. The plan is to make it thread safe by moving it to Working Area instead.

**Test Plan**:
It should pass the same test code (AutoSkipCompressionManager) written in compression_test.cc one that was return for the non-thread safe AutoSkipCompressor.