### PR TITLE
Expose Simulation Cache through JNI

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -66,6 +66,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/rocks_callback_object.cc
         rocksjni/rocksdb_exception_test.cc
         rocksjni/rocksjni.cc
+        rocksjni/sim_cache.cc
         rocksjni/slice.cc
         rocksjni/snapshot.cc
         rocksjni/sst_file_manager.cc
@@ -237,6 +238,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/RocksMutableObject.java
   src/main/java/org/rocksdb/RocksObject.java
   src/main/java/org/rocksdb/SanityLevel.java
+  src/main/java/org/rocksdb/SimCache.java
   src/main/java/org/rocksdb/SizeApproximationFlag.java
   src/main/java/org/rocksdb/SkipListMemTableConfig.java
   src/main/java/org/rocksdb/Slice.java
@@ -740,6 +742,7 @@ if(${CMAKE_VERSION} VERSION_LESS "3.11.4")
           org.rocksdb.RocksMemEnv
           org.rocksdb.RocksMutableObject
           org.rocksdb.RocksObject
+          org.rocksdb.SimCache
           org.rocksdb.SkipListMemTableConfig
           org.rocksdb.Slice
           org.rocksdb.Snapshot

--- a/java/Makefile
+++ b/java/Makefile
@@ -63,6 +63,7 @@ NATIVE_JAVA_CLASSES = \
 	org.rocksdb.RocksEnv\
 	org.rocksdb.RocksIterator\
 	org.rocksdb.RocksMemEnv\
+	org.rocksdb.SimCache\
 	org.rocksdb.SkipListMemTableConfig\
 	org.rocksdb.Slice\
 	org.rocksdb.SstFileManager\
@@ -184,6 +185,7 @@ JAVA_TESTS = \
 	org.rocksdb.RocksMemEnvTest\
 	org.rocksdb.util.SizeUnitTest\
 	org.rocksdb.SecondaryDBTest\
+	org.rocksdb.SimCacheTest\
 	org.rocksdb.SliceTest\
 	org.rocksdb.SnapshotTest\
 	org.rocksdb.SstFileManagerTest\

--- a/java/rocksjni/sim_cache.cc
+++ b/java/rocksjni/sim_cache.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the "bridge" between Java and C++ for
+// ROCKSDB_NAMESPACE::SimCache.
+
+#include "include/rocksdb/utilities/sim_cache.h"
+
+#include <jni.h>
+
+#include "include/org_rocksdb_SimCache.h"
+#include "rocksjni/cplusplus_to_java_convert.h"
+
+/*
+ * Class:     org_rocksdb_SimCache
+ * Method:    newSimCache
+ * Signature: (JJI)J
+ */
+jlong Java_org_rocksdb_SimCache_newSimCache(JNIEnv* /*env*/, jclass /*jcls*/,
+                                            jlong jhandle,
+                                            jlong jcapacity,
+                                            jint jnum_shard_bits) {
+  auto* sptr_sim_cache = new std::shared_ptr<ROCKSDB_NAMESPACE::Cache>(
+      ROCKSDB_NAMESPACE::NewSimCache(
+          *reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Cache>*>(jhandle),
+          static_cast<size_t>(jcapacity), 
+          static_cast<int>(jnum_shard_bits)));
+  return GET_CPLUSPLUS_POINTER(sptr_sim_cache);
+}
+
+/*
+ * Class:     org_rocksdb_SimCache
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_SimCache_disposeInternal(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
+  auto* sptr_sim_cache =
+      reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Cache>*>(jhandle);
+  delete sptr_sim_cache;  // delete std::shared_ptr
+}

--- a/java/src/main/java/org/rocksdb/SimCache.java
+++ b/java/src/main/java/org/rocksdb/SimCache.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Simulation Cache
+ */
+public class SimCache extends Cache {
+
+  /**
+   * Create a new key only cache with a fixed size capacity. The cache is sharded
+   * to 2^numShardBits shards, by hash of the key. The total capacity
+   * is divided and evenly assigned to each shard.
+   * numShardBits = -1 means it is automatically determined: every shard
+   * will be at least 512KB and number of shard bits will not exceed 6.
+   *
+   * @param handle The native handle of the real cache
+   * @param capacity The fixed size capacity of the key only cache
+   * @param numShardBits The key only cache is sharded to 2^numShardBits shards,
+   *     by hash of the key
+   */
+  public SimCache(final long handle, final long capacity, final int numShardBits) {
+    super(newSimCache(handle, capacity, numShardBits));
+  }
+
+  private static native long newSimCache(final long handle, final long capacity, final int numShardBits);
+  @Override protected final native void disposeInternal(final long handle);
+}

--- a/java/src/test/java/org/rocksdb/SimCacheTest.java
+++ b/java/src/test/java/org/rocksdb/SimCacheTest.java
@@ -1,0 +1,35 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class SimCacheTest {
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Test
+  public void newSimCache() {
+    final long capacity = 80000000;
+    final int numShardBits = 16;
+    final boolean strictCapacityLimit = true;
+    final double highPriPoolRatio = 0.5;
+    final double lowPriPoolRatio = 0.5;
+    try (final Cache lruCache = new LRUCache(
+          capacity, numShardBits, strictCapacityLimit, highPriPoolRatio, lowPriPoolRatio)) {
+      try (final Cache simCache = new SimCache(
+            lruCache.getNativeHandle(), capacity, numShardBits)) {
+        //no op
+        assertThat(simCache.getUsage()).isGreaterThanOrEqualTo(0);
+        assertThat(simCache.getPinnedUsage()).isGreaterThanOrEqualTo(0);
+      }
+    }
+  }
+}

--- a/src.mk
+++ b/src.mk
@@ -723,6 +723,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/rocks_callback_object.cc                      \
   java/rocksjni/rocksjni.cc                                   \
   java/rocksjni/rocksdb_exception_test.cc                     \
+  java/rocksjni/sim_cache.cc                                  \
   java/rocksjni/slice.cc                                      \
   java/rocksjni/snapshot.cc                                   \
   java/rocksjni/sst_file_manager.cc                           \


### PR DESCRIPTION
Exposes a JNI constructor for `SimCache`, so that users can wrap `LRUCache` instances in Java code.

During manual tests I also confirmed that tickers `SIM_BLOCK_CACHE_HIT` and `SIM_BLOCK_CACHE_MISS` were being updated as expected.

I have completed the CLA.