### PR TITLE
Remove reservation mismatch assert in cache adapter destructor

### DIFF
--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -121,16 +121,13 @@ CacheWithSecondaryAdapter::~CacheWithSecondaryAdapter() {
     assert(s.ok());
     assert(placeholder_usage_ == 0);
     assert(reserved_usage_ == 0);
-    bool pri_cache_res_mismatch =
-        pri_cache_res_->GetTotalMemoryUsed() != sec_capacity;
-    if (pri_cache_res_mismatch) {
+    if (pri_cache_res_->GetTotalMemoryUsed() != sec_capacity) {
       fprintf(stderr,
               "~CacheWithSecondaryAdapter: Primary cache reservation: "
               "%zu, Secondary cache capacity: %zu, "
               "Secondary cache reserved: %zu\n",
               pri_cache_res_->GetTotalMemoryUsed(), sec_capacity,
               sec_reserved_);
-      assert(!pri_cache_res_mismatch);
     }
   }
 #endif  // NDEBUG

--- a/cache/secondary_cache_adapter.cc
+++ b/cache/secondary_cache_adapter.cc
@@ -122,7 +122,7 @@ CacheWithSecondaryAdapter::~CacheWithSecondaryAdapter() {
     assert(placeholder_usage_ == 0);
     assert(reserved_usage_ == 0);
     if (pri_cache_res_->GetTotalMemoryUsed() != sec_capacity) {
-      fprintf(stderr,
+      fprintf(stdout,
               "~CacheWithSecondaryAdapter: Primary cache reservation: "
               "%zu, Secondary cache capacity: %zu, "
               "Secondary cache reserved: %zu\n",


### PR DESCRIPTION
The assert occasionally throws off the stress test runs. We already have sufficient logging in place to collect the signal about secondary cache capacity exceeding primary cache reservation for further investigation.