### PR TITLE
Fix an assertion failure in stress test

### DIFF
--- a/table/block_based/partitioned_index_iterator.h
+++ b/table/block_based/partitioned_index_iterator.h
@@ -81,8 +81,6 @@ class PartitionedIndexIterator : public InternalIteratorBase<IndexValue> {
     }
   }
   inline IterBoundCheck UpperBoundCheckResult() override {
-    // Shouldn't be called.
-    assert(false);
     return IterBoundCheck::kUnknown;
   }
   void SetPinnedItersMgr(PinnedIteratorsManager*) override {


### PR DESCRIPTION
Summary: for MultiScan and UDI we start to use bound check from index iterator, so removing this assert here.

Test plan: existing test