### PR TITLE
math.h BottomNBits: Fix integer underflow

### DIFF
--- a/util/hash_test.cc
+++ b/util/hash_test.cc
@@ -615,6 +615,13 @@ static void test_BitOps() {
 
     // BottomNBits
     {
+      // build the mask the extremely slow way
+      T bottom_n_mask = 0x00;
+      for (int j = 0; j < i; j++) {
+        bottom_n_mask <<= 1;
+        bottom_n_mask |= 0x1;
+      }
+
       // An essentially full length value
       T x = everyOtherBit;
       if (i > 2) {
@@ -623,6 +630,11 @@ static void test_BitOps() {
       }
       auto a = BottomNBits(x, i);
       auto b = BottomNBits(~x, i);
+
+      // check that a and b match the expected values
+      EXPECT_EQ(a, x & bottom_n_mask);
+      EXPECT_EQ(b, (~x) & bottom_n_mask);
+
       EXPECT_EQ(x | a, x);
       EXPECT_EQ(a | b, vm1);
       EXPECT_EQ(a & b, T{0});

--- a/util/math.h
+++ b/util/math.h
@@ -41,7 +41,9 @@ inline T BottomNBits(T v, int nbits) {
 #endif
   // Newer compilers compile this down to bzhi on x86, but some older
   // ones don't, thus the need for the intrinsic above.
-  return static_cast<T>(v & ((T{1} << nbits) - 1));
+  using UnsignedT = std::make_unsigned_t<T>;
+  UnsignedT mask = (static_cast<UnsignedT>(1) << nbits) - 1;
+  return static_cast<T>(static_cast<UnsignedT>(v) & mask);
 }
 
 // Fast implementation of floor(log2(v)). Undefined for 0 or negative


### PR DESCRIPTION
When running make check on aarch64, hash_test reports an integer underflows:

    util/math.h:44:46: runtime error: signed integer overflow:
    -2147483648 - 1 cannot be represented in type 'int'
    util/math.h:44:46: runtime error: signed integer overflow:
    -9223372036854775808 - 1 cannot be represented in type 'long long'
    util/math.h:44:46: runtime error: signed integer overflow:
    -9223372036854775808 - 1 cannot be represented in type 'long'

The issue is when BottomNBits(int32 value, 31) does not use BMI2, it executes the following:

    return static_cast<T>(v & ((T{1} << nbits) - 1));

For int32_t, (1 << 31) is the minimum value, and -1 is an integer underflow. The fix is to cast T to an unsigned type and use that for the bit manipulation.

I used Compiler Explorer to verify that this still compiles to the BZHI instruction mentioned in the comment with -march=x86-64-v3: https://godbolt.org/z/8bcTE8xbf

To reproduce these errors on x86-64, disable the BMI code path:
```
USE_CLANG=1 PORTABLE=x86-64-v2 LDFLAGS=-fsanitize=undefined CXXFLAGS=-fsanitize=undefined make -j20 hash_test
```