### PR TITLE
Fix DeleteFile error handling in SstFileWriter::Finish

### DIFF
--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -497,9 +497,9 @@ Status SstFileWriter::Finish(ExternalSstFileInfo* file_info) {
   }
   if (!s.ok()) {
     Status status = r->ioptions.env->DeleteFile(r->file_info.file_path);
-    // Silence ASSERT_STATUS_CHECKED warning
-    assert(status.ok());
-    ;
+    // Silence ASSERT_STATUS_CHECKED warning, since DeleteFile may fail under
+    // some error injection, and we can just ignore the failure
+    status.PermitUncheckedError();
   }
 
   if (file_info != nullptr) {


### PR DESCRIPTION
In SstFileWriter::Finish, the call to DeleteFile to delete the output file in case of an error may fail. The current behavior is to ignore the error. In stress tests, there may be expected failures due to error injection. Not acting on the return status will cause the ASSERT_STATUS_CHECKED test to fail, so silence it.