### PR TITLE
Add prefetch feature enum to FSSupportedOps

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -1272,6 +1272,8 @@ class PosixFileSystem : public FileSystem {
       supported_ops |= (1 << FSSupportedOps::kAsyncIO);
     }
 #endif
+    // PosixFileSystem supports prefetch operations
+    supported_ops |= (1 << FSSupportedOps::kFSPrefetch);
   }
 
 #if defined(ROCKSDB_IOURING_PRESENT)

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -89,6 +89,7 @@ enum FSSupportedOps {
   kVerifyAndReconstructRead,  // Supports a higher level of data integrity. See
                               // the verify_and_reconstruct_read flag in
                               // IOOptions.
+  kFSPrefetch,                // Supports prefetch operations
 };
 
 // Per-request options that can be passed down to the FileSystem
@@ -778,12 +779,17 @@ class FileSystem : public Customizable {
   //  If async_io is supported by the underlying FileSystem, then supported_ops
   //  will have corresponding bit (i.e FSSupportedOps::kAsyncIO) set to 1.
   //
-  // By default, async_io operation is set and FS should override this API and
-  // set all the operations they support provided in FSSupportedOps (including
-  // async_io).
+  // By default, async_io and prefetch operation are set and FS should override
+  // this API and set all the operations they support provided in FSSupportedOps
+  // (including async_io and prefetch).
+  //
+  // Prefetch is enabled by default and FS is expected to override this API and
+  // set it to 0 if it doesn't support. This preserves the original behavior
+  // where prefetch was called on all file systems.
   virtual void SupportedOps(int64_t& supported_ops) {
     supported_ops = 0;
     supported_ops |= (1 << FSSupportedOps::kAsyncIO);
+    supported_ops |= (1 << FSSupportedOps::kFSPrefetch);
   }
 
   // If you're adding methods here, remember to add them to EnvWrapper too.

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1067,7 +1067,8 @@ Status BlockBasedTable::PrefetchTail(
   Status s = file->PrepareIOOptions(ro, opts, &dbg);
   // Try file system prefetch
   if (s.ok() && !file->use_direct_io() && !force_direct_prefetch) {
-    if (!file->Prefetch(opts, prefetch_off, prefetch_len).IsNotSupported()) {
+    if (CheckFSFeatureSupport(ioptions.fs.get(), FSSupportedOps::kFSPrefetch) &&
+        !file->Prefetch(opts, prefetch_off, prefetch_len).IsNotSupported()) {
       prefetch_buffer->reset(new FilePrefetchBuffer(
           ReadaheadParams(), false /* enable */, true /* track_min_offset */));
       return Status::OK();

--- a/table/block_based/block_prefetcher.cc
+++ b/table/block_based/block_prefetcher.cc
@@ -44,12 +44,17 @@ void BlockPrefetcher::PrefetchIfNeeded(
       if (!s.ok()) {
         return;
       }
-      s = rep->file->Prefetch(opts, offset, len + compaction_readahead_size_);
-      if (s.ok()) {
-        readahead_limit_ = offset + len + compaction_readahead_size_;
-        return;
-      } else if (!s.IsNotSupported()) {
-        return;
+      if (CheckFSFeatureSupport(rep->ioptions.fs.get(),
+                                FSSupportedOps::kFSPrefetch)) {
+        s = rep->file->Prefetch(opts, offset, len + compaction_readahead_size_);
+        if (s.ok()) {
+          readahead_limit_ = offset + len + compaction_readahead_size_;
+          return;
+        } else if (!s.IsNotSupported()) {
+          return;
+        }
+        // If prefetch returned NotSupported despite feature bit being set,
+        // fall through to use internal prefetch buffer
       }
     }
     // If FS prefetch is not supported, fall back to use internal prefetch
@@ -142,19 +147,30 @@ void BlockPrefetcher::PrefetchIfNeeded(
   if (!s.ok()) {
     return;
   }
-  s = rep->file->Prefetch(
-      opts, handle.offset(),
-      BlockBasedTable::BlockSizeWithTrailer(handle) + readahead_size_);
-  if (s.IsNotSupported()) {
+
+  if (CheckFSFeatureSupport(rep->ioptions.fs.get(),
+                            FSSupportedOps::kFSPrefetch)) {
+    s = rep->file->Prefetch(
+        opts, handle.offset(),
+        BlockBasedTable::BlockSizeWithTrailer(handle) + readahead_size_);
+    if (s.IsNotSupported()) {
+      // If prefetch returned NotSupported despite feature bit being set,
+      // fall back to use internal prefetch buffer
+      rep->CreateFilePrefetchBufferIfNotExists(
+          readahead_params, &prefetch_buffer_, readaheadsize_cb,
+          /*usage=*/FilePrefetchBufferUsage::kUserScanPrefetch);
+      return;
+    }
+
+    readahead_limit_ = offset + len + readahead_size_;
+    // Keep exponentially increasing readahead size until
+    // max_auto_readahead_size.
+    readahead_size_ = std::min(max_auto_readahead_size, readahead_size_ * 2);
+  } else {
+    // If prefetch is not supported, fall back to use internal prefetch buffer.
     rep->CreateFilePrefetchBufferIfNotExists(
         readahead_params, &prefetch_buffer_, readaheadsize_cb,
         /*usage=*/FilePrefetchBufferUsage::kUserScanPrefetch);
-    return;
   }
-
-  readahead_limit_ = offset + len + readahead_size_;
-  // Keep exponentially increasing readahead size until
-  // max_auto_readahead_size.
-  readahead_size_ = std::min(max_auto_readahead_size, readahead_size_ * 2);
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -593,7 +593,8 @@ Status PartitionedFilterBlockReader::CacheDependencies(
     IOOptions opts;
     IODebugContext dbg;
     s = rep->file->PrepareIOOptions(ro, opts, &dbg);
-    if (s.ok()) {
+    if (s.ok() && CheckFSFeatureSupport(rep->ioptions.fs.get(),
+                                        FSSupportedOps::kFSPrefetch)) {
       s = prefetch_buffer->Prefetch(opts, rep->file.get(), prefetch_off,
                                     static_cast<size_t>(prefetch_len));
     }


### PR DESCRIPTION
Summary:

Problem: RocksDB was making unnecessary prefetch system calls on file systems that don't support prefetch operations, potentially leading to wasted CPU cycles.

Fix: Add kFSPrefetch to FSSupportedOps enum to allow file systems to indicate prefetch support capability. File systems can now opt out of prefetch calls by not setting this bit, while preserving backwards compatibility.

Backwards compatibility: File systems that don't override SupportedOps() continue to receive prefetch calls exactly as before. Only file systems that explicitly opt out by not setting kFSPrefetch will avoid the calls.

Test Plan: