### PR TITLE
Add background CompactRange on excessive key skips in Seek

### DIFF
--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -315,6 +315,7 @@ class DBIter final : public Iterator {
   // If prefix is not null, we need to set the iterator to invalid if no more
   // entry can be found within the prefix.
   void PrevInternal(const Slice* prefix);
+  void trigger_compact();
   bool TooManyInternalKeysSkipped(bool increment = true);
   bool IsVisible(SequenceNumber sequence, const Slice& ts,
                  bool* more_recent = nullptr);
@@ -474,6 +475,7 @@ class DBIter final : public Iterator {
   uint64_t saved_write_unix_time_;
   std::string saved_value_;
   Slice pinned_value_;
+  Slice first_key_without_ts;
   // for prefix seek mode to support prev()
   // Value of the default column
   Slice value_;
@@ -519,6 +521,13 @@ class DBIter final : public Iterator {
   // This information is used as that the next entry will be for another
   // user key.
   bool is_key_seqnum_zero_;
+  // Default false.
+  // If 'need_compact_' is true, 'max_skippable_internal_keys_' needs to be configured 
+  // with the appropriate value and 'max_background_compactions' needs to be greater than 1 to take effect.
+  // When the number of keys skipped in a single query is greater than 'max_skippable_internal_keys_', 
+  // a background thread is triggered to perform a small-scale compact.
+  bool need_compact_;
+  bool prepare_compact_ = false;
   const bool prefix_same_as_start_;
   // Means that we will pin all data blocks we read as long the Iterator
   // is not deleted, will be true if ReadOptions::pin_data is true

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1904,6 +1904,13 @@ struct ReadOptions {
   // never fail a request as incomplete, even on skipping too many keys.
   uint64_t max_skippable_internal_keys = 0;
 
+  // It only takes effect after the `max_skippable_internal_keys` > 0 is configured and 
+  // `max_background_compactions` needs to be greater than 1 to take effect.
+  // When the number of keys skipped in a single query is greater than 'max_skippable_internal_keys_', 
+  // a background thread is triggered to perform a small-scale compact.
+  // Default: false
+  bool need_compact = false;
+
   // `iterate_lower_bound` defines the smallest key at which the backward
   // iterator can return an entry. Once the bound is passed, Valid() will be
   // false. `iterate_lower_bound` is inclusive ie the bound value is a valid


### PR DESCRIPTION
1.Add a new ReadOptions member `bool need_compact`, which defaults to false.When a user calls `DBIter::Seek` and encounters a situation where too many keys are skipped in a single Seek, the background thread automatically triggers a CompactRange that determines the upper and lower bounds based on this query.
2.This configuration item takes effect by setting `max_skippable_internal_keys_ > 0` and `max_background_compactions > 1`.
3.New function: `DBIter::trigger_compact` used to trigger the background thread to execute 'CompactRange'.
4.New function: `DBImpl: : MaybeScheduleCompactionRange` and `DBImpl: : BGWorkCompactRange` for background threads execute `CompactRange`.