### PR TITLE
Fix: track file size correctly for importing sst

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -6211,6 +6211,12 @@ Status DBImpl::CreateColumnFamilyWithImport(
     sv_context.Clean();
   }
 
+  auto sfm = static_cast<SstFileManagerImpl*>(
+      immutable_db_options_.sst_file_manager.get());
+  if (status.ok() && sfm) {
+    TrackExistingDataFiles({});
+  }
+
   {
     InstrumentedMutexLock l(&mutex_);
     ReleaseFileNumberFromPendingOutputs(pending_output_elem);

--- a/unreleased_history/bug_fixes/get_sst_size_after_import_column_family.md
+++ b/unreleased_history/bug_fixes/get_sst_size_after_import_column_family.md
@@ -1,0 +1,1 @@
+* Fix the issue where `SstFileManagerImpl::GetTotalSize` returns 0 for new column families after importing


### PR DESCRIPTION
Summary: By `DB::CreateColumnFamilyWithImport` 
the sst in the newly added column family is not tracked 
normally, so the result of `SstFileManagerImpl::GetTotalSize` 
does not contain the files in it, which is much lower than 
the true value. Now fixed.

Test Plan: added a new unittest to verify it.