### PR TITLE
Fix nightly build failure because preferred compression type was kNoCompression.

### DIFF
--- a/util/auto_tune_compressor.cc
+++ b/util/auto_tune_compressor.cc
@@ -294,7 +294,6 @@ std::unique_ptr<Compressor> CostAwareCompressorManager::GetCompressorForSST(
     const FilterBuildingContext& context, const CompressionOptions& opts,
     CompressionType preferred) {
   assert(GetSupportedCompressions().size() > 1);
-  assert(preferred != kNoCompression);
   (void)context;
   (void)preferred;
   return std::make_unique<CostAwareCompressor>(opts);


### PR DESCRIPTION
Summary:
CostAwareCompressor simply ignores the preferred compression type as compression manager setting takes precedence over the compression type setting. Thus, I am removing the assert statement as it itself is unnecessary for this case.

Test Plan:
Run nightly build test
```bash
make V=1 J=4 -j4 check
```