### PR TITLE
fix warnings

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2850,13 +2850,9 @@ void VersionStorageInfo::SetFinalized() {
     assert(MaxBytesForLevel(level) >= max_bytes_prev_level);
     max_bytes_prev_level = MaxBytesForLevel(level);
   }
-  int num_empty_non_l0_level = 0;
   for (int level = 0; level < num_levels(); level++) {
     assert(LevelFiles(level).size() == 0 ||
            LevelFiles(level).size() == LevelFilesBrief(level).num_files);
-    if (level > 0 && NumLevelBytes(level) > 0) {
-      num_empty_non_l0_level++;
-    }
     if (LevelFiles(level).size() > 0) {
       assert(level < num_non_empty_levels());
     }

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -102,6 +102,7 @@ struct MutableDBOptions {
   static const char* kName() { return "MutableDBOptions"; }
   MutableDBOptions();
   explicit MutableDBOptions(const MutableDBOptions& options) = default;
+  MutableDBOptions& operator=(const MutableDBOptions&) = default;
   explicit MutableDBOptions(const DBOptions& options);
 
   void Dump(Logger* log) const;

--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -403,6 +403,7 @@ Status Replayer::Replay() {
   ReadOptions roptions;
   Trace trace;
   uint64_t ops = 0;
+  (void)ops;  // Used for counting operations
   Iterator* single_iter = nullptr;
   while (s.ok()) {
     trace.reset();
@@ -542,6 +543,7 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
   WriteOptions woptions;
   ReadOptions roptions;
   uint64_t ops = 0;
+  (void)ops;  // Used for counting operations
   while (s.ok()) {
     std::unique_ptr<ReplayerWorkerArg> ra(new ReplayerWorkerArg);
     ra->db = db_;


### PR DESCRIPTION
Compiling in Mac gets this werror

```log
trace_replay/trace_replay.cc:405:12: error: variable 'ops' set but not used [-Werror,-Wunused-but-set-variable]
  uint64_t ops = 0;
           ^

./options/db_options.h:104:12: error: definition of implicit copy assignment operator for 'MutableDBOptions' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
  explicit MutableDBOptions(const MutableDBOptions& options) = default;
           ^
db/db_impl/db_impl.cc:1146:27: note: in implicit copy assignment operator for 'rocksdb::MutableDBOptions' first required here
      mutable_db_options_ = new_options;
```

Test Plan:

make test