### PR TITLE
fix compiler warning for mutex->AssertHeld

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5551,17 +5551,17 @@ void VersionSet::UpdatedMutableDbOptions(
   // Must be holding mutex if not called during initialization
   if (mu) {
     mu->AssertHeld();
-    file_options_.writable_file_max_buffer_size =
-        updated_options.writable_file_max_buffer_size;
-    min_max_manifest_file_size_ = updated_options.max_manifest_file_size;
-    max_manifest_space_amp_pct_ = static_cast<unsigned>(
-        std::max(updated_options.max_manifest_space_amp_pct, 0));
-    manifest_preallocation_size_ = updated_options.manifest_preallocation_size;
-    TuneMaxManifestFileSize();
   } else {
-    // called from the constructor
+    // manifest_file_size_ must be 0 if called from the constructor
     assert(manifest_file_size_ == 0);
   }
+  file_options_.writable_file_max_buffer_size =
+      updated_options.writable_file_max_buffer_size;
+  min_max_manifest_file_size_ = updated_options.max_manifest_file_size;
+  max_manifest_space_amp_pct_ = static_cast<unsigned>(
+      std::max(updated_options.max_manifest_space_amp_pct, 0));
+  manifest_preallocation_size_ = updated_options.manifest_preallocation_size;
+  TuneMaxManifestFileSize();
 }
 
 void VersionSet::TuneMaxManifestFileSize() {


### PR DESCRIPTION
We are seeing Github actions failures due to a compiler error:  

https://github.com/facebook/rocksdb/actions/runs/19190877461/job/54865138898?fbclid=IwY2xjawN_Hc9leHRuA2FlbQIxMQBicmlkETFZeGlpZXZXMGlDTVhTYldwc3J0YwZhcHBfaWQBMAABHp6JoIoMBbZq-8Kgfc1honBdkAbHAZzW2ORiCM2Br2D9utxtMlq6IIqUUQnu_aem_SOU-DDsjDDMB3mTncKfLwQ&brid=VRqQ-asf2myW425wX1qqhg

When UpdatedMutableDbOptions is called from the VersionSet constructor, manifest_file_size_ is 0, and mu is nullptr. This is expected and fine, and we never enter the block where AssertHeld is called. 

All other times UpdatedMutableDbOptions is called, the mutex must be held. This PR just checks that mu is not null, to satisfy the compiler. We could alternatively intentionally crash if there is concern over a silent failure if mu is passed as nullptr