### PR TITLE
Allow UDIs with non BytewiseComparator

### DIFF
--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1190,12 +1190,6 @@ struct BlockBasedTableBuilder::Rep {
         SetStatus(
             Status::InvalidArgument("user_defined_index_factory not supported "
                                     "with parallel compression"));
-      } else if (ioptions.user_comparator != BytewiseComparator()) {
-        // TODO: Pass the user_comparator to the UDI and let it validate. Do
-        // it in a major release.
-        SetStatus(
-            Status::InvalidArgument("user_defined_index_factory only supported "
-                                    "with bytewise comparator"));
       } else {
         std::unique_ptr<UserDefinedIndexBuilder> user_defined_index_builder(
             table_options.user_defined_index_factory->NewBuilder());

--- a/unreleased_history/behavior_changes/udi_non_bytewise_comparator.md
+++ b/unreleased_history/behavior_changes/udi_non_bytewise_comparator.md
@@ -1,0 +1,1 @@
+Allow UDIs with a non BytewiseComparator


### PR DESCRIPTION
Remove the restriction of only using BytewiseComparator(). In a follow on PR, the UDI interface will be updated to take the Comparator as a parameter.

Test plan:
Add a unit test in table_test.cc