### PR TITLE
Add GetOptionConfigName() for test debugging

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -160,6 +160,93 @@ bool DBTestBase::ShouldSkipOptions(int option_config, int skip_mask) {
   return false;
 }
 
+const char* DBTestBase::GetOptionConfigName(int option_config) {
+  switch (option_config) {
+    case kDefault:
+      return "kDefault";
+    case kBlockBasedTableWithPrefixHashIndex:
+      return "kBlockBasedTableWithPrefixHashIndex";
+    case kBlockBasedTableWithWholeKeyHashIndex:
+      return "kBlockBasedTableWithWholeKeyHashIndex";
+    case kPlainTableFirstBytePrefix:
+      return "kPlainTableFirstBytePrefix";
+    case kPlainTableCappedPrefix:
+      return "kPlainTableCappedPrefix";
+    case kPlainTableCappedPrefixNonMmap:
+      return "kPlainTableCappedPrefixNonMmap";
+    case kPlainTableAllBytesPrefix:
+      return "kPlainTableAllBytesPrefix";
+    case kVectorRep:
+      return "kVectorRep";
+    case kHashLinkList:
+      return "kHashLinkList";
+    case kMergePut:
+      return "kMergePut";
+    case kFilter:
+      return "kFilter";
+    case kFullFilterWithNewTableReaderForCompactions:
+      return "kFullFilterWithNewTableReaderForCompactions";
+    case kUncompressed:
+      return "kUncompressed";
+    case kNumLevel_3:
+      return "kNumLevel_3";
+    case kDBLogDir:
+      return "kDBLogDir";
+    case kWalDirAndMmapReads:
+      return "kWalDirAndMmapReads";
+    case kManifestFileSize:
+      return "kManifestFileSize";
+    case kPerfOptions:
+      return "kPerfOptions";
+    case kHashSkipList:
+      return "kHashSkipList";
+    case kUniversalCompaction:
+      return "kUniversalCompaction";
+    case kUniversalCompactionMultiLevel:
+      return "kUniversalCompactionMultiLevel";
+    case kInfiniteMaxOpenFiles:
+      return "kInfiniteMaxOpenFiles";
+    case kCRC32cChecksum:
+      return "kCRC32cChecksum";
+    case kFIFOCompaction:
+      return "kFIFOCompaction";
+    case kOptimizeFiltersForHits:
+      return "kOptimizeFiltersForHits";
+    case kRowCache:
+      return "kRowCache";
+    case kRecycleLogFiles:
+      return "kRecycleLogFiles";
+    case kConcurrentSkipList:
+      return "kConcurrentSkipList";
+    case kPipelinedWrite:
+      return "kPipelinedWrite";
+    case kConcurrentWALWrites:
+      return "kConcurrentWALWrites";
+    case kDirectIO:
+      return "kDirectIO";
+    case kLevelSubcompactions:
+      return "kLevelSubcompactions";
+    case kBlockBasedTableWithIndexRestartInterval:
+      return "kBlockBasedTableWithIndexRestartInterval";
+    case kBlockBasedTableWithPartitionedIndex:
+      return "kBlockBasedTableWithPartitionedIndex";
+    case kBlockBasedTableWithPartitionedIndexFormat4:
+      return "kBlockBasedTableWithPartitionedIndexFormat4";
+    case kBlockBasedTableWithLatestFormat:
+      return "kBlockBasedTableWithLatestFormat";
+    case kPartitionedFilterWithNewTableReaderForCompactions:
+      return "kPartitionedFilterWithNewTableReaderForCompactions";
+    case kUniversalSubcompactions:
+      return "kUniversalSubcompactions";
+    case kUnorderedWrite:
+      return "kUnorderedWrite";
+    case kBlockBasedTableWithBinarySearchWithFirstKeyIndex:
+      return "kBlockBasedTableWithBinarySearchWithFirstKeyIndex";
+    default:
+      return "Unknown";
+  }
+}
+
 // Switch to a fresh database with the next option configuration to
 // test.  Return false if there are no more configurations to test.
 bool DBTestBase::ChangeOptions(int skip_mask) {

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -1122,6 +1122,9 @@ class DBTestBase : public testing::Test {
 
   static bool ShouldSkipOptions(int option_config, int skip_mask = kNoSkip);
 
+  // Get the name of the option configuration
+  static const char* GetOptionConfigName(int option_config);
+
   // Switch to a fresh database with the next option configuration to
   // test.  Return false if there are no more configurations to test.
   bool ChangeOptions(int skip_mask = kNoSkip);

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1143,6 +1143,8 @@ TEST_F(ExternalSSTFileTest, MultiThreaded) {
   }
 
   do {
+    fprintf(stderr, "=== Testing with DBTestBase option config=%d (%s) ===\n",
+            option_config_, DBTestBase::GetOptionConfigName(option_config_));
     Options options = CurrentOptions();
     options.disable_auto_compactions = true;
     std::atomic<int> thread_num(0);


### PR DESCRIPTION
**Summary:** Add GetOptionConfigName() helper to log DB configs in tests

**Why?** Many tests in RocksDB test different DB option configs in a single test run using a for loop. When such tests fail, it's difficult to know which config failed as there's no obvious way to see this in the stack trace.

**How?** Added GetOptionConfigName() to convert an option config int to string (readable name). This method can be used to log the config names being tested, making it easy to identify at which point the test fails.

Tests:
Option config name printed out in external_sst_file_test 
```
$ ./external_sst_file_test --gtest_filter="*MultiThreaded*"
Note: Google Test filter = *MultiThreaded*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from ExternalSSTFileTest
[ RUN      ] ExternalSSTFileTest.MultiThreaded
=== Testing with DBTestBase option config=0 (kDefault) ===
Wrote 10 files (10000 keys)
Loaded 10 files (10000 keys)
Verified 10000 values
=== Testing with DBTestBase option config=1 (kBlockBasedTableWithPrefixHashIndex) ===
Wrote 10 files (10000 keys)
Loaded 10 files (10000 keys)
Verified 10000 values
=== Testing with DBTestBase option config=2 (kBlockBasedTableWithWholeKeyHashIndex) ===
Wrote 10 files (10000 keys)
Loaded 10 files (10000 keys)
Verified 10000 values

....
```

