### PR TITLE
Bug Fix in MultiScan max_prefetch_size

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1189,6 +1189,7 @@ class LevelIterator final : public InternalIterator {
     // Propagate io colaescing threshold
     for (auto& file_to_arg : *file_to_scan_opts_) {
       file_to_arg.second.io_coalesce_threshold = so->io_coalesce_threshold;
+      file_to_arg.second.max_prefetch_size = so->max_prefetch_size;
       file_to_arg.second.use_async_io = so->use_async_io;
     }
   }


### PR DESCRIPTION
Summary:

Fix a small bug in MultiScan max_prefetch_size handling. It was not passed down to file level correctly.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags: