### PR TITLE
Fix incorrect MultiScan handling of range limit between files

### DIFF
--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -59,7 +59,7 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   bool NextAndGetResult(IterateResult* result) override;
   void Prev() override;
   bool Valid() const override {
-    return !is_out_of_bound_ &&
+    return !is_out_of_bound_ && multi_scan_status_.ok() &&
            (is_at_first_key_from_index_ ||
             (block_iter_points_to_real_block_ && block_iter_.Valid()));
   }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -8464,6 +8464,22 @@ TEST_F(UserDefinedIndexTest, MultiScanFailureTest) {
   iter->Seek(key_ranges[2]);
   // Seek should fail as its not in the order specified in scan_options
   ASSERT_EQ(iter->status(), Status::InvalidArgument());
+  ASSERT_FALSE(iter->Valid());
+  iter.reset();
+
+  iter.reset(db->NewIterator(ro, cfh));
+  ASSERT_NE(iter, nullptr);
+  scan_options.max_prefetch_size = 0;
+  iter->Prepare(scan_options);
+  ub = key_ranges[1];
+  iter->Seek(key_ranges[0]);
+  ASSERT_OK(iter->status()) << iter->status().ToString();
+  ASSERT_TRUE(iter->Valid());
+  ub = key_ranges[3];
+  iter->Seek("key13");
+  // Seek should fail as its not in the order specified in scan_options
+  ASSERT_EQ(iter->status(), Status::InvalidArgument());
+  ASSERT_FALSE(iter->Valid());
   iter.reset();
 
   iter.reset(db->NewIterator(ro, cfh));

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1184,15 +1184,15 @@ def finalize_and_sanitize(src_params):
     # Continuous verification fails with secondaries inside NonBatchedOpsStressTest
     if dest_params.get("test_secondary") == 1:
         dest_params["continuous_verification_interval"] = 0
-    if (
-        dest_params.get("prefix_size", 0) > 0
-        or dest_params.get("read_fault_one_in", 0) > 0
-    ):
-        dest_params["use_multiscan"] = 0
     if dest_params.get("use_multiscan") == 1:
         dest_params["async_io"] = 0
         dest_params["delpercent"] += dest_params["delrangepercent"]
         dest_params["delrangepercent"] = 0
+        dest_params["prefix_size"] = -1
+        dest_params["iterpercent"] += dest_params["prefixpercent"]
+        dest_params["prefixpercent"] = 0
+        dest_params["read_fault_one_in"] = 0
+        dest_params["memtable_prefix_bloom_size_ratio"] = 0
     return dest_params
 
 

--- a/unreleased_history/bug_fixes/mscan_range_limit_between_files.md
+++ b/unreleased_history/bug_fixes/mscan_range_limit_between_files.md
@@ -1,0 +1,1 @@
+Fix incorrect MultiScan seek error status due to bugs in handling range limit falling between adjacent SST files key range.


### PR DESCRIPTION
This PR fixes a bug in how MultiScan handled a scan range limit falling in the key range between files. The bug was in LevelIterator, where Prepare() relied on FindFile to determine the lower bound file for the range limit. FindFile returns the smallest file index with `range.limit < file.largest_key`. However, that doesn't guarantee that the range overlaps the file, as the `range.limit` could be smaller than `file.smallest_key`.

This also fixes a bug in BlockBasedTableIterator of Valid() returning true even if status() returned error. This was exposed by the previous bug.

Test plan:
Add unit tests in db_iterator_test and table_test