### PR TITLE
Check op count in WBWI vs WB when ingesting WBWI 

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -876,6 +876,10 @@ Status StressTest::CommitTxn(Transaction& txn, ThreadState* thread) {
     return Status::InvalidArgument("CommitTxn when FLAGS_use_txn is not set");
   }
   Status s = Status::OK();
+  // We don't issue write to transaction's underlying WriteBatch in stress test
+  assert(txn.GetWriteBatch()->GetWriteBatch()->Count());
+  assert(txn.GetWriteBatch()->GetWBWIOpCount() ==
+         txn.GetWriteBatch()->GetWriteBatch()->Count());
   if (FLAGS_use_optimistic_txn) {
     assert(optimistic_txn_db_);
     s = txn.Commit();

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -396,9 +396,9 @@ struct TransactionOptions {
   // due to too many memtables.
   // Note that the ingestion relies on the transaction's underlying index,
   // (WriteBatchWithIndex), so updates that are added to the transaction
-  // without indexing (e.g. added directly to the transaction underlying
+  // without indexing (i.e. added directly to the transaction underlying
   // write batch through Transaction::GetWriteBatch()->GetWriteBatch())
-  // are not supported. They will not be applied to the DB.
+  // are not supported, and the optimization will not apply in that case.
   //
   // NOTE: since WBWI keep track of the most recent update per key, a Put
   // followed by a SingleDelete will be written to DB as a SingleDelete. This

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -379,6 +379,7 @@ class WriteBatchWithIndex : public WriteBatchBase {
   };
   const std::unordered_map<uint32_t, CFStat>& GetCFStats() const;
 
+  size_t GetWBWIOpCount() const;
   bool GetOverwriteKey() const;
 
  private:

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -379,6 +379,7 @@ class WriteBatchWithIndex : public WriteBatchBase {
   };
   const std::unordered_map<uint32_t, CFStat>& GetCFStats() const;
 
+  // The total number of operations issued into this WBWI.
   size_t GetWBWIOpCount() const;
   bool GetOverwriteKey() const;
 

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -904,7 +904,7 @@ Status WriteCommittedTxn::CommitInternal() {
             "Transaction %s qualifies for commit optimization due to update "
             "count. However, it will commit normally due to wbwi and wb record "
             "count mismatch. Some updates were added directly to the "
-            "transaction's underlying writ batch.",
+            "transaction's underlying write batch.",
             GetName().c_str());
       } else {
         bypass_memtable = true;
@@ -917,7 +917,7 @@ Status WriteCommittedTxn::CommitInternal() {
             "Transaction %s qualifies for commit optimization due to write "
             "batch size. However, it will commit normally due to wbwi and wb "
             "record count mismatch. Some updates were added directly to the "
-            "transaction's underlying writ batch.",
+            "transaction's underlying write batch.",
             GetName().c_str());
       } else {
         bypass_memtable = true;

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -898,10 +898,30 @@ Status WriteCommittedTxn::CommitInternal() {
   if (!needs_ts) {
     if (commit_bypass_memtable_threshold_ &&
         wb_count >= commit_bypass_memtable_threshold_) {
-      bypass_memtable = true;
+      if (wbwi->GetWBWIOpCount() != wb_count) {
+        ROCKS_LOG_WARN(
+            db_impl_->immutable_db_options().info_log,
+            "Transaction %s qualifies for commit optimization due to update "
+            "count. However, it will commit normally due to wbwi and wb record "
+            "count mismatch. Some updates were added directly to the "
+            "transaction's underlying writ batch.",
+            GetName().c_str());
+      } else {
+        bypass_memtable = true;
+      }
     } else if (commit_bypass_memtable_byte_threshold_ &&
                wb->GetDataSize() >= commit_bypass_memtable_byte_threshold_) {
-      bypass_memtable = true;
+      if (wbwi->GetWBWIOpCount() != wb_count) {
+        ROCKS_LOG_WARN(
+            db_impl_->immutable_db_options().info_log,
+            "Transaction %s qualifies for commit optimization due to write "
+            "batch size. However, it will commit normally due to wbwi and wb "
+            "record count mismatch. Some updates were added directly to the "
+            "transaction's underlying writ batch.",
+            GetName().c_str());
+      } else {
+        bypass_memtable = true;
+      }
     }
   }
   if (!bypass_memtable) {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -9929,6 +9929,56 @@ TEST_P(CommitBypassMemtableTest,
 
   delete txn_cf;
 }
+
+TEST_P(CommitBypassMemtableTest, WBWIOpCountMismatchWBCount) {
+  // Tests that large txn optimization checks op count in WBWI vs WB. When an
+  // update is written directly to a transaction's underlying write batch, the
+  // optimization should not apply.
+  const uint64_t size_threshold = 100;
+  SetUpTransactionDB();
+  bool commit_bypass_memtable = false;
+  SyncPoint::GetInstance()->SetCallBack(
+      "WriteCommittedTxn::CommitInternal:bypass_memtable",
+      [&](void* arg) { commit_bypass_memtable = *(static_cast<bool*>(arg)); });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Random rnd(301);
+  {
+    WriteOptions wopts;
+    TransactionOptions txn_opts;
+    txn_opts.large_txn_commit_optimize_byte_threshold = size_threshold;
+    // Test default
+    auto txn = txn_db->BeginTransaction(wopts, txn_opts, nullptr);
+    ASSERT_OK(txn->SetName("xid0"));
+    ASSERT_OK(txn->Put("k1", rnd.RandomString(1000)));
+    ASSERT_OK(txn->GetWriteBatch()->GetWriteBatch()->Put("meta", "1"));
+    ASSERT_OK(txn->Prepare());
+    ASSERT_OK(txn->Commit());
+    ASSERT_FALSE(commit_bypass_memtable);
+
+    ASSERT_EQ(Get("meta"), "1");
+    delete txn;
+  }
+
+  {
+    WriteOptions wopts;
+    TransactionOptions txn_opts;
+    txn_opts.large_txn_commit_optimize_threshold = 10;
+    // Test default
+    auto txn = txn_db->BeginTransaction(wopts, txn_opts, nullptr);
+    ASSERT_OK(txn->SetName("xid0"));
+    for (int i = 0; i < 10; ++i) {
+      ASSERT_OK(txn->Put(Key(i), rnd.RandomString(10)));
+    }
+    ASSERT_OK(txn->GetWriteBatch()->GetWriteBatch()->Put("meta", "2"));
+    ASSERT_OK(txn->Prepare());
+    ASSERT_OK(txn->Commit());
+    ASSERT_FALSE(commit_bypass_memtable);
+
+    ASSERT_EQ(Get("meta"), "2");
+    delete txn;
+  }
+}
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -49,7 +49,7 @@ struct WriteBatchWithIndex::Rep {
   // Tracks ids of CFs that have updates in this WBWI, number of updates and
   // number of overwritten single deletions per cf. Useful for WBWIMemTable
   // when this WBWI is ingested into a DB.
-  UnorderedMap<uint32_t, CFStat> cf_id_to_stat;
+  std::unordered_map<uint32_t, WriteBatchWithIndex::CFStat> cf_id_to_stat;
   size_t op_count;
 
   // In overwrite mode, find the existing entry for the same key and update it

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -32,7 +32,8 @@ struct WriteBatchWithIndex::Rep {
         skip_list(comparator, &arena),
         last_sub_batch_offset(0),
         sub_batch_cnt(1),
-        overwrite_key(_overwrite_key) {}
+        overwrite_key(_overwrite_key),
+        op_count(0) {}
   ReadableWriteBatch write_batch;
   WriteBatchEntryComparator comparator;
   Arena arena;
@@ -48,7 +49,8 @@ struct WriteBatchWithIndex::Rep {
   // Tracks ids of CFs that have updates in this WBWI, number of updates and
   // number of overwritten single deletions per cf. Useful for WBWIMemTable
   // when this WBWI is ingested into a DB.
-  std::unordered_map<uint32_t, CFStat> cf_id_to_stat;
+  UnorderedMap<uint32_t, CFStat> cf_id_to_stat;
+  size_t op_count;
 
   // In overwrite mode, find the existing entry for the same key and update it
   // to point to the current entry if this is not a Merge operation.
@@ -154,6 +156,7 @@ bool WriteBatchWithIndex::Rep::UpdateExistingEntryWithCfId(
 void WriteBatchWithIndex::Rep::AddOrUpdateIndexWithCfId(
     uint32_t cf_id, const Slice& key, WriteType type, size_t last_entry_offset,
     const Comparator* cf_cmp) {
+  op_count++;
   uint32_t update_count = 0;
   if (!UpdateExistingEntryWithCfId(cf_id, key, type, last_entry_offset,
                                    &update_count)) {
@@ -201,7 +204,6 @@ void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id,
 
 void WriteBatchWithIndex::Rep::Clear() {
   write_batch.Clear();
-  cf_id_to_stat.clear();
   ClearIndex();
 }
 
@@ -212,6 +214,8 @@ void WriteBatchWithIndex::Rep::ClearIndex() {
   new (&skip_list) WriteBatchEntrySkipList(comparator, &arena);
   last_sub_batch_offset = 0;
   sub_batch_cnt = 1;
+  cf_id_to_stat.clear();
+  op_count = 0;
 }
 
 Status WriteBatchWithIndex::Rep::ReBuildIndex() {
@@ -1172,6 +1176,8 @@ const std::unordered_map<uint32_t, WriteBatchWithIndex::CFStat>&
 WriteBatchWithIndex::GetCFStats() const {
   return rep->cf_id_to_stat;
 }
+
+size_t WriteBatchWithIndex::GetWBWIOpCount() const { return rep->op_count; }
 
 bool WriteBatchWithIndex::GetOverwriteKey() const { return rep->overwrite_key; }
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -342,6 +342,11 @@ void AssertIterEqual(WBWIIteratorImpl* wbwii,
   }
   ASSERT_FALSE(wbwii->Valid());
 }
+
+void AssertWBWICountEQWBCount(WriteBatchWithIndex& wbwi) {
+  std::cout << wbwi.GetWBWIOpCount() << std::endl;
+  ASSERT_EQ(wbwi.GetWBWIOpCount(), wbwi.GetWriteBatch()->Count());
+}
 }  // namespace
 
 class WBWIBaseTest : public testing::Test {
@@ -356,6 +361,8 @@ class WBWIBaseTest : public testing::Test {
   }
 
   virtual ~WBWIBaseTest() {
+    AssertWBWICountEQWBCount(*batch_);
+
     if (db_ != nullptr) {
       ReleaseSnapshot();
       delete db_;
@@ -715,6 +722,7 @@ TEST_P(WriteBatchWithIndexTest, TestValueAsSecondaryIndex) {
   batch_.reset(new WriteBatchWithIndex(nullptr, 20, GetParam()));
 
   TestValueAsSecondaryIndexHelper(entries_list, batch_.get(), GetParam());
+  AssertWBWICountEQWBCount(*batch_);
 
   // Clear batch and re-run test with new values
   batch_->Clear();
@@ -729,6 +737,7 @@ TEST_P(WriteBatchWithIndexTest, TestValueAsSecondaryIndex) {
   entries_list = std::vector<Entry>(new_entries, new_entries + 8);
 
   TestValueAsSecondaryIndexHelper(entries_list, batch_.get(), GetParam());
+  AssertWBWICountEQWBCount(*batch_);
 }
 
 TEST_P(WriteBatchWithIndexTest, WBWIIteratorImpl) {
@@ -3816,6 +3825,7 @@ TEST_F(WBWIMemTableTest, ReadFromWBWIMemtable) {
     // See comment for WBWIMemTable for sequence number assignment method.
     expected_seqno[idx]++;
   }
+  AssertWBWICountEQWBCount(*wbwi);
   // Get a non-existing key
   found_final_value = false;
   ASSERT_EQ("NOT_FOUND", Get("foo", wbwi_mem, visible_seq, &found_final_value));

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -344,7 +344,6 @@ void AssertIterEqual(WBWIIteratorImpl* wbwii,
 }
 
 void AssertWBWICountEQWBCount(WriteBatchWithIndex& wbwi) {
-  std::cout << wbwi.GetWBWIOpCount() << std::endl;
   ASSERT_EQ(wbwi.GetWBWIOpCount(), wbwi.GetWriteBatch()->Count());
 }
 }  // namespace


### PR DESCRIPTION
Summary: Large txn commit optimization requires all updates are added to a transaction's WriteBatchWithIndex. However, some usage of transactions may add updates directly to the WBWI's underlying write batch. In these cases, we should not attempt to ingest the WBWI since it will drop these updates. This PR adds sanity checking for this.


Test plan:
- added checks in unit test and stress test
- manually check LOG files for the new unit test