### PR TITLE
Bug fix in MultiScan and stress test

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1681,6 +1681,9 @@ Status StressTest::TestMultiScan(ThreadState* thread,
   start_key_strs.reserve(num_scans);
   end_key_strs.reserve(num_scans);
 
+  // Will be initialized before Seek() below.
+  Slice ub;
+  ro.iterate_upper_bound = &ub;
   for (size_t i = 0; i < num_scans * 2; i += 2) {
     assert(rand_keys[i] <= rand_keys[i + 1]);
     start_key_strs.emplace_back(Key(rand_keys[i]));
@@ -1745,8 +1748,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
     assert(scan_opt.range.start);
     assert(scan_opt.range.limit);
     Slice key = scan_opt.range.start.value();
-    Slice ub = scan_opt.range.limit.value();
-    ro.iterate_upper_bound = &ub;
+    ub = scan_opt.range.limit.value();
 
     LastIterateOp last_op;
     iter->Seek(key);

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -932,6 +932,7 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
 // ReadOptions::max_skippable_internal_keys or reseeking into range deletion
 // end key. So these Seeks can cause iterator to fall back to normal
 // (non-prepared) iterator and ignore the optimizations done in Prepare().
+// TODO: support fill_cache = false and when block cache is disabled.
 void BlockBasedTableIterator::Prepare(
     const std::vector<ScanOptions>* scan_opts) {
   index_iter_->Prepare(scan_opts);
@@ -1009,6 +1010,12 @@ void BlockBasedTableIterator::Prepare(
       index_iter_->Next();
       check_overlap = false;
     }
+
+    if (!index_iter_->status().ok()) {
+      // Abort: index iterator error
+      return;
+    }
+
     // Stop until index->key > limit
     // Include the current block since it can still contain keys <= limit
     if (index_iter_->Valid()) {
@@ -1019,13 +1026,15 @@ void BlockBasedTableIterator::Prepare(
         blocks_to_prepare.push_back(index_iter_->value().handle);
       }
       ++num_blocks;
-    }
-
-    if (!index_iter_->status().ok()) {
-      // Abort: index iterator error
+    } else if (num_blocks == 0) {
+      assert(false);
+      // We should not have scan ranges that are completely after the file's
+      // range. This is important for FindBlockForwardInMultiScan() which only
+      // lets the upper layer (LevelIterator) advance to the next SST file when
+      // the last scan range is exhausted.
       return;
     }
-
+    assert(num_blocks);
     block_ranges_per_scan.emplace_back(blocks_to_prepare.size() - num_blocks,
                                        blocks_to_prepare.size());
   }
@@ -1168,6 +1177,7 @@ void BlockBasedTableIterator::Prepare(
           // Abort: failed to create and pin block in cache
           return;
         }
+        assert(pinned_data_blocks_guard[block_idx].GetValue());
       }
     }
   }
@@ -1234,6 +1244,10 @@ bool BlockBasedTableIterator::SeekMultiScan(const Slice* target) {
     return true;
   }
 
+  // We are aborting MultiScan.
+  ResetDataIter();
+  assert(!is_index_at_curr_block_);
+  assert(!block_iter_points_to_real_block_);
   return false;
 }
 
@@ -1247,7 +1261,21 @@ void BlockBasedTableIterator::FindBlockForwardInMultiScan() {
       return;
     }
 
+    // If is_out_of_bound_ is true, upper layer (LevelIterator) considers this
+    // level has reached iterate_upper_bound_ and will not continue to iterate
+    // into the next file. When we are doing the last scan within a MultiScan
+    // for this file, it may need to continue to scan into the next file, so
+    // we do not set is_out_of_bound_ in this case.
     if (multi_scan_->cur_data_block_idx + 1 >= cur_scan_end_idx) {
+      if (multi_scan_->next_scan_idx >=
+          multi_scan_->block_ranges_per_scan.size()) {
+        // We are done with this file, should let LevelIter advance to the next
+        // file instead of ending the scan
+        ResetDataIter();
+        assert(!is_out_of_bound_);
+        assert(!Valid());
+        return;
+      }
       // We don't ResetDataIter() here since next scan might be reading from
       // the same block. ResetDataIter() will free the underlying block cache
       // handle and we don't want the block to be unpinned.

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -1027,7 +1027,6 @@ void BlockBasedTableIterator::Prepare(
       }
       ++num_blocks;
     } else if (num_blocks == 0) {
-      assert(false);
       // We should not have scan ranges that are completely after the file's
       // range. This is important for FindBlockForwardInMultiScan() which only
       // lets the upper layer (LevelIterator) advance to the next SST file when

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -160,6 +160,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     } else if (block_upper_bound_check_ ==
                BlockUpperBound::kUpperBoundBeyondCurBlock) {
       assert(!is_out_of_bound_);
+      // MultiScan does not do block level upper bound check yet.
+      assert(!multi_scan_);
       return IterBoundCheck::kInbound;
     } else {
       return IterBoundCheck::kUnknown;

--- a/unreleased_history/bug_fixes/multi-scan.md
+++ b/unreleased_history/bug_fixes/multi-scan.md
@@ -1,0 +1,1 @@
+* Fix a bug in MultiScan where incorrect results can be returned when a Scan's range is across multiple files.


### PR DESCRIPTION
Summary: Fix a bug in MultiScan where BlockBasedTableIterator should not return out-of-bound when the all blocks of the last scan are exhausted. This prevented LevelIterator from entering the next file so iterator is returning less keys than expected.

Also fixed stress testing to specify iterate_upper_bound correctly.

Test plan:
- the following fails quickly before this PR and finishes after this PR
```python3 tools/db_crashtest.py whitebox --iterpercent=60 --prefix_size=-1 --prefixpercent=0 --readpercent=0 --test_batches_snapshots=0 --use_multiscan=1 --seed=1 --fill_cache=1 --read_fault_one_in=0 --column_families=1 --allow_unprepared_value=0 --kill_random_test=88888```
- new unit test that fails before this PR