### PR TITLE
Fix UB in ReadBe64FromKey shift by 64

### DIFF
--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -167,7 +167,9 @@ static uint64_t ReadBe64FromKey(Slice s, bool is_user_key, size_t offset) {
   for (size_t i = 0; i < len; i++) {
     val = (val << 8) | static_cast<uint8_t>(s.data()[offset + i]);
   }
-  val <<= (8 - len) * 8;  // Pad zeros on the right
+  if (len > 0 && len < 8) {
+    val <<= (8 - len) * 8;  // Pad zeros on the right
+  }
   return val;
 }
 


### PR DESCRIPTION
`ReadBe64FromKey` pads its result with `val <<= (8 - len) * 8` to right-align partial reads. When the seek target's user key is shorter than shared_prefix_len, len is 0 and this becomes a shift by 64, which is undefined behavior for uint64_t. On x86 this happens to produce 0 (the correct result), but UBSan rightfully flags it. Guard the shift with `len > 0 && len < 8`.

Reviewed By: joshkang97

Differential Revision: D93435715


