### PR TITLE
fix: lib name match with NativeLibraryLoader ROCKSDB_LIBRARY_NAME value

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -121,7 +121,7 @@ public class RocksDB extends RocksObject {
       for (final String path : paths) {
         try {
           System.load(path + "/" +
-              Environment.getJniLibraryFileName("rocksdbjni"));
+              Environment.getJniLibraryFileName("rocksdb"));
           success = true;
           break;
         } catch (final UnsatisfiedLinkError e) {


### PR DESCRIPTION
Hi there,

Is it normal that this value is not the same as the ROCKSDB_LIBRARY_NAME in NativeLibraryLoader.java ?
This cause an error if you try to load the .so manually and then load RockDB, see example below : 

```java
String customDir = "/custom/path/";
NativeLibraryLoader.getInstance().loadLibrary(customDir);
RocksDB.loadLibrary(customDir);
```
- The NativeLibraryLoader.getInstance().loadLibrary(customDir) will load a file named `librocksdbjni-linux64.so`
- But the RocksDB.loadLibrary(customDir) will try to find `librocksdbjnijni-linux64.so` (NB: *jnijni*)

I assume it's not on purpose but let me now if there is a good reason for that !

And if you want to know why I need to load the .so manually : 
On securized linux environnement, the /tmp does not allow to dynamically link libs (see this message for more info : https://github.com/docker-flink/docker-flink/issues/46#issuecomment-408817762)
As I can't neither change that or change the java.io.tmpdir to an other path (because I want the rest of my temporary files to stay in the /tmp dir). I'm forced to load the .so manually.

Also I now that I could use the ROCKSDB_SHAREDLIB_DIR environnement variable, but I don't want that my code depends on environments values (for many reasons)


Edit: I find out that by calling RocksDB.loadLibrary() without the path, the function find out that the lib has already been loaded thanks to the "initialized" variable in the NativeLibraryLoader class.
```java
String customDir = "/custom/path/";
NativeLibraryLoader.getInstance().loadLibrary(customDir);
RocksDB.loadLibrary();
```