### PR TITLE
[10.11.x and older] Fix format compatibility issue compacting files from 2.x releases

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2453,7 +2453,12 @@ bool CompactionJob::UpdateInternalStatsFromInputFiles(
   // the presence of the user property "rocksdb.block.based.table.index.type",
   // which was added in RocksDB 2.8 and is always present in block-based tables.
   for (const auto& tp_pair : input_table_properties) {
-    if (tp_pair.second && tp_pair.second->format_version < 5) {
+    if (!tp_pair.second) {
+      // Missing table properties - can't verify record counts
+      job_stats_->has_accurate_num_input_records = false;
+      break;
+    }
+    if (tp_pair.second->format_version < 5) {
       // Check for block-based table by looking for its index type property
       const auto& user_props = tp_pair.second->user_collected_properties;
       if (user_props.find(BlockBasedTablePropertyNames::kIndexType) !=
@@ -2491,7 +2496,8 @@ bool CompactionJob::UpdateInternalStatsFromInputFiles(
         std::string fn = TableFileName(compaction->immutable_options().cf_paths,
                                        file_number, file_meta->fd.GetPathId());
         const auto& tp = input_table_properties.find(fn);
-        if (tp != input_table_properties.end()) {
+        if (tp != input_table_properties.end() && tp->second &&
+            tp->second->num_entries > 0) {
           file_input_entries = tp->second->num_entries;
           file_num_range_del = tp->second->num_range_deletions;
         } else {

--- a/unreleased_history/bug_fixes/deleterange_format_compatible.md
+++ b/unreleased_history/bug_fixes/deleterange_format_compatible.md
@@ -1,1 +1,1 @@
-* Fix longstanding failures that can arise from reading and/or compacting old DB dirs with range deletions (likely from version < 5.19.0) in many newer versions.
+* Fix some longstanding failures that can arise from reading and/or compacting old DB dirs (likely from version < 5.19.0) in many newer versions.


### PR DESCRIPTION
Summary: Found using updated format-compatible test on the 10.11.fb branch, especially on 2.2.fb and 2.6.fb branches.

This change is irrelevant to the `main` branch, which has removed support for even reading these old format versions.

I intend to back-port this to older releases, on top of #14323. Both might need some tweaking working our way backwards.

Test Plan: LONG_TEST=1 J=140 tools/check_format_compatible.sh
(too tricky to create unit tests, especially for old releases like this)