### PR TITLE
A simple cleanup to CompactionJob::Run() 

### DIFF
--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -225,7 +225,7 @@ class CompactionJob {
  private:
   friend class CompactionJobTestBase;
 
-  // Collect the following stats from Input Table Properties
+  // Collect the following stats from input files and table properties
   // - num_input_files_in_non_output_levels
   // - num_input_files_in_output_level
   // - bytes_read_non_output_levels
@@ -242,8 +242,7 @@ class CompactionJob {
   // num_input_range_del are calculated successfully.
   //
   // This should be called only once for compactions (not per subcompaction)
-  bool BuildStatsFromInputTableProperties(
-      uint64_t* num_input_range_del = nullptr);
+  bool BuildStatsFromInputFiles(uint64_t* num_input_range_del = nullptr);
 
   void UpdateCompactionJobInputStats(
       const InternalStats::CompactionStatsFull& internal_stats,


### PR DESCRIPTION
**Context/Summary:**
This update, which should have been part of a previous refactoring [PR](https://github.com/facebook/rocksdb/commit/d2ac955881e856fc69d5b15427d742fc635aaead), involves simple renaming for clarity and ensures output table properties are only set when compaction succeeds. Output properties are not meaningful if compaction fails, so this change prevents their population in such cases. Additionally, subsequent statistics updates already do not rely on output file table properties, maintaining correctness regardless of compaction success.

**Test:**
Existing unit tests