### PR TITLE
Correctly handle upper bound iteration result from a UDI

### DIFF
--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -1337,14 +1337,14 @@ bool BlockBasedTableIterator::CollectBlockHandles(
         scan_block_handles->push_back(index_iter_->value().handle);
       }
       ++num_blocks;
-    } else if (num_blocks == 0) {
+    } else if (num_blocks == 0 && index_iter_->UpperBoundCheckResult() !=
+                                      IterBoundCheck::kOutOfBound) {
       // We should not have scan ranges that are completely after the file's
       // range. This is important for FindBlockForwardInMultiScan() which only
       // lets the upper layer (LevelIterator) advance to the next SST file when
       // the last scan range is exhausted.
       return false;
     }
-    assert(num_blocks);
     block_index_ranges_per_scan->emplace_back(
         scan_block_handles->size() - num_blocks, scan_block_handles->size());
   }

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -251,6 +251,10 @@ class UserDefinedIndexIteratorWrapper
     }
   }
 
+  IterBoundCheck UpperBoundCheckResult() override {
+    return result_.bound_check_result;
+  }
+
  private:
   std::unique_ptr<UserDefinedIndexIterator> udi_iter_;
   IterateResult result_;

--- a/unreleased_history/bug_fixes/udi_empty_scan_range_fix.md
+++ b/unreleased_history/bug_fixes/udi_empty_scan_range_fix.md
@@ -1,0 +1,1 @@
+Fix a bug in RocksDB MultiScan with UDI when one of the scan ranges is determined to be empty by the UDI, which causes incorrect results.


### PR DESCRIPTION
This PR fixes a bug in BlockBasedTableIterator::Prepare in conjunction with a user defined index (UDI). If the UDI determines a scan range to be empty and thus returns the kOutOfBound iteration result during Seek, the iteration result is not propagated up and Prepare() assumes end of file and aborts the remaining scans. This results in incorrect behavior and unpredictable multi scan results.

Test plan:
Add unit test to table_test.cc