### PR TITLE
Compression API clairifcations/minor fixes

### DIFF
--- a/table/block_based/block_builder.cc
+++ b/table/block_based/block_builder.cc
@@ -21,15 +21,19 @@
 // An entry for a particular key-value pair has the form:
 //     shared_bytes: varint32
 //     unshared_bytes: varint32
-//     value_length: varint32
+//     value_length: varint32 (NOTE1)
 //     key_delta: char[unshared_bytes]
 //     value: char[value_length]
-// shared_bytes == 0 for restart points.
+// shared_bytes == 0 (explicitly stored) for restart points.
 //
 // The trailer of the block has the form:
 //     restarts: uint32[num_restarts]
 //     num_restarts: uint32
 // restarts[i] contains the offset within the block of the ith restart point.
+//
+// NOTE1: omitted for format_version >= 4 index blocks, because the value is
+// composed of one (shared_bytes > 0) or two (shared_bytes == 0) varints, whose
+// length is self-describing.
 
 #include "table/block_based/block_builder.h"
 

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -746,6 +746,8 @@ class BuiltinDecompressorV2WithDict : public BuiltinDecompressorV2 {
 
 Status BuiltinDecompressorV2::MaybeCloneForDict(
     const Slice& dict, std::unique_ptr<Decompressor>* out) {
+  // Check RocksDB-promised precondition
+  assert(dict.size() > 0);
   // Because of unfortunate decisions in handling built-in compression types,
   // all the compression types before ZSTD that do not actually support
   // dictionary compression pretend to support it. Specifically, we have to be

--- a/util/compression_test.cc
+++ b/util/compression_test.cc
@@ -1124,6 +1124,27 @@ TEST_F(DBCompressionTest, CompressionManagerWrapper) {
                                        out_compression_type, working_area);
       }
     }
+
+    // Also check WorkingArea handling
+    struct MyWorkingArea : public WorkingArea {
+      MyWorkingArea(ManagedWorkingArea&& wrapped)
+          : wrapped_(std::move(wrapped)) {}
+      ManagedWorkingArea wrapped_;
+    };
+    ManagedWorkingArea ObtainWorkingArea() override {
+      ManagedWorkingArea rv{
+          new MyWorkingArea{CompressorWrapper::ObtainWorkingArea()}, this};
+      if (GetPreferredCompressionType() == kZSTD) {
+        // ZSTD should always use WorkingArea, so this is our chance to ensure
+        // CompressorWrapper::ObtainWorkingArea() is properly connected
+        assert(rv.get() != nullptr);
+      }
+      return rv;
+    };
+
+    void ReleaseWorkingArea(WorkingArea* wa) override {
+      delete static_cast<MyWorkingArea*>(wa);
+    }
   };
   struct MyManager : public CompressionManagerWrapper {
     using CompressionManagerWrapper::CompressionManagerWrapper;


### PR DESCRIPTION
Summary:
* A number of comments clarifying contracts, etc.
* Make ReleaseWorkingArea public instead of protected because there are some limited cases where a wrapper implementation might want to call it directly
* Check non-empty dictionary precondition on MaybeCloneForDict
* Expand testing of wrapped WorkingAreas
* Random documentation improvement in block_builder.cc

Test Plan: existing and expanded tests and assertions