### PR TITLE
Use system call I/O in PosixSequentialFile instead of libc stdio to avoid extra buffer copies and FreeBSD stdio open file limits

### DIFF
--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -275,13 +275,12 @@ class LogicalBlockSizeCache {
 class PosixSequentialFile : public FSSequentialFile {
  private:
   std::string filename_;
-  FILE* file_;
   int fd_;
   bool use_direct_io_;
   size_t logical_sector_size_;
 
  public:
-  PosixSequentialFile(const std::string& fname, FILE* file, int fd,
+  PosixSequentialFile(const std::string& fname, int fd,
                       size_t logical_block_size, const EnvOptions& options);
   virtual ~PosixSequentialFile();
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2267,7 +2267,7 @@ static std::unordered_map<OperationType, std::string, std::hash<unsigned char>>
     OperationTypeString = {{kRead, "read"},         {kWrite, "write"},
                            {kDelete, "delete"},     {kSeek, "seek"},
                            {kMerge, "merge"},       {kUpdate, "update"},
-                           {kCompress, "compress"}, {kCompress, "uncompress"},
+                           {kCompress, "compress"}, {kUncompress, "uncompress"},
                            {kCrc, "crc"},           {kHash, "hash"},
                            {kOthers, "op"},         {kMultiScan, "multiscan"}};
 

--- a/util/compression.cc
+++ b/util/compression.cc
@@ -1404,6 +1404,7 @@ class BuiltinDecompressorV2SnappyOnly final : public BuiltinDecompressorV2 {
     args.uncompressed_size = uncompressed_length;
     return Status::OK();
 #else
+    (void)args;
     return Status::NotSupported("Snappy not supported in this build");
 #endif
   }

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -3663,7 +3663,7 @@ TEST_P(WriteBatchWithIndexTest, TrackAndClearCFStats) {
   {
     auto& cf_id_to_count = batch_->GetCFStats();
     ASSERT_EQ(2, cf_id_to_count.size());
-    for (const auto [cf_id, stat] : cf_id_to_count) {
+    for (const auto& [cf_id, stat] : cf_id_to_count) {
       if (cf_id == 0) {
         ASSERT_EQ(2, stat.entry_count);
         ASSERT_EQ(0, stat.overwritten_sd_count);


### PR DESCRIPTION
PosixSequentialFile as currently implemented opens a file using posix system calls, then uses buffered libc stdio to wrap the file descriptor and perform all subsequent I/O.

As users of PosixSequentialFile handle their own buffering, the additional buffering provided by stdio introduces needless additional copying of memory on I/O. Notably none of the other Posix*File classes (PosixWritableFile, PosixRandomAccessFile, PosixMmapFile, etc.) make any use of libc stdio calls relying exclusively on file descriptors and posix system calls.

Finally some platforms' libc stdio implementations are limited and fail unexpectedly in the face of large numbers of open file description, most notably FreeBSD's libc stdio which causes rocksdb to fail when more than 32,767 files are open.

This pull request removes the FILE file member from  PosixSequentialFile and replaces use of stdio fdopen/fread/fseek/fclose calls with the equivalent -/read/lseek/close system calls instead.

Note there is additional code in function PosixHelper::GetQueueSysfsFileValueOfFd() in env/io_posix.cc that uses libc stdio fopen() and friends to read files under /sys/dev/block however this code is all under an #ifdef OS_LINUX condition compile block and so is not present in FreeBSD builds hence was left alone for the purposes of this pull request.

During development the following trivial bugs arose and were fixed in this pull request as well:
- fix unreferenced parameter error in util/compression.cc when compiling without snappy
- fix needless loop variable value copying error in utilities/write_batch_with_index/write_batch_with_index_test.cc
- fix mismapped operation type string in tools/db_bench_tool.cc