### PR TITLE
Support Delete Direct along the same lines as PutDirect in SstFileWriter

### DIFF
--- a/java/rocksjni/sst_file_writerjni.cc
+++ b/java/rocksjni/sst_file_writerjni.cc
@@ -285,6 +285,25 @@ void Java_org_rocksdb_SstFileWriter_delete__JJ(JNIEnv *env, jclass /*jcls*/,
 
 /*
  * Class:     org_rocksdb_SstFileWriter
+ * Method:    deleteDirect
+ * Signature: (JLjava/nio/ByteBuffer;IIL)V
+ */
+void Java_org_rocksdb_SstFileWriter_deleteDirect(JNIEnv *env, jclass /*jcls*/,
+                                              jlong jdb_handle, jobject jkey,
+                                              jint jkey_off, jint jkey_len) {
+  auto *writer = reinterpret_cast<ROCKSDB_NAMESPACE::SstFileWriter *>(jdb_handle);
+  auto Delete = [&env, &writer](ROCKSDB_NAMESPACE::Slice &key) {
+      ROCKSDB_NAMESPACE::Status s = writer->Delete(key);
+      if (s.ok()) {
+        return;
+      }
+      ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
+  };
+  ROCKSDB_NAMESPACE::JniUtil::k_op_direct(Delete, env, jkey, jkey_off, jkey_len);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileWriter
  * Method:    finish
  * Signature: (J)V
  */

--- a/java/src/main/java/org/rocksdb/SstFileWriter.java
+++ b/java/src/main/java/org/rocksdb/SstFileWriter.java
@@ -151,6 +151,20 @@ public class SstFileWriter extends RocksObject {
   }
 
   /**
+   * Add a Delete key with value to currently opened file.
+   *
+   * @param key the specified key to be inserted.
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public void delete(final ByteBuffer key) throws RocksDBException {
+    assert key.isDirect();
+    deleteDirect(nativeHandle_, key, key.position(), key.remaining());
+    key.position(key.limit());
+  }
+
+  /**
    * Add a deletion key to currently opened file.
    *
    * @param key the specified key to be deleted.
@@ -226,6 +240,9 @@ public class SstFileWriter extends RocksObject {
       throws RocksDBException;
 
   private static native void delete(final long handle, final byte[] key) throws RocksDBException;
+
+  private static native void deleteDirect(long handle, ByteBuffer key, int keyOffset, int keyLength)
+      throws RocksDBException;
 
   private static native void finish(final long handle) throws RocksDBException;
 


### PR DESCRIPTION
Support DeleteDirect in SstFileWriter along the same lines as putDirect. Apache Ozone heavily relies on direct buffer APIs for rocksdb level optimizations. This would be a good addition to the already supported APIs.