### PR TITLE
Remove deprecated SliceTransform::InRange() virtual method

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -596,7 +596,6 @@ struct rocksdb_slicetransform_t : public SliceTransform {
   char* (*transform_)(void*, const char* key, size_t length,
                       size_t* dst_length);
   unsigned char (*in_domain_)(void*, const char* key, size_t length);
-  unsigned char (*in_range_)(void*, const char* key, size_t length);
 
   ~rocksdb_slicetransform_t() override { (*destructor_)(state_); }
 
@@ -610,10 +609,6 @@ struct rocksdb_slicetransform_t : public SliceTransform {
 
   bool InDomain(const Slice& src) const override {
     return (*in_domain_)(state_, src.data(), src.size());
-  }
-
-  bool InRange(const Slice& src) const override {
-    return (*in_range_)(state_, src.data(), src.size());
   }
 };
 
@@ -6892,14 +6887,12 @@ rocksdb_slicetransform_t* rocksdb_slicetransform_create(
     char* (*transform)(void*, const char* key, size_t length,
                        size_t* dst_length),
     unsigned char (*in_domain)(void*, const char* key, size_t length),
-    unsigned char (*in_range)(void*, const char* key, size_t length),
     const char* (*name)(void*)) {
   rocksdb_slicetransform_t* result = new rocksdb_slicetransform_t;
   result->state_ = state;
   result->destructor_ = destructor;
   result->transform_ = transform;
   result->in_domain_ = in_domain;
-  result->in_range_ = in_range;
   result->name_ = name;
   return result;
 }
@@ -6915,7 +6908,6 @@ struct SliceTransformWrapper : public rocksdb_slicetransform_t {
     return rep_->Transform(src);
   }
   bool InDomain(const Slice& src) const override { return rep_->InDomain(src); }
-  bool InRange(const Slice& src) const override { return rep_->InRange(src); }
   static void DoNothing(void*) {}
 };
 

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -137,11 +137,6 @@ class SliceTransformLimitedDomainGeneric : public SliceTransform {
     // prefix will be x????
     return src.size() >= 5;
   }
-
-  bool InRange(const Slice& dst) const override {
-    // prefix will be x????
-    return dst.size() == 5;
-  }
 };
 
 // KeyMayExist can lead to a few false positives, but not false negatives.
@@ -2076,11 +2071,6 @@ class SliceTransformLimitedDomain : public SliceTransform {
   bool InDomain(const Slice& src) const override {
     // prefix will be x????
     return src.size() >= 5 && src[0] == 'x';
-  }
-
-  bool InRange(const Slice& dst) const override {
-    // prefix will be x????
-    return dst.size() == 5 && dst[0] == 'x';
   }
 };
 

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -1842,11 +1842,6 @@ class SliceTransformLimitedDomainGeneric : public SliceTransform {
     // prefix will be x????
     return src.size() >= 1;
   }
-
-  bool InRange(const Slice& dst) const override {
-    // prefix will be x????
-    return dst.size() == 1;
-  }
 };
 
 TEST_P(DBIteratorTest, IterSeekForPrevCrossingFiles) {

--- a/db/db_memtable_test.cc
+++ b/db/db_memtable_test.cc
@@ -117,8 +117,6 @@ class TestPrefixExtractor : public SliceTransform {
     return separator(key) != nullptr;
   }
 
-  bool InRange(const Slice& /*key*/) const override { return false; }
-
  private:
   const char* separator(const Slice& key) const {
     return static_cast<const char*>(memchr(key.data(), '_', key.size()));

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -980,11 +980,6 @@ class InternalKeySliceTransform : public SliceTransform {
     return transform_->InDomain(user_key);
   }
 
-  bool InRange(const Slice& dst) const override {
-    auto user_key = ExtractUserKey(dst);
-    return transform_->InRange(user_key);
-  }
-
   const SliceTransform* user_prefix_extractor() const { return transform_; }
 
  private:

--- a/db/prefix_test.cc
+++ b/db/prefix_test.cc
@@ -220,8 +220,6 @@ class SamePrefixTransform : public SliceTransform {
     return false;
   }
 
-  bool InRange(const Slice& dst) const override { return dst == prefix_; }
-
   bool FullLengthEnabled(size_t* /*len*/) const override { return false; }
 };
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2725,7 +2725,6 @@ rocksdb_slicetransform_create(
     char* (*transform)(void*, const char* key, size_t length,
                        size_t* dst_length),
     unsigned char (*in_domain)(void*, const char* key, size_t length),
-    unsigned char (*in_range)(void*, const char* key, size_t length),
     const char* (*name)(void*));
 extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
 rocksdb_slicetransform_create_fixed_prefix(size_t);

--- a/include/rocksdb/slice_transform.h
+++ b/include/rocksdb/slice_transform.h
@@ -8,9 +8,8 @@
 //
 // Class for specifying user-defined functions which perform a
 // transformation on a slice.  It is not required that every slice
-// belong to the domain and/or range of a function.  Subclasses should
-// define InDomain and InRange to determine which slices are in either
-// of these sets respectively.
+// belong to the domain of a function.  Subclasses should
+// define InDomain to determine which slices are in this set.
 
 #pragma once
 
@@ -69,10 +68,6 @@ class SliceTransform : public Customizable {
   // https://github.com/facebook/rocksdb/wiki/Prefix-Seek
   //
   virtual bool InDomain(const Slice& key) const = 0;
-
-  // DEPRECATED: This is currently not used and remains here for backward
-  // compatibility.
-  virtual bool InRange(const Slice& /*dst*/) const { return false; }
 
   // Returns information on maximum prefix length, if there is one.
   // If Transform(x).size() == n for some keys and otherwise < n,

--- a/options/customizable_test.cc
+++ b/options/customizable_test.cc
@@ -1281,8 +1281,6 @@ class MockSliceTransform : public SliceTransform {
   Slice Transform(const Slice& /*key*/) const override { return Slice(); }
 
   bool InDomain(const Slice& /*key*/) const override { return false; }
-
-  bool InRange(const Slice& /*key*/) const override { return false; }
 };
 
 class MockMemoryAllocator : public BaseMemoryAllocator {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -740,9 +740,6 @@ class FixedOrLessPrefixTransform : public SliceTransform {
 
   bool InDomain(const Slice& /*src*/) const override { return true; }
 
-  bool InRange(const Slice& dst) const override {
-    return (dst.size() <= prefix_len_);
-  }
   bool FullLengthEnabled(size_t* /*len*/) const override { return false; }
 };
 
@@ -5323,10 +5320,6 @@ class TestPrefixExtractor : public ROCKSDB_NAMESPACE::SliceTransform {
 
   bool InDomain(const ROCKSDB_NAMESPACE::Slice& src) const override {
     return IsValid(src);
-  }
-
-  bool InRange(const ROCKSDB_NAMESPACE::Slice& /*dst*/) const override {
-    return true;
   }
 
   bool IsValid(const ROCKSDB_NAMESPACE::Slice& src) const {

--- a/unreleased_history/public_api_changes/remove_slice_transform_inrange.md
+++ b/unreleased_history/public_api_changes/remove_slice_transform_inrange.md
@@ -1,0 +1,1 @@
+Remove deprecated `SliceTransform::InRange()` virtual method and the `in_range` callback parameter from `rocksdb_slicetransform_create()` in the C API. `InRange()` was never called by RocksDB and existed only for backward compatibility.

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -61,10 +61,6 @@ class FixedPrefixTransform : public SliceTransform {
     return (src.size() >= prefix_len_);
   }
 
-  bool InRange(const Slice& dst) const override {
-    return (dst.size() == prefix_len_);
-  }
-
   bool FullLengthEnabled(size_t* len) const override {
     *len = prefix_len_;
     return true;
@@ -111,10 +107,6 @@ class CappedPrefixTransform : public SliceTransform {
 
   bool InDomain(const Slice& /*src*/) const override { return true; }
 
-  bool InRange(const Slice& dst) const override {
-    return (dst.size() <= cap_len_);
-  }
-
   bool FullLengthEnabled(size_t* len) const override {
     *len = cap_len_;
     return true;
@@ -135,8 +127,6 @@ class NoopTransform : public SliceTransform {
   Slice Transform(const Slice& src) const override { return src; }
 
   bool InDomain(const Slice& /*src*/) const override { return true; }
-
-  bool InRange(const Slice& /*dst*/) const override { return true; }
 
   bool SameResultWhenAppended(const Slice& /*prefix*/) const override {
     return false;

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -216,8 +216,6 @@ class DummySliceTransform : public SliceTransform {
   // determine whether this is a valid src upon the function applies
   bool InDomain(const Slice& /*src*/) const override { return false; }
 
-  // determine whether dst=Transform(src) for some src
-  bool InRange(const Slice& /*dst*/) const override { return false; }
 };
 
 }  // namespace


### PR DESCRIPTION
**Summary/Context:**

Remove the `InRange()` virtual method from `SliceTransform` and all its overrides. This method was marked DEPRECATED, never called by RocksDB, and existed only for backward compatibility.

Also removes the `in_range` callback parameter from `rocksdb_slicetransform_create()` in the C API, which is a breaking change appropriate for a major version release.

**Test plan:**
Make check