### PR TITLE
Fix remote compaction stress test

### DIFF
--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -135,12 +135,14 @@ bool RunStressTestImpl(SharedState* shared) {
   }
 
   std::vector<ThreadState*> remote_compaction_worker_threads;
-  remote_compaction_worker_threads.reserve(
-      remote_compaction_worker_thread_count);
-  for (uint32_t i = 0; i < remote_compaction_worker_thread_count; i++) {
-    ThreadState* ts = new ThreadState(i, shared);
-    remote_compaction_worker_threads.push_back(ts);
-    db_stress_env->StartThread(RemoteCompactionWorkerThread, ts);
+  if (remote_compaction_worker_thread_count > 0) {
+    remote_compaction_worker_threads.reserve(
+        remote_compaction_worker_thread_count);
+    for (uint32_t i = 0; i < remote_compaction_worker_thread_count; i++) {
+      ThreadState* ts = new ThreadState(i, shared);
+      remote_compaction_worker_threads.push_back(ts);
+      db_stress_env->StartThread(RemoteCompactionWorkerThread, ts);
+    }
   }
 
   // Each thread goes through the following states:

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -135,14 +135,12 @@ bool RunStressTestImpl(SharedState* shared) {
   }
 
   std::vector<ThreadState*> remote_compaction_worker_threads;
-  if (remote_compaction_worker_thread_count > 0) {
-    remote_compaction_worker_threads.reserve(
-        remote_compaction_worker_thread_count);
-    for (uint32_t i = 0; i < remote_compaction_worker_thread_count; i++) {
-      remote_compaction_worker_threads[i] = new ThreadState(i, shared);
-      db_stress_env->StartThread(RemoteCompactionWorkerThread,
-                                 remote_compaction_worker_threads[i]);
-    }
+  remote_compaction_worker_threads.reserve(
+      remote_compaction_worker_thread_count);
+  for (uint32_t i = 0; i < remote_compaction_worker_thread_count; i++) {
+    ThreadState* ts = new ThreadState(i, shared);
+    remote_compaction_worker_threads.push_back(ts);
+    db_stress_env->StartThread(RemoteCompactionWorkerThread, ts);
   }
 
   // Each thread goes through the following states:
@@ -253,7 +251,7 @@ bool RunStressTestImpl(SharedState* shared) {
       FLAGS_continuous_verification_interval > 0 ||
       FLAGS_compressed_secondary_cache_size > 0 ||
       FLAGS_compressed_secondary_cache_ratio > 0.0 ||
-      FLAGS_remote_compaction_worker_threads > 0) {
+      remote_compaction_worker_thread_count > 0) {
     MutexLock l(shared->GetMutex());
     shared->SetShouldStopBgThread();
     while (!shared->BgThreadsFinished()) {
@@ -261,14 +259,13 @@ bool RunStressTestImpl(SharedState* shared) {
     }
   }
 
-  // Kill remote compaction workers
+  assert(remote_compaction_worker_threads.size() ==
+         remote_compaction_worker_thread_count);
   if (remote_compaction_worker_thread_count > 0) {
-    assert(remote_compaction_worker_threads.capacity() ==
-           remote_compaction_worker_thread_count);
-    for (uint32_t i = 0; i < remote_compaction_worker_thread_count; i++) {
-      delete remote_compaction_worker_threads[i];
-      remote_compaction_worker_threads[i] = nullptr;
+    for (ThreadState* thread_state : remote_compaction_worker_threads) {
+      delete thread_state;
     }
+    remote_compaction_worker_threads.clear();
   }
 
   if (shared->HasVerificationFailedYet()) {

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1086,6 +1086,9 @@ def finalize_and_sanitize(src_params):
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
     if dest_params.get("test_secondary") == 1:
         dest_params["continuous_verification_interval"] = 0
+    # TODO Fix races when both Remote Compaction + BlobDB enabled
+    if dest_params.get("remote_compaction_worker_threads") > 0:
+       dest_params["enable_blob_files"] = 0
     return dest_params
 
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -343,9 +343,8 @@ default_params = {
     "use_timed_put_one_in": lambda: random.choice([0] * 7 + [1, 5, 10]),
     "universal_max_read_amp": lambda: random.choice([-1] * 3 + [0, 4, 10]),
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
-    "allow_unprepared_value": lambda: random.choice([0, 1]),
-    # TODO(jaykorean): re-enable remote compaction stress test once fixed
-    "remote_compaction_worker_threads": lambda: 0,
+    "allow_unprepared_value": lambda: random.choice([0, 1]),    
+    "remote_compaction_worker_threads": lambda: random.choice([0, 8]),
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
     "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
     "memtable_avg_op_scan_flush_trigger": lambda: random.choice([0, 2, 20, 200]),


### PR DESCRIPTION
# Summary

Remote Compaction in the stress test previously failed with the following error, so we temporarily disabled it in PR #13815 :

```
reference std::vector<rocksdb::ThreadState *>::operator[](size_type) [_Tp = rocksdb::ThreadState *, _Alloc = std::allocator<rocksdb::ThreadState *>]: Assertion '__n < this->size()' failed.
```

The error was from accessing `remote_compaction_worker_threads[i]` when `i < remote_compaction_worker_threads.size()` which leads to an undefined behavior. This PR fixes the issue by properly setting the worker thread pointers in `remote_compaction_worker_threads`.

Note: We are still encountering errors when both BlobDB and Remote Compaction are enabled. It appears to be a race condition. For now, BlobDB is temporarily disabled if remote compaction is enabled. We will fix the race condition and re-enable BlobDB as a follow-up.

# Test Plan
```
python3 -u tools/db_crashtest.py blackbox --remote_compaction_worker_threads=16 --interval=2 --duration=180 
```