### PR TITLE
Revert "Improve random seed override support in stress test (#13952)"

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -11,48 +11,22 @@ import sys
 import tempfile
 import time
 
-per_iteration_random_seed_override = 0
-
-def get_random_seed(override):
-    if override == 0:
-        return random.randint(1, 2**64)
-    else:
-        return override
 
 def setup_random_seed_before_main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--initial_random_seed_override",
+        "--random_seed",
         default=0,
         type=int,
-        help="Random seed used for initialize the test parameters at the beginning of stress test run",
+        help="Random seed used for reproduce the same test parameter set",
     )
-    # sometimes the failure appeared after a few iteration, to reproduce the error, we have to wait for the test to run
-    # multiple iterations to reach the iteration that fails the test. By overriding the seed used within each iteration,
-    # we could skip all the previous iterations.
-    parser.add_argument(
-        "--per_iteration_random_seed_override",
-        default=0,
-        type=int,
-        help="Random seed used for initialize the test parameters in each iteration of the stress test run",
+    args, _ = parser.parse_known_args()
+    random_seed = (
+        random.randint(1, 2**64) if args.random_seed == 0 else args.random_seed
     )
+    print(f"Start with random seed {random_seed}")
+    random.seed(random_seed)
 
-    args, remain_args = parser.parse_known_args()
-    init_random_seed = get_random_seed(args.initial_random_seed_override)
-    global per_iteration_random_seed_override
-    per_iteration_random_seed_override = args.per_iteration_random_seed_override
-
-    print(f"Start with random seed {init_random_seed}")
-    random.seed(init_random_seed)
-
-    # reset the sys.argv with the remaining args, so that the rest of the argument parser would not see these 2 args
-    sys.argv = remain_args
-
-def apply_random_seed_per_iteration():
-    global per_iteration_random_seed_override
-    per_iteration_random_seed = get_random_seed(per_iteration_random_seed_override)
-    print(f"Use random seed for iteration {per_iteration_random_seed}")
-    random.seed(per_iteration_random_seed)
 
 # Random seed has to be setup before the rest of the script, so that the random
 # value selected in the global variable uses the random seed specified
@@ -393,7 +367,7 @@ default_params = {
     "memtable_veirfy_per_key_checksum_on_seek": lambda: random.choice([0] * 7 + [1]),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
     # TODO(hx235): enable `track_and_verify_wals` after stabalizing the stress test
-    "track_and_verify_wals": lambda: random.choice([0]),
+    "track_and_verify_wals": lambda: random.choice([0]),    
     "remote_compaction_worker_threads": lambda: random.choice([0, 8]),
     # TODO(jaykorean): Change to lambda: random.choice([0, 1]) after addressing all remote compaction failures
     "remote_compaction_failure_fall_back_to_local": 1,
@@ -1256,6 +1230,7 @@ def gen_cmd(params, unknown_params):
             not in {
                 "test_type",
                 "simple",
+                "random_seed",
                 "duration",
                 "interval",
                 "random_kill_odd",
@@ -1339,7 +1314,6 @@ def blackbox_crash_main(args, unknown_args):
     )
 
     while time.time() < exit_time:
-        apply_random_seed_per_iteration()
         cmd = gen_cmd(
             dict(list(cmd_params.items()) + list({"db": dbname}.items())), unknown_args
         )
@@ -1402,7 +1376,6 @@ def whitebox_crash_main(args, unknown_args):
     succeeded = True
     hit_timeout = False
     while time.time() < exit_time:
-        apply_random_seed_per_iteration()
         if check_mode == 0:
             additional_opts = {
                 # use large ops per thread since we will kill it anyway


### PR DESCRIPTION
**Context/Summary**
This reverts commit 73432a3f369d2f6331b68c907a0ffac4e9a3d653. This is due to it mysteriously fails our internal CI running with this change to db_crashtest.py. The root-cause is unknown but the error only reproed with this commit frequently but not the one before it. The error message appears to be the command parsing leading to the db_stress binary can't be found  


```
Traceback (most recent call last):
  File "/data/sandcastle/boxes/trunk-hg-full-fbsource/fbcode/internal_repo_rocksdb/repo/tools/db_crashtest.py", line 1638, in <module>
    main()
  File "/data/sandcastle/boxes/trunk-hg-full-fbsource/fbcode/internal_repo_rocksdb/repo/tools/db_crashtest.py", line 1627, in main
    blackbox_crash_main(args, unknown_args)
  File "/data/sandcastle/boxes/trunk-hg-full-fbsource/fbcode/internal_repo_rocksdb/repo/tools/db_crashtest.py", line 1347, in blackbox_crash_main
    hit_timeout, retcode, outs, errs = execute_cmd(cmd, cmd_params["interval"])
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/sandcastle/boxes/trunk-hg-full-fbsource/fbcode/internal_repo_rocksdb/repo/tools/db_crashtest.py", line 1283, in execute_cmd
    child = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/fbcode/platform010/lib/python3.12/subprocess.py", line 1028, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/fbcode/platform010/lib/python3.12/subprocess.py", line 1957, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: './db_stress'
```


**Test plan**
- Rehearsal crash test 