### PR TITLE
Ignore IOActivity check for ManagedSnapshot snapshot_guard(db_); for TestMultiScan

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1666,7 +1666,11 @@ Status StressTest::TestMultiScan(ThreadState* thread,
   assert(!rand_column_families.empty());
   assert(!rand_keys.empty());
 
+  ThreadStatus::OperationType cur_op_type =
+      ThreadStatusUtil::GetThreadOperation();
+  ThreadStatusUtil::SetThreadOperation(ThreadStatus::OperationType::OP_UNKNOWN);
   ManagedSnapshot snapshot_guard(db_);
+  ThreadStatusUtil::SetThreadOperation(cur_op_type);
 
   ReadOptions ro = read_opts;
   ro.snapshot = snapshot_guard.snapshot();


### PR DESCRIPTION
**Context/Summary:**

RocksDB stress test verifies IOActivity is set correctly through reusing the pass-in Read/Write options through assertion. This is too strict for API that does not take or do not need to take Read/WriteOptions yet hence assertion failure. 
```
stderr:
 db_stress: ... db_stress_tool/db_stress_env_wrapper.h:24: void rocksdb::(anonymous namespace)::CheckIOActivity(const IOOptions &): Assertion `io_activity == Env::IOActivity::kUnknown || io_activity == options.io_activity' failed.
Received signal 6 (Aborted)
```
An example is ManagedSnapshot snapshot_guard(db_); in TestMultiScan(). 


This PR ignores such check. 


**Test:**
The same command repro-ed this assertion failure passes after this fix
