### PR TITLE
Use unique DB directory when TEST_TMPDIR is set

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -461,13 +461,19 @@ def is_release_mode():
     return os.environ.get(_DEBUG_LEVEL_ENV_VAR) == "0"
 
 
+# Generate a unique run ID for this script execution. This ensures each run
+# gets a unique database directory when TEST_TMPDIR is set, avoiding issues
+# with parameter changes (like use_put_entity_one_in) between runs.
+run_id = str(random.randint(0, 2**63))
+
+
 def get_dbname(test_name):
     test_dir_name = "rocksdb_crashtest_" + test_name
     test_tmpdir = os.environ.get(_TEST_DIR_ENV_VAR)
     if test_tmpdir is None or test_tmpdir == "":
         dbname = tempfile.mkdtemp(prefix=test_dir_name)
     else:
-        dbname = test_tmpdir + "/" + test_dir_name
+        dbname = test_tmpdir + "/" + test_dir_name + "_" + run_id
         if not is_remote_db:
             shutil.rmtree(dbname, True)
             if cleanup_cmd is not None:


### PR DESCRIPTION
Summary:

Some of the stress tests script run tests multiple times with TEST_TMPDIR set. When TEST_TMPDIR is set, the db directory is a fixed string. This caused the same DB directory was reused across db_crashtest.py script run. Each db_crashtest.py run would randomize some of the parameters. This caused different parameters to be used with same DB directory, violating some of the assumption such as use_put_entity_one_in parameter. This change added a suffix to DB directory, so that each db_crashtest.py script run would generate a unique DB directory, which prevents the issue from happening again.

Test Plan:

Stress test local run

```
TEST_TMPDIR=/tmp/aaa /usr/local/bin/python3 -u tools/db_crashtest.py --stress_cmd=./db_stress --cleanup_cmd='' --simple blackbox  --duration 15 --interval 10

>>> Running db_stress with pid=113810: ./db_stress ... --db=/tmp/aaa/rocksdb_crashtest_blackbox_6967584463401575611 ...
```

Reviewers:

Subscribers:

Tasks:

Tags: