### PR TITLE
Use wget for folly dependency download

### DIFF
--- a/.github/actions/setup-folly/action.yml
+++ b/.github/actions/setup-folly/action.yml
@@ -3,5 +3,7 @@ runs:
   using: composite
   steps:
   - name: Checkout folly sources
-    run: make checkout_folly
+    run: |
+      make checkout_folly
+      echo "export GETDEPS_USE_WGET=1" >> $GITHUB_ENV
     shell: bash

--- a/.github/actions/setup-folly/action.yml
+++ b/.github/actions/setup-folly/action.yml
@@ -5,5 +5,5 @@ runs:
   - name: Checkout folly sources
     run: |
       make checkout_folly
-      echo "export GETDEPS_USE_WGET=1" >> $GITHUB_ENV
+      echo "GETDEPS_USE_WGET=1" >> "$GITHUB_ENV"
     shell: bash

--- a/Makefile
+++ b/Makefile
@@ -2506,7 +2506,7 @@ checkout_folly:
 	fi
 	@# Pin to a particular version for public CI, so that PR authors don't
 	@# need to worry about folly breaking our integration. Update periodically
-	cd third-party/folly && git reset --hard 4df7ae967488c4210162552254597c075d9682c4
+	cd third-party/folly && git reset --hard e95383b7c8b5b1e46cf47acf2f317d54f93c8268
 	@# Apparently missing include
 	perl -pi -e 's/(#include <atomic>)/$$1\n#include <cstring>/' third-party/folly/folly/lang/Exception.h
 	@# Warning-as-error on memcpy

--- a/Makefile
+++ b/Makefile
@@ -2506,7 +2506,7 @@ checkout_folly:
 	fi
 	@# Pin to a particular version for public CI, so that PR authors don't
 	@# need to worry about folly breaking our integration. Update periodically
-	cd third-party/folly && git reset --hard e95383b7c8b5b1e46cf47acf2f317d54f93c8268
+	cd third-party/folly && git reset --hard 4df7ae967488c4210162552254597c075d9682c4
 	@# Apparently missing include
 	perl -pi -e 's/(#include <atomic>)/$$1\n#include <cstring>/' third-party/folly/folly/lang/Exception.h
 	@# Warning-as-error on memcpy


### PR DESCRIPTION
Fix the binutils truncated download issue by switching to wget in the folly build scripts for downloading dependencies.

Test plan:
make build_folly