### PR TITLE
Unpin skipped data blocks in MultiScan

### DIFF
--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -1047,6 +1047,10 @@ bool BlockBasedTableIterator::SeekMultiScan(const Slice* target) {
     // Unexpected seek key
     multi_scan_.reset();
   } else {
+    if (multi_scan_->next_scan_idx > 0) {
+      UnpinPreviousScanBlocks(multi_scan_->next_scan_idx);
+    }
+
     auto [cur_scan_start_idx, cur_scan_end_idx] =
         multi_scan_->block_index_ranges_per_scan[multi_scan_->next_scan_idx];
     // We should have the data block already loaded
@@ -1089,6 +1093,24 @@ bool BlockBasedTableIterator::SeekMultiScan(const Slice* target) {
   assert(!is_index_at_curr_block_);
   assert(!block_iter_points_to_real_block_);
   return false;
+}
+
+void BlockBasedTableIterator::UnpinPreviousScanBlocks(size_t current_scan_idx) {
+  // TODO: support aborting and clearn up async IO requests, currently
+  // only unpins already initialized blocks
+  assert(multi_scan_);
+  if (current_scan_idx == 0) return;
+
+  auto [prev_start_block_idx, prev_end_block_idx] =
+      multi_scan_->block_index_ranges_per_scan[current_scan_idx - 1];
+  auto [curr_start_block_idx, curr_end_block_idx] =
+      multi_scan_->block_index_ranges_per_scan[current_scan_idx];
+  for (size_t block_idx = prev_start_block_idx;
+       block_idx < curr_start_block_idx; ++block_idx) {
+    if (!multi_scan_->pinned_data_blocks[block_idx].IsEmpty()) {
+      multi_scan_->pinned_data_blocks[block_idx].Reset();
+    }
+  }
 }
 
 void BlockBasedTableIterator::FindBlockForwardInMultiScan() {

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -1099,10 +1099,14 @@ void BlockBasedTableIterator::UnpinPreviousScanBlocks(size_t current_scan_idx) {
   // TODO: support aborting and clearn up async IO requests, currently
   // only unpins already initialized blocks
   assert(multi_scan_);
+  assert(current_scan_idx < multi_scan_->block_index_ranges_per_scan.size());
   if (current_scan_idx == 0) return;
 
   auto [prev_start_block_idx, prev_end_block_idx] =
       multi_scan_->block_index_ranges_per_scan[current_scan_idx - 1];
+  // Since a block can be shared between consecutive scans, we need
+  // curr_start_block_idx here instead of just release blocks
+  // up to prev_end_block_idx.
   auto [curr_start_block_idx, curr_end_block_idx] =
       multi_scan_->block_index_ranges_per_scan[current_scan_idx];
   for (size_t block_idx = prev_start_block_idx;

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -238,6 +238,16 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
 
   std::unique_ptr<InternalIteratorBase<IndexValue>> index_iter_;
 
+  bool TEST_IsBlockPinnedByMultiScan(size_t block_idx) {
+    if (!multi_scan_) {
+      return false;
+    }
+    if (block_idx >= multi_scan_->pinned_data_blocks.size()) {
+      return false;
+    }
+    return !multi_scan_->pinned_data_blocks[block_idx].IsEmpty();
+  }
+
  private:
   enum class IterDirection {
     kForward,
@@ -593,6 +603,9 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   bool SeekMultiScan(const Slice* target);
 
   void FindBlockForwardInMultiScan();
+
+  // Unpins blocks from the immediately previous scan range.
+  void UnpinPreviousScanBlocks(size_t current_scan_idx);
 
   void PrepareReadAsyncCallBack(FSReadRequest& req, void* cb_arg) {
     // Record status, result and sanity check offset from `req`.

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -22,6 +22,7 @@
 #include "rocksdb/options.h"
 #include "table/block_based/block_based_table_builder.h"
 #include "table/block_based/block_based_table_factory.h"
+#include "table/block_based/block_based_table_iterator.h"
 #include "table/block_based/partitioned_index_iterator.h"
 #include "table/format.h"
 #include "test_util/testharness.h"
@@ -1428,6 +1429,69 @@ TEST_P(BlockBasedTableReaderTest, MultiScanPrefetchSizeLimit) {
     // Should not hit prefetch limit
     ASSERT_OK(iter->status());
     ASSERT_EQ(scanned_keys, 5 + 4 * kEntriesPerBlock + 1 * kEntriesPerBlock);
+  }
+}
+
+TEST_P(BlockBasedTableReaderTest, MultiScanUnpinPreviousBlocks) {
+  std::vector<std::pair<std::string, std::string>> kv =
+      BlockBasedTableReaderBaseTest::GenerateKVMap(
+          30 /* num_block */,
+          true /* mixed_with_human_readable_string_value */);
+  std::string table_name = "BlockBasedTableReaderTest_UnpinPreviousBlocks" +
+                           CompressionTypeToString(compression_type_);
+  ImmutableOptions ioptions(options_);
+  CreateTable(table_name, ioptions, compression_type_, kv,
+              compression_parallel_threads_, compression_dict_bytes_);
+
+  std::unique_ptr<BlockBasedTable> table;
+  FileOptions foptions;
+  foptions.use_direct_reads = use_direct_reads_;
+  InternalKeyComparator comparator(options_.comparator);
+  NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table,
+                           true /* bool prefetch_index_and_filter_in_cache */,
+                           nullptr /* status */, persist_udt_);
+
+  ReadOptions read_opts;
+  std::unique_ptr<InternalIterator> iter;
+  iter.reset(table->NewIterator(
+      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
+      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+
+  MultiScanArgs scan_options(BytewiseComparator());
+  // Create ranges with gaps: Range 0: blocks 0-4, Range 1: blocks 10-14
+  scan_options.insert(ExtractUserKey(kv[0 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[5 * kEntriesPerBlock - 2].first));
+  scan_options.insert(ExtractUserKey(kv[5 * kEntriesPerBlock - 1].first),
+                      ExtractUserKey(kv[15 * kEntriesPerBlock].first));
+
+  iter->Prepare(&scan_options);
+  auto* bbiter = dynamic_cast<BlockBasedTableIterator*>(iter.get());
+  ASSERT_TRUE(bbiter);
+  for (int block = 0; block < 15; ++block) {
+    ASSERT_TRUE(bbiter->TEST_IsBlockPinnedByMultiScan(block)) << block;
+  }
+
+  // Seek to first range: MultiScan require seeks to be called in scan_option
+  // order
+  iter->Seek(kv[0 * kEntriesPerBlock].first);
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+
+  // Seek to second range - should unpin blocks from first range
+  iter->Seek(kv[5 * kEntriesPerBlock - 1].first);
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_OK(iter->status());
+
+  // Block from first range should be unpinned, except for the last block
+  // which is shared with the second range
+  for (int block = 0; block < 4; ++block) {
+    ASSERT_FALSE(bbiter->TEST_IsBlockPinnedByMultiScan(block)) << block;
+  }
+  // Blocks from second range still in cache
+  // We skip block 4 here since it's ownership is moved to the actual data
+  // block iter.
+  for (int block = 5; block < 15; ++block) {
+    ASSERT_TRUE(bbiter->TEST_IsBlockPinnedByMultiScan(block)) << block;
   }
 }
 


### PR DESCRIPTION
Summary: Currently in MultiScan we only unpins a block after we scan through it. This PR adds unpinning during Seek to release all blocks pinned by the previous scan range. This is useful when users do not scan through the entire scan range. I plan to follow up with support for aborting async IOs from the previous scan.


Test plan: new test MultiScanUnpinPreviousBlocks validates unpinning behavior
