### PR TITLE
User defined index builder

### DIFF
--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -44,6 +44,7 @@ class TableReader;
 class WritableFileWriter;
 struct ConfigOptions;
 struct EnvOptions;
+class UserDefinedIndexFactory;
 
 // Types of checksums to use for checking integrity of logical blocks within
 // files. All checksums currently use 32 bits of checking power (1 in 4B
@@ -492,7 +493,15 @@ struct BlockBasedTableOptions {
   // Because filters only impact performance and are not data-critical, an
   // SST file can be opened and used without filters if (a) the filter
   // policy name or schema is unrecognized, or (b) filter_policy is nullptr.
+  // See filter_policy regarding filters.
   std::shared_ptr<const FilterPolicy> filter_policy = nullptr;
+
+  // EXPERIMENTAL
+  //
+  // If non-nullptr, use the specified factory to build user-defined index.
+  // This allows users to define their own index format and build the index
+  // during table building.
+  std::shared_ptr<UserDefinedIndexFactory> user_defined_index_factory = nullptr;
 
   // If true, place whole keys in the filter (not just prefixes).
   // This must generally be true for gets to be efficient.

--- a/include/rocksdb/user_defined_index.h
+++ b/include/rocksdb/user_defined_index.h
@@ -1,0 +1,88 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+//  *****************************************************************
+//  EXPERIMENTAL - subject to change while under development
+//  *****************************************************************
+
+#pragma once
+
+#include <string>
+
+#include "rocksdb/customizable.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Prefix for user-defined index block names
+inline const std::string kUserDefinedIndexPrefix =
+    "rocksdb.user_defined_index.";
+
+// This is a public API for user-defined index builders.
+// It allows users to define their own index format and build custom
+// indexes during table building.
+
+// The interface for building user-defined index.
+class UserDefinedIndexBuilder {
+ public:
+  // Right now, we only support Puts. In the future, we may support merges,
+  // deletions etc.
+  enum ValueType {
+    kValue,
+    kTypeMax,
+  };
+
+  // File offset and size of the data block
+  struct BlockHandle {
+    uint64_t offset;
+    uint64_t size;
+  };
+
+  virtual ~UserDefinedIndexBuilder() = default;
+
+  // Add a new index entry to index block. The key for the new index entry
+  // should be >= last_key_in_current_block and < first_key_in_next_block.
+  // The previous index entry key and the new index entry key cover
+  // all the keys in the data block associated with the new index entry.
+  //
+  // Called before the OnKeyAdded() call for first_key_in_next_block.
+  // @last_key_in_current_block: The last key in the current data block
+  // @first_key_in_next_block: it will be nullptr if the entry being added is
+  //                           the last one in the table
+  // @separator_scratch: a scratch buffer to back a computed separator between
+  //                     those, as needed. May be modified on each call.
+  // @return: the key or separator stored in the index, which could be
+  //          last_key_in_current_block or a computed separator backed by
+  //          separator_scratch.
+  virtual Slice AddIndexEntry(const Slice& last_key_in_current_block,
+                              const Slice* first_key_in_next_block,
+                              const BlockHandle& block_handle,
+                              std::string* separator_scratch) = 0;
+
+  // This method will be called whenever a key is added. The subclasses may
+  // override OnKeyAdded() if they need to collect additional information.
+  // The type argument indicates whether the value is a full value or partial.
+  // At the moment, only full values are supported.
+  virtual void OnKeyAdded(const Slice& /*key*/, ValueType /*type*/,
+                          const Slice& /*value*/) {}
+
+  // Finish building the index.
+  // Returns a Status and the serialized index contents.
+  // The memory backing the contents should not be freed until this builder
+  // object is destructed.
+  virtual Status Finish(Slice* index_contents) = 0;
+};
+
+// Factory for creating user-defined index builders.
+class UserDefinedIndexFactory : public Customizable {
+ public:
+  virtual ~UserDefinedIndexFactory() = default;
+
+  // Create a new builder for user-defined index.
+  virtual UserDefinedIndexBuilder* NewBuilder() const = 0;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -129,6 +129,8 @@ TEST_F(OptionsSettableTest, BlockBasedTableOptionsAllFieldsSettable) {
        sizeof(CacheUsageOptions)},
       {offsetof(struct BlockBasedTableOptions, filter_policy),
        sizeof(std::shared_ptr<const FilterPolicy>)},
+      {offsetof(struct BlockBasedTableOptions, user_defined_index_factory),
+       sizeof(std::shared_ptr<UserDefinedIndexFactory>)},
   };
 
   // In this test, we catch a new option of BlockBasedTableOptions that is not

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -690,6 +690,12 @@ Status BlockBasedTableFactory::ValidateOptions(
         "data_block_hash_table_util_ratio should be greater than 0 when "
         "data_block_index_type is set to kDataBlockBinaryAndHash");
   }
+  if (table_options_.user_defined_index_factory &&
+      (cf_opts.compression_opts.parallel_threads > 1 ||
+       cf_opts.bottommost_compression_opts.parallel_threads > 1)) {
+    return Status::InvalidArgument(
+        "user_defined_index_factory not supported with parallel compression");
+  }
   if (db_opts.unordered_write && cf_opts.max_successive_merges > 0) {
     // TODO(myabandeh): support it
     return Status::InvalidArgument(

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -46,6 +46,7 @@
 #include "rocksdb/table.h"
 #include "rocksdb/table_properties.h"
 #include "rocksdb/trace_record.h"
+#include "rocksdb/user_defined_index.h"
 #include "table/block_based/binary_search_index_reader.h"
 #include "table/block_based/block.h"
 #include "table/block_based/block_based_table_factory.h"
@@ -2745,6 +2746,10 @@ BlockType BlockBasedTable::GetBlockTypeForMetaBlockByName(
 
   if (meta_block_name == kIndexBlockName) {
     return BlockType::kIndex;
+  }
+
+  if (meta_block_name.starts_with(kUserDefinedIndexPrefix)) {
+    return BlockType::kUserDefinedIndex;
   }
 
   if (meta_block_name.starts_with(kObsoleteFilterBlockPrefix)) {

--- a/table/block_based/block_type.h
+++ b/table/block_based/block_type.h
@@ -27,6 +27,7 @@ enum class BlockType : uint8_t {
   kHashIndexMetadata,
   kMetaIndex,
   kIndex,
+  kUserDefinedIndex,
   // Note: keep kInvalid the last value when adding new enum values.
   kInvalid
 };

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -1,0 +1,126 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "rocksdb/user_defined_index.h"
+#include "table/block_based/block_type.h"
+#include "table/block_based/index_builder.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// UserDefinedIndexWrapper wraps around the existing index types in block based
+// table, and supports plugging in an additional user defined index. The wrapper
+// class forwards calls to both the wrapped internal index, and a user defined
+// index builder.
+class UserDefinedIndexBuilderWrapper : public IndexBuilder {
+ public:
+  UserDefinedIndexBuilderWrapper(
+      const std::string& name,
+      std::unique_ptr<IndexBuilder> internal_index_builder,
+      std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder,
+      const InternalKeyComparator* comparator, size_t ts_sz,
+      bool persist_user_defined_timestamps)
+      : IndexBuilder(comparator, ts_sz, persist_user_defined_timestamps),
+        name_(name),
+        internal_index_builder_(std::move(internal_index_builder)),
+        user_defined_index_builder_(std::move(user_defined_index_builder)) {}
+
+  // Note: We don't provide a simplified constructor that tries to extract
+  // parameters from internal_index_builder because IndexBuilder's members are
+  // protected and there are no accessor methods to get them
+
+  ~UserDefinedIndexBuilderWrapper() override = default;
+
+  Slice AddIndexEntry(const Slice& last_key_in_current_block,
+                      const Slice* first_key_in_next_block,
+                      const BlockHandle& block_handle,
+                      std::string* separator_scratch) override {
+    UserDefinedIndexBuilder::BlockHandle handle;
+    handle.offset = block_handle.offset();
+    handle.size = block_handle.size();
+    // Forward the call to both index builders
+    user_defined_index_builder_->AddIndexEntry(last_key_in_current_block,
+                                               first_key_in_next_block, handle,
+                                               separator_scratch);
+    return internal_index_builder_->AddIndexEntry(
+        last_key_in_current_block, first_key_in_next_block, block_handle,
+        separator_scratch);
+  }
+
+  void OnKeyAdded(const Slice& key,
+                  const std::optional<Slice>& value) override {
+    if (status_.ok()) {
+      if (!value.has_value()) {
+        status_ = Status::InvalidArgument(
+            "user_defined_index_factory not supported with parallel "
+            "compression");
+      } else {
+        ParsedInternalKey pkey;
+        status_ = ParseInternalKey(key, &pkey, /*lof_err_key*/ false);
+        if (status_.ok() && pkey.type != ValueType::kTypeValue) {
+          status_ = Status::InvalidArgument(
+              "user_defined_index_factory only supported with Puts");
+        }
+      }
+    }
+    if (!status_.ok()) {
+      return;
+    }
+
+    // Forward the call to both index builders
+    internal_index_builder_->OnKeyAdded(key, value);
+    user_defined_index_builder_->OnKeyAdded(
+        key, UserDefinedIndexBuilder::ValueType::kValue, value.value());
+  }
+
+  Status Finish(IndexBlocks* index_blocks,
+                const BlockHandle& last_partition_block_handle) override {
+    if (!status_.ok()) {
+      return status_;
+    }
+
+    // Finish the internal index builder
+    status_ = internal_index_builder_->Finish(index_blocks,
+                                              last_partition_block_handle);
+    if (!status_.ok()) {
+      return status_;
+    }
+
+    // Finish the user defined index builder
+    Slice user_index_contents;
+    status_ = user_defined_index_builder_->Finish(&user_index_contents);
+    if (!status_.ok()) {
+      return status_;
+    }
+
+    // Add the user defined index to the meta blocks
+    std::string block_name = kUserDefinedIndexPrefix + name_;
+    index_blocks->meta_blocks.insert(
+        {block_name, {BlockType::kUserDefinedIndex, user_index_contents}});
+
+    index_size_ = internal_index_builder_->IndexSize();
+    return status_;
+  }
+
+  size_t IndexSize() const override { return index_size_; }
+
+  bool seperator_is_key_plus_seq() override {
+    return internal_index_builder_->seperator_is_key_plus_seq();
+  }
+
+ private:
+  const std::string name_;
+  std::unique_ptr<IndexBuilder> internal_index_builder_;
+  std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder_;
+  Status status_;
+};
+}  // namespace ROCKSDB_NAMESPACE

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -303,7 +303,7 @@ class ExternalTableBuilderAdapter : public TableBuilder {
         properties_.num_entries++;
         properties_.raw_key_size += key.size();
         properties_.raw_value_size += value.size();
-        NotifyCollectTableCollectorsOnAdd(key, value, /*offset=*/0,
+        NotifyCollectTableCollectorsOnAdd(key, value, /*file_size=*/0,
                                           table_properties_collectors_,
                                           ioptions_.logger);
       }

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -472,6 +472,7 @@ Status SstFileWriter::Finish(ExternalSstFileInfo* file_info) {
   }
   if (r->file_info.num_entries == 0 &&
       r->file_info.num_range_del_entries == 0) {
+    r->builder->status().PermitUncheckedError();
     return Status::InvalidArgument("Cannot create sst file with no entries");
   }
 
@@ -495,7 +496,10 @@ Status SstFileWriter::Finish(ExternalSstFileInfo* file_info) {
         r->file_writer->GetFileChecksumFuncName();
   }
   if (!s.ok()) {
-    r->ioptions.env->DeleteFile(r->file_info.file_path);
+    Status status = r->ioptions.env->DeleteFile(r->file_info.file_path);
+    // Silence ASSERT_STATUS_CHECKED warning
+    assert(status.ok());
+    ;
   }
 
   if (file_info != nullptr) {


### PR DESCRIPTION
Summary:
Add UserDefinedIndexFactory and UserDefinedIndexBuilder interfaces to allow users to plugin custom index implementation into block based table. The factory is specified in BlockBasedTableOptions. If non-null, BlockBasedTableBuilder allocates a wrapper index builder encapsulating the native index and the custom index. The custom index is exposed to BlockBasedTableBuilder as a meta_block of type kUserDefinedIndex. This block type is not compressed.

The IndexBuilder OnKeyAdded interface is enhanced to accept the value in addition to the key. Only full values are supported, and parallel compression is not supported since we cannot obtain the value when calling OnKeyAdded.

Differential Revision: D76165614


