### PR TITLE
Disable AutoSkipCompressionManager test

### DIFF
--- a/util/compression_test.cc
+++ b/util/compression_test.cc
@@ -190,7 +190,12 @@ class DBAutoSkip : public DBTestBase {
   }
 };
 
-TEST_F(DBAutoSkip, AutoSkipCompressionManager) {
+// FIXME: the test is failing the assertion in auto_skip_compressor.cc
+// when run on nightly build in build-linux-arm-test-full mode [1].
+//
+// [1]
+// auto_skip_compressor.cc:101: Assertion `preferred != kNoCompression' failed.
+TEST_F(DBAutoSkip, DISABLED_AutoSkipCompressionManager) {
   if (GetSupportedCompressions().size() > 1) {
     const int kValueSize = 20000;
     // This will set the rejection ratio to 60%


### PR DESCRIPTION
Auto skip compression manager code is currently running only in context of test / db bench. Disable failing test to allow the job to continue testing release code changes, bypassing this specific error.