### PR TITLE
Enable track_and_verify_wal in stress test 

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -343,7 +343,8 @@ default_params = {
     "use_timed_put_one_in": lambda: random.choice([0] * 7 + [1, 5, 10]),
     "universal_max_read_amp": lambda: random.choice([-1] * 3 + [0, 4, 10]),
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
-    "allow_unprepared_value": lambda: random.choice([0, 1]),    
+    "allow_unprepared_value": lambda: random.choice([0, 1]),
+    "track_and_verify_wals": lambda: random.choice([0, 1]),
     # TODO(jaykorean): Re-enable remote compaction once all incompatible features are addressed in stress test
     "remote_compaction_worker_threads": lambda: 0,
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),


### PR DESCRIPTION
**Context/Summary:** 
https://github.com/facebook/rocksdb/pull/13508 accidentally didn't enable track_and_verify_wal back and this PR will enable it. 

**Test** 
Rehearsal stress test passes without relevant errors 