### PR TITLE
Fix compaction error when upgrading from RocksDB v5.10.3 to v8.11.4

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -56,6 +56,7 @@
 #include "table/meta_blocks.h"
 #include "table/table_builder.h"
 #include "table/unique_id_impl.h"
+#include "table/block_based/block_based_table_reader.h"
 #include "test_util/sync_point.h"
 #include "util/stop_watch.h"
 
@@ -2474,10 +2475,34 @@ bool CompactionJob::UpdateInternalStatsFromInputFiles(
       }
       internal_stats_.output_level_stats.num_input_records +=
           file_input_entries;
-      if (num_input_range_del) {
-        *num_input_range_del += file_num_range_del;
+      if (file_num_range_del == 0 &&
+          compaction->mutable_cf_options().table_factory->Name() ==
+              TableFactory::kBlockBasedTableName()) {
+        std::shared_ptr<const FragmentedRangeTombstoneList> range_del;
+        bool has_range_del = false;
+        if (file_meta->fd.table_reader != nullptr) {
+          BlockBasedTable* table_reader =
+              static_cast<BlockBasedTable*>(file_meta->fd.table_reader);
+          has_range_del =
+              nullptr != table_reader->get_rep()->fragmented_range_dels;
+        } else {
+          has_range_del = HasTableFragmentedRangeDels(
+              compact_->compaction->immutable_options(),
+              compact_->compaction->mutable_cf_options(), file_meta,
+              ReadOptions(Env::IOActivity::kCompaction));
+        }
+        if (has_range_del) {
+          has_error = true;
+          ROCKS_LOG_WARN(
+              db_options_.info_log,
+              " table #%lu has range delete, but num_range_deletions is 0",
+              file_meta->fd.GetNumber());
+        }
       }
-    }
+        if (num_input_range_del) {
+          *num_input_range_del += file_num_range_del;
+        }
+      }
 
     const std::vector<FileMetaData*>& filtered_flevel =
         compaction->filtered_input_levels(input_level);
@@ -2764,6 +2789,49 @@ Status CompactionJob::ReadOutputFilesTableProperties(
     output_files_table_properties.push_back(tp);
   }
   return s;
+}
+
+bool CompactionJob::HasTableFragmentedRangeDels(
+    const ImmutableOptions& ioptions, const MutableCFOptions& moptions,
+    const FileMetaData* file_meta, const ReadOptions& read_options) {
+  std::unique_ptr<FSRandomAccessFile> file;
+  std::string file_name = GetTableFileName(file_meta->fd.GetNumber());
+  Status s = ioptions.fs->NewRandomAccessFile(file_name, file_options_, &file,
+                                              nullptr /* dbg */);
+  if (!s.ok()) {
+    return false;
+  }
+
+  std::unique_ptr<RandomAccessFileReader> file_reader(
+      new RandomAccessFileReader(
+          std::move(file), file_name, ioptions.clock, io_tracer_,
+          ioptions.stats, Histograms::SST_READ_MICROS /* hist_type */,
+          nullptr /* file_read_hist */, ioptions.rate_limiter.get(),
+          ioptions.listeners));
+
+  std::unique_ptr<FragmentedRangeTombstoneList> fragmented_range_tombstone;
+
+  uint64_t magic_number = kBlockBasedTableMagicNumber;
+
+  const auto* table_factory = moptions.table_factory.get();
+  if (table_factory == nullptr) {
+    return false;
+  } else {
+    const auto& table_factory_name = table_factory->Name();
+    if (table_factory_name == TableFactory::kPlainTableName()) {
+      magic_number = kPlainTableMagicNumber;
+    } else if (table_factory_name == TableFactory::kCuckooTableName()) {
+      magic_number = kCuckooTableMagicNumber;
+    }
+  }
+  BlockHandle range_del_handle;
+  s = FindMetaBlockInFile(file_reader.get(), file_meta->fd.GetFileSize(),
+                          magic_number, ioptions, read_options,
+                          kRangeDelBlockName, &range_del_handle);
+  if (!s.ok()) {
+    return false;
+  }
+  return true;
 }
 
 void CompactionJob::RestoreCompactionOutputs(

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -536,6 +536,11 @@ class CompactionJob {
       const FileMetaData* file_meta, const ReadOptions& read_options,
       std::shared_ptr<const TableProperties>* tp);
 
+  bool HasTableFragmentedRangeDels(const ImmutableOptions& ioptions,
+                                   const MutableCFOptions& moptions,
+                                   const FileMetaData* file_meta,
+                                   const ReadOptions& read_options);
+
   void RestoreCompactionOutputs(
       const ColumnFamilyData* cfd,
       const std::vector<std::shared_ptr<const TableProperties>>&


### PR DESCRIPTION
When I upgraded RocksDB from version v5.10.1 to v8.11.4, a compaction error occurred:
`
2025/12/19-08:41:47.105378 139671781758720 [WARN] [db/compaction/compaction_job.cc:848] [default] [JOB 6] Compaction Total number of input records: 44912, but processed 44911 records.
`
The root cause of this issue is that the SST metadata in RocksDB v5.10.3 does not include the `num_range_deletion` field, whereas this field was added in v8.11.4 with a default value of 0.
After the upgrade, when compaction reads the metadata of legacy SST files, it fails to retrieve the `num_range_deletions` value and thus assigns it a default of 0. However, these legacy SST files actually contain DeleteRange operations.
Upon completion of compaction, a validation check is performed: 
`
// rocksdb-8.11.4/db/compaction/compaction_job.cc
uint64_t expected =
          compaction_stats_.stats.num_input_records - num_input_range_del;
      uint64_t actual = compaction_job_stats_->num_input_records;
      if (expected != actual) {
          xxx // error
`
Since `num_range_deletion` is assigned a value of 0, this validation check fails.

Reproduction code as follows:
Generate data directory with v5.10.3:
`
int main() {
  Options options;
  options.create_if_missing = true;
  DB* db;
  Status s = DB::Open(options, "../db", &db);
  assert(s.ok());
  auto generate_sst = [&]() {
    for (int i = 0; i < 100; ++i) {
      string key = "key" + to_string(i);
      string value = "value" + to_string(i);
      s = db->Put(WriteOptions(), key, value);
      assert(s.ok());
    }
    s = db->DeleteRange(WriteOptions(), db->DefaultColumnFamily(), "key3", "key8");
    assert(s.ok());
    s = db->Flush(FlushOptions());
    assert(s.ok());
  };
  // generate 2 sst files
  generate_sst();
  generate_sst();
  delete db;
  return 0;
}
`
Upgrade and verify with v8.11.4:
`
int main() {
    DB* db;
    Options options;
    options.create_if_missing = true;
    Status status = DB::Open(options, "../db/", &db);
    if (!status.ok()) {
        std::cout << "open db failed: " << status.ToString() << std::endl;
        return -1;
    }
    status = db->CompactRange(CompactRangeOptions(), nullptr, nullptr);
    if (!status.ok()) {
        std::cout << "compact db failed: " << status.ToString() << std::endl;
        return -1;
    }
    delete db;
    return 0;
}
`
// will print
`
compact db failed: Corruption: Compaction number of input keys does not match number of keys processed. Expected 92 but processed 90. Compaction summary: Base version 2 Base level 0, inputs: [10(1881B) 7(1881B)]
`

The fix approach is as follows: when `num_range_deletions` is 0, check whether there are `fragmented_range_dels`. If `fragmented_range_dels` exist, throw an error and skip the validation check following the original process.
