### PR TITLE
Remote Compaction support TTL table

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2566,6 +2566,11 @@ struct CompactionServiceOptionsOverride {
 
   // All other options to override. Unknown options will be ignored.
   std::unordered_map<std::string, std::string> options_map;
+
+  // Enables TTL table feature when set to a non-nullopt value.
+  // When enabled, `DBWithTTLImpl::SanitizeOptions` will be invoked
+  // to reset compaction_filter and merge_operator.
+  std::optional<int32_t> ttl = std::nullopt;
 };
 
 struct OpenAndCompactOptions {


### PR DESCRIPTION
I intentionally avoided calling `DBWithTTL::Open` or instantiating new `DBWithTTLImpl` because the subsequent logic converts them into `DBImplSecondary*` instances. 

It seems that remote-compaction does not call `Put`, `Get` and other interfaces

May I confirm if this architectural approach is acceptable? 

Thanks !
