### PR TITLE
Remove the 2 duplicated fields in block.h Block class

### DIFF
--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -163,8 +163,8 @@ class Block {
 
   ~Block();
 
-  size_t size() const { return size_; }
-  const char* data() const { return data_; }
+  size_t size() const { return contents_.data.size(); }
+  const char* data() const { return contents_.data.data(); }
   // The additional memory space taken by the block data.
   size_t usable_size() const { return contents_.usable_size(); }
   uint32_t NumRestarts() const;
@@ -277,8 +277,6 @@ class Block {
 
  private:
   BlockContents contents_;
-  const char* data_;         // contents_.data.data()
-  size_t size_;              // contents_.data.size()
   uint32_t restart_offset_;  // Offset in data_ of restart array
   uint32_t num_restarts_;
   std::unique_ptr<BlockReadAmpBitmap> read_amp_bitmap_;


### PR DESCRIPTION
Summary:
`data_` and `size_` fields are duplicated in `Block` class, as `contents_` field already have a `data` member variable, which contains `data` and `size` already. This reduces memory consumption by 16 bytes per block.

Test Plan:

Unit test

Reviewers:

Subscribers:

Tasks:

Tags: