### PR TITLE
WBWI supports writing timestamps as you go

### DIFF
--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -49,6 +49,7 @@ struct WriteEntry {
   WriteType type = kUnknownRecord;
   Slice key;
   Slice value;
+  Slice timestamp;
 };
 
 // Iterator of one column family out of a WriteBatchWithIndex.
@@ -116,10 +117,30 @@ class WriteBatchWithIndex : public WriteBatchBase {
   //                show two entries with the same key.
   //                Note that for Merge, it's added as a new update instead
   //                of overwriting the existing one.
+  // require_timestamps: If true, then WriteBatchWithIndex will require
+  //                     timestamps be specified for mutations to column
+  //                     families that have timestamps. In other words, when
+  //                     true, it is invalid to call Put() without a timestamp
+  //                     on a column family that has timestamps enabled.
+  //                     Likewise, when false, it is an error to call Put() with
+  //                     a timestamp on a column family that has timestamps
+  //                     enabled.
+  //
+  //                     Note that regardless of whether require_timestamps is
+  //                     true or false, read semantics are RYOW. In other words,
+  //                     its as-if your read timesstamp is the max written
+  //                     timestamp in the batch. A timestamp specified in
+  //                     read_options affects visibility of records in the DB,
+  //                     but not in the batch.
+  //
+  //                     IMPORTANT: UpdateTimestamps() need not be called with
+  //                     require_timestamps=true and will overwrite any
+  //                     timestamps supplied at mutation time.
   explicit WriteBatchWithIndex(
       const Comparator* backup_index_comparator = BytewiseComparator(),
       size_t reserved_bytes = 0, bool overwrite_key = false,
-      size_t max_bytes = 0, size_t protection_bytes_per_key = 0);
+      size_t max_bytes = 0, size_t protection_bytes_per_key = 0,
+      bool require_timestamps = false);
 
   ~WriteBatchWithIndex() override;
   WriteBatchWithIndex(WriteBatchWithIndex&&);

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -25,7 +25,8 @@ namespace ROCKSDB_NAMESPACE {
 struct WriteBatchWithIndex::Rep {
   explicit Rep(const Comparator* index_comparator, size_t reserved_bytes = 0,
                size_t max_bytes = 0, bool _overwrite_key = false,
-               size_t protection_bytes_per_key = 0)
+               size_t protection_bytes_per_key = 0,
+               bool _require_timestamps = false)
       : write_batch(reserved_bytes, max_bytes, protection_bytes_per_key,
                     index_comparator ? index_comparator->timestamp_size() : 0),
         comparator(index_comparator, &write_batch),
@@ -33,6 +34,7 @@ struct WriteBatchWithIndex::Rep {
         last_sub_batch_offset(0),
         sub_batch_cnt(1),
         overwrite_key(_overwrite_key),
+        require_timestamps(_require_timestamps),
         op_count(0) {}
   ReadableWriteBatch write_batch;
   WriteBatchEntryComparator comparator;
@@ -46,6 +48,7 @@ struct WriteBatchWithIndex::Rep {
   size_t sub_batch_cnt;
 
   const bool overwrite_key;
+  const bool require_timestamps;
   // Tracks ids of CFs that have updates in this WBWI, number of updates and
   // number of overwritten single deletions per cf. Useful for WBWIMemTable
   // when this WBWI is ingested into a DB.
@@ -57,9 +60,10 @@ struct WriteBatchWithIndex::Rep {
   // Return true if the key is found and updated.
   // most_recent_entry_update_count will be set to the update count of the
   // most recent index entry for `key` if exists.
-  bool UpdateExistingEntryWithCfId(uint32_t column_family_id, const Slice& key,
-                                   WriteType type, size_t last_entry_offset,
-                                   uint32_t* most_recent_entry_update_count);
+  std::pair<Status, bool> UpdateExistingEntryWithCfId(
+      uint32_t column_family_id, const Slice& key, const Slice& ts,
+      WriteType type, size_t last_entry_offset,
+      uint32_t* most_recent_entry_update_count, const Comparator* cf_cmp);
 
   // Add or update the index for the given `key` of `type`
   // at `last_entry_offset` in the write batch.
@@ -69,20 +73,51 @@ struct WriteBatchWithIndex::Rep {
   //
   // If `cf_cmp` is provided and there is no compartor stored
   // for this cf, it will be stored as the comparator to use for this cf.
-  void AddOrUpdateIndexWithCfId(uint32_t cf_id, const Slice& key,
-                                WriteType type, size_t last_entry_offset,
-                                const Comparator* cf_cmp = nullptr);
+  Status AddOrUpdateIndexWithCfId(uint32_t cf_id, const Slice& key,
+                                  const Slice& ts, WriteType type,
+                                  size_t last_entry_offset,
+                                  const Comparator* cf_cmp);
 
-  void AddOrUpdateIndex(ColumnFamilyHandle* cfh, const Slice& key,
-                        WriteType type, size_t last_entry_offset) {
-    AddOrUpdateIndexWithCfId(GetColumnFamilyID(cfh), key, type,
-                             last_entry_offset,
-                             GetColumnFamilyUserComparator(cfh));
+  Status AddOrUpdateIndex(ColumnFamilyHandle* cfh, const Slice& key,
+                          const Slice& ts, WriteType type,
+                          size_t last_entry_offset) {
+    return AddOrUpdateIndexWithCfId(GetColumnFamilyID(cfh), key, ts, type,
+                                    last_entry_offset,
+                                    GetColumnFamilyUserComparator(cfh));
   }
 
-  void AddOrUpdateIndex(const Slice& key, WriteType type,
-                        size_t last_entry_offset) {
-    AddOrUpdateIndexWithCfId(0, key, type, last_entry_offset);
+  Status CheckTsArg(ColumnFamilyHandle* cfh, const Slice* ts) {
+    if (!require_timestamps) {
+      return ts ? Status::InvalidArgument("ts must not be specified")
+                : Status::OK();
+    }
+    Status s;
+    size_t ts_sz;
+    std::tie(s, std::ignore, ts_sz) =
+        WriteBatchInternal::GetColumnFamilyIdAndTimestampSize(&write_batch,
+                                                              cfh);
+    if (!s.ok()) {
+      return s;
+    }
+    if (ts) {
+      if (ts_sz == ts->size()) {
+        return Status::OK();
+      } else if (ts_sz == 0) {
+        return Status::InvalidArgument("ts must not be specified");
+      } else {
+        return Status::InvalidArgument(
+            "ts does not match the timestamp size of the column family");
+      }
+    } else {
+      return ts_sz > 0 ? Status::InvalidArgument("ts must be specified")
+                       : Status::OK();
+    }
+  }
+
+  Status AddOrUpdateIndex(const Slice& key, const Slice& ts, WriteType type,
+                          size_t last_entry_offset) {
+    return AddOrUpdateIndexWithCfId(0, key, ts, type, last_entry_offset,
+                                    comparator.GetComparator(0u));
   }
 
   // Add a new index entry pointing to the the entry at `last_entry_offset`
@@ -101,22 +136,39 @@ struct WriteBatchWithIndex::Rep {
   Status ReBuildIndex();
 };
 
-bool WriteBatchWithIndex::Rep::UpdateExistingEntryWithCfId(
-    uint32_t column_family_id, const Slice& key, WriteType type,
-    size_t last_entry_offset, uint32_t* most_recent_entry_update_count) {
+std::pair<Status, bool> WriteBatchWithIndex::Rep::UpdateExistingEntryWithCfId(
+    uint32_t column_family_id, const Slice& key, const Slice& ts,
+    WriteType type, size_t last_entry_offset,
+    uint32_t* most_recent_entry_update_count, const Comparator* cf_cmp) {
   assert(most_recent_entry_update_count);
   if (!overwrite_key) {
-    return false;
+    return {Status::OK(), false};
   }
 
   WBWIIteratorImpl iter(column_family_id, &skip_list, &write_batch,
                         &comparator);
   iter.Seek(key);
   if (!iter.Valid()) {
-    return false;
+    return {Status::OK(), false};
   } else if (!iter.MatchesKey(column_family_id, key)) {
-    return false;
+    return {Status::OK(), false};
   }
+
+  if (require_timestamps) {
+    size_t ts_sz = cf_cmp ? cf_cmp->timestamp_size() : 0;
+    if (ts_sz > 0) {
+      Slice last_ts_for_key = iter.Entry().timestamp;
+      int compare_result = cf_cmp->CompareTimestamp(last_ts_for_key, ts);
+      if (compare_result != 0) {
+        if (compare_result < 0) {
+          return {Status::OK(), false};
+        }
+        return {Status::InvalidArgument("cannot write below max ts for key"),
+                false};
+      }
+    }
+  }
+
   // Seek() and MatchesKey() guarantees that we are at the first entry with
   // key == `key`, which is the most recently update to `key`.
   WriteBatchIndexEntry* most_recent_entry =
@@ -141,7 +193,7 @@ bool WriteBatchWithIndex::Rep::UpdateExistingEntryWithCfId(
   }
   if (type == kMergeRecord) {
     assert(iter.Entry().type != kSingleDeleteRecord);
-    return false;
+    return {Status::OK(), false};
   } else {
     // We still increment the update count when updating in-place. This is
     // useful for WBWIMemTable when it needs to emit overwritten SingleDeletes.
@@ -149,22 +201,29 @@ bool WriteBatchWithIndex::Rep::UpdateExistingEntryWithCfId(
     // update_count is 0. So any later update should have update_count > 0.
     most_recent_entry->update_count++;
     most_recent_entry->offset = last_entry_offset;
-    return true;
+    return {Status::OK(), true};
   }
 }
 
-void WriteBatchWithIndex::Rep::AddOrUpdateIndexWithCfId(
-    uint32_t cf_id, const Slice& key, WriteType type, size_t last_entry_offset,
-    const Comparator* cf_cmp) {
+Status WriteBatchWithIndex::Rep::AddOrUpdateIndexWithCfId(
+    uint32_t cf_id, const Slice& key, const Slice& ts, WriteType type,
+    size_t last_entry_offset, const Comparator* cf_cmp) {
   op_count++;
   uint32_t update_count = 0;
-  if (!UpdateExistingEntryWithCfId(cf_id, key, type, last_entry_offset,
-                                   &update_count)) {
+  Status s;
+  bool overwritten;
+  std::tie(s, overwritten) = UpdateExistingEntryWithCfId(
+      cf_id, key, ts, type, last_entry_offset, &update_count, cf_cmp);
+  if (!s.ok()) {
+    return s;
+  }
+  if (!overwritten) {
     if (cf_cmp) {
       comparator.SetComparatorForCF(cf_id, cf_cmp);
     }
     AddNewEntry(cf_id, type, last_entry_offset, update_count + 1);
   }
+  return s;
 }
 
 void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id,
@@ -248,9 +307,12 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
                                  &blob, &xid, &unix_write_time);
     auto* ucmp = comparator.GetComparator(column_family_id);
     size_t ts_sz = ucmp ? ucmp->timestamp_size() : 0;
+    Slice ts;
     if (ts_sz > 0) {
       assert(key.size() >= ts_sz);
+      ts = key;
       key.remove_suffix(ts_sz);
+      ts.remove_prefix(key.size());
     }
     if (!s.ok()) {
       break;
@@ -260,26 +322,27 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
       case kTypeColumnFamilyValue:
       case kTypeValue:
         found++;
-        AddOrUpdateIndexWithCfId(column_family_id, key, kPutRecord,
-                                 last_entry_offset);
+        s = AddOrUpdateIndexWithCfId(column_family_id, key, ts, kPutRecord,
+                                     last_entry_offset, ucmp);
         break;
       case kTypeColumnFamilyDeletion:
       case kTypeDeletion:
         found++;
-        AddOrUpdateIndexWithCfId(column_family_id, key, kDeleteRecord,
-                                 last_entry_offset);
+        s = AddOrUpdateIndexWithCfId(column_family_id, key, ts, kDeleteRecord,
+                                     last_entry_offset, ucmp);
         break;
       case kTypeColumnFamilySingleDeletion:
       case kTypeSingleDeletion:
         found++;
-        AddOrUpdateIndexWithCfId(column_family_id, key, kSingleDeleteRecord,
-                                 last_entry_offset);
+        s = AddOrUpdateIndexWithCfId(column_family_id, key, ts,
+                                     kSingleDeleteRecord, last_entry_offset,
+                                     ucmp);
         break;
       case kTypeColumnFamilyMerge:
       case kTypeMerge:
         found++;
-        AddOrUpdateIndexWithCfId(column_family_id, key, kMergeRecord,
-                                 last_entry_offset);
+        s = AddOrUpdateIndexWithCfId(column_family_id, key, ts, kMergeRecord,
+                                     last_entry_offset, ucmp);
         break;
       case kTypeLogData:
       case kTypeBeginPrepareXID:
@@ -294,8 +357,8 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
       case kTypeColumnFamilyWideColumnEntity:
       case kTypeWideColumnEntity:
         found++;
-        AddOrUpdateIndexWithCfId(column_family_id, key, kPutEntityRecord,
-                                 last_entry_offset);
+        s = AddOrUpdateIndexWithCfId(column_family_id, key, ts,
+                                     kPutEntityRecord, last_entry_offset, ucmp);
         break;
       case kTypeColumnFamilyValuePreferredSeqno:
       case kTypeValuePreferredSeqno:
@@ -319,9 +382,11 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
 
 WriteBatchWithIndex::WriteBatchWithIndex(
     const Comparator* default_index_comparator, size_t reserved_bytes,
-    bool overwrite_key, size_t max_bytes, size_t protection_bytes_per_key)
+    bool overwrite_key, size_t max_bytes, size_t protection_bytes_per_key,
+    bool require_timestamps)
     : rep(new Rep(default_index_comparator, reserved_bytes, max_bytes,
-                  overwrite_key, protection_bytes_per_key)) {}
+                  overwrite_key, protection_bytes_per_key,
+                  require_timestamps)) {}
 
 WriteBatchWithIndex::~WriteBatchWithIndex() = default;
 
@@ -368,7 +433,8 @@ Iterator* WriteBatchWithIndex::NewIteratorWithBase(
 
   return new BaseDeltaIterator(column_family, base_iterator, wbwiii,
                                GetColumnFamilyUserComparator(column_family),
-                               read_options);
+                               read_options,
+                               /*fill_timestamps=*/rep->require_timestamps);
 }
 
 Iterator* WriteBatchWithIndex::NewIteratorWithBase(
@@ -386,124 +452,185 @@ Iterator* WriteBatchWithIndex::NewIteratorWithBase(
 
   return new BaseDeltaIterator(nullptr, base_iterator, wbwiii,
                                rep->comparator.default_comparator(),
-                               /* read_options */ nullptr);
+                               /* read_options */ nullptr,
+                               /*fill_timestamps=*/rep->require_timestamps);
 }
 
 Status WriteBatchWithIndex::Put(ColumnFamilyHandle* column_family,
                                 const Slice& key, const Slice& value) {
+  Status s = rep->CheckTsArg(column_family, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  auto s = rep->write_batch.Put(column_family, key, value);
+  s = rep->write_batch.Put(column_family, key, value);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key, kPutRecord, last_entry_offset);
+    s = rep->AddOrUpdateIndex(column_family, key, /*ts=*/Slice(), kPutRecord,
+                              last_entry_offset);
   }
   return s;
 }
 
 Status WriteBatchWithIndex::Put(const Slice& key, const Slice& value) {
+  Status s = rep->CheckTsArg(nullptr, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  auto s = rep->write_batch.Put(key, value);
+  s = rep->write_batch.Put(key, value);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(key, kPutRecord, last_entry_offset);
+    s = rep->AddOrUpdateIndex(key, /*ts=*/Slice(), kPutRecord,
+                              last_entry_offset);
   }
   return s;
 }
 
 Status WriteBatchWithIndex::Put(ColumnFamilyHandle* column_family,
-                                const Slice& /*key*/, const Slice& /*ts*/,
-                                const Slice& /*value*/) {
-  if (!column_family) {
-    return Status::InvalidArgument("column family handle cannot be nullptr");
+                                const Slice& key, const Slice& ts,
+                                const Slice& value) {
+  Status s = rep->CheckTsArg(column_family, &ts);
+  if (!s.ok()) {
+    return s;
   }
-  // TODO: support WBWI::Put() with timestamp.
-  return Status::NotSupported();
+  size_t last_entry_offset = rep->write_batch.GetDataSize();
+  s = rep->write_batch.Put(column_family, key, ts, value);
+  if (s.ok()) {
+    s = rep->AddOrUpdateIndex(column_family, key, ts, kPutRecord,
+                              last_entry_offset);
+  }
+  return s;
 }
 
 Status WriteBatchWithIndex::PutEntity(ColumnFamilyHandle* column_family,
                                       const Slice& key,
                                       const WideColumns& columns) {
-  assert(rep);
+  Status s = rep->CheckTsArg(column_family, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  const Status s = rep->write_batch.PutEntity(column_family, key, columns);
+  s = rep->write_batch.PutEntity(column_family, key, columns);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key, kPutEntityRecord,
-                          last_entry_offset);
+    s = rep->AddOrUpdateIndex(column_family, key, /*ts=*/Slice(),
+                              kPutEntityRecord, last_entry_offset);
   }
   return s;
 }
 
 Status WriteBatchWithIndex::Delete(ColumnFamilyHandle* column_family,
                                    const Slice& key) {
+  Status s = rep->CheckTsArg(column_family, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  auto s = rep->write_batch.Delete(column_family, key);
+  s = rep->write_batch.Delete(column_family, key);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key, kDeleteRecord, last_entry_offset);
+    s = rep->AddOrUpdateIndex(column_family, key, /*ts=*/Slice(), kDeleteRecord,
+                              last_entry_offset);
   }
   return s;
 }
 
 Status WriteBatchWithIndex::Delete(const Slice& key) {
+  Status s = rep->CheckTsArg(nullptr, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  auto s = rep->write_batch.Delete(key);
+  s = rep->write_batch.Delete(key);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(key, kDeleteRecord, last_entry_offset);
+    s = rep->AddOrUpdateIndex(key, /*ts=*/Slice(), kDeleteRecord,
+                              last_entry_offset);
   }
   return s;
 }
 
 Status WriteBatchWithIndex::Delete(ColumnFamilyHandle* column_family,
-                                   const Slice& /*key*/, const Slice& /*ts*/) {
-  if (!column_family) {
-    return Status::InvalidArgument("column family handle cannot be nullptr");
+                                   const Slice& key, const Slice& ts) {
+  Status s = rep->CheckTsArg(column_family, &ts);
+  if (!s.ok()) {
+    return s;
   }
-  // TODO: support WBWI::Delete() with timestamp.
-  return Status::NotSupported();
+  size_t last_entry_offset = rep->write_batch.GetDataSize();
+  s = rep->write_batch.Delete(column_family, key, ts);
+  if (s.ok()) {
+    s = rep->AddOrUpdateIndex(column_family, key, ts, kDeleteRecord,
+                              last_entry_offset);
+  }
+  return s;
 }
 
 Status WriteBatchWithIndex::SingleDelete(ColumnFamilyHandle* column_family,
                                          const Slice& key) {
+  Status s = rep->CheckTsArg(column_family, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  auto s = rep->write_batch.SingleDelete(column_family, key);
+  s = rep->write_batch.SingleDelete(column_family, key);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key, kSingleDeleteRecord,
-                          last_entry_offset);
+    s = rep->AddOrUpdateIndex(column_family, key, /*ts=*/Slice(),
+                              kSingleDeleteRecord, last_entry_offset);
   }
   return s;
 }
 
 Status WriteBatchWithIndex::SingleDelete(const Slice& key) {
+  Status s = rep->CheckTsArg(nullptr, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  auto s = rep->write_batch.SingleDelete(key);
+  s = rep->write_batch.SingleDelete(key);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(key, kSingleDeleteRecord, last_entry_offset);
+    s = rep->AddOrUpdateIndex(key, /*ts=*/Slice(), kSingleDeleteRecord,
+                              last_entry_offset);
   }
   return s;
 }
 
 Status WriteBatchWithIndex::SingleDelete(ColumnFamilyHandle* column_family,
-                                         const Slice& /*key*/,
-                                         const Slice& /*ts*/) {
-  if (!column_family) {
-    return Status::InvalidArgument("column family handle cannot be nullptr");
+                                         const Slice& key, const Slice& ts) {
+  Status s = rep->CheckTsArg(column_family, /*ts=*/&ts);
+  if (!s.ok()) {
+    return s;
   }
-  // TODO: support WBWI::SingleDelete() with timestamp.
-  return Status::NotSupported();
+
+  size_t last_entry_offset = rep->write_batch.GetDataSize();
+  s = rep->write_batch.SingleDelete(column_family, key, ts);
+  if (s.ok()) {
+    s = rep->AddOrUpdateIndex(column_family, key, ts, kSingleDeleteRecord,
+                              last_entry_offset);
+  }
+  return s;
 }
 
 Status WriteBatchWithIndex::Merge(ColumnFamilyHandle* column_family,
                                   const Slice& key, const Slice& value) {
+  Status s = rep->CheckTsArg(column_family, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  auto s = rep->write_batch.Merge(column_family, key, value);
+  s = rep->write_batch.Merge(column_family, key, value);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key, kMergeRecord, last_entry_offset);
+    s = rep->AddOrUpdateIndex(column_family, key, /*ts=*/Slice(), kMergeRecord,
+                              last_entry_offset);
   }
   return s;
 }
 
 Status WriteBatchWithIndex::Merge(const Slice& key, const Slice& value) {
+  Status s = rep->CheckTsArg(nullptr, /*ts=*/nullptr);
+  if (!s.ok()) {
+    return s;
+  }
   size_t last_entry_offset = rep->write_batch.GetDataSize();
-  auto s = rep->write_batch.Merge(key, value);
+  s = rep->write_batch.Merge(key, value);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(key, kMergeRecord, last_entry_offset);
+    s = rep->AddOrUpdateIndex(key, /*ts=*/Slice(), kMergeRecord,
+                              last_entry_offset);
   }
   return s;
 }

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -37,7 +37,7 @@ class BaseDeltaIterator : public Iterator {
   BaseDeltaIterator(ColumnFamilyHandle* column_family, Iterator* base_iterator,
                     WBWIIteratorImpl* delta_iterator,
                     const Comparator* comparator,
-                    const ReadOptions* read_options);
+                    const ReadOptions* read_options, bool fill_timestamps);
 
   ~BaseDeltaIterator() override;
 
@@ -97,6 +97,9 @@ class BaseDeltaIterator : public Iterator {
   bool current_at_base_;
   bool equal_keys_;
   bool allow_unprepared_value_;
+  // if set, the iterator will return Entrys with timestamps filled in.
+  // Otherwise the iterator returns the empty Slice for timestamp().
+  bool fill_timestamps_;
   Status status_;
   ColumnFamilyHandle* column_family_;
   std::unique_ptr<Iterator> base_iterator_;
@@ -368,6 +371,8 @@ class WBWIIteratorImpl final : public WBWIIterator {
   const WriteBatchIndexEntry* GetRawEntry() const {
     return skip_list_iter_.key();
   }
+
+  const ReadableWriteBatch* GetWriteBatch() const { return write_batch_; }
 
   bool MatchesKey(uint32_t cf_id, const Slice& key);
 

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -331,6 +331,7 @@ void AssertIterEqual(WBWIIteratorImpl* wbwii,
   for (const auto& k : keys) {
     ASSERT_TRUE(wbwii->Valid());
     ASSERT_EQ(wbwii->Entry().key, k);
+    ASSERT_EQ(wbwii->Entry().timestamp, Slice());
     wbwii->NextKey();
   }
   ASSERT_FALSE(wbwii->Valid());
@@ -338,6 +339,7 @@ void AssertIterEqual(WBWIIteratorImpl* wbwii,
   for (auto kit = keys.rbegin(); kit != keys.rend(); ++kit) {
     ASSERT_TRUE(wbwii->Valid());
     ASSERT_EQ(wbwii->Entry().key, *kit);
+    ASSERT_EQ(wbwii->Entry().timestamp, Slice());
     wbwii->PrevKey();
   }
   ASSERT_FALSE(wbwii->Valid());
@@ -457,6 +459,182 @@ class WriteBatchWithIndexTest : public WBWIBaseTest,
  public:
   WriteBatchWithIndexTest() : WBWIBaseTest(GetParam()) {}
 };
+
+class WriteBatchWithIndexRequireTimestampsTest
+    : public WBWIBaseTest,
+      public testing::WithParamInterface<bool> {
+ public:
+  WriteBatchWithIndexRequireTimestampsTest() : WBWIBaseTest(GetParam()) {
+    batch_.reset(new WriteBatchWithIndex{
+        /*backup_index_comparator=*/BytewiseComparator(),
+        /*reserved_bytes=*/0, /*overwrite_key=*/GetParam(),
+        /*max_bytes=*/0, /*protection_bytes_per_key=*/0,
+        /*require_timestamps=*/true});
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(WBWIRequireTimestamps,
+                        WriteBatchWithIndexRequireTimestampsTest,
+                        testing::Bool());
+
+namespace {
+std::string Pack64(uint64_t v) {
+  std::string ret;
+  PutFixed64(&ret, v);
+  return ret;
+}
+}  // namespace
+
+TEST_P(WriteBatchWithIndexRequireTimestampsTest,
+       MultipleVersionsWithTimestamps) {
+  // MultipleVersionsWithTimestamps tests that timestamps are preserved with
+  // require_timestamps and the batch can be written out without
+  // UpdateTimestamps. Additionally it validates iteration order and timestamp
+  // visibility rules within the write batch.
+  std::string scope_name{"OverwriteKey="};
+  scope_name += (GetParam() ? "true" : "false");
+  SCOPED_TRACE(scope_name);
+
+  ASSERT_OK(OpenDB());
+  ColumnFamilyHandle* cf;
+  {
+    ColumnFamilyOptions opts;
+    opts.comparator = test::BytewiseComparatorWithU64TsWrapper();
+    Status s = db_->CreateColumnFamily(opts, "test_cf", &cf);
+    ASSERT_OK(s);
+    ASSERT_TRUE(cf);
+  }
+  struct Guard {
+    DB* db;
+    ColumnFamilyHandle* cf;
+    ~Guard() { db->DestroyColumnFamilyHandle(cf); }
+  } g{db_, cf};
+
+  using Record =
+      std::tuple<std::string /*Key*/, std::string /*Ts*/, std::string /*Val*/>;
+  const std::vector<Record> recs{
+      {"k1", Pack64(1), "v1"},   // 0
+      {"k1", Pack64(3), "v10"},  // 1
+      {"k1", Pack64(3), "v2"},   // 2
+      {"k1", Pack64(4), "v3"},   // 3
+      {"k2", Pack64(2), "v5"},   // 4
+  };
+  for (size_t i = 0; i < recs.size(); i++) {
+    Slice key, ts, value;
+    std::tie(key, ts, value) = recs[i];
+    ASSERT_OK(batch_->Put(cf, key, ts, value));
+    if (i == 1) {
+      batch_->SetSavePoint();
+    }
+  }
+  {
+    SCOPED_TRACE("rebuild index");
+    ASSERT_OK(batch_->RollbackToSavePoint());
+    for (size_t i = 2; i < recs.size(); i++) {
+      Slice key, ts, value;
+      std::tie(key, ts, value) = recs[i];
+      ASSERT_OK(batch_->Put(cf, key, ts, value));
+    }
+  }
+
+  {
+    SCOPED_TRACE("batch iteration order");
+    std::vector<Record> iterate_recs{
+        recs[3],
+        recs[2],
+    };
+    if (!GetParam()) {
+      // overwrite_key = false
+      iterate_recs.push_back(recs[1]);
+    }
+    iterate_recs.push_back(recs[0]);
+    iterate_recs.push_back(recs[4]);
+
+    std::unique_ptr<WBWIIterator> wbwi_iter(batch_->NewIterator(cf));
+    wbwi_iter->SeekToFirst();
+    for (size_t i = 0; i < iterate_recs.size(); i++) {
+      Slice key, ts, value;
+      std::tie(key, ts, value) = iterate_recs.at(i);
+      ASSERT_TRUE(wbwi_iter->Valid());
+      WriteEntry entry = wbwi_iter->Entry();
+      ASSERT_OK(wbwi_iter->status()) << i;
+      EXPECT_EQ(entry.key.ToStringView(), key.ToStringView()) << i;
+      EXPECT_EQ(entry.timestamp.ToString(/*hex=*/true), ts.ToString(true)) << i;
+      EXPECT_EQ(entry.value.ToStringView(), value.ToStringView()) << i;
+      EXPECT_EQ(entry.type, WriteType::kPutRecord) << i;
+      wbwi_iter->Next();
+    }
+    ASSERT_FALSE(wbwi_iter->Valid());
+  }
+  {
+    // timestamp is implicitly the last written timestamp in RYOW
+    // with require_timestamps set (same as without it set)
+    // read_timestamp only affects what rows are visible in the DB (not the
+    // batch)
+    SCOPED_TRACE("batch read-your-own-write");
+    ReadOptions opts;
+    const std::string read_timestamp = Pack64(0);
+    const Slice read_ts_slice = read_timestamp;
+    opts.timestamp = &read_ts_slice;
+    const std::vector<Record> iterate_recs{
+        recs[3],
+        recs[4],
+    };
+
+    Iterator* base_iter = db_->NewIterator(opts, cf);
+    std::unique_ptr<Iterator> iter(
+        batch_->NewIteratorWithBase(cf, base_iter, &opts));
+    iter->SeekToFirst();
+    for (size_t i = 0; i < iterate_recs.size(); i++) {
+      Slice key, ts, value;
+      std::tie(key, ts, value) = iterate_recs.at(i);
+      ASSERT_TRUE(iter->Valid()) << i;
+      ASSERT_OK(iter->status()) << i;
+      EXPECT_EQ(iter->key().ToStringView(), key.ToStringView()) << i;
+      EXPECT_EQ(iter->timestamp().ToString(/*hex=*/true), ts.ToString(true))
+          << i;
+      EXPECT_EQ(iter->value().ToStringView(), value.ToStringView()) << i;
+
+      PinnableSlice actual_value;
+      ASSERT_OK(batch_->GetFromBatchAndDB(db_, opts, cf, key, &actual_value))
+          << i;
+      EXPECT_EQ(actual_value.ToStringView(), value.ToStringView()) << i;
+      iter->Next();
+    }
+    ASSERT_FALSE(iter->Valid());
+  }
+
+  {
+    WriteOptions opts;
+    ASSERT_OK(db_->Write(opts, batch_->GetWriteBatch()));
+  }
+
+  {
+    SCOPED_TRACE("batch flushed to memtable reads back");
+    ReadOptions opts;
+    const std::string read_timestamp = Pack64(3);
+    const Slice read_ts_slice = read_timestamp;
+    opts.timestamp = &read_ts_slice;
+    const std::vector<Record> iterate_recs{
+        recs[2],
+        recs[4],
+    };
+    std::unique_ptr<Iterator> iter(db_->NewIterator(opts, cf));
+    iter->SeekToFirst();
+    for (size_t i = 0; i < iterate_recs.size(); i++) {
+      Slice key, ts, value;
+      std::tie(key, ts, value) = iterate_recs.at(i);
+      ASSERT_TRUE(iter->Valid()) << i;
+      ASSERT_OK(iter->status()) << i;
+      EXPECT_EQ(iter->key().ToStringView(), key.ToStringView()) << i;
+      EXPECT_EQ(iter->timestamp().ToString(/*hex=*/true), ts.ToString(true))
+          << i;
+      EXPECT_EQ(iter->value().ToStringView(), value.ToStringView()) << i;
+      iter->Next();
+    }
+    ASSERT_FALSE(iter->Valid());
+  }
+}
 
 void TestValueAsSecondaryIndexHelper(std::vector<Entry> entries,
                                      WriteBatchWithIndex* batch,
@@ -2955,6 +3133,7 @@ TEST_P(WriteBatchWithIndexTest, TestBadMergeOperator) {
 
 TEST_P(WriteBatchWithIndexTest, UDTRollback) {
   ASSERT_OK(OpenDB());
+  const std::string dummy_ts = Pack64(0);
   ColumnFamilyHandleImplDummy cf2(2,
                                   test::BytewiseComparatorWithU64TsWrapper());
   ASSERT_OK(batch_->Put(&cf2, "k1", "v1"));
@@ -2970,12 +3149,15 @@ TEST_P(WriteBatchWithIndexTest, UDTRollback) {
   ASSERT_TRUE(iter->Valid());
   ASSERT_OK(iter->status());
   EXPECT_EQ(iter->Entry().key.ToString(), "k1");
+  EXPECT_EQ(iter->Entry().timestamp.ToString(), dummy_ts);
   EXPECT_EQ(iter->Entry().value.ToString(), "v2");
   iter->Next();
   const bool overwrite = GetParam();
   ASSERT_EQ(iter->Valid(), !overwrite);
   if (!overwrite) {
     ASSERT_OK(iter->status());
+    EXPECT_EQ(iter->Entry().key.ToString(), "k1");
+    EXPECT_EQ(iter->Entry().timestamp.ToString(), dummy_ts);
     EXPECT_EQ(iter->Entry().value.ToString(), "v1");
   }
 }
@@ -2987,13 +3169,13 @@ TEST_P(WriteBatchWithIndexTest, ColumnFamilyWithTimestamp) {
                                   test::BytewiseComparatorWithU64TsWrapper());
 
   // Sanity checks
-  ASSERT_TRUE(batch_->Put(&cf2, "key", "ts", "value").IsNotSupported());
+  ASSERT_TRUE(batch_->Put(&cf2, "key", "ts", "value").IsInvalidArgument());
   ASSERT_TRUE(batch_->Put(/*column_family=*/nullptr, "key", "ts", "value")
                   .IsInvalidArgument());
-  ASSERT_TRUE(batch_->Delete(&cf2, "key", "ts").IsNotSupported());
+  ASSERT_TRUE(batch_->Delete(&cf2, "key", "ts").IsInvalidArgument());
   ASSERT_TRUE(batch_->Delete(/*column_family=*/nullptr, "key", "ts")
                   .IsInvalidArgument());
-  ASSERT_TRUE(batch_->SingleDelete(&cf2, "key", "ts").IsNotSupported());
+  ASSERT_TRUE(batch_->SingleDelete(&cf2, "key2", "ts").IsInvalidArgument());
   ASSERT_TRUE(batch_->SingleDelete(/*column_family=*/nullptr, "key", "ts")
                   .IsInvalidArgument());
   {


### PR DESCRIPTION
Summary:
Adds support to write timestamps as-you-go for UDT-enabled CFs within a WBWI (WriteBatchWithIndex). When a WBWI is instantiated with require_timestamps=true, mutations *must* supply a timestamp iff the CF is UDT-enabled. Callers *should not* call UpdateTimestamps when `required_timestamps=true` as this will overwrite the timestamps supplied with mutations.

When require_timestamps = false, the previous behavior is maintained. In other words timestamps must never be supplied with mutations and UpdateTimestamps must be called before writing the batch to DB.

Differential Revision: D85605627


