### PR TITLE
Add optional `getdents64(2)` syscall bypass in read-only open

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -4404,6 +4404,16 @@ unsigned char rocksdb_options_get_skip_checking_sst_file_sizes_on_db_open(
   return opt->rep.skip_checking_sst_file_sizes_on_db_open;
 }
 
+void rocksdb_options_set_skip_directory_scan_on_readonly_db_open(
+    rocksdb_options_t* opt, unsigned char val) {
+  opt->rep.skip_directory_scan_on_readonly_db_open = val;
+}
+
+unsigned char rocksdb_options_get_skip_directory_scan_on_readonly_db_open(
+    rocksdb_options_t* opt) {
+  return opt->rep.skip_directory_scan_on_readonly_db_open;
+}
+
 /* Blob Options Settings */
 void rocksdb_options_set_enable_blob_files(rocksdb_options_t* opt,
                                            unsigned char val) {

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -723,7 +723,9 @@ Status DBImpl::Recover(
     // attention to it in case we are recovering a database
     // produced by an older version of rocksdb.
     auto wal_dir = immutable_db_options_.GetWalDir();
-    if (!immutable_db_options_.best_efforts_recovery) {
+    if (!immutable_db_options_.best_efforts_recovery &&
+        !(read_only &&
+          immutable_db_options_.skip_directory_scan_on_readonly_db_open)) {
       IOOptions io_opts;
       io_opts.do_not_recurse = true;
       s = immutable_db_options_.fs->GetChildren(
@@ -824,7 +826,8 @@ Status DBImpl::Recover(
     }
   }
 
-  if (read_only) {
+  if (read_only &&
+      !immutable_db_options_.skip_directory_scan_on_readonly_db_open) {
     // If we are opening as read-only, we need to update options_file_number_
     // to reflect the most recent OPTIONS file. It does not matter for regular
     // read-write db instance because options_file_number_ will later be

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1621,6 +1621,12 @@ rocksdb_options_set_skip_checking_sst_file_sizes_on_db_open(
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_options_get_skip_checking_sst_file_sizes_on_db_open(
     rocksdb_options_t* opt);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_skip_directory_scan_on_readonly_db_open(
+    rocksdb_options_t* opt, unsigned char val);
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_options_get_skip_directory_scan_on_readonly_db_open(
+    rocksdb_options_t* opt);
 
 /* Blob Options Settings */
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_enable_blob_files(

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1373,6 +1373,19 @@ struct DBOptions {
   // Default: false
   bool skip_checking_sst_file_sizes_on_db_open = false;
 
+  // If true, skip directory listing operations (readdir/getdents64) during
+  // read-only database open. Use this for file systems that do not support
+  // directory listing.
+  //
+  // When enabled, WAL directory scanning is skipped. This is safe for any
+  // database that was closed cleanly or flushed before being opened
+  // read-only.
+  //
+  // Only affects DB::OpenForReadOnly(); ignored for read-write opens.
+  //
+  // Default: false
+  bool skip_directory_scan_on_readonly_db_open = false;
+
   // Recovery mode to control the consistency while replaying WAL
   // Default: kPointInTimeRecovery
   WALRecoveryMode wal_recovery_mode = WALRecoveryMode::kPointInTimeRecovery;

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -1985,6 +1985,30 @@ jboolean Java_org_rocksdb_Options_skipCheckingSstFileSizesOnDbOpen(
 
 /*
  * Class:     org_rocksdb_Options
+ * Method:    setSkipDirectoryScanOnReadOnlyDbOpen
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_Options_setSkipDirectoryScanOnReadOnlyDbOpen(
+    JNIEnv*, jclass, jlong jhandle,
+    jboolean jskip_directory_scan_on_read_only_db_open) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->skip_directory_scan_on_readonly_db_open =
+      static_cast<bool>(jskip_directory_scan_on_read_only_db_open);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    skipDirectoryScanOnReadOnlyDbOpen
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_Options_skipDirectoryScanOnReadOnlyDbOpen(
+    JNIEnv*, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jboolean>(opt->skip_directory_scan_on_readonly_db_open);
+}
+
+/*
+ * Class:     org_rocksdb_Options
  * Method:    setWalRecoveryMode
  * Signature: (JB)V
  */

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -263,6 +263,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    skip_checking_sst_file_sizes_on_db_open),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"skip_directory_scan_on_readonly_db_open",
+         {offsetof(struct ImmutableDBOptions,
+                   skip_directory_scan_on_readonly_db_open),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         {"new_table_reader_for_compaction_inputs",
          {0, OptionType::kBoolean, OptionVerificationType::kDeprecated,
           OptionTypeFlags::kNone}},
@@ -769,6 +774,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       skip_stats_update_on_db_open(options.skip_stats_update_on_db_open),
       skip_checking_sst_file_sizes_on_db_open(
           options.skip_checking_sst_file_sizes_on_db_open),
+      skip_directory_scan_on_readonly_db_open(
+          options.skip_directory_scan_on_readonly_db_open),
       wal_recovery_mode(options.wal_recovery_mode),
       allow_2pc(options.allow_2pc),
       row_cache(options.row_cache),

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -71,6 +71,7 @@ struct ImmutableDBOptions {
   uint64_t write_thread_slow_yield_usec;
   bool skip_stats_update_on_db_open;
   bool skip_checking_sst_file_sizes_on_db_open;
+  bool skip_directory_scan_on_readonly_db_open;
   WALRecoveryMode wal_recovery_mode;
   bool allow_2pc;
   std::shared_ptr<Cache> row_cache;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -151,6 +151,8 @@ void BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.skip_stats_update_on_db_open;
   options.skip_checking_sst_file_sizes_on_db_open =
       immutable_db_options.skip_checking_sst_file_sizes_on_db_open;
+  options.skip_directory_scan_on_readonly_db_open =
+      immutable_db_options.skip_directory_scan_on_readonly_db_open;
   options.wal_recovery_mode = immutable_db_options.wal_recovery_mode;
   options.allow_2pc = immutable_db_options.allow_2pc;
   options.row_cache = immutable_db_options.row_cache;

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -744,6 +744,23 @@ class StringFS : public FileSystemWrapper {
   std::unordered_map<std::string, std::string> files_;
 };
 
+// Filesystem wrapper that rejects directory listing operations (GetChildren).
+// Used for testing skip_directory_scan_on_readonly_db_open option.
+class NoReaddirFS : public FileSystemWrapper {
+ public:
+  explicit NoReaddirFS(const std::shared_ptr<FileSystem>& base)
+      : FileSystemWrapper(base) {}
+
+  static const char* kClassName() { return "NoReaddirFS"; }
+  const char* Name() const override { return kClassName(); }
+
+  IOStatus GetChildren(const std::string& /*dir*/, const IOOptions& /*opts*/,
+                       std::vector<std::string>* /*result*/,
+                       IODebugContext* /*dbg*/) override {
+    return IOStatus::NotSupported("Directory listing not supported");
+  }
+};
+
 // A compressor that essentially implements a custom compression algorithm
 // by leveraging an existing compression algorithm and putting a custom header
 // on it to detect any attempts to decompress it with the wrong compression


### PR DESCRIPTION
I am trying to use RocksDB in ReadOnly mode with a POSIX file system that does not correctly support `open(2)` with `O_DIRECTORY` or `getdents64()` syscalls. As a result, I see ReadOnly database open failures relating to the file system reporting non-zero exit code for `getdents64(2)`:

Example strace output:
```
[pid 1121067] openat(AT_FDCWD, "/path/to/rocksdb-backup/", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 3 <0.000280>
[pid 1121067] newfstatat(3, "", {st_mode=S_IFDIR|0777, st_size=0, ...}, AT_EMPTY_PATH) = 0 <0.000005>
[pid 1121067] getdents64(3, 0x58dd5cb5b140, 32768) = -1 EOPNOTSUPP (Operation not supported) <0.000049>
```

Looking at the ReadOnly open code, it seems the `getdents64(2)` and `open(2)` are byproducts of [GetChildren()](https://github.com/facebook/rocksdb/blob/e77ba4bc95a3ad06fa87a14d7b6d9fc64f4fd0eb/env/fs_posix.cc#L577), which calls `opendir(3)` and `readdir(3)` to range over the database directory. The practical applications of these callsites are to:
1. Find unknown WAL files not present in a descriptor
2. Find the latest `OPTIONS-$N` file for `GetLiveFiles()` inclusion

Neither of these appears to be relevant for our use case of simple RocksDB backup -> ReadOnly restore, which makes me think they can be safely bypassed in the ReadOnly open path.

This change adds a new database option, `skip_directory_scan_on_readonly_db_open`, that allows RocksDB users to omit directory listing related system calls, with a default of `false`. I think generally, this is probably useful for folks using RocksDB over customized file systems (be it FUSE or NFS etc), that may only implement partial POSIX support. With this change, we are able to use successfully use RocksDB in ReadOnly mode with our customized file system. 

Note: `best_efforts_recovery` does bypass the WAL dir scan, but doesn't skip the scan for the OPTIONs file. I also think using `best_efforts_recovery` as a proxy for bypassing `getdents64(2)` deviates from the options original intent.

<details>
<summary> Reproduce database open failure </summary>

Example program opening database in ReadOnly mode, fails during `getdents64(2)`.

```cpp
  DBOptions db_options;
 
  // Enable this to skip directory scans (getdents64)
  // db_options.skip_directory_scan_on_open = true;

  std::vector<ColumnFamilyDescriptor> column_families;
  column_families.push_back(ColumnFamilyDescriptor(
      ROCKSDB_NAMESPACE::kDefaultColumnFamilyName, ColumnFamilyOptions()));
  column_families.push_back(
      ColumnFamilyDescriptor("metadata", ColumnFamilyOptions()));

  std::vector<ColumnFamilyHandle*> handles;
  DB* db = nullptr;

  // strace -e open,openat,getdents64 ./bin
  Status s = DB::OpenForReadOnly(db_options, kDBPath, column_families, &handles, &db);

  if (!s.ok()) {
    std::cerr << "Failed to open DB: " << s.ToString() << std::endl;
    return 1;
  }
```

</details> 

As far as I can tell, this seems safe? This could also be two DB options, to eliminate composite side effects of this option, and might be clearer overall. But I'm looking for maintainers with better context to help me understand why this might be a bad idea. Thanks