### PR TITLE
Findzstd.cmake: support pkg-config based zstd detection

### DIFF
--- a/cmake/modules/Findzstd.cmake
+++ b/cmake/modules/Findzstd.cmake
@@ -14,6 +14,10 @@ find_library(ZSTD_LIBRARIES
   HINTS ${zstd_ROOT_DIR}/lib)
 
 include(FindPackageHandleStandardArgs)
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(ZSTD QUIET libzstd)
+endif()
 find_package_handle_standard_args(zstd DEFAULT_MSG ZSTD_LIBRARIES ZSTD_INCLUDE_DIRS)
 
 mark_as_advanced(


### PR DESCRIPTION
In Yocto builds, zstd is built via Makefile and does not install
CMake package configuration files. As a result, Findzstd.cmake
fails to detect ZSTD_INCLUDE_DIRS.

Add pkg-config based detection as a fallback to properly locate
zstd headers and libraries.

fix error:
usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
|   Could NOT find zstd (missing: ZSTD_INCLUDE_DIRS)
| Call Stack (most recent call first):
|   /home/kiminja/linux-workspace/scarthg