### PR TITLE
Change PosixWritableFile Truncate to reseek to new end of file

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1406,6 +1406,7 @@ IOStatus PosixWritableFile::Truncate(uint64_t size, const IOOptions& /*opts*/,
                 filename_, errno);
   } else {
     filesize_ = size;
+    lseek(fd_, filesize_, SEEK_SET);
   }
   return s;
 }

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1166,8 +1166,10 @@ class FSWritableFile {
 
   // Truncate is necessary to trim the file to the correct size
   // before closing. It is not always possible to keep track of the file
-  // size due to whole pages writes. The behavior is undefined if called
-  // with other writes to follow.
+  // size due to whole pages writes. If called with other writes to follow,
+  // the behavior is file system specific. Posix will reseek to the new EOF.
+  // Other file systems may behave differently. Its the caller's
+  // responsibility to check the file system contract.
   virtual IOStatus Truncate(uint64_t /*size*/, const IOOptions& /*options*/,
                             IODebugContext* /*dbg*/) {
     return IOStatus::OK();

--- a/unreleased_history/behavior_changes/posix_writable_file_truncate.md
+++ b/unreleased_history/behavior_changes/posix_writable_file_truncate.md
@@ -1,0 +1,1 @@
+PosixWritableFile now repositions the seek pointer to the new end of file after a call to Truncate.


### PR DESCRIPTION
Change PosixWritableFile's Truncate to the new end offset. This ensures that future appends are written with no holes or overwrites. RocksDB doesn't guarantee this in the FileSystem contract, and its left up to the specific implementation.