### PR TITLE
Add corruption guards against hardware bit flips

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -263,6 +263,10 @@ Status BuildTable(
         break;
       }
       builder->Add(key_after_flush, value_after_flush);
+      if (!builder->status().ok()) {
+        s = builder->status();
+        break;
+      }
 
       if (flush_stats) {
         flush_stats->num_output_records++;

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -2557,6 +2557,10 @@ int main(int argc, char** argv) {
     CheckNoError(err);
 
     rocksdb_cuckoo_options_destroy(cuckoo_options);
+
+    // Reset table factory back to block-based so subsequent test phases
+    // (e.g., transactions) don't inherit the cuckoo table factory.
+    rocksdb_options_set_block_based_table_factory(options, table_options);
   }
 
   StartPhase("options");

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -887,6 +887,43 @@ Status CompactionJob::VerifyOutputFiles() {
   VerifyOutputFlags verify_output_flags =
       compact_->compaction->mutable_cf_options().verify_output_flags;
 
+  // Check compaction output/input size ratio. A corrupted value (e.g., from
+  // a hardware bit flip in Slice::size_) can inflate the output file far
+  // beyond what the input data justifies.
+  const uint64_t max_ratio = compact_->compaction->mutable_cf_options()
+                                 .max_compaction_output_to_input_ratio;
+  if (max_ratio > 0) {
+    uint64_t total_input_bytes =
+        compact_->compaction->CalculateTotalInputSize();
+    uint64_t total_output_bytes = 0;
+    for (const auto& state : compact_->sub_compact_states) {
+      for (const auto& output : state.GetOutputs()) {
+        total_output_bytes += output.meta.fd.file_size;
+      }
+    }
+    // Only apply the ratio check when input is large enough for the ratio
+    // to be meaningful. Small inputs (e.g., < 1MB) can legitimately produce
+    // larger output due to block overhead, index/filter blocks, and metadata.
+    static constexpr uint64_t kMinInputForRatioCheck = 1u << 20;  // 1MB
+    if (total_input_bytes >= kMinInputForRatioCheck &&
+        total_output_bytes > total_input_bytes * max_ratio) {
+      ROCKS_LOG_ERROR(
+          db_options_.info_log,
+          "[%s] [JOB %d] Compaction output size anomaly: "
+          "output=%" PRIu64 " input=%" PRIu64 " ratio=%.1f max_ratio=%" PRIu64
+          ". Possible data corruption (e.g., hardware bit flip).",
+          cfd->GetName().c_str(), job_id_, total_output_bytes,
+          total_input_bytes,
+          static_cast<double>(total_output_bytes) / total_input_bytes,
+          max_ratio);
+      status = Status::Corruption(
+          "Compaction output size (" + std::to_string(total_output_bytes) +
+          ") exceeds " + std::to_string(max_ratio) + "x input size (" +
+          std::to_string(total_input_bytes) + "). Possible data corruption.");
+      return status;
+    }
+  }
+
   // For backward compatibility
   if (paranoid_file_checks_) {
     verify_output_flags |= VerifyOutputFlags::kVerifyIteration;

--- a/db/compaction/compaction_outputs.cc
+++ b/db/compaction/compaction_outputs.cc
@@ -421,6 +421,9 @@ Status CompactionOutputs::AddToOutput(
     return s;
   }
   builder_->Add(key, value);
+  if (!builder_->status().ok()) {
+    return builder_->status();
+  }
 
   stats_.num_output_records++;
   current_output_file_size_ = builder_->EstimatedFileSize();

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -11663,6 +11663,211 @@ TEST_F(DBCompactionTest, PeriodicTask) {
   ASSERT_EQ(listener->num_periodic_compactions, 1);
   Close();
 }
+// End-to-end test: verify that a transient hardware bit flip in a value
+// Slice's size_ during compaction is detected, the first compaction attempt
+// fails gracefully (without making DB read-only), and the retry succeeds
+// because the transient error does not recur.
+TEST_F(DBCompactionTest, ValueSliceBitFlipDuringCompaction) {
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.num_levels = 3;
+  options.level0_file_num_compaction_trigger = 3;
+  // Disable auto compaction so we can trigger it manually.
+  options.disable_auto_compactions = true;
+  DestroyAndReopen(options);
+
+  // Write 3 L0 files with overlapping key ranges.
+  for (int file = 0; file < 3; file++) {
+    for (int i = 0; i < 10; i++) {
+      ASSERT_OK(Put(Key(i),
+                    "value_" + std::to_string(file) + "_" + std::to_string(i)));
+    }
+    ASSERT_OK(Flush());
+  }
+  ASSERT_EQ("3", FilesPerLevel());
+
+  // Verify all data is readable before compaction.
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ("value_2_" + std::to_string(i), Get(Key(i)));
+  }
+
+  // Set up SyncPoint to flip bit 32 on the 5th key's value during compaction.
+  // Uses atomic to be safe and only corrupts once (simulating transient error).
+  std::atomic<int> add_count{0};
+  std::atomic<bool> corrupted{false};
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlockBasedTableBuilder::Add:TamperWithValue", [&](void* arg) {
+        int count = add_count.fetch_add(1);
+        if (count == 4 && !corrupted.load()) {
+          corrupted.store(true);
+          Slice* v = static_cast<Slice*>(arg);
+          v->size_ |= size_t{1} << 32;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // First compaction attempt: fails due to bit flip, but treated as transient.
+  Status s = dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+
+  // Disable the corruption injection before testing DB availability.
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  // DB should NOT be in a fatal error state — transient corruption allows
+  // retry. Reads should still work.
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ("value_2_" + std::to_string(i), Get(Key(i)));
+  }
+
+  // Writes should still work (DB is not read-only).
+  ASSERT_OK(Put(Key(100), "new_value"));
+  ASSERT_OK(Flush());
+
+  // Second compaction attempt: succeeds because the bit flip was transient.
+  s = dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_OK(s) << s.ToString();
+
+  // All data should be readable after successful retry.
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ("value_2_" + std::to_string(i), Get(Key(i)));
+  }
+  ASSERT_EQ("new_value", Get(Key(100)));
+
+  // Verify the retry counter was reset: new writes, flushes, and compactions
+  // should all succeed, proving the DB is fully recovered.
+  for (int i = 200; i < 210; i++) {
+    ASSERT_OK(Put(Key(i), "post_recovery_" + std::to_string(i)));
+  }
+  ASSERT_OK(Flush());
+  s = dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_OK(s) << s.ToString();
+
+  // All data (old and new) should be readable.
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ("value_2_" + std::to_string(i), Get(Key(i)));
+  }
+  for (int i = 200; i < 210; i++) {
+    ASSERT_EQ("post_recovery_" + std::to_string(i), Get(Key(i)));
+  }
+}
+
+// End-to-end test: verify that a persistent (non-transient) bit flip causes
+// the DB to become read-only after the retry fails. The first compaction
+// attempt is retried, but the second attempt also hits the corruption
+// (because we keep the SyncPoint active), so the DB escalates to fatal.
+TEST_F(DBCompactionTest, PersistentBitFlipMakesDBReadOnly) {
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.num_levels = 3;
+  options.level0_file_num_compaction_trigger = 3;
+  options.disable_auto_compactions = true;
+  DestroyAndReopen(options);
+
+  for (int file = 0; file < 3; file++) {
+    for (int i = 0; i < 10; i++) {
+      ASSERT_OK(Put(Key(i),
+                    "value_" + std::to_string(file) + "_" + std::to_string(i)));
+    }
+    ASSERT_OK(Flush());
+  }
+  ASSERT_EQ("3", FilesPerLevel());
+
+  // Set up SyncPoint to ALWAYS corrupt (simulating persistent hardware error).
+  // Every compaction attempt will hit this corruption.
+  std::atomic<int> add_count{0};
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlockBasedTableBuilder::Add:TamperWithValue", [&](void* arg) {
+        int count = add_count.fetch_add(1);
+        // Corrupt the 5th key in every compaction attempt
+        if (count % 10 == 4) {
+          Slice* v = static_cast<Slice*>(arg);
+          v->size_ |= size_t{1} << 32;
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // First compaction attempt: fails, but treated as transient (retry allowed).
+  Status s = dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+
+  // Reads should still work after first failure (no BG error set).
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ("value_2_" + std::to_string(i), Get(Key(i)));
+  }
+
+  // Writes should still work after first failure.
+  ASSERT_OK(Put(Key(200), "still_writable"));
+
+  // Second compaction attempt: also fails. This time it should escalate
+  // to a fatal BG error because the corruption is persistent.
+  s = dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  // Reads of existing data should still work even after fatal error.
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ("value_2_" + std::to_string(i), Get(Key(i)));
+  }
+
+  // Writes should now FAIL because the DB is in a fatal error state.
+  s = Put(Key(300), "should_fail");
+  ASSERT_TRUE(!s.ok()) << "Put should fail after persistent corruption: "
+                       << s.ToString();
+}
+
+// End-to-end test: verify that the max_compaction_output_to_input_ratio
+// check detects grossly inflated compaction output and aborts the compaction.
+TEST_F(DBCompactionTest, CompactionOutputToInputRatioCheck) {
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.num_levels = 3;
+  options.level0_file_num_compaction_trigger = 3;
+  options.disable_auto_compactions = true;
+  // Set a tight ratio to make it easy to trigger.
+  options.max_compaction_output_to_input_ratio = 2;
+  DestroyAndReopen(options);
+
+  // Write 3 L0 files large enough to exceed the 1MB minimum threshold
+  // for the ratio check.
+  std::string value_1kb(1024, 'x');
+  for (int file = 0; file < 3; file++) {
+    for (int i = 0; i < 500; i++) {
+      ASSERT_OK(Put(Key(i), value_1kb));
+    }
+    ASSERT_OK(Flush());
+  }
+  ASSERT_EQ("3", FilesPerLevel());
+
+  // Set up SyncPoint to inflate every value to 2MB during compaction.
+  // This will make the output file much larger than input.
+  std::string large_buf(2 << 20, 'x');  // 2MB buffer
+
+  int add_count = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlockBasedTableBuilder::Add:TamperWithValue", [&](void* arg) {
+        add_count++;
+        Slice* v = static_cast<Slice*>(arg);
+        v->data_ = large_buf.data();
+        v->size_ = large_buf.size();
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // Trigger compaction. The output should be much larger than input,
+  // exceeding the 2x ratio limit.
+  Status s = dbfull()->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
+  // The compaction should have failed due to the output/input ratio check.
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+  ASSERT_TRUE(s.ToString().find("exceeds") != std::string::npos)
+      << s.ToString();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -3051,6 +3051,17 @@ class DBImpl : public DB {
   // stores the number of compactions are currently running
   int num_running_compactions_ = 0;
 
+  // Count consecutive transient in-memory corruption errors (e.g., hardware
+  // bit flips). On first occurrence, allow retry. On second, escalate to fatal.
+  int transient_corruption_retry_count_ = 0;
+
+  // Returns true if the error is a transient data corruption that should be
+  // retried rather than escalated to a fatal BG error. On first occurrence,
+  // returns true and increments the counter. On second consecutive occurrence,
+  // returns false (escalate). Resets counter on non-transient errors.
+  // Requires: db_mutex_ held.
+  bool ShouldRetryTransientCorruption(const Status& s, const char* context);
+
   // number of background memtable flush jobs, submitted to the HIGH pool
   int bg_flush_scheduled_ = 0;
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -142,6 +142,31 @@ IOStatus DBImpl::SyncClosedWals(const WriteOptions& write_options,
   return io_s;
 }
 
+bool DBImpl::ShouldRetryTransientCorruption(const Status& s,
+                                            const char* context) {
+  mutex_.AssertHeld();
+  if (!s.IsCorruption() || s.subcode() != Status::kTransientDataCorruption) {
+    // Not a transient corruption — reset counter and don't retry.
+    transient_corruption_retry_count_ = 0;
+    return false;
+  }
+  if (transient_corruption_retry_count_ == 0) {
+    // First occurrence — allow retry.
+    transient_corruption_retry_count_++;
+    ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                   "[%s] Transient data corruption detected, will retry: %s",
+                   context, s.ToString().c_str());
+    return true;
+  }
+  // Second consecutive occurrence — escalate to fatal.
+  ROCKS_LOG_ERROR(immutable_db_options_.info_log,
+                  "[%s] Transient data corruption persisted after retry, "
+                  "escalating to fatal error: %s",
+                  context, s.ToString().c_str());
+  transient_corruption_retry_count_ = 0;
+  return false;
+}
+
 Status DBImpl::FlushMemTableToOutputFile(
     ColumnFamilyData* cfd, const MutableCFOptions& mutable_cf_options,
     bool* made_progress, JobContext* job_context, FlushReason flush_reason,
@@ -330,7 +355,10 @@ Status DBImpl::FlushMemTableToOutputFile(
 
   if (!s.ok() && !s.IsShutdownInProgress() && !s.IsColumnFamilyDropped() &&
       !skip_set_bg_error) {
-    if (log_io_s.ok()) {
+    if (ShouldRetryTransientCorruption(s, cfd->GetName().c_str())) {
+      // Transient corruption: memtable has been rolled back and
+      // imm_flush_needed is set, so the flush will be rescheduled.
+    } else if (log_io_s.ok()) {
       // Error while writing to MANIFEST.
       // In fact, versions_->io_status() can also be the result of renaming
       // CURRENT file. With current code, it's just difficult to tell. So just
@@ -1710,7 +1738,8 @@ Status DBImpl::CompactFilesImpl(
   mutex_.Lock();
 
   if (status.ok()) {
-    // Done
+    // Done. Reset transient corruption counter on success.
+    transient_corruption_retry_count_ = 0;
   } else if (status.IsColumnFamilyDropped() || status.IsShutdownInProgress()) {
     // Ignore compaction errors found during shutting down
   } else if (status.IsManualCompactionPaused()) {
@@ -1724,6 +1753,9 @@ Status DBImpl::CompactFilesImpl(
     ROCKS_LOG_INFO(
         immutable_db_options_.info_log, "[%s] [JOB %d] Compaction aborted",
         c->column_family_data()->GetName().c_str(), job_context->job_id);
+  } else if (ShouldRetryTransientCorruption(
+                 status, c->column_family_data()->GetName().c_str())) {
+    // Transient corruption: input files intact, output not installed.
   } else {
     ROCKS_LOG_WARN(immutable_db_options_.info_log,
                    "[%s] [JOB %d] Compaction error: %s",
@@ -4464,9 +4496,14 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
 
   if (status.ok() || status.IsCompactionTooLarge() ||
       status.IsManualCompactionPaused() || status.IsCompactionAborted()) {
-    // Done
+    // Done. Reset transient corruption counter on success.
+    if (status.ok()) {
+      transient_corruption_retry_count_ = 0;
+    }
   } else if (status.IsColumnFamilyDropped() || status.IsShutdownInProgress()) {
     // Ignore compaction errors found during shutting down
+  } else if (ShouldRetryTransientCorruption(status, "BackgroundCompaction")) {
+    // Transient corruption: input files intact, output not installed.
   } else {
     ROCKS_LOG_WARN(immutable_db_options_.info_log, "Compaction error: %s",
                    status.ToString().c_str());

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -326,6 +326,7 @@ DECLARE_int32(approximate_size_one_in);
 DECLARE_bool(best_efforts_recovery);
 DECLARE_bool(skip_verifydb);
 DECLARE_bool(paranoid_file_checks);
+DECLARE_uint64(max_compaction_output_to_input_ratio);
 DECLARE_uint64(batch_protection_bytes_per_key);
 DECLARE_uint32(memtable_protection_bytes_per_key);
 DECLARE_uint32(block_protection_bytes_per_key);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1130,6 +1130,11 @@ DEFINE_bool(paranoid_file_checks, true,
             "After writing every SST file, reopen it and read all the keys "
             "and validate checksums");
 
+DEFINE_uint64(max_compaction_output_to_input_ratio,
+              ROCKSDB_NAMESPACE::Options().max_compaction_output_to_input_ratio,
+              "Maximum allowed ratio of compaction output size to input size. "
+              "Set to 0 to disable.");
+
 DEFINE_uint64(batch_protection_bytes_per_key, 0,
               "If nonzero, enables integrity protection in `WriteBatch` at the "
               "specified number of bytes per key. Currently the only supported "

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -4585,6 +4585,8 @@ void InitializeOptionsFromFlags(
 
   options.best_efforts_recovery = FLAGS_best_efforts_recovery;
   options.paranoid_file_checks = FLAGS_paranoid_file_checks;
+  options.max_compaction_output_to_input_ratio =
+      FLAGS_max_compaction_output_to_input_ratio;
 
   if (FLAGS_user_timestamp_size > 0) {
     CheckAndSetOptionsForUserTimestamp(options);

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -823,6 +823,18 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through SetOptions() API
   bool paranoid_file_checks = false;
 
+  // Maximum allowed ratio of compaction output size to input size.
+  // If the total output file size exceeds this ratio times the total input
+  // file size, the compaction is aborted with Status::Corruption.
+  // This catches silent data corruption (e.g., hardware bit flips) that
+  // inflates values or blocks to unreasonable sizes.
+  // Set to 0 to disable this check.
+  //
+  // Default: 10 (output cannot exceed 10x input size)
+  //
+  // Dynamically changeable through SetOptions() API.
+  uint64_t max_compaction_output_to_input_ratio = 10;
+
   // Bitmask enum for output verification option.
   //
   // Default: 0 (kVerifyNone)

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -118,6 +118,7 @@ class Status {
     kPrefetchLimitReached = 17,
     kNotExpectedCodePath = 18,
     kCompactionAborted = 19,
+    kTransientDataCorruption = 20,
     kMaxSubCode
   };
 
@@ -208,6 +209,10 @@ class Status {
   }
   static Status Corruption(SubCode msg = kNone) {
     return Status(kCorruption, msg);
+  }
+  static Status Corruption(SubCode sub_code, const Slice& msg,
+                           const Slice& msg2 = Slice()) {
+    return Status(kCorruption, sub_code, msg, msg2);
   }
 
   static Status NotSupported(const Slice& msg, const Slice& msg2 = Slice()) {

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -404,6 +404,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableCFOptions, paranoid_file_checks),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"max_compaction_output_to_input_ratio",
+         {offsetof(struct MutableCFOptions,
+                   max_compaction_output_to_input_ratio),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
         {"verify_output_flags",
          {offsetof(struct MutableCFOptions, verify_output_flags),
           OptionType::kUInt32T, OptionVerificationType::kNormal,
@@ -1224,6 +1229,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  max_sequential_skip_in_iterations);
   ROCKS_LOG_INFO(log, "                     paranoid_file_checks: %d",
                  paranoid_file_checks);
+  ROCKS_LOG_INFO(log, "     max_compaction_output_to_input_ratio: %" PRIu64,
+                 max_compaction_output_to_input_ratio);
   ROCKS_LOG_INFO(log, "                       report_bg_io_stats: %d",
                  report_bg_io_stats);
   ROCKS_LOG_INFO(log, "                              compression: %d",

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -161,6 +161,8 @@ struct MutableCFOptions {
         max_sequential_skip_in_iterations(
             options.max_sequential_skip_in_iterations),
         paranoid_file_checks(options.paranoid_file_checks),
+        max_compaction_output_to_input_ratio(
+            options.max_compaction_output_to_input_ratio),
         report_bg_io_stats(options.report_bg_io_stats),
         compression(options.compression),
         bottommost_compression(options.bottommost_compression),
@@ -230,6 +232,7 @@ struct MutableCFOptions {
         prepopulate_blob_cache(PrepopulateBlobCache::kDisable),
         max_sequential_skip_in_iterations(0),
         paranoid_file_checks(false),
+        max_compaction_output_to_input_ratio(10),
         report_bg_io_stats(false),
         compression(Snappy_Supported() ? kSnappyCompression : kNoCompression),
         bottommost_compression(kDisableCompressionOption),
@@ -336,6 +339,7 @@ struct MutableCFOptions {
   // Misc options
   uint64_t max_sequential_skip_in_iterations;
   bool paranoid_file_checks;
+  uint64_t max_compaction_output_to_input_ratio;
   bool report_bg_io_stats;
   CompressionType compression;
   CompressionType bottommost_compression;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -294,6 +294,8 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->max_sequential_skip_in_iterations =
       moptions.max_sequential_skip_in_iterations;
   cf_opts->paranoid_file_checks = moptions.paranoid_file_checks;
+  cf_opts->max_compaction_output_to_input_ratio =
+      moptions.max_compaction_output_to_input_ratio;
   cf_opts->report_bg_io_stats = moptions.report_bg_io_stats;
   cf_opts->compression = moptions.compression;
   cf_opts->compression_opts = moptions.compression_opts;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -643,6 +643,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "memtable_insert_with_hint_prefix_extractor=rocksdb.CappedPrefix.13;"
       "check_flush_compaction_key_order=false;"
       "paranoid_file_checks=true;"
+      "max_compaction_output_to_input_ratio=10;"
       "force_consistency_checks=true;"
       "inplace_update_num_locks=7429;"
       "experimental_mempurge_threshold=0.0001;"

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1530,6 +1530,26 @@ void BlockBasedTableBuilder::Add(const Slice& ikey, const Slice& value) {
       }
     }
 
+    TEST_SYNC_POINT_CALLBACK("BlockBasedTableBuilder::Add:TamperWithValue",
+                             const_cast<Slice*>(&value));
+
+    // Detect corruption in Slice::size_ that would be silently truncated by
+    // BlockBuilder's static_cast<uint32_t> varint encoding. A bit flip in
+    // bits 32+ causes the varint to record the correct (truncated) size while
+    // buffer_.append() uses the full 64-bit size, writing gigabytes of garbage.
+    if (UNLIKELY(value.size() !=
+                 static_cast<size_t>(static_cast<uint32_t>(value.size())))) {
+      ROCKS_LOG_ERROR(r->ioptions.logger,
+                      "Value size corruption detected: size=%zu exceeds "
+                      "uint32_t range. Likely hardware bit flip.",
+                      value.size());
+      r->SetStatus(Status::Corruption(Status::kTransientDataCorruption,
+                                      "Value size " +
+                                          std::to_string(value.size()) +
+                                          " exceeds uint32_t range"));
+      return;
+    }
+
     r->data_block.AddWithLastKey(ikey, value, r->last_ikey);
     r->last_ikey.assign(ikey.data(), ikey.size());
     assert(!r->last_ikey.empty());

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -314,6 +314,9 @@ default_params = {
     "get_property_one_in": lambda: random.choice([100000, 1000000]),
     "get_properties_of_all_tables_one_in": lambda: random.choice([100000, 1000000]),
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
+    "max_compaction_output_to_input_ratio": lambda: random.choice(
+        [0, 10, 10, 10]
+    ),
     "max_write_buffer_size_to_maintain": lambda: random.choice(
         [0, 1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024, 8 * 1024 * 1024]
     ),

--- a/unreleased_history/new_features/corruption_detection_guards.md
+++ b/unreleased_history/new_features/corruption_detection_guards.md
@@ -1,0 +1,1 @@
+Added corruption detection guards against hardware bit flips during SST file building. Transient corruptions are retried once before escalating to a fatal error. Added `MutableCFOptions::max_compaction_output_to_input_ratio` (default: 10, 0 to disable) to detect grossly inflated compaction output.

--- a/util/status.cc
+++ b/util/status.cc
@@ -49,6 +49,7 @@ static const char* msgs[static_cast<int>(Status::kMaxSubCode)] = {
     "MultiScan reached file prefetch limit",         // kPrefetchLimitReached
     "Not expected code path",                        // kNotExpectedCodePath
     "All compactions aborted",                       // kCompactionAborted
+    "Transient data corruption",                     // kTransientDataCorruption
 };
 
 Status::Status(Code _code, SubCode _subcode, const Slice& msg,


### PR DESCRIPTION
Summary:
Investigation of a production SST corruption revealed that a single hardware bit flip (bit 32) in a value Slice's size_ field during compaction caused a 5.6MB value to be treated as 4.3GB. The corruption was silent because:
- BlockBuilder's varint encoding uses static_cast<uint32_t>(value.size()), which truncated the corrupted size back to the correct value
- buffer_.append(value.data(), value.size()) used the full 64-bit corrupted size, appending 4GB of adjacent heap memory into the block
- The block checksum was computed over the corrupted data, so it matched
- Compression was bypassed (block exceeded kCompressionSizeLimit)
- paranoid_file_checks was disabled

This change adds 2 layers of defense:

1. **BlockBuilder uint32 truncation guard**: In AddWithLastKeyImpl, detect when value.size() exceeds uint32_t range before the varint encoding silently truncates it. This catches bit flips in bits 32-63 and aborts immediately, preventing the massive buffer_.append from occurring. This applies to both flush and compaction paths since all key-value pairs flow through BlockBuilder::AddWithLastKeyImpl.

2. **Compaction output/input size ratio check**: New option max_compaction_output_to_input_ratio (default: 10, 0 to disable) in MutableCFOptions. After compaction, if total output size exceeds this ratio times total input size, return Status::Corruption. This catches cases where corrupted values inflate the output file far beyond what input data justifies. This check applies to compaction only (not flush), since flush writes from a memtable and does not have input files for comparison. However, flush output is still protected by guards #1 and #2.

Test Plan:
Unit test