### PR TITLE
Do not delete file at high priority thread pool

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -3029,7 +3029,7 @@ class DBImpl : public DB {
   // stores the number of flushes are currently running
   int num_running_flushes_ = 0;
 
-  // number of background obsolete file purge jobs, submitted to the HIGH pool
+  // number of background obsolete file purge jobs, submitted to the LOW pool
   int bg_purge_scheduled_ = 0;
 
   std::deque<ManualCompactionState*> manual_compaction_dequeue_;

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -3378,7 +3378,10 @@ void DBImpl::BackgroundCallFlush(Env::Priority thread_pri) {
       // It also applies to access other states that DB owns.
       log_buffer.FlushBufferToLog();
       if (job_context.HaveSomethingToDelete()) {
-        PurgeObsoleteFiles(job_context);
+        // The Flush thread dedicated solely to Flush, don't perform Purge
+        // tasks.
+        bool schedule_only = thread_pri == Env::HIGH;
+        PurgeObsoleteFiles(job_context, schedule_only);
       }
       job_context.Clean();
       mutex_.Lock();


### PR DESCRIPTION
Running both Flush and Purge operations in the HIGH Priority thread pool poses a risk. Compared to Purge, if Flush becomes slow, it can lead to Write Stop, which is an extremely severe issue. Therefore, Purge operations must use the LOW Priority thread pool.