### PR TITLE
Fix stress test deadlock failure in TestPut

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -1911,6 +1911,7 @@ class NonBatchedOpsStressTest : public StressTest {
       // same key space but does not acquire stress test level mutex. So it is
       // possible RocksDB returns deadlock or timeout. Return OK() for these
       // cases
+      pending_expected_value.Rollback();
       return Status::OK();
     }
 


### PR DESCRIPTION
Summary:

Deadlock or timeout is possible in TestPut, when TestMultiGet was executed at the same time, because it executes MaybeAddKeyToTxnForRYW, which writes to the same key space but does not acquire stress test level mutex. Therefore, RocksDB could return deadlock error.

Test Plan:

Stress test

Reviewers:

Subscribers:

Tasks:

Tags: