### PR TITLE
Improve file checksum handling for ingestion

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -446,7 +446,7 @@ TEST_F(ExternalSSTFileBasicTest, BasicWithFileChecksumCrc32c) {
 namespace {
 class VariousFileChecksumGenerator : public FileChecksumGenCrc32c {
  public:
-  VariousFileChecksumGenerator(const std::string& name)
+  explicit VariousFileChecksumGenerator(const std::string& name)
       : FileChecksumGenCrc32c({}), name_(name) {}
 
   const char* Name() const override { return name_.c_str(); }

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -16,6 +16,7 @@
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
 #include "util/defer.h"
+#include "util/file_checksum_helper.h"
 #include "util/random.h"
 #include "utilities/fault_injection_env.h"
 
@@ -346,7 +347,8 @@ class ChecksumVerifyHelper {
 
   Status GetSingleFileChecksumAndFuncName(
       const std::string& file_path, std::string* file_checksum,
-      std::string* file_checksum_func_name) {
+      std::string* file_checksum_func_name,
+      const std::string& requested_func_name = {}) {
     Status s;
     EnvOptions soptions;
     std::unique_ptr<SequentialFile> file_reader;
@@ -364,6 +366,8 @@ class ChecksumVerifyHelper {
       return Status::OK();
     } else {
       FileChecksumGenContext gen_context;
+      gen_context.file_name = file_path;
+      gen_context.requested_checksum_func_name = requested_func_name;
       std::unique_ptr<FileChecksumGenerator> file_checksum_gen =
           file_checksum_gen_factory->CreateFileChecksumGenerator(gen_context);
       *file_checksum_func_name = file_checksum_gen->Name();
@@ -439,10 +443,50 @@ TEST_F(ExternalSSTFileBasicTest, BasicWithFileChecksumCrc32c) {
   DestroyAndRecreateExternalSSTFilesDir();
 }
 
+namespace {
+class VariousFileChecksumGenerator : public FileChecksumGenCrc32c {
+ public:
+  VariousFileChecksumGenerator(const std::string& name)
+      : FileChecksumGenCrc32c({}), name_(name) {}
+
+  const char* Name() const override { return name_.c_str(); }
+
+  std::string GetChecksum() const override {
+    return FileChecksumGenCrc32c::GetChecksum() + "_" + name_;
+  }
+
+ private:
+  const std::string name_;
+};
+
+class VariousFileChecksumGenFactory : public FileChecksumGenFactory {
+ public:
+  std::unique_ptr<FileChecksumGenerator> CreateFileChecksumGenerator(
+      const FileChecksumGenContext& context) override {
+    static RelaxedAtomic<int> counter{0};
+    if (Slice(context.requested_checksum_func_name).starts_with("Various")) {
+      return std::make_unique<VariousFileChecksumGenerator>(
+          context.requested_checksum_func_name);
+    } else if (context.requested_checksum_func_name.empty()) {
+      // Lacking a specific request, use a different function name for each
+      // result.
+      return std::make_unique<VariousFileChecksumGenerator>(
+          "Various" + std::to_string(counter.FetchAddRelaxed(1)));
+    } else {
+      return nullptr;
+    }
+  }
+
+  static const char* kClassName() { return "VariousFileChecksumGenFactory"; }
+  const char* Name() const override { return kClassName(); }
+};
+}  // namespace
+
 TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   Options old_options = CurrentOptions();
   Options options = CurrentOptions();
-  options.file_checksum_gen_factory = GetFileChecksumGenCrc32cFactory();
+  options.file_checksum_gen_factory =
+      std::make_shared<VariousFileChecksumGenFactory>();
   const ImmutableCFOptions ioptions(options);
   ChecksumVerifyHelper checksum_helper(options);
 
@@ -463,7 +507,8 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   ASSERT_EQ(file1_info.largest_key, Key(1099));
   std::string file_checksum1, file_checksum_func_name1;
   ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
-      file1, &file_checksum1, &file_checksum_func_name1));
+      file1, &file_checksum1, &file_checksum_func_name1,
+      file1_info.file_checksum_func_name));
   ASSERT_EQ(file1_info.file_checksum, file_checksum1);
   ASSERT_EQ(file1_info.file_checksum_func_name, file_checksum_func_name1);
 
@@ -482,7 +527,8 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   ASSERT_EQ(file2_info.largest_key, Key(1299));
   std::string file_checksum2, file_checksum_func_name2;
   ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
-      file2, &file_checksum2, &file_checksum_func_name2));
+      file2, &file_checksum2, &file_checksum_func_name2,
+      file2_info.file_checksum_func_name));
   ASSERT_EQ(file2_info.file_checksum, file_checksum2);
   ASSERT_EQ(file2_info.file_checksum_func_name, file_checksum_func_name2);
 
@@ -501,7 +547,8 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   ASSERT_EQ(file3_info.largest_key, Key(1499));
   std::string file_checksum3, file_checksum_func_name3;
   ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
-      file3, &file_checksum3, &file_checksum_func_name3));
+      file3, &file_checksum3, &file_checksum_func_name3,
+      file3_info.file_checksum_func_name));
   ASSERT_EQ(file3_info.file_checksum, file_checksum3);
   ASSERT_EQ(file3_info.file_checksum_func_name, file_checksum_func_name3);
 
@@ -520,7 +567,8 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   ASSERT_EQ(file4_info.largest_key, Key(1799));
   std::string file_checksum4, file_checksum_func_name4;
   ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
-      file4, &file_checksum4, &file_checksum_func_name4));
+      file4, &file_checksum4, &file_checksum_func_name4,
+      file4_info.file_checksum_func_name));
   ASSERT_EQ(file4_info.file_checksum, file_checksum4);
   ASSERT_EQ(file4_info.file_checksum_func_name, file_checksum_func_name4);
 
@@ -539,7 +587,8 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   ASSERT_EQ(file5_info.largest_key, Key(1999));
   std::string file_checksum5, file_checksum_func_name5;
   ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
-      file5, &file_checksum5, &file_checksum_func_name5));
+      file5, &file_checksum5, &file_checksum_func_name5,
+      file5_info.file_checksum_func_name));
   ASSERT_EQ(file5_info.file_checksum, file_checksum5);
   ASSERT_EQ(file5_info.file_checksum_func_name, file_checksum_func_name5);
 
@@ -558,7 +607,8 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   ASSERT_EQ(file6_info.largest_key, Key(2199));
   std::string file_checksum6, file_checksum_func_name6;
   ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
-      file6, &file_checksum6, &file_checksum_func_name6));
+      file6, &file_checksum6, &file_checksum_func_name6,
+      file6_info.file_checksum_func_name));
   ASSERT_EQ(file6_info.file_checksum, file_checksum6);
   ASSERT_EQ(file6_info.file_checksum_func_name, file_checksum_func_name6);
 
@@ -628,18 +678,23 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   }
   ASSERT_OK(env_->FileExists(file2));
 
-  // Enable verify_file_checksum option
-  // No checksum information is provided, generate it when ingesting
-  std::vector<std::string> checksum, checksum_func;
-  s = AddFileWithFileChecksum({file3}, checksum, checksum_func, true, false,
-                              false, false);
+  // Enable verify_file_checksum option. No checksum information is provided,
+  // so it is generated when ingesting. The configured checksum factory will
+  // use a different function than before.
+  s = AddFileWithFileChecksum({file3}, {}, {}, true, false, false, false);
   ASSERT_OK(s) << s.ToString();
   std::vector<LiveFileMetaData> live_files2;
   dbfull()->GetLiveFilesMetaData(&live_files2);
   for (const auto& f : live_files2) {
     if (set1.find(f.name) == set1.end()) {
-      ASSERT_EQ(f.file_checksum, file_checksum3);
-      ASSERT_EQ(f.file_checksum_func_name, file_checksum_func_name3);
+      // Recomputed checksum, different function
+      EXPECT_NE(f.file_checksum_func_name, file_checksum_func_name3);
+      std::string cur_checksum3, cur_checksum_func_name3;
+      ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
+          dbname_ + f.name, &cur_checksum3, &cur_checksum_func_name3,
+          f.file_checksum_func_name));
+      EXPECT_EQ(f.file_checksum, cur_checksum3);
+      EXPECT_EQ(f.file_checksum_func_name, cur_checksum_func_name3);
       set1.insert(f.name);
     }
   }
@@ -653,8 +708,9 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   ASSERT_NOK(s) << s.ToString();
 
   // Does not enable verify_file_checksum options
-  // Checksum function name matches, store the checksum being ingested.
-  s = AddFileWithFileChecksum({file4}, {"asd"}, {file_checksum_func_name4},
+  // Checksum function name is recognized, so store the checksum being ingested.
+  std::string file_checksum_func_name4alt = "VariousABCD";
+  s = AddFileWithFileChecksum({file4}, {"asd"}, {file_checksum_func_name4alt},
                               false, false, false, false);
   ASSERT_OK(s) << s.ToString();
   std::vector<LiveFileMetaData> live_files3;
@@ -663,7 +719,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
     if (set1.find(f.name) == set1.end()) {
       ASSERT_FALSE(f.file_checksum == file_checksum4);
       ASSERT_EQ(f.file_checksum, "asd");
-      ASSERT_EQ(f.file_checksum_func_name, file_checksum_func_name4);
+      ASSERT_EQ(f.file_checksum_func_name, file_checksum_func_name4alt);
       set1.insert(f.name);
     }
   }
@@ -672,7 +728,8 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
 
   // enable verify_file_checksum options, DB enable checksum, and enable
   // write_global_seq. So the checksum stored is different from the one
-  // ingested due to the sequence number changes.
+  // ingested due to the sequence number changes. The checksum function name
+  // may also change since the checksum is recomputed.
   s = AddFileWithFileChecksum({file5}, {file_checksum5},
                               {file_checksum_func_name5}, true, false, false,
                               true);
@@ -681,11 +738,14 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   dbfull()->GetLiveFilesMetaData(&live_files4);
   for (const auto& f : live_files4) {
     if (set1.find(f.name) == set1.end()) {
+      // Recomputed checksum, different function
+      EXPECT_NE(f.file_checksum_func_name, file_checksum_func_name5);
       std::string cur_checksum5, cur_checksum_func_name5;
       ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
-          dbname_ + f.name, &cur_checksum5, &cur_checksum_func_name5));
-      ASSERT_EQ(f.file_checksum, cur_checksum5);
-      ASSERT_EQ(f.file_checksum_func_name, file_checksum_func_name5);
+          dbname_ + f.name, &cur_checksum5, &cur_checksum_func_name5,
+          f.file_checksum_func_name));
+      EXPECT_EQ(f.file_checksum, cur_checksum5);
+      EXPECT_EQ(f.file_checksum_func_name, cur_checksum_func_name5);
       set1.insert(f.name);
     }
   }
@@ -693,18 +753,22 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithFileChecksum) {
   ASSERT_OK(env_->FileExists(file5));
 
   // Does not enable verify_file_checksum options and also the ingested file
-  // checksum information is empty. DB will generate and store the checksum
-  // in Manifest.
-  std::vector<std::string> files_c6, files_name6;
-  s = AddFileWithFileChecksum({file6}, files_c6, files_name6, false, false,
-                              false, false);
+  // checksum information is empty. DB will generate and store file checksum
+  // in Manifest, which could be different from the previous invocation.
+  s = AddFileWithFileChecksum({file6}, {}, {}, false, false, false, false);
   ASSERT_OK(s) << s.ToString();
   std::vector<LiveFileMetaData> live_files6;
   dbfull()->GetLiveFilesMetaData(&live_files6);
   for (const auto& f : live_files6) {
     if (set1.find(f.name) == set1.end()) {
-      ASSERT_EQ(f.file_checksum, file_checksum6);
-      ASSERT_EQ(f.file_checksum_func_name, file_checksum_func_name6);
+      // Recomputed checksum, different function
+      EXPECT_NE(f.file_checksum_func_name, file_checksum_func_name6);
+      std::string cur_checksum6, cur_checksum_func_name6;
+      ASSERT_OK(checksum_helper.GetSingleFileChecksumAndFuncName(
+          dbname_ + f.name, &cur_checksum6, &cur_checksum_func_name6,
+          f.file_checksum_func_name));
+      EXPECT_EQ(f.file_checksum, cur_checksum6);
+      EXPECT_EQ(f.file_checksum_func_name, cur_checksum_func_name6);
       set1.insert(f.name);
     }
   }

--- a/include/rocksdb/file_checksum.h
+++ b/include/rocksdb/file_checksum.h
@@ -80,7 +80,8 @@ class FileChecksumGenFactory : public Customizable {
       const ConfigOptions& options, const std::string& value,
       std::shared_ptr<FileChecksumGenFactory>* result);
 
-  // Create a new FileChecksumGenerator.
+  // Create a new FileChecksumGenerator. Recommended to return nullptr if the
+  // requested function name is not recognized.
   virtual std::unique_ptr<FileChecksumGenerator> CreateFileChecksumGenerator(
       const FileChecksumGenContext& context) = 0;
 

--- a/unreleased_history/bug_fixes/ingestion_file_checksum.md
+++ b/unreleased_history/bug_fixes/ingestion_file_checksum.md
@@ -1,0 +1,1 @@
+* Fixed handling of file checksums in IngestExternalFile() to allow providing checksums using recognized but not necessarily the DB's preferred checksum function, to ease migration between checksum functions.


### PR DESCRIPTION
Summary:
* Improve debugability with better error messages (including the returned status, not just log messages)
* Tolerate user providing file checksums recognized by the factory but not the same function as currently, generally provided by the factory. This makes it practical to transition from one type of checksum to another without major hiccups in ingestion workflows.

Test Plan: updated unit test, manually inspect LOG file from the unit test