### PR TITLE
Removing typo sss in spelling of the compression

### DIFF
--- a/util/compression_test.cc
+++ b/util/compression_test.cc
@@ -293,10 +293,10 @@ class CostAwareTestFlushBlockPolicyFactory : public FlushBlockPolicyFactory {
  private:
   int window_;
 };
-class DBCompresssionCostPredictor : public DBTestBase {
+class DBCompressionCostPredictor : public DBTestBase {
  public:
   Options options;
-  DBCompresssionCostPredictor()
+  DBCompressionCostPredictor()
       : DBTestBase("db_cpuio_skip", /*env_do_fsync=*/true),
         options(CurrentOptions()) {
     options.compression_manager = CreateCostAwareCompressionManager();
@@ -311,7 +311,7 @@ class DBCompresssionCostPredictor : public DBTestBase {
     DestroyAndReopen(options);
   }
 };
-TEST_F(DBCompresssionCostPredictor, CostAwareCompressorManager) {
+TEST_F(DBCompressionCostPredictor, CostAwareCompressorManager) {
   // making sure that the compression is supported
   if (!ZSTD_Supported()) {
     return;


### PR DESCRIPTION
Summary:
Corrected misspelling of "Compression". Changed "Compresssion" to "Compression".

Test Plan:
All the test case for compression is still working properly.
```bash
./compression_test
```