### PR TITLE
Add method to estimate index size

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -5193,6 +5193,12 @@ cpp_unittest_wrapper(name="import_column_family_test",
             extra_compiler_flags=[])
 
 
+cpp_unittest_wrapper(name="index_builder_test",
+            srcs=["table/block_based/index_builder_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
 cpp_unittest_wrapper(name="inlineskiplist_test",
             srcs=["memtable/inlineskiplist_test.cc"],
             deps=[":rocksdb_test_lib"],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1438,6 +1438,7 @@ if(WITH_TESTS)
         table/block_based/block_based_table_reader_test.cc
         table/block_based/block_test.cc
         table/block_based/data_block_hash_index_test.cc
+        table/block_based/index_builder_test.cc
         table/block_based/full_filter_block_test.cc
         table/block_based/partitioned_filter_block_test.cc
         table/cleanable_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1739,6 +1739,9 @@ block_test: $(OBJ_DIR)/table/block_based/block_test.o $(TEST_LIBRARY) $(LIBRARY)
 data_block_hash_index_test: $(OBJ_DIR)/table/block_based/data_block_hash_index_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+index_builder_test: $(OBJ_DIR)/table/block_based/index_builder_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 inlineskiplist_test: $(OBJ_DIR)/memtable/inlineskiplist_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/src.mk
+++ b/src.mk
@@ -588,6 +588,7 @@ TEST_MAIN_SOURCES =                                                     \
   table/block_based/block_based_table_reader_test.cc                    \
   table/block_based/block_test.cc                                       \
   table/block_based/data_block_hash_index_test.cc                       \
+  table/block_based/index_builder_test.cc                               \
   table/block_based/full_filter_block_test.cc                           \
   table/block_based/partitioned_filter_block_test.cc                    \
   table/cleanable_test.cc                                               \

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -117,6 +117,22 @@ Slice ShortenedIndexBuilder::FindShortInternalKeySuccessor(
   }
 }
 
+uint64_t ShortenedIndexBuilder::EstimateCurrentIndexSize() const {
+  uint64_t current_size =
+      must_use_separator_with_seq_
+          ? index_block_builder_.CurrentSizeEstimate()
+          : index_block_builder_without_seq_.CurrentSizeEstimate();
+
+  if (num_index_entries_ == 0) {
+    return current_size;
+  }
+
+  uint64_t avg_entry_size = current_size / num_index_entries_;
+
+  // Add buffer to account for the next index entry
+  return current_size + (2 * avg_entry_size);
+}
+
 PartitionedIndexBuilder* PartitionedIndexBuilder::CreateIndexBuilder(
     const InternalKeyComparator* comparator,
     const bool use_value_delta_encoding,

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -129,7 +129,7 @@ uint64_t ShortenedIndexBuilder::EstimateCurrentIndexSize() const {
 
   uint64_t avg_entry_size = current_size / num_index_entries_;
 
-  // Add buffer to account for the next index entry
+  // Add buffer to generously account (in most cases) for the next index entry
   return current_size + (2 * avg_entry_size);
 }
 

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -156,8 +156,7 @@ class IndexBuilder {
   // Get an estimate for current total index size based on current builder
   // state.
   //
-  // Called during compaction to estimate final index size for ShouldStopBefore
-  // decisions.
+  // Called during compaction to estimate final index size for file cutting decisions.
   virtual uint64_t EstimateCurrentIndexSize() const = 0;
 
   virtual bool separator_is_key_plus_seq() { return true; }
@@ -566,6 +565,7 @@ class HashIndexBuilder : public IndexBuilder {
            prefix_meta_block_.size();
   }
 
+  // TODO: implement
   uint64_t EstimateCurrentIndexSize() const override { return 0; }
 
   bool separator_is_key_plus_seq() override {
@@ -641,6 +641,8 @@ class PartitionedIndexBuilder : public IndexBuilder {
   size_t IndexSize() const override { return index_size_; }
   size_t TopLevelIndexSize(uint64_t) const { return top_level_index_size_; }
   size_t NumPartitions() const;
+
+  // TODO: implement
   uint64_t EstimateCurrentIndexSize() const override { return 0; }
 
   inline bool ShouldCutFilterBlock() {

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -156,7 +156,8 @@ class IndexBuilder {
   // Get an estimate for current total index size based on current builder
   // state.
   //
-  // Called during compaction to estimate final index size for file cutting decisions.
+  // Called during compaction to estimate final index size for file cutting
+  // decisions.
   virtual uint64_t EstimateCurrentIndexSize() const = 0;
 
   virtual bool separator_is_key_plus_seq() { return true; }

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -153,6 +153,13 @@ class IndexBuilder {
   // Get the size for index block. Must be called after ::Finish.
   virtual size_t IndexSize() const = 0;
 
+  // Get an estimate for current total index size based on current builder
+  // state.
+  //
+  // Called during compaction to estimate final index size for ShouldStopBefore
+  // decisions.
+  virtual uint64_t EstimateCurrentIndexSize() const = 0;
+
   virtual bool separator_is_key_plus_seq() { return true; }
 
  protected:
@@ -317,6 +324,8 @@ class ShortenedIndexBuilder : public IndexBuilder {
                                            encoded_entry,
                                            &delta_encoded_entry_slice);
     }
+
+    ++num_index_entries_;
   }
 
   Slice AddIndexEntry(const Slice& last_key_in_current_block,
@@ -406,6 +415,8 @@ class ShortenedIndexBuilder : public IndexBuilder {
 
   size_t IndexSize() const override { return index_size_; }
 
+  uint64_t EstimateCurrentIndexSize() const override;
+
   bool separator_is_key_plus_seq() override {
     return must_use_separator_with_seq_;
   }
@@ -436,6 +447,7 @@ class ShortenedIndexBuilder : public IndexBuilder {
   BlockBasedTableOptions::IndexShorteningMode shortening_mode_;
   BlockHandle last_encoded_handle_ = BlockHandle::NullBlockHandle();
   std::string current_block_first_internal_key_;
+  uint64_t num_index_entries_ = 0;
 };
 
 // HashIndexBuilder contains a binary-searchable primary index and the
@@ -554,6 +566,8 @@ class HashIndexBuilder : public IndexBuilder {
            prefix_meta_block_.size();
   }
 
+  uint64_t EstimateCurrentIndexSize() const override { return 0; }
+
   bool separator_is_key_plus_seq() override {
     return primary_index_builder_.separator_is_key_plus_seq();
   }
@@ -627,6 +641,7 @@ class PartitionedIndexBuilder : public IndexBuilder {
   size_t IndexSize() const override { return index_size_; }
   size_t TopLevelIndexSize(uint64_t) const { return top_level_index_size_; }
   size_t NumPartitions() const;
+  uint64_t EstimateCurrentIndexSize() const override { return 0; }
 
   inline bool ShouldCutFilterBlock() {
     // Current policy is to align the partitions of index and filters

--- a/table/block_based/index_builder_test.cc
+++ b/table/block_based/index_builder_test.cc
@@ -1,4 +1,4 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).

--- a/table/block_based/index_builder_test.cc
+++ b/table/block_based/index_builder_test.cc
@@ -1,0 +1,183 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "table/block_based/index_builder.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "db/dbformat.h"
+#include "rocksdb/comparator.h"
+#include "table/format.h"
+#include "test_util/testharness.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class IndexBuilderTest
+    : public testing::Test,
+      public testing::WithParamInterface<BlockBasedTableOptions::IndexType> {
+ public:
+  IndexBuilderTest() : icomp_(BytewiseComparator()) {}
+
+  std::unique_ptr<IndexBuilder> CreateIndexBuilder() {
+    BlockBasedTableOptions table_options;
+    BlockBasedTableOptions::IndexType index_type = GetParam();
+    return std::unique_ptr<IndexBuilder>(IndexBuilder::CreateIndexBuilder(
+        index_type, &icomp_, nullptr, false /* use_value_delta_encoding */,
+        table_options, 0 /* ts_sz */,
+        true /* persist_user_defined_timestamps */));
+  }
+
+  std::string MakeKey(int i) {
+    return InternalKey(std::string("key") + std::to_string(i), 100 - i,
+                       kTypeValue)
+        .Encode()
+        .ToString();
+  }
+
+  BlockHandle MakeBlockHandle(uint64_t offset, uint64_t size) {
+    BlockHandle handle;
+    handle.set_offset(offset);
+    handle.set_size(size);
+    return handle;
+  }
+
+  void AddEntriesToBuilder(IndexBuilder* builder, int num_entries,
+                           std::vector<uint64_t>* estimates = nullptr) {
+    for (int i = 1; i <= num_entries; ++i) {
+      std::string key_current = MakeKey(i);
+      BlockHandle handle = MakeBlockHandle(i * kBlockOffset, kBlockSize);
+      std::string separator_scratch;
+
+      if (i == num_entries) {
+        // Last entry - no next key
+        builder->AddIndexEntry(key_current, nullptr, handle,
+                               &separator_scratch);
+      } else {
+        std::string key_next = MakeKey(i + 1);
+        Slice key_next_slice(key_next);
+        builder->AddIndexEntry(key_current, &key_next_slice, handle,
+                               &separator_scratch);
+      }
+
+      if (estimates) {
+        uint64_t current_estimate = builder->EstimateCurrentIndexSize();
+        estimates->push_back(current_estimate);
+      }
+    }
+  }
+
+ protected:
+  InternalKeyComparator icomp_;
+  static const uint64_t kBlockOffset = 1000;
+  static const uint64_t kBlockSize = 4096;
+  // BlockBuilder initial overhead
+  // See BlockBuilder constructor and Reset()
+  static const uint64_t kBlockBuilderInitialOverhead = 2 * sizeof(uint32_t);
+};
+
+const uint64_t IndexBuilderTest::kBlockOffset;
+const uint64_t IndexBuilderTest::kBlockSize;
+const uint64_t IndexBuilderTest::kBlockBuilderInitialOverhead;
+
+TEST_P(IndexBuilderTest, EstimateCurrentIndexSize) {
+  auto builder = CreateIndexBuilder();
+  BlockBasedTableOptions::IndexType index_type = GetParam();
+
+  // Empty builder
+  uint64_t empty_size = builder->EstimateCurrentIndexSize();
+  if (index_type == BlockBasedTableOptions::kBinarySearch) {
+    EXPECT_EQ(empty_size, kBlockBuilderInitialOverhead)
+        << "Empty ShortenedIndexBuilder should return BlockBuilder initial "
+           "overhead ("
+        << kBlockBuilderInitialOverhead;
+  } else {
+    EXPECT_EQ(empty_size, 0) << "Other builders should return 0 when empty";
+  }
+
+  // Add one entry
+  AddEntriesToBuilder(builder.get(), 1);
+  uint64_t size_after_one = builder->EstimateCurrentIndexSize();
+
+  if (index_type == BlockBasedTableOptions::kBinarySearch) {
+    EXPECT_GT(size_after_one, kBlockBuilderInitialOverhead)
+        << "Estimate should be greater than initial overhead";
+  } else {
+    // Other builders currently return 0 (which is expected)
+    EXPECT_EQ(size_after_one, 0) << "Other index builders currently return 0";
+  }
+
+  // Add multiple entries and capture all estimates
+  std::vector<uint64_t> estimates;
+  auto new_builder = CreateIndexBuilder();
+  AddEntriesToBuilder(new_builder.get(), 5, &estimates);
+
+  // Validate reported estimates
+  for (size_t i = 0; i < estimates.size(); ++i) {
+    uint64_t estimate = estimates[i];
+
+    if (index_type == BlockBasedTableOptions::kBinarySearch) {
+      EXPECT_GT(estimate, 0)
+          << "Estimate should be positive for " << i << " entry";
+      if (i > 0) {
+        EXPECT_GT(estimate, estimates[i - 1])
+            << "Estimate should not decrease with more entries (entry " << i - 1
+            << ": " << estimates[i - 1] << ", entry " << i << ": " << estimate
+            << ")";
+      }
+    } else {
+      EXPECT_EQ(estimate, 0) << "Other index builders currently return 0";
+    }
+  }
+
+  // Multiple calls should return the same value if the builder state is not
+  // modified
+  uint64_t estimate1 = builder->EstimateCurrentIndexSize();
+  uint64_t estimate2 = builder->EstimateCurrentIndexSize();
+  uint64_t estimate3 = builder->EstimateCurrentIndexSize();
+
+  EXPECT_EQ(estimate1, estimate2);
+  EXPECT_EQ(estimate2, estimate3);
+
+  // Test behavior after Finish() - only for builders that can be finished
+  // successfully
+  if (index_type == BlockBasedTableOptions::kBinarySearch) {
+    uint64_t estimate_before_finish = builder->EstimateCurrentIndexSize();
+
+    IndexBuilder::IndexBlocks index_blocks;
+    Status s = builder->Finish(&index_blocks);
+    EXPECT_TRUE(s.ok()) << "ShortenedIndexBuilder should finish successfully: "
+                        << s.ToString();
+
+    uint64_t estimate_after_finish = builder->EstimateCurrentIndexSize();
+    EXPECT_GT(estimate_after_finish, 0);
+    EXPECT_LE(estimate_before_finish, estimate_after_finish)
+        << "Estimate should not decrease after finish";
+
+    // Ensure that the actual index size is not greater than the estimated size
+    // after finish is called to prevent underestimation.
+    uint64_t actual_index_size = builder->IndexSize();
+    EXPECT_LE(actual_index_size, estimate_after_finish)
+        << "Actual index size should not be greater than estimated size: "
+           "actual size:  "
+        << actual_index_size << ", estimated size: " << estimate_after_finish;
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    IndexBuilderTypes, IndexBuilderTest,
+    ::testing::Values(BlockBasedTableOptions::kBinarySearch,
+                      BlockBasedTableOptions::kHashSearch,
+                      BlockBasedTableOptions::kTwoLevelIndexSearch));
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/table/block_based/user_defined_index_wrapper.h
+++ b/table/block_based/user_defined_index_wrapper.h
@@ -155,6 +155,8 @@ class UserDefinedIndexBuilderWrapper : public IndexBuilder {
 
   size_t IndexSize() const override { return index_size_; }
 
+  uint64_t EstimateCurrentIndexSize() const override { return 0; }
+
   bool separator_is_key_plus_seq() override {
     return internal_index_builder_->separator_is_key_plus_seq();
   }


### PR DESCRIPTION
Summary:
This method will be used to improve the compaction logic by accounting for the tail size, in addition to the data size,  when determining when to cut a file.

Problem: Currently the file cutting logic only considers data size when determining where to cut a file, failing to reserve space for index and filter blocks that are added when the file is finalized.

Key changes:
- Add EstimateCurrentIndexSize() to IndexBuilder interface
- Implement in ShortenedIndexBuilder with buffer that accounts for the next index entry. The buffer addresses under-estimation where the current index size doesn't account for the next index entry associated with the data block currently being built. The 2x multiplier bounds the estimate in the right direction and handles outlier cases with large keys.
- Add num_index_entries_ member to track added index entries (== data blocks emitted). This is thread-safe since it's updated/read in the serialized emit step.

Next steps:
- Partitioned index size estimation implementation
- Update compaction file cutting logic to consider index size estimation

Test Plan:
Added a new test class with unit tests for new builder size estimation across all IndexBuilder implementations.
