### PR TITLE
Some follow-up to parallel compression revamp

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -342,6 +342,9 @@ Status BuildTable(
     if (s.ok() && !empty) {
       if (flush_stats) {
         flush_stats->bytes_written_pre_comp = builder->PreCompressionSize();
+        // Add worker CPU micros here. Caller needs to add CPU micros from
+        // calling thread.
+        flush_stats->cpu_micros += builder->GetWorkerCPUMicros();
       }
       uint64_t file_size = builder->FileSize();
       meta->fd.file_size = file_size;

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1578,9 +1578,8 @@ void CompactionJob::FinalizeSubcompactionJobStats(
                                            cur_cpu_micros, prev_cpu_micros);
 
   // Finalize timing and I/O statistics
-
   sub_compact->compaction_job_stats.cpu_micros =
-      cur_cpu_micros - start_cpu_micros;
+      cur_cpu_micros - start_cpu_micros + sub_compact->GetWorkerCPUMicros();
 
   if (measure_io_stats_) {
     sub_compact->compaction_job_stats.file_write_nanos +=

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -56,6 +56,7 @@ Status CompactionOutputs::Finish(
   stats_.bytes_written += current_bytes;
   stats_.bytes_written_pre_comp += builder_->PreCompressionSize();
   stats_.num_output_files = static_cast<int>(outputs_.size());
+  worker_cpu_micros_ += builder_->GetWorkerCPUMicros();
 
   return s;
 }

--- a/db/compaction/compaction_outputs.h
+++ b/db/compaction/compaction_outputs.h
@@ -168,6 +168,10 @@ class CompactionOutputs {
 
   uint64_t NumEntries() const { return builder_->NumEntries(); }
 
+  uint64_t GetWorkerCPUMicros() const {
+    return worker_cpu_micros_ + (builder_ ? builder_->GetWorkerCPUMicros() : 0);
+  }
+
   void ResetBuilder() {
     builder_.reset();
     current_output_file_size_ = 0;
@@ -295,6 +299,9 @@ class CompactionOutputs {
   std::unique_ptr<WritableFileWriter> file_writer_;
   uint64_t current_output_file_size_ = 0;
   SequenceNumber smallest_preferred_seqno_ = kMaxSequenceNumber;
+
+  // Sum of all the GetWorkerCPUMicros() for all the closed builders so far.
+  uint64_t worker_cpu_micros_ = 0;
 
   // all the compaction outputs so far
   std::vector<Output> outputs_;

--- a/db/compaction/subcompaction_state.h
+++ b/db/compaction/subcompaction_state.h
@@ -191,6 +191,14 @@ class SubcompactionState {
     return &compaction_outputs_.stats_;
   }
 
+  uint64_t GetWorkerCPUMicros() const {
+    uint64_t rv = compaction_outputs_.GetWorkerCPUMicros();
+    if (compaction->SupportsPerKeyPlacement()) {
+      rv += proximal_level_outputs_.GetWorkerCPUMicros();
+    }
+    return rv;
+  }
+
   CompactionRangeDelAggregator* RangeDelAgg() const {
     return range_del_agg_.get();
   }

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -1104,13 +1104,13 @@ Status FlushJob::WriteLevel0Table() {
   const uint64_t micros = clock_->NowMicros() - start_micros;
   const uint64_t cpu_micros = clock_->CPUMicros() - start_cpu_micros;
   flush_stats.micros = micros;
-  flush_stats.cpu_micros = cpu_micros;
+  flush_stats.cpu_micros += cpu_micros;
 
   ROCKS_LOG_INFO(db_options_.info_log,
                  "[%s] [JOB %d] Flush lasted %" PRIu64
                  " microseconds, and %" PRIu64 " cpu microseconds.\n",
                  cfd_->GetName().c_str(), job_context_->job_id, micros,
-                 cpu_micros);
+                 flush_stats.cpu_micros);
 
   if (has_output) {
     flush_stats.bytes_written = meta_.fd.GetFileSize();

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -582,7 +582,7 @@ struct BlockBasedTableBuilder::ParallelCompressionRep {
 
       // If didn't find higher priority work
       if (next_thread_state == ThreadState::kEnd) {
-        if (next_state.Get<NextToCompress>() != seen_state.Get<NextToEmit>()) {
+        if (next_state.Get<NextToCompress>() != next_state.Get<NextToEmit>()) {
           // Compression work is available, select that
           if (thread_kind == ThreadKind::kWorker &&
               next_state.Get<NextToCompress>() ==
@@ -894,6 +894,7 @@ struct BlockBasedTableBuilder::Rep {
   std::vector<std::unique_ptr<InternalTblPropColl>> table_properties_collectors;
 
   std::unique_ptr<ParallelCompressionRep> pc_rep;
+  RelaxedAtomic<uint64_t> worker_cpu_micros{0};
   BlockCreateContext create_context;
 
   // The size of the "tail" part of a SST file. "Tail" refers to
@@ -1276,6 +1277,11 @@ struct BlockBasedTableBuilder::Rep {
       SetStatus(Status::InvalidArgument(
           "Enable block_align, but compression enabled"));
     }
+  }
+
+  ~Rep() {
+    // Must have been cleaned up by StopParallelCompression
+    assert(pc_rep == nullptr);
   }
 
   Rep(const Rep&) = delete;
@@ -1714,7 +1720,19 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& uncompressed_block_data,
   }
 }
 
+uint64_t BlockBasedTableBuilder::GetWorkerCPUMicros() const {
+  return rep_->worker_cpu_micros.LoadRelaxed();
+}
+
 void BlockBasedTableBuilder::BGWorker(WorkingAreaPair& working_area) {
+  // Record CPU usage of this thread
+  const uint64_t start_cpu_micros =
+      rep_->ioptions.env->GetSystemClock()->CPUMicros();
+  Defer log_cpu{[this, start_cpu_micros]() {
+    rep_->worker_cpu_micros.FetchAddRelaxed(
+        rep_->ioptions.env->GetSystemClock()->CPUMicros() - start_cpu_micros);
+  }};
+
   auto& pc_rep = *rep_->pc_rep;
 #ifndef NDEBUG
   // Tracking for watchdog
@@ -2004,6 +2022,18 @@ IOStatus BlockBasedTableBuilder::WriteMaybeCompressedBlockImpl(
 
 void BlockBasedTableBuilder::MaybeStartParallelCompression() {
   if (rep_->compression_parallel_threads <= 1) {
+    return;
+  }
+  // Although in theory having a separate thread for writing to the SST file
+  // could help to hide the latency associated with writing, it is more often
+  // the case that the latency comes in large units for rare calls to write that
+  // flush downstream buffers, including in WritableFileWriter. The buffering
+  // provided by the compression ring buffer is almost negligible for hiding
+  // that latency. So even with some optimizations, turning on the parallel
+  // framework when compression is disabled just eats more CPU with little-to-no
+  // improvement in throughput.
+  if (rep_->data_block_compressor == nullptr) {
+    // Force the generally best configuration for no compression: no parallelism
     return;
   }
   rep_->pc_rep = std::make_unique<ParallelCompressionRep>(

--- a/table/block_based/block_based_table_builder.h
+++ b/table/block_based/block_based_table_builder.h
@@ -112,6 +112,8 @@ class BlockBasedTableBuilder : public TableBuilder {
   void SetSeqnoTimeTableProperties(const SeqnoToTimeMapping& relevant_mapping,
                                    uint64_t oldest_ancestor_time) override;
 
+  uint64_t GetWorkerCPUMicros() const override;
+
  private:
   bool ok() const;
 

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -245,6 +245,11 @@ class TableBuilder {
   virtual void SetSeqnoTimeTableProperties(
       const SeqnoToTimeMapping& /*relevant_mapping*/,
       uint64_t /*oldest_ancestor_time*/) {}
+
+  // If this builder used CPU work from threads other than the caller, return
+  // the CPU microseconds used. 0 = no work outside calling thread, or not
+  // supported.
+  virtual uint64_t GetWorkerCPUMicros() const { return 0; }
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/unreleased_history/bug_fixes/compaction_cpu.md
+++ b/unreleased_history/bug_fixes/compaction_cpu.md
@@ -1,0 +1,1 @@
+* Reported numbers for compaction and flush CPU usage now include time spent by parallel compression worker threads. This now means compaction/flush CPU usage could exceed the wall clock time.

--- a/util/bit_fields.h
+++ b/util/bit_fields.h
@@ -83,7 +83,6 @@ struct BitFields {
     explicit Reference(BitFields& bf) : bf_(bf) {}
     Reference(const Reference&) = default;
     Reference& operator=(const Reference&) = default;
-    // no moves
     Reference(Reference&&) = default;
     Reference& operator=(Reference&&) = default;
 


### PR DESCRIPTION
Summary:
* Fix compaction/flush CPU usage stats to include CPU usage by parallel compression workers. (Validated with manual db_bench testing.)
* Disable the parallel compression framework when compression is disabled. See new code comment for details, because in theory it could be useful to hide SST write latency, but manual testing with db_bench and -rate_limiter_bytes_per_sec or -simulate_hdd options shows no useful increase in throughput, just more CPU usage.
* Fix some minor clean-up items in the implementation

Test Plan: Also ran some tests like in #13910 to ensure the new CPU usage tracking did not regress performance, all good.