### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -78,13 +78,12 @@ const char* GetExecutableName() {
 #elif defined(OS_OPENBSD)
   int mib[4] = {CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_ARGV};
   size_t namesz = sizeof(name);
-  char* bin[namesz];
 
-  auto ret = sysctl(mib, 4, bin, &namesz, nullptr, 0);
+  auto ret = sysctl(mib, 4, name, &namesz, nullptr, 0);
   if (-1 == ret) {
     return nullptr;
   } else {
-    return bin[0];
+    return name;
   }
 #else
   char link[1024];


### PR DESCRIPTION
```
port/stack_trace.cc:81:13: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
   81 |   char* bin[namesz];
      |             ^~~~~~
port/stack_trace.cc:81:13: note: read of non-const variable 'namesz' is not allowed in a constant expression
port/stack_trace.cc:80:10: note: declared here
   80 |   size_t namesz = sizeof(name);
      |          ^
1 error generated.
```