### PR TITLE
Use the standard 'C' locale to handle option conversions correctly in the JNI context. Fixes #13841

### DIFF
--- a/java/rocksjni/env.cc
+++ b/java/rocksjni/env.cc
@@ -19,6 +19,13 @@
 #include "portal.h"
 #include "rocksjni/cplusplus_to_java_convert.h"
 
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM*, void*) {
+  // Use the standard 'C' locale to handle option conversions correctly
+  assert(setlocale(LC_ALL, "C") != nullptr);
+
+  return JNI_VERSION_1_6;
+}
+
 /*
  * Class:     org_rocksdb_Env
  * Method:    getDefaultEnvInternal


### PR DESCRIPTION
RocksDB heavily relies on the default 'C' locale when storing to and reading options from the OPTIONS file.

For example, filter_policy option for bloomfilter has a parameter bits_per_key of double type. When this options is written to the OPTIONS file the value returned by BloomLikeFilterPolicy::GetId() is used. To compose the value, decimal dot is explicitly used:
https://github.com/facebook/rocksdb/blob/d87e598f70c960e3de2ea1984111f4fa35cbfee6/table/block_based/filter_policy.cc#L1568-L1584

To read the option parameter the standard C++ std::stod() function is used:
https://github.com/facebook/rocksdb/blob/d87e598f70c960e3de2ea1984111f4fa35cbfee6/util/string_util.cc#L398-L404

std::stod() is a locale dependent and for some locales (de_DE.UTF-8, fr_FR.UTF-8, ru_RU.UTF-8, etc) decimal comma is expected and because of this fractional part is not read. Whereas C/C++ code of RocksDB seems to never change the default locale and it's guaranteed to be 'C' by the standard, Java sets locale (for JNI code) according to the system environment. 

This bug leads to failures or exceptions in java tests (for example OptionsUtilTest.loadLatestTableFormatOptions) if the said locales are set in the user system.

I suggest to enforce default 'C' locale when JNI library is loaded defining JNI_OnLoad() function from jni.h.

This PR fixes #13841.