### PR TITLE
[Legacy Blob DB] Remove unused public APIs

### DIFF
--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -174,10 +174,6 @@ class BlobDB : public StackableDB {
                      std::vector<ColumnFamilyHandle*>* handles,
                      BlobDB** blob_db);
 
-  virtual BlobDBOptions GetBlobDBOptions() const = 0;
-
-  virtual Status SyncBlobFiles(const WriteOptions& write_options) = 0;
-
   ~BlobDB() override {}
 
  protected:

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -131,8 +131,6 @@ Status BlobDBImpl::CloseImpl() {
   return s;
 }
 
-BlobDBOptions BlobDBImpl::GetBlobDBOptions() const { return bdb_options_; }
-
 Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   assert(handles != nullptr);
   assert(db_ == nullptr);

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -75,9 +75,6 @@ class BlobDBImpl : public BlobDB {
   friend class BlobIndexCompactionFilterGC;
 
  public:
-  // deletions check period
-  static constexpr uint32_t kDeleteCheckPeriodMillisecs = 2 * 1000;
-
   // sanity check task
   static constexpr uint32_t kSanityCheckPeriodMillisecs = 20 * 60 * 1000;
 
@@ -140,8 +137,6 @@ class BlobDBImpl : public BlobDB {
       std::vector<std::string>* const output_file_names = nullptr,
       CompactionJobInfo* compaction_job_info = nullptr) override;
 
-  BlobDBOptions GetBlobDBOptions() const override;
-
   BlobDBImpl(const std::string& dbname, const BlobDBOptions& bdb_options,
              const DBOptions& db_options,
              const ColumnFamilyOptions& cf_options);
@@ -160,8 +155,6 @@ class BlobDBImpl : public BlobDB {
   ~BlobDBImpl();
 
   Status Open(std::vector<ColumnFamilyHandle*>* handles);
-
-  Status SyncBlobFiles(const WriteOptions& write_options) override;
 
   // Common part of the two GetCompactionContext methods below.
   // REQUIRES: read lock on mutex_
@@ -213,6 +206,8 @@ class BlobDBImpl : public BlobDB {
   // Create a snapshot if there isn't one in read options.
   // Return true if a snapshot is created.
   bool SetSnapshotIfNeeded(ReadOptions* read_options);
+
+  Status SyncBlobFiles(const WriteOptions& write_options);
 
   Status GetImpl(const ReadOptions& read_options,
                  ColumnFamilyHandle* column_family, const Slice& key,

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -84,6 +84,7 @@ class BlobDBTest : public testing::Test {
       options.stats_dump_period_sec = 0;
       options.stats_persist_period_sec = 0;
     }
+    bdb_options_ = bdb_options;
     return BlobDB::Open(options, bdb_options, dbname_, &blob_db_);
   }
 
@@ -109,10 +110,9 @@ class BlobDBTest : public testing::Test {
   void Destroy() {
     if (blob_db_) {
       Options options = blob_db_->GetOptions();
-      BlobDBOptions bdb_options = blob_db_->GetBlobDBOptions();
       delete blob_db_;
       blob_db_ = nullptr;
-      ASSERT_OK(DestroyBlobDB(dbname_, options, bdb_options));
+      ASSERT_OK(DestroyBlobDB(dbname_, options, bdb_options_));
     }
   }
 
@@ -295,6 +295,7 @@ class BlobDBTest : public testing::Test {
   std::unique_ptr<Env> mock_env_;
   std::unique_ptr<FaultInjectionTestEnv> fault_injection_env_;
   BlobDB* blob_db_;
+  BlobDBOptions bdb_options_;
 };  // class BlobDBTest
 
 TEST_F(BlobDBTest, Put) {


### PR DESCRIPTION
Remove `GetBlobDBOptions()` and `SyncBlobFiles()` from the public `BlobDB` interface. `GetBlobDBOptions()` is now replaced by storing `bdb_options_` as a member in the test class. `SyncBlobFiles()` is moved to private in `BlobDBImpl` since it's only called internally. Also remove unused `kDeleteCheckPeriodMillisecs` constant.

Reviewed By: xingbowang

Differential Revision: D91089111


