### PR TITLE
Fix PosixFileSystem to probe io_uring with correct flags

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -755,10 +755,7 @@ IOStatus PosixRandomAccessFile::MultiRead(FSReadRequest* reqs, size_t num_reqs,
     iu = static_cast<struct io_uring*>(
         thread_local_multi_read_io_urings_->Get());
     if (iu == nullptr) {
-      unsigned int flags = 0;
-      flags |= IORING_SETUP_SINGLE_ISSUER;
-      flags |= IORING_SETUP_DEFER_TASKRUN;
-      iu = CreateIOUring(flags);
+      iu = CreateIOUring();
       if (iu != nullptr) {
         thread_local_multi_read_io_urings_->Reset(iu);
       }
@@ -1090,10 +1087,7 @@ IOStatus PosixRandomAccessFile::ReadAsync(
     iu = static_cast<struct io_uring*>(
         thread_local_async_read_io_urings_->Get());
     if (iu == nullptr) {
-      unsigned int flags = 0;
-      flags |= IORING_SETUP_SINGLE_ISSUER;
-      flags |= IORING_SETUP_DEFER_TASKRUN;
-      iu = CreateIOUring(flags);
+      iu = CreateIOUring();
       if (iu != nullptr) {
         thread_local_async_read_io_urings_->Reset(iu);
       }

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -333,8 +333,11 @@ inline void DeleteIOUring(void* p) {
   delete iu;
 }
 
-inline struct io_uring* CreateIOUring(unsigned int flags = 0) {
+inline struct io_uring* CreateIOUring() {
   struct io_uring* new_io_uring = new struct io_uring;
+  unsigned int flags = 0;
+  flags |= IORING_SETUP_SINGLE_ISSUER;
+  flags |= IORING_SETUP_DEFER_TASKRUN;
   int ret = io_uring_queue_init(kIoUringDepth, new_io_uring, flags);
   if (ret) {
     delete new_io_uring;


### PR DESCRIPTION
Summary:
The constructor probed io_uring with no flags, but ReadAsync and MultiRead actually use IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_DEFER_TASKRUN. On older kernels (5.x) that support basic io_uring but not these flags, the probe passed but ReadAsync failed at runtime with NotSupported. This caused degraded performance from async path overhead (double buffering, two-pass seeks) without actually doing async I/O.

Fix the constructor to probe with the same flags used at runtime, so the probe correctly fails on unsupported kernels. Also add a thread_local_async_read_io_urings_ null check in SupportedOps as a secondary guard, ensuring kAsyncIO is only advertised when the runtime probe actually succeeded.

Differential Revision: D93780065


