### PR TITLE
Move table usability and paranoid file check inside each subcompaction

### DIFF
--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -301,7 +301,8 @@ class CompactionJob {
   bool HasNewBlobFiles() const;
   Status CollectSubcompactionErrors();
   Status SyncOutputDirectories();
-  Status VerifyOutputFiles();
+  Status VerifyOutputFile(SubcompactionState* sub_compact,
+                          const CompactionOutputs::Output& output);
   void SetOutputTableProperties();
   // Aggregates subcompaction output stats to internal stat, and aggregates
   // subcompaction's compaction job stats to the whole entire surrounding

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -52,7 +52,7 @@ Status CompactionOutputs::Finish(
     meta->user_defined_timestamps_persisted = static_cast<bool>(
         builder_->GetTableProperties().user_defined_timestamps_persisted);
   }
-  current_output().finished = true;
+  GetCurrentOutputRef().finished = true;
   stats_.bytes_written += current_bytes;
   stats_.bytes_written_pre_comp += builder_->PreCompressionSize();
   stats_.num_output_files = static_cast<int>(outputs_.size());
@@ -410,7 +410,7 @@ Status CompactionOutputs::AddToOutput(
 
   assert(builder_ != nullptr);
   const Slice& value = c_iter.value();
-  s = current_output().validator.Add(key, value);
+  s = GetCurrentOutputRef().validator.Add(key, value);
   if (!s.ok()) {
     return s;
   }
@@ -433,8 +433,8 @@ Status CompactionOutputs::AddToOutput(
     smallest_preferred_seqno_ =
         std::min(smallest_preferred_seqno_, preferred_seqno);
   }
-  s = current_output().meta.UpdateBoundaries(key, value, ikey.sequence,
-                                             ikey.type);
+  s = GetCurrentOutputRef().meta.UpdateBoundaries(key, value, ikey.sequence,
+                                                  ikey.type);
 
   return s;
 }
@@ -477,7 +477,7 @@ Status CompactionOutputs::AddRangeDels(
   // and meta.largest will be set to comp_start_user_key@kMaxSequenceNumber
   // which violates the assumption that meta.smallest should be <= meta.largest.
   assert(!range_del_agg.IsEmpty());
-  FileMetaData& meta = current_output().meta;
+  FileMetaData& meta = GetCurrentOutputRef().meta;
   const Comparator* ucmp = icmp.user_comparator();
   InternalKey lower_bound_buf, upper_bound_buf;
   Slice lower_bound_guard, upper_bound_guard;


### PR DESCRIPTION
**Context/Summary:**

Currently we check the table is usable by reopening it and do "paranoid file check" on each output file after all subcompactions have finished. We could have done it after each output file is produced within a subcompaction leading to same if not better performance. This eliminates the persistence of output file info needed for this check as part of the compaction progress for resumption because the output file will be verified before saved to the progress. This will address the limitation in https://github.com/facebook/rocksdb/pull/13984/files#diff-17fbdec07244b1f07d1a4e5aed0a6feecf4474d20b3129818c10fc0ff9f3d547R1303-R1314. 


**Test:**
Existing UTs such as `TEST_F(CorruptionTest, ParanoidFileChecksOnCompact)` 


**TODO:**
Remove the constraint in https://github.com/facebook/rocksdb/pull/13984/files#diff-17fbdec07244b1f07d1a4e5aed0a6feecf4474d20b3129818c10fc0ff9f3d547R1303-R1314