### PR TITLE
Revert change to existing OptionChangeMigration() API 

### DIFF
--- a/include/rocksdb/utilities/option_change_migration.h
+++ b/include/rocksdb/utilities/option_change_migration.h
@@ -25,7 +25,7 @@ namespace ROCKSDB_NAMESPACE {
 // with `Options::compaction_options_fifo.max_table_files_size` > 0 can cause
 // the whole DB to be dropped right after migration if the migrated data is
 // larger than `max_table_files_size`
-Status OptionChangeMigration(const std::string& dbname, const Options& old_opts,
+Status OptionChangeMigration(std::string dbname, const Options& old_opts,
                              const Options& new_opts);
 
 // Multi-CF version: Prepares a database with multiple column families to be

--- a/utilities/option_change_migration/option_change_migration.cc
+++ b/utilities/option_change_migration/option_change_migration.cc
@@ -341,7 +341,7 @@ Status OptionChangeMigration(
   return s;
 }
 
-Status OptionChangeMigration(const std::string& dbname, const Options& old_opts,
+Status OptionChangeMigration(std::string dbname, const Options& old_opts,
                              const Options& new_opts) {
   DBOptions old_db_opts(old_opts);
   DBOptions new_db_opts(new_opts);


### PR DESCRIPTION
**Context/Summary:**
https://github.com/facebook/rocksdb/pull/14059/files#diff-af82da51fd2cb4db9fef5625d8b86f26177d3036f9eb869b98b8498596bdee92 accidentally made a parameter became a reference in an existing OptionChangeMigration() while introducing a more generalized version of this API. This may cause trouble to existing users who have been copying a short-lived (even shorter than OptionChangeMigration() lifetime, though unlikely) string variable.

**Test:**
Existing tests 