### PR TITLE
Fix cases of db dir going missing in db_crashtest.py

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -474,10 +474,7 @@ def get_dbname(test_name):
                 print("Running DB cleanup command - %s\n" % cleanup_cmd)
                 # Ignore failure
                 os.system(cleanup_cmd)
-            try:
-                os.mkdir(dbname)
-            except OSError:
-                pass
+            os.makedirs(dbname, exist_ok=True)
     return dbname
 
 
@@ -535,6 +532,8 @@ def is_direct_io_supported(dbname):
     if is_remote_db:
         return False
     else:
+        # Note: db dir might be removed on check_mode change. Re-create it
+        os.makedirs(dbname, exist_ok=True)
         with tempfile.NamedTemporaryFile(dir=dbname) as f:
             try:
                 os.open(f.name, os.O_DIRECT)


### PR DESCRIPTION
Summary: My PR #14195 regressed a case in which db_crashtest.py calling db_stress with --destroy_db_initially=1 could lead to dbname directory being nonexistant for subsequent calls to gen_cmd -> finalize_and_sanitize -> is_direct_io_supported which would fail in creating a temporary file. Fix this (and clean up existing related code) using os.makedirs.

Test Plan: I don't have a good reproducer for the error but some manual testing indicates this change is at least safe