### PR TITLE
Fix array subscript 32 is above array bounds when compiling.

### DIFF
--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -129,7 +129,7 @@ class MultiGetContext {
       lookup_key_ptr_ = reinterpret_cast<LookupKey*>(lookup_key_heap_buf.get());
     }
 
-    for (size_t iter = 0; iter != num_keys_; ++iter) {
+    for (size_t iter = 0; iter != num_keys_ && iter != MAX_BATCH_SIZE; ++iter) {
       // autovector may not be contiguous storage, so make a copy
       sorted_keys_[iter] = (*sorted_keys)[begin + iter];
       sorted_keys_[iter]->lkey = new (&lookup_key_ptr_[iter])


### PR DESCRIPTION
close #13870 

Although there is assertion to ensure that no out-of-bounds occurs, it is performed dynamically.

We need to make the compiler's static checker happy.

This problem may only occur in newer versions of the C++ compiler.