### PR TITLE
Track FSRandomRWFile open/close in Fault injection fs

### DIFF
--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -106,8 +106,8 @@ class TestFSWritableFile : public FSWritableFile {
   const bool unsync_data_loss_;
 };
 
-// A wrapper around WritableFileWriter* file
-// is written to or sync'ed.
+// A wrapper around FSRandomRWFile* file
+// is read from/write to or sync'ed.
 class TestFSRandomRWFile : public FSRandomRWFile {
  public:
   explicit TestFSRandomRWFile(const std::string& fname,
@@ -128,6 +128,9 @@ class TestFSRandomRWFile : public FSRandomRWFile {
   bool use_direct_io() const override { return target_->use_direct_io(); }
 
  private:
+  // keep a copy of file name, so we can untrack it in File system, when it is
+  // closed
+  std::string fname_;
   std::unique_ptr<FSRandomRWFile> target_;
   bool file_opened_;
   FaultInjectionTestFS* fs_;
@@ -340,6 +343,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   void WritableFileSynced(const FSFileState& state);
 
   void WritableFileAppended(const FSFileState& state);
+
+  void RandomRWFileClosed(const std::string& fname);
 
   IOStatus DropUnsyncedFileData();
 


### PR DESCRIPTION
Summary:
The Stress test was broken due to a change in switching from ReopenWritableFile to FSRandomRWFile for sync linked file in external Sst ingestion job. The Stress test is using FaultInjectionFs, which tracks the opening of ReopenWritableFile properly, but does not track FSRandomRWFile properly. This change fixes the tracking of FSRandomRWFile in FaultInjectionFs.

Test Plan:

unit test, stress test

Reviewers:

Subscribers:

Tasks:

Tags: