### PR TITLE
Speed up AutoHCC check in dtor

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -2062,9 +2062,10 @@ AutoHyperClockTable::~AutoHyperClockTable() {
   }
   // This check can be extra expensive for a cache that is just created,
   // maybe used for a small number of entries, as in a unit test, and then
-  // destroyed. Only do this in rare modes.
+  // destroyed. Only do this in rare modes. REVISED: Don't scan the whole mmap,
+  // just a reasonable frontier past what we expect to have written.
 #ifdef MUST_FREE_HEAP_ALLOCATIONS
-  for (size_t i = used_end; i < array_.Count(); i++) {
+  for (size_t i = used_end; i < array_.Count() && i < used_end + 64U; i++) {
     assert(array_[i].head_next_with_shift.LoadRelaxed() == 0);
     assert(array_[i].chain_next_with_shift.LoadRelaxed() == 0);
     assert(array_[i].meta.LoadRelaxed() == 0);


### PR DESCRIPTION
Summary: In #13964 I changed an expensive DEBUG check in ~AutoHyperClockTable to only run in ASAN builds. It's still expensive so I'm modifying it to scan only about one page beyond what we expect to have written to the anonymous mmap, rather than scanning the whole thing.

Test Plan: manually checked that lru_cache_test running time went from 5.0s to 4.0s after the change. Verified that existing unit test ClockCacheTest.Limits uses the full anonymous mmap to be sure it is sized as expected, by temporarily breaking AutoHyperClockTable::Grow() to allow slightly exceeding the anonymous mmap size.