### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/benchmark-linux.yml
+++ b/.github/workflows/benchmark-linux.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.repository_owner == 'facebook' }}
     runs-on: ubuntu-latest # FIXME: change this back to self-hosted when ready
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/build-for-benchmarks"
     - uses: "./.github/actions/perform-benchmarks"
     - uses: "./.github/actions/post-benchmarks"

--- a/.github/workflows/nightly-candidate.yml
+++ b/.github/workflows/nightly-candidate.yml
@@ -12,7 +12,7 @@ jobs:
       image: ubuntu-2004:202111-02
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/install-gflags"
     - run: make V=1 J=4 -j4 check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0 # Need full repo history
         fetch-tags: true
@@ -37,7 +37,7 @@ jobs:
     env:
       TEST_TMPDIR: "/tmp/rocksdb_test_tmp"
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: make V=1 -j32 check
     - uses: "./.github/actions/post-steps"
@@ -52,7 +52,7 @@ jobs:
       CC: clang-18
       CXX: clang++-18
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/setup-folly"
     - uses: "./.github/actions/build-folly"
@@ -66,7 +66,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/setup-folly"
     - uses: "./.github/actions/cache-folly"
@@ -84,7 +84,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/setup-folly"
     - run: "DEBUG_LEVEL=0 make -j20 build_folly"
@@ -98,14 +98,14 @@ jobs:
       CMAKE_GENERATOR: Visual Studio 17 2022
       CMAKE_PORTABLE: AVX2
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/windows-build-steps"
   build-linux-arm-test-full:
     if: ${{ github.repository_owner == 'facebook' }}
     runs-on:
       labels: 4-core-ubuntu-arm
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v6
       - uses: "./.github/actions/pre-steps"
       - run: sudo apt-get update && sudo apt-get install -y build-essential libgflags-dev
       - run: make V=1 J=4 -j4 check
@@ -115,7 +115,7 @@ jobs:
     runs-on:
       labels: 4-core-ubuntu-arm
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: sudo apt-get update && sudo apt-get install -y build-essential libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
     - run: sudo mount -o remount,size=16G /dev/shm
@@ -132,7 +132,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - name: Build examples
       run: make V=1 -j4 static_lib && cd examples && make V=1 -j4
@@ -145,7 +145,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:24.0
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - name: Build rocksdb lib
       run: CC=clang-18 CXX=clang++-18 USE_CLANG=1 make -j4 static_lib
@@ -160,7 +160,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/setup-folly"
     - run: "(mkdir build && cd build && cmake -DUSE_FOLLY_LITE=1 -DWITH_GFLAGS=1 -DCMAKE_CXX_FLAGS=-DGLOG_USE_GLOG_EXPORT .. && make VERBOSE=1 -j20 && ctest -j20)"

--- a/.github/workflows/pr-jobs-candidate.yml
+++ b/.github/workflows/pr-jobs-candidate.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:
       labels: arm64large # GitHub hosted ARM runners do not yet exist
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/install-gflags"
     - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make V=1 J=4 -j4 all_but_some_tests check_some
@@ -22,7 +22,7 @@ jobs:
     env:
       JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-arm64"
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/install-gflags"
     - name: Set Java Environment

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -33,13 +33,13 @@ jobs:
     if: ${{ github.repository_owner == 'facebook' }}
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0 # Need full checkout to determine merge base
         fetch-tags: true
     - uses: "./.github/actions/setup-upstream"
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
     - name: Install Dependencies
       run: python -m pip install --upgrade pip
     - name: Install argparse
@@ -69,7 +69,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: make V=1 J=32 -j32 check
     - uses: "./.github/actions/post-steps"
@@ -81,7 +81,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:24.0
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
     - name: Build cmake-mingw
@@ -100,7 +100,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/setup-folly"
     - uses: "./.github/actions/cache-folly"
@@ -118,7 +118,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/setup-folly"
     - run: USE_FOLLY_LITE=1 EXTRA_CXXFLAGS=-DGLOG_USE_GLOG_EXPORT V=1 make -j32 all
@@ -131,7 +131,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - uses: "./.github/actions/setup-folly"
     - uses: "./.github/actions/cache-folly"
@@ -149,7 +149,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: mkdir build && cd build && cmake -DWITH_GFLAGS=1 -DWITH_BENCHMARK=1 -DCMAKE_CXX_FLAGS=-DNROCKSDB_THREAD_STATUS .. && make VERBOSE=1 -j20 && ctest -j20
     - uses: "./.github/actions/post-steps"
@@ -161,7 +161,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: ENCRYPTED_ENV=1 ROCKSDB_DISABLE_SNAPPY=1 ROCKSDB_DISABLE_ZLIB=1 ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 make V=1 J=32 -j32 check
     - run: "./sst_dump --help | grep -E -q 'Supported built-in compression types: kNoCompression$' # Verify no compiled in compression\n"
@@ -175,7 +175,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - run: make V=1 -j32 LIB_MODE=shared release
     - run: ls librocksdb.so
     - run: "./trace_analyzer --version" # A tool dependent on gflags that can run in release build
@@ -201,7 +201,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     # FIXME: get back to "all microbench" targets
     - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 EXTRA_CXXFLAGS=-stdlib=libc++ EXTRA_LDFLAGS=-stdlib=libc++ make -j32 shared_lib
@@ -217,7 +217,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:24.0
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: CC=clang-18 CXX=clang++-18 USE_CLANG=1 make -j32 all microbench
     - run: make clean
@@ -231,7 +231,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:24.0
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: CC=gcc-14 CXX=g++-14 V=1 make -j32 all microbench
     - uses: "./.github/actions/post-steps"
@@ -245,14 +245,14 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:24.0
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: CC=clang-18 CXX=clang++-18 ROCKSDB_DISABLE_ALIGNED_NEW=1 CLANG_ANALYZER="/usr/bin/clang++-18" CLANG_SCAN_BUILD=scan-build-18 USE_CLANG=1 make V=1 -j32 analyze
     - uses: "./.github/actions/post-steps"
     - name: compress test report
       run: tar -cvzf scan_build_report.tar.gz scan_build_report
       if: failure()
-    - uses: actions/upload-artifact@v4.0.0
+    - uses: actions/upload-artifact@v6
       with:
         name: scan-build-report
         path: scan_build_report.tar.gz
@@ -264,7 +264,7 @@ jobs:
       image: gcc:latest
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - run: apt-get update -y && apt-get install -y libgflags-dev
     - name: Unity build
       run: make V=1 -j8 unity_test
@@ -278,7 +278,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: ulimit -S -n `ulimit -H -n` && make V=1 -j8 CRASH_TEST_EXT_ARGS='--duration=960 --max_key=2500000' blackbox_crash_test_with_atomic_flush
     - uses: "./.github/actions/post-steps"
@@ -291,7 +291,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:24.0
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: COMPILE_WITH_ASAN=1 COMPILE_WITH_UBSAN=1 CC=clang-18 CXX=clang++-18 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j40 check
     - uses: "./.github/actions/post-steps"
@@ -303,7 +303,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:24.0
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: COMPILE_WITH_TSAN=1 CC=clang-18 CXX=clang++-18 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j32 check
     - uses: "./.github/actions/post-steps"
@@ -315,7 +315,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: ASSERT_STATUS_CHECKED=1 TEST_UINT128_COMPAT=1 ROCKSDB_MODIFY_NPHASH=1 LIB_MODE=static OPT="-DROCKSDB_USE_STD_SEMAPHORES -DROCKSDB_NAMESPACE=alternative_rocksdb_ns" make V=1 -j24 check
     - uses: "./.github/actions/post-steps"
@@ -326,7 +326,7 @@ jobs:
     env:
       ROCKSDB_DISABLE_JEMALLOC: 1
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
@@ -344,7 +344,7 @@ jobs:
       matrix:
         run_sharded_tests: [0, 1, 2, 3]
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
@@ -377,7 +377,7 @@ jobs:
       CMAKE_GENERATOR: Visual Studio 17 2022
       CMAKE_PORTABLE: 1
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/windows-build-steps"
   # ============================ Java Jobs ============================ #
   build-linux-java:
@@ -449,7 +449,7 @@ jobs:
       JAVA_HOME: "/Library/Java/JavaVirtualMachines/liberica-jdk-8.jdk/Contents/Home"
       ROCKSDB_DISABLE_JEMALLOC: 1
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
@@ -471,7 +471,7 @@ jobs:
     env:
       JAVA_HOME: "/Library/Java/JavaVirtualMachines/liberica-jdk-8.jdk/Contents/Home"
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
@@ -493,7 +493,7 @@ jobs:
     env:
       JAVA_HOME: "/Library/Java/JavaVirtualMachines/liberica-jdk-8.jdk/Contents/Home"
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
@@ -517,7 +517,7 @@ jobs:
       image: evolvedbinary/rocksjava:alpine3_x64-be
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/install-maven"
     - uses: "./.github/actions/pre-steps"
     - name: Set Java Environment
@@ -527,11 +527,11 @@ jobs:
         which javac && javac -version
     - name: PMD RocksDBJava
       run: make V=1 J=8 -j8 jpmd
-    - uses: actions/upload-artifact@v4.0.0
+    - uses: actions/upload-artifact@v6
       with:
         name: pmd-report
         path: "${{ github.workspace }}/java/target/pmd.xml"
-    - uses: actions/upload-artifact@v4.0.0
+    - uses: actions/upload-artifact@v6
       with:
         name: maven-site
         path: "${{ github.workspace }}/java/target/site"
@@ -540,7 +540,7 @@ jobs:
     runs-on:
       labels: 4-core-ubuntu-arm
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v6
       - uses: "./.github/actions/pre-steps"
       - run: sudo apt-get update && sudo apt-get install -y build-essential
       - run: ROCKSDBTESTS_PLATFORM_DEPENDENT=only make V=1 J=4 -j4 all_but_some_tests check_some

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,7 +14,7 @@ jobs:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/pre-steps"
     - run: make V=1 -j20 valgrind_test
     - uses: "./.github/actions/post-steps"


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/setup-python` | [``](https://github.com/actions/setup-python/releases/tag/) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
