### PR TITLE
Default CompactionOptionsUniversal::reduce_file_locking to be true

### DIFF
--- a/include/rocksdb/universal_compaction.h
+++ b/include/rocksdb/universal_compaction.h
@@ -111,8 +111,6 @@ class CompactionOptionsUniversal {
   // Default: false
   bool incremental;
 
-  // EXPERIMENTAL
-  //
   // If true, auto universal compaction picking will adjust to minimize locking
   // of input files when bottom priority compactions are waiting to run. This
   // can increase the likelihood of existing L0s being selected for compaction,
@@ -120,7 +118,7 @@ class CompactionOptionsUniversal {
   // the overrall write amplification and compaction load on low priority
   // threads.
   //
-  // Default: false (disabled)
+  // Default: true (enabled)
   //
   // This options does not apply to manual compactions.
   //
@@ -142,7 +140,7 @@ class CompactionOptionsUniversal {
         stop_style(kCompactionStopStyleTotalSize),
         allow_trivial_move(false),
         incremental(false),
-        reduce_file_locking(false) {}
+        reduce_file_locking(true) {}
 
   bool operator==(const CompactionOptionsUniversal& rhs) const = default;
 };

--- a/unreleased_history/behavior_changes/reduce_file_locking_default_true.md
+++ b/unreleased_history/behavior_changes/reduce_file_locking_default_true.md
@@ -1,0 +1,1 @@
+Change the default value of `CompactionOptionsUniversal::reduce_file_locking` from `false` to `true` to improve write stall and reduce read regression


### PR DESCRIPTION
**Context/Summary:**

Internal adoption has demonstrated stability and measurable improvements of this feature without much cost so we can turn it on by default. Eventually we'd like to remove this configuration and make this an expected behavior.

**Test:**
Existing unit test 
