### PR TITLE
Upgrade Maven to 3.9.11

### DIFF
--- a/.github/actions/install-maven/action.yml
+++ b/.github/actions/install-maven/action.yml
@@ -4,8 +4,8 @@ runs:
   steps:
   - name: Install Maven
     run: |
-      wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz
-      tar zxf apache-maven-3.9.10-bin.tar.gz
-      echo "export M2_HOME=$(pwd)/apache-maven-3.9.10" >> $GITHUB_ENV
-      echo "$(pwd)/apache-maven-3.9.10/bin" >> $GITHUB_PATH
+      wget --no-check-certificate https://rocksdb-deps.s3.us-west-2.amazonaws.com/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
+      tar zxf apache-maven-3.9.11-bin.tar.gz
+      echo "export M2_HOME=$(pwd)/apache-maven-3.9.11" >> $GITHUB_ENV
+      echo "$(pwd)/apache-maven-3.9.11/bin" >> $GITHUB_PATH
     shell: bash

--- a/.github/actions/install-maven/action.yml
+++ b/.github/actions/install-maven/action.yml
@@ -4,7 +4,7 @@ runs:
   steps:
   - name: Install Maven
     run: |
-      wget --no-check-certificate https://rocksdb-deps.s3.us-west-2.amazonaws.com/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
+      wget --no-check-certificate https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
       tar zxf apache-maven-3.9.11-bin.tar.gz
       echo "export M2_HOME=$(pwd)/apache-maven-3.9.11" >> $GITHUB_ENV
       echo "$(pwd)/apache-maven-3.9.11/bin" >> $GITHUB_PATH


### PR DESCRIPTION
# Summary

Similar to https://github.com/facebook/rocksdb/pull/13684, the link for version 3.9.10 is broken again, and we are upgrading Maven as part of the fix.

This time, we are no longer using the link from https://dlcdn.apache.org/maven/maven-3/ because they occasionally remove versions, which can break our CI at any time.

Instead, changing the link to use Apache Archive which should be stable

# Test Plan

CI

`install-maven` step is now passing - https://github.com/facebook/rocksdb/actions/runs/16328986469/job/46126398150?pr=13779