### PR TITLE
Add upper bound support for forward scans in MultiScan

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -88,6 +88,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "db/memtable_list.cc",
         "db/merge_helper.cc",
         "db/merge_operator.cc",
+        "db/multi_scan.cc",
         "db/output_validator.cc",
         "db/periodic_task_scheduler.cc",
         "db/range_del_aggregator.cc",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,6 +721,7 @@ set(SOURCES
         db/memtable_list.cc
         db/merge_helper.cc
         db/merge_operator.cc
+        db/multi_scan.cc
         db/output_validator.cc
         db/periodic_task_scheduler.cc
         db/range_del_aggregator.cc

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3823,10 +3823,8 @@ bool DBImpl::KeyMayExist(const ReadOptions& read_options,
 std::unique_ptr<MultiScan> DBImpl::NewMultiScan(
     const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
     const std::vector<ScanOptions>& scan_opts) {
-  std::unique_ptr<Iterator> iter(NewIterator(_read_options, column_family));
-  iter->Prepare(scan_opts);
-  std::unique_ptr<MultiScan> ms_iter =
-      std::make_unique<MultiScan>(scan_opts, std::move(iter));
+  std::unique_ptr<MultiScan> ms_iter = std::make_unique<MultiScan>(
+      _read_options, scan_opts, this, column_family);
   return ms_iter;
 }
 

--- a/db/multi_scan.cc
+++ b/db/multi_scan.cc
@@ -19,6 +19,8 @@ MultiScan::MultiScan(const ReadOptions& read_options,
   if (scan_opts[0].range.limit) {
     upper_bound_ = *scan_opts[0].range.limit;
     read_options_.iterate_upper_bound = &upper_bound_;
+  } else {
+    read_options_.iterate_upper_bound = nullptr;
   }
   for (auto opts : scan_opts) {
     // Check that all the ScanOptions either specify an upper bound or not. If

--- a/db/multi_scan.cc
+++ b/db/multi_scan.cc
@@ -1,0 +1,68 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/db.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+using MultiScanIterator = MultiScan::MultiScanIterator;
+
+MultiScan::MultiScan(const ReadOptions& read_options,
+                     const std::vector<ScanOptions>& scan_opts, DB* db,
+                     ColumnFamilyHandle* cfh)
+    : read_options_(read_options), scan_opts_(scan_opts), db_(db), cfh_(cfh) {
+  bool slow_path = false;
+  // Setup read_options with iterate_uuper_bound based on the first scan.
+  // Subsequent scans will update and allocate a new DB iterator as necessary
+  if (scan_opts[0].range.limit) {
+    upper_bound_ = *scan_opts[0].range.limit;
+    read_options_.iterate_upper_bound = &upper_bound_;
+  }
+  for (auto opts : scan_opts) {
+    // Check that all the ScanOptions either specify an upper bound or not. If
+    // its mixed we take the slow path which avoids calling Prepare: we have to
+    // reallocate the Iterator with updated read_options everytime we switch
+    // between upper bound or no upper bound, which complicates Prepare.
+    if (opts.range.limit.has_value() != scan_opts[0].range.limit.has_value()) {
+      slow_path = true;
+      break;
+    }
+  }
+  db_iter_.reset(db->NewIterator(read_options_, cfh));
+  if (!slow_path) {
+    db_iter_->Prepare(scan_opts);
+  }
+}
+
+MultiScanIterator& MultiScanIterator::operator++() {
+  if (idx_ >= scan_opts_.size()) {
+    throw std::logic_error("Index out of range");
+  }
+  idx_++;
+  if (idx_ < scan_opts_.size()) {
+    // Check if we need to update read_options_
+    if (scan_opts_[idx_].range.limit.has_value() !=
+        (read_options_.iterate_upper_bound != nullptr)) {
+      if (scan_opts_[idx_].range.limit) {
+        *upper_bound_ = *scan_opts_[idx_].range.limit;
+        read_options_.iterate_upper_bound = upper_bound_;
+      } else {
+        read_options_.iterate_upper_bound = nullptr;
+      }
+      db_iter_.reset(db_->NewIterator(read_options_, cfh_));
+      scan_.Reset(db_iter_.get());
+    } else if (scan_opts_[idx_].range.limit) {
+      *upper_bound_ = *scan_opts_[idx_].range.limit;
+    }
+    db_iter_->Seek(*scan_opts_[idx_].range.start);
+    status_ = db_iter_->status();
+    if (!status_.ok()) {
+      throw MultiScanException(status_);
+    }
+  }
+  return *this;
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1094,7 +1094,29 @@ class DB {
   // Get an iterator that scans multiple key ranges. The scan ranges should
   // be in increasing order of start key. See multi_scan_iterator.h for more
   // details. For optimal performance, ensure that either all entries in
-  // scan_opts specify the range limit, or none of them do
+  // scan_opts specify the range limit, or none of them do.
+  //
+  // NOTE: iterate_upper_bound in ReadOptions will be ignored. Instead, the
+  // range.limit in ScanOptions is consulted to determine the upper bound key,
+  // if specified.
+  //
+  // Example usage -
+  //  std::vector<ScanOptions> scans{{.start = Slice("bar")},
+  //                              {.start = Slice("foo")}};
+  //  std::unique_ptr<MultiScan> iter.reset(
+  //                                      db->NewMultiScan());
+  //  try {
+  //    for (auto scan : *iter) {
+  //      for (auto it : scan) {
+  //        // Do something with key - it.first
+  //        // Do something with value - it.second
+  //      }
+  //    }
+  //  } catch (MultiScanException& ex) {
+  //    // Check ex.status()
+  //  } catch (std::logic_error& ex) {
+  //    // Check ex.what()
+  //  }
   virtual std::unique_ptr<MultiScan> NewMultiScan(
       const ReadOptions& /*options*/, ColumnFamilyHandle* /*column_family*/,
       const std::vector<ScanOptions>& /*scan_opts*/) {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -57,6 +57,7 @@ struct WaitForCompactOptions;
 class Env;
 class EventListener;
 class FileSystem;
+class MultiScan;
 class Replayer;
 class StatsHistoryIterator;
 class TraceReader;
@@ -1092,7 +1093,8 @@ class DB {
 
   // Get an iterator that scans multiple key ranges. The scan ranges should
   // be in increasing order of start key. See multi_scan_iterator.h for more
-  // details.
+  // details. For optimal performance, ensure that either all entries in
+  // scan_opts specify the range limit, or none of them do
   virtual std::unique_ptr<MultiScan> NewMultiScan(
       const ReadOptions& /*options*/, ColumnFamilyHandle* /*column_family*/,
       const std::vector<ScanOptions>& /*scan_opts*/) {

--- a/src.mk
+++ b/src.mk
@@ -80,6 +80,7 @@ LIB_SOURCES =                                                   \
   db/memtable_list.cc                                           \
   db/merge_helper.cc                                            \
   db/merge_operator.cc                                          \
+  db/multi_scan.cc						\
   db/output_validator.cc                                        \
   db/periodic_task_scheduler.cc                                 \
   db/range_del_aggregator.cc                                    \

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -7396,6 +7396,7 @@ TEST_F(ExternalTableTest, IngestionTest) {
   ASSERT_OK(db->DestroyColumnFamilyHandle(cfh));
   ASSERT_OK(db->Close());
 }
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/unreleased_history/bug_fixes/multi_scan_upper_bound.md
+++ b/unreleased_history/bug_fixes/multi_scan_upper_bound.md
@@ -1,0 +1,1 @@
+Fix DB::NewMultiScan iterator to respect the scan upper bound specified in ScanOptions


### PR DESCRIPTION
Respect the scan upper bound/limit, if specified, in `MultiScan`. This applies to block based table and other native RocksDB SSTs. In order to properly support it, the `MultiScan` object caches the `ReadOptions` passed by the user and sets the `iterate_upper_bound` as appropriate. We optimize for the case of either all scans specifying the upper bound, or none of them. In case of mixed scans, we reallocate the DB iterator anytime `ReadOptions` has to be updated.

Tests:
New unit tests in `db_iterator_test`