### PR TITLE
Refactor CompactionJob::Run() into smaller focused methods

### DIFF
--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -279,6 +279,22 @@ class CompactionJob {
   // Release all reserved threads and update the compaction limits.
   void ReleaseSubcompactionResources();
 
+  void InitializeCompactionRun();
+  void RunSubcompactions();
+  void UpdateTimingStats(uint64_t start_micros);
+  void RemoveEmptyOutputs();
+  bool HasNewBlobFiles();
+  Status CollectSubcompactionErrors();
+  Status SyncOutputDirectories();
+  Status VerifyOutputFiles();
+  void SetOutputTableProperties();
+  void AggregateSubcompactionStats();
+  Status VerifyCompactionRecordCounts(bool stats_built_from_input_table_prop,
+                                      uint64_t num_input_range_del);
+  void FinalizeCompactionRun(const Status& status,
+                             bool stats_built_from_input_table_prop,
+                             uint64_t num_input_range_del);
+
   CompactionServiceJobStatus ProcessKeyValueCompactionWithCompactionService(
       SubcompactionState* sub_compact);
 

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -283,7 +283,7 @@ class CompactionJob {
   void RunSubcompactions();
   void UpdateTimingStats(uint64_t start_micros);
   void RemoveEmptyOutputs();
-  bool HasNewBlobFiles();
+  bool HasNewBlobFiles() const;
   Status CollectSubcompactionErrors();
   Status SyncOutputDirectories();
   Status VerifyOutputFiles();


### PR DESCRIPTION
**Context/Summary:**
The `CompactionJob::Run()` method has grown too large and complex, making it difficult to implement moderate changes or reason about the code flow (e.g., determining where to save compaction progress for resuming). This PR refactors the method into smaller, more focused functions to improve readability and maintainability.

The refactoring consists mostly of cosmetic changes that extract logical sections into separate methods, with two notable functional improvements:

1.  **Relocated output processing logic**: Moved code under `RemoveEmptyOutputs()` and `HasNewBlobFiles()` to where it's actually needed, rather than piggy-backing on the subcompaction state loop. While this introduces 2 additional loops over subcompactions, the performance impact should be negligible given the improved code clarity.
    
2.  **Repositioned statistics updates**: Moved `UpdateCompactionJobInputStats()` and `UpdateCompactionJobOutputStats()` from the record verification section to the end `FinalizeCompactionRun()` methods. This change is safe since record verification is a read-only operation that doesn't modify any statistics.


**Test:**
Existing unit tests