### PR TITLE
Introduction of MultiScanOptions

### DIFF
--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -98,7 +98,7 @@ class ArenaWrappedDBIter : public Iterator {
 
   bool PrepareValue() override { return db_iter_->PrepareValue(); }
 
-  void Prepare(const MultiScanOptions& scan_opts) override {
+  void Prepare(const MultiScanArgs& scan_opts) override {
     db_iter_->Prepare(scan_opts);
   }
 

--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -98,7 +98,7 @@ class ArenaWrappedDBIter : public Iterator {
 
   bool PrepareValue() override { return db_iter_->PrepareValue(); }
 
-  void Prepare(const std::vector<ScanOptions>& scan_opts) override {
+  void Prepare(const MultiScanOptions& scan_opts) override {
     db_iter_->Prepare(scan_opts);
   }
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3835,7 +3835,7 @@ bool DBImpl::KeyMayExist(const ReadOptions& read_options,
 
 std::unique_ptr<MultiScan> DBImpl::NewMultiScan(
     const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
-    const MultiScanOptions& scan_opts) {
+    const MultiScanArgs& scan_opts) {
   std::unique_ptr<MultiScan> ms_iter = std::make_unique<MultiScan>(
       _read_options, scan_opts, this, column_family);
   return ms_iter;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3835,7 +3835,7 @@ bool DBImpl::KeyMayExist(const ReadOptions& read_options,
 
 std::unique_ptr<MultiScan> DBImpl::NewMultiScan(
     const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
-    const std::vector<ScanOptions>& scan_opts) {
+    const MultiScanOptions& scan_opts) {
   std::unique_ptr<MultiScan> ms_iter = std::make_unique<MultiScan>(
       _read_options, scan_opts, this, column_family);
   return ms_iter;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -386,7 +386,7 @@ class DBImpl : public DB {
   using DB::NewMultiScan;
   std::unique_ptr<MultiScan> NewMultiScan(
       const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
-      const MultiScanOptions& scan_opts) override;
+      const MultiScanArgs& scan_opts) override;
 
   const Snapshot* GetSnapshot() override;
   void ReleaseSnapshot(const Snapshot* snapshot) override;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -386,7 +386,7 @@ class DBImpl : public DB {
   using DB::NewMultiScan;
   std::unique_ptr<MultiScan> NewMultiScan(
       const ReadOptions& _read_options, ColumnFamilyHandle* column_family,
-      const std::vector<ScanOptions>& scan_opts) override;
+      const MultiScanOptions& scan_opts) override;
 
   const Snapshot* GetSnapshot() override;
   void ReleaseSnapshot(const Snapshot* snapshot) override;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -240,8 +240,8 @@ class DBIter final : public Iterator {
 
   bool PrepareValue() override;
 
-  void Prepare(const std::vector<ScanOptions>& scan_opts) override {
-    std::optional<std::vector<ScanOptions>> new_scan_opts;
+  void Prepare(const MultiScanOptions& scan_opts) override {
+    std::optional<MultiScanOptions> new_scan_opts;
     new_scan_opts.emplace(scan_opts);
     scan_opts_.swap(new_scan_opts);
     if (!scan_opts.empty()) {
@@ -505,7 +505,7 @@ class DBIter final : public Iterator {
   const Slice* const timestamp_lb_;
   const size_t timestamp_size_;
   std::string saved_timestamp_;
-  std::optional<std::vector<ScanOptions>> scan_opts_;
+  std::optional<MultiScanOptions> scan_opts_;
   ReadOnlyMemTable* const active_mem_;
   SequenceNumber memtable_seqno_lb_;
   uint32_t memtable_op_scan_flush_trigger_;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -240,8 +240,8 @@ class DBIter final : public Iterator {
 
   bool PrepareValue() override;
 
-  void Prepare(const MultiScanOptions& scan_opts) override {
-    std::optional<MultiScanOptions> new_scan_opts;
+  void Prepare(const MultiScanArgs& scan_opts) override {
+    std::optional<MultiScanArgs> new_scan_opts;
     new_scan_opts.emplace(scan_opts);
     scan_opts_.swap(new_scan_opts);
     if (!scan_opts.empty()) {
@@ -505,7 +505,7 @@ class DBIter final : public Iterator {
   const Slice* const timestamp_lb_;
   const size_t timestamp_size_;
   std::string saved_timestamp_;
-  std::optional<MultiScanOptions> scan_opts_;
+  std::optional<MultiScanArgs> scan_opts_;
   ReadOnlyMemTable* const active_mem_;
   SequenceNumber memtable_seqno_lb_;
   uint32_t memtable_op_scan_flush_trigger_;

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -4159,7 +4159,7 @@ TEST_F(DBMultiScanIteratorTest, BasicTest) {
 
   std::vector<std::string> key_ranges({"k03", "k10", "k25", "k50"});
   ReadOptions ro;
-  MultiScanOptions scan_options(BytewiseComparator());
+  MultiScanArgs scan_options(BytewiseComparator());
   scan_options.insert(key_ranges[0], key_ranges[1]);
   scan_options.insert(key_ranges[2], key_ranges[3]);
   ColumnFamilyHandle* cfh = dbfull()->DefaultColumnFamily();
@@ -4190,7 +4190,7 @@ TEST_F(DBMultiScanIteratorTest, BasicTest) {
 
   // Test the overlapping scan case
   key_ranges[1] = "k30";
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(key_ranges[0], key_ranges[1]);
   scan_options.insert(key_ranges[2], key_ranges[3]);
 
@@ -4219,7 +4219,7 @@ TEST_F(DBMultiScanIteratorTest, BasicTest) {
   iter.reset();
 
   // Test the no limit scan case
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(key_ranges[0]);
   scan_options.insert(key_ranges[2]);
   iter = dbfull()->NewMultiScan(ro, cfh, scan_options);
@@ -4261,7 +4261,7 @@ TEST_F(DBMultiScanIteratorTest, MixedBoundsTest) {
   std::vector<std::string> key_ranges(
       {"k03", "k10", "k25", "k50", "k75", "k90"});
   ReadOptions ro;
-  MultiScanOptions scan_options(BytewiseComparator());
+  MultiScanArgs scan_options(BytewiseComparator());
   scan_options.insert(key_ranges[0], key_ranges[1]);
   scan_options.insert(key_ranges[2]);
   scan_options.insert(key_ranges[4], key_ranges[5]);
@@ -4275,12 +4275,12 @@ TEST_F(DBMultiScanIteratorTest, MixedBoundsTest) {
       for (auto it : range) {
         ASSERT_GE(
             it.first.ToString().compare(
-                scan_options.GetScanOptions()[idx].range.start->ToString()),
+                scan_options.GetScanRanges()[idx].range.start->ToString()),
             0);
-        if (scan_options.GetScanOptions()[idx].range.limit) {
+        if (scan_options.GetScanRanges()[idx].range.limit) {
           ASSERT_LT(
               it.first.ToString().compare(
-                  scan_options.GetScanOptions()[idx].range.limit->ToString()),
+                  scan_options.GetScanRanges()[idx].range.limit->ToString()),
               0);
         }
         count++;
@@ -4298,7 +4298,7 @@ TEST_F(DBMultiScanIteratorTest, MixedBoundsTest) {
     abort();
   }
   iter.reset();
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(key_ranges[0]);
   scan_options.insert(key_ranges[2], key_ranges[3]);
   scan_options.insert(key_ranges[4]);
@@ -4310,12 +4310,12 @@ TEST_F(DBMultiScanIteratorTest, MixedBoundsTest) {
       for (auto it : range) {
         ASSERT_GE(
             it.first.ToString().compare(
-                scan_options.GetScanOptions()[idx].range.start->ToString()),
+                scan_options.GetScanRanges()[idx].range.start->ToString()),
             0);
-        if (scan_options.GetScanOptions()[idx].range.limit) {
+        if (scan_options.GetScanRanges()[idx].range.limit) {
           ASSERT_LT(
               it.first.ToString().compare(
-                  scan_options.GetScanOptions()[idx].range.limit->ToString()),
+                  scan_options.GetScanRanges()[idx].range.limit->ToString()),
               0);
         }
         count++;
@@ -4354,7 +4354,7 @@ TEST_F(DBMultiScanIteratorTest, RangeAcrossFiles) {
   ASSERT_EQ(2, NumTableFilesAtLevel(49));
   std::vector<std::string> key_ranges({Key(10), Key(90)});
   ReadOptions ro;
-  MultiScanOptions scan_options(BytewiseComparator());
+  MultiScanArgs scan_options(BytewiseComparator());
   scan_options.insert(key_ranges[0], key_ranges[1]);
   ColumnFamilyHandle* cfh = dbfull()->DefaultColumnFamily();
   std::unique_ptr<MultiScan> iter =

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -4350,8 +4350,8 @@ TEST_F(DBMultiScanIteratorTest, RangeAcrossFiles) {
   ASSERT_EQ(2, NumTableFilesAtLevel(49));
   std::vector<std::string> key_ranges({Key(10), Key(90)});
   ReadOptions ro;
-  std::vector<ScanOptions> scan_options(
-      {ScanOptions(key_ranges[0], key_ranges[1])});
+  MultiScanOptions scan_options(BytewiseComparator());
+  scan_options.insert(key_ranges[0], key_ranges[1]);
   ColumnFamilyHandle* cfh = dbfull()->DefaultColumnFamily();
   std::unique_ptr<MultiScan> iter =
       dbfull()->NewMultiScan(ro, cfh, scan_options);

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -4190,7 +4190,10 @@ TEST_F(DBMultiScanIteratorTest, BasicTest) {
 
   // Test the overlapping scan case
   key_ranges[1] = "k30";
-  scan_options.GetScanOptions()[0] = ScanOptions(key_ranges[0], key_ranges[1]);
+  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options.insert(key_ranges[0], key_ranges[1]);
+  scan_options.insert(key_ranges[2], key_ranges[3]);
+
   iter = dbfull()->NewMultiScan(ro, cfh, scan_options);
   try {
     int idx = 0;
@@ -4216,8 +4219,9 @@ TEST_F(DBMultiScanIteratorTest, BasicTest) {
   iter.reset();
 
   // Test the no limit scan case
-  scan_options.GetScanOptions()[0] = ScanOptions(key_ranges[0]);
-  scan_options.GetScanOptions()[1] = ScanOptions(key_ranges[2]);
+  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options.insert(key_ranges[0]);
+  scan_options.insert(key_ranges[2]);
   iter = dbfull()->NewMultiScan(ro, cfh, scan_options);
   try {
     int idx = 0;
@@ -4294,10 +4298,10 @@ TEST_F(DBMultiScanIteratorTest, MixedBoundsTest) {
     abort();
   }
   iter.reset();
-  auto& opts = scan_options.GetScanOptions();
-  opts[0] = ScanOptions(key_ranges[0]);
-  opts[1] = ScanOptions(key_ranges[2], key_ranges[3]);
-  opts[2] = ScanOptions(key_ranges[4]);
+  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options.insert(key_ranges[0]);
+  scan_options.insert(key_ranges[2], key_ranges[3]);
+  scan_options.insert(key_ranges[4]);
   iter = dbfull()->NewMultiScan(ro, cfh, scan_options);
   try {
     int idx = 0;

--- a/db/multi_scan.cc
+++ b/db/multi_scan.cc
@@ -22,7 +22,7 @@ MultiScan::MultiScan(const ReadOptions& read_options,
   } else {
     read_options_.iterate_upper_bound = nullptr;
   }
-  for (auto opts : scan_opts.GetScanOptions()) {
+  for (const auto& opts : scan_opts.GetScanOptions()) {
     // Check that all the ScanOptions either specify an upper bound or not. If
     // its mixed we take the slow path which avoids calling Prepare: we have to
     // reallocate the Iterator with updated read_options everytime we switch

--- a/db/multi_scan.cc
+++ b/db/multi_scan.cc
@@ -10,24 +10,25 @@ namespace ROCKSDB_NAMESPACE {
 using MultiScanIterator = MultiScan::MultiScanIterator;
 
 MultiScan::MultiScan(const ReadOptions& read_options,
-                     const std::vector<ScanOptions>& scan_opts, DB* db,
+                     const MultiScanOptions& scan_opts, DB* db,
                      ColumnFamilyHandle* cfh)
     : read_options_(read_options), scan_opts_(scan_opts), db_(db), cfh_(cfh) {
   bool slow_path = false;
   // Setup read_options with iterate_uuper_bound based on the first scan.
   // Subsequent scans will update and allocate a new DB iterator as necessary
-  if (scan_opts[0].range.limit) {
-    upper_bound_ = *scan_opts[0].range.limit;
+  if (scan_opts.GetScanOptions()[0].range.limit) {
+    upper_bound_ = *scan_opts.GetScanOptions()[0].range.limit;
     read_options_.iterate_upper_bound = &upper_bound_;
   } else {
     read_options_.iterate_upper_bound = nullptr;
   }
-  for (auto opts : scan_opts) {
+  for (auto opts : scan_opts.GetScanOptions()) {
     // Check that all the ScanOptions either specify an upper bound or not. If
     // its mixed we take the slow path which avoids calling Prepare: we have to
     // reallocate the Iterator with updated read_options everytime we switch
     // between upper bound or no upper bound, which complicates Prepare.
-    if (opts.range.limit.has_value() != scan_opts[0].range.limit.has_value()) {
+    if (opts.range.limit.has_value() !=
+        scan_opts.GetScanOptions()[0].range.limit.has_value()) {
       slow_path = true;
       break;
     }

--- a/db/multi_scan.cc
+++ b/db/multi_scan.cc
@@ -10,25 +10,25 @@ namespace ROCKSDB_NAMESPACE {
 using MultiScanIterator = MultiScan::MultiScanIterator;
 
 MultiScan::MultiScan(const ReadOptions& read_options,
-                     const MultiScanOptions& scan_opts, DB* db,
+                     const MultiScanArgs& scan_opts, DB* db,
                      ColumnFamilyHandle* cfh)
     : read_options_(read_options), scan_opts_(scan_opts), db_(db), cfh_(cfh) {
   bool slow_path = false;
   // Setup read_options with iterate_uuper_bound based on the first scan.
   // Subsequent scans will update and allocate a new DB iterator as necessary
-  if (scan_opts.GetScanOptions()[0].range.limit) {
-    upper_bound_ = *scan_opts.GetScanOptions()[0].range.limit;
+  if (scan_opts.GetScanRanges()[0].range.limit) {
+    upper_bound_ = *scan_opts.GetScanRanges()[0].range.limit;
     read_options_.iterate_upper_bound = &upper_bound_;
   } else {
     read_options_.iterate_upper_bound = nullptr;
   }
-  for (const auto& opts : scan_opts.GetScanOptions()) {
+  for (const auto& opts : scan_opts.GetScanRanges()) {
     // Check that all the ScanOptions either specify an upper bound or not. If
     // its mixed we take the slow path which avoids calling Prepare: we have to
     // reallocate the Iterator with updated read_options everytime we switch
     // between upper bound or no upper bound, which complicates Prepare.
     if (opts.range.limit.has_value() !=
-        scan_opts.GetScanOptions()[0].range.limit.has_value()) {
+        scan_opts.GetScanRanges()[0].range.limit.has_value()) {
       slow_path = true;
       break;
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1139,9 +1139,8 @@ class LevelIterator final : public InternalIterator {
       // 3. [  S  ] ...... [  E  ]
       for (auto i = fstart; i <= fend; i++) {
         if (i < flevel_->num_files) {
-          (*file_to_scan_opts_)[i].insert(start.value(), end.value());
-          (*file_to_scan_opts_)[i].GetScanOptions().back().property_bag =
-              opt.property_bag;
+          (*file_to_scan_opts_)[i].insert(start.value(), end.value(),
+                                          opt.property_bag);
         }
       }
     }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1677,7 +1677,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
 
   std::vector<std::string> start_key_strs;
   std::vector<std::string> end_key_strs;
-  MultiScanOptions scan_opts;
+  MultiScanArgs scan_opts;
   start_key_strs.reserve(num_scans);
   end_key_strs.reserve(num_scans);
 
@@ -1715,7 +1715,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
     return true;
   };
 
-  for (const ScanOptions& scan_opt : scan_opts.GetScanOptions()) {
+  for (const ScanOptions& scan_opt : scan_opts.GetScanRanges()) {
     if (op_logs.size() > kOpLogsLimit) {
       // Shouldn't take too much memory for the history log. Clear it.
       op_logs = "(cleared...)\n";

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1677,7 +1677,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
 
   std::vector<std::string> start_key_strs;
   std::vector<std::string> end_key_strs;
-  std::vector<ScanOptions> scan_opts;
+  MultiScanOptions scan_opts;
   start_key_strs.reserve(num_scans);
   end_key_strs.reserve(num_scans);
 
@@ -1688,7 +1688,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
     assert(rand_keys[i] <= rand_keys[i + 1]);
     start_key_strs.emplace_back(Key(rand_keys[i]));
     end_key_strs.emplace_back(Key(rand_keys[i + 1]));
-    scan_opts.emplace_back(start_key_strs.back(), end_key_strs.back());
+    scan_opts.insert(Slice(start_key_strs.back()), Slice(end_key_strs.back()));
   }
 
   std::string op_logs;
@@ -1715,7 +1715,7 @@ Status StressTest::TestMultiScan(ThreadState* thread,
     return true;
   };
 
-  for (const ScanOptions& scan_opt : scan_opts) {
+  for (const ScanOptions& scan_opt : scan_opts.GetScanOptions()) {
     if (op_logs.size() > kOpLogsLimit) {
       // Shouldn't take too much memory for the history log. Clear it.
       op_logs = "(cleared...)\n";

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1119,7 +1119,7 @@ class DB {
   //  }
   virtual std::unique_ptr<MultiScan> NewMultiScan(
       const ReadOptions& /*options*/, ColumnFamilyHandle* /*column_family*/,
-      const MultiScanOptions& /*scan_opts*/) {
+      const MultiScanArgs& /*scan_opts*/) {
     std::unique_ptr<Iterator> iter(NewErrorIterator(Status::NotSupported()));
     std::unique_ptr<MultiScan> ms_iter =
         std::make_unique<MultiScan>(std::move(iter));

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1119,7 +1119,7 @@ class DB {
   //  }
   virtual std::unique_ptr<MultiScan> NewMultiScan(
       const ReadOptions& /*options*/, ColumnFamilyHandle* /*column_family*/,
-      const std::vector<ScanOptions>& /*scan_opts*/) {
+      const MultiScanOptions& /*scan_opts*/) {
     std::unique_ptr<Iterator> iter(NewErrorIterator(Status::NotSupported()));
     std::unique_ptr<MultiScan> ms_iter =
         std::make_unique<MultiScan>(std::move(iter));

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -109,7 +109,7 @@ class Iterator : public IteratorBase {
   //
   // If Prepare() is called, it overrides the iterate_upper_bound in
   // ReadOptions
-  virtual void Prepare(const MultiScanOptions& /*scan_opts*/) {}
+  virtual void Prepare(const MultiScanArgs& /*scan_opts*/) {}
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -109,7 +109,7 @@ class Iterator : public IteratorBase {
   //
   // If Prepare() is called, it overrides the iterate_upper_bound in
   // ReadOptions
-  virtual void Prepare(const std::vector<ScanOptions>& /*scan_opts*/) {}
+  virtual void Prepare(const MultiScanOptions& /*scan_opts*/) {}
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/multi_scan.h
+++ b/include/rocksdb/multi_scan.h
@@ -152,9 +152,8 @@ class Scan {
 // A Status exception is thrown if there is an error.
 class MultiScan {
  public:
-  MultiScan(const ReadOptions& read_options,
-            const std::vector<ScanOptions>& scan_opts, DB* db,
-            ColumnFamilyHandle* cfh);
+  MultiScan(const ReadOptions& read_options, const MultiScanOptions& scan_opts,
+            DB* db, ColumnFamilyHandle* cfh);
 
   explicit MultiScan(std::unique_ptr<Iterator>&& db_iter)
       : db_iter_(std::move(db_iter)) {}
@@ -220,15 +219,15 @@ class MultiScan {
   };
 
   MultiScanIterator begin() {
-    return MultiScanIterator(scan_opts_, db_, cfh_, read_options_,
-                             &upper_bound_, db_iter_);
+    return MultiScanIterator(scan_opts_.GetScanOptions(), db_, cfh_,
+                             read_options_, &upper_bound_, db_iter_);
   }
 
   std::nullptr_t end() { return nullptr; }
 
  private:
   ReadOptions read_options_;
-  const std::vector<ScanOptions> scan_opts_;
+  const MultiScanOptions scan_opts_;
   DB* db_;
   ColumnFamilyHandle* cfh_;
   Slice upper_bound_;

--- a/include/rocksdb/multi_scan.h
+++ b/include/rocksdb/multi_scan.h
@@ -152,7 +152,7 @@ class Scan {
 // A Status exception is thrown if there is an error.
 class MultiScan {
  public:
-  MultiScan(const ReadOptions& read_options, const MultiScanOptions& scan_opts,
+  MultiScan(const ReadOptions& read_options, const MultiScanArgs& scan_opts,
             DB* db, ColumnFamilyHandle* cfh);
 
   explicit MultiScan(std::unique_ptr<Iterator>&& db_iter)
@@ -219,7 +219,7 @@ class MultiScan {
   };
 
   MultiScanIterator begin() {
-    return MultiScanIterator(scan_opts_.GetScanOptions(), db_, cfh_,
+    return MultiScanIterator(scan_opts_.GetScanRanges(), db_, cfh_,
                              read_options_, &upper_bound_, db_iter_);
   }
 
@@ -227,7 +227,7 @@ class MultiScan {
 
  private:
   ReadOptions read_options_;
-  const MultiScanOptions scan_opts_;
+  const MultiScanArgs scan_opts_;
   DB* db_;
   ColumnFamilyHandle* cfh_;
   Slice upper_bound_;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1787,28 +1787,28 @@ struct ScanOptions {
 // Container for multiple scan ranges that can be used with MultiScan.
 // This replaces std::vector<ScanOptions> with a more efficient implementation
 // that can merge overlapping ranges.
-class MultiScanOptions {
+class MultiScanArgs {
  public:
   // Constructor that takes a comparator
-  explicit MultiScanOptions(const Comparator* comparator = BytewiseComparator())
+  explicit MultiScanArgs(const Comparator* comparator = BytewiseComparator())
       : comp_(comparator) {}
 
   // Copy Constructor
-  MultiScanOptions(const MultiScanOptions& other) {
+  MultiScanArgs(const MultiScanArgs& other) {
     comp_ = other.comp_;
     original_ranges_ = other.original_ranges_;
   }
-  MultiScanOptions(MultiScanOptions&& other) noexcept
+  MultiScanArgs(MultiScanArgs&& other) noexcept
       : comp_(other.comp_),
         original_ranges_(std::move(other.original_ranges_)) {}
 
-  MultiScanOptions& operator=(const MultiScanOptions& other) {
+  MultiScanArgs& operator=(const MultiScanArgs& other) {
     comp_ = other.comp_;
     original_ranges_ = other.original_ranges_;
     return *this;
   }
 
-  MultiScanOptions& operator=(MultiScanOptions&& other) noexcept {
+  MultiScanArgs& operator=(MultiScanArgs&& other) noexcept {
     if (this != &other) {
       comp_ = other.comp_;
       original_ranges_ = std::move(other.original_ranges_);
@@ -1845,9 +1845,9 @@ class MultiScanOptions {
 
   operator const std::vector<ScanOptions>*() const { return &original_ranges_; }
   // Destructor
-  ~MultiScanOptions() {}
+  ~MultiScanArgs() {}
 
-  const std::vector<ScanOptions>& GetScanOptions() const {
+  const std::vector<ScanOptions>& GetScanRanges() const {
     return original_ranges_;
   }
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1798,13 +1798,21 @@ class MultiScanOptions {
     comp_ = other.comp_;
     original_ranges_ = other.original_ranges_;
   }
-
-  MultiScanOptions(MultiScanOptions& other) = default;
-  MultiScanOptions& operator=(MultiScanOptions& other) = default;
+  MultiScanOptions(MultiScanOptions&& other) noexcept
+      : comp_(other.comp_),
+        original_ranges_(std::move(other.original_ranges_)) {}
 
   MultiScanOptions& operator=(const MultiScanOptions& other) {
     comp_ = other.comp_;
     original_ranges_ = other.original_ranges_;
+    return *this;
+  }
+
+  MultiScanOptions& operator=(MultiScanOptions&& other) noexcept {
+    if (this != &other) {
+      comp_ = other.comp_;
+      original_ranges_ = std::move(other.original_ranges_);
+    }
     return *this;
   }
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1820,7 +1820,21 @@ class MultiScanOptions {
     original_ranges_.emplace_back(s, b);
   }
 
+  void insert(const Slice& s, const Slice& b,
+              const std::optional<std::unordered_map<std::string, std::string>>&
+                  property_bag) {
+    original_ranges_.emplace_back(s, b);
+    original_ranges_.back().property_bag = property_bag;
+  }
+
   void insert(const Slice& s) { original_ranges_.emplace_back(s); }
+
+  void insert(const Slice& s,
+              const std::optional<std::unordered_map<std::string, std::string>>&
+                  property_bag) {
+    original_ranges_.emplace_back(s);
+    original_ranges_.back().property_bag = property_bag;
+  }
 
   size_t size() const { return original_ranges_.size(); }
   bool empty() const { return original_ranges_.empty(); }
@@ -1832,8 +1846,6 @@ class MultiScanOptions {
   operator const std::vector<ScanOptions>*() const { return &original_ranges_; }
   // Destructor
   ~MultiScanOptions() {}
-
-  std::vector<ScanOptions>& GetScanOptions() { return original_ranges_; }
 
   const std::vector<ScanOptions>& GetScanOptions() const {
     return original_ranges_;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -292,7 +292,7 @@ class StackableDB : public DB {
   using DB::NewMultiScan;
   std::unique_ptr<MultiScan> NewMultiScan(
       const ReadOptions& opts, ColumnFamilyHandle* column_family,
-      const std::vector<ScanOptions>& scan_opts) override {
+      const MultiScanOptions& scan_opts) override {
     return db_->NewMultiScan(opts, column_family, scan_opts);
   }
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -292,7 +292,7 @@ class StackableDB : public DB {
   using DB::NewMultiScan;
   std::unique_ptr<MultiScan> NewMultiScan(
       const ReadOptions& opts, ColumnFamilyHandle* column_family,
-      const MultiScanOptions& scan_opts) override {
+      const MultiScanArgs& scan_opts) override {
     return db_->NewMultiScan(opts, column_family, scan_opts);
   }
 

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -932,7 +932,7 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
 // ReadOptions::max_skippable_internal_keys or reseeking into range deletion
 // end key. So these Seeks can cause iterator to fall back to normal
 // (non-prepared) iterator and ignore the optimizations done in Prepare().
-void BlockBasedTableIterator::Prepare(const MultiScanOptions* multiscan_opts) {
+void BlockBasedTableIterator::Prepare(const MultiScanArgs* multiscan_opts) {
   index_iter_->Prepare(multiscan_opts);
 
   assert(!multi_scan_);
@@ -944,7 +944,7 @@ void BlockBasedTableIterator::Prepare(const MultiScanOptions* multiscan_opts) {
     return;
   }
 
-  const std::vector<ScanOptions>* scan_opts = &multiscan_opts->GetScanOptions();
+  const std::vector<ScanOptions>* scan_opts = &multiscan_opts->GetScanRanges();
   const bool has_limit = scan_opts->front().range.limit.has_value();
   if (!has_limit && scan_opts->size() > 1) {
     // Abort: overlapping ranges
@@ -1203,7 +1203,7 @@ bool BlockBasedTableIterator::SeekMultiScan(const Slice* target) {
   } else if (user_comparator_.CompareWithoutTimestamp(
                  ExtractUserKey(*target), /*a_has_ts=*/true,
                  multi_scan_->scan_opts
-                     ->GetScanOptions()[multi_scan_->next_scan_idx]
+                     ->GetScanRanges()[multi_scan_->next_scan_idx]
                      .range.start.value(),
                  /*b_has_ts=*/false) != 0) {
     // Unexpected seek key

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -1183,7 +1183,7 @@ void BlockBasedTableIterator::Prepare(const MultiScanOptions* multiscan_opts) {
 
   // Successful Prepare, init related states so the iterator reads from prepared
   // blocks
-  multi_scan_.reset(new MultiScanState(scan_opts,
+  multi_scan_.reset(new MultiScanState(multiscan_opts,
                                        std::move(pinned_data_blocks_guard),
                                        std::move(block_ranges_per_scan)));
   is_index_at_curr_block_ = false;
@@ -1202,7 +1202,8 @@ bool BlockBasedTableIterator::SeekMultiScan(const Slice* target) {
     multi_scan_.reset();
   } else if (user_comparator_.CompareWithoutTimestamp(
                  ExtractUserKey(*target), /*a_has_ts=*/true,
-                 (*multi_scan_->scan_opts)[multi_scan_->next_scan_idx]
+                 multi_scan_->scan_opts
+                     ->GetScanOptions()[multi_scan_->next_scan_idx]
                      .range.start.value(),
                  /*b_has_ts=*/false) != 0) {
     // Unexpected seek key

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -932,19 +932,19 @@ void BlockBasedTableIterator::BlockCacheLookupForReadAheadSize(
 // ReadOptions::max_skippable_internal_keys or reseeking into range deletion
 // end key. So these Seeks can cause iterator to fall back to normal
 // (non-prepared) iterator and ignore the optimizations done in Prepare().
-// TODO: support fill_cache = false and when block cache is disabled.
-void BlockBasedTableIterator::Prepare(
-    const std::vector<ScanOptions>* scan_opts) {
-  index_iter_->Prepare(scan_opts);
+void BlockBasedTableIterator::Prepare(const MultiScanOptions* multiscan_opts) {
+  index_iter_->Prepare(multiscan_opts);
 
   assert(!multi_scan_);
   if (multi_scan_) {
     multi_scan_.reset();
     return;
   }
-  if (scan_opts == nullptr || scan_opts->empty()) {
+  if (multiscan_opts == nullptr || multiscan_opts->empty()) {
     return;
   }
+
+  const std::vector<ScanOptions>* scan_opts = &multiscan_opts->GetScanOptions();
   const bool has_limit = scan_opts->front().range.limit.has_value();
   if (!has_limit && scan_opts->size() > 1) {
     // Abort: overlapping ranges

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -375,7 +375,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   // *** BEGIN MultiScan related states ***
   struct MultiScanState {
     // bool prepared_ = false;
-    const std::vector<ScanOptions>* scan_opts;
+    const MultiScanOptions* scan_opts;
     std::vector<CachableEntry<Block>> pinned_data_blocks;
 
     // Indicies into multiscan_pinned_data_blocks_ for data blocks that are
@@ -386,7 +386,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     size_t cur_data_block_idx;
 
     MultiScanState(
-        const std::vector<ScanOptions>* _scan_opts,
+        const MultiScanOptions* _scan_opts,
         std::vector<CachableEntry<Block>>&& _pinned_data_blocks,
         std::vector<std::tuple<size_t, size_t>>&& _block_ranges_per_scan)
         : scan_opts(_scan_opts),

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -227,7 +227,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     }
   }
 
-  void Prepare(const MultiScanOptions* scan_opts) override;
+  void Prepare(const MultiScanArgs* scan_opts) override;
 
   FilePrefetchBuffer* prefetch_buffer() {
     return block_prefetcher_.prefetch_buffer();
@@ -375,7 +375,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   // *** BEGIN MultiScan related states ***
   struct MultiScanState {
     // bool prepared_ = false;
-    const MultiScanOptions* scan_opts;
+    const MultiScanArgs* scan_opts;
     std::vector<CachableEntry<Block>> pinned_data_blocks;
 
     // Indicies into multiscan_pinned_data_blocks_ for data blocks that are
@@ -386,7 +386,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     size_t cur_data_block_idx;
 
     MultiScanState(
-        const MultiScanOptions* _scan_opts,
+        const MultiScanArgs* _scan_opts,
         std::vector<CachableEntry<Block>>&& _pinned_data_blocks,
         std::vector<std::tuple<size_t, size_t>>&& _block_ranges_per_scan)
         : scan_opts(_scan_opts),

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -227,7 +227,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
     }
   }
 
-  void Prepare(const std::vector<ScanOptions>* scan_opts) override;
+  void Prepare(const MultiScanOptions* scan_opts) override;
 
   FilePrefetchBuffer* prefetch_buffer() {
     return block_prefetcher_.prefetch_buffer();

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -1024,7 +1024,7 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
 
   // Should coalesce into a single I/O
-  MultiScanOptions scan_options(BytewiseComparator());
+  MultiScanArgs scan_options(BytewiseComparator());
   scan_options.insert(ExtractUserKey(kv[0].first),
                       ExtractUserKey(kv[kEntriesPerBlock].first));
   scan_options.insert(ExtractUserKey(kv[2 * kEntriesPerBlock].first),
@@ -1057,7 +1057,7 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
       read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
   // No IO coalesce, should do MultiRead with 2 read requests.
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(ExtractUserKey(kv[70 * kEntriesPerBlock].first),
                       ExtractUserKey(kv[75 * kEntriesPerBlock].first));
   scan_options.insert(ExtractUserKey(kv[90 * kEntriesPerBlock].first),
@@ -1090,7 +1090,7 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
   // Should do two I/Os since blocks 80-81 and 90-95 are already in block cache,
   // reads from blocks 50-79 and 82-.. are co
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(ExtractUserKey(kv[50 * kEntriesPerBlock].first));
   read_count_before =
       options.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
@@ -1111,7 +1111,7 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
   iter.reset(table->NewIterator(
       read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(ExtractUserKey(kv[10 * kEntriesPerBlock].first),
                       ExtractUserKey(kv[20 * kEntriesPerBlock].first));
   scan_options.insert(ExtractUserKey(kv[30 * kEntriesPerBlock].first),
@@ -1138,7 +1138,7 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
   iter.reset(table->NewIterator(
       read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(ExtractUserKey(kv[10 * kEntriesPerBlock].first));
   scan_options.insert(ExtractUserKey(kv[11 * kEntriesPerBlock].first));
   iter->Prepare(&scan_options);

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -1024,11 +1024,11 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
 
   // Should coalesce into a single I/O
-  std::vector<ScanOptions> scan_options(
-      {ScanOptions(ExtractUserKey(kv[0].first),
-                   ExtractUserKey(kv[kEntriesPerBlock].first)),
-       ScanOptions(ExtractUserKey(kv[2 * kEntriesPerBlock].first),
-                   ExtractUserKey(kv[3 * kEntriesPerBlock].first))});
+  MultiScanOptions scan_options(BytewiseComparator());
+  scan_options.insert(ExtractUserKey(kv[0].first),
+                      ExtractUserKey(kv[kEntriesPerBlock].first));
+  scan_options.insert(ExtractUserKey(kv[2 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[3 * kEntriesPerBlock].first));
 
   auto read_count_before =
       options.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
@@ -1057,10 +1057,12 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
       read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
   // No IO coalesce, should do MultiRead with 2 read requests.
-  scan_options = {ScanOptions(ExtractUserKey(kv[70 * kEntriesPerBlock].first),
-                              ExtractUserKey(kv[75 * kEntriesPerBlock].first)),
-                  ScanOptions(ExtractUserKey(kv[90 * kEntriesPerBlock].first),
-                              ExtractUserKey(kv[95 * kEntriesPerBlock].first))};
+  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options.insert(ExtractUserKey(kv[70 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[75 * kEntriesPerBlock].first));
+  scan_options.insert(ExtractUserKey(kv[90 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[95 * kEntriesPerBlock].first));
+
   read_count_before =
       options.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
   iter->Prepare(&scan_options);
@@ -1088,7 +1090,8 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
   // Should do two I/Os since blocks 80-81 and 90-95 are already in block cache,
   // reads from blocks 50-79 and 82-.. are co
-  scan_options = {ScanOptions(ExtractUserKey(kv[50 * kEntriesPerBlock].first))};
+  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options.insert(ExtractUserKey(kv[50 * kEntriesPerBlock].first));
   read_count_before =
       options.statistics->getTickerCount(NON_LAST_LEVEL_READ_COUNT);
   iter->Prepare(&scan_options);
@@ -1108,10 +1111,11 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
   iter.reset(table->NewIterator(
       read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-  scan_options = {ScanOptions(ExtractUserKey(kv[10 * kEntriesPerBlock].first),
-                              ExtractUserKey(kv[20 * kEntriesPerBlock].first)),
-                  ScanOptions(ExtractUserKey(kv[30 * kEntriesPerBlock].first),
-                              ExtractUserKey(kv[40 * kEntriesPerBlock].first))};
+  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options.insert(ExtractUserKey(kv[10 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[20 * kEntriesPerBlock].first));
+  scan_options.insert(ExtractUserKey(kv[30 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[40 * kEntriesPerBlock].first));
   iter->Prepare(&scan_options);
   // Match start key
   iter->Seek(kv[10 * kEntriesPerBlock].first);
@@ -1134,8 +1138,9 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrepare) {
   iter.reset(table->NewIterator(
       read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kUncategorized));
-  scan_options = {ScanOptions(ExtractUserKey(kv[10 * kEntriesPerBlock].first)),
-                  ScanOptions(ExtractUserKey(kv[11 * kEntriesPerBlock].first))};
+  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options.insert(ExtractUserKey(kv[10 * kEntriesPerBlock].first));
+  scan_options.insert(ExtractUserKey(kv[11 * kEntriesPerBlock].first));
   iter->Prepare(&scan_options);
   // Does not match the first ScanOptions.
   iter->SeekToFirst();

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -181,8 +181,11 @@ class UserDefinedIndexIteratorWrapper
 
   Status status() const override { return status_; }
 
-  void Prepare(const std::vector<ScanOptions>* scan_opts) override {
-    udi_iter_->Prepare(scan_opts->data(), scan_opts->size());
+  void Prepare(const MultiScanOptions* scan_opts) override {
+    if (scan_opts) {
+      udi_iter_->Prepare(scan_opts->GetScanOptions().data(),
+                         scan_opts->GetScanOptions().size());
+    }
   }
 
  private:

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -181,10 +181,10 @@ class UserDefinedIndexIteratorWrapper
 
   Status status() const override { return status_; }
 
-  void Prepare(const MultiScanOptions* scan_opts) override {
+  void Prepare(const MultiScanArgs* scan_opts) override {
     if (scan_opts) {
-      udi_iter_->Prepare(scan_opts->GetScanOptions().data(),
-                         scan_opts->GetScanOptions().size());
+      udi_iter_->Prepare(scan_opts->GetScanRanges().data(),
+                         scan_opts->GetScanRanges().size());
     }
   }
 

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -131,9 +131,9 @@ class ExternalTableIteratorAdapter : public InternalIterator {
 
   Status status() const override { return status_; }
 
-  void Prepare(const MultiScanOptions* scan_opts) override {
+  void Prepare(const MultiScanArgs* scan_opts) override {
     if (iterator_ && scan_opts) {
-      iterator_->Prepare(scan_opts->GetScanOptions().data(), scan_opts->size());
+      iterator_->Prepare(scan_opts->GetScanRanges().data(), scan_opts->size());
     } else if (iterator_) {
       iterator_->Prepare(nullptr, 0);
     }

--- a/table/external_table.cc
+++ b/table/external_table.cc
@@ -131,9 +131,11 @@ class ExternalTableIteratorAdapter : public InternalIterator {
 
   Status status() const override { return status_; }
 
-  void Prepare(const std::vector<ScanOptions>* scan_opts) override {
-    if (iterator_) {
-      iterator_->Prepare(scan_opts->data(), scan_opts->size());
+  void Prepare(const MultiScanOptions* scan_opts) override {
+    if (iterator_ && scan_opts) {
+      iterator_->Prepare(scan_opts->GetScanOptions().data(), scan_opts->size());
+    } else if (iterator_) {
+      iterator_->Prepare(nullptr, 0);
     }
   }
 

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -200,7 +200,7 @@ class InternalIteratorBase : public Cleanable {
   // used by MergingIterator and LevelIterator for now.
   virtual bool IsDeleteRangeSentinelKey() const { return false; }
 
-  virtual void Prepare(const std::vector<ScanOptions>* /*scan_opts*/) {}
+  virtual void Prepare(const MultiScanOptions* /*scan_opts*/) {}
 
  protected:
   void SeekForPrevImpl(const Slice& target, const CompareInterface* cmp) {

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -200,7 +200,7 @@ class InternalIteratorBase : public Cleanable {
   // used by MergingIterator and LevelIterator for now.
   virtual bool IsDeleteRangeSentinelKey() const { return false; }
 
-  virtual void Prepare(const MultiScanOptions* /*scan_opts*/) {}
+  virtual void Prepare(const MultiScanArgs* /*scan_opts*/) {}
 
  protected:
   void SeekForPrevImpl(const Slice& target, const CompareInterface* cmp) {

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -197,7 +197,7 @@ class IteratorWrapperBase {
 
   // scan_opts lifetime is guaranteed until the iterator is destructed, or
   // Prepare() is called with a new scan_opts
-  void Prepare(const std::vector<ScanOptions>* scan_opts) {
+  void Prepare(const MultiScanOptions* scan_opts) {
     if (iter_) {
       iter_->Prepare(scan_opts);
     }

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -197,7 +197,7 @@ class IteratorWrapperBase {
 
   // scan_opts lifetime is guaranteed until the iterator is destructed, or
   // Prepare() is called with a new scan_opts
-  void Prepare(const MultiScanOptions* scan_opts) {
+  void Prepare(const MultiScanArgs* scan_opts) {
     if (iter_) {
       iter_->Prepare(scan_opts);
     }

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -482,7 +482,7 @@ class MergingIterator : public InternalIterator {
            current_->IsValuePinned();
   }
 
-  void Prepare(const MultiScanOptions* scan_opts) override {
+  void Prepare(const MultiScanArgs* scan_opts) override {
     for (auto& child : children_) {
       child.iter.Prepare(scan_opts);
     }

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -482,7 +482,7 @@ class MergingIterator : public InternalIterator {
            current_->IsValuePinned();
   }
 
-  void Prepare(const std::vector<ScanOptions>* scan_opts) override {
+  void Prepare(const MultiScanOptions* scan_opts) override {
     for (auto& child : children_) {
       child.iter.Prepare(scan_opts);
     }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -7198,7 +7198,7 @@ TEST_F(ExternalTableTest, DBMultiScanTest) {
 
   std::vector<std::string> key_ranges({"k03", "k10", "k25", "k50"});
   ReadOptions ro;
-  MultiScanOptions scan_options(BytewiseComparator());
+  MultiScanArgs scan_options(BytewiseComparator());
   scan_options.insert(key_ranges[0], key_ranges[1]);
   scan_options.insert(key_ranges[2], key_ranges[3]);
   std::unique_ptr<MultiScan> iter = db->NewMultiScan(ro, cfh, scan_options);
@@ -7227,7 +7227,7 @@ TEST_F(ExternalTableTest, DBMultiScanTest) {
 
   // Test the overlapping scan case
   key_ranges[1] = "k30";
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(key_ranges[0], key_ranges[1]);
   scan_options.insert(key_ranges[2], key_ranges[3]);
 
@@ -7256,7 +7256,7 @@ TEST_F(ExternalTableTest, DBMultiScanTest) {
   iter.reset();
 
   // Test the no limit scan case
-  scan_options = MultiScanOptions(BytewiseComparator());
+  scan_options = MultiScanArgs(BytewiseComparator());
   scan_options.insert(key_ranges[0]);
   scan_options.insert(key_ranges[2]);
   iter = db->NewMultiScan(ro, cfh, scan_options);
@@ -7815,7 +7815,7 @@ TEST_F(UserDefinedIndexTest, BasicTest) {
   ro.iterate_upper_bound = nullptr;
   iter.reset(reader->NewIterator(ro));
   ASSERT_NE(iter, nullptr);
-  MultiScanOptions scan_opts(BytewiseComparator());
+  MultiScanArgs scan_opts(BytewiseComparator());
 
   std::unordered_map<std::string, std::string> property_bag;
   property_bag["count"] = std::to_string(25);
@@ -7823,7 +7823,7 @@ TEST_F(UserDefinedIndexTest, BasicTest) {
   iter->Prepare(scan_opts);
   // Test that we can read all the keys
   key_count = 0;
-  for (iter->Seek(scan_opts.GetScanOptions()[0].range.start.value());
+  for (iter->Seek(scan_opts.GetScanRanges()[0].range.start.value());
        iter->Valid(); iter->Next()) {
     key_count++;
   }
@@ -7976,14 +7976,14 @@ TEST_F(UserDefinedIndexTest, IngestTest) {
   ro.iterate_upper_bound = nullptr;
   iter.reset(db->NewIterator(ro, cfh));
   ASSERT_NE(iter, nullptr);
-  MultiScanOptions scan_opts;
+  MultiScanArgs scan_opts;
   std::unordered_map<std::string, std::string> property_bag;
   property_bag["count"] = std::to_string(25);
   scan_opts.insert(Slice("key20"), std::optional(property_bag));
   iter->Prepare(scan_opts);
   // Test that we can read all the keys
   key_count = 0;
-  for (iter->Seek(scan_opts.GetScanOptions()[0].range.start.value());
+  for (iter->Seek(scan_opts.GetScanRanges()[0].range.start.value());
        iter->Valid(); iter->Next()) {
     key_count++;
   }

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6412,7 +6412,7 @@ class Benchmark {
     Duration duration(FLAGS_duration, reads_);
     while (!duration.Done(1)) {
       DB* db = SelectDB(thread);
-      std::vector<ScanOptions> opts;
+      MultiScanOptions opts;
       std::vector<std::unique_ptr<const char[]>> guards;
       opts.reserve(multiscan_size);
       // We create 1 random start, and then multiscan will start from that
@@ -6433,7 +6433,7 @@ class Benchmark {
         uint64_t end_key = start_key + scan_size;
         GenerateKeyFromInt(end_key, FLAGS_num, &ekey);
 
-        opts.emplace_back(skey, ekey);
+        opts.insert(skey, ekey);
         start_key += scan_size + FLAGS_multiscan_stride;
       }
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6412,7 +6412,7 @@ class Benchmark {
     Duration duration(FLAGS_duration, reads_);
     while (!duration.Done(1)) {
       DB* db = SelectDB(thread);
-      MultiScanOptions opts;
+      MultiScanArgs opts;
       std::vector<std::unique_ptr<const char[]>> guards;
       opts.reserve(multiscan_size);
       // We create 1 random start, and then multiscan will start from that


### PR DESCRIPTION
To better support future options, and changes, we need to convert the std::vector<ScanOptions> to something more malleable. 

This diff introduces the MultiScanOptions structure and pipes it through the various points in the code in the Prepare path.


Test Plan:
Ensure all associated tests pass
```
make check all
```