### PR TITLE
Support DeleteRangeDirect and WriteBatch DeleteRangeDirect along the same lines as PutDirect and WriteBatch PutDirect

### DIFF
--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -436,6 +436,32 @@ void Java_org_rocksdb_WriteBatch_deleteRangeJni__J_3BI_3BIJ(
 
 /*
  * Class:     org_rocksdb_WriteBatch
+ * Method:    deleteRangeDirect
+ * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)V
+ */
+void Java_org_rocksdb_WriteBatch_deleteRangeDirectJni(JNIEnv* env, jclass /*jobj*/,
+                                                      jlong jwb_handle, jobject jbegin_key,
+                                                      jint jbegin_key_offset, jint jbegin_key_len,
+                                                      jobject jend_key, jint jend_key_offset,
+                                                      jint jend_key_len, jlong jcf_handle) {
+  auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
+  assert(wb != nullptr);
+  auto* cf_handle =
+          reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+  auto put = [&wb, &cf_handle](ROCKSDB_NAMESPACE::Slice& begin_key,
+                               ROCKSDB_NAMESPACE::Slice& end_key) {
+      if (cf_handle == nullptr) {
+        wb->DeleteRange(begin_key, end_key);
+      } else {
+        wb->DeleteRange(cf_handle, begin_key, end_key);
+      }
+  };
+  ROCKSDB_NAMESPACE::JniUtil::kv_op_direct(
+          put, env, jbegin_key, jbegin_key_offset, jbegin_key_len, jend_key, jend_key_offset, jend_key_len);
+}
+
+/*
+ * Class:     org_rocksdb_WriteBatch
  * Method:    putLogData
  * Signature: (J[BI)V
  */

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -372,6 +372,31 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRangeJni__J_3BI_3BIJ(
 
 /*
  * Class:     org_rocksdb_WriteBatchWithIndex
+ * Method:    deleteRangeDirect
+ * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IIJ)V
+ */
+void Java_org_rocksdb_WriteBatchWithIndex_deleteRangeDirectJni(
+        JNIEnv* env, jclass /*jobj*/, jlong jwb_handle, jobject jbegin_key,
+        jint jbegin_key_offset, jint jbegin_key_len, jobject jend_key, jint jend_key_offset,
+        jint jend_key_len, jlong jcf_handle) {
+  auto* wb = reinterpret_cast<ROCKSDB_NAMESPACE::WriteBatch*>(jwb_handle);
+  assert(wb != nullptr);
+  auto* cf_handle =
+          reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+  auto put = [&wb, &cf_handle](ROCKSDB_NAMESPACE::Slice& begin_key,
+                               ROCKSDB_NAMESPACE::Slice& end_key) {
+      if (cf_handle == nullptr) {
+        wb->DeleteRange(begin_key, end_key);
+      } else {
+        wb->DeleteRange(cf_handle, begin_key, end_key);
+      }
+  };
+  ROCKSDB_NAMESPACE::JniUtil::kv_op_direct(
+          put, env, jbegin_key, jbegin_key_offset, jbegin_key_len, jend_key, jend_key_offset, jend_key_len);
+}
+
+/*
+ * Class:     org_rocksdb_WriteBatchWithIndex
  * Method:    putLogData
  * Signature: (J[BI)V
  */

--- a/java/src/main/java/org/rocksdb/AbstractWriteBatch.java
+++ b/java/src/main/java/org/rocksdb/AbstractWriteBatch.java
@@ -111,6 +111,25 @@ public abstract class AbstractWriteBatch extends RocksObject
   }
 
   @Override
+  public void deleteRange(ByteBuffer beginKey, ByteBuffer endKey) throws RocksDBException {
+    assert beginKey.isDirect() && endKey.isDirect();
+    deleteRangeDirect(nativeHandle_, beginKey, beginKey.position(), beginKey.remaining(), endKey, endKey.position(),
+        endKey.remaining(), 0);
+    beginKey.position(beginKey.limit());
+    endKey.position(endKey.limit());
+  }
+
+  @Override
+  public void deleteRange(ColumnFamilyHandle columnFamilyHandle, ByteBuffer beginKey, ByteBuffer endKey)
+      throws RocksDBException {
+    assert beginKey.isDirect() && endKey.isDirect();
+    deleteRangeDirect(nativeHandle_, beginKey, beginKey.position(), beginKey.remaining(), endKey, endKey.position(),
+        endKey.remaining(), columnFamilyHandle.nativeHandle_);
+    beginKey.position(beginKey.limit());
+    endKey.position(endKey.limit());
+  }
+
+  @Override
   public void putLogData(final byte[] blob) throws RocksDBException {
     putLogData(nativeHandle_, blob, blob.length);
   }
@@ -185,6 +204,10 @@ public abstract class AbstractWriteBatch extends RocksObject
 
   abstract void deleteRange(final long handle, final byte[] beginKey, final int beginKeyLen,
       final byte[] endKey, final int endKeyLen, final long cfHandle) throws RocksDBException;
+
+  abstract void deleteRangeDirect(final long handle, final ByteBuffer beginKey, final int beginKeyOffset,
+      final int beginKeyLength, final ByteBuffer endKey, final int endKeyOffset, final int endKeyValue,
+      final long cfHandle);
 
   abstract void putLogData(final long handle, final byte[] blob,
       final int blobLen) throws RocksDBException;

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -1580,6 +1580,59 @@ public class RocksDB extends RocksObject {
         columnFamilyHandle.nativeHandle_);
   }
 
+  /**
+   * Removes the database entries in the range ["beginKey", "endKey"), i.e.,
+   * including "beginKey" and excluding "endKey". a non-OK status on error. It
+   * is not an error if no keys exist in the range ["beginKey", "endKey").
+   * <p>
+   * Delete the database entry (if any) for "key". Returns OK on success, and a
+   * non-OK status on error. It is not an error if "key" did not exist in the
+   * database.
+   *
+   * @param beginKey First key to delete within database (inclusive)
+   * @param endKey Last key to delete within database (exclusive)
+   *
+   * @throws RocksDBException thrown if error happens in underlying native
+   *     library.
+   */
+  public void deleteRange(final WriteOptions writeOpt,
+      final ByteBuffer beginKey, final ByteBuffer endKey) throws RocksDBException {
+    assert beginKey.isDirect() && endKey.isDirect();
+    if (beginKey.isDirect() && endKey.isDirect()) {
+      deleteRangeDirect(nativeHandle_, writeOpt.nativeHandle_, beginKey, beginKey.position(), beginKey.remaining(), endKey,
+          endKey.position(), endKey.remaining(), 0);
+    }
+    beginKey.position(beginKey.limit());
+    endKey.position(endKey.limit());
+  }
+
+  /**
+   * Removes the database entries in the range ["beginKey", "endKey"), i.e.,
+   * including "beginKey" and excluding "endKey". a non-OK status on error. It
+   * is not an error if no keys exist in the range ["beginKey", "endKey").
+   * <p>
+   * Delete the database entry (if any) for "key". Returns OK on success, and a
+   * non-OK status on error. It is not an error if "key" did not exist in the
+   * database.
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle} instance
+   * @param beginKey First key to delete within database (inclusive)
+   * @param endKey Last key to delete within database (exclusive)
+   *
+   * @throws RocksDBException thrown if error happens in underlying native
+   *     library.
+   */
+  public void deleteRange(final ColumnFamilyHandle columnFamilyHandle, final WriteOptions writeOpt,
+      final ByteBuffer beginKey, final ByteBuffer endKey) throws RocksDBException {
+    assert beginKey.isDirect() && endKey.isDirect();
+    if (beginKey.isDirect() && endKey.isDirect()) {
+      deleteRangeDirect(nativeHandle_, writeOpt.nativeHandle_, beginKey, beginKey.position(), beginKey.remaining(), endKey,
+          endKey.position(), endKey.remaining(), columnFamilyHandle.nativeHandle_);
+    }
+    beginKey.position(beginKey.limit());
+    endKey.position(endKey.limit());
+  }
+
 
   /**
    * Add merge operand for key/value pair.
@@ -4913,6 +4966,9 @@ public class RocksDB extends RocksObject {
       final byte[] beginKey, final int beginKeyOffset, final int beginKeyLength,
       final byte[] endKey, final int endKeyOffset, final int endKeyLength, final long cfHandle)
       throws RocksDBException;
+  private static native void deleteRangeDirect(long handle, long writeOptHandle, ByteBuffer key,
+      int keyOffset, int keyLength, ByteBuffer value, int valueOffset, int valueLength,
+      long cfHandle) throws RocksDBException;
   private static native void clipColumnFamily(final long handle, final long cfHandle,
       final byte[] beginKey, final int beginKeyOffset, final int beginKeyLength,
       final byte[] endKey, final int endKeyOffset, final int endKeyLength) throws RocksDBException;

--- a/java/src/main/java/org/rocksdb/WriteBatch.java
+++ b/java/src/main/java/org/rocksdb/WriteBatch.java
@@ -333,6 +333,17 @@ public class WriteBatch extends AbstractWriteBatch {
       final int beginKeyLen, final byte[] endKey, final int endKeyLen, final long cfHandle);
 
   @Override
+  final void deleteRangeDirect(final long handle, final ByteBuffer beginKey, final int beginKeyOffset,
+      final int beginKeyLength, final ByteBuffer endKey, final int endKeyOffset, final int endKeyValue,
+      final long cfHandle) {
+    deleteRangeDirectJni(handle, beginKey, beginKeyOffset, beginKeyLength, endKey, endKeyOffset, endKeyValue, cfHandle);
+  }
+
+  private static native void deleteRangeDirectJni(final long handle, final ByteBuffer key,
+      final int keyOffset, final int keyLength, final ByteBuffer value, final int valueOffset,
+      final int valueLength, final long cfHandle);
+
+  @Override
   final void putLogData(final long handle, final byte[] blob, final int blobLen)
       throws RocksDBException {
     putLogDataJni(handle, blob, blobLen);

--- a/java/src/main/java/org/rocksdb/WriteBatchInterface.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchInterface.java
@@ -219,6 +219,42 @@ public interface WriteBatchInterface {
         throws RocksDBException;
 
     /**
+     * Removes the database entries in the range ["beginKey", "endKey"), i.e.,
+     * including "beginKey" and excluding "endKey". a non-OK status on error. It
+     * is not an error if no keys exist in the range ["beginKey", "endKey").
+     * <p>
+     * Delete the database entry (if any) for "key". Returns OK on success, and a
+     * non-OK status on error. It is not an error if "key" did not exist in the
+     * database.
+     *
+     * @param beginKey
+     *          First key to delete within database (included)
+     * @param endKey
+     *          Last key to delete within database (excluded)
+     * @throws RocksDBException thrown if error happens in underlying native library.
+     */
+    void deleteRange(ByteBuffer beginKey, ByteBuffer endKey) throws RocksDBException;
+
+    /**
+     * Removes the database entries in the range ["beginKey", "endKey"), i.e.,
+     * including "beginKey" and excluding "endKey". a non-OK status on error. It
+     * is not an error if no keys exist in the range ["beginKey", "endKey").
+     * <p>
+     * Delete the database entry (if any) for "key". Returns OK on success, and a
+     * non-OK status on error. It is not an error if "key" did not exist in the
+     * database.
+     *
+     * @param columnFamilyHandle {@link ColumnFamilyHandle} instance
+     * @param beginKey
+     *          First key to delete within database (included)
+     * @param endKey
+     *          Last key to delete within database (excluded)
+     * @throws RocksDBException thrown if error happens in underlying native library.
+     */
+    void deleteRange(ColumnFamilyHandle columnFamilyHandle, ByteBuffer beginKey, ByteBuffer endKey)
+        throws RocksDBException;
+
+    /**
      * Append a blob of arbitrary size to the records in this batch. The blob will
      * be stored in the transaction log but not in any other file. In particular,
      * it will not be persisted to the SST files. When iterating over this

--- a/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
@@ -409,6 +409,17 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
     deleteRangeJni(handle, beginKey, beginKeyLen, endKey, endKeyLen, cfHandle);
   }
 
+  @Override
+  final void deleteRangeDirect(final long handle, final ByteBuffer beginKey, final int beginKeyOffset,
+      final int beginKeyLength, final ByteBuffer endKey, final int endKeyOffset, final int endKeyLength,
+      final long cfHandle) {
+    deleteRangeDirectJni(handle, beginKey, beginKeyOffset, beginKeyLength, endKey, endKeyOffset, endKeyLength, cfHandle);
+  }
+
+  private static native void deleteRangeDirectJni(final long handle, final ByteBuffer beginKey,
+      final int beginKeyOffset, final int beginKeyLength, final ByteBuffer endKey, final int endKeyOffset,
+      final int endKeyLength, final long cfHandle);
+
   private static native void deleteRangeJni(final long handle, final byte[] beginKey,
       final int beginKeyLen, final byte[] endKey, final int endKeyLen, final long cfHandle);
 

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -626,6 +626,29 @@ public class RocksDBTest {
   }
 
   @Test
+  public void deleteRangeWithByteBuffer() throws RocksDBException {
+    try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath())) {
+      db.put("key1".getBytes(), "value".getBytes());
+      db.put("key2".getBytes(), "12345678".getBytes());
+      db.put("key3".getBytes(), "abcdefg".getBytes());
+      db.put("key4".getBytes(), "xyz".getBytes());
+      assertThat(db.get("key1".getBytes())).isEqualTo("value".getBytes());
+      assertThat(db.get("key2".getBytes())).isEqualTo("12345678".getBytes());
+      assertThat(db.get("key3".getBytes())).isEqualTo("abcdefg".getBytes());
+      assertThat(db.get("key4".getBytes())).isEqualTo("xyz".getBytes());
+      ByteBuffer startKey = ByteBuffer.allocateDirect(128);
+      startKey.put("key2".getBytes()).flip();
+      ByteBuffer endKey = ByteBuffer.allocateDirect(128);
+      endKey.put("key4".getBytes()).flip();
+      db.deleteRange(new WriteOptions(), startKey, endKey);
+      assertThat(db.get("key1".getBytes())).isEqualTo("value".getBytes());
+      assertThat(db.get("key2".getBytes())).isNull();
+      assertThat(db.get("key3".getBytes())).isNull();
+      assertThat(db.get("key4".getBytes())).isEqualTo("xyz".getBytes());
+    }
+  }
+
+  @Test
   public void clipColumnFamily() throws RocksDBException {
     try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath())) {
       db.put("key1".getBytes(), "value".getBytes());

--- a/java/src/test/java/org/rocksdb/WriteBatchTest.java
+++ b/java/src/test/java/org/rocksdb/WriteBatchTest.java
@@ -241,6 +241,33 @@ public class WriteBatchTest {
   }
 
   @Test
+  public void deleteRangeWithByteBuffer() throws RocksDBException {
+    try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath());
+         final WriteBatch batch = new WriteBatch();
+         final WriteOptions wOpt = new WriteOptions()) {
+      db.put("key1".getBytes(), "value".getBytes());
+      db.put("key2".getBytes(), "12345678".getBytes());
+      db.put("key3".getBytes(), "abcdefg".getBytes());
+      db.put("key4".getBytes(), "xyz".getBytes());
+      assertThat(db.get("key1".getBytes())).isEqualTo("value".getBytes());
+      assertThat(db.get("key2".getBytes())).isEqualTo("12345678".getBytes());
+      assertThat(db.get("key3".getBytes())).isEqualTo("abcdefg".getBytes());
+      assertThat(db.get("key4".getBytes())).isEqualTo("xyz".getBytes());
+      ByteBuffer beginKey = ByteBuffer.allocateDirect(128);
+      beginKey.put("key2".getBytes()).flip();
+      ByteBuffer endKey = ByteBuffer.allocateDirect(128);
+      endKey.put("key4".getBytes()).flip();
+      batch.deleteRange(beginKey, endKey);
+      db.write(wOpt, batch);
+
+      assertThat(db.get("key1".getBytes())).isEqualTo("value".getBytes());
+      assertThat(db.get("key2".getBytes())).isNull();
+      assertThat(db.get("key3".getBytes())).isNull();
+      assertThat(db.get("key4".getBytes())).isEqualTo("xyz".getBytes());
+    }
+  }
+
+  @Test
   public void restorePoints() throws RocksDBException {
     try (final WriteBatch batch = new WriteBatch()) {
 


### PR DESCRIPTION
Support deleteRangeDirect and deleteRangeDirect in writeBatch similar to the putDirect implementation in WriteBatch and RocksDB class