### PR TITLE
Fix unused parameter warning when Snappy is disabled

### DIFF
--- a/util/compression.cc
+++ b/util/compression.cc
@@ -693,6 +693,7 @@ class BuiltinDecompressorV2SnappyOnly : public BuiltinDecompressorV2 {
     args.uncompressed_size = uncompressed_length;
     return Status::OK();
 #else
+    (void)args;
     return Status::NotSupported("Snappy not supported in this build");
 #endif
   }


### PR DESCRIPTION
Fixed a compilation warning in `BuiltinDecompressorV2SnappyOnly::ExtractUncompressedSize` method. When building without Snappy support, `args` is unused and causing compile error.