### PR TITLE
Fixing typos in comments and documentation

### DIFF
--- a/cache/cache_test.cc
+++ b/cache/cache_test.cc
@@ -644,7 +644,7 @@ using TypedHandle = SharedCache::TypedHandle;
 
 TEST_P(CacheTest, SetCapacity) {
   if (IsHyperClock()) {
-    // TODO: update test & code for limited supoort
+    // TODO: update test & code for limited support
     ROCKSDB_GTEST_BYPASS(
         "HyperClockCache doesn't support arbitrary capacity "
         "adjustments.");

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -1503,7 +1503,7 @@ TEST_P(BasicSecondaryCacheTest, FullCapacityTest) {
         /*context*/ this, Cache::Priority::LOW);
     ASSERT_EQ(handle1, nullptr);
 
-    // k1 promotion can fail with strict_capacit_limit=true, but Lookup still
+    // k1 promotion can fail with strict_capacity_limit=true, but Lookup still
     // succeeds using a standalone handle
     handle1 = cache->Lookup(k1.AsSlice(), GetHelper(),
                             /*context*/ this, Cache::Priority::LOW);
@@ -1680,7 +1680,7 @@ TEST_P(DBSecondaryCacheTest, TestSecondaryCacheCorrectness2) {
   // After Flush is successful, RocksDB will do the paranoid check for the new
   // SST file. Meta blocks are always cached in the block cache and they
   // will not be evicted. When block_2 is cache miss and read out, it is
-  // inserted to the block cache. Thefore, block_1 is evicted from block
+  // inserted to the block cache. Therefore, block_1 is evicted from block
   // cache and successfully inserted to the secondary cache. Here are 2
   // lookups in the secondary cache for block_1 and block_2.
   ASSERT_EQ(secondary_cache->num_inserts(), 1u);
@@ -1721,7 +1721,7 @@ TEST_P(DBSecondaryCacheTest, TestSecondaryCacheCorrectness2) {
   v = Get(Key(0));
   ASSERT_EQ(1007, v.size());
   // This Get needs to access block_1, since block_1 is not in block cache
-  // there is one econdary cache lookup. Then, block_1 is cached in the
+  // there is one secondary cache lookup. Then, block_1 is cached in the
   // block cache.
   ASSERT_EQ(secondary_cache->num_inserts(), 2u);
   ASSERT_EQ(secondary_cache->num_lookups(), 5u);
@@ -1785,7 +1785,7 @@ TEST_P(DBSecondaryCacheTest, NoSecondaryCacheInsertion) {
   std::string v = Get(Key(0));
   ASSERT_EQ(1000, v.size());
   // Since the block cache is large enough, all the blocks are cached. we
-  // do not need to lookup the seondary cache.
+  // do not need to lookup the secondary cache.
   ASSERT_EQ(secondary_cache->num_inserts(), 0u);
   ASSERT_EQ(secondary_cache->num_lookups(), 2u);
 
@@ -2150,7 +2150,7 @@ TEST_P(DBSecondaryCacheTest, LRUCacheDumpLoadBasic) {
   ASSERT_OK(Flush());
   Compact("a", "z");
 
-  // do th eread for all the key value pairs, so all the blocks should be in
+  // do the read for all the key value pairs, so all the blocks should be in
   // cache
   uint32_t start_insert = cache->GetInsertCount();
   uint32_t start_lookup = cache->GetLookupcount();
@@ -2464,7 +2464,7 @@ TEST_P(DBSecondaryCacheTest, TestSecondaryCacheOptionBasic) {
   std::string v = Get(Key(0));
   ASSERT_EQ(1007, v.size());
 
-  // Check the data in first block. Cache miss, direclty read from SST file.
+  // Check the data in first block. Cache miss, directly read from SST file.
   ASSERT_EQ(secondary_cache->num_inserts(), 0u);
   ASSERT_EQ(secondary_cache->num_lookups(), 0u);
 
@@ -2598,7 +2598,7 @@ TEST_P(DBSecondaryCacheTest, TestSecondaryCacheOptionChange) {
 }
 
 // Two DB test. We create 2 DBs sharing the same block cache and secondary
-// cache. We diable the secondary cache option for DB2.
+// cache. We disable the secondary cache option for DB2.
 TEST_P(DBSecondaryCacheTest, TestSecondaryCacheOptionTwoDB) {
   if (IsHyperClock()) {
     ROCKSDB_GTEST_BYPASS("Test depends on LRUCache-specific behaviors");

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -101,7 +101,7 @@ TEST_F(DBFlushTest, SyncFail) {
   TEST_SYNC_POINT("DBFlushTest::SyncFail:2");
   fault_injection_env->SetFilesystemActive(true);
   // Now the background job will do the flush; wait for it.
-  // Returns the IO error happend during flush.
+  // Returns the IO error happened during flush.
   ASSERT_NOK(dbfull()->TEST_WaitForFlushMemTable());
   ASSERT_EQ("", FilesPerLevel());  // flush failed.
   Destroy(options);
@@ -518,11 +518,11 @@ TEST_F(DBFlushTest, StatisticsGarbageInsertAndDeletes) {
   // Note : one set of delete for KEY1, KEY2, KEY3 is written to
   // SSTable to propagate the delete operations to K-V pairs
   // that could have been inserted into the database during past Flush
-  // opeartions.
+  // operations.
   EXPECTED_MEMTABLE_GARBAGE_BYTES_AT_FLUSH -=
       KEY1.size() + KEY2.size() + KEY3.size() + 3 * sizeof(uint64_t);
 
-  // Additional useful paylaod.
+  // Additional useful payload.
   ASSERT_OK(Delete(KEY4));
   ASSERT_OK(Delete(KEY5));
   ASSERT_OK(Delete(KEY6));
@@ -614,7 +614,7 @@ TEST_F(DBFlushTest, StatisticsGarbageRangeDeletes) {
 
   // Note : one set of deleteRange for (KEY1, KEY2) and (KEY2, KEY3) is written
   // to SSTable to propagate the deleteRange operations to K-V pairs that could
-  // have been inserted into the database during past Flush opeartions.
+  // have been inserted into the database during past Flush operations.
   EXPECTED_MEMTABLE_GARBAGE_BYTES_AT_FLUSH -=
       (KEY1.size() + KEY2.size() + sizeof(uint64_t)) +
       (KEY2.size() + KEY3.size() + sizeof(uint64_t));
@@ -842,7 +842,7 @@ TEST_F(DBFlushTest, FixFlushReasonRaceFromConcurrentFlushes) {
     ASSERT_OK(Put(1, Key(idx), std::string(1, 'v')));
   }
 
-  // To coerce a manual flush happenning in the middle of GetLiveFiles's flush,
+  // To coerce a manual flush happening in the middle of GetLiveFiles's flush,
   // we need to pause background flush thread and enable it later.
   std::shared_ptr<test::SleepingBackgroundTask> sleeping_task =
       std::make_shared<test::SleepingBackgroundTask>();
@@ -851,7 +851,7 @@ TEST_F(DBFlushTest, FixFlushReasonRaceFromConcurrentFlushes) {
                  sleeping_task.get(), Env::Priority::HIGH);
   sleeping_task->WaitUntilSleeping();
 
-  // Coerce a manual flush happenning in the middle of GetLiveFiles's flush
+  // Coerce a manual flush happening in the middle of GetLiveFiles's flush
   bool get_live_files_paused_at_sync_point = false;
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::AtomicFlushMemTables:AfterScheduleFlush", [&](void* /* arg */) {
@@ -1428,7 +1428,7 @@ TEST_F(DBFlushTest, MemPurgeDeleteAndDeleteRange) {
   Close();
 }
 
-// Create a Compaction Fitler that will be invoked
+// Create a Compaction Filter that will be invoked
 // at flush time and will update the value of a KV pair
 // if the key string is "lower" than the filter_key_ string.
 class ConditionalUpdateFilter : public CompactionFilter {

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -93,8 +93,8 @@ struct BufferInfo {
   //
   // For example - if end offset of previous buffer was 100 and because of
   // readahead_size optimization, end_offset was trimmed to 60. Then for next
-  // prefetch call, start_offset should be intialized to 100 i.e  start_offset =
-  // buf->initial_end_offset_.
+  // prefetch call, start_offset should be initialized to 100 i.e  start_offset
+  // = buf->initial_end_offset_.
   uint64_t initial_end_offset_ = 0;
 
   bool IsDataBlockInBuffer(uint64_t offset, size_t length) {
@@ -155,7 +155,7 @@ enum class FilePrefetchBufferUsage {
 // When reusing the file system allocated buffer, overlap_buf_ is used if the
 // main buffer only contains part of the requested data. It is returned to
 // the caller after the remaining data is fetched.
-// If num_buffers_ > 1, then the data is prefetched asynchronosuly in the
+// If num_buffers_ > 1, then the data is prefetched asynchronously in the
 // buffers whenever the data is consumed from the buffers and that buffer is
 // freed.
 // If num_buffers > 1, then requested data can be overlapping between 2 buffers.

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -669,7 +669,7 @@ TEST_P(PrefetchTest, ConfigureAutoMaxReadaheadSize) {
     MoveFilesToLevel(level);
   }
   Close();
-  std::vector<int> buff_prefectch_level_count = {0, 0, 0};
+  std::vector<int> buff_prefetch_level_count = {0, 0, 0};
   ASSERT_OK(TryReopen(options));
   {
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
@@ -707,7 +707,7 @@ TEST_P(PrefetchTest, ConfigureAutoMaxReadaheadSize) {
         iter->Next();
       }
 
-      buff_prefectch_level_count[level] = buff_prefetch_count;
+      buff_prefetch_level_count[level] = buff_prefetch_count;
       if (support_prefetch && !use_direct_io) {
         if (level == 0) {
           ASSERT_FALSE(fs->IsPrefetchCalled());
@@ -728,7 +728,7 @@ TEST_P(PrefetchTest, ConfigureAutoMaxReadaheadSize) {
   }
 
   if (!support_prefetch) {
-    ASSERT_GT(buff_prefectch_level_count[1], buff_prefectch_level_count[2]);
+    ASSERT_GT(buff_prefetch_level_count[1], buff_prefetch_level_count[2]);
   }
 
   SyncPoint::GetInstance()->DisableProcessing();
@@ -814,7 +814,7 @@ TEST_P(PrefetchTest, ConfigureInternalAutoReadaheadSize) {
                                       "{initial_auto_readahead_size=0;}"}}));
           break;
         case 1:
-          // intial_auto_readahead_size and max_auto_readahead_size are set
+          // initial_auto_readahead_size and max_auto_readahead_size are set
           // same so readahead_size remains same.
           ASSERT_OK(db_->SetOptions({{"block_based_table_factory",
                                       "{initial_auto_readahead_size=4096;max_"
@@ -1081,7 +1081,7 @@ TEST_P(PrefetchTest, PrefetchWhenReseek) {
   }
   {
     /*
-     * Reesek keys from Single Data Block.
+     * Reseek keys from Single Data Block.
      */
     auto iter = std::unique_ptr<Iterator>(db_->NewIterator(ReadOptions()));
     iter->Seek(BuildKey(0));
@@ -1116,9 +1116,8 @@ TEST_P(PrefetchTest, PrefetchWhenReseek) {
     ASSERT_TRUE(iter->Valid());
     iter->Seek(BuildKey(1008));
     ASSERT_TRUE(iter->Valid());
-    iter->Seek(
-        BuildKey(996));  // Reseek won't prefetch any data and
-                         // readahead_size will be initiallized to 8*1024.
+    iter->Seek(BuildKey(996));  // Reseek won't prefetch any data and
+                                // readahead_size will be initialized to 8*1024.
     ASSERT_TRUE(iter->Valid());
     iter->Seek(BuildKey(992));
     ASSERT_TRUE(iter->Valid());
@@ -1590,7 +1589,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         // Params are as follows -
         // Param 0 - TableOptions::index_shortening
-        // Param 2 - ReadOptinos::auto_readahead_size
+        // Param 2 - ReadOptions::auto_readahead_size
         ::testing::Values(
             BlockBasedTableOptions::IndexShorteningMode::kNoShortening,
             BlockBasedTableOptions::IndexShorteningMode::kShortenSeparators,
@@ -3303,7 +3302,7 @@ TEST_F(FilePrefetchBufferTest, SyncReadaheadStats) {
   ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_HITS), 1);
   ASSERT_EQ(stats->getAndResetTickerCount(PREFETCH_BYTES_USEFUL), 8192);
 
-  // Now read some data with length doesn't align with aligment and it needs
+  // Now read some data with length doesn't align with alignment and it needs
   // prefetching. Read from 16000 with length 10000 (i.e. requested end offset -
   // 26000).
   ASSERT_TRUE(

--- a/include/rocksdb/advanced_cache.h
+++ b/include/rocksdb/advanced_cache.h
@@ -318,7 +318,7 @@ class Cache : public Customizable {
   // REQUIRES: handle must have been returned by a method on *this.
   virtual bool Release(Handle* handle, bool erase_if_last_ref = false) = 0;
 
-  // Return the object assiciated with a handle returned by a successful
+  // Return the object associated with a handle returned by a successful
   // Lookup(). For historical reasons, this is also known at the "value"
   // associated with the key.
   // REQUIRES: handle must not have been released yet.

--- a/include/rocksdb/experimental.h
+++ b/include/rocksdb/experimental.h
@@ -86,7 +86,7 @@ Status UpdateManifestForFilesState(
 // keys in a category to return an empty sequence of segments.
 //
 // To eliminate a confusing distinction between a segment that is empty vs.
-// "not present" for a particular key, each key is logically assiciated with
+// "not present" for a particular key, each key is logically associated with
 // an infinite sequence of segments, including some infinite tail of 0-length
 // segments. In practice, we only represent a finite sequence that (at least)
 // covers the non-trivial segments.
@@ -220,7 +220,7 @@ Status UpdateManifestForFilesState(
 // whole key.
 // * Range query - Whether there {definitely isn't, might be} any entries
 // within a lower and upper key bound, in an SST file (or partition, etc.).
-//    NOTE: For this disucssion, we ignore the detail of inclusive vs.
+//    NOTE: For this discussion, we ignore the detail of inclusive vs.
 //    exclusive bounds by assuming a generalized notion of "bound" (vs. key)
 //    that conveniently represents spaces between keys. For details, see
 //    https://github.com/facebook/rocksdb/pull/11434
@@ -300,7 +300,7 @@ Status UpdateManifestForFilesState(
 //     * Keys x and z are in categories in category set s, and
 //     * Key y is ordered x < y < z according to the CF comparator,
 // then both
-//     * The common segment prefix property is satisifed through ordinal i-1
+//     * The common segment prefix property is satisfied through ordinal i-1
 //     and with category set s
 //     * x_i..j <= y_i..j <= z_i..j according to segment comparator c, where
 //     x_i..j is the concatenation of segments i through j of key x (etc.).

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -767,7 +767,7 @@ void BlockBasedTableIterator::InitializeStartAndEndOffsets(
       // It can be when Reseek is from block cache (which doesn't clear the
       // buffers in FilePrefetchBuffer but clears block handles from queue) and
       // reseek also lies within the buffer. So Next will get data from
-      // exisiting buffers untill this callback is made to prefetch additional
+      // existing buffers until this callback is made to prefetch additional
       // data. All handles need to be added to the queue starting from
       // index_iter_.
       assert(index_iter_->Valid());
@@ -1046,7 +1046,7 @@ void BlockBasedTableIterator::Prepare(const MultiScanArgs* multiscan_opts) {
 
 void BlockBasedTableIterator::SeekMultiScan(const Slice* seek_target) {
   assert(multi_scan_ && multi_scan_status_.ok());
-  // This is a MultiScan and Preapre() has been called.
+  // This is a MultiScan and Prepare() has been called.
 
   // Reset out of bound on seek, if it is out of bound again, it will be set
   // properly later in the code path
@@ -1153,7 +1153,7 @@ void BlockBasedTableIterator::SeekMultiScan(const Slice* seek_target) {
       // This should never happen, the reason is that the
       // multi_scan_->next_scan_idx is set to a non zero value is due to a seek
       // target larger or equal to the start key of multi_scan_->next_scan_idx-1
-      // happended earlier. If a seek happens before the start key of
+      // happened earlier. If a seek happens before the start key of
       // multi_scan_->next_scan_idx-1, it would seek a key that is less than
       // what was seeked before.
       assert(!seek_target_before_previous_prepared_range);

--- a/tools/block_cache_analyzer/block_cache_trace_analyzer_test.cc
+++ b/tools/block_cache_analyzer/block_cache_trace_analyzer_test.cc
@@ -88,7 +88,7 @@ class BlockCacheTracerTest : public testing::Test {
       case 4:
         return TableReaderCaller::kUserIterator;
     }
-    // This cannot happend.
+    // This cannot happen.
     assert(false);
     return TableReaderCaller::kMaxBlockCacheLookupCaller;
   }


### PR DESCRIPTION
Summary:
Fixed various spelling errors throughout RocksDB codebase including:
- assiciated → associated
- disucssion → discussion
- satisifed → satisfied
- supoort → support
- capacit_limit → capacity_limit
- direclty → directly
- diable → disable
- opeartions → operations
- paylaod → payload
- happenning/happended → happening/happened
- intialized/initiallized → initialized
- asynchronosuly → asynchronously
- exisiting → existing
- persitence → persistence
- and several others

These changes are in comments, test code, and documentation only.

Differential Revision: D89800154


