### PR TITLE
Test compaction forward compatibility

### DIFF
--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -369,7 +369,7 @@ do
     compare_db $db_test_dir/$checkout_ref $current_db_test_dir forward_${checkout_ref}_dump.txt 0
 
     echo "== Use $checkout_ref to compact a copy of DB generated using $current_checkout_name..."
-    cp -a $current_db_test_dir ${current_db_test_dir}_copy_for_${checkout_ref}
+    [ "$SANITY_CHECK" ] || cp -a $current_db_test_dir ${current_db_test_dir}_copy_for_${checkout_ref}
     compact_db ${current_db_test_dir}_copy_for_${checkout_ref} 0
 
     echo "== After compaction, re-verify DB copy originally from $current_checkout_name..."


### PR DESCRIPTION
Summary: Extending #14323 by testing scenarios for compaction after downgrade. Detail: we shouldn't need to test loading options with compaction, as options file inclusion is mostly a sanity check for "can you open the DB with options file?"

Test Plan: manual run of SHORT_TEST=1 J=140 tools/check