### PR TITLE
Set decouple_partitioned_filters=true by default

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -366,11 +366,6 @@ Options DBTestBase::GetOptions(
     table_options.block_cache = NewLRUCache(/* too small */ 1);
   }
 
-  // Test anticipated new default as much as reasonably possible (and remove
-  // this code when obsolete)
-  assert(!table_options.decouple_partitioned_filters);
-  table_options.decouple_partitioned_filters = true;
-
   bool can_allow_mmap = IsMemoryMappedAccessSupported();
   switch (option_config) {
     case kHashSkipList:

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -440,10 +440,9 @@ struct BlockBasedTableOptions {
   // versions of RocksDB able to read partitioned filters are able to read
   // decoupled partitioned filters.)
   //
-  // decouple_partitioned_filters = false is the original behavior, because of
-  // limitations in the initial implementation, and the new behavior
-  // decouple_partitioned_filters = true is expected to become the new default.
-  bool decouple_partitioned_filters = false;
+  // decouple_partitioned_filters = true is the new default. This option is now
+  // DEPRECATED and might be ignored and/or removed in a future release.
+  bool decouple_partitioned_filters = true;
 
   // Option to generate Bloom/Ribbon filters that minimize memory
   // internal fragmentation.

--- a/unreleased_history/public_api_changes/decouple.md
+++ b/unreleased_history/public_api_changes/decouple.md
@@ -1,0 +1,1 @@
+* `decouple_partitioned_filters = true` is now the default in BlockBasedTableOptions.


### PR DESCRIPTION
Summary: This is an important feature for avoiding (reducing) unfair block cache treatment for a lot of blocks. It should also unlock some parallel optimizations (#13850) and code simplification.

Consider for follow-up:
* Feature to avoid majorly under0sized data blocks and filter and index partition blocks

Test Plan: existing tests, been looking good in production