### PR TITLE
TryCatchUpWithPrimary: skip MANIFEST tail reads when file size did not change

### DIFF
--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1855,6 +1855,8 @@ class ReactiveVersionSet : public VersionSet {
     return Status::NotSupported("not supported in reactive mode");
   }
 
+  Status TryGetManifestSize(log::Reader* reader, uint64_t* size) const;
+
   // No copy allowed
   ReactiveVersionSet(const ReactiveVersionSet&);
   ReactiveVersionSet& operator=(const ReactiveVersionSet&);


### PR DESCRIPTION
I noticed that `TryCatchUpWithPrimary` takes a lot of time in my setup even when there were no changes in DB. In my case for 500 GB RocksDB instance it takes up to ~50 ms and most of this time is tail reading of MANIFEST file. 

In this PR I implement the following optimization - to cache MANIFEST file size and if it did not grow since last call immediately return control. It makes sense for 2 reasons:
- Manifest does not change often
- Syscall to get file size is much cheaper operation than reading file from specific offset

Implementation details:
- add a helper for `ReactiveVersionSet` to query the current `MANIFEST` size via the filesystem
- cache the last known size using the existing `VersionSet::manifest_file_size_` and skip `ManifestTailer::Iterate()` when the file hasn’t grown
- reset the cached size whenever we reopen/switch the MANIFEST so the next pass reprocesses from the beginning

This optimization speeds up `TryCatchUpWithPrimary` up to **3 times** in my tests.