### PR TITLE
Allow writes during SST file ingestion

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5749,6 +5749,16 @@ Status DBImpl::IngestExternalFiles(
   if (args.empty()) {
     return Status::InvalidArgument("ingestion arg list is empty");
   }
+  // Supported only when all args have the consistent `allow_write` behavior, as
+  // `allow_write` determines whether stopping writes to the DB affects all
+  // args.
+  bool allow_write = args[0].options.allow_write;
+  for (const auto& arg : args) {
+    if (arg.options.allow_write != allow_write) {
+      return Status::InvalidArgument(
+          "Inconsistent allow_writes values across ingestion arguments");
+    }
+  }
   {
     std::unordered_set<ColumnFamilyHandle*> unique_cfhs;
     for (const auto& arg : args) {
@@ -5907,19 +5917,25 @@ Status DBImpl::IngestExternalFiles(
 
     // Stop writes to the DB by entering both write threads
     WriteThread::Writer w;
-    write_thread_.EnterUnbatched(&w, &mutex_);
     WriteThread::Writer nonmem_w;
-    if (two_write_queues_) {
-      nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
-    }
-    PERF_TIMER_GUARD(file_ingestion_blocking_live_writes_nanos);
+    if (!allow_write) {
+      // Stop writes to the DB by entering both write threads.
+      write_thread_.EnterUnbatched(&w, &mutex_);
+      if (two_write_queues_) {
+        nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
+      }
 
-    // When unordered_write is enabled, the keys are writing to memtable in an
-    // unordered way. If the ingestion job checks memtable key range before the
-    // key landing in memtable, the ingestion job may skip the necessary
-    // memtable flush.
-    // So wait here to ensure there is no pending write to memtable.
-    WaitForPendingWrites();
+
+      // When unordered_write is enabled, the keys are writing to memtable in an
+      // unordered way. If the ingestion job checks memtable key range before the
+      // key landing in memtable, the ingestion job may skip the necessary
+      // memtable flush.
+      // So wait here to ensure there is no pending write to memtable.
+      WaitForPendingWrites();
+    }
+
+    TEST_SYNC_POINT_CALLBACK("DBImpl::IngestExternalFile:AfterAllowWriteCheck",
+                             nullptr);
 
     num_running_ingest_file_ += static_cast<int>(num_cfs);
     TEST_SYNC_POINT("DBImpl::IngestExternalFile:AfterIncIngestFileCounter");
@@ -5954,7 +5970,7 @@ Status DBImpl::IngestExternalFiles(
         mutex_.Unlock();
         status = AtomicFlushMemTables(
             flush_opts, FlushReason::kExternalFileIngestion,
-            {} /* provided_candidate_cfds */, true /* entered_write_thread */);
+            {} /* provided_candidate_cfds */, !allow_write /* entered_write_thread */);
         mutex_.Lock();
       } else {
         for (size_t i = 0; i != num_cfs; ++i) {
@@ -5963,7 +5979,7 @@ Status DBImpl::IngestExternalFiles(
             status =
                 FlushMemTable(ingestion_jobs[i].GetColumnFamilyData(),
                               flush_opts, FlushReason::kExternalFileIngestion,
-                              true /* entered_write_thread */);
+                              !allow_write /* entered_write_thread */);
             mutex_.Lock();
             if (!status.ok()) {
               break;
@@ -6070,11 +6086,12 @@ Status DBImpl::IngestExternalFiles(
     }
 
     // Resume writes to the DB
-    if (two_write_queues_) {
-      nonmem_write_thread_.ExitUnbatched(&nonmem_w);
+    if (!allow_write) {
+      if (two_write_queues_) {
+        nonmem_write_thread_.ExitUnbatched(&nonmem_w);
+      }
+      write_thread_.ExitUnbatched(&w);
     }
-    write_thread_.ExitUnbatched(&w);
-    PERF_TIMER_STOP(file_ingestion_blocking_live_writes_nanos);
 
     if (status.ok()) {
       for (auto& job : ingestion_jobs) {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -2722,6 +2722,10 @@ struct IngestExternalFileOptions {
   //    reassigned).
   bool allow_db_generated_files = false;
 
+
+  // Set to TRUE if user wants to allow writes to the DB during ingestion.
+  // User must ensure no writes overlap with the ingested data.
+  bool allow_write = false;
   // Controls whether data and metadata blocks (e.g. index, filter) read during
   // file ingestion will be added to block cache.
   // Users may wish to set this to false when bulk loading into a CF that is not


### PR DESCRIPTION
Fixes: https://github.com/facebook/rocksdb/issues/14137

## Summary
This change adds `allow_write` to `IngestExternalFileOptions` so users can opt in to allowing writes during SST ingestion.

Previously ingest always entered write threads and blocked concurrent writes. With `allow_write=true`, ingestion can proceed without globally blocking write threads.

## What changed
In `DBImpl::IngestExternalFile`, when `allow_write=true`:
- skip entering write threads (`EnterUnbatched`)
- skip waiting for pending writes (`WaitForPendingWrites`)
- skip exiting write threads (`ExitUnbatched`)
- pass `!allow_write` to flush path where `entered_write_thread` is needed

Additional safety:
- validate that `allow_write` is consistent across all files in one ingest batch
- add the new option field in `IngestExternalFileOptions` (default `false`)

## Correctness notes
Using `allow_write=true` requires callers to ensure writes do not conflict with ingested key ranges.

## Test Plan
- Updated `external_sst_file_test.cc` cases to include the new option (default `false` behavior unchanged).
- Existing ingestion tests pass with the new option integrated.
