### PR TITLE
Add parallel_threads override test

### DIFF
--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -792,10 +792,14 @@ TEST_F(OptionsTest, CompressionOptionsFromString) {
   ASSERT_OK(GetColumnFamilyOptionsFromString(
       config_options, base_cf_opt,
       "compression_opts.enabled=false; "
-      "bottommost_compression_opts.enabled=true; ",
+      "bottommost_compression_opts.enabled=true; "
+      "compression_opts.parallel_threads=8; "
+      "bottommost_compression_opts.parallel_threads=3; ",
       &new_cf_opt));
   ASSERT_EQ(new_cf_opt.compression_opts.enabled, false);
   ASSERT_EQ(new_cf_opt.bottommost_compression_opts.enabled, true);
+  ASSERT_EQ(new_cf_opt.compression_opts.parallel_threads, 8);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.parallel_threads, 3);
 
   // Now test some illegal values
   ConfigOptions ignore;


### PR DESCRIPTION
# Summary

Quick sanity check to override `CompressionOptions::parallel_threads` in CF Options.

# Test Plan

```
./options_test --gtest_filter="*CompressionOptionsFromString*"
```