### PR TITLE
Change GetWaitingTxns() to return blocking lock on timeout

### DIFF
--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -421,6 +421,11 @@ struct TransactionOptions {
   //
   // Default: 0 (disabled).
   uint64_t large_txn_commit_optimize_byte_threshold = 0;
+
+  // EXPERIMENTAL, SUBJECT TO CHANGE
+  // Determines if we update waiting transaction information on timeout so
+  // GetWaitingTxns() returns non-zero values
+  bool enable_get_waiting_txn_after_timeout = false;
 };
 
 // The per-write optimizations that do not involve transactions. TransactionDB

--- a/utilities/transactions/lock/point/point_lock_manager.cc
+++ b/utilities/transactions/lock/point/point_lock_manager.cc
@@ -355,6 +355,9 @@ Status PointLockManager::AcquireWithTimeout(
       result = AcquireLocked(lock_map, stripe, key, env, lock_info,
                              &expire_time_hint, &wait_ids);
     } while (!result.ok() && !timed_out);
+    if (txn->EnableGetWaitingTxnAfterTimeout() && timed_out && !result.ok()) {
+      txn->SetWaitingTxn(wait_ids, column_family_id, &key, true);
+    }
   }
 
   stripe->stripe_mutex->UnLock();

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -50,6 +50,7 @@ PessimisticTransaction::PessimisticTransaction(
       lock_timeout_(0),
       deadlock_detect_(false),
       deadlock_detect_depth_(0),
+      enable_get_waiting_txn_after_timeout_(false),
       skip_concurrency_control_(false) {
   txn_db_impl_ = static_cast_with_check<PessimisticTransactionDB>(txn_db);
   db_impl_ = static_cast_with_check<DBImpl>(db_);
@@ -72,6 +73,7 @@ void PessimisticTransaction::Initialize(const TransactionOptions& txn_options) {
 
   deadlock_detect_ = txn_options.deadlock_detect;
   deadlock_detect_depth_ = txn_options.deadlock_detect_depth;
+  enable_get_waiting_txn_after_timeout_ = txn_options.enable_get_waiting_txn_after_timeout;
   write_batch_.SetMaxBytes(txn_options.max_write_batch_size);
   write_batch_.GetWriteBatch()->SetTrackTimestampSize(
       txn_options.write_batch_track_timestamp_size);


### PR DESCRIPTION
Summary:
While a transaction is waiting on a lock, we can use GetWaitingTxns() to determine the transactionID of the blocking transaction and the contended key. However, this gets cleared when the lock times out. So if a client has widespread timeout errors, you need to catch a transaction 'in the act' before they actually hit the timeout in order to understand the contention pattern. This diff adds a new TransactionOptions variable enable_get_waiting_txn_after_timeout, which persists the lock contention information after timeout so it can be accessed by the client after they have received the timeout error.

Test Plan:
- updated TransactionTest.WaitingTxn to test the changed behavior
- ran production shadow tests on traffic with frequent timeouts

Reviewers:
cbi42

Subscribers:

Tasks:

Tags: