### PR TITLE
Add claude md file for deprecated option removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,9 @@ The following patterns emerged as frequent sources of review feedback:
 ### Adding new option
     Refer to claude_md/add_option.md
 
+### Removing deprecated option
+    Refer to claude_md/remove_option.md
+
 ### Metrics
 * When adding a new feature, evaluate whether there is opportunity to add
     metrics. Try to avoid causing performance regression on hot path when adding

--- a/claude_md/remove_option.md
+++ b/claude_md/remove_option.md
@@ -1,0 +1,7 @@
+# Removing Deprecated Options from RocksDB
+### Keep in these files:
+- [ ] **KEEP** entry in type_info (`options/cf_options.cc` or `options/db_options.cc`) with `OptionVerificationType::kDeprecated` for loading old option files
+- [ ] **KEEP** or add test in `options/options_test.cc` `OptionsOldApiTest::GetOptionsFromMapTest` for loading old option files
+
+### Documentation:
+- [ ] Add release note to `HISTORY.md` and `unreleased_history/`


### PR DESCRIPTION
**Context/Summary:**

It's very easy to make mistake in removing deprecated option such as deleting the corresponding entry in type info that breaks backward compatibility or missing tests to test backward compatibility. Example: https://github.com/facebook/rocksdb/pull/14350#discussion_r2834554287. Added a claude md file for that.

**Test:**
In claude code, prompted for deprecated option removal with this claude md file in a repo separated from my previous deprecation efforts as much as possible and received correct change at one try. 