### PR TITLE
Add a cleanup target to crash_test.mk

### DIFF
--- a/crash_test.mk
+++ b/crash_test.mk
@@ -34,6 +34,7 @@ CRASHTEST_PY=$(PYTHON) -u tools/db_crashtest.py --stress_cmd=$(DB_STRESS_CMD) --
 	whitebox_crash_test_with_txn whitebox_crash_test_with_ts \
 	whitebox_crash_test_with_optimistic_txn \
 	whitebox_crash_test_with_tiered_storage \
+	crash_test_db_cleanup \
 
 crash_test: $(DB_STRESS_CMD)
 # Do not parallelize
@@ -160,6 +161,9 @@ whitebox_crash_test_with_tiered_storage: $(DB_STRESS_CMD)
 whitebox_crash_test_with_optimistic_txn: $(DB_STRESS_CMD)
 	$(CRASHTEST_PY) --optimistic_txn whitebox --random_kill_odd \
       $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
+
+crash_test_db_cleanup: $(DB_STRESS_CMD)
+	$(DB_STRESS_CMD) --delete_dir_and_exit=$(TEST_TMPDIR)
 
 # Old names DEPRECATED
 crash_test_with_txn: crash_test_with_wc_txn

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -101,6 +101,7 @@ DECLARE_bool(verify_before_write);
 DECLARE_bool(histogram);
 DECLARE_bool(destroy_db_initially);
 DECLARE_bool(destroy_db_and_exit);
+DECLARE_string(delete_dir_and_exit);
 DECLARE_bool(verbose);
 DECLARE_bool(progress_reports);
 DECLARE_uint64(db_write_buffer_size);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -139,6 +139,10 @@ DEFINE_bool(destroy_db_and_exit, false,
             "Destroys the database dir and exits. Useful for cleanup without "
             "running stress test. Other options are mostly ignored.");
 
+DEFINE_string(delete_dir_and_exit, "",
+              "Recursively deletes the specified directory and exits. "
+              "Useful for cleaning up TEST_TMPDIR after crash tests.");
+
 DEFINE_bool(verbose, false, "Verbose");
 
 DEFINE_bool(progress_reports, true,

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -111,6 +111,20 @@ int db_stress_tool(int argc, char** argv) {
     }
   }
 
+  // Handle --delete_dir_and_exit early, before other option validation
+  if (!FLAGS_delete_dir_and_exit.empty()) {
+    s = DestroyDir(raw_env, FLAGS_delete_dir_and_exit);
+    if (s.ok()) {
+      fprintf(stdout, "Successfully deleted directory %s\n",
+              FLAGS_delete_dir_and_exit.c_str());
+      return 0;
+    } else {
+      fprintf(stderr, "Failed to delete directory %s: %s\n",
+              FLAGS_delete_dir_and_exit.c_str(), s.ToString().c_str());
+      return 1;
+    }
+  }
+
   FLAGS_rep_factory = StringToRepFactory(FLAGS_memtablerep.c_str());
 
   // The number of background threads should be at least as much the


### PR DESCRIPTION
Summary: Add the db_c leanup target which can be used by CI test scripts to delete the db on failure. The db_crashtest.py doesn't automatically delete on error.

Differential Revision: D91912877


