### PR TITLE
Fix flushed size update error on repeated flush

### DIFF
--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -860,8 +860,7 @@ IOStatus WritableFileWriter::WriteDirect(const IOOptions& opts) {
     left -= size;
     src += size;
     write_offset += size;
-    uint64_t cur_size = flushed_size_.load(std::memory_order_acquire);
-    flushed_size_.store(cur_size + size, std::memory_order_release);
+    flushed_size_.store(write_offset, std::memory_order_release);
     assert((next_write_offset_ % alignment) == 0);
   }
 
@@ -966,8 +965,7 @@ IOStatus WritableFileWriter::WriteDirectWithChecksum(const IOOptions& opts) {
 
   IOSTATS_ADD(bytes_written, left);
   assert((next_write_offset_ % alignment) == 0);
-  uint64_t cur_size = flushed_size_.load(std::memory_order_acquire);
-  flushed_size_.store(cur_size + left, std::memory_order_release);
+  flushed_size_.store(next_write_offset_ + left, std::memory_order_release);
 
   if (s.ok()) {
     // Move the tail to the beginning of the buffer


### PR DESCRIPTION
Fix an over-count when `WritableFileWriter::Flush` is called repeatedly in direct I/O mode, update `flushed_size_` to the current write offset instead of incrementing blindly, add `WritableFileWriterTest.RepeatedFlushWithDirectIO` to prove the value stays stable across consecutive flushes.