### PR TITLE
Fix race exposed by TSAN in arm64

### DIFF
--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -53,7 +53,7 @@ ASSERT_FEATURE_COMPAT_HEADER();
 #endif
 
 #if defined(HAVE_ARM64_CRC)
-bool pmull_runtime_flag = false;
+std::atomic<bool> pmull_runtime_flag = false;
 #endif
 
 namespace ROCKSDB_NAMESPACE::crc32c {

--- a/util/crc32c_arm64.cc
+++ b/util/crc32c_arm64.cc
@@ -29,6 +29,8 @@
 #include <sys/types.h>
 #endif
 
+#include <atomic>
+
 #ifdef HAVE_ARM64_CRYPTO
 /* unfolding to compute 8 * 3 = 24 bytes parallelly */
 #define CRC32C24BYTES(ITR)                                    \
@@ -49,7 +51,7 @@
   } while (0)
 #endif
 
-extern bool pmull_runtime_flag;
+extern std::atomic<bool> pmull_runtime_flag;
 
 uint32_t crc32c_runtime_check(void) {
 #if defined(ROCKSDB_AUXV_GETAUXVAL_PRESENT) || defined(__FreeBSD__)


### PR DESCRIPTION
Fix TSAN race for ARM64:
```
    [FAILED]  crash_report

  ****> "all" failed:
SUT was aborted: 
Report of 'arangod' in /tmp/ArangoDB/0/arangosh_i5YmFA/rta_makedata_test/dbserver_2/tsan.log.arangod.2188 contains: 
==================
WARNING: ThreadSanitizer: data race (pid=2188)
  Write of size 1 at 0xab741f8954c0 by main thread:
    #0 rocksdb::crc32c::IsFastCrc32Supported[abi:cxx11]() /root/project/3rdParty/rocksdb/util/crc32c.cc:380 (arangod+0x7c6eb54) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #1 DumpSupportInfo /root/project/3rdParty/rocksdb/db/db_impl/db_impl.cc:152 (arangod+0x7790138) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #2 rocksdb::DBImpl::DBImpl(rocksdb::DBOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool, bool, bool) /root/project/3rdParty/rocksdb/db/db_impl/db_impl.cc:302 (arangod+0x7790138)
    #3 rocksdb::DBImpl::Open(rocksdb::DBOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::vector<rocksdb::ColumnFamilyDescriptor, std::allocator<rocksdb::ColumnFamilyDescriptor>> const&, std::vector<rocksdb::ColumnFamilyHandle*, std::allocator<rocksdb::ColumnFamilyHandle*>>*, rocksdb::DB**, bool, bool, bool, bool*) /root/project/3rdParty/rocksdb/db/db_impl/db_impl_open.cc:2042 (arangod+0x7855cac) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #4 rocksdb::DB::Open(rocksdb::DBOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::vector<rocksdb::ColumnFamilyDescriptor, std::allocator<rocksdb::ColumnFamilyDescriptor>> const&, std::vector<rocksdb::ColumnFamilyHandle*, std::allocator<rocksdb::ColumnFamilyHandle*>>*, rocksdb::DB**) /root/project/3rdParty/rocksdb/db/db_impl/db_impl_open.cc:1849 (arangod+0x7855774) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #5 arangodb::RocksDBTempStorage::init() /root/project/arangod/RocksDBEngine/RocksDBTempStorage.cpp:253 (arangod+0x4d11e18) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)

  Previous read of size 1 at 0xab741f8954c0 by thread T269 (mutexes: write M0):
    #0 crc32c_arm64(unsigned int, unsigned char const*, unsigned long) /root/project/3rdParty/rocksdb/util/crc32c_arm64.cc:128 (arangod+0x7d4cf80) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #1 rocksdb::crc32c::ExtendARMImpl(unsigned int, char const*, unsigned long) /root/project/3rdParty/rocksdb/util/crc32c.cc:358 (arangod+0x7c6ea78) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #2 rocksdb::crc32c::Extend(unsigned int, char const*, unsigned long) /root/project/3rdParty/rocksdb/util/crc32c.cc:1133 (arangod+0x7c6eee8) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #3 Value /root/project/3rdParty/rocksdb/util/crc32c.h:35 (arangod+0x78e8774) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #4 rocksdb::log::Writer::EmitPhysicalRecord(rocksdb::WriteOptions const&, rocksdb::log::RecordType, char const*, unsigned long) /root/project/3rdParty/rocksdb/db/log_writer.cc:326 (arangod+0x78e8774)
    #5 rocksdb::log::Writer::AddRecord(rocksdb::WriteOptions const&, rocksdb::Slice const&) /root/project/3rdParty/rocksdb/db/log_writer.cc:181 (arangod+0x78e807c) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #6 rocksdb::DBImpl::WriteToWAL(rocksdb::WriteBatch const&, rocksdb::WriteOptions const&, rocksdb::log::Writer*, unsigned long*, unsigned long*, rocksdb::DBImpl::LogFileNumberSize&) /root/project/3rdParty/rocksdb/db/db_impl/db_impl_write.cc:1403 (arangod+0x7805514) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #7 rocksdb::DBImpl::WriteToWAL(rocksdb::WriteThread::WriteGroup const&, rocksdb::log::Writer*, unsigned long*, bool, bool, unsigned long, rocksdb::DBImpl::LogFileNumberSize&) /root/project/3rdParty/rocksdb/db/db_impl/db_impl_write.cc:1451 (arangod+0x7800cec) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #8 rocksdb::DBImpl::PipelinedWriteImpl(rocksdb::WriteOptions const&, rocksdb::WriteBatch*, rocksdb::WriteCallback*, rocksdb::UserWriteCallback*, unsigned long*, unsigned long, bool, unsigned long*) /root/project/3rdParty/rocksdb/db/db_impl/db_impl_write.cc:794 (arangod+0x77fea5c) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #9 rocksdb::DBImpl::WriteImpl(rocksdb::WriteOptions const&, rocksdb::WriteBatch*, rocksdb::WriteCallback*, rocksdb::UserWriteCallback*, unsigned long*, unsigned long, bool, unsigned long*, unsigned long, rocksdb::PreReleaseCallback*, rocksdb::PostMemTableCallback*) /root/project/3rdParty/rocksdb/db/db_impl/db_impl_write.cc:340 (arangod+0x77f9318) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #10 rocksdb::DBImpl::Write(rocksdb::WriteOptions const&, rocksdb::WriteBatch*) /root/project/3rdParty/rocksdb/db/db_impl/db_impl_write.cc:157 (arangod+0x77f89c8) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #11 arangodb::RocksDBSettingsManager::sync(bool) /root/project/arangod/RocksDBEngine/RocksDBSettingsManager.cpp:206 (arangod+0x4d0b694) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)

  Location is global 'pmull_runtime_flag' of size 1 at 0xab741f8954c0 (arangod+0x9e254c0)

  Mutex M0 (0xff97ff83d3a8) created at:
    #0 pthread_mutex_lock <null> (arangod+0x21f6098) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #1 __gthread_mutex_lock /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/aarch64-linux-gnu/c++/13/bits/gthr-default.h:749 (arangod+0x4d0ad48) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #2 lock /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/std_mutex.h:113 (arangod+0x4d0ad48)
    #3 lock /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/unique_lock.h:141 (arangod+0x4d0ad48)
    #4 arangodb::RocksDBSettingsManager::sync(bool) /root/project/arangod/RocksDBEngine/RocksDBSettingsManager.cpp:115 (arangod+0x4d0ad48)
    #5 arangodb::RocksDBBackgroundThread::run() /root/project/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp:116 (arangod+0x4bb0388) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #6 arangodb::Thread::runMe() /root/project/lib/Basics/Thread.cpp:344 (arangod+0x83cad6c) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #7 arangodb::Thread::startThread(void*) /root/project/lib/Basics/Thread.cpp:147 (arangod+0x83ca9a0) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #8 ThreadStarter(void*) /root/project/lib/Basics/threads-posix.cpp:78 (arangod+0x83ede2c) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)

  Thread T269 'RocksDBThread' (tid=2485, running) created by main thread at:
    #0 pthread_create <null> (arangod+0x21f3d9c) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #1 TRI_StartThread(unsigned long*, char const*, void (*)(void*), void*) /root/project/lib/Basics/threads-posix.cpp:137 (arangod+0x83eda1c) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #2 arangodb::Thread::start(arangodb::basics::ConditionVariable*) /root/project/lib/Basics/Thread.cpp:314 (arangod+0x83cc744) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #3 arangodb::RocksDBEngine::start() /root/project/arangod/RocksDBEngine/RocksDBEngine.cpp:1333 (arangod+0x4b75308) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #4 arangodb::application_features::ApplicationServer::start() /root/project/lib/ApplicationFeatures/ApplicationServer.cpp:644 (arangod+0x4e2a368) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #5 arangodb::application_features::ApplicationServer::run(int, char**) /root/project/lib/ApplicationFeatures/ApplicationServer.cpp:210 (arangod+0x4e254f8) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #6 runServer /root/project/arangod/RestServer/arangod.cpp:216 (arangod+0x228611c) (BuildId: 45c1d62fced3a7d8294080007341ca55bfe38193)
    #7 main /root/project/arangod/RestServer/arangod.cpp:278 (arangod+0x228611c)

SUMMARY: ThreadSanitizer: data race /root/project/3rdParty/rocksdb/util/crc32c.cc:380 in rocksdb::crc32c::IsFastCrc32Supported[abi:cxx11]()
==================
ThreadSanitizer: reported 1 warnings
```