### PR TITLE
Propagate file_checksum through FileOptions on NewRandomAccessFile

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2807,7 +2807,10 @@ Status CompactionJob::ReadTablePropertiesDirectly(
     std::shared_ptr<const TableProperties>* tp) {
   std::unique_ptr<FSRandomAccessFile> file;
   std::string file_name = GetTableFileName(file_meta->fd.GetNumber());
-  Status s = ioptions.fs->NewRandomAccessFile(file_name, file_options_, &file,
+  FileOptions fopts = file_options_;
+  fopts.file_checksum = file_meta->file_checksum;
+  fopts.file_checksum_func_name = file_meta->file_checksum_func_name;
+  Status s = ioptions.fs->NewRandomAccessFile(file_name, fopts, &file,
                                               nullptr /* dbg */);
   if (!s.ok()) {
     return s;

--- a/db/convenience.cc
+++ b/db/convenience.cc
@@ -65,7 +65,7 @@ Status VerifySstFileChecksum(const Options& options,
 }
 
 Status VerifySstFileChecksumInternal(const Options& options,
-                                     const EnvOptions& env_options,
+                                     const FileOptions& file_options,
                                      const ReadOptions& read_options,
                                      const std::string& file_path,
                                      const SequenceNumber& largest_seqno) {
@@ -74,8 +74,8 @@ Status VerifySstFileChecksumInternal(const Options& options,
   InternalKeyComparator internal_comparator(options.comparator);
   ImmutableOptions ioptions(options);
 
-  Status s = ioptions.fs->NewRandomAccessFile(
-      file_path, FileOptions(env_options), &file, nullptr);
+  Status s =
+      ioptions.fs->NewRandomAccessFile(file_path, file_options, &file, nullptr);
   if (s.ok()) {
     s = ioptions.fs->GetFileSize(file_path, IOOptions(), &file_size, nullptr);
   } else {
@@ -94,7 +94,7 @@ Status VerifySstFileChecksumInternal(const Options& options,
   const bool kImmortal = true;
   auto reader_options = TableReaderOptions(
       ioptions, options.prefix_extractor, options.compression_manager.get(),
-      env_options, internal_comparator, options.block_protection_bytes_per_key,
+      file_options, internal_comparator, options.block_protection_bytes_per_key,
       false /* skip_filters */, !kImmortal, false /* force_direct_prefetch */,
       -1 /* level */);
   reader_options.largest_seqno = largest_seqno;

--- a/db/convenience_impl.h
+++ b/db/convenience_impl.h
@@ -5,10 +5,11 @@
 
 #pragma once
 #include "rocksdb/db.h"
+#include "rocksdb/file_system.h"
 
 namespace ROCKSDB_NAMESPACE {
 Status VerifySstFileChecksumInternal(const Options& options,
-                                     const EnvOptions& env_options,
+                                     const FileOptions& file_options,
                                      const ReadOptions& read_options,
                                      const std::string& file_path,
                                      const SequenceNumber& largest_seqno = 0);

--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -310,8 +310,10 @@ Status ImportColumnFamilyJob::GetIngestedFileInfo(
   std::unique_ptr<FSRandomAccessFile> sst_file;
   std::unique_ptr<RandomAccessFileReader> sst_file_reader;
 
-  status =
-      fs_->NewRandomAccessFile(external_file, env_options_, &sst_file, nullptr);
+  FileOptions fo{env_options_};
+  fo.file_checksum = file_meta.file_checksum;
+  fo.file_checksum_func_name = file_meta.file_checksum_func_name;
+  status = fs_->NewRandomAccessFile(external_file, fo, &sst_file, nullptr);
   if (!status.ok()) {
     return status;
   }

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -98,6 +98,8 @@ Status TableCache::GetTableReader(
   std::unique_ptr<FSRandomAccessFile> file;
   FileOptions fopts = file_options;
   fopts.temperature = file_temperature;
+  fopts.file_checksum = file_meta.file_checksum;
+  fopts.file_checksum_func_name = file_meta.file_checksum_func_name;
   Status s = PrepareIOFromReadOptions(ro, ioptions_.clock, fopts.io_options);
   TEST_SYNC_POINT_CALLBACK("TableCache::GetTableReader:BeforeOpenFile",
                            const_cast<Status*>(&s));
@@ -113,8 +115,7 @@ Status TableCache::GetTableReader(
     Status temp_s =
         PrepareIOFromReadOptions(ro, ioptions_.clock, fopts.io_options);
     if (temp_s.ok()) {
-      temp_s = ioptions_.fs->NewRandomAccessFile(fname, file_options, &file,
-                                                 nullptr);
+      temp_s = ioptions_.fs->NewRandomAccessFile(fname, fopts, &file, nullptr);
     }
     if (temp_s.ok()) {
       RecordTick(ioptions_.stats, NO_FILE_OPENS);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1820,8 +1820,10 @@ Status Version::GetTableProperties(const ReadOptions& read_options,
     file_name = TableFileName(ioptions.cf_paths, file_meta->fd.GetNumber(),
                               file_meta->fd.GetPathId());
   }
-  s = ioptions.fs->NewRandomAccessFile(file_name, file_options_, &file,
-                                       nullptr);
+  FileOptions fopts = file_options_;
+  fopts.file_checksum = file_meta->file_checksum;
+  fopts.file_checksum_func_name = file_meta->file_checksum_func_name;
+  s = ioptions.fs->NewRandomAccessFile(file_name, fopts, &file, nullptr);
   if (!s.ok()) {
     return s;
   }

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -94,8 +94,10 @@ int db_stress_tool(int argc, char** argv) {
     raw_env = fault_env_guard.get();
   }
 
-  env_wrapper_guard = std::make_shared<CompositeEnvWrapper>(
-      raw_env, std::make_shared<DbStressFSWrapper>(raw_env->GetFileSystem()));
+  auto db_stress_fs =
+      std::make_shared<DbStressFSWrapper>(raw_env->GetFileSystem());
+  env_wrapper_guard =
+      std::make_shared<CompositeEnvWrapper>(raw_env, db_stress_fs);
   db_stress_env = env_wrapper_guard.get();
 
   // Handle --destroy_db_and_exit early, before other option validation

--- a/file/file_util.h
+++ b/file/file_util.h
@@ -83,7 +83,8 @@ IOStatus GenerateOneFileChecksum(
     std::string* file_checksum_func_name,
     size_t verify_checksums_readahead_size, bool allow_mmap_reads,
     std::shared_ptr<IOTracer>& io_tracer, RateLimiter* rate_limiter,
-    const ReadOptions& read_options, Statistics* stats, SystemClock* clock);
+    const ReadOptions& read_options, Statistics* stats, SystemClock* clock,
+    const FileOptions& file_options);
 
 inline IOStatus PrepareIOFromReadOptions(const ReadOptions& ro,
                                          SystemClock* clock, IOOptions& opts,

--- a/include/rocksdb/file_checksum.h
+++ b/include/rocksdb/file_checksum.h
@@ -22,7 +22,12 @@ namespace ROCKSDB_NAMESPACE {
 // The unknown file checksum.
 constexpr char kUnknownFileChecksum[] = "";
 // The unknown sst file checksum function name.
+// Indicates that the file metadata says that no checksum factory was configured
+// when the file was written.
 constexpr char kUnknownFileChecksumFuncName[] = "Unknown";
+// Used when opening a file and there is no file checksum metadata to propagate
+// at all.
+constexpr char kNoFileChecksumFuncName[] = "Unavailable";
 // The standard DB file checksum function name.
 // This is the name of the checksum function returned by
 // GetFileChecksumGenCrc32cFactory();

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -201,6 +201,19 @@ struct FileOptions : EnvOptions {
   // FSWritableFile object creation.
   Env::WriteLifeTimeHint write_hint = Env::WLTH_NOT_SET;
 
+  // File checksum of the file being opened. Empty string if no checksum is
+  // available.
+  std::string file_checksum;
+
+  // Name of the checksum function used to compute file_checksum. Set to
+  // kUnknownFileChecksumFuncName when file was created without a checksum
+  // factory. Set to kNoFileChecksumFuncName when no checksum metadata is
+  // available.
+  // Production FileSystems will accept empty values for both
+  // file_checksum and file_checksum_func_name, but internally within RocksDB
+  // that is forbidden for checking/auditing purposes.
+  std::string file_checksum_func_name;
+
   FileOptions() : EnvOptions(), handoff_checksum_type(ChecksumType::kCRC32c) {}
 
   FileOptions(const DBOptions& opts)
@@ -216,7 +229,9 @@ struct FileOptions : EnvOptions {
         io_options(opts.io_options),
         temperature(opts.temperature),
         handoff_checksum_type(opts.handoff_checksum_type),
-        write_hint(opts.write_hint) {}
+        write_hint(opts.write_hint),
+        file_checksum(opts.file_checksum),
+        file_checksum_func_name(opts.file_checksum_func_name) {}
 
   FileOptions& operator=(const FileOptions&) = default;
 };

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -23,6 +23,7 @@
 #include "port/port.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
+#include "rocksdb/file_checksum.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/status.h"
@@ -85,6 +86,7 @@ Status SstFileDumper::GetTableReader(const std::string& file_path) {
   uint64_t file_size = 0;
   FileOptions fopts = soptions_;
   fopts.temperature = file_temp_;
+  fopts.file_checksum_func_name = kNoFileChecksumFuncName;
   Status s = fs->NewRandomAccessFile(file_path, fopts, &file, nullptr);
   if (s.ok()) {
     // check empty file
@@ -129,6 +131,7 @@ Status SstFileDumper::GetTableReader(const std::string& file_path) {
       if (magic_number == kCuckooTableMagicNumber) {
         fopts = soptions_;
         fopts.temperature = file_temp_;
+        fopts.file_checksum_func_name = kNoFileChecksumFuncName;
       }
 
       fs->NewRandomAccessFile(file_path, fopts, &file, nullptr);

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -11,6 +11,7 @@
 #include "file/random_access_file_reader.h"
 #include "options/cf_options.h"
 #include "rocksdb/env.h"
+#include "rocksdb/file_checksum.h"
 #include "rocksdb/file_system.h"
 #include "table/get_context.h"
 #include "table/table_builder.h"
@@ -51,6 +52,7 @@ Status SstFileReader::Open(const std::string& file_path) {
   std::unique_ptr<FSRandomAccessFile> file;
   std::unique_ptr<RandomAccessFileReader> file_reader;
   FileOptions fopts(r->soptions);
+  fopts.file_checksum_func_name = kNoFileChecksumFuncName;
   const auto& fs = r->options.env->GetFileSystem();
 
   s = fs->GetFileSize(file_path, fopts.io_options, &file_size, nullptr);


### PR DESCRIPTION
Summary: Add file_checksum and file_checksum_func_name fields to FileOptions so that downstream FileSystem implementations can access per-file checksum metadata when SST files are opened. The fields are populated from FileMetaData at all call sites where SST files are opened via NewRandomAccessFile: TableCache::GetTableReader, Version::GetTableProperties, and CompactionJob::ReadTablePropertiesDirectly. Also fixes the fallback path in TableCache::GetTableReader to use the local fopts (with temperature and checksum) instead of the original file_options.

Differential Revision: D92728944


