### PR TITLE
C rocksdb_create_column_family(_with_ttl): Fix leak on error

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1827,9 +1827,13 @@ rocksdb_column_family_handle_t* rocksdb_create_column_family_with_ttl(
   ROCKSDB_NAMESPACE::DBWithTTL* db_with_ttl =
       static_cast<ROCKSDB_NAMESPACE::DBWithTTL*>(db->rep);
   rocksdb_column_family_handle_t* handle = new rocksdb_column_family_handle_t;
-  SaveError(errptr, db_with_ttl->CreateColumnFamilyWithTtl(
-                        ColumnFamilyOptions(column_family_options->rep),
-                        std::string(column_family_name), &(handle->rep), ttl));
+  if (SaveError(errptr,
+                db_with_ttl->CreateColumnFamilyWithTtl(
+                    ColumnFamilyOptions(column_family_options->rep),
+                    std::string(column_family_name), &(handle->rep), ttl))) {
+    delete handle;
+    return nullptr;
+  }
   handle->immortal = false;
   return handle;
 }

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -933,9 +933,10 @@ int main(int argc, char** argv) {
   Free(&err);
 
   StartPhase("open_error");
-  rocksdb_open(options, dbname, &err);
+  db = rocksdb_open(options, dbname, &err);
   CheckCondition(err != NULL);
   Free(&err);
+  CheckCondition(db == NULL);
 
   StartPhase("open");
   rocksdb_options_set_create_if_missing(options, 1);
@@ -2034,10 +2035,19 @@ int main(int argc, char** argv) {
 
     rocksdb_options_set_create_if_missing(db_options, 0);
     db = rocksdb_open(db_options, dbname, &err);
+
+    // create cf1
     rocksdb_column_family_handle_t* cfh;
     cfh = rocksdb_create_column_family(db, db_options, "cf1", &err);
     rocksdb_column_family_handle_destroy(cfh);
     CheckNoError(err);
+
+    // create cf1 again: must return an error and a NULL pointer
+    cfh = rocksdb_create_column_family(db, db_options, "cf1", &err);
+    CheckCondition(err != NULL);
+    Free(&err);
+    CheckCondition(cfh == NULL);
+
     rocksdb_close(db);
 
     size_t cflen;
@@ -4957,6 +4967,31 @@ int main(int argc, char** argv) {
     // The handle should be NULL on error (this is the bug fix)
     CheckCondition(cf_handle == NULL);
     free(cf_err);
+  }
+
+  StartPhase("create_column_family_with_ttl");
+  {
+    static const int test_ttl = 10;
+    // create a new TTL database
+    CheckCondition(db != NULL);
+    rocksdb_close(db);
+    rocksdb_destroy_db(options, dbname, &err);
+    CheckNoError(err);
+
+    db = rocksdb_open_with_ttl(options, dbname, -1, &err);
+    CheckNoError(err);
+
+    rocksdb_column_family_handle_t* cf = rocksdb_create_column_family_with_ttl(
+        db, options, "cf_ttl", test_ttl, &err);
+    CheckNoError(err);
+    rocksdb_column_family_handle_destroy(cf);
+
+    // create cf again: must return an error and a NULL pointer
+    cf = rocksdb_create_column_family_with_ttl(db, options, "cf_ttl", test_ttl,
+                                               &err);
+    CheckCondition(err != NULL);
+    Free(&err);
+    CheckCondition(cf == NULL);
   }
 
   StartPhase("cancel_all_background_work");


### PR DESCRIPTION
Previously, these functions returned an error and a non-NULL pointer when there is an error. Most users of this API are unlikely to free the pointer on error, causing a very minor memory leak.

Fix these functions to delete the allocated C struct when returning an error. Extend the C API test to cover these cases.