### PR TITLE
[Remote Compaction] Stress Test Improvement

### DIFF
--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -280,7 +280,7 @@ void RemoteCompactionWorkerThread(void* v) {
       // Add the output regardless of status, so that primary DB doesn't rely on
       // the timeout to finish waiting. The actual failure from the
       // deserialization can fail the compaction properly
-      shared->AddRemoteCompactionResult(job_id, serialized_output);
+      shared->AddRemoteCompactionResult(job_id, s, serialized_output);
     }
     db_stress_env->SleepForMicroseconds(
         thread->rand.Next() % FLAGS_remote_compaction_worker_interval * 1000 +

--- a/db_stress_tool/db_stress_compaction_service.h
+++ b/db_stress_tool/db_stress_compaction_service.h
@@ -47,7 +47,7 @@ class DbStressCompactionService : public CompactionService {
       if (aborted_.load()) {
         return CompactionServiceJobStatus::kAborted;
       }
-      auto maybeResultStatus =
+      const auto& maybeResultStatus =
           shared_->GetRemoteCompactionResult(scheduled_job_id, result);
       if (maybeResultStatus.has_value()) {
         auto s = maybeResultStatus.value();

--- a/db_stress_tool/db_stress_compaction_service.h
+++ b/db_stress_tool/db_stress_compaction_service.h
@@ -55,10 +55,6 @@ class DbStressCompactionService : public CompactionService {
       } else if (s.IsNotFound()) {
         // Result not found - Remote Compaction is still running
         Env::Default()->SleepForMicroseconds(kWaitIntervalInMicros);
-      } else if (s.IsShutdownInProgress() || s.IsManualCompactionPaused()) {
-        // Race: Remote worker aborted before primary sets aborted_ = true
-        // Let primary handle this after fall back to local
-        return CompactionServiceJobStatus::kUseLocal;
       } else {
         // Remote Compaction failed
         if (failure_should_fall_back_to_local_) {

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -301,7 +301,8 @@ class SharedState {
     return false;
   }
 
-  void AddRemoteCompactionResult(const std::string& job_id, Status status,
+  void AddRemoteCompactionResult(const std::string& job_id,
+                                 const Status& status,
                                  const std::string& result) {
     MutexLock l(&remote_compaction_result_map_mu_);
     remote_compaction_result_map_.emplace(

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -309,8 +309,8 @@ class SharedState {
         job_id, std::pair<Status, std::string>{status, result});
   }
 
-  Status GetRemoteCompactionResult(const std::string& job_id,
-                                   std::string* result) {
+  std::optional<Status> GetRemoteCompactionResult(const std::string& job_id,
+                                                  std::string* result) {
     MutexLock l(&remote_compaction_result_map_mu_);
     if (remote_compaction_result_map_.find(job_id) !=
         remote_compaction_result_map_.end()) {
@@ -318,7 +318,7 @@ class SharedState {
       *result = pair.second;
       return pair.first;
     }
-    return Status::NotFound();
+    return std::nullopt;
   }
 
   void RemoveRemoteCompactionResult(const std::string& job_id) {


### PR DESCRIPTION
# Summary

- Include Status in RemoteCompactionResultMap in SharedState so that we can directly check the status of the remote compaction in `DbStressCompactionService::Wait()`
- If result is empty, populate the result with the status that was returned from `GetRemoteCompactionResult()` so that the status can be bubbled up to the primary (main db thread)
- Get rid of Timeout in `Wait()`

# Test Plan

With fall-back
```
python3 -u tools/db_crashtest.py blackbox --remote_compaction_worker_threads=8 --remote_compaction_failure_fall_back_to_local=1 
```

Without fall-back
```
python3 -u tools/db_crashtest.py blackbox --remote_compaction_worker_threads=8 --remote_compaction_failure_fall_back_to_local=0
```