### PR TITLE
Publish/support format_version=7, related enhancements

### DIFF
--- a/cache/compressed_secondary_cache.cc
+++ b/cache/compressed_secondary_cache.cc
@@ -80,15 +80,16 @@ std::unique_ptr<SecondaryCacheResultHandle> CompressedSecondaryCache::Lookup(
     ptr = reinterpret_cast<CacheAllocationPtr*>(handle_value);
     handle_value_charge = cache_->GetCharge(lru_handle);
     data_ptr = ptr->get();
-    data_ptr = GetVarint32Ptr(data_ptr, data_ptr + 1,
-                              static_cast<uint32_t*>(&type_32));
+    const char* limit = ptr->get() + handle_value_charge;
+    data_ptr =
+        GetVarint32Ptr(data_ptr, limit, static_cast<uint32_t*>(&type_32));
     type = static_cast<CompressionType>(type_32);
-    data_ptr = GetVarint32Ptr(data_ptr, data_ptr + 1,
-                              static_cast<uint32_t*>(&source_32));
+    data_ptr =
+        GetVarint32Ptr(data_ptr, limit, static_cast<uint32_t*>(&source_32));
     source = static_cast<CacheTier>(source_32);
     uint64_t data_size = 0;
-    data_ptr = GetVarint64Ptr(data_ptr, ptr->get() + handle_value_charge,
-                              static_cast<uint64_t*>(&data_size));
+    data_ptr =
+        GetVarint64Ptr(data_ptr, limit, static_cast<uint64_t*>(&data_size));
     assert(handle_value_charge > data_size);
     handle_value_charge = data_size;
   }

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -833,7 +833,6 @@ TEST_F(DBBlockCacheTest, CacheCompressionDict) {
       GetSupportedDictCompressions();
   Random rnd(301);
   // Format version before and after compression handling changes
-  TEST_AllowUnsupportedFormatVersion() = true;
   for (int format_version : {6, 7}) {
     // Test all supported compression types because (at least historically)
     // dictionary compression could be enabled and a dictionary block saved

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -6209,6 +6209,7 @@ TEST_F(DBTest, L0L1L2AndUpHitCounter) {
 }
 
 TEST_F(DBTest, EncodeDecompressedBlockSizeTest) {
+  // Allow testing format_version=1
   bool& allow_unsupported_fv = TEST_AllowUnsupportedFormatVersion();
   SaveAndRestore guard(&allow_unsupported_fv);
   ASSERT_FALSE(allow_unsupported_fv);

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2282,7 +2282,7 @@ TEST_F(DBTest2, CompressionManagerCustomCompression) {
     ASSERT_EQ(NumTableFilesAtLevel(0), 2);
     ASSERT_EQ(Get("b"), value);
 
-    // Verify it was compressed with snappy
+    // Verify it was compressed with LZ4
     r = {"b", "b0"};
     tables_properties.clear();
     ASSERT_OK(db_->GetPropertiesOfTablesInRange(db_->DefaultColumnFamily(), &r,
@@ -2323,7 +2323,7 @@ TEST_F(DBTest2, CompressionManagerCustomCompression) {
     ASSERT_EQ(NumTableFilesAtLevel(0), 4);
     ASSERT_EQ(Get("d"), value);
 
-    // Verify it was compressed with snappy
+    // Verify it was compressed with LZ4
     r = {"d", "d0"};
     tables_properties.clear();
     ASSERT_OK(db_->GetPropertiesOfTablesInRange(db_->DefaultColumnFamily(), &r,

--- a/db_stress_tool/db_stress_compression_manager.h
+++ b/db_stress_tool/db_stress_compression_manager.h
@@ -41,7 +41,7 @@ class DbStressCustomCompressionManager : public CompressionManager {
             test::CompressorCustomAlg<kCustomCompressionAC>>();
       // Also support built-in compression algorithms
       default:
-        return GetDefaultBuiltinCompressionManager()->GetCompressor(opts, type);
+        return GetBuiltinV2CompressionManager()->GetCompressor(opts, type);
     }
   }
 
@@ -59,7 +59,7 @@ class DbStressCustomCompressionManager : public CompressionManager {
 
  protected:
   std::shared_ptr<CompressionManager> default_ =
-      GetDefaultBuiltinCompressionManager();
+      GetBuiltinV2CompressionManager();
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3435,15 +3435,15 @@ void StressTest::Open(SharedState* shared, bool reopen) {
     options_.compression_manager =
         std::make_shared<DbStressCustomCompressionManager>();
   } else if (!strcasecmp(FLAGS_compression_manager.c_str(), "mixed")) {
-    options_.compression_manager = std::make_shared<RoundRobinManager>(
-        GetDefaultBuiltinCompressionManager());
+    options_.compression_manager =
+        std::make_shared<RoundRobinManager>(GetBuiltinV2CompressionManager());
   } else if (!strcasecmp(FLAGS_compression_manager.c_str(), "randommixed")) {
     options_.compression_manager =
         std::make_shared<RandomMixedCompressionManager>(
-            GetDefaultBuiltinCompressionManager());
+            GetBuiltinV2CompressionManager());
   } else if (!strcasecmp(FLAGS_compression_manager.c_str(), "autoskip")) {
     options_.compression_manager =
-        CreateAutoSkipCompressionManager(GetDefaultBuiltinCompressionManager());
+        CreateAutoSkipCompressionManager(GetBuiltinV2CompressionManager());
   } else if (!strcasecmp(FLAGS_compression_manager.c_str(), "none")) {
     // Nothing to do using default compression manager
   } else {

--- a/include/rocksdb/advanced_compression.h
+++ b/include/rocksdb/advanced_compression.h
@@ -371,8 +371,9 @@ class CompressionManager
                                  const std::string& id,
                                  std::shared_ptr<CompressionManager>* result);
 
-  // Will this compression type be used if requested in calling
-  // GetCompressor/GetCompressorForSST?
+  // Returns false iff a configuration that would pass the given compression
+  // type to GetCompressor/GetCompressorForSST should be rejected (not
+  // supported)
   virtual bool SupportsCompressionType(CompressionType type) const = 0;
 
   // TODO: function to check compatibility with or sanitize CompressionOptions
@@ -577,11 +578,17 @@ class CompressionManagerWrapper : public CompressionManager {
   std::shared_ptr<CompressionManager> wrapped_;
 };
 
-// Compression manager that implements built-in compression strategy. The
-// behavior of compression_manager=nullptr is essentially equivalent to
-// using this compression manager.
-const std::shared_ptr<CompressionManager>&
-GetDefaultBuiltinCompressionManager();
+// Compression manager that implements the second schema for RocksDB built-in
+// compression support. (The first schema is intentionally not provided here.)
+// *** CURRENT STATE ***
+// This is currently the latest schema for built-in compression, and the
+// compression manager used when compression_manager=nullptr.
+const std::shared_ptr<CompressionManager>& GetBuiltinV2CompressionManager();
+
+// NOTE: No GetLatestBuiltinCompressionManager() is provided because that could
+// lead to unexpected schema changes for user CompressionManagers building on
+// the built-in schema, in the unlikely/rare case of a new built-in schema.
+
 // Gets CompressionManager designed for the automated compression strategy.
 // This may include deciding to compress or not.
 // In future should be able to select compression algorithm based on the CPU

--- a/include/rocksdb/compression_type.h
+++ b/include/rocksdb/compression_type.h
@@ -32,6 +32,7 @@ enum CompressionType : unsigned char {
 
   // For use by user custom CompressionManagers
   kCustomCompression80 = 0x80,
+  kFirstCustomCompression = kCustomCompression80,
   kCustomCompression81 = 0x81,
   kCustomCompression82 = 0x82,
   kCustomCompression83 = 0x83,
@@ -158,6 +159,7 @@ enum CompressionType : unsigned char {
   kCustomCompressionFC = 0xFC,
   kCustomCompressionFD = 0xFD,
   kCustomCompressionFE = 0xFE,
+  kLastCustomCompression = kCustomCompressionFE,
 
   // kDisableCompressionOption is used to disable some compression options.
   kDisableCompressionOption = 0xff,

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -561,6 +561,10 @@ struct BlockBasedTableOptions {
   // misplaced within or between files is as likely to fail checksum
   // verification as random corruption. Also checksum-protects SST footer.
   // Can be read by RocksDB versions >= 8.6.0.
+  // 7 -- Support for custom compression algorithms with a CompressionManager
+  // using a non-built-in CompatibilityName(). See `compression_manager` in
+  // ColumnFamilyOptions. Also changes the format of TableProperties field
+  // `compression_name`. Can be read by RocksDB versions >= 10.4.0.
   //
   // Using the default setting of format_version is strongly recommended, so
   // that available enhancements are adopted eventually and automatically. The

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -355,7 +355,13 @@ struct TableProperties {
   // behave, this must be set to "ZSTD" if any blocks are compressed
   // with zstd and must NOT be set to "NoCompression" if any blocks are
   // compressed.
-  // * For format_version >= 7, it is ...
+  // * For format_version >= 7, the format is
+  //   <compatibility_name>;<hex-coded compression types>;<future use>
+  // where <compatibility_name> is the CompatibilityName() of the
+  // CompressionManager used for the file, or empty if compression was
+  // disabled; <hex-coded compression types> represents a sorted set of
+  // CompressionType values used in the file other than kNoCompression, each
+  // as 2-digit hex, e.g. 04 for LZ$, 07 for ZSTD, etc.
   std::string compression_name;
 
   // Compression options used to compress the SST files.

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -705,10 +705,9 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       12345);
   // TODO: try to enhance ObjectLibrary to support singletons
   // ASSERT_EQ(new_options->compression_manager,
-  //           GetBuiltinCompressionManager(/*compression_format_version*/ 2));
-  ASSERT_STREQ(
-      new_options->compression_manager->Name(),
-      GetBuiltinCompressionManager(/*compression_format_version*/ 2)->Name());
+  //           GetBuiltinV2CompressionManager());
+  ASSERT_STREQ(new_options->compression_manager->Name(),
+               GetBuiltinV2CompressionManager()->Name());
 
   ColumnFamilyOptions rnd_filled_options = *new_options;
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -977,7 +977,10 @@ struct BlockBasedTableBuilder::Rep {
       assert(mgr);
       // Use newer compression_name property
       props.compression_name.reserve(32);
-      props.compression_name.append(mgr->CompatibilityName());
+      // If compression is disabled, use empty manager name
+      if (basic_compressor) {
+        props.compression_name.append(mgr->CompatibilityName());
+      }
       props.compression_name.push_back(';');
       // Rest of property to be filled out at the end of building the file
     } else {

--- a/table/format.h
+++ b/table/format.h
@@ -157,10 +157,15 @@ inline uint32_t GetCompressFormatForVersion(uint32_t format_version) {
   // As of format_version 2, we encode compressed block with
   // compress_format_version == 2. Before that, the version is 1.
   // DO NOT CHANGE THIS FUNCTION, it affects disk format
+  // As of format_version 7 and opening up to custom compression, the
+  // compression format version is essentially independent of the block-based
+  // table format version, and encoded in the compression_name table property.
+  // Thus, this function can go away once we remove support for reading
+  // format_version=1.
   return format_version >= 2 ? 2 : 1;
 }
 
-constexpr uint32_t kLatestFormatVersion = 6;
+constexpr uint32_t kLatestFormatVersion = 7;
 
 inline bool IsSupportedFormatVersion(uint32_t version) {
   return version <= kLatestFormatVersion;

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -740,9 +740,9 @@ template <CompressionType kCompression>
 struct CompressorCustomAlg : public CompressorWrapper {
   static bool Supported() { return LZ4_Supported(); }
 
-  explicit CompressorCustomAlg(std::unique_ptr<Compressor> wrapped =
-                                   GetDefaultBuiltinCompressionManager()
-                                       ->GetCompressor({}, kLZ4Compression))
+  explicit CompressorCustomAlg(
+      std::unique_ptr<Compressor> wrapped =
+          GetBuiltinV2CompressionManager()->GetCompressor({}, kLZ4Compression))
       : CompressorWrapper(std::move(wrapped)),
         dictionary_hash_(GetSliceHash(wrapped_->GetSerializedDict())) {
     static_assert(kCompression > kLastBuiltinCompression);
@@ -783,9 +783,8 @@ struct CompressorCustomAlg : public CompressorWrapper {
 struct DecompressorCustomAlg : public DecompressorWrapper {
   using TypeSet = SmallEnumSet<CompressionType, kDisableCompressionOption>;
 
-  DecompressorCustomAlg(
-      std::shared_ptr<Decompressor> wrapped =
-          GetDefaultBuiltinCompressionManager()->GetDecompressor())
+  DecompressorCustomAlg(std::shared_ptr<Decompressor> wrapped =
+                            GetBuiltinV2CompressionManager()->GetDecompressor())
       : DecompressorWrapper(std::move(wrapped)),
         dictionary_hash_(GetSliceHash(wrapped_->GetSerializedDict())),
         allowed_types_(TypeSet::All()) {}

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -750,12 +750,16 @@ struct CompressorCustomAlg : public CompressorWrapper {
 
   const char* Name() const override { return "CompressorCustomAlg"; }
 
+  CompressionType GetPreferredCompressionType() const override {
+    return kCompression;
+  }
+
   Status CompressBlock(Slice uncompressed_data, std::string* compressed_output,
                        CompressionType* out_compression_type,
                        ManagedWorkingArea* working_area) override {
     Status s = wrapped_->CompressBlock(uncompressed_data, compressed_output,
                                        out_compression_type, working_area);
-    if (*out_compression_type != kNoCompression) {
+    if (s.ok() && *out_compression_type != kNoCompression) {
       assert(*out_compression_type == kLZ4Compression);
       std::string header(/*size=*/5, 0);
       header[0] = lossless_cast<char>(kCompression);
@@ -807,7 +811,8 @@ struct DecompressorCustomAlg : public DecompressorWrapper {
   }
 
   Status ExtractUncompressedSize(Args& args) override {
-    if (args.compression_type > kLastBuiltinCompression) {
+    if (args.compression_type >= kFirstCustomCompression &&
+        args.compression_type <= kLastCustomCompression) {
       assert(args.compressed_data.size() > 0);
       assert(args.compressed_data[0] ==
              lossless_cast<char>(args.compression_type));
@@ -827,7 +832,8 @@ struct DecompressorCustomAlg : public DecompressorWrapper {
   }
 
   Status DecompressBlock(const Args& args, char* uncompressed_output) override {
-    if (args.compression_type > kLastBuiltinCompression) {
+    if (args.compression_type >= kFirstCustomCompression &&
+        args.compression_type <= kLastCustomCompression) {
       // Also allowed to copy args and modify
       Args modified_args = args;
       modified_args.compression_type = kLZ4Compression;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4653,7 +4653,7 @@ class Benchmark {
         options.bottommost_compression = kZSTD;
 
         mgr = std::make_shared<RoundRobinManager>(
-            GetDefaultBuiltinCompressionManager());
+            GetBuiltinV2CompressionManager());
       } else if (!strcasecmp(FLAGS_compression_manager.c_str(), "autoskip")) {
         options.compression = FLAGS_compression_type_e;
         if (FLAGS_compression_type_e == kNoCompression) {
@@ -4662,8 +4662,8 @@ class Benchmark {
                   "autoskip");
           ErrorExit();
         }
-        mgr = CreateAutoSkipCompressionManager(
-            GetDefaultBuiltinCompressionManager());
+        mgr =
+            CreateAutoSkipCompressionManager(GetBuiltinV2CompressionManager());
       } else {
         // not defined -> exit with error
         fprintf(stderr, "Requested compression manager not supported");

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -870,8 +870,8 @@ bool LDBCommand::ParseCompressionTypeOption(
       }
       options_.compression = kZSTD;
       options_.bottommost_compression = kZSTD;
-      auto mgr = std::make_shared<RoundRobinManager>(
-          GetDefaultBuiltinCompressionManager());
+      auto mgr =
+          std::make_shared<RoundRobinManager>(GetBuiltinV2CompressionManager());
       options_.compression_manager = mgr;
 
       // Need to list zstd in the compression_name table property if it's

--- a/unreleased_history/new_features/format_version_7.md
+++ b/unreleased_history/new_features/format_version_7.md
@@ -1,0 +1,1 @@
+* Add new `format_version=7` to aid experimental support of custom compression algorithms with CompressionManager and block-based table. This format version includes changing the format of `TableProperties::compression_name`.

--- a/util/auto_skip_compressor.cc
+++ b/util/auto_skip_compressor.cc
@@ -126,6 +126,6 @@ std::unique_ptr<Compressor> AutoSkipCompressorManager::GetCompressorForSST(
 std::shared_ptr<CompressionManagerWrapper> CreateAutoSkipCompressionManager(
     std::shared_ptr<CompressionManager> wrapped) {
   return std::make_shared<AutoSkipCompressorManager>(
-      wrapped == nullptr ? GetDefaultBuiltinCompressionManager() : wrapped);
+      wrapped == nullptr ? GetBuiltinV2CompressionManager() : wrapped);
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -1043,8 +1043,7 @@ const std::shared_ptr<CompressionManager>& GetBuiltinCompressionManager(
   }
 }
 
-const std::shared_ptr<CompressionManager>&
-GetDefaultBuiltinCompressionManager() {
+const std::shared_ptr<CompressionManager>& GetBuiltinV2CompressionManager() {
   return GetBuiltinCompressionManager(2);
 }
 

--- a/util/compression.h
+++ b/util/compression.h
@@ -754,8 +754,11 @@ inline std::string CompressionTypeToString(CompressionType compression_type) {
     case kDisableCompressionOption:
       return "DisableOption";
     default: {
+      bool is_custom = compression_type >= kFirstCustomCompression &&
+                       compression_type <= kLastCustomCompression;
       char c = lossless_cast<char>(compression_type);
-      return "Custom" + Slice(&c, 1).ToString(/*hex=*/true);
+      return (is_custom ? "Custom" : "Reserved") +
+             Slice(&c, 1).ToString(/*hex=*/true);
     }
   }
 }

--- a/util/compression.h
+++ b/util/compression.h
@@ -756,9 +756,9 @@ inline std::string CompressionTypeToString(CompressionType compression_type) {
     default: {
       bool is_custom = compression_type >= kFirstCustomCompression &&
                        compression_type <= kLastCustomCompression;
-      char c = lossless_cast<char>(compression_type);
+      unsigned char c = lossless_cast<unsigned char>(compression_type);
       return (is_custom ? "Custom" : "Reserved") +
-             Slice(&c, 1).ToString(/*hex=*/true);
+             ToBaseCharsString<16>(2, c, /*uppercase=*/true);
     }
   }
 }

--- a/util/compression_test.cc
+++ b/util/compression_test.cc
@@ -158,7 +158,7 @@ class DBAutoSkip : public DBTestBase {
         rnd_(231),
         key_index_(0) {
     options.compression_manager =
-        CreateAutoSkipCompressionManager(GetDefaultBuiltinCompressionManager());
+        CreateAutoSkipCompressionManager(GetBuiltinV2CompressionManager());
     auto statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
     options.statistics = statistics;
     options.statistics->set_stats_level(StatsLevel::kExceptTimeForMutex);

--- a/util/simple_mixed_compressor.cc
+++ b/util/simple_mixed_compressor.cc
@@ -17,7 +17,8 @@ namespace ROCKSDB_NAMESPACE {
 // MultiCompressorWrapper implementation
 MultiCompressorWrapper::MultiCompressorWrapper(const CompressionOptions& opts,
                                                CompressionDict&& dict) {
-  auto builtInManager = GetDefaultBuiltinCompressionManager();
+  // TODO: make the compression manager a field
+  auto builtInManager = GetBuiltinV2CompressionManager();
   const auto& compressions = GetSupportedCompressions();
   for (auto type : compressions) {
     if (type == kNoCompression) {

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -14,6 +14,7 @@
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
 #include "util/cast_util.h"
+#include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -408,6 +409,17 @@ TEST(UnownedPtrTest, Tests) {
     ASSERT_EQ(q->first, 1);
     // Not committing to any moved-from semantics (on p here)
   }
+}
+
+TEST(ToBaseCharsStringTest, Tests) {
+  using ROCKSDB_NAMESPACE::ToBaseCharsString;
+  // Base 16
+  ASSERT_EQ(ToBaseCharsString<16>(5, 0, true), "00000");
+  ASSERT_EQ(ToBaseCharsString<16>(5, 42, true), "0002A");
+  ASSERT_EQ(ToBaseCharsString<16>(5, 42, false), "0002a");
+  ASSERT_EQ(ToBaseCharsString<16>(2, 255, false), "ff");
+  // Base 32
+  ASSERT_EQ(ToBaseCharsString<32>(2, 255, false), "7v");
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -40,6 +40,16 @@ inline void PutBaseChars(char** buf, size_t n, uint64_t v, bool uppercase) {
   *buf += n;
 }
 
+// Construct a string of n digits from v in base kBase
+template <size_t kBase>
+inline std::string ToBaseCharsString(size_t n, uint64_t v, bool uppercase) {
+  std::string result;
+  result.resize(n);
+  char* buf = &result[0];
+  PutBaseChars<kBase>(&buf, n, v, uppercase);
+  return result;
+}
+
 // Parse n digits from *buf in base kBase to *v and advance *buf to the
 // position after what was read. On success, true is returned. On failure,
 // false is returned, *buf is placed at the first bad character, and *v


### PR DESCRIPTION
Summary:
* Make new format_version=7 a supported setting.
* Fix a bug in compressed_secondary_cache.cc that is newly exercised by custom compression types and showing up in crash test with tiered secondary cache
* Small change to handling of disabled compression in fv=7: use empty compression manager compatibility name.
* Get rid of GetDefaultBuiltinCompressionManager() in public API because it could cause unexpected+unsafe schema change on a user's CompressionManager if built upon the default built-in manager and we add a new built-in schema. Now must be referenced by explicit compression schema version in the public API. (That notion was already exposed in compressed secondary cache API, for better or worse.)
* Improve some error messages for compression misconfiguration
* Improve testing with ObjectLibrary and CompressionManagers
* Improve testing of compression_name table property in BlockBasedTableTest.BlockBasedTableProperties2
* Improve some comments

Test Plan: existing and updated tests. Notably, the crash test has already been running with (unpublished) format_version=7