### PR TITLE
Only call libc close() once

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1695,11 +1695,12 @@ IOStatus PosixRandomRWFile::Fsync(const IOOptions& /*opts*/,
 
 IOStatus PosixRandomRWFile::Close(const IOOptions& /*opts*/,
                                   IODebugContext* /*dbg*/) {
+  IOStatus s = IOStatus::OK();
   if (close(fd_) < 0) {
-    return IOError("While close random read/write file", filename_, errno);
+    s = IOError("While close random read/write file", filename_, errno);
   }
   fd_ = -1;
-  return IOStatus::OK();
+  return s;
 }
 
 PosixMemoryMappedFileBuffer::~PosixMemoryMappedFileBuffer() {
@@ -1743,9 +1744,8 @@ IOStatus PosixDirectory::Close(const IOOptions& /*opts*/,
   IOStatus s = IOStatus::OK();
   if (close(fd_) < 0) {
     s = IOError("While closing directory ", directory_name_, errno);
-  } else {
-    fd_ = -1;
   }
+  fd_ = -1;
   return s;
 }
 


### PR DESCRIPTION
The changes in this PR prevent [close(2)](https://man7.org/linux/man-pages/man2/close.2.html) from being called multiple times against a single file descriptor. On Linux, but not necessarily other posix boxen, calling `close()` is considered "wrong" (their words):

> Retrying the close() after a failure return is the wrong thing to
  do, since this may cause a reused file descriptor from another
  thread to be closed.  This can occur because the Linux kernel
  always releases the file descriptor early in the close operation,
  freeing it for reuse; the steps that may return an error, such as
  flushing data to the filesystem or device, occur only later in the
  close operation.

The PR changes here provide a speculative fix to issues such as [this one](https://github.com/osquery/osquery/issues/7884) in osquery. The error from RocksDB in osquery is EISDIR, an unexpected error in this context (see log). This has the distinct smell of an incorrect file descriptor in use. I hypothesize this is down to a call to ::Close(...) returning an IOStatus error and not setting fd to -1 and then subsequently, the destructors for `PosixRandomRWFile` and/or `PosixDirectory`, invoking close() on the now invalid file descriptor. Between the first and second call of close(), the file descriptor id can be recycled and used in a different context. This is described in [open(2)](https://man7.org/linux/man-pages/man2/open.2.html) which states:

> The file descriptor returned by a successful call will be the lowest-numbered file descriptor not currently open for the process.

The erroneous call to close() in the destructor **could** therefore impact reused file descriptor ids thus leading to unexpected and difficult to debug error cases.