### PR TITLE
Fix forcing the compression algorithm to be any supported compression algorithm beside KNoCompression

### DIFF
--- a/util/compression_test.cc
+++ b/util/compression_test.cc
@@ -167,6 +167,16 @@ class DBAutoSkip : public DBTestBase {
     bbto.flush_block_policy_factory.reset(
         new AutoSkipTestFlushBlockPolicyFactory(10, statistics));
     options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+    auto compressions = GetSupportedCompressions();
+    if (compressions.size() > 1) {
+      // We want to get the compression algorithm in random beside
+      // kNoCompression, This is assuming that kNoCompression is the first
+      // compression algorithm
+      auto selected_index = rnd_.Uniform(compressions.size() - 2) + 1;
+      auto compression = compressions[selected_index];
+      options.compression = compression;
+      options.bottommost_compression = compression;
+    }
     DestroyAndReopen(options);
   }
 


### PR DESCRIPTION
Summary:
The nightly build was failing because when we were using the AutoSkipCompressionManager with kNoCompression. The test cases should not be running with NoCompression.

Test Plan:
Run the test code being run on the nightly build.
```bash
  make V=1 J=4 -j4 check
```