### PR TITLE
OptimisticTransactionDBOptions support for C/FFI API

### DIFF
--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -134,10 +134,13 @@ typedef struct rocksdb_pinnableslice_t rocksdb_pinnableslice_t;
 typedef struct rocksdb_transactiondb_options_t rocksdb_transactiondb_options_t;
 typedef struct rocksdb_transactiondb_t rocksdb_transactiondb_t;
 typedef struct rocksdb_transaction_options_t rocksdb_transaction_options_t;
+typedef struct rocksdb_optimistictransactiondb_options_t
+    rocksdb_optimistictransactiondb_options_t;
 typedef struct rocksdb_optimistictransactiondb_t
     rocksdb_optimistictransactiondb_t;
 typedef struct rocksdb_optimistictransaction_options_t
     rocksdb_optimistictransaction_options_t;
+typedef struct rocksdb_occ_lock_buckets_t rocksdb_occ_lock_buckets_t;
 typedef struct rocksdb_transaction_t rocksdb_transaction_t;
 typedef struct rocksdb_checkpoint_t rocksdb_checkpoint_t;
 typedef struct rocksdb_wal_iterator_t rocksdb_wal_iterator_t;
@@ -3272,12 +3275,16 @@ rocksdb_transactiondb_checkpoint_object_create(rocksdb_transactiondb_t* txn_db,
                                                char** errptr);
 
 extern ROCKSDB_LIBRARY_API rocksdb_optimistictransactiondb_t*
-rocksdb_optimistictransactiondb_open(const rocksdb_options_t* options,
-                                     const char* name, char** errptr);
+rocksdb_optimistictransactiondb_open(
+    const rocksdb_options_t* options,
+    const rocksdb_optimistictransactiondb_options_t* occ_options,
+    const char* name, char** errptr);
 
 extern ROCKSDB_LIBRARY_API rocksdb_optimistictransactiondb_t*
 rocksdb_optimistictransactiondb_open_column_families(
-    const rocksdb_options_t* options, const char* name, int num_column_families,
+    const rocksdb_options_t* options,
+    const rocksdb_optimistictransactiondb_options_t* occ_options,
+    const char* name, int num_column_families,
     const char* const* column_family_names,
     const rocksdb_options_t* const* column_family_options,
     rocksdb_column_family_handle_t** column_family_handles, char** errptr);
@@ -3358,6 +3365,40 @@ rocksdb_transaction_options_set_max_write_batch_size(
 
 extern ROCKSDB_LIBRARY_API void rocksdb_transaction_options_set_skip_prepare(
     rocksdb_transaction_options_t* opt, unsigned char v);
+
+extern ROCKSDB_LIBRARY_API rocksdb_optimistictransactiondb_options_t*
+rocksdb_optimistictransactiondb_options_create(void);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_optimistictransactiondb_options_destroy(
+    rocksdb_optimistictransactiondb_options_t* opt);
+
+// Maps to ROCKSDB_NAMESPACE::OccValidationPolicy.
+enum {
+  rocksdb_validation_policy_validate_serial = 0,
+  rocksdb_validation_policy_validate_parallel = 1,
+};
+extern ROCKSDB_LIBRARY_API void
+rocksdb_optimistictransactiondb_options_set_validate_policy(
+    rocksdb_optimistictransactiondb_options_t* opt, int validation_policy);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_optimistictransactiondb_options_set_occ_lock_buckets(
+    rocksdb_optimistictransactiondb_options_t* opt, uint32_t occ_lock_buckets);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_optimistictransactiondb_options_set_shared_lock_buckets(
+    rocksdb_optimistictransactiondb_options_t* opt,
+    rocksdb_occ_lock_buckets_t* buckets);
+
+extern ROCKSDB_LIBRARY_API rocksdb_occ_lock_buckets_t*
+rocksdb_occ_lock_buckets_create(size_t bucket_count,
+                                unsigned char cache_aligned);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_occ_lock_buckets_destroy(
+    rocksdb_occ_lock_buckets_t* opt);
+
+extern ROCKSDB_LIBRARY_API size_t
+rocksdb_occ_lock_buckets_approximate_memory_usage(rocksdb_occ_lock_buckets_t*);
 
 extern ROCKSDB_LIBRARY_API rocksdb_optimistictransaction_options_t*
 rocksdb_optimistictransaction_options_create(void);

--- a/include/rocksdb/utilities/optimistic_transaction_db.h
+++ b/include/rocksdb/utilities/optimistic_transaction_db.h
@@ -90,6 +90,11 @@ class OptimisticTransactionDB : public StackableDB {
   static Status Open(const Options& options, const std::string& dbname,
                      OptimisticTransactionDB** dbptr);
 
+  static Status Open(const Options& options,
+                     const OptimisticTransactionDBOptions& occ_options,
+                     const std::string& dbname,
+                     OptimisticTransactionDB** dbptr);
+
   static Status Open(const DBOptions& db_options, const std::string& dbname,
                      const std::vector<ColumnFamilyDescriptor>& column_families,
                      std::vector<ColumnFamilyHandle*>* handles,

--- a/utilities/transactions/optimistic_transaction_db_impl.cc
+++ b/utilities/transactions/optimistic_transaction_db_impl.cc
@@ -39,12 +39,19 @@ Transaction* OptimisticTransactionDBImpl::BeginTransaction(
 Status OptimisticTransactionDB::Open(const Options& options,
                                      const std::string& dbname,
                                      OptimisticTransactionDB** dbptr) {
+  return Open(options, OptimisticTransactionDBOptions(), dbname, dbptr);
+}
+
+Status OptimisticTransactionDB::Open(
+    const Options& options, const OptimisticTransactionDBOptions& occ_options,
+    const std::string& dbname, OptimisticTransactionDB** dbptr) {
   DBOptions db_options(options);
   ColumnFamilyOptions cf_options(options);
   std::vector<ColumnFamilyDescriptor> column_families;
   column_families.emplace_back(kDefaultColumnFamilyName, cf_options);
   std::vector<ColumnFamilyHandle*> handles;
-  Status s = Open(db_options, dbname, column_families, &handles, dbptr);
+  Status s =
+      Open(db_options, occ_options, dbname, column_families, &handles, dbptr);
   if (s.ok()) {
     assert(handles.size() == 1);
     // i can delete the handle since DBImpl is always holding a reference to


### PR DESCRIPTION
I am trying to use `rocksdb::OptimisticTransactionDB` over FFI and noticed the option I need, `occ_lock_buckets`, isn't settable. I noticed this related issue https://github.com/facebook/rocksdb/issues/11703 was marked up for grabs and I went ahead and introduced `OptimisticTransactionDBOptions` to the C API.

Unfortunately, this contains a breaking change in the C API, in that I decided to include `rocksdb_optimistictransactiondb_options_t *` in the signature of `rocksdb_optimistictransactiondb_open()` and `rocksdb_optimistictransactiondb_open_column_families()`. 

We could preserve backwards compatibility by adding logical overloads that include the options pointer, but I am a bit partial to keeping the APIs consistent with `transactiondb` if possible. Happy to go the other way if the community feels otherwise. For the open functions, setting `rocksdb_optimistictransactiondb_options_t *` to null causes the defaults of `OptimisticTransactionDB` to get applied. Passing an options pointer without any of the fields mutated will assume the defaults in `OptimisticTransactionDB`.

I added a new overload for `OptimisticTransactionDB::Open()` that imitates the "simple" overload signature. It omits the CF-handle related arguments, but allows the caller to pass `OptimisticTransactionDBOptions`. The original "simple" overload now calls this new overload, assuming the default constructed `OptimisticTransactionDBOptions`. This allowed me to reduce CF-handle related logic in the C interface, and centralize more in the core RocksDB layer. This `Open()` refactor could stand to be its own PR, since it's useful when using the C++ interface. 