### PR TITLE
Fix race condition causing flaky hang in WritePreparedTransactionSeqnoTest 

### DIFF
--- a/utilities/transactions/write_prepared_transaction_test_seqno.cc
+++ b/utilities/transactions/write_prepared_transaction_test_seqno.cc
@@ -150,11 +150,13 @@ TEST_F(WritePreparedTransactionSeqnoTest,
   Status s = db_->Flush(FlushOptions());
   ASSERT_NOK(s);
 
-  // Wait for recovery to start, then re-enable filesystem and let it proceed
+  // Wait for recovery to start, then re-enable filesystem and let it proceed.
+  // Clear the callback first to prevent it from re-disabling the filesystem
+  // if recovery's ResumeImpl triggers WriteManifest before we re-enable.
   TEST_SYNC_POINT("SeqnoGoesBackwardsDuringErrorRecovery:0");
-  fault_fs_->SetFilesystemActive(true);
   SyncPoint::GetInstance()->ClearCallBack(
       "VersionSet::LogAndApply:WriteManifest");
+  fault_fs_->SetFilesystemActive(true);
   TEST_SYNC_POINT("SeqnoGoesBackwardsDuringErrorRecovery:1");
 
   // Wait for recovery to complete
@@ -266,11 +268,13 @@ TEST_F(WritePreparedTransactionSeqnoTest, SeqnoDiscrepancyDuringErrorRecovery) {
   Status flush_s = db_->Flush(FlushOptions());
   ASSERT_NOK(flush_s);
 
-  // Wait for recovery to start, re-enable filesystem, let it proceed
+  // Wait for recovery to start, re-enable filesystem, let it proceed.
+  // Clear the callback first to prevent it from re-disabling the filesystem
+  // if recovery's ResumeImpl triggers WriteManifest before we re-enable.
   TEST_SYNC_POINT("SeqnoDiscrepancyDuringErrorRecovery:0");
-  fault_fs_->SetFilesystemActive(true);
   SyncPoint::GetInstance()->ClearCallBack(
       "VersionSet::LogAndApply:WriteManifest");
+  fault_fs_->SetFilesystemActive(true);
   TEST_SYNC_POINT("SeqnoDiscrepancyDuringErrorRecovery:1");
 
   // Wait for recovery to complete
@@ -384,11 +388,13 @@ TEST_F(WritePreparedTransactionSeqnoTest, ConcurrentWritesDuringErrorRecovery) {
   Status flush_s = db_->Flush(FlushOptions());
   ASSERT_NOK(flush_s);
 
-  // Wait for recovery to start, re-enable filesystem, let it proceed
+  // Wait for recovery to start, re-enable filesystem, let it proceed.
+  // Clear the callback first to prevent it from re-disabling the filesystem
+  // if recovery's ResumeImpl triggers WriteManifest before we re-enable.
   TEST_SYNC_POINT("ConcurrentWritesDuringErrorRecovery:0");
-  fault_fs_->SetFilesystemActive(true);
   SyncPoint::GetInstance()->ClearCallBack(
       "VersionSet::LogAndApply:WriteManifest");
+  fault_fs_->SetFilesystemActive(true);
   TEST_SYNC_POINT("ConcurrentWritesDuringErrorRecovery:1");
 
   // Wait for recovery to complete


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                                                              
                                                            
  - Fix a race condition in three WritePreparedTransactionSeqnoTest tests (SeqnoGoesBackwardsDuringErrorRecovery, SeqnoDiscrepancyDuringErrorRecovery, ConcurrentWritesDuringErrorRecovery) that could cause permanent hangs.
  - The tests inject a filesystem error during flush via a WriteManifest sync point callback, then wait for background error recovery to complete. The bug was in the ordering of operations after recovery starts: SetFilesystemActive(true) was called before ClearCallBack, allowing a window where recovery's ResumeImpl could trigger the callback and re-disable the filesystem. This left the filesystem permanently disabled, causing all recovery retries to fail and exit without firing the RecoverSuccess sync point, leaving the test thread blocked forever.
  - The fix swaps the order so ClearCallBack is called before SetFilesystemActive(true), ensuring the filesystem cannot be re-disabled by a late callback firing.

  Test plan

  - Stress tested with gtest_parallel (500 iterations, 32 workers, 60s timeout) with no hangs observed.
  - Previously reproduced the hang at ~7% rate under stress with 15s timeout before the fix.