### PR TITLE
Use atomic flush during some auto recovery; Renable track_and_verify_wals in crash test 

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -209,7 +209,7 @@ Status DBImpl::IngestWriteBatchWithIndex(
     WriteBatch dummy_empty_batch;
     s = WriteImpl(
         write_options, /*updates=*/&dummy_empty_batch, /*callback=*/nullptr,
-        /*user_write_cb=*/nullptr, /*log_used=*/nullptr, /*log_ref=*/0,
+        /*user_write_cb=*/nullptr, /*wal_used=*/nullptr, /*log_ref=*/0,
         /*disable_memtable=*/false, /*seq_used=*/nullptr,
         /*batch_cnt=*/0, /*pre_release_callback=*/nullptr,
         /*post_memtable_callback=*/nullptr, /*wbwi=*/wbwi);
@@ -1984,8 +1984,9 @@ void DBImpl::SelectColumnFamiliesForAtomicFlush(
 }
 
 // Assign sequence number for atomic flush.
-void DBImpl::AssignAtomicFlushSeq(const autovector<ColumnFamilyData*>& cfds) {
-  assert(immutable_db_options_.atomic_flush);
+void DBImpl::AssignAtomicFlushSeq(const autovector<ColumnFamilyData*>& cfds,
+                                  [[maybe_unused]] FlushReason flush_reason) {
+  assert(ShouldUseAtomicFlushBehavior(flush_reason));
   auto seq = versions_->LastSequence();
   for (auto cfd : cfds) {
     // cfd can be nullptr, see ScheduleFlushes()

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -1051,10 +1051,14 @@ struct AdvancedColumnFamilyOptions {
   // When setting this flag to `false`, users should also call
   // `DB::IncreaseFullHistoryTsLow` to set a cutoff timestamp for flush. RocksDB
   // refrains from flushing a memtable with data still above
-  // the cutoff timestamp with best effort. One limitation of this best effort
-  // is that when `max_write_buffer_number` is equal to or smaller than 2,
-  // RocksDB will not attempt to retain user-defined timestamps, all flush jobs
-  // continue normally.
+  // the cutoff timestamp with best effort. Limitations of this best effort
+  // include:
+  // 1) When `max_write_buffer_number` is equal to or smaller than 2,
+  //    RocksDB will not attempt to retain user-defined timestamps, all flush
+  //    jobs continue normally.
+  // 2) Some error recovery flushes (i.e, kErrorRecovery) will
+  //    bypass the cutoff timestamp limitation and proceed immediately to
+  //    maintain database stability and consistency.
   //
   // Users can do user-defined
   // multi-versioned read above the cutoff timestamp. When users try to read

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -344,8 +344,7 @@ default_params = {
     "universal_max_read_amp": lambda: random.choice([-1] * 3 + [0, 4, 10]),
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
-    # TODO(hx235): enable `track_and_verify_wals` after stabalizing the stress test
-    "track_and_verify_wals": lambda: random.choice([0]),
+    "track_and_verify_wals": lambda: random.choice([0, 1]),
     # TODO(jaykorean): Re-enable remote compaction once all incompatible features are addressed in stress test
     "remote_compaction_worker_threads": lambda: 0,
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),


### PR DESCRIPTION
**Context/Summary:**
The purpose of auto recovery flushing with potential WAL corruption (i.e,`FlushReason::kErrorRecovery`) is to persist memtable data to SST files so that corrupted WAL can be safely discarded. However, when multiple column families are present and Options::atomic_flush=false, currently we do individual CF flushing which can prevent us from discarding that WAL:
1.  Recovery flush begins, flushing each CF individually
2.  Some CFs complete their flush successfully
3.  Database crashes before other CFs finish flushing
4.  Upon restart, the database cannot advance past the corrupted WAL entry because not all CFs have persisted their data from that WAL
5.  Recovery will stop at at before corrupted WAL, while the flushed CFs have persistent data past that WAL
6.  This caused the error: "Column family inconsistency: SST file contains data beyond the point of corruption"

This PR uses atomic flush in this type of auto recovery flushing. By using atomic flush behavior during those error recovery, we ensure that either ALL column families flush their data together atomically, or none do. This prevents partial-flush inconsistencies and maintains cross-CF data integrity during recovery operations.

This PR also e-enables track_and_verify_wals in crash test that surfaced the above case. 

**Test:**
- Existing UTs
- db stress command failed quickly within 30 seconds before the fix and passed for 30 min
```
./db_stres --db=/tmp/rocksdb_crashtest_blackbox3hitiize --expected_values_dir=/tmp/rocksdb_crashtest_expected_pieoe_ek --column_families=9 --WAL_size_limit_MB=1 --WAL_ttl_seconds=1 --acquire_snapshot_one_in=10000 --adaptive_readahead=0 --adm_policy=0 --advise_random_on_open=1 --allow_data_in_errors=True --allow_fallocate=1 --allow_unprepared_value=1 --async_io=0 --auto_readahead_size=0 --auto_refresh_iterator_with_snapshot=0 --avoid_flush_during_recovery=0 --avoid_flush_during_shutdown=0 --avoid_unnecessary_blocking_io=0 --backup_max_size=104857600 --backup_one_in=3 --batch_protection_bytes_per_key=8 --bgerror_resume_retry_interval=20 --block_align=0 --block_protection_bytes_per_key=8 --block_size=16384 --bloom_before_level=2147483646 --bloom_bits=7.790646688877747 --bottommost_compression_type=zstd --bottommost_file_compaction_delay=0 --bytes_per_sync=0 --cache_index_and_filter_blocks=0 --cache_index_and_filter_blocks_with_high_priority=1 --cache_size=33554432 --cache_type=lru_cache --charge_compression_dictionary_building_buffer=0 --charge_file_metadata=0 --charge_filter_construction=1 --charge_table_reader=0 --check_multiget_consistency=1 --check_multiget_entity_consistency=0 --checkpoint_one_in=1000000 --checksum_type=kxxHash64 --clear_column_family_one_in=0 --compact_files_one_in=1000000 --compact_range_one_in=1000 --compaction_pri=3 --compaction_readahead_size=0 --compaction_style=0 --compaction_ttl=100 --compress_format_version=1 --compressed_secondary_cache_size=8388608 --compression_checksum=1 --compression_manager=mixed --compression_max_dict_buffer_bytes=7 --compression_max_dict_bytes=16384 --compression_parallel_threads=1 --compression_type=lz4hc --compression_use_zstd_dict_trainer=0 --compression_zstd_max_train_bytes=0 --continuous_verification_interval=0 --daily_offpeak_time_utc=23:30-03:15 --data_block_index_type=0 --db_write_buffer_size=0 --decouple_partitioned_filters=1 --default_temperature=kHot --default_write_temperature=kHot --delete_obsolete_files_period_micros=21600000000 --delpercent=0 --delrangepercent=0 --destroy_db_initially=0 --detect_filter_construct_corruption=0 --disable_file_deletions_one_in=10000 --disable_manual_compaction_one_in=1000000 --disable_wal=0 --dump_malloc_stats=1 --enable_checksum_handoff=1 --enable_compaction_filter=0 --enable_custom_split_merge=0 --enable_do_not_compress_roles=1 --enable_index_compression=1 --enable_memtable_insert_with_hint_prefix_extractor=0 --enable_pipelined_write=1 --enable_sst_partitioner_factory=0 --enable_thread_tracking=0 --enable_write_thread_adaptive_yield=0 --error_recovery_with_no_fault_injection=0 --exclude_wal_from_write_fault_injection=0 --fifo_allow_compaction=0 --file_checksum_impl=none --file_temperature_age_thresholds= --fill_cache=1 --flush_one_in=0 --format_version=3 --get_all_column_family_metadata_one_in=10000 --get_current_wal_file_one_in=0 --get_live_files_apis_one_in=10000 --get_properties_of_all_tables_one_in=100000 --get_property_one_in=100000 --get_sorted_wal_files_one_in=0 --hard_pending_compaction_bytes_limit=274877906944 --high_pri_pool_ratio=0 --index_block_restart_interval=5 --index_shortening=2 --index_type=2 --ingest_external_file_one_in=1000 --ingest_wbwi_one_in=0 --initial_auto_readahead_size=16384 --inplace_update_support=0 --iterpercent=0 --key_len_percent_dist=1,30,69 --key_may_exist_one_in=100000 --last_level_temperature=kCold --level_compaction_dynamic_level_bytes=0 --lock_wal_one_in=0 --log_file_time_to_roll=0 --log_readahead_size=16777216 --long_running_snapshots=1 --low_pri_pool_ratio=0 --lowest_used_cache_tier=0 --manifest_preallocation_size=5120 --manual_wal_flush_one_in=0 --mark_for_compaction_one_file_in=10 --max_auto_readahead_size=0 --max_background_compactions=2 --max_bytes_for_level_base=10485760 --max_key=100000 --max_key_len=3 --max_log_file_size=0 --max_manifest_file_size=1073741824 --max_sequential_skip_in_iterations=1 --max_total_wal_size=67108864 --max_write_batch_group_size_bytes=16 --max_write_buffer_number=10 --max_write_buffer_size_to_maintain=0 --memtable_avg_op_scan_flush_trigger=200 --memtable_insert_hint_per_batch=1 --memtable_max_range_deletions=0 --memtable_op_scan_flush_trigger=0 --memtable_prefix_bloom_size_ratio=0.01 --memtable_protection_bytes_per_key=4 --memtable_whole_key_filtering=1 --metadata_charge_policy=1 --metadata_read_fault_one_in=0 --metadata_write_fault_one_in=128 --min_write_buffer_number_to_merge=1 --mmap_read=0 --mock_direct_io=False --nooverwritepercent=1 --num_bottom_pri_threads=0 --num_file_reads_for_auto_readahead=1 --open_files=-1 --open_metadata_read_fault_one_in=0 --open_metadata_write_fault_one_in=0 --open_read_fault_one_in=0 --open_write_fault_one_in=0 --ops_per_thread=100000000 --optimize_filters_for_hits=1 --optimize_filters_for_memory=0 --optimize_multiget_for_io=0 --paranoid_file_checks=1 --paranoid_memory_checks=0 --partition_filters=1 --partition_pinning=2 --pause_background_one_in=10000 --periodic_compaction_seconds=10 --prefix_size=7 --prefixpercent=0 --prepopulate_block_cache=0 --preserve_internal_time_seconds=36000 --progress_reports=0 --promote_l0_one_in=0 --read_amp_bytes_per_bit=0 --read_fault_one_in=0 --readahead_size=524288 --readpercent=0 --recycle_log_file_num=0 --remote_compaction_worker_threads=0 --reopen=0 --report_bg_io_stats=1 --reset_stats_one_in=10000 --sample_for_compression=0 --secondary_cache_fault_one_in=0 --secondary_cache_uri= --set_options_one_in=1000 --skip_stats_update_on_db_open=0 --snapshot_hold_ops=100000 --soft_pending_compaction_bytes_limit=1048576 --sqfc_name=foo --sqfc_version=1 --sst_file_manager_bytes_per_sec=104857600 --sst_file_manager_bytes_per_truncate=0 --stats_dump_period_sec=0 --stats_history_buffer_size=1048576 --strict_bytes_per_sync=0 --subcompactions=4 --sync=0 --sync_fault_injection=0 --table_cache_numshardbits=0 --target_file_size_base=2097152 --target_file_size_multiplier=2 --test_batches_snapshots=0 --test_ingest_standalone_range_deletion_one_in=10 --top_level_index_pinning=1 --track_and_verify_wals=1 --uncache_aggressiveness=0 --universal_max_read_amp=-1 --universal_reduce_file_locking=1 --unpartitioned_pinning=1 --use_adaptive_mutex=1 --use_adaptive_mutex_lru=1 --use_attribute_group=0 --use_delta_encoding=1 --use_direct_io_for_flush_and_compaction=1 --use_direct_reads=1 --use_full_merge_v1=0 --use_get_entity=0 --use_merge=0 --use_multi_cf_iterator=1 --use_multi_get_entity=0 --use_multiget=0 --use_multiscan=0 --use_put_entity_one_in=10 --use_sqfc_for_range_queries=1 --use_timed_put_one_in=0 --use_write_buffer_manager=0 --user_timestamp_size=0 --value_size_mult=32 --verification_only=0 --verify_checksum=1 --verify_checksum_one_in=1000 --verify_compression=0 --verify_db_one_in=10000 --verify_file_checksums_one_in=0 --verify_iterator_with_expected_state_one_in=5 --verify_sst_unique_id_in_manifest=1 --wal_bytes_per_sync=0 --wal_compression=none --write_buffer_size=4194304 --write_dbid_to_manifest=1 --write_fault_one_in=5 --write_identity_file=0 --writepercent=100
``` 
- Rehearsal crash test passed

**Followup:** 
- Remove the short-term fix in https://github.com/facebook/rocksdb/pull/13000
