### PR TITLE
fix: handle pending async requests correctly during abortIO with async_io enabled

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1074,6 +1074,29 @@ class PosixFileSystem : public FileSystem {
       return false;
     }
   }
+
+  void HandleFinishedIO(struct io_uring_cqe* cqe, Posix_IOHandle* posix_handle) {
+    FSReadRequest req;
+    req.scratch = posix_handle->scratch;
+    req.offset = posix_handle->offset;
+    req.len = posix_handle->len;
+
+    size_t finished_len = 0;
+    size_t bytes_read = 0;
+    bool read_again = false;
+    UpdateResult(cqe, "", req.len, posix_handle->iov.iov_len,
+                  true /*async_read*/, posix_handle->use_direct_io,
+                  posix_handle->alignment, finished_len, &req, bytes_read,
+                  read_again);
+    posix_handle->is_finished = true;
+    // Reset cqe data to catch any stray reuse of it
+    static_cast<struct io_uring_cqe*>(cqe)->user_data = 0xd5d5d5d5d5d5d5d5;
+    io_uring_cqe_seen(posix_handle->iu, cqe);
+    posix_handle->cb(req, posix_handle->cb_arg);
+    (void)finished_len;
+    (void)bytes_read;
+    (void)read_again;
+  }
 #endif  // ROCKSDB_IOURING_PRESENT
 
   // TODO:
@@ -1120,28 +1143,7 @@ class PosixFileSystem : public FileSystem {
         if (posix_handle->iu != iu) {
           return IOStatus::IOError("");
         }
-        // Reset cqe data to catch any stray reuse of it
-        static_cast<struct io_uring_cqe*>(cqe)->user_data = 0xd5d5d5d5d5d5d5d5;
-
-        FSReadRequest req;
-        req.scratch = posix_handle->scratch;
-        req.offset = posix_handle->offset;
-        req.len = posix_handle->len;
-
-        size_t finished_len = 0;
-        size_t bytes_read = 0;
-        bool read_again = false;
-        UpdateResult(cqe, "", req.len, posix_handle->iov.iov_len,
-                     true /*async_read*/, posix_handle->use_direct_io,
-                     posix_handle->alignment, finished_len, &req, bytes_read,
-                     read_again);
-        posix_handle->is_finished = true;
-        io_uring_cqe_seen(iu, cqe);
-        posix_handle->cb(req, posix_handle->cb_arg);
-
-        (void)finished_len;
-        (void)bytes_read;
-        (void)read_again;
+        HandleFinishedIO(cqe, posix_handle);
 
         if (static_cast<Posix_IOHandle*>(io_handles[i]) == posix_handle) {
           break;
@@ -1198,6 +1200,8 @@ class PosixFileSystem : public FileSystem {
         return IOStatus::IOError("io_uring_submit() requested but returned " +
                                  std::to_string(ret));
       }
+      // Set the flag to indicate that the request is aborted.
+      posix_handle->is_aborted = true;
     }
 
     // After submitting the requests, wait for the requests.
@@ -1223,8 +1227,13 @@ class PosixFileSystem : public FileSystem {
         if (posix_handle->iu != iu) {
           return IOStatus::IOError("");
         }
-        posix_handle->req_count++;
 
+        // If the request is not aborted, it means the request is completed successfully.
+        if (!posix_handle->is_aborted) {
+          HandleFinishedIO(cqe, posix_handle);
+          continue;
+        }
+        posix_handle->req_count++;
         // Reset cqe data to catch any stray reuse of it
         static_cast<struct io_uring_cqe*>(cqe)->user_data = 0xd5d5d5d5d5d5d5d5;
         io_uring_cqe_seen(iu, cqe);
@@ -1240,14 +1249,15 @@ class PosixFileSystem : public FileSystem {
         //
         // Every handle has to wait for 2 requests completion: original one and
         // the cancel request which is tracked by PosixHandle::req_count.
-        if (posix_handle->req_count == 2 &&
-            static_cast<Posix_IOHandle*>(io_handles[i]) == posix_handle) {
+        if (posix_handle->req_count == 2) {
+          // io_uring cancel requests return out of order
           posix_handle->is_finished = true;
           FSReadRequest req;
           req.status = IOStatus::Aborted();
           posix_handle->cb(req, posix_handle->cb_arg);
-
-          break;
+          if (static_cast<Posix_IOHandle*>(io_handles[i]) == posix_handle) {
+            break;
+          }
         }
       }
     }

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -117,6 +117,7 @@ struct Posix_IOHandle {
         use_direct_io(_use_direct_io),
         alignment(_alignment),
         is_finished(false),
+        is_aborted(false),
         req_count(0) {}
 
   struct iovec iov;
@@ -130,6 +131,7 @@ struct Posix_IOHandle {
   size_t alignment;
   bool is_finished;
   // req_count is used by AbortIO API to keep track of number of requests.
+  bool is_aborted;
   uint32_t req_count;
 };
 


### PR DESCRIPTION
    When async_io is enabled, invoking abortIO may leave pending asynchronous requests
    unprocessed, leading to the inability to handle subsequent normal requests. This can
    ultimately result in thread blocking.
    
    This commit ensures that new requests are properly scheduled and processed even
    during or after an abortIO operation, preventing potential deadlocks or stalls.

Example:
1. In MergingIterator, iterators exist for level0, level1, and level2, and prefetching is enabled for all levels. However, none of the prefetched data has been polled yet.
2. A `Next()` call is made on level0, which triggers switching to the next SST file. This results in deletion of the `file_prefetch_buffer`, which in turn invokes `abortIO`.
3. The async prefetch operations in level1 are silently canceled without proper handling during abortIO, leaving their state inconsistent.
4. When level1 later attempts to retrieve data via `poll()` during its own `Next()` call, it blocks indefinitely due to the incomplete or unhandled cancellation, potentially causing the entire iterator to stall.

Test:

fill data:
``
./db_bench -db=/tmp/my_db -benchmarks="fillseqdeterministic" -key_size=32 -value_size=512 -num=5000000 -num_levels=4 -multiread_batched=true -use_direct_reads=false -adaptive_readahead=true -threads=1 -async_io=false -multiread_stride=40000 -disable_auto_compactions=true -compaction_style=1 -bloom_bits=10
``

read data: seek with next 

``
./db_bench -use_existing_db=true -db=/tmp/my_db -benchmarks="seekrandom" -key_size=32 -value_size=512 -num=5000000 -batch_size=8 -multiread_batched=true -use_direct_reads=true -reads=1000 -ops_between_duration_checks=1 -readonly=true -threads=1 -cache_size=0 -async_io=true -multiread_stride=10000 -statistics -adaptive_readahead=true -bloom_bits=10 -seek_nexts=10000
``

