### PR TITLE
prefetch_test.cc: Fix address sanitizer warning

### DIFF
--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -390,6 +390,9 @@ TEST_P(PrefetchTest, Basic) {
       buff_prefetch_count = 0;
     }
   }
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
   Close();
 }
 
@@ -3705,7 +3708,12 @@ class FSBufferPrefetchTest
     stats_ = CreateDBStatistics();
   }
 
-  void TearDown() override { EXPECT_OK(DestroyDir(env_, test_dir_)); }
+  void TearDown() override {
+    // needed for FSBufferPrefetchUnalignedReads which has early returns
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+    ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+    EXPECT_OK(DestroyDir(env_, test_dir_));
+  }
 
   void Write(const std::string& fname, const std::string& content) {
     std::unique_ptr<FSWritableFile> f;
@@ -3974,6 +3982,7 @@ TEST_P(FSBufferPrefetchTest, FSBufferPrefetchUnalignedReads) {
                          stats.get());
 
   int overlap_buffer_write_ct = 0;
+  // cleared by FSBufferPrefetchTest::TearDown so it happens for early returns
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "FilePrefetchBuffer::CopyDataToOverlapBuffer:Complete",
       [&](void* /*arg*/) { overlap_buffer_write_ct++; });


### PR DESCRIPTION
This fixes the following warning from make check. This is triggered because FSBufferPrefetchUnalignedReads did not clear the callbacks, and its installed callback can be triggered by other tests.

Add 2 ClearAllCallbacks calls to attempt to avoid these problems. The callback in TEST_P(PrefetchTest, Basic) did not cause sanitizer problems, but code inspection shows that I don't think it clears the callbacks and it probably should.

Fixes:
```
==1472548==ERROR: AddressSanitizer: stack-use-after-return on address 0x7693d37dc3d0 at pc 0x5603e97a25b9 bp 0x7fffa002dfa0 sp 0x7fffa002df98 READ of size 4 at 0x7693d37dc3d0 thread T0
    #0 0x5603e97a25b8 in rocksdb::FSBufferPrefetchTest_FSBufferPrefetchUnalignedReads_Test::TestBody()::$_0::operator()(void*) const /home/bits/rocksdb/file/prefetch_test.cc:3728:51
```