### PR TITLE
[Legacy BlobDB] Remove path_relative config option

### DIFF
--- a/utilities/blob_db/blob_db.cc
+++ b/utilities/blob_db/blob_db.cc
@@ -72,9 +72,6 @@ void BlobDBOptions::Dump(Logger* log) const {
       log, "                                  BlobDBOptions.blob_dir: %s",
       blob_dir.c_str());
   ROCKS_LOG_HEADER(
-      log, "                             BlobDBOptions.path_relative: %d",
-      path_relative);
-  ROCKS_LOG_HEADER(
       log, "                               BlobDBOptions.max_db_size: %" PRIu64,
       max_db_size);
   ROCKS_LOG_HEADER(

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -32,9 +32,6 @@ struct BlobDBOptions {
   // Default is "blob_dir"
   std::string blob_dir = "blob_dir";
 
-  // whether the blob_dir path is relative or absolute.
-  bool path_relative = true;
-
   // Maximum size of the database (including SST files and blob files).
   //
   // Default: 0 (no limits)

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -88,9 +88,7 @@ BlobDBImpl::BlobDBImpl(const std::string& dbname,
       live_sst_size_(0),
       debug_level_(0) {
   clock_ = env_->GetSystemClock().get();
-  blob_dir_ = (bdb_options_.path_relative)
-                  ? dbname + "/" + bdb_options_.blob_dir
-                  : bdb_options_.blob_dir;
+  blob_dir_ = dbname + "/" + bdb_options_.blob_dir;
   file_options_.bytes_per_sync = blob_db_options.bytes_per_sync;
 }
 
@@ -1977,9 +1975,7 @@ Status DestroyBlobDB(const std::string& dbname, const Options& options,
   Env* env = soptions.env;
 
   Status status;
-  std::string blobdir;
-  blobdir = (bdb_options.path_relative) ? dbname + "/" + bdb_options.blob_dir
-                                        : bdb_options.blob_dir;
+  std::string blobdir = dbname + "/" + bdb_options.blob_dir;
 
   std::vector<std::string> filenames;
   if (env->GetChildren(blobdir, &filenames).ok()) {

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -59,10 +59,6 @@ Status BlobDBImpl::EnableFileDeletions() {
 Status BlobDBImpl::GetLiveFiles(std::vector<std::string>& ret,
                                 uint64_t* manifest_file_size,
                                 bool flush_memtable) {
-  if (!bdb_options_.path_relative) {
-    return Status::NotSupported(
-        "Not able to get relative blob file path from absolute blob_dir.");
-  }
   // Hold a lock in the beginning to avoid updates to base DB during the call
   ReadLock rl(&mutex_);
   Status s = db_->GetLiveFiles(ret, manifest_file_size, flush_memtable);
@@ -80,8 +76,6 @@ Status BlobDBImpl::GetLiveFiles(std::vector<std::string>& ret,
 }
 
 void BlobDBImpl::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
-  // Path should be relative to db_name.
-  assert(bdb_options_.path_relative);
   // Hold a lock in the beginning to avoid updates to base DB during the call
   ReadLock rl(&mutex_);
   db_->GetLiveFilesMetaData(metadata);

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -755,7 +755,6 @@ TEST_F(BlobDBTest, GetLiveFilesMetaData) {
 
   BlobDBOptions bdb_options;
   bdb_options.blob_dir = "blob_dir";
-  bdb_options.path_relative = true;
   bdb_options.ttl_range_secs = 10;
   bdb_options.disable_background_tasks = true;
 


### PR DESCRIPTION
Changes:
- Remove `path_relative` field from `BlobDBOptions`
- Simplify `blob_dir_` construction in `BlobDBImpl` constructor
- Simplify path construction in `DestroyBlobDB()`
- Remove `NotSupported` check in `GetLiveFiles()`
- Remove assertion in `GetLiveFilesMetaData()`
- Remove logging of `path_relative` in `Dump()`
- Remove redundant `path_relative = true` in tests

Reviewed By: xingbowang

Differential Revision: D91089016


