### PR TITLE
IsFastCrc32Supported: Print the correct arch when not supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,11 +279,11 @@ endif
 
 CXXFLAGS += $(ARCHFLAG)
 
-ifeq (,$(shell $(CXX) -fsyntax-only -march=armv8-a+crc+crypto -xc /dev/null 2>&1))
+# compile aarch64 CRC and pmull (in the aes set) instructions: Linux aarch64 default excludes them
+ifeq (,$(shell $(CXX) -fsyntax-only -march=armv8-a+crc+aes -xc /dev/null 2>&1))
 ifneq ($(PLATFORM),OS_MACOSX)
-CXXFLAGS += -march=armv8-a+crc+crypto
-CFLAGS += -march=armv8-a+crc+crypto
-ARMCRC_SOURCE=1
+CXXFLAGS += -march=armv8-a+crc+aes
+CFLAGS += -march=armv8-a+crc+aes
 endif
 endif
 

--- a/util/crc32c_arm64.cc
+++ b/util/crc32c_arm64.cc
@@ -5,7 +5,7 @@
 
 #include "util/crc32c_arm64.h"
 
-#if defined(HAVE_ARM64_CRC)
+#if defined(__ARM_FEATURE_CRC32)
 
 #if defined(__linux__)
 #include <asm/hwcap.h>
@@ -29,7 +29,7 @@
 #include <sys/types.h>
 #endif
 
-#ifdef HAVE_ARM64_CRYPTO
+#ifdef __ARM_FEATURE_CRC32
 /* unfolding to compute 8 * 3 = 24 bytes parallelly */
 #define CRC32C24BYTES(ITR)                                    \
   crc1 = crc32c_u64(crc1, *(buf64 + BLK_LENGTH + (ITR)));     \
@@ -125,8 +125,8 @@ uint32_t crc32c_arm64(uint32_t crc, unsigned char const* data, size_t len) {
    * Skip Crc32c Parallel computation if no crypto extension available.
    */
   if (pmull_runtime_flag) {
-/* Macro (HAVE_ARM64_CRYPTO) is used for compiling check  */
-#ifdef HAVE_ARM64_CRYPTO
+/* Macro __ARM_FEATURE_AES is required to support pmull instruction */
+#ifdef __ARM_FEATURE_AES
 /* Crc32c Parallel computation
  *   Algorithm comes from Intel whitepaper:
  *   crc-iscsi-polynomial-crc32-instruction-paper

--- a/util/crc32c_arm64.h
+++ b/util/crc32c_arm64.h
@@ -12,7 +12,6 @@
 #if defined(__aarch64__) || defined(__AARCH64__)
 
 #ifdef __ARM_FEATURE_CRC32
-#define HAVE_ARM64_CRC
 #include <arm_acle.h>
 #define crc32c_u8(crc, v) __crc32cb(crc, v)
 #define crc32c_u16(crc, v) __crc32ch(crc, v)
@@ -40,10 +39,9 @@ uint32_t crc32c_arm64(uint32_t crc, unsigned char const* data, size_t len);
 uint32_t crc32c_runtime_check(void);
 bool crc32c_pmull_runtime_check(void);
 
-#ifdef __ARM_FEATURE_CRYPTO
-#define HAVE_ARM64_CRYPTO
+#ifdef __ARM_FEATURE_AES
 #include <arm_neon.h>
-#endif  // __ARM_FEATURE_CRYPTO
+#endif  // __ARM_FEATURE_AES
 #endif  // __ARM_FEATURE_CRC32
 
 #endif  // defined(__aarch64__) || defined(__AARCH64__)

--- a/util/crc32c_test.cc
+++ b/util/crc32c_test.cc
@@ -169,6 +169,38 @@ TEST(CRC, Crc32cCombineBigSizeTest) {
   ASSERT_EQ(crc1_2, crc1_2_combine);
 }
 
+TEST(CRC, IsFastCrc32Supported) {
+  std::string output = IsFastCrc32Supported();
+
+  std::string test_detected_arch = "TODO: add arch defines to test";
+  bool test_fast_crc_supported = false;
+
+#if defined(__x86_64__) || defined(_M_X64)
+  test_detected_arch = "x86";
+
+#if defined(__SSE4_2__)
+  test_fast_crc_supported = true;
+#endif
+
+#elif defined(__aarch64__) || defined(_M_ARM64)
+  test_detected_arch = "Arm64";
+
+#ifdef __ARM_FEATURE_CRC32
+  test_fast_crc_supported = true;
+#endif
+
+#endif
+
+  std::string supported_string = "Not supported";
+  if (test_fast_crc_supported) {
+    supported_string = "Supported";
+  }
+  std::string expected = supported_string = " on " + test_detected_arch;
+
+  ASSERT_NE(output.find(expected), std::string::npos)
+      << "expected=" << expected << "output=" << output;
+}
+
 }  // namespace ROCKSDB_NAMESPACE::crc32c
 
 // copied from folly


### PR DESCRIPTION
When crc32 was not supported and compiled for aarch64, RocksDB logs "Not supported on x86". Change to "Not supported on Arm64".

Add a unit test for the function.

For aarch64: Switch from the deprecated `__ARM_FEATURE_CRYPTO` macro to the finer-grained `__ARM_FEATURE_AES` macro, which determines if the pmull instruction is supported. Use these instead of `HAVE_*` since they are well documented and supported by Clang and GCC.

The deprecation notice for `__ARM_FEATURE_CRYPTO`:
https://arm-software.github.io/acle/main/acle.html#crypto-extension