### PR TITLE
Fix handling of out-of-range scan option

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1193,6 +1193,7 @@ class LevelIterator final : public InternalIterator {
       file_to_arg.second.io_coalesce_threshold = so->io_coalesce_threshold;
       file_to_arg.second.max_prefetch_size = so->max_prefetch_size;
       file_to_arg.second.use_async_io = so->use_async_io;
+      file_to_arg.second.require_file_overlap = true;
     }
   }
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1876,6 +1876,11 @@ class MultiScanArgs {
   // When false, it will use synchronous MultiRead().
   bool use_async_io = false;
 
+  // Internal use only.
+  // Fail the Prepare() on a file if a scan range does not overlap
+  // with the file.
+  bool require_file_overlap = false;
+
  private:
   // The comparator used for ordering ranges
   const Comparator* comp_;

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -963,6 +963,15 @@ BlockBasedTableIterator::MultiScanState::~MultiScanState() {
 // - After Prepare(), the iterator expects Seek to be called on the start key
 // of each ScanOption in order. If any other Seek is done, an error status is
 // returned
+// - Whenever all blocks of a scan opt are exhausted, the iterator will become
+// invalid and UpperBoundCheckResult() will return kOutOfBound. So that the
+// upper layer (LevelIterator) will stop scanning instead thinking EOF is
+// reached and continue into the next file. The only exception is for the last
+// scan opt. If we reach the end of the last scan opt, UpperBoundCheckResult()
+// will return kUnknown instead of kOutOfBound. This mechanism requires that
+// scan opts are properly pruned such that there is no scan opt that is after
+// this file's key range. This check can be enforeced by setting
+// MultiScanArgs::require_file_overlap to true.
 // FIXME: DBIter and MergingIterator may
 // internally do Seek() on child iterators, e.g. due to
 // ReadOptions::max_skippable_internal_keys or reseeking into range deletion
@@ -989,8 +998,9 @@ void BlockBasedTableIterator::Prepare(const MultiScanArgs* multiscan_opts) {
   std::vector<BlockHandle> scan_block_handles;
   std::vector<std::tuple<size_t, size_t>> block_index_ranges_per_scan;
   const std::vector<ScanOptions>& scan_opts = multiscan_opts->GetScanRanges();
-  multi_scan_status_ = CollectBlockHandles(scan_opts, &scan_block_handles,
-                                           &block_index_ranges_per_scan);
+  multi_scan_status_ =
+      CollectBlockHandles(scan_opts, multiscan_opts, &scan_block_handles,
+                          &block_index_ranges_per_scan);
   if (!multi_scan_status_.ok()) {
     return;
   }
@@ -1317,6 +1327,7 @@ Status BlockBasedTableIterator::ValidateScanOptions(
 
 Status BlockBasedTableIterator::CollectBlockHandles(
     const std::vector<ScanOptions>& scan_opts,
+    const MultiScanArgs* multiscan_opts,
     std::vector<BlockHandle>* scan_block_handles,
     std::vector<std::tuple<size_t, size_t>>* block_index_ranges_per_scan) {
   for (const auto& scan_opt : scan_opts) {
@@ -1368,12 +1379,14 @@ Status BlockBasedTableIterator::CollectBlockHandles(
       ++num_blocks;
     } else if (num_blocks == 0 && index_iter_->UpperBoundCheckResult() !=
                                       IterBoundCheck::kOutOfBound) {
-      // We should not have scan ranges that are completely after the file's
-      // range. This is important for FindBlockForwardInMultiScan() which only
-      // lets the upper layer (LevelIterator) advance to the next SST file when
-      // the last scan range is exhausted.
-      return Status::InvalidArgument("Scan does not intersect with file");
-      ;
+      // If require_file_overlap is set, then the scan ranges for this file
+      // must intersect with the file. Otherwise, allow empty intersection.
+      if (multiscan_opts->require_file_overlap) {
+        // This is important for FindBlockForwardInMultiScan() which only
+        // lets the upper layer (LevelIterator) advance to the next SST file
+        // when the last scan range is exhausted.
+        return Status::InvalidArgument("Scan does not intersect with file");
+      }
     }
     block_index_ranges_per_scan->emplace_back(
         scan_block_handles->size() - num_blocks, scan_block_handles->size());

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -670,6 +670,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
 
   Status CollectBlockHandles(
       const std::vector<ScanOptions>& scan_opts,
+      const MultiScanArgs* multiscan_opts,
       std::vector<BlockHandle>* scan_block_handles,
       std::vector<std::tuple<size_t, size_t>>* block_index_ranges_per_scan);
 

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -1492,6 +1492,52 @@ TEST_P(BlockBasedTableReaderTest, MultiScanUnpinPreviousBlocks) {
   }
 }
 
+TEST_P(BlockBasedTableReaderTest, MultiScanOptFileOverlapChecking) {
+  std::vector<std::pair<std::string, std::string>> kv =
+      BlockBasedTableReaderBaseTest::GenerateKVMap(
+          20 /* num_block */,
+          true /* mixed_with_human_readable_string_value */);
+  std::vector<std::pair<std::string, std::string>> actual_kv(
+      kv.begin(), kv.begin() + 15 * kEntriesPerBlock);
+
+  std::string table_name = "BlockBasedTableReaderTest_UnpinPreviousBlocks" +
+                           CompressionTypeToString(compression_type_);
+  ImmutableOptions ioptions(options_);
+  CreateTable(table_name, ioptions, compression_type_, actual_kv,
+              compression_parallel_threads_, compression_dict_bytes_);
+
+  std::unique_ptr<BlockBasedTable> table;
+  FileOptions foptions;
+  foptions.use_direct_reads = use_direct_reads_;
+  InternalKeyComparator comparator(options_.comparator);
+  NewBlockBasedTableReader(foptions, ioptions, comparator, table_name, &table,
+                           true /* bool prefetch_index_and_filter_in_cache */,
+                           nullptr /* status */, persist_udt_);
+
+  ReadOptions read_opts;
+  std::unique_ptr<InternalIterator> iter;
+  iter.reset(table->NewIterator(
+      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
+      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+
+  MultiScanArgs scan_options(BytewiseComparator());
+  scan_options.require_file_overlap = false;
+  scan_options.insert(ExtractUserKey(kv[5 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[6 * kEntriesPerBlock].first));
+  scan_options.insert(ExtractUserKey(kv[16 * kEntriesPerBlock].first),
+                      ExtractUserKey(kv[17 * kEntriesPerBlock].first));
+
+  iter->Prepare(&scan_options);
+  ASSERT_OK(iter->status());
+
+  iter.reset(table->NewIterator(
+      read_opts, options_.prefix_extractor.get(), /*arena=*/nullptr,
+      /*skip_filters=*/false, TableReaderCaller::kUncategorized));
+  scan_options.require_file_overlap = true;
+  iter->Prepare(&scan_options);
+  ASSERT_TRUE(iter->status().IsInvalidArgument());
+}
+
 // Param 1: compression type
 // Param 2: whether to use direct reads
 // Param 3: Block Based Table Index type, partitioned filters are also enabled


### PR DESCRIPTION
Summary: currently BlockBasedTableIterator::Prepare() fails the iterator with non-ok status if an out-of-range scan option is detected. This is due to the interaction between LevelIterator and BlockBasedTableIterator, see added comment above BlockBasedTableIterator::Prepare(). This can fail stress test for L0 files since it doesn't use LevelIterator and scan options are not pruned. This PR fixes this by adding an internal option to MultiScanArgs that enables this check. 

Test plan: 
- new unit test
- stress test that fails before this pr: `python3 -u ./tools/db_crashtest.py whitebox --iterpercent=60 --prefix_size=-1 --prefixpercent=0 --readpercent=0 --test_batches_snapshots=0 --use_multiscan=1 --read_fault_one_in=0 --kill_random_test=88888 --interval=60 --multiscan_use_async_io=0 --mmap_read=0 --level0_file_num_compaction_trigger=20`