### PR TITLE
Disable Remote Compaction when Integrated BlobDB is enabled in Stress Test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -626,6 +626,9 @@ blob_params = {
     "use_shared_block_and_blob_cache": lambda: random.randint(0, 1),
     "blob_cache_size": lambda: random.choice([1048576, 2097152, 4194304, 8388608]),
     "prepopulate_blob_cache": lambda: random.randint(0, 1),
+
+     # TODO Fix races when both Remote Compaction + BlobDB enabled
+     "remote_compaction_worker_threads": 0,
 }
 
 ts_params = {
@@ -784,6 +787,7 @@ def finalize_and_sanitize(src_params):
         # TODO Fix races when both Remote Compaction + BlobDB enabled
         dest_params["enable_blob_files"] = 0
         dest_params["enable_blob_garbage_collection"] = 0
+        dest_params["allow_setting_blob_options_dynamically"] = 0
         # TODO Fix - Remote worker shouldn't recover from WAL
         dest_params["disable_wal"] = 1
         # Disable Incompatible Ones

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -680,6 +680,8 @@ multiops_txn_params = {
     "two_write_queues": lambda: random.choice([0, 1]),
     # TODO: enable write-prepared
     "disable_wal": 0,
+    # TODO: Re-enable this once we fix WAL + Remote Compaction in Stress Test
+    "remote_compaction_worker_threads": 0,
     "use_only_the_last_commit_time_batch_for_recovery": lambda: random.choice([0, 1]),
     "clear_column_family_one_in": 0,
     "column_families": 1,


### PR DESCRIPTION
# Summary

Fixing "Integrated BlobDB is currently incompatible with Remote Compaction" error

https://github.com/facebook/rocksdb/actions/runs/17417658959/job/49449586139

# Test Plan

CI