### PR TITLE
fix: checkpoint log_size_for_flush parameter ignored due to empty WAL file list

### DIFF
--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -52,7 +52,13 @@ Status WalManager::GetSortedWalFiles(VectorWalPtr& files, bool need_seqnos,
   VectorWalPtr logs;
   s = GetSortedWalsOfType(wal_dir_, logs, kAliveLogFile, need_seqnos);
 
-  if (!include_archived || !s.ok()) {
+  if (!s.ok()) {
+    return s;
+  }
+
+  if (!include_archived) {
+    // Return only the live logs without archived logs
+    files = std::move(logs);
     return s;
   }
 


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                            
  The log_size_for_flush parameter in CreateCheckpoint() was completely non-functional. When set to a non-zero value, it should trigger a flush only when the total WAL size exceeds the threshold. Instead, flushes were never triggered regardless of WAL size, causing checkpoints to always include WAL files instead of flushing data to SST files.
                                                                                                                                                                                                                                            
  This breaks the documented API contract and prevents users from controlling checkpoint behavior. Applications relying on log_size_for_flush to ensure checkpoints contain flushed SST data (for faster recovery or smaller checkpoint sizes) were silently getting WAL-based checkpoints instead.
                                                                                                                                                                                                                                            
## Root Cause                                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
  In WalManager::GetSortedWalFiles(), when called with include_archived=false, the function returned early without copying the live WAL files to the output vector:                                                                         
                                                                                                                                                                                                                                            
  ```
// Before (buggy)                                                                                                                                                                                                                         
  s = GetSortedWalsOfType(wal_dir_, logs, kAliveLogFile, need_seqnos);                                                                                                                                                                      
  if (!include_archived || !s.ok()) {                                                                                                                                                                                                       
      return s;  // Returns without populating 'files'!                                                                                                                                                                                     
  }  
```                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                            
  This caused GetLiveFilesStorageInfo() to calculate WAL size as 0, so the condition 0 < log_size_for_flush was always true, skipping the flush.  
  
## Fix                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                            
  Return the live WAL files before the early return when include_archived=false:                                                                                                                                                            
                                                                                                                                                                                                                                            
  ```
// After (fixed)                                                                                                                                                                                                                          
  if (!s.ok()) {                                                                                                                                                                                                                            
      return s;                                                                                                                                                                                                                             
  }                                                                                                                                                                                                                                         
  if (!include_archived) {                                                                                                                                                                                                                  
      files = std::move(logs);                                                                                                                                                                                                              
      return s;                                                                                                                                                                                                                             
  }            
```