### PR TITLE
Fix: Limit the sorting files based on max_compaction_jobs instead of kNumberFilesToSort to reduce write amplification

### DIFF
--- a/db/version_set.h
+++ b/db/version_set.h
@@ -184,7 +184,8 @@ class VersionStorageInfo {
   void AddBlobFile(std::shared_ptr<BlobFileMetaData> blob_file_meta);
 
   void PrepareForVersionAppend(const ImmutableOptions& immutable_options,
-                               const MutableCFOptions& mutable_cf_options);
+                               const MutableCFOptions& mutable_cf_options,
+                               uint32_t max_compation_job = 0);
 
   // REQUIRES: PrepareForVersionAppend has been called
   void SetFinalized();
@@ -648,7 +649,8 @@ class VersionStorageInfo {
   void CalculateBaseBytes(const ImmutableOptions& ioptions,
                           const MutableCFOptions& options);
   void UpdateFilesByCompactionPri(const ImmutableOptions& immutable_options,
-                                  const MutableCFOptions& mutable_cf_options);
+                                  const MutableCFOptions& mutable_cf_options,
+                                  uint32_t max_compaction_job);
 
   void GenerateFileIndexer() {
     file_indexer_.UpdateIndex(&arena_, num_non_empty_levels_, files_);


### PR DESCRIPTION
PR #10161 improves compaction performance by using a partial‑sorting mechanism that operates on a fixed number of files (kNumberFilesToSort). However, when the number of concurrent background compaction jobs exceeds kNumberFilesToSort, this strategy causes write amplification. The fix selects sorting files according to the max_compaction_jobs setting in order to mitigate write amplification and keep the performance.

Benchmarks with db_bench fillrandom demonstrate that, when max_compaction_jobs is configured to 128, write amplification is reduced by 25 % without performance degradation.