### PR TITLE
[RFC] IOExecutor Class for Prefetch Management

### DIFF
--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -98,7 +98,8 @@ class ArenaWrappedDBIter : public Iterator {
 
   bool PrepareValue() override { return db_iter_->PrepareValue(); }
 
-  void Prepare(const std::vector<ScanOptions>& scan_opts) override {
+  void Prepare(const std::vector<ScanOptions>& scan_opts,
+               [[maybe_unused]] IOExecutor* io_executor) override {
     db_iter_->Prepare(scan_opts);
   }
 

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -15,6 +15,7 @@
 #include "memory/arena.h"
 #include "options/cf_options.h"
 #include "rocksdb/db.h"
+#include "rocksdb/io_executor.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/wide_columns.h"
 #include "table/iterator_wrapper.h"
@@ -240,7 +241,8 @@ class DBIter final : public Iterator {
 
   bool PrepareValue() override;
 
-  void Prepare(const std::vector<ScanOptions>& scan_opts) override {
+  void Prepare(const std::vector<ScanOptions>& scan_opts,
+               [[maybe_unused]] IOExecutor* io_executor = nullptr) override {
     std::optional<std::vector<ScanOptions>> new_scan_opts;
     new_scan_opts.emplace(scan_opts);
     scan_opts_.swap(new_scan_opts);

--- a/include/rocksdb/io_executor.h
+++ b/include/rocksdb/io_executor.h
@@ -1,0 +1,25 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+// IOExecutor controls the execution of async IO operations. It is used to
+// control the amount specific operation (i.e., scans) prefetch.
+#pragma once
+
+#include <cstddef>
+
+namespace ROCKSDB_NAMESPACE {
+
+class IOExecutor {
+ public:
+  IOExecutor(size_t max_inflight_bytes, size_t max_inflight_ops)
+      : max_inflight_ops_(max_inflight_ops),
+        max_bytes_inflight_(max_inflight_bytes) {}
+
+ private:
+  size_t max_inflight_ops_;
+  size_t max_bytes_inflight_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -107,7 +107,7 @@ class Iterator : public IteratorBase {
   // If Prepare() is called, it overrides the iterate_upper_bound in
   // ReadOptions
   virtual void Prepare(const std::vector<ScanOptions>& /*scan_opts*/,
-                       IOExecutor* /*io_executor*/) {}
+                       [[maybe_unused]] IOExecutor* io_executor = nullptr) {}
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -20,6 +20,7 @@
 
 #include <string>
 
+#include "rocksdb/io_executor.h"
 #include "rocksdb/iterator_base.h"
 #include "rocksdb/options.h"
 #include "rocksdb/wide_columns.h"
@@ -105,7 +106,8 @@ class Iterator : public IteratorBase {
   // call Prepare().
   // If Prepare() is called, it overrides the iterate_upper_bound in
   // ReadOptions
-  virtual void Prepare(const std::vector<ScanOptions>& /*scan_opts*/) {}
+  virtual void Prepare(const std::vector<ScanOptions>& /*scan_opts*/,
+                       IOExecutor* /*io_executor*/) {}
 };
 
 // Return an empty iterator (yields nothing).


### PR DESCRIPTION
With the introduction of the MultiScan API, comes the problem of managing how much we prefetch at a given time.

Without restriction a large enough MultiScan could cause large amounts of memory bloat and possibly OOM users. Users require some ability to control how prefetching and specifically their IO's are dispatched.

I suggest the creation and usage of an IOExecutor class in which iterators will submit jobs (i.e., blocks) for the executor to dispatch and prefetch on their behalf, allowing for scans to be properly boxed. The IOExecutor will further keep track of completed jobs etc that can be queries by callers.