### PR TITLE
Fix AutoSkipCompressorWrapper with new logic

### DIFF
--- a/include/rocksdb/advanced_compression.h
+++ b/include/rocksdb/advanced_compression.h
@@ -125,7 +125,7 @@ class Compressor {
   // dictionary associated with a returned compressor must be read from
   // GetSerializedDict().
   virtual std::unique_ptr<Compressor> MaybeCloneSpecialized(
-      CacheEntryRole block_type, DictSampleArgs&& dict_samples) {
+      CacheEntryRole block_type, DictSampleArgs&& dict_samples) const {
     // Default implementation: no specialization
     (void)block_type;
     (void)dict_samples;
@@ -138,7 +138,7 @@ class Compressor {
   // A convenience function when a clone is needed and may or may not be
   // specialized.
   std::unique_ptr<Compressor> CloneMaybeSpecialized(
-      CacheEntryRole block_type, DictSampleArgs&& dict_samples) {
+      CacheEntryRole block_type, DictSampleArgs&& dict_samples) const {
     auto clone = MaybeCloneSpecialized(block_type, std::move(dict_samples));
     if (clone == nullptr) {
       clone = Clone();
@@ -496,7 +496,7 @@ class CompressorWrapper : public Compressor {
   // when the wrapped Compressor uses the default implementation of
   // MaybeCloneSpecialized(). This needs to be overridden if not.
   std::unique_ptr<Compressor> MaybeCloneSpecialized(
-      CacheEntryRole block_type, DictSampleArgs&& dict_samples) override {
+      CacheEntryRole block_type, DictSampleArgs&& dict_samples) const override {
     auto clone =
         wrapped_->MaybeCloneSpecialized(block_type, std::move(dict_samples));
     // Assert default no-op MaybeCloneSpecialized()

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -796,7 +796,7 @@ struct CompressorCustomAlg : public CompressorWrapper {
   }
 
   std::unique_ptr<Compressor> MaybeCloneSpecialized(
-      CacheEntryRole block_type, DictSampleArgs&& dict_samples) override {
+      CacheEntryRole block_type, DictSampleArgs&& dict_samples) const override {
     auto clone =
         wrapped_->CloneMaybeSpecialized(block_type, std::move(dict_samples));
     return std::make_unique<CompressorCustomAlg>(std::move(clone));

--- a/util/auto_tune_compressor.cc
+++ b/util/auto_tune_compressor.cc
@@ -63,6 +63,13 @@ std::unique_ptr<Compressor> AutoSkipCompressorWrapper::Clone() const {
   return std::make_unique<AutoSkipCompressorWrapper>(wrapped_->Clone(), opts_);
 }
 
+std::unique_ptr<Compressor> AutoSkipCompressorWrapper::MaybeCloneSpecialized(
+    CacheEntryRole block_type, DictSampleArgs&& dict_samples) const {
+  auto clone =
+      wrapped_->CloneMaybeSpecialized(block_type, std::move(dict_samples));
+  return std::make_unique<AutoSkipCompressorWrapper>(std::move(clone), opts_);
+}
+
 Status AutoSkipCompressorWrapper::CompressBlock(
     Slice uncompressed_data, char* compressed_output,
     size_t* compressed_output_size, CompressionType* out_compression_type,
@@ -198,7 +205,7 @@ CompressionType CostAwareCompressor::GetPreferredCompressionType() const {
   return kZSTD;
 }
 std::unique_ptr<Compressor> CostAwareCompressor::MaybeCloneSpecialized(
-    CacheEntryRole block_type, DictSampleArgs&& dict_samples) {
+    CacheEntryRole block_type, DictSampleArgs&& dict_samples) const {
   // TODO: full dictionary compression support. Currently this just falls
   // back on a non-multi compressor when asked to use a dictionary.
   auto idx = allcompressors_index_.back();

--- a/util/auto_tune_compressor.h
+++ b/util/auto_tune_compressor.h
@@ -65,6 +65,8 @@ class AutoSkipCompressorWrapper : public CompressorWrapper {
                                      const CompressionOptions& opts);
 
   std::unique_ptr<Compressor> Clone() const override;
+  std::unique_ptr<Compressor> MaybeCloneSpecialized(
+      CacheEntryRole block_type, DictSampleArgs&& dict_samples) const override;
   Status CompressBlock(Slice uncompressed_data, char* compressed_output,
                        size_t* compressed_output_size,
                        CompressionType* out_compression_type,
@@ -156,7 +158,7 @@ class CostAwareCompressor : public Compressor {
   CompressionType GetPreferredCompressionType() const override;
   ManagedWorkingArea ObtainWorkingArea() override;
   std::unique_ptr<Compressor> MaybeCloneSpecialized(
-      CacheEntryRole block_type, DictSampleArgs&& dict_samples) override;
+      CacheEntryRole block_type, DictSampleArgs&& dict_samples) const override;
 
   Status CompressBlock(Slice uncompressed_data, char* compressed_output,
                        size_t* compressed_output_size,

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -162,7 +162,7 @@ class CompressorBase : public Compressor {
   CompressionOptions opts_;
 };
 
-class BuiltinCompressorV1 : public CompressorBase {
+class BuiltinCompressorV1 final : public CompressorBase {
  public:
   const char* Name() const override { return "BuiltinCompressorV1"; }
 
@@ -236,7 +236,7 @@ class CompressorWithSimpleDictBase : public CompressorBase {
 
   std::unique_ptr<Compressor> MaybeCloneSpecialized(
       CacheEntryRole /*block_type*/,
-      DictSampleArgs&& dict_samples) final override {
+      DictSampleArgs&& dict_samples) const final override {
     assert(dict_samples.Verify());
     if (dict_samples.empty()) {
       // Nothing to specialize on
@@ -256,7 +256,7 @@ class CompressorWithSimpleDictBase : public CompressorBase {
 // NOTE: the legacy behavior is to pretend to use dictionary compression when
 // enabled, including storing a dictionary block, but to ignore it. That is
 // matched here.
-class BuiltinSnappyCompressorV2 : public CompressorWithSimpleDictBase {
+class BuiltinSnappyCompressorV2 final : public CompressorWithSimpleDictBase {
  public:
   using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
 
@@ -349,7 +349,7 @@ std::pair<char*, size_t> StartCompressBlockV2(Slice uncompressed_data,
   return {alg_output, alg_max_output_size};
 }
 
-class BuiltinZlibCompressorV2 : public CompressorWithSimpleDictBase {
+class BuiltinZlibCompressorV2 final : public CompressorWithSimpleDictBase {
  public:
   using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
 
@@ -448,7 +448,7 @@ class BuiltinZlibCompressorV2 : public CompressorWithSimpleDictBase {
   }
 };
 
-class BuiltinBZip2CompressorV2 : public CompressorWithSimpleDictBase {
+class BuiltinBZip2CompressorV2 final : public CompressorWithSimpleDictBase {
  public:
   using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
 
@@ -624,7 +624,8 @@ class BuiltinLZ4CompressorV2WithDict : public CompressorWithSimpleDictBase {
   }
 };
 
-class BuiltinLZ4CompressorV2NoDict : public BuiltinLZ4CompressorV2WithDict {
+class BuiltinLZ4CompressorV2NoDict final
+    : public BuiltinLZ4CompressorV2WithDict {
  public:
   BuiltinLZ4CompressorV2NoDict(const CompressionOptions& opts)
       : BuiltinLZ4CompressorV2WithDict(opts, /*dict_data=*/{}) {}
@@ -694,7 +695,7 @@ class BuiltinLZ4CompressorV2NoDict : public BuiltinLZ4CompressorV2WithDict {
   }
 };
 
-class BuiltinLZ4HCCompressorV2 : public CompressorWithSimpleDictBase {
+class BuiltinLZ4HCCompressorV2 final : public CompressorWithSimpleDictBase {
  public:
   using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
 
@@ -790,7 +791,7 @@ class BuiltinLZ4HCCompressorV2 : public CompressorWithSimpleDictBase {
   }
 };
 
-class BuiltinXpressCompressorV2 : public CompressorWithSimpleDictBase {
+class BuiltinXpressCompressorV2 final : public CompressorWithSimpleDictBase {
  public:
   using CompressorWithSimpleDictBase::CompressorWithSimpleDictBase;
 
@@ -840,7 +841,7 @@ class BuiltinXpressCompressorV2 : public CompressorWithSimpleDictBase {
   }
 };
 
-class BuiltinZSTDCompressorV2 : public CompressorBase {
+class BuiltinZSTDCompressorV2 final : public CompressorBase {
  public:
   explicit BuiltinZSTDCompressorV2(const CompressionOptions& opts,
                                    CompressionDict&& dict = {})
@@ -972,7 +973,8 @@ class BuiltinZSTDCompressorV2 : public CompressorBase {
   }
 
   std::unique_ptr<Compressor> MaybeCloneSpecialized(
-      CacheEntryRole /*block_type*/, DictSampleArgs&& dict_samples) override {
+      CacheEntryRole /*block_type*/,
+      DictSampleArgs&& dict_samples) const override {
     assert(dict_samples.Verify());
     if (dict_samples.empty()) {
       // Nothing to specialize on
@@ -1009,7 +1011,7 @@ class BuiltinZSTDCompressorV2 : public CompressorBase {
 
 // NOTE: this implementation is intentionally SIMPLE based on existing code
 // and NOT EFFICIENT because this is an old/deprecated format.
-class BuiltinDecompressorV1 : public Decompressor {
+class BuiltinDecompressorV1 final : public Decompressor {
  public:
   const char* Name() const override { return "BuiltinDecompressorV1"; }
 
@@ -1061,7 +1063,7 @@ class BuiltinDecompressorV1 : public Decompressor {
   }
 };
 
-class BuiltinCompressionManagerV1 : public CompressionManager {
+class BuiltinCompressionManagerV1 final : public CompressionManager {
  public:
   BuiltinCompressionManagerV1() = default;
   ~BuiltinCompressionManagerV1() override = default;
@@ -1384,7 +1386,7 @@ class BuiltinDecompressorV2 : public Decompressor {
   }
 };
 
-class BuiltinDecompressorV2SnappyOnly : public BuiltinDecompressorV2 {
+class BuiltinDecompressorV2SnappyOnly final : public BuiltinDecompressorV2 {
  public:
   const char* Name() const override {
     return "BuiltinDecompressorV2SnappyOnly";
@@ -1412,7 +1414,7 @@ class BuiltinDecompressorV2SnappyOnly : public BuiltinDecompressorV2 {
   }
 };
 
-class BuiltinDecompressorV2WithDict : public BuiltinDecompressorV2 {
+class BuiltinDecompressorV2WithDict final : public BuiltinDecompressorV2 {
  public:
   explicit BuiltinDecompressorV2WithDict(const Slice& dict) : dict_(dict) {}
 
@@ -1505,7 +1507,7 @@ class BuiltinDecompressorV2OptimizeZstd : public BuiltinDecompressorV2 {
                            std::unique_ptr<Decompressor>* /*out*/) override;
 };
 
-class BuiltinDecompressorV2OptimizeZstdWithDict
+class BuiltinDecompressorV2OptimizeZstdWithDict final
     : public BuiltinDecompressorV2OptimizeZstd {
  public:
   explicit BuiltinDecompressorV2OptimizeZstdWithDict(const Slice& dict)
@@ -1569,7 +1571,7 @@ Status BuiltinDecompressorV2OptimizeZstd::MaybeCloneForDict(
       serialized_dict);
   return Status::OK();
 }
-class BuiltinCompressionManagerV2 : public CompressionManager {
+class BuiltinCompressionManagerV2 final : public CompressionManager {
  public:
   BuiltinCompressionManagerV2() = default;
   ~BuiltinCompressionManagerV2() override = default;

--- a/util/simple_mixed_compressor.cc
+++ b/util/simple_mixed_compressor.cc
@@ -48,7 +48,7 @@ Compressor::ManagedWorkingArea MultiCompressorWrapper::ObtainWorkingArea() {
 }
 
 std::unique_ptr<Compressor> MultiCompressorWrapper::MaybeCloneSpecialized(
-    CacheEntryRole block_type, DictSampleArgs&& dict_samples) {
+    CacheEntryRole block_type, DictSampleArgs&& dict_samples) const {
   // TODO: full dictionary compression support. Currently this just falls
   // back on a non-multi compressor when asked to use a dictionary.
   return compressors_.back()->MaybeCloneSpecialized(block_type,

--- a/util/simple_mixed_compressor.h
+++ b/util/simple_mixed_compressor.h
@@ -25,7 +25,7 @@ class MultiCompressorWrapper : public Compressor {
   CompressionType GetPreferredCompressionType() const override;
   ManagedWorkingArea ObtainWorkingArea() override;
   std::unique_ptr<Compressor> MaybeCloneSpecialized(
-      CacheEntryRole block_type, DictSampleArgs&& dict_samples) override;
+      CacheEntryRole block_type, DictSampleArgs&& dict_samples) const override;
 
  protected:
   const CompressionOptions opts_;


### PR DESCRIPTION
Summary: ... from #14140. The assertion in the default implementation of CompressorWrapper::MaybeCloneSpecialized() could fail because this wrapper wasn't overriding it when it should. (See the NOTE on that implementation.)

Because this release already has a breaking modification to the Compressor API (adding Clone()), I took this opportunity to add 'const' to MaybeCloneSpecialized(). Also marked some compression classes as 'final' that could be marked as such.

Test Plan: unit test expanded to cover this case (verified failing before). Audited the rest of our CompressorWrappers.