### PR TITLE
PhysicalCoreID: Use sched_getcpu on aarch64 with glibc >= 2.35

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -4615,6 +4615,25 @@ TEST_F(EnvTest, WriteStringToFileCloseFailureDeletesFile) {
   ASSERT_TRUE(exists.IsNotFound()) << exists.ToString();
 }
 
+TEST_F(EnvPosixTest, PhysicalCoreID) {
+  // we expect PhysicalCoreID to actually work on supported platform
+  // TODO: support PPC?
+  int core1 = port::PhysicalCoreID();
+  int core2 = port::PhysicalCoreID();
+  ASSERT_GE(core1, -1);
+  ASSERT_GE(core2, -1);
+
+  // this SHOULD be equal, but ...this could be flaky
+  ASSERT_EQ(core1, core2);
+
+  // on supported platforms: we expect this to return a "real" value
+  // as of 2026-01-06 this is not supported on Mac OS X
+#if defined(ROCKSDB_SCHED_GETCPU_PRESENT) || defined(OS_WIN)
+  ASSERT_NE(core1, -1) << "platform support may be missing";
+  ASSERT_NE(core2, -1);
+#endif
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -5037,6 +5037,23 @@ TEST_F(EnvTest, WriteStringToFileCloseFailureDeletesFile) {
   ASSERT_TRUE(exists.IsNotFound()) << exists.ToString();
 }
 
+TEST_F(EnvPosixTest, PhysicalCoreID) {
+  // PhysicalCoreID must be > -1 on supported platforms
+  // TODO: support PPC?
+  int core1 = port::PhysicalCoreID();
+  int core2 = port::PhysicalCoreID();
+  ASSERT_GE(core1, -1);
+  ASSERT_GE(core2, -1);
+
+  // this SHOULD be equal, but this can theoretically flake
+  ASSERT_EQ(core1, core2);
+
+#if defined(ROCKSDB_SCHED_GETCPU_PRESENT)
+  ASSERT_NE(core1, -1) << "platform support may be missing";
+  ASSERT_NE(core2, -1);
+#endif
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -174,11 +174,13 @@ void RWMutex::WriteUnlock() {
 }
 
 int PhysicalCoreID() {
-#if defined(ROCKSDB_SCHED_GETCPU_PRESENT) && defined(__x86_64__) && \
-    (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 22))
-  // sched_getcpu uses VDSO getcpu() syscall since 2.22. I believe Linux offers
-  // VDSO support only on x86_64. This is the fastest/preferred method if
-  // available.
+#if defined(ROCKSDB_SCHED_GETCPU_PRESENT) &&                          \
+    ((defined(__x86_64__) &&                                          \
+      (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GNUC_MINOR__ >= 22))) || \
+     (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 35)))
+  // sched_getcpu uses VDSO getcpu() syscall since glibc 2.22 on x86_64, and
+  // restartable sequences since glibc 2.35 everywhere. This is the
+  // fastest/preferred method if available.
   int cpuno = sched_getcpu();
   if (cpuno < 0) {
     return -1;

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -198,11 +198,12 @@ void RWMutex::WriteUnlock() {
 }
 
 int PhysicalCoreID() {
-#if defined(ROCKSDB_SCHED_GETCPU_PRESENT) && defined(__x86_64__) && \
-    (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 22))
-  // sched_getcpu uses VDSO getcpu() syscall since 2.22. I believe Linux offers
-  // VDSO support only on x86_64. This is the fastest/preferred method if
-  // available.
+#if defined(ROCKSDB_SCHED_GETCPU_PRESENT) &&                             \
+    (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 35))
+  // sched_getcpu uses VDSO getcpu() syscall since glibc 2.22 on x86_64, and
+  // restartable sequences since glibc 2.35 everywhere. This is the
+  // fastest/preferred method if available. The macro just checks for glibc
+  // >= 2.35 since it was released in 2022.
   int cpuno = sched_getcpu();
   if (cpuno < 0) {
     return -1;


### PR DESCRIPTION
The Linux sched_getcpu function was changed to use the glibc "restartable sequences" since glibc 2.35 in in 2022. At this point, most recent Linux distributions have picked this up. The preprocessor macro will conditionally enable it based on the version of glibc, so this should make this faster on newer aarch64 builds, without impacting old ones. I have tested with a microbenchmark that the performance with new glibc is the same as x86-64 (a few ns/call).

I added a test to try to check this. It was useful for me in testing this, but it is probably "wrong": without duplicating the check exactly, it is hard to test the support. It is possible we should remove the test.

Correct the macro: it should be testing `__GLIBC__` and `__GLIBC_MINOR__` for the glibc version, rather than `__GNUC__` and `__GNUC_MINOR__` for the gcc/clang version.

Linux distribution support for this feature:

RHEL 9 glibc glibc 2.34 released 2022-05-17 (TOO OLD)
RHEL 9.1 glibc 2.35 released 2022-11-15 [1]
RHEL 10 glibc 2.39 released 2025-05-20

Ubuntu LTS 20.04 glibc 2.31 released 2020-04-23 (TOO OLD)
Ubuntu LTS 22.04 glibc 2.35 released 2022-04-21
Ubuntu LTS 24.04 glibc 2.39 released 2024-04-25

Debian 11 glibc 2.31 released 2021-08-14 (TOO OLD)
Debian 12 glibc 2.36 released 2023-06-14
Debian 13 glibc 2.41 released 2025-08-09

[1] https://developers.redhat.com/articles/2022/12/22/restartable-sequences-support-glibc-rhel-9