### PR TITLE
[Legacy Blob DB] Remove blob_dir config option

### DIFF
--- a/utilities/blob_db/blob_db.cc
+++ b/utilities/blob_db/blob_db.cc
@@ -69,9 +69,6 @@ BlobDB::BlobDB() : StackableDB(nullptr) {}
 
 void BlobDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(
-      log, "                                  BlobDBOptions.blob_dir: %s",
-      blob_dir.c_str());
-  ROCKS_LOG_HEADER(
       log, "                               BlobDBOptions.max_db_size: %" PRIu64,
       max_db_size);
   ROCKS_LOG_HEADER(

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -25,13 +25,10 @@ namespace blob_db {
 // users to use blob DB.
 
 constexpr uint64_t kNoExpiration = std::numeric_limits<uint64_t>::max();
+// Name of the directory under the base DB where blobs will be stored.
+constexpr const char* kBlobDirName = "blob_dir";
 
 struct BlobDBOptions {
-  // Name of the directory under the base DB where blobs will be stored. Using
-  // a directory where the base DB stores its SST files is not supported.
-  // Default is "blob_dir"
-  std::string blob_dir = "blob_dir";
-
   // Maximum size of the database (including SST files and blob files).
   //
   // Default: 0 (no limits)

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -88,7 +88,7 @@ BlobDBImpl::BlobDBImpl(const std::string& dbname,
       live_sst_size_(0),
       debug_level_(0) {
   clock_ = env_->GetSystemClock().get();
-  blob_dir_ = dbname + "/" + bdb_options_.blob_dir;
+  blob_dir_ = dbname + "/" + kBlobDirName;
   file_options_.bytes_per_sync = blob_db_options.bytes_per_sync;
 }
 
@@ -1970,12 +1970,12 @@ Iterator* BlobDBImpl::NewIterator(const ReadOptions& _read_options) {
 }
 
 Status DestroyBlobDB(const std::string& dbname, const Options& options,
-                     const BlobDBOptions& bdb_options) {
+                     const BlobDBOptions& /*bdb_options*/) {
   const ImmutableDBOptions soptions(SanitizeOptions(dbname, options));
   Env* env = soptions.env;
 
   Status status;
-  std::string blobdir = dbname + "/" + bdb_options.blob_dir;
+  std::string blobdir = dbname + "/" + kBlobDirName;
 
   std::vector<std::string> filenames;
   if (env->GetChildren(blobdir, &filenames).ok()) {

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -70,7 +70,7 @@ Status BlobDBImpl::GetLiveFiles(std::vector<std::string>& ret,
     auto blob_file = bfile_pair.second;
     // Path should be relative to db_name, but begin with slash.
     ret.emplace_back(
-        BlobFileName("", bdb_options_.blob_dir, blob_file->BlobFileNumber()));
+        BlobFileName("", kBlobDirName, blob_file->BlobFileNumber()));
   }
   return Status::OK();
 }
@@ -85,7 +85,7 @@ void BlobDBImpl::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
     filemetadata.size = blob_file->GetFileSize();
     const uint64_t file_number = blob_file->BlobFileNumber();
     // Path should be relative to db_name, but begin with slash.
-    filemetadata.name = BlobFileName("", bdb_options_.blob_dir, file_number);
+    filemetadata.name = BlobFileName("", kBlobDirName, file_number);
     filemetadata.file_number = file_number;
     if (blob_file->HasTTL()) {
       filemetadata.oldest_ancester_time = blob_file->GetExpirationRange().first;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -754,7 +754,6 @@ TEST_F(BlobDBTest, GetLiveFilesMetaData) {
   Random rnd(301);
 
   BlobDBOptions bdb_options;
-  bdb_options.blob_dir = "blob_dir";
   bdb_options.ttl_range_secs = 10;
   bdb_options.disable_background_tasks = true;
 


### PR DESCRIPTION
Replace the configurable `blob_dir` option with a constant `kBlobDirName`. This simplifies the code and further reduces the configuration surface.

Reviewed By: xingbowang

Differential Revision: D91089039


