### PR TITLE
Add Txn db support to ldb

### DIFF
--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -23,6 +23,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/utilities/db_ttl.h"
 #include "rocksdb/utilities/ldb_cmd_execute_result.h"
+#include "rocksdb/utilities/transaction_db.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -42,6 +43,8 @@ class LDBCommand {
   static const std::string ARG_TTL;
   static const std::string ARG_TTL_START;
   static const std::string ARG_TTL_END;
+  static const std::string ARG_USE_TXN;
+  static const std::string ARG_TXN_WRITE_POLICY;
   static const std::string ARG_TIMESTAMP;
   static const std::string ARG_TRY_LOAD_OPTIONS;
   static const std::string ARG_IGNORE_UNKNOWN_OPTIONS;
@@ -164,6 +167,7 @@ class LDBCommand {
   std::string column_family_name_;
   DB* db_;
   DBWithTTL* db_ttl_;
+  TransactionDB* db_txn_;
   std::map<std::string, ColumnFamilyHandle*> cf_handles_;
   std::map<uint32_t, const Comparator*> ucmps_;
 
@@ -181,6 +185,13 @@ class LDBCommand {
 
   /** If true, the value is treated as timestamp suffixed */
   bool is_db_ttl_;
+
+  /** If true, open the DB as TransactionDB */
+  bool is_db_txn_;
+
+  /** Transaction write policy (0=WRITE_COMMITTED, 1=WRITE_PREPARED,
+   * 2=WRITE_UNPREPARED) */
+  int txn_write_policy_;
 
   // If true, the kvs are output with their insert/modify timestamp in a ttl db
   bool timestamp_;

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -347,6 +347,44 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunFAIL("get --ttl a3")
         self.assertRunOK("checkconsistency", "OK")
 
+    def testTxnPutGet(self):
+        print("Running testTxnPutGet...")
+        # Test basic put/get with TransactionDB (WriteCommitted - default)
+        self.assertRunOK("put t1 v1 --use_txn --create_if_missing", "OK")
+        self.assertRunOK("put t2 v2 --use_txn", "OK")
+        self.assertRunOK("put t3 v3 --use_txn", "OK")
+        # Verify data can be read back with TransactionDB
+        self.assertRunOK("batchput t4 v4 t5 v5 --use_txn", "OK")
+
+        # Test with WritePrepared policy (txn_write_policy=1)
+        self.assertRunOK("put t6 v6 --use_txn --txn_write_policy=1", "OK")
+
+        # Test with WriteUnprepared policy (txn_write_policy=2)
+        self.assertRunOK("put t7 v7 --use_txn --txn_write_policy=2", "OK")
+
+        # Verify all data persists and can be read without --use_txn
+        # (regular DB::Open should work for WriteCommitted data)
+        self.assertRunOK(
+            "scan",
+            "t1 ==> v1\nt2 ==> v2\nt3 ==> v3\nt4 ==> v4\nt5 ==> v5\nt6 ==> v6\nt7 ==> v7",
+        )
+
+        # Test delete with TransactionDB
+        self.assertRunOK("delete t3 --use_txn", "OK")
+        self.assertRunOK(
+            "scan",
+            "t1 ==> v1\nt2 ==> v2\nt4 ==> v4\nt5 ==> v5\nt6 ==> v6\nt7 ==> v7",
+        )
+
+        # Verify that --use_txn and --ttl cannot be used together
+        self.assertRunFAIL("put x1 y1 --use_txn --ttl --create_if_missing")
+
+        # Verify invalid txn_write_policy values are handled
+        # (values outside 0-2 should fall back to 0)
+        self.assertRunOK("put t8 v8 --use_txn --txn_write_policy=0", "OK")
+
+        self.assertRunOK("checkconsistency", "OK")
+
     def testInvalidCmdLines(self):  # noqa: F811 T25377293 Grandfathered in
         print("Running testInvalidCmdLines...")
         # db not specified

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -52,6 +52,13 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
   ret.append("  --" + LDBCommand::ARG_TTL +
              " with 'put','get','scan','dump','query','batchput'"
              " : DB supports ttl and value is internally timestamp-suffixed\n");
+  ret.append("  --" + LDBCommand::ARG_USE_TXN +
+             " : Open database as TransactionDB. Required for databases "
+             "created with WritePrepared or WriteUnprepared transactions.\n");
+  ret.append("  --" + LDBCommand::ARG_TXN_WRITE_POLICY +
+             "=<0|1|2> : Transaction write policy. "
+             "0=WRITE_COMMITTED (default), 1=WRITE_PREPARED, "
+             "2=WRITE_UNPREPARED\n");
   ret.append("  --" + LDBCommand::ARG_TRY_LOAD_OPTIONS +
              " : Try to load option file from DB. Default to true if " +
              LDBCommand::ARG_DB +


### PR DESCRIPTION
  This change adds the ability to open and operate on databases as TransactionDB in the ldb command-line tool.                                                                                                          
                                                                                                                                                                                                                        
  New Command-Line Options                                                                                                                                                                                              
                                                                                                                                                                                                                        
  - --use_txn - Opens the database as a TransactionDB instead of a regular DB                                                                                                                                           
  - --txn_write_policy=<0|1|2> - Sets the transaction write policy:                                                                                                                                                     
    - 0 = WRITE_COMMITTED (default)                                                                                                                                                                                     
    - 1 = WRITE_PREPARED                                                                                                                                                                                                
    - 2 = WRITE_UNPREPARED                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                
  Use Case                                                                                                                                                                                                              
                                                                                                                                                                                                                      This is needed to inspect or modify databases that were created with WritePrepared or WriteUnprepared transactions, which require opening via TransactionDB::Open() rather than the regular DB::Open().    

Test plan:
Tests (tools/ldb_test.py): Adds testTxnPutGet() covering:                                                                                                                                                          
    - Basic put/get/delete with TransactionDB                                                                                                                                                                           
    - All three write policies                                                                                                                                                                                          
    - Validation that --use_txn and --ttl are mutually exclusive                                                                                                                                                        
          
