### PR TITLE
Fix WBWI index corruption with UDT + overwrite

### DIFF
--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -246,6 +246,12 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
 
     s = ReadRecordFromWriteBatch(&input, &tag, &column_family_id, &key, &value,
                                  &blob, &xid, &unix_write_time);
+    auto* ucmp = comparator.GetComparator(column_family_id);
+    size_t ts_sz = ucmp ? ucmp->timestamp_size() : 0;
+    if (ts_sz > 0) {
+      assert(key.size() >= ts_sz);
+      key.remove_suffix(ts_sz);
+    }
     if (!s.ok()) {
       break;
     }


### PR DESCRIPTION
Summary:
When WBWI, UDT CF, overwrite and rollback are used together, WBWI index is corrupted and will contain duplicate key entries. The problem, which is fixed by this diff, is that the record reader does not strip the timestamp packed with the key.

This results in corruption of the index during rebuild, since overwrite deduplication uses the slice read from the batch. The indexed key is still correct, as AddOrUpdate re-reads the key from the offset, resulting in the key being stripped.

Differential Revision: D85616849


