### PR TITLE
Fix build with libcxx 20.1.8

### DIFF
--- a/util/stderr_logger.cc
+++ b/util/stderr_logger.cc
@@ -4,6 +4,8 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <stdlib.h>
+
 #include "util/stderr_logger.h"
 
 #include "port/malloc.h"


### PR DESCRIPTION
 This include is required for `free` since libcxx about version 20.1.8.
```
/root/rocksdb/util/stderr_logger.cc:17:5: error: use of undeclared identifier 'free'
   17 |     free((void*)log_prefix);
      |     ^
1 error generated.
```