### PR TITLE
Add support for index size estimation during table building

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -4771,6 +4771,12 @@ cpp_unittest_wrapper(name="data_block_hash_index_test",
             extra_compiler_flags=[])
 
 
+cpp_unittest_wrapper(name="index_builder_test",
+            srcs=["table/block_based/index_builder_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
 cpp_unittest_wrapper(name="db_basic_test",
             srcs=["db/db_basic_test.cc"],
             deps=[":rocksdb_test_lib"],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1438,6 +1438,7 @@ if(WITH_TESTS)
         table/block_based/block_based_table_reader_test.cc
         table/block_based/block_test.cc
         table/block_based/data_block_hash_index_test.cc
+        table/block_based/index_builder_test.cc
         table/block_based/full_filter_block_test.cc
         table/block_based/partitioned_filter_block_test.cc
         table/cleanable_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1739,6 +1739,9 @@ block_test: $(OBJ_DIR)/table/block_based/block_test.o $(TEST_LIBRARY) $(LIBRARY)
 data_block_hash_index_test: $(OBJ_DIR)/table/block_based/data_block_hash_index_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+index_builder_test: $(OBJ_DIR)/table/block_based/index_builder_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 inlineskiplist_test: $(OBJ_DIR)/memtable/inlineskiplist_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/src.mk
+++ b/src.mk
@@ -588,6 +588,7 @@ TEST_MAIN_SOURCES =                                                     \
   table/block_based/block_based_table_reader_test.cc                    \
   table/block_based/block_test.cc                                       \
   table/block_based/data_block_hash_index_test.cc                       \
+  table/block_based/index_builder_test.cc                               \
   table/block_based/full_filter_block_test.cc                           \
   table/block_based/partitioned_filter_block_test.cc                    \
   table/cleanable_test.cc                                               \

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -117,6 +117,24 @@ Slice ShortenedIndexBuilder::FindShortInternalKeySuccessor(
   }
 }
 
+uint64_t ShortenedIndexBuilder::EstimateCurrentIndexSize() const {
+  // Get current size estimate from the appropriate block builder
+  uint64_t current_size = must_use_separator_with_seq_
+      ? index_block_builder_.CurrentSizeEstimate()
+      : index_block_builder_without_seq_.CurrentSizeEstimate();
+  
+  if (num_index_entries_ == 0) {
+    return current_size;
+  }
+  
+  // Calculate average entry size based on entries added so far
+  uint64_t avg_entry_size = current_size / num_index_entries_;
+  
+  // Add 2x the average entry size to account for the next index entry
+  // This bounds the estimate in the right direction as suggested in the feedback
+  return current_size + (2 * avg_entry_size);
+}
+
 PartitionedIndexBuilder* PartitionedIndexBuilder::CreateIndexBuilder(
     const InternalKeyComparator* comparator,
     const bool use_value_delta_encoding,

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -153,6 +153,13 @@ class IndexBuilder {
   // Get the size for index block. Must be called after ::Finish.
   virtual size_t IndexSize() const = 0;
 
+  // Get an estimate for current total index size based on current builder
+  // state.
+  //
+  // Called during compaction to estimate final index size for ShouldStopBefore
+  // decisions.
+  virtual uint64_t EstimateCurrentIndexSize() const = 0;
+
   virtual bool separator_is_key_plus_seq() { return true; }
 
  protected:
@@ -332,6 +339,7 @@ class ShortenedIndexBuilder : public IndexBuilder {
     AddIndexEntryImpl(separator_with_seq, first_internal_key, block_handle,
                       must_use_separator_with_seq_);
     current_block_first_internal_key_.clear();
+    ++num_index_entries_;
     return separator_with_seq;
   }
 
@@ -381,6 +389,7 @@ class ShortenedIndexBuilder : public IndexBuilder {
     entry->SaveFrom(separator, first_internal_key,
                     must_use_separator_with_seq_);
     current_block_first_internal_key_.clear();
+    ++num_index_entries_;
   }
 
   void FinishIndexEntry(const BlockHandle& block_handle,
@@ -405,6 +414,8 @@ class ShortenedIndexBuilder : public IndexBuilder {
   }
 
   size_t IndexSize() const override { return index_size_; }
+
+  uint64_t EstimateCurrentIndexSize() const override;
 
   bool separator_is_key_plus_seq() override {
     return must_use_separator_with_seq_;
@@ -436,6 +447,8 @@ class ShortenedIndexBuilder : public IndexBuilder {
   BlockBasedTableOptions::IndexShorteningMode shortening_mode_;
   BlockHandle last_encoded_handle_ = BlockHandle::NullBlockHandle();
   std::string current_block_first_internal_key_;
+  // Number of index entries added so far
+  uint64_t num_index_entries_ = 0;
 };
 
 // HashIndexBuilder contains a binary-searchable primary index and the
@@ -554,6 +567,8 @@ class HashIndexBuilder : public IndexBuilder {
            prefix_meta_block_.size();
   }
 
+  uint64_t EstimateCurrentIndexSize() const override { return 0; }
+
   bool separator_is_key_plus_seq() override {
     return primary_index_builder_.separator_is_key_plus_seq();
   }
@@ -627,6 +642,7 @@ class PartitionedIndexBuilder : public IndexBuilder {
   size_t IndexSize() const override { return index_size_; }
   size_t TopLevelIndexSize(uint64_t) const { return top_level_index_size_; }
   size_t NumPartitions() const;
+  uint64_t EstimateCurrentIndexSize() const override { return 0; }
 
   inline bool ShouldCutFilterBlock() {
     // Current policy is to align the partitions of index and filters

--- a/table/block_based/index_builder_test.cc
+++ b/table/block_based/index_builder_test.cc
@@ -1,0 +1,181 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "table/block_based/index_builder.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "db/dbformat.h"
+#include "rocksdb/comparator.h"
+#include "table/format.h"
+#include "test_util/testharness.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class IndexBuilderTest
+    : public testing::Test,
+      public testing::WithParamInterface<BlockBasedTableOptions::IndexType> {
+ public:
+  IndexBuilderTest() : icomp_(BytewiseComparator()) {}
+
+  std::unique_ptr<IndexBuilder> CreateIndexBuilder() {
+    BlockBasedTableOptions table_options;
+    BlockBasedTableOptions::IndexType index_type = GetParam();
+    return std::unique_ptr<IndexBuilder>(IndexBuilder::CreateIndexBuilder(
+        index_type, &icomp_, nullptr, false /* use_value_delta_encoding */,
+        table_options, 0 /* ts_sz */,
+        true /* persist_user_defined_timestamps */));
+  }
+
+  std::string MakeKey(int i) {
+    return InternalKey(std::string("key") + std::to_string(i), 100 - i,
+                       kTypeValue)
+        .Encode()
+        .ToString();
+  }
+
+  BlockHandle MakeBlockHandle(uint64_t offset, uint64_t size) {
+    BlockHandle handle;
+    handle.set_offset(offset);
+    handle.set_size(size);
+    return handle;
+  }
+
+  void AddEntriesToBuilder(IndexBuilder* builder, int num_entries,
+                           std::vector<uint64_t>* estimates = nullptr) {
+    for (int i = 1; i <= num_entries; ++i) {
+      std::string key_current = MakeKey(i);
+      BlockHandle handle = MakeBlockHandle(i * kBlockOffset, kBlockSize);
+      std::string separator_scratch;
+
+      if (i == num_entries) {
+        // Last entry - no next key
+        builder->AddIndexEntry(key_current, nullptr, handle,
+                               &separator_scratch);
+      } else {
+        std::string key_next = MakeKey(i + 1);
+        Slice key_next_slice(key_next);
+        builder->AddIndexEntry(key_current, &key_next_slice, handle,
+                               &separator_scratch);
+      }
+
+      if (estimates) {
+        uint64_t current_estimate = builder->EstimateCurrentIndexSize();
+        estimates->push_back(current_estimate);
+      }
+    }
+  }
+
+ protected:
+  InternalKeyComparator icomp_;
+  static const uint64_t kBlockOffset = 1000;
+  static const uint64_t kBlockSize = 4096;
+  // BlockBuilder initial overhead
+  // See BlockBuilder constructor and Reset()
+  static const uint64_t kBlockBuilderInitialOverhead = 2 * sizeof(uint32_t);
+};
+
+const uint64_t IndexBuilderTest::kBlockOffset;
+const uint64_t IndexBuilderTest::kBlockSize;
+const uint64_t IndexBuilderTest::kBlockBuilderInitialOverhead;
+
+TEST_P(IndexBuilderTest, EstimateCurrentIndexSize) {
+  auto builder = CreateIndexBuilder();
+  BlockBasedTableOptions::IndexType index_type = GetParam();
+
+  // Empty builder
+  uint64_t empty_size = builder->EstimateCurrentIndexSize();
+  if (index_type == BlockBasedTableOptions::kBinarySearch) {
+    EXPECT_EQ(empty_size, kBlockBuilderInitialOverhead)
+        << "Empty ShortenedIndexBuilder should return BlockBuilder initial "
+           "overhead ("
+        << kBlockBuilderInitialOverhead;
+  } else {
+    EXPECT_EQ(empty_size, 0) << "Other builders should return 0 when empty";
+  }
+
+  // Add one entry
+  AddEntriesToBuilder(builder.get(), 1);
+  uint64_t size_after_one = builder->EstimateCurrentIndexSize();
+
+  if (index_type == BlockBasedTableOptions::kBinarySearch) {
+    EXPECT_GT(size_after_one, kBlockBuilderInitialOverhead)
+        << "Estimate should be greater than initial overhead";
+  } else {
+    // Other builders currently return 0 (which is expected)
+    EXPECT_EQ(size_after_one, 0) << "Other index builders currently return 0";
+  }
+
+  // Add multiple entries and capture all estimates
+  std::vector<uint64_t> estimates;
+  auto new_builder = CreateIndexBuilder();
+  AddEntriesToBuilder(new_builder.get(), 5, &estimates);
+
+  // Validate reported estimates
+  for (size_t i = 0; i < estimates.size(); ++i) {
+    uint64_t estimate = estimates[i];
+
+    if (index_type == BlockBasedTableOptions::kBinarySearch) {
+      EXPECT_GT(estimate, 0)
+          << "Estimate should be positive for " << i << " entry";
+      if (i > 0) {
+        EXPECT_GT(estimate, estimates[i - 1])
+            << "Estimate should not decrease with more entries (entry " << i
+            << ": " << estimates[i - 1] << ", entry " << i << ": " << estimate
+            << ")";
+      }
+    } else {
+      EXPECT_EQ(estimate, 0) << "Other index builders currently return 0";
+    }
+  }
+
+  // Test consistency - multiple calls should return the same value if the
+  // builder state is not modified
+  uint64_t estimate1 = builder->EstimateCurrentIndexSize();
+  uint64_t estimate2 = builder->EstimateCurrentIndexSize();
+  uint64_t estimate3 = builder->EstimateCurrentIndexSize();
+
+  EXPECT_EQ(estimate1, estimate2);
+  EXPECT_EQ(estimate2, estimate3);
+
+  // Test behavior after Finish() - only for builders that can be finished
+  // successfully
+  if (index_type == BlockBasedTableOptions::kBinarySearch) {
+    uint64_t estimate_before_finish = builder->EstimateCurrentIndexSize();
+
+    IndexBuilder::IndexBlocks index_blocks;
+    Status s = builder->Finish(&index_blocks);
+    EXPECT_TRUE(s.ok()) << "ShortenedIndexBuilder should finish successfully: "
+                        << s.ToString();
+
+    if (s.ok()) {
+      uint64_t estimate_after_finish = builder->EstimateCurrentIndexSize();
+      EXPECT_GT(estimate_after_finish, 0)
+          << "Estimate should still be positive after finish";
+      // Estimate should remain reasonably consistent after finish
+      EXPECT_LE(std::abs(static_cast<int64_t>(estimate_after_finish -
+                                              estimate_before_finish)),
+                static_cast<int64_t>(estimate_before_finish / 2))
+          << "Estimate should not change dramatically after finish";
+    }
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    IndexBuilderTypes, IndexBuilderTest,
+    ::testing::Values(BlockBasedTableOptions::kBinarySearch,
+                      BlockBasedTableOptions::kHashSearch,
+                      BlockBasedTableOptions::kTwoLevelIndexSearch));
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Add `EstimateCurrentIndexSize()` method to index builder interface. This method is used to provide size estimation during index building which will be used to improve our file cutting logic. 

Problem: Currently the file cutting logic only considers data size when determining where to cut a file, failing to reserve space for index and filter blocks that are added when the file is finalized.

Key Details:
*  ShortenedIndexBuilder: Implemented ShortenedIndexBuilder size estimation using current BlockBuilder size + buffer for next index entry (2x average entry size). The buffer addresses under-estimation where the current index size doesn't account for the next index entry associated with the "active" data block being built. The buffer accounts for the index entry timing lag: when a data block is emitted and gets its index entry added, the next data block has already started consuming keys but won't receive its index entry until the following block begins.
*  Other builders: Continue returning 0 (HashIndexBuilder, PartitionedIndexBuilder). To be implemented later.