### PR TITLE
Fix error from transactiondb layer in stress test

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -3198,8 +3198,9 @@ class NonBatchedOpsStressTest : public StressTest {
       }
 
       // It is possible that multiple thread concurrently try to write to the
-      // same key, which could cause lock timeout or deadlock, even before
-      // transaction is rolled back. E.g.
+      // same key, which could cause lock timeout or deadlock in the
+      // transactiondb layer, before transaction is rolled back.
+      // E.g.
       // Timestamp 1: Transaction A: lock key M for write
       // Timestamp 2: Transaction B: lock key N for write
       // Timestamp 3: Transaction B: try to lock key M for write -> wait


### PR DESCRIPTION
Summary:

The stress test runs concurrent transactions through many threads at the same time on a shared key space. It is possible that a dead lock or a timeout is detected from the transactiondb layer. When this happens, simply return from the function and continue the test, instead of fail the test.

Test Plan:

Stress test pass locally with the same random seed from stress test 14723229280871643749.

Reviewers:

Subscribers:

Tasks:

Tags: