### PR TITLE
Refactor/improve PartitionedIndexBuilder::AddIndexEntry

### DIFF
--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1938,7 +1938,7 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
           rep_->p_index_builder_->TopLevelIndexSize(rep_->offset);
     }
     rep_->props.index_key_is_user_key =
-        !rep_->index_builder->seperator_is_key_plus_seq();
+        !rep_->index_builder->separator_is_key_plus_seq();
     rep_->props.index_value_is_delta_encoded =
         rep_->use_delta_encoding_for_index_values;
     if (rep_->sampled_input_data_bytes > 0) {

--- a/table/block_based/flush_block_policy.cc
+++ b/table/block_based/flush_block_policy.cc
@@ -19,7 +19,7 @@
 namespace ROCKSDB_NAMESPACE {
 
 // Flush block by size
-class FlushBlockBySizePolicy : public FlushBlockPolicy {
+class FlushBlockBySizePolicy : public RetargetableFlushBlockPolicy {
  public:
   // @params block_size:           Approximate size of user data packed per
   //                               block.
@@ -28,19 +28,19 @@ class FlushBlockBySizePolicy : public FlushBlockPolicy {
   FlushBlockBySizePolicy(const uint64_t block_size,
                          const uint64_t block_size_deviation, const bool align,
                          const BlockBuilder& data_block_builder)
-      : block_size_(block_size),
+      : RetargetableFlushBlockPolicy(data_block_builder),
+        block_size_(block_size),
         block_size_deviation_limit_(
             ((block_size * (100 - block_size_deviation)) + 99) / 100),
-        align_(align),
-        data_block_builder_(data_block_builder) {}
+        align_(align) {}
 
   bool Update(const Slice& key, const Slice& value) override {
     // it makes no sense to flush when the data block is empty
-    if (data_block_builder_.empty()) {
+    if (data_block_builder_->empty()) {
       return false;
     }
 
-    auto curr_size = data_block_builder_.CurrentSizeEstimate();
+    auto curr_size = data_block_builder_->CurrentSizeEstimate();
 
     // Do flush if one of the below two conditions is true:
     // 1) if the current estimated size already exceeds the block size,
@@ -56,9 +56,9 @@ class FlushBlockBySizePolicy : public FlushBlockPolicy {
       return false;
     }
 
-    const auto curr_size = data_block_builder_.CurrentSizeEstimate();
+    const auto curr_size = data_block_builder_->CurrentSizeEstimate();
     auto estimated_size_after =
-        data_block_builder_.EstimateSizeAfterKV(key, value);
+        data_block_builder_->EstimateSizeAfterKV(key, value);
 
     if (align_) {
       estimated_size_after += BlockBasedTable::kBlockTrailerSize;
@@ -72,7 +72,6 @@ class FlushBlockBySizePolicy : public FlushBlockPolicy {
   const uint64_t block_size_;
   const uint64_t block_size_deviation_limit_;
   const bool align_;
-  const BlockBuilder& data_block_builder_;
 };
 
 FlushBlockPolicy* FlushBlockBySizePolicyFactory::NewFlushBlockPolicy(
@@ -83,10 +82,18 @@ FlushBlockPolicy* FlushBlockBySizePolicyFactory::NewFlushBlockPolicy(
       table_options.block_align, data_block_builder);
 }
 
+std::unique_ptr<RetargetableFlushBlockPolicy> NewFlushBlockBySizePolicy(
+    const uint64_t size, const int deviation,
+    const BlockBuilder& data_block_builder) {
+  return std::make_unique<FlushBlockBySizePolicy>(size, deviation, false,
+                                                  data_block_builder);
+}
+
 FlushBlockPolicy* FlushBlockBySizePolicyFactory::NewFlushBlockPolicy(
     const uint64_t size, const int deviation,
     const BlockBuilder& data_block_builder) {
-  return new FlushBlockBySizePolicy(size, deviation, false, data_block_builder);
+  return NewFlushBlockBySizePolicy(size, deviation, data_block_builder)
+      .release();
 }
 
 static int RegisterFlushBlockPolicyFactories(ObjectLibrary& library,

--- a/table/block_based/flush_block_policy_impl.h
+++ b/table/block_based/flush_block_policy_impl.h
@@ -42,7 +42,7 @@ class FlushBlockEveryKeyPolicyFactory : public FlushBlockPolicyFactory {
 // be safely re-targeted to another block builder.
 class RetargetableFlushBlockPolicy : public FlushBlockPolicy {
  public:
-  RetargetableFlushBlockPolicy(const BlockBuilder& data_block_builder)
+  explicit RetargetableFlushBlockPolicy(const BlockBuilder& data_block_builder)
       : data_block_builder_(&data_block_builder) {}
 
   void Retarget(const BlockBuilder& data_block_builder) {

--- a/table/block_based/flush_block_policy_impl.h
+++ b/table/block_based/flush_block_policy_impl.h
@@ -3,6 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#pragma once
 #include "rocksdb/flush_block_policy.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/table/block_based/flush_block_policy_impl.h
+++ b/table/block_based/flush_block_policy_impl.h
@@ -37,4 +37,23 @@ class FlushBlockEveryKeyPolicyFactory : public FlushBlockPolicyFactory {
   }
 };
 
+// For internal use, policy that is stateless after creation, meaning it can
+// be safely re-targeted to another block builder.
+class RetargetableFlushBlockPolicy : public FlushBlockPolicy {
+ public:
+  RetargetableFlushBlockPolicy(const BlockBuilder& data_block_builder)
+      : data_block_builder_(&data_block_builder) {}
+
+  void Retarget(const BlockBuilder& data_block_builder) {
+    data_block_builder_ = &data_block_builder;
+  }
+
+ protected:
+  const BlockBuilder* data_block_builder_;
+};
+
+std::unique_ptr<RetargetableFlushBlockPolicy> NewFlushBlockBySizePolicy(
+    const uint64_t size, const int deviation,
+    const BlockBuilder& data_block_builder);
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -240,7 +240,7 @@ Status PartitionedFilterBlockBuilder::Finish(
 
     index_on_filter_block_builder_.Add(e.ikey, handle_encoding,
                                        &handle_delta_encoding_slice);
-    if (!p_index_builder_->seperator_is_key_plus_seq()) {
+    if (!p_index_builder_->separator_is_key_plus_seq()) {
       index_on_filter_block_builder_without_seq_.Add(
           ExtractUserKey(e.ikey), handle_encoding,
           &handle_delta_encoding_slice);
@@ -267,7 +267,7 @@ Status PartitionedFilterBlockBuilder::Finish(
     if (UNLIKELY(filters_.empty())) {
       if (!index_on_filter_block_builder_.empty()) {
         // Simplest to just add them all at the end
-        if (p_index_builder_->seperator_is_key_plus_seq()) {
+        if (p_index_builder_->separator_is_key_plus_seq()) {
           *filter = index_on_filter_block_builder_.Finish();
         } else {
           *filter = index_on_filter_block_builder_without_seq_.Finish();

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -27,7 +27,7 @@ class MockedBlockBasedTable : public BlockBasedTable {
   MockedBlockBasedTable(Rep* rep, PartitionedIndexBuilder* pib)
       : BlockBasedTable(rep, /*block_cache_tracer=*/nullptr) {
     // Initialize what Open normally does as much as necessary for the test
-    rep->index_key_includes_seq = pib->seperator_is_key_plus_seq();
+    rep->index_key_includes_seq = pib->separator_is_key_plus_seq();
     rep->index_value_is_full = !pib->get_use_value_delta_encoding();
   }
 };

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -111,8 +111,8 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
 
   size_t IndexSize() const override { return index_size_; }
 
-  bool seperator_is_key_plus_seq() override {
-    return internal_index_builder_->seperator_is_key_plus_seq();
+  bool separator_is_key_plus_seq() override {
+    return internal_index_builder_->separator_is_key_plus_seq();
   }
 
  private:


### PR DESCRIPTION
Summary: In anticipation of an enhancement related to parallel compression
* Rename confusing state variables `seperator_is_key_plus_seq_` -> `must_use_separator_with_seq_`
* Eliminate copy-paste code in `PartitionedIndexBuilder::AddIndexEntry`
* Optimize/simplify `PartitionedIndexBuilder::flush_policy_` by allowing a single policy to be re-targetted to different block builders. Added some additional internal APIs to make this work, and it only works because the FlushBlockBySizePolicy is otherwise stateless (after creation).
* Improve some comments, including another proposed optimization especially for the common case of no live snapshots affecting a large compaction

Test Plan: existing tests are pretty exhaustive, especially with crash test

Planning to validate performance in combination with next change. (This change is saving some extra allocate/deallocate with partitioned index.)