### PR TITLE
Del redundant-static-def in internal_repo_rocksdb/repo/tools/sst_dump_test.cc +1

### DIFF
--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -177,7 +177,6 @@ class SSTDumpToolTest : public testing::Test {
   constexpr static int kNumKey = 1024;
 };
 
-constexpr int SSTDumpToolTest::kNumKey;
 
 TEST_F(SSTDumpToolTest, HelpAndVersion) {
   Options opts;


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wdeprecated-redundant-constexpr-static-def` which raises the warning:

> warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated

Since we are now on C++20, we can remove the out-of-line definition of constexpr static data members. This diff does so.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D78635005


