### PR TITLE
Fix missing const for arg of OptionChangeMigration

### DIFF
--- a/include/rocksdb/utilities/option_change_migration.h
+++ b/include/rocksdb/utilities/option_change_migration.h
@@ -25,7 +25,7 @@ namespace ROCKSDB_NAMESPACE {
 // with `Options::compaction_options_fifo.max_table_files_size` > 0 can cause
 // the whole DB to be dropped right after migration if the migrated data is
 // larger than `max_table_files_size`
-Status OptionChangeMigration(std::string& dbname, const Options& old_opts,
+Status OptionChangeMigration(const std::string& dbname, const Options& old_opts,
                              const Options& new_opts);
 
 // Multi-CF version: Prepares a database with multiple column families to be

--- a/utilities/option_change_migration/option_change_migration.cc
+++ b/utilities/option_change_migration/option_change_migration.cc
@@ -341,7 +341,7 @@ Status OptionChangeMigration(
   return s;
 }
 
-Status OptionChangeMigration(std::string& dbname, const Options& old_opts,
+Status OptionChangeMigration(const std::string& dbname, const Options& old_opts,
                              const Options& new_opts) {
   DBOptions old_db_opts(old_opts);
   DBOptions new_db_opts(new_opts);


### PR DESCRIPTION
Summary:
Fix missing const for arg of OptionChangeMigration

We switched from std::string to std::string & for API OptionChangeMigration, which caused const qualifier to be lost at call site, which causes compilation failure.

Test Plan:
Unit test

Reviewers:

Subscribers:

Tasks:

Tags: