### PR TITLE
Tune the level hint for lower WAF

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5066,16 +5066,32 @@ Env::WriteLifeTimeHint VersionStorageInfo::CalculateSSTWriteHint(
         return Env::WLTH_MEDIUM;
       }
 
-      // L1: medium, L2: long, ...
-      if (level - base_level_ >= 2) {
-        return Env::WLTH_EXTREME;
-      } else if (level < base_level_) {
-        // There is no restriction which prevents level passed in to be smaller
-        // than base_level.
-        return Env::WLTH_MEDIUM;
-      }
-      return static_cast<Env::WriteLifeTimeHint>(
+      // num_levels is less than 6
+      if (num_levels() <= 5) {
+        // L1: medium, L2: long, ...
+        if (level - base_level_ >= 2) {
+          return Env::WLTH_EXTREME;
+        } else if (level < base_level_) {
+          // There is no restriction which prevents level passed in to be smaller
+          // than base_level.
+          return Env::WLTH_MEDIUM;
+        }
+        return static_cast<Env::WriteLifeTimeHint>(
           level - base_level_ + static_cast<int>(Env::WLTH_MEDIUM));
+      }
+      // num_levels is greater than 5
+      else {
+        // L0-L3: medium, L4: long, ...
+        if (level - base_level_ >= 4) {
+          return Env::WLTH_EXTREME;
+        } else if (level - base_level_ < 3) {
+          return Env::WLTH_MEDIUM;
+        } else {
+          return static_cast<Env::WriteLifeTimeHint>(
+            level - base_level_ + static_cast<int>(Env::WLTH_NONE));
+        }
+      }
+
     case kCompactionStyleUniversal:
       if (level == 0) {
         return Env::WLTH_SHORT;


### PR DESCRIPTION
RocksDB has hint policy for fcntl to decrease WAF. The native hint policy is: short for WAF, medium for L0-L1, long for L2 and extreme for >=L3. However, based on our experiments on the FDP SSD, the reduction in the WAF is not significant.

As we observed the data lifetime of each levels, we changed the hint policy for fcntl. The new policy is short for WAF, medium for L0-L3, long for L4 and extreme for >=L5. The WAF gained reduction dramatically on the experimental results.

| **Lifetime** | **Hint  Policy (native, num_levels <=5)** | **Hint Policy (tuned, num_levels >=6)** | 
| ------------ | ----------------------------------------- | ------------------------------------------- |
| WLTH_SHORT   | WAL                                       | WAL                                         |
| WLTH_MEDIUM  | Level0  ~  Level1                         | Level0  ~  Level3                           |
| WLTH_LONG    | Level2                                    | Level4                                      |
| WLTH_EXTREME | >=  Level3                                | >=  Level5                                  |

e.g. With YCSB workload, load 200 million records and update 100 million records, RocksDB WAF on ext4 was reduced from 2.7 (legacy SSD) to 2.4 (FDP SSD) on native hint policy, but from 2.7 (legacy SSD) to 1.9 (FDP SSD). P.S. The results were shared in OCP'25 Storage Tech Talk.

The patch differentiates cases based on the num_levels option configuration. If the num_levels option is configured <=5, keeps the native hint policy. If the num_levels option is configured >=6, use the new hint policy.

 The proportion of trivial move is small and it would not affect the WAF result.