### PR TITLE
add optimized single and batched prefix existence APIs

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -63,6 +63,7 @@ cpp_library_wrapper(name="rocksdb_lib", srcs=[
         "db/db_impl/db_impl_files.cc",
         "db/db_impl/db_impl_follower.cc",
         "db/db_impl/db_impl_open.cc",
+        "db/db_impl/db_impl_prefix_exists.cc",
         "db/db_impl/db_impl_readonly.cc",
         "db/db_impl/db_impl_secondary.cc",
         "db/db_impl/db_impl_write.cc",
@@ -5406,6 +5407,12 @@ cpp_unittest_wrapper(name="point_lock_manager_test",
 
 cpp_unittest_wrapper(name="prefetch_test",
             srcs=["file/prefetch_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
+cpp_unittest_wrapper(name="prefix_exists_test",
+            srcs=["db/prefix_exists_test.cc"],
             deps=[":rocksdb_test_lib"],
             extra_compiler_flags=[])
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,6 +711,7 @@ set(SOURCES
         db/db_impl/db_impl_debug.cc
         db/db_impl/db_impl_experimental.cc
         db/db_impl/db_impl_readonly.cc
+        db/db_impl/db_impl_prefix_exists.cc
         db/db_impl/db_impl_secondary.cc
         db/db_info_dumper.cc
         db/db_iter.cc
@@ -1412,6 +1413,7 @@ if(WITH_TESTS)
         db/plain_table_db_test.cc
         db/seqno_time_test.cc
         db/prefix_test.cc
+        db/prefix_exists_test.cc
         db/range_del_aggregator_test.cc
         db/range_tombstone_fragmenter_test.cc
         db/repair_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1633,6 +1633,9 @@ perf_context_test: $(OBJ_DIR)/db/perf_context_test.o $(TEST_LIBRARY) $(LIBRARY)
 prefix_test: $(OBJ_DIR)/db/prefix_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+prefix_exists_test: $(OBJ_DIR)/db/prefix_exists_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 backup_engine_test: $(OBJ_DIR)/utilities/backup/backup_engine_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -376,6 +376,18 @@ class DBImpl : public DB {
                    std::string* value, std::string* timestamp,
                    bool* value_found = nullptr) override;
 
+  // Optimized prefix existence check
+  using DB::PrefixExists;
+  Status PrefixExists(const ReadOptions& options,
+                      ColumnFamilyHandle* column_family,
+                      const Slice& prefix) override;
+
+  using DB::PrefixExistsMulti;
+  void PrefixExistsMulti(const ReadOptions& options,
+                         ColumnFamilyHandle* column_family,
+                         bool prefixes_sorted, size_t num_prefixes,
+                         const Slice* prefixes, Status* statuses) override;
+
   using DB::NewIterator;
   Iterator* NewIterator(const ReadOptions& _read_options,
                         ColumnFamilyHandle* column_family) override;

--- a/db/db_impl/db_impl_prefix_exists.cc
+++ b/db/db_impl/db_impl_prefix_exists.cc
@@ -1,0 +1,581 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "db/column_family.h"
+#include "db/db_impl/db_impl.h"
+#include "db/dbformat.h"
+#include "db/memtable.h"
+#include "db/memtable_list.h"
+#include "db/version_set.h"
+#include "memory/arena.h"
+#include "table/table_reader.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// Advance iterator to the first entry of the next distinct user key.
+// This avoids considering older versions (smaller sequence numbers) of
+// the same user key after we have already inspected its most recent entry.
+inline void SkipToNextUserKey(InternalIterator* it) {
+  if (!it->Valid()) return;
+  Slice uk = ExtractUserKey(it->key());
+  std::string user_key_copy(uk.data(), uk.size());
+  do {
+    it->Next();
+    if (!it->Valid()) break;
+    Slice cur = ExtractUserKey(it->key());
+    if (cur.size() != user_key_copy.size() ||
+        memcmp(cur.data(), user_key_copy.data(), user_key_copy.size()) != 0) {
+      break;
+    }
+  } while (true);
+}
+
+// Check if any key exists with the given prefix.
+// - Enables prefix_same_as_start when a prefix extractor is configured.
+// - Primarily relies on table filters and index blocks to avoid data block
+//   reads when possible; data blocks may still be read if filters indicate a
+//   potential hit.
+// - Snapshot-aware: ignores entries newer than the snapshot sequence number.
+// - Skips tombstones and older versions by advancing to the next user key.
+// - Uses the extracted (effective) prefix only to bound iteration; existence
+//   is determined against the full user-requested prefix.
+// - Early-aborts on first visible non-deletion match in mem, immutable
+//   memtables, or SST layers.
+// - Reads sequence/type from the internal-key footer to avoid full
+//   ParseInternalKey overhead in hot loops.
+Status DBImpl::PrefixExists(const ReadOptions& options,
+                            ColumnFamilyHandle* column_family,
+                            const Slice& prefix) {
+  if (column_family == nullptr) {
+    column_family = DefaultColumnFamily();
+  }
+
+  // column_family is guaranteed to be ColumnFamilyHandleImpl by the DB
+  // interface
+  auto cfh = static_cast<ColumnFamilyHandleImpl*>(column_family);
+  auto cfd = cfh->cfd();
+
+  if (cfd == nullptr) {
+    return Status::InvalidArgument("Column family not found");
+  }
+
+  // SuperVersion and options needed for prefix_extractor and iterators
+  SuperVersion* sv = GetAndRefSuperVersion(cfd);
+  if (sv == nullptr) {
+    return Status::InvalidArgument("Column family not found");
+  }
+
+  const SliceTransform* prefix_extractor =
+      sv->mutable_cf_options.prefix_extractor.get();
+
+  // If no prefix extractor is configured, we'll still benefit from:
+  // 1. Early abort on first key match
+  // 2. No data block loading
+  // We'll use the input as a search key and check if found keys start with it.
+  Slice actual_prefix = prefix;
+  // requested_prefix is the exact prefix the caller asked for. When an
+  // extractor exists, actual_prefix is the extractor's Transform(prefix) and
+  // is only used to bound iteration. Any match must still start with
+  // requested_prefix to return OK.
+  const Slice& requested_prefix = prefix;  // full user-specified prefix
+  if (prefix_extractor != nullptr) {
+    // Validate that the prefix is in the domain
+    if (!prefix_extractor->InDomain(prefix)) {
+      ReturnAndCleanupSuperVersion(cfd, sv);
+      return Status::NotFound();
+    }
+    // Extract the actual prefix
+    actual_prefix = prefix_extractor->Transform(prefix);
+  }
+
+  // Create an internal key for searching
+  std::string internal_key_str;
+  AppendInternalKey(
+      &internal_key_str,
+      ParsedInternalKey(actual_prefix, kMaxSequenceNumber, kTypeValue));
+  Slice internal_key(internal_key_str);
+
+  // Use a local Arena for any temporary allocations needed by iterators
+  Arena arena;
+
+  // Use prefix_same_as_start when an extractor exists to constrain seeks
+  ReadOptions ro = options;
+  if (prefix_extractor != nullptr) {
+    ro.prefix_same_as_start = true;
+    ro.total_order_seek = false;
+  }
+
+  // Step 1: Check mutable memtable
+  // Snapshot-aware: skip entries with sequence > snapshot; the first visible
+  // version decides existence (non-deletion => OK, deletion => move to next
+  // user key). Sequence/type are decoded from the internal-key footer to avoid
+  // full parsing overhead. Iterators allocated from an Arena must be destroyed
+  // to run their destructors. We wrap them with ScopedArenaPtr so their
+  // destructors run and release any cache pins before we release the
+  // SuperVersion.
+  if (sv->mem != nullptr) {
+    InternalIterator* mem_iter_ptr =
+        sv->mem->NewIterator(ro, nullptr, &arena, prefix_extractor, false);
+    ScopedArenaPtr<InternalIterator> mem_iter(mem_iter_ptr);
+    mem_iter->Seek(internal_key);
+    SequenceNumber snap_seq =
+        ro.snapshot ? ro.snapshot->GetSequenceNumber() : kMaxSequenceNumber;
+    while (mem_iter->Valid()) {
+      Slice found_user_key = ExtractUserKey(mem_iter->key());
+      // Stop when we leave the effective (extracted) prefix domain
+      if (!(found_user_key.size() >= actual_prefix.size() &&
+            memcmp(found_user_key.data(), actual_prefix.data(),
+                   actual_prefix.size()) == 0)) {
+        break;
+      }
+      uint64_t footer = ExtractInternalKeyFooter(mem_iter->key());
+      SequenceNumber seq = footer >> 8;
+      ValueType vt = static_cast<ValueType>(footer & 0xff);
+      {
+        if (seq > snap_seq) {
+          // Not visible yet at snapshot; advance within same user key
+          mem_iter->Next();
+          continue;
+        }
+        // First visible version at/under snapshot_seq decides existence
+        if (vt != kTypeDeletion && vt != kTypeSingleDeletion &&
+            found_user_key.size() >= requested_prefix.size() &&
+            memcmp(found_user_key.data(), requested_prefix.data(),
+                   requested_prefix.size()) == 0) {
+          mem_iter.reset();
+          ReturnAndCleanupSuperVersion(cfd, sv);
+          return Status::OK();
+        }
+        // Visible deletion: skip to next distinct user key
+        SkipToNextUserKey(mem_iter.get());
+        continue;
+      }
+    }
+  }
+
+  // Step 2: Check immutable memtables
+  // Snapshot-aware with the same visibility rules as memtable. Sequence/type
+  // are decoded from the footer as well. Multiple imm memtables may exist;
+  // each iterator is wrapped so cleanup runs deterministically on early return.
+  if (sv->imm != nullptr) {
+    std::vector<InternalIterator*> imm_iters_raw;
+    sv->imm->AddIterators(ro, nullptr, prefix_extractor, &imm_iters_raw,
+                          &arena);
+    for (auto raw : imm_iters_raw) {
+      ScopedArenaPtr<InternalIterator> iter(raw);
+      iter->Seek(internal_key);
+      SequenceNumber snap_seq =
+          ro.snapshot ? ro.snapshot->GetSequenceNumber() : kMaxSequenceNumber;
+      while (iter->Valid()) {
+        Slice found_user_key = ExtractUserKey(iter->key());
+        if (!(found_user_key.size() >= actual_prefix.size() &&
+              memcmp(found_user_key.data(), actual_prefix.data(),
+                     actual_prefix.size()) == 0)) {
+          break;
+        }
+        uint64_t footer = ExtractInternalKeyFooter(iter->key());
+        SequenceNumber seq = footer >> 8;
+        ValueType vt = static_cast<ValueType>(footer & 0xff);
+        {
+          if (seq > snap_seq) {
+            iter->Next();
+            continue;
+          }
+          if (vt != kTypeDeletion && vt != kTypeSingleDeletion &&
+              found_user_key.size() >= requested_prefix.size() &&
+              memcmp(found_user_key.data(), requested_prefix.data(),
+                     requested_prefix.size()) == 0) {
+            iter.reset();
+            ReturnAndCleanupSuperVersion(cfd, sv);
+            return Status::OK();
+          }
+          SkipToNextUserKey(iter.get());
+          continue;
+        }
+      }
+    }
+  }
+
+  // Step 3: Check SST files using filter policies and index blocks
+  // Filter policies (bloom, ribbon, etc.) eliminate files that don't contain
+  // the prefix. Index blocks are consulted first; data blocks may still be
+  // read when the filter indicates a potential match.
+  Version* current = sv->current;
+  if (current == nullptr) {
+    ReturnAndCleanupSuperVersion(cfd, sv);
+    return Status::NotFound();
+  }
+
+  // Create an iterator to seek through SST files.
+  // Use the overload that refs its own SuperVersion so we can explicitly
+  // return the TLS-acquired SuperVersion before iterating. The SST scan is
+  // also snapshot-aware and uses the extracted prefix only to bound iteration;
+  // matches are verified against the requested prefix. Sequence/type are read
+  // via footer decoding.
+  ScopedArenaPtr<InternalIterator> iter_guard(
+      NewInternalIterator(ro, &arena, kMaxSequenceNumber, column_family,
+                          /*allow_unprepared_value=*/true));
+  InternalIterator* iter = iter_guard.get();
+
+  // Return the TLS SuperVersion now; the SST iterator holds its own ref.
+  ReturnAndCleanupSuperVersion(cfd, sv);
+
+  iter->Seek(internal_key);
+  SequenceNumber snap_seq =
+      ro.snapshot ? ro.snapshot->GetSequenceNumber() : kMaxSequenceNumber;
+  while (iter->Valid()) {
+    Slice found_user_key = ExtractUserKey(iter->key());
+    if (!(found_user_key.size() >= actual_prefix.size() &&
+          memcmp(found_user_key.data(), actual_prefix.data(),
+                 actual_prefix.size()) == 0)) {
+      break;
+    }
+    uint64_t footer = ExtractInternalKeyFooter(iter->key());
+    SequenceNumber seq = footer >> 8;
+    ValueType vt = static_cast<ValueType>(footer & 0xff);
+    {
+      if (seq > snap_seq) {
+        iter->Next();
+        continue;
+      }
+      if (vt != kTypeDeletion && vt != kTypeSingleDeletion &&
+          found_user_key.size() >= requested_prefix.size() &&
+          memcmp(found_user_key.data(), requested_prefix.data(),
+                 requested_prefix.size()) == 0) {
+        // Ensure iterator cleanups (including SV release) run before return.
+        iter_guard.reset();
+        return Status::OK();
+      }
+      SkipToNextUserKey(iter);
+      continue;
+    }
+  }
+
+  // Ensure SST iterator cleanups run before return.
+  iter_guard.reset();
+  return Status::NotFound();
+}
+
+// Batched prefix existence checks.
+// - Enables prefix_same_as_start when a prefix extractor is configured.
+// - Reuses a single SuperVersion and shared iterators (mem/imm/SST).
+// - Snapshot-aware across all layers: entries newer than the snapshot are
+//   skipped; the first visible version decides existence.
+// - Uses extracted (effective) prefixes to bound iteration and the full
+//   requested prefixes to determine existence per item (exact per-requested-
+//   prefix semantics within each effective-prefix group).
+// - Reads sequence/type from internal-key footers in hot loops to avoid full
+//   ParseInternalKey overhead.
+// - Mem/imm iterators are Arena-backed and wrapped with ScopedArenaPtr so
+//   destructors run and release cache pins before exit.
+// - The SST iterator is created via NewInternalIterator() overload that refs
+//   its own SuperVersion; we then release the TLS SuperVersion at function end.
+// - Optionally sorts and deduplicates effective prefixes when
+//   prefixes_sorted == false, then maps results back to original order.
+void DBImpl::PrefixExistsMulti(const ReadOptions& options,
+                               ColumnFamilyHandle* column_family,
+                               bool prefixes_sorted, size_t num_prefixes,
+                               const Slice* prefixes, Status* statuses) {
+  if (column_family == nullptr) {
+    column_family = DefaultColumnFamily();
+  }
+
+  auto cfh = static_cast<ColumnFamilyHandleImpl*>(column_family);
+  auto cfd = cfh->cfd();
+
+  if (cfd == nullptr) {
+    for (size_t i = 0; i < num_prefixes; ++i) {
+      statuses[i] = Status::InvalidArgument("Column family not found");
+    }
+    return;
+  }
+
+  // Prepare SuperVersion once, needed for options and iterator reuse
+  SuperVersion* sv = GetAndRefSuperVersion(cfd);
+  if (sv == nullptr) {
+    for (size_t i = 0; i < num_prefixes; ++i) {
+      statuses[i] = Status::InvalidArgument("Column family not found");
+    }
+    return;
+  }
+
+  const SliceTransform* prefix_extractor =
+      sv->mutable_cf_options.prefix_extractor.get();
+
+  // Preprocess prefixes: domain check and transform
+  std::vector<Slice> actual_prefixes;
+  actual_prefixes.reserve(num_prefixes);
+  std::vector<std::string> transformed_storage;  // own storage for transformed
+  transformed_storage.reserve(num_prefixes);
+
+  for (size_t i = 0; i < num_prefixes; ++i) {
+    if (prefix_extractor != nullptr) {
+      // Validate the requested prefix is in extractor domain before Transform.
+      if (!prefix_extractor->InDomain(prefixes[i])) {
+        // Not in domain: cannot exist under extracted namespace.
+        statuses[i] = Status::NotFound();
+        // Placeholder slice to keep vector sizes aligned; will be ignored.
+        actual_prefixes.emplace_back(Slice());
+      } else {
+        // Transform the requested prefix to the effective prefix. If the
+        // transform returns a Slice that aliases the input memory, we can
+        // safely reference it directly (the caller-owned input outlives this
+        // call). Otherwise, make an owned copy to ensure stability. This avoids
+        // an allocation/copy in the common case where the extractor returns a
+        // sub-slice of the input.
+        Slice transformed = prefix_extractor->Transform(prefixes[i]);
+        const char* base = prefixes[i].data();
+        const size_t base_len = prefixes[i].size();
+        const char* tdata = transformed.data();
+        const size_t tlen = transformed.size();
+        const bool aliases_input =
+            tdata >= base && (tdata + tlen) <= (base + base_len);
+        if (aliases_input) {
+          actual_prefixes.emplace_back(transformed);
+        } else {
+          transformed_storage.emplace_back(tdata, tlen);
+          actual_prefixes.emplace_back(transformed_storage.back());
+        }
+        // Mark as pending; will be set to OK/NotFound per requested prefix.
+        statuses[i] = Status::OK();
+      }
+    } else {
+      actual_prefixes.emplace_back(prefixes[i]);
+      statuses[i] = Status::OK();
+    }
+  }
+
+  // Prepare processing order with optional sorting/deduplication.
+  struct Item {
+    size_t idx;
+    Slice pfx;  // actual effective prefix
+  };
+  std::vector<Item> items;
+  items.reserve(num_prefixes);
+  for (size_t i = 0; i < num_prefixes; ++i) {
+    if (statuses[i].ok()) {
+      items.push_back({i, actual_prefixes[i]});
+    }
+  }
+
+  if (!prefixes_sorted) {
+    std::stable_sort(items.begin(), items.end(),
+                     [](const Item& a, const Item& b) {
+                       int r = a.pfx.compare(b.pfx);
+                       return r < 0;
+                     });
+  }
+
+  // Local arena for iterators
+  Arena arena;
+
+  // Build shared iterators once, using prefix_same_as_start when extractor
+  // exists
+  ReadOptions ro = options;
+  if (prefix_extractor != nullptr) {
+    ro.prefix_same_as_start = true;
+    ro.total_order_seek = false;
+  }
+
+  // Build shared iterators once
+  InternalIterator* mem_iter = nullptr;
+  ScopedArenaPtr<InternalIterator> mem_iter_guard;
+  if (sv->mem != nullptr) {
+    mem_iter =
+        sv->mem->NewIterator(ro, nullptr, &arena, prefix_extractor, false);
+    mem_iter_guard.reset(mem_iter);
+  }
+
+  std::vector<InternalIterator*> imm_iters;
+  std::vector<ScopedArenaPtr<InternalIterator>> imm_iters_guards;
+  if (sv->imm != nullptr) {
+    sv->imm->AddIterators(ro, nullptr, prefix_extractor, &imm_iters, &arena);
+    imm_iters_guards.reserve(imm_iters.size());
+    for (auto* p : imm_iters) {
+      imm_iters_guards.emplace_back(p);
+    }
+  }
+
+  Version* current = sv->current;
+  ScopedArenaPtr<InternalIterator> sst_iter;
+  if (current != nullptr) {
+    sst_iter.reset(NewInternalIterator(ro, &arena, kMaxSequenceNumber,
+                                       column_family,
+                                       /*allow_unprepared_value=*/true));
+  }
+
+  // Process prefixes in selected order, with deduplication across equal
+  // effective prefixes. Within each group, compute results per requested
+  // prefix: a match only if found key starts with the exact requested prefix.
+  // Track per-item matches and stop scanning the group early once all are
+  // satisfied or the iterator exits the effective-prefix range.
+  size_t pos = 0;
+  while (pos < items.size()) {
+    size_t start = pos;
+    const Slice& p = items[pos].pfx;
+    // group equal prefixes
+    while (pos < items.size() && items[pos].pfx.compare(p) == 0) {
+      ++pos;
+    }
+
+    // Build internal key for this prefix
+    std::string ikey_str;
+    AppendInternalKey(&ikey_str,
+                      ParsedInternalKey(p, kMaxSequenceNumber, kTypeValue));
+    Slice ikey(ikey_str);
+
+    // Track per-item matches in this group
+    const size_t group_size = pos - start;
+    std::vector<unsigned char> matched(group_size, 0);
+    size_t remaining = group_size;
+
+    // Check mutable memtable
+    if (mem_iter) {
+      mem_iter->Seek(ikey);
+      SequenceNumber snap_seq =
+          ro.snapshot ? ro.snapshot->GetSequenceNumber() : kMaxSequenceNumber;
+      while (mem_iter->Valid()) {
+        Slice fuk = ExtractUserKey(mem_iter->key());
+        // Bound by effective prefix without calling Transform(found_key)
+        if (!(fuk.size() >= p.size() &&
+              memcmp(fuk.data(), p.data(), p.size()) == 0)) {
+          break;
+        }
+        uint64_t footer = ExtractInternalKeyFooter(mem_iter->key());
+        SequenceNumber seq = footer >> 8;
+        ValueType vt = static_cast<ValueType>(footer & 0xff);
+        {
+          if (seq > snap_seq) {
+            mem_iter->Next();
+            continue;
+          }
+          if (vt != kTypeDeletion && vt != kTypeSingleDeletion) {
+            // Assign per requested prefix in this group
+            for (size_t j = 0; j < group_size; ++j) {
+              if (matched[j]) continue;
+              size_t idx = items[start + j].idx;
+              const Slice& req = prefixes[idx];
+              if (fuk.size() >= req.size() &&
+                  memcmp(fuk.data(), req.data(), req.size()) == 0) {
+                statuses[idx] = Status::OK();
+                matched[j] = 1;
+                if (--remaining == 0) break;
+              }
+            }
+            if (remaining == 0) break;
+          }
+          SkipToNextUserKey(mem_iter);
+          continue;
+        }
+      }
+    }
+
+    // Check immutable memtables
+    if (remaining > 0 && !imm_iters.empty()) {
+      for (auto& guard : imm_iters_guards) {
+        InternalIterator* iter = guard.get();
+        iter->Seek(ikey);
+        SequenceNumber snap_seq =
+            ro.snapshot ? ro.snapshot->GetSequenceNumber() : kMaxSequenceNumber;
+        while (iter->Valid()) {
+          Slice fuk = ExtractUserKey(iter->key());
+          // Bound by effective prefix without calling Transform(found_key)
+          if (!(fuk.size() >= p.size() &&
+                memcmp(fuk.data(), p.data(), p.size()) == 0)) {
+            break;
+          }
+          uint64_t footer = ExtractInternalKeyFooter(iter->key());
+          SequenceNumber seq = footer >> 8;
+          ValueType vt = static_cast<ValueType>(footer & 0xff);
+          {
+            if (seq > snap_seq) {
+              iter->Next();
+              continue;
+            }
+            if (vt != kTypeDeletion && vt != kTypeSingleDeletion) {
+              for (size_t j = 0; j < group_size; ++j) {
+                if (matched[j]) continue;
+                size_t idx = items[start + j].idx;
+                const Slice& req = prefixes[idx];
+                if (fuk.size() >= req.size() &&
+                    memcmp(fuk.data(), req.data(), req.size()) == 0) {
+                  statuses[idx] = Status::OK();
+                  matched[j] = 1;
+                  if (--remaining == 0) break;
+                }
+              }
+              if (remaining == 0) break;
+            }
+            SkipToNextUserKey(iter);
+            continue;
+          }
+        }
+        if (remaining == 0) break;
+      }
+    }
+
+    // Check SST files (index blocks first, snapshot-aware)
+    if (remaining > 0 && sst_iter) {
+      sst_iter->Seek(ikey);
+      SequenceNumber snap_seq =
+          ro.snapshot ? ro.snapshot->GetSequenceNumber() : kMaxSequenceNumber;
+      while (sst_iter->Valid()) {
+        Slice fuk = ExtractUserKey(sst_iter->key());
+        if (!(fuk.size() >= p.size() &&
+              memcmp(fuk.data(), p.data(), p.size()) == 0)) {
+          break;
+        }
+        uint64_t footer = ExtractInternalKeyFooter(sst_iter->key());
+        SequenceNumber seq = footer >> 8;
+        ValueType vt = static_cast<ValueType>(footer & 0xff);
+        {
+          if (seq > snap_seq) {
+            sst_iter->Next();
+            continue;
+          }
+          if (vt != kTypeDeletion && vt != kTypeSingleDeletion) {
+            for (size_t j = 0; j < group_size; ++j) {
+              if (matched[j]) continue;
+              size_t idx = items[start + j].idx;
+              const Slice& req = prefixes[idx];
+              if (fuk.size() >= req.size() &&
+                  memcmp(fuk.data(), req.data(), req.size()) == 0) {
+                statuses[idx] = Status::OK();
+                matched[j] = 1;
+                if (--remaining == 0) break;
+              }
+            }
+            if (remaining == 0) break;
+          }
+          SkipToNextUserKey(sst_iter.get());
+          continue;
+        }
+      }
+    }
+
+    // Assign NotFound to any unmatched requested prefixes in this group
+    if (remaining > 0) {
+      for (size_t j = 0; j < group_size; ++j) {
+        if (!matched[j]) {
+          statuses[items[start + j].idx] = Status::NotFound();
+        }
+      }
+    }
+  }
+
+  // Ensure SST iterator cleanups run before return.
+  if (sst_iter) {
+    sst_iter.reset();
+  }
+  // Now release the TLS-acquired SuperVersion.
+  ReturnAndCleanupSuperVersion(cfd, sv);
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/prefix_exists_test.cc
+++ b/db/prefix_exists_test.cc
@@ -1,0 +1,540 @@
+// Copyright (c) 2011-present, Facebook, Inc.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#include <string>
+#include <vector>
+
+#include "rocksdb/db.h"
+#include "rocksdb/filter_policy.h"
+#include "rocksdb/options.h"
+#include "rocksdb/slice_transform.h"
+#include "rocksdb/table.h"
+#include "table/block_based/block_based_table_factory.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class PrefixExistsTest : public testing::Test {
+ public:
+  PrefixExistsTest() : db_(nullptr) {}
+
+  ~PrefixExistsTest() override {
+    if (db_ != nullptr) {
+      delete db_;
+      db_ = nullptr;
+    }
+  }
+
+ protected:
+  void SetUp() override {
+    dbname_ = test::PerThreadDBPath("prefix_exists_test");
+    ASSERT_OK(DestroyDB(dbname_, Options()));
+  }
+
+  void TearDown() override {
+    if (db_ != nullptr) {
+      delete db_;
+      db_ = nullptr;
+    }
+    ASSERT_OK(DestroyDB(dbname_, Options()));
+  }
+
+  void OpenDB(const Options& options) {
+    Options opts = options;
+    if (!opts.create_if_missing) {
+      opts.create_if_missing = true;
+    }
+    Status s = DB::Open(opts, dbname_, &db_);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    ASSERT_NE(db_, nullptr);
+  }
+
+  DB* db_;
+  std::string dbname_;
+};
+
+TEST_F(PrefixExistsTest, BasicWithExtractorMemtable) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc1", "v1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "abc2", "v2"));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, Slice("abc")));
+  ASSERT_TRUE(db_->PrefixExists(ro, Slice("xyz")).IsNotFound());
+}
+
+TEST_F(PrefixExistsTest, WithoutExtractorMemtable) {
+  Options options;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "key1", "v1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "key2", "v2"));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, Slice("key")));
+  ASSERT_TRUE(db_->PrefixExists(ro, Slice("zzz")).IsNotFound());
+}
+
+TEST_F(PrefixExistsTest, WithSSTAndBloom) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+  BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(10));
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "pfx1", "v1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "pfx2", "v2"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, Slice("pfx")));
+  ASSERT_TRUE(db_->PrefixExists(ro, Slice("zzz")).IsNotFound());
+}
+
+TEST_F(PrefixExistsTest, DeletedKeyReturnsNotFound) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "aa1", "v1"));
+  ASSERT_OK(db_->Delete(WriteOptions(), "aa1"));
+
+  ReadOptions ro;
+  ASSERT_TRUE(db_->PrefixExists(ro, Slice("aa")).IsNotFound());
+}
+
+class PrefixExistsComprehensiveTest : public testing::Test {
+ public:
+  PrefixExistsComprehensiveTest() : db_(nullptr) {}
+  ~PrefixExistsComprehensiveTest() override {
+    if (db_ != nullptr) {
+      delete db_;
+    }
+  }
+
+ protected:
+  void SetUp() override {
+    dbname_ = test::PerThreadDBPath("prefix_exists_comprehensive_test");
+    ASSERT_OK(DestroyDB(dbname_, Options()));
+  }
+
+  void TearDown() override {
+    if (db_ != nullptr) {
+      delete db_;
+      db_ = nullptr;
+    }
+    ASSERT_OK(DestroyDB(dbname_, Options()));
+  }
+
+  void OpenDB(const Options& options = Options()) {
+    Options opts = options;
+    if (!opts.create_if_missing) {
+      opts.create_if_missing = true;
+    }
+    Status s = DB::Open(opts, dbname_, &db_);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    ASSERT_NE(db_, nullptr);
+  }
+
+  DB* db_;
+  std::string dbname_;
+};
+
+// MEMTABLE PREFIX BLOOM FILTER TESTS
+TEST_F(PrefixExistsComprehensiveTest, MemtablePrefixBloomEnabled) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+  options.memtable_prefix_bloom_size_ratio = 0.25;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc1", "value1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "abc2", "value2"));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "abc"));
+  ASSERT_TRUE(db_->PrefixExists(ro, "xyz").IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, MemtablePrefixBloomDisabled) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+  options.memtable_prefix_bloom_size_ratio = 0.0;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc1", "value1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "abc2", "value2"));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "abc"));
+  ASSERT_TRUE(db_->PrefixExists(ro, "xyz").IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, MemtablePrefixBloomFalsePositive) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+  options.memtable_prefix_bloom_size_ratio = 0.25;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc1", "value1"));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "abc"));
+  ASSERT_TRUE(db_->PrefixExists(ro, "def").IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, NoExtractorWithMemtablePrefixBloom) {
+  Options options;
+  options.memtable_prefix_bloom_size_ratio = 0.25;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "key1", "value1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "key2", "value2"));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "key"));
+  ASSERT_TRUE(db_->PrefixExists(ro, "zzz").IsNotFound());
+}
+
+// MULTIPLE IMMUTABLE MEMTABLES TESTS
+TEST_F(PrefixExistsComprehensiveTest, MultipleImmutableMemtables) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  options.write_buffer_size = 1024;
+  OpenDB(options);
+
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(db_->Put(WriteOptions(), "aa" + std::to_string(i), "v"));
+  }
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(db_->Put(WriteOptions(), "bb" + std::to_string(i), "v"));
+  }
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(db_->Put(WriteOptions(), "cc" + std::to_string(i), "v"));
+  }
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "aa"));
+  ASSERT_OK(db_->PrefixExists(ro, "bb"));
+  ASSERT_OK(db_->PrefixExists(ro, "cc"));
+}
+
+TEST_F(PrefixExistsComprehensiveTest, KeyInFirstImmutableMemtable) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  options.write_buffer_size = 1024;
+  OpenDB(options);
+
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(db_->Put(WriteOptions(), "aa" + std::to_string(i), "v"));
+  }
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_OK(db_->Put(WriteOptions(), "bb" + std::to_string(i), "v"));
+  }
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "aa"));
+}
+
+// SST FILE FILTER POLICY TESTS
+TEST_F(PrefixExistsComprehensiveTest, BloomFilterInSST) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+
+  BlockBasedTableOptions tbo;
+  tbo.filter_policy.reset(NewBloomFilterPolicy(10));
+  options.table_factory.reset(NewBlockBasedTableFactory(tbo));
+
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc1", "value1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "abc2", "value2"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "abc"));
+  ASSERT_TRUE(db_->PrefixExists(ro, "xyz").IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, NoFilterPolicyInSST) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+
+  BlockBasedTableOptions tbo;
+  options.table_factory.reset(NewBlockBasedTableFactory(tbo));
+
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc1", "value1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "abc2", "value2"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "abc"));
+  ASSERT_TRUE(db_->PrefixExists(ro, "xyz").IsNotFound());
+}
+
+// MULTIPLE SST FILES AT DIFFERENT LEVELS
+TEST_F(PrefixExistsComprehensiveTest, KeyInMultipleLevels) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  options.level0_file_num_compaction_trigger = 2;
+  OpenDB(options);
+
+  for (int level = 0; level < 3; ++level) {
+    for (int i = 0; i < 100; ++i) {
+      std::string key;
+      key.push_back(static_cast<char>('a' + level));
+      key.push_back(static_cast<char>('a' + (i % 26)));
+      key += std::to_string(i);
+      ASSERT_OK(db_->Put(WriteOptions(), key, "v"));
+    }
+    ASSERT_OK(db_->Flush(FlushOptions()));
+  }
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "aa"));
+  ASSERT_OK(db_->PrefixExists(ro, "ba"));
+  ASSERT_OK(db_->PrefixExists(ro, "ca"));
+}
+
+// DELETED KEY HANDLING TESTS
+TEST_F(PrefixExistsComprehensiveTest, DeletedKeyInMemtableWithBloom) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  options.memtable_prefix_bloom_size_ratio = 0.25;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "aa1", "v1"));
+  ASSERT_OK(db_->Delete(WriteOptions(), "aa1"));
+
+  ReadOptions ro;
+  ASSERT_TRUE(db_->PrefixExists(ro, "aa").IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, DeletedKeyInSST) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "aa1", "v1"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  ASSERT_OK(db_->Delete(WriteOptions(), "aa1"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  ReadOptions ro;
+  ASSERT_TRUE(db_->PrefixExists(ro, "aa").IsNotFound());
+}
+
+// SNAPSHOT ISOLATION TESTS
+TEST_F(PrefixExistsComprehensiveTest, SnapshotWithMemtablePrefixBloom) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  options.memtable_prefix_bloom_size_ratio = 0.25;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "aa1", "v1"));
+
+  const Snapshot* snapshot = db_->GetSnapshot();
+
+  ASSERT_OK(db_->Put(WriteOptions(), "aa2", "v2"));
+
+  ReadOptions ro;
+  ro.snapshot = snapshot;
+
+  ASSERT_OK(db_->PrefixExists(ro, "aa1"));
+  ASSERT_TRUE(db_->PrefixExists(ro, "aa2").IsNotFound());
+
+  db_->ReleaseSnapshot(snapshot);
+}
+
+// EDGE CASE TESTS
+TEST_F(PrefixExistsComprehensiveTest, VeryLargePrefix) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(100));
+  OpenDB(options);
+
+  std::string large_key(200, 'a');
+  ASSERT_OK(db_->Put(WriteOptions(), large_key, "v"));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, large_key));
+}
+
+TEST_F(PrefixExistsComprehensiveTest, SingleCharacterPrefix) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(1));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "a1", "v1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "a2", "v2"));
+  ASSERT_OK(db_->Put(WriteOptions(), "b1", "v3"));
+
+  ReadOptions ro;
+  ASSERT_OK(db_->PrefixExists(ro, "a"));
+  ASSERT_OK(db_->PrefixExists(ro, "b"));
+  ASSERT_TRUE(db_->PrefixExists(ro, "c").IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, EmptyKeyAfterExtraction) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(10));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc", "v"));
+
+  ReadOptions ro;
+  Status s = db_->PrefixExists(ro, "abc");
+  ASSERT_TRUE(s.ok() || s.IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, BatchWithExtractorMemtable) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc1", "v1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "abd1", "v2"));
+
+  ReadOptions ro;
+  const Slice prefixes[] = {Slice("abc"), Slice("abe"), Slice("abd")};
+  Status statuses[3];
+  db_->PrefixExistsMulti(ro, false, 3, prefixes, statuses);
+  ASSERT_TRUE(statuses[0].ok());
+  ASSERT_TRUE(statuses[1].IsNotFound());
+  ASSERT_TRUE(statuses[2].ok());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, BatchWithoutExtractorMemtable) {
+  Options options;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "key1", "v1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "key2", "v2"));
+
+  ReadOptions ro;
+  const Slice prefixes[] = {Slice("key"), Slice("zzz")};
+  Status statuses[2];
+  db_->PrefixExistsMulti(ro, false, 2, prefixes, statuses);
+  ASSERT_TRUE(statuses[0].ok());
+  ASSERT_TRUE(statuses[1].IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, BatchFlushAndDelete) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "aa1", "v1"));
+  ASSERT_OK(db_->Put(WriteOptions(), "bb1", "v2"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  ReadOptions ro;
+  const Slice prefixes1[] = {Slice("aa"), Slice("bb"), Slice("cc")};
+  Status statuses1[3];
+  db_->PrefixExistsMulti(ro, false, 3, prefixes1, statuses1);
+  ASSERT_TRUE(statuses1[0].ok());
+  ASSERT_TRUE(statuses1[1].ok());
+  ASSERT_TRUE(statuses1[2].IsNotFound());
+
+  ASSERT_OK(db_->Delete(WriteOptions(), "aa1"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  const Slice prefixes2[] = {Slice("aa"), Slice("bb")};
+  Status statuses2[2];
+  db_->PrefixExistsMulti(ro, false, 2, prefixes2, statuses2);
+  ASSERT_TRUE(statuses2[0].IsNotFound());
+  ASSERT_TRUE(statuses2[1].ok());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, BatchSortedHintWithDuplicates) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(3));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "abc1", "v1"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  ReadOptions ro;
+  const Slice prefixes[] = {Slice("abc"), Slice("abc"), Slice("abe"),
+                            Slice("abe")};
+  Status statuses[4];
+  db_->PrefixExistsMulti(ro, true /*sorted*/, 4, prefixes, statuses);
+  ASSERT_TRUE(statuses[0].ok());
+  ASSERT_TRUE(statuses[1].ok());
+  ASSERT_TRUE(statuses[2].IsNotFound());
+  ASSERT_TRUE(statuses[3].IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, BatchSortedHintWithoutExtractor) {
+  Options options;
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "key1", "v1"));
+
+  ReadOptions ro;
+  const Slice prefixes[] = {Slice("key"), Slice("key"), Slice("zzz")};
+  Status statuses[3];
+  db_->PrefixExistsMulti(ro, true /*sorted*/, 3, prefixes, statuses);
+  ASSERT_TRUE(statuses[0].ok());
+  ASSERT_TRUE(statuses[1].ok());
+  ASSERT_TRUE(statuses[2].IsNotFound());
+}
+
+TEST_F(PrefixExistsComprehensiveTest, BatchSnapshotIsolation) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "aa1", "v1"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  const Snapshot* snap = db_->GetSnapshot();
+  ASSERT_NE(snap, nullptr);
+
+  // Delete after snapshot
+  ASSERT_OK(db_->Delete(WriteOptions(), "aa1"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  ReadOptions ro;
+  ro.snapshot = snap;
+  const Slice prefixes[] = {Slice("aa"), Slice("bb")};
+  Status statuses[2];
+  db_->PrefixExistsMulti(ro, false, 2, prefixes, statuses);
+  ASSERT_TRUE(statuses[0].ok());
+  ASSERT_TRUE(statuses[1].IsNotFound());
+
+  db_->ReleaseSnapshot(snap);
+}
+
+// In Multi, different requested prefixes that map to the same effective
+// (extracted) prefix must be evaluated independently. Only requests whose
+// exact requested prefix matches the found key should return OK.
+TEST_F(PrefixExistsComprehensiveTest, BatchExactRequestedPrefixSemantics) {
+  Options options;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  OpenDB(options);
+
+  ASSERT_OK(db_->Put(WriteOptions(), "aa1", "v1"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+
+  ReadOptions ro;
+  const Slice prefixes[] = {Slice("aa1"), Slice("aa2")};
+  Status statuses[2];
+  db_->PrefixExistsMulti(ro, false /*sorted*/, 2, prefixes, statuses);
+  ASSERT_TRUE(statuses[0].ok());
+  ASSERT_TRUE(statuses[1].IsNotFound());
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -220,6 +220,22 @@ class StackableDB : public DB {
     return db_->KeyMayExist(options, column_family, key, value, value_found);
   }
 
+  using DB::PrefixExists;
+  Status PrefixExists(const ReadOptions& options,
+                      ColumnFamilyHandle* column_family,
+                      const Slice& prefix) override {
+    return db_->PrefixExists(options, column_family, prefix);
+  }
+
+  using DB::PrefixExistsMulti;
+  void PrefixExistsMulti(const ReadOptions& options,
+                         ColumnFamilyHandle* column_family,
+                         bool prefixes_sorted, size_t num_prefixes,
+                         const Slice* prefixes, Status* statuses) override {
+    db_->PrefixExistsMulti(options, column_family, prefixes_sorted,
+                           num_prefixes, prefixes, statuses);
+  }
+
   using DB::Delete;
   Status Delete(const WriteOptions& wopts, ColumnFamilyHandle* column_family,
                 const Slice& key) override {

--- a/src.mk
+++ b/src.mk
@@ -56,6 +56,7 @@ LIB_SOURCES =                                                   \
   db/db_impl/db_impl_follower.cc                                \
   db/db_impl/db_impl_open.cc                                    \
   db/db_impl/db_impl_readonly.cc                                \
+  db/db_impl/db_impl_prefix_exists.cc                           \
   db/db_impl/db_impl_secondary.cc                               \
   db/db_impl/db_impl_write.cc                                   \
   db/db_info_dumper.cc                                          \
@@ -548,6 +549,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/periodic_task_scheduler_test.cc                                    \
   db/plain_table_db_test.cc                                             \
   db/prefix_test.cc                                                     \
+  db/prefix_exists_test.cc                                              \
   db/repair_test.cc                                                     \
   db/range_del_aggregator_test.cc                                       \
   db/range_tombstone_fragmenter_test.cc                                 \


### PR DESCRIPTION
### Problem
Today, users who only need to know “does any key with this prefix exist?” typically:

- Create a new iterator
- Enable prefix_same_as_start
- Seek to the prefix
- Tear down the iterator

This pattern incurs expensive iterator lifecycle overhead per prefix, touches many index/filter blocks with poor locality, and forces every user to reinvent the same existence check.

### Solution
Introduce prefix-existence APIs that:

1. Avoid value materialization and scan only as far as the first matching key.
2. Reuse one SuperVersion and one set of iterators (memtable, imm memtables, and SSTs) for the entire batch via PrefixExistsMulti
3. Offer a prefixes_sorted hint so callers who pre-sort/dedup can skip internal sorting; otherwise the implementation sorts/dedups to maximize locality and reduce seeks.

### Performance

- Compared to creating/destroying an iterator per prefix (no reuse), PrefixExistsMulti reduces overhead substantially by amortizing iterator setup and improving locality via sorting/dedup. Typical gains for batch workloads are significant.
- Compared to single-prefix PrefixExists (per-call setup), PrefixExistsMulti is faster for any meaningful batch (N ≥ 4–8) due to amortized setup and fewer overall seeks.
- Qualitative expectations in common setups (prefix extractor + partitioned filters + prefix_same_as_start):
  - Old pattern (new iterator per prefix) → Baseline (slowest).
  - Single-prefix PrefixExists → Moderately faster than baseline due to existence-only short-circuit.
  - Batched PrefixExistsMulti → Substantially faster than baseline for N>1; best when inputs are unsorted or have duplicates.
  
  
 
Note that for my workload. I do over 100K+ prefix checks per second right now, and we can definitely batch so batching is very important and optimizing this path is critical for us. I'm very open to making any other changes that will help make this path more efficient so open to suggestions.