### PR TITLE
cmake: fix libatomic detection on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,8 +324,35 @@ int main() {
 }
 " BUILTIN_ATOMIC)
   if (NOT BUILTIN_ATOMIC)
-    #TODO: Check if -latomic exists
-    list(APPEND THIRDPARTY_LIBS atomic)
+    # Only consider -latomic when not on Apple (macOS has no separate libatomic)
+    if (APPLE)
+      message(STATUS "Builtin atomics probe failed, but skipping -latomic on Apple")
+    else()
+      # Prefer a positive link test with -latomic; if that succeeds, then add it.
+      set(_OLD_REQ_LIBS ${CMAKE_REQUIRED_LIBRARIES})
+      list(APPEND CMAKE_REQUIRED_LIBRARIES atomic)
+      unset(HAVE_WORKING_LIBATOMIC CACHE)
+      CHECK_CXX_SOURCE_COMPILES("
+#include <atomic>
+std::atomic<unsigned __int128> x{};
+int main() { auto v = x.load(std::memory_order_relaxed); (void)v; return 0; }
+" HAVE_WORKING_LIBATOMIC)
+      set(CMAKE_REQUIRED_LIBRARIES ${_OLD_REQ_LIBS})
+
+      if (HAVE_WORKING_LIBATOMIC)
+        list(APPEND THIRDPARTY_LIBS atomic)
+        message(STATUS "Using -latomic (probe succeeded)")
+      else()
+        # Fallback: try to locate the library and add it only if it actually exists
+        find_library(ATOMIC_LIBRARY atomic)
+        if (ATOMIC_LIBRARY)
+          list(APPEND THIRDPARTY_LIBS atomic)
+          message(STATUS "Using -latomic (found in system)")
+        else()
+          message(STATUS "libatomic not found or not required; continuing without it")
+        endif()
+      endif()
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
### Summary

On macOS, the build currently fails with:

    ld: library 'atomic' not found
because CMake unconditionally adds `-latomic` when the builtin atomic probe fails.

However:
- macOS libc++/Clang provides atomics without a separate `libatomic`
- the system does not ship `libatomic` at all

### What this patch does

This patch refines the detection logic:

- Skip `-latomic` entirely on Apple platforms.
- On non-Apple platforms, re-probe with `-latomic` using `unsigned __int128`
  (a more reliable trigger for architectures that actually need it).
- As a fallback, use `find_library(atomic)` and only add `-latomic` if it exists.

This avoids build failures on macOS while preserving correct behavior on Linux
platforms where `-latomic` is truly required.

### Reproduction (macOS 15.6.1, Apple clang 17.0.0)

```bash
rm -rf build && mkdir build && cd build
CC=clang CXX=clang++ cmake .. \
  -DCMAKE_BUILD_TYPE=Release \
  -DROCKSDB_BUILD_SHARED=ON \
  -DWITH_GFLAGS=ON -DWITH_SNAPPY=ON -DWITH_LZ4=ON \
  -DWITH_ZLIB=ON -DWITH_ZSTD=ON -DWITH_BZ2=ON
cmake --build . -j"$(sysctl -n hw.ncpu)"

Before this patch：

[ 92%] Built target rocksdb
[ 92%] Linking CXX shared library librocksdb.dylib
ld: library 'atomic' not found
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [CMakeFiles/rocksdb-shared.dir/build.make:5703: librocksdb.10.7.0.dylib] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:201: CMakeFiles/rocksdb-shared.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2


After this patch:

[100%] Linking CXX executable db_bench
[100%] Built target db_bench
[100%] Linking CXX executable db_stress
[100%] Built target db_stress


