### PR TITLE
Attempt fix initialization order dep on kPageSize

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -1727,9 +1727,11 @@ inline uint64_t UsedLengthToLengthInfo(size_t used_length) {
 }
 
 inline size_t GetStartingLength(size_t capacity) {
-  if (capacity > port::kPageSize) {
+  // Avoid potential initialization order race with port::kPageSize
+  constexpr size_t kPresumedPageSize = 4096;
+  if (capacity > kPresumedPageSize) {
     // Start with one memory page
-    return port::kPageSize / sizeof(AutoHyperClockTable::HandleImpl);
+    return kPresumedPageSize / sizeof(AutoHyperClockTable::HandleImpl);
   } else {
     // Mostly to make unit tests happy
     return 4;


### PR DESCRIPTION
Summary: If there's a static initialization of Options() this could now instantiate an AutoHyperClockTable before kPageSize is initialized. Break the dependency because it's a very minor optimization.

Test Plan: internal CI (not able to reproduce locally)