### PR TITLE
Surface MultiScan async read failure instead of asserting

### DIFF
--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -652,8 +652,6 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
             std::to_string(async_state->offset) + " and async callback " +
             std::to_string(req.offset));
       }
-    } else {
-      assert(async_state->status.IsAborted());
     }
   }
 


### PR DESCRIPTION
Crash tests have been failing of late with this assertion failure - db_stress: `./table/block_based/block_based_table_iterator.h:656: void rocksdb::BlockBasedTableIterator::PrepareReadAsyncCallBack(rocksdb::FSReadRequest &, void *): Assertion `async_state->status.IsAborted()' failed.` Instead of asserting, surface the failure status so we can troubleshoot.