### PR TITLE
Compressor::CompressBlock API change and refactoring/improvement

### DIFF
--- a/db/compact_files_test.cc
+++ b/db/compact_files_test.cc
@@ -441,6 +441,10 @@ TEST_F(CompactFilesTest, SentinelCompressionType) {
 }
 
 TEST_F(CompactFilesTest, CompressionWithBlockAlign) {
+  if (!Snappy_Supported()) {
+    ROCKSDB_GTEST_SKIP("Test requires Snappy support");
+    return;
+  }
   Options options;
   options.compression = CompressionType::kNoCompression;
   options.create_if_missing = true;

--- a/port/win/xpress_win.h
+++ b/port/win/xpress_win.h
@@ -19,6 +19,10 @@ namespace xpress {
 
 bool Compress(const char* input, size_t length, std::string* output);
 
+// Returns written size or 0 on failure including if buffer is too small.
+size_t CompressWithMaxSize(const char* input, size_t length, char* output,
+                           size_t max_output_size);
+
 char* Decompress(const char* input_data, size_t input_length,
                  size_t* uncompressed_size);
 

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -177,7 +177,7 @@ class BlockBasedTableBuilder : public TableBuilder {
   // compression type
   void CompressAndVerifyBlock(const Slice& uncompressed_block_data,
                               bool is_data_block, WorkingAreaPair& working_area,
-                              std::string* compressed_output,
+                              GrowableBuffer* compressed_output,
                               CompressionType* result_compression_type,
                               Status* out_status);
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -6230,6 +6230,12 @@ TEST_P(BlockBasedTableTest, OutOfBoundOnNext) {
 class ChargeCompressionDictionaryBuildingBufferTest
     : public BlockBasedTableTestBase {};
 TEST_F(ChargeCompressionDictionaryBuildingBufferTest, Basic) {
+  if (GetSupportedDictCompressions().empty()) {
+    ROCKSDB_GTEST_SKIP("No supported dict compression");
+    return;
+  }
+  const auto kCompression = GetSupportedDictCompressions()[0];
+
   constexpr std::size_t kSizeDummyEntry = 256 * 1024;
   constexpr std::size_t kMetaDataChargeOverhead = 10000;
   constexpr std::size_t kCacheCapacity = 8 * 1024 * 1024;
@@ -6253,7 +6259,7 @@ TEST_F(ChargeCompressionDictionaryBuildingBufferTest, Basic) {
         {CacheEntryRole::kCompressionDictionaryBuildingBuffer,
          {/*.charged = */ charge_compression_dictionary_building_buffer}});
     Options options;
-    options.compression = kSnappyCompression;
+    options.compression = kCompression;
     options.compression_opts.max_dict_bytes = kMaxDictBytes;
     options.compression_opts.max_dict_buffer_bytes = kMaxDictBufferBytes;
     options.table_factory.reset(NewBlockBasedTableFactory(table_options));
@@ -6274,7 +6280,7 @@ TEST_F(ChargeCompressionDictionaryBuildingBufferTest, Basic) {
         options.table_factory->NewTableBuilder(
             TableBuilderOptions(ioptions, moptions, read_options, write_options,
                                 ikc, &internal_tbl_prop_coll_factories,
-                                kSnappyCompression, options.compression_opts,
+                                kCompression, options.compression_opts,
                                 kUnknownColumnFamily, "test_cf", -1 /* level */,
                                 kUnknownNewestKeyTime),
             file_writer.get()));
@@ -6313,6 +6319,12 @@ TEST_F(ChargeCompressionDictionaryBuildingBufferTest, Basic) {
 
 TEST_F(ChargeCompressionDictionaryBuildingBufferTest,
        BasicWithBufferLimitExceed) {
+  if (GetSupportedDictCompressions().empty()) {
+    ROCKSDB_GTEST_SKIP("No supported dict compression");
+    return;
+  }
+  const auto kCompression = GetSupportedDictCompressions()[0];
+
   constexpr std::size_t kSizeDummyEntry = 256 * 1024;
   constexpr std::size_t kMetaDataChargeOverhead = 10000;
   constexpr std::size_t kCacheCapacity = 8 * 1024 * 1024;
@@ -6332,7 +6344,7 @@ TEST_F(ChargeCompressionDictionaryBuildingBufferTest,
       std::make_shared<FlushBlockEveryKeyPolicyFactory>();
 
   Options options;
-  options.compression = kSnappyCompression;
+  options.compression = kCompression;
   options.compression_opts.max_dict_bytes = kMaxDictBytes;
   options.compression_opts.max_dict_buffer_bytes = kMaxDictBufferBytes;
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
@@ -6351,7 +6363,7 @@ TEST_F(ChargeCompressionDictionaryBuildingBufferTest,
   const WriteOptions write_options;
   std::unique_ptr<TableBuilder> builder(options.table_factory->NewTableBuilder(
       TableBuilderOptions(ioptions, moptions, read_options, write_options, ikc,
-                          &internal_tbl_prop_coll_factories, kSnappyCompression,
+                          &internal_tbl_prop_coll_factories, kCompression,
                           options.compression_opts, kUnknownColumnFamily,
                           "test_cf", -1 /* level */, kUnknownNewestKeyTime),
       file_writer.get()));
@@ -6394,6 +6406,12 @@ TEST_F(ChargeCompressionDictionaryBuildingBufferTest,
 }
 
 TEST_F(ChargeCompressionDictionaryBuildingBufferTest, BasicWithCacheFull) {
+  if (GetSupportedDictCompressions().empty()) {
+    ROCKSDB_GTEST_SKIP("No supported dict compression");
+    return;
+  }
+  const auto kCompression = GetSupportedDictCompressions()[0];
+
   constexpr std::size_t kSizeDummyEntry = 256 * 1024;
   constexpr std::size_t kMetaDataChargeOverhead = 10000;
   // A small kCacheCapacity is chosen so that increase cache charging for
@@ -6419,7 +6437,7 @@ TEST_F(ChargeCompressionDictionaryBuildingBufferTest, BasicWithCacheFull) {
       std::make_shared<FlushBlockEveryKeyPolicyFactory>();
 
   Options options;
-  options.compression = kSnappyCompression;
+  options.compression = kCompression;
   options.compression_opts.max_dict_bytes = kMaxDictBytes;
   options.compression_opts.max_dict_buffer_bytes = kMaxDictBufferBytes;
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
@@ -6438,7 +6456,7 @@ TEST_F(ChargeCompressionDictionaryBuildingBufferTest, BasicWithCacheFull) {
   const WriteOptions write_options;
   std::unique_ptr<TableBuilder> builder(options.table_factory->NewTableBuilder(
       TableBuilderOptions(ioptions, moptions, read_options, write_options, ikc,
-                          &internal_tbl_prop_coll_factories, kSnappyCompression,
+                          &internal_tbl_prop_coll_factories, kCompression,
                           options.compression_opts, kUnknownColumnFamily,
                           "test_cf", -1 /* level */, kUnknownNewestKeyTime),
       file_writer.get()));

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6440,7 +6440,7 @@ class Benchmark {
       auto iter =
           db->NewMultiScan(read_options_, db->DefaultColumnFamily(), opts);
       for (auto rng : *iter) {
-        size_t keys = 0;
+        [[maybe_unused]] size_t keys = 0;
         for (auto it __attribute__((__unused__)) : rng) {
           keys++;
         }

--- a/unreleased_history/performance_improvements/compression_perf.md
+++ b/unreleased_history/performance_improvements/compression_perf.md
@@ -1,0 +1,1 @@
+* Small improvement to CPU efficiency of compression using built-in algorithms, and a dramatic efficiency improvement for LZ4HC, based on reusing data structures between invocations.

--- a/unreleased_history/public_api_changes/lz4_etc.md
+++ b/unreleased_history/public_api_changes/lz4_etc.md
@@ -1,0 +1,2 @@
+* Minimum supported version of LZ4 library is now 1.7.0 (r129 from 2015)
+* Some changes to experimental Compressor and CompressionManager APIs

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cassert>
 
+#include "port/malloc.h"
 #include "port/port.h"
 #include "rocksdb/file_system.h"
 namespace ROCKSDB_NAMESPACE {
@@ -251,4 +252,50 @@ class AlignedBuffer {
 
   void Size(size_t cursize) { cursize_ = cursize; }
 };
+
+// Related to std::string but more easily avoids zeroing out a buffer that's
+// going to be overwritten anyway.
+class GrowableBuffer {
+ public:
+  GrowableBuffer() : capacity_(0) {}
+  ~GrowableBuffer() { free(data_); }
+
+  char* data() { return data_; }
+  const char* data() const { return data_; }
+
+  size_t size() const { return size_; }
+  size_t& MutableSize() { return size_; }
+
+  bool empty() const { return size_ == 0; }
+
+  void Reset() { size_ = 0; }
+  void ResetForSize(size_t new_size) {
+    if (new_size > capacity_) {
+      free(data_);
+      size_t new_capacity = std::max(capacity_ * 2, new_size);
+      new_capacity = std::max(size_t{64}, new_capacity);
+      data_ = static_cast<char*>(malloc(new_capacity));
+#ifdef ROCKSDB_MALLOC_USABLE_SIZE
+      capacity_ = malloc_usable_size(data_);
+#else
+      capacity_ = new_capacity;
+#endif
+      // Warm the memory in CPU cache
+      for (size_t i = 0; i < new_capacity; i += CACHE_LINE_SIZE) {
+        data_[i] = 1;
+      }
+    }
+    size_ = new_size;
+  }
+
+  Slice AsSlice() const { return Slice(data_, size_); }
+  operator Slice() const { return AsSlice(); }
+
+ private:
+  char* data_ = nullptr;
+  size_t size_ = 0;
+  size_t capacity_;
+  static const Slice kEmptySlice;
+};
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -259,6 +259,29 @@ class GrowableBuffer {
  public:
   GrowableBuffer() : capacity_(0) {}
   ~GrowableBuffer() { free(data_); }
+  // No copies
+  GrowableBuffer(const GrowableBuffer&) = delete;
+  GrowableBuffer& operator=(const GrowableBuffer&) = delete;
+  // Movable
+  GrowableBuffer(GrowableBuffer&& other) noexcept
+      : data_(other.data_), size_(other.size_), capacity_(other.capacity_) {
+    other.data_ = nullptr;
+    other.size_ = 0;
+    other.capacity_ = 0;
+  }
+  GrowableBuffer& operator=(GrowableBuffer&& other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
+    free(data_);
+    data_ = other.data_;
+    size_ = other.size_;
+    capacity_ = other.capacity_;
+    other.data_ = nullptr;
+    other.size_ = 0;
+    other.capacity_ = 0;
+    return *this;
+  }
 
   char* data() { return data_; }
   const char* data() const { return data_; }
@@ -295,7 +318,6 @@ class GrowableBuffer {
   char* data_ = nullptr;
   size_t size_ = 0;
   size_t capacity_;
-  static const Slice kEmptySlice;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/auto_tune_compressor.h
+++ b/util/auto_tune_compressor.h
@@ -24,8 +24,8 @@ class CompressionRejectionProbabilityPredictor {
         compressed_count_(0),
         window_size_(window_size) {}
   int Predict() const;
-  bool Record(Slice uncompressed_block_data, std::string* compressed_output,
-              const CompressionOptions& opts);
+  bool Record(Slice uncompressed_block_data, char* compressed_output,
+              size_t compressed_output_size, CompressionType compression_type);
   size_t attempted_compression_count() const;
 
  protected:
@@ -64,7 +64,8 @@ class AutoSkipCompressorWrapper : public CompressorWrapper {
   explicit AutoSkipCompressorWrapper(std::unique_ptr<Compressor> compressor,
                                      const CompressionOptions& opts);
 
-  Status CompressBlock(Slice uncompressed_data, std::string* compressed_output,
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
                        CompressionType* out_compression_type,
                        ManagedWorkingArea* wa) override;
   ManagedWorkingArea ObtainWorkingArea() override;
@@ -72,7 +73,8 @@ class AutoSkipCompressorWrapper : public CompressorWrapper {
 
  private:
   Status CompressBlockAndRecord(Slice uncompressed_data,
-                                std::string* compressed_output,
+                                char* compressed_output,
+                                size_t* compressed_output_size,
                                 CompressionType* out_compression_type,
                                 AutoSkipWorkingArea* wa);
   static constexpr int kExplorationPercentage = 10;
@@ -154,7 +156,8 @@ class CostAwareCompressor : public Compressor {
   std::unique_ptr<Compressor> MaybeCloneSpecialized(
       CacheEntryRole block_type, DictSampleArgs&& dict_samples) override;
 
-  Status CompressBlock(Slice uncompressed_data, std::string* compressed_output,
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
                        CompressionType* out_compression_type,
                        ManagedWorkingArea* wa) override;
   void ReleaseWorkingArea(WorkingArea* wa) override;
@@ -163,7 +166,8 @@ class CostAwareCompressor : public Compressor {
   Status CompressBlockAndRecord(size_t choosen_compression_type,
                                 size_t compresion_level_ptr,
                                 Slice uncompressed_data,
-                                std::string* compressed_output,
+                                char* compressed_output,
+                                size_t* compressed_output_size,
                                 CompressionType* out_compression_type,
                                 CostAwareWorkingArea* wa);
   static constexpr int kExplorationPercentage = 10;

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -563,9 +563,9 @@ class BuiltinLZ4CompressorV2 : public CompressorWithSimpleDictBase {
 
     ManagedWorkingArea tmp_wa;
     LZ4_stream_t* stream;
-    if (wa->get() != nullptr && wa->owner() == this) {
+    if (wa != nullptr && wa->owner() == this) {
       stream = reinterpret_cast<LZ4_stream_t*>(wa->get());
-#if LZ4_VERSION_NUMBER >= 10802  // >= version 1.8.2
+#if LZ4_VERSION_NUMBER >= 10900  // >= version 1.9.0
       LZ4_resetStream_fast(stream);
 #else
       LZ4_resetStream(stream);
@@ -603,6 +603,7 @@ class BuiltinLZ4CompressorV2 : public CompressorWithSimpleDictBase {
 #else
     (void)uncompressed_data;
     (void)compressed_output;
+    (void)wa;
     // Compression bypassed (not supported)
     *compressed_output_size = 0;
 #endif
@@ -662,13 +663,13 @@ class BuiltinLZ4HCCompressorV2 : public CompressorWithSimpleDictBase {
 
     ManagedWorkingArea tmp_wa;
     LZ4_streamHC_t* stream;
-    if (wa->get() != nullptr && wa->owner() == this) {
+    if (wa != nullptr && wa->owner() == this) {
       stream = reinterpret_cast<LZ4_streamHC_t*>(wa->get());
     } else {
       tmp_wa = ObtainWorkingArea();
       stream = reinterpret_cast<LZ4_streamHC_t*>(tmp_wa.get());
     }
-#if LZ4_VERSION_NUMBER >= 10802  // >= version 1.8.2
+#if LZ4_VERSION_NUMBER >= 10900  // >= version 1.9.0
     LZ4_resetStreamHC_fast(stream, level);
 #else
     LZ4_resetStreamHC(stream, level);
@@ -697,6 +698,7 @@ class BuiltinLZ4HCCompressorV2 : public CompressorWithSimpleDictBase {
 #else
     (void)uncompressed_data;
     (void)compressed_output;
+    (void)wa;
     // Compression bypassed (not supported)
     *compressed_output_size = 0;
 #endif

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -6,6 +6,7 @@
 #include "util/compression.h"
 
 #include "options/options_helper.h"
+#include "port/lang.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/utilities/object_registry.h"
 
@@ -154,19 +155,28 @@ const Slice& Decompressor::GetSerializedDict() const {
 
 namespace {
 
-class BuiltinCompressorV1 : public Compressor {
+class CompressorBase : public Compressor {
+ public:
+  explicit CompressorBase(const CompressionOptions& opts) : opts_(opts) {}
+
+ protected:
+  CompressionOptions opts_;
+};
+
+class BuiltinCompressorV1 : public CompressorBase {
  public:
   const char* Name() const override { return "BuiltinCompressorV1"; }
 
   explicit BuiltinCompressorV1(const CompressionOptions& opts,
                                CompressionType type)
-      : opts_(opts), type_(type) {
+      : CompressorBase(opts), type_(type) {
     assert(type != kNoCompression);
   }
 
   CompressionType GetPreferredCompressionType() const override { return type_; }
 
-  Status CompressBlock(Slice uncompressed_data, std::string* compressed_output,
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
                        CompressionType* out_compression_type,
                        ManagedWorkingArea* wa) override {
     std::optional<CompressionContext> tmp_ctx;
@@ -179,30 +189,580 @@ class BuiltinCompressorV1 : public Compressor {
       ctx = &*tmp_ctx;
     }
     CompressionInfo info(opts_, *ctx, CompressionDict::GetEmptyDict(), type_);
+    std::string str_output;
+    str_output.reserve(uncompressed_data.size());
     if (!OLD_CompressData(uncompressed_data, info,
-                          1 /*compress_format_version*/, compressed_output)) {
+                          1 /*compress_format_version*/, &str_output)) {
+      // Maybe rejected or bypassed
+      *compressed_output_size = str_output.size();
       *out_compression_type = kNoCompression;
       return Status::OK();
     }
+    if (str_output.size() > *compressed_output_size) {
+      // Compression rejected
+      *out_compression_type = kNoCompression;
+      return Status::OK();
+    }
+    std::memcpy(compressed_output, str_output.data(), str_output.size());
+    *compressed_output_size = str_output.size();
     *out_compression_type = type_;
     return Status::OK();
   }
 
  protected:
-  const CompressionOptions opts_;
   const CompressionType type_;
 };
 
-class BuiltinCompressorV2 : public Compressor {
+class CompressorWithSimpleDictBase : public CompressorBase {
  public:
-  const char* Name() const override { return "BuiltinCompressorV2"; }
+  explicit CompressorWithSimpleDictBase(const CompressionOptions& opts,
+                                        std::string&& dict_data = {})
+      : CompressorBase(opts), dict_data_(std::move(dict_data)) {}
 
-  explicit BuiltinCompressorV2(const CompressionOptions& opts,
-                               CompressionType type,
-                               CompressionDict&& dict = {})
-      : opts_(opts), type_(type), dict_(std::move(dict)) {
-    assert(type != kNoCompression);
+  size_t GetMaxSampleSizeIfWantDict(
+      CacheEntryRole /*block_type*/) const override {
+    return opts_.max_dict_bytes;
   }
+
+  // NOTE: empty dict is equivalent to no dict
+  Slice GetSerializedDict() const override { return dict_data_; }
+
+  std::unique_ptr<Compressor> MaybeCloneSpecialized(
+      CacheEntryRole /*block_type*/,
+      DictSampleArgs&& dict_samples) final override {
+    assert(dict_samples.Verify());
+    if (dict_samples.empty()) {
+      // Nothing to specialize on
+      return nullptr;
+    } else {
+      return CloneForDict(std::move(dict_samples.sample_data));
+    }
+  }
+
+  virtual std::unique_ptr<Compressor> CloneForDict(std::string&& dict_data) = 0;
+
+ protected:
+  const std::string dict_data_;
+};
+
+// NOTE: the legacy behavior is to pretend to use dictionary compression when
+// enabled, including storing a dictionary block, but to ignore it. That is
+// matched here.
+class BuiltinSnappyCompressorV2 : public CompressorWithSimpleDictBase {
+ public:
+  using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
+
+  const char* Name() const override { return "BuiltinSnappyCompressorV2"; }
+
+  CompressionType GetPreferredCompressionType() const override {
+    return kSnappyCompression;
+  }
+
+  std::unique_ptr<Compressor> CloneForDict(std::string&& dict_data) override {
+    return std::make_unique<BuiltinSnappyCompressorV2>(opts_,
+                                                       std::move(dict_data));
+  }
+
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
+                       CompressionType* out_compression_type,
+                       ManagedWorkingArea*) override {
+#ifdef SNAPPY
+    struct MySink : public snappy::Sink {
+      MySink(char* output, size_t output_size)
+          : output_(output), output_size_(output_size) {}
+
+      char* output_;
+      size_t output_size_;
+      size_t pos_ = 0;
+
+      void Append(const char* data, size_t n) override {
+        if (pos_ + n <= output_size_) {
+          std::memcpy(output_ + pos_, data, n);
+          pos_ += n;
+        } else {
+          // Virtual abort
+          pos_ = output_size_ + 1;
+        }
+      }
+
+      char* GetAppendBuffer(size_t length, char* scratch) override {
+        if (pos_ + length <= output_size_) {
+          return output_ + pos_;
+        }
+        return scratch;
+      }
+    };
+    MySink sink{compressed_output, *compressed_output_size};
+    snappy::ByteArraySource source{uncompressed_data.data(),
+                                   uncompressed_data.size()};
+
+    size_t outlen = snappy::Compress(&source, &sink);
+    if (outlen > 0 && sink.pos_ <= sink.output_size_) {
+      // Compression kept/successful
+      assert(outlen == sink.pos_);
+      *compressed_output_size = outlen;
+      *out_compression_type = kSnappyCompression;
+      return Status::OK();
+    }
+    // Compression rejected
+    *compressed_output_size = 1;
+#else
+    (void)uncompressed_data;
+    (void)compressed_output;
+    // Compression bypassed (not supported)
+    *compressed_output_size = 0;
+#endif
+    *out_compression_type = kNoCompression;
+    return Status::OK();
+  }
+
+  std::shared_ptr<Decompressor> GetOptimizedDecompressor() const override;
+};
+
+[[maybe_unused]]
+std::pair<char*, size_t> StartCompressBlockV2(Slice uncompressed_data,
+                                              char* compressed_output,
+                                              size_t compressed_output_size) {
+  if (  // Can't compress more than 4GB
+      uncompressed_data.size() > std::numeric_limits<uint32_t>::max() ||
+      // Need enough output space for encoding uncompressed size
+      compressed_output_size <= 5) {
+    // Compression bypassed
+    return {nullptr, 0};
+  }
+  // Standard format for prepending uncompressed size to the compressed
+  // data in compress_format_version=2
+  char* alg_output = EncodeVarint32(
+      compressed_output, static_cast<uint32_t>(uncompressed_data.size()));
+  size_t alg_max_output_size =
+      compressed_output_size - (alg_output - compressed_output);
+  return {alg_output, alg_max_output_size};
+}
+
+class BuiltinZlibCompressorV2 : public CompressorWithSimpleDictBase {
+ public:
+  using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
+
+  const char* Name() const override { return "BuiltinZlibCompressorV2"; }
+
+  CompressionType GetPreferredCompressionType() const override {
+    return kZlibCompression;
+  }
+
+  std::unique_ptr<Compressor> CloneForDict(std::string&& dict_data) override {
+    return std::make_unique<BuiltinZlibCompressorV2>(opts_,
+                                                     std::move(dict_data));
+  }
+
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
+                       CompressionType* out_compression_type,
+                       ManagedWorkingArea*) override {
+#ifdef ZLIB
+    auto [alg_output, alg_max_output_size] = StartCompressBlockV2(
+        uncompressed_data, compressed_output, *compressed_output_size);
+    if (alg_max_output_size == 0) {
+      // Compression bypassed
+      *compressed_output_size = 0;
+      *out_compression_type = kNoCompression;
+      return Status::OK();
+    }
+
+    // The memLevel parameter specifies how much memory should be allocated for
+    // the internal compression state.
+    // memLevel=1 uses minimum memory but is slow and reduces compression ratio.
+    // memLevel=9 uses maximum memory for optimal speed.
+    // The default value is 8. See zconf.h for more details.
+    static const int memLevel = 8;
+    int level = opts_.level;
+    if (level == CompressionOptions::kDefaultCompressionLevel) {
+      level = Z_DEFAULT_COMPRESSION;
+    }
+
+    z_stream stream;
+    memset(&stream, 0, sizeof(z_stream));
+
+    // Initialize the zlib stream
+    int st = deflateInit2(&stream, level, Z_DEFLATED, opts_.window_bits,
+                          memLevel, opts_.strategy);
+    if (st != Z_OK) {
+      *compressed_output_size = 0;
+      *out_compression_type = kNoCompression;
+      return Status::OK();
+    }
+
+    // Set dictionary if available
+    if (!dict_data_.empty()) {
+      st = deflateSetDictionary(
+          &stream, reinterpret_cast<const Bytef*>(dict_data_.data()),
+          static_cast<unsigned int>(dict_data_.size()));
+      if (st != Z_OK) {
+        deflateEnd(&stream);
+        *compressed_output_size = 0;
+        *out_compression_type = kNoCompression;
+        return Status::OK();
+      }
+    }
+
+    // Set up input
+    stream.next_in = (Bytef*)uncompressed_data.data();
+    stream.avail_in = static_cast<unsigned int>(uncompressed_data.size());
+
+    // Set up output
+    stream.next_out = reinterpret_cast<Bytef*>(alg_output);
+    stream.avail_out = static_cast<unsigned int>(alg_max_output_size);
+
+    // Compress
+    st = deflate(&stream, Z_FINISH);
+    size_t outlen = alg_max_output_size - stream.avail_out;
+    deflateEnd(&stream);
+
+    if (st == Z_STREAM_END) {
+      // Compression kept/successful
+      *compressed_output_size =
+          outlen + /*header size*/ (alg_output - compressed_output);
+      *out_compression_type = kZlibCompression;
+      return Status::OK();
+    }
+    // Compression failed or rejected
+    *compressed_output_size = 1;
+#else
+    (void)uncompressed_data;
+    (void)compressed_output;
+    // Compression bypassed (not supported)
+    *compressed_output_size = 0;
+#endif
+    *out_compression_type = kNoCompression;
+    return Status::OK();
+  }
+};
+
+class BuiltinBZip2CompressorV2 : public CompressorWithSimpleDictBase {
+ public:
+  using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
+
+  const char* Name() const override { return "BuiltinBZip2CompressorV2"; }
+
+  CompressionType GetPreferredCompressionType() const override {
+    return kBZip2Compression;
+  }
+
+  std::unique_ptr<Compressor> CloneForDict(std::string&& dict_data) override {
+    return std::make_unique<BuiltinBZip2CompressorV2>(opts_,
+                                                      std::move(dict_data));
+  }
+
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
+                       CompressionType* out_compression_type,
+                       ManagedWorkingArea*) override {
+#ifdef BZIP2
+    auto [alg_output, alg_max_output_size] = StartCompressBlockV2(
+        uncompressed_data, compressed_output, *compressed_output_size);
+    if (alg_max_output_size == 0) {
+      // Compression bypassed
+      *compressed_output_size = 0;
+      *out_compression_type = kNoCompression;
+      return Status::OK();
+    }
+
+    // BZip2 doesn't actually use the dictionary, but we store it for
+    // compatibility similar to BuiltinSnappyCompressorV2
+
+    // Initialize the bzip2 stream
+    bz_stream stream;
+    memset(&stream, 0, sizeof(bz_stream));
+
+    // Block size 1 is 100K.
+    // 0 is for silent.
+    // 30 is the default workFactor
+    int st = BZ2_bzCompressInit(&stream, 1, 0, 30);
+    if (st != BZ_OK) {
+      *compressed_output_size = 0;
+      *out_compression_type = kNoCompression;
+      return Status::OK();
+    }
+
+    // Set up input
+    stream.next_in = const_cast<char*>(uncompressed_data.data());
+    stream.avail_in = static_cast<unsigned int>(uncompressed_data.size());
+
+    // Set up output
+    stream.next_out = alg_output;
+    stream.avail_out = static_cast<unsigned int>(alg_max_output_size);
+
+    // Compress
+    st = BZ2_bzCompress(&stream, BZ_FINISH);
+    size_t outlen = alg_max_output_size - stream.avail_out;
+    BZ2_bzCompressEnd(&stream);
+
+    // Check for success
+    if (st == BZ_STREAM_END) {
+      // Compression kept/successful
+      *compressed_output_size = outlen + (alg_output - compressed_output);
+      *out_compression_type = kBZip2Compression;
+      return Status::OK();
+    }
+    // Compression failed or rejected
+    *compressed_output_size = 1;
+#else
+    (void)uncompressed_data;
+    (void)compressed_output;
+    // Compression bypassed (not supported)
+    *compressed_output_size = 0;
+#endif
+    *out_compression_type = kNoCompression;
+    return Status::OK();
+  }
+};
+
+class BuiltinLZ4CompressorV2 : public CompressorWithSimpleDictBase {
+ public:
+  using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
+
+  const char* Name() const override { return "BuiltinLZ4CompressorV2"; }
+
+  CompressionType GetPreferredCompressionType() const override {
+    return kLZ4Compression;
+  }
+
+  std::unique_ptr<Compressor> CloneForDict(std::string&& dict_data) override {
+    return std::make_unique<BuiltinLZ4CompressorV2>(opts_,
+                                                    std::move(dict_data));
+  }
+
+  ManagedWorkingArea ObtainWorkingArea() override {
+#ifdef LZ4
+    return {reinterpret_cast<WorkingArea*>(LZ4_createStream()), this};
+#else
+    return {};
+#endif
+  }
+  void ReleaseWorkingArea(WorkingArea* wa) override {
+    if (wa) {
+#ifdef LZ4
+      LZ4_freeStream(reinterpret_cast<LZ4_stream_t*>(wa));
+#endif
+    }
+  }
+
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
+                       CompressionType* out_compression_type,
+                       ManagedWorkingArea* wa) override {
+#ifdef LZ4
+    auto [alg_output, alg_max_output_size] = StartCompressBlockV2(
+        uncompressed_data, compressed_output, *compressed_output_size);
+    if (alg_max_output_size == 0) {
+      // Compression bypassed
+      *compressed_output_size = 0;
+      *out_compression_type = kNoCompression;
+      return Status::OK();
+    }
+
+    ManagedWorkingArea tmp_wa;
+    LZ4_stream_t* stream;
+    if (wa->get() != nullptr && wa->owner() == this) {
+      stream = reinterpret_cast<LZ4_stream_t*>(wa->get());
+#if LZ4_VERSION_NUMBER >= 10802  // >= version 1.8.2
+      LZ4_resetStream_fast(stream);
+#else
+      LZ4_resetStream(stream);
+#endif
+    } else {
+      tmp_wa = ObtainWorkingArea();
+      stream = reinterpret_cast<LZ4_stream_t*>(tmp_wa.get());
+    }
+    if (!dict_data_.empty()) {
+      // TODO: more optimization possible here?
+      LZ4_loadDict(stream, dict_data_.data(),
+                   static_cast<int>(dict_data_.size()));
+    }
+    int acceleration;
+    if (opts_.level < 0) {
+      acceleration = -opts_.level;
+    } else {
+      acceleration = 1;
+    }
+    auto outlen = LZ4_compress_fast_continue(
+        stream, uncompressed_data.data(), alg_output,
+        static_cast<int>(uncompressed_data.size()),
+        static_cast<int>(alg_max_output_size), acceleration);
+    if (outlen > 0) {
+      // Compression kept/successful
+      size_t output_size = static_cast<size_t>(
+          outlen + /*header size*/ (alg_output - compressed_output));
+      assert(output_size <= *compressed_output_size);
+      *compressed_output_size = output_size;
+      *out_compression_type = kLZ4Compression;
+      return Status::OK();
+    }
+    // Compression rejected
+    *compressed_output_size = 1;
+#else
+    (void)uncompressed_data;
+    (void)compressed_output;
+    // Compression bypassed (not supported)
+    *compressed_output_size = 0;
+#endif
+    *out_compression_type = kNoCompression;
+    return Status::OK();
+  }
+};
+
+class BuiltinLZ4HCCompressorV2 : public CompressorWithSimpleDictBase {
+ public:
+  using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
+
+  const char* Name() const override { return "BuiltinLZ4HCCompressorV2"; }
+
+  CompressionType GetPreferredCompressionType() const override {
+    return kLZ4HCCompression;
+  }
+
+  std::unique_ptr<Compressor> CloneForDict(std::string&& dict_data) override {
+    return std::make_unique<BuiltinLZ4HCCompressorV2>(opts_,
+                                                      std::move(dict_data));
+  }
+
+  ManagedWorkingArea ObtainWorkingArea() override {
+#ifdef LZ4
+    return {reinterpret_cast<WorkingArea*>(LZ4_createStreamHC()), this};
+#else
+    return {};
+#endif
+  }
+  void ReleaseWorkingArea(WorkingArea* wa) override {
+    if (wa) {
+#ifdef LZ4
+      LZ4_freeStreamHC(reinterpret_cast<LZ4_streamHC_t*>(wa));
+#endif
+    }
+  }
+
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
+                       CompressionType* out_compression_type,
+                       ManagedWorkingArea* wa) override {
+#ifdef LZ4
+    auto [alg_output, alg_max_output_size] = StartCompressBlockV2(
+        uncompressed_data, compressed_output, *compressed_output_size);
+    if (alg_max_output_size == 0) {
+      // Compression bypassed
+      *compressed_output_size = 0;
+      *out_compression_type = kNoCompression;
+      return Status::OK();
+    }
+
+    int level = opts_.level;
+    if (level == CompressionOptions::kDefaultCompressionLevel) {
+      level = 0;  // lz4hc.h says any value < 1 will be sanitized to default
+    }
+
+    ManagedWorkingArea tmp_wa;
+    LZ4_streamHC_t* stream;
+    if (wa->get() != nullptr && wa->owner() == this) {
+      stream = reinterpret_cast<LZ4_streamHC_t*>(wa->get());
+    } else {
+      tmp_wa = ObtainWorkingArea();
+      stream = reinterpret_cast<LZ4_streamHC_t*>(tmp_wa.get());
+    }
+#if LZ4_VERSION_NUMBER >= 10802  // >= version 1.8.2
+    LZ4_resetStreamHC_fast(stream, level);
+#else
+    LZ4_resetStreamHC(stream, level);
+#endif
+    if (dict_data_.size() > 0) {
+      // TODO: more optimization possible here?
+      LZ4_loadDictHC(stream, dict_data_.data(),
+                     static_cast<int>(dict_data_.size()));
+    }
+
+    auto outlen =
+        LZ4_compress_HC_continue(stream, uncompressed_data.data(), alg_output,
+                                 static_cast<int>(uncompressed_data.size()),
+                                 static_cast<int>(alg_max_output_size));
+    if (outlen > 0) {
+      // Compression kept/successful
+      size_t output_size = static_cast<size_t>(
+          outlen + /*header size*/ (alg_output - compressed_output));
+      assert(output_size <= *compressed_output_size);
+      *compressed_output_size = output_size;
+      *out_compression_type = kLZ4HCCompression;
+      return Status::OK();
+    }
+    // Compression rejected
+    *compressed_output_size = 1;
+#else
+    (void)uncompressed_data;
+    (void)compressed_output;
+    // Compression bypassed (not supported)
+    *compressed_output_size = 0;
+#endif
+    *out_compression_type = kNoCompression;
+    return Status::OK();
+  }
+};
+
+class BuiltinXpressCompressorV2 : public CompressorWithSimpleDictBase {
+ public:
+  using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
+
+  const char* Name() const override { return "BuiltinXpressCompressorV2"; }
+
+  CompressionType GetPreferredCompressionType() const override {
+    return kXpressCompression;
+  }
+
+  std::unique_ptr<Compressor> CloneForDict(std::string&& dict_data) override {
+    return std::make_unique<BuiltinXpressCompressorV2>(opts_,
+                                                       std::move(dict_data));
+  }
+
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
+                       CompressionType* out_compression_type,
+                       ManagedWorkingArea*) override {
+#ifdef XPRESS
+    // XPRESS doesn't actually use the dictionary, but we store it for
+    // compatibility similar to BuiltinSnappyCompressorV2
+
+    // Use the new CompressWithMaxSize function that writes directly to the
+    // output buffer
+    size_t compressed_size = port::xpress::CompressWithMaxSize(
+        uncompressed_data.data(), uncompressed_data.size(), compressed_output,
+        *compressed_output_size);
+
+    if (compressed_size > 0) {
+      // Compression kept/successful
+      *compressed_output_size = compressed_size;
+      *out_compression_type = kXpressCompression;
+      return Status::OK();
+    }
+
+    // Compression rejected or failed
+    *compressed_output_size = 1;
+#else
+    (void)uncompressed_data;
+    (void)compressed_output;
+    // Compression bypassed (not supported)
+    *compressed_output_size = 0;
+#endif
+    *out_compression_type = kNoCompression;
+    return Status::OK();
+  }
+};
+
+class BuiltinZSTDCompressorV2 : public CompressorBase {
+ public:
+  BuiltinZSTDCompressorV2(const CompressionOptions& opts,
+                          CompressionDict&& dict = {})
+      : CompressorBase(opts), dict_(std::move(dict)) {}
+
+  const char* Name() const override { return "BuiltinZSTDCompressorV2"; }
+
+  CompressionType GetPreferredCompressionType() const override { return kZSTD; }
 
   size_t GetMaxSampleSizeIfWantDict(
       CacheEntryRole /*block_type*/) const override {
@@ -210,16 +770,113 @@ class BuiltinCompressorV2 : public Compressor {
       // Dictionary compression disabled
       return 0;
     } else {
-      return type_ == kZSTD && opts_.zstd_max_train_bytes > 0
-                 ? opts_.zstd_max_train_bytes
-                 : opts_.max_dict_bytes;
+      return opts_.zstd_max_train_bytes > 0 ? opts_.zstd_max_train_bytes
+                                            : opts_.max_dict_bytes;
     }
   }
 
   // NOTE: empty dict is equivalent to no dict
   Slice GetSerializedDict() const override { return dict_.GetRawDict(); }
 
-  CompressionType GetPreferredCompressionType() const override { return type_; }
+  ManagedWorkingArea ObtainWorkingArea() override {
+#ifdef ZSTD
+    ZSTD_CCtx* ctx =
+#ifdef ROCKSDB_ZSTD_CUSTOM_MEM
+        ZSTD_createCCtx_advanced(port::GetJeZstdAllocationOverrides());
+#else   // ROCKSDB_ZSTD_CUSTOM_MEM
+        ZSTD_createCCtx();
+#endif  // ROCKSDB_ZSTD_CUSTOM_MEM
+    auto level = opts_.level;
+    if (level == CompressionOptions::kDefaultCompressionLevel) {
+      // NB: ZSTD_CLEVEL_DEFAULT is historically == 3
+      level = ZSTD_CLEVEL_DEFAULT;
+    }
+    size_t err = ZSTD_CCtx_setParameter(ctx, ZSTD_c_compressionLevel, level);
+    if (ZSTD_isError(err)) {
+      assert(false);
+      ZSTD_freeCCtx(ctx);
+      ctx = ZSTD_createCCtx();
+    }
+    if (opts_.checksum) {
+      err = ZSTD_CCtx_setParameter(ctx, ZSTD_c_checksumFlag, 1);
+      if (ZSTD_isError(err)) {
+        assert(false);
+        ZSTD_freeCCtx(ctx);
+        ctx = ZSTD_createCCtx();
+      }
+    }
+    return ManagedWorkingArea(reinterpret_cast<WorkingArea*>(ctx), this);
+#else
+    return {};
+#endif  // ZSTD
+  }
+
+  void ReleaseWorkingArea(WorkingArea* wa) override {
+    if (wa) {
+#ifdef ZSTD
+      ZSTD_freeCCtx(reinterpret_cast<ZSTD_CCtx*>(wa));
+#endif  // ZSTD
+    }
+  }
+
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
+                       CompressionType* out_compression_type,
+                       ManagedWorkingArea* wa) override {
+#ifdef ZSTD
+    auto [alg_output, alg_max_output_size] = StartCompressBlockV2(
+        uncompressed_data, compressed_output, *compressed_output_size);
+    if (alg_max_output_size == 0) {
+      // Compression bypassed
+      *compressed_output_size = 0;
+      *out_compression_type = kNoCompression;
+      return Status::OK();
+    }
+
+    ManagedWorkingArea tmp_wa;
+    if (wa == nullptr || wa->owner() != this) {
+      tmp_wa = ObtainWorkingArea();
+      wa = &tmp_wa;
+    }
+    assert(wa->get() != nullptr);
+    ZSTD_CCtx* ctx = reinterpret_cast<ZSTD_CCtx*>(wa->get());
+
+    if (dict_.GetDigestedZstdCDict() != nullptr) {
+      ZSTD_CCtx_refCDict(ctx, dict_.GetDigestedZstdCDict());
+    } else {
+      ZSTD_CCtx_loadDictionary(ctx, dict_.GetRawDict().data(),
+                               dict_.GetRawDict().size());
+    }
+
+    // Compression level is set in `contex` during ObtainWorkingArea()
+    size_t outlen =
+        ZSTD_compress2(ctx, alg_output, alg_max_output_size,
+                       uncompressed_data.data(), uncompressed_data.size());
+    if (!ZSTD_isError(outlen)) {
+      // Compression kept/successful
+      size_t output_size = static_cast<size_t>(
+          outlen + /*header size*/ (alg_output - compressed_output));
+      assert(output_size <= *compressed_output_size);
+      *compressed_output_size = output_size;
+      *out_compression_type = kZSTD;
+      return Status::OK();
+    }
+    if (ZSTD_getErrorCode(outlen) != ZSTD_error_dstSize_tooSmall) {
+      return Status::Corruption(std::string("ZSTD_compress2 failed: ") +
+                                ZSTD_getErrorName(outlen));
+    }
+    // Compression rejected
+    *compressed_output_size = 1;
+#else
+    (void)uncompressed_data;
+    (void)compressed_output;
+    (void)wa;
+    // Compression bypassed (not supported)
+    *compressed_output_size = 0;
+#endif
+    *out_compression_type = kNoCompression;
+    return Status::OK();
+  }
 
   std::unique_ptr<Compressor> MaybeCloneSpecialized(
       CacheEntryRole /*block_type*/, DictSampleArgs&& dict_samples) override {
@@ -230,7 +887,7 @@ class BuiltinCompressorV2 : public Compressor {
     }
     std::string dict_data;
     // Migrated from BlockBasedTableBuilder::EnterUnbuffered()
-    if (type_ == kZSTD && opts_.zstd_max_train_bytes > 0) {
+    if (opts_.zstd_max_train_bytes > 0) {
       assert(dict_samples.sample_data.size() <= opts_.zstd_max_train_bytes);
       if (opts_.use_zstd_dict_trainer) {
         dict_data = ZSTD_TrainDictionary(dict_samples.sample_data,
@@ -247,43 +904,13 @@ class BuiltinCompressorV2 : public Compressor {
       // dictionary." Or similar for other compressions.
       dict_data = std::move(dict_samples.sample_data);
     }
-    CompressionDict dict{std::move(dict_data), type_, opts_.level};
-    return std::make_unique<BuiltinCompressorV2>(opts_, type_, std::move(dict));
+    CompressionDict dict{std::move(dict_data), kZSTD, opts_.level};
+    return std::make_unique<BuiltinZSTDCompressorV2>(opts_, std::move(dict));
   }
 
-  // TODO: use ZSTD_CCtx directly
-  ManagedWorkingArea ObtainWorkingArea() override {
-    return ManagedWorkingArea(new CompressionContext(type_, opts_), this);
-  }
-  void ReleaseWorkingArea(WorkingArea* wa) override {
-    delete static_cast<CompressionContext*>(wa);
-  }
-  Status CompressBlock(Slice uncompressed_data, std::string* compressed_output,
-                       CompressionType* out_compression_type,
-                       ManagedWorkingArea* wa) override {
-    std::optional<CompressionContext> tmp_ctx;
-    CompressionContext* ctx = nullptr;
-    if (wa != nullptr && wa->owner() == this) {
-      ctx = static_cast<CompressionContext*>(wa->get());
-    }
-    CompressionType type = type_;
-    if (ctx == nullptr) {
-      tmp_ctx.emplace(type, opts_);
-      ctx = &*tmp_ctx;
-    }
-    CompressionInfo info(opts_, *ctx, dict_, type);
-    if (!OLD_CompressData(uncompressed_data, info,
-                          2 /*compress_format_version*/, compressed_output)) {
-      *out_compression_type = kNoCompression;
-      return Status::OK();
-    }
-    *out_compression_type = type;
-    return Status::OK();
-  }
+  std::shared_ptr<Decompressor> GetOptimizedDecompressor() const override;
 
  protected:
-  const CompressionOptions opts_;
-  const CompressionType type_;
   const CompressionDict dict_;
 };
 
@@ -480,7 +1107,6 @@ Status LZ4_DecompressBlock(const Decompressor::Args& args, Slice dict,
                            char* uncompressed_output) {
 #ifdef LZ4
   int expected_uncompressed_size = static_cast<int>(args.uncompressed_size);
-#if LZ4_VERSION_NUMBER >= 10400  // r124+
   LZ4_streamDecode_t* stream = LZ4_createStreamDecode();
   if (!dict.empty()) {
     LZ4_setStreamDecode(stream, dict.data(), static_cast<int>(dict.size()));
@@ -490,16 +1116,6 @@ Status LZ4_DecompressBlock(const Decompressor::Args& args, Slice dict,
       static_cast<int>(args.compressed_data.size()),
       expected_uncompressed_size);
   LZ4_freeStreamDecode(stream);
-#else   // up to r123
-  if (!dict.empty()) {
-    return Status::NotSupported(
-        "This build doesn't support dictionary compression with LZ4");
-  }
-  int uncompressed_size =
-      LZ4_decompress_safe(args.compressed_data.data(), uncompressed_output,
-                          static_cast<int>(args.compressed_data.size()),
-                          expected_uncompressed_size);
-#endif  // LZ4_VERSION_NUMBER >= 10400
 
   if (uncompressed_size != expected_uncompressed_size) {
     if (uncompressed_size < 0) {
@@ -875,14 +1491,29 @@ class BuiltinCompressionManagerV2 : public CompressionManager {
       // No acceptable compression ratio => no compression
       return nullptr;
     }
-    if (type > kLastBuiltinCompression) {
-      // Unrecognized; fall back on default compression
+    if (!SupportsCompressionType(type)) {
+      // Unrecognized or support not compiled in. Fall back on default
       type = ColumnFamilyOptions{}.compression;
     }
-    if (type == kNoCompression) {
-      return nullptr;
-    } else {
-      return std::make_unique<BuiltinCompressorV2>(opts, type);
+    switch (type) {
+      case kNoCompression:
+      default:
+        assert(type == kNoCompression);  // Others should be excluded above
+        return nullptr;
+      case kSnappyCompression:
+        return std::make_unique<BuiltinSnappyCompressorV2>(opts);
+      case kZlibCompression:
+        return std::make_unique<BuiltinZlibCompressorV2>(opts);
+      case kBZip2Compression:
+        return std::make_unique<BuiltinBZip2CompressorV2>(opts);
+      case kLZ4Compression:
+        return std::make_unique<BuiltinLZ4CompressorV2>(opts);
+      case kLZ4HCCompression:
+        return std::make_unique<BuiltinLZ4HCCompressorV2>(opts);
+      case kXpressCompression:
+        return std::make_unique<BuiltinXpressCompressorV2>(opts);
+      case kZSTD:
+        return std::make_unique<BuiltinZSTDCompressorV2>(opts);
     }
   }
 
@@ -913,20 +1544,6 @@ class BuiltinCompressionManagerV2 : public CompressionManager {
       return GetGeneralDecompressor();
     }
   }
-  std::shared_ptr<Decompressor> GetDecompressorForCompressor(
-      const Compressor& compressor) override {
-#ifdef ROCKSDB_USE_RTTI
-    // To be extra safe, only optimize here if we are certain we are not
-    // looking at a wrapped compressor, so that we are sure it only uses that
-    // one compression type.
-    if (dynamic_cast<const BuiltinCompressorV2*>(&compressor)) {
-      CompressionType type = compressor.GetPreferredCompressionType();
-      return GetDecompressorForTypes(&type, &type + 1);
-    }
-#endif
-    // Fallback
-    return CompressionManager::GetDecompressorForCompressor(compressor);
-  }
 
   bool SupportsCompressionType(CompressionType type) const override {
     return CompressionTypeSupported(type);
@@ -937,6 +1554,7 @@ class BuiltinCompressionManagerV2 : public CompressionManager {
   BuiltinDecompressorV2OptimizeZstd zstd_decompressor_;
   BuiltinDecompressorV2SnappyOnly snappy_decompressor_;
 
+ public:
   inline std::shared_ptr<Decompressor> GetGeneralDecompressor() {
     return std::shared_ptr<Decompressor>(shared_from_this(), &decompressor_);
   }
@@ -958,6 +1576,16 @@ const std::shared_ptr<BuiltinCompressionManagerV1>
 const std::shared_ptr<BuiltinCompressionManagerV2>
     kBuiltinCompressionManagerV2 =
         std::make_shared<BuiltinCompressionManagerV2>();
+
+std::shared_ptr<Decompressor>
+BuiltinZSTDCompressorV2::GetOptimizedDecompressor() const {
+  return kBuiltinCompressionManagerV2->GetZstdDecompressor();
+}
+
+std::shared_ptr<Decompressor>
+BuiltinSnappyCompressorV2::GetOptimizedDecompressor() const {
+  return kBuiltinCompressionManagerV2->GetSnappyDecompressor();
+}
 
 }  // namespace
 

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -6,7 +6,6 @@
 #include "util/compression.h"
 
 #include "options/options_helper.h"
-#include "port/lang.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/utilities/object_registry.h"
 
@@ -758,8 +757,8 @@ class BuiltinXpressCompressorV2 : public CompressorWithSimpleDictBase {
 
 class BuiltinZSTDCompressorV2 : public CompressorBase {
  public:
-  BuiltinZSTDCompressorV2(const CompressionOptions& opts,
-                          CompressionDict&& dict = {})
+  explicit BuiltinZSTDCompressorV2(const CompressionOptions& opts,
+                                   CompressionDict&& dict = {})
       : CompressorBase(opts), dict_(std::move(dict)) {}
 
   const char* Name() const override { return "BuiltinZSTDCompressorV2"; }
@@ -1417,7 +1416,7 @@ class BuiltinDecompressorV2OptimizeZstd : public BuiltinDecompressorV2 {
 class BuiltinDecompressorV2OptimizeZstdWithDict
     : public BuiltinDecompressorV2OptimizeZstd {
  public:
-  BuiltinDecompressorV2OptimizeZstdWithDict(const Slice& dict)
+  explicit BuiltinDecompressorV2OptimizeZstdWithDict(const Slice& dict)
       :
 #ifdef ROCKSDB_ZSTD_DDICT
         dict_(dict),

--- a/util/compression.h
+++ b/util/compression.h
@@ -34,6 +34,7 @@
 #include "util/string_util.h"
 
 #ifdef SNAPPY
+#include <snappy-sinksource.h>
 #include <snappy.h>
 #endif
 
@@ -48,10 +49,14 @@
 #if defined(LZ4)
 #include <lz4.h>
 #include <lz4hc.h>
+#if LZ4_VERSION_NUMBER < 10700  // < r129
+#error "LZ4 support requires version >= 1.7.0 (lz4-devel)"
+#endif
 #endif
 
 #ifdef ZSTD
 #include <zstd.h>
+#include <zstd_errors.h>
 // ZSTD_Compress2(), ZSTD_compressStream2() and frame parameters all belong to
 // advanced APIs and require v1.4.0+, which is from April 2019.
 // https://github.com/facebook/zstd/blob/eb9f881eb810f2242f1ef36b3f3e7014eecb8fa6/lib/zstd.h#L297C40-L297C45

--- a/util/simple_mixed_compressor.cc
+++ b/util/simple_mixed_compressor.cc
@@ -60,13 +60,15 @@ const char* RandomMixedCompressor::Name() const {
 }
 
 Status RandomMixedCompressor::CompressBlock(
-    Slice uncompressed_data, std::string* compressed_output,
-    CompressionType* out_compression_type, ManagedWorkingArea* wa) {
+    Slice uncompressed_data, char* compressed_output,
+    size_t* compressed_output_size, CompressionType* out_compression_type,
+    ManagedWorkingArea* wa) {
   auto selected =
       Random::GetTLSInstance()->Uniform(static_cast<int>(compressors_.size()));
   auto& compressor = compressors_[selected];
   return compressor->CompressBlock(uncompressed_data, compressed_output,
-                                   out_compression_type, wa);
+                                   compressed_output_size, out_compression_type,
+                                   wa);
 }
 
 const char* RandomMixedCompressionManager::Name() const {
@@ -85,13 +87,15 @@ const char* RoundRobinCompressor::Name() const {
 }
 
 Status RoundRobinCompressor::CompressBlock(
-    Slice uncompressed_data, std::string* compressed_output,
-    CompressionType* out_compression_type, ManagedWorkingArea* wa) {
+    Slice uncompressed_data, char* compressed_output,
+    size_t* compressed_output_size, CompressionType* out_compression_type,
+    ManagedWorkingArea* wa) {
   auto counter = block_counter.FetchAddRelaxed(1);
   auto sel_idx = counter % (compressors_.size());
   auto& compressor = compressors_[sel_idx];
   return compressor->CompressBlock(uncompressed_data, compressed_output,
-                                   out_compression_type, wa);
+                                   compressed_output_size, out_compression_type,
+                                   wa);
 }
 
 RelaxedAtomic<uint64_t> RoundRobinCompressor::block_counter{0};

--- a/util/simple_mixed_compressor.h
+++ b/util/simple_mixed_compressor.h
@@ -34,7 +34,8 @@ class MultiCompressorWrapper : public Compressor {
 struct RandomMixedCompressor : public MultiCompressorWrapper {
   using MultiCompressorWrapper::MultiCompressorWrapper;
   const char* Name() const override;
-  Status CompressBlock(Slice uncompressed_data, std::string* compressed_output,
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
                        CompressionType* out_compression_type,
                        ManagedWorkingArea* wa) override;
 };
@@ -50,7 +51,8 @@ class RandomMixedCompressionManager : public CompressionManagerWrapper {
 struct RoundRobinCompressor : public MultiCompressorWrapper {
   using MultiCompressorWrapper::MultiCompressorWrapper;
   const char* Name() const override;
-  Status CompressBlock(Slice uncompressed_data, std::string* compressed_output,
+  Status CompressBlock(Slice uncompressed_data, char* compressed_output,
+                       size_t* compressed_output_size,
                        CompressionType* out_compression_type,
                        ManagedWorkingArea* wa) override;
   static RelaxedAtomic<uint64_t> block_counter;


### PR DESCRIPTION
Summary: The main motivation for this change is to more flexibly and efficiently support compressing data without extra copies when we do not want to support saving compressed data that is LARGER than the uncompressed. We believe pretty strongly that for the various workloads served by RocksDB, it is well worth a single byte compression marker so that we have the flexibility to save compressed or uncompressed data when compression is attempted. Why? Compression algorithms can add tens of bytes in fixed overheads and percents of bytes in relative overheads. It is also an advantage for the reader when they can bypass decompression, including at least a buffer copy in most cases, after reading just one byte.

The block-based table format in RocksDB follows this model with a single-byte compression marker, and at least after https://github.com/facebook/rocksdb/pull/13797 so does CompressedSecondaryCache. (Notably, the blob file format DOES NOT. This is left to follow-up work.)

In particular, Compressor::CompressBlock now takes in a fixed size buffer for output rather than a `std::string*`. CompressBlock itself rejects the compression if the output would not fit in the provided buffer. This also works well with `max_compressed_bytes_per_kb` option to reject compression even sooner if its ratio is insufficient (implemented in this change). In the future we might use this functionality to reduce a buffer copy (in many cases) into the WritableFileWriter buffer of the block based table builder.

This is a large change because we needed to (or were compelled to)
* Update all the existing callers of CompressBlock, sometimes with substantial changes. This includes introducing GrowableBuffer to reuse between calls rather than std::string, which (at least in C++17) requires zeroing out data when allocating/growing a buffer.
* Re-implement built-in Compressors (V2; V1 is obsolete) to efficiently implement the new version of the API, no longer wrapping the `OLD_CompressData()` function. The new compressors appropriately leverage the CompressBlock virtual call required for the customization interface and no rely on `switch` on compression type for each block. The implementations are largely adaptations of the old implementations, except
  * LZ4 and LZ4HC are notably upgraded to take advantage of WorkingArea (see performance tests). And for simplicity in the new implementation, we are dropping support for some super old versions of the library.
  * Getting snappy to work with limited-size output buffer required using the Sink/Source interfaces, which appear to be well supported for a long time and efficient (see performance tests).
* Replace awkward old CompressionManager::GetDecompressorForCompressor with Compressor::GetOptimizedDecompressor (which is optional to implement)
* Small behavior change where we treat lack of support for compression closer to not configuring compression, such as incompatibility with block_align. This is motivated by giving CompressionManager the freedom of determining when compression can be excluded for an entire file despite the configured "compression" type, and thus only surfacing actual incompatibilities not hypothetical ones that might be irrelevant to the CompressionManager (or build configuration). Unit tests in `table_test` and `compact_files_test` required update.
* Some lingering clean up of CompressedSecondaryCache and a re-optimization made possible by compressing into an existing buffer.

Test Plan: for correctness, existing tests

## Performance Test

As I generally only modified compression paths, I'm using a db_bench write benchmark, with before & after configurations running at the same time. vc=1 means verify_compression=1

```
USE_CLANG=1 DEBUG_LEVEL=0 LIB_MODE=static make -j100 db_bench
SUFFIX=`tty | sed 's|/|_|g'`; for CT in zlib bzip2 none snappy zstd lz4 lz4hc none snappy zstd lz4 bzip2; do for VC in 0 1; do echo "$CT vc=$VC"; (for I in `seq 1 20`; do BIN=/dev/shm/dbbench${SUFFIX}.bin; rm -f $BIN; cp db_bench $BIN; $BIN -db=/dev/shm/dbbench$SUFFIX --benchmarks=fillseq -num=10000000 -compaction_style=2 -fifo_compaction_max_table_files_size_mb=1000 -fifo_compaction_allow_compaction=0 -disable_wal -write_buffer_size=12000000 -format_version=7 -compression_type=$CT -verify_compression=$VC 2>&1 | grep micros/op; done) | awk '{n++; sum += $5;} END { print int(sum / n); }'; done; done
```

zlib vc=0 524198 -> 524904 (+0.1%)
zlib vc=1 430521 -> 430699 (+0.0%)
bzip2 vc=0 61841 -> 60835 (-1.6%)
bzip2 vc=1 49232 -> 48734 (-1.0%)
none vc=0 1802375 -> 1906227 (+5.8%)
none vc=1 1837181 -> 1950308 (+6.2%)
snappy vc=0 1783266 -> 1901461 (+6.6%)
snappy vc=1 1799703 -> 1879660 (+4.4%)
zstd vc=0 1216779 -> 1230507 (+1.1%)
zstd vc=1 996370 -> 1015415 (+1.9%)
lz4 vc=0 1801473 -> 1943095 (+7.9%)
lz4 vc=1 1799155 -> 1935242 (+7.6%)
lz4hc vc=0 349719 -> 1126909 (+222.2%)
lz4hc vc=1 348099 -> 1108933 (+218.6%)
(Repeating the most important ones)
none vc=0 1816878 -> 1952221 (+7.4%)
none vc=1 1813736 -> 1904622 (+5.0%)
snappy vc=0 1794816 -> 1875062 (+4.5%)
snappy vc=1 1789363 -> 1873771 (+4.7%)
zstd vc=0 1202592 -> 1225164 (+1.9%)
zstd vc=1 994322 -> 1016688 (+2.2%)
lz4 vc=0 1786959 -> 1971518 (+10.3%)
lz4 vc=1 1829483 -> 1935871 (+5.8%)

I confirmed manually that the new WorkingArea for LZ4HC makes the huge difference on that one, but not as much difference for LZ4, presumably because LZ4HC uses much larger buffers/structures/whatever for better compression ratios.