### PR TITLE
Avoid reseeking upon skipping too many keys in crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1197,6 +1197,7 @@ def finalize_and_sanitize(src_params):
         dest_params["prefixpercent"] = 0
         dest_params["read_fault_one_in"] = 0
         dest_params["memtable_prefix_bloom_size_ratio"] = 0
+        dest_params["test_ingest_standalone_range_deletion_one_in"] = 0
 
     # inplace update and key checksum verification during seek would cause race condition
     # Therefore, when inplace_update_support is enabled, disable memtable_veirfy_per_key_checksum_on_seek

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1197,6 +1197,7 @@ def finalize_and_sanitize(src_params):
         dest_params["prefixpercent"] = 0
         dest_params["read_fault_one_in"] = 0
         dest_params["memtable_prefix_bloom_size_ratio"] = 0
+        dest_params["max_sequential_skip_in_iterations"] = sys.maxsize
         dest_params["test_ingest_standalone_range_deletion_one_in"] = 0
 
     # inplace update and key checksum verification during seek would cause race condition

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -1198,7 +1198,6 @@ def finalize_and_sanitize(src_params):
         dest_params["read_fault_one_in"] = 0
         dest_params["memtable_prefix_bloom_size_ratio"] = 0
         dest_params["max_sequential_skip_in_iterations"] = sys.maxsize
-        dest_params["test_ingest_standalone_range_deletion_one_in"] = 0
 
     # inplace update and key checksum verification during seek would cause race condition
     # Therefore, when inplace_update_support is enabled, disable memtable_veirfy_per_key_checksum_on_seek


### PR DESCRIPTION
Implicit reseek in the middle of an iteration is not supported with MultiScan. Avoid this for now in crash tests by setting max_sequential_skip_in_iterations to an absurdly high value.