### PR TITLE
Resolve missing/inconsistent tickers in Java

### DIFF
--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -5199,16 +5199,12 @@ class TickerTypeJni {
         return -0x31;
       case ROCKSDB_NAMESPACE::Tickers::WARM_FILE_READ_BYTES:
         return -0x32;
-      case ROCKSDB_NAMESPACE::Tickers::COOL_FILE_READ_BYTES:
-        return -0x5B;
       case ROCKSDB_NAMESPACE::Tickers::COLD_FILE_READ_BYTES:
         return -0x33;
       case ROCKSDB_NAMESPACE::Tickers::HOT_FILE_READ_COUNT:
         return -0x34;
       case ROCKSDB_NAMESPACE::Tickers::WARM_FILE_READ_COUNT:
         return -0x35;
-      case ROCKSDB_NAMESPACE::Tickers::COOL_FILE_READ_COUNT:
-        return -0x5C;
       case ROCKSDB_NAMESPACE::Tickers::COLD_FILE_READ_COUNT:
         return -0x36;
       case ROCKSDB_NAMESPACE::Tickers::LAST_LEVEL_READ_BYTES:
@@ -5283,6 +5279,14 @@ class TickerTypeJni {
         return -0x59;
       case ROCKSDB_NAMESPACE::Tickers::ICE_FILE_READ_COUNT:
         return -0x5A;
+      case ROCKSDB_NAMESPACE::Tickers::COOL_FILE_READ_BYTES:
+        return -0x5B;
+      case ROCKSDB_NAMESPACE::Tickers::COOL_FILE_READ_COUNT:
+        return -0x5C;
+      case ROCKSDB_NAMESPACE::Tickers::NUMBER_WBWI_INGEST:
+        return -0x5D;
+      case ROCKSDB_NAMESPACE::Tickers::SST_USER_DEFINED_INDEX_LOAD_FAIL_COUNT:
+        return -0x5E;
       case ROCKSDB_NAMESPACE::Tickers::TICKER_ENUM_MAX:
         // -0x54 is the max value at this time. Since these values are exposed
         // directly to Java clients, we'll keep the value the same till the next
@@ -5668,16 +5672,12 @@ class TickerTypeJni {
         return ROCKSDB_NAMESPACE::Tickers::HOT_FILE_READ_BYTES;
       case -0x32:
         return ROCKSDB_NAMESPACE::Tickers::WARM_FILE_READ_BYTES;
-      case -0x5B:
-        return ROCKSDB_NAMESPACE::Tickers::COOL_FILE_READ_BYTES;
       case -0x33:
         return ROCKSDB_NAMESPACE::Tickers::COLD_FILE_READ_BYTES;
       case -0x34:
         return ROCKSDB_NAMESPACE::Tickers::HOT_FILE_READ_COUNT;
       case -0x35:
         return ROCKSDB_NAMESPACE::Tickers::WARM_FILE_READ_COUNT;
-      case -0x5C:
-        return ROCKSDB_NAMESPACE::Tickers::COOL_FILE_READ_COUNT;
       case -0x36:
         return ROCKSDB_NAMESPACE::Tickers::COLD_FILE_READ_COUNT;
       case -0x37:
@@ -5755,6 +5755,15 @@ class TickerTypeJni {
         return ROCKSDB_NAMESPACE::Tickers::ICE_FILE_READ_BYTES;
       case -0x5A:
         return ROCKSDB_NAMESPACE::Tickers::ICE_FILE_READ_COUNT;
+      case -0x5B:
+        return ROCKSDB_NAMESPACE::Tickers::COOL_FILE_READ_BYTES;
+      case -0x5C:
+        return ROCKSDB_NAMESPACE::Tickers::COOL_FILE_READ_COUNT;
+      case -0x5D:
+        return ROCKSDB_NAMESPACE::Tickers::NUMBER_WBWI_INGEST;
+      case -0x5E:
+        return ROCKSDB_NAMESPACE::Tickers::
+            SST_USER_DEFINED_INDEX_LOAD_FAIL_COUNT;
       case -0x54:
         // -0x54 is the max value at this time. Since these values are exposed
         // directly to Java clients, we'll keep the value the same till the next

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -766,12 +766,12 @@ public enum TickerType {
     WARM_FILE_READ_BYTES((byte) -0x32),
     COOL_FILE_READ_BYTES((byte) -0x5B),
     COLD_FILE_READ_BYTES((byte) -0x33),
-    ICE_FILE_READ_BYTES((byte) -0x58),
+    ICE_FILE_READ_BYTES((byte) -0x59),
     HOT_FILE_READ_COUNT((byte) -0x34),
     WARM_FILE_READ_COUNT((byte) -0x35),
     COOL_FILE_READ_COUNT((byte) -0x5C),
     COLD_FILE_READ_COUNT((byte) -0x36),
-    ICE_FILE_READ_COUNT((byte) -0x59),
+    ICE_FILE_READ_COUNT((byte) -0x5A),
 
     /**
      * (non-)last level read statistics
@@ -873,6 +873,8 @@ public enum TickerType {
     FIFO_MAX_SIZE_COMPACTIONS((byte) -0x4F),
 
     FIFO_TTL_COMPACTIONS((byte) -0x50),
+
+    FIFO_CHANGE_TEMPERATURE_COMPACTIONS((byte) -0x58),
 
     PREFETCH_BYTES((byte) -0x51),
 

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -888,6 +888,19 @@ public enum TickerType {
 
     FILE_READ_CORRUPTION_RETRY_SUCCESS_COUNT((byte) -0x57),
 
+    /**
+     * Counter for the number of times a WBWI is ingested into the DB. This
+     * happens when IngestWriteBatchWithIndex() is used and when large
+     * transaction optimization is enabled through
+     * TransactionOptions::large_txn_commit_optimize_threshold.
+     */
+    NUMBER_WBWI_INGEST((byte) -0x5D),
+
+    /**
+     * Failure to load the UDI during SST table open
+     */
+    SST_USER_DEFINED_INDEX_LOAD_FAIL_COUNT((byte) -0x5E),
+
     TICKER_ENUM_MAX((byte) -0x54);
 
     private final byte value;


### PR DESCRIPTION
Summary: Pretty self-explanatory from the changes, including re-arranging the "COOL" entries for easier tracking of which values are used.

I'm not touching the TICKER_ENUM_MAX issue because IIRC we've gotten in trouble in the past for changing any Java ticker values.

Test Plan: CI, sufficient prompts to get AI to discover the known issues relayed by hx235, to help ensure we found any other outstanding issues.