### PR TITLE
fs: ignore . and .. in children no matter what type it is

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -596,13 +596,12 @@ class PosixFileSystem : public FileSystem {
       // filter out '.' and '..' directory entries
       // which appear only on some platforms
       const bool ignore =
-          entry->d_type == DT_DIR &&
           (strcmp(entry->d_name, ".") == 0 ||
            strcmp(entry->d_name, "..") == 0
 #ifndef ASSERT_STATUS_CHECKED
            // In case of ASSERT_STATUS_CHECKED, GetChildren support older
            // version of API for debugging purpose.
-           || opts.do_not_recurse
+           || (entry->d_type == DT_DIR && opts.do_not_recurse)
 #endif
           );
       if (!ignore) {


### PR DESCRIPTION
If a directory is symlink, current implementation will return '.' and '..' as results, breaks the guarantee in docs that

> The names are relative to "dir", and shall never include the
names `.` or `..`.