### PR TITLE
Disable multiscan+timestamp in crash test

### DIFF
--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1105,9 +1105,12 @@ class DB {
   // details. For optimal performance, ensure that either all entries in
   // scan_opts specify the range limit, or none of them do.
   //
-  // NOTE: iterate_upper_bound in ReadOptions will be ignored. Instead, the
-  // range.limit in ScanOptions is consulted to determine the upper bound key,
-  // if specified.
+  // NOTE: NOT YET SUPPORTED in DBs using user timestamp (see
+  // Comparator::timestamp_size())
+  //
+  // NOTE: iterate_upper_bound in ReadOptions will
+  // be ignored. Instead, the range.limit in ScanOptions is consulted to
+  // determine the upper bound key, if specified.
   //
   // Example usage -
   //  std::vector<ScanOptions> scans{{.start = Slice("bar")},

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -692,6 +692,8 @@ ts_params = {
     # Below flag is randomly picked once and kept consistent in following runs.
     "persist_user_defined_timestamps": random.choice([0, 1, 1]),
     "use_merge": 0,
+    # Causing failures and not yet compatible
+    "use_multiscan": 0,
     "use_full_merge_v1": 0,
     "use_txn": 0,
     "ingest_external_file_one_in": 0,


### PR DESCRIPTION
Summary: Causing failures and not yet supported. Also putting a note in db.h about the combination being unsupported.

Test Plan: started up blackbox_crash_test_with_ts many times and checked command line to be confident it's excluded.