### PR TITLE
Add support for musl libc builds of RocksJava on RISC-V 64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2353,6 +2353,10 @@ rocksdbjavastaticdockers390xmusl:
 	mkdir -p java/target
 	docker run --rm --name rocksdb_linux_s390x-musl-be --platform linux/s390x --attach stdin --attach stdout --attach stderr --volume $(HOME)/.m2:/root/.m2:ro --volume `pwd`:/rocksdb-host:ro --volume /rocksdb-local-build --volume `pwd`/java/target:/rocksdb-java-target --env DEBUG_LEVEL=$(DEBUG_LEVEL) --env J=$(J) evolvedbinary/rocksjava:alpine3_s390x-be /rocksdb-host/java/crossbuild/docker-build-linux.sh
 
+rocksdbjavastaticdockerriscv64musl:
+	mkdir -p java/target
+	docker run --rm --name rocksdb_linux_riscv64-musl-be --platform linux/riscv64 --attach stdin --attach stdout --attach stderr --volume $(HOME)/.m2:/root/.m2:ro --volume `pwd`:/rocksdb-host:ro --volume /rocksdb-local-build --volume `pwd`/java/target:/rocksdb-java-target --env DEBUG_LEVEL=$(DEBUG_LEVEL) --env J=$(J) evolvedbinary/rocksjava:alpine3_riscv64-be /rocksdb-host/java/crossbuild/docker-build-linux.sh
+
 rocksdbjavastaticpublish: rocksdbjavastaticrelease rocksdbjavastaticpublishcentral
 
 rocksdbjavastaticpublishdocker: rocksdbjavastaticreleasedocker rocksdbjavastaticpublishcentral


### PR DESCRIPTION
We can now build releases of RocksJava for RISC-V 64 linux targeting musl libc, previously we only targeted glibc on RISC-V 64.